### PR TITLE
feat: Implement ManifestTenantConfigProvider

### DIFF
--- a/services/payment-order/adapters/gateway/stripe/manifest_tenant_config.go
+++ b/services/payment-order/adapters/gateway/stripe/manifest_tenant_config.go
@@ -1,0 +1,149 @@
+package stripe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"google.golang.org/grpc/metadata"
+)
+
+var (
+	// ErrNilManifestClient is returned when the ManifestHistoryService client is nil.
+	ErrNilManifestClient = errors.New("manifest history service client is required")
+	// ErrNilLogger is returned when the logger is nil.
+	ErrNilLogger = errors.New("logger is required")
+)
+
+// ManifestTenantConfigProvider retrieves Stripe Connect configuration for a tenant
+// by querying the control-plane ManifestHistoryService gRPC endpoint.
+// Results are cached with a configurable TTL to avoid hitting the control-plane on every request.
+type ManifestTenantConfigProvider struct {
+	client controlplanev1.ManifestHistoryServiceClient
+	logger *slog.Logger
+	ttl    time.Duration
+
+	mu    sync.RWMutex
+	cache map[string]cacheEntry
+}
+
+// cacheEntry stores a cached TenantConfig with an expiration time.
+type cacheEntry struct {
+	config    TenantConfig
+	expiresAt time.Time
+}
+
+// ManifestTenantConfigProviderConfig holds configuration for ManifestTenantConfigProvider.
+type ManifestTenantConfigProviderConfig struct {
+	// Client is the gRPC client for ManifestHistoryService.
+	Client controlplanev1.ManifestHistoryServiceClient
+	// Logger is the structured logger.
+	Logger *slog.Logger
+	// CacheTTL is the duration to cache tenant configs. Defaults to 5 minutes.
+	CacheTTL time.Duration
+}
+
+const defaultCacheTTL = 5 * time.Minute
+
+// stripeConnectProvider is the payment rails provider name for Stripe Connect.
+const stripeConnectProvider = "stripe_connect"
+
+// NewManifestTenantConfigProvider creates a new ManifestTenantConfigProvider.
+func NewManifestTenantConfigProvider(cfg ManifestTenantConfigProviderConfig) (*ManifestTenantConfigProvider, error) {
+	if cfg.Client == nil {
+		return nil, ErrNilManifestClient
+	}
+	if cfg.Logger == nil {
+		return nil, ErrNilLogger
+	}
+	ttl := cfg.CacheTTL
+	if ttl == 0 {
+		ttl = defaultCacheTTL
+	}
+	return &ManifestTenantConfigProvider{
+		client: cfg.Client,
+		logger: cfg.Logger,
+		ttl:    ttl,
+		cache:  make(map[string]cacheEntry),
+	}, nil
+}
+
+// GetTenantConfig returns the Stripe Connect config for the given tenant.
+// Returns ErrTenantConfigNotFound if the tenant has no payment_rails with stripe_connect provider.
+func (p *ManifestTenantConfigProvider) GetTenantConfig(tenantID string) (TenantConfig, error) {
+	// Check cache first
+	p.mu.RLock()
+	entry, ok := p.cache[tenantID]
+	p.mu.RUnlock()
+	if ok && time.Now().Before(entry.expiresAt) {
+		return entry.config, nil
+	}
+
+	// Cache miss or expired - fetch from control-plane
+	cfg, err := p.fetchFromManifest(tenantID)
+	if err != nil {
+		return TenantConfig{}, err
+	}
+
+	// Store in cache
+	p.mu.Lock()
+	p.cache[tenantID] = cacheEntry{
+		config:    cfg,
+		expiresAt: time.Now().Add(p.ttl),
+	}
+	p.mu.Unlock()
+
+	return cfg, nil
+}
+
+// fetchFromManifest calls GetCurrentManifest on the control-plane with the tenant's context
+// and extracts the Stripe Connect configuration from the payment_rails section.
+func (p *ManifestTenantConfigProvider) fetchFromManifest(tenantID string) (TenantConfig, error) {
+	// Set tenant ID in outgoing gRPC metadata
+	ctx := metadata.AppendToOutgoingContext(
+		context.Background(),
+		tenant.TenantIDKey, tenantID,
+	)
+
+	resp, err := p.client.GetCurrentManifest(ctx, &controlplanev1.GetCurrentManifestRequest{})
+	if err != nil {
+		return TenantConfig{}, fmt.Errorf("failed to get manifest for tenant %s: %w", tenantID, err)
+	}
+
+	manifest := resp.GetVersion().GetManifest()
+	if manifest == nil {
+		return TenantConfig{}, ErrTenantConfigNotFound
+	}
+
+	// Find stripe_connect payment rail
+	for _, rail := range manifest.GetPaymentRails() {
+		if rail.GetProvider() != stripeConnectProvider {
+			continue
+		}
+
+		cfg := TenantConfig{
+			ConnectedAccountID:    rail.GetAccountId(),
+			WebhookEndpointSecret: rail.GetWebhookEndpointSecret(),
+		}
+
+		if err := cfg.Validate(); err != nil {
+			p.logger.Warn("invalid stripe config in manifest",
+				"tenant_id", tenantID,
+				"error", err)
+			return TenantConfig{}, fmt.Errorf("invalid stripe config for tenant %s: %w", tenantID, err)
+		}
+
+		p.logger.Debug("loaded stripe config from manifest",
+			"tenant_id", tenantID,
+			"connected_account_id", cfg.ConnectedAccountID)
+
+		return cfg, nil
+	}
+
+	return TenantConfig{}, ErrTenantConfigNotFound
+}

--- a/services/payment-order/adapters/gateway/stripe/manifest_tenant_config_test.go
+++ b/services/payment-order/adapters/gateway/stripe/manifest_tenant_config_test.go
@@ -1,0 +1,381 @@
+package stripe
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// mockManifestClient implements ManifestHistoryServiceClient for testing.
+type mockManifestClient struct {
+	controlplanev1.ManifestHistoryServiceClient
+	currentManifestFn func(ctx context.Context, req *controlplanev1.GetCurrentManifestRequest, opts ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error)
+	callCount         atomic.Int32
+}
+
+func (m *mockManifestClient) GetCurrentManifest(ctx context.Context, req *controlplanev1.GetCurrentManifestRequest, opts ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+	m.callCount.Add(1)
+	return m.currentManifestFn(ctx, req, opts...)
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func manifestWithStripeRails(accountID, webhookSecret, feeValue string) *controlplanev1.Manifest {
+	return &controlplanev1.Manifest{
+		Version: "1.0",
+		Metadata: &controlplanev1.ManifestMetadata{
+			Name:     "Test Tenant",
+			Industry: "energy",
+		},
+		PaymentRails: []*controlplanev1.PaymentRails{
+			{
+				Provider:              "stripe_connect",
+				Mode:                  controlplanev1.ConnectMode_CONNECT_MODE_STANDARD,
+				AccountId:             accountID,
+				WebhookEndpointSecret: webhookSecret,
+				PlatformFee: &controlplanev1.PlatformFee{
+					Type:  controlplanev1.PlatformFeeType_PLATFORM_FEE_TYPE_PERCENTAGE,
+					Value: feeValue,
+				},
+				PayoutSchedule:   controlplanev1.PayoutSchedule_PAYOUT_SCHEDULE_DAILY,
+				SupportedMethods: []string{"card"},
+			},
+		},
+	}
+}
+
+func TestManifestTenantConfigProvider_GetTenantConfig(t *testing.T) {
+	mock := &mockManifestClient{
+		currentManifestFn: func(ctx context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+			// Verify tenant ID is propagated in metadata
+			md, ok := metadata.FromOutgoingContext(ctx)
+			if !ok {
+				return nil, status.Error(codes.InvalidArgument, "missing metadata")
+			}
+			vals := md.Get(tenant.TenantIDKey)
+			if len(vals) == 0 || vals[0] == "" {
+				return nil, status.Error(codes.InvalidArgument, "missing tenant ID")
+			}
+
+			return &controlplanev1.GetCurrentManifestResponse{
+				Version: &controlplanev1.ManifestVersion{
+					Manifest: manifestWithStripeRails(
+						"acct_1234567890abcdef",
+						"whsec_test_secret",
+						"2.5",
+					),
+				},
+			}, nil
+		},
+	}
+
+	provider, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+		Client:   mock,
+		Logger:   testLogger(),
+		CacheTTL: 1 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	cfg, err := provider.GetTenantConfig("tenant_abc")
+	require.NoError(t, err)
+	assert.Equal(t, "acct_1234567890abcdef", cfg.ConnectedAccountID)
+	assert.Equal(t, "whsec_test_secret", cfg.WebhookEndpointSecret)
+}
+
+func TestManifestTenantConfigProvider_CacheHit(t *testing.T) {
+	mock := &mockManifestClient{
+		currentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+			return &controlplanev1.GetCurrentManifestResponse{
+				Version: &controlplanev1.ManifestVersion{
+					Manifest: manifestWithStripeRails(
+						"acct_1234567890abcdef",
+						"whsec_test_secret",
+						"2.5",
+					),
+				},
+			}, nil
+		},
+	}
+
+	provider, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+		Client:   mock,
+		Logger:   testLogger(),
+		CacheTTL: 1 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// First call - cache miss
+	cfg1, err := provider.GetTenantConfig("tenant_abc")
+	require.NoError(t, err)
+	assert.Equal(t, "acct_1234567890abcdef", cfg1.ConnectedAccountID)
+	assert.Equal(t, int32(1), mock.callCount.Load())
+
+	// Second call - cache hit (should NOT make gRPC call)
+	cfg2, err := provider.GetTenantConfig("tenant_abc")
+	require.NoError(t, err)
+	assert.Equal(t, cfg1, cfg2)
+	assert.Equal(t, int32(1), mock.callCount.Load(), "second call should use cache")
+}
+
+func TestManifestTenantConfigProvider_CacheExpiry(t *testing.T) {
+	mock := &mockManifestClient{
+		currentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+			return &controlplanev1.GetCurrentManifestResponse{
+				Version: &controlplanev1.ManifestVersion{
+					Manifest: manifestWithStripeRails(
+						"acct_1234567890abcdef",
+						"whsec_test_secret",
+						"2.5",
+					),
+				},
+			}, nil
+		},
+	}
+
+	provider, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+		Client:   mock,
+		Logger:   testLogger(),
+		CacheTTL: 1 * time.Millisecond, // Very short TTL
+	})
+	require.NoError(t, err)
+
+	// First call
+	_, err = provider.GetTenantConfig("tenant_abc")
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), mock.callCount.Load())
+
+	// Wait for cache to expire
+	time.Sleep(5 * time.Millisecond)
+
+	// Second call - cache expired
+	_, err = provider.GetTenantConfig("tenant_abc")
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), mock.callCount.Load(), "should make new gRPC call after cache expiry")
+}
+
+func TestManifestTenantConfigProvider_NoPaymentRails(t *testing.T) {
+	mock := &mockManifestClient{
+		currentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+			return &controlplanev1.GetCurrentManifestResponse{
+				Version: &controlplanev1.ManifestVersion{
+					Manifest: &controlplanev1.Manifest{
+						Version: "1.0",
+						Metadata: &controlplanev1.ManifestMetadata{
+							Name: "No Rails Tenant",
+						},
+						PaymentRails: nil,
+					},
+				},
+			}, nil
+		},
+	}
+
+	provider, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+		Client:   mock,
+		Logger:   testLogger(),
+		CacheTTL: 1 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	_, err = provider.GetTenantConfig("tenant_no_rails")
+	assert.ErrorIs(t, err, ErrTenantConfigNotFound)
+}
+
+func TestManifestTenantConfigProvider_NonStripeProvider(t *testing.T) {
+	mock := &mockManifestClient{
+		currentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+			return &controlplanev1.GetCurrentManifestResponse{
+				Version: &controlplanev1.ManifestVersion{
+					Manifest: &controlplanev1.Manifest{
+						Version: "1.0",
+						Metadata: &controlplanev1.ManifestMetadata{
+							Name: "Other Provider Tenant",
+						},
+						PaymentRails: []*controlplanev1.PaymentRails{
+							{
+								Provider:  "other_provider",
+								AccountId: "other_123",
+								PlatformFee: &controlplanev1.PlatformFee{
+									Type:  controlplanev1.PlatformFeeType_PLATFORM_FEE_TYPE_FLAT,
+									Value: "1.00",
+								},
+								SupportedMethods: []string{"card"},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	provider, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+		Client:   mock,
+		Logger:   testLogger(),
+		CacheTTL: 1 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	_, err = provider.GetTenantConfig("tenant_other")
+	assert.ErrorIs(t, err, ErrTenantConfigNotFound)
+}
+
+func TestManifestTenantConfigProvider_GRPCError(t *testing.T) {
+	mock := &mockManifestClient{
+		currentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+			return nil, status.Error(codes.Unavailable, "control-plane unavailable")
+		},
+	}
+
+	provider, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+		Client:   mock,
+		Logger:   testLogger(),
+		CacheTTL: 1 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	_, err = provider.GetTenantConfig("tenant_abc")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get manifest")
+}
+
+func TestManifestTenantConfigProvider_NilManifest(t *testing.T) {
+	mock := &mockManifestClient{
+		currentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+			return &controlplanev1.GetCurrentManifestResponse{
+				Version: &controlplanev1.ManifestVersion{
+					Manifest: nil,
+				},
+			}, nil
+		},
+	}
+
+	provider, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+		Client:   mock,
+		Logger:   testLogger(),
+		CacheTTL: 1 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	_, err = provider.GetTenantConfig("tenant_abc")
+	assert.ErrorIs(t, err, ErrTenantConfigNotFound)
+}
+
+func TestManifestTenantConfigProvider_MissingAccountID(t *testing.T) {
+	mock := &mockManifestClient{
+		currentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+			return &controlplanev1.GetCurrentManifestResponse{
+				Version: &controlplanev1.ManifestVersion{
+					Manifest: manifestWithStripeRails(
+						"", // missing account ID
+						"whsec_test_secret",
+						"2.5",
+					),
+				},
+			}, nil
+		},
+	}
+
+	provider, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+		Client:   mock,
+		Logger:   testLogger(),
+		CacheTTL: 1 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	_, err = provider.GetTenantConfig("tenant_abc")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid stripe config")
+}
+
+func TestNewManifestTenantConfigProvider_NilClient(t *testing.T) {
+	_, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+		Client: nil,
+		Logger: testLogger(),
+	})
+	assert.ErrorIs(t, err, ErrNilManifestClient)
+}
+
+func TestNewManifestTenantConfigProvider_NilLogger(t *testing.T) {
+	mock := &mockManifestClient{}
+	_, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+		Client: mock,
+		Logger: nil,
+	})
+	assert.ErrorIs(t, err, ErrNilLogger)
+}
+
+func TestNewManifestTenantConfigProvider_DefaultTTL(t *testing.T) {
+	mock := &mockManifestClient{
+		currentManifestFn: func(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+			return &controlplanev1.GetCurrentManifestResponse{
+				Version: &controlplanev1.ManifestVersion{
+					Manifest: manifestWithStripeRails(
+						"acct_1234567890abcdef",
+						"whsec_test_secret",
+						"2.5",
+					),
+				},
+			}, nil
+		},
+	}
+
+	provider, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+		Client: mock,
+		Logger: testLogger(),
+		// CacheTTL not set - should use default
+	})
+	require.NoError(t, err)
+	assert.Equal(t, defaultCacheTTL, provider.ttl)
+}
+
+func TestManifestTenantConfigProvider_DifferentTenants(t *testing.T) {
+	mock := &mockManifestClient{
+		currentManifestFn: func(ctx context.Context, _ *controlplanev1.GetCurrentManifestRequest, _ ...grpc.CallOption) (*controlplanev1.GetCurrentManifestResponse, error) {
+			md, _ := metadata.FromOutgoingContext(ctx)
+			tenantIDVals := md.Get(tenant.TenantIDKey)
+			tenantID := tenantIDVals[0]
+
+			// Return different configs per tenant
+			accountID := "acct_" + tenantID + "1234567890"
+			return &controlplanev1.GetCurrentManifestResponse{
+				Version: &controlplanev1.ManifestVersion{
+					Manifest: manifestWithStripeRails(
+						accountID,
+						"whsec_"+tenantID,
+						"2.5",
+					),
+				},
+			}, nil
+		},
+	}
+
+	provider, err := NewManifestTenantConfigProvider(ManifestTenantConfigProviderConfig{
+		Client:   mock,
+		Logger:   testLogger(),
+		CacheTTL: 1 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	cfg1, err := provider.GetTenantConfig("tenant_a")
+	require.NoError(t, err)
+
+	cfg2, err := provider.GetTenantConfig("tenant_b")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, cfg1.ConnectedAccountID, cfg2.ConnectedAccountID)
+	assert.Equal(t, int32(2), mock.callCount.Load(), "should make separate gRPC call per tenant")
+}

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -15,6 +15,7 @@ import (
 
 	stripego "github.com/stripe/stripe-go/v82"
 
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
 	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
 	stripegateway "github.com/meridianhub/meridian/services/payment-order/adapters/gateway/stripe"
@@ -33,6 +34,8 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"github.com/meridianhub/meridian/shared/platform/ports"
 	"github.com/redis/go-redis/v9"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 
@@ -821,12 +824,9 @@ func createStripeWebhookHandler(webhookHandler *webhookhttp.WebhookHandler, logg
 		return nil, nil //nolint:nilnil // nil handler is intentional: ServerConfig treats nil as "feature disabled"
 	}
 
-	stripeWebhookSecret := env.GetEnvOrDefault("STRIPE_WEBHOOK_SECRET", "")
-
-	// Use env-based tenant config provider as a stub until Task 6 implements
-	// the real TenantConfigProvider backed by control-plane gRPC.
-	provider := &envTenantConfigProvider{
-		webhookSecret: stripeWebhookSecret,
+	provider, err := createTenantConfigProvider(logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tenant config provider: %w", err)
 	}
 
 	cfg := stripegateway.DefaultConfig()
@@ -850,9 +850,54 @@ func createStripeWebhookHandler(webhookHandler *webhookhttp.WebhookHandler, logg
 	return handler, nil
 }
 
-// envTenantConfigProvider is a stub TenantConfigProvider that returns a global
-// webhook secret from environment variables. This will be replaced by a real
-// implementation in Task 6 that fetches per-tenant config from the control plane.
+// createTenantConfigProvider creates the appropriate TenantConfigProvider.
+// If CONTROL_PLANE_ADDR is set, creates a ManifestTenantConfigProvider that
+// queries the control-plane ManifestHistoryService for per-tenant Stripe config.
+// Otherwise, falls back to the env-based stub provider.
+func createTenantConfigProvider(logger *slog.Logger) (stripegateway.TenantConfigProvider, error) {
+	controlPlaneAddr := env.GetEnvOrDefault("CONTROL_PLANE_ADDR", "")
+	if controlPlaneAddr != "" {
+		return createManifestTenantConfigProvider(controlPlaneAddr, logger)
+	}
+
+	logger.Warn("CONTROL_PLANE_ADDR not set, using env-based tenant config provider (single-tenant fallback)")
+	stripeWebhookSecret := env.GetEnvOrDefault("STRIPE_WEBHOOK_SECRET", "")
+	return &envTenantConfigProvider{
+		webhookSecret: stripeWebhookSecret,
+	}, nil
+}
+
+// createManifestTenantConfigProvider creates a ManifestTenantConfigProvider
+// backed by the control-plane ManifestHistoryService gRPC endpoint.
+func createManifestTenantConfigProvider(addr string, logger *slog.Logger) (*stripegateway.ManifestTenantConfigProvider, error) {
+	conn, err := grpc.NewClient(addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to control-plane at %s: %w", addr, err)
+	}
+
+	client := controlplanev1.NewManifestHistoryServiceClient(conn)
+	cacheTTL := env.GetEnvAsDuration("TENANT_CONFIG_CACHE_TTL", 5*time.Minute)
+
+	provider, err := stripegateway.NewManifestTenantConfigProvider(stripegateway.ManifestTenantConfigProviderConfig{
+		Client:   client,
+		Logger:   logger,
+		CacheTTL: cacheTTL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create manifest tenant config provider: %w", err)
+	}
+
+	logger.Info("tenant config provider backed by control-plane manifest",
+		"control_plane_addr", addr,
+		"cache_ttl", cacheTTL)
+
+	return provider, nil
+}
+
+// envTenantConfigProvider is a fallback TenantConfigProvider that returns a global
+// webhook secret from environment variables. Used when CONTROL_PLANE_ADDR is not set.
 type envTenantConfigProvider struct {
 	webhookSecret string
 }
@@ -862,7 +907,7 @@ func (p *envTenantConfigProvider) GetTenantConfig(_ string) (stripegateway.Tenan
 		return stripegateway.TenantConfig{}, stripegateway.ErrTenantConfigNotFound
 	}
 	return stripegateway.TenantConfig{
-		ConnectedAccountID:    "platform", // Placeholder until per-tenant config
+		ConnectedAccountID:    "platform", // Placeholder for single-tenant fallback
 		WebhookEndpointSecret: p.webhookSecret,
 	}, nil
 }


### PR DESCRIPTION
## Summary

- Implement `ManifestTenantConfigProvider` that queries control-plane `ManifestHistoryService` gRPC to retrieve per-tenant Stripe Connect configuration from manifest `payment_rails` section
- TTL-based in-memory cache (configurable via `TENANT_CONFIG_CACHE_TTL`, default 5m) avoids hitting control-plane on every request
- Graceful fallback to env-based `envTenantConfigProvider` when `CONTROL_PLANE_ADDR` is not set (backward-compatible for existing single-tenant deployments)
- Wire provider into payment-order `main.go`, replacing the stub

## Changes Made

| File | Change |
|------|--------|
| `services/payment-order/adapters/gateway/stripe/manifest_tenant_config.go` | New `ManifestTenantConfigProvider` implementation |
| `services/payment-order/adapters/gateway/stripe/manifest_tenant_config_test.go` | 12 unit tests covering cache hit/miss/expiry, error paths, multi-tenant |
| `services/payment-order/cmd/main.go` | Wire provider with `CONTROL_PLANE_ADDR` env var, retain env fallback |

## Task Master Reference

Task: stripe-connect-wiring.6 - Implement TenantConfigProvider with control-plane manifest integration

## Test Plan

- [x] Unit test: mock ManifestService returning tenant config
- [x] Unit test: cache hit (second call does not make gRPC call)
- [x] Unit test: cache expiry (expired entry triggers new gRPC call)
- [x] Unit test: ErrTenantConfigNotFound when tenant has no payment_rails
- [x] Unit test: ErrTenantConfigNotFound when provider is not stripe_connect
- [x] Unit test: gRPC error propagation
- [x] Unit test: nil manifest handling
- [x] Unit test: missing account ID validation
- [x] Unit test: constructor validation (nil client, nil logger)
- [x] Unit test: default TTL applied when not configured
- [x] Unit test: different tenants get separate configs and cache entries
- [x] All existing stripe package tests continue to pass