### PR TITLE
feat: Wire StarlarkSagaRunner into payment orchestrator

### DIFF
--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -40,7 +40,13 @@ import (
 	currentaccountclient "github.com/meridianhub/meridian/services/current-account/client"
 	financialaccountingclient "github.com/meridianhub/meridian/services/financial-accounting/client"
 	internalbankaccountclient "github.com/meridianhub/meridian/services/internal-bank-account/client"
+	partyclient "github.com/meridianhub/meridian/services/party/client"
 	positionkeepingclient "github.com/meridianhub/meridian/services/position-keeping/client"
+
+	// Reference data client for saga definitions and instrument lookups
+	poclients "github.com/meridianhub/meridian/services/payment-order/adapters/clients"
+	referencedataclient "github.com/meridianhub/meridian/services/reference-data/client"
+
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 )
 
@@ -230,12 +236,52 @@ func run(logger *slog.Logger) error {
 		}
 	}
 
+	// Create Party client for Starlark handlers (party.get_default_payment_method).
+	partyClient, partyCleanup, err := partyclient.New(partyclient.Config{
+		ServiceName: partyclient.ServiceName,
+		Namespace:   namespace,
+		Port:        ports.Party,
+		Timeout:     defaults.DefaultRPCTimeout,
+		Tracer:      tracer,
+	})
+	if err != nil {
+		logger.Warn("party client unavailable, Starlark party handlers not registered",
+			"error", err)
+	} else {
+		defer partyCleanup()
+		if err := partyclient.RegisterStarlarkHandlers(handlerRegistry, partyClient); err != nil {
+			logger.Warn("failed to register party handlers", "error", err)
+		}
+	}
+
+	// Create Reference Data client for saga definitions and instrument lookups.
+	// Uses the shared gRPC connection via ReferenceDataClientWrapper which implements
+	// service.ReferenceDataClient (GetSaga + RetrieveInstrument).
+	refDataClient, refDataCleanup, err := referencedataclient.New(ctx, referencedataclient.Config{
+		ServiceName: referencedataclient.ServiceName,
+		Namespace:   namespace,
+		Port:        ports.ReferenceData,
+		Timeout:     defaults.DefaultRPCTimeout,
+		Tracer:      tracer,
+	})
+	var referenceDataClient service.ReferenceDataClient
+	if err != nil {
+		logger.Warn("reference-data client unavailable, saga definitions will not be fetched",
+			"error", err)
+	} else {
+		defer func() {
+			if err := refDataCleanup(); err != nil {
+				logger.Error("failed to close reference-data client", "error", err)
+			}
+		}()
+		// Wrap the reference-data client to implement service.ReferenceDataClient interface
+		referenceDataClient = poclients.NewReferenceDataClient(refDataClient.Conn())
+		// Register reference-data Starlark handlers if needed in the future
+		logger.Info("reference-data client connected", "port", ports.ReferenceData)
+	}
+
 	logger.Info("Starlark handler registry initialized",
 		"registered_handlers", len(handlerRegistry.List()))
-
-	// handlerRegistry is available for use with StarlarkRunner when
-	// payment execution sagas are migrated from Go orchestrators to Starlark.
-	_ = handlerRegistry
 
 	// Start billing background workers (feature-flagged)
 	billingEnabled := env.GetEnvAsBool("BILLING_ENABLED", false)
@@ -304,6 +350,7 @@ func run(logger *slog.Logger) error {
 		CurrentAccountClient:      currentAccountClient,
 		FinancialAccountingClient: financialAccountingClient,
 		InternalBankAccountClient: internalBankAccountClient, // May be nil if internal clearing disabled
+		ReferenceDataClient:       referenceDataClient,       // May be nil if reference-data unavailable
 		PaymentGateway:            paymentGateway,
 		GatewayAccountConfig:      gatewayAccountConfig,
 		KafkaPublisher:            kafkaProducer,
@@ -311,6 +358,7 @@ func run(logger *slog.Logger) error {
 		Logger:                    logger,
 		Tracer:                    tracer,
 		InternalClearingEnabled:   internalClearingEnabled,
+		HandlerRegistry:           handlerRegistry,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create payment order service: %w", err)

--- a/services/payment-order/service/grpc_service.go
+++ b/services/payment-order/service/grpc_service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/meridianhub/meridian/services/payment-order/config"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/protobuf/proto"
@@ -251,6 +252,12 @@ type Config struct {
 	// InternalClearingEnabled enables internal clearing operations (default: false).
 	// When enabled, the service uses InternalBankAccountClient for clearing account resolution.
 	InternalClearingEnabled bool
+
+	// HandlerRegistry is an optional external handler registry with cross-service Starlark
+	// handlers (e.g., party.get_default_payment_method). When provided, the orchestrator
+	// registers its internal payment_order.* handlers on this registry so saga scripts
+	// have access to all registered handlers. When nil, a new empty registry is created.
+	HandlerRegistry *saga.HandlerRegistry
 }
 
 // NewService creates a new payment order service with minimal dependencies.
@@ -356,6 +363,7 @@ func NewServiceWithConfig(cfg Config) (*Service, error) {
 		KafkaPublisher:            cfg.KafkaPublisher,
 		LienExecutionRetryConfig:  cfg.LienExecutionRetryConfig,
 		InternalClearingEnabled:   cfg.InternalClearingEnabled,
+		HandlerRegistry:           cfg.HandlerRegistry,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create payment orchestrator: %w", err)

--- a/services/payment-order/service/payment_orchestrator.go
+++ b/services/payment-order/service/payment_orchestrator.go
@@ -91,6 +91,13 @@ type PaymentOrchestratorConfig struct {
 	LienExecutionRetryConfig  *sharedclients.RetryConfig
 	InternalClearingEnabled   bool
 	LockClient                LockClient // Distributed lock client for preventing concurrent lien execution
+
+	// HandlerRegistry is an optional external handler registry with cross-service handlers
+	// (e.g., party.get_default_payment_method, current_account.*). When provided, the
+	// orchestrator registers its internal payment_order.* handlers on this registry and
+	// uses it for the StarlarkSagaRunner, giving saga scripts access to all handlers.
+	// When nil, a new empty registry is created (backward compatible).
+	HandlerRegistry *saga.HandlerRegistry
 }
 
 // NewPaymentOrchestrator creates a new payment orchestrator with the given dependencies.
@@ -126,8 +133,14 @@ func NewPaymentOrchestrator(cfg PaymentOrchestratorConfig) (*PaymentOrchestrator
 		return nil, fmt.Errorf("failed to create bucket evaluator: %w", err)
 	}
 
-	// Create handler registry and register payment-order handlers
-	handlerRegistry := saga.NewHandlerRegistry()
+	// Use external handler registry if provided (contains cross-service handlers),
+	// otherwise create a new empty one.
+	handlerRegistry := cfg.HandlerRegistry
+	if handlerRegistry == nil {
+		handlerRegistry = saga.NewHandlerRegistry()
+	}
+
+	// Register payment-order-specific handlers on the registry
 	handlerDeps := &PaymentOrderHandlerDeps{
 		CurrentAccountClient:      cfg.CurrentAccountClient,
 		PaymentGateway:            cfg.PaymentGateway,


### PR DESCRIPTION
## Summary
- Remove discarded `handlerRegistry` (`_ = handlerRegistry`) in `main.go`
- Add Party gRPC client and register `party.get_default_payment_method` Starlark handler
- Add Reference Data client for saga definition fetching (`GetSaga`) and instrument lookups
- Pass external `HandlerRegistry` through `service.Config` to `PaymentOrchestratorConfig`
- Orchestrator uses external registry (with cross-service handlers) and registers its internal `payment_order.*` handlers on it
- Wire `ReferenceDataClient` into `service.Config` for saga script resolution

## Task Master
Tag: stripe-connect-wiring, Task: 5

## Test Plan
- [x] `handlerRegistry` no longer discarded
- [x] `StarlarkSagaRunner` created with cross-service handler registry
- [x] `go vet` clean
- [x] All existing payment-order service tests pass
- [x] Pre-commit checks (gofumpt, golangci-lint) pass
- [ ] CI pipeline