### PR TITLE
chore: Transfer licensor to Meridian Hub Ltd

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -3,7 +3,7 @@
 By submitting a pull request or patch to this project, you agree to the following:
 
 1. You assign all copyright and intellectual property rights in your
-   contribution to Benjamin John Coombs.
+   contribution to Meridian Hub Ltd.
 
 2. Your submission confirms that you have the legal right to make this assignment.
 

--- a/LICENSE
+++ b/LICENSE
@@ -6,7 +6,7 @@ Parameters
 
 Licensor:             Meridian Hub Ltd
 Licensed Work:        Meridian
-                      The Licensed Work is (c) 2025 Meridian Hub Ltd.
+                      The Licensed Work is (c) 2025-2026 Meridian Hub Ltd.
 Additional Use Grant: You may make production use of the Licensed Work, provided
                       Your use does not include offering the Licensed Work to third
                       parties as a commercial billing, ledger, treasury, or financial

--- a/LICENSE
+++ b/LICENSE
@@ -4,14 +4,14 @@ Business Source License 1.1
 
 Parameters
 
-Licensor:             Benjamin John Coombs
+Licensor:             Meridian Hub Ltd
 Licensed Work:        Meridian
-                      The Licensed Work is (c) 2025 Benjamin John Coombs.
+                      The Licensed Work is (c) 2025 Meridian Hub Ltd.
 Additional Use Grant: You may make production use of the Licensed Work, provided
                       Your use does not include offering the Licensed Work to third
                       parties as a commercial billing, ledger, treasury, or financial
                       accounting service that competes with Meridian Hub products.
-Change Date:          January 14, 2030
+Change Date:          February 12, 2030
 Change License:       Apache License, Version 2.0
 
 For information about alternative licensing arrangements, contact ben@meridianhub.org.


### PR DESCRIPTION
## Summary

- Transfer BSL 1.1 licensor from Benjamin John Coombs to Meridian Hub Ltd (Company No. 17024653)
- Update CLA copyright assignment to Meridian Hub Ltd
- Update Change Date to February 12, 2030 (4-year BSL window, idiomatic for infrastructure projects)

## Changes

| File | Change |
|------|--------|
| `LICENSE` | Licensor, copyright holder, Change Date |
| `CLA.md` | IP assignment entity |

## Context

Meridian Hub Ltd was incorporated on the UK Companies Register. This PR transfers the project's intellectual property attribution from the individual founder to the company entity.

The Change Date of 4 years aligns with CockroachDB, HashiCorp, Redpanda, and Materialize precedent for BSL-licensed infrastructure projects.

Company registration: https://find-and-update.company-information.service.gov.uk/company/17024653