### PR TITLE
feat: wire Kafka event publisher in main.go

### DIFF
--- a/services/reconciliation/cmd/main.go
+++ b/services/reconciliation/cmd/main.go
@@ -14,6 +14,7 @@ import (
 
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/adapters/messaging"
 	"github.com/meridianhub/meridian/services/reconciliation/adapters/persistence"
 	"github.com/meridianhub/meridian/services/reconciliation/config"
 	"github.com/meridianhub/meridian/services/reconciliation/observability"
@@ -96,6 +97,25 @@ func run(logger *slog.Logger) error {
 
 	logger.Info("database connection established")
 
+	// Wire event publisher based on Kafka configuration
+	var eventPublisher service.EventPublisher
+	if cfg.Kafka.Enabled {
+		kafkaPub, kafkaErr := messaging.NewKafkaPublisher(cfg.Kafka.Brokers, logger)
+		if kafkaErr != nil {
+			return fmt.Errorf("failed to create kafka publisher: %w", kafkaErr)
+		}
+		eventPublisher = kafkaPub
+		logger.Info("kafka publisher configured", "brokers", cfg.Kafka.Brokers)
+	} else {
+		eventPublisher = messaging.NewNoopPublisher(logger)
+		logger.Info("noop publisher configured (kafka disabled)")
+	}
+	defer func() {
+		if closer, ok := eventPublisher.(interface{ Close() }); ok {
+			closer.Close()
+		}
+	}()
+
 	// Instantiate persistence repositories
 	runRepo := persistence.NewSettlementRunRepository(db)
 	snapshotRepo := persistence.NewSettlementSnapshotRepository(db)
@@ -108,6 +128,7 @@ func run(logger *slog.Logger) error {
 		service.WithDisputeRepository(disputeRepo),
 		service.WithVarianceRepository(varianceRepo),
 		service.WithVarianceListRepository(varianceRepo),
+		service.WithEventPublisher(eventPublisher),
 		service.WithLogger(logger),
 	}
 

--- a/services/reconciliation/cmd/main_test.go
+++ b/services/reconciliation/cmd/main_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/adapters/messaging"
 	"github.com/meridianhub/meridian/services/reconciliation/adapters/persistence"
 	"github.com/meridianhub/meridian/services/reconciliation/service"
 	"github.com/meridianhub/meridian/shared/pkg/health"
@@ -146,12 +147,16 @@ func startTestGRPCServer(t *testing.T, db *gorm.DB, logger *slog.Logger) (string
 	// Wire VarianceDetector (repos only, always available)
 	detector := service.NewVarianceDetector(runRepo, snapshotRepo, varianceRepo)
 
+	// Wire NoopPublisher (Kafka disabled in tests)
+	publisher := messaging.NewNoopPublisher(logger)
+
 	// Create service with all available options
 	svc := service.NewAccountReconciliationService(
 		service.WithSettlementRunRepository(runRepo),
 		service.WithDisputeRepository(disputeRepo),
 		service.WithVarianceRepository(varianceRepo),
 		service.WithVarianceListRepository(varianceRepo),
+		service.WithEventPublisher(publisher),
 		service.WithVarianceDetector(detector.DetectVariances),
 		service.WithLogger(logger),
 	)
@@ -356,6 +361,69 @@ func TestMainWiring_AssertBalanceRegression(t *testing.T) {
 	require.Error(t, err)
 	// Should fail validation, not be unimplemented
 	assert.Contains(t, err.Error(), "scope")
+}
+
+func TestMainWiring_NoopPublisherWiredWhenKafkaDisabled(t *testing.T) {
+	db, cleanup := setupIntegrationDB(t)
+	defer cleanup()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Wire NoopPublisher (simulates Kafka disabled)
+	publisher := messaging.NewNoopPublisher(logger)
+
+	runRepo := persistence.NewSettlementRunRepository(db)
+	disputeRepo := persistence.NewDisputeRepository(db)
+	varianceRepo := persistence.NewVarianceRepository(db)
+
+	// Create service with publisher wired
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(runRepo),
+		service.WithDisputeRepository(disputeRepo),
+		service.WithVarianceRepository(varianceRepo),
+		service.WithVarianceListRepository(varianceRepo),
+		service.WithEventPublisher(publisher),
+		service.WithLogger(logger),
+	)
+
+	grpcServer := grpc.NewServer()
+	reconciliationv1.RegisterAccountReconciliationServiceServer(grpcServer, svc)
+
+	lis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "localhost:0")
+	require.NoError(t, err)
+	go func() {
+		_ = grpcServer.Serve(lis)
+	}()
+	defer grpcServer.GracefulStop()
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	client := reconciliationv1.NewAccountReconciliationServiceClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// InitiateAccountReconciliation should work with publisher wired
+	// (returns validation error, not unimplemented)
+	_, err = client.InitiateAccountReconciliation(ctx, &reconciliationv1.InitiateAccountReconciliationRequest{
+		AccountId: "ACC-001",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scope")
+	assert.NotContains(t, err.Error(), "Unimplemented")
+}
+
+func TestNoopPublisher_ImplementsEventPublisher(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	publisher := messaging.NewNoopPublisher(logger)
+
+	// Verify NoopPublisher satisfies the EventPublisher interface
+	var _ service.EventPublisher = publisher
+
+	// Verify Publish returns no error
+	err := publisher.Publish(context.Background(), "test.topic", map[string]string{"key": "value"})
+	assert.NoError(t, err)
 }
 
 func TestParseLogLevel(t *testing.T) {


### PR DESCRIPTION
## Summary

- Wire `KafkaPublisher` or `NoopPublisher` in `cmd/main.go` based on `cfg.Kafka.Enabled` configuration
- Add publisher to `serviceOpts` via `service.WithEventPublisher()`
- Implement graceful shutdown using `Close()` interface detection for `KafkaPublisher`
- Update test helper to wire `NoopPublisher` matching production pattern
- Add dedicated tests verifying NoopPublisher satisfies `EventPublisher` interface

## Technical Details

After database initialization in `run()`, the publisher is conditionally created:
- `KAFKA_BROKERS` set: `messaging.NewKafkaPublisher(brokers, logger)` with error propagation
- `KAFKA_BROKERS` empty: `messaging.NewNoopPublisher(logger)` for graceful degradation

Shutdown uses type assertion to `interface{ Close() }` so only `KafkaPublisher` (which has `Close()`) triggers flush/close, while `NoopPublisher` is a no-op.

## Task Master

Tag: `reconciliation-service-phase2`, Task: `4`

## Test Plan

- [x] `TestNoopPublisher_ImplementsEventPublisher` - compile-time interface check + Publish returns nil
- [x] `TestMainWiring_NoopPublisherWiredWhenKafkaDisabled` - integration test verifying service works with publisher wired
- [x] Existing `startTestGRPCServer` updated to include publisher in wiring (matches production)
- [x] `go vet` clean, `golangci-lint` clean, all pre-commit hooks pass