### PR TITLE
feat: replace metadata role extraction with validated JWT claims

### DIFF
--- a/services/reconciliation/service/extract_caller_role_test.go
+++ b/services/reconciliation/service/extract_caller_role_test.go
@@ -1,0 +1,109 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
+)
+
+func claimsContext(roles ...string) context.Context {
+	claims := &auth.Claims{
+		UserID: "test-user",
+		Roles:  roles,
+	}
+	return context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
+}
+
+func metadataContext(role string) context.Context {
+	md := metadata.New(map[string]string{"x-meridian-role": role})
+	return metadata.NewIncomingContext(context.Background(), md)
+}
+
+func TestExtractCallerRole_JWTServiceRole(t *testing.T) {
+	ctx := claimsContext("service")
+	assert.Equal(t, CallerRoleSystem, extractCallerRole(ctx))
+}
+
+func TestExtractCallerRole_JWTAdminRole(t *testing.T) {
+	ctx := claimsContext("admin")
+	assert.Equal(t, CallerRoleSystem, extractCallerRole(ctx))
+}
+
+func TestExtractCallerRole_JWTAuditorRole(t *testing.T) {
+	ctx := claimsContext("auditor")
+	assert.Equal(t, CallerRoleAuditor, extractCallerRole(ctx))
+}
+
+func TestExtractCallerRole_JWTOperatorRole(t *testing.T) {
+	ctx := claimsContext("operator")
+	assert.Equal(t, CallerRoleTenantAdmin, extractCallerRole(ctx))
+}
+
+func TestExtractCallerRole_JWTUnknownRole(t *testing.T) {
+	ctx := claimsContext("viewer")
+	assert.Equal(t, CallerRoleTenantAdmin, extractCallerRole(ctx))
+}
+
+func TestExtractCallerRole_JWTNoRoles(t *testing.T) {
+	ctx := claimsContext()
+	assert.Equal(t, CallerRoleTenantAdmin, extractCallerRole(ctx))
+}
+
+func TestExtractCallerRole_NoClaims_DefaultsTenantAdmin(t *testing.T) {
+	ctx := context.Background()
+	assert.Equal(t, CallerRoleTenantAdmin, extractCallerRole(ctx))
+}
+
+func TestExtractCallerRole_NoClaims_MetadataSystem(t *testing.T) {
+	ctx := metadataContext("SYSTEM")
+	assert.Equal(t, CallerRoleSystem, extractCallerRole(ctx))
+}
+
+func TestExtractCallerRole_NoClaims_MetadataAuditor(t *testing.T) {
+	ctx := metadataContext("AUDITOR")
+	assert.Equal(t, CallerRoleAuditor, extractCallerRole(ctx))
+}
+
+func TestExtractCallerRole_NoClaims_MetadataUnknown(t *testing.T) {
+	ctx := metadataContext("UNKNOWN")
+	assert.Equal(t, CallerRoleTenantAdmin, extractCallerRole(ctx))
+}
+
+func TestExtractCallerRole_NoClaims_EmptyMetadata(t *testing.T) {
+	md := metadata.New(map[string]string{})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	assert.Equal(t, CallerRoleTenantAdmin, extractCallerRole(ctx))
+}
+
+// TestExtractCallerRole_JWTWinsOverMetadata is a security test.
+// When valid JWT claims exist (TENANT_ADMIN role), malicious metadata
+// claiming SYSTEM role must be ignored. The JWT claim takes precedence.
+func TestExtractCallerRole_JWTWinsOverMetadata(t *testing.T) {
+	// Create context with JWT claims (operator role = TenantAdmin)
+	claims := &auth.Claims{
+		UserID: "test-user",
+		Roles:  []string{"operator"},
+	}
+	ctx := context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
+
+	// Add malicious metadata claiming SYSTEM role
+	md := metadata.New(map[string]string{"x-meridian-role": "SYSTEM"})
+	ctx = metadata.NewIncomingContext(ctx, md)
+
+	// JWT claims must win - operator maps to TenantAdmin, not System
+	assert.Equal(t, CallerRoleTenantAdmin, extractCallerRole(ctx))
+}
+
+func TestExtractCallerRole_JWTMultipleRoles(t *testing.T) {
+	// Service role should take precedence when multiple roles present
+	ctx := claimsContext("operator", "service")
+	assert.Equal(t, CallerRoleSystem, extractCallerRole(ctx))
+}
+
+func TestExtractCallerRole_JWTAuditorAndOperator(t *testing.T) {
+	ctx := claimsContext("operator", "auditor")
+	assert.Equal(t, CallerRoleAuditor, extractCallerRole(ctx))
+}

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -15,6 +15,7 @@ import (
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
 	"github.com/meridianhub/meridian/services/reconciliation/domain"
 	"github.com/meridianhub/meridian/shared/pkg/valuation"
+	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/shopspring/decimal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -632,11 +633,41 @@ func (s *AccountReconciliationService) AssertBalance(
 	}, nil
 }
 
-// extractCallerRole reads the caller's role from gRPC metadata.
-// TODO: Replace with validated role from auth interceptor/gateway. Currently
-// trusts client-supplied metadata which is acceptable for internal service-to-service
-// calls but must be secured before external exposure.
+// extractCallerRole determines the caller's role from validated JWT claims.
+// When auth is enabled, the auth interceptor validates the JWT and stores claims
+// in context. This function extracts the role from those validated claims.
+// When auth is disabled (development mode), no claims are present in context,
+// so it falls back to reading the role from gRPC metadata headers.
 func extractCallerRole(ctx context.Context) CallerRole {
+	// Primary: extract role from validated JWT claims (production path)
+	if claims, ok := auth.GetClaimsFromContext(ctx); ok {
+		return mapClaimsToCallerRole(claims)
+	}
+
+	// Fallback: no JWT claims in context means auth is disabled (development mode).
+	// Trust metadata-based role extraction for local development and testing.
+	return extractCallerRoleFromMetadata(ctx)
+}
+
+// mapClaimsToCallerRole maps validated JWT claims to a CallerRole.
+// The role hierarchy uses auth.Role constants from the RBAC system:
+//   - auth.RoleService ("service") -> CallerRoleSystem (service-to-service calls)
+//   - auth.RoleAdmin ("admin") -> CallerRoleSystem (admin has full access)
+//   - auth.RoleAuditor ("auditor") -> CallerRoleAuditor (read-only audit access)
+//   - All others -> CallerRoleTenantAdmin (default tenant-scoped access)
+func mapClaimsToCallerRole(claims *auth.Claims) CallerRole {
+	if claims.HasRole(auth.RoleService.String()) || claims.HasRole(auth.RoleAdmin.String()) {
+		return CallerRoleSystem
+	}
+	if claims.HasRole(auth.RoleAuditor.String()) {
+		return CallerRoleAuditor
+	}
+	return CallerRoleTenantAdmin
+}
+
+// extractCallerRoleFromMetadata reads the caller's role from gRPC metadata.
+// This is only used when auth is disabled (AUTH_ENABLED=false) for development.
+func extractCallerRoleFromMetadata(ctx context.Context) CallerRole {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return CallerRoleTenantAdmin


### PR DESCRIPTION
## Summary

- Replace trusted metadata pattern in `extractCallerRole()` with validated JWT claim extraction from the auth interceptor context
- Map `auth.RoleService`/`auth.RoleAdmin` to `CallerRoleSystem`, `auth.RoleAuditor` to `CallerRoleAuditor`, all others to `CallerRoleTenantAdmin`
- Retain metadata-based extraction only as fallback when auth is disabled (`AUTH_ENABLED=false`) for development mode

## Changes

**`services/reconciliation/service/service.go`**
- Updated `extractCallerRole()` to first check `auth.GetClaimsFromContext(ctx)` for validated JWT claims
- Added `mapClaimsToCallerRole()` to map JWT roles to `CallerRole` enum using `auth.Role` constants
- Extracted metadata path to `extractCallerRoleFromMetadata()` as dev-only fallback
- Removed TODO about replacing with validated role

**`services/reconciliation/service/extract_caller_role_test.go`** (new)
- 14 unit tests covering all role mappings from JWT claims
- Tests for metadata fallback in development mode
- Security test: valid JWT claims (operator/TenantAdmin) + malicious metadata (SYSTEM) verifies JWT wins
- Tests for multiple roles, empty roles, unknown roles

## Security

- **Production**: JWT claims are validated by `auth.Interceptor` before reaching service code. Role extraction uses only validated claims from context.
- **Development**: When `AUTH_ENABLED=false`, no auth interceptor runs and no claims exist in context. Metadata fallback activates only in this case.
- **Attack mitigation**: Even if an attacker sends malicious `x-meridian-role: SYSTEM` metadata alongside a valid JWT with `operator` role, the JWT claims take precedence (verified by `TestExtractCallerRole_JWTWinsOverMetadata`).

## Test plan

- [x] Unit tests for all JWT role mappings (service, admin, auditor, operator, unknown, empty)
- [x] Unit tests for metadata fallback (SYSTEM, AUDITOR, unknown, empty)
- [x] Security test: JWT claims override malicious metadata
- [x] Multiple role tests (service+operator, auditor+operator)
- [x] Full service test suite passes

## Task Master

reconciliation-service-phase2.7 - Secure auth role extraction using validated JWT claims