### PR TITLE
feat: wire VarianceValuator with stub valuation engine

### DIFF
--- a/services/reconciliation/cmd/main.go
+++ b/services/reconciliation/cmd/main.go
@@ -150,10 +150,20 @@ func run(logger *slog.Logger) error {
 		service.WithVarianceDetector(detector.DetectVariances),
 	)
 
-	// VarianceValuator requires valuation engine + reference data provider (not yet available)
+	// Wire VarianceValuator with stub engine (temporary until valuation service ready)
+	// TODO: Replace stub engine with shared/pkg/valuation concrete Engine when available
+	// TODO: Replace stub ref data with gRPC client to Reference Data service
+	stubEngine := service.NewStubValuationEngine()
+	stubRefData := service.NewStubReferenceDataProvider()
+	valuator := service.NewVarianceValuator(stubEngine, stubRefData, varianceRepo, runRepo)
+	serviceOpts = append(serviceOpts,
+		service.WithVarianceValuator(valuator.ValueVariances),
+	)
+	logger.Info("variance valuator configured (using stub engine)",
+		"note", "identity valuation until shared/pkg/valuation implementation available")
+
 	// BalanceAssertor requires assertion repo + PK client (not yet available)
-	// Both will return UNIMPLEMENTED until their dependencies are wired in future tasks
-	logger.Warn("variance valuator not configured: valuation engine not yet available")
+	// Will return UNIMPLEMENTED until its dependencies are wired in future tasks
 	logger.Warn("balance assertor not configured: assertion repository not yet available")
 
 	// Create AccountReconciliationService

--- a/services/reconciliation/service/stub_valuation_engine.go
+++ b/services/reconciliation/service/stub_valuation_engine.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/pkg/valuation"
+	"github.com/shopspring/decimal"
+)
+
+// TODO: Replace StubValuationEngine and StubReferenceDataProvider with real
+// implementations when shared/pkg/valuation has a concrete Engine and the
+// Reference Data service exposes a gRPC client for valuation method lookups.
+
+// StubValuationEngine is a minimal valuation.Engine that performs identity
+// valuation: it returns the input amount unchanged in the same instrument.
+// This unblocks VarianceValuator wiring without waiting for the full
+// valuation service implementation.
+type StubValuationEngine struct{}
+
+// NewStubValuationEngine creates a new StubValuationEngine.
+func NewStubValuationEngine() *StubValuationEngine {
+	return &StubValuationEngine{}
+}
+
+// Valuate returns the input quantity as-is (identity valuation).
+func (e *StubValuationEngine) Valuate(_ context.Context, req *valuation.Request) (*valuation.Response, error) {
+	return &valuation.Response{
+		ValuedAmount: valuation.Quantity{
+			Amount:         req.Quantity.Amount,
+			InstrumentCode: req.Quantity.InstrumentCode,
+		},
+		ComputedAt: time.Now(),
+	}, nil
+}
+
+// StubReferenceDataProvider is a minimal ReferenceDataProvider that returns
+// stub values: a random method ID and a default materiality threshold of 0.01.
+type StubReferenceDataProvider struct{}
+
+// NewStubReferenceDataProvider creates a new StubReferenceDataProvider.
+func NewStubReferenceDataProvider() *StubReferenceDataProvider {
+	return &StubReferenceDataProvider{}
+}
+
+// GetValuationMethodID returns a new random UUID as the valuation method ID.
+func (p *StubReferenceDataProvider) GetValuationMethodID(_ context.Context, _ string) (uuid.UUID, error) {
+	return uuid.New(), nil
+}
+
+// GetMaterialityThreshold returns 0.01 as the default materiality threshold.
+func (p *StubReferenceDataProvider) GetMaterialityThreshold(_ context.Context, _ string) (decimal.Decimal, error) {
+	return decimal.NewFromFloat(0.01), nil
+}

--- a/services/reconciliation/service/stub_valuation_engine_test.go
+++ b/services/reconciliation/service/stub_valuation_engine_test.go
@@ -1,0 +1,162 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/shared/pkg/valuation"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStubValuationEngine_IdentityValuation(t *testing.T) {
+	engine := NewStubValuationEngine()
+
+	req := &valuation.Request{
+		RequestID: uuid.New(),
+		MethodID:  uuid.New(),
+		Quantity: valuation.Quantity{
+			Amount:         decimal.NewFromFloat(100.50),
+			InstrumentCode: "GBP",
+		},
+		AccountID:   uuid.New(),
+		PartyID:     uuid.New(),
+		KnowledgeAt: time.Now(),
+	}
+
+	resp, err := engine.Valuate(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.True(t, req.Quantity.Amount.Equal(resp.ValuedAmount.Amount),
+		"stub engine should return input amount unchanged, got %s", resp.ValuedAmount.Amount)
+	assert.Equal(t, "GBP", resp.ValuedAmount.InstrumentCode,
+		"output instrument should match input instrument")
+	assert.NotZero(t, resp.ComputedAt, "computed_at should be set")
+}
+
+func TestStubValuationEngine_PreservesInstrumentCode(t *testing.T) {
+	engine := NewStubValuationEngine()
+
+	instruments := []string{"GBP", "KWH", "USD", "TONNE_CO2E", "GPU_HOUR"}
+	for _, code := range instruments {
+		req := &valuation.Request{
+			RequestID: uuid.New(),
+			MethodID:  uuid.New(),
+			Quantity: valuation.Quantity{
+				Amount:         decimal.NewFromFloat(42.00),
+				InstrumentCode: code,
+			},
+			AccountID:   uuid.New(),
+			PartyID:     uuid.New(),
+			KnowledgeAt: time.Now(),
+		}
+
+		resp, err := engine.Valuate(context.Background(), req)
+		require.NoError(t, err)
+		assert.Equal(t, code, resp.ValuedAmount.InstrumentCode,
+			"instrument code should be preserved for %s", code)
+	}
+}
+
+func TestStubValuationEngine_VariousAmounts(t *testing.T) {
+	engine := NewStubValuationEngine()
+
+	amounts := []decimal.Decimal{
+		decimal.NewFromFloat(0.001),
+		decimal.NewFromFloat(100.00),
+		decimal.NewFromFloat(-25.50),
+		decimal.NewFromFloat(999999.99),
+		decimal.Zero,
+	}
+
+	for _, amount := range amounts {
+		req := &valuation.Request{
+			RequestID: uuid.New(),
+			MethodID:  uuid.New(),
+			Quantity: valuation.Quantity{
+				Amount:         amount,
+				InstrumentCode: "GBP",
+			},
+			AccountID:   uuid.New(),
+			PartyID:     uuid.New(),
+			KnowledgeAt: time.Now(),
+		}
+
+		resp, err := engine.Valuate(context.Background(), req)
+		require.NoError(t, err)
+		assert.True(t, amount.Equal(resp.ValuedAmount.Amount),
+			"amount %s should pass through unchanged", amount)
+	}
+}
+
+func TestStubReferenceDataProvider_GetValuationMethodID(t *testing.T) {
+	provider := NewStubReferenceDataProvider()
+
+	id, err := provider.GetValuationMethodID(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, id, "should return a non-nil UUID")
+}
+
+func TestStubReferenceDataProvider_GetMaterialityThreshold(t *testing.T) {
+	provider := NewStubReferenceDataProvider()
+
+	threshold, err := provider.GetMaterialityThreshold(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromFloat(0.01).Equal(threshold),
+		"default materiality threshold should be 0.01, got %s", threshold)
+}
+
+func TestStubValuationEngine_IntegrationWithVarianceValuator(t *testing.T) {
+	runRepo := newMockRunRepo()
+	varianceRepo := &mockVarianceRepoFull{}
+
+	run := newRunningTestRun(t)
+	_ = runRepo.Create(context.Background(), run)
+
+	// Create a detected variance with amount 100.00 GBP
+	v := createDetectedVariance(t, run.RunID, "ACC-001", "GBP", decimal.NewFromFloat(100.00))
+	varianceRepo.variances = []*domain.Variance{v}
+
+	stubEngine := NewStubValuationEngine()
+	stubRefData := NewStubReferenceDataProvider()
+
+	valuator := NewVarianceValuator(stubEngine, stubRefData, varianceRepo, runRepo)
+	err := valuator.ValueVariances(context.Background(), run.RunID)
+	require.NoError(t, err)
+
+	// Identity valuation: ValueDelta should match the variance amount
+	assert.Equal(t, domain.VarianceStatusValued, varianceRepo.variances[0].Status,
+		"variance should transition DETECTED -> VALUED")
+	assert.True(t, varianceRepo.variances[0].ValueDelta.Equal(v.VarianceAmount),
+		"value delta should match variance amount for identity valuation")
+	assert.Equal(t, "GBP", varianceRepo.variances[0].Currency)
+}
+
+func TestStubValuationEngine_MaterialityAutoAccept(t *testing.T) {
+	runRepo := newMockRunRepo()
+	varianceRepo := &mockVarianceRepoFull{}
+
+	run := newRunningTestRun(t)
+	_ = runRepo.Create(context.Background(), run)
+
+	// Create a variance with amount below default threshold (0.01)
+	v := createDetectedVariance(t, run.RunID, "ACC-001", "GBP", decimal.NewFromFloat(0.005))
+	varianceRepo.variances = []*domain.Variance{v}
+
+	stubEngine := NewStubValuationEngine()
+	stubRefData := NewStubReferenceDataProvider()
+
+	valuator := NewVarianceValuator(stubEngine, stubRefData, varianceRepo, runRepo)
+	err := valuator.ValueVariances(context.Background(), run.RunID)
+	require.NoError(t, err)
+
+	// Below materiality threshold: should be auto-accepted
+	assert.Equal(t, domain.VarianceStatusAccepted, varianceRepo.variances[0].Status,
+		"variance below materiality should be auto-accepted")
+	assert.Contains(t, varianceRepo.variances[0].ResolutionNote, "auto-accepted")
+}


### PR DESCRIPTION
## Summary

- Add `StubValuationEngine` that performs identity valuation (returns input amount unchanged in same instrument) to unblock `VarianceValuator` wiring
- Add `StubReferenceDataProvider` returning stub method IDs and default 0.01 materiality threshold
- Wire `VarianceValuator` in `cmd/main.go` with stub dependencies, replacing the "not configured" warning

## Changes

| File | Change |
|------|--------|
| `service/stub_valuation_engine.go` | New stub `valuation.Engine` and `ReferenceDataProvider` implementations |
| `service/stub_valuation_engine_test.go` | Unit tests (identity valuation, instrument preservation, various amounts) and integration tests (DETECTED->VALUED, materiality auto-accept) |
| `cmd/main.go` | Wire `VarianceValuator` with stub engine after `VarianceDetector`; remove valuator warning |

## Task Master

Task: `reconciliation-service-phase2.5` - Wire VarianceValuator with stub valuation engine

## Test Plan

- [x] Unit: StubValuationEngine returns input amount unchanged
- [x] Unit: StubValuationEngine preserves instrument code across GBP, KWH, USD, TONNE_CO2E, GPU_HOUR
- [x] Unit: StubValuationEngine handles zero, negative, small, and large amounts
- [x] Unit: StubReferenceDataProvider returns non-nil UUID and 0.01 threshold
- [x] Integration: Variance with 100.00 GBP transitions DETECTED -> VALUED with correct ValueDelta
- [x] Integration: Variance with 0.005 (below 0.01 threshold) auto-accepted
- [x] All existing reconciliation service tests continue to pass