### PR TITLE
feat: implement BalanceAssertionRepository persistence adapter

### DIFF
--- a/services/reconciliation/adapters/persistence/balance_assertion_repository.go
+++ b/services/reconciliation/adapters/persistence/balance_assertion_repository.go
@@ -1,0 +1,289 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+// Compile-time check that BalanceAssertionRepository implements domain.BalanceAssertionRepository.
+var _ domain.BalanceAssertionRepository = (*BalanceAssertionRepository)(nil)
+
+// BalanceAssertionEntity is the GORM entity for the balance_assertion table.
+type BalanceAssertionEntity struct {
+	ID              uuid.UUID       `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	CreatedAt       time.Time       `gorm:"not null;default:now()"`
+	UpdatedAt       time.Time       `gorm:"not null;default:now()"`
+	AssertionID     uuid.UUID       `gorm:"column:assertion_id;uniqueIndex:idx_ba_assertion_id;type:uuid;not null"`
+	RunID           *uuid.UUID      `gorm:"column:run_id;index:idx_ba_run_id;type:uuid"`
+	AccountID       string          `gorm:"column:account_id;index:idx_ba_account_id;size:34;not null"`
+	InstrumentCode  string          `gorm:"column:instrument_code;index:idx_ba_instrument_code;size:20;not null"`
+	Expression      string          `gorm:"column:expression;type:text;not null"`
+	ExpectedBalance decimal.Decimal `gorm:"column:expected_balance;type:decimal(38,18);not null"`
+	ActualBalance   decimal.Decimal `gorm:"column:actual_balance;type:decimal(38,18);not null;default:0"`
+	Status          string          `gorm:"column:status;index:idx_ba_status;size:20;not null;default:PENDING"`
+	FailureReason   *string         `gorm:"column:failure_reason;type:text"`
+	OverrideReason  *string         `gorm:"column:override_reason;type:text"`
+	Attributes      JSONMap         `gorm:"column:attributes;type:jsonb"`
+	Metadata        JSONMap         `gorm:"column:metadata;type:jsonb"`
+	AssertedAt      *time.Time      `gorm:"column:asserted_at"`
+	Version         int64           `gorm:"column:version;not null;default:1"`
+}
+
+// TableName returns the table name for the balance assertion entity.
+func (BalanceAssertionEntity) TableName() string {
+	return "balance_assertion"
+}
+
+// BalanceAssertionRepository provides GORM-based persistence for balance assertions.
+type BalanceAssertionRepository struct {
+	db *gorm.DB
+}
+
+// NewBalanceAssertionRepository creates a new balance assertion repository.
+func NewBalanceAssertionRepository(db *gorm.DB) *BalanceAssertionRepository {
+	return &BalanceAssertionRepository{db: db}
+}
+
+// withTenantTransaction executes fn within a tenant-scoped transaction.
+func (r *BalanceAssertionRepository) withTenantTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	if r.isInTransaction() {
+		tx, err := db.WithGormTenantScope(ctx, r.db.WithContext(ctx))
+		if err != nil {
+			return err
+		}
+		return fn(tx)
+	}
+	return db.WithGormTenantTransaction(ctx, r.db, fn)
+}
+
+// isInTransaction checks if the repository's db connection is already within a transaction.
+func (r *BalanceAssertionRepository) isInTransaction() bool {
+	if r.db.Statement == nil || r.db.Statement.ConnPool == nil {
+		return false
+	}
+	committer, ok := r.db.Statement.ConnPool.(gorm.TxCommitter)
+	return ok && committer != nil
+}
+
+// Create persists a new BalanceAssertion.
+func (r *BalanceAssertionRepository) Create(ctx context.Context, assertion *domain.BalanceAssertion) error {
+	entity := toBalanceAssertionEntity(assertion)
+	if entity.Version == 0 {
+		entity.Version = 1
+	}
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Create(entity).Error
+	})
+}
+
+// FindByID retrieves a BalanceAssertion by its AssertionID.
+func (r *BalanceAssertionRepository) FindByID(ctx context.Context, assertionID uuid.UUID) (*domain.BalanceAssertion, error) {
+	var entity BalanceAssertionEntity
+	var queryErr error
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Where("assertion_id = ?", assertionID).First(&entity)
+		if result.Error != nil {
+			queryErr = result.Error
+			return result.Error
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(queryErr, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, err
+	}
+
+	return toDomainBalanceAssertion(&entity), nil
+}
+
+// FindByRunID retrieves all assertions for a settlement run.
+func (r *BalanceAssertionRepository) FindByRunID(ctx context.Context, runID uuid.UUID) ([]*domain.BalanceAssertion, error) {
+	var entities []BalanceAssertionEntity
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Where("run_id = ?", runID).
+			Order("created_at ASC").
+			Find(&entities).Error
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toBalanceAssertionDomainSlice(entities), nil
+}
+
+// Update updates an existing BalanceAssertion using optimistic locking.
+func (r *BalanceAssertionRepository) Update(ctx context.Context, assertion *domain.BalanceAssertion) error {
+	entity := toBalanceAssertionEntity(assertion)
+	var rowsAffected int64
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Model(&BalanceAssertionEntity{}).
+			Where("assertion_id = ? AND version = ?", entity.AssertionID, entity.Version-1).
+			Updates(map[string]interface{}{
+				"status":          entity.Status,
+				"actual_balance":  entity.ActualBalance,
+				"failure_reason":  entity.FailureReason,
+				"override_reason": entity.OverrideReason,
+				"attributes":      entity.Attributes,
+				"metadata":        entity.Metadata,
+				"asserted_at":     entity.AssertedAt,
+				"version":         entity.Version,
+				"updated_at":      time.Now().UTC(),
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		var count int64
+		countErr := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+			return tx.Model(&BalanceAssertionEntity{}).Where("assertion_id = ?", entity.AssertionID).Count(&count).Error
+		})
+		if countErr != nil {
+			return countErr
+		}
+		if count == 0 {
+			return domain.ErrNotFound
+		}
+		return domain.ErrOptimisticLock
+	}
+	return nil
+}
+
+// List retrieves assertions matching the given filter with pagination.
+func (r *BalanceAssertionRepository) List(ctx context.Context, filter domain.AssertionFilter) ([]*domain.BalanceAssertion, error) {
+	var entities []BalanceAssertionEntity
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		query := tx.Model(&BalanceAssertionEntity{})
+
+		if filter.RunID != nil {
+			query = query.Where("run_id = ?", *filter.RunID)
+		}
+		if filter.AccountID != nil {
+			query = query.Where("account_id = ?", *filter.AccountID)
+		}
+		if filter.InstrumentCode != nil {
+			query = query.Where("instrument_code = ?", *filter.InstrumentCode)
+		}
+		if filter.Status != nil {
+			query = query.Where("status = ?", string(*filter.Status))
+		}
+
+		limit := filter.Limit
+		if limit <= 0 {
+			limit = 50
+		}
+		if limit > 1000 {
+			limit = 1000
+		}
+		query = query.Limit(limit)
+
+		if filter.Offset > 0 {
+			query = query.Offset(filter.Offset)
+		}
+
+		return query.Order("created_at DESC").Find(&entities).Error
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toBalanceAssertionDomainSlice(entities), nil
+}
+
+// toBalanceAssertionEntity converts a domain BalanceAssertion to a persistence entity.
+func toBalanceAssertionEntity(a *domain.BalanceAssertion) *BalanceAssertionEntity {
+	entity := &BalanceAssertionEntity{
+		AssertionID:     a.AssertionID,
+		RunID:           a.RunID,
+		AccountID:       a.AccountID,
+		InstrumentCode:  a.InstrumentCode,
+		Expression:      a.Expression,
+		ExpectedBalance: a.ExpectedBalance,
+		ActualBalance:   a.ActualBalance,
+		Status:          string(a.Status),
+		CreatedAt:       a.CreatedAt,
+		UpdatedAt:       a.UpdatedAt,
+		Version:         a.Version,
+	}
+
+	if a.FailureReason != "" {
+		entity.FailureReason = &a.FailureReason
+	}
+	if a.OverrideReason != "" {
+		entity.OverrideReason = &a.OverrideReason
+	}
+	if a.Attributes != nil {
+		entity.Attributes = JSONMap(a.Attributes)
+	}
+	if a.Metadata != nil {
+		entity.Metadata = JSONMap(a.Metadata)
+	}
+	if !a.AssertedAt.IsZero() {
+		assertedAt := a.AssertedAt
+		entity.AssertedAt = &assertedAt
+	}
+
+	return entity
+}
+
+// toDomainBalanceAssertion converts a persistence entity to a domain BalanceAssertion.
+func toDomainBalanceAssertion(e *BalanceAssertionEntity) *domain.BalanceAssertion {
+	a := &domain.BalanceAssertion{
+		AssertionID:     e.AssertionID,
+		RunID:           e.RunID,
+		AccountID:       e.AccountID,
+		InstrumentCode:  e.InstrumentCode,
+		Expression:      e.Expression,
+		ExpectedBalance: e.ExpectedBalance,
+		ActualBalance:   e.ActualBalance,
+		Status:          domain.AssertionStatus(e.Status),
+		CreatedAt:       e.CreatedAt,
+		UpdatedAt:       e.UpdatedAt,
+		Version:         e.Version,
+	}
+
+	if e.FailureReason != nil {
+		a.FailureReason = *e.FailureReason
+	}
+	if e.OverrideReason != nil {
+		a.OverrideReason = *e.OverrideReason
+	}
+	if e.Attributes != nil {
+		a.Attributes = map[string]string(e.Attributes)
+	}
+	if e.Metadata != nil {
+		a.Metadata = map[string]string(e.Metadata)
+	}
+	if e.AssertedAt != nil {
+		a.AssertedAt = *e.AssertedAt
+	}
+
+	return a
+}
+
+// toBalanceAssertionDomainSlice converts a slice of entities to domain objects.
+func toBalanceAssertionDomainSlice(entities []BalanceAssertionEntity) []*domain.BalanceAssertion {
+	assertions := make([]*domain.BalanceAssertion, 0, len(entities))
+	for i := range entities {
+		assertions = append(assertions, toDomainBalanceAssertion(&entities[i]))
+	}
+	return assertions
+}

--- a/services/reconciliation/adapters/persistence/balance_assertion_repository_test.go
+++ b/services/reconciliation/adapters/persistence/balance_assertion_repository_test.go
@@ -1,0 +1,453 @@
+package persistence_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/adapters/persistence"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestBalanceAssertion(t *testing.T) *domain.BalanceAssertion {
+	t.Helper()
+	runID := uuid.New()
+	a, err := domain.NewBalanceAssertion(
+		&runID, "ACC-001", "GBP",
+		"sum(positions) == expected",
+		decimal.NewFromFloat(10000.00),
+	)
+	require.NoError(t, err)
+	return a
+}
+
+func TestBalanceAssertionRepository_Create(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewBalanceAssertionRepository(db)
+	ctx := tenantCtx()
+
+	assertion := newTestBalanceAssertion(t)
+	assertion.Attributes = map[string]string{"source": "test"}
+	assertion.Metadata = map[string]string{"tenant": "demo"}
+
+	err := repo.Create(ctx, assertion)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, assertion.AssertionID)
+	require.NoError(t, err)
+	assert.Equal(t, assertion.AssertionID, found.AssertionID)
+	assert.Equal(t, "ACC-001", found.AccountID)
+	assert.Equal(t, "GBP", found.InstrumentCode)
+	assert.Equal(t, "sum(positions) == expected", found.Expression)
+	assert.True(t, decimal.NewFromFloat(10000.00).Equal(found.ExpectedBalance))
+	assert.True(t, decimal.Zero.Equal(found.ActualBalance))
+	assert.Equal(t, domain.AssertionStatusPending, found.Status)
+	assert.Equal(t, int64(1), found.Version)
+	assert.Equal(t, "test", found.Attributes["source"])
+	assert.Equal(t, "demo", found.Metadata["tenant"])
+	assert.Empty(t, found.FailureReason)
+	assert.Empty(t, found.OverrideReason)
+	assert.NotNil(t, found.RunID)
+}
+
+func TestBalanceAssertionRepository_CreateStandalone(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewBalanceAssertionRepository(db)
+	ctx := tenantCtx()
+
+	a, err := domain.NewBalanceAssertion(
+		nil, "ACC-002", "EUR",
+		"total_debits == total_credits",
+		decimal.Zero,
+	)
+	require.NoError(t, err)
+
+	err = repo.Create(ctx, a)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, a.AssertionID)
+	require.NoError(t, err)
+	assert.Nil(t, found.RunID)
+	assert.Equal(t, "ACC-002", found.AccountID)
+	assert.Equal(t, "EUR", found.InstrumentCode)
+}
+
+func TestBalanceAssertionRepository_FindByID(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewBalanceAssertionRepository(db)
+	ctx := tenantCtx()
+
+	t.Run("existing assertion", func(t *testing.T) {
+		assertion := newTestBalanceAssertion(t)
+		require.NoError(t, repo.Create(ctx, assertion))
+
+		found, err := repo.FindByID(ctx, assertion.AssertionID)
+		require.NoError(t, err)
+		assert.Equal(t, assertion.AssertionID, found.AssertionID)
+		assert.Equal(t, assertion.AccountID, found.AccountID)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := repo.FindByID(ctx, uuid.New())
+		assert.ErrorIs(t, err, domain.ErrNotFound)
+	})
+}
+
+func TestBalanceAssertionRepository_FindByRunID(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewBalanceAssertionRepository(db)
+	ctx := tenantCtx()
+
+	runID := uuid.New()
+
+	a1, err := domain.NewBalanceAssertion(&runID, "ACC-001", "GBP", "expr1", decimal.NewFromFloat(100.00))
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, a1))
+
+	a2, err := domain.NewBalanceAssertion(&runID, "ACC-001", "EUR", "expr2", decimal.NewFromFloat(200.00))
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, a2))
+
+	// Different run
+	otherRunID := uuid.New()
+	a3, err := domain.NewBalanceAssertion(&otherRunID, "ACC-001", "GBP", "expr3", decimal.NewFromFloat(300.00))
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, a3))
+
+	found, err := repo.FindByRunID(ctx, runID)
+	require.NoError(t, err)
+	assert.Len(t, found, 2)
+
+	t.Run("empty result for unknown run", func(t *testing.T) {
+		found, err := repo.FindByRunID(ctx, uuid.New())
+		require.NoError(t, err)
+		assert.Empty(t, found)
+	})
+}
+
+func TestBalanceAssertionRepository_Update(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewBalanceAssertionRepository(db)
+	ctx := tenantCtx()
+
+	assertion := newTestBalanceAssertion(t)
+	require.NoError(t, repo.Create(ctx, assertion))
+
+	// Pass the assertion
+	require.NoError(t, assertion.Pass(decimal.NewFromFloat(10000.00)))
+	err := repo.Update(ctx, assertion)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, assertion.AssertionID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.AssertionStatusPassed, found.Status)
+	assert.True(t, decimal.NewFromFloat(10000.00).Equal(found.ActualBalance))
+	assert.Equal(t, int64(2), found.Version)
+	assert.False(t, found.AssertedAt.IsZero())
+}
+
+func TestBalanceAssertionRepository_UpdateFailed(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewBalanceAssertionRepository(db)
+	ctx := tenantCtx()
+
+	assertion := newTestBalanceAssertion(t)
+	require.NoError(t, repo.Create(ctx, assertion))
+
+	require.NoError(t, assertion.Fail(decimal.NewFromFloat(9500.00), "Balance mismatch"))
+	require.NoError(t, repo.Update(ctx, assertion))
+
+	found, err := repo.FindByID(ctx, assertion.AssertionID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.AssertionStatusFailed, found.Status)
+	assert.True(t, decimal.NewFromFloat(9500.00).Equal(found.ActualBalance))
+	assert.Equal(t, "Balance mismatch", found.FailureReason)
+	assert.Equal(t, int64(2), found.Version)
+}
+
+func TestBalanceAssertionRepository_UpdateOverride(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewBalanceAssertionRepository(db)
+	ctx := tenantCtx()
+
+	assertion := newTestBalanceAssertion(t)
+	require.NoError(t, repo.Create(ctx, assertion))
+
+	// Fail then override
+	require.NoError(t, assertion.Fail(decimal.NewFromFloat(9500.00), "mismatch"))
+	require.NoError(t, repo.Update(ctx, assertion))
+
+	require.NoError(t, assertion.Override("approved by manager"))
+	require.NoError(t, repo.Update(ctx, assertion))
+
+	found, err := repo.FindByID(ctx, assertion.AssertionID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.AssertionStatusOverride, found.Status)
+	assert.Equal(t, "mismatch", found.FailureReason)
+	assert.Equal(t, "approved by manager", found.OverrideReason)
+	assert.Equal(t, int64(3), found.Version)
+}
+
+func TestBalanceAssertionRepository_UpdateOptimisticLock(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewBalanceAssertionRepository(db)
+	ctx := tenantCtx()
+
+	assertion := newTestBalanceAssertion(t)
+	require.NoError(t, repo.Create(ctx, assertion))
+
+	// Load two copies
+	copy1, err := repo.FindByID(ctx, assertion.AssertionID)
+	require.NoError(t, err)
+
+	copy2, err := repo.FindByID(ctx, assertion.AssertionID)
+	require.NoError(t, err)
+
+	// First update succeeds
+	require.NoError(t, copy1.Pass(decimal.NewFromFloat(10000.00)))
+	err = repo.Update(ctx, copy1)
+	require.NoError(t, err)
+
+	// Second update with stale version fails
+	require.NoError(t, copy2.Fail(decimal.NewFromFloat(9500.00), "mismatch"))
+	err = repo.Update(ctx, copy2)
+	assert.ErrorIs(t, err, domain.ErrOptimisticLock)
+}
+
+func TestBalanceAssertionRepository_UpdateNotFound(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewBalanceAssertionRepository(db)
+	ctx := tenantCtx()
+
+	assertion := newTestBalanceAssertion(t)
+	assertion.Version = 2
+
+	err := repo.Update(ctx, assertion)
+	assert.ErrorIs(t, err, domain.ErrNotFound)
+}
+
+func TestBalanceAssertionRepository_List(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewBalanceAssertionRepository(db)
+	ctx := tenantCtx()
+
+	runID := uuid.New()
+	otherRunID := uuid.New()
+
+	a1, err := domain.NewBalanceAssertion(&runID, "ACC-001", "GBP", "expr1", decimal.NewFromFloat(100.00))
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, a1))
+
+	a2, err := domain.NewBalanceAssertion(&runID, "ACC-002", "EUR", "expr2", decimal.NewFromFloat(200.00))
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, a2))
+
+	a3, err := domain.NewBalanceAssertion(&otherRunID, "ACC-001", "GBP", "expr3", decimal.NewFromFloat(300.00))
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, a3))
+
+	// Fail one for status filtering
+	require.NoError(t, a3.Fail(decimal.NewFromFloat(250.00), "mismatch"))
+	require.NoError(t, repo.Update(ctx, a3))
+
+	t.Run("list all", func(t *testing.T) {
+		found, err := repo.List(ctx, domain.AssertionFilter{})
+		require.NoError(t, err)
+		assert.Len(t, found, 3)
+	})
+
+	t.Run("filter by run", func(t *testing.T) {
+		found, err := repo.List(ctx, domain.AssertionFilter{RunID: &runID})
+		require.NoError(t, err)
+		assert.Len(t, found, 2)
+	})
+
+	t.Run("filter by account", func(t *testing.T) {
+		accountID := "ACC-001"
+		found, err := repo.List(ctx, domain.AssertionFilter{AccountID: &accountID})
+		require.NoError(t, err)
+		assert.Len(t, found, 2)
+		for _, a := range found {
+			assert.Equal(t, "ACC-001", a.AccountID)
+		}
+	})
+
+	t.Run("filter by instrument code", func(t *testing.T) {
+		instrumentCode := "EUR"
+		found, err := repo.List(ctx, domain.AssertionFilter{InstrumentCode: &instrumentCode})
+		require.NoError(t, err)
+		assert.Len(t, found, 1)
+		assert.Equal(t, "EUR", found[0].InstrumentCode)
+	})
+
+	t.Run("filter by status", func(t *testing.T) {
+		status := domain.AssertionStatusFailed
+		found, err := repo.List(ctx, domain.AssertionFilter{Status: &status})
+		require.NoError(t, err)
+		assert.Len(t, found, 1)
+		assert.Equal(t, domain.AssertionStatusFailed, found[0].Status)
+	})
+
+	t.Run("filter by pending status", func(t *testing.T) {
+		status := domain.AssertionStatusPending
+		found, err := repo.List(ctx, domain.AssertionFilter{Status: &status})
+		require.NoError(t, err)
+		assert.Len(t, found, 2)
+	})
+}
+
+func TestBalanceAssertionRepository_ListPagination(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewBalanceAssertionRepository(db)
+	ctx := tenantCtx()
+
+	// Create 5 assertions
+	for i := 0; i < 5; i++ {
+		a := newTestBalanceAssertion(t)
+		require.NoError(t, repo.Create(ctx, a))
+		// Small delay to ensure distinct created_at for ordering
+		time.Sleep(time.Millisecond)
+	}
+
+	t.Run("limit", func(t *testing.T) {
+		found, err := repo.List(ctx, domain.AssertionFilter{Limit: 2})
+		require.NoError(t, err)
+		assert.Len(t, found, 2)
+	})
+
+	t.Run("offset", func(t *testing.T) {
+		found, err := repo.List(ctx, domain.AssertionFilter{Limit: 10, Offset: 3})
+		require.NoError(t, err)
+		assert.Len(t, found, 2)
+	})
+
+	t.Run("default limit", func(t *testing.T) {
+		found, err := repo.List(ctx, domain.AssertionFilter{})
+		require.NoError(t, err)
+		assert.Len(t, found, 5)
+	})
+
+	t.Run("max limit cap", func(t *testing.T) {
+		found, err := repo.List(ctx, domain.AssertionFilter{Limit: 5000})
+		require.NoError(t, err)
+		assert.Len(t, found, 5)
+	})
+}
+
+func TestBalanceAssertionRepository_DomainConversionRoundtrip(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewBalanceAssertionRepository(db)
+	ctx := tenantCtx()
+
+	runID := uuid.New()
+	original, err := domain.NewBalanceAssertion(
+		&runID, "ACC-001", "GBP",
+		"sum(positions) == expected",
+		decimal.NewFromFloat(10000.50),
+	)
+	require.NoError(t, err)
+	original.Attributes = map[string]string{"key1": "val1", "key2": "val2"}
+	original.Metadata = map[string]string{"env": "test", "region": "uk"}
+
+	require.NoError(t, repo.Create(ctx, original))
+
+	// Fail it to populate more fields
+	require.NoError(t, original.Fail(decimal.NewFromFloat(9999.25), "off by 1.25"))
+	require.NoError(t, repo.Update(ctx, original))
+
+	// Override it
+	require.NoError(t, original.Override("within tolerance"))
+	require.NoError(t, repo.Update(ctx, original))
+
+	found, err := repo.FindByID(ctx, original.AssertionID)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.AssertionID, found.AssertionID)
+	assert.Equal(t, *original.RunID, *found.RunID)
+	assert.Equal(t, original.AccountID, found.AccountID)
+	assert.Equal(t, original.InstrumentCode, found.InstrumentCode)
+	assert.Equal(t, original.Expression, found.Expression)
+	assert.True(t, original.ExpectedBalance.Equal(found.ExpectedBalance))
+	assert.True(t, original.ActualBalance.Equal(found.ActualBalance))
+	assert.Equal(t, original.Status, found.Status)
+	assert.Equal(t, original.FailureReason, found.FailureReason)
+	assert.Equal(t, original.OverrideReason, found.OverrideReason)
+	assert.Equal(t, original.Attributes, found.Attributes)
+	assert.Equal(t, original.Metadata, found.Metadata)
+	assert.Equal(t, original.Version, found.Version)
+	assert.False(t, found.AssertedAt.IsZero())
+}
+
+func TestBalanceAssertionRepository_JSONBSerialization(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewBalanceAssertionRepository(db)
+	ctx := tenantCtx()
+
+	t.Run("nil attributes and metadata", func(t *testing.T) {
+		a := newTestBalanceAssertion(t)
+		a.Attributes = nil
+		a.Metadata = nil
+		require.NoError(t, repo.Create(ctx, a))
+
+		found, err := repo.FindByID(ctx, a.AssertionID)
+		require.NoError(t, err)
+		assert.Nil(t, found.Attributes)
+		assert.Nil(t, found.Metadata)
+	})
+
+	t.Run("empty attributes and metadata", func(t *testing.T) {
+		a := newTestBalanceAssertion(t)
+		a.Attributes = map[string]string{}
+		a.Metadata = map[string]string{}
+		require.NoError(t, repo.Create(ctx, a))
+
+		found, err := repo.FindByID(ctx, a.AssertionID)
+		require.NoError(t, err)
+		// Empty maps may come back as nil from JSONB
+		assert.True(t, len(found.Attributes) == 0)
+		assert.True(t, len(found.Metadata) == 0)
+	})
+
+	t.Run("populated attributes and metadata", func(t *testing.T) {
+		a := newTestBalanceAssertion(t)
+		a.Attributes = map[string]string{"key": "value", "special": "chars!@#$%"}
+		a.Metadata = map[string]string{"version": "1.0", "source": "api"}
+		require.NoError(t, repo.Create(ctx, a))
+
+		found, err := repo.FindByID(ctx, a.AssertionID)
+		require.NoError(t, err)
+		assert.Equal(t, "value", found.Attributes["key"])
+		assert.Equal(t, "chars!@#$%", found.Attributes["special"])
+		assert.Equal(t, "1.0", found.Metadata["version"])
+		assert.Equal(t, "api", found.Metadata["source"])
+	})
+}

--- a/services/reconciliation/adapters/persistence/dispute_repository_test.go
+++ b/services/reconciliation/adapters/persistence/dispute_repository_test.go
@@ -117,6 +117,32 @@ func setupTestDB(t *testing.T) (*gorm.DB, func()) {
 		);
 		CREATE UNIQUE INDEX IF NOT EXISTS "idx_d_disp_id" ON "dispute" ("dispute_id");
 
+		CREATE TABLE IF NOT EXISTS "balance_assertion" (
+			"id" uuid NOT NULL DEFAULT gen_random_uuid(),
+			"created_at" timestamptz NOT NULL DEFAULT now(),
+			"updated_at" timestamptz NOT NULL DEFAULT now(),
+			"assertion_id" uuid NOT NULL,
+			"run_id" uuid NULL,
+			"account_id" character varying(34) NOT NULL,
+			"instrument_code" character varying(20) NOT NULL,
+			"expression" text NOT NULL,
+			"expected_balance" decimal(38, 18) NOT NULL,
+			"actual_balance" decimal(38, 18) NOT NULL DEFAULT 0,
+			"status" character varying(20) NOT NULL DEFAULT 'PENDING',
+			"failure_reason" text NULL,
+			"override_reason" text NULL,
+			"attributes" jsonb NULL,
+			"metadata" jsonb NULL,
+			"asserted_at" timestamptz NULL,
+			"version" bigint NOT NULL DEFAULT 1,
+			PRIMARY KEY ("id")
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS "idx_ba_assertion_id" ON "balance_assertion" ("assertion_id");
+		CREATE INDEX IF NOT EXISTS "idx_ba_run_id" ON "balance_assertion" ("run_id");
+		CREATE INDEX IF NOT EXISTS "idx_ba_account_id" ON "balance_assertion" ("account_id");
+		CREATE INDEX IF NOT EXISTS "idx_ba_instrument_code" ON "balance_assertion" ("instrument_code");
+		CREATE INDEX IF NOT EXISTS "idx_ba_status" ON "balance_assertion" ("status");
+
 		SET search_path TO public;
 	`
 	err = db.Exec(migrationSQL).Error

--- a/services/reconciliation/domain/balance_assertion.go
+++ b/services/reconciliation/domain/balance_assertion.go
@@ -44,11 +44,20 @@ type BalanceAssertion struct {
 	// Attributes stores flexible metadata.
 	Attributes map[string]string
 
+	// Metadata stores additional structured metadata.
+	Metadata map[string]string
+
 	// AssertedAt is when the assertion was evaluated.
 	AssertedAt time.Time
 
 	// CreatedAt is when this record was created.
 	CreatedAt time.Time
+
+	// UpdatedAt is when this record was last updated.
+	UpdatedAt time.Time
+
+	// Version is used for optimistic locking.
+	Version int64
 }
 
 // NewBalanceAssertion creates a new BalanceAssertion with validation.
@@ -79,6 +88,8 @@ func NewBalanceAssertion(
 		ExpectedBalance: expectedBalance,
 		Status:          AssertionStatusPending,
 		CreatedAt:       now,
+		UpdatedAt:       now,
+		Version:         1,
 	}, nil
 }
 
@@ -87,9 +98,12 @@ func (a *BalanceAssertion) Pass(actualBalance decimal.Decimal) error {
 	if !a.Status.CanTransitionTo(AssertionStatusPassed) {
 		return ErrInvalidStatusTransition
 	}
+	now := time.Now().UTC()
 	a.Status = AssertionStatusPassed
 	a.ActualBalance = actualBalance
-	a.AssertedAt = time.Now().UTC()
+	a.AssertedAt = now
+	a.UpdatedAt = now
+	a.Version++
 	return nil
 }
 
@@ -98,10 +112,13 @@ func (a *BalanceAssertion) Fail(actualBalance decimal.Decimal, reason string) er
 	if !a.Status.CanTransitionTo(AssertionStatusFailed) {
 		return ErrInvalidStatusTransition
 	}
+	now := time.Now().UTC()
 	a.Status = AssertionStatusFailed
 	a.ActualBalance = actualBalance
 	a.FailureReason = reason
-	a.AssertedAt = time.Now().UTC()
+	a.AssertedAt = now
+	a.UpdatedAt = now
+	a.Version++
 	return nil
 }
 
@@ -114,5 +131,7 @@ func (a *BalanceAssertion) Override(reason string) error {
 	}
 	a.Status = AssertionStatusOverride
 	a.OverrideReason = reason
+	a.UpdatedAt = time.Now().UTC()
+	a.Version++
 	return nil
 }


### PR DESCRIPTION
## Summary

- Implement GORM-based persistence adapter for `BalanceAssertion` domain entity with full CRUD operations
- Add optimistic locking via version field on domain model and entity
- Add `Metadata`, `UpdatedAt`, and `Version` fields to domain `BalanceAssertion` struct
- CockroachDB compatible (no triggers, no LISTEN/NOTIFY)

## Changes

### Domain (`services/reconciliation/domain/balance_assertion.go`)
- Add `Version int64`, `UpdatedAt time.Time`, `Metadata map[string]string` fields
- Initialize `Version=1` and `UpdatedAt` in constructor
- Bump version on state transitions (Pass, Fail, Override)

### Repository (`services/reconciliation/adapters/persistence/balance_assertion_repository.go`)
- `BalanceAssertionEntity` with GORM tags, indexes, and JSONB columns
- `Create` - tenant-scoped insert with default version
- `FindByID` - tenant-scoped query returning `ErrNotFound` for missing records
- `FindByRunID` - tenant-scoped query returning all assertions for a run
- `Update` - optimistic locking via `WHERE version = version-1`, returns `ErrOptimisticLock` on conflict
- `List` - filtered query with pagination (limit/offset), supports RunID, AccountID, InstrumentCode, Status filters
- Domain-entity conversion functions with JSONB and nullable field handling

### Tests (`services/reconciliation/adapters/persistence/balance_assertion_repository_test.go`)
- Integration tests using `testdb.SetupCockroachDB`
- Covers: Create, CreateStandalone, FindByID (existing + not found), FindByRunID (multiple + empty), Update, UpdateFailed, UpdateOverride, UpdateOptimisticLock, UpdateNotFound, List (6 filter combinations), ListPagination (4 scenarios), DomainConversionRoundtrip, JSONBSerialization (nil/empty/populated)

## Test plan

- [x] All domain tests pass (no regressions from new fields)
- [x] All 13 integration test functions pass against CockroachDB testcontainers
- [x] Pre-commit checks pass (gofumpt + golangci-lint)
- [ ] CI pipeline passes

## Task Master

reconciliation-service-phase2.1 - Implement BalanceAssertionRepository persistence adapter