### PR TITLE
feat: wire settlement scheduler with Redis leader election

### DIFF
--- a/services/reconciliation/cmd/main.go
+++ b/services/reconciliation/cmd/main.go
@@ -12,15 +12,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
 	"github.com/meridianhub/meridian/services/reconciliation/adapters/persistence"
 	"github.com/meridianhub/meridian/services/reconciliation/config"
 	"github.com/meridianhub/meridian/services/reconciliation/observability"
 	"github.com/meridianhub/meridian/services/reconciliation/service"
+	"github.com/meridianhub/meridian/services/reconciliation/worker"
 	"github.com/meridianhub/meridian/shared/pkg/health"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/redis/go-redis/v9"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -159,6 +162,38 @@ func run(logger *slog.Logger) error {
 	// Create AccountReconciliationService
 	reconciliationSvc := service.NewAccountReconciliationService(serviceOpts...)
 
+	// Initialize Redis client (optional, needed for scheduler leader election)
+	var redisClient *redis.Client
+	if cfg.Redis.Enabled && cfg.Redis.URL != "" {
+		redisCfg := bootstrap.RedisConfig{
+			URL:    cfg.Redis.URL,
+			Logger: logger,
+		}
+		var redisErr error
+		redisClient, redisErr = bootstrap.NewRedisClient(ctx, redisCfg)
+		if redisErr != nil {
+			logger.Warn("Redis connection failed, scheduler and Redis health check disabled",
+				"error", redisErr)
+		} else {
+			logger.Info("Redis client connected")
+		}
+	}
+	defer func() {
+		if redisClient != nil {
+			if err := redisClient.Close(); err != nil {
+				logger.Error("failed to close Redis client", "error", err)
+			}
+		}
+	}()
+
+	// Wire settlement scheduler (optional, depends on Redis + config)
+	var scheduler *worker.SettlementScheduler
+	if cfg.Scheduler.Enabled {
+		scheduler = wireScheduler(ctx, cfg, redisClient, logger)
+	} else {
+		logger.Info("settlement scheduler disabled")
+	}
+
 	// Initialize auth interceptor
 	authConfig := bootstrap.DefaultAuthConfig(logger)
 	authInterceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
@@ -174,10 +209,14 @@ func run(logger *slog.Logger) error {
 	// Register AccountReconciliationService
 	reconciliationv1.RegisterAccountReconciliationServiceServer(grpcServer, reconciliationSvc)
 
-	// Register health check service
-	healthAggregator := health.NewAggregator([]health.Checker{
+	// Register health check service with available checkers
+	healthCheckers := []health.Checker{
 		observability.NewDatabaseChecker(db),
-	})
+	}
+	if redisClient != nil {
+		healthCheckers = append(healthCheckers, observability.NewRedisChecker(redisClient))
+	}
+	healthAggregator := health.NewAggregator(healthCheckers)
 	healthServer := newHealthServer(healthAggregator, logger)
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
 
@@ -202,6 +241,17 @@ func run(logger *slog.Logger) error {
 			serverErrors <- err
 		}
 	}()
+
+	// Start settlement scheduler in background (after gRPC server is listening)
+	schedulerCtx, schedulerCancel := context.WithCancel(context.Background())
+	defer schedulerCancel()
+	if scheduler != nil {
+		go func() {
+			if err := scheduler.Start(schedulerCtx); err != nil {
+				logger.Error("scheduler stopped with error", "error", err)
+			}
+		}()
+	}
 
 	// Start HTTP server for metrics and health endpoints
 	httpMux := http.NewServeMux()
@@ -248,6 +298,14 @@ func run(logger *slog.Logger) error {
 	// Graceful shutdown
 	logger.Info("shutting down servers...")
 
+	// Stop scheduler first (it makes gRPC calls to self)
+	if scheduler != nil {
+		logger.Info("stopping settlement scheduler...")
+		schedulerCancel()
+		scheduler.Stop()
+		logger.Info("settlement scheduler stopped")
+	}
+
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.Server.GracefulShutdownTimeout)
 	defer cancel()
 
@@ -267,6 +325,83 @@ func run(logger *slog.Logger) error {
 	}
 
 	return nil
+}
+
+// wireScheduler creates and configures the SettlementScheduler with all its dependencies.
+// Returns nil if any required dependency is not available.
+func wireScheduler(ctx context.Context, cfg *config.Config, redisClient *redis.Client, logger *slog.Logger) *worker.SettlementScheduler {
+	if redisClient == nil {
+		logger.Warn("scheduler disabled: Redis not configured (required for leader election)")
+		return nil
+	}
+
+	// Create leader elector
+	leaderElector := worker.NewRedisLeaderElector(
+		redisClient,
+		worker.RedisLeaderConfig{
+			LockTTL:       cfg.Scheduler.LeaderLockTTL,
+			RenewInterval: cfg.Scheduler.LeaderRenewInterval,
+		},
+		logger,
+	)
+
+	// Create execution store (requires pgxpool for direct pgx queries)
+	pool, err := pgxpool.New(ctx, cfg.Database.URL)
+	if err != nil {
+		logger.Warn("scheduler disabled: failed to create pgx pool for execution store",
+			"error", err)
+		return nil
+	}
+	executionStore := worker.NewPgExecutionStore(pool)
+
+	// Create Reference Data client (stub until proto available)
+	refDataClient := worker.NewStubReferenceDataClient(logger)
+
+	// Create reconciliation self-client (loopback to this service)
+	reconConn, err := grpc.NewClient(
+		fmt.Sprintf("localhost:%s", cfg.Server.Port),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		logger.Warn("scheduler disabled: failed to create reconciliation self-client",
+			"error", err)
+		pool.Close()
+		return nil
+	}
+	reconGrpcClient := reconciliationv1.NewAccountReconciliationServiceClient(reconConn)
+	reconClient := worker.NewGrpcReconciliationClient(reconGrpcClient)
+
+	// Create scheduler
+	schedulerCfg := worker.SchedulerConfig{
+		PollInterval:    cfg.Scheduler.PollInterval,
+		ShutdownTimeout: cfg.Scheduler.ShutdownTimeout,
+	}
+
+	scheduler, err := worker.NewSettlementScheduler(
+		refDataClient,
+		reconClient,
+		leaderElector,
+		schedulerCfg,
+		logger,
+		nil, // metrics - use default
+		worker.WithExecutionStore(executionStore),
+	)
+	if err != nil {
+		logger.Warn("scheduler disabled: failed to create scheduler",
+			"error", err)
+		pool.Close()
+		if closeErr := reconConn.Close(); closeErr != nil {
+			logger.Error("failed to close reconciliation connection", "error", closeErr)
+		}
+		return nil
+	}
+
+	logger.Info("settlement scheduler configured",
+		"poll_interval", cfg.Scheduler.PollInterval,
+		"leader_lock_ttl", cfg.Scheduler.LeaderLockTTL,
+		"shutdown_timeout", cfg.Scheduler.ShutdownTimeout)
+
+	return scheduler
 }
 
 // healthServer implements the gRPC health checking protocol.

--- a/services/reconciliation/cmd/main_test.go
+++ b/services/reconciliation/cmd/main_test.go
@@ -9,12 +9,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
 	"github.com/meridianhub/meridian/services/reconciliation/adapters/persistence"
+	"github.com/meridianhub/meridian/services/reconciliation/config"
+	"github.com/meridianhub/meridian/services/reconciliation/observability"
 	"github.com/meridianhub/meridian/services/reconciliation/service"
 	"github.com/meridianhub/meridian/shared/pkg/health"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -380,4 +384,237 @@ func TestParseLogLevel(t *testing.T) {
 			assert.Equal(t, tc.expected, parseLogLevel(tc.input))
 		})
 	}
+}
+
+// --- Scheduler wiring tests ---
+
+func TestWireScheduler_NilRedis_ReturnsNil(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	cfg := &config.Config{
+		Scheduler: config.SchedulerConfig{
+			Enabled:             true,
+			PollInterval:        1 * time.Hour,
+			ShutdownTimeout:     30 * time.Second,
+			LeaderLockTTL:       30 * time.Second,
+			LeaderRenewInterval: 10 * time.Second,
+		},
+		Server: config.ServerConfig{
+			Port: "50051",
+		},
+		Database: config.DatabaseConfig{
+			URL: "postgres://invalid@localhost:26257/invalid",
+		},
+	}
+
+	scheduler := wireScheduler(context.Background(), cfg, nil, logger)
+	assert.Nil(t, scheduler, "scheduler should be nil when Redis client is nil")
+}
+
+func TestWireScheduler_InvalidDatabaseURL_ReturnsNil(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	mr := miniredis.RunT(t)
+	redisClient := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer redisClient.Close()
+
+	cfg := &config.Config{
+		Scheduler: config.SchedulerConfig{
+			Enabled:             true,
+			PollInterval:        1 * time.Hour,
+			ShutdownTimeout:     30 * time.Second,
+			LeaderLockTTL:       30 * time.Second,
+			LeaderRenewInterval: 10 * time.Second,
+		},
+		Server: config.ServerConfig{
+			Port: "50051",
+		},
+		Database: config.DatabaseConfig{
+			// Completely invalid URL to ensure pgxpool.New fails
+			URL: "not-a-valid-url",
+		},
+	}
+
+	scheduler := wireScheduler(context.Background(), cfg, redisClient, logger)
+	assert.Nil(t, scheduler, "scheduler should be nil when database URL is invalid")
+}
+
+func TestWireScheduler_ValidConfig_ReturnsScheduler(t *testing.T) {
+	db, cleanup := setupIntegrationDB(t)
+	defer cleanup()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Get the database URL from the gorm connection
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	_ = sqlDB // Just to verify it's valid
+
+	mr := miniredis.RunT(t)
+	redisClient := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer redisClient.Close()
+
+	// We need a valid database URL; get it from the test container.
+	// The setupIntegrationDB doesn't expose the URL, so we use the testdb
+	// package directly. Since wireScheduler creates its own pgxpool, we need
+	// the DATABASE_URL env var or a connection string.
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("DATABASE_URL not set (integration test container doesn't expose URL directly)")
+	}
+
+	cfg := &config.Config{
+		Scheduler: config.SchedulerConfig{
+			Enabled:             true,
+			PollInterval:        1 * time.Hour,
+			ShutdownTimeout:     30 * time.Second,
+			LeaderLockTTL:       30 * time.Second,
+			LeaderRenewInterval: 10 * time.Second,
+		},
+		Server: config.ServerConfig{
+			Port: "50099",
+		},
+		Database: config.DatabaseConfig{
+			URL: dbURL,
+		},
+	}
+
+	scheduler := wireScheduler(context.Background(), cfg, redisClient, logger)
+	assert.NotNil(t, scheduler, "scheduler should be created with valid config")
+
+	// Clean up - stop the scheduler before test ends
+	if scheduler != nil {
+		scheduler.Stop()
+	}
+}
+
+func TestMainWiring_SchedulerDisabled_NoScheduler(t *testing.T) {
+	// Verify that when scheduler is disabled, no Redis errors occur
+	// This is a unit-level test of the conditional logic
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	cfg := &config.Config{
+		Scheduler: config.SchedulerConfig{
+			Enabled: false,
+		},
+	}
+
+	// Should not attempt to create scheduler when disabled
+	assert.False(t, cfg.Scheduler.Enabled)
+	_ = logger // Just verifying the logic path
+}
+
+func TestMainWiring_HealthCheckWithRedis(t *testing.T) {
+	db, cleanup := setupIntegrationDB(t)
+	defer cleanup()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	mr := miniredis.RunT(t)
+	redisClient := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer redisClient.Close()
+
+	// Create repositories and service
+	runRepo := persistence.NewSettlementRunRepository(db)
+	disputeRepo := persistence.NewDisputeRepository(db)
+	varianceRepo := persistence.NewVarianceRepository(db)
+	snapshotRepo := persistence.NewSettlementSnapshotRepository(db)
+
+	detector := service.NewVarianceDetector(runRepo, snapshotRepo, varianceRepo)
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(runRepo),
+		service.WithDisputeRepository(disputeRepo),
+		service.WithVarianceRepository(varianceRepo),
+		service.WithVarianceListRepository(varianceRepo),
+		service.WithVarianceDetector(detector.DetectVariances),
+		service.WithLogger(logger),
+	)
+
+	// Create gRPC server with Redis health checker
+	grpcServer := grpc.NewServer()
+	reconciliationv1.RegisterAccountReconciliationServiceServer(grpcServer, svc)
+
+	healthCheckers := []health.Checker{
+		observability.NewDatabaseChecker(db),
+		observability.NewRedisChecker(redisClient),
+	}
+	healthAggregator := health.NewAggregator(healthCheckers)
+	healthSrv := newHealthServer(healthAggregator, logger)
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthSrv)
+	reflection.Register(grpcServer)
+
+	lis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "localhost:0")
+	require.NoError(t, err)
+	go func() {
+		_ = grpcServer.Serve(lis)
+	}()
+	defer grpcServer.GracefulStop()
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Health check should include Redis
+	client := grpc_health_v1.NewHealthClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+}
+
+func TestMainWiring_HealthCheckWithRedisDown(t *testing.T) {
+	db, cleanup := setupIntegrationDB(t)
+	defer cleanup()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	mr := miniredis.RunT(t)
+	redisClient := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer redisClient.Close()
+
+	// Close Redis to simulate failure
+	mr.Close()
+
+	// Create minimal service
+	runRepo := persistence.NewSettlementRunRepository(db)
+	disputeRepo := persistence.NewDisputeRepository(db)
+	varianceRepo := persistence.NewVarianceRepository(db)
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(runRepo),
+		service.WithDisputeRepository(disputeRepo),
+		service.WithVarianceRepository(varianceRepo),
+		service.WithVarianceListRepository(varianceRepo),
+		service.WithLogger(logger),
+	)
+
+	grpcServer := grpc.NewServer()
+	reconciliationv1.RegisterAccountReconciliationServiceServer(grpcServer, svc)
+
+	healthCheckers := []health.Checker{
+		observability.NewDatabaseChecker(db),
+		observability.NewRedisChecker(redisClient),
+	}
+	healthAggregator := health.NewAggregator(healthCheckers)
+	healthSrv := newHealthServer(healthAggregator, logger)
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthSrv)
+
+	lis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "localhost:0")
+	require.NoError(t, err)
+	go func() {
+		_ = grpcServer.Serve(lis)
+	}()
+	defer grpcServer.GracefulStop()
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Health check should report NOT_SERVING when Redis is down
+	client := grpc_health_v1.NewHealthClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING, resp.Status)
 }

--- a/services/reconciliation/observability/redis_health.go
+++ b/services/reconciliation/observability/redis_health.go
@@ -1,0 +1,62 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/health"
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisChecker checks the health of a Redis connection.
+type RedisChecker struct {
+	client *redis.Client
+}
+
+// NewRedisChecker creates a new Redis health checker.
+func NewRedisChecker(client *redis.Client) *RedisChecker {
+	if client == nil {
+		panic("NewRedisChecker: client cannot be nil")
+	}
+	return &RedisChecker{
+		client: client,
+	}
+}
+
+// Name returns the component name.
+func (r *RedisChecker) Name() string {
+	return "redis"
+}
+
+// Check performs a Redis health check by pinging the connection.
+func (r *RedisChecker) Check(ctx context.Context) health.ComponentResult {
+	start := time.Now()
+
+	checkCtx := ctx
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		checkCtx, cancel = context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+	}
+
+	err := r.client.Ping(checkCtx).Err()
+	responseTime := time.Since(start)
+
+	status := health.StatusHealthy
+	message := "redis connection successful"
+
+	if err != nil {
+		status = health.StatusUnhealthy
+		message = fmt.Sprintf("redis ping failed: %v", err)
+	}
+
+	return health.ComponentResult{
+		Name:         r.Name(),
+		Status:       status,
+		Message:      message,
+		ResponseTime: responseTime,
+		CheckedAt:    start,
+		Error:        err,
+	}
+}

--- a/services/reconciliation/observability/redis_health_test.go
+++ b/services/reconciliation/observability/redis_health_test.go
@@ -1,0 +1,47 @@
+package observability
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/meridianhub/meridian/shared/pkg/health"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedisChecker_Healthy(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	checker := NewRedisChecker(client)
+	assert.Equal(t, "redis", checker.Name())
+
+	result := checker.Check(context.Background())
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.Contains(t, result.Message, "successful")
+	assert.NoError(t, result.Error)
+}
+
+func TestRedisChecker_Unhealthy(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	// Close the miniredis server to simulate connection failure
+	mr.Close()
+
+	checker := NewRedisChecker(client)
+	result := checker.Check(context.Background())
+	assert.Equal(t, health.StatusUnhealthy, result.Status)
+	assert.Contains(t, result.Message, "ping failed")
+	assert.Error(t, result.Error)
+}
+
+func TestNewRedisChecker_NilPanics(t *testing.T) {
+	require.Panics(t, func() {
+		NewRedisChecker(nil)
+	})
+}

--- a/services/reconciliation/worker/errors.go
+++ b/services/reconciliation/worker/errors.go
@@ -19,4 +19,10 @@ var (
 	ErrAlreadyRunning = errors.New("scheduler is already running")
 	// ErrRunAlreadyExists is returned when a reconciliation run already exists for the period.
 	ErrRunAlreadyExists = errors.New("reconciliation run already exists for this period")
+	// ErrNilRunResponse is returned when the gRPC response contains a nil run.
+	ErrNilRunResponse = errors.New("initiate reconciliation returned nil run")
+	// ErrUnknownScope is returned when the reconciliation scope string is not recognized.
+	ErrUnknownScope = errors.New("unknown reconciliation scope")
+	// ErrUnknownSettlementType is returned when the settlement type string is not recognized.
+	ErrUnknownSettlementType = errors.New("unknown settlement type")
 )

--- a/services/reconciliation/worker/grpc_recon_client.go
+++ b/services/reconciliation/worker/grpc_recon_client.go
@@ -1,0 +1,89 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// GrpcReconciliationClient adapts the generated gRPC client to the
+// ReconciliationClient interface used by the scheduler.
+type GrpcReconciliationClient struct {
+	client reconciliationv1.AccountReconciliationServiceClient
+}
+
+// NewGrpcReconciliationClient creates a new adapter wrapping the gRPC client.
+func NewGrpcReconciliationClient(client reconciliationv1.AccountReconciliationServiceClient) *GrpcReconciliationClient {
+	return &GrpcReconciliationClient{client: client}
+}
+
+// InitiateReconciliation calls the gRPC InitiateAccountReconciliation RPC and
+// returns the run ID. If the server returns AlreadyExists, it wraps the error
+// with ErrRunAlreadyExists so the scheduler can handle deduplication.
+func (c *GrpcReconciliationClient) InitiateReconciliation(ctx context.Context, req InitiateRequest) (string, error) {
+	scope, err := parseScope(req.Scope)
+	if err != nil {
+		return "", err
+	}
+	settlementType, err := parseSettlementType(req.SettlementType)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.client.InitiateAccountReconciliation(ctx, &reconciliationv1.InitiateAccountReconciliationRequest{
+		AccountId:      req.AccountID,
+		Scope:          scope,
+		SettlementType: settlementType,
+		PeriodStart:    timestamppb.New(req.PeriodStart),
+		PeriodEnd:      timestamppb.New(req.PeriodEnd),
+		InitiatedBy:    req.InitiatedBy,
+	})
+	if err != nil {
+		if st, ok := status.FromError(err); ok && st.Code() == codes.AlreadyExists {
+			return "", fmt.Errorf("%w: %s", ErrRunAlreadyExists, st.Message())
+		}
+		return "", fmt.Errorf("initiate reconciliation RPC failed: %w", err)
+	}
+
+	if resp.GetRun() == nil {
+		return "", ErrNilRunResponse
+	}
+
+	return resp.GetRun().GetRunId(), nil
+}
+
+func parseScope(s string) (reconciliationv1.ReconciliationScope, error) {
+	switch s {
+	case "ACCOUNT":
+		return reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT, nil
+	case "INSTRUMENT":
+		return reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_INSTRUMENT, nil
+	case "PORTFOLIO":
+		return reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_PORTFOLIO, nil
+	case "FULL":
+		return reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_FULL, nil
+	default:
+		return reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_UNSPECIFIED,
+			fmt.Errorf("%w: %q", ErrUnknownScope, s)
+	}
+}
+
+func parseSettlementType(s string) (reconciliationv1.SettlementType, error) {
+	switch s {
+	case "DAILY":
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY, nil
+	case "WEEKLY":
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_WEEKLY, nil
+	case "MONTHLY":
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_MONTHLY, nil
+	case "ON_DEMAND":
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_ON_DEMAND, nil
+	default:
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_UNSPECIFIED,
+			fmt.Errorf("%w: %q", ErrUnknownSettlementType, s)
+	}
+}

--- a/services/reconciliation/worker/grpc_recon_client_test.go
+++ b/services/reconciliation/worker/grpc_recon_client_test.go
@@ -1,0 +1,224 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// mockAccountReconciliationServiceClient implements the generated gRPC client interface.
+type mockAccountReconciliationServiceClient struct {
+	reconciliationv1.AccountReconciliationServiceClient
+	resp *reconciliationv1.InitiateAccountReconciliationResponse
+	err  error
+}
+
+func (m *mockAccountReconciliationServiceClient) InitiateAccountReconciliation(
+	_ context.Context,
+	_ *reconciliationv1.InitiateAccountReconciliationRequest,
+	_ ...grpc.CallOption,
+) (*reconciliationv1.InitiateAccountReconciliationResponse, error) {
+	return m.resp, m.err
+}
+
+func TestGrpcReconciliationClient_InitiateReconciliation_Success(t *testing.T) {
+	mock := &mockAccountReconciliationServiceClient{
+		resp: &reconciliationv1.InitiateAccountReconciliationResponse{
+			Run: &reconciliationv1.SettlementRunSummary{
+				RunId: "run-123",
+			},
+		},
+	}
+
+	client := NewGrpcReconciliationClient(mock)
+	runID, err := client.InitiateReconciliation(context.Background(), InitiateRequest{
+		AccountID:      "ACC-001",
+		Scope:          "ACCOUNT",
+		SettlementType: "DAILY",
+		PeriodStart:    time.Date(2026, 2, 8, 0, 0, 0, 0, time.UTC),
+		PeriodEnd:      time.Date(2026, 2, 9, 0, 0, 0, 0, time.UTC),
+		InitiatedBy:    "settlement-scheduler",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "run-123", runID)
+}
+
+func TestGrpcReconciliationClient_InitiateReconciliation_AlreadyExists(t *testing.T) {
+	mock := &mockAccountReconciliationServiceClient{
+		err: status.Errorf(codes.AlreadyExists, "run already exists"),
+	}
+
+	client := NewGrpcReconciliationClient(mock)
+	_, err := client.InitiateReconciliation(context.Background(), InitiateRequest{
+		AccountID:      "ACC-001",
+		Scope:          "ACCOUNT",
+		SettlementType: "DAILY",
+		PeriodStart:    time.Date(2026, 2, 8, 0, 0, 0, 0, time.UTC),
+		PeriodEnd:      time.Date(2026, 2, 9, 0, 0, 0, 0, time.UTC),
+		InitiatedBy:    "settlement-scheduler",
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrRunAlreadyExists)
+}
+
+func TestGrpcReconciliationClient_InitiateReconciliation_InvalidScope(t *testing.T) {
+	mock := &mockAccountReconciliationServiceClient{}
+
+	client := NewGrpcReconciliationClient(mock)
+	_, err := client.InitiateReconciliation(context.Background(), InitiateRequest{
+		AccountID:      "ACC-001",
+		Scope:          "BOGUS",
+		SettlementType: "DAILY",
+		PeriodStart:    time.Now().UTC(),
+		PeriodEnd:      time.Now().UTC(),
+		InitiatedBy:    "test",
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownScope)
+}
+
+func TestGrpcReconciliationClient_InitiateReconciliation_InvalidSettlementType(t *testing.T) {
+	mock := &mockAccountReconciliationServiceClient{}
+
+	client := NewGrpcReconciliationClient(mock)
+	_, err := client.InitiateReconciliation(context.Background(), InitiateRequest{
+		AccountID:      "ACC-001",
+		Scope:          "ACCOUNT",
+		SettlementType: "BOGUS",
+		PeriodStart:    time.Now().UTC(),
+		PeriodEnd:      time.Now().UTC(),
+		InitiatedBy:    "test",
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownSettlementType)
+}
+
+func TestParseScope(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected reconciliationv1.ReconciliationScope
+		wantErr  bool
+	}{
+		{"ACCOUNT", reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT, false},
+		{"INSTRUMENT", reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_INSTRUMENT, false},
+		{"PORTFOLIO", reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_PORTFOLIO, false},
+		{"FULL", reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_FULL, false},
+		{"UNKNOWN", reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_UNSPECIFIED, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got, err := parseScope(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestParseSettlementType(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected reconciliationv1.SettlementType
+		wantErr  bool
+	}{
+		{"DAILY", reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY, false},
+		{"WEEKLY", reconciliationv1.SettlementType_SETTLEMENT_TYPE_WEEKLY, false},
+		{"MONTHLY", reconciliationv1.SettlementType_SETTLEMENT_TYPE_MONTHLY, false},
+		{"ON_DEMAND", reconciliationv1.SettlementType_SETTLEMENT_TYPE_ON_DEMAND, false},
+		{"UNKNOWN", reconciliationv1.SettlementType_SETTLEMENT_TYPE_UNSPECIFIED, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got, err := parseSettlementType(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, got)
+			}
+		})
+	}
+}
+
+// Verify InitiateAccountReconciliation constructs the correct proto request.
+func TestGrpcReconciliationClient_InitiateReconciliation_NilResponse(t *testing.T) {
+	mock := &mockAccountReconciliationServiceClient{
+		resp: &reconciliationv1.InitiateAccountReconciliationResponse{
+			Run: nil,
+		},
+	}
+
+	client := NewGrpcReconciliationClient(mock)
+	_, err := client.InitiateReconciliation(context.Background(), InitiateRequest{
+		AccountID:      "ACC-001",
+		Scope:          "ACCOUNT",
+		SettlementType: "DAILY",
+		PeriodStart:    time.Now().UTC(),
+		PeriodEnd:      time.Now().UTC(),
+		InitiatedBy:    "test",
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNilRunResponse)
+}
+
+// capturingMockClient captures the request for verification.
+type capturingMockClient struct {
+	reconciliationv1.AccountReconciliationServiceClient
+	capturedReq *reconciliationv1.InitiateAccountReconciliationRequest
+}
+
+func (m *capturingMockClient) InitiateAccountReconciliation(
+	_ context.Context,
+	req *reconciliationv1.InitiateAccountReconciliationRequest,
+	_ ...grpc.CallOption,
+) (*reconciliationv1.InitiateAccountReconciliationResponse, error) {
+	m.capturedReq = req
+	return &reconciliationv1.InitiateAccountReconciliationResponse{
+		Run: &reconciliationv1.SettlementRunSummary{RunId: "captured-run"},
+	}, nil
+}
+
+func TestGrpcReconciliationClient_CorrectProtoMapping(t *testing.T) {
+	mock := &capturingMockClient{}
+	client := NewGrpcReconciliationClient(mock)
+
+	periodStart := time.Date(2026, 2, 8, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 2, 9, 0, 0, 0, 0, time.UTC)
+
+	_, err := client.InitiateReconciliation(context.Background(), InitiateRequest{
+		AccountID:      "ACC-001",
+		Scope:          "INSTRUMENT",
+		SettlementType: "WEEKLY",
+		PeriodStart:    periodStart,
+		PeriodEnd:      periodEnd,
+		InitiatedBy:    "settlement-scheduler",
+	})
+	require.NoError(t, err)
+
+	req := mock.capturedReq
+	require.NotNil(t, req)
+	assert.Equal(t, "ACC-001", req.AccountId)
+	assert.Equal(t, reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_INSTRUMENT, req.Scope)
+	assert.Equal(t, reconciliationv1.SettlementType_SETTLEMENT_TYPE_WEEKLY, req.SettlementType)
+	assert.Equal(t, timestamppb.New(periodStart).AsTime(), req.PeriodStart.AsTime())
+	assert.Equal(t, timestamppb.New(periodEnd).AsTime(), req.PeriodEnd.AsTime())
+	assert.Equal(t, "settlement-scheduler", req.InitiatedBy)
+}

--- a/services/reconciliation/worker/stub_refdata_client.go
+++ b/services/reconciliation/worker/stub_refdata_client.go
@@ -1,0 +1,25 @@
+package worker
+
+import (
+	"context"
+	"log/slog"
+)
+
+// StubReferenceDataClient is a temporary implementation of ReferenceDataClient
+// that returns an empty schedule list. It will be replaced once the Reference Data
+// service proto definitions are available and a gRPC adapter can be created.
+type StubReferenceDataClient struct {
+	logger *slog.Logger
+}
+
+// NewStubReferenceDataClient creates a new stub reference data client.
+func NewStubReferenceDataClient(logger *slog.Logger) *StubReferenceDataClient {
+	return &StubReferenceDataClient{logger: logger}
+}
+
+// ListSettlementSchedules returns an empty list. The scheduler will pick up
+// real schedules once the Reference Data gRPC client is wired in.
+func (c *StubReferenceDataClient) ListSettlementSchedules(_ context.Context) ([]SettlementSchedule, error) {
+	c.logger.Debug("stub reference data client: returning empty schedule list")
+	return nil, nil
+}

--- a/services/reconciliation/worker/stub_refdata_client_test.go
+++ b/services/reconciliation/worker/stub_refdata_client_test.go
@@ -1,0 +1,26 @@
+package worker
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStubReferenceDataClient_ReturnsEmptyList(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	client := NewStubReferenceDataClient(logger)
+
+	schedules, err := client.ListSettlementSchedules(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, schedules)
+}
+
+func TestStubReferenceDataClient_ImplementsInterface(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	var client ReferenceDataClient = NewStubReferenceDataClient(logger)
+	assert.NotNil(t, client)
+}


### PR DESCRIPTION
## Summary

- Wire the existing `SettlementScheduler` worker into `cmd/main.go` with Redis leader election, execution store, and graceful shutdown
- Add `GrpcReconciliationClient` adapter to bridge the generated gRPC client to the `ReconciliationClient` interface
- Add `StubReferenceDataClient` as a temporary implementation until Reference Data proto definitions are available
- Add `RedisChecker` for health monitoring of the Redis connection
- Add Redis health check to the health aggregator (only when Redis is configured)

## Changes Made

**New files:**
- `worker/grpc_recon_client.go` - Adapts generated gRPC client to `ReconciliationClient` interface with scope/type enum mapping and `AlreadyExists` translation
- `worker/stub_refdata_client.go` - Stub returning empty schedule list until Reference Data proto is available
- `observability/redis_health.go` - Redis health checker following position-keeping service pattern

**Modified files:**
- `worker/errors.go` - Add `ErrNilRunResponse`, `ErrUnknownScope`, `ErrUnknownSettlementType` static errors
- `cmd/main.go` - Wire scheduler with Redis client, leader elector, pgxpool execution store, self-loopback gRPC client, and graceful shutdown ordering

## Technical Details

- Scheduler is gated behind `SETTLEMENT_SCHEDULER_ENABLED` env var (default: false)
- Gracefully degrades when Redis or database dependencies are unavailable (warns and continues without scheduler)
- `wireScheduler()` extracted as a separate function for testability and clarity
- Shutdown ordering: scheduler stops first (releases leader lock, waits for in-flight jobs), then gRPC server
- Separate `pgxpool.Pool` created for execution store (scheduler uses pgx directly, not GORM)
- Redis client initialized via `bootstrap.NewRedisClient` with connection validation

## Test Plan

- [x] Unit tests for `GrpcReconciliationClient` (success, AlreadyExists, invalid scope/type, nil response)
- [x] Unit tests for `StubReferenceDataClient` (returns empty list, implements interface)
- [x] Unit tests for `parseScope` and `parseSettlementType` enum mapping
- [x] Unit tests for `wireScheduler` (nil Redis returns nil, invalid DB URL returns nil)
- [x] Unit test for Redis health checker (healthy, unhealthy, nil panics)
- [x] Integration test: health check with Redis (miniredis + CockroachDB testcontainer)
- [x] Integration test: health check reports NOT_SERVING when Redis is down
- [x] Regression: all existing main_test.go integration tests still pass
- [x] All pre-commit checks pass (gofumpt, golangci-lint)