### PR TITLE
feat: implement PAUSE/RESUME control actions for reconciliation runs

### DIFF
--- a/api/proto/meridian/reconciliation/v1/reconciliation.proto
+++ b/api/proto/meridian/reconciliation/v1/reconciliation.proto
@@ -94,6 +94,8 @@ enum RunStatus {
   RUN_STATUS_FAILED = 4;
   // RUN_STATUS_CANCELLED means the run was cancelled.
   RUN_STATUS_CANCELLED = 5;
+  // RUN_STATUS_PAUSED means the run has been paused and can be resumed.
+  RUN_STATUS_PAUSED = 6;
 }
 
 // VarianceStatus represents the resolution state of a variance.

--- a/services/reconciliation/adapters/persistence/dispute_repository_test.go
+++ b/services/reconciliation/adapters/persistence/dispute_repository_test.go
@@ -51,6 +51,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, func()) {
 			"completed_at" timestamptz NULL,
 			"variance_count" integer NOT NULL DEFAULT 0,
 			"failure_reason" text NULL,
+			"last_completed_phase" character varying(30) NULL,
 			"attributes" jsonb NULL,
 			"version" bigint NOT NULL DEFAULT 1,
 			PRIMARY KEY ("id")

--- a/services/reconciliation/adapters/persistence/settlement_run_repository.go
+++ b/services/reconciliation/adapters/persistence/settlement_run_repository.go
@@ -16,22 +16,23 @@ var _ domain.SettlementRunRepository = (*SettlementRunRepository)(nil)
 
 // SettlementRunEntity is the GORM entity for the settlement_run table.
 type SettlementRunEntity struct {
-	ID             uuid.UUID  `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
-	CreatedAt      time.Time  `gorm:"not null;default:now()"`
-	UpdatedAt      time.Time  `gorm:"not null;default:now()"`
-	RunID          uuid.UUID  `gorm:"column:run_id;uniqueIndex:idx_sr_run_id;type:uuid;not null"`
-	AccountID      string     `gorm:"column:account_id;index:idx_sr_account_id;size:34;not null"`
-	Scope          string     `gorm:"column:scope;size:20;not null;default:ACCOUNT"`
-	SettlementType string     `gorm:"column:settlement_type;size:20;not null;default:DAILY"`
-	Status         string     `gorm:"column:status;index:idx_sr_status;size:20;not null;default:PENDING"`
-	PeriodStart    time.Time  `gorm:"column:period_start;not null"`
-	PeriodEnd      time.Time  `gorm:"column:period_end;not null"`
-	InitiatedBy    string     `gorm:"column:initiated_by;size:100;not null"`
-	CompletedAt    *time.Time `gorm:"column:completed_at"`
-	VarianceCount  int        `gorm:"column:variance_count;not null;default:0"`
-	FailureReason  *string    `gorm:"column:failure_reason;type:text"`
-	Attributes     JSONMap    `gorm:"column:attributes;type:jsonb"`
-	Version        int64      `gorm:"column:version;not null;default:1"`
+	ID                 uuid.UUID  `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	CreatedAt          time.Time  `gorm:"not null;default:now()"`
+	UpdatedAt          time.Time  `gorm:"not null;default:now()"`
+	RunID              uuid.UUID  `gorm:"column:run_id;uniqueIndex:idx_sr_run_id;type:uuid;not null"`
+	AccountID          string     `gorm:"column:account_id;index:idx_sr_account_id;size:34;not null"`
+	Scope              string     `gorm:"column:scope;size:20;not null;default:ACCOUNT"`
+	SettlementType     string     `gorm:"column:settlement_type;size:20;not null;default:DAILY"`
+	Status             string     `gorm:"column:status;index:idx_sr_status;size:20;not null;default:PENDING"`
+	PeriodStart        time.Time  `gorm:"column:period_start;not null"`
+	PeriodEnd          time.Time  `gorm:"column:period_end;not null"`
+	InitiatedBy        string     `gorm:"column:initiated_by;size:100;not null"`
+	CompletedAt        *time.Time `gorm:"column:completed_at"`
+	VarianceCount      int        `gorm:"column:variance_count;not null;default:0"`
+	FailureReason      *string    `gorm:"column:failure_reason;type:text"`
+	Attributes         JSONMap    `gorm:"column:attributes;type:jsonb"`
+	LastCompletedPhase *string    `gorm:"column:last_completed_phase;size:30"`
+	Version            int64      `gorm:"column:version;not null;default:1"`
 }
 
 // TableName returns the table name for the settlement run entity.
@@ -113,13 +114,14 @@ func (r *SettlementRunRepository) Update(ctx context.Context, run *domain.Settle
 		result := tx.Model(&SettlementRunEntity{}).
 			Where("run_id = ? AND version = ?", entity.RunID, entity.Version-1).
 			Updates(map[string]interface{}{
-				"status":         entity.Status,
-				"completed_at":   entity.CompletedAt,
-				"variance_count": entity.VarianceCount,
-				"failure_reason": entity.FailureReason,
-				"attributes":     entity.Attributes,
-				"version":        entity.Version,
-				"updated_at":     time.Now().UTC(),
+				"status":               entity.Status,
+				"completed_at":         entity.CompletedAt,
+				"variance_count":       entity.VarianceCount,
+				"failure_reason":       entity.FailureReason,
+				"last_completed_phase": entity.LastCompletedPhase,
+				"attributes":           entity.Attributes,
+				"version":              entity.Version,
+				"updated_at":           time.Now().UTC(),
 			})
 		if result.Error != nil {
 			return result.Error
@@ -217,6 +219,10 @@ func toSettlementRunEntity(r *domain.SettlementRun) *SettlementRunEntity {
 	if r.FailureReason != "" {
 		entity.FailureReason = &r.FailureReason
 	}
+	if r.LastCompletedPhase != nil {
+		s := string(*r.LastCompletedPhase)
+		entity.LastCompletedPhase = &s
+	}
 	if r.Attributes != nil {
 		entity.Attributes = JSONMap(r.Attributes)
 	}
@@ -244,6 +250,10 @@ func toSettlementRunDomain(e *SettlementRunEntity) *domain.SettlementRun {
 
 	if e.FailureReason != nil {
 		run.FailureReason = *e.FailureReason
+	}
+	if e.LastCompletedPhase != nil {
+		phase := domain.ReconciliationPhase(*e.LastCompletedPhase)
+		run.LastCompletedPhase = &phase
 	}
 	if e.Attributes != nil {
 		run.Attributes = map[string]string(e.Attributes)

--- a/services/reconciliation/domain/run_status.go
+++ b/services/reconciliation/domain/run_status.go
@@ -7,6 +7,7 @@ type RunStatus string
 const (
 	RunStatusPending   RunStatus = "PENDING"
 	RunStatusRunning   RunStatus = "RUNNING"
+	RunStatusPaused    RunStatus = "PAUSED"
 	RunStatusCompleted RunStatus = "COMPLETED"
 	RunStatusFinalized RunStatus = "FINALIZED"
 	RunStatusFailed    RunStatus = "FAILED"
@@ -16,7 +17,7 @@ const (
 // IsValid checks if the run status is a recognized value.
 func (s RunStatus) IsValid() bool {
 	switch s {
-	case RunStatusPending, RunStatusRunning, RunStatusCompleted,
+	case RunStatusPending, RunStatusRunning, RunStatusPaused, RunStatusCompleted,
 		RunStatusFinalized, RunStatusFailed, RunStatusCancelled:
 		return true
 	}
@@ -41,7 +42,8 @@ func (s RunStatus) CanTransitionTo(target RunStatus) bool {
 
 	validTransitions := map[RunStatus][]RunStatus{
 		RunStatusPending:   {RunStatusRunning, RunStatusCancelled},
-		RunStatusRunning:   {RunStatusCompleted, RunStatusFailed, RunStatusCancelled},
+		RunStatusRunning:   {RunStatusCompleted, RunStatusFailed, RunStatusCancelled, RunStatusPaused},
+		RunStatusPaused:    {RunStatusRunning, RunStatusCancelled},
 		RunStatusCompleted: {RunStatusFinalized},
 	}
 

--- a/services/reconciliation/domain/run_status_test.go
+++ b/services/reconciliation/domain/run_status_test.go
@@ -12,6 +12,7 @@ func TestRunStatus_IsValid(t *testing.T) {
 		{"valid running", RunStatusRunning, true},
 		{"valid completed", RunStatusCompleted, true},
 		{"valid failed", RunStatusFailed, true},
+		{"valid paused", RunStatusPaused, true},
 		{"valid cancelled", RunStatusCancelled, true},
 		{"valid finalized", RunStatusFinalized, true},
 		{"invalid status", RunStatus("INVALID"), false},
@@ -35,6 +36,7 @@ func TestRunStatus_IsFinal(t *testing.T) {
 	}{
 		{"pending not final", RunStatusPending, false},
 		{"running not final", RunStatusRunning, false},
+		{"paused not final", RunStatusPaused, false},
 		{"completed not final", RunStatusCompleted, false},
 		{"finalized is final", RunStatusFinalized, true},
 		{"failed is final", RunStatusFailed, true},
@@ -70,8 +72,20 @@ func TestRunStatus_CanTransitionTo(t *testing.T) {
 		{"running to failed", RunStatusRunning, RunStatusFailed, true},
 		{"running to cancelled", RunStatusRunning, RunStatusCancelled, true},
 
+		// Valid transitions from RUNNING (pause)
+		{"running to paused", RunStatusRunning, RunStatusPaused, true},
+
 		// Invalid transitions from RUNNING
 		{"running to pending", RunStatusRunning, RunStatusPending, false},
+
+		// Valid transitions from PAUSED
+		{"paused to running", RunStatusPaused, RunStatusRunning, true},
+		{"paused to cancelled", RunStatusPaused, RunStatusCancelled, true},
+
+		// Invalid transitions from PAUSED
+		{"paused to completed", RunStatusPaused, RunStatusCompleted, false},
+		{"paused to pending", RunStatusPaused, RunStatusPending, false},
+		{"paused to failed", RunStatusPaused, RunStatusFailed, false},
 
 		// Valid transitions from COMPLETED
 		{"completed to finalized", RunStatusCompleted, RunStatusFinalized, true},
@@ -104,6 +118,7 @@ func TestRunStatus_String(t *testing.T) {
 	}{
 		{"pending", RunStatusPending, "PENDING"},
 		{"running", RunStatusRunning, "RUNNING"},
+		{"paused", RunStatusPaused, "PAUSED"},
 		{"completed", RunStatusCompleted, "COMPLETED"},
 		{"failed", RunStatusFailed, "FAILED"},
 		{"cancelled", RunStatusCancelled, "CANCELLED"},
@@ -127,6 +142,7 @@ func TestParseRunStatus(t *testing.T) {
 	}{
 		{"valid pending", "PENDING", RunStatusPending},
 		{"valid running", "RUNNING", RunStatusRunning},
+		{"valid paused", "PAUSED", RunStatusPaused},
 		{"valid completed", "COMPLETED", RunStatusCompleted},
 		{"invalid defaults to pending", "INVALID", RunStatusPending},
 		{"empty defaults to pending", "", RunStatusPending},

--- a/services/reconciliation/domain/settlement_run.go
+++ b/services/reconciliation/domain/settlement_run.go
@@ -6,6 +6,17 @@ import (
 	"github.com/google/uuid"
 )
 
+// ReconciliationPhase represents a phase in the reconciliation pipeline.
+type ReconciliationPhase string
+
+// Reconciliation pipeline phases in execution order.
+const (
+	PhaseSnapshotCapture   ReconciliationPhase = "SNAPSHOT_CAPTURE"
+	PhaseVarianceDetection ReconciliationPhase = "VARIANCE_DETECTION"
+	PhaseVarianceValuation ReconciliationPhase = "VARIANCE_VALUATION"
+	PhaseBalanceAssertion  ReconciliationPhase = "BALANCE_ASSERTION"
+)
+
 // SettlementRun is the Command Record (CR) that orchestrates a reconciliation run.
 // It captures the scope, type, period, and outcome of a reconciliation process.
 //
@@ -44,6 +55,10 @@ type SettlementRun struct {
 
 	// FailureReason records why the run failed (empty if not failed).
 	FailureReason string
+
+	// LastCompletedPhase records the last pipeline phase that completed before a pause.
+	// nil when the run has not been paused or no phases have completed.
+	LastCompletedPhase *ReconciliationPhase
 
 	// Attributes stores flexible metadata for this run.
 	Attributes map[string]string
@@ -178,6 +193,30 @@ func (r *SettlementRun) Cancel() error {
 	r.Status = RunStatusCancelled
 	r.CompletedAt = &now
 	r.UpdatedAt = now
+	r.Version++
+	return nil
+}
+
+// Pause transitions the run to PAUSED and records the last completed phase as a checkpoint.
+func (r *SettlementRun) Pause(checkpoint ReconciliationPhase) error {
+	if !r.Status.CanTransitionTo(RunStatusPaused) {
+		return ErrInvalidStatusTransition
+	}
+	r.Status = RunStatusPaused
+	r.LastCompletedPhase = &checkpoint
+	r.UpdatedAt = time.Now().UTC()
+	r.Version++
+	return nil
+}
+
+// Resume transitions the run from PAUSED back to RUNNING.
+// The LastCompletedPhase is preserved so the pipeline can skip already-completed phases.
+func (r *SettlementRun) Resume() error {
+	if r.Status != RunStatusPaused {
+		return ErrInvalidStatusTransition
+	}
+	r.Status = RunStatusRunning
+	r.UpdatedAt = time.Now().UTC()
 	r.Version++
 	return nil
 }

--- a/services/reconciliation/domain/settlement_run.go
+++ b/services/reconciliation/domain/settlement_run.go
@@ -209,6 +209,13 @@ func (r *SettlementRun) Pause(checkpoint ReconciliationPhase) error {
 	return nil
 }
 
+// SetCheckpoint records the last completed pipeline phase on a running settlement run.
+func (r *SettlementRun) SetCheckpoint(phase ReconciliationPhase) {
+	r.LastCompletedPhase = &phase
+	r.UpdatedAt = time.Now().UTC()
+	r.Version++
+}
+
 // Resume transitions the run from PAUSED back to RUNNING.
 // The LastCompletedPhase is preserved so the pipeline can skip already-completed phases.
 func (r *SettlementRun) Resume() error {

--- a/services/reconciliation/domain/settlement_run.go
+++ b/services/reconciliation/domain/settlement_run.go
@@ -198,12 +198,13 @@ func (r *SettlementRun) Cancel() error {
 }
 
 // Pause transitions the run to PAUSED and records the last completed phase as a checkpoint.
-func (r *SettlementRun) Pause(checkpoint ReconciliationPhase) error {
+// checkpoint may be nil if no phases have completed yet.
+func (r *SettlementRun) Pause(checkpoint *ReconciliationPhase) error {
 	if !r.Status.CanTransitionTo(RunStatusPaused) {
 		return ErrInvalidStatusTransition
 	}
 	r.Status = RunStatusPaused
-	r.LastCompletedPhase = &checkpoint
+	r.LastCompletedPhase = checkpoint
 	r.UpdatedAt = time.Now().UTC()
 	r.Version++
 	return nil

--- a/services/reconciliation/domain/settlement_run_test.go
+++ b/services/reconciliation/domain/settlement_run_test.go
@@ -215,6 +215,22 @@ func TestSettlementRun_MultiplePauseResumeCycles(t *testing.T) {
 	assert.Equal(t, domain.RunStatusCompleted, run.Status)
 }
 
+func TestSettlementRun_SetCheckpoint(t *testing.T) {
+	run := newTestRun(t)
+	require.NoError(t, run.Start())
+
+	versionBefore := run.Version
+	run.SetCheckpoint(domain.PhaseVarianceDetection)
+
+	require.NotNil(t, run.LastCompletedPhase)
+	assert.Equal(t, domain.PhaseVarianceDetection, *run.LastCompletedPhase)
+	assert.Equal(t, versionBefore+1, run.Version)
+
+	// Overwrite with a later phase
+	run.SetCheckpoint(domain.PhaseVarianceValuation)
+	assert.Equal(t, domain.PhaseVarianceValuation, *run.LastCompletedPhase)
+}
+
 func TestSettlementRun_CancelFromPaused(t *testing.T) {
 	run := newTestRun(t)
 	require.NoError(t, run.Start())

--- a/services/reconciliation/domain/settlement_run_test.go
+++ b/services/reconciliation/domain/settlement_run_test.go
@@ -163,6 +163,68 @@ func TestSettlementRun_CancelLifecycle(t *testing.T) {
 	assert.Equal(t, int64(2), run.Version)
 }
 
+func TestSettlementRun_PauseResumeLifecycle(t *testing.T) {
+	run := newTestRun(t)
+	require.NoError(t, run.Start())
+	assert.Equal(t, domain.RunStatusRunning, run.Status)
+	versionAfterStart := run.Version
+
+	// Pause
+	phase := domain.PhaseVarianceDetection
+	require.NoError(t, run.Pause(phase))
+	assert.Equal(t, domain.RunStatusPaused, run.Status)
+	require.NotNil(t, run.LastCompletedPhase)
+	assert.Equal(t, domain.PhaseVarianceDetection, *run.LastCompletedPhase)
+	assert.Equal(t, versionAfterStart+1, run.Version)
+
+	// Resume
+	versionAfterPause := run.Version
+	require.NoError(t, run.Resume())
+	assert.Equal(t, domain.RunStatusRunning, run.Status)
+	// LastCompletedPhase should be preserved for pipeline checkpoint
+	require.NotNil(t, run.LastCompletedPhase)
+	assert.Equal(t, domain.PhaseVarianceDetection, *run.LastCompletedPhase)
+	assert.Equal(t, versionAfterPause+1, run.Version)
+
+	// Can complete after resume
+	require.NoError(t, run.Complete(2))
+	assert.Equal(t, domain.RunStatusCompleted, run.Status)
+	assert.Equal(t, 2, run.VarianceCount)
+}
+
+func TestSettlementRun_MultiplePauseResumeCycles(t *testing.T) {
+	run := newTestRun(t)
+	require.NoError(t, run.Start())
+
+	// Cycle 1: pause at SNAPSHOT_CAPTURE, resume
+	require.NoError(t, run.Pause(domain.PhaseSnapshotCapture))
+	assert.Equal(t, domain.RunStatusPaused, run.Status)
+	require.NoError(t, run.Resume())
+	assert.Equal(t, domain.RunStatusRunning, run.Status)
+
+	// Cycle 2: pause at VARIANCE_VALUATION, resume
+	require.NoError(t, run.Pause(domain.PhaseVarianceValuation))
+	assert.Equal(t, domain.RunStatusPaused, run.Status)
+	require.NotNil(t, run.LastCompletedPhase)
+	assert.Equal(t, domain.PhaseVarianceValuation, *run.LastCompletedPhase)
+	require.NoError(t, run.Resume())
+	assert.Equal(t, domain.RunStatusRunning, run.Status)
+
+	// Can still complete
+	require.NoError(t, run.Complete(0))
+	assert.Equal(t, domain.RunStatusCompleted, run.Status)
+}
+
+func TestSettlementRun_CancelFromPaused(t *testing.T) {
+	run := newTestRun(t)
+	require.NoError(t, run.Start())
+	require.NoError(t, run.Pause(domain.PhaseSnapshotCapture))
+
+	require.NoError(t, run.Cancel())
+	assert.Equal(t, domain.RunStatusCancelled, run.Status)
+	assert.NotNil(t, run.CompletedAt)
+}
+
 func TestSettlementRun_InvalidTransitions(t *testing.T) {
 	t.Run("cannot complete from pending", func(t *testing.T) {
 		run := newTestRun(t)
@@ -189,6 +251,33 @@ func TestSettlementRun_InvalidTransitions(t *testing.T) {
 		require.NoError(t, run.Start())
 		require.NoError(t, run.Complete(0))
 		err := run.Cancel()
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+
+	t.Run("cannot pause from pending", func(t *testing.T) {
+		run := newTestRun(t)
+		err := run.Pause(domain.PhaseSnapshotCapture)
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+
+	t.Run("cannot pause from completed", func(t *testing.T) {
+		run := newTestRun(t)
+		require.NoError(t, run.Start())
+		require.NoError(t, run.Complete(0))
+		err := run.Pause(domain.PhaseBalanceAssertion)
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+
+	t.Run("cannot resume from running", func(t *testing.T) {
+		run := newTestRun(t)
+		require.NoError(t, run.Start())
+		err := run.Resume()
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+
+	t.Run("cannot resume from pending", func(t *testing.T) {
+		run := newTestRun(t)
+		err := run.Resume()
 		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
 	})
 }

--- a/services/reconciliation/domain/settlement_run_test.go
+++ b/services/reconciliation/domain/settlement_run_test.go
@@ -170,8 +170,7 @@ func TestSettlementRun_PauseResumeLifecycle(t *testing.T) {
 	versionAfterStart := run.Version
 
 	// Pause
-	phase := domain.PhaseVarianceDetection
-	require.NoError(t, run.Pause(phase))
+	require.NoError(t, run.Pause(phasePtr(domain.PhaseVarianceDetection)))
 	assert.Equal(t, domain.RunStatusPaused, run.Status)
 	require.NotNil(t, run.LastCompletedPhase)
 	assert.Equal(t, domain.PhaseVarianceDetection, *run.LastCompletedPhase)
@@ -192,18 +191,33 @@ func TestSettlementRun_PauseResumeLifecycle(t *testing.T) {
 	assert.Equal(t, 2, run.VarianceCount)
 }
 
+func TestSettlementRun_PauseWithNilCheckpoint(t *testing.T) {
+	run := newTestRun(t)
+	require.NoError(t, run.Start())
+
+	// Pause before any phase completes (nil checkpoint)
+	require.NoError(t, run.Pause(nil))
+	assert.Equal(t, domain.RunStatusPaused, run.Status)
+	assert.Nil(t, run.LastCompletedPhase)
+
+	// Resume should work, and nil checkpoint means startIndex=0 (all phases run)
+	require.NoError(t, run.Resume())
+	assert.Equal(t, domain.RunStatusRunning, run.Status)
+	assert.Nil(t, run.LastCompletedPhase)
+}
+
 func TestSettlementRun_MultiplePauseResumeCycles(t *testing.T) {
 	run := newTestRun(t)
 	require.NoError(t, run.Start())
 
 	// Cycle 1: pause at SNAPSHOT_CAPTURE, resume
-	require.NoError(t, run.Pause(domain.PhaseSnapshotCapture))
+	require.NoError(t, run.Pause(phasePtr(domain.PhaseSnapshotCapture)))
 	assert.Equal(t, domain.RunStatusPaused, run.Status)
 	require.NoError(t, run.Resume())
 	assert.Equal(t, domain.RunStatusRunning, run.Status)
 
 	// Cycle 2: pause at VARIANCE_VALUATION, resume
-	require.NoError(t, run.Pause(domain.PhaseVarianceValuation))
+	require.NoError(t, run.Pause(phasePtr(domain.PhaseVarianceValuation)))
 	assert.Equal(t, domain.RunStatusPaused, run.Status)
 	require.NotNil(t, run.LastCompletedPhase)
 	assert.Equal(t, domain.PhaseVarianceValuation, *run.LastCompletedPhase)
@@ -234,7 +248,7 @@ func TestSettlementRun_SetCheckpoint(t *testing.T) {
 func TestSettlementRun_CancelFromPaused(t *testing.T) {
 	run := newTestRun(t)
 	require.NoError(t, run.Start())
-	require.NoError(t, run.Pause(domain.PhaseSnapshotCapture))
+	require.NoError(t, run.Pause(phasePtr(domain.PhaseSnapshotCapture)))
 
 	require.NoError(t, run.Cancel())
 	assert.Equal(t, domain.RunStatusCancelled, run.Status)
@@ -272,7 +286,7 @@ func TestSettlementRun_InvalidTransitions(t *testing.T) {
 
 	t.Run("cannot pause from pending", func(t *testing.T) {
 		run := newTestRun(t)
-		err := run.Pause(domain.PhaseSnapshotCapture)
+		err := run.Pause(phasePtr(domain.PhaseSnapshotCapture))
 		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
 	})
 
@@ -280,7 +294,7 @@ func TestSettlementRun_InvalidTransitions(t *testing.T) {
 		run := newTestRun(t)
 		require.NoError(t, run.Start())
 		require.NoError(t, run.Complete(0))
-		err := run.Pause(domain.PhaseBalanceAssertion)
+		err := run.Pause(phasePtr(domain.PhaseBalanceAssertion))
 		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
 	})
 
@@ -311,4 +325,8 @@ func newTestRun(t *testing.T) *domain.SettlementRun {
 	)
 	require.NoError(t, err)
 	return run
+}
+
+func phasePtr(p domain.ReconciliationPhase) *domain.ReconciliationPhase {
+	return &p
 }

--- a/services/reconciliation/migrations/20260209000005_pause_resume.sql
+++ b/services/reconciliation/migrations/20260209000005_pause_resume.sql
@@ -1,0 +1,17 @@
+-- Pause/Resume: Add PAUSED status and last_completed_phase checkpoint column.
+
+-- Add PAUSED to settlement_run status constraint
+ALTER TABLE "settlement_run" DROP CONSTRAINT "chk_settlement_run_status";
+ALTER TABLE "settlement_run"
+  ADD CONSTRAINT "chk_settlement_run_status"
+  CHECK ("status" IN ('PENDING', 'RUNNING', 'PAUSED', 'COMPLETED', 'FINALIZED', 'FAILED', 'CANCELLED'));
+
+-- Add checkpoint column for pipeline resumption
+ALTER TABLE "settlement_run"
+  ADD COLUMN "last_completed_phase" character varying(30) NULL;
+
+ALTER TABLE "settlement_run"
+  ADD CONSTRAINT "chk_settlement_run_last_completed_phase"
+  CHECK ("last_completed_phase" IS NULL OR "last_completed_phase" IN (
+    'SNAPSHOT_CAPTURE', 'VARIANCE_DETECTION', 'VARIANCE_VALUATION', 'BALANCE_ASSERTION'
+  ));

--- a/services/reconciliation/service/control_handler_test.go
+++ b/services/reconciliation/service/control_handler_test.go
@@ -131,10 +131,10 @@ func TestControlAccountReconciliation_PauseRunning(t *testing.T) {
 	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_PAUSED, resp.GetRun().GetStatus())
 	assert.Equal(t, run.RunID.String(), resp.GetRun().GetRunId())
 
-	// Verify persisted
-	updated := repo.runs[run.RunID]
+	// Verify persisted - no phases completed yet so checkpoint is nil
+	updated := repo.getRun(run.RunID)
 	assert.Equal(t, domain.RunStatusPaused, updated.Status)
-	require.NotNil(t, updated.LastCompletedPhase)
+	assert.Nil(t, updated.LastCompletedPhase)
 }
 
 func TestControlAccountReconciliation_PauseCompleted(t *testing.T) {
@@ -187,7 +187,7 @@ func newPausedRun(t *testing.T) *domain.SettlementRun {
 	t.Helper()
 	run := newRunningRun(t)
 	phase := domain.PhaseSnapshotCapture
-	err := run.Pause(phase)
+	err := run.Pause(&phase)
 	require.NoError(t, err)
 	return run
 }

--- a/services/reconciliation/service/control_handler_test.go
+++ b/services/reconciliation/service/control_handler_test.go
@@ -214,8 +214,8 @@ func TestControlAccountReconciliation_ResumePaused(t *testing.T) {
 	require.NotNil(t, resp.GetRun())
 	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_RUNNING, resp.GetRun().GetStatus())
 
-	// Verify persisted
-	updated := repo.runs[run.RunID]
+	// Verify persisted (use thread-safe accessor since resume spawns a background goroutine)
+	updated := repo.getRun(run.RunID)
 	assert.Equal(t, domain.RunStatusRunning, updated.Status)
 }
 

--- a/services/reconciliation/service/control_handler_test.go
+++ b/services/reconciliation/service/control_handler_test.go
@@ -111,9 +111,37 @@ func TestControlAccountReconciliation_CancelCompleted(t *testing.T) {
 	assert.Contains(t, st.Message(), "cannot cancel run in COMPLETED state")
 }
 
-func TestControlAccountReconciliation_PauseUnimplemented(t *testing.T) {
+func TestControlAccountReconciliation_PauseRunning(t *testing.T) {
 	repo := newMockSettlementRunRepo()
 	run := newRunningRun(t)
+	repo.runs[run.RunID] = run
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  run.RunID.String(),
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_PAUSE,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.GetRun())
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_PAUSED, resp.GetRun().GetStatus())
+	assert.Equal(t, run.RunID.String(), resp.GetRun().GetRunId())
+
+	// Verify persisted
+	updated := repo.runs[run.RunID]
+	assert.Equal(t, domain.RunStatusPaused, updated.Status)
+	require.NotNil(t, updated.LastCompletedPhase)
+}
+
+func TestControlAccountReconciliation_PauseCompleted(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+	run := newRunningRun(t)
+	err := run.Complete(0)
+	require.NoError(t, err)
 	repo.runs[run.RunID] = run
 
 	svc := service.NewAccountReconciliationService(
@@ -129,11 +157,69 @@ func TestControlAccountReconciliation_PauseUnimplemented(t *testing.T) {
 	require.Error(t, err)
 	st, ok := status.FromError(err)
 	require.True(t, ok)
-	assert.Equal(t, codes.Unimplemented, st.Code())
-	assert.Contains(t, st.Message(), "PAUSE action not yet supported")
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "cannot pause run in COMPLETED state")
 }
 
-func TestControlAccountReconciliation_ResumeUnimplemented(t *testing.T) {
+func TestControlAccountReconciliation_PausePending(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+	run := newPendingRun(t)
+	repo.runs[run.RunID] = run
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  run.RunID.String(),
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_PAUSE,
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "cannot pause run in PENDING state")
+}
+
+func newPausedRun(t *testing.T) *domain.SettlementRun {
+	t.Helper()
+	run := newRunningRun(t)
+	phase := domain.PhaseSnapshotCapture
+	err := run.Pause(phase)
+	require.NoError(t, err)
+	return run
+}
+
+func TestControlAccountReconciliation_ResumePaused(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+	run := newPausedRun(t)
+	repo.runs[run.RunID] = run
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+		service.WithSnapshotCapturer(func(_ context.Context, _ uuid.UUID) error { return nil }),
+		service.WithVarianceDetector(func(_ context.Context, _ uuid.UUID) ([]*domain.Variance, error) { return nil, nil }),
+		service.WithVarianceValuator(func(_ context.Context, _ uuid.UUID) error { return nil }),
+	)
+
+	resp, err := svc.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  run.RunID.String(),
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_RESUME,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.GetRun())
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_RUNNING, resp.GetRun().GetStatus())
+
+	// Verify persisted
+	updated := repo.runs[run.RunID]
+	assert.Equal(t, domain.RunStatusRunning, updated.Status)
+}
+
+func TestControlAccountReconciliation_ResumeRunning(t *testing.T) {
 	repo := newMockSettlementRunRepo()
 	run := newRunningRun(t)
 	repo.runs[run.RunID] = run
@@ -151,8 +237,32 @@ func TestControlAccountReconciliation_ResumeUnimplemented(t *testing.T) {
 	require.Error(t, err)
 	st, ok := status.FromError(err)
 	require.True(t, ok)
-	assert.Equal(t, codes.Unimplemented, st.Code())
-	assert.Contains(t, st.Message(), "RESUME action not yet supported")
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "cannot resume run in RUNNING state")
+}
+
+func TestControlAccountReconciliation_ResumeCompleted(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+	run := newRunningRun(t)
+	err := run.Complete(0)
+	require.NoError(t, err)
+	repo.runs[run.RunID] = run
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  run.RunID.String(),
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_RESUME,
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "cannot resume run in COMPLETED state")
 }
 
 func TestControlAccountReconciliation_NotFound(t *testing.T) {

--- a/services/reconciliation/service/mapping.go
+++ b/services/reconciliation/service/mapping.go
@@ -60,6 +60,8 @@ func toProtoRunStatus(s domain.RunStatus) reconciliationv1.RunStatus {
 		return reconciliationv1.RunStatus_RUN_STATUS_PENDING
 	case domain.RunStatusRunning:
 		return reconciliationv1.RunStatus_RUN_STATUS_RUNNING
+	case domain.RunStatusPaused:
+		return reconciliationv1.RunStatus_RUN_STATUS_PAUSED
 	case domain.RunStatusCompleted, domain.RunStatusFinalized:
 		return reconciliationv1.RunStatus_RUN_STATUS_COMPLETED
 	case domain.RunStatusFailed:

--- a/services/reconciliation/service/retrieve_handler_test.go
+++ b/services/reconciliation/service/retrieve_handler_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,7 +18,9 @@ import (
 )
 
 // mockSettlementRunRepo implements domain.SettlementRunRepository for testing.
+// It is thread-safe to support tests that exercise async pipeline goroutines.
 type mockSettlementRunRepo struct {
+	mu   sync.RWMutex
 	runs map[uuid.UUID]*domain.SettlementRun
 	err  error // injected error for testing
 }
@@ -27,11 +30,15 @@ func newMockSettlementRunRepo() *mockSettlementRunRepo {
 }
 
 func (m *mockSettlementRunRepo) Create(_ context.Context, run *domain.SettlementRun) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.runs[run.RunID] = run
 	return nil
 }
 
 func (m *mockSettlementRunRepo) FindByID(_ context.Context, runID uuid.UUID) (*domain.SettlementRun, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -39,10 +46,15 @@ func (m *mockSettlementRunRepo) FindByID(_ context.Context, runID uuid.UUID) (*d
 	if !ok {
 		return nil, domain.ErrNotFound
 	}
-	return run, nil
+	// Return a copy to match real DB behavior and avoid data races
+	// when background goroutines (e.g. resumePipeline) modify the returned object.
+	cp := *run
+	return &cp, nil
 }
 
 func (m *mockSettlementRunRepo) Update(_ context.Context, run *domain.SettlementRun) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if _, ok := m.runs[run.RunID]; !ok {
 		return domain.ErrNotFound
 	}
@@ -51,11 +63,20 @@ func (m *mockSettlementRunRepo) Update(_ context.Context, run *domain.Settlement
 }
 
 func (m *mockSettlementRunRepo) List(_ context.Context, _ domain.RunFilter) ([]*domain.SettlementRun, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	result := make([]*domain.SettlementRun, 0, len(m.runs))
 	for _, r := range m.runs {
 		result = append(result, r)
 	}
 	return result, nil
+}
+
+// getRun safely retrieves a run from the mock for test assertions.
+func (m *mockSettlementRunRepo) getRun(runID uuid.UUID) *domain.SettlementRun {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.runs[runID]
 }
 
 func TestRetrieveAccountReconciliation_Success(t *testing.T) {

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -510,12 +510,9 @@ func (s *AccountReconciliationService) checkPause(pauseCh chan struct{}) bool {
 }
 
 // getCheckpointPhase returns the last completed pipeline phase for the run.
-// If no phase has been recorded yet, defaults to SNAPSHOT_CAPTURE.
-func getCheckpointPhase(run *domain.SettlementRun) domain.ReconciliationPhase {
-	if run.LastCompletedPhase != nil {
-		return *run.LastCompletedPhase
-	}
-	return domain.PhaseSnapshotCapture
+// Returns nil if no phase has been completed yet.
+func getCheckpointPhase(run *domain.SettlementRun) *domain.ReconciliationPhase {
+	return run.LastCompletedPhase
 }
 
 // phaseIndex returns the ordinal position of a phase in the pipeline.
@@ -645,12 +642,16 @@ func (s *AccountReconciliationService) ControlAccountReconciliation(
 			return nil, status.Error(codes.Internal, "failed to persist settlement run")
 		}
 		s.signalPause(runID)
+		checkpointStr := "<none>"
+		if checkpoint != nil {
+			checkpointStr = string(*checkpoint)
+		}
 		slog.InfoContext(ctx, "settlement run paused",
 			"run_id", runID,
 			"action", action.String(),
 			"status_before", statusBefore.String(),
 			"status_after", run.Status.String(),
-			"checkpoint", string(checkpoint),
+			"checkpoint", checkpointStr,
 		)
 
 	case reconciliationv1.ControlAction_CONTROL_ACTION_RESUME:

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -538,11 +538,11 @@ func phaseIndex(phase domain.ReconciliationPhase) int {
 // resumePipeline re-launches the pipeline from the run's checkpoint.
 //
 //nolint:contextcheck // Intentionally uses background context for async pipeline that outlives the RPC
-func (s *AccountReconciliationService) resumePipeline(run *domain.SettlementRun) {
+func (s *AccountReconciliationService) resumePipeline(runID uuid.UUID) {
 	pipelineCtx, pipelineCancel := context.WithTimeout(context.Background(), pipelineTimeout) //nolint:contextcheck
 	go func() {
 		defer pipelineCancel()
-		s.executePipeline(pipelineCtx, run.RunID)
+		s.executePipeline(pipelineCtx, runID)
 	}()
 }
 
@@ -666,14 +666,21 @@ func (s *AccountReconciliationService) ControlAccountReconciliation(
 			slog.ErrorContext(ctx, "failed to persist resumed run", "run_id", runID, "error", err)
 			return nil, status.Error(codes.Internal, "failed to persist settlement run")
 		}
+		// Capture the response before launching the pipeline goroutine to avoid
+		// a data race between the background goroutine writing to the run and the
+		// response reading it.
+		resp := &reconciliationv1.ControlAccountReconciliationResponse{
+			Run: toProtoRunSummary(run),
+		}
 		// Re-launch the pipeline from the checkpoint
-		s.resumePipeline(run)
+		s.resumePipeline(run.RunID)
 		slog.InfoContext(ctx, "settlement run resumed",
 			"run_id", runID,
 			"action", action.String(),
 			"status_before", statusBefore.String(),
 			"status_after", run.Status.String(),
 		)
+		return resp, nil
 
 	default:
 		return nil, status.Errorf(codes.InvalidArgument, "unknown control action: %v", action)

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -365,6 +365,7 @@ func (s *AccountReconciliationService) executePipeline(ctx context.Context, runI
 	persistCancel()
 	if err != nil {
 		slog.Error("failed to retrieve run for pipeline start", "run_id", runID, "error", err)
+		s.failRun(ctx, runID, "failed to retrieve run for pipeline start: "+err.Error())
 		return
 	}
 	if run.LastCompletedPhase != nil {
@@ -444,9 +445,7 @@ func (s *AccountReconciliationService) updateCheckpoint(_ context.Context, runID
 		slog.Error("failed to retrieve run for checkpoint", "run_id", runID, "error", err)
 		return
 	}
-	run.LastCompletedPhase = &phase
-	run.UpdatedAt = time.Now().UTC()
-	run.Version++
+	run.SetCheckpoint(phase)
 	if err := s.runRepo.Update(persistCtx, run); err != nil { //nolint:contextcheck
 		slog.Error("failed to persist checkpoint", "run_id", runID, "phase", string(phase), "error", err)
 	}
@@ -510,10 +509,9 @@ func (s *AccountReconciliationService) checkPause(pauseCh chan struct{}) bool {
 	}
 }
 
-// getCurrentPhase determines the current/last completed phase of a running settlement run
-// based on the LastCompletedPhase field. If no phase has been recorded, returns
-// SNAPSHOT_CAPTURE as the initial phase.
-func getCurrentPhase(run *domain.SettlementRun) domain.ReconciliationPhase {
+// getCheckpointPhase returns the last completed pipeline phase for the run.
+// If no phase has been recorded yet, defaults to SNAPSHOT_CAPTURE.
+func getCheckpointPhase(run *domain.SettlementRun) domain.ReconciliationPhase {
 	if run.LastCompletedPhase != nil {
 		return *run.LastCompletedPhase
 	}
@@ -634,7 +632,7 @@ func (s *AccountReconciliationService) ControlAccountReconciliation(
 		)
 
 	case reconciliationv1.ControlAction_CONTROL_ACTION_PAUSE:
-		checkpoint := getCurrentPhase(run)
+		checkpoint := getCheckpointPhase(run)
 		statusBefore := run.Status
 		if err := run.Pause(checkpoint); err != nil {
 			if errors.Is(err, domain.ErrInvalidStatusTransition) {

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -64,6 +65,10 @@ type AccountReconciliationService struct {
 	snapshotCapturer SnapshotCapturerFunc
 	varianceDetector VarianceDetectorFunc
 	varianceValuator VarianceValuatorFunc
+
+	// pauseMu protects pauseSignals map.
+	pauseMu      sync.Mutex
+	pauseSignals map[uuid.UUID]chan struct{}
 }
 
 // Option configures the AccountReconciliationService.
@@ -170,7 +175,9 @@ func WithVarianceValuator(fn VarianceValuatorFunc) Option {
 // NewAccountReconciliationService creates a new AccountReconciliationService.
 // The assertor is optional; if nil, AssertBalance returns UNIMPLEMENTED.
 func NewAccountReconciliationService(opts ...Option) *AccountReconciliationService {
-	svc := &AccountReconciliationService{}
+	svc := &AccountReconciliationService{
+		pauseSignals: make(map[uuid.UUID]chan struct{}),
+	}
 	for _, opt := range opts {
 		opt(svc)
 	}
@@ -332,7 +339,12 @@ func (s *AccountReconciliationService) ExecuteAccountReconciliation(
 
 // executePipeline runs the reconciliation pipeline in the background.
 // The caller is responsible for providing a detached context with timeout.
+// The pipeline supports checkpointing: on resume from a PAUSED state, phases
+// that completed before the pause are skipped based on LastCompletedPhase.
 func (s *AccountReconciliationService) executePipeline(ctx context.Context, runID uuid.UUID) {
+	pauseCh := s.registerPauseSignal(runID)
+	defer s.removePauseSignal(runID)
+
 	defer func() {
 		if r := recover(); r != nil {
 			slog.Error("reconciliation pipeline panicked",
@@ -345,32 +357,66 @@ func (s *AccountReconciliationService) executePipeline(ctx context.Context, runI
 
 	slog.Info("reconciliation pipeline started", "run_id", runID)
 
-	// Step 1: Capture snapshots
-	if err := s.snapshotCapturer(ctx, runID); err != nil {
-		slog.Error("snapshot capture failed", "run_id", runID, "error", err)
-		s.failRun(ctx, runID, err.Error())
+	// Determine the starting phase by checking the run's checkpoint.
+	startIndex := 0
+	persistCtx, persistCancel := context.WithTimeout(context.Background(), persistTimeout) //nolint:contextcheck
+	run, err := s.runRepo.FindByID(persistCtx, runID)                                      //nolint:contextcheck
+	persistCancel()
+	if err != nil {
+		slog.Error("failed to retrieve run for pipeline start", "run_id", runID, "error", err)
 		return
+	}
+	if run.LastCompletedPhase != nil {
+		startIndex = phaseIndex(*run.LastCompletedPhase) + 1
+	}
+
+	// Step 1: Capture snapshots
+	if startIndex <= phaseIndex(domain.PhaseSnapshotCapture) {
+		if err := s.snapshotCapturer(ctx, runID); err != nil {
+			slog.Error("snapshot capture failed", "run_id", runID, "error", err)
+			s.failRun(ctx, runID, err.Error())
+			return
+		}
+		s.updateCheckpoint(ctx, runID, domain.PhaseSnapshotCapture)
+		if s.checkPause(pauseCh) {
+			slog.Info("pipeline paused after snapshot capture", "run_id", runID)
+			return
+		}
 	}
 
 	// Step 2: Detect variances
-	if _, err := s.varianceDetector(ctx, runID); err != nil {
-		slog.Error("variance detection failed", "run_id", runID, "error", err)
-		s.failRun(ctx, runID, err.Error())
-		return
+	if startIndex <= phaseIndex(domain.PhaseVarianceDetection) {
+		if _, err := s.varianceDetector(ctx, runID); err != nil {
+			slog.Error("variance detection failed", "run_id", runID, "error", err)
+			s.failRun(ctx, runID, err.Error())
+			return
+		}
+		s.updateCheckpoint(ctx, runID, domain.PhaseVarianceDetection)
+		if s.checkPause(pauseCh) {
+			slog.Info("pipeline paused after variance detection", "run_id", runID)
+			return
+		}
 	}
 
 	// Step 3: Value variances
-	if err := s.varianceValuator(ctx, runID); err != nil {
-		slog.Error("variance valuation failed", "run_id", runID, "error", err)
-		s.failRun(ctx, runID, err.Error())
-		return
+	if startIndex <= phaseIndex(domain.PhaseVarianceValuation) {
+		if err := s.varianceValuator(ctx, runID); err != nil {
+			slog.Error("variance valuation failed", "run_id", runID, "error", err)
+			s.failRun(ctx, runID, err.Error())
+			return
+		}
+		s.updateCheckpoint(ctx, runID, domain.PhaseVarianceValuation)
+		if s.checkPause(pauseCh) {
+			slog.Info("pipeline paused after variance valuation", "run_id", runID)
+			return
+		}
 	}
 
 	// Pipeline succeeded: transition to COMPLETED.
 	// Use a fresh context so persistence succeeds even if the pipeline context has expired.
-	persistCtx, persistCancel := context.WithTimeout(context.Background(), persistTimeout) //nolint:contextcheck
-	defer persistCancel()
-	run, err := s.runRepo.FindByID(persistCtx, runID) //nolint:contextcheck
+	completeCtx, completeCancel := context.WithTimeout(context.Background(), persistTimeout) //nolint:contextcheck
+	defer completeCancel()
+	run, err = s.runRepo.FindByID(completeCtx, runID) //nolint:contextcheck
 	if err != nil {
 		slog.Error("failed to retrieve run for completion", "run_id", runID, "error", err)
 		return
@@ -379,12 +425,30 @@ func (s *AccountReconciliationService) executePipeline(ctx context.Context, runI
 		slog.Error("failed to transition run to COMPLETED", "run_id", runID, "error", err)
 		return
 	}
-	if err := s.runRepo.Update(persistCtx, run); err != nil { //nolint:contextcheck
+	if err := s.runRepo.Update(completeCtx, run); err != nil { //nolint:contextcheck
 		slog.Error("failed to persist COMPLETED state", "run_id", runID, "error", err)
 		return
 	}
 
 	slog.Info("reconciliation pipeline completed", "run_id", runID)
+}
+
+// updateCheckpoint persists the last completed phase on the settlement run.
+// It uses a fresh context so persistence succeeds even if the pipeline context has expired.
+func (s *AccountReconciliationService) updateCheckpoint(_ context.Context, runID uuid.UUID, phase domain.ReconciliationPhase) {
+	persistCtx, persistCancel := context.WithTimeout(context.Background(), persistTimeout) //nolint:contextcheck
+	defer persistCancel()
+	run, err := s.runRepo.FindByID(persistCtx, runID) //nolint:contextcheck
+	if err != nil {
+		slog.Error("failed to retrieve run for checkpoint", "run_id", runID, "error", err)
+		return
+	}
+	run.LastCompletedPhase = &phase
+	run.UpdatedAt = time.Now().UTC()
+	run.Version++
+	if err := s.runRepo.Update(persistCtx, run); err != nil { //nolint:contextcheck
+		slog.Error("failed to persist checkpoint", "run_id", runID, "phase", string(phase), "error", err)
+	}
 }
 
 // failRun transitions a settlement run to FAILED with the given error message.
@@ -404,6 +468,82 @@ func (s *AccountReconciliationService) failRun(_ context.Context, runID uuid.UUI
 	if err := s.runRepo.Update(persistCtx, run); err != nil { //nolint:contextcheck
 		slog.Error("failed to persist FAILED state", "run_id", runID, "error", err)
 	}
+}
+
+// registerPauseSignal creates a pause signal channel for a run and returns it.
+func (s *AccountReconciliationService) registerPauseSignal(runID uuid.UUID) chan struct{} {
+	s.pauseMu.Lock()
+	defer s.pauseMu.Unlock()
+	ch := make(chan struct{}, 1)
+	s.pauseSignals[runID] = ch
+	return ch
+}
+
+// signalPause sends a pause signal to the pipeline goroutine for a run.
+func (s *AccountReconciliationService) signalPause(runID uuid.UUID) {
+	s.pauseMu.Lock()
+	defer s.pauseMu.Unlock()
+	if ch, ok := s.pauseSignals[runID]; ok {
+		select {
+		case ch <- struct{}{}:
+		default:
+			// Already signaled
+		}
+	}
+}
+
+// removePauseSignal cleans up the pause signal channel for a run.
+func (s *AccountReconciliationService) removePauseSignal(runID uuid.UUID) {
+	s.pauseMu.Lock()
+	defer s.pauseMu.Unlock()
+	delete(s.pauseSignals, runID)
+}
+
+// checkPause returns true if a pause signal has been received for this run.
+func (s *AccountReconciliationService) checkPause(pauseCh chan struct{}) bool {
+	select {
+	case <-pauseCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// getCurrentPhase determines the current/last completed phase of a running settlement run
+// based on the LastCompletedPhase field. If no phase has been recorded, returns
+// SNAPSHOT_CAPTURE as the initial phase.
+func getCurrentPhase(run *domain.SettlementRun) domain.ReconciliationPhase {
+	if run.LastCompletedPhase != nil {
+		return *run.LastCompletedPhase
+	}
+	return domain.PhaseSnapshotCapture
+}
+
+// phaseIndex returns the ordinal position of a phase in the pipeline.
+func phaseIndex(phase domain.ReconciliationPhase) int {
+	switch phase {
+	case domain.PhaseSnapshotCapture:
+		return 0
+	case domain.PhaseVarianceDetection:
+		return 1
+	case domain.PhaseVarianceValuation:
+		return 2
+	case domain.PhaseBalanceAssertion:
+		return 3
+	default:
+		return -1
+	}
+}
+
+// resumePipeline re-launches the pipeline from the run's checkpoint.
+//
+//nolint:contextcheck // Intentionally uses background context for async pipeline that outlives the RPC
+func (s *AccountReconciliationService) resumePipeline(run *domain.SettlementRun) {
+	pipelineCtx, pipelineCancel := context.WithTimeout(context.Background(), pipelineTimeout) //nolint:contextcheck
+	go func() {
+		defer pipelineCancel()
+		s.executePipeline(pipelineCtx, run.RunID)
+	}()
 }
 
 // RetrieveAccountReconciliation retrieves a settlement run summary.
@@ -493,10 +633,47 @@ func (s *AccountReconciliationService) ControlAccountReconciliation(
 		)
 
 	case reconciliationv1.ControlAction_CONTROL_ACTION_PAUSE:
-		return nil, status.Error(codes.Unimplemented, "PAUSE action not yet supported")
+		checkpoint := getCurrentPhase(run)
+		statusBefore := run.Status
+		if err := run.Pause(checkpoint); err != nil {
+			if errors.Is(err, domain.ErrInvalidStatusTransition) {
+				return nil, status.Errorf(codes.FailedPrecondition, "cannot pause run in %s state", run.Status)
+			}
+			return nil, status.Error(codes.Internal, "failed to pause settlement run")
+		}
+		if err := s.runRepo.Update(ctx, run); err != nil {
+			slog.ErrorContext(ctx, "failed to persist paused run", "run_id", runID, "error", err)
+			return nil, status.Error(codes.Internal, "failed to persist settlement run")
+		}
+		s.signalPause(runID)
+		slog.InfoContext(ctx, "settlement run paused",
+			"run_id", runID,
+			"action", action.String(),
+			"status_before", statusBefore.String(),
+			"status_after", run.Status.String(),
+			"checkpoint", string(checkpoint),
+		)
 
 	case reconciliationv1.ControlAction_CONTROL_ACTION_RESUME:
-		return nil, status.Error(codes.Unimplemented, "RESUME action not yet supported")
+		statusBefore := run.Status
+		if err := run.Resume(); err != nil {
+			if errors.Is(err, domain.ErrInvalidStatusTransition) {
+				return nil, status.Errorf(codes.FailedPrecondition, "cannot resume run in %s state", run.Status)
+			}
+			return nil, status.Error(codes.Internal, "failed to resume settlement run")
+		}
+		if err := s.runRepo.Update(ctx, run); err != nil {
+			slog.ErrorContext(ctx, "failed to persist resumed run", "run_id", runID, "error", err)
+			return nil, status.Error(codes.Internal, "failed to persist settlement run")
+		}
+		// Re-launch the pipeline from the checkpoint
+		s.resumePipeline(run)
+		slog.InfoContext(ctx, "settlement run resumed",
+			"run_id", runID,
+			"action", action.String(),
+			"status_before", statusBefore.String(),
+			"status_after", run.Status.String(),
+		)
 
 	default:
 		return nil, status.Errorf(codes.InvalidArgument, "unknown control action: %v", action)

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -414,6 +414,10 @@ func (s *AccountReconciliationService) executePipeline(ctx context.Context, runI
 		}
 	}
 
+	// NOTE: PhaseBalanceAssertion is defined in the domain model but the pipeline step
+	// is not yet implemented. When the balance assertion step is added, insert it here
+	// before the completion block, following the same checkpoint/pause pattern above.
+
 	// Pipeline succeeded: transition to COMPLETED.
 	// Use a fresh context so persistence succeeds even if the pipeline context has expired.
 	completeCtx, completeCancel := context.WithTimeout(context.Background(), persistTimeout) //nolint:contextcheck
@@ -516,6 +520,8 @@ func getCheckpointPhase(run *domain.SettlementRun) *domain.ReconciliationPhase {
 }
 
 // phaseIndex returns the ordinal position of a phase in the pipeline.
+// PhaseBalanceAssertion (index 3) is reserved for future use; the pipeline
+// currently completes after PhaseVarianceValuation (index 2).
 func phaseIndex(phase domain.ReconciliationPhase) int {
 	switch phase {
 	case domain.PhaseSnapshotCapture:


### PR DESCRIPTION
## Summary

- Add PAUSED status to settlement run lifecycle with RUNNING->PAUSED and PAUSED->RUNNING transitions
- Implement checkpoint-based pipeline resumption: on pause, last completed phase is recorded; on resume, completed phases are skipped
- Channel-based pause signaling between control RPC and background pipeline goroutine

## Changes

### Domain (`services/reconciliation/domain/`)
- `run_status.go`: Add `RunStatusPaused` constant and valid transitions (RUNNING->PAUSED, PAUSED->RUNNING, PAUSED->CANCELLED)
- `settlement_run.go`: Add `ReconciliationPhase` type (SNAPSHOT_CAPTURE, VARIANCE_DETECTION, VARIANCE_VALUATION, BALANCE_ASSERTION), `LastCompletedPhase` checkpoint field, `Pause(checkpoint)` and `Resume()` methods

### Service (`services/reconciliation/service/`)
- `service.go`: Add `pauseSignals` map with mutex for pipeline goroutine signaling. Implement PAUSE/RESUME cases in `ControlAccountReconciliation`. Update `executePipeline` with checkpoint persistence and pause checks between phases
- `mapping.go`: Add PAUSED status proto mapping

### Persistence (`services/reconciliation/adapters/persistence/`)
- `settlement_run_repository.go`: Add `LastCompletedPhase` to entity, Update map, and domain mappers

### Migration
- `20260209000005_pause_resume.sql`: Add PAUSED to status constraint, add `last_completed_phase` column with CHECK constraint

### Proto
- Add `RUN_STATUS_PAUSED = 6` to `RunStatus` enum

## Task Master

| TM Task | Description |
|---------|-------------|
| reconciliation-service-phase2.8 | Implement PAUSE/RESUME control actions |

## Test plan

- [x] Domain: RUNNING->PAUSED transition allowed
- [x] Domain: PAUSED->RUNNING transition allowed
- [x] Domain: Invalid transitions rejected (PENDING->PAUSED, COMPLETED->PAUSED, RUNNING->RESUME, PENDING->RESUME)
- [x] Domain: Pause() sets checkpoint correctly
- [x] Domain: Resume() preserves checkpoint
- [x] Domain: Multiple pause/resume cycles
- [x] Domain: Cancel from PAUSED state
- [x] Service: PAUSE on RUNNING run succeeds with status PAUSED
- [x] Service: PAUSE on COMPLETED/PENDING run fails with FailedPrecondition
- [x] Service: RESUME on PAUSED run succeeds with status RUNNING
- [x] Service: RESUME on RUNNING/COMPLETED run fails with FailedPrecondition
- [ ] Integration: Pipeline pause/resume with phase skipping (requires CockroachDB testcontainer)