### PR TITLE
feat: wire BalanceAssertor in main.go

### DIFF
--- a/services/reconciliation/cmd/main.go
+++ b/services/reconciliation/cmd/main.go
@@ -124,6 +124,8 @@ func run(logger *slog.Logger) error {
 	snapshotRepo := persistence.NewSettlementSnapshotRepository(db)
 	varianceRepo := persistence.NewVarianceRepository(db)
 	disputeRepo := persistence.NewDisputeRepository(db)
+	assertionRepo := persistence.NewBalanceAssertionRepository(db)
+	trendRepo := persistence.NewImbalanceTrendRepository(db)
 
 	// Build service options with repositories (always available)
 	serviceOpts := []service.Option{
@@ -157,8 +159,17 @@ func run(logger *slog.Logger) error {
 
 		logger.Info("snapshot capturer configured",
 			"position_keeping_url", cfg.Services.PositionKeepingURL)
+
+		// Wire BalanceAssertor (requires PK client for position summaries)
+		balancePKClient := service.NewGrpcPositionKeepingClient(pkClient)
+		assertor := service.NewBalanceAssertor(assertionRepo, trendRepo, balancePKClient, nil, nil, logger)
+		serviceOpts = append(serviceOpts,
+			service.WithBalanceAssertor(assertor),
+		)
+		logger.Info("balance assertor configured")
 	} else {
 		logger.Warn("snapshot capturer not configured: POSITION_KEEPING_URL not set")
+		logger.Warn("balance assertor not configured: position keeping client unavailable")
 	}
 	defer func() {
 		if pkConn != nil {
@@ -185,10 +196,6 @@ func run(logger *slog.Logger) error {
 	)
 	logger.Info("variance valuator configured (using stub engine)",
 		"note", "identity valuation until shared/pkg/valuation implementation available")
-
-	// BalanceAssertor requires assertion repo + PK client (not yet available)
-	// Will return UNIMPLEMENTED until its dependencies are wired in future tasks
-	logger.Warn("balance assertor not configured: assertion repository not yet available")
 
 	// Create AccountReconciliationService
 	reconciliationSvc := service.NewAccountReconciliationService(serviceOpts...)

--- a/services/reconciliation/service/grpc_pk_client.go
+++ b/services/reconciliation/service/grpc_pk_client.go
@@ -53,7 +53,7 @@ func (c *GrpcPositionKeepingClient) GetPositionSummary(ctx context.Context, acco
 
 				amount, err := moneyToDecimal(m)
 				if err != nil {
-					continue
+					return nil, fmt.Errorf("converting amount for entry in log %s: %w", log.GetLogId(), err)
 				}
 
 				switch entry.GetDirection() {

--- a/services/reconciliation/service/grpc_pk_client.go
+++ b/services/reconciliation/service/grpc_pk_client.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	"github.com/shopspring/decimal"
+)
+
+// GrpcPositionKeepingClient adapts the generated PK gRPC client to the
+// PositionKeepingClient interface used by BalanceAssertor.
+type GrpcPositionKeepingClient struct {
+	client positionkeepingv1.PositionKeepingServiceClient
+}
+
+// NewGrpcPositionKeepingClient creates a new adapter wrapping the PK gRPC client.
+func NewGrpcPositionKeepingClient(client positionkeepingv1.PositionKeepingServiceClient) *GrpcPositionKeepingClient {
+	return &GrpcPositionKeepingClient{client: client}
+}
+
+// GetPositionSummary fetches position logs for the given account and instrument code,
+// aggregating total debits and credits across all pages.
+func (c *GrpcPositionKeepingClient) GetPositionSummary(ctx context.Context, accountID, instrumentCode string) (*PositionSummary, error) {
+	totalDebits := decimal.Zero
+	totalCredits := decimal.Zero
+	pageToken := ""
+
+	for {
+		resp, err := c.client.ListFinancialPositionLogs(ctx, &positionkeepingv1.ListFinancialPositionLogsRequest{
+			AccountId: accountID,
+			Pagination: &commonv1.Pagination{
+				PageSize:  100,
+				PageToken: pageToken,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing position logs: %w", err)
+		}
+
+		for _, log := range resp.GetLogs() {
+			for _, entry := range log.GetTransactionLogEntries() {
+				m := entry.GetAmount().GetAmount()
+				if m == nil {
+					continue
+				}
+
+				// Filter by instrument code using the entry's currency code.
+				if instrumentCode != "" && m.GetCurrencyCode() != instrumentCode {
+					continue
+				}
+
+				amount, err := moneyToDecimal(m)
+				if err != nil {
+					continue
+				}
+
+				switch entry.GetDirection() {
+				case commonv1.PostingDirection_POSTING_DIRECTION_DEBIT:
+					totalDebits = totalDebits.Add(amount)
+				case commonv1.PostingDirection_POSTING_DIRECTION_CREDIT:
+					totalCredits = totalCredits.Add(amount)
+				}
+			}
+		}
+
+		nextToken := ""
+		if resp.GetPagination() != nil {
+			nextToken = resp.GetPagination().GetNextPageToken()
+		}
+		if nextToken == "" {
+			break
+		}
+		pageToken = nextToken
+	}
+
+	return &PositionSummary{
+		InstrumentCode: instrumentCode,
+		TotalDebits:    totalDebits,
+		TotalCredits:   totalCredits,
+	}, nil
+}

--- a/services/reconciliation/service/grpc_pk_client.go
+++ b/services/reconciliation/service/grpc_pk_client.go
@@ -61,6 +61,8 @@ func (c *GrpcPositionKeepingClient) GetPositionSummary(ctx context.Context, acco
 					totalDebits = totalDebits.Add(amount)
 				case commonv1.PostingDirection_POSTING_DIRECTION_CREDIT:
 					totalCredits = totalCredits.Add(amount)
+				case commonv1.PostingDirection_POSTING_DIRECTION_UNSPECIFIED:
+					// Skip entries with unspecified direction
 				}
 			}
 		}

--- a/services/reconciliation/service/grpc_pk_client_test.go
+++ b/services/reconciliation/service/grpc_pk_client_test.go
@@ -1,0 +1,159 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/type/money"
+	"google.golang.org/grpc"
+)
+
+// stubPKServiceClient is a minimal test double for positionkeepingv1.PositionKeepingServiceClient.
+// Only ListFinancialPositionLogs is used by GrpcPositionKeepingClient.
+type stubPKServiceClient struct {
+	positionkeepingv1.PositionKeepingServiceClient
+	responses []*positionkeepingv1.ListFinancialPositionLogsResponse
+	callIdx   int
+	err       error
+}
+
+func (s *stubPKServiceClient) ListFinancialPositionLogs(
+	_ context.Context,
+	_ *positionkeepingv1.ListFinancialPositionLogsRequest,
+	_ ...grpc.CallOption,
+) (*positionkeepingv1.ListFinancialPositionLogsResponse, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.callIdx >= len(s.responses) {
+		return &positionkeepingv1.ListFinancialPositionLogsResponse{}, nil
+	}
+	resp := s.responses[s.callIdx]
+	s.callIdx++
+	return resp, nil
+}
+
+func makeEntry(currencyCode string, units int64, direction commonv1.PostingDirection) *positionkeepingv1.TransactionLogEntry {
+	return &positionkeepingv1.TransactionLogEntry{
+		Direction: direction,
+		Amount: &commonv1.MoneyAmount{
+			Amount: &money.Money{CurrencyCode: currencyCode, Units: units, Nanos: 0},
+		},
+	}
+}
+
+func TestGrpcPositionKeepingClient_GetPositionSummary_SinglePage(t *testing.T) {
+	stub := &stubPKServiceClient{
+		responses: []*positionkeepingv1.ListFinancialPositionLogsResponse{
+			{
+				Logs: []*positionkeepingv1.FinancialPositionLog{
+					{
+						LogId:     "log-1",
+						AccountId: "acct-1",
+						TransactionLogEntries: []*positionkeepingv1.TransactionLogEntry{
+							makeEntry("GBP", 100, commonv1.PostingDirection_POSTING_DIRECTION_DEBIT),
+							makeEntry("GBP", 50, commonv1.PostingDirection_POSTING_DIRECTION_CREDIT),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	client := NewGrpcPositionKeepingClient(stub)
+	summary, err := client.GetPositionSummary(context.Background(), "acct-1", "GBP")
+
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromInt(100).Equal(summary.TotalDebits), "expected 100 debits, got %s", summary.TotalDebits)
+	assert.True(t, decimal.NewFromInt(50).Equal(summary.TotalCredits), "expected 50 credits, got %s", summary.TotalCredits)
+	assert.Equal(t, "GBP", summary.InstrumentCode)
+}
+
+func TestGrpcPositionKeepingClient_GetPositionSummary_FiltersInstrumentCode(t *testing.T) {
+	stub := &stubPKServiceClient{
+		responses: []*positionkeepingv1.ListFinancialPositionLogsResponse{
+			{
+				Logs: []*positionkeepingv1.FinancialPositionLog{
+					{
+						TransactionLogEntries: []*positionkeepingv1.TransactionLogEntry{
+							makeEntry("GBP", 100, commonv1.PostingDirection_POSTING_DIRECTION_DEBIT),
+							makeEntry("EUR", 200, commonv1.PostingDirection_POSTING_DIRECTION_DEBIT),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	client := NewGrpcPositionKeepingClient(stub)
+	summary, err := client.GetPositionSummary(context.Background(), "acct-1", "GBP")
+
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromInt(100).Equal(summary.TotalDebits), "should only include GBP debits")
+	assert.True(t, decimal.Zero.Equal(summary.TotalCredits))
+}
+
+func TestGrpcPositionKeepingClient_GetPositionSummary_MultiPage(t *testing.T) {
+	stub := &stubPKServiceClient{
+		responses: []*positionkeepingv1.ListFinancialPositionLogsResponse{
+			{
+				Logs: []*positionkeepingv1.FinancialPositionLog{
+					{
+						TransactionLogEntries: []*positionkeepingv1.TransactionLogEntry{
+							makeEntry("GBP", 50, commonv1.PostingDirection_POSTING_DIRECTION_DEBIT),
+						},
+					},
+				},
+				Pagination: &commonv1.PaginationResponse{NextPageToken: "page2"},
+			},
+			{
+				Logs: []*positionkeepingv1.FinancialPositionLog{
+					{
+						TransactionLogEntries: []*positionkeepingv1.TransactionLogEntry{
+							makeEntry("GBP", 30, commonv1.PostingDirection_POSTING_DIRECTION_DEBIT),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	client := NewGrpcPositionKeepingClient(stub)
+	summary, err := client.GetPositionSummary(context.Background(), "acct-1", "GBP")
+
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromInt(80).Equal(summary.TotalDebits), "expected 50+30=80 debits across pages")
+}
+
+func TestGrpcPositionKeepingClient_GetPositionSummary_RPCError(t *testing.T) {
+	stub := &stubPKServiceClient{
+		err: errors.New("connection refused"),
+	}
+
+	client := NewGrpcPositionKeepingClient(stub)
+	_, err := client.GetPositionSummary(context.Background(), "acct-1", "GBP")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listing position logs")
+}
+
+func TestGrpcPositionKeepingClient_GetPositionSummary_EmptyResponse(t *testing.T) {
+	stub := &stubPKServiceClient{
+		responses: []*positionkeepingv1.ListFinancialPositionLogsResponse{
+			{Logs: nil},
+		},
+	}
+
+	client := NewGrpcPositionKeepingClient(stub)
+	summary, err := client.GetPositionSummary(context.Background(), "acct-1", "GBP")
+
+	require.NoError(t, err)
+	assert.True(t, decimal.Zero.Equal(summary.TotalDebits))
+	assert.True(t, decimal.Zero.Equal(summary.TotalCredits))
+}


### PR DESCRIPTION
## Summary

- Wire `BalanceAssertor` service component in `cmd/main.go` with `BalanceAssertionRepository`, `ImbalanceTrendRepository`, and a new `GrpcPositionKeepingClient` adapter
- `AssertBalance` RPC now returns real assertion results (instead of `UNIMPLEMENTED`) when `POSITION_KEEPING_URL` is configured
- Remove obsolete warning log about assertion repository not being available

## Changes

- **`services/reconciliation/cmd/main.go`**: Instantiate `assertionRepo` and `trendRepo` after existing repositories; wire `BalanceAssertor` inside the `pkConn != nil` guard with appropriate logging for both configured and unconfigured paths
- **`services/reconciliation/service/grpc_pk_client.go`** (new): `GrpcPositionKeepingClient` adapter that implements `PositionKeepingClient` by aggregating debit/credit totals from `ListFinancialPositionLogs` with pagination and instrument code filtering
- **`services/reconciliation/service/grpc_pk_client_test.go`** (new): Unit tests covering single-page, multi-page, instrument filtering, RPC error, and empty response scenarios

## Test plan

- [x] Unit tests for `GrpcPositionKeepingClient` adapter (5 tests, all passing)
- [x] Existing service test suite passes (no regressions)
- [x] Build succeeds (`go build`, `go vet`)
- [ ] CI pipeline

Task Master: `reconciliation-service-phase2.3`