### PR TITLE
feat: Implement Stripe webhook event processor

### DIFF
--- a/services/payment-order/adapters/gateway/stripe/webhook_adapter.go
+++ b/services/payment-order/adapters/gateway/stripe/webhook_adapter.go
@@ -30,6 +30,8 @@ const (
 // payment-order domain. The http package converts this to WebhookRequest
 // for processing through the existing pipeline.
 type ParsedWebhookEvent struct {
+	// EventID is the Stripe event ID (e.g., "evt_1234"), used for idempotency.
+	EventID            string
 	GatewayReferenceID string
 	PaymentOrderID     string
 	Status             string
@@ -91,6 +93,7 @@ func (a *WebhookAdapter) parsePaymentIntentSucceeded(event *stripego.Event) (Par
 	}
 
 	return ParsedWebhookEvent{
+		EventID:            event.ID,
 		GatewayReferenceID: pi.ID,
 		PaymentOrderID:     pi.Metadata["payment_order_id"],
 		Status:             "SETTLED",
@@ -110,6 +113,7 @@ func (a *WebhookAdapter) parsePaymentIntentFailed(event *stripego.Event) (Parsed
 	}
 
 	return ParsedWebhookEvent{
+		EventID:            event.ID,
 		GatewayReferenceID: pi.ID,
 		PaymentOrderID:     pi.Metadata["payment_order_id"],
 		Status:             "REJECTED",
@@ -127,6 +131,7 @@ func (a *WebhookAdapter) parseChargeRefunded(event *stripego.Event) (ParsedWebho
 	paymentOrderID := extractPaymentOrderID(&charge)
 
 	return ParsedWebhookEvent{
+		EventID:            event.ID,
 		GatewayReferenceID: charge.ID,
 		PaymentOrderID:     paymentOrderID,
 		Status:             "REFUNDED",
@@ -160,6 +165,7 @@ func (a *WebhookAdapter) parseChargeDisputed(event *stripego.Event) (ParsedWebho
 	}
 
 	return ParsedWebhookEvent{
+		EventID:            event.ID,
 		GatewayReferenceID: dispute.Charge.ID,
 		PaymentOrderID:     paymentOrderID,
 		Status:             "DISPUTED",

--- a/services/payment-order/adapters/http/stripe_event_processor.go
+++ b/services/payment-order/adapters/http/stripe_event_processor.go
@@ -1,0 +1,125 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// StripeEventProcessor errors.
+var (
+	ErrNilRedisClient        = errors.New("redis client cannot be nil")
+	ErrEventAlreadyProcessed = errors.New("stripe event already processed")
+)
+
+// Stripe event processor constants.
+const (
+	// processedWebhookKeyPrefix is the Redis key prefix for deduplicating Stripe webhook events.
+	processedWebhookKeyPrefix = "processed_webhook:"
+
+	// processedWebhookTTL is how long processed event IDs are retained in Redis (48 hours).
+	processedWebhookTTL = 48 * time.Hour
+
+	// dunningRetryZSet is the Redis sorted set key for dunning retry scheduling.
+	// This matches the key used by DunningWorker.
+	dunningRetryZSet = "dunning:retries"
+
+	// defaultDunningDelay is the default delay before the first dunning retry.
+	defaultDunningDelay = 24 * time.Hour
+)
+
+// StripeEventProcessor processes Stripe webhook events with idempotency guarantees.
+// It provides a Stripe-specific deduplication layer using event IDs, complementing
+// the existing idempotency in UpdatePaymentOrder (which uses webhook-level keys).
+//
+// Responsibilities:
+//   - Deduplicate Stripe events by event ID (Redis SET with 48h TTL)
+//   - Trigger dunning for failed payments (add to Redis ZSET)
+type StripeEventProcessor struct {
+	redis  *redis.Client
+	logger *slog.Logger
+}
+
+// StripeEventProcessorConfig contains configuration for creating a StripeEventProcessor.
+type StripeEventProcessorConfig struct {
+	RedisClient *redis.Client
+	Logger      *slog.Logger
+}
+
+// NewStripeEventProcessor creates a new StripeEventProcessor.
+func NewStripeEventProcessor(cfg StripeEventProcessorConfig) (*StripeEventProcessor, error) {
+	if cfg.RedisClient == nil {
+		return nil, ErrNilRedisClient
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &StripeEventProcessor{
+		redis:  cfg.RedisClient,
+		logger: logger,
+	}, nil
+}
+
+// PreProcess checks whether a Stripe event has already been processed.
+// Returns ErrEventAlreadyProcessed if the event ID was already seen.
+// Otherwise, marks the event as processed in Redis with a 48h TTL.
+// On Redis failure, returns nil to allow processing to continue
+// (the downstream UpdatePaymentOrder has its own idempotency layer).
+func (p *StripeEventProcessor) PreProcess(ctx context.Context, eventID string) error {
+	key := processedWebhookKeyPrefix + eventID
+
+	// SET NX - only sets if key does not exist, returns true if set (new event)
+	wasSet, err := p.redis.SetNX(ctx, key, time.Now().Unix(), processedWebhookTTL).Result()
+	if err != nil {
+		p.logger.Error("failed to check stripe event idempotency",
+			"event_id", eventID,
+			"error", err)
+		return nil
+	}
+
+	if !wasSet {
+		p.logger.Info("stripe event already processed, skipping",
+			"event_id", eventID)
+		return ErrEventAlreadyProcessed
+	}
+
+	p.logger.Debug("stripe event marked as processing",
+		"event_id", eventID)
+
+	return nil
+}
+
+// ScheduleDunning adds a payment order to the dunning retry sorted set.
+// Called when a payment_intent.payment_failed event is received.
+// The dunning worker will pick up the entry and trigger escalation.
+func (p *StripeEventProcessor) ScheduleDunning(ctx context.Context, paymentOrderID string) error {
+	if paymentOrderID == "" {
+		p.logger.Warn("cannot schedule dunning: empty payment order ID")
+		return nil
+	}
+
+	dueAt := time.Now().Add(defaultDunningDelay)
+	member := redis.Z{
+		Score:  float64(dueAt.Unix()),
+		Member: fmt.Sprintf("stripe:%s", paymentOrderID),
+	}
+
+	err := p.redis.ZAdd(ctx, dunningRetryZSet, member).Err()
+	if err != nil {
+		p.logger.Error("failed to schedule dunning retry",
+			"payment_order_id", paymentOrderID,
+			"error", err)
+		return fmt.Errorf("failed to schedule dunning retry: %w", err)
+	}
+
+	p.logger.Info("dunning retry scheduled for failed stripe payment",
+		"payment_order_id", paymentOrderID,
+		"due_at", dueAt)
+
+	return nil
+}

--- a/services/payment-order/adapters/http/stripe_event_processor.go
+++ b/services/payment-order/adapters/http/stripe_event_processor.go
@@ -71,6 +71,11 @@ func NewStripeEventProcessor(cfg StripeEventProcessorConfig) (*StripeEventProces
 // On Redis failure, returns nil to allow processing to continue
 // (the downstream UpdatePaymentOrder has its own idempotency layer).
 func (p *StripeEventProcessor) PreProcess(ctx context.Context, eventID string) error {
+	if eventID == "" {
+		p.logger.Warn("cannot preprocess stripe event: empty event ID")
+		return nil
+	}
+
 	key := processedWebhookKeyPrefix + eventID
 
 	// SET NX - only sets if key does not exist, returns true if set (new event)

--- a/services/payment-order/adapters/http/stripe_event_processor_test.go
+++ b/services/payment-order/adapters/http/stripe_event_processor_test.go
@@ -1,0 +1,162 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestRedis(t *testing.T) (*redis.Client, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return client, mr
+}
+
+func setupTestEventProcessor(t *testing.T) (*StripeEventProcessor, *redis.Client, *miniredis.Miniredis) {
+	t.Helper()
+	client, mr := setupTestRedis(t)
+	proc, err := NewStripeEventProcessor(StripeEventProcessorConfig{
+		RedisClient: client,
+	})
+	require.NoError(t, err)
+	return proc, client, mr
+}
+
+func TestNewStripeEventProcessor(t *testing.T) {
+	t.Run("valid config", func(t *testing.T) {
+		client, _ := setupTestRedis(t)
+		proc, err := NewStripeEventProcessor(StripeEventProcessorConfig{
+			RedisClient: client,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, proc)
+	})
+
+	t.Run("nil redis client", func(t *testing.T) {
+		proc, err := NewStripeEventProcessor(StripeEventProcessorConfig{
+			RedisClient: nil,
+		})
+		assert.ErrorIs(t, err, ErrNilRedisClient)
+		assert.Nil(t, proc)
+	})
+}
+
+func TestStripeEventProcessor_PreProcess(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("new event is accepted", func(t *testing.T) {
+		proc, client, _ := setupTestEventProcessor(t)
+
+		err := proc.PreProcess(ctx, "evt_new_123")
+		assert.NoError(t, err)
+
+		// Verify the key was set in Redis
+		exists, err := client.Exists(ctx, processedWebhookKeyPrefix+"evt_new_123").Result()
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), exists)
+	})
+
+	t.Run("duplicate event is rejected", func(t *testing.T) {
+		proc, _, _ := setupTestEventProcessor(t)
+
+		// First call should succeed
+		err := proc.PreProcess(ctx, "evt_dup_456")
+		assert.NoError(t, err)
+
+		// Second call with same event ID should return ErrEventAlreadyProcessed
+		err = proc.PreProcess(ctx, "evt_dup_456")
+		assert.ErrorIs(t, err, ErrEventAlreadyProcessed)
+	})
+
+	t.Run("different events are independent", func(t *testing.T) {
+		proc, _, _ := setupTestEventProcessor(t)
+
+		err := proc.PreProcess(ctx, "evt_a")
+		assert.NoError(t, err)
+
+		err = proc.PreProcess(ctx, "evt_b")
+		assert.NoError(t, err)
+	})
+
+	t.Run("redis failure allows processing to continue", func(t *testing.T) {
+		proc, _, mr := setupTestEventProcessor(t)
+
+		// Close miniredis to simulate failure
+		mr.Close()
+
+		err := proc.PreProcess(ctx, "evt_fail")
+		// Should return nil (not an error) to allow processing to continue
+		assert.NoError(t, err)
+	})
+
+	t.Run("ttl is set on processed key", func(t *testing.T) {
+		proc, _, mr := setupTestEventProcessor(t)
+
+		err := proc.PreProcess(ctx, "evt_ttl_check")
+		assert.NoError(t, err)
+
+		ttl := mr.TTL(processedWebhookKeyPrefix + "evt_ttl_check")
+		assert.Equal(t, processedWebhookTTL, ttl)
+	})
+}
+
+func TestStripeEventProcessor_ScheduleDunning(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("schedules dunning for payment order", func(t *testing.T) {
+		proc, client, _ := setupTestEventProcessor(t)
+
+		err := proc.ScheduleDunning(ctx, "po-123")
+		assert.NoError(t, err)
+
+		// Verify the entry was added to the ZSET
+		members, err := client.ZRangeByScore(ctx, dunningRetryZSet, &redis.ZRangeBy{
+			Min: "-inf",
+			Max: "+inf",
+		}).Result()
+		require.NoError(t, err)
+		assert.Len(t, members, 1)
+		assert.Equal(t, "stripe:po-123", members[0])
+	})
+
+	t.Run("empty payment order ID is a no-op", func(t *testing.T) {
+		proc, client, _ := setupTestEventProcessor(t)
+
+		err := proc.ScheduleDunning(ctx, "")
+		assert.NoError(t, err)
+
+		// Verify nothing was added to the ZSET
+		count, err := client.ZCard(ctx, dunningRetryZSet).Result()
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), count)
+	})
+
+	t.Run("multiple dunning entries are independent", func(t *testing.T) {
+		proc, client, _ := setupTestEventProcessor(t)
+
+		err := proc.ScheduleDunning(ctx, "po-aaa")
+		assert.NoError(t, err)
+
+		err = proc.ScheduleDunning(ctx, "po-bbb")
+		assert.NoError(t, err)
+
+		count, err := client.ZCard(ctx, dunningRetryZSet).Result()
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), count)
+	})
+
+	t.Run("redis failure returns error", func(t *testing.T) {
+		proc, _, mr := setupTestEventProcessor(t)
+
+		mr.Close()
+
+		err := proc.ScheduleDunning(ctx, "po-fail")
+		assert.Error(t, err)
+	})
+}

--- a/services/payment-order/adapters/http/stripe_event_processor_test.go
+++ b/services/payment-order/adapters/http/stripe_event_processor_test.go
@@ -50,6 +50,18 @@ func TestNewStripeEventProcessor(t *testing.T) {
 func TestStripeEventProcessor_PreProcess(t *testing.T) {
 	ctx := context.Background()
 
+	t.Run("empty event ID is a no-op", func(t *testing.T) {
+		proc, client, _ := setupTestEventProcessor(t)
+
+		err := proc.PreProcess(ctx, "")
+		assert.NoError(t, err)
+
+		// Verify no key was set in Redis
+		keys, err := client.Keys(ctx, processedWebhookKeyPrefix+"*").Result()
+		require.NoError(t, err)
+		assert.Empty(t, keys)
+	})
+
 	t.Run("new event is accepted", func(t *testing.T) {
 		proc, client, _ := setupTestEventProcessor(t)
 

--- a/services/payment-order/adapters/http/stripe_webhook_handler.go
+++ b/services/payment-order/adapters/http/stripe_webhook_handler.go
@@ -27,6 +27,7 @@ const StripeWebhookMaxBodySize = 512 * 1024
 type StripeWebhookHandler struct {
 	clientFactory  *stripe.ClientFactory
 	webhookHandler *WebhookHandler
+	eventProcessor *StripeEventProcessor
 	logger         *slog.Logger
 }
 
@@ -34,6 +35,9 @@ type StripeWebhookHandler struct {
 type StripeWebhookHandlerConfig struct {
 	ClientFactory  *stripe.ClientFactory
 	WebhookHandler *WebhookHandler
+	// EventProcessor is optional. When set, provides Stripe event ID-based
+	// idempotency and dunning scheduling for failed payments.
+	EventProcessor *StripeEventProcessor
 	Logger         *slog.Logger
 }
 
@@ -52,6 +56,7 @@ func NewStripeWebhookHandler(cfg StripeWebhookHandlerConfig) (*StripeWebhookHand
 	return &StripeWebhookHandler{
 		clientFactory:  cfg.ClientFactory,
 		webhookHandler: cfg.WebhookHandler,
+		eventProcessor: cfg.EventProcessor,
 		logger:         logger,
 	}, nil
 }
@@ -134,6 +139,19 @@ func (h *StripeWebhookHandler) HandleStripeWebhook(w http.ResponseWriter, r *htt
 		return
 	}
 
+	// Check Stripe event-level idempotency via event processor (if configured)
+	if h.eventProcessor != nil && parsed.EventID != "" {
+		if err := h.eventProcessor.PreProcess(ctx, parsed.EventID); err != nil {
+			if errors.Is(err, ErrEventAlreadyProcessed) {
+				h.writeSuccessResponse(w, "event already processed")
+				return
+			}
+			// PreProcess logs the error internally and returns nil on Redis failure,
+			// so a non-nil, non-duplicate error is unexpected. Log and continue.
+			h.logger.Warn("unexpected event processor error", "error", err)
+		}
+	}
+
 	// Convert ParsedWebhookEvent to WebhookRequest
 	webhookReq := WebhookRequest{
 		GatewayReferenceID: parsed.GatewayReferenceID,
@@ -157,6 +175,7 @@ func (h *StripeWebhookHandler) HandleStripeWebhook(w http.ResponseWriter, r *htt
 	idempotencyKey := h.webhookHandler.generateIdempotencyKey(webhookReq)
 
 	h.logger.Info("processing stripe webhook",
+		"event_id", parsed.EventID,
 		"gateway_reference_id", webhookReq.GatewayReferenceID,
 		"payment_order_id", webhookReq.PaymentOrderID,
 		"status", webhookReq.Status,
@@ -164,6 +183,16 @@ func (h *StripeWebhookHandler) HandleStripeWebhook(w http.ResponseWriter, r *htt
 	)
 
 	h.webhookHandler.processWebhookRequest(ctx, w, webhookReq, gatewayStatus, idempotencyKey)
+
+	// Schedule dunning for failed payments (fire-and-forget, does not affect response)
+	if h.eventProcessor != nil && parsed.Status == "REJECTED" && parsed.PaymentOrderID != "" {
+		if dunningErr := h.eventProcessor.ScheduleDunning(ctx, parsed.PaymentOrderID); dunningErr != nil {
+			h.logger.Error("failed to schedule dunning for failed payment",
+				"payment_order_id", parsed.PaymentOrderID,
+				"event_id", parsed.EventID,
+				"error", dunningErr)
+		}
+	}
 }
 
 func (h *StripeWebhookHandler) writeSuccessResponse(w http.ResponseWriter, message string) {

--- a/services/payment-order/adapters/http/stripe_webhook_handler_test.go
+++ b/services/payment-order/adapters/http/stripe_webhook_handler_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stripe/stripe-go/v82/webhook"
@@ -250,4 +252,229 @@ func TestStripeWebhookHandler_MethodNotAllowed(t *testing.T) {
 	handler.HandleStripeWebhook(rr, req)
 
 	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+// setupStripeWebhookHandlerWithProcessor creates a handler with the event processor wired in.
+func setupStripeWebhookHandlerWithProcessor(t *testing.T) (*StripeWebhookHandler, *mockPaymentOrderService, *redis.Client, *miniredis.Miniredis) {
+	t.Helper()
+
+	mr := miniredis.RunT(t)
+	redisClient := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = redisClient.Close() })
+
+	eventProcessor, err := NewStripeEventProcessor(StripeEventProcessorConfig{
+		RedisClient: redisClient,
+	})
+	require.NoError(t, err)
+
+	mockSvc := &mockPaymentOrderService{
+		updateFunc: func(_ context.Context, _ *pb.UpdatePaymentOrderRequest) (*pb.UpdatePaymentOrderResponse, error) {
+			return &pb.UpdatePaymentOrderResponse{
+				PaymentOrder: &pb.PaymentOrder{
+					PaymentOrderId: "test-order",
+					Status:         pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+				},
+			}, nil
+		},
+	}
+
+	webhookHandler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: mockSvc,
+		HMACSecret:          []byte("generic-secret"),
+	})
+	require.NoError(t, err)
+
+	provider := &testConfigProvider{
+		configs: map[string]stripe.TenantConfig{
+			"test-tenant": {
+				ConnectedAccountID:    "acct_test_123",
+				WebhookEndpointSecret: testStripeWebhookSecret,
+			},
+		},
+	}
+
+	factory, err := stripe.NewClientFactory(testStripeConfig(), provider, nil)
+	require.NoError(t, err)
+
+	stripeHandler, err := NewStripeWebhookHandler(StripeWebhookHandlerConfig{
+		ClientFactory:  factory,
+		WebhookHandler: webhookHandler,
+		EventProcessor: eventProcessor,
+	})
+	require.NoError(t, err)
+
+	return stripeHandler, mockSvc, redisClient, mr
+}
+
+func TestStripeWebhookHandler_EventProcessorIdempotency(t *testing.T) {
+	handler, mockSvc, redisClient, _ := setupStripeWebhookHandlerWithProcessor(t)
+	ctx := context.Background()
+
+	callCount := 0
+	mockSvc.updateFunc = func(_ context.Context, _ *pb.UpdatePaymentOrderRequest) (*pb.UpdatePaymentOrderResponse, error) {
+		callCount++
+		return &pb.UpdatePaymentOrderResponse{
+			PaymentOrder: &pb.PaymentOrder{
+				PaymentOrderId: "po-idem",
+				Status:         pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+			},
+		}, nil
+	}
+
+	payload := buildTestStripePayload(t, "evt_idem_test", "payment_intent.succeeded", map[string]any{
+		"id":       "pi_idem_123",
+		"object":   "payment_intent",
+		"amount":   1000,
+		"currency": "usd",
+		"metadata": map[string]string{"payment_order_id": "po-idem"},
+		"status":   "succeeded",
+	})
+	sig := signTestPayload(t, payload, testStripeWebhookSecret)
+
+	// First request should be processed
+	tenantCtx := tenant.WithTenant(context.Background(), "test-tenant")
+	req1 := httptest.NewRequest(http.MethodPost, "/webhook/stripe", bytes.NewReader(payload)).WithContext(tenantCtx)
+	req1.Header.Set("Stripe-Signature", sig)
+	rr1 := httptest.NewRecorder()
+	handler.HandleStripeWebhook(rr1, req1)
+
+	assert.Equal(t, http.StatusOK, rr1.Code)
+	assert.Equal(t, 1, callCount)
+
+	// Verify Redis key was set
+	exists, err := redisClient.Exists(ctx, processedWebhookKeyPrefix+"evt_idem_test").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), exists)
+
+	// Second request with same event ID should be deduplicated
+	// Need to re-sign because Stripe checks timestamp freshness
+	payload2 := buildTestStripePayload(t, "evt_idem_test", "payment_intent.succeeded", map[string]any{
+		"id":       "pi_idem_123",
+		"object":   "payment_intent",
+		"amount":   1000,
+		"currency": "usd",
+		"metadata": map[string]string{"payment_order_id": "po-idem"},
+		"status":   "succeeded",
+	})
+	sig2 := signTestPayload(t, payload2, testStripeWebhookSecret)
+	req2 := httptest.NewRequest(http.MethodPost, "/webhook/stripe", bytes.NewReader(payload2)).WithContext(tenantCtx)
+	req2.Header.Set("Stripe-Signature", sig2)
+	rr2 := httptest.NewRecorder()
+	handler.HandleStripeWebhook(rr2, req2)
+
+	assert.Equal(t, http.StatusOK, rr2.Code)
+	// Service should NOT be called again (deduplicated by event processor)
+	assert.Equal(t, 1, callCount)
+
+	// Verify response indicates already processed
+	var resp WebhookResponse
+	err = json.Unmarshal(rr2.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.True(t, resp.Acknowledged)
+	assert.Equal(t, "event already processed", resp.Message)
+}
+
+func TestStripeWebhookHandler_FailedPaymentTriggersDunning(t *testing.T) {
+	handler, mockSvc, redisClient, _ := setupStripeWebhookHandlerWithProcessor(t)
+	ctx := context.Background()
+
+	mockSvc.updateFunc = func(_ context.Context, _ *pb.UpdatePaymentOrderRequest) (*pb.UpdatePaymentOrderResponse, error) {
+		return &pb.UpdatePaymentOrderResponse{
+			PaymentOrder: &pb.PaymentOrder{
+				PaymentOrderId: "po-failed",
+				Status:         pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_FAILED,
+			},
+		}, nil
+	}
+
+	payload := buildTestStripePayload(t, "evt_fail_dun", "payment_intent.payment_failed", map[string]any{
+		"id":                 "pi_fail_456",
+		"object":             "payment_intent",
+		"amount":             2000,
+		"currency":           "gbp",
+		"metadata":           map[string]string{"payment_order_id": "po-failed"},
+		"status":             "requires_payment_method",
+		"last_payment_error": map[string]any{"message": "card declined"},
+	})
+	sig := signTestPayload(t, payload, testStripeWebhookSecret)
+
+	tenantCtx := tenant.WithTenant(context.Background(), "test-tenant")
+	req := httptest.NewRequest(http.MethodPost, "/webhook/stripe", bytes.NewReader(payload)).WithContext(tenantCtx)
+	req.Header.Set("Stripe-Signature", sig)
+
+	rr := httptest.NewRecorder()
+	handler.HandleStripeWebhook(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	// Verify dunning was scheduled in the ZSET
+	members, err := redisClient.ZRangeByScore(ctx, dunningRetryZSet, &redis.ZRangeBy{
+		Min: "-inf",
+		Max: "+inf",
+	}).Result()
+	require.NoError(t, err)
+	assert.Len(t, members, 1)
+	assert.Equal(t, "stripe:po-failed", members[0])
+}
+
+func TestStripeWebhookHandler_SucceededPaymentDoesNotTriggerDunning(t *testing.T) {
+	handler, _, redisClient, _ := setupStripeWebhookHandlerWithProcessor(t)
+	ctx := context.Background()
+
+	payload := buildTestStripePayload(t, "evt_succ_no_dun", "payment_intent.succeeded", map[string]any{
+		"id":       "pi_succ_789",
+		"object":   "payment_intent",
+		"amount":   3000,
+		"currency": "gbp",
+		"metadata": map[string]string{"payment_order_id": "po-success"},
+		"status":   "succeeded",
+	})
+	sig := signTestPayload(t, payload, testStripeWebhookSecret)
+
+	tenantCtx := tenant.WithTenant(context.Background(), "test-tenant")
+	req := httptest.NewRequest(http.MethodPost, "/webhook/stripe", bytes.NewReader(payload)).WithContext(tenantCtx)
+	req.Header.Set("Stripe-Signature", sig)
+
+	rr := httptest.NewRecorder()
+	handler.HandleStripeWebhook(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	// Verify dunning was NOT scheduled
+	count, err := redisClient.ZCard(ctx, dunningRetryZSet).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestStripeWebhookHandler_RefundedDoesNotTriggerDunning(t *testing.T) {
+	handler, _, redisClient, _ := setupStripeWebhookHandlerWithProcessor(t)
+	ctx := context.Background()
+
+	payload := buildTestStripePayload(t, "evt_refund_no_dun", "charge.refunded", map[string]any{
+		"id":       "ch_refund_101",
+		"object":   "charge",
+		"amount":   4000,
+		"currency": "gbp",
+		"metadata": map[string]string{"payment_order_id": "po-refunded"},
+		"payment_intent": map[string]any{
+			"id":       "pi_refund_101",
+			"object":   "payment_intent",
+			"metadata": map[string]string{"payment_order_id": "po-refunded"},
+		},
+	})
+	sig := signTestPayload(t, payload, testStripeWebhookSecret)
+
+	tenantCtx := tenant.WithTenant(context.Background(), "test-tenant")
+	req := httptest.NewRequest(http.MethodPost, "/webhook/stripe", bytes.NewReader(payload)).WithContext(tenantCtx)
+	req.Header.Set("Stripe-Signature", sig)
+
+	rr := httptest.NewRecorder()
+	handler.HandleStripeWebhook(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	// Verify dunning was NOT scheduled for refunds
+	count, err := redisClient.ZCard(ctx, dunningRetryZSet).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
 }

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -401,8 +401,17 @@ func run(logger *slog.Logger) error {
 		return fmt.Errorf("failed to create webhook handler: %w", err)
 	}
 
+	// Create Stripe event processor for webhook idempotency and dunning
+	eventProcessor, err := webhookhttp.NewStripeEventProcessor(webhookhttp.StripeEventProcessorConfig{
+		RedisClient: redisClient,
+		Logger:      logger,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create stripe event processor: %w", err)
+	}
+
 	// Create Stripe webhook handler (optional - only if STRIPE_API_KEY is configured)
-	stripeWebhookHandler, err := createStripeWebhookHandler(svcConfig, webhookHandler, logger)
+	stripeWebhookHandler, err := createStripeWebhookHandler(svcConfig, webhookHandler, eventProcessor, logger)
 	if err != nil {
 		return fmt.Errorf("failed to create stripe webhook handler: %w", err)
 	}
@@ -854,7 +863,7 @@ func createGatewayAccountConfig(logger *slog.Logger) (*config.GatewayAccountConf
 
 // createStripeWebhookHandler creates the StripeWebhookHandler if Stripe provider is configured.
 // Returns nil (no error) when Stripe is not the active provider, making the handler optional.
-func createStripeWebhookHandler(svcConfig config.ServiceConfig, webhookHandler *webhookhttp.WebhookHandler, logger *slog.Logger) (*webhookhttp.StripeWebhookHandler, error) {
+func createStripeWebhookHandler(svcConfig config.ServiceConfig, webhookHandler *webhookhttp.WebhookHandler, eventProcessor *webhookhttp.StripeEventProcessor, logger *slog.Logger) (*webhookhttp.StripeWebhookHandler, error) {
 	if svcConfig.StripeAPIKey == "" {
 		logger.Info("Stripe API key not set, Stripe webhook handler disabled")
 		return nil, nil //nolint:nilnil // nil handler is intentional: ServerConfig treats nil as "feature disabled"
@@ -876,6 +885,7 @@ func createStripeWebhookHandler(svcConfig config.ServiceConfig, webhookHandler *
 	handler, err := webhookhttp.NewStripeWebhookHandler(webhookhttp.StripeWebhookHandlerConfig{
 		ClientFactory:  clientFactory,
 		WebhookHandler: webhookHandler,
+		EventProcessor: eventProcessor,
 		Logger:         logger,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- Create StripeEventProcessor for handling Stripe webhook event deduplication and dunning
- Redis SETNX-based idempotency using Stripe event IDs with 48h TTL
- Dunning scheduling for failed payments via Redis ZSET (consumed by DunningWorker)
- Wire into StripeWebhookHandler as optional pre-processing layer
- Wire into cmd/main.go using existing Redis client

## Task Master
Tag: stripe-connect-wiring, Task: 8

## Changes
- `services/payment-order/adapters/http/stripe_event_processor.go` - New StripeEventProcessor with PreProcess (idempotency) and ScheduleDunning methods
- `services/payment-order/adapters/http/stripe_event_processor_test.go` - Unit tests with miniredis
- `services/payment-order/adapters/http/stripe_webhook_handler.go` - Add optional EventProcessor field, call PreProcess before and ScheduleDunning after webhook processing
- `services/payment-order/adapters/http/stripe_webhook_handler_test.go` - Integration tests for idempotency dedup, dunning on failure, no-dunning for succeeded/refunded
- `services/payment-order/adapters/gateway/stripe/webhook_adapter.go` - Add EventID field to ParsedWebhookEvent
- `services/payment-order/cmd/main.go` - Wire StripeEventProcessor into createStripeWebhookHandler

## Test Plan
- [x] payment_intent.succeeded processes and posts ledger entries (existing test passes)
- [x] payment_intent.payment_failed triggers dunning ZSET entry
- [x] charge.refunded does NOT trigger dunning
- [x] Idempotency: duplicate Stripe events (same event ID) are no-ops
- [x] Redis failure on idempotency check allows processing (fallback to downstream idempotency)
- [x] Redis failure on dunning returns error (logged, does not affect response)
- [x] Existing StripeWebhookHandler tests pass (backward compatible - EventProcessor is optional)
- [x] All golangci-lint checks pass