### PR TITLE
feat: saga execution logging and feature flag for payment orchestrator

### DIFF
--- a/services/payment-order/adapters/persistence/saga_execution_repository.go
+++ b/services/payment-order/adapters/persistence/saga_execution_repository.go
@@ -44,12 +44,27 @@ func NewSagaExecutionRepository(db *gorm.DB) *SagaExecutionRepository {
 
 // PersistExecution creates or updates a saga execution record.
 func (r *SagaExecutionRepository) PersistExecution(ctx context.Context, execution *domain.SagaExecution) error {
-	inputJSON, err := json.Marshal(execution.Input)
+	if execution == nil {
+		return fmt.Errorf("nil saga execution")
+	}
+
+	// Normalize nil maps to empty objects so json.Marshal produces "{}" not "null",
+	// which would violate the NOT NULL JSONB column constraints.
+	input := execution.Input
+	if input == nil {
+		input = map[string]any{}
+	}
+	output := execution.Output
+	if output == nil {
+		output = map[string]any{}
+	}
+
+	inputJSON, err := json.Marshal(input)
 	if err != nil {
 		return fmt.Errorf("failed to marshal saga execution input: %w", err)
 	}
 
-	outputJSON, err := json.Marshal(execution.Output)
+	outputJSON, err := json.Marshal(output)
 	if err != nil {
 		return fmt.Errorf("failed to marshal saga execution output: %w", err)
 	}

--- a/services/payment-order/adapters/persistence/saga_execution_repository.go
+++ b/services/payment-order/adapters/persistence/saga_execution_repository.go
@@ -1,0 +1,79 @@
+package persistence
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"gorm.io/gorm"
+)
+
+// sagaExecutionEntity is the GORM entity for the saga_executions table.
+type sagaExecutionEntity struct {
+	ID             uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+	PaymentOrderID uuid.UUID  `gorm:"type:uuid;not null"`
+	SagaName       string     `gorm:"column:saga_name;type:varchar(128);not null"`
+	SagaVersion    int        `gorm:"column:saga_version;not null;default:0"`
+	Status         string     `gorm:"column:status;type:varchar(32);not null;default:'RUNNING'"`
+	CorrelationID  string     `gorm:"column:correlation_id;type:varchar(128);not null;default:''"`
+	Input          []byte     `gorm:"column:input;type:jsonb;not null;default:'{}'"`
+	Output         []byte     `gorm:"column:output;type:jsonb;not null;default:'{}'"`
+	ErrorMessage   string     `gorm:"column:error_message;type:text;not null;default:''"`
+	StepCount      int        `gorm:"column:step_count;not null;default:0"`
+	DurationMs     int64      `gorm:"column:duration_ms;not null;default:0"`
+	StartedAt      time.Time  `gorm:"column:started_at;not null;default:now()"`
+	CompletedAt    *time.Time `gorm:"column:completed_at"`
+}
+
+func (sagaExecutionEntity) TableName() string {
+	return "saga_executions"
+}
+
+// SagaExecutionRepository implements domain.SagaExecutionLogger using GORM.
+type SagaExecutionRepository struct {
+	db *gorm.DB
+}
+
+// NewSagaExecutionRepository creates a new SagaExecutionRepository.
+func NewSagaExecutionRepository(db *gorm.DB) *SagaExecutionRepository {
+	return &SagaExecutionRepository{db: db}
+}
+
+// PersistExecution creates or updates a saga execution record.
+func (r *SagaExecutionRepository) PersistExecution(ctx context.Context, execution *domain.SagaExecution) error {
+	inputJSON, err := json.Marshal(execution.Input)
+	if err != nil {
+		return fmt.Errorf("failed to marshal saga execution input: %w", err)
+	}
+
+	outputJSON, err := json.Marshal(execution.Output)
+	if err != nil {
+		return fmt.Errorf("failed to marshal saga execution output: %w", err)
+	}
+
+	entity := sagaExecutionEntity{
+		ID:             execution.ID,
+		PaymentOrderID: execution.PaymentOrderID,
+		SagaName:       execution.SagaName,
+		SagaVersion:    execution.SagaVersion,
+		Status:         string(execution.Status),
+		CorrelationID:  execution.CorrelationID,
+		Input:          inputJSON,
+		Output:         outputJSON,
+		ErrorMessage:   execution.ErrorMessage,
+		StepCount:      execution.StepCount,
+		DurationMs:     execution.DurationMs,
+		StartedAt:      execution.StartedAt,
+		CompletedAt:    execution.CompletedAt,
+	}
+
+	result := r.db.WithContext(ctx).Save(&entity)
+	if result.Error != nil {
+		return fmt.Errorf("failed to persist saga execution: %w", result.Error)
+	}
+
+	return nil
+}

--- a/services/payment-order/adapters/persistence/saga_execution_repository.go
+++ b/services/payment-order/adapters/persistence/saga_execution_repository.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -10,6 +11,9 @@ import (
 	"github.com/meridianhub/meridian/services/payment-order/domain"
 	"gorm.io/gorm"
 )
+
+// ErrNilSagaExecution is returned when PersistExecution is called with a nil execution.
+var ErrNilSagaExecution = errors.New("nil saga execution")
 
 // sagaExecutionEntity is the GORM entity for the saga_executions table.
 type sagaExecutionEntity struct {
@@ -45,7 +49,7 @@ func NewSagaExecutionRepository(db *gorm.DB) *SagaExecutionRepository {
 // PersistExecution creates or updates a saga execution record.
 func (r *SagaExecutionRepository) PersistExecution(ctx context.Context, execution *domain.SagaExecution) error {
 	if execution == nil {
-		return fmt.Errorf("nil saga execution")
+		return ErrNilSagaExecution
 	}
 
 	// Normalize nil maps to empty objects so json.Marshal produces "{}" not "null",

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -344,6 +344,12 @@ func run(logger *slog.Logger) error {
 		logger.Info("billing workers disabled (BILLING_ENABLED=false)")
 	}
 
+	// Create saga execution repository for audit logging
+	sagaExecutionRepo := persistence.NewSagaExecutionRepository(db)
+
+	logger.Info("saga orchestration configuration",
+		"saga_orchestration_enabled", svcConfig.SagaOrchestrationEnabled)
+
 	// Create payment order service
 	paymentOrderService, err := service.NewServiceWithConfig(service.Config{
 		Repository:                repo,
@@ -359,6 +365,8 @@ func run(logger *slog.Logger) error {
 		Tracer:                    tracer,
 		InternalClearingEnabled:   internalClearingEnabled,
 		HandlerRegistry:           handlerRegistry,
+		SagaExecutionLogger:       sagaExecutionRepo,
+		SagaOrchestrationEnabled:  svcConfig.SagaOrchestrationEnabled,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create payment order service: %w", err)

--- a/services/payment-order/config/service_config.go
+++ b/services/payment-order/config/service_config.go
@@ -41,6 +41,12 @@ type ServiceConfig struct {
 	// DunningPollInterval is how often the dunning worker polls for overdue
 	// billing runs. Default: 5m.
 	DunningPollInterval time.Duration
+
+	// SagaOrchestrationEnabled controls whether payment orders are orchestrated
+	// via Starlark saga scripts. When false (default), the existing Go-based
+	// orchestration is used. When true, the orchestrator loads and executes
+	// saga scripts from reference-data service.
+	SagaOrchestrationEnabled bool
 }
 
 // Configuration validation errors.
@@ -54,13 +60,14 @@ var (
 // a populated ServiceConfig. It does NOT validate — call Validate separately.
 func LoadServiceConfig() ServiceConfig {
 	return ServiceConfig{
-		PaymentGatewayProvider: env.GetEnvOrDefault("PAYMENT_GATEWAY_PROVIDER", gateway.ProviderMock),
-		StripeAPIKey:           env.GetEnvOrDefault("STRIPE_API_KEY", ""),
-		StripeWebhookSecret:    env.GetEnvOrDefault("STRIPE_WEBHOOK_SECRET", ""),
-		BillingEnabled:         env.GetEnvAsBool("BILLING_ENABLED", false),
-		BillingCronSchedule:    env.GetEnvOrDefault("BILLING_CRON_SCHEDULE", "0 0 * * *"),
-		BillingShadowMode:      env.GetEnvAsBool("BILLING_SHADOW_MODE", false),
-		DunningPollInterval:    env.GetEnvAsDuration("DUNNING_POLL_INTERVAL", 5*time.Minute),
+		PaymentGatewayProvider:   env.GetEnvOrDefault("PAYMENT_GATEWAY_PROVIDER", gateway.ProviderMock),
+		StripeAPIKey:             env.GetEnvOrDefault("STRIPE_API_KEY", ""),
+		StripeWebhookSecret:      env.GetEnvOrDefault("STRIPE_WEBHOOK_SECRET", ""),
+		BillingEnabled:           env.GetEnvAsBool("BILLING_ENABLED", false),
+		BillingCronSchedule:      env.GetEnvOrDefault("BILLING_CRON_SCHEDULE", "0 0 * * *"),
+		BillingShadowMode:        env.GetEnvAsBool("BILLING_SHADOW_MODE", false),
+		DunningPollInterval:      env.GetEnvAsDuration("DUNNING_POLL_INTERVAL", 5*time.Minute),
+		SagaOrchestrationEnabled: env.GetEnvAsBool("USE_SAGA_ORCHESTRATION", false),
 	}
 }
 
@@ -94,6 +101,7 @@ func (c ServiceConfig) LogValues(logger *slog.Logger) {
 		"billing_cron_schedule", c.BillingCronSchedule,
 		"billing_shadow_mode", c.BillingShadowMode,
 		"dunning_poll_interval", c.DunningPollInterval,
+		"saga_orchestration_enabled", c.SagaOrchestrationEnabled,
 	)
 }
 

--- a/services/payment-order/config/service_config.go
+++ b/services/payment-order/config/service_config.go
@@ -43,9 +43,9 @@ type ServiceConfig struct {
 	DunningPollInterval time.Duration
 
 	// SagaOrchestrationEnabled controls whether payment orders are orchestrated
-	// via Starlark saga scripts. When false (default), the existing Go-based
-	// orchestration is used. When true, the orchestrator loads and executes
-	// saga scripts from reference-data service.
+	// via Starlark saga scripts. When false (default), saga orchestration is
+	// disabled and payment orchestration fails fast. When true, the orchestrator
+	// loads and executes saga scripts from reference-data service.
 	SagaOrchestrationEnabled bool
 }
 

--- a/services/payment-order/domain/saga.go
+++ b/services/payment-order/domain/saga.go
@@ -1,0 +1,54 @@
+// Package domain contains the PaymentOrder aggregate root and related domain logic
+// for orchestrating payment saga workflows.
+package domain
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SagaExecutionStatus represents the lifecycle state of a saga execution record.
+type SagaExecutionStatus string
+
+const (
+	// SagaExecutionStatusRunning indicates the saga is currently executing.
+	SagaExecutionStatusRunning SagaExecutionStatus = "RUNNING"
+	// SagaExecutionStatusCompleted indicates the saga completed successfully.
+	SagaExecutionStatusCompleted SagaExecutionStatus = "COMPLETED"
+	// SagaExecutionStatusFailed indicates the saga failed.
+	SagaExecutionStatusFailed SagaExecutionStatus = "FAILED"
+	// SagaExecutionStatusCompensated indicates the saga failed and compensation ran.
+	SagaExecutionStatusCompensated SagaExecutionStatus = "COMPENSATED"
+)
+
+// SagaExecution represents a record of a saga execution in the payment-order service.
+type SagaExecution struct {
+	ID             uuid.UUID
+	PaymentOrderID uuid.UUID
+	SagaName       string
+	SagaVersion    int
+	Status         SagaExecutionStatus
+	CorrelationID  string
+	Input          map[string]any
+	Output         map[string]any
+	ErrorMessage   string
+	StepCount      int
+	DurationMs     int64
+	StartedAt      time.Time
+	CompletedAt    *time.Time
+}
+
+// SagaExecutionLogger persists saga execution records for audit and debugging.
+type SagaExecutionLogger interface {
+	// PersistExecution creates or updates a saga execution record.
+	PersistExecution(ctx context.Context, execution *SagaExecution) error
+}
+
+// SagaDefinitionRepository loads saga definitions for execution.
+type SagaDefinitionRepository interface {
+	// LoadSagaDefinition fetches a saga script by name and version.
+	// If version is 0, the ACTIVE version is returned.
+	LoadSagaDefinition(ctx context.Context, sagaName string, version int) (sagaScript string, sagaVersion int, err error)
+}

--- a/services/payment-order/migrations/20260212000001_saga_executions.sql
+++ b/services/payment-order/migrations/20260212000001_saga_executions.sql
@@ -1,0 +1,35 @@
+-- Create saga_executions table for persisting saga execution records.
+-- This provides an audit trail of all saga executions performed by the
+-- payment-order service, enabling debugging, monitoring, and compliance.
+
+CREATE TABLE IF NOT EXISTS saga_executions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    payment_order_id UUID NOT NULL,
+    saga_name VARCHAR(128) NOT NULL,
+    saga_version INT NOT NULL DEFAULT 0,
+    status VARCHAR(32) NOT NULL DEFAULT 'RUNNING',
+    correlation_id VARCHAR(128) NOT NULL DEFAULT '',
+    input JSONB NOT NULL DEFAULT '{}',
+    output JSONB NOT NULL DEFAULT '{}',
+    error_message TEXT NOT NULL DEFAULT '',
+    step_count INT NOT NULL DEFAULT 0,
+    duration_ms BIGINT NOT NULL DEFAULT 0,
+    started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at TIMESTAMPTZ,
+
+    CONSTRAINT saga_executions_status_check CHECK (
+        status IN ('RUNNING', 'COMPLETED', 'FAILED', 'COMPENSATED')
+    )
+);
+
+-- Index for querying executions by payment order
+CREATE INDEX IF NOT EXISTS idx_saga_executions_payment_order_id
+    ON saga_executions (payment_order_id);
+
+-- Index for querying executions by saga name and status
+CREATE INDEX IF NOT EXISTS idx_saga_executions_saga_name_status
+    ON saga_executions (saga_name, status);
+
+-- Index for querying executions by correlation ID
+CREATE INDEX IF NOT EXISTS idx_saga_executions_correlation_id
+    ON saga_executions (correlation_id);

--- a/services/payment-order/migrations/atlas.sum
+++ b/services/payment-order/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:NWuDRvN4AT3dp512N11tH8OiNxJsMvtZs/todu4OzWM=
+h1:1Cby4ckMRNWlbfAfl+0V34EiQN3B7N4vNhMA78X3cIE=
 20251216000001_initial.sql h1:9Pt9iC/k1YkmfjyO/F0ioNbPswzzgCP2aHtFlFHnSMY=
 20251217000001_audit_system.sql h1:YD9HdFm+NRTihCM/PBU7EYEmdttWjvGPCIE408A8HFg=
 20251223000001_fix_audit_schema_compatibility.sql h1:QxqR4DwdQ5cNXHCxTvtHgQmhSnD8xptkoFnxNcZ5ehY=
@@ -6,3 +6,4 @@ h1:NWuDRvN4AT3dp512N11tH8OiNxJsMvtZs/todu4OzWM=
 20260204000001_create_event_outbox.sql h1:QvPBgr/Z0FpRT7kR0huU7R4GYD7xzpBxlT4rdjS2c/g=
 20260210000001_billing.sql h1:E/Bg1NLhonN7hCHEL5fyrAYMmfoBQRTKzlvCSiB9kTA=
 20260211000001_billing_dunning.sql h1:nxy+LNCaGfAqsXSlugNsl9pVctGJ7XukG2+RXB2Xe9Y=
+20260212000001_saga_executions.sql h1:k7h82QCBS/M8a//FAdgB/nZzHC4L3Ybww5Cq/XPWEmY=

--- a/services/payment-order/service/bucket_solvency_test.go
+++ b/services/payment-order/service/bucket_solvency_test.go
@@ -339,6 +339,7 @@ func TestPaymentOrchestrator_Orchestrate_PassesBucketIDToLien(t *testing.T) {
 			MaxRetries:      1,
 			InitialInterval: 1 * time.Millisecond,
 		},
+		SagaOrchestrationEnabled: true,
 	})
 	require.NoError(t, err)
 
@@ -422,6 +423,7 @@ func TestPaymentOrchestrator_Orchestrate_NoBucketIDForFullyFungible(t *testing.T
 			MaxRetries:      1,
 			InitialInterval: 1 * time.Millisecond,
 		},
+		SagaOrchestrationEnabled: true,
 	})
 	require.NoError(t, err)
 
@@ -503,6 +505,7 @@ func TestPaymentOrchestrator_Orchestrate_UpdatesPaymentOrderWithBucketID(t *test
 			MaxRetries:      1,
 			InitialInterval: 1 * time.Millisecond,
 		},
+		SagaOrchestrationEnabled: true,
 	})
 	require.NoError(t, err)
 

--- a/services/payment-order/service/grpc_service.go
+++ b/services/payment-order/service/grpc_service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
 	"github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
 	"github.com/meridianhub/meridian/services/payment-order/config"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
@@ -258,6 +259,15 @@ type Config struct {
 	// registers its internal payment_order.* handlers on this registry so saga scripts
 	// have access to all registered handlers. When nil, a new empty registry is created.
 	HandlerRegistry *saga.HandlerRegistry
+
+	// SagaExecutionLogger persists saga execution records for audit. Optional.
+	SagaExecutionLogger domain.SagaExecutionLogger
+
+	// SagaOrchestrationEnabled controls whether the Starlark saga orchestration
+	// path is used. When false (default), the orchestrator marks payment orders
+	// as failed since Go-based orchestration was removed. Set
+	// USE_SAGA_ORCHESTRATION=true to enable.
+	SagaOrchestrationEnabled bool
 }
 
 // NewService creates a new payment order service with minimal dependencies.
@@ -364,6 +374,8 @@ func NewServiceWithConfig(cfg Config) (*Service, error) {
 		LienExecutionRetryConfig:  cfg.LienExecutionRetryConfig,
 		InternalClearingEnabled:   cfg.InternalClearingEnabled,
 		HandlerRegistry:           cfg.HandlerRegistry,
+		SagaExecutionLogger:       cfg.SagaExecutionLogger,
+		SagaOrchestrationEnabled:  cfg.SagaOrchestrationEnabled,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create payment orchestrator: %w", err)

--- a/services/payment-order/service/grpc_service_test.go
+++ b/services/payment-order/service/grpc_service_test.go
@@ -2069,11 +2069,12 @@ func TestSagaOrchestration_HappyPath(t *testing.T) {
 
 	// Create orchestrator with all dependencies
 	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
-		Logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		Repo:                 repo,
-		CurrentAccountClient: caClient,
-		PaymentGateway:       gwMock,
-		ReferenceDataClient:  NewMockReferenceDataClient(),
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Repo:                     repo,
+		CurrentAccountClient:     caClient,
+		PaymentGateway:           gwMock,
+		ReferenceDataClient:      NewMockReferenceDataClient(),
+		SagaOrchestrationEnabled: true,
 	})
 	require.NoError(t, err)
 
@@ -2141,11 +2142,12 @@ func TestSagaOrchestration_LienFailure(t *testing.T) {
 
 	// Create orchestrator with dependencies
 	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
-		Logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		Repo:                 repo,
-		CurrentAccountClient: caClient,
-		PaymentGateway:       gwMock,
-		ReferenceDataClient:  NewMockReferenceDataClient(),
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Repo:                     repo,
+		CurrentAccountClient:     caClient,
+		PaymentGateway:           gwMock,
+		ReferenceDataClient:      NewMockReferenceDataClient(),
+		SagaOrchestrationEnabled: true,
 	})
 	require.NoError(t, err)
 
@@ -2210,11 +2212,12 @@ func TestSagaOrchestration_GatewayFailure(t *testing.T) {
 
 	// Create orchestrator with dependencies
 	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
-		Logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		Repo:                 repo,
-		CurrentAccountClient: caClient,
-		PaymentGateway:       gwMock,
-		ReferenceDataClient:  NewMockReferenceDataClient(),
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Repo:                     repo,
+		CurrentAccountClient:     caClient,
+		PaymentGateway:           gwMock,
+		ReferenceDataClient:      NewMockReferenceDataClient(),
+		SagaOrchestrationEnabled: true,
 	})
 	require.NoError(t, err)
 
@@ -2305,11 +2308,12 @@ func TestSagaOrchestration_Timeout(t *testing.T) {
 
 	// Create orchestrator with dependencies
 	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
-		Logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		Repo:                 repo,
-		CurrentAccountClient: caClient,
-		PaymentGateway:       gwMock,
-		ReferenceDataClient:  NewMockReferenceDataClient(),
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Repo:                     repo,
+		CurrentAccountClient:     caClient,
+		PaymentGateway:           gwMock,
+		ReferenceDataClient:      NewMockReferenceDataClient(),
+		SagaOrchestrationEnabled: true,
 	})
 	require.NoError(t, err)
 
@@ -2472,11 +2476,12 @@ func TestSagaOrchestration_MalformedLienResponse(t *testing.T) {
 
 	// Create orchestrator with dependencies
 	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
-		Logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		Repo:                 repo,
-		CurrentAccountClient: caClient,
-		PaymentGateway:       gwClient,
-		ReferenceDataClient:  NewMockReferenceDataClient(),
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Repo:                     repo,
+		CurrentAccountClient:     caClient,
+		PaymentGateway:           gwClient,
+		ReferenceDataClient:      NewMockReferenceDataClient(),
+		SagaOrchestrationEnabled: true,
 	})
 	require.NoError(t, err)
 
@@ -2539,11 +2544,12 @@ func TestSagaOrchestration_GatewayPending(t *testing.T) {
 
 	// Create orchestrator with dependencies
 	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
-		Logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		Repo:                 repo,
-		CurrentAccountClient: caClient,
-		PaymentGateway:       gwClient,
-		ReferenceDataClient:  NewMockReferenceDataClient(),
+		Logger:                   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		Repo:                     repo,
+		CurrentAccountClient:     caClient,
+		PaymentGateway:           gwClient,
+		ReferenceDataClient:      NewMockReferenceDataClient(),
+		SagaOrchestrationEnabled: true,
 	})
 	require.NoError(t, err)
 

--- a/services/payment-order/service/integration_test.go
+++ b/services/payment-order/service/integration_test.go
@@ -624,6 +624,7 @@ func TestIntegration_HappyPath_Initiate_Reserve_Execute_Complete(t *testing.T) {
 		KafkaPublisher:            nil, // Optional for tests
 		IdempotencyService:        NewMockIdempotencyService(),
 		Logger:                    logger,
+		SagaOrchestrationEnabled:  true,
 		SagaTimeout:               30 * time.Second,
 	})
 	require.NoError(t, err)
@@ -699,6 +700,7 @@ func TestIntegration_Idempotency_SameKeyReturnsSameResult(t *testing.T) {
 		KafkaPublisher:            nil, // Optional for tests
 		IdempotencyService:        NewMockIdempotencyService(),
 		Logger:                    logger,
+		SagaOrchestrationEnabled:  true,
 	})
 	require.NoError(t, err)
 
@@ -776,6 +778,7 @@ func TestIntegration_DuplicateWebhook_Idempotent(t *testing.T) {
 		KafkaPublisher:            nil, // Optional for tests
 		IdempotencyService:        NewMockIdempotencyService(),
 		Logger:                    logger,
+		SagaOrchestrationEnabled:  true,
 	})
 	require.NoError(t, err)
 
@@ -851,6 +854,7 @@ func TestIntegration_InsufficientFunds_SagaFails(t *testing.T) {
 		KafkaPublisher:            nil, // Optional for tests
 		IdempotencyService:        NewMockIdempotencyService(),
 		Logger:                    logger,
+		SagaOrchestrationEnabled:  true,
 	})
 	require.NoError(t, err)
 
@@ -896,6 +900,7 @@ func TestIntegration_GatewayTimeout_CompensationReleasesLien(t *testing.T) {
 		KafkaPublisher:            nil, // Optional for tests
 		IdempotencyService:        NewMockIdempotencyService(),
 		Logger:                    logger,
+		SagaOrchestrationEnabled:  true,
 	})
 	require.NoError(t, err)
 
@@ -945,6 +950,7 @@ func TestIntegration_GatewayRejects_StatusFailed(t *testing.T) {
 		KafkaPublisher:            nil, // Optional for tests
 		IdempotencyService:        NewMockIdempotencyService(),
 		Logger:                    logger,
+		SagaOrchestrationEnabled:  true,
 	})
 	require.NoError(t, err)
 
@@ -992,6 +998,7 @@ func TestIntegration_ConcurrentPayments_SameAccount(t *testing.T) {
 		KafkaPublisher:            nil, // Optional for tests
 		IdempotencyService:        NewMockIdempotencyService(),
 		Logger:                    logger,
+		SagaOrchestrationEnabled:  true,
 	})
 	require.NoError(t, err)
 
@@ -1072,6 +1079,7 @@ func TestIntegration_NetworkTimeout_DuringExecutePhase(t *testing.T) {
 		KafkaPublisher:            nil, // Optional for tests
 		IdempotencyService:        NewMockIdempotencyService(),
 		Logger:                    logger,
+		SagaOrchestrationEnabled:  true,
 		SagaTimeout:               3 * time.Second, // Short timeout for test
 	})
 	require.NoError(t, err)
@@ -1131,6 +1139,7 @@ func TestIntegration_PartialFailure_GatewayAcceptsLedgerFails(t *testing.T) {
 		KafkaPublisher:            nil, // Optional for tests
 		IdempotencyService:        NewMockIdempotencyService(),
 		Logger:                    logger,
+		SagaOrchestrationEnabled:  true,
 	})
 	require.NoError(t, err)
 
@@ -1190,6 +1199,7 @@ func TestIntegration_MoneyPrecision_ThroughAllTranslations(t *testing.T) {
 		KafkaPublisher:            nil, // Optional for tests
 		IdempotencyService:        NewMockIdempotencyService(),
 		Logger:                    logger,
+		SagaOrchestrationEnabled:  true,
 	})
 	require.NoError(t, err)
 
@@ -1283,6 +1293,7 @@ func TestIntegration_InvalidInputs_ValidationErrors(t *testing.T) {
 		KafkaPublisher:            nil, // Optional for tests
 		IdempotencyService:        NewMockIdempotencyService(),
 		Logger:                    logger,
+		SagaOrchestrationEnabled:  true,
 	})
 	require.NoError(t, err)
 
@@ -1373,6 +1384,7 @@ func TestIntegration_RetrievePaymentOrder(t *testing.T) {
 		KafkaPublisher:            nil, // Optional for tests
 		IdempotencyService:        NewMockIdempotencyService(),
 		Logger:                    logger,
+		SagaOrchestrationEnabled:  true,
 	})
 	require.NoError(t, err)
 
@@ -1425,6 +1437,7 @@ func TestIntegration_CancelPaymentOrder(t *testing.T) {
 		KafkaPublisher:            nil, // Optional for tests
 		IdempotencyService:        NewMockIdempotencyService(),
 		Logger:                    logger,
+		SagaOrchestrationEnabled:  true,
 	})
 	require.NoError(t, err)
 
@@ -1477,6 +1490,7 @@ func TestIntegration_ListPaymentOrders_Pagination(t *testing.T) {
 		KafkaPublisher:            nil, // Optional for tests
 		IdempotencyService:        NewMockIdempotencyService(),
 		Logger:                    logger,
+		SagaOrchestrationEnabled:  true,
 	})
 	require.NoError(t, err)
 
@@ -1589,6 +1603,7 @@ func TestIntegration_ReversePaymentOrder(t *testing.T) {
 		KafkaPublisher:            nil, // Optional for tests
 		IdempotencyService:        NewMockIdempotencyService(),
 		Logger:                    logger,
+		SagaOrchestrationEnabled:  true,
 	})
 	require.NoError(t, err)
 

--- a/services/payment-order/service/payment_orchestrator.go
+++ b/services/payment-order/service/payment_orchestrator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
 	"github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
 	"github.com/meridianhub/meridian/services/payment-order/config"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"google.golang.org/protobuf/proto"
@@ -72,8 +73,10 @@ type PaymentOrchestrator struct {
 	lockClient                LockClient // Distributed lock client for preventing concurrent lien execution
 
 	// Starlark saga execution fields
-	starlarkRunner  *saga.StarlarkSagaRunner // Executes saga scripts
-	handlerRegistry *saga.HandlerRegistry    // Registry of payment-order handlers
+	starlarkRunner           *saga.StarlarkSagaRunner // Executes saga scripts
+	handlerRegistry          *saga.HandlerRegistry    // Registry of payment-order handlers
+	sagaExecutionLogger      domain.SagaExecutionLogger
+	sagaOrchestrationEnabled bool // Feature flag: when true, use Starlark saga orchestration
 }
 
 // PaymentOrchestratorConfig contains dependencies for creating a PaymentOrchestrator
@@ -98,6 +101,14 @@ type PaymentOrchestratorConfig struct {
 	// uses it for the StarlarkSagaRunner, giving saga scripts access to all handlers.
 	// When nil, a new empty registry is created (backward compatible).
 	HandlerRegistry *saga.HandlerRegistry
+
+	// SagaExecutionLogger persists saga execution records for audit. Optional.
+	SagaExecutionLogger domain.SagaExecutionLogger
+
+	// SagaOrchestrationEnabled controls whether the Starlark saga orchestration
+	// path is used. When false, a stub error is returned to callers of
+	// ExecutePaymentSaga, and Orchestrate uses the existing Go-based flow.
+	SagaOrchestrationEnabled bool
 }
 
 // NewPaymentOrchestrator creates a new payment orchestrator with the given dependencies.
@@ -188,6 +199,8 @@ func NewPaymentOrchestrator(cfg PaymentOrchestratorConfig) (*PaymentOrchestrator
 		lockClient:                cfg.LockClient,
 		starlarkRunner:            starlarkRunner,
 		handlerRegistry:           handlerRegistry,
+		sagaExecutionLogger:       cfg.SagaExecutionLogger,
+		sagaOrchestrationEnabled:  cfg.SagaOrchestrationEnabled,
 	}
 
 	// Set orchestrator reference in handler deps for PostLedgerEntries callback

--- a/services/payment-order/service/payment_orchestrator_saga.go
+++ b/services/payment-order/service/payment_orchestrator_saga.go
@@ -14,16 +14,27 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// ErrSagaOrchestrationDisabled is returned when ExecutePaymentSaga is called
-// but USE_SAGA_ORCHESTRATION is not enabled.
-var ErrSagaOrchestrationDisabled = errors.New("saga orchestration is not enabled")
+// Saga orchestration errors.
+var (
+	// ErrSagaOrchestrationDisabled is returned when ExecutePaymentSaga is called
+	// but USE_SAGA_ORCHESTRATION is not enabled.
+	ErrSagaOrchestrationDisabled = errors.New("saga orchestration is not enabled")
+
+	// ErrSagaDepsNotConfigured is returned when required saga dependencies
+	// (CurrentAccountClient, PaymentGateway) are nil at execution time.
+	ErrSagaDepsNotConfigured = errors.New("saga dependencies not configured")
+
+	// ErrRefDataClientNotConfigured is returned when the reference data client
+	// is nil and a saga definition cannot be fetched.
+	ErrRefDataClientNotConfigured = errors.New("reference data client not configured")
+)
 
 // Orchestrate executes the payment saga using Starlark script execution.
 // The saga script is fetched from reference-data service and executed via StarlarkSagaRunner.
 // Compensation is handled automatically by the Starlark runtime on failure.
 //
 // When sagaOrchestrationEnabled is false, this method logs a warning and marks the
-// payment order as failed because the Go-based orchestration was removed in favour of
+// payment order as failed because the Go-based orchestration was removed in favor of
 // Starlark. Enable USE_SAGA_ORCHESTRATION=true to use Starlark saga execution.
 func (o *PaymentOrchestrator) Orchestrate(ctx context.Context, po *domain.PaymentOrder) {
 	if !o.sagaOrchestrationEnabled {
@@ -79,7 +90,7 @@ func (o *PaymentOrchestrator) ExecutePaymentSaga(ctx context.Context, paymentOrd
 				"payment_order_id", po.ID.String(),
 				"error", err)
 		}
-		return nil, fmt.Errorf("saga dependencies not configured")
+		return nil, ErrSagaDepsNotConfigured
 	}
 
 	// Check if reference data client is available for GetSaga
@@ -91,7 +102,7 @@ func (o *PaymentOrchestrator) ExecutePaymentSaga(ctx context.Context, paymentOrd
 				"payment_order_id", po.ID.String(),
 				"error", err)
 		}
-		return nil, fmt.Errorf("reference data client not configured")
+		return nil, ErrRefDataClientNotConfigured
 	}
 
 	// Fetch saga script from reference-data service

--- a/services/payment-order/service/payment_orchestrator_saga.go
+++ b/services/payment-order/service/payment_orchestrator_saga.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
@@ -12,25 +14,72 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// ErrSagaOrchestrationDisabled is returned when ExecutePaymentSaga is called
+// but USE_SAGA_ORCHESTRATION is not enabled.
+var ErrSagaOrchestrationDisabled = errors.New("saga orchestration is not enabled")
+
 // Orchestrate executes the payment saga using Starlark script execution.
 // The saga script is fetched from reference-data service and executed via StarlarkSagaRunner.
 // Compensation is handled automatically by the Starlark runtime on failure.
+//
+// When sagaOrchestrationEnabled is false, this method logs a warning and marks the
+// payment order as failed because the Go-based orchestration was removed in favour of
+// Starlark. Enable USE_SAGA_ORCHESTRATION=true to use Starlark saga execution.
 func (o *PaymentOrchestrator) Orchestrate(ctx context.Context, po *domain.PaymentOrder) {
-	o.logger.Info("starting payment saga with Starlark execution",
+	if !o.sagaOrchestrationEnabled {
+		o.logger.Warn("saga orchestration disabled, payment order will not be processed",
+			"payment_order_id", po.ID.String(),
+			"hint", "set USE_SAGA_ORCHESTRATION=true to enable Starlark saga execution")
+		if err := o.failPaymentOrder(ctx, po, "saga orchestration is disabled (USE_SAGA_ORCHESTRATION=false)", "SAGA_DISABLED"); err != nil {
+			o.logger.Error("failed to mark payment order as failed",
+				"payment_order_id", po.ID.String(),
+				"error", err)
+		}
+		return
+	}
+
+	output, err := o.ExecutePaymentSaga(ctx, po.ID, "payment_execution", po)
+	if err != nil {
+		o.logger.Error("ExecutePaymentSaga returned error",
+			"payment_order_id", po.ID.String(),
+			"error", err)
+		return
+	}
+
+	o.logger.Info("Orchestrate completed via ExecutePaymentSaga",
 		"payment_order_id", po.ID.String(),
+		"success", output.Success)
+}
+
+// ExecutePaymentSaga loads a saga definition, executes it via StarlarkSagaRunner,
+// persists the execution record, and handles the result. This is the primary
+// integration point between the payment orchestrator and the saga engine.
+//
+// Flow: load saga -> build input -> execute via sagaRunner.Run() -> persist execution -> return output
+func (o *PaymentOrchestrator) ExecutePaymentSaga(ctx context.Context, paymentOrderID uuid.UUID, sagaName string, po *domain.PaymentOrder) (*saga.RunnerOutput, error) {
+	if !o.sagaOrchestrationEnabled {
+		return nil, ErrSagaOrchestrationDisabled
+	}
+
+	startTime := time.Now()
+	executionID := uuid.New()
+
+	o.logger.Info("starting payment saga execution",
+		"payment_order_id", paymentOrderID.String(),
+		"saga_name", sagaName,
+		"execution_id", executionID.String(),
 		"correlation_id", po.CorrelationID)
 
 	// Check if all dependencies are available
 	if o.currentAccountClient == nil || o.paymentGateway == nil {
 		o.logger.Error("saga dependencies not configured",
 			"payment_order_id", po.ID.String())
-		// Async path: log and swallow error - best effort failure handling
 		if err := o.failPaymentOrder(ctx, po, "service configuration error", "INTERNAL_ERROR"); err != nil {
 			o.logger.Error("failed to mark payment order as failed",
 				"payment_order_id", po.ID.String(),
 				"error", err)
 		}
-		return
+		return nil, fmt.Errorf("saga dependencies not configured")
 	}
 
 	// Check if reference data client is available for GetSaga
@@ -42,22 +91,22 @@ func (o *PaymentOrchestrator) Orchestrate(ctx context.Context, po *domain.Paymen
 				"payment_order_id", po.ID.String(),
 				"error", err)
 		}
-		return
+		return nil, fmt.Errorf("reference data client not configured")
 	}
 
 	// Fetch saga script from reference-data service
-	sagaDef, err := o.referenceDataClient.GetSaga(ctx, "payment_execution", 0) // 0 = fetch ACTIVE version
+	sagaDef, err := o.referenceDataClient.GetSaga(ctx, sagaName, 0) // 0 = fetch ACTIVE version
 	if err != nil {
 		o.logger.Error("failed to fetch saga definition from reference-data",
 			"payment_order_id", po.ID.String(),
-			"saga_name", "payment_execution",
+			"saga_name", sagaName,
 			"error", err)
 		if err := o.failPaymentOrder(ctx, po, fmt.Sprintf("failed to fetch saga: %v", err), "INTERNAL_ERROR"); err != nil {
 			o.logger.Error("failed to mark payment order as failed",
 				"payment_order_id", po.ID.String(),
 				"error", err)
 		}
-		return
+		return nil, fmt.Errorf("failed to fetch saga definition: %w", err)
 	}
 
 	o.logger.Info("fetched saga definition from reference-data",
@@ -75,38 +124,112 @@ func (o *PaymentOrchestrator) Orchestrate(ctx context.Context, po *domain.Paymen
 		correlationID = uuid.New()
 	}
 
-	// Map PaymentOrder domain object to RunnerInput.Input map
-	runnerInput := saga.RunnerInput{
-		SagaExecutionID: uuid.New(),
-		CorrelationID:   correlationID,
-		Input: map[string]interface{}{
-			"payment_order_id":   po.ID.String(),
-			"debtor_account_id":  po.DebtorAccountID,
-			"creditor_reference": po.CreditorReference,
-			"amount_cents":       domain.ToMinorUnits(po.Amount),
-			"currency":           domain.CurrencyCode(po.Amount),
-			"idempotency_key":    po.IdempotencyKey,
-			"instrument_code":    po.InstrumentCode,
-			"payment_attributes": po.PaymentAttributes,
-		},
+	// Build saga input from payment order
+	sagaInput := map[string]interface{}{
+		"payment_order_id":   po.ID.String(),
+		"debtor_account_id":  po.DebtorAccountID,
+		"creditor_reference": po.CreditorReference,
+		"amount_cents":       domain.ToMinorUnits(po.Amount),
+		"currency":           domain.CurrencyCode(po.Amount),
+		"idempotency_key":    po.IdempotencyKey,
+		"instrument_code":    po.InstrumentCode,
+		"payment_attributes": po.PaymentAttributes,
 	}
 
+	runnerInput := saga.RunnerInput{
+		SagaExecutionID: executionID,
+		CorrelationID:   correlationID,
+		Input:           sagaInput,
+	}
+
+	// Persist initial execution record (RUNNING)
+	o.logSagaExecution(ctx, &domain.SagaExecution{
+		ID:             executionID,
+		PaymentOrderID: paymentOrderID,
+		SagaName:       sagaName,
+		SagaVersion:    sagaDef.Version,
+		Status:         domain.SagaExecutionStatusRunning,
+		CorrelationID:  correlationID.String(),
+		Input:          sagaInput,
+		StartedAt:      startTime,
+	})
+
 	// Execute saga via StarlarkSagaRunner
-	result, err := o.starlarkRunner.ExecuteSaga(ctx, "payment_execution", sagaDef.Script, runnerInput)
+	result, err := o.starlarkRunner.ExecuteSaga(ctx, sagaName, sagaDef.Script, runnerInput)
+	durationMs := time.Since(startTime).Milliseconds()
+
 	if err != nil {
 		o.logger.Error("starlark saga runner returned error",
 			"payment_order_id", po.ID.String(),
-			"error", err)
+			"execution_id", executionID.String(),
+			"error", err,
+			"duration_ms", durationMs)
+
+		now := time.Now()
+		o.logSagaExecution(ctx, &domain.SagaExecution{
+			ID:             executionID,
+			PaymentOrderID: paymentOrderID,
+			SagaName:       sagaName,
+			SagaVersion:    sagaDef.Version,
+			Status:         domain.SagaExecutionStatusFailed,
+			CorrelationID:  correlationID.String(),
+			Input:          sagaInput,
+			ErrorMessage:   err.Error(),
+			DurationMs:     durationMs,
+			StartedAt:      startTime,
+			CompletedAt:    &now,
+		})
+
 		if err := o.failPaymentOrder(ctx, po, fmt.Sprintf("saga execution error: %v", err), "SAGA_FAILED"); err != nil {
 			o.logger.Error("failed to mark payment order as failed",
 				"payment_order_id", po.ID.String(),
 				"error", err)
 		}
-		return
+		return nil, fmt.Errorf("saga execution failed: %w", err)
 	}
 
-	// Handle saga result
+	// Persist completed execution record
+	now := time.Now()
+	execStatus := domain.SagaExecutionStatusCompleted
+	errorMsg := ""
+	if !result.Success {
+		execStatus = domain.SagaExecutionStatusFailed
+		errorMsg = result.Error
+	}
+	o.logSagaExecution(ctx, &domain.SagaExecution{
+		ID:             executionID,
+		PaymentOrderID: paymentOrderID,
+		SagaName:       sagaName,
+		SagaVersion:    sagaDef.Version,
+		Status:         execStatus,
+		CorrelationID:  correlationID.String(),
+		Input:          sagaInput,
+		Output:         result.Output,
+		ErrorMessage:   errorMsg,
+		StepCount:      len(result.StepResults),
+		DurationMs:     durationMs,
+		StartedAt:      startTime,
+		CompletedAt:    &now,
+	})
+
+	// Handle saga result (state transitions, events)
 	o.handleStarlarkSagaResult(ctx, po, result)
+
+	return result, nil
+}
+
+// logSagaExecution persists a saga execution record if the logger is configured.
+func (o *PaymentOrchestrator) logSagaExecution(ctx context.Context, execution *domain.SagaExecution) {
+	if o.sagaExecutionLogger == nil {
+		return
+	}
+	if err := o.sagaExecutionLogger.PersistExecution(ctx, execution); err != nil {
+		o.logger.Error("failed to persist saga execution record",
+			"execution_id", execution.ID.String(),
+			"payment_order_id", execution.PaymentOrderID.String(),
+			"status", execution.Status,
+			"error", err)
+	}
 }
 
 // handleStarlarkSagaResult processes the result from StarlarkSagaRunner execution.

--- a/services/payment-order/service/saga_integration_test.go
+++ b/services/payment-order/service/saga_integration_test.go
@@ -1,0 +1,298 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/meridianhub/meridian/services/payment-order/domain/testfixtures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MockSagaExecutionLogger implements domain.SagaExecutionLogger for testing.
+type MockSagaExecutionLogger struct {
+	mu         sync.Mutex
+	executions []*domain.SagaExecution
+	err        error
+}
+
+func NewMockSagaExecutionLogger() *MockSagaExecutionLogger {
+	return &MockSagaExecutionLogger{}
+}
+
+func (m *MockSagaExecutionLogger) PersistExecution(_ context.Context, execution *domain.SagaExecution) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return m.err
+	}
+	// Store a copy to avoid mutations
+	exec := *execution
+	m.executions = append(m.executions, &exec)
+	return nil
+}
+
+func (m *MockSagaExecutionLogger) Executions() []*domain.SagaExecution {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]*domain.SagaExecution, len(m.executions))
+	copy(result, m.executions)
+	return result
+}
+
+// sagaTestOrchestrator creates a PaymentOrchestrator configured for saga integration testing.
+func sagaTestOrchestrator(t *testing.T, opts ...func(*PaymentOrchestratorConfig)) (*PaymentOrchestrator, *MockRepository, *MockSagaExecutionLogger) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := NewMockRepository()
+	sagaLogger := NewMockSagaExecutionLogger()
+
+	cfg := PaymentOrchestratorConfig{
+		Logger: logger,
+		Repo:   repo,
+		CurrentAccountClient: &MockCurrentAccountClient{
+			initiateLienResp: &currentaccountv1.InitiateLienResponse{
+				Lien: &currentaccountv1.Lien{
+					LienId: "lien-" + uuid.New().String(),
+				},
+			},
+		},
+		PaymentGateway: &MockPaymentGateway{
+			response: gateway.PaymentResponse{
+				GatewayReferenceID: "gw-ref-" + uuid.New().String(),
+				Status:             "PENDING",
+			},
+		},
+		ReferenceDataClient:      NewMockReferenceDataClient(),
+		SagaExecutionLogger:      sagaLogger,
+		SagaOrchestrationEnabled: true,
+	}
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	orchestrator, err := NewPaymentOrchestrator(cfg)
+	require.NoError(t, err)
+	return orchestrator, repo, sagaLogger
+}
+
+// TestExecutePaymentSaga_DisabledReturnsError verifies that ExecutePaymentSaga
+// returns ErrSagaOrchestrationDisabled when the feature flag is off.
+func TestExecutePaymentSaga_DisabledReturnsError(t *testing.T) {
+	orchestrator, _, _ := sagaTestOrchestrator(t, func(cfg *PaymentOrchestratorConfig) {
+		cfg.SagaOrchestrationEnabled = false
+	})
+
+	po := testfixtures.NewPaymentOrder(t)
+	output, err := orchestrator.ExecutePaymentSaga(context.Background(), po.ID, "payment_execution", po)
+
+	assert.Nil(t, output)
+	assert.ErrorIs(t, err, ErrSagaOrchestrationDisabled)
+}
+
+// TestExecutePaymentSaga_EnabledExecutesSaga verifies that when enabled,
+// ExecutePaymentSaga fetches the saga definition and executes it.
+func TestExecutePaymentSaga_EnabledExecutesSaga(t *testing.T) {
+	orchestrator, repo, sagaLogger := sagaTestOrchestrator(t)
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	output, err := orchestrator.ExecutePaymentSaga(context.Background(), po.ID, "payment_execution", po)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.True(t, output.Success)
+
+	// Verify saga execution was logged
+	executions := sagaLogger.Executions()
+	require.GreaterOrEqual(t, len(executions), 2, "expected at least RUNNING + COMPLETED execution records")
+
+	// First record should be RUNNING
+	assert.Equal(t, domain.SagaExecutionStatusRunning, executions[0].Status)
+	assert.Equal(t, "payment_execution", executions[0].SagaName)
+	assert.Equal(t, po.ID, executions[0].PaymentOrderID)
+
+	// Last record should be COMPLETED
+	last := executions[len(executions)-1]
+	assert.Equal(t, domain.SagaExecutionStatusCompleted, last.Status)
+	assert.Greater(t, last.StepCount, 0)
+	assert.NotNil(t, last.CompletedAt)
+}
+
+// TestExecutePaymentSaga_GetSagaError verifies that a failure to fetch the saga
+// definition marks the payment order as failed and returns an error.
+func TestExecutePaymentSaga_GetSagaError(t *testing.T) {
+	refClient := NewMockReferenceDataClient()
+	refClient.getSagaErr = errors.New("reference-data unavailable")
+
+	orchestrator, repo, _ := sagaTestOrchestrator(t, func(cfg *PaymentOrchestratorConfig) {
+		cfg.ReferenceDataClient = refClient
+	})
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	output, err := orchestrator.ExecutePaymentSaga(context.Background(), po.ID, "payment_execution", po)
+
+	assert.Nil(t, output)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch saga definition")
+
+	// Payment order should be marked as FAILED
+	updated, findErr := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, findErr)
+	assert.Equal(t, domain.PaymentOrderStatusFailed, updated.Status)
+	assert.Equal(t, "INTERNAL_ERROR", updated.ErrorCode)
+}
+
+// TestExecutePaymentSaga_NilReferenceDataClient verifies that ExecutePaymentSaga
+// fails when no reference data client is configured.
+func TestExecutePaymentSaga_NilReferenceDataClient(t *testing.T) {
+	orchestrator, repo, _ := sagaTestOrchestrator(t, func(cfg *PaymentOrchestratorConfig) {
+		cfg.ReferenceDataClient = nil
+	})
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	output, err := orchestrator.ExecutePaymentSaga(context.Background(), po.ID, "payment_execution", po)
+
+	assert.Nil(t, output)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "reference data client not configured")
+}
+
+// TestExecutePaymentSaga_PersistsExecutionOnFailure verifies that when the saga
+// execution fails, the execution record is persisted with FAILED status.
+func TestExecutePaymentSaga_PersistsExecutionOnFailure(t *testing.T) {
+	// Use a saga script that will fail - reference a non-existent handler
+	refClient := NewMockReferenceDataClient()
+	refClient.sagaScript = `
+def bad_saga():
+    step(name="will_fail")
+    invoke_handler(handler="nonexistent.handler", params={})
+    return {}
+
+output = bad_saga()
+`
+
+	orchestrator, repo, sagaLogger := sagaTestOrchestrator(t, func(cfg *PaymentOrchestratorConfig) {
+		cfg.ReferenceDataClient = refClient
+	})
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	output, err := orchestrator.ExecutePaymentSaga(context.Background(), po.ID, "payment_execution", po)
+
+	// The saga runner returns a result with Success=false (not a Go error)
+	// when a handler is not found. ExecutePaymentSaga returns the result.
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.False(t, output.Success)
+
+	// Verify execution records were logged
+	executions := sagaLogger.Executions()
+	require.GreaterOrEqual(t, len(executions), 2, "expected RUNNING + FAILED execution records")
+
+	// First should be RUNNING
+	assert.Equal(t, domain.SagaExecutionStatusRunning, executions[0].Status)
+
+	// Last should be FAILED (because output.Success was false)
+	last := executions[len(executions)-1]
+	assert.Equal(t, domain.SagaExecutionStatusFailed, last.Status)
+	assert.NotEmpty(t, last.ErrorMessage)
+	assert.NotNil(t, last.CompletedAt)
+}
+
+// TestOrchestrate_DisabledFlagMarksPaymentFailed verifies that when
+// sagaOrchestrationEnabled is false, Orchestrate marks the payment order as
+// FAILED with error code SAGA_DISABLED.
+func TestOrchestrate_DisabledFlagMarksPaymentFailed(t *testing.T) {
+	orchestrator, repo, _ := sagaTestOrchestrator(t, func(cfg *PaymentOrchestratorConfig) {
+		cfg.SagaOrchestrationEnabled = false
+	})
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	orchestrator.Orchestrate(context.Background(), po)
+
+	// Payment order should be FAILED with SAGA_DISABLED
+	updated, err := repo.FindByID(context.Background(), po.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentOrderStatusFailed, updated.Status)
+	assert.Equal(t, "SAGA_DISABLED", updated.ErrorCode)
+	assert.Contains(t, updated.FailureReason, "saga orchestration is disabled")
+}
+
+// TestOrchestrate_EnabledDelegatestoExecutePaymentSaga verifies that when
+// enabled, Orchestrate delegates to ExecutePaymentSaga and processes the result.
+func TestOrchestrate_EnabledDelegatestoExecutePaymentSaga(t *testing.T) {
+	orchestrator, repo, sagaLogger := sagaTestOrchestrator(t)
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	orchestrator.Orchestrate(context.Background(), po)
+
+	// Saga should have executed and logged records
+	executions := sagaLogger.Executions()
+	require.GreaterOrEqual(t, len(executions), 2)
+
+	// Last execution should be COMPLETED (the default mock saga script succeeds)
+	last := executions[len(executions)-1]
+	assert.Equal(t, domain.SagaExecutionStatusCompleted, last.Status)
+}
+
+// TestExecutePaymentSaga_NilSagaExecutionLogger verifies that the orchestrator
+// works correctly when no execution logger is configured (optional dependency).
+func TestExecutePaymentSaga_NilSagaExecutionLogger(t *testing.T) {
+	orchestrator, repo, _ := sagaTestOrchestrator(t, func(cfg *PaymentOrchestratorConfig) {
+		cfg.SagaExecutionLogger = nil
+	})
+
+	po := testfixtures.NewPaymentOrder(t)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	// Should succeed without panicking despite nil logger
+	output, err := orchestrator.ExecutePaymentSaga(context.Background(), po.ID, "payment_execution", po)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.True(t, output.Success)
+}
+
+// TestExecutePaymentSaga_ExecutionRecordContainsInput verifies that the
+// persisted execution record contains the correct input data from the payment order.
+func TestExecutePaymentSaga_ExecutionRecordContainsInput(t *testing.T) {
+	orchestrator, repo, sagaLogger := sagaTestOrchestrator(t)
+
+	po := testfixtures.NewPaymentOrder(t,
+		testfixtures.WithDebtorAccountID("DEBTOR-TEST-123"),
+		testfixtures.WithCreditorReference("CRED-REF-456"),
+	)
+	require.NoError(t, repo.Create(context.Background(), po))
+
+	_, err := orchestrator.ExecutePaymentSaga(context.Background(), po.ID, "payment_execution", po)
+	require.NoError(t, err)
+
+	executions := sagaLogger.Executions()
+	require.GreaterOrEqual(t, len(executions), 1)
+
+	// Check the RUNNING record has correct input
+	input := executions[0].Input
+	assert.Equal(t, po.ID.String(), input["payment_order_id"])
+	assert.Equal(t, "DEBTOR-TEST-123", input["debtor_account_id"])
+	assert.Equal(t, "CRED-REF-456", input["creditor_reference"])
+}

--- a/services/payment-order/service/saga_integration_test.go
+++ b/services/payment-order/service/saga_integration_test.go
@@ -168,8 +168,7 @@ func TestExecutePaymentSaga_NilReferenceDataClient(t *testing.T) {
 	output, err := orchestrator.ExecutePaymentSaga(context.Background(), po.ID, "payment_execution", po)
 
 	assert.Nil(t, output)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "reference data client not configured")
+	assert.ErrorIs(t, err, ErrRefDataClientNotConfigured)
 }
 
 // TestExecutePaymentSaga_PersistsExecutionOnFailure verifies that when the saga


### PR DESCRIPTION
## Summary

- Add `SagaExecutionLogger` interface and `SagaExecutionRepository` persistence adapter to record saga execution lifecycle (RUNNING -> COMPLETED/FAILED) with audit details including correlation IDs, step counts, duration, and input/output payloads
- Add `SagaDefinitionRepository` interface in domain layer for saga script loading abstraction
- Add `ExecutePaymentSaga()` method as the primary integration point between the payment orchestrator and saga engine, with full lifecycle management: load definition -> build input -> persist RUNNING record -> execute via StarlarkSagaRunner -> persist final status -> handle result
- Wire `USE_SAGA_ORCHESTRATION` env var feature flag (default: false) to control Starlark saga execution path, with clear error messaging when disabled
- Add CockroachDB migration for `saga_executions` table with indexes on payment_order_id, (saga_name, status), and correlation_id
- Add 9 new unit tests covering feature flag behavior, execution logging, error paths, and nil logger tolerance

## Task Master Reference

stripe-connect-wiring.7 - Create payment orchestrator saga integration layer

## Test plan

- [x] `TestExecutePaymentSaga_DisabledReturnsError` - feature flag off returns sentinel error
- [x] `TestExecutePaymentSaga_EnabledExecutesSaga` - successful saga execution with logging
- [x] `TestExecutePaymentSaga_GetSagaError` - reference-data failure marks PO as FAILED
- [x] `TestExecutePaymentSaga_NilReferenceDataClient` - missing dependency handled gracefully
- [x] `TestExecutePaymentSaga_PersistsExecutionOnFailure` - FAILED status logged with error details
- [x] `TestOrchestrate_DisabledFlagMarksPaymentFailed` - Orchestrate with flag off -> SAGA_DISABLED
- [x] `TestOrchestrate_EnabledDelegatestoExecutePaymentSaga` - Orchestrate delegates correctly
- [x] `TestExecutePaymentSaga_NilSagaExecutionLogger` - nil logger does not panic
- [x] `TestExecutePaymentSaga_ExecutionRecordContainsInput` - input data correctly captured
- [x] All pre-existing unit tests pass (saga orchestration, bucket solvency, gRPC service)