### PR TITLE
fix: address AI review findings across reconciliation and grpc packages

### DIFF
--- a/services/reconciliation/domain/balance_assertion.go
+++ b/services/reconciliation/domain/balance_assertion.go
@@ -41,10 +41,10 @@ type BalanceAssertion struct {
 	// OverrideReason records why a failed assertion was overridden.
 	OverrideReason string
 
-	// Attributes stores flexible metadata.
+	// Attributes stores caller-supplied business data (tags, labels, custom identifiers).
 	Attributes map[string]string
 
-	// Metadata stores additional structured metadata.
+	// Metadata stores system-defined internal data (processing hints, audit info).
 	Metadata map[string]string
 
 	// AssertedAt is when the assertion was evaluated.
@@ -126,6 +126,9 @@ func (a *BalanceAssertion) Fail(actualBalance decimal.Decimal, reason string) er
 // The original FailureReason is preserved; the override justification
 // is stored in OverrideReason.
 func (a *BalanceAssertion) Override(reason string) error {
+	if reason == "" {
+		return ErrEmptyOverrideReason
+	}
 	if !a.Status.CanTransitionTo(AssertionStatusOverride) {
 		return ErrInvalidStatusTransition
 	}

--- a/services/reconciliation/domain/balance_assertion_test.go
+++ b/services/reconciliation/domain/balance_assertion_test.go
@@ -126,6 +126,13 @@ func TestBalanceAssertion_Override(t *testing.T) {
 	assert.Equal(t, "approved by manager", a.OverrideReason)
 }
 
+func TestBalanceAssertion_OverrideEmptyReason(t *testing.T) {
+	a := newTestAssertion(t)
+	require.NoError(t, a.Fail(decimal.NewFromFloat(9500.00), "mismatch"))
+	err := a.Override("")
+	assert.ErrorIs(t, err, domain.ErrEmptyOverrideReason)
+}
+
 func TestBalanceAssertion_OverrideFromNonFailed(t *testing.T) {
 	t.Run("cannot override from pending", func(t *testing.T) {
 		a := newTestAssertion(t)

--- a/services/reconciliation/domain/errors.go
+++ b/services/reconciliation/domain/errors.go
@@ -45,4 +45,6 @@ var (
 	ErrRunNotCompleted = errors.New("settlement run must be in COMPLETED state to finalize")
 	// ErrPositionLockFailed is returned when the position lock request to PK fails after retries.
 	ErrPositionLockFailed = errors.New("failed to acquire position lock")
+	// ErrEmptyOverrideReason is returned when override reason is empty.
+	ErrEmptyOverrideReason = errors.New("override reason cannot be empty")
 )

--- a/services/reconciliation/service/stub_valuation_engine_test.go
+++ b/services/reconciliation/service/stub_valuation_engine_test.go
@@ -137,7 +137,7 @@ func TestStubValuationEngine_IntegrationWithVarianceValuator(t *testing.T) {
 	assert.Equal(t, "GBP", varianceRepo.variances[0].Currency)
 }
 
-func TestStubValuationEngine_MaterialityAutoAccept(t *testing.T) {
+func TestVarianceValuator_MaterialityAutoAccept(t *testing.T) {
 	runRepo := newMockRunRepo()
 	varianceRepo := &mockVarianceRepoFull{}
 

--- a/services/reconciliation/worker/stub_refdata_client_test.go
+++ b/services/reconciliation/worker/stub_refdata_client_test.go
@@ -10,9 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
 func TestStubReferenceDataClient_ReturnsEmptyList(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
-	client := NewStubReferenceDataClient(logger)
+	client := NewStubReferenceDataClient(newTestLogger())
 
 	schedules, err := client.ListSettlementSchedules(context.Background())
 	require.NoError(t, err)
@@ -20,7 +23,6 @@ func TestStubReferenceDataClient_ReturnsEmptyList(t *testing.T) {
 }
 
 func TestStubReferenceDataClient_ImplementsInterface(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
-	var client ReferenceDataClient = NewStubReferenceDataClient(logger)
+	var client ReferenceDataClient = NewStubReferenceDataClient(newTestLogger())
 	assert.NotNil(t, client)
 }

--- a/shared/pkg/grpc/client.go
+++ b/shared/pkg/grpc/client.go
@@ -67,7 +67,7 @@ type ClientConfig struct {
 //	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 //	defer cancel()
 //
-//	conn, err := grpc.NewClient(ctx, grpc.ClientConfig{
+//	conn, err := NewClient(ctx, ClientConfig{
 //	    ServiceName: "financial-accounting",
 //	    Namespace:   "default",
 //	    Port:        50052,


### PR DESCRIPTION
## Summary

- Add empty reason validation to `BalanceAssertion.Override()` with `ErrEmptyOverrideReason` sentinel error, strengthening audit trail integrity
- Clarify `Attributes` vs `Metadata` field doc comments in `BalanceAssertion` (caller-supplied business data vs system-defined internal data)
- Rename `TestStubValuationEngine_MaterialityAutoAccept` to `TestVarianceValuator_MaterialityAutoAccept` to accurately reflect test subject
- Extract `newTestLogger()` helper in `stub_refdata_client_test.go` to remove duplicate logger setup
- Fix doc comment example in `shared/pkg/grpc/client.go` to use `NewClient(ctx, ClientConfig{` instead of `grpc.NewClient(ctx, grpc.ClientConfig{`

## Findings triaged

5 of 10 GitHub AI review findings were false positives:

| Finding | Verdict | Reason |
|---------|---------|--------|
| F1: range over integer | False positive | `range N` is valid Go 1.22+ syntax (project is Go 1.26) |
| F3: Pass() balance validation | False positive | Would break `balance_assertor.go` where `ExpectedBalance` is audit-only metadata |
| F5: Missing newRunningTestRun | False positive | Exists in `variance_detector_test.go` (same package) |
| F6: Missing createDetectedVariance | False positive | Exists in `variance_valuator_test.go` (same package) |

## Test plan

- [x] `TestBalanceAssertion_OverrideEmptyReason` added and passing
- [x] All existing `TestBalanceAssertion_*` tests passing (no regressions)
- [ ] CI pipeline validates full build and lint