### PR TITLE
fix: scope dunning retry ZSET key by tenant ID

### DIFF
--- a/services/payment-order/adapters/http/stripe_event_processor.go
+++ b/services/payment-order/adapters/http/stripe_event_processor.go
@@ -24,9 +24,10 @@ const (
 	// processedWebhookTTL is how long processed event IDs are retained in Redis (48 hours).
 	processedWebhookTTL = 48 * time.Hour
 
-	// dunningRetryZSet is the Redis sorted set key for dunning retry scheduling.
-	// This matches the key used by DunningWorker.
-	dunningRetryZSet = "dunning:retries"
+	// dunningRetryZSetPrefix is the Redis sorted set key prefix for dunning retry scheduling.
+	// The full key is "dunning:retries:{tenantID}" for tenant isolation.
+	// This matches the key pattern used by DunningWorker.
+	dunningRetryZSetPrefix = "dunning:retries:"
 
 	// defaultDunningDelay is the default delay before the first dunning retry.
 	defaultDunningDelay = 24 * time.Hour
@@ -99,12 +100,16 @@ func (p *StripeEventProcessor) PreProcess(ctx context.Context, eventID string) e
 	return nil
 }
 
-// ScheduleDunning adds a payment order to the dunning retry sorted set.
+// ScheduleDunning adds a payment order to the tenant-scoped dunning retry sorted set.
 // Called when a payment_intent.payment_failed event is received.
 // The dunning worker will pick up the entry and trigger escalation.
-func (p *StripeEventProcessor) ScheduleDunning(ctx context.Context, paymentOrderID string) error {
+func (p *StripeEventProcessor) ScheduleDunning(ctx context.Context, tenantID, paymentOrderID string) error {
 	if paymentOrderID == "" {
 		p.logger.Warn("cannot schedule dunning: empty payment order ID")
+		return nil
+	}
+	if tenantID == "" {
+		p.logger.Warn("cannot schedule dunning: empty tenant ID")
 		return nil
 	}
 
@@ -114,16 +119,19 @@ func (p *StripeEventProcessor) ScheduleDunning(ctx context.Context, paymentOrder
 		Member: fmt.Sprintf("stripe:%s", paymentOrderID),
 	}
 
-	err := p.redis.ZAdd(ctx, dunningRetryZSet, member).Err()
+	key := dunningRetryZSetPrefix + tenantID
+	err := p.redis.ZAdd(ctx, key, member).Err()
 	if err != nil {
 		p.logger.Error("failed to schedule dunning retry",
 			"payment_order_id", paymentOrderID,
+			"tenant_id", tenantID,
 			"error", err)
 		return fmt.Errorf("failed to schedule dunning retry: %w", err)
 	}
 
 	p.logger.Info("dunning retry scheduled for failed stripe payment",
 		"payment_order_id", paymentOrderID,
+		"tenant_id", tenantID,
 		"due_at", dueAt)
 
 	return nil

--- a/services/payment-order/adapters/http/stripe_event_processor.go
+++ b/services/payment-order/adapters/http/stripe_event_processor.go
@@ -14,6 +14,7 @@ import (
 var (
 	ErrNilRedisClient        = errors.New("redis client cannot be nil")
 	ErrEventAlreadyProcessed = errors.New("stripe event already processed")
+	ErrDunningMissingTenant  = errors.New("tenant ID is required for dunning scheduling")
 )
 
 // Stripe event processor constants.
@@ -109,8 +110,9 @@ func (p *StripeEventProcessor) ScheduleDunning(ctx context.Context, tenantID, pa
 		return nil
 	}
 	if tenantID == "" {
-		p.logger.Warn("cannot schedule dunning: empty tenant ID")
-		return nil
+		p.logger.Error("cannot schedule dunning: empty tenant ID",
+			"payment_order_id", paymentOrderID)
+		return ErrDunningMissingTenant
 	}
 
 	dueAt := time.Now().Add(defaultDunningDelay)

--- a/services/payment-order/adapters/http/stripe_event_processor_test.go
+++ b/services/payment-order/adapters/http/stripe_event_processor_test.go
@@ -151,11 +151,11 @@ func TestStripeEventProcessor_ScheduleDunning(t *testing.T) {
 		assert.Equal(t, int64(0), count)
 	})
 
-	t.Run("empty tenant ID is a no-op", func(t *testing.T) {
+	t.Run("empty tenant ID returns error", func(t *testing.T) {
 		proc, _, _ := setupTestEventProcessor(t)
 
 		err := proc.ScheduleDunning(ctx, "", "po-123")
-		assert.NoError(t, err)
+		assert.ErrorIs(t, err, ErrDunningMissingTenant)
 	})
 
 	t.Run("multiple dunning entries are independent", func(t *testing.T) {

--- a/services/payment-order/adapters/http/stripe_event_processor_test.go
+++ b/services/payment-order/adapters/http/stripe_event_processor_test.go
@@ -120,15 +120,17 @@ func TestStripeEventProcessor_PreProcess(t *testing.T) {
 
 func TestStripeEventProcessor_ScheduleDunning(t *testing.T) {
 	ctx := context.Background()
+	const testTenantID = "test_tenant"
+	zsetKey := dunningRetryZSetPrefix + testTenantID
 
 	t.Run("schedules dunning for payment order", func(t *testing.T) {
 		proc, client, _ := setupTestEventProcessor(t)
 
-		err := proc.ScheduleDunning(ctx, "po-123")
+		err := proc.ScheduleDunning(ctx, testTenantID, "po-123")
 		assert.NoError(t, err)
 
-		// Verify the entry was added to the ZSET
-		members, err := client.ZRangeByScore(ctx, dunningRetryZSet, &redis.ZRangeBy{
+		// Verify the entry was added to the tenant-scoped ZSET
+		members, err := client.ZRangeByScore(ctx, zsetKey, &redis.ZRangeBy{
 			Min: "-inf",
 			Max: "+inf",
 		}).Result()
@@ -140,25 +142,32 @@ func TestStripeEventProcessor_ScheduleDunning(t *testing.T) {
 	t.Run("empty payment order ID is a no-op", func(t *testing.T) {
 		proc, client, _ := setupTestEventProcessor(t)
 
-		err := proc.ScheduleDunning(ctx, "")
+		err := proc.ScheduleDunning(ctx, testTenantID, "")
 		assert.NoError(t, err)
 
 		// Verify nothing was added to the ZSET
-		count, err := client.ZCard(ctx, dunningRetryZSet).Result()
+		count, err := client.ZCard(ctx, zsetKey).Result()
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), count)
+	})
+
+	t.Run("empty tenant ID is a no-op", func(t *testing.T) {
+		proc, _, _ := setupTestEventProcessor(t)
+
+		err := proc.ScheduleDunning(ctx, "", "po-123")
+		assert.NoError(t, err)
 	})
 
 	t.Run("multiple dunning entries are independent", func(t *testing.T) {
 		proc, client, _ := setupTestEventProcessor(t)
 
-		err := proc.ScheduleDunning(ctx, "po-aaa")
+		err := proc.ScheduleDunning(ctx, testTenantID, "po-aaa")
 		assert.NoError(t, err)
 
-		err = proc.ScheduleDunning(ctx, "po-bbb")
+		err = proc.ScheduleDunning(ctx, testTenantID, "po-bbb")
 		assert.NoError(t, err)
 
-		count, err := client.ZCard(ctx, dunningRetryZSet).Result()
+		count, err := client.ZCard(ctx, zsetKey).Result()
 		require.NoError(t, err)
 		assert.Equal(t, int64(2), count)
 	})
@@ -168,7 +177,39 @@ func TestStripeEventProcessor_ScheduleDunning(t *testing.T) {
 
 		mr.Close()
 
-		err := proc.ScheduleDunning(ctx, "po-fail")
+		err := proc.ScheduleDunning(ctx, testTenantID, "po-fail")
 		assert.Error(t, err)
+	})
+
+	t.Run("tenant isolation between tenants", func(t *testing.T) {
+		proc, client, _ := setupTestEventProcessor(t)
+
+		const tenantA = "tenant_a"
+		const tenantB = "tenant_b"
+
+		err := proc.ScheduleDunning(ctx, tenantA, "po-a1")
+		assert.NoError(t, err)
+		err = proc.ScheduleDunning(ctx, tenantB, "po-b1")
+		assert.NoError(t, err)
+
+		// Verify tenant A's key only has tenant A's entry
+		keyA := dunningRetryZSetPrefix + tenantA
+		membersA, err := client.ZRangeByScore(ctx, keyA, &redis.ZRangeBy{
+			Min: "-inf",
+			Max: "+inf",
+		}).Result()
+		require.NoError(t, err)
+		assert.Len(t, membersA, 1)
+		assert.Equal(t, "stripe:po-a1", membersA[0])
+
+		// Verify tenant B's key only has tenant B's entry
+		keyB := dunningRetryZSetPrefix + tenantB
+		membersB, err := client.ZRangeByScore(ctx, keyB, &redis.ZRangeBy{
+			Min: "-inf",
+			Max: "+inf",
+		}).Result()
+		require.NoError(t, err)
+		assert.Len(t, membersB, 1)
+		assert.Equal(t, "stripe:po-b1", membersB[0])
 	})
 }

--- a/services/payment-order/adapters/http/stripe_webhook_handler.go
+++ b/services/payment-order/adapters/http/stripe_webhook_handler.go
@@ -186,9 +186,10 @@ func (h *StripeWebhookHandler) HandleStripeWebhook(w http.ResponseWriter, r *htt
 
 	// Schedule dunning for failed payments (fire-and-forget, does not affect response)
 	if h.eventProcessor != nil && parsed.Status == "REJECTED" && parsed.PaymentOrderID != "" {
-		if dunningErr := h.eventProcessor.ScheduleDunning(ctx, parsed.PaymentOrderID); dunningErr != nil {
+		if dunningErr := h.eventProcessor.ScheduleDunning(ctx, tenantID.String(), parsed.PaymentOrderID); dunningErr != nil {
 			h.logger.Error("failed to schedule dunning for failed payment",
 				"payment_order_id", parsed.PaymentOrderID,
+				"tenant_id", tenantID.String(),
 				"event_id", parsed.EventID,
 				"error", dunningErr)
 		}

--- a/services/payment-order/adapters/http/stripe_webhook_handler_test.go
+++ b/services/payment-order/adapters/http/stripe_webhook_handler_test.go
@@ -408,7 +408,7 @@ func TestStripeWebhookHandler_FailedPaymentTriggersDunning(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// Verify dunning was scheduled in the ZSET
-	members, err := redisClient.ZRangeByScore(ctx, dunningRetryZSet, &redis.ZRangeBy{
+	members, err := redisClient.ZRangeByScore(ctx, dunningRetryZSetPrefix+"test-tenant", &redis.ZRangeBy{
 		Min: "-inf",
 		Max: "+inf",
 	}).Result()
@@ -441,7 +441,7 @@ func TestStripeWebhookHandler_SucceededPaymentDoesNotTriggerDunning(t *testing.T
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// Verify dunning was NOT scheduled
-	count, err := redisClient.ZCard(ctx, dunningRetryZSet).Result()
+	count, err := redisClient.ZCard(ctx, dunningRetryZSetPrefix+"test-tenant").Result()
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count)
 }
@@ -474,7 +474,7 @@ func TestStripeWebhookHandler_RefundedDoesNotTriggerDunning(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 
 	// Verify dunning was NOT scheduled for refunds
-	count, err := redisClient.ZCard(ctx, dunningRetryZSet).Result()
+	count, err := redisClient.ZCard(ctx, dunningRetryZSetPrefix+"test-tenant").Result()
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count)
 }

--- a/services/payment-order/worker/dunning_worker.go
+++ b/services/payment-order/worker/dunning_worker.go
@@ -18,12 +18,14 @@ import (
 
 // Dunning worker errors.
 var (
-	ErrNilDunningCallback = errors.New("dunning callback is required")
-	ErrDunningKeyTooShort = errors.New("dunning retry key too short")
+	ErrNilDunningCallback   = errors.New("dunning callback is required")
+	ErrDunningKeyTooShort   = errors.New("dunning retry key too short")
+	ErrDunningMissingTenant = errors.New("tenant ID is required for dunning retry")
 )
 
-// dunningRetryZSet is the Redis sorted set key for dunning retry scheduling.
-const dunningRetryZSet = "dunning:retries"
+// dunningRetryZSetPrefix is the Redis sorted set key prefix for dunning retry scheduling.
+// The full key is "dunning:retries:{tenantID}" for tenant isolation.
+const dunningRetryZSetPrefix = "dunning:retries:"
 
 // DunningWorkerConfig holds configuration for the dunning retry worker.
 type DunningWorkerConfig struct {
@@ -145,42 +147,75 @@ func (w *DunningWorker) pollLoop(ctx context.Context) error {
 	}
 }
 
-// ScheduleDunningRetry adds a billing run to the sorted set with a score
-// equal to the Unix timestamp when the retry becomes due.
-func (w *DunningWorker) ScheduleDunningRetry(ctx context.Context, billingRunID uuid.UUID, delay time.Duration) error {
+// ScheduleDunningRetry adds a billing run to the tenant-scoped sorted set with
+// a score equal to the Unix timestamp when the retry becomes due.
+func (w *DunningWorker) ScheduleDunningRetry(ctx context.Context, tenantID string, billingRunID uuid.UUID, delay time.Duration) error {
+	if tenantID == "" {
+		return ErrDunningMissingTenant
+	}
 	dueAt := NowFunc().Add(delay)
 	member := redis.Z{
 		Score:  float64(dueAt.Unix()),
 		Member: billingRunID.String(),
 	}
-	err := w.redis.ZAdd(ctx, dunningRetryZSet, member).Err()
+	key := dunningRetryZSetPrefix + tenantID
+	err := w.redis.ZAdd(ctx, key, member).Err()
 	if err != nil {
 		return fmt.Errorf("failed to schedule dunning retry: %w", err)
 	}
 
 	w.logger.Info("dunning retry scheduled",
 		"billing_run_id", billingRunID,
+		"tenant_id", tenantID,
 		"delay", delay,
 		"due_at", dueAt)
 
 	return nil
 }
 
-// processDueRetries queries the sorted set for all members whose score (due
-// timestamp) is at or before the current time, processes each one, and removes
-// it from the set.
+// processDueRetries scans for all tenant-scoped dunning ZSET keys and processes
+// due retries from each. Uses SCAN to discover keys matching "dunning:retries:*".
 func (w *DunningWorker) processDueRetries(ctx context.Context) {
+	// Discover all tenant-scoped dunning keys
+	keys, err := w.scanDunningKeys(ctx)
+	if err != nil {
+		w.logger.Error("failed to scan dunning retry keys", "error", err)
+		return
+	}
+
+	for _, key := range keys {
+		w.processDueRetriesForKey(ctx, key)
+	}
+}
+
+// scanDunningKeys returns all Redis keys matching the dunning retry ZSET pattern.
+func (w *DunningWorker) scanDunningKeys(ctx context.Context) ([]string, error) {
+	var allKeys []string
+	pattern := dunningRetryZSetPrefix + "*"
+	iter := w.redis.Scan(ctx, 0, pattern, 100).Iterator()
+	for iter.Next(ctx) {
+		allKeys = append(allKeys, iter.Val())
+	}
+	if err := iter.Err(); err != nil {
+		return nil, fmt.Errorf("failed to scan dunning keys: %w", err)
+	}
+	return allKeys, nil
+}
+
+// processDueRetriesForKey queries a single tenant's sorted set for all members
+// whose score (due timestamp) is at or before the current time, processes each
+// one, and removes it from the set.
+func (w *DunningWorker) processDueRetriesForKey(ctx context.Context, key string) {
 	now := NowFunc()
 	maxScore := strconv.FormatInt(now.Unix(), 10)
 
-	// Fetch billing run IDs that are due
-	members, err := w.redis.ZRangeByScore(ctx, dunningRetryZSet, &redis.ZRangeBy{
+	members, err := w.redis.ZRangeByScore(ctx, key, &redis.ZRangeBy{
 		Min:   "-inf",
 		Max:   maxScore,
 		Count: 100,
 	}).Result()
 	if err != nil {
-		w.logger.Error("failed to query dunning retries", "error", err)
+		w.logger.Error("failed to query dunning retries", "key", key, "error", err)
 		return
 	}
 
@@ -192,20 +227,19 @@ func (w *DunningWorker) processDueRetries(ctx context.Context) {
 	for _, member := range members {
 		billingRunID, parseErr := uuid.Parse(member)
 		if parseErr != nil {
-			w.logger.Error("invalid billing run ID in dunning set", "member", member, "error", parseErr)
-			w.redis.ZRem(ctx, dunningRetryZSet, member)
+			w.logger.Error("invalid billing run ID in dunning set", "key", key, "member", member, "error", parseErr)
+			w.redis.ZRem(ctx, key, member)
 			continue
 		}
 
 		if w.processRetry(ctx, billingRunID) {
-			// Only remove on success; transient failures retain the member for next poll
-			w.redis.ZRem(ctx, dunningRetryZSet, member)
+			w.redis.ZRem(ctx, key, member)
 			processed++
 		}
 	}
 
 	if processed > 0 {
-		w.logger.Info("processed dunning retries", "count", processed)
+		w.logger.Info("processed dunning retries", "key", key, "count", processed)
 	}
 }
 
@@ -283,8 +317,12 @@ func (w *DunningWorker) executeRetry(ctx context.Context, billingRunID uuid.UUID
 	return true
 }
 
-// CancelDunningRetry removes a billing run from the retry set.
+// CancelDunningRetry removes a billing run from the tenant-scoped retry set.
 // Called when a billing run is resolved (e.g., manual payment succeeds).
-func (w *DunningWorker) CancelDunningRetry(ctx context.Context, billingRunID uuid.UUID) error {
-	return w.redis.ZRem(ctx, dunningRetryZSet, billingRunID.String()).Err()
+func (w *DunningWorker) CancelDunningRetry(ctx context.Context, tenantID string, billingRunID uuid.UUID) error {
+	if tenantID == "" {
+		return ErrDunningMissingTenant
+	}
+	key := dunningRetryZSetPrefix + tenantID
+	return w.redis.ZRem(ctx, key, billingRunID.String()).Err()
 }

--- a/services/payment-order/worker/dunning_worker_test.go
+++ b/services/payment-order/worker/dunning_worker_test.go
@@ -191,6 +191,9 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 	logger := dunningTestLogger()
 	metrics := dunningTestMetrics(t)
 
+	const testTenantID = "tenant_1"
+	zsetKey := dunningRetryZSetPrefix + testTenantID
+
 	t.Run("schedules and processes retry", func(t *testing.T) {
 		repo := newMockBillingRepo()
 
@@ -198,7 +201,7 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 		billingRunID := uuid.New()
 		run := &domain.BillingRun{
 			ID:           billingRunID,
-			TenantID:     "tenant-1",
+			TenantID:     testTenantID,
 			Status:       domain.BillingRunStatusFailed,
 			DunningLevel: 1,
 			CycleStart:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -226,7 +229,7 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 		NowFunc = func() time.Time { return time.Now().UTC() }
 		defer func() { NowFunc = originalNowFunc }()
 
-		err = w.ScheduleDunningRetry(context.Background(), billingRunID, -1*time.Minute)
+		err = w.ScheduleDunningRetry(context.Background(), testTenantID, billingRunID, -1*time.Minute)
 		require.NoError(t, err)
 
 		// Start the worker
@@ -248,7 +251,7 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 		w.Stop()
 
 		// Verify the retry was removed from the ZSET
-		members, err := client.ZRangeByScore(context.Background(), dunningRetryZSet, &redis.ZRangeBy{
+		members, err := client.ZRangeByScore(context.Background(), zsetKey, &redis.ZRangeBy{
 			Min: "-inf",
 			Max: "+inf",
 		}).Result()
@@ -262,7 +265,7 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 		billingRunID := uuid.New()
 		run := &domain.BillingRun{
 			ID:         billingRunID,
-			TenantID:   "tenant-1",
+			TenantID:   testTenantID,
 			Status:     domain.BillingRunStatusCompleted, // Not failed
 			CycleStart: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 			CycleEnd:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
@@ -284,10 +287,10 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 		require.NoError(t, err)
 
 		// Clean ZSET from previous test
-		client.Del(context.Background(), dunningRetryZSet)
+		client.Del(context.Background(), zsetKey)
 
 		// Schedule in the past
-		err = w.ScheduleDunningRetry(context.Background(), billingRunID, -1*time.Minute)
+		err = w.ScheduleDunningRetry(context.Background(), testTenantID, billingRunID, -1*time.Minute)
 		require.NoError(t, err)
 
 		go func() {
@@ -313,9 +316,9 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 		require.NoError(t, err)
 
 		// Clean ZSET
-		client.Del(context.Background(), dunningRetryZSet)
+		client.Del(context.Background(), zsetKey)
 
-		err = w.ScheduleDunningRetry(context.Background(), billingRunID, -1*time.Minute)
+		err = w.ScheduleDunningRetry(context.Background(), testTenantID, billingRunID, -1*time.Minute)
 		require.NoError(t, err)
 
 		go func() {
@@ -326,7 +329,7 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 		w.Stop()
 
 		// Verify the retry was removed from the ZSET (dropped)
-		members, err := client.ZRangeByScore(context.Background(), dunningRetryZSet, &redis.ZRangeBy{
+		members, err := client.ZRangeByScore(context.Background(), zsetKey, &redis.ZRangeBy{
 			Min: "-inf",
 			Max: "+inf",
 		}).Result()
@@ -340,7 +343,7 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 		billingRunID := uuid.New()
 		run := &domain.BillingRun{
 			ID:           billingRunID,
-			TenantID:     "tenant-1",
+			TenantID:     testTenantID,
 			Status:       domain.BillingRunStatusFailed,
 			DunningLevel: 1,
 			CycleStart:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -361,9 +364,9 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 		require.NoError(t, err)
 
 		// Clean ZSET
-		client.Del(context.Background(), dunningRetryZSet)
+		client.Del(context.Background(), zsetKey)
 
-		err = w.ScheduleDunningRetry(context.Background(), billingRunID, -1*time.Minute)
+		err = w.ScheduleDunningRetry(context.Background(), testTenantID, billingRunID, -1*time.Minute)
 		require.NoError(t, err)
 
 		go func() {
@@ -374,9 +377,22 @@ func TestDunningWorker_ScheduleAndProcess(t *testing.T) {
 		w.Stop()
 
 		// Verify the retry is still in the ZSET
-		count, err := client.ZCard(context.Background(), dunningRetryZSet).Result()
+		count, err := client.ZCard(context.Background(), zsetKey).Result()
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), count, "failed retry should be retained in ZSET")
+	})
+
+	t.Run("rejects empty tenant ID", func(t *testing.T) {
+		repo := newMockBillingRepo()
+
+		w, err := NewDunningWorker(repo, client, DunningWorkerConfig{
+			PollInterval:    50 * time.Millisecond,
+			ShutdownTimeout: 2 * time.Second,
+		}, noopCallback, logger, metrics)
+		require.NoError(t, err)
+
+		err = w.ScheduleDunningRetry(context.Background(), "", uuid.New(), time.Hour)
+		assert.ErrorIs(t, err, ErrDunningMissingTenant)
 	})
 
 	// Clean up ZSET for other tests
@@ -389,6 +405,9 @@ func TestDunningWorker_CancelRetry(t *testing.T) {
 	repo := newMockBillingRepo()
 	metrics := dunningTestMetrics(t)
 
+	const testTenantID = "tenant_1"
+	zsetKey := dunningRetryZSetPrefix + testTenantID
+
 	w, err := NewDunningWorker(repo, client, DunningWorkerConfig{
 		PollInterval:    50 * time.Millisecond,
 		ShutdownTimeout: 2 * time.Second,
@@ -399,22 +418,27 @@ func TestDunningWorker_CancelRetry(t *testing.T) {
 	billingRunID := uuid.New()
 
 	// Schedule a retry
-	err = w.ScheduleDunningRetry(ctx, billingRunID, time.Hour)
+	err = w.ScheduleDunningRetry(ctx, testTenantID, billingRunID, time.Hour)
 	require.NoError(t, err)
 
 	// Verify it's in the ZSET
-	count, err := client.ZCard(ctx, dunningRetryZSet).Result()
+	count, err := client.ZCard(ctx, zsetKey).Result()
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 
 	// Cancel it
-	err = w.CancelDunningRetry(ctx, billingRunID)
+	err = w.CancelDunningRetry(ctx, testTenantID, billingRunID)
 	require.NoError(t, err)
 
 	// Verify it's gone
-	count, err = client.ZCard(ctx, dunningRetryZSet).Result()
+	count, err = client.ZCard(ctx, zsetKey).Result()
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count)
+
+	t.Run("rejects empty tenant ID", func(t *testing.T) {
+		err := w.CancelDunningRetry(ctx, "", uuid.New())
+		assert.ErrorIs(t, err, ErrDunningMissingTenant)
+	})
 }
 
 func TestDunningWorker_PerItemLocking(t *testing.T) {
@@ -423,10 +447,12 @@ func TestDunningWorker_PerItemLocking(t *testing.T) {
 	repo := newMockBillingRepo()
 	metrics := dunningTestMetrics(t)
 
+	const testTenantID = "tenant_1"
+
 	billingRunID := uuid.New()
 	run := &domain.BillingRun{
 		ID:           billingRunID,
-		TenantID:     "tenant-1",
+		TenantID:     testTenantID,
 		Status:       domain.BillingRunStatusFailed,
 		DunningLevel: 1,
 		CycleStart:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -458,7 +484,7 @@ func TestDunningWorker_PerItemLocking(t *testing.T) {
 	ctx := context.Background()
 
 	// Schedule retry in the past
-	err = w1.ScheduleDunningRetry(ctx, billingRunID, -1*time.Minute)
+	err = w1.ScheduleDunningRetry(ctx, testTenantID, billingRunID, -1*time.Minute)
 	require.NoError(t, err)
 
 	// Both workers try to process - only one should succeed due to locking
@@ -479,10 +505,12 @@ func TestDunningWorker_GracefulShutdownWaitsForInFlight(t *testing.T) {
 	repo := newMockBillingRepo()
 	metrics := dunningTestMetrics(t)
 
+	const testTenantID = "tenant_1"
+
 	billingRunID := uuid.New()
 	run := &domain.BillingRun{
 		ID:           billingRunID,
-		TenantID:     "tenant-1",
+		TenantID:     testTenantID,
 		Status:       domain.BillingRunStatusFailed,
 		DunningLevel: 1,
 		CycleStart:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -506,7 +534,7 @@ func TestDunningWorker_GracefulShutdownWaitsForInFlight(t *testing.T) {
 	require.NoError(t, err)
 
 	// Schedule retry in the past
-	err = w.ScheduleDunningRetry(context.Background(), billingRunID, -1*time.Minute)
+	err = w.ScheduleDunningRetry(context.Background(), testTenantID, billingRunID, -1*time.Minute)
 	require.NoError(t, err)
 
 	go func() {
@@ -528,6 +556,9 @@ func TestDunningWorker_InvalidMemberInZSET(t *testing.T) {
 	repo := newMockBillingRepo()
 	metrics := dunningTestMetrics(t)
 
+	const testTenantID = "tenant_1"
+	zsetKey := dunningRetryZSetPrefix + testTenantID
+
 	w, err := NewDunningWorker(repo, client, DunningWorkerConfig{
 		PollInterval:    50 * time.Millisecond,
 		ShutdownTimeout: 2 * time.Second,
@@ -536,8 +567,8 @@ func TestDunningWorker_InvalidMemberInZSET(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Add an invalid UUID to the ZSET
-	client.ZAdd(ctx, dunningRetryZSet, redis.Z{
+	// Add an invalid UUID to the tenant-scoped ZSET
+	client.ZAdd(ctx, zsetKey, redis.Z{
 		Score:  float64(time.Now().Add(-1 * time.Minute).Unix()),
 		Member: "not-a-uuid",
 	})
@@ -550,7 +581,7 @@ func TestDunningWorker_InvalidMemberInZSET(t *testing.T) {
 	w.Stop()
 
 	// Invalid member should be removed
-	members, err := client.ZRangeByScore(ctx, dunningRetryZSet, &redis.ZRangeBy{
+	members, err := client.ZRangeByScore(ctx, zsetKey, &redis.ZRangeBy{
 		Min: "-inf",
 		Max: "+inf",
 	}).Result()
@@ -565,6 +596,9 @@ func TestDunningWorker_RepoErrorRetainsRetry(t *testing.T) {
 	repo.findErr = errors.New("database unavailable")
 	metrics := dunningTestMetrics(t)
 
+	const testTenantID = "tenant_1"
+	zsetKey := dunningRetryZSetPrefix + testTenantID
+
 	w, err := NewDunningWorker(repo, client, DunningWorkerConfig{
 		PollInterval:    50 * time.Millisecond,
 		ShutdownTimeout: 2 * time.Second,
@@ -575,9 +609,9 @@ func TestDunningWorker_RepoErrorRetainsRetry(t *testing.T) {
 	billingRunID := uuid.New()
 
 	// Clean ZSET
-	client.Del(ctx, dunningRetryZSet)
+	client.Del(ctx, zsetKey)
 
-	err = w.ScheduleDunningRetry(ctx, billingRunID, -1*time.Minute)
+	err = w.ScheduleDunningRetry(ctx, testTenantID, billingRunID, -1*time.Minute)
 	require.NoError(t, err)
 
 	go func() {
@@ -588,7 +622,184 @@ func TestDunningWorker_RepoErrorRetainsRetry(t *testing.T) {
 	w.Stop()
 
 	// Retry should still be in the ZSET
-	count, err := client.ZCard(ctx, dunningRetryZSet).Result()
+	count, err := client.ZCard(ctx, zsetKey).Result()
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count, "retry should be retained when repo returns error")
+}
+
+func TestDunningWorker_TenantIsolation(t *testing.T) {
+	mr, client := setupDunningMiniredis(t)
+	logger := dunningTestLogger()
+	metrics := dunningTestMetrics(t)
+
+	const tenantA = "tenant_alpha"
+	const tenantB = "tenant_beta"
+
+	repo := newMockBillingRepo()
+
+	// Create billing runs for two different tenants
+	runA := &domain.BillingRun{
+		ID:           uuid.New(),
+		TenantID:     tenantA,
+		Status:       domain.BillingRunStatusFailed,
+		DunningLevel: 1,
+		CycleStart:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		CycleEnd:     time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	runB := &domain.BillingRun{
+		ID:           uuid.New(),
+		TenantID:     tenantB,
+		Status:       domain.BillingRunStatusFailed,
+		DunningLevel: 1,
+		CycleStart:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		CycleEnd:     time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	repo.mu.Lock()
+	repo.runs[runA.ID] = runA
+	repo.runs[runB.ID] = runB
+	repo.mu.Unlock()
+
+	w, err := NewDunningWorker(repo, client, DunningWorkerConfig{
+		PollInterval:    50 * time.Millisecond,
+		ShutdownTimeout: 2 * time.Second,
+	}, noopCallback, logger, metrics)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Schedule retries for both tenants
+	err = w.ScheduleDunningRetry(ctx, tenantA, runA.ID, time.Hour)
+	require.NoError(t, err)
+	err = w.ScheduleDunningRetry(ctx, tenantB, runB.ID, time.Hour)
+	require.NoError(t, err)
+
+	// Verify each tenant's ZSET contains only their own billing run
+	keyA := dunningRetryZSetPrefix + tenantA
+	keyB := dunningRetryZSetPrefix + tenantB
+
+	membersA, err := client.ZRangeByScore(ctx, keyA, &redis.ZRangeBy{
+		Min: "-inf",
+		Max: "+inf",
+	}).Result()
+	require.NoError(t, err)
+	assert.Len(t, membersA, 1)
+	assert.Equal(t, runA.ID.String(), membersA[0])
+
+	membersB, err := client.ZRangeByScore(ctx, keyB, &redis.ZRangeBy{
+		Min: "-inf",
+		Max: "+inf",
+	}).Result()
+	require.NoError(t, err)
+	assert.Len(t, membersB, 1)
+	assert.Equal(t, runB.ID.String(), membersB[0])
+
+	// Cancel tenant A's retry and verify tenant B is unaffected
+	err = w.CancelDunningRetry(ctx, tenantA, runA.ID)
+	require.NoError(t, err)
+
+	countA, err := client.ZCard(ctx, keyA).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), countA, "tenant A's ZSET should be empty after cancel")
+
+	countB, err := client.ZCard(ctx, keyB).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), countB, "tenant B's ZSET should be unaffected by tenant A's cancel")
+
+	mr.FlushAll()
+}
+
+func TestDunningWorker_TenantIsolation_Processing(t *testing.T) {
+	_, client := setupDunningMiniredis(t)
+	logger := dunningTestLogger()
+	metrics := dunningTestMetrics(t)
+
+	const tenantA = "tenant_alpha"
+	const tenantB = "tenant_beta"
+
+	repo := newMockBillingRepo()
+
+	runA := &domain.BillingRun{
+		ID:           uuid.New(),
+		TenantID:     tenantA,
+		Status:       domain.BillingRunStatusFailed,
+		DunningLevel: 1,
+		CycleStart:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		CycleEnd:     time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	runB := &domain.BillingRun{
+		ID:           uuid.New(),
+		TenantID:     tenantB,
+		Status:       domain.BillingRunStatusFailed,
+		DunningLevel: 1,
+		CycleStart:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		CycleEnd:     time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	repo.mu.Lock()
+	repo.runs[runA.ID] = runA
+	repo.runs[runB.ID] = runB
+	repo.mu.Unlock()
+
+	// Track which billing run IDs get processed using atomic counters
+	var processedA atomic.Bool
+	var processedB atomic.Bool
+	callback := func(_ context.Context, r *domain.BillingRun) error {
+		if r.ID == runA.ID {
+			processedA.Store(true)
+		}
+		if r.ID == runB.ID {
+			processedB.Store(true)
+		}
+		return nil
+	}
+
+	w, err := NewDunningWorker(repo, client, DunningWorkerConfig{
+		PollInterval:    50 * time.Millisecond,
+		ShutdownTimeout: 2 * time.Second,
+	}, callback, logger, metrics)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Schedule both in the past so they're immediately due
+	originalNowFunc := NowFunc
+	NowFunc = func() time.Time { return time.Now().UTC() }
+	defer func() { NowFunc = originalNowFunc }()
+
+	err = w.ScheduleDunningRetry(ctx, tenantA, runA.ID, -1*time.Minute)
+	require.NoError(t, err)
+	err = w.ScheduleDunningRetry(ctx, tenantB, runB.ID, -1*time.Minute)
+	require.NoError(t, err)
+
+	// Start worker and let it process
+	go func() {
+		_ = w.Start(context.Background())
+	}()
+
+	// Wait for both to be processed
+	deadline := time.After(5 * time.Second)
+	for !processedA.Load() || !processedB.Load() {
+		select {
+		case <-deadline:
+			t.Fatalf("expected both tenants processed, got A=%v B=%v", processedA.Load(), processedB.Load())
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	w.Stop()
+
+	// Both billing runs should have been processed
+	assert.True(t, processedA.Load(), "tenant A's billing run should have been processed")
+	assert.True(t, processedB.Load(), "tenant B's billing run should have been processed")
+
+	// Both tenant ZSETs should be empty
+	keyA := dunningRetryZSetPrefix + tenantA
+	keyB := dunningRetryZSetPrefix + tenantB
+	countA, err := client.ZCard(ctx, keyA).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), countA)
+
+	countB, err := client.ZCard(ctx, keyB).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), countB)
 }


### PR DESCRIPTION
## Summary

- Fixes cross-tenant data leak in the dunning retry worker where all tenants shared a single global Redis sorted set key (`dunning:retries`)
- The ZSET key is now tenant-scoped: `dunning:retries:{tenantID}`
- The poll loop uses `SCAN` to discover all tenant-scoped keys and processes each independently

## Changes Made

**`services/payment-order/worker/dunning_worker.go`**
- Renamed constant `dunningRetryZSet` to `dunningRetryZSetPrefix` (`dunning:retries:`)
- `ScheduleDunningRetry(ctx, tenantID, billingRunID, delay)` now requires tenant ID
- `CancelDunningRetry(ctx, tenantID, billingRunID)` now requires tenant ID
- `processDueRetries` uses `SCAN dunning:retries:*` to find all tenant keys, then processes each via `processDueRetriesForKey`
- Added `ErrDunningMissingTenant` sentinel error for empty tenant ID validation

**`services/payment-order/adapters/http/stripe_event_processor.go`**
- Renamed constant `dunningRetryZSet` to `dunningRetryZSetPrefix`
- `ScheduleDunning(ctx, tenantID, paymentOrderID)` now requires tenant ID

**`services/payment-order/adapters/http/stripe_webhook_handler.go`**
- Passes `tenantID.String()` from request context to `ScheduleDunning`

## Testing

- All existing tests updated for new tenant ID parameter
- Added `TestDunningWorker_TenantIsolation` - schedules retries for two tenants, verifies each tenant's ZSET contains only their own entries, cancels one and verifies the other is unaffected
- Added `TestDunningWorker_TenantIsolation_Processing` - schedules due retries for two tenants, starts the worker, verifies both are processed from their respective tenant-scoped keys
- Added `TestStripeEventProcessor_ScheduleDunning/tenant_isolation_between_tenants`
- Added empty tenant ID rejection tests for both `ScheduleDunningRetry` and `CancelDunningRetry`

## Risk Assessment

- **Breaking change**: `ScheduleDunningRetry`, `CancelDunningRetry`, and `ScheduleDunning` signatures changed (new `tenantID` parameter). All internal callers updated.
- **Migration**: Existing items in the old global `dunning:retries` key will not be processed by the new code. These will drain naturally as they age out, or can be manually migrated. Given dunning retries have short TTLs (24h default delay), the old key will be empty within a day of deployment.

## Deployment Notes

No database migration needed. Redis key format change only. Old `dunning:retries` key items will be orphaned and ignored; they will naturally expire or can be cleaned up with `DEL dunning:retries` after confirming all retries have been reprocessed.