### PR TITLE
fix: Add GetBalance request validation and response formatting

### DIFF
--- a/services/internal-bank-account/service/balance_service_test.go
+++ b/services/internal-bank-account/service/balance_service_test.go
@@ -467,14 +467,16 @@ func TestBalanceService_GetBalance_EmptyAccountIdReturnsInvalidArgument(t *testi
 
 	ctx := context.Background()
 
-	_, err = svc.GetBalance(ctx, &pb.GetBalanceRequest{
-		AccountId: "",
-	})
-	assert.Error(t, err)
-	st, ok := status.FromError(err)
-	require.True(t, ok)
-	assert.Equal(t, codes.InvalidArgument, st.Code())
-	assert.Contains(t, st.Message(), "account_id is required")
+	for _, accountID := range []string{"", "   ", "\t"} {
+		_, err = svc.GetBalance(ctx, &pb.GetBalanceRequest{
+			AccountId: accountID,
+		})
+		assert.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "account_id is required")
+	}
 }
 
 func TestBalanceService_GetBalance_MissingCurrentBalanceReturnsNilBalance(t *testing.T) {

--- a/services/internal-bank-account/service/balance_service_test.go
+++ b/services/internal-bank-account/service/balance_service_test.go
@@ -459,6 +459,106 @@ func TestBalanceService_MultipleBalanceTypes(t *testing.T) {
 	assert.Equal(t, "12500.00", balanceResp.CurrentBalance.Amount)
 }
 
+func TestBalanceService_GetBalance_EmptyAccountIdReturnsInvalidArgument(t *testing.T) {
+	repo := newMockRepository()
+	posClient := &mockPositionKeepingClient{}
+	svc, err := NewServiceWithClients(repo, posClient, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	_, err = svc.GetBalance(ctx, &pb.GetBalanceRequest{
+		AccountId: "",
+	})
+	assert.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "account_id is required")
+}
+
+func TestBalanceService_GetBalance_MissingCurrentBalanceReturnsNilBalance(t *testing.T) {
+	// Position Keeping returns balances but none is BALANCE_TYPE_CURRENT
+	repo := newMockRepository()
+	posClient := &mockPositionKeepingClient{
+		balances: []*positionkeepingv1.BalanceEntry{
+			{
+				BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_AVAILABLE,
+				Amount: &quantityv1.InstrumentAmount{
+					InstrumentCode: "USD",
+					Amount:         "5000.00",
+				},
+			},
+		},
+	}
+	svc, err := NewServiceWithClients(repo, posClient, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
+		AccountCode:     "CLR-USD-NOCUR",
+		Name:            "No Current Balance Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
+	})
+	require.NoError(t, err)
+
+	balanceResp, err := svc.GetBalance(ctx, &pb.GetBalanceRequest{
+		AccountId: createResp.Facility.AccountCode,
+	})
+	require.NoError(t, err)
+
+	// When no CURRENT balance exists, response should have nil current_balance
+	assert.Nil(t, balanceResp.CurrentBalance)
+	// as_of should still be populated
+	assert.NotNil(t, balanceResp.AsOf)
+	assert.Equal(t, createResp.Facility.AccountCode, balanceResp.AccountId)
+}
+
+func TestBalanceService_GetBalance_NilAsOfTimestampReturnsFallback(t *testing.T) {
+	// Position Keeping returns a CURRENT balance but no as_of timestamp
+	repo := newMockRepository()
+	posClient := &mockPositionKeepingClient{
+		balances: []*positionkeepingv1.BalanceEntry{
+			{
+				BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
+				Amount: &quantityv1.InstrumentAmount{
+					InstrumentCode: "USD",
+					Amount:         "7500.00",
+				},
+			},
+		},
+		asOfSet: true,
+		asOf:    nil, // Explicitly no as_of from Position Keeping
+	}
+	svc, err := NewServiceWithClients(repo, posClient, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
+		AccountCode:     "CLR-USD-NOASOF",
+		Name:            "No AsOf Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
+	})
+	require.NoError(t, err)
+
+	balanceResp, err := svc.GetBalance(ctx, &pb.GetBalanceRequest{
+		AccountId: createResp.Facility.AccountCode,
+	})
+	require.NoError(t, err)
+
+	// Balance should be present
+	assert.NotNil(t, balanceResp.CurrentBalance)
+	assert.Equal(t, "7500.00", balanceResp.CurrentBalance.Amount)
+	// as_of should be populated with a fallback timestamp even when PK returns nil
+	assert.NotNil(t, balanceResp.AsOf)
+}
+
 // ============================================================================
 // Performance Benchmarks
 // ============================================================================

--- a/services/internal-bank-account/service/server.go
+++ b/services/internal-bank-account/service/server.go
@@ -578,7 +578,7 @@ func (s *Service) GetBalance(ctx context.Context, req *pb.GetBalanceRequest) (*p
 		ibaobservability.RecordOperationDuration("get_balance", operationStatus, time.Since(start))
 	}()
 
-	if req.AccountId == "" {
+	if strings.TrimSpace(req.AccountId) == "" {
 		operationStatus = operationStatusFailed
 		return nil, status.Error(codes.InvalidArgument, "account_id is required")
 	}

--- a/services/internal-bank-account/service/server.go
+++ b/services/internal-bank-account/service/server.go
@@ -14,6 +14,7 @@ import (
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
 	"github.com/meridianhub/meridian/services/internal-bank-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/internal-bank-account/domain"
@@ -577,6 +578,11 @@ func (s *Service) GetBalance(ctx context.Context, req *pb.GetBalanceRequest) (*p
 		ibaobservability.RecordOperationDuration("get_balance", operationStatus, time.Since(start))
 	}()
 
+	if req.AccountId == "" {
+		operationStatus = operationStatusFailed
+		return nil, status.Error(codes.InvalidArgument, "account_id is required")
+	}
+
 	// Validate account exists and is active
 	account, err := s.findAccountByID(ctx, req.AccountId)
 	if err != nil {
@@ -621,30 +627,26 @@ func (s *Service) GetBalance(ctx context.Context, req *pb.GetBalanceRequest) (*p
 	// Record successful balance query duration (target <50ms p99)
 	ibaobservability.RecordBalanceQueryDuration(operationStatusSuccess, pkDuration)
 
+	// Resolve as_of: use Position Keeping's timestamp, fall back to current time
+	asOf := balanceResp.GetAsOf()
+	if asOf == nil {
+		asOf = timestamppb.Now()
+	}
+
 	// Find the current balance from the response.
-	// AsOf reflects the timestamp from Position Keeping when the balance was calculated.
-	var currentBalanceResp *pb.GetBalanceResponse
+	var currentBalance *quantityv1.InstrumentAmount
 	for _, entry := range balanceResp.GetBalances() {
 		if entry.GetBalanceType() == positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT {
-			currentBalanceResp = &pb.GetBalanceResponse{
-				AccountId:      req.AccountId,
-				CurrentBalance: entry.GetAmount(),
-				AsOf:           balanceResp.GetAsOf(), // Use Position Keeping's as_of timestamp
-			}
+			currentBalance = entry.GetAmount()
 			break
 		}
 	}
 
-	if currentBalanceResp == nil {
-		// No current balance found - return zero balance with current time
-		return &pb.GetBalanceResponse{
-			AccountId:      req.AccountId,
-			CurrentBalance: nil,
-			AsOf:           timestamppb.Now(),
-		}, nil
-	}
-
-	return currentBalanceResp, nil
+	return &pb.GetBalanceResponse{
+		AccountId:      req.AccountId,
+		CurrentBalance: currentBalance,
+		AsOf:           asOf,
+	}, nil
 }
 
 // mapPositionKeepingErrorToGRPC maps Position Keeping service errors to appropriate gRPC status codes.

--- a/services/internal-bank-account/service/server_test.go
+++ b/services/internal-bank-account/service/server_test.go
@@ -91,6 +91,8 @@ func (m *mockRepository) ExistsByCode(_ context.Context, accountCode string) (bo
 type mockPositionKeepingClient struct {
 	balances       []*positionkeepingv1.BalanceEntry
 	err            error
+	asOf           *timestamppb.Timestamp // optional override; nil means omit as_of from response
+	asOfSet        bool                   // true when asOf was explicitly set (even to nil)
 	singleBalance  *quantityv1.InstrumentAmount
 	singleBalError error
 }
@@ -99,10 +101,14 @@ func (m *mockPositionKeepingClient) GetAccountBalances(_ context.Context, req *p
 	if m.err != nil {
 		return nil, m.err
 	}
+	asOf := timestamppb.Now()
+	if m.asOfSet {
+		asOf = m.asOf
+	}
 	return &positionkeepingv1.GetAccountBalancesResponse{
 		AccountId: req.AccountId,
 		Balances:  m.balances,
-		AsOf:      timestamppb.Now(), // Provide timestamp for balance calculation time
+		AsOf:      asOf,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- Add empty `account_id` validation to `GetBalance` RPC, returning `InvalidArgument` before attempting database lookup
- Add `as_of` timestamp fallback when Position Keeping returns nil, ensuring response always has a populated timestamp
- Simplify response construction to handle missing CURRENT balance uniformly with the found-balance path

## Task Master

Tag: `account-service-wiring`, Task: 20

## Changes

### `services/internal-bank-account/service/server.go`
- Add `account_id == ""` guard at top of `GetBalance` returning `codes.InvalidArgument`
- Add `quantityv1` import for `InstrumentAmount` type reference
- Refactor balance response construction: resolve `asOf` once (with nil fallback), find `currentBalance` in loop, return single response struct

### `services/internal-bank-account/service/server_test.go`
- Add `asOf` and `asOfSet` fields to `mockPositionKeepingClient` for testing nil `as_of` scenarios
- Update `GetAccountBalances` mock to use optional `asOf` override

### `services/internal-bank-account/service/balance_service_test.go`
- `TestBalanceService_GetBalance_EmptyAccountIdReturnsInvalidArgument` - verifies empty account_id returns InvalidArgument
- `TestBalanceService_GetBalance_MissingCurrentBalanceReturnsNilBalance` - verifies response when PK has no CURRENT balance type
- `TestBalanceService_GetBalance_NilAsOfTimestampReturnsFallback` - verifies as_of fallback when PK returns nil timestamp

## Test Plan

- [x] All 14 balance service tests pass
- [x] All server unit tests pass (InitiateInternalBankAccount, ControlInternalBankAccount, etc.)
- [x] Build compiles cleanly
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)