### PR TITLE
feat: Add instrument definition lifecycle enforcement

### DIFF
--- a/services/reference-data/registry/instrument_status.go
+++ b/services/reference-data/registry/instrument_status.go
@@ -1,0 +1,66 @@
+// Package registry provides the InstrumentRegistry implementation backed by PostgreSQL.
+package registry
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Valid state transitions for instrument definitions:
+//
+//	DRAFT -> ACTIVE (activation)
+//	ACTIVE -> DEPRECATED (deprecation)
+//	DEPRECATED is terminal - no transitions allowed
+var validInstrumentStatusTransitions = map[Status]map[Status]bool{
+	StatusDraft: {
+		StatusActive: true,
+	},
+	StatusActive: {
+		StatusDeprecated: true,
+	},
+	StatusDeprecated: {
+		// Terminal state - no valid transitions
+	},
+}
+
+// CanTransitionTo checks if a transition from the current status to the target status is valid.
+func (s Status) CanTransitionTo(target Status) bool {
+	if s == target {
+		return false
+	}
+	allowed, exists := validInstrumentStatusTransitions[s]
+	if !exists {
+		return false
+	}
+	return allowed[target]
+}
+
+// ValidateStatusTransition checks if transitioning from one status to another is valid.
+// Returns an error if the transition is not allowed.
+func ValidateStatusTransition(from, to Status) error {
+	if from == to {
+		return fmt.Errorf("%w: source and target status are the same (%s)", ErrInvalidStateTransition, from)
+	}
+	if !from.CanTransitionTo(to) {
+		return fmt.Errorf("%w: cannot transition from %s to %s", ErrInvalidStateTransition, from, to)
+	}
+	return nil
+}
+
+// IsValid returns true if the status is a recognized valid value.
+func (s Status) IsValid() bool {
+	switch s {
+	case StatusDraft, StatusActive, StatusDeprecated:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the string representation of the status.
+func (s Status) String() string {
+	return string(s)
+}
+
+// ErrSuccessorWriteOnce is returned when attempting to change a successor_id that is already set.
+var ErrSuccessorWriteOnce = errors.New("cannot modify successor_id once set (write-once semantics)")

--- a/services/reference-data/registry/postgres_registry.go
+++ b/services/reference-data/registry/postgres_registry.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -399,7 +398,6 @@ func (r *PostgresRegistry) UpdateDefinition(ctx context.Context, code string, ve
 // ActivateInstrument transitions an instrument from DRAFT to ACTIVE.
 func (r *PostgresRegistry) ActivateInstrument(ctx context.Context, code string, version int) error {
 	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
-		// Check current state
 		var isSystem bool
 		var currentStatus string
 
@@ -416,11 +414,10 @@ func (r *PostgresRegistry) ActivateInstrument(ctx context.Context, code string, 
 			return ErrSystemInstrumentReadOnly
 		}
 
-		if currentStatus != string(StatusDraft) {
+		if err := ValidateStatusTransition(Status(currentStatus), StatusActive); err != nil {
 			return ErrNotDraft
 		}
 
-		// Transition to ACTIVE
 		now := time.Now()
 		updateQuery := `
 			UPDATE instrument_definition SET
@@ -439,16 +436,21 @@ func (r *PostgresRegistry) ActivateInstrument(ctx context.Context, code string, 
 }
 
 // DeprecateInstrument transitions an instrument from ACTIVE to DEPRECATED.
-// If successorID is provided, the database trigger validates that the successor exists,
-// is ACTIVE, and has the same dimension as the deprecated instrument.
+// Successor validation is enforced at the Go application layer (CockroachDB does not support PL/pgSQL triggers):
+// the successor must exist, be ACTIVE, have the same dimension, and not be self-referential.
+// Successor ID is write-once: once set, it cannot be changed.
 func (r *PostgresRegistry) DeprecateInstrument(ctx context.Context, code string, version int, successorID *uuid.UUID) error {
 	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
-		// Check current state
+		var instrumentID uuid.UUID
 		var isSystem bool
 		var currentStatus string
+		var currentDimension string
+		var existingSuccessorID *uuid.UUID
 
-		checkQuery := `SELECT is_system, status FROM instrument_definition WHERE code = $1 AND version = $2`
-		err := tx.QueryRow(ctx, checkQuery, code, version).Scan(&isSystem, &currentStatus)
+		checkQuery := `SELECT id, is_system, status, dimension, successor_id
+			FROM instrument_definition WHERE code = $1 AND version = $2`
+		err := tx.QueryRow(ctx, checkQuery, code, version).Scan(
+			&instrumentID, &isSystem, &currentStatus, &currentDimension, &existingSuccessorID)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return ErrNotFound
@@ -460,11 +462,22 @@ func (r *PostgresRegistry) DeprecateInstrument(ctx context.Context, code string,
 			return ErrSystemInstrumentReadOnly
 		}
 
-		if currentStatus != string(StatusActive) {
+		if err := ValidateStatusTransition(Status(currentStatus), StatusDeprecated); err != nil {
 			return ErrNotActive
 		}
 
-		// Transition to DEPRECATED with optional successor
+		// Enforce write-once semantics for successor_id
+		if existingSuccessorID != nil && successorID != nil && *existingSuccessorID != *successorID {
+			return ErrSuccessorWriteOnce
+		}
+
+		// Validate successor if provided
+		if successorID != nil {
+			if err := r.validateSuccessor(ctx, tx, instrumentID, *successorID, currentDimension); err != nil {
+				return err
+			}
+		}
+
 		now := time.Now()
 		updateQuery := `
 			UPDATE instrument_definition SET
@@ -476,28 +489,41 @@ func (r *PostgresRegistry) DeprecateInstrument(ctx context.Context, code string,
 
 		_, err = tx.Exec(ctx, updateQuery, now, code, version, successorID)
 		if err != nil {
-			// Check if the error is from the successor validation trigger
-			var pgErr *pgconn.PgError
-			if errors.As(err, &pgErr) && pgErr.Code == "P0001" { // raise_exception
-				// Map specific trigger errors based on error message
-				msg := pgErr.Message
-				msgLower := strings.ToLower(msg)
-				switch {
-				case strings.Contains(msgLower, "successor"):
-					return ErrSuccessorInvalid
-				case strings.Contains(msgLower, "cannot transition"):
-					return ErrInvalidStateTransition
-				case strings.Contains(msgLower, "cannot modify"):
-					return ErrInvalidStatus
-				default:
-					return fmt.Errorf("%w: %s", ErrInvalidStatus, msg)
-				}
-			}
 			return fmt.Errorf("failed to deprecate instrument: %w", err)
 		}
 
 		return nil
 	})
+}
+
+// validateSuccessor checks that a proposed successor instrument is valid.
+// It must exist, be ACTIVE, have the same dimension, and not be the instrument itself.
+func (r *PostgresRegistry) validateSuccessor(ctx context.Context, tx pgx.Tx, instrumentID, successorID uuid.UUID, requiredDimension string) error {
+	// Cannot designate self as successor
+	if successorID == instrumentID {
+		return ErrSuccessorInvalid
+	}
+
+	var successorStatus string
+	var successorDimension string
+	query := `SELECT status, dimension FROM instrument_definition WHERE id = $1`
+	err := tx.QueryRow(ctx, query, successorID).Scan(&successorStatus, &successorDimension)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrSuccessorInvalid
+		}
+		return fmt.Errorf("failed to query successor instrument: %w", err)
+	}
+
+	if successorStatus != string(StatusActive) {
+		return ErrSuccessorInvalid
+	}
+
+	if successorDimension != requiredDimension {
+		return ErrSuccessorInvalid
+	}
+
+	return nil
 }
 
 // ValidateAttributes executes the CEL validation expression against the provided attributes.

--- a/services/reference-data/registry/postgres_registry_test.go
+++ b/services/reference-data/registry/postgres_registry_test.go
@@ -879,42 +879,163 @@ func TestPostgresRegistry_SuccessorWriteOnce(t *testing.T) {
 	require.NoError(t, reg.CreateDraft(ctx, successor1))
 	require.NoError(t, reg.ActivateInstrument(ctx, "WRITEONCE_NEW1", 1))
 
-	successor2 := &registry.InstrumentDefinition{
-		Code:      "WRITEONCE_NEW2",
+	t.Run("deprecate with successor succeeds first time", func(t *testing.T) {
+		err := reg.DeprecateInstrument(ctx, "WRITEONCE_OLD", 1, &successor1.ID)
+		require.NoError(t, err)
+
+		result, err := reg.GetDefinition(ctx, "WRITEONCE_OLD", 1)
+		require.NoError(t, err)
+		assert.Equal(t, successor1.ID, *result.SuccessorID)
+	})
+
+	t.Run("deprecate already deprecated instrument fails", func(t *testing.T) {
+		// The instrument is already DEPRECATED, so trying to deprecate again
+		// should fail with ErrNotActive (state machine rejects DEPRECATED->DEPRECATED)
+		successor2 := &registry.InstrumentDefinition{
+			Code:      "WRITEONCE_NEW2",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, successor2))
+		require.NoError(t, reg.ActivateInstrument(ctx, "WRITEONCE_NEW2", 1))
+
+		err := reg.DeprecateInstrument(ctx, "WRITEONCE_OLD", 1, &successor2.ID)
+		require.ErrorIs(t, err, registry.ErrNotActive)
+	})
+}
+
+func TestPostgresRegistry_StatusStateMachine(t *testing.T) {
+	t.Run("valid transitions", func(t *testing.T) {
+		assert.NoError(t, registry.ValidateStatusTransition(registry.StatusDraft, registry.StatusActive))
+		assert.NoError(t, registry.ValidateStatusTransition(registry.StatusActive, registry.StatusDeprecated))
+	})
+
+	t.Run("invalid transitions", func(t *testing.T) {
+		// ACTIVE -> DRAFT
+		err := registry.ValidateStatusTransition(registry.StatusActive, registry.StatusDraft)
+		require.ErrorIs(t, err, registry.ErrInvalidStateTransition)
+
+		// DEPRECATED -> DRAFT
+		err = registry.ValidateStatusTransition(registry.StatusDeprecated, registry.StatusDraft)
+		require.ErrorIs(t, err, registry.ErrInvalidStateTransition)
+
+		// DEPRECATED -> ACTIVE
+		err = registry.ValidateStatusTransition(registry.StatusDeprecated, registry.StatusActive)
+		require.ErrorIs(t, err, registry.ErrInvalidStateTransition)
+
+		// DRAFT -> DEPRECATED (not allowed for instrument definitions)
+		err = registry.ValidateStatusTransition(registry.StatusDraft, registry.StatusDeprecated)
+		require.ErrorIs(t, err, registry.ErrInvalidStateTransition)
+
+		// Same status
+		err = registry.ValidateStatusTransition(registry.StatusActive, registry.StatusActive)
+		require.ErrorIs(t, err, registry.ErrInvalidStateTransition)
+	})
+
+	t.Run("IsValid", func(t *testing.T) {
+		assert.True(t, registry.StatusDraft.IsValid())
+		assert.True(t, registry.StatusActive.IsValid())
+		assert.True(t, registry.StatusDeprecated.IsValid())
+		assert.False(t, registry.Status("UNKNOWN").IsValid())
+	})
+
+	t.Run("CanTransitionTo", func(t *testing.T) {
+		assert.True(t, registry.StatusDraft.CanTransitionTo(registry.StatusActive))
+		assert.True(t, registry.StatusActive.CanTransitionTo(registry.StatusDeprecated))
+		assert.False(t, registry.StatusActive.CanTransitionTo(registry.StatusDraft))
+		assert.False(t, registry.StatusDeprecated.CanTransitionTo(registry.StatusActive))
+		assert.False(t, registry.StatusDraft.CanTransitionTo(registry.StatusDraft))
+	})
+}
+
+func TestPostgresRegistry_DeprecatedIsTerminal(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-terminal")
+
+	// Create, activate, deprecate
+	def := &registry.InstrumentDefinition{
+		Code:      "TERMINAL1",
 		Version:   1,
 		Dimension: registry.DimensionMonetary,
 		Precision: 2,
 	}
-	require.NoError(t, reg.CreateDraft(ctx, successor2))
-	require.NoError(t, reg.ActivateInstrument(ctx, "WRITEONCE_NEW2", 1))
+	require.NoError(t, reg.CreateDraft(ctx, def))
+	require.NoError(t, reg.ActivateInstrument(ctx, "TERMINAL1", 1))
+	require.NoError(t, reg.DeprecateInstrument(ctx, "TERMINAL1", 1, nil))
 
-	t.Run("cannot change successor_id once set", func(t *testing.T) {
-		// Deprecate with first successor
-		err := reg.DeprecateInstrument(ctx, "WRITEONCE_OLD", 1, &successor1.ID)
+	t.Run("cannot activate deprecated instrument", func(t *testing.T) {
+		err := reg.ActivateInstrument(ctx, "TERMINAL1", 1)
+		require.ErrorIs(t, err, registry.ErrNotDraft)
+	})
+
+	t.Run("cannot deprecate already deprecated instrument", func(t *testing.T) {
+		err := reg.DeprecateInstrument(ctx, "TERMINAL1", 1, nil)
+		require.ErrorIs(t, err, registry.ErrNotActive)
+	})
+
+	t.Run("cannot update deprecated instrument", func(t *testing.T) {
+		updates := &registry.InstrumentDefinition{
+			DisplayName: "Should fail",
+		}
+		err := reg.UpdateDefinition(ctx, "TERMINAL1", 1, updates)
+		require.ErrorIs(t, err, registry.ErrNotDraft)
+	})
+}
+
+func TestPostgresRegistry_UpdatedAtManagement(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-timestamps")
+
+	def := &registry.InstrumentDefinition{
+		Code:      "TIMESTAMP1",
+		Version:   1,
+		Dimension: registry.DimensionMonetary,
+		Precision: 2,
+	}
+	require.NoError(t, reg.CreateDraft(ctx, def))
+
+	t.Run("updated_at advances on update", func(t *testing.T) {
+		original, err := reg.GetDefinition(ctx, "TIMESTAMP1", 1)
 		require.NoError(t, err)
 
-		// Verify successor was set
-		result, err := reg.GetDefinition(ctx, "WRITEONCE_OLD", 1)
+		time.Sleep(10 * time.Millisecond)
+
+		updates := &registry.InstrumentDefinition{
+			DisplayName: "Updated Name",
+		}
+		require.NoError(t, reg.UpdateDefinition(ctx, "TIMESTAMP1", 1, updates))
+
+		updated, err := reg.GetDefinition(ctx, "TIMESTAMP1", 1)
 		require.NoError(t, err)
-		assert.Equal(t, successor1.ID, *result.SuccessorID)
+		assert.True(t, updated.UpdatedAt.After(original.UpdatedAt))
+	})
 
-		// Try to change successor - this should fail via trigger
-		// We need to attempt an UPDATE directly since the API doesn't expose this
-		// The trigger should reject this attempt
-		tenantID, _ := tenant.FromContext(ctx)
-		schemaName := tenantID.SchemaName()
-
-		tx, err := pool.Begin(ctx)
+	t.Run("updated_at advances on activation", func(t *testing.T) {
+		before, err := reg.GetDefinition(ctx, "TIMESTAMP1", 1)
 		require.NoError(t, err)
 
-		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+		time.Sleep(10 * time.Millisecond)
+
+		require.NoError(t, reg.ActivateInstrument(ctx, "TIMESTAMP1", 1))
+
+		after, err := reg.GetDefinition(ctx, "TIMESTAMP1", 1)
+		require.NoError(t, err)
+		assert.True(t, after.UpdatedAt.After(before.UpdatedAt))
+		assert.NotNil(t, after.ActivatedAt)
+	})
+
+	t.Run("updated_at advances on deprecation", func(t *testing.T) {
+		before, err := reg.GetDefinition(ctx, "TIMESTAMP1", 1)
 		require.NoError(t, err)
 
-		_, err = tx.Exec(ctx, `UPDATE instrument_definition SET successor_id = $1 WHERE code = 'WRITEONCE_OLD' AND version = 1`, successor2.ID)
-		// Should fail due to write-once trigger
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "write-once")
+		time.Sleep(10 * time.Millisecond)
 
-		_ = tx.Rollback(ctx)
+		require.NoError(t, reg.DeprecateInstrument(ctx, "TIMESTAMP1", 1, nil))
+
+		after, err := reg.GetDefinition(ctx, "TIMESTAMP1", 1)
+		require.NoError(t, err)
+		assert.True(t, after.UpdatedAt.After(before.UpdatedAt))
+		assert.NotNil(t, after.DeprecatedAt)
 	})
 }


### PR DESCRIPTION
## Summary

Move instrument definition lifecycle enforcement from PL/pgSQL triggers to the Go application layer for CockroachDB compatibility.

- Add `Status` state machine with `CanTransitionTo()`, `ValidateStatusTransition()`, `IsValid()` following the pattern in `services/market-information/domain/dataset_status.go`
- Replace trigger-based successor validation with Go-layer checks in `DeprecateInstrument()`: existence, ACTIVE status, same dimension, not self-referential
- Add `ErrSuccessorWriteOnce` for write-once semantics enforcement
- Remove `pgconn.PgError` P0001 trigger error mapping from `DeprecateInstrument()`
- Add tests: terminal state enforcement, state machine unit tests, `updated_at` timestamp management, successor write-once via API

## Task Master

Tag: `tilt-fixes`, Task: `2` - Go-layer instrument definition lifecycle enforcement

## Test plan

- [x] All 16 existing + new test functions pass (43 subtests)
- [x] State machine unit tests cover valid/invalid transitions, `IsValid`, `CanTransitionTo`
- [x] DEPRECATED terminal state: cannot activate, deprecate, or update
- [x] `updated_at` advances on update, activation, and deprecation
- [x] Successor write-once enforced via API (DEPRECATED instrument rejects re-deprecation)
- [x] Pre-commit hooks pass (gitleaks, gofumpt, golangci-lint)