### PR TITLE
fix: Align OpenTelemetry semconv imports to v1.39.0

### DIFF
--- a/shared/platform/observability/grpc.go
+++ b/shared/platform/observability/grpc.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -86,8 +86,8 @@ func (t *Tracer) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 		ctx, span := t.Start(ctx, info.FullMethod,
 			trace.WithSpanKind(trace.SpanKindServer),
 			trace.WithAttributes(
-				semconv.RPCSystemKey.String("grpc"),
-				semconv.RPCServiceKey.String(service),
+				semconv.RPCSystemNameKey.String("grpc"),
+				attribute.String("rpc.service", service),
 				semconv.RPCMethodKey.String(method),
 			),
 		)
@@ -154,8 +154,8 @@ func (t *Tracer) StreamServerInterceptor() grpc.StreamServerInterceptor {
 		ctx, span := t.Start(ctx, info.FullMethod,
 			trace.WithSpanKind(trace.SpanKindServer),
 			trace.WithAttributes(
-				semconv.RPCSystemKey.String("grpc"),
-				semconv.RPCServiceKey.String(service),
+				semconv.RPCSystemNameKey.String("grpc"),
+				attribute.String("rpc.service", service),
 				semconv.RPCMethodKey.String(method),
 				attribute.Bool("rpc.stream", true),
 			),
@@ -267,8 +267,8 @@ func (t *Tracer) UnaryClientInterceptor() grpc.UnaryClientInterceptor {
 		ctx, span := t.Start(ctx, method,
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(
-				semconv.RPCSystemKey.String("grpc"),
-				semconv.RPCServiceKey.String(service),
+				semconv.RPCSystemNameKey.String("grpc"),
+				attribute.String("rpc.service", service),
 				semconv.RPCMethodKey.String(methodName),
 			),
 		)
@@ -330,8 +330,8 @@ func (t *Tracer) StreamClientInterceptor() grpc.StreamClientInterceptor {
 		ctx, span := t.Start(ctx, method,
 			trace.WithSpanKind(trace.SpanKindClient),
 			trace.WithAttributes(
-				semconv.RPCSystemKey.String("grpc"),
-				semconv.RPCServiceKey.String(service),
+				semconv.RPCSystemNameKey.String("grpc"),
+				attribute.String("rpc.service", service),
 				semconv.RPCMethodKey.String(methodName),
 				attribute.Bool("rpc.stream", true),
 			),

--- a/shared/platform/observability/helpers.go
+++ b/shared/platform/observability/helpers.go
@@ -8,7 +8,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/shared/platform/observability/semconv_integration_test.go
+++ b/shared/platform/observability/semconv_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
 )
 
 // newTestTracerWithExporter creates a tracer with an in-memory exporter for testing


### PR DESCRIPTION
## Summary

- Align all observability package semconv imports to v1.39.0, the latest semantic conventions version available in the OTel Go SDK v1.40.0
- Previously grpc.go and helpers.go used v1.37.0 while tracing.go already used v1.39.0
- Update grpc.go to use `RPCSystemNameKey` (replacing removed `RPCSystemKey`) and inline `attribute.String("rpc.service", ...)` (replacing removed `RPCServiceKey`)

## Context

Task tilt-fixes.4. The original task specified "v1.40.0" but semconv v1.40.0 does not exist as a package -- semconv versions follow the OpenTelemetry Semantic Conventions spec versioning (currently v1.39.0), not the Go SDK version (v1.40.0). v1.39.0 is the highest available.

## Test plan

- [x] `go build ./shared/platform/observability/...` compiles successfully
- [x] `go test -v ./shared/platform/observability/...` all tests pass
- [x] `go vet ./shared/platform/observability/...` no issues
- [x] Pre-commit hooks (gofumpt, golangci-lint, gitleaks) all pass