### PR TITLE
feat: Implement Onfido provider adapter

### DIFF
--- a/services/party/verification/factory.go
+++ b/services/party/verification/factory.go
@@ -3,6 +3,7 @@ package verification
 
 import (
 	"errors"
+	"log/slog"
 	"strings"
 
 	"github.com/meridianhub/meridian/services/party/config"
@@ -18,10 +19,10 @@ var (
 //
 // Currently supported providers:
 //   - "mock": Returns a MockProvider for testing and development
+//   - "onfido": Onfido identity verification
 //
 // Future providers (stubs, not yet implemented):
 //   - "jumio": Jumio identity verification
-//   - "onfido": Onfido identity verification
 //
 // Returns ErrUnsupportedProvider for any unrecognized provider name.
 // The MockProvider is configured with AlwaysApprove=true by default.
@@ -38,8 +39,7 @@ func NewProvider(cfg *config.VerificationConfig) (Provider, error) {
 		// Jumio provider not yet implemented
 		return nil, ErrUnsupportedProvider
 	case "onfido":
-		// Onfido provider not yet implemented
-		return nil, ErrUnsupportedProvider
+		return NewOnfidoProvider(cfg, slog.Default())
 	default:
 		return nil, ErrUnsupportedProvider
 	}
@@ -77,7 +77,7 @@ func NewProviderWithOptions(cfg *config.VerificationConfig, opts ProviderOptions
 	case "jumio":
 		return nil, ErrUnsupportedProvider
 	case "onfido":
-		return nil, ErrUnsupportedProvider
+		return NewOnfidoProvider(cfg, slog.Default())
 	default:
 		return nil, ErrUnsupportedProvider
 	}

--- a/services/party/verification/factory_test.go
+++ b/services/party/verification/factory_test.go
@@ -63,7 +63,7 @@ func TestNewProvider_JumioProvider_NotImplemented(t *testing.T) {
 	assert.ErrorIs(t, err, ErrUnsupportedProvider)
 }
 
-func TestNewProvider_OnfidoProvider_NotImplemented(t *testing.T) {
+func TestNewProvider_OnfidoProvider(t *testing.T) {
 	cfg := &config.VerificationConfig{
 		Provider:       "onfido",
 		WebhookSecret:  "secret",
@@ -73,8 +73,11 @@ func TestNewProvider_OnfidoProvider_NotImplemented(t *testing.T) {
 
 	provider, err := NewProvider(cfg)
 
-	assert.Nil(t, provider)
-	assert.ErrorIs(t, err, ErrUnsupportedProvider)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	_, ok := provider.(*OnfidoProvider)
+	assert.True(t, ok, "expected *OnfidoProvider type")
 }
 
 func TestNewProvider_UnknownProvider(t *testing.T) {
@@ -171,7 +174,7 @@ func TestNewProviderWithOptions_RespectsAsyncMode(t *testing.T) {
 }
 
 func TestNewProviderWithOptions_NonMockProvider_ReturnsError(t *testing.T) {
-	testCases := []string{"jumio", "onfido", "unknown"}
+	testCases := []string{"jumio", "unknown"}
 
 	for _, providerName := range testCases {
 		t.Run(providerName, func(t *testing.T) {
@@ -188,4 +191,21 @@ func TestNewProviderWithOptions_NonMockProvider_ReturnsError(t *testing.T) {
 			assert.ErrorIs(t, err, ErrUnsupportedProvider)
 		})
 	}
+}
+
+func TestNewProviderWithOptions_OnfidoProvider(t *testing.T) {
+	cfg := &config.VerificationConfig{
+		Provider:       "onfido",
+		WebhookSecret:  "secret",
+		WebhookURL:     "https://example.com/webhook",
+		ProviderConfig: map[string]string{"api_key": "key", "api_secret": "secret"},
+	}
+
+	provider, err := NewProviderWithOptions(cfg, DefaultProviderOptions())
+
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	_, ok := provider.(*OnfidoProvider)
+	assert.True(t, ok, "expected *OnfidoProvider type")
 }

--- a/services/party/verification/onfido_provider.go
+++ b/services/party/verification/onfido_provider.go
@@ -1,0 +1,433 @@
+package verification
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/meridianhub/meridian/services/party/config"
+	"github.com/meridianhub/meridian/services/party/domain"
+)
+
+const (
+	onfidoDefaultBaseURL = "https://api.onfido.com/v3.6"
+	onfidoHTTPTimeout    = 30 * time.Second
+)
+
+// Onfido-specific errors
+var (
+	ErrOnfidoMissingAPIKey  = errors.New("onfido: api_key is required in provider config")
+	ErrOnfidoUnauthorized   = errors.New("onfido: unauthorized - check API token")
+	ErrOnfidoRateLimited    = errors.New("onfido: rate limited - retry later")
+	ErrOnfidoServerError    = errors.New("onfido: server error")
+	ErrOnfidoValidationFail = errors.New("onfido: validation error")
+)
+
+// OnfidoProvider implements the Provider interface using the Onfido API.
+type OnfidoProvider struct {
+	apiToken string
+	baseURL  string
+	client   *http.Client
+	logger   *slog.Logger
+}
+
+// Ensure OnfidoProvider implements Provider at compile time.
+var _ Provider = (*OnfidoProvider)(nil)
+
+// NewOnfidoProvider creates a new OnfidoProvider from the given configuration.
+func NewOnfidoProvider(cfg *config.VerificationConfig, logger *slog.Logger) (*OnfidoProvider, error) {
+	apiKey := cfg.ProviderConfig["api_key"]
+	if apiKey == "" {
+		return nil, ErrOnfidoMissingAPIKey
+	}
+
+	baseURL := cfg.ProviderConfig["base_url"]
+	if baseURL == "" {
+		baseURL = onfidoDefaultBaseURL
+	}
+
+	return &OnfidoProvider{
+		apiToken: apiKey,
+		baseURL:  baseURL,
+		client: &http.Client{
+			Timeout: onfidoHTTPTimeout,
+		},
+		logger: logger,
+	}, nil
+}
+
+// onfidoApplicantRequest is the request body for creating an Onfido applicant.
+type onfidoApplicantRequest struct {
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+}
+
+// onfidoApplicantResponse is the response from creating an Onfido applicant.
+type onfidoApplicantResponse struct {
+	ID        string `json:"id"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+}
+
+// onfidoCheckRequest is the request body for creating an Onfido check.
+type onfidoCheckRequest struct {
+	ApplicantID string   `json:"applicant_id"`
+	ReportNames []string `json:"report_names"`
+}
+
+// onfidoCheckResponse is the response from creating or retrieving an Onfido check.
+type onfidoCheckResponse struct {
+	ID          string `json:"id"`
+	Status      string `json:"status"`
+	Result      string `json:"result"`
+	ApplicantID string `json:"applicant_id"`
+}
+
+// onfidoErrorResponse is the error response from the Onfido API.
+type onfidoErrorResponse struct {
+	Error struct {
+		Type    string            `json:"type"`
+		Message string            `json:"message"`
+		Fields  map[string]string `json:"fields"`
+	} `json:"error"`
+}
+
+// VerifyIdentity creates an Onfido applicant and initiates an identity check.
+func (p *OnfidoProvider) VerifyIdentity(ctx context.Context, party *domain.Party) (Result, error) {
+	p.logger.Info("initiating identity verification",
+		slog.String("party_id", party.ID().String()),
+		slog.String("party_type", string(party.PartyType())),
+	)
+
+	// Create applicant
+	firstName, lastName := splitName(party.LegalName())
+	applicant, err := p.createApplicant(ctx, firstName, lastName)
+	if err != nil {
+		return Result{}, fmt.Errorf("onfido: create applicant: %w", err)
+	}
+
+	// Create identity check
+	check, err := p.createCheck(ctx, applicant.ID, []string{"identity_enhanced"})
+	if err != nil {
+		return Result{}, fmt.Errorf("onfido: create check: %w", err)
+	}
+
+	status, reason, riskScore := mapOnfidoCheckStatus(check.Status, check.Result)
+
+	var completedAt *time.Time
+	if status != StatusPending {
+		now := time.Now()
+		completedAt = &now
+	}
+
+	result := Result{
+		VerificationID: check.ID,
+		Status:         status,
+		Reason:         reason,
+		RiskScore:      riskScore,
+		CompletedAt:    completedAt,
+		Metadata: map[string]string{
+			"provider":     "onfido",
+			"applicant_id": applicant.ID,
+			"party_id":     party.ID().String(),
+			"party_type":   string(party.PartyType()),
+			"check_status": check.Status,
+			"check_result": check.Result,
+		},
+	}
+
+	p.logger.Info("identity verification initiated",
+		slog.String("verification_id", check.ID),
+		slog.String("status", string(status)),
+	)
+
+	return result, nil
+}
+
+// CheckSanctions creates an Onfido applicant and initiates a watchlist check.
+func (p *OnfidoProvider) CheckSanctions(ctx context.Context, party *domain.Party) (SanctionsResult, error) {
+	p.logger.Info("initiating sanctions screening",
+		slog.String("party_id", party.ID().String()),
+		slog.String("party_name", party.LegalName()),
+	)
+
+	// Create applicant
+	firstName, lastName := splitName(party.LegalName())
+	applicant, err := p.createApplicant(ctx, firstName, lastName)
+	if err != nil {
+		return SanctionsResult{}, fmt.Errorf("onfido: create applicant: %w", err)
+	}
+
+	// Create watchlist check
+	check, err := p.createCheck(ctx, applicant.ID, []string{"watchlist_enhanced"})
+	if err != nil {
+		return SanctionsResult{}, fmt.Errorf("onfido: create check: %w", err)
+	}
+
+	sanctionsStatus, matches := mapOnfidoSanctionsStatus(check.Status, check.Result)
+
+	result := SanctionsResult{
+		ScreeningID: check.ID,
+		Status:      sanctionsStatus,
+		Matches:     matches,
+		ScreenedAt:  time.Now(),
+		Metadata: map[string]string{
+			"provider":     "onfido",
+			"applicant_id": applicant.ID,
+			"party_id":     party.ID().String(),
+			"check_status": check.Status,
+			"check_result": check.Result,
+		},
+	}
+
+	p.logger.Info("sanctions screening initiated",
+		slog.String("screening_id", check.ID),
+		slog.String("status", string(sanctionsStatus)),
+	)
+
+	return result, nil
+}
+
+// GetVerificationStatus retrieves the current status of an Onfido check.
+func (p *OnfidoProvider) GetVerificationStatus(ctx context.Context, verificationID string) (Result, error) {
+	p.logger.Info("retrieving verification status",
+		slog.String("verification_id", verificationID),
+	)
+
+	check, err := p.getCheck(ctx, verificationID)
+	if err != nil {
+		return Result{}, fmt.Errorf("onfido: get check: %w", err)
+	}
+
+	status, reason, riskScore := mapOnfidoCheckStatus(check.Status, check.Result)
+
+	var completedAt *time.Time
+	if status != StatusPending {
+		now := time.Now()
+		completedAt = &now
+	}
+
+	result := Result{
+		VerificationID: check.ID,
+		Status:         status,
+		Reason:         reason,
+		RiskScore:      riskScore,
+		CompletedAt:    completedAt,
+		Metadata: map[string]string{
+			"provider":     "onfido",
+			"check_status": check.Status,
+			"check_result": check.Result,
+		},
+	}
+
+	return result, nil
+}
+
+// createApplicant creates a new applicant in Onfido.
+func (p *OnfidoProvider) createApplicant(ctx context.Context, firstName, lastName string) (*onfidoApplicantResponse, error) {
+	reqBody := onfidoApplicantRequest{
+		FirstName: firstName,
+		LastName:  lastName,
+	}
+
+	var resp onfidoApplicantResponse
+	if err := p.postJSON(ctx, "/applicants", reqBody, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// createCheck creates a new check in Onfido.
+func (p *OnfidoProvider) createCheck(ctx context.Context, applicantID string, reportNames []string) (*onfidoCheckResponse, error) {
+	reqBody := onfidoCheckRequest{
+		ApplicantID: applicantID,
+		ReportNames: reportNames,
+	}
+
+	var resp onfidoCheckResponse
+	if err := p.postJSON(ctx, "/checks", reqBody, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// getCheck retrieves a check by ID from Onfido.
+func (p *OnfidoProvider) getCheck(ctx context.Context, checkID string) (*onfidoCheckResponse, error) {
+	var resp onfidoCheckResponse
+	if err := p.getJSON(ctx, "/checks/"+checkID, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// postJSON sends a POST request with JSON body and decodes the response.
+func (p *OnfidoProvider) postJSON(ctx context.Context, path string, body interface{}, result interface{}) error {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+path, bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Token token="+p.apiToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	p.logger.Debug("sending POST request",
+		slog.String("path", path),
+	)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return p.handleResponse(resp, result)
+}
+
+// getJSON sends a GET request and decodes the JSON response.
+func (p *OnfidoProvider) getJSON(ctx context.Context, path string, result interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Token token="+p.apiToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	p.logger.Debug("sending GET request",
+		slog.String("path", path),
+	)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return p.handleResponse(resp, result)
+}
+
+// handleResponse processes the HTTP response and decodes the JSON body.
+func (p *OnfidoProvider) handleResponse(resp *http.Response, result interface{}) error {
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		if err := json.Unmarshal(respBody, result); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+		return nil
+
+	case resp.StatusCode == http.StatusUnauthorized:
+		p.logger.Error("authentication failed",
+			slog.Int("status_code", resp.StatusCode),
+		)
+		return ErrOnfidoUnauthorized
+
+	case resp.StatusCode == http.StatusTooManyRequests:
+		p.logger.Warn("rate limited by Onfido API",
+			slog.Int("status_code", resp.StatusCode),
+		)
+		return ErrOnfidoRateLimited
+
+	case resp.StatusCode == http.StatusNotFound:
+		return ErrVerificationNotFound
+
+	default:
+		var onfidoErr onfidoErrorResponse
+		if jsonErr := json.Unmarshal(respBody, &onfidoErr); jsonErr == nil && onfidoErr.Error.Message != "" {
+			p.logger.Error("onfido API error",
+				slog.Int("status_code", resp.StatusCode),
+				slog.String("error_type", onfidoErr.Error.Type),
+				slog.String("error_message", onfidoErr.Error.Message),
+			)
+			return fmt.Errorf("%w: %s: %s", ErrOnfidoValidationFail, onfidoErr.Error.Type, onfidoErr.Error.Message)
+		}
+
+		p.logger.Error("unexpected API response",
+			slog.Int("status_code", resp.StatusCode),
+		)
+		return fmt.Errorf("%w: status %d", ErrOnfidoServerError, resp.StatusCode)
+	}
+}
+
+// splitName splits a full name into first and last name components.
+// If the name contains no space, the entire name is used as the first name
+// and the last name defaults to "-" (Onfido requires a last name).
+func splitName(fullName string) (string, string) {
+	parts := strings.SplitN(fullName, " ", 2)
+	if len(parts) == 1 {
+		return parts[0], "-"
+	}
+	return parts[0], parts[1]
+}
+
+// mapOnfidoCheckStatus maps Onfido check status and result to our domain types.
+func mapOnfidoCheckStatus(onfidoStatus, onfidoResult string) (Status, string, float64) {
+	switch onfidoStatus {
+	case "in_progress", "awaiting_applicant":
+		return StatusPending, "Verification in progress", 0.0
+
+	case "complete":
+		switch onfidoResult {
+		case "clear":
+			return StatusApproved, "Identity verification passed", 0.1
+		case "consider":
+			return StatusManualReview, "Verification requires manual review", 0.5
+		default:
+			return StatusRejected, "Identity verification failed", 0.9
+		}
+
+	case "withdrawn", "cancelled":
+		return StatusRejected, "Verification was cancelled", 0.0
+
+	case "paused":
+		return StatusManualReview, "Verification paused - manual review required", 0.5
+
+	default:
+		return StatusPending, "Unknown status: " + onfidoStatus, 0.0
+	}
+}
+
+// mapOnfidoSanctionsStatus maps Onfido watchlist check results to sanctions domain types.
+func mapOnfidoSanctionsStatus(onfidoStatus, onfidoResult string) (SanctionsStatus, []SanctionsMatch) {
+	switch onfidoStatus {
+	case "in_progress", "awaiting_applicant":
+		return SanctionsStatusPending, nil
+
+	case "complete":
+		switch onfidoResult {
+		case "clear":
+			return SanctionsStatusClear, nil
+		default:
+			return SanctionsStatusMatch, []SanctionsMatch{
+				{
+					ListName:        "ONFIDO_WATCHLIST",
+					MatchedName:     "potential match detected",
+					MatchConfidence: 0.8,
+					ListEntryID:     "onfido-watchlist-match",
+				},
+			}
+		}
+
+	default:
+		return SanctionsStatusError, nil
+	}
+}

--- a/services/party/verification/onfido_provider.go
+++ b/services/party/verification/onfido_provider.go
@@ -155,7 +155,7 @@ func (p *OnfidoProvider) VerifyIdentity(ctx context.Context, party *domain.Party
 func (p *OnfidoProvider) CheckSanctions(ctx context.Context, party *domain.Party) (SanctionsResult, error) {
 	p.logger.Info("initiating sanctions screening",
 		slog.String("party_id", party.ID().String()),
-		slog.String("party_name", party.LegalName()),
+		slog.String("party_type", string(party.PartyType())),
 	)
 
 	// Create applicant

--- a/services/party/verification/onfido_provider.go
+++ b/services/party/verification/onfido_provider.go
@@ -372,11 +372,14 @@ func (p *OnfidoProvider) handleResponse(resp *http.Response, result interface{})
 // If the name contains no space, the entire name is used as the first name
 // and the last name defaults to "-" (Onfido requires a last name).
 func splitName(fullName string) (string, string) {
-	parts := strings.SplitN(fullName, " ", 2)
+	parts := strings.Fields(fullName)
+	if len(parts) == 0 {
+		return "-", "-"
+	}
 	if len(parts) == 1 {
 		return parts[0], "-"
 	}
-	return parts[0], parts[1]
+	return parts[0], strings.Join(parts[1:], " ")
 }
 
 // mapOnfidoCheckStatus maps Onfido check status and result to our domain types.

--- a/services/party/verification/onfido_provider_test.go
+++ b/services/party/verification/onfido_provider_test.go
@@ -1,0 +1,628 @@
+package verification
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/party/config"
+	"github.com/meridianhub/meridian/services/party/domain"
+)
+
+func newTestParty(t *testing.T, name string) *domain.Party {
+	t.Helper()
+	party, err := domain.NewParty(domain.PartyTypePerson, name)
+	require.NoError(t, err)
+	return party
+}
+
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(&strings.Builder{}, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func newTestConfig(baseURL string) *config.VerificationConfig {
+	return &config.VerificationConfig{
+		Provider: "onfido",
+		ProviderConfig: map[string]string{
+			"api_key":  "test_token_abc123",
+			"base_url": baseURL,
+		},
+		WebhookSecret: "webhook-secret",
+		WebhookURL:    "https://example.com/webhook",
+	}
+}
+
+func TestNewOnfidoProvider_Success(t *testing.T) {
+	cfg := newTestConfig("https://api.onfido.com/v3.6")
+
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+	assert.Equal(t, "test_token_abc123", provider.apiToken)
+	assert.Equal(t, "https://api.onfido.com/v3.6", provider.baseURL)
+}
+
+func TestNewOnfidoProvider_DefaultBaseURL(t *testing.T) {
+	cfg := &config.VerificationConfig{
+		Provider: "onfido",
+		ProviderConfig: map[string]string{
+			"api_key": "test_token",
+		},
+	}
+
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, onfidoDefaultBaseURL, provider.baseURL)
+}
+
+func TestNewOnfidoProvider_MissingAPIKey(t *testing.T) {
+	cfg := &config.VerificationConfig{
+		Provider:       "onfido",
+		ProviderConfig: map[string]string{},
+	}
+
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+
+	assert.Nil(t, provider)
+	assert.ErrorIs(t, err, ErrOnfidoMissingAPIKey)
+}
+
+func TestNewOnfidoProvider_NilProviderConfig(t *testing.T) {
+	cfg := &config.VerificationConfig{
+		Provider:       "onfido",
+		ProviderConfig: nil,
+	}
+
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+
+	assert.Nil(t, provider)
+	assert.ErrorIs(t, err, ErrOnfidoMissingAPIKey)
+}
+
+func TestOnfidoProvider_VerifyIdentity_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Token token=test_token_abc123", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/applicants":
+			var req onfidoApplicantRequest
+			err := json.NewDecoder(r.Body).Decode(&req)
+			require.NoError(t, err)
+			assert.Equal(t, "Jane", req.FirstName)
+			assert.Equal(t, "Smith", req.LastName)
+
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoApplicantResponse{
+				ID:        "applicant-001",
+				FirstName: req.FirstName,
+				LastName:  req.LastName,
+			})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/checks":
+			var req onfidoCheckRequest
+			err := json.NewDecoder(r.Body).Decode(&req)
+			require.NoError(t, err)
+			assert.Equal(t, "applicant-001", req.ApplicantID)
+			assert.Equal(t, []string{"identity_enhanced"}, req.ReportNames)
+
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoCheckResponse{
+				ID:          "check-001",
+				Status:      "complete",
+				Result:      "clear",
+				ApplicantID: req.ApplicantID,
+			})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	party := newTestParty(t, "Jane Smith")
+	result, err := provider.VerifyIdentity(context.Background(), party)
+
+	require.NoError(t, err)
+	assert.Equal(t, "check-001", result.VerificationID)
+	assert.Equal(t, StatusApproved, result.Status)
+	assert.Equal(t, "Identity verification passed", result.Reason)
+	assert.InDelta(t, 0.1, result.RiskScore, 0.001)
+	assert.NotNil(t, result.CompletedAt)
+	assert.Equal(t, "onfido", result.Metadata["provider"])
+	assert.Equal(t, "applicant-001", result.Metadata["applicant_id"])
+}
+
+func TestOnfidoProvider_VerifyIdentity_Rejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/applicants":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoApplicantResponse{ID: "applicant-002"})
+
+		case "/checks":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoCheckResponse{
+				ID:     "check-002",
+				Status: "complete",
+				Result: "unidentified",
+			})
+		}
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	party := newTestParty(t, "John Doe")
+	result, err := provider.VerifyIdentity(context.Background(), party)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusRejected, result.Status)
+	assert.Equal(t, "Identity verification failed", result.Reason)
+	assert.InDelta(t, 0.9, result.RiskScore, 0.001)
+}
+
+func TestOnfidoProvider_VerifyIdentity_ManualReview(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/applicants":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoApplicantResponse{ID: "applicant-003"})
+
+		case "/checks":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoCheckResponse{
+				ID:     "check-003",
+				Status: "complete",
+				Result: "consider",
+			})
+		}
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	party := newTestParty(t, "Alice Jones")
+	result, err := provider.VerifyIdentity(context.Background(), party)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusManualReview, result.Status)
+	assert.Equal(t, "Verification requires manual review", result.Reason)
+	assert.InDelta(t, 0.5, result.RiskScore, 0.001)
+}
+
+func TestOnfidoProvider_VerifyIdentity_Pending(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/applicants":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoApplicantResponse{ID: "applicant-004"})
+
+		case "/checks":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoCheckResponse{
+				ID:     "check-004",
+				Status: "in_progress",
+				Result: "",
+			})
+		}
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	party := newTestParty(t, "Bob Builder")
+	result, err := provider.VerifyIdentity(context.Background(), party)
+
+	require.NoError(t, err)
+	assert.Equal(t, StatusPending, result.Status)
+	assert.Nil(t, result.CompletedAt)
+}
+
+func TestOnfidoProvider_VerifyIdentity_SingleName(t *testing.T) {
+	var capturedFirstName, capturedLastName string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/applicants":
+			var req onfidoApplicantRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			capturedFirstName = req.FirstName
+			capturedLastName = req.LastName
+
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoApplicantResponse{ID: "applicant-005"})
+
+		case "/checks":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoCheckResponse{
+				ID:     "check-005",
+				Status: "complete",
+				Result: "clear",
+			})
+		}
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	party := newTestParty(t, "Madonna")
+	_, err = provider.VerifyIdentity(context.Background(), party)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Madonna", capturedFirstName)
+	assert.Equal(t, "-", capturedLastName)
+}
+
+func TestOnfidoProvider_CheckSanctions_Clear(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/applicants":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoApplicantResponse{ID: "applicant-010"})
+
+		case "/checks":
+			var req onfidoCheckRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			assert.Equal(t, []string{"watchlist_enhanced"}, req.ReportNames)
+
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoCheckResponse{
+				ID:     "check-010",
+				Status: "complete",
+				Result: "clear",
+			})
+		}
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	party := newTestParty(t, "Safe Person")
+	result, err := provider.CheckSanctions(context.Background(), party)
+
+	require.NoError(t, err)
+	assert.Equal(t, SanctionsStatusClear, result.Status)
+	assert.Empty(t, result.Matches)
+	assert.NotEmpty(t, result.ScreeningID)
+	assert.Equal(t, "onfido", result.Metadata["provider"])
+}
+
+func TestOnfidoProvider_CheckSanctions_Match(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/applicants":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoApplicantResponse{ID: "applicant-011"})
+
+		case "/checks":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoCheckResponse{
+				ID:     "check-011",
+				Status: "complete",
+				Result: "consider",
+			})
+		}
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	party := newTestParty(t, "Suspicious Person")
+	result, err := provider.CheckSanctions(context.Background(), party)
+
+	require.NoError(t, err)
+	assert.Equal(t, SanctionsStatusMatch, result.Status)
+	assert.Len(t, result.Matches, 1)
+	assert.Equal(t, "ONFIDO_WATCHLIST", result.Matches[0].ListName)
+}
+
+func TestOnfidoProvider_CheckSanctions_Pending(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/applicants":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoApplicantResponse{ID: "applicant-012"})
+
+		case "/checks":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoCheckResponse{
+				ID:     "check-012",
+				Status: "in_progress",
+			})
+		}
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	party := newTestParty(t, "Pending Person")
+	result, err := provider.CheckSanctions(context.Background(), party)
+
+	require.NoError(t, err)
+	assert.Equal(t, SanctionsStatusPending, result.Status)
+	assert.Empty(t, result.Matches)
+}
+
+func TestOnfidoProvider_GetVerificationStatus_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/checks/check-020" {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(onfidoCheckResponse{
+				ID:     "check-020",
+				Status: "complete",
+				Result: "clear",
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	result, err := provider.GetVerificationStatus(context.Background(), "check-020")
+
+	require.NoError(t, err)
+	assert.Equal(t, "check-020", result.VerificationID)
+	assert.Equal(t, StatusApproved, result.Status)
+	assert.NotNil(t, result.CompletedAt)
+}
+
+func TestOnfidoProvider_GetVerificationStatus_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	_, err = provider.GetVerificationStatus(context.Background(), "nonexistent")
+
+	assert.ErrorIs(t, err, ErrVerificationNotFound)
+}
+
+func TestOnfidoProvider_AuthenticationFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(onfidoErrorResponse{
+			Error: struct {
+				Type    string            `json:"type"`
+				Message string            `json:"message"`
+				Fields  map[string]string `json:"fields"`
+			}{
+				Type:    "authorization_error",
+				Message: "Invalid token",
+			},
+		})
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	party := newTestParty(t, "John Doe")
+	_, err = provider.VerifyIdentity(context.Background(), party)
+
+	assert.ErrorIs(t, err, ErrOnfidoUnauthorized)
+}
+
+func TestOnfidoProvider_RateLimited(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	party := newTestParty(t, "John Doe")
+	_, err = provider.VerifyIdentity(context.Background(), party)
+
+	assert.ErrorIs(t, err, ErrOnfidoRateLimited)
+}
+
+func TestOnfidoProvider_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	party := newTestParty(t, "John Doe")
+	_, err = provider.VerifyIdentity(context.Background(), party)
+
+	assert.ErrorIs(t, err, ErrOnfidoServerError)
+}
+
+func TestOnfidoProvider_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		// Server never responds - context should cancel the request
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	party := newTestParty(t, "John Doe")
+	_, err = provider.VerifyIdentity(ctx, party)
+
+	assert.Error(t, err)
+}
+
+func TestOnfidoProvider_ServerErrorWithBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		json.NewEncoder(w).Encode(onfidoErrorResponse{
+			Error: struct {
+				Type    string            `json:"type"`
+				Message string            `json:"message"`
+				Fields  map[string]string `json:"fields"`
+			}{
+				Type:    "validation_error",
+				Message: "first_name is required",
+			},
+		})
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	party := newTestParty(t, "John Doe")
+	_, err = provider.VerifyIdentity(context.Background(), party)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "validation_error")
+	assert.Contains(t, err.Error(), "first_name is required")
+}
+
+func TestOnfidoProvider_AuthorizationHeader(t *testing.T) {
+	var capturedAuthHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuthHeader = r.Header.Get("Authorization")
+
+		switch r.URL.Path {
+		case "/applicants":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoApplicantResponse{ID: "applicant-auth"})
+		case "/checks":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(onfidoCheckResponse{
+				ID:     "check-auth",
+				Status: "complete",
+				Result: "clear",
+			})
+		}
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	cfg.ProviderConfig["api_key"] = "my_secret_token"
+	provider, err := NewOnfidoProvider(cfg, newTestLogger())
+	require.NoError(t, err)
+
+	party := newTestParty(t, "John Doe")
+	_, err = provider.VerifyIdentity(context.Background(), party)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Token token=my_secret_token", capturedAuthHeader)
+}
+
+func TestSplitName(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedFirst string
+		expectedLast  string
+	}{
+		{"two parts", "John Smith", "John", "Smith"},
+		{"three parts", "Mary Jane Watson", "Mary", "Jane Watson"},
+		{"single name", "Madonna", "Madonna", "-"},
+		{"with spaces", "Jean Claude Van Damme", "Jean", "Claude Van Damme"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			first, last := splitName(tc.input)
+			assert.Equal(t, tc.expectedFirst, first)
+			assert.Equal(t, tc.expectedLast, last)
+		})
+	}
+}
+
+func TestMapOnfidoCheckStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		onfidoStatus   string
+		onfidoResult   string
+		expectedStatus Status
+		expectedScore  float64
+	}{
+		{"in_progress", "in_progress", "", StatusPending, 0.0},
+		{"awaiting_applicant", "awaiting_applicant", "", StatusPending, 0.0},
+		{"complete_clear", "complete", "clear", StatusApproved, 0.1},
+		{"complete_consider", "complete", "consider", StatusManualReview, 0.5},
+		{"complete_unidentified", "complete", "unidentified", StatusRejected, 0.9},
+		{"withdrawn", "withdrawn", "", StatusRejected, 0.0},
+		{"cancelled", "cancelled", "", StatusRejected, 0.0},
+		{"paused", "paused", "", StatusManualReview, 0.5},
+		{"unknown", "unknown_status", "", StatusPending, 0.0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status, _, riskScore := mapOnfidoCheckStatus(tc.onfidoStatus, tc.onfidoResult)
+			assert.Equal(t, tc.expectedStatus, status)
+			assert.InDelta(t, tc.expectedScore, riskScore, 0.001)
+		})
+	}
+}
+
+func TestMapOnfidoSanctionsStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		onfidoStatus   string
+		onfidoResult   string
+		expectedStatus SanctionsStatus
+		expectMatches  bool
+	}{
+		{"pending", "in_progress", "", SanctionsStatusPending, false},
+		{"clear", "complete", "clear", SanctionsStatusClear, false},
+		{"match", "complete", "consider", SanctionsStatusMatch, true},
+		{"error_unknown", "error", "", SanctionsStatusError, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status, matches := mapOnfidoSanctionsStatus(tc.onfidoStatus, tc.onfidoResult)
+			assert.Equal(t, tc.expectedStatus, status)
+			if tc.expectMatches {
+				assert.NotEmpty(t, matches)
+			} else {
+				assert.Empty(t, matches)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Implement OnfidoProvider struct implementing the verification.Provider interface
- Add VerifyIdentity, CheckSanctions, and GetVerificationStatus methods against Onfido API v3.6
- HTTP client with token auth, rate limit handling (429), auth failure (401), and structured error responses
- Unit tests using httptest for all success and error paths (39 tests pass)
- Update factory to wire Onfido provider, update factory tests accordingly

## Task Master
Tag: party-kyc-aml, Task: 2

## Test plan
- [x] All unit tests pass (39 tests)
- [x] Provider implements interface correctly (compile-time check via `var _ Provider = (*OnfidoProvider)(nil)`)
- [x] Error handling covers auth failure, rate limit, network errors, validation errors
- [x] Context cancellation is respected
- [x] Name splitting handles single names (e.g. "Madonna")
- [x] Status mapping covers all Onfido check states (in_progress, complete/clear, complete/consider, withdrawn, paused)
- [x] Sanctions mapping covers clear, match, pending, and error states
- [x] Pre-commit hooks pass (gitleaks, gofumpt, golangci-lint)