### PR TITLE
docs: Add GetBalance documentation, smoke test, and nil guard decision

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -815,6 +815,16 @@ local_resource(
   trigger_mode=TRIGGER_MODE_MANUAL,  # Can be re-run manually via 'tilt trigger keycloak-setup'
 )
 
+# GetBalance smoke test - manual trigger for verifying balance query flow
+local_resource(
+  'smoke-test-get-balance',
+  cmd='./scripts/smoke-test-get-balance.sh',
+  resource_deps=['internal-bank-account', 'position-keeping'],
+  labels=['test'],
+  auto_init=False,  # Run manually with 'tilt trigger smoke-test-get-balance'
+  trigger_mode=TRIGGER_MODE_MANUAL,
+)
+
 # =============================================================================
 # UI Configuration
 # =============================================================================

--- a/docs/adr/0031-getbalance-nil-guard-retention.md
+++ b/docs/adr/0031-getbalance-nil-guard-retention.md
@@ -1,0 +1,90 @@
+---
+name: adr-0031-getbalance-nil-guard-retention
+description: Retain the nil guard on PositionKeepingClient in GetBalance for safety and testability
+triggers:
+  - Reviewing defensive nil checks on service dependencies in GetBalance
+  - Evaluating whether to remove nil guards after constructor validation is added
+  - Adding new constructors that may omit optional dependencies
+instructions: |
+  Keep the nil guard on positionKeepingClient in GetBalance (server.go). The guard
+  returns codes.Unimplemented with a clear error message rather than panicking on a nil
+  pointer dereference. This is intentional because multiple constructors exist that do
+  not require a PK client, and the guard has zero performance cost.
+---
+
+# 31. Retain nil guard on PositionKeepingClient in GetBalance
+
+Date: 2026-02-13
+
+## Status
+
+Accepted
+
+## Context
+
+The `GetBalance` method in `services/internal-bank-account/service/server.go` includes a nil check on the `positionKeepingClient` field before calling Position Keeping:
+
+```go
+if s.positionKeepingClient == nil {
+    operationStatus = operationStatusFailed
+    return nil, status.Error(codes.Unimplemented, "position keeping service not configured")
+}
+```
+
+During review of the account service wiring, the question was raised whether this guard is redundant given that production constructors (`NewServiceWithClients`, `NewServiceFull`) always receive a PK client. The concern was that nil guards on injected dependencies can mask configuration errors.
+
+## Decision Drivers
+
+* Multiple constructors exist with different dependency requirements
+* Test code regularly uses `NewService(repo)` without a PK client
+* A nil pointer panic produces an unhelpful stack trace compared to a gRPC status error
+* The guard has zero runtime cost (single pointer comparison)
+
+## Considered Options
+
+1. Remove the nil guard (rely on constructor validation)
+2. Keep the nil guard (current behavior)
+
+## Decision Outcome
+
+Chosen option: "Keep the nil guard", because it provides safety across all constructors with no cost.
+
+### Positive Consequences
+
+* Tests using `NewService(repo)` receive a clear `Unimplemented` error instead of a nil pointer panic when GetBalance is called
+* Future constructors or configurations that omit PK client are handled gracefully
+* The error message is actionable: callers know PK is not configured rather than debugging a nil dereference
+* Zero performance impact: a single pointer comparison in a method that makes a network call
+
+### Negative Consequences
+
+* The guard could mask a misconfigured production deployment where PK client was accidentally nil. This risk is mitigated by the health check system, which reports PK connectivity status independently.
+
+## Pros and Cons of the Options
+
+### Remove the nil guard
+
+Rely on constructor validation to ensure PK client is always non-nil.
+
+* Good, because it reduces code in the hot path
+* Bad, because `NewService` and `NewServiceWithValuationFeatures` constructors legitimately create services without a PK client
+* Bad, because a nil pointer panic in production produces an opaque error with no gRPC status code
+
+### Keep the nil guard
+
+Retain the explicit nil check with a descriptive error.
+
+* Good, because it supports all existing constructors safely
+* Good, because the error message tells callers exactly what is wrong
+* Good, because it costs nothing at runtime
+* Good, because it provides a defensive layer independent of constructor logic
+
+## Links
+
+* [ADR-0023: Balance Delegation to Position Keeping](0023-balance-delegation-to-position-keeping.md)
+* [ADR-0024: Internal Bank Account Service](0024-internal-bank-account-service.md)
+* Related code: `services/internal-bank-account/service/server.go` (GetBalance method)
+
+## Notes
+
+Re-evaluate if the service is refactored to a single constructor that requires all dependencies. If all constructors mandate a non-nil PK client, the guard becomes truly redundant and can be removed.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -76,6 +76,8 @@ Architectural Decision Records) format.
 | [ADR-0027](0027-market-information-management.md) | Market Information Management Service Architecture | Accepted | 2026-01-19 |
 <!-- markdownlint-disable-next-line MD013 -->
 | [ADR-0028](0028-starlark-saga-cel-valuation.md) | Starlark Saga Orchestration with CEL Valuation | Accepted | 2025-01-20 |
+<!-- markdownlint-disable-next-line MD013 -->
+| [ADR-0031](0031-getbalance-nil-guard-retention.md) | Retain Nil Guard on PositionKeepingClient in GetBalance | Accepted | 2026-02-13 |
 
 ## Architecture Decision Relationships
 

--- a/scripts/smoke-test-get-balance.sh
+++ b/scripts/smoke-test-get-balance.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Smoke test for GetBalance in a Tilt environment.
+#
+# Verifies that:
+#   1. internal-bank-account and position-keeping services are healthy
+#   2. A test account can be created via InitiateInternalBankAccount
+#   3. GetBalance returns a response (not an error) for the created account
+#
+# Prerequisites:
+#   - grpcurl installed
+#   - Services running in Tilt (internal-bank-account on 50057, position-keeping on 50053)
+#
+# Usage:
+#   ./scripts/smoke-test-get-balance.sh
+#   tilt trigger smoke-test-get-balance
+
+set -euo pipefail
+
+IBA_ADDR="${IBA_ADDR:-localhost:50057}"
+PK_ADDR="${PK_ADDR:-localhost:50053}"
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-60}"
+POLL_INTERVAL=2
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+# Wait for a gRPC health check to return SERVING.
+# Args: $1=address $2=service-name $3=display-name
+wait_for_health() {
+    local addr="$1" svc="$2" name="$3"
+    local elapsed=0
+
+    log_info "Waiting for ${name} health check at ${addr} (timeout: ${HEALTH_TIMEOUT}s)..."
+    while [ "$elapsed" -lt "$HEALTH_TIMEOUT" ]; do
+        if grpcurl -plaintext -d "{\"service\": \"${svc}\"}" \
+            "${addr}" grpc.health.v1.Health/Check 2>/dev/null | grep -q "SERVING"; then
+            log_info "${name} is SERVING"
+            return 0
+        fi
+        sleep "$POLL_INTERVAL"
+        elapsed=$((elapsed + POLL_INTERVAL))
+    done
+
+    log_error "${name} did not become healthy within ${HEALTH_TIMEOUT}s"
+    return 1
+}
+
+# --- Step 1: Wait for services to be healthy ---
+
+wait_for_health "$IBA_ADDR" "internal-bank-account" "Internal Bank Account"
+wait_for_health "$PK_ADDR"  "position-keeping"      "Position Keeping"
+
+# --- Step 2: Create a test account ---
+
+IDEMPOTENCY_KEY="smoke-test-getbalance-$(date +%s)"
+ACCOUNT_CODE="SMOKE-BAL-$(date +%s)"
+
+log_info "Creating test account (code: ${ACCOUNT_CODE})..."
+
+CREATE_RESP=$(grpcurl -plaintext -d "{
+  \"account_code\": \"${ACCOUNT_CODE}\",
+  \"name\": \"Smoke Test GetBalance Account\",
+  \"account_type\": \"INTERNAL_ACCOUNT_TYPE_CLEARING\",
+  \"instrument_code\": \"GBP\",
+  \"clearing_purpose\": \"CLEARING_PURPOSE_GENERAL\",
+  \"idempotency_key\": {\"key\": \"${IDEMPOTENCY_KEY}\"}
+}" "$IBA_ADDR" meridian.internal_bank_account.v1.InternalBankAccountService/InitiateInternalBankAccount 2>&1)
+
+ACCOUNT_ID=$(echo "$CREATE_RESP" | grep -o '"accountId":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"accountId":[[:space:]]*"\([^"]*\)".*/\1/')
+
+if [ -z "$ACCOUNT_ID" ]; then
+    log_error "Failed to create test account. Response:"
+    echo "$CREATE_RESP"
+    exit 1
+fi
+
+log_info "Created account: ${ACCOUNT_ID}"
+
+# --- Step 3: Call GetBalance and verify response ---
+
+log_info "Calling GetBalance for account ${ACCOUNT_ID}..."
+
+BALANCE_RESP=$(grpcurl -plaintext -d "{\"account_id\": \"${ACCOUNT_ID}\"}" \
+    "$IBA_ADDR" meridian.internal_bank_account.v1.InternalBankAccountService/GetBalance 2>&1)
+
+BALANCE_EXIT=$?
+
+if [ "$BALANCE_EXIT" -ne 0 ]; then
+    log_error "GetBalance call failed (exit code: ${BALANCE_EXIT}). Response:"
+    echo "$BALANCE_RESP"
+    exit 1
+fi
+
+# Verify the response contains accountId (basic structural check)
+if echo "$BALANCE_RESP" | grep -q '"accountId"'; then
+    log_info "GetBalance returned a valid response"
+else
+    log_error "GetBalance response missing accountId field. Response:"
+    echo "$BALANCE_RESP"
+    exit 1
+fi
+
+# Check for currentBalance presence (may be null if no position exists yet, which is acceptable)
+if echo "$BALANCE_RESP" | grep -q '"currentBalance"'; then
+    log_info "Response includes currentBalance field"
+else
+    log_warn "Response does not include currentBalance (position may not exist yet - acceptable for smoke test)"
+fi
+
+# --- Done ---
+
+log_info "Smoke test PASSED"
+echo ""
+echo "  Account ID: ${ACCOUNT_ID}"
+echo "  Response:"
+echo "$BALANCE_RESP" | sed 's/^/    /'
+echo ""

--- a/scripts/smoke-test-get-balance.sh
+++ b/scripts/smoke-test-get-balance.sh
@@ -71,7 +71,7 @@ CREATE_RESP=$(grpcurl -plaintext -d "{
   \"instrument_code\": \"GBP\",
   \"clearing_purpose\": \"CLEARING_PURPOSE_GENERAL\",
   \"idempotency_key\": {\"key\": \"${IDEMPOTENCY_KEY}\"}
-}" "$IBA_ADDR" meridian.internal_bank_account.v1.InternalBankAccountService/InitiateInternalBankAccount 2>&1)
+}" "$IBA_ADDR" meridian.internal_bank_account.v1.InternalBankAccountService/InitiateInternalBankAccount 2>&1) || true
 
 ACCOUNT_ID=$(echo "$CREATE_RESP" | grep -o '"accountId":[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"accountId":[[:space:]]*"\([^"]*\)".*/\1/')
 
@@ -88,9 +88,8 @@ log_info "Created account: ${ACCOUNT_ID}"
 log_info "Calling GetBalance for account ${ACCOUNT_ID}..."
 
 BALANCE_RESP=$(grpcurl -plaintext -d "{\"account_id\": \"${ACCOUNT_ID}\"}" \
-    "$IBA_ADDR" meridian.internal_bank_account.v1.InternalBankAccountService/GetBalance 2>&1)
-
-BALANCE_EXIT=$?
+    "$IBA_ADDR" meridian.internal_bank_account.v1.InternalBankAccountService/GetBalance 2>&1) || BALANCE_EXIT=$?
+BALANCE_EXIT=${BALANCE_EXIT:-0}
 
 if [ "$BALANCE_EXIT" -ne 0 ]; then
     log_error "GetBalance call failed (exit code: ${BALANCE_EXIT}). Response:"

--- a/services/internal-bank-account/README.md
+++ b/services/internal-bank-account/README.md
@@ -112,7 +112,9 @@ resp, err := client.ControlInternalBankAccount(ctx, req)
 
 #### GetBalance
 
-Queries account balance from Position Keeping service.
+Queries the current balance for an internal account by proxying to the
+Position Keeping service, which is the single source of truth for all
+balance data.
 
 ```go
 req := &iba.GetBalanceRequest{
@@ -124,6 +126,64 @@ resp, err := client.GetBalance(ctx, req)
 // resp.CurrentBalance.InstrumentCode = "USD"
 // resp.AsOf = timestamp from Position Keeping
 ```
+
+**Prerequisites:**
+
+- Position Keeping service must be deployed and reachable
+- Account must be in `ACTIVE` status (suspended/closed accounts return `FailedPrecondition`)
+- A position record must exist in Position Keeping for the account/instrument combination
+
+**Behavior:**
+
+- Returns `BALANCE_TYPE_CURRENT` from the Position Keeping response
+- O(1) query: Position Keeping maintains pre-computed running balance totals
+- 5-second timeout on the Position Keeping call (`context.WithTimeout`)
+- Response includes `as_of` timestamp from Position Keeping (falls back to current time if absent)
+
+**Error Scenarios:**
+
+| gRPC Code | Condition | Description |
+|-----------|-----------|-------------|
+| `Unimplemented` | Position Keeping client not configured | Service constructed without PK client (e.g., `NewService` instead of `NewServiceWithClients`) |
+| `FailedPrecondition` | Account not active | Account is suspended or closed |
+| `NotFound` | Account does not exist | Account ID/code not found in local database |
+| `Internal` | Position not found in PK | PK returned NotFound (position record missing) |
+| `Unavailable` | PK service unreachable | PK unavailable, deadline exceeded, or resource exhausted |
+| `Internal` | PK invalid argument | Request to PK was malformed (indicates a code defect) |
+| `InvalidArgument` | Empty account_id | Request missing required `account_id` field |
+
+**Monitoring:**
+
+| Metric | Description |
+|--------|-------------|
+| `internal_bank_account_operation_duration_seconds{operation="get_balance"}` | Total GetBalance RPC duration |
+| `internal_bank_account_balance_query_duration_seconds{status}` | Duration of the PK call specifically (target p99 < 50ms) |
+| `internal_bank_account_errors_total{category="position_keeping"}` | PK-related error counter |
+
+The health check endpoint (`grpc.health.v1.Health/Check`) reports PK
+connectivity as a degraded (not critical) dependency. The service
+continues serving non-balance operations even when PK is unreachable.
+
+**Local Development (grpcurl):**
+
+```bash
+# Query balance for an account
+grpcurl -plaintext -d '{"account_id": "<account-id>"}' \
+  localhost:50057 meridian.internal_bank_account.v1.InternalBankAccountService/GetBalance
+
+# Check health (includes PK connectivity status)
+grpcurl -plaintext -d '{"service": "internal-bank-account"}' \
+  localhost:50057 grpc.health.v1.Health/Check
+```
+
+**Production Deployment:**
+
+| Attribute | Value |
+|-----------|-------|
+| Service name | `internal-bank-account` |
+| gRPC port | `50057` |
+| Health endpoint | `grpc.health.v1.Health/Check` (service: `internal-bank-account`) |
+| PK dependency | `position-keeping:50053` |
 
 ## Domain Model
 

--- a/services/internal-bank-account/service/server.go
+++ b/services/internal-bank-account/service/server.go
@@ -596,7 +596,12 @@ func (s *Service) GetBalance(ctx context.Context, req *pb.GetBalanceRequest) (*p
 		return nil, status.Errorf(codes.FailedPrecondition, "account not active: %s", string(account.Status()))
 	}
 
-	// Position Keeping client must be configured for balance queries
+	// Position Keeping client must be configured for balance queries.
+	// Decision: KEEP this nil guard (see ADR-0031). Rationale:
+	//   - Provides explicit error message instead of nil pointer panic
+	//   - Supports constructors that omit PK client (NewService, NewServiceWithValuationFeatures)
+	//   - Zero performance cost (single pointer comparison)
+	//   - Future refactoring may make PK optional for other balance sources
 	if s.positionKeepingClient == nil {
 		operationStatus = operationStatusFailed
 		return nil, status.Error(codes.Unimplemented, "position keeping service not configured")


### PR DESCRIPTION
## Summary

- Add GetBalance operational behavior documentation to the internal-bank-account service README,
  covering prerequisites, error scenarios, monitoring metrics, and local development commands
- Add `scripts/smoke-test-get-balance.sh` for Tilt environment verification of the GetBalance
  flow (health check wait, account creation, balance query), registered as a manual-trigger
  `local_resource` in the Tiltfile
- Document the decision to retain the nil guard on `positionKeepingClient` in GetBalance as
  ADR-0031, with inline rationale comment at the guard site

## Task Master

| TM Task | Description |
|---------|-------------|
| account-service-wiring.13 | Document GetBalance operational behavior in service README |
| account-service-wiring.17 | Add smoke test for GetBalance in Tilt environment |
| account-service-wiring.18 | Document nil guard decision (KEEP the guard) |

## Test plan

- [ ] Verify markdownlint passes on updated README and ADR files
- [ ] Verify `smoke-test-get-balance.sh` is executable and syntactically valid
- [ ] Verify Tiltfile parses correctly with the new `smoke-test-get-balance` resource
- [ ] Verify golangci-lint passes on the comment-only server.go change