### PR TITLE
feat: Add reference-data service entry point and Dockerfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -477,6 +477,7 @@ k8s_resource(
 #   - Tenant:               50056
 #   - InternalBankAccount:  50057
 #   - MarketInformation:    50058
+#   - ReferenceData:        50059
 #   - Reconciliation:       50060
 #   - Forecasting:          50061
 #   - Gateway (HTTP):       8080
@@ -860,6 +861,7 @@ Microservices:
   • Tenant                 → localhost:50056 (gRPC)
   • Internal-Bank-Account  → localhost:50057 (gRPC)
   • Market-Information     → localhost:50058 (gRPC)
+  • Reference-Data         → localhost:50059 (gRPC)
   • Reconciliation         → localhost:50060 (gRPC)
   • Forecasting            → localhost:50061 (gRPC)
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -90,6 +90,7 @@ db_urls = {
   'market_information': os.getenv('MARKET_INFORMATION_DATABASE_URL', 'postgres://meridian_market_information_user@cockroachdb:26257/meridian_market_information?sslmode=disable'),
   'reconciliation': os.getenv('RECONCILIATION_DATABASE_URL', 'postgres://meridian_reconciliation_user@cockroachdb:26257/meridian_reconciliation?sslmode=disable'),
   'forecasting': os.getenv('FORECASTING_DATABASE_URL', 'postgres://meridian_forecasting_user@cockroachdb:26257/meridian_forecasting?sslmode=disable'),
+  'reference_data': os.getenv('REFERENCE_DATA_DATABASE_URL', 'postgres://meridian_reference_data_user@cockroachdb:26257/meridian_reference_data?sslmode=disable'),
 }
 
 # NOTE: Migrations now run as Kubernetes Jobs inside the cluster
@@ -552,6 +553,13 @@ grpc_microservice(
     resource_deps=['cockroachdb', 'migrate-forecasting', 'market-information'],
 )
 
+# Reference Data Service - gRPC microservice for instrument definitions, nodes, and saga definitions
+grpc_microservice(
+    'reference-data',
+    grpc_port=50059,  # ports.ReferenceData
+    resource_deps=['cockroachdb', 'migrate-reference-data'],
+)
+
 # =============================================================================
 # Gateway Service
 # =============================================================================
@@ -784,6 +792,13 @@ migration_job(
   resource_deps=['init-database'],  # Independent database, only needs init to complete
 )
 
+migration_job(
+  'migrate-reference-data',
+  'reference-data',
+  'reference_data',
+  resource_deps=['init-database'],  # Independent database, only needs init to complete
+)
+
 # Kafka cluster health check - runs automatically after kafka-cluster is ready
 local_resource(
   'kafka-health',
@@ -887,12 +902,13 @@ Database Architecture (database-per-service):
     - meridian_market_information
     - meridian_reconciliation
     - meridian_forecasting
+    - meridian_reference_data
   • Within each database: org schemas for multi-tenant isolation
   • Tables use singular, unqualified names (search_path routing)
   • See ADR-0003 for architecture details
 
 Database Migrations:
-  • Migrations run automatically on startup (10 resources):
+  • Migrations run automatically on startup (11 resources):
     1. current_account → meridian_current_account (account, lien, audit tables)
     2. financial_accounting → meridian_financial_accounting (ledger, booking)
     3. position_keeping → meridian_position_keeping (positions, transactions)
@@ -903,7 +919,8 @@ Database Migrations:
     8. market_information → meridian_market_information (price benchmarks, market data)
     9. reconciliation → meridian_reconciliation (reconciliation processes)
     10. forecasting → meridian_forecasting (forecasting strategies)
-  • Parallel execution: current_account + financial_accounting + party + tenant + internal_bank_account + market_information + reconciliation + forecasting
+    11. reference_data → meridian_reference_data (instrument definitions, nodes, saga definitions)
+  • Parallel execution: current_account + financial_accounting + party + tenant + internal_bank_account + market_information + reconciliation + forecasting + reference_data
   • Sequential dependencies:
     - position_keeping waits for current_account (Account FK)
     - payment_order waits for current_account (Account FK)
@@ -918,6 +935,7 @@ Database Migrations:
     - tilt trigger migrate-market-information
     - tilt trigger migrate-reconciliation
     - tilt trigger migrate-forecasting
+    - tilt trigger migrate-reference-data
 
 Testing Kafka Failover:
   kubectl delete pod kafka-1  # Kill broker

--- a/scripts/init-database.sh
+++ b/scripts/init-database.sh
@@ -28,6 +28,7 @@ DATABASES=(
   "meridian_market_information:meridian_market_information_user"
   "meridian_reconciliation:meridian_reconciliation_user"
   "meridian_forecasting:meridian_forecasting_user"
+  "meridian_reference_data:meridian_reference_data_user"
 )
 
 echo "Initializing CockroachDB databases..."

--- a/services/reference-data/cmd/Dockerfile
+++ b/services/reference-data/cmd/Dockerfile
@@ -1,0 +1,56 @@
+# Reference Data Service - Multi-Stage Dockerfile
+# Manages instrument definitions, reference data nodes, and saga definitions
+# Uses distroless base image (~2MB) enabled by pure-Go dependencies
+
+# Build stage
+FROM golang:1.26.0-bookworm AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum* ./
+RUN go mod download && go mod verify
+
+# Copy source code
+COPY . .
+
+# Build static binary (no CGO required)
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} go build \
+    -ldflags="-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildDate=${BUILD_DATE}" \
+    -o reference-data \
+    ./services/reference-data/cmd
+
+# Verify the binary exists and is executable
+RUN test -x reference-data && echo "Binary built successfully"
+
+# Runtime stage - distroless for minimal attack surface (~2MB base)
+FROM gcr.io/distroless/static-debian12
+
+# Copy timezone data from builder for time-sensitive operations
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Copy binary from builder
+COPY --from=builder /build/reference-data /reference-data
+
+# Use non-root user (distroless provides nonroot user at uid 65532)
+USER nonroot:nonroot
+
+# Expose gRPC port
+EXPOSE 50059
+
+# Note: Health checks handled by gRPC health check service
+
+# Run the binary
+ENTRYPOINT ["/reference-data"]

--- a/services/reference-data/cmd/main.go
+++ b/services/reference-data/cmd/main.go
@@ -1,0 +1,231 @@
+// Package main is the entry point for the Reference Data service.
+// Manages instrument definitions, reference data nodes, and saga definitions.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
+	refcel "github.com/meridianhub/meridian/services/reference-data/cel"
+	"github.com/meridianhub/meridian/services/reference-data/handler"
+	"github.com/meridianhub/meridian/services/reference-data/node"
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+	"github.com/meridianhub/meridian/services/reference-data/saga"
+	"github.com/meridianhub/meridian/shared/platform/bootstrap"
+	"github.com/meridianhub/meridian/shared/platform/defaults"
+	"github.com/meridianhub/meridian/shared/platform/env"
+	"github.com/meridianhub/meridian/shared/platform/ports"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+)
+
+// Build information set via ldflags during compilation
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)
+
+func main() {
+	logLevel := parseLogLevel(os.Getenv("LOG_LEVEL"))
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevel,
+	}))
+	slog.SetDefault(logger)
+
+	logger.Info("starting reference-data service",
+		"version", Version,
+		"commit", Commit,
+		"build_date", BuildDate)
+
+	if err := run(logger); err != nil {
+		logger.Error("service failed", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("service stopped gracefully")
+}
+
+func run(logger *slog.Logger) error {
+	ctx := context.Background()
+
+	// Initialize OpenTelemetry tracer
+	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
+		ServiceName:    "reference-data-service",
+		ServiceVersion: Version,
+		Logger:         logger,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize tracer: %w", err)
+	}
+	defer bootstrap.ShutdownTracer(tracer, logger)
+
+	// Initialize database connection
+	dbURL := env.GetEnvOrDefault("DATABASE_URL",
+		"postgres://meridian_reference_data_user@localhost:26257/meridian_reference_data?sslmode=disable")
+	dbPool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		return fmt.Errorf("failed to create database connection pool: %w", err)
+	}
+	defer dbPool.Close()
+
+	if err := dbPool.Ping(ctx); err != nil {
+		return fmt.Errorf("failed to ping database: %w", err)
+	}
+	logger.Info("database connection established", "url", dbURL)
+
+	// Create instrument registry
+	instrumentRegistry, err := registry.NewPostgresRegistry(dbPool)
+	if err != nil {
+		return fmt.Errorf("failed to create instrument registry: %w", err)
+	}
+	logger.Info("instrument registry initialized")
+
+	// Create CEL compiler
+	compiler, err := refcel.NewCompiler()
+	if err != nil {
+		return fmt.Errorf("failed to create CEL compiler: %w", err)
+	}
+	logger.Info("CEL compiler initialized")
+
+	// Create node repository
+	nodeRepo := node.NewPostgresRepository(dbPool)
+	logger.Info("node repository initialized")
+
+	// Create saga registry (validator is nil for now — will be wired when full validation pipeline is available)
+	sagaRegistry := saga.NewPostgresRegistry(dbPool, nil)
+	logger.Info("saga registry initialized")
+
+	// Create gRPC service handlers
+	refDataSvc, err := handler.NewService(instrumentRegistry, compiler, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create reference data service: %w", err)
+	}
+
+	nodeSvc, err := handler.NewNodeService(nodeRepo, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create node service: %w", err)
+	}
+
+	sagaSvc := saga.NewRegistryHandler(sagaRegistry, nil, nil, logger)
+
+	logger.Info("gRPC service handlers initialized")
+
+	// Initialize auth interceptor
+	authConfig := bootstrap.DefaultAuthConfig(logger)
+	authInterceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth: %w", err)
+	}
+
+	// Create gRPC server
+	grpcServer := bootstrap.NewGrpcServerBuilder(tracer, logger).
+		WithAuthInterceptor(authInterceptor).
+		Build()
+
+	// Register gRPC services
+	referencedatav1.RegisterReferenceDataServiceServer(grpcServer, refDataSvc)
+	referencedatav1.RegisterNodeServiceServer(grpcServer, nodeSvc)
+	sagav1.RegisterSagaRegistryServiceServer(grpcServer, sagaSvc)
+
+	// Register health check service
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("reference-data", grpc_health_v1.HealthCheckResponse_SERVING)
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
+
+	// Register reflection service for debugging
+	reflection.Register(grpcServer)
+
+	logger.Info("gRPC services registered")
+
+	// Get ports
+	port := env.GetEnvOrDefault("GRPC_PORT", strconv.Itoa(ports.ReferenceData))
+	address := fmt.Sprintf(":%s", port)
+	metricsPort := env.GetEnvOrDefault("METRICS_PORT", "8082")
+
+	// Create listener
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", address)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", address, err)
+	}
+
+	serverErrors := make(chan error, 2)
+	go func() {
+		logger.Info("starting gRPC server", "address", address)
+		if err := grpcServer.Serve(listener); err != nil {
+			serverErrors <- err
+		}
+	}()
+
+	// Start HTTP server for metrics and health
+	httpMux := http.NewServeMux()
+	httpMux.Handle("/metrics", promhttp.Handler())
+	httpMux.HandleFunc("/health", healthHandler(grpcServer))
+	httpMux.HandleFunc("/ready", healthHandler(grpcServer))
+
+	httpServer := &http.Server{
+		Addr:              fmt.Sprintf(":%s", metricsPort),
+		Handler:           httpMux,
+		ReadHeaderTimeout: defaults.DefaultHTTPReadHeaderTimeout,
+		WriteTimeout:      defaults.DefaultHTTPWriteTimeout,
+	}
+
+	go func() {
+		logger.Info("starting HTTP server for metrics", "address", httpServer.Addr)
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("HTTP server error", "error", err)
+			serverErrors <- fmt.Errorf("HTTP server error: %w", err)
+		}
+	}()
+
+	// Wait for shutdown
+	orchestrator := bootstrap.NewShutdownOrchestrator(grpcServer, logger)
+
+	orchestrator.AddCleanup(func() error {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), defaults.DefaultGracefulShutdown)
+		defer cancel()
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			logger.Error("HTTP server shutdown error", "error", err)
+			return err
+		}
+		logger.Info("HTTP server stopped")
+		return nil
+	})
+
+	return orchestrator.Wait(serverErrors)
+}
+
+func healthHandler(_ *grpc.Server) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("SERVING")); err != nil {
+			slog.Warn("failed to write health response", "error", err)
+		}
+	}
+}
+
+func parseLogLevel(levelStr string) slog.Level {
+	switch strings.ToLower(levelStr) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}


### PR DESCRIPTION
## Summary

- Create `services/reference-data/cmd/main.go` wiring instrument registry, node, and saga registry gRPC handlers with database, CEL compiler, auth, health check, metrics, and graceful shutdown
- Create `services/reference-data/cmd/Dockerfile` following the existing multi-stage distroless pattern
- Add reference-data to Tiltfile: database URL, migration job, and `grpc_microservice` on port 50059
- Add `meridian_reference_data` database and user to `init-database.sh`

## Test plan

- [ ] `go build ./services/reference-data/cmd/` compiles cleanly
- [ ] `go vet ./services/reference-data/cmd/` passes
- [ ] Pre-commit hooks (gitleaks, gofumpt, golangci-lint) pass
- [ ] Tilt startup creates the reference-data service and migration job
- [ ] gRPC health check responds on port 50059