### PR TITLE
feat: add catch-up logic for missed scheduler windows

### DIFF
--- a/shared/platform/scheduler/catchup.go
+++ b/shared/platform/scheduler/catchup.go
@@ -134,6 +134,12 @@ func (s *CronScheduler) catchUpSchedule(ctx context.Context, sched Schedule, now
 
 // executeCatchUpWindow executes a single missed window, acquiring the per-schedule
 // distributed lock (like normal executeJob) to prevent duplicates.
+//
+// Unlike executeJob, this does not use lifecycle.ExecuteGuarded because catch-up
+// runs synchronously inside Start() before cron.Start(). The Start goroutine
+// itself blocks until catch-up completes or the context is cancelled, so the
+// lifecycle already knows work is in progress. Context cancellation (from Stop)
+// is checked between iterations in catchUpSchedule.
 func (s *CronScheduler) executeCatchUpWindow(ctx context.Context, sched Schedule, scheduledAt time.Time) {
 	// Acquire per-schedule lock (consistent with normal executeJob).
 	if s.lock != nil {

--- a/shared/platform/scheduler/catchup.go
+++ b/shared/platform/scheduler/catchup.go
@@ -1,0 +1,196 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// runCatchUp detects and re-executes missed cron windows since the last known
+// execution for each schedule. It runs once on startup, before the live cron
+// runner begins. Only the leader pod executes catch-up (via distributed lock).
+//
+// For each schedule:
+//   - Windows within MaxCatchUpAge are executed.
+//   - Windows older than MaxCatchUpAge are recorded as MISSED (audit trail only).
+//   - If no ExecutionStore is configured, catch-up is skipped entirely.
+func (s *CronScheduler) runCatchUp(ctx context.Context) {
+	if s.store == nil {
+		return
+	}
+
+	// Acquire a dedicated catch-up lock to prevent multiple pods from running catch-up.
+	if s.lock != nil {
+		lockKey := fmt.Sprintf("%s:catch-up", s.config.Name)
+		acquired, release, err := s.lock.Acquire(ctx, "", lockKey)
+		if err != nil {
+			s.logger.Error("failed to acquire catch-up lock", "error", err)
+			return
+		}
+		if !acquired {
+			s.logger.Info("catch-up lock not acquired, another pod is handling catch-up")
+			return
+		}
+		defer release()
+	}
+
+	s.mu.Lock()
+	schedules := make([]Schedule, 0, len(s.schedules))
+	for _, sched := range s.schedules {
+		schedules = append(schedules, sched)
+	}
+	s.mu.Unlock()
+
+	if len(schedules) == 0 {
+		return
+	}
+
+	s.logger.Info("starting catch-up for missed windows",
+		"schedule_count", len(schedules),
+		"max_catch_up_age", s.config.MaxCatchUpAge)
+
+	now := time.Now().UTC()
+	catchUpCutoff := now.Add(-s.config.MaxCatchUpAge)
+
+	for _, sched := range schedules {
+		if ctx.Err() != nil {
+			return
+		}
+		s.catchUpSchedule(ctx, sched, now, catchUpCutoff)
+	}
+
+	s.logger.Info("catch-up completed")
+}
+
+// catchUpSchedule processes catch-up for a single schedule.
+func (s *CronScheduler) catchUpSchedule(ctx context.Context, sched Schedule, now, catchUpCutoff time.Time) {
+	// Set tenant context for store operations.
+	schedCtx := ctx
+	if sched.TenantID != "" {
+		if tid, err := tenant.NewTenantID(sched.TenantID); err == nil {
+			schedCtx = tenant.WithTenant(ctx, tid)
+		}
+	}
+
+	// Determine start point for walking cron windows.
+	// - If we have a last execution, start from there (to record MISSED for old windows).
+	// - If no prior execution, start from the catch-up cutoff (only execute recent windows).
+	lastExec, err := s.store.LastExecution(schedCtx, s.config.Name, sched.ID)
+	if err != nil && !errors.Is(err, ErrNoExecution) {
+		s.logger.Error("failed to query last execution for catch-up",
+			"schedule_id", sched.ID,
+			"error", err)
+		return
+	}
+
+	startFrom := catchUpCutoff
+	if lastExec != nil {
+		startFrom = lastExec.ScheduledAt
+	}
+
+	// Parse the cron expression to walk forward through time.
+	cronSched, err := s.parser.Parse(sched.CronExpr)
+	if err != nil {
+		s.logger.Error("failed to parse cron expression for catch-up",
+			"schedule_id", sched.ID,
+			"cron_expr", sched.CronExpr,
+			"error", err)
+		return
+	}
+
+	// Walk the cron expression forward from startFrom to now.
+	var missedCount, executedCount int
+	nextTime := cronSched.Next(startFrom)
+
+	for !nextTime.After(now) {
+		if ctx.Err() != nil {
+			return
+		}
+
+		if nextTime.Before(catchUpCutoff) {
+			// Too old to execute: record as MISSED for audit trail.
+			s.recordMissedWindow(schedCtx, sched, nextTime)
+			missedCount++
+		} else {
+			// Within catch-up age: execute.
+			s.executeCatchUpWindow(schedCtx, sched, nextTime)
+			executedCount++
+		}
+
+		nextTime = cronSched.Next(nextTime)
+	}
+
+	if missedCount > 0 || executedCount > 0 {
+		s.logger.Info("catch-up processed schedule",
+			"schedule_id", sched.ID,
+			"executed", executedCount,
+			"missed", missedCount)
+	}
+}
+
+// executeCatchUpWindow executes a single missed window, acquiring the per-schedule
+// distributed lock (like normal executeJob) to prevent duplicates.
+func (s *CronScheduler) executeCatchUpWindow(ctx context.Context, sched Schedule, scheduledAt time.Time) {
+	// Acquire per-schedule lock (consistent with normal executeJob).
+	if s.lock != nil {
+		lockKey := s.lockKey(sched.ID)
+		acquired, release, err := s.lock.Acquire(ctx, sched.TenantID, lockKey)
+		if err != nil {
+			s.logger.Error("failed to acquire lock for catch-up execution",
+				"schedule_id", sched.ID,
+				"scheduled_at", scheduledAt,
+				"error", err)
+			return
+		}
+		if !acquired {
+			s.logger.Debug("lock not acquired for catch-up execution, skipping",
+				"schedule_id", sched.ID,
+				"scheduled_at", scheduledAt)
+			return
+		}
+		defer release()
+	}
+
+	execID := uuid.New()
+	s.recordExecutionStart(ctx, execID, sched, scheduledAt)
+
+	execCtx, cancel := context.WithTimeout(ctx, s.config.ExecutionTimeout)
+	defer cancel()
+
+	err := s.executor.Execute(execCtx, sched)
+	s.recordExecutionResult(ctx, execID, sched, err)
+
+	if err != nil {
+		s.logger.Error("catch-up execution failed",
+			"schedule_id", sched.ID,
+			"scheduled_at", scheduledAt,
+			"error", err)
+		return
+	}
+
+	s.logger.Info("catch-up execution completed",
+		"schedule_id", sched.ID,
+		"scheduled_at", scheduledAt)
+}
+
+// recordMissedWindow records a MISSED execution for audit trail without executing.
+func (s *CronScheduler) recordMissedWindow(ctx context.Context, sched Schedule, scheduledAt time.Time) {
+	exec := Execution{
+		ID:            uuid.New(),
+		SchedulerName: s.config.Name,
+		ScheduleID:    sched.ID,
+		ScheduledAt:   scheduledAt,
+		Status:        ExecutionStatusMissed,
+		ErrorMessage:  strPtr("window older than max catch-up age"),
+	}
+	if err := s.store.RecordExecution(ctx, exec); err != nil {
+		s.logger.Error("failed to record missed window",
+			"schedule_id", sched.ID,
+			"scheduled_at", scheduledAt,
+			"error", err)
+	}
+}

--- a/shared/platform/scheduler/catchup_test.go
+++ b/shared/platform/scheduler/catchup_test.go
@@ -99,19 +99,34 @@ func TestCatchUp_NoPriorExecution_CatchesUpFromMaxAge(t *testing.T) {
 }
 
 func TestCatchUp_RecentExecution_NoCatchUpNeeded(t *testing.T) {
-	// Schedule runs every 10 minutes. Last execution was 2 minutes ago.
-	// No catch-up windows should exist.
+	// Schedule runs every 10 minutes. Seed the last execution at the most recent
+	// cron window so there are zero missed windows between seed and now.
 	cronExpr := "0 */10 * * * *"
 	now := time.Now().UTC()
+
+	// Find the most recent cron window at or before now.
+	sched, err := secondsParser.Parse(cronExpr)
+	require.NoError(t, err)
+	// Walk backwards: find the window just before now by checking next-after(now - 10m).
+	recentWindow := sched.Next(now.Add(-10 * time.Minute))
+	// If recentWindow is after now, step back one more interval.
+	if recentWindow.After(now) {
+		recentWindow = sched.Next(now.Add(-20 * time.Minute))
+	}
 
 	store := &stubExecutionStore{}
 	recentExec := scheduler.Execution{
 		SchedulerName: "test-scheduler",
 		ScheduleID:    "sched-1",
-		ScheduledAt:   now.Add(-2 * time.Minute),
+		ScheduledAt:   recentWindow,
 		Status:        scheduler.ExecutionStatusCompleted,
 	}
 	_ = store.RecordExecution(context.Background(), recentExec)
+
+	// Verify our assumption: no cron windows between recentWindow and now.
+	nextAfterSeed := sched.Next(recentWindow)
+	require.True(t, nextAfterSeed.After(now),
+		"seed should be the most recent window; next window %v should be after now %v", nextAfterSeed, now)
 
 	provider := &stubProvider{
 		schedules: []scheduler.Schedule{
@@ -136,7 +151,7 @@ func TestCatchUp_RecentExecution_NoCatchUpNeeded(t *testing.T) {
 		_ = s.Start(ctx)
 	}()
 
-	err := await.New().AtMost(2 * time.Second).PollInterval(50 * time.Millisecond).Until(func() bool {
+	err = await.New().AtMost(2 * time.Second).PollInterval(50 * time.Millisecond).Until(func() bool {
 		return s.ScheduleCount() == 1
 	})
 	require.NoError(t, err)

--- a/shared/platform/scheduler/catchup_test.go
+++ b/shared/platform/scheduler/catchup_test.go
@@ -1,0 +1,435 @@
+package scheduler_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/meridianhub/meridian/shared/platform/scheduler"
+	"github.com/robfig/cron/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// secondsParser is a cron.Parser matching the seconds-level cron runner used in tests.
+var secondsParser = cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+
+// expectedWindowCount counts how many cron windows exist between start (exclusive) and end (inclusive).
+func expectedWindowCount(t *testing.T, cronExpr string, start, end time.Time) int {
+	t.Helper()
+	sched, err := secondsParser.Parse(cronExpr)
+	require.NoError(t, err)
+
+	count := 0
+	next := sched.Next(start)
+	for !next.After(end) {
+		count++
+		next = sched.Next(next)
+	}
+	return count
+}
+
+// newTestScheduler creates a CronScheduler configured for testing with the
+// seconds-level cron runner and matching parser.
+func newTestScheduler(
+	provider scheduler.ScheduleProvider,
+	executor scheduler.Executor,
+	lock scheduler.DistributedLock,
+	config scheduler.CronSchedulerConfig,
+	opts ...scheduler.CronSchedulerOption,
+) *scheduler.CronScheduler {
+	allOpts := make([]scheduler.CronSchedulerOption, 0, 2+len(opts))
+	allOpts = append(allOpts,
+		scheduler.WithCronRunner(secondsCron()),
+		scheduler.WithCronParser(secondsParser),
+	)
+	allOpts = append(allOpts, opts...)
+	return scheduler.NewCronScheduler(
+		provider, executor, lock, config, slog.Default(), allOpts...,
+	)
+}
+
+func TestCatchUp_NoPriorExecution_CatchesUpFromMaxAge(t *testing.T) {
+	// Schedule runs every 10 minutes. With 1h MaxCatchUpAge and no prior execution,
+	// catch-up should execute ~6 windows (every 10 min for 1 hour).
+	cronExpr := "0 */10 * * * *"
+	store := &stubExecutionStore{}
+	provider := &stubProvider{
+		schedules: []scheduler.Schedule{
+			{ID: "sched-1", CronExpr: cronExpr, TenantID: "tenant1"},
+		},
+	}
+	executeCh := make(chan struct{}, 100)
+	executor := &stubExecutor{executeCh: executeCh}
+	lock := &stubLock{acquired: true}
+
+	maxCatchUpAge := time.Hour
+
+	s := newTestScheduler(provider, executor, lock,
+		scheduler.CronSchedulerConfig{
+			Name:            "test-scheduler",
+			RefreshInterval: time.Hour,
+			ShutdownTimeout: 2 * time.Second,
+			MaxCatchUpAge:   maxCatchUpAge,
+		},
+		scheduler.WithCronExecutionStore(store),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		_ = s.Start(ctx)
+	}()
+
+	now := time.Now().UTC()
+	expected := expectedWindowCount(t, cronExpr, now.Add(-maxCatchUpAge), now)
+	require.Greater(t, expected, 0, "should have at least one expected window")
+
+	err := await.New().AtMost(5 * time.Second).PollInterval(50 * time.Millisecond).Until(func() bool {
+		return executor.callCount.Load() >= int32(expected)
+	})
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, int(executor.callCount.Load()), expected)
+
+	cancel()
+	s.Stop()
+}
+
+func TestCatchUp_RecentExecution_NoCatchUpNeeded(t *testing.T) {
+	// Schedule runs every 10 minutes. Last execution was 2 minutes ago.
+	// No catch-up windows should exist.
+	cronExpr := "0 */10 * * * *"
+	now := time.Now().UTC()
+
+	store := &stubExecutionStore{}
+	recentExec := scheduler.Execution{
+		SchedulerName: "test-scheduler",
+		ScheduleID:    "sched-1",
+		ScheduledAt:   now.Add(-2 * time.Minute),
+		Status:        scheduler.ExecutionStatusCompleted,
+	}
+	_ = store.RecordExecution(context.Background(), recentExec)
+
+	provider := &stubProvider{
+		schedules: []scheduler.Schedule{
+			{ID: "sched-1", CronExpr: cronExpr, TenantID: "tenant1"},
+		},
+	}
+	executor := &stubExecutor{}
+	lock := &stubLock{acquired: true}
+
+	s := newTestScheduler(provider, executor, lock,
+		scheduler.CronSchedulerConfig{
+			Name:            "test-scheduler",
+			RefreshInterval: time.Hour,
+			ShutdownTimeout: 2 * time.Second,
+			MaxCatchUpAge:   time.Hour,
+		},
+		scheduler.WithCronExecutionStore(store),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		_ = s.Start(ctx)
+	}()
+
+	err := await.New().AtMost(2 * time.Second).PollInterval(50 * time.Millisecond).Until(func() bool {
+		return s.ScheduleCount() == 1
+	})
+	require.NoError(t, err)
+
+	// Give a moment for any catch-up to complete.
+	time.Sleep(200 * time.Millisecond)
+
+	// Executor should not have been called by catch-up.
+	assert.Equal(t, int32(0), executor.callCount.Load(),
+		"no catch-up executions expected when last execution is recent")
+
+	cancel()
+	s.Stop()
+}
+
+func TestCatchUp_StaleExecution_CatchesUpFromLastExec(t *testing.T) {
+	// Schedule runs every 10 minutes. Last execution was 30 minutes ago.
+	// Should catch up ~3 windows (10m, 20m, 30m ago range).
+	cronExpr := "0 */10 * * * *"
+	now := time.Now().UTC()
+	lastExecTime := now.Add(-30 * time.Minute)
+
+	store := &stubExecutionStore{}
+	staleExec := scheduler.Execution{
+		SchedulerName: "test-scheduler",
+		ScheduleID:    "sched-1",
+		ScheduledAt:   lastExecTime,
+		Status:        scheduler.ExecutionStatusCompleted,
+	}
+	_ = store.RecordExecution(context.Background(), staleExec)
+
+	provider := &stubProvider{
+		schedules: []scheduler.Schedule{
+			{ID: "sched-1", CronExpr: cronExpr, TenantID: "tenant1"},
+		},
+	}
+	executor := &stubExecutor{executeCh: make(chan struct{}, 100)}
+	lock := &stubLock{acquired: true}
+
+	s := newTestScheduler(provider, executor, lock,
+		scheduler.CronSchedulerConfig{
+			Name:            "test-scheduler",
+			RefreshInterval: time.Hour,
+			ShutdownTimeout: 2 * time.Second,
+			MaxCatchUpAge:   time.Hour,
+		},
+		scheduler.WithCronExecutionStore(store),
+	)
+
+	expected := expectedWindowCount(t, cronExpr, lastExecTime, now)
+	require.Greater(t, expected, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		_ = s.Start(ctx)
+	}()
+
+	err := await.New().AtMost(5 * time.Second).PollInterval(50 * time.Millisecond).Until(func() bool {
+		return executor.callCount.Load() >= int32(expected)
+	})
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, int(executor.callCount.Load()), expected)
+
+	cancel()
+	s.Stop()
+}
+
+func TestCatchUp_VeryOldExecution_RecordsMissedAndExecutesRecent(t *testing.T) {
+	// Schedule runs every 10 minutes. Last execution was 2 hours ago.
+	// MaxCatchUpAge is 30 minutes.
+	// Windows between 2h and 30m ago: MISSED (audit only).
+	// Windows within 30m: executed.
+	cronExpr := "0 */10 * * * *"
+	now := time.Now().UTC()
+	lastExecTime := now.Add(-2 * time.Hour)
+	maxCatchUpAge := 30 * time.Minute
+	catchUpCutoff := now.Add(-maxCatchUpAge)
+
+	store := &stubExecutionStore{}
+	oldExec := scheduler.Execution{
+		SchedulerName: "test-scheduler",
+		ScheduleID:    "sched-1",
+		ScheduledAt:   lastExecTime,
+		Status:        scheduler.ExecutionStatusCompleted,
+	}
+	_ = store.RecordExecution(context.Background(), oldExec)
+
+	provider := &stubProvider{
+		schedules: []scheduler.Schedule{
+			{ID: "sched-1", CronExpr: cronExpr, TenantID: "tenant1"},
+		},
+	}
+	executor := &stubExecutor{executeCh: make(chan struct{}, 100)}
+	lock := &stubLock{acquired: true}
+
+	s := newTestScheduler(provider, executor, lock,
+		scheduler.CronSchedulerConfig{
+			Name:            "test-scheduler",
+			RefreshInterval: time.Hour,
+			ShutdownTimeout: 2 * time.Second,
+			MaxCatchUpAge:   maxCatchUpAge,
+		},
+		scheduler.WithCronExecutionStore(store),
+	)
+
+	expectedExecuted := expectedWindowCount(t, cronExpr, catchUpCutoff, now)
+	expectedMissed := expectedWindowCount(t, cronExpr, lastExecTime, catchUpCutoff)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		_ = s.Start(ctx)
+	}()
+
+	// Wait for all catch-up processing (executed + missed should appear in store).
+	totalExpected := expectedExecuted + expectedMissed
+	err := await.New().AtMost(5 * time.Second).PollInterval(50 * time.Millisecond).Until(func() bool {
+		execs := store.getExecutions()
+		// Subtract the seed execution.
+		catchUpRecords := len(execs) - 1
+		return catchUpRecords >= totalExpected
+	})
+	require.NoError(t, err)
+
+	// Verify executor was called only for recent windows.
+	assert.GreaterOrEqual(t, int(executor.callCount.Load()), expectedExecuted)
+
+	// Verify MISSED records exist.
+	execs := store.getExecutions()
+	missedCount := 0
+	for _, e := range execs {
+		if e.Status == scheduler.ExecutionStatusMissed {
+			missedCount++
+		}
+	}
+	assert.GreaterOrEqual(t, missedCount, expectedMissed,
+		"should have MISSED records for windows beyond MaxCatchUpAge")
+
+	cancel()
+	s.Stop()
+}
+
+func TestCatchUp_NoExecutionStore_IsNoOp(t *testing.T) {
+	provider := &stubProvider{
+		schedules: []scheduler.Schedule{
+			{ID: "sched-1", CronExpr: "0 */10 * * * *", TenantID: "tenant1"},
+		},
+	}
+	executor := &stubExecutor{}
+	lock := &stubLock{acquired: true}
+
+	// No execution store configured.
+	s := newTestScheduler(provider, executor, lock,
+		scheduler.CronSchedulerConfig{
+			Name:            "test-scheduler",
+			RefreshInterval: time.Hour,
+			ShutdownTimeout: 2 * time.Second,
+			MaxCatchUpAge:   time.Hour,
+		},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		_ = s.Start(ctx)
+	}()
+
+	err := await.New().AtMost(2 * time.Second).PollInterval(50 * time.Millisecond).Until(func() bool {
+		return s.ScheduleCount() == 1
+	})
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Executor should not have been called by catch-up (no store = no catch-up).
+	assert.Equal(t, int32(0), executor.callCount.Load())
+
+	cancel()
+	s.Stop()
+}
+
+func TestCatchUp_MultipleSchedules_IndependentCatchUp(t *testing.T) {
+	// Two schedules with different cron expressions and different staleness.
+	now := time.Now().UTC()
+	maxCatchUpAge := time.Hour
+
+	store := &stubExecutionStore{}
+	// sched-1: last executed 40 minutes ago, runs every 10 min
+	_ = store.RecordExecution(context.Background(), scheduler.Execution{
+		SchedulerName: "test-scheduler",
+		ScheduleID:    "sched-1",
+		ScheduledAt:   now.Add(-40 * time.Minute),
+		Status:        scheduler.ExecutionStatusCompleted,
+	})
+	// sched-2: last executed 20 minutes ago, runs every 15 min
+	_ = store.RecordExecution(context.Background(), scheduler.Execution{
+		SchedulerName: "test-scheduler",
+		ScheduleID:    "sched-2",
+		ScheduledAt:   now.Add(-20 * time.Minute),
+		Status:        scheduler.ExecutionStatusCompleted,
+	})
+
+	provider := &stubProvider{
+		schedules: []scheduler.Schedule{
+			{ID: "sched-1", CronExpr: "0 */10 * * * *", TenantID: "tenant1"},
+			{ID: "sched-2", CronExpr: "0 */15 * * * *", TenantID: "tenant1"},
+		},
+	}
+
+	var mu sync.Mutex
+	callsBySchedule := make(map[string]int)
+	executor := &stubExecutor{
+		executeFunc: func(_ context.Context, schedule scheduler.Schedule) error {
+			mu.Lock()
+			callsBySchedule[schedule.ID]++
+			mu.Unlock()
+			return nil
+		},
+	}
+	lock := &stubLock{acquired: true}
+
+	s := newTestScheduler(provider, executor, lock,
+		scheduler.CronSchedulerConfig{
+			Name:            "test-scheduler",
+			RefreshInterval: time.Hour,
+			ShutdownTimeout: 2 * time.Second,
+			MaxCatchUpAge:   maxCatchUpAge,
+		},
+		scheduler.WithCronExecutionStore(store),
+	)
+
+	expected1 := expectedWindowCount(t, "0 */10 * * * *", now.Add(-40*time.Minute), now)
+	expected2 := expectedWindowCount(t, "0 */15 * * * *", now.Add(-20*time.Minute), now)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		_ = s.Start(ctx)
+	}()
+
+	totalExpected := expected1 + expected2
+	err := await.New().AtMost(5 * time.Second).PollInterval(50 * time.Millisecond).Until(func() bool {
+		return executor.callCount.Load() >= int32(totalExpected)
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	calls1 := callsBySchedule["sched-1"]
+	calls2 := callsBySchedule["sched-2"]
+	mu.Unlock()
+
+	assert.GreaterOrEqual(t, calls1, expected1,
+		"sched-1 should have caught up independently")
+	assert.GreaterOrEqual(t, calls2, expected2,
+		"sched-2 should have caught up independently")
+
+	cancel()
+	s.Stop()
+}
+
+func TestCatchUp_LockNotAcquired_SkipsCatchUp(t *testing.T) {
+	// When the catch-up lock cannot be acquired, no catch-up should happen.
+	store := &stubExecutionStore{}
+	provider := &stubProvider{
+		schedules: []scheduler.Schedule{
+			{ID: "sched-1", CronExpr: "0 */10 * * * *", TenantID: "tenant1"},
+		},
+	}
+	executor := &stubExecutor{}
+	lock := &stubLock{acquired: false}
+
+	s := newTestScheduler(provider, executor, lock,
+		scheduler.CronSchedulerConfig{
+			Name:            "test-scheduler",
+			RefreshInterval: time.Hour,
+			ShutdownTimeout: 2 * time.Second,
+			MaxCatchUpAge:   time.Hour,
+		},
+		scheduler.WithCronExecutionStore(store),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		_ = s.Start(ctx)
+	}()
+
+	// Wait for scheduler to start (schedule won't register since lock fails for cron too).
+	// Instead, wait a moment for the start sequence to complete.
+	time.Sleep(500 * time.Millisecond)
+
+	// No catch-up records should exist.
+	execs := store.getExecutions()
+	assert.Empty(t, execs, "no catch-up records when lock not acquired")
+	assert.Equal(t, int32(0), executor.callCount.Load())
+
+	cancel()
+	s.Stop()
+}

--- a/shared/platform/scheduler/catchup_test.go
+++ b/shared/platform/scheduler/catchup_test.go
@@ -78,14 +78,15 @@ func TestCatchUp_NoPriorExecution_CatchesUpFromMaxAge(t *testing.T) {
 		scheduler.WithCronExecutionStore(store),
 	)
 
+	// Capture now before starting the scheduler to avoid race at cron boundaries.
+	now := time.Now().UTC()
+	expected := expectedWindowCount(t, cronExpr, now.Add(-maxCatchUpAge), now)
+	require.Greater(t, expected, 0, "should have at least one expected window")
+
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		_ = s.Start(ctx)
 	}()
-
-	now := time.Now().UTC()
-	expected := expectedWindowCount(t, cronExpr, now.Add(-maxCatchUpAge), now)
-	require.Greater(t, expected, 0, "should have at least one expected window")
 
 	err := await.New().AtMost(5 * time.Second).PollInterval(50 * time.Millisecond).Until(func() bool {
 		return executor.callCount.Load() >= int32(expected)

--- a/shared/platform/scheduler/cron.go
+++ b/shared/platform/scheduler/cron.go
@@ -48,6 +48,10 @@ type CronSchedulerConfig struct {
 	ShutdownTimeout time.Duration
 	// ExecutionTimeout is the maximum time a single job execution can take.
 	ExecutionTimeout time.Duration
+	// MaxCatchUpAge is the maximum age of missed cron windows to re-execute on startup.
+	// Windows older than this are recorded as MISSED but not executed.
+	// Default: 1 hour.
+	MaxCatchUpAge time.Duration
 }
 
 func (c CronSchedulerConfig) withDefaults() CronSchedulerConfig {
@@ -62,6 +66,9 @@ func (c CronSchedulerConfig) withDefaults() CronSchedulerConfig {
 	}
 	if c.ExecutionTimeout <= 0 {
 		c.ExecutionTimeout = 5 * time.Minute
+	}
+	if c.MaxCatchUpAge <= 0 {
+		c.MaxCatchUpAge = time.Hour
 	}
 	return c
 }
@@ -79,6 +86,7 @@ type CronScheduler struct {
 	logger    *slog.Logger
 
 	cron      *cron.Cron
+	parser    cron.Parser
 	mu        sync.Mutex
 	entryIDs  map[string]cron.EntryID
 	schedules map[string]Schedule
@@ -99,11 +107,11 @@ func NewCronScheduler(
 		logger = slog.Default()
 	}
 
+	defaultParser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+
 	cronRunner := cron.New(
 		cron.WithLocation(time.UTC),
-		cron.WithParser(cron.NewParser(
-			cron.Minute|cron.Hour|cron.Dom|cron.Month|cron.Dow,
-		)),
+		cron.WithParser(defaultParser),
 	)
 
 	s := &CronScheduler{
@@ -114,6 +122,7 @@ func NewCronScheduler(
 		config:    config,
 		logger:    logger.With("component", config.Name),
 		cron:      cronRunner,
+		parser:    defaultParser,
 		entryIDs:  make(map[string]cron.EntryID),
 		schedules: make(map[string]Schedule),
 	}
@@ -136,10 +145,20 @@ func WithCronExecutionStore(store ExecutionStore) CronSchedulerOption {
 }
 
 // WithCronRunner replaces the default cron runner (e.g. to inject a
-// seconds-level parser for faster tests).
+// seconds-level parser for faster tests). When using a custom runner with a
+// different parser, also use WithCronParser so that catch-up logic can parse
+// cron expressions consistently.
 func WithCronRunner(c *cron.Cron) CronSchedulerOption {
 	return func(s *CronScheduler) {
 		s.cron = c
+	}
+}
+
+// WithCronParser overrides the cron expression parser used by catch-up logic.
+// This must match the parser configured on the cron runner.
+func WithCronParser(p cron.Parser) CronSchedulerOption {
+	return func(s *CronScheduler) {
+		s.parser = p
 	}
 }
 
@@ -155,6 +174,9 @@ func (s *CronScheduler) Start(ctx context.Context) error {
 		if err := s.refreshSchedules(workCtx); err != nil {
 			s.logger.Error("failed to load initial schedules", "error", err)
 		}
+
+		// Run catch-up for missed windows before starting live cron
+		s.runCatchUp(workCtx)
 
 		s.cron.Start()
 		defer func() {


### PR DESCRIPTION
## Summary
- Adds missed-window detection and re-execution on CronScheduler startup
- Walks cron expressions from last known execution to present
- Records MISSED status for windows beyond MaxCatchUpAge (audit trail only, no execution)
- Leader-only catch-up via dedicated distributed lock (`{schedulerName}:catch-up`)
- Per-schedule locks acquired for each caught-up execution (consistent with normal executeJob)

## Changes
- `shared/platform/scheduler/catchup.go` -- catch-up detection and execution logic
- `shared/platform/scheduler/catchup_test.go` -- 7 scenario tests covering all catch-up paths
- `shared/platform/scheduler/cron.go` -- MaxCatchUpAge config field, parser field, Start() integration, WithCronParser option

## Test plan
- [x] No prior execution: catches up from now - MaxCatchUpAge
- [x] Recent execution: no catch-up needed
- [x] Stale execution within MaxCatchUpAge: catches up from last execution
- [x] Very old execution beyond MaxCatchUpAge: records MISSED for old windows, executes recent ones
- [x] No execution store: catch-up is a no-op
- [x] Multiple schedules: each caught up independently
- [x] Lock not acquired: catch-up skipped entirely
- [x] `go test ./shared/platform/scheduler/... -count=1 -v` passes (all existing + new tests)
- [x] `go vet` clean
- [x] `golangci-lint` clean