### PR TITLE
refactor: Remove obsolete nil guards from withdrawal handlers

### DIFF
--- a/services/current-account/service/grpc_withdrawal_execute.go
+++ b/services/current-account/service/grpc_withdrawal_execute.go
@@ -49,11 +49,6 @@ func (s *Service) ExecuteWithdrawal(ctx context.Context, req *pb.ExecuteWithdraw
 
 	if req.WithdrawalId != "" {
 		// Look up pending withdrawal by reference
-		if s.withdrawalRepo == nil {
-			operationStatus = opStatusNotImplemented
-			return nil, status.Error(codes.Unimplemented, "withdrawal persistence not configured")
-		}
-
 		var err error
 		pendingWithdrawal, err = s.withdrawalRepo.FindByReference(ctx, req.WithdrawalId)
 		if err != nil {

--- a/services/current-account/service/grpc_withdrawal_manage.go
+++ b/services/current-account/service/grpc_withdrawal_manage.go
@@ -167,12 +167,6 @@ func (s *Service) UpdateWithdrawal(ctx context.Context, req *pb.UpdateWithdrawal
 		return nil, status.Error(codes.InvalidArgument, "withdrawal_id is required")
 	}
 
-	// Check if withdrawal repository is configured
-	if s.withdrawalRepo == nil {
-		operationStatus = opStatusNotImplemented
-		return nil, status.Error(codes.Unimplemented, "withdrawal persistence not configured")
-	}
-
 	// Lookup withdrawal by reference
 	withdrawal, err := s.withdrawalRepo.FindByReference(ctx, req.WithdrawalId)
 	if err != nil {
@@ -251,34 +245,6 @@ func (s *Service) RetrieveWithdrawal(ctx context.Context, req *pb.RetrieveWithdr
 	if req.WithdrawalId == "" && req.AccountId == "" {
 		operationStatus = opStatusMissingIdentifier
 		return nil, status.Error(codes.InvalidArgument, "either withdrawal_id or account_id is required")
-	}
-
-	// Check if withdrawal repository is configured
-	if s.withdrawalRepo == nil {
-		// For backward compatibility, return empty list when listing by account ID
-		// but error when looking up by withdrawal ID
-		if req.WithdrawalId != "" {
-			operationStatus = opStatusNotImplemented
-			return nil, status.Error(codes.Unimplemented, "withdrawal persistence not configured")
-		}
-		// Validate account exists before returning empty list
-		_, err := s.repo.FindByID(ctx, req.AccountId)
-		if err != nil {
-			if errors.Is(err, persistence.ErrAccountNotFound) {
-				operationStatus = opStatusAccountNotFound
-				return nil, status.Errorf(codes.NotFound, "account not found: %s", req.AccountId)
-			}
-			operationStatus = opStatusRetrieveFailed
-			return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
-		}
-		// Return empty list for account queries when repo not configured
-		return &pb.RetrieveWithdrawalResponse{
-			Withdrawals: []*pb.Withdrawal{},
-			Pagination: &commonpb.PaginationResponse{
-				NextPageToken: "",
-				TotalCount:    0,
-			},
-		}, nil
 	}
 
 	// Single withdrawal lookup by ID

--- a/services/current-account/service/withdrawal_test.go
+++ b/services/current-account/service/withdrawal_test.go
@@ -610,10 +610,15 @@ func TestRetrieveWithdrawal_ByAccountID(t *testing.T) {
 	db, ctx, cleanup := setupIntegrationTestDB(t)
 	defer cleanup()
 
+	// Create withdrawal table (withdrawalRepo is unconditionally initialized in production)
+	err := db.AutoMigrate(&persistence.WithdrawalEntity{})
+	require.NoError(t, err, "failed to create withdrawal table")
+
 	repo := persistence.NewRepository(db)
 	_ = createTestAccountWithBalance(t, ctx, repo, "ACC-RET-WTH-001", 100000)
 
 	svc := mustNewService(t, repo, nil)
+	svc.withdrawalRepo = persistence.NewWithdrawalRepository(db)
 
 	req := &pb.RetrieveWithdrawalRequest{
 		AccountId: "ACC-RET-WTH-001",
@@ -623,7 +628,6 @@ func TestRetrieveWithdrawal_ByAccountID(t *testing.T) {
 
 	require.NoError(t, err, "RetrieveWithdrawal should succeed")
 	require.NotNil(t, resp.Withdrawals)
-	// Currently returns empty list as persistence is not implemented
 	assert.Equal(t, int64(0), resp.Pagination.TotalCount)
 }
 


### PR DESCRIPTION
## Summary

- Remove unreachable nil guards for `withdrawalRepo` from `ExecuteWithdrawal`, `UpdateWithdrawal`, and `RetrieveWithdrawal` handlers
- The `withdrawalRepo` is unconditionally initialized in `cmd/main.go:97` via `persistence.NewWithdrawalRepository(db)`, making these guards dead code
- Eliminates the `codes.Unimplemented` / graceful degradation paths that could never be reached in production

## Changes Made

**`services/current-account/service/grpc_withdrawal_execute.go`**
- Removed nil guard at the entry of the `WithdrawalId` branch in `ExecuteWithdrawal` (4 lines)

**`services/current-account/service/grpc_withdrawal_manage.go`**
- Removed nil guard at the entry of `UpdateWithdrawal` (5 lines)
- Removed nil guard block in `RetrieveWithdrawal` that provided empty-list fallback and Unimplemented error (26 lines)

## Task Master

| TM Task | Description |
|---------|-------------|
| account-service-wiring.2 | Remove nil guard from ExecuteWithdrawal handler |
| account-service-wiring.3 | Remove nil guard from UpdateWithdrawal handler |
| account-service-wiring.4 | Remove nil guard from RetrieveWithdrawal handler |

## Test Plan

- [x] Pre-commit hooks pass (gofumpt, golangci-lint, gitleaks)
- [ ] CI pipeline passes