### PR TITLE
feat: Add environment-specific validation for verification config

### DIFF
--- a/services/party/cmd/main.go
+++ b/services/party/cmd/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -94,11 +95,24 @@ func run(logger *slog.Logger) error {
 	}
 	partyService.WithPaymentMethodRepository(pmRepo)
 
-	// Load verification config (graceful - service runs without KYC)
+	// Load verification config with environment-aware validation.
+	// Production: fail fast if config is missing or invalid.
+	// Development: allow service to start without provider (warn and continue).
+	environment := env.GetEnvOrDefault("ENVIRONMENT", "development")
+	isProduction := environment == "production" || environment == "prod"
+
 	verificationCfg, err := config.LoadVerificationConfig()
 	if err != nil {
+		if isProduction {
+			return fmt.Errorf("verification config required in production: %w", err)
+		}
 		logger.Warn("verification config not loaded - KYC provider disabled", "error", err)
 		verificationCfg = nil
+	}
+	if verificationCfg != nil {
+		if err := verificationCfg.ValidateForEnvironment(environment); err != nil {
+			return fmt.Errorf("verification config invalid for environment %q: %w", environment, err)
+		}
 	}
 
 	// Create verification provider and service when configured
@@ -198,10 +212,7 @@ func run(logger *slog.Logger) error {
 		}
 
 		httpMux.HandleFunc("/webhooks/verification/", webhookHandler.HandleWebhook)
-		httpMux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("OK"))
-		})
+		httpMux.HandleFunc("/health", newHTTPHealthHandler(verificationCfg))
 
 		httpPort := env.GetEnvOrDefault("HTTP_PORT", "8081")
 		httpServer := &http.Server{
@@ -262,5 +273,32 @@ func parseLogLevel(levelStr string) slog.Level {
 		return slog.LevelError
 	default:
 		return slog.LevelInfo
+	}
+}
+
+// httpHealthResponse is the JSON structure returned by the HTTP health endpoint.
+type httpHealthResponse struct {
+	Status               string `json:"status"`
+	Timestamp            string `json:"timestamp"`
+	VerificationEnabled  bool   `json:"verification_enabled"`
+	VerificationProvider string `json:"verification_provider,omitempty"`
+}
+
+// newHTTPHealthHandler returns an HTTP handler that reports service health
+// including verification provider status.
+func newHTTPHealthHandler(verificationCfg *config.VerificationConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		resp := httpHealthResponse{
+			Status:    "ok",
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+		}
+		if verificationCfg != nil {
+			resp.VerificationEnabled = true
+			resp.VerificationProvider = verificationCfg.Provider
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
 	}
 }

--- a/services/party/config/verification.go
+++ b/services/party/config/verification.go
@@ -45,6 +45,9 @@ var (
 	ErrEmptyWebhookURLForNonMock    = errors.New("webhook URL is required for non-mock providers")
 	ErrMissingProviderAPIKey        = errors.New("api_key is required in provider config")
 	ErrMissingProviderAPISecret     = errors.New("api_secret is required in provider config")
+	ErrMockProviderInProduction     = errors.New("mock provider not allowed in production")
+	ErrWebhookHTTPSRequired         = errors.New("webhook URL must use HTTPS in production")
+	ErrWebhookSecretTooShort        = errors.New("webhook secret must be at least 32 characters in production")
 )
 
 // SupportedProviders lists all supported verification provider names.
@@ -135,6 +138,31 @@ func (c *VerificationConfig) isSupportedProvider() bool {
 		}
 	}
 	return false
+}
+
+// ValidateForEnvironment validates the configuration with additional
+// constraints based on the deployment environment. In production:
+//   - Mock provider is not allowed
+//   - Webhook URL must use HTTPS
+//   - Webhook secret must be at least 32 characters
+func (c *VerificationConfig) ValidateForEnvironment(environment string) error {
+	if err := c.Validate(); err != nil {
+		return err
+	}
+
+	if strings.ToLower(environment) == "production" || strings.ToLower(environment) == "prod" {
+		if c.IsMock() {
+			return ErrMockProviderInProduction
+		}
+		if !strings.HasPrefix(c.WebhookURL, "https://") {
+			return ErrWebhookHTTPSRequired
+		}
+		if len(c.WebhookSecret) < 32 {
+			return ErrWebhookSecretTooShort
+		}
+	}
+
+	return nil
 }
 
 // IsMock returns true if the mock provider is configured.

--- a/services/party/config/verification.go
+++ b/services/party/config/verification.go
@@ -154,7 +154,7 @@ func (c *VerificationConfig) ValidateForEnvironment(environment string) error {
 		if c.IsMock() {
 			return ErrMockProviderInProduction
 		}
-		if !strings.HasPrefix(c.WebhookURL, "https://") {
+		if !strings.HasPrefix(strings.ToLower(c.WebhookURL), "https://") {
 			return ErrWebhookHTTPSRequired
 		}
 		if len(c.WebhookSecret) < 32 {

--- a/services/party/config/verification_test.go
+++ b/services/party/config/verification_test.go
@@ -263,3 +263,87 @@ func TestVerificationConfig_SupportedProviders(t *testing.T) {
 	assert.Contains(t, SupportedProviders, "onfido")
 	assert.Len(t, SupportedProviders, 3)
 }
+
+func TestVerificationConfig_ValidateForEnvironment_ProductionRejectsMock(t *testing.T) {
+	cfg := &VerificationConfig{
+		Provider: "mock",
+	}
+
+	err := cfg.ValidateForEnvironment("production")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMockProviderInProduction)
+}
+
+func TestVerificationConfig_ValidateForEnvironment_ProductionRejectsHTTPWebhook(t *testing.T) {
+	cfg := &VerificationConfig{
+		Provider:       "jumio",
+		WebhookSecret:  "a]strongsecretthatis32charslong!!", // 32+ chars
+		WebhookURL:     "http://api.example.com/webhooks",   // HTTP, not HTTPS
+		ProviderConfig: map[string]string{"api_key": "key", "api_secret": "secret"},
+	}
+
+	err := cfg.ValidateForEnvironment("production")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrWebhookHTTPSRequired)
+}
+
+func TestVerificationConfig_ValidateForEnvironment_ProductionRejectsWeakSecret(t *testing.T) {
+	cfg := &VerificationConfig{
+		Provider:       "jumio",
+		WebhookSecret:  "short-secret", // < 32 chars
+		WebhookURL:     "https://api.example.com/webhooks",
+		ProviderConfig: map[string]string{"api_key": "key", "api_secret": "secret"},
+	}
+
+	err := cfg.ValidateForEnvironment("production")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrWebhookSecretTooShort)
+}
+
+func TestVerificationConfig_ValidateForEnvironment_DevelopmentAllowsMock(t *testing.T) {
+	cfg := &VerificationConfig{
+		Provider: "mock",
+	}
+
+	err := cfg.ValidateForEnvironment("development")
+
+	assert.NoError(t, err)
+}
+
+func TestVerificationConfig_ValidateForEnvironment_ProductionAcceptsValidConfig(t *testing.T) {
+	cfg := &VerificationConfig{
+		Provider:       "jumio",
+		WebhookSecret:  "a-very-strong-secret-that-is-at-least-32-characters-long",
+		WebhookURL:     "https://api.example.com/webhooks/verification",
+		ProviderConfig: map[string]string{"api_key": "key", "api_secret": "secret"},
+	}
+
+	err := cfg.ValidateForEnvironment("production")
+
+	assert.NoError(t, err)
+}
+
+func TestVerificationConfig_ValidateForEnvironment_ProdShorthandAlsoEnforces(t *testing.T) {
+	cfg := &VerificationConfig{
+		Provider: "mock",
+	}
+
+	err := cfg.ValidateForEnvironment("prod")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMockProviderInProduction)
+}
+
+func TestVerificationConfig_ValidateForEnvironment_RunsBaseValidateFirst(t *testing.T) {
+	cfg := &VerificationConfig{
+		Provider: "", // empty - should fail base Validate()
+	}
+
+	err := cfg.ValidateForEnvironment("production")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEmptyProvider)
+}


### PR DESCRIPTION
## Summary
- Add `ValidateForEnvironment` to enforce production constraints on verification config
- Production: reject mock provider, require HTTPS webhooks, enforce strong secrets (32+ chars)
- Fail fast in production when verification config is missing or invalid
- Enhanced HTTP health endpoint with verification provider status

## Task Master
Tag: party-kyc-aml, Task: 8

## Test plan
- [x] Production rejects mock provider
- [x] Production rejects HTTP webhook URL
- [x] Production rejects weak webhook secret (<32 chars)
- [x] Development allows mock provider
- [x] Production accepts valid config
- [x] Base validation runs before environment checks
- [x] "prod" shorthand also enforces production rules
- [x] Health endpoint reports verification status