### PR TITLE
chore: add Redis dependency to forecasting service infrastructure

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -551,7 +551,7 @@ grpc_microservice(
 grpc_microservice(
     'forecasting',
     grpc_port=50061,  # ports.Forecasting
-    resource_deps=['cockroachdb', 'migrate-forecasting', 'market-information'],
+    resource_deps=['cockroachdb', 'migrate-forecasting', 'market-information', 'redis'],
 )
 
 # Reference Data Service - gRPC microservice for instrument definitions, nodes, and saga definitions

--- a/services/forecasting/k8s/configmap.yaml
+++ b/services/forecasting/k8s/configmap.yaml
@@ -24,5 +24,8 @@ data:
   OTEL_SERVICE_NAME: "forecasting-service"
   OTEL_SAMPLING_RATE: "0.1"
 
+  # Redis configuration (distributed locking for scheduler)
+  REDIS_ADDR: "redis:6379"
+
   # Authentication configuration
   AUTH_ENABLED: "false"

--- a/services/forecasting/k8s/deployment.yaml
+++ b/services/forecasting/k8s/deployment.yaml
@@ -106,4 +106,4 @@ spec:
       volumes:
       - name: tmp
         emptyDir: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60


### PR DESCRIPTION
## Summary
- Adds `redis` to forecasting service `resource_deps` in Tiltfile so it starts after Redis is available
- Adds `REDIS_ADDR: "redis:6379"` to forecasting K8s configmap for distributed locking (consumed by `env.GetEnvOrDefault("REDIS_ADDR", "localhost:6379")` in main.go)
- Increases `terminationGracePeriodSeconds` from 30s to 60s to allow scheduler graceful shutdown

Required after PR #945 added shared scheduler with Redis distributed locking to the forecasting service.

## Changes
- `Tiltfile` -- add `redis` to forecasting `resource_deps`
- `services/forecasting/k8s/configmap.yaml` -- add `REDIS_ADDR` env var
- `services/forecasting/k8s/deployment.yaml` -- increase `terminationGracePeriodSeconds` to 60s

## Test plan
- [ ] Tiltfile syntax valid
- [ ] Forecasting service starts with Redis in local K8s
- [ ] Scheduler acquires distributed lock via Redis