### PR TITLE
docs: Add KYC/AML verification runbook and developer guide

### DIFF
--- a/docs/runbooks/party-kyc-verification.md
+++ b/docs/runbooks/party-kyc-verification.md
@@ -1,0 +1,376 @@
+---
+name: party-kyc-verification
+description: >-
+  Operational procedures for KYC/AML identity verification via Onfido,
+  including setup, monitoring, troubleshooting, and manual operations
+triggers:
+  - Troubleshooting KYC verification failures
+  - Investigating stuck PENDING verifications
+  - Webhook signature validation errors
+  - High manual review rate from Onfido
+  - Timeout handler behavior questions
+  - Force-updating a verification status
+instructions: |
+  Use this runbook for KYC/AML verification operations in the Party service.
+  Verification provider: Onfido (identity_enhanced + watchlist_enhanced checks).
+  Webhook endpoint: POST /webhooks/verification/{provider} on HTTP port (default 8081).
+  Timeout handler polls every 1h for PENDING verifications older than 24h.
+  Terminal statuses: APPROVED, REJECTED, MANUAL_REVIEW. Only PENDING is non-terminal.
+---
+
+# Party KYC/AML Verification Runbook
+
+**When to use this runbook**: Managing KYC/AML identity verification
+operations, investigating webhook failures, resolving stuck verifications,
+or configuring the Onfido integration.
+
+## Verification Flow Overview
+
+The Party service uses Onfido as its external KYC/AML provider.
+The flow is asynchronous:
+
+1. Party onboarding triggers `VerifyIdentity` and `CheckSanctions`
+   calls to Onfido
+2. Onfido creates an applicant, initiates checks
+   (`identity_enhanced`, `watchlist_enhanced`)
+3. Onfido processes the check asynchronously and sends a webhook
+   callback when complete
+4. The webhook handler validates the HMAC signature, parses the
+   result, and updates the verification record
+5. If no webhook arrives within 24 hours, the timeout handler polls
+   Onfido for status and resolves the verification
+
+### Verification Statuses
+
+| Status | Meaning | Terminal |
+|--------|---------|----------|
+| `PENDING` | Awaiting provider result | No |
+| `APPROVED` | Identity verified, sanctions clear | Yes |
+| `REJECTED` | Verification failed or sanctions match | Yes |
+| `MANUAL_REVIEW` | Requires human review | Yes |
+
+### Sanctions Screening Statuses
+
+| Status | Meaning |
+|--------|---------|
+| `CLEAR` | No watchlist matches found |
+| `MATCH` | Potential watchlist match detected |
+| `PENDING` | Screening in progress |
+| `ERROR` | Screening failed |
+
+## Environment Variables
+
+| Variable | Required | Default |
+|----------|----------|---------|
+| `VERIFICATION_PROVIDER` | Yes | - |
+| `VERIFICATION_API_KEY` | Yes (non-mock) | - |
+| `VERIFICATION_API_SECRET` | Yes (non-mock) | - |
+| `VERIFICATION_BASE_URL` | No | `https://api.onfido.com/v3.6` |
+| `VERIFICATION_WEBHOOK_SECRET` | Yes (non-mock) | - |
+| `VERIFICATION_WEBHOOK_URL` | Yes (non-mock) | - |
+| `HTTP_PORT` | No | `8081` |
+| `ENVIRONMENT` | No | `development` |
+| `LOG_LEVEL` | No | `info` |
+
+**Variable descriptions:**
+
+- `VERIFICATION_PROVIDER` -- Provider name: `onfido` (production)
+  or `mock` (development)
+- `VERIFICATION_API_KEY` -- Onfido API token
+- `VERIFICATION_API_SECRET` -- Onfido API secret
+- `VERIFICATION_BASE_URL` -- Onfido API base URL (uses default if
+  not set)
+- `VERIFICATION_WEBHOOK_SECRET` -- HMAC-SHA256 secret for webhook
+  signature validation (min 32 chars in production)
+- `VERIFICATION_WEBHOOK_URL` -- Public URL where Onfido sends
+  callbacks (must be HTTPS in production)
+- `HTTP_PORT` -- Port for the webhook HTTP server
+- `ENVIRONMENT` -- Set to `production` or `prod` for strict
+  validation
+- `LOG_LEVEL` -- Logging level: `debug`, `info`, `warn`, `error`
+
+### Production Validation Rules
+
+When `ENVIRONMENT` is `production` or `prod`:
+
+- `mock` provider is rejected (`ErrMockProviderInProduction`)
+- Webhook URL must use HTTPS
+- Webhook secret must be at least 32 characters
+
+## Onfido Setup
+
+### 1. Create an Onfido Account
+
+Obtain API credentials from the Onfido dashboard. You need:
+
+- An API token (used as `VERIFICATION_API_KEY`)
+- A webhook secret (used as `VERIFICATION_WEBHOOK_SECRET`)
+
+### 2. Configure Webhook in Onfido Dashboard
+
+Register a webhook endpoint in Onfido pointing to your deployment:
+
+```text
+URL: https://<your-domain>/webhooks/verification/onfido
+Events: check.completed
+```
+
+The webhook handler extracts the provider name from the URL path
+segment after `/webhooks/verification/`.
+
+### 3. Set Environment Variables
+
+```bash
+export VERIFICATION_PROVIDER=onfido
+export VERIFICATION_API_KEY=<your-onfido-api-token>
+export VERIFICATION_API_SECRET=<your-onfido-api-secret>
+export VERIFICATION_WEBHOOK_SECRET=<your-webhook-secret-min-32-chars>
+export VERIFICATION_WEBHOOK_URL=\
+  https://<your-domain>/webhooks/verification/onfido
+export ENVIRONMENT=production
+```
+
+### 4. Verify Configuration
+
+The service validates configuration at startup. Check logs for:
+
+```json
+{"msg":"verification provider initialized","provider":"onfido"}
+{"msg":"starting HTTP server for webhooks","port":"8081"}
+```
+
+If configuration is invalid in production, the service exits
+immediately. In development, it logs a warning and starts without
+verification:
+
+```json
+{"msg":"verification config not loaded - KYC provider disabled"}
+```
+
+## Monitoring
+
+### Key Log Entries
+
+| Log Message | Level |
+|-------------|-------|
+| `verification provider initialized` | INFO |
+| `identity verification initiated` | INFO |
+| `sanctions screening initiated` | INFO |
+| `webhook processed successfully` | INFO |
+| `webhook already processed (idempotent)` | INFO |
+| `invalid webhook signature` | WARN |
+| `missing webhook signature` | WARN |
+| `webhook timestamp too old` | WARN |
+| `timed-out verification resolved` | INFO |
+| `authentication failed` | ERROR |
+| `rate limited by Onfido API` | WARN |
+| `timeout handler started` | INFO |
+
+### Health Check
+
+The HTTP server exposes a health endpoint:
+
+```bash
+curl http://<host>:8081/health
+```
+
+Response:
+
+```json
+{
+  "status": "ok",
+  "timestamp": "2026-02-14T12:00:00Z",
+  "verification_enabled": true,
+  "verification_provider": "onfido"
+}
+```
+
+## Troubleshooting
+
+### Stuck PENDING Verifications
+
+**Symptoms**: Verifications remain in `PENDING` status indefinitely.
+
+**Automatic resolution**: The timeout handler runs every 1 hour and
+checks for verifications older than 24 hours. For each stuck
+verification, it:
+
+1. Calls `GetVerificationStatus` on the Onfido API to check if a
+   result is available
+2. If Onfido returns a terminal status (`complete` with
+   `clear`/`consider`/other), uses that status
+3. If Onfido still returns `in_progress`, escalates to
+   `MANUAL_REVIEW` with reason "Verification timed out after 24h"
+
+**Manual investigation**:
+
+```sql
+-- Find PENDING verifications older than 24 hours
+SELECT id, party_id, verification_id, provider, status, created_at
+FROM party_verifications
+WHERE status = 'PENDING'
+  AND created_at < NOW() - INTERVAL '24 hours'
+ORDER BY created_at;
+```
+
+**Possible causes**:
+
+- Onfido webhook not configured or pointing to wrong URL
+- Network/firewall blocking incoming webhooks
+- Webhook signature mismatch causing rejection
+- Onfido experiencing delays in processing
+
+### Webhook Signature Failures
+
+**Symptoms**: Logs show `invalid webhook signature` or
+`missing webhook signature`.
+
+**Diagnosis**:
+
+1. Verify `VERIFICATION_WEBHOOK_SECRET` matches the secret
+   configured in Onfido dashboard
+2. Check that the webhook request includes the
+   `X-Webhook-Signature` header
+3. The signature must be a hex-encoded HMAC-SHA256 of the raw
+   request body using the shared secret
+
+**Signature computation**:
+
+```text
+HMAC-SHA256(body, secret) -> hex_encode -> X-Webhook-Signature
+```
+
+**Common causes**:
+
+- Secret mismatch between Onfido dashboard and environment variable
+- Reverse proxy modifying the request body before it reaches the
+  handler
+- Using a different HMAC algorithm (must be SHA-256)
+
+### High Manual Review Rate
+
+**Symptoms**: Large percentage of verifications ending in
+`MANUAL_REVIEW`.
+
+**Onfido status mapping**:
+
+| Onfido Status | Onfido Result | Meridian Status |
+|---------------|---------------|-----------------|
+| `in_progress` | - | `PENDING` |
+| `complete` | `clear` | `APPROVED` |
+| `complete` | `consider` | `MANUAL_REVIEW` |
+| `complete` | (other) | `REJECTED` |
+| `paused` | - | `MANUAL_REVIEW` |
+| `withdrawn` | - | `REJECTED` |
+| (timeout, still pending) | - | `MANUAL_REVIEW` |
+
+**Investigation steps**:
+
+- Check if Onfido is returning `consider` results (document quality
+  issues, partial matches)
+- Check if verifications are timing out (look for
+  "Verification timed out" in reason field)
+- Review Onfido dashboard for applicant-level details
+
+### Timeout Handler Not Running
+
+**Symptoms**: No `timeout handler started` log entry, stuck
+verifications not being resolved.
+
+**Possible causes**:
+
+- Verification config not loaded (check for
+  `verification config not loaded` warning)
+- Service started without `VERIFICATION_PROVIDER` set
+- Timeout handler creation failed (check for
+  `failed to create timeout handler` error)
+
+The timeout handler starts only when both `verificationSvc` and
+`verificationCfg` are non-nil (i.e., verification is fully
+configured).
+
+### Onfido API Errors
+
+| Error | Meaning | Action |
+|-------|---------|--------|
+| `onfido: unauthorized` | 401 | Check API key |
+| `onfido: rate limited` | 429 | Back off; auto-recovers |
+| `onfido: server error` | 5xx | Transient; retries next attempt |
+| `onfido: validation error` | 422 | Check request data |
+
+## Manual Operations
+
+### Force-Update a Verification Status
+
+To manually resolve a stuck or incorrectly-classified verification,
+update the database directly:
+
+```sql
+-- Update a specific verification to APPROVED
+UPDATE party_verifications
+SET status = 'APPROVED',
+    risk_score = 0.1,
+    reason = 'Manually approved by operator',
+    completed_at = NOW(),
+    version = version + 1,
+    updated_at = NOW()
+WHERE id = '<verification-uuid>'
+  AND status = 'PENDING';
+```
+
+```sql
+-- Update a specific verification to MANUAL_REVIEW
+UPDATE party_verifications
+SET status = 'MANUAL_REVIEW',
+    reason = 'Escalated for manual review by operator',
+    completed_at = NOW(),
+    version = version + 1,
+    updated_at = NOW()
+WHERE id = '<verification-uuid>'
+  AND status = 'PENDING';
+```
+
+The `version` column implements optimistic locking. Always increment
+it and include the current status in the `WHERE` clause to avoid
+overwriting concurrent updates.
+
+### Query Verification History for a Party
+
+```sql
+SELECT id, verification_id, provider, status, risk_score, reason,
+       created_at, completed_at
+FROM party_verifications
+WHERE party_id = '<party-uuid>'
+ORDER BY created_at DESC;
+```
+
+### Replay a Webhook Manually
+
+If a webhook was lost or rejected, you can replay it using the same
+format the handler expects:
+
+```bash
+# Generate the HMAC signature
+BODY='{"verification_id":"<onfido-check-id>","status":"APPROVED",'\
+'"risk_score":0.1,"reason":"Identity verified",'\
+'"timestamp":"2026-02-14T12:00:00Z"}'
+SIGNATURE=$(echo -n "$BODY" \
+  | openssl dgst -sha256 -hmac "<webhook-secret>" \
+  | awk '{print $2}')
+
+# Send the webhook
+curl -X POST http://<host>:8081/webhooks/verification/onfido \
+  -H "Content-Type: application/json" \
+  -H "X-Webhook-Signature: $SIGNATURE" \
+  -d "$BODY"
+```
+
+The handler is idempotent: if the verification is already in a
+terminal state, it returns success without modifying the record.
+
+### Webhook Timestamp Validation
+
+The handler rejects webhooks with timestamps older than 5 minutes
+(`DefaultWebhookMaxAge`) or more than 30 seconds in the future
+(`DefaultClockDriftTolerance`). If replaying a webhook, ensure the
+timestamp is current.

--- a/docs/services/party/verification-guide.md
+++ b/docs/services/party/verification-guide.md
@@ -1,0 +1,338 @@
+# KYC/AML Verification Developer Guide
+
+This guide covers the architecture, extension points, and testing
+approach for the Party service's KYC/AML verification system.
+
+## Architecture Overview
+
+The verification system follows a provider-adapter pattern. The
+`Provider` interface abstracts external KYC services, the webhook
+handler receives asynchronous results, and the timeout handler
+resolves stuck verifications.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant PartyService
+    participant VerificationService
+    participant OnfidoProvider
+    participant Onfido API
+    participant WebhookHandler
+    participant TimeoutHandler
+    participant Database
+
+    Client->>PartyService: ExchangeDemographics
+    PartyService->>OnfidoProvider: VerifyIdentity(party)
+    OnfidoProvider->>Onfido API: POST /applicants
+    Onfido API-->>OnfidoProvider: applicant_id
+    OnfidoProvider->>Onfido API: POST /checks
+    Onfido API-->>OnfidoProvider: check_id (in_progress)
+    OnfidoProvider-->>PartyService: Result(PENDING)
+    PartyService->>Database: Store verification
+    PartyService-->>Client: Party created
+
+    Note over Onfido API,WebhookHandler: Async callback
+
+    Onfido API->>WebhookHandler: POST /webhooks/verification/onfido
+    WebhookHandler->>WebhookHandler: Validate HMAC-SHA256
+    WebhookHandler->>VerificationService: UpdateVerification
+    VerificationService->>Database: Update status
+
+    Note over TimeoutHandler,Database: Fallback (24h)
+
+    TimeoutHandler->>Database: List PENDING > 24h
+    TimeoutHandler->>OnfidoProvider: GetVerificationStatus
+    OnfidoProvider->>Onfido API: GET /checks/{id}
+    Onfido API-->>OnfidoProvider: status, result
+    TimeoutHandler->>Database: Update to terminal status
+```
+
+### Key Components
+
+| Component | Location |
+|-----------|----------|
+| `Provider` interface | `verification/provider.go` |
+| `OnfidoProvider` | `verification/onfido_provider.go` |
+| `MockProvider` | `verification/mock_provider.go` |
+| Provider factory | `verification/factory.go` |
+| `VerificationConfig` | `config/verification.go` |
+| `VerificationService` | `service/verification_service.go` |
+| Webhook handler | `adapters/http/verification_webhook.go` |
+| `TimeoutHandler` | `verification/timeout_handler.go` |
+| Verification repo | `adapters/persistence/verification_repository.go` |
+| Main wiring | `cmd/main.go` |
+
+All paths are relative to `services/party/`.
+
+## Adding a New Provider
+
+To add a new verification provider (e.g., Jumio):
+
+### 1. Implement the Provider Interface
+
+Create `services/party/verification/jumio_provider.go`:
+
+```go
+package verification
+
+import (
+    "context"
+    "errors"
+    "log/slog"
+
+    "github.com/meridianhub/meridian/services/party/config"
+    "github.com/meridianhub/meridian/services/party/domain"
+)
+
+type JumioProvider struct {
+    apiKey  string
+    baseURL string
+    // ...
+}
+
+// Compile-time interface check
+var _ Provider = (*JumioProvider)(nil)
+
+func NewJumioProvider(
+    cfg *config.VerificationConfig,
+    logger *slog.Logger,
+) (*JumioProvider, error) {
+    apiKey := cfg.ProviderConfig["api_key"]
+    if apiKey == "" {
+        return nil, errors.New("jumio: api_key is required")
+    }
+    // ...
+}
+
+func (p *JumioProvider) VerifyIdentity(
+    ctx context.Context,
+    party *domain.Party,
+) (Result, error) {
+    // Call Jumio API, return Result with VerificationID
+}
+
+func (p *JumioProvider) CheckSanctions(
+    ctx context.Context,
+    party *domain.Party,
+) (SanctionsResult, error) {
+    // Call Jumio screening API
+}
+
+func (p *JumioProvider) GetVerificationStatus(
+    ctx context.Context,
+    verificationID string,
+) (Result, error) {
+    // Poll Jumio for check status
+}
+```
+
+The three interface methods:
+
+- **`VerifyIdentity`**: Creates an applicant/subject and initiates
+  an identity check. Returns a `Result` with a `VerificationID`
+  that the provider uses to track the check.
+- **`CheckSanctions`**: Initiates a sanctions/watchlist screening.
+  Returns a `SanctionsResult` with match details.
+- **`GetVerificationStatus`**: Retrieves the current status of a
+  previously initiated check (used by the timeout handler).
+
+### 2. Register in the Factory
+
+Update `services/party/verification/factory.go`:
+
+```go
+case "jumio":
+    return NewJumioProvider(cfg, slog.Default())
+```
+
+The factory already has a `"jumio"` stub that returns
+`ErrUnsupportedProvider`. Replace it with the actual constructor.
+
+### 3. Update Config Validation
+
+The `SupportedProviders` list in
+`services/party/config/verification.go` already includes `"jumio"`.
+If adding a different provider, add it to the list:
+
+```go
+var SupportedProviders = []string{
+    "mock", "jumio", "onfido", "your_provider",
+}
+```
+
+### 4. Configure Webhook Secret
+
+If the new provider uses a different webhook secret, the
+`VerificationWebhookHandler` supports per-provider secrets via the
+`HMACSecrets` map:
+
+```go
+HMACSecrets: map[string][]byte{
+    "onfido": []byte(onfidoSecret),
+    "jumio":  []byte(jumioSecret),
+},
+```
+
+The handler extracts the provider name from the URL path
+(`/webhooks/verification/{provider}`) and looks up the
+corresponding secret. If not found, it falls back to the
+`"default"` key.
+
+## Webhook Signature Validation
+
+The webhook handler uses HMAC-SHA256 to verify incoming requests:
+
+1. The provider sends the request body with an
+   `X-Webhook-Signature` header containing a hex-encoded
+   HMAC-SHA256 hash
+2. The handler computes `HMAC-SHA256(request_body, shared_secret)`
+   and hex-encodes the result
+3. The two values are compared using `hmac.Equal` (constant-time
+   comparison to prevent timing attacks)
+
+### Replay Protection
+
+The handler validates the `timestamp` field in the webhook payload:
+
+- Rejects timestamps older than 5 minutes
+  (`DefaultWebhookMaxAge`)
+- Rejects timestamps more than 30 seconds in the future
+  (`DefaultClockDriftTolerance`)
+
+### Idempotency
+
+If a webhook arrives for a verification already in a terminal state
+(`APPROVED`, `REJECTED`, `MANUAL_REVIEW`), the handler returns
+HTTP 200 with `"webhook already processed"` without modifying the
+record. This handles provider retries gracefully.
+
+## Testing
+
+### Unit Tests
+
+Unit tests use the `MockProvider` which supports two modes:
+
+**Synchronous mode** (default): Returns a final status immediately.
+
+```go
+provider := verification.NewMockProvider().
+    WithAlwaysApprove(true)
+result, err := provider.VerifyIdentity(ctx, party)
+// result.Status == APPROVED
+```
+
+**Asynchronous mode**: Returns `PENDING` initially, transitions to
+final status after the configured delay.
+
+```go
+provider := verification.NewMockProvider().
+    WithAsyncMode(true).
+    WithSimulatedDelay(100 * time.Millisecond)
+
+result, _ := provider.VerifyIdentity(ctx, party)
+// result.Status == PENDING
+
+time.Sleep(150 * time.Millisecond)
+status, _ := provider.GetVerificationStatus(
+    ctx, result.VerificationID,
+)
+// status.Status == APPROVED
+```
+
+### Webhook Handler Tests
+
+Test the webhook handler by constructing signed requests using the
+`GenerateWebhookSignature` helper:
+
+```go
+body, _ := json.Marshal(
+    httpAdapter.VerificationWebhookRequest{
+        VerificationID: "test-check-id",
+        Status:         "APPROVED",
+        RiskScore:      float64Ptr(0.1),
+        Timestamp:      time.Now().UTC(),
+    },
+)
+
+signature := httpAdapter.GenerateWebhookSignature(
+    body, []byte("test-secret"),
+)
+
+req := httptest.NewRequest(
+    http.MethodPost,
+    "/webhooks/verification/onfido",
+    bytes.NewReader(body),
+)
+req.Header.Set("X-Webhook-Signature", signature)
+req.Header.Set("Content-Type", "application/json")
+```
+
+### Integration Tests
+
+Integration tests live in
+`services/party/verification/integration_test.go` and use
+CockroachDB testcontainers for database operations. They test the
+full flow from verification creation through webhook update.
+
+### Manual Testing with Onfido Sandbox
+
+Onfido provides a sandbox environment for testing without real
+identity documents:
+
+1. Set `VERIFICATION_BASE_URL` to the Onfido sandbox URL (or omit
+   to use the default, which works with sandbox API tokens)
+2. Use sandbox API tokens from the Onfido dashboard
+3. Create applicants with Onfido's test names to trigger specific
+   outcomes:
+   - Standard names return `clear` results
+   - Specific test names trigger `consider` or rejection results
+     (refer to Onfido sandbox documentation)
+
+### Running Tests
+
+```bash
+# Unit tests for verification package
+cd services/party
+go test ./verification/... -v
+
+# Unit tests for webhook handler
+go test ./adapters/http/... -v
+
+# Unit tests for verification service
+go test ./service/... -v -run TestVerification
+
+# Integration tests (requires Docker for testcontainers)
+go test ./verification/... -v -run Integration
+```
+
+## Common Pitfalls
+
+**Onfido requires a last name**: The `splitName` function in
+`onfido_provider.go` handles single-word names by using `"-"` as
+the last name, since Onfido's API requires both fields.
+
+**Webhook body modification**: If a reverse proxy or middleware
+modifies the request body (e.g., re-encoding JSON), the HMAC
+signature will not match. Ensure the raw body reaches the handler
+unchanged.
+
+**Optimistic locking on updates**: The verification repository uses
+a `version` column for optimistic locking.
+`UpdateVerificationStatus` requires the current version and
+increments it. Concurrent updates to the same verification will
+fail with a conflict, which is the intended behavior to prevent
+race conditions between webhook delivery and timeout handler.
+
+**Webhook max body size**: The handler limits request body reads to
+1 MB (`1 << 20` bytes). Onfido payloads are well within this
+limit, but custom providers with large metadata payloads may need
+adjustment.
+
+**Event publisher is optional**: The `VerificationService` accepts
+a nil `eventPublisher`. When nil, no events are emitted on status
+transitions. This is the current state -- event publishing will be
+wired when the outbox pattern integration is complete.
+
+**Mock provider in production**: The config validator rejects
+`VERIFICATION_PROVIDER=mock` when `ENVIRONMENT` is `production` or
+`prod`. This prevents accidental deployment with the test provider.


### PR DESCRIPTION
## Summary
- Operator runbook for KYC/AML verification operations (`docs/runbooks/party-kyc-verification.md`)
- Developer guide for extending the verification system (`docs/services/party/verification-guide.md`)
- Covers Onfido integration, webhook handling, timeout behavior, and adding new providers

## Task Master
Tag: party-kyc-aml, Task: 10

## Test plan
- [ ] All environment variables documented
- [ ] Setup steps clear and actionable
- [ ] Troubleshooting covers common scenarios (stuck PENDING, webhook failures, timeouts)
- [ ] Developer guide includes code examples for adding a new provider
- [ ] Mermaid architecture diagram renders correctly