### PR TITLE
feat: Enable mock KYC/AML provider in local Tilt environment

### DIFF
--- a/services/party/k8s/configmap.yaml
+++ b/services/party/k8s/configmap.yaml
@@ -26,3 +26,8 @@ data:
 
   # Authentication configuration
   AUTH_ENABLED: "false"
+
+  # KYC/AML verification - mock provider for local development
+  VERIFICATION_PROVIDER: "mock"
+  ENVIRONMENT: "development"
+  HTTP_PORT: "8081"

--- a/services/party/k8s/deployment.yaml
+++ b/services/party/k8s/deployment.yaml
@@ -40,6 +40,9 @@ spec:
         - name: grpc
           containerPort: 50055
           protocol: TCP
+        - name: http
+          containerPort: 8081
+          protocol: TCP
         envFrom:
         - configMapRef:
             name: party-config

--- a/services/party/k8s/deployment.yaml
+++ b/services/party/k8s/deployment.yaml
@@ -1,5 +1,5 @@
 # Port Configuration: See shared/platform/ports/ports.go for canonical port assignments.
-# This service uses ports.Party for gRPC.
+# This service uses ports.Party for gRPC and ports.HTTPHealth for HTTP webhooks/health.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/services/party/k8s/service.yaml
+++ b/services/party/k8s/service.yaml
@@ -1,5 +1,5 @@
 # Port Configuration: See shared/platform/ports/ports.go for canonical port assignments.
-# This service uses ports.Party for gRPC.
+# This service uses ports.Party for gRPC and ports.HTTPHealth for HTTP webhooks/health.
 apiVersion: v1
 kind: Service
 metadata:

--- a/services/party/k8s/service.yaml
+++ b/services/party/k8s/service.yaml
@@ -15,5 +15,9 @@ spec:
     port: 50055
     targetPort: grpc
     protocol: TCP
+  - name: http
+    port: 8081
+    targetPort: http
+    protocol: TCP
   selector:
     app: party


### PR DESCRIPTION
## Summary
- Configures party service to use the built-in mock verification provider (`VERIFICATION_PROVIDER=mock`) when running locally via Tilt
- Exposes HTTP port 8081 for webhook endpoint in deployment and service manifests
- Enables the full KYC/AML flow (identity checks, sanctions screening, webhooks, timeout handler) without an external provider account

## Changes Made
- `services/party/k8s/configmap.yaml`: Add `VERIFICATION_PROVIDER`, `ENVIRONMENT`, `HTTP_PORT`
- `services/party/k8s/deployment.yaml`: Add HTTP container port 8081
- `services/party/k8s/service.yaml`: Add HTTP service port 8081

## Test plan
- [ ] `tilt up` starts party service with mock verification provider active
- [ ] HTTP health endpoint responds at `party:8081/health` with `verification_enabled: true`
- [ ] gRPC ExchangeDemographics returns PENDING status (mock async flow)