### PR TITLE
feat: add org-scoped account and syndicate association protobuf definitions

### DIFF
--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -154,6 +154,13 @@ message CurrentAccountFacility {
   // transaction_history tracks recent transactions for this account
   // Task 5.4: Add transaction history and account status management features
   TransactionHistory transaction_history = 10;
+
+  // org_party_id references the organization party for org-scoped accounts.
+  // Empty for personal accounts. Used for syndicate-style multi-party ownership.
+  string org_party_id = 11 [(buf.validate.field).string = {
+    pattern: "^[a-zA-Z0-9_-]*$"
+    max_len: 100
+  }];
 }
 
 // AccountBalance represents the current balance state of an account
@@ -331,6 +338,13 @@ message InitiateCurrentAccountRequest {
   meridian.common.v1.Currency base_currency = 3 [(buf.validate.field).enum = {
     defined_only: true
     not_in: [0]
+  }];
+
+  // org_party_id references the organization party for org-scoped accounts.
+  // Empty for personal accounts. Used for syndicate-style multi-party ownership.
+  string org_party_id = 4 [(buf.validate.field).string = {
+    pattern: "^[a-zA-Z0-9_-]*$"
+    max_len: 100
   }];
 }
 

--- a/api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
+++ b/api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
@@ -280,6 +280,13 @@ message InternalBankAccountFacility {
   //
   // See ADR-0025: Clearing Purpose Specialization for design rationale.
   ClearingPurpose clearing_purpose = 12;
+
+  // org_party_id references the organization party for org-scoped accounts.
+  // Empty for global accounts. Org-scoped accounts CANNOT be CLEARING type (enforced at application layer).
+  string org_party_id = 13 [(buf.validate.field).string = {
+    pattern: "^[a-zA-Z0-9_-]*$"
+    max_len: 100
+  }];
 }
 
 // LienStatus defines the lifecycle state of a fund reservation (lien).
@@ -350,6 +357,13 @@ message InitiateInternalBankAccountRequest {
   //   account_type: INTERNAL_ACCOUNT_TYPE_CLEARING
   //   clearing_purpose: CLEARING_PURPOSE_DEPOSIT
   ClearingPurpose clearing_purpose = 8;
+
+  // org_party_id references the organization party for org-scoped accounts.
+  // Empty for global accounts. Org-scoped accounts CANNOT be CLEARING type (enforced at application layer).
+  string org_party_id = 9 [(buf.validate.field).string = {
+    pattern: "^[a-zA-Z0-9_-]*$"
+    max_len: 100
+  }];
 }
 
 // InitiateInternalBankAccountResponse returns the newly created account.

--- a/api/proto/meridian/party/v1/party.proto
+++ b/api/proto/meridian/party/v1/party.proto
@@ -5,6 +5,7 @@ package meridian.party.v1;
 import "buf/validate/validate.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/field_mask.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
@@ -114,6 +115,22 @@ enum RelationshipType {
   RELATIONSHIP_TYPE_GUARANTOR = 4;
   // RELATIONSHIP_TYPE_BENEFICIAL_OWNER is a beneficial ownership relationship.
   RELATIONSHIP_TYPE_BENEFICIAL_OWNER = 5;
+  // RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT is a syndicate participation relationship.
+  RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT = 6;
+  // RELATIONSHIP_TYPE_SYNDICATE_HOST is a syndicate hosting relationship.
+  RELATIONSHIP_TYPE_SYNDICATE_HOST = 7;
+}
+
+// AssociationStatus defines the lifecycle state of a party association.
+enum AssociationStatus {
+  // ASSOCIATION_STATUS_UNSPECIFIED means the status is unknown.
+  ASSOCIATION_STATUS_UNSPECIFIED = 0;
+  // ASSOCIATION_STATUS_ACTIVE means the association is currently active.
+  ASSOCIATION_STATUS_ACTIVE = 1;
+  // ASSOCIATION_STATUS_SUSPENDED means the association is temporarily suspended.
+  ASSOCIATION_STATUS_SUSPENDED = 2;
+  // ASSOCIATION_STATUS_TERMINATED means the association has been permanently ended.
+  ASSOCIATION_STATUS_TERMINATED = 3;
 }
 
 // Party represents a legal entity in the BIAN Party Reference Data Directory.
@@ -391,6 +408,18 @@ message RegisterAssociationsRequest {
     defined_only: true
     not_in: [0] // Prevent UNSPECIFIED
   }];
+
+  // metadata contains syndicate structuring data (e.g., allocation_share, role).
+  google.protobuf.Struct metadata = 4;
+
+  // status is the lifecycle state of this association (defaults to ACTIVE if not specified).
+  AssociationStatus status = 5;
+
+  // effective_from is when this association becomes effective.
+  google.protobuf.Timestamp effective_from = 6;
+
+  // effective_to is when this association expires (null means indefinite).
+  google.protobuf.Timestamp effective_to = 7;
 }
 
 // RegisterAssociationsResponse is the response after registering an association.
@@ -409,6 +438,18 @@ message RegisterAssociationsResponse {
 
   // created_at is when the association was created.
   google.protobuf.Timestamp created_at = 5 [(buf.validate.field).required = true];
+
+  // metadata contains syndicate structuring data.
+  google.protobuf.Struct metadata = 6;
+
+  // status is the lifecycle state of the association.
+  AssociationStatus status = 7;
+
+  // effective_from is when this association became effective.
+  google.protobuf.Timestamp effective_from = 8;
+
+  // effective_to is when this association expires.
+  google.protobuf.Timestamp effective_to = 9;
 }
 
 // UpdateAssociationsRequest is the request to update a party association.
@@ -480,6 +521,18 @@ message Association {
 
   // updated_at is when the association was last updated.
   google.protobuf.Timestamp updated_at = 5;
+
+  // metadata contains syndicate structuring data (e.g., allocation_share, role).
+  google.protobuf.Struct metadata = 6;
+
+  // status is the lifecycle state of this association.
+  AssociationStatus status = 7;
+
+  // effective_from is when this association became effective.
+  google.protobuf.Timestamp effective_from = 8;
+
+  // effective_to is when this association expires (null means indefinite).
+  google.protobuf.Timestamp effective_to = 9;
 }
 
 // --- Business Qualifier: Demographics ---

--- a/services/party/domain/party.go
+++ b/services/party/domain/party.go
@@ -82,18 +82,21 @@ type RelationshipType string
 
 // Relationship type constants
 const (
-	RelationshipTypeSpouse          RelationshipType = "SPOUSE"
-	RelationshipTypeDependent       RelationshipType = "DEPENDENT"
-	RelationshipTypeBusinessPartner RelationshipType = "BUSINESS_PARTNER"
-	RelationshipTypeGuarantor       RelationshipType = "GUARANTOR"
-	RelationshipTypeBeneficialOwner RelationshipType = "BENEFICIAL_OWNER"
+	RelationshipTypeSpouse               RelationshipType = "SPOUSE"
+	RelationshipTypeDependent            RelationshipType = "DEPENDENT"
+	RelationshipTypeBusinessPartner      RelationshipType = "BUSINESS_PARTNER"
+	RelationshipTypeGuarantor            RelationshipType = "GUARANTOR"
+	RelationshipTypeBeneficialOwner      RelationshipType = "BENEFICIAL_OWNER"
+	RelationshipTypeSyndicateParticipant RelationshipType = "SYNDICATE_PARTICIPANT"
+	RelationshipTypeSyndicateHost        RelationshipType = "SYNDICATE_HOST"
 )
 
 // IsValid checks if the relationship type is valid
 func (rt RelationshipType) IsValid() bool {
 	switch rt {
 	case RelationshipTypeSpouse, RelationshipTypeDependent, RelationshipTypeBusinessPartner,
-		RelationshipTypeGuarantor, RelationshipTypeBeneficialOwner:
+		RelationshipTypeGuarantor, RelationshipTypeBeneficialOwner,
+		RelationshipTypeSyndicateParticipant, RelationshipTypeSyndicateHost:
 		return true
 	default:
 		return false

--- a/services/party/service/grpc_service.go
+++ b/services/party/service/grpc_service.go
@@ -931,6 +931,10 @@ func protoToRelationshipType(rt pb.RelationshipType) string {
 		return string(domain.RelationshipTypeGuarantor)
 	case pb.RelationshipType_RELATIONSHIP_TYPE_BENEFICIAL_OWNER:
 		return string(domain.RelationshipTypeBeneficialOwner)
+	case pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT:
+		return string(domain.RelationshipTypeSyndicateParticipant)
+	case pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_HOST:
+		return string(domain.RelationshipTypeSyndicateHost)
 	default:
 		return "UNSPECIFIED"
 	}
@@ -949,6 +953,10 @@ func relationshipTypeToProto(rt string) pb.RelationshipType {
 		return pb.RelationshipType_RELATIONSHIP_TYPE_GUARANTOR
 	case string(domain.RelationshipTypeBeneficialOwner):
 		return pb.RelationshipType_RELATIONSHIP_TYPE_BENEFICIAL_OWNER
+	case string(domain.RelationshipTypeSyndicateParticipant):
+		return pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT
+	case string(domain.RelationshipTypeSyndicateHost):
+		return pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_HOST
 	default:
 		return pb.RelationshipType_RELATIONSHIP_TYPE_UNSPECIFIED
 	}


### PR DESCRIPTION
## Summary

- Add `SYNDICATE_PARTICIPANT` and `SYNDICATE_HOST` relationship types to `RelationshipType` enum in party.proto
- Add `AssociationStatus` enum (ACTIVE, SUSPENDED, TERMINATED) for association lifecycle management
- Enhance `Association` message with metadata (Struct), status, effective_from, and effective_to fields
- Update `RegisterAssociationsRequest` and `RegisterAssociationsResponse` with new association fields
- Add `org_party_id` to `CurrentAccountFacility` and `InitiateCurrentAccountRequest` for org-scoped current accounts
- Add `org_party_id` to `InternalBankAccountFacility` and `InitiateInternalBankAccountRequest` for org-scoped internal bank accounts

All changes are backward-compatible (new fields and enum values only). Passes buf lint and buf breaking checks.

## Task Master

Tag: org-scoped-accounts
Task: 4 - Update Protobuf definitions for org-scoped accounts and enhanced associations

## Test plan

- [x] `buf lint` passes
- [x] `buf breaking --against develop` passes (no breaking changes)
- [x] `go build ./...` compiles successfully with generated code
- [ ] CI pipeline passes