### PR TITLE
feat: add org-scoped account support to internal bank account domain

### DIFF
--- a/services/internal-bank-account/adapters/persistence/mappers_test.go
+++ b/services/internal-bank-account/adapters/persistence/mappers_test.go
@@ -749,6 +749,153 @@ func TestReconstructCorrespondent(t *testing.T) {
 	})
 }
 
+// TestToEntity_WithOrgPartyID tests that toEntity correctly maps the org_party_id field.
+func TestToEntity_WithOrgPartyID(t *testing.T) {
+	ctx := createTestContextForMappers()
+
+	t.Run("org-scoped account", func(t *testing.T) {
+		orgID := uuid.New()
+		account, err := domain.NewInternalBankAccount(
+			"IBA-ORG-001",
+			"ORG_HOLDING",
+			"Org Holding Account",
+			domain.AccountTypeHolding,
+			domain.ClearingPurposeUnspecified,
+			"GBP",
+			"CURRENCY",
+			domain.WithOrgPartyID(orgID),
+		)
+		require.NoError(t, err)
+
+		entity := toEntity(ctx, account)
+
+		require.NotNil(t, entity.OrgPartyID)
+		assert.Equal(t, orgID, *entity.OrgPartyID)
+	})
+
+	t.Run("global account", func(t *testing.T) {
+		account, err := domain.NewInternalBankAccount(
+			"IBA-GLOBAL-001",
+			"GLOBAL_HOLDING",
+			"Global Holding Account",
+			domain.AccountTypeHolding,
+			domain.ClearingPurposeUnspecified,
+			"GBP",
+			"CURRENCY",
+		)
+		require.NoError(t, err)
+
+		entity := toEntity(ctx, account)
+
+		assert.Nil(t, entity.OrgPartyID)
+	})
+}
+
+// TestToDomain_WithOrgPartyID tests reconstructing org_party_id from entity.
+func TestToDomain_WithOrgPartyID(t *testing.T) {
+	now := time.Now()
+
+	t.Run("org-scoped entity", func(t *testing.T) {
+		orgID := uuid.New()
+		entity := &InternalBankAccountEntity{
+			ID:             uuid.New(),
+			AccountID:      "IBA-ORG-010",
+			AccountCode:    "ORG_HOLDING",
+			Name:           "Org Holding",
+			AccountType:    "HOLDING",
+			InstrumentCode: "GBP",
+			Dimension:      "CURRENCY",
+			Status:         "ACTIVE",
+			OrgPartyID:     &orgID,
+			Attributes:     make(AttributesJSON),
+			Version:        1,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+			CreatedBy:      "system",
+			UpdatedBy:      "system",
+		}
+
+		account := toDomain(entity)
+
+		require.NotNil(t, account.OrgPartyID())
+		assert.Equal(t, orgID, *account.OrgPartyID())
+		assert.True(t, account.IsScopedToOrganization())
+	})
+
+	t.Run("global entity", func(t *testing.T) {
+		entity := &InternalBankAccountEntity{
+			ID:             uuid.New(),
+			AccountID:      "IBA-GLOBAL-010",
+			AccountCode:    "GLOBAL_HOLDING",
+			Name:           "Global Holding",
+			AccountType:    "HOLDING",
+			InstrumentCode: "GBP",
+			Dimension:      "CURRENCY",
+			Status:         "ACTIVE",
+			OrgPartyID:     nil,
+			Attributes:     make(AttributesJSON),
+			Version:        1,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+			CreatedBy:      "system",
+			UpdatedBy:      "system",
+		}
+
+		account := toDomain(entity)
+
+		assert.Nil(t, account.OrgPartyID())
+		assert.False(t, account.IsScopedToOrganization())
+	})
+}
+
+// TestRoundTrip_OrgScopedAccount tests domain -> entity -> domain preserves OrgPartyID.
+func TestRoundTrip_OrgScopedAccount(t *testing.T) {
+	ctx := createTestContextForMappers()
+	orgID := uuid.New()
+
+	original, err := domain.NewInternalBankAccount(
+		"IBA-RT-ORG-001",
+		"ORG_NOSTRO",
+		"Org Scoped Nostro",
+		domain.AccountTypeNostro,
+		domain.ClearingPurposeUnspecified,
+		"USD",
+		"CURRENCY",
+		domain.WithOrgPartyID(orgID),
+	)
+	require.NoError(t, err)
+
+	entity := toEntity(ctx, original)
+	reconstructed := toDomain(entity)
+
+	require.NotNil(t, reconstructed.OrgPartyID())
+	assert.Equal(t, orgID, *reconstructed.OrgPartyID())
+	assert.True(t, reconstructed.IsScopedToOrganization())
+	assert.Equal(t, original.AccountID(), reconstructed.AccountID())
+}
+
+// TestRoundTrip_GlobalAccount tests that global account round-trips with nil OrgPartyID.
+func TestRoundTrip_GlobalAccount(t *testing.T) {
+	ctx := createTestContextForMappers()
+
+	original, err := domain.NewInternalBankAccount(
+		"IBA-RT-GLOBAL-001",
+		"GLOBAL_NOSTRO",
+		"Global Nostro",
+		domain.AccountTypeNostro,
+		domain.ClearingPurposeUnspecified,
+		"USD",
+		"CURRENCY",
+	)
+	require.NoError(t, err)
+
+	entity := toEntity(ctx, original)
+	reconstructed := toDomain(entity)
+
+	assert.Nil(t, reconstructed.OrgPartyID())
+	assert.False(t, reconstructed.IsScopedToOrganization())
+}
+
 // TestToDomain_PartialCorrespondent tests handling when only some correspondent fields are set.
 func TestToDomain_PartialCorrespondent(t *testing.T) {
 	now := time.Now()

--- a/services/internal-bank-account/adapters/persistence/repository.go
+++ b/services/internal-bank-account/adapters/persistence/repository.go
@@ -255,6 +255,9 @@ func (r *Repository) List(ctx context.Context, filter domain.ListFilter) ([]doma
 		if filter.ClearingPurpose != nil {
 			query = query.Where("clearing_purpose = ?", string(*filter.ClearingPurpose))
 		}
+		if filter.OrgPartyID != nil {
+			query = query.Where("org_party_id = ?", *filter.OrgPartyID)
+		}
 
 		// Apply pagination
 		if filter.Limit > 0 {
@@ -281,6 +284,12 @@ func (r *Repository) List(ctx context.Context, filter domain.ListFilter) ([]doma
 		return nil, err
 	}
 	return accounts, nil
+}
+
+// FindByOrganization retrieves all accounts scoped to the given organization party ID.
+// Returns an empty slice if no accounts match.
+func (r *Repository) FindByOrganization(ctx context.Context, orgPartyID uuid.UUID) ([]domain.InternalBankAccount, error) {
+	return r.List(ctx, domain.ListFilter{OrgPartyID: &orgPartyID})
 }
 
 // ExistsByCode checks if an account with the given code exists.

--- a/services/internal-bank-account/adapters/persistence/repository_integration_test.go
+++ b/services/internal-bank-account/adapters/persistence/repository_integration_test.go
@@ -1240,8 +1240,9 @@ func TestIntegration_FindByOrganization(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, tc.repo.Save(ctx, accountB1))
 
-	// Create global account (no org)
-	globalAccount := createTestAccountIntegration(t, "IBA-GLOBAL-002", "GLOBAL_CLR_002", "Global Clearing", domain.AccountTypeClearing)
+	// Create global account (no org) - use HOLDING since createTestAccountIntegration
+	// uses ClearingPurposeUnspecified which is invalid for CLEARING accounts
+	globalAccount := createTestAccountIntegration(t, "IBA-GLOBAL-002", "GLOBAL_HOLD_002", "Global Holding", domain.AccountTypeHolding)
 	require.NoError(t, tc.repo.Save(ctx, globalAccount))
 
 	// FindByOrganization for org A
@@ -1284,8 +1285,9 @@ func TestIntegration_ListWithOrgPartyIDFilter(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, tc.repo.Save(ctx, orgAccount))
 
-	// Create global account
-	globalAccount := createTestAccountIntegration(t, "IBA-FILTER-GLOBAL-001", "FILTER_GLOBAL_CLR", "Global Clearing", domain.AccountTypeClearing)
+	// Create global account - use HOLDING since createTestAccountIntegration
+	// uses ClearingPurposeUnspecified which is invalid for CLEARING accounts
+	globalAccount := createTestAccountIntegration(t, "IBA-FILTER-GLOBAL-001", "FILTER_GLOBAL_HOLD", "Global Holding", domain.AccountTypeHolding)
 	require.NoError(t, tc.repo.Save(ctx, globalAccount))
 
 	// List with OrgPartyID filter should return only org-scoped accounts

--- a/services/internal-bank-account/adapters/persistence/repository_integration_test.go
+++ b/services/internal-bank-account/adapters/persistence/repository_integration_test.go
@@ -1126,6 +1126,181 @@ func TestIntegration_MultiTenant_MissingContext(t *testing.T) {
 }
 
 // ============================================================================
+// Org-Scoped Account Tests
+// ============================================================================
+
+// TestIntegration_SaveOrgScopedAccount tests persisting an org-scoped account.
+func TestIntegration_SaveOrgScopedAccount(t *testing.T) {
+	tc := setupIntegrationTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := createTestContext()
+	orgID := uuid.New()
+
+	account, err := domain.NewInternalBankAccount(
+		"IBA-ORG-INT-001",
+		"ORG_HOLDING_001",
+		"Org Scoped Holding",
+		domain.AccountTypeHolding,
+		domain.ClearingPurposeUnspecified,
+		"GBP",
+		"CURRENCY",
+		domain.WithOrgPartyID(orgID),
+	)
+	require.NoError(t, err)
+
+	// Save
+	err = tc.repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	// Retrieve and verify org_party_id persisted
+	retrieved, err := tc.repo.FindByID(ctx, account.ID())
+	require.NoError(t, err)
+
+	require.NotNil(t, retrieved.OrgPartyID())
+	assert.Equal(t, orgID, *retrieved.OrgPartyID())
+	assert.True(t, retrieved.IsScopedToOrganization())
+}
+
+// TestIntegration_SaveGlobalAccount_NilOrgPartyID tests that global accounts persist with null org_party_id.
+func TestIntegration_SaveGlobalAccount_NilOrgPartyID(t *testing.T) {
+	tc := setupIntegrationTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := createTestContext()
+
+	account, err := domain.NewInternalBankAccount(
+		"IBA-GLOBAL-INT-001",
+		"GLOBAL_HOLDING_001",
+		"Global Holding",
+		domain.AccountTypeHolding,
+		domain.ClearingPurposeUnspecified,
+		"GBP",
+		"CURRENCY",
+	)
+	require.NoError(t, err)
+
+	err = tc.repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	retrieved, err := tc.repo.FindByID(ctx, account.ID())
+	require.NoError(t, err)
+
+	assert.Nil(t, retrieved.OrgPartyID())
+	assert.False(t, retrieved.IsScopedToOrganization())
+}
+
+// TestIntegration_FindByOrganization tests finding accounts by org party ID.
+func TestIntegration_FindByOrganization(t *testing.T) {
+	tc := setupIntegrationTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := createTestContext()
+	orgA := uuid.New()
+	orgB := uuid.New()
+
+	// Create org-scoped accounts for org A
+	accountA1, err := domain.NewInternalBankAccount(
+		"IBA-ORGA-001",
+		"ORGA_HOLDING_001",
+		"Org A Holding 1",
+		domain.AccountTypeHolding,
+		domain.ClearingPurposeUnspecified,
+		"GBP",
+		"CURRENCY",
+		domain.WithOrgPartyID(orgA),
+	)
+	require.NoError(t, err)
+	require.NoError(t, tc.repo.Save(ctx, accountA1))
+
+	accountA2, err := domain.NewInternalBankAccount(
+		"IBA-ORGA-002",
+		"ORGA_SUSPENSE_001",
+		"Org A Suspense",
+		domain.AccountTypeSuspense,
+		domain.ClearingPurposeUnspecified,
+		"GBP",
+		"CURRENCY",
+		domain.WithOrgPartyID(orgA),
+	)
+	require.NoError(t, err)
+	require.NoError(t, tc.repo.Save(ctx, accountA2))
+
+	// Create org-scoped account for org B
+	accountB1, err := domain.NewInternalBankAccount(
+		"IBA-ORGB-001",
+		"ORGB_HOLDING_001",
+		"Org B Holding",
+		domain.AccountTypeHolding,
+		domain.ClearingPurposeUnspecified,
+		"USD",
+		"CURRENCY",
+		domain.WithOrgPartyID(orgB),
+	)
+	require.NoError(t, err)
+	require.NoError(t, tc.repo.Save(ctx, accountB1))
+
+	// Create global account (no org)
+	globalAccount := createTestAccountIntegration(t, "IBA-GLOBAL-002", "GLOBAL_CLR_002", "Global Clearing", domain.AccountTypeClearing)
+	require.NoError(t, tc.repo.Save(ctx, globalAccount))
+
+	// FindByOrganization for org A
+	orgAAccounts, err := tc.repo.FindByOrganization(ctx, orgA)
+	require.NoError(t, err)
+	assert.Len(t, orgAAccounts, 2)
+
+	// FindByOrganization for org B
+	orgBAccounts, err := tc.repo.FindByOrganization(ctx, orgB)
+	require.NoError(t, err)
+	assert.Len(t, orgBAccounts, 1)
+	assert.Equal(t, "ORGB_HOLDING_001", orgBAccounts[0].AccountCode())
+
+	// FindByOrganization for non-existent org
+	nonExistentOrg := uuid.New()
+	noAccounts, err := tc.repo.FindByOrganization(ctx, nonExistentOrg)
+	require.NoError(t, err)
+	assert.Empty(t, noAccounts)
+}
+
+// TestIntegration_ListWithOrgPartyIDFilter tests the List method with OrgPartyID filter.
+func TestIntegration_ListWithOrgPartyIDFilter(t *testing.T) {
+	tc := setupIntegrationTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := createTestContext()
+	orgID := uuid.New()
+
+	// Create org-scoped account
+	orgAccount, err := domain.NewInternalBankAccount(
+		"IBA-FILTER-ORG-001",
+		"FILTER_ORG_HOLD",
+		"Org Holding",
+		domain.AccountTypeHolding,
+		domain.ClearingPurposeUnspecified,
+		"GBP",
+		"CURRENCY",
+		domain.WithOrgPartyID(orgID),
+	)
+	require.NoError(t, err)
+	require.NoError(t, tc.repo.Save(ctx, orgAccount))
+
+	// Create global account
+	globalAccount := createTestAccountIntegration(t, "IBA-FILTER-GLOBAL-001", "FILTER_GLOBAL_CLR", "Global Clearing", domain.AccountTypeClearing)
+	require.NoError(t, tc.repo.Save(ctx, globalAccount))
+
+	// List with OrgPartyID filter should return only org-scoped accounts
+	results, err := tc.repo.List(ctx, domain.ListFilter{OrgPartyID: &orgID})
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, "FILTER_ORG_HOLD", results[0].AccountCode())
+
+	// List without filter returns all
+	allResults, err := tc.repo.List(ctx, domain.ListFilter{})
+	require.NoError(t, err)
+	assert.Len(t, allResults, 2)
+}
+
+// ============================================================================
 // Performance Benchmarks
 // ============================================================================
 //

--- a/services/internal-bank-account/domain/internal_account.go
+++ b/services/internal-bank-account/domain/internal_account.go
@@ -281,6 +281,12 @@ func (a InternalBankAccount) OrgPartyID() *uuid.UUID {
 	return a.orgPartyID
 }
 
+// IsScopedToOrganization returns true if the account is scoped to a specific organization.
+// Global accounts (orgPartyID == nil) return false.
+func (a InternalBankAccount) IsScopedToOrganization() bool {
+	return a.orgPartyID != nil
+}
+
 // Correspondent returns the correspondent bank details.
 // Returns nil for non-NOSTRO/VOSTRO accounts.
 func (a InternalBankAccount) Correspondent() *CorrespondentDetails {

--- a/services/internal-bank-account/domain/internal_account_test.go
+++ b/services/internal-bank-account/domain/internal_account_test.go
@@ -1254,6 +1254,63 @@ func TestBuilder_WithOrgPartyID(t *testing.T) {
 	assert.Equal(t, orgID, *account.OrgPartyID())
 }
 
+func TestIsScopedToOrganization(t *testing.T) {
+	t.Run("global account returns false", func(t *testing.T) {
+		account, err := NewInternalBankAccount(
+			"IBA-GLOBAL",
+			"GLOBAL_HOLDING",
+			"Global Holding",
+			AccountTypeHolding,
+			ClearingPurposeUnspecified,
+			"USD",
+			"CURRENCY",
+		)
+		require.NoError(t, err)
+		assert.False(t, account.IsScopedToOrganization())
+	})
+
+	t.Run("org-scoped account returns true", func(t *testing.T) {
+		orgID := uuid.New()
+		account, err := NewInternalBankAccount(
+			"IBA-ORG",
+			"ORG_HOLDING",
+			"Org Holding",
+			AccountTypeHolding,
+			ClearingPurposeUnspecified,
+			"USD",
+			"CURRENCY",
+			WithOrgPartyID(orgID),
+		)
+		require.NoError(t, err)
+		assert.True(t, account.IsScopedToOrganization())
+	})
+
+	t.Run("builder with nil OrgPartyID returns false", func(t *testing.T) {
+		account := NewInternalBankAccountBuilder().
+			WithID(uuid.New()).
+			WithAccountID("IBA-001").
+			WithAccountCode("TEST").
+			WithName("Test").
+			WithAccountType(AccountTypeHolding).
+			WithOrgPartyID(nil).
+			Build()
+		assert.False(t, account.IsScopedToOrganization())
+	})
+
+	t.Run("builder with OrgPartyID returns true", func(t *testing.T) {
+		orgID := uuid.New()
+		account := NewInternalBankAccountBuilder().
+			WithID(uuid.New()).
+			WithAccountID("IBA-001").
+			WithAccountCode("TEST").
+			WithName("Test").
+			WithAccountType(AccountTypeHolding).
+			WithOrgPartyID(&orgID).
+			Build()
+		assert.True(t, account.IsScopedToOrganization())
+	})
+}
+
 func TestBuilder_WithOrgPartyID_Nil(t *testing.T) {
 	account := NewInternalBankAccountBuilder().
 		WithID(uuid.New()).

--- a/services/internal-bank-account/domain/repository.go
+++ b/services/internal-bank-account/domain/repository.go
@@ -50,6 +50,10 @@ type ListFilter struct {
 	// Only meaningful when filtering for CLEARING account types.
 	ClearingPurpose *ClearingPurpose
 
+	// OrgPartyID filters by organization party ID.
+	// Nil matches all accounts (both global and org-scoped).
+	OrgPartyID *uuid.UUID
+
 	// Limit specifies the maximum number of results to return.
 	// Zero or negative values use the implementation's default limit.
 	Limit int


### PR DESCRIPTION
## Summary

- Add `IsScopedToOrganization()` convenience method to `InternalBankAccount` domain model
- Add `OrgPartyID` field to `ListFilter` for filtering accounts by organization
- Add `FindByOrganization(ctx, orgPartyID)` method to persistence repository
- Wire `OrgPartyID` filter into the `List` query

## Context

Part of the org-scoped accounts epic. The domain model, entity, mappers, builder, and CLEARING validation were already implemented in develop. This PR adds the remaining pieces: the `IsScopedToOrganization` helper, org-based filtering in `ListFilter`, the `FindByOrganization` repository method, and associated tests.

Task Master: `org-scoped-accounts.6`

## Changes Made

**Domain layer** (`services/internal-bank-account/domain/`):
- `internal_account.go`: Add `IsScopedToOrganization() bool` method
- `repository.go`: Add `OrgPartyID *uuid.UUID` to `ListFilter` struct

**Persistence layer** (`services/internal-bank-account/adapters/persistence/`):
- `repository.go`: Add `FindByOrganization` method; add `OrgPartyID` filtering to `List`

## Testing

- Unit tests for `IsScopedToOrganization` (global, org-scoped, builder variants)
- Mapper round-trip tests for `OrgPartyID` (toEntity, toDomain, round-trip)
- Integration tests for `FindByOrganization`, `List` with `OrgPartyID` filter, org-scoped account persistence