### PR TITLE
feat: add org-scoped account support to current account domain and repository

### DIFF
--- a/services/current-account/adapters/persistence/org_scoped_account_test.go
+++ b/services/current-account/adapters/persistence/org_scoped_account_test.go
@@ -43,6 +43,8 @@ func setupOrgScopedTestDB(t *testing.T) (*gorm.DB, *Repository, context.Context,
 		balance_updated_at TIMESTAMP WITH TIME ZONE,
 		opened_at TIMESTAMP WITH TIME ZONE,
 		closed_at TIMESTAMP WITH TIME ZONE,
+		freeze_reason VARCHAR(1000),
+		status_history JSONB NOT NULL DEFAULT '[]',
 		version BIGINT NOT NULL DEFAULT 1,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
 		created_by VARCHAR(100) NOT NULL DEFAULT 'test',
@@ -61,7 +63,7 @@ func setupOrgScopedTestDB(t *testing.T) (*gorm.DB, *Repository, context.Context,
 	return db, repo, ctx, cleanup
 }
 
-func TestOrgScopedAccount_CanCreateWithOrgPartyID(t *testing.T) {
+func TestOrgScopedAccount_SaveWithOrgPartyID(t *testing.T) {
 	db, repo, ctx, cleanup := setupOrgScopedTestDB(t)
 	defer cleanup()
 
@@ -70,17 +72,14 @@ func TestOrgScopedAccount_CanCreateWithOrgPartyID(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP")
+	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP",
+		domain.WithOrgPartyID(orgPartyID))
 	require.NoError(t, err)
 
 	err = repo.Save(ctx, account)
 	require.NoError(t, err)
 
-	// Set org_party_id directly via raw SQL since the domain model doesn't expose it yet
-	err = db.Exec("UPDATE account SET org_party_id = ? WHERE account_id = ?", orgPartyID, accountID).Error
-	require.NoError(t, err)
-
-	// Verify org_party_id was stored
+	// Verify org_party_id was persisted via entity
 	var entity CurrentAccountEntity
 	err = db.Where("account_id = ?", accountID).First(&entity).Error
 	require.NoError(t, err)
@@ -88,8 +87,33 @@ func TestOrgScopedAccount_CanCreateWithOrgPartyID(t *testing.T) {
 	assert.Equal(t, orgPartyID, *entity.OrgPartyID)
 }
 
+func TestOrgScopedAccount_RoundTripPreservesOrgPartyID(t *testing.T) {
+	_, repo, ctx, cleanup := setupOrgScopedTestDB(t)
+	defer cleanup()
+
+	partyID := uuid.New().String()
+	orgPartyID := uuid.New()
+	accountID := "ACC-" + uuid.New().String()[:8]
+	iban := "GB82WEST12345698765432"
+
+	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP",
+		domain.WithOrgPartyID(orgPartyID))
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	// Retrieve and verify domain model has OrgPartyID
+	retrieved, err := repo.FindByID(ctx, accountID)
+	require.NoError(t, err)
+
+	assert.True(t, retrieved.IsScopedToOrganization())
+	require.NotNil(t, retrieved.OrgPartyID())
+	assert.Equal(t, orgPartyID, *retrieved.OrgPartyID())
+}
+
 func TestOrgScopedAccount_PersonalAccountHasNullOrgPartyID(t *testing.T) {
-	db, repo, ctx, cleanup := setupOrgScopedTestDB(t)
+	_, repo, ctx, cleanup := setupOrgScopedTestDB(t)
 	defer cleanup()
 
 	partyID := uuid.New().String()
@@ -102,9 +126,218 @@ func TestOrgScopedAccount_PersonalAccountHasNullOrgPartyID(t *testing.T) {
 	err = repo.Save(ctx, account)
 	require.NoError(t, err)
 
-	// Verify personal account has NULL org_party_id
-	var entity CurrentAccountEntity
-	err = db.Where("account_id = ?", accountID).First(&entity).Error
+	// Retrieve and verify personal account has nil OrgPartyID
+	retrieved, err := repo.FindByID(ctx, accountID)
 	require.NoError(t, err)
-	assert.Nil(t, entity.OrgPartyID, "Personal account should have NULL org_party_id")
+
+	assert.False(t, retrieved.IsScopedToOrganization())
+	assert.Nil(t, retrieved.OrgPartyID())
+}
+
+func TestOrgScopedAccount_FindByScopedParty(t *testing.T) {
+	_, repo, ctx, cleanup := setupOrgScopedTestDB(t)
+	defer cleanup()
+
+	partyID := uuid.New().String()
+	orgPartyID := uuid.New()
+	accountID := "ACC-" + uuid.New().String()[:8]
+	iban := "GB82WEST12345698765432"
+
+	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP",
+		domain.WithOrgPartyID(orgPartyID))
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	// Find by scoped party
+	found, err := repo.FindByScopedParty(ctx, partyID, orgPartyID, "GBP")
+	require.NoError(t, err)
+
+	assert.Equal(t, accountID, found.AccountID())
+	require.NotNil(t, found.OrgPartyID())
+	assert.Equal(t, orgPartyID, *found.OrgPartyID())
+}
+
+func TestOrgScopedAccount_FindByScopedParty_NotFound(t *testing.T) {
+	_, repo, ctx, cleanup := setupOrgScopedTestDB(t)
+	defer cleanup()
+
+	// Search for non-existent scoped account
+	_, err := repo.FindByScopedParty(ctx, uuid.New().String(), uuid.New(), "GBP")
+	assert.ErrorIs(t, err, ErrAccountNotFound)
+}
+
+func TestOrgScopedAccount_FindByScopedParty_WrongCurrency(t *testing.T) {
+	_, repo, ctx, cleanup := setupOrgScopedTestDB(t)
+	defer cleanup()
+
+	partyID := uuid.New().String()
+	orgPartyID := uuid.New()
+	accountID := "ACC-" + uuid.New().String()[:8]
+	iban := "GB82WEST12345698765432"
+
+	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP",
+		domain.WithOrgPartyID(orgPartyID))
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	// Search with wrong currency
+	_, err = repo.FindByScopedParty(ctx, partyID, orgPartyID, "EUR")
+	assert.ErrorIs(t, err, ErrAccountNotFound)
+}
+
+func TestOrgScopedAccount_ListByOrganization(t *testing.T) {
+	_, repo, ctx, cleanup := setupOrgScopedTestDB(t)
+	defer cleanup()
+
+	orgPartyID := uuid.New()
+
+	// Create two accounts for different parties within the same org
+	party1 := uuid.New().String()
+	party2 := uuid.New().String()
+
+	acc1, err := domain.NewCurrentAccount("ACC-"+uuid.New().String()[:8], "GB82WEST12345698765432", party1, "GBP",
+		domain.WithOrgPartyID(orgPartyID))
+	require.NoError(t, err)
+
+	acc2, err := domain.NewCurrentAccount("ACC-"+uuid.New().String()[:8], "GB82WEST98765432123456", party2, "GBP",
+		domain.WithOrgPartyID(orgPartyID))
+	require.NoError(t, err)
+
+	// Create a personal account (not org-scoped) - should not appear
+	acc3, err := domain.NewCurrentAccount("ACC-"+uuid.New().String()[:8], "GB82WEST55555555555555", uuid.New().String(), "GBP")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, acc1)
+	require.NoError(t, err)
+	err = repo.Save(ctx, acc2)
+	require.NoError(t, err)
+	err = repo.Save(ctx, acc3)
+	require.NoError(t, err)
+
+	// List by organization
+	accounts, err := repo.ListByOrganization(ctx, orgPartyID)
+	require.NoError(t, err)
+
+	assert.Len(t, accounts, 2, "Should return only the 2 org-scoped accounts")
+	for _, acc := range accounts {
+		assert.True(t, acc.IsScopedToOrganization())
+		assert.Equal(t, orgPartyID, *acc.OrgPartyID())
+	}
+}
+
+func TestOrgScopedAccount_ListByOrganization_Empty(t *testing.T) {
+	_, repo, ctx, cleanup := setupOrgScopedTestDB(t)
+	defer cleanup()
+
+	// List by non-existent org
+	accounts, err := repo.ListByOrganization(ctx, uuid.New())
+	require.NoError(t, err)
+
+	assert.Empty(t, accounts)
+}
+
+func TestOrgScopedAccount_ListByOrganization_ExcludesDeleted(t *testing.T) {
+	_, repo, ctx, cleanup := setupOrgScopedTestDB(t)
+	defer cleanup()
+
+	orgPartyID := uuid.New()
+	partyID := uuid.New().String()
+	accountID := "ACC-" + uuid.New().String()[:8]
+
+	account, err := domain.NewCurrentAccount(accountID, "GB82WEST12345698765432", partyID, "GBP",
+		domain.WithOrgPartyID(orgPartyID))
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	// Soft delete
+	err = repo.Delete(ctx, accountID)
+	require.NoError(t, err)
+
+	// Should not appear in list
+	accounts, err := repo.ListByOrganization(ctx, orgPartyID)
+	require.NoError(t, err)
+	assert.Empty(t, accounts)
+}
+
+// Entity mapping unit tests
+
+func TestToEntity_MapsOrgPartyID(t *testing.T) {
+	orgPartyID := uuid.New()
+	partyID := uuid.New().String()
+
+	account, err := domain.NewCurrentAccount("ACC-001", "GB82WEST12345698765432", partyID, "GBP",
+		domain.WithOrgPartyID(orgPartyID))
+	require.NoError(t, err)
+
+	entity, err := toEntity(context.Background(), account)
+	require.NoError(t, err)
+
+	require.NotNil(t, entity.OrgPartyID)
+	assert.Equal(t, orgPartyID, *entity.OrgPartyID)
+}
+
+func TestToEntity_NilOrgPartyIDForPersonalAccount(t *testing.T) {
+	partyID := uuid.New().String()
+
+	account, err := domain.NewCurrentAccount("ACC-001", "GB82WEST12345698765432", partyID, "GBP")
+	require.NoError(t, err)
+
+	entity, err := toEntity(context.Background(), account)
+	require.NoError(t, err)
+
+	assert.Nil(t, entity.OrgPartyID)
+}
+
+func TestToDomain_MapsOrgPartyID(t *testing.T) {
+	orgPartyID := uuid.New()
+	entity := &CurrentAccountEntity{
+		ID:                    uuid.New(),
+		AccountID:             "ACC-001",
+		AccountIdentification: "GB82WEST12345698765432",
+		AccountType:           "current",
+		PartyID:               uuid.New(),
+		OrgPartyID:            &orgPartyID,
+		Currency:              "GBP",
+		Status:                "ACTIVE",
+		StatusHistory:         StatusHistoryJSON{},
+		Version:               1,
+		CreatedBy:             "system",
+		UpdatedBy:             "system",
+	}
+
+	account, err := toDomain(entity)
+	require.NoError(t, err)
+
+	assert.True(t, account.IsScopedToOrganization())
+	require.NotNil(t, account.OrgPartyID())
+	assert.Equal(t, orgPartyID, *account.OrgPartyID())
+}
+
+func TestToDomain_NilOrgPartyIDForPersonalAccount(t *testing.T) {
+	entity := &CurrentAccountEntity{
+		ID:                    uuid.New(),
+		AccountID:             "ACC-001",
+		AccountIdentification: "GB82WEST12345698765432",
+		AccountType:           "current",
+		PartyID:               uuid.New(),
+		OrgPartyID:            nil,
+		Currency:              "GBP",
+		Status:                "ACTIVE",
+		StatusHistory:         StatusHistoryJSON{},
+		Version:               1,
+		CreatedBy:             "system",
+		UpdatedBy:             "system",
+	}
+
+	account, err := toDomain(entity)
+	require.NoError(t, err)
+
+	assert.False(t, account.IsScopedToOrganization())
+	assert.Nil(t, account.OrgPartyID())
 }

--- a/services/current-account/adapters/persistence/repository.go
+++ b/services/current-account/adapters/persistence/repository.go
@@ -370,6 +370,68 @@ func (r *Repository) FindByPartyID(ctx context.Context, partyID string) ([]domai
 	return accounts, nil
 }
 
+// FindByScopedParty retrieves an account by party ID, org party ID, and currency.
+// This supports org-scoped account lookups where an individual (partyID) holds
+// an account within an organization (orgPartyID) in a specific currency.
+// In multi-org mode, the context must contain the organization ID for schema routing.
+func (r *Repository) FindByScopedParty(ctx context.Context, partyID string, orgPartyID uuid.UUID, currency string) (domain.CurrentAccount, error) {
+	var account domain.CurrentAccount
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		partyUUID, err := uuid.Parse(partyID)
+		if err != nil {
+			return fmt.Errorf("invalid party ID %q: %w", partyID, err)
+		}
+
+		var entity CurrentAccountEntity
+		result := tx.Where("party_id = ? AND org_party_id = ? AND currency = ? AND deleted_at IS NULL",
+			partyUUID, orgPartyID, currency).First(&entity)
+
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return ErrAccountNotFound
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+
+		account, err = toDomain(&entity)
+		return err
+	})
+	if err != nil {
+		return domain.CurrentAccount{}, err
+	}
+	return account, nil
+}
+
+// ListByOrganization retrieves all accounts scoped to an organization.
+// This returns all accounts where org_party_id matches, supporting NFR-2
+// (list all syndicate participant accounts for an organization).
+// In multi-org mode, the context must contain the organization ID for schema routing.
+func (r *Repository) ListByOrganization(ctx context.Context, orgPartyID uuid.UUID) ([]domain.CurrentAccount, error) {
+	var accounts []domain.CurrentAccount
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var entities []CurrentAccountEntity
+		result := tx.Where("org_party_id = ? AND deleted_at IS NULL", orgPartyID).Find(&entities)
+
+		if result.Error != nil {
+			return result.Error
+		}
+
+		accounts = make([]domain.CurrentAccount, 0, len(entities))
+		for _, entity := range entities {
+			account, err := toDomain(&entity)
+			if err != nil {
+				return err
+			}
+			accounts = append(accounts, account)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return accounts, nil
+}
+
 // Delete soft deletes an account by its internal account ID.
 // In multi-org mode, the context must contain the organization ID for schema routing.
 func (r *Repository) Delete(ctx context.Context, accountID string) error {
@@ -432,6 +494,7 @@ func toEntity(ctx context.Context, account domain.CurrentAccount) (*CurrentAccou
 		Currency:              string(account.Balance().Currency()),
 		Status:                string(account.Status()),
 		PartyID:               partyUUID,
+		OrgPartyID:            account.OrgPartyID(),
 		OverdraftLimit:        account.OverdraftLimit().ToMinorUnitsUnchecked(),
 		OverdraftRate:         account.OverdraftRate(),
 		Balance:               account.Balance().ToMinorUnitsUnchecked(),          // gorm:"-" - not persisted
@@ -505,6 +568,7 @@ func toDomain(entity *CurrentAccountEntity) (domain.CurrentAccount, error) {
 		WithAccountID(entity.AccountID).
 		WithAccountIdentification(entity.AccountIdentification).
 		WithPartyID(entity.PartyID.String()).
+		WithOrgPartyID(entity.OrgPartyID).
 		WithBalance(balance).
 		WithAvailableBalance(availableBalance).
 		WithStatus(domain.AccountStatus(entity.Status)).

--- a/services/current-account/adapters/persistence/repository_test.go
+++ b/services/current-account/adapters/persistence/repository_test.go
@@ -49,6 +49,8 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		balance_updated_at TIMESTAMP WITH TIME ZONE,
 		opened_at TIMESTAMP WITH TIME ZONE,
 		closed_at TIMESTAMP WITH TIME ZONE,
+		freeze_reason VARCHAR(1000),
+		status_history JSONB NOT NULL DEFAULT '[]',
 		version BIGINT NOT NULL DEFAULT 1,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
 		created_by VARCHAR(100) NOT NULL DEFAULT 'test',

--- a/services/current-account/domain/account.go
+++ b/services/current-account/domain/account.go
@@ -20,6 +20,7 @@ var (
 	ErrNegativeOverdraftRate   = errors.New("overdraft rate cannot be negative")
 	ErrNonZeroBalance          = errors.New("account balance must be zero to close")
 	ErrActiveLiens             = errors.New("account has active liens and cannot be closed")
+	ErrOrgScopedWithoutParty   = errors.New("org-scoped account requires a party ID")
 )
 
 // AccountStatus represents the lifecycle state of an account
@@ -59,6 +60,7 @@ type CurrentAccount struct {
 	accountID             string
 	accountIdentification string // IBAN
 	partyID               string
+	orgPartyID            *uuid.UUID // NULL for personal accounts, set for org-scoped accounts
 	balance               Money
 	availableBalance      Money
 	status                AccountStatus
@@ -73,16 +75,28 @@ type CurrentAccount struct {
 	updatedAt             time.Time
 }
 
+// AccountOption is a functional option for configuring new account creation.
+type AccountOption func(*CurrentAccount)
+
+// WithOrgPartyID sets the organization party ID for org-scoped accounts.
+func WithOrgPartyID(orgPartyID uuid.UUID) AccountOption {
+	return func(a *CurrentAccount) {
+		id := orgPartyID
+		a.orgPartyID = &id
+	}
+}
+
 // NewCurrentAccount creates a new current account with the given parameters.
 // Returns a value type (not pointer) following immutability principles.
-func NewCurrentAccount(accountID, iban, partyID, currency string) (CurrentAccount, error) {
+// Use WithOrgPartyID option to create an org-scoped account.
+func NewCurrentAccount(accountID, iban, partyID, currency string, opts ...AccountOption) (CurrentAccount, error) {
 	now := time.Now()
 	zeroMoney, err := NewMoney(currency, 0)
 	if err != nil {
 		return CurrentAccount{}, err
 	}
 
-	return CurrentAccount{
+	account := CurrentAccount{
 		id:                    uuid.New(),
 		accountID:             accountID,
 		accountIdentification: iban,
@@ -97,7 +111,18 @@ func NewCurrentAccount(accountID, iban, partyID, currency string) (CurrentAccoun
 		version:               1,
 		createdAt:             now,
 		updatedAt:             now,
-	}, nil
+	}
+
+	for _, opt := range opts {
+		opt(&account)
+	}
+
+	// Validation: org-scoped account requires a party ID
+	if account.orgPartyID != nil && account.partyID == "" {
+		return CurrentAccount{}, ErrOrgScopedWithoutParty
+	}
+
+	return account, nil
 }
 
 // Deposit adds funds to the account and returns a new account with the updated balance.
@@ -136,6 +161,7 @@ func (a CurrentAccount) Deposit(amount Money) (CurrentAccount, error) {
 		accountID:             a.accountID,
 		accountIdentification: a.accountIdentification,
 		partyID:               a.partyID,
+		orgPartyID:            a.orgPartyID,
 		balance:               newBalance,
 		availableBalance:      newAvailableBalance,
 		status:                a.status,
@@ -172,6 +198,7 @@ func (a CurrentAccount) PrepareForCredit() (CurrentAccount, error) {
 		accountID:             a.accountID,
 		accountIdentification: a.accountIdentification,
 		partyID:               a.partyID,
+		orgPartyID:            a.orgPartyID,
 		balance:               a.balance, // Balance NOT modified - Position Keeping is source of truth
 		availableBalance:      a.availableBalance,
 		status:                a.status,
@@ -223,6 +250,7 @@ func (a CurrentAccount) PrepareForDebit(amount Money) (CurrentAccount, error) {
 		accountID:             a.accountID,
 		accountIdentification: a.accountIdentification,
 		partyID:               a.partyID,
+		orgPartyID:            a.orgPartyID,
 		balance:               a.balance, // Balance NOT modified - Position Keeping is source of truth
 		availableBalance:      a.availableBalance,
 		status:                a.status,
@@ -280,6 +308,7 @@ func (a CurrentAccount) Withdraw(amount Money) (CurrentAccount, error) {
 		accountID:             a.accountID,
 		accountIdentification: a.accountIdentification,
 		partyID:               a.partyID,
+		orgPartyID:            a.orgPartyID,
 		balance:               newBalance,
 		availableBalance:      newAvailableBalance,
 		status:                a.status,
@@ -348,6 +377,7 @@ func (a CurrentAccount) withStatusChange(newStatus AccountStatus, reason string)
 		accountID:             a.accountID,
 		accountIdentification: a.accountIdentification,
 		partyID:               a.partyID,
+		orgPartyID:            a.orgPartyID,
 		balance:               a.balance,
 		availableBalance:      a.availableBalance,
 		status:                newStatus,
@@ -474,6 +504,7 @@ func (a CurrentAccount) SetOverdraftLimit(limit Money, rate float64, enabled boo
 		accountID:             a.accountID,
 		accountIdentification: a.accountIdentification,
 		partyID:               a.partyID,
+		orgPartyID:            a.orgPartyID,
 		balance:               a.balance,
 		availableBalance:      newAvailableBalance,
 		status:                a.status,
@@ -503,6 +534,12 @@ func (a CurrentAccount) AccountIdentification() string { return a.accountIdentif
 
 // PartyID returns the party (customer) identifier.
 func (a CurrentAccount) PartyID() string { return a.partyID }
+
+// OrgPartyID returns the organization party ID, or nil for personal accounts.
+func (a CurrentAccount) OrgPartyID() *uuid.UUID { return a.orgPartyID }
+
+// IsScopedToOrganization returns true if this account is scoped to an organization.
+func (a CurrentAccount) IsScopedToOrganization() bool { return a.orgPartyID != nil }
 
 // Balance returns the current balance.
 func (a CurrentAccount) Balance() Money { return a.balance }
@@ -586,6 +623,12 @@ func (b *CurrentAccountBuilder) WithAccountIdentification(iban string) *CurrentA
 // WithPartyID sets the party identifier.
 func (b *CurrentAccountBuilder) WithPartyID(partyID string) *CurrentAccountBuilder {
 	b.account.partyID = partyID
+	return b
+}
+
+// WithOrgPartyID sets the organization party ID. Pass nil for personal accounts.
+func (b *CurrentAccountBuilder) WithOrgPartyID(orgPartyID *uuid.UUID) *CurrentAccountBuilder {
+	b.account.orgPartyID = orgPartyID
 	return b
 }
 

--- a/services/current-account/domain/account_test.go
+++ b/services/current-account/domain/account_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1285,4 +1286,119 @@ func TestBuilderWithStatusHistory(t *testing.T) {
 
 	assert.Len(t, account.StatusHistory(), 1)
 	assert.Equal(t, "Initial freeze", account.StatusHistory()[0].Reason)
+}
+
+// Org-scoped account tests
+
+func TestNewCurrentAccount_WithOrgPartyID(t *testing.T) {
+	orgPartyID := uuid.New()
+	account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP",
+		WithOrgPartyID(orgPartyID))
+	require.NoError(t, err)
+
+	assert.True(t, account.IsScopedToOrganization())
+	require.NotNil(t, account.OrgPartyID())
+	assert.Equal(t, orgPartyID, *account.OrgPartyID())
+	assert.Equal(t, "PARTY-001", account.PartyID())
+}
+
+func TestNewCurrentAccount_WithoutOrgPartyID(t *testing.T) {
+	account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
+	require.NoError(t, err)
+
+	assert.False(t, account.IsScopedToOrganization())
+	assert.Nil(t, account.OrgPartyID())
+}
+
+func TestNewCurrentAccount_OrgScopedWithoutPartyID_ReturnsError(t *testing.T) {
+	orgPartyID := uuid.New()
+	_, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "", "GBP",
+		WithOrgPartyID(orgPartyID))
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrOrgScopedWithoutParty)
+}
+
+func TestOrgPartyID_PreservedAcrossOperations(t *testing.T) {
+	orgPartyID := uuid.New()
+	account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP",
+		WithOrgPartyID(orgPartyID))
+	require.NoError(t, err)
+
+	// Deposit
+	deposit, _ := NewMoney("GBP", 10000)
+	afterDeposit, err := account.Deposit(deposit)
+	require.NoError(t, err)
+	require.NotNil(t, afterDeposit.OrgPartyID())
+	assert.Equal(t, orgPartyID, *afterDeposit.OrgPartyID())
+
+	// Withdraw
+	withdrawal, _ := NewMoney("GBP", 5000)
+	afterWithdraw, err := afterDeposit.Withdraw(withdrawal)
+	require.NoError(t, err)
+	require.NotNil(t, afterWithdraw.OrgPartyID())
+	assert.Equal(t, orgPartyID, *afterWithdraw.OrgPartyID())
+
+	// Freeze
+	frozen, err := afterWithdraw.Freeze("Suspicious activity detected on account")
+	require.NoError(t, err)
+	require.NotNil(t, frozen.OrgPartyID())
+	assert.Equal(t, orgPartyID, *frozen.OrgPartyID())
+
+	// Unfreeze
+	unfrozen, err := frozen.Unfreeze()
+	require.NoError(t, err)
+	require.NotNil(t, unfrozen.OrgPartyID())
+	assert.Equal(t, orgPartyID, *unfrozen.OrgPartyID())
+
+	// PrepareForCredit
+	prepared, err := unfrozen.PrepareForCredit()
+	require.NoError(t, err)
+	require.NotNil(t, prepared.OrgPartyID())
+	assert.Equal(t, orgPartyID, *prepared.OrgPartyID())
+
+	// SetOverdraftLimit
+	limit, _ := NewMoney("GBP", 5000)
+	afterOverdraft, err := prepared.SetOverdraftLimit(limit, 10.0, true)
+	require.NoError(t, err)
+	require.NotNil(t, afterOverdraft.OrgPartyID())
+	assert.Equal(t, orgPartyID, *afterOverdraft.OrgPartyID())
+}
+
+func TestBuilder_WithOrgPartyID(t *testing.T) {
+	orgPartyID := uuid.New()
+	balance, _ := NewMoney("GBP", 10000)
+
+	account := NewCurrentAccountBuilder().
+		WithAccountID("ACC-001").
+		WithAccountIdentification("GB82WEST12345698765432").
+		WithPartyID("party-123").
+		WithOrgPartyID(&orgPartyID).
+		WithBalance(balance).
+		WithAvailableBalance(balance).
+		WithStatus(AccountStatusActive).
+		WithVersion(1).
+		Build()
+
+	assert.True(t, account.IsScopedToOrganization())
+	require.NotNil(t, account.OrgPartyID())
+	assert.Equal(t, orgPartyID, *account.OrgPartyID())
+}
+
+func TestBuilder_WithNilOrgPartyID(t *testing.T) {
+	balance, _ := NewMoney("GBP", 10000)
+
+	account := NewCurrentAccountBuilder().
+		WithAccountID("ACC-001").
+		WithAccountIdentification("GB82WEST12345698765432").
+		WithPartyID("party-123").
+		WithOrgPartyID(nil).
+		WithBalance(balance).
+		WithAvailableBalance(balance).
+		WithStatus(AccountStatusActive).
+		WithVersion(1).
+		Build()
+
+	assert.False(t, account.IsScopedToOrganization())
+	assert.Nil(t, account.OrgPartyID())
 }


### PR DESCRIPTION
## Summary

- Add `OrgPartyID` field to `CurrentAccount` domain model with functional options pattern (`WithOrgPartyID`) for backward-compatible construction
- Add `IsScopedToOrganization()` method, `OrgPartyID()` accessor, and validation (org-scoped accounts require a party ID)
- Preserve `OrgPartyID` across all immutable copy operations (Deposit, Withdraw, Freeze, Unfreeze, PrepareForCredit, PrepareForDebit, SetOverdraftLimit)
- Update `toEntity`/`toDomain` persistence mappers for `OrgPartyID` round-trip
- Add `FindByScopedParty(ctx, partyID, orgPartyID, currency)` repository method
- Add `ListByOrganization(ctx, orgPartyID)` repository method for NFR-2 support

## Task Master

Tag: `org-scoped-accounts`, Task: `org-scoped-accounts.5`

## Changes Made

| File | Change |
|------|--------|
| `services/current-account/domain/account.go` | Add `orgPartyID *uuid.UUID` field, `AccountOption` functional options, `WithOrgPartyID` option, `IsScopedToOrganization()` method, `ErrOrgScopedWithoutParty` error, builder `WithOrgPartyID` method. Propagate field in all 7 copy-constructor methods. |
| `services/current-account/domain/account_test.go` | Tests for org-scoped construction, validation, field preservation across operations, builder with org party ID |
| `services/current-account/adapters/persistence/repository.go` | Map `OrgPartyID` in `toEntity`/`toDomain`. Add `FindByScopedParty` and `ListByOrganization` repository methods |
| `services/current-account/adapters/persistence/repository_test.go` | Add `freeze_reason` and `status_history` columns to test schema |
| `services/current-account/adapters/persistence/org_scoped_account_test.go` | Integration tests for Save with OrgPartyID, round-trip preservation, FindByScopedParty, ListByOrganization, entity mapping unit tests |

## Testing

- Unit tests: domain model construction, validation, field preservation across all operations, builder
- Unit tests: entity `toEntity`/`toDomain` mapping with and without OrgPartyID
- Integration tests: Save, FindByScopedParty, ListByOrganization, soft delete exclusion (CockroachDB testcontainer via CI)

## Risk Assessment

Low risk. Backward compatible changes:
- `NewCurrentAccount` signature uses variadic options, no existing callers affected
- Entity already had `OrgPartyID` field, just wasn't mapped to/from domain
- New repository methods are additive, no existing methods changed