### PR TITLE
feat: add syndicate participant query handlers to party service

### DIFF
--- a/api/proto/meridian/party/v1/party.proto
+++ b/api/proto/meridian/party/v1/party.proto
@@ -533,6 +533,9 @@ message Association {
 
   // effective_to is when this association expires (null means indefinite).
   google.protobuf.Timestamp effective_to = 9;
+
+  // party_id is the identifier of the party that holds this association.
+  string party_id = 10;
 }
 
 // --- Business Qualifier: Demographics ---

--- a/api/proto/meridian/party/v1/party.proto
+++ b/api/proto/meridian/party/v1/party.proto
@@ -685,6 +685,59 @@ message RetrieveBankRelationsResponse {
   google.protobuf.Timestamp updated_at = 5;
 }
 
+// --- Business Qualifier: Syndicate Participants ---
+
+// ListParticipantsRequest is the request to list active participants for a syndicate.
+message ListParticipantsRequest {
+  // org_party_id is the identifier of the syndicate (organization party).
+  string org_party_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // relationship_type filters participants by relationship type.
+  RelationshipType relationship_type = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+}
+
+// ListParticipantsResponse is the response containing active participants.
+message ListParticipantsResponse {
+  // participants is the list of active participant associations.
+  repeated Association participants = 1;
+}
+
+// GetStructuringDataRequest is the request to retrieve structuring metadata for a participant.
+message GetStructuringDataRequest {
+  // party_id is the identifier of the participant party.
+  string party_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // org_party_id is the identifier of the syndicate (organization party).
+  string org_party_id = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // relationship_type is the type of relationship to query.
+  RelationshipType relationship_type = 3 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+}
+
+// GetStructuringDataResponse is the response containing the structuring metadata.
+message GetStructuringDataResponse {
+  // metadata contains the structuring data (e.g., allocation_share, role).
+  google.protobuf.Struct metadata = 1;
+}
+
 // --- Business Qualifier: PaymentMethods ---
 
 // PaymentMethodProvider defines supported external payment providers.
@@ -1003,6 +1056,22 @@ service PartyService {
   rpc RetrieveBankRelations(RetrieveBankRelationsRequest) returns (RetrieveBankRelationsResponse) {
     option (google.api.http) = {
       get: "/v1/parties/{party_id}/bank-relations"
+    };
+  }
+
+  // --- Business Qualifier: Syndicate Participant Operations ---
+
+  // ListParticipants returns all active participants for a syndicate (org party).
+  rpc ListParticipants(ListParticipantsRequest) returns (ListParticipantsResponse) {
+    option (google.api.http) = {
+      get: "/v1/parties/{org_party_id}/participants"
+    };
+  }
+
+  // GetStructuringData returns the structuring metadata for a specific participant in a syndicate.
+  rpc GetStructuringData(GetStructuringDataRequest) returns (GetStructuringDataResponse) {
+    option (google.api.http) = {
+      get: "/v1/parties/{org_party_id}/participants/{party_id}/structuring-data"
     };
   }
 

--- a/services/party/adapters/persistence/bq_entities.go
+++ b/services/party/adapters/persistence/bq_entities.go
@@ -9,12 +9,16 @@ import (
 
 // PartyAssociationEntity represents a relationship between two parties
 type PartyAssociationEntity struct {
-	ID               uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
-	PartyID          uuid.UUID `gorm:"column:party_id;type:uuid;not null;index:idx_party_association_party_id"`
-	RelatedPartyID   uuid.UUID `gorm:"column:related_party_id;type:uuid;not null;index:idx_party_association_related_party_id"`
-	RelationshipType string    `gorm:"column:relationship_type;type:varchar(50);not null;index:idx_party_association_relationship_type"`
-	CreatedAt        time.Time `gorm:"column:created_at;not null;default:now()"`
-	UpdatedAt        time.Time `gorm:"column:updated_at;not null;default:now()"`
+	ID               uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+	PartyID          uuid.UUID  `gorm:"column:party_id;type:uuid;not null;index:idx_party_association_party_id"`
+	RelatedPartyID   uuid.UUID  `gorm:"column:related_party_id;type:uuid;not null;index:idx_party_association_related_party_id"`
+	RelationshipType string     `gorm:"column:relationship_type;type:varchar(50);not null;index:idx_party_association_relationship_type"`
+	Metadata         *string    `gorm:"column:metadata;type:jsonb;default:'{}'"`
+	Status           string     `gorm:"column:status;type:varchar(20);not null;default:'ACTIVE'"`
+	EffectiveFrom    time.Time  `gorm:"column:effective_from;not null;default:now()"`
+	EffectiveTo      *time.Time `gorm:"column:effective_to"`
+	CreatedAt        time.Time  `gorm:"column:created_at;not null;default:now()"`
+	UpdatedAt        time.Time  `gorm:"column:updated_at;not null;default:now()"`
 }
 
 // TableName overrides the default table name

--- a/services/party/adapters/persistence/repository.go
+++ b/services/party/adapters/persistence/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -411,17 +412,47 @@ func isDuplicateKeyError(err error) bool {
 		strings.Contains(errStr, "unique constraint")
 }
 
+// AssociationInput holds optional fields for creating a party association.
+type AssociationInput struct {
+	Metadata      *string
+	Status        string
+	EffectiveFrom *time.Time
+	EffectiveTo   *time.Time
+}
+
 // SaveAssociation saves a party association.
 // Returns ErrAssociationExists if an association already exists between the parties.
 func (r *Repository) SaveAssociation(ctx context.Context, partyID, relatedPartyID uuid.UUID, relationshipType string) (uuid.UUID, error) {
+	return r.SaveAssociationWithInput(ctx, partyID, relatedPartyID, relationshipType, nil)
+}
+
+// SaveAssociationWithInput saves a party association with optional metadata and lifecycle fields.
+// Returns ErrAssociationExists if an association already exists between the parties.
+func (r *Repository) SaveAssociationWithInput(ctx context.Context, partyID, relatedPartyID uuid.UUID, relationshipType string, input *AssociationInput) (uuid.UUID, error) {
+	now := time.Now()
 	associationID := uuid.New()
 	entity := &PartyAssociationEntity{
 		ID:               associationID,
 		PartyID:          partyID,
 		RelatedPartyID:   relatedPartyID,
 		RelationshipType: relationshipType,
-		CreatedAt:        time.Now(),
-		UpdatedAt:        time.Now(),
+		Status:           "ACTIVE",
+		EffectiveFrom:    now,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	if input != nil {
+		if input.Metadata != nil {
+			entity.Metadata = input.Metadata
+		}
+		if input.Status != "" {
+			entity.Status = input.Status
+		}
+		if input.EffectiveFrom != nil {
+			entity.EffectiveFrom = *input.EffectiveFrom
+		}
+		entity.EffectiveTo = input.EffectiveTo
 	}
 
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
@@ -682,4 +713,49 @@ func (r *Repository) FindBankRelation(ctx context.Context, partyID uuid.UUID) (*
 		return nil, nil //nolint:nilnil // nil,nil signals "not found" without error
 	}
 	return &bankRelation, nil
+}
+
+// ListParticipants retrieves all ACTIVE associations where the given orgPartyID is the related_party_id
+// (i.e., the org is the syndicate host and participants point to it) with the given relationship type.
+func (r *Repository) ListParticipants(ctx context.Context, orgPartyID uuid.UUID, relationshipType string) ([]PartyAssociationEntity, error) {
+	var associations []PartyAssociationEntity
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Where("related_party_id = ? AND relationship_type = ? AND status = ?",
+			orgPartyID, relationshipType, "ACTIVE").
+			Find(&associations).Error
+	})
+	return associations, err
+}
+
+// GetStructuringData retrieves the metadata JSONB for a specific association.
+// Returns an empty map (not an error) if no association is found.
+func (r *Repository) GetStructuringData(ctx context.Context, partyID, orgPartyID uuid.UUID, relationshipType string) (map[string]interface{}, error) {
+	var entity PartyAssociationEntity
+	var found bool
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Where("party_id = ? AND related_party_id = ? AND relationship_type = ?",
+			partyID, orgPartyID, relationshipType).
+			First(&entity)
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			found = false
+			return nil
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+		found = true
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !found || entity.Metadata == nil {
+		return map[string]interface{}{}, nil
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal([]byte(*entity.Metadata), &metadata); err != nil {
+		return nil, fmt.Errorf("unmarshal association metadata: %w", err)
+	}
+	return metadata, nil
 }

--- a/services/party/adapters/persistence/repository_test.go
+++ b/services/party/adapters/persistence/repository_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/lib/pq"
 
@@ -66,6 +67,21 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		transaction_id VARCHAR(100),
 		client_ip VARCHAR(45),
 		user_agent TEXT
+	)`, pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// Create the party_association table in the tenant schema
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.party_association (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		party_id UUID NOT NULL,
+		related_party_id UUID NOT NULL,
+		relationship_type VARCHAR(50) NOT NULL,
+		metadata JSONB NULL DEFAULT '{}'::jsonb,
+		status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+		effective_from TIMESTAMPTZ NOT NULL DEFAULT now(),
+		effective_to TIMESTAMPTZ NULL,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
 	)`, pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
@@ -652,6 +668,196 @@ func TestFindByIDForUpdate_WithOrganizationContext_UsesOrgScope(t *testing.T) {
 	found, err = repo.FindByIDForUpdate(orgCtx, party.ID())
 	// May find via public schema fallback
 	t.Logf("FindByIDForUpdate with org context: found=%v, err=%v", found != nil, err)
+}
+
+// ListParticipants and GetStructuringData repository tests
+
+func TestListParticipants_ReturnsActiveAssociations(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	orgPartyID := uuid.New()
+	participant1 := uuid.New()
+	participant2 := uuid.New()
+
+	// Create two ACTIVE associations pointing to the same org
+	_, err := repo.SaveAssociationWithInput(ctx, participant1, orgPartyID, "SYNDICATE_MEMBER", &AssociationInput{
+		Status: "ACTIVE",
+	})
+	require.NoError(t, err)
+
+	_, err = repo.SaveAssociationWithInput(ctx, participant2, orgPartyID, "SYNDICATE_MEMBER", &AssociationInput{
+		Status: "ACTIVE",
+	})
+	require.NoError(t, err)
+
+	// List participants
+	results, err := repo.ListParticipants(ctx, orgPartyID, "SYNDICATE_MEMBER")
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+
+	// Verify both participants are returned
+	partyIDs := make(map[uuid.UUID]bool)
+	for _, a := range results {
+		partyIDs[a.PartyID] = true
+	}
+	assert.True(t, partyIDs[participant1])
+	assert.True(t, partyIDs[participant2])
+}
+
+func TestListParticipants_ExcludesSuspendedAndTerminated(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	orgPartyID := uuid.New()
+	activeParty := uuid.New()
+	suspendedParty := uuid.New()
+	terminatedParty := uuid.New()
+
+	_, err := repo.SaveAssociationWithInput(ctx, activeParty, orgPartyID, "SYNDICATE_MEMBER", &AssociationInput{
+		Status: "ACTIVE",
+	})
+	require.NoError(t, err)
+
+	_, err = repo.SaveAssociationWithInput(ctx, suspendedParty, orgPartyID, "SYNDICATE_MEMBER", &AssociationInput{
+		Status: "SUSPENDED",
+	})
+	require.NoError(t, err)
+
+	_, err = repo.SaveAssociationWithInput(ctx, terminatedParty, orgPartyID, "SYNDICATE_MEMBER", &AssociationInput{
+		Status: "TERMINATED",
+	})
+	require.NoError(t, err)
+
+	results, err := repo.ListParticipants(ctx, orgPartyID, "SYNDICATE_MEMBER")
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, activeParty, results[0].PartyID)
+}
+
+func TestListParticipants_FiltersRelationshipType(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	orgPartyID := uuid.New()
+	member := uuid.New()
+	agent := uuid.New()
+
+	_, err := repo.SaveAssociationWithInput(ctx, member, orgPartyID, "SYNDICATE_MEMBER", nil)
+	require.NoError(t, err)
+
+	_, err = repo.SaveAssociationWithInput(ctx, agent, orgPartyID, "AGENT", nil)
+	require.NoError(t, err)
+
+	results, err := repo.ListParticipants(ctx, orgPartyID, "SYNDICATE_MEMBER")
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, member, results[0].PartyID)
+}
+
+func TestListParticipants_EmptyResult(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	results, err := repo.ListParticipants(ctx, uuid.New(), "SYNDICATE_MEMBER")
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestGetStructuringData_ReturnsMetadata(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	partyID := uuid.New()
+	orgPartyID := uuid.New()
+	metadata := `{"commitment_amount":"5000000","share_percentage":"25.5","role":"lead_arranger"}`
+
+	_, err := repo.SaveAssociationWithInput(ctx, partyID, orgPartyID, "SYNDICATE_MEMBER", &AssociationInput{
+		Metadata: &metadata,
+	})
+	require.NoError(t, err)
+
+	result, err := repo.GetStructuringData(ctx, partyID, orgPartyID, "SYNDICATE_MEMBER")
+	require.NoError(t, err)
+	assert.Equal(t, "5000000", result["commitment_amount"])
+	assert.Equal(t, "25.5", result["share_percentage"])
+	assert.Equal(t, "lead_arranger", result["role"])
+}
+
+func TestGetStructuringData_NotFoundReturnsEmptyMap(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	result, err := repo.GetStructuringData(ctx, uuid.New(), uuid.New(), "SYNDICATE_MEMBER")
+	require.NoError(t, err)
+	assert.NotNil(t, result, "Should return empty map, not nil")
+	assert.Empty(t, result, "Should return empty map when not found")
+}
+
+func TestGetStructuringData_NilMetadataReturnsEmptyMap(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	partyID := uuid.New()
+	orgPartyID := uuid.New()
+
+	// Create association without metadata
+	_, err := repo.SaveAssociationWithInput(ctx, partyID, orgPartyID, "SYNDICATE_MEMBER", nil)
+	require.NoError(t, err)
+
+	result, err := repo.GetStructuringData(ctx, partyID, orgPartyID, "SYNDICATE_MEMBER")
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Empty(t, result)
+}
+
+func TestSaveAssociationWithInput_PersistsAllFields(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	partyID := uuid.New()
+	relatedID := uuid.New()
+	metadata := `{"key":"value"}`
+	effectiveFrom := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	effectiveTo := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
+
+	associationID, err := repo.SaveAssociationWithInput(ctx, partyID, relatedID, "SYNDICATE_MEMBER", &AssociationInput{
+		Metadata:      &metadata,
+		Status:        "SUSPENDED",
+		EffectiveFrom: &effectiveFrom,
+		EffectiveTo:   &effectiveTo,
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, associationID)
+
+	// Verify persisted via FindAssociations
+	associations, err := repo.FindAssociations(ctx, partyID)
+	require.NoError(t, err)
+	require.Len(t, associations, 1)
+
+	a := associations[0]
+	assert.Equal(t, "SUSPENDED", a.Status)
+	assert.NotNil(t, a.Metadata)
+	assert.Contains(t, *a.Metadata, "key")
+	assert.Equal(t, effectiveFrom.UTC().Unix(), a.EffectiveFrom.UTC().Unix())
+	assert.NotNil(t, a.EffectiveTo)
+	assert.Equal(t, effectiveTo.UTC().Unix(), a.EffectiveTo.UTC().Unix())
 }
 
 func TestPing_WorksWithoutOrganizationContext(t *testing.T) {

--- a/services/party/adapters/persistence/repository_test.go
+++ b/services/party/adapters/persistence/repository_test.go
@@ -683,18 +683,18 @@ func TestListParticipants_ReturnsActiveAssociations(t *testing.T) {
 	participant2 := uuid.New()
 
 	// Create two ACTIVE associations pointing to the same org
-	_, err := repo.SaveAssociationWithInput(ctx, participant1, orgPartyID, "SYNDICATE_MEMBER", &AssociationInput{
+	_, err := repo.SaveAssociationWithInput(ctx, participant1, orgPartyID, string(domain.RelationshipTypeSyndicateParticipant), &AssociationInput{
 		Status: "ACTIVE",
 	})
 	require.NoError(t, err)
 
-	_, err = repo.SaveAssociationWithInput(ctx, participant2, orgPartyID, "SYNDICATE_MEMBER", &AssociationInput{
+	_, err = repo.SaveAssociationWithInput(ctx, participant2, orgPartyID, string(domain.RelationshipTypeSyndicateParticipant), &AssociationInput{
 		Status: "ACTIVE",
 	})
 	require.NoError(t, err)
 
 	// List participants
-	results, err := repo.ListParticipants(ctx, orgPartyID, "SYNDICATE_MEMBER")
+	results, err := repo.ListParticipants(ctx, orgPartyID, string(domain.RelationshipTypeSyndicateParticipant))
 	require.NoError(t, err)
 	assert.Len(t, results, 2)
 
@@ -718,22 +718,22 @@ func TestListParticipants_ExcludesSuspendedAndTerminated(t *testing.T) {
 	suspendedParty := uuid.New()
 	terminatedParty := uuid.New()
 
-	_, err := repo.SaveAssociationWithInput(ctx, activeParty, orgPartyID, "SYNDICATE_MEMBER", &AssociationInput{
+	_, err := repo.SaveAssociationWithInput(ctx, activeParty, orgPartyID, string(domain.RelationshipTypeSyndicateParticipant), &AssociationInput{
 		Status: "ACTIVE",
 	})
 	require.NoError(t, err)
 
-	_, err = repo.SaveAssociationWithInput(ctx, suspendedParty, orgPartyID, "SYNDICATE_MEMBER", &AssociationInput{
+	_, err = repo.SaveAssociationWithInput(ctx, suspendedParty, orgPartyID, string(domain.RelationshipTypeSyndicateParticipant), &AssociationInput{
 		Status: "SUSPENDED",
 	})
 	require.NoError(t, err)
 
-	_, err = repo.SaveAssociationWithInput(ctx, terminatedParty, orgPartyID, "SYNDICATE_MEMBER", &AssociationInput{
+	_, err = repo.SaveAssociationWithInput(ctx, terminatedParty, orgPartyID, string(domain.RelationshipTypeSyndicateParticipant), &AssociationInput{
 		Status: "TERMINATED",
 	})
 	require.NoError(t, err)
 
-	results, err := repo.ListParticipants(ctx, orgPartyID, "SYNDICATE_MEMBER")
+	results, err := repo.ListParticipants(ctx, orgPartyID, string(domain.RelationshipTypeSyndicateParticipant))
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, activeParty, results[0].PartyID)
@@ -749,13 +749,13 @@ func TestListParticipants_FiltersRelationshipType(t *testing.T) {
 	member := uuid.New()
 	agent := uuid.New()
 
-	_, err := repo.SaveAssociationWithInput(ctx, member, orgPartyID, "SYNDICATE_MEMBER", nil)
+	_, err := repo.SaveAssociationWithInput(ctx, member, orgPartyID, string(domain.RelationshipTypeSyndicateParticipant), nil)
 	require.NoError(t, err)
 
 	_, err = repo.SaveAssociationWithInput(ctx, agent, orgPartyID, "AGENT", nil)
 	require.NoError(t, err)
 
-	results, err := repo.ListParticipants(ctx, orgPartyID, "SYNDICATE_MEMBER")
+	results, err := repo.ListParticipants(ctx, orgPartyID, string(domain.RelationshipTypeSyndicateParticipant))
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, member, results[0].PartyID)
@@ -767,7 +767,7 @@ func TestListParticipants_EmptyResult(t *testing.T) {
 
 	repo := NewRepository(db)
 
-	results, err := repo.ListParticipants(ctx, uuid.New(), "SYNDICATE_MEMBER")
+	results, err := repo.ListParticipants(ctx, uuid.New(), string(domain.RelationshipTypeSyndicateParticipant))
 	require.NoError(t, err)
 	assert.Empty(t, results)
 }
@@ -782,12 +782,12 @@ func TestGetStructuringData_ReturnsMetadata(t *testing.T) {
 	orgPartyID := uuid.New()
 	metadata := `{"commitment_amount":"5000000","share_percentage":"25.5","role":"lead_arranger"}`
 
-	_, err := repo.SaveAssociationWithInput(ctx, partyID, orgPartyID, "SYNDICATE_MEMBER", &AssociationInput{
+	_, err := repo.SaveAssociationWithInput(ctx, partyID, orgPartyID, string(domain.RelationshipTypeSyndicateParticipant), &AssociationInput{
 		Metadata: &metadata,
 	})
 	require.NoError(t, err)
 
-	result, err := repo.GetStructuringData(ctx, partyID, orgPartyID, "SYNDICATE_MEMBER")
+	result, err := repo.GetStructuringData(ctx, partyID, orgPartyID, string(domain.RelationshipTypeSyndicateParticipant))
 	require.NoError(t, err)
 	assert.Equal(t, "5000000", result["commitment_amount"])
 	assert.Equal(t, "25.5", result["share_percentage"])
@@ -800,7 +800,7 @@ func TestGetStructuringData_NotFoundReturnsEmptyMap(t *testing.T) {
 
 	repo := NewRepository(db)
 
-	result, err := repo.GetStructuringData(ctx, uuid.New(), uuid.New(), "SYNDICATE_MEMBER")
+	result, err := repo.GetStructuringData(ctx, uuid.New(), uuid.New(), string(domain.RelationshipTypeSyndicateParticipant))
 	require.NoError(t, err)
 	assert.NotNil(t, result, "Should return empty map, not nil")
 	assert.Empty(t, result, "Should return empty map when not found")
@@ -816,10 +816,10 @@ func TestGetStructuringData_NilMetadataReturnsEmptyMap(t *testing.T) {
 	orgPartyID := uuid.New()
 
 	// Create association without metadata
-	_, err := repo.SaveAssociationWithInput(ctx, partyID, orgPartyID, "SYNDICATE_MEMBER", nil)
+	_, err := repo.SaveAssociationWithInput(ctx, partyID, orgPartyID, string(domain.RelationshipTypeSyndicateParticipant), nil)
 	require.NoError(t, err)
 
-	result, err := repo.GetStructuringData(ctx, partyID, orgPartyID, "SYNDICATE_MEMBER")
+	result, err := repo.GetStructuringData(ctx, partyID, orgPartyID, string(domain.RelationshipTypeSyndicateParticipant))
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Empty(t, result)
@@ -837,7 +837,7 @@ func TestSaveAssociationWithInput_PersistsAllFields(t *testing.T) {
 	effectiveFrom := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	effectiveTo := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
 
-	associationID, err := repo.SaveAssociationWithInput(ctx, partyID, relatedID, "SYNDICATE_MEMBER", &AssociationInput{
+	associationID, err := repo.SaveAssociationWithInput(ctx, partyID, relatedID, string(domain.RelationshipTypeSyndicateParticipant), &AssociationInput{
 		Metadata:      &metadata,
 		Status:        "SUSPENDED",
 		EffectiveFrom: &effectiveFrom,

--- a/services/party/service/grpc_service.go
+++ b/services/party/service/grpc_service.go
@@ -1039,6 +1039,7 @@ func (s *Service) GetStructuringData(ctx context.Context, req *pb.GetStructuring
 func associationEntityToProto(entity *persistence.PartyAssociationEntity) *pb.Association {
 	assoc := &pb.Association{
 		AssociationId:    entity.ID.String(),
+		PartyId:          entity.PartyID.String(),
 		RelatedPartyId:   entity.RelatedPartyID.String(),
 		RelationshipType: relationshipTypeToProto(entity.RelationshipType),
 		CreatedAt:        timestamppb.New(entity.CreatedAt),

--- a/services/party/service/grpc_service.go
+++ b/services/party/service/grpc_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/auth"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gorm.io/gorm"
 )
@@ -71,6 +72,11 @@ type Repository interface {
 
 	SaveBankRelation(ctx context.Context, partyID uuid.UUID, accountOfficerID, relationshipManagerID, assignedBranch string) error
 	FindBankRelation(ctx context.Context, partyID uuid.UUID) (*persistence.PartyBankRelationEntity, error)
+
+	// Syndicate participant operations
+	SaveAssociationWithInput(ctx context.Context, partyID, relatedPartyID uuid.UUID, relationshipType string, input *persistence.AssociationInput) (uuid.UUID, error)
+	ListParticipants(ctx context.Context, orgPartyID uuid.UUID, relationshipType string) ([]persistence.PartyAssociationEntity, error)
+	GetStructuringData(ctx context.Context, partyID, orgPartyID uuid.UUID, relationshipType string) (map[string]interface{}, error)
 }
 
 // Service implements the PartyService gRPC service
@@ -629,9 +635,33 @@ func (s *Service) RegisterAssociations(ctx context.Context, req *pb.RegisterAsso
 		return nil, status.Errorf(codes.InvalidArgument, "circular association detected")
 	}
 
-	// Save association
+	// Build association input with optional fields
 	relationshipType := protoToRelationshipType(req.RelationshipType)
-	associationID, err := s.repo.SaveAssociation(ctx, partyID, relatedPartyID, relationshipType)
+	var input *persistence.AssociationInput
+	if req.Metadata != nil || req.Status != pb.AssociationStatus_ASSOCIATION_STATUS_UNSPECIFIED || req.EffectiveFrom != nil || req.EffectiveTo != nil {
+		input = &persistence.AssociationInput{}
+		if req.Metadata != nil {
+			metadataBytes, marshalErr := json.Marshal(req.Metadata.AsMap())
+			if marshalErr == nil {
+				metadataStr := string(metadataBytes)
+				input.Metadata = &metadataStr
+			}
+		}
+		if req.Status != pb.AssociationStatus_ASSOCIATION_STATUS_UNSPECIFIED {
+			input.Status = protoAssociationStatusToString(req.Status)
+		}
+		if req.EffectiveFrom != nil {
+			ef := req.EffectiveFrom.AsTime()
+			input.EffectiveFrom = &ef
+		}
+		if req.EffectiveTo != nil {
+			et := req.EffectiveTo.AsTime()
+			input.EffectiveTo = &et
+		}
+	}
+
+	// Save association
+	associationID, err := s.repo.SaveAssociationWithInput(ctx, partyID, relatedPartyID, relationshipType, input)
 	if err != nil {
 		s.logger.Error("failed to save association", "party_id", req.PartyId, "error", err)
 		if errors.Is(err, persistence.ErrAssociationExists) {
@@ -642,13 +672,45 @@ func (s *Service) RegisterAssociations(ctx context.Context, req *pb.RegisterAsso
 
 	s.logger.Info("party association registered", "party_id", req.PartyId, "related_party_id", req.RelatedPartyId)
 
-	return &pb.RegisterAssociationsResponse{
+	resp := &pb.RegisterAssociationsResponse{
 		AssociationId:    associationID.String(),
 		PartyId:          req.PartyId,
 		RelatedPartyId:   req.RelatedPartyId,
 		RelationshipType: req.RelationshipType,
 		CreatedAt:        timestamppb.Now(),
-	}, nil
+		Metadata:         req.Metadata,
+		Status:           req.Status,
+		EffectiveFrom:    req.EffectiveFrom,
+		EffectiveTo:      req.EffectiveTo,
+	}
+	if resp.Status == pb.AssociationStatus_ASSOCIATION_STATUS_UNSPECIFIED {
+		resp.Status = pb.AssociationStatus_ASSOCIATION_STATUS_ACTIVE
+	}
+
+	return resp, nil
+}
+
+// Association status string constants
+const (
+	associationStatusActive     = "ACTIVE"
+	associationStatusSuspended  = "SUSPENDED"
+	associationStatusTerminated = "TERMINATED"
+)
+
+// protoAssociationStatusToString converts proto AssociationStatus to string
+func protoAssociationStatusToString(s pb.AssociationStatus) string {
+	switch s {
+	case pb.AssociationStatus_ASSOCIATION_STATUS_ACTIVE:
+		return associationStatusActive
+	case pb.AssociationStatus_ASSOCIATION_STATUS_SUSPENDED:
+		return associationStatusSuspended
+	case pb.AssociationStatus_ASSOCIATION_STATUS_TERMINATED:
+		return associationStatusTerminated
+	case pb.AssociationStatus_ASSOCIATION_STATUS_UNSPECIFIED:
+		return associationStatusActive
+	default:
+		return associationStatusActive
+	}
 }
 
 // UpdateAssociations updates a party association
@@ -694,13 +756,7 @@ func (s *Service) RetrieveAssociations(ctx context.Context, req *pb.RetrieveAsso
 
 	pbAssociations := make([]*pb.Association, len(associations))
 	for i, assoc := range associations {
-		pbAssociations[i] = &pb.Association{
-			AssociationId:    assoc.ID.String(),
-			RelatedPartyId:   assoc.RelatedPartyID.String(),
-			RelationshipType: relationshipTypeToProto(assoc.RelationshipType),
-			CreatedAt:        timestamppb.New(assoc.CreatedAt),
-			UpdatedAt:        timestamppb.New(assoc.UpdatedAt),
-		}
+		pbAssociations[i] = associationEntityToProto(&assoc)
 	}
 
 	return &pb.RetrieveAssociationsResponse{
@@ -914,6 +970,111 @@ func (s *Service) RetrieveBankRelations(ctx context.Context, req *pb.RetrieveBan
 	}
 
 	return resp, nil
+}
+
+// ListParticipants returns all active participants for a syndicate (org party).
+func (s *Service) ListParticipants(ctx context.Context, req *pb.ListParticipantsRequest) (*pb.ListParticipantsResponse, error) {
+	orgPartyID, err := uuid.Parse(req.OrgPartyId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid org_party_id format: %v", err)
+	}
+
+	relationshipType := protoToRelationshipType(req.RelationshipType)
+
+	associations, err := s.repo.ListParticipants(ctx, orgPartyID, relationshipType)
+	if err != nil {
+		s.logger.Error("failed to list participants",
+			"org_party_id", req.OrgPartyId,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to list participants: %v", err)
+	}
+
+	participants := make([]*pb.Association, len(associations))
+	for i, assoc := range associations {
+		participants[i] = associationEntityToProto(&assoc)
+	}
+
+	return &pb.ListParticipantsResponse{
+		Participants: participants,
+	}, nil
+}
+
+// GetStructuringData returns the structuring metadata for a specific participant in a syndicate.
+func (s *Service) GetStructuringData(ctx context.Context, req *pb.GetStructuringDataRequest) (*pb.GetStructuringDataResponse, error) {
+	partyID, err := uuid.Parse(req.PartyId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid party_id format: %v", err)
+	}
+
+	orgPartyID, err := uuid.Parse(req.OrgPartyId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid org_party_id format: %v", err)
+	}
+
+	relationshipType := protoToRelationshipType(req.RelationshipType)
+
+	metadata, err := s.repo.GetStructuringData(ctx, partyID, orgPartyID, relationshipType)
+	if err != nil {
+		s.logger.Error("failed to get structuring data",
+			"party_id", req.PartyId,
+			"org_party_id", req.OrgPartyId,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to get structuring data: %v", err)
+	}
+
+	pbStruct, err := structpb.NewStruct(metadata)
+	if err != nil {
+		s.logger.Error("failed to convert metadata to proto struct",
+			"party_id", req.PartyId,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to convert metadata: %v", err)
+	}
+
+	return &pb.GetStructuringDataResponse{
+		Metadata: pbStruct,
+	}, nil
+}
+
+// associationEntityToProto converts a persistence entity to a proto Association message.
+func associationEntityToProto(entity *persistence.PartyAssociationEntity) *pb.Association {
+	assoc := &pb.Association{
+		AssociationId:    entity.ID.String(),
+		RelatedPartyId:   entity.RelatedPartyID.String(),
+		RelationshipType: relationshipTypeToProto(entity.RelationshipType),
+		CreatedAt:        timestamppb.New(entity.CreatedAt),
+		UpdatedAt:        timestamppb.New(entity.UpdatedAt),
+		Status:           associationStatusToProto(entity.Status),
+		EffectiveFrom:    timestamppb.New(entity.EffectiveFrom),
+	}
+
+	if entity.EffectiveTo != nil {
+		assoc.EffectiveTo = timestamppb.New(*entity.EffectiveTo)
+	}
+
+	if entity.Metadata != nil && *entity.Metadata != "" && *entity.Metadata != "{}" {
+		var metadataMap map[string]interface{}
+		if err := json.Unmarshal([]byte(*entity.Metadata), &metadataMap); err == nil {
+			if pbStruct, err := structpb.NewStruct(metadataMap); err == nil {
+				assoc.Metadata = pbStruct
+			}
+		}
+	}
+
+	return assoc
+}
+
+// associationStatusToProto converts a status string to proto AssociationStatus
+func associationStatusToProto(status string) pb.AssociationStatus {
+	switch status {
+	case associationStatusActive:
+		return pb.AssociationStatus_ASSOCIATION_STATUS_ACTIVE
+	case associationStatusSuspended:
+		return pb.AssociationStatus_ASSOCIATION_STATUS_SUSPENDED
+	case associationStatusTerminated:
+		return pb.AssociationStatus_ASSOCIATION_STATUS_TERMINATED
+	default:
+		return pb.AssociationStatus_ASSOCIATION_STATUS_UNSPECIFIED
+	}
 }
 
 // protoToRelationshipType converts proto RelationshipType to domain string

--- a/services/party/service/grpc_service_integration_test.go
+++ b/services/party/service/grpc_service_integration_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -19,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 	"gorm.io/gorm"
 )
 
@@ -75,6 +77,21 @@ func setupIntegrationTest(t *testing.T) (*Service, *gorm.DB, context.Context, fu
 		transaction_id VARCHAR(100),
 		client_ip VARCHAR(45),
 		user_agent TEXT
+	)`, pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// Create the party_association table in the tenant schema
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.party_association (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		party_id UUID NOT NULL,
+		related_party_id UUID NOT NULL,
+		relationship_type VARCHAR(50) NOT NULL,
+		metadata JSONB NULL DEFAULT '{}'::jsonb,
+		status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+		effective_from TIMESTAMPTZ NOT NULL DEFAULT now(),
+		effective_to TIMESTAMPTZ NULL,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
 	)`, pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
@@ -472,3 +489,326 @@ func TestNewService_NilRepository(t *testing.T) {
 	assert.Nil(t, svc, "Service should be nil")
 	assert.ErrorIs(t, err, ErrRepositoryNil)
 }
+
+// createSyndicateWithParticipants creates an org party and N participant parties
+// with SYNDICATE_PARTICIPANT associations, returning the org party ID and participant IDs.
+func createSyndicateWithParticipants(t *testing.T, svc *Service, ctx context.Context, numParticipants int) (string, []string) {
+	t.Helper()
+
+	// Create org party (syndicate host)
+	orgResp, err := svc.RegisterParty(ctx, &pb.RegisterPartyRequest{
+		PartyType: pb.PartyType_PARTY_TYPE_ORGANIZATION,
+		LegalName: "Syndicate Host Ltd",
+	})
+	require.NoError(t, err)
+	orgPartyID := orgResp.Party.PartyId
+
+	participantIDs := make([]string, numParticipants)
+	for i := 0; i < numParticipants; i++ {
+		// Create participant party
+		partResp, err := svc.RegisterParty(ctx, &pb.RegisterPartyRequest{
+			PartyType: pb.PartyType_PARTY_TYPE_ORGANIZATION,
+			LegalName: fmt.Sprintf("Participant %d Ltd", i+1),
+		})
+		require.NoError(t, err)
+		participantIDs[i] = partResp.Party.PartyId
+
+		// Create syndicate participant association with metadata
+		metadata, err := structpb.NewStruct(map[string]interface{}{
+			"allocation_share": float64(100) / float64(numParticipants),
+			"role":             fmt.Sprintf("participant_%d", i+1),
+		})
+		require.NoError(t, err)
+
+		_, err = svc.RegisterAssociations(ctx, &pb.RegisterAssociationsRequest{
+			PartyId:          participantIDs[i],
+			RelatedPartyId:   orgPartyID,
+			RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT,
+			Metadata:         metadata,
+			Status:           pb.AssociationStatus_ASSOCIATION_STATUS_ACTIVE,
+		})
+		require.NoError(t, err)
+	}
+
+	return orgPartyID, participantIDs
+}
+
+// TestListParticipants_ReturnsActiveParticipants verifies that ListParticipants
+// returns all active syndicate participants for an organization party.
+func TestListParticipants_ReturnsActiveParticipants(t *testing.T) {
+	svc, _, ctx, cleanup := setupIntegrationTest(t)
+	defer cleanup()
+
+	orgPartyID, participantIDs := createSyndicateWithParticipants(t, svc, ctx, 3)
+
+	resp, err := svc.ListParticipants(ctx, &pb.ListParticipantsRequest{
+		OrgPartyId:       orgPartyID,
+		RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Participants, 3, "Should return 3 active participants")
+
+	// Verify each participant has the expected fields
+	returnedPartyIDs := make(map[string]bool)
+	for _, p := range resp.Participants {
+		assert.NotEmpty(t, p.AssociationId)
+		assert.Equal(t, pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT, p.RelationshipType)
+		assert.Equal(t, pb.AssociationStatus_ASSOCIATION_STATUS_ACTIVE, p.Status)
+		assert.NotNil(t, p.CreatedAt)
+		assert.NotNil(t, p.EffectiveFrom)
+		assert.NotNil(t, p.Metadata)
+		// The related_party_id in the association is the org party
+		assert.Equal(t, orgPartyID, p.RelatedPartyId)
+		returnedPartyIDs[p.AssociationId] = true
+	}
+
+	// Verify all 3 distinct association IDs returned
+	assert.Len(t, returnedPartyIDs, 3)
+
+	_ = participantIDs // used by createSyndicateWithParticipants
+}
+
+// TestListParticipants_ExcludesSuspended verifies that SUSPENDED associations
+// are excluded from ListParticipants results.
+func TestListParticipants_ExcludesSuspended(t *testing.T) {
+	svc, db, ctx, cleanup := setupIntegrationTest(t)
+	defer cleanup()
+
+	orgPartyID, _ := createSyndicateWithParticipants(t, svc, ctx, 3)
+
+	// Suspend one participant's association directly in DB
+	err := db.Exec("UPDATE party_association SET status = 'SUSPENDED' WHERE related_party_id = ? LIMIT 1",
+		orgPartyID).Error
+	// LIMIT not supported in all DB engines, use a subquery approach instead
+	if err != nil {
+		// Fallback: update first association found
+		var assocID string
+		db.Raw("SELECT id FROM party_association WHERE related_party_id = ? LIMIT 1", orgPartyID).Scan(&assocID)
+		err = db.Exec("UPDATE party_association SET status = 'SUSPENDED' WHERE id = ?", assocID).Error
+		require.NoError(t, err)
+	}
+
+	resp, err := svc.ListParticipants(ctx, &pb.ListParticipantsRequest{
+		OrgPartyId:       orgPartyID,
+		RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT,
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp.Participants, 2, "Should return only 2 active participants (1 suspended)")
+
+	for _, p := range resp.Participants {
+		assert.Equal(t, pb.AssociationStatus_ASSOCIATION_STATUS_ACTIVE, p.Status)
+	}
+}
+
+// TestListParticipants_EmptyResult verifies that ListParticipants returns
+// an empty list (not an error) when no participants exist.
+func TestListParticipants_EmptyResult(t *testing.T) {
+	svc, _, ctx, cleanup := setupIntegrationTest(t)
+	defer cleanup()
+
+	// Create an org party with no participants
+	orgResp, err := svc.RegisterParty(ctx, &pb.RegisterPartyRequest{
+		PartyType: pb.PartyType_PARTY_TYPE_ORGANIZATION,
+		LegalName: "Empty Syndicate Ltd",
+	})
+	require.NoError(t, err)
+
+	resp, err := svc.ListParticipants(ctx, &pb.ListParticipantsRequest{
+		OrgPartyId:       orgResp.Party.PartyId,
+		RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Participants)
+}
+
+// TestListParticipants_InvalidOrgPartyID verifies that an invalid UUID returns InvalidArgument.
+func TestListParticipants_InvalidOrgPartyID(t *testing.T) {
+	svc, _, ctx, cleanup := setupIntegrationTest(t)
+	defer cleanup()
+
+	resp, err := svc.ListParticipants(ctx, &pb.ListParticipantsRequest{
+		OrgPartyId:       "not-a-uuid",
+		RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT,
+	})
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// TestGetStructuringData_ReturnsMetadata verifies that GetStructuringData
+// returns the correct metadata for a specific participant.
+func TestGetStructuringData_ReturnsMetadata(t *testing.T) {
+	svc, _, ctx, cleanup := setupIntegrationTest(t)
+	defer cleanup()
+
+	orgPartyID, participantIDs := createSyndicateWithParticipants(t, svc, ctx, 2)
+
+	// Get structuring data for first participant
+	resp, err := svc.GetStructuringData(ctx, &pb.GetStructuringDataRequest{
+		PartyId:          participantIDs[0],
+		OrgPartyId:       orgPartyID,
+		RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Metadata)
+
+	metadataMap := resp.Metadata.AsMap()
+	assert.Equal(t, float64(50), metadataMap["allocation_share"])
+	assert.Equal(t, "participant_1", metadataMap["role"])
+}
+
+// TestGetStructuringData_NotFoundReturnsEmpty verifies that GetStructuringData
+// returns an empty metadata map (not an error) when no association exists.
+func TestGetStructuringData_NotFoundReturnsEmpty(t *testing.T) {
+	svc, _, ctx, cleanup := setupIntegrationTest(t)
+	defer cleanup()
+
+	resp, err := svc.GetStructuringData(ctx, &pb.GetStructuringDataRequest{
+		PartyId:          uuid.New().String(),
+		OrgPartyId:       uuid.New().String(),
+		RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Metadata)
+
+	// Should be empty, not nil
+	metadataMap := resp.Metadata.AsMap()
+	assert.Empty(t, metadataMap)
+}
+
+// TestGetStructuringData_InvalidPartyID verifies that invalid UUIDs return InvalidArgument.
+func TestGetStructuringData_InvalidPartyID(t *testing.T) {
+	svc, _, ctx, cleanup := setupIntegrationTest(t)
+	defer cleanup()
+
+	resp, err := svc.GetStructuringData(ctx, &pb.GetStructuringDataRequest{
+		PartyId:          "not-a-uuid",
+		OrgPartyId:       uuid.New().String(),
+		RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT,
+	})
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// TestGetStructuringData_InvalidOrgPartyID verifies that invalid org party UUID returns InvalidArgument.
+func TestGetStructuringData_InvalidOrgPartyID(t *testing.T) {
+	svc, _, ctx, cleanup := setupIntegrationTest(t)
+	defer cleanup()
+
+	resp, err := svc.GetStructuringData(ctx, &pb.GetStructuringDataRequest{
+		PartyId:          uuid.New().String(),
+		OrgPartyId:       "not-a-uuid",
+		RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT,
+	})
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// TestRegisterAssociations_WithMetadata verifies that associations can be
+// created with metadata and the new lifecycle fields.
+func TestRegisterAssociations_WithMetadata(t *testing.T) {
+	svc, _, ctx, cleanup := setupIntegrationTest(t)
+	defer cleanup()
+
+	// Create two parties
+	party1Resp, err := svc.RegisterParty(ctx, &pb.RegisterPartyRequest{
+		PartyType: pb.PartyType_PARTY_TYPE_ORGANIZATION,
+		LegalName: "Host Corp",
+	})
+	require.NoError(t, err)
+
+	party2Resp, err := svc.RegisterParty(ctx, &pb.RegisterPartyRequest{
+		PartyType: pb.PartyType_PARTY_TYPE_ORGANIZATION,
+		LegalName: "Participant Corp",
+	})
+	require.NoError(t, err)
+
+	metadata, err := structpb.NewStruct(map[string]interface{}{
+		"allocation_share": 25.5,
+		"tier":             "gold",
+	})
+	require.NoError(t, err)
+
+	assocResp, err := svc.RegisterAssociations(ctx, &pb.RegisterAssociationsRequest{
+		PartyId:          party2Resp.Party.PartyId,
+		RelatedPartyId:   party1Resp.Party.PartyId,
+		RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT,
+		Metadata:         metadata,
+		Status:           pb.AssociationStatus_ASSOCIATION_STATUS_ACTIVE,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, assocResp.AssociationId)
+	assert.Equal(t, pb.AssociationStatus_ASSOCIATION_STATUS_ACTIVE, assocResp.Status)
+
+	// Verify metadata was persisted via GetStructuringData
+	structResp, err := svc.GetStructuringData(ctx, &pb.GetStructuringDataRequest{
+		PartyId:          party2Resp.Party.PartyId,
+		OrgPartyId:       party1Resp.Party.PartyId,
+		RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT,
+	})
+	require.NoError(t, err)
+
+	metadataMap := structResp.Metadata.AsMap()
+	assert.Equal(t, 25.5, metadataMap["allocation_share"])
+	assert.Equal(t, "gold", metadataMap["tier"])
+}
+
+// TestRetrieveAssociations_IncludesNewFields verifies that RetrieveAssociations
+// returns the new metadata, status, effective_from, effective_to fields.
+func TestRetrieveAssociations_IncludesNewFields(t *testing.T) {
+	svc, _, ctx, cleanup := setupIntegrationTest(t)
+	defer cleanup()
+
+	// Create two parties and an association with metadata
+	party1Resp, err := svc.RegisterParty(ctx, &pb.RegisterPartyRequest{
+		PartyType: pb.PartyType_PARTY_TYPE_ORGANIZATION,
+		LegalName: "Host Corp",
+	})
+	require.NoError(t, err)
+
+	party2Resp, err := svc.RegisterParty(ctx, &pb.RegisterPartyRequest{
+		PartyType: pb.PartyType_PARTY_TYPE_ORGANIZATION,
+		LegalName: "Partner Corp",
+	})
+	require.NoError(t, err)
+
+	metadata, err := structpb.NewStruct(map[string]interface{}{
+		"allocation_share": 50.0,
+	})
+	require.NoError(t, err)
+
+	_, err = svc.RegisterAssociations(ctx, &pb.RegisterAssociationsRequest{
+		PartyId:          party2Resp.Party.PartyId,
+		RelatedPartyId:   party1Resp.Party.PartyId,
+		RelationshipType: pb.RelationshipType_RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT,
+		Metadata:         metadata,
+	})
+	require.NoError(t, err)
+
+	// Retrieve associations for party2
+	assocResp, err := svc.RetrieveAssociations(ctx, &pb.RetrieveAssociationsRequest{
+		PartyId: party2Resp.Party.PartyId,
+	})
+	require.NoError(t, err)
+	require.Len(t, assocResp.Associations, 1)
+
+	assoc := assocResp.Associations[0]
+	assert.Equal(t, pb.AssociationStatus_ASSOCIATION_STATUS_ACTIVE, assoc.Status)
+	assert.NotNil(t, assoc.EffectiveFrom)
+	assert.Nil(t, assoc.EffectiveTo)
+	assert.NotNil(t, assoc.Metadata)
+
+	metadataMap := assoc.Metadata.AsMap()
+	assert.Equal(t, 50.0, metadataMap["allocation_share"])
+}
+
+// Suppress unused import warnings
+var (
+	_ = json.Marshal
+	_ = structpb.NewStruct
+)

--- a/services/party/service/grpc_service_test.go
+++ b/services/party/service/grpc_service_test.go
@@ -138,6 +138,18 @@ func (m *mockRepository) FindBankRelation(_ context.Context, _ uuid.UUID) (*pers
 	return nil, nil
 }
 
+func (m *mockRepository) SaveAssociationWithInput(_ context.Context, _, _ uuid.UUID, _ string, _ *persistence.AssociationInput) (uuid.UUID, error) {
+	return uuid.New(), nil
+}
+
+func (m *mockRepository) ListParticipants(_ context.Context, _ uuid.UUID, _ string) ([]persistence.PartyAssociationEntity, error) {
+	return []persistence.PartyAssociationEntity{}, nil
+}
+
+func (m *mockRepository) GetStructuringData(_ context.Context, _, _ uuid.UUID, _ string) (map[string]interface{}, error) {
+	return map[string]interface{}{}, nil
+}
+
 func newTestService(mock *mockRepository) *Service {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	svc, _ := NewService(mock, logger)

--- a/services/party/service/lifecycle_integration_test.go
+++ b/services/party/service/lifecycle_integration_test.go
@@ -97,6 +97,10 @@ func setupLifecycleIntegrationTest(t *testing.T) (*Service, *gorm.DB, context.Co
 		party_id UUID NOT NULL REFERENCES %[1]s.party(id) ON DELETE CASCADE,
 		related_party_id UUID NOT NULL,
 		relationship_type VARCHAR(50) NOT NULL,
+		metadata JSONB NULL DEFAULT '{}'::jsonb,
+		status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+		effective_from TIMESTAMPTZ NOT NULL DEFAULT now(),
+		effective_to TIMESTAMPTZ NULL,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
 		UNIQUE(party_id, related_party_id, relationship_type)


### PR DESCRIPTION
## Summary

- Add `ListParticipants` and `GetStructuringData` repository query methods for syndicate associations
- Add corresponding gRPC service handlers with proto RPC definitions and HTTP annotations
- Update `PartyAssociationEntity` with lifecycle fields (metadata, status, effective_from, effective_to)
- Update `RegisterAssociations` to pass through metadata and lifecycle fields
- Update `RetrieveAssociations` to include new fields via shared conversion helper

## Changes

### Repository Layer
- `PartyAssociationEntity`: Added metadata (JSONB), status, effective_from, effective_to fields
- `AssociationInput` struct: New input type for creating associations with optional metadata
- `SaveAssociationWithInput`: New method preserving backward compatibility with existing `SaveAssociation`
- `ListParticipants(ctx, orgPartyID, relationshipType)`: Queries ACTIVE associations where related_party_id matches
- `GetStructuringData(ctx, partyID, orgPartyID, relationshipType)`: Returns metadata as map, empty map if not found

### Proto Definitions
- `ListParticipants` RPC with HTTP GET `/v1/parties/{org_party_id}/participants`
- `GetStructuringData` RPC with HTTP GET `/v1/parties/{org_party_id}/participants/{party_id}/structuring-data`

### gRPC Handlers
- `ListParticipants`: Returns active participants for an org party, with metadata and lifecycle fields
- `GetStructuringData`: Returns structuring metadata as proto Struct, empty struct if not found
- `RegisterAssociations`: Updated to accept and persist metadata, status, effective_from, effective_to
- `RetrieveAssociations`: Updated to return new fields via shared `associationEntityToProto` helper

## Test Plan

- [x] Repository unit tests for ListParticipants (active filtering, status exclusion, relationship type filtering, empty results)
- [x] Repository unit tests for GetStructuringData (metadata retrieval, not-found returns empty map, nil metadata)
- [x] Repository unit tests for SaveAssociationWithInput (all fields persisted)
- [x] gRPC unit tests compile with updated mock repository
- [x] Integration tests for ListParticipants (active filtering, suspended exclusion, empty result, invalid ID)
- [x] Integration tests for GetStructuringData (metadata retrieval, not-found, invalid IDs)
- [x] Integration tests for RegisterAssociations with metadata passthrough
- [x] Integration tests for RetrieveAssociations with new fields

Part of org-scoped-accounts epic (Task Master: org-scoped-accounts.7)