### PR TITLE
feat: add Starlark saga handlers for org-scoped account workflows

### DIFF
--- a/services/party/client/client.go
+++ b/services/party/client/client.go
@@ -277,6 +277,52 @@ func (c *Client) GetDefaultPaymentMethod(ctx context.Context, req *partyv1.GetDe
 	return resp, nil
 }
 
+// ListParticipants returns all active participants for a syndicate (org party).
+// This is an idempotent read operation, so it uses circuit breaker with retry.
+func (c *Client) ListParticipants(ctx context.Context, req *partyv1.ListParticipantsRequest) (*partyv1.ListParticipantsResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilience(ctx, c.resilient, "ListParticipants", func() (*partyv1.ListParticipantsResponse, error) {
+			return c.party.ListParticipants(ctx, req)
+		})
+	}
+
+	resp, err := c.party.ListParticipants(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list participants: %w", err)
+	}
+
+	return resp, nil
+}
+
+// GetStructuringData returns the structuring metadata for a specific participant in a syndicate.
+// This is an idempotent read operation, so it uses circuit breaker with retry.
+func (c *Client) GetStructuringData(ctx context.Context, req *partyv1.GetStructuringDataRequest) (*partyv1.GetStructuringDataResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilience(ctx, c.resilient, "GetStructuringData", func() (*partyv1.GetStructuringDataResponse, error) {
+			return c.party.GetStructuringData(ctx, req)
+		})
+	}
+
+	resp, err := c.party.GetStructuringData(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get structuring data: %w", err)
+	}
+
+	return resp, nil
+}
+
 // Close terminates the gRPC connection gracefully.
 func (c *Client) Close() error {
 	if c.conn != nil {

--- a/services/party/client/starlark.go
+++ b/services/party/client/starlark.go
@@ -11,10 +11,16 @@ import (
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
+	_structpb "google.golang.org/protobuf/types/known/structpb"
 )
 
-// errMissingPaymentMethod is returned when the gRPC response contains no payment method.
-var errMissingPaymentMethod = errors.New("missing payment method in response")
+var (
+	// errMissingPaymentMethod is returned when the gRPC response contains no payment method.
+	errMissingPaymentMethod = errors.New("missing payment method in response")
+
+	// errInvalidRelationshipType is returned when the relationship_type parameter is not recognized.
+	errInvalidRelationshipType = errors.New("invalid relationship_type")
+)
 
 // RegisterStarlarkHandlers registers all Starlark service bindings for the Party service.
 // These handlers adapt the Starlark interface (map[string]any) to gRPC client calls.
@@ -25,6 +31,18 @@ func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, client *Client) er
 	}{
 		"party.get_default_payment_method": {
 			handler: getDefaultPaymentMethodHandler(client),
+			metadata: saga.HandlerMetadata{
+				ProducesInstruments: []string{},
+			},
+		},
+		"party.list_participants": {
+			handler: listParticipantsHandler(client),
+			metadata: saga.HandlerMetadata{
+				ProducesInstruments: []string{},
+			},
+		},
+		"party.get_structuring_data": {
+			handler: getStructuringDataHandler(client),
 			metadata: saga.HandlerMetadata{
 				ProducesInstruments: []string{},
 			},
@@ -82,6 +100,178 @@ func getDefaultPaymentMethodHandler(client *Client) saga.Handler {
 			"method_type":          pm.GetMethodType().String(),
 		}, nil
 	}
+}
+
+// listParticipantsHandler returns active participants for a syndicate organization.
+// Results are cached in the saga LookupCache for deterministic replay.
+//
+// Parameters:
+//   - org_id (string): Organization party identifier (UUID)
+//   - relationship_type (string): Relationship type filter (e.g., "SYNDICATE_PARTICIPANT")
+//
+// Returns a list of dicts, each containing:
+//   - party_id: Participant party identifier
+//   - metadata: Structuring metadata dict (e.g., allocation_share, role)
+func listParticipantsHandler(client *Client) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		orgID, err := saga.RequireStringParam(params, "org_id")
+		if err != nil {
+			return nil, err
+		}
+
+		relType, err := parseRelationshipType(params)
+		if err != nil {
+			return nil, fmt.Errorf("party.list_participants: %w", err)
+		}
+
+		// Check lookup cache for deterministic replay
+		cacheKey := saga.GenerateCacheKey("party.list_participants", params)
+		if cached, ok := lookupCachedSlice(ctx, cacheKey); ok {
+			return cached, nil
+		}
+
+		clientCtx := preparePartyClientContext(ctx)
+
+		resp, err := client.ListParticipants(clientCtx, &partyv1.ListParticipantsRequest{
+			OrgPartyId:       orgID,
+			RelationshipType: relType,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("party.list_participants: %w", err)
+		}
+
+		result := convertParticipantsToResult(resp.GetParticipants())
+
+		// Cache result for replay
+		if ctx.LookupCache != nil {
+			ctx.LookupCache.Set(cacheKey, result)
+		}
+
+		return result, nil
+	}
+}
+
+// getStructuringDataHandler retrieves structuring metadata for a participant in a syndicate.
+// Results are cached in the saga LookupCache for deterministic replay.
+//
+// Parameters:
+//   - party_id (string): Participant party identifier (UUID)
+//   - org_id (string): Organization party identifier (UUID)
+//   - relationship_type (string): Relationship type (e.g., "SYNDICATE_PARTICIPANT")
+//
+// Returns a dict of metadata or empty dict if not found.
+func getStructuringDataHandler(client *Client) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		partyID, err := saga.RequireStringParam(params, "party_id")
+		if err != nil {
+			return nil, err
+		}
+
+		orgID, err := saga.RequireStringParam(params, "org_id")
+		if err != nil {
+			return nil, err
+		}
+
+		relType, err := parseRelationshipType(params)
+		if err != nil {
+			return nil, fmt.Errorf("party.get_structuring_data: %w", err)
+		}
+
+		// Check lookup cache for deterministic replay
+		cacheKey := saga.GenerateCacheKey("party.get_structuring_data", params)
+		if cached, ok := lookupCachedMap(ctx, cacheKey); ok {
+			return cached, nil
+		}
+
+		clientCtx := preparePartyClientContext(ctx)
+
+		resp, err := client.GetStructuringData(clientCtx, &partyv1.GetStructuringDataRequest{
+			PartyId:          partyID,
+			OrgPartyId:       orgID,
+			RelationshipType: relType,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("party.get_structuring_data: %w", err)
+		}
+
+		result := structToMap(resp.GetMetadata())
+
+		// Cache result for replay
+		if ctx.LookupCache != nil {
+			ctx.LookupCache.Set(cacheKey, result)
+		}
+
+		return result, nil
+	}
+}
+
+// structToMap converts a protobuf Struct to map[string]any.
+func structToMap(s *_structpb.Struct) map[string]any {
+	if s == nil {
+		return map[string]any{}
+	}
+	m := s.AsMap()
+	result := make(map[string]any, len(m))
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}
+
+// parseRelationshipType extracts and validates the relationship_type parameter.
+func parseRelationshipType(params map[string]any) (partyv1.RelationshipType, error) {
+	relTypeStr, err := saga.RequireStringParam(params, "relationship_type")
+	if err != nil {
+		return 0, err
+	}
+
+	val, ok := partyv1.RelationshipType_value[relTypeStr]
+	if !ok {
+		return 0, fmt.Errorf("%w: %q", errInvalidRelationshipType, relTypeStr)
+	}
+	return partyv1.RelationshipType(val), nil
+}
+
+// lookupCachedSlice checks the LookupCache for a cached slice result.
+func lookupCachedSlice(ctx *saga.StarlarkContext, cacheKey string) ([]any, bool) {
+	if ctx.LookupCache == nil {
+		return nil, false
+	}
+	cached, found := ctx.LookupCache.Get(cacheKey)
+	if !found {
+		return nil, false
+	}
+	if result, ok := cached.([]any); ok {
+		return result, true
+	}
+	return nil, false
+}
+
+// lookupCachedMap checks the LookupCache for a cached map result.
+func lookupCachedMap(ctx *saga.StarlarkContext, cacheKey string) (map[string]any, bool) {
+	if ctx.LookupCache == nil {
+		return nil, false
+	}
+	cached, found := ctx.LookupCache.Get(cacheKey)
+	if !found {
+		return nil, false
+	}
+	if result, ok := cached.(map[string]any); ok {
+		return result, true
+	}
+	return nil, false
+}
+
+// convertParticipantsToResult converts proto Association messages to a result slice.
+func convertParticipantsToResult(participants []*partyv1.Association) []any {
+	result := make([]any, 0, len(participants))
+	for _, p := range participants {
+		result = append(result, map[string]any{
+			"party_id": p.GetRelatedPartyId(),
+			"metadata": structToMap(p.GetMetadata()),
+		})
+	}
+	return result
 }
 
 // preparePartyClientContext enriches the gRPC client context with saga metadata.

--- a/services/party/client/starlark.go
+++ b/services/party/client/starlark.go
@@ -119,6 +119,10 @@ func listParticipantsHandler(client *Client) saga.Handler {
 			return nil, err
 		}
 
+		if err := ctx.ValidatePartyAccessFromString(orgID); err != nil {
+			return nil, fmt.Errorf("party.list_participants: %w", err)
+		}
+
 		relType, err := parseRelationshipType(params)
 		if err != nil {
 			return nil, fmt.Errorf("party.list_participants: %w", err)
@@ -170,6 +174,13 @@ func getStructuringDataHandler(client *Client) saga.Handler {
 		orgID, err := saga.RequireStringParam(params, "org_id")
 		if err != nil {
 			return nil, err
+		}
+
+		if err := ctx.ValidatePartyAccessFromString(partyID); err != nil {
+			return nil, fmt.Errorf("party.get_structuring_data: %w", err)
+		}
+		if err := ctx.ValidatePartyAccessFromString(orgID); err != nil {
+			return nil, fmt.Errorf("party.get_structuring_data: %w", err)
 		}
 
 		relType, err := parseRelationshipType(params)

--- a/services/party/client/starlark_test.go
+++ b/services/party/client/starlark_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/google/uuid"
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/stretchr/testify/assert"
@@ -12,19 +13,30 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // mockPartyServiceClient implements partyv1.PartyServiceClient for testing.
 type mockPartyServiceClient struct {
 	partyv1.PartyServiceClient
-	getDefaultPMResp *partyv1.GetDefaultPaymentMethodResponse
-	getDefaultPMErr  error
+	getDefaultPMResp      *partyv1.GetDefaultPaymentMethodResponse
+	getDefaultPMErr       error
+	listParticipants      *partyv1.ListParticipantsResponse
+	listParticipantsErr   error
+	getStructuringData    *partyv1.GetStructuringDataResponse
+	getStructuringDataErr error
 }
 
 func (m *mockPartyServiceClient) GetDefaultPaymentMethod(_ context.Context, _ *partyv1.GetDefaultPaymentMethodRequest, _ ...grpc.CallOption) (*partyv1.GetDefaultPaymentMethodResponse, error) {
 	return m.getDefaultPMResp, m.getDefaultPMErr
+}
+
+func (m *mockPartyServiceClient) ListParticipants(_ context.Context, _ *partyv1.ListParticipantsRequest, _ ...grpc.CallOption) (*partyv1.ListParticipantsResponse, error) {
+	return m.listParticipants, m.listParticipantsErr
+}
+
+func (m *mockPartyServiceClient) GetStructuringData(_ context.Context, _ *partyv1.GetStructuringDataRequest, _ ...grpc.CallOption) (*partyv1.GetStructuringDataResponse, error) {
+	return m.getStructuringData, m.getStructuringDataErr
 }
 
 func newTestStarlarkContext() *saga.StarlarkContext {
@@ -44,6 +56,8 @@ func TestRegisterStarlarkHandlers(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, registry.Has("party.get_default_payment_method"))
+	assert.True(t, registry.Has("party.list_participants"))
+	assert.True(t, registry.Has("party.get_structuring_data"))
 }
 
 func TestRegisterStarlarkHandlers_DuplicateRegistration(t *testing.T) {
@@ -180,4 +194,372 @@ func TestGetDefaultPaymentMethodHandler_PartyScopeViolation(t *testing.T) {
 	})
 
 	assert.ErrorIs(t, err, saga.ErrPartyScopeViolation)
+}
+
+// --- ListParticipants handler tests ---
+
+func TestListParticipantsHandler_Success(t *testing.T) {
+	metadata, err := structpb.NewStruct(map[string]interface{}{
+		"allocation_share": 0.25,
+		"role":             "participant",
+	})
+	require.NoError(t, err)
+
+	participantID := uuid.New().String()
+	mock := &mockPartyServiceClient{
+		listParticipants: &partyv1.ListParticipantsResponse{
+			Participants: []*partyv1.Association{
+				{
+					RelatedPartyId: participantID,
+					Metadata:       metadata,
+				},
+			},
+		},
+	}
+
+	client := &Client{party: mock}
+	registry := saga.NewHandlerRegistry()
+	err = RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.list_participants")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	result, err := handler(ctx, map[string]any{
+		"org_id":            uuid.New().String(),
+		"relationship_type": "RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT",
+	})
+
+	require.NoError(t, err)
+	resultList, ok := result.([]any)
+	require.True(t, ok)
+	require.Len(t, resultList, 1)
+
+	entry, ok := resultList[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, participantID, entry["party_id"])
+
+	md, ok := entry["metadata"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 0.25, md["allocation_share"])
+	assert.Equal(t, "participant", md["role"])
+}
+
+func TestListParticipantsHandler_EmptyList(t *testing.T) {
+	mock := &mockPartyServiceClient{
+		listParticipants: &partyv1.ListParticipantsResponse{
+			Participants: []*partyv1.Association{},
+		},
+	}
+
+	client := &Client{party: mock}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.list_participants")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	result, err := handler(ctx, map[string]any{
+		"org_id":            uuid.New().String(),
+		"relationship_type": "RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT",
+	})
+
+	require.NoError(t, err)
+	resultList, ok := result.([]any)
+	require.True(t, ok)
+	assert.Empty(t, resultList)
+}
+
+func TestListParticipantsHandler_MissingOrgID(t *testing.T) {
+	client := &Client{party: &mockPartyServiceClient{}}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.list_participants")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{
+		"relationship_type": "RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT",
+	})
+	assert.ErrorIs(t, err, saga.ErrMissingParam)
+}
+
+func TestListParticipantsHandler_MissingRelationshipType(t *testing.T) {
+	client := &Client{party: &mockPartyServiceClient{}}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.list_participants")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{
+		"org_id": uuid.New().String(),
+	})
+	assert.ErrorIs(t, err, saga.ErrMissingParam)
+}
+
+func TestListParticipantsHandler_InvalidRelationshipType(t *testing.T) {
+	client := &Client{party: &mockPartyServiceClient{}}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.list_participants")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{
+		"org_id":            uuid.New().String(),
+		"relationship_type": "INVALID_TYPE",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid relationship_type")
+}
+
+func TestListParticipantsHandler_GRPCError(t *testing.T) {
+	mock := &mockPartyServiceClient{
+		listParticipantsErr: status.Errorf(codes.NotFound, "syndicate not found"),
+	}
+
+	client := &Client{party: mock}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.list_participants")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{
+		"org_id":            uuid.New().String(),
+		"relationship_type": "RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "party.list_participants")
+}
+
+func TestListParticipantsHandler_CacheHit(t *testing.T) {
+	// First call returns real data
+	participantID := uuid.New().String()
+	mock := &mockPartyServiceClient{
+		listParticipants: &partyv1.ListParticipantsResponse{
+			Participants: []*partyv1.Association{
+				{RelatedPartyId: participantID},
+			},
+		},
+	}
+
+	client := &Client{party: mock}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.list_participants")
+	require.NoError(t, err)
+
+	orgID := uuid.New().String()
+	ctx := newTestStarlarkContext()
+	ctx.LookupCache = saga.NewLookupResultCache()
+
+	params := map[string]any{
+		"org_id":            orgID,
+		"relationship_type": "RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT",
+	}
+
+	// First call populates cache
+	result1, err := handler(ctx, params)
+	require.NoError(t, err)
+
+	// Make mock return error - second call should use cache
+	mock.listParticipantsErr = status.Errorf(codes.Internal, "should not be called")
+	mock.listParticipants = nil
+
+	result2, err := handler(ctx, params)
+	require.NoError(t, err)
+
+	// Both should return same data
+	list1, ok := result1.([]any)
+	require.True(t, ok)
+	list2, ok := result2.([]any)
+	require.True(t, ok)
+	assert.Equal(t, len(list1), len(list2))
+}
+
+// --- GetStructuringData handler tests ---
+
+func TestGetStructuringDataHandler_Success(t *testing.T) {
+	metadata, err := structpb.NewStruct(map[string]interface{}{
+		"allocation_share": 0.5,
+		"role":             "lead",
+	})
+	require.NoError(t, err)
+
+	mock := &mockPartyServiceClient{
+		getStructuringData: &partyv1.GetStructuringDataResponse{
+			Metadata: metadata,
+		},
+	}
+
+	client := &Client{party: mock}
+	registry := saga.NewHandlerRegistry()
+	err = RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.get_structuring_data")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	result, err := handler(ctx, map[string]any{
+		"party_id":          uuid.New().String(),
+		"org_id":            uuid.New().String(),
+		"relationship_type": "RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT",
+	})
+
+	require.NoError(t, err)
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 0.5, resultMap["allocation_share"])
+	assert.Equal(t, "lead", resultMap["role"])
+}
+
+func TestGetStructuringDataHandler_EmptyMetadata(t *testing.T) {
+	mock := &mockPartyServiceClient{
+		getStructuringData: &partyv1.GetStructuringDataResponse{
+			Metadata: nil,
+		},
+	}
+
+	client := &Client{party: mock}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.get_structuring_data")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	result, err := handler(ctx, map[string]any{
+		"party_id":          uuid.New().String(),
+		"org_id":            uuid.New().String(),
+		"relationship_type": "RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT",
+	})
+
+	require.NoError(t, err)
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Empty(t, resultMap)
+}
+
+func TestGetStructuringDataHandler_MissingPartyID(t *testing.T) {
+	client := &Client{party: &mockPartyServiceClient{}}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.get_structuring_data")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{
+		"org_id":            uuid.New().String(),
+		"relationship_type": "RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT",
+	})
+	assert.ErrorIs(t, err, saga.ErrMissingParam)
+}
+
+func TestGetStructuringDataHandler_MissingOrgID(t *testing.T) {
+	client := &Client{party: &mockPartyServiceClient{}}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.get_structuring_data")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{
+		"party_id":          uuid.New().String(),
+		"relationship_type": "RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT",
+	})
+	assert.ErrorIs(t, err, saga.ErrMissingParam)
+}
+
+func TestGetStructuringDataHandler_GRPCError(t *testing.T) {
+	mock := &mockPartyServiceClient{
+		getStructuringDataErr: status.Errorf(codes.NotFound, "structuring data not found"),
+	}
+
+	client := &Client{party: mock}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.get_structuring_data")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{
+		"party_id":          uuid.New().String(),
+		"org_id":            uuid.New().String(),
+		"relationship_type": "RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "party.get_structuring_data")
+}
+
+func TestGetStructuringDataHandler_CacheHit(t *testing.T) {
+	metadata, err := structpb.NewStruct(map[string]interface{}{
+		"allocation_share": 0.75,
+	})
+	require.NoError(t, err)
+
+	mock := &mockPartyServiceClient{
+		getStructuringData: &partyv1.GetStructuringDataResponse{
+			Metadata: metadata,
+		},
+	}
+
+	client := &Client{party: mock}
+	registry := saga.NewHandlerRegistry()
+	err = RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.get_structuring_data")
+	require.NoError(t, err)
+
+	partyID := uuid.New().String()
+	orgID := uuid.New().String()
+	ctx := newTestStarlarkContext()
+	ctx.LookupCache = saga.NewLookupResultCache()
+
+	params := map[string]any{
+		"party_id":          partyID,
+		"org_id":            orgID,
+		"relationship_type": "RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT",
+	}
+
+	// First call populates cache
+	result1, err := handler(ctx, params)
+	require.NoError(t, err)
+
+	// Make mock return error - second call should use cache
+	mock.getStructuringDataErr = status.Errorf(codes.Internal, "should not be called")
+	mock.getStructuringData = nil
+
+	result2, err := handler(ctx, params)
+	require.NoError(t, err)
+
+	// Both should return same data
+	map1, ok := result1.(map[string]any)
+	require.True(t, ok)
+	map2, ok := result2.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, map1["allocation_share"], map2["allocation_share"])
 }

--- a/services/party/client/starlark_test.go
+++ b/services/party/client/starlark_test.go
@@ -563,3 +563,66 @@ func TestGetStructuringDataHandler_CacheHit(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, map1["allocation_share"], map2["allocation_share"])
 }
+
+func TestListParticipantsHandler_PartyScopeViolation(t *testing.T) {
+	client := &Client{party: &mockPartyServiceClient{}}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.list_participants")
+	require.NoError(t, err)
+
+	ownPartyID := uuid.New()
+	foreignOrgID := uuid.New()
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		CorrelationID:   uuid.New(),
+		Logger:          slog.Default(),
+		PartyScope: &saga.PartyScope{
+			PartyID:        ownPartyID,
+			VisibleParties: []uuid.UUID{ownPartyID},
+		},
+	}
+
+	_, err = handler(ctx, map[string]any{
+		"org_id":            foreignOrgID.String(),
+		"relationship_type": "RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT",
+	})
+
+	assert.ErrorIs(t, err, saga.ErrPartyScopeViolation)
+}
+
+func TestGetStructuringDataHandler_PartyScopeViolation(t *testing.T) {
+	client := &Client{party: &mockPartyServiceClient{}}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.get_structuring_data")
+	require.NoError(t, err)
+
+	ownPartyID := uuid.New()
+	foreignPartyID := uuid.New()
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		CorrelationID:   uuid.New(),
+		Logger:          slog.Default(),
+		PartyScope: &saga.PartyScope{
+			PartyID:        ownPartyID,
+			VisibleParties: []uuid.UUID{ownPartyID},
+		},
+	}
+
+	_, err = handler(ctx, map[string]any{
+		"party_id":          foreignPartyID.String(),
+		"org_id":            ownPartyID.String(),
+		"relationship_type": "RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT",
+	})
+
+	assert.ErrorIs(t, err, saga.ErrPartyScopeViolation)
+}

--- a/services/reference-data/saga/defaults/dividend_distribution/v1.0.0.star
+++ b/services/reference-data/saga/defaults/dividend_distribution/v1.0.0.star
@@ -1,0 +1,101 @@
+# Saga: dividend_distribution
+# Version: 1.0.0
+# Previous: none
+# Changed: Initial implementation of org-scoped dividend distribution
+# Author: Platform Team
+# Date: 2026-02-16
+#
+# This Starlark script defines the dividend distribution saga for org-scoped
+# syndicate workflows. It demonstrates how to use party.list_participants,
+# party.get_structuring_data, build_org_account_ref, and resolve_account
+# with composite references to distribute funds across syndicate members.
+#
+# Steps (executed sequentially):
+#   1. list_participants: Retrieve all active syndicate participants
+#   2. For each participant:
+#      a. get_structuring_data: Get allocation share metadata
+#      b. resolve_account: Resolve participant's org-scoped account
+#      c. log_position: Create CREDIT entry in PositionKeeping
+#   3. finalize: Persist distribution metadata
+#
+# Input data (provided via input_data dictionary):
+#   - org_id: string - Syndicate organization party ID
+#   - total_amount: string - Total dividend amount as decimal string
+#   - currency: string - Currency code (e.g., "GBP")
+#   - transaction_id: string - Unique transaction identifier
+
+# Define the dividend distribution saga
+distribution_saga = saga(name="dividend_distribution")
+
+def execute_distribution():
+    # Extract input data
+    org_id = input_data["org_id"]
+    total_amount = Decimal(input_data["total_amount"])
+    currency = input_data["currency"]
+    transaction_id = input_data["transaction_id"]
+
+    # Step 1: List all active syndicate participants
+    step(name="list_participants")
+    participants = party.list_participants(
+        org_id=org_id,
+        relationship_type="RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT",
+    )
+
+    distributions = []
+
+    # Step 2: For each participant, calculate and distribute
+    for participant in participants:
+        party_id = participant["party_id"]
+        metadata = participant["metadata"]
+
+        # Get detailed structuring data if needed
+        step(name="get_structuring_data_" + party_id)
+        structuring = party.get_structuring_data(
+            party_id=party_id,
+            org_id=org_id,
+            relationship_type="RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT",
+        )
+
+        # Calculate participant's share
+        allocation_share = Decimal(str(structuring.get("allocation_share", "0")))
+        participant_amount = total_amount * allocation_share
+
+        # Build composite account reference for org-scoped resolution
+        account_ref = build_org_account_ref(
+            party_id=party_id,
+            org_id=org_id,
+            currency=currency,
+        )
+
+        # Resolve the org-scoped account
+        account_id = resolve_account(reference=account_ref)
+
+        # Log the credit position for this participant
+        step(name="log_position_" + party_id)
+        log_result = position_keeping.initiate_log(
+            position_id=account_id,
+            amount=participant_amount,
+            currency=currency,
+            direction="CREDIT",
+            transaction_id=transaction_id,
+        )
+
+        distributions.append({
+            "party_id": party_id,
+            "account_id": account_id,
+            "amount": str(participant_amount),
+            "log_id": log_result.log_id,
+        })
+
+    # Output the saga result
+    result = {
+        "status": "COMPLETED",
+        "transaction_id": transaction_id,
+        "org_id": org_id,
+        "participant_count": len(distributions),
+        "distributions": distributions,
+    }
+    return result
+
+# Execute the saga
+execute_distribution()

--- a/services/reference-data/saga/defaults/dividend_distribution/v1.0.0.star
+++ b/services/reference-data/saga/defaults/dividend_distribution/v1.0.0.star
@@ -16,7 +16,7 @@
 #      a. get_structuring_data: Get allocation share metadata
 #      b. resolve_account: Resolve participant's org-scoped account
 #      c. log_position: Create CREDIT entry in PositionKeeping
-#   3. finalize: Persist distribution metadata
+#   3. Return distribution result with per-participant details
 #
 # Input data (provided via input_data dictionary):
 #   - org_id: string - Syndicate organization party ID

--- a/services/reference-data/saga/e2e_seeder_test.go
+++ b/services/reference-data/saga/e2e_seeder_test.go
@@ -135,7 +135,7 @@ def posting_rules(ctx):
 			migratedCount++
 		}
 	}
-	assert.Equal(t, 7, migratedCount, "all 7 sagas should be migrated")
+	assert.Equal(t, 8, migratedCount, "all 8 sagas should be migrated")
 
 	// Verify beta's sagas now use platform_ref
 	betaCtx := tenant.WithTenant(ctx, betaID)
@@ -180,7 +180,7 @@ func TestE2E_SeededSagasAreActive(t *testing.T) {
 		count++
 	}
 	require.NoError(t, rows.Err())
-	assert.Equal(t, 7, count, "should have 7 seeded sagas")
+	assert.Equal(t, 8, count, "should have 8 seeded sagas")
 }
 
 // TestE2E_ReseedingDoesNotDuplicate verifies ON CONFLICT idempotency.
@@ -212,13 +212,13 @@ func TestE2E_ReseedingDoesNotDuplicate(t *testing.T) {
 	err = seeder.SeedTenant(ctx, tenantID)
 	require.NoError(t, err)
 
-	// Count should still be exactly 7
+	// Count should still be exactly 8
 	var count int
 	err = pool.QueryRow(ctx,
 		"SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE is_system = true").
 		Scan(&count)
 	require.NoError(t, err)
-	assert.Equal(t, 7, count, "re-seeding should not create duplicates")
+	assert.Equal(t, 8, count, "re-seeding should not create duplicates")
 }
 
 // TestE2E_PlatformRefIntegrityConstraint verifies the CHECK constraint:

--- a/services/reference-data/saga/override_api_test.go
+++ b/services/reference-data/saga/override_api_test.go
@@ -191,7 +191,7 @@ func TestOverrideService_MigrateToPlatformRef(t *testing.T) {
 					"identical scripts should have >= 95%% similarity")
 			}
 		}
-		assert.Equal(t, 7, wouldMigrateCount, "all 7 platform sagas should be candidates")
+		assert.Equal(t, 8, wouldMigrateCount, "all 8 platform sagas should be candidates")
 
 		// Verify nothing actually changed
 		var scriptCount int
@@ -199,7 +199,7 @@ func TestOverrideService_MigrateToPlatformRef(t *testing.T) {
 			"SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE script IS NOT NULL AND script != ''").
 			Scan(&scriptCount)
 		require.NoError(t, err)
-		assert.Equal(t, 7, scriptCount, "dry run should not modify data")
+		assert.Equal(t, 8, scriptCount, "dry run should not modify data")
 	})
 
 	t.Run("apply migration converts to platform refs", func(t *testing.T) {
@@ -212,7 +212,7 @@ func TestOverrideService_MigrateToPlatformRef(t *testing.T) {
 				migratedCount++
 			}
 		}
-		assert.Equal(t, 7, migratedCount, "all 7 platform sagas should be migrated")
+		assert.Equal(t, 8, migratedCount, "all 8 platform sagas should be migrated")
 
 		// Verify scripts are now NULL and platform_ref is set
 		var refCount int
@@ -220,7 +220,7 @@ func TestOverrideService_MigrateToPlatformRef(t *testing.T) {
 			"SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE platform_ref IS NOT NULL AND (script IS NULL OR script = '')").
 			Scan(&refCount)
 		require.NoError(t, err)
-		assert.Equal(t, 7, refCount, "all sagas should now use platform_ref")
+		assert.Equal(t, 8, refCount, "all sagas should now use platform_ref")
 	})
 
 	t.Run("re-running migration skips already-migrated sagas", func(t *testing.T) {

--- a/services/reference-data/saga/seeder_test.go
+++ b/services/reference-data/saga/seeder_test.go
@@ -54,7 +54,7 @@ func TestPlatformDefaults(t *testing.T) {
 	defaults, err := PlatformDefaults()
 	require.NoError(t, err)
 
-	assert.Len(t, defaults, 7)
+	assert.Len(t, defaults, 8)
 
 	// Verify each default has required fields
 	for _, meta := range defaults {
@@ -76,6 +76,7 @@ func TestPlatformDefaults(t *testing.T) {
 	assert.Contains(t, names, "stripe_payment")
 	assert.Contains(t, names, "dunning_escalation")
 	assert.Contains(t, names, "dunning_unfreeze")
+	assert.Contains(t, names, "dividend_distribution")
 }
 
 func TestSeeder_SeedTenant(t *testing.T) {
@@ -105,7 +106,7 @@ func TestSeeder_SeedTenant(t *testing.T) {
 		var count int
 		err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE is_system = true").Scan(&count)
 		require.NoError(t, err)
-		assert.Equal(t, 7, count, "expected 7 system sagas")
+		assert.Equal(t, 8, count, "expected 8 system sagas")
 
 		// Verify each saga has platform_ref and no script
 		rows, err := pool.Query(ctx, `

--- a/shared/pkg/saga/builtins.go
+++ b/shared/pkg/saga/builtins.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"go.starlark.net/starlark"
 )
@@ -30,6 +31,9 @@ var (
 
 	// ErrInvalidParameterType is returned when a parameter has an unexpected type.
 	ErrInvalidParameterType = errors.New("invalid parameter type")
+
+	// ErrEmptyParam is returned when a required parameter is provided but empty.
+	ErrEmptyParam = errors.New("parameter must not be empty")
 )
 
 // NewRestrictedBuiltins creates a hardened Starlark environment with whitelisted functions.
@@ -200,10 +204,20 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 	})
 
 	// resolve_account - resolve account ID from reference
+	// Supports both simple references (e.g., "ACC-001") and composite references
+	// (e.g., "party:<party_id>:org:<org_id>:currency:<code>") for org-scoped account resolution.
+	// Composite references are validated before being passed to the ReferenceDataClient.
 	builtins["resolve_account"] = starlark.NewBuiltin("resolve_account", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var reference string
 		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "reference", &reference); err != nil {
 			return nil, err
+		}
+
+		// Validate composite reference format if it contains colons
+		if strings.Contains(reference, ":") {
+			if _, err := ParseCompositeAccountRef(reference); err != nil {
+				return nil, fmt.Errorf("resolve_account: %w", err)
+			}
 		}
 
 		// Get StarlarkContext from thread
@@ -299,6 +313,34 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 		}
 
 		return starlark.String(instrumentID), nil
+	})
+
+	// build_org_account_ref - build a composite account reference for org-scoped resolution
+	// Returns a properly formatted composite reference string:
+	//   party:<party_id>:org:<org_id>:currency:<currency_code>
+	// This prevents manual string concatenation errors in saga scripts.
+	builtins["build_org_account_ref"] = starlark.NewBuiltin("build_org_account_ref", func(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var partyID, orgID, currency string
+		if err := starlark.UnpackArgs(b.Name(), args, kwargs,
+			"party_id", &partyID,
+			"org_id", &orgID,
+			"currency", &currency,
+		); err != nil {
+			return nil, err
+		}
+
+		if partyID == "" {
+			return nil, fmt.Errorf("build_org_account_ref: %w: party_id", ErrEmptyParam)
+		}
+		if orgID == "" {
+			return nil, fmt.Errorf("build_org_account_ref: %w: org_id", ErrEmptyParam)
+		}
+		if currency == "" {
+			return nil, fmt.Errorf("build_org_account_ref: %w: currency", ErrEmptyParam)
+		}
+
+		ref := BuildCompositeAccountRef(partyID, orgID, currency)
+		return starlark.String(ref), nil
 	})
 
 	// invoke_saga - invoke a child saga

--- a/shared/pkg/saga/builtins_dsl_test.go
+++ b/shared/pkg/saga/builtins_dsl_test.go
@@ -24,6 +24,7 @@ func newMockReferenceDataClient() *mockReferenceDataClient {
 		accounts: map[string]string{
 			"customer-001": "account-123",
 			"customer-002": "account-456",
+			"party:party-123:org:org-456:currency:GBP": "org-account-789",
 		},
 		instruments: map[string]string{
 			"USD": "instr-usd",
@@ -382,5 +383,150 @@ func TestConvertStarlarkToGo(t *testing.T) {
 		// Should only contain the valid key, non-string key is logged and dropped
 		expected := map[string]interface{}{"valid": "value"}
 		assert.Equal(t, expected, result)
+	})
+}
+
+func TestBuildOrgAccountRefBuiltin(t *testing.T) {
+	t.Run("builds valid composite reference", func(t *testing.T) {
+		builtins := NewRestrictedBuiltins(nil)
+		buildRef := builtins["build_org_account_ref"].(*starlark.Builtin)
+
+		thread := &starlark.Thread{Name: "test"}
+		result, err := buildRef.CallInternal(thread, nil, []starlark.Tuple{
+			{starlark.String("party_id"), starlark.String("party-123")},
+			{starlark.String("org_id"), starlark.String("org-456")},
+			{starlark.String("currency"), starlark.String("GBP")},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, `"party:party-123:org:org-456:currency:GBP"`, result.String())
+	})
+
+	t.Run("rejects empty party_id", func(t *testing.T) {
+		builtins := NewRestrictedBuiltins(nil)
+		buildRef := builtins["build_org_account_ref"].(*starlark.Builtin)
+
+		thread := &starlark.Thread{Name: "test"}
+		_, err := buildRef.CallInternal(thread, nil, []starlark.Tuple{
+			{starlark.String("party_id"), starlark.String("")},
+			{starlark.String("org_id"), starlark.String("org-456")},
+			{starlark.String("currency"), starlark.String("GBP")},
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrEmptyParam)
+		assert.Contains(t, err.Error(), "party_id")
+	})
+
+	t.Run("rejects empty org_id", func(t *testing.T) {
+		builtins := NewRestrictedBuiltins(nil)
+		buildRef := builtins["build_org_account_ref"].(*starlark.Builtin)
+
+		thread := &starlark.Thread{Name: "test"}
+		_, err := buildRef.CallInternal(thread, nil, []starlark.Tuple{
+			{starlark.String("party_id"), starlark.String("party-123")},
+			{starlark.String("org_id"), starlark.String("")},
+			{starlark.String("currency"), starlark.String("GBP")},
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrEmptyParam)
+		assert.Contains(t, err.Error(), "org_id")
+	})
+
+	t.Run("rejects empty currency", func(t *testing.T) {
+		builtins := NewRestrictedBuiltins(nil)
+		buildRef := builtins["build_org_account_ref"].(*starlark.Builtin)
+
+		thread := &starlark.Thread{Name: "test"}
+		_, err := buildRef.CallInternal(thread, nil, []starlark.Tuple{
+			{starlark.String("party_id"), starlark.String("party-123")},
+			{starlark.String("org_id"), starlark.String("org-456")},
+			{starlark.String("currency"), starlark.String("")},
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrEmptyParam)
+		assert.Contains(t, err.Error(), "currency")
+	})
+
+	t.Run("missing required parameter", func(t *testing.T) {
+		builtins := NewRestrictedBuiltins(nil)
+		buildRef := builtins["build_org_account_ref"].(*starlark.Builtin)
+
+		thread := &starlark.Thread{Name: "test"}
+		_, err := buildRef.CallInternal(thread, nil, []starlark.Tuple{
+			{starlark.String("party_id"), starlark.String("party-123")},
+		})
+
+		require.Error(t, err)
+	})
+}
+
+func TestResolveAccountBuiltin_CompositeReference(t *testing.T) {
+	t.Run("resolves composite reference", func(t *testing.T) {
+		mockClient := newMockReferenceDataClient()
+		thread := &starlark.Thread{Name: "test"}
+		ctx := &StarlarkContext{
+			Context:     context.Background(),
+			KnowledgeAt: time.Now(),
+			LookupCache: NewLookupResultCache(),
+		}
+		thread.SetLocal("saga.StarlarkContext", ctx)
+		thread.SetLocal("saga.ReferenceDataClient", mockClient)
+
+		builtins := NewRestrictedBuiltins(nil)
+		resolveAccount := builtins["resolve_account"].(*starlark.Builtin)
+
+		// Build a composite reference
+		ref := BuildCompositeAccountRef("party-123", "org-456", "GBP")
+		args := starlark.Tuple{starlark.String(ref)}
+		result, err := resolveAccount.CallInternal(thread, args, nil)
+
+		require.NoError(t, err)
+		// The mock returns based on the reference string
+		assert.NotEmpty(t, result.String())
+	})
+
+	t.Run("rejects malformed composite reference", func(t *testing.T) {
+		thread := &starlark.Thread{Name: "test"}
+		ctx := &StarlarkContext{
+			Context:     context.Background(),
+			KnowledgeAt: time.Now(),
+			LookupCache: NewLookupResultCache(),
+		}
+		thread.SetLocal("saga.StarlarkContext", ctx)
+
+		builtins := NewRestrictedBuiltins(nil)
+		resolveAccount := builtins["resolve_account"].(*starlark.Builtin)
+
+		// Malformed: wrong segment count
+		args := starlark.Tuple{starlark.String("party:123:org:456")}
+		_, err := resolveAccount.CallInternal(thread, args, nil)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrMalformedCompositeRef)
+	})
+
+	t.Run("backward compatible with simple references", func(t *testing.T) {
+		mockClient := newMockReferenceDataClient()
+		thread := &starlark.Thread{Name: "test"}
+		ctx := &StarlarkContext{
+			Context:     context.Background(),
+			KnowledgeAt: time.Now(),
+			LookupCache: NewLookupResultCache(),
+		}
+		thread.SetLocal("saga.StarlarkContext", ctx)
+		thread.SetLocal("saga.ReferenceDataClient", mockClient)
+
+		builtins := NewRestrictedBuiltins(nil)
+		resolveAccount := builtins["resolve_account"].(*starlark.Builtin)
+
+		// Simple reference without colons - should work as before
+		args := starlark.Tuple{starlark.String("customer-001")}
+		result, err := resolveAccount.CallInternal(thread, args, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, `"account-123"`, result.String())
 	})
 }

--- a/shared/pkg/saga/composite_ref.go
+++ b/shared/pkg/saga/composite_ref.go
@@ -1,0 +1,75 @@
+package saga
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// CompositeAccountRef represents a parsed composite account reference
+// in the format: party:<party_id>:org:<org_id>:currency:<code>
+type CompositeAccountRef struct {
+	PartyID  string
+	OrgID    string
+	Currency string
+}
+
+// ErrMalformedCompositeRef is returned when a composite reference has an invalid format.
+var ErrMalformedCompositeRef = errors.New("malformed composite account reference")
+
+// compositeRefSegmentCount is the expected number of segments in a composite reference.
+// Format: party:<party_id>:org:<org_id>:currency:<code> = 6 segments.
+const compositeRefSegmentCount = 6
+
+// BuildCompositeAccountRef constructs a properly formatted composite account reference.
+// Format: party:<party_id>:org:<org_id>:currency:<code>
+func BuildCompositeAccountRef(partyID, orgID, currency string) string {
+	return fmt.Sprintf("party:%s:org:%s:currency:%s", partyID, orgID, currency)
+}
+
+// ParseCompositeAccountRef parses a composite account reference string into its components.
+// Expected format: party:<party_id>:org:<org_id>:currency:<code>
+// Returns ErrMalformedCompositeRef if the format is invalid.
+func ParseCompositeAccountRef(ref string) (*CompositeAccountRef, error) {
+	parts := strings.Split(ref, ":")
+	if len(parts) != compositeRefSegmentCount {
+		return nil, fmt.Errorf("%w: expected %d segments, got %d in %q",
+			ErrMalformedCompositeRef, compositeRefSegmentCount, len(parts), ref)
+	}
+
+	if parts[0] != "party" {
+		return nil, fmt.Errorf("%w: expected segment 1 to be \"party\", got %q", ErrMalformedCompositeRef, parts[0])
+	}
+	if parts[2] != "org" {
+		return nil, fmt.Errorf("%w: expected segment 3 to be \"org\", got %q", ErrMalformedCompositeRef, parts[2])
+	}
+	if parts[4] != "currency" {
+		return nil, fmt.Errorf("%w: expected segment 5 to be \"currency\", got %q", ErrMalformedCompositeRef, parts[4])
+	}
+
+	partyID := parts[1]
+	orgID := parts[3]
+	currency := parts[5]
+
+	if partyID == "" {
+		return nil, fmt.Errorf("%w: party_id must not be empty", ErrMalformedCompositeRef)
+	}
+	if orgID == "" {
+		return nil, fmt.Errorf("%w: org_id must not be empty", ErrMalformedCompositeRef)
+	}
+	if currency == "" {
+		return nil, fmt.Errorf("%w: currency must not be empty", ErrMalformedCompositeRef)
+	}
+
+	return &CompositeAccountRef{
+		PartyID:  partyID,
+		OrgID:    orgID,
+		Currency: currency,
+	}, nil
+}
+
+// IsCompositeAccountRef returns true if the reference contains colons,
+// indicating it may be a composite reference format.
+func IsCompositeAccountRef(ref string) bool {
+	return strings.Contains(ref, ":")
+}

--- a/shared/pkg/saga/composite_ref_test.go
+++ b/shared/pkg/saga/composite_ref_test.go
@@ -1,0 +1,111 @@
+package saga
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCompositeAccountRef(t *testing.T) {
+	ref := BuildCompositeAccountRef("party-123", "org-456", "GBP")
+	assert.Equal(t, "party:party-123:org:org-456:currency:GBP", ref)
+}
+
+func TestBuildCompositeAccountRef_UUIDs(t *testing.T) {
+	ref := BuildCompositeAccountRef(
+		"550e8400-e29b-41d4-a716-446655440000",
+		"6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+		"USD",
+	)
+	assert.Equal(t, "party:550e8400-e29b-41d4-a716-446655440000:org:6ba7b810-9dad-11d1-80b4-00c04fd430c8:currency:USD", ref)
+}
+
+func TestParseCompositeAccountRef_Success(t *testing.T) {
+	ref, err := ParseCompositeAccountRef("party:party-123:org:org-456:currency:GBP")
+	require.NoError(t, err)
+	assert.Equal(t, "party-123", ref.PartyID)
+	assert.Equal(t, "org-456", ref.OrgID)
+	assert.Equal(t, "GBP", ref.Currency)
+}
+
+func TestParseCompositeAccountRef_Roundtrip(t *testing.T) {
+	original := BuildCompositeAccountRef("my-party", "my-org", "EUR")
+	parsed, err := ParseCompositeAccountRef(original)
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-party", parsed.PartyID)
+	assert.Equal(t, "my-org", parsed.OrgID)
+	assert.Equal(t, "EUR", parsed.Currency)
+
+	// Rebuild and verify equality
+	rebuilt := BuildCompositeAccountRef(parsed.PartyID, parsed.OrgID, parsed.Currency)
+	assert.Equal(t, original, rebuilt)
+}
+
+func TestParseCompositeAccountRef_TooFewSegments(t *testing.T) {
+	_, err := ParseCompositeAccountRef("party:123:org:456")
+	assert.ErrorIs(t, err, ErrMalformedCompositeRef)
+	assert.Contains(t, err.Error(), "expected 6 segments, got 4")
+}
+
+func TestParseCompositeAccountRef_TooManySegments(t *testing.T) {
+	_, err := ParseCompositeAccountRef("party:123:org:456:currency:GBP:extra:data")
+	assert.ErrorIs(t, err, ErrMalformedCompositeRef)
+	assert.Contains(t, err.Error(), "expected 6 segments, got 8")
+}
+
+func TestParseCompositeAccountRef_WrongFirstSegment(t *testing.T) {
+	_, err := ParseCompositeAccountRef("account:123:org:456:currency:GBP")
+	assert.ErrorIs(t, err, ErrMalformedCompositeRef)
+	assert.Contains(t, err.Error(), "expected segment 1 to be \"party\"")
+}
+
+func TestParseCompositeAccountRef_WrongThirdSegment(t *testing.T) {
+	_, err := ParseCompositeAccountRef("party:123:tenant:456:currency:GBP")
+	assert.ErrorIs(t, err, ErrMalformedCompositeRef)
+	assert.Contains(t, err.Error(), "expected segment 3 to be \"org\"")
+}
+
+func TestParseCompositeAccountRef_WrongFifthSegment(t *testing.T) {
+	_, err := ParseCompositeAccountRef("party:123:org:456:amount:GBP")
+	assert.ErrorIs(t, err, ErrMalformedCompositeRef)
+	assert.Contains(t, err.Error(), "expected segment 5 to be \"currency\"")
+}
+
+func TestParseCompositeAccountRef_EmptyPartyID(t *testing.T) {
+	_, err := ParseCompositeAccountRef("party::org:456:currency:GBP")
+	assert.ErrorIs(t, err, ErrMalformedCompositeRef)
+	assert.Contains(t, err.Error(), "party_id must not be empty")
+}
+
+func TestParseCompositeAccountRef_EmptyOrgID(t *testing.T) {
+	_, err := ParseCompositeAccountRef("party:123:org::currency:GBP")
+	assert.ErrorIs(t, err, ErrMalformedCompositeRef)
+	assert.Contains(t, err.Error(), "org_id must not be empty")
+}
+
+func TestParseCompositeAccountRef_EmptyCurrency(t *testing.T) {
+	_, err := ParseCompositeAccountRef("party:123:org:456:currency:")
+	assert.ErrorIs(t, err, ErrMalformedCompositeRef)
+	assert.Contains(t, err.Error(), "currency must not be empty")
+}
+
+func TestIsCompositeAccountRef(t *testing.T) {
+	tests := []struct {
+		ref      string
+		expected bool
+	}{
+		{"party:123:org:456:currency:GBP", true},
+		{"ACC-001", false},
+		{"simple-ref", false},
+		{"has:colons", true},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsCompositeAccountRef(tt.ref))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `party.list_participants` and `party.get_structuring_data` Starlark handlers to Party service client with `LookupCache` caching for deterministic saga replay (FR-34)
- Extend `resolve_account` builtin to validate composite reference format (`party:<id>:org:<id>:currency:<code>`) for org-scoped account resolution, with backward compatibility for simple references
- Add `build_org_account_ref` Starlark built-in helper to safely construct composite account references from saga scripts
- Include `dividend_distribution/v1.0.0.star` example saga demonstrating the full org-scoped workflow

## Changes Made

### Party Service Client (`services/party/client/`)
- `client.go`: Add `ListParticipants` and `GetStructuringData` gRPC wrapper methods with timeout, correlation ID, and resilience support
- `starlark.go`: Register `party.list_participants` and `party.get_structuring_data` handlers with cache support, relationship type validation, and helper extraction for lint compliance
- `starlark_test.go`: 19 tests covering success, empty results, missing params, invalid types, gRPC errors, cache hits, and party scope violations

### Saga Package (`shared/pkg/saga/`)
- `composite_ref.go`: `BuildCompositeAccountRef`, `ParseCompositeAccountRef`, `IsCompositeAccountRef` for structured org-scoped account references
- `composite_ref_test.go`: Tests for build, parse (roundtrip, segment count, wrong labels, empty fields), and detection
- `builtins.go`: Extend `resolve_account` with composite reference validation; add `build_org_account_ref` builtin with `ErrEmptyParam` sentinel error
- `builtins_dsl_test.go`: Tests for `build_org_account_ref` (valid, empty fields, missing params) and `resolve_account` composite reference support

### Reference Data (`services/reference-data/saga/defaults/`)
- `dividend_distribution/v1.0.0.star`: Example saga using `party.list_participants`, `party.get_structuring_data`, `build_org_account_ref`, and `resolve_account` for syndicate dividend distribution

## Test Plan

- [x] All 19 party client handler tests pass
- [x] All composite reference tests pass
- [x] All builtin DSL tests pass (build_org_account_ref + resolve_account composite)
- [x] Full project `go build ./...` clean
- [x] golangci-lint passes (err113, gocognit fixed)
- [x] gofumpt formatting verified
- [x] Gitleaks secret scan clean

## Task Master

Tag: `org-scoped-accounts`
Task: `8` - Starlark saga handlers and account resolution
Subtasks: 8.1 (party handlers), 8.2 (composite resolve_account), 8.3 (build_org_account_ref), 8.4 (example saga + tests)