### PR TITLE
fix: configure account validation URLs for position-keeping service

### DIFF
--- a/services/position-keeping/k8s/configmap.yaml
+++ b/services/position-keeping/k8s/configmap.yaml
@@ -24,6 +24,11 @@ data:
   REDIS_ENABLED: "true"
   REDIS_ADDRESS: "redis:6379"
 
+  # Account validation - validates accounts exist before creating position logs
+  ACCOUNT_VALIDATION_ENABLED: "true"
+  CURRENT_ACCOUNT_SERVICE_URL: "current-account:50051"
+  INTERNAL_BANK_ACCOUNT_SERVICE_URL: "internal-bank-account:50057"
+
   # OpenTelemetry configuration
   OTEL_SERVICE_NAME: "position-keeping-service"
   OTEL_SAMPLING_RATE: "0.1"


### PR DESCRIPTION
## Summary

- Position-keeping service crashes on startup with `at least one account service URL is required when account validation is enabled` because `ACCOUNT_VALIDATION_ENABLED` defaults to `true` but the k8s configmap was missing both `CURRENT_ACCOUNT_SERVICE_URL` and `INTERNAL_BANK_ACCOUNT_SERVICE_URL`
- Adds both account service URLs (`current-account:50051`, `internal-bank-account:50057`) to the configmap, matching production behaviour

## Technical Details

- `ACCOUNT_VALIDATION_ENABLED` defaults to `true` in `app/config.go:248`
- Validation at `app/config.go:335` requires at least one URL when enabled
- No circular dependency: position-keeping does not depend on current-account or internal-bank-account at the Tilt level
- gRPC connections are lazy (`grpc.NewClient`), so position-keeping starts regardless of whether account services are ready
- Ports confirmed from `shared/platform/ports/ports.go`: CurrentAccount=50051, InternalBankAccount=50057

## Test plan

- [ ] Position-keeping service starts without the account URL crash
- [ ] InitiateLog RPC validates accounts correctly against both services