### PR TITLE
fix: include saga script assets in current-account container image

### DIFF
--- a/services/current-account/cmd/Dockerfile
+++ b/services/current-account/cmd/Dockerfile
@@ -44,6 +44,10 @@ COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 # Copy binary from builder
 COPY --from=builder /build/current-account /current-account
 
+# Copy saga script assets required at runtime
+COPY --from=builder /build/services/reference-data/saga/defaults/ /saga-assets/services/reference-data/saga/defaults/
+COPY --from=builder /build/shared/pkg/saga/schema/handlers.yaml /saga-assets/shared/pkg/saga/schema/handlers.yaml
+
 # Use non-root user (distroless provides nonroot user at uid 65532)
 USER nonroot:nonroot
 

--- a/services/current-account/k8s/configmap.yaml
+++ b/services/current-account/k8s/configmap.yaml
@@ -36,6 +36,9 @@ data:
   # Maximum retry attempts for failed webhook deliveries
   WEBHOOK_MAX_RETRIES: "3"
 
+  # Saga script assets directory (must match Dockerfile COPY destination)
+  SAGA_ASSET_DIR: "/saga-assets"
+
   # Authentication configuration
   # Set to "true" to require JWT validation on gRPC calls
   AUTH_ENABLED: "false"


### PR DESCRIPTION
## Summary

- Copy saga `.star` defaults and `handlers.yaml` schema into `/saga-assets/` directory in the distroless runtime image
- Set `SAGA_ASSET_DIR=/saga-assets` in the current-account configmap so `loadSagaAsset()` resolves files correctly
- Resolves the startup crash caused by missing saga script files in the container (Task startup-resilience.2)

## Technical Details

The current-account service's `loadSagaAsset()` function reads `.star` scripts and `handlers.yaml` at startup from a path resolved via `SAGA_ASSET_DIR` (or the executable's directory as fallback). The multi-stage Dockerfile only copied the compiled binary to the runtime stage, leaving the saga assets behind in the builder stage. In the distroless container, the binary sits at `/current-account` so the fallback path (`/`) never contains the expected `services/reference-data/saga/defaults/...` tree.

**Changes:**
1. `services/current-account/cmd/Dockerfile` -- Two `COPY --from=builder` instructions bring the saga defaults directory and handlers schema into `/saga-assets/` in the runtime image
2. `services/current-account/k8s/configmap.yaml` -- Added `SAGA_ASSET_DIR: "/saga-assets"` so the service uses the correct base directory

**Files loaded at startup:**
- `services/reference-data/saga/defaults/deposit/v1.0.0.star`
- `services/reference-data/saga/defaults/withdrawal/v1.0.0.star`
- `shared/pkg/saga/schema/handlers.yaml`

## Test plan

- [ ] CI passes (Dockerfile syntax, Go build)
- [ ] Verify container image includes `/saga-assets/` tree (Tilt rebuild in local cluster)
- [ ] current-account pod starts without `failed to load deposit saga script` crash