### PR TITLE
Rewrite README as developer-focused billing engine overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,405 +1,108 @@
 # Meridian
 
-**Trust Your Numbers.** Source-available treasury infrastructure for the modern economy.
+Open-source billing engine with a double-entry ledger.
+Define your pricing and settlement logic in code —
+Meridian handles the bookkeeping, audit trails, and payment collection.
 
-> **Status: Active Development** | Core ledger, audit trails, and saga orchestration implemented.
-> Valuation/settlement integrations are architectural placeholders.
+> **Status**: Active development. Core ledger, saga orchestration, and Stripe Connect
+> integration are implemented. Looking for design partners.
+> [Contact](mailto:ben@meridianhub.org)
 
-## Editions
+## The Problem
 
-Meridian is available in two editions:
+Billing starts as a Stripe checkout and a cron job. Then you need usage metering.
+Then revenue splits. Then your auditor asks for a transaction trail.
+Then estimates need to reconcile with actuals.
+Now you're maintaining a financial system — and you're not a financial company.
 
-| Capability | Meridian Core | Meridian Enterprise |
-| :--- | :---: | :---: |
-| **Double-Entry Ledger** | Yes | Yes |
-| **Multi-Asset Support** (Crypto, Commodities, kWh) | Yes | Yes |
-| **BIAN-Compliant Architecture** | Yes | Yes |
-| **Atomic Audit Trails** | Yes | Yes |
-| **Saga Orchestration** | Yes | Yes |
-| **Valuation** | Static Rates | Dynamic Engine (CEL + Market Data) |
-| **Billing** | Manual API Trigger | Automated Settlement Workers |
-| **Payments** | Log / No-Op | Stripe / Adyen / SWIFT Integration |
-| **Marketplace** | Atomic Swaps | Revenue Splitting and Fan-out |
-| **Tenancy** | Single Schema | Multi-Tenant / Schema-per-Tenant |
+## How It Works
 
-*All current code is Meridian Core. Enterprise features are on the roadmap.*
+You write business logic in [Starlark](https://github.com/google/starlark-go)
+(a deterministic Python subset — no imports, no filesystem, no network).
+Meridian runs it on a double-entry ledger with automatic compensation on failure.
 
-## Mission
-
-When your system accuses someone of a shortfall, you need absolute certainty. Meridian is
-source-available treasury infrastructure designed to prove itself - every position recorded with
-atomic audit trails, every transaction path traceable, every balance verifiable.
-
-### Measure
-
-Every position recorded with atomic audit trails. Parent-child transaction lineage preserved.
-Idempotent operations mean the same request twice produces the same result once. The accused
-can demand proof - and get it.
-
-### Value
-
-Value does not always look like currency anymore. Kilowatt-hours, tonnes of CO₂, commodity
-units - the economy runs on assets that traditional ledgers cannot handle. Multi-asset
-architecture handles diverse units with the same rigour as pounds and euros. Proper
-dimensional typing prevents nonsense calculations at compile time.
-
-### Settle
-
-When settlement fails, it cascades. Livelihoods depend on money arriving when promised,
-not stuck in a partial state that requires manual intervention. Lien-based fund reservation
-ensures availability before commitment. Saga orchestration with automatic compensation -
-if anything fails, the system unwinds cleanly. Settlement completes or reverts.
-
-### Why Trust It
-
-Meridian is infrastructure you actually own. BIAN-compliant architecture means your team speaks
-the same technical language as the world's largest banks. Kubernetes-native, horizontally scalable,
-built for growth. Every deployment builds institutional expertise that stays with you.
-Full sovereignty. Open access. Verify everything.
-
-## Use Cases
-
-Meridian's multi-asset architecture enables transaction integrity across diverse domains:
-
-### Energy Retail
-
-Quality-aware metering with the Time-Bound Quality Ladder. One meter read creates two positions:
-what the customer owes you (revenue at tariff), what you owe the grid (cost at wholesale). GSP
-exposure visible at the moment of consumption, not at month-end. When estimates become actuals,
-the ledger reloads automatically with full bi-temporal audit trail.
-
-### Wealth Management
-
-One event, multiple accounting views. Corporate actions like accumulating dividends adjust cost
-basis without cash movement. Market value and tax basis tracked as separate views on the same
-positions. Bi-temporal queries answer "what was the cost basis on that date?" without reconstruction.
-
-### Edge Computing
-
-The same BIAN-compliant engine that runs in the cloud, running on Pi Zero class hardware.
-In-home displays compute value locally in sub-second response times. 13 months of history on-device.
-When connectivity is flaky, idempotency ensures no double-counting. Only settlement-ready aggregates
-leave the home.
-
-See [meridianhub.org](https://meridianhub.org) for detailed use case documentation.
-
-## What it Demonstrates
-
-- BIAN-compliant service domain architecture
-- Modern microservices patterns for financial systems
-- Double-entry accounting in distributed systems
-- Protocol Buffer-based API design
-- Event-driven architecture with Kafka
-- Kubernetes-native deployment
-- Multi-asset ledger capabilities with dimensional type safety
-  ([ADR-0013](docs/adr/0013-generic-asset-quantity-types.md))
-- Tenant-defined instrument catalogs with CEL validation
-  ([ADR-0014](docs/adr/0014-financial-instrument-reference-data.md))
-- Bi-temporal market data with quality ladder (ESTIMATE < PROVISIONAL < ACTUAL < REVISED)
-- Internal bank accounts for nostro/vostro and operational accounting
-
-## Multi-Asset Capabilities
-
-Meridian's [Quantity\[D\] type system](docs/adr/0013-generic-asset-quantity-types.md) separates
-physics (compile-time dimensional safety) from policy (runtime instrument definitions), enabling
-universal transaction integrity across asset classes.
-
-### Monetary Dimension
-
-| Instrument Type | Example | Valuation Approach |
-|-----------------|---------|---------------------|
-| Currency | USD, EUR, GBP | Identity (implemented) |
-| Debt | Bonds, Loans | Market price × accrued interest |
-| Equity | Shares, Stock | Market price |
-| Derivatives | Options, Futures | Pricing model |
-
-### Commodity Dimension
-
-| Instrument Type | Example | Valuation Approach |
-|-----------------|---------|---------------------|
-| Utility Units | kWh, therms | Rate schedule |
-| Compute Resources | GPU-hours, vCPU-seconds | Spot pricing |
-| Environmental Credits | tCO₂e | Exchange pricing |
-| Physical Goods | kg, units | Market pricing |
-
-*Valuation providers are pluggable. Currency identity is implemented; other valuation
-approaches show the extensibility model. See [ADR-0013](docs/adr/0013-generic-asset-quantity-types.md)
-for the ValuationProvider interface.*
-
-## Features
-
-- Production-grade architecture patterns for financial systems
-- Comprehensive API design with Protocol Buffers
-- Distributed transaction handling and event-driven workflows
-
-## Project Structure
-
-```text
-meridian/
-├── services/                    # Service implementations
-│   ├── current-account/         # CurrentAccount service
-│   │   ├── cmd/                 # Entry point and Dockerfile
-│   │   ├── domain/              # Business logic and entities
-│   │   ├── adapters/            # Persistence, messaging adapters
-│   │   ├── service/             # gRPC service implementation
-│   │   ├── client/              # Service-owned gRPC client
-│   │   ├── atlas/               # Atlas schema config
-│   │   ├── migrations/          # Database migrations
-│   │   └── k8s/                 # Kubernetes manifests
-│   ├── financial-accounting/    # FinancialAccounting service
-│   ├── gateway/                 # Gateway service
-│   ├── internal-bank-account/   # InternalBankAccount service
-│   ├── market-information/      # MarketInformation service
-│   ├── party/                   # Party service
-│   ├── payment-order/           # PaymentOrder service
-│   ├── position-keeping/        # PositionKeeping service
-│   ├── reference-data/          # ReferenceData service
-│   ├── reconciliation/          # Account Reconciliation service
-│   ├── tenant/                  # Tenant service
-│   ├── control-plane/           # SaaS control plane
-│   ├── forecasting/             # Forecasting service
-│   ├── audit-worker/            # Audit log processor
-│   └── utilization-metering-consumer/  # Usage metering
-├── shared/                      # Cross-service shared code
-│   ├── platform/                # Infrastructure (auth, db, kafka, observability)
-│   ├── domain/                  # Shared domain models and primitives
-│   └── pkg/                     # Shared utilities (health, idempotency, clients)
-├── cmd/                         # CLI tools
-│   └── tenantctl/               # Tenant management CLI
-├── utilities/                   # Development utilities
-│   ├── atlas-loader/            # Migration schema loader
-│   └── horizon-demo/            # Demo utility
-├── api/proto/                   # Protocol Buffer API definitions
-├── deployments/k8s/             # Shared Kubernetes resources
-└── docs/                        # Documentation and ADRs
+```python
+def charge_subscription(ctx):
+    account = resolve_account(party_id=ctx.customer_id, org_id=ctx.org_id, currency="GBP")
+    post(account, ctx.amount, "DEBIT")
+    record_receivable(account, ctx.amount, due_date=ctx.billing_date)
 ```
 
-## BIAN Service Domains
+When you need more — revenue splits, usage metering, multi-party settlement — the same engine handles it:
 
-This implementation includes the following BIAN service domains:
+```python
+def distribute_revenue(ctx):
+    for p in party.list_participants(ctx.org_id):
+        share = party.get_structuring_data(p.id, ctx.org_id)["allocation_share"]
+        account = resolve_account(party_id=p.id, org_id=ctx.org_id, currency="GBP")
+        post(account, ctx.amount * Decimal(share), "CREDIT")
+```
 
-| Service | BIAN Domain | Purpose | Standalone | BIAN Spec |
-|---------|-------------|---------|:----------:|-----------|
-| [**CurrentAccount**][svc-ca] | Current Account | Customer-facing account management and transaction orchestration | No | [OAS3][bian-ca] |
-| [**FinancialAccounting**][svc-fa] | Financial Standard Management | Double-entry bookkeeping and general ledger | Yes | [OAS3][bian-fa] |
-| [**InternalBankAccount**][svc-iba] | Internal Bank Account | Nostro/vostro, clearing, and operational accounts | Yes | [OAS3][bian-iba] |
-| [**MarketInformation**][svc-mi] | Market Information Management | Bi-temporal market data with quality ladder | Yes | [OAS3][bian-mi] |
-| [**Party**][svc-party] | Party Reference Data Directory | Customer and party reference data management | Yes | [OAS3][bian-party] |
-| [**PaymentOrder**][svc-po] | Payment Order | Payment initiation, saga orchestration, and settlement | No | [OAS3][bian-po] |
-| [**PositionKeeping**][svc-pk] | Position Keeping | Pre-ledger transaction log and position tracking | Yes | [OAS3][bian-pk] |
-| [**Reconciliation**][svc-recon] | Account Reconciliation | Settlement lifecycle, variance detection, and dispute management | Yes | [OAS3][bian-recon] |
-| [**ReferenceData**][svc-rd] | Financial Instrument Reference Data Management | Tenant-defined instrument catalog with CEL validation | Yes | [OAS3][bian-rd] |
+Validation and pricing rules use [CEL](https://cel.dev/) expressions:
 
-Each service domain follows BIAN's control record pattern with behavior qualifiers for operations.
-Services marked as "Standalone" can operate independently; others require upstream dependencies.
+```cel
+// Enforce daily spending limit
+transaction.amount <= account.daily_limit - account.daily_spent
 
-Reference specifications: [BIAN Service Landscape 13.0.0](https://github.com/bian-official/public/tree/main/release13.0.0)
+// Time-of-use pricing
+rate_schedule.lookup(timestamp.hour) * quantity
+```
 
-[bian-ca]: https://github.com/bian-official/public/blob/main/release13.0.0/semantic-apis/oas3/yamls/CurrentAccount.yaml
-[bian-fa]: https://github.com/bian-official/public/blob/main/release13.0.0/semantic-apis/oas3/yamls/FinancialAccounting.yaml
-[bian-iba]: https://github.com/bian-official/public/blob/main/release13.0.0/semantic-apis/oas3/yamls/InternalBankAccount.yaml
-[bian-mi]: https://github.com/bian-official/public/blob/main/release13.0.0/semantic-apis/oas3/yamls/MarketInformationManagement.yaml
-[bian-party]: https://github.com/bian-official/public/blob/main/release13.0.0/semantic-apis/oas3/yamls/PartyReferenceDataDirectory.yaml
-[bian-po]: https://github.com/bian-official/public/blob/main/release13.0.0/semantic-apis/oas3/yamls/PaymentOrder.yaml
-[bian-pk]: https://github.com/bian-official/public/blob/main/release13.0.0/semantic-apis/oas3/yamls/PositionKeeping.yaml
-[bian-rd]: https://github.com/bian-official/public/blob/main/release13.0.0/semantic-apis/oas3/yamls/FinancialInstrumentReferenceDataManagement.yaml
-[svc-ca]: services/current-account/
-[svc-fa]: services/financial-accounting/
-[svc-iba]: services/internal-bank-account/
-[svc-mi]: services/market-information/
-[svc-party]: services/party/
-[svc-po]: services/payment-order/
-[svc-pk]: services/position-keeping/
-[bian-recon]: https://github.com/bian-official/public/blob/main/release13.0.0/semantic-apis/oas3/yamls/AccountReconciliation.yaml
-[svc-recon]: services/reconciliation/
-[svc-rd]: services/reference-data/
-[svc-tenant]: services/tenant/
-[svc-cp]: services/control-plane/
-[svc-forecasting]: services/forecasting/
+## What's Built
 
-### Infrastructure Services
-
-| Service | Purpose |
-|---------|---------|
-| [**Tenant**][svc-tenant] | Multi-tenant platform management with schema-per-tenant isolation |
-| [**ControlPlane**][svc-cp] | SaaS operations layer for manifest management and Stripe billing |
-| [**Forecasting**][svc-forecasting] | Forward curve computation and scheduled forecast execution |
-| **Gateway** | API gateway for external access |
-| **audit-worker** | Processes audit log outbox entries |
-| **utilization-metering-consumer** | Usage metering for billing |
-
-These services are not part of the BIAN standard but provide platform infrastructure.
-
-## Technology Stack
-
-- **Language**: Go 1.26+
-- **API Protocol**: Protocol Buffers 3 + gRPC
-- **API Tooling**: buf CLI for linting and code generation
-- **Database**: CockroachDB or YugabyteDB (distributed SQL)
-- **Event Streaming**: Apache Kafka 3.x (3-broker cluster with KRaft)
-- **Cache**: Redis 7.x
-- **Container Orchestration**: Kubernetes 1.28+
-- **Local Development**: Kind + ctlptl + Tilt for fast local Kubernetes workflows
-- **Observability**: OpenTelemetry, Prometheus, Grafana
-
-## System Requirements
-
-**Minimum**: 12GB RAM (may experience swap with other applications running)
-**Recommended**: 16GB RAM (comfortable development with IDE, browser, etc.)
-
-**Resource Breakdown**:
-
-- Kubernetes (Kind): ~1GB
-- CockroachDB: ~1-2GB
-- Kafka cluster (3 brokers): ~1.5GB
-- Redis: ~128MB
-- Meridian service: ~256MB
-- OS overhead: ~2GB
-
-**For 8GB RAM machines**: See [Resource-Constrained Development](docs/skills/tilt.md#resource-constrained-development)
-for single-broker Kafka configuration.
+- **Double-entry ledger** with immutable, bi-temporal audit trail
+- **Saga orchestration** with automatic compensation — settlement completes or reverts
+- **Stripe Connect** integration for multi-tenant payment collection
+- **Multi-asset support** — currency, kWh, carbon credits, compute hours
+- **Reconciliation** — variance detection between expected and actual
+- **Usage metering** — ingest events, apply pricing rules, produce invoices
+- **Identity verification** — pluggable providers (Onfido, mock for development)
+- **Multi-tenant** — org-scoped accounts with data isolation
 
 ## Quick Start
 
-**Prerequisites**: Go 1.26+, Docker, kubectl, kind, tilt ([see detailed
-setup](CONTRIBUTING.md#development-environment-setup))
+**Prerequisites**: Go 1.26+, Docker, kubectl, kind, tilt
 
 ```bash
-
-# 1. Clone and install dependencies
-
 git clone git@github.com:meridianhub/meridian.git
 cd meridian
 go mod download
-./setup-hooks.sh
-
-# 2. Setup local development secrets
-
-./scripts/setup-local-secrets.sh
-
-# 3. Create local Kubernetes cluster (Docker must be running)
 
 ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
-
-# 4. Start development environment
-
 tilt up
 ```
 
-**Access services**:
-
 - Tilt UI: <http://localhost:10350>
-- Meridian API: <http://localhost:8080>
-- Meridian gRPC: localhost:9090
+- API: <http://localhost:8080>
+- gRPC: localhost:9090
 
-For detailed development instructions, see [CONTRIBUTING.md](CONTRIBUTING.md).
-
-## Development
-
-**Common commands**:
-
-```bash
-make proto         # Generate protobuf code
-make build         # Build the project
-make test          # Run tests
-make lint          # Run linters
-```
-
-**Local development**: Use `tilt up` for hot-reload Kubernetes development ([Tilt guide](docs/skills/tilt.md))
-
-**Working with protobuf**: See [api/proto/README.md](api/proto/README.md) and [Schema Evolution
-skill](docs/skills/schema-evolution.md)
+See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed setup and development workflow.
 
 ## Architecture
 
-**Key architectural decisions** are documented in [docs/adr/](docs/adr/) including:
+Built on [BIAN](https://bian.org/) banking service domain patterns.
 
-- Microservices per BIAN domain
-- Database schema migrations with Atlas
-- Event schema evolution with protobuf
-- Adapter pattern for layer translation
-- Local development with Tilt
-- Standard service directory structure
-- [Universal Quantity Type System](docs/adr/0013-generic-asset-quantity-types.md) - Dimensional type
-  safety for multi-asset ledger
-- [Financial Instrument Reference Data](docs/adr/0014-financial-instrument-reference-data.md) -
-  Tenant-defined instrument catalog with CEL validation
+| Service | Purpose |
+|---------|---------|
+| **CurrentAccount** | Customer accounts, transaction orchestration |
+| **PositionKeeping** | Pre-ledger transaction log, position tracking |
+| **FinancialAccounting** | Double-entry bookkeeping |
+| **PaymentOrder** | Saga orchestration, settlement, Stripe integration |
+| **MarketInformation** | Pricing data with quality ladder (estimate / actual / verified) |
+| **Party** | Customer data, identity verification |
+| **Reconciliation** | Variance detection, dispute management |
+| **ControlPlane** | Tenant management, billing configuration |
 
-**Architecture diagrams:**
+See [docs/adr/](docs/adr/) for architectural decisions.
 
-- [Service API Interfaces](api/proto/README.md#service-architecture) - gRPC methods and service dependencies
-- [Runtime Architecture](services/README.md) - All protocols (gRPC, Kafka, HTTP, Database, Redis)
+## Technology
 
-See [docs/adr/README.md](docs/adr/README.md) for the complete catalog.
-
-## API Documentation
-
-Protocol Buffer definitions for all services are in [api/proto/](api/proto/).
-
-**Key APIs**:
-
-- Common types: Quantity[D], Money, AccountType, Currency, Pagination
-- Financial instruments: Dimensional type system with runtime instrument definitions
-- Error codes: Categorized by domain (general, financial, BIAN-specific)
-- Health checks: Standard health service for all components
-
-See [api/proto/README.md](api/proto/README.md) for detailed API documentation.
-
-## Troubleshooting
-
-For setup and development issues, see:
-
-- [CONTRIBUTING.md](CONTRIBUTING.md) - Development setup troubleshooting
-- [docs/skills/docker.md](docs/skills/docker.md) - Docker configuration
-- [docs/skills/tilt.md](docs/skills/tilt.md) - Tilt and Kubernetes issues
-- [docs/runbooks/](docs/runbooks/) - Operational procedures
-
-## Contributing
-
-Contributions welcome! We value collaboration and view questions and feedback as opportunities for continuous improvement.
-
-**Quick start**:
-
-1. Fork and create a feature branch
-2. Make changes following [code standards](CONTRIBUTING.md#code-standards)
-3. Run `make test` and `make lint`
-4. Create a Pull Request
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines on:
-
-- Development environment setup
-- Code standards (immutability, TDD, defensive testing)
-- Pull request process
-- Architecture decision records
-
-## Learning Resources
-
-**BIAN Standards**:
-
-- [BIAN Service Landscape](https://bian.org/servicelandscape/) - Banking service domain architecture
-- [BIAN Semantic APIs](https://bian.org/semantic-apis/) - API design standards
-
-**Technologies**:
-
-- [Protocol Buffers](https://protobuf.dev/) & [buf CLI](https://buf.build/docs/)
-- [gRPC](https://grpc.io/) - API framework
-- [CockroachDB](https://www.cockroachlabs.com/docs/) - Distributed SQL database
-- [Apache Kafka](https://kafka.apache.org/documentation/) - Event streaming
+Go | Protocol Buffers + gRPC | CockroachDB | Apache Kafka | Kubernetes | Stripe Connect
 
 ## License
 
-Business Source License 1.1 - See [LICENSE](LICENSE) file for details.
+Business Source License 1.1 — See [LICENSE](LICENSE).
 
-**What this means:**
-
-- You can read, use, and modify the code for development and internal use
-- You cannot offer a commercial Billing, Ledger, or Treasury-as-a-Service that competes with Meridian Hub
-- On January 14, 2030, this version automatically converts to Apache License 2.0
-
-This is the same licensing model used by CockroachDB, MariaDB, and HashiCorp.
-
-## Disclaimer
-
-This software is provided "as-is" under the Business Source License 1.1. Before deploying in production environments,
-ensure thorough security audits, compliance verification, and testing appropriate for your regulatory requirements
-and risk profile.
+- Use, modify, and deploy for any internal purpose
+- Cannot offer a competing Billing/Treasury-as-a-Service
+- Converts to Apache 2.0 on February 12, 2030

--- a/README.md
+++ b/README.md
@@ -22,20 +22,59 @@ You write business logic in [Starlark](https://github.com/google/starlark-go)
 Meridian runs it on a double-entry ledger with automatic compensation on failure.
 
 ```python
-def charge_subscription(ctx):
-    account = resolve_account(party_id=ctx.customer_id, org_id=ctx.org_id, currency="GBP")
-    post(account, ctx.amount, "DEBIT")
-    record_receivable(account, ctx.amount, due_date=ctx.billing_date)
+deposit_saga = saga(name="current_account_deposit")
+
+def execute_deposit():
+    amount = Decimal(input_data["amount"])
+    account_id = input_data["account_id"]
+
+    step(name="log_position")
+    position_keeping.initiate_log(
+        position_id=account_id,
+        amount=amount,
+        currency=input_data["currency"],
+        direction="CREDIT",
+        transaction_id=input_data["transaction_id"],
+    )
+
+    step(name="post_to_ledger")
+    financial_accounting.capture_posting(
+        account_id=account_id,
+        amount=amount,
+        currency=input_data["currency"],
+        direction="CREDIT",
+        transaction_id=input_data["transaction_id"],
+    )
+
+execute_deposit()
 ```
 
-When you need more — revenue splits, usage metering, multi-party settlement — the same engine handles it:
+When you need revenue splits across participants, the same engine handles it:
 
 ```python
-def distribute_revenue(ctx):
-    for p in party.list_participants(ctx.org_id):
-        share = party.get_structuring_data(p.id, ctx.org_id)["allocation_share"]
-        account = resolve_account(party_id=p.id, org_id=ctx.org_id, currency="GBP")
-        post(account, ctx.amount * Decimal(share), "CREDIT")
+def execute_distribution():
+    total = Decimal(input_data["total_amount"])
+
+    step(name="list_participants")
+    participants = party.list_participants(org_id=input_data["org_id"])
+
+    for p in participants:
+        share = Decimal(str(p["metadata"]["allocation_share"]))
+        account_ref = build_org_account_ref(
+            party_id=p["party_id"],
+            org_id=input_data["org_id"],
+            currency="GBP",
+        )
+        account_id = resolve_account(reference=account_ref)
+
+        step(name="credit_" + p["party_id"])
+        position_keeping.initiate_log(
+            position_id=account_id,
+            amount=total * share,
+            currency="GBP",
+            direction="CREDIT",
+            transaction_id=input_data["transaction_id"],
+        )
 ```
 
 Validation and pricing rules use [CEL](https://cel.dev/) expressions:


### PR DESCRIPTION
## Summary

- Repositions Meridian from "treasury infrastructure" to "billing engine" framing
- Cuts ~400 lines to ~100, focused on what's built and how to use it
- Adds honest stage signal ("Active development. Looking for design partners.")
- Corrects license date to February 12, 2030 (was January 14)
- Fixes KYC description to "pluggable providers (Onfido, mock for development)"
- Drops BSL comparison companies line (CockroachDB moved away from BSL, HashiCorp acquired)
- Code examples lead with simple (charge_subscription) then complex (distribute_revenue)

## Context

Informed by two go-to-market conversations: one with a startup founder on validation
strategy, one with a GTM advisor who recommended "boil to one sentence" and "less is more."
Previous pitch to an energy company ops manager failed because he didn't understand what
the product does. This rewrite prioritises clarity over completeness.

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm all links resolve (CONTRIBUTING.md, docs/adr/, LICENSE, Starlark, CEL)