### PR TITLE
Add per-service Swagger UI for manual API testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,8 @@ __debug_bin
 *_grpc.pb.go
 
 # Generated OpenAPI specs (regenerate with buf generate)
-api/openapi/
+api/openapi/*
+!api/openapi/swagger-ui.html
 __pycache__/
 # Add current-account binary to .gitignore (use leading / to avoid matching directories)
 /current-account

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GOMOD=$(GOCMD) mod
 GOGET=$(GOCMD) get
 GOFMT=$(GOCMD) fmt
 
-.PHONY: all help build test lint clean proto proto-v1 proto-v2 proto-openapi proto-lint proto-breaking docker deploy-local fmt tidy deps coverage install proto-validate proto-deps-update proto-deps-graph proto-plugins-info validate-tilt validate-semconv validate-sagas proto-jsonschema validate-manifest-jsonschema validate-manifests control-plane-ci test-control-plane migrate-diff-all migrate-diff-current migrate-diff-position migrate-apply-all migrate-status-all migrate-lint-all migrate-hash-all migrate-apply-orgs migrate-status-orgs docs generate-saga-docs
+.PHONY: all help build test lint clean proto proto-v1 proto-v2 proto-openapi proto-lint proto-breaking docker deploy-local fmt tidy deps coverage install proto-validate proto-deps-update proto-deps-graph proto-plugins-info validate-tilt validate-semconv validate-sagas proto-jsonschema validate-manifest-jsonschema validate-manifests control-plane-ci test-control-plane migrate-diff-all migrate-diff-current migrate-diff-position migrate-apply-all migrate-status-all migrate-lint-all migrate-hash-all migrate-apply-orgs migrate-status-orgs docs generate-saga-docs swagger-split swagger-ui
 
 # Default target
 all: help
@@ -81,6 +81,10 @@ help:
 	@echo ""
 	@echo "Documentation targets:"
 	@echo "  make generate-saga-docs        - Generate Markdown and JSON Schema docs for saga handlers"
+	@echo ""
+	@echo "API Explorer targets:"
+	@echo "  make swagger-split             - Split monolithic swagger into per-service files"
+	@echo "  make swagger-ui                - Start local Swagger UI server (requires Tilt running)"
 	@echo ""
 	@echo "Variables:"
 	@echo "  VERSION=$(VERSION)"
@@ -217,6 +221,7 @@ swagger-split:
 
 ## swagger-ui: Serve Swagger UI for interactive API exploration
 swagger-ui: swagger-split
+	@command -v python3 >/dev/null || { echo "Error: python3 is required for the HTTP server"; exit 1; }
 	@echo ""
 	@echo "Meridian API Explorer"
 	@echo "  Open: http://localhost:8091/swagger-ui.html"

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,22 @@ proto-openapi: proto
 		echo "Note: Run 'make proto' first to generate the spec"; \
 	fi
 
+## swagger-split: Split monolithic swagger into per-service files
+swagger-split:
+	@./scripts/split-swagger.sh
+
+## swagger-ui: Serve Swagger UI for interactive API exploration
+swagger-ui: swagger-split
+	@echo ""
+	@echo "Meridian API Explorer"
+	@echo "  Open: http://localhost:8091/swagger-ui.html"
+	@echo "  Gateway: http://localhost:8090"
+	@echo ""
+	@echo "  Use the dropdown to switch between services."
+	@echo "  Press Ctrl+C to stop."
+	@echo ""
+	@cd api/openapi && python3 -m http.server 8091
+
 ## proto-validate: Validate protobuf directory structure and versions
 proto-validate:
 	@echo "Validating protobuf directory structure..."

--- a/api/openapi/swagger-ui.html
+++ b/api/openapi/swagger-ui.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Meridian API Explorer</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    .topbar {
+      background: #1a1a2e;
+      padding: 12px 24px;
+      display: flex;
+      align-items: center;
+      gap: 20px;
+      flex-wrap: wrap;
+    }
+    .topbar h1 {
+      color: #e0e0e0;
+      font-family: system-ui, sans-serif;
+      font-size: 18px;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+    .topbar select {
+      padding: 8px 12px;
+      border-radius: 6px;
+      border: 1px solid #444;
+      background: #2a2a3e;
+      color: #e0e0e0;
+      font-size: 14px;
+      font-family: system-ui, sans-serif;
+      min-width: 260px;
+      cursor: pointer;
+    }
+    .topbar select:focus { outline: 2px solid #6c63ff; }
+    .topbar .meta {
+      color: #888;
+      font-family: monospace;
+      font-size: 13px;
+      margin-left: auto;
+    }
+    .topbar .meta span { color: #6c63ff; }
+
+    #swagger-ui { padding: 0; }
+
+    /* Override swagger-ui topbar */
+    .swagger-ui .topbar { display: none; }
+  </style>
+</head>
+<body>
+  <div class="topbar">
+    <h1>Meridian API Explorer</h1>
+    <select id="service-select">
+      <option value="meridian.swagger.json">All Services (132 endpoints)</option>
+    </select>
+    <div class="meta">
+      Gateway: <span id="gateway-url">http://localhost:8090</span>
+    </div>
+  </div>
+  <div id="swagger-ui"></div>
+
+  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script>
+    const GATEWAY_URL = 'http://localhost:8090';
+
+    // Load catalog and populate dropdown
+    async function loadCatalog() {
+      const select = document.getElementById('service-select');
+      try {
+        const resp = await fetch('services/catalog.json');
+        const catalog = await resp.json();
+        catalog.forEach(svc => {
+          const opt = document.createElement('option');
+          opt.value = `services/${svc.file}`;
+          // Format: "Current Account (12 endpoints)"
+          const label = svc.name.replace(/Service$/, '').replace(/([A-Z])/g, ' $1').trim();
+          opt.textContent = `${label} (${svc.endpoints} endpoints)`;
+          select.appendChild(opt);
+        });
+      } catch (e) {
+        console.warn('No catalog.json found. Run: make swagger-split');
+      }
+    }
+
+    // Initialize Swagger UI
+    function loadSwagger(specUrl) {
+      SwaggerUIBundle({
+        url: specUrl,
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIBundle.SwaggerUIStandalonePreset
+        ],
+        layout: 'BaseLayout',
+        defaultModelsExpandDepth: 0,
+        docExpansion: 'list',
+        filter: true,
+        requestInterceptor: (req) => {
+          // Rewrite requests to go through the local gateway
+          if (req.url && !req.url.startsWith('http')) {
+            req.url = GATEWAY_URL + req.url;
+          }
+          // If request goes to a swagger spec host, redirect to gateway
+          const url = new URL(req.url);
+          if (url.port !== '8090' && !req.url.includes('swagger')) {
+            url.host = 'localhost:8090';
+            url.protocol = 'http:';
+            req.url = url.toString();
+          }
+          return req;
+        }
+      });
+    }
+
+    // Wire up service selector
+    document.getElementById('service-select').addEventListener('change', (e) => {
+      loadSwagger(e.target.value);
+    });
+
+    // Boot
+    loadCatalog();
+    loadSwagger('meridian.swagger.json');
+  </script>
+</body>
+</html>

--- a/api/openapi/swagger-ui.html
+++ b/api/openapi/swagger-ui.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Meridian API Explorer</title>
-  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.18.2/swagger-ui.css">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -61,7 +61,7 @@
   </div>
   <div id="swagger-ui"></div>
 
-  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script src="https://unpkg.com/swagger-ui-dist@5.18.2/swagger-ui-bundle.js"></script>
   <script>
     const GATEWAY_URL = 'http://localhost:8090';
 
@@ -70,6 +70,10 @@
       const select = document.getElementById('service-select');
       try {
         const resp = await fetch('services/catalog.json');
+        if (!resp.ok) {
+          console.warn(`Catalog fetch failed (${resp.status}). Run: make swagger-split`);
+          return;
+        }
         const catalog = await resp.json();
         catalog.forEach(svc => {
           const opt = document.createElement('option');
@@ -80,7 +84,7 @@
           select.appendChild(opt);
         });
       } catch (e) {
-        console.warn('No catalog.json found. Run: make swagger-split');
+        console.warn('Failed to load catalog.json. Run: make swagger-split');
       }
     }
 
@@ -103,12 +107,14 @@
           if (req.url && !req.url.startsWith('http')) {
             req.url = GATEWAY_URL + req.url;
           }
-          // If request goes to a swagger spec host, redirect to gateway
-          const url = new URL(req.url);
-          if (url.port !== '8090' && !req.url.includes('swagger')) {
-            url.host = 'localhost:8090';
-            url.protocol = 'http:';
-            req.url = url.toString();
+          // Redirect API calls (not swagger spec fetches) to the local gateway
+          if (!req.url.includes('swagger') && !req.url.includes(':8091')) {
+            const url = new URL(req.url);
+            if (url.host !== 'localhost:8090') {
+              url.host = 'localhost:8090';
+              url.protocol = 'http:';
+              req.url = url.toString();
+            }
           }
           return req;
         }

--- a/scripts/split-swagger.sh
+++ b/scripts/split-swagger.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# split-swagger.sh - Split monolithic swagger into per-service files
+#
+# Usage: ./scripts/split-swagger.sh [input-file] [output-dir]
+#
+# Generates one swagger JSON per service tag, plus a catalog.json
+# index file for the Swagger UI service picker.
+
+set -euo pipefail
+
+INPUT="${1:-api/openapi/meridian.swagger.json}"
+OUTPUT_DIR="${2:-api/openapi/services}"
+
+if [ ! -f "$INPUT" ]; then
+  echo "Error: $INPUT not found. Run 'make proto' first." >&2
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq is required. Install with: brew install jq" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+# Extract all service tags
+TAGS=$(jq -r '.tags[].name' "$INPUT")
+
+# Convert CamelCase tag to kebab-case filename
+# CurrentAccountService -> current-account
+to_filename() {
+  echo "$1" \
+    | sed 's/Service$//' \
+    | sed 's/\([A-Z]\)/-\1/g' \
+    | sed 's/^-//' \
+    | tr '[:upper:]' '[:lower:]'
+}
+
+# Build catalog entries
+CATALOG="["
+FIRST=true
+
+for TAG in $TAGS; do
+  FILENAME=$(to_filename "$TAG")
+
+  # Split: keep global metadata, filter paths by tag, include all definitions
+  jq --arg tag "$TAG" --arg filename "$FILENAME" '{
+    swagger: .swagger,
+    info: {
+      title: ($tag | gsub("(?<a>[A-Z])"; " \(.a)") | ltrimstr(" ")),
+      description: .info.description,
+      version: .info.version,
+      contact: .info.contact,
+      license: .info.license
+    },
+    tags: [.tags[] | select(.name == $tag)],
+    schemes: .schemes,
+    consumes: .consumes,
+    produces: .produces,
+    paths: (
+      .paths | to_entries | map(
+        select(
+          .value | to_entries | any(
+            .value.tags // [] | index($tag)
+          )
+        )
+      ) | from_entries
+    ),
+    definitions: .definitions
+  }' "$INPUT" > "$OUTPUT_DIR/$FILENAME.swagger.json"
+
+  # Count endpoints in this service
+  COUNT=$(jq '.paths | [to_entries[].value | keys[]] | length' "$OUTPUT_DIR/$FILENAME.swagger.json")
+
+  if [ "$FIRST" = true ]; then
+    FIRST=false
+  else
+    CATALOG="$CATALOG,"
+  fi
+  CATALOG="$CATALOG{\"name\":\"$TAG\",\"file\":\"$FILENAME.swagger.json\",\"endpoints\":$COUNT}"
+
+  echo "  $FILENAME.swagger.json ($COUNT endpoints)"
+done
+
+CATALOG="$CATALOG]"
+echo "$CATALOG" | jq '.' > "$OUTPUT_DIR/catalog.json"
+
+TOTAL=$(echo "$CATALOG" | jq 'length')
+echo ""
+echo "Split into $TOTAL service files in $OUTPUT_DIR/"
+echo "Catalog written to $OUTPUT_DIR/catalog.json"

--- a/scripts/split-swagger.sh
+++ b/scripts/split-swagger.sh
@@ -17,7 +17,7 @@ if [ ! -f "$INPUT" ]; then
 fi
 
 if ! command -v jq &>/dev/null; then
-  echo "Error: jq is required. Install with: brew install jq" >&2
+  echo "Error: jq is required. Install with your package manager (e.g. brew install jq, apt install jq)." >&2
   exit 1
 fi
 
@@ -36,11 +36,11 @@ to_filename() {
     | tr '[:upper:]' '[:lower:]'
 }
 
-# Build catalog entries
-CATALOG="["
-FIRST=true
+# Initialize empty catalog
+echo '[]' > "$OUTPUT_DIR/catalog.json"
 
-for TAG in $TAGS; do
+printf '%s\n' "$TAGS" | while IFS= read -r TAG; do
+  [ -z "$TAG" ] && continue
   FILENAME=$(to_filename "$TAG")
 
   # Split: keep global metadata, filter paths by tag, include all definitions
@@ -69,23 +69,17 @@ for TAG in $TAGS; do
     definitions: .definitions
   }' "$INPUT" > "$OUTPUT_DIR/$FILENAME.swagger.json"
 
-  # Count endpoints in this service
+  # Count endpoints and append to catalog using jq
   COUNT=$(jq '.paths | [to_entries[].value | keys[]] | length' "$OUTPUT_DIR/$FILENAME.swagger.json")
 
-  if [ "$FIRST" = true ]; then
-    FIRST=false
-  else
-    CATALOG="$CATALOG,"
-  fi
-  CATALOG="$CATALOG{\"name\":\"$TAG\",\"file\":\"$FILENAME.swagger.json\",\"endpoints\":$COUNT}"
+  jq --arg name "$TAG" --arg file "$FILENAME.swagger.json" --argjson count "$COUNT" \
+    '. += [{"name": $name, "file": $file, "endpoints": $count}]' \
+    "$OUTPUT_DIR/catalog.json" > "$OUTPUT_DIR/catalog.tmp" && mv "$OUTPUT_DIR/catalog.tmp" "$OUTPUT_DIR/catalog.json"
 
   echo "  $FILENAME.swagger.json ($COUNT endpoints)"
 done
 
-CATALOG="$CATALOG]"
-echo "$CATALOG" | jq '.' > "$OUTPUT_DIR/catalog.json"
-
-TOTAL=$(echo "$CATALOG" | jq 'length')
+TOTAL=$(jq 'length' "$OUTPUT_DIR/catalog.json")
 echo ""
 echo "Split into $TOTAL service files in $OUTPUT_DIR/"
 echo "Catalog written to $OUTPUT_DIR/catalog.json"


### PR DESCRIPTION
## Summary

- Split the monolithic 580KB swagger spec into 19 per-service files for focused API exploration
- Add a standalone Swagger UI page with service dropdown, pointed at the local gateway on `:8090`
- Add `make swagger-split` and `make swagger-ui` targets

## Services (19 total, 132 endpoints)

| Service | Endpoints | Domain |
|---------|-----------|--------|
| Current Account | 21 | Accounts, deposits, withdrawals, liens, valuations |
| Party | 21 | Customer/org management, demographics, eligibility |
| Internal Bank Account | 16 | Nostro/vostro accounts, booking logs |
| Position Keeping | 15 | Financial position logs, transactions |
| Market Information | 14 | Rates, quotes, instruments |
| Saga Registry | 10 | Starlark saga CRUD, validation, activation |
| Account Reconciliation | 9 | Settlement runs, variances, disputes |
| Financial Accounting | 9 | Journals, booking logs |
| Node | 9 | Hierarchy/tree structure |
| Reference Data | 8 | Instruments, data sets |
| Payment Order | 6 | Payment initiation, execution |
| Tenant | 6 | Tenant management |
| Balance Sheet | 3 | Position aggregation, CSV export |
| Causation Visualizer | 3 | Event/transaction tracing |
| Manifest History | 3 | Manifest versioning |
| Auth | 1 | API key validation |
| Forecasting | 1 | Forward curve computation |
| Health | 1 | Health check |
| Saga Admin | 1 | Causation tree debugging |

## Usage

```bash
# With Tilt running:
make swagger-ui
# Open http://localhost:8091/swagger-ui.html
```

## Test plan

- [ ] Run `make swagger-split` and verify 19 service files + catalog.json generated
- [ ] Run `make swagger-ui` and verify Swagger UI loads at localhost:8091
- [ ] Select individual services from dropdown and verify endpoints filter correctly
- [ ] Execute a request against the running gateway (e.g., health check)