### PR TITLE
feat: add RetryableError and error classification for startup retry

### DIFF
--- a/shared/platform/bootstrap/retry.go
+++ b/shared/platform/bootstrap/retry.go
@@ -14,6 +14,9 @@ type PermanentError struct {
 }
 
 func (e *PermanentError) Error() string {
+	if e.Err == nil {
+		return "permanent: <nil>"
+	}
 	return "permanent: " + e.Err.Error()
 }
 

--- a/shared/platform/bootstrap/retry.go
+++ b/shared/platform/bootstrap/retry.go
@@ -1,0 +1,82 @@
+package bootstrap
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"syscall"
+)
+
+// PermanentError wraps an error to signal that it should not be retried.
+// Use Permanent() to create one.
+type PermanentError struct {
+	Err error
+}
+
+func (e *PermanentError) Error() string {
+	return "permanent: " + e.Err.Error()
+}
+
+func (e *PermanentError) Unwrap() error {
+	return e.Err
+}
+
+// Permanent wraps err to indicate that it is a permanent (non-retryable) error.
+// Returns nil if err is nil.
+func Permanent(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &PermanentError{Err: err}
+}
+
+// IsPermanent reports whether err (or any error in its chain) is a PermanentError.
+func IsPermanent(err error) bool {
+	var pe *PermanentError
+	return errors.As(err, &pe)
+}
+
+// transientSubstrings are substrings in error messages that indicate
+// transient infrastructure errors worth retrying during startup.
+var transientSubstrings = []string{
+	"connection refused",
+	"connection reset",
+	"i/o timeout",
+	"dial tcp",
+	"server is not ready",
+	"node is not ready",
+}
+
+// IsRetryableStartupError classifies err as retryable (transient infrastructure
+// error) or not. It returns false for nil, PermanentError, and unrecognized errors.
+func IsRetryableStartupError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if IsPermanent(err) {
+		return false
+	}
+
+	// Check for net.OpError in the chain.
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+
+	// Check for known transient syscall errors in the chain.
+	if errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ETIMEDOUT) ||
+		errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+
+	// Fall back to substring matching on the error message.
+	msg := strings.ToLower(err.Error())
+	for _, sub := range transientSubstrings {
+		if strings.Contains(msg, sub) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/shared/platform/bootstrap/retry_test.go
+++ b/shared/platform/bootstrap/retry_test.go
@@ -1,0 +1,145 @@
+package bootstrap
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+)
+
+var errSentinel = errors.New("sentinel error")
+
+func TestPermanent_NilReturnsNil(t *testing.T) {
+	if got := Permanent(nil); got != nil {
+		t.Errorf("Permanent(nil) = %v, want nil", got)
+	}
+}
+
+func TestIsPermanent_ReturnsTrueForPermanentError(t *testing.T) {
+	err := Permanent(errors.New("bad config"))
+	if !IsPermanent(err) {
+		t.Error("IsPermanent(Permanent(err)) = false, want true")
+	}
+}
+
+func TestIsPermanent_ReturnsFalseForRegularError(t *testing.T) {
+	err := fmt.Errorf("some error")
+	if IsPermanent(err) {
+		t.Error("IsPermanent(regular error) = true, want false")
+	}
+}
+
+func TestPermanent_UnwrapChainPreservesSentinel(t *testing.T) {
+	wrapped := Permanent(errSentinel)
+	if !errors.Is(wrapped, errSentinel) {
+		t.Error("errors.Is(Permanent(sentinel), sentinel) = false, want true")
+	}
+}
+
+func TestPermanentError_ErrorMessage(t *testing.T) {
+	inner := errors.New("bad config value")
+	pe := Permanent(inner)
+	want := "permanent: bad config value"
+	if got := pe.Error(); got != want {
+		t.Errorf("PermanentError.Error() = %q, want %q", got, want)
+	}
+}
+
+func TestIsRetryableStartupError_Nil(t *testing.T) {
+	if IsRetryableStartupError(nil) {
+		t.Error("IsRetryableStartupError(nil) = true, want false")
+	}
+}
+
+func TestIsRetryableStartupError_PermanentError(t *testing.T) {
+	err := Permanent(errors.New("bad config"))
+	if IsRetryableStartupError(err) {
+		t.Error("IsRetryableStartupError(PermanentError) = true, want false")
+	}
+}
+
+func TestIsRetryableStartupError_NetOpError(t *testing.T) {
+	err := &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Addr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 5432,
+		},
+		Err: syscall.ECONNREFUSED,
+	}
+	if !IsRetryableStartupError(err) {
+		t.Error("IsRetryableStartupError(net.OpError) = false, want true")
+	}
+}
+
+func TestIsRetryableStartupError_WrappedNetOpError(t *testing.T) {
+	inner := &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+		Addr: &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 5432,
+		},
+		Err: syscall.ECONNREFUSED,
+	}
+	err := fmt.Errorf("failed to connect: %w", inner)
+	if !IsRetryableStartupError(err) {
+		t.Error("IsRetryableStartupError(wrapped net.OpError) = false, want true")
+	}
+}
+
+func TestIsRetryableStartupError_ConnectionRefusedString(t *testing.T) {
+	err := fmt.Errorf("connection refused")
+	if !IsRetryableStartupError(err) {
+		t.Error("IsRetryableStartupError('connection refused') = false, want true")
+	}
+}
+
+func TestIsRetryableStartupError_TransientStrings(t *testing.T) {
+	transientMessages := []string{
+		"connection refused",
+		"connection reset by peer",
+		"i/o timeout",
+		"dial tcp 127.0.0.1:5432: connect: connection refused",
+		"server is not ready",
+		"node is not ready",
+	}
+
+	for _, msg := range transientMessages {
+		t.Run(msg, func(t *testing.T) {
+			err := fmt.Errorf("startup failed: %s", msg)
+			if !IsRetryableStartupError(err) {
+				t.Errorf("IsRetryableStartupError(%q) = false, want true", msg)
+			}
+		})
+	}
+}
+
+func TestIsRetryableStartupError_UnrecognizedError(t *testing.T) {
+	err := errors.New("invalid configuration value")
+	if IsRetryableStartupError(err) {
+		t.Error("IsRetryableStartupError(unrecognized error) = true, want false")
+	}
+}
+
+func TestIsRetryableStartupError_SyscallErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"ECONNREFUSED", syscall.ECONNREFUSED},
+		{"ETIMEDOUT", syscall.ETIMEDOUT},
+		{"ECONNRESET", syscall.ECONNRESET},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapped := fmt.Errorf("dial failed: %w", tt.err)
+			if !IsRetryableStartupError(wrapped) {
+				t.Errorf("IsRetryableStartupError(%s) = false, want true", tt.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `PermanentError` type and `Permanent()` wrapper to signal non-retryable errors
- Add `IsPermanent()` predicate using `errors.As` for error chain inspection
- Add `IsRetryableStartupError()` classifier that detects transient infrastructure errors (`net.OpError`, `ECONNREFUSED`, `ETIMEDOUT`, `ECONNRESET`, and common connection-related error messages)
- Foundation for the startup retry wrapper (startup-resilience.7)

## Test plan

- [x] `Permanent(nil)` returns nil
- [x] `IsPermanent(Permanent(err))` returns true
- [x] `IsPermanent(regularErr)` returns false
- [x] `errors.Is(Permanent(sentinel), sentinel)` preserves unwrap chain
- [x] `IsRetryableStartupError(nil)` returns false
- [x] `IsRetryableStartupError(PermanentError)` returns false
- [x] `IsRetryableStartupError(net.OpError)` returns true
- [x] `IsRetryableStartupError(wrapped net.OpError)` returns true
- [x] Transient string patterns detected: connection refused, reset, i/o timeout, dial tcp, server/node not ready
- [x] Syscall errors detected: ECONNREFUSED, ETIMEDOUT, ECONNRESET
- [x] Unrecognized errors return false