### PR TITLE
feat: add init containers for infrastructure dependency readiness

### DIFF
--- a/services/current-account/k8s/deployment.yaml
+++ b/services/current-account/k8s/deployment.yaml
@@ -32,6 +32,85 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-cockroachdb
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for CockroachDB...'
+          until nc -z cockroachdb 26257; do
+            echo 'CockroachDB not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'CockroachDB is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+      - name: wait-for-redis
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for Redis...'
+          until nc -z redis 6379; do
+            echo 'Redis not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'Redis is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+      - name: wait-for-kafka
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for Kafka...'
+          until nc -z kafka 9092; do
+            echo 'Kafka not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'Kafka is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
       containers:
       - name: current-account
         image: current-account:latest

--- a/services/financial-accounting/k8s/deployment.yaml
+++ b/services/financial-accounting/k8s/deployment.yaml
@@ -32,6 +32,85 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-cockroachdb
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for CockroachDB...'
+          until nc -z cockroachdb 26257; do
+            echo 'CockroachDB not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'CockroachDB is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+      - name: wait-for-redis
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for Redis...'
+          until nc -z redis 6379; do
+            echo 'Redis not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'Redis is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+      - name: wait-for-kafka
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for Kafka...'
+          until nc -z kafka 9092; do
+            echo 'Kafka not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'Kafka is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
       containers:
       - name: financial-accounting
         image: financial-accounting:latest

--- a/services/forecasting/k8s/deployment.yaml
+++ b/services/forecasting/k8s/deployment.yaml
@@ -32,6 +32,59 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-cockroachdb
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for CockroachDB...'
+          until nc -z cockroachdb 26257; do
+            echo 'CockroachDB not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'CockroachDB is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+      - name: wait-for-redis
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for Redis...'
+          until nc -z redis 6379; do
+            echo 'Redis not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'Redis is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
       containers:
       - name: forecasting
         image: forecasting:latest

--- a/services/gateway/k8s/deployment.yaml
+++ b/services/gateway/k8s/deployment.yaml
@@ -32,6 +32,59 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-cockroachdb
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for CockroachDB...'
+          until nc -z cockroachdb 26257; do
+            echo 'CockroachDB not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'CockroachDB is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+      - name: wait-for-redis
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for Redis...'
+          until nc -z redis 6379; do
+            echo 'Redis not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'Redis is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
       containers:
       - name: gateway
         image: gateway:latest

--- a/services/internal-bank-account/k8s/deployment.yaml
+++ b/services/internal-bank-account/k8s/deployment.yaml
@@ -32,6 +32,33 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-cockroachdb
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for CockroachDB...'
+          until nc -z cockroachdb 26257; do
+            echo 'CockroachDB not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'CockroachDB is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
       containers:
       - name: internal-bank-account
         image: internal-bank-account:latest

--- a/services/market-information/k8s/deployment.yaml
+++ b/services/market-information/k8s/deployment.yaml
@@ -32,6 +32,33 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-cockroachdb
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for CockroachDB...'
+          until nc -z cockroachdb 26257; do
+            echo 'CockroachDB not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'CockroachDB is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
       containers:
       - name: market-information
         image: market-information:latest

--- a/services/party/k8s/deployment.yaml
+++ b/services/party/k8s/deployment.yaml
@@ -32,6 +32,33 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-cockroachdb
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for CockroachDB...'
+          until nc -z cockroachdb 26257; do
+            echo 'CockroachDB not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'CockroachDB is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
       containers:
       - name: party
         image: party:latest

--- a/services/payment-order/k8s/deployment.yaml
+++ b/services/payment-order/k8s/deployment.yaml
@@ -32,6 +32,85 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-cockroachdb
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for CockroachDB...'
+          until nc -z cockroachdb 26257; do
+            echo 'CockroachDB not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'CockroachDB is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+      - name: wait-for-redis
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for Redis...'
+          until nc -z redis 6379; do
+            echo 'Redis not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'Redis is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+      - name: wait-for-kafka
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for Kafka...'
+          until nc -z kafka 9092; do
+            echo 'Kafka not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'Kafka is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
       containers:
       - name: payment-order
         image: payment-order:latest

--- a/services/position-keeping/k8s/deployment.yaml
+++ b/services/position-keeping/k8s/deployment.yaml
@@ -32,6 +32,85 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-cockroachdb
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for CockroachDB...'
+          until nc -z cockroachdb 26257; do
+            echo 'CockroachDB not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'CockroachDB is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+      - name: wait-for-redis
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for Redis...'
+          until nc -z redis 6379; do
+            echo 'Redis not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'Redis is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+      - name: wait-for-kafka
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for Kafka...'
+          until nc -z kafka 9092; do
+            echo 'Kafka not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'Kafka is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
       containers:
       - name: position-keeping
         image: position-keeping:latest

--- a/services/reconciliation/k8s/deployment.yaml
+++ b/services/reconciliation/k8s/deployment.yaml
@@ -32,6 +32,85 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-cockroachdb
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for CockroachDB...'
+          until nc -z cockroachdb 26257; do
+            echo 'CockroachDB not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'CockroachDB is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+      - name: wait-for-redis
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for Redis...'
+          until nc -z redis 6379; do
+            echo 'Redis not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'Redis is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+      - name: wait-for-kafka
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for Kafka...'
+          until nc -z kafka 9092; do
+            echo 'Kafka not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'Kafka is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
       containers:
       - name: reconciliation
         image: reconciliation:latest

--- a/services/reference-data/k8s/deployment.yaml
+++ b/services/reference-data/k8s/deployment.yaml
@@ -32,6 +32,33 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-cockroachdb
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for CockroachDB...'
+          until nc -z cockroachdb 26257; do
+            echo 'CockroachDB not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'CockroachDB is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
       containers:
       - name: reference-data
         image: reference-data:latest

--- a/services/tenant/k8s/deployment.yaml
+++ b/services/tenant/k8s/deployment.yaml
@@ -32,6 +32,59 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-cockroachdb
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for CockroachDB...'
+          until nc -z cockroachdb 26257; do
+            echo 'CockroachDB not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'CockroachDB is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+      - name: wait-for-redis
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for Redis...'
+          until nc -z redis 6379; do
+            echo 'Redis not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'Redis is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
       containers:
       - name: tenant
         image: tenant:latest

--- a/services/utilization-metering-consumer/k8s/deployment.yaml
+++ b/services/utilization-metering-consumer/k8s/deployment.yaml
@@ -32,6 +32,33 @@ spec:
         fsGroup: 65532
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-kafka
+        image: busybox:1.36
+        command:
+        - sh
+        - -c
+        - |
+          echo 'Waiting for Kafka...'
+          until nc -z kafka 9092; do
+            echo 'Kafka not ready, retrying in 2s'
+            sleep 2
+          done
+          echo 'Kafka is ready'
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
       containers:
       - name: utilization-metering-consumer
         image: utilization-metering-consumer:latest


### PR DESCRIPTION
## Summary

- Add busybox init containers to all 13 service deployment.yaml files that TCP-check required infrastructure (CockroachDB, Redis, Kafka) before the main container starts
- Prevents wasted startup probe budget when infrastructure is unavailable during cold starts or rolling restarts
- Init containers use minimal resources (10m/16Mi request, 50m/32Mi limit) and include security hardening (runAsNonRoot, no privilege escalation)

## Verified Dependency Matrix

| Service | CockroachDB | Redis | Kafka |
|---|---|---|---|
| tenant | yes | yes | - |
| current-account | yes | yes | yes |
| position-keeping | yes | yes | yes |
| financial-accounting | yes | yes | yes |
| party | yes | - | - |
| internal-bank-account | yes | - | - |
| reference-data | yes | - | - |
| payment-order | yes | yes | yes |
| gateway | yes | yes | - |
| market-information | yes | - | - |
| reconciliation | yes | yes | yes |
| forecasting | yes | yes | - |
| utilization-metering-consumer | - | - | yes |

Dependencies verified by reading each service's `k8s/configmap.yaml` and `cmd/main.go`.

Note: `audit-worker` has no k8s directory and is excluded from this change.

## Test Plan

- [ ] Verify YAML validity (all 13 files validated with Python yaml parser)
- [ ] Confirm init containers appear in Tilt local environment
- [ ] Verify services start successfully after init containers complete
- [ ] Confirm init containers block when infrastructure is unavailable