### PR TITLE
feat: add RunWithRetry startup retry wrapper

### DIFF
--- a/shared/platform/bootstrap/retry.go
+++ b/shared/platform/bootstrap/retry.go
@@ -2,9 +2,13 @@ package bootstrap
 
 import (
 	"errors"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
 	"net"
 	"strings"
 	"syscall"
+	"time"
 )
 
 // PermanentError wraps an error to signal that it should not be retried.
@@ -82,4 +86,111 @@ func IsRetryableStartupError(err error) bool {
 	}
 
 	return false
+}
+
+// retryConfig holds configuration for RunWithRetry.
+type retryConfig struct {
+	maxAttempts int
+	initialWait time.Duration
+	maxWait     time.Duration
+	multiplier  float64
+	logger      *slog.Logger
+}
+
+// RetryOption configures RunWithRetry behavior.
+type RetryOption func(*retryConfig)
+
+// WithMaxAttempts sets the maximum number of attempts (default: 10).
+func WithMaxAttempts(n int) RetryOption {
+	return func(c *retryConfig) { c.maxAttempts = n }
+}
+
+// WithInitialWait sets the initial wait duration between retries (default: 1s).
+func WithInitialWait(d time.Duration) RetryOption {
+	return func(c *retryConfig) { c.initialWait = d }
+}
+
+// WithMaxWait sets the maximum wait duration between retries (default: 30s).
+func WithMaxWait(d time.Duration) RetryOption {
+	return func(c *retryConfig) { c.maxWait = d }
+}
+
+// WithRetryLogger sets a structured logger for retry events.
+func WithRetryLogger(l *slog.Logger) RetryOption {
+	return func(c *retryConfig) { c.logger = l }
+}
+
+// RunWithRetry executes fn with exponential backoff retry for transient startup
+// errors. Permanent errors (wrapped with Permanent) cause immediate return with
+// no further retries. Unknown errors are retried conservatively.
+func RunWithRetry(fn func() error, opts ...RetryOption) error {
+	cfg := retryConfig{
+		maxAttempts: 10,
+		initialWait: 1 * time.Second,
+		maxWait:     30 * time.Second,
+		multiplier:  2.0,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	wait := cfg.initialWait
+	var lastErr error
+
+	for attempt := 1; attempt <= cfg.maxAttempts; attempt++ {
+		lastErr = fn()
+		if lastErr == nil {
+			return nil
+		}
+
+		if IsPermanent(lastErr) {
+			if cfg.logger != nil {
+				cfg.logger.Error("permanent startup error, not retrying",
+					"attempt", attempt,
+					"error", lastErr,
+				)
+			}
+			return lastErr
+		}
+
+		if attempt == cfg.maxAttempts {
+			break
+		}
+
+		// Add jitter: +-20%
+		jittered := applyJitter(wait)
+
+		if cfg.logger != nil {
+			cfg.logger.Warn("transient startup error, retrying",
+				"attempt", attempt,
+				"max_attempts", cfg.maxAttempts,
+				"next_wait", jittered,
+				"error", lastErr,
+			)
+		}
+
+		time.Sleep(jittered)
+
+		// Exponential increase for next iteration, capped at maxWait
+		wait = time.Duration(float64(wait) * cfg.multiplier)
+		if wait > cfg.maxWait {
+			wait = cfg.maxWait
+		}
+	}
+
+	if cfg.logger != nil {
+		cfg.logger.Error("all startup retry attempts exhausted",
+			"attempts", cfg.maxAttempts,
+			"error", lastErr,
+		)
+	}
+
+	return fmt.Errorf("startup failed after %d attempts: %w", cfg.maxAttempts, lastErr)
+}
+
+// applyJitter adds +-20% jitter to a duration to avoid thundering herd.
+func applyJitter(d time.Duration) time.Duration {
+	// jitter in range [-0.2, +0.2]
+	jitter := (rand.Float64()*0.4 - 0.2)
+	return time.Duration(float64(d) * (1.0 + jitter))
 }

--- a/shared/platform/bootstrap/retry_test.go
+++ b/shared/platform/bootstrap/retry_test.go
@@ -3,9 +3,12 @@ package bootstrap
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
+	"sync/atomic"
 	"syscall"
 	"testing"
+	"time"
 )
 
 var errSentinel = errors.New("sentinel error")
@@ -141,5 +144,216 @@ func TestIsRetryableStartupError_SyscallErrors(t *testing.T) {
 				t.Errorf("IsRetryableStartupError(%s) = false, want true", tt.name)
 			}
 		})
+	}
+}
+
+// --- RunWithRetry tests ---
+
+func TestRunWithRetry_SucceedsOnFirstTry(t *testing.T) {
+	var calls atomic.Int32
+	err := RunWithRetry(func() error {
+		calls.Add(1)
+		return nil
+	})
+	if err != nil {
+		t.Errorf("RunWithRetry() = %v, want nil", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("fn called %d times, want 1", got)
+	}
+}
+
+func TestRunWithRetry_SucceedsAfterTransientErrors(t *testing.T) {
+	var calls atomic.Int32
+	transient := fmt.Errorf("startup failed: connection refused")
+
+	err := RunWithRetry(func() error {
+		n := calls.Add(1)
+		if n < 3 {
+			return transient
+		}
+		return nil
+	}, WithInitialWait(1*time.Millisecond), WithMaxWait(2*time.Millisecond))
+	if err != nil {
+		t.Errorf("RunWithRetry() = %v, want nil", err)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Errorf("fn called %d times, want 3", got)
+	}
+}
+
+func TestRunWithRetry_PermanentErrorOnFirstAttempt(t *testing.T) {
+	inner := errors.New("bad config")
+	permErr := Permanent(inner)
+
+	var calls atomic.Int32
+	err := RunWithRetry(func() error {
+		calls.Add(1)
+		return permErr
+	}, WithInitialWait(1*time.Millisecond))
+
+	if err == nil {
+		t.Fatal("RunWithRetry() = nil, want error")
+	}
+	if !IsPermanent(err) {
+		t.Errorf("returned error is not PermanentError: %v", err)
+	}
+	if !errors.Is(err, inner) {
+		t.Errorf("returned error does not wrap inner: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("fn called %d times, want 1", got)
+	}
+}
+
+func TestRunWithRetry_PermanentErrorOnSecondAttempt(t *testing.T) {
+	transient := fmt.Errorf("startup failed: connection refused")
+	inner := errors.New("missing required table")
+	permErr := Permanent(inner)
+
+	var calls atomic.Int32
+	err := RunWithRetry(func() error {
+		n := calls.Add(1)
+		if n == 1 {
+			return transient
+		}
+		return permErr
+	}, WithInitialWait(1*time.Millisecond))
+
+	if err == nil {
+		t.Fatal("RunWithRetry() = nil, want error")
+	}
+	if !IsPermanent(err) {
+		t.Errorf("returned error is not PermanentError: %v", err)
+	}
+	if !errors.Is(err, inner) {
+		t.Errorf("returned error does not wrap inner: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("fn called %d times, want 2", got)
+	}
+}
+
+func TestRunWithRetry_AllAttemptsExhausted(t *testing.T) {
+	transient := fmt.Errorf("startup failed: connection refused")
+
+	var calls atomic.Int32
+	err := RunWithRetry(func() error {
+		calls.Add(1)
+		return transient
+	}, WithMaxAttempts(3), WithInitialWait(1*time.Millisecond), WithMaxWait(2*time.Millisecond))
+
+	if err == nil {
+		t.Fatal("RunWithRetry() = nil, want error")
+	}
+	if got := calls.Load(); got != 3 {
+		t.Errorf("fn called %d times, want 3", got)
+	}
+	// Should return the last error (not wrapped in PermanentError)
+	if IsPermanent(err) {
+		t.Error("exhausted error should not be PermanentError")
+	}
+}
+
+func TestRunWithRetry_OptionConfigsApply(t *testing.T) {
+	transient := fmt.Errorf("startup failed: connection refused")
+
+	var calls atomic.Int32
+	start := time.Now()
+	err := RunWithRetry(func() error {
+		calls.Add(1)
+		return transient
+	},
+		WithMaxAttempts(2),
+		WithInitialWait(10*time.Millisecond),
+		WithMaxWait(20*time.Millisecond),
+	)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("RunWithRetry() = nil, want error")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("fn called %d times, want 2", got)
+	}
+	// With 2 attempts, there is 1 wait interval (between attempt 1 and 2).
+	// initialWait is 10ms with +-20% jitter = 8ms-12ms.
+	// Allow generous bounds for CI variability.
+	if elapsed < 5*time.Millisecond {
+		t.Errorf("elapsed %v is too short, expected at least ~8ms", elapsed)
+	}
+}
+
+func TestRunWithRetry_UnknownErrorsAreRetried(t *testing.T) {
+	// Unknown errors (not classified as permanent or transient) should be retried
+	// per the conservative approach specified in requirements.
+	unknown := errors.New("something unexpected happened")
+
+	var calls atomic.Int32
+	err := RunWithRetry(func() error {
+		n := calls.Add(1)
+		if n < 2 {
+			return unknown
+		}
+		return nil
+	}, WithInitialWait(1*time.Millisecond))
+	if err != nil {
+		t.Errorf("RunWithRetry() = %v, want nil", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("fn called %d times, want 2", got)
+	}
+}
+
+func TestRunWithRetry_WithLogger(t *testing.T) {
+	// Verify that WithRetryLogger does not panic and the logger is used.
+	// We just verify no panic; log output verification would require a custom handler.
+	logger := slog.Default()
+	transient := fmt.Errorf("startup failed: connection refused")
+
+	var calls atomic.Int32
+	_ = RunWithRetry(func() error {
+		n := calls.Add(1)
+		if n < 2 {
+			return transient
+		}
+		return nil
+	}, WithRetryLogger(logger), WithInitialWait(1*time.Millisecond))
+
+	if got := calls.Load(); got != 2 {
+		t.Errorf("fn called %d times, want 2", got)
+	}
+}
+
+func TestRunWithRetry_ExponentialBackoff(t *testing.T) {
+	// Verify that wait times increase exponentially.
+	transient := fmt.Errorf("startup failed: connection refused")
+
+	var timestamps []time.Time
+	_ = RunWithRetry(func() error {
+		timestamps = append(timestamps, time.Now())
+		if len(timestamps) < 4 {
+			return transient
+		}
+		return nil
+	}, WithMaxAttempts(4), WithInitialWait(20*time.Millisecond), WithMaxWait(200*time.Millisecond))
+
+	if len(timestamps) != 4 {
+		t.Fatalf("expected 4 timestamps, got %d", len(timestamps))
+	}
+
+	// Between attempt 1 and 2: ~20ms (+-20% jitter = 16-24ms)
+	// Between attempt 2 and 3: ~40ms (+-20% jitter = 32-48ms)
+	// Between attempt 3 and 4: ~80ms (+-20% jitter = 64-96ms)
+	gap1 := timestamps[1].Sub(timestamps[0])
+	gap2 := timestamps[2].Sub(timestamps[1])
+	gap3 := timestamps[3].Sub(timestamps[2])
+
+	// Second gap should be larger than first (exponential growth)
+	if gap2 < gap1 {
+		t.Errorf("gap2 (%v) should be >= gap1 (%v) for exponential backoff", gap2, gap1)
+	}
+	if gap3 < gap2 {
+		t.Errorf("gap3 (%v) should be >= gap2 (%v) for exponential backoff", gap3, gap2)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `RunWithRetry` function to `shared/platform/bootstrap` that wraps a service's `run()` function with exponential backoff retry, preventing CrashLoopBackOff for transient startup failures while failing fast for permanent configuration errors
- Functional options pattern: `WithMaxAttempts`, `WithInitialWait`, `WithMaxWait`, `WithRetryLogger`
- Defaults: 10 attempts, 1s initial wait, 30s max wait, 2x multiplier, +-20% jitter

## Changes Made

- `shared/platform/bootstrap/retry.go`: Added `retryConfig`, `RetryOption`, `RunWithRetry`, `applyJitter`, and four option functions
- `shared/platform/bootstrap/retry_test.go`: Added 9 unit tests covering success, transient retry, permanent error bail-out, exhaustion, options, unknown errors, logger, and exponential backoff verification

## Task Master

Task: `startup-resilience.7`

## Test Plan

- [x] Succeeds on first try
- [x] Succeeds on 3rd try after 2 transient errors
- [x] Permanent error on attempt 1 returns immediately
- [x] Permanent error on attempt 2 returns immediately
- [x] All attempts exhausted returns last error
- [x] RetryOption configs apply correctly
- [x] Unknown errors are retried (conservative approach)
- [x] WithRetryLogger does not panic
- [x] Exponential backoff gaps increase