### PR TITLE
feat: add LazyClient for optional dependency lazy initialization

### DIFF
--- a/shared/platform/bootstrap/lazy.go
+++ b/shared/platform/bootstrap/lazy.go
@@ -1,0 +1,138 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ResolveFunc attempts to create a client of type T. On success it returns the
+// client value, a cleanup function (called during shutdown), and nil error.
+// On failure it returns a non-nil error, and the LazyClient background
+// goroutine will retry with exponential backoff.
+type ResolveFunc[T any] func(ctx context.Context) (T, func(), error)
+
+// LazyClient wraps an optional dependency that resolves asynchronously in the
+// background. This allows the gRPC server to start immediately and health
+// probes to pass while optional clients connect with retry.
+type LazyClient[T any] struct {
+	name    string
+	client  atomic.Pointer[T]
+	resolve ResolveFunc[T]
+}
+
+// lazyConfig holds configuration for NewLazyClient.
+type lazyConfig struct {
+	initialWait time.Duration
+	maxWait     time.Duration
+	multiplier  float64
+	logger      *slog.Logger
+	onCleanup   func(func())
+}
+
+// LazyOption configures LazyClient behavior.
+type LazyOption func(*lazyConfig)
+
+// WithLazyInitialWait sets the initial backoff wait between retries (default: 1s).
+func WithLazyInitialWait(d time.Duration) LazyOption {
+	return func(c *lazyConfig) { c.initialWait = d }
+}
+
+// WithLazyMaxWait sets the maximum backoff wait between retries (default: 30s).
+func WithLazyMaxWait(d time.Duration) LazyOption {
+	return func(c *lazyConfig) { c.maxWait = d }
+}
+
+// WithLazyLogger sets a structured logger for resolution events.
+func WithLazyLogger(l *slog.Logger) LazyOption {
+	return func(c *lazyConfig) { c.logger = l }
+}
+
+// WithLazyOnCleanup registers a callback that is invoked with the resolve
+// function's cleanup func on successful resolution. The caller can use this
+// to append to a cleanup slice with appropriate synchronization.
+func WithLazyOnCleanup(fn func(func())) LazyOption {
+	return func(c *lazyConfig) { c.onCleanup = fn }
+}
+
+// NewLazyClient creates a LazyClient that resolves its dependency in a background
+// goroutine with exponential backoff retry. The background goroutine stops when
+// ctx is cancelled or resolution succeeds.
+func NewLazyClient[T any](ctx context.Context, name string, resolve ResolveFunc[T], opts ...LazyOption) *LazyClient[T] {
+	cfg := lazyConfig{
+		initialWait: 1 * time.Second,
+		maxWait:     30 * time.Second,
+		multiplier:  2.0,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	lc := &LazyClient[T]{
+		name:    name,
+		resolve: resolve,
+	}
+
+	go lc.backgroundResolve(ctx, cfg)
+
+	return lc
+}
+
+// Get returns the resolved client or a gRPC Unavailable status error if the
+// client has not been resolved yet.
+func (lc *LazyClient[T]) Get() (T, error) {
+	if p := lc.client.Load(); p != nil {
+		return *p, nil
+	}
+	var zero T
+	return zero, status.Errorf(codes.Unavailable, "%s is not yet available", lc.name)
+}
+
+// IsReady reports whether the client has been successfully resolved.
+func (lc *LazyClient[T]) IsReady() bool {
+	return lc.client.Load() != nil
+}
+
+// backgroundResolve runs in a goroutine and attempts to resolve the client with
+// exponential backoff until success or context cancellation.
+func (lc *LazyClient[T]) backgroundResolve(ctx context.Context, cfg lazyConfig) {
+	wait := cfg.initialWait
+
+	for {
+		client, cleanup, err := lc.resolve(ctx)
+		if err == nil {
+			lc.client.Store(&client)
+			if cfg.onCleanup != nil && cleanup != nil {
+				cfg.onCleanup(cleanup)
+			}
+			if cfg.logger != nil {
+				cfg.logger.Info(fmt.Sprintf("lazy client %q resolved", lc.name))
+			}
+			return
+		}
+
+		if cfg.logger != nil {
+			cfg.logger.Warn(fmt.Sprintf("lazy client %q resolve failed, retrying", lc.name),
+				"error", err,
+				"next_wait", wait,
+			)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(wait):
+		}
+
+		// Exponential backoff, capped at maxWait
+		wait = time.Duration(float64(wait) * cfg.multiplier)
+		if wait > cfg.maxWait {
+			wait = cfg.maxWait
+		}
+	}
+}

--- a/shared/platform/bootstrap/lazy_test.go
+++ b/shared/platform/bootstrap/lazy_test.go
@@ -1,0 +1,243 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeClient is a test double for LazyClient resolution.
+type fakeClient struct {
+	Name string
+}
+
+func TestLazyClient_GetBeforeResolution_ReturnsUnavailable(t *testing.T) {
+	// resolve blocks forever so Get is always called before resolution
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lc := NewLazyClient[*fakeClient](ctx, "test-client", func(ctx context.Context) (*fakeClient, func(), error) {
+		<-ctx.Done()
+		return nil, nil, ctx.Err()
+	})
+
+	_, err := lc.Get()
+	if err == nil {
+		t.Fatal("Get() before resolution should return error")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T: %v", err, err)
+	}
+	if st.Code() != codes.Unavailable {
+		t.Errorf("Get() status code = %v, want %v", st.Code(), codes.Unavailable)
+	}
+}
+
+func TestLazyClient_GetAfterResolution_ReturnsClient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	want := &fakeClient{Name: "resolved"}
+	lc := NewLazyClient[*fakeClient](ctx, "test-client", func(_ context.Context) (*fakeClient, func(), error) {
+		return want, func() {}, nil
+	})
+
+	// Wait for background resolution
+	waitForReady(t, lc, 2*time.Second)
+
+	got, err := lc.Get()
+	if err != nil {
+		t.Fatalf("Get() after resolution: unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("Get() = %v, want %v", got, want)
+	}
+}
+
+func TestLazyClient_IsReady_FalseBeforeTrueAfter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resolved := make(chan struct{})
+	lc := NewLazyClient[*fakeClient](ctx, "test-client", func(_ context.Context) (*fakeClient, func(), error) {
+		<-resolved
+		return &fakeClient{Name: "ready"}, func() {}, nil
+	})
+
+	if lc.IsReady() {
+		t.Error("IsReady() before resolution = true, want false")
+	}
+
+	close(resolved)
+	waitForReady(t, lc, 2*time.Second)
+
+	if !lc.IsReady() {
+		t.Error("IsReady() after resolution = false, want true")
+	}
+}
+
+func TestLazyClient_RetriesOnError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var attempts atomic.Int32
+	lc := NewLazyClient[*fakeClient](ctx, "test-client", func(_ context.Context) (*fakeClient, func(), error) {
+		n := attempts.Add(1)
+		if n < 3 {
+			return nil, nil, errors.New("connection refused")
+		}
+		return &fakeClient{Name: "eventually"}, func() {}, nil
+	}, WithLazyInitialWait(1*time.Millisecond), WithLazyMaxWait(5*time.Millisecond))
+
+	waitForReady(t, lc, 2*time.Second)
+
+	got, err := lc.Get()
+	if err != nil {
+		t.Fatalf("Get() after retry: unexpected error: %v", err)
+	}
+	if got.Name != "eventually" {
+		t.Errorf("Get().Name = %q, want %q", got.Name, "eventually")
+	}
+	if n := attempts.Load(); n < 3 {
+		t.Errorf("resolve called %d times, want >= 3", n)
+	}
+}
+
+func TestLazyClient_ContextCancellation_StopsBackground(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var attempts atomic.Int32
+	blocked := make(chan struct{})
+
+	_ = NewLazyClient[*fakeClient](ctx, "test-client", func(_ context.Context) (*fakeClient, func(), error) {
+		n := attempts.Add(1)
+		if n == 1 {
+			close(blocked)
+		}
+		return nil, nil, errors.New("connection refused")
+	}, WithLazyInitialWait(1*time.Millisecond), WithLazyMaxWait(5*time.Millisecond))
+
+	// Wait for at least one attempt
+	<-blocked
+
+	// Cancel context to stop background goroutine
+	cancel()
+
+	// Give goroutine time to observe cancellation
+	time.Sleep(50 * time.Millisecond)
+
+	countAfterCancel := attempts.Load()
+	// Wait a bit more to ensure no new attempts happen
+	time.Sleep(50 * time.Millisecond)
+
+	if got := attempts.Load(); got != countAfterCancel {
+		t.Errorf("attempts increased from %d to %d after context cancellation", countAfterCancel, got)
+	}
+}
+
+func TestLazyClient_CleanupAppended(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var cleaned atomic.Bool
+	cleanupFn := func() { cleaned.Store(true) }
+
+	var mu sync.Mutex
+	var cleanups []func()
+
+	lc := NewLazyClient[*fakeClient](ctx, "test-client", func(_ context.Context) (*fakeClient, func(), error) {
+		return &fakeClient{Name: "ok"}, cleanupFn, nil
+	}, WithLazyOnCleanup(func(fn func()) {
+		mu.Lock()
+		defer mu.Unlock()
+		cleanups = append(cleanups, fn)
+	}))
+
+	waitForReady(t, lc, 2*time.Second)
+
+	mu.Lock()
+	n := len(cleanups)
+	mu.Unlock()
+	if n != 1 {
+		t.Fatalf("cleanup slice len = %d, want 1", n)
+	}
+
+	mu.Lock()
+	fn := cleanups[0]
+	mu.Unlock()
+	fn()
+	if !cleaned.Load() {
+		t.Error("cleanup function was not called")
+	}
+}
+
+func TestLazyClient_ConcurrentGet_NoRace(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resolved := make(chan struct{})
+	want := &fakeClient{Name: "concurrent"}
+	lc := NewLazyClient[*fakeClient](ctx, "test-client", func(_ context.Context) (*fakeClient, func(), error) {
+		<-resolved
+		return want, func() {}, nil
+	})
+
+	var wg sync.WaitGroup
+	const goroutines = 20
+
+	// Start concurrent Get() calls before resolution
+	errCh := make(chan error, goroutines)
+	clientCh := make(chan *fakeClient, goroutines)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Some calls before resolution, some after
+			c, err := lc.Get()
+			if err != nil {
+				errCh <- err
+			} else {
+				clientCh <- c
+			}
+		}()
+	}
+
+	// Unblock resolution partway through
+	close(resolved)
+	wg.Wait()
+	close(errCh)
+	close(clientCh)
+
+	// All results should be either Unavailable error or the correct client
+	for err := range errCh {
+		st, ok := status.FromError(err)
+		if !ok || st.Code() != codes.Unavailable {
+			t.Errorf("concurrent Get() error = %v, want codes.Unavailable", err)
+		}
+	}
+	for c := range clientCh {
+		if c != want {
+			t.Errorf("concurrent Get() = %v, want %v", c, want)
+		}
+	}
+}
+
+// waitForReady polls IsReady() until true or timeout.
+func waitForReady[T any](t *testing.T, lc *LazyClient[T], timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if lc.IsReady() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("LazyClient did not become ready within timeout")
+}


### PR DESCRIPTION
## Summary

- Adds `LazyClient[T]` generic wrapper to `shared/platform/bootstrap` that resolves optional dependencies asynchronously in the background
- Allows gRPC server to start immediately and health probes to pass while optional clients connect with exponential backoff retry
- `Get()` returns client or gRPC `codes.Unavailable` status error; `IsReady()` reports resolution state

## Details

- Background goroutine with configurable exponential backoff (1s initial, 30s max, 2x multiplier)
- Context cancellation stops background goroutine
- `WithLazyOnCleanup` callback for thread-safe cleanup registration on successful resolution
- Configurable via functional options: `WithLazyInitialWait`, `WithLazyMaxWait`, `WithLazyLogger`, `WithLazyOnCleanup`

## Task Master

Tag: `startup-resilience`, Task: 9

## Test plan

- [x] Get() before resolution returns `codes.Unavailable`
- [x] Get() after resolution returns client value
- [x] IsReady() false before, true after resolution
- [x] Background goroutine retries on error until success
- [x] Context cancellation stops background goroutine
- [x] Cleanup callback invoked on success
- [x] Multiple concurrent Get() calls -- no race
- [x] All tests pass with `-race` flag