### PR TITLE
feat: apply RunWithRetry to all service entry points

### DIFF
--- a/cmd/audit-consumer/main.go
+++ b/cmd/audit-consumer/main.go
@@ -158,14 +158,16 @@ func run(logger *slog.Logger) error {
 	sigChan, signalCleanup := bootstrap.SignalHandler()
 	defer signalCleanup()
 
+	var runErr error
 	select {
 	case sig := <-sigChan:
 		logger.Info("received signal", "signal", sig)
 	case err := <-serverErrors:
-		return err
+		logger.Error("HTTP server error", "error", err)
+		runErr = err
 	}
 
-	// Graceful shutdown
+	// Graceful shutdown (runs for both signal and server error paths)
 	logger.Info("shutting down...")
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), config.Service.GracefulShutdownTimeout)
@@ -181,5 +183,5 @@ func run(logger *slog.Logger) error {
 		logger.Error("container close error", "error", err)
 	}
 
-	return nil
+	return runErr
 }

--- a/cmd/audit-consumer/main.go
+++ b/cmd/audit-consumer/main.go
@@ -94,16 +94,28 @@ func main() {
 	}))
 	slog.SetDefault(logger)
 
-	logger.Info("audit-consumer starting",
+	logger.Info("starting audit-consumer service",
 		"version", Version,
 		"commit", Commit,
-		"built", BuildDate)
+		"build_date", BuildDate)
 
-	// Load configuration from environment
+	// Run the service with retry for transient startup errors
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("service stopped gracefully")
+}
+
+func run(logger *slog.Logger) error {
+	// Load configuration from environment (permanent error if invalid)
 	config, err := app.LoadConfig()
 	if err != nil {
-		logger.Error("failed to load configuration", "error", err)
-		os.Exit(1)
+		return bootstrap.Permanent(fmt.Errorf("failed to load configuration: %w", err))
 	}
 
 	logger.Info("configuration loaded",
@@ -116,14 +128,12 @@ func main() {
 	ctx := context.Background()
 	container, err := app.NewContainer(ctx, config, logger)
 	if err != nil {
-		logger.Error("failed to initialize container", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to initialize container: %w", err)
 	}
 
 	// Start audit consumer
 	if err := container.AuditConsumer.Start(config.Kafka.Topic); err != nil {
-		logger.Error("failed to start audit consumer", "error", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to start audit consumer: %w", err)
 	}
 	logger.Info("audit consumer started", "topic", config.Kafka.Topic)
 
@@ -136,22 +146,30 @@ func main() {
 	server.Handler = mux
 
 	// Start server in background
+	serverErrors := make(chan error, 1)
 	go func() {
 		logger.Info("starting HTTP server", "port", config.Service.Port)
 		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			logger.Error("failed to start HTTP server", "error", err)
-			os.Exit(1)
+			serverErrors <- fmt.Errorf("HTTP server error: %w", err)
 		}
 	}()
 
-	// Wait for interrupt signal
+	// Wait for interrupt signal or server error
 	sigChan, signalCleanup := bootstrap.SignalHandler()
-	<-sigChan
+	defer signalCleanup()
 
-	logger.Info("shutdown signal received, starting graceful shutdown...")
+	select {
+	case sig := <-sigChan:
+		logger.Info("received signal", "signal", sig)
+	case err := <-serverErrors:
+		return err
+	}
 
-	// Graceful shutdown with timeout
+	// Graceful shutdown
+	logger.Info("shutting down...")
+
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), config.Service.GracefulShutdownTimeout)
+	defer cancel()
 
 	// Shutdown HTTP server
 	if err := server.Shutdown(shutdownCtx); err != nil {
@@ -159,18 +177,9 @@ func main() {
 	}
 
 	// Close container resources (includes consumer and database)
-	closeErr := container.Close(shutdownCtx)
-
-	// Cancel context after all shutdown operations complete
-	cancel()
-
-	// Clean up signal handler before potential exit
-	signalCleanup()
-
-	if closeErr != nil {
-		logger.Error("container close error", "error", closeErr)
-		os.Exit(1)
+	if err := container.Close(shutdownCtx); err != nil {
+		logger.Error("container close error", "error", err)
 	}
 
-	logger.Info("shutdown complete")
+	return nil
 }

--- a/services/audit-worker/cmd/main.go
+++ b/services/audit-worker/cmd/main.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"net/http"
 	"os"
@@ -20,8 +19,6 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
-
-// Note: fmt.Fprintf is used for HTTP responses, log.Printf for application lifecycle logging
 
 var (
 	Version   = "dev"
@@ -77,30 +74,39 @@ func getPort() string {
 	return port
 }
 
+// Static errors for configuration validation.
+var (
+	ErrDatabaseURLRequired = errors.New("DATABASE_URL environment variable is required")
+	ErrAuditSchemaRequired = errors.New("AUDIT_SCHEMA environment variable is required")
+)
+
 // getDBConnectionString returns database connection string from environment.
-// DATABASE_URL is required - the service will fail fast if not provided.
-func getDBConnectionString() string {
+// DATABASE_URL is required - returns an error if not provided.
+func getDBConnectionString() (string, error) {
 	connStr := os.Getenv("DATABASE_URL")
 	if connStr == "" {
-		log.Fatal("DATABASE_URL environment variable is required")
+		return "", ErrDatabaseURLRequired
 	}
-	return connStr
+	return connStr, nil
 }
 
 // getAuditSchema returns the audit schema from environment.
 // Per ADR-0020, each service should run its own embedded worker.
 // The AUDIT_SCHEMA environment variable must be set to specify which schema to process.
-func getAuditSchema() string {
+func getAuditSchema() (string, error) {
 	schema := os.Getenv("AUDIT_SCHEMA")
 	if schema == "" {
-		log.Fatal("AUDIT_SCHEMA environment variable is required")
+		return "", ErrAuditSchemaRequired
 	}
-	return schema
+	return schema, nil
 }
 
 // setupDatabase initializes the database connection with GORM
 func setupDatabase(_ context.Context) (*gorm.DB, error) {
-	connStr := getDBConnectionString()
+	connStr, err := getDBConnectionString()
+	if err != nil {
+		return nil, bootstrap.Permanent(err)
+	}
 
 	// Initialize GORM with PostgreSQL driver
 	gormDB, err := gorm.Open(postgres.Open(connStr), &gorm.Config{
@@ -126,69 +132,101 @@ func setupDatabase(_ context.Context) (*gorm.DB, error) {
 }
 
 func main() {
-	log.Printf("audit-worker v%s (commit: %s, built: %s)", Version, Commit, BuildDate)
-
 	// Setup logger
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	}))
 	slog.SetDefault(logger)
 
-	// Initialize database connection
+	logger.Info("starting audit-worker service",
+		"version", Version,
+		"commit", Commit,
+		"build_date", BuildDate)
+
+	// Run the service with retry for transient startup errors
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("service stopped gracefully")
+}
+
+func run(logger *slog.Logger) error {
 	ctx := context.Background()
+
+	// Validate audit schema (permanent config error)
+	schema, err := getAuditSchema()
+	if err != nil {
+		return bootstrap.Permanent(err)
+	}
+
+	// Initialize database connection
 	gormDB, err := setupDatabase(ctx)
 	if err != nil {
-		log.Fatalf("Failed to setup database: %v", err)
+		return fmt.Errorf("failed to setup database: %w", err)
 	}
-	log.Println("Database connection established")
+	logger.Info("database connection established")
 
 	// Start audit worker
-	// The AUDIT_SCHEMA env var specifies which audit schema this worker processes.
-	schema := getAuditSchema()
 	auditWorker := audit.NewAuditWorker(gormDB, schema, logger)
 	workerCtx, workerCancel := context.WithCancel(ctx)
+	defer workerCancel()
 	auditWorker.Start(workerCtx)
-	log.Printf("Audit worker started for schema: %s", schema)
+	logger.Info("audit worker started", "schema", schema)
 
 	// Get port from environment or use default
 	port := getPort()
 
-	// Setup routes on default mux
-	setupRoutes(http.DefaultServeMux)
+	// Setup routes on a new mux
+	mux := http.NewServeMux()
+	setupRoutes(mux)
 
 	// Create server with proper timeouts (security best practice)
 	server := createServer(port)
+	server.Handler = mux
 
 	// Start server in background
+	serverErrors := make(chan error, 1)
 	go func() {
-		log.Printf("Starting HTTP server on :%s\n", port)
+		logger.Info("starting HTTP server", "port", port)
 		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Fatalf("Failed to start server: %v", err)
+			serverErrors <- fmt.Errorf("HTTP server error: %w", err)
 		}
 	}()
 
-	// Wait for interrupt signal
+	// Wait for interrupt signal or server error
 	sigChan, signalCleanup := bootstrap.SignalHandler()
 	defer signalCleanup()
-	<-sigChan
 
-	log.Println("Shutting down server...")
+	select {
+	case sig := <-sigChan:
+		logger.Info("received signal", "signal", sig)
+	case err := <-serverErrors:
+		return err
+	}
 
-	// Cancel audit worker context
+	// Graceful shutdown
+	logger.Info("shutting down...")
+
+	// Cancel audit worker context (also deferred above for early-return paths)
 	workerCancel()
 
 	// Stop audit worker gracefully
-	log.Println("Stopping audit worker...")
+	logger.Info("stopping audit worker...")
 	auditWorker.Stop()
-	log.Println("Audit worker stopped")
+	logger.Info("audit worker stopped")
 
 	// Graceful shutdown with timeout
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), defaults.DefaultGracefulShutdown)
 	defer cancel()
 
 	if err := server.Shutdown(shutdownCtx); err != nil {
-		log.Printf("Server shutdown error: %v", err)
+		logger.Error("server shutdown error", "error", err)
 	}
 
-	log.Println("Shutdown complete")
+	return nil
 }

--- a/services/audit-worker/cmd/main.go
+++ b/services/audit-worker/cmd/main.go
@@ -202,14 +202,16 @@ func run(logger *slog.Logger) error {
 	sigChan, signalCleanup := bootstrap.SignalHandler()
 	defer signalCleanup()
 
+	var runErr error
 	select {
 	case sig := <-sigChan:
 		logger.Info("received signal", "signal", sig)
 	case err := <-serverErrors:
-		return err
+		logger.Error("HTTP server error", "error", err)
+		runErr = err
 	}
 
-	// Graceful shutdown
+	// Graceful shutdown (runs for both signal and server error paths)
 	logger.Info("shutting down...")
 
 	// Cancel audit worker context (also deferred above for early-return paths)
@@ -228,5 +230,5 @@ func run(logger *slog.Logger) error {
 		logger.Error("server shutdown error", "error", err)
 	}
 
-	return nil
+	return runErr
 }

--- a/services/audit-worker/cmd/main_test.go
+++ b/services/audit-worker/cmd/main_test.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
-	"strings"
 	"testing"
 	"time"
 )
@@ -175,46 +173,34 @@ func TestGetDBConnectionString_RequiresDatabaseURL(t *testing.T) {
 	testURL := "postgres://test:test@testhost:5432/testdb"
 	_ = os.Setenv("DATABASE_URL", testURL)
 
-	got := getDBConnectionString()
+	got, err := getDBConnectionString()
+	if err != nil {
+		t.Fatalf("getDBConnectionString() returned unexpected error: %v", err)
+	}
 	if got != testURL {
 		t.Errorf("getDBConnectionString() = %q, want %q", got, testURL)
 	}
 }
 
-func TestGetDBConnectionString_FailsFastWhenMissing(t *testing.T) {
-	// This test verifies that the binary fails fast when DATABASE_URL is missing.
-	// We use a subprocess test pattern because log.Fatal calls os.Exit(1).
-	if os.Getenv("TEST_SUBPROCESS") == "1" {
-		// We're in the subprocess - unset DATABASE_URL and call the function
-		_ = os.Unsetenv("DATABASE_URL")
-		getDBConnectionString() // This should call log.Fatal
-		return
-	}
-
-	// We're in the parent test - run ourselves as a subprocess
-	ctx := context.Background()
-	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestGetDBConnectionString_FailsFastWhenMissing")
-	cmd.Env = append(os.Environ(), "TEST_SUBPROCESS=1")
-
-	// Ensure DATABASE_URL is not set in subprocess
-	var filteredEnv []string
-	for _, env := range cmd.Env {
-		if !strings.HasPrefix(env, "DATABASE_URL=") {
-			filteredEnv = append(filteredEnv, env)
+func TestGetDBConnectionString_ReturnsErrorWhenMissing(t *testing.T) {
+	// Save original value
+	originalValue := os.Getenv("DATABASE_URL")
+	defer func() {
+		if originalValue != "" {
+			_ = os.Setenv("DATABASE_URL", originalValue)
+		} else {
+			_ = os.Unsetenv("DATABASE_URL")
 		}
-	}
-	cmd.Env = filteredEnv
+	}()
 
-	output, err := cmd.CombinedOutput()
+	// Unset DATABASE_URL and verify error is returned
+	_ = os.Unsetenv("DATABASE_URL")
 
-	// Expect the subprocess to exit with non-zero status
+	_, err := getDBConnectionString()
 	if err == nil {
-		t.Fatal("Expected process to exit with error when DATABASE_URL is missing, but it succeeded")
+		t.Fatal("Expected error when DATABASE_URL is missing, but got nil")
 	}
-
-	// Verify the error message explicitly mentions DATABASE_URL requirement
-	outputStr := string(output)
-	if !strings.Contains(outputStr, "DATABASE_URL environment variable is required") {
-		t.Errorf("Expected error message to mention 'DATABASE_URL environment variable is required', got: %s", outputStr)
+	if !errors.Is(err, ErrDatabaseURLRequired) {
+		t.Errorf("Expected ErrDatabaseURLRequired, got: %v", err)
 	}
 }

--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -58,9 +58,12 @@ func main() {
 		"commit", Commit,
 		"build_date", BuildDate)
 
-	// Run the service
-	if err := run(logger); err != nil {
-		logger.Error("service failed", "error", err)
+	// Run the service with retry for transient startup errors
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
 		os.Exit(1)
 	}
 

--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -80,9 +80,12 @@ func main() {
 	environment := env.GetEnvOrDefault("ENVIRONMENT", "production")
 	logger.Info("service environment configured", "environment", environment)
 
-	// Run the service
-	if err := run(logger); err != nil {
-		logger.Error("service failed", "error", err)
+	// Run the service with retry for transient startup errors
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
 		os.Exit(1)
 	}
 
@@ -151,7 +154,7 @@ func run(logger *slog.Logger) error {
 			if env.IsProduction() {
 				logger.Error("CRITICAL: Failed to create Kafka producer in production - failing fast",
 					"error", err)
-				return fmt.Errorf("%w: %w", ErrKafkaRequiredInProduction, err)
+				return bootstrap.Permanent(fmt.Errorf("%w: %w", ErrKafkaRequiredInProduction, err))
 			}
 			logger.Warn("failed to create Kafka producer for outbox worker - DEVELOPMENT ONLY",
 				"error", err,
@@ -167,7 +170,7 @@ func run(logger *slog.Logger) error {
 		if env.IsProduction() {
 			logger.Error("CRITICAL: Kafka unavailable in production - failing fast",
 				"reason", "KAFKA_BOOTSTRAP_SERVERS not set")
-			return ErrKafkaRequiredInProduction
+			return bootstrap.Permanent(ErrKafkaRequiredInProduction)
 		}
 		logger.Warn("outbox worker disabled - DEVELOPMENT ONLY",
 			"reason", "KAFKA_BOOTSTRAP_SERVERS not set",
@@ -185,15 +188,15 @@ func run(logger *slog.Logger) error {
 			"poll_interval", workerConfig.PollInterval)
 	}
 
-	// Validate bank cash account ID is configured
+	// Validate bank cash account ID is configured (permanent config error)
 	bankCashAccountID := env.GetEnvOrDefault("BANK_CASH_ACCOUNT_ID", "")
 	if bankCashAccountID == "" {
-		return ErrBankCashAccountIDRequired
+		return bootstrap.Permanent(ErrBankCashAccountIDRequired)
 	}
 
-	// Validate UUID format
+	// Validate UUID format (permanent config error)
 	if _, err := uuid.Parse(bankCashAccountID); err != nil {
-		return fmt.Errorf("%w: %w", ErrBankCashAccountIDInvalid, err)
+		return bootstrap.Permanent(fmt.Errorf("%w: %w", ErrBankCashAccountIDInvalid, err))
 	}
 
 	logger.Info("bank cash account configured",
@@ -253,7 +256,7 @@ func run(logger *slog.Logger) error {
 		if env.IsProduction() {
 			logger.Error("CRITICAL: Redis unavailable in production - failing fast",
 				"error", err)
-			return fmt.Errorf("%w: %w", ErrRedisRequiredInProduction, err)
+			return bootstrap.Permanent(fmt.Errorf("%w: %w", ErrRedisRequiredInProduction, err))
 		}
 		// Non-fatal in non-production: fall back to noop service for development/testing
 		logger.Warn("using noop idempotency service - DEVELOPMENT ONLY",

--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -491,14 +491,16 @@ func run(logger *slog.Logger) error {
 	sigChan, signalCleanup := bootstrap.SignalHandler()
 	defer signalCleanup()
 
+	var runErr error
 	select {
 	case sig := <-sigChan:
 		logger.Info("received signal", "signal", sig)
 	case err := <-serverErrors:
-		return fmt.Errorf("server error: %w", err)
+		logger.Error("server error", "error", err)
+		runErr = fmt.Errorf("server error: %w", err)
 	}
 
-	// Graceful shutdown
+	// Graceful shutdown (runs for both signal and server error paths)
 	logger.Info("shutting down server...")
 
 	// Create shutdown context with timeout
@@ -556,7 +558,7 @@ func run(logger *slog.Logger) error {
 		grpcServer.Stop()
 	}
 
-	return nil
+	return runErr
 }
 
 // createRedisClient creates and validates a Redis client connection.

--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -183,6 +183,9 @@ func run(logger *slog.Logger) error {
 		workerConfig := events.DefaultWorkerConfig("financial-accounting")
 		outboxWorker = events.NewWorker(outboxRepo, kafkaProducer, workerConfig, logger)
 		outboxWorker.Start(ctx)
+		// Ensure worker is stopped if run() returns early (e.g., init failure after this point).
+		// The shutdown block also calls Stop(), but calling it twice is safe.
+		defer outboxWorker.Stop()
 		logger.Info("outbox worker started",
 			"batch_size", workerConfig.BatchSize,
 			"poll_interval", workerConfig.PollInterval)

--- a/services/forecasting/cmd/main.go
+++ b/services/forecasting/cmd/main.go
@@ -55,8 +55,12 @@ func main() {
 		"commit", Commit,
 		"build_date", BuildDate)
 
-	if err := run(logger); err != nil {
-		logger.Error("service failed", "error", err)
+	// Run the service with retry for transient startup errors
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
 		os.Exit(1)
 	}
 

--- a/services/gateway/cmd/main.go
+++ b/services/gateway/cmd/main.go
@@ -37,9 +37,12 @@ func main() {
 		"commit", Commit,
 		"build_date", BuildDate)
 
-	// Run the service
-	if err := run(logger); err != nil {
-		logger.Error("service failed", "error", err)
+	// Run the service with retry for transient startup errors
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
 		os.Exit(1)
 	}
 
@@ -47,16 +50,16 @@ func main() {
 }
 
 func run(logger *slog.Logger) error {
-	// Load configuration
+	// Load configuration (permanent error if invalid)
 	config, err := gateway.LoadConfig()
 	if err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
+		return bootstrap.Permanent(fmt.Errorf("failed to load configuration: %w", err))
 	}
 
 	// Production safety check: LOCAL_DEV_MODE must not be enabled in production namespaces
 	namespace := os.Getenv("POD_NAMESPACE")
 	if err := config.ValidateForNamespace(namespace); err != nil {
-		return err
+		return bootstrap.Permanent(err)
 	}
 
 	logger.Info("configuration loaded",

--- a/services/gateway/cmd/main.go
+++ b/services/gateway/cmd/main.go
@@ -125,24 +125,26 @@ func run(logger *slog.Logger) error {
 	sigChan, signalCleanup := bootstrap.SignalHandler()
 	defer signalCleanup()
 
+	var runErr error
 	select {
 	case sig := <-sigChan:
 		logger.Info("received signal", "signal", sig)
 	case err := <-serverErrors:
-		return fmt.Errorf("server error: %w", err)
+		logger.Error("server error", "error", err)
+		runErr = fmt.Errorf("server error: %w", err)
 	}
 
-	// Graceful shutdown
+	// Graceful shutdown (runs for both signal and server error paths)
 	logger.Info("initiating graceful shutdown...")
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	if err := server.Shutdown(shutdownCtx); err != nil {
-		return fmt.Errorf("shutdown error: %w", err)
+		logger.Error("shutdown error", "error", err)
 	}
 
-	return nil
+	return runErr
 }
 
 // parseLogLevel converts a string log level to slog.Level.

--- a/services/internal-bank-account/cmd/main.go
+++ b/services/internal-bank-account/cmd/main.go
@@ -49,9 +49,12 @@ func main() {
 		"commit", Commit,
 		"build_date", BuildDate)
 
-	// Run the service
-	if err := run(logger); err != nil {
-		logger.Error("service failed", "error", err)
+	// Run the service with retry for transient startup errors
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
 		os.Exit(1)
 	}
 

--- a/services/market-information/cmd/main.go
+++ b/services/market-information/cmd/main.go
@@ -49,9 +49,12 @@ func main() {
 		"commit", Commit,
 		"build_date", BuildDate)
 
-	// Run the service
-	if err := run(logger); err != nil {
-		logger.Error("service failed", "error", err)
+	// Run the service with retry for transient startup errors
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
 		os.Exit(1)
 	}
 

--- a/services/party/cmd/main.go
+++ b/services/party/cmd/main.go
@@ -51,9 +51,12 @@ func main() {
 		"commit", Commit,
 		"build_date", BuildDate)
 
-	// Run the service
-	if err := run(logger); err != nil {
-		logger.Error("service failed", "error", err)
+	// Run the service with retry for transient startup errors
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
 		os.Exit(1)
 	}
 
@@ -104,14 +107,14 @@ func run(logger *slog.Logger) error {
 	verificationCfg, err := config.LoadVerificationConfig()
 	if err != nil {
 		if isProduction {
-			return fmt.Errorf("verification config required in production: %w", err)
+			return bootstrap.Permanent(fmt.Errorf("verification config required in production: %w", err))
 		}
 		logger.Warn("verification config not loaded - KYC provider disabled", "error", err)
 		verificationCfg = nil
 	}
 	if verificationCfg != nil {
 		if err := verificationCfg.ValidateForEnvironment(environment); err != nil {
-			return fmt.Errorf("verification config invalid for environment %q: %w", environment, err)
+			return bootstrap.Permanent(fmt.Errorf("verification config invalid for environment %q: %w", environment, err))
 		}
 	}
 

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -80,9 +80,12 @@ func main() {
 		"commit", Commit,
 		"build_date", BuildDate)
 
-	// Run the service
-	if err := run(logger); err != nil {
-		logger.Error("service failed", "error", err)
+	// Run the service with retry for transient startup errors
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
 		os.Exit(1)
 	}
 
@@ -92,10 +95,10 @@ func main() {
 func run(logger *slog.Logger) error {
 	ctx := context.Background()
 
-	// Load and validate service configuration early (fail fast).
+	// Load and validate service configuration early (permanent error if invalid)
 	svcConfig := config.LoadServiceConfig()
 	if err := svcConfig.Validate(); err != nil {
-		return fmt.Errorf("invalid service configuration: %w", err)
+		return bootstrap.Permanent(fmt.Errorf("invalid service configuration: %w", err))
 	}
 	svcConfig.LogValues(logger)
 
@@ -438,7 +441,7 @@ func run(logger *slog.Logger) error {
 	// Create HTTP webhook handler
 	hmacSecret := []byte(env.GetEnvOrDefault("WEBHOOK_HMAC_SECRET", ""))
 	if len(hmacSecret) == 0 {
-		return ErrMissingHMACSecret
+		return bootstrap.Permanent(ErrMissingHMACSecret)
 	}
 
 	// Create a gRPC client wrapper for the local service

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -548,6 +548,15 @@ func run(logger *slog.Logger) error {
 	case err := <-serverErrors:
 		logger.Error("server error", "error", err)
 		runErr = err
+
+		// Prefer graceful exit if a shutdown signal is already pending.
+		// Without this, RunWithRetry would retry despite SIGTERM intent.
+		select {
+		case sig := <-sigChan:
+			logger.Info("received signal during error handling, treating as shutdown", "signal", sig)
+			runErr = nil
+		default:
+		}
 	}
 
 	// Graceful shutdown (runs for both signal and server error paths)

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -541,14 +541,16 @@ func run(logger *slog.Logger) error {
 	sigChan, signalCleanup := bootstrap.SignalHandler()
 	defer signalCleanup()
 
+	var runErr error
 	select {
 	case sig := <-sigChan:
 		logger.Info("received signal", "signal", sig)
 	case err := <-serverErrors:
-		return err
+		logger.Error("server error", "error", err)
+		runErr = err
 	}
 
-	// Graceful shutdown
+	// Graceful shutdown (runs for both signal and server error paths)
 	logger.Info("shutting down servers...")
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), defaults.DefaultGracefulShutdown)
@@ -589,7 +591,7 @@ func run(logger *slog.Logger) error {
 		grpcServer.Stop()
 	}
 
-	return nil
+	return runErr
 }
 
 // localPaymentOrderClient wraps the local service to implement the client interface.

--- a/services/position-keeping/cmd/main.go
+++ b/services/position-keeping/cmd/main.go
@@ -441,16 +441,19 @@ func run(logger *slog.Logger) error {
 	sigChan, signalCleanup := bootstrap.SignalHandler()
 	defer signalCleanup()
 
+	var runErr error
 	select {
 	case sig := <-sigChan:
 		logger.Info("received signal", "signal", sig)
 	case err := <-grpcErrors:
-		return fmt.Errorf("gRPC server error: %w", err)
+		logger.Error("gRPC server error", "error", err)
+		runErr = fmt.Errorf("gRPC server error: %w", err)
 	case err := <-httpErrors:
-		return fmt.Errorf("HTTP server error: %w", err)
+		logger.Error("HTTP server error", "error", err)
+		runErr = fmt.Errorf("HTTP server error: %w", err)
 	}
 
-	// Graceful shutdown
+	// Graceful shutdown (runs for both signal and error paths)
 	logger.Info("shutting down servers...")
 
 	// Shutdown outbox worker before stopping servers.
@@ -502,7 +505,7 @@ func run(logger *slog.Logger) error {
 		grpcServer.Stop()
 	}
 
-	return nil
+	return runErr
 }
 
 // healthServer implements the gRPC health checking protocol

--- a/services/position-keeping/cmd/main.go
+++ b/services/position-keeping/cmd/main.go
@@ -85,9 +85,12 @@ func main() {
 		"commit", Commit,
 		"build_date", BuildDate)
 
-	// Run the service
-	if err := run(logger); err != nil {
-		logger.Error("service failed", "error", err)
+	// Run the service with retry for transient startup errors
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
 		os.Exit(1)
 	}
 
@@ -97,10 +100,10 @@ func main() {
 func run(logger *slog.Logger) error {
 	ctx := context.Background()
 
-	// Load configuration
+	// Load configuration (permanent error if invalid)
 	config, err := app.LoadConfig()
 	if err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
+		return bootstrap.Permanent(fmt.Errorf("failed to load configuration: %w", err))
 	}
 
 	// Override observability config with build info

--- a/services/reconciliation/cmd/main.go
+++ b/services/reconciliation/cmd/main.go
@@ -52,8 +52,12 @@ func main() {
 		"commit", Commit,
 		"build_date", BuildDate)
 
-	if err := run(logger); err != nil {
-		logger.Error("service failed", "error", err)
+	// Run the service with retry for transient startup errors
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
 		os.Exit(1)
 	}
 
@@ -63,10 +67,10 @@ func main() {
 func run(logger *slog.Logger) error {
 	ctx := context.Background()
 
-	// Load configuration
+	// Load configuration (permanent error if invalid)
 	cfg, err := config.LoadConfig()
 	if err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
+		return bootstrap.Permanent(fmt.Errorf("failed to load configuration: %w", err))
 	}
 
 	logger.Info("configuration loaded",

--- a/services/reconciliation/cmd/main.go
+++ b/services/reconciliation/cmd/main.go
@@ -332,14 +332,16 @@ func run(logger *slog.Logger) error {
 	sigChan, signalCleanup := bootstrap.SignalHandler()
 	defer signalCleanup()
 
+	var runErr error
 	select {
 	case sig := <-sigChan:
 		logger.Info("received signal", "signal", sig)
 	case err := <-serverErrors:
-		return fmt.Errorf("server error: %w", err)
+		logger.Error("server error", "error", err)
+		runErr = fmt.Errorf("server error: %w", err)
 	}
 
-	// Graceful shutdown
+	// Graceful shutdown (runs for both signal and server error paths)
 	logger.Info("shutting down servers...")
 
 	// Stop scheduler first (it makes gRPC calls to self)
@@ -368,7 +370,7 @@ func run(logger *slog.Logger) error {
 		grpcServer.Stop()
 	}
 
-	return nil
+	return runErr
 }
 
 // wireScheduler creates and configures the CronScheduler with all its dependencies.

--- a/services/reference-data/cmd/main.go
+++ b/services/reference-data/cmd/main.go
@@ -51,8 +51,12 @@ func main() {
 		"commit", Commit,
 		"build_date", BuildDate)
 
-	if err := run(logger); err != nil {
-		logger.Error("service failed", "error", err)
+	// Run the service with retry for transient startup errors
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
 		os.Exit(1)
 	}
 

--- a/services/tenant/cmd/main.go
+++ b/services/tenant/cmd/main.go
@@ -97,9 +97,12 @@ func main() {
 		"commit", Commit,
 		"build_date", BuildDate)
 
-	// Run the service
-	if err := run(logger); err != nil {
-		logger.Error("service failed", "error", err)
+	// Run the service with retry for transient startup errors
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
 		os.Exit(1)
 	}
 
@@ -224,7 +227,7 @@ func run(logger *slog.Logger) error {
 	if provisioningEnabled == envValueTrue && schemaProvisioner != nil {
 		config, err := loadWorkerConfig()
 		if err != nil {
-			return fmt.Errorf("failed to load worker configuration: %w", err)
+			return bootstrap.Permanent(fmt.Errorf("failed to load worker configuration: %w", err))
 		}
 
 		provisioningWorker, err = worker.NewProvisioningWorker(

--- a/services/utilization-metering-consumer/cmd/main.go
+++ b/services/utilization-metering-consumer/cmd/main.go
@@ -106,9 +106,12 @@ func main() {
 		"commit", Commit,
 		"build_date", BuildDate)
 
-	// Run the service
-	if err := run(logger); err != nil {
-		logger.Error("service failed", "error", err)
+	// Run the service with retry for transient startup errors
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
 		os.Exit(1)
 	}
 
@@ -116,10 +119,10 @@ func main() {
 }
 
 func run(logger *slog.Logger) error {
-	// Load configuration
+	// Load configuration (permanent error if invalid)
 	config, err := app.LoadConfig()
 	if err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
+		return bootstrap.Permanent(fmt.Errorf("failed to load configuration: %w", err))
 	}
 
 	logger.Info("configuration loaded",
@@ -215,16 +218,16 @@ func run(logger *slog.Logger) error {
 			"mds_service_addr", config.MDSServiceAddr)
 	}
 
-	// Parse tenant zero ID
+	// Parse tenant zero ID (permanent error if invalid)
 	tenantZeroID, err := uuid.Parse(config.TenantZeroID)
 	if err != nil {
-		return fmt.Errorf("invalid TENANT_ZERO_ID: %w", err)
+		return bootstrap.Permanent(fmt.Errorf("invalid TENANT_ZERO_ID: %w", err))
 	}
 
-	// Load tenant-to-account mapping from configuration
+	// Load tenant-to-account mapping from configuration (permanent error if invalid)
 	tenantAccountMap, err := domain.ParseTenantAccountMapping(config.TenantAccountMapping)
 	if err != nil {
-		return fmt.Errorf("failed to load tenant account mapping: %w", err)
+		return bootstrap.Permanent(fmt.Errorf("failed to load tenant account mapping: %w", err))
 	}
 
 	// Ensure tenant-zero maps to itself if not explicitly configured

--- a/services/utilization-metering-consumer/cmd/main.go
+++ b/services/utilization-metering-consumer/cmd/main.go
@@ -292,16 +292,19 @@ func run(logger *slog.Logger) error {
 	sigChan, signalCleanup := bootstrap.SignalHandler()
 	defer signalCleanup()
 
+	var runErr error
 	select {
 	case sig := <-sigChan:
 		logger.Info("received signal", "signal", sig)
 	case err := <-serverErrors:
-		return fmt.Errorf("server error: %w", err)
+		logger.Error("server error", "error", err)
+		runErr = fmt.Errorf("server error: %w", err)
 	case err := <-consumerErrors:
-		return fmt.Errorf("consumer error: %w", err)
+		logger.Error("consumer error", "error", err)
+		runErr = fmt.Errorf("consumer error: %w", err)
 	}
 
-	// Graceful shutdown
+	// Graceful shutdown (runs for both signal and error paths)
 	logger.Info("shutting down server...")
 
 	// Create shutdown context with timeout
@@ -332,7 +335,7 @@ func run(logger *slog.Logger) error {
 		logger.Info("HTTP server stopped")
 	}
 
-	return nil
+	return runErr
 }
 
 // initMDSPublisher creates and returns a MarketDataPublisher and its underlying gRPC connection.

--- a/services/utilization-metering-consumer/cmd/main.go
+++ b/services/utilization-metering-consumer/cmd/main.go
@@ -154,6 +154,15 @@ func run(logger *slog.Logger) error {
 		}
 	}()
 
+	// Ensure the HTTP listener is released if init fails and RunWithRetry restarts.
+	// On the happy path, httpServer.Shutdown in the shutdown block closes it first,
+	// so the deferred Close sees ErrServerClosed (which we ignore).
+	defer func() {
+		if err := httpServer.Close(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Warn("failed to close HTTP server", "error", err)
+		}
+	}()
+
 	// Initialize Position Keeping client
 	logger.Info("initializing position keeping client", "endpoint", config.PositionKeepingEndpoint)
 


### PR DESCRIPTION
## Summary

- Wrap each service's `run()` function with `bootstrap.RunWithRetry` in `main()` so transient startup errors (database unavailable, Kafka not ready) are retried with exponential backoff
- Annotate permanent configuration errors (missing env vars, invalid UUIDs, schema validation) with `bootstrap.Permanent()` to fail fast without retry
- Restructure `audit-worker` and `audit-consumer` from `log.Fatal`/`os.Exit` patterns into proper `run()` functions returning errors for RunWithRetry compatibility

## Services Updated (15)

| Service | RunWithRetry | Permanent Errors |
|---------|:---:|:---:|
| tenant | Y | WorkerConfig validation |
| current-account | Y | - |
| position-keeping | Y | LoadConfig |
| financial-accounting | Y | BANK_CASH_ACCOUNT_ID, Kafka/Redis in prod |
| party | Y | Verification config, ValidateForEnvironment |
| internal-bank-account | Y | - |
| reference-data | Y | - |
| market-information | Y | - |
| reconciliation | Y | LoadConfig |
| payment-order | Y | svcConfig.Validate, HMAC secret |
| audit-worker | Y | DATABASE_URL, AUDIT_SCHEMA |
| audit-consumer | Y | LoadConfig |
| utilization-metering-consumer | Y | LoadConfig, TENANT_ZERO_ID, tenant mapping |
| gateway | Y | LoadConfig, ValidateForNamespace |
| forecasting | Y | - |

## Test plan

- [x] All services compile: `go build ./services/... ./cmd/...`
- [x] Pre-commit lint passes (golangci-lint, gofumpt, gitleaks)
- [x] Existing audit-worker tests updated for new error-returning signatures
- [ ] CI passes all checks

Task: startup-resilience.8