### PR TITLE
feat: add embedded migration runner for unified binary

### DIFF
--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -1,0 +1,48 @@
+// Package main is the entry point for the Meridian unified binary.
+//
+// It supports a --migrate flag that applies all embedded service migrations
+// to CockroachDB before starting the application.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/meridianhub/meridian/internal/migrations"
+	"github.com/meridianhub/meridian/services"
+)
+
+func main() {
+	migrate := flag.Bool("migrate", false, "Apply all embedded SQL migrations to CockroachDB and exit")
+	databaseURL := flag.String("database-url", "", "Superuser DSN for CockroachDB (e.g., postgres://root@localhost:26257/defaultdb?sslmode=disable)")
+	flag.Parse()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	if *migrate {
+		dsn := *databaseURL
+		if dsn == "" {
+			dsn = os.Getenv("DATABASE_URL")
+		}
+		if dsn == "" {
+			fmt.Fprintln(os.Stderr, "error: --database-url flag or DATABASE_URL environment variable required for --migrate")
+			os.Exit(1)
+		}
+
+		ctx := context.Background()
+		if err := migrations.RunMigrations(ctx, services.MigrationFS, dsn, logger); err != nil {
+			logger.Error("migration failed", "error", err)
+			os.Exit(1)
+		}
+
+		logger.Info("all migrations applied successfully")
+		return
+	}
+
+	fmt.Println("meridian: unified binary (use --migrate to apply database migrations)")
+}

--- a/internal/migrations/runner.go
+++ b/internal/migrations/runner.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -170,21 +171,21 @@ func provisionAll(ctx context.Context, superuserDSN string, databases map[string
 }
 
 // provisionDatabases creates databases and users as needed.
+// Each DDL statement is executed individually because pgx v5's extended
+// protocol does not support multi-statement query strings.
 func provisionDatabases(ctx context.Context, conn *pgx.Conn, databases map[string]ServiceDatabase, logger *slog.Logger) error {
 	for dbName, sdb := range databases {
 		logger.Info("provisioning database", "database", dbName, "user", sdb.User)
 
-		sql := fmt.Sprintf(
-			`CREATE DATABASE IF NOT EXISTS %s;
-			 CREATE USER IF NOT EXISTS %s;
-			 GRANT ALL ON DATABASE %s TO %s;`,
-			quoteIdent(dbName),
-			quoteIdent(sdb.User),
-			quoteIdent(dbName),
-			quoteIdent(sdb.User),
-		)
-		if _, err := conn.Exec(ctx, sql); err != nil {
-			return fmt.Errorf("provision %s: %w", dbName, err)
+		stmts := []string{
+			fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", quoteIdent(dbName)),
+			fmt.Sprintf("CREATE USER IF NOT EXISTS %s", quoteIdent(sdb.User)),
+			fmt.Sprintf("GRANT ALL ON DATABASE %s TO %s", quoteIdent(dbName), quoteIdent(sdb.User)),
+		}
+		for _, stmt := range stmts {
+			if _, err := conn.Exec(ctx, stmt); err != nil {
+				return fmt.Errorf("provision %s: %w", dbName, err)
+			}
 		}
 	}
 	return nil
@@ -307,38 +308,38 @@ func recordMigration(ctx context.Context, conn *pgx.Conn, service, filename stri
 }
 
 // buildServiceDSN modifies a superuser DSN to target a specific database and user.
-// It parses the DSN, replaces the database name and user, then builds a postgres:// URL.
+// It parses the URL, replaces user/database, and preserves all query parameters
+// (TLS settings, timeouts, etc.). It also sets simple_protocol exec mode so that
+// multi-statement migration files can be executed in a single Exec() call.
 func buildServiceDSN(superuserDSN string, sdb ServiceDatabase) string {
-	cfg, err := pgx.ParseConfig(superuserDSN)
+	parsed, err := url.Parse(superuserDSN)
 	if err != nil {
 		return superuserDSN
 	}
 
-	cfg.Database = sdb.Database
-	cfg.User = sdb.User
+	// Replace user credentials.
 	if sdb.Password != "" {
-		cfg.Password = sdb.Password
+		parsed.User = url.UserPassword(sdb.User, sdb.Password)
+	} else {
+		parsed.User = url.User(sdb.User)
 	}
 
-	// Build a proper postgres:// URL since ConnString() may return
-	// a registered config reference that doesn't work for new connections.
-	host := cfg.Host
-	port := cfg.Port
-	if port == 0 {
-		port = 26257
+	// Replace database in path (postgres://user@host:port/database).
+	parsed.Path = "/" + sdb.Database
+
+	// Ensure default port for CockroachDB if not specified.
+	if parsed.Port() == "" {
+		parsed.Host = parsed.Hostname() + ":26257"
 	}
 
-	sslmode := "disable"
-	if cfg.TLSConfig != nil {
-		sslmode = "require"
+	// Enable simple protocol so multi-statement migration SQL files work with pgx v5.
+	q := parsed.Query()
+	if q.Get("default_query_exec_mode") == "" {
+		q.Set("default_query_exec_mode", "simple_protocol")
 	}
+	parsed.RawQuery = q.Encode()
 
-	if sdb.Password != "" {
-		return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
-			sdb.User, sdb.Password, host, port, sdb.Database, sslmode)
-	}
-	return fmt.Sprintf("postgres://%s@%s:%d/%s?sslmode=%s",
-		sdb.User, host, port, sdb.Database, sslmode)
+	return parsed.String()
 }
 
 // quoteIdent wraps a SQL identifier in double quotes, escaping any embedded double quotes.

--- a/internal/migrations/runner.go
+++ b/internal/migrations/runner.go
@@ -1,0 +1,347 @@
+// Package migrations provides an embedded migration runner that applies
+// SQL migration files from an embed.FS to CockroachDB databases.
+//
+// It handles database and user provisioning, migration tracking via
+// a _meridian_migrations table, and idempotent re-runs.
+package migrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// ErrUnknownService is returned when a migration file belongs to a service
+// that has no entry in ServiceDatabases.
+var ErrUnknownService = errors.New("unknown service: no database mapping")
+
+// ServiceDatabase maps a service directory name to its target database, user, and password.
+type ServiceDatabase struct {
+	Database string
+	User     string
+	Password string
+}
+
+// ServiceDatabases defines the mapping from service directory names to
+// CockroachDB database names, users, and passwords.
+//
+// Two services (tenant, control-plane) share meridian_platform.
+// Their migrations are applied in service-name order (control-plane before tenant).
+var ServiceDatabases = map[string]ServiceDatabase{
+	"control-plane":         {Database: "meridian_platform", User: "meridian_platform_user", Password: ""},
+	"tenant":                {Database: "meridian_platform", User: "meridian_platform_user", Password: ""},
+	"current-account":       {Database: "meridian_current_account", User: "meridian_current_account_user", Password: ""},
+	"financial-accounting":  {Database: "meridian_financial_accounting", User: "meridian_financial_accounting_user", Password: ""},
+	"position-keeping":      {Database: "meridian_position_keeping", User: "meridian_position_keeping_user", Password: ""},
+	"payment-order":         {Database: "meridian_payment_order", User: "meridian_payment_order_user", Password: ""},
+	"party":                 {Database: "meridian_party", User: "meridian_party_user", Password: ""},
+	"internal-bank-account": {Database: "meridian_internal_bank_account", User: "meridian_internal_bank_account_user", Password: ""},
+	"market-information":    {Database: "meridian_market_information", User: "meridian_market_information_user", Password: ""},
+	"reconciliation":        {Database: "meridian_reconciliation", User: "meridian_reconciliation_user", Password: ""},
+	"forecasting":           {Database: "meridian_forecasting", User: "meridian_forecasting_user", Password: ""},
+	"reference-data":        {Database: "meridian_reference_data", User: "meridian_reference_data_user", Password: ""},
+}
+
+// serviceMigration holds a single migration file for a service.
+type serviceMigration struct {
+	Service  string
+	Filename string
+	SQL      string
+}
+
+// RunMigrations discovers migration files from the provided embed.FS, provisions
+// databases and users as superuser, then applies unapplied migrations in order.
+//
+// The superuserDSN should connect to CockroachDB as a privileged user (e.g., root)
+// capable of CREATE DATABASE, CREATE USER, and GRANT operations.
+//
+// Migration state is tracked per-database in a _meridian_migrations table.
+// Running this function multiple times is safe (idempotent).
+func RunMigrations(ctx context.Context, migrationFS fs.FS, superuserDSN string, logger *slog.Logger) error {
+	migrations, err := discoverMigrations(migrationFS)
+	if err != nil {
+		return fmt.Errorf("discover migrations: %w", err)
+	}
+
+	if len(migrations) == 0 {
+		logger.Info("no migrations found")
+		return nil
+	}
+
+	// Collect unique databases to provision.
+	dbSet := make(map[string]ServiceDatabase)
+	for _, m := range migrations {
+		sdb, ok := ServiceDatabases[m.Service]
+		if !ok {
+			return fmt.Errorf("service %q: %w", m.Service, ErrUnknownService)
+		}
+		dbSet[sdb.Database] = sdb
+	}
+
+	// Connect as superuser to provision databases and users, then close.
+	if err := provisionAll(ctx, superuserDSN, dbSet, logger); err != nil {
+		return err
+	}
+
+	// Group migrations by target database.
+	byDB := groupByDatabase(migrations)
+
+	// Apply migrations to each database.
+	for dbName, dbMigrations := range byDB {
+		sdb := dbMigrations[0].sdb
+		dsn := buildServiceDSN(superuserDSN, sdb)
+
+		if err := applyDatabaseMigrations(ctx, dsn, dbName, dbMigrations, logger); err != nil {
+			return fmt.Errorf("apply migrations to %s: %w", dbName, err)
+		}
+	}
+
+	return nil
+}
+
+// discoverMigrations reads migration SQL files from the embedded filesystem.
+// It expects paths of the form: <service>/migrations/<filename>.sql
+func discoverMigrations(migrationFS fs.FS) ([]serviceMigration, error) {
+	var migrations []serviceMigration
+
+	err := fs.WalkDir(migrationFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".sql") {
+			return nil
+		}
+
+		// Expected path: <service>/migrations/<filename>.sql
+		parts := strings.Split(path, "/")
+		if len(parts) != 3 || parts[1] != "migrations" {
+			return nil
+		}
+
+		service := parts[0]
+		filename := parts[2]
+
+		content, err := fs.ReadFile(migrationFS, path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+
+		migrations = append(migrations, serviceMigration{
+			Service:  service,
+			Filename: filename,
+			SQL:      string(content),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort by service name then filename for deterministic ordering.
+	sort.Slice(migrations, func(i, j int) bool {
+		if migrations[i].Service != migrations[j].Service {
+			return migrations[i].Service < migrations[j].Service
+		}
+		return migrations[i].Filename < migrations[j].Filename
+	})
+
+	return migrations, nil
+}
+
+// provisionAll connects as superuser, provisions databases, and closes the connection.
+func provisionAll(ctx context.Context, superuserDSN string, databases map[string]ServiceDatabase, logger *slog.Logger) error {
+	superConn, err := pgx.Connect(ctx, superuserDSN)
+	if err != nil {
+		return fmt.Errorf("connect as superuser: %w", err)
+	}
+	defer func() { _ = superConn.Close(ctx) }()
+
+	return provisionDatabases(ctx, superConn, databases, logger)
+}
+
+// provisionDatabases creates databases and users as needed.
+func provisionDatabases(ctx context.Context, conn *pgx.Conn, databases map[string]ServiceDatabase, logger *slog.Logger) error {
+	for dbName, sdb := range databases {
+		logger.Info("provisioning database", "database", dbName, "user", sdb.User)
+
+		sql := fmt.Sprintf(
+			`CREATE DATABASE IF NOT EXISTS %s;
+			 CREATE USER IF NOT EXISTS %s;
+			 GRANT ALL ON DATABASE %s TO %s;`,
+			quoteIdent(dbName),
+			quoteIdent(sdb.User),
+			quoteIdent(dbName),
+			quoteIdent(sdb.User),
+		)
+		if _, err := conn.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("provision %s: %w", dbName, err)
+		}
+	}
+	return nil
+}
+
+type dbMigration struct {
+	sdb      ServiceDatabase
+	service  string
+	filename string
+	sql      string
+}
+
+// groupByDatabase groups migrations by their target database name.
+// Within each database, migrations are sorted by filename (lexicographic).
+func groupByDatabase(migrations []serviceMigration) map[string][]dbMigration {
+	result := make(map[string][]dbMigration)
+
+	for _, m := range migrations {
+		sdb := ServiceDatabases[m.Service]
+		result[sdb.Database] = append(result[sdb.Database], dbMigration{
+			sdb:      sdb,
+			service:  m.Service,
+			filename: m.Filename,
+			sql:      m.SQL,
+		})
+	}
+
+	// Sort each database's migrations by service then filename.
+	for _, dbMigs := range result {
+		sort.Slice(dbMigs, func(i, j int) bool {
+			if dbMigs[i].service != dbMigs[j].service {
+				return dbMigs[i].service < dbMigs[j].service
+			}
+			return dbMigs[i].filename < dbMigs[j].filename
+		})
+	}
+
+	return result
+}
+
+// applyDatabaseMigrations connects to a specific database and applies unapplied migrations.
+func applyDatabaseMigrations(ctx context.Context, dsn, dbName string, migrations []dbMigration, logger *slog.Logger) error {
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		return fmt.Errorf("connect to %s: %w", dbName, err)
+	}
+	defer func() { _ = conn.Close(ctx) }()
+
+	if err := ensureMigrationsTable(ctx, conn); err != nil {
+		return fmt.Errorf("create tracking table: %w", err)
+	}
+
+	applied, err := getAppliedMigrations(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("read applied migrations: %w", err)
+	}
+
+	for _, m := range migrations {
+		key := m.service + "/" + m.filename
+		if applied[key] {
+			logger.Debug("skipping already applied migration", "database", dbName, "service", m.service, "file", m.filename)
+			continue
+		}
+
+		logger.Info("applying migration", "database", dbName, "service", m.service, "file", m.filename)
+
+		if _, err := conn.Exec(ctx, m.sql); err != nil {
+			return fmt.Errorf("execute %s/%s: %w", m.service, m.filename, err)
+		}
+
+		if err := recordMigration(ctx, conn, m.service, m.filename); err != nil {
+			return fmt.Errorf("record %s/%s: %w", m.service, m.filename, err)
+		}
+	}
+
+	return nil
+}
+
+// ensureMigrationsTable creates the _meridian_migrations tracking table if it does not exist.
+func ensureMigrationsTable(ctx context.Context, conn *pgx.Conn) error {
+	_, err := conn.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS _meridian_migrations (
+			id          INT8 NOT NULL DEFAULT unique_rowid(),
+			service     VARCHAR(255) NOT NULL,
+			filename    VARCHAR(255) NOT NULL,
+			applied_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+			PRIMARY KEY (id),
+			UNIQUE (service, filename)
+		)
+	`)
+	return err
+}
+
+// getAppliedMigrations returns a set of "service/filename" keys for already-applied migrations.
+func getAppliedMigrations(ctx context.Context, conn *pgx.Conn) (map[string]bool, error) {
+	rows, err := conn.Query(ctx, `SELECT service, filename FROM _meridian_migrations`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	applied := make(map[string]bool)
+	for rows.Next() {
+		var service, filename string
+		if err := rows.Scan(&service, &filename); err != nil {
+			return nil, err
+		}
+		applied[service+"/"+filename] = true
+	}
+	return applied, rows.Err()
+}
+
+// recordMigration inserts a record into _meridian_migrations for a successfully applied migration.
+func recordMigration(ctx context.Context, conn *pgx.Conn, service, filename string) error {
+	_, err := conn.Exec(ctx,
+		`INSERT INTO _meridian_migrations (service, filename, applied_at) VALUES ($1, $2, $3)`,
+		service, filename, time.Now(),
+	)
+	return err
+}
+
+// buildServiceDSN modifies a superuser DSN to target a specific database and user.
+// It parses the DSN, replaces the database name and user, then builds a postgres:// URL.
+func buildServiceDSN(superuserDSN string, sdb ServiceDatabase) string {
+	cfg, err := pgx.ParseConfig(superuserDSN)
+	if err != nil {
+		return superuserDSN
+	}
+
+	cfg.Database = sdb.Database
+	cfg.User = sdb.User
+	if sdb.Password != "" {
+		cfg.Password = sdb.Password
+	}
+
+	// Build a proper postgres:// URL since ConnString() may return
+	// a registered config reference that doesn't work for new connections.
+	host := cfg.Host
+	port := cfg.Port
+	if port == 0 {
+		port = 26257
+	}
+
+	sslmode := "disable"
+	if cfg.TLSConfig != nil {
+		sslmode = "require"
+	}
+
+	if sdb.Password != "" {
+		return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
+			sdb.User, sdb.Password, host, port, sdb.Database, sslmode)
+	}
+	return fmt.Sprintf("postgres://%s@%s:%d/%s?sslmode=%s",
+		sdb.User, host, port, sdb.Database, sslmode)
+}
+
+// quoteIdent wraps a SQL identifier in double quotes, escaping any embedded double quotes.
+func quoteIdent(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}

--- a/internal/migrations/runner_test.go
+++ b/internal/migrations/runner_test.go
@@ -1,0 +1,343 @@
+package migrations_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/meridianhub/meridian/internal/migrations"
+	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
+)
+
+// setupTestCockroachDB starts a CockroachDB testcontainer and returns a
+// root DSN and cleanup function.
+func setupTestCockroachDB(t *testing.T) (string, func()) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	container, err := cockroachdb.Run(ctx,
+		"cockroachdb/cockroach:v24.3.0",
+		cockroachdb.WithDatabase("defaultdb"),
+		cockroachdb.WithUser("root"),
+		cockroachdb.WithInsecure(),
+	)
+	if err != nil {
+		t.Fatalf("start CockroachDB container: %v", err)
+	}
+
+	connConfig, err := container.ConnectionConfig(ctx)
+	if err != nil {
+		t.Fatalf("get connection config: %v", err)
+	}
+	dsn := fmt.Sprintf("postgres://%s@%s:%d/%s?sslmode=disable",
+		connConfig.User, connConfig.Host, connConfig.Port, connConfig.Database)
+
+	cleanup := func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		_ = container.Terminate(cleanupCtx)
+	}
+
+	return dsn, cleanup
+}
+
+// testMigrationFS creates a test embed.FS with dummy SQL migrations for two services.
+func testMigrationFS() fstest.MapFS {
+	return fstest.MapFS{
+		"current-account/migrations/20240101000001_create_accounts.sql": &fstest.MapFile{
+			Data: []byte(`CREATE TABLE IF NOT EXISTS account (
+				id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+				name VARCHAR(255) NOT NULL,
+				created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+			);`),
+		},
+		"current-account/migrations/20240101000002_add_status.sql": &fstest.MapFile{
+			Data: []byte(`ALTER TABLE account ADD COLUMN IF NOT EXISTS status VARCHAR(50) DEFAULT 'ACTIVE';`),
+		},
+		"party/migrations/20240101000001_create_parties.sql": &fstest.MapFile{
+			Data: []byte(`CREATE TABLE IF NOT EXISTS party (
+				id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+				name VARCHAR(255) NOT NULL
+			);`),
+		},
+	}
+}
+
+func TestRunMigrations(t *testing.T) {
+	if os.Getenv("CI") == "" && testing.Short() {
+		t.Skip("skipping integration test; use -short=false or set CI=true")
+	}
+
+	dsn, cleanup := setupTestCockroachDB(t)
+	defer cleanup()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	ctx := context.Background()
+	testFS := testMigrationFS()
+
+	err := migrations.RunMigrations(ctx, testFS, dsn, logger)
+	if err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+
+	// Verify databases were created.
+	rootConn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect to verify: %v", err)
+	}
+	defer rootConn.Close(ctx)
+
+	for _, dbName := range []string{"meridian_current_account", "meridian_party"} {
+		var exists bool
+		err := rootConn.QueryRow(ctx,
+			`SELECT EXISTS(SELECT 1 FROM [SHOW DATABASES] WHERE database_name = $1)`,
+			dbName,
+		).Scan(&exists)
+		if err != nil {
+			t.Fatalf("check database %s: %v", dbName, err)
+		}
+		if !exists {
+			t.Errorf("database %s was not created", dbName)
+		}
+	}
+
+	// Verify migrations were recorded in current-account database.
+	caDSN := replaceDSNDatabase(t, dsn, "meridian_current_account")
+	caConn, err := pgx.Connect(ctx, caDSN)
+	if err != nil {
+		t.Fatalf("connect to meridian_current_account: %v", err)
+	}
+	defer caConn.Close(ctx)
+
+	var count int
+	err = caConn.QueryRow(ctx, `SELECT count(*) FROM _meridian_migrations`).Scan(&count)
+	if err != nil {
+		t.Fatalf("count migrations in current_account: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 migrations recorded in current_account, got %d", count)
+	}
+
+	// Verify the account table exists with the status column.
+	var hasStatus bool
+	err = caConn.QueryRow(ctx,
+		`SELECT EXISTS(
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'account' AND column_name = 'status'
+		)`,
+	).Scan(&hasStatus)
+	if err != nil {
+		t.Fatalf("check status column: %v", err)
+	}
+	if !hasStatus {
+		t.Error("account table missing status column")
+	}
+
+	// Verify party database migrations.
+	partyDSN := replaceDSNDatabase(t, dsn, "meridian_party")
+	partyConn, err := pgx.Connect(ctx, partyDSN)
+	if err != nil {
+		t.Fatalf("connect to meridian_party: %v", err)
+	}
+	defer partyConn.Close(ctx)
+
+	err = partyConn.QueryRow(ctx, `SELECT count(*) FROM _meridian_migrations`).Scan(&count)
+	if err != nil {
+		t.Fatalf("count migrations in party: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 migration recorded in party, got %d", count)
+	}
+}
+
+func TestRunMigrations_Idempotent(t *testing.T) {
+	if os.Getenv("CI") == "" && testing.Short() {
+		t.Skip("skipping integration test; use -short=false or set CI=true")
+	}
+
+	dsn, cleanup := setupTestCockroachDB(t)
+	defer cleanup()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	ctx := context.Background()
+	testFS := testMigrationFS()
+
+	// Run first time.
+	if err := migrations.RunMigrations(ctx, testFS, dsn, logger); err != nil {
+		t.Fatalf("first RunMigrations: %v", err)
+	}
+
+	// Run second time - should be idempotent.
+	if err := migrations.RunMigrations(ctx, testFS, dsn, logger); err != nil {
+		t.Fatalf("second RunMigrations: %v", err)
+	}
+
+	// Verify no duplicate records.
+	caDSN := replaceDSNDatabase(t, dsn, "meridian_current_account")
+	caConn, err := pgx.Connect(ctx, caDSN)
+	if err != nil {
+		t.Fatalf("connect to meridian_current_account: %v", err)
+	}
+	defer caConn.Close(ctx)
+
+	var count int
+	err = caConn.QueryRow(ctx, `SELECT count(*) FROM _meridian_migrations`).Scan(&count)
+	if err != nil {
+		t.Fatalf("count migrations: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 migrations (no duplicates), got %d", count)
+	}
+}
+
+func TestRunMigrations_SharedDatabase(t *testing.T) {
+	if os.Getenv("CI") == "" && testing.Short() {
+		t.Skip("skipping integration test; use -short=false or set CI=true")
+	}
+
+	dsn, cleanup := setupTestCockroachDB(t)
+	defer cleanup()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	ctx := context.Background()
+
+	// Both tenant and control-plane target meridian_platform.
+	testFS := fstest.MapFS{
+		"control-plane/migrations/20240101000001_staff.sql": &fstest.MapFile{
+			Data: []byte(`CREATE TABLE IF NOT EXISTS staff_user (
+				id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+				email VARCHAR(255) NOT NULL
+			);`),
+		},
+		"tenant/migrations/20240101000001_tenants.sql": &fstest.MapFile{
+			Data: []byte(`CREATE TABLE IF NOT EXISTS tenant_registry (
+				id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+				name VARCHAR(255) NOT NULL
+			);`),
+		},
+	}
+
+	if err := migrations.RunMigrations(ctx, testFS, dsn, logger); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+
+	// Both tables should exist in meridian_platform.
+	platformDSN := replaceDSNDatabase(t, dsn, "meridian_platform")
+	conn, err := pgx.Connect(ctx, platformDSN)
+	if err != nil {
+		t.Fatalf("connect to meridian_platform: %v", err)
+	}
+	defer conn.Close(ctx)
+
+	for _, table := range []string{"staff_user", "tenant_registry"} {
+		var exists bool
+		err := conn.QueryRow(ctx,
+			`SELECT EXISTS(
+				SELECT 1 FROM information_schema.tables
+				WHERE table_name = $1
+			)`,
+			table,
+		).Scan(&exists)
+		if err != nil {
+			t.Fatalf("check table %s: %v", table, err)
+		}
+		if !exists {
+			t.Errorf("table %s not found in meridian_platform", table)
+		}
+	}
+
+	// Verify migration tracking records both services.
+	var count int
+	err = conn.QueryRow(ctx, `SELECT count(DISTINCT service) FROM _meridian_migrations`).Scan(&count)
+	if err != nil {
+		t.Fatalf("count services: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 distinct services in migration tracking, got %d", count)
+	}
+}
+
+func TestRunMigrations_NoMigrations(t *testing.T) {
+	if os.Getenv("CI") == "" && testing.Short() {
+		t.Skip("skipping integration test; use -short=false or set CI=true")
+	}
+
+	dsn, cleanup := setupTestCockroachDB(t)
+	defer cleanup()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	ctx := context.Background()
+
+	emptyFS := fstest.MapFS{}
+
+	if err := migrations.RunMigrations(ctx, emptyFS, dsn, logger); err != nil {
+		t.Fatalf("RunMigrations with empty FS: %v", err)
+	}
+}
+
+func TestRunMigrations_FailingMigration(t *testing.T) {
+	if os.Getenv("CI") == "" && testing.Short() {
+		t.Skip("skipping integration test; use -short=false or set CI=true")
+	}
+
+	dsn, cleanup := setupTestCockroachDB(t)
+	defer cleanup()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	ctx := context.Background()
+
+	testFS := fstest.MapFS{
+		"current-account/migrations/20240101000001_good.sql": &fstest.MapFile{
+			Data: []byte(`CREATE TABLE IF NOT EXISTS good_table (id UUID PRIMARY KEY DEFAULT gen_random_uuid());`),
+		},
+		"current-account/migrations/20240101000002_bad.sql": &fstest.MapFile{
+			Data: []byte(`THIS IS NOT VALID SQL;`),
+		},
+	}
+
+	err := migrations.RunMigrations(ctx, testFS, dsn, logger)
+	if err == nil {
+		t.Fatal("expected error for invalid SQL migration, got nil")
+	}
+
+	// The first migration should have been applied, but the second should have failed.
+	caDSN := replaceDSNDatabase(t, dsn, "meridian_current_account")
+	caConn, err2 := pgx.Connect(ctx, caDSN)
+	if err2 != nil {
+		t.Fatalf("connect to meridian_current_account: %v", err2)
+	}
+	defer caConn.Close(ctx)
+
+	var count int
+	err2 = caConn.QueryRow(ctx, `SELECT count(*) FROM _meridian_migrations`).Scan(&count)
+	if err2 != nil {
+		t.Fatalf("count migrations: %v", err2)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 migration (first succeeded, second failed), got %d", count)
+	}
+}
+
+// replaceDSNDatabase parses a pgx DSN and replaces the database name.
+// It also connects as root since the service users may not have been
+// fully provisioned in insecure CockroachDB mode.
+func replaceDSNDatabase(t *testing.T, dsn, database string) string {
+	t.Helper()
+	cfg, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse DSN: %v", err)
+	}
+	port := cfg.Port
+	if port == 0 {
+		port = 26257
+	}
+	return fmt.Sprintf("postgres://%s@%s:%d/%s?sslmode=disable",
+		cfg.User, cfg.Host, port, database)
+}

--- a/services/embed.go
+++ b/services/embed.go
@@ -1,0 +1,13 @@
+// Package services provides embedded access to all service migration SQL files.
+//
+// The embed.FS bundles every services/*/migrations/*.sql file at compile time,
+// allowing the unified binary to apply migrations without reading the filesystem.
+package services
+
+import "embed"
+
+// MigrationFS contains all SQL migration files from services/*/migrations/.
+// Paths within the FS use the form: <service>/migrations/<filename>.sql
+//
+//go:embed */migrations/*.sql
+var MigrationFS embed.FS


### PR DESCRIPTION
## Summary

Implement an embedded SQL migration runner (`internal/migrations`) that bundles all service migration files via Go's `embed.FS` and applies them to CockroachDB databases at startup. This is the foundation for the unified Meridian binary (`cmd/meridian`).

- **`services/embed.go`**: Declares `embed.FS` to bundle all `services/*/migrations/*.sql` files at compile time
- **`internal/migrations/runner.go`**: Migration discovery, database/user provisioning (CREATE DATABASE/USER/GRANT), and idempotent migration application with `_meridian_migrations` tracking table
- **`cmd/meridian/main.go`**: Unified binary entry point with `--migrate` flag and `--database-url` / `DATABASE_URL` support
- Handles shared databases (tenant + control-plane both target `meridian_platform`)
- Maps all 12 service directories to their 11 CockroachDB databases

## Test plan

- [x] `TestRunMigrations` - Creates 2 databases, applies migrations, verifies tables and tracking records
- [x] `TestRunMigrations_Idempotent` - Runs twice, verifies no duplicate migration records
- [x] `TestRunMigrations_SharedDatabase` - Both control-plane and tenant migrations applied to meridian_platform
- [x] `TestRunMigrations_NoMigrations` - Empty FS produces no errors
- [x] `TestRunMigrations_FailingMigration` - Invalid SQL fails fast, first migration still recorded

All tests use CockroachDB testcontainers for production parity.

---

Task: `meridian-unified.1` - Embedded Migration Runner