### PR TITLE
feat: add Postgres-backed idempotency service

### DIFF
--- a/shared/pkg/idempotency/postgres_service.go
+++ b/shared/pkg/idempotency/postgres_service.go
@@ -97,8 +97,13 @@ func (s *PostgresService) Check(ctx context.Context, key Key) (*Result, error) {
 
 	// Check TTL expiry
 	if expiresAt != nil && time.Now().After(*expiresAt) {
-		// Expired: clean up and report not found
-		_, _ = s.pool.Exec(ctx, `DELETE FROM _idempotency_keys WHERE key = $1`, dbKey)
+		// Expired: clean up and report not found.
+		// Guard the DELETE with expires_at < NOW() to avoid removing a record
+		// that was refreshed by another process between our SELECT and DELETE.
+		_, _ = s.pool.Exec(ctx,
+			`DELETE FROM _idempotency_keys WHERE key = $1 AND expires_at IS NOT NULL AND expires_at < NOW()`,
+			dbKey,
+		)
 		return nil, ErrResultNotFound
 	}
 

--- a/shared/pkg/idempotency/postgres_service.go
+++ b/shared/pkg/idempotency/postgres_service.go
@@ -1,0 +1,415 @@
+package idempotency
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostgresService implements Service using PostgreSQL/CockroachDB for distributed
+// idempotency and locking. It uses a single _idempotency_keys table for both
+// idempotency checking (Checker) and distributed locking (Locker).
+type PostgresService struct {
+	pool            *pgxpool.Pool
+	cleanupInterval time.Duration
+}
+
+// PostgresOption configures a PostgresService.
+type PostgresOption func(*PostgresService)
+
+// WithCleanupInterval sets the interval for the TTL cleanup goroutine.
+func WithCleanupInterval(d time.Duration) PostgresOption {
+	return func(s *PostgresService) {
+		s.cleanupInterval = d
+	}
+}
+
+// NewPostgresService creates a new PostgreSQL/CockroachDB-based idempotency service.
+func NewPostgresService(pool *pgxpool.Pool, opts ...PostgresOption) *PostgresService {
+	s := &PostgresService{
+		pool:            pool,
+		cleanupInterval: 60 * time.Second,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// EnsureTable creates the _idempotency_keys table and index if they do not exist.
+// Safe to call multiple times (idempotent).
+func (s *PostgresService) EnsureTable(ctx context.Context) error {
+	createTable := `
+		CREATE TABLE IF NOT EXISTS _idempotency_keys (
+			key            TEXT PRIMARY KEY,
+			status         TEXT NOT NULL,
+			result         JSONB,
+			token          TEXT,
+			expires_at     TIMESTAMPTZ,
+			created_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`
+
+	if _, err := s.pool.Exec(ctx, createTable); err != nil {
+		return fmt.Errorf("failed to create _idempotency_keys table: %w", err)
+	}
+
+	createIndex := `
+		CREATE INDEX IF NOT EXISTS idx_idempotency_keys_expires_at
+		ON _idempotency_keys (expires_at) WHERE expires_at IS NOT NULL`
+
+	if _, err := s.pool.Exec(ctx, createIndex); err != nil {
+		return fmt.Errorf("failed to create expires_at index: %w", err)
+	}
+
+	return nil
+}
+
+// Check verifies if an operation has already been processed.
+// Returns ErrOperationAlreadyProcessed if the operation was already completed.
+// Returns ErrResultNotFound if no record exists for the key.
+func (s *PostgresService) Check(ctx context.Context, key Key) (*Result, error) {
+	if err := key.Validate(); err != nil {
+		return nil, err
+	}
+
+	dbKey := key.String()
+
+	var status string
+	var resultJSON []byte
+	var expiresAt *time.Time
+	var createdAt time.Time
+
+	err := s.pool.QueryRow(ctx,
+		`SELECT status, result, expires_at, created_at FROM _idempotency_keys WHERE key = $1`,
+		dbKey,
+	).Scan(&status, &resultJSON, &expiresAt, &createdAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrResultNotFound
+		}
+		return nil, fmt.Errorf("failed to check idempotency: %w", err)
+	}
+
+	// Check TTL expiry
+	if expiresAt != nil && time.Now().After(*expiresAt) {
+		// Expired: clean up and report not found
+		_, _ = s.pool.Exec(ctx, `DELETE FROM _idempotency_keys WHERE key = $1`, dbKey)
+		return nil, ErrResultNotFound
+	}
+
+	result := &Result{
+		Key:       key,
+		Status:    OperationStatus(status),
+		CreatedAt: createdAt,
+	}
+
+	if resultJSON != nil {
+		result.Data = resultJSON
+	}
+
+	if result.Status == StatusCompleted {
+		return result, ErrOperationAlreadyProcessed
+	}
+
+	return result, nil
+}
+
+// MarkPending marks an operation as in-progress.
+// Uses INSERT ON CONFLICT DO NOTHING so concurrent calls don't error.
+func (s *PostgresService) MarkPending(ctx context.Context, key Key, ttl time.Duration) error {
+	if err := key.Validate(); err != nil {
+		return err
+	}
+	if ttl <= 0 {
+		return ErrInvalidTTL
+	}
+
+	dbKey := key.String()
+	expiresAt := time.Now().Add(ttl)
+
+	tag, err := s.pool.Exec(ctx,
+		`INSERT INTO _idempotency_keys (key, status, expires_at) VALUES ($1, $2, $3)
+		 ON CONFLICT (key) DO NOTHING`,
+		dbKey, string(StatusPending), expiresAt,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to mark pending: %w", err)
+	}
+
+	if tag.RowsAffected() == 0 {
+		// Key already existed - check if it's expired
+		var expiresAtExisting *time.Time
+		err := s.pool.QueryRow(ctx,
+			`SELECT expires_at FROM _idempotency_keys WHERE key = $1`, dbKey,
+		).Scan(&expiresAtExisting)
+		if err != nil {
+			return fmt.Errorf("failed to check existing key: %w", err)
+		}
+		// If existing key is expired, replace it
+		if expiresAtExisting != nil && time.Now().After(*expiresAtExisting) {
+			_, err = s.pool.Exec(ctx,
+				`UPDATE _idempotency_keys SET status = $1, expires_at = $2, result = NULL, token = NULL, created_at = CURRENT_TIMESTAMP WHERE key = $3`,
+				string(StatusPending), expiresAt, dbKey,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to replace expired key: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// StoreResult saves the operation result for future idempotency checks.
+func (s *PostgresService) StoreResult(ctx context.Context, result Result) error {
+	if err := result.Key.Validate(); err != nil {
+		return err
+	}
+	if result.TTL <= 0 {
+		return ErrInvalidTTL
+	}
+
+	dbKey := result.Key.String()
+	expiresAt := time.Now().Add(result.TTL)
+
+	var resultJSON []byte
+	if result.Data != nil {
+		// Validate that Data is valid JSON for the JSONB column
+		if !json.Valid(result.Data) {
+			// Wrap the raw bytes as a JSON string
+			var err error
+			resultJSON, err = json.Marshal(string(result.Data))
+			if err != nil {
+				return fmt.Errorf("failed to marshal result data: %w", err)
+			}
+		} else {
+			resultJSON = result.Data
+		}
+	}
+
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO _idempotency_keys (key, status, result, expires_at)
+		 VALUES ($1, $2, $3, $4)
+		 ON CONFLICT (key) DO UPDATE SET status = $2, result = $3, expires_at = $4`,
+		dbKey, string(result.Status), resultJSON, expiresAt,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to store result: %w", err)
+	}
+
+	return nil
+}
+
+// Delete removes an idempotency record.
+func (s *PostgresService) Delete(ctx context.Context, key Key) error {
+	if err := key.Validate(); err != nil {
+		return err
+	}
+
+	dbKey := key.String()
+	_, err := s.pool.Exec(ctx, `DELETE FROM _idempotency_keys WHERE key = $1`, dbKey)
+	if err != nil {
+		return fmt.Errorf("failed to delete key: %w", err)
+	}
+
+	return nil
+}
+
+// lockKey returns the lock row key for a given idempotency key.
+func lockKey(key Key) string {
+	return key.String() + "__lock"
+}
+
+// Acquire attempts to acquire a distributed lock using row-level locking.
+// It inserts a lock row and uses SELECT FOR UPDATE SKIP LOCKED to ensure mutual exclusion.
+func (s *PostgresService) Acquire(ctx context.Context, key Key, opts LockOptions) error {
+	if err := key.Validate(); err != nil {
+		return err
+	}
+	if opts.TTL <= 0 {
+		return ErrInvalidTTL
+	}
+	if opts.Token == "" {
+		return ErrEmptyToken
+	}
+
+	lk := lockKey(key)
+	expiresAt := time.Now().Add(opts.TTL)
+
+	for attempt := 0; attempt <= opts.MaxRetries; attempt++ {
+		acquired, err := s.tryAcquire(ctx, lk, opts.Token, expiresAt)
+		if err != nil {
+			return fmt.Errorf("failed to acquire lock: %w", err)
+		}
+		if acquired {
+			return nil
+		}
+
+		if attempt < opts.MaxRetries {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("lock acquisition cancelled: %w", ctx.Err())
+			case <-time.After(opts.RetryDelay):
+				continue
+			}
+		}
+	}
+
+	return ErrLockAcquisitionFailed
+}
+
+// tryAcquire attempts a single lock acquisition within a transaction.
+func (s *PostgresService) tryAcquire(ctx context.Context, lk, token string, expiresAt time.Time) (bool, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	// First, clean up any expired lock
+	_, err = tx.Exec(ctx,
+		`DELETE FROM _idempotency_keys WHERE key = $1 AND expires_at IS NOT NULL AND expires_at < NOW()`,
+		lk,
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to clean expired lock: %w", err)
+	}
+
+	// Try to insert a new lock row. If it already exists (and isn't expired, since
+	// we just cleaned expired ones), the ON CONFLICT DO NOTHING means 0 rows affected.
+	tag, err := tx.Exec(ctx,
+		`INSERT INTO _idempotency_keys (key, status, token, expires_at)
+		 VALUES ($1, 'lock', $2, $3)
+		 ON CONFLICT (key) DO NOTHING`,
+		lk, token, expiresAt,
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to insert lock row: %w", err)
+	}
+
+	if tag.RowsAffected() == 0 {
+		// Lock row exists and is not expired - someone else holds it.
+		// Try SELECT FOR UPDATE SKIP LOCKED to see if we can grab it.
+		var existingToken string
+		err = tx.QueryRow(ctx,
+			`SELECT token FROM _idempotency_keys WHERE key = $1 FOR UPDATE SKIP LOCKED`,
+			lk,
+		).Scan(&existingToken)
+		if err != nil {
+			// ErrNoRows means the row is locked by another transaction
+			if errors.Is(err, pgx.ErrNoRows) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to check lock: %w", err)
+		}
+		// We got the row - someone else's lock. We can't take it.
+		return false, nil
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return false, fmt.Errorf("failed to commit lock: %w", err)
+	}
+
+	return true, nil
+}
+
+// Release releases a previously acquired lock.
+// Returns ErrLockNotHeld if the lock is not held by this token.
+func (s *PostgresService) Release(ctx context.Context, key Key, token string) error {
+	if err := key.Validate(); err != nil {
+		return err
+	}
+	if token == "" {
+		return ErrEmptyToken
+	}
+
+	lk := lockKey(key)
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM _idempotency_keys WHERE key = $1 AND token = $2`,
+		lk, token,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to release lock: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrLockNotHeld
+	}
+
+	return nil
+}
+
+// Refresh extends the TTL of a held lock.
+// Returns ErrLockNotHeld if the lock is not held by this token.
+func (s *PostgresService) Refresh(ctx context.Context, key Key, token string, ttl time.Duration) error {
+	if err := key.Validate(); err != nil {
+		return err
+	}
+	if ttl <= 0 {
+		return ErrInvalidTTL
+	}
+	if token == "" {
+		return ErrEmptyToken
+	}
+
+	lk := lockKey(key)
+	newExpiresAt := time.Now().Add(ttl)
+
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE _idempotency_keys SET expires_at = $1 WHERE key = $2 AND token = $3`,
+		newExpiresAt, lk, token,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to refresh lock: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrLockNotHeld
+	}
+
+	return nil
+}
+
+// IsHeld checks if a lock is currently held (by any token).
+func (s *PostgresService) IsHeld(ctx context.Context, key Key) (bool, error) {
+	if err := key.Validate(); err != nil {
+		return false, err
+	}
+
+	lk := lockKey(key)
+	var exists bool
+	err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM _idempotency_keys WHERE key = $1 AND (expires_at IS NULL OR expires_at > NOW()))`,
+		lk,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("failed to check lock: %w", err)
+	}
+
+	return exists, nil
+}
+
+// StartCleanup runs a background goroutine that periodically deletes expired rows.
+// It stops when the context is cancelled.
+func (s *PostgresService) StartCleanup(ctx context.Context) {
+	ticker := time.NewTicker(s.cleanupInterval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				_, _ = s.pool.Exec(ctx,
+					`DELETE FROM _idempotency_keys WHERE expires_at IS NOT NULL AND expires_at < NOW()`,
+				)
+			}
+		}
+	}()
+}
+
+// Verify interface compliance at compile time.
+var _ Service = (*PostgresService)(nil)

--- a/shared/pkg/idempotency/postgres_service.go
+++ b/shared/pkg/idempotency/postgres_service.go
@@ -142,23 +142,16 @@ func (s *PostgresService) MarkPending(ctx context.Context, key Key, ttl time.Dur
 	}
 
 	if tag.RowsAffected() == 0 {
-		// Key already existed - check if it's expired
-		var expiresAtExisting *time.Time
-		err := s.pool.QueryRow(ctx,
-			`SELECT expires_at FROM _idempotency_keys WHERE key = $1`, dbKey,
-		).Scan(&expiresAtExisting)
+		// Key already existed - atomically replace it only if it's expired.
+		// The WHERE clause guards against race conditions where another writer
+		// refreshes the row between our INSERT and this UPDATE.
+		_, err = s.pool.Exec(ctx,
+			`UPDATE _idempotency_keys SET status = $1, expires_at = $2, result = NULL, token = NULL, created_at = CURRENT_TIMESTAMP
+			 WHERE key = $3 AND expires_at IS NOT NULL AND expires_at < NOW()`,
+			string(StatusPending), expiresAt, dbKey,
+		)
 		if err != nil {
-			return fmt.Errorf("failed to check existing key: %w", err)
-		}
-		// If existing key is expired, replace it
-		if expiresAtExisting != nil && time.Now().After(*expiresAtExisting) {
-			_, err = s.pool.Exec(ctx,
-				`UPDATE _idempotency_keys SET status = $1, expires_at = $2, result = NULL, token = NULL, created_at = CURRENT_TIMESTAMP WHERE key = $3`,
-				string(StatusPending), expiresAt, dbKey,
-			)
-			if err != nil {
-				return fmt.Errorf("failed to replace expired key: %w", err)
-			}
+			return fmt.Errorf("failed to replace expired key: %w", err)
 		}
 	}
 
@@ -393,8 +386,12 @@ func (s *PostgresService) IsHeld(ctx context.Context, key Key) (bool, error) {
 }
 
 // StartCleanup runs a background goroutine that periodically deletes expired rows.
-// It stops when the context is cancelled.
+// It stops when the context is cancelled. If cleanupInterval is zero or negative,
+// this is a no-op.
 func (s *PostgresService) StartCleanup(ctx context.Context) {
+	if s.cleanupInterval <= 0 {
+		return
+	}
 	ticker := time.NewTicker(s.cleanupInterval)
 	go func() {
 		defer ticker.Stop()

--- a/shared/pkg/idempotency/postgres_service_test.go
+++ b/shared/pkg/idempotency/postgres_service_test.go
@@ -1,0 +1,700 @@
+package idempotency
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
+)
+
+// Shared container and pool for all Postgres service tests.
+// Lazily initialized on first use so redis-only test runs don't start CockroachDB.
+var (
+	pgOnce        sync.Once
+	pgPool        *pgxpool.Pool
+	pgContainer   testcontainers.Container
+	pgInitErr     error
+	pgInitCleanup func()
+)
+
+func getSharedPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	pgOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
+
+		container, err := cockroachdb.Run(ctx,
+			"cockroachdb/cockroach:v24.3.0",
+			cockroachdb.WithDatabase("test_db"),
+			cockroachdb.WithUser("root"),
+			cockroachdb.WithInsecure(),
+		)
+		if err != nil {
+			pgInitErr = err
+			return
+		}
+		pgContainer = container
+
+		connConfig, err := container.ConnectionConfig(ctx)
+		if err != nil {
+			pgInitErr = err
+			return
+		}
+
+		pool, err := pgxpool.New(ctx, connConfig.ConnString())
+		if err != nil {
+			pgInitErr = err
+			return
+		}
+		pgPool = pool
+
+		svc := NewPostgresService(pool)
+		if err := svc.EnsureTable(ctx); err != nil {
+			pgInitErr = err
+			pool.Close()
+			return
+		}
+
+		pgInitCleanup = func() {
+			pool.Close()
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cleanupCancel()
+			_ = container.Terminate(cleanupCtx)
+		}
+	})
+
+	if pgInitErr != nil {
+		t.Fatalf("Failed to initialize shared CockroachDB: %v", pgInitErr)
+	}
+
+	// Register cleanup only once via t.Cleanup won't work well with shared state.
+	// The container lives for the entire test run and is cleaned up at process exit.
+	// For long-lived test processes, the Go runtime will clean up.
+
+	return pgPool
+}
+
+// freshService returns a service backed by the shared pool after truncating the table.
+func freshService(t *testing.T) *PostgresService {
+	t.Helper()
+	pool := getSharedPool(t)
+	_, err := pool.Exec(context.Background(), `DELETE FROM _idempotency_keys`)
+	if err != nil {
+		t.Fatalf("Failed to truncate _idempotency_keys: %v", err)
+	}
+	return NewPostgresService(pool)
+}
+
+func pgTestKey() Key {
+	return Key{
+		Namespace: "current-account",
+		Operation: "deposit",
+		EntityID:  "ACC-12345",
+		RequestID: uuid.NewString(),
+	}
+}
+
+// Interface compliance
+func TestPostgresService_InterfaceCompliance(_ *testing.T) {
+	var _ Service = (*PostgresService)(nil)
+}
+
+// -- Checker tests --
+
+func TestPostgresService_Check_NotFound(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+
+	result, err := svc.Check(ctx, pgTestKey())
+	if result != nil {
+		t.Errorf("Expected nil result, got %v", result)
+	}
+	if !errors.Is(err, ErrResultNotFound) {
+		t.Errorf("Expected ErrResultNotFound, got %v", err)
+	}
+}
+
+func TestPostgresService_MarkPending_ThenCheck(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+	key := pgTestKey()
+
+	if err := svc.MarkPending(ctx, key, time.Hour); err != nil {
+		t.Fatalf("MarkPending failed: %v", err)
+	}
+
+	result, err := svc.Check(ctx, key)
+	if err != nil {
+		t.Errorf("Expected no error for pending, got %v", err)
+	}
+	if result == nil {
+		t.Fatal("Expected result, got nil")
+	}
+	if result.Status != StatusPending {
+		t.Errorf("Expected status %v, got %v", StatusPending, result.Status)
+	}
+}
+
+func TestPostgresService_StoreResult_ThenCheck(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+	key := pgTestKey()
+
+	completedResult := Result{
+		Key:         key,
+		Status:      StatusCompleted,
+		Data:        []byte(`{"amount": 100}`),
+		CompletedAt: time.Now(),
+		TTL:         time.Hour,
+	}
+	if err := svc.StoreResult(ctx, completedResult); err != nil {
+		t.Fatalf("StoreResult failed: %v", err)
+	}
+
+	result, err := svc.Check(ctx, key)
+	if !errors.Is(err, ErrOperationAlreadyProcessed) {
+		t.Errorf("Expected ErrOperationAlreadyProcessed, got %v", err)
+	}
+	if result == nil {
+		t.Fatal("Expected result, got nil")
+	}
+	if result.Status != StatusCompleted {
+		t.Errorf("Expected status %v, got %v", StatusCompleted, result.Status)
+	}
+	if string(result.Data) != `{"amount": 100}` {
+		t.Errorf("Expected data %q, got %q", `{"amount": 100}`, string(result.Data))
+	}
+}
+
+func TestPostgresService_Delete_ThenCheck(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+	key := pgTestKey()
+
+	if err := svc.MarkPending(ctx, key, time.Hour); err != nil {
+		t.Fatalf("MarkPending failed: %v", err)
+	}
+
+	if err := svc.Delete(ctx, key); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	result, err := svc.Check(ctx, key)
+	if result != nil {
+		t.Errorf("Expected nil result after delete, got %v", result)
+	}
+	if !errors.Is(err, ErrResultNotFound) {
+		t.Errorf("Expected ErrResultNotFound after delete, got %v", err)
+	}
+}
+
+func TestPostgresService_TTLExpiry(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+	key := pgTestKey()
+
+	// Store with a long TTL first
+	result := Result{
+		Key:    key,
+		Status: StatusCompleted,
+		Data:   []byte(`{"test": true}`),
+		TTL:    time.Hour,
+	}
+	if err := svc.StoreResult(ctx, result); err != nil {
+		t.Fatalf("StoreResult failed: %v", err)
+	}
+
+	// Force expires_at into the past using CockroachDB's own clock to avoid host/container clock skew
+	_, err := svc.pool.Exec(ctx,
+		`UPDATE _idempotency_keys SET expires_at = NOW() - INTERVAL '1 minute' WHERE key = $1`,
+		key.String(),
+	)
+	if err != nil {
+		t.Fatalf("Failed to backdate expires_at: %v", err)
+	}
+
+	// Check should return not found (expired)
+	checked, err := svc.Check(ctx, key)
+	if checked != nil {
+		t.Errorf("Expected nil result after TTL expiry, got %v", checked)
+	}
+	if !errors.Is(err, ErrResultNotFound) {
+		t.Errorf("Expected ErrResultNotFound after TTL expiry, got %v", err)
+	}
+}
+
+// -- Locker tests --
+
+func TestPostgresService_Acquire_Success(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+	key := pgTestKey()
+	token := uuid.NewString()
+
+	opts := LockOptions{
+		TTL:        30 * time.Second,
+		RetryDelay: 10 * time.Millisecond,
+		MaxRetries: 0,
+		Token:      token,
+	}
+
+	if err := svc.Acquire(ctx, key, opts); err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+
+	held, err := svc.IsHeld(ctx, key)
+	if err != nil {
+		t.Fatalf("IsHeld failed: %v", err)
+	}
+	if !held {
+		t.Error("Expected lock to be held after acquisition")
+	}
+}
+
+func TestPostgresService_Acquire_AlreadyHeld(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+	key := pgTestKey()
+
+	opts1 := LockOptions{
+		TTL:        30 * time.Second,
+		RetryDelay: 10 * time.Millisecond,
+		MaxRetries: 0,
+		Token:      uuid.NewString(),
+	}
+	if err := svc.Acquire(ctx, key, opts1); err != nil {
+		t.Fatalf("First acquire failed: %v", err)
+	}
+
+	opts2 := LockOptions{
+		TTL:        30 * time.Second,
+		RetryDelay: 10 * time.Millisecond,
+		MaxRetries: 0,
+		Token:      uuid.NewString(),
+	}
+	err := svc.Acquire(ctx, key, opts2)
+	if !errors.Is(err, ErrLockAcquisitionFailed) {
+		t.Errorf("Expected ErrLockAcquisitionFailed, got %v", err)
+	}
+}
+
+func TestPostgresService_Release_WrongToken(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+	key := pgTestKey()
+	token := uuid.NewString()
+
+	opts := LockOptions{
+		TTL:   30 * time.Second,
+		Token: token,
+	}
+	if err := svc.Acquire(ctx, key, opts); err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+
+	err := svc.Release(ctx, key, uuid.NewString())
+	if !errors.Is(err, ErrLockNotHeld) {
+		t.Errorf("Expected ErrLockNotHeld, got %v", err)
+	}
+}
+
+func TestPostgresService_Release_CorrectToken_ThenReAcquire(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+	key := pgTestKey()
+	token := uuid.NewString()
+
+	opts := LockOptions{
+		TTL:   30 * time.Second,
+		Token: token,
+	}
+	if err := svc.Acquire(ctx, key, opts); err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+
+	if err := svc.Release(ctx, key, token); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	// Re-acquire with a new token
+	newToken := uuid.NewString()
+	opts2 := LockOptions{
+		TTL:   30 * time.Second,
+		Token: newToken,
+	}
+	if err := svc.Acquire(ctx, key, opts2); err != nil {
+		t.Errorf("Re-acquire after release failed: %v", err)
+	}
+}
+
+func TestPostgresService_Refresh(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+	key := pgTestKey()
+	token := uuid.NewString()
+
+	opts := LockOptions{
+		TTL:   5 * time.Second,
+		Token: token,
+	}
+	if err := svc.Acquire(ctx, key, opts); err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+
+	// Refresh with longer TTL
+	if err := svc.Refresh(ctx, key, token, 60*time.Second); err != nil {
+		t.Errorf("Refresh failed: %v", err)
+	}
+
+	// Verify lock is still held
+	held, err := svc.IsHeld(ctx, key)
+	if err != nil {
+		t.Fatalf("IsHeld failed: %v", err)
+	}
+	if !held {
+		t.Error("Expected lock to still be held after refresh")
+	}
+}
+
+func TestPostgresService_Refresh_WrongToken(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+	key := pgTestKey()
+	token := uuid.NewString()
+
+	opts := LockOptions{
+		TTL:   30 * time.Second,
+		Token: token,
+	}
+	if err := svc.Acquire(ctx, key, opts); err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+
+	err := svc.Refresh(ctx, key, uuid.NewString(), time.Minute)
+	if !errors.Is(err, ErrLockNotHeld) {
+		t.Errorf("Expected ErrLockNotHeld, got %v", err)
+	}
+}
+
+func TestPostgresService_IsHeld(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+	key := pgTestKey()
+	token := uuid.NewString()
+
+	// Not held initially
+	held, err := svc.IsHeld(ctx, key)
+	if err != nil {
+		t.Fatalf("IsHeld failed: %v", err)
+	}
+	if held {
+		t.Error("Expected lock to not be held initially")
+	}
+
+	// Acquire
+	opts := LockOptions{TTL: 30 * time.Second, Token: token}
+	if err := svc.Acquire(ctx, key, opts); err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+
+	// Held after acquire
+	held, err = svc.IsHeld(ctx, key)
+	if err != nil {
+		t.Fatalf("IsHeld failed: %v", err)
+	}
+	if !held {
+		t.Error("Expected lock to be held after acquisition")
+	}
+
+	// Release
+	if err := svc.Release(ctx, key, token); err != nil {
+		t.Fatalf("Release failed: %v", err)
+	}
+
+	// Not held after release
+	held, err = svc.IsHeld(ctx, key)
+	if err != nil {
+		t.Fatalf("IsHeld failed: %v", err)
+	}
+	if held {
+		t.Error("Expected lock to not be held after release")
+	}
+}
+
+// -- TTL Cleanup test --
+
+func TestPostgresService_StartCleanup(t *testing.T) {
+	svc := freshService(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	key := pgTestKey()
+
+	// Store a result first (with a long TTL so it inserts successfully)
+	result := Result{
+		Key:    key,
+		Status: StatusPending,
+		Data:   []byte(`{}`),
+		TTL:    time.Hour,
+	}
+	if err := svc.StoreResult(ctx, result); err != nil {
+		t.Fatalf("StoreResult failed: %v", err)
+	}
+
+	// Force expires_at into the past using CockroachDB's own clock to avoid host/container clock skew
+	_, err := svc.pool.Exec(ctx,
+		`UPDATE _idempotency_keys SET expires_at = NOW() - INTERVAL '1 minute' WHERE key = $1`,
+		key.String(),
+	)
+	if err != nil {
+		t.Fatalf("Failed to backdate expires_at: %v", err)
+	}
+
+	// Create a new service instance with short cleanup interval for this test
+	pool := getSharedPool(t)
+	cleanupSvc := NewPostgresService(pool, WithCleanupInterval(100*time.Millisecond))
+	cleanupSvc.StartCleanup(ctx)
+
+	// Wait for cleanup to run
+	time.Sleep(500 * time.Millisecond)
+
+	// Row should be cleaned up
+	var count int
+	err = svc.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM _idempotency_keys WHERE key = $1`, key.String(),
+	).Scan(&count)
+	if err != nil {
+		t.Fatalf("Count query failed: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("Expected 0 rows after cleanup, got %d", count)
+	}
+}
+
+// -- Concurrency test --
+
+func TestPostgresService_Acquire_Concurrent(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+	key := pgTestKey()
+	var successCount atomic.Int32
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			opts := LockOptions{
+				TTL:        30 * time.Second,
+				RetryDelay: 10 * time.Millisecond,
+				MaxRetries: 0,
+				Token:      uuid.NewString(),
+			}
+			if err := svc.Acquire(ctx, key, opts); err == nil {
+				successCount.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if successCount.Load() != 1 {
+		t.Errorf("Expected exactly 1 successful acquisition, got %d", successCount.Load())
+	}
+}
+
+// -- EnsureTable idempotency test --
+
+func TestPostgresService_EnsureTable_Idempotent(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+
+	// Call EnsureTable again (already called during init)
+	if err := svc.EnsureTable(ctx); err != nil {
+		t.Fatalf("Second EnsureTable call failed: %v", err)
+	}
+
+	// Third time for good measure
+	if err := svc.EnsureTable(ctx); err != nil {
+		t.Fatalf("Third EnsureTable call failed: %v", err)
+	}
+}
+
+// -- Validation tests --
+
+func TestPostgresService_InvalidKey(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+	invalidKey := Key{} // Missing required fields
+
+	_, err := svc.Check(ctx, invalidKey)
+	if !errors.Is(err, ErrInvalidKey) {
+		t.Errorf("Check: expected ErrInvalidKey, got %v", err)
+	}
+
+	err = svc.MarkPending(ctx, invalidKey, time.Hour)
+	if !errors.Is(err, ErrInvalidKey) {
+		t.Errorf("MarkPending: expected ErrInvalidKey, got %v", err)
+	}
+
+	err = svc.Delete(ctx, invalidKey)
+	if !errors.Is(err, ErrInvalidKey) {
+		t.Errorf("Delete: expected ErrInvalidKey, got %v", err)
+	}
+
+	opts := DefaultLockOptions()
+	opts.Token = uuid.NewString()
+	err = svc.Acquire(ctx, invalidKey, opts)
+	if !errors.Is(err, ErrInvalidKey) {
+		t.Errorf("Acquire: expected ErrInvalidKey, got %v", err)
+	}
+
+	err = svc.Release(ctx, invalidKey, "token")
+	if !errors.Is(err, ErrInvalidKey) {
+		t.Errorf("Release: expected ErrInvalidKey, got %v", err)
+	}
+
+	_, err = svc.IsHeld(ctx, invalidKey)
+	if !errors.Is(err, ErrInvalidKey) {
+		t.Errorf("IsHeld: expected ErrInvalidKey, got %v", err)
+	}
+}
+
+func TestPostgresService_StoreResult_InvalidTTL(t *testing.T) {
+	svc := freshService(t)
+
+	key := Key{
+		Namespace: "test",
+		Operation: "test-op",
+		EntityID:  "test-123",
+	}
+
+	tests := []struct {
+		name string
+		ttl  time.Duration
+	}{
+		{"zero TTL", 0},
+		{"negative TTL", -1 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Result{
+				Key:    key,
+				Status: StatusCompleted,
+				TTL:    tt.ttl,
+			}
+			err := svc.StoreResult(context.Background(), result)
+			if !errors.Is(err, ErrInvalidTTL) {
+				t.Errorf("StoreResult() with %s: got error %v, want %v", tt.name, err, ErrInvalidTTL)
+			}
+		})
+	}
+}
+
+func TestPostgresService_MarkPending_InvalidTTL(t *testing.T) {
+	svc := freshService(t)
+
+	key := Key{
+		Namespace: "test",
+		Operation: "test-op",
+		EntityID:  "test-123",
+	}
+
+	err := svc.MarkPending(context.Background(), key, 0)
+	if !errors.Is(err, ErrInvalidTTL) {
+		t.Errorf("Expected ErrInvalidTTL, got %v", err)
+	}
+
+	err = svc.MarkPending(context.Background(), key, -1*time.Second)
+	if !errors.Is(err, ErrInvalidTTL) {
+		t.Errorf("Expected ErrInvalidTTL, got %v", err)
+	}
+}
+
+func TestPostgresService_Refresh_InvalidTTL(t *testing.T) {
+	svc := freshService(t)
+
+	key := Key{
+		Namespace: "test",
+		Operation: "test-lock",
+		EntityID:  "test-123",
+	}
+	token := uuid.NewString()
+
+	opts := LockOptions{
+		TTL:        1 * time.Minute,
+		Token:      token,
+		MaxRetries: 0,
+	}
+	if err := svc.Acquire(context.Background(), key, opts); err != nil {
+		t.Fatalf("Failed to acquire lock: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		ttl  time.Duration
+	}{
+		{"zero TTL", 0},
+		{"negative TTL", -1 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := svc.Refresh(context.Background(), key, token, tt.ttl)
+			if !errors.Is(err, ErrInvalidTTL) {
+				t.Errorf("Refresh() with %s: got error %v, want %v", tt.name, err, ErrInvalidTTL)
+			}
+		})
+	}
+}
+
+// -- Tenant isolation test --
+
+func TestPostgresService_TenantIsolation(t *testing.T) {
+	svc := freshService(t)
+	ctx := context.Background()
+
+	key1 := Key{
+		TenantID:  "tenant-a",
+		Namespace: "ns",
+		Operation: "op",
+		EntityID:  "entity-1",
+	}
+	key2 := Key{
+		TenantID:  "tenant-b",
+		Namespace: "ns",
+		Operation: "op",
+		EntityID:  "entity-1",
+	}
+
+	// Store for tenant-a
+	if err := svc.MarkPending(ctx, key1, time.Hour); err != nil {
+		t.Fatalf("MarkPending tenant-a failed: %v", err)
+	}
+
+	// Check tenant-b should not find it
+	result, err := svc.Check(ctx, key2)
+	if result != nil {
+		t.Errorf("Expected nil result for tenant-b, got %v", result)
+	}
+	if !errors.Is(err, ErrResultNotFound) {
+		t.Errorf("Expected ErrResultNotFound for tenant-b, got %v", err)
+	}
+
+	// Check tenant-a should find it
+	result, err = svc.Check(ctx, key1)
+	if err != nil {
+		t.Errorf("Expected no error for tenant-a, got %v", err)
+	}
+	if result == nil {
+		t.Fatal("Expected result for tenant-a, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `PostgresService` struct in `shared/pkg/idempotency/postgres_service.go` that satisfies the `idempotency.Service` interface (Checker + Locker) using CockroachDB/PostgreSQL via `*pgxpool.Pool`
- Provides an alternative backend to the existing `RedisService` for environments where Redis is not available
- Uses `_idempotency_keys` table with JSONB result storage, row-level locking via `INSERT ON CONFLICT` + `SELECT FOR UPDATE SKIP LOCKED`, and TTL-based expiry

## Changes Made

**`shared/pkg/idempotency/postgres_service.go`** (new):
- `EnsureTable()` - Creates table and partial index (CockroachDB-safe: separate statements)
- `Check()` - SELECT with TTL expiry check, returns `ErrOperationAlreadyProcessed` for completed ops
- `MarkPending()` - INSERT ON CONFLICT DO NOTHING with expired key replacement
- `StoreResult()` - UPSERT with JSON serialization for JSONB column
- `Delete()` - DELETE by key
- `Acquire()` - Row-level distributed lock using INSERT + SELECT FOR UPDATE SKIP LOCKED with retry loop
- `Release()` - DELETE with token verification (returns `ErrLockNotHeld` on mismatch)
- `Refresh()` - UPDATE expires_at with token verification
- `IsHeld()` - EXISTS check excluding expired locks
- `StartCleanup()` - Background goroutine for periodic TTL cleanup
- `PostgresOption` functional options pattern with `WithCleanupInterval`

**`shared/pkg/idempotency/postgres_service_test.go`** (new):
- Integration tests using shared CockroachDB testcontainer (lazy `sync.Once` init, not `TestMain`)
- Container only starts when postgres tests run (redis-only runs stay fast)
- Table truncated between tests for isolation
- 20 test cases covering: Checker (Check, MarkPending, StoreResult, Delete, TTL expiry), Locker (Acquire, Release, Refresh, IsHeld), validation, concurrent lock acquisition (50 goroutines), EnsureTable idempotency, tenant isolation, cleanup goroutine

## Task Master

Task: meridian-unified.2

## Test Plan

- [x] All 20 PostgresService tests pass against CockroachDB testcontainer
- [x] All existing RedisService tests pass (no regression)
- [x] Interface compliance verified at compile time
- [x] Concurrent lock acquisition: exactly 1 winner out of 50 goroutines
- [x] golangci-lint passes with zero issues