### PR TITLE
feat: implement StripeWebhookAdapter for Stripe Identity webhooks

### DIFF
--- a/services/party/adapters/http/stripe_webhook_adapter.go
+++ b/services/party/adapters/http/stripe_webhook_adapter.go
@@ -1,0 +1,315 @@
+// Package http provides the HTTP adapter for receiving KYC/AML verification webhooks.
+package http
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/meridianhub/meridian/services/party/verification"
+)
+
+// Stripe webhook adapter errors.
+var (
+	ErrStripeSignatureMissing = errors.New("missing Stripe-Signature header")
+	ErrStripeSignatureInvalid = errors.New("invalid Stripe webhook signature")
+	ErrStripeTimestampExpired = errors.New("stripe webhook timestamp expired")
+	ErrStripeEventParseFailed = errors.New("failed to parse Stripe event")
+	ErrStripeUnknownEventType = errors.New("unknown or irrelevant Stripe event type")
+	ErrNilInnerHandler        = errors.New("inner webhook handler cannot be nil")
+	ErrEmptyStripeSecret      = errors.New("stripe webhook secret cannot be empty")
+	ErrEmptyInnerSecret       = errors.New("inner HMAC secret cannot be empty")
+)
+
+// stripeSignatureHeader is the HTTP header Stripe uses for webhook signatures.
+const stripeSignatureHeader = "Stripe-Signature"
+
+// stripeTimestampTolerance is the maximum age of a Stripe webhook timestamp.
+const stripeTimestampTolerance = 5 * time.Minute
+
+// stripeEvent represents the top-level Stripe webhook event payload.
+type stripeEvent struct {
+	ID   string          `json:"id"`
+	Type string          `json:"type"`
+	Data stripeEventData `json:"data"`
+}
+
+type stripeEventData struct {
+	Object stripeVerificationSession `json:"object"`
+}
+
+type stripeVerificationSession struct {
+	ID                     string            `json:"id"`
+	Status                 string            `json:"status"`
+	LastVerificationReport string            `json:"last_verification_report"`
+	Metadata               map[string]string `json:"metadata"`
+}
+
+// StripeWebhookAdapter translates Stripe Identity webhooks into the generic
+// VerificationWebhookHandler format.
+type StripeWebhookAdapter struct {
+	inner           *VerificationWebhookHandler
+	stripeSecret    []byte
+	innerHMACSecret []byte
+	logger          *slog.Logger
+}
+
+// StripeWebhookAdapterConfig contains configuration for creating a StripeWebhookAdapter.
+type StripeWebhookAdapterConfig struct {
+	// InnerHandler is the generic webhook handler to delegate to after translation.
+	InnerHandler *VerificationWebhookHandler
+	// WebhookSecret is the Stripe webhook endpoint secret used to validate inbound signatures.
+	WebhookSecret []byte
+	// InnerHMACSecret is the HMAC secret used to sign the synthetic request sent to InnerHandler.
+	// This must match the secret configured in InnerHandler for the "stripe" or "default" provider.
+	InnerHMACSecret []byte
+	Logger          *slog.Logger
+}
+
+// NewStripeWebhookAdapter creates a new StripeWebhookAdapter.
+func NewStripeWebhookAdapter(cfg StripeWebhookAdapterConfig) (*StripeWebhookAdapter, error) {
+	if cfg.InnerHandler == nil {
+		return nil, ErrNilInnerHandler
+	}
+	if len(cfg.WebhookSecret) == 0 {
+		return nil, ErrEmptyStripeSecret
+	}
+	if len(cfg.InnerHMACSecret) == 0 {
+		return nil, ErrEmptyInnerSecret
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &StripeWebhookAdapter{
+		inner:           cfg.InnerHandler,
+		stripeSecret:    cfg.WebhookSecret,
+		innerHMACSecret: cfg.InnerHMACSecret,
+		logger:          logger,
+	}, nil
+}
+
+// ServeHTTP implements http.Handler. It validates the Stripe signature, translates
+// the event to the generic VerificationWebhookRequest, and delegates to the inner handler.
+func (a *StripeWebhookAdapter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Only accept POST requests
+	if r.Method != http.MethodPost {
+		writeStripeErrorResponse(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	// Read raw body — needed for signature validation
+	defer func() { _ = r.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1 MB limit
+	if err != nil {
+		a.logger.Error("failed to read Stripe webhook body", "error", err)
+		writeStripeErrorResponse(w, http.StatusBadRequest, ErrInvalidRequestBody.Error())
+		return
+	}
+
+	// Validate Stripe signature
+	sigHeader := r.Header.Get(stripeSignatureHeader)
+	if sigHeader == "" {
+		a.logger.Warn("missing Stripe-Signature header")
+		writeStripeErrorResponse(w, http.StatusUnauthorized, ErrStripeSignatureMissing.Error())
+		return
+	}
+
+	if err := validateStripeSignature(body, sigHeader, a.stripeSecret, stripeTimestampTolerance); err != nil {
+		if errors.Is(err, ErrStripeTimestampExpired) {
+			a.logger.Warn("Stripe webhook timestamp expired")
+			writeStripeErrorResponse(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		a.logger.Warn("invalid Stripe webhook signature", "error", err)
+		writeStripeErrorResponse(w, http.StatusUnauthorized, ErrStripeSignatureInvalid.Error())
+		return
+	}
+
+	// Parse Stripe event
+	var event stripeEvent
+	if err := json.Unmarshal(body, &event); err != nil {
+		a.logger.Error("failed to parse Stripe event", "error", err)
+		writeStripeErrorResponse(w, http.StatusBadRequest, ErrStripeEventParseFailed.Error())
+		return
+	}
+
+	// Map Stripe event type to verification status
+	status, ok := mapStripeEventToStatus(event.Type)
+	if !ok {
+		a.logger.Info("ignoring irrelevant Stripe event type", "event_type", event.Type)
+		// Acknowledge gracefully — Stripe expects 2xx for events we don't care about
+		writeStripeSuccessResponse(w, "event type not relevant")
+		return
+	}
+
+	// Build the generic VerificationWebhookRequest
+	now := time.Now().UTC()
+	webhookReq := VerificationWebhookRequest{
+		VerificationID: event.Data.Object.ID,
+		Status:         string(status),
+		Timestamp:      now,
+		Metadata:       event.Data.Object.Metadata,
+	}
+
+	// Marshal to JSON for the synthetic request
+	syntheticBody, err := json.Marshal(webhookReq)
+	if err != nil {
+		a.logger.Error("failed to marshal synthetic webhook request", "error", err)
+		writeStripeErrorResponse(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	// Sign the synthetic body with the inner handler's HMAC secret
+	sig := GenerateWebhookSignature(syntheticBody, a.innerHMACSecret)
+
+	// Build a synthetic http.Request targeting the inner handler
+	syntheticReq, err := http.NewRequestWithContext(
+		r.Context(),
+		http.MethodPost,
+		"/webhooks/verification/stripe",
+		bytes.NewReader(syntheticBody),
+	)
+	if err != nil {
+		a.logger.Error("failed to create synthetic request", "error", err)
+		writeStripeErrorResponse(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	syntheticReq.Header.Set("Content-Type", "application/json")
+	syntheticReq.Header.Set(WebhookSignatureHeader, sig)
+
+	// Delegate to the inner handler, capturing its response
+	rr := httptest.NewRecorder()
+	a.inner.HandleWebhook(rr, syntheticReq)
+
+	// Relay the inner handler's response back to the Stripe caller
+	for k, vs := range rr.Header() {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(rr.Code)
+	_, _ = w.Write(rr.Body.Bytes())
+}
+
+// parseStripeSignature parses the Stripe-Signature header.
+// Format: "t=<timestamp>,v1=<sig1>,v1=<sig2>,..."
+func parseStripeSignature(header string) (timestamp string, signatures []string, err error) {
+	parts := strings.Split(header, ",")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		idx := strings.IndexByte(part, '=')
+		if idx < 0 {
+			continue
+		}
+		key := part[:idx]
+		val := part[idx+1:]
+		switch key {
+		case "t":
+			timestamp = val
+		case "v1":
+			signatures = append(signatures, val)
+		}
+	}
+	if timestamp == "" {
+		return "", nil, ErrStripeSignatureInvalid
+	}
+	if len(signatures) == 0 {
+		return "", nil, ErrStripeSignatureInvalid
+	}
+	return timestamp, signatures, nil
+}
+
+// validateStripeSignature validates the Stripe webhook signature.
+func validateStripeSignature(payload []byte, sigHeader string, secret []byte, tolerance time.Duration) error {
+	timestamp, signatures, err := parseStripeSignature(sigHeader)
+	if err != nil {
+		return ErrStripeSignatureInvalid
+	}
+
+	// Validate timestamp
+	ts, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return ErrStripeSignatureInvalid
+	}
+	webhookTime := time.Unix(ts, 0)
+	age := time.Since(webhookTime)
+	if age > tolerance {
+		return ErrStripeTimestampExpired
+	}
+
+	// Compute expected signature: HMAC-SHA256(secret, timestamp + "." + payload)
+	signedPayload := timestamp + "." + string(payload)
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(signedPayload))
+	expected := hex.EncodeToString(mac.Sum(nil))
+
+	// Accept if any v1 signature matches (constant-time comparison)
+	for _, sig := range signatures {
+		expectedBytes, err := hex.DecodeString(expected)
+		if err != nil {
+			continue
+		}
+		sigBytes, err := hex.DecodeString(sig)
+		if err != nil {
+			continue
+		}
+		if hmac.Equal(expectedBytes, sigBytes) {
+			return nil
+		}
+	}
+	return ErrStripeSignatureInvalid
+}
+
+// mapStripeEventToStatus maps a Stripe Identity event type to a verification.Status.
+// Returns (status, true) for known event types, ("", false) for unknown/irrelevant ones.
+func mapStripeEventToStatus(eventType string) (verification.Status, bool) {
+	switch eventType {
+	case "identity.verification_session.verified":
+		return verification.StatusApproved, true
+	case "identity.verification_session.canceled":
+		return verification.StatusRejected, true
+	case "identity.verification_session.requires_input":
+		return verification.StatusPending, true
+	case "identity.verification_session.processing":
+		return verification.StatusPending, true
+	case "identity.verification_session.redacted":
+		return verification.StatusRejected, true
+	default:
+		return "", false
+	}
+}
+
+// writeStripeErrorResponse writes an error response in the standard webhook format.
+func writeStripeErrorResponse(w http.ResponseWriter, statusCode int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	resp := VerificationWebhookResponse{
+		Acknowledged: false,
+		Error:        message,
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// writeStripeSuccessResponse writes a success response in the standard webhook format.
+func writeStripeSuccessResponse(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	resp := VerificationWebhookResponse{
+		Acknowledged: true,
+		Message:      message,
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/services/party/adapters/http/stripe_webhook_adapter_test.go
+++ b/services/party/adapters/http/stripe_webhook_adapter_test.go
@@ -1,0 +1,519 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/party/service"
+	"github.com/meridianhub/meridian/services/party/verification"
+)
+
+// generateStripeSignature generates a valid Stripe-Signature header for testing.
+func generateStripeSignature(t *testing.T, payload []byte, secret []byte) string {
+	t.Helper()
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	signedPayload := timestamp + "." + string(payload)
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(signedPayload))
+	sig := hex.EncodeToString(mac.Sum(nil))
+	return fmt.Sprintf("t=%s,v1=%s", timestamp, sig)
+}
+
+// generateStripeSignatureWithTime generates a Stripe-Signature header with a specific timestamp.
+func generateStripeSignatureWithTime(t *testing.T, payload []byte, secret []byte, ts time.Time) string {
+	t.Helper()
+	timestamp := strconv.FormatInt(ts.Unix(), 10)
+	signedPayload := timestamp + "." + string(payload)
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(signedPayload))
+	sig := hex.EncodeToString(mac.Sum(nil))
+	return fmt.Sprintf("t=%s,v1=%s", timestamp, sig)
+}
+
+// buildAdapter constructs a StripeWebhookAdapter with a mock inner handler for testing.
+func buildAdapter(t *testing.T, stripeSecret, innerSecret []byte, svc VerificationUpdater) *StripeWebhookAdapter {
+	t.Helper()
+	if svc == nil {
+		svc = &mockVerificationService{}
+	}
+	inner, err := NewVerificationWebhookHandler(VerificationWebhookHandlerConfig{
+		VerificationService: svc,
+		HMACSecrets:         map[string][]byte{"stripe": innerSecret},
+	})
+	require.NoError(t, err)
+
+	adapter, err := NewStripeWebhookAdapter(StripeWebhookAdapterConfig{
+		InnerHandler:    inner,
+		WebhookSecret:   stripeSecret,
+		InnerHMACSecret: innerSecret,
+	})
+	require.NoError(t, err)
+	return adapter
+}
+
+// buildStripeBody creates a Stripe event JSON payload.
+func buildStripeBody(t *testing.T, eventType, sessionID string, meta map[string]string) []byte {
+	t.Helper()
+	if meta == nil {
+		meta = map[string]string{}
+	}
+	event := stripeEvent{
+		ID:   "evt_test_123",
+		Type: eventType,
+		Data: stripeEventData{
+			Object: stripeVerificationSession{
+				ID:       sessionID,
+				Status:   "verified",
+				Metadata: meta,
+			},
+		},
+	}
+	body, err := json.Marshal(event)
+	require.NoError(t, err)
+	return body
+}
+
+// --- Constructor tests ---
+
+func TestNewStripeWebhookAdapter_NilInnerHandler(t *testing.T) {
+	_, err := NewStripeWebhookAdapter(StripeWebhookAdapterConfig{
+		InnerHandler:    nil,
+		WebhookSecret:   []byte("secret"),
+		InnerHMACSecret: []byte("inner"),
+	})
+	assert.ErrorIs(t, err, ErrNilInnerHandler)
+}
+
+func TestNewStripeWebhookAdapter_EmptyStripeSecret(t *testing.T) {
+	inner, err := NewVerificationWebhookHandler(VerificationWebhookHandlerConfig{
+		VerificationService: &mockVerificationService{},
+		HMACSecrets:         map[string][]byte{"default": []byte("s")},
+	})
+	require.NoError(t, err)
+
+	_, err = NewStripeWebhookAdapter(StripeWebhookAdapterConfig{
+		InnerHandler:    inner,
+		WebhookSecret:   []byte{},
+		InnerHMACSecret: []byte("inner"),
+	})
+	assert.ErrorIs(t, err, ErrEmptyStripeSecret)
+}
+
+func TestNewStripeWebhookAdapter_EmptyInnerSecret(t *testing.T) {
+	inner, err := NewVerificationWebhookHandler(VerificationWebhookHandlerConfig{
+		VerificationService: &mockVerificationService{},
+		HMACSecrets:         map[string][]byte{"default": []byte("s")},
+	})
+	require.NoError(t, err)
+
+	_, err = NewStripeWebhookAdapter(StripeWebhookAdapterConfig{
+		InnerHandler:    inner,
+		WebhookSecret:   []byte("stripe-secret"),
+		InnerHMACSecret: []byte{},
+	})
+	assert.ErrorIs(t, err, ErrEmptyInnerSecret)
+}
+
+func TestNewStripeWebhookAdapter_ValidConfig(t *testing.T) {
+	inner, err := NewVerificationWebhookHandler(VerificationWebhookHandlerConfig{
+		VerificationService: &mockVerificationService{},
+		HMACSecrets:         map[string][]byte{"stripe": []byte("inner-secret")},
+	})
+	require.NoError(t, err)
+
+	adapter, err := NewStripeWebhookAdapter(StripeWebhookAdapterConfig{
+		InnerHandler:    inner,
+		WebhookSecret:   []byte("stripe-secret"),
+		InnerHMACSecret: []byte("inner-secret"),
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, adapter)
+}
+
+// --- Signature validation tests ---
+
+func TestStripeAdapter_MissingSignatureHeader(t *testing.T) {
+	stripeSecret := []byte("whsec_test")
+	innerSecret := []byte("inner-secret")
+	adapter := buildAdapter(t, stripeSecret, innerSecret, nil)
+
+	body := buildStripeBody(t, "identity.verification_session.verified", "vs_test", nil)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/verification/stripe", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	adapter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	var resp VerificationWebhookResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.False(t, resp.Acknowledged)
+	assert.Equal(t, ErrStripeSignatureMissing.Error(), resp.Error)
+}
+
+func TestStripeAdapter_InvalidSignature(t *testing.T) {
+	stripeSecret := []byte("whsec_test")
+	innerSecret := []byte("inner-secret")
+	adapter := buildAdapter(t, stripeSecret, innerSecret, nil)
+
+	body := buildStripeBody(t, "identity.verification_session.verified", "vs_test", nil)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/verification/stripe", bytes.NewReader(body))
+	// Sign with wrong secret
+	req.Header.Set(stripeSignatureHeader, generateStripeSignature(t, body, []byte("wrong-secret")))
+	rr := httptest.NewRecorder()
+	adapter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	var resp VerificationWebhookResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.False(t, resp.Acknowledged)
+	assert.Equal(t, ErrStripeSignatureInvalid.Error(), resp.Error)
+}
+
+func TestStripeAdapter_ExpiredTimestamp(t *testing.T) {
+	stripeSecret := []byte("whsec_test")
+	innerSecret := []byte("inner-secret")
+	adapter := buildAdapter(t, stripeSecret, innerSecret, nil)
+
+	body := buildStripeBody(t, "identity.verification_session.verified", "vs_test", nil)
+	// Timestamp 10 minutes in the past
+	oldTime := time.Now().Add(-10 * time.Minute)
+	sig := generateStripeSignatureWithTime(t, body, stripeSecret, oldTime)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/verification/stripe", bytes.NewReader(body))
+	req.Header.Set(stripeSignatureHeader, sig)
+	rr := httptest.NewRecorder()
+	adapter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	var resp VerificationWebhookResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.False(t, resp.Acknowledged)
+	assert.Equal(t, ErrStripeTimestampExpired.Error(), resp.Error)
+}
+
+func TestStripeAdapter_ValidSignature_Accepted(t *testing.T) {
+	stripeSecret := []byte("whsec_test")
+	innerSecret := []byte("inner-secret")
+	mock := &mockVerificationService{}
+	adapter := buildAdapter(t, stripeSecret, innerSecret, mock)
+
+	body := buildStripeBody(t, "identity.verification_session.verified", "vs_abc123", nil)
+	sig := generateStripeSignature(t, body, stripeSecret)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/verification/stripe", bytes.NewReader(body))
+	req.Header.Set(stripeSignatureHeader, sig)
+	rr := httptest.NewRecorder()
+	adapter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestStripeAdapter_MultipleV1Signatures_OneValid(t *testing.T) {
+	stripeSecret := []byte("whsec_test")
+	innerSecret := []byte("inner-secret")
+	mock := &mockVerificationService{}
+	adapter := buildAdapter(t, stripeSecret, innerSecret, mock)
+
+	body := buildStripeBody(t, "identity.verification_session.verified", "vs_test", nil)
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	// Generate one invalid and one valid v1 sig
+	badSig := "0000000000000000000000000000000000000000000000000000000000000000"
+	signedPayload := timestamp + "." + string(body)
+	mac := hmac.New(sha256.New, stripeSecret)
+	mac.Write([]byte(signedPayload))
+	goodSig := hex.EncodeToString(mac.Sum(nil))
+	sigHeader := fmt.Sprintf("t=%s,v1=%s,v1=%s", timestamp, badSig, goodSig)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/verification/stripe", bytes.NewReader(body))
+	req.Header.Set(stripeSignatureHeader, sigHeader)
+	rr := httptest.NewRecorder()
+	adapter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestStripeAdapter_FutureTimestampWithinTolerance_Accepted(t *testing.T) {
+	stripeSecret := []byte("whsec_test")
+	innerSecret := []byte("inner-secret")
+	mock := &mockVerificationService{}
+	adapter := buildAdapter(t, stripeSecret, innerSecret, mock)
+
+	body := buildStripeBody(t, "identity.verification_session.verified", "vs_test", nil)
+	// 10 seconds in the future — within the stripe tolerance (5 min max age check)
+	// Note: tolerance is on age, not future drift; Stripe docs don't check future drift
+	futureTime := time.Now().Add(10 * time.Second)
+	sig := generateStripeSignatureWithTime(t, body, stripeSecret, futureTime)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/verification/stripe", bytes.NewReader(body))
+	req.Header.Set(stripeSignatureHeader, sig)
+	rr := httptest.NewRecorder()
+	adapter.ServeHTTP(rr, req)
+
+	// Future timestamps within tolerance are accepted (age < tolerance)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+// --- Event type mapping tests ---
+
+func TestMapStripeEventToStatus(t *testing.T) {
+	tests := []struct {
+		eventType      string
+		expectedStatus verification.Status
+		expectedOK     bool
+	}{
+		{"identity.verification_session.verified", verification.StatusApproved, true},
+		{"identity.verification_session.canceled", verification.StatusRejected, true},
+		{"identity.verification_session.requires_input", verification.StatusPending, true},
+		{"identity.verification_session.processing", verification.StatusPending, true},
+		{"identity.verification_session.redacted", verification.StatusRejected, true},
+		{"identity.verification_session.created", "", false},
+		{"payment_intent.succeeded", "", false},
+		{"", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.eventType, func(t *testing.T) {
+			status, ok := mapStripeEventToStatus(tt.eventType)
+			assert.Equal(t, tt.expectedOK, ok)
+			assert.Equal(t, tt.expectedStatus, status)
+		})
+	}
+}
+
+func TestStripeAdapter_VerifiedEvent_MapsToApproved(t *testing.T) {
+	stripeSecret := []byte("whsec_test")
+	innerSecret := []byte("inner-secret")
+	mock := &mockVerificationService{}
+	adapter := buildAdapter(t, stripeSecret, innerSecret, mock)
+
+	body := buildStripeBody(t, "identity.verification_session.verified", "vs_verified_123", nil)
+	sig := generateStripeSignature(t, body, stripeSecret)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/verification/stripe", bytes.NewReader(body))
+	req.Header.Set(stripeSignatureHeader, sig)
+	rr := httptest.NewRecorder()
+	adapter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	require.Len(t, mock.calls, 1)
+	assert.Equal(t, "vs_verified_123", mock.calls[0].ProviderVerificationID)
+	assert.Equal(t, "APPROVED", mock.calls[0].Status)
+}
+
+func TestStripeAdapter_CanceledEvent_MapsToRejected(t *testing.T) {
+	stripeSecret := []byte("whsec_test")
+	innerSecret := []byte("inner-secret")
+	mock := &mockVerificationService{}
+	adapter := buildAdapter(t, stripeSecret, innerSecret, mock)
+
+	body := buildStripeBody(t, "identity.verification_session.canceled", "vs_canceled_456", nil)
+	sig := generateStripeSignature(t, body, stripeSecret)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/verification/stripe", bytes.NewReader(body))
+	req.Header.Set(stripeSignatureHeader, sig)
+	rr := httptest.NewRecorder()
+	adapter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	require.Len(t, mock.calls, 1)
+	assert.Equal(t, "vs_canceled_456", mock.calls[0].ProviderVerificationID)
+	assert.Equal(t, "REJECTED", mock.calls[0].Status)
+}
+
+func TestStripeAdapter_RequiresInputEvent_MapsToPending(t *testing.T) {
+	stripeSecret := []byte("whsec_test")
+	innerSecret := []byte("inner-secret")
+	mock := &mockVerificationService{}
+	adapter := buildAdapter(t, stripeSecret, innerSecret, mock)
+
+	body := buildStripeBody(t, "identity.verification_session.requires_input", "vs_pending_789", nil)
+	sig := generateStripeSignature(t, body, stripeSecret)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/verification/stripe", bytes.NewReader(body))
+	req.Header.Set(stripeSignatureHeader, sig)
+	rr := httptest.NewRecorder()
+	adapter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	require.Len(t, mock.calls, 1)
+	assert.Equal(t, "PENDING", mock.calls[0].Status)
+}
+
+func TestStripeAdapter_ProcessingEvent_MapsToPending(t *testing.T) {
+	stripeSecret := []byte("whsec_test")
+	innerSecret := []byte("inner-secret")
+	mock := &mockVerificationService{}
+	adapter := buildAdapter(t, stripeSecret, innerSecret, mock)
+
+	body := buildStripeBody(t, "identity.verification_session.processing", "vs_processing_000", nil)
+	sig := generateStripeSignature(t, body, stripeSecret)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/verification/stripe", bytes.NewReader(body))
+	req.Header.Set(stripeSignatureHeader, sig)
+	rr := httptest.NewRecorder()
+	adapter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	require.Len(t, mock.calls, 1)
+	assert.Equal(t, "PENDING", mock.calls[0].Status)
+}
+
+func TestStripeAdapter_UnknownEventType_Ignored(t *testing.T) {
+	stripeSecret := []byte("whsec_test")
+	innerSecret := []byte("inner-secret")
+	mock := &mockVerificationService{}
+	adapter := buildAdapter(t, stripeSecret, innerSecret, mock)
+
+	body := buildStripeBody(t, "identity.verification_session.created", "vs_created_000", nil)
+	sig := generateStripeSignature(t, body, stripeSecret)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/verification/stripe", bytes.NewReader(body))
+	req.Header.Set(stripeSignatureHeader, sig)
+	rr := httptest.NewRecorder()
+	adapter.ServeHTTP(rr, req)
+
+	// Should return 200 with acknowledged=true and "not relevant" message
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp VerificationWebhookResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.True(t, resp.Acknowledged)
+	assert.Contains(t, resp.Message, "not relevant")
+	// Inner handler must NOT have been called
+	assert.Empty(t, mock.calls)
+}
+
+// --- Method not allowed ---
+
+func TestStripeAdapter_MethodNotAllowed(t *testing.T) {
+	stripeSecret := []byte("whsec_test")
+	innerSecret := []byte("inner-secret")
+	adapter := buildAdapter(t, stripeSecret, innerSecret, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/webhooks/verification/stripe", nil)
+	rr := httptest.NewRecorder()
+	adapter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+// --- End-to-end flow tests ---
+
+func TestStripeAdapter_EndToEnd_InnerHandlerReceivesCorrectRequest(t *testing.T) {
+	stripeSecret := []byte("whsec_e2e_test")
+	innerSecret := []byte("inner-hmac-secret")
+	mock := &mockVerificationService{}
+	adapter := buildAdapter(t, stripeSecret, innerSecret, mock)
+
+	meta := map[string]string{
+		"party_id":   "550e8400-e29b-41d4-a716-446655440000",
+		"party_type": "PERSON",
+	}
+	body := buildStripeBody(t, "identity.verification_session.verified", "vs_e2e_test", meta)
+	sig := generateStripeSignature(t, body, stripeSecret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/verification/stripe", bytes.NewReader(body))
+	req.Header.Set(stripeSignatureHeader, sig)
+	rr := httptest.NewRecorder()
+	adapter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	require.Len(t, mock.calls, 1)
+
+	call := mock.calls[0]
+	assert.Equal(t, "vs_e2e_test", call.ProviderVerificationID)
+	assert.Equal(t, "APPROVED", call.Status)
+	assert.Equal(t, meta, call.Metadata)
+	assert.NotNil(t, call.CompletedAt)
+}
+
+func TestStripeAdapter_EndToEnd_InnerHMACCorrectlyComputed(t *testing.T) {
+	// This test verifies the inner HMAC is computed correctly by using a
+	// wrong innerHMACSecret and confirming the inner handler rejects it.
+	stripeSecret := []byte("whsec_test")
+	correctInnerSecret := []byte("correct-inner-secret")
+	wrongInnerSecret := []byte("wrong-inner-secret")
+
+	// Build inner handler with correct secret
+	inner, err := NewVerificationWebhookHandler(VerificationWebhookHandlerConfig{
+		VerificationService: &mockVerificationService{},
+		HMACSecrets:         map[string][]byte{"stripe": correctInnerSecret},
+	})
+	require.NoError(t, err)
+
+	// Build adapter with WRONG inner secret — it will sign with wrong key
+	adapter, err := NewStripeWebhookAdapter(StripeWebhookAdapterConfig{
+		InnerHandler:    inner,
+		WebhookSecret:   stripeSecret,
+		InnerHMACSecret: wrongInnerSecret,
+	})
+	require.NoError(t, err)
+
+	body := buildStripeBody(t, "identity.verification_session.verified", "vs_test", nil)
+	sig := generateStripeSignature(t, body, stripeSecret)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/verification/stripe", bytes.NewReader(body))
+	req.Header.Set(stripeSignatureHeader, sig)
+	rr := httptest.NewRecorder()
+	adapter.ServeHTTP(rr, req)
+
+	// Inner handler should reject the badly-signed synthetic request
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestStripeAdapter_IdempotentAlreadyCompleted(t *testing.T) {
+	stripeSecret := []byte("whsec_test")
+	innerSecret := []byte("inner-secret")
+	mock := &mockVerificationService{
+		updateFunc: func(_ context.Context, _ service.UpdateVerificationRequest) error {
+			return service.ErrVerificationAlreadyCompleted
+		},
+	}
+	adapter := buildAdapter(t, stripeSecret, innerSecret, mock)
+
+	body := buildStripeBody(t, "identity.verification_session.verified", "vs_done", nil)
+	sig := generateStripeSignature(t, body, stripeSecret)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/verification/stripe", bytes.NewReader(body))
+	req.Header.Set(stripeSignatureHeader, sig)
+	rr := httptest.NewRecorder()
+	adapter.ServeHTTP(rr, req)
+
+	// Idempotent — inner handler returns 200 for already-completed
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp VerificationWebhookResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.True(t, resp.Acknowledged)
+}
+
+// --- parseStripeSignature tests ---
+
+func TestParseStripeSignature_Valid(t *testing.T) {
+	header := "t=1614556800,v1=abc123,v1=def456"
+	ts, sigs, err := parseStripeSignature(header)
+	require.NoError(t, err)
+	assert.Equal(t, "1614556800", ts)
+	assert.Equal(t, []string{"abc123", "def456"}, sigs)
+}
+
+func TestParseStripeSignature_MissingTimestamp(t *testing.T) {
+	header := "v1=abc123"
+	_, _, err := parseStripeSignature(header)
+	assert.Error(t, err)
+}
+
+func TestParseStripeSignature_MissingSignature(t *testing.T) {
+	header := "t=1614556800"
+	_, _, err := parseStripeSignature(header)
+	assert.Error(t, err)
+}
+
+func TestParseStripeSignature_ExtraFields_Ignored(t *testing.T) {
+	header := "t=1614556800,v0=old,v1=good,v2=unknown"
+	ts, sigs, err := parseStripeSignature(header)
+	require.NoError(t, err)
+	assert.Equal(t, "1614556800", ts)
+	// Only v1 signatures are returned
+	assert.Equal(t, []string{"good"}, sigs)
+}


### PR DESCRIPTION
## Summary

- Implement `StripeWebhookAdapter` that translates Stripe Identity webhook format to the generic `VerificationWebhookHandler`
- Validates `Stripe-Signature` header (HMAC-SHA256 with 5-minute timestamp tolerance, constant-time comparison, multiple v1 signature support)
- Maps all Stripe Identity event types to domain verification statuses (`verified`→APPROVED, `canceled`→REJECTED, `requires_input`/`processing`→PENDING, `redacted`→REJECTED)
- Delegates to existing `VerificationWebhookHandler` via signed synthetic request; unknown event types acknowledged gracefully with 200

## Changes Made

- `services/party/adapters/http/stripe_webhook_adapter.go` — new adapter implementing `http.Handler`
- `services/party/adapters/http/stripe_webhook_adapter_test.go` — comprehensive unit tests

## Technical Details

The adapter wraps the existing `VerificationWebhookHandler` (unchanged). It validates the inbound Stripe signature, constructs a `VerificationWebhookRequest`, signs it with the inner handler's HMAC secret via `GenerateWebhookSignature`, and delegates via a synthetic `*http.Request`. This preserves the inner handler's security model.

## Test Plan

- [ ] All new Stripe webhook adapter tests pass (26 new test cases)
- [ ] All existing webhook handler tests pass (no regressions)
- [ ] CI green

## Task Master

Covers stripe-identity-kyc.5 (StripeWebhookAdapter) and stripe-identity-kyc.7 (unit tests for webhook adapter).