### PR TITLE
feat: wire Stripe Identity provider into config, factory, and HTTP routes

### DIFF
--- a/services/party/cmd/main.go
+++ b/services/party/cmd/main.go
@@ -223,12 +223,31 @@ func run(logger *slog.Logger) error {
 				VerificationService: verificationSvc,
 				HMACSecrets: map[string][]byte{
 					"default": []byte(verificationCfg.WebhookSecret),
+					"stripe":  []byte(verificationCfg.WebhookSecret),
 				},
 				Logger: logger,
 			},
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create webhook handler: %w", err)
+		}
+
+		// Register provider-specific webhook routes before the generic catch-all.
+		// For Stripe, we use the StripeWebhookAdapter which validates the Stripe-Signature
+		// header and translates the Stripe event format to our generic webhook format.
+		if strings.ToLower(verificationCfg.Provider) == "stripe" {
+			stripeAdapter, err := httpAdapter.NewStripeWebhookAdapter(
+				httpAdapter.StripeWebhookAdapterConfig{
+					InnerHandler:    webhookHandler,
+					WebhookSecret:   []byte(verificationCfg.WebhookSecret),
+					InnerHMACSecret: []byte(verificationCfg.WebhookSecret),
+					Logger:          logger,
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("failed to create stripe webhook adapter: %w", err)
+			}
+			httpMux.Handle("/webhooks/verification/stripe", stripeAdapter)
 		}
 
 		httpMux.HandleFunc("/webhooks/verification/", webhookHandler.HandleWebhook)

--- a/services/party/cmd/main.go
+++ b/services/party/cmd/main.go
@@ -246,7 +246,7 @@ func run(logger *slog.Logger) error {
 				},
 			)
 			if err != nil {
-				return fmt.Errorf("failed to create stripe webhook adapter: %w", err)
+				return bootstrap.Permanent(fmt.Errorf("failed to create stripe webhook adapter: %w", err))
 			}
 			httpMux.Handle("/webhooks/verification/stripe", stripeAdapter)
 		}

--- a/services/party/cmd/main.go
+++ b/services/party/cmd/main.go
@@ -234,12 +234,13 @@ func run(logger *slog.Logger) error {
 
 		// Register provider-specific webhook routes before the generic catch-all.
 		// For Stripe, we use the StripeWebhookAdapter which validates the Stripe-Signature
-		// header and translates the Stripe event format to our generic webhook format.
+		// header (using the Stripe endpoint signing secret) and translates the Stripe event
+		// format to our generic webhook format (signed with the generic HMAC secret).
 		if strings.ToLower(verificationCfg.Provider) == "stripe" {
 			stripeAdapter, err := httpAdapter.NewStripeWebhookAdapter(
 				httpAdapter.StripeWebhookAdapterConfig{
 					InnerHandler:    webhookHandler,
-					WebhookSecret:   []byte(verificationCfg.WebhookSecret),
+					WebhookSecret:   []byte(verificationCfg.StripeWebhookSecret),
 					InnerHMACSecret: []byte(verificationCfg.WebhookSecret),
 					Logger:          logger,
 				},

--- a/services/party/config/verification.go
+++ b/services/party/config/verification.go
@@ -18,21 +18,33 @@ import (
 // ProviderConfig contains provider-specific settings like API keys and endpoints.
 // Required keys vary by provider.
 //
-// WebhookSecret is the HMAC secret used to verify incoming webhook signatures.
-// This prevents malicious actors from spoofing verification callbacks.
+// WebhookSecret is the HMAC secret used to verify incoming webhook signatures
+// for the generic webhook handler and as the inner HMAC secret for the Stripe
+// adapter. This prevents malicious actors from spoofing verification callbacks.
+//
+// StripeWebhookSecret is the Stripe endpoint signing secret (whsec_ prefixed)
+// used exclusively to validate the Stripe-Signature header on inbound Stripe
+// webhooks. Required when provider is "stripe".
 //
 // WebhookURL is the publicly accessible URL where providers send verification
 // callbacks. Required for production deployments.
 type VerificationConfig struct {
-	// Provider is the verification provider to use ("mock", "jumio", "onfido").
+	// Provider is the verification provider to use ("mock", "jumio", "onfido", "stripe").
 	Provider string
 
 	// ProviderConfig contains provider-specific configuration.
 	// For jumio/onfido: "api_key", "api_secret", "base_url" (optional).
+	// For stripe: "api_key", "base_url" (optional), "stripe_account" (optional).
 	ProviderConfig map[string]string
 
-	// WebhookSecret is the HMAC secret for validating webhook signatures.
+	// WebhookSecret is the HMAC secret for validating webhook signatures on the
+	// generic handler and as the inner HMAC secret for the Stripe adapter.
 	WebhookSecret string
+
+	// StripeWebhookSecret is the Stripe endpoint signing secret (whsec_ prefixed)
+	// used to validate inbound Stripe webhook signatures.
+	// Loaded from STRIPE_WEBHOOK_SECRET. Required when provider is "stripe".
+	StripeWebhookSecret string
 
 	// WebhookURL is the public URL for provider callbacks (e.g., "https://api.example.com/webhooks/verification").
 	WebhookURL string
@@ -46,6 +58,7 @@ var (
 	ErrEmptyWebhookURLForNonMock    = errors.New("webhook URL is required for non-mock providers")
 	ErrMissingProviderAPIKey        = errors.New("api_key is required in provider config")
 	ErrMissingProviderAPISecret     = errors.New("api_secret is required in provider config")
+	ErrMissingStripeWebhookSecret   = errors.New("stripe_webhook_secret is required when provider is stripe (set STRIPE_WEBHOOK_SECRET)")
 	ErrMockProviderInProduction     = errors.New("mock provider not allowed in production")
 	ErrWebhookHTTPSRequired         = errors.New("webhook URL must use HTTPS in production")
 	ErrWebhookSecretTooShort        = errors.New("webhook secret must be at least 32 characters in production")
@@ -60,13 +73,17 @@ var SupportedProviders = []string{"mock", "jumio", "onfido", "stripe"}
 //   - VERIFICATION_PROVIDER: The provider to use (required)
 //
 // Conditional environment variables (required for non-mock providers):
-//   - VERIFICATION_WEBHOOK_SECRET: HMAC secret for webhook validation
+//   - VERIFICATION_WEBHOOK_SECRET: HMAC secret for generic webhook validation
 //   - VERIFICATION_WEBHOOK_URL: Public webhook callback URL
 //
 // Provider-specific environment variables:
 //   - VERIFICATION_API_KEY: Provider API key
-//   - VERIFICATION_API_SECRET: Provider API secret
+//   - VERIFICATION_API_SECRET: Provider API secret (not required for Stripe)
 //   - VERIFICATION_BASE_URL: Provider base URL (optional, provider default used if not set)
+//
+// Stripe-specific environment variables:
+//   - STRIPE_WEBHOOK_SECRET: Stripe endpoint signing secret (whsec_ prefixed).
+//     Required when VERIFICATION_PROVIDER=stripe.
 func LoadVerificationConfig() (*VerificationConfig, error) {
 	providerConfig := make(map[string]string)
 
@@ -82,10 +99,11 @@ func LoadVerificationConfig() (*VerificationConfig, error) {
 	}
 
 	cfg := &VerificationConfig{
-		Provider:       strings.TrimSpace(os.Getenv("VERIFICATION_PROVIDER")),
-		ProviderConfig: providerConfig,
-		WebhookSecret:  strings.TrimSpace(os.Getenv("VERIFICATION_WEBHOOK_SECRET")),
-		WebhookURL:     strings.TrimSpace(os.Getenv("VERIFICATION_WEBHOOK_URL")),
+		Provider:            strings.TrimSpace(os.Getenv("VERIFICATION_PROVIDER")),
+		ProviderConfig:      providerConfig,
+		WebhookSecret:       strings.TrimSpace(os.Getenv("VERIFICATION_WEBHOOK_SECRET")),
+		StripeWebhookSecret: strings.TrimSpace(os.Getenv("STRIPE_WEBHOOK_SECRET")),
+		WebhookURL:          strings.TrimSpace(os.Getenv("VERIFICATION_WEBHOOK_URL")),
 	}
 
 	if err := cfg.Validate(); err != nil {
@@ -126,6 +144,11 @@ func (c *VerificationConfig) Validate() error {
 	// Stripe only needs api_key; other providers require api_secret as well
 	if strings.ToLower(c.Provider) != "stripe" && c.ProviderConfig["api_secret"] == "" {
 		return ErrMissingProviderAPISecret
+	}
+
+	// Stripe requires its own endpoint signing secret (distinct from the generic HMAC secret)
+	if strings.ToLower(c.Provider) == "stripe" && c.StripeWebhookSecret == "" {
+		return ErrMissingStripeWebhookSecret
 	}
 
 	return nil

--- a/services/party/config/verification.go
+++ b/services/party/config/verification.go
@@ -13,6 +13,7 @@ import (
 //   - "mock": Mock provider for testing (always available)
 //   - "jumio": Jumio identity verification
 //   - "onfido": Onfido identity verification
+//   - "stripe": Stripe Identity verification
 //
 // ProviderConfig contains provider-specific settings like API keys and endpoints.
 // Required keys vary by provider.
@@ -51,7 +52,7 @@ var (
 )
 
 // SupportedProviders lists all supported verification provider names.
-var SupportedProviders = []string{"mock", "jumio", "onfido"}
+var SupportedProviders = []string{"mock", "jumio", "onfido", "stripe"}
 
 // LoadVerificationConfig loads verification configuration from environment variables.
 //
@@ -122,7 +123,8 @@ func (c *VerificationConfig) Validate() error {
 	if c.ProviderConfig["api_key"] == "" {
 		return ErrMissingProviderAPIKey
 	}
-	if c.ProviderConfig["api_secret"] == "" {
+	// Stripe only needs api_key; other providers require api_secret as well
+	if strings.ToLower(c.Provider) != "stripe" && c.ProviderConfig["api_secret"] == "" {
 		return ErrMissingProviderAPISecret
 	}
 

--- a/services/party/config/verification_test.go
+++ b/services/party/config/verification_test.go
@@ -17,6 +17,7 @@ func clearVerificationEnv(t *testing.T) {
 		"VERIFICATION_API_KEY",
 		"VERIFICATION_API_SECRET",
 		"VERIFICATION_BASE_URL",
+		"STRIPE_WEBHOOK_SECRET",
 	}
 	for _, key := range envVars {
 		_ = os.Unsetenv(key)
@@ -271,6 +272,7 @@ func TestLoadVerificationConfig_StripeProvider_OnlyNeedsAPIKey(t *testing.T) {
 	t.Setenv("VERIFICATION_WEBHOOK_SECRET", "webhook-secret")
 	t.Setenv("VERIFICATION_WEBHOOK_URL", "https://api.example.com/webhooks/verification")
 	t.Setenv("VERIFICATION_API_KEY", "sk_test_my-stripe-key")
+	t.Setenv("STRIPE_WEBHOOK_SECRET", "whsec_test_stripe_endpoint_secret")
 	// No VERIFICATION_API_SECRET — Stripe does not need it
 
 	cfg, err := LoadVerificationConfig()
@@ -279,6 +281,21 @@ func TestLoadVerificationConfig_StripeProvider_OnlyNeedsAPIKey(t *testing.T) {
 	assert.Equal(t, "stripe", cfg.Provider)
 	assert.Equal(t, "sk_test_my-stripe-key", cfg.ProviderConfig["api_key"])
 	assert.Empty(t, cfg.ProviderConfig["api_secret"])
+	assert.Equal(t, "whsec_test_stripe_endpoint_secret", cfg.StripeWebhookSecret)
+}
+
+func TestLoadVerificationConfig_StripeProvider_MissingStripeWebhookSecret(t *testing.T) {
+	clearVerificationEnv(t)
+	t.Setenv("VERIFICATION_PROVIDER", "stripe")
+	t.Setenv("VERIFICATION_WEBHOOK_SECRET", "webhook-secret")
+	t.Setenv("VERIFICATION_WEBHOOK_URL", "https://api.example.com/webhooks/verification")
+	t.Setenv("VERIFICATION_API_KEY", "sk_test_my-stripe-key")
+	// No STRIPE_WEBHOOK_SECRET — required for Stripe
+
+	_, err := LoadVerificationConfig()
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingStripeWebhookSecret)
 }
 
 func TestVerificationConfig_Validate_StripeRequiresWebhookConfig(t *testing.T) {
@@ -296,15 +313,31 @@ func TestVerificationConfig_Validate_StripeRequiresWebhookConfig(t *testing.T) {
 
 func TestVerificationConfig_Validate_StripeWithoutAPISecretPasses(t *testing.T) {
 	cfg := &VerificationConfig{
-		Provider:       "stripe",
-		WebhookSecret:  "webhook-secret",
-		WebhookURL:     "https://example.com/webhooks/verification",
-		ProviderConfig: map[string]string{"api_key": "sk_test_key"},
+		Provider:            "stripe",
+		WebhookSecret:       "webhook-secret",
+		StripeWebhookSecret: "whsec_test_endpoint_secret",
+		WebhookURL:          "https://example.com/webhooks/verification",
+		ProviderConfig:      map[string]string{"api_key": "sk_test_key"},
 	}
 
 	err := cfg.Validate()
 
 	assert.NoError(t, err)
+}
+
+func TestVerificationConfig_Validate_StripeMissingStripeWebhookSecret(t *testing.T) {
+	cfg := &VerificationConfig{
+		Provider:            "stripe",
+		WebhookSecret:       "webhook-secret",
+		StripeWebhookSecret: "", // missing
+		WebhookURL:          "https://example.com/webhooks/verification",
+		ProviderConfig:      map[string]string{"api_key": "sk_test_key"},
+	}
+
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingStripeWebhookSecret)
 }
 
 func TestVerificationConfig_ValidateForEnvironment_ProductionRejectsMock(t *testing.T) {

--- a/services/party/config/verification_test.go
+++ b/services/party/config/verification_test.go
@@ -261,7 +261,50 @@ func TestVerificationConfig_SupportedProviders(t *testing.T) {
 	assert.Contains(t, SupportedProviders, "mock")
 	assert.Contains(t, SupportedProviders, "jumio")
 	assert.Contains(t, SupportedProviders, "onfido")
-	assert.Len(t, SupportedProviders, 3)
+	assert.Contains(t, SupportedProviders, "stripe")
+	assert.Len(t, SupportedProviders, 4)
+}
+
+func TestLoadVerificationConfig_StripeProvider_OnlyNeedsAPIKey(t *testing.T) {
+	clearVerificationEnv(t)
+	t.Setenv("VERIFICATION_PROVIDER", "stripe")
+	t.Setenv("VERIFICATION_WEBHOOK_SECRET", "webhook-secret")
+	t.Setenv("VERIFICATION_WEBHOOK_URL", "https://api.example.com/webhooks/verification")
+	t.Setenv("VERIFICATION_API_KEY", "sk_test_my-stripe-key")
+	// No VERIFICATION_API_SECRET — Stripe does not need it
+
+	cfg, err := LoadVerificationConfig()
+
+	require.NoError(t, err)
+	assert.Equal(t, "stripe", cfg.Provider)
+	assert.Equal(t, "sk_test_my-stripe-key", cfg.ProviderConfig["api_key"])
+	assert.Empty(t, cfg.ProviderConfig["api_secret"])
+}
+
+func TestVerificationConfig_Validate_StripeRequiresWebhookConfig(t *testing.T) {
+	cfg := &VerificationConfig{
+		Provider:       "stripe",
+		ProviderConfig: map[string]string{"api_key": "sk_test_key"},
+		// Missing WebhookSecret and WebhookURL
+	}
+
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEmptyWebhookSecretForNonMock)
+}
+
+func TestVerificationConfig_Validate_StripeWithoutAPISecretPasses(t *testing.T) {
+	cfg := &VerificationConfig{
+		Provider:       "stripe",
+		WebhookSecret:  "webhook-secret",
+		WebhookURL:     "https://example.com/webhooks/verification",
+		ProviderConfig: map[string]string{"api_key": "sk_test_key"},
+	}
+
+	err := cfg.Validate()
+
+	assert.NoError(t, err)
 }
 
 func TestVerificationConfig_ValidateForEnvironment_ProductionRejectsMock(t *testing.T) {

--- a/services/party/verification/factory.go
+++ b/services/party/verification/factory.go
@@ -20,6 +20,7 @@ var (
 // Currently supported providers:
 //   - "mock": Returns a MockProvider for testing and development
 //   - "onfido": Onfido identity verification
+//   - "stripe": Stripe Identity verification
 //
 // Future providers (stubs, not yet implemented):
 //   - "jumio": Jumio identity verification
@@ -40,6 +41,8 @@ func NewProvider(cfg *config.VerificationConfig) (Provider, error) {
 		return nil, ErrUnsupportedProvider
 	case "onfido":
 		return NewOnfidoProvider(cfg, slog.Default())
+	case "stripe":
+		return NewStripeIdentityProvider(cfg, slog.Default())
 	default:
 		return nil, ErrUnsupportedProvider
 	}
@@ -78,6 +81,8 @@ func NewProviderWithOptions(cfg *config.VerificationConfig, opts ProviderOptions
 		return nil, ErrUnsupportedProvider
 	case "onfido":
 		return NewOnfidoProvider(cfg, slog.Default())
+	case "stripe":
+		return NewStripeIdentityProvider(cfg, slog.Default())
 	default:
 		return nil, ErrUnsupportedProvider
 	}

--- a/services/party/verification/factory_test.go
+++ b/services/party/verification/factory_test.go
@@ -195,10 +195,11 @@ func TestNewProviderWithOptions_NonMockProvider_ReturnsError(t *testing.T) {
 
 func TestNewProvider_StripeProvider(t *testing.T) {
 	cfg := &config.VerificationConfig{
-		Provider:       "stripe",
-		WebhookSecret:  "webhook-secret",
-		WebhookURL:     "https://example.com/webhook",
-		ProviderConfig: map[string]string{"api_key": "sk_test_key"},
+		Provider:            "stripe",
+		WebhookSecret:       "webhook-secret",
+		StripeWebhookSecret: "whsec_test_endpoint_secret",
+		WebhookURL:          "https://example.com/webhook",
+		ProviderConfig:      map[string]string{"api_key": "sk_test_key"},
 	}
 
 	provider, err := NewProvider(cfg)
@@ -212,10 +213,11 @@ func TestNewProvider_StripeProvider(t *testing.T) {
 
 func TestNewProviderWithOptions_StripeProvider(t *testing.T) {
 	cfg := &config.VerificationConfig{
-		Provider:       "stripe",
-		WebhookSecret:  "webhook-secret",
-		WebhookURL:     "https://example.com/webhook",
-		ProviderConfig: map[string]string{"api_key": "sk_test_key"},
+		Provider:            "stripe",
+		WebhookSecret:       "webhook-secret",
+		StripeWebhookSecret: "whsec_test_endpoint_secret",
+		WebhookURL:          "https://example.com/webhook",
+		ProviderConfig:      map[string]string{"api_key": "sk_test_key"},
 	}
 
 	provider, err := NewProviderWithOptions(cfg, DefaultProviderOptions())

--- a/services/party/verification/factory_test.go
+++ b/services/party/verification/factory_test.go
@@ -193,6 +193,40 @@ func TestNewProviderWithOptions_NonMockProvider_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestNewProvider_StripeProvider(t *testing.T) {
+	cfg := &config.VerificationConfig{
+		Provider:       "stripe",
+		WebhookSecret:  "webhook-secret",
+		WebhookURL:     "https://example.com/webhook",
+		ProviderConfig: map[string]string{"api_key": "sk_test_key"},
+	}
+
+	provider, err := NewProvider(cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	_, ok := provider.(*StripeIdentityProvider)
+	assert.True(t, ok, "expected *StripeIdentityProvider type")
+}
+
+func TestNewProviderWithOptions_StripeProvider(t *testing.T) {
+	cfg := &config.VerificationConfig{
+		Provider:       "stripe",
+		WebhookSecret:  "webhook-secret",
+		WebhookURL:     "https://example.com/webhook",
+		ProviderConfig: map[string]string{"api_key": "sk_test_key"},
+	}
+
+	provider, err := NewProviderWithOptions(cfg, DefaultProviderOptions())
+
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	_, ok := provider.(*StripeIdentityProvider)
+	assert.True(t, ok, "expected *StripeIdentityProvider type")
+}
+
 func TestNewProviderWithOptions_OnfidoProvider(t *testing.T) {
 	cfg := &config.VerificationConfig{
 		Provider:       "onfido",

--- a/services/party/verification/stripe_integration_test.go
+++ b/services/party/verification/stripe_integration_test.go
@@ -89,11 +89,13 @@ func TestStripeProvider_FullLifecycleViaFactory(t *testing.T) {
 	server := newFakeStripeServer(t)
 	defer server.Close()
 
-	// Build config pointing at the fake server, with only api_key (no api_secret)
+	// Build config pointing at the fake server, with only api_key (no api_secret).
+	// StripeWebhookSecret is distinct from the generic WebhookSecret.
 	cfg := &config.VerificationConfig{
-		Provider:      "stripe",
-		WebhookSecret: "webhook-secret",
-		WebhookURL:    "https://example.com/webhooks/verification",
+		Provider:            "stripe",
+		WebhookSecret:       "generic-hmac-secret",
+		StripeWebhookSecret: "whsec_test_endpoint_secret",
+		WebhookURL:          "https://example.com/webhooks/verification",
 		ProviderConfig: map[string]string{
 			"api_key":  "sk_test_fake_key",
 			"base_url": server.URL,
@@ -148,9 +150,10 @@ func TestStripeProvider_GetVerificationStatus_NotFound(t *testing.T) {
 	defer server.Close()
 
 	cfg := &config.VerificationConfig{
-		Provider:      "stripe",
-		WebhookSecret: "webhook-secret",
-		WebhookURL:    "https://example.com/webhooks/verification",
+		Provider:            "stripe",
+		WebhookSecret:       "generic-hmac-secret",
+		StripeWebhookSecret: "whsec_test_endpoint_secret",
+		WebhookURL:          "https://example.com/webhooks/verification",
 		ProviderConfig: map[string]string{
 			"api_key":  "sk_test_fake_key",
 			"base_url": server.URL,
@@ -170,9 +173,10 @@ func TestStripeProvider_FactoryWithOptions(t *testing.T) {
 	defer server.Close()
 
 	cfg := &config.VerificationConfig{
-		Provider:      "stripe",
-		WebhookSecret: "webhook-secret",
-		WebhookURL:    "https://example.com/webhooks/verification",
+		Provider:            "stripe",
+		WebhookSecret:       "generic-hmac-secret",
+		StripeWebhookSecret: "whsec_test_endpoint_secret",
+		WebhookURL:          "https://example.com/webhooks/verification",
 		ProviderConfig: map[string]string{
 			"api_key":  "sk_test_fake_key",
 			"base_url": server.URL,

--- a/services/party/verification/stripe_integration_test.go
+++ b/services/party/verification/stripe_integration_test.go
@@ -1,0 +1,188 @@
+package verification_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/party/config"
+	"github.com/meridianhub/meridian/services/party/domain"
+	"github.com/meridianhub/meridian/services/party/verification"
+)
+
+// stripeSessionResponse mirrors the Stripe API response shape.
+type stripeSessionResponse struct {
+	ID           string `json:"id"`
+	Status       string `json:"status"`
+	ClientSecret string `json:"client_secret"`
+}
+
+// newFakeStripeServer creates a mock HTTP server that simulates the Stripe Identity API.
+// It handles:
+//   - POST /v1/identity/verification_sessions → creates a session
+//   - GET  /v1/identity/verification_sessions/:id → retrieves session status
+func newFakeStripeServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	sessions := map[string]stripeSessionResponse{}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/v1/identity/verification_sessions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		sess := stripeSessionResponse{
+			ID:           "vs_test_abc123",
+			Status:       "requires_input",
+			ClientSecret: "vs_test_abc123_secret_xyz",
+		}
+		sessions[sess.ID] = sess
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(sess)
+	})
+
+	mux.HandleFunc("/v1/identity/verification_sessions/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		// Extract session ID from path
+		sessionID := r.URL.Path[len("/v1/identity/verification_sessions/"):]
+
+		// Return verified status for the session
+		sess, ok := sessions[sessionID]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"type":"invalid_request_error","message":"No such identity verification session"}}`))
+			return
+		}
+
+		// Return session with verified status to simulate completion
+		sess.Status = "verified"
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(sess)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+// TestStripeProvider_FullLifecycleViaFactory tests the full Stripe provider lifecycle
+// using the factory. It validates that:
+//  1. A Stripe config with only api_key (no api_secret) passes validation
+//  2. The factory creates a StripeIdentityProvider
+//  3. VerifyIdentity creates a verification session and returns PENDING
+//  4. GetVerificationStatus returns APPROVED when Stripe reports "verified"
+//  5. CheckSanctions returns CLEAR (Stripe Identity doesn't support sanctions)
+func TestStripeProvider_FullLifecycleViaFactory(t *testing.T) {
+	server := newFakeStripeServer(t)
+	defer server.Close()
+
+	// Build config pointing at the fake server, with only api_key (no api_secret)
+	cfg := &config.VerificationConfig{
+		Provider:      "stripe",
+		WebhookSecret: "webhook-secret",
+		WebhookURL:    "https://example.com/webhooks/verification",
+		ProviderConfig: map[string]string{
+			"api_key":  "sk_test_fake_key",
+			"base_url": server.URL,
+		},
+	}
+
+	// Validate config passes without api_secret
+	require.NoError(t, cfg.Validate(), "stripe config with only api_key should be valid")
+
+	// Create provider via factory
+	provider, err := verification.NewProvider(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	// Verify it's a StripeIdentityProvider (via factory, not direct construction)
+	_, ok := provider.(*verification.StripeIdentityProvider)
+	require.True(t, ok, "factory should return *StripeIdentityProvider for stripe config")
+
+	// Create a test party
+	party, err := domain.NewParty(domain.PartyTypePerson, "Alice Test")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Step 1: Initiate verification — Stripe returns "requires_input" which maps to PENDING
+	result, err := provider.VerifyIdentity(ctx, party)
+	require.NoError(t, err)
+	assert.Equal(t, "vs_test_abc123", result.VerificationID)
+	assert.Equal(t, verification.StatusPending, result.Status, "requires_input should map to PENDING")
+	assert.Nil(t, result.CompletedAt, "PENDING result should have no completion time")
+	assert.Equal(t, "stripe", result.Metadata["provider"])
+
+	// Step 2: Retrieve status — fake server returns "verified" which maps to APPROVED
+	statusResult, err := provider.GetVerificationStatus(ctx, result.VerificationID)
+	require.NoError(t, err)
+	assert.Equal(t, "vs_test_abc123", statusResult.VerificationID)
+	assert.Equal(t, verification.StatusApproved, statusResult.Status, "verified should map to APPROVED")
+	assert.NotNil(t, statusResult.CompletedAt, "APPROVED result should have completion time")
+
+	// Step 3: Sanctions check — Stripe Identity does not support this
+	sanctionsResult, err := provider.CheckSanctions(ctx, party)
+	require.NoError(t, err)
+	assert.Equal(t, verification.SanctionsStatusClear, sanctionsResult.Status)
+	assert.Equal(t, "stripe", sanctionsResult.Metadata["provider"])
+	assert.Contains(t, sanctionsResult.Metadata["note"], "sanctions screening not supported")
+}
+
+// TestStripeProvider_GetVerificationStatus_NotFound validates that a missing session
+// returns ErrVerificationNotFound.
+func TestStripeProvider_GetVerificationStatus_NotFound(t *testing.T) {
+	server := newFakeStripeServer(t)
+	defer server.Close()
+
+	cfg := &config.VerificationConfig{
+		Provider:      "stripe",
+		WebhookSecret: "webhook-secret",
+		WebhookURL:    "https://example.com/webhooks/verification",
+		ProviderConfig: map[string]string{
+			"api_key":  "sk_test_fake_key",
+			"base_url": server.URL,
+		},
+	}
+
+	provider, err := verification.NewProvider(cfg)
+	require.NoError(t, err)
+
+	_, err = provider.GetVerificationStatus(context.Background(), "vs_nonexistent")
+	assert.ErrorIs(t, err, verification.ErrVerificationNotFound)
+}
+
+// TestStripeProvider_FactoryWithOptions validates NewProviderWithOptions also creates StripeIdentityProvider.
+func TestStripeProvider_FactoryWithOptions(t *testing.T) {
+	server := newFakeStripeServer(t)
+	defer server.Close()
+
+	cfg := &config.VerificationConfig{
+		Provider:      "stripe",
+		WebhookSecret: "webhook-secret",
+		WebhookURL:    "https://example.com/webhooks/verification",
+		ProviderConfig: map[string]string{
+			"api_key":  "sk_test_fake_key",
+			"base_url": server.URL,
+		},
+	}
+
+	provider, err := verification.NewProviderWithOptions(cfg, verification.DefaultProviderOptions())
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	_, ok := provider.(*verification.StripeIdentityProvider)
+	assert.True(t, ok, "NewProviderWithOptions should return *StripeIdentityProvider for stripe config")
+}


### PR DESCRIPTION
## Summary

- Add `stripe` to `SupportedProviders` in verification config
- Relax `api_secret` validation for Stripe — Stripe only requires `api_key`
- Register `StripeIdentityProvider` in `NewProvider` and `NewProviderWithOptions` factories
- Wire `StripeWebhookAdapter` at `/webhooks/verification/stripe` in the HTTP server (registered before the generic catch-all)
- Add `stripe` key to `HMACSecrets` map so the inner webhook handler can validate synthetic requests from the adapter

## Changes Made

### `services/party/config/verification.go`
- `SupportedProviders`: added `"stripe"` (now 4 providers)
- `Validate()`: Stripe skips the `api_secret` check; all other non-mock providers still require it

### `services/party/verification/factory.go`
- `NewProvider`: added `"stripe"` case → `NewStripeIdentityProvider`
- `NewProviderWithOptions`: added `"stripe"` case → `NewStripeIdentityProvider`

### `services/party/cmd/main.go`
- Added `"stripe"` to `HMACSecrets` map in `VerificationWebhookHandlerConfig`
- When `verificationCfg.Provider == "stripe"`, create `StripeWebhookAdapter` and register it at `/webhooks/verification/stripe` before the generic route

## Testing

- `services/party/config/verification_test.go`: three new tests covering Stripe-specific config validation
- `services/party/verification/factory_test.go`: two new tests asserting the factory returns `*StripeIdentityProvider`
- `services/party/verification/stripe_integration_test.go` (new): full lifecycle integration test using a mock HTTP server simulating the Stripe API — tests `VerifyIdentity`, `GetVerificationStatus`, `CheckSanctions`, and 404 handling

## Test plan
- [x] Config validation tests pass (Stripe-specific cases)
- [x] Factory tests pass (Stripe provider creation)
- [x] Integration test passes (full lifecycle via factory)
- [x] Full party service test suite passes (`go test ./services/party/... -count=1`)
- [ ] CI green