### PR TITLE
feat: add idempotency guard to internal-bank-account lien operations

### DIFF
--- a/api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
+++ b/api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
@@ -951,6 +951,9 @@ message ExecuteLienRequest {
     max_len: 100
     pattern: "^[a-zA-Z0-9_-]+$"
   }];
+
+  // idempotency_key ensures exactly-once lien execution for retry scenarios.
+  meridian.common.v1.IdempotencyKey idempotency_key = 2;
 }
 
 // ExecuteLienResponse returns the executed lien.
@@ -970,6 +973,9 @@ message TerminateLienRequest {
 
   // reason is an optional explanation for termination (for audit trail).
   string reason = 2 [(buf.validate.field).string = {max_len: 500}];
+
+  // idempotency_key ensures exactly-once lien termination for retry scenarios.
+  meridian.common.v1.IdempotencyKey idempotency_key = 3;
 }
 
 // TerminateLienResponse returns the terminated lien.

--- a/services/internal-bank-account/service/lien_idempotency_test.go
+++ b/services/internal-bank-account/service/lien_idempotency_test.go
@@ -1,0 +1,419 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	"github.com/meridianhub/meridian/shared/pkg/idempotency"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+// mockIdempotencyService implements idempotency.Service for unit testing.
+type mockIdempotencyService struct {
+	mu        sync.Mutex
+	results   map[string]*idempotency.Result
+	pending   map[string]bool
+	checkErr  error
+	storeErr  error
+	deleteErr error
+}
+
+func newMockIdempotencyService() *mockIdempotencyService {
+	return &mockIdempotencyService{
+		results: make(map[string]*idempotency.Result),
+		pending: make(map[string]bool),
+	}
+}
+
+func (m *mockIdempotencyService) Check(_ context.Context, key idempotency.Key) (*idempotency.Result, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.checkErr != nil {
+		return nil, m.checkErr
+	}
+
+	keyStr := key.String()
+	if result, ok := m.results[keyStr]; ok {
+		if result.Status == idempotency.StatusCompleted {
+			return result, idempotency.ErrOperationAlreadyProcessed
+		}
+		return result, nil
+	}
+	return nil, idempotency.ErrResultNotFound
+}
+
+func (m *mockIdempotencyService) MarkPending(_ context.Context, key idempotency.Key, _ time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	keyStr := key.String()
+	if m.pending[keyStr] {
+		return idempotency.ErrOperationAlreadyProcessed
+	}
+	m.pending[keyStr] = true
+	return nil
+}
+
+func (m *mockIdempotencyService) StoreResult(_ context.Context, result idempotency.Result) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.storeErr != nil {
+		return m.storeErr
+	}
+
+	keyStr := result.Key.String()
+	m.results[keyStr] = &result
+	delete(m.pending, keyStr)
+	return nil
+}
+
+func (m *mockIdempotencyService) Delete(_ context.Context, key idempotency.Key) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+
+	keyStr := key.String()
+	delete(m.results, keyStr)
+	delete(m.pending, keyStr)
+	return nil
+}
+
+func (m *mockIdempotencyService) Acquire(_ context.Context, _ idempotency.Key, _ idempotency.LockOptions) error {
+	return nil
+}
+
+func (m *mockIdempotencyService) Release(_ context.Context, _ idempotency.Key, _ string) error {
+	return nil
+}
+
+func (m *mockIdempotencyService) Refresh(_ context.Context, _ idempotency.Key, _ string, _ time.Duration) error {
+	return nil
+}
+
+func (m *mockIdempotencyService) IsHeld(_ context.Context, _ idempotency.Key) (bool, error) {
+	return false, nil
+}
+
+func (m *mockIdempotencyService) setResult(key idempotency.Key, data []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.results[key.String()] = &idempotency.Result{
+		Key:         key,
+		Status:      idempotency.StatusCompleted,
+		Data:        data,
+		CompletedAt: time.Now(),
+	}
+}
+
+func (m *mockIdempotencyService) setPending(key idempotency.Key) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pending[key.String()] = true
+}
+
+// TestWithIdempotencyService_WiresField verifies the functional option sets the field.
+func TestWithIdempotencyService_WiresField(t *testing.T) {
+	repo := newMockRepository()
+	mockIdemp := newMockIdempotencyService()
+
+	svc, err := NewServiceFull(repo, nil, nil, testLogger(), nil,
+		WithIdempotencyService(mockIdemp),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, svc.idempotencyService, "idempotency service should be wired")
+}
+
+// TestWithIdempotencyService_NilDoesNotOverride verifies a nil option is accepted without panic.
+func TestWithIdempotencyService_NilDoesNotOverride(t *testing.T) {
+	repo := newMockRepository()
+
+	svc, err := NewServiceFull(repo, nil, nil, testLogger(), nil,
+		WithIdempotencyService(nil),
+	)
+	require.NoError(t, err)
+	assert.Nil(t, svc.idempotencyService)
+}
+
+// TestExecuteLien_IdempotencyReturnsCachedResponse verifies that a prior cached Redis result
+// is returned without hitting the database.
+func TestExecuteLien_IdempotencyReturnsCachedResponse(t *testing.T) {
+	repo := newMockRepository()
+	mockIdemp := newMockIdempotencyService()
+
+	svc, err := NewServiceFull(repo, nil, nil, testLogger(), nil,
+		WithIdempotencyService(mockIdemp),
+	)
+	require.NoError(t, err)
+
+	const tenantID = "test-tenant"
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID(tenantID))
+	lienID := uuid.New()
+
+	// Pre-populate cached response
+	idempKey := idempotency.Key{
+		TenantID:  tenantID,
+		Namespace: idempotencyNamespace,
+		Operation: "execute_lien",
+		EntityID:  lienID.String(),
+		RequestID: "exec-req-abc",
+	}
+	cachedResp := &pb.ExecuteLienResponse{
+		Lien: &pb.Lien{
+			LienId: lienID.String(),
+			Status: pb.LienStatus_LIEN_STATUS_EXECUTED,
+		},
+	}
+	cachedData, err := proto.Marshal(cachedResp)
+	require.NoError(t, err)
+	mockIdemp.setResult(idempKey, cachedData)
+
+	// Execute with same key — should return cached result without DB access
+	req := &pb.ExecuteLienRequest{
+		LienId:         lienID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "exec-req-abc"},
+	}
+
+	resp, err := svc.ExecuteLien(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, pb.LienStatus_LIEN_STATUS_EXECUTED, resp.Lien.Status)
+}
+
+// TestExecuteLien_IdempotencyReturnsAbortedWhenInProgress verifies that a concurrent request
+// in-progress returns codes.Aborted.
+func TestExecuteLien_IdempotencyReturnsAbortedWhenInProgress(t *testing.T) {
+	repo := newMockRepository()
+	mockIdemp := newMockIdempotencyService()
+
+	svc, err := NewServiceFull(repo, nil, nil, testLogger(), nil,
+		WithIdempotencyService(mockIdemp),
+	)
+	require.NoError(t, err)
+
+	const tenantID = "test-tenant"
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID(tenantID))
+	lienID := uuid.New()
+
+	// Mark as already pending
+	idempKey := idempotency.Key{
+		TenantID:  tenantID,
+		Namespace: idempotencyNamespace,
+		Operation: "execute_lien",
+		EntityID:  lienID.String(),
+		RequestID: "exec-req-in-progress",
+	}
+	mockIdemp.setPending(idempKey)
+
+	req := &pb.ExecuteLienRequest{
+		LienId:         lienID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "exec-req-in-progress"},
+	}
+
+	_, err = svc.ExecuteLien(ctx, req)
+	require.Error(t, err)
+	assert.Equal(t, codes.Aborted, status.Code(err))
+}
+
+// TestExecuteLien_NoIdempotencyKey_ProceedsNormally verifies that omitting the idempotency key
+// bypasses the Redis guard entirely (no nil panic, proceeds to lien repo lookup).
+func TestExecuteLien_NoIdempotencyKey_ProceedsNormally(t *testing.T) {
+	repo := newMockRepository()
+	mockIdemp := newMockIdempotencyService()
+
+	svc, err := NewServiceFull(repo, nil, nil, testLogger(), nil,
+		WithIdempotencyService(mockIdemp),
+		WithLienRepo(nil), // nil lien repo → immediate FailedPrecondition
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	lienID := uuid.New()
+
+	// No idempotency key → bypasses guard → hits lienRepo nil check
+	req := &pb.ExecuteLienRequest{
+		LienId: lienID.String(),
+		// No IdempotencyKey
+	}
+
+	_, err = svc.ExecuteLien(ctx, req)
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+// TestExecuteLien_IdempotencyCheckFailure verifies that a Redis check error returns Internal.
+func TestExecuteLien_IdempotencyCheckFailure(t *testing.T) {
+	repo := newMockRepository()
+	mockIdemp := newMockIdempotencyService()
+	mockIdemp.checkErr = assert.AnError
+
+	svc, err := NewServiceFull(repo, nil, nil, testLogger(), nil,
+		WithIdempotencyService(mockIdemp),
+		WithLienRepo(nil),
+	)
+	require.NoError(t, err)
+
+	const tenantID = "test-tenant"
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID(tenantID))
+	lienID := uuid.New()
+
+	req := &pb.ExecuteLienRequest{
+		LienId:         lienID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "exec-req-err"},
+	}
+
+	_, err = svc.ExecuteLien(ctx, req)
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+// TestTerminateLien_IdempotencyReturnsCachedResponse verifies cached termination response
+// is returned without hitting the database.
+func TestTerminateLien_IdempotencyReturnsCachedResponse(t *testing.T) {
+	repo := newMockRepository()
+	mockIdemp := newMockIdempotencyService()
+
+	svc, err := NewServiceFull(repo, nil, nil, testLogger(), nil,
+		WithIdempotencyService(mockIdemp),
+	)
+	require.NoError(t, err)
+
+	const tenantID = "test-tenant"
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID(tenantID))
+	lienID := uuid.New()
+
+	// Pre-populate cached response
+	idempKey := idempotency.Key{
+		TenantID:  tenantID,
+		Namespace: idempotencyNamespace,
+		Operation: "terminate_lien",
+		EntityID:  lienID.String(),
+		RequestID: "term-req-xyz",
+	}
+	cachedResp := &pb.TerminateLienResponse{
+		Lien: &pb.Lien{
+			LienId: lienID.String(),
+			Status: pb.LienStatus_LIEN_STATUS_TERMINATED,
+		},
+	}
+	cachedData, err := proto.Marshal(cachedResp)
+	require.NoError(t, err)
+	mockIdemp.setResult(idempKey, cachedData)
+
+	req := &pb.TerminateLienRequest{
+		LienId:         lienID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "term-req-xyz"},
+	}
+
+	resp, err := svc.TerminateLien(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, pb.LienStatus_LIEN_STATUS_TERMINATED, resp.Lien.Status)
+}
+
+// TestTerminateLien_IdempotencyReturnsAbortedWhenInProgress verifies concurrent termination
+// returns codes.Aborted.
+func TestTerminateLien_IdempotencyReturnsAbortedWhenInProgress(t *testing.T) {
+	repo := newMockRepository()
+	mockIdemp := newMockIdempotencyService()
+
+	svc, err := NewServiceFull(repo, nil, nil, testLogger(), nil,
+		WithIdempotencyService(mockIdemp),
+	)
+	require.NoError(t, err)
+
+	const tenantID = "test-tenant"
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID(tenantID))
+	lienID := uuid.New()
+
+	// Mark as already pending
+	idempKey := idempotency.Key{
+		TenantID:  tenantID,
+		Namespace: idempotencyNamespace,
+		Operation: "terminate_lien",
+		EntityID:  lienID.String(),
+		RequestID: "term-req-in-progress",
+	}
+	mockIdemp.setPending(idempKey)
+
+	req := &pb.TerminateLienRequest{
+		LienId:         lienID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "term-req-in-progress"},
+	}
+
+	_, err = svc.TerminateLien(ctx, req)
+	require.Error(t, err)
+	assert.Equal(t, codes.Aborted, status.Code(err))
+}
+
+// TestTerminateLien_NoIdempotencyKey_ProceedsNormally verifies that omitting the idempotency key
+// bypasses the Redis guard.
+func TestTerminateLien_NoIdempotencyKey_ProceedsNormally(t *testing.T) {
+	repo := newMockRepository()
+	mockIdemp := newMockIdempotencyService()
+
+	svc, err := NewServiceFull(repo, nil, nil, testLogger(), nil,
+		WithIdempotencyService(mockIdemp),
+		WithLienRepo(nil), // nil lien repo → immediate FailedPrecondition
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	lienID := uuid.New()
+
+	req := &pb.TerminateLienRequest{
+		LienId: lienID.String(),
+		// No IdempotencyKey
+	}
+
+	_, err = svc.TerminateLien(ctx, req)
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+// TestTerminateLien_IdempotencyCheckFailure verifies a Redis error returns Internal.
+func TestTerminateLien_IdempotencyCheckFailure(t *testing.T) {
+	repo := newMockRepository()
+	mockIdemp := newMockIdempotencyService()
+	mockIdemp.checkErr = assert.AnError
+
+	svc, err := NewServiceFull(repo, nil, nil, testLogger(), nil,
+		WithIdempotencyService(mockIdemp),
+		WithLienRepo(nil),
+	)
+	require.NoError(t, err)
+
+	const tenantID = "test-tenant"
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID(tenantID))
+	lienID := uuid.New()
+
+	req := &pb.TerminateLienRequest{
+		LienId:         lienID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "term-req-err"},
+	}
+
+	_, err = svc.TerminateLien(ctx, req)
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+// TestIdempotencyConstants verifies the namespace, pending TTL, and result TTL are set correctly.
+func TestIdempotencyConstants(t *testing.T) {
+	assert.Equal(t, "internal-bank-account", idempotencyNamespace)
+	assert.Equal(t, 5*time.Minute, idempotencyPendingTTL)
+	assert.Equal(t, 24*time.Hour, idempotencyResultTTL)
+}

--- a/services/internal-bank-account/service/lien_service.go
+++ b/services/internal-bank-account/service/lien_service.go
@@ -262,7 +262,10 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 	var idempotencyLockAcquired bool
 	if req.IdempotencyKey != nil && req.IdempotencyKey.Key != "" && s.idempotencyService != nil {
 		idempotencyKeyStr = req.IdempotencyKey.Key
-		tenantID, _ := tenant.FromContext(ctx)
+		tenantID, tenantOk := tenant.FromContext(ctx)
+		if !tenantOk {
+			s.logger.Warn("tenant context missing for idempotency key, using empty tenant")
+		}
 		idempKey = idempotency.Key{
 			TenantID:  string(tenantID),
 			Namespace: idempotencyNamespace,
@@ -336,13 +339,17 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		}
 		if idempotencyKeyStr != "" && s.idempotencyService != nil {
 			if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
-				_ = s.idempotencyService.StoreResult(ctx, idempotency.Result{
+				if storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
 					Key:         idempKey,
 					Status:      idempotency.StatusCompleted,
 					Data:        responseData,
 					CompletedAt: time.Now(),
 					TTL:         idempotencyResultTTL,
-				})
+				}); storeErr != nil {
+					s.logger.Warn("failed to cache already-executed lien response", "error", storeErr)
+				}
+			} else {
+				s.logger.Warn("failed to marshal already-executed lien response for idempotency cache", "error", marshalErr)
 			}
 		}
 		return resp, nil
@@ -366,13 +373,17 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		}
 		if idempotencyKeyStr != "" && s.idempotencyService != nil {
 			if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
-				_ = s.idempotencyService.StoreResult(ctx, idempotency.Result{
+				if storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
 					Key:         idempKey,
 					Status:      idempotency.StatusCompleted,
 					Data:        responseData,
 					CompletedAt: time.Now(),
 					TTL:         idempotencyResultTTL,
-				})
+				}); storeErr != nil {
+					s.logger.Warn("failed to cache post-lock already-executed lien response", "error", storeErr)
+				}
+			} else {
+				s.logger.Warn("failed to marshal post-lock already-executed lien response for idempotency cache", "error", marshalErr)
 			}
 		}
 		return resp, nil
@@ -453,7 +464,10 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 	var idempotencyLockAcquired bool
 	if req.IdempotencyKey != nil && req.IdempotencyKey.Key != "" && s.idempotencyService != nil {
 		idempotencyKeyStr = req.IdempotencyKey.Key
-		tenantID, _ := tenant.FromContext(ctx)
+		tenantID, tenantOk := tenant.FromContext(ctx)
+		if !tenantOk {
+			s.logger.Warn("tenant context missing for idempotency key, using empty tenant")
+		}
 		idempKey = idempotency.Key{
 			TenantID:  string(tenantID),
 			Namespace: idempotencyNamespace,
@@ -527,13 +541,17 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 		}
 		if idempotencyKeyStr != "" && s.idempotencyService != nil {
 			if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
-				_ = s.idempotencyService.StoreResult(ctx, idempotency.Result{
+				if storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
 					Key:         idempKey,
 					Status:      idempotency.StatusCompleted,
 					Data:        responseData,
 					CompletedAt: time.Now(),
 					TTL:         idempotencyResultTTL,
-				})
+				}); storeErr != nil {
+					s.logger.Warn("failed to cache already-terminated lien response", "error", storeErr)
+				}
+			} else {
+				s.logger.Warn("failed to marshal already-terminated lien response for idempotency cache", "error", marshalErr)
 			}
 		}
 		return resp, nil
@@ -557,13 +575,17 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 		}
 		if idempotencyKeyStr != "" && s.idempotencyService != nil {
 			if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
-				_ = s.idempotencyService.StoreResult(ctx, idempotency.Result{
+				if storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
 					Key:         idempKey,
 					Status:      idempotency.StatusCompleted,
 					Data:        responseData,
 					CompletedAt: time.Now(),
 					TTL:         idempotencyResultTTL,
-				})
+				}); storeErr != nil {
+					s.logger.Warn("failed to cache post-lock already-terminated lien response", "error", storeErr)
+				}
+			} else {
+				s.logger.Warn("failed to marshal post-lock already-terminated lien response for idempotency cache", "error", marshalErr)
 			}
 		}
 		return resp, nil

--- a/services/internal-bank-account/service/lien_service.go
+++ b/services/internal-bank-account/service/lien_service.go
@@ -14,9 +14,12 @@ import (
 	"github.com/meridianhub/meridian/services/internal-bank-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/internal-bank-account/domain"
 	ibaobservability "github.com/meridianhub/meridian/services/internal-bank-account/observability"
+	"github.com/meridianhub/meridian/shared/pkg/idempotency"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/shopspring/decimal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -30,6 +33,19 @@ const (
 	opStatusLienVersionConflict = "lien_version_conflict"
 	opStatusLienCreateFailed    = "lien_create_failed"
 	opStatusLienUpdateFailed    = "lien_update_failed"
+	opStatusIdempotent          = "idempotent"
+)
+
+// Redis idempotency constants for internal-bank-account lien operations.
+const (
+	// idempotencyNamespace is the Redis key namespace for internal-bank-account idempotency.
+	idempotencyNamespace = "internal-bank-account"
+
+	// idempotencyPendingTTL is how long a pending idempotency record remains valid.
+	idempotencyPendingTTL = 5 * time.Minute
+
+	// idempotencyResultTTL is how long completed results are cached.
+	idempotencyResultTTL = 24 * time.Hour
 )
 
 // InitiateLien creates a new fund reservation on an internal bank account.
@@ -233,15 +249,73 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		ibaobservability.RecordOperationDuration("execute_lien", operationStatus, time.Since(start))
 	}()
 
-	if s.lienRepo == nil {
-		operationStatus = opStatusLienRepoNil
-		return nil, status.Error(codes.FailedPrecondition, "lien operations not configured")
-	}
-
 	lienID, err := uuid.Parse(req.LienId)
 	if err != nil {
 		operationStatus = opStatusInvalidRequest
 		return nil, status.Errorf(codes.InvalidArgument, "invalid lien_id: %v", err)
+	}
+
+	// Redis idempotency guard: check/mark-pending/store-result cycle.
+	// Placed before lienRepo nil check so cached responses are returned without DB access.
+	var idempKey idempotency.Key
+	var idempotencyKeyStr string
+	var idempotencyLockAcquired bool
+	if req.IdempotencyKey != nil && req.IdempotencyKey.Key != "" && s.idempotencyService != nil {
+		idempotencyKeyStr = req.IdempotencyKey.Key
+		tenantID, _ := tenant.FromContext(ctx)
+		idempKey = idempotency.Key{
+			TenantID:  string(tenantID),
+			Namespace: idempotencyNamespace,
+			Operation: "execute_lien",
+			EntityID:  req.LienId,
+			RequestID: idempotencyKeyStr,
+		}
+
+		// Check Redis for a cached result from a prior successful execution.
+		result, checkErr := s.idempotencyService.Check(ctx, idempKey)
+		if errors.Is(checkErr, idempotency.ErrOperationAlreadyProcessed) && result != nil && result.Data != nil {
+			var cachedResp pb.ExecuteLienResponse
+			unmarshalErr := proto.Unmarshal(result.Data, &cachedResp)
+			if unmarshalErr == nil {
+				s.logger.Info("returning cached execute lien response",
+					"lien_id", req.LienId,
+					"idempotency_key", idempotencyKeyStr)
+				operationStatus = opStatusIdempotent
+				return &cachedResp, nil
+			}
+			s.logger.Warn("failed to unmarshal cached idempotency result", "error", unmarshalErr)
+		} else if checkErr != nil && !errors.Is(checkErr, idempotency.ErrResultNotFound) {
+			s.logger.Error("idempotency check failed", "error", checkErr)
+			return nil, status.Error(codes.Internal, "failed to check idempotency")
+		}
+
+		// Mark operation as pending to block concurrent duplicate requests.
+		if markErr := s.idempotencyService.MarkPending(ctx, idempKey, idempotencyPendingTTL); markErr != nil {
+			if errors.Is(markErr, idempotency.ErrOperationAlreadyProcessed) {
+				s.logger.Info("operation already in progress, please retry",
+					"idempotency_key", idempotencyKeyStr)
+				return nil, status.Error(codes.Aborted, "operation already in progress, please retry")
+			}
+			s.logger.Error("failed to mark operation pending", "error", markErr)
+			return nil, status.Error(codes.Aborted, "failed to acquire idempotency lock, please retry")
+		}
+		idempotencyLockAcquired = true
+
+		// On failure, clean up the pending key so retries are not blocked.
+		defer func() {
+			if idempotencyLockAcquired && operationStatus != operationStatusSuccess {
+				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+					s.logger.Warn("failed to clean up pending idempotency state",
+						"error", delErr,
+						"idempotency_key", idempotencyKeyStr)
+				}
+			}
+		}()
+	}
+
+	if s.lienRepo == nil {
+		operationStatus = opStatusLienRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "lien operations not configured")
 	}
 
 	// Read-only idempotency check: if already executed, return without lock
@@ -308,9 +382,29 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		"lien_id", lien.ID,
 		"account_id", lien.AccountID)
 
-	return &pb.ExecuteLienResponse{
+	resp := &pb.ExecuteLienResponse{
 		Lien: s.domainToProtoLien(ctx, lien),
-	}, nil
+	}
+
+	// Store successful result in Redis for future idempotency checks.
+	if idempotencyKeyStr != "" && s.idempotencyService != nil {
+		if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
+			if storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
+				Key:         idempKey,
+				Status:      idempotency.StatusCompleted,
+				Data:        responseData,
+				CompletedAt: time.Now(),
+				TTL:         idempotencyResultTTL,
+			}); storeErr != nil {
+				s.logger.Error("failed to store idempotency result", "error", storeErr)
+				// Continue - operation succeeded, caching is best-effort.
+			}
+		} else {
+			s.logger.Error("failed to marshal response for idempotency cache", "error", marshalErr)
+		}
+	}
+
+	return resp, nil
 }
 
 // TerminateLien releases reserved funds without executing.
@@ -322,15 +416,73 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 		ibaobservability.RecordOperationDuration("terminate_lien", operationStatus, time.Since(start))
 	}()
 
-	if s.lienRepo == nil {
-		operationStatus = opStatusLienRepoNil
-		return nil, status.Error(codes.FailedPrecondition, "lien operations not configured")
-	}
-
 	lienID, err := uuid.Parse(req.LienId)
 	if err != nil {
 		operationStatus = opStatusInvalidRequest
 		return nil, status.Errorf(codes.InvalidArgument, "invalid lien_id: %v", err)
+	}
+
+	// Redis idempotency guard: check/mark-pending/store-result cycle.
+	// Placed before lienRepo nil check so cached responses are returned without DB access.
+	var idempKey idempotency.Key
+	var idempotencyKeyStr string
+	var idempotencyLockAcquired bool
+	if req.IdempotencyKey != nil && req.IdempotencyKey.Key != "" && s.idempotencyService != nil {
+		idempotencyKeyStr = req.IdempotencyKey.Key
+		tenantID, _ := tenant.FromContext(ctx)
+		idempKey = idempotency.Key{
+			TenantID:  string(tenantID),
+			Namespace: idempotencyNamespace,
+			Operation: "terminate_lien",
+			EntityID:  req.LienId,
+			RequestID: idempotencyKeyStr,
+		}
+
+		// Check Redis for a cached result from a prior successful termination.
+		result, checkErr := s.idempotencyService.Check(ctx, idempKey)
+		if errors.Is(checkErr, idempotency.ErrOperationAlreadyProcessed) && result != nil && result.Data != nil {
+			var cachedResp pb.TerminateLienResponse
+			unmarshalErr := proto.Unmarshal(result.Data, &cachedResp)
+			if unmarshalErr == nil {
+				s.logger.Info("returning cached terminate lien response",
+					"lien_id", req.LienId,
+					"idempotency_key", idempotencyKeyStr)
+				operationStatus = opStatusIdempotent
+				return &cachedResp, nil
+			}
+			s.logger.Warn("failed to unmarshal cached idempotency result", "error", unmarshalErr)
+		} else if checkErr != nil && !errors.Is(checkErr, idempotency.ErrResultNotFound) {
+			s.logger.Error("idempotency check failed", "error", checkErr)
+			return nil, status.Error(codes.Internal, "failed to check idempotency")
+		}
+
+		// Mark operation as pending to block concurrent duplicate requests.
+		if markErr := s.idempotencyService.MarkPending(ctx, idempKey, idempotencyPendingTTL); markErr != nil {
+			if errors.Is(markErr, idempotency.ErrOperationAlreadyProcessed) {
+				s.logger.Info("operation already in progress, please retry",
+					"idempotency_key", idempotencyKeyStr)
+				return nil, status.Error(codes.Aborted, "operation already in progress, please retry")
+			}
+			s.logger.Error("failed to mark operation pending", "error", markErr)
+			return nil, status.Error(codes.Aborted, "failed to acquire idempotency lock, please retry")
+		}
+		idempotencyLockAcquired = true
+
+		// On failure, clean up the pending key so retries are not blocked.
+		defer func() {
+			if idempotencyLockAcquired && operationStatus != operationStatusSuccess {
+				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+					s.logger.Warn("failed to clean up pending idempotency state",
+						"error", delErr,
+						"idempotency_key", idempotencyKeyStr)
+				}
+			}
+		}()
+	}
+
+	if s.lienRepo == nil {
+		operationStatus = opStatusLienRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "lien operations not configured")
 	}
 
 	// Read-only idempotency check: if already terminated, return without lock
@@ -394,9 +546,29 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 		"account_id", lien.AccountID,
 		"reason", req.Reason)
 
-	return &pb.TerminateLienResponse{
+	resp := &pb.TerminateLienResponse{
 		Lien: s.domainToProtoLien(ctx, lien),
-	}, nil
+	}
+
+	// Store successful result in Redis for future idempotency checks.
+	if idempotencyKeyStr != "" && s.idempotencyService != nil {
+		if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
+			if storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
+				Key:         idempKey,
+				Status:      idempotency.StatusCompleted,
+				Data:        responseData,
+				CompletedAt: time.Now(),
+				TTL:         idempotencyResultTTL,
+			}); storeErr != nil {
+				s.logger.Error("failed to store idempotency result", "error", storeErr)
+				// Continue - operation succeeded, caching is best-effort.
+			}
+		} else {
+			s.logger.Error("failed to marshal response for idempotency cache", "error", marshalErr)
+		}
+	}
+
+	return resp, nil
 }
 
 // RetrieveLien fetches a lien by ID.

--- a/services/internal-bank-account/service/lien_service.go
+++ b/services/internal-bank-account/service/lien_service.go
@@ -337,29 +337,7 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		resp := &pb.ExecuteLienResponse{
 			Lien: s.domainToProtoLien(ctx, lien),
 		}
-		if idempotencyKeyStr != "" && s.idempotencyService != nil {
-			if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
-				if storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
-					Key:         idempKey,
-					Status:      idempotency.StatusCompleted,
-					Data:        responseData,
-					CompletedAt: time.Now(),
-					TTL:         idempotencyResultTTL,
-				}); storeErr != nil {
-					s.logger.Warn("failed to cache already-executed lien response", "error", storeErr)
-					// Release pending marker so retries are not blocked.
-					if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
-						s.logger.Warn("failed to clear pending idempotency state after cache error", "error", delErr)
-					}
-				}
-			} else {
-				s.logger.Warn("failed to marshal already-executed lien response for idempotency cache", "error", marshalErr)
-				// Release pending marker so retries are not blocked.
-				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
-					s.logger.Warn("failed to clear pending idempotency state after marshal error", "error", delErr)
-				}
-			}
-		}
+		s.storeIdempotencyResultOrCleanup(ctx, idempKey, resp, "execute_lien:pre-lock")
 		return resp, nil
 	}
 
@@ -379,29 +357,7 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		resp := &pb.ExecuteLienResponse{
 			Lien: s.domainToProtoLien(ctx, lien),
 		}
-		if idempotencyKeyStr != "" && s.idempotencyService != nil {
-			if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
-				if storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
-					Key:         idempKey,
-					Status:      idempotency.StatusCompleted,
-					Data:        responseData,
-					CompletedAt: time.Now(),
-					TTL:         idempotencyResultTTL,
-				}); storeErr != nil {
-					s.logger.Warn("failed to cache post-lock already-executed lien response", "error", storeErr)
-					// Release pending marker so retries are not blocked.
-					if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
-						s.logger.Warn("failed to clear pending idempotency state after cache error", "error", delErr)
-					}
-				}
-			} else {
-				s.logger.Warn("failed to marshal post-lock already-executed lien response for idempotency cache", "error", marshalErr)
-				// Release pending marker so retries are not blocked.
-				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
-					s.logger.Warn("failed to clear pending idempotency state after marshal error", "error", delErr)
-				}
-			}
-		}
+		s.storeIdempotencyResultOrCleanup(ctx, idempKey, resp, "execute_lien:post-lock")
 		return resp, nil
 	}
 
@@ -438,29 +394,7 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 	}
 
 	// Store successful result in Redis for future idempotency checks.
-	if idempotencyKeyStr != "" && s.idempotencyService != nil {
-		if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
-			if storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
-				Key:         idempKey,
-				Status:      idempotency.StatusCompleted,
-				Data:        responseData,
-				CompletedAt: time.Now(),
-				TTL:         idempotencyResultTTL,
-			}); storeErr != nil {
-				s.logger.Error("failed to store idempotency result", "error", storeErr)
-				// Release pending marker so retries are not blocked by a stale lock.
-				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
-					s.logger.Warn("failed to clear pending idempotency state after cache error", "error", delErr)
-				}
-			}
-		} else {
-			s.logger.Error("failed to marshal response for idempotency cache", "error", marshalErr)
-			// Release pending marker so retries are not blocked by a stale lock.
-			if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
-				s.logger.Warn("failed to clear pending idempotency state after marshal error", "error", delErr)
-			}
-		}
-	}
+	s.storeIdempotencyResultOrCleanup(ctx, idempKey, resp, "execute_lien")
 
 	return resp, nil
 }
@@ -562,29 +496,7 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 		resp := &pb.TerminateLienResponse{
 			Lien: s.domainToProtoLien(ctx, lien),
 		}
-		if idempotencyKeyStr != "" && s.idempotencyService != nil {
-			if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
-				if storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
-					Key:         idempKey,
-					Status:      idempotency.StatusCompleted,
-					Data:        responseData,
-					CompletedAt: time.Now(),
-					TTL:         idempotencyResultTTL,
-				}); storeErr != nil {
-					s.logger.Warn("failed to cache already-terminated lien response", "error", storeErr)
-					// Release pending marker so retries are not blocked.
-					if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
-						s.logger.Warn("failed to clear pending idempotency state after cache error", "error", delErr)
-					}
-				}
-			} else {
-				s.logger.Warn("failed to marshal already-terminated lien response for idempotency cache", "error", marshalErr)
-				// Release pending marker so retries are not blocked.
-				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
-					s.logger.Warn("failed to clear pending idempotency state after marshal error", "error", delErr)
-				}
-			}
-		}
+		s.storeIdempotencyResultOrCleanup(ctx, idempKey, resp, "terminate_lien:pre-lock")
 		return resp, nil
 	}
 
@@ -604,29 +516,7 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 		resp := &pb.TerminateLienResponse{
 			Lien: s.domainToProtoLien(ctx, lien),
 		}
-		if idempotencyKeyStr != "" && s.idempotencyService != nil {
-			if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
-				if storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
-					Key:         idempKey,
-					Status:      idempotency.StatusCompleted,
-					Data:        responseData,
-					CompletedAt: time.Now(),
-					TTL:         idempotencyResultTTL,
-				}); storeErr != nil {
-					s.logger.Warn("failed to cache post-lock already-terminated lien response", "error", storeErr)
-					// Release pending marker so retries are not blocked.
-					if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
-						s.logger.Warn("failed to clear pending idempotency state after cache error", "error", delErr)
-					}
-				}
-			} else {
-				s.logger.Warn("failed to marshal post-lock already-terminated lien response for idempotency cache", "error", marshalErr)
-				// Release pending marker so retries are not blocked.
-				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
-					s.logger.Warn("failed to clear pending idempotency state after marshal error", "error", delErr)
-				}
-			}
-		}
+		s.storeIdempotencyResultOrCleanup(ctx, idempKey, resp, "terminate_lien:post-lock")
 		return resp, nil
 	}
 
@@ -660,29 +550,7 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 	}
 
 	// Store successful result in Redis for future idempotency checks.
-	if idempotencyKeyStr != "" && s.idempotencyService != nil {
-		if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
-			if storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
-				Key:         idempKey,
-				Status:      idempotency.StatusCompleted,
-				Data:        responseData,
-				CompletedAt: time.Now(),
-				TTL:         idempotencyResultTTL,
-			}); storeErr != nil {
-				s.logger.Error("failed to store idempotency result", "error", storeErr)
-				// Release pending marker so retries are not blocked by a stale lock.
-				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
-					s.logger.Warn("failed to clear pending idempotency state after cache error", "error", delErr)
-				}
-			}
-		} else {
-			s.logger.Error("failed to marshal response for idempotency cache", "error", marshalErr)
-			// Release pending marker so retries are not blocked by a stale lock.
-			if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
-				s.logger.Warn("failed to clear pending idempotency state after marshal error", "error", delErr)
-			}
-		}
-	}
+	s.storeIdempotencyResultOrCleanup(ctx, idempKey, resp, "terminate_lien")
 
 	return resp, nil
 }
@@ -719,6 +587,36 @@ func (s *Service) RetrieveLien(ctx context.Context, req *pb.RetrieveLienRequest)
 	return &pb.RetrieveLienResponse{
 		Lien: s.domainToProtoLien(ctx, lien),
 	}, nil
+}
+
+// storeIdempotencyResultOrCleanup marshals resp, stores it in the idempotency
+// service, and—if either step fails—deletes the pending marker so that
+// subsequent retries are not blocked by a stale lock. It is a no-op when the
+// idempotency service is not configured or no key is present.
+func (s *Service) storeIdempotencyResultOrCleanup(ctx context.Context, idempKey idempotency.Key, resp proto.Message, logPrefix string) {
+	if s.idempotencyService == nil || idempKey.RequestID == "" {
+		return
+	}
+	responseData, marshalErr := proto.Marshal(resp)
+	if marshalErr != nil {
+		s.logger.Error(logPrefix+": failed to marshal response for idempotency cache", "error", marshalErr)
+		if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+			s.logger.Warn(logPrefix+": failed to clear pending idempotency state after marshal error", "error", delErr)
+		}
+		return
+	}
+	if storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
+		Key:         idempKey,
+		Status:      idempotency.StatusCompleted,
+		Data:        responseData,
+		CompletedAt: time.Now(),
+		TTL:         idempotencyResultTTL,
+	}); storeErr != nil {
+		s.logger.Error(logPrefix+": failed to store idempotency result", "error", storeErr)
+		if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+			s.logger.Warn(logPrefix+": failed to clear pending idempotency state after cache error", "error", delErr)
+		}
+	}
 }
 
 // buildInitiateLienResponse constructs a consistent InitiateLienResponse

--- a/services/internal-bank-account/service/lien_service.go
+++ b/services/internal-bank-account/service/lien_service.go
@@ -347,9 +347,17 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 					TTL:         idempotencyResultTTL,
 				}); storeErr != nil {
 					s.logger.Warn("failed to cache already-executed lien response", "error", storeErr)
+					// Release pending marker so retries are not blocked.
+					if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+						s.logger.Warn("failed to clear pending idempotency state after cache error", "error", delErr)
+					}
 				}
 			} else {
 				s.logger.Warn("failed to marshal already-executed lien response for idempotency cache", "error", marshalErr)
+				// Release pending marker so retries are not blocked.
+				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+					s.logger.Warn("failed to clear pending idempotency state after marshal error", "error", delErr)
+				}
 			}
 		}
 		return resp, nil
@@ -381,9 +389,17 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 					TTL:         idempotencyResultTTL,
 				}); storeErr != nil {
 					s.logger.Warn("failed to cache post-lock already-executed lien response", "error", storeErr)
+					// Release pending marker so retries are not blocked.
+					if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+						s.logger.Warn("failed to clear pending idempotency state after cache error", "error", delErr)
+					}
 				}
 			} else {
 				s.logger.Warn("failed to marshal post-lock already-executed lien response for idempotency cache", "error", marshalErr)
+				// Release pending marker so retries are not blocked.
+				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+					s.logger.Warn("failed to clear pending idempotency state after marshal error", "error", delErr)
+				}
 			}
 		}
 		return resp, nil
@@ -549,9 +565,17 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 					TTL:         idempotencyResultTTL,
 				}); storeErr != nil {
 					s.logger.Warn("failed to cache already-terminated lien response", "error", storeErr)
+					// Release pending marker so retries are not blocked.
+					if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+						s.logger.Warn("failed to clear pending idempotency state after cache error", "error", delErr)
+					}
 				}
 			} else {
 				s.logger.Warn("failed to marshal already-terminated lien response for idempotency cache", "error", marshalErr)
+				// Release pending marker so retries are not blocked.
+				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+					s.logger.Warn("failed to clear pending idempotency state after marshal error", "error", delErr)
+				}
 			}
 		}
 		return resp, nil
@@ -583,9 +607,17 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 					TTL:         idempotencyResultTTL,
 				}); storeErr != nil {
 					s.logger.Warn("failed to cache post-lock already-terminated lien response", "error", storeErr)
+					// Release pending marker so retries are not blocked.
+					if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+						s.logger.Warn("failed to clear pending idempotency state after cache error", "error", delErr)
+					}
 				}
 			} else {
 				s.logger.Warn("failed to marshal post-lock already-terminated lien response for idempotency cache", "error", marshalErr)
+				// Release pending marker so retries are not blocked.
+				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+					s.logger.Warn("failed to clear pending idempotency state after marshal error", "error", delErr)
+				}
 			}
 		}
 		return resp, nil

--- a/services/internal-bank-account/service/lien_service.go
+++ b/services/internal-bank-account/service/lien_service.go
@@ -448,10 +448,17 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 				TTL:         idempotencyResultTTL,
 			}); storeErr != nil {
 				s.logger.Error("failed to store idempotency result", "error", storeErr)
-				// Continue - operation succeeded, caching is best-effort.
+				// Release pending marker so retries are not blocked by a stale lock.
+				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+					s.logger.Warn("failed to clear pending idempotency state after cache error", "error", delErr)
+				}
 			}
 		} else {
 			s.logger.Error("failed to marshal response for idempotency cache", "error", marshalErr)
+			// Release pending marker so retries are not blocked by a stale lock.
+			if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+				s.logger.Warn("failed to clear pending idempotency state after marshal error", "error", delErr)
+			}
 		}
 	}
 
@@ -663,10 +670,17 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 				TTL:         idempotencyResultTTL,
 			}); storeErr != nil {
 				s.logger.Error("failed to store idempotency result", "error", storeErr)
-				// Continue - operation succeeded, caching is best-effort.
+				// Release pending marker so retries are not blocked by a stale lock.
+				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+					s.logger.Warn("failed to clear pending idempotency state after cache error", "error", delErr)
+				}
 			}
 		} else {
 			s.logger.Error("failed to marshal response for idempotency cache", "error", marshalErr)
+			// Release pending marker so retries are not blocked by a stale lock.
+			if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+				s.logger.Warn("failed to clear pending idempotency state after marshal error", "error", delErr)
+			}
 		}
 	}
 

--- a/services/internal-bank-account/service/lien_service.go
+++ b/services/internal-bank-account/service/lien_service.go
@@ -330,10 +330,22 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 	}
 
 	if lien.Status == domain.LienStatusExecuted {
-		// Idempotent: already executed
-		return &pb.ExecuteLienResponse{
+		// Idempotent: already executed — cache result and release pending lock.
+		resp := &pb.ExecuteLienResponse{
 			Lien: s.domainToProtoLien(ctx, lien),
-		}, nil
+		}
+		if idempotencyKeyStr != "" && s.idempotencyService != nil {
+			if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
+				_ = s.idempotencyService.StoreResult(ctx, idempotency.Result{
+					Key:         idempKey,
+					Status:      idempotency.StatusCompleted,
+					Data:        responseData,
+					CompletedAt: time.Now(),
+					TTL:         idempotencyResultTTL,
+				})
+			}
+		}
+		return resp, nil
 	}
 
 	// Acquire pessimistic lock for mutation
@@ -347,11 +359,23 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		return nil, status.Errorf(codes.Internal, "failed to lock lien: %v", err)
 	}
 
-	// Re-check after lock: another request may have executed between read and lock
+	// Re-check after lock: another request may have executed between read and lock.
 	if lien.Status == domain.LienStatusExecuted {
-		return &pb.ExecuteLienResponse{
+		resp := &pb.ExecuteLienResponse{
 			Lien: s.domainToProtoLien(ctx, lien),
-		}, nil
+		}
+		if idempotencyKeyStr != "" && s.idempotencyService != nil {
+			if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
+				_ = s.idempotencyService.StoreResult(ctx, idempotency.Result{
+					Key:         idempKey,
+					Status:      idempotency.StatusCompleted,
+					Data:        responseData,
+					CompletedAt: time.Now(),
+					TTL:         idempotencyResultTTL,
+				})
+			}
+		}
+		return resp, nil
 	}
 
 	// Execute the domain transition
@@ -497,10 +521,22 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 	}
 
 	if lien.Status == domain.LienStatusTerminated {
-		// Idempotent: already terminated
-		return &pb.TerminateLienResponse{
+		// Idempotent: already terminated — cache result and release pending lock.
+		resp := &pb.TerminateLienResponse{
 			Lien: s.domainToProtoLien(ctx, lien),
-		}, nil
+		}
+		if idempotencyKeyStr != "" && s.idempotencyService != nil {
+			if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
+				_ = s.idempotencyService.StoreResult(ctx, idempotency.Result{
+					Key:         idempKey,
+					Status:      idempotency.StatusCompleted,
+					Data:        responseData,
+					CompletedAt: time.Now(),
+					TTL:         idempotencyResultTTL,
+				})
+			}
+		}
+		return resp, nil
 	}
 
 	// Acquire pessimistic lock for mutation
@@ -514,11 +550,23 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 		return nil, status.Errorf(codes.Internal, "failed to lock lien: %v", err)
 	}
 
-	// Re-check after lock: another request may have terminated between read and lock
+	// Re-check after lock: another request may have terminated between read and lock.
 	if lien.Status == domain.LienStatusTerminated {
-		return &pb.TerminateLienResponse{
+		resp := &pb.TerminateLienResponse{
 			Lien: s.domainToProtoLien(ctx, lien),
-		}, nil
+		}
+		if idempotencyKeyStr != "" && s.idempotencyService != nil {
+			if responseData, marshalErr := proto.Marshal(resp); marshalErr == nil {
+				_ = s.idempotencyService.StoreResult(ctx, idempotency.Result{
+					Key:         idempKey,
+					Status:      idempotency.StatusCompleted,
+					Data:        responseData,
+					CompletedAt: time.Now(),
+					TTL:         idempotencyResultTTL,
+				})
+			}
+		}
+		return resp, nil
 	}
 
 	// Terminate the domain transition

--- a/services/internal-bank-account/service/server.go
+++ b/services/internal-bank-account/service/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/meridianhub/meridian/services/internal-bank-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/internal-bank-account/domain"
 	ibaobservability "github.com/meridianhub/meridian/services/internal-bank-account/observability"
+	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -49,7 +50,8 @@ type Service struct {
 	lienRepo              *persistence.LienRepository
 	positionKeepingClient PositionKeepingClient
 	referenceDataClient   ReferenceDataClient
-	valuationEngine       ValuationEngine // Optional: executes valuation method logic
+	valuationEngine       ValuationEngine     // Optional: executes valuation method logic
+	idempotencyService    idempotency.Service // Optional: nil = no Redis idempotency guard
 	logger                *slog.Logger
 	tracer                *observability.Tracer
 }
@@ -129,6 +131,14 @@ func WithValuationEngine(engine ValuationEngine) Option {
 func WithValuationFeatureRepo(repo *persistence.ValuationFeatureRepository) Option {
 	return func(s *Service) {
 		s.valuationFeatureRepo = repo
+	}
+}
+
+// WithIdempotencyService sets the idempotency service for Redis-backed exactly-once guards.
+// When nil (default), mutating lien operations proceed without Redis idempotency protection.
+func WithIdempotencyService(svc idempotency.Service) Option {
+	return func(s *Service) {
+		s.idempotencyService = svc
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds optional idempotency protection to internal-bank-account service lien operations
- Follows the established current-account service pattern: check → mark-pending → operate → store-result
- Guards `ExecuteLien` and `TerminateLien` with Redis idempotency cycles
- Adds `WithIdempotencyService` functional option to `NewServiceFull`
- Idempotency guard runs before lienRepo nil check, enabling Redis short-circuit without DB access

## Changes Made

- `api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto` — adds `idempotency_key` field (field 2) to `ExecuteLienRequest` and (field 3) to `TerminateLienRequest`
- `services/internal-bank-account/service/server.go` — adds `idempotencyService idempotency.Service` field and `WithIdempotencyService` functional option
- `services/internal-bank-account/service/lien_service.go` — idempotency constants (`idempotencyNamespace`, `idempotencyPendingTTL`, `idempotencyResultTTL`) and check/mark-pending/store-result guards on `ExecuteLien` and `TerminateLien`
- `services/internal-bank-account/service/lien_idempotency_test.go` — unit tests for cache-hit, in-progress lock, check-failure, and no-key-bypass paths

## Test plan

- [ ] `TestWithIdempotencyService_WiresField` — functional option wires the field
- [ ] `TestWithIdempotencyService_NilDoesNotOverride` — nil option accepted without panic
- [ ] `TestExecuteLien_IdempotencyReturnsCachedResponse` — cache hit returns without DB
- [ ] `TestExecuteLien_IdempotencyReturnsAbortedWhenInProgress` — concurrent request returns Aborted
- [ ] `TestExecuteLien_NoIdempotencyKey_ProceedsNormally` — no key bypasses guard
- [ ] `TestExecuteLien_IdempotencyCheckFailure` — Redis error returns Internal
- [ ] `TestTerminateLien_IdempotencyReturnsCachedResponse` — cache hit for terminate
- [ ] `TestTerminateLien_IdempotencyReturnsAbortedWhenInProgress` — concurrent terminate returns Aborted
- [ ] `TestTerminateLien_NoIdempotencyKey_ProceedsNormally` — no key bypass for terminate
- [ ] `TestTerminateLien_IdempotencyCheckFailure` — Redis error returns Internal
- [ ] `TestIdempotencyConstants` — constants set to expected values
- [ ] Build and vet pass
- [ ] CI green