### PR TITLE
chore: add Dockerfile for unified meridian binary

### DIFF
--- a/cmd/meridian/Dockerfile
+++ b/cmd/meridian/Dockerfile
@@ -1,0 +1,56 @@
+# meridian unified binary - Multi-Stage Dockerfile
+# Optimized for security, size, and performance
+# Uses distroless base image (~2MB) enabled by CGO_ENABLED=0 static binary
+
+# Build stage
+FROM golang:1.26.0-bookworm AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum* ./
+RUN go mod download && go mod verify
+
+# Copy full source (needed for //go:embed directives spanning services/*/migrations/)
+COPY . .
+
+# Build static binary
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} go build \
+    -ldflags="-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildDate=${BUILD_DATE}" \
+    -o meridian \
+    ./cmd/meridian/
+
+# Verify the binary exists and is executable
+RUN test -x meridian && echo "Binary built successfully"
+
+# Runtime stage - distroless for minimal attack surface (~2MB base)
+FROM gcr.io/distroless/static-debian12
+
+# Copy timezone data from builder for time-sensitive operations
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Copy binary from builder
+COPY --from=builder /build/meridian /meridian
+
+# Use non-root user (distroless provides nonroot user at uid 65532)
+USER nonroot:nonroot
+
+# gRPC port and HTTP gateway port
+EXPOSE 50051 8090
+
+# Note: Health checks handled by gRPC health check service
+
+# Run the binary
+ENTRYPOINT ["/meridian"]


### PR DESCRIPTION
## Summary

- Adds multi-stage Dockerfile for the unified meridian binary at `cmd/meridian/Dockerfile`
- Builder stage: `golang:1.26.0-bookworm`, `CGO_ENABLED=0` for a fully static binary
- Runtime stage: `gcr.io/distroless/static-debian12` for minimal attack surface
- Supports `VERSION`, `COMMIT`, and `BUILD_DATE` build args for stamping
- Exposes gRPC (50051) and HTTP gateway (8090) ports

## Changes Made

- Added `cmd/meridian/Dockerfile`

## Notes

- Build context must be repo root: `docker build -f cmd/meridian/Dockerfile -t meridian:local .`
- Migration SQL files are embedded at build time via `//go:embed` — no runtime COPY of sql files needed
- Follows the same pattern as other service Dockerfiles in the repo (e.g. `services/party/cmd/Dockerfile`)

## Test plan

- [ ] `docker build -f cmd/meridian/Dockerfile -t meridian:local .` succeeds from repo root
- [ ] CI green