### PR TITLE
fix: check for port conflicts before starting dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -486,8 +486,23 @@ control-plane-ci: validate-manifest-jsonschema validate-manifests test-control-p
 	@echo "Control plane CI pipeline passed"
 
 ## dev-up: Start entire Meridian platform in dev mode
+DEV_PORTS=26257 8080 50051 8090
 dev-up:
 	@command -v docker >/dev/null || { echo "Error: docker is required"; exit 1; }
+	@failed=0; for port in $(DEV_PORTS); do \
+		pid=$$(lsof -ti :$$port 2>/dev/null | head -1); \
+		if [ -n "$$pid" ]; then \
+			proc=$$(ps -p $$pid -o comm= 2>/dev/null || echo "unknown"); \
+			echo "Error: port $$port already in use by $$proc (pid $$pid)"; \
+			failed=1; \
+		fi; \
+	done; \
+	if [ $$failed -eq 1 ]; then \
+		echo ""; \
+		echo "Hint: if Tilt is running, stop it first:  tilt down"; \
+		echo "      or stop leftover containers:        make dev-down"; \
+		exit 1; \
+	fi
 	@echo "Starting Meridian dev environment..."
 	docker compose -f $(DEV_COMPOSE) up --build
 


### PR DESCRIPTION
## Summary

- Add port availability check to `make dev-up` before launching Docker Compose
- Checks all four dev ports (26257, 8080, 50051, 8090) and reports which process holds each one
- Provides actionable hints (`tilt down` or `make dev-down`) when conflicts are detected

## Context

Running `make dev-up` while Tilt is active (or leftover containers are running) fails with a cryptic Docker error: `bind: address already in use`. The new check catches this upfront with a clear message:

```
Error: port 26257 already in use by tilt (pid 60224)
Error: port 8080 already in use by tilt (pid 60224)
Error: port 50051 already in use by tilt (pid 60224)

Hint: if Tilt is running, stop it first:  tilt down
      or stop leftover containers:        make dev-down
```

## Test plan

- [x] Verified with Tilt running on all four ports — check fires correctly
- [ ] Verify `make dev-up` starts normally when no ports are occupied