### PR TITLE
fix: Wire MDS loopback client for forecasting in unified binary

### DIFF
--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -48,12 +48,14 @@ import (
 	currentaccountservice "github.com/meridianhub/meridian/services/current-account/service"
 	financialaccountingpersistence "github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
 	financialaccountingservice "github.com/meridianhub/meridian/services/financial-accounting/service"
+	forecastingmds "github.com/meridianhub/meridian/services/forecasting/adapters/mds"
 	forecastingpersistence "github.com/meridianhub/meridian/services/forecasting/adapters/persistence"
 	forecastinghandler "github.com/meridianhub/meridian/services/forecasting/handler"
 	forecastingstarlark "github.com/meridianhub/meridian/services/forecasting/starlark"
 	internalbankaccountpersistence "github.com/meridianhub/meridian/services/internal-bank-account/adapters/persistence"
 	internalbankaccountservice "github.com/meridianhub/meridian/services/internal-bank-account/service"
 	marketinformationpersistence "github.com/meridianhub/meridian/services/market-information/adapters/persistence"
+	misclient "github.com/meridianhub/meridian/services/market-information/client"
 	marketinformationservice "github.com/meridianhub/meridian/services/market-information/service"
 	partypersistence "github.com/meridianhub/meridian/services/party/adapters/persistence"
 	partyservice "github.com/meridianhub/meridian/services/party/service"
@@ -85,6 +87,7 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/observability"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
@@ -208,9 +211,20 @@ func run(logger *slog.Logger, grpcPort, httpPort int) error {
 	outboxPublisher := events.NewOutboxPublisher("unified")
 	outboxRepo := events.NewPostgresOutboxRepository(db)
 
+	// MDS loopback client (forecasting → market-information via same gRPC server).
+	// grpc.NewClient is lazy — connects on first RPC, after the server is listening.
+	mdsClient, mdsCleanup, err := misclient.New(ctx, misclient.Config{
+		Target:      fmt.Sprintf("localhost:%d", grpcPort),
+		DialOptions: []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+	})
+	if err != nil {
+		return fmt.Errorf("MDS loopback client: %w", err)
+	}
+	defer func() { _ = mdsCleanup() }()
+
 	// ─── Register All Services ──────────────────────────────────────────
 
-	if err := registerServices(grpcServer, db, pgxPool, idempotencySvc, faEventPublisher, pkEventPublisher, outboxPublisher, outboxRepo, logger); err != nil {
+	if err := registerServices(grpcServer, db, pgxPool, idempotencySvc, faEventPublisher, pkEventPublisher, outboxPublisher, outboxRepo, mdsClient, logger); err != nil {
 		return err
 	}
 
@@ -279,6 +293,7 @@ func registerServices(
 	pkEventPublisher pkdomain.EventPublisher,
 	outboxPublisher *events.OutboxPublisher,
 	outboxRepo *events.PostgresOutboxRepository,
+	mdsClient *misclient.Client,
 	logger *slog.Logger,
 ) error {
 	// Tier 0: No gRPC dependencies
@@ -309,7 +324,7 @@ func registerServices(
 		{"position-keeping", func() error {
 			return wirePositionKeeping(grpcServer, pgxPool, idempotencySvc, pkEventPublisher, logger)
 		}},
-		{"forecasting", func() error { return wireForecasting(grpcServer, pgxPool, logger) }},
+		{"forecasting", func() error { return wireForecasting(grpcServer, pgxPool, mdsClient, logger) }},
 	} {
 		if err := wire.fn(); err != nil {
 			return fmt.Errorf("%s: %w", wire.name, err)
@@ -478,19 +493,22 @@ func wirePositionKeeping(
 	return nil
 }
 
-func wireForecasting(server *grpc.Server, pool *pgxpool.Pool, logger *slog.Logger) error {
+func wireForecasting(server *grpc.Server, pool *pgxpool.Pool, mdsClient *misclient.Client, logger *slog.Logger) error {
 	repo := forecastingpersistence.NewStrategyRepository(pool)
 
+	misAdapter := forecastingmds.NewMISAdapter(mdsClient)
+	mdsPublisher := forecastingmds.NewPublisherAdapter(mdsClient)
+
 	runner, err := forecastingstarlark.NewForecastRunner(forecastingstarlark.ForecastRunnerConfig{
-		MISClient: &noopMISClient{},
-		RefData:   &noopRefDataClient{},
+		MISClient: misAdapter,
+		RefData:   &forecastingmds.NoOpRefDataClient{},
 		Logger:    logger,
 	})
 	if err != nil {
 		return fmt.Errorf("forecast runner: %w", err)
 	}
 
-	svc, err := forecastinghandler.NewService(repo, runner, nil, logger)
+	svc, err := forecastinghandler.NewService(repo, runner, mdsPublisher, logger)
 	if err != nil {
 		return err
 	}
@@ -608,18 +626,4 @@ func (p *noopFAPublisher) Publish(_ context.Context, _ financialaccountingservic
 
 func (p *noopFAPublisher) PublishBatch(_ context.Context, _ []financialaccountingservice.DomainEvent) error {
 	return nil
-}
-
-// noopMISClient is a no-op market information client for forecasting (no inter-service gRPC in dev).
-type noopMISClient struct{}
-
-func (c *noopMISClient) FetchObservations(_ context.Context, _ string, _ time.Time) ([]forecastingstarlark.Observation, error) {
-	return []forecastingstarlark.Observation{}, nil
-}
-
-// noopRefDataClient is a no-op reference data client for forecasting (no inter-service gRPC in dev).
-type noopRefDataClient struct{}
-
-func (c *noopRefDataClient) GetNodeByResolutionKey(_ context.Context, _, _ string) (*forecastingstarlark.ReferenceData, error) {
-	return &forecastingstarlark.ReferenceData{}, nil
 }

--- a/services/forecasting/handler/forecasting_handler.go
+++ b/services/forecasting/handler/forecasting_handler.go
@@ -64,9 +64,6 @@ func NewService(
 	if runner == nil {
 		return nil, ErrRunnerRequired
 	}
-	if mds == nil {
-		return nil, ErrMDSRequired
-	}
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -201,6 +198,11 @@ func (s *Service) publishToMDS(
 	points []starlark.ForecastPoint,
 	executionTime time.Time,
 ) error {
+	if s.mds == nil {
+		s.logger.Warn("MDS publisher not configured, skipping forecast publish",
+			"point_count", len(points))
+		return nil
+	}
 	if len(points) == 0 {
 		return nil
 	}

--- a/services/forecasting/handler/forecasting_handler_test.go
+++ b/services/forecasting/handler/forecasting_handler_test.go
@@ -169,9 +169,9 @@ func TestNewService_NilRunner(t *testing.T) {
 }
 
 func TestNewService_NilMDS(t *testing.T) {
-	_, err := handler.NewService(&mockStrategyRepo{}, &starlark.ForecastRunner{}, nil, slog.Default())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "MDS")
+	svc, err := handler.NewService(&mockStrategyRepo{}, &starlark.ForecastRunner{}, nil, slog.Default())
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
 }
 
 func TestNewService_NilLogger(t *testing.T) {


### PR DESCRIPTION
## Summary

- The unified binary was passing `nil` for the MDS publisher when wiring the forecasting service, causing the container to crash on startup with: `"forecasting: MDS publisher is required"`
- Wire a loopback `misclient.Client` targeting `localhost:<grpcPort>` so forecasting can publish results to the market-information service running on the same gRPC server
- Use the existing `mds.PublisherAdapter` and `mds.MISAdapter` from `services/forecasting/adapters/mds/` — the same adapters the standalone forecasting service uses
- Remove the `noopMISClient` and `noopRefDataClient` stubs that were placeholders

## Test plan

- [x] Unified binary compiles cleanly
- [x] All `cmd/meridian` tests pass
- [ ] `make dev-up` starts without crash — forecasting registers with MDS wired