### PR TITLE
Add IntelliJ gRPC client files for API testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ __pycache__/
 deployments/k8s/*/secret.yaml
 deployments/k8s/base/secret.yaml
 *.local.md
+
+# IntelliJ HTTP Client private environment (may contain secrets)
+http/http-client.private.env.json

--- a/http/00-happy-path.http
+++ b/http/00-happy-path.http
@@ -1,0 +1,271 @@
+### Meridian Happy Path - End-to-End Flow (gRPC)
+# Demonstrates the core Meridian story: party registration, account opening,
+# deposits, withdrawals, liens, and balance verification.
+#
+# Prerequisites: `make dev-up` running locally
+# Environment: Select "local" in IntelliJ HTTP Client
+# Requires: IntelliJ "gRPC" and "Protocol Buffers" plugins
+
+### 1. Health Check (HTTP - gateway health endpoint)
+GET {{host}}/health
+
+> {%
+    client.test("Health check returns 200", function() {
+        client.assert(response.status === 200, "Expected 200");
+    });
+%}
+
+### 2. Register Party
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/RegisterParty
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyType": "PARTY_TYPE_PERSON",
+  "legalName": "Jane Smith",
+  "displayName": "Jane"
+}
+
+> {%
+    client.test("Party registered", function() {
+        client.assert(response.body.party.partyId, "Expected partyId");
+    });
+    client.global.set("party_id", response.body.party.partyId);
+%}
+
+### 3. Retrieve Party (verify)
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/RetrieveParty
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}"
+}
+
+> {%
+    client.test("Party retrieved", function() {
+        client.assert(response.body.party.legalName === "Jane Smith", "Expected legal name");
+        client.assert(response.body.party.status === "PARTY_STATUS_ACTIVE", "Expected ACTIVE");
+    });
+%}
+
+### 4. Open Current Account (GBP)
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/InitiateCurrentAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}",
+  "accountIdentification": "GB29NWBK60161331926819",
+  "baseCurrency": "CURRENCY_GBP"
+}
+
+> {%
+    client.test("Account created", function() {
+        client.assert(response.body.facility.accountId, "Expected accountId");
+    });
+    client.global.set("account_id", response.body.facility.accountId);
+%}
+
+### 5. Retrieve Account (verify ACTIVE)
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{account_id}}"
+}
+
+> {%
+    client.test("Account is active", function() {
+        client.assert(response.body.facility.accountStatus === "ACCOUNT_STATUS_ACTIVE", "Expected ACTIVE");
+    });
+%}
+
+### 6. Deposit 1000 GBP
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/ExecuteDeposit
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{account_id}}",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "1000"
+    }
+  },
+  "description": "Initial deposit",
+  "reference": "DEP-001",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.test("Deposit successful", function() {
+        client.assert(response.body.transactionId, "Expected transactionId");
+    });
+%}
+
+### 7. Check Balance (position-keeping)
+GRPC {{grpc_host}}/meridian.position_keeping.v1.PositionKeepingService/GetAccountBalances
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{account_id}}"
+}
+
+> {%
+    client.test("Balance query returns results", function() {
+        client.assert(response.body.balances, "Expected balances");
+    });
+%}
+
+### 8. Deposit 500 GBP
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/ExecuteDeposit
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{account_id}}",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "500"
+    }
+  },
+  "description": "Second deposit",
+  "reference": "DEP-002",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.test("Second deposit successful", function() {
+        client.assert(response.body.transactionId, "Expected transactionId");
+    });
+%}
+
+### 9. Initiate Withdrawal 200 GBP
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/InitiateWithdrawal
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{account_id}}",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "200"
+    }
+  },
+  "description": "ATM withdrawal",
+  "reference": "WD-001",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.test("Withdrawal initiated", function() {
+        client.assert(response.body.withdrawal.withdrawalId, "Expected withdrawalId");
+    });
+    client.global.set("withdrawal_id", response.body.withdrawal.withdrawalId);
+%}
+
+### 10. Execute Withdrawal
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/ExecuteWithdrawal
+x-tenant-id: {{tenant_id}}
+
+{
+  "withdrawalId": "{{withdrawal_id}}",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.test("Withdrawal executed", function() {
+        client.assert(response.body.withdrawal.status === "WITHDRAWAL_STATUS_COMPLETED", "Expected COMPLETED");
+    });
+%}
+
+### 11. Initiate Lien (reserve 100 GBP)
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/InitiateLien
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{account_id}}",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "100"
+    }
+  },
+  "paymentOrderReference": "PO-HAPPY-001",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.test("Lien created", function() {
+        client.assert(response.body.lien.lienId, "Expected lienId");
+    });
+    client.global.set("lien_id", response.body.lien.lienId);
+%}
+
+### 12. Retrieve Lien (verify ACTIVE)
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/RetrieveLien
+x-tenant-id: {{tenant_id}}
+
+{
+  "lienId": "{{lien_id}}"
+}
+
+> {%
+    client.test("Lien is active", function() {
+        client.assert(response.body.lien.status === "LIEN_STATUS_ACTIVE", "Expected ACTIVE");
+    });
+%}
+
+### 13. Execute Lien (convert to debit)
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/ExecuteLien
+x-tenant-id: {{tenant_id}}
+
+{
+  "lienId": "{{lien_id}}",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.test("Lien executed", function() {
+        client.assert(response.body.lien.status === "LIEN_STATUS_EXECUTED", "Expected EXECUTED");
+    });
+%}
+
+### 14. Get All Balances (final verification)
+# Expected: 1000 + 500 - 200 - 100 = 1200 GBP
+GRPC {{grpc_host}}/meridian.position_keeping.v1.PositionKeepingService/GetAccountBalances
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{account_id}}"
+}
+
+> {%
+    client.test("Final balance query succeeds", function() {
+        client.assert(response.body.balances, "Expected balances");
+    });
+%}
+
+### 15. Retrieve Account (final state)
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{account_id}}"
+}
+
+> {%
+    client.test("Account still active", function() {
+        client.assert(response.body.facility.accountStatus === "ACCOUNT_STATUS_ACTIVE", "Expected ACTIVE");
+    });
+%}

--- a/http/01-party.http
+++ b/http/01-party.http
@@ -1,0 +1,235 @@
+### Party Reference Data Directory Service
+# BIAN-compliant party management: registration, lifecycle, associations, payment methods.
+# Proto: api/proto/meridian/party/v1/party.proto
+
+## --- Registration ---
+
+### Register Party (person)
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/RegisterParty
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyType": "PARTY_TYPE_PERSON",
+  "legalName": "Jane Smith",
+  "displayName": "Jane"
+}
+
+> {%
+    client.global.set("party_id", response.body.party.partyId);
+%}
+
+### Register Party (organization)
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/RegisterParty
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyType": "PARTY_TYPE_ORGANIZATION",
+  "legalName": "Acme Trading Ltd",
+  "displayName": "Acme",
+  "externalReference": "CRM-ORG-001",
+  "externalReferenceType": "EXTERNAL_REFERENCE_TYPE_CRM"
+}
+
+> {%
+    client.global.set("org_party_id", response.body.party.partyId);
+%}
+
+### Retrieve Party
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/RetrieveParty
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}"
+}
+
+### Update Party
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/UpdateParty
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}",
+  "displayName": "Jane S."
+}
+
+## --- Lifecycle Control ---
+
+### Control Party (restrict)
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/ControlParty
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}",
+  "action": "CONTROL_ACTION_RESTRICT",
+  "reason": "KYC review pending"
+}
+
+### Control Party (activate after restriction)
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/ControlParty
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}",
+  "action": "CONTROL_ACTION_ACTIVATE",
+  "reason": "KYC review completed"
+}
+
+### Control Party (suspend)
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/ControlParty
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}",
+  "action": "CONTROL_ACTION_SUSPEND",
+  "reason": "Fraud investigation"
+}
+
+## --- Reference BQ ---
+
+### Update Reference
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/UpdateReference
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}",
+  "externalReference": "CRM-12345",
+  "externalReferenceType": "EXTERNAL_REFERENCE_TYPE_CRM"
+}
+
+### Retrieve Reference
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/RetrieveReference
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}"
+}
+
+## --- Demographics BQ ---
+
+### Exchange Demographics
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/ExchangeDemographics
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}",
+  "dateOfBirth": "1990-06-15",
+  "nationality": "GB",
+  "residenceCountry": "GB"
+}
+
+### Retrieve Demographics
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/RetrieveDemographics
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}"
+}
+
+## --- Bank Relations BQ ---
+
+### Update Bank Relations
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/UpdateBankRelations
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}",
+  "relationshipType": "RELATIONSHIP_TYPE_CUSTOMER",
+  "relationshipStatus": "RELATIONSHIP_STATUS_ACTIVE"
+}
+
+### Retrieve Bank Relations
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/RetrieveBankRelations
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}"
+}
+
+## --- Associations BQ ---
+
+### Register Association
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/RegisterAssociations
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}",
+  "associatedPartyId": "{{org_party_id}}",
+  "associationType": "ASSOCIATION_TYPE_EMPLOYEE"
+}
+
+### Retrieve Associations
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/RetrieveAssociations
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}"
+}
+
+## --- Payment Methods ---
+
+### Add Payment Method
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/AddPaymentMethod
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}",
+  "provider": "PAYMENT_METHOD_PROVIDER_STRIPE",
+  "type": "PAYMENT_METHOD_TYPE_CARD",
+  "externalId": "pm_test_visa_4242",
+  "label": "Personal Visa"
+}
+
+> {%
+    client.global.set("payment_method_id", response.body.paymentMethod.paymentMethodId);
+%}
+
+### List Payment Methods
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/ListPaymentMethods
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}"
+}
+
+### Set Default Payment Method
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/SetDefaultPaymentMethod
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}",
+  "paymentMethodId": "{{payment_method_id}}"
+}
+
+### Get Default Payment Method
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/GetDefaultPaymentMethod
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}"
+}
+
+### Remove Payment Method
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/RemovePaymentMethod
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{party_id}}",
+  "paymentMethodId": "{{payment_method_id}}"
+}
+
+## --- Syndicate / Structuring ---
+
+### List Participants
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/ListParticipants
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{org_party_id}}"
+}
+
+### Get Structuring Data
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/GetStructuringData
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{org_party_id}}"
+}

--- a/http/02-current-account.http
+++ b/http/02-current-account.http
@@ -1,0 +1,323 @@
+### Current Account Service
+# BIAN-compliant current account operations: deposits, withdrawals, liens, valuation features.
+# Proto: api/proto/meridian/current_account/v1/current_account.proto
+
+## --- Setup: Create Party + Account ---
+
+### Register Party (for account setup)
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/RegisterParty
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyType": "PARTY_TYPE_PERSON",
+  "legalName": "Account Test User",
+  "displayName": "Account Tester"
+}
+
+> {%
+    client.global.set("ca_party_id", response.body.party.partyId);
+%}
+
+### Open Current Account (GBP)
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/InitiateCurrentAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{ca_party_id}}",
+  "accountIdentification": "GB82WEST12345698765432",
+  "baseCurrency": "CURRENCY_GBP"
+}
+
+> {%
+    client.global.set("ca_account_id", response.body.accountId);
+%}
+
+### Open Current Account (USD)
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/InitiateCurrentAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{ca_party_id}}",
+  "accountIdentification": "GB45WEST12345612345678",
+  "baseCurrency": "CURRENCY_USD"
+}
+
+### Retrieve Account
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{ca_account_id}}"
+}
+
+### Update Account
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/UpdateCurrentAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{ca_account_id}}",
+  "overdraftLimit": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "500"
+    }
+  }
+}
+
+## --- Deposits ---
+
+### Deposit 1000 GBP
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/ExecuteDeposit
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{ca_account_id}}",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "1000"
+    }
+  },
+  "description": "Salary credit",
+  "reference": "SAL-2025-01",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+### Deposit fractional amount
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/ExecuteDeposit
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{ca_account_id}}",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "0",
+      "nanos": 990000000
+    }
+  },
+  "description": "Interest payment",
+  "reference": "INT-001",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+## --- Withdrawals (two-phase) ---
+
+### Initiate Withdrawal
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/InitiateWithdrawal
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{ca_account_id}}",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "250"
+    }
+  },
+  "description": "ATM withdrawal",
+  "reference": "ATM-001",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.global.set("ca_withdrawal_id", response.body.withdrawal.withdrawalId);
+%}
+
+### Execute Withdrawal
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/ExecuteWithdrawal
+x-tenant-id: {{tenant_id}}
+
+{
+  "withdrawalId": "{{ca_withdrawal_id}}",
+  "accountId": "{{ca_account_id}}",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+### Retrieve Withdrawal
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/RetrieveWithdrawal
+x-tenant-id: {{tenant_id}}
+
+{
+  "withdrawalId": "{{ca_withdrawal_id}}"
+}
+
+## --- Withdrawals (direct execution) ---
+
+### Direct Withdrawal (skip initiate)
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/ExecuteWithdrawal
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{ca_account_id}}",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "50"
+    }
+  },
+  "description": "POS purchase",
+  "reference": "POS-001",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+## --- Liens ---
+
+### Initiate Lien
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/InitiateLien
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{ca_account_id}}",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "200"
+    }
+  },
+  "paymentOrderReference": "PO-TEST-001",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.global.set("ca_lien_id", response.body.lien.lienId);
+%}
+
+### Retrieve Lien
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/RetrieveLien
+x-tenant-id: {{tenant_id}}
+
+{
+  "lienId": "{{ca_lien_id}}"
+}
+
+### Execute Lien
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/ExecuteLien
+x-tenant-id: {{tenant_id}}
+
+{
+  "lienId": "{{ca_lien_id}}",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+### Initiate Another Lien (for termination test)
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/InitiateLien
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{ca_account_id}}",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "100"
+    }
+  },
+  "paymentOrderReference": "PO-TEST-002",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.global.set("ca_lien_id_2", response.body.lien.lienId);
+%}
+
+### Terminate Lien
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/TerminateLien
+x-tenant-id: {{tenant_id}}
+
+{
+  "lienId": "{{ca_lien_id_2}}",
+  "reason": "Payment order cancelled"
+}
+
+### Get Active Amount Blocks
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/GetActiveAmountBlocks
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{ca_account_id}}"
+}
+
+## --- Account Lifecycle ---
+
+### Control Account (freeze)
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/ControlCurrentAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{ca_account_id}}",
+  "action": "CONTROL_ACTION_FREEZE",
+  "reason": "Suspicious activity investigation"
+}
+
+### Control Account (unfreeze)
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/ControlCurrentAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{ca_account_id}}",
+  "action": "CONTROL_ACTION_UNFREEZE",
+  "reason": "Investigation cleared"
+}
+
+## --- Valuation Features ---
+
+### Create Valuation Feature (EUR->GBP)
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/CreateValuationFeature
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{ca_account_id}}",
+  "instrumentCode": "EUR",
+  "valuationMethodId": "fx-spot-rate",
+  "valuationMethodVersion": 1,
+  "outputInstrument": "GBP",
+  "parameters": "{\"spread\": \"0.002\"}"
+}
+
+> {%
+    client.global.set("ca_vf_id", response.body.feature.id);
+%}
+
+### List Valuation Features
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/ListValuationFeatures
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{ca_account_id}}"
+}
+
+### Get Valuation Feature
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/GetValuationFeature
+x-tenant-id: {{tenant_id}}
+
+{
+  "featureId": "{{ca_vf_id}}"
+}
+
+### Evaluate Asset Valuation (inquiry)
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/EvaluateAssetValuation
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{ca_account_id}}",
+  "input": {
+    "amount": "500.00",
+    "instrumentCode": "EUR"
+  }
+}

--- a/http/03-position-keeping.http
+++ b/http/03-position-keeping.http
@@ -1,0 +1,174 @@
+### Position Keeping Service
+# BIAN-compliant position tracking: balance queries, position logs, reservations.
+# Proto: api/proto/meridian/position_keeping/v1/position_keeping.proto
+
+## --- Setup: Create Party + Account + Deposit ---
+
+### Register Party
+GRPC {{grpc_host}}/meridian.party.v1.PartyService/RegisterParty
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyType": "PARTY_TYPE_PERSON",
+  "legalName": "Position Test User",
+  "displayName": "PK Tester"
+}
+
+> {%
+    client.global.set("pk_party_id", response.body.party.partyId);
+%}
+
+### Open Account
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/InitiateCurrentAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "partyId": "{{pk_party_id}}",
+  "accountIdentification": "GB11NWBK60161331926820",
+  "baseCurrency": "CURRENCY_GBP"
+}
+
+> {%
+    client.global.set("pk_account_id", response.body.accountId);
+%}
+
+### Seed Deposit
+GRPC {{grpc_host}}/meridian.current_account.v1.CurrentAccountService/ExecuteDeposit
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{pk_account_id}}",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "5000"
+    }
+  },
+  "description": "Seed deposit for position tests",
+  "reference": "PK-SEED-001",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+## --- Balance Queries ---
+
+### Get Account Balance (current)
+GRPC {{grpc_host}}/meridian.position_keeping.v1.PositionKeepingService/GetAccountBalance
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{pk_account_id}}"
+}
+
+### Get All Balances (current + available + reserved)
+GRPC {{grpc_host}}/meridian.position_keeping.v1.PositionKeepingService/GetAccountBalances
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{pk_account_id}}"
+}
+
+### Get Projected Balance
+GRPC {{grpc_host}}/meridian.position_keeping.v1.PositionKeepingService/GetProjectedBalance
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{pk_account_id}}"
+}
+
+## --- Position Logs ---
+
+### Initiate Financial Position Log
+GRPC {{grpc_host}}/meridian.position_keeping.v1.PositionKeepingService/InitiateFinancialPositionLog
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{pk_account_id}}",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "100"
+    }
+  },
+  "direction": "POSTING_DIRECTION_CREDIT",
+  "description": "Manual adjustment",
+  "reference": "ADJ-001",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.global.set("pk_log_id", response.body.positionLogId);
+%}
+
+### Retrieve Financial Position Log
+GRPC {{grpc_host}}/meridian.position_keeping.v1.PositionKeepingService/RetrieveFinancialPositionLog
+x-tenant-id: {{tenant_id}}
+
+{
+  "positionLogId": "{{pk_log_id}}"
+}
+
+### List Financial Position Logs
+GRPC {{grpc_host}}/meridian.position_keeping.v1.PositionKeepingService/ListFinancialPositionLogs
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{pk_account_id}}",
+  "pageSize": 20
+}
+
+### Initiate Batch Position Logs
+GRPC {{grpc_host}}/meridian.position_keeping.v1.PositionKeepingService/InitiateFinancialPositionLogBatch
+x-tenant-id: {{tenant_id}}
+
+{
+  "entries": [
+    {
+      "accountId": "{{pk_account_id}}",
+      "amount": {
+        "amount": {
+          "currencyCode": "GBP",
+          "units": "50"
+        }
+      },
+      "direction": "POSTING_DIRECTION_CREDIT",
+      "description": "Batch entry 1",
+      "reference": "BATCH-001",
+      "idempotencyKey": {
+        "key": "{{$uuid}}"
+      }
+    }
+  ]
+}
+
+## --- Reservations ---
+
+### Record Reservation
+GRPC {{grpc_host}}/meridian.position_keeping.v1.PositionKeepingService/RecordReservation
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{pk_account_id}}",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "300"
+    }
+  },
+  "reference": "RES-001"
+}
+
+> {%
+    client.global.set("pk_reservation_id", response.body.reservationId);
+%}
+
+### Release Reservation
+GRPC {{grpc_host}}/meridian.position_keeping.v1.PositionKeepingService/ReleaseReservation
+x-tenant-id: {{tenant_id}}
+
+{
+  "reservationId": "{{pk_reservation_id}}"
+}

--- a/http/04-financial-accounting.http
+++ b/http/04-financial-accounting.http
@@ -1,0 +1,150 @@
+### Financial Accounting Service
+# BIAN-compliant double-entry bookkeeping: booking logs, ledger postings.
+# Proto: api/proto/meridian/financial_accounting/v1/financial_accounting.proto
+
+## --- Booking Log Lifecycle ---
+
+### Initiate Booking Log
+GRPC {{grpc_host}}/meridian.financial_accounting.v1.FinancialAccountingService/InitiateFinancialBookingLog
+x-tenant-id: {{tenant_id}}
+
+{
+  "description": "Monthly revenue recognition",
+  "reference": "REV-2025-01",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.global.set("fa_log_id", response.body.bookingLogId);
+%}
+
+### Retrieve Booking Log
+GRPC {{grpc_host}}/meridian.financial_accounting.v1.FinancialAccountingService/RetrieveFinancialBookingLog
+x-tenant-id: {{tenant_id}}
+
+{
+  "bookingLogId": "{{fa_log_id}}"
+}
+
+### List Booking Logs
+GRPC {{grpc_host}}/meridian.financial_accounting.v1.FinancialAccountingService/ListFinancialBookingLogs
+x-tenant-id: {{tenant_id}}
+
+{
+  "pageSize": 20
+}
+
+### Update Booking Log
+GRPC {{grpc_host}}/meridian.financial_accounting.v1.FinancialAccountingService/UpdateFinancialBookingLog
+x-tenant-id: {{tenant_id}}
+
+{
+  "bookingLogId": "{{fa_log_id}}",
+  "status": "BOOKING_LOG_STATUS_POSTED"
+}
+
+## --- Ledger Postings (double-entry) ---
+
+### Capture Debit Posting
+GRPC {{grpc_host}}/meridian.financial_accounting.v1.FinancialAccountingService/CaptureLedgerPosting
+x-tenant-id: {{tenant_id}}
+
+{
+  "bookingLogId": "{{fa_log_id}}",
+  "accountId": "revenue-gbp-001",
+  "postingDirection": "POSTING_DIRECTION_DEBIT",
+  "postingAmount": {
+    "currencyCode": "GBP",
+    "units": "500"
+  },
+  "description": "Revenue debit entry",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.global.set("fa_debit_id", response.body.ledgerPostingId);
+%}
+
+### Capture Credit Posting (balancing entry)
+GRPC {{grpc_host}}/meridian.financial_accounting.v1.FinancialAccountingService/CaptureLedgerPosting
+x-tenant-id: {{tenant_id}}
+
+{
+  "bookingLogId": "{{fa_log_id}}",
+  "accountId": "accounts-receivable-001",
+  "postingDirection": "POSTING_DIRECTION_CREDIT",
+  "postingAmount": {
+    "currencyCode": "GBP",
+    "units": "500"
+  },
+  "description": "AR credit entry",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.global.set("fa_credit_id", response.body.ledgerPostingId);
+%}
+
+### Retrieve Ledger Posting
+GRPC {{grpc_host}}/meridian.financial_accounting.v1.FinancialAccountingService/RetrieveLedgerPosting
+x-tenant-id: {{tenant_id}}
+
+{
+  "ledgerPostingId": "{{fa_debit_id}}"
+}
+
+### List Ledger Postings
+GRPC {{grpc_host}}/meridian.financial_accounting.v1.FinancialAccountingService/ListLedgerPostings
+x-tenant-id: {{tenant_id}}
+
+{
+  "bookingLogId": "{{fa_log_id}}",
+  "pageSize": 50
+}
+
+### Update Ledger Posting
+GRPC {{grpc_host}}/meridian.financial_accounting.v1.FinancialAccountingService/UpdateLedgerPosting
+x-tenant-id: {{tenant_id}}
+
+{
+  "ledgerPostingId": "{{fa_debit_id}}",
+  "description": "Revenue debit entry (updated)"
+}
+
+## --- Booking Log Lifecycle Control ---
+
+### Control Booking Log (suspend)
+GRPC {{grpc_host}}/meridian.financial_accounting.v1.FinancialAccountingService/ControlFinancialBookingLog
+x-tenant-id: {{tenant_id}}
+
+{
+  "bookingLogId": "{{fa_log_id}}",
+  "action": "BOOKING_LOG_CONTROL_ACTION_SUSPEND",
+  "reason": "Pending audit review"
+}
+
+### Control Booking Log (resume)
+GRPC {{grpc_host}}/meridian.financial_accounting.v1.FinancialAccountingService/ControlFinancialBookingLog
+x-tenant-id: {{tenant_id}}
+
+{
+  "bookingLogId": "{{fa_log_id}}",
+  "action": "BOOKING_LOG_CONTROL_ACTION_RESUME",
+  "reason": "Audit review completed"
+}
+
+### Control Booking Log (terminate)
+GRPC {{grpc_host}}/meridian.financial_accounting.v1.FinancialAccountingService/ControlFinancialBookingLog
+x-tenant-id: {{tenant_id}}
+
+{
+  "bookingLogId": "{{fa_log_id}}",
+  "action": "BOOKING_LOG_CONTROL_ACTION_TERMINATE",
+  "reason": "End of period"
+}

--- a/http/05-payment-order.http
+++ b/http/05-payment-order.http
@@ -1,6 +1,7 @@
 ### Payment Order Service
 # BIAN-compliant saga orchestration: funds reservation, gateway execution, ledger booking.
 # Proto: api/proto/meridian/payment_order/v1/payment_order.proto
+# Prerequisites: Run 00-happy-path.http or 02-current-account.http first to set account_id
 #
 # State Machine: INITIATED -> RESERVED -> EXECUTING -> COMPLETED
 

--- a/http/05-payment-order.http
+++ b/http/05-payment-order.http
@@ -1,0 +1,102 @@
+### Payment Order Service
+# BIAN-compliant saga orchestration: funds reservation, gateway execution, ledger booking.
+# Proto: api/proto/meridian/payment_order/v1/payment_order.proto
+#
+# State Machine: INITIATED -> RESERVED -> EXECUTING -> COMPLETED
+
+## --- Payment Order Lifecycle ---
+
+### Initiate Payment Order
+GRPC {{grpc_host}}/meridian.payment_order.v1.PaymentOrderService/InitiatePaymentOrder
+x-tenant-id: {{tenant_id}}
+
+{
+  "debtorAccountId": "{{account_id}}",
+  "creditorReference": "GB29NWBK60161331926819",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "150"
+    }
+  },
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.global.set("po_id", response.body.paymentOrderId);
+%}
+
+### Retrieve Payment Order
+GRPC {{grpc_host}}/meridian.payment_order.v1.PaymentOrderService/RetrievePaymentOrder
+x-tenant-id: {{tenant_id}}
+
+{
+  "paymentOrderId": "{{po_id}}"
+}
+
+### Update Payment Order (gateway callback)
+GRPC {{grpc_host}}/meridian.payment_order.v1.PaymentOrderService/UpdatePaymentOrder
+x-tenant-id: {{tenant_id}}
+
+{
+  "paymentOrderId": "{{po_id}}",
+  "gatewayReference": "GW-REF-12345",
+  "gatewayStatus": "COMPLETED"
+}
+
+### List Payment Orders
+GRPC {{grpc_host}}/meridian.payment_order.v1.PaymentOrderService/ListPaymentOrders
+x-tenant-id: {{tenant_id}}
+
+{
+  "pageSize": 20
+}
+
+## --- Cancellation ---
+
+### Initiate Payment Order (for cancellation test)
+GRPC {{grpc_host}}/meridian.payment_order.v1.PaymentOrderService/InitiatePaymentOrder
+x-tenant-id: {{tenant_id}}
+
+{
+  "debtorAccountId": "{{account_id}}",
+  "creditorReference": "GB82WEST12345698765432",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "75"
+    }
+  },
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.global.set("po_cancel_id", response.body.paymentOrderId);
+%}
+
+### Cancel Payment Order
+GRPC {{grpc_host}}/meridian.payment_order.v1.PaymentOrderService/CancelPaymentOrder
+x-tenant-id: {{tenant_id}}
+
+{
+  "paymentOrderId": "{{po_cancel_id}}",
+  "reason": "Customer requested cancellation"
+}
+
+## --- Reversal ---
+
+### Reverse Payment Order
+GRPC {{grpc_host}}/meridian.payment_order.v1.PaymentOrderService/ReversePaymentOrder
+x-tenant-id: {{tenant_id}}
+
+{
+  "paymentOrderId": "{{po_id}}",
+  "reason": "Duplicate payment detected",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}

--- a/http/06-market-information.http
+++ b/http/06-market-information.http
@@ -1,0 +1,154 @@
+### Market Information Service
+# Market data management: datasets, sources, observations for valuation and pricing.
+# Proto: api/proto/meridian/market_information/v1/market_information.proto
+
+## --- Datasets ---
+
+### Register Dataset
+GRPC {{grpc_host}}/meridian.market_information.v1.MarketInformationService/RegisterDataSet
+x-tenant-id: {{tenant_id}}
+
+{
+  "name": "fx-spot-rates",
+  "description": "Live FX spot rates from Reuters",
+  "assetClass": "FX"
+}
+
+> {%
+    client.global.set("mi_dataset_id", response.body.dataSet.dataSetId);
+%}
+
+### Retrieve Dataset
+GRPC {{grpc_host}}/meridian.market_information.v1.MarketInformationService/RetrieveDataSet
+x-tenant-id: {{tenant_id}}
+
+{
+  "dataSetId": "{{mi_dataset_id}}"
+}
+
+### Update Dataset
+GRPC {{grpc_host}}/meridian.market_information.v1.MarketInformationService/UpdateDataSet
+x-tenant-id: {{tenant_id}}
+
+{
+  "dataSetId": "{{mi_dataset_id}}",
+  "description": "Live FX spot rates from Reuters (updated feed)"
+}
+
+### Activate Dataset
+GRPC {{grpc_host}}/meridian.market_information.v1.MarketInformationService/ActivateDataSet
+x-tenant-id: {{tenant_id}}
+
+{
+  "dataSetId": "{{mi_dataset_id}}"
+}
+
+### List Datasets
+GRPC {{grpc_host}}/meridian.market_information.v1.MarketInformationService/ListDataSets
+x-tenant-id: {{tenant_id}}
+
+{}
+
+### Deprecate Dataset
+GRPC {{grpc_host}}/meridian.market_information.v1.MarketInformationService/DeprecateDataSet
+x-tenant-id: {{tenant_id}}
+
+{
+  "dataSetId": "{{mi_dataset_id}}"
+}
+
+## --- Data Sources ---
+
+### Register Data Source
+GRPC {{grpc_host}}/meridian.market_information.v1.MarketInformationService/RegisterDataSource
+x-tenant-id: {{tenant_id}}
+
+{
+  "dataSetId": "{{mi_dataset_id}}",
+  "name": "reuters-fx",
+  "description": "Reuters FX feed"
+}
+
+> {%
+    client.global.set("mi_source_id", response.body.dataSource.dataSourceId);
+%}
+
+### Update Data Source
+GRPC {{grpc_host}}/meridian.market_information.v1.MarketInformationService/UpdateDataSource
+x-tenant-id: {{tenant_id}}
+
+{
+  "dataSourceId": "{{mi_source_id}}",
+  "description": "Reuters FX feed (primary)"
+}
+
+### List Data Sources
+GRPC {{grpc_host}}/meridian.market_information.v1.MarketInformationService/ListDataSources
+x-tenant-id: {{tenant_id}}
+
+{
+  "dataSetId": "{{mi_dataset_id}}"
+}
+
+### Deactivate Data Source
+GRPC {{grpc_host}}/meridian.market_information.v1.MarketInformationService/DeactivateDataSource
+x-tenant-id: {{tenant_id}}
+
+{
+  "dataSourceId": "{{mi_source_id}}"
+}
+
+## --- Observations ---
+
+### Record Single Observation
+GRPC {{grpc_host}}/meridian.market_information.v1.MarketInformationService/RecordObservation
+x-tenant-id: {{tenant_id}}
+
+{
+  "dataSetId": "{{mi_dataset_id}}",
+  "dataSourceId": "{{mi_source_id}}",
+  "instrumentCode": "EUR/GBP",
+  "value": "0.8456"
+}
+
+> {%
+    client.global.set("mi_obs_id", response.body.observation.observationId);
+%}
+
+### Record Batch Observations
+GRPC {{grpc_host}}/meridian.market_information.v1.MarketInformationService/RecordObservationBatch
+x-tenant-id: {{tenant_id}}
+
+{
+  "observations": [
+    {
+      "dataSetId": "{{mi_dataset_id}}",
+      "dataSourceId": "{{mi_source_id}}",
+      "instrumentCode": "USD/GBP",
+      "value": "0.7923"
+    },
+    {
+      "dataSetId": "{{mi_dataset_id}}",
+      "dataSourceId": "{{mi_source_id}}",
+      "instrumentCode": "JPY/GBP",
+      "value": "0.005234"
+    }
+  ]
+}
+
+### Retrieve Observation
+GRPC {{grpc_host}}/meridian.market_information.v1.MarketInformationService/RetrieveObservation
+x-tenant-id: {{tenant_id}}
+
+{
+  "observationId": "{{mi_obs_id}}"
+}
+
+### List Observations
+GRPC {{grpc_host}}/meridian.market_information.v1.MarketInformationService/ListObservations
+x-tenant-id: {{tenant_id}}
+
+{
+  "dataSetId": "{{mi_dataset_id}}",
+  "pageSize": 50
+}

--- a/http/07-reconciliation.http
+++ b/http/07-reconciliation.http
@@ -1,6 +1,7 @@
 ### Reconciliation Service
 # BIAN-compliant account reconciliation: settlement runs, balance assertions, disputes.
 # Proto: api/proto/meridian/reconciliation/v1/reconciliation.proto
+# Prerequisites: Run 00-happy-path.http or 02-current-account.http first to set account_id
 
 ## --- Settlement Runs ---
 

--- a/http/07-reconciliation.http
+++ b/http/07-reconciliation.http
@@ -1,0 +1,116 @@
+### Reconciliation Service
+# BIAN-compliant account reconciliation: settlement runs, balance assertions, disputes.
+# Proto: api/proto/meridian/reconciliation/v1/reconciliation.proto
+
+## --- Settlement Runs ---
+
+### Initiate Account Reconciliation
+GRPC {{grpc_host}}/meridian.reconciliation.v1.AccountReconciliationService/InitiateAccountReconciliation
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{account_id}}",
+  "scope": "RECONCILIATION_SCOPE_ACCOUNT",
+  "settlementType": "SETTLEMENT_TYPE_END_OF_DAY",
+  "periodStart": "2025-01-01T00:00:00Z",
+  "periodEnd": "2025-01-31T23:59:59Z",
+  "initiatedBy": "system-scheduler",
+  "instrumentCode": "GBP",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+> {%
+    client.global.set("recon_id", response.body.reconciliation.reconciliationId);
+%}
+
+### Execute Account Reconciliation
+GRPC {{grpc_host}}/meridian.reconciliation.v1.AccountReconciliationService/ExecuteAccountReconciliation
+x-tenant-id: {{tenant_id}}
+
+{
+  "reconciliationId": "{{recon_id}}"
+}
+
+### Retrieve Account Reconciliation
+GRPC {{grpc_host}}/meridian.reconciliation.v1.AccountReconciliationService/RetrieveAccountReconciliation
+x-tenant-id: {{tenant_id}}
+
+{
+  "reconciliationId": "{{recon_id}}"
+}
+
+### List Reconciliation Results
+GRPC {{grpc_host}}/meridian.reconciliation.v1.AccountReconciliationService/ListReconciliationResults
+x-tenant-id: {{tenant_id}}
+
+{
+  "reconciliationId": "{{recon_id}}",
+  "pageSize": 50
+}
+
+### Control Reconciliation (cancel)
+GRPC {{grpc_host}}/meridian.reconciliation.v1.AccountReconciliationService/ControlAccountReconciliation
+x-tenant-id: {{tenant_id}}
+
+{
+  "reconciliationId": "{{recon_id}}",
+  "action": "CONTROL_ACTION_CANCEL",
+  "reason": "Incorrect period selected"
+}
+
+## --- Balance Assertions ---
+
+### Assert Balance
+GRPC {{grpc_host}}/meridian.reconciliation.v1.AccountReconciliationService/AssertBalance
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{account_id}}",
+  "expectedBalance": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "1200"
+    }
+  }
+}
+
+## --- Disputes ---
+
+### Initiate Dispute
+GRPC {{grpc_host}}/meridian.reconciliation.v1.AccountReconciliationService/InitiateDispute
+x-tenant-id: {{tenant_id}}
+
+{
+  "reconciliationId": "{{recon_id}}",
+  "description": "Unmatched transaction from external system",
+  "amount": {
+    "amount": {
+      "currencyCode": "GBP",
+      "units": "50"
+    }
+  }
+}
+
+> {%
+    client.global.set("dispute_id", response.body.dispute.disputeId);
+%}
+
+### Retrieve Dispute
+GRPC {{grpc_host}}/meridian.reconciliation.v1.AccountReconciliationService/RetrieveDispute
+x-tenant-id: {{tenant_id}}
+
+{
+  "disputeId": "{{dispute_id}}"
+}
+
+### Control Dispute (resolve)
+GRPC {{grpc_host}}/meridian.reconciliation.v1.AccountReconciliationService/ControlDispute
+x-tenant-id: {{tenant_id}}
+
+{
+  "disputeId": "{{dispute_id}}",
+  "action": "DISPUTE_CONTROL_ACTION_RESOLVE",
+  "reason": "Transaction matched after investigation"
+}

--- a/http/08-internal-bank-account.http
+++ b/http/08-internal-bank-account.http
@@ -1,0 +1,178 @@
+### Internal Bank Account Service
+# Treasury and internal (nostro/vostro/clearing) account management.
+# Proto: api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
+
+## --- Account Lifecycle ---
+
+### Create Internal Bank Account (Nostro)
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/InitiateInternalBankAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountCode": "NOSTRO-GBP-BARC",
+  "name": "GBP Nostro account at Barclays",
+  "accountType": "INTERNAL_ACCOUNT_TYPE_NOSTRO",
+  "instrumentCode": "GBP",
+  "description": "Primary GBP nostro for correspondent banking"
+}
+
+> {%
+    client.global.set("iba_id", response.body.account.accountId);
+%}
+
+### Retrieve Internal Bank Account
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/RetrieveInternalBankAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{iba_id}}"
+}
+
+### Update Internal Bank Account
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/UpdateInternalBankAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{iba_id}}",
+  "description": "GBP Nostro account at Barclays (primary)"
+}
+
+### List Internal Bank Accounts
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/ListInternalBankAccounts
+x-tenant-id: {{tenant_id}}
+
+{}
+
+### Get Balance
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/GetBalance
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{iba_id}}"
+}
+
+## --- Lifecycle Control ---
+
+### Control Account (suspend)
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/ControlInternalBankAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{iba_id}}",
+  "controlAction": "CONTROL_ACTION_SUSPEND",
+  "reason": "Pending correspondent bank reconciliation review"
+}
+
+### Control Account (activate / unsuspend)
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/ControlInternalBankAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{iba_id}}",
+  "controlAction": "CONTROL_ACTION_ACTIVATE",
+  "reason": "Reconciliation completed successfully"
+}
+
+### Control Account (close)
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/ControlInternalBankAccount
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{iba_id}}",
+  "controlAction": "CONTROL_ACTION_CLOSE",
+  "reason": "Account decommissioned - correspondent relationship ended"
+}
+
+## --- Valuation Features ---
+
+### Create Valuation Feature
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/CreateValuationFeature
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{iba_id}}",
+  "instrumentCode": "EUR",
+  "valuationMethodId": "fx-spot-rate",
+  "valuationMethodVersion": 1,
+  "outputInstrument": "GBP",
+  "parameters": "{\"spread\": \"0.003\"}"
+}
+
+> {%
+    client.global.set("iba_vf_id", response.body.feature.id);
+%}
+
+### List Valuation Features
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/ListValuationFeatures
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{iba_id}}"
+}
+
+### Get Valuation Feature
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/GetValuationFeature
+x-tenant-id: {{tenant_id}}
+
+{
+  "featureId": "{{iba_vf_id}}"
+}
+
+### Evaluate Valuation (inquiry)
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/EvaluateAssetValuation
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{iba_id}}",
+  "input": {
+    "amount": "1000.00",
+    "instrumentCode": "EUR"
+  }
+}
+
+## --- Liens ---
+
+### Initiate Lien on Internal Account
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/InitiateLien
+x-tenant-id: {{tenant_id}}
+
+{
+  "accountId": "{{iba_id}}",
+  "input": {
+    "amount": "5000.00",
+    "instrumentCode": "GBP"
+  },
+  "paymentOrderReference": "TREASURY-PO-001"
+}
+
+> {%
+    client.global.set("iba_lien_id", response.body.lien.lienId);
+%}
+
+### Retrieve Lien
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/RetrieveLien
+x-tenant-id: {{tenant_id}}
+
+{
+  "lienId": "{{iba_lien_id}}"
+}
+
+### Execute Lien
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/ExecuteLien
+x-tenant-id: {{tenant_id}}
+
+{
+  "lienId": "{{iba_lien_id}}",
+  "idempotencyKey": {
+    "key": "{{$uuid}}"
+  }
+}
+
+### Terminate Lien
+GRPC {{grpc_host}}/meridian.internal_bank_account.v1.InternalBankAccountService/TerminateLien
+x-tenant-id: {{tenant_id}}
+
+{
+  "lienId": "{{iba_lien_id}}",
+  "reason": "Treasury transfer cancelled"
+}

--- a/http/09-saga-registry.http
+++ b/http/09-saga-registry.http
@@ -1,0 +1,97 @@
+### Saga Registry Service
+# Workflow definition management: register, validate, activate Starlark sagas.
+# Proto: api/proto/meridian/saga/v1/saga_registry.proto
+
+## --- Saga Lifecycle ---
+
+### Create Saga Draft
+GRPC {{grpc_host}}/meridian.saga.v1.SagaRegistryService/CreateSagaDraft
+x-tenant-id: {{tenant_id}}
+
+{
+  "name": "payment_transfer",
+  "version": 1,
+  "displayName": "Payment Transfer",
+  "description": "Standard payment transfer saga with lien reservation",
+  "script": "def execute(ctx):\n    lien = current_account.initiate_lien(\n        account_id=ctx.debtor_account_id,\n        amount=ctx.amount,\n        payment_order_reference=ctx.payment_order_id\n    )\n    return {\"lien_id\": lien.lien_id}\n\ndef compensate(ctx):\n    current_account.terminate_lien(\n        lien_id=ctx.lien_id,\n        reason=\"Saga compensation\"\n    )\n"
+}
+
+> {%
+    client.global.set("saga_id", response.body.saga.id);
+%}
+
+### Retrieve Saga by ID
+GRPC {{grpc_host}}/meridian.saga.v1.SagaRegistryService/GetSaga
+x-tenant-id: {{tenant_id}}
+
+{
+  "id": "{{saga_id}}"
+}
+
+### Get Active Saga by Name
+GRPC {{grpc_host}}/meridian.saga.v1.SagaRegistryService/GetActiveSaga
+x-tenant-id: {{tenant_id}}
+
+{
+  "name": "payment_transfer"
+}
+
+### List All Sagas
+GRPC {{grpc_host}}/meridian.saga.v1.SagaRegistryService/ListSagas
+x-tenant-id: {{tenant_id}}
+
+{}
+
+### Update Saga Definition
+GRPC {{grpc_host}}/meridian.saga.v1.SagaRegistryService/UpdateSagaDefinition
+x-tenant-id: {{tenant_id}}
+
+{
+  "id": "{{saga_id}}",
+  "description": "Standard payment transfer saga with lien reservation and gateway execution"
+}
+
+## --- Validation ---
+
+### Validate Existing Saga Draft
+GRPC {{grpc_host}}/meridian.saga.v1.SagaRegistryService/ValidateSagaDraft
+x-tenant-id: {{tenant_id}}
+
+{
+  "id": "{{saga_id}}"
+}
+
+### Validate Saga Script (inline, without saving)
+GRPC {{grpc_host}}/meridian.saga.v1.SagaRegistryService/ValidateSaga
+x-tenant-id: {{tenant_id}}
+
+{
+  "sagaName": "test_saga",
+  "script": "def execute(ctx):\n    return {\"status\": \"ok\"}\n\ndef compensate(ctx):\n    pass\n"
+}
+
+## --- Lifecycle Management ---
+
+### Activate Saga
+GRPC {{grpc_host}}/meridian.saga.v1.SagaRegistryService/ActivateSaga
+x-tenant-id: {{tenant_id}}
+
+{
+  "id": "{{saga_id}}"
+}
+
+### Deprecate Saga
+GRPC {{grpc_host}}/meridian.saga.v1.SagaRegistryService/DeprecateSaga
+x-tenant-id: {{tenant_id}}
+
+{
+  "id": "{{saga_id}}"
+}
+
+### Analyze Deprecation Impact
+GRPC {{grpc_host}}/meridian.saga.v1.SagaRegistryService/AnalyzeDeprecationImpact
+x-tenant-id: {{tenant_id}}
+
+{
+  "instrumentCode": "GBP"
+}

--- a/http/10-tenant.http
+++ b/http/10-tenant.http
@@ -50,8 +50,10 @@ x-tenant-id: {{tenant_id}}
   "tenantId": "{{new_tenant_id}}"
 }
 
-### Reconcile Migrations
+### Reconcile Migrations (specific tenant)
 GRPC {{grpc_host}}/meridian.tenant.v1.TenantService/ReconcileMigrations
 x-tenant-id: {{tenant_id}}
 
-{}
+{
+  "tenantId": "{{new_tenant_id}}"
+}

--- a/http/10-tenant.http
+++ b/http/10-tenant.http
@@ -1,0 +1,57 @@
+### Tenant Service
+# Multi-tenant configuration and provisioning.
+# Proto: api/proto/meridian/tenant/v1/tenant.proto
+
+## --- Tenant Management ---
+
+### Create Tenant
+GRPC {{grpc_host}}/meridian.tenant.v1.TenantService/InitiateTenant
+x-tenant-id: {{tenant_id}}
+
+{
+  "tenantId": "acme_energy",
+  "displayName": "Acme Energy Corp",
+  "settlementAsset": "GBP",
+  "subdomain": "acme-energy"
+}
+
+> {%
+    client.global.set("new_tenant_id", response.body.tenant.tenantId);
+%}
+
+### Retrieve Tenant
+GRPC {{grpc_host}}/meridian.tenant.v1.TenantService/RetrieveTenant
+x-tenant-id: {{tenant_id}}
+
+{
+  "tenantId": "{{new_tenant_id}}"
+}
+
+### List Tenants
+GRPC {{grpc_host}}/meridian.tenant.v1.TenantService/ListTenants
+x-tenant-id: {{tenant_id}}
+
+{}
+
+### Update Tenant Status
+GRPC {{grpc_host}}/meridian.tenant.v1.TenantService/UpdateTenantStatus
+x-tenant-id: {{tenant_id}}
+
+{
+  "tenantId": "{{new_tenant_id}}",
+  "status": "TENANT_STATUS_ACTIVE"
+}
+
+### Get Provisioning Status
+GRPC {{grpc_host}}/meridian.tenant.v1.TenantService/GetTenantProvisioningStatus
+x-tenant-id: {{tenant_id}}
+
+{
+  "tenantId": "{{new_tenant_id}}"
+}
+
+### Reconcile Migrations
+GRPC {{grpc_host}}/meridian.tenant.v1.TenantService/ReconcileMigrations
+x-tenant-id: {{tenant_id}}
+
+{}

--- a/http/11-admin.http
+++ b/http/11-admin.http
@@ -1,0 +1,63 @@
+### Admin / Control Plane Service
+# Operational tooling: causation trees, balance sheets, system diagnostics.
+# Proto: api/proto/meridian/control_plane/v1/admin.proto
+
+## --- Causation Trees ---
+# Trace the causal chain of events across services.
+# Useful for debugging saga flows and understanding event propagation.
+
+### Get Causation Tree by Position ID
+# Traces all events that led to a specific position entry
+GRPC {{grpc_host}}/meridian.control_plane.v1.CausationVisualizerService/GetCausationTreeForPosition
+x-tenant-id: {{tenant_id}}
+
+{
+  "positionId": "{{position_id}}"
+}
+
+### Get Causation Tree by Transaction ID
+# Traces all events related to a specific transaction
+GRPC {{grpc_host}}/meridian.control_plane.v1.CausationVisualizerService/GetCausationTreeForTransaction
+x-tenant-id: {{tenant_id}}
+
+{
+  "transactionId": "{{transaction_id}}"
+}
+
+### Get Causation Tree by Event ID
+# Traces events from a specific event in the chain
+GRPC {{grpc_host}}/meridian.control_plane.v1.CausationVisualizerService/GetCausationTreeForEvent
+x-tenant-id: {{tenant_id}}
+
+{
+  "eventId": "{{event_id}}"
+}
+
+## --- Balance Sheets ---
+# Aggregate financial position reports across all accounts.
+
+### Get Balance Sheet for Tenant
+GRPC {{grpc_host}}/meridian.control_plane.v1.BalanceSheetService/GetBalanceSheet
+x-tenant-id: {{tenant_id}}
+
+{
+  "tenantId": "{{tenant_id}}"
+}
+
+### Get Position Details (by account type and instrument)
+GRPC {{grpc_host}}/meridian.control_plane.v1.BalanceSheetService/GetPositionDetails
+x-tenant-id: {{tenant_id}}
+
+{
+  "tenantId": "{{tenant_id}}",
+  "accountType": "ACCOUNT_TYPE_CURRENT",
+  "instrumentCode": "GBP"
+}
+
+### Export Balance Sheet CSV
+GRPC {{grpc_host}}/meridian.control_plane.v1.BalanceSheetService/ExportBalanceSheetCSV
+x-tenant-id: {{tenant_id}}
+
+{
+  "tenantId": "{{tenant_id}}"
+}

--- a/http/11-admin.http
+++ b/http/11-admin.http
@@ -1,6 +1,7 @@
 ### Admin / Control Plane Service
 # Operational tooling: causation trees, balance sheets, system diagnostics.
 # Proto: api/proto/meridian/control_plane/v1/admin.proto
+# Prerequisites: Set position_id / transaction_id / event_id from prior operations
 
 ## --- Causation Trees ---
 # Trace the causal chain of events across services.

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,0 +1,12 @@
+{
+  "local": {
+    "host": "http://localhost:8090",
+    "grpc_host": "localhost:50051",
+    "tenant_id": "default"
+  },
+  "tilt": {
+    "host": "http://localhost:8090",
+    "grpc_host": "localhost:50051",
+    "tenant_id": "default"
+  }
+}


### PR DESCRIPTION
## Summary

- Add 12 IntelliJ `.http` files using the native gRPC client format (`GRPC` keyword) for interactive testing of all Meridian services
- Target the gRPC server directly on port 50051, bypassing the HTTP gateway (which lacks gRPC-gateway transcoding)
- Include environment config (`http-client.env.json`) with `local` and `tilt` profiles, and gitignore for private env overrides

## Files

| File | Service | Highlights |
|------|---------|------------|
| `00-happy-path.http` | Multi-service | 15 chained requests: party → account → deposits → withdrawals → liens → balance verification |
| `01-party.http` | `PartyService` | Registration, lifecycle, associations, demographics, payment methods |
| `02-current-account.http` | `CurrentAccountService` | Account open, deposits, two-phase/direct withdrawals, liens, amount blocks, valuation features |
| `03-position-keeping.http` | `PositionKeepingService` | Balance queries, position logs, batch entries, reservations |
| `04-financial-accounting.http` | `FinancialAccountingService` | Booking logs, double-entry ledger postings, lifecycle control |
| `05-payment-order.http` | `PaymentOrderService` | Initiate, retrieve, update, list, cancel, reverse |
| `06-market-information.http` | `MarketInformationService` | Datasets, data sources, observations |
| `07-reconciliation.http` | `AccountReconciliationService` | Settlement runs, balance assertions, disputes |
| `08-internal-bank-account.http` | `InternalBankAccountService` | Treasury accounts, lifecycle control, valuation features, liens |
| `09-saga-registry.http` | `SagaRegistryService` | Workflow CRUD, validation, activation, deprecation |
| `10-tenant.http` | `TenantService` | Tenant provisioning, status, migration reconciliation |
| `11-admin.http` | `CausationVisualizerService`, `BalanceSheetService` | Causation trees, balance sheets, CSV export |

## Prerequisites

- IntelliJ with **gRPC** and **Protocol Buffers** plugins installed
- `make dev-up` running locally
- Select "local" environment in IntelliJ HTTP Client

## Test plan

- [ ] Open `00-happy-path.http` in IntelliJ, select "local" environment, run requests sequentially
- [ ] Verify each service-specific file connects to gRPC and returns valid responses
- [ ] Verify variable chaining works (party_id, account_id, etc. propagate between requests)