### PR TITLE
feat: add Go domain model for AccountTypeRegistry

### DIFF
--- a/services/reference-data/accounttype/behavior_class.go
+++ b/services/reference-data/accounttype/behavior_class.go
@@ -1,0 +1,56 @@
+package accounttype
+
+// BehaviorClass categorizes the accounting and operational behavior of an account type.
+type BehaviorClass string
+
+const (
+	// BehaviorClassCustomer represents customer-facing accounts.
+	BehaviorClassCustomer BehaviorClass = "CUSTOMER"
+
+	// BehaviorClassClearing represents clearing accounts used to temporarily hold funds.
+	BehaviorClassClearing BehaviorClass = "CLEARING"
+
+	// BehaviorClassNostro represents nostro accounts (our account at another bank).
+	BehaviorClassNostro BehaviorClass = "NOSTRO"
+
+	// BehaviorClassVostro represents vostro accounts (another bank's account at us).
+	BehaviorClassVostro BehaviorClass = "VOSTRO"
+
+	// BehaviorClassHolding represents holding accounts for safekeeping of assets.
+	BehaviorClassHolding BehaviorClass = "HOLDING"
+
+	// BehaviorClassSuspense represents suspense accounts for unresolved transactions.
+	BehaviorClassSuspense BehaviorClass = "SUSPENSE"
+
+	// BehaviorClassRevenue represents revenue accounts for income tracking.
+	BehaviorClassRevenue BehaviorClass = "REVENUE"
+
+	// BehaviorClassExpense represents expense accounts for cost tracking.
+	BehaviorClassExpense BehaviorClass = "EXPENSE"
+
+	// BehaviorClassInventory represents inventory accounts for asset tracking.
+	BehaviorClassInventory BehaviorClass = "INVENTORY"
+)
+
+// IsValid returns true if the behavior class is a recognized valid value.
+func (b BehaviorClass) IsValid() bool {
+	switch b {
+	case BehaviorClassCustomer,
+		BehaviorClassClearing,
+		BehaviorClassNostro,
+		BehaviorClassVostro,
+		BehaviorClassHolding,
+		BehaviorClassSuspense,
+		BehaviorClassRevenue,
+		BehaviorClassExpense,
+		BehaviorClassInventory:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the string representation of the behavior class.
+func (b BehaviorClass) String() string {
+	return string(b)
+}

--- a/services/reference-data/accounttype/definition.go
+++ b/services/reference-data/accounttype/definition.go
@@ -1,0 +1,187 @@
+package accounttype
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Definition defines the structural and behavioral characteristics
+// of an account type within the ledger system.
+// External callers reference this as accounttype.Definition.
+type Definition struct {
+	// ID is the unique identifier for this definition.
+	ID uuid.UUID
+
+	// Code is the human-readable account type code (e.g., "CUSTOMER_CURRENT").
+	Code string
+
+	// Version allows multiple versions of the same account type code.
+	Version int
+
+	// DisplayName is a human-readable name for the account type.
+	DisplayName string
+
+	// Description provides additional context about this account type.
+	Description string
+
+	// NormalBalance defines the expected sign of the balance under normal conditions.
+	NormalBalance NormalBalance
+
+	// BehaviorClass categorizes the accounting and operational behavior.
+	BehaviorClass BehaviorClass
+
+	// InstrumentCode is the instrument code associated with this account type (e.g., "GBP").
+	InstrumentCode string
+
+	// DefaultSagaPrefix is the saga prefix used for operations on accounts of this type.
+	DefaultSagaPrefix string
+
+	// DefaultConversionMethodID is the UUID of the default valuation method for currency conversion.
+	// Must be set together with DefaultConversionMethodVersion (pair constraint).
+	DefaultConversionMethodID *uuid.UUID
+
+	// DefaultConversionMethodVersion is the version of the default conversion method.
+	// Must be set together with DefaultConversionMethodID (pair constraint).
+	DefaultConversionMethodVersion *int
+
+	// ValuationMethods lists the valuation method templates associated with this account type.
+	ValuationMethods []ValuationMethodTemplate
+
+	// ValidationCEL is a CEL expression for validating account operations.
+	ValidationCEL string
+
+	// BucketingCEL is a CEL expression for determining fungibility buckets.
+	BucketingCEL string
+
+	// EligibilityCEL is a CEL expression for determining account eligibility.
+	EligibilityCEL string
+
+	// AttributeSchema defines the JSON schema for allowed attributes (optional).
+	AttributeSchema json.RawMessage
+
+	// Attributes holds additional structured metadata for this account type.
+	Attributes map[string]any
+
+	// Status is the current lifecycle status.
+	Status Status
+
+	// IsSystem indicates this is a system account type seeded during tenant provisioning.
+	IsSystem bool
+
+	// SuccessorID is the UUID of the account type that replaces this one when deprecated.
+	SuccessorID *uuid.UUID
+
+	// CreatedAt is when this definition was created.
+	CreatedAt time.Time
+
+	// UpdatedAt is when this definition was last modified.
+	UpdatedAt time.Time
+
+	// ActivatedAt is when this definition transitioned to ACTIVE (nil if never activated).
+	ActivatedAt *time.Time
+
+	// DeprecatedAt is when this definition transitioned to DEPRECATED (nil if not deprecated).
+	DeprecatedAt *time.Time
+}
+
+// ValuationMethodTemplate defines a valuation method associated with an account type.
+type ValuationMethodTemplate struct {
+	// ID is the unique identifier for this template.
+	ID uuid.UUID
+
+	// AccountTypeID is the UUID of the parent account type Definition.
+	AccountTypeID uuid.UUID
+
+	// InputInstrument is the instrument code that is the input for this valuation method.
+	InputInstrument string
+
+	// ValuationMethodID is the UUID of the referenced valuation method.
+	ValuationMethodID uuid.UUID
+
+	// ValuationMethodVersion is the version of the referenced valuation method.
+	ValuationMethodVersion int
+
+	// Parameters holds additional configuration for this valuation method template.
+	Parameters map[string]any
+
+	// Status is the current lifecycle status.
+	Status Status
+
+	// SuccessorID is the UUID of the template that replaces this one when deprecated.
+	SuccessorID *uuid.UUID
+
+	// CreatedAt is when this template was created.
+	CreatedAt time.Time
+
+	// UpdatedAt is when this template was last modified.
+	UpdatedAt time.Time
+}
+
+// NewDefinitionParams holds the input parameters for creating a new account type Definition.
+type NewDefinitionParams struct {
+	Code                           string
+	DisplayName                    string
+	Description                    string
+	NormalBalance                  string
+	BehaviorClass                  string
+	InstrumentCode                 string
+	DefaultSagaPrefix              string
+	DefaultConversionMethodID      *uuid.UUID
+	DefaultConversionMethodVersion *int
+	ValidationCEL                  string
+	BucketingCEL                   string
+	EligibilityCEL                 string
+	AttributeSchema                json.RawMessage
+	Attributes                     map[string]any
+}
+
+// NewDefinition creates a new account type Definition in DRAFT status.
+// Code, BehaviorClass, NormalBalance, and InstrumentCode are normalized to uppercase.
+// Returns an error if any typed enum field is invalid or the pair constraint is violated.
+func NewDefinition(p NewDefinitionParams) (*Definition, error) {
+	normalBalance := NormalBalance(strings.ToUpper(p.NormalBalance))
+	behaviorClass := BehaviorClass(strings.ToUpper(p.BehaviorClass))
+	code := strings.ToUpper(p.Code)
+	instrumentCode := strings.ToUpper(p.InstrumentCode)
+
+	if !normalBalance.IsValid() {
+		return nil, ErrInvalidNormalBalance
+	}
+	if !behaviorClass.IsValid() {
+		return nil, ErrInvalidBehaviorClass
+	}
+
+	// Pair constraint: both must be set or both must be nil.
+	if (p.DefaultConversionMethodID == nil) != (p.DefaultConversionMethodVersion == nil) {
+		return nil, ErrConversionMethodPair
+	}
+
+	now := time.Now().UTC()
+
+	return &Definition{
+		ID:                             uuid.New(),
+		Code:                           code,
+		Version:                        1,
+		DisplayName:                    p.DisplayName,
+		Description:                    p.Description,
+		NormalBalance:                  normalBalance,
+		BehaviorClass:                  behaviorClass,
+		InstrumentCode:                 instrumentCode,
+		DefaultSagaPrefix:              p.DefaultSagaPrefix,
+		DefaultConversionMethodID:      p.DefaultConversionMethodID,
+		DefaultConversionMethodVersion: p.DefaultConversionMethodVersion,
+		ValuationMethods:               []ValuationMethodTemplate{},
+		ValidationCEL:                  p.ValidationCEL,
+		BucketingCEL:                   p.BucketingCEL,
+		EligibilityCEL:                 p.EligibilityCEL,
+		AttributeSchema:                p.AttributeSchema,
+		Attributes:                     p.Attributes,
+		Status:                         StatusDraft,
+		IsSystem:                       false,
+		CreatedAt:                      now,
+		UpdatedAt:                      now,
+	}, nil
+}

--- a/services/reference-data/accounttype/definition_test.go
+++ b/services/reference-data/accounttype/definition_test.go
@@ -1,0 +1,192 @@
+package accounttype_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validParams() accounttype.NewDefinitionParams {
+	return accounttype.NewDefinitionParams{
+		Code:              "CUSTOMER_CURRENT",
+		DisplayName:       "Customer Current Account",
+		Description:       "Standard customer current account",
+		NormalBalance:     "CREDIT",
+		BehaviorClass:     "CUSTOMER",
+		InstrumentCode:    "GBP",
+		DefaultSagaPrefix: "payment",
+		AttributeSchema:   json.RawMessage(`{}`),
+		Attributes:        map[string]any{},
+	}
+}
+
+func TestNewDefinition_NormalizesLowercaseToUppercase(t *testing.T) {
+	params := validParams()
+	params.Code = "customer_current"
+	params.NormalBalance = "credit"
+	params.BehaviorClass = "customer"
+	params.InstrumentCode = "gbp"
+
+	def, err := accounttype.NewDefinition(params)
+	require.NoError(t, err)
+
+	assert.Equal(t, "CUSTOMER_CURRENT", def.Code)
+	assert.Equal(t, accounttype.NormalBalanceCredit, def.NormalBalance)
+	assert.Equal(t, accounttype.BehaviorClassCustomer, def.BehaviorClass)
+	assert.Equal(t, "GBP", def.InstrumentCode)
+}
+
+func TestNewDefinition_InitialStatusIsDraft(t *testing.T) {
+	def, err := accounttype.NewDefinition(validParams())
+	require.NoError(t, err)
+
+	assert.Equal(t, accounttype.StatusDraft, def.Status)
+}
+
+func TestNewDefinition_AssignsNewUUID(t *testing.T) {
+	def, err := accounttype.NewDefinition(validParams())
+	require.NoError(t, err)
+
+	assert.NotEqual(t, uuid.Nil, def.ID)
+}
+
+func TestNewDefinition_RejectsInvalidBehaviorClass(t *testing.T) {
+	params := validParams()
+	params.BehaviorClass = "INVALID_CLASS"
+
+	_, err := accounttype.NewDefinition(params)
+	require.ErrorIs(t, err, accounttype.ErrInvalidBehaviorClass)
+}
+
+func TestNewDefinition_RejectsInvalidNormalBalance(t *testing.T) {
+	params := validParams()
+	params.NormalBalance = "NEITHER"
+
+	_, err := accounttype.NewDefinition(params)
+	require.ErrorIs(t, err, accounttype.ErrInvalidNormalBalance)
+}
+
+func TestNewDefinition_AcceptsAllValidBehaviorClasses(t *testing.T) {
+	classes := []string{
+		"CUSTOMER", "CLEARING", "NOSTRO", "VOSTRO",
+		"HOLDING", "SUSPENSE", "REVENUE", "EXPENSE", "INVENTORY",
+	}
+	for _, class := range classes {
+		params := validParams()
+		params.BehaviorClass = class
+		_, err := accounttype.NewDefinition(params)
+		assert.NoError(t, err, "expected %s to be valid", class)
+	}
+}
+
+func TestNewDefinition_PairConstraint_BothNilOK(t *testing.T) {
+	params := validParams()
+	params.DefaultConversionMethodID = nil
+	params.DefaultConversionMethodVersion = nil
+
+	_, err := accounttype.NewDefinition(params)
+	require.NoError(t, err)
+}
+
+func TestNewDefinition_PairConstraint_BothSetOK(t *testing.T) {
+	params := validParams()
+	id := uuid.New()
+	v := 1
+	params.DefaultConversionMethodID = &id
+	params.DefaultConversionMethodVersion = &v
+
+	_, err := accounttype.NewDefinition(params)
+	require.NoError(t, err)
+}
+
+func TestNewDefinition_PairConstraint_IDWithoutVersion(t *testing.T) {
+	params := validParams()
+	id := uuid.New()
+	params.DefaultConversionMethodID = &id
+	params.DefaultConversionMethodVersion = nil
+
+	_, err := accounttype.NewDefinition(params)
+	require.Error(t, err)
+}
+
+func TestNewDefinition_PairConstraint_VersionWithoutID(t *testing.T) {
+	params := validParams()
+	v := 1
+	params.DefaultConversionMethodID = nil
+	params.DefaultConversionMethodVersion = &v
+
+	_, err := accounttype.NewDefinition(params)
+	require.Error(t, err)
+}
+
+func TestStatusIsValid_KnownValues(t *testing.T) {
+	assert.True(t, accounttype.StatusDraft.IsValid())
+	assert.True(t, accounttype.StatusActive.IsValid())
+	assert.True(t, accounttype.StatusDeprecated.IsValid())
+}
+
+func TestStatusIsValid_UnknownValue(t *testing.T) {
+	assert.False(t, accounttype.Status("UNKNOWN").IsValid())
+	assert.False(t, accounttype.Status("").IsValid())
+}
+
+func TestStatusCanTransitionTo_DraftToActive(t *testing.T) {
+	assert.True(t, accounttype.StatusDraft.CanTransitionTo(accounttype.StatusActive))
+}
+
+func TestStatusCanTransitionTo_ActiveToDeprecated(t *testing.T) {
+	assert.True(t, accounttype.StatusActive.CanTransitionTo(accounttype.StatusDeprecated))
+}
+
+func TestStatusCanTransitionTo_DraftToDeprecatedForbidden(t *testing.T) {
+	assert.False(t, accounttype.StatusDraft.CanTransitionTo(accounttype.StatusDeprecated))
+}
+
+func TestStatusCanTransitionTo_ActiveToDraftForbidden(t *testing.T) {
+	assert.False(t, accounttype.StatusActive.CanTransitionTo(accounttype.StatusDraft))
+}
+
+func TestStatusCanTransitionTo_DeprecatedIsTerminal(t *testing.T) {
+	assert.False(t, accounttype.StatusDeprecated.CanTransitionTo(accounttype.StatusDraft))
+	assert.False(t, accounttype.StatusDeprecated.CanTransitionTo(accounttype.StatusActive))
+}
+
+func TestStatusCanTransitionTo_SameStatusForbidden(t *testing.T) {
+	assert.False(t, accounttype.StatusDraft.CanTransitionTo(accounttype.StatusDraft))
+	assert.False(t, accounttype.StatusActive.CanTransitionTo(accounttype.StatusActive))
+}
+
+func TestBehaviorClassIsValid_KnownValues(t *testing.T) {
+	known := []accounttype.BehaviorClass{
+		accounttype.BehaviorClassCustomer,
+		accounttype.BehaviorClassClearing,
+		accounttype.BehaviorClassNostro,
+		accounttype.BehaviorClassVostro,
+		accounttype.BehaviorClassHolding,
+		accounttype.BehaviorClassSuspense,
+		accounttype.BehaviorClassRevenue,
+		accounttype.BehaviorClassExpense,
+		accounttype.BehaviorClassInventory,
+	}
+	for _, b := range known {
+		assert.True(t, b.IsValid(), "expected %s to be valid", b)
+	}
+}
+
+func TestBehaviorClassIsValid_UnknownValue(t *testing.T) {
+	assert.False(t, accounttype.BehaviorClass("UNKNOWN").IsValid())
+}
+
+func TestNormalBalanceIsValid_KnownValues(t *testing.T) {
+	assert.True(t, accounttype.NormalBalanceDebit.IsValid())
+	assert.True(t, accounttype.NormalBalanceCredit.IsValid())
+}
+
+func TestNormalBalanceIsValid_UnknownValue(t *testing.T) {
+	assert.False(t, accounttype.NormalBalance("BOTH").IsValid())
+	assert.False(t, accounttype.NormalBalance("").IsValid())
+}

--- a/services/reference-data/accounttype/errors.go
+++ b/services/reference-data/accounttype/errors.go
@@ -1,0 +1,37 @@
+package accounttype
+
+import "errors"
+
+// Domain error sentinels for AccountTypeDefinition operations.
+var (
+	// ErrNotDraft is returned when an operation requires DRAFT status but the definition is not in DRAFT.
+	ErrNotDraft = errors.New("account type definition is not in DRAFT status")
+
+	// ErrNotActive is returned when an operation requires ACTIVE status but the definition is not ACTIVE.
+	ErrNotActive = errors.New("account type definition is not ACTIVE")
+
+	// ErrFieldImmutable is returned when attempting to modify an immutable field after creation.
+	ErrFieldImmutable = errors.New("field is immutable after creation")
+
+	// ErrOptimisticLock is returned when concurrent modification is detected.
+	ErrOptimisticLock = errors.New("concurrent modification detected")
+
+	// ErrActiveCodeExists is returned when an ACTIVE definition already exists for the given code.
+	ErrActiveCodeExists = errors.New("an ACTIVE definition already exists for this code")
+
+	// ErrSagaNotFound is returned when no saga is found for the given prefix and operation.
+	ErrSagaNotFound = errors.New("no saga found for the given prefix and operation")
+
+	// ErrInvalidBehaviorClass is returned when the provided behavior class is not a recognized value.
+	ErrInvalidBehaviorClass = errors.New("invalid behavior class")
+
+	// ErrInvalidNormalBalance is returned when the provided normal balance is not a recognized value.
+	ErrInvalidNormalBalance = errors.New("invalid normal balance")
+
+	// ErrInvalidStatus is returned when the provided status is not a recognized value.
+	ErrInvalidStatus = errors.New("invalid status")
+
+	// ErrConversionMethodPair is returned when DefaultConversionMethodID and DefaultConversionMethodVersion
+	// are not both set or both nil (pair constraint violation).
+	ErrConversionMethodPair = errors.New("DefaultConversionMethodID and DefaultConversionMethodVersion must both be set or both be nil")
+)

--- a/services/reference-data/accounttype/normal_balance.go
+++ b/services/reference-data/accounttype/normal_balance.go
@@ -1,0 +1,28 @@
+package accounttype
+
+// NormalBalance defines the expected sign of the balance for an account type
+// under normal operating conditions.
+type NormalBalance string
+
+const (
+	// NormalBalanceDebit indicates the account type normally carries a debit balance (assets, expenses).
+	NormalBalanceDebit NormalBalance = "DEBIT"
+
+	// NormalBalanceCredit indicates the account type normally carries a credit balance (liabilities, revenue, equity).
+	NormalBalanceCredit NormalBalance = "CREDIT"
+)
+
+// IsValid returns true if the normal balance is a recognized valid value.
+func (n NormalBalance) IsValid() bool {
+	switch n {
+	case NormalBalanceDebit, NormalBalanceCredit:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the string representation of the normal balance.
+func (n NormalBalance) String() string {
+	return string(n)
+}

--- a/services/reference-data/accounttype/status.go
+++ b/services/reference-data/accounttype/status.go
@@ -1,0 +1,62 @@
+// Package accounttype provides the domain model for AccountTypeDefinitions,
+// which define the structural and behavioral characteristics of account types
+// within the ledger system.
+package accounttype
+
+// Status represents the lifecycle status of an AccountTypeDefinition.
+type Status string
+
+const (
+	// StatusDraft indicates an account type that is not yet active and can be modified.
+	StatusDraft Status = "DRAFT"
+
+	// StatusActive indicates an account type that is in use and immutable.
+	StatusActive Status = "ACTIVE"
+
+	// StatusDeprecated indicates an account type that should no longer be used for new accounts.
+	StatusDeprecated Status = "DEPRECATED"
+)
+
+// Valid state transitions for account type definitions:
+//
+//	DRAFT -> ACTIVE (activation)
+//	ACTIVE -> DEPRECATED (deprecation)
+//	DEPRECATED is terminal - no transitions allowed
+var validStatusTransitions = map[Status]map[Status]bool{
+	StatusDraft: {
+		StatusActive: true,
+	},
+	StatusActive: {
+		StatusDeprecated: true,
+	},
+	StatusDeprecated: {
+		// Terminal state - no valid transitions
+	},
+}
+
+// IsValid returns true if the status is a recognized valid value.
+func (s Status) IsValid() bool {
+	switch s {
+	case StatusDraft, StatusActive, StatusDeprecated:
+		return true
+	default:
+		return false
+	}
+}
+
+// CanTransitionTo checks if a transition from the current status to the target status is valid.
+func (s Status) CanTransitionTo(target Status) bool {
+	if s == target {
+		return false
+	}
+	allowed, exists := validStatusTransitions[s]
+	if !exists {
+		return false
+	}
+	return allowed[target]
+}
+
+// String returns the string representation of the status.
+func (s Status) String() string {
+	return string(s)
+}


### PR DESCRIPTION
## Summary
- Add `services/reference-data/accounttype/` package with typed string enums
- Domain structs: `Definition` (accounttype.Definition), `ValuationMethodTemplate`
- Constructor `NewDefinition` with uppercase normalization and enum validation
- Status transitions: DRAFT -> ACTIVE -> DEPRECATED (terminal)
- Pair constraint enforced for `DefaultConversionMethodID` / `DefaultConversionMethodVersion`
- Domain error sentinels: `ErrNotDraft`, `ErrNotActive`, `ErrFieldImmutable`, `ErrOptimisticLock`, `ErrActiveCodeExists`, `ErrSagaNotFound`, `ErrInvalidBehaviorClass`, `ErrInvalidNormalBalance`, `ErrInvalidStatus`, `ErrConversionMethodPair`

## Task Master
Tag: product-directory, Task: 2

## Test plan
- [x] Constructor normalizes lowercase Code, NormalBalance, BehaviorClass, InstrumentCode to uppercase
- [x] Constructor sets initial Status to DRAFT and assigns new UUID
- [x] Constructor rejects invalid BehaviorClass and NormalBalance with sentinel errors
- [x] Constructor accepts all 9 valid BehaviorClass values
- [x] Pair constraint: both DefaultConversionMethod fields nil OK, both set OK, mismatched returns error
- [x] Status.IsValid() returns false for unknown/empty values
- [x] CanTransitionTo enforces DRAFT->ACTIVE->DEPRECATED, DEPRECATED is terminal
- [x] 22 unit tests, all passing, golangci-lint clean