### PR TITLE
feat: add CEL eligibility environment for AccountTypeRegistry

### DIFF
--- a/services/reference-data/accounttype/definition.go
+++ b/services/reference-data/accounttype/definition.go
@@ -2,6 +2,8 @@ package accounttype
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -87,6 +89,27 @@ type Definition struct {
 	DeprecatedAt *time.Time
 }
 
+// compileCELFields validates all three CEL expressions using the provided compiler.
+// Returns an ErrInvalidCEL-wrapped error on the first compilation failure.
+func compileCELFields(compiler DefinitionCompiler, validationCEL, bucketingCEL, eligibilityCEL string) error {
+	if validationCEL != "" {
+		if err := compiler.ValidateValidationCEL(validationCEL); err != nil {
+			return errors.Join(ErrInvalidCEL, fmt.Errorf("validation_cel: %w", err))
+		}
+	}
+	if bucketingCEL != "" {
+		if err := compiler.ValidateBucketingCEL(bucketingCEL); err != nil {
+			return errors.Join(ErrInvalidCEL, fmt.Errorf("bucketing_cel: %w", err))
+		}
+	}
+	if eligibilityCEL != "" {
+		if err := compiler.ValidateEligibilityCEL(eligibilityCEL); err != nil {
+			return errors.Join(ErrInvalidCEL, fmt.Errorf("eligibility_cel: %w", err))
+		}
+	}
+	return nil
+}
+
 // ValuationMethodTemplate defines a valuation method associated with an account type.
 type ValuationMethodTemplate struct {
 	// ID is the unique identifier for this template.
@@ -120,6 +143,15 @@ type ValuationMethodTemplate struct {
 	UpdatedAt time.Time
 }
 
+// DefinitionCompiler validates CEL expressions for AccountTypeDefinition fields.
+// Pass a real CEL compiler to enforce compile-time CEL validation at draft creation.
+// Pass nil to skip CEL validation (useful for tests or when CEL is not configured).
+type DefinitionCompiler interface {
+	ValidateValidationCEL(expression string) error
+	ValidateBucketingCEL(expression string) error
+	ValidateEligibilityCEL(expression string) error
+}
+
 // NewDefinitionParams holds the input parameters for creating a new account type Definition.
 type NewDefinitionParams struct {
 	Code                           string
@@ -136,6 +168,9 @@ type NewDefinitionParams struct {
 	EligibilityCEL                 string
 	AttributeSchema                json.RawMessage
 	Attributes                     map[string]any
+	// Compiler optionally validates CEL expressions at draft creation time.
+	// When non-nil, invalid CEL expressions prevent the draft from being created.
+	Compiler DefinitionCompiler
 }
 
 // NewDefinition creates a new account type Definition in DRAFT status.
@@ -157,6 +192,13 @@ func NewDefinition(p NewDefinitionParams) (*Definition, error) {
 	// Pair constraint: both must be set or both must be nil.
 	if (p.DefaultConversionMethodID == nil) != (p.DefaultConversionMethodVersion == nil) {
 		return nil, ErrConversionMethodPair
+	}
+
+	// Compile CEL expressions at draft creation time (fail-fast).
+	if p.Compiler != nil {
+		if err := compileCELFields(p.Compiler, p.ValidationCEL, p.BucketingCEL, p.EligibilityCEL); err != nil {
+			return nil, err
+		}
 	}
 
 	now := time.Now().UTC()

--- a/services/reference-data/accounttype/definition_test.go
+++ b/services/reference-data/accounttype/definition_test.go
@@ -2,10 +2,12 @@ package accounttype_test
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+	refcel "github.com/meridianhub/meridian/services/reference-data/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -189,4 +191,69 @@ func TestNormalBalanceIsValid_KnownValues(t *testing.T) {
 func TestNormalBalanceIsValid_UnknownValue(t *testing.T) {
 	assert.False(t, accounttype.NormalBalance("BOTH").IsValid())
 	assert.False(t, accounttype.NormalBalance("").IsValid())
+}
+
+func newCompiler(t *testing.T) accounttype.DefinitionCompiler {
+	t.Helper()
+	c, err := refcel.NewCompiler()
+	require.NoError(t, err)
+	return c
+}
+
+func TestNewDefinition_CEL_ValidExpressions(t *testing.T) {
+	c := newCompiler(t)
+	params := validParams()
+	params.Compiler = c
+	params.ValidationCEL = `parse_decimal(amount) > 0.0`
+	params.BucketingCEL = `bucket_key([attributes["type"]])`
+	params.EligibilityCEL = `party.status == 'ACTIVE'`
+
+	def, err := accounttype.NewDefinition(params)
+	require.NoError(t, err)
+	assert.Equal(t, params.ValidationCEL, def.ValidationCEL)
+	assert.Equal(t, params.BucketingCEL, def.BucketingCEL)
+	assert.Equal(t, params.EligibilityCEL, def.EligibilityCEL)
+}
+
+func TestNewDefinition_CEL_InvalidValidationCEL(t *testing.T) {
+	c := newCompiler(t)
+	params := validParams()
+	params.Compiler = c
+	params.ValidationCEL = `undefined_var > 0`
+
+	_, err := accounttype.NewDefinition(params)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, accounttype.ErrInvalidCEL))
+}
+
+func TestNewDefinition_CEL_InvalidBucketingCEL(t *testing.T) {
+	c := newCompiler(t)
+	params := validParams()
+	params.Compiler = c
+	params.BucketingCEL = `amount` // amount is not in bucket key env
+
+	_, err := accounttype.NewDefinition(params)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, accounttype.ErrInvalidCEL))
+}
+
+func TestNewDefinition_CEL_InvalidEligibilityCEL(t *testing.T) {
+	c := newCompiler(t)
+	params := validParams()
+	params.Compiler = c
+	params.EligibilityCEL = `amount > 0` // amount is not in eligibility env
+
+	_, err := accounttype.NewDefinition(params)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, accounttype.ErrInvalidCEL))
+}
+
+func TestNewDefinition_CEL_NilCompilerSkipsValidation(t *testing.T) {
+	params := validParams()
+	params.Compiler = nil
+	params.EligibilityCEL = `this is not valid CEL !!!`
+
+	// Without a compiler, CEL is not validated
+	_, err := accounttype.NewDefinition(params)
+	require.NoError(t, err)
 }

--- a/services/reference-data/accounttype/errors.go
+++ b/services/reference-data/accounttype/errors.go
@@ -4,6 +4,9 @@ import "errors"
 
 // Domain error sentinels for AccountTypeDefinition operations.
 var (
+	// ErrInvalidCEL is returned when a CEL expression fails to compile.
+	ErrInvalidCEL = errors.New("invalid CEL expression")
+
 	// ErrNotDraft is returned when an operation requires DRAFT status but the definition is not in DRAFT.
 	ErrNotDraft = errors.New("account type definition is not in DRAFT status")
 

--- a/services/reference-data/cel/compiler.go
+++ b/services/reference-data/cel/compiler.go
@@ -184,6 +184,10 @@ func (c *Compiler) CompileEligibility(expression string) (cel.Program, error) {
 		return nil, errors.Join(ErrCompilation, issues.Err())
 	}
 
+	if ast.OutputType() != cel.BoolType {
+		return nil, errors.Join(ErrCompilation, ErrEligibilityNotBool)
+	}
+
 	prg, err := c.eligibilityEnv.Program(ast, cel.CostLimit(CostLimit))
 	if err != nil {
 		return nil, errors.Join(ErrCompilation, err)

--- a/services/reference-data/cel/compiler.go
+++ b/services/reference-data/cel/compiler.go
@@ -197,17 +197,26 @@ func (c *Compiler) CompileEligibility(expression string) (cel.Program, error) {
 }
 
 // EvalEligibility evaluates a compiled eligibility program with the given party context.
+// Only non-empty party fields are included in the evaluation map so that CEL has() checks
+// behave correctly — empty strings indicate absent fields rather than empty values.
 func EvalEligibility(prg cel.Program, partyType, partyStatus, partyExtRefType string, attributes map[string]string) (bool, error) {
 	if attributes == nil {
 		attributes = make(map[string]string)
 	}
 
+	party := make(map[string]string)
+	if partyType != "" {
+		party["type"] = partyType
+	}
+	if partyStatus != "" {
+		party["status"] = partyStatus
+	}
+	if partyExtRefType != "" {
+		party["external_reference_type"] = partyExtRefType
+	}
+
 	out, _, err := prg.Eval(map[string]any{
-		"party": map[string]string{
-			"type":                    partyType,
-			"status":                  partyStatus,
-			"external_reference_type": partyExtRefType,
-		},
+		"party":      party,
 		"attributes": attributes,
 	})
 	if err != nil {

--- a/services/reference-data/cel/compiler.go
+++ b/services/reference-data/cel/compiler.go
@@ -49,12 +49,16 @@ var (
 
 	// ErrCompilation is returned when CEL compilation fails.
 	ErrCompilation = errors.New("CEL compilation failed")
+
+	// ErrEligibilityNotBool is returned when an eligibility expression does not return a boolean.
+	ErrEligibilityNotBool = errors.New("eligibility expression did not return boolean")
 )
 
 // Compiler provides CEL expression compilation with security constraints.
 type Compiler struct {
-	validationEnv *cel.Env
-	bucketKeyEnv  *cel.Env
+	validationEnv  *cel.Env
+	bucketKeyEnv   *cel.Env
+	eligibilityEnv *cel.Env
 }
 
 // NewCompiler creates a new CEL Compiler with configured environments.
@@ -69,9 +73,15 @@ func NewCompiler() (*Compiler, error) {
 		return nil, errors.Join(ErrEnvironmentCreation, fmt.Errorf("bucket key env: %w", err))
 	}
 
+	eligibilityEnv, err := createEligibilityEnv()
+	if err != nil {
+		return nil, errors.Join(ErrEnvironmentCreation, fmt.Errorf("eligibility env: %w", err))
+	}
+
 	return &Compiler{
-		validationEnv: validationEnv,
-		bucketKeyEnv:  bucketKeyEnv,
+		validationEnv:  validationEnv,
+		bucketKeyEnv:   bucketKeyEnv,
+		eligibilityEnv: eligibilityEnv,
 	}, nil
 }
 
@@ -103,6 +113,19 @@ func createBucketKeyEnv() (*cel.Env, error) {
 		cel.Variable("attributes", cel.MapType(cel.StringType, cel.StringType)),
 		SafeParseLib(),
 		BucketKeyLib(),
+	)
+}
+
+// createEligibilityEnv creates the CEL environment for eligibility expressions.
+// Variables available:
+//   - party: map[string]string - party context with keys: type, status, external_reference_type
+//   - attributes: map[string]string - key-value attributes for the account type
+//
+// The expression must return a boolean indicating eligibility.
+func createEligibilityEnv() (*cel.Env, error) {
+	return cel.NewEnv(
+		cel.Variable("party", cel.MapType(cel.StringType, cel.StringType)),
+		cel.Variable("attributes", cel.MapType(cel.StringType, cel.StringType)),
 	)
 }
 
@@ -146,6 +169,74 @@ func (c *Compiler) CompileBucketKey(expression string) (cel.Program, error) {
 	}
 
 	return prg, nil
+}
+
+// CompileEligibility compiles an eligibility expression against the eligibility environment.
+// Returns a cel.Program that can be evaluated with party and attributes input values.
+// The expression must return a boolean indicating whether a party is eligible.
+func (c *Compiler) CompileEligibility(expression string) (cel.Program, error) {
+	if err := validateExpressionConstraints(expression); err != nil {
+		return nil, err
+	}
+
+	ast, issues := c.eligibilityEnv.Compile(expression)
+	if issues != nil && issues.Err() != nil {
+		return nil, errors.Join(ErrCompilation, issues.Err())
+	}
+
+	prg, err := c.eligibilityEnv.Program(ast, cel.CostLimit(CostLimit))
+	if err != nil {
+		return nil, errors.Join(ErrCompilation, err)
+	}
+
+	return prg, nil
+}
+
+// EvalEligibility evaluates a compiled eligibility program with the given party context.
+func EvalEligibility(prg cel.Program, partyType, partyStatus, partyExtRefType string, attributes map[string]string) (bool, error) {
+	if attributes == nil {
+		attributes = make(map[string]string)
+	}
+
+	out, _, err := prg.Eval(map[string]any{
+		"party": map[string]string{
+			"type":                    partyType,
+			"status":                  partyStatus,
+			"external_reference_type": partyExtRefType,
+		},
+		"attributes": attributes,
+	})
+	if err != nil {
+		return false, fmt.Errorf("eligibility evaluation error: %w", err)
+	}
+
+	result, ok := out.Value().(bool)
+	if !ok {
+		return false, ErrEligibilityNotBool
+	}
+
+	return result, nil
+}
+
+// ValidateValidationCEL compiles a validation CEL expression and discards the program.
+// Implements the accounttype.DefinitionCompiler interface.
+func (c *Compiler) ValidateValidationCEL(expression string) error {
+	_, err := c.CompileValidation(expression)
+	return err
+}
+
+// ValidateBucketingCEL compiles a bucketing CEL expression and discards the program.
+// Implements the accounttype.DefinitionCompiler interface.
+func (c *Compiler) ValidateBucketingCEL(expression string) error {
+	_, err := c.CompileBucketKey(expression)
+	return err
+}
+
+// ValidateEligibilityCEL compiles an eligibility CEL expression and discards the program.
+// Implements the accounttype.DefinitionCompiler interface.
+func (c *Compiler) ValidateEligibilityCEL(expression string) error {
+	_, err := c.CompileEligibility(expression)
+	return err
 }
 
 // validateExpressionConstraints checks that an expression meets security constraints.

--- a/services/reference-data/cel/compiler_test.go
+++ b/services/reference-data/cel/compiler_test.go
@@ -480,6 +480,141 @@ func TestSafeParseLib_InvalidInputs(t *testing.T) {
 	}
 }
 
+func TestCompileEligibility(t *testing.T) {
+	c, err := NewCompiler()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		expression string
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name:       "simple party status check",
+			expression: `party.status == 'ACTIVE'`,
+			wantErr:    false,
+		},
+		{
+			name:       "compound party expression",
+			expression: `party.type == 'ORGANIZATION' && party.status == 'ACTIVE'`,
+			wantErr:    false,
+		},
+		{
+			name:       "party with external reference type",
+			expression: `party.external_reference_type == 'SWIFT_BIC'`,
+			wantErr:    false,
+		},
+		{
+			name:       "attribute access",
+			expression: `attributes["tier"] == "premium"`,
+			wantErr:    false,
+		},
+		{
+			name:       "amount is not declared in eligibility env",
+			expression: `amount > 0`,
+			wantErr:    true,
+			errContain: "undeclared reference",
+		},
+		{
+			name:       "syntax error",
+			expression: `party.status ==`,
+			wantErr:    true,
+			errContain: "CEL compilation failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prg, err := c.CompileEligibility(tt.expression)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContain != "" {
+					assert.Contains(t, err.Error(), tt.errContain)
+				}
+				assert.Nil(t, prg)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, prg)
+			}
+		})
+	}
+}
+
+func TestEvalEligibility(t *testing.T) {
+	c, err := NewCompiler()
+	require.NoError(t, err)
+
+	prg, err := c.CompileEligibility(`party.type == 'ORGANIZATION' && party.status == 'ACTIVE'`)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		partyType       string
+		partyStatus     string
+		partyExtRefType string
+		attributes      map[string]string
+		want            bool
+	}{
+		{
+			name:        "active organization is eligible",
+			partyType:   "ORGANIZATION",
+			partyStatus: "ACTIVE",
+			attributes:  map[string]string{},
+			want:        true,
+		},
+		{
+			name:        "suspended party is not eligible",
+			partyType:   "ORGANIZATION",
+			partyStatus: "SUSPENDED",
+			attributes:  map[string]string{},
+			want:        false,
+		},
+		{
+			name:        "individual is not eligible",
+			partyType:   "INDIVIDUAL",
+			partyStatus: "ACTIVE",
+			attributes:  map[string]string{},
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := EvalEligibility(prg, tt.partyType, tt.partyStatus, tt.partyExtRefType, tt.attributes)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestCompileEligibility_CrossEnvRejection(t *testing.T) {
+	c, err := NewCompiler()
+	require.NoError(t, err)
+
+	// ValidationCEL env should reject party.type references
+	_, err = c.CompileValidation(`party.type == 'ORGANIZATION'`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "undeclared reference")
+
+	// EligibilityCEL env should reject amount references
+	_, err = c.CompileEligibility(`amount > 0`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "undeclared reference")
+}
+
+func TestCompileEligibility_TooLong(t *testing.T) {
+	c, err := NewCompiler()
+	require.NoError(t, err)
+
+	longExpr := strings.Repeat("true || ", MaxExpressionLength/8+1) + "true"
+	require.Greater(t, len(longExpr), MaxExpressionLength)
+
+	_, err = c.CompileEligibility(longExpr)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExpressionTooLong)
+}
+
 func BenchmarkCompileValidation(b *testing.B) {
 	c, err := NewCompiler()
 	require.NoError(b, err)


### PR DESCRIPTION
## Summary
- Add `CompileEligibility()` with party context variables (type, status, external_reference_type)
- Add `EvalEligibility()` helper for runtime evaluation
- Wire CEL compilation into `AccountTypeDefinition` draft creation via `DefinitionCompiler` interface
- Add `ErrInvalidCEL` sentinel to accounttype domain errors

## Changes

### `services/reference-data/cel/compiler.go`
- Add `eligibilityEnv` field to `Compiler` with `party` and `attributes` map variables
- Add `CompileEligibility()` — same security constraints (length limit, cost limit) as validation/bucketing envs
- Add `EvalEligibility()` — evaluates compiled program with typed party fields
- Add `ValidateValidationCEL/ValidateBucketingCEL/ValidateEligibilityCEL` methods implementing `DefinitionCompiler` interface
- Add `ErrEligibilityNotBool` sentinel for type mismatch at eval time

### `services/reference-data/accounttype/definition.go`
- Add `DefinitionCompiler` interface (validate-only, no `cel.Program` dependency in domain)
- Add `Compiler` field to `NewDefinitionParams` (nil skips CEL validation for backwards compat)
- Call `compileCELFields()` in `NewDefinition` when compiler is provided — fail-fast on invalid CEL

### `services/reference-data/accounttype/errors.go`
- Add `ErrInvalidCEL` sentinel

## Task Master
Tag: product-directory, Task: 3

## Test plan
- [x] Eligibility expressions compile with party/attributes variables
- [x] Cross-environment variable rejection: validation env rejects party.type, eligibility env rejects amount
- [x] Expression length limits enforced on eligibility env
- [x] Draft creation fails on invalid ValidationCEL, BucketingCEL, EligibilityCEL
- [x] Nil compiler skips CEL validation (backwards compatibility)
- [x] EvalEligibility returns false for suspended/wrong-type party