### PR TITLE
feat: add platform blueprint seeder for AccountTypeRegistry

### DIFF
--- a/services/reference-data/accounttype/errors.go
+++ b/services/reference-data/accounttype/errors.go
@@ -58,4 +58,8 @@ var (
 
 	// ErrAttributesInvalid is returned when attributes do not validate against the attribute_schema.
 	ErrAttributesInvalid = errors.New("attributes do not validate against attribute_schema")
+
+	// ErrSystemAccountTypeReadOnly is returned when attempting to modify or deprecate a system account type.
+	// System account types (IsSystem=true) are seeded by the platform and are read-only.
+	ErrSystemAccountTypeReadOnly = errors.New("system account type is read-only")
 )

--- a/services/reference-data/accounttype/postgres_registry.go
+++ b/services/reference-data/accounttype/postgres_registry.go
@@ -387,6 +387,9 @@ func (r *PostgresRegistry) fetchForUpdate(ctx context.Context, tx pgx.Tx, code s
 		}
 		return nil, fmt.Errorf("failed to check account type: %w", err)
 	}
+	if cur.isSystem {
+		return nil, ErrSystemAccountTypeReadOnly
+	}
 	if cur.status != string(StatusDraft) {
 		return nil, ErrNotDraft
 	}
@@ -609,17 +612,22 @@ func (r *PostgresRegistry) DeprecateAccountType(ctx context.Context, code string
 	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
 		var defID uuid.UUID
 		var currentStatus string
+		var isSystem bool
 		var existingSuccessorID *uuid.UUID
 
-		checkQuery := `SELECT id, status, successor_id
+		checkQuery := `SELECT id, status, is_system, successor_id
 			FROM account_type_definitions WHERE code = $1 AND version = $2`
 		err := tx.QueryRow(ctx, checkQuery, code, version).Scan(
-			&defID, &currentStatus, &existingSuccessorID)
+			&defID, &currentStatus, &isSystem, &existingSuccessorID)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return ErrNotFound
 			}
 			return fmt.Errorf("failed to check account type: %w", err)
+		}
+
+		if isSystem {
+			return ErrSystemAccountTypeReadOnly
 		}
 
 		if currentStatus != string(StatusActive) {

--- a/services/reference-data/accounttype/seeder.go
+++ b/services/reference-data/accounttype/seeder.go
@@ -1,0 +1,124 @@
+package accounttype
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// namespaceAccountType is the fixed UUID namespace for deterministic blueprint IDs.
+// Using a stable SHA1 namespace ensures the same Code always produces the same UUID
+// regardless of when or where the seeder runs.
+var namespaceAccountType = uuid.MustParse("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
+
+// platformBlueprintSpec defines a platform-level account type blueprint.
+type platformBlueprintSpec struct {
+	Code           string
+	DisplayName    string
+	BehaviorClass  BehaviorClass
+	NormalBalance  NormalBalance
+	InstrumentCode string
+}
+
+// platformBlueprints defines the 12 canonical account type blueprints covering
+// the full BehaviorClass range. These are seeded into every new tenant as system
+// definitions with IsSystem=true.
+//
+// DefaultSagaPrefix is intentionally omitted so activation does not require
+// saga definitions to exist at seeding time. Tenants configure saga routing
+// post-seeding via their own saga definitions.
+var platformBlueprints = []platformBlueprintSpec{
+	{Code: "CURRENT_ACCOUNT_GBP", DisplayName: "GBP Current Account", BehaviorClass: BehaviorClassCustomer, NormalBalance: NormalBalanceCredit, InstrumentCode: "GBP"},
+	{Code: "CURRENT_ACCOUNT_USD", DisplayName: "USD Current Account", BehaviorClass: BehaviorClassCustomer, NormalBalance: NormalBalanceCredit, InstrumentCode: "USD"},
+	{Code: "CURRENT_ACCOUNT_EUR", DisplayName: "EUR Current Account", BehaviorClass: BehaviorClassCustomer, NormalBalance: NormalBalanceCredit, InstrumentCode: "EUR"},
+	{Code: "CLEARING_GBP", DisplayName: "GBP Clearing Account", BehaviorClass: BehaviorClassClearing, NormalBalance: NormalBalanceDebit, InstrumentCode: "GBP"},
+	{Code: "NOSTRO_GBP", DisplayName: "GBP Nostro Account", BehaviorClass: BehaviorClassNostro, NormalBalance: NormalBalanceDebit, InstrumentCode: "GBP"},
+	{Code: "VOSTRO_GBP", DisplayName: "GBP Vostro Account", BehaviorClass: BehaviorClassVostro, NormalBalance: NormalBalanceCredit, InstrumentCode: "GBP"},
+	{Code: "HOLDING_ESCROW", DisplayName: "Escrow Holding Account", BehaviorClass: BehaviorClassHolding, NormalBalance: NormalBalanceCredit, InstrumentCode: "GBP"},
+	{Code: "SUSPENSE_UNALLOCATED", DisplayName: "Unallocated Suspense", BehaviorClass: BehaviorClassSuspense, NormalBalance: NormalBalanceDebit, InstrumentCode: "GBP"},
+	{Code: "REVENUE_FEES", DisplayName: "Fee Revenue Account", BehaviorClass: BehaviorClassRevenue, NormalBalance: NormalBalanceCredit, InstrumentCode: "GBP"},
+	{Code: "EXPENSE_OPERATIONS", DisplayName: "Operations Expense", BehaviorClass: BehaviorClassExpense, NormalBalance: NormalBalanceDebit, InstrumentCode: "GBP"},
+	{Code: "CARBON_CREDIT_HOLDING", DisplayName: "Carbon Credit Holding", BehaviorClass: BehaviorClassInventory, NormalBalance: NormalBalanceDebit, InstrumentCode: "TONNE_CO2E"},
+	{Code: "INVENTORY_KWH", DisplayName: "kWh Inventory Account", BehaviorClass: BehaviorClassInventory, NormalBalance: NormalBalanceDebit, InstrumentCode: "KWH"},
+}
+
+// BlueprintSeeder seeds platform account type blueprints into tenant schemas.
+type BlueprintSeeder struct {
+	registry Registry
+	logger   *slog.Logger
+}
+
+// NewBlueprintSeeder creates a new BlueprintSeeder backed by the given Registry.
+func NewBlueprintSeeder(registry Registry) *BlueprintSeeder {
+	return &BlueprintSeeder{
+		registry: registry,
+		logger:   slog.Default().With("component", "account_type_blueprint_seeder"),
+	}
+}
+
+// SeedTenant seeds all platform blueprints into the tenant identified by tenantID.
+// It delegates to SeedPlatformBlueprints with a tenant-scoped context.
+func (s *BlueprintSeeder) SeedTenant(ctx context.Context, tenantID tenant.TenantID) error {
+	tctx := tenant.WithTenant(ctx, tenantID)
+	s.logger.Info("seeding platform account type blueprints", "tenant_id", tenantID.String())
+	if err := SeedPlatformBlueprints(tctx, s.registry); err != nil {
+		s.logger.Error("failed to seed platform blueprints", "tenant_id", tenantID.String(), "error", err)
+		return err
+	}
+	s.logger.Info("platform account type blueprints seeded", "tenant_id", tenantID.String(), "count", len(platformBlueprints))
+	return nil
+}
+
+// AsPostProvisioningHook returns a function compatible with the provisioning worker's
+// PostProvisioningHook signature for seeding blueprints into newly provisioned tenants.
+//
+// Usage:
+//
+//	seeder := accounttype.NewBlueprintSeeder(registry)
+//	worker.RegisterPostProvisioningHook("account-type-blueprints", seeder.AsPostProvisioningHook())
+func (s *BlueprintSeeder) AsPostProvisioningHook() func(ctx context.Context, tenantID tenant.TenantID) error {
+	return s.SeedTenant
+}
+
+// SeedPlatformBlueprints seeds the 12 canonical platform account type blueprints
+// into the registry using ctx (which must carry tenant context).
+//
+// Each blueprint is created as DRAFT then immediately activated. The operation is
+// idempotent: CreateDraft uses ON CONFLICT DO NOTHING and ActivateAccountType
+// returns nil if already ACTIVE. Running SeedPlatformBlueprints multiple times
+// produces identical state.
+//
+// Blueprint IDs are deterministic: uuid.NewSHA1(namespaceAccountType, []byte(Code)).
+// This ensures the same blueprint always gets the same UUID across tenants and re-runs.
+//
+// All blueprints have IsSystem=true. System blueprints reject UpdateDefinition and
+// DeprecateAccountType calls with ErrSystemAccountTypeReadOnly.
+func SeedPlatformBlueprints(ctx context.Context, registry Registry) error {
+	for _, bp := range platformBlueprints {
+		def := &Definition{
+			ID:             uuid.NewSHA1(namespaceAccountType, []byte(bp.Code)),
+			Code:           bp.Code,
+			Version:        1,
+			DisplayName:    bp.DisplayName,
+			BehaviorClass:  bp.BehaviorClass,
+			NormalBalance:  bp.NormalBalance,
+			InstrumentCode: bp.InstrumentCode,
+			IsSystem:       true,
+			Status:         StatusDraft,
+			Attributes:     map[string]any{},
+		}
+
+		if err := registry.CreateDraft(ctx, def); err != nil {
+			return fmt.Errorf("seed %s: %w", bp.Code, err)
+		}
+
+		if err := registry.ActivateAccountType(ctx, bp.Code, 1); err != nil {
+			return fmt.Errorf("activate %s: %w", bp.Code, err)
+		}
+	}
+
+	return nil
+}

--- a/services/reference-data/accounttype/seeder_test.go
+++ b/services/reference-data/accounttype/seeder_test.go
@@ -1,0 +1,141 @@
+package accounttype_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeedPlatformBlueprints_Success(t *testing.T) {
+	reg, pool := setupTestAccountTypeRegistry(t)
+	ctx := setupAccountTypeTenantContext(t, pool, "tenant-blueprint-seed-1")
+
+	instruments := []string{"GBP", "USD", "EUR", "TONNE_CO2E", "KWH"}
+	for _, code := range instruments {
+		seedInstrument(t, pool, ctx, code)
+	}
+
+	err := accounttype.SeedPlatformBlueprints(ctx, reg)
+	require.NoError(t, err)
+
+	// Verify all 12 blueprints are ACTIVE
+	active, err := reg.ListActive(ctx)
+	require.NoError(t, err)
+	assert.Len(t, active, 12, "expected 12 ACTIVE platform blueprints")
+
+	// Verify all are system definitions
+	for _, def := range active {
+		assert.True(t, def.IsSystem, "blueprint %s should be a system definition", def.Code)
+		assert.Equal(t, accounttype.StatusActive, def.Status)
+	}
+}
+
+func TestSeedPlatformBlueprints_Idempotent(t *testing.T) {
+	reg, pool := setupTestAccountTypeRegistry(t)
+	ctx := setupAccountTypeTenantContext(t, pool, "tenant-blueprint-idempotent")
+
+	instruments := []string{"GBP", "USD", "EUR", "TONNE_CO2E", "KWH"}
+	for _, code := range instruments {
+		seedInstrument(t, pool, ctx, code)
+	}
+
+	// First seed
+	err := accounttype.SeedPlatformBlueprints(ctx, reg)
+	require.NoError(t, err)
+
+	// Second seed should be idempotent
+	err = accounttype.SeedPlatformBlueprints(ctx, reg)
+	require.NoError(t, err)
+
+	// Count should still be 12
+	active, err := reg.ListActive(ctx)
+	require.NoError(t, err)
+	assert.Len(t, active, 12, "idempotent seed should not create duplicates")
+}
+
+func TestSeedPlatformBlueprints_DeterministicUUIDs(t *testing.T) {
+	reg, pool := setupTestAccountTypeRegistry(t)
+	ctx := setupAccountTypeTenantContext(t, pool, "tenant-blueprint-uuids")
+
+	instruments := []string{"GBP", "USD", "EUR", "TONNE_CO2E", "KWH"}
+	for _, code := range instruments {
+		seedInstrument(t, pool, ctx, code)
+	}
+
+	err := accounttype.SeedPlatformBlueprints(ctx, reg)
+	require.NoError(t, err)
+
+	// Deterministic UUID namespace (must match seeder.go)
+	ns := uuid.MustParse("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
+
+	// Verify specific blueprints have deterministic UUIDs
+	codes := []string{
+		"CURRENT_ACCOUNT_GBP", "CURRENT_ACCOUNT_USD", "CURRENT_ACCOUNT_EUR",
+		"CLEARING_GBP", "INVENTORY_KWH", "CARBON_CREDIT_HOLDING",
+	}
+	for _, code := range codes {
+		expected := uuid.NewSHA1(ns, []byte(code))
+		def, err := reg.GetDefinition(ctx, code, 1)
+		require.NoError(t, err, "blueprint %s should exist", code)
+		assert.Equal(t, expected, def.ID, "blueprint %s should have deterministic UUID", code)
+	}
+}
+
+func TestSeedPlatformBlueprints_InventoryKWH_Attributes(t *testing.T) {
+	reg, pool := setupTestAccountTypeRegistry(t)
+	ctx := setupAccountTypeTenantContext(t, pool, "tenant-blueprint-kwh")
+
+	instruments := []string{"GBP", "USD", "EUR", "TONNE_CO2E", "KWH"}
+	for _, code := range instruments {
+		seedInstrument(t, pool, ctx, code)
+	}
+
+	err := accounttype.SeedPlatformBlueprints(ctx, reg)
+	require.NoError(t, err)
+
+	def, err := reg.GetDefinition(ctx, "INVENTORY_KWH", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, accounttype.BehaviorClassInventory, def.BehaviorClass)
+	assert.Equal(t, accounttype.NormalBalanceDebit, def.NormalBalance)
+	assert.Equal(t, "KWH", def.InstrumentCode)
+	assert.True(t, def.IsSystem)
+}
+
+func TestSeedPlatformBlueprints_SystemProtection_UpdateRejected(t *testing.T) {
+	reg, pool := setupTestAccountTypeRegistry(t)
+	ctx := setupAccountTypeTenantContext(t, pool, "tenant-blueprint-update-guard")
+
+	instruments := []string{"GBP", "USD", "EUR", "TONNE_CO2E", "KWH"}
+	for _, code := range instruments {
+		seedInstrument(t, pool, ctx, code)
+	}
+
+	err := accounttype.SeedPlatformBlueprints(ctx, reg)
+	require.NoError(t, err)
+
+	// Attempt to update a system blueprint's display name - should fail
+	updates := &accounttype.Definition{DisplayName: "Hijacked Name"}
+	err = reg.UpdateDefinition(ctx, "CURRENT_ACCOUNT_GBP", 1, updates)
+	require.ErrorIs(t, err, accounttype.ErrSystemAccountTypeReadOnly)
+}
+
+func TestSeedPlatformBlueprints_SystemProtection_DeprecateRejected(t *testing.T) {
+	reg, pool := setupTestAccountTypeRegistry(t)
+	ctx := setupAccountTypeTenantContext(t, pool, "tenant-blueprint-deprecate-guard")
+
+	instruments := []string{"GBP", "USD", "EUR", "TONNE_CO2E", "KWH"}
+	for _, code := range instruments {
+		seedInstrument(t, pool, ctx, code)
+	}
+
+	err := accounttype.SeedPlatformBlueprints(ctx, reg)
+	require.NoError(t, err)
+
+	// Attempt to deprecate a system blueprint - should fail
+	err = reg.DeprecateAccountType(ctx, "CLEARING_GBP", 1, nil)
+	require.ErrorIs(t, err, accounttype.ErrSystemAccountTypeReadOnly)
+}


### PR DESCRIPTION
## Summary

- Implements 12 canonical platform account type blueprints covering the full BehaviorClass range (CUSTOMER, CLEARING, NOSTRO, VOSTRO, HOLDING, SUSPENSE, REVENUE, EXPENSE, INVENTORY)
- Adds `BlueprintSeeder` with `SeedPlatformBlueprints` function and `AsPostProvisioningHook()` for integration with tenant provisioning worker
- Deterministic UUIDs via SHA1 namespace ensure idempotent seeding across tenant provisioning runs
- System blueprint protection: `ErrSystemAccountTypeReadOnly` returned for `UpdateDefinition` and `DeprecateAccountType` on system blueprints

## Task Master

Tag: product-directory, Task: 5

## Test plan

- [ ] Seeder runs cleanly on fresh tenant (12 blueprints created and activated)
- [ ] Idempotent on re-run (ON CONFLICT DO NOTHING + ActivateAccountType returns nil if ACTIVE)
- [ ] System blueprints reject UpdateDefinition with ErrSystemAccountTypeReadOnly
- [ ] System blueprints reject DeprecateAccountType with ErrSystemAccountTypeReadOnly
- [ ] INVENTORY_KWH has BehaviorClass=INVENTORY and NormalBalance=DEBIT
- [ ] Deterministic UUIDs via SHA1 namespace verified