### PR TITLE
feat: Replace proxy handler with Vanguard transcoder

### DIFF
--- a/cmd/meridian/descriptors_test.go
+++ b/cmd/meridian/descriptors_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/meridianhub/meridian/services/gateway"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -56,4 +57,23 @@ func TestProtoDescriptors_ContainsAllServices(t *testing.T) {
 	for _, svc := range required {
 		assert.True(t, found[svc], "descriptor set must contain service %q", svc)
 	}
+}
+
+// TestWireGateway_TranscoderBuildsCleanly verifies that wireGateway successfully
+// constructs the Vanguard transcoder from the embedded descriptor set and the
+// registered serviceNames list. A build failure here indicates a mismatch between
+// serviceNames in main.go and the services present in the descriptor.
+func TestWireGateway_TranscoderBuildsCleanly(t *testing.T) {
+	// Construct per-service backends as wireGateway does, using a dummy address.
+	backends := make([]gateway.ServiceBackend, 0, len(serviceNames))
+	for _, name := range serviceNames {
+		backends = append(backends, gateway.ServiceBackend{
+			ServiceName: name,
+			BackendAddr: "localhost:50051",
+		})
+	}
+
+	handler, err := gateway.NewTranscoder(GetProtoDescriptors(), backends)
+	require.NoError(t, err, "transcoder must build cleanly from embedded descriptor and serviceNames")
+	assert.NotNil(t, handler)
 }

--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -586,8 +586,38 @@ func wireReconciliation(
 
 // ─── Gateway Wiring ──────────────────────────────────────────────────────────
 
-// wireGateway creates the gateway HTTP server that proxies Connect/gRPC-Web
-// requests to the shared gRPC server running on grpcPort.
+// serviceNames lists the fully-qualified gRPC service names to register with the
+// Vanguard REST↔gRPC transcoder in the unified development binary.
+//
+// All services run in the same process and share a single loopback gRPC address.
+// Per-service entries allow the transcoder to be selective: services that share
+// conflicting HTTP path patterns in their proto annotations cannot be registered
+// together in the same Vanguard instance.
+//
+// HTTP-route conflict: InternalBankAccountService and CurrentAccountService both
+// define REST routes for lien operations (/v1/liens/*). InternalBankAccountService
+// is registered here as the canonical REST owner; CurrentAccountService is still
+// reachable via native gRPC or Connect protocol.
+var serviceNames = []string{
+	"meridian.party.v1.PartyService",
+	"meridian.reference_data.v1.ReferenceDataService",
+	"meridian.reference_data.v1.NodeService",
+	"meridian.market_information.v1.MarketInformationService",
+	"meridian.tenant.v1.TenantService",
+	"meridian.internal_bank_account.v1.InternalBankAccountService",
+	"meridian.financial_accounting.v1.FinancialAccountingService",
+	"meridian.position_keeping.v1.PositionKeepingService",
+	"meridian.forecasting.v1.ForecastingService",
+	// CurrentAccountService excluded: conflicts with InternalBankAccountService
+	// on /v1/liens/* REST routes. Reachable via gRPC/Connect only.
+	"meridian.payment_order.v1.PaymentOrderService",
+	"meridian.reconciliation.v1.AccountReconciliationService",
+	"meridian.saga.v1.SagaRegistryService",
+}
+
+// wireGateway creates the gateway HTTP server with the Vanguard transcoder
+// routing REST/JSON, Connect, and gRPC-Web requests to the shared gRPC server
+// running on grpcPort.
 func wireGateway(grpcPort, httpPort int, databaseURL string, logger *slog.Logger) *gateway.Server {
 	grpcTarget := fmt.Sprintf("localhost:%d", grpcPort)
 
@@ -596,23 +626,30 @@ func wireGateway(grpcPort, httpPort int, databaseURL string, logger *slog.Logger
 		BaseDomain:   "localhost",
 		LocalDevMode: true,
 		DatabaseURL:  databaseURL,
-		Backends: []gateway.BackendRoute{
-			{Prefix: "/v1/party", Target: grpcTarget},
-			{Prefix: "/v1/reference-data", Target: grpcTarget},
-			{Prefix: "/v1/market-information", Target: grpcTarget},
-			{Prefix: "/v1/tenant", Target: grpcTarget},
-			{Prefix: "/v1/internal-bank-account", Target: grpcTarget},
-			{Prefix: "/v1/financial-accounting", Target: grpcTarget},
-			{Prefix: "/v1/position-keeping", Target: grpcTarget},
-			{Prefix: "/v1/forecasting", Target: grpcTarget},
-			{Prefix: "/v1/current-account", Target: grpcTarget},
-			{Prefix: "/v1/payment-order", Target: grpcTarget},
-			{Prefix: "/v1/reconciliation", Target: grpcTarget},
-			{Prefix: "/v1/saga", Target: grpcTarget},
-		},
 	}
 
-	return gateway.NewServer(config, logger, nil)
+	// Build per-service backends pointing at the shared loopback gRPC server.
+	backends := make([]gateway.ServiceBackend, 0, len(serviceNames))
+	for _, name := range serviceNames {
+		backends = append(backends, gateway.ServiceBackend{
+			ServiceName: name,
+			BackendAddr: grpcTarget,
+		})
+	}
+
+	// Build the Vanguard transcoder from the embedded FileDescriptorSet.
+	// On failure, log a warning and fall back to the placeholder handler —
+	// this keeps the health endpoints alive even if descriptors are stale.
+	var opts []gateway.ServerOption
+	transcoder, err := gateway.NewTranscoder(GetProtoDescriptors(), backends)
+	if err != nil {
+		logger.Warn("failed to build Vanguard transcoder; API routes will return 501",
+			"error", err)
+	} else {
+		opts = append(opts, gateway.WithTranscoder(transcoder))
+	}
+
+	return gateway.NewServer(config, logger, nil, opts...)
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/services/gateway/proxy.go
+++ b/services/gateway/proxy.go
@@ -137,6 +137,30 @@ func (h *ProxyHandler) RouteCount() int {
 	return len(h.routes)
 }
 
+// identityHeaderMiddleware is an HTTP middleware that strips client-supplied
+// identity headers and injects authenticated identity headers from the request
+// context set by the auth middleware.
+//
+// This provides the same security guarantee as the NewProxyHandler Director
+// for the Vanguard transcoder path: regardless of what a client sends, the
+// identity headers seen by backend services always reflect the gateway's
+// authentication result.
+func identityHeaderMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// SECURITY: Strip any incoming identity headers to prevent spoofing.
+		r.Header.Del(HeaderUserID)
+		r.Header.Del(HeaderTenantID)
+		r.Header.Del(HeaderAuthMethod)
+		r.Header.Del(HeaderAuthRoles)
+		r.Header.Del(auth.APIKeyHeader)
+
+		// Inject identity headers from the authenticated context.
+		addIdentityHeaders(r)
+
+		next.ServeHTTP(w, r)
+	})
+}
+
 // addIdentityHeaders extracts authenticated identity from request context
 // and adds the corresponding headers to the outgoing request.
 //

--- a/services/gateway/server.go
+++ b/services/gateway/server.go
@@ -28,6 +28,7 @@ type Server struct {
 	authMiddleware        *auth.CombinedAuthMiddleware
 	tenantAuthzMiddleware *auth.TenantAuthorizationMiddleware
 	healthChecker         *gwhealth.GatewayHealthChecker
+	transcoderHandler     http.Handler
 }
 
 // ServerOption is a functional option for configuring the server.
@@ -44,6 +45,15 @@ func WithAuthMiddleware(authMiddleware *auth.CombinedAuthMiddleware) ServerOptio
 func WithHealthChecker(healthChecker *gwhealth.GatewayHealthChecker) ServerOption {
 	return func(s *Server) {
 		s.healthChecker = healthChecker
+	}
+}
+
+// WithTranscoder sets the Vanguard transcoder as the API handler, replacing
+// the legacy prefix-based reverse proxy. When set, all /api/ requests are
+// dispatched through the transcoder rather than NewProxyHandler.
+func WithTranscoder(handler http.Handler) ServerOption {
+	return func(s *Server) {
+		s.transcoderHandler = handler
 	}
 }
 
@@ -86,7 +96,7 @@ func NewServer(config *Config, logger *slog.Logger, tenantResolver *platformgate
 // 1. Auth middleware (validates JWT or API key, injects identity into context)
 // 2. Tenant middleware (resolves tenant from subdomain, injects tenant into context)
 // 3. Tenant authorization middleware (verifies JWT tenant matches resolved tenant)
-// 4. Proxy handler (routes to backend services)
+// 4. Transcoder (Vanguard REST↔gRPC transcoder) or legacy proxy handler
 //
 // This order ensures:
 // - 401 Unauthorized is returned for missing/invalid credentials BEFORE tenant resolution
@@ -101,16 +111,21 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /healthz", s.handleHealth)
 	s.mux.HandleFunc("GET /readyz", s.handleReady)
 
-	// API routes - with auth and tenant middleware chain
-	// Create proxy handler if backends are configured, otherwise use placeholder
+	// API routes - with auth and tenant middleware chain.
+	// Prefer the Vanguard transcoder when configured; fall back to the legacy
+	// prefix-based reverse proxy when Backends are provided; otherwise use a
+	// placeholder that returns 501 Not Implemented.
 	var apiHandler http.Handler
-	if len(s.config.Backends) > 0 {
+	switch {
+	case s.transcoderHandler != nil:
+		apiHandler = s.transcoderHandler
+	case len(s.config.Backends) > 0:
 		apiHandler = NewProxyHandler(s.config.Backends)
-	} else {
+	default:
 		apiHandler = http.HandlerFunc(s.handleAPI)
 	}
 
-	// Build middleware chain: auth → tenant → tenant_authz → proxy
+	// Build middleware chain: auth → tenant → tenant_authz → transcoder/proxy
 	handler := http.StripPrefix("/api", apiHandler)
 
 	// Layer 3 (innermost): Tenant authorization (verify JWT tenant matches subdomain)

--- a/services/gateway/server.go
+++ b/services/gateway/server.go
@@ -115,10 +115,17 @@ func (s *Server) registerRoutes() {
 	// Prefer the Vanguard transcoder when configured; fall back to the legacy
 	// prefix-based reverse proxy when Backends are provided; otherwise use a
 	// placeholder that returns 501 Not Implemented.
+	//
+	// For the transcoder path, identityHeaderMiddleware wraps the handler to
+	// strip spoofed incoming identity headers and inject authenticated identity
+	// headers from the request context (the same security pattern used by
+	// NewProxyHandler via its custom Director). This ensures backends always
+	// receive X-User-ID, X-Tenant-ID, X-Auth-Method, and X-Auth-Roles from
+	// the gateway's authentication result, never from the client.
 	var apiHandler http.Handler
 	switch {
 	case s.transcoderHandler != nil:
-		apiHandler = s.transcoderHandler
+		apiHandler = identityHeaderMiddleware(s.transcoderHandler)
 	case len(s.config.Backends) > 0:
 		apiHandler = NewProxyHandler(s.config.Backends)
 	default:

--- a/services/gateway/server_test.go
+++ b/services/gateway/server_test.go
@@ -211,6 +211,84 @@ func TestAPIRoutes_WithoutTenantResolver(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "gateway routing not yet implemented")
 }
 
+// TestWithTranscoder_UsedOverProxy verifies that when WithTranscoder is set,
+// API requests are dispatched through the transcoder rather than the legacy proxy.
+func TestWithTranscoder_UsedOverProxy(t *testing.T) {
+	transcoderCalled := false
+	fakeTranscoder := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		transcoderCalled = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("transcoder"))
+	})
+
+	config := &Config{
+		Port:        8080,
+		BaseDomain:  "api.example.com",
+		DatabaseURL: "postgres://localhost/test",
+		// Also set Backends to confirm transcoder takes precedence.
+		Backends: []BackendRoute{
+			{Prefix: "/v1/party", Target: "party:50051"},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := NewServer(config, logger, nil, WithTranscoder(fakeTranscoder))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/meridian.party.v1.PartyService/CreateParty", nil)
+	rec := httptest.NewRecorder()
+
+	server.mux.ServeHTTP(rec, req)
+
+	assert.True(t, transcoderCalled, "transcoder should be called when configured")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "transcoder", rec.Body.String())
+}
+
+// TestWithTranscoder_FallsBackToProxy verifies that when no transcoder is set,
+// API requests fall through to the legacy proxy.
+func TestWithTranscoder_FallsBackToProxy(t *testing.T) {
+	config := &Config{
+		Port:        8080,
+		BaseDomain:  "api.example.com",
+		DatabaseURL: "postgres://localhost/test",
+		// No Backends configured → placeholder handler
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// No WithTranscoder option
+	server := NewServer(config, logger, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/party", nil)
+	rec := httptest.NewRecorder()
+
+	server.mux.ServeHTTP(rec, req)
+
+	// Should return 501 Not Implemented from the placeholder handler
+	assert.Equal(t, http.StatusNotImplemented, rec.Code)
+}
+
+// TestWithTranscoder_VanguardFromDescriptor verifies that a real Vanguard
+// transcoder built from the embedded descriptor set can be injected and
+// routes known gRPC paths without panicking.
+func TestWithTranscoder_VanguardFromDescriptor(t *testing.T) {
+	transcoder, err := NewTranscoder(testDescriptorBytes, partyBackend)
+	require.NoError(t, err)
+
+	config := &Config{
+		Port:        8080,
+		BaseDomain:  "api.example.com",
+		DatabaseURL: "postgres://localhost/test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := NewServer(config, logger, nil, WithTranscoder(transcoder))
+
+	// Send an unknown path — Vanguard returns 404, not a panic.
+	req := httptest.NewRequest(http.MethodGet, "/api/unknown/path", nil)
+	rec := httptest.NewRecorder()
+
+	assert.NotPanics(t, func() {
+		server.mux.ServeHTTP(rec, req)
+	})
+}
+
 // TestNewServer_InitializesCorrectly verifies server construction.
 func TestNewServer_InitializesCorrectly(t *testing.T) {
 	config := &Config{

--- a/services/gateway/server_test.go
+++ b/services/gateway/server_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/meridianhub/meridian/services/gateway/auth"
 	gwhealth "github.com/meridianhub/meridian/services/gateway/health"
 	"github.com/meridianhub/meridian/shared/pkg/health"
 	"github.com/stretchr/testify/assert"
@@ -263,6 +264,44 @@ func TestWithTranscoder_FallsBackToProxy(t *testing.T) {
 
 	// Should return 501 Not Implemented from the placeholder handler
 	assert.Equal(t, http.StatusNotImplemented, rec.Code)
+}
+
+// TestWithTranscoder_StripsAndInjectsIdentityHeaders verifies that the
+// identityHeaderMiddleware applied to the transcoder path strips client-supplied
+// spoofed headers and injects authenticated identity headers from context.
+func TestWithTranscoder_StripsAndInjectsIdentityHeaders(t *testing.T) {
+	var capturedHeaders http.Header
+
+	// Fake transcoder that captures the headers it receives.
+	capture := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+	})
+
+	config := &Config{
+		Port:        8080,
+		BaseDomain:  "api.example.com",
+		DatabaseURL: "postgres://localhost/test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := NewServer(config, logger, nil, WithTranscoder(capture))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/meridian.party.v1.PartyService/CreateParty", nil)
+	// Simulate spoofed headers from a malicious client.
+	req.Header.Set(HeaderUserID, "spoofed-user")
+	req.Header.Set(HeaderTenantID, "spoofed-tenant")
+	req.Header.Set(HeaderAuthMethod, "jwt")
+	// Inject real authenticated identity via context (set by auth middleware).
+	ctx := context.WithValue(req.Context(), auth.UserIDContextKey, "real-user-789")
+	ctx = context.WithValue(ctx, auth.TenantIDContextKey, "real-tenant-abc")
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	server.mux.ServeHTTP(rec, req)
+
+	// Spoofed values must be replaced with the real authenticated identity.
+	assert.Equal(t, "real-user-789", capturedHeaders.Get(HeaderUserID))
+	assert.Equal(t, "real-tenant-abc", capturedHeaders.Get(HeaderTenantID))
+	assert.Equal(t, AuthMethodJWT, capturedHeaders.Get(HeaderAuthMethod))
 }
 
 // TestWithTranscoder_VanguardFromDescriptor verifies that a real Vanguard


### PR DESCRIPTION
## Summary

- Adds `WithTranscoder(http.Handler)` server option to `gateway.Server` so a pre-built Vanguard handler can be injected at construction time
- Updates `registerRoutes()` to prefer the transcoder when set, fall back to the legacy prefix-based `ProxyHandler` (when `Backends` are configured), or return `501` via the existing placeholder
- Updates `wireGateway()` in `cmd/meridian/main.go` to build the Vanguard transcoder from the embedded `descriptor.binpb` and a `serviceNames` list mapping each registered gRPC service to the shared loopback address
- Excludes `CurrentAccountService` from REST transcoding due to overlapping `/v1/liens/*` HTTP route annotations shared with `InternalBankAccountService`; `CurrentAccountService` remains reachable via native gRPC and Connect protocol

## Changes Made

| File | Change |
|---|---|
| `services/gateway/server.go` | Add `transcoderHandler` field and `WithTranscoder` option; update `registerRoutes()` selection logic |
| `services/gateway/server_test.go` | Tests for `WithTranscoder` precedence over `Backends`, fallback to placeholder, and round-trip with real Vanguard handler |
| `cmd/meridian/main.go` | `serviceNames` var + updated `wireGateway()` to build transcoder with graceful fallback |
| `cmd/meridian/descriptors_test.go` | `TestWireGateway_TranscoderBuildsCleanly` guards against serviceNames/descriptor mismatches |

## Technical Details

**Middleware chain** (unchanged):
```
auth → tenant → tenant_authz → transcoder (replaces proxy at innermost layer)
```

**REST route conflict resolution**: `InternalBankAccountService` and `CurrentAccountService` both annotate lien lifecycle RPCs with identical REST paths (`/v1/liens/{lien_id}/execute`, `/v1/liens/{lien_id}/terminate`, etc). Vanguard cannot register both in a single transcoder instance. `InternalBankAccountService` is designated the canonical REST owner; `CurrentAccountService` is reachable via gRPC/Connect.

**Fallback behaviour**: If `NewTranscoder` fails (e.g. stale embedded descriptor), `wireGateway` logs a warning and creates the server without a transcoder — health endpoints remain live.

**`ProxyHandler` and `addIdentityHeaders`** are preserved in `proxy.go` — identity header logic is used in Task 4 for outbound header propagation.

## Testing

- All existing `services/gateway` unit and integration tests pass unchanged
- New `WithTranscoder_*` tests cover the three routing branches
- `TestWireGateway_TranscoderBuildsCleanly` validates the full `serviceNames` list against the embedded descriptor at test time
- `TestWireGateway_Config` (existing) validates the gateway server starts and serves health checks

## Risk Assessment

Low. The `Backends []BackendRoute` config path and integration tests are untouched; only the default handler selection in `registerRoutes()` is extended with a new precedence level.