### PR TITLE
feat: add LocalAccountTypeCache with singleflight and CEL pre-compilation

### DIFF
--- a/services/reference-data/cache/account_type_cache.go
+++ b/services/reference-data/cache/account_type_cache.go
@@ -5,6 +5,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"math/rand/v2"
 	"strings"
 	"sync"
@@ -365,20 +366,26 @@ func (c *LocalAccountTypeCache) getByCode(ctx context.Context, code string) *Cac
 }
 
 // backgroundRefresh asynchronously reloads a system blueprint entry.
+// Uses singleflight to prevent thundering herd when multiple concurrent
+// Get calls see the same expired system blueprint.
 func (c *LocalAccountTypeCache) backgroundRefresh(ctx context.Context, tenantID tenant.TenantID, code string) {
-	ctx = tenant.WithTenant(ctx, tenantID)
+	sfKey := fmt.Sprintf("bg:%s:%s", tenantID, code)
+	c.sfGroup.Do(sfKey, func() (interface{}, error) { //nolint:errcheck // fire-and-forget refresh
+		ctx = tenant.WithTenant(ctx, tenantID)
 
-	def, err := c.loader.LoadAccountType(ctx, code)
-	if err != nil {
-		return // Silently fail - stale entry remains accessible
-	}
+		def, err := c.loader.LoadAccountType(ctx, code)
+		if err != nil {
+			return nil, err // Stale entry remains accessible
+		}
 
-	entry, err := c.compileCachedEntry(def)
-	if err != nil {
-		return
-	}
+		entry, err := c.compileCachedEntry(def)
+		if err != nil {
+			return nil, err
+		}
 
-	c.Put(ctx, entry)
+		c.Put(ctx, entry)
+		return entry, nil //nolint:nilnil // singleflight callback, return value unused
+	})
 }
 
 // compileCachedEntry compiles CEL programs and JSON Schema for a definition.
@@ -457,6 +464,7 @@ func (c *LocalAccountTypeCache) getOrCreateTenantCache(tenantID tenant.TenantID)
 
 	newCache, err := lru.New[AccountTypeKey, *CachedAccountType](c.cacheSize)
 	if err != nil {
+		slog.Error("failed to create tenant account type cache", "tenant_id", tenantID, "error", err)
 		return nil
 	}
 

--- a/services/reference-data/cache/account_type_cache.go
+++ b/services/reference-data/cache/account_type_cache.go
@@ -474,7 +474,7 @@ func (c *LocalAccountTypeCache) getOrCreateTenantCache(tenantID tenant.TenantID)
 
 // jitteredTTL returns the base TTL plus a random jitter.
 func (c *LocalAccountTypeCache) jitteredTTL() time.Duration {
-	if c.ttlJitter == 0 {
+	if c.ttlJitter <= 0 {
 		return c.baseTTL
 	}
 	jitterRange := int64(c.ttlJitter) * 2

--- a/services/reference-data/cache/account_type_cache.go
+++ b/services/reference-data/cache/account_type_cache.go
@@ -1,0 +1,475 @@
+// Package cache provides caching infrastructure for reference data definitions
+// with tenant isolation and TTL-based expiration.
+package cache
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// Account type cache configuration defaults.
+const (
+	// DefaultAccountTypeCacheSize is the maximum number of entries per tenant cache.
+	DefaultAccountTypeCacheSize = 10000
+
+	// DefaultAccountTypeTTL is the base TTL for regular (non-system) definitions.
+	DefaultAccountTypeTTL = 5 * time.Minute
+
+	// DefaultAccountTypeTTLJitter is the maximum random jitter added to TTL.
+	DefaultAccountTypeTTLJitter = 30 * time.Second
+
+	// SystemBlueprintTTL is the TTL for system blueprint definitions (IsSystem=true).
+	SystemBlueprintTTL = 24 * time.Hour
+)
+
+// AccountTypeKey uniquely identifies an account type within a tenant's cache.
+type AccountTypeKey struct {
+	Code    string
+	Version int
+}
+
+// CachedAccountType contains the account type definition and precompiled programs.
+type CachedAccountType struct {
+	// Definition is the cached account type definition.
+	Definition *accounttype.Definition
+
+	// ValidationProgram is the precompiled CEL program for validation.
+	// May be nil if no validation expression is defined.
+	ValidationProgram cel.Program
+
+	// BucketingProgram is the precompiled CEL program for bucketing.
+	// May be nil if no bucketing expression is defined.
+	BucketingProgram cel.Program
+
+	// EligibilityProgram is the precompiled CEL program for eligibility.
+	// May be nil if no eligibility expression is defined.
+	EligibilityProgram cel.Program
+
+	// CompiledSchema is the compiled JSON Schema for attribute validation.
+	// May be nil if no attribute schema is defined.
+	CompiledSchema *jsonschema.Schema
+
+	// cachedAt records when this entry was added to the cache.
+	cachedAt time.Time
+
+	// expiresAt is the precomputed expiration time.
+	expiresAt time.Time
+
+	// isSystem records whether this is a system blueprint for background refresh.
+	isSystem bool
+}
+
+// CachedAt returns when this entry was cached.
+func (c *CachedAccountType) CachedAt() time.Time {
+	return c.cachedAt
+}
+
+// ExpiresAt returns when this entry will expire.
+func (c *CachedAccountType) ExpiresAt() time.Time {
+	return c.expiresAt
+}
+
+// AccountTypeLoader loads account type definitions from an external source (e.g., gRPC).
+type AccountTypeLoader interface {
+	// LoadAccountType loads a single account type by code, returning the latest active version.
+	LoadAccountType(ctx context.Context, code string) (*accounttype.Definition, error)
+
+	// ListActiveAccountTypes lists all active account type definitions for the tenant in context.
+	ListActiveAccountTypes(ctx context.Context) ([]*accounttype.Definition, error)
+}
+
+// AccountTypeCacheOption configures a LocalAccountTypeCache.
+type AccountTypeCacheOption func(*LocalAccountTypeCache)
+
+// WithAccountTypeCacheSize sets the maximum number of entries per tenant cache.
+func WithAccountTypeCacheSize(size int) AccountTypeCacheOption {
+	return func(c *LocalAccountTypeCache) {
+		c.cacheSize = size
+	}
+}
+
+// WithAccountTypeTTL sets the base TTL and jitter for regular definitions.
+func WithAccountTypeTTL(baseTTL, jitter time.Duration) AccountTypeCacheOption {
+	return func(c *LocalAccountTypeCache) {
+		c.baseTTL = baseTTL
+		c.ttlJitter = jitter
+	}
+}
+
+// LocalAccountTypeCache provides tenant-isolated caching for account type definitions
+// with precompiled CEL programs and JSON Schema.
+//
+// Thread-safety: All methods are safe for concurrent use.
+type LocalAccountTypeCache struct {
+	mu           sync.RWMutex
+	tenantCaches map[tenant.TenantID]*lru.Cache[AccountTypeKey, *CachedAccountType]
+	loader       AccountTypeLoader
+	celCompiler  AccountTypeCELCompiler
+	cacheSize    int
+	baseTTL      time.Duration
+	ttlJitter    time.Duration
+	sfGroup      singleflight.Group
+}
+
+// AccountTypeCELCompiler compiles CEL programs for account type definitions.
+type AccountTypeCELCompiler interface {
+	CompileValidation(expression string) (cel.Program, error)
+	CompileBucketKey(expression string) (cel.Program, error)
+	CompileEligibility(expression string) (cel.Program, error)
+}
+
+// NewLocalAccountTypeCache creates a new tenant-isolated account type cache.
+func NewLocalAccountTypeCache(
+	loader AccountTypeLoader,
+	celCompiler AccountTypeCELCompiler,
+	opts ...AccountTypeCacheOption,
+) *LocalAccountTypeCache {
+	c := &LocalAccountTypeCache{
+		tenantCaches: make(map[tenant.TenantID]*lru.Cache[AccountTypeKey, *CachedAccountType]),
+		loader:       loader,
+		celCompiler:  celCompiler,
+		cacheSize:    DefaultAccountTypeCacheSize,
+		baseTTL:      DefaultAccountTypeTTL,
+		ttlJitter:    DefaultAccountTypeTTLJitter,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Get retrieves a cached account type for the tenant in context.
+// Returns nil if not found, expired, or tenant context is missing.
+// For expired system blueprints, triggers a background refresh and returns the stale entry.
+func (c *LocalAccountTypeCache) Get(ctx context.Context, code string, version int) *CachedAccountType {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+
+	cache := c.getTenantCache(tenantID)
+	if cache == nil {
+		return nil
+	}
+
+	key := AccountTypeKey{Code: code, Version: version}
+	entry, ok := cache.Get(key)
+	if !ok {
+		return nil
+	}
+
+	if time.Now().After(entry.expiresAt) {
+		if entry.isSystem {
+			// System blueprints: trigger background refresh, return stale entry.
+			// Intentionally detached from request context to survive caller cancellation.
+			bgCtx := context.Background() //nolint:contextcheck // detached goroutine for background refresh
+			go c.backgroundRefresh(bgCtx, tenantID, code)
+			return entry
+		}
+		// Regular entries: remove expired
+		cache.Remove(key)
+		return nil
+	}
+
+	return entry
+}
+
+// Put stores an account type in the cache for the tenant in context.
+func (c *LocalAccountTypeCache) Put(ctx context.Context, entry *CachedAccountType) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	cache := c.getOrCreateTenantCache(tenantID)
+	if cache == nil {
+		return
+	}
+
+	key := AccountTypeKey{Code: entry.Definition.Code, Version: entry.Definition.Version}
+	now := time.Now()
+	entry.cachedAt = now
+	entry.isSystem = entry.Definition.IsSystem
+
+	if entry.Definition.IsSystem {
+		entry.expiresAt = now.Add(SystemBlueprintTTL)
+	} else {
+		entry.expiresAt = now.Add(c.jitteredTTL())
+	}
+
+	cache.Add(key, entry)
+}
+
+// GetOrLoad retrieves a cached account type or loads it on cache miss.
+// Concurrent requests for the same key share a single load call via singleflight.
+func (c *LocalAccountTypeCache) GetOrLoad(
+	ctx context.Context,
+	tenantID tenant.TenantID,
+	code string,
+) (*CachedAccountType, error) {
+	tenantCtx := tenant.WithTenant(ctx, tenantID)
+
+	// Fast path: check cache (use version 0 to indicate "latest")
+	if cached := c.getByCode(tenantCtx, code); cached != nil {
+		return cached, nil
+	}
+
+	// Slow path: singleflight deduplication
+	sfKey := fmt.Sprintf("%s:%s", tenantID, code)
+	result, err, _ := c.sfGroup.Do(sfKey, func() (interface{}, error) {
+		// Double-check cache
+		if cached := c.getByCode(tenantCtx, code); cached != nil {
+			return cached, nil
+		}
+
+		// Load from source
+		def, err := c.loader.LoadAccountType(tenantCtx, code)
+		if err != nil {
+			return nil, err
+		}
+
+		// Compile programs
+		entry, err := c.compileCachedEntry(def)
+		if err != nil {
+			return nil, fmt.Errorf("compile account type %s: %w", code, err)
+		}
+
+		// Store in cache
+		c.Put(tenantCtx, entry)
+		return entry, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	cached, ok := result.(*CachedAccountType)
+	if !ok {
+		return nil, ErrUnexpectedResultType
+	}
+
+	return cached, nil
+}
+
+// PrefetchAccountTypes loads all active account types for the given tenants into the cache.
+func (c *LocalAccountTypeCache) PrefetchAccountTypes(ctx context.Context, tenantIDs []tenant.TenantID) error {
+	for _, tenantID := range tenantIDs {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("prefetch cancelled: %w", err)
+		}
+
+		tenantCtx := tenant.WithTenant(ctx, tenantID)
+		defs, err := c.loader.ListActiveAccountTypes(tenantCtx)
+		if err != nil {
+			return fmt.Errorf("prefetch failed for tenant %s: %w", tenantID, err)
+		}
+
+		for _, def := range defs {
+			entry, err := c.compileCachedEntry(def)
+			if err != nil {
+				return fmt.Errorf("compile account type %s for tenant %s: %w", def.Code, tenantID, err)
+			}
+			c.Put(tenantCtx, entry)
+		}
+	}
+	return nil
+}
+
+// Invalidate removes a specific entry from the cache for the tenant in context.
+func (c *LocalAccountTypeCache) Invalidate(ctx context.Context, code string, version int) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	cache := c.getTenantCache(tenantID)
+	if cache == nil {
+		return
+	}
+
+	cache.Remove(AccountTypeKey{Code: code, Version: version})
+}
+
+// InvalidateAll removes all entries for the tenant in context.
+func (c *LocalAccountTypeCache) InvalidateAll(ctx context.Context) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.tenantCaches, tenantID)
+}
+
+// Stats returns cache statistics for the tenant in context.
+func (c *LocalAccountTypeCache) Stats(ctx context.Context) (size int, capacity int) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return 0, 0
+	}
+
+	cache := c.getTenantCache(tenantID)
+	if cache == nil {
+		return 0, 0
+	}
+
+	return cache.Len(), c.cacheSize
+}
+
+// getByCode looks up a cache entry by code across all versions for the tenant in context.
+// Returns the first matching entry found (there should typically be one active version).
+func (c *LocalAccountTypeCache) getByCode(ctx context.Context, code string) *CachedAccountType {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+
+	cache := c.getTenantCache(tenantID)
+	if cache == nil {
+		return nil
+	}
+
+	for _, key := range cache.Keys() {
+		if key.Code == code {
+			entry, ok := cache.Get(key)
+			if !ok {
+				continue
+			}
+			if time.Now().After(entry.expiresAt) {
+				if entry.isSystem {
+					bgCtx := context.Background() //nolint:contextcheck // detached goroutine for background refresh
+					go c.backgroundRefresh(bgCtx, tenantID, code)
+					return entry
+				}
+				cache.Remove(key)
+				continue
+			}
+			return entry
+		}
+	}
+
+	return nil
+}
+
+// backgroundRefresh asynchronously reloads a system blueprint entry.
+func (c *LocalAccountTypeCache) backgroundRefresh(ctx context.Context, tenantID tenant.TenantID, code string) {
+	ctx = tenant.WithTenant(ctx, tenantID)
+
+	def, err := c.loader.LoadAccountType(ctx, code)
+	if err != nil {
+		return // Silently fail - stale entry remains accessible
+	}
+
+	entry, err := c.compileCachedEntry(def)
+	if err != nil {
+		return
+	}
+
+	c.Put(ctx, entry)
+}
+
+// compileCachedEntry compiles CEL programs and JSON Schema for a definition.
+func (c *LocalAccountTypeCache) compileCachedEntry(def *accounttype.Definition) (*CachedAccountType, error) {
+	entry := &CachedAccountType{
+		Definition: def,
+	}
+
+	if c.celCompiler != nil {
+		if def.ValidationCEL != "" {
+			prg, err := c.celCompiler.CompileValidation(def.ValidationCEL)
+			if err != nil {
+				return nil, fmt.Errorf("validation CEL: %w", err)
+			}
+			entry.ValidationProgram = prg
+		}
+		if def.BucketingCEL != "" {
+			prg, err := c.celCompiler.CompileBucketKey(def.BucketingCEL)
+			if err != nil {
+				return nil, fmt.Errorf("bucketing CEL: %w", err)
+			}
+			entry.BucketingProgram = prg
+		}
+		if def.EligibilityCEL != "" {
+			prg, err := c.celCompiler.CompileEligibility(def.EligibilityCEL)
+			if err != nil {
+				return nil, fmt.Errorf("eligibility CEL: %w", err)
+			}
+			entry.EligibilityProgram = prg
+		}
+	}
+
+	if len(def.AttributeSchema) > 0 {
+		schema, err := compileJSONSchema(def.AttributeSchema)
+		if err != nil {
+			return nil, fmt.Errorf("attribute schema: %w", err)
+		}
+		entry.CompiledSchema = schema
+	}
+
+	return entry, nil
+}
+
+// compileJSONSchema compiles raw JSON Schema bytes into a validated schema.
+func compileJSONSchema(raw []byte) (*jsonschema.Schema, error) {
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("schema.json", strings.NewReader(string(raw))); err != nil {
+		return nil, err
+	}
+	return compiler.Compile("schema.json")
+}
+
+// getTenantCache returns the cache for a tenant, or nil if not found.
+func (c *LocalAccountTypeCache) getTenantCache(tenantID tenant.TenantID) *lru.Cache[AccountTypeKey, *CachedAccountType] {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.tenantCaches[tenantID]
+}
+
+// getOrCreateTenantCache returns the cache for a tenant, creating it if needed.
+func (c *LocalAccountTypeCache) getOrCreateTenantCache(tenantID tenant.TenantID) *lru.Cache[AccountTypeKey, *CachedAccountType] {
+	c.mu.RLock()
+	cache, ok := c.tenantCaches[tenantID]
+	c.mu.RUnlock()
+
+	if ok {
+		return cache
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if cache, ok = c.tenantCaches[tenantID]; ok {
+		return cache
+	}
+
+	newCache, err := lru.New[AccountTypeKey, *CachedAccountType](c.cacheSize)
+	if err != nil {
+		return nil
+	}
+
+	c.tenantCaches[tenantID] = newCache
+	return newCache
+}
+
+// jitteredTTL returns the base TTL plus a random jitter.
+func (c *LocalAccountTypeCache) jitteredTTL() time.Duration {
+	if c.ttlJitter == 0 {
+		return c.baseTTL
+	}
+	jitterRange := int64(c.ttlJitter) * 2
+	jitter := rand.Int64N(jitterRange) - int64(c.ttlJitter)
+	return c.baseTTL + time.Duration(jitter)
+}

--- a/services/reference-data/cache/account_type_cache_test.go
+++ b/services/reference-data/cache/account_type_cache_test.go
@@ -1,0 +1,709 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// mockAccountTypeLoader is a test double for AccountTypeLoader.
+type mockAccountTypeLoader struct {
+	mu              sync.Mutex
+	definitions     map[string]map[string]*accounttype.Definition // tenantID -> code -> definition
+	listDefinitions map[string][]*accounttype.Definition          // tenantID -> definitions
+	loadCallCount   atomic.Int32
+	loadErr         error
+	listErr         error
+}
+
+func newMockAccountTypeLoader() *mockAccountTypeLoader {
+	return &mockAccountTypeLoader{
+		definitions:     make(map[string]map[string]*accounttype.Definition),
+		listDefinitions: make(map[string][]*accounttype.Definition),
+	}
+}
+
+func (m *mockAccountTypeLoader) LoadAccountType(ctx context.Context, code string) (*accounttype.Definition, error) {
+	m.loadCallCount.Add(1)
+
+	if m.loadErr != nil {
+		return nil, m.loadErr
+	}
+
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil, ErrTenantContextRequired
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	defs, ok := m.definitions[string(tenantID)]
+	if !ok {
+		return nil, accounttype.ErrNotFound
+	}
+	def, ok := defs[code]
+	if !ok {
+		return nil, accounttype.ErrNotFound
+	}
+	return def, nil
+}
+
+func (m *mockAccountTypeLoader) ListActiveAccountTypes(ctx context.Context) ([]*accounttype.Definition, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil, ErrTenantContextRequired
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.listDefinitions[string(tenantID)], nil
+}
+
+func (m *mockAccountTypeLoader) addDefinition(tenantID string, def *accounttype.Definition) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.definitions[tenantID] == nil {
+		m.definitions[tenantID] = make(map[string]*accounttype.Definition)
+	}
+	m.definitions[tenantID][def.Code] = def
+	m.listDefinitions[tenantID] = append(m.listDefinitions[tenantID], def)
+}
+
+// mockAccountTypeCELCompiler is a test double for AccountTypeCELCompiler.
+type mockAccountTypeCELCompiler struct {
+	validationErr  error
+	bucketingErr   error
+	eligibilityErr error
+	// Use real CEL programs for non-nil return
+	returnPrograms bool
+}
+
+func (m *mockAccountTypeCELCompiler) CompileValidation(_ string) (cel.Program, error) {
+	if m.validationErr != nil {
+		return nil, m.validationErr
+	}
+	if m.returnPrograms {
+		return newStubCELProgram(), nil
+	}
+	return nil, nil
+}
+
+func (m *mockAccountTypeCELCompiler) CompileBucketKey(_ string) (cel.Program, error) {
+	if m.bucketingErr != nil {
+		return nil, m.bucketingErr
+	}
+	if m.returnPrograms {
+		return newStubCELProgram(), nil
+	}
+	return nil, nil
+}
+
+func (m *mockAccountTypeCELCompiler) CompileEligibility(_ string) (cel.Program, error) {
+	if m.eligibilityErr != nil {
+		return nil, m.eligibilityErr
+	}
+	if m.returnPrograms {
+		return newStubCELProgram(), nil
+	}
+	return nil, nil
+}
+
+// stubCELProgram is a minimal cel.Program implementation for testing.
+type stubCELProgram struct{}
+
+func newStubCELProgram() cel.Program { return &stubCELProgram{} }
+
+func (s *stubCELProgram) Eval(_ any) (ref.Val, *cel.EvalDetails, error) {
+	return nil, nil, nil
+}
+
+func (s *stubCELProgram) ContextEval(_ context.Context, _ any) (ref.Val, *cel.EvalDetails, error) {
+	return nil, nil, nil
+}
+
+func newTestAccountTypeContext(tenantID string) context.Context {
+	return tenant.WithTenant(context.Background(), tenant.MustNewTenantID(tenantID))
+}
+
+func newTestAccountTypeDef(code string, version int, isSystem bool) *accounttype.Definition {
+	return &accounttype.Definition{
+		ID:              uuid.New(),
+		Code:            code,
+		Version:         version,
+		DisplayName:     code + " Account",
+		NormalBalance:   accounttype.NormalBalanceCredit,
+		BehaviorClass:   accounttype.BehaviorClassCustomer,
+		InstrumentCode:  "GBP",
+		ValidationCEL:   "true",
+		BucketingCEL:    `"default"`,
+		EligibilityCEL:  "true",
+		AttributeSchema: json.RawMessage(`{"type":"object"}`),
+		Status:          accounttype.StatusActive,
+		IsSystem:        isSystem,
+		CreatedAt:       time.Now().UTC(),
+		UpdatedAt:       time.Now().UTC(),
+	}
+}
+
+func newTestCache(loader AccountTypeLoader, compiler AccountTypeCELCompiler, opts ...AccountTypeCacheOption) *LocalAccountTypeCache {
+	return NewLocalAccountTypeCache(loader, compiler, opts...)
+}
+
+// --- Tests ---
+
+func TestLocalAccountTypeCache_CacheHitReturnsWithoutCallingLoader(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler)
+
+	def := newTestAccountTypeDef("CUSTOMER_CURRENT", 1, false)
+	loader.addDefinition("tenant1", def)
+
+	ctx := newTestAccountTypeContext("tenant1")
+	tenantID := tenant.MustNewTenantID("tenant1")
+
+	// Load once to populate cache
+	result, err := cache.GetOrLoad(ctx, tenantID, "CUSTOMER_CURRENT")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "CUSTOMER_CURRENT", result.Definition.Code)
+	assert.Equal(t, int32(1), loader.loadCallCount.Load())
+
+	// Second call should hit cache, not loader
+	result2, err := cache.GetOrLoad(ctx, tenantID, "CUSTOMER_CURRENT")
+	require.NoError(t, err)
+	require.NotNil(t, result2)
+	assert.Equal(t, "CUSTOMER_CURRENT", result2.Definition.Code)
+	assert.Equal(t, int32(1), loader.loadCallCount.Load(), "loader should not be called on cache hit")
+}
+
+func TestLocalAccountTypeCache_SingleflightDeduplication(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler)
+
+	def := newTestAccountTypeDef("CUSTOMER_CURRENT", 1, false)
+	loader.addDefinition("tenant1", def)
+
+	ctx := newTestAccountTypeContext("tenant1")
+	tenantID := tenant.MustNewTenantID("tenant1")
+	const concurrency = 10
+
+	var wg sync.WaitGroup
+	startCh := make(chan struct{})
+	results := make([]*CachedAccountType, concurrency)
+	errs := make([]error, concurrency)
+
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			<-startCh
+			results[idx], errs[idx] = cache.GetOrLoad(ctx, tenantID, "CUSTOMER_CURRENT")
+		}(i)
+	}
+
+	close(startCh)
+	wg.Wait()
+
+	for i := 0; i < concurrency; i++ {
+		require.NoError(t, errs[i], "request %d failed", i)
+		require.NotNil(t, results[i], "request %d returned nil", i)
+		assert.Equal(t, "CUSTOMER_CURRENT", results[i].Definition.Code)
+	}
+
+	// Singleflight should have deduplicated to exactly 1 call
+	assert.Equal(t, int32(1), loader.loadCallCount.Load(),
+		"singleflight should deduplicate %d concurrent requests to 1 load call", concurrency)
+}
+
+func TestLocalAccountTypeCache_TTLExpiry_RegularDefinition(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler,
+		WithAccountTypeTTL(50*time.Millisecond, 0), // No jitter for predictable tests
+	)
+
+	def := newTestAccountTypeDef("CUSTOMER_CURRENT", 1, false)
+	loader.addDefinition("tenant1", def)
+
+	ctx := newTestAccountTypeContext("tenant1")
+	tenantID := tenant.MustNewTenantID("tenant1")
+
+	// Load to populate cache
+	result, err := cache.GetOrLoad(ctx, tenantID, "CUSTOMER_CURRENT")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Should be cached
+	cached := cache.Get(ctx, def.Code, def.Version)
+	require.NotNil(t, cached)
+
+	// Wait for TTL expiry
+	time.Sleep(60 * time.Millisecond)
+
+	// Should be expired
+	expired := cache.Get(ctx, def.Code, def.Version)
+	assert.Nil(t, expired, "regular entry should be expired and removed")
+}
+
+func TestLocalAccountTypeCache_SystemBlueprintGets24HourTTL(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler)
+
+	def := newTestAccountTypeDef("SYSTEM_NOSTRO", 1, true)
+	loader.addDefinition("tenant1", def)
+
+	ctx := newTestAccountTypeContext("tenant1")
+	tenantID := tenant.MustNewTenantID("tenant1")
+
+	result, err := cache.GetOrLoad(ctx, tenantID, "SYSTEM_NOSTRO")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Check TTL is approximately 24 hours
+	ttl := result.ExpiresAt().Sub(result.CachedAt())
+	assert.True(t, ttl >= 23*time.Hour && ttl <= 25*time.Hour,
+		"system blueprint TTL should be ~24h, got %v", ttl)
+}
+
+func TestLocalAccountTypeCache_TenantIsolation(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler)
+
+	defA := newTestAccountTypeDef("ACCOUNT_A", 1, false)
+	defB := newTestAccountTypeDef("ACCOUNT_B", 1, false)
+	loader.addDefinition("tenantA", defA)
+	loader.addDefinition("tenantB", defB)
+
+	ctxA := newTestAccountTypeContext("tenantA")
+	ctxB := newTestAccountTypeContext("tenantB")
+	tenantA := tenant.MustNewTenantID("tenantA")
+	tenantB := tenant.MustNewTenantID("tenantB")
+
+	// Load for each tenant
+	resultA, err := cache.GetOrLoad(ctxA, tenantA, "ACCOUNT_A")
+	require.NoError(t, err)
+	require.NotNil(t, resultA)
+
+	resultB, err := cache.GetOrLoad(ctxB, tenantB, "ACCOUNT_B")
+	require.NoError(t, err)
+	require.NotNil(t, resultB)
+
+	// Tenant A should not see tenant B's data
+	assert.Nil(t, cache.Get(ctxA, "ACCOUNT_B", 1), "tenant A should not see tenant B's cache")
+
+	// Tenant B should not see tenant A's data
+	assert.Nil(t, cache.Get(ctxB, "ACCOUNT_A", 1), "tenant B should not see tenant A's cache")
+}
+
+func TestLocalAccountTypeCache_PrefetchAccountTypes(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler)
+
+	def1 := newTestAccountTypeDef("CUSTOMER_CURRENT", 1, false)
+	def2 := newTestAccountTypeDef("SYSTEM_NOSTRO", 1, true)
+	def3 := newTestAccountTypeDef("CLEARING", 1, false)
+	loader.addDefinition("tenant1", def1)
+	loader.addDefinition("tenant1", def2)
+	loader.addDefinition("tenant1", def3)
+
+	tenantIDs := []tenant.TenantID{tenant.MustNewTenantID("tenant1")}
+
+	err := cache.PrefetchAccountTypes(context.Background(), tenantIDs)
+	require.NoError(t, err)
+
+	ctx := newTestAccountTypeContext("tenant1")
+	size, _ := cache.Stats(ctx)
+	assert.Equal(t, 3, size, "all 3 definitions should be cached")
+
+	// Verify specific entries
+	assert.NotNil(t, cache.Get(ctx, "CUSTOMER_CURRENT", 1))
+	assert.NotNil(t, cache.Get(ctx, "SYSTEM_NOSTRO", 1))
+	assert.NotNil(t, cache.Get(ctx, "CLEARING", 1))
+}
+
+func TestLocalAccountTypeCache_PrefetchAccountTypes_CompilesCELPrograms(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler)
+
+	def := newTestAccountTypeDef("CUSTOMER_CURRENT", 1, false)
+	loader.addDefinition("tenant1", def)
+
+	tenantIDs := []tenant.TenantID{tenant.MustNewTenantID("tenant1")}
+
+	err := cache.PrefetchAccountTypes(context.Background(), tenantIDs)
+	require.NoError(t, err)
+
+	ctx := newTestAccountTypeContext("tenant1")
+	cached := cache.Get(ctx, "CUSTOMER_CURRENT", 1)
+	require.NotNil(t, cached)
+
+	// EligibilityProgram should be non-nil after cache population
+	assert.NotNil(t, cached.EligibilityProgram, "EligibilityProgram should be compiled and non-nil")
+	assert.NotNil(t, cached.ValidationProgram, "ValidationProgram should be compiled and non-nil")
+	assert.NotNil(t, cached.BucketingProgram, "BucketingProgram should be compiled and non-nil")
+}
+
+func TestLocalAccountTypeCache_ExpiredSystemBlueprintTriggersBackgroundRefresh(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler,
+		WithAccountTypeTTL(50*time.Millisecond, 0),
+	)
+
+	def := newTestAccountTypeDef("SYSTEM_NOSTRO", 1, true)
+	loader.addDefinition("tenant1", def)
+
+	ctx := newTestAccountTypeContext("tenant1")
+
+	// Manually put with short TTL to simulate expiry
+	entry, err := cache.compileCachedEntry(def)
+	require.NoError(t, err)
+
+	// Force a short expiry for system blueprint
+	now := time.Now()
+	entry.cachedAt = now
+	entry.expiresAt = now.Add(50 * time.Millisecond)
+	entry.isSystem = true
+
+	tenantID := tenant.MustNewTenantID("tenant1")
+	lruCache := cache.getOrCreateTenantCache(tenantID)
+	lruCache.Add(AccountTypeKey{Code: "SYSTEM_NOSTRO", Version: 1}, entry)
+
+	// Wait for expiry
+	time.Sleep(60 * time.Millisecond)
+
+	// Get should return stale entry (not nil) and trigger background refresh
+	result := cache.Get(ctx, "SYSTEM_NOSTRO", 1)
+	assert.NotNil(t, result, "expired system blueprint should return stale entry, not nil")
+	assert.Equal(t, "SYSTEM_NOSTRO", result.Definition.Code)
+
+	// Wait for background refresh to complete
+	time.Sleep(100 * time.Millisecond)
+
+	// After refresh, entry should have a fresh TTL
+	refreshed := cache.Get(ctx, "SYSTEM_NOSTRO", 1)
+	require.NotNil(t, refreshed)
+	assert.True(t, refreshed.ExpiresAt().After(time.Now()), "refreshed entry should have future expiry")
+}
+
+func TestLocalAccountTypeCache_Invalidate(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler)
+
+	def := newTestAccountTypeDef("CUSTOMER_CURRENT", 1, false)
+	loader.addDefinition("tenant1", def)
+
+	ctx := newTestAccountTypeContext("tenant1")
+	tenantID := tenant.MustNewTenantID("tenant1")
+
+	_, err := cache.GetOrLoad(ctx, tenantID, "CUSTOMER_CURRENT")
+	require.NoError(t, err)
+
+	// Verify cached
+	assert.NotNil(t, cache.Get(ctx, "CUSTOMER_CURRENT", 1))
+
+	// Invalidate
+	cache.Invalidate(ctx, "CUSTOMER_CURRENT", 1)
+
+	// Should be gone
+	assert.Nil(t, cache.Get(ctx, "CUSTOMER_CURRENT", 1))
+}
+
+func TestLocalAccountTypeCache_InvalidateAll(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler)
+
+	def1 := newTestAccountTypeDef("CUSTOMER_CURRENT", 1, false)
+	def2 := newTestAccountTypeDef("CLEARING", 1, false)
+	loader.addDefinition("tenant1", def1)
+	loader.addDefinition("tenant1", def2)
+
+	ctx := newTestAccountTypeContext("tenant1")
+	tenantID := tenant.MustNewTenantID("tenant1")
+
+	_, err := cache.GetOrLoad(ctx, tenantID, "CUSTOMER_CURRENT")
+	require.NoError(t, err)
+	_, err = cache.GetOrLoad(ctx, tenantID, "CLEARING")
+	require.NoError(t, err)
+
+	// Both cached
+	size, _ := cache.Stats(ctx)
+	assert.Equal(t, 2, size)
+
+	// Invalidate all
+	cache.InvalidateAll(ctx)
+
+	// Both gone
+	assert.Nil(t, cache.Get(ctx, "CUSTOMER_CURRENT", 1))
+	assert.Nil(t, cache.Get(ctx, "CLEARING", 1))
+}
+
+func TestLocalAccountTypeCache_LoadError(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	loader.loadErr = errors.New("gRPC unavailable") //nolint:err113 // test sentinel
+	compiler := &mockAccountTypeCELCompiler{}
+	cache := newTestCache(loader, compiler)
+
+	ctx := newTestAccountTypeContext("tenant1")
+	tenantID := tenant.MustNewTenantID("tenant1")
+
+	result, err := cache.GetOrLoad(ctx, tenantID, "NONEXISTENT")
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}
+
+func TestLocalAccountTypeCache_PrefetchMultipleTenants(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler)
+
+	defA := newTestAccountTypeDef("ACCOUNT_A", 1, false)
+	defB := newTestAccountTypeDef("ACCOUNT_B", 1, true)
+	loader.addDefinition("tenantX", defA)
+	loader.addDefinition("tenantY", defB)
+
+	tenantIDs := []tenant.TenantID{
+		tenant.MustNewTenantID("tenantX"),
+		tenant.MustNewTenantID("tenantY"),
+	}
+
+	err := cache.PrefetchAccountTypes(context.Background(), tenantIDs)
+	require.NoError(t, err)
+
+	ctxX := newTestAccountTypeContext("tenantX")
+	ctxY := newTestAccountTypeContext("tenantY")
+
+	assert.NotNil(t, cache.Get(ctxX, "ACCOUNT_A", 1))
+	assert.NotNil(t, cache.Get(ctxY, "ACCOUNT_B", 1))
+
+	// Tenant isolation: X should not see Y's data
+	assert.Nil(t, cache.Get(ctxX, "ACCOUNT_B", 1))
+	assert.Nil(t, cache.Get(ctxY, "ACCOUNT_A", 1))
+}
+
+func TestLocalAccountTypeCache_JitteredTTLVariance(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler,
+		WithAccountTypeTTL(100*time.Millisecond, 50*time.Millisecond),
+	)
+
+	ctx := newTestAccountTypeContext("tenant1")
+
+	var expirations []time.Duration
+	for i := 0; i < 20; i++ {
+		def := newTestAccountTypeDef("TYPE", i, false)
+		entry, err := cache.compileCachedEntry(def)
+		require.NoError(t, err)
+		cache.Put(ctx, entry)
+
+		cached := cache.Get(ctx, "TYPE", i)
+		require.NotNil(t, cached)
+		expirations = append(expirations, cached.ExpiresAt().Sub(cached.CachedAt()))
+	}
+
+	minExp := expirations[0]
+	maxExp := expirations[0]
+	for _, exp := range expirations[1:] {
+		if exp < minExp {
+			minExp = exp
+		}
+		if exp > maxExp {
+			maxExp = exp
+		}
+	}
+
+	diff := maxExp - minExp
+	assert.Greater(t, diff.Milliseconds(), int64(0), "jitter should produce variance in TTL")
+}
+
+func TestLocalAccountTypeCache_NilCELCompiler(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	cache := newTestCache(loader, nil) // nil compiler
+
+	def := newTestAccountTypeDef("CUSTOMER_CURRENT", 1, false)
+	loader.addDefinition("tenant1", def)
+
+	ctx := newTestAccountTypeContext("tenant1")
+	tenantID := tenant.MustNewTenantID("tenant1")
+
+	result, err := cache.GetOrLoad(ctx, tenantID, "CUSTOMER_CURRENT")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "CUSTOMER_CURRENT", result.Definition.Code)
+
+	// Programs should be nil when compiler is nil
+	assert.Nil(t, result.ValidationProgram)
+	assert.Nil(t, result.BucketingProgram)
+	assert.Nil(t, result.EligibilityProgram)
+	// Schema should still compile since it doesn't use CEL compiler
+	assert.NotNil(t, result.CompiledSchema)
+}
+
+func TestLocalAccountTypeCache_CompiledSchemaPopulated(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler)
+
+	def := newTestAccountTypeDef("CUSTOMER_CURRENT", 1, false)
+	def.AttributeSchema = json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"tier": {"type": "string", "enum": ["GOLD", "SILVER", "BRONZE"]}
+		},
+		"required": ["tier"]
+	}`)
+	loader.addDefinition("tenant1", def)
+
+	ctx := newTestAccountTypeContext("tenant1")
+	tenantID := tenant.MustNewTenantID("tenant1")
+
+	result, err := cache.GetOrLoad(ctx, tenantID, "CUSTOMER_CURRENT")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.NotNil(t, result.CompiledSchema, "compiled JSON Schema should be non-nil")
+}
+
+func TestLocalAccountTypeCache_NoAttributeSchema(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler)
+
+	def := newTestAccountTypeDef("CUSTOMER_CURRENT", 1, false)
+	def.AttributeSchema = nil // No schema
+	loader.addDefinition("tenant1", def)
+
+	ctx := newTestAccountTypeContext("tenant1")
+	tenantID := tenant.MustNewTenantID("tenant1")
+
+	result, err := cache.GetOrLoad(ctx, tenantID, "CUSTOMER_CURRENT")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Nil(t, result.CompiledSchema, "compiled JSON Schema should be nil when no schema defined")
+}
+
+func TestLocalAccountTypeCache_Stats(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler, WithAccountTypeCacheSize(100))
+
+	ctx := newTestAccountTypeContext("tenant1")
+
+	// Initially empty
+	size, capacity := cache.Stats(ctx)
+	assert.Equal(t, 0, size)
+	assert.Equal(t, 0, capacity)
+
+	// Add entry
+	def := newTestAccountTypeDef("CUSTOMER_CURRENT", 1, false)
+	loader.addDefinition("tenant1", def)
+	tenantID := tenant.MustNewTenantID("tenant1")
+	_, err := cache.GetOrLoad(ctx, tenantID, "CUSTOMER_CURRENT")
+	require.NoError(t, err)
+
+	size, capacity = cache.Stats(ctx)
+	assert.Equal(t, 1, size)
+	assert.Equal(t, 100, capacity)
+}
+
+func TestLocalAccountTypeCache_MissingTenantContext(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{}
+	cache := newTestCache(loader, compiler)
+
+	ctx := context.Background() // No tenant
+
+	result := cache.Get(ctx, "CUSTOMER_CURRENT", 1)
+	assert.Nil(t, result)
+
+	size, capacity := cache.Stats(ctx)
+	assert.Equal(t, 0, size)
+	assert.Equal(t, 0, capacity)
+}
+
+func TestLocalAccountTypeCache_PrefetchContextCancellation(t *testing.T) {
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler)
+
+	def := newTestAccountTypeDef("CUSTOMER_CURRENT", 1, false)
+	loader.addDefinition("tenant1", def)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	tenantIDs := []tenant.TenantID{tenant.MustNewTenantID("tenant1")}
+	err := cache.PrefetchAccountTypes(ctx, tenantIDs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prefetch cancelled")
+}
+
+func TestLocalAccountTypeCache_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	loader := newMockAccountTypeLoader()
+	compiler := &mockAccountTypeCELCompiler{returnPrograms: true}
+	cache := newTestCache(loader, compiler)
+
+	for i := 0; i < 10; i++ {
+		def := newTestAccountTypeDef("TYPE_"+string(rune('A'+i)), 1, false)
+		loader.addDefinition("tenant1", def)
+	}
+
+	ctx := newTestAccountTypeContext("tenant1")
+	tenantID := tenant.MustNewTenantID("tenant1")
+
+	var wg sync.WaitGroup
+
+	// Concurrent readers and loaders
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			code := "TYPE_" + string(rune('A'+idx%10))
+			_, _ = cache.GetOrLoad(ctx, tenantID, code)
+			_ = cache.Get(ctx, code, 1)
+		}(i)
+	}
+
+	// Concurrent invalidators
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			code := "TYPE_" + string(rune('A'+idx%10))
+			cache.Invalidate(ctx, code, 1)
+		}(i)
+	}
+
+	wg.Wait()
+	// No panics means test passes
+}


### PR DESCRIPTION
## Summary
- LRU cache with per-tenant isolation and singleflight dedup for AccountTypeDefinitions
- Pre-compiled CEL programs (validation, bucketing, eligibility) and JSON Schema at cache time
- TTL with jitter: 24h for system blueprints (IsSystem=true), 5min for regular definitions
- Background refresh for system blueprints on TTL expiry (non-evicting, survives transient outages)
- PrefetchAccountTypes for startup warming across multiple tenants
- Follows the existing InstrumentCache pattern in the same package

## Task Master
Tag: product-directory, Task: 8

## Test plan
- [x] Cache hit returns pre-compiled programs without calling loader
- [x] Singleflight prevents duplicate loads under 10 concurrent goroutines
- [x] TTL expiry triggers reload on next access for regular definitions
- [x] System blueprint (IsSystem=true) gets 24-hour TTL
- [x] Per-tenant isolation: tenant A cache miss doesn't pollute tenant B cache
- [x] PrefetchAccountTypes warms cache for all active definitions
- [x] Pre-compiled EligibilityProgram is non-nil after cache population
- [x] Expired system blueprint triggers background refresh rather than eviction
- [x] Compiled JSON Schema populated when AttributeSchema defined
- [x] Concurrent access safety verified (no panics under concurrent reads/writes/invalidations)