### PR TITLE
feat: Implement HTTP header to gRPC metadata propagation

### DIFF
--- a/services/gateway/metadata.go
+++ b/services/gateway/metadata.go
@@ -1,0 +1,92 @@
+package gateway
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/meridianhub/meridian/services/gateway/auth"
+)
+
+// metadataPropagationMiddleware is an HTTP middleware for the Vanguard transcoder
+// path that propagates identity context as lowercase gRPC metadata headers.
+//
+// It performs two operations in sequence:
+//
+//  1. Security: Strip any incoming identity headers to prevent client spoofing.
+//     Clients must not be able to inject their own x-user-id, x-tenant-id,
+//     x-auth-method, or x-auth-roles headers.
+//
+//  2. Propagation: Read the authenticated identity from the request context
+//     (set by the auth middleware) and write it as lowercase HTTP headers.
+//     These headers are forwarded by Vanguard to the gRPC backend, where the
+//     gRPC server reads them as incoming metadata. The existing interceptor
+//     chain (TenantExtractionInterceptor, auth.Interceptor) reads these keys:
+//     - x-user-id  → identifies the authenticated principal
+//     - x-tenant-id → identifies the tenant (read by TenantExtractionInterceptor)
+//     - x-auth-method → "jwt" or "apikey"
+//     - x-auth-roles → comma-separated role list (JWT only)
+//
+// This middleware is the Vanguard equivalent of the security logic in
+// NewProxyHandler's Director function, ensuring that all backend paths
+// (legacy proxy and Vanguard transcoder) apply the same security model.
+func metadataPropagationMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// SECURITY: Strip all incoming identity headers (both canonical and
+		// lowercase forms) to prevent client spoofing before writing new ones.
+		r.Header.Del(HeaderUserID)
+		r.Header.Del(HeaderTenantID)
+		r.Header.Del(HeaderAuthMethod)
+		r.Header.Del(HeaderAuthRoles)
+		r.Header.Del(auth.APIKeyHeader)
+
+		// Write authenticated identity as lowercase gRPC metadata headers.
+		writeIdentityMetadata(r)
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// writeIdentityMetadata reads authenticated identity from the request context
+// and writes it as lowercase HTTP headers compatible with gRPC metadata.
+//
+// JWT authentication sets:
+//   - x-user-id     from JWT user_id claim
+//   - x-tenant-id   from JWT tenant_id claim (if present)
+//   - x-auth-method "jwt"
+//   - x-auth-roles  comma-separated roles (if present and non-empty)
+//
+// API key authentication sets:
+//   - x-user-id     from resolved API key identity
+//   - x-tenant-id   from resolved tenant (if present)
+//   - x-auth-method "apikey"
+//
+// If no authenticated identity is found in context, no headers are written.
+func writeIdentityMetadata(req *http.Request) {
+	ctx := req.Context()
+
+	// JWT takes precedence over API key when both are present.
+	if userID, ok := auth.GetUserIDFromContext(ctx); ok && userID != "" {
+		req.Header.Set("x-user-id", userID)
+		req.Header.Set("x-auth-method", AuthMethodJWT)
+
+		if tenantID, ok := auth.GetTenantIDFromContext(ctx); ok && tenantID != "" {
+			req.Header.Set("x-tenant-id", tenantID)
+		}
+
+		if roles, ok := auth.GetRolesFromContext(ctx); ok && len(roles) > 0 {
+			req.Header.Set("x-auth-roles", strings.Join(roles, ","))
+		}
+
+		return
+	}
+
+	// Fall back to API key identity.
+	if identity := auth.GetAPIKeyIdentity(ctx); identity != "" {
+		req.Header.Set("x-user-id", identity)
+		req.Header.Set("x-auth-method", AuthMethodAPIKey)
+
+		if tenantID, ok := auth.GetTenantIDFromContext(ctx); ok && tenantID != "" {
+			req.Header.Set("x-tenant-id", tenantID)
+		}
+	}
+}

--- a/services/gateway/metadata_test.go
+++ b/services/gateway/metadata_test.go
@@ -1,0 +1,235 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/gateway/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMetadataPropagationMiddleware_JWTAuthenticated verifies that JWT-authenticated
+// requests propagate identity as lowercase gRPC metadata headers.
+func TestMetadataPropagationMiddleware_JWTAuthenticated(t *testing.T) {
+	var capturedHeaders http.Header
+
+	handler := metadataPropagationMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/meridian.party.v1.PartyService/CreateParty", nil)
+	ctx := context.WithValue(req.Context(), auth.UserIDContextKey, "user-123")
+	ctx = context.WithValue(ctx, auth.TenantIDContextKey, "tenant-abc")
+	req = req.WithContext(ctx)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "user-123", capturedHeaders.Get("x-user-id"))
+	assert.Equal(t, "tenant-abc", capturedHeaders.Get("x-tenant-id"))
+	assert.Equal(t, AuthMethodJWT, capturedHeaders.Get("x-auth-method"))
+}
+
+// TestMetadataPropagationMiddleware_JWTWithRoles verifies that JWT roles are
+// propagated as a comma-separated gRPC metadata header.
+func TestMetadataPropagationMiddleware_JWTWithRoles(t *testing.T) {
+	var capturedHeaders http.Header
+
+	handler := metadataPropagationMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	ctx := context.WithValue(req.Context(), auth.UserIDContextKey, "user-456")
+	ctx = context.WithValue(ctx, auth.TenantIDContextKey, "tenant-xyz")
+	ctx = context.WithValue(ctx, auth.RolesContextKey, []string{"admin", "operator"})
+	req = req.WithContext(ctx)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "admin,operator", capturedHeaders.Get("x-auth-roles"))
+}
+
+// TestMetadataPropagationMiddleware_APIKeyAuthenticated verifies that API key
+// authenticated requests propagate identity as lowercase gRPC metadata headers.
+func TestMetadataPropagationMiddleware_APIKeyAuthenticated(t *testing.T) {
+	var capturedHeaders http.Header
+
+	handler := metadataPropagationMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	ctx := context.WithValue(req.Context(), auth.APIKeyIdentityKey, "service-payment-processor")
+	req = req.WithContext(ctx)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "service-payment-processor", capturedHeaders.Get("x-user-id"))
+	assert.Equal(t, AuthMethodAPIKey, capturedHeaders.Get("x-auth-method"))
+	assert.Empty(t, capturedHeaders.Get("x-tenant-id"), "API key without tenant should not set x-tenant-id")
+}
+
+// TestMetadataPropagationMiddleware_APIKeyWithTenant verifies that API keys
+// with a resolved tenant ID propagate the tenant as gRPC metadata.
+func TestMetadataPropagationMiddleware_APIKeyWithTenant(t *testing.T) {
+	var capturedHeaders http.Header
+
+	handler := metadataPropagationMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	ctx := context.WithValue(req.Context(), auth.APIKeyIdentityKey, "service-a")
+	ctx = context.WithValue(ctx, auth.TenantIDContextKey, "tenant-001")
+	req = req.WithContext(ctx)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "service-a", capturedHeaders.Get("x-user-id"))
+	assert.Equal(t, AuthMethodAPIKey, capturedHeaders.Get("x-auth-method"))
+	assert.Equal(t, "tenant-001", capturedHeaders.Get("x-tenant-id"))
+}
+
+// TestMetadataPropagationMiddleware_SecurityStripsIncomingIdentityHeaders verifies
+// that spoofed identity headers are stripped before adding authenticated ones.
+func TestMetadataPropagationMiddleware_SecurityStripsIncomingIdentityHeaders(t *testing.T) {
+	var capturedHeaders http.Header
+
+	handler := metadataPropagationMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	// Attacker sends spoofed identity headers
+	req.Header.Set("x-user-id", "spoofed-admin")
+	req.Header.Set("x-tenant-id", "spoofed-tenant")
+	req.Header.Set("x-auth-method", "jwt")
+	req.Header.Set("x-auth-roles", "superadmin,root")
+	// No auth context — unauthenticated request
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	// All spoofed headers must be stripped
+	assert.Empty(t, capturedHeaders.Get("x-user-id"))
+	assert.Empty(t, capturedHeaders.Get("x-tenant-id"))
+	assert.Empty(t, capturedHeaders.Get("x-auth-method"))
+	assert.Empty(t, capturedHeaders.Get("x-auth-roles"))
+}
+
+// TestMetadataPropagationMiddleware_SecurityReplacesCanonicalSpoofedHeaders verifies
+// that canonical-case spoofed headers (X-User-ID) are also stripped.
+func TestMetadataPropagationMiddleware_SecurityReplacesCanonicalSpoofedHeaders(t *testing.T) {
+	var capturedHeaders http.Header
+
+	handler := metadataPropagationMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	// Client sends canonical-case spoofed headers
+	req.Header.Set(HeaderUserID, "spoofed-admin")
+	req.Header.Set(HeaderTenantID, "spoofed-tenant")
+	req.Header.Set(HeaderAuthMethod, "jwt")
+	req.Header.Set(HeaderAuthRoles, "superadmin")
+
+	// Real authenticated identity in context
+	ctx := context.WithValue(req.Context(), auth.UserIDContextKey, "real-user-789")
+	ctx = context.WithValue(ctx, auth.TenantIDContextKey, "real-tenant-def")
+	req = req.WithContext(ctx)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	// Real identity replaces spoofed headers
+	assert.Equal(t, "real-user-789", capturedHeaders.Get("x-user-id"))
+	assert.Equal(t, "real-tenant-def", capturedHeaders.Get("x-tenant-id"))
+	assert.Equal(t, AuthMethodJWT, capturedHeaders.Get("x-auth-method"))
+	// No roles set in context → no x-auth-roles
+	assert.Empty(t, capturedHeaders.Get("x-auth-roles"))
+}
+
+// TestMetadataPropagationMiddleware_SecurityStripsAPIKeyHeader verifies that
+// the raw API key header is stripped before forwarding to the backend.
+func TestMetadataPropagationMiddleware_SecurityStripsAPIKeyHeader(t *testing.T) {
+	var capturedHeaders http.Header
+
+	handler := metadataPropagationMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.Header.Set(auth.APIKeyHeader, "secret-api-key-value")
+	ctx := context.WithValue(req.Context(), auth.APIKeyIdentityKey, "service-b")
+	req = req.WithContext(ctx)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	// Raw API key credential must not leak to backend
+	assert.Empty(t, capturedHeaders.Get(auth.APIKeyHeader))
+	// But resolved identity must be present
+	assert.Equal(t, "service-b", capturedHeaders.Get("x-user-id"))
+}
+
+// TestMetadataPropagationMiddleware_Unauthenticated verifies that unauthenticated
+// requests receive no identity metadata headers.
+func TestMetadataPropagationMiddleware_Unauthenticated(t *testing.T) {
+	var capturedHeaders http.Header
+
+	handler := metadataPropagationMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	// No auth context
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Empty(t, capturedHeaders.Get("x-user-id"))
+	assert.Empty(t, capturedHeaders.Get("x-tenant-id"))
+	assert.Empty(t, capturedHeaders.Get("x-auth-method"))
+	assert.Empty(t, capturedHeaders.Get("x-auth-roles"))
+}
+
+// TestMetadataPropagationMiddleware_EmptyRolesNotPropagated verifies that an
+// empty roles slice does not result in an empty x-auth-roles metadata header.
+func TestMetadataPropagationMiddleware_EmptyRolesNotPropagated(t *testing.T) {
+	var capturedHeaders http.Header
+
+	handler := metadataPropagationMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	ctx := context.WithValue(req.Context(), auth.UserIDContextKey, "user-no-roles")
+	ctx = context.WithValue(ctx, auth.TenantIDContextKey, "tenant-abc")
+	ctx = context.WithValue(ctx, auth.RolesContextKey, []string{})
+	req = req.WithContext(ctx)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "user-no-roles", capturedHeaders.Get("x-user-id"))
+	assert.Empty(t, capturedHeaders.Get("x-auth-roles"), "empty roles slice should not set header")
+}
+
+// TestMetadataPropagationMiddleware_JWTPrioritizedOverAPIKey verifies that
+// when both JWT and API key identities are present, JWT takes precedence.
+func TestMetadataPropagationMiddleware_JWTPrioritizedOverAPIKey(t *testing.T) {
+	var capturedHeaders http.Header
+
+	handler := metadataPropagationMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	ctx := context.WithValue(req.Context(), auth.UserIDContextKey, "jwt-user")
+	ctx = context.WithValue(ctx, auth.TenantIDContextKey, "jwt-tenant")
+	ctx = context.WithValue(ctx, auth.APIKeyIdentityKey, "apikey-service")
+	req = req.WithContext(ctx)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "jwt-user", capturedHeaders.Get("x-user-id"))
+	assert.Equal(t, AuthMethodJWT, capturedHeaders.Get("x-auth-method"))
+	assert.Equal(t, "jwt-tenant", capturedHeaders.Get("x-tenant-id"))
+}

--- a/services/gateway/proxy.go
+++ b/services/gateway/proxy.go
@@ -137,30 +137,6 @@ func (h *ProxyHandler) RouteCount() int {
 	return len(h.routes)
 }
 
-// identityHeaderMiddleware is an HTTP middleware that strips client-supplied
-// identity headers and injects authenticated identity headers from the request
-// context set by the auth middleware.
-//
-// This provides the same security guarantee as the NewProxyHandler Director
-// for the Vanguard transcoder path: regardless of what a client sends, the
-// identity headers seen by backend services always reflect the gateway's
-// authentication result.
-func identityHeaderMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// SECURITY: Strip any incoming identity headers to prevent spoofing.
-		r.Header.Del(HeaderUserID)
-		r.Header.Del(HeaderTenantID)
-		r.Header.Del(HeaderAuthMethod)
-		r.Header.Del(HeaderAuthRoles)
-		r.Header.Del(auth.APIKeyHeader)
-
-		// Inject identity headers from the authenticated context.
-		addIdentityHeaders(r)
-
-		next.ServeHTTP(w, r)
-	})
-}
-
 // addIdentityHeaders extracts authenticated identity from request context
 // and adds the corresponding headers to the outgoing request.
 //

--- a/services/gateway/server.go
+++ b/services/gateway/server.go
@@ -116,16 +116,16 @@ func (s *Server) registerRoutes() {
 	// prefix-based reverse proxy when Backends are provided; otherwise use a
 	// placeholder that returns 501 Not Implemented.
 	//
-	// For the transcoder path, identityHeaderMiddleware wraps the handler to
+	// For the transcoder path, metadataPropagationMiddleware wraps the handler to
 	// strip spoofed incoming identity headers and inject authenticated identity
-	// headers from the request context (the same security pattern used by
-	// NewProxyHandler via its custom Director). This ensures backends always
-	// receive X-User-ID, X-Tenant-ID, X-Auth-Method, and X-Auth-Roles from
-	// the gateway's authentication result, never from the client.
+	// as lowercase gRPC metadata headers (x-user-id, x-tenant-id, x-auth-method,
+	// x-auth-roles). Vanguard forwards these headers to the gRPC backend where
+	// they are read as incoming metadata by the existing interceptor chain
+	// (TenantExtractionInterceptor reads x-tenant-id).
 	var apiHandler http.Handler
 	switch {
 	case s.transcoderHandler != nil:
-		apiHandler = identityHeaderMiddleware(s.transcoderHandler)
+		apiHandler = metadataPropagationMiddleware(s.transcoderHandler)
 	case len(s.config.Backends) > 0:
 		apiHandler = NewProxyHandler(s.config.Backends)
 	default:


### PR DESCRIPTION
## Summary

- Adds `metadataPropagationMiddleware` in `services/gateway/metadata.go` wrapping the Vanguard transcoder handler
- Strips incoming identity headers (`x-user-id`, `x-tenant-id`, `x-auth-method`, `x-auth-roles`, `X-API-Key`) to prevent client spoofing
- Reads authenticated identity from request context and writes lowercase gRPC metadata headers that Vanguard forwards to backends
- Removes the now-unused `identityHeaderMiddleware` from `proxy.go` (replaced by `metadataPropagationMiddleware` in the transcoder path)

## Changes Made

**`services/gateway/metadata.go`** (new):
- `metadataPropagationMiddleware(next http.Handler) http.Handler` — security strip + identity injection
- `writeIdentityMetadata(req *http.Request)` — reads auth context, writes lowercase gRPC metadata headers (`x-user-id`, `x-tenant-id`, `x-auth-method`, `x-auth-roles`)
- JWT takes precedence over API key when both context values are present

**`services/gateway/server.go`**:
- Transcoder path now uses `metadataPropagationMiddleware` instead of `identityHeaderMiddleware`
- Updated comment describes gRPC metadata key convention and how `TenantExtractionInterceptor` reads `x-tenant-id`

**`services/gateway/proxy.go`**:
- Removed `identityHeaderMiddleware` (now unused; functionality moved to `metadataPropagationMiddleware`)

## Technical Details

HTTP/2 gRPC normalises all header names to lowercase. When Vanguard transcodes a REST/JSON or Connect request to gRPC and forwards it via the backend reverse proxy, the backend gRPC server's `ServeHTTP` reads HTTP/2 headers as incoming `google.golang.org/grpc/metadata`. The existing `TenantExtractionInterceptor` reads `x-tenant-id` from this metadata to populate tenant context, so headers set by this middleware flow through the entire interceptor chain unchanged.

## Testing

- 10 unit tests covering JWT auth, API key auth (with and without tenant), spoofing prevention (lowercase and canonical-case headers), API key header stripping, unauthenticated requests, empty roles, and JWT-over-API-key priority
- All 100+ existing gateway tests continue to pass

## Risk Assessment

Low. The middleware performs the same strip-then-inject pattern as the removed `identityHeaderMiddleware`. The only behaviour change is using lowercase header names (e.g. `x-user-id` instead of `X-User-Id`), which are equivalent at the HTTP/2 wire level and are idiomatic for gRPC metadata.