### PR TITLE
feat: CurrentAccount migration to product_type_code

### DIFF
--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -161,6 +161,12 @@ message CurrentAccountFacility {
     pattern: "^[a-zA-Z0-9_-]*$"
     max_len: 100
   }];
+
+  // product_type_code is the account type code from the Product Directory (immutable after creation).
+  string product_type_code = 12;
+
+  // product_type_version is the pinned version of the product type definition (immutable after creation).
+  int32 product_type_version = 13;
 }
 
 // AccountBalance represents the current balance state of an account
@@ -346,6 +352,24 @@ message InitiateCurrentAccountRequest {
     pattern: "^[a-zA-Z0-9_-]*$"
     max_len: 100
   }];
+
+  // product_type_code references an account type definition in the Product Directory.
+  // When provided, the service resolves the product type via LocalAccountTypeCache,
+  // validates BehaviorClass == CUSTOMER, evaluates EligibilityCEL, validates attributes
+  // against AttributeSchema, and seeds ValuationFeatures from templates.
+  // During transition, if empty, the service falls back to base_currency-derived defaults.
+  string product_type_code = 5 [(buf.validate.field).string = {
+    max_len: 50
+    pattern: "^[A-Z0-9_]*$"
+  }];
+
+  // product_type_version pins a specific version of the product type definition.
+  // If not specified, the latest active version is used.
+  optional int32 product_type_version = 6;
+
+  // attributes contains optional key-value pairs validated against the product type's
+  // AttributeSchema (JSON Schema). Stored on the account for product-specific metadata.
+  map<string, string> attributes = 7;
 }
 
 // Response for initiating a current account

--- a/services/current-account/adapters/persistence/account_entity.go
+++ b/services/current-account/adapters/persistence/account_entity.go
@@ -31,6 +31,8 @@ type CurrentAccountEntity struct {
 	OrgPartyID            *uuid.UUID `gorm:"column:org_party_id;type:uuid"`             // NULL for personal accounts, set for org-scoped accounts
 	OverdraftLimit        int64      `gorm:"column:overdraft_limit;not null;default:0"` // in smallest currency unit
 	OverdraftRate         float64    `gorm:"column:overdraft_rate;type:numeric(5,4);not null;default:0"`
+	ProductTypeCode       *string    `gorm:"column:product_type_code;type:varchar(50)"` // NULL for legacy accounts
+	ProductTypeVersion    *int       `gorm:"column:product_type_version"`               // NULL for legacy accounts
 
 	// Balance fields - NOT persisted to database (gorm:"-"), but kept for in-memory use.
 	// Balance computation is delegated to Position Keeping service per BIAN architecture.

--- a/services/current-account/adapters/persistence/repository.go
+++ b/services/current-account/adapters/persistence/repository.go
@@ -482,6 +482,16 @@ func toEntity(ctx context.Context, account domain.CurrentAccount) (*CurrentAccou
 		freezeReason = &reason
 	}
 
+	// Map product type fields (nil if empty for backwards compatibility)
+	var productTypeCode *string
+	var productTypeVersion *int
+	if account.ProductTypeCode() != "" {
+		code := account.ProductTypeCode()
+		productTypeCode = &code
+		version := account.ProductTypeVersion()
+		productTypeVersion = &version
+	}
+
 	// ToMinorUnitsUnchecked is safe here: domain layer validates amounts before persistence,
 	// so overflow (>92 quadrillion cents) cannot occur for valid accounts
 	// Note: Balance fields are not persisted to DB (gorm:"-") but kept on entity for
@@ -497,6 +507,8 @@ func toEntity(ctx context.Context, account domain.CurrentAccount) (*CurrentAccou
 		OrgPartyID:            account.OrgPartyID(),
 		OverdraftLimit:        account.OverdraftLimit().ToMinorUnitsUnchecked(),
 		OverdraftRate:         account.OverdraftRate(),
+		ProductTypeCode:       productTypeCode,
+		ProductTypeVersion:    productTypeVersion,
 		Balance:               account.Balance().ToMinorUnitsUnchecked(),          // gorm:"-" - not persisted
 		AvailableBalance:      account.AvailableBalance().ToMinorUnitsUnchecked(), // gorm:"-" - not persisted
 		FreezeReason:          freezeReason,
@@ -560,6 +572,16 @@ func toDomain(entity *CurrentAccountEntity) (domain.CurrentAccount, error) {
 		freezeReason = *entity.FreezeReason
 	}
 
+	// Map product type fields (empty string / 0 if nil for domain model)
+	productTypeCode := ""
+	productTypeVersion := 0
+	if entity.ProductTypeCode != nil {
+		productTypeCode = *entity.ProductTypeCode
+	}
+	if entity.ProductTypeVersion != nil {
+		productTypeVersion = *entity.ProductTypeVersion
+	}
+
 	// Use builder pattern to construct immutable domain model
 	// Note: Balance comes from entity's in-memory fields (gorm:"-") if populated,
 	// otherwise zero. Service layer should fetch authoritative balance from Position Keeping.
@@ -581,6 +603,8 @@ func toDomain(entity *CurrentAccountEntity) (domain.CurrentAccount, error) {
 		WithVersion(entity.Version).
 		WithCreatedAt(entity.CreatedAt).
 		WithUpdatedAt(entity.UpdatedAt).
+		WithProductTypeCode(productTypeCode).
+		WithProductTypeVersion(productTypeVersion).
 		Build(), nil
 }
 

--- a/services/current-account/domain/account.go
+++ b/services/current-account/domain/account.go
@@ -73,6 +73,8 @@ type CurrentAccount struct {
 	version               int64
 	createdAt             time.Time
 	updatedAt             time.Time
+	productTypeCode       string // Immutable after creation - references Product Directory
+	productTypeVersion    int    // Immutable after creation - pinned version
 }
 
 // AccountOption is a functional option for configuring new account creation.
@@ -83,6 +85,14 @@ func WithOrgPartyID(orgPartyID uuid.UUID) AccountOption {
 	return func(a *CurrentAccount) {
 		id := orgPartyID
 		a.orgPartyID = &id
+	}
+}
+
+// WithProductType sets the product type code and version (immutable after creation).
+func WithProductType(code string, version int) AccountOption {
+	return func(a *CurrentAccount) {
+		a.productTypeCode = code
+		a.productTypeVersion = version
 	}
 }
 
@@ -174,6 +184,8 @@ func (a CurrentAccount) Deposit(amount Money) (CurrentAccount, error) {
 		version:               a.version + 1,
 		createdAt:             a.createdAt,
 		updatedAt:             now,
+		productTypeCode:       a.productTypeCode,
+		productTypeVersion:    a.productTypeVersion,
 	}, nil
 }
 
@@ -211,6 +223,8 @@ func (a CurrentAccount) PrepareForCredit() (CurrentAccount, error) {
 		version:               a.version + 1, // Version incremented for optimistic locking
 		createdAt:             a.createdAt,
 		updatedAt:             now,
+		productTypeCode:       a.productTypeCode,
+		productTypeVersion:    a.productTypeVersion,
 	}, nil
 }
 
@@ -263,6 +277,8 @@ func (a CurrentAccount) PrepareForDebit(amount Money) (CurrentAccount, error) {
 		version:               a.version + 1, // Version incremented for optimistic locking
 		createdAt:             a.createdAt,
 		updatedAt:             now,
+		productTypeCode:       a.productTypeCode,
+		productTypeVersion:    a.productTypeVersion,
 	}, nil
 }
 
@@ -321,6 +337,8 @@ func (a CurrentAccount) Withdraw(amount Money) (CurrentAccount, error) {
 		version:               a.version + 1,
 		createdAt:             a.createdAt,
 		updatedAt:             now,
+		productTypeCode:       a.productTypeCode,
+		productTypeVersion:    a.productTypeVersion,
 	}, nil
 }
 
@@ -390,6 +408,8 @@ func (a CurrentAccount) withStatusChange(newStatus AccountStatus, reason string)
 		version:               a.version + 1,
 		createdAt:             a.createdAt,
 		updatedAt:             now,
+		productTypeCode:       a.productTypeCode,
+		productTypeVersion:    a.productTypeVersion,
 	}
 }
 
@@ -517,6 +537,8 @@ func (a CurrentAccount) SetOverdraftLimit(limit Money, rate float64, enabled boo
 		version:               a.version + 1,
 		createdAt:             a.createdAt,
 		updatedAt:             time.Now(),
+		productTypeCode:       a.productTypeCode,
+		productTypeVersion:    a.productTypeVersion,
 	}, nil
 }
 
@@ -586,6 +608,12 @@ func (a CurrentAccount) CreatedAt() time.Time { return a.createdAt }
 
 // UpdatedAt returns when the account was last updated.
 func (a CurrentAccount) UpdatedAt() time.Time { return a.updatedAt }
+
+// ProductTypeCode returns the product type code from the Product Directory.
+func (a CurrentAccount) ProductTypeCode() string { return a.productTypeCode }
+
+// ProductTypeVersion returns the pinned product type version.
+func (a CurrentAccount) ProductTypeVersion() int { return a.productTypeVersion }
 
 // Builder pattern for reconstructing accounts from persistence layer.
 // This is needed because the persistence layer needs to set all fields
@@ -701,6 +729,18 @@ func (b *CurrentAccountBuilder) WithCreatedAt(t time.Time) *CurrentAccountBuilde
 // WithUpdatedAt sets when the account was last updated.
 func (b *CurrentAccountBuilder) WithUpdatedAt(t time.Time) *CurrentAccountBuilder {
 	b.account.updatedAt = t
+	return b
+}
+
+// WithProductTypeCode sets the product type code.
+func (b *CurrentAccountBuilder) WithProductTypeCode(code string) *CurrentAccountBuilder {
+	b.account.productTypeCode = code
+	return b
+}
+
+// WithProductTypeVersion sets the product type version.
+func (b *CurrentAccountBuilder) WithProductTypeVersion(version int) *CurrentAccountBuilder {
+	b.account.productTypeVersion = version
 	return b
 }
 

--- a/services/current-account/migrations/20260220000001_add_product_type_columns.sql
+++ b/services/current-account/migrations/20260220000001_add_product_type_columns.sql
@@ -1,0 +1,6 @@
+-- Add product_type_code and product_type_version to account table.
+-- These are immutable after account creation and reference the Product Directory.
+-- NULL during transition period for accounts created before product type migration.
+
+ALTER TABLE "account" ADD COLUMN "product_type_code" VARCHAR(50) NULL;
+ALTER TABLE "account" ADD COLUMN "product_type_version" INT NULL;

--- a/services/current-account/migrations/20260220000002_add_product_type_index.sql
+++ b/services/current-account/migrations/20260220000002_add_product_type_index.sql
@@ -1,0 +1,5 @@
+-- Index on product_type_code for querying accounts by product type.
+-- Separate migration from column addition per CockroachDB requirement:
+-- columns must be "public" before being referenced in indexes.
+
+CREATE INDEX "idx_account_product_type_code" ON "account" ("product_type_code");

--- a/services/current-account/migrations/atlas.sum
+++ b/services/current-account/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:9YXznqaPmfL5olkjNL573OqFN5leX2nR3CKaMRmvH1Y=
+h1:IE6VEc7Hdkr+JDlt/7m9Co3FDCHpiR8A+xixoAHnUpE=
 20251216000001_initial.sql h1:nyRf35O3eYNJqShAvOEhvliXKLIR6e/V8B9JhOHde9w=
 20251216000002_audit_system.sql h1:X/0ZHt9cGTYmFbUUvKAkBgEiGw9fYEqfnbMB8I4SCR8=
 20251217000001_fix_audit_status_constraint.sql h1:yQxsHxbUp5g+ehkKFjOhZs59SbfaQIPw4/sA2xE2rwU=
@@ -13,3 +13,5 @@ h1:9YXznqaPmfL5olkjNL573OqFN5leX2nR3CKaMRmvH1Y=
 20260206000003_add_lien_valuation_fields.sql h1:j1n+Fi0GhHa8oLPrl4NRB0TkdeCpS8hE7y3PB2SIhWg=
 20260214000001_add_org_party_id.sql h1:sbqizFbesVkTKaJ18+Ztt+qr7Fvdp/9oeYMWIIe4kyI=
 20260214000002_add_org_scoping_indexes.sql h1:p2lT9KnjRIgMJ2Pf5YzKtnnw86a9Jylu+r7n9ejDp3A=
+20260220000001_add_product_type_columns.sql h1:s8eMBKruWtNsWaUiok598RebucwW5s4RcjDXQ3sovXM=
+20260220000002_add_product_type_index.sql h1:jPsYaxj4polHDAY2QweDbChuyBzYrH16ZQtcLhgbyXM=

--- a/services/current-account/service/account_control_integration_test.go
+++ b/services/current-account/service/account_control_integration_test.go
@@ -54,6 +54,8 @@ func setupControlTestDB(t *testing.T) (*persistence.Repository, *persistence.Lie
 		closed_at TIMESTAMP WITH TIME ZONE,
 		freeze_reason VARCHAR(1000),
 		status_history JSONB NOT NULL DEFAULT '[]'::jsonb,
+		product_type_code VARCHAR(50) NULL,
+		product_type_version INT NULL,
 		version BIGINT NOT NULL DEFAULT 1,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
 		created_by VARCHAR(100) NOT NULL DEFAULT 'test',

--- a/services/current-account/service/grpc_account_endpoints.go
+++ b/services/current-account/service/grpc_account_endpoints.go
@@ -280,7 +280,7 @@ func (s *Service) seedValuationFeatures(ctx context.Context, accountID uuid.UUID
 			tmpl.InputInstrument,
 			tmpl.ValuationMethodID,
 			tmpl.ValuationMethodVersion,
-			nil, // No initial parameters from template
+			tmpl.Parameters,
 			"system",
 		)
 		if err != nil {

--- a/services/current-account/service/grpc_account_endpoints.go
+++ b/services/current-account/service/grpc_account_endpoints.go
@@ -118,7 +118,15 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 		}
 
 		// Evaluate CEL eligibility if an eligibility program is configured
-		if cachedType.EligibilityProgram != nil && s.partyClient != nil {
+		if cachedType.EligibilityProgram != nil {
+			if s.partyClient == nil {
+				operationStatus = "eligibility_unavailable"
+				s.logger.Error("party client not configured but eligibility program requires it",
+					"product_type_code", req.ProductTypeCode,
+					"party_id", req.PartyId,
+					"account_id", accountID)
+				return nil, status.Error(codes.FailedPrecondition, "party service is required for eligibility checks")
+			}
 			eligible, eligErr := s.evaluateEligibility(ctx, cachedType, req.PartyId, req.Attributes)
 			if eligErr != nil {
 				operationStatus = "eligibility_check_failed"
@@ -154,10 +162,19 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 			}
 		}
 
-		// Determine version: use requested version or latest from definition
+		// Determine version: use requested version or latest from definition.
+		// When a specific version is requested, validate it does not exceed the
+		// latest known version since the cache only holds the latest definition.
 		version := cachedType.Definition.Version
 		if req.ProductTypeVersion != nil {
-			version = int(*req.ProductTypeVersion)
+			requested := int(*req.ProductTypeVersion)
+			if requested > cachedType.Definition.Version {
+				operationStatus = "invalid_version"
+				return nil, status.Errorf(codes.InvalidArgument,
+					"requested version %d exceeds latest version %d for product type %s",
+					requested, cachedType.Definition.Version, req.ProductTypeCode)
+			}
+			version = requested
 		}
 
 		opts = append(opts, domain.WithProductType(req.ProductTypeCode, version))

--- a/services/current-account/service/grpc_account_endpoints.go
+++ b/services/current-account/service/grpc_account_endpoints.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -11,11 +13,20 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+	celutil "github.com/meridianhub/meridian/services/reference-data/cel"
+	vf "github.com/meridianhub/meridian/shared/pkg/valuationfeature"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-// InitiateCurrentAccount creates a new current account facility
+// InitiateCurrentAccount creates a new current account facility.
+// When product_type_code is provided, the account type definition is resolved from the
+// Product Directory, BehaviorClass is validated as CUSTOMER, CEL eligibility is evaluated
+// with party context, attributes are validated against the JSON Schema, and ValuationFeatures
+// are seeded from the product type templates.
+// When product_type_code is empty, backwards-compatible behavior is used (legacy path).
 func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCurrentAccountRequest) (*pb.InitiateCurrentAccountResponse, error) {
 	start := time.Now()
 	operationStatus := operationStatusSuccess
@@ -72,12 +83,98 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 			"account_id", accountID)
 	}
 
-	// Create domain model (now returns value, not pointer)
+	// Resolve product type if provided
+	var opts []domain.AccountOption
+	var cachedType *CachedAccountType
+
+	if req.ProductTypeCode != "" && s.accountTypeCache != nil {
+		tenantID, ok := tenant.FromContext(ctx)
+		if !ok {
+			operationStatus = "missing_tenant"
+			return nil, status.Error(codes.FailedPrecondition, "tenant context is required for product type resolution")
+		}
+
+		var err error
+		cachedType, err = s.accountTypeCache.GetOrLoad(ctx, tenantID, req.ProductTypeCode)
+		if err != nil {
+			operationStatus = "product_type_not_found"
+			s.logger.Warn("product type resolution failed",
+				"product_type_code", req.ProductTypeCode,
+				"account_id", accountID,
+				"error", err)
+			return nil, status.Errorf(codes.InvalidArgument, "product type not found: %s", req.ProductTypeCode)
+		}
+
+		// Gate: BehaviorClass must be CUSTOMER for current accounts
+		if cachedType.Definition.BehaviorClass != accounttype.BehaviorClassCustomer {
+			operationStatus = "invalid_behavior_class"
+			s.logger.Warn("product type has non-CUSTOMER behavior class",
+				"product_type_code", req.ProductTypeCode,
+				"behavior_class", cachedType.Definition.BehaviorClass,
+				"account_id", accountID)
+			return nil, status.Errorf(codes.InvalidArgument,
+				"product type %s has behavior class %s, expected CUSTOMER",
+				req.ProductTypeCode, cachedType.Definition.BehaviorClass)
+		}
+
+		// Evaluate CEL eligibility if an eligibility program is configured
+		if cachedType.EligibilityProgram != nil && s.partyClient != nil {
+			eligible, eligErr := s.evaluateEligibility(ctx, cachedType, req.PartyId, req.Attributes)
+			if eligErr != nil {
+				operationStatus = "eligibility_check_failed"
+				s.logger.Error("eligibility evaluation failed",
+					"product_type_code", req.ProductTypeCode,
+					"party_id", req.PartyId,
+					"account_id", accountID,
+					"error", eligErr)
+				return nil, status.Errorf(codes.Internal, "eligibility check failed: %v", eligErr)
+			}
+			if !eligible {
+				operationStatus = "party_not_eligible"
+				s.logger.Warn("party not eligible for product type",
+					"product_type_code", req.ProductTypeCode,
+					"party_id", req.PartyId,
+					"account_id", accountID)
+				return nil, status.Errorf(codes.FailedPrecondition,
+					"party %s is not eligible for product type %s", req.PartyId, req.ProductTypeCode)
+			}
+		}
+
+		// Validate attributes against JSON Schema if schema is defined.
+		// Always validate when a schema exists - this catches missing required fields
+		// even when no attributes are provided.
+		if cachedType.CompiledSchema != nil {
+			attrs := req.Attributes
+			if attrs == nil {
+				attrs = map[string]string{}
+			}
+			if err := validateAttributes(cachedType.CompiledSchema, attrs); err != nil {
+				operationStatus = "invalid_attributes"
+				return nil, status.Errorf(codes.InvalidArgument, "attribute validation failed: %v", err)
+			}
+		}
+
+		// Determine version: use requested version or latest from definition
+		version := cachedType.Definition.Version
+		if req.ProductTypeVersion != nil {
+			version = int(*req.ProductTypeVersion)
+		}
+
+		opts = append(opts, domain.WithProductType(req.ProductTypeCode, version))
+
+		s.logger.Info("product type resolved for account creation",
+			"product_type_code", req.ProductTypeCode,
+			"product_type_version", version,
+			"account_id", accountID)
+	}
+
+	// Create domain model
 	account, err := domain.NewCurrentAccount(
 		accountID,
 		req.AccountIdentification,
 		req.PartyId,
 		currency,
+		opts...,
 	)
 	if err != nil {
 		operationStatus = "domain_error"
@@ -90,6 +187,17 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 		return nil, status.Errorf(codes.Internal, "failed to create account: %v", err)
 	}
 
+	// Seed ValuationFeatures from product type templates (best-effort after account creation)
+	if cachedType != nil && len(cachedType.Definition.ValuationMethods) > 0 && s.valuationFeatureRepo != nil {
+		if err := s.seedValuationFeatures(ctx, account.ID(), cachedType.Definition.ValuationMethods); err != nil {
+			// Log but do not fail account creation - VF seeding is best-effort
+			s.logger.Error("failed to seed valuation features",
+				"account_id", accountID,
+				"product_type_code", req.ProductTypeCode,
+				"error", err)
+		}
+	}
+
 	// Record initial balance
 	caobservability.RecordBalance(safeMinorUnits(account.Balance()), currency)
 
@@ -98,6 +206,86 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 		AccountId: accountID,
 		Facility:  toProtoFacility(account),
 	}, nil
+}
+
+// evaluateEligibility retrieves party details and evaluates the CEL eligibility expression.
+func (s *Service) evaluateEligibility(ctx context.Context, cachedType *CachedAccountType, partyID string, attributes map[string]string) (bool, error) {
+	party, err := s.partyClient.GetParty(ctx, partyID)
+	if err != nil {
+		return false, fmt.Errorf("failed to retrieve party for eligibility: %w", err)
+	}
+
+	// Map proto enum values to the string keys expected by CEL expressions.
+	// Proto enums use names like "PARTY_TYPE_PERSON" - strip prefix for CEL.
+	partyType := stripEnumPrefix(party.GetPartyType().String(), "PARTY_TYPE_")
+	partyStatus := stripEnumPrefix(party.GetStatus().String(), "PARTY_STATUS_")
+	extRefType := stripEnumPrefix(party.GetExternalReferenceType().String(), "EXTERNAL_REFERENCE_TYPE_")
+
+	return celutil.EvalEligibility(cachedType.EligibilityProgram, partyType, partyStatus, extRefType, attributes)
+}
+
+// stripEnumPrefix removes the proto enum prefix to produce CEL-friendly values.
+// Example: "PARTY_TYPE_PERSON" -> "PERSON", "PARTY_STATUS_ACTIVE" -> "ACTIVE"
+func stripEnumPrefix(value, prefix string) string {
+	return strings.TrimPrefix(value, prefix)
+}
+
+// validateAttributes validates the request attributes against the compiled JSON Schema.
+func validateAttributes(compiledSchema interface{ Validate(interface{}) error }, attributes map[string]string) error {
+	// Convert map[string]string to map[string]interface{} for JSON Schema validation
+	attrMap := make(map[string]interface{}, len(attributes))
+	for k, v := range attributes {
+		attrMap[k] = v
+	}
+
+	// JSON Schema validators expect deserialized JSON (map[string]interface{}).
+	// Round-trip through JSON to ensure proper types.
+	raw, err := json.Marshal(attrMap)
+	if err != nil {
+		return fmt.Errorf("failed to marshal attributes: %w", err)
+	}
+
+	var parsed interface{}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return fmt.Errorf("failed to unmarshal attributes: %w", err)
+	}
+
+	return compiledSchema.Validate(parsed)
+}
+
+// seedValuationFeatures creates ValuationFeature records from product type templates.
+// Each template maps an input instrument to a valuation method.
+// Features are created in INITIATED status and immediately activated.
+func (s *Service) seedValuationFeatures(ctx context.Context, accountID uuid.UUID, templates []accounttype.ValuationMethodTemplate) error {
+	for _, tmpl := range templates {
+		feature, err := vf.NewValuationFeature(
+			accountID,
+			tmpl.InputInstrument,
+			tmpl.ValuationMethodID,
+			tmpl.ValuationMethodVersion,
+			nil, // No initial parameters from template
+			"system",
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create valuation feature for instrument %s: %w", tmpl.InputInstrument, err)
+		}
+
+		// Activate immediately for newly seeded features
+		if err := feature.Activate("system"); err != nil {
+			return fmt.Errorf("failed to activate valuation feature for instrument %s: %w", tmpl.InputInstrument, err)
+		}
+
+		if err := s.valuationFeatureRepo.Create(ctx, feature); err != nil {
+			return fmt.Errorf("failed to persist valuation feature for instrument %s: %w", tmpl.InputInstrument, err)
+		}
+
+		s.logger.Info("seeded valuation feature",
+			"account_id", accountID,
+			"instrument_code", tmpl.InputInstrument,
+			"valuation_method_id", tmpl.ValuationMethodID,
+			"valuation_method_version", tmpl.ValuationMethodVersion)
+	}
+	return nil
 }
 
 // RetrieveCurrentAccount gets current account details including balance from Position Keeping.

--- a/services/current-account/service/grpc_mappers.go
+++ b/services/current-account/service/grpc_mappers.go
@@ -39,6 +39,9 @@ func toProtoFacility(account domain.CurrentAccount) *pb.CurrentAccountFacility {
 			IsEnabled:      account.OverdraftEnabled(),
 			LastUpdated:    timestamppb.New(time.Now()),
 		},
+		ProductTypeCode: account.ProductTypeCode(),
+		// #nosec G115 - ProductTypeVersion is bounded by database constraints
+		ProductTypeVersion: int32(account.ProductTypeVersion()),
 	}
 }
 

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -9,14 +9,19 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/google/cel-go/cel"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/config"
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
 	"github.com/meridianhub/meridian/shared/platform/events"
 	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/protobuf/proto"
 	"gorm.io/gorm"
 )
@@ -121,6 +126,66 @@ func (p *NoOpAccountEventPublisher) PublishWithTenant(_ context.Context, _, _ st
 	return nil
 }
 
+// CachedAccountType holds a resolved product type definition with precompiled programs.
+// This mirrors the fields from cache.CachedAccountType that the service needs.
+type CachedAccountType struct {
+	Definition         *accounttype.Definition
+	EligibilityProgram cel.Program
+	CompiledSchema     *jsonschema.Schema
+}
+
+// AccountTypeCache defines the interface for resolving product type definitions.
+// Implemented by cache.LocalAccountTypeCache (via an adapter).
+type AccountTypeCache interface {
+	GetOrLoad(ctx context.Context, tenantID tenant.TenantID, code string) (*CachedAccountType, error)
+}
+
+// Option is a functional option for configuring optional Service dependencies.
+type Option func(*Service)
+
+// WithAccountTypeCache sets the account type cache for product type resolution.
+func WithAccountTypeCache(cache AccountTypeCache) Option {
+	return func(s *Service) {
+		s.accountTypeCache = cache
+	}
+}
+
+// WithValuationFeatureRepo sets the valuation feature repository for VF seeding.
+func WithValuationFeatureRepo(repo *persistence.ValuationFeatureRepository) Option {
+	return func(s *Service) {
+		s.valuationFeatureRepo = repo
+	}
+}
+
+// WithValuationEngine sets the valuation engine for executing valuation logic.
+func WithValuationEngine(engine ValuationEngine) Option {
+	return func(s *Service) {
+		s.valuationEngine = engine
+	}
+}
+
+// WithEventPublisher sets the event publisher for lifecycle events.
+func WithEventPublisher(publisher AccountEventPublisher) Option {
+	return func(s *Service) {
+		s.eventPublisher = publisher
+	}
+}
+
+// WithWebhookNotifier sets the webhook notifier for lifecycle events.
+func WithWebhookNotifier(notifier WebhookNotifier) Option {
+	return func(s *Service) {
+		s.webhookNotifier = notifier
+	}
+}
+
+// ApplyOptions applies functional options to the service.
+// This allows optional dependencies to be set after construction.
+func (s *Service) ApplyOptions(opts ...Option) {
+	for _, opt := range opts {
+		opt(s)
+	}
+}
+
 // Service implements the CurrentAccountService gRPC service
 type Service struct {
 	pb.UnimplementedCurrentAccountServiceServer
@@ -133,7 +198,8 @@ type Service struct {
 	posKeepingClient       PositionKeepingClient
 	finAcctClient          FinancialAccountingClient
 	partyClient            PartyClient
-	valuationEngine        ValuationEngine // Optional: executes valuation method logic
+	accountTypeCache       AccountTypeCache // Optional: resolves product type definitions
+	valuationEngine        ValuationEngine  // Optional: executes valuation method logic
 	accountConfig          *config.AccountConfig
 	idempotencyService     idempotency.Service
 	eventPublisher         AccountEventPublisher // Optional: publishes lifecycle events to Kafka

--- a/services/current-account/service/grpc_service_party_integration_test.go
+++ b/services/current-account/service/grpc_service_party_integration_test.go
@@ -37,18 +37,20 @@ var (
 
 // mockPartyClient implements clients.PartyClient for testing
 type mockPartyClient struct {
-	mu              sync.Mutex
-	validateCalls   int
-	getCalls        int
-	validateError   error
-	getError        error
-	partyStatus     partyv1.PartyStatus
-	partyExists     bool
-	simulateTimeout bool
-	timeoutDuration time.Duration
-	closeCalls      int
-	lastValidatedID string
-	lastRetrievedID string
+	mu                sync.Mutex
+	validateCalls     int
+	getCalls          int
+	validateError     error
+	getError          error
+	partyStatus       partyv1.PartyStatus
+	partyTypeOverride partyv1.PartyType // Override party type in GetParty response
+	extRefType        partyv1.ExternalReferenceType
+	partyExists       bool
+	simulateTimeout   bool
+	timeoutDuration   time.Duration
+	closeCalls        int
+	lastValidatedID   string
+	lastRetrievedID   string
 }
 
 func (m *mockPartyClient) ValidateParty(ctx context.Context, partyID string) error {
@@ -94,6 +96,8 @@ func (m *mockPartyClient) GetParty(_ context.Context, partyID string) (*partyv1.
 	getError := m.getError
 	partyExists := m.partyExists
 	partyStatus := m.partyStatus
+	partyType := m.partyTypeOverride
+	extRefType := m.extRefType
 	m.mu.Unlock()
 
 	if getError != nil {
@@ -105,9 +109,11 @@ func (m *mockPartyClient) GetParty(_ context.Context, partyID string) (*partyv1.
 	}
 
 	return &partyv1.Party{
-		PartyId:   partyID,
-		LegalName: "Test Party",
-		Status:    partyStatus,
+		PartyId:               partyID,
+		LegalName:             "Test Party",
+		PartyType:             partyType,
+		Status:                partyStatus,
+		ExternalReferenceType: extRefType,
 	}, nil
 }
 

--- a/services/current-account/service/grpc_service_product_type_test.go
+++ b/services/current-account/service/grpc_service_product_type_test.go
@@ -675,6 +675,7 @@ func TestInitiateCurrentAccount_WithProductType_ValuationFeatureSeeding(t *testi
 			ValuationMethodID:      methodID,
 			ValuationMethodVersion: 1,
 			Status:                 accounttype.StatusActive,
+			Parameters:             map[string]any{"source": "ECB", "frequency": "daily"},
 		},
 		{
 			ID:                     uuid.New(),
@@ -683,6 +684,7 @@ func TestInitiateCurrentAccount_WithProductType_ValuationFeatureSeeding(t *testi
 			ValuationMethodID:      methodID,
 			ValuationMethodVersion: 1,
 			Status:                 accounttype.StatusActive,
+			Parameters:             map[string]any{"source": "ECB", "frequency": "daily"},
 		},
 	}
 
@@ -726,13 +728,15 @@ func TestInitiateCurrentAccount_WithProductType_ValuationFeatureSeeding(t *testi
 	require.NoError(t, err)
 	assert.Len(t, features, 2, "Should have seeded 2 valuation features")
 
-	// Verify instruments
+	// Verify instruments and parameters
 	instruments := make(map[string]bool)
 	for _, f := range features {
 		instruments[f.InstrumentCode] = true
 		assert.Equal(t, methodID, f.ValuationMethodID)
 		assert.Equal(t, 1, f.ValuationMethodVersion)
 		assert.True(t, f.IsActive(), "Seeded features should be ACTIVE")
+		assert.Equal(t, "ECB", f.Parameters["source"], "Template parameters should be propagated")
+		assert.Equal(t, "daily", f.Parameters["frequency"], "Template parameters should be propagated")
 	}
 	assert.True(t, instruments["USD"], "Should have USD feature")
 	assert.True(t, instruments["EUR"], "Should have EUR feature")

--- a/services/current-account/service/grpc_service_product_type_test.go
+++ b/services/current-account/service/grpc_service_product_type_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"testing"
@@ -81,7 +82,7 @@ type jsonStringReader struct {
 
 func (r *jsonStringReader) Read(p []byte) (n int, err error) {
 	if r.i >= len(r.s) {
-		return 0, fmt.Errorf("EOF")
+		return 0, io.EOF
 	}
 	n = copy(p, r.s[r.i:])
 	r.i += n
@@ -408,6 +409,97 @@ func TestInitiateCurrentAccount_WithProductType_CELEligibility(t *testing.T) {
 		assert.Equal(t, codes.FailedPrecondition, st.Code())
 		assert.Contains(t, st.Message(), "not eligible")
 	})
+}
+
+// TestInitiateCurrentAccount_WithProductType_EligibilityRequiresPartyClient verifies
+// that account creation fails fast when an eligibility program is configured but
+// the party client is not available.
+func TestInitiateCurrentAccount_WithProductType_EligibilityRequiresPartyClient(t *testing.T) {
+	db, ctx, cleanup := setupProductTypeTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+
+	prg := compileTestEligibilityProgram(t, `party.type == "PERSON"`)
+
+	def := newTestDefinition("PERSONAL_CURRENT", accounttype.BehaviorClassCustomer)
+	def.EligibilityCEL = `party.type == "PERSON"`
+	cache := &mockAccountTypeCache{
+		entries: map[string]*CachedAccountType{
+			"PERSONAL_CURRENT": {
+				Definition:         def,
+				EligibilityProgram: prg,
+			},
+		},
+	}
+
+	svc := &Service{
+		repo:             repo,
+		partyClient:      nil, // No party client configured
+		accountTypeCache: cache,
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	req := &pb.InitiateCurrentAccountRequest{
+		AccountIdentification: "GB82WEST12345698765432",
+		PartyId:               newTestPartyID(),
+		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+		ProductTypeCode:       "PERSONAL_CURRENT",
+	}
+	resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "party service is required")
+}
+
+// TestInitiateCurrentAccount_WithProductType_VersionExceedsLatest verifies
+// that requesting a version higher than the latest cached version is rejected.
+func TestInitiateCurrentAccount_WithProductType_VersionExceedsLatest(t *testing.T) {
+	db, ctx, cleanup := setupProductTypeTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+
+	def := newTestDefinition("CURRENT_GBP", accounttype.BehaviorClassCustomer)
+	def.Version = 3 // latest version is 3
+	cache := &mockAccountTypeCache{
+		entries: map[string]*CachedAccountType{
+			"CURRENT_GBP": {Definition: def},
+		},
+	}
+
+	mockParty := &mockPartyClient{
+		partyExists: true,
+		partyStatus: partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+	}
+
+	svc := &Service{
+		repo:             repo,
+		partyClient:      mockParty,
+		accountTypeCache: cache,
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	requestedVersion := int32(5) // higher than latest version 3
+	req := &pb.InitiateCurrentAccountRequest{
+		AccountIdentification: "GB82WEST12345698765432",
+		PartyId:               newTestPartyID(),
+		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+		ProductTypeCode:       "CURRENT_GBP",
+		ProductTypeVersion:    &requestedVersion,
+	}
+	resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "exceeds latest version")
 }
 
 // TestInitiateCurrentAccount_WithProductType_AttributeValidation verifies

--- a/services/current-account/service/grpc_service_product_type_test.go
+++ b/services/current-account/service/grpc_service_product_type_test.go
@@ -1,0 +1,793 @@
+// Package service provides integration tests for Product Type validation
+// during account creation in the CurrentAccount service.
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+	celutil "github.com/meridianhub/meridian/services/reference-data/cel"
+	vf "github.com/meridianhub/meridian/shared/pkg/valuationfeature"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+// mockAccountTypeCache implements AccountTypeCache for testing
+type mockAccountTypeCache struct {
+	entries map[string]*CachedAccountType
+	err     error
+}
+
+func (m *mockAccountTypeCache) GetOrLoad(_ context.Context, _ tenant.TenantID, code string) (*CachedAccountType, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	entry, ok := m.entries[code]
+	if !ok {
+		return nil, fmt.Errorf("account type %s not found", code)
+	}
+	return entry, nil
+}
+
+// compileTestEligibilityProgram compiles a CEL eligibility expression for testing.
+func compileTestEligibilityProgram(t *testing.T, expression string) cel.Program {
+	t.Helper()
+	compiler, err := celutil.NewCompiler()
+	require.NoError(t, err)
+	prg, err := compiler.CompileEligibility(expression)
+	require.NoError(t, err)
+	return prg
+}
+
+// compileTestSchema compiles a JSON Schema for testing.
+func compileTestSchema(t *testing.T, schemaJSON string) *jsonschema.Schema {
+	t.Helper()
+	compiler := jsonschema.NewCompiler()
+	err := compiler.AddResource("schema.json", jsonReader(schemaJSON))
+	require.NoError(t, err)
+	schema, err := compiler.Compile("schema.json")
+	require.NoError(t, err)
+	return schema
+}
+
+func jsonReader(s string) *jsonStringReader {
+	return &jsonStringReader{s: s, i: 0}
+}
+
+type jsonStringReader struct {
+	s string
+	i int
+}
+
+func (r *jsonStringReader) Read(p []byte) (n int, err error) {
+	if r.i >= len(r.s) {
+		return 0, fmt.Errorf("EOF")
+	}
+	n = copy(p, r.s[r.i:])
+	r.i += n
+	return n, nil
+}
+
+const productTypeTestTenantID = "test_product_type_tenant"
+
+func setupProductTypeTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
+	t.Helper()
+	db, cleanup := testdb.SetupPostgres(t, []interface{}{
+		&persistence.CurrentAccountEntity{},
+		&vf.Entity{},
+	})
+
+	tid := tenant.TenantID(productTypeTestTenantID)
+	schemaName := tid.SchemaName()
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// AutoMigrate tables in tenant schema
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	err = db.AutoMigrate(&persistence.CurrentAccountEntity{}, &vf.Entity{})
+	require.NoError(t, err)
+
+	ctx := tenant.WithTenant(context.Background(), tid)
+	return db, ctx, cleanup
+}
+
+func newTestDefinition(code string, behaviorClass accounttype.BehaviorClass) *accounttype.Definition {
+	return &accounttype.Definition{
+		ID:             uuid.New(),
+		Code:           code,
+		Version:        1,
+		DisplayName:    "Test " + code,
+		BehaviorClass:  behaviorClass,
+		InstrumentCode: "GBP",
+		Status:         accounttype.StatusActive,
+	}
+}
+
+// --- Test Cases ---
+
+// TestInitiateCurrentAccount_WithProductType_Success verifies account creation
+// with a valid CUSTOMER product type code.
+func TestInitiateCurrentAccount_WithProductType_Success(t *testing.T) {
+	db, ctx, cleanup := setupProductTypeTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+
+	def := newTestDefinition("CURRENT_GBP", accounttype.BehaviorClassCustomer)
+	cache := &mockAccountTypeCache{
+		entries: map[string]*CachedAccountType{
+			"CURRENT_GBP": {Definition: def},
+		},
+	}
+
+	mockParty := &mockPartyClient{
+		partyExists: true,
+		partyStatus: partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+	}
+
+	svc := &Service{
+		repo:             repo,
+		partyClient:      mockParty,
+		accountTypeCache: cache,
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	req := &pb.InitiateCurrentAccountRequest{
+		AccountIdentification: "GB82WEST12345698765432",
+		PartyId:               newTestPartyID(),
+		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+		ProductTypeCode:       "CURRENT_GBP",
+	}
+	resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.AccountId)
+	assert.Equal(t, "CURRENT_GBP", resp.Facility.ProductTypeCode)
+	assert.Equal(t, int32(1), resp.Facility.ProductTypeVersion)
+}
+
+// TestInitiateCurrentAccount_WithProductType_VersionOverride verifies that
+// the requested product_type_version overrides the latest version.
+func TestInitiateCurrentAccount_WithProductType_VersionOverride(t *testing.T) {
+	db, ctx, cleanup := setupProductTypeTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+
+	def := newTestDefinition("CURRENT_GBP", accounttype.BehaviorClassCustomer)
+	def.Version = 3 // latest version is 3
+	cache := &mockAccountTypeCache{
+		entries: map[string]*CachedAccountType{
+			"CURRENT_GBP": {Definition: def},
+		},
+	}
+
+	mockParty := &mockPartyClient{
+		partyExists: true,
+		partyStatus: partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+	}
+
+	svc := &Service{
+		repo:             repo,
+		partyClient:      mockParty,
+		accountTypeCache: cache,
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	requestedVersion := int32(2)
+	req := &pb.InitiateCurrentAccountRequest{
+		AccountIdentification: "GB82WEST12345698765432",
+		PartyId:               newTestPartyID(),
+		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+		ProductTypeCode:       "CURRENT_GBP",
+		ProductTypeVersion:    &requestedVersion,
+	}
+	resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int32(2), resp.Facility.ProductTypeVersion)
+}
+
+// TestInitiateCurrentAccount_WithProductType_NotFound verifies that account creation
+// fails when the product type code is not found in the cache.
+func TestInitiateCurrentAccount_WithProductType_NotFound(t *testing.T) {
+	db, ctx, cleanup := setupProductTypeTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	cache := &mockAccountTypeCache{
+		entries: map[string]*CachedAccountType{}, // empty - no definitions
+	}
+
+	mockParty := &mockPartyClient{
+		partyExists: true,
+		partyStatus: partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+	}
+
+	svc := &Service{
+		repo:             repo,
+		partyClient:      mockParty,
+		accountTypeCache: cache,
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	req := &pb.InitiateCurrentAccountRequest{
+		AccountIdentification: "GB82WEST12345698765432",
+		PartyId:               newTestPartyID(),
+		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+		ProductTypeCode:       "NONEXISTENT",
+	}
+	resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "product type not found")
+}
+
+// TestInitiateCurrentAccount_WithProductType_NonCustomerBehaviorClass verifies
+// that account creation fails when the product type has a non-CUSTOMER behavior class.
+func TestInitiateCurrentAccount_WithProductType_NonCustomerBehaviorClass(t *testing.T) {
+	tests := []struct {
+		name          string
+		behaviorClass accounttype.BehaviorClass
+	}{
+		{"CLEARING", accounttype.BehaviorClassClearing},
+		{"NOSTRO", accounttype.BehaviorClassNostro},
+		{"SUSPENSE", accounttype.BehaviorClassSuspense},
+		{"REVENUE", accounttype.BehaviorClassRevenue},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, ctx, cleanup := setupProductTypeTestDB(t)
+			defer cleanup()
+
+			repo := persistence.NewRepository(db)
+
+			def := newTestDefinition("INTERNAL_"+tt.name, tt.behaviorClass)
+			cache := &mockAccountTypeCache{
+				entries: map[string]*CachedAccountType{
+					"INTERNAL_" + tt.name: {Definition: def},
+				},
+			}
+
+			mockParty := &mockPartyClient{
+				partyExists: true,
+				partyStatus: partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+			}
+
+			svc := &Service{
+				repo:             repo,
+				partyClient:      mockParty,
+				accountTypeCache: cache,
+				logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
+			}
+
+			req := &pb.InitiateCurrentAccountRequest{
+				AccountIdentification: "GB82WEST12345698765432",
+				PartyId:               newTestPartyID(),
+				BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+				ProductTypeCode:       "INTERNAL_" + tt.name,
+			}
+			resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+			require.Error(t, err)
+			assert.Nil(t, resp)
+			st, ok := status.FromError(err)
+			require.True(t, ok)
+			assert.Equal(t, codes.InvalidArgument, st.Code())
+			assert.Contains(t, st.Message(), "behavior class")
+			assert.Contains(t, st.Message(), "expected CUSTOMER")
+		})
+	}
+}
+
+// TestInitiateCurrentAccount_WithProductType_CELEligibility verifies
+// CEL eligibility evaluation with party context.
+func TestInitiateCurrentAccount_WithProductType_CELEligibility(t *testing.T) {
+	t.Run("eligible party passes", func(t *testing.T) {
+		db, ctx, cleanup := setupProductTypeTestDB(t)
+		defer cleanup()
+
+		repo := persistence.NewRepository(db)
+
+		// CEL expression that requires party type to be PERSON
+		prg := compileTestEligibilityProgram(t, `party.type == "PERSON"`)
+
+		def := newTestDefinition("PERSONAL_CURRENT", accounttype.BehaviorClassCustomer)
+		def.EligibilityCEL = `party.type == "PERSON"`
+		cache := &mockAccountTypeCache{
+			entries: map[string]*CachedAccountType{
+				"PERSONAL_CURRENT": {
+					Definition:         def,
+					EligibilityProgram: prg,
+				},
+			},
+		}
+
+		mockParty := &mockPartyClient{
+			partyExists: true,
+			partyStatus: partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+		}
+		// Override GetParty to return PERSON type
+		mockParty.partyTypeOverride = partyv1.PartyType_PARTY_TYPE_PERSON
+
+		svc := &Service{
+			repo:             repo,
+			partyClient:      mockParty,
+			accountTypeCache: cache,
+			logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		}
+
+		req := &pb.InitiateCurrentAccountRequest{
+			AccountIdentification: "GB82WEST12345698765432",
+			PartyId:               newTestPartyID(),
+			BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+			ProductTypeCode:       "PERSONAL_CURRENT",
+		}
+		resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "PERSONAL_CURRENT", resp.Facility.ProductTypeCode)
+	})
+
+	t.Run("ineligible party rejected", func(t *testing.T) {
+		db, ctx, cleanup := setupProductTypeTestDB(t)
+		defer cleanup()
+
+		repo := persistence.NewRepository(db)
+
+		// CEL expression that requires party type to be PERSON
+		prg := compileTestEligibilityProgram(t, `party.type == "PERSON"`)
+
+		def := newTestDefinition("PERSONAL_CURRENT", accounttype.BehaviorClassCustomer)
+		def.EligibilityCEL = `party.type == "PERSON"`
+		cache := &mockAccountTypeCache{
+			entries: map[string]*CachedAccountType{
+				"PERSONAL_CURRENT": {
+					Definition:         def,
+					EligibilityProgram: prg,
+				},
+			},
+		}
+
+		// Party is ORGANIZATION, not PERSON - should fail eligibility
+		mockParty := &mockPartyClient{
+			partyExists: true,
+			partyStatus: partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+		}
+		mockParty.partyTypeOverride = partyv1.PartyType_PARTY_TYPE_ORGANIZATION
+
+		svc := &Service{
+			repo:             repo,
+			partyClient:      mockParty,
+			accountTypeCache: cache,
+			logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		}
+
+		req := &pb.InitiateCurrentAccountRequest{
+			AccountIdentification: "GB82WEST12345698765432",
+			PartyId:               newTestPartyID(),
+			BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+			ProductTypeCode:       "PERSONAL_CURRENT",
+		}
+		resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+		assert.Contains(t, st.Message(), "not eligible")
+	})
+}
+
+// TestInitiateCurrentAccount_WithProductType_AttributeValidation verifies
+// JSON Schema attribute validation.
+func TestInitiateCurrentAccount_WithProductType_AttributeValidation(t *testing.T) {
+	schemaJSON := `{
+		"type": "object",
+		"properties": {
+			"risk_level": {
+				"type": "string",
+				"enum": ["LOW", "MEDIUM", "HIGH"]
+			}
+		},
+		"required": ["risk_level"]
+	}`
+
+	t.Run("valid attributes pass", func(t *testing.T) {
+		db, ctx, cleanup := setupProductTypeTestDB(t)
+		defer cleanup()
+
+		repo := persistence.NewRepository(db)
+
+		def := newTestDefinition("RISK_CURRENT", accounttype.BehaviorClassCustomer)
+		def.AttributeSchema = json.RawMessage(schemaJSON)
+		compiledSchema := compileTestSchema(t, schemaJSON)
+
+		cache := &mockAccountTypeCache{
+			entries: map[string]*CachedAccountType{
+				"RISK_CURRENT": {
+					Definition:     def,
+					CompiledSchema: compiledSchema,
+				},
+			},
+		}
+
+		mockParty := &mockPartyClient{
+			partyExists: true,
+			partyStatus: partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+		}
+
+		svc := &Service{
+			repo:             repo,
+			partyClient:      mockParty,
+			accountTypeCache: cache,
+			logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		}
+
+		req := &pb.InitiateCurrentAccountRequest{
+			AccountIdentification: "GB82WEST12345698765432",
+			PartyId:               newTestPartyID(),
+			BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+			ProductTypeCode:       "RISK_CURRENT",
+			Attributes:            map[string]string{"risk_level": "LOW"},
+		}
+		resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("invalid attributes rejected", func(t *testing.T) {
+		db, ctx, cleanup := setupProductTypeTestDB(t)
+		defer cleanup()
+
+		repo := persistence.NewRepository(db)
+
+		def := newTestDefinition("RISK_CURRENT", accounttype.BehaviorClassCustomer)
+		def.AttributeSchema = json.RawMessage(schemaJSON)
+		compiledSchema := compileTestSchema(t, schemaJSON)
+
+		cache := &mockAccountTypeCache{
+			entries: map[string]*CachedAccountType{
+				"RISK_CURRENT": {
+					Definition:     def,
+					CompiledSchema: compiledSchema,
+				},
+			},
+		}
+
+		mockParty := &mockPartyClient{
+			partyExists: true,
+			partyStatus: partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+		}
+
+		svc := &Service{
+			repo:             repo,
+			partyClient:      mockParty,
+			accountTypeCache: cache,
+			logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		}
+
+		req := &pb.InitiateCurrentAccountRequest{
+			AccountIdentification: "GB82WEST12345698765432",
+			PartyId:               newTestPartyID(),
+			BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+			ProductTypeCode:       "RISK_CURRENT",
+			Attributes:            map[string]string{"risk_level": "EXTREME"}, // Invalid enum value
+		}
+		resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "attribute validation failed")
+	})
+
+	t.Run("missing required attributes rejected", func(t *testing.T) {
+		db, ctx, cleanup := setupProductTypeTestDB(t)
+		defer cleanup()
+
+		repo := persistence.NewRepository(db)
+
+		def := newTestDefinition("RISK_CURRENT", accounttype.BehaviorClassCustomer)
+		def.AttributeSchema = json.RawMessage(schemaJSON)
+		compiledSchema := compileTestSchema(t, schemaJSON)
+
+		cache := &mockAccountTypeCache{
+			entries: map[string]*CachedAccountType{
+				"RISK_CURRENT": {
+					Definition:     def,
+					CompiledSchema: compiledSchema,
+				},
+			},
+		}
+
+		mockParty := &mockPartyClient{
+			partyExists: true,
+			partyStatus: partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+		}
+
+		svc := &Service{
+			repo:             repo,
+			partyClient:      mockParty,
+			accountTypeCache: cache,
+			logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		}
+
+		req := &pb.InitiateCurrentAccountRequest{
+			AccountIdentification: "GB82WEST12345698765432",
+			PartyId:               newTestPartyID(),
+			BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+			ProductTypeCode:       "RISK_CURRENT",
+			Attributes:            map[string]string{}, // Missing required risk_level
+		}
+		resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+}
+
+// TestInitiateCurrentAccount_WithProductType_ValuationFeatureSeeding verifies
+// that ValuationFeatures are seeded from product type templates.
+func TestInitiateCurrentAccount_WithProductType_ValuationFeatureSeeding(t *testing.T) {
+	db, ctx, cleanup := setupProductTypeTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	vfRepo := vf.NewRepository(db)
+
+	methodID := uuid.New()
+	def := newTestDefinition("MULTI_CCY_CURRENT", accounttype.BehaviorClassCustomer)
+	def.ValuationMethods = []accounttype.ValuationMethodTemplate{
+		{
+			ID:                     uuid.New(),
+			AccountTypeID:          def.ID,
+			InputInstrument:        "USD",
+			ValuationMethodID:      methodID,
+			ValuationMethodVersion: 1,
+			Status:                 accounttype.StatusActive,
+		},
+		{
+			ID:                     uuid.New(),
+			AccountTypeID:          def.ID,
+			InputInstrument:        "EUR",
+			ValuationMethodID:      methodID,
+			ValuationMethodVersion: 1,
+			Status:                 accounttype.StatusActive,
+		},
+	}
+
+	cache := &mockAccountTypeCache{
+		entries: map[string]*CachedAccountType{
+			"MULTI_CCY_CURRENT": {Definition: def},
+		},
+	}
+
+	mockParty := &mockPartyClient{
+		partyExists: true,
+		partyStatus: partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+	}
+
+	svc := &Service{
+		repo:                 repo,
+		partyClient:          mockParty,
+		accountTypeCache:     cache,
+		valuationFeatureRepo: vfRepo,
+		logger:               slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	req := &pb.InitiateCurrentAccountRequest{
+		AccountIdentification: "GB82WEST12345698765432",
+		PartyId:               newTestPartyID(),
+		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+		ProductTypeCode:       "MULTI_CCY_CURRENT",
+	}
+	resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Verify the account was created
+	account, err := repo.FindByID(ctx, resp.AccountId)
+	require.NoError(t, err)
+
+	// Retrieve seeded ValuationFeatures
+	activeStatus := vf.LifecycleStatusActive
+	features, err := vfRepo.FindByAccountID(ctx, account.ID(), &activeStatus)
+	require.NoError(t, err)
+	assert.Len(t, features, 2, "Should have seeded 2 valuation features")
+
+	// Verify instruments
+	instruments := make(map[string]bool)
+	for _, f := range features {
+		instruments[f.InstrumentCode] = true
+		assert.Equal(t, methodID, f.ValuationMethodID)
+		assert.Equal(t, 1, f.ValuationMethodVersion)
+		assert.True(t, f.IsActive(), "Seeded features should be ACTIVE")
+	}
+	assert.True(t, instruments["USD"], "Should have USD feature")
+	assert.True(t, instruments["EUR"], "Should have EUR feature")
+}
+
+// TestInitiateCurrentAccount_BackwardsCompatibility verifies that account creation
+// still works without product_type_code (legacy path).
+func TestInitiateCurrentAccount_BackwardsCompatibility(t *testing.T) {
+	db, ctx, cleanup := setupProductTypeTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+
+	mockParty := &mockPartyClient{
+		partyExists: true,
+		partyStatus: partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+	}
+
+	svc := &Service{
+		repo:        repo,
+		partyClient: mockParty,
+		logger:      slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	// No product_type_code - legacy behavior
+	req := &pb.InitiateCurrentAccountRequest{
+		AccountIdentification: "GB82WEST12345698765432",
+		PartyId:               newTestPartyID(),
+		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+	}
+	resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.AccountId)
+	// Product type fields should be empty/zero for legacy accounts
+	assert.Empty(t, resp.Facility.ProductTypeCode)
+	assert.Equal(t, int32(0), resp.Facility.ProductTypeVersion)
+}
+
+// TestInitiateCurrentAccount_WithProductType_NoCacheConfigured verifies that
+// product type code is silently ignored when no cache is configured.
+func TestInitiateCurrentAccount_WithProductType_NoCacheConfigured(t *testing.T) {
+	db, ctx, cleanup := setupProductTypeTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+
+	mockParty := &mockPartyClient{
+		partyExists: true,
+		partyStatus: partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+	}
+
+	svc := &Service{
+		repo:        repo,
+		partyClient: mockParty,
+		// accountTypeCache is nil - not configured
+		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	req := &pb.InitiateCurrentAccountRequest{
+		AccountIdentification: "GB82WEST12345698765432",
+		PartyId:               newTestPartyID(),
+		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+		ProductTypeCode:       "CURRENT_GBP", // Provided but will be ignored
+	}
+	resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	// Product type is not resolved when cache is nil
+	assert.Empty(t, resp.Facility.ProductTypeCode)
+}
+
+// TestInitiateCurrentAccount_WithProductType_MissingTenantContext verifies
+// that product type resolution fails gracefully when tenant context is missing.
+func TestInitiateCurrentAccount_WithProductType_MissingTenantContext(t *testing.T) {
+	db, _, cleanup := setupProductTypeTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+
+	cache := &mockAccountTypeCache{
+		entries: map[string]*CachedAccountType{},
+	}
+
+	// Use context WITHOUT tenant
+	ctx := context.Background()
+
+	svc := &Service{
+		repo:             repo,
+		accountTypeCache: cache,
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	req := &pb.InitiateCurrentAccountRequest{
+		AccountIdentification: "GB82WEST12345698765432",
+		PartyId:               newTestPartyID(),
+		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+		ProductTypeCode:       "CURRENT_GBP",
+	}
+	resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "tenant context")
+}
+
+// TestInitiateCurrentAccount_WithProductType_CacheError verifies
+// handling of cache/loader errors.
+func TestInitiateCurrentAccount_WithProductType_CacheError(t *testing.T) {
+	db, ctx, cleanup := setupProductTypeTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+
+	cache := &mockAccountTypeCache{
+		err: errors.New("cache connection refused"),
+	}
+
+	mockParty := &mockPartyClient{
+		partyExists: true,
+		partyStatus: partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+	}
+
+	svc := &Service{
+		repo:             repo,
+		partyClient:      mockParty,
+		accountTypeCache: cache,
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	req := &pb.InitiateCurrentAccountRequest{
+		AccountIdentification: "GB82WEST12345698765432",
+		PartyId:               newTestPartyID(),
+		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+		ProductTypeCode:       "CURRENT_GBP",
+	}
+	resp, err := svc.InitiateCurrentAccount(ctx, req)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "product type not found")
+}

--- a/services/current-account/service/lien_service_test.go
+++ b/services/current-account/service/lien_service_test.go
@@ -1439,6 +1439,8 @@ func setupAtomicValuationLienTest(t *testing.T, engine ValuationEngine, accountB
 		opened_at TIMESTAMP WITH TIME ZONE,
 		closed_at TIMESTAMP WITH TIME ZONE,
 		freeze_reason TEXT,
+		product_type_code VARCHAR(50) NULL,
+		product_type_version INT NULL,
 		version BIGINT NOT NULL DEFAULT 1
 	)`, pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)

--- a/services/current-account/service/valuation_engine_test.go
+++ b/services/current-account/service/valuation_engine_test.go
@@ -92,6 +92,8 @@ func setupValuationEngineTestWithEngine(t *testing.T, engine ValuationEngine) (*
 		opened_at TIMESTAMP WITH TIME ZONE,
 		closed_at TIMESTAMP WITH TIME ZONE,
 		freeze_reason TEXT,
+		product_type_code VARCHAR(50) NULL,
+		product_type_version INT NULL,
 		version BIGINT NOT NULL DEFAULT 1
 	)`, schemaName)).Error
 	require.NoError(t, err)

--- a/services/current-account/service/valuation_feature_service_test.go
+++ b/services/current-account/service/valuation_feature_service_test.go
@@ -52,6 +52,8 @@ func setupValuationFeatureServiceTest(t *testing.T) (*Service, context.Context, 
 		opened_at TIMESTAMP WITH TIME ZONE,
 		closed_at TIMESTAMP WITH TIME ZONE,
 		freeze_reason TEXT,
+		product_type_code VARCHAR(50) NULL,
+		product_type_version INT NULL,
 		version BIGINT NOT NULL DEFAULT 1
 	)`, schemaName)).Error
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Add `product_type_code`, `product_type_version`, and `attributes` fields to `InitiateCurrentAccountRequest` proto, enabling accounts to reference Product Directory definitions
- Implement full validation pipeline during account creation: BehaviorClass==CUSTOMER gating, CEL eligibility evaluation with party context, JSON Schema attribute validation
- Seed ValuationFeatures from product type templates after account creation
- Add DB migrations for `product_type_code`/`product_type_version` columns with index (CockroachDB-safe: split across two migrations)
- Propagate new fields through all immutable domain copy constructors (Deposit, Withdraw, PrepareForCredit, PrepareForDebit, withStatusChange, SetOverdraftLimit)
- Full backwards compatibility: empty `product_type_code` follows legacy code path

## Changes

**Proto** (`current_account.proto`):
- `InitiateCurrentAccountRequest`: fields 5-7 (`product_type_code`, `product_type_version`, `attributes`)
- `CurrentAccountFacility`: fields 12-13 (`product_type_code`, `product_type_version`)

**Domain** (`domain/account.go`):
- `WithProductType(code, version)` functional option
- `ProductTypeCode()`, `ProductTypeVersion()` accessors
- Builder methods `WithProductTypeCode`, `WithProductTypeVersion`
- All 6 immutable copy methods propagate new fields

**Persistence** (`adapters/persistence/`):
- Nullable `ProductTypeCode *string` and `ProductTypeVersion *int` on entity
- `toEntity`/`toDomain` mapping (nil for empty, zero-value for nil)

**Service** (`service/`):
- `AccountTypeCache` interface + `CachedAccountType` struct for product type resolution
- `Option` functional options (`WithAccountTypeCache`, `WithValuationFeatureRepo`, etc.)
- `evaluateEligibility()`: retrieves party via `GetParty`, strips proto enum prefixes, calls `cel.EvalEligibility`
- `validateAttributes()`: round-trips through JSON for schema validation
- `seedValuationFeatures()`: creates + activates features from templates (best-effort)

**Migrations**:
- `20260220000001_add_product_type_columns.sql`: ADD COLUMN product_type_code, product_type_version
- `20260220000002_add_product_type_index.sql`: CREATE INDEX idx_account_product_type_code

## Test plan

- [x] Product type resolution success (CUSTOMER class)
- [x] Version override via `product_type_version` field
- [x] Product type not found returns InvalidArgument
- [x] Non-CUSTOMER behavior class rejected (CLEARING, NOSTRO, SUSPENSE, REVENUE)
- [x] CEL eligibility: eligible PERSON party passes, ineligible ORGANIZATION rejected
- [x] JSON Schema: valid attributes pass, invalid enum rejected, missing required rejected
- [x] ValuationFeature seeding: 2 templates create 2 ACTIVE features with correct instruments
- [x] Backwards compatibility: empty product_type_code creates account without product type fields
- [x] No cache configured: product_type_code silently ignored
- [x] Missing tenant context: FailedPrecondition returned
- [x] Cache error: InvalidArgument returned
- [x] Existing party validation tests still pass (no regressions)

Task: product-directory.10