### PR TITLE
feat: Tune error handling and status code mapping for JSON transcoding

### DIFF
--- a/services/gateway/error_response.go
+++ b/services/gateway/error_response.go
@@ -31,9 +31,11 @@ var grpcCodeNames = map[int]string{
 
 // vanguardErrorBody is the JSON structure that Vanguard emits for error responses.
 // It follows the google.rpc.Status format with a numeric code.
+// Pointer fields allow presence detection: a missing field stays nil, enabling
+// us to distinguish a real Vanguard body from generic JSON errors.
 type vanguardErrorBody struct {
-	Code    int               `json:"code"`
-	Message string            `json:"message"`
+	Code    *int              `json:"code"`
+	Message *string           `json:"message"`
 	Details []json.RawMessage `json:"details"`
 }
 
@@ -49,12 +51,17 @@ type canonicalErrorBody struct {
 // allowing the middleware to rewrite error responses before they are sent to the client.
 type errorReformattingWriter struct {
 	http.ResponseWriter
-	statusCode int
-	body       bytes.Buffer
+	statusCode  int
+	body        bytes.Buffer
+	wroteHeader bool
 }
 
 func (w *errorReformattingWriter) WriteHeader(statusCode int) {
+	if w.wroteHeader {
+		return
+	}
 	w.statusCode = statusCode
+	w.wroteHeader = true
 }
 
 func (w *errorReformattingWriter) Write(b []byte) (int, error) {
@@ -91,10 +98,10 @@ func errorReformattingMiddleware(next http.Handler) http.Handler {
 		bodyBytes := rw.body.Bytes()
 
 		var vErr vanguardErrorBody
-		if isJSONContentType(ct) && json.Unmarshal(bodyBytes, &vErr) == nil {
-			codeName := grpcCodeName(vErr.Code)
+		if isJSONContentType(ct) && json.Unmarshal(bodyBytes, &vErr) == nil && vErr.Code != nil && vErr.Message != nil {
+			codeName := grpcCodeName(*vErr.Code)
 			canonical := canonicalErrorBody{
-				Error:   vErr.Message,
+				Error:   *vErr.Message,
 				Code:    codeName,
 				Details: vErr.Details,
 			}

--- a/services/gateway/error_response.go
+++ b/services/gateway/error_response.go
@@ -1,0 +1,136 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+// grpcCodeNames maps numeric gRPC status codes to their canonical string names.
+// These correspond to google.golang.org/grpc/codes.Code values.
+var grpcCodeNames = map[int]string{
+	0:  "OK",
+	1:  "CANCELLED",
+	2:  "UNKNOWN",
+	3:  "INVALID_ARGUMENT",
+	4:  "DEADLINE_EXCEEDED",
+	5:  "NOT_FOUND",
+	6:  "ALREADY_EXISTS",
+	7:  "PERMISSION_DENIED",
+	8:  "RESOURCE_EXHAUSTED",
+	9:  "FAILED_PRECONDITION",
+	10: "ABORTED",
+	11: "OUT_OF_RANGE",
+	12: "UNIMPLEMENTED",
+	13: "INTERNAL",
+	14: "UNAVAILABLE",
+	15: "DATA_LOSS",
+	16: "UNAUTHENTICATED",
+}
+
+// vanguardErrorBody is the JSON structure that Vanguard emits for error responses.
+// It follows the google.rpc.Status format with a numeric code.
+type vanguardErrorBody struct {
+	Code    int               `json:"code"`
+	Message string            `json:"message"`
+	Details []json.RawMessage `json:"details"`
+}
+
+// canonicalErrorBody is our API's error response format, which uses a human-readable
+// string code alongside the error message.
+type canonicalErrorBody struct {
+	Error   string            `json:"error"`
+	Code    string            `json:"code"`
+	Details []json.RawMessage `json:"details,omitempty"`
+}
+
+// errorReformattingWriter intercepts the response to capture the status and body,
+// allowing the middleware to rewrite error responses before they are sent to the client.
+type errorReformattingWriter struct {
+	http.ResponseWriter
+	statusCode int
+	body       bytes.Buffer
+	written    bool
+}
+
+func (w *errorReformattingWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+}
+
+func (w *errorReformattingWriter) Write(b []byte) (int, error) {
+	w.written = true
+	return w.body.Write(b)
+}
+
+// Flush implements http.Flusher so that underlying response writers that
+// implement http.Flusher are not broken by the wrapper.
+func (w *errorReformattingWriter) Flush() {
+	// Buffer is flushed in the middleware after rewriting; nothing to do here.
+}
+
+// errorReformattingMiddleware wraps an HTTP handler and rewrites error responses
+// (non-2xx with application/json body) from Vanguard's google.rpc.Status format
+// into the canonical API error format:
+//
+//	{"error": "<message>", "code": "<GRPC_CODE_NAME>", "details": [...]}
+//
+// This provides a consistent, human-readable error body for REST API consumers.
+func errorReformattingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rw := &errorReformattingWriter{ResponseWriter: w, statusCode: http.StatusOK}
+		next.ServeHTTP(rw, r)
+
+		// Pass through successful responses without modification.
+		if rw.statusCode >= http.StatusOK && rw.statusCode < http.StatusMultipleChoices {
+			w.WriteHeader(rw.statusCode)
+			_, _ = w.Write(rw.body.Bytes())
+			return
+		}
+
+		// Attempt to reformat the error body if it looks like JSON.
+		ct := w.Header().Get("Content-Type")
+		bodyBytes := rw.body.Bytes()
+
+		var vErr vanguardErrorBody
+		if isJSONContentType(ct) && json.Unmarshal(bodyBytes, &vErr) == nil {
+			codeName := grpcCodeName(vErr.Code)
+			canonical := canonicalErrorBody{
+				Error:   vErr.Message,
+				Code:    codeName,
+				Details: vErr.Details,
+			}
+			out, err := json.Marshal(canonical)
+			if err == nil {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(rw.statusCode)
+				_, _ = w.Write(out)
+				return
+			}
+		}
+
+		// Fall through: pass the original response unmodified.
+		w.WriteHeader(rw.statusCode)
+		_, _ = w.Write(bodyBytes)
+	})
+}
+
+// grpcCodeName returns the canonical string name for a gRPC status code integer.
+// Unknown codes fall back to "UNKNOWN".
+func grpcCodeName(code int) string {
+	if name, ok := grpcCodeNames[code]; ok {
+		return name
+	}
+	return "UNKNOWN"
+}
+
+// isJSONContentType reports whether the content-type header indicates JSON.
+func isJSONContentType(ct string) bool {
+	// Accept "application/json" and variants like "application/json; charset=utf-8".
+	for i := 0; i < len(ct); i++ {
+		if ct[i] == ';' {
+			ct = ct[:i]
+			break
+		}
+	}
+	return ct == "application/json"
+}

--- a/services/gateway/error_response.go
+++ b/services/gateway/error_response.go
@@ -51,7 +51,6 @@ type errorReformattingWriter struct {
 	http.ResponseWriter
 	statusCode int
 	body       bytes.Buffer
-	written    bool
 }
 
 func (w *errorReformattingWriter) WriteHeader(statusCode int) {
@@ -59,7 +58,6 @@ func (w *errorReformattingWriter) WriteHeader(statusCode int) {
 }
 
 func (w *errorReformattingWriter) Write(b []byte) (int, error) {
-	w.written = true
 	return w.body.Write(b)
 }
 

--- a/services/gateway/error_response.go
+++ b/services/gateway/error_response.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"strings"
 )
 
 // grpcCodeNames maps numeric gRPC status codes to their canonical string names.
@@ -124,13 +125,11 @@ func grpcCodeName(code int) string {
 }
 
 // isJSONContentType reports whether the content-type header indicates JSON.
+// Media type tokens are compared case-insensitively per RFC 2616 §3.7.
 func isJSONContentType(ct string) bool {
-	// Accept "application/json" and variants like "application/json; charset=utf-8".
-	for i := 0; i < len(ct); i++ {
-		if ct[i] == ';' {
-			ct = ct[:i]
-			break
-		}
+	// Strip parameters (everything after the first ';').
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
 	}
-	return ct == "application/json"
+	return strings.EqualFold(strings.TrimSpace(ct), "application/json")
 }

--- a/services/gateway/error_response.go
+++ b/services/gateway/error_response.go
@@ -102,6 +102,9 @@ func errorReformattingMiddleware(next http.Handler) http.Handler {
 			}
 			out, err := json.Marshal(canonical)
 			if err == nil {
+				// Remove Content-Length so it is not stale after reformatting.
+				// The marshaled body length differs from the original.
+				w.Header().Del("Content-Length")
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(rw.statusCode)
 				_, _ = w.Write(out)

--- a/services/gateway/error_response_test.go
+++ b/services/gateway/error_response_test.go
@@ -154,11 +154,18 @@ func TestErrorReformattingMiddleware_AllVanguardErrorCodes(t *testing.T) {
 	}
 }
 
-// TestIsJSONContentType verifies content-type detection logic.
+// TestIsJSONContentType verifies content-type detection logic, including
+// RFC 2616 §3.7 case-insensitive media type matching.
 func TestIsJSONContentType(t *testing.T) {
+	// Exact match and with parameters
 	assert.True(t, isJSONContentType("application/json"))
 	assert.True(t, isJSONContentType("application/json; charset=utf-8"))
 	assert.True(t, isJSONContentType("application/json;charset=utf-8"))
+	// Mixed-case variants must also match per RFC 2616
+	assert.True(t, isJSONContentType("Application/JSON"))
+	assert.True(t, isJSONContentType("APPLICATION/JSON"))
+	assert.True(t, isJSONContentType("application/JSON; charset=utf-8"))
+	// Non-JSON types
 	assert.False(t, isJSONContentType("text/plain"))
 	assert.False(t, isJSONContentType("text/html"))
 	assert.False(t, isJSONContentType(""))

--- a/services/gateway/error_response_test.go
+++ b/services/gateway/error_response_test.go
@@ -154,6 +154,38 @@ func TestErrorReformattingMiddleware_AllVanguardErrorCodes(t *testing.T) {
 	}
 }
 
+// TestErrorReformattingMiddleware_PassesThroughNonVanguardJSON verifies that
+// generic JSON error bodies without Vanguard's code/message fields are passed
+// through unmodified rather than being overwritten with empty values.
+func TestErrorReformattingMiddleware_PassesThroughNonVanguardJSON(t *testing.T) {
+	originalBody := `{"error":"bad request"}`
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(originalBody))
+	})
+
+	handler := errorReformattingMiddleware(inner)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, originalBody, rec.Body.String(), "non-Vanguard JSON must pass through unmodified")
+}
+
+// TestErrorReformattingWriter_WriteHeaderGuard verifies that only the first
+// WriteHeader call is honored, matching net/http semantics.
+func TestErrorReformattingWriter_WriteHeaderGuard(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := &errorReformattingWriter{ResponseWriter: rec, statusCode: http.StatusOK}
+
+	rw.WriteHeader(http.StatusNotFound)
+	rw.WriteHeader(http.StatusInternalServerError) // should be ignored
+
+	assert.Equal(t, http.StatusNotFound, rw.statusCode)
+}
+
 // TestIsJSONContentType verifies content-type detection logic, including
 // RFC 2616 §3.7 case-insensitive media type matching.
 func TestIsJSONContentType(t *testing.T) {

--- a/services/gateway/error_response_test.go
+++ b/services/gateway/error_response_test.go
@@ -1,0 +1,165 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGRPCCodeName verifies that numeric gRPC codes are converted to their
+// canonical string names.
+func TestGRPCCodeName(t *testing.T) {
+	cases := []struct {
+		code     int
+		expected string
+	}{
+		{0, "OK"},
+		{1, "CANCELLED"},
+		{2, "UNKNOWN"},
+		{3, "INVALID_ARGUMENT"},
+		{4, "DEADLINE_EXCEEDED"},
+		{5, "NOT_FOUND"},
+		{6, "ALREADY_EXISTS"},
+		{7, "PERMISSION_DENIED"},
+		{8, "RESOURCE_EXHAUSTED"},
+		{9, "FAILED_PRECONDITION"},
+		{10, "ABORTED"},
+		{11, "OUT_OF_RANGE"},
+		{12, "UNIMPLEMENTED"},
+		{13, "INTERNAL"},
+		{14, "UNAVAILABLE"},
+		{15, "DATA_LOSS"},
+		{16, "UNAUTHENTICATED"},
+		{99, "UNKNOWN"}, // out-of-range falls back to UNKNOWN
+	}
+
+	for _, tc := range cases {
+		assert.Equal(t, tc.expected, grpcCodeName(tc.code), "code %d", tc.code)
+	}
+}
+
+// TestErrorReformattingMiddleware_RewritesErrorBody verifies that the middleware
+// rewrites Vanguard's numeric-code JSON error format to the canonical string-code format.
+func TestErrorReformattingMiddleware_RewritesErrorBody(t *testing.T) {
+	// Inner handler simulates what Vanguard emits for a NOT_FOUND error.
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"code":5,"message":"party not found","details":[]}`))
+	})
+
+	handler := errorReformattingMiddleware(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/parties/x", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Type"), "application/json")
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	assert.Equal(t, "NOT_FOUND", body["code"], "code must be string NOT_FOUND")
+	assert.Equal(t, "party not found", body["error"], "error must be the gRPC message")
+	_, hasMessage := body["message"]
+	assert.False(t, hasMessage, "must not contain Vanguard's 'message' field")
+}
+
+// TestErrorReformattingMiddleware_PassesThroughSuccessResponse verifies that
+// successful (2xx) responses are not modified.
+func TestErrorReformattingMiddleware_PassesThroughSuccessResponse(t *testing.T) {
+	expectedBody := `{"partyId":"abc","legalName":"Alice"}`
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(expectedBody))
+	})
+
+	handler := errorReformattingMiddleware(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/parties/abc", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, expectedBody, rec.Body.String())
+}
+
+// TestErrorReformattingMiddleware_PassesThroughNonJSONError verifies that
+// non-JSON error responses (e.g. plain text "Not Found") are passed through unmodified.
+func TestErrorReformattingMiddleware_PassesThroughNonJSONError(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("Not Found"))
+	})
+
+	handler := errorReformattingMiddleware(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/unknown/path", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, "Not Found", rec.Body.String())
+}
+
+// TestErrorReformattingMiddleware_AllVanguardErrorCodes verifies that all numeric
+// gRPC codes emitted by Vanguard are rewritten to their string equivalents.
+func TestErrorReformattingMiddleware_AllVanguardErrorCodes(t *testing.T) {
+	cases := []struct {
+		numericCode int
+		httpStatus  int
+		stringCode  string
+	}{
+		{3, http.StatusBadRequest, "INVALID_ARGUMENT"},
+		{4, http.StatusGatewayTimeout, "DEADLINE_EXCEEDED"},
+		{5, http.StatusNotFound, "NOT_FOUND"},
+		{7, http.StatusForbidden, "PERMISSION_DENIED"},
+		{13, http.StatusInternalServerError, "INTERNAL"},
+		{14, http.StatusServiceUnavailable, "UNAVAILABLE"},
+		{16, http.StatusUnauthorized, "UNAUTHENTICATED"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.stringCode, func(t *testing.T) {
+			inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.httpStatus)
+				body, _ := json.Marshal(map[string]interface{}{
+					"code":    tc.numericCode,
+					"message": strings.ToLower(tc.stringCode),
+					"details": []interface{}{},
+				})
+				_, _ = w.Write(body)
+			})
+
+			handler := errorReformattingMiddleware(inner)
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, tc.httpStatus, rec.Code)
+
+			var result map[string]interface{}
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
+			assert.Equal(t, tc.stringCode, result["code"])
+		})
+	}
+}
+
+// TestIsJSONContentType verifies content-type detection logic.
+func TestIsJSONContentType(t *testing.T) {
+	assert.True(t, isJSONContentType("application/json"))
+	assert.True(t, isJSONContentType("application/json; charset=utf-8"))
+	assert.True(t, isJSONContentType("application/json;charset=utf-8"))
+	assert.False(t, isJSONContentType("text/plain"))
+	assert.False(t, isJSONContentType("text/html"))
+	assert.False(t, isJSONContentType(""))
+}

--- a/services/gateway/transcoder.go
+++ b/services/gateway/transcoder.go
@@ -100,7 +100,9 @@ func NewTranscoder(descriptorBytes []byte, backends []ServiceBackend) (http.Hand
 		return nil, fmt.Errorf("create vanguard transcoder: %w", err)
 	}
 
-	return transcoder, nil
+	// 5. Wrap with error reformatting middleware to produce a consistent JSON
+	//    error body format across all gRPC error codes.
+	return errorReformattingMiddleware(transcoder), nil
 }
 
 // newGRPCReverseProxy builds an httputil.ReverseProxy that forwards requests to addr

--- a/services/gateway/transcoding_test.go
+++ b/services/gateway/transcoding_test.go
@@ -73,11 +73,31 @@ func (m *mockPartyService) RegisterParty(ctx context.Context, req *partyv1.Regis
 
 func (m *mockPartyService) RetrieveParty(ctx context.Context, req *partyv1.RetrievePartyRequest) (*partyv1.RetrievePartyResponse, error) {
 	m.captureMetadata(ctx)
-	if req.PartyId == "not-found" {
+	switch req.PartyId {
+	case "not-found":
 		return nil, status.Errorf(codes.NotFound, "party %q not found", req.PartyId)
-	}
-	if req.PartyId == "invalid" {
+	case "invalid":
 		return nil, status.Errorf(codes.InvalidArgument, "invalid party_id format")
+	case "unauthenticated":
+		return nil, status.Errorf(codes.Unauthenticated, "authentication required")
+	case "permission-denied":
+		return nil, status.Errorf(codes.PermissionDenied, "insufficient permissions")
+	case "internal":
+		return nil, status.Errorf(codes.Internal, "internal server error")
+	case "deadline-exceeded":
+		return nil, status.Errorf(codes.DeadlineExceeded, "deadline exceeded")
+	case "unavailable":
+		return nil, status.Errorf(codes.Unavailable, "service unavailable")
+	case "data-loss":
+		return nil, status.Errorf(codes.DataLoss, "data loss occurred")
+	case "unknown":
+		return nil, status.Errorf(codes.Unknown, "unknown error")
+	case "already-exists":
+		return nil, status.Errorf(codes.AlreadyExists, "party already exists")
+	case "resource-exhausted":
+		return nil, status.Errorf(codes.ResourceExhausted, "quota exceeded")
+	case "unimplemented":
+		return nil, status.Errorf(codes.Unimplemented, "method not implemented")
 	}
 	return &partyv1.RetrievePartyResponse{
 		Party: &partyv1.Party{
@@ -564,7 +584,11 @@ func TestTranscoding_Proto3JSON_NestedMessage(t *testing.T) {
 // Error Response Mapping (gRPC code -> HTTP status)
 // ---------------------------------------------------------------------------
 
-// TestTranscoding_Error_NotFound tests gRPC NOT_FOUND -> HTTP 404.
+// ---------------------------------------------------------------------------
+// Error Response Format Tests
+// ---------------------------------------------------------------------------
+
+// TestTranscoding_Error_NotFound tests gRPC NOT_FOUND -> HTTP 404 with canonical error body.
 func TestTranscoding_Error_NotFound(t *testing.T) {
 	env := startTranscodingTestEnv(t, []ServiceBackend{
 		{ServiceName: "meridian.party.v1.PartyService"},
@@ -577,12 +601,12 @@ func TestTranscoding_Error_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 
 	result := readJSONBody(t, resp)
-	// gRPC error body should contain a message
-	assert.NotEmpty(t, result["message"], "error response should contain a message field")
-	assert.Contains(t, result["message"], "not found")
+	assert.Equal(t, "NOT_FOUND", result["code"], "error code should be string NOT_FOUND")
+	assert.NotEmpty(t, result["error"], "error response should contain an error field")
+	assert.Contains(t, result["error"], "not found")
 }
 
-// TestTranscoding_Error_InvalidArgument tests gRPC INVALID_ARGUMENT -> HTTP 400.
+// TestTranscoding_Error_InvalidArgument tests gRPC INVALID_ARGUMENT -> HTTP 400 with canonical error body.
 func TestTranscoding_Error_InvalidArgument(t *testing.T) {
 	env := startTranscodingTestEnv(t, []ServiceBackend{
 		{ServiceName: "meridian.party.v1.PartyService"},
@@ -595,7 +619,240 @@ func TestTranscoding_Error_InvalidArgument(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	result := readJSONBody(t, resp)
-	assert.NotEmpty(t, result["message"])
+	assert.Equal(t, "INVALID_ARGUMENT", result["code"])
+	assert.NotEmpty(t, result["error"])
+}
+
+// TestTranscoding_Error_Unauthenticated tests gRPC UNAUTHENTICATED -> HTTP 401.
+func TestTranscoding_Error_Unauthenticated(t *testing.T) {
+	env := startTranscodingTestEnv(t, []ServiceBackend{
+		{ServiceName: "meridian.party.v1.PartyService"},
+	})
+
+	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/unauthenticated")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	result := readJSONBody(t, resp)
+	assert.Equal(t, "UNAUTHENTICATED", result["code"])
+	assert.Equal(t, "authentication required", result["error"])
+}
+
+// TestTranscoding_Error_PermissionDenied tests gRPC PERMISSION_DENIED -> HTTP 403.
+func TestTranscoding_Error_PermissionDenied(t *testing.T) {
+	env := startTranscodingTestEnv(t, []ServiceBackend{
+		{ServiceName: "meridian.party.v1.PartyService"},
+	})
+
+	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/permission-denied")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	result := readJSONBody(t, resp)
+	assert.Equal(t, "PERMISSION_DENIED", result["code"])
+	assert.NotEmpty(t, result["error"])
+}
+
+// TestTranscoding_Error_Internal tests gRPC INTERNAL -> HTTP 500.
+func TestTranscoding_Error_Internal(t *testing.T) {
+	env := startTranscodingTestEnv(t, []ServiceBackend{
+		{ServiceName: "meridian.party.v1.PartyService"},
+	})
+
+	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/internal")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	result := readJSONBody(t, resp)
+	assert.Equal(t, "INTERNAL", result["code"])
+	assert.NotEmpty(t, result["error"])
+}
+
+// TestTranscoding_Error_DeadlineExceeded tests gRPC DEADLINE_EXCEEDED -> HTTP 504.
+func TestTranscoding_Error_DeadlineExceeded(t *testing.T) {
+	env := startTranscodingTestEnv(t, []ServiceBackend{
+		{ServiceName: "meridian.party.v1.PartyService"},
+	})
+
+	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/deadline-exceeded")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusGatewayTimeout, resp.StatusCode)
+
+	result := readJSONBody(t, resp)
+	assert.Equal(t, "DEADLINE_EXCEEDED", result["code"])
+	assert.NotEmpty(t, result["error"])
+}
+
+// TestTranscoding_Error_Unavailable tests gRPC UNAVAILABLE -> HTTP 503.
+func TestTranscoding_Error_Unavailable(t *testing.T) {
+	env := startTranscodingTestEnv(t, []ServiceBackend{
+		{ServiceName: "meridian.party.v1.PartyService"},
+	})
+
+	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/unavailable")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	result := readJSONBody(t, resp)
+	assert.Equal(t, "UNAVAILABLE", result["code"])
+	assert.NotEmpty(t, result["error"])
+}
+
+// TestTranscoding_Error_DataLoss tests gRPC DATA_LOSS -> HTTP 500.
+func TestTranscoding_Error_DataLoss(t *testing.T) {
+	env := startTranscodingTestEnv(t, []ServiceBackend{
+		{ServiceName: "meridian.party.v1.PartyService"},
+	})
+
+	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/data-loss")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	result := readJSONBody(t, resp)
+	assert.Equal(t, "DATA_LOSS", result["code"])
+	assert.NotEmpty(t, result["error"])
+}
+
+// TestTranscoding_Error_Unknown tests gRPC UNKNOWN -> HTTP 500.
+func TestTranscoding_Error_Unknown(t *testing.T) {
+	env := startTranscodingTestEnv(t, []ServiceBackend{
+		{ServiceName: "meridian.party.v1.PartyService"},
+	})
+
+	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/unknown")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	result := readJSONBody(t, resp)
+	assert.Equal(t, "UNKNOWN", result["code"])
+	assert.NotEmpty(t, result["error"])
+}
+
+// TestTranscoding_Error_AllStandardCodes verifies that all standard gRPC->HTTP
+// status code mappings produce the canonical error body format.
+func TestTranscoding_Error_AllStandardCodes(t *testing.T) {
+	env := startTranscodingTestEnv(t, []ServiceBackend{
+		{ServiceName: "meridian.party.v1.PartyService"},
+	})
+
+	cases := []struct {
+		partyID    string
+		httpStatus int
+		grpcCode   string
+	}{
+		{"not-found", http.StatusNotFound, "NOT_FOUND"},
+		{"invalid", http.StatusBadRequest, "INVALID_ARGUMENT"},
+		{"unauthenticated", http.StatusUnauthorized, "UNAUTHENTICATED"},
+		{"permission-denied", http.StatusForbidden, "PERMISSION_DENIED"},
+		{"internal", http.StatusInternalServerError, "INTERNAL"},
+		{"deadline-exceeded", http.StatusGatewayTimeout, "DEADLINE_EXCEEDED"},
+		{"unavailable", http.StatusServiceUnavailable, "UNAVAILABLE"},
+		{"data-loss", http.StatusInternalServerError, "DATA_LOSS"},
+		{"unknown", http.StatusInternalServerError, "UNKNOWN"},
+		{"already-exists", http.StatusConflict, "ALREADY_EXISTS"},
+		{"resource-exhausted", http.StatusTooManyRequests, "RESOURCE_EXHAUSTED"},
+		{"unimplemented", http.StatusNotImplemented, "UNIMPLEMENTED"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.grpcCode, func(t *testing.T) {
+			resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/"+tc.partyID)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tc.httpStatus, resp.StatusCode, "HTTP status for %s", tc.grpcCode)
+
+			result := readJSONBody(t, resp)
+			assert.Equal(t, tc.grpcCode, result["code"], "code field for %s", tc.grpcCode)
+			assert.NotEmpty(t, result["error"], "error field for %s", tc.grpcCode)
+		})
+	}
+}
+
+// TestTranscoding_Error_BodyFormat verifies the canonical error body has the
+// correct fields: error (string), code (string), and no numeric code field.
+func TestTranscoding_Error_BodyFormat(t *testing.T) {
+	env := startTranscodingTestEnv(t, []ServiceBackend{
+		{ServiceName: "meridian.party.v1.PartyService"},
+	})
+
+	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/not-found")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	result := readJSONBody(t, resp)
+
+	// Must have string code
+	code, ok := result["code"].(string)
+	require.True(t, ok, "code field must be a string, got %T", result["code"])
+	assert.Equal(t, "NOT_FOUND", code)
+
+	// Must have error message
+	errMsg, ok := result["error"].(string)
+	require.True(t, ok, "error field must be a string, got %T", result["error"])
+	assert.NotEmpty(t, errMsg)
+
+	// Must NOT have numeric code or message (Vanguard's original format)
+	_, hasNumericCode := result["message"]
+	assert.False(t, hasNumericCode, "response must not contain 'message' field (Vanguard raw format)")
+}
+
+// TestTranscoding_Error_ContentTypeJSON verifies that error responses are returned
+// with application/json Content-Type.
+func TestTranscoding_Error_ContentTypeJSON(t *testing.T) {
+	env := startTranscodingTestEnv(t, []ServiceBackend{
+		{ServiceName: "meridian.party.v1.PartyService"},
+	})
+
+	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/not-found")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+}
+
+// TestTranscoding_Error_MalformedRequestBody tests behavior with invalid JSON body.
+// Vanguard attempts to transcode the body to proto; when that fails the gRPC backend
+// receives an UNKNOWN/INTERNAL error which maps to HTTP 500.
+func TestTranscoding_Error_MalformedRequestBody(t *testing.T) {
+	env := startTranscodingTestEnv(t, []ServiceBackend{
+		{ServiceName: "meridian.party.v1.PartyService"},
+	})
+
+	// Send malformed JSON to a POST endpoint
+	resp, err := httpPost(context.Background(), env.baseURL+"/api/v1/parties", "application/json", strings.NewReader("this is not json"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Malformed JSON results in a proto parsing error; Vanguard maps this to UNKNOWN → 500.
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	// Response should still be JSON with our canonical error format
+	ct := resp.Header.Get("Content-Type")
+	assert.Contains(t, ct, "application/json")
+
+	result := readJSONBody(t, resp)
+	assert.NotEmpty(t, result["error"], "error field must be present")
+	code, ok := result["code"].(string)
+	assert.True(t, ok, "code must be a string")
+	assert.NotEmpty(t, code)
 }
 
 // TestTranscoding_Error_NotFoundTenant tests gRPC NOT_FOUND -> HTTP 404 for tenant.
@@ -609,6 +866,9 @@ func TestTranscoding_Error_NotFoundTenant(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	result := readJSONBody(t, resp)
+	assert.Equal(t, "NOT_FOUND", result["code"])
 }
 
 // TestTranscoding_Error_UnknownRoute tests that an unknown route returns 404.


### PR DESCRIPTION
## Summary

- Introduce `errorReformattingMiddleware` that wraps the Vanguard transcoder and rewrites error responses from Vanguard's `google.rpc.Status` numeric-code format to a canonical API error shape
- All 17 standard gRPC status codes are mapped to string names (e.g. `NOT_FOUND`, `INVALID_ARGUMENT`, `UNAUTHENTICATED`)
- Error body format: `{"error": "<message>", "code": "<GRPC_CODE_NAME>", "details": [...]}`

## Changes Made

**`services/gateway/error_response.go`** (new)
- `errorReformattingMiddleware`: HTTP middleware that intercepts non-2xx responses with `application/json` content-type and rewrites them from Vanguard's numeric `{"code": 5, "message": "...", "details": []}` format to `{"error": "...", "code": "NOT_FOUND", "details": [...]}`
- `grpcCodeNames`: complete lookup table for all 17 gRPC status codes
- `grpcCodeName()`, `isJSONContentType()`: helper functions

**`services/gateway/transcoder.go`**
- Wire `errorReformattingMiddleware` around the Vanguard transcoder in `NewTranscoder`

**`services/gateway/error_response_test.go`** (new)
- Unit tests for `grpcCodeName`, `isJSONContentType`, and the middleware itself (rewrite, pass-through success, pass-through non-JSON, all common error codes)

**`services/gateway/transcoding_test.go`**
- Extended `mockPartyService.RetrieveParty` with 10 additional error code triggers
- Updated existing error tests to verify canonical format (`code` as string, `error` field)
- Added `TestTranscoding_Error_AllStandardCodes` covering 12 gRPC codes end-to-end
- Added `TestTranscoding_Error_BodyFormat` verifying shape (string code, no raw `message`)
- Added `TestTranscoding_Error_ContentTypeJSON` and `TestTranscoding_Error_MalformedRequestBody`

## Technical Details

Vanguard emits errors as `google.rpc.Status` JSON with a numeric `code` field. REST API consumers expect human-readable error codes. The middleware uses a buffered response writer to capture error responses, parses the Vanguard body, and emits the canonical format. Successful (2xx) and non-JSON responses pass through unmodified.

gRPC→HTTP mappings verified:
| gRPC Code | HTTP Status |
|-----------|-------------|
| NOT_FOUND | 404 |
| INVALID_ARGUMENT | 400 |
| UNAUTHENTICATED | 401 |
| PERMISSION_DENIED | 403 |
| INTERNAL | 500 |
| DEADLINE_EXCEEDED | 504 |
| UNAVAILABLE | 503 |
| DATA_LOSS | 500 |
| UNKNOWN | 500 |
| ALREADY_EXISTS | 409 |
| RESOURCE_EXHAUSTED | 429 |
| UNIMPLEMENTED | 501 |

## Test plan

- [x] All pre-existing transcoding tests pass (proto3 JSON, metadata propagation, multi-service)
- [x] 12 gRPC error code mappings verified via `TestTranscoding_Error_AllStandardCodes`
- [x] Canonical error body format verified (string code, `error` field, no `message` field)
- [x] Unit tests for middleware: rewrite, pass-through success, pass-through non-JSON
- [x] `go test ./services/gateway/...` - all pass