### PR TITLE
feat: implement saga routing with product_type prefix resolution

### DIFF
--- a/services/current-account/service/deposit_orchestrator.go
+++ b/services/current-account/service/deposit_orchestrator.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -14,9 +15,11 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/config"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
+	refsaga "github.com/meridianhub/meridian/services/reference-data/saga"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -34,6 +37,7 @@ type DepositOrchestrator struct {
 	fungibilityValidator *FungibilityValidator
 	sagaRunner           *saga.StarlarkSagaRunner
 	depositScript        string
+	sagaResolver         *refsaga.ProductTypeSagaResolver
 }
 
 // DepositOrchestratorConfig contains dependencies for creating a DepositOrchestrator
@@ -52,8 +56,13 @@ type DepositOrchestratorConfig struct {
 	FungibilityValidator *FungibilityValidator
 	// SagaRunner executes Starlark saga definitions.
 	SagaRunner *saga.StarlarkSagaRunner
-	// DepositScript is the Starlark script for the deposit saga.
+	// DepositScript is the Starlark script for the default deposit saga.
+	// Used when SagaResolver is nil or the account has no ProductTypeCode.
 	DepositScript string
+	// SagaResolver optionally resolves the saga definition from the registry
+	// based on the account's ProductTypeCode. When set and the account has a
+	// ProductTypeCode, the resolved script is used instead of DepositScript.
+	SagaResolver *refsaga.ProductTypeSagaResolver
 }
 
 // NewDepositOrchestrator creates a new deposit orchestrator with the given dependencies.
@@ -87,6 +96,7 @@ func NewDepositOrchestrator(cfg DepositOrchestratorConfig) (*DepositOrchestrator
 		fungibilityValidator: cfg.FungibilityValidator,
 		sagaRunner:           cfg.SagaRunner,
 		depositScript:        cfg.DepositScript,
+		sagaResolver:         cfg.SagaResolver,
 	}, nil
 }
 
@@ -189,14 +199,27 @@ func (o *DepositOrchestrator) Orchestrate(ctx context.Context, account domain.Cu
 	})
 	ctx = context.WithValue(ctx, ContextKeyAccount, account)
 
+	// Resolve saga script: use ProductTypeSagaResolver when configured and account has a product type,
+	// otherwise fall back to the static default deposit script.
+	depositScript, err := o.resolveDepositScript(ctx, account)
+	if err != nil {
+		sagaStatus = operationStatusFailed
+		o.logger.Error("failed to resolve deposit saga",
+			"account_id", account.AccountID(),
+			"product_type_code", account.ProductTypeCode(),
+			"error", err)
+		return nil, status.Errorf(codes.NotFound, "deposit saga not found for product type: %v", err)
+	}
+
 	// Execute saga via StarlarkSagaRunner
 	o.logger.Info("executing deposit saga via Starlark",
 		"account_id", account.AccountID(),
 		"transaction_id", transactionID,
 		"saga_execution_id", input.SagaExecutionID,
-		"correlation_id", correlationID)
+		"correlation_id", correlationID,
+		"product_type_code", account.ProductTypeCode())
 
-	output, err := o.sagaRunner.ExecuteSaga(ctx, "current_account_deposit", o.depositScript, input)
+	output, err := o.sagaRunner.ExecuteSaga(ctx, "current_account_deposit", depositScript, input)
 	if err != nil {
 		sagaStatus = operationStatusFailed
 		o.logger.Error("deposit saga failed",
@@ -270,4 +293,50 @@ func (o *DepositOrchestrator) resolveClearingAccountID(ctx context.Context, curr
 	// Neither configured - single-entry mode
 	o.logger.Debug("no clearing account configured, operating in single-entry mode")
 	return ""
+}
+
+// resolveDepositScript returns the saga script to execute for the given account.
+//
+// Resolution order:
+//  1. If SagaResolver is configured and the account has a ProductTypeCode, resolve the
+//     saga definition from the registry using ProductTypeSagaResolver. The definition's
+//     ResolvedScript is used. If the resolver returns ErrSagaNotFound, the error is
+//     propagated (fail-fast: a prefixed product type must have a corresponding saga).
+//  2. Otherwise, fall back to the static default DepositScript.
+func (o *DepositOrchestrator) resolveDepositScript(ctx context.Context, account domain.CurrentAccount) (string, error) {
+	if o.sagaResolver == nil || account.ProductTypeCode() == "" {
+		return o.depositScript, nil
+	}
+
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		// No tenant context — fall back to static script
+		return o.depositScript, nil
+	}
+
+	def, err := o.sagaResolver.ResolveForProductType(ctx, tenantID, account.ProductTypeCode(), "deposit")
+	if err != nil {
+		if errors.Is(err, refsaga.ErrSagaNotFound) {
+			// Prefix is defined but no saga found — fail fast per PRD convention
+			return "", err
+		}
+		// ErrNotFound (product type or generic saga missing) — fall back to static script
+		o.logger.Warn("saga resolution fell through to default deposit script",
+			"product_type_code", account.ProductTypeCode(),
+			"error", err)
+		return o.depositScript, nil
+	}
+
+	if def.ResolvedScript == "" {
+		// Definition has no resolved script — fall back to static script
+		o.logger.Warn("resolved saga definition has no script, using default",
+			"saga_name", def.Name,
+			"product_type_code", account.ProductTypeCode())
+		return o.depositScript, nil
+	}
+
+	o.logger.Debug("using product-type-specific deposit saga",
+		"saga_name", def.Name,
+		"product_type_code", account.ProductTypeCode())
+	return def.ResolvedScript, nil
 }

--- a/services/current-account/service/withdrawal_orchestrator.go
+++ b/services/current-account/service/withdrawal_orchestrator.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -14,9 +15,11 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/config"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
+	refsaga "github.com/meridianhub/meridian/services/reference-data/saga"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -35,6 +38,7 @@ type WithdrawalOrchestrator struct {
 	fungibilityValidator *FungibilityValidator
 	sagaRunner           *saga.StarlarkSagaRunner
 	withdrawalScript     string
+	sagaResolver         *refsaga.ProductTypeSagaResolver
 }
 
 // WithdrawalOrchestratorConfig contains dependencies for creating a WithdrawalOrchestrator
@@ -53,8 +57,13 @@ type WithdrawalOrchestratorConfig struct {
 	FungibilityValidator *FungibilityValidator
 	// SagaRunner executes Starlark saga definitions.
 	SagaRunner *saga.StarlarkSagaRunner
-	// WithdrawalScript is the Starlark script for the withdrawal saga.
+	// WithdrawalScript is the Starlark script for the default withdrawal saga.
+	// Used when SagaResolver is nil or the account has no ProductTypeCode.
 	WithdrawalScript string
+	// SagaResolver optionally resolves the saga definition from the registry
+	// based on the account's ProductTypeCode. When set and the account has a
+	// ProductTypeCode, the resolved script is used instead of WithdrawalScript.
+	SagaResolver *refsaga.ProductTypeSagaResolver
 }
 
 // NewWithdrawalOrchestrator creates a new withdrawal orchestrator with the given dependencies.
@@ -88,6 +97,7 @@ func NewWithdrawalOrchestrator(cfg WithdrawalOrchestratorConfig) (*WithdrawalOrc
 		fungibilityValidator: cfg.FungibilityValidator,
 		sagaRunner:           cfg.SagaRunner,
 		withdrawalScript:     cfg.WithdrawalScript,
+		sagaResolver:         cfg.SagaResolver,
 	}, nil
 }
 
@@ -191,14 +201,27 @@ func (o *WithdrawalOrchestrator) Orchestrate(ctx context.Context, account domain
 	})
 	ctx = context.WithValue(ctx, ContextKeyAccount, account)
 
+	// Resolve saga script: use ProductTypeSagaResolver when configured and account has a product type,
+	// otherwise fall back to the static default withdrawal script.
+	withdrawalScript, err := o.resolveWithdrawalScript(ctx, account)
+	if err != nil {
+		sagaStatus = operationStatusFailed
+		o.logger.Error("failed to resolve withdrawal saga",
+			"account_id", account.AccountID(),
+			"product_type_code", account.ProductTypeCode(),
+			"error", err)
+		return nil, status.Errorf(codes.NotFound, "withdrawal saga not found for product type: %v", err)
+	}
+
 	// Execute saga via StarlarkSagaRunner
 	o.logger.Info("executing withdrawal saga via Starlark",
 		"account_id", account.AccountID(),
 		"transaction_id", transactionID,
 		"saga_execution_id", input.SagaExecutionID,
-		"correlation_id", correlationID)
+		"correlation_id", correlationID,
+		"product_type_code", account.ProductTypeCode())
 
-	output, err := o.sagaRunner.ExecuteSaga(ctx, "current_account_withdrawal", o.withdrawalScript, input)
+	output, err := o.sagaRunner.ExecuteSaga(ctx, "current_account_withdrawal", withdrawalScript, input)
 	if err != nil {
 		sagaStatus = operationStatusFailed
 		o.logger.Error("withdrawal saga failed",
@@ -266,4 +289,50 @@ func (o *WithdrawalOrchestrator) resolveClearingAccountID(ctx context.Context, c
 	// Neither configured - single-entry mode
 	o.logger.Debug("no clearing account configured, operating in single-entry mode")
 	return ""
+}
+
+// resolveWithdrawalScript returns the saga script to execute for the given account.
+//
+// Resolution order:
+//  1. If SagaResolver is configured and the account has a ProductTypeCode, resolve the
+//     saga definition from the registry using ProductTypeSagaResolver. The definition's
+//     ResolvedScript is used. If the resolver returns ErrSagaNotFound, the error is
+//     propagated (fail-fast: a prefixed product type must have a corresponding saga).
+//  2. Otherwise, fall back to the static default WithdrawalScript.
+func (o *WithdrawalOrchestrator) resolveWithdrawalScript(ctx context.Context, account domain.CurrentAccount) (string, error) {
+	if o.sagaResolver == nil || account.ProductTypeCode() == "" {
+		return o.withdrawalScript, nil
+	}
+
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		// No tenant context — fall back to static script
+		return o.withdrawalScript, nil
+	}
+
+	def, err := o.sagaResolver.ResolveForProductType(ctx, tenantID, account.ProductTypeCode(), "withdrawal")
+	if err != nil {
+		if errors.Is(err, refsaga.ErrSagaNotFound) {
+			// Prefix is defined but no saga found — fail fast per PRD convention
+			return "", err
+		}
+		// ErrNotFound (product type or generic saga missing) — fall back to static script
+		o.logger.Warn("saga resolution fell through to default withdrawal script",
+			"product_type_code", account.ProductTypeCode(),
+			"error", err)
+		return o.withdrawalScript, nil
+	}
+
+	if def.ResolvedScript == "" {
+		// Definition has no resolved script — fall back to static script
+		o.logger.Warn("resolved saga definition has no script, using default",
+			"saga_name", def.Name,
+			"product_type_code", account.ProductTypeCode())
+		return o.withdrawalScript, nil
+	}
+
+	o.logger.Debug("using product-type-specific withdrawal saga",
+		"saga_name", def.Name,
+		"product_type_code", account.ProductTypeCode())
+	return def.ResolvedScript, nil
 }

--- a/services/reference-data/saga/product_type_resolver.go
+++ b/services/reference-data/saga/product_type_resolver.go
@@ -2,6 +2,7 @@ package saga
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/meridianhub/meridian/services/reference-data/cache"
@@ -60,8 +61,15 @@ func (r *ProductTypeSagaResolver) ResolveForProductType(
 	sagaName := prefix + "." + operation
 	def, err := r.registry.GetActive(ctx, sagaName)
 	if err != nil {
-		return nil, fmt.Errorf("%w: no saga '%s' found for product type '%s' operation '%s'",
-			ErrSagaNotFound, sagaName, productTypeCode, operation)
+		if errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("%w: no saga '%s' found for product type '%s' operation '%s'",
+				ErrSagaNotFound, sagaName, productTypeCode, operation)
+		}
+		// Propagate transient errors (e.g. DB timeout, context cancellation) without
+		// wrapping as ErrSagaNotFound, so callers can distinguish infrastructure failures
+		// from a genuinely missing saga definition.
+		return nil, fmt.Errorf("failed to resolve saga '%s' for product type '%s': %w",
+			sagaName, productTypeCode, err)
 	}
 	return def, nil
 }

--- a/services/reference-data/saga/product_type_resolver.go
+++ b/services/reference-data/saga/product_type_resolver.go
@@ -1,0 +1,67 @@
+package saga
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/meridianhub/meridian/services/reference-data/cache"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// ProductTypeSagaResolver resolves saga definitions based on an account's product type.
+//
+// Resolution rules:
+//   - If the product type has a non-empty DefaultSagaPrefix, the saga name is
+//     "{prefix}.{operation}". If no active saga with that name exists,
+//     ErrSagaNotFound is returned — there is NO fallback to the generic operation.
+//   - If the product type has an empty DefaultSagaPrefix, the generic "{operation}"
+//     saga is resolved via the underlying Registry.
+//   - If the product type code is not found in the cache, the generic "{operation}"
+//     saga is resolved as a fallback.
+type ProductTypeSagaResolver struct {
+	registry         Registry
+	accountTypeCache *cache.LocalAccountTypeCache
+}
+
+// NewProductTypeSagaResolver creates a new ProductTypeSagaResolver.
+func NewProductTypeSagaResolver(registry Registry, accountTypeCache *cache.LocalAccountTypeCache) *ProductTypeSagaResolver {
+	return &ProductTypeSagaResolver{
+		registry:         registry,
+		accountTypeCache: accountTypeCache,
+	}
+}
+
+// ResolveForProductType resolves the saga definition for a given product type and operation.
+//
+// If the product type has a DefaultSagaPrefix, the saga name "{prefix}.{operation}" is
+// resolved. If that saga is not found, ErrSagaNotFound is returned (no fallback to generic).
+//
+// If the product type has no DefaultSagaPrefix, or if the product type is not found in
+// the cache, the generic "{operation}" saga is resolved.
+func (r *ProductTypeSagaResolver) ResolveForProductType(
+	ctx context.Context,
+	tenantID tenant.TenantID,
+	productTypeCode string,
+	operation string,
+) (*Definition, error) {
+	cached, err := r.accountTypeCache.GetOrLoad(ctx, tenantID, productTypeCode)
+	if err != nil {
+		// Product type not found or unavailable — fall back to generic operation.
+		return r.registry.GetActive(ctx, operation)
+	}
+
+	prefix := cached.Definition.DefaultSagaPrefix
+	if prefix == "" {
+		// No prefix defined — resolve generic operation.
+		return r.registry.GetActive(ctx, operation)
+	}
+
+	// Prefix defined — resolve "{prefix}.{operation}" with no fallback.
+	sagaName := prefix + "." + operation
+	def, err := r.registry.GetActive(ctx, sagaName)
+	if err != nil {
+		return nil, fmt.Errorf("%w: no saga '%s' found for product type '%s' operation '%s'",
+			ErrSagaNotFound, sagaName, productTypeCode, operation)
+	}
+	return def, nil
+}

--- a/services/reference-data/saga/product_type_resolver_test.go
+++ b/services/reference-data/saga/product_type_resolver_test.go
@@ -1,0 +1,245 @@
+package saga_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+	"github.com/meridianhub/meridian/services/reference-data/cache"
+	"github.com/meridianhub/meridian/services/reference-data/saga"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Fake registry ---
+
+type fakeRegistry struct {
+	sagas map[string]*saga.Definition
+}
+
+func (f *fakeRegistry) GetByID(_ context.Context, id uuid.UUID) (*saga.Definition, error) {
+	for _, d := range f.sagas {
+		if d.ID == id {
+			return d, nil
+		}
+	}
+	return nil, saga.ErrNotFound
+}
+
+func (f *fakeRegistry) GetDefinition(_ context.Context, name string, _ int) (*saga.Definition, error) {
+	if d, ok := f.sagas[name]; ok {
+		return d, nil
+	}
+	return nil, saga.ErrNotFound
+}
+
+func (f *fakeRegistry) GetActive(_ context.Context, name string) (*saga.Definition, error) {
+	if d, ok := f.sagas[name]; ok {
+		return d, nil
+	}
+	return nil, saga.ErrNotFound
+}
+
+func (f *fakeRegistry) ListByStatus(_ context.Context, _ saga.Status) ([]*saga.Definition, error) {
+	return nil, nil
+}
+
+func (f *fakeRegistry) CreateDraft(_ context.Context, _ *saga.Definition) error {
+	return nil
+}
+
+func (f *fakeRegistry) UpdateDefinition(_ context.Context, _ uuid.UUID, _ *saga.Definition) error {
+	return nil
+}
+
+func (f *fakeRegistry) ActivateSaga(_ context.Context, _ uuid.UUID) error {
+	return nil
+}
+
+func (f *fakeRegistry) DeprecateSaga(_ context.Context, _ uuid.UUID, _ *uuid.UUID) error {
+	return nil
+}
+
+// --- Fake account type loader for cache ---
+
+type fakeAccountTypeLoader struct {
+	types map[string]*accounttype.Definition
+}
+
+func (f *fakeAccountTypeLoader) LoadAccountType(_ context.Context, code string) (*accounttype.Definition, error) {
+	if d, ok := f.types[code]; ok {
+		return d, nil
+	}
+	return nil, accounttype.ErrNotFound
+}
+
+func (f *fakeAccountTypeLoader) ListActiveAccountTypes(_ context.Context) ([]*accounttype.Definition, error) {
+	list := make([]*accounttype.Definition, 0, len(f.types))
+	for _, d := range f.types {
+		list = append(list, d)
+	}
+	return list, nil
+}
+
+// buildCache returns a LocalAccountTypeCache with the given loader and no CEL compiler.
+func buildCache(loader cache.AccountTypeLoader) *cache.LocalAccountTypeCache {
+	return cache.NewLocalAccountTypeCache(loader, nil)
+}
+
+// tenantCtx returns a context with a test tenant ID set.
+func tenantCtxForResolver(t *testing.T) context.Context {
+	t.Helper()
+	tid := tenant.TenantID("test-tenant-resolver")
+	return tenant.WithTenant(context.Background(), tid)
+}
+
+func TestProductTypeSagaResolver_ResolveForProductType(t *testing.T) {
+	t.Run("product type with DefaultSagaPrefix resolves prefixed saga name", func(t *testing.T) {
+		ctx := tenantCtxForResolver(t)
+		tid, _ := tenant.FromContext(ctx)
+
+		registry := &fakeRegistry{
+			sagas: map[string]*saga.Definition{
+				"SAVINGS.deposit": {
+					ID:     uuid.New(),
+					Name:   "SAVINGS.deposit",
+					Status: saga.StatusActive,
+					Script: "def main(): pass",
+				},
+			},
+		}
+
+		loader := &fakeAccountTypeLoader{
+			types: map[string]*accounttype.Definition{
+				"SAVINGS_ACCOUNT": {
+					Code:              "SAVINGS_ACCOUNT",
+					DefaultSagaPrefix: "SAVINGS",
+					Status:            accounttype.StatusActive,
+				},
+			},
+		}
+
+		resolver := saga.NewProductTypeSagaResolver(registry, buildCache(loader))
+		def, err := resolver.ResolveForProductType(ctx, tid, "SAVINGS_ACCOUNT", "deposit")
+
+		require.NoError(t, err)
+		assert.Equal(t, "SAVINGS.deposit", def.Name)
+	})
+
+	t.Run("prefixed saga not found returns ErrSagaNotFound with no fallback", func(t *testing.T) {
+		ctx := tenantCtxForResolver(t)
+		tid, _ := tenant.FromContext(ctx)
+
+		registry := &fakeRegistry{
+			// "SAVINGS.deposit" does NOT exist - only the generic "deposit"
+			sagas: map[string]*saga.Definition{
+				"deposit": {
+					ID:     uuid.New(),
+					Name:   "deposit",
+					Status: saga.StatusActive,
+					Script: "def main(): pass",
+				},
+			},
+		}
+
+		loader := &fakeAccountTypeLoader{
+			types: map[string]*accounttype.Definition{
+				"SAVINGS_ACCOUNT": {
+					Code:              "SAVINGS_ACCOUNT",
+					DefaultSagaPrefix: "SAVINGS",
+					Status:            accounttype.StatusActive,
+				},
+			},
+		}
+
+		resolver := saga.NewProductTypeSagaResolver(registry, buildCache(loader))
+		_, err := resolver.ResolveForProductType(ctx, tid, "SAVINGS_ACCOUNT", "deposit")
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, saga.ErrSagaNotFound),
+			"expected ErrSagaNotFound, got: %v", err)
+	})
+
+	t.Run("product type with empty DefaultSagaPrefix resolves generic operation", func(t *testing.T) {
+		ctx := tenantCtxForResolver(t)
+		tid, _ := tenant.FromContext(ctx)
+
+		registry := &fakeRegistry{
+			sagas: map[string]*saga.Definition{
+				"deposit": {
+					ID:     uuid.New(),
+					Name:   "deposit",
+					Status: saga.StatusActive,
+					Script: "def main(): pass",
+				},
+			},
+		}
+
+		loader := &fakeAccountTypeLoader{
+			types: map[string]*accounttype.Definition{
+				"GENERIC_ACCOUNT": {
+					Code:              "GENERIC_ACCOUNT",
+					DefaultSagaPrefix: "", // no prefix
+					Status:            accounttype.StatusActive,
+				},
+			},
+		}
+
+		resolver := saga.NewProductTypeSagaResolver(registry, buildCache(loader))
+		def, err := resolver.ResolveForProductType(ctx, tid, "GENERIC_ACCOUNT", "deposit")
+
+		require.NoError(t, err)
+		assert.Equal(t, "deposit", def.Name)
+	})
+
+	t.Run("product type not found falls back to generic operation", func(t *testing.T) {
+		ctx := tenantCtxForResolver(t)
+		tid, _ := tenant.FromContext(ctx)
+
+		registry := &fakeRegistry{
+			sagas: map[string]*saga.Definition{
+				"deposit": {
+					ID:     uuid.New(),
+					Name:   "deposit",
+					Status: saga.StatusActive,
+					Script: "def main(): pass",
+				},
+			},
+		}
+
+		loader := &fakeAccountTypeLoader{
+			types: map[string]*accounttype.Definition{
+				// UNKNOWN_TYPE not registered
+			},
+		}
+
+		resolver := saga.NewProductTypeSagaResolver(registry, buildCache(loader))
+		def, err := resolver.ResolveForProductType(ctx, tid, "UNKNOWN_TYPE", "deposit")
+
+		require.NoError(t, err)
+		assert.Equal(t, "deposit", def.Name)
+	})
+
+	t.Run("product type not found and generic saga not found returns ErrNotFound", func(t *testing.T) {
+		ctx := tenantCtxForResolver(t)
+		tid, _ := tenant.FromContext(ctx)
+
+		registry := &fakeRegistry{
+			sagas: map[string]*saga.Definition{},
+		}
+
+		loader := &fakeAccountTypeLoader{
+			types: map[string]*accounttype.Definition{},
+		}
+
+		resolver := saga.NewProductTypeSagaResolver(registry, buildCache(loader))
+		_, err := resolver.ResolveForProductType(ctx, tid, "UNKNOWN_TYPE", "deposit")
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, saga.ErrNotFound),
+			"expected ErrNotFound, got: %v", err)
+	})
+}

--- a/services/reference-data/saga/registry.go
+++ b/services/reference-data/saga/registry.go
@@ -68,6 +68,11 @@ var (
 	// ErrNoScriptSource is returned when a saga has neither a custom script nor a platform_ref.
 	ErrNoScriptSource = errors.New("saga has no script source: neither custom script nor platform reference")
 
+	// ErrSagaNotFound is returned when no saga is found for a given product type prefix and operation.
+	// This is distinct from ErrNotFound: ErrSagaNotFound is used when prefix-based resolution
+	// fails with no fallback (a product type has a DefaultSagaPrefix but no matching saga exists).
+	ErrSagaNotFound = errors.New("saga not found for product type operation")
+
 	// ErrScriptHashMismatch is returned during replay when the pinned script hash
 	// does not match the current script, indicating potential corruption.
 	ErrScriptHashMismatch = errors.New("script hash mismatch: pinned version differs from current")


### PR DESCRIPTION
## Summary

- Adds `ProductTypeSagaResolver` in `services/reference-data/saga/` that routes saga execution to `{prefix}.{operation}` when a product type's `DefaultSagaPrefix` is non-empty
- Fail-fast convention: when a prefix is configured, `ErrSagaNotFound` is returned if no matching saga exists (no silent fallback to the generic operation)
- Fallback behaviour: product type not found in cache, or prefix is empty → resolve the generic `{operation}` saga
- Integrates resolver into `DepositOrchestrator` and `WithdrawalOrchestrator`; the `SagaResolver` field is optional so existing static-script behaviour is unchanged
- Adds `ErrSagaNotFound` sentinel to the saga registry package (distinct from `ErrNotFound`)

## Test plan

- [x] Unit tests for `ProductTypeSagaResolver` (5 scenarios: prefix match, prefix miss → ErrSagaNotFound, no prefix → generic, product type unknown → generic, both unknown → ErrNotFound)
- [x] Build passes (`go build ./...`)
- [x] `go vet` clean on changed packages
- [x] golangci-lint passes (pre-commit hook)