### PR TITLE
docs: Add JSON API documentation, onboarding guide, and Vanguard ADR

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,65 +190,75 @@ grpcurl -plaintext localhost:50051 describe meridian.party.v1.RegisterPartyReque
 
 ### Basic Business Flow
 
-The following commands execute a complete deposit flow: create a party, open an account, and post a
-deposit. All commands target the HTTP gateway on port 8090.
+The gateway accepts REST/JSON on port 8090 and native gRPC on port 50051. The following commands
+execute a complete deposit flow via the HTTP/JSON gateway.
 
 ```bash
 # 1. Register a party (customer)
 PARTY=$(curl -s -X POST http://localhost:8090/v1/parties \
   -H "Content-Type: application/json" \
-  -d '{"party_type": "PARTY_TYPE_INDIVIDUAL", "legal_name": "Alice Smith"}')
+  -H "X-Tenant-ID: default" \
+  -d '{"partyType": "PARTY_TYPE_PERSON", "legalName": "Alice Smith"}')
 echo $PARTY | jq .
-PARTY_ID=$(echo $PARTY | jq -r '.partyId')
+PARTY_ID=$(echo $PARTY | jq -r '.party.partyId')
 
-# 2. Open a current account
+# 2. Open a current account (GBP)
 ACCOUNT=$(curl -s -X POST http://localhost:8090/v1/current-accounts \
   -H "Content-Type: application/json" \
+  -H "X-Tenant-ID: default" \
   -d "{
-    \"party_id\": \"$PARTY_ID\",
-    \"account_identification\": \"GB29NWBK60161331926819\",
-    \"base_currency\": \"CURRENCY_GBP\"
+    \"partyId\": \"$PARTY_ID\",
+    \"accountIdentification\": \"GB29NWBK60161331926819\",
+    \"baseCurrency\": \"CURRENCY_GBP\"
   }")
 echo $ACCOUNT | jq .
-ACCOUNT_ID=$(echo $ACCOUNT | jq -r '.accountId')
+ACCOUNT_ID=$(echo $ACCOUNT | jq -r '.facility.accountId')
 
-# 3. Execute a deposit
+# 3. Deposit 100 GBP
 curl -s -X POST "http://localhost:8090/v1/current-accounts/$ACCOUNT_ID/deposits" \
   -H "Content-Type: application/json" \
+  -H "X-Tenant-ID: default" \
   -d '{
-    "amount": {"amount": {"currency_code": "GBP", "units": "100", "nanos": 0}},
+    "amount": {"amount": {"currencyCode": "GBP", "units": "100"}},
     "description": "Initial deposit",
-    "reference": "REF-001"
+    "reference": "REF-001",
+    "idempotencyKey": {"key": "dep-001"}
   }' | jq .
 
-# 4. Retrieve the account to verify balance
-curl -s "http://localhost:8090/v1/current-accounts/$ACCOUNT_ID" | jq .
+# 4. Check balances
+curl -s "http://localhost:8090/v1/accounts/$ACCOUNT_ID/balances" \
+  -H "X-Tenant-ID: default" | jq .
 ```
 
-The same flow is available over gRPC:
+The same flow is available over native gRPC (bypasses the gateway):
 
 ```bash
 # Register a party
-grpcurl -plaintext -d '{
-  "party_type": "PARTY_TYPE_INDIVIDUAL",
-  "legal_name": "Alice Smith"
-}' localhost:50051 meridian.party.v1.PartyService/RegisterParty
+grpcurl -plaintext \
+  -H "x-tenant-id: default" \
+  -d '{"partyType": "PARTY_TYPE_PERSON", "legalName": "Alice Smith"}' \
+  localhost:50051 meridian.party.v1.PartyService/RegisterParty
 
 # Open a current account (substitute PARTY_ID from previous response)
-grpcurl -plaintext -d '{
-  "party_id": "PARTY_ID",
-  "account_identification": "GB29NWBK60161331926819",
-  "base_currency": "CURRENCY_GBP"
-}' localhost:50051 meridian.current_account.v1.CurrentAccountService/InitiateCurrentAccount
+grpcurl -plaintext \
+  -H "x-tenant-id: default" \
+  -d '{"partyId": "PARTY_ID", "accountIdentification": "GB29NWBK60161331926819", "baseCurrency": "CURRENCY_GBP"}' \
+  localhost:50051 meridian.current_account.v1.CurrentAccountService/InitiateCurrentAccount
 
-# Execute a deposit (substitute ACCOUNT_ID from previous response)
-grpcurl -plaintext -d '{
-  "account_id": "ACCOUNT_ID",
-  "amount": {"amount": {"currency_code": "GBP", "units": "100"}},
-  "description": "Initial deposit",
-  "reference": "REF-001"
-}' localhost:50051 meridian.current_account.v1.CurrentAccountService/ExecuteDeposit
+# Deposit 100 GBP (substitute ACCOUNT_ID from previous response)
+grpcurl -plaintext \
+  -H "x-tenant-id: default" \
+  -d '{
+    "accountId": "ACCOUNT_ID",
+    "amount": {"amount": {"currencyCode": "GBP", "units": "100"}},
+    "description": "Initial deposit",
+    "reference": "REF-001"
+  }' \
+  localhost:50051 meridian.current_account.v1.CurrentAccountService/ExecuteDeposit
 ```
+
+See [docs/guides/calling-meridian-apis.md](docs/guides/calling-meridian-apis.md) for a detailed
+API guide covering all supported protocols, error handling, and tenant isolation.
 
 ### API Explorer
 

--- a/docs/adr/0032-vanguard-json-transcoding-gateway.md
+++ b/docs/adr/0032-vanguard-json-transcoding-gateway.md
@@ -1,0 +1,216 @@
+---
+name: adr-0032-vanguard-json-transcoding-gateway
+description: Use Vanguard (connectrpc.com/vanguard) as the HTTP/JSON-to-gRPC transcoding layer in the API gateway
+triggers:
+  - Adding new protocol support to the gateway (REST, Connect, gRPC-Web)
+  - Evaluating protocol translation options for gRPC backends
+  - Understanding why the gateway accepts HTTP/JSON but backends speak only gRPC
+  - Choosing between gRPC-gateway and Vanguard for REST transcoding
+instructions: |
+  The gateway uses Vanguard to translate between REST/JSON, Connect, gRPC-Web, and native gRPC.
+  Backend services always speak gRPC; Vanguard handles all protocol translation at the gateway edge.
+  HTTP/JSON URL paths and request shapes come from google.api.http annotations in the proto files.
+  Run `make proto-descriptors` to regenerate the embedded FileDescriptorSet after proto changes.
+---
+
+# 32. Vanguard HTTP/JSON Transcoding Gateway
+
+Date: 2026-02-20
+
+## Status
+
+Accepted
+
+## Context
+
+Meridian's backend services communicate exclusively over gRPC using Protocol Buffers. External clients
+(browsers, curl, mobile applications) need to call these services using familiar HTTP/JSON semantics.
+
+Two widely-used options exist for bridging HTTP/JSON to gRPC:
+
+1. **grpc-gateway** (grpc-ecosystem/grpc-gateway) — generates a separate reverse proxy that translates
+   REST requests to gRPC. The proxy binary is generated from proto annotations at compile time.
+
+2. **Vanguard** (connectrpc.com/vanguard) — an embeddable Go library that translates between REST/JSON,
+   Connect, gRPC-Web, and gRPC in-process, using a compiled proto `FileDescriptorSet` loaded at startup.
+
+The gateway service needed to expose all backend gRPC services over HTTP/JSON without requiring
+changes to the backend services themselves.
+
+## Decision Drivers
+
+* **Protocol breadth**: Support REST/JSON for external clients, Connect for browser clients, gRPC-Web
+  for legacy proxies, and native gRPC passthrough — from a single gateway port.
+* **No backend changes**: Backend services must not need modification. The transcoding layer should
+  be transparent to them.
+* **Embeddable**: The transcoder should run inside the existing gateway Go binary without a separate
+  proxy process.
+* **Schema-driven**: URL routing and request/response mapping must come from proto annotations
+  (`google.api.http`), keeping the source of truth in the proto files.
+* **Maintainability**: Generated code should be minimal; runtime schema loading is preferred over
+  compile-time code generation for proxy logic.
+
+## Considered Options
+
+1. **grpc-gateway** — Generate an HTTP reverse proxy binary from proto annotations
+2. **Vanguard** — Embed a transcoding handler in the existing gateway service
+3. **Custom transcoding** — Write bespoke HTTP-to-gRPC translation per service
+
+## Decision Outcome
+
+Chosen option: **Vanguard**, because it satisfies all decision drivers with the least operational
+complexity.
+
+### Positive Consequences
+
+* A single gateway binary handles REST/JSON, Connect, gRPC-Web, and gRPC-native requests without
+  any additional processes.
+* Backend services require zero changes — they continue to accept only gRPC connections.
+* URL routing and field mapping are derived from existing `google.api.http` proto annotations,
+  which are already maintained for documentation purposes.
+* The compiled `FileDescriptorSet` (`descriptor.binpb`) is embedded in the binary at build time
+  and loaded at startup; adding a new service requires only regenerating the descriptor and
+  registering a `ServiceBackend`.
+* Protocol selection is automatic, driven by the request `Content-Type` header; the same URL can
+  serve REST/JSON and Connect clients without configuration.
+
+### Negative Consequences
+
+* The `descriptor.binpb` file must be regenerated (`make proto-descriptors`) after any proto
+  change and committed to the repository.
+* Vanguard is a relatively new library (connectrpc.com ecosystem); grpc-gateway has a longer
+  production history and larger community.
+* Streaming RPCs require HTTP/2 when using gRPC-Web or native gRPC; REST/JSON clients cannot
+  use server-streaming or bidirectional-streaming RPCs.
+
+## Pros and Cons of the Options
+
+### grpc-gateway
+
+Generates a standalone Go HTTP proxy from proto annotations via `protoc-gen-grpc-gateway`. The
+generated proxy translates REST requests to gRPC calls.
+
+* Good, because it has a large community and extensive documentation
+* Good, because URL routing is statically checked at code-generation time
+* Bad, because it produces a separate binary (or large generated source files) per service
+* Bad, because it supports only REST↔gRPC translation; Connect and gRPC-Web require additional middleware
+* Bad, because generated files must be regenerated and committed on every proto change, adding noise
+
+### Vanguard
+
+An embeddable Go library that performs live protocol translation using a runtime-loaded proto
+`FileDescriptorSet`.
+
+* Good, because it handles REST/JSON, Connect, gRPC-Web, and native gRPC from one handler
+* Good, because no code generation is required beyond the existing `buf generate` step
+* Good, because adding a new service only requires updating `descriptor.binpb` and a `ServiceBackend` entry
+* Good, because it integrates cleanly with the existing `http.Handler` middleware chain
+* Bad, because the descriptor binary must be kept in sync with proto definitions
+* Bad, because it is newer and less widely adopted than grpc-gateway
+
+### Custom transcoding
+
+Implement HTTP-to-gRPC translation by hand for each service endpoint.
+
+* Good, because it gives complete control over request/response transformation
+* Bad, because it is a large maintenance burden as the number of endpoints grows
+* Bad, because it duplicates logic already handled by proto annotations and existing libraries
+
+## Architecture
+
+### Protocol Flow
+
+```
+Client
+  │
+  ├─ REST/JSON   (Content-Type: application/json)
+  ├─ Connect     (Content-Type: application/connect+json)
+  ├─ gRPC-Web    (Content-Type: application/grpc-web+proto)
+  │
+  ▼
+Gateway :8090  (HTTP/1.1 or HTTP/2)
+  └─ Vanguard Transcoder
+       │  translates to gRPC
+       ▼
+Backend Service :50051  (gRPC/HTTP2 only)
+```
+
+Native gRPC clients that support HTTP/2 can connect directly to any backend service on port 50051,
+bypassing the gateway entirely.
+
+### Service Registration
+
+Each backend service is registered with Vanguard by providing its fully-qualified proto service
+name and backend address:
+
+```go
+backends := []gateway.ServiceBackend{
+    {ServiceName: "meridian.party.v1.PartyService",           BackendAddr: "party-service:50051"},
+    {ServiceName: "meridian.current_account.v1.CurrentAccountService", BackendAddr: "current-account-service:50051"},
+    // ... one entry per backend service
+}
+handler, err := gateway.NewTranscoder(descriptorBytes, backends)
+```
+
+The `descriptorBytes` are the embedded `cmd/meridian/descriptor.binpb` file, produced by
+`make proto-descriptors` (`buf build api/proto -o cmd/meridian/descriptor.binpb`).
+
+### URL Path Mapping
+
+REST URL paths are derived from `google.api.http` annotations in the proto files:
+
+```protobuf
+rpc RegisterParty(RegisterPartyRequest) returns (RegisterPartyResponse) {
+  option (google.api.http) = {
+    post: "/v1/parties"
+    body: "*"
+  };
+}
+```
+
+This maps `POST /api/v1/parties` to `PartyService.RegisterParty`. The `/api` prefix is stripped
+by the gateway's route registration (`http.StripPrefix`).
+
+### Header Propagation
+
+The `metadataPropagationMiddleware` runs before Vanguard and:
+
+1. Strips any incoming `x-user-id`, `x-tenant-id`, `x-auth-method`, `x-auth-roles` headers
+   (to prevent spoofing).
+2. Injects authenticated identity from the auth context as lowercase metadata headers, which
+   Vanguard forwards to the gRPC backend as incoming metadata.
+
+## Proto Descriptor Build Step
+
+The descriptor is built and embedded at compile time:
+
+```bash
+# Regenerate after any proto change
+make proto-descriptors
+# This runs: buf build api/proto -o cmd/meridian/descriptor.binpb
+```
+
+The file is committed to the repository so that the gateway binary can be built without running
+`buf build` in production CI. The `cmd/meridian/main.go` embeds it with:
+
+```go
+//go:embed descriptor.binpb
+var descriptorBytes []byte
+```
+
+## Links
+
+* [connectrpc.com/vanguard documentation](https://pkg.go.dev/connectrpc.com/vanguard)
+* [grpc-ecosystem/grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway)
+* [google.api.http annotation reference](https://cloud.google.com/endpoints/docs/grpc/transcoding)
+* [ADR-0002: Microservices per BIAN Domain](0002-microservices-per-bian-domain.md)
+* [ADR-0010: gRPC Client-Side Load Balancing](0010-grpc-client-side-load-balancing.md)
+* Related code: `services/gateway/transcoder.go`, `cmd/meridian/main.go`
+
+## Notes
+
+Re-evaluate if the gateway needs advanced features not yet in Vanguard (e.g., request-level
+WebSocket bridging, rich response streaming for REST clients). At that point grpc-gateway or
+a custom layer may offer more control. The decision to use a single embedded `descriptor.binpb`
+for all services should be revisited if the total proto surface grows large enough to cause
+meaningful startup latency from descriptor parsing.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -78,6 +78,8 @@ Architectural Decision Records) format.
 | [ADR-0028](0028-starlark-saga-cel-valuation.md) | Starlark Saga Orchestration with CEL Valuation | Accepted | 2025-01-20 |
 <!-- markdownlint-disable-next-line MD013 -->
 | [ADR-0031](0031-getbalance-nil-guard-retention.md) | Retain Nil Guard on PositionKeepingClient in GetBalance | Accepted | 2026-02-13 |
+<!-- markdownlint-disable-next-line MD013 -->
+| [ADR-0032](0032-vanguard-json-transcoding-gateway.md) | Vanguard HTTP/JSON Transcoding Gateway | Accepted | 2026-02-20 |
 
 ## Architecture Decision Relationships
 
@@ -141,6 +143,10 @@ graph LR
 ### Quality & Testing
 
 - [ADR-0008](0008-defensive-testing-standards.md) - Defensive Testing Standards
+
+### API Gateway & Protocols
+
+- [ADR-0032](0032-vanguard-json-transcoding-gateway.md) - Vanguard HTTP/JSON Transcoding Gateway
 
 ### Multi-Tenancy
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -6,6 +6,7 @@ This directory contains how-to guides and usage documentation for Meridian devel
 
 | Guide | Description |
 |-------|-------------|
+| [Calling Meridian APIs](calling-meridian-apis.md) | HTTP/JSON, Connect, and gRPC — authentication, tenant isolation, quick start |
 | [Multi-Asset Integration](multi-asset-integration.md) | End-to-end guide for tracking non-fiat instruments (energy, carbon, compute) |
 | [New BIAN Service Checklist](new-bian-service-checklist.md) | Complete checklist for creating a new BIAN service domain |
 | [Circuit Breaker Usage](circuit-breaker-usage.md) | Using circuit breakers for resilient inter-service calls |

--- a/docs/guides/calling-meridian-apis.md
+++ b/docs/guides/calling-meridian-apis.md
@@ -1,0 +1,255 @@
+# Calling Meridian APIs
+
+This guide explains how to call Meridian backend services using HTTP/JSON, Connect, and gRPC.
+
+## Overview
+
+Meridian exposes its gRPC services through an HTTP gateway that supports four protocols:
+
+| Protocol | Port | Content-Type | Best for |
+|----------|------|--------------|----------|
+| REST/JSON | 8090 | `application/json` | curl, browsers, any HTTP client |
+| Connect | 8090 | `application/connect+json` | Browser clients needing RPC semantics |
+| gRPC-Web | 8090 | `application/grpc-web+proto` | Legacy proxies, browsers without HTTP/2 |
+| Native gRPC | 50051 | — (gRPC framing) | Server-to-server, grpcurl, Go clients |
+
+The gateway automatically selects the transcoding path from the request `Content-Type` header.
+Backend services always receive native gRPC; protocol translation happens at the gateway edge.
+
+## Prerequisites
+
+Start the dev stack:
+
+```bash
+make dev-up
+```
+
+This starts CockroachDB, runs schema migrations, and starts the Meridian binary.
+
+Verify the gateway is running:
+
+```bash
+curl -s http://localhost:8090/healthz
+# OK
+```
+
+## HTTP/JSON (REST)
+
+The JSON API follows RESTful conventions. URL paths and HTTP methods come from `google.api.http`
+annotations in the proto files; the same annotations generate the OpenAPI spec in
+`api/openapi/meridian.swagger.json`.
+
+### Authentication and Tenant Identification
+
+In local development mode (`AUTH_MODE=disabled`), authentication is disabled. Pass the tenant
+identifier via the `X-Tenant-ID` header:
+
+```bash
+curl -H "X-Tenant-ID: default" http://localhost:8090/v1/parties
+```
+
+In production, include a signed JWT in the `Authorization: Bearer <token>` header. The gateway
+validates the token, extracts the tenant from the `tenant_id` claim, and propagates the identity
+to backend services.
+
+### Quick Start: Register a Party and Open an Account
+
+```bash
+# 1. Register a party
+PARTY=$(curl -s -X POST http://localhost:8090/v1/parties \
+  -H "Content-Type: application/json" \
+  -H "X-Tenant-ID: default" \
+  -d '{"partyType": "PARTY_TYPE_PERSON", "legalName": "Alice Smith"}')
+echo $PARTY | jq .
+PARTY_ID=$(echo $PARTY | jq -r '.party.partyId')
+
+# 2. Open a current account (GBP)
+ACCOUNT=$(curl -s -X POST http://localhost:8090/v1/current-accounts \
+  -H "Content-Type: application/json" \
+  -H "X-Tenant-ID: default" \
+  -d "{
+    \"partyId\": \"$PARTY_ID\",
+    \"accountIdentification\": \"GB29NWBK60161331926819\",
+    \"baseCurrency\": \"CURRENCY_GBP\"
+  }")
+echo $ACCOUNT | jq .
+ACCOUNT_ID=$(echo $ACCOUNT | jq -r '.facility.accountId')
+
+# 3. Deposit 100 GBP
+curl -s -X POST "http://localhost:8090/v1/current-accounts/$ACCOUNT_ID/deposits" \
+  -H "Content-Type: application/json" \
+  -H "X-Tenant-ID: default" \
+  -d '{
+    "amount": {
+      "amount": {"currencyCode": "GBP", "units": "100"}
+    },
+    "description": "Initial deposit",
+    "reference": "REF-001",
+    "idempotencyKey": {"key": "dep-001"}
+  }' | jq .
+
+# 4. Check balances
+curl -s "http://localhost:8090/v1/accounts/$ACCOUNT_ID/balances" \
+  -H "X-Tenant-ID: default" | jq .
+```
+
+### Field Naming
+
+Proto field names use `snake_case`. The gateway maps them to `camelCase` in JSON responses
+following the [proto JSON mapping](https://protobuf.dev/programming-guides/proto3/#json) convention.
+
+Request bodies accept both `camelCase` and `snake_case` field names.
+
+### Idempotency
+
+Mutating operations (POST/PATCH) accept an optional `idempotencyKey` in the request body:
+
+```json
+{
+  "idempotencyKey": {"key": "unique-client-chosen-key"}
+}
+```
+
+Submitting the same key twice returns the original response without reprocessing the operation.
+Use UUIDs or deterministic keys based on your client's operation context.
+
+### Error Format
+
+Errors follow Google's canonical JSON error format:
+
+```json
+{
+  "code": 5,
+  "message": "party not found",
+  "details": []
+}
+```
+
+The `code` field is the gRPC status code integer (3 = InvalidArgument, 5 = NotFound, etc.).
+HTTP status codes are mapped from gRPC status codes:
+
+| gRPC Code | HTTP Status |
+|-----------|-------------|
+| OK (0) | 200 |
+| InvalidArgument (3) | 400 |
+| NotFound (5) | 404 |
+| AlreadyExists (6) | 409 |
+| PermissionDenied (7) | 403 |
+| Unauthenticated (16) | 401 |
+| Internal (13) | 500 |
+| Unavailable (14) | 503 |
+
+## Native gRPC
+
+Backend services expose native gRPC on port 50051. Use this for server-to-server communication
+or tooling like grpcurl. All services have reflection enabled in development.
+
+```bash
+# List all services
+grpcurl -plaintext localhost:50051 list
+
+# List methods for a service
+grpcurl -plaintext localhost:50051 list meridian.party.v1.PartyService
+
+# Describe a request message
+grpcurl -plaintext localhost:50051 describe meridian.party.v1.RegisterPartyRequest
+
+# Register a party
+grpcurl -plaintext \
+  -H "x-tenant-id: default" \
+  -d '{"partyType": "PARTY_TYPE_PERSON", "legalName": "Alice Smith"}' \
+  localhost:50051 meridian.party.v1.PartyService/RegisterParty
+
+# Open a current account
+grpcurl -plaintext \
+  -H "x-tenant-id: default" \
+  -d '{"partyId": "PARTY_ID", "accountIdentification": "GB29NWBK60161331926819", "baseCurrency": "CURRENCY_GBP"}' \
+  localhost:50051 meridian.current_account.v1.CurrentAccountService/InitiateCurrentAccount
+```
+
+## Connect Protocol
+
+The Connect protocol is compatible with HTTP/1.1 and HTTP/2. It is the recommended choice for
+browser clients that need RPC-style semantics (unary and server-streaming calls).
+
+Use the `connectrpc.com/connect` Go client or the [connect-es](https://connectrpc.com/docs/web/getting-started)
+TypeScript client:
+
+```http
+POST http://localhost:8090/api/meridian.party.v1.PartyService/RegisterParty
+Content-Type: application/connect+json
+
+{"partyType": "PARTY_TYPE_PERSON", "legalName": "Alice Smith"}
+```
+
+Note the `/api/` prefix and the fully-qualified service path. The gateway strips `/api` before
+dispatching to Vanguard.
+
+## gRPC-Web
+
+gRPC-Web is supported for environments where native gRPC (HTTP/2) is not available (e.g., some
+browser or proxy configurations):
+
+```http
+POST http://localhost:8090/api/meridian.party.v1.PartyService/RegisterParty
+Content-Type: application/grpc-web+proto
+```
+
+The request body uses length-prefixed protobuf frames (5-byte prefix per message). Most gRPC-Web
+client libraries handle framing automatically.
+
+## API Explorer (Swagger UI)
+
+Browse the full REST API interactively while the dev stack is running:
+
+```bash
+make swagger-ui
+# Open http://localhost:8091/swagger-ui.html
+```
+
+The Swagger UI serves the OpenAPI spec generated from the proto annotations. Use the service
+dropdown to switch between individual service specs. The "Try it out" feature sends requests
+directly to the local gateway on port 8090.
+
+## API Services Reference
+
+| Service | Base Path | gRPC Package |
+|---------|-----------|--------------|
+| Party | `/v1/parties` | `meridian.party.v1.PartyService` |
+| Current Account | `/v1/current-accounts` | `meridian.current_account.v1.CurrentAccountService` |
+| Position Keeping | `/v1/accounts/{id}/balances` | `meridian.position_keeping.v1.PositionKeepingService` |
+| Financial Accounting | `/v1/financial-accounting` | `meridian.financial_accounting.v1.FinancialAccountingService` |
+| Payment Order | `/v1/payment-orders` | `meridian.payment_order.v1.PaymentOrderService` |
+| Market Information | `/v1/market-information` | `meridian.market_information.v1.MarketInformationService` |
+| Reconciliation | `/v1/reconciliation` | `meridian.reconciliation.v1.ReconciliationService` |
+| Internal Bank Account | `/v1/internal-bank-accounts` | `meridian.internal_bank_account.v1.InternalBankAccountService` |
+| Saga Registry | `/v1/sagas` | `meridian.saga.v1.SagaRegistryService` |
+| Tenant | `/v1/tenants` | `meridian.tenant.v1.TenantService` |
+| Admin | `/v1/admin` | `meridian.control_plane.v1.AdminService` |
+
+## Using the HTTP Client Files
+
+The `http/` directory contains IntelliJ HTTP Client files (`.http` and `.grpc.http`) with
+pre-built requests for all services. See [http/README.md](../../http/README.md) for usage
+instructions.
+
+## Tenant Isolation
+
+All operations are scoped to the authenticated tenant. In local development mode:
+
+- The `X-Tenant-ID: default` header specifies the tenant for HTTP/JSON requests.
+- The `x-tenant-id: default` metadata header specifies the tenant for gRPC requests.
+
+In production:
+
+- The `tenant_id` claim in the JWT token identifies the tenant.
+- The gateway rejects requests where the JWT tenant does not match the subdomain tenant.
+- API key authentication (for service-to-service) trusts the `X-Tenant-ID` header from the
+  calling service.
+
+## See Also
+
+- [ADR-0032: Vanguard HTTP/JSON Transcoding Gateway](../adr/0032-vanguard-json-transcoding-gateway.md)
+- [Gateway Service README](../../services/gateway/README.md)
+- [HTTP Client Files](../../http/README.md)
+- [API Proto Documentation](../../api/proto/README.md)

--- a/http/README.md
+++ b/http/README.md
@@ -1,0 +1,123 @@
+# HTTP Client Files
+
+This directory contains [IntelliJ HTTP Client](https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html)
+request files for all Meridian API services.
+
+## File Naming
+
+Each service has two files:
+
+| File | Protocol | Port | Notes |
+|------|----------|------|-------|
+| `NN-service-name.http` | REST/JSON over HTTP | 8090 (gateway) | Standard curl-style requests |
+| `NN-service-name.grpc.http` | Native gRPC | 50051 (direct) | Requires IntelliJ gRPC plugin |
+
+The numbered prefix (`00-`, `01-`, etc.) indicates the recommended order for end-to-end flows
+(party before account, account before deposit, etc.).
+
+### When to Use Each Format
+
+**Use `.http` files (REST/JSON)** when you want to:
+
+- Test the full gateway stack including auth and transcoding
+- Quickly inspect request/response shapes without gRPC tooling
+- Share requests with teammates who do not have gRPC plugins installed
+
+**Use `.grpc.http` files (native gRPC)** when you want to:
+
+- Bypass the gateway and call backend services directly
+- Test proto message shapes before they are exposed through the gateway
+- Debug gRPC metadata propagation
+
+## Available Files
+
+| Prefix | Service | `.http` | `.grpc.http` |
+|--------|---------|---------|-------------|
+| 00 | Happy Path (end-to-end) | `00-happy-path.http` | `00-happy-path.grpc.http` |
+| 01 | Party | `01-party.http` | `01-party.grpc.http` |
+| 02 | Current Account | `02-current-account.http` | `02-current-account.grpc.http` |
+| 03 | Position Keeping | `03-position-keeping.http` | `03-position-keeping.grpc.http` |
+| 04 | Financial Accounting | `04-financial-accounting.http` | `04-financial-accounting.grpc.http` |
+| 05 | Payment Order | `05-payment-order.http` | `05-payment-order.grpc.http` |
+| 06 | Market Information | `06-market-information.http` | `06-market-information.grpc.http` |
+| 07 | Reconciliation | `07-reconciliation.http` | `07-reconciliation.grpc.http` |
+| 08 | Internal Bank Account | `08-internal-bank-account.http` | `08-internal-bank-account.grpc.http` |
+| 09 | Saga Registry | `09-saga-registry.http` | `09-saga-registry.grpc.http` |
+| 10 | Tenant | `10-tenant.http` | `10-tenant.grpc.http` |
+| 11 | Admin | `11-admin.http` | `11-admin.grpc.http` |
+
+## Setup
+
+### Prerequisites
+
+1. Start the dev stack: `make dev-up`
+2. In IntelliJ IDEA / GoLand, open the `http/` directory
+
+### Environment Configuration
+
+The `http-client.env.json` file defines environments for all request files:
+
+```json
+{
+  "local": {
+    "host": "http://localhost:8090",
+    "grpc_host": "localhost:50051",
+    "tenant_id": "default"
+  }
+}
+```
+
+Select the **local** environment in IntelliJ before running requests. Variables like `{{host}}`,
+`{{grpc_host}}`, and `{{tenant_id}}` are substituted automatically.
+
+### Running Requests
+
+1. Open a `.http` or `.grpc.http` file in IntelliJ
+2. Select **local** from the environment dropdown (top right of editor)
+3. Click the green run button next to any request
+
+For `.grpc.http` files, the [Protocol Buffers](https://plugins.jetbrains.com/plugin/14004-protocol-buffers)
+plugin must be installed. IntelliJ discovers proto schemas from the workspace automatically.
+
+### Running with VS Code
+
+The `.http` files use IntelliJ HTTP Client syntax. For VS Code, use the
+[REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension.
+The variable syntax (`{{variable}}`) and test scripts (`> {% ... %}`) are compatible with REST
+Client with minor adjustments:
+
+1. Copy `http-client.env.json` to `.env` and adjust the format if needed.
+2. Replace `client.assert(...)` test blocks with REST Client assertions or remove them.
+
+### Running with curl
+
+Each request in the `.http` files maps directly to a curl command. For example:
+
+```bash
+# From 01-party.http: Register Party
+curl -s -X POST http://localhost:8090/v1/parties \
+  -H "Content-Type: application/json" \
+  -H "X-Tenant-ID: default" \
+  -d '{"partyType": "PARTY_TYPE_PERSON", "legalName": "Alice Smith"}' | jq .
+```
+
+## Chaining Requests (Response Variables)
+
+The `.http` files use IntelliJ's response handler scripts to store values between requests:
+
+```javascript
+// At the end of "Register Party":
+client.global.set("party_id", response.body.party.partyId);
+
+// In the next request:
+GET {{host}}/v1/parties/{{party_id}}
+```
+
+Run the **00-happy-path.http** file as a sequence to execute a complete end-to-end flow
+automatically.
+
+## See Also
+
+- [Developer Guide: Calling Meridian APIs](../docs/guides/calling-meridian-apis.md)
+- [API Explorer (Swagger UI)](../api/openapi/swagger-ui.html) — run `make swagger-ui`
+- [Gateway Service README](../services/gateway/README.md)

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -1,61 +1,92 @@
 ---
 name: gateway-service
-description: Multi-tenant API gateway with JWT/API key authentication and request routing
+description: Multi-tenant API gateway with HTTP/JSON transcoding, JWT/API key authentication, and request routing
 triggers:
   - JWT authentication and JWKS configuration
   - API key authentication and rate limiting
   - Tenant resolution from subdomain or headers
-  - Request routing and proxy configuration
+  - HTTP/JSON to gRPC transcoding via Vanguard
+  - Adding a new backend service to the gateway
   - Local development mode setup
 instructions: |
-  Gateway handles authentication (JWT or API key), tenant resolution, and proxying.
-  Configure via environment variables: BASE_DOMAIN, JWKS_URL, API_KEYS, BACKENDS.
-  Use LOCAL_DEV_MODE=true with X-Tenant-Slug header for local development.
+  Gateway handles authentication (JWT or API key), tenant resolution, and HTTP/JSON↔gRPC
+  transcoding. Backend services always speak gRPC; Vanguard translates REST/JSON, Connect,
+  and gRPC-Web at the gateway edge.
 
-  Port: 8080 (HTTP)
+  Ports: 8090 (HTTP gateway), 50051 (native gRPC on backend services directly)
+
+  After any proto change, regenerate the descriptor: `make proto-descriptors`
+  To add a new service, add a ServiceBackend entry in cmd/meridian/main.go and rerun proto-descriptors.
+
+  Local dev: AUTH_MODE=disabled. Pass X-Tenant-ID header for tenant identification.
 ---
 
 # Gateway Service
 
 The Gateway Service is a multi-tenant API gateway that provides authentication,
-authorization, and request routing for the Meridian platform.
+authorization, HTTP/JSON transcoding, and request routing for the Meridian platform.
 
 ## Overview
 
 The gateway handles:
 
+- **HTTP/JSON Transcoding**: Accepts REST/JSON, Connect, and gRPC-Web requests and translates
+  them to gRPC for backend services (via [Vanguard](https://connectrpc.com/vanguard))
 - **JWT Authentication**: Validates Bearer tokens using JWKS (JSON Web Key Set)
 - **API Key Authentication**: Validates service-to-service API keys with rate limiting
 - **Tenant Resolution**: Extracts tenant identity from subdomain or headers
 - **Tenant Authorization**: Verifies authenticated identity is authorized for the resolved tenant
-- **Request Proxying**: Routes authenticated requests to backend services
+- **Identity Propagation**: Injects authenticated user/tenant context as gRPC metadata headers
 
 ## Architecture
 
 ```mermaid
 flowchart LR
-    subgraph External
-        Client["Client"]
-        JWKS["JWKS Provider<br/>(Auth0, Keycloak)"]
+    subgraph Clients
+        REST["REST/JSON Client<br/>(curl, browser)"]
+        ConnectClient["Connect Client<br/>(browser RPC)"]
+        GRPCWeb["gRPC-Web Client"]
+        GRPC["gRPC Client<br/>(server-to-server)"]
     end
 
-    subgraph Gateway["Gateway (proxy)"]
-        Auth["Auth<br/>Middleware"]
-        Tenant["Tenant<br/>Resolver"]
+    subgraph Gateway["Gateway :8090"]
+        Auth["Auth Middleware<br/>(JWT / API Key)"]
+        TenantRes["Tenant Resolver"]
+        TenantAuthz["Tenant Authz"]
+        Vanguard["Vanguard Transcoder<br/>(REST ↔ gRPC)"]
     end
 
-    subgraph Identity["Identity Context"]
-        Ctx["- User ID<br/>- Tenant ID<br/>- Roles/Scopes"]
+    subgraph Backends[":50051"]
+        Party["Party Service"]
+        Account["Current Account"]
+        PK["Position Keeping"]
+        Other["... other services"]
     end
 
-    Backend["Backend<br/>Services"]
+    JWKS["JWKS Provider"]
 
-    Client --> Gateway
-    JWKS -.->|"JWKS fetch"| Auth
-    Gateway --> Backend
-    Auth --> Tenant
-    Tenant --> Ctx
+    REST -->|HTTP/JSON| Auth
+    ConnectClient -->|Connect| Auth
+    GRPCWeb -->|gRPC-Web| Auth
+    GRPC -->|gRPC| Party
+    GRPC -->|gRPC| Account
+
+    Auth --> TenantRes
+    JWKS -.->|JWKS fetch| Auth
+    TenantRes --> TenantAuthz
+    TenantAuthz --> Vanguard
+    Vanguard -->|gRPC| Party
+    Vanguard -->|gRPC| Account
+    Vanguard -->|gRPC| PK
+    Vanguard -->|gRPC| Other
 ```
+
+### Ports
+
+| Port | Purpose |
+|------|---------|
+| **8090** | HTTP gateway — accepts REST/JSON, Connect, gRPC-Web |
+| **50051** | Native gRPC — direct backend access (dev only) |
 
 ### Middleware Chain
 
@@ -64,9 +95,49 @@ The gateway applies middleware in this order for `/api/*` routes:
 1. **Auth Middleware** (outermost): Validates JWT or API key, returns 401 if invalid
 2. **Tenant Middleware**: Resolves tenant from subdomain/header, injects into context
 3. **Tenant Authorization**: Verifies JWT tenant matches resolved tenant, returns 403 if mismatch
-4. **Backend Proxy**: Routes request to appropriate backend service
+4. **Identity Propagation**: Strips spoofed identity headers; injects authenticated context as gRPC metadata
+5. **Vanguard Transcoder**: Translates REST/JSON, Connect, or gRPC-Web to native gRPC; routes to backend
 
 Health endpoints (`/health`, `/ready`) bypass all middleware for Kubernetes probe compatibility.
+
+## HTTP/JSON Transcoding
+
+The gateway uses [Vanguard](https://pkg.go.dev/connectrpc.com/vanguard) to translate between
+REST/JSON and gRPC. See [ADR-0032](../../docs/adr/0032-vanguard-json-transcoding-gateway.md) for
+the decision rationale.
+
+### Supported Protocols
+
+| Protocol | Content-Type | URL Pattern |
+|----------|--------------|-------------|
+| REST/JSON | `application/json` | `/api/v1/parties`, `/api/v1/current-accounts`, etc. |
+| Connect | `application/connect+json` | `/api/<package>.<Service>/<Method>` |
+| gRPC-Web | `application/grpc-web+proto` | `/api/<package>.<Service>/<Method>` |
+| Native gRPC | — | Direct to `:50051` |
+
+### Proto Descriptor
+
+Vanguard discovers service schemas from a compiled `FileDescriptorSet` embedded in the binary:
+
+```bash
+# Regenerate after any proto change
+make proto-descriptors
+# This runs: buf build api/proto -o cmd/meridian/descriptor.binpb
+```
+
+Commit the updated `cmd/meridian/descriptor.binpb` after regenerating.
+
+### Adding a New Service
+
+1. Add `google.api.http` annotations to the proto file.
+2. Run `make proto-descriptors` to regenerate the descriptor.
+3. Add a `ServiceBackend` entry in `cmd/meridian/main.go`:
+
+   ```go
+   {ServiceName: "meridian.myservice.v1.MyService", BackendAddr: "my-service:50051"},
+   ```
+
+4. Commit both `descriptor.binpb` and the `main.go` change.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- **ADR-0032**: Documents the decision to use Vanguard over grpc-gateway for HTTP/JSON-to-gRPC transcoding, with architecture diagrams, protocol support matrix, and notes on the proto descriptor build step.
- **Developer onboarding guide** (`docs/guides/calling-meridian-apis.md`): Covers REST/JSON, native gRPC, Connect, and gRPC-Web protocols with quick-start curl examples, authentication, tenant isolation, error format, and Swagger UI instructions.
- **HTTP client directory README** (`http/README.md`): Explains `.http` vs `.grpc.http` file conventions, environment setup, and how to use files in IntelliJ, VS Code, and curl.
- **Gateway README update**: Adds Vanguard transcoder to the architecture diagram, documents supported protocols and ports (8090/50051), and adds instructions for adding new services.
- **Main README update**: Corrects field names to camelCase, adds `X-Tenant-ID` header, and links to the new API guide.

## Changes Made

| File | Change |
|------|--------|
| `docs/adr/0032-vanguard-json-transcoding-gateway.md` | New ADR documenting Vanguard vs grpc-gateway decision |
| `docs/adr/README.md` | Add ADR-0032 to index and API Gateway category |
| `docs/guides/calling-meridian-apis.md` | New developer onboarding guide for all protocols |
| `docs/guides/README.md` | Add new guide to table of contents |
| `http/README.md` | New README explaining .http vs .grpc.http file conventions |
| `services/gateway/README.md` | Update architecture diagram and add transcoding section |
| `README.md` | Fix curl examples to match JSON API response shape |

## Test Plan

- [ ] Verify curl examples in README.md work against `make dev-up`
- [ ] Verify Swagger UI loads at `http://localhost:8091/swagger-ui.html` after `make swagger-ui`
- [ ] Verify IntelliJ HTTP Client files run against local dev stack using the `local` environment
- [ ] Check all markdown renders correctly (no broken links in ADR/guide cross-references)