### PR TITLE
feat: implement ValuationFeature seeding from product type templates

### DIFF
--- a/services/current-account/service/grpc_account_endpoints.go
+++ b/services/current-account/service/grpc_account_endpoints.go
@@ -206,7 +206,7 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 
 	// Seed ValuationFeatures from product type templates (best-effort after account creation)
 	if cachedType != nil && len(cachedType.Definition.ValuationMethods) > 0 && s.valuationFeatureRepo != nil {
-		if err := s.seedValuationFeatures(ctx, account.ID(), cachedType.Definition.ValuationMethods); err != nil {
+		if err := s.seedValuationFeatures(ctx, account.ID(), cachedType.Definition); err != nil {
 			// Log but do not fail account creation - VF seeding is best-effort
 			s.logger.Error("failed to seed valuation features",
 				"account_id", accountID,
@@ -270,39 +270,12 @@ func validateAttributes(compiledSchema interface{ Validate(interface{}) error },
 	return compiledSchema.Validate(parsed)
 }
 
-// seedValuationFeatures creates ValuationFeature records from product type templates.
-// Each template maps an input instrument to a valuation method.
-// Features are created in INITIATED status and immediately activated.
-func (s *Service) seedValuationFeatures(ctx context.Context, accountID uuid.UUID, templates []accounttype.ValuationMethodTemplate) error {
-	for _, tmpl := range templates {
-		feature, err := vf.NewValuationFeature(
-			accountID,
-			tmpl.InputInstrument,
-			tmpl.ValuationMethodID,
-			tmpl.ValuationMethodVersion,
-			tmpl.Parameters,
-			"system",
-		)
-		if err != nil {
-			return fmt.Errorf("failed to create valuation feature for instrument %s: %w", tmpl.InputInstrument, err)
-		}
-
-		// Activate immediately for newly seeded features
-		if err := feature.Activate("system"); err != nil {
-			return fmt.Errorf("failed to activate valuation feature for instrument %s: %w", tmpl.InputInstrument, err)
-		}
-
-		if err := s.valuationFeatureRepo.Create(ctx, feature); err != nil {
-			return fmt.Errorf("failed to persist valuation feature for instrument %s: %w", tmpl.InputInstrument, err)
-		}
-
-		s.logger.Info("seeded valuation feature",
-			"account_id", accountID,
-			"instrument_code", tmpl.InputInstrument,
-			"valuation_method_id", tmpl.ValuationMethodID,
-			"valuation_method_version", tmpl.ValuationMethodVersion)
-	}
-	return nil
+// seedValuationFeatures seeds ValuationFeature records from product type templates.
+// Delegates to the shared ProductTypeSeeder which filters ACTIVE templates and
+// uses upsert semantics for saga retry safety.
+func (s *Service) seedValuationFeatures(ctx context.Context, accountID uuid.UUID, productType *accounttype.Definition) error {
+	seeder := vf.NewProductTypeSeeder(s.valuationFeatureRepo)
+	return seeder.SeedFromProductType(ctx, accountID, productType, time.Now().UTC())
 }
 
 // RetrieveCurrentAccount gets current account details including balance from Position Keeping.

--- a/services/current-account/service/grpc_service_product_type_test.go
+++ b/services/current-account/service/grpc_service_product_type_test.go
@@ -110,6 +110,13 @@ func setupProductTypeTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	err = db.AutoMigrate(&persistence.CurrentAccountEntity{}, &vf.Entity{})
 	require.NoError(t, err)
 
+	// Create the partial unique index required by UpsertFeature's ON CONFLICT clause.
+	// AutoMigrate only creates the table structure; partial indexes must be created manually.
+	err = db.Exec(fmt.Sprintf(`CREATE UNIQUE INDEX IF NOT EXISTS idx_valuation_feature_account_instrument_active
+		ON %s.valuation_features (account_id, instrument_code)
+		WHERE lifecycle_status = 'ACTIVE' AND valid_to = '9999-12-31 23:59:59+00'`, pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
 	ctx := tenant.WithTenant(context.Background(), tid)
 	return db, ctx, cleanup
 }

--- a/services/internal-bank-account/service/server.go
+++ b/services/internal-bank-account/service/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/meridianhub/meridian/services/reference-data/accounttype"
 	"github.com/meridianhub/meridian/services/reference-data/cache"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
+	vf "github.com/meridianhub/meridian/shared/pkg/valuationfeature"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
@@ -256,7 +257,7 @@ func (s *Service) InitiateInternalBankAccount(ctx context.Context, req *pb.Initi
 	var clearingPurpose domain.ClearingPurpose
 	var dimension string
 	var productTypeVersion int
-	var valuationTemplates []accounttype.ValuationMethodTemplate
+	var productTypeDef *accounttype.Definition
 
 	// 2. Product type resolution via cache (if cache is configured and code is available)
 	if s.accountTypeCache != nil && productTypeCode != "" {
@@ -336,7 +337,7 @@ func (s *Service) InitiateInternalBankAccount(ctx context.Context, req *pb.Initi
 		// Derive account type from BehaviorClass via mapping
 		accountType = behaviorClassToAccountType[def.BehaviorClass]
 		productTypeVersion = def.Version
-		valuationTemplates = def.ValuationMethods
+		productTypeDef = def
 
 		// Derive dimension from instrument via Reference Data (if available)
 	} else if s.accountTypeCache == nil && req.ProductTypeCode != "" {
@@ -495,41 +496,14 @@ func (s *Service) InitiateInternalBankAccount(ctx context.Context, req *pb.Initi
 		return nil, status.Errorf(codes.Internal, "failed to create account: %v", err)
 	}
 
-	// Seed ValuationFeatures from product type templates
-	if s.valuationFeatureRepo != nil && len(valuationTemplates) > 0 {
-		for _, tmpl := range valuationTemplates {
-			if tmpl.Status != accounttype.StatusActive {
-				continue
-			}
-			feature, err := domain.NewValuationFeature(
-				account.ID(),
-				tmpl.InputInstrument,
-				tmpl.ValuationMethodID,
-				tmpl.ValuationMethodVersion,
-				tmpl.Parameters,
-				"system",
-			)
-			if err != nil {
-				s.logger.Warn("failed to create valuation feature from template",
-					"account_id", accountID,
-					"template_id", tmpl.ID.String(),
-					"error", err)
-				continue
-			}
-			// Auto-activate seeded features
-			if err := feature.Activate("system"); err != nil {
-				s.logger.Warn("failed to activate valuation feature from template",
-					"account_id", accountID,
-					"template_id", tmpl.ID.String(),
-					"error", err)
-				continue
-			}
-			if err := s.valuationFeatureRepo.Create(ctx, feature); err != nil {
-				s.logger.Warn("failed to persist valuation feature from template",
-					"account_id", accountID,
-					"template_id", tmpl.ID.String(),
-					"error", err)
-			}
+	// Seed ValuationFeatures from product type templates using upsert semantics.
+	if s.valuationFeatureRepo != nil && productTypeDef != nil && len(productTypeDef.ValuationMethods) > 0 {
+		seeder := vf.NewProductTypeSeeder(s.valuationFeatureRepo)
+		if err := seeder.SeedFromProductType(ctx, account.ID(), productTypeDef, time.Now().UTC()); err != nil {
+			s.logger.Warn("failed to seed valuation features from product type",
+				"account_id", accountID,
+				"product_type_code", productTypeCode,
+				"error", err)
 		}
 	}
 

--- a/shared/pkg/valuationfeature/errors.go
+++ b/shared/pkg/valuationfeature/errors.go
@@ -22,6 +22,7 @@ var (
 
 // Service errors
 var (
-	ErrMethodOutputMismatch = errors.New("valuation method output_instrument does not match account native instrument")
-	ErrInvalidAction        = errors.New("invalid valuation feature action")
+	ErrMethodOutputMismatch  = errors.New("valuation method output_instrument does not match account native instrument")
+	ErrInvalidAction         = errors.New("invalid valuation feature action")
+	ErrNoConversionAvailable = errors.New("no conversion method available for the given instrument pair")
 )

--- a/shared/pkg/valuationfeature/repository.go
+++ b/shared/pkg/valuationfeature/repository.go
@@ -224,6 +224,48 @@ func (r *Repository) Update(ctx context.Context, feature *ValuationFeature) erro
 	return nil
 }
 
+// UpsertFeature inserts a valuation feature or silently skips if an active feature
+// already exists for the same (account_id, instrument_code) pair.
+// This is idempotent: calling it multiple times with the same pair is safe.
+// Uses INSERT ... ON CONFLICT (account_id, instrument_code) WHERE lifecycle_status = 'ACTIVE' DO NOTHING.
+func (r *Repository) UpsertFeature(ctx context.Context, feature *ValuationFeature) error {
+	entity, err := toEntity(feature)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidParameters, err)
+	}
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Exec(`
+			INSERT INTO valuation_features (
+				id, account_id, instrument_code,
+				valuation_method_id, valuation_method_version,
+				parameters, lifecycle_status,
+				valid_from, valid_to,
+				created_at, created_by,
+				updated_at, updated_by,
+				version
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT (account_id, instrument_code)
+			WHERE lifecycle_status = 'ACTIVE' AND valid_to = '9999-12-31 23:59:59+00'
+			DO NOTHING`,
+			entity.ID,
+			entity.AccountID,
+			entity.InstrumentCode,
+			entity.ValuationMethodID,
+			entity.ValuationMethodVersion,
+			entity.Parameters,
+			entity.LifecycleStatus,
+			entity.ValidFrom,
+			entity.ValidTo,
+			entity.CreatedAt,
+			entity.CreatedBy,
+			entity.UpdatedAt,
+			entity.UpdatedBy,
+			entity.Version,
+		)
+		return result.Error
+	})
+}
+
 // FindByIDForUpdate retrieves a valuation feature by its UUID with a pessimistic lock.
 func (r *Repository) FindByIDForUpdate(ctx context.Context, id uuid.UUID) (*ValuationFeature, error) {
 	var entity Entity

--- a/shared/pkg/valuationfeature/resolution.go
+++ b/shared/pkg/valuationfeature/resolution.go
@@ -1,0 +1,51 @@
+package valuationfeature
+
+import (
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+)
+
+// ConversionMethod holds the resolved valuation method ID and version for a
+// cross-instrument conversion.
+type ConversionMethod struct {
+	ValuationMethodID      uuid.UUID
+	ValuationMethodVersion int
+}
+
+// ResolveConversionMethod returns the valuation method for converting
+// inputInstrument into an account whose product type is productType.
+//
+// Resolution order:
+//  1. Check for an explicit ACTIVE ValuationMethodTemplate for
+//     (productType, inputInstrument.Code). If found, return that method.
+//  2. If inputInstrument and the account instrument share the same Dimension,
+//     use productType.DefaultConversionMethodID (same-dimension conversion).
+//  3. Neither condition satisfied → return ErrNoConversionAvailable.
+func ResolveConversionMethod(
+	productType *accounttype.Definition,
+	inputInstrument *registry.InstrumentDefinition,
+	accountInstrument *registry.InstrumentDefinition,
+) (*ConversionMethod, error) {
+	// Tier 1: explicit cross-dimension template.
+	for _, tmpl := range productType.ValuationMethods {
+		if tmpl.Status == accounttype.StatusActive && tmpl.InputInstrument == inputInstrument.Code {
+			return &ConversionMethod{
+				ValuationMethodID:      tmpl.ValuationMethodID,
+				ValuationMethodVersion: tmpl.ValuationMethodVersion,
+			}, nil
+		}
+	}
+
+	// Tier 2: same-dimension fallback via DefaultConversionMethodID.
+	if inputInstrument.Dimension == accountInstrument.Dimension {
+		if productType.DefaultConversionMethodID != nil && productType.DefaultConversionMethodVersion != nil {
+			return &ConversionMethod{
+				ValuationMethodID:      *productType.DefaultConversionMethodID,
+				ValuationMethodVersion: *productType.DefaultConversionMethodVersion,
+			}, nil
+		}
+	}
+
+	return nil, ErrNoConversionAvailable
+}

--- a/shared/pkg/valuationfeature/resolution_test.go
+++ b/shared/pkg/valuationfeature/resolution_test.go
@@ -1,0 +1,201 @@
+package valuationfeature
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveConversionMethod_ExplicitTemplate(t *testing.T) {
+	methodID := uuid.New()
+	convMethodID := uuid.New()
+	convMethodVersion := 3
+
+	productType := &accounttype.Definition{
+		ID:                             uuid.New(),
+		Code:                           "TEST_TYPE",
+		DefaultConversionMethodID:      &convMethodID,
+		DefaultConversionMethodVersion: &convMethodVersion,
+		ValuationMethods: []accounttype.ValuationMethodTemplate{
+			{
+				ID:                     uuid.New(),
+				InputInstrument:        "TONNE_CO2E",
+				ValuationMethodID:      methodID,
+				ValuationMethodVersion: 1,
+				Status:                 accounttype.StatusActive,
+			},
+		},
+	}
+
+	inputInstrument := &registry.InstrumentDefinition{
+		Code:      "TONNE_CO2E",
+		Dimension: registry.DimensionMass,
+	}
+	accountInstrument := &registry.InstrumentDefinition{
+		Code:      "GBP",
+		Dimension: registry.DimensionMonetary,
+	}
+
+	result, err := ResolveConversionMethod(productType, inputInstrument, accountInstrument)
+
+	require.NoError(t, err)
+	assert.Equal(t, methodID, result.ValuationMethodID)
+	assert.Equal(t, 1, result.ValuationMethodVersion)
+}
+
+func TestResolveConversionMethod_SameDimensionFallback(t *testing.T) {
+	convMethodID := uuid.New()
+	convMethodVersion := 2
+
+	productType := &accounttype.Definition{
+		ID:                             uuid.New(),
+		Code:                           "TEST_TYPE",
+		DefaultConversionMethodID:      &convMethodID,
+		DefaultConversionMethodVersion: &convMethodVersion,
+		ValuationMethods:               []accounttype.ValuationMethodTemplate{},
+	}
+
+	inputInstrument := &registry.InstrumentDefinition{
+		Code:      "EUR",
+		Dimension: registry.DimensionMonetary,
+	}
+	accountInstrument := &registry.InstrumentDefinition{
+		Code:      "GBP",
+		Dimension: registry.DimensionMonetary,
+	}
+
+	result, err := ResolveConversionMethod(productType, inputInstrument, accountInstrument)
+
+	require.NoError(t, err)
+	assert.Equal(t, convMethodID, result.ValuationMethodID)
+	assert.Equal(t, convMethodVersion, result.ValuationMethodVersion)
+}
+
+func TestResolveConversionMethod_ExplicitTemplateBeforeSameDimension(t *testing.T) {
+	explicitMethodID := uuid.New()
+	defaultMethodID := uuid.New()
+	defaultVersion := 1
+
+	productType := &accounttype.Definition{
+		ID:                             uuid.New(),
+		Code:                           "TEST_TYPE",
+		DefaultConversionMethodID:      &defaultMethodID,
+		DefaultConversionMethodVersion: &defaultVersion,
+		ValuationMethods: []accounttype.ValuationMethodTemplate{
+			{
+				ID:                     uuid.New(),
+				InputInstrument:        "EUR",
+				ValuationMethodID:      explicitMethodID,
+				ValuationMethodVersion: 5,
+				Status:                 accounttype.StatusActive,
+			},
+		},
+	}
+
+	// Both instruments share the same dimension, but an explicit template exists.
+	// The explicit template should take priority.
+	inputInstrument := &registry.InstrumentDefinition{
+		Code:      "EUR",
+		Dimension: registry.DimensionMonetary,
+	}
+	accountInstrument := &registry.InstrumentDefinition{
+		Code:      "GBP",
+		Dimension: registry.DimensionMonetary,
+	}
+
+	result, err := ResolveConversionMethod(productType, inputInstrument, accountInstrument)
+
+	require.NoError(t, err)
+	assert.Equal(t, explicitMethodID, result.ValuationMethodID, "explicit template takes priority over same-dimension default")
+	assert.Equal(t, 5, result.ValuationMethodVersion)
+}
+
+func TestResolveConversionMethod_CrossDimensionNoTemplate(t *testing.T) {
+	convMethodID := uuid.New()
+	convMethodVersion := 1
+
+	productType := &accounttype.Definition{
+		ID:                             uuid.New(),
+		Code:                           "TEST_TYPE",
+		DefaultConversionMethodID:      &convMethodID,
+		DefaultConversionMethodVersion: &convMethodVersion,
+		ValuationMethods:               []accounttype.ValuationMethodTemplate{},
+	}
+
+	inputInstrument := &registry.InstrumentDefinition{
+		Code:      "KWH",
+		Dimension: registry.DimensionEnergy,
+	}
+	accountInstrument := &registry.InstrumentDefinition{
+		Code:      "GBP",
+		Dimension: registry.DimensionMonetary,
+	}
+
+	_, err := ResolveConversionMethod(productType, inputInstrument, accountInstrument)
+
+	assert.ErrorIs(t, err, ErrNoConversionAvailable)
+}
+
+func TestResolveConversionMethod_SameDimensionNoDefault(t *testing.T) {
+	productType := &accounttype.Definition{
+		ID:                             uuid.New(),
+		Code:                           "TEST_TYPE",
+		DefaultConversionMethodID:      nil,
+		DefaultConversionMethodVersion: nil,
+		ValuationMethods:               []accounttype.ValuationMethodTemplate{},
+	}
+
+	inputInstrument := &registry.InstrumentDefinition{
+		Code:      "EUR",
+		Dimension: registry.DimensionMonetary,
+	}
+	accountInstrument := &registry.InstrumentDefinition{
+		Code:      "GBP",
+		Dimension: registry.DimensionMonetary,
+	}
+
+	_, err := ResolveConversionMethod(productType, inputInstrument, accountInstrument)
+
+	assert.ErrorIs(t, err, ErrNoConversionAvailable)
+}
+
+func TestResolveConversionMethod_DeprecatedTemplateSkipped(t *testing.T) {
+	convMethodID := uuid.New()
+	convMethodVersion := 1
+
+	productType := &accounttype.Definition{
+		ID:                             uuid.New(),
+		Code:                           "TEST_TYPE",
+		DefaultConversionMethodID:      &convMethodID,
+		DefaultConversionMethodVersion: &convMethodVersion,
+		ValuationMethods: []accounttype.ValuationMethodTemplate{
+			{
+				ID:                     uuid.New(),
+				InputInstrument:        "TONNE_CO2E",
+				ValuationMethodID:      uuid.New(),
+				ValuationMethodVersion: 1,
+				Status:                 accounttype.StatusDeprecated, // should not match
+			},
+		},
+	}
+
+	inputInstrument := &registry.InstrumentDefinition{
+		Code:      "TONNE_CO2E",
+		Dimension: registry.DimensionMass,
+	}
+	accountInstrument := &registry.InstrumentDefinition{
+		Code:      "GBP",
+		Dimension: registry.DimensionMonetary,
+	}
+
+	// Deprecated template does not match, no same-dimension fallback possible (different dimensions),
+	// no default method for cross-dimension → ErrNoConversionAvailable.
+	// (DefaultConversionMethodID only helps for same-dimension; here dimensions differ.)
+	_, err := ResolveConversionMethod(productType, inputInstrument, accountInstrument)
+
+	assert.ErrorIs(t, err, ErrNoConversionAvailable)
+}

--- a/shared/pkg/valuationfeature/seeder.go
+++ b/shared/pkg/valuationfeature/seeder.go
@@ -1,0 +1,70 @@
+package valuationfeature
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+)
+
+// ProductTypeSeeder seeds ValuationFeature records from a product type's
+// ValuationMethodTemplate list at account creation time.
+// It uses upsert semantics so saga retries are safe.
+type ProductTypeSeeder struct {
+	repo *Repository
+}
+
+// NewProductTypeSeeder creates a new ProductTypeSeeder.
+func NewProductTypeSeeder(repo *Repository) *ProductTypeSeeder {
+	return &ProductTypeSeeder{repo: repo}
+}
+
+// SeedFromProductType seeds ValuationFeature records for a new account based on
+// the product type's ValuationMethodTemplate list.
+//
+// Only ACTIVE templates are seeded. DRAFT and DEPRECATED templates are skipped.
+// Same-dimension conversions (resolved via DefaultConversionMethodID at runtime)
+// do NOT need seeded features — they are resolved from the product type at eval time.
+//
+// Uses INSERT ... ON CONFLICT DO NOTHING for idempotency: calling this method
+// multiple times for the same (accountID, instrumentCode) pair is safe.
+func (s *ProductTypeSeeder) SeedFromProductType(
+	ctx context.Context,
+	accountID uuid.UUID,
+	productType *accounttype.Definition,
+	now time.Time,
+) error {
+	maxTime := time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
+
+	for _, tmpl := range productType.ValuationMethods {
+		if tmpl.Status != accounttype.StatusActive {
+			continue
+		}
+
+		feature := &ValuationFeature{
+			ID:                     uuid.New(),
+			AccountID:              accountID,
+			InstrumentCode:         tmpl.InputInstrument,
+			ValuationMethodID:      tmpl.ValuationMethodID,
+			ValuationMethodVersion: tmpl.ValuationMethodVersion,
+			Parameters:             tmpl.Parameters,
+			LifecycleStatus:        LifecycleStatusActive,
+			ValidFrom:              now,
+			ValidTo:                maxTime,
+			CreatedAt:              now,
+			CreatedBy:              "system",
+			UpdatedAt:              now,
+			UpdatedBy:              "system",
+			Version:                1,
+		}
+
+		if err := s.repo.UpsertFeature(ctx, feature); err != nil {
+			return fmt.Errorf("seed valuation feature %s for account %s: %w",
+				tmpl.InputInstrument, accountID, err)
+		}
+	}
+
+	return nil
+}

--- a/shared/pkg/valuationfeature/seeder_test.go
+++ b/shared/pkg/valuationfeature/seeder_test.go
@@ -1,0 +1,354 @@
+package valuationfeature
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reference-data/accounttype"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestDBForSeeder reuses setupTestDB defined in repository_test.go.
+
+func TestProductTypeSeeder_SeedFromProductType_ActiveTemplates(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	seeder := NewProductTypeSeeder(repo)
+
+	accountID := uuid.New()
+	methodID1 := uuid.New()
+	methodID2 := uuid.New()
+
+	productType := &accounttype.Definition{
+		ID:   uuid.New(),
+		Code: "TEST_TYPE",
+		ValuationMethods: []accounttype.ValuationMethodTemplate{
+			{
+				ID:                     uuid.New(),
+				InputInstrument:        "USD",
+				ValuationMethodID:      methodID1,
+				ValuationMethodVersion: 1,
+				Status:                 accounttype.StatusActive,
+				Parameters:             map[string]any{"source": "ECB"},
+			},
+			{
+				ID:                     uuid.New(),
+				InputInstrument:        "EUR",
+				ValuationMethodID:      methodID2,
+				ValuationMethodVersion: 2,
+				Status:                 accounttype.StatusActive,
+				Parameters:             nil,
+			},
+		},
+	}
+
+	now := time.Now().UTC()
+	err := seeder.SeedFromProductType(ctx, accountID, productType, now)
+	require.NoError(t, err)
+
+	active := LifecycleStatusActive
+	features, err := repo.FindByAccountID(ctx, accountID, &active)
+	require.NoError(t, err)
+	assert.Len(t, features, 2, "should seed 2 ACTIVE features from 2 ACTIVE templates")
+
+	byCode := make(map[string]*ValuationFeature, len(features))
+	for _, f := range features {
+		byCode[f.InstrumentCode] = f
+	}
+
+	usd := byCode["USD"]
+	require.NotNil(t, usd)
+	assert.Equal(t, methodID1, usd.ValuationMethodID)
+	assert.Equal(t, 1, usd.ValuationMethodVersion)
+	assert.Equal(t, LifecycleStatusActive, usd.LifecycleStatus)
+	assert.Equal(t, "ECB", usd.Parameters["source"])
+
+	eur := byCode["EUR"]
+	require.NotNil(t, eur)
+	assert.Equal(t, methodID2, eur.ValuationMethodID)
+	assert.Equal(t, 2, eur.ValuationMethodVersion)
+	assert.Equal(t, LifecycleStatusActive, eur.LifecycleStatus)
+}
+
+func TestProductTypeSeeder_SeedFromProductType_SkipsNonActiveTemplates(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	seeder := NewProductTypeSeeder(repo)
+
+	accountID := uuid.New()
+	methodID := uuid.New()
+
+	productType := &accounttype.Definition{
+		ID:   uuid.New(),
+		Code: "TEST_TYPE",
+		ValuationMethods: []accounttype.ValuationMethodTemplate{
+			{
+				ID:                     uuid.New(),
+				InputInstrument:        "USD",
+				ValuationMethodID:      methodID,
+				ValuationMethodVersion: 1,
+				Status:                 accounttype.StatusActive,
+			},
+			{
+				ID:                     uuid.New(),
+				InputInstrument:        "EUR",
+				ValuationMethodID:      methodID,
+				ValuationMethodVersion: 1,
+				Status:                 accounttype.StatusDeprecated, // should be skipped
+			},
+			{
+				ID:                     uuid.New(),
+				InputInstrument:        "GBP",
+				ValuationMethodID:      methodID,
+				ValuationMethodVersion: 1,
+				Status:                 accounttype.StatusDraft, // should be skipped
+			},
+		},
+	}
+
+	now := time.Now().UTC()
+	err := seeder.SeedFromProductType(ctx, accountID, productType, now)
+	require.NoError(t, err)
+
+	features, err := repo.FindByAccountID(ctx, accountID, nil)
+	require.NoError(t, err)
+	assert.Len(t, features, 1, "only ACTIVE templates should be seeded")
+	assert.Equal(t, "USD", features[0].InstrumentCode)
+}
+
+func TestProductTypeSeeder_SeedFromProductType_Idempotent(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	seeder := NewProductTypeSeeder(repo)
+
+	accountID := uuid.New()
+	methodID := uuid.New()
+
+	productType := &accounttype.Definition{
+		ID:   uuid.New(),
+		Code: "TEST_TYPE",
+		ValuationMethods: []accounttype.ValuationMethodTemplate{
+			{
+				ID:                     uuid.New(),
+				InputInstrument:        "USD",
+				ValuationMethodID:      methodID,
+				ValuationMethodVersion: 1,
+				Status:                 accounttype.StatusActive,
+			},
+		},
+	}
+
+	now := time.Now().UTC()
+
+	// First seed
+	err := seeder.SeedFromProductType(ctx, accountID, productType, now)
+	require.NoError(t, err)
+
+	// Second seed - must not fail and must not create duplicates
+	err = seeder.SeedFromProductType(ctx, accountID, productType, now)
+	require.NoError(t, err, "second seed must be idempotent")
+
+	active := LifecycleStatusActive
+	features, err := repo.FindByAccountID(ctx, accountID, &active)
+	require.NoError(t, err)
+	assert.Len(t, features, 1, "no duplicates after double seed")
+}
+
+func TestProductTypeSeeder_SeedFromProductType_EmptyTemplates(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	seeder := NewProductTypeSeeder(repo)
+
+	accountID := uuid.New()
+	productType := &accounttype.Definition{
+		ID:               uuid.New(),
+		Code:             "EMPTY_TYPE",
+		ValuationMethods: []accounttype.ValuationMethodTemplate{},
+	}
+
+	now := time.Now().UTC()
+	err := seeder.SeedFromProductType(ctx, accountID, productType, now)
+	require.NoError(t, err)
+
+	features, err := repo.FindByAccountID(ctx, accountID, nil)
+	require.NoError(t, err)
+	assert.Empty(t, features)
+}
+
+func TestRepository_UpsertFeature_CreatesFeature(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	accountID := uuid.New()
+	methodID := uuid.New()
+	now := time.Now().UTC()
+	maxTime := time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
+
+	feature := &ValuationFeature{
+		ID:                     uuid.New(),
+		AccountID:              accountID,
+		InstrumentCode:         "USD",
+		ValuationMethodID:      methodID,
+		ValuationMethodVersion: 1,
+		LifecycleStatus:        LifecycleStatusActive,
+		ValidFrom:              now,
+		ValidTo:                maxTime,
+		CreatedAt:              now,
+		CreatedBy:              "system",
+		UpdatedAt:              now,
+		UpdatedBy:              "system",
+		Version:                1,
+	}
+
+	err := repo.UpsertFeature(ctx, feature)
+	require.NoError(t, err)
+
+	retrieved, err := repo.FindByAccountIDAndInstrument(ctx, accountID, "USD", now)
+	require.NoError(t, err)
+	assert.Equal(t, methodID, retrieved.ValuationMethodID)
+	assert.Equal(t, LifecycleStatusActive, retrieved.LifecycleStatus)
+}
+
+func TestRepository_UpsertFeature_DoesNothingOnConflict(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	accountID := uuid.New()
+	methodID1 := uuid.New()
+	methodID2 := uuid.New()
+	now := time.Now().UTC()
+	maxTime := time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
+
+	first := &ValuationFeature{
+		ID:                     uuid.New(),
+		AccountID:              accountID,
+		InstrumentCode:         "USD",
+		ValuationMethodID:      methodID1,
+		ValuationMethodVersion: 1,
+		LifecycleStatus:        LifecycleStatusActive,
+		ValidFrom:              now,
+		ValidTo:                maxTime,
+		CreatedAt:              now,
+		CreatedBy:              "system",
+		UpdatedAt:              now,
+		UpdatedBy:              "system",
+		Version:                1,
+	}
+	require.NoError(t, repo.UpsertFeature(ctx, first))
+
+	// Second upsert with different method ID for the same (account, instrument)
+	second := &ValuationFeature{
+		ID:                     uuid.New(),
+		AccountID:              accountID,
+		InstrumentCode:         "USD",
+		ValuationMethodID:      methodID2,
+		ValuationMethodVersion: 2,
+		LifecycleStatus:        LifecycleStatusActive,
+		ValidFrom:              now,
+		ValidTo:                maxTime,
+		CreatedAt:              now,
+		CreatedBy:              "system",
+		UpdatedAt:              now,
+		UpdatedBy:              "system",
+		Version:                1,
+	}
+	err := repo.UpsertFeature(ctx, second)
+	require.NoError(t, err, "upsert on conflict must not return an error")
+
+	// The original feature must remain unchanged
+	retrieved, err := repo.FindByAccountIDAndInstrument(ctx, accountID, "USD", now)
+	require.NoError(t, err)
+	assert.Equal(t, first.ID, retrieved.ID, "original feature ID must be preserved")
+	assert.Equal(t, methodID1, retrieved.ValuationMethodID, "original method must not be overwritten")
+}
+
+func TestProductTypeSeeder_SeedFromProductType_MultipleTenants(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Create a second tenant schema
+	tid2 := tenant.TenantID("test_tenant_2")
+	schemaName2 := tid2.SchemaName()
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName2)).Error
+	require.NoError(t, err)
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.valuation_features (
+		id UUID PRIMARY KEY,
+		account_id UUID NOT NULL,
+		instrument_code VARCHAR(32) NOT NULL,
+		valuation_method_id UUID NOT NULL,
+		valuation_method_version INT NOT NULL,
+		parameters JSONB,
+		lifecycle_status VARCHAR(16) NOT NULL,
+		valid_from TIMESTAMP WITH TIME ZONE NOT NULL,
+		valid_to TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_by VARCHAR(100) NOT NULL,
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		updated_by VARCHAR(100) NOT NULL,
+		version INT NOT NULL DEFAULT 1,
+		CONSTRAINT chk_vf_t2_lifecycle_status CHECK (lifecycle_status IN ('INITIATED','ACTIVE','TERMINATED'))
+	)`, schemaName2)).Error
+	require.NoError(t, err)
+	err = db.Exec(fmt.Sprintf(`CREATE UNIQUE INDEX idx_vf_t2_account_instrument_active
+		ON %q.valuation_features (account_id, instrument_code)
+		WHERE lifecycle_status = 'ACTIVE' AND valid_to = '9999-12-31 23:59:59+00'`, schemaName2)).Error
+	require.NoError(t, err)
+
+	ctx2 := tenant.WithTenant(context.Background(), tid2)
+
+	repo := NewRepository(db)
+	seeder := NewProductTypeSeeder(repo)
+
+	accountID1 := uuid.New()
+	accountID2 := uuid.New()
+	methodID := uuid.New()
+	now := time.Now().UTC()
+
+	productType := &accounttype.Definition{
+		ID:   uuid.New(),
+		Code: "TEST_TYPE",
+		ValuationMethods: []accounttype.ValuationMethodTemplate{
+			{
+				ID:                     uuid.New(),
+				InputInstrument:        "USD",
+				ValuationMethodID:      methodID,
+				ValuationMethodVersion: 1,
+				Status:                 accounttype.StatusActive,
+			},
+		},
+	}
+
+	// Seed for tenant 1
+	err = seeder.SeedFromProductType(ctx, accountID1, productType, now)
+	require.NoError(t, err)
+
+	// Seed for tenant 2
+	err = seeder.SeedFromProductType(ctx2, accountID2, productType, now)
+	require.NoError(t, err)
+
+	// Tenant 1 sees its own feature
+	active := LifecycleStatusActive
+	features1, err := repo.FindByAccountID(ctx, accountID1, &active)
+	require.NoError(t, err)
+	assert.Len(t, features1, 1)
+
+	// Tenant 2 sees its own feature
+	features2, err := repo.FindByAccountID(ctx2, accountID2, &active)
+	require.NoError(t, err)
+	assert.Len(t, features2, 1)
+}


### PR DESCRIPTION
## Summary
- Add `ProductTypeSeeder` to `shared/pkg/valuationfeature` that seeds `ValuationFeature` records from a product type's `ValuationMethodTemplate` list using upsert semantics for saga retry safety
- Add `Repository.UpsertFeature` using `INSERT ... ON CONFLICT (account_id, instrument_code) WHERE lifecycle_status = 'ACTIVE' DO NOTHING` for idempotent inserts
- Add `ResolveConversionMethod` documenting two-tier resolution order: explicit template → same-dimension `DefaultConversionMethodID` fallback → `ErrNoConversionAvailable`
- Migrate `current-account` and `internal-bank-account` services to use `ProductTypeSeeder` instead of inline seeding logic

## Test plan
- [x] Unit tests for `ResolveConversionMethod`: explicit template, same-dimension fallback, explicit takes priority, cross-dimension without template, missing default, deprecated template skipped
- [x] Integration tests for `ProductTypeSeeder.SeedFromProductType`: 2 ACTIVE templates → 2 features, DEPRECATED/DRAFT templates skipped, double-seed idempotency, empty templates, multi-tenant isolation
- [x] Integration tests for `Repository.UpsertFeature`: creates feature, DO NOTHING on conflict preserves original