### PR TITLE
Reframe Claude review as domain risk assessor complementing CodeRabbit

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -257,16 +257,18 @@ jobs:
             For each changed function, check whether the test file is in the diff. If it is, review whether the test actually verifies the behavior. If not, check if a `*_test.go` file exists for the package, then note: "No test changes for [function] - verify existing tests cover the new behavior" or "No test file found for [file]." Focus on domain edge cases, not generic coverage.
 
             **Questions for the Author (根回し - Nemawashi):**
-            End your review with 2-5 probing questions. Each question
-            MUST reference a specific file and line number from the diff.
-            The goal is not "have you considered..." but to surface
-            unstated assumptions, implicit invariants, and the gap between
-            intent and reality.
+            Only include questions when you have genuine uncertainty about
+            the change. A clean config tweak or straightforward bug fix
+            needs zero questions. Do not manufacture questions to fill a
+            section.
 
-            Question types that produce depth:
+            When questions ARE warranted, each MUST reference a specific
+            file and line number from the diff. The goal is to surface
+            unstated assumptions and the gap between intent and reality:
+
             - **Invariant surfacing**: "Line 47 of `registry.go` assumes
               `account.Balance` is non-negative. What enforces that
-              upstream? If nothing, this is a latent bug."
+              upstream?"
             - **Interest behind position**: "Why synchronous here
               (`handler.go:82`) rather than async? The saga pattern
               elsewhere suggests eventual consistency was the intent."
@@ -278,11 +280,11 @@ jobs:
               than adding a new code path?"
             - **Current vs ideal state**: "The test at `_test.go:92`
               asserts the happy path. What's the actual failure mode when
-              the upstream returns partial data - silent corruption or
-              explicit error?"
+              the upstream returns partial data?"
 
-            Avoid generic questions. If you can't anchor a question to a
-            specific line, it probably isn't specific enough to be useful.
+            If you can't anchor a question to a specific line, it
+            probably isn't specific enough to be useful. Omit the section
+            entirely rather than ask generic questions.
 
             For PRDs and architecture docs, also ask:
             - What edge cases are missing from the spec?
@@ -352,9 +354,8 @@ jobs:
             | 🔴 | `file.go:42` | Description | Open |
             | 🟡 | `file.go:88` | Description | Open |
 
-            ### Questions for the Author
-            1. `file.go:47` - [Probing question about invariant/assumption/intent]
-            2. `other.go:82` - [Question anchored to specific code]
+            ### Questions for the Author (omit if none)
+            1. `file.go:47` - [Question anchored to specific code]
 
             ### Previously Flagged
             | Severity | Location | Description | Status |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -247,7 +247,7 @@ jobs:
             - **Cross-system impact**: Dependencies on other services, data contracts, breaking changes?
 
             **Test Coverage Review:**
-            For each changed function, check whether the test file is in the diff. If it is, review whether the test actually verifies the behavior. If not, note: "No test changes for [function] - verify existing tests cover the new behavior." Focus on domain edge cases, not generic coverage.
+            For each changed function, check whether the test file is in the diff. If it is, review whether the test actually verifies the behavior. If not, check if a `*_test.go` file exists for the package, then note: "No test changes for [function] - verify existing tests cover the new behavior" or "No test file found for [file]." Focus on domain edge cases, not generic coverage.
 
             **Questions for the Author:**
             End your review with 2-5 specific questions about the change. Frame as genuine questions the diff alone does not answer:
@@ -315,6 +315,7 @@ jobs:
             | Blast radius | Low/Med/High | What breaks if this is wrong |
             | Rollback | Safe/Risky | Can this be reverted cleanly? |
             | Scale | Low/Med/High | Impact at 10x/100x load |
+            | Cross-system | Low/Med/High | Dependencies, data contracts, breaking changes |
             | Migration | N/A/Safe/Risky | CockroachDB compatibility |
 
             ### Findings
@@ -523,11 +524,15 @@ jobs:
             gh api repos/${{ github.repository }}/contents/docs/adr?ref=${{ github.event.pull_request.head.sha }} --jq '.[].name'
             gh api repos/${{ github.repository }}/contents/docs/prd?ref=${{ github.event.pull_request.head.sha }} --jq '.[].name'
             gh api repos/${{ github.repository }}/contents/docs/skills?ref=${{ github.event.pull_request.head.sha }} --jq '.[].name'
+            gh api repos/${{ github.repository }}/contents/docs/runbooks?ref=${{ github.event.pull_request.head.sha }} --jq '.[].name'
             ```
 
             2. Pick the 1-3 files whose names relate to the PR's changed
                services or features. Read their YAML frontmatter (first 20
-               lines) to confirm relevance via `triggers` and `description`.
+               lines) to confirm relevance via `triggers` and `description`:
+            ```bash
+            gh api repos/${{ github.repository }}/contents/docs/adr/{filename}?ref=${{ github.event.pull_request.head.sha }} --jq '.content' | base64 -d | head -20
+            ```
 
             3. For confirmed matches, read the full doc. Use the `instructions`
                field and body content to verify:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -82,16 +82,41 @@ jobs:
 
             You are reviewing code written by a colleague who has been working with Claude Code locally. This PR represents a collaboration - they've iterated, tested, and refined this work. Your review is the validation step in that partnership.
 
-            ## Your Role
+            ## Your Role: Domain Risk Assessor
 
-            Review as an experienced engineer who genuinely cares about the code AND the person who wrote it. You have autonomy over how you structure your feedback - trust your judgment on what this specific PR needs.
+            You are a senior Meridian engineer reviewing for **domain-level risks** that no linter or AST tool can catch.
+
+            **CodeRabbit reviews this PR in parallel and handles:**
+            - Missing error checks, unchecked type assertions, comma-ok patterns
+            - Nil pointer risks, unused variables, Go idiom violations
+            - Basic concurrency flags, code duplication, API deprecations
+
+            **DO NOT duplicate CodeRabbit's work.** If you catch a line-level Go bug, you are likely producing a false positive or duplicating a finding CodeRabbit already posted. Focus instead on what requires understanding the SYSTEM:
+
+            - **Saga correctness**: Do compensation steps reverse in correct LIFO order? Can partial failure leave inconsistent state?
+            - **Temporal data integrity**: Does code respect the quality ladder (ESTIMATE -> COEFFICIENT -> ACTUAL -> REVISED)? Are bi-temporal queries correct?
+            - **Multi-tenant isolation**: Can tenant A's data leak to tenant B? Are all queries scoped via WithGormTenantScope?
+            - **CockroachDB migration safety**: Does the migration violate CockroachDB limitations? (No partial indexes on new columns in same migration, no PL/pgSQL, no LISTEN/NOTIFY, no expression indexes with context-dependent functions)
+            - **Domain invariant violations**: Does the change break contracts defined in handlers.yaml or BIAN service domain boundaries?
+            - **Blast radius**: If this change fails in production, what breaks? Can it be rolled back without data loss?
+
+            ## Read Before You Review
+
+            **Before commenting on any function, read its full file.** The diff alone hides critical context: surrounding error handling, interface contracts, lock scoping, caller expectations.
+
+            For each Go file with non-trivial changes:
+            ```bash
+            gh api repos/${{ github.repository }}/contents/{filepath}?ref=${{ github.event.pull_request.head.sha }} --jq '.content' | base64 -d
+            ```
+
+            If the file imports a Meridian package central to the change, read that package's types/interface file too. If the file is a test, read the file being tested. Spend more time reading than commenting.
 
             ## Proportional Response
 
             Match your review depth to the change:
             - **Small changes** (typos, config tweaks, one-liners): Brief acknowledgment. Don't manufacture issues.
-            - **Medium changes** (new functions, bug fixes, refactors): Focused review on the changed code.
-            - **Large changes** (new features, architecture): Thorough review with attention to design, edge cases, integration.
+            - **Medium changes** (new functions, bug fixes, refactors): Read changed files in full, review with domain context.
+            - **Large changes** (new features, architecture): Read changed files AND key imports, thorough domain risk assessment.
 
             A 5-line fix doesn't need 500 words of feedback. Respect the author's time.
 
@@ -207,20 +232,29 @@ jobs:
             ## Feedback Principles
 
             - **Be direct**: "Use X because Y" not "Consider using X"
-            - **Be accurate**: Verify before flagging. One accurate finding beats six incorrect ones.
-            - **Be proportional**: Don't pad reviews with low-value suggestions
-            - **Be yourself**: Genuine engagement, not robotic checklist. You care about the code and the person who wrote it.
+            - **Be accurate**: Read the full file before flagging. One accurate finding beats six incorrect ones.
+            - **Questions over assertions**: When uncertain, ask a question. An incorrect assertion erodes trust. A good question starts a conversation.
+            - **No line-level Go linting**: Do not flag error handling, nil checks, concurrency patterns, or Go idioms. CodeRabbit covers these with AST analysis you cannot match from diff text.
 
-            ## Quality Standards
+            ## Review Focus: What Didn't We Think About?
 
-            Hold PRs against these standards. Ask: **"What didn't we think about?"**
+            Your unique value is domain knowledge that no linter has. For each non-trivial change, assess:
 
-            - **Both paths tested?** Happy path AND unhappy path (error conditions, edge cases, null handling)
-            - **Boundary conditions?** Invalid inputs, concurrent access, retry behavior, timeout handling
-            - **Scale and performance?** What happens at 10x, 100x load? Are there N+1 queries, unbounded loops, missing indexes?
-            - **Production readiness?** Observability (logs, metrics), graceful degradation, blast radius if this fails
-            - **Cross-system impact?** Dependencies on other services, data contracts, migration concerns
-            - **Security?** Input validation, authentication/authorization, secrets handling
+            **Risk Assessment:**
+            - **Blast radius**: If this fails in production, what breaks? (Single endpoint / Service / Cross-service / Data corruption)
+            - **Rollback safety**: Can this be reverted cleanly? Flag irreversible changes (migrations, data transforms).
+            - **Scale**: What happens at 10x, 100x load? N+1 queries, unbounded loops, missing indexes?
+            - **Cross-system impact**: Dependencies on other services, data contracts, breaking changes?
+
+            **Test Coverage Review:**
+            For each changed function, check whether the test file is in the diff. If it is, review whether the test actually verifies the behavior. If not, note: "No test changes for [function] - verify existing tests cover the new behavior." Focus on domain edge cases, not generic coverage.
+
+            **Questions for the Author:**
+            End your review with 2-5 specific questions about the change. Frame as genuine questions the diff alone does not answer:
+            - "What happens to in-flight sagas if this migration runs while the service is processing?"
+            - "The test covers the happy path. How does this behave when the upstream service returns a partial response?"
+            - "This changes the tenant scoping query. Have you verified this against multi-tenant integration tests?"
+            - "Is the compensation logic correct if step 3 fails after step 2 commits?"
 
             For PRDs and architecture docs, also ask:
             - What edge cases are missing from the spec?
@@ -275,11 +309,22 @@ jobs:
             ### Summary
             [Concise review - what's good, what needs attention]
 
+            ### Risk Assessment
+            | Area | Level | Detail |
+            |------|-------|--------|
+            | Blast radius | Low/Med/High | What breaks if this is wrong |
+            | Rollback | Safe/Risky | Can this be reverted cleanly? |
+            | Migration | N/A/Safe/Risky | CockroachDB compatibility |
+
             ### Findings
             | Severity | Location | Description | Status |
             |----------|----------|-------------|--------|
             | 🔴 | `file.go:42` | Description | Open |
             | 🟡 | `file.go:88` | Description | Open |
+
+            ### Questions for the Author
+            1. [Specific question about design/edge case/untested scenario]
+            2. [Another question the diff alone does not answer]
 
             ### Previously Flagged
             | Severity | Location | Description | Status |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -109,6 +109,13 @@ jobs:
             gh api repos/${{ github.repository }}/contents/{filepath}?ref=${{ github.event.pull_request.head.sha }} --jq '.content' | base64 -d
             ```
 
+            Note: The contents API has a 1MB limit. If a file returns
+            403/404 (e.g., large generated files or test tables), fall
+            back to the blob API:
+            ```bash
+            gh api repos/${{ github.repository }}/git/blobs/{blob_sha} --jq '.content' | base64 -d
+            ```
+
             If the file imports a Meridian package central to the change, read that package's types/interface file too. If the file is a test, read the file being tested. Spend more time reading than commenting.
 
             ## Proportional Response
@@ -249,12 +256,33 @@ jobs:
             **Test Coverage Review:**
             For each changed function, check whether the test file is in the diff. If it is, review whether the test actually verifies the behavior. If not, check if a `*_test.go` file exists for the package, then note: "No test changes for [function] - verify existing tests cover the new behavior" or "No test file found for [file]." Focus on domain edge cases, not generic coverage.
 
-            **Questions for the Author:**
-            End your review with 2-5 specific questions about the change. Frame as genuine questions the diff alone does not answer:
-            - "What happens to in-flight sagas if this migration runs while the service is processing?"
-            - "The test covers the happy path. How does this behave when the upstream service returns a partial response?"
-            - "This changes the tenant scoping query. Have you verified this against multi-tenant integration tests?"
-            - "Is the compensation logic correct if step 3 fails after step 2 commits?"
+            **Questions for the Author (根回し - Nemawashi):**
+            End your review with 2-5 probing questions. Each question
+            MUST reference a specific file and line number from the diff.
+            The goal is not "have you considered..." but to surface
+            unstated assumptions, implicit invariants, and the gap between
+            intent and reality.
+
+            Question types that produce depth:
+            - **Invariant surfacing**: "Line 47 of `registry.go` assumes
+              `account.Balance` is non-negative. What enforces that
+              upstream? If nothing, this is a latent bug."
+            - **Interest behind position**: "Why synchronous here
+              (`handler.go:82`) rather than async? The saga pattern
+              elsewhere suggests eventual consistency was the intent."
+            - **What happens if we do nothing**: "If we skip this
+              migration (`003_add_index.sql`), does the query at
+              `repository.go:145` degrade gracefully or fail hard?"
+            - **Elimination over addition**: "Could `processor.go:60-80`
+              be replaced by the existing `shared/pkg/valuation` rather
+              than adding a new code path?"
+            - **Current vs ideal state**: "The test at `_test.go:92`
+              asserts the happy path. What's the actual failure mode when
+              the upstream returns partial data - silent corruption or
+              explicit error?"
+
+            Avoid generic questions. If you can't anchor a question to a
+            specific line, it probably isn't specific enough to be useful.
 
             For PRDs and architecture docs, also ask:
             - What edge cases are missing from the spec?
@@ -325,8 +353,8 @@ jobs:
             | 🟡 | `file.go:88` | Description | Open |
 
             ### Questions for the Author
-            1. [Specific question about design/edge case/untested scenario]
-            2. [Another question the diff alone does not answer]
+            1. `file.go:47` - [Probing question about invariant/assumption/intent]
+            2. `other.go:82` - [Question anchored to specific code]
 
             ### Previously Flagged
             | Severity | Location | Description | Status |
@@ -545,8 +573,8 @@ jobs:
 
             Also reference: CONTRIBUTING.md, service README files
 
-          # Using Opus 4.5 for higher quality code reviews
-          claude_args: '--model claude-opus-4-5-20251101 --allowed-tools "Bash(gh api:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          # Using Opus 4.6 for highest quality code reviews
+          claude_args: '--model claude-opus-4-6 --allowed-tools "Bash(gh api:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
       - name: Report Final Status
         if: always()

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -314,6 +314,7 @@ jobs:
             |------|-------|--------|
             | Blast radius | Low/Med/High | What breaks if this is wrong |
             | Rollback | Safe/Risky | Can this be reverted cleanly? |
+            | Scale | Low/Med/High | Impact at 10x/100x load |
             | Migration | N/A/Safe/Risky | CockroachDB compatibility |
 
             ### Findings
@@ -502,8 +503,42 @@ jobs:
 
             ---
 
-            PROJECT CONTEXT (reference as needed):
-            - CONTRIBUTING.md, docs/adr/, docs/prd/, service README files
+            ## Project Documentation Discovery
+
+            The repo has structured documentation with YAML frontmatter
+            containing `name`, `description`, `triggers`, and `instructions`
+            fields. Use these to verify the PR aligns with the holistic
+            architectural vision, not just local correctness.
+
+            **Directories:**
+            - `docs/skills/` - Operational guides (testing, starlark sagas, docker, etc.)
+            - `docs/adr/` - Architecture Decision Records (temporal quality ladder, asset types, saga orchestration, etc.)
+            - `docs/prd/` - Product Requirements Documents (feature specs, BIAN mappings, acceptance criteria)
+            - `docs/runbooks/` - Operational procedures (saga recovery, deployments)
+
+            **Discovery process (do NOT bulk-load all docs):**
+
+            1. List filenames in each directory - names are descriptive:
+            ```bash
+            gh api repos/${{ github.repository }}/contents/docs/adr?ref=${{ github.event.pull_request.head.sha }} --jq '.[].name'
+            gh api repos/${{ github.repository }}/contents/docs/prd?ref=${{ github.event.pull_request.head.sha }} --jq '.[].name'
+            gh api repos/${{ github.repository }}/contents/docs/skills?ref=${{ github.event.pull_request.head.sha }} --jq '.[].name'
+            ```
+
+            2. Pick the 1-3 files whose names relate to the PR's changed
+               services or features. Read their YAML frontmatter (first 20
+               lines) to confirm relevance via `triggers` and `description`.
+
+            3. For confirmed matches, read the full doc. Use the `instructions`
+               field and body content to verify:
+               - Does the PR fulfill the documented requirements?
+               - Does it follow the architectural decisions?
+               - Are there constraints or patterns the PR should respect?
+
+            This is your "holistic goal" check. A PR that passes linting
+            but violates an ADR or misses a PRD requirement is still wrong.
+
+            Also reference: CONTRIBUTING.md, service README files
 
           # Using Opus 4.5 for higher quality code reviews
           claude_args: '--model claude-opus-4-5-20251101 --allowed-tools "Bash(gh api:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## Summary

Analysis of 20 merged PRs revealed a clear pattern: CodeRabbit finds line-level bugs (33 inline comments: error handling 30%, concurrency 12%, logic bugs 12%, contract violations 9%) while Claude's review produces architectural summaries with near-zero bug detection. Rather than making Claude a worse version of CodeRabbit, this reframes Claude's role to focus on what no linter can detect.

## Changes Made

Four targeted replacements in the review prompt (net +45 lines, replacing generic sections with domain-specific ones):

| Change | What it replaces | Why |
|--------|-----------------|-----|
| **Complementary coverage declaration** | Generic "Your Role" | Explicitly tells Claude what CodeRabbit covers, prevents duplication |
| **File fetching instructions** | (new section) | Claude already has `gh api` access but was never told to read full files. The diff alone hides critical context. |
| **Domain-specific review focus** | Generic "Quality Standards" checklist | Saga correctness, temporal integrity, multi-tenant isolation, CockroachDB safety, blast radius |
| **Question-mode output** | (replaces assertion-style output) | Questions sidestep the self-review blind spot. An incorrect assertion erodes trust; a good question starts a conversation. |

## Analysis Methodology

Six Thinking Hats analysis on 20 merged PRs:

- **White Hat (Facts)**: Categorized all 33 CodeRabbit findings and all Claude review outputs. Found zero overlap -- they operate at completely different abstraction levels.
- **Black Hat (Risks)**: Identified that most of the gap is structural (AST vs text). Adding bug-hunting checklists would produce false positives that make developers stop reading reviews entirely. The self-review blind spot (same model reviewing its own code) cannot be fixed by checklists.
- **Green Hat (Creative)**: File fetching is the highest-leverage change (capability exists, prompt just doesn't use it). Complementary coverage declaration makes the problem disappear by explicit division of labor. Question mode sidesteps rather than fights the blind spot.
- **Blue Hat (Synthesis)**: Claude's review transforms from "mediocre bug-finder" to "senior Meridian engineer asking sharp questions about domain risks."

## What we explicitly decided NOT to do

- **No Go bug-hunting checklist** -- Claude pattern-matching on diff text produces false positives. CodeRabbit has AST analysis we can't match.
- **No two-pass split** -- Doubles API cost for marginal benefit. Single well-structured prompt is sufficient.
- **No staticcheck/errcheck CI changes** -- Separate initiative, tracked independently.

## How to measure success (after 10-15 PRs)

1. **Actionable rate**: Claude comments that prompt author action. Target: 40%+ (up from ~0% on domain items)
2. **False positive rate**: Target below 15%. If above 30%, partially revert.
3. **Question engagement**: Author substantively answers questions. Target: 2+ per review on non-trivial PRs.
4. **Unique catches**: Domain-specific finds CodeRabbit missed. Target: 1 per 5 PRs (saga, tenant, migration).

## Test plan

- [ ] Monitor next 5 PRs for review output quality
- [ ] Check that Claude actually reads full files (look for `gh api contents` in review logs)
- [ ] Verify questions section appears in summary comments
- [ ] Verify risk assessment table appears in summary comments
- [ ] Compare CodeRabbit findings overlap -- should approach zero duplication