### PR TITLE
docs: PRD for structured inbound mapping layer

### DIFF
--- a/docs/prd/024-structured-inbound-mapping.md
+++ b/docs/prd/024-structured-inbound-mapping.md
@@ -1,0 +1,360 @@
+# PRD: Structured Inbound Mapping Layer
+
+## Problem Statement
+
+External systems send JSON in their own formats — a bank's party payload looks
+different from an energy retailer's, which looks different from a carbon registry's.
+Today, every integration must manually conform to Meridian's exact proto-derived
+JSON structure (`camelCase` field names, specific enum strings, nested message
+shapes). This creates friction: integrators must read proto definitions to
+understand the expected format, and any structural mismatch causes opaque
+validation failures.
+
+Meanwhile, Meridian's three domains handle flexibility inconsistently:
+
+| Domain | Attributes | Validation | Computed | Customization |
+|--------|-----------|------------|----------|---------------|
+| Reference Data | JSON Schema + `AttributeEntry` | CEL | Fungibility keys | Full |
+| Party | Fixed + `Struct` metadata | None | None | None |
+| Market Data | JSON Schema + `AttributeEntry` + `Struct` | CEL | Resolution keys | Full |
+
+The Vanguard transcoder (tasks 1-10) solved **protocol transcoding**
+(HTTP/JSON ↔ gRPC). This PRD addresses the next layer: **semantic
+transcoding** — mapping external data formats to internal proto structures
+with validation, transformation, and computed field generation.
+
+## Technical Context
+
+### What Exists Today
+
+**Protocol Layer** (solved by gateway-json-transcoding):
+
+- Vanguard transcodes REST/JSON → gRPC proto using `google.api.http` annotations
+- Handles Content-Type negotiation (JSON, Connect, gRPC-Web)
+- Identity headers propagate as gRPC metadata
+
+**Schema Infrastructure** (exists in reference-data and market-information):
+
+- `attribute_schema` (JSON Schema, max 16KB) — defines valid attributes per entity type
+- CEL compiler (`services/reference-data/cel/compiler.go`) with security constraints:
+  - Max 4096 bytes, max 10 nesting depth, cost limit 10,000
+  - Guaranteed termination (no while loops, no recursion)
+- `repeated AttributeEntry` for deterministic attribute ordering
+- Schema discovery RPCs (`GetAttributeSchema`)
+
+**Handler Schema** (exists for saga orchestration):
+
+- `handlers.yaml` defines typed handler signatures
+- Auto-generates type-safe Starlark clients
+- Compile-time validation of saga workflows
+
+### What's Missing
+
+1. **Inbound mapping definitions**: No way to say "when tenant X sends
+   `{"govt_id": "..."}`, map it to `government_id` in the Party
+   Reference qualifier"
+2. **Consistent schema validation across domains**: Party has none;
+   reference data and market data have CEL but with different patterns
+3. **Gateway-level transformation**: Vanguard handles 1:1 proto JSON
+   mapping; no tenant-aware transformations
+4. **Computed field generation at ingress**: Resolution keys, fungibility
+   keys computed deep in service layers — could be computed earlier
+5. **External format discovery**: No way for integrators to ask "what JSON
+   shape does tenant X expect for party onboarding?"
+
+## Solution: Inbound Mapping Definitions
+
+### Core Concept
+
+An **Inbound Mapping** is a tenant-configurable definition that describes how
+to transform external JSON into Meridian's internal proto structure. Each
+mapping targets a specific RPC (e.g., `RegisterParty`, `CreateInstrument`,
+`RecordObservation`) and defines:
+
+1. **Field mappings**: External field paths → internal proto field paths
+2. **Type coercions**: String→enum, string→decimal, date format normalization
+3. **Validation rules**: CEL expressions for cross-field validation
+4. **Computed fields**: CEL expressions that derive values from input (resolution keys, default values)
+5. **Attribute flattening**: Map flat external JSON keys into `repeated AttributeEntry` or `google.protobuf.Struct`
+
+### Architecture
+
+```text
+External JSON → Gateway → Mapping Engine → Proto-conformant JSON → Vanguard → gRPC
+                               ↑
+                     InboundMappingDefinition
+                     (tenant-configured, per-RPC)
+```
+
+The Mapping Engine sits as middleware **before** Vanguard in the gateway chain. It:
+
+1. Identifies the target RPC from the URL path
+2. Looks up the tenant's mapping definition for that RPC
+3. Transforms the request body
+4. Passes the conformant JSON to Vanguard for proto transcoding
+
+### Data Model
+
+```protobuf
+// api/proto/meridian/mapping/v1/mapping.proto
+
+message InboundMappingDefinition {
+  string id = 1;
+  string tenant_id = 2;
+  string name = 3;                          // e.g., "bank-x-party-onboarding"
+  string target_service = 4;                // e.g., "meridian.party.v1.PartyService"
+  string target_rpc = 5;                    // e.g., "RegisterParty"
+  string version = 6;                       // Semver for safe evolution
+  MappingStatus status = 7;                 // DRAFT → ACTIVE → DEPRECATED
+
+  // Schema of expected inbound JSON (for discovery/docs)
+  string input_schema = 8;                  // JSON Schema describing external format
+
+  // Transformation rules (ordered, applied sequentially)
+  repeated FieldMapping field_mappings = 9;
+  repeated ComputedField computed_fields = 10;
+  string validation_expression = 11;        // CEL: cross-field validation (post-mapping)
+
+  // Metadata
+  google.protobuf.Timestamp created_at = 12;
+  google.protobuf.Timestamp updated_at = 13;
+}
+
+message FieldMapping {
+  string source_path = 1;                   // JSONPath in external JSON: "$.govt_id"
+  string target_path = 2;                   // Proto field path: "reference.government_id"
+  FieldTransform transform = 3;             // Optional transformation
+}
+
+message FieldTransform {
+  oneof transform {
+    string cel_expression = 1;              // CEL: "source.toUpper()"
+    EnumMapping enum_mapping = 2;           // {"INDIVIDUAL": "PARTY_TYPE_PERSON", ...}
+    string date_format = 3;                 // "2006-01-02" → RFC3339
+    string default_value = 4;               // If source missing, use this
+    AttributeFlatten attribute_flatten = 5;  // Map flat keys → AttributeEntry[]
+  }
+}
+
+message EnumMapping {
+  map<string, string> values = 1;           // External → internal enum string
+  string fallback = 2;                      // Default if no match
+}
+
+message AttributeFlatten {
+  repeated string source_keys = 1;          // External keys to collect
+  string target_field = 2;                  // "attributes" (repeated AttributeEntry)
+}
+
+message ComputedField {
+  string target_path = 1;                   // Proto field to populate
+  string cel_expression = 2;               // CEL using mapped fields as input
+}
+```
+
+### Example: Bank Party Onboarding Mapping
+
+**External JSON** (from a bank's system):
+
+```json
+{
+  "type": "individual",
+  "full_name": "Alice Smith",
+  "govt_id": "AB123456C",
+  "govt_id_type": "national_insurance",
+  "dob": "1990-05-15",
+  "account_officer": "AO-42",
+  "branch": "LONDON-01"
+}
+```
+
+**Mapping Definition**:
+
+```yaml
+name: bank-x-party-onboarding
+target_service: meridian.party.v1.PartyService
+target_rpc: RegisterParty
+
+field_mappings:
+  - source: "$.type"
+    target: "party_type"
+    transform:
+      enum_mapping:
+        values: {"individual": "PARTY_TYPE_PERSON", "corporate": "PARTY_TYPE_ORGANIZATION"}
+
+  - source: "$.full_name"
+    target: "legal_name"
+
+  - source: "$.govt_id"
+    target: "reference.government_id"
+
+  - source: "$.govt_id_type"
+    target: "reference.issuing_authority"
+
+  - source: "$.account_officer"
+    target: "bank_relations.account_officer_id"
+
+  - source: "$.branch"
+    target: "bank_relations.assigned_branch"
+
+computed_fields:
+  - target: "display_name"
+    cel: "input.full_name.split(' ')[0]"   # First name as display name
+
+validation:
+  cel: "has(input.full_name) && size(input.full_name) > 0"
+```
+
+**Result** (proto-conformant JSON passed to Vanguard):
+
+```json
+{
+  "partyType": "PARTY_TYPE_PERSON",
+  "legalName": "Alice Smith",
+  "displayName": "Alice",
+  "reference": {
+    "governmentId": "AB123456C",
+    "issuingAuthority": "national_insurance"
+  },
+  "bankRelations": {
+    "accountOfficerId": "AO-42",
+    "assignedBranch": "LONDON-01"
+  }
+}
+```
+
+### Example: Energy Retailer Market Data Mapping
+
+**External JSON** (from a metering system):
+
+```json
+{
+  "meter_id": "MPAN-1234567890",
+  "reading": 42.5,
+  "unit": "kWh",
+  "timestamp": "2026-02-20T10:30:00Z",
+  "quality": "estimated",
+  "tenor": "HH",
+  "settlement": "D+1"
+}
+```
+
+**Mapping Definition** transforms to `RecordObservation` with:
+
+- `quality: "estimated"` → `QUALITY_ESTIMATE`
+- Flat `tenor` + `settlement` → `repeated AttributeEntry`
+- Computed `resolution_key_value` from attributes via CEL
+
+### Example: Asset Class Definition Mapping
+
+**External JSON** (from a carbon registry):
+
+```json
+{
+  "asset_type": "voluntary_carbon_credit",
+  "registry": "verra",
+  "vintage_year": 2025,
+  "methodology": "VM0007",
+  "unit": "tCO2e",
+  "min_amount": 0.001,
+  "precision": 3
+}
+```
+
+**Mapping Definition** transforms to `RegisterInstrument` with:
+
+- `unit: "tCO2e"` → instrument code lookup/creation
+- Flat `registry`, `vintage_year`, `methodology` → `repeated AttributeEntry`
+- `validation_expression` computed: `"value >= 0.001"`
+- `dimension` derived from unit type
+
+## Scope
+
+### In Scope (This PRD)
+
+1. **InboundMappingDefinition proto** — data model for mapping definitions
+2. **Mapping CRUD service** — create, update, version, activate/deprecate mappings
+3. **Mapping Engine middleware** — gateway component that applies mappings before Vanguard
+4. **CEL-based transforms** — reuse existing CEL compiler with mapping-specific extensions
+5. **Schema discovery API** — "what JSON shape does this mapping expect?"
+6. **Mapping validation** — compile-time verification that mappings produce valid proto JSON
+7. **Three reference mappings** — one each for Party, Reference Data, and Market Data
+
+### Out of Scope
+
+- **Outbound mapping** (response transformation) — separate PRD
+- **Streaming/batch mapping** — this covers request/response only
+- **UI for mapping creation** — API-first, UI later
+- **Mapping marketplace** — sharing mappings between tenants
+- **AI-assisted mapping generation** — future enhancement (LLM generates mapping from sample JSON)
+
+## Design Constraints
+
+### Safety (Non-negotiable)
+
+All mapping definitions must be **safe by construction**:
+
+1. **CEL only** for expressions — guaranteed termination, bounded cost, no side effects
+2. **JSON Schema validation** of both input and output — catch errors at definition time
+3. **Mapping compilation** at registration — parse all paths, compile all
+   CEL, validate all enum mappings. Reject invalid mappings immediately.
+4. **Cost limits** — reuse existing CEL compiler constraints
+   (max 4096 bytes, cost limit 10,000)
+5. **Immutable versions** — once active, a mapping version is frozen.
+   Changes create new versions.
+
+### Performance
+
+1. **Compiled mappings cached** — don't re-parse on every request. Cache
+   compiled CEL programs and path extractors per tenant+mapping.
+2. **Sub-millisecond overhead** for simple field mappings (rename + type coercion)
+3. **< 5ms overhead** for complex mappings with CEL evaluation
+4. **Zero overhead** when no mapping defined — passthrough to Vanguard unchanged
+
+### Consistency
+
+1. **Unified pattern** — Party, Reference Data, and Market Data all use the same mapping infrastructure
+2. **Deterministic** — same input + same mapping = same output, always
+3. **Bi-temporal aware** — mappings can set temporal fields (valid_from/valid_to) from external formats
+
+## Success Criteria
+
+1. An external system can send JSON in its own format and have it correctly mapped to a Meridian RPC
+2. A tenant can register a mapping definition via API and see it take effect immediately
+3. Mapping validation rejects invalid definitions at registration time (not at request time)
+4. Schema discovery API returns the expected input JSON shape for a given mapping
+5. Performance overhead < 5ms p99 for complex mappings
+6. All three domains (Party, Reference Data, Market Data) have working reference mappings
+
+## Complexity Estimate
+
+**Total: 21 points** (decomposition needed)
+
+- Proto definition + CRUD service: 5 points
+- Mapping engine middleware: 8 points (core complexity — path extraction, CEL evaluation, attribute flattening)
+- Gateway integration: 3 points
+- Reference mappings + tests: 5 points
+
+**Critical path**: Proto → Engine → Gateway integration (16 points sequential)
+**Parallelizable**: Reference mappings can run alongside gateway integration
+
+## Open Questions
+
+1. **Where does the mapping engine live?** Gateway middleware (request-level)
+   vs dedicated mapping service (RPC-level)? Gateway is simpler but couples
+   mapping logic to the gateway. Dedicated service is cleaner but adds a
+   network hop.
+
+2. **Mapping inheritance?** Should tenants inherit from a base mapping and
+   override specific fields? Useful for "bank template" + tenant
+   customizations.
+
+3. **Versioned RPCs?** If a proto message evolves (new fields), should
+   mappings auto-adapt or require explicit versioning?
+
+4. **Batch operations?** Some domains accept batch requests (bulk
+   observations). Should mappings apply per-item within a batch?
+
+5. **Error granularity?** When mapping fails, should the error indicate
+   which field/transform failed? (Yes, almost certainly — but how
+   detailed?)

--- a/docs/prd/024-structured-inbound-mapping.md
+++ b/docs/prd/024-structured-inbound-mapping.md
@@ -24,12 +24,13 @@ Party has none of this — custom data lives in unvalidated
 `google.protobuf.Struct` metadata on associations only.
 
 The Vanguard transcoder (tasks 1-10) solved **protocol transcoding**
-(HTTP/JSON to gRPC). This PRD addresses three layers above that:
+(HTTP/JSON to gRPC). This PRD addresses two layers above that:
 
 1. **Consistent property model** — bring Party in line with Reference
    Data and Market Data
-2. **Inbound mapping** — transform external JSON to internal proto
-3. **Outbound mapping** — transform internal proto to external JSON
+2. **Bidirectional mapping** — a single definition that transforms
+   external JSON to internal proto (inbound) and internal proto back
+   to external JSON (outbound), without duplicating logic
 
 ## Technical Context
 
@@ -79,22 +80,19 @@ The Vanguard transcoder (tasks 1-10) solved **protocol transcoding**
 5. **Format discovery**: No way for integrators to ask "what JSON shape
    does tenant X expect?"
 
-## Solution: Three-Phase Mapping Layer
+## Solution: Two-Phase Mapping Layer
 
 ### Phase 1: Unified Property Model
 
 Bring Party into consistency with Reference Data and Market Data by
 adding structured attribute support and CEL validation.
 
-### Phase 2: Inbound Mapping
+### Phase 2: Bidirectional Mapping
 
-Tenant-configurable definitions that transform external JSON into
-Meridian's internal proto structures before Vanguard processes them.
-
-### Phase 3: Outbound Mapping
-
-Tenant-configurable definitions that transform internal proto responses
-back into partner-specific JSON formats after Vanguard processes them.
+A single `MappingDefinition` describes the correspondence between
+external and internal fields. The engine runs it **forward** for
+inbound requests and **backward** for outbound responses — no
+duplicate definitions needed.
 
 ---
 
@@ -171,33 +169,43 @@ No new CEL functions needed — `parse_iso_date`, `parse_int`,
 | Party attributes field + migration | 3 |
 | CEL compiler integration in Party service | 2 |
 | Schema validation at registration | 3 |
+| Manifest: add `party_types` + differ/planner | 3 |
 | Tests + reference party type definitions | 2 |
-| **Total** | **13** |
+| **Total** | **16** |
 
 ---
 
-## Phase 2: Inbound Mapping
+## Phase 2: Bidirectional Mapping
 
 ### Core Concept
 
-An **Inbound Mapping** is a tenant-configurable definition that
-describes how to transform external JSON into Meridian's internal proto
-structure. Each mapping targets a specific RPC and defines:
+A **MappingDefinition** is a single, bidirectional definition that
+describes the correspondence between external and internal fields.
+The mapping engine runs it **forward** (external to proto) for inbound
+requests and **backward** (proto to external) for outbound responses.
 
-1. **Field mappings**: External field paths to internal proto field paths
-2. **Type coercions**: String to enum, string to decimal, date format
-   normalization
-3. **Validation rules**: CEL expressions for cross-field validation
-4. **Computed fields**: CEL expressions that derive values from input
-5. **Attribute flattening**: Map flat external JSON keys into
-   `repeated AttributeEntry` or `google.protobuf.Struct`
+Most transforms are naturally reversible:
+
+| Transform | Inbound | Outbound |
+|-----------|---------|----------|
+| Field rename | Read external, write internal | Read internal, write external |
+| Enum mapping | Look up external key | Invert: look up internal key |
+| Date format | Parse external format to RFC3339 | Format RFC3339 to external |
+| Attribute flatten | Collect keys into `AttributeEntry[]` | Unflatten to flat keys |
+| Default value | Apply if source missing | Skip (inbound-only) |
+| CEL expression | **Not reversible** — needs explicit pair | See `CelTransform` below |
+
+For the one non-reversible transform (CEL), we provide explicit
+`inbound_cel` and `outbound_cel` fields. This means **one mapping
+definition handles both directions** — no duplicate definitions, no
+pairing logic, no version synchronization problem.
 
 ### Routing Strategy
 
-Mapped requests use a **dedicated ingress path**:
+Mapped requests use a **dedicated path**:
 
 ```text
-POST /inbound/{mapping_name}
+POST /mapping/{mapping_name}
 ```
 
 The gateway:
@@ -207,9 +215,11 @@ The gateway:
    the **latest ACTIVE version**. If no ACTIVE version exists, return
    404. Version override via `X-Mapping-Version` header is supported
    but optional.
-3. Transforms the request body using the mapping rules
+3. **Inbound**: transforms the request body (external to proto)
 4. Rewrites the request internally to the `target_service`/`target_rpc`
 5. Forwards the proto-conformant JSON to Vanguard
+6. **Outbound**: transforms the response body (proto to external)
+7. Returns the partner-format JSON to the caller
 
 This avoids intercepting standard gRPC paths (e.g., `/v1/party`) and
 supports multiple mappings per RPC — a tenant can have
@@ -227,8 +237,8 @@ metadata about how to interpret data, analogous to Instrument
 Definitions and Attribute Schemas.
 
 The **Mapping Engine middleware** lives in `services/gateway/` — it
-intercepts `/inbound/` requests, resolves the mapping definition,
-applies transforms, and forwards to Vanguard.
+intercepts `/mapping/` requests, resolves the mapping definition,
+applies transforms in both directions, and forwards to Vanguard.
 
 ### Data Model
 
@@ -242,64 +252,74 @@ enum MappingStatus {
   MAPPING_STATUS_DEPRECATED = 3;
 }
 
-enum MappingDirection {
-  MAPPING_DIRECTION_UNSPECIFIED = 0;
-  MAPPING_DIRECTION_INBOUND = 1;   // Phase 2
-  MAPPING_DIRECTION_OUTBOUND = 2;  // Phase 3
-}
-
 message MappingDefinition {
   string id = 1;
   string tenant_id = 2;
   string name = 3;              // "bank-x-party-onboarding"
-  MappingDirection direction = 4;
-  string target_service = 5;    // "meridian.party.v1.PartyService"
-  string target_rpc = 6;        // "RegisterParty"
-  string version = 7;           // Semver for safe evolution
-  MappingStatus status = 8;
+  string target_service = 4;    // "meridian.party.v1.PartyService"
+  string target_rpc = 5;        // "RegisterParty"
+  string version = 6;           // Semver for safe evolution
+  MappingStatus status = 7;
 
   // Schema of expected external JSON (for discovery/docs)
-  string external_schema = 9;   // JSON Schema
+  string external_schema = 8;   // JSON Schema
 
-  // Transformation pipeline (executed in order below)
-  repeated FieldMapping field_mappings = 10;
-  repeated ComputedField computed_fields = 11;
-  string validation_cel = 12;   // CEL: post-mapping validation
+  // Bidirectional field correspondences
+  repeated FieldCorrespondence fields = 9;
+
+  // Direction-specific computed fields
+  repeated ComputedField inbound_computed_fields = 10;
+  repeated ComputedField outbound_computed_fields = 11;
+
+  // Direction-specific validation
+  string inbound_validation_cel = 12;
+  string outbound_validation_cel = 13;
 
   // Metadata
-  google.protobuf.Timestamp created_at = 13;
-  google.protobuf.Timestamp updated_at = 14;
+  google.protobuf.Timestamp created_at = 14;
+  google.protobuf.Timestamp updated_at = 15;
 
-  // Batch support
-  bool is_batch = 15;           // Input is JSON array
-  string batch_target_path = 16; // Wrap array at this path
+  // Batch support (inbound only)
+  bool is_batch = 16;           // Input is JSON array
+  string batch_target_path = 17; // Wrap array at this path
 }
 ```
 
-**Execution order**: `field_mappings` (sequentially) then
-`computed_fields` (sequentially, on post-mapped state) then
-`validation_cel` (on final state, must return `true`).
+**Inbound execution order**: `fields` (forward, sequentially) then
+`inbound_computed_fields` (sequentially) then `inbound_validation_cel`
+(must return `true`).
+
+**Outbound execution order**: `fields` (reverse, sequentially) then
+`outbound_computed_fields` (sequentially) then
+`outbound_validation_cel` (must return `true`).
 
 ```protobuf
-message FieldMapping {
-  string source_path = 1;       // gjson path: "govt_id"
-  string target_path = 2;       // Proto path: "reference.government_id"
-  FieldTransform transform = 3; // Optional transformation
+message FieldCorrespondence {
+  string external_path = 1;       // gjson path: "govt_id"
+  string internal_path = 2;       // Proto path: "reference.government_id"
+  FieldTransform transform = 3;   // Optional transformation
 }
 
 message FieldTransform {
   oneof transform {
-    string cel_expression = 1;
-    EnumMapping enum_mapping = 2;
-    string date_format = 3;       // "2006-01-02" to RFC3339
-    string default_value = 4;     // Fallback if source missing
-    AttributeFlatten attribute_flatten = 5;
+    CelTransform cel_transform = 1;  // Explicit inbound + outbound
+    EnumMapping enum_mapping = 2;    // Auto-reversible
+    string date_format = 3;          // Auto-reversible
+    string default_value = 4;        // Inbound only
+    AttributeFlatten attribute_flatten = 5; // Auto-reversible
   }
+}
+
+// For transforms that aren't naturally reversible
+message CelTransform {
+  string inbound_cel = 1;   // external value -> internal value
+  string outbound_cel = 2;  // internal value -> external value
 }
 
 message EnumMapping {
   map<string, string> values = 1; // External to internal
-  string fallback = 2;            // Default if no match
+  string fallback = 2;            // Default if no match (inbound)
+  string outbound_fallback = 3;   // Default if no match (outbound)
 }
 
 message AttributeFlatten {
@@ -308,30 +328,40 @@ message AttributeFlatten {
 }
 
 message ComputedField {
-  string target_path = 1;         // Proto field to populate
-  string cel_expression = 2;      // CEL using mapped fields
+  string target_path = 1;         // Field to populate
+  string cel_expression = 2;      // CEL expression
 }
 ```
 
 #### Path Syntax
 
-Source paths use **gjson syntax** (no `$` prefix):
+`external_path` uses **gjson syntax** (no `$` prefix):
 
 - Object fields: `govt_id`, `reference.government_id`
 - Array index: `items.0`
 - Array length: `items.#`
 - Nested array map: `items.#.name`
 
-Target paths use **proto field path notation** (dot-separated field
+`internal_path` uses **proto field path notation** (dot-separated field
 names matching the proto message structure).
 
 #### CEL Expression Context
 
-| Location | Variables | Return Type |
-|----------|-----------|-------------|
-| `FieldTransform.cel_expression` | `source` (extracted value) | Target field type |
-| `ComputedField.cel_expression` | `input` (original JSON), `mapped` (post-mapping state) | Target field type |
-| `validation_cel` | `input`, `mapped` | `bool` (false = reject with 400) |
+**Inbound:**
+
+| Location | Variables | Return |
+|----------|-----------|--------|
+| `CelTransform.inbound_cel` | `source` (extracted external value) | Internal field type |
+| `inbound_computed_fields` | `input` (external JSON), `mapped` (post-mapping) | Target field type |
+| `inbound_validation_cel` | `input`, `mapped` | `bool` |
+
+**Outbound:**
+
+| Location | Variables | Return |
+|----------|-----------|--------|
+| `CelTransform.outbound_cel` | `source` (internal proto value) | External field type |
+| `outbound_computed_fields` | `input` (proto JSON), `mapped` (post-mapping) | Target field type |
+| `outbound_validation_cel` | `input`, `mapped` | `bool` |
 
 All CEL expressions are subject to existing compiler constraints:
 max 4096 bytes, max 10 nesting depth, cost limit 10,000.
@@ -347,11 +377,11 @@ When `is_batch = true`:
 2. Applies field_mappings and computed_fields to each element
 3. Wraps the transformed array at `batch_target_path`
 
-### Example: Bank Party Onboarding
+### Example: Bank Party Onboarding (Bidirectional)
 
-**Request**: `POST /inbound/bank-x-party-onboarding`
+**Inbound request**: `POST /mapping/bank-x-party-onboarding`
 
-**External JSON**:
+**External JSON** (from bank's system):
 
 ```json
 {
@@ -365,46 +395,46 @@ When `is_batch = true`:
 }
 ```
 
-**Mapping Definition**:
+**Mapping Definition** (single definition, works both directions):
 
 ```yaml
 name: bank-x-party-onboarding
-direction: INBOUND
 target_service: meridian.party.v1.PartyService
 target_rpc: RegisterParty
 
-field_mappings:
-  - source_path: "type"
-    target_path: "party_type"
+fields:
+  - external_path: "type"
+    internal_path: "party_type"
     transform:
       enum_mapping:
         values:
           individual: "PARTY_TYPE_PERSON"
           corporate: "PARTY_TYPE_ORGANIZATION"
 
-  - source_path: "full_name"
-    target_path: "legal_name"
+  - external_path: "full_name"
+    internal_path: "legal_name"
 
-  - source_path: "govt_id"
-    target_path: "reference.government_id"
+  - external_path: "govt_id"
+    internal_path: "reference.government_id"
 
-  - source_path: "govt_id_type"
-    target_path: "reference.issuing_authority"
+  - external_path: "govt_id_type"
+    internal_path: "reference.issuing_authority"
 
-  - source_path: "account_officer"
-    target_path: "bank_relations.account_officer_id"
+  - external_path: "account_officer"
+    internal_path: "bank_relations.account_officer_id"
 
-  - source_path: "branch"
-    target_path: "bank_relations.assigned_branch"
+  - external_path: "branch"
+    internal_path: "bank_relations.assigned_branch"
 
-computed_fields:
+inbound_computed_fields:
   - target_path: "display_name"
     cel_expression: "input.full_name.split(' ')[0]"
 
-validation_cel: "has(input.full_name) && size(input.full_name) > 0"
+inbound_validation_cel: >
+  has(input.full_name) && size(input.full_name) > 0
 ```
 
-**Output** (proto-conformant JSON forwarded to Vanguard):
+**Inbound output** (proto-conformant JSON forwarded to Vanguard):
 
 ```json
 {
@@ -422,9 +452,58 @@ validation_cel: "has(input.full_name) && size(input.full_name) > 0"
 }
 ```
 
+**Outbound** — the same mapping auto-reverses the response. The gRPC
+service returns proto-JSON:
+
+```json
+{
+  "partyId": "p-123",
+  "partyType": "PARTY_TYPE_PERSON",
+  "legalName": "Alice Smith",
+  "displayName": "Alice",
+  "status": "PARTY_STATUS_ACTIVE",
+  "createdAt": "2026-02-20T10:30:00Z"
+}
+```
+
+The engine reverses `fields` — enum mappings invert automatically
+(`PARTY_TYPE_PERSON` to `individual`), field renames reverse
+(`legal_name` to `full_name`). Fields not in the mapping
+(`partyId`, `status`, `createdAt`) pass through unchanged:
+
+```json
+{
+  "partyId": "p-123",
+  "type": "individual",
+  "full_name": "Alice Smith",
+  "displayName": "Alice",
+  "status": "PARTY_STATUS_ACTIVE",
+  "createdAt": "2026-02-20T10:30:00Z"
+}
+```
+
+To suppress or rename unmapped response fields, add them to `fields`:
+
+```yaml
+  # Pass through with rename
+  - external_path: "id"
+    internal_path: "party_id"
+  - external_path: "status"
+    internal_path: "status"
+    transform:
+      enum_mapping:
+        values:
+          active: "PARTY_STATUS_ACTIVE"
+          suspended: "PARTY_STATUS_SUSPENDED"
+  - external_path: "created_date"
+    internal_path: "created_at"
+    transform:
+      date_format: "2006-01-02"
+```
+
 ### Example: Energy Retailer Market Data (Batch)
 
-**Request**: `POST /inbound/energy-metering-feed`
+**Request**: `POST /mapping/energy-metering-feed`
 
 **External JSON** (batch of readings):
 
@@ -455,26 +534,27 @@ validation_cel: "has(input.full_name) && size(input.full_name) > 0"
 
 ```yaml
 name: energy-metering-feed
-direction: INBOUND
 target_service: meridian.market_information.v1.MarketInformationService
 target_rpc: RecordObservationBatch
 is_batch: true
 batch_target_path: "observations"
 
-field_mappings:
-  - source_path: "meter_id"
-    target_path: "instrument_code"
+fields:
+  - external_path: "meter_id"
+    internal_path: "instrument_code"
 
-  - source_path: "reading"
-    target_path: "value"
+  - external_path: "reading"
+    internal_path: "value"
     transform:
-      cel_expression: "string(source)"
+      cel_transform:
+        inbound_cel: "string(source)"
+        outbound_cel: "double(source)"
 
-  - source_path: "timestamp"
-    target_path: "observed_at"
+  - external_path: "timestamp"
+    internal_path: "observed_at"
 
-  - source_path: "quality"
-    target_path: "quality_level"
+  - external_path: "quality"
+    internal_path: "quality_level"
     transform:
       enum_mapping:
         values:
@@ -482,20 +562,20 @@ field_mappings:
           actual: "QUALITY_LEVEL_ACTUAL"
           verified: "QUALITY_LEVEL_VERIFIED"
 
-  - source_path: "tenor"
-    target_path: "attributes"
+  - external_path: "tenor"
+    internal_path: "attributes"
     transform:
       attribute_flatten:
         source_keys: ["tenor", "settlement"]
         target_field: "attributes"
 
-computed_fields:
+inbound_computed_fields:
   - target_path: "resolution_key_value"
     cel_expression: >
       mapped.attributes.tenor + ':' + mapped.attributes.settlement
 ```
 
-**Output** (wrapped batch forwarded to Vanguard):
+**Inbound output** (wrapped batch forwarded to Vanguard):
 
 ```json
 {
@@ -528,7 +608,7 @@ computed_fields:
 
 ### Example: Carbon Registry Asset Class
 
-**Request**: `POST /inbound/verra-carbon-credit`
+**Request**: `POST /mapping/verra-carbon-credit`
 
 **External JSON**:
 
@@ -548,43 +628,46 @@ computed_fields:
 
 ```yaml
 name: verra-carbon-credit
-direction: INBOUND
 target_service: meridian.reference_data.v1.ReferenceDataService
 target_rpc: RegisterInstrument
 
-field_mappings:
-  - source_path: "asset_type"
-    target_path: "instrument_code"
+fields:
+  - external_path: "asset_type"
+    internal_path: "instrument_code"
 
-  - source_path: "unit"
-    target_path: "unit_of_measure"
+  - external_path: "unit"
+    internal_path: "unit_of_measure"
 
-  - source_path: "precision"
-    target_path: "decimal_precision"
+  - external_path: "precision"
+    internal_path: "decimal_precision"
     transform:
-      cel_expression: "int(source)"
+      cel_transform:
+        inbound_cel: "int(source)"
+        outbound_cel: "int(source)"
 
-  - source_path: "registry"
-    target_path: "attributes"
+  - external_path: "registry"
+    internal_path: "attributes"
     transform:
       attribute_flatten:
         source_keys: ["registry", "vintage_year", "methodology"]
         target_field: "attributes"
 
-  - source_path: "min_amount"
-    target_path: "minimum_amount"
+  - external_path: "min_amount"
+    internal_path: "minimum_amount"
     transform:
-      cel_expression: "string(source)"
+      cel_transform:
+        inbound_cel: "string(source)"
+        outbound_cel: "double(source)"
 
-computed_fields:
+inbound_computed_fields:
   - target_path: "dimension"
     cel_expression: "'DIMENSION_CARBON'"
 
-validation_cel: >
+inbound_validation_cel: >
   has(input.registry) && has(input.unit) && input.min_amount > 0
 ```
 
-**Output** (proto-conformant JSON forwarded to Vanguard):
+**Inbound output** (proto-conformant JSON forwarded to Vanguard):
 
 ```json
 {
@@ -606,154 +689,14 @@ validation_cel: >
 | Item | Points |
 |------|--------|
 | MappingDefinition proto + CRUD service | 5 |
-| Mapping engine core (path extraction, CEL, flattening) | 8 |
-| Gateway `/inbound/` routing handler | 3 |
-| DryRunMapping RPC + transformation trace | 3 |
+| Bidirectional engine core (path extraction, CEL, flattening) | 8 |
+| Outbound reverse engine (auto-invert transforms) | 3 |
+| Gateway `/mapping/` routing + response interception | 4 |
+| DryRunMapping RPC (inbound + outbound) + trace | 3 |
 | Batch support (`is_batch` + `batch_target_path`) | 2 |
-| Reference mappings (Party, Market Data, Reference Data) | 5 |
-| **Total** | **26** |
-
----
-
-## Phase 3: Outbound Mapping
-
-### Core Concept
-
-An **Outbound Mapping** transforms Meridian's internal proto-JSON
-responses back into partner-specific formats. This is the reverse of
-Phase 2 — same engine, opposite direction.
-
-### Routing and Version Selection
-
-Outbound mappings are activated by the **same ingress path**:
-
-```text
-POST /inbound/{mapping_name}
-```
-
-Outbound mappings are linked to inbound mappings via
-`outbound_mapping_id`:
-
-```protobuf
-message MappingDefinition {
-  // ... existing fields ...
-  string outbound_mapping_id = 17; // Paired outbound mapping
-}
-```
-
-**Version selection rules:**
-
-1. When resolving the inbound mapping, the gateway also resolves its
-   paired outbound mapping via `outbound_mapping_id`
-2. If the inbound mapping has no `outbound_mapping_id`, the gateway
-   looks up the latest ACTIVE outbound `MappingDefinition` with the
-   same `name` and `direction = OUTBOUND`
-3. If no ACTIVE outbound mapping exists, the gateway returns
-   Vanguard's raw proto-JSON response unchanged (no transformation)
-   and logs a debug-level missing-outbound notice
-4. The resolved outbound mapping version is included in the
-   `X-Outbound-Mapping-Version` response header for traceability
-
-### Architecture
-
-```text
-POST /inbound/{mapping_name}
-  |
-  v
-Gateway --> Inbound Engine --> Proto JSON --> Vanguard --> gRPC Service
-                                                |
-                                           Proto JSON Response
-                                                |
-                                                v
-                               Outbound Engine --> Partner JSON Response
-                                    |
-                          OutboundMappingDefinition
-```
-
-### Data Model
-
-Outbound mappings reuse the same `MappingDefinition` proto with
-`direction = OUTBOUND`. The field semantics reverse:
-
-- `source_path` refers to proto response fields (gjson on proto-JSON)
-- `target_path` refers to the partner's expected output structure
-- `computed_fields` derive values from the response
-- `validation_cel` validates the output before returning
-
-### Example: Bank Party Response
-
-**Internal proto-JSON** (from Vanguard):
-
-```json
-{
-  "partyId": "p-123",
-  "partyType": "PARTY_TYPE_PERSON",
-  "legalName": "Alice Smith",
-  "displayName": "Alice",
-  "status": "PARTY_STATUS_ACTIVE",
-  "createdAt": "2026-02-20T10:30:00Z"
-}
-```
-
-**Outbound Mapping** (`bank-x-party-response`):
-
-```yaml
-name: bank-x-party-response
-direction: OUTBOUND
-target_service: meridian.party.v1.PartyService
-target_rpc: RegisterParty
-
-field_mappings:
-  - source_path: "partyId"
-    target_path: "id"
-
-  - source_path: "partyType"
-    target_path: "type"
-    transform:
-      enum_mapping:
-        values:
-          PARTY_TYPE_PERSON: "individual"
-          PARTY_TYPE_ORGANIZATION: "corporate"
-
-  - source_path: "legalName"
-    target_path: "full_name"
-
-  - source_path: "status"
-    target_path: "status"
-    transform:
-      enum_mapping:
-        values:
-          PARTY_STATUS_ACTIVE: "active"
-          PARTY_STATUS_SUSPENDED: "suspended"
-
-  - source_path: "createdAt"
-    target_path: "created_date"
-    transform:
-      date_format: "2006-01-02"
-```
-
-**Partner receives**:
-
-```json
-{
-  "id": "p-123",
-  "type": "individual",
-  "full_name": "Alice Smith",
-  "status": "active",
-  "created_date": "2026-02-20"
-}
-```
-
-### Phase 3 Scope
-
-| Item | Points |
-|------|--------|
-| Outbound engine (reverse field mapping) | 5 |
-| Gateway response interception middleware | 3 |
-| Inbound/outbound pairing logic | 2 |
-| DryRunMapping extension for outbound | 2 |
-| Reference outbound mappings + tests | 3 |
-| **Total** | **15** |
+| Manifest integration (differ, planner, validator) | 3 |
+| Reference mappings (Party, Market Data, Ref Data) | 5 |
+| **Total** | **33** |
 
 ---
 
@@ -777,8 +720,8 @@ All mapping definitions must be **safe by construction**:
 5. **Immutable versions** — once active, a mapping version is frozen.
    Changes create new versions.
 6. **Recursion guard** — a mapping cannot target an RPC that triggers
-   another mapping. The `/inbound/` routing strategy prevents this
-   naturally since Vanguard forwards to gRPC, not back to `/inbound/`.
+   another mapping. The `/mapping/` routing strategy prevents this
+   naturally since Vanguard forwards to gRPC, not back to `/mapping/`.
 7. **Service validation** — at registration, `target_service` is
    validated against the proto descriptor set (compiled into the
    gateway) to ensure it refers to a known gRPC service.
@@ -792,8 +735,8 @@ All mapping definitions must be **safe by construction**:
 3. **< 5ms overhead** for complex mappings with CEL evaluation
 4. **Zero overhead** when no mapping defined — passthrough to Vanguard
    unchanged
-5. **Lazy JSON path extraction** — use `tidwall/gjson` for source_path
-   extraction to avoid full unmarshaling where possible
+5. **Lazy JSON path extraction** — use `tidwall/gjson` for
+   external_path/internal_path extraction to avoid full unmarshaling
 
 ### Consistency
 
@@ -817,8 +760,8 @@ When a mapping fails, the external partner receives a structured error:
   "trace_id": "abc-123",
   "details": {
     "field": "govt_id_type",
-    "source_path": "govt_id_type",
-    "target_path": "reference.issuing_authority",
+    "external_path": "govt_id_type",
+    "internal_path": "reference.issuing_authority",
     "transform": "enum_mapping",
     "error": "No mapping for value 'passport_number' and no fallback"
   }
@@ -848,32 +791,31 @@ payload format without sending live requests.
 1. (Phase 1) Party supports `repeated AttributeEntry` with JSON Schema
    validation and CEL expressions, consistent with Reference Data and
    Market Data
-2. (Phase 2) An external system can `POST /inbound/{mapping_name}`
+2. (Phase 2) An external system can `POST /mapping/{mapping_name}`
    with JSON in its own format and have it correctly mapped to a
    Meridian RPC
-3. (Phase 2) A tenant can register a mapping definition via API and
+3. (Phase 2) The same mapping definition auto-reverses responses back
+   to the partner's JSON format (bidirectional)
+4. (Phase 2) A tenant can register a mapping definition via API and
    see it take effect immediately
-4. (Phase 2) Mapping validation rejects invalid definitions at
+5. (Phase 2) Mapping validation rejects invalid definitions at
    registration time (not at request time)
-5. (Phase 2) Schema discovery API returns the expected input JSON shape
-6. (Phase 2) DryRunMapping shows transformed output or detailed errors
-7. (Phase 2) Batch array inputs are correctly wrapped and forwarded
-8. (Phase 2) Error responses include field path, transform type, error
+6. (Phase 2) Schema discovery API returns the expected external JSON
+   shape
+7. (Phase 2) DryRunMapping shows transformed output (both directions)
+   or detailed errors
+8. (Phase 2) Batch array inputs are correctly wrapped and forwarded
+9. (Phase 2) Error responses include field path, transform type, error
    message, and trace ID
-9. (Phase 2) Performance overhead < 5ms p99 for complex mappings
-10. (Phase 3) Outbound mappings transform proto-JSON responses back to
-    partner-specific formats
-11. (Phase 3) Inbound/outbound mapping pairs work end-to-end on a
-    single `/inbound/` request
+10. (Phase 2) Performance overhead < 5ms p99 for complex mappings
 
 ## Complexity Estimate
 
 | Phase | Points | Description |
 |-------|--------|-------------|
-| Phase 1 | 13 | Unified property model (Party consistency) |
-| Phase 2 | 26 | Inbound mapping (engine, gateway, DryRun, batch) |
-| Phase 3 | 15 | Outbound mapping (reverse engine, response middleware) |
-| **Total** | **54** | |
+| Phase 1 | 16 | Unified property model + manifest integration |
+| Phase 2 | 33 | Bidirectional mapping + manifest integration |
+| **Total** | **49** | |
 
 ### Phase 2 Build Order
 
@@ -885,16 +827,17 @@ it's a simple RPC with no routing or Vanguard integration.
 Recommended sequence:
 
 1. Proto + CRUD (foundation)
-2. Mapping engine core (pure transform logic, no HTTP)
-3. DryRunMapping RPC (engine + RPC wrapper, full unit test coverage)
-4. Gateway `/inbound/` middleware (engine + HTTP routing + Vanguard)
-5. Reference mappings + integration tests
+2. Mapping engine core — inbound transforms (pure logic, no HTTP)
+3. Reverse engine — outbound auto-inversion of transforms
+4. DryRunMapping RPC (engine + RPC, inbound + outbound, unit tests)
+5. Gateway `/mapping/` middleware (routing + response interception)
+6. Reference mappings + integration tests
 
 ### Phase Dependencies
 
 ```text
 Phase 1 ──┐
-           ├──> Phase 2 ──> Phase 3
+           ├──> Phase 2
            │
 (Phase 1 is recommended before Phase 2 for full consistency,
  but Phase 2 can start in parallel if Party attributes are
@@ -905,9 +848,9 @@ Phase 1 ──┐
 
 ### Dependencies
 
-- **`tidwall/gjson`**: Add to `go.mod` for `source_path` extraction.
-  Not currently in the module. gjson syntax uses dot notation without
-  `$` prefix (e.g., `govt_id` not `$.govt_id`).
+- **`tidwall/gjson`**: Add to `go.mod` for path extraction. Not
+  currently in the module. gjson syntax uses dot notation without `$`
+  prefix (e.g., `govt_id` not `$.govt_id`).
 - **`hashicorp/golang-lru/v2`**: Already in `go.mod` (v2.0.7). Use
   for compiled mapping cache in the gateway middleware.
 
@@ -934,6 +877,95 @@ The gateway must cache compiled mapping definitions.
   CEL compiler from `services/reference-data/cel/` to
   `shared/pkg/cel/` so both Party and the mapping engine can use it
   without importing the reference-data service.
+
+## Manifest Integration
+
+The tenant manifest
+(`api/proto/meridian/control_plane/v1/manifest.proto`) is the atomic
+configuration snapshot for a Meridian tenant. It currently declares
+instruments, account types, valuation rules, sagas, payment rails,
+and seed data. Both phases of this PRD require manifest extensions.
+
+### Phase 1: Add `party_types` to Manifest
+
+```protobuf
+message Manifest {
+  // ... existing fields ...
+  repeated PartyTypeDefinition party_types = 9;
+}
+```
+
+This lets tenants declare party type schemas, validation rules, and
+eligibility checks alongside their other business model definitions.
+The control-plane differ and planner must be extended to handle
+`party_types` — diff changes, plan additions/removals, and apply
+them via the Party service CRUD RPCs.
+
+### Phase 2: Add `mappings` to Manifest
+
+```protobuf
+message Manifest {
+  // ... existing fields ...
+  repeated MappingDefinition mappings = 10;
+}
+```
+
+This lets tenants declare their bidirectional mapping definitions
+as part of the manifest. The control-plane must diff mapping changes
+and apply them via the Reference Data mapping CRUD RPCs.
+
+### Files Requiring Updates
+
+| File | Change |
+|------|--------|
+| `api/proto/meridian/control_plane/v1/manifest.proto` | Add fields |
+| `api/jsonschema/manifest.v1.schema.json` | Regenerate |
+| `api/proto/meridian/control_plane/v1/examples/*.manifest.json` | Add examples |
+| `services/control-plane/internal/differ/` | Diff party_types + mappings |
+| `services/control-plane/internal/planner/` | Plan apply operations |
+| `services/control-plane/internal/validator/` | Validate references |
+| `scripts/validate-manifest-jsonschema.sh` | No change (auto) |
+
+### Example: Energy Trading Manifest with Mappings
+
+```json
+{
+  "version": "1.0",
+  "metadata": {
+    "name": "Nordic Energy Trading",
+    "industry": "energy"
+  },
+  "instruments": [ ... ],
+  "accountTypes": [ ... ],
+  "mappings": [
+    {
+      "name": "energy-metering-feed",
+      "targetService": "meridian.market_information.v1.MarketInformationService",
+      "targetRpc": "RecordObservationBatch",
+      "isBatch": true,
+      "batchTargetPath": "observations",
+      "fields": [
+        {
+          "externalPath": "meter_id",
+          "internalPath": "instrument_code"
+        },
+        {
+          "externalPath": "quality",
+          "internalPath": "quality_level",
+          "transform": {
+            "enumMapping": {
+              "values": {
+                "estimated": "QUALITY_LEVEL_ESTIMATE",
+                "actual": "QUALITY_LEVEL_ACTUAL"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
 
 ## Open Questions
 

--- a/docs/prd/024-structured-inbound-mapping.md
+++ b/docs/prd/024-structured-inbound-mapping.md
@@ -1,4 +1,4 @@
-# PRD: Structured Inbound Mapping Layer
+# PRD: Structured Mapping Layer
 
 ## Problem Statement
 
@@ -7,21 +7,29 @@ looks different from an energy retailer's, which looks different from a
 carbon registry's. Today, every integration must manually conform to
 Meridian's exact proto-derived JSON structure (`camelCase` field names,
 specific enum strings, nested message shapes). This creates friction:
-integrators must read proto definitions to understand the expected format,
-and any structural mismatch causes opaque validation failures.
+integrators must read proto definitions to understand the expected
+format, and any structural mismatch causes opaque validation failures.
 
-Meanwhile, Meridian's three domains handle flexibility inconsistently:
+Meanwhile, Meridian's three domains handle flexibility **inconsistently**:
 
-| Domain | Attributes | Validation | Computed | Customization |
-|--------|-----------|------------|----------|---------------|
-| Reference Data | JSON Schema + `AttributeEntry` | CEL | Fungibility keys | Full |
-| Party | Fixed + `Struct` metadata | None | None | None |
-| Market Data | JSON Schema + `AttributeEntry` + `Struct` | CEL | Resolution keys | Full |
+| Domain | Attributes | Schema | Validation | Computed |
+|--------|-----------|--------|------------|----------|
+| Reference Data | `repeated AttributeEntry` | JSON Schema (string) | CEL | Fungibility keys |
+| Market Data | `repeated AttributeEntry` | JSON Schema (Struct) | CEL | Resolution keys |
+| Party | None (fixed fields only) | None | buf.validate only | None |
+
+Party is the outlier. Reference Data and Market Data both support
+tenant-configurable schemas, CEL-based validation, and computed keys.
+Party has none of this — custom data lives in unvalidated
+`google.protobuf.Struct` metadata on associations only.
 
 The Vanguard transcoder (tasks 1-10) solved **protocol transcoding**
-(HTTP/JSON to gRPC). This PRD addresses the next layer: **semantic
-transcoding** — mapping external data formats to internal proto structures
-with validation, transformation, and computed field generation.
+(HTTP/JSON to gRPC). This PRD addresses three layers above that:
+
+1. **Consistent property model** — bring Party in line with Reference
+   Data and Market Data
+2. **Inbound mapping** — transform external JSON to internal proto
+3. **Outbound mapping** — transform internal proto to external JSON
 
 ## Technical Context
 
@@ -34,60 +42,159 @@ with validation, transformation, and computed field generation.
 - Handles Content-Type negotiation (JSON, Connect, gRPC-Web)
 - Identity headers propagate as gRPC metadata
 
-**Schema Infrastructure** (exists in reference-data and
-market-information):
+**Schema Infrastructure** (Reference Data + Market Data):
 
 - `attribute_schema` (JSON Schema, max 16KB) — defines valid attributes
   per entity type
-- CEL compiler (`services/reference-data/cel/compiler.go`) with security
-  constraints:
-  - Max 4096 bytes, max 10 nesting depth, cost limit 10,000
-  - Guaranteed termination (no while loops, no recursion)
+- CEL compiler (`services/reference-data/cel/compiler.go`) with:
+  - Validation environment: `attributes`, `amount`, `valid_from`,
+    `valid_to`, `source`
+  - Bucket key environment: `attributes` + `bucket_key()` function
+  - Eligibility environment: `party`, `attributes`
+  - Custom functions: `parse_iso_date`, `parse_int`, `parse_decimal`,
+    `parse_bool`, `bucket_key`
+  - Security: max 4096 bytes, max 10 depth, cost limit 10,000
 - `repeated AttributeEntry` for deterministic attribute ordering
 - Schema discovery RPCs (`GetAttributeSchema`)
 
-**Handler Schema** (exists for saga orchestration):
+**Party Service** (the gap):
 
-- `handlers.yaml` defines typed handler signatures
-- Auto-generates type-safe Starlark clients
-- Compile-time validation of saga workflows
+- Fixed proto fields: `legal_name`, `display_name`, `party_type`,
+  `status`, `external_reference`
+- `google.protobuf.Struct metadata` on `Association` only — unvalidated,
+  no schema, no CEL
+- No `AttributeEntry`, no `attribute_schema`, no computed fields
+- Persistence: simple GORM entity with string columns, no JSON column
 
 ### What's Missing
 
-1. **Inbound mapping definitions**: No way to say "when tenant X sends
-   `{"govt_id": "..."}`, map it to `government_id` in the Party
-   Reference qualifier"
-2. **Consistent schema validation across domains**: Party has none;
-   reference data and market data have CEL but with different patterns
-3. **Gateway-level transformation**: Vanguard handles 1:1 proto JSON
-   mapping; no tenant-aware transformations
-4. **Computed field generation at ingress**: Resolution keys, fungibility
-   keys computed deep in service layers — could be computed earlier
-5. **External format discovery**: No way for integrators to ask "what
-   JSON shape does tenant X expect for party onboarding?"
+1. **Party extensibility**: No way to define tenant-specific party
+   attributes with validation (e.g., "tier", "risk_rating", "kyc_level")
+2. **Consistent schema validation**: Party has none; Reference Data and
+   Market Data have CEL but with slightly different patterns
+3. **Inbound transformation**: No way to map external JSON formats to
+   internal proto structures
+4. **Outbound transformation**: No way to map internal proto responses
+   back to partner-specific JSON formats
+5. **Format discovery**: No way for integrators to ask "what JSON shape
+   does tenant X expect?"
 
-## Solution: Inbound Mapping Definitions
+## Solution: Three-Phase Mapping Layer
+
+### Phase 1: Unified Property Model
+
+Bring Party into consistency with Reference Data and Market Data by
+adding structured attribute support and CEL validation.
+
+### Phase 2: Inbound Mapping
+
+Tenant-configurable definitions that transform external JSON into
+Meridian's internal proto structures before Vanguard processes them.
+
+### Phase 3: Outbound Mapping
+
+Tenant-configurable definitions that transform internal proto responses
+back into partner-specific JSON formats after Vanguard processes them.
+
+---
+
+## Phase 1: Unified Property Model
+
+### Goal
+
+Eliminate the inconsistency table above. After Phase 1:
+
+| Domain | Attributes | Schema | Validation | Computed |
+|--------|-----------|--------|------------|----------|
+| Reference Data | `repeated AttributeEntry` | JSON Schema | CEL | Fungibility keys |
+| Market Data | `repeated AttributeEntry` | JSON Schema | CEL | Resolution keys |
+| Party | `repeated AttributeEntry` | JSON Schema | CEL | Eligibility keys |
+
+### Changes to Party Proto
+
+Add to `Party` message in `api/proto/meridian/party/v1/party.proto`:
+
+```protobuf
+// Tenant-configurable structured attributes
+repeated meridian.quantity.v1.AttributeEntry attributes = N;
+```
+
+Add to `PartyType` definition (or a new `PartyTypeDefinition` message):
+
+```protobuf
+message PartyTypeDefinition {
+  string party_type = 1;          // e.g., "PERSON", "ORGANIZATION"
+  string tenant_id = 2;
+  string attribute_schema = 3;    // JSON Schema (max 16KB)
+  string validation_cel = 4;      // CEL: cross-field validation
+  string eligibility_cel = 5;     // CEL: account type eligibility
+  string error_message_cel = 6;   // CEL: custom error messages
+}
+```
+
+### Changes to Party Persistence
+
+Add a JSONB column to the party entity for attributes:
+
+```sql
+ALTER TABLE party ADD COLUMN attributes JSONB DEFAULT '[]';
+```
+
+Store `repeated AttributeEntry` as a JSON array, consistent with how
+Reference Data and Market Data persist attributes.
+
+### CEL Compiler Reuse
+
+The existing CEL compiler in `services/reference-data/cel/compiler.go`
+already supports three environments (validation, bucket key,
+eligibility). Party reuses the **eligibility environment** which already
+exposes `party` and `attributes` variables.
+
+No new CEL functions needed — `parse_iso_date`, `parse_int`,
+`parse_decimal`, `parse_bool` cover Party's needs.
+
+### Migration Path
+
+1. Add `PartyTypeDefinition` proto + CRUD RPCs to Party service
+2. Add `attributes` field to `Party` proto and persistence
+3. Wire CEL compiler (import from reference-data or extract to shared)
+4. Validate attributes against schema at `RegisterParty` /
+   `UpdateParty` time
+5. Keep existing `Association.metadata` (Struct) for backwards
+   compatibility — deprecate over time
+
+### Phase 1 Scope
+
+| Item | Points |
+|------|--------|
+| PartyTypeDefinition proto + CRUD | 3 |
+| Party attributes field + migration | 3 |
+| CEL compiler integration in Party service | 2 |
+| Schema validation at registration | 3 |
+| Tests + reference party type definitions | 2 |
+| **Total** | **13** |
+
+---
+
+## Phase 2: Inbound Mapping
 
 ### Core Concept
 
-An **Inbound Mapping** is a tenant-configurable definition that describes
-how to transform external JSON into Meridian's internal proto structure.
-Each mapping targets a specific RPC (e.g., `RegisterParty`,
-`CreateInstrument`, `RecordObservation`) and defines:
+An **Inbound Mapping** is a tenant-configurable definition that
+describes how to transform external JSON into Meridian's internal proto
+structure. Each mapping targets a specific RPC and defines:
 
 1. **Field mappings**: External field paths to internal proto field paths
 2. **Type coercions**: String to enum, string to decimal, date format
    normalization
 3. **Validation rules**: CEL expressions for cross-field validation
 4. **Computed fields**: CEL expressions that derive values from input
-   (resolution keys, default values)
 5. **Attribute flattening**: Map flat external JSON keys into
    `repeated AttributeEntry` or `google.protobuf.Struct`
 
 ### Routing Strategy
 
-Mapped requests use a **dedicated ingress path** to disambiguate from
-direct API calls:
+Mapped requests use a **dedicated ingress path**:
 
 ```text
 POST /inbound/{mapping_name}
@@ -96,40 +203,32 @@ POST /inbound/{mapping_name}
 The gateway:
 
 1. Extracts `mapping_name` from the URL path
-2. Looks up the mapping definition by name (tenant-scoped via identity
-   headers)
+2. Resolves the mapping: look up by name (tenant-scoped), always use
+   the **latest ACTIVE version**. If no ACTIVE version exists, return
+   404. Version override via `X-Mapping-Version` header is supported
+   but optional.
 3. Transforms the request body using the mapping rules
 4. Rewrites the request internally to the `target_service`/`target_rpc`
 5. Forwards the proto-conformant JSON to Vanguard
 
-This avoids intercepting standard gRPC paths (e.g., `/v1/party`), which
-would risk breaking clients that already send valid proto-JSON. It also
+This avoids intercepting standard gRPC paths (e.g., `/v1/party`) and
 supports multiple mappings per RPC — a tenant can have
 `bank-x-party-onboarding` and `bank-y-party-onboarding` targeting the
-same `RegisterParty` RPC with different field layouts.
+same `RegisterParty` with different field layouts.
 
-### Architecture
-
-```text
-POST /inbound/{mapping_name}
-  |
-  v
-Gateway --> Mapping Engine --> Proto-conformant JSON --> Vanguard --> gRPC
-                 |
-       InboundMappingDefinition
-       (tenant-configured, per-mapping-name)
-```
+**Cache key**: `{tenant_id}:{mapping_name}:{version}`. When no explicit
+version is provided, the gateway resolves latest ACTIVE and caches
+under the resolved version.
 
 ### Service Ownership
 
 Mapping CRUD lives in **`services/reference-data/`**. Mappings are
-metadata about how to interpret data, analogous to Instrument Definitions
-and Attribute Schemas. They reuse the CEL compiler infrastructure already
-present in Reference Data (`services/reference-data/cel/compiler.go`).
+metadata about how to interpret data, analogous to Instrument
+Definitions and Attribute Schemas.
 
 The **Mapping Engine middleware** lives in `services/gateway/` — it
-intercepts `/inbound/` requests, calls Reference Data to resolve the
-mapping definition, applies transforms, and forwards to Vanguard.
+intercepts `/inbound/` requests, resolves the mapping definition,
+applies transforms, and forwards to Vanguard.
 
 ### Data Model
 
@@ -143,34 +242,47 @@ enum MappingStatus {
   MAPPING_STATUS_DEPRECATED = 3;
 }
 
-message InboundMappingDefinition {
+enum MappingDirection {
+  MAPPING_DIRECTION_UNSPECIFIED = 0;
+  MAPPING_DIRECTION_INBOUND = 1;   // Phase 2
+  MAPPING_DIRECTION_OUTBOUND = 2;  // Phase 3
+}
+
+message MappingDefinition {
   string id = 1;
   string tenant_id = 2;
   string name = 3;              // "bank-x-party-onboarding"
-  string target_service = 4;    // "meridian.party.v1.PartyService"
-  string target_rpc = 5;        // "RegisterParty"
-  string version = 6;           // Semver for safe evolution
-  MappingStatus status = 7;
+  MappingDirection direction = 4;
+  string target_service = 5;    // "meridian.party.v1.PartyService"
+  string target_rpc = 6;        // "RegisterParty"
+  string version = 7;           // Semver for safe evolution
+  MappingStatus status = 8;
 
-  // Schema of expected inbound JSON (for discovery/docs)
-  string input_schema = 8;      // JSON Schema
+  // Schema of expected external JSON (for discovery/docs)
+  string external_schema = 9;   // JSON Schema
 
-  // Transformation rules (ordered, applied sequentially)
-  repeated FieldMapping field_mappings = 9;
-  repeated ComputedField computed_fields = 10;
-  string validation_expression = 11;  // CEL: post-mapping validation
+  // Transformation pipeline (executed in order below)
+  repeated FieldMapping field_mappings = 10;
+  repeated ComputedField computed_fields = 11;
+  string validation_cel = 12;   // CEL: post-mapping validation
 
   // Metadata
-  google.protobuf.Timestamp created_at = 12;
-  google.protobuf.Timestamp updated_at = 13;
+  google.protobuf.Timestamp created_at = 13;
+  google.protobuf.Timestamp updated_at = 14;
 
   // Batch support
-  bool is_batch = 14;           // Input is JSON array
-  string batch_target_path = 15; // Wrap array at this path
+  bool is_batch = 15;           // Input is JSON array
+  string batch_target_path = 16; // Wrap array at this path
 }
+```
 
+**Execution order**: `field_mappings` (sequentially) then
+`computed_fields` (sequentially, on post-mapped state) then
+`validation_cel` (on final state, must return `true`).
+
+```protobuf
 message FieldMapping {
-  string source_path = 1;       // JSONPath: "$.govt_id"
+  string source_path = 1;       // gjson path: "govt_id"
   string target_path = 2;       // Proto path: "reference.government_id"
   FieldTransform transform = 3; // Optional transformation
 }
@@ -201,20 +313,27 @@ message ComputedField {
 }
 ```
 
+#### Path Syntax
+
+Source paths use **gjson syntax** (no `$` prefix):
+
+- Object fields: `govt_id`, `reference.government_id`
+- Array index: `items.0`
+- Array length: `items.#`
+- Nested array map: `items.#.name`
+
+Target paths use **proto field path notation** (dot-separated field
+names matching the proto message structure).
+
 #### CEL Expression Context
 
-CEL expressions have access to different variables depending on where
-they appear:
+| Location | Variables | Return Type |
+|----------|-----------|-------------|
+| `FieldTransform.cel_expression` | `source` (extracted value) | Target field type |
+| `ComputedField.cel_expression` | `input` (original JSON), `mapped` (post-mapping state) | Target field type |
+| `validation_cel` | `input`, `mapped` | `bool` (false = reject with 400) |
 
-- **`FieldTransform.cel_expression`**: `source` (the extracted source
-  field value). Return type must match the target field type.
-- **`ComputedField.cel_expression`**: `input` (original external JSON
-  as `map<string, any>`) and `mapped` (intermediate state after
-  field_mappings applied as `map<string, any>`).
-- **`validation_expression`**: `input` and `mapped`. Must return
-  `bool` — `false` rejects the request with a 400 error.
-
-All CEL expressions are subject to the existing compiler constraints:
+All CEL expressions are subject to existing compiler constraints:
 max 4096 bytes, max 10 nesting depth, cost limit 10,000.
 
 ### Batch Support
@@ -228,14 +347,11 @@ When `is_batch = true`:
 2. Applies field_mappings and computed_fields to each element
 3. Wraps the transformed array at `batch_target_path`
 
-Example: An energy feed sends `[{meter, reading}, {meter, reading}]`.
-With `batch_target_path = "observations"`, the engine produces
-`{"observations": [{mapped1}, {mapped2}]}` for
-`RecordObservationBatch`.
+### Example: Bank Party Onboarding
 
-### Example: Bank Party Onboarding Mapping
+**Request**: `POST /inbound/bank-x-party-onboarding`
 
-**External JSON** (from a bank's system):
+**External JSON**:
 
 ```json
 {
@@ -249,17 +365,16 @@ With `batch_target_path = "observations"`, the engine produces
 }
 ```
 
-**Request**: `POST /inbound/bank-x-party-onboarding`
-
 **Mapping Definition**:
 
 ```yaml
 name: bank-x-party-onboarding
+direction: INBOUND
 target_service: meridian.party.v1.PartyService
 target_rpc: RegisterParty
 
 field_mappings:
-  - source: "$.type"
+  - source: "type"
     target: "party_type"
     transform:
       enum_mapping:
@@ -267,30 +382,29 @@ field_mappings:
           individual: "PARTY_TYPE_PERSON"
           corporate: "PARTY_TYPE_ORGANIZATION"
 
-  - source: "$.full_name"
+  - source: "full_name"
     target: "legal_name"
 
-  - source: "$.govt_id"
+  - source: "govt_id"
     target: "reference.government_id"
 
-  - source: "$.govt_id_type"
+  - source: "govt_id_type"
     target: "reference.issuing_authority"
 
-  - source: "$.account_officer"
+  - source: "account_officer"
     target: "bank_relations.account_officer_id"
 
-  - source: "$.branch"
+  - source: "branch"
     target: "bank_relations.assigned_branch"
 
 computed_fields:
   - target: "display_name"
     cel: "input.full_name.split(' ')[0]"
 
-validation:
-  cel: "has(input.full_name) && size(input.full_name) > 0"
+validation_cel: "has(input.full_name) && size(input.full_name) > 0"
 ```
 
-**Result** (proto-conformant JSON forwarded to Vanguard):
+**Output** (proto-conformant JSON forwarded to Vanguard):
 
 ```json
 {
@@ -308,32 +422,114 @@ validation:
 }
 ```
 
-### Example: Energy Retailer Market Data Mapping
+### Example: Energy Retailer Market Data (Batch)
 
-**External JSON** (from a metering system):
+**Request**: `POST /inbound/energy-metering-feed`
+
+**External JSON** (batch of readings):
+
+```json
+[
+  {
+    "meter_id": "MPAN-1234567890",
+    "reading": 42.5,
+    "unit": "kWh",
+    "timestamp": "2026-02-20T10:30:00Z",
+    "quality": "estimated",
+    "tenor": "HH",
+    "settlement": "D+1"
+  },
+  {
+    "meter_id": "MPAN-1234567890",
+    "reading": 43.1,
+    "unit": "kWh",
+    "timestamp": "2026-02-20T11:00:00Z",
+    "quality": "estimated",
+    "tenor": "HH",
+    "settlement": "D+1"
+  }
+]
+```
+
+**Mapping Definition**:
+
+```yaml
+name: energy-metering-feed
+direction: INBOUND
+target_service: meridian.market_information.v1.MarketInformationService
+target_rpc: RecordObservationBatch
+is_batch: true
+batch_target_path: "observations"
+
+field_mappings:
+  - source: "meter_id"
+    target: "instrument_code"
+
+  - source: "reading"
+    target: "value"
+    transform:
+      cel_expression: "string(source)"
+
+  - source: "timestamp"
+    target: "observed_at"
+
+  - source: "quality"
+    target: "quality_level"
+    transform:
+      enum_mapping:
+        values:
+          estimated: "QUALITY_LEVEL_ESTIMATE"
+          actual: "QUALITY_LEVEL_ACTUAL"
+          verified: "QUALITY_LEVEL_VERIFIED"
+
+  - source: "tenor"
+    target: "attributes"
+    transform:
+      attribute_flatten:
+        source_keys: ["tenor", "settlement"]
+        target_field: "attributes"
+
+computed_fields:
+  - target: "resolution_key_value"
+    cel: "mapped.attributes.tenor + ':' + mapped.attributes.settlement"
+```
+
+**Output** (wrapped batch forwarded to Vanguard):
 
 ```json
 {
-  "meter_id": "MPAN-1234567890",
-  "reading": 42.5,
-  "unit": "kWh",
-  "timestamp": "2026-02-20T10:30:00Z",
-  "quality": "estimated",
-  "tenor": "HH",
-  "settlement": "D+1"
+  "observations": [
+    {
+      "instrumentCode": "MPAN-1234567890",
+      "value": "42.5",
+      "observedAt": "2026-02-20T10:30:00Z",
+      "qualityLevel": "QUALITY_LEVEL_ESTIMATE",
+      "attributes": [
+        {"key": "tenor", "value": "HH"},
+        {"key": "settlement", "value": "D+1"}
+      ],
+      "resolutionKeyValue": "HH:D+1"
+    },
+    {
+      "instrumentCode": "MPAN-1234567890",
+      "value": "43.1",
+      "observedAt": "2026-02-20T11:00:00Z",
+      "qualityLevel": "QUALITY_LEVEL_ESTIMATE",
+      "attributes": [
+        {"key": "tenor", "value": "HH"},
+        {"key": "settlement", "value": "D+1"}
+      ],
+      "resolutionKeyValue": "HH:D+1"
+    }
+  ]
 }
 ```
 
-**Mapping Definition** transforms to `RecordObservation` with:
+### Example: Carbon Registry Asset Class
 
-- `quality: "estimated"` mapped to `QUALITY_ESTIMATE` via enum_mapping
-- Flat `tenor` + `settlement` collected into
-  `repeated AttributeEntry` via attribute_flatten
-- Computed `resolution_key_value` from attributes via CEL
+**Request**: `POST /inbound/verra-carbon-credit`
 
-### Example: Asset Class Definition Mapping
-
-**External JSON** (from a carbon registry):
+**External JSON**:
 
 ```json
 {
@@ -347,43 +543,209 @@ validation:
 }
 ```
 
-**Mapping Definition** transforms to `RegisterInstrument` with:
+**Mapping Definition**:
 
-- `unit: "tCO2e"` mapped to instrument code lookup/creation
-- Flat `registry`, `vintage_year`, `methodology` collected into
-  `repeated AttributeEntry`
-- `validation_expression`: `"value >= 0.001"`
-- `dimension` derived from unit type
+```yaml
+name: verra-carbon-credit
+direction: INBOUND
+target_service: meridian.reference_data.v1.ReferenceDataService
+target_rpc: RegisterInstrument
 
-## Scope
+field_mappings:
+  - source: "asset_type"
+    target: "instrument_code"
 
-### In Scope (This PRD)
+  - source: "unit"
+    target: "unit_of_measure"
 
-1. **InboundMappingDefinition proto** — data model for mapping
-   definitions
-2. **Mapping CRUD service** — create, update, version,
-   activate/deprecate mappings (in `services/reference-data/`)
-3. **Mapping Engine middleware** — gateway component that intercepts
-   `/inbound/{mapping_name}` and applies mappings before Vanguard
-4. **CEL-based transforms** — reuse existing CEL compiler with
-   mapping-specific extensions
-5. **Schema discovery API** — "what JSON shape does this mapping
-   expect?"
-6. **Mapping validation** — compile-time verification that mappings
-   produce valid proto JSON
-7. **DryRunMapping RPC** — paste JSON, see transformed output or errors
-8. **Batch support** — `is_batch` + `batch_target_path` for array
-   inputs
-9. **Three reference mappings** — one each for Party, Reference Data,
-   and Market Data
+  - source: "precision"
+    target: "decimal_precision"
+    transform:
+      cel_expression: "int(source)"
 
-### Out of Scope
+  - source: "registry"
+    target: "attributes"
+    transform:
+      attribute_flatten:
+        source_keys: ["registry", "vintage_year", "methodology"]
+        target_field: "attributes"
 
-- **Outbound mapping** (response transformation) — separate PRD
-- **Streaming mapping** — this covers request/response only
-- **UI for mapping creation** — API-first, UI later
-- **Mapping marketplace** — sharing mappings between tenants
-- **AI-assisted mapping generation** — future enhancement
+  - source: "min_amount"
+    target: "minimum_amount"
+    transform:
+      cel_expression: "string(source)"
+
+computed_fields:
+  - target: "dimension"
+    cel: "'DIMENSION_CARBON'"
+
+validation_cel: >
+  has(input.registry) && has(input.unit) && input.min_amount > 0
+```
+
+**Output** (proto-conformant JSON forwarded to Vanguard):
+
+```json
+{
+  "instrumentCode": "voluntary_carbon_credit",
+  "unitOfMeasure": "tCO2e",
+  "decimalPrecision": 3,
+  "minimumAmount": "0.001",
+  "dimension": "DIMENSION_CARBON",
+  "attributes": [
+    {"key": "registry", "value": "verra"},
+    {"key": "vintage_year", "value": "2025"},
+    {"key": "methodology", "value": "VM0007"}
+  ]
+}
+```
+
+### Phase 2 Scope
+
+| Item | Points |
+|------|--------|
+| MappingDefinition proto + CRUD service | 5 |
+| Mapping engine core (path extraction, CEL, flattening) | 8 |
+| Gateway `/inbound/` routing handler | 3 |
+| DryRunMapping RPC + transformation trace | 3 |
+| Batch support (`is_batch` + `batch_target_path`) | 2 |
+| Reference mappings (Party, Market Data, Reference Data) | 5 |
+| **Total** | **26** |
+
+---
+
+## Phase 3: Outbound Mapping
+
+### Core Concept
+
+An **Outbound Mapping** transforms Meridian's internal proto-JSON
+responses back into partner-specific formats. This is the reverse of
+Phase 2 — same engine, opposite direction.
+
+### Routing Strategy
+
+Outbound mappings are activated by the **same ingress path**:
+
+```text
+POST /inbound/{mapping_name}
+```
+
+When a `MappingDefinition` with `direction = OUTBOUND` exists for the
+same `mapping_name` (or a paired outbound mapping is linked), the
+gateway applies it to the response body **after** Vanguard returns the
+proto-JSON response.
+
+Alternatively, outbound mappings can be explicitly linked:
+
+```protobuf
+message MappingDefinition {
+  // ... existing fields ...
+  string outbound_mapping_id = 17; // Optional: paired outbound mapping
+}
+```
+
+### Architecture
+
+```text
+POST /inbound/{mapping_name}
+  |
+  v
+Gateway --> Inbound Engine --> Proto JSON --> Vanguard --> gRPC Service
+                                                |
+                                           Proto JSON Response
+                                                |
+                                                v
+                               Outbound Engine --> Partner JSON Response
+                                    |
+                          OutboundMappingDefinition
+```
+
+### Data Model
+
+Outbound mappings reuse the same `MappingDefinition` proto with
+`direction = OUTBOUND`. The field semantics reverse:
+
+- `source_path` refers to proto response fields (gjson on proto-JSON)
+- `target_path` refers to the partner's expected output structure
+- `computed_fields` derive values from the response
+- `validation_cel` validates the output before returning
+
+### Example: Bank Party Response
+
+**Internal proto-JSON** (from Vanguard):
+
+```json
+{
+  "partyId": "p-123",
+  "partyType": "PARTY_TYPE_PERSON",
+  "legalName": "Alice Smith",
+  "displayName": "Alice",
+  "status": "PARTY_STATUS_ACTIVE",
+  "createdAt": "2026-02-20T10:30:00Z"
+}
+```
+
+**Outbound Mapping** (`bank-x-party-response`):
+
+```yaml
+name: bank-x-party-response
+direction: OUTBOUND
+target_service: meridian.party.v1.PartyService
+target_rpc: RegisterParty
+
+field_mappings:
+  - source: "partyId"
+    target: "id"
+
+  - source: "partyType"
+    target: "type"
+    transform:
+      enum_mapping:
+        values:
+          PARTY_TYPE_PERSON: "individual"
+          PARTY_TYPE_ORGANIZATION: "corporate"
+
+  - source: "legalName"
+    target: "full_name"
+
+  - source: "status"
+    target: "status"
+    transform:
+      enum_mapping:
+        values:
+          PARTY_STATUS_ACTIVE: "active"
+          PARTY_STATUS_SUSPENDED: "suspended"
+
+  - source: "createdAt"
+    target: "created_date"
+    transform:
+      date_format: "2006-01-02"
+```
+
+**Partner receives**:
+
+```json
+{
+  "id": "p-123",
+  "type": "individual",
+  "full_name": "Alice Smith",
+  "status": "active",
+  "created_date": "2026-02-20"
+}
+```
+
+### Phase 3 Scope
+
+| Item | Points |
+|------|--------|
+| Outbound engine (reverse field mapping) | 5 |
+| Gateway response interception middleware | 3 |
+| Inbound/outbound pairing logic | 2 |
+| DryRunMapping extension for outbound | 2 |
+| Reference outbound mappings + tests | 3 |
+| **Total** | **15** |
+
+---
 
 ## Design Constraints
 
@@ -393,11 +755,13 @@ All mapping definitions must be **safe by construction**:
 
 1. **CEL only** for expressions — guaranteed termination, bounded cost,
    no side effects
-2. **JSON Schema validation** of both input and output — catch errors at
-   definition time
+2. **Schema validation** — input validated against `external_schema`
+   (JSON Schema), output validated against the target proto message
+   descriptor via proto descriptor reflection
 3. **Mapping compilation** at registration — parse all paths, compile
-   all CEL, validate all enum mappings. Reject invalid mappings
-   immediately.
+   all CEL, validate all enum mappings, verify `batch_target_path`
+   (if specified) points to a valid repeated field. Reject invalid
+   mappings immediately.
 4. **Cost limits** — reuse existing CEL compiler constraints (max 4096
    bytes, cost limit 10,000)
 5. **Immutable versions** — once active, a mapping version is frozen.
@@ -405,14 +769,16 @@ All mapping definitions must be **safe by construction**:
 6. **Recursion guard** — a mapping cannot target an RPC that triggers
    another mapping. The `/inbound/` routing strategy prevents this
    naturally since Vanguard forwards to gRPC, not back to `/inbound/`.
+7. **Service validation** — at registration, `target_service` is
+   validated against the proto descriptor set (compiled into the
+   gateway) to ensure it refers to a known gRPC service.
 
 ### Performance
 
-1. **Compiled mappings cached** — don't re-parse on every request. Cache
-   compiled CEL programs and path extractors per tenant+mapping using
-   `hashicorp/golang-lru` (same pattern as Reference Data).
-2. **Sub-millisecond overhead** for simple field mappings (rename + type
-   coercion)
+1. **Compiled mappings cached** — cache compiled CEL programs and path
+   extractors per tenant+mapping using `hashicorp/golang-lru/v2`.
+2. **Sub-millisecond overhead** for simple field mappings (rename +
+   type coercion)
 3. **< 5ms overhead** for complex mappings with CEL evaluation
 4. **Zero overhead** when no mapping defined — passthrough to Vanguard
    unchanged
@@ -421,8 +787,8 @@ All mapping definitions must be **safe by construction**:
 
 ### Consistency
 
-1. **Unified pattern** — Party, Reference Data, and Market Data all use
-   the same mapping infrastructure
+1. **Unified pattern** — all three domains use the same attribute,
+   schema, and validation infrastructure (Phase 1 prerequisite)
 2. **Deterministic** — same input + same mapping = same output, always
 3. **Bi-temporal aware** — mappings can set temporal fields
    (valid_from/valid_to) from external formats
@@ -432,9 +798,26 @@ All mapping definitions must be **safe by construction**:
 ### Transformation Trace
 
 Every mapping execution generates a trace ID logged by the gateway.
-When a mapping fails (CEL error, missing required field, schema
-violation), the external partner receives a 400 with the trace ID for
-correlation.
+When a mapping fails, the external partner receives a structured error:
+
+```json
+{
+  "code": 400,
+  "message": "Mapping transform failed",
+  "trace_id": "abc-123",
+  "details": {
+    "field": "govt_id_type",
+    "source_path": "govt_id_type",
+    "target_path": "reference.issuing_authority",
+    "transform": "enum_mapping",
+    "error": "No mapping for value 'passport_number' and no fallback"
+  }
+}
+```
+
+Error responses include: the failed field path (source and target),
+the transform type that failed, the specific error message, and the
+trace ID for correlation.
 
 ### DryRunMapping RPC
 
@@ -445,65 +828,49 @@ A `DryRunMapping` RPC (analogous to `EvaluateAssetValuation` and
 2. Receive the transformed output or detailed error diagnostics
 3. See which fields mapped, which defaulted, which CEL expressions
    evaluated
+4. Works for both inbound and outbound mappings
 
-This is essential for integrator DX — partners can iterate on their
-payload format against a mapping definition without sending live
-requests.
+This is essential for integrator DX — partners iterate on their
+payload format without sending live requests.
 
 ## Success Criteria
 
-1. An external system can `POST /inbound/{mapping_name}` with JSON in
-   its own format and have it correctly mapped to a Meridian RPC
-2. A tenant can register a mapping definition via API and see it take
-   effect immediately
-3. Mapping validation rejects invalid definitions at registration time
-   (not at request time)
-4. Schema discovery API returns the expected input JSON shape for a
-   given mapping
-5. DryRunMapping shows transformed output or detailed errors for sample
-   input
-6. Performance overhead < 5ms p99 for complex mappings
-7. All three domains (Party, Reference Data, Market Data) have working
-   reference mappings
-8. Batch array inputs are correctly wrapped and forwarded
+1. (Phase 1) Party supports `repeated AttributeEntry` with JSON Schema
+   validation and CEL expressions, consistent with Reference Data and
+   Market Data
+2. (Phase 2) An external system can `POST /inbound/{mapping_name}`
+   with JSON in its own format and have it correctly mapped to a
+   Meridian RPC
+3. (Phase 2) A tenant can register a mapping definition via API and
+   see it take effect immediately
+4. (Phase 2) Mapping validation rejects invalid definitions at
+   registration time (not at request time)
+5. (Phase 2) Schema discovery API returns the expected input JSON shape
+6. (Phase 2) DryRunMapping shows transformed output or detailed errors
+7. (Phase 2) Batch array inputs are correctly wrapped and forwarded
+8. (Phase 2) Error responses include field path, transform type, error
+   message, and trace ID
+9. (Phase 2) Performance overhead < 5ms p99 for complex mappings
+10. (Phase 3) Outbound mappings transform proto-JSON responses back to
+    partner-specific formats
+11. (Phase 3) Inbound/outbound mapping pairs work end-to-end on a
+    single `/inbound/` request
 
 ## Complexity Estimate
 
-**Total: 26 points** (decomposition needed)
+| Phase | Points | Description |
+|-------|--------|-------------|
+| Phase 1 | 13 | Unified property model (Party consistency) |
+| Phase 2 | 26 | Inbound mapping (engine, gateway, DryRun, batch) |
+| Phase 3 | 15 | Outbound mapping (reverse engine, response middleware) |
+| **Total** | **54** | |
 
-- Proto definition + CRUD service: 5 points
-- Mapping engine middleware: 8 points (path extraction, CEL evaluation,
-  attribute flattening, batch wrapping)
-- Gateway routing (`/inbound/` handler): 3 points
-- DryRunMapping RPC + trace logging: 3 points
-- Batch support: 2 points
-- Reference mappings + tests: 5 points
-
-**Critical path**: Proto (5) then Engine+DryRun (11) then Gateway (3)
-= 19 points sequential
-
-**Parallelizable**: Batch support (2) and reference mappings (5) can
-run alongside gateway integration
-
-## Implementation Advisory
-
-### Dependencies
-
-- **`tidwall/gjson`**: Add to `go.mod` for `source_path` extraction.
-  Not currently in the module — must be added. Significantly faster
-  than `encoding/json` for path-based extraction (no full unmarshal).
-  Fall back to `encoding/json` only for complex nested writes.
-- **`hashicorp/golang-lru/v2`**: Already in `go.mod` (v2.0.7). Use
-  for compiled mapping cache in the gateway middleware.
-
-### Build Order
+### Phase 2 Build Order
 
 Implement **DryRunMapping before the live middleware**. DryRun shares
 ~90% of the transformation logic (path extraction, CEL evaluation,
 enum mapping, attribute flattening) but is easier to unit test because
-it's a simple RPC with no routing or Vanguard integration. Once DryRun
-works, the live middleware wraps the same engine with HTTP routing and
-request forwarding.
+it's a simple RPC with no routing or Vanguard integration.
 
 Recommended sequence:
 
@@ -513,32 +880,50 @@ Recommended sequence:
 4. Gateway `/inbound/` middleware (engine + HTTP routing + Vanguard)
 5. Reference mappings + integration tests
 
+### Phase Dependencies
+
+```text
+Phase 1 ──┐
+           ├──> Phase 2 ──> Phase 3
+           │
+(Phase 1 is recommended before Phase 2 for full consistency,
+ but Phase 2 can start in parallel if Party attributes are
+ not in the initial reference mappings)
+```
+
+## Implementation Advisory
+
+### Dependencies
+
+- **`tidwall/gjson`**: Add to `go.mod` for `source_path` extraction.
+  Not currently in the module. gjson syntax uses dot notation without
+  `$` prefix (e.g., `govt_id` not `$.govt_id`).
+- **`hashicorp/golang-lru/v2`**: Already in `go.mod` (v2.0.7). Use
+  for compiled mapping cache in the gateway middleware.
+
 ### Caching Strategy
 
-The gateway must cache compiled mapping definitions to avoid
-re-fetching and re-compiling on every request.
+The gateway must cache compiled mapping definitions.
 
-- **Cache implementation**: `hashicorp/golang-lru/v2` with a bounded
+- **Cache implementation**: `hashicorp/golang-lru/v2` with bounded
   size per tenant. Key: `{tenant_id}:{mapping_name}:{version}`.
-- **Invalidation (V1)**: Short TTL of 1-5 minutes. Simple, no
-  infrastructure dependency. Acceptable because mapping definitions
-  change infrequently (registration/activation, not per-request).
-- **Invalidation (V2)**: Hook into the Event Bus via
+- **Invalidation (V1)**: Short TTL of 1-5 minutes. Acceptable because
+  mapping definitions change infrequently.
+- **Invalidation (V2)**: Hook into Event Bus via
   `reference-data.mapping.updated` events for near-instant
-  invalidation. This aligns with the existing event-driven patterns
-  but is not required for the initial implementation.
+  invalidation.
 
 ### Other Notes
 
 - **CEL Compilation**: Pre-compile all CEL expressions at mapping
   registration time. Store compiled programs alongside the mapping
-  definition in the cache. Reuse the existing CEL compiler constraints
-  from `services/reference-data/cel/`.
-- **Recursion Guard**: The `/inbound/` routing strategy naturally
-  prevents recursion — Vanguard forwards to gRPC backends, not back
-  to the gateway's `/inbound/` handler. Validate at registration time
-  that `target_service` is a known gRPC service, not a mapping
-  endpoint.
+  definition in the cache.
+- **Recursion Guard**: Validated at registration — `target_service`
+  checked against proto descriptor set.
+- **CEL Compiler Location**: If Phase 1 proceeds first, extract the
+  CEL compiler from `services/reference-data/cel/` to
+  `shared/pkg/cel/` so both Party and the mapping engine can use it
+  without importing the reference-data service.
 
 ## Open Questions
 
@@ -548,7 +933,3 @@ re-fetching and re-compiling on every request.
 
 2. **Versioned RPCs?** If a proto message evolves (new fields), should
    mappings auto-adapt or require explicit versioning?
-
-3. **Error granularity?** When mapping fails, should the error indicate
-   which field/transform failed? (Yes, almost certainly — but how
-   detailed?)

--- a/docs/prd/024-structured-inbound-mapping.md
+++ b/docs/prd/024-structured-inbound-mapping.md
@@ -374,32 +374,32 @@ target_service: meridian.party.v1.PartyService
 target_rpc: RegisterParty
 
 field_mappings:
-  - source: "type"
-    target: "party_type"
+  - source_path: "type"
+    target_path: "party_type"
     transform:
       enum_mapping:
         values:
           individual: "PARTY_TYPE_PERSON"
           corporate: "PARTY_TYPE_ORGANIZATION"
 
-  - source: "full_name"
-    target: "legal_name"
+  - source_path: "full_name"
+    target_path: "legal_name"
 
-  - source: "govt_id"
-    target: "reference.government_id"
+  - source_path: "govt_id"
+    target_path: "reference.government_id"
 
-  - source: "govt_id_type"
-    target: "reference.issuing_authority"
+  - source_path: "govt_id_type"
+    target_path: "reference.issuing_authority"
 
-  - source: "account_officer"
-    target: "bank_relations.account_officer_id"
+  - source_path: "account_officer"
+    target_path: "bank_relations.account_officer_id"
 
-  - source: "branch"
-    target: "bank_relations.assigned_branch"
+  - source_path: "branch"
+    target_path: "bank_relations.assigned_branch"
 
 computed_fields:
-  - target: "display_name"
-    cel: "input.full_name.split(' ')[0]"
+  - target_path: "display_name"
+    cel_expression: "input.full_name.split(' ')[0]"
 
 validation_cel: "has(input.full_name) && size(input.full_name) > 0"
 ```
@@ -462,19 +462,19 @@ is_batch: true
 batch_target_path: "observations"
 
 field_mappings:
-  - source: "meter_id"
-    target: "instrument_code"
+  - source_path: "meter_id"
+    target_path: "instrument_code"
 
-  - source: "reading"
-    target: "value"
+  - source_path: "reading"
+    target_path: "value"
     transform:
       cel_expression: "string(source)"
 
-  - source: "timestamp"
-    target: "observed_at"
+  - source_path: "timestamp"
+    target_path: "observed_at"
 
-  - source: "quality"
-    target: "quality_level"
+  - source_path: "quality"
+    target_path: "quality_level"
     transform:
       enum_mapping:
         values:
@@ -482,16 +482,17 @@ field_mappings:
           actual: "QUALITY_LEVEL_ACTUAL"
           verified: "QUALITY_LEVEL_VERIFIED"
 
-  - source: "tenor"
-    target: "attributes"
+  - source_path: "tenor"
+    target_path: "attributes"
     transform:
       attribute_flatten:
         source_keys: ["tenor", "settlement"]
         target_field: "attributes"
 
 computed_fields:
-  - target: "resolution_key_value"
-    cel: "mapped.attributes.tenor + ':' + mapped.attributes.settlement"
+  - target_path: "resolution_key_value"
+    cel_expression: >
+      mapped.attributes.tenor + ':' + mapped.attributes.settlement
 ```
 
 **Output** (wrapped batch forwarded to Vanguard):
@@ -552,32 +553,32 @@ target_service: meridian.reference_data.v1.ReferenceDataService
 target_rpc: RegisterInstrument
 
 field_mappings:
-  - source: "asset_type"
-    target: "instrument_code"
+  - source_path: "asset_type"
+    target_path: "instrument_code"
 
-  - source: "unit"
-    target: "unit_of_measure"
+  - source_path: "unit"
+    target_path: "unit_of_measure"
 
-  - source: "precision"
-    target: "decimal_precision"
+  - source_path: "precision"
+    target_path: "decimal_precision"
     transform:
       cel_expression: "int(source)"
 
-  - source: "registry"
-    target: "attributes"
+  - source_path: "registry"
+    target_path: "attributes"
     transform:
       attribute_flatten:
         source_keys: ["registry", "vintage_year", "methodology"]
         target_field: "attributes"
 
-  - source: "min_amount"
-    target: "minimum_amount"
+  - source_path: "min_amount"
+    target_path: "minimum_amount"
     transform:
       cel_expression: "string(source)"
 
 computed_fields:
-  - target: "dimension"
-    cel: "'DIMENSION_CARBON'"
+  - target_path: "dimension"
+    cel_expression: "'DIMENSION_CARBON'"
 
 validation_cel: >
   has(input.registry) && has(input.unit) && input.min_amount > 0
@@ -622,7 +623,7 @@ An **Outbound Mapping** transforms Meridian's internal proto-JSON
 responses back into partner-specific formats. This is the reverse of
 Phase 2 — same engine, opposite direction.
 
-### Routing Strategy
+### Routing and Version Selection
 
 Outbound mappings are activated by the **same ingress path**:
 
@@ -630,19 +631,28 @@ Outbound mappings are activated by the **same ingress path**:
 POST /inbound/{mapping_name}
 ```
 
-When a `MappingDefinition` with `direction = OUTBOUND` exists for the
-same `mapping_name` (or a paired outbound mapping is linked), the
-gateway applies it to the response body **after** Vanguard returns the
-proto-JSON response.
-
-Alternatively, outbound mappings can be explicitly linked:
+Outbound mappings are linked to inbound mappings via
+`outbound_mapping_id`:
 
 ```protobuf
 message MappingDefinition {
   // ... existing fields ...
-  string outbound_mapping_id = 17; // Optional: paired outbound mapping
+  string outbound_mapping_id = 17; // Paired outbound mapping
 }
 ```
+
+**Version selection rules:**
+
+1. When resolving the inbound mapping, the gateway also resolves its
+   paired outbound mapping via `outbound_mapping_id`
+2. If the inbound mapping has no `outbound_mapping_id`, the gateway
+   looks up the latest ACTIVE outbound `MappingDefinition` with the
+   same `name` and `direction = OUTBOUND`
+3. If no ACTIVE outbound mapping exists, the gateway returns
+   Vanguard's raw proto-JSON response unchanged (no transformation)
+   and logs a debug-level missing-outbound notice
+4. The resolved outbound mapping version is included in the
+   `X-Outbound-Mapping-Version` response header for traceability
 
 ### Architecture
 
@@ -694,30 +704,30 @@ target_service: meridian.party.v1.PartyService
 target_rpc: RegisterParty
 
 field_mappings:
-  - source: "partyId"
-    target: "id"
+  - source_path: "partyId"
+    target_path: "id"
 
-  - source: "partyType"
-    target: "type"
+  - source_path: "partyType"
+    target_path: "type"
     transform:
       enum_mapping:
         values:
           PARTY_TYPE_PERSON: "individual"
           PARTY_TYPE_ORGANIZATION: "corporate"
 
-  - source: "legalName"
-    target: "full_name"
+  - source_path: "legalName"
+    target_path: "full_name"
 
-  - source: "status"
-    target: "status"
+  - source_path: "status"
+    target_path: "status"
     transform:
       enum_mapping:
         values:
           PARTY_STATUS_ACTIVE: "active"
           PARTY_STATUS_SUSPENDED: "suspended"
 
-  - source: "createdAt"
-    target: "created_date"
+  - source_path: "createdAt"
+    target_path: "created_date"
     transform:
       date_format: "2006-01-02"
 ```

--- a/docs/prd/024-structured-inbound-mapping.md
+++ b/docs/prd/024-structured-inbound-mapping.md
@@ -479,23 +479,66 @@ requests.
 - Batch support: 2 points
 - Reference mappings + tests: 5 points
 
-**Critical path**: Proto, Engine, Gateway routing (16 points sequential)
-**Parallelizable**: DryRunMapping, batch support, and reference mappings
-can run alongside gateway integration
+**Critical path**: Proto (5) then Engine+DryRun (11) then Gateway (3)
+= 19 points sequential
+
+**Parallelizable**: Batch support (2) and reference mappings (5) can
+run alongside gateway integration
 
 ## Implementation Advisory
 
-- **JSON Path Library**: Use `tidwall/gjson` for `source_path`
-  extraction. Avoids full unmarshaling for performance. Fall back to
-  full `encoding/json` only for complex nested writes.
-- **CEL Compilation**: Pre-compile `FieldTransform` CEL expressions at
-  mapping registration. Cache compiled programs in the gateway
-  middleware using `hashicorp/golang-lru` (same pattern as
-  `services/reference-data/cel/`).
+### Dependencies
+
+- **`tidwall/gjson`**: Add to `go.mod` for `source_path` extraction.
+  Not currently in the module — must be added. Significantly faster
+  than `encoding/json` for path-based extraction (no full unmarshal).
+  Fall back to `encoding/json` only for complex nested writes.
+- **`hashicorp/golang-lru/v2`**: Already in `go.mod` (v2.0.7). Use
+  for compiled mapping cache in the gateway middleware.
+
+### Build Order
+
+Implement **DryRunMapping before the live middleware**. DryRun shares
+~90% of the transformation logic (path extraction, CEL evaluation,
+enum mapping, attribute flattening) but is easier to unit test because
+it's a simple RPC with no routing or Vanguard integration. Once DryRun
+works, the live middleware wraps the same engine with HTTP routing and
+request forwarding.
+
+Recommended sequence:
+
+1. Proto + CRUD (foundation)
+2. Mapping engine core (pure transform logic, no HTTP)
+3. DryRunMapping RPC (engine + RPC wrapper, full unit test coverage)
+4. Gateway `/inbound/` middleware (engine + HTTP routing + Vanguard)
+5. Reference mappings + integration tests
+
+### Caching Strategy
+
+The gateway must cache compiled mapping definitions to avoid
+re-fetching and re-compiling on every request.
+
+- **Cache implementation**: `hashicorp/golang-lru/v2` with a bounded
+  size per tenant. Key: `{tenant_id}:{mapping_name}:{version}`.
+- **Invalidation (V1)**: Short TTL of 1-5 minutes. Simple, no
+  infrastructure dependency. Acceptable because mapping definitions
+  change infrequently (registration/activation, not per-request).
+- **Invalidation (V2)**: Hook into the Event Bus via
+  `reference-data.mapping.updated` events for near-instant
+  invalidation. This aligns with the existing event-driven patterns
+  but is not required for the initial implementation.
+
+### Other Notes
+
+- **CEL Compilation**: Pre-compile all CEL expressions at mapping
+  registration time. Store compiled programs alongside the mapping
+  definition in the cache. Reuse the existing CEL compiler constraints
+  from `services/reference-data/cel/`.
 - **Recursion Guard**: The `/inbound/` routing strategy naturally
-  prevents recursion — Vanguard forwards to gRPC backends, not back to
-  the gateway's `/inbound/` handler. Validate at registration time that
-  `target_service` is a known gRPC service, not a mapping endpoint.
+  prevents recursion — Vanguard forwards to gRPC backends, not back
+  to the gateway's `/inbound/` handler. Validate at registration time
+  that `target_service` is a known gRPC service, not a mapping
+  endpoint.
 
 ## Open Questions
 

--- a/docs/prd/024-structured-inbound-mapping.md
+++ b/docs/prd/024-structured-inbound-mapping.md
@@ -2,13 +2,13 @@
 
 ## Problem Statement
 
-External systems send JSON in their own formats — a bank's party payload looks
-different from an energy retailer's, which looks different from a carbon registry's.
-Today, every integration must manually conform to Meridian's exact proto-derived
-JSON structure (`camelCase` field names, specific enum strings, nested message
-shapes). This creates friction: integrators must read proto definitions to
-understand the expected format, and any structural mismatch causes opaque
-validation failures.
+External systems send JSON in their own formats — a bank's party payload
+looks different from an energy retailer's, which looks different from a
+carbon registry's. Today, every integration must manually conform to
+Meridian's exact proto-derived JSON structure (`camelCase` field names,
+specific enum strings, nested message shapes). This creates friction:
+integrators must read proto definitions to understand the expected format,
+and any structural mismatch causes opaque validation failures.
 
 Meanwhile, Meridian's three domains handle flexibility inconsistently:
 
@@ -19,7 +19,7 @@ Meanwhile, Meridian's three domains handle flexibility inconsistently:
 | Market Data | JSON Schema + `AttributeEntry` + `Struct` | CEL | Resolution keys | Full |
 
 The Vanguard transcoder (tasks 1-10) solved **protocol transcoding**
-(HTTP/JSON ↔ gRPC). This PRD addresses the next layer: **semantic
+(HTTP/JSON to gRPC). This PRD addresses the next layer: **semantic
 transcoding** — mapping external data formats to internal proto structures
 with validation, transformation, and computed field generation.
 
@@ -29,14 +29,18 @@ with validation, transformation, and computed field generation.
 
 **Protocol Layer** (solved by gateway-json-transcoding):
 
-- Vanguard transcodes REST/JSON → gRPC proto using `google.api.http` annotations
+- Vanguard transcodes REST/JSON to gRPC proto using `google.api.http`
+  annotations
 - Handles Content-Type negotiation (JSON, Connect, gRPC-Web)
 - Identity headers propagate as gRPC metadata
 
-**Schema Infrastructure** (exists in reference-data and market-information):
+**Schema Infrastructure** (exists in reference-data and
+market-information):
 
-- `attribute_schema` (JSON Schema, max 16KB) — defines valid attributes per entity type
-- CEL compiler (`services/reference-data/cel/compiler.go`) with security constraints:
+- `attribute_schema` (JSON Schema, max 16KB) — defines valid attributes
+  per entity type
+- CEL compiler (`services/reference-data/cel/compiler.go`) with security
+  constraints:
   - Max 4096 bytes, max 10 nesting depth, cost limit 10,000
   - Guaranteed termination (no while loops, no recursion)
 - `repeated AttributeEntry` for deterministic attribute ordering
@@ -59,98 +63,175 @@ with validation, transformation, and computed field generation.
    mapping; no tenant-aware transformations
 4. **Computed field generation at ingress**: Resolution keys, fungibility
    keys computed deep in service layers — could be computed earlier
-5. **External format discovery**: No way for integrators to ask "what JSON
-   shape does tenant X expect for party onboarding?"
+5. **External format discovery**: No way for integrators to ask "what
+   JSON shape does tenant X expect for party onboarding?"
 
 ## Solution: Inbound Mapping Definitions
 
 ### Core Concept
 
-An **Inbound Mapping** is a tenant-configurable definition that describes how
-to transform external JSON into Meridian's internal proto structure. Each
-mapping targets a specific RPC (e.g., `RegisterParty`, `CreateInstrument`,
-`RecordObservation`) and defines:
+An **Inbound Mapping** is a tenant-configurable definition that describes
+how to transform external JSON into Meridian's internal proto structure.
+Each mapping targets a specific RPC (e.g., `RegisterParty`,
+`CreateInstrument`, `RecordObservation`) and defines:
 
-1. **Field mappings**: External field paths → internal proto field paths
-2. **Type coercions**: String→enum, string→decimal, date format normalization
+1. **Field mappings**: External field paths to internal proto field paths
+2. **Type coercions**: String to enum, string to decimal, date format
+   normalization
 3. **Validation rules**: CEL expressions for cross-field validation
-4. **Computed fields**: CEL expressions that derive values from input (resolution keys, default values)
-5. **Attribute flattening**: Map flat external JSON keys into `repeated AttributeEntry` or `google.protobuf.Struct`
+4. **Computed fields**: CEL expressions that derive values from input
+   (resolution keys, default values)
+5. **Attribute flattening**: Map flat external JSON keys into
+   `repeated AttributeEntry` or `google.protobuf.Struct`
+
+### Routing Strategy
+
+Mapped requests use a **dedicated ingress path** to disambiguate from
+direct API calls:
+
+```text
+POST /inbound/{mapping_name}
+```
+
+The gateway:
+
+1. Extracts `mapping_name` from the URL path
+2. Looks up the mapping definition by name (tenant-scoped via identity
+   headers)
+3. Transforms the request body using the mapping rules
+4. Rewrites the request internally to the `target_service`/`target_rpc`
+5. Forwards the proto-conformant JSON to Vanguard
+
+This avoids intercepting standard gRPC paths (e.g., `/v1/party`), which
+would risk breaking clients that already send valid proto-JSON. It also
+supports multiple mappings per RPC — a tenant can have
+`bank-x-party-onboarding` and `bank-y-party-onboarding` targeting the
+same `RegisterParty` RPC with different field layouts.
 
 ### Architecture
 
 ```text
-External JSON → Gateway → Mapping Engine → Proto-conformant JSON → Vanguard → gRPC
-                               ↑
-                     InboundMappingDefinition
-                     (tenant-configured, per-RPC)
+POST /inbound/{mapping_name}
+  |
+  v
+Gateway --> Mapping Engine --> Proto-conformant JSON --> Vanguard --> gRPC
+                 |
+       InboundMappingDefinition
+       (tenant-configured, per-mapping-name)
 ```
 
-The Mapping Engine sits as middleware **before** Vanguard in the gateway chain. It:
+### Service Ownership
 
-1. Identifies the target RPC from the URL path
-2. Looks up the tenant's mapping definition for that RPC
-3. Transforms the request body
-4. Passes the conformant JSON to Vanguard for proto transcoding
+Mapping CRUD lives in **`services/reference-data/`**. Mappings are
+metadata about how to interpret data, analogous to Instrument Definitions
+and Attribute Schemas. They reuse the CEL compiler infrastructure already
+present in Reference Data (`services/reference-data/cel/compiler.go`).
+
+The **Mapping Engine middleware** lives in `services/gateway/` — it
+intercepts `/inbound/` requests, calls Reference Data to resolve the
+mapping definition, applies transforms, and forwards to Vanguard.
 
 ### Data Model
 
 ```protobuf
 // api/proto/meridian/mapping/v1/mapping.proto
 
+enum MappingStatus {
+  MAPPING_STATUS_UNSPECIFIED = 0;
+  MAPPING_STATUS_DRAFT = 1;
+  MAPPING_STATUS_ACTIVE = 2;
+  MAPPING_STATUS_DEPRECATED = 3;
+}
+
 message InboundMappingDefinition {
   string id = 1;
   string tenant_id = 2;
-  string name = 3;                          // e.g., "bank-x-party-onboarding"
-  string target_service = 4;                // e.g., "meridian.party.v1.PartyService"
-  string target_rpc = 5;                    // e.g., "RegisterParty"
-  string version = 6;                       // Semver for safe evolution
-  MappingStatus status = 7;                 // DRAFT → ACTIVE → DEPRECATED
+  string name = 3;              // "bank-x-party-onboarding"
+  string target_service = 4;    // "meridian.party.v1.PartyService"
+  string target_rpc = 5;        // "RegisterParty"
+  string version = 6;           // Semver for safe evolution
+  MappingStatus status = 7;
 
   // Schema of expected inbound JSON (for discovery/docs)
-  string input_schema = 8;                  // JSON Schema describing external format
+  string input_schema = 8;      // JSON Schema
 
   // Transformation rules (ordered, applied sequentially)
   repeated FieldMapping field_mappings = 9;
   repeated ComputedField computed_fields = 10;
-  string validation_expression = 11;        // CEL: cross-field validation (post-mapping)
+  string validation_expression = 11;  // CEL: post-mapping validation
 
   // Metadata
   google.protobuf.Timestamp created_at = 12;
   google.protobuf.Timestamp updated_at = 13;
+
+  // Batch support
+  bool is_batch = 14;           // Input is JSON array
+  string batch_target_path = 15; // Wrap array at this path
 }
 
 message FieldMapping {
-  string source_path = 1;                   // JSONPath in external JSON: "$.govt_id"
-  string target_path = 2;                   // Proto field path: "reference.government_id"
-  FieldTransform transform = 3;             // Optional transformation
+  string source_path = 1;       // JSONPath: "$.govt_id"
+  string target_path = 2;       // Proto path: "reference.government_id"
+  FieldTransform transform = 3; // Optional transformation
 }
 
 message FieldTransform {
   oneof transform {
-    string cel_expression = 1;              // CEL: "source.toUpper()"
-    EnumMapping enum_mapping = 2;           // {"INDIVIDUAL": "PARTY_TYPE_PERSON", ...}
-    string date_format = 3;                 // "2006-01-02" → RFC3339
-    string default_value = 4;               // If source missing, use this
-    AttributeFlatten attribute_flatten = 5;  // Map flat keys → AttributeEntry[]
+    string cel_expression = 1;
+    EnumMapping enum_mapping = 2;
+    string date_format = 3;       // "2006-01-02" to RFC3339
+    string default_value = 4;     // Fallback if source missing
+    AttributeFlatten attribute_flatten = 5;
   }
 }
 
 message EnumMapping {
-  map<string, string> values = 1;           // External → internal enum string
-  string fallback = 2;                      // Default if no match
+  map<string, string> values = 1; // External to internal
+  string fallback = 2;            // Default if no match
 }
 
 message AttributeFlatten {
-  repeated string source_keys = 1;          // External keys to collect
-  string target_field = 2;                  // "attributes" (repeated AttributeEntry)
+  repeated string source_keys = 1; // External keys to collect
+  string target_field = 2;         // "attributes"
 }
 
 message ComputedField {
-  string target_path = 1;                   // Proto field to populate
-  string cel_expression = 2;               // CEL using mapped fields as input
+  string target_path = 1;         // Proto field to populate
+  string cel_expression = 2;      // CEL using mapped fields
 }
 ```
+
+#### CEL Expression Context
+
+CEL expressions have access to different variables depending on where
+they appear:
+
+- **`FieldTransform.cel_expression`**: `source` (the extracted source
+  field value). Return type must match the target field type.
+- **`ComputedField.cel_expression`**: `input` (original external JSON
+  as `map<string, any>`) and `mapped` (intermediate state after
+  field_mappings applied as `map<string, any>`).
+- **`validation_expression`**: `input` and `mapped`. Must return
+  `bool` — `false` rejects the request with a 400 error.
+
+All CEL expressions are subject to the existing compiler constraints:
+max 4096 bytes, max 10 nesting depth, cost limit 10,000.
+
+### Batch Support
+
+External feeds often send JSON arrays (e.g., `[{obs1}, {obs2}]`) while
+Vanguard expects a wrapper object (e.g., `{"observations": [...]}`).
+
+When `is_batch = true`:
+
+1. The engine validates the input is a JSON array
+2. Applies field_mappings and computed_fields to each element
+3. Wraps the transformed array at `batch_target_path`
+
+Example: An energy feed sends `[{meter, reading}, {meter, reading}]`.
+With `batch_target_path = "observations"`, the engine produces
+`{"observations": [{mapped1}, {mapped2}]}` for
+`RecordObservationBatch`.
 
 ### Example: Bank Party Onboarding Mapping
 
@@ -168,6 +249,8 @@ message ComputedField {
 }
 ```
 
+**Request**: `POST /inbound/bank-x-party-onboarding`
+
 **Mapping Definition**:
 
 ```yaml
@@ -180,7 +263,9 @@ field_mappings:
     target: "party_type"
     transform:
       enum_mapping:
-        values: {"individual": "PARTY_TYPE_PERSON", "corporate": "PARTY_TYPE_ORGANIZATION"}
+        values:
+          individual: "PARTY_TYPE_PERSON"
+          corporate: "PARTY_TYPE_ORGANIZATION"
 
   - source: "$.full_name"
     target: "legal_name"
@@ -199,13 +284,13 @@ field_mappings:
 
 computed_fields:
   - target: "display_name"
-    cel: "input.full_name.split(' ')[0]"   # First name as display name
+    cel: "input.full_name.split(' ')[0]"
 
 validation:
   cel: "has(input.full_name) && size(input.full_name) > 0"
 ```
 
-**Result** (proto-conformant JSON passed to Vanguard):
+**Result** (proto-conformant JSON forwarded to Vanguard):
 
 ```json
 {
@@ -241,8 +326,9 @@ validation:
 
 **Mapping Definition** transforms to `RecordObservation` with:
 
-- `quality: "estimated"` → `QUALITY_ESTIMATE`
-- Flat `tenor` + `settlement` → `repeated AttributeEntry`
+- `quality: "estimated"` mapped to `QUALITY_ESTIMATE` via enum_mapping
+- Flat `tenor` + `settlement` collected into
+  `repeated AttributeEntry` via attribute_flatten
 - Computed `resolution_key_value` from attributes via CEL
 
 ### Example: Asset Class Definition Mapping
@@ -263,30 +349,41 @@ validation:
 
 **Mapping Definition** transforms to `RegisterInstrument` with:
 
-- `unit: "tCO2e"` → instrument code lookup/creation
-- Flat `registry`, `vintage_year`, `methodology` → `repeated AttributeEntry`
-- `validation_expression` computed: `"value >= 0.001"`
+- `unit: "tCO2e"` mapped to instrument code lookup/creation
+- Flat `registry`, `vintage_year`, `methodology` collected into
+  `repeated AttributeEntry`
+- `validation_expression`: `"value >= 0.001"`
 - `dimension` derived from unit type
 
 ## Scope
 
 ### In Scope (This PRD)
 
-1. **InboundMappingDefinition proto** — data model for mapping definitions
-2. **Mapping CRUD service** — create, update, version, activate/deprecate mappings
-3. **Mapping Engine middleware** — gateway component that applies mappings before Vanguard
-4. **CEL-based transforms** — reuse existing CEL compiler with mapping-specific extensions
-5. **Schema discovery API** — "what JSON shape does this mapping expect?"
-6. **Mapping validation** — compile-time verification that mappings produce valid proto JSON
-7. **Three reference mappings** — one each for Party, Reference Data, and Market Data
+1. **InboundMappingDefinition proto** — data model for mapping
+   definitions
+2. **Mapping CRUD service** — create, update, version,
+   activate/deprecate mappings (in `services/reference-data/`)
+3. **Mapping Engine middleware** — gateway component that intercepts
+   `/inbound/{mapping_name}` and applies mappings before Vanguard
+4. **CEL-based transforms** — reuse existing CEL compiler with
+   mapping-specific extensions
+5. **Schema discovery API** — "what JSON shape does this mapping
+   expect?"
+6. **Mapping validation** — compile-time verification that mappings
+   produce valid proto JSON
+7. **DryRunMapping RPC** — paste JSON, see transformed output or errors
+8. **Batch support** — `is_batch` + `batch_target_path` for array
+   inputs
+9. **Three reference mappings** — one each for Party, Reference Data,
+   and Market Data
 
 ### Out of Scope
 
 - **Outbound mapping** (response transformation) — separate PRD
-- **Streaming/batch mapping** — this covers request/response only
+- **Streaming mapping** — this covers request/response only
 - **UI for mapping creation** — API-first, UI later
 - **Mapping marketplace** — sharing mappings between tenants
-- **AI-assisted mapping generation** — future enhancement (LLM generates mapping from sample JSON)
+- **AI-assisted mapping generation** — future enhancement
 
 ## Design Constraints
 
@@ -294,67 +391,121 @@ validation:
 
 All mapping definitions must be **safe by construction**:
 
-1. **CEL only** for expressions — guaranteed termination, bounded cost, no side effects
-2. **JSON Schema validation** of both input and output — catch errors at definition time
-3. **Mapping compilation** at registration — parse all paths, compile all
-   CEL, validate all enum mappings. Reject invalid mappings immediately.
-4. **Cost limits** — reuse existing CEL compiler constraints
-   (max 4096 bytes, cost limit 10,000)
+1. **CEL only** for expressions — guaranteed termination, bounded cost,
+   no side effects
+2. **JSON Schema validation** of both input and output — catch errors at
+   definition time
+3. **Mapping compilation** at registration — parse all paths, compile
+   all CEL, validate all enum mappings. Reject invalid mappings
+   immediately.
+4. **Cost limits** — reuse existing CEL compiler constraints (max 4096
+   bytes, cost limit 10,000)
 5. **Immutable versions** — once active, a mapping version is frozen.
    Changes create new versions.
+6. **Recursion guard** — a mapping cannot target an RPC that triggers
+   another mapping. The `/inbound/` routing strategy prevents this
+   naturally since Vanguard forwards to gRPC, not back to `/inbound/`.
 
 ### Performance
 
 1. **Compiled mappings cached** — don't re-parse on every request. Cache
-   compiled CEL programs and path extractors per tenant+mapping.
-2. **Sub-millisecond overhead** for simple field mappings (rename + type coercion)
+   compiled CEL programs and path extractors per tenant+mapping using
+   `hashicorp/golang-lru` (same pattern as Reference Data).
+2. **Sub-millisecond overhead** for simple field mappings (rename + type
+   coercion)
 3. **< 5ms overhead** for complex mappings with CEL evaluation
-4. **Zero overhead** when no mapping defined — passthrough to Vanguard unchanged
+4. **Zero overhead** when no mapping defined — passthrough to Vanguard
+   unchanged
+5. **Lazy JSON path extraction** — use `tidwall/gjson` for source_path
+   extraction to avoid full unmarshaling where possible
 
 ### Consistency
 
-1. **Unified pattern** — Party, Reference Data, and Market Data all use the same mapping infrastructure
+1. **Unified pattern** — Party, Reference Data, and Market Data all use
+   the same mapping infrastructure
 2. **Deterministic** — same input + same mapping = same output, always
-3. **Bi-temporal aware** — mappings can set temporal fields (valid_from/valid_to) from external formats
+3. **Bi-temporal aware** — mappings can set temporal fields
+   (valid_from/valid_to) from external formats
+
+## Debugging and Visibility
+
+### Transformation Trace
+
+Every mapping execution generates a trace ID logged by the gateway.
+When a mapping fails (CEL error, missing required field, schema
+violation), the external partner receives a 400 with the trace ID for
+correlation.
+
+### DryRunMapping RPC
+
+A `DryRunMapping` RPC (analogous to `EvaluateAssetValuation` and
+`ExecuteDryRun` in sagas) allows a tenant to:
+
+1. Submit sample JSON and a mapping name
+2. Receive the transformed output or detailed error diagnostics
+3. See which fields mapped, which defaulted, which CEL expressions
+   evaluated
+
+This is essential for integrator DX — partners can iterate on their
+payload format against a mapping definition without sending live
+requests.
 
 ## Success Criteria
 
-1. An external system can send JSON in its own format and have it correctly mapped to a Meridian RPC
-2. A tenant can register a mapping definition via API and see it take effect immediately
-3. Mapping validation rejects invalid definitions at registration time (not at request time)
-4. Schema discovery API returns the expected input JSON shape for a given mapping
-5. Performance overhead < 5ms p99 for complex mappings
-6. All three domains (Party, Reference Data, Market Data) have working reference mappings
+1. An external system can `POST /inbound/{mapping_name}` with JSON in
+   its own format and have it correctly mapped to a Meridian RPC
+2. A tenant can register a mapping definition via API and see it take
+   effect immediately
+3. Mapping validation rejects invalid definitions at registration time
+   (not at request time)
+4. Schema discovery API returns the expected input JSON shape for a
+   given mapping
+5. DryRunMapping shows transformed output or detailed errors for sample
+   input
+6. Performance overhead < 5ms p99 for complex mappings
+7. All three domains (Party, Reference Data, Market Data) have working
+   reference mappings
+8. Batch array inputs are correctly wrapped and forwarded
 
 ## Complexity Estimate
 
-**Total: 21 points** (decomposition needed)
+**Total: 26 points** (decomposition needed)
 
 - Proto definition + CRUD service: 5 points
-- Mapping engine middleware: 8 points (core complexity — path extraction, CEL evaluation, attribute flattening)
-- Gateway integration: 3 points
+- Mapping engine middleware: 8 points (path extraction, CEL evaluation,
+  attribute flattening, batch wrapping)
+- Gateway routing (`/inbound/` handler): 3 points
+- DryRunMapping RPC + trace logging: 3 points
+- Batch support: 2 points
 - Reference mappings + tests: 5 points
 
-**Critical path**: Proto → Engine → Gateway integration (16 points sequential)
-**Parallelizable**: Reference mappings can run alongside gateway integration
+**Critical path**: Proto, Engine, Gateway routing (16 points sequential)
+**Parallelizable**: DryRunMapping, batch support, and reference mappings
+can run alongside gateway integration
+
+## Implementation Advisory
+
+- **JSON Path Library**: Use `tidwall/gjson` for `source_path`
+  extraction. Avoids full unmarshaling for performance. Fall back to
+  full `encoding/json` only for complex nested writes.
+- **CEL Compilation**: Pre-compile `FieldTransform` CEL expressions at
+  mapping registration. Cache compiled programs in the gateway
+  middleware using `hashicorp/golang-lru` (same pattern as
+  `services/reference-data/cel/`).
+- **Recursion Guard**: The `/inbound/` routing strategy naturally
+  prevents recursion — Vanguard forwards to gRPC backends, not back to
+  the gateway's `/inbound/` handler. Validate at registration time that
+  `target_service` is a known gRPC service, not a mapping endpoint.
 
 ## Open Questions
 
-1. **Where does the mapping engine live?** Gateway middleware (request-level)
-   vs dedicated mapping service (RPC-level)? Gateway is simpler but couples
-   mapping logic to the gateway. Dedicated service is cleaner but adds a
-   network hop.
-
-2. **Mapping inheritance?** Should tenants inherit from a base mapping and
-   override specific fields? Useful for "bank template" + tenant
+1. **Mapping inheritance?** Should tenants inherit from a base mapping
+   and override specific fields? Useful for "bank template" + tenant
    customizations.
 
-3. **Versioned RPCs?** If a proto message evolves (new fields), should
+2. **Versioned RPCs?** If a proto message evolves (new fields), should
    mappings auto-adapt or require explicit versioning?
 
-4. **Batch operations?** Some domains accept batch requests (bulk
-   observations). Should mappings apply per-item within a batch?
-
-5. **Error granularity?** When mapping fails, should the error indicate
+3. **Error granularity?** When mapping fails, should the error indicate
    which field/transform failed? (Yes, almost certainly — but how
    detailed?)

--- a/docs/prd/024-structured-inbound-mapping.md
+++ b/docs/prd/024-structured-inbound-mapping.md
@@ -155,7 +155,7 @@ No new CEL functions needed — `parse_iso_date`, `parse_int`,
 
 1. Add `PartyTypeDefinition` proto + CRUD RPCs to Party service
 2. Add `attributes` field to `Party` proto and persistence
-3. Wire CEL compiler (import from reference-data or extract to shared)
+3. Extract CEL compiler to `shared/pkg/cel/` (hard prerequisite)
 4. Validate attributes against schema at `RegisterParty` /
    `UpdateParty` time
 5. Keep existing `Association.metadata` (Struct) for backwards
@@ -167,11 +167,11 @@ No new CEL functions needed — `parse_iso_date`, `parse_int`,
 |------|--------|
 | PartyTypeDefinition proto + CRUD | 3 |
 | Party attributes field + migration | 3 |
-| CEL compiler integration in Party service | 2 |
+| Extract CEL compiler to `shared/pkg/cel/` + Party integration | 3 |
 | Schema validation at registration | 3 |
 | Manifest: add `party_types` + differ/planner | 3 |
 | Tests + reference party type definitions | 2 |
-| **Total** | **16** |
+| **Total** | **17** |
 
 ---
 
@@ -240,6 +240,14 @@ The **Mapping Engine middleware** lives in `services/gateway/` — it
 intercepts `/mapping/` requests, resolves the mapping definition,
 applies transforms in both directions, and forwards to Vanguard.
 
+**Hard prerequisite (Phase 1)**: The CEL compiler must be extracted
+from `services/reference-data/cel/` to **`shared/pkg/cel/`** before
+Phase 2 begins. Both the Party service (Phase 1) and the mapping
+engine in the gateway (Phase 2) need CEL compilation. Without
+extraction, the gateway would import the reference-data service
+package — creating a circular dependency. This extraction is
+scoped as part of Phase 1's CEL compiler integration work.
+
 ### Data Model
 
 ```protobuf
@@ -282,12 +290,48 @@ message MappingDefinition {
   // Batch support (inbound only)
   bool is_batch = 16;           // Input is JSON array
   string batch_target_path = 17; // Wrap array at this path
+
+  // Idempotency derivation rules
+  IdempotencyConfig idempotency = 18;
 }
 ```
 
+#### Idempotency
+
+External systems (dumb pipes) often retry requests without internal
+request IDs, risking duplicate records. The `IdempotencyConfig` lets
+the mapping derive an idempotency key from the request itself, so the
+gateway can deduplicate retries before they reach the gRPC service.
+
+```protobuf
+message IdempotencyConfig {
+  // Extract from header or body path
+  // e.g., "header:X-Request-ID" or "body:transaction_ref"
+  string source_selector = 1;
+
+  // Derive key from content hash (e.g., hash of meter_id + timestamp)
+  bool use_content_hash = 2;
+  repeated string content_hash_fields = 3;
+}
+```
+
+**Resolution order**:
+
+1. If `source_selector` is set and the value exists in the request,
+   use it as the idempotency key
+2. If `use_content_hash = true`, hash the specified
+   `content_hash_fields` (post-mapping values) to derive the key
+3. If neither is configured, no deduplication is applied (passthrough)
+
+The derived key is passed as gRPC metadata to the target service,
+which uses its existing idempotency infrastructure to detect
+duplicates. For batch requests (`is_batch = true`), the key is
+derived **per element** using the element's field values.
+
 **Inbound execution order**: `fields` (forward, sequentially) then
 `inbound_computed_fields` (sequentially) then `inbound_validation_cel`
-(must return `true`).
+(must return `true`) then `idempotency` (derive key from mapped
+values).
 
 **Outbound execution order**: `fields` (reverse, sequentially) then
 `outbound_computed_fields` (sequentially) then
@@ -813,9 +857,9 @@ payload format without sending live requests.
 
 | Phase | Points | Description |
 |-------|--------|-------------|
-| Phase 1 | 16 | Unified property model + manifest integration |
+| Phase 1 | 17 | Unified property model + CEL extraction + manifest |
 | Phase 2 | 33 | Bidirectional mapping + manifest integration |
-| **Total** | **49** | |
+| **Total** | **50** | |
 
 ### Phase 2 Build Order
 
@@ -873,10 +917,9 @@ The gateway must cache compiled mapping definitions.
   definition in the cache.
 - **Recursion Guard**: Validated at registration — `target_service`
   checked against proto descriptor set.
-- **CEL Compiler Location**: If Phase 1 proceeds first, extract the
-  CEL compiler from `services/reference-data/cel/` to
-  `shared/pkg/cel/` so both Party and the mapping engine can use it
-  without importing the reference-data service.
+- **CEL Compiler Location**: Hard requirement — extract the CEL
+  compiler from `services/reference-data/cel/` to `shared/pkg/cel/`
+  in Phase 1. See Service Ownership section.
 
 ## Manifest Integration
 

--- a/docs/prd/024-structured-inbound-mapping.md
+++ b/docs/prd/024-structured-inbound-mapping.md
@@ -1,4 +1,38 @@
+---
+name: prd-structured-mapping-layer
+description: Bidirectional JSON mapping engine with unified property model across Party, Reference Data, and Market Data
+triggers:
+  - Implementing external JSON format mapping or transformation
+  - Building tenant-configurable field mappings or enum translations
+  - Working on inbound or outbound data transformation at the gateway
+  - Adding structured attributes or CEL validation to Party service
+  - Integrating external systems that send non-proto JSON formats
+  - Working on mapping definitions in the tenant manifest
+  - Questions about FieldCorrespondence, MappingDefinition, or DryRunMapping
+  - Batch JSON array ingestion for market data or observations
+instructions: |
+  Two phases. Phase 1: Unified Property Model — extract CEL compiler
+  to shared/pkg/cel/, add repeated AttributeEntry + JSON Schema +
+  CEL validation to Party (matching Reference Data and Market Data
+  patterns), add party_types to tenant manifest. Phase 2: Bidirectional
+  Mapping — single MappingDefinition with FieldCorrespondence
+  (external_path/internal_path), auto-reversible transforms (enum,
+  date, attribute flatten), explicit CelTransform (inbound_cel +
+  outbound_cel), IdempotencyConfig for dedup, DryRunMapping RPC,
+  gateway middleware at /mapping/{name}, manifest integration. CRUD
+  in services/reference-data/, engine middleware in services/gateway/.
+  Key deps: tidwall/gjson (add to go.mod), hashicorp/golang-lru/v2
+  (already present). All CEL expressions bounded: max 4096 bytes,
+  cost limit 10,000, guaranteed termination.
+---
+
 # PRD: Structured Mapping Layer
+
+**Status:** Not Started
+**Version:** 1.0
+**Date:** 2026-02-21
+**Author:** Architecture Team
+**Task Master Tag:** `structured-mapping-layer`
 
 ## Problem Statement
 


### PR DESCRIPTION
## Summary

- Defines the **semantic transcoding** layer that maps external JSON formats to
  Meridian's internal proto structures with validation, transformation, and
  computed field generation
- Covers all three domains: Party, Reference Data, and Market Data
- Proposes tenant-configurable `InboundMappingDefinition` with field mappings,
  CEL-based transforms, enum coercions, attribute flattening, and schema discovery

## Context

The Vanguard transcoder (gateway-json-transcoding.1-10) solved protocol
transcoding (HTTP/JSON to gRPC). This PRD plans the next layer: letting
external systems send JSON in their own format and having it automatically
mapped to the correct proto structure.

## Task Master

Tag: `gateway-json-transcoding`, Task: 11

## Test plan

- [ ] PRD reviewed for technical accuracy against existing codebase
- [ ] Complexity estimates validated
- [ ] Open questions discussed and resolved