### PR TITLE
feat: Add MappingDefinition proto and tidwall/gjson dependency

### DIFF
--- a/api/proto/meridian/mapping/v1/mapping.proto
+++ b/api/proto/meridian/mapping/v1/mapping.proto
@@ -52,7 +52,11 @@ message EnumMapping {
 message AttributeFlatten {
   // source_keys lists the gjson paths (external) or proto paths (internal) to collect into the target.
   // Each key's value is placed into the target map under that key name.
-  repeated string source_keys = 1 [(buf.validate.field).repeated.max_items = 64];
+  // At least one key must be provided for the flatten to have effect.
+  repeated string source_keys = 1 [(buf.validate.field).repeated = {
+    min_items: 1
+    max_items: 64
+  }];
 
   // target_field is the name of the map field in the target message that receives the flattened values.
   string target_field = 2 [(buf.validate.field).string = {
@@ -62,9 +66,11 @@ message AttributeFlatten {
 }
 
 // FieldTransform defines how a single field value is transformed during mapping.
-// Exactly one transform type must be set.
+// At most one transform type may be set (proto oneof semantics). The Go service
+// layer validates that at least one is provided when a FieldTransform is specified.
 message FieldTransform {
-  // transform is the transformation to apply. Exactly one must be set.
+  // transform is the transformation to apply. At most one may be set per proto oneof semantics.
+  // The Go service layer enforces that at least one variant is selected when a transform is present.
   oneof transform {
     // cel applies bidirectional CEL expressions for value transformation.
     CelTransform cel = 1;
@@ -397,10 +403,13 @@ message UpdateMappingRequest {
   google.protobuf.FieldMask update_mask = 12;
 
   // name is the updated human-readable name (optional).
-  string name = 2 [(buf.validate.field).string = {
-    min_len: 1
-    max_len: 255
-  }];
+  // When "name" is included in update_mask, the Go service layer enforces min_len = 1.
+  // IGNORE_IF_ZERO_VALUE is used so that the default empty string does not fail validation
+  // when "name" is not included in update_mask (FieldMask partial update semantics).
+  string name = 2 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string.max_len = 255
+  ];
 
   // external_schema is the updated JSON Schema string (optional).
   string external_schema = 3 [(buf.validate.field).string.max_len = 65536];

--- a/api/proto/meridian/mapping/v1/mapping.proto
+++ b/api/proto/meridian/mapping/v1/mapping.proto
@@ -74,10 +74,10 @@ message FieldTransform {
 
     // date_format specifies a Go time layout string for parsing and formatting date/time values.
     // Example: "2006-01-02" for ISO date, "2006-01-02T15:04:05Z07:00" for RFC3339.
-    string date_format = 3;
+    string date_format = 3 [(buf.validate.field).string.max_len = 128];
 
     // default_value is a literal string value used when the source field is absent or empty.
-    string default_value = 4;
+    string default_value = 4 [(buf.validate.field).string.max_len = 1024];
 
     // attribute_flatten collects multiple source keys into a single target map field.
     AttributeFlatten attribute_flatten = 5;
@@ -196,13 +196,13 @@ message MappingDefinition {
   string external_schema = 8 [(buf.validate.field).string.max_len = 65536];
 
   // fields defines the field-level correspondences between external and internal formats.
-  repeated FieldCorrespondence fields = 9;
+  repeated FieldCorrespondence fields = 9 [(buf.validate.field).repeated.max_items = 256];
 
   // inbound_computed_fields defines fields computed during inbound (external -> internal) mapping.
-  repeated ComputedField inbound_computed_fields = 10;
+  repeated ComputedField inbound_computed_fields = 10 [(buf.validate.field).repeated.max_items = 64];
 
   // outbound_computed_fields defines fields computed during outbound (internal -> external) mapping.
-  repeated ComputedField outbound_computed_fields = 11;
+  repeated ComputedField outbound_computed_fields = 11 [(buf.validate.field).repeated.max_items = 64];
 
   // inbound_validation_cel is a CEL expression evaluated against the raw external payload
   // before inbound mapping. The expression must return a boolean; false causes rejection.
@@ -311,13 +311,13 @@ message CreateMappingRequest {
   string external_schema = 5 [(buf.validate.field).string.max_len = 65536];
 
   // fields defines the field-level correspondences between external and internal formats.
-  repeated FieldCorrespondence fields = 6;
+  repeated FieldCorrespondence fields = 6 [(buf.validate.field).repeated.max_items = 256];
 
   // inbound_computed_fields defines fields computed during inbound mapping.
-  repeated ComputedField inbound_computed_fields = 7;
+  repeated ComputedField inbound_computed_fields = 7 [(buf.validate.field).repeated.max_items = 64];
 
   // outbound_computed_fields defines fields computed during outbound mapping.
-  repeated ComputedField outbound_computed_fields = 8;
+  repeated ComputedField outbound_computed_fields = 8 [(buf.validate.field).repeated.max_items = 64];
 
   // inbound_validation_cel is a CEL expression for inbound payload validation.
   string inbound_validation_cel = 9 [(buf.validate.field).string.max_len = 2048];
@@ -403,13 +403,13 @@ message UpdateMappingRequest {
   string external_schema = 3 [(buf.validate.field).string.max_len = 65536];
 
   // fields replaces the field-level correspondences (optional).
-  repeated FieldCorrespondence fields = 4;
+  repeated FieldCorrespondence fields = 4 [(buf.validate.field).repeated.max_items = 256];
 
   // inbound_computed_fields replaces the inbound computed fields (optional).
-  repeated ComputedField inbound_computed_fields = 5;
+  repeated ComputedField inbound_computed_fields = 5 [(buf.validate.field).repeated.max_items = 64];
 
   // outbound_computed_fields replaces the outbound computed fields (optional).
-  repeated ComputedField outbound_computed_fields = 6;
+  repeated ComputedField outbound_computed_fields = 6 [(buf.validate.field).repeated.max_items = 64];
 
   // inbound_validation_cel is the updated inbound validation expression (optional).
   string inbound_validation_cel = 7 [(buf.validate.field).string.max_len = 2048];

--- a/api/proto/meridian/mapping/v1/mapping.proto
+++ b/api/proto/meridian/mapping/v1/mapping.proto
@@ -367,7 +367,8 @@ message ListMappingsRequest {
   // target_service filters results by target service name. Empty means no filter.
   string target_service = 2 [(buf.validate.field).string.max_len = 255];
 
-  // page_size is the maximum number of results to return (1-100). Defaults to 20.
+  // page_size is the maximum number of results to return (0-100).
+  // A value of 0 uses the server default (20). Maximum is 100.
   int32 page_size = 3 [(buf.validate.field).int32 = {
     gte: 0
     lte: 100

--- a/api/proto/meridian/mapping/v1/mapping.proto
+++ b/api/proto/meridian/mapping/v1/mapping.proto
@@ -36,7 +36,7 @@ message CelTransform {
 message EnumMapping {
   // values maps external enum string values to internal enum string values.
   // Example: {"ACTIVE": "STATUS_ACTIVE", "INACTIVE": "STATUS_INACTIVE"}
-  map<string, string> values = 1;
+  map<string, string> values = 1 [(buf.validate.field).map.max_pairs = 256];
 
   // fallback is the internal value to use when an external value is not found in the map.
   // If empty, an unmapped inbound value causes an error.
@@ -397,7 +397,10 @@ message UpdateMappingRequest {
   google.protobuf.FieldMask update_mask = 12;
 
   // name is the updated human-readable name (optional).
-  string name = 2 [(buf.validate.field).string.max_len = 255];
+  string name = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
 
   // external_schema is the updated JSON Schema string (optional).
   string external_schema = 3 [(buf.validate.field).string.max_len = 65536];

--- a/api/proto/meridian/mapping/v1/mapping.proto
+++ b/api/proto/meridian/mapping/v1/mapping.proto
@@ -1,0 +1,432 @@
+syntax = "proto3";
+
+package meridian.mapping.v1;
+
+import "buf/validate/validate.proto";
+import "google/api/annotations.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1;mappingv1";
+
+// MappingStatus defines the lifecycle state of a mapping definition.
+enum MappingStatus {
+  // MAPPING_STATUS_UNSPECIFIED means the status is unknown.
+  MAPPING_STATUS_UNSPECIFIED = 0;
+  // MAPPING_STATUS_DRAFT means the mapping is being defined and cannot be used.
+  MAPPING_STATUS_DRAFT = 1;
+  // MAPPING_STATUS_ACTIVE means the mapping is available for use.
+  MAPPING_STATUS_ACTIVE = 2;
+  // MAPPING_STATUS_DEPRECATED means the mapping is no longer recommended for new use.
+  MAPPING_STATUS_DEPRECATED = 3;
+}
+
+// CelTransform defines bidirectional CEL expressions for field transformation.
+message CelTransform {
+  // inbound_cel is the CEL expression applied when mapping from external to internal format.
+  // Example: "value.lowerAscii()" to normalize incoming string values.
+  string inbound_cel = 1 [(buf.validate.field).string.max_len = 2048];
+
+  // outbound_cel is the CEL expression applied when mapping from internal to external format.
+  // Example: "value.upperAscii()" to format outgoing string values.
+  string outbound_cel = 2 [(buf.validate.field).string.max_len = 2048];
+}
+
+// EnumMapping defines a bidirectional mapping between external and internal enum values.
+message EnumMapping {
+  // values maps external enum string values to internal enum string values.
+  // Example: {"ACTIVE": "STATUS_ACTIVE", "INACTIVE": "STATUS_INACTIVE"}
+  map<string, string> values = 1;
+
+  // fallback is the internal value to use when an external value is not found in the map.
+  // If empty, an unmapped inbound value causes an error.
+  string fallback = 2 [(buf.validate.field).string.max_len = 256];
+
+  // outbound_fallback is the external value to use when an internal value is not found in the map.
+  // If empty, an unmapped outbound value causes an error.
+  string outbound_fallback = 3 [(buf.validate.field).string.max_len = 256];
+}
+
+// AttributeFlatten defines a transform that merges multiple source fields into a single target map field.
+// Useful for collecting scattered external fields into an attributes map.
+message AttributeFlatten {
+  // source_keys lists the gjson paths (external) or proto paths (internal) to collect into the target.
+  // Each key's value is placed into the target map under that key name.
+  repeated string source_keys = 1 [(buf.validate.field).repeated.max_items = 64];
+
+  // target_field is the name of the map field in the target message that receives the flattened values.
+  string target_field = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 256
+  }];
+}
+
+// FieldTransform defines how a single field value is transformed during mapping.
+// Exactly one transform type must be set.
+message FieldTransform {
+  // transform is the transformation to apply. Exactly one must be set.
+  oneof transform {
+    // cel applies bidirectional CEL expressions for value transformation.
+    CelTransform cel = 1;
+
+    // enum_mapping maps between external and internal enum string representations.
+    EnumMapping enum_mapping = 2;
+
+    // date_format specifies a Go time layout string for parsing and formatting date/time values.
+    // Example: "2006-01-02" for ISO date, "2006-01-02T15:04:05Z07:00" for RFC3339.
+    string date_format = 3;
+
+    // default_value is a literal string value used when the source field is absent or empty.
+    string default_value = 4;
+
+    // attribute_flatten collects multiple source keys into a single target map field.
+    AttributeFlatten attribute_flatten = 5;
+  }
+}
+
+// FieldCorrespondence maps a single external field to an internal proto field.
+message FieldCorrespondence {
+  // external_path is the gjson path expression for locating the value in the external JSON payload.
+  // Supports dot notation, array indexing, and gjson modifiers.
+  // Example: "customer.address.city", "items.#.price", "meta|@flatten"
+  string external_path = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 512
+  }];
+
+  // internal_path is the proto field path in the internal message (dot-separated).
+  // Example: "customer_id", "line_items.unit_price", "metadata.source"
+  string internal_path = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 512
+  }];
+
+  // transform defines an optional value transformation applied during mapping.
+  // If not set, the raw string value is used as-is.
+  FieldTransform transform = 3;
+}
+
+// ComputedField defines a field whose value is derived from a CEL expression
+// rather than directly mapped from the source payload.
+message ComputedField {
+  // target_path is the proto field path in the internal message (dot-separated).
+  // Example: "created_at", "metadata.ingested_by"
+  string target_path = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 512
+  }];
+
+  // cel_expression is a CEL expression evaluated against the full source payload.
+  // The expression may reference any field from the source document.
+  // Example: "now()" for timestamp, "'v1.' + version" for derived strings.
+  string cel_expression = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 2048
+  }];
+}
+
+// IdempotencyConfig controls how idempotency keys are derived for mapped requests.
+message IdempotencyConfig {
+  // source_selector is a gjson path expression that extracts the idempotency key
+  // from the external payload.
+  // Example: "header.idempotency_key", "transaction.reference_id"
+  string source_selector = 1 [(buf.validate.field).string.max_len = 512];
+
+  // use_content_hash indicates that the idempotency key should be derived from
+  // a hash of the selected content fields rather than a direct field value.
+  bool use_content_hash = 2;
+
+  // content_hash_fields lists the gjson paths whose values are included in the content hash.
+  // Only used when use_content_hash is true.
+  repeated string content_hash_fields = 3 [(buf.validate.field).repeated.max_items = 32];
+}
+
+// MappingDefinition defines a bidirectional transformation between an external JSON
+// schema and an internal Meridian gRPC service RPC.
+//
+// It supports:
+//   - Field-level correspondence with optional transforms (CEL, enums, date formats)
+//   - Computed fields derived from CEL expressions
+//   - Inbound and outbound CEL validation
+//   - Batch ingestion via gjson array paths
+//   - Idempotency key configuration
+message MappingDefinition {
+  // id is the unique identifier for this mapping definition (UUID).
+  string id = 1 [(buf.validate.field).string.uuid = true];
+
+  // tenant_id is the tenant that owns this mapping definition (UUID).
+  string tenant_id = 2 [(buf.validate.field).string.uuid = true];
+
+  // name is the human-readable name for this mapping.
+  // Example: "Stripe Webhook -> Payment Order"
+  string name = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // target_service is the Meridian gRPC service this mapping calls.
+  // Example: "meridian.payment_order.v1.PaymentOrderService"
+  string target_service = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // target_rpc is the RPC method on the target service to invoke after mapping.
+  // Example: "InitiatePaymentOrder"
+  string target_rpc = 5 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 128
+  }];
+
+  // version is the schema version for this mapping definition (monotonically increasing).
+  int32 version = 6 [(buf.validate.field).int32.gte = 1];
+
+  // status is the lifecycle state of this mapping definition.
+  MappingStatus status = 7 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // external_schema is a JSON Schema string describing the expected external payload structure.
+  // Used for documentation and inbound validation.
+  string external_schema = 8 [(buf.validate.field).string.max_len = 65536];
+
+  // fields defines the field-level correspondences between external and internal formats.
+  repeated FieldCorrespondence fields = 9;
+
+  // inbound_computed_fields defines fields computed during inbound (external -> internal) mapping.
+  repeated ComputedField inbound_computed_fields = 10;
+
+  // outbound_computed_fields defines fields computed during outbound (internal -> external) mapping.
+  repeated ComputedField outbound_computed_fields = 11;
+
+  // inbound_validation_cel is a CEL expression evaluated against the raw external payload
+  // before inbound mapping. The expression must return a boolean; false causes rejection.
+  // Example: "has(payload.customer_id) && payload.amount > 0"
+  string inbound_validation_cel = 12 [(buf.validate.field).string.max_len = 2048];
+
+  // outbound_validation_cel is a CEL expression evaluated against the mapped internal message
+  // before outbound mapping. The expression must return a boolean; false causes rejection.
+  string outbound_validation_cel = 13 [(buf.validate.field).string.max_len = 2048];
+
+  // created_at is when this mapping definition was created.
+  google.protobuf.Timestamp created_at = 14;
+
+  // updated_at is when this mapping definition was last modified.
+  google.protobuf.Timestamp updated_at = 15;
+
+  // is_batch indicates this mapping handles array payloads.
+  // When true, batch_target_path must be set.
+  bool is_batch = 16;
+
+  // batch_target_path is the gjson path expression that selects the array of items
+  // to process when is_batch is true.
+  // Example: "events", "data.items"
+  string batch_target_path = 17 [(buf.validate.field).string.max_len = 512];
+
+  // idempotency defines how idempotency keys are derived for requests produced by this mapping.
+  IdempotencyConfig idempotency = 18;
+}
+
+// ========================================
+// Service Definition
+// ========================================
+
+// MappingService manages mapping definitions - the configuration that describes
+// how external JSON payloads are transformed into internal Meridian gRPC calls.
+service MappingService {
+  // CreateMapping creates a new mapping definition in DRAFT status.
+  // Returns ALREADY_EXISTS if a mapping with the same name and version exists.
+  rpc CreateMapping(CreateMappingRequest) returns (CreateMappingResponse) {
+    option (google.api.http) = {
+      post: "/v1/mappings"
+      body: "*"
+    };
+  }
+
+  // GetMapping retrieves a specific mapping definition by ID.
+  // Returns NOT_FOUND if the mapping does not exist.
+  rpc GetMapping(GetMappingRequest) returns (GetMappingResponse) {
+    option (google.api.http) = {
+      get: "/v1/mappings/{id}"
+    };
+  }
+
+  // ListMappings returns mapping definitions for the tenant, with optional filtering.
+  rpc ListMappings(ListMappingsRequest) returns (ListMappingsResponse) {
+    option (google.api.http) = {
+      get: "/v1/mappings"
+    };
+  }
+
+  // UpdateMapping modifies an existing mapping definition.
+  // Returns NOT_FOUND if the mapping does not exist.
+  // Returns FAILED_PRECONDITION if the mapping is not in DRAFT status.
+  rpc UpdateMapping(UpdateMappingRequest) returns (UpdateMappingResponse) {
+    option (google.api.http) = {
+      put: "/v1/mappings/{id}"
+      body: "*"
+    };
+  }
+
+  // DeleteMapping removes a mapping definition.
+  // Returns NOT_FOUND if the mapping does not exist.
+  // Returns FAILED_PRECONDITION if the mapping is in ACTIVE status.
+  rpc DeleteMapping(DeleteMappingRequest) returns (DeleteMappingResponse) {
+    option (google.api.http) = {
+      delete: "/v1/mappings/{id}"
+    };
+  }
+}
+
+// CreateMappingRequest is the request to create a new mapping definition.
+message CreateMappingRequest {
+  // name is the human-readable name for this mapping.
+  string name = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // target_service is the Meridian gRPC service this mapping calls.
+  string target_service = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // target_rpc is the RPC method on the target service to invoke after mapping.
+  string target_rpc = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 128
+  }];
+
+  // version is the schema version for this mapping definition.
+  int32 version = 4 [(buf.validate.field).int32.gte = 1];
+
+  // external_schema is a JSON Schema string describing the expected external payload structure.
+  string external_schema = 5 [(buf.validate.field).string.max_len = 65536];
+
+  // fields defines the field-level correspondences between external and internal formats.
+  repeated FieldCorrespondence fields = 6;
+
+  // inbound_computed_fields defines fields computed during inbound mapping.
+  repeated ComputedField inbound_computed_fields = 7;
+
+  // outbound_computed_fields defines fields computed during outbound mapping.
+  repeated ComputedField outbound_computed_fields = 8;
+
+  // inbound_validation_cel is a CEL expression for inbound payload validation.
+  string inbound_validation_cel = 9 [(buf.validate.field).string.max_len = 2048];
+
+  // outbound_validation_cel is a CEL expression for outbound payload validation.
+  string outbound_validation_cel = 10 [(buf.validate.field).string.max_len = 2048];
+
+  // is_batch indicates this mapping handles array payloads.
+  bool is_batch = 11;
+
+  // batch_target_path is the gjson path for selecting the array when is_batch is true.
+  string batch_target_path = 12 [(buf.validate.field).string.max_len = 512];
+
+  // idempotency defines how idempotency keys are derived for requests.
+  IdempotencyConfig idempotency = 13;
+}
+
+// CreateMappingResponse is the response after creating a mapping definition.
+message CreateMappingResponse {
+  // mapping is the newly created mapping definition.
+  MappingDefinition mapping = 1 [(buf.validate.field).required = true];
+}
+
+// GetMappingRequest is the request to retrieve a mapping definition by ID.
+message GetMappingRequest {
+  // id is the unique identifier of the mapping definition (UUID).
+  string id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// GetMappingResponse is the response containing the requested mapping definition.
+message GetMappingResponse {
+  // mapping is the requested mapping definition.
+  MappingDefinition mapping = 1 [(buf.validate.field).required = true];
+}
+
+// ListMappingsRequest is the request to list mapping definitions for a tenant.
+message ListMappingsRequest {
+  // status filters results by lifecycle status. If UNSPECIFIED, all statuses are returned.
+  MappingStatus status = 1 [(buf.validate.field).enum.defined_only = true];
+
+  // target_service filters results by target service name. Empty means no filter.
+  string target_service = 2 [(buf.validate.field).string.max_len = 255];
+
+  // page_size is the maximum number of results to return (1-100). Defaults to 20.
+  int32 page_size = 3 [(buf.validate.field).int32 = {
+    gte: 0
+    lte: 100
+  }];
+
+  // page_token is the pagination token from a previous ListMappingsResponse.
+  string page_token = 4 [(buf.validate.field).string.max_len = 512];
+}
+
+// ListMappingsResponse is the response containing a page of mapping definitions.
+message ListMappingsResponse {
+  // mappings is the list of mapping definitions matching the request criteria.
+  repeated MappingDefinition mappings = 1;
+
+  // next_page_token is the pagination token for the next page. Empty if no more results.
+  string next_page_token = 2;
+
+  // total_count is the total number of mappings matching the filter criteria.
+  int32 total_count = 3;
+}
+
+// UpdateMappingRequest is the request to update an existing mapping definition.
+message UpdateMappingRequest {
+  // id is the unique identifier of the mapping definition to update (UUID).
+  string id = 1 [(buf.validate.field).string.uuid = true];
+
+  // name is the updated human-readable name (optional).
+  string name = 2 [(buf.validate.field).string.max_len = 255];
+
+  // external_schema is the updated JSON Schema string (optional).
+  string external_schema = 3 [(buf.validate.field).string.max_len = 65536];
+
+  // fields replaces the field-level correspondences (optional).
+  repeated FieldCorrespondence fields = 4;
+
+  // inbound_computed_fields replaces the inbound computed fields (optional).
+  repeated ComputedField inbound_computed_fields = 5;
+
+  // outbound_computed_fields replaces the outbound computed fields (optional).
+  repeated ComputedField outbound_computed_fields = 6;
+
+  // inbound_validation_cel is the updated inbound validation expression (optional).
+  string inbound_validation_cel = 7 [(buf.validate.field).string.max_len = 2048];
+
+  // outbound_validation_cel is the updated outbound validation expression (optional).
+  string outbound_validation_cel = 8 [(buf.validate.field).string.max_len = 2048];
+
+  // is_batch is the updated batch flag (optional).
+  bool is_batch = 9;
+
+  // batch_target_path is the updated batch target path (optional).
+  string batch_target_path = 10 [(buf.validate.field).string.max_len = 512];
+
+  // idempotency is the updated idempotency configuration (optional).
+  IdempotencyConfig idempotency = 11;
+}
+
+// UpdateMappingResponse is the response after updating a mapping definition.
+message UpdateMappingResponse {
+  // mapping is the updated mapping definition.
+  MappingDefinition mapping = 1 [(buf.validate.field).required = true];
+}
+
+// DeleteMappingRequest is the request to delete a mapping definition.
+message DeleteMappingRequest {
+  // id is the unique identifier of the mapping definition to delete (UUID).
+  string id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// DeleteMappingResponse is the response after deleting a mapping definition.
+message DeleteMappingResponse {
+  // id is the identifier of the deleted mapping definition.
+  string id = 1;
+}

--- a/api/proto/meridian/mapping/v1/mapping.proto
+++ b/api/proto/meridian/mapping/v1/mapping.proto
@@ -4,6 +4,7 @@ package meridian.mapping.v1;
 
 import "buf/validate/validate.proto";
 import "google/api/annotations.proto";
+import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1;mappingv1";
@@ -125,9 +126,13 @@ message ComputedField {
 }
 
 // IdempotencyConfig controls how idempotency keys are derived for mapped requests.
+//
+// Cross-field validation (enforced at the Go service layer):
+//   - When use_content_hash is false: source_selector must be non-empty.
+//   - When use_content_hash is true: content_hash_fields must contain at least one entry.
 message IdempotencyConfig {
   // source_selector is a gjson path expression that extracts the idempotency key
-  // from the external payload.
+  // from the external payload. Required when use_content_hash is false.
   // Example: "header.idempotency_key", "transaction.reference_id"
   string source_selector = 1 [(buf.validate.field).string.max_len = 512];
 
@@ -136,7 +141,7 @@ message IdempotencyConfig {
   bool use_content_hash = 2;
 
   // content_hash_fields lists the gjson paths whose values are included in the content hash.
-  // Only used when use_content_hash is true.
+  // Required (non-empty) when use_content_hash is true.
   repeated string content_hash_fields = 3 [(buf.validate.field).repeated.max_items = 32];
 }
 
@@ -215,11 +220,12 @@ message MappingDefinition {
   google.protobuf.Timestamp updated_at = 15;
 
   // is_batch indicates this mapping handles array payloads.
-  // When true, batch_target_path must be set.
+  // Cross-field validation (enforced at Go service layer): when is_batch is true,
+  // batch_target_path must be non-empty.
   bool is_batch = 16;
 
   // batch_target_path is the gjson path expression that selects the array of items
-  // to process when is_batch is true.
+  // to process when is_batch is true. Required when is_batch is true.
   // Example: "events", "data.items"
   string batch_target_path = 17 [(buf.validate.field).string.max_len = 512];
 
@@ -378,9 +384,17 @@ message ListMappingsResponse {
 }
 
 // UpdateMappingRequest is the request to update an existing mapping definition.
+// Use update_mask to specify which fields to update. Only fields listed in the mask are modified.
+// Supported paths: "name", "external_schema", "fields", "inbound_computed_fields",
+// "outbound_computed_fields", "inbound_validation_cel", "outbound_validation_cel",
+// "is_batch", "batch_target_path", "idempotency".
 message UpdateMappingRequest {
   // id is the unique identifier of the mapping definition to update (UUID).
   string id = 1 [(buf.validate.field).string.uuid = true];
+
+  // update_mask specifies which fields to update. Only paths listed in the mask are modified.
+  // When empty, all provided fields are updated (full replace semantics).
+  google.protobuf.FieldMask update_mask = 12;
 
   // name is the updated human-readable name (optional).
   string name = 2 [(buf.validate.field).string.max_len = 255];

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/kafka v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/redis v0.40.0
+	github.com/tidwall/gjson v1.18.0
 	github.com/twmb/franz-go v1.20.6
 	github.com/twmb/franz-go/pkg/kadm v1.17.2
 	go.opentelemetry.io/otel v1.40.0
@@ -63,7 +64,6 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,9 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1173,6 +1173,12 @@ github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0 h1:s2bIayFX
 github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0/go.mod h1:h+u/2KoREGTnTl9UwrQ/g+XhasAT8E6dClclAADeXoQ=
 github.com/testcontainers/testcontainers-go/modules/redis v0.40.0 h1:OG4qwcxp2O0re7V7M9lY9w0v6wWgWf7j7rtkpAnGMd0=
 github.com/testcontainers/testcontainers-go/modules/redis v0.40.0/go.mod h1:Bc+EDhKMo5zI5V5zdBkHiMVzeAXbtI4n5isS/nzf6zw=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/shared/pkg/mapping/gjson.go
+++ b/shared/pkg/mapping/gjson.go
@@ -1,0 +1,32 @@
+// Package mapping provides utilities for transforming external JSON payloads
+// into internal Meridian gRPC request messages and vice versa.
+//
+// Field extraction from external payloads uses gjson path expressions,
+// which support dot notation, array indexing, and modifiers:
+//
+//	"customer.id"            — nested field
+//	"items.#.price"          — array element iteration
+//	"meta|@flatten"          — gjson modifier
+//
+// See https://github.com/tidwall/gjson for full path syntax documentation.
+package mapping
+
+import "github.com/tidwall/gjson"
+
+// Extract returns the gjson Result for the given path expression applied to the JSON payload.
+// Returns a zero-value Result if the path is not found or the JSON is invalid.
+func Extract(json, path string) gjson.Result {
+	return gjson.Get(json, path)
+}
+
+// ExtractString returns the string value at path in the JSON payload.
+// Returns an empty string if the path is not found.
+func ExtractString(json, path string) string {
+	return gjson.Get(json, path).String()
+}
+
+// ExtractAll returns all gjson Results for the given path expression,
+// useful for iterating over arrays.
+func ExtractAll(json, path string) []gjson.Result {
+	return gjson.Get(json, path).Array()
+}


### PR DESCRIPTION
## Summary
- Adds tidwall/gjson v1.18.0 for JSON path querying in the mapping engine
- Creates MappingDefinition proto with all transform types for bidirectional mapping
- Adds MappingService with CRUD RPCs and HTTP annotations

## Changes Made
- `go.mod` / `go.sum`: added `github.com/tidwall/gjson v1.18.0`
- `api/proto/meridian/mapping/v1/mapping.proto`: new proto defining:
  - `MappingStatus` enum (UNSPECIFIED, DRAFT, ACTIVE, DEPRECATED)
  - `MappingDefinition` with 18 fields: id, tenant_id, name, target_service, target_rpc, version, status, external_schema, fields (FieldCorrespondence), inbound/outbound computed fields, inbound/outbound CEL validation, created_at, updated_at, is_batch, batch_target_path, idempotency
  - `FieldCorrespondence`: gjson external_path, proto internal_path, optional FieldTransform
  - `FieldTransform` oneof: CelTransform (bidirectional CEL), EnumMapping (with fallbacks), date_format, default_value, AttributeFlatten (multi-key flattening)
  - `ComputedField`: target_path + CEL expression
  - `IdempotencyConfig`: source_selector, use_content_hash, content_hash_fields
  - `MappingService` CRUD RPCs: CreateMapping, GetMapping, ListMappings, UpdateMapping, DeleteMapping

## Test plan
- [x] buf lint passes
- [x] buf generate succeeds
- [x] Go compilation succeeds (`go build ./api/proto/meridian/mapping/...`)
- [x] gjson imports correctly (`go list -m github.com/tidwall/gjson`)