### PR TITLE
feat: Add attributes field to Party proto and persistence

### DIFF
--- a/api/proto/meridian/party/v1/party.proto
+++ b/api/proto/meridian/party/v1/party.proto
@@ -7,6 +7,7 @@ import "google/api/annotations.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
+import "meridian/quantity/v1/quantity.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
 option go_package = "github.com/meridianhub/meridian/api/proto/meridian/party/v1;partyv1";
@@ -185,6 +186,10 @@ message Party {
 
   // version is for optimistic locking.
   int32 version = 10 [(buf.validate.field).int32 = {gte: 0}];
+
+  // attributes contains structured key-value metadata for this party,
+  // validated against the party type's attribute_schema at registration and update time.
+  repeated meridian.quantity.v1.AttributeEntry attributes = 11;
 }
 
 // RegisterPartyRequest is the request to register a new party in the directory.
@@ -209,6 +214,9 @@ message RegisterPartyRequest {
 
   // external_reference_type indicates the type of external reference provided.
   ExternalReferenceType external_reference_type = 5 [(buf.validate.field).enum = {defined_only: true}];
+
+  // attributes contains structured key-value metadata for this party.
+  repeated meridian.quantity.v1.AttributeEntry attributes = 6;
 }
 
 // RegisterPartyResponse is the response after registering a party.

--- a/services/party/adapters/persistence/party_attributes_test.go
+++ b/services/party/adapters/persistence/party_attributes_test.go
@@ -1,0 +1,154 @@
+package persistence
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/services/party/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Unit tests for attribute serialization helpers ---
+
+func TestSerializeAttributes_Empty(t *testing.T) {
+	raw := serializeAttributes([]domain.AttributeEntry{})
+	assert.JSONEq(t, "[]", string(raw))
+}
+
+func TestSerializeAttributes_Nil(t *testing.T) {
+	raw := serializeAttributes(nil)
+	assert.JSONEq(t, "[]", string(raw))
+}
+
+func TestSerializeAttributes_Single(t *testing.T) {
+	attrs := []domain.AttributeEntry{{Key: "industry", Value: "finance"}}
+	raw := serializeAttributes(attrs)
+	assert.JSONEq(t, `[{"key":"industry","value":"finance"}]`, string(raw))
+}
+
+func TestSerializeAttributes_Multiple(t *testing.T) {
+	attrs := []domain.AttributeEntry{
+		{Key: "industry", Value: "finance"},
+		{Key: "region", Value: "EMEA"},
+	}
+	raw := serializeAttributes(attrs)
+	assert.JSONEq(t, `[{"key":"industry","value":"finance"},{"key":"region","value":"EMEA"}]`, string(raw))
+}
+
+func TestDeserializeAttributes_Empty(t *testing.T) {
+	attrs := deserializeAttributes([]byte("[]"))
+	assert.Empty(t, attrs)
+}
+
+func TestDeserializeAttributes_Nil(t *testing.T) {
+	attrs := deserializeAttributes(nil)
+	assert.Empty(t, attrs)
+}
+
+func TestDeserializeAttributes_Single(t *testing.T) {
+	attrs := deserializeAttributes([]byte(`[{"key":"industry","value":"finance"}]`))
+	require.Len(t, attrs, 1)
+	assert.Equal(t, "industry", attrs[0].Key)
+	assert.Equal(t, "finance", attrs[0].Value)
+}
+
+func TestDeserializeAttributes_Multiple(t *testing.T) {
+	attrs := deserializeAttributes([]byte(`[{"key":"industry","value":"finance"},{"key":"region","value":"EMEA"}]`))
+	require.Len(t, attrs, 2)
+	assert.Equal(t, domain.AttributeEntry{Key: "industry", Value: "finance"}, attrs[0])
+	assert.Equal(t, domain.AttributeEntry{Key: "region", Value: "EMEA"}, attrs[1])
+}
+
+func TestDeserializeAttributes_InvalidJSON(t *testing.T) {
+	attrs := deserializeAttributes([]byte("not-json"))
+	assert.Empty(t, attrs)
+}
+
+func TestSerializeDeserialize_RoundTrip(t *testing.T) {
+	original := []domain.AttributeEntry{
+		{Key: "industry", Value: "finance"},
+		{Key: "region", Value: "EMEA"},
+		{Key: "risk_tier", Value: "low"},
+	}
+	raw := serializeAttributes(original)
+	restored := deserializeAttributes(raw)
+	assert.Equal(t, original, restored)
+}
+
+// --- Integration tests for attribute persistence ---
+
+func TestSaveAndLoadPartyWithAttributes(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	party, err := domain.NewParty(domain.PartyTypePerson, "Alice Smith")
+	require.NoError(t, err)
+	party.SetAttributes([]domain.AttributeEntry{
+		{Key: "industry", Value: "finance"},
+		{Key: "region", Value: "EMEA"},
+	})
+
+	err = repo.Save(ctx, party)
+	require.NoError(t, err)
+
+	loaded, err := repo.FindByID(ctx, party.ID())
+	require.NoError(t, err)
+
+	attrs := loaded.Attributes()
+	require.Len(t, attrs, 2)
+	assert.Equal(t, "industry", attrs[0].Key)
+	assert.Equal(t, "finance", attrs[0].Value)
+	assert.Equal(t, "region", attrs[1].Key)
+	assert.Equal(t, "EMEA", attrs[1].Value)
+}
+
+func TestUpdatePartyAttributes(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	party, err := domain.NewParty(domain.PartyTypePerson, "Bob Jones")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, party)
+	require.NoError(t, err)
+
+	// Load and update attributes
+	loaded, err := repo.FindByID(ctx, party.ID())
+	require.NoError(t, err)
+	assert.Empty(t, loaded.Attributes())
+
+	loaded.SetAttributes([]domain.AttributeEntry{
+		{Key: "risk_tier", Value: "high"},
+	})
+	err = repo.Save(ctx, loaded)
+	require.NoError(t, err)
+
+	updated, err := repo.FindByID(ctx, party.ID())
+	require.NoError(t, err)
+	attrs := updated.Attributes()
+	require.Len(t, attrs, 1)
+	assert.Equal(t, "risk_tier", attrs[0].Key)
+	assert.Equal(t, "high", attrs[0].Value)
+}
+
+func TestSavePartyWithNoAttributes_DefaultsToEmpty(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	party, err := domain.NewParty(domain.PartyTypeOrganization, "Acme Corp")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, party)
+	require.NoError(t, err)
+
+	loaded, err := repo.FindByID(ctx, party.ID())
+	require.NoError(t, err)
+	assert.NotNil(t, loaded.Attributes())
+	assert.Empty(t, loaded.Attributes())
+}

--- a/services/party/adapters/persistence/party_entity.go
+++ b/services/party/adapters/persistence/party_entity.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/shared/platform/audit"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
@@ -23,6 +24,9 @@ type PartyEntity struct {
 	Status                string  `gorm:"column:status;type:varchar(20);not null;default:'ACTIVE';index:idx_party_status"`
 	ExternalReference     *string `gorm:"column:external_reference;type:varchar(100);uniqueIndex:idx_party_external_ref,where:external_reference IS NOT NULL AND deleted_at IS NULL"`
 	ExternalReferenceType *string `gorm:"column:external_reference_type;type:varchar(30);uniqueIndex:idx_party_external_ref,where:external_reference IS NOT NULL AND deleted_at IS NULL"`
+
+	// Attributes stores structured key-value metadata as a JSONB array of {key, value} objects.
+	Attributes datatypes.JSON `gorm:"column:attributes;type:jsonb;not null;default:'[]'"`
 
 	// Optimistic locking
 	Version int64 `gorm:"column:version;not null;default:1"`

--- a/services/party/adapters/persistence/payment_method_repository_test.go
+++ b/services/party/adapters/persistence/payment_method_repository_test.go
@@ -41,6 +41,7 @@ func setupPaymentMethodTestDB(t *testing.T) (*gorm.DB, context.Context, func()) 
 		status VARCHAR(20) NOT NULL,
 		external_reference VARCHAR(255),
 		external_reference_type VARCHAR(50),
+		attributes JSONB NOT NULL DEFAULT '[]'::jsonb,
 		version BIGINT NOT NULL DEFAULT 1,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,

--- a/services/party/adapters/persistence/repository.go
+++ b/services/party/adapters/persistence/repository.go
@@ -12,6 +12,7 @@ import (
 	"github.com/meridianhub/meridian/services/party/domain"
 	"github.com/meridianhub/meridian/shared/platform/audit"
 	"github.com/meridianhub/meridian/shared/platform/db"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -38,6 +39,41 @@ func toJSONB(s string) string {
 	// Marshal as JSON string
 	b, _ := json.Marshal(s)
 	return string(b)
+}
+
+// attributeEntryJSON is the on-disk JSON representation of a domain.AttributeEntry.
+type attributeEntryJSON struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// serializeAttributes marshals domain AttributeEntry slice to JSONB-ready bytes.
+func serializeAttributes(attrs []domain.AttributeEntry) datatypes.JSON {
+	if len(attrs) == 0 {
+		return datatypes.JSON([]byte("[]"))
+	}
+	entries := make([]attributeEntryJSON, len(attrs))
+	for i, a := range attrs {
+		entries[i] = attributeEntryJSON{Key: a.Key, Value: a.Value}
+	}
+	b, _ := json.Marshal(entries)
+	return datatypes.JSON(b)
+}
+
+// deserializeAttributes unmarshals JSONB bytes to a domain AttributeEntry slice.
+func deserializeAttributes(raw datatypes.JSON) []domain.AttributeEntry {
+	if len(raw) == 0 {
+		return []domain.AttributeEntry{}
+	}
+	var entries []attributeEntryJSON
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return []domain.AttributeEntry{}
+	}
+	attrs := make([]domain.AttributeEntry, len(entries))
+	for i, e := range entries {
+		attrs[i] = domain.AttributeEntry{Key: e.Key, Value: e.Value}
+	}
+	return attrs
 }
 
 // Repository provides persistence operations for parties
@@ -170,6 +206,7 @@ func (r *Repository) Save(ctx context.Context, party *domain.Party) error {
 					"status":                  entity.Status,
 					"external_reference":      entity.ExternalReference,
 					"external_reference_type": entity.ExternalReferenceType,
+					"attributes":              entity.Attributes,
 					"version":                 entity.Version,
 					"updated_at":              entity.UpdatedAt,
 					"updated_by":              entity.UpdatedBy,
@@ -333,15 +370,16 @@ func toEntity(ctx context.Context, party *domain.Party) *PartyEntity {
 	auditUser := audit.GetUserFromContext(ctx)
 
 	entity := &PartyEntity{
-		ID:        party.ID(),
-		PartyType: string(party.PartyType()),
-		LegalName: party.LegalName(),
-		Status:    string(party.Status()),
-		Version:   party.Version(),
-		CreatedAt: party.CreatedAt(),
-		UpdatedAt: party.UpdatedAt(),
-		CreatedBy: auditUser,
-		UpdatedBy: auditUser,
+		ID:         party.ID(),
+		PartyType:  string(party.PartyType()),
+		LegalName:  party.LegalName(),
+		Status:     string(party.Status()),
+		Attributes: serializeAttributes(party.Attributes()),
+		Version:    party.Version(),
+		CreatedAt:  party.CreatedAt(),
+		UpdatedAt:  party.UpdatedAt(),
+		CreatedBy:  auditUser,
+		UpdatedBy:  auditUser,
 	}
 
 	// Handle optional display name
@@ -390,6 +428,7 @@ func toDomain(entity *PartyEntity) *domain.Party {
 		domain.DemographicData{},
 		domain.ReferenceData{},
 		domain.BankRelationship{},
+		deserializeAttributes(entity.Attributes),
 		entity.CreatedAt,
 		entity.UpdatedAt,
 		entity.Version,

--- a/services/party/adapters/persistence/repository_test.go
+++ b/services/party/adapters/persistence/repository_test.go
@@ -41,6 +41,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		status VARCHAR(20) NOT NULL,
 		external_reference VARCHAR(255),
 		external_reference_type VARCHAR(50),
+		attributes JSONB NOT NULL DEFAULT '[]'::jsonb,
 		version BIGINT NOT NULL DEFAULT 1,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,

--- a/services/party/adapters/persistence/verification_repository_test.go
+++ b/services/party/adapters/persistence/verification_repository_test.go
@@ -41,6 +41,7 @@ func setupVerificationTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		status VARCHAR(20) NOT NULL,
 		external_reference VARCHAR(255),
 		external_reference_type VARCHAR(50),
+		attributes JSONB NOT NULL DEFAULT '[]'::jsonb,
 		version BIGINT NOT NULL DEFAULT 1,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,

--- a/services/party/domain/party.go
+++ b/services/party/domain/party.go
@@ -200,6 +200,13 @@ type BankRelationship struct {
 	RelationshipStartDate time.Time
 }
 
+// AttributeEntry represents a single key-value attribute for a party.
+// Keys are snake_case identifiers validated against the party type's attribute_schema.
+type AttributeEntry struct {
+	Key   string
+	Value string
+}
+
 // Party represents a BIAN Party Reference Data Directory domain model.
 //
 // The Version field implements optimistic concurrency control to prevent lost updates
@@ -219,6 +226,7 @@ type Party struct {
 	demographics          DemographicData
 	referenceData         ReferenceData
 	bankRelations         BankRelationship
+	attributes            []AttributeEntry
 	createdAt             time.Time
 	updatedAt             time.Time
 	version               int64
@@ -236,13 +244,14 @@ func NewParty(partyType PartyType, legalName string) (*Party, error) {
 
 	now := time.Now()
 	return &Party{
-		id:        uuid.New(),
-		partyType: partyType,
-		legalName: legalName,
-		status:    PartyStatusActive,
-		createdAt: now,
-		updatedAt: now,
-		version:   1,
+		id:         uuid.New(),
+		partyType:  partyType,
+		legalName:  legalName,
+		status:     PartyStatusActive,
+		attributes: []AttributeEntry{},
+		createdAt:  now,
+		updatedAt:  now,
+		version:    1,
 	}, nil
 }
 
@@ -260,10 +269,14 @@ func ReconstructParty(
 	demographics DemographicData,
 	referenceData ReferenceData,
 	bankRelations BankRelationship,
+	attributes []AttributeEntry,
 	createdAt time.Time,
 	updatedAt time.Time,
 	version int64,
 ) *Party {
+	if attributes == nil {
+		attributes = []AttributeEntry{}
+	}
 	return &Party{
 		id:                    id,
 		partyType:             partyType,
@@ -276,6 +289,7 @@ func ReconstructParty(
 		demographics:          demographics,
 		referenceData:         referenceData,
 		bankRelations:         bankRelations,
+		attributes:            attributes,
 		createdAt:             createdAt,
 		updatedAt:             updatedAt,
 		version:               version,
@@ -352,6 +366,23 @@ func (p *Party) ReferenceData() ReferenceData {
 // BankRelations returns the party's bank relationship information
 func (p *Party) BankRelations() BankRelationship {
 	return p.bankRelations
+}
+
+// Attributes returns a copy of the party's structured key-value attributes.
+func (p *Party) Attributes() []AttributeEntry {
+	result := make([]AttributeEntry, len(p.attributes))
+	copy(result, p.attributes)
+	return result
+}
+
+// SetAttributes replaces the party's attributes.
+func (p *Party) SetAttributes(attrs []AttributeEntry) {
+	if attrs == nil {
+		attrs = []AttributeEntry{}
+	}
+	p.attributes = attrs
+	p.updatedAt = time.Now()
+	p.version++
 }
 
 // SetDisplayName sets the party's display name

--- a/services/party/domain/party.go
+++ b/services/party/domain/party.go
@@ -376,11 +376,14 @@ func (p *Party) Attributes() []AttributeEntry {
 }
 
 // SetAttributes replaces the party's attributes.
+// The input slice is copied defensively so callers cannot mutate Party state after the call.
 func (p *Party) SetAttributes(attrs []AttributeEntry) {
 	if attrs == nil {
 		attrs = []AttributeEntry{}
 	}
-	p.attributes = attrs
+	copied := make([]AttributeEntry, len(attrs))
+	copy(copied, attrs)
+	p.attributes = copied
 	p.updatedAt = time.Now()
 	p.version++
 }

--- a/services/party/domain/party_bq_test.go
+++ b/services/party/domain/party_bq_test.go
@@ -536,6 +536,7 @@ func TestReconstructParty_WithBQData(t *testing.T) {
 		demographics,
 		referenceData,
 		bankRelations,
+		[]AttributeEntry{},
 		createdAt,
 		updatedAt,
 		5,

--- a/services/party/domain/party_test.go
+++ b/services/party/domain/party_test.go
@@ -568,6 +568,7 @@ func TestReconstructParty(t *testing.T) {
 		DemographicData{},
 		ReferenceData{},
 		BankRelationship{},
+		[]AttributeEntry{},
 		createdAt,
 		updatedAt,
 		5,

--- a/services/party/migrations/20260221000001_add_party_attributes.sql
+++ b/services/party/migrations/20260221000001_add_party_attributes.sql
@@ -1,0 +1,5 @@
+-- Add attributes JSONB column to party table for structured key-value metadata
+ALTER TABLE "party" ADD COLUMN "attributes" JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN "party"."attributes" IS
+  'Structured key-value attributes for this party, validated against the party type attribute_schema. Stored as a JSON array of {key, value} objects.';

--- a/services/party/migrations/20260221000002_add_party_attributes_index.sql
+++ b/services/party/migrations/20260221000002_add_party_attributes_index.sql
@@ -1,0 +1,3 @@
+-- GIN index on party.attributes to support efficient JSONB containment queries
+-- Must be a separate migration from the column addition (CockroachDB requires column to be public first)
+CREATE INDEX "idx_party_attributes" ON "party" USING GIN("attributes");

--- a/services/party/migrations/atlas.sum
+++ b/services/party/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:BA8roKSOHv4D6cT/a+OuAgglhW+BNb510MPqnu74xwc=
+h1:UEdQ/37pNZLLjMko3fcU1f5E4FI5f15CAOsI1iBk3gY=
 20251216000001_initial.sql h1:e2vtJfpgkEvioqxJ1piy7QAbmihqftHOSlkPDLs8jac=
 20251217000001_audit_system.sql h1:qB+oshTdK74dZ1qX/6Ux9Hz/Ij5yayGpjjSMrgoPIcg=
 20251223000001_business_qualifiers.sql h1:1wSGqT3zHTHS0AYHMjj/zd2JyMnM01AJtL89BmkieLU=
@@ -7,3 +7,5 @@ h1:BA8roKSOHv4D6cT/a+OuAgglhW+BNb510MPqnu74xwc=
 20260210000001_party_payment_methods.sql h1:akA923j6wcLaupuJ7cT0TcBivxSB5NqCIlJAF/V0ZC0=
 20260214000001_enhance_party_association.sql h1:+Tyn/PEjjxRT85MsnhudeYSXYU6FGrZPeXnp4FQ0pUA=
 20260214000002_party_association_constraints.sql h1:4WScSXRbZVcwINJAd3Xt0k98zIt5+s5zlEywXITiMpg=
+20260221000001_add_party_attributes.sql h1:Kx3SKZXqTmf1YE7louYsrG0Qc89mHEoEhwNE4dXLys8=
+20260221000002_add_party_attributes_index.sql h1:kr9wxy6WLP9un4IQ/napA03VxqUbpbqa+psaZu3E0C4=

--- a/services/party/service/grpc_payment_methods_integration_test.go
+++ b/services/party/service/grpc_payment_methods_integration_test.go
@@ -46,6 +46,7 @@ func setupPaymentMethodIntegrationTest(t *testing.T) (*Service, *gorm.DB, contex
 		status VARCHAR(20) NOT NULL,
 		external_reference VARCHAR(255),
 		external_reference_type VARCHAR(50),
+		attributes JSONB NOT NULL DEFAULT '[]'::jsonb,
 		version BIGINT NOT NULL DEFAULT 1,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,

--- a/services/party/service/grpc_service.go
+++ b/services/party/service/grpc_service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	"github.com/meridianhub/meridian/services/party/adapters/persistence"
 	"github.com/meridianhub/meridian/services/party/domain"
 	"github.com/meridianhub/meridian/services/party/verification"
@@ -169,6 +170,11 @@ func (s *Service) RegisterParty(ctx context.Context, req *pb.RegisterPartyReques
 		}
 	}
 
+	// Set optional attributes (stored without incrementing version since this is initial creation)
+	if len(req.Attributes) > 0 {
+		party.SetAttributes(protoAttributesToDomain(req.Attributes))
+	}
+
 	// === External reference handling ===
 
 	if req.ExternalReference != "" {
@@ -264,11 +270,32 @@ func domainToProto(party *domain.Party) *pb.Party {
 		Status:                partyStatusToProto(party.Status()),
 		ExternalReference:     party.ExternalReference(),
 		ExternalReferenceType: externalRefTypeToProto(party.ExternalReferenceType()),
+		Attributes:            domainAttributesToProto(party.Attributes()),
 		CreatedAt:             timestamppb.New(party.CreatedAt()),
 		UpdatedAt:             timestamppb.New(party.UpdatedAt()),
 		// #nosec G115 - Version is bounded by database constraints
 		Version: int32(party.Version()),
 	}
+}
+
+// domainAttributesToProto converts domain AttributeEntry slice to proto AttributeEntry slice.
+func domainAttributesToProto(attrs []domain.AttributeEntry) []*quantityv1.AttributeEntry {
+	result := make([]*quantityv1.AttributeEntry, len(attrs))
+	for i, a := range attrs {
+		result[i] = &quantityv1.AttributeEntry{Key: a.Key, Value: a.Value}
+	}
+	return result
+}
+
+// protoAttributesToDomain converts proto AttributeEntry slice to domain AttributeEntry slice.
+func protoAttributesToDomain(attrs []*quantityv1.AttributeEntry) []domain.AttributeEntry {
+	result := make([]domain.AttributeEntry, len(attrs))
+	for i, a := range attrs {
+		if a != nil {
+			result[i] = domain.AttributeEntry{Key: a.Key, Value: a.Value}
+		}
+	}
+	return result
 }
 
 // protoToPartyType converts a proto PartyType to domain PartyType

--- a/services/party/service/grpc_service.go
+++ b/services/party/service/grpc_service.go
@@ -288,11 +288,12 @@ func domainAttributesToProto(attrs []domain.AttributeEntry) []*quantityv1.Attrib
 }
 
 // protoAttributesToDomain converts proto AttributeEntry slice to domain AttributeEntry slice.
+// Nil proto entries are skipped.
 func protoAttributesToDomain(attrs []*quantityv1.AttributeEntry) []domain.AttributeEntry {
-	result := make([]domain.AttributeEntry, len(attrs))
-	for i, a := range attrs {
+	result := make([]domain.AttributeEntry, 0, len(attrs))
+	for _, a := range attrs {
 		if a != nil {
-			result[i] = domain.AttributeEntry{Key: a.Key, Value: a.Value}
+			result = append(result, domain.AttributeEntry{Key: a.Key, Value: a.Value})
 		}
 	}
 	return result

--- a/services/party/service/grpc_service.go
+++ b/services/party/service/grpc_service.go
@@ -170,7 +170,7 @@ func (s *Service) RegisterParty(ctx context.Context, req *pb.RegisterPartyReques
 		}
 	}
 
-	// Set optional attributes (stored without incrementing version since this is initial creation)
+	// Set optional attributes if provided at registration time.
 	if len(req.Attributes) > 0 {
 		party.SetAttributes(protoAttributesToDomain(req.Attributes))
 	}

--- a/services/party/service/grpc_service_integration_test.go
+++ b/services/party/service/grpc_service_integration_test.go
@@ -51,6 +51,7 @@ func setupIntegrationTest(t *testing.T) (*Service, *gorm.DB, context.Context, fu
 		status VARCHAR(20) NOT NULL,
 		external_reference VARCHAR(255),
 		external_reference_type VARCHAR(50),
+		attributes JSONB NOT NULL DEFAULT '[]'::jsonb,
 		version BIGINT NOT NULL DEFAULT 1,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,

--- a/services/party/service/kyc_guard_test.go
+++ b/services/party/service/kyc_guard_test.go
@@ -49,6 +49,7 @@ func setupKYCTest(t *testing.T) (*Service, *gorm.DB, context.Context, func()) {
 		status VARCHAR(20) NOT NULL,
 		external_reference VARCHAR(255),
 		external_reference_type VARCHAR(50),
+		attributes JSONB NOT NULL DEFAULT '[]'::jsonb,
 		version BIGINT NOT NULL DEFAULT 1,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,

--- a/services/party/service/lifecycle_integration_test.go
+++ b/services/party/service/lifecycle_integration_test.go
@@ -55,6 +55,7 @@ func setupLifecycleIntegrationTest(t *testing.T) (*Service, *gorm.DB, context.Co
 		status VARCHAR(20) NOT NULL,
 		external_reference VARCHAR(255),
 		external_reference_type VARCHAR(50),
+		attributes JSONB NOT NULL DEFAULT '[]'::jsonb,
 		version BIGINT NOT NULL DEFAULT 1,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,

--- a/services/party/service/verification_integration_test.go
+++ b/services/party/service/verification_integration_test.go
@@ -68,6 +68,7 @@ func setupIntegrationTest(t *testing.T) (*integrationTestEnv, func()) {
 		status VARCHAR(20) NOT NULL,
 		external_reference VARCHAR(255),
 		external_reference_type VARCHAR(50),
+		attributes JSONB NOT NULL DEFAULT '[]'::jsonb,
 		version BIGINT NOT NULL DEFAULT 1,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,


### PR DESCRIPTION
## Summary

- Adds `repeated meridian.quantity.v1.AttributeEntry attributes` field (field 11) to the `Party` proto message, enabling structured key-value metadata validated against the party type's `attribute_schema`
- Adds `attributes` to `RegisterPartyRequest` (field 6) so parties can be created with initial attributes
- Creates CockroachDB-compatible Atlas migrations: column addition and GIN index in separate files per CLAUDE.md constraints
- Updates GORM `PartyEntity` with `datatypes.JSON` `Attributes` field and repository serialization/deserialization helpers
- Adds `AttributeEntry` domain type with `Attributes()`/`SetAttributes()` on the `Party` aggregate
- Wires proto-domain conversion in `domainToProto` and `RegisterParty` handler

## Changes Made

- `api/proto/meridian/party/v1/party.proto` — added `attributes` field to `Party` and `RegisterPartyRequest`, imported `meridian/quantity/v1/quantity.proto`
- `services/party/migrations/20260221000001_add_party_attributes.sql` — `ALTER TABLE party ADD COLUMN attributes JSONB`
- `services/party/migrations/20260221000002_add_party_attributes_index.sql` — `CREATE INDEX ... USING GIN` (separate migration per CockroachDB constraint)
- `services/party/adapters/persistence/party_entity.go` — added `Attributes datatypes.JSON` field
- `services/party/adapters/persistence/repository.go` — added `serializeAttributes`/`deserializeAttributes` helpers, wired into `toEntity`/`toDomain`, and included `attributes` in the optimistic-lock update map
- `services/party/domain/party.go` — added `AttributeEntry` type, `attributes` field on `Party`, `Attributes()`/`SetAttributes()` accessors, updated `NewParty`/`ReconstructParty`
- `services/party/service/grpc_service.go` — added `domainAttributesToProto`/`protoAttributesToDomain` converters, wired into `domainToProto` and `RegisterParty`
- All integration test files — added `attributes JSONB NOT NULL DEFAULT '[]'::jsonb` to in-test DDL

## Test plan

- [x] Attribute serialization round-trip unit tests (`TestSerializeDeserialize_RoundTrip`)
- [x] Empty/nil/invalid JSON edge cases in deserialization
- [x] Integration: `TestSaveAndLoadPartyWithAttributes` — save with attributes, load and verify
- [x] Integration: `TestUpdatePartyAttributes` — update attributes via `SetAttributes`, verify persistence
- [x] Integration: `TestSavePartyWithNoAttributes_DefaultsToEmpty` — new parties default to empty slice
- [x] All existing party service tests pass (domain, persistence, service, verification)
- [x] Migration runs on PostgreSQL testcontainer (CockroachDB parity maintained via separate DDL files)
- [x] GIN index in separate migration per CockroachDB column-must-be-public constraint