### PR TITLE
feat(party): implement PartyTypeDefinition CRUD service layer

### DIFF
--- a/services/party/adapters/persistence/party_type_definition_entity.go
+++ b/services/party/adapters/persistence/party_type_definition_entity.go
@@ -1,0 +1,53 @@
+// Package persistence provides database persistence for the party domain
+package persistence
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// PartyTypeDefinitionEntity represents the database persistence model for party type definitions.
+// Tenant-configurable schema for a party type, including JSON Schema for attribute validation
+// and CEL expressions for cross-field validation, account eligibility, and custom error messages.
+//
+// The unique constraint (tenant_id, party_type) ensures each tenant can have at most one
+// definition per party type.
+type PartyTypeDefinitionEntity struct {
+	// Primary key
+	ID uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+
+	// TenantID is the tenant that owns this party type definition.
+	// Scopes definitions to a specific tenant.
+	TenantID string `gorm:"column:tenant_id;type:varchar(100);not null;uniqueIndex:idx_party_type_def_tenant_type"`
+
+	// PartyType is the party classification this definition applies to (e.g., "PERSON", "ORGANIZATION").
+	// Uppercase alphanumeric with underscores, max 100 characters.
+	PartyType string `gorm:"column:party_type;type:varchar(100);not null;uniqueIndex:idx_party_type_def_tenant_type"`
+
+	// AttributeSchema is a JSON Schema document defining the structure and constraints
+	// for party attributes of this type. Stored as text (up to 16KB).
+	AttributeSchema string `gorm:"column:attribute_schema;type:text;not null"`
+
+	// ValidationCEL is a CEL expression for cross-field validation of party attributes.
+	ValidationCEL string `gorm:"column:validation_cel;type:text;not null;default:''"`
+
+	// EligibilityCEL is a CEL expression for determining account type eligibility.
+	EligibilityCEL string `gorm:"column:eligibility_cel;type:text;not null;default:''"`
+
+	// ErrorMessageCEL is a CEL expression for generating custom error messages.
+	ErrorMessageCEL string `gorm:"column:error_message_cel;type:text;not null;default:''"`
+
+	// Optimistic locking
+	Version int64 `gorm:"column:version;not null;default:1"`
+
+	// Timestamps
+	CreatedAt time.Time `gorm:"column:created_at;not null;default:now()"`
+	UpdatedAt time.Time `gorm:"column:updated_at;not null;default:now()"`
+}
+
+// TableName overrides the default table name.
+// Uses singular, unqualified name per database-per-service architecture.
+func (PartyTypeDefinitionEntity) TableName() string {
+	return "party_type_definition"
+}

--- a/services/party/adapters/persistence/party_type_definition_repository.go
+++ b/services/party/adapters/persistence/party_type_definition_repository.go
@@ -1,0 +1,151 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"gorm.io/gorm"
+)
+
+// PartyTypeDefinitionRepository errors
+var (
+	ErrPartyTypeDefinitionNotFound = errors.New("party type definition not found")
+	ErrPartyTypeDefinitionExists   = errors.New("party type definition already exists for this tenant and party type")
+	ErrPartyTypeVersionConflict    = errors.New("version conflict: party type definition was modified by another transaction")
+)
+
+// PartyTypeDefinitionRepository provides persistence operations for party type definitions.
+type PartyTypeDefinitionRepository struct {
+	db *gorm.DB
+}
+
+// NewPartyTypeDefinitionRepository creates a new party type definition repository.
+func NewPartyTypeDefinitionRepository(db *gorm.DB) *PartyTypeDefinitionRepository {
+	return &PartyTypeDefinitionRepository{db: db}
+}
+
+// withTenantTransaction executes the given function with tenant scoping.
+func (r *PartyTypeDefinitionRepository) withTenantTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	return db.WithGormTenantTransaction(ctx, r.db, fn)
+}
+
+// Create inserts a new party type definition.
+// Returns ErrPartyTypeDefinitionExists if a definition already exists for the same tenant and party type.
+func (r *PartyTypeDefinitionRepository) Create(ctx context.Context, entity *PartyTypeDefinitionEntity) error {
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		if err := tx.Create(entity).Error; err != nil {
+			if isDuplicateKeyError(err) {
+				return ErrPartyTypeDefinitionExists
+			}
+			return err
+		}
+		return nil
+	})
+}
+
+// GetByID retrieves a party type definition by its UUID.
+// Returns ErrPartyTypeDefinitionNotFound if not found.
+func (r *PartyTypeDefinitionRepository) GetByID(ctx context.Context, id uuid.UUID) (*PartyTypeDefinitionEntity, error) {
+	var entity PartyTypeDefinitionEntity
+	var found bool
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Where("id = ?", id).First(&entity)
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return ErrPartyTypeDefinitionNotFound
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+		found = true
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, ErrPartyTypeDefinitionNotFound
+	}
+	return &entity, nil
+}
+
+// GetByTenantAndType retrieves a party type definition by tenant ID and party type.
+// Returns ErrPartyTypeDefinitionNotFound if not found.
+func (r *PartyTypeDefinitionRepository) GetByTenantAndType(ctx context.Context, tenantID, partyType string) (*PartyTypeDefinitionEntity, error) {
+	var entity PartyTypeDefinitionEntity
+	var found bool
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Where("tenant_id = ? AND party_type = ?", tenantID, partyType).First(&entity)
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return ErrPartyTypeDefinitionNotFound
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+		found = true
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, ErrPartyTypeDefinitionNotFound
+	}
+	return &entity, nil
+}
+
+// ListByTenant retrieves all party type definitions for a tenant.
+// Optionally filters by party type if partyType is non-empty.
+func (r *PartyTypeDefinitionRepository) ListByTenant(ctx context.Context, tenantID string, partyType string) ([]*PartyTypeDefinitionEntity, error) {
+	var entities []*PartyTypeDefinitionEntity
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		q := tx.Where("tenant_id = ?", tenantID)
+		if partyType != "" {
+			q = q.Where("party_type = ?", partyType)
+		}
+		return q.Find(&entities).Error
+	})
+	if err != nil {
+		return nil, err
+	}
+	return entities, nil
+}
+
+// Update applies optimistic-locked updates to a party type definition.
+// Returns ErrPartyTypeVersionConflict if another transaction has modified the record.
+// Returns ErrPartyTypeDefinitionNotFound if the record does not exist.
+func (r *PartyTypeDefinitionRepository) Update(ctx context.Context, entity *PartyTypeDefinitionEntity) error {
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		// entity.Version is the target version; DB should still have Version-1.
+		expectedDBVersion := entity.Version - 1
+
+		result := tx.Model(&PartyTypeDefinitionEntity{}).
+			Where("id = ? AND version = ?", entity.ID, expectedDBVersion).
+			Updates(map[string]interface{}{
+				"attribute_schema":  entity.AttributeSchema,
+				"validation_cel":    entity.ValidationCEL,
+				"eligibility_cel":   entity.EligibilityCEL,
+				"error_message_cel": entity.ErrorMessageCEL,
+				"version":           entity.Version,
+				"updated_at":        time.Now(),
+			})
+
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			// Check whether the record exists at all
+			var count int64
+			if err := tx.Model(&PartyTypeDefinitionEntity{}).Where("id = ?", entity.ID).Count(&count).Error; err != nil {
+				return err
+			}
+			if count == 0 {
+				return ErrPartyTypeDefinitionNotFound
+			}
+			return ErrPartyTypeVersionConflict
+		}
+		return nil
+	})
+}

--- a/services/party/adapters/persistence/party_type_definition_repository_test.go
+++ b/services/party/adapters/persistence/party_type_definition_repository_test.go
@@ -1,0 +1,335 @@
+package persistence
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+const testPartyTypeSchema = `{"type":"object","properties":{"annual_income":{"type":"string"}}}`
+
+func setupPartyTypeTestDB(t *testing.T) (*gorm.DB, interface{ String() string }, func()) {
+	t.Helper()
+	db, cleanup := testdb.SetupPostgres(t, []interface{}{&PartyTypeDefinitionEntity{}})
+
+	tid := tenant.TenantID(testTenantID)
+	schemaName := tid.SchemaName()
+
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.party_type_definition (
+		id               UUID        NOT NULL DEFAULT gen_random_uuid(),
+		tenant_id        VARCHAR(100) NOT NULL,
+		party_type       VARCHAR(100) NOT NULL,
+		attribute_schema TEXT         NOT NULL,
+		validation_cel   TEXT         NOT NULL DEFAULT '',
+		eligibility_cel  TEXT         NOT NULL DEFAULT '',
+		error_message_cel TEXT        NOT NULL DEFAULT '',
+		version          BIGINT       NOT NULL DEFAULT 1,
+		created_at       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+		updated_at       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+		PRIMARY KEY (id),
+		UNIQUE (tenant_id, party_type)
+	)`, pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	return db, tid, cleanup
+}
+
+func TestPartyTypeDefinitionRepository_Create(t *testing.T) {
+	db, tid, cleanup := setupPartyTypeTestDB(t)
+	defer cleanup()
+
+	ctx := tenant.WithTenant(t.Context(), tenant.TenantID(tid.String()))
+	repo := NewPartyTypeDefinitionRepository(db)
+
+	entity := &PartyTypeDefinitionEntity{
+		ID:              uuid.New(),
+		TenantID:        tid.String(),
+		PartyType:       "PERSON",
+		AttributeSchema: testPartyTypeSchema,
+		ValidationCEL:   "",
+		EligibilityCEL:  "",
+		ErrorMessageCEL: "",
+		Version:         1,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+
+	err := repo.Create(ctx, entity)
+	require.NoError(t, err)
+}
+
+func TestPartyTypeDefinitionRepository_Create_DuplicateReturnsError(t *testing.T) {
+	db, tid, cleanup := setupPartyTypeTestDB(t)
+	defer cleanup()
+
+	ctx := tenant.WithTenant(t.Context(), tenant.TenantID(tid.String()))
+	repo := NewPartyTypeDefinitionRepository(db)
+
+	entity1 := &PartyTypeDefinitionEntity{
+		ID:              uuid.New(),
+		TenantID:        tid.String(),
+		PartyType:       "ORGANIZATION",
+		AttributeSchema: testPartyTypeSchema,
+		Version:         1,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+	require.NoError(t, repo.Create(ctx, entity1))
+
+	entity2 := &PartyTypeDefinitionEntity{
+		ID:              uuid.New(),
+		TenantID:        tid.String(),
+		PartyType:       "ORGANIZATION",
+		AttributeSchema: testPartyTypeSchema,
+		Version:         1,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+	err := repo.Create(ctx, entity2)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrPartyTypeDefinitionExists))
+}
+
+func TestPartyTypeDefinitionRepository_GetByID(t *testing.T) {
+	db, tid, cleanup := setupPartyTypeTestDB(t)
+	defer cleanup()
+
+	ctx := tenant.WithTenant(t.Context(), tenant.TenantID(tid.String()))
+	repo := NewPartyTypeDefinitionRepository(db)
+
+	id := uuid.New()
+	entity := &PartyTypeDefinitionEntity{
+		ID:              id,
+		TenantID:        tid.String(),
+		PartyType:       "PERSON",
+		AttributeSchema: testPartyTypeSchema,
+		ValidationCEL:   "true",
+		Version:         1,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+	require.NoError(t, repo.Create(ctx, entity))
+
+	retrieved, err := repo.GetByID(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, id, retrieved.ID)
+	assert.Equal(t, "PERSON", retrieved.PartyType)
+	assert.Equal(t, testPartyTypeSchema, retrieved.AttributeSchema)
+	assert.Equal(t, "true", retrieved.ValidationCEL)
+	assert.Equal(t, int64(1), retrieved.Version)
+}
+
+func TestPartyTypeDefinitionRepository_GetByID_NotFound(t *testing.T) {
+	db, tid, cleanup := setupPartyTypeTestDB(t)
+	defer cleanup()
+
+	ctx := tenant.WithTenant(t.Context(), tenant.TenantID(tid.String()))
+	repo := NewPartyTypeDefinitionRepository(db)
+
+	_, err := repo.GetByID(ctx, uuid.New())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrPartyTypeDefinitionNotFound))
+}
+
+func TestPartyTypeDefinitionRepository_GetByTenantAndType(t *testing.T) {
+	db, tid, cleanup := setupPartyTypeTestDB(t)
+	defer cleanup()
+
+	ctx := tenant.WithTenant(t.Context(), tenant.TenantID(tid.String()))
+	repo := NewPartyTypeDefinitionRepository(db)
+
+	entity := &PartyTypeDefinitionEntity{
+		ID:              uuid.New(),
+		TenantID:        tid.String(),
+		PartyType:       "CORPORATE",
+		AttributeSchema: testPartyTypeSchema,
+		Version:         1,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+	require.NoError(t, repo.Create(ctx, entity))
+
+	retrieved, err := repo.GetByTenantAndType(ctx, tid.String(), "CORPORATE")
+	require.NoError(t, err)
+	assert.Equal(t, entity.ID, retrieved.ID)
+	assert.Equal(t, "CORPORATE", retrieved.PartyType)
+}
+
+func TestPartyTypeDefinitionRepository_GetByTenantAndType_NotFound(t *testing.T) {
+	db, tid, cleanup := setupPartyTypeTestDB(t)
+	defer cleanup()
+
+	ctx := tenant.WithTenant(t.Context(), tenant.TenantID(tid.String()))
+	repo := NewPartyTypeDefinitionRepository(db)
+
+	_, err := repo.GetByTenantAndType(ctx, tid.String(), "NONEXISTENT")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrPartyTypeDefinitionNotFound))
+}
+
+func TestPartyTypeDefinitionRepository_ListByTenant(t *testing.T) {
+	db, tid, cleanup := setupPartyTypeTestDB(t)
+	defer cleanup()
+
+	ctx := tenant.WithTenant(t.Context(), tenant.TenantID(tid.String()))
+	repo := NewPartyTypeDefinitionRepository(db)
+
+	for _, pt := range []string{"PERSON", "ORGANIZATION", "TRUST"} {
+		e := &PartyTypeDefinitionEntity{
+			ID:              uuid.New(),
+			TenantID:        tid.String(),
+			PartyType:       pt,
+			AttributeSchema: testPartyTypeSchema,
+			Version:         1,
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
+		}
+		require.NoError(t, repo.Create(ctx, e))
+	}
+
+	results, err := repo.ListByTenant(ctx, tid.String(), "")
+	require.NoError(t, err)
+	assert.Len(t, results, 3)
+}
+
+func TestPartyTypeDefinitionRepository_ListByTenant_FilterByType(t *testing.T) {
+	db, tid, cleanup := setupPartyTypeTestDB(t)
+	defer cleanup()
+
+	ctx := tenant.WithTenant(t.Context(), tenant.TenantID(tid.String()))
+	repo := NewPartyTypeDefinitionRepository(db)
+
+	for _, pt := range []string{"PERSON", "ORGANIZATION"} {
+		e := &PartyTypeDefinitionEntity{
+			ID:              uuid.New(),
+			TenantID:        tid.String(),
+			PartyType:       pt,
+			AttributeSchema: testPartyTypeSchema,
+			Version:         1,
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
+		}
+		require.NoError(t, repo.Create(ctx, e))
+	}
+
+	results, err := repo.ListByTenant(ctx, tid.String(), "PERSON")
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, "PERSON", results[0].PartyType)
+}
+
+func TestPartyTypeDefinitionRepository_ListByTenant_Empty(t *testing.T) {
+	db, tid, cleanup := setupPartyTypeTestDB(t)
+	defer cleanup()
+
+	ctx := tenant.WithTenant(t.Context(), tenant.TenantID(tid.String()))
+	repo := NewPartyTypeDefinitionRepository(db)
+
+	results, err := repo.ListByTenant(ctx, tid.String(), "")
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestPartyTypeDefinitionRepository_Update(t *testing.T) {
+	db, tid, cleanup := setupPartyTypeTestDB(t)
+	defer cleanup()
+
+	ctx := tenant.WithTenant(t.Context(), tenant.TenantID(tid.String()))
+	repo := NewPartyTypeDefinitionRepository(db)
+
+	id := uuid.New()
+	entity := &PartyTypeDefinitionEntity{
+		ID:              id,
+		TenantID:        tid.String(),
+		PartyType:       "PERSON",
+		AttributeSchema: testPartyTypeSchema,
+		Version:         1,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+	require.NoError(t, repo.Create(ctx, entity))
+
+	// Update: increment version, change schema
+	entity.AttributeSchema = `{"type":"object","properties":{"income":{"type":"number"}}}`
+	entity.ValidationCEL = "true"
+	entity.Version = 2
+
+	err := repo.Update(ctx, entity)
+	require.NoError(t, err)
+
+	// Verify update persisted
+	updated, err := repo.GetByID(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), updated.Version)
+	assert.Equal(t, "true", updated.ValidationCEL)
+	assert.Contains(t, updated.AttributeSchema, "income")
+}
+
+func TestPartyTypeDefinitionRepository_Update_VersionConflict(t *testing.T) {
+	db, tid, cleanup := setupPartyTypeTestDB(t)
+	defer cleanup()
+
+	ctx := tenant.WithTenant(t.Context(), tenant.TenantID(tid.String()))
+	repo := NewPartyTypeDefinitionRepository(db)
+
+	id := uuid.New()
+	entity := &PartyTypeDefinitionEntity{
+		ID:              id,
+		TenantID:        tid.String(),
+		PartyType:       "PERSON",
+		AttributeSchema: testPartyTypeSchema,
+		Version:         1,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+	require.NoError(t, repo.Create(ctx, entity))
+
+	// Try to update with wrong version (version=1, but expecting DB to have version=0 for update to succeed)
+	// entity.Version=1 means expectedDBVersion=0, but DB has version=1 → conflict
+	stale := &PartyTypeDefinitionEntity{
+		ID:              id,
+		TenantID:        tid.String(),
+		PartyType:       "PERSON",
+		AttributeSchema: testPartyTypeSchema,
+		Version:         1, // target=1, so expectedDB=0, but DB has 1 → conflict
+		UpdatedAt:       time.Now(),
+	}
+	err := repo.Update(ctx, stale)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrPartyTypeVersionConflict))
+}
+
+func TestPartyTypeDefinitionRepository_Update_NotFound(t *testing.T) {
+	db, tid, cleanup := setupPartyTypeTestDB(t)
+	defer cleanup()
+
+	ctx := tenant.WithTenant(t.Context(), tenant.TenantID(tid.String()))
+	repo := NewPartyTypeDefinitionRepository(db)
+
+	entity := &PartyTypeDefinitionEntity{
+		ID:              uuid.New(),
+		TenantID:        tid.String(),
+		PartyType:       "PERSON",
+		AttributeSchema: testPartyTypeSchema,
+		Version:         2, // targets DB version=1, but record doesn't exist
+		UpdatedAt:       time.Now(),
+	}
+	err := repo.Update(ctx, entity)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrPartyTypeDefinitionNotFound))
+}

--- a/services/party/cmd/main.go
+++ b/services/party/cmd/main.go
@@ -90,6 +90,7 @@ func run(logger *slog.Logger) error {
 	// Create repositories
 	repo := persistence.NewRepository(db)
 	pmRepo := persistence.NewPaymentMethodRepository(db)
+	partyTypeRepo := persistence.NewPartyTypeDefinitionRepository(db)
 
 	// Create party service
 	partyService, err := service.NewService(repo, logger)
@@ -97,6 +98,13 @@ func run(logger *slog.Logger) error {
 		return fmt.Errorf("failed to create party service: %w", err)
 	}
 	partyService.WithPaymentMethodRepository(pmRepo)
+
+	// Create and wire party type definition service
+	partyTypeSvc, err := service.NewPartyTypeDefinitionService(partyTypeRepo)
+	if err != nil {
+		return fmt.Errorf("failed to create party type definition service: %w", err)
+	}
+	partyService.WithPartyTypeDefinitionService(partyTypeSvc)
 
 	// Load verification config with environment-aware validation.
 	// Production: fail fast if config is missing or invalid.

--- a/services/party/migrations/20260221000003_party_type_definition.sql
+++ b/services/party/migrations/20260221000003_party_type_definition.sql
@@ -1,0 +1,16 @@
+-- Create party_type_definition table for tenant-configurable party type schemas.
+-- Stores JSON Schema for attribute validation and CEL expressions for cross-field
+-- validation, account eligibility, and custom error messages.
+CREATE TABLE "party_type_definition" (
+    "id"               UUID         NOT NULL DEFAULT gen_random_uuid(),
+    "tenant_id"        VARCHAR(100) NOT NULL,
+    "party_type"       VARCHAR(100) NOT NULL,
+    "attribute_schema" TEXT         NOT NULL,
+    "validation_cel"   TEXT         NOT NULL DEFAULT '',
+    "eligibility_cel"  TEXT         NOT NULL DEFAULT '',
+    "error_message_cel" TEXT        NOT NULL DEFAULT '',
+    "version"          BIGINT       NOT NULL DEFAULT 1,
+    "created_at"       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    "updated_at"       TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    PRIMARY KEY ("id")
+);

--- a/services/party/migrations/20260221000004_party_type_definition_index.sql
+++ b/services/party/migrations/20260221000004_party_type_definition_index.sql
@@ -1,0 +1,4 @@
+-- Add unique index on (tenant_id, party_type) for the party_type_definition table.
+-- Separated from table creation per CockroachDB requirements: a partial or unique index
+-- on a newly-added column requires the column to be "public" (committed) first.
+CREATE UNIQUE INDEX "idx_party_type_def_tenant_type" ON "party_type_definition" ("tenant_id", "party_type");

--- a/services/party/migrations/atlas.sum
+++ b/services/party/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:UEdQ/37pNZLLjMko3fcU1f5E4FI5f15CAOsI1iBk3gY=
+h1:VOWVqxt4R8TEiUgTKR6RqxWX2mFNwr9FY5ONjE/VElY=
 20251216000001_initial.sql h1:e2vtJfpgkEvioqxJ1piy7QAbmihqftHOSlkPDLs8jac=
 20251217000001_audit_system.sql h1:qB+oshTdK74dZ1qX/6Ux9Hz/Ij5yayGpjjSMrgoPIcg=
 20251223000001_business_qualifiers.sql h1:1wSGqT3zHTHS0AYHMjj/zd2JyMnM01AJtL89BmkieLU=
@@ -9,3 +9,5 @@ h1:UEdQ/37pNZLLjMko3fcU1f5E4FI5f15CAOsI1iBk3gY=
 20260214000002_party_association_constraints.sql h1:4WScSXRbZVcwINJAd3Xt0k98zIt5+s5zlEywXITiMpg=
 20260221000001_add_party_attributes.sql h1:Kx3SKZXqTmf1YE7louYsrG0Qc89mHEoEhwNE4dXLys8=
 20260221000002_add_party_attributes_index.sql h1:kr9wxy6WLP9un4IQ/napA03VxqUbpbqa+psaZu3E0C4=
+20260221000003_party_type_definition.sql h1:xHhyjWCcI8t/L+r4TRHDKKMySdgQ/DqrJVRJT/duur4=
+20260221000004_party_type_definition_index.sql h1:QcyC+PBTXv4+duHqUt6HQJDd2+CnGnV98PlUKASHp5g=

--- a/services/party/service/grpc_party_type.go
+++ b/services/party/service/grpc_party_type.go
@@ -73,6 +73,10 @@ func (s *Service) GetPartyType(ctx context.Context, req *pb.GetPartyTypeRequest)
 		return nil, status.Error(codes.Unimplemented, "party type definition operations not configured")
 	}
 
+	if _, err := tenant.RequireFromContext(ctx); err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "tenant context required: %v", err)
+	}
+
 	id, err := uuid.Parse(req.Id)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid party type definition ID format: %v", err)
@@ -129,6 +133,10 @@ func (s *Service) UpdatePartyType(ctx context.Context, req *pb.UpdatePartyTypeRe
 		return nil, status.Error(codes.Unimplemented, "party type definition operations not configured")
 	}
 
+	if _, err := tenant.RequireFromContext(ctx); err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "tenant context required: %v", err)
+	}
+
 	id, err := uuid.Parse(req.Id)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid party type definition ID format: %v", err)
@@ -144,21 +152,23 @@ func (s *Service) UpdatePartyType(ctx context.Context, req *pb.UpdatePartyTypeRe
 		for _, path := range req.UpdateMask.Paths {
 			switch path {
 			case "attribute_schema":
-				input.AttributeSchema = req.AttributeSchema
+				input.AttributeSchema = &req.AttributeSchema
 			case "validation_cel":
-				input.ValidationCEL = req.ValidationCel
+				input.ValidationCEL = &req.ValidationCel
 			case "eligibility_cel":
-				input.EligibilityCEL = req.EligibilityCel
+				input.EligibilityCEL = &req.EligibilityCel
 			case "error_message_cel":
-				input.ErrorMessageCEL = req.ErrorMessageCel
+				input.ErrorMessageCEL = &req.ErrorMessageCel
+			default:
+				return nil, status.Errorf(codes.InvalidArgument, "unsupported update mask path: %q", path)
 			}
 		}
 	} else {
-		// No field mask - update all provided non-empty fields
-		input.AttributeSchema = req.AttributeSchema
-		input.ValidationCEL = req.ValidationCel
-		input.EligibilityCEL = req.EligibilityCel
-		input.ErrorMessageCEL = req.ErrorMessageCel
+		// No field mask - update all fields
+		input.AttributeSchema = &req.AttributeSchema
+		input.ValidationCEL = &req.ValidationCel
+		input.EligibilityCEL = &req.EligibilityCel
+		input.ErrorMessageCEL = &req.ErrorMessageCel
 	}
 
 	entity, err := s.partyTypeService.Update(ctx, id, input)

--- a/services/party/service/grpc_party_type.go
+++ b/services/party/service/grpc_party_type.go
@@ -1,0 +1,210 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/meridianhub/meridian/services/party/adapters/persistence"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// WithPartyTypeDefinitionService attaches a party type definition service to the gRPC service.
+// When set, party type definition gRPC operations are enabled.
+func (s *Service) WithPartyTypeDefinitionService(ptd *PartyTypeDefinitionService) *Service {
+	s.partyTypeService = ptd
+	return s
+}
+
+// RegisterPartyType creates a new tenant-configurable party type definition.
+func (s *Service) RegisterPartyType(ctx context.Context, req *pb.RegisterPartyTypeRequest) (*pb.RegisterPartyTypeResponse, error) {
+	if s.partyTypeService == nil {
+		return nil, status.Error(codes.Unimplemented, "party type definition operations not configured")
+	}
+
+	tenantID, err := tenant.RequireFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "tenant context required: %v", err)
+	}
+
+	entity, err := s.partyTypeService.Register(ctx, RegisterPartyTypeInput{
+		TenantID:        tenantID.String(),
+		PartyType:       req.PartyType,
+		AttributeSchema: req.AttributeSchema,
+		ValidationCEL:   req.ValidationCel,
+		EligibilityCEL:  req.EligibilityCel,
+		ErrorMessageCEL: req.ErrorMessageCel,
+	})
+	if err != nil {
+		if errors.Is(err, persistence.ErrPartyTypeDefinitionExists) {
+			return nil, status.Errorf(codes.AlreadyExists, "party type definition already exists for type %q", req.PartyType)
+		}
+		if errors.Is(err, ErrAttributeSchemaEmpty) ||
+			errors.Is(err, ErrAttributeSchemaTooBig) ||
+			errors.Is(err, ErrAttributeSchemaInvalidJSON) ||
+			errors.Is(err, ErrValidationCELInvalid) ||
+			errors.Is(err, ErrEligibilityCELInvalid) ||
+			errors.Is(err, ErrErrorMessageCELInvalid) {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid party type definition: %v", err)
+		}
+		s.logger.Error("failed to register party type definition",
+			"party_type", req.PartyType,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to register party type definition: %v", err)
+	}
+
+	s.logger.Info("party type definition registered",
+		"id", entity.ID.String(),
+		"tenant_id", tenantID.String(),
+		"party_type", entity.PartyType)
+
+	return &pb.RegisterPartyTypeResponse{
+		PartyTypeDefinition: partyTypeDefinitionToProto(entity),
+	}, nil
+}
+
+// GetPartyType retrieves a party type definition by ID.
+func (s *Service) GetPartyType(ctx context.Context, req *pb.GetPartyTypeRequest) (*pb.GetPartyTypeResponse, error) {
+	if s.partyTypeService == nil {
+		return nil, status.Error(codes.Unimplemented, "party type definition operations not configured")
+	}
+
+	id, err := uuid.Parse(req.Id)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid party type definition ID format: %v", err)
+	}
+
+	entity, err := s.partyTypeService.GetByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, persistence.ErrPartyTypeDefinitionNotFound) {
+			return nil, status.Errorf(codes.NotFound, "party type definition not found: %s", req.Id)
+		}
+		s.logger.Error("failed to retrieve party type definition",
+			"id", req.Id,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to retrieve party type definition: %v", err)
+	}
+
+	return &pb.GetPartyTypeResponse{
+		PartyTypeDefinition: partyTypeDefinitionToProto(entity),
+	}, nil
+}
+
+// ListPartyTypes lists all party type definitions for the tenant.
+func (s *Service) ListPartyTypes(ctx context.Context, req *pb.ListPartyTypesRequest) (*pb.ListPartyTypesResponse, error) {
+	if s.partyTypeService == nil {
+		return nil, status.Error(codes.Unimplemented, "party type definition operations not configured")
+	}
+
+	tenantID, err := tenant.RequireFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "tenant context required: %v", err)
+	}
+
+	entities, err := s.partyTypeService.ListByTenant(ctx, tenantID.String(), req.PartyType)
+	if err != nil {
+		s.logger.Error("failed to list party type definitions",
+			"tenant_id", tenantID.String(),
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to list party type definitions: %v", err)
+	}
+
+	defs := make([]*pb.PartyTypeDefinition, len(entities))
+	for i, e := range entities {
+		defs[i] = partyTypeDefinitionToProto(e)
+	}
+
+	return &pb.ListPartyTypesResponse{
+		PartyTypeDefinitions: defs,
+	}, nil
+}
+
+// UpdatePartyType updates a party type definition.
+func (s *Service) UpdatePartyType(ctx context.Context, req *pb.UpdatePartyTypeRequest) (*pb.UpdatePartyTypeResponse, error) {
+	if s.partyTypeService == nil {
+		return nil, status.Error(codes.Unimplemented, "party type definition operations not configured")
+	}
+
+	id, err := uuid.Parse(req.Id)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid party type definition ID format: %v", err)
+	}
+
+	// Build the update input, applying field mask if provided
+	input := UpdatePartyTypeInput{
+		// #nosec G115 - Version is bounded by database constraints
+		Version: int64(req.Version),
+	}
+
+	if req.UpdateMask != nil && len(req.UpdateMask.Paths) > 0 {
+		for _, path := range req.UpdateMask.Paths {
+			switch path {
+			case "attribute_schema":
+				input.AttributeSchema = req.AttributeSchema
+			case "validation_cel":
+				input.ValidationCEL = req.ValidationCel
+			case "eligibility_cel":
+				input.EligibilityCEL = req.EligibilityCel
+			case "error_message_cel":
+				input.ErrorMessageCEL = req.ErrorMessageCel
+			}
+		}
+	} else {
+		// No field mask - update all provided non-empty fields
+		input.AttributeSchema = req.AttributeSchema
+		input.ValidationCEL = req.ValidationCel
+		input.EligibilityCEL = req.EligibilityCel
+		input.ErrorMessageCEL = req.ErrorMessageCel
+	}
+
+	entity, err := s.partyTypeService.Update(ctx, id, input)
+	if err != nil {
+		if errors.Is(err, persistence.ErrPartyTypeDefinitionNotFound) {
+			return nil, status.Errorf(codes.NotFound, "party type definition not found: %s", req.Id)
+		}
+		if errors.Is(err, persistence.ErrPartyTypeVersionConflict) {
+			return nil, status.Errorf(codes.Aborted, "version conflict: party type definition was modified by another transaction")
+		}
+		if errors.Is(err, ErrAttributeSchemaEmpty) ||
+			errors.Is(err, ErrAttributeSchemaTooBig) ||
+			errors.Is(err, ErrAttributeSchemaInvalidJSON) ||
+			errors.Is(err, ErrValidationCELInvalid) ||
+			errors.Is(err, ErrEligibilityCELInvalid) ||
+			errors.Is(err, ErrErrorMessageCELInvalid) {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid update: %v", err)
+		}
+		s.logger.Error("failed to update party type definition",
+			"id", req.Id,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to update party type definition: %v", err)
+	}
+
+	s.logger.Info("party type definition updated",
+		"id", req.Id,
+		"version", entity.Version)
+
+	return &pb.UpdatePartyTypeResponse{
+		PartyTypeDefinition: partyTypeDefinitionToProto(entity),
+	}, nil
+}
+
+// partyTypeDefinitionToProto converts a persistence entity to a proto PartyTypeDefinition.
+func partyTypeDefinitionToProto(e *persistence.PartyTypeDefinitionEntity) *pb.PartyTypeDefinition {
+	return &pb.PartyTypeDefinition{
+		Id:              e.ID.String(),
+		TenantId:        e.TenantID,
+		PartyType:       e.PartyType,
+		AttributeSchema: e.AttributeSchema,
+		ValidationCel:   e.ValidationCEL,
+		EligibilityCel:  e.EligibilityCEL,
+		ErrorMessageCel: e.ErrorMessageCEL,
+		// #nosec G115 - Version is bounded by database constraints
+		Version:   int32(e.Version),
+		CreatedAt: timestamppb.New(e.CreatedAt),
+		UpdatedAt: timestamppb.New(e.UpdatedAt),
+	}
+}

--- a/services/party/service/grpc_service.go
+++ b/services/party/service/grpc_service.go
@@ -86,6 +86,7 @@ type Service struct {
 	repo                 Repository
 	pmRepo               PaymentMethodRepository
 	verificationProvider verification.Provider
+	partyTypeService     *PartyTypeDefinitionService
 	logger               *slog.Logger
 }
 

--- a/services/party/service/party_type_service.go
+++ b/services/party/service/party_type_service.go
@@ -183,10 +183,15 @@ func (s *PartyTypeDefinitionService) validateAttributeSchema(schema string) erro
 	if len(schema) > MaxAttributeSchemaSize {
 		return ErrAttributeSchemaTooBig
 	}
-	// Must be a valid JSON object (JSON Schema is always a JSON object)
-	var parsed map[string]interface{}
+	// Must be a valid JSON object (JSON Schema is always a JSON object).
+	// Unmarshal into interface{} first so that JSON null (valid JSON but not an object)
+	// is caught by the type assertion below rather than silently yielding a nil map.
+	var parsed interface{}
 	if err := json.Unmarshal([]byte(schema), &parsed); err != nil {
 		return fmt.Errorf("%w: %w", ErrAttributeSchemaInvalidJSON, err)
+	}
+	if _, ok := parsed.(map[string]interface{}); !ok {
+		return ErrAttributeSchemaInvalidJSON
 	}
 	return nil
 }

--- a/services/party/service/party_type_service.go
+++ b/services/party/service/party_type_service.go
@@ -69,11 +69,12 @@ type RegisterPartyTypeInput struct {
 }
 
 // UpdatePartyTypeInput holds the input for updating a party type definition.
+// Pointer fields distinguish "not provided" (nil = preserve existing) from "set to empty" (ptr to "" = clear).
 type UpdatePartyTypeInput struct {
-	AttributeSchema string
-	ValidationCEL   string
-	EligibilityCEL  string
-	ErrorMessageCEL string
+	AttributeSchema *string
+	ValidationCEL   *string
+	EligibilityCEL  *string
+	ErrorMessageCEL *string
 	Version         int64
 }
 
@@ -135,27 +136,26 @@ func (s *PartyTypeDefinitionService) Update(ctx context.Context, id uuid.UUID, i
 		return nil, persistence.ErrPartyTypeVersionConflict
 	}
 
-	// Apply updates (non-empty fields overwrite existing)
-	if input.AttributeSchema != "" {
-		if err := s.validateAttributeSchema(input.AttributeSchema); err != nil {
+	// Apply updates: nil pointer means "not provided" (preserve existing); non-nil means "set to this value" (including empty = clear).
+	if input.AttributeSchema != nil {
+		if err := s.validateAttributeSchema(*input.AttributeSchema); err != nil {
 			return nil, err
 		}
-		existing.AttributeSchema = input.AttributeSchema
+		existing.AttributeSchema = *input.AttributeSchema
 	}
 
-	// For CEL fields, apply if provided (even if empty string means "clear")
 	updatedValidationCEL := existing.ValidationCEL
 	updatedEligibilityCEL := existing.EligibilityCEL
 	updatedErrorMessageCEL := existing.ErrorMessageCEL
 
-	if input.ValidationCEL != "" {
-		updatedValidationCEL = input.ValidationCEL
+	if input.ValidationCEL != nil {
+		updatedValidationCEL = *input.ValidationCEL
 	}
-	if input.EligibilityCEL != "" {
-		updatedEligibilityCEL = input.EligibilityCEL
+	if input.EligibilityCEL != nil {
+		updatedEligibilityCEL = *input.EligibilityCEL
 	}
-	if input.ErrorMessageCEL != "" {
-		updatedErrorMessageCEL = input.ErrorMessageCEL
+	if input.ErrorMessageCEL != nil {
+		updatedErrorMessageCEL = *input.ErrorMessageCEL
 	}
 
 	if err := s.validateCELExpressions(updatedValidationCEL, updatedEligibilityCEL, updatedErrorMessageCEL); err != nil {

--- a/services/party/service/party_type_service.go
+++ b/services/party/service/party_type_service.go
@@ -131,8 +131,8 @@ func (s *PartyTypeDefinitionService) Update(ctx context.Context, id uuid.UUID, i
 		return nil, err
 	}
 
-	// Optimistic locking check
-	if input.Version > 0 && existing.Version != input.Version {
+	// Optimistic locking check: caller must always supply the current version.
+	if existing.Version != input.Version {
 		return nil, persistence.ErrPartyTypeVersionConflict
 	}
 
@@ -165,6 +165,7 @@ func (s *PartyTypeDefinitionService) Update(ctx context.Context, id uuid.UUID, i
 	existing.ValidationCEL = updatedValidationCEL
 	existing.EligibilityCEL = updatedEligibilityCEL
 	existing.ErrorMessageCEL = updatedErrorMessageCEL
+	existing.UpdatedAt = time.Now()
 	existing.Version++
 
 	if err := s.repo.Update(ctx, existing); err != nil {

--- a/services/party/service/party_type_service.go
+++ b/services/party/service/party_type_service.go
@@ -1,0 +1,213 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/party/adapters/persistence"
+	sharedcel "github.com/meridianhub/meridian/shared/pkg/cel"
+)
+
+// MaxAttributeSchemaSize is the maximum allowed size of an attribute schema in bytes (16KB).
+const MaxAttributeSchemaSize = 16 * 1024
+
+// Party type definition service errors
+var (
+	ErrPartyTypeRepoNil           = errors.New("party type definition repository cannot be nil")
+	ErrAttributeSchemaEmpty       = errors.New("attribute_schema must not be empty")
+	ErrAttributeSchemaTooBig      = errors.New("attribute_schema exceeds maximum size of 16KB")
+	ErrAttributeSchemaInvalidJSON = errors.New("attribute_schema must be a valid JSON Schema object")
+	ErrValidationCELInvalid       = errors.New("validation_cel expression is invalid")
+	ErrEligibilityCELInvalid      = errors.New("eligibility_cel expression is invalid")
+	ErrErrorMessageCELInvalid     = errors.New("error_message_cel expression is invalid")
+)
+
+// PartyTypeDefinitionRepository defines the interface for party type definition persistence.
+type PartyTypeDefinitionRepository interface {
+	Create(ctx context.Context, entity *persistence.PartyTypeDefinitionEntity) error
+	GetByID(ctx context.Context, id uuid.UUID) (*persistence.PartyTypeDefinitionEntity, error)
+	GetByTenantAndType(ctx context.Context, tenantID, partyType string) (*persistence.PartyTypeDefinitionEntity, error)
+	ListByTenant(ctx context.Context, tenantID string, partyType string) ([]*persistence.PartyTypeDefinitionEntity, error)
+	Update(ctx context.Context, entity *persistence.PartyTypeDefinitionEntity) error
+}
+
+// PartyTypeDefinitionService provides business logic for managing party type definitions.
+type PartyTypeDefinitionService struct {
+	repo        PartyTypeDefinitionRepository
+	celCompiler *sharedcel.Compiler
+}
+
+// NewPartyTypeDefinitionService creates a new party type definition service.
+func NewPartyTypeDefinitionService(repo PartyTypeDefinitionRepository) (*PartyTypeDefinitionService, error) {
+	if repo == nil {
+		return nil, ErrPartyTypeRepoNil
+	}
+
+	compiler, err := sharedcel.NewCompiler()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL compiler: %w", err)
+	}
+
+	return &PartyTypeDefinitionService{
+		repo:        repo,
+		celCompiler: compiler,
+	}, nil
+}
+
+// RegisterPartyTypeInput holds the input for registering a new party type definition.
+type RegisterPartyTypeInput struct {
+	TenantID        string
+	PartyType       string
+	AttributeSchema string
+	ValidationCEL   string
+	EligibilityCEL  string
+	ErrorMessageCEL string
+}
+
+// UpdatePartyTypeInput holds the input for updating a party type definition.
+type UpdatePartyTypeInput struct {
+	AttributeSchema string
+	ValidationCEL   string
+	EligibilityCEL  string
+	ErrorMessageCEL string
+	Version         int64
+}
+
+// Register creates a new party type definition after validating the JSON Schema and CEL expressions.
+func (s *PartyTypeDefinitionService) Register(ctx context.Context, input RegisterPartyTypeInput) (*persistence.PartyTypeDefinitionEntity, error) {
+	if err := s.validateAttributeSchema(input.AttributeSchema); err != nil {
+		return nil, err
+	}
+	if err := s.validateCELExpressions(input.ValidationCEL, input.EligibilityCEL, input.ErrorMessageCEL); err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	entity := &persistence.PartyTypeDefinitionEntity{
+		ID:              uuid.New(),
+		TenantID:        input.TenantID,
+		PartyType:       input.PartyType,
+		AttributeSchema: input.AttributeSchema,
+		ValidationCEL:   input.ValidationCEL,
+		EligibilityCEL:  input.EligibilityCEL,
+		ErrorMessageCEL: input.ErrorMessageCEL,
+		Version:         1,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+
+	if err := s.repo.Create(ctx, entity); err != nil {
+		return nil, err
+	}
+
+	return entity, nil
+}
+
+// GetByID retrieves a party type definition by ID.
+func (s *PartyTypeDefinitionService) GetByID(ctx context.Context, id uuid.UUID) (*persistence.PartyTypeDefinitionEntity, error) {
+	return s.repo.GetByID(ctx, id)
+}
+
+// GetByTenantAndType retrieves a party type definition by tenant and party type.
+func (s *PartyTypeDefinitionService) GetByTenantAndType(ctx context.Context, tenantID, partyType string) (*persistence.PartyTypeDefinitionEntity, error) {
+	return s.repo.GetByTenantAndType(ctx, tenantID, partyType)
+}
+
+// ListByTenant retrieves all party type definitions for a tenant, optionally filtered by party type.
+func (s *PartyTypeDefinitionService) ListByTenant(ctx context.Context, tenantID string, partyType string) ([]*persistence.PartyTypeDefinitionEntity, error) {
+	return s.repo.ListByTenant(ctx, tenantID, partyType)
+}
+
+// Update applies partial updates to a party type definition with optimistic locking.
+func (s *PartyTypeDefinitionService) Update(ctx context.Context, id uuid.UUID, input UpdatePartyTypeInput) (*persistence.PartyTypeDefinitionEntity, error) {
+	// Load current definition
+	existing, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	// Optimistic locking check
+	if input.Version > 0 && existing.Version != input.Version {
+		return nil, persistence.ErrPartyTypeVersionConflict
+	}
+
+	// Apply updates (non-empty fields overwrite existing)
+	if input.AttributeSchema != "" {
+		if err := s.validateAttributeSchema(input.AttributeSchema); err != nil {
+			return nil, err
+		}
+		existing.AttributeSchema = input.AttributeSchema
+	}
+
+	// For CEL fields, apply if provided (even if empty string means "clear")
+	updatedValidationCEL := existing.ValidationCEL
+	updatedEligibilityCEL := existing.EligibilityCEL
+	updatedErrorMessageCEL := existing.ErrorMessageCEL
+
+	if input.ValidationCEL != "" {
+		updatedValidationCEL = input.ValidationCEL
+	}
+	if input.EligibilityCEL != "" {
+		updatedEligibilityCEL = input.EligibilityCEL
+	}
+	if input.ErrorMessageCEL != "" {
+		updatedErrorMessageCEL = input.ErrorMessageCEL
+	}
+
+	if err := s.validateCELExpressions(updatedValidationCEL, updatedEligibilityCEL, updatedErrorMessageCEL); err != nil {
+		return nil, err
+	}
+
+	existing.ValidationCEL = updatedValidationCEL
+	existing.EligibilityCEL = updatedEligibilityCEL
+	existing.ErrorMessageCEL = updatedErrorMessageCEL
+	existing.Version++
+
+	if err := s.repo.Update(ctx, existing); err != nil {
+		return nil, err
+	}
+
+	return existing, nil
+}
+
+// validateAttributeSchema validates that the attribute schema is a valid non-empty JSON object
+// and within the 16KB size limit.
+func (s *PartyTypeDefinitionService) validateAttributeSchema(schema string) error {
+	if schema == "" {
+		return ErrAttributeSchemaEmpty
+	}
+	if len(schema) > MaxAttributeSchemaSize {
+		return ErrAttributeSchemaTooBig
+	}
+	// Must be a valid JSON object (JSON Schema is always a JSON object)
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(schema), &parsed); err != nil {
+		return fmt.Errorf("%w: %w", ErrAttributeSchemaInvalidJSON, err)
+	}
+	return nil
+}
+
+// validateCELExpressions compiles each non-empty CEL expression to catch syntax errors early.
+func (s *PartyTypeDefinitionService) validateCELExpressions(validationCEL, eligibilityCEL, errorMessageCEL string) error {
+	if validationCEL != "" {
+		if _, err := s.celCompiler.CompileValidation(validationCEL); err != nil {
+			return fmt.Errorf("%w: %w", ErrValidationCELInvalid, err)
+		}
+	}
+	if eligibilityCEL != "" {
+		if _, err := s.celCompiler.CompileEligibility(eligibilityCEL); err != nil {
+			return fmt.Errorf("%w: %w", ErrEligibilityCELInvalid, err)
+		}
+	}
+	if errorMessageCEL != "" {
+		// Error message CEL is a value expression (string output), use CompileValueExpression
+		if _, err := s.celCompiler.CompileValueExpression(errorMessageCEL); err != nil {
+			return fmt.Errorf("%w: %w", ErrErrorMessageCELInvalid, err)
+		}
+	}
+	return nil
+}

--- a/services/party/service/party_type_service_test.go
+++ b/services/party/service/party_type_service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -110,6 +111,8 @@ func testCtx() context.Context {
 	return tenant.WithTenant(context.Background(), tenant.TenantID(testTenantID))
 }
 
+func strPtr(s string) *string { return &s }
+
 // --- Constructor tests ---
 
 func TestNewPartyTypeDefinitionService_NilRepoReturnsError(t *testing.T) {
@@ -160,7 +163,7 @@ func TestRegister_SchemaTooBigReturnsError(t *testing.T) {
 	svc, _ := newTestPartyTypeService(t)
 
 	bigSchema := `{"type":"object","properties":{"k":{"type":"string","description":"` +
-		string(make([]byte, MaxAttributeSchemaSize)) + `"}}}`
+		strings.Repeat("a", MaxAttributeSchemaSize) + `"}}}`
 
 	_, err := svc.Register(testCtx(), RegisterPartyTypeInput{
 		TenantID:        testTenantID,
@@ -309,7 +312,7 @@ func TestUpdate_Success(t *testing.T) {
 
 	newSchema := `{"type":"object","properties":{"income":{"type":"number"}}}`
 	updated, err := svc.Update(ctx, id, UpdatePartyTypeInput{
-		AttributeSchema: newSchema,
+		AttributeSchema: strPtr(newSchema),
 		Version:         1,
 	})
 
@@ -335,7 +338,7 @@ func TestUpdate_VersionConflict(t *testing.T) {
 
 	// Client thinks version is 1, but DB has 2
 	_, err := svc.Update(ctx, id, UpdatePartyTypeInput{
-		AttributeSchema: validAttributeSchema,
+		AttributeSchema: strPtr(validAttributeSchema),
 		Version:         1,
 	})
 
@@ -347,7 +350,7 @@ func TestUpdate_NotFound(t *testing.T) {
 	svc, _ := newTestPartyTypeService(t)
 
 	_, err := svc.Update(testCtx(), uuid.New(), UpdatePartyTypeInput{
-		AttributeSchema: validAttributeSchema,
+		AttributeSchema: strPtr(validAttributeSchema),
 		Version:         1,
 	})
 
@@ -371,7 +374,7 @@ func TestUpdate_InvalidSchemaReturnsError(t *testing.T) {
 	}
 
 	_, err := svc.Update(ctx, id, UpdatePartyTypeInput{
-		AttributeSchema: "not valid json",
+		AttributeSchema: strPtr("not valid json"),
 		Version:         1,
 	})
 
@@ -395,9 +398,9 @@ func TestUpdate_PreservesExistingCELWhenNotProvided(t *testing.T) {
 		UpdatedAt:       time.Now(),
 	}
 
-	// Update only AttributeSchema, not ValidationCEL
+	// Update only AttributeSchema, not ValidationCEL (nil ValidationCEL means preserve existing)
 	updated, err := svc.Update(ctx, id, UpdatePartyTypeInput{
-		AttributeSchema: `{"type":"object","properties":{"income":{"type":"number"}}}`,
+		AttributeSchema: strPtr(`{"type":"object","properties":{"income":{"type":"number"}}}`),
 		Version:         1,
 	})
 

--- a/services/party/service/party_type_service_test.go
+++ b/services/party/service/party_type_service_test.go
@@ -1,0 +1,406 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/party/adapters/persistence"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// testTenantID is already defined in grpc_service_integration_test.go
+	validAttributeSchema = `{"type":"object","properties":{"annual_income":{"type":"string"}}}`
+)
+
+// mockPartyTypeDefinitionRepository is a simple in-memory mock for testing.
+type mockPartyTypeDefinitionRepository struct {
+	entities  map[uuid.UUID]*persistence.PartyTypeDefinitionEntity
+	createErr error
+	getErr    error
+	updateErr error
+}
+
+func newMockPartyTypeRepo() *mockPartyTypeDefinitionRepository {
+	return &mockPartyTypeDefinitionRepository{
+		entities: make(map[uuid.UUID]*persistence.PartyTypeDefinitionEntity),
+	}
+}
+
+func (m *mockPartyTypeDefinitionRepository) Create(_ context.Context, entity *persistence.PartyTypeDefinitionEntity) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	// Check duplicate
+	for _, e := range m.entities {
+		if e.TenantID == entity.TenantID && e.PartyType == entity.PartyType {
+			return persistence.ErrPartyTypeDefinitionExists
+		}
+	}
+	cp := *entity
+	m.entities[entity.ID] = &cp
+	return nil
+}
+
+func (m *mockPartyTypeDefinitionRepository) GetByID(_ context.Context, id uuid.UUID) (*persistence.PartyTypeDefinitionEntity, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	e, ok := m.entities[id]
+	if !ok {
+		return nil, persistence.ErrPartyTypeDefinitionNotFound
+	}
+	cp := *e
+	return &cp, nil
+}
+
+func (m *mockPartyTypeDefinitionRepository) GetByTenantAndType(_ context.Context, tenantID, partyType string) (*persistence.PartyTypeDefinitionEntity, error) {
+	for _, e := range m.entities {
+		if e.TenantID == tenantID && e.PartyType == partyType {
+			cp := *e
+			return &cp, nil
+		}
+	}
+	return nil, persistence.ErrPartyTypeDefinitionNotFound
+}
+
+func (m *mockPartyTypeDefinitionRepository) ListByTenant(_ context.Context, tenantID string, partyType string) ([]*persistence.PartyTypeDefinitionEntity, error) {
+	var result []*persistence.PartyTypeDefinitionEntity
+	for _, e := range m.entities {
+		if e.TenantID == tenantID {
+			if partyType == "" || e.PartyType == partyType {
+				cp := *e
+				result = append(result, &cp)
+			}
+		}
+	}
+	return result, nil
+}
+
+func (m *mockPartyTypeDefinitionRepository) Update(_ context.Context, entity *persistence.PartyTypeDefinitionEntity) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	existing, ok := m.entities[entity.ID]
+	if !ok {
+		return persistence.ErrPartyTypeDefinitionNotFound
+	}
+	if existing.Version != entity.Version-1 {
+		return persistence.ErrPartyTypeVersionConflict
+	}
+	cp := *entity
+	m.entities[entity.ID] = &cp
+	return nil
+}
+
+func newTestPartyTypeService(t *testing.T) (*PartyTypeDefinitionService, *mockPartyTypeDefinitionRepository) {
+	t.Helper()
+	repo := newMockPartyTypeRepo()
+	svc, err := NewPartyTypeDefinitionService(repo)
+	require.NoError(t, err)
+	return svc, repo
+}
+
+func testCtx() context.Context {
+	return tenant.WithTenant(context.Background(), tenant.TenantID(testTenantID))
+}
+
+// --- Constructor tests ---
+
+func TestNewPartyTypeDefinitionService_NilRepoReturnsError(t *testing.T) {
+	_, err := NewPartyTypeDefinitionService(nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrPartyTypeRepoNil))
+}
+
+func TestNewPartyTypeDefinitionService_Success(t *testing.T) {
+	svc, _ := newTestPartyTypeService(t)
+	assert.NotNil(t, svc)
+}
+
+// --- Register tests ---
+
+func TestRegister_Success(t *testing.T) {
+	svc, _ := newTestPartyTypeService(t)
+	ctx := testCtx()
+
+	entity, err := svc.Register(ctx, RegisterPartyTypeInput{
+		TenantID:        testTenantID,
+		PartyType:       "PERSON",
+		AttributeSchema: validAttributeSchema,
+	})
+
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, entity.ID)
+	assert.Equal(t, testTenantID, entity.TenantID)
+	assert.Equal(t, "PERSON", entity.PartyType)
+	assert.Equal(t, validAttributeSchema, entity.AttributeSchema)
+	assert.Equal(t, int64(1), entity.Version)
+}
+
+func TestRegister_EmptySchemaReturnsError(t *testing.T) {
+	svc, _ := newTestPartyTypeService(t)
+
+	_, err := svc.Register(testCtx(), RegisterPartyTypeInput{
+		TenantID:        testTenantID,
+		PartyType:       "PERSON",
+		AttributeSchema: "",
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAttributeSchemaEmpty))
+}
+
+func TestRegister_SchemaTooBigReturnsError(t *testing.T) {
+	svc, _ := newTestPartyTypeService(t)
+
+	bigSchema := `{"type":"object","properties":{"k":{"type":"string","description":"` +
+		string(make([]byte, MaxAttributeSchemaSize)) + `"}}}`
+
+	_, err := svc.Register(testCtx(), RegisterPartyTypeInput{
+		TenantID:        testTenantID,
+		PartyType:       "PERSON",
+		AttributeSchema: bigSchema,
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAttributeSchemaTooBig))
+}
+
+func TestRegister_InvalidJSONSchemaReturnsError(t *testing.T) {
+	svc, _ := newTestPartyTypeService(t)
+
+	_, err := svc.Register(testCtx(), RegisterPartyTypeInput{
+		TenantID:        testTenantID,
+		PartyType:       "PERSON",
+		AttributeSchema: "not valid json",
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAttributeSchemaInvalidJSON))
+}
+
+func TestRegister_NonObjectJSONSchemaReturnsError(t *testing.T) {
+	svc, _ := newTestPartyTypeService(t)
+
+	// Valid JSON but not an object (array)
+	_, err := svc.Register(testCtx(), RegisterPartyTypeInput{
+		TenantID:        testTenantID,
+		PartyType:       "PERSON",
+		AttributeSchema: `["not", "an", "object"]`,
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAttributeSchemaInvalidJSON))
+}
+
+func TestRegister_InvalidValidationCELReturnsError(t *testing.T) {
+	svc, _ := newTestPartyTypeService(t)
+
+	_, err := svc.Register(testCtx(), RegisterPartyTypeInput{
+		TenantID:        testTenantID,
+		PartyType:       "PERSON",
+		AttributeSchema: validAttributeSchema,
+		ValidationCEL:   "this is not valid CEL !!@#$",
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrValidationCELInvalid))
+}
+
+func TestRegister_InvalidEligibilityCELReturnsError(t *testing.T) {
+	svc, _ := newTestPartyTypeService(t)
+
+	_, err := svc.Register(testCtx(), RegisterPartyTypeInput{
+		TenantID:        testTenantID,
+		PartyType:       "PERSON",
+		AttributeSchema: validAttributeSchema,
+		EligibilityCEL:  "invalid !! CEL",
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrEligibilityCELInvalid))
+}
+
+func TestRegister_ValidCELExpressions(t *testing.T) {
+	svc, _ := newTestPartyTypeService(t)
+
+	entity, err := svc.Register(testCtx(), RegisterPartyTypeInput{
+		TenantID:        testTenantID,
+		PartyType:       "PERSON",
+		AttributeSchema: validAttributeSchema,
+		ValidationCEL:   `attributes["annual_income"] != ""`,
+		EligibilityCEL:  `party["type"] == "PERSON"`,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, `attributes["annual_income"] != ""`, entity.ValidationCEL)
+}
+
+func TestRegister_DuplicateReturnsError(t *testing.T) {
+	svc, _ := newTestPartyTypeService(t)
+
+	input := RegisterPartyTypeInput{
+		TenantID:        testTenantID,
+		PartyType:       "PERSON",
+		AttributeSchema: validAttributeSchema,
+	}
+
+	_, err := svc.Register(testCtx(), input)
+	require.NoError(t, err)
+
+	_, err = svc.Register(testCtx(), input)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, persistence.ErrPartyTypeDefinitionExists))
+}
+
+// --- GetByID tests ---
+
+func TestGetByID_Success(t *testing.T) {
+	svc, repo := newTestPartyTypeService(t)
+	ctx := testCtx()
+
+	id := uuid.New()
+	repo.entities[id] = &persistence.PartyTypeDefinitionEntity{
+		ID:              id,
+		TenantID:        testTenantID,
+		PartyType:       "PERSON",
+		AttributeSchema: validAttributeSchema,
+		Version:         1,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+
+	entity, err := svc.GetByID(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, id, entity.ID)
+}
+
+func TestGetByID_NotFound(t *testing.T) {
+	svc, _ := newTestPartyTypeService(t)
+
+	_, err := svc.GetByID(testCtx(), uuid.New())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, persistence.ErrPartyTypeDefinitionNotFound))
+}
+
+// --- Update tests ---
+
+func TestUpdate_Success(t *testing.T) {
+	svc, repo := newTestPartyTypeService(t)
+	ctx := testCtx()
+
+	id := uuid.New()
+	repo.entities[id] = &persistence.PartyTypeDefinitionEntity{
+		ID:              id,
+		TenantID:        testTenantID,
+		PartyType:       "PERSON",
+		AttributeSchema: validAttributeSchema,
+		ValidationCEL:   "",
+		Version:         1,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+
+	newSchema := `{"type":"object","properties":{"income":{"type":"number"}}}`
+	updated, err := svc.Update(ctx, id, UpdatePartyTypeInput{
+		AttributeSchema: newSchema,
+		Version:         1,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), updated.Version)
+	assert.Equal(t, newSchema, updated.AttributeSchema)
+}
+
+func TestUpdate_VersionConflict(t *testing.T) {
+	svc, repo := newTestPartyTypeService(t)
+	ctx := testCtx()
+
+	id := uuid.New()
+	repo.entities[id] = &persistence.PartyTypeDefinitionEntity{
+		ID:              id,
+		TenantID:        testTenantID,
+		PartyType:       "PERSON",
+		AttributeSchema: validAttributeSchema,
+		Version:         2, // DB is at version 2
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+
+	// Client thinks version is 1, but DB has 2
+	_, err := svc.Update(ctx, id, UpdatePartyTypeInput{
+		AttributeSchema: validAttributeSchema,
+		Version:         1,
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, persistence.ErrPartyTypeVersionConflict))
+}
+
+func TestUpdate_NotFound(t *testing.T) {
+	svc, _ := newTestPartyTypeService(t)
+
+	_, err := svc.Update(testCtx(), uuid.New(), UpdatePartyTypeInput{
+		AttributeSchema: validAttributeSchema,
+		Version:         1,
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, persistence.ErrPartyTypeDefinitionNotFound))
+}
+
+func TestUpdate_InvalidSchemaReturnsError(t *testing.T) {
+	svc, repo := newTestPartyTypeService(t)
+	ctx := testCtx()
+
+	id := uuid.New()
+	repo.entities[id] = &persistence.PartyTypeDefinitionEntity{
+		ID:              id,
+		TenantID:        testTenantID,
+		PartyType:       "PERSON",
+		AttributeSchema: validAttributeSchema,
+		Version:         1,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+
+	_, err := svc.Update(ctx, id, UpdatePartyTypeInput{
+		AttributeSchema: "not valid json",
+		Version:         1,
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAttributeSchemaInvalidJSON))
+}
+
+func TestUpdate_PreservesExistingCELWhenNotProvided(t *testing.T) {
+	svc, repo := newTestPartyTypeService(t)
+	ctx := testCtx()
+
+	id := uuid.New()
+	repo.entities[id] = &persistence.PartyTypeDefinitionEntity{
+		ID:              id,
+		TenantID:        testTenantID,
+		PartyType:       "PERSON",
+		AttributeSchema: validAttributeSchema,
+		ValidationCEL:   `attributes["annual_income"] != ""`,
+		Version:         1,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+
+	// Update only AttributeSchema, not ValidationCEL
+	updated, err := svc.Update(ctx, id, UpdatePartyTypeInput{
+		AttributeSchema: `{"type":"object","properties":{"income":{"type":"number"}}}`,
+		Version:         1,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, `attributes["annual_income"] != ""`, updated.ValidationCEL)
+}

--- a/utilities/atlas-loader/main.go
+++ b/utilities/atlas-loader/main.go
@@ -67,6 +67,7 @@ func main() {
 		// Party service for customer/organization identity management
 		modelList = []interface{}{
 			&partypersistence.PartyEntity{},
+			&partypersistence.PartyTypeDefinitionEntity{},
 		}
 	case schemaPaymentOrder:
 		// Payment order service for payment processing


### PR DESCRIPTION
## Summary

- Adds `PartyTypeDefinitionEntity` GORM model with optimistic locking via `version` field
- Adds `PartyTypeDefinitionRepository` with Create, GetByID, GetByTenantAndType, ListByTenant, Update (distinguishes NotFound vs VersionConflict)
- Adds `PartyTypeDefinitionService` with JSON Schema validation (16KB limit, must be JSON object) and CEL expression compilation via `shared/pkg/cel`
- Adds gRPC handlers for RegisterPartyType, GetPartyType, ListPartyTypes, UpdatePartyType with field mask support on Update
- Atlas migrations split across two files per CockroachDB column-visibility rules (table in `20260221000003`, unique index in `20260221000004`)
- Wires repository and service into `cmd/main.go`; registers entity in `atlas-loader`

## Changes

- `services/party/adapters/persistence/party_type_definition_entity.go` — GORM entity
- `services/party/adapters/persistence/party_type_definition_repository.go` — repository with optimistic locking
- `services/party/adapters/persistence/party_type_definition_repository_test.go` — 11 integration tests (postgres testcontainer)
- `services/party/service/party_type_service.go` — service with schema + CEL validation
- `services/party/service/party_type_service_test.go` — 18 unit tests (in-memory mock)
- `services/party/service/grpc_party_type.go` — gRPC handler implementations
- `services/party/service/grpc_service.go` — adds `partyTypeService` field to `Service` struct
- `services/party/migrations/20260221000003_party_type_definition.sql` — table DDL
- `services/party/migrations/20260221000004_party_type_definition_index.sql` — unique index DDL
- `services/party/migrations/atlas.sum` — updated hash
- `utilities/atlas-loader/main.go` — registers `PartyTypeDefinitionEntity` under party schema
- `services/party/cmd/main.go` — wires repo, service, and `WithPartyTypeDefinitionService`

## Testing

- 18 service unit tests with in-memory mock repository (no containers needed, fast)
- 11 repository integration tests against postgres testcontainer covering Create, GetByID, GetByTenantAndType, ListByTenant (with/without filter), Update (success, version conflict, not found)
- All tests passing

## Task

structured-mapping-layer.4 — Implement PartyTypeDefinition CRUD service layer