### PR TITLE
feat(reference-data): add MappingDefinition CRUD (structured-mapping-layer.8)

### DIFF
--- a/services/reference-data/cmd/main.go
+++ b/services/reference-data/cmd/main.go
@@ -14,14 +14,17 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
 	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
 	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
 	"github.com/meridianhub/meridian/services/reference-data/accounttype"
 	refcel "github.com/meridianhub/meridian/services/reference-data/cel"
 	"github.com/meridianhub/meridian/services/reference-data/handler"
+	"github.com/meridianhub/meridian/services/reference-data/mapping"
 	"github.com/meridianhub/meridian/services/reference-data/node"
 	"github.com/meridianhub/meridian/services/reference-data/registry"
 	"github.com/meridianhub/meridian/services/reference-data/saga"
+	sharedcel "github.com/meridianhub/meridian/shared/pkg/cel"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
 	"github.com/meridianhub/meridian/shared/platform/env"
@@ -121,6 +124,18 @@ func run(logger *slog.Logger) error {
 	}
 	logger.Info("account type registry initialized")
 
+	// Create mapping repository and validator
+	mappingRepo := mapping.NewPostgresRepository(dbPool)
+	mappingCELCompiler, err := sharedcel.NewCompiler()
+	if err != nil {
+		return fmt.Errorf("failed to create mapping CEL compiler: %w", err)
+	}
+	mappingValidator, err := mapping.NewValidator(mappingCELCompiler)
+	if err != nil {
+		return fmt.Errorf("failed to create mapping validator: %w", err)
+	}
+	logger.Info("mapping repository and validator initialized")
+
 	// Create gRPC service handlers
 	refDataSvc, err := handler.NewService(instrumentRegistry, compiler, logger)
 	if err != nil {
@@ -137,6 +152,11 @@ func run(logger *slog.Logger) error {
 	accountTypeSvc, err := handler.NewAccountTypeService(accountTypeRegistry, instrumentRegistry, compiler, logger)
 	if err != nil {
 		return fmt.Errorf("failed to create account type service: %w", err)
+	}
+
+	mappingSvc, err := handler.NewMappingService(mappingRepo, mappingValidator, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create mapping service: %w", err)
 	}
 
 	logger.Info("gRPC service handlers initialized")
@@ -158,6 +178,7 @@ func run(logger *slog.Logger) error {
 	referencedatav1.RegisterNodeServiceServer(grpcServer, nodeSvc)
 	referencedatav1.RegisterAccountTypeRegistryServiceServer(grpcServer, accountTypeSvc)
 	sagav1.RegisterSagaRegistryServiceServer(grpcServer, sagaSvc)
+	mappingv1.RegisterMappingServiceServer(grpcServer, mappingSvc)
 
 	// Register health check service
 	healthServer := health.NewServer()

--- a/services/reference-data/handler/mapping_handler.go
+++ b/services/reference-data/handler/mapping_handler.go
@@ -13,6 +13,7 @@ import (
 
 	pb "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
 	"github.com/meridianhub/meridian/services/reference-data/mapping"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
 // MappingService implements MappingServiceServer for MappingDefinition CRUD.
@@ -237,6 +238,7 @@ func (s *MappingService) mapDomainError(ctx context.Context, err error, operatio
 	}
 
 	errorMappings := []errorEntry{
+		{tenant.ErrMissingTenantContext, codes.Unauthenticated, "missing tenant context", slog.LevelWarn},
 		{mapping.ErrNotFound, codes.NotFound, "mapping definition not found", slog.LevelWarn},
 		{mapping.ErrNotDraft, codes.FailedPrecondition, "mapping definition must be in DRAFT status", slog.LevelWarn},
 		{mapping.ErrNotActive, codes.FailedPrecondition, "mapping definition must be in ACTIVE status", slog.LevelWarn},
@@ -249,6 +251,7 @@ func (s *MappingService) mapDomainError(ctx context.Context, err error, operatio
 		{mapping.ErrBatchTargetPathRequired, codes.InvalidArgument, "batch_target_path required", slog.LevelWarn},
 		{mapping.ErrIdempotencyConfig, codes.InvalidArgument, "invalid idempotency config", slog.LevelWarn},
 		{mapping.ErrOptimisticLock, codes.Aborted, "mapping definition was modified concurrently", slog.LevelWarn},
+		{mapping.ErrInvalidStatusTransition, codes.FailedPrecondition, "invalid status transition", slog.LevelWarn},
 	}
 
 	for _, m := range errorMappings {

--- a/services/reference-data/handler/mapping_handler.go
+++ b/services/reference-data/handler/mapping_handler.go
@@ -1,0 +1,472 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	"github.com/meridianhub/meridian/services/reference-data/mapping"
+)
+
+// MappingService implements MappingServiceServer for MappingDefinition CRUD.
+type MappingService struct {
+	pb.UnimplementedMappingServiceServer
+	repo      mapping.Repository
+	validator *mapping.Validator
+	logger    *slog.Logger
+}
+
+// ErrMappingRepoNil is returned when a nil repository is provided.
+var ErrMappingRepoNil = errors.New("mapping repository cannot be nil")
+
+// NewMappingService creates a new MappingService.
+func NewMappingService(repo mapping.Repository, validator *mapping.Validator, logger *slog.Logger) (*MappingService, error) {
+	if repo == nil {
+		return nil, ErrMappingRepoNil
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	}
+	return &MappingService{
+		repo:      repo,
+		validator: validator,
+		logger:    logger,
+	}, nil
+}
+
+// CreateMapping creates a new mapping definition in DRAFT status.
+func (s *MappingService) CreateMapping(ctx context.Context, req *pb.CreateMappingRequest) (*pb.CreateMappingResponse, error) {
+	def := &mapping.Definition{
+		Name:                  req.GetName(),
+		TargetService:         req.GetTargetService(),
+		TargetRPC:             req.GetTargetRpc(),
+		Version:               int(req.GetVersion()),
+		ExternalSchema:        req.GetExternalSchema(),
+		Fields:                protoFieldsToCorrespondences(req.GetFields()),
+		InboundComputed:       protoComputedFieldsToDomain(req.GetInboundComputedFields()),
+		OutboundComputed:      protoComputedFieldsToDomain(req.GetOutboundComputedFields()),
+		InboundValidationCEL:  req.GetInboundValidationCel(),
+		OutboundValidationCEL: req.GetOutboundValidationCel(),
+		IsBatch:               req.GetIsBatch(),
+		BatchTargetPath:       req.GetBatchTargetPath(),
+		Idempotency:           protoIdempotencyToDomain(req.GetIdempotency()),
+	}
+
+	if s.validator != nil {
+		if err := s.validator.Validate(def); err != nil {
+			return nil, s.mapDomainError(ctx, err, "CreateMapping", def.Name)
+		}
+	}
+
+	if err := s.repo.Create(ctx, def); err != nil {
+		return nil, s.mapDomainError(ctx, err, "CreateMapping", def.Name)
+	}
+
+	s.logger.Info("mapping created", "id", def.ID, "name", def.Name)
+
+	return &pb.CreateMappingResponse{
+		Mapping: mappingToProto(def),
+	}, nil
+}
+
+// GetMapping retrieves a mapping definition by ID.
+func (s *MappingService) GetMapping(ctx context.Context, req *pb.GetMappingRequest) (*pb.GetMappingResponse, error) {
+	id, err := uuid.Parse(req.GetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid id: %v", err)
+	}
+
+	def, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, s.mapDomainError(ctx, err, "GetMapping", req.GetId())
+	}
+
+	return &pb.GetMappingResponse{
+		Mapping: mappingToProto(def),
+	}, nil
+}
+
+// ListMappings returns mapping definitions for the tenant with optional filtering.
+func (s *MappingService) ListMappings(ctx context.Context, req *pb.ListMappingsRequest) (*pb.ListMappingsResponse, error) {
+	statusFilter := protoStatusToDomainMapping(req.GetStatus())
+	pageSize := int(req.GetPageSize())
+	if pageSize <= 0 {
+		pageSize = DefaultPageSize
+	}
+	if pageSize > MaxPageSize {
+		pageSize = MaxPageSize
+	}
+
+	defs, total, err := s.repo.ListByTenant(ctx, statusFilter, req.GetTargetService(), pageSize, req.GetPageToken())
+	if err != nil {
+		s.logger.Error("failed to list mappings", "error", err)
+		return nil, status.Errorf(codes.Internal, "failed to list mappings: %v", err)
+	}
+
+	mappings := make([]*pb.MappingDefinition, len(defs))
+	for i, def := range defs {
+		mappings[i] = mappingToProto(def)
+	}
+
+	var nextPageToken string
+	if len(defs) == pageSize {
+		nextPageToken = defs[len(defs)-1].ID.String()
+	}
+
+	return &pb.ListMappingsResponse{
+		Mappings:      mappings,
+		NextPageToken: nextPageToken,
+		TotalCount:    int32(total),
+	}, nil
+}
+
+// UpdateMapping modifies an existing DRAFT mapping definition.
+func (s *MappingService) UpdateMapping(ctx context.Context, req *pb.UpdateMappingRequest) (*pb.UpdateMappingResponse, error) {
+	id, err := uuid.Parse(req.GetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid id: %v", err)
+	}
+
+	existing, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, s.mapDomainError(ctx, err, "UpdateMapping", req.GetId())
+	}
+
+	// Apply field mask or full replace
+	updated := applyUpdateMask(existing, req)
+
+	if s.validator != nil {
+		if err := s.validator.Validate(updated); err != nil {
+			return nil, s.mapDomainError(ctx, err, "UpdateMapping", req.GetId())
+		}
+	}
+
+	if err := s.repo.Update(ctx, updated, existing.UpdatedAt); err != nil {
+		return nil, s.mapDomainError(ctx, err, "UpdateMapping", req.GetId())
+	}
+
+	s.logger.Info("mapping updated", "id", id)
+
+	return &pb.UpdateMappingResponse{
+		Mapping: mappingToProto(updated),
+	}, nil
+}
+
+// DeleteMapping removes a mapping definition. Returns FAILED_PRECONDITION if ACTIVE.
+func (s *MappingService) DeleteMapping(ctx context.Context, req *pb.DeleteMappingRequest) (*pb.DeleteMappingResponse, error) {
+	id, err := uuid.Parse(req.GetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid id: %v", err)
+	}
+
+	if err := s.repo.Delete(ctx, id); err != nil {
+		return nil, s.mapDomainError(ctx, err, "DeleteMapping", req.GetId())
+	}
+
+	s.logger.Info("mapping deleted", "id", id)
+
+	return &pb.DeleteMappingResponse{Id: req.GetId()}, nil
+}
+
+// --- Helpers ---
+
+func applyUpdateMask(existing *mapping.Definition, req *pb.UpdateMappingRequest) *mapping.Definition {
+	updated := *existing
+
+	mask := req.GetUpdateMask()
+	if mask == nil || len(mask.GetPaths()) == 0 {
+		// Full replace semantics: update all provided fields.
+		if req.GetName() != "" {
+			updated.Name = req.GetName()
+		}
+		updated.ExternalSchema = req.GetExternalSchema()
+		updated.Fields = protoFieldsToCorrespondences(req.GetFields())
+		updated.InboundComputed = protoComputedFieldsToDomain(req.GetInboundComputedFields())
+		updated.OutboundComputed = protoComputedFieldsToDomain(req.GetOutboundComputedFields())
+		updated.InboundValidationCEL = req.GetInboundValidationCel()
+		updated.OutboundValidationCEL = req.GetOutboundValidationCel()
+		updated.IsBatch = req.GetIsBatch()
+		updated.BatchTargetPath = req.GetBatchTargetPath()
+		updated.Idempotency = protoIdempotencyToDomain(req.GetIdempotency())
+		return &updated
+	}
+
+	// FieldMask partial update.
+	for _, path := range mask.GetPaths() {
+		switch path {
+		case "name":
+			updated.Name = req.GetName()
+		case "external_schema":
+			updated.ExternalSchema = req.GetExternalSchema()
+		case "fields":
+			updated.Fields = protoFieldsToCorrespondences(req.GetFields())
+		case "inbound_computed_fields":
+			updated.InboundComputed = protoComputedFieldsToDomain(req.GetInboundComputedFields())
+		case "outbound_computed_fields":
+			updated.OutboundComputed = protoComputedFieldsToDomain(req.GetOutboundComputedFields())
+		case "inbound_validation_cel":
+			updated.InboundValidationCEL = req.GetInboundValidationCel()
+		case "outbound_validation_cel":
+			updated.OutboundValidationCEL = req.GetOutboundValidationCel()
+		case "is_batch":
+			updated.IsBatch = req.GetIsBatch()
+		case "batch_target_path":
+			updated.BatchTargetPath = req.GetBatchTargetPath()
+		case "idempotency":
+			updated.Idempotency = protoIdempotencyToDomain(req.GetIdempotency())
+		}
+	}
+
+	return &updated
+}
+
+// mapDomainError converts mapping domain errors to gRPC status codes.
+func (s *MappingService) mapDomainError(ctx context.Context, err error, operation, identifier string) error {
+	type errorEntry struct {
+		sentinel error
+		code     codes.Code
+		message  string
+		logLevel slog.Level
+	}
+
+	errorMappings := []errorEntry{
+		{mapping.ErrNotFound, codes.NotFound, "mapping definition not found", slog.LevelWarn},
+		{mapping.ErrNotDraft, codes.FailedPrecondition, "mapping definition must be in DRAFT status", slog.LevelWarn},
+		{mapping.ErrNotActive, codes.FailedPrecondition, "mapping definition must be in ACTIVE status", slog.LevelWarn},
+		{mapping.ErrAlreadyExists, codes.AlreadyExists, "mapping definition already exists", slog.LevelWarn},
+		{mapping.ErrInvalidCEL, codes.InvalidArgument, "invalid CEL expression", slog.LevelWarn},
+		{mapping.ErrInvalidJSONSchema, codes.InvalidArgument, "invalid JSON Schema", slog.LevelWarn},
+		{mapping.ErrInvalidGjsonPath, codes.InvalidArgument, "invalid gjson path", slog.LevelWarn},
+		{mapping.ErrDuplicateExternalPath, codes.InvalidArgument, "duplicate external_path in fields", slog.LevelWarn},
+		{mapping.ErrDuplicateInternalPath, codes.InvalidArgument, "duplicate internal_path in fields", slog.LevelWarn},
+		{mapping.ErrBatchTargetPathRequired, codes.InvalidArgument, "batch_target_path required", slog.LevelWarn},
+		{mapping.ErrIdempotencyConfig, codes.InvalidArgument, "invalid idempotency config", slog.LevelWarn},
+		{mapping.ErrOptimisticLock, codes.Aborted, "mapping definition was modified concurrently", slog.LevelWarn},
+	}
+
+	for _, m := range errorMappings {
+		if errors.Is(err, m.sentinel) {
+			s.logger.Log(ctx, m.logLevel, m.message,
+				"operation", operation,
+				"identifier", identifier,
+				"error", err)
+			return status.Errorf(m.code, "%s: %v", m.message, err)
+		}
+	}
+
+	s.logger.ErrorContext(ctx, "internal error",
+		"operation", operation,
+		"identifier", identifier,
+		"error", err)
+	return status.Errorf(codes.Internal, "internal error: %v", err)
+}
+
+// --- Proto <-> Domain conversions ---
+
+func mappingToProto(def *mapping.Definition) *pb.MappingDefinition {
+	if def == nil {
+		return nil
+	}
+
+	return &pb.MappingDefinition{
+		Id:                     def.ID.String(),
+		TenantId:               def.TenantID,
+		Name:                   def.Name,
+		TargetService:          def.TargetService,
+		TargetRpc:              def.TargetRPC,
+		Version:                int32(def.Version),
+		Status:                 domainStatusToProtoMapping(def.Status),
+		ExternalSchema:         def.ExternalSchema,
+		Fields:                 correspondencesToProto(def.Fields),
+		InboundComputedFields:  computedFieldsToProto(def.InboundComputed),
+		OutboundComputedFields: computedFieldsToProto(def.OutboundComputed),
+		InboundValidationCel:   def.InboundValidationCEL,
+		OutboundValidationCel:  def.OutboundValidationCEL,
+		IsBatch:                def.IsBatch,
+		BatchTargetPath:        def.BatchTargetPath,
+		Idempotency:            domainIdempotencyToProto(def.Idempotency),
+		CreatedAt:              timestamppb.New(def.CreatedAt),
+		UpdatedAt:              timestamppb.New(def.UpdatedAt),
+	}
+}
+
+func domainStatusToProtoMapping(s mapping.Status) pb.MappingStatus {
+	switch s {
+	case mapping.StatusDraft:
+		return pb.MappingStatus_MAPPING_STATUS_DRAFT
+	case mapping.StatusActive:
+		return pb.MappingStatus_MAPPING_STATUS_ACTIVE
+	case mapping.StatusDeprecated:
+		return pb.MappingStatus_MAPPING_STATUS_DEPRECATED
+	default:
+		return pb.MappingStatus_MAPPING_STATUS_UNSPECIFIED
+	}
+}
+
+func protoStatusToDomainMapping(s pb.MappingStatus) mapping.Status {
+	switch s {
+	case pb.MappingStatus_MAPPING_STATUS_UNSPECIFIED:
+		return ""
+	case pb.MappingStatus_MAPPING_STATUS_DRAFT:
+		return mapping.StatusDraft
+	case pb.MappingStatus_MAPPING_STATUS_ACTIVE:
+		return mapping.StatusActive
+	case pb.MappingStatus_MAPPING_STATUS_DEPRECATED:
+		return mapping.StatusDeprecated
+	default:
+		return ""
+	}
+}
+
+func protoFieldsToCorrespondences(fields []*pb.FieldCorrespondence) []mapping.FieldCorrespondence {
+	if fields == nil {
+		return nil
+	}
+	result := make([]mapping.FieldCorrespondence, len(fields))
+	for i, f := range fields {
+		result[i] = mapping.FieldCorrespondence{
+			ExternalPath: f.GetExternalPath(),
+			InternalPath: f.GetInternalPath(),
+			Transform:    protoTransformToDomain(f.GetTransform()),
+		}
+	}
+	return result
+}
+
+func correspondencesToProto(fields []mapping.FieldCorrespondence) []*pb.FieldCorrespondence {
+	if fields == nil {
+		return nil
+	}
+	result := make([]*pb.FieldCorrespondence, len(fields))
+	for i, f := range fields {
+		result[i] = &pb.FieldCorrespondence{
+			ExternalPath: f.ExternalPath,
+			InternalPath: f.InternalPath,
+			Transform:    domainTransformToProto(f.Transform),
+		}
+	}
+	return result
+}
+
+func protoTransformToDomain(t *pb.FieldTransform) *mapping.FieldTransform {
+	if t == nil {
+		return nil
+	}
+	ft := &mapping.FieldTransform{}
+	switch v := t.GetTransform().(type) {
+	case *pb.FieldTransform_Cel:
+		ft.CEL = &mapping.CelTransform{
+			InboundCEL:  v.Cel.GetInboundCel(),
+			OutboundCEL: v.Cel.GetOutboundCel(),
+		}
+	case *pb.FieldTransform_EnumMapping:
+		ft.EnumMapping = &mapping.EnumMapping{
+			Values:           v.EnumMapping.GetValues(),
+			Fallback:         v.EnumMapping.GetFallback(),
+			OutboundFallback: v.EnumMapping.GetOutboundFallback(),
+		}
+	case *pb.FieldTransform_DateFormat:
+		ft.DateFormat = v.DateFormat
+	case *pb.FieldTransform_DefaultValue:
+		ft.DefaultValue = v.DefaultValue
+	case *pb.FieldTransform_AttributeFlatten:
+		ft.AttributeFlatten = &mapping.AttributeFlatten{
+			SourceKeys:  v.AttributeFlatten.GetSourceKeys(),
+			TargetField: v.AttributeFlatten.GetTargetField(),
+		}
+	}
+	return ft
+}
+
+func domainTransformToProto(t *mapping.FieldTransform) *pb.FieldTransform {
+	if t == nil {
+		return nil
+	}
+	ft := &pb.FieldTransform{}
+	switch {
+	case t.CEL != nil:
+		ft.Transform = &pb.FieldTransform_Cel{
+			Cel: &pb.CelTransform{
+				InboundCel:  t.CEL.InboundCEL,
+				OutboundCel: t.CEL.OutboundCEL,
+			},
+		}
+	case t.EnumMapping != nil:
+		ft.Transform = &pb.FieldTransform_EnumMapping{
+			EnumMapping: &pb.EnumMapping{
+				Values:           t.EnumMapping.Values,
+				Fallback:         t.EnumMapping.Fallback,
+				OutboundFallback: t.EnumMapping.OutboundFallback,
+			},
+		}
+	case t.DateFormat != "":
+		ft.Transform = &pb.FieldTransform_DateFormat{DateFormat: t.DateFormat}
+	case t.DefaultValue != "":
+		ft.Transform = &pb.FieldTransform_DefaultValue{DefaultValue: t.DefaultValue}
+	case t.AttributeFlatten != nil:
+		ft.Transform = &pb.FieldTransform_AttributeFlatten{
+			AttributeFlatten: &pb.AttributeFlatten{
+				SourceKeys:  t.AttributeFlatten.SourceKeys,
+				TargetField: t.AttributeFlatten.TargetField,
+			},
+		}
+	}
+	return ft
+}
+
+func protoComputedFieldsToDomain(fields []*pb.ComputedField) []mapping.ComputedField {
+	if fields == nil {
+		return nil
+	}
+	result := make([]mapping.ComputedField, len(fields))
+	for i, f := range fields {
+		result[i] = mapping.ComputedField{
+			TargetPath:    f.GetTargetPath(),
+			CELExpression: f.GetCelExpression(),
+		}
+	}
+	return result
+}
+
+func computedFieldsToProto(fields []mapping.ComputedField) []*pb.ComputedField {
+	if fields == nil {
+		return nil
+	}
+	result := make([]*pb.ComputedField, len(fields))
+	for i, f := range fields {
+		result[i] = &pb.ComputedField{
+			TargetPath:    f.TargetPath,
+			CelExpression: f.CELExpression,
+		}
+	}
+	return result
+}
+
+func protoIdempotencyToDomain(cfg *pb.IdempotencyConfig) *mapping.IdempotencyConfig {
+	if cfg == nil {
+		return nil
+	}
+	return &mapping.IdempotencyConfig{
+		SourceSelector:    cfg.GetSourceSelector(),
+		UseContentHash:    cfg.GetUseContentHash(),
+		ContentHashFields: cfg.GetContentHashFields(),
+	}
+}
+
+func domainIdempotencyToProto(cfg *mapping.IdempotencyConfig) *pb.IdempotencyConfig {
+	if cfg == nil {
+		return nil
+	}
+	return &pb.IdempotencyConfig{
+		SourceSelector:    cfg.SourceSelector,
+		UseContentHash:    cfg.UseContentHash,
+		ContentHashFields: cfg.ContentHashFields,
+	}
+}

--- a/services/reference-data/handler/mapping_handler.go
+++ b/services/reference-data/handler/mapping_handler.go
@@ -107,8 +107,7 @@ func (s *MappingService) ListMappings(ctx context.Context, req *pb.ListMappingsR
 
 	defs, total, err := s.repo.ListByTenant(ctx, statusFilter, req.GetTargetService(), pageSize, req.GetPageToken())
 	if err != nil {
-		s.logger.Error("failed to list mappings", "error", err)
-		return nil, status.Errorf(codes.Internal, "failed to list mappings: %v", err)
+		return nil, s.mapDomainError(ctx, err, "ListMappings", "")
 	}
 
 	mappings := make([]*pb.MappingDefinition, len(defs))

--- a/services/reference-data/handler/mapping_handler_test.go
+++ b/services/reference-data/handler/mapping_handler_test.go
@@ -1,0 +1,290 @@
+package handler_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	handlerpkg "github.com/meridianhub/meridian/services/reference-data/handler"
+	"github.com/meridianhub/meridian/services/reference-data/mapping"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// --- In-memory stub repository ---
+
+type stubMappingRepo struct {
+	defs   map[uuid.UUID]*mapping.Definition
+	failOn string
+}
+
+func newStubRepo() *stubMappingRepo {
+	return &stubMappingRepo{defs: make(map[uuid.UUID]*mapping.Definition)}
+}
+
+func (r *stubMappingRepo) Create(ctx context.Context, def *mapping.Definition) error {
+	if r.failOn == "create" {
+		return mapping.ErrAlreadyExists
+	}
+	if def.ID == uuid.Nil {
+		def.ID = uuid.New()
+	}
+	def.Status = mapping.StatusDraft
+	def.CreatedAt = time.Now()
+	def.UpdatedAt = time.Now()
+
+	tid, _ := tenant.FromContext(ctx)
+	def.TenantID = tid.String()
+	r.defs[def.ID] = def
+	return nil
+}
+
+func (r *stubMappingRepo) GetByID(_ context.Context, id uuid.UUID) (*mapping.Definition, error) {
+	if r.failOn == "get" {
+		return nil, mapping.ErrNotFound
+	}
+	def, ok := r.defs[id]
+	if !ok {
+		return nil, mapping.ErrNotFound
+	}
+	return def, nil
+}
+
+func (r *stubMappingRepo) GetLatestActive(_ context.Context, _ string) (*mapping.Definition, error) {
+	return nil, mapping.ErrNotFound
+}
+
+func (r *stubMappingRepo) ListByTenant(_ context.Context, _ mapping.Status, _ string, _ int, _ string) ([]*mapping.Definition, int, error) {
+	results := make([]*mapping.Definition, 0, len(r.defs))
+	for _, d := range r.defs {
+		results = append(results, d)
+	}
+	return results, len(results), nil
+}
+
+func (r *stubMappingRepo) Update(_ context.Context, def *mapping.Definition, _ time.Time) error {
+	if r.failOn == "update" {
+		return mapping.ErrNotDraft
+	}
+	existing, ok := r.defs[def.ID]
+	if !ok {
+		return mapping.ErrNotFound
+	}
+	existing.Name = def.Name
+	existing.ExternalSchema = def.ExternalSchema
+	existing.Fields = def.Fields
+	existing.UpdatedAt = time.Now()
+	return nil
+}
+
+func (r *stubMappingRepo) UpdateStatus(_ context.Context, id uuid.UUID, newStatus mapping.Status) error {
+	def, ok := r.defs[id]
+	if !ok {
+		return mapping.ErrNotFound
+	}
+	def.Status = newStatus
+	return nil
+}
+
+func (r *stubMappingRepo) Delete(_ context.Context, id uuid.UUID) error {
+	if r.failOn == "delete" {
+		return mapping.ErrNotActive
+	}
+	def, ok := r.defs[id]
+	if !ok {
+		return mapping.ErrNotFound
+	}
+	if def.Status == mapping.StatusActive {
+		return mapping.ErrNotActive
+	}
+	delete(r.defs, id)
+	return nil
+}
+
+// --- Helpers ---
+
+func newMappingService(t *testing.T, repo mapping.Repository) *handlerpkg.MappingService {
+	t.Helper()
+	svc, err := handlerpkg.NewMappingService(repo, nil, nil)
+	require.NoError(t, err)
+	return svc
+}
+
+func tenantCtx() context.Context {
+	return tenant.WithTenant(context.Background(), tenant.MustNewTenantID("testtenant01"))
+}
+
+// --- Tests ---
+
+func TestMappingService_CreateMapping_Success(t *testing.T) {
+	repo := newStubRepo()
+	svc := newMappingService(t, repo)
+
+	resp, err := svc.CreateMapping(tenantCtx(), &pb.CreateMappingRequest{
+		Name:          "my-mapping",
+		TargetService: "meridian.payment_order.v1.PaymentOrderService",
+		TargetRpc:     "InitiatePaymentOrder",
+		Version:       1,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.GetMapping().GetId())
+	assert.Equal(t, "my-mapping", resp.GetMapping().GetName())
+	assert.Equal(t, pb.MappingStatus_MAPPING_STATUS_DRAFT, resp.GetMapping().GetStatus())
+}
+
+func TestMappingService_CreateMapping_AlreadyExists(t *testing.T) {
+	repo := newStubRepo()
+	repo.failOn = "create"
+	svc := newMappingService(t, repo)
+
+	_, err := svc.CreateMapping(tenantCtx(), &pb.CreateMappingRequest{
+		Name:          "dup",
+		TargetService: "svc",
+		TargetRpc:     "Rpc",
+		Version:       1,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err))
+}
+
+func TestMappingService_GetMapping_NotFound(t *testing.T) {
+	repo := newStubRepo()
+	svc := newMappingService(t, repo)
+
+	_, err := svc.GetMapping(tenantCtx(), &pb.GetMappingRequest{Id: uuid.New().String()})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestMappingService_GetMapping_InvalidUUID(t *testing.T) {
+	repo := newStubRepo()
+	svc := newMappingService(t, repo)
+
+	_, err := svc.GetMapping(tenantCtx(), &pb.GetMappingRequest{Id: "not-a-uuid"})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestMappingService_GetMapping_Success(t *testing.T) {
+	repo := newStubRepo()
+	svc := newMappingService(t, repo)
+	ctx := tenantCtx()
+
+	// Create first
+	createResp, err := svc.CreateMapping(ctx, &pb.CreateMappingRequest{
+		Name:          "get-test",
+		TargetService: "svc",
+		TargetRpc:     "Rpc",
+		Version:       1,
+	})
+	require.NoError(t, err)
+
+	getResp, err := svc.GetMapping(ctx, &pb.GetMappingRequest{Id: createResp.GetMapping().GetId()})
+	require.NoError(t, err)
+	assert.Equal(t, createResp.GetMapping().GetId(), getResp.GetMapping().GetId())
+}
+
+func TestMappingService_ListMappings(t *testing.T) {
+	repo := newStubRepo()
+	svc := newMappingService(t, repo)
+	ctx := tenantCtx()
+
+	for i := 1; i <= 3; i++ {
+		_, err := svc.CreateMapping(ctx, &pb.CreateMappingRequest{
+			Name:          "m-" + string(rune('0'+i)),
+			TargetService: "svc",
+			TargetRpc:     "Rpc",
+			Version:       1,
+		})
+		require.NoError(t, err)
+	}
+
+	resp, err := svc.ListMappings(ctx, &pb.ListMappingsRequest{})
+	require.NoError(t, err)
+	assert.Len(t, resp.GetMappings(), 3)
+	assert.Equal(t, int32(3), resp.GetTotalCount())
+}
+
+func TestMappingService_UpdateMapping_Success(t *testing.T) {
+	repo := newStubRepo()
+	svc := newMappingService(t, repo)
+	ctx := tenantCtx()
+
+	createResp, err := svc.CreateMapping(ctx, &pb.CreateMappingRequest{
+		Name:          "to-update",
+		TargetService: "svc",
+		TargetRpc:     "Rpc",
+		Version:       1,
+	})
+	require.NoError(t, err)
+
+	updateResp, err := svc.UpdateMapping(ctx, &pb.UpdateMappingRequest{
+		Id:             createResp.GetMapping().GetId(),
+		Name:           "updated-name",
+		ExternalSchema: `{"type":"object"}`,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "updated-name", updateResp.GetMapping().GetName())
+}
+
+func TestMappingService_UpdateMapping_NotFound(t *testing.T) {
+	repo := newStubRepo()
+	svc := newMappingService(t, repo)
+
+	_, err := svc.UpdateMapping(tenantCtx(), &pb.UpdateMappingRequest{
+		Id:   uuid.New().String(),
+		Name: "x",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestMappingService_DeleteMapping_Success(t *testing.T) {
+	repo := newStubRepo()
+	svc := newMappingService(t, repo)
+	ctx := tenantCtx()
+
+	createResp, err := svc.CreateMapping(ctx, &pb.CreateMappingRequest{
+		Name:          "to-delete",
+		TargetService: "svc",
+		TargetRpc:     "Rpc",
+		Version:       1,
+	})
+	require.NoError(t, err)
+
+	delResp, err := svc.DeleteMapping(ctx, &pb.DeleteMappingRequest{Id: createResp.GetMapping().GetId()})
+	require.NoError(t, err)
+	assert.Equal(t, createResp.GetMapping().GetId(), delResp.GetId())
+}
+
+func TestMappingService_DeleteMapping_Active_Fails(t *testing.T) {
+	repo := newStubRepo()
+	svc := newMappingService(t, repo)
+	ctx := tenantCtx()
+
+	createResp, err := svc.CreateMapping(ctx, &pb.CreateMappingRequest{
+		Name:          "active-mapping",
+		TargetService: "svc",
+		TargetRpc:     "Rpc",
+		Version:       1,
+	})
+	require.NoError(t, err)
+
+	id, _ := uuid.Parse(createResp.GetMapping().GetId())
+	require.NoError(t, repo.UpdateStatus(ctx, id, mapping.StatusActive))
+
+	_, err = svc.DeleteMapping(ctx, &pb.DeleteMappingRequest{Id: createResp.GetMapping().GetId()})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+func TestMappingService_NewMappingService_NilRepo(t *testing.T) {
+	_, err := handlerpkg.NewMappingService(nil, nil, nil)
+	require.Error(t, err)
+}

--- a/services/reference-data/mapping/domain.go
+++ b/services/reference-data/mapping/domain.go
@@ -1,0 +1,162 @@
+// Package mapping provides domain types and persistence for MappingDefinition CRUD.
+package mapping
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Status represents the lifecycle state of a MappingDefinition.
+type Status string
+
+// Status constants for the MappingDefinition lifecycle.
+const (
+	StatusDraft      Status = "DRAFT"
+	StatusActive     Status = "ACTIVE"
+	StatusDeprecated Status = "DEPRECATED"
+)
+
+// CelTransform holds bidirectional CEL expressions for a field.
+type CelTransform struct {
+	InboundCEL  string `json:"inbound_cel,omitempty"`
+	OutboundCEL string `json:"outbound_cel,omitempty"`
+}
+
+// EnumMapping maps external enum values to internal enum values bidirectionally.
+type EnumMapping struct {
+	Values           map[string]string `json:"values,omitempty"`
+	Fallback         string            `json:"fallback,omitempty"`
+	OutboundFallback string            `json:"outbound_fallback,omitempty"`
+}
+
+// AttributeFlatten merges multiple source keys into a single target map field.
+type AttributeFlatten struct {
+	SourceKeys  []string `json:"source_keys"`
+	TargetField string   `json:"target_field"`
+}
+
+// FieldTransform defines a single field transformation variant.
+// Exactly one of the variant fields should be set.
+type FieldTransform struct {
+	CEL              *CelTransform     `json:"cel,omitempty"`
+	EnumMapping      *EnumMapping      `json:"enum_mapping,omitempty"`
+	DateFormat       string            `json:"date_format,omitempty"`
+	DefaultValue     string            `json:"default_value,omitempty"`
+	AttributeFlatten *AttributeFlatten `json:"attribute_flatten,omitempty"`
+}
+
+// FieldCorrespondence maps a single external field to an internal proto field.
+type FieldCorrespondence struct {
+	ExternalPath string          `json:"external_path"`
+	InternalPath string          `json:"internal_path"`
+	Transform    *FieldTransform `json:"transform,omitempty"`
+}
+
+// ComputedField derives a field value from a CEL expression.
+type ComputedField struct {
+	TargetPath    string `json:"target_path"`
+	CELExpression string `json:"cel_expression"`
+}
+
+// IdempotencyConfig controls how idempotency keys are derived.
+type IdempotencyConfig struct {
+	SourceSelector    string   `json:"source_selector,omitempty"`
+	UseContentHash    bool     `json:"use_content_hash,omitempty"`
+	ContentHashFields []string `json:"content_hash_fields,omitempty"`
+}
+
+// Definition represents a MappingDefinition in the domain layer.
+type Definition struct {
+	ID                    uuid.UUID
+	TenantID              string
+	Name                  string
+	TargetService         string
+	TargetRPC             string
+	Version               int
+	Status                Status
+	ExternalSchema        string
+	Fields                []FieldCorrespondence
+	InboundComputed       []ComputedField
+	OutboundComputed      []ComputedField
+	InboundValidationCEL  string
+	OutboundValidationCEL string
+	IsBatch               bool
+	BatchTargetPath       string
+	Idempotency           *IdempotencyConfig
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+}
+
+// MarshalFields serializes the fields slice to JSON for storage.
+func MarshalFields(fields []FieldCorrespondence) (json.RawMessage, error) {
+	if fields == nil {
+		return json.RawMessage("[]"), nil
+	}
+	b, err := json.Marshal(fields)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// UnmarshalFields deserializes the fields JSON from storage.
+func UnmarshalFields(data []byte) ([]FieldCorrespondence, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var fields []FieldCorrespondence
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil, err
+	}
+	return fields, nil
+}
+
+// MarshalComputedFields serializes a computed fields slice to JSON for storage.
+func MarshalComputedFields(fields []ComputedField) (json.RawMessage, error) {
+	if fields == nil {
+		return json.RawMessage("[]"), nil
+	}
+	b, err := json.Marshal(fields)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// UnmarshalComputedFields deserializes a computed fields JSON from storage.
+func UnmarshalComputedFields(data []byte) ([]ComputedField, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var fields []ComputedField
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil, err
+	}
+	return fields, nil
+}
+
+// MarshalIdempotency serializes the IdempotencyConfig to JSON for storage.
+func MarshalIdempotency(cfg *IdempotencyConfig) (json.RawMessage, error) {
+	if cfg == nil {
+		return json.RawMessage("null"), nil
+	}
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// UnmarshalIdempotency deserializes the IdempotencyConfig JSON from storage.
+func UnmarshalIdempotency(data []byte) (*IdempotencyConfig, error) {
+	if len(data) == 0 {
+		return nil, nil //nolint:nilnil // nil config with nil error signals "no idempotency config stored"
+	}
+	var cfg IdempotencyConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}

--- a/services/reference-data/mapping/domain.go
+++ b/services/reference-data/mapping/domain.go
@@ -2,6 +2,7 @@
 package mapping
 
 import (
+	"bytes"
 	"encoding/json"
 	"time"
 
@@ -17,6 +18,21 @@ const (
 	StatusActive     Status = "ACTIVE"
 	StatusDeprecated Status = "DEPRECATED"
 )
+
+// CanTransitionTo returns true if transitioning from s to next is a valid lifecycle step.
+// Allowed transitions: DRAFT → ACTIVE, ACTIVE → DEPRECATED.
+func (s Status) CanTransitionTo(next Status) bool {
+	switch s {
+	case StatusDraft:
+		return next == StatusActive
+	case StatusActive:
+		return next == StatusDeprecated
+	case StatusDeprecated:
+		return false
+	default:
+		return false
+	}
+}
 
 // CelTransform holds bidirectional CEL expressions for a field.
 type CelTransform struct {
@@ -151,11 +167,12 @@ func MarshalIdempotency(cfg *IdempotencyConfig) (json.RawMessage, error) {
 
 // UnmarshalIdempotency deserializes the IdempotencyConfig JSON from storage.
 func UnmarshalIdempotency(data []byte) (*IdempotencyConfig, error) {
-	if len(data) == 0 {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
 		return nil, nil //nolint:nilnil // nil config with nil error signals "no idempotency config stored"
 	}
 	var cfg IdempotencyConfig
-	if err := json.Unmarshal(data, &cfg); err != nil {
+	if err := json.Unmarshal(trimmed, &cfg); err != nil {
 		return nil, err
 	}
 	return &cfg, nil

--- a/services/reference-data/mapping/errors.go
+++ b/services/reference-data/mapping/errors.go
@@ -42,6 +42,9 @@ var (
 	// ErrOptimisticLock is returned when an optimistic-lock conflict is detected on update.
 	ErrOptimisticLock = errors.New("mapping definition was modified by another transaction")
 
+	// ErrInvalidStatusTransition is returned when a status transition violates the lifecycle.
+	ErrInvalidStatusTransition = errors.New("invalid status transition")
+
 	// ErrTransformVariantRequired is returned when a FieldTransform has no variant set.
 	ErrTransformVariantRequired = errors.New("at least one transform variant must be set")
 

--- a/services/reference-data/mapping/errors.go
+++ b/services/reference-data/mapping/errors.go
@@ -53,4 +53,7 @@ var (
 
 	// ErrCELCompilerNil is returned when a nil CEL compiler is provided.
 	ErrCELCompilerNil = errors.New("cel compiler cannot be nil")
+
+	// ErrRequiredField is returned when a required field is empty or missing.
+	ErrRequiredField = errors.New("required field is missing")
 )

--- a/services/reference-data/mapping/errors.go
+++ b/services/reference-data/mapping/errors.go
@@ -1,0 +1,53 @@
+package mapping
+
+import "errors"
+
+var (
+	// ErrNotFound is returned when a mapping definition is not found.
+	ErrNotFound = errors.New("mapping definition not found")
+
+	// ErrNotDraft is returned when an operation requires DRAFT status.
+	ErrNotDraft = errors.New("mapping definition must be in DRAFT status")
+
+	// ErrNotActive is returned when deprecation requires ACTIVE status.
+	ErrNotActive = errors.New("mapping definition must be in ACTIVE status")
+
+	// ErrAlreadyExists is returned when a mapping with the same (tenant, name, version) already exists.
+	ErrAlreadyExists = errors.New("mapping definition already exists")
+
+	// ErrInvalidCEL is returned when a CEL expression fails to compile.
+	ErrInvalidCEL = errors.New("invalid CEL expression")
+
+	// ErrInvalidJSON is returned when provided JSON is malformed.
+	ErrInvalidJSON = errors.New("invalid JSON")
+
+	// ErrInvalidJSONSchema is returned when external_schema is not a valid JSON Schema.
+	ErrInvalidJSONSchema = errors.New("invalid JSON Schema")
+
+	// ErrInvalidGjsonPath is returned when a gjson path is syntactically invalid.
+	ErrInvalidGjsonPath = errors.New("invalid gjson path")
+
+	// ErrDuplicateExternalPath is returned when two fields share an external_path.
+	ErrDuplicateExternalPath = errors.New("duplicate external_path in fields")
+
+	// ErrDuplicateInternalPath is returned when two fields share an internal_path.
+	ErrDuplicateInternalPath = errors.New("duplicate internal_path in fields")
+
+	// ErrBatchTargetPathRequired is returned when is_batch is true but batch_target_path is empty.
+	ErrBatchTargetPathRequired = errors.New("batch_target_path is required when is_batch is true")
+
+	// ErrIdempotencyConfig is returned when an IdempotencyConfig is self-contradictory.
+	ErrIdempotencyConfig = errors.New("invalid idempotency configuration")
+
+	// ErrOptimisticLock is returned when an optimistic-lock conflict is detected on update.
+	ErrOptimisticLock = errors.New("mapping definition was modified by another transaction")
+
+	// ErrTransformVariantRequired is returned when a FieldTransform has no variant set.
+	ErrTransformVariantRequired = errors.New("at least one transform variant must be set")
+
+	// ErrTransformVariantConflict is returned when a FieldTransform has more than one variant set.
+	ErrTransformVariantConflict = errors.New("at most one transform variant may be set")
+
+	// ErrCELCompilerNil is returned when a nil CEL compiler is provided.
+	ErrCELCompilerNil = errors.New("cel compiler cannot be nil")
+)

--- a/services/reference-data/mapping/repository.go
+++ b/services/reference-data/mapping/repository.go
@@ -377,9 +377,12 @@ func (r *PostgresRepository) UpdateStatus(ctx context.Context, id uuid.UUID, new
 
 		now := time.Now().UTC()
 		updateQuery := `UPDATE mapping_definition SET status = $1, updated_at = $2 WHERE id = $3`
-		_, err := tx.Exec(ctx, updateQuery, string(newStatus), now, id)
+		result, err := tx.Exec(ctx, updateQuery, string(newStatus), now, id)
 		if err != nil {
 			return fmt.Errorf("failed to update mapping status: %w", err)
+		}
+		if result.RowsAffected() == 0 {
+			return ErrNotFound
 		}
 		return nil
 	})

--- a/services/reference-data/mapping/repository.go
+++ b/services/reference-data/mapping/repository.go
@@ -263,7 +263,7 @@ func (r *PostgresRepository) ListByTenant(ctx context.Context, statusFilter Stat
 				created_at, updated_at
 			FROM mapping_definition
 			WHERE 1=1%s
-			ORDER BY name, version DESC
+			ORDER BY id
 			LIMIT $%d`, whereClause, argIdx)
 
 		rows, err := tx.Query(ctx, listQuery, args...)
@@ -358,6 +358,7 @@ func (r *PostgresRepository) Update(ctx context.Context, def *Definition, expect
 }
 
 // UpdateStatus transitions the status of a mapping definition.
+// Enforces lifecycle: DRAFT → ACTIVE → DEPRECATED.
 func (r *PostgresRepository) UpdateStatus(ctx context.Context, id uuid.UUID, newStatus Status) error {
 	return r.withWriteTx(ctx, func(tx pgx.Tx) error {
 		var currentStatus string
@@ -367,6 +368,11 @@ func (r *PostgresRepository) UpdateStatus(ctx context.Context, id uuid.UUID, new
 				return ErrNotFound
 			}
 			return fmt.Errorf("failed to fetch mapping status: %w", err)
+		}
+
+		current := Status(currentStatus)
+		if !current.CanTransitionTo(newStatus) {
+			return fmt.Errorf("%w: %s → %s", ErrInvalidStatusTransition, current, newStatus)
 		}
 
 		now := time.Now().UTC()
@@ -380,11 +386,12 @@ func (r *PostgresRepository) UpdateStatus(ctx context.Context, id uuid.UUID, new
 }
 
 // Delete removes a DRAFT or DEPRECATED mapping definition. Returns ErrNotActive if ACTIVE.
+// Uses SELECT FOR UPDATE to prevent a concurrent activation racing the delete.
 func (r *PostgresRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	return r.withWriteTx(ctx, func(tx pgx.Tx) error {
 		var currentStatus string
-		checkQuery := sqlFetchStatus
-		if err := tx.QueryRow(ctx, checkQuery, id).Scan(&currentStatus); err != nil {
+		lockQuery := `SELECT status FROM mapping_definition WHERE id = $1 FOR UPDATE`
+		if err := tx.QueryRow(ctx, lockQuery, id).Scan(&currentStatus); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return ErrNotFound
 			}

--- a/services/reference-data/mapping/repository.go
+++ b/services/reference-data/mapping/repository.go
@@ -1,0 +1,509 @@
+package mapping
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// Repository provides CRUD operations for MappingDefinition.
+type Repository interface {
+	Create(ctx context.Context, def *Definition) error
+	GetByID(ctx context.Context, id uuid.UUID) (*Definition, error)
+	GetLatestActive(ctx context.Context, name string) (*Definition, error)
+	ListByTenant(ctx context.Context, statusFilter Status, targetServiceFilter string, pageSize int, pageToken string) ([]*Definition, int, error)
+	Update(ctx context.Context, def *Definition, expectedUpdatedAt time.Time) error
+	UpdateStatus(ctx context.Context, id uuid.UUID, newStatus Status) error
+	Delete(ctx context.Context, id uuid.UUID) error
+}
+
+// sqlFetchStatus is a reusable query for checking the current status of a mapping by ID.
+const sqlFetchStatus = `SELECT status FROM mapping_definition WHERE id = $1`
+
+// PostgresRepository implements Repository using PostgreSQL via pgx.
+type PostgresRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresRepository creates a new PostgreSQL-backed mapping repository.
+func NewPostgresRepository(pool *pgxpool.Pool) *PostgresRepository {
+	return &PostgresRepository{pool: pool}
+}
+
+// setSearchPath sets the PostgreSQL search_path for the transaction.
+func (r *PostgresRepository) setSearchPath(ctx context.Context, tx pgx.Tx) error {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return tenant.ErrMissingTenantContext
+	}
+
+	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
+	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	_, err := tx.Exec(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to set tenant schema scope: %w", err)
+	}
+
+	return nil
+}
+
+// withReadTx executes fn within a read transaction with tenant scope.
+func (r *PostgresRepository) withReadTx(ctx context.Context, fn func(pgx.Tx) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+// withWriteTx executes fn within a write transaction with tenant scope.
+func (r *PostgresRepository) withWriteTx(ctx context.Context, fn func(pgx.Tx) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+// Create inserts a new mapping definition in DRAFT status.
+func (r *PostgresRepository) Create(ctx context.Context, def *Definition) error {
+	return r.withWriteTx(ctx, func(tx pgx.Tx) error {
+		if def.ID == uuid.Nil {
+			def.ID = uuid.New()
+		}
+		now := time.Now().UTC()
+		def.CreatedAt = now
+		def.UpdatedAt = now
+		def.Status = StatusDraft
+
+		tenantID, ok := tenant.FromContext(ctx)
+		if !ok {
+			return tenant.ErrMissingTenantContext
+		}
+		def.TenantID = tenantID.String()
+
+		fieldsJSON, err := MarshalFields(def.Fields)
+		if err != nil {
+			return fmt.Errorf("failed to marshal fields: %w", err)
+		}
+		inboundJSON, err := MarshalComputedFields(def.InboundComputed)
+		if err != nil {
+			return fmt.Errorf("failed to marshal inbound_computed_fields: %w", err)
+		}
+		outboundJSON, err := MarshalComputedFields(def.OutboundComputed)
+		if err != nil {
+			return fmt.Errorf("failed to marshal outbound_computed_fields: %w", err)
+		}
+		idempotencyJSON, err := MarshalIdempotency(def.Idempotency)
+		if err != nil {
+			return fmt.Errorf("failed to marshal idempotency: %w", err)
+		}
+
+		query := `
+			INSERT INTO mapping_definition (
+				id, tenant_id, name, target_service, target_rpc, version, status,
+				external_schema, fields, inbound_computed_fields, outbound_computed_fields,
+				inbound_validation_cel, outbound_validation_cel,
+				is_batch, batch_target_path, idempotency,
+				created_at, updated_at
+			) VALUES (
+				$1, $2, $3, $4, $5, $6, $7,
+				$8, $9, $10, $11,
+				$12, $13,
+				$14, $15, $16,
+				$17, $18
+			)`
+
+		_, err = tx.Exec(ctx, query,
+			def.ID, def.TenantID, def.Name, def.TargetService, def.TargetRPC, def.Version, string(def.Status),
+			nullString(def.ExternalSchema), fieldsJSON, inboundJSON, outboundJSON,
+			nullString(def.InboundValidationCEL), nullString(def.OutboundValidationCEL),
+			def.IsBatch, nullString(def.BatchTargetPath), idempotencyJSON,
+			def.CreatedAt, def.UpdatedAt,
+		)
+		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				return ErrAlreadyExists
+			}
+			return fmt.Errorf("failed to insert mapping definition: %w", err)
+		}
+		return nil
+	})
+}
+
+// GetByID retrieves a mapping definition by its UUID.
+func (r *PostgresRepository) GetByID(ctx context.Context, id uuid.UUID) (*Definition, error) {
+	var result *Definition
+	err := r.withReadTx(ctx, func(tx pgx.Tx) error {
+		def, err := r.getByIDInTx(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		result = def
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (r *PostgresRepository) getByIDInTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*Definition, error) {
+	query := `
+		SELECT id, tenant_id, name, target_service, target_rpc, version, status,
+			external_schema, fields, inbound_computed_fields, outbound_computed_fields,
+			inbound_validation_cel, outbound_validation_cel,
+			is_batch, batch_target_path, idempotency,
+			created_at, updated_at
+		FROM mapping_definition
+		WHERE id = $1`
+	row := tx.QueryRow(ctx, query, id)
+	return r.scanRow(row)
+}
+
+// GetLatestActive retrieves the latest ACTIVE mapping definition by name.
+func (r *PostgresRepository) GetLatestActive(ctx context.Context, name string) (*Definition, error) {
+	var result *Definition
+	err := r.withReadTx(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, tenant_id, name, target_service, target_rpc, version, status,
+				external_schema, fields, inbound_computed_fields, outbound_computed_fields,
+				inbound_validation_cel, outbound_validation_cel,
+				is_batch, batch_target_path, idempotency,
+				created_at, updated_at
+			FROM mapping_definition
+			WHERE name = $1 AND status = 'ACTIVE'
+			ORDER BY version DESC
+			LIMIT 1`
+		row := tx.QueryRow(ctx, query, name)
+		def, err := r.scanRow(row)
+		if err != nil {
+			return err
+		}
+		result = def
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// ListByTenant returns mapping definitions for the current tenant with optional filtering.
+// Returns (results, totalCount, error).
+func (r *PostgresRepository) ListByTenant(ctx context.Context, statusFilter Status, targetServiceFilter string, pageSize int, pageToken string) ([]*Definition, int, error) {
+	var results []*Definition
+	var total int
+
+	err := r.withReadTx(ctx, func(tx pgx.Tx) error {
+		args := []any{}
+		whereClause := ""
+		argIdx := 1
+
+		if statusFilter != "" {
+			whereClause += fmt.Sprintf(" AND status = $%d", argIdx)
+			args = append(args, string(statusFilter))
+			argIdx++
+		}
+		if targetServiceFilter != "" {
+			whereClause += fmt.Sprintf(" AND target_service = $%d", argIdx)
+			args = append(args, targetServiceFilter)
+			argIdx++
+		}
+
+		// Count query
+		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM mapping_definition WHERE 1=1%s", whereClause)
+		if err := tx.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {
+			return fmt.Errorf("failed to count mappings: %w", err)
+		}
+
+		// Cursor pagination: pageToken is the last id seen
+		if pageToken != "" {
+			whereClause += fmt.Sprintf(" AND id > $%d", argIdx)
+			args = append(args, pageToken)
+			argIdx++
+		}
+
+		if pageSize <= 0 {
+			pageSize = 20
+		}
+		args = append(args, pageSize)
+
+		listQuery := fmt.Sprintf(`
+			SELECT id, tenant_id, name, target_service, target_rpc, version, status,
+				external_schema, fields, inbound_computed_fields, outbound_computed_fields,
+				inbound_validation_cel, outbound_validation_cel,
+				is_batch, batch_target_path, idempotency,
+				created_at, updated_at
+			FROM mapping_definition
+			WHERE 1=1%s
+			ORDER BY name, version DESC
+			LIMIT $%d`, whereClause, argIdx)
+
+		rows, err := tx.Query(ctx, listQuery, args...)
+		if err != nil {
+			return fmt.Errorf("failed to list mappings: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			def, err := r.scanRows(rows)
+			if err != nil {
+				return err
+			}
+			results = append(results, def)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return results, total, nil
+}
+
+// Update applies field updates to an existing DRAFT mapping definition using optimistic locking.
+func (r *PostgresRepository) Update(ctx context.Context, def *Definition, expectedUpdatedAt time.Time) error {
+	return r.withWriteTx(ctx, func(tx pgx.Tx) error {
+		// Verify it exists and is DRAFT
+		var currentStatus string
+		checkQuery := sqlFetchStatus
+		if err := tx.QueryRow(ctx, checkQuery, def.ID).Scan(&currentStatus); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to fetch mapping for update: %w", err)
+		}
+		if currentStatus != string(StatusDraft) {
+			return ErrNotDraft
+		}
+
+		fieldsJSON, err := MarshalFields(def.Fields)
+		if err != nil {
+			return fmt.Errorf("failed to marshal fields: %w", err)
+		}
+		inboundJSON, err := MarshalComputedFields(def.InboundComputed)
+		if err != nil {
+			return fmt.Errorf("failed to marshal inbound_computed_fields: %w", err)
+		}
+		outboundJSON, err := MarshalComputedFields(def.OutboundComputed)
+		if err != nil {
+			return fmt.Errorf("failed to marshal outbound_computed_fields: %w", err)
+		}
+		idempotencyJSON, err := MarshalIdempotency(def.Idempotency)
+		if err != nil {
+			return fmt.Errorf("failed to marshal idempotency: %w", err)
+		}
+
+		now := time.Now().UTC()
+		updateQuery := `
+			UPDATE mapping_definition SET
+				name = $1,
+				external_schema = $2,
+				fields = $3,
+				inbound_computed_fields = $4,
+				outbound_computed_fields = $5,
+				inbound_validation_cel = $6,
+				outbound_validation_cel = $7,
+				is_batch = $8,
+				batch_target_path = $9,
+				idempotency = $10,
+				updated_at = $11
+			WHERE id = $12 AND updated_at = $13`
+
+		result, err := tx.Exec(ctx, updateQuery,
+			def.Name,
+			nullString(def.ExternalSchema),
+			fieldsJSON, inboundJSON, outboundJSON,
+			nullString(def.InboundValidationCEL), nullString(def.OutboundValidationCEL),
+			def.IsBatch, nullString(def.BatchTargetPath), idempotencyJSON,
+			now,
+			def.ID, expectedUpdatedAt,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to update mapping definition: %w", err)
+		}
+		if result.RowsAffected() == 0 {
+			return ErrOptimisticLock
+		}
+		def.UpdatedAt = now
+		return nil
+	})
+}
+
+// UpdateStatus transitions the status of a mapping definition.
+func (r *PostgresRepository) UpdateStatus(ctx context.Context, id uuid.UUID, newStatus Status) error {
+	return r.withWriteTx(ctx, func(tx pgx.Tx) error {
+		var currentStatus string
+		checkQuery := sqlFetchStatus
+		if err := tx.QueryRow(ctx, checkQuery, id).Scan(&currentStatus); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to fetch mapping status: %w", err)
+		}
+
+		now := time.Now().UTC()
+		updateQuery := `UPDATE mapping_definition SET status = $1, updated_at = $2 WHERE id = $3`
+		_, err := tx.Exec(ctx, updateQuery, string(newStatus), now, id)
+		if err != nil {
+			return fmt.Errorf("failed to update mapping status: %w", err)
+		}
+		return nil
+	})
+}
+
+// Delete removes a DRAFT or DEPRECATED mapping definition. Returns ErrNotActive if ACTIVE.
+func (r *PostgresRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	return r.withWriteTx(ctx, func(tx pgx.Tx) error {
+		var currentStatus string
+		checkQuery := sqlFetchStatus
+		if err := tx.QueryRow(ctx, checkQuery, id).Scan(&currentStatus); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to fetch mapping for delete: %w", err)
+		}
+
+		if currentStatus == string(StatusActive) {
+			return ErrNotActive
+		}
+
+		deleteQuery := `DELETE FROM mapping_definition WHERE id = $1`
+		_, err := tx.Exec(ctx, deleteQuery, id)
+		if err != nil {
+			return fmt.Errorf("failed to delete mapping definition: %w", err)
+		}
+		return nil
+	})
+}
+
+// --- Scan helpers ---
+
+func (r *PostgresRepository) scanRow(row pgx.Row) (*Definition, error) {
+	var def Definition
+	var status string
+	var externalSchema, inboundCEL, outboundCEL, batchTargetPath sql.NullString
+	var fieldsJSON, inboundComputedJSON, outboundComputedJSON, idempotencyJSON []byte
+
+	err := row.Scan(
+		&def.ID, &def.TenantID, &def.Name, &def.TargetService, &def.TargetRPC,
+		&def.Version, &status,
+		&externalSchema, &fieldsJSON, &inboundComputedJSON, &outboundComputedJSON,
+		&inboundCEL, &outboundCEL,
+		&def.IsBatch, &batchTargetPath, &idempotencyJSON,
+		&def.CreatedAt, &def.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("failed to scan mapping definition: %w", err)
+	}
+
+	return populateFromScan(&def, status, externalSchema, inboundCEL, outboundCEL, batchTargetPath,
+		fieldsJSON, inboundComputedJSON, outboundComputedJSON, idempotencyJSON)
+}
+
+func (r *PostgresRepository) scanRows(rows pgx.Rows) (*Definition, error) {
+	var def Definition
+	var status string
+	var externalSchema, inboundCEL, outboundCEL, batchTargetPath sql.NullString
+	var fieldsJSON, inboundComputedJSON, outboundComputedJSON, idempotencyJSON []byte
+
+	err := rows.Scan(
+		&def.ID, &def.TenantID, &def.Name, &def.TargetService, &def.TargetRPC,
+		&def.Version, &status,
+		&externalSchema, &fieldsJSON, &inboundComputedJSON, &outboundComputedJSON,
+		&inboundCEL, &outboundCEL,
+		&def.IsBatch, &batchTargetPath, &idempotencyJSON,
+		&def.CreatedAt, &def.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan mapping definition row: %w", err)
+	}
+
+	return populateFromScan(&def, status, externalSchema, inboundCEL, outboundCEL, batchTargetPath,
+		fieldsJSON, inboundComputedJSON, outboundComputedJSON, idempotencyJSON)
+}
+
+func populateFromScan(
+	def *Definition,
+	status string,
+	externalSchema, inboundCEL, outboundCEL, batchTargetPath sql.NullString,
+	fieldsJSON, inboundComputedJSON, outboundComputedJSON, idempotencyJSON []byte,
+) (*Definition, error) {
+	def.Status = Status(status)
+	if externalSchema.Valid {
+		def.ExternalSchema = externalSchema.String
+	}
+	if inboundCEL.Valid {
+		def.InboundValidationCEL = inboundCEL.String
+	}
+	if outboundCEL.Valid {
+		def.OutboundValidationCEL = outboundCEL.String
+	}
+	if batchTargetPath.Valid {
+		def.BatchTargetPath = batchTargetPath.String
+	}
+
+	fields, err := UnmarshalFields(fieldsJSON)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal fields: %w", err)
+	}
+	def.Fields = fields
+
+	inbound, err := UnmarshalComputedFields(inboundComputedJSON)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal inbound_computed_fields: %w", err)
+	}
+	def.InboundComputed = inbound
+
+	outbound, err := UnmarshalComputedFields(outboundComputedJSON)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal outbound_computed_fields: %w", err)
+	}
+	def.OutboundComputed = outbound
+
+	idempotency, err := UnmarshalIdempotency(idempotencyJSON)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal idempotency: %w", err)
+	}
+	def.Idempotency = idempotency
+
+	return def, nil
+}
+
+// nullString converts a string to sql.NullString, treating empty strings as NULL.
+func nullString(s string) sql.NullString {
+	if s == "" {
+		return sql.NullString{Valid: false}
+	}
+	return sql.NullString{String: s, Valid: true}
+}

--- a/services/reference-data/mapping/repository.go
+++ b/services/reference-data/mapping/repository.go
@@ -379,6 +379,10 @@ func (r *PostgresRepository) UpdateStatus(ctx context.Context, id uuid.UUID, new
 		updateQuery := `UPDATE mapping_definition SET status = $1, updated_at = $2 WHERE id = $3`
 		result, err := tx.Exec(ctx, updateQuery, string(newStatus), now, id)
 		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				return ErrAlreadyExists
+			}
 			return fmt.Errorf("failed to update mapping status: %w", err)
 		}
 		if result.RowsAffected() == 0 {

--- a/services/reference-data/mapping/repository_test.go
+++ b/services/reference-data/mapping/repository_test.go
@@ -1,0 +1,240 @@
+package mapping_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/reference-data/mapping"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+)
+
+func newTestDef() *mapping.Definition {
+	return &mapping.Definition{
+		Name:          "test-mapping",
+		TargetService: "meridian.payment_order.v1.PaymentOrderService",
+		TargetRPC:     "InitiatePaymentOrder",
+		Version:       1,
+		Fields: []mapping.FieldCorrespondence{
+			{ExternalPath: "amount", InternalPath: "amount"},
+		},
+	}
+}
+
+func TestRepository_CreateAndGetByID(t *testing.T) {
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("reference-data"))
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, "testtenant01", "reference-data")
+	defer cleanup()
+
+	repo := mapping.NewPostgresRepository(pool)
+
+	def := newTestDef()
+	require.NoError(t, repo.Create(ctx, def))
+	assert.NotEqual(t, uuid.Nil, def.ID)
+	assert.Equal(t, mapping.StatusDraft, def.Status)
+
+	got, err := repo.GetByID(ctx, def.ID)
+	require.NoError(t, err)
+	assert.Equal(t, def.ID, got.ID)
+	assert.Equal(t, "test-mapping", got.Name)
+	assert.Equal(t, "InitiatePaymentOrder", got.TargetRPC)
+	assert.Len(t, got.Fields, 1)
+}
+
+func TestRepository_Create_Duplicate_ReturnsAlreadyExists(t *testing.T) {
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("reference-data"))
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, "testtenant02", "reference-data")
+	defer cleanup()
+
+	repo := mapping.NewPostgresRepository(pool)
+
+	def := newTestDef()
+	require.NoError(t, repo.Create(ctx, def))
+
+	def2 := newTestDef()
+	def2.ID = uuid.Nil
+	err := repo.Create(ctx, def2)
+	assert.ErrorIs(t, err, mapping.ErrAlreadyExists)
+}
+
+func TestRepository_GetByID_NotFound(t *testing.T) {
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("reference-data"))
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, "testtenant03", "reference-data")
+	defer cleanup()
+
+	repo := mapping.NewPostgresRepository(pool)
+
+	_, err := repo.GetByID(ctx, uuid.New())
+	assert.ErrorIs(t, err, mapping.ErrNotFound)
+}
+
+func TestRepository_Update(t *testing.T) {
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("reference-data"))
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, "testtenant04", "reference-data")
+	defer cleanup()
+
+	repo := mapping.NewPostgresRepository(pool)
+
+	def := newTestDef()
+	require.NoError(t, repo.Create(ctx, def))
+
+	def.Name = "updated-mapping"
+	def.ExternalSchema = `{"type":"object"}`
+	err := repo.Update(ctx, def, def.UpdatedAt)
+	require.NoError(t, err)
+
+	got, err := repo.GetByID(ctx, def.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "updated-mapping", got.Name)
+	assert.Equal(t, `{"type":"object"}`, got.ExternalSchema)
+}
+
+func TestRepository_Update_NotDraft_Fails(t *testing.T) {
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("reference-data"))
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, "testtenant05", "reference-data")
+	defer cleanup()
+
+	repo := mapping.NewPostgresRepository(pool)
+
+	def := newTestDef()
+	require.NoError(t, repo.Create(ctx, def))
+	require.NoError(t, repo.UpdateStatus(ctx, def.ID, mapping.StatusActive))
+
+	def.Name = "changed"
+	err := repo.Update(ctx, def, def.UpdatedAt)
+	assert.ErrorIs(t, err, mapping.ErrNotDraft)
+}
+
+func TestRepository_UpdateStatus(t *testing.T) {
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("reference-data"))
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, "testtenant06", "reference-data")
+	defer cleanup()
+
+	repo := mapping.NewPostgresRepository(pool)
+
+	def := newTestDef()
+	require.NoError(t, repo.Create(ctx, def))
+
+	require.NoError(t, repo.UpdateStatus(ctx, def.ID, mapping.StatusActive))
+
+	got, err := repo.GetByID(ctx, def.ID)
+	require.NoError(t, err)
+	assert.Equal(t, mapping.StatusActive, got.Status)
+}
+
+func TestRepository_ListByTenant(t *testing.T) {
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("reference-data"))
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, "testtenant07", "reference-data")
+	defer cleanup()
+
+	repo := mapping.NewPostgresRepository(pool)
+
+	for i := 1; i <= 3; i++ {
+		d := &mapping.Definition{
+			Name:          "mapping-" + string(rune('A'-1+i)),
+			TargetService: "svc",
+			TargetRPC:     "Rpc",
+			Version:       1,
+		}
+		require.NoError(t, repo.Create(ctx, d))
+	}
+
+	defs, total, err := repo.ListByTenant(ctx, "", "", 10, "")
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+	assert.Len(t, defs, 3)
+}
+
+func TestRepository_ListByTenant_StatusFilter(t *testing.T) {
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("reference-data"))
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, "testtenant08", "reference-data")
+	defer cleanup()
+
+	repo := mapping.NewPostgresRepository(pool)
+
+	def := newTestDef()
+	require.NoError(t, repo.Create(ctx, def))
+	require.NoError(t, repo.UpdateStatus(ctx, def.ID, mapping.StatusActive))
+
+	def2 := &mapping.Definition{Name: "draft-one", TargetService: "svc", TargetRPC: "Rpc", Version: 1}
+	require.NoError(t, repo.Create(ctx, def2))
+
+	activeDefs, _, err := repo.ListByTenant(ctx, mapping.StatusActive, "", 10, "")
+	require.NoError(t, err)
+	assert.Len(t, activeDefs, 1)
+
+	draftDefs, _, err := repo.ListByTenant(ctx, mapping.StatusDraft, "", 10, "")
+	require.NoError(t, err)
+	assert.Len(t, draftDefs, 1)
+}
+
+func TestRepository_Delete(t *testing.T) {
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("reference-data"))
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, "testtenant09", "reference-data")
+	defer cleanup()
+
+	repo := mapping.NewPostgresRepository(pool)
+
+	def := newTestDef()
+	require.NoError(t, repo.Create(ctx, def))
+
+	require.NoError(t, repo.Delete(ctx, def.ID))
+
+	_, err := repo.GetByID(ctx, def.ID)
+	assert.ErrorIs(t, err, mapping.ErrNotFound)
+}
+
+func TestRepository_Delete_Active_Fails(t *testing.T) {
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("reference-data"))
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, "testtenant10", "reference-data")
+	defer cleanup()
+
+	repo := mapping.NewPostgresRepository(pool)
+
+	def := newTestDef()
+	require.NoError(t, repo.Create(ctx, def))
+	require.NoError(t, repo.UpdateStatus(ctx, def.ID, mapping.StatusActive))
+
+	err := repo.Delete(ctx, def.ID)
+	assert.ErrorIs(t, err, mapping.ErrNotActive)
+}
+
+func TestRepository_GetLatestActive(t *testing.T) {
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("reference-data"))
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, "testtenant11", "reference-data")
+	defer cleanup()
+
+	repo := mapping.NewPostgresRepository(pool)
+
+	def := newTestDef()
+	require.NoError(t, repo.Create(ctx, def))
+	require.NoError(t, repo.UpdateStatus(ctx, def.ID, mapping.StatusActive))
+
+	got, err := repo.GetLatestActive(ctx, "test-mapping")
+	require.NoError(t, err)
+	assert.Equal(t, def.ID, got.ID)
+	assert.Equal(t, mapping.StatusActive, got.Status)
+}
+
+func TestRepository_OptimisticLock(t *testing.T) {
+	pool := testdb.NewTestPool(t, testdb.WithMigrations("reference-data"))
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, "testtenant12", "reference-data")
+	defer cleanup()
+
+	repo := mapping.NewPostgresRepository(pool)
+
+	def := newTestDef()
+	require.NoError(t, repo.Create(ctx, def))
+
+	// First update succeeds
+	originalUpdatedAt := def.UpdatedAt
+	def.Name = "first-update"
+	require.NoError(t, repo.Update(ctx, def, originalUpdatedAt))
+
+	// Second update with stale updated_at fails
+	def.Name = "second-update"
+	err := repo.Update(ctx, def, originalUpdatedAt) // still using old timestamp
+	assert.ErrorIs(t, err, mapping.ErrOptimisticLock)
+}

--- a/services/reference-data/mapping/validator.go
+++ b/services/reference-data/mapping/validator.go
@@ -26,6 +26,9 @@ func NewValidator(compiler *sharedcel.Compiler) (*Validator, error) {
 
 // Validate performs all semantic validations on a mapping definition.
 func (v *Validator) Validate(def *Definition) error {
+	if def == nil {
+		return fmt.Errorf("%w: definition cannot be nil", ErrRequiredField)
+	}
 	var errs []error
 
 	if err := v.validateExternalSchema(def.ExternalSchema); err != nil {

--- a/services/reference-data/mapping/validator.go
+++ b/services/reference-data/mapping/validator.go
@@ -92,6 +92,12 @@ func (v *Validator) validateFields(fields []FieldCorrespondence) error {
 		if !isValidGjsonPath(f.ExternalPath) {
 			return fmt.Errorf("%w: fields[%d].external_path %q", ErrInvalidGjsonPath, i, f.ExternalPath)
 		}
+		if strings.TrimSpace(f.InternalPath) == "" {
+			return fmt.Errorf("%w: fields[%d].internal_path is required", ErrInvalidGjsonPath, i)
+		}
+		if !isValidGjsonPath(f.InternalPath) {
+			return fmt.Errorf("%w: fields[%d].internal_path %q", ErrInvalidGjsonPath, i, f.InternalPath)
+		}
 		if externalPaths[f.ExternalPath] {
 			return fmt.Errorf("%w: %q", ErrDuplicateExternalPath, f.ExternalPath)
 		}

--- a/services/reference-data/mapping/validator.go
+++ b/services/reference-data/mapping/validator.go
@@ -1,0 +1,246 @@
+package mapping
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/tidwall/gjson"
+
+	sharedcel "github.com/meridianhub/meridian/shared/pkg/cel"
+)
+
+// Validator validates a MappingDefinition's content before persistence.
+type Validator struct {
+	celCompiler *sharedcel.Compiler
+}
+
+// NewValidator creates a Validator using the shared CEL compiler.
+func NewValidator(compiler *sharedcel.Compiler) (*Validator, error) {
+	if compiler == nil {
+		return nil, ErrCELCompilerNil
+	}
+	return &Validator{celCompiler: compiler}, nil
+}
+
+// Validate performs all semantic validations on a mapping definition.
+func (v *Validator) Validate(def *Definition) error {
+	var errs []error
+
+	if err := v.validateExternalSchema(def.ExternalSchema); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := v.validateFields(def.Fields); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := v.validateComputedFields(def.InboundComputed, "inbound_computed_fields"); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := v.validateComputedFields(def.OutboundComputed, "outbound_computed_fields"); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := v.validateCELExpression(def.InboundValidationCEL, "inbound_validation_cel"); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := v.validateCELExpression(def.OutboundValidationCEL, "outbound_validation_cel"); err != nil {
+		errs = append(errs, err)
+	}
+
+	if def.IsBatch && def.BatchTargetPath == "" {
+		errs = append(errs, fmt.Errorf("%w: batch_target_path is required when is_batch is true", ErrBatchTargetPathRequired))
+	}
+
+	if def.BatchTargetPath != "" && !isValidGjsonPath(def.BatchTargetPath) {
+		errs = append(errs, fmt.Errorf("%w: batch_target_path %q", ErrInvalidGjsonPath, def.BatchTargetPath))
+	}
+
+	if def.Idempotency != nil {
+		if err := v.validateIdempotency(def.Idempotency); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (v *Validator) validateExternalSchema(schema string) error {
+	if schema == "" {
+		return nil
+	}
+
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource("schema.json", strings.NewReader(schema)); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidJSONSchema, err)
+	}
+	if _, err := c.Compile("schema.json"); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidJSONSchema, err)
+	}
+	return nil
+}
+
+func (v *Validator) validateFields(fields []FieldCorrespondence) error {
+	externalPaths := make(map[string]bool)
+	internalPaths := make(map[string]bool)
+
+	for i, f := range fields {
+		if !isValidGjsonPath(f.ExternalPath) {
+			return fmt.Errorf("%w: fields[%d].external_path %q", ErrInvalidGjsonPath, i, f.ExternalPath)
+		}
+		if externalPaths[f.ExternalPath] {
+			return fmt.Errorf("%w: %q", ErrDuplicateExternalPath, f.ExternalPath)
+		}
+		externalPaths[f.ExternalPath] = true
+
+		if internalPaths[f.InternalPath] {
+			return fmt.Errorf("%w: %q", ErrDuplicateInternalPath, f.InternalPath)
+		}
+		internalPaths[f.InternalPath] = true
+
+		if f.Transform != nil {
+			if err := v.validateFieldTransform(f.Transform, i); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (v *Validator) validateFieldTransform(t *FieldTransform, idx int) error {
+	// Ensure exactly one transform variant is set
+	variants := 0
+	if t.CEL != nil {
+		variants++
+		if err := v.validateCELTransform(t.CEL, idx); err != nil {
+			return err
+		}
+	}
+	if t.EnumMapping != nil {
+		variants++
+	}
+	if t.DateFormat != "" {
+		variants++
+	}
+	if t.DefaultValue != "" {
+		variants++
+	}
+	if t.AttributeFlatten != nil {
+		variants++
+		if err := v.validateAttributeFlatten(t.AttributeFlatten, idx); err != nil {
+			return err
+		}
+	}
+
+	if variants == 0 {
+		return fmt.Errorf("fields[%d].transform: %w", idx, ErrTransformVariantRequired)
+	}
+	if variants > 1 {
+		return fmt.Errorf("fields[%d].transform: %w", idx, ErrTransformVariantConflict)
+	}
+	return nil
+}
+
+func (v *Validator) validateCELTransform(t *CelTransform, idx int) error {
+	if t.InboundCEL != "" {
+		if err := v.validateCELExpressionRaw(t.InboundCEL); err != nil {
+			return fmt.Errorf("fields[%d].transform.cel.inbound_cel: %w", idx, err)
+		}
+	}
+	if t.OutboundCEL != "" {
+		if err := v.validateCELExpressionRaw(t.OutboundCEL); err != nil {
+			return fmt.Errorf("fields[%d].transform.cel.outbound_cel: %w", idx, err)
+		}
+	}
+	return nil
+}
+
+func (v *Validator) validateAttributeFlatten(af *AttributeFlatten, idx int) error {
+	for _, key := range af.SourceKeys {
+		if !isValidGjsonPath(key) {
+			return fmt.Errorf("%w: fields[%d].transform.attribute_flatten.source_keys %q",
+				ErrInvalidGjsonPath, idx, key)
+		}
+	}
+	return nil
+}
+
+func (v *Validator) validateComputedFields(fields []ComputedField, fieldName string) error {
+	for i, f := range fields {
+		if err := v.validateCELExpressionRaw(f.CELExpression); err != nil {
+			return fmt.Errorf("%s[%d].cel_expression: %w: %w", fieldName, i, ErrInvalidCEL, err)
+		}
+	}
+	return nil
+}
+
+func (v *Validator) validateCELExpression(expr, fieldName string) error {
+	if expr == "" {
+		return nil
+	}
+	if err := v.validateCELExpressionRaw(expr); err != nil {
+		return fmt.Errorf("%s: %w: %w", fieldName, ErrInvalidCEL, err)
+	}
+	return nil
+}
+
+// validateCELExpressionRaw uses the shared CEL compiler to validate an expression.
+// We re-use the validation environment as a general-purpose CEL check.
+func (v *Validator) validateCELExpressionRaw(expr string) error {
+	return v.celCompiler.ValidateValidationCEL(expr)
+}
+
+func (v *Validator) validateIdempotency(cfg *IdempotencyConfig) error {
+	if !cfg.UseContentHash && cfg.SourceSelector == "" {
+		return fmt.Errorf("%w: source_selector is required when use_content_hash is false", ErrIdempotencyConfig)
+	}
+	if cfg.UseContentHash && len(cfg.ContentHashFields) == 0 {
+		return fmt.Errorf("%w: content_hash_fields must have at least one entry when use_content_hash is true", ErrIdempotencyConfig)
+	}
+	if cfg.SourceSelector != "" && !isValidGjsonPath(cfg.SourceSelector) {
+		return fmt.Errorf("%w: idempotency.source_selector %q", ErrInvalidGjsonPath, cfg.SourceSelector)
+	}
+	for _, f := range cfg.ContentHashFields {
+		if !isValidGjsonPath(f) {
+			return fmt.Errorf("%w: idempotency.content_hash_fields %q", ErrInvalidGjsonPath, f)
+		}
+	}
+	return nil
+}
+
+// isValidGjsonPath checks that the given string is a syntactically valid gjson path.
+// gjson.Get with an empty JSON string returns a Result; any non-panic is considered valid syntax.
+// We use gjson.ParseMany to check path syntax without requiring actual data.
+func isValidGjsonPath(path string) bool {
+	if path == "" {
+		return false
+	}
+	// gjson paths are validated by attempting to parse them.
+	// A path with unbalanced brackets/braces is invalid.
+	result := gjson.Get("{}", path)
+	// If result type is JSON and the raw value is populated it means gjson parsed the path OK.
+	// Even when the key is absent the result exists without error.
+	_ = result
+	return isGjsonPathSyntaxValid(path)
+}
+
+// isGjsonPathSyntaxValid checks for balanced brackets and valid modifiers.
+func isGjsonPathSyntaxValid(path string) bool {
+	depth := 0
+	for _, ch := range path {
+		switch ch {
+		case '[', '{':
+			depth++
+		case ']', '}':
+			depth--
+			if depth < 0 {
+				return false
+			}
+		}
+	}
+	return depth == 0
+}

--- a/services/reference-data/mapping/validator.go
+++ b/services/reference-data/mapping/validator.go
@@ -166,6 +166,9 @@ func (v *Validator) validateCELTransform(t *CelTransform, idx int) error {
 }
 
 func (v *Validator) validateAttributeFlatten(af *AttributeFlatten, idx int) error {
+	if strings.TrimSpace(af.TargetField) == "" {
+		return fmt.Errorf("%w: fields[%d].transform.attribute_flatten.target_field", ErrRequiredField, idx)
+	}
 	for _, key := range af.SourceKeys {
 		if !isValidGjsonPath(key) {
 			return fmt.Errorf("%w: fields[%d].transform.attribute_flatten.source_keys %q",
@@ -177,6 +180,12 @@ func (v *Validator) validateAttributeFlatten(af *AttributeFlatten, idx int) erro
 
 func (v *Validator) validateComputedFields(fields []ComputedField, fieldName string) error {
 	for i, f := range fields {
+		if strings.TrimSpace(f.TargetPath) == "" {
+			return fmt.Errorf("%w: %s[%d].target_path", ErrRequiredField, fieldName, i)
+		}
+		if !isValidGjsonPath(f.TargetPath) {
+			return fmt.Errorf("%w: %s[%d].target_path %q", ErrInvalidGjsonPath, fieldName, i, f.TargetPath)
+		}
 		if err := v.validateCELExpressionRaw(f.CELExpression); err != nil {
 			return fmt.Errorf("%s[%d].cel_expression: %w: %w", fieldName, i, ErrInvalidCEL, err)
 		}

--- a/services/reference-data/mapping/validator.go
+++ b/services/reference-data/mapping/validator.go
@@ -246,19 +246,25 @@ func isValidGjsonPath(path string) bool {
 	return isGjsonPathSyntaxValid(path)
 }
 
-// isGjsonPathSyntaxValid checks for balanced brackets and valid modifiers.
+// isGjsonPathSyntaxValid checks for balanced and correctly matched brackets.
+// Uses a stack to enforce that each closing bracket matches its opener,
+// catching mismatched pairs like "[}" which a simple depth counter misses.
 func isGjsonPathSyntaxValid(path string) bool {
-	depth := 0
+	stack := make([]rune, 0, 8)
 	for _, ch := range path {
 		switch ch {
 		case '[', '{':
-			depth++
+			stack = append(stack, ch)
 		case ']', '}':
-			depth--
-			if depth < 0 {
+			if len(stack) == 0 {
+				return false
+			}
+			open := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if (ch == ']' && open != '[') || (ch == '}' && open != '{') {
 				return false
 			}
 		}
 	}
-	return depth == 0
+	return len(stack) == 0
 }

--- a/services/reference-data/mapping/validator_test.go
+++ b/services/reference-data/mapping/validator_test.go
@@ -1,0 +1,240 @@
+package mapping_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/reference-data/mapping"
+	sharedcel "github.com/meridianhub/meridian/shared/pkg/cel"
+)
+
+func newTestValidator(t *testing.T) *mapping.Validator {
+	t.Helper()
+	compiler, err := sharedcel.NewCompiler()
+	require.NoError(t, err)
+	v, err := mapping.NewValidator(compiler)
+	require.NoError(t, err)
+	return v
+}
+
+func TestValidator_ValidDef(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Fields: []mapping.FieldCorrespondence{
+			{ExternalPath: "amount", InternalPath: "amount"},
+		},
+	}
+	assert.NoError(t, v.Validate(def))
+}
+
+func TestValidator_InvalidExternalSchema(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		ExternalSchema: `not valid json schema`,
+	}
+	err := v.Validate(def)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, mapping.ErrInvalidJSONSchema)
+}
+
+func TestValidator_ValidExternalSchema(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		ExternalSchema: `{"type":"object","properties":{"amount":{"type":"string"}}}`,
+	}
+	assert.NoError(t, v.Validate(def))
+}
+
+func TestValidator_DuplicateExternalPath(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Fields: []mapping.FieldCorrespondence{
+			{ExternalPath: "amount", InternalPath: "amount"},
+			{ExternalPath: "amount", InternalPath: "other_field"},
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrDuplicateExternalPath)
+}
+
+func TestValidator_DuplicateInternalPath(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Fields: []mapping.FieldCorrespondence{
+			{ExternalPath: "a", InternalPath: "amount"},
+			{ExternalPath: "b", InternalPath: "amount"},
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrDuplicateInternalPath)
+}
+
+func TestValidator_InvalidGjsonPath(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Fields: []mapping.FieldCorrespondence{
+			{ExternalPath: "[invalid", InternalPath: "amount"},
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrInvalidGjsonPath)
+}
+
+func TestValidator_IsBatch_MissingBatchTargetPath(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		IsBatch:         true,
+		BatchTargetPath: "",
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrBatchTargetPathRequired)
+}
+
+func TestValidator_IsBatch_WithBatchTargetPath(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		IsBatch:         true,
+		BatchTargetPath: "events",
+	}
+	assert.NoError(t, v.Validate(def))
+}
+
+func TestValidator_InvalidCEL_InboundValidation(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		InboundValidationCEL: "this is not valid CEL !!!",
+	}
+	err := v.Validate(def)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, mapping.ErrInvalidCEL)
+}
+
+func TestValidator_ValidCEL_InboundValidation(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		InboundValidationCEL: "attributes.size() > 0",
+	}
+	assert.NoError(t, v.Validate(def))
+}
+
+func TestValidator_InvalidCEL_ComputedField(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		InboundComputed: []mapping.ComputedField{
+			{TargetPath: "created_at", CELExpression: "not valid !!!"},
+		},
+	}
+	err := v.Validate(def)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, mapping.ErrInvalidCEL)
+}
+
+func TestValidator_IdempotencyConfig_MissingSourceSelector(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Idempotency: &mapping.IdempotencyConfig{
+			UseContentHash: false,
+			SourceSelector: "",
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrIdempotencyConfig)
+}
+
+func TestValidator_IdempotencyConfig_ContentHash_MissingFields(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Idempotency: &mapping.IdempotencyConfig{
+			UseContentHash:    true,
+			ContentHashFields: nil,
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrIdempotencyConfig)
+}
+
+func TestValidator_IdempotencyConfig_Valid(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Idempotency: &mapping.IdempotencyConfig{
+			SourceSelector: "header.idempotency_key",
+		},
+	}
+	assert.NoError(t, v.Validate(def))
+}
+
+func TestValidator_CelTransform_Valid(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Fields: []mapping.FieldCorrespondence{
+			{
+				ExternalPath: "amount",
+				InternalPath: "amount",
+				Transform: &mapping.FieldTransform{
+					CEL: &mapping.CelTransform{
+						InboundCEL: "attributes.size() > 0",
+					},
+				},
+			},
+		},
+	}
+	assert.NoError(t, v.Validate(def))
+}
+
+func TestValidator_EnumMapping_Valid(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Fields: []mapping.FieldCorrespondence{
+			{
+				ExternalPath: "status",
+				InternalPath: "status",
+				Transform: &mapping.FieldTransform{
+					EnumMapping: &mapping.EnumMapping{
+						Values: map[string]string{
+							"ACTIVE":   "STATUS_ACTIVE",
+							"INACTIVE": "STATUS_INACTIVE",
+						},
+					},
+				},
+			},
+		},
+	}
+	assert.NoError(t, v.Validate(def))
+}
+
+func TestValidator_MultipleTransformVariants_Rejected(t *testing.T) {
+	v := newTestValidator(t)
+
+	def := &mapping.Definition{
+		Fields: []mapping.FieldCorrespondence{
+			{
+				ExternalPath: "status",
+				InternalPath: "status",
+				Transform: &mapping.FieldTransform{
+					DateFormat:   "2006-01-02",
+					DefaultValue: "fallback",
+				},
+			},
+		},
+	}
+	err := v.Validate(def)
+	assert.ErrorIs(t, err, mapping.ErrTransformVariantConflict)
+}

--- a/services/reference-data/migrations/20260221000001_mapping_definition.sql
+++ b/services/reference-data/migrations/20260221000001_mapping_definition.sql
@@ -1,0 +1,44 @@
+-- MappingDefinition: versioned registry of external-to-internal mapping schemas.
+-- Supports DRAFT → ACTIVE → DEPRECATED lifecycle per tenant.
+-- JSONB columns store structured data (fields, computed_fields, idempotency).
+-- tenant_id is stored as a column (multi-tenant, schema-per-tenant architecture).
+
+CREATE TABLE "mapping_definition" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "tenant_id" text NOT NULL,
+  "name" character varying(255) NOT NULL,
+  "target_service" character varying(255) NOT NULL,
+  "target_rpc" character varying(128) NOT NULL,
+  "version" integer NOT NULL DEFAULT 1,
+  "status" character varying(20) NOT NULL DEFAULT 'DRAFT',
+  "external_schema" text NULL,
+  "fields" jsonb NOT NULL DEFAULT '[]',
+  "inbound_computed_fields" jsonb NOT NULL DEFAULT '[]',
+  "outbound_computed_fields" jsonb NOT NULL DEFAULT '[]',
+  "inbound_validation_cel" text NULL,
+  "outbound_validation_cel" text NULL,
+  "is_batch" boolean NOT NULL DEFAULT false,
+  "batch_target_path" character varying(512) NULL,
+  "idempotency" jsonb NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "uq_mapping_tenant_name_version"
+    UNIQUE ("tenant_id", "name", "version"),
+  CONSTRAINT "chk_mapping_status"
+    CHECK ("status" IN ('DRAFT', 'ACTIVE', 'DEPRECATED')),
+  CONSTRAINT "chk_mapping_version_positive"
+    CHECK ("version" >= 1)
+);
+
+-- Index for listing mappings by tenant and status
+CREATE INDEX "idx_mapping_tenant_status" ON "mapping_definition" ("tenant_id", "status");
+
+-- Index for looking up all versions of a mapping by name
+CREATE INDEX "idx_mapping_tenant_name" ON "mapping_definition" ("tenant_id", "name");
+
+-- NOTE: Lifecycle enforcement (status transitions, immutable fields, timestamp management)
+-- is handled at the application layer. CockroachDB does not support PL/pgSQL triggers.
+-- CHECK constraints above provide database-level safety.
+-- Partial unique index (only one ACTIVE version per tenant+name) is in a separate migration
+-- per CockroachDB requirement: partial indexes require the table to be fully committed first.

--- a/services/reference-data/migrations/20260221000002_mapping_definition_active_index.sql
+++ b/services/reference-data/migrations/20260221000002_mapping_definition_active_index.sql
@@ -1,0 +1,8 @@
+-- Partial unique index: only one ACTIVE version per (tenant_id, name).
+-- Separated into its own migration per CockroachDB requirement:
+-- partial indexes on a newly added column/table require the table to be
+-- fully committed ("public") before the partial index can reference it.
+
+CREATE UNIQUE INDEX "uq_mapping_tenant_name_active"
+  ON "mapping_definition" ("tenant_id", "name")
+  WHERE "status" = 'ACTIVE';

--- a/services/reference-data/migrations/atlas.sum
+++ b/services/reference-data/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:9uvMNqMdU5ppdrnQbK2+d9lxZKKzUNJgvbeWunT12aA=
+h1:qNXnWbsNKxbJuRKU3QgWqMbpA9US5jfUh52K2GatXsU=
 20260104000001_initial.sql h1:2h8BgK7z85efnTzrKZ23RRN3HPtRf9UOTy9FXhA33ik=
 20260105000001_add_is_system.sql h1:eRDijg0+SC31BlTqSxDUO/5651nNGlvfHCRhP2W1xlk=
 20260106000001_add_successor_id.sql h1:QasQ5t/OPJ8j138LFpSwy38qGwTyKWwWSlVg1EsPifc=
@@ -21,3 +21,5 @@ h1:9uvMNqMdU5ppdrnQbK2+d9lxZKKzUNJgvbeWunT12aA=
 20260211000002_account_type_active_unique_index.sql h1:IfW9H4oskycME7Sdn7BXl8Upnh/Cq2KxsFLPoPnjSAo=
 20260211000003_account_type_valuation_methods.sql h1:20+TtpfM3FjEboyaNEniUTmu/kDvsPoXJnXSUig49M8=
 20260211000004_account_type_val_method_active_index.sql h1:aFoxOlhX9XdwTGEg+tuLa27BeVnaU7lYzKvjuBAct4E=
+20260221000001_mapping_definition.sql h1:npYQTdrDNnIXe01VFTb85l/LJXj4m2WMzMrb+3pnALI=
+20260221000002_mapping_definition_active_index.sql h1:v/yCArDD8nVfv3g1+QfR5bPTiJKXCM5Vmycflrlg3a8=


### PR DESCRIPTION
## Summary

Implements `structured-mapping-layer.8`: MappingDefinition CRUD in the reference-data service.

This adds the full lifecycle management (DRAFT → ACTIVE → DEPRECATED) for MappingDefinitions — the schema registry entries that map external payload fields to internal Meridian proto fields.

## Changes Made

### Domain layer (`services/reference-data/mapping/`)
- `domain.go`: `Definition` struct with all field types: `FieldCorrespondence`, `FieldTransform` (CEL / EnumMapping / DateFormat / DefaultValue / AttributeFlatten), `ComputedField`, `IdempotencyConfig`; JSON marshal/unmarshal helpers for JSONB columns
- `errors.go`: Sentinel errors for all lifecycle and validation failure modes (ErrNotFound, ErrNotDraft, ErrNotActive, ErrAlreadyExists, ErrOptimisticLock, validation errors)
- `repository.go`: `PostgresRepository` using pgx with tenant search_path scoping, optimistic locking on `updated_at`, cursor-based `ListByTenant` pagination
- `validator.go`: Validates JSON Schema (via `santhosh-tekuri/jsonschema/v5`), CEL expressions (via `shared/pkg/cel`), gjson paths, duplicate field paths, batch config, idempotency config

### gRPC handler (`services/reference-data/handler/`)
- `mapping_handler.go`: `MappingService` implementing `MappingServiceServer` for all 5 RPCs (Create/Get/List/Update/Delete); `UpdateMapping` supports FieldMask partial updates; full proto ↔ domain conversion

### Migrations (`services/reference-data/migrations/`)
- `20260221000001_mapping_definition.sql`: `mapping_definition` table with `tenant_id text`, JSONB columns for fields/computed/idempotency, status CHECK constraint, unique constraint on `(tenant_id, name, version)`
- `20260221000002_mapping_definition_active_index.sql`: Partial unique index `WHERE status = 'ACTIVE'` — split into a separate migration per CockroachDB column-visibility requirement

### Wire-up (`services/reference-data/cmd/main.go`)
- Registers `MappingService` with the gRPC server alongside existing services

## Testing

- **17 validator unit tests** — covers all validation paths (JSON Schema, CEL, gjson, duplicate paths, batch, idempotency, transform variants)
- **12 handler unit tests** — full CRUD coverage with in-memory stub repository; tests all gRPC error code mappings
- **11 repository integration tests** — full pgx/testcontainer tests covering create, get, list (with status filter), update (optimistic lock), updateStatus, delete, getLatestActive

All tests pass. Build is clean with no linter issues.

## Technical Details

- Uses `tenant_id text` (not UUID) — consistent with the alphanumeric TenantID format used throughout reference-data
- Optimistic locking via `WHERE id = $N AND updated_at = $M` with `ErrOptimisticLock` on 0 rows affected
- CockroachDB-compatible: no triggers, no expression indexes, partial index in separate migration file
- Atlas hash updated for both new migration files