### PR TITLE
feat: Add party_types to Manifest proto and control-plane

### DIFF
--- a/api/jsonschema/manifest.v1.schema.json
+++ b/api/jsonschema/manifest.v1.schema.json
@@ -11,7 +11,8 @@
                 "valuationRules",
                 "sagas",
                 "seedData",
-                "paymentRails"
+                "paymentRails",
+                "partyTypes"
             ],
             "properties": {
                 "version": {
@@ -67,6 +68,14 @@
                     "additionalProperties": false,
                     "type": "array",
                     "description": "payment_rails defines external payment provider integrations for this tenant."
+                },
+                "partyTypes": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.party.v1.PartyTypeDefinition"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "party_types defines the tenant-configurable party type schemas for this tenant."
                 }
             },
             "additionalProperties": false,
@@ -432,6 +441,68 @@
             "type": "object",
             "title": "Valuation Rule",
             "description": "ValuationRule defines how one instrument is converted to another. Used for cross-instrument transactions (e.g., kWh to GBP, USD to EUR)."
+        },
+        "meridian.party.v1.PartyTypeDefinition": {
+            "required": [
+                "id",
+                "tenantId",
+                "partyType",
+                "attributeSchema",
+                "validationCel",
+                "eligibilityCel",
+                "errorMessageCel",
+                "createdAt",
+                "updatedAt",
+                "version"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "id is the unique identifier for this party type definition."
+                },
+                "tenantId": {
+                    "type": "string",
+                    "description": "tenant_id is the tenant that owns this party type definition."
+                },
+                "partyType": {
+                    "type": "string",
+                    "description": "party_type is the party classification this definition applies to (e.g., \"PERSON\", \"ORGANIZATION\"). Uppercase alphanumeric with underscores, max 100 characters."
+                },
+                "attributeSchema": {
+                    "type": "string",
+                    "description": "attribute_schema is a JSON Schema document defining the structure and constraints for party attributes of this type (max 16KB). Must be non-empty when provided."
+                },
+                "validationCel": {
+                    "type": "string",
+                    "description": "validation_cel is a CEL expression for cross-field validation of party attributes. Evaluated at party registration and update time."
+                },
+                "eligibilityCel": {
+                    "type": "string",
+                    "description": "eligibility_cel is a CEL expression for determining account type eligibility for parties of this type."
+                },
+                "errorMessageCel": {
+                    "type": "string",
+                    "description": "error_message_cel is a CEL expression for generating custom error messages when validation or eligibility checks fail."
+                },
+                "createdAt": {
+                    "type": "string",
+                    "description": "created_at is when this party type definition was created.",
+                    "format": "date-time"
+                },
+                "updatedAt": {
+                    "type": "string",
+                    "description": "updated_at is when this party type definition was last modified.",
+                    "format": "date-time"
+                },
+                "version": {
+                    "type": "integer",
+                    "description": "version is for optimistic locking."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "--- Party Type Definitions ---",
+            "description": "--- Party Type Definitions ---  PartyTypeDefinition defines a tenant-configurable schema for a party type, including JSON Schema for attribute validation and CEL expressions for cross-field validation, account eligibility, and custom error messages."
         }
     }
 }

--- a/api/proto/meridian/control_plane/v1/manifest.proto
+++ b/api/proto/meridian/control_plane/v1/manifest.proto
@@ -4,6 +4,7 @@ package meridian.control_plane.v1;
 
 import "buf/validate/validate.proto";
 import "google/protobuf/struct.proto";
+import "meridian/party/v1/party.proto";
 
 option go_package = "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1;controlplanev1";
 
@@ -50,6 +51,9 @@ message Manifest {
 
   // payment_rails defines external payment provider integrations for this tenant.
   repeated PaymentRails payment_rails = 8;
+
+  // party_types defines the tenant-configurable party type schemas for this tenant.
+  repeated meridian.party.v1.PartyTypeDefinition party_types = 9;
 }
 
 // ========================================

--- a/services/control-plane/internal/differ/manifest_differ.go
+++ b/services/control-plane/internal/differ/manifest_differ.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -52,6 +53,7 @@ func (d *ManifestDiffer) Diff(ctx context.Context, lastApplied, newManifest *con
 	d.diffAccountTypes(lastApplied, newManifest, plan)
 	d.diffValuationRules(lastApplied, newManifest, plan)
 	d.diffSagas(lastApplied, newManifest, plan)
+	d.diffPartyTypes(lastApplied, newManifest, plan)
 
 	// Run safety checks on all DELETE actions
 	if err := d.runSafetyChecks(ctx, plan); err != nil {
@@ -262,6 +264,50 @@ func (d *ManifestDiffer) diffSagas(lastApplied, newManifest *controlplanev1.Mani
 	}
 }
 
+func (d *ManifestDiffer) diffPartyTypes(lastApplied, newManifest *controlplanev1.Manifest, plan *DiffPlan) {
+	oldMap := partyTypeMap(getPartyTypes(lastApplied))
+	newMap := partyTypeMap(newManifest.GetPartyTypes())
+
+	for key, updated := range newMap {
+		prev, exists := oldMap[key]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourcePartyType,
+				ResourceCode: key,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create party type %s", key),
+			})
+			continue
+		}
+		if !proto.Equal(prev, updated) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourcePartyType,
+				ResourceCode: key,
+				Action:       ActionUpdate,
+				Description:  describePartyTypeChanges(key, prev, updated),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourcePartyType,
+				ResourceCode: key,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Party type %s unchanged", key),
+			})
+		}
+	}
+
+	for key := range oldMap {
+		if _, exists := newMap[key]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourcePartyType,
+				ResourceCode: key,
+				Action:       ActionDelete,
+				Description:  fmt.Sprintf("Delete party type %s", key),
+			})
+		}
+	}
+}
+
 func (d *ManifestDiffer) runSafetyChecks(ctx context.Context, plan *DiffPlan) error {
 	for _, action := range plan.Actions {
 		if action.Action != ActionDelete {
@@ -279,6 +325,8 @@ func (d *ManifestDiffer) runSafetyChecks(ctx context.Context, plan *DiffPlan) er
 			blocked, err = d.safety.CheckSagaDeletion(ctx, action.ResourceCode)
 		case ResourceValuationRule:
 			// Valuation rules have no downstream dependencies to check
+		case ResourcePartyType:
+			// Party types have no downstream dependencies to check via safety checker
 		}
 
 		if err != nil {
@@ -321,6 +369,13 @@ func getSagas(m *controlplanev1.Manifest) []*controlplanev1.SagaDefinition {
 	return m.GetSagas()
 }
 
+func getPartyTypes(m *controlplanev1.Manifest) []*partyv1.PartyTypeDefinition {
+	if m == nil {
+		return nil
+	}
+	return m.GetPartyTypes()
+}
+
 // Map-building helpers keyed by stable identifiers.
 
 func instrumentMap(instruments []*controlplanev1.InstrumentDefinition) map[string]*controlplanev1.InstrumentDefinition {
@@ -351,6 +406,20 @@ func sagaMap(sagas []*controlplanev1.SagaDefinition) map[string]*controlplanev1.
 	m := make(map[string]*controlplanev1.SagaDefinition, len(sagas))
 	for _, s := range sagas {
 		m[s.GetName()] = s
+	}
+	return m
+}
+
+// partyTypeKey produces a stable identifier for a party type definition.
+// The key is (tenant_id, party_type) to match uniqueness constraints.
+func partyTypeKey(tenantID, partyType string) string {
+	return tenantID + ":" + partyType
+}
+
+func partyTypeMap(defs []*partyv1.PartyTypeDefinition) map[string]*partyv1.PartyTypeDefinition {
+	m := make(map[string]*partyv1.PartyTypeDefinition, len(defs))
+	for _, d := range defs {
+		m[partyTypeKey(d.GetTenantId(), d.GetPartyType())] = d
 	}
 	return m
 }
@@ -403,4 +472,24 @@ func describeSagaChanges(name string, prev, updated *controlplanev1.SagaDefiniti
 		return fmt.Sprintf("Update saga %s", name)
 	}
 	return fmt.Sprintf("Update saga %s (%s)", name, strings.Join(changes, "; "))
+}
+
+func describePartyTypeChanges(key string, prev, updated *partyv1.PartyTypeDefinition) string {
+	var changes []string
+	if prev.GetAttributeSchema() != updated.GetAttributeSchema() {
+		changes = append(changes, "attribute_schema changed")
+	}
+	if prev.GetValidationCel() != updated.GetValidationCel() {
+		changes = append(changes, "validation_cel changed")
+	}
+	if prev.GetEligibilityCel() != updated.GetEligibilityCel() {
+		changes = append(changes, "eligibility_cel changed")
+	}
+	if prev.GetErrorMessageCel() != updated.GetErrorMessageCel() {
+		changes = append(changes, "error_message_cel changed")
+	}
+	if len(changes) == 0 {
+		return fmt.Sprintf("Update party type %s", key)
+	}
+	return fmt.Sprintf("Update party type %s (%s)", key, strings.Join(changes, "; "))
 }

--- a/services/control-plane/internal/differ/manifest_differ_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -703,4 +704,159 @@ func filterActionsByResource(actions []PlannedAction, actionType ActionType, res
 		}
 	}
 	return result
+}
+
+// --- Party type differ tests ---
+
+func testPartyTypeDefinition(tenantID, partyType, schema string) *partyv1.PartyTypeDefinition {
+	return &partyv1.PartyTypeDefinition{
+		TenantId:        tenantID,
+		PartyType:       partyType,
+		AttributeSchema: schema,
+	}
+}
+
+func TestDiff_PartyTypeAdded_Create(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		testPartyTypeDefinition("tenant-1", "PERSON", `{"type":"object"}`),
+	}
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourcePartyType)
+	assert.Len(t, creates, 1)
+	assert.Equal(t, "tenant-1:PERSON", creates[0].ResourceCode)
+	assert.Contains(t, creates[0].Description, "Create party type")
+}
+
+func TestDiff_PartyTypeRemoved_Delete(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+	oldManifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		testPartyTypeDefinition("tenant-1", "PERSON", `{"type":"object"}`),
+	}
+
+	newManifest := testManifest()
+	// No party types in new manifest
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourcePartyType)
+	assert.Len(t, deletes, 1)
+	assert.Equal(t, "tenant-1:PERSON", deletes[0].ResourceCode)
+	assert.True(t, deletes[0].Breaking)
+	assert.True(t, plan.HasBreakingChanges)
+}
+
+func TestDiff_PartyTypeUnchanged_NoChange(t *testing.T) {
+	d := New(nil, nil)
+	partyType := testPartyTypeDefinition("tenant-1", "ORGANIZATION", `{"type":"object","properties":{}}`)
+	manifest := testManifest()
+	manifest.PartyTypes = []*partyv1.PartyTypeDefinition{partyType}
+
+	plan, err := d.Diff(context.Background(), manifest, manifest)
+	require.NoError(t, err)
+
+	noChanges := filterActionsByResource(plan.Actions, ActionNoChange, ResourcePartyType)
+	assert.Len(t, noChanges, 1)
+	assert.Equal(t, "tenant-1:ORGANIZATION", noChanges[0].ResourceCode)
+}
+
+func TestDiff_PartyTypeModifiedSchema_Update(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+	oldManifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		testPartyTypeDefinition("tenant-1", "PERSON", `{"type":"object"}`),
+	}
+
+	newManifest := testManifest()
+	newManifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		testPartyTypeDefinition("tenant-1", "PERSON", `{"type":"object","properties":{"name":{"type":"string"}}}`),
+	}
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourcePartyType)
+	assert.Len(t, updates, 1)
+	assert.Equal(t, "tenant-1:PERSON", updates[0].ResourceCode)
+	assert.Contains(t, updates[0].Description, "attribute_schema changed")
+}
+
+func TestDiff_PartyTypeModifiedCEL_DescribesChange(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+	oldManifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		{
+			TenantId:        "tenant-1",
+			PartyType:       "PERSON",
+			AttributeSchema: `{"type":"object"}`,
+			ValidationCel:   "attributes.age > 18",
+		},
+	}
+
+	newManifest := testManifest()
+	newManifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		{
+			TenantId:        "tenant-1",
+			PartyType:       "PERSON",
+			AttributeSchema: `{"type":"object"}`,
+			ValidationCel:   "attributes.age > 21",
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourcePartyType)
+	assert.Len(t, updates, 1)
+	assert.Contains(t, updates[0].Description, "validation_cel changed")
+}
+
+func TestDiff_MultiplePartyTypes_DifferentTenants(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		testPartyTypeDefinition("tenant-1", "PERSON", `{"type":"object"}`),
+		testPartyTypeDefinition("tenant-2", "PERSON", `{"type":"object"}`),
+		testPartyTypeDefinition("tenant-1", "ORGANIZATION", `{"type":"object"}`),
+	}
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourcePartyType)
+	assert.Len(t, creates, 3, "all three party types should be created")
+}
+
+func TestDiff_PartyTypeKey_IsCompositeOfTenantAndType(t *testing.T) {
+	// Same party_type, different tenants = different keys
+	assert.NotEqual(t, partyTypeKey("tenant-1", "PERSON"), partyTypeKey("tenant-2", "PERSON"))
+	// Same tenant, different party_types = different keys
+	assert.NotEqual(t, partyTypeKey("tenant-1", "PERSON"), partyTypeKey("tenant-1", "ORGANIZATION"))
+	// Same values = same key
+	assert.Equal(t, partyTypeKey("tenant-1", "PERSON"), partyTypeKey("tenant-1", "PERSON"))
+}
+
+func TestDiff_NilLastApplied_WithPartyTypes_AllCreates(t *testing.T) {
+	d := New(nil, nil)
+	manifest := testManifest()
+	manifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		testPartyTypeDefinition("tenant-1", "PERSON", `{"type":"object"}`),
+	}
+
+	plan, err := d.Diff(context.Background(), nil, manifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourcePartyType)
+	assert.Len(t, creates, 1)
+	assert.Equal(t, "tenant-1:PERSON", creates[0].ResourceCode)
 }

--- a/services/control-plane/internal/differ/types.go
+++ b/services/control-plane/internal/differ/types.go
@@ -32,6 +32,7 @@ const (
 	ResourceAccountType   ResourceType = "account_type"
 	ResourceValuationRule ResourceType = "valuation_rule"
 	ResourceSaga          ResourceType = "saga"
+	ResourcePartyType     ResourceType = "party_type"
 )
 
 // PlannedAction represents a single action in the diff plan.

--- a/services/control-plane/internal/planner/manifest_planner.go
+++ b/services/control-plane/internal/planner/manifest_planner.go
@@ -15,6 +15,10 @@ var ErrNilDiffPlan = errors.New("diff plan cannot be nil")
 // ErrNoMethodMapping is returned when no gRPC method mapping exists for a resource type/action combination.
 var ErrNoMethodMapping = errors.New("no gRPC method mapping")
 
+// ErrDeleteNotSupportedForPartyType is returned when a DELETE action is attempted on a party type.
+// Party types are managed through schema updates; deletion via manifest apply is not supported.
+var ErrDeleteNotSupportedForPartyType = errors.New("delete not supported for party types: update the schema instead")
+
 // ManifestPlanner transforms a DiffPlan into a dependency-ordered
 // ExecutionPlan of gRPC calls. It assigns each action to a phase
 // based on resource type dependencies and maps actions to the
@@ -108,6 +112,9 @@ func phaseForResource(rt differ.ResourceType) Phase {
 
 // grpcMethodFor returns the gRPC method for a resource type and action.
 func grpcMethodFor(rt differ.ResourceType, action differ.ActionType) (GRPCMethod, error) {
+	if rt == differ.ResourcePartyType && action == differ.ActionDelete {
+		return "", ErrDeleteNotSupportedForPartyType
+	}
 	key := methodKey{rt, action}
 	method, ok := grpcMethodMap[key]
 	if !ok {

--- a/services/control-plane/internal/planner/manifest_planner.go
+++ b/services/control-plane/internal/planner/manifest_planner.go
@@ -99,6 +99,8 @@ func phaseForResource(rt differ.ResourceType) Phase {
 		return PhaseValuationRules
 	case differ.ResourceSaga:
 		return PhaseSagas
+	case differ.ResourcePartyType:
+		return PhasePartyTypes
 	default:
 		return PhaseSeedData
 	}
@@ -142,6 +144,12 @@ var grpcMethodMap = map[methodKey]GRPCMethod{
 	{differ.ResourceSaga, differ.ActionCreate}: MethodCreateSagaDraft,
 	{differ.ResourceSaga, differ.ActionUpdate}: MethodUpdateSagaDefinition,
 	{differ.ResourceSaga, differ.ActionDelete}: MethodDeprecateSaga,
+
+	// Party Types
+	{differ.ResourcePartyType, differ.ActionCreate}: MethodRegisterPartyType,
+	{differ.ResourcePartyType, differ.ActionUpdate}: MethodUpdatePartyType,
+	// DELETE for party types is not supported (party types are managed through schema updates)
+	// No delete method registered intentionally.
 }
 
 // GenerateIdempotencyKey produces a deterministic SHA-256 based idempotency key.

--- a/services/control-plane/internal/planner/manifest_planner_test.go
+++ b/services/control-plane/internal/planner/manifest_planner_test.go
@@ -530,6 +530,56 @@ func TestPlan_FullEnergyManifest_DryRun(t *testing.T) {
 		"idempotency key should not change based on dry run flag")
 }
 
+// --- Party type planner tests ---
+
+func TestPlan_PartyTypesInPhase6(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourcePartyType, ResourceCode: "tenant-1:PERSON", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+	assert.Equal(t, PhasePartyTypes, plan.Calls[0].Phase)
+}
+
+func TestPlan_GRPCMethodMapping_PartyTypes(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourcePartyType, ResourceCode: "tenant-1:PERSON", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourcePartyType, ResourceCode: "tenant-1:ORGANIZATION", Action: differ.ActionUpdate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+
+	callsByCode := indexCallsByResourceID(plan.Calls)
+	assert.Equal(t, MethodRegisterPartyType, callsByCode["tenant-1:PERSON"].GRPCMethod)
+	assert.Equal(t, MethodUpdatePartyType, callsByCode["tenant-1:ORGANIZATION"].GRPCMethod)
+}
+
+func TestPlan_PartyType_Delete_NoMethodMapping(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourcePartyType, ResourceCode: "tenant-1:PERSON", Action: differ.ActionDelete},
+		},
+	}
+
+	_, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	assert.Error(t, err, "DELETE for party types should fail as no method is mapped")
+	assert.ErrorIs(t, err, ErrNoMethodMapping)
+}
+
+func TestPhaseLabel_PartyTypes(t *testing.T) {
+	assert.Equal(t, "Party Types", PhaseLabel(PhasePartyTypes))
+}
+
 // --- Test helpers ---
 
 func indexCallsByResourceID(calls []PlannedCall) map[string]PlannedCall {

--- a/services/control-plane/internal/planner/manifest_planner_test.go
+++ b/services/control-plane/internal/planner/manifest_planner_test.go
@@ -461,6 +461,7 @@ func TestPhaseLabel(t *testing.T) {
 	assert.Equal(t, "Valuation Rules", PhaseLabel(PhaseValuationRules))
 	assert.Equal(t, "Saga Definitions", PhaseLabel(PhaseSagas))
 	assert.Equal(t, "Seed Data", PhaseLabel(PhaseSeedData))
+	assert.Equal(t, "Party Types", PhaseLabel(PhasePartyTypes))
 	assert.True(t, strings.HasPrefix(PhaseLabel(Phase(99)), "Phase("))
 }
 
@@ -563,7 +564,7 @@ func TestPlan_GRPCMethodMapping_PartyTypes(t *testing.T) {
 	assert.Equal(t, MethodUpdatePartyType, callsByCode["tenant-1:ORGANIZATION"].GRPCMethod)
 }
 
-func TestPlan_PartyType_Delete_NoMethodMapping(t *testing.T) {
+func TestPlan_PartyType_Delete_NotSupported(t *testing.T) {
 	p := NewManifestPlanner()
 	diffPlan := &differ.DiffPlan{
 		Actions: []differ.PlannedAction{
@@ -572,12 +573,8 @@ func TestPlan_PartyType_Delete_NoMethodMapping(t *testing.T) {
 	}
 
 	_, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
-	assert.Error(t, err, "DELETE for party types should fail as no method is mapped")
-	assert.ErrorIs(t, err, ErrNoMethodMapping)
-}
-
-func TestPhaseLabel_PartyTypes(t *testing.T) {
-	assert.Equal(t, "Party Types", PhaseLabel(PhasePartyTypes))
+	assert.Error(t, err, "DELETE for party types should fail")
+	assert.ErrorIs(t, err, ErrDeleteNotSupportedForPartyType)
 }
 
 // --- Test helpers ---

--- a/services/control-plane/internal/planner/types.go
+++ b/services/control-plane/internal/planner/types.go
@@ -31,6 +31,9 @@ const (
 	// PhaseSeedData provisions seed data via various service calls
 	// (depends on all above being registered first).
 	PhaseSeedData Phase = 5
+	// PhasePartyTypes registers party type definitions with the Party Service
+	// (no dependencies on other manifest sections).
+	PhasePartyTypes Phase = 6
 )
 
 // PhaseLabel returns a human-readable label for a phase.
@@ -46,6 +49,8 @@ func PhaseLabel(p Phase) string {
 		return "Saga Definitions"
 	case PhaseSeedData:
 		return "Seed Data"
+	case PhasePartyTypes:
+		return "Party Types"
 	default:
 		return fmt.Sprintf("Phase(%d)", p)
 	}
@@ -70,6 +75,10 @@ const (
 	MethodUpdateSagaDefinition GRPCMethod = "meridian.saga.v1.SagaRegistryService/UpdateSagaDefinition"
 	MethodDeprecateSaga        GRPCMethod = "meridian.saga.v1.SagaRegistryService/DeprecateSaga"
 	MethodActivateSaga         GRPCMethod = "meridian.saga.v1.SagaRegistryService/ActivateSaga"
+
+	// Party Service
+	MethodRegisterPartyType GRPCMethod = "meridian.party.v1.PartyService/RegisterPartyType"
+	MethodUpdatePartyType   GRPCMethod = "meridian.party.v1.PartyService/UpdatePartyType"
 )
 
 // PlannedCall represents a single gRPC call in the execution plan.
@@ -173,7 +182,7 @@ func (p *ExecutionPlan) Visualize() string {
 	fmt.Fprintf(&b, "Total calls: %d\n\n", len(p.Calls))
 
 	byPhase := p.ByPhase()
-	for phase := PhaseInstruments; phase <= PhaseSeedData; phase++ {
+	for phase := PhaseInstruments; phase <= PhasePartyTypes; phase++ {
 		calls, ok := byPhase[phase]
 		if !ok {
 			continue

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -6,6 +6,7 @@
 package validator
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -142,9 +143,10 @@ type ValidationResult struct {
 
 // ManifestValidator validates Meridian manifests.
 type ManifestValidator struct {
-	protoValidator protovalidate.Validator
-	celEnv         *cel.Env
-	bucketCelEnv   *cel.Env
+	protoValidator  protovalidate.Validator
+	celEnv          *cel.Env
+	bucketCelEnv    *cel.Env
+	partyTypeCelEnv *cel.Env
 }
 
 // New creates a new ManifestValidator.
@@ -178,10 +180,21 @@ func New() (*ManifestValidator, error) {
 		return nil, fmt.Errorf("failed to create bucket CEL environment: %w", err)
 	}
 
+	// CEL environment for party type validation/eligibility expressions.
+	// These expressions operate on party attributes.
+	partyTypeCelEnv, err := cel.NewEnv(
+		cel.Variable("attributes", cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable("party_type", cel.StringType),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create party type CEL environment: %w", err)
+	}
+
 	return &ManifestValidator{
-		protoValidator: pv,
-		celEnv:         celEnv,
-		bucketCelEnv:   bucketCelEnv,
+		protoValidator:  pv,
+		celEnv:          celEnv,
+		bucketCelEnv:    bucketCelEnv,
+		partyTypeCelEnv: partyTypeCelEnv,
 	}, nil
 }
 
@@ -211,7 +224,10 @@ func (v *ManifestValidator) Validate(
 	// 6. Payment rails validation
 	v.validatePaymentRails(manifest, result)
 
-	// 7. Immutability checks
+	// 7. Party types validation
+	v.validatePartyTypes(manifest, result)
+
+	// 8. Immutability checks
 	if previousManifest != nil {
 		v.validateImmutability(manifest, previousManifest, result)
 	}
@@ -631,6 +647,62 @@ func checkInstrumentRef(
 		ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
 	}
 	addError(result, ve)
+}
+
+// celPartyTypeFields lists the variables available in party type CEL expressions.
+var celPartyTypeFields = []string{"attributes", "party_type"}
+
+// validatePartyTypes validates all party type definitions in the manifest.
+func (v *ManifestValidator) validatePartyTypes(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	// Check duplicate (tenant_id, party_type) pairs
+	seen := make(map[string]int)
+	for i, pt := range manifest.GetPartyTypes() {
+		key := pt.GetTenantId() + ":" + pt.GetPartyType()
+		if prev, exists := seen[key]; exists {
+			addError(result, ValidationError{
+				Severity: SeverityError,
+				Path:     fmt.Sprintf("party_types[%d].party_type", i),
+				Code:     "DUPLICATE_PARTY_TYPE",
+				Message:  fmt.Sprintf("duplicate party_type %q for tenant %q (first defined at party_types[%d])", pt.GetPartyType(), pt.GetTenantId(), prev),
+			})
+		} else {
+			seen[key] = i
+		}
+
+		basePath := fmt.Sprintf("party_types[%d]", i)
+
+		// Validate attribute_schema is valid JSON
+		if schema := pt.GetAttributeSchema(); schema != "" {
+			v.validatePartyTypeSchema(schema, basePath+".attribute_schema", result)
+		}
+
+		// Validate CEL expressions
+		if expr := pt.GetValidationCel(); expr != "" {
+			v.validateCELExpression(expr, basePath+".validation_cel", v.partyTypeCelEnv, celPartyTypeFields, result)
+		}
+		if expr := pt.GetEligibilityCel(); expr != "" {
+			v.validateCELExpression(expr, basePath+".eligibility_cel", v.partyTypeCelEnv, celPartyTypeFields, result)
+		}
+		if expr := pt.GetErrorMessageCel(); expr != "" {
+			v.validateCELExpression(expr, basePath+".error_message_cel", v.partyTypeCelEnv, celPartyTypeFields, result)
+		}
+	}
+}
+
+// validatePartyTypeSchema validates that a party type attribute_schema is valid JSON.
+func (v *ManifestValidator) validatePartyTypeSchema(schema, path string, result *ValidationResult) {
+	var js json.RawMessage
+	if err := json.Unmarshal([]byte(schema), &js); err != nil {
+		addError(result, ValidationError{
+			Severity: SeverityError,
+			Path:     path,
+			Code:     "INVALID_JSON_SCHEMA",
+			Message:  fmt.Sprintf("attribute_schema is not valid JSON: %s", err.Error()),
+		})
+	}
 }
 
 // validateImmutability checks that immutable code fields have not been changed.

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -1245,4 +1248,221 @@ func TestValidateImmutability_AddNewInstrument(t *testing.T) {
 	if !result.Valid {
 		t.Errorf("expected valid manifest when adding new instrument, got errors: %v", result.Errors)
 	}
+}
+
+// --- Party type validator tests ---
+
+func TestValidatePartyTypes_ValidDefinition(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		{
+			Id:              "ptd-person-001",
+			TenantId:        "tenant-1",
+			PartyType:       "PERSON",
+			AttributeSchema: `{"type": "object", "properties": {"name": {"type": "string"}}}`,
+		},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.True(t, result.Valid, "valid party type should pass validation, errors: %v", result.Errors)
+}
+
+func TestValidatePartyTypes_InvalidJSON_Schema(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		{
+			Id:              "ptd-person-001",
+			TenantId:        "tenant-1",
+			PartyType:       "PERSON",
+			AttributeSchema: `{not valid json`,
+		},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+	// Find the JSON schema error (there may be other errors)
+	var jsonSchemaErr *ValidationError
+	for i := range result.Errors {
+		if result.Errors[i].Code == "INVALID_JSON_SCHEMA" {
+			jsonSchemaErr = &result.Errors[i]
+			break
+		}
+	}
+	require.NotNil(t, jsonSchemaErr, "expected INVALID_JSON_SCHEMA error, got: %v", result.Errors)
+	assert.Contains(t, jsonSchemaErr.Path, "party_types[0].attribute_schema")
+}
+
+func TestValidatePartyTypes_DuplicatePartyType(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		{
+			Id:              "ptd-person-001",
+			TenantId:        "tenant-1",
+			PartyType:       "PERSON",
+			AttributeSchema: `{"type": "object"}`,
+		},
+		{
+			Id:              "ptd-person-002",
+			TenantId:        "tenant-1",
+			PartyType:       "PERSON",
+			AttributeSchema: `{"type": "object", "properties": {}}`,
+		},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+	var dupErr *ValidationError
+	for i := range result.Errors {
+		if result.Errors[i].Code == "DUPLICATE_PARTY_TYPE" {
+			dupErr = &result.Errors[i]
+			break
+		}
+	}
+	require.NotNil(t, dupErr, "expected DUPLICATE_PARTY_TYPE error, got: %v", result.Errors)
+	assert.Contains(t, dupErr.Path, "party_types[1].party_type")
+}
+
+func TestValidatePartyTypes_DifferentTenants_SamePartyType_Valid(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		{
+			Id:              "ptd-t1-person",
+			TenantId:        "tenant-1",
+			PartyType:       "PERSON",
+			AttributeSchema: `{"type": "object"}`,
+		},
+		{
+			Id:              "ptd-t2-person",
+			TenantId:        "tenant-2",
+			PartyType:       "PERSON",
+			AttributeSchema: `{"type": "object"}`,
+		},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.True(t, result.Valid, "same party type for different tenants should be valid, errors: %v", result.Errors)
+}
+
+func TestValidatePartyTypes_ValidCELExpressions(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		{
+			Id:              "ptd-person-001",
+			TenantId:        "tenant-1",
+			PartyType:       "PERSON",
+			AttributeSchema: `{"type": "object"}`,
+			ValidationCel:   "party_type == \"PERSON\"",
+			EligibilityCel:  "party_type != \"\"",
+		},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.True(t, result.Valid, "valid CEL expressions should pass, errors: %v", result.Errors)
+}
+
+func TestValidatePartyTypes_InvalidValidationCEL(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		{
+			Id:              "ptd-person-001",
+			TenantId:        "tenant-1",
+			PartyType:       "PERSON",
+			AttributeSchema: `{"type": "object"}`,
+			ValidationCel:   "undeclared_var > 0",
+		},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+	var celErr *ValidationError
+	for i := range result.Errors {
+		if result.Errors[i].Code == "CEL_UNDECLARED_REFERENCE" {
+			celErr = &result.Errors[i]
+			break
+		}
+	}
+	require.NotNil(t, celErr, "expected CEL_UNDECLARED_REFERENCE error, got: %v", result.Errors)
+	assert.Contains(t, celErr.Path, "party_types[0].validation_cel")
+}
+
+func TestValidatePartyTypes_InvalidEligibilityCEL(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		{
+			Id:              "ptd-person-001",
+			TenantId:        "tenant-1",
+			PartyType:       "PERSON",
+			AttributeSchema: `{"type": "object"}`,
+			EligibilityCel:  "invalid_field_name + 1",
+		},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+	var celErr *ValidationError
+	for i := range result.Errors {
+		if result.Errors[i].Code == "CEL_UNDECLARED_REFERENCE" {
+			celErr = &result.Errors[i]
+			break
+		}
+	}
+	require.NotNil(t, celErr, "expected CEL_UNDECLARED_REFERENCE error, got: %v", result.Errors)
+	assert.Contains(t, celErr.Path, "party_types[0].eligibility_cel")
+}
+
+func TestValidatePartyTypes_EmptyPartyTypes_Valid(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	// No party_types field - should be valid
+	result := v.Validate(manifest, nil)
+	assert.True(t, result.Valid, "manifest with no party types should be valid")
+}
+
+func TestValidatePartyTypes_MultipleErrors_ReportedAll(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		{
+			Id:              "ptd-person-001",
+			TenantId:        "tenant-1",
+			PartyType:       "PERSON",
+			AttributeSchema: `{bad json`,
+			ValidationCel:   "unknown_var > 0",
+		},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+	// Should have at least: INVALID_JSON_SCHEMA + CEL_UNDECLARED_REFERENCE
+	codes := make([]string, 0, len(result.Errors))
+	for _, e := range result.Errors {
+		codes = append(codes, e.Code)
+	}
+	assert.Contains(t, codes, "INVALID_JSON_SCHEMA")
+	assert.Contains(t, codes, "CEL_UNDECLARED_REFERENCE")
 }


### PR DESCRIPTION
## Summary
- Extends Manifest proto with `repeated meridian.party.v1.PartyTypeDefinition party_types = 9` field
- Implements differ, planner, and validator for party_types following existing manifest patterns
- Follows existing manifest patterns for instruments/account types/sagas

## Changes Made

### Proto (6.1)
- Added import for `meridian/party/v1/party.proto` in `manifest.proto`
- Added `repeated meridian.party.v1.PartyTypeDefinition party_types = 9` field to `Manifest` message
- Updated JSON Schema (auto-regenerated by pre-commit hook)

### Differ (6.2)
- Added `ResourcePartyType` constant to `differ/types.go`
- Implemented `diffPartyTypes` using composite key `(tenant_id, party_type)` as stable identifier
- Added `getPartyTypes`, `partyTypeMap`, `partyTypeKey`, `describePartyTypeChanges` helpers
- Added `ResourcePartyType` case to exhaustive switch in `runSafetyChecks`

### Planner (6.3)
- Added `PhasePartyTypes = 6` constant with `"Party Types"` label
- Added `MethodRegisterPartyType` and `MethodUpdatePartyType` gRPC method constants
- Wired `ResourcePartyType` to `PhasePartyTypes` in `phaseForResource`
- Added CREATE and UPDATE entries to `grpcMethodMap` (DELETE intentionally omitted — party types are modified via schema updates, not removed)

### Validator (6.4)
- Added `partyTypeCelEnv` CEL environment with `attributes` and `party_type` variables
- Implemented `validatePartyTypes`: duplicate `(tenant_id, party_type)` detection, JSON schema validity, CEL expression validation for `validation_cel`, `eligibility_cel`, and `error_message_cel`

## Test plan
- [ ] Differ correctly identifies added/modified/removed party types by (tenant_id, party_type) key
- [ ] Differ describes changes to attribute_schema, validation_cel, eligibility_cel, error_message_cel
- [ ] Planner assigns party types to PhasePartyTypes (phase 6)
- [ ] Planner maps CREATE to RegisterPartyType and UPDATE to UpdatePartyType
- [ ] Planner returns ErrNoMethodMapping for DELETE (not supported)
- [ ] Validator rejects invalid JSON attribute_schema
- [ ] Validator rejects duplicate (tenant_id, party_type) pairs
- [ ] Validator allows same party_type for different tenants
- [ ] Validator rejects invalid CEL expressions in validation_cel, eligibility_cel
- [ ] All existing control-plane tests pass