### PR TITLE
feat(party): Integrate attribute validation in Party service

### DIFF
--- a/api/proto/meridian/party/v1/party.proto
+++ b/api/proto/meridian/party/v1/party.proto
@@ -244,7 +244,7 @@ message RetrievePartyResponse {
 // UpdatePartyRequest is the request to update party details (BIAN UpCR).
 // When update_mask is provided, only the specified fields are updated.
 // When update_mask is empty or not provided, only display_name is updated.
-// Supported update_mask paths: "display_name".
+// Supported update_mask paths: "display_name", "attributes".
 message UpdatePartyRequest {
   // party_id is the unique identifier of the party to update.
   string party_id = 1 [(buf.validate.field).string = {
@@ -254,7 +254,7 @@ message UpdatePartyRequest {
   }];
 
   // update_mask specifies which fields to update (partial update support).
-  // Supported paths: "display_name". Other fields are reserved for future use.
+  // Supported paths: "display_name", "attributes".
   google.protobuf.FieldMask update_mask = 2;
 
   // legal_name is the updated official registered name (optional).
@@ -271,6 +271,10 @@ message UpdatePartyRequest {
 
   // version is for optimistic locking.
   int32 version = 7 [(buf.validate.field).int32 = {gte: 0}];
+
+  // attributes contains structured key-value metadata to set on the party.
+  // Validated against the tenant's PartyTypeDefinition schema when present.
+  repeated meridian.quantity.v1.AttributeEntry attributes = 8;
 }
 
 // UpdatePartyResponse is the response after updating a party.

--- a/services/party/cmd/main.go
+++ b/services/party/cmd/main.go
@@ -106,6 +106,13 @@ func run(logger *slog.Logger) error {
 	}
 	partyService.WithPartyTypeDefinitionService(partyTypeSvc)
 
+	// Create and wire attribute validator
+	attributeValidator, err := service.NewAttributeValidator(partyTypeRepo, partyTypeSvc.CELCompiler())
+	if err != nil {
+		return fmt.Errorf("failed to create attribute validator: %w", err)
+	}
+	partyService.WithAttributeValidator(attributeValidator)
+
 	// Load verification config with environment-aware validation.
 	// Production: fail fast if config is missing or invalid.
 	// Development: allow service to start without provider (warn and continue).

--- a/services/party/service/attribute_validation_integration_test.go
+++ b/services/party/service/attribute_validation_integration_test.go
@@ -1,0 +1,285 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+	"github.com/meridianhub/meridian/services/party/domain"
+	sharedcel "github.com/meridianhub/meridian/shared/pkg/cel"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+// newTestServiceWithValidator creates a Service with an AttributeValidator for testing.
+func newTestServiceWithValidator(mock *mockRepository, ptRepo PartyTypeDefinitionRepository) *Service {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc, _ := NewService(mock, logger)
+
+	compiler, err := sharedcel.NewCompiler()
+	if err != nil {
+		panic(err)
+	}
+	validator, err := NewAttributeValidator(ptRepo, compiler)
+	if err != nil {
+		panic(err)
+	}
+	svc.WithAttributeValidator(validator)
+	return svc
+}
+
+// tenantCtx returns a context carrying the test tenant ID.
+func tenantCtx() context.Context {
+	return tenant.WithTenant(context.Background(), tenant.TenantID(testTenantID))
+}
+
+// TestRegisterParty_AttributeValidation tests attribute validation in RegisterParty.
+func TestRegisterParty_AttributeValidation(t *testing.T) {
+	t.Parallel()
+
+	schema := `{
+		"type": "object",
+		"properties": {
+			"annual_income": {"type": "string"}
+		},
+		"required": ["annual_income"]
+	}`
+
+	t.Run("valid attributes pass validation", func(t *testing.T) {
+		mock := newMockRepository()
+		ptRepo := newMockPartyTypeRepo()
+		ptRepo.entities[uuid.New()] = makePartyTypeDefinition(testTenantID, "PERSON", schema, "")
+
+		svc := newTestServiceWithValidator(mock, ptRepo)
+
+		resp, err := svc.RegisterParty(tenantCtx(), &pb.RegisterPartyRequest{
+			PartyType: pb.PartyType_PARTY_TYPE_PERSON,
+			LegalName: "Alice Smith",
+			Attributes: []*quantityv1.AttributeEntry{
+				{Key: "annual_income", Value: "50000"},
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.NotEmpty(t, resp.Party.PartyId)
+	})
+
+	t.Run("missing required attribute fails validation", func(t *testing.T) {
+		mock := newMockRepository()
+		ptRepo := newMockPartyTypeRepo()
+		ptRepo.entities[uuid.New()] = makePartyTypeDefinition(testTenantID, "PERSON", schema, "")
+
+		svc := newTestServiceWithValidator(mock, ptRepo)
+
+		resp, err := svc.RegisterParty(tenantCtx(), &pb.RegisterPartyRequest{
+			PartyType: pb.PartyType_PARTY_TYPE_PERSON,
+			LegalName: "Bob Jones",
+			// No attributes - required annual_income missing
+		})
+
+		assert.Nil(t, resp)
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "attribute validation failed")
+	})
+
+	t.Run("no type definition skips validation", func(t *testing.T) {
+		mock := newMockRepository()
+		ptRepo := newMockPartyTypeRepo()
+		// No definition registered for PERSON
+
+		svc := newTestServiceWithValidator(mock, ptRepo)
+
+		resp, err := svc.RegisterParty(tenantCtx(), &pb.RegisterPartyRequest{
+			PartyType: pb.PartyType_PARTY_TYPE_PERSON,
+			LegalName: "Carol White",
+			// No attributes - but no schema to validate against
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("no validator set skips validation", func(t *testing.T) {
+		// Service without AttributeValidator - should work as before
+		mock := newMockRepository()
+		svc := newTestService(mock)
+
+		resp, err := svc.RegisterParty(context.Background(), &pb.RegisterPartyRequest{
+			PartyType: pb.PartyType_PARTY_TYPE_PERSON,
+			LegalName: "Dave Brown",
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("no tenant context skips validation", func(t *testing.T) {
+		mock := newMockRepository()
+		ptRepo := newMockPartyTypeRepo()
+		ptRepo.entities[uuid.New()] = makePartyTypeDefinition(testTenantID, "PERSON", schema, "")
+
+		svc := newTestServiceWithValidator(mock, ptRepo)
+
+		// No tenant context - validation skipped
+		resp, err := svc.RegisterParty(context.Background(), &pb.RegisterPartyRequest{
+			PartyType: pb.PartyType_PARTY_TYPE_PERSON,
+			LegalName: "Eve Davis",
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("CEL validation failure rejects registration", func(t *testing.T) {
+		mock := newMockRepository()
+		ptRepo := newMockPartyTypeRepo()
+		celSchema := `{"type":"object","properties":{"income":{"type":"string"}}}`
+		celExpr := `"income" in attributes && attributes["income"] != ""`
+		ptRepo.entities[uuid.New()] = makePartyTypeDefinition(testTenantID, "PERSON", celSchema, celExpr)
+
+		svc := newTestServiceWithValidator(mock, ptRepo)
+
+		resp, err := svc.RegisterParty(tenantCtx(), &pb.RegisterPartyRequest{
+			PartyType: pb.PartyType_PARTY_TYPE_PERSON,
+			LegalName: "Frank Lee",
+			Attributes: []*quantityv1.AttributeEntry{
+				{Key: "income", Value: ""}, // empty income fails CEL
+			},
+		})
+
+		assert.Nil(t, resp)
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+}
+
+// TestUpdateParty_AttributeValidation tests attribute validation in UpdateParty.
+func TestUpdateParty_AttributeValidation(t *testing.T) {
+	t.Parallel()
+
+	schema := `{
+		"type": "object",
+		"properties": {
+			"annual_income": {"type": "string"}
+		},
+		"required": ["annual_income"]
+	}`
+
+	// Helper to set up a party in the mock repository
+	setupParty := func(mock *mockRepository) *domain.Party {
+		party, err := domain.NewParty(domain.PartyTypePerson, "Test Person")
+		if err != nil {
+			panic(err)
+		}
+		mock.parties[party.ID()] = party
+		return party
+	}
+
+	t.Run("valid attributes pass validation with update mask", func(t *testing.T) {
+		mock := newMockRepository()
+		ptRepo := newMockPartyTypeRepo()
+		ptRepo.entities[uuid.New()] = makePartyTypeDefinition(testTenantID, "PERSON", schema, "")
+
+		svc := newTestServiceWithValidator(mock, ptRepo)
+		party := setupParty(mock)
+
+		resp, err := svc.UpdateParty(tenantCtx(), &pb.UpdatePartyRequest{
+			PartyId: party.ID().String(),
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"attributes"},
+			},
+			Attributes: []*quantityv1.AttributeEntry{
+				{Key: "annual_income", Value: "60000"},
+			},
+			Version: int32(party.Version()),
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Len(t, resp.Party.Attributes, 1)
+	})
+
+	t.Run("invalid attributes fail validation with update mask", func(t *testing.T) {
+		mock := newMockRepository()
+		ptRepo := newMockPartyTypeRepo()
+		ptRepo.entities[uuid.New()] = makePartyTypeDefinition(testTenantID, "PERSON", schema, "")
+
+		svc := newTestServiceWithValidator(mock, ptRepo)
+		party := setupParty(mock)
+
+		resp, err := svc.UpdateParty(tenantCtx(), &pb.UpdatePartyRequest{
+			PartyId: party.ID().String(),
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"attributes"},
+			},
+			Attributes: []*quantityv1.AttributeEntry{
+				// Missing required annual_income
+				{Key: "other_field", Value: "value"},
+			},
+			Version: int32(party.Version()),
+		})
+
+		assert.Nil(t, resp)
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("attributes not in update mask skips validation", func(t *testing.T) {
+		mock := newMockRepository()
+		ptRepo := newMockPartyTypeRepo()
+		ptRepo.entities[uuid.New()] = makePartyTypeDefinition(testTenantID, "PERSON", schema, "")
+
+		svc := newTestServiceWithValidator(mock, ptRepo)
+		party := setupParty(mock)
+
+		// Update display_name only - attributes validation should be skipped
+		resp, err := svc.UpdateParty(tenantCtx(), &pb.UpdatePartyRequest{
+			PartyId: party.ID().String(),
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"display_name"},
+			},
+			DisplayName: "Updated Name",
+			Version:     int32(party.Version()),
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("no update mask applies attributes without required validation skipping", func(t *testing.T) {
+		// Without field mask, the existing attributes on the party are not changed
+		// unless explicitly updated (matching existing behavior)
+		mock := newMockRepository()
+		ptRepo := newMockPartyTypeRepo()
+		ptRepo.entities[uuid.New()] = makePartyTypeDefinition(testTenantID, "PERSON", schema, "")
+
+		svc := newTestServiceWithValidator(mock, ptRepo)
+		party := setupParty(mock)
+
+		// No field mask, no attributes provided - just update display name
+		resp, err := svc.UpdateParty(tenantCtx(), &pb.UpdatePartyRequest{
+			PartyId:     party.ID().String(),
+			DisplayName: "New Name",
+			Version:     int32(party.Version()),
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+}

--- a/services/party/service/attribute_validator.go
+++ b/services/party/service/attribute_validator.go
@@ -1,0 +1,191 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	lru "github.com/hashicorp/golang-lru/v2"
+
+	"github.com/meridianhub/meridian/services/party/adapters/persistence"
+	"github.com/meridianhub/meridian/services/party/domain"
+	sharedcel "github.com/meridianhub/meridian/shared/pkg/cel"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+// celCacheSize is the maximum number of compiled CEL programs retained in the LRU cache.
+const celCacheSize = 256
+
+// Attribute validator errors.
+var (
+	// ErrAttributeValidatorRepoNil is returned when creating an AttributeValidator with a nil repository.
+	ErrAttributeValidatorRepoNil = errors.New("party type definition repository cannot be nil")
+
+	// ErrAttributeValidatorCompilerNil is returned when creating an AttributeValidator with a nil compiler.
+	ErrAttributeValidatorCompilerNil = errors.New("CEL compiler cannot be nil")
+
+	// ErrAttributeValidationFailed is returned when attribute validation fails against the schema or CEL rule.
+	ErrAttributeValidationFailed = errors.New("attribute validation failed")
+
+	// ErrCELNotBoolean is returned when a CEL validation expression does not return a boolean.
+	ErrCELNotBoolean = errors.New("validation CEL expression did not return boolean")
+
+	// ErrCELValidationFailed is returned when a CEL validation expression evaluates to false.
+	ErrCELValidationFailed = errors.New("validation CEL expression returned false")
+)
+
+// AttributeValidator validates party attributes against a tenant's PartyTypeDefinition.
+// It performs JSON Schema validation and optional CEL-based cross-field validation.
+// Compiled CEL programs are cached in an LRU cache to avoid recompilation per request.
+type AttributeValidator struct {
+	repo        PartyTypeDefinitionRepository
+	celCompiler *sharedcel.Compiler
+	// cache keys are "<tenantID>:<partyType>" → compiled CEL program
+	cache *lru.Cache[string, cel.Program]
+}
+
+// NewAttributeValidator creates a new AttributeValidator.
+// Returns an error if either dependency is nil.
+func NewAttributeValidator(repo PartyTypeDefinitionRepository, compiler *sharedcel.Compiler) (*AttributeValidator, error) {
+	if repo == nil {
+		return nil, ErrAttributeValidatorRepoNil
+	}
+	if compiler == nil {
+		return nil, ErrAttributeValidatorCompilerNil
+	}
+
+	cache, err := lru.New[string, cel.Program](celCacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL program cache: %w", err)
+	}
+
+	return &AttributeValidator{
+		repo:        repo,
+		celCompiler: compiler,
+		cache:       cache,
+	}, nil
+}
+
+// CacheLen returns the number of compiled CEL programs currently held in the cache.
+// Intended for testing and observability.
+func (v *AttributeValidator) CacheLen() int {
+	return v.cache.Len()
+}
+
+// ValidateAttributes validates party attributes against the tenant's PartyTypeDefinition
+// for the given party type. If no definition exists for the tenant+type combination,
+// validation is skipped (definitions are optional). Returns ErrAttributeValidationFailed
+// (wrapping details) when validation fails.
+func (v *AttributeValidator) ValidateAttributes(ctx context.Context, tenantID, partyType string, party *domain.Party) error {
+	// Look up the party type definition
+	def, err := v.repo.GetByTenantAndType(ctx, tenantID, partyType)
+	if err != nil {
+		if errors.Is(err, persistence.ErrPartyTypeDefinitionNotFound) {
+			// No definition registered - validation is optional, skip
+			return nil
+		}
+		return fmt.Errorf("failed to look up party type definition: %w", err)
+	}
+
+	// Build attribute map from party's attributes
+	attrMap := attributeEntriesToMap(party.Attributes())
+
+	// 1. JSON Schema validation
+	if err := validateAttributesAgainstSchema(def.AttributeSchema, attrMap); err != nil {
+		return fmt.Errorf("%w: %w", ErrAttributeValidationFailed, err)
+	}
+
+	// 2. CEL cross-field validation (only when a validation expression is configured)
+	if def.ValidationCEL != "" {
+		if err := v.evaluateValidationCEL(def, attrMap); err != nil {
+			return fmt.Errorf("%w: %w", ErrAttributeValidationFailed, err)
+		}
+	}
+
+	return nil
+}
+
+// evaluateValidationCEL compiles (or retrieves from cache) and evaluates the validation
+// CEL expression for the given party type definition.
+func (v *AttributeValidator) evaluateValidationCEL(def *persistence.PartyTypeDefinitionEntity, attrMap map[string]string) error {
+	cacheKey := def.TenantID + ":" + def.PartyType
+
+	prg, ok := v.cache.Get(cacheKey)
+	if !ok {
+		compiled, err := v.celCompiler.CompileValidation(def.ValidationCEL)
+		if err != nil {
+			return fmt.Errorf("failed to compile validation CEL: %w", err)
+		}
+		v.cache.Add(cacheKey, compiled)
+		prg = compiled
+	}
+
+	// Evaluate CEL with the attribute map.
+	// The validation environment expects: attributes (map<string,string>), amount (string),
+	// valid_from (timestamp), valid_to (timestamp), source (string).
+	// For party attribute validation we only populate 'attributes'; other vars use zero values.
+	zero := time.Time{}
+	out, _, err := prg.Eval(map[string]any{
+		"attributes": attrMap,
+		"amount":     "",
+		"valid_from": zero,
+		"valid_to":   zero,
+		"source":     "",
+	})
+	if err != nil {
+		return fmt.Errorf("CEL evaluation error: %w", err)
+	}
+
+	result, ok := out.Value().(bool)
+	if !ok {
+		return ErrCELNotBoolean
+	}
+
+	if !result {
+		return ErrCELValidationFailed
+	}
+
+	return nil
+}
+
+// validateAttributesAgainstSchema validates the attribute map against a JSON Schema.
+// The schema is compiled inline; for production-scale use the schema would also be cached.
+func validateAttributesAgainstSchema(schemaJSON string, attrMap map[string]string) error {
+	compiler := jsonschema.NewCompiler()
+	compiler.Draft = jsonschema.Draft7
+
+	// Add the schema as an in-memory resource
+	schemaURL := "mem:///party_attributes_schema.json"
+	if err := compiler.AddResource(schemaURL, strings.NewReader(schemaJSON)); err != nil {
+		return fmt.Errorf("invalid attribute schema: %w", err)
+	}
+
+	sch, err := compiler.Compile(schemaURL)
+	if err != nil {
+		return fmt.Errorf("failed to compile attribute schema: %w", err)
+	}
+
+	// Convert map[string]string to map[string]interface{} for schema validation
+	doc := make(map[string]interface{}, len(attrMap))
+	for k, val := range attrMap {
+		doc[k] = val
+	}
+
+	if err := sch.Validate(doc); err != nil {
+		return fmt.Errorf("attributes do not match schema: %w", err)
+	}
+
+	return nil
+}
+
+// attributeEntriesToMap converts a slice of AttributeEntry to a map[string]string.
+func attributeEntriesToMap(entries []domain.AttributeEntry) map[string]string {
+	result := make(map[string]string, len(entries))
+	for _, e := range entries {
+		result[e.Key] = e.Value
+	}
+	return result
+}

--- a/services/party/service/attribute_validator.go
+++ b/services/party/service/attribute_validator.go
@@ -43,7 +43,8 @@ var (
 type AttributeValidator struct {
 	repo        PartyTypeDefinitionRepository
 	celCompiler *sharedcel.Compiler
-	// cache keys are "<tenantID>:<partyType>" → compiled CEL program
+	// cache keys are "<tenantID>:<partyType>:<version>" → compiled CEL program.
+	// The version component ensures stale entries are evicted when ValidationCEL is updated.
 	cache *lru.Cache[string, cel.Program]
 }
 
@@ -111,7 +112,7 @@ func (v *AttributeValidator) ValidateAttributes(ctx context.Context, tenantID, p
 // evaluateValidationCEL compiles (or retrieves from cache) and evaluates the validation
 // CEL expression for the given party type definition.
 func (v *AttributeValidator) evaluateValidationCEL(def *persistence.PartyTypeDefinitionEntity, attrMap map[string]string) error {
-	cacheKey := def.TenantID + ":" + def.PartyType
+	cacheKey := fmt.Sprintf("%s:%s:%d", def.TenantID, def.PartyType, def.Version)
 
 	prg, ok := v.cache.Get(cacheKey)
 	if !ok {

--- a/services/party/service/attribute_validator_test.go
+++ b/services/party/service/attribute_validator_test.go
@@ -1,0 +1,285 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/party/adapters/persistence"
+	"github.com/meridianhub/meridian/services/party/domain"
+	sharedcel "github.com/meridianhub/meridian/shared/pkg/cel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestAttributeValidator creates an AttributeValidator with a mock repo and real CEL compiler.
+func newTestAttributeValidator(t *testing.T, repo PartyTypeDefinitionRepository) *AttributeValidator {
+	t.Helper()
+	compiler, err := sharedcel.NewCompiler()
+	require.NoError(t, err)
+	v, err := NewAttributeValidator(repo, compiler)
+	require.NoError(t, err)
+	return v
+}
+
+// makePartyTypeDefinition creates a test entity with given parameters.
+func makePartyTypeDefinition(tenantID, partyType, schema, validationCEL string) *persistence.PartyTypeDefinitionEntity {
+	return &persistence.PartyTypeDefinitionEntity{
+		ID:              uuid.New(),
+		TenantID:        tenantID,
+		PartyType:       partyType,
+		AttributeSchema: schema,
+		ValidationCEL:   validationCEL,
+		Version:         1,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+}
+
+// makeParty creates a domain Party with the given attributes.
+func makeParty(partyType domain.PartyType, attrs []domain.AttributeEntry) *domain.Party {
+	p, err := domain.NewParty(partyType, "Test Party")
+	if err != nil {
+		panic(err)
+	}
+	if attrs != nil {
+		p.SetAttributes(attrs)
+	}
+	return p
+}
+
+// TestNewAttributeValidator_NilRepoReturnsError verifies that a nil repository is rejected.
+func TestNewAttributeValidator_NilRepoReturnsError(t *testing.T) {
+	compiler, err := sharedcel.NewCompiler()
+	require.NoError(t, err)
+
+	_, err = NewAttributeValidator(nil, compiler)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAttributeValidatorRepoNil)
+}
+
+// TestNewAttributeValidator_NilCompilerReturnsError verifies that a nil compiler is rejected.
+func TestNewAttributeValidator_NilCompilerReturnsError(t *testing.T) {
+	repo := newMockPartyTypeRepo()
+
+	_, err := NewAttributeValidator(repo, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAttributeValidatorCompilerNil)
+}
+
+// TestValidateAttributes_NoDefinitionSkipsValidation verifies that when no PartyTypeDefinition
+// is registered for a tenant+type, validation is skipped (not an error).
+func TestValidateAttributes_NoDefinitionSkipsValidation(t *testing.T) {
+	repo := newMockPartyTypeRepo()
+	v := newTestAttributeValidator(t, repo)
+
+	party := makeParty(domain.PartyTypePerson, []domain.AttributeEntry{
+		{Key: "foo", Value: "bar"},
+	})
+
+	err := v.ValidateAttributes(context.Background(), testTenantID, "PERSON", party)
+	require.NoError(t, err)
+}
+
+// TestValidateAttributes_EmptyAttributesPassValidation verifies that empty attributes
+// pass validation when there is no required schema constraint.
+func TestValidateAttributes_EmptyAttributesPassValidation(t *testing.T) {
+	repo := newMockPartyTypeRepo()
+	schema := `{"type":"object","properties":{"name":{"type":"string"}}}`
+	repo.entities[uuid.New()] = makePartyTypeDefinition(testTenantID, "PERSON", schema, "")
+
+	v := newTestAttributeValidator(t, repo)
+	party := makeParty(domain.PartyTypePerson, nil)
+
+	err := v.ValidateAttributes(context.Background(), testTenantID, "PERSON", party)
+	require.NoError(t, err)
+}
+
+// TestValidateAttributes_ValidAttributesPassJSONSchema verifies that attributes matching
+// the JSON Schema pass validation.
+func TestValidateAttributes_ValidAttributesPassJSONSchema(t *testing.T) {
+	repo := newMockPartyTypeRepo()
+	schema := `{
+		"type": "object",
+		"properties": {
+			"annual_income": {"type": "string"},
+			"employment_status": {"type": "string", "enum": ["EMPLOYED", "SELF_EMPLOYED", "UNEMPLOYED"]}
+		},
+		"required": ["annual_income"]
+	}`
+	repo.entities[uuid.New()] = makePartyTypeDefinition(testTenantID, "PERSON", schema, "")
+
+	v := newTestAttributeValidator(t, repo)
+	party := makeParty(domain.PartyTypePerson, []domain.AttributeEntry{
+		{Key: "annual_income", Value: "50000"},
+		{Key: "employment_status", Value: "EMPLOYED"},
+	})
+
+	err := v.ValidateAttributes(context.Background(), testTenantID, "PERSON", party)
+	require.NoError(t, err)
+}
+
+// TestValidateAttributes_MissingRequiredFieldFailsJSONSchema verifies that missing required
+// attributes are rejected.
+func TestValidateAttributes_MissingRequiredFieldFailsJSONSchema(t *testing.T) {
+	repo := newMockPartyTypeRepo()
+	schema := `{
+		"type": "object",
+		"properties": {
+			"annual_income": {"type": "string"}
+		},
+		"required": ["annual_income"]
+	}`
+	repo.entities[uuid.New()] = makePartyTypeDefinition(testTenantID, "PERSON", schema, "")
+
+	v := newTestAttributeValidator(t, repo)
+	party := makeParty(domain.PartyTypePerson, []domain.AttributeEntry{
+		{Key: "other_field", Value: "value"},
+	})
+
+	err := v.ValidateAttributes(context.Background(), testTenantID, "PERSON", party)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAttributeValidationFailed)
+}
+
+// TestValidateAttributes_AdditionalPropertiesFailsWhenDisallowed verifies that extra
+// attributes are rejected when additionalProperties is false.
+func TestValidateAttributes_AdditionalPropertiesFailsWhenDisallowed(t *testing.T) {
+	repo := newMockPartyTypeRepo()
+	schema := `{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"}
+		},
+		"additionalProperties": false
+	}`
+	repo.entities[uuid.New()] = makePartyTypeDefinition(testTenantID, "PERSON", schema, "")
+
+	v := newTestAttributeValidator(t, repo)
+	party := makeParty(domain.PartyTypePerson, []domain.AttributeEntry{
+		{Key: "name", Value: "Alice"},
+		{Key: "unknown_field", Value: "value"},
+	})
+
+	err := v.ValidateAttributes(context.Background(), testTenantID, "PERSON", party)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAttributeValidationFailed)
+}
+
+// TestValidateAttributes_ValidationCELPasses verifies that a passing CEL expression
+// allows the request through.
+func TestValidateAttributes_ValidationCELPasses(t *testing.T) {
+	repo := newMockPartyTypeRepo()
+	schema := `{"type":"object","properties":{"annual_income":{"type":"string"}}}`
+	// Use "in" operator to check map key presence (CEL has() works on proto fields, not map keys)
+	validationCEL := `"annual_income" in attributes && attributes["annual_income"] != ""`
+	repo.entities[uuid.New()] = makePartyTypeDefinition(testTenantID, "PERSON", schema, validationCEL)
+
+	v := newTestAttributeValidator(t, repo)
+	party := makeParty(domain.PartyTypePerson, []domain.AttributeEntry{
+		{Key: "annual_income", Value: "75000"},
+	})
+
+	err := v.ValidateAttributes(context.Background(), testTenantID, "PERSON", party)
+	require.NoError(t, err)
+}
+
+// TestValidateAttributes_ValidationCELFails verifies that a failing CEL expression
+// rejects the request.
+func TestValidateAttributes_ValidationCELFails(t *testing.T) {
+	repo := newMockPartyTypeRepo()
+	schema := `{"type":"object","properties":{"annual_income":{"type":"string"}}}`
+	// CEL that requires annual_income to be non-empty
+	validationCEL := `"annual_income" in attributes && attributes["annual_income"] != ""`
+	repo.entities[uuid.New()] = makePartyTypeDefinition(testTenantID, "PERSON", schema, validationCEL)
+
+	v := newTestAttributeValidator(t, repo)
+	party := makeParty(domain.PartyTypePerson, []domain.AttributeEntry{
+		{Key: "annual_income", Value: ""},
+	})
+
+	err := v.ValidateAttributes(context.Background(), testTenantID, "PERSON", party)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAttributeValidationFailed)
+}
+
+// TestValidateAttributes_CachingReducesCompilation verifies the LRU cache works by
+// validating the same tenant+type twice - the second call should use the cached program.
+func TestValidateAttributes_CachingReducesCompilation(t *testing.T) {
+	repo := newMockPartyTypeRepo()
+	schema := `{"type":"object","properties":{"x":{"type":"string"}}}`
+	validationCEL := `"x" in attributes`
+	repo.entities[uuid.New()] = makePartyTypeDefinition(testTenantID, "PERSON", schema, validationCEL)
+
+	v := newTestAttributeValidator(t, repo)
+	party := makeParty(domain.PartyTypePerson, []domain.AttributeEntry{
+		{Key: "x", Value: "1"},
+	})
+
+	// First call
+	err := v.ValidateAttributes(context.Background(), testTenantID, "PERSON", party)
+	require.NoError(t, err)
+
+	// Second call - should use cached program
+	err = v.ValidateAttributes(context.Background(), testTenantID, "PERSON", party)
+	require.NoError(t, err)
+
+	// Cache should have one entry
+	assert.Equal(t, 1, v.CacheLen())
+}
+
+// errRepo is a stub repository that returns errors for GetByTenantAndType.
+type errRepo struct {
+	mockPartyTypeDefinitionRepository
+	getTenantTypeErr error
+}
+
+func (r *errRepo) GetByTenantAndType(_ context.Context, _, _ string) (*persistence.PartyTypeDefinitionEntity, error) {
+	if r.getTenantTypeErr != nil {
+		return nil, r.getTenantTypeErr
+	}
+	return nil, persistence.ErrPartyTypeDefinitionNotFound
+}
+
+// TestValidateAttributes_RepoErrorPropagates verifies that repository errors are propagated.
+func TestValidateAttributes_RepoErrorPropagates(t *testing.T) {
+	repo := &errRepo{
+		mockPartyTypeDefinitionRepository: *newMockPartyTypeRepo(),
+		getTenantTypeErr:                  errors.New("database error"),
+	}
+
+	v := newTestAttributeValidator(t, repo)
+	party := makeParty(domain.PartyTypePerson, nil)
+
+	err := v.ValidateAttributes(context.Background(), testTenantID, "PERSON", party)
+	require.Error(t, err)
+}
+
+// TestValidateAttributes_DifferentTenantsSeparateDefinitions verifies that tenant isolation
+// works: each tenant has its own definition.
+func TestValidateAttributes_DifferentTenantsSeparateDefinitions(t *testing.T) {
+	repo := newMockPartyTypeRepo()
+
+	// Tenant A: requires annual_income
+	schemaA := `{"type":"object","required":["annual_income"],"properties":{"annual_income":{"type":"string"}}}`
+	repo.entities[uuid.New()] = makePartyTypeDefinition("tenant_a", "PERSON", schemaA, "")
+
+	// Tenant B: no requirements
+	schemaB := `{"type":"object","properties":{"name":{"type":"string"}}}`
+	repo.entities[uuid.New()] = makePartyTypeDefinition("tenant_b", "PERSON", schemaB, "")
+
+	v := newTestAttributeValidator(t, repo)
+
+	// Tenant A party without annual_income should fail
+	partyA := makeParty(domain.PartyTypePerson, nil)
+	err := v.ValidateAttributes(context.Background(), "tenant_a", "PERSON", partyA)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAttributeValidationFailed)
+
+	// Tenant B party without annual_income should pass
+	partyB := makeParty(domain.PartyTypePerson, nil)
+	err = v.ValidateAttributes(context.Background(), "tenant_b", "PERSON", partyB)
+	require.NoError(t, err)
+}

--- a/services/party/service/grpc_service.go
+++ b/services/party/service/grpc_service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/meridianhub/meridian/services/party/domain"
 	"github.com/meridianhub/meridian/services/party/verification"
 	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -87,6 +88,7 @@ type Service struct {
 	pmRepo               PaymentMethodRepository
 	verificationProvider verification.Provider
 	partyTypeService     *PartyTypeDefinitionService
+	attributeValidator   *AttributeValidator
 	logger               *slog.Logger
 }
 
@@ -117,6 +119,14 @@ func (s *Service) WithPaymentMethodRepository(pmRepo PaymentMethodRepository) *S
 // When set, ExchangeDemographics delegates to the real provider instead of returning a stub.
 func (s *Service) WithVerificationProvider(provider verification.Provider) *Service {
 	s.verificationProvider = provider
+	return s
+}
+
+// WithAttributeValidator sets the attribute validator on the service.
+// When set, RegisterParty and UpdateParty validate attributes against the tenant's
+// PartyTypeDefinition schema and CEL rules.
+func (s *Service) WithAttributeValidator(v *AttributeValidator) *Service {
+	s.attributeValidator = v
 	return s
 }
 
@@ -174,6 +184,22 @@ func (s *Service) RegisterParty(ctx context.Context, req *pb.RegisterPartyReques
 	// Set optional attributes if provided at registration time.
 	if len(req.Attributes) > 0 {
 		party.SetAttributes(protoAttributesToDomain(req.Attributes))
+	}
+
+	// === Attribute validation ===
+
+	// Validate attributes against the tenant's PartyTypeDefinition schema and CEL rules.
+	// Validation is skipped when no validator is configured or no tenant context is present.
+	if s.attributeValidator != nil {
+		if tid, ok := tenant.FromContext(ctx); ok {
+			if err := s.attributeValidator.ValidateAttributes(ctx, tid.String(), string(partyType), party); err != nil {
+				s.logger.Warn("attribute validation failed during registration",
+					"party_type", partyType,
+					"tenant_id", tid.String(),
+					"error", err)
+				return nil, status.Errorf(codes.InvalidArgument, "attribute validation failed: %v", err)
+			}
+		}
 	}
 
 	// === External reference handling ===
@@ -404,8 +430,12 @@ func (s *Service) UpdateParty(ctx context.Context, req *pb.UpdatePartyRequest) (
 	}
 
 	// Apply field mask updates
+	attributesUpdated := false
 	if req.UpdateMask != nil && len(req.UpdateMask.Paths) > 0 {
 		for _, path := range req.UpdateMask.Paths {
+			if path == "attributes" {
+				attributesUpdated = true
+			}
 			if err := s.applyFieldUpdate(party, path, req); err != nil {
 				s.logger.Error("failed to apply field update", "field", path, "error", err)
 				return nil, status.Errorf(codes.InvalidArgument, "failed to update field %s: %v", path, err)
@@ -417,6 +447,22 @@ func (s *Service) UpdateParty(ctx context.Context, req *pb.UpdatePartyRequest) (
 			if err := party.SetDisplayName(req.DisplayName); err != nil {
 				s.logger.Error("invalid display name", "error", err)
 				return nil, status.Errorf(codes.InvalidArgument, "invalid display name: %v", err)
+			}
+		}
+	}
+
+	// Validate attributes if they were updated and a validator is configured.
+	// Validation is skipped when no validator is configured or no tenant context is present.
+	if attributesUpdated && s.attributeValidator != nil {
+		if tid, ok := tenant.FromContext(ctx); ok {
+			partyType := string(party.PartyType())
+			if err := s.attributeValidator.ValidateAttributes(ctx, tid.String(), partyType, party); err != nil {
+				s.logger.Warn("attribute validation failed during update",
+					"party_id", req.PartyId,
+					"party_type", partyType,
+					"tenant_id", tid.String(),
+					"error", err)
+				return nil, status.Errorf(codes.InvalidArgument, "attribute validation failed: %v", err)
 			}
 		}
 	}
@@ -445,6 +491,8 @@ func (s *Service) applyFieldUpdate(party *domain.Party, path string, req *pb.Upd
 		if req.DisplayName != "" {
 			return party.SetDisplayName(req.DisplayName)
 		}
+	case "attributes":
+		party.SetAttributes(protoAttributesToDomain(req.Attributes))
 	default:
 		return ErrUnsupportedFieldUpdate
 	}

--- a/services/party/service/party_type_service.go
+++ b/services/party/service/party_type_service.go
@@ -108,6 +108,12 @@ func (s *PartyTypeDefinitionService) Register(ctx context.Context, input Registe
 	return entity, nil
 }
 
+// CELCompiler returns the CEL compiler used by this service.
+// Allows sharing the compiler with other components such as AttributeValidator.
+func (s *PartyTypeDefinitionService) CELCompiler() *sharedcel.Compiler {
+	return s.celCompiler
+}
+
 // GetByID retrieves a party type definition by ID.
 func (s *PartyTypeDefinitionService) GetByID(ctx context.Context, id uuid.UUID) (*persistence.PartyTypeDefinitionEntity, error) {
 	return s.repo.GetByID(ctx, id)


### PR DESCRIPTION
## Summary

- Adds `AttributeValidator` that validates party attributes against tenant's `PartyTypeDefinition` using JSON Schema and CEL cross-field validation
- LRU cache (256 entries, hashicorp/golang-lru) for compiled CEL programs to avoid recompilation per request
- `RegisterParty` validates attributes against schema and `validation_cel` when tenant context is present
- `UpdateParty` validates attributes only when `"attributes"` is in the update mask
- Added `attributes` field to `UpdatePartyRequest` proto (field 8)
- Added `"attributes"` path handling to `applyFieldUpdate` in `UpdateParty` handler
- `AttributeValidator` wired in `cmd/main.go`, sharing the CEL compiler from `PartyTypeDefinitionService`
- Validation skipped gracefully when no `PartyTypeDefinition` is registered for the tenant+type, or when no tenant context is present (backwards compatible)

## Test plan

- [x] `AttributeValidator` unit tests: nil repo/compiler rejection, no-definition skip, JSON Schema pass/fail, additionalProperties enforcement, CEL pass/fail, LRU cache hit counting, repo error propagation, tenant isolation
- [x] `RegisterParty` integration tests: valid attributes pass, missing required fails, no definition skips, no validator skips, no tenant context skips, CEL failure rejects
- [x] `UpdateParty` integration tests: valid attributes with update mask pass, invalid attributes with update mask fail, attributes not in mask skips validation, no mask without attributes skips
- [x] All existing party service unit tests pass
- [x] Pre-commit hooks pass (gitleaks, buf lint, gofumpt, golangci-lint)