### PR TITLE
feat: Implement bidirectional mapping engine core

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/redis v0.40.0
 	github.com/tidwall/gjson v1.18.0
+	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.20.6
 	github.com/twmb/franz-go/pkg/kadm v1.17.2
 	go.opentelemetry.io/otel v1.40.0

--- a/go.sum
+++ b/go.sum
@@ -1173,12 +1173,15 @@ github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0 h1:s2bIayFX
 github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0/go.mod h1:h+u/2KoREGTnTl9UwrQ/g+XhasAT8E6dClclAADeXoQ=
 github.com/testcontainers/testcontainers-go/modules/redis v0.40.0 h1:OG4qwcxp2O0re7V7M9lY9w0v6wWgWf7j7rtkpAnGMd0=
 github.com/testcontainers/testcontainers-go/modules/redis v0.40.0/go.mod h1:Bc+EDhKMo5zI5V5zdBkHiMVzeAXbtI4n5isS/nzf6zw=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/services/gateway/internal/mapping/engine.go
+++ b/services/gateway/internal/mapping/engine.go
@@ -1,0 +1,584 @@
+// Package mapping provides a bidirectional JSON transformation engine that applies
+// MappingDefinition proto transforms between external and internal formats.
+package mapping
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/ext"
+	lru "github.com/hashicorp/golang-lru/v2"
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ErrFieldExtraction indicates a failure extracting or setting a field value.
+var ErrFieldExtraction = errors.New("field extraction failed")
+
+// ErrTransform indicates a general transform failure.
+var ErrTransform = errors.New("transform failed")
+
+// ErrValidation indicates a validation CEL expression returned false or failed.
+var ErrValidation = errors.New("validation failed")
+
+// ErrCELCompilation indicates a CEL expression failed to compile.
+var ErrCELCompilation = errors.New("CEL compilation failed")
+
+// ErrCELEvaluation indicates a CEL expression failed during evaluation.
+var ErrCELEvaluation = errors.New("CEL evaluation failed")
+
+// ErrIdempotencyKey indicates a failure deriving the idempotency key.
+var ErrIdempotencyKey = errors.New("idempotency key derivation failed")
+
+// ErrInvalidJSON indicates the input was not valid JSON.
+var ErrInvalidJSON = errors.New("invalid JSON input")
+
+// ErrEnumNotMapped indicates an enum value had no mapping and no fallback.
+var ErrEnumNotMapped = errors.New("enum value not mapped")
+
+// ErrDateParse indicates a date/time string could not be parsed with the given layout.
+var ErrDateParse = errors.New("date parse failed")
+
+// ErrAttributeFlatten indicates a failure during attribute flatten/unflatten.
+var ErrAttributeFlatten = errors.New("attribute flatten failed")
+
+const defaultCacheSize = 256
+
+// Engine applies MappingDefinition transforms in both inbound and outbound directions.
+type Engine struct {
+	celCache *lru.Cache[string, cel.Program]
+	env      *cel.Env
+}
+
+// NewEngine creates a new mapping Engine with a CEL program cache.
+func NewEngine() (*Engine, error) {
+	return NewEngineWithCacheSize(defaultCacheSize)
+}
+
+// NewEngineWithCacheSize creates a new Engine with the specified CEL cache capacity.
+func NewEngineWithCacheSize(cacheSize int) (*Engine, error) {
+	cache, err := lru.New[string, cel.Program](cacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("creating CEL cache: %w", err)
+	}
+
+	env, err := createMappingCELEnv()
+	if err != nil {
+		return nil, fmt.Errorf("creating CEL environment: %w", err)
+	}
+
+	return &Engine{
+		celCache: cache,
+		env:      env,
+	}, nil
+}
+
+// createMappingCELEnv creates a CEL environment for mapping expressions.
+// Variables available: value (dynamic), input (map), mapped (map), payload (map).
+func createMappingCELEnv() (*cel.Env, error) {
+	return cel.NewEnv(
+		cel.Variable("value", cel.DynType),
+		cel.Variable("input", cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable("mapped", cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable("payload", cel.MapType(cel.StringType, cel.DynType)),
+		ext.Strings(),
+		ext.Encoders(),
+		ext.Math(),
+	)
+}
+
+// InboundResult holds the result of an inbound transformation.
+type InboundResult struct {
+	ProtoJSON      []byte
+	IdempotencyKey string
+}
+
+// TransformInbound maps an external JSON payload to internal proto JSON using the mapping definition.
+func (e *Engine) TransformInbound(mapping *mappingv1.MappingDefinition, externalJSON []byte) (*InboundResult, error) {
+	if !gjson.ValidBytes(externalJSON) {
+		return nil, ErrInvalidJSON
+	}
+
+	if err := e.runValidationCEL(mapping.GetInboundValidationCel(), externalJSON); err != nil {
+		return nil, fmt.Errorf("%w: inbound validation: %w", ErrValidation, err)
+	}
+
+	output, err := e.applyInboundFields(mapping.GetFields(), externalJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err = e.applyComputedFields(mapping.GetInboundComputedFields(), externalJSON, output)
+	if err != nil {
+		return nil, err
+	}
+
+	idempotencyKey, err := e.deriveIdempotencyKey(mapping.GetIdempotency(), externalJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	return &InboundResult{
+		ProtoJSON:      []byte(output),
+		IdempotencyKey: idempotencyKey,
+	}, nil
+}
+
+// TransformOutbound maps an internal proto JSON payload to external JSON using the mapping definition.
+func (e *Engine) TransformOutbound(mapping *mappingv1.MappingDefinition, protoJSON []byte) ([]byte, error) {
+	if !gjson.ValidBytes(protoJSON) {
+		return nil, ErrInvalidJSON
+	}
+
+	if err := e.runValidationCEL(mapping.GetOutboundValidationCel(), protoJSON); err != nil {
+		return nil, fmt.Errorf("%w: outbound validation: %w", ErrValidation, err)
+	}
+
+	output, err := e.applyOutboundFields(mapping.GetFields(), protoJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err = e.applyComputedFields(mapping.GetOutboundComputedFields(), protoJSON, output)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(output), nil
+}
+
+// runValidationCEL evaluates a validation CEL expression against the source JSON.
+// Returns nil if the expression is empty or evaluates to true.
+func (e *Engine) runValidationCEL(expr string, sourceJSON []byte) error {
+	if expr == "" {
+		return nil
+	}
+
+	inputMap := gjsonToMap(gjson.ParseBytes(sourceJSON))
+	pass, err := e.evalBoolCEL(expr, map[string]any{
+		"payload": inputMap,
+		"input":   inputMap,
+	})
+	if err != nil {
+		return err
+	}
+	if !pass {
+		return fmt.Errorf("%w: validation expression returned false", ErrValidation)
+	}
+	return nil
+}
+
+// applyInboundFields applies field correspondences for inbound transformation.
+func (e *Engine) applyInboundFields(fields []*mappingv1.FieldCorrespondence, externalJSON []byte) (string, error) {
+	output := "{}"
+	for _, field := range fields {
+		val := gjson.GetBytes(externalJSON, field.GetExternalPath())
+		if !val.Exists() {
+			var err error
+			output, err = e.applyDefaultIfPresent(field, output)
+			if err != nil {
+				return "", err
+			}
+			continue
+		}
+
+		transformed, err := e.applyInboundTransform(field.GetTransform(), val, externalJSON)
+		if err != nil {
+			return "", fmt.Errorf("field %s -> %s: %w", field.GetExternalPath(), field.GetInternalPath(), err)
+		}
+
+		output, err = sjson.Set(output, field.GetInternalPath(), transformed)
+		if err != nil {
+			return "", fmt.Errorf("%w: setting %s: %w", ErrFieldExtraction, field.GetInternalPath(), err)
+		}
+	}
+	return output, nil
+}
+
+// applyDefaultIfPresent sets a default value if the field transform specifies one.
+func (e *Engine) applyDefaultIfPresent(field *mappingv1.FieldCorrespondence, output string) (string, error) {
+	ft := field.GetTransform()
+	if ft == nil {
+		return output, nil
+	}
+	dv := ft.GetDefaultValue()
+	if dv == "" {
+		return output, nil
+	}
+	result, err := sjson.Set(output, field.GetInternalPath(), dv)
+	if err != nil {
+		return "", fmt.Errorf("%w: setting default for %s: %w", ErrFieldExtraction, field.GetInternalPath(), err)
+	}
+	return result, nil
+}
+
+// applyOutboundFields applies field correspondences for outbound transformation.
+func (e *Engine) applyOutboundFields(fields []*mappingv1.FieldCorrespondence, protoJSON []byte) (string, error) {
+	output := string(protoJSON)
+	for _, field := range fields {
+		val := gjson.GetBytes(protoJSON, field.GetInternalPath())
+		if !val.Exists() {
+			continue
+		}
+
+		transformed, err := e.applyOutboundTransform(field.GetTransform(), val, protoJSON)
+		if err != nil {
+			return "", fmt.Errorf("field %s -> %s: %w", field.GetInternalPath(), field.GetExternalPath(), err)
+		}
+
+		output, err = sjson.Set(output, field.GetExternalPath(), transformed)
+		if err != nil {
+			return "", fmt.Errorf("%w: setting %s: %w", ErrFieldExtraction, field.GetExternalPath(), err)
+		}
+	}
+	return output, nil
+}
+
+// applyComputedFields evaluates computed CEL fields and adds them to the output.
+func (e *Engine) applyComputedFields(fields []*mappingv1.ComputedField, sourceJSON []byte, output string) (string, error) {
+	if len(fields) == 0 {
+		return output, nil
+	}
+
+	inputMap := gjsonToMap(gjson.ParseBytes(sourceJSON))
+	mappedMap := gjsonToMap(gjson.Parse(output))
+
+	for _, cf := range fields {
+		result, err := e.evalCEL(cf.GetCelExpression(), map[string]any{
+			"input":  inputMap,
+			"mapped": mappedMap,
+		})
+		if err != nil {
+			return "", fmt.Errorf("%w: computed field %s: %w", ErrCELEvaluation, cf.GetTargetPath(), err)
+		}
+
+		output, err = sjson.Set(output, cf.GetTargetPath(), celValToInterface(result))
+		if err != nil {
+			return "", fmt.Errorf("%w: setting computed field %s: %w", ErrFieldExtraction, cf.GetTargetPath(), err)
+		}
+		mappedMap = gjsonToMap(gjson.Parse(output))
+	}
+	return output, nil
+}
+
+// applyInboundTransform applies the field transform for inbound direction.
+func (e *Engine) applyInboundTransform(ft *mappingv1.FieldTransform, val gjson.Result, sourceJSON []byte) (any, error) {
+	if ft == nil {
+		return gjsonToInterface(val), nil
+	}
+
+	switch {
+	case ft.GetEnumMapping() != nil:
+		return e.applyEnumInbound(ft.GetEnumMapping(), val)
+	case ft.GetDateFormat() != "":
+		return e.applyDateInbound(ft.GetDateFormat(), val)
+	case ft.GetCel() != nil:
+		return e.applyCELInbound(ft.GetCel(), val, sourceJSON)
+	case ft.GetAttributeFlatten() != nil:
+		return e.applyAttributeFlattenInbound(ft.GetAttributeFlatten(), sourceJSON)
+	default:
+		return gjsonToInterface(val), nil
+	}
+}
+
+// applyOutboundTransform applies the field transform for outbound (reverse) direction.
+func (e *Engine) applyOutboundTransform(ft *mappingv1.FieldTransform, val gjson.Result, sourceJSON []byte) (any, error) {
+	if ft == nil {
+		return gjsonToInterface(val), nil
+	}
+
+	switch {
+	case ft.GetEnumMapping() != nil:
+		return e.applyEnumOutbound(ft.GetEnumMapping(), val)
+	case ft.GetDateFormat() != "":
+		return e.applyDateOutbound(ft.GetDateFormat(), val)
+	case ft.GetCel() != nil:
+		return e.applyCELOutbound(ft.GetCel(), val, sourceJSON)
+	case ft.GetAttributeFlatten() != nil:
+		return e.applyAttributeFlattenOutbound(val)
+	default:
+		return gjsonToInterface(val), nil
+	}
+}
+
+func (e *Engine) applyEnumInbound(em *mappingv1.EnumMapping, val gjson.Result) (any, error) {
+	extVal := val.String()
+	if mapped, ok := em.GetValues()[extVal]; ok {
+		return mapped, nil
+	}
+	if fb := em.GetFallback(); fb != "" {
+		return fb, nil
+	}
+	return nil, fmt.Errorf("%w: no mapping for external value %q", ErrEnumNotMapped, extVal)
+}
+
+func (e *Engine) applyEnumOutbound(em *mappingv1.EnumMapping, val gjson.Result) (any, error) {
+	intVal := val.String()
+	for extKey, intKey := range em.GetValues() {
+		if intKey == intVal {
+			return extKey, nil
+		}
+	}
+	if fb := em.GetOutboundFallback(); fb != "" {
+		return fb, nil
+	}
+	return nil, fmt.Errorf("%w: no mapping for internal value %q", ErrEnumNotMapped, intVal)
+}
+
+func (e *Engine) applyDateInbound(layout string, val gjson.Result) (any, error) {
+	t, err := time.Parse(layout, val.String())
+	if err != nil {
+		return nil, fmt.Errorf("%w: parsing %q with layout %q: %w", ErrDateParse, val.String(), layout, err)
+	}
+	return t.Format(time.RFC3339), nil
+}
+
+func (e *Engine) applyDateOutbound(layout string, val gjson.Result) (any, error) {
+	t, err := time.Parse(time.RFC3339, val.String())
+	if err != nil {
+		return nil, fmt.Errorf("%w: parsing RFC3339 %q: %w", ErrDateParse, val.String(), err)
+	}
+	return t.Format(layout), nil
+}
+
+func (e *Engine) applyCELInbound(ct *mappingv1.CelTransform, val gjson.Result, sourceJSON []byte) (any, error) {
+	expr := ct.GetInboundCel()
+	if expr == "" {
+		return gjsonToInterface(val), nil
+	}
+
+	result, err := e.evalCEL(expr, map[string]any{
+		"value": gjsonToInterface(val),
+		"input": gjsonToMap(gjson.ParseBytes(sourceJSON)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: inbound CEL %q: %w", ErrCELEvaluation, expr, err)
+	}
+	return celValToInterface(result), nil
+}
+
+func (e *Engine) applyCELOutbound(ct *mappingv1.CelTransform, val gjson.Result, sourceJSON []byte) (any, error) {
+	expr := ct.GetOutboundCel()
+	if expr == "" {
+		return gjsonToInterface(val), nil
+	}
+
+	result, err := e.evalCEL(expr, map[string]any{
+		"value": gjsonToInterface(val),
+		"input": gjsonToMap(gjson.ParseBytes(sourceJSON)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: outbound CEL %q: %w", ErrCELEvaluation, expr, err)
+	}
+	return celValToInterface(result), nil
+}
+
+func (e *Engine) applyAttributeFlattenInbound(af *mappingv1.AttributeFlatten, sourceJSON []byte) (any, error) {
+	var entries []map[string]string
+	for _, key := range af.GetSourceKeys() {
+		val := gjson.GetBytes(sourceJSON, key)
+		if val.Exists() {
+			entries = append(entries, map[string]string{
+				"key":   key,
+				"value": val.String(),
+			})
+		}
+	}
+	return entries, nil
+}
+
+func (e *Engine) applyAttributeFlattenOutbound(val gjson.Result) (any, error) {
+	result := map[string]string{}
+	val.ForEach(func(_, entry gjson.Result) bool {
+		k := entry.Get("key").String()
+		v := entry.Get("value").String()
+		if k != "" {
+			result[k] = v
+		}
+		return true
+	})
+	return result, nil
+}
+
+func (e *Engine) deriveIdempotencyKey(config *mappingv1.IdempotencyConfig, externalJSON []byte) (string, error) {
+	if config == nil {
+		return "", nil
+	}
+
+	if config.GetUseContentHash() {
+		return e.deriveContentHash(config.GetContentHashFields(), externalJSON)
+	}
+
+	return e.deriveFromSelector(config.GetSourceSelector(), externalJSON)
+}
+
+func (e *Engine) deriveContentHash(fields []string, externalJSON []byte) (string, error) {
+	if len(fields) == 0 {
+		return "", fmt.Errorf("%w: content hash mode requires at least one field", ErrIdempotencyKey)
+	}
+
+	hasher := sha256.New()
+	sortedFields := make([]string, len(fields))
+	copy(sortedFields, fields)
+	sort.Strings(sortedFields)
+
+	for _, path := range sortedFields {
+		val := gjson.GetBytes(externalJSON, path)
+		hasher.Write([]byte(path))
+		hasher.Write([]byte("="))
+		hasher.Write([]byte(val.String()))
+		hasher.Write([]byte(";"))
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func (e *Engine) deriveFromSelector(selector string, externalJSON []byte) (string, error) {
+	if selector == "" {
+		return "", fmt.Errorf("%w: source_selector is required when use_content_hash is false", ErrIdempotencyKey)
+	}
+
+	val := gjson.GetBytes(externalJSON, selector)
+	if !val.Exists() {
+		return "", fmt.Errorf("%w: source_selector %q not found in payload", ErrIdempotencyKey, selector)
+	}
+
+	return val.String(), nil
+}
+
+// CEL evaluation helpers.
+
+func (e *Engine) compileCEL(expression string) (cel.Program, error) {
+	key := celCacheKey(expression)
+	if prg, ok := e.celCache.Get(key); ok {
+		return prg, nil
+	}
+
+	ast, issues := e.env.Compile(expression)
+	if issues != nil && issues.Err() != nil {
+		return nil, fmt.Errorf("%w: %w", ErrCELCompilation, issues.Err())
+	}
+
+	prg, err := e.env.Program(ast)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrCELCompilation, err)
+	}
+
+	e.celCache.Add(key, prg)
+	return prg, nil
+}
+
+func (e *Engine) evalCEL(expression string, vars map[string]any) (ref.Val, error) {
+	prg, err := e.compileCEL(expression)
+	if err != nil {
+		return nil, err
+	}
+
+	out, _, err := prg.Eval(vars)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrCELEvaluation, err)
+	}
+	return out, nil
+}
+
+func (e *Engine) evalBoolCEL(expression string, vars map[string]any) (bool, error) {
+	result, err := e.evalCEL(expression, vars)
+	if err != nil {
+		return false, err
+	}
+
+	b, ok := result.Value().(bool)
+	if !ok {
+		return false, fmt.Errorf("%w: expected bool, got %T", ErrCELEvaluation, result.Value())
+	}
+	return b, nil
+}
+
+func celCacheKey(expression string) string {
+	h := sha256.Sum256([]byte(expression))
+	return hex.EncodeToString(h[:])
+}
+
+// JSON helpers.
+
+func gjsonToInterface(r gjson.Result) any {
+	switch r.Type {
+	case gjson.Null:
+		return nil
+	case gjson.False:
+		return false
+	case gjson.True:
+		return true
+	case gjson.Number:
+		if r.Num == float64(int64(r.Num)) {
+			return int64(r.Num)
+		}
+		return r.Num
+	case gjson.String:
+		return r.Str
+	case gjson.JSON:
+		if r.IsArray() {
+			var arr []any
+			r.ForEach(func(_, v gjson.Result) bool {
+				arr = append(arr, gjsonToInterface(v))
+				return true
+			})
+			return arr
+		}
+		if r.IsObject() {
+			return gjsonToMap(r)
+		}
+		return r.Raw
+	default:
+		return r.Raw
+	}
+}
+
+func gjsonToMap(r gjson.Result) map[string]any {
+	m := make(map[string]any)
+	r.ForEach(func(key, value gjson.Result) bool {
+		m[key.Str] = gjsonToInterface(value)
+		return true
+	})
+	return m
+}
+
+func celValToInterface(v ref.Val) any {
+	if v == nil {
+		return nil
+	}
+	switch v.Type() {
+	case types.BoolType, types.IntType, types.DoubleType, types.StringType:
+		return v.Value()
+	case types.TimestampType:
+		if t, ok := v.Value().(time.Time); ok {
+			return t.Format(time.RFC3339)
+		}
+		return v.Value()
+	default:
+		return v.Value()
+	}
+}
+
+// CacheLen returns the number of cached CEL programs (for testing).
+func (e *Engine) CacheLen() int {
+	return e.celCache.Len()
+}
+
+// CacheContains checks if a CEL expression is cached (for testing).
+func (e *Engine) CacheContains(expression string) bool {
+	return e.celCache.Contains(celCacheKey(expression))
+}
+
+// EscapeJSONPath escapes special characters in a JSON path for sjson.
+func EscapeJSONPath(path string) string {
+	return strings.ReplaceAll(path, ".", "\\.")
+}

--- a/services/gateway/internal/mapping/engine.go
+++ b/services/gateway/internal/mapping/engine.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
 	"github.com/google/cel-go/ext"
 	lru "github.com/hashicorp/golang-lru/v2"
 	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
@@ -182,6 +183,20 @@ func (e *Engine) applyInboundFields(fields []*mappingv1.FieldCorrespondence, ext
 	output := "{}"
 	for _, field := range fields {
 		val := gjson.GetBytes(externalJSON, field.GetExternalPath())
+
+		// Attribute flatten derives from multiple source keys; run regardless of ExternalPath existence.
+		if ft := field.GetTransform(); ft != nil && ft.GetAttributeFlatten() != nil {
+			transformed, err := e.applyInboundTransform(ft, val, externalJSON)
+			if err != nil {
+				return "", fmt.Errorf("field %s -> %s: %w", field.GetExternalPath(), field.GetInternalPath(), err)
+			}
+			output, err = sjson.Set(output, field.GetInternalPath(), transformed)
+			if err != nil {
+				return "", fmt.Errorf("%w: setting %s: %w", ErrFieldExtraction, field.GetInternalPath(), err)
+			}
+			continue
+		}
+
 		if !val.Exists() {
 			var err error
 			output, err = e.applyDefaultIfPresent(field, output)
@@ -222,6 +237,8 @@ func (e *Engine) applyDefaultIfPresent(field *mappingv1.FieldCorrespondence, out
 }
 
 // applyOutboundFields applies field correspondences for outbound transformation.
+// After mapping each field to its external path, the original internal path is removed
+// from the output to prevent leaking internal field names to external consumers.
 func (e *Engine) applyOutboundFields(fields []*mappingv1.FieldCorrespondence, protoJSON []byte) (string, error) {
 	output := string(protoJSON)
 	for _, field := range fields {
@@ -238,6 +255,11 @@ func (e *Engine) applyOutboundFields(fields []*mappingv1.FieldCorrespondence, pr
 		output, err = sjson.Set(output, field.GetExternalPath(), transformed)
 		if err != nil {
 			return "", fmt.Errorf("%w: setting %s: %w", ErrFieldExtraction, field.GetExternalPath(), err)
+		}
+
+		// Remove the original internal field to avoid leaking internal names.
+		if field.GetInternalPath() != field.GetExternalPath() {
+			output, _ = sjson.Delete(output, field.GetInternalPath())
 		}
 	}
 	return output, nil
@@ -433,6 +455,9 @@ func (e *Engine) deriveContentHash(fields []string, externalJSON []byte) (string
 
 	for _, path := range sortedFields {
 		val := gjson.GetBytes(externalJSON, path)
+		if !val.Exists() {
+			return "", fmt.Errorf("%w: content hash field %q not found in payload", ErrIdempotencyKey, path)
+		}
 		hasher.Write([]byte(path))
 		hasher.Write([]byte("="))
 		hasher.Write([]byte(val.String()))
@@ -564,6 +589,23 @@ func celValToInterface(v ref.Val) any {
 		}
 		return v.Value()
 	default:
+		if l, ok := v.(traits.Lister); ok {
+			it := l.Iterator()
+			var out []any
+			for it.HasNext() == types.True {
+				out = append(out, celValToInterface(it.Next()))
+			}
+			return out
+		}
+		if m, ok := v.(traits.Mapper); ok {
+			it := m.Iterator()
+			out := map[string]any{}
+			for it.HasNext() == types.True {
+				k := it.Next()
+				out[fmt.Sprint(k.Value())] = celValToInterface(m.Get(k))
+			}
+			return out
+		}
 		return v.Value()
 	}
 }

--- a/services/gateway/internal/mapping/engine_test.go
+++ b/services/gateway/internal/mapping/engine_test.go
@@ -1,0 +1,1159 @@
+package mapping
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestEngine(t *testing.T) *Engine {
+	t.Helper()
+	eng, err := NewEngine()
+	require.NoError(t, err)
+	return eng
+}
+
+// --- Simple field mapping (rename only) ---
+
+func TestTransformInbound_SimpleFieldMapping(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "customer_name", InternalPath: "name"},
+			{ExternalPath: "customer_email", InternalPath: "email"},
+			{ExternalPath: "order.total", InternalPath: "amount"},
+		},
+	}
+
+	input := []byte(`{"customer_name":"Alice","customer_email":"alice@example.com","order":{"total":99.95}}`)
+
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+
+	assert.Equal(t, "Alice", out["name"])
+	assert.Equal(t, "alice@example.com", out["email"])
+	assert.Equal(t, 99.95, out["amount"])
+}
+
+func TestTransformOutbound_SimpleFieldMapping(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "customer_name", InternalPath: "name"},
+			{ExternalPath: "customer_email", InternalPath: "email"},
+		},
+	}
+
+	input := []byte(`{"name":"Alice","email":"alice@example.com"}`)
+
+	output, err := eng.TransformOutbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(output, &out))
+
+	assert.Equal(t, "Alice", out["customer_name"])
+	assert.Equal(t, "alice@example.com", out["customer_email"])
+}
+
+func TestTransformInbound_MissingField_Skipped(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "name", InternalPath: "name"},
+			{ExternalPath: "missing_field", InternalPath: "optional"},
+		},
+	}
+
+	input := []byte(`{"name":"Bob"}`)
+
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+
+	assert.Equal(t, "Bob", out["name"])
+	_, exists := out["optional"]
+	assert.False(t, exists)
+}
+
+func TestTransformInbound_NestedPaths(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "data.customer.id", InternalPath: "customer_id"},
+			{ExternalPath: "data.amount", InternalPath: "payment.amount"},
+		},
+	}
+
+	input := []byte(`{"data":{"customer":{"id":"cust-123"},"amount":50.00}}`)
+
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+
+	assert.Equal(t, "cust-123", out["customer_id"])
+	payment, ok := out["payment"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 50.0, payment["amount"])
+}
+
+// --- Enum mapping ---
+
+func TestTransformInbound_EnumMapping(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "status",
+				InternalPath: "order_status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_EnumMapping{
+						EnumMapping: &mappingv1.EnumMapping{
+							Values: map[string]string{
+								"active":   "STATUS_ACTIVE",
+								"inactive": "STATUS_INACTIVE",
+								"pending":  "STATUS_PENDING",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	input := []byte(`{"status":"active"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+	assert.Equal(t, "STATUS_ACTIVE", out["order_status"])
+}
+
+func TestTransformInbound_EnumMapping_Fallback(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "status",
+				InternalPath: "order_status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_EnumMapping{
+						EnumMapping: &mappingv1.EnumMapping{
+							Values:   map[string]string{"known": "KNOWN"},
+							Fallback: "STATUS_UNKNOWN",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	input := []byte(`{"status":"unknown_value"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+	assert.Equal(t, "STATUS_UNKNOWN", out["order_status"])
+}
+
+func TestTransformInbound_EnumMapping_NoFallback_Error(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "status",
+				InternalPath: "order_status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_EnumMapping{
+						EnumMapping: &mappingv1.EnumMapping{
+							Values: map[string]string{"known": "KNOWN"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	input := []byte(`{"status":"unmapped"}`)
+	_, err := eng.TransformInbound(mapping, input)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnumNotMapped)
+}
+
+func TestTransformOutbound_EnumMapping_ReverseMap(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "status",
+				InternalPath: "order_status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_EnumMapping{
+						EnumMapping: &mappingv1.EnumMapping{
+							Values: map[string]string{
+								"active":   "STATUS_ACTIVE",
+								"inactive": "STATUS_INACTIVE",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	input := []byte(`{"order_status":"STATUS_ACTIVE"}`)
+	output, err := eng.TransformOutbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(output, &out))
+	assert.Equal(t, "active", out["status"])
+}
+
+func TestTransformOutbound_EnumMapping_OutboundFallback(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "status",
+				InternalPath: "order_status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_EnumMapping{
+						EnumMapping: &mappingv1.EnumMapping{
+							Values:           map[string]string{"active": "STATUS_ACTIVE"},
+							OutboundFallback: "unknown",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	input := []byte(`{"order_status":"STATUS_NEW"}`)
+	output, err := eng.TransformOutbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(output, &out))
+	assert.Equal(t, "unknown", out["status"])
+}
+
+// --- Date format ---
+
+func TestTransformInbound_DateFormat(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "created",
+				InternalPath: "created_at",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_DateFormat{
+						DateFormat: "2006-01-02",
+					},
+				},
+			},
+		},
+	}
+
+	input := []byte(`{"created":"2024-03-15"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+	assert.Equal(t, "2024-03-15T00:00:00Z", out["created_at"])
+}
+
+func TestTransformOutbound_DateFormat(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "created",
+				InternalPath: "created_at",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_DateFormat{
+						DateFormat: "2006-01-02",
+					},
+				},
+			},
+		},
+	}
+
+	input := []byte(`{"created_at":"2024-03-15T00:00:00Z"}`)
+	output, err := eng.TransformOutbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(output, &out))
+	assert.Equal(t, "2024-03-15", out["created"])
+}
+
+func TestTransformInbound_DateFormat_InvalidDate_Error(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "created",
+				InternalPath: "created_at",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_DateFormat{
+						DateFormat: "2006-01-02",
+					},
+				},
+			},
+		},
+	}
+
+	input := []byte(`{"created":"not-a-date"}`)
+	_, err := eng.TransformInbound(mapping, input)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDateParse)
+}
+
+// --- CEL transform ---
+
+func TestTransformInbound_CELTransform(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "name",
+				InternalPath: "normalized_name",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_Cel{
+						Cel: &mappingv1.CelTransform{
+							InboundCel:  `value + "_processed"`,
+							OutboundCel: `value.replace("_processed", "")`,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	input := []byte(`{"name":"Alice"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+	assert.Equal(t, "Alice_processed", out["normalized_name"])
+}
+
+func TestTransformOutbound_CELTransform(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "name",
+				InternalPath: "normalized_name",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_Cel{
+						Cel: &mappingv1.CelTransform{
+							InboundCel:  `value + "_processed"`,
+							OutboundCel: `value.replace("_processed", "")`,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	input := []byte(`{"normalized_name":"Alice_processed"}`)
+	output, err := eng.TransformOutbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(output, &out))
+	assert.Equal(t, "Alice", out["name"])
+}
+
+func TestTransformInbound_CELTransform_WithInputContext(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "amount",
+				InternalPath: "total",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_Cel{
+						Cel: &mappingv1.CelTransform{
+							InboundCel: `string(value)`,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	input := []byte(`{"amount":42.5,"currency":"USD"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+	assert.Equal(t, "42.5", out["total"])
+}
+
+// --- Attribute flatten ---
+
+func TestTransformInbound_AttributeFlatten(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "color",
+				InternalPath: "attributes",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_AttributeFlatten{
+						AttributeFlatten: &mappingv1.AttributeFlatten{
+							SourceKeys:  []string{"color", "size", "weight"},
+							TargetField: "attributes",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	input := []byte(`{"color":"red","size":"large","weight":"5kg"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+
+	attrs, ok := out["attributes"].([]any)
+	require.True(t, ok, "attributes should be an array, got %T", out["attributes"])
+	assert.Len(t, attrs, 3)
+
+	// Verify entries contain key-value pairs.
+	keys := make(map[string]string)
+	for _, entry := range attrs {
+		e, ok := entry.(map[string]any)
+		require.True(t, ok)
+		keys[e["key"].(string)] = e["value"].(string)
+	}
+	assert.Equal(t, "red", keys["color"])
+	assert.Equal(t, "large", keys["size"])
+	assert.Equal(t, "5kg", keys["weight"])
+}
+
+func TestTransformOutbound_AttributeFlatten(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "color",
+				InternalPath: "attributes",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_AttributeFlatten{
+						AttributeFlatten: &mappingv1.AttributeFlatten{
+							SourceKeys:  []string{"color", "size"},
+							TargetField: "attributes",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	input := []byte(`{"attributes":[{"key":"color","value":"red"},{"key":"size","value":"large"}]}`)
+	output, err := eng.TransformOutbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(output, &out))
+
+	// The outbound flatten produces a map of key->value.
+	flatMap, ok := out["color"].(map[string]any)
+	require.True(t, ok, "expected map, got %T: %v", out["color"], out["color"])
+	assert.Equal(t, "red", flatMap["color"])
+	assert.Equal(t, "large", flatMap["size"])
+}
+
+// --- Default value ---
+
+func TestTransformInbound_DefaultValue(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "source",
+				InternalPath: "source",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_DefaultValue{
+						DefaultValue: "WEBHOOK",
+					},
+				},
+			},
+		},
+	}
+
+	// Field is missing, should get default.
+	input := []byte(`{"other":"data"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+	assert.Equal(t, "WEBHOOK", out["source"])
+}
+
+func TestTransformInbound_DefaultValue_FieldExists(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "source",
+				InternalPath: "source",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_DefaultValue{
+						DefaultValue: "WEBHOOK",
+					},
+				},
+			},
+		},
+	}
+
+	// Field exists, should use actual value.
+	input := []byte(`{"source":"API"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+	assert.Equal(t, "API", out["source"])
+}
+
+// --- Computed fields with CEL ---
+
+func TestTransformInbound_ComputedFields(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "name", InternalPath: "name"},
+		},
+		InboundComputedFields: []*mappingv1.ComputedField{
+			{
+				TargetPath:    "display_name",
+				CelExpression: `"Hello, " + input.name`,
+			},
+		},
+	}
+
+	input := []byte(`{"name":"Alice"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+	assert.Equal(t, "Alice", out["name"])
+	assert.Equal(t, "Hello, Alice", out["display_name"])
+}
+
+func TestTransformInbound_ComputedFields_ChainedAccess(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "first", InternalPath: "first_name"},
+			{ExternalPath: "last", InternalPath: "last_name"},
+		},
+		InboundComputedFields: []*mappingv1.ComputedField{
+			{
+				TargetPath:    "full_name",
+				CelExpression: `mapped.first_name + " " + mapped.last_name`,
+			},
+		},
+	}
+
+	input := []byte(`{"first":"Alice","last":"Smith"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+	assert.Equal(t, "Alice Smith", out["full_name"])
+}
+
+func TestTransformOutbound_ComputedFields(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "name", InternalPath: "name"},
+		},
+		OutboundComputedFields: []*mappingv1.ComputedField{
+			{
+				TargetPath:    "greeting",
+				CelExpression: `"Welcome, " + input.name`,
+			},
+		},
+	}
+
+	input := []byte(`{"name":"Bob"}`)
+	output, err := eng.TransformOutbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(output, &out))
+	assert.Equal(t, "Welcome, Bob", out["greeting"])
+}
+
+// --- Validation CEL ---
+
+func TestTransformInbound_ValidationCEL_Pass(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		InboundValidationCel: `has(payload.customer_id) && has(payload.amount)`,
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "customer_id", InternalPath: "customer_id"},
+			{ExternalPath: "amount", InternalPath: "amount"},
+		},
+	}
+
+	input := []byte(`{"customer_id":"cust-1","amount":100}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestTransformInbound_ValidationCEL_Fail(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		InboundValidationCel: `has(payload.customer_id) && has(payload.amount)`,
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "customer_id", InternalPath: "customer_id"},
+		},
+	}
+
+	input := []byte(`{"customer_id":"cust-1"}`)
+	_, err := eng.TransformInbound(mapping, input)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrValidation)
+}
+
+func TestTransformOutbound_ValidationCEL_Fail(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		OutboundValidationCel: `has(payload.status)`,
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "name", InternalPath: "name"},
+		},
+	}
+
+	input := []byte(`{"name":"Alice"}`)
+	_, err := eng.TransformOutbound(mapping, input)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrValidation)
+}
+
+// --- Idempotency key derivation ---
+
+func TestTransformInbound_IdempotencyKey_SourceSelector(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "data", InternalPath: "data"},
+		},
+		Idempotency: &mappingv1.IdempotencyConfig{
+			SourceSelector: "header.idempotency_key",
+		},
+	}
+
+	input := []byte(`{"header":{"idempotency_key":"abc-123"},"data":"test"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+	assert.Equal(t, "abc-123", result.IdempotencyKey)
+}
+
+func TestTransformInbound_IdempotencyKey_ContentHash(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "amount", InternalPath: "amount"},
+		},
+		Idempotency: &mappingv1.IdempotencyConfig{
+			UseContentHash:    true,
+			ContentHashFields: []string{"customer_id", "amount"},
+		},
+	}
+
+	input := []byte(`{"customer_id":"cust-1","amount":100}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result.IdempotencyKey)
+	assert.Len(t, result.IdempotencyKey, 64) // SHA256 hex
+
+	// Same input should produce the same hash.
+	result2, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+	assert.Equal(t, result.IdempotencyKey, result2.IdempotencyKey)
+
+	// Different input should produce a different hash.
+	input2 := []byte(`{"customer_id":"cust-2","amount":100}`)
+	result3, err := eng.TransformInbound(mapping, input2)
+	require.NoError(t, err)
+	assert.NotEqual(t, result.IdempotencyKey, result3.IdempotencyKey)
+}
+
+func TestTransformInbound_IdempotencyKey_NoConfig(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "data", InternalPath: "data"},
+		},
+	}
+
+	input := []byte(`{"data":"test"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+	assert.Empty(t, result.IdempotencyKey)
+}
+
+func TestTransformInbound_IdempotencyKey_MissingSelector_Error(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "data", InternalPath: "data"},
+		},
+		Idempotency: &mappingv1.IdempotencyConfig{
+			SourceSelector: "nonexistent.path",
+		},
+	}
+
+	input := []byte(`{"data":"test"}`)
+	_, err := eng.TransformInbound(mapping, input)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIdempotencyKey)
+}
+
+// --- CEL cache ---
+
+func TestCELCache_HitAndMiss(t *testing.T) {
+	eng := newTestEngine(t)
+	assert.Equal(t, 0, eng.CacheLen())
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "val",
+				InternalPath: "result",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_Cel{
+						Cel: &mappingv1.CelTransform{
+							InboundCel: `value + "_suffix"`,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	input := []byte(`{"val":"hello"}`)
+
+	// First call: cache miss.
+	_, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+	assert.Equal(t, 1, eng.CacheLen())
+	assert.True(t, eng.CacheContains(`value + "_suffix"`))
+
+	// Second call: cache hit (same program reused).
+	_, err = eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+	assert.Equal(t, 1, eng.CacheLen())
+}
+
+// --- Bidirectional round-trip ---
+
+func TestRoundTrip_SimpleFields(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "ext_name", InternalPath: "int_name"},
+			{ExternalPath: "ext_email", InternalPath: "int_email"},
+		},
+	}
+
+	original := []byte(`{"ext_name":"Alice","ext_email":"alice@test.com"}`)
+
+	// Inbound.
+	inResult, err := eng.TransformInbound(mapping, original)
+	require.NoError(t, err)
+
+	var internal map[string]any
+	require.NoError(t, json.Unmarshal(inResult.ProtoJSON, &internal))
+	assert.Equal(t, "Alice", internal["int_name"])
+	assert.Equal(t, "alice@test.com", internal["int_email"])
+
+	// Outbound (reverse).
+	outResult, err := eng.TransformOutbound(mapping, inResult.ProtoJSON)
+	require.NoError(t, err)
+
+	var external map[string]any
+	require.NoError(t, json.Unmarshal(outResult, &external))
+	assert.Equal(t, "Alice", external["ext_name"])
+	assert.Equal(t, "alice@test.com", external["ext_email"])
+}
+
+func TestRoundTrip_EnumMapping(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "status",
+				InternalPath: "order_status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_EnumMapping{
+						EnumMapping: &mappingv1.EnumMapping{
+							Values: map[string]string{
+								"active":   "STATUS_ACTIVE",
+								"inactive": "STATUS_INACTIVE",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	original := []byte(`{"status":"active"}`)
+
+	inResult, err := eng.TransformInbound(mapping, original)
+	require.NoError(t, err)
+
+	outResult, err := eng.TransformOutbound(mapping, inResult.ProtoJSON)
+	require.NoError(t, err)
+
+	var external map[string]any
+	require.NoError(t, json.Unmarshal(outResult, &external))
+	assert.Equal(t, "active", external["status"])
+}
+
+func TestRoundTrip_DateFormat(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "date",
+				InternalPath: "timestamp",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_DateFormat{
+						DateFormat: "2006-01-02",
+					},
+				},
+			},
+		},
+	}
+
+	original := []byte(`{"date":"2024-06-15"}`)
+
+	inResult, err := eng.TransformInbound(mapping, original)
+	require.NoError(t, err)
+
+	outResult, err := eng.TransformOutbound(mapping, inResult.ProtoJSON)
+	require.NoError(t, err)
+
+	var external map[string]any
+	require.NoError(t, json.Unmarshal(outResult, &external))
+	assert.Equal(t, "2024-06-15", external["date"])
+}
+
+func TestRoundTrip_CELTransform(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "code",
+				InternalPath: "code",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_Cel{
+						Cel: &mappingv1.CelTransform{
+							InboundCel:  `"PREFIX_" + value`,
+							OutboundCel: `value.replace("PREFIX_", "")`,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	original := []byte(`{"code":"ABC"}`)
+
+	inResult, err := eng.TransformInbound(mapping, original)
+	require.NoError(t, err)
+
+	var internal map[string]any
+	require.NoError(t, json.Unmarshal(inResult.ProtoJSON, &internal))
+	assert.Equal(t, "PREFIX_ABC", internal["code"])
+
+	outResult, err := eng.TransformOutbound(mapping, inResult.ProtoJSON)
+	require.NoError(t, err)
+
+	var external map[string]any
+	require.NoError(t, json.Unmarshal(outResult, &external))
+	assert.Equal(t, "ABC", external["code"])
+}
+
+// --- Invalid JSON ---
+
+func TestTransformInbound_InvalidJSON_Error(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "name", InternalPath: "name"},
+		},
+	}
+
+	_, err := eng.TransformInbound(mapping, []byte(`{invalid`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidJSON)
+}
+
+func TestTransformOutbound_InvalidJSON_Error(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "name", InternalPath: "name"},
+		},
+	}
+
+	_, err := eng.TransformOutbound(mapping, []byte(`{invalid`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidJSON)
+}
+
+// --- Outbound passthrough ---
+
+func TestTransformOutbound_PassthroughUnmappedFields(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "ext_name", InternalPath: "name"},
+		},
+	}
+
+	// Proto JSON has extra fields not in the mapping.
+	input := []byte(`{"name":"Alice","extra_field":"should_remain","nested":{"deep":"value"}}`)
+	output, err := eng.TransformOutbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(output, &out))
+
+	assert.Equal(t, "Alice", out["ext_name"])
+	assert.Equal(t, "should_remain", out["extra_field"])
+
+	nested, ok := out["nested"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "value", nested["deep"])
+}
+
+// --- Multiple transforms in same mapping ---
+
+func TestTransformInbound_MultipleTransformTypes(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "name", InternalPath: "name"},
+			{
+				ExternalPath: "status",
+				InternalPath: "status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_EnumMapping{
+						EnumMapping: &mappingv1.EnumMapping{
+							Values: map[string]string{"active": "ACTIVE", "inactive": "INACTIVE"},
+						},
+					},
+				},
+			},
+			{
+				ExternalPath: "created",
+				InternalPath: "created_at",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_DateFormat{
+						DateFormat: "02/01/2006",
+					},
+				},
+			},
+			{
+				ExternalPath: "code",
+				InternalPath: "code",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_Cel{
+						Cel: &mappingv1.CelTransform{
+							InboundCel: `value + "-v2"`,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	input := []byte(`{"name":"Alice","status":"active","created":"15/03/2024","code":"ABC"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+
+	assert.Equal(t, "Alice", out["name"])
+	assert.Equal(t, "ACTIVE", out["status"])
+	assert.Equal(t, "2024-03-15T00:00:00Z", out["created_at"])
+	assert.Equal(t, "ABC-v2", out["code"])
+}
+
+// --- Boolean and numeric field types ---
+
+func TestTransformInbound_BooleanAndNumericFields(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "active", InternalPath: "is_active"},
+			{ExternalPath: "count", InternalPath: "item_count"},
+			{ExternalPath: "price", InternalPath: "unit_price"},
+		},
+	}
+
+	input := []byte(`{"active":true,"count":42,"price":19.99}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+
+	assert.Equal(t, true, out["is_active"])
+	assert.Equal(t, float64(42), out["item_count"])
+	assert.Equal(t, 19.99, out["unit_price"])
+}
+
+// --- Edge cases ---
+
+func TestTransformInbound_EmptyFields(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{},
+	}
+
+	input := []byte(`{"anything":"here"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(result.ProtoJSON))
+}
+
+func TestTransformOutbound_EmptyFields(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{},
+	}
+
+	input := []byte(`{"anything":"here"}`)
+	output, err := eng.TransformOutbound(mapping, input)
+	require.NoError(t, err)
+	// Outbound passes through the original proto JSON.
+	assert.Contains(t, string(output), "anything")
+}
+
+func TestTransformInbound_ArrayValues(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "tags", InternalPath: "labels"},
+		},
+	}
+
+	input := []byte(`{"tags":["foo","bar","baz"]}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+
+	labels, ok := out["labels"].([]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"foo", "bar", "baz"}, labels)
+}
+
+// --- Engine creation ---
+
+func TestNewEngine_Success(t *testing.T) {
+	eng, err := NewEngine()
+	require.NoError(t, err)
+	assert.NotNil(t, eng)
+}
+
+func TestNewEngineWithCacheSize(t *testing.T) {
+	eng, err := NewEngineWithCacheSize(10)
+	require.NoError(t, err)
+	assert.NotNil(t, eng)
+}
+
+// --- CEL compilation error ---
+
+func TestTransformInbound_InvalidCEL_Error(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		InboundValidationCel: `this is not valid CEL!!!`,
+	}
+
+	input := []byte(`{"data":"test"}`)
+	_, err := eng.TransformInbound(mapping, input)
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "CEL"))
+}

--- a/services/gateway/internal/mapping/engine_test.go
+++ b/services/gateway/internal/mapping/engine_test.go
@@ -771,6 +771,27 @@ func TestTransformInbound_IdempotencyKey_MissingSelector_Error(t *testing.T) {
 	assert.ErrorIs(t, err, ErrIdempotencyKey)
 }
 
+func TestTransformInbound_IdempotencyKey_ContentHash_MissingField_Error(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "amount", InternalPath: "amount"},
+		},
+		Idempotency: &mappingv1.IdempotencyConfig{
+			UseContentHash:    true,
+			ContentHashFields: []string{"customer_id", "amount"},
+		},
+	}
+
+	// customer_id is missing from the payload.
+	input := []byte(`{"amount":100}`)
+	_, err := eng.TransformInbound(mapping, input)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIdempotencyKey)
+	assert.Contains(t, err.Error(), "customer_id")
+}
+
 // --- CEL cache ---
 
 func TestCELCache_HitAndMiss(t *testing.T) {
@@ -993,10 +1014,59 @@ func TestTransformOutbound_PassthroughUnmappedFields(t *testing.T) {
 
 	assert.Equal(t, "Alice", out["ext_name"])
 	assert.Equal(t, "should_remain", out["extra_field"])
+	// Internal field "name" should be removed since it differs from external "ext_name".
+	_, namePresent := out["name"]
+	assert.False(t, namePresent, "internal field 'name' should be removed from outbound output")
 
 	nested, ok := out["nested"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "value", nested["deep"])
+}
+
+func TestTransformOutbound_InternalFieldsRemovedWhenRenamed(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "customer_name", InternalPath: "name"},
+			{ExternalPath: "customer_email", InternalPath: "email"},
+		},
+	}
+
+	input := []byte(`{"name":"Alice","email":"alice@example.com"}`)
+	output, err := eng.TransformOutbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(output, &out))
+
+	// External paths should be present.
+	assert.Equal(t, "Alice", out["customer_name"])
+	assert.Equal(t, "alice@example.com", out["customer_email"])
+
+	// Internal paths should be removed.
+	_, namePresent := out["name"]
+	assert.False(t, namePresent, "internal field 'name' should not leak")
+	_, emailPresent := out["email"]
+	assert.False(t, emailPresent, "internal field 'email' should not leak")
+}
+
+func TestTransformOutbound_SamePaths_NotDeleted(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "name", InternalPath: "name"},
+		},
+	}
+
+	input := []byte(`{"name":"Alice"}`)
+	output, err := eng.TransformOutbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(output, &out))
+	assert.Equal(t, "Alice", out["name"])
 }
 
 // --- Multiple transforms in same mapping ---
@@ -1144,6 +1214,95 @@ func TestNewEngineWithCacheSize(t *testing.T) {
 }
 
 // --- CEL compilation error ---
+
+func TestTransformInbound_AttributeFlatten_ExternalPathMissing(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				// ExternalPath is "color" but may not exist; flatten should still run using source_keys.
+				ExternalPath: "color",
+				InternalPath: "attributes",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_AttributeFlatten{
+						AttributeFlatten: &mappingv1.AttributeFlatten{
+							SourceKeys:  []string{"size", "weight"},
+							TargetField: "attributes",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// "color" is absent but "size" and "weight" exist.
+	input := []byte(`{"size":"large","weight":"5kg"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+
+	attrs, ok := out["attributes"].([]any)
+	require.True(t, ok, "attributes should be an array")
+	assert.Len(t, attrs, 2)
+}
+
+func TestTransformInbound_CELListResult(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "name", InternalPath: "name"},
+		},
+		InboundComputedFields: []*mappingv1.ComputedField{
+			{
+				TargetPath:    "tags",
+				CelExpression: `["tag1", "tag2", "tag3"]`,
+			},
+		},
+	}
+
+	input := []byte(`{"name":"Alice"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+
+	tags, ok := out["tags"].([]any)
+	require.True(t, ok, "tags should be an array, got %T", out["tags"])
+	assert.Equal(t, []any{"tag1", "tag2", "tag3"}, tags)
+}
+
+func TestTransformInbound_CELMapResult(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "name", InternalPath: "name"},
+		},
+		InboundComputedFields: []*mappingv1.ComputedField{
+			{
+				TargetPath:    "metadata",
+				CelExpression: `{"source": "webhook", "version": "v2"}`,
+			},
+		},
+	}
+
+	input := []byte(`{"name":"Alice"}`)
+	result, err := eng.TransformInbound(mapping, input)
+	require.NoError(t, err)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result.ProtoJSON, &out))
+
+	meta, ok := out["metadata"].(map[string]any)
+	require.True(t, ok, "metadata should be a map, got %T", out["metadata"])
+	assert.Equal(t, "webhook", meta["source"])
+	assert.Equal(t, "v2", meta["version"])
+}
 
 func TestTransformInbound_InvalidCEL_Error(t *testing.T) {
 	eng := newTestEngine(t)


### PR DESCRIPTION
## Summary
- Core mapping engine (`services/gateway/internal/mapping/engine.go`) with `TransformInbound` and `TransformOutbound` methods
- All transform types: enum mapping (with fallback), date format conversion, CEL expressions (with LRU cache), attribute flatten/unflatten, and default values
- Computed fields with CEL evaluation using `{input, mapped}` context
- Validation CEL for inbound and outbound rejection
- Idempotency key derivation (source selector and content hash modes)
- CEL environment includes string, encoder, and math extensions for flexible expressions

Implements structured-mapping-layer.9.

## Test plan
- [x] Simple field mapping (rename only, nested paths)
- [x] Each transform type tested individually (enum, date, CEL, attribute flatten, default value)
- [x] Bidirectional round-trip tests (simple, enum, date, CEL)
- [x] Computed fields with CEL (input context, chained mapped access)
- [x] Validation rejection (inbound and outbound)
- [x] Idempotency key derivation (source selector, content hash, determinism)
- [x] CEL cache hit/miss verification
- [x] Error cases (invalid JSON, unmapped enum, bad date, invalid CEL, missing selector)
- [x] Edge cases (empty fields, boolean/numeric types, array values, passthrough unmapped)