### PR TITLE
feat: Add mappings to Manifest proto and control-plane integration

### DIFF
--- a/api/jsonschema/manifest.v1.schema.json
+++ b/api/jsonschema/manifest.v1.schema.json
@@ -11,7 +11,8 @@
                 "valuationRules",
                 "sagas",
                 "seedData",
-                "paymentRails"
+                "paymentRails",
+                "mappings"
             ],
             "properties": {
                 "version": {
@@ -67,6 +68,14 @@
                     "additionalProperties": false,
                     "type": "array",
                     "description": "payment_rails defines external payment provider integrations for this tenant."
+                },
+                "mappings": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.mapping.v1.MappingDefinition"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "mappings defines the bidirectional field mapping definitions available to this tenant. Each mapping describes how an external JSON payload is transformed into an internal Meridian gRPC service call."
                 }
             },
             "additionalProperties": false,
@@ -432,6 +441,377 @@
             "type": "object",
             "title": "Valuation Rule",
             "description": "ValuationRule defines how one instrument is converted to another. Used for cross-instrument transactions (e.g., kWh to GBP, USD to EUR)."
+        },
+        "meridian.mapping.v1.AttributeFlatten": {
+            "required": [
+                "sourceKeys",
+                "targetField"
+            ],
+            "properties": {
+                "sourceKeys": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array",
+                    "description": "source_keys lists the gjson paths (external) or proto paths (internal) to collect into the target. Each key's value is placed into the target map under that key name. At least one key must be provided for the flatten to have effect."
+                },
+                "targetField": {
+                    "type": "string",
+                    "description": "target_field is the name of the map field in the target message that receives the flattened values."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Attribute Flatten",
+            "description": "AttributeFlatten defines a transform that merges multiple source fields into a single target map field. Useful for collecting scattered external fields into an attributes map."
+        },
+        "meridian.mapping.v1.CelTransform": {
+            "required": [
+                "inboundCel",
+                "outboundCel"
+            ],
+            "properties": {
+                "inboundCel": {
+                    "type": "string",
+                    "description": "inbound_cel is the CEL expression applied when mapping from external to internal format. Example: \"value.lowerAscii()\" to normalize incoming string values."
+                },
+                "outboundCel": {
+                    "type": "string",
+                    "description": "outbound_cel is the CEL expression applied when mapping from internal to external format. Example: \"value.upperAscii()\" to format outgoing string values."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Cel Transform",
+            "description": "CelTransform defines bidirectional CEL expressions for field transformation."
+        },
+        "meridian.mapping.v1.ComputedField": {
+            "required": [
+                "targetPath",
+                "celExpression"
+            ],
+            "properties": {
+                "targetPath": {
+                    "type": "string",
+                    "description": "target_path is the proto field path in the internal message (dot-separated). Example: \"created_at\", \"metadata.ingested_by\""
+                },
+                "celExpression": {
+                    "type": "string",
+                    "description": "cel_expression is a CEL expression evaluated against the full source payload. The expression may reference any field from the source document. Example: \"now()\" for timestamp, \"'v1.' + version\" for derived strings."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Computed Field",
+            "description": "ComputedField defines a field whose value is derived from a CEL expression rather than directly mapped from the source payload."
+        },
+        "meridian.mapping.v1.EnumMapping": {
+            "required": [
+                "values",
+                "fallback",
+                "outboundFallback"
+            ],
+            "properties": {
+                "values": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": "object",
+                    "description": "values maps external enum string values to internal enum string values. Example: {\"ACTIVE\": \"STATUS_ACTIVE\", \"INACTIVE\": \"STATUS_INACTIVE\"}"
+                },
+                "fallback": {
+                    "type": "string",
+                    "description": "fallback is the internal value to use when an external value is not found in the map. If empty, an unmapped inbound value causes an error."
+                },
+                "outboundFallback": {
+                    "type": "string",
+                    "description": "outbound_fallback is the external value to use when an internal value is not found in the map. If empty, an unmapped outbound value causes an error."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Enum Mapping",
+            "description": "EnumMapping defines a bidirectional mapping between external and internal enum values."
+        },
+        "meridian.mapping.v1.FieldCorrespondence": {
+            "required": [
+                "externalPath",
+                "internalPath",
+                "transform"
+            ],
+            "properties": {
+                "externalPath": {
+                    "type": "string",
+                    "description": "external_path is the gjson path expression for locating the value in the external JSON payload. Supports dot notation, array indexing, and gjson modifiers. Example: \"customer.address.city\", \"items.#.price\", \"meta|@flatten\""
+                },
+                "internalPath": {
+                    "type": "string",
+                    "description": "internal_path is the proto field path in the internal message (dot-separated). Example: \"customer_id\", \"line_items.unit_price\", \"metadata.source\""
+                },
+                "transform": {
+                    "$ref": "#/definitions/meridian.mapping.v1.FieldTransform",
+                    "additionalProperties": false,
+                    "description": "transform defines an optional value transformation applied during mapping. If not set, the raw string value is used as-is."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Field Correspondence",
+            "description": "FieldCorrespondence maps a single external field to an internal proto field."
+        },
+        "meridian.mapping.v1.FieldTransform": {
+            "properties": {
+                "cel": {
+                    "$ref": "#/definitions/meridian.mapping.v1.CelTransform",
+                    "additionalProperties": false,
+                    "description": "cel applies bidirectional CEL expressions for value transformation."
+                },
+                "enumMapping": {
+                    "$ref": "#/definitions/meridian.mapping.v1.EnumMapping",
+                    "additionalProperties": false,
+                    "description": "enum_mapping maps between external and internal enum string representations."
+                },
+                "dateFormat": {
+                    "type": "string",
+                    "description": "date_format specifies a Go time layout string for parsing and formatting date/time values. Example: \"2006-01-02\" for ISO date, \"2006-01-02T15:04:05Z07:00\" for RFC3339."
+                },
+                "defaultValue": {
+                    "type": "string",
+                    "description": "default_value is a literal string value used when the source field is absent or empty."
+                },
+                "attributeFlatten": {
+                    "$ref": "#/definitions/meridian.mapping.v1.AttributeFlatten",
+                    "additionalProperties": false,
+                    "description": "attribute_flatten collects multiple source keys into a single target map field."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "allOf": [
+                {
+                    "oneOf": [
+                        {
+                            "not": {
+                                "anyOf": [
+                                    {
+                                        "required": [
+                                            "cel"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "enumMapping"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "dateFormat"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "defaultValue"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "attributeFlatten"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "required": [
+                                "cel"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "enumMapping"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "dateFormat"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "defaultValue"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "attributeFlatten"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "title": "Field Transform",
+            "description": "FieldTransform defines how a single field value is transformed during mapping. At most one transform type may be set (proto oneof semantics). The Go service layer validates that at least one is provided when a FieldTransform is specified."
+        },
+        "meridian.mapping.v1.IdempotencyConfig": {
+            "required": [
+                "sourceSelector",
+                "useContentHash",
+                "contentHashFields"
+            ],
+            "properties": {
+                "sourceSelector": {
+                    "type": "string",
+                    "description": "source_selector is a gjson path expression that extracts the idempotency key from the external payload. Required when use_content_hash is false. Example: \"header.idempotency_key\", \"transaction.reference_id\""
+                },
+                "useContentHash": {
+                    "type": "boolean",
+                    "description": "use_content_hash indicates that the idempotency key should be derived from a hash of the selected content fields rather than a direct field value."
+                },
+                "contentHashFields": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array",
+                    "description": "content_hash_fields lists the gjson paths whose values are included in the content hash. Required (non-empty) when use_content_hash is true."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Idempotency Config",
+            "description": "IdempotencyConfig controls how idempotency keys are derived for mapped requests. Cross-field validation (enforced at the Go service layer):   - When use_content_hash is false: source_selector must be non-empty.   - When use_content_hash is true: content_hash_fields must contain at least one entry."
+        },
+        "meridian.mapping.v1.MappingDefinition": {
+            "required": [
+                "id",
+                "tenantId",
+                "name",
+                "targetService",
+                "targetRpc",
+                "version",
+                "status",
+                "externalSchema",
+                "fields",
+                "inboundComputedFields",
+                "outboundComputedFields",
+                "inboundValidationCel",
+                "outboundValidationCel",
+                "createdAt",
+                "updatedAt",
+                "isBatch",
+                "batchTargetPath",
+                "idempotency"
+            ],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "id is the unique identifier for this mapping definition (UUID)."
+                },
+                "tenantId": {
+                    "type": "string",
+                    "description": "tenant_id is the tenant that owns this mapping definition (UUID)."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "name is the human-readable name for this mapping. Example: \"Stripe Webhook -\u003e Payment Order\""
+                },
+                "targetService": {
+                    "type": "string",
+                    "description": "target_service is the Meridian gRPC service this mapping calls. Example: \"meridian.payment_order.v1.PaymentOrderService\""
+                },
+                "targetRpc": {
+                    "type": "string",
+                    "description": "target_rpc is the RPC method on the target service to invoke after mapping. Example: \"InitiatePaymentOrder\""
+                },
+                "version": {
+                    "type": "integer",
+                    "description": "version is the schema version for this mapping definition (monotonically increasing)."
+                },
+                "status": {
+                    "enum": [
+                        "MAPPING_STATUS_UNSPECIFIED",
+                        0,
+                        "MAPPING_STATUS_DRAFT",
+                        1,
+                        "MAPPING_STATUS_ACTIVE",
+                        2,
+                        "MAPPING_STATUS_DEPRECATED",
+                        3
+                    ],
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "title": "Mapping Status",
+                    "description": "MappingStatus defines the lifecycle state of a mapping definition."
+                },
+                "externalSchema": {
+                    "type": "string",
+                    "description": "external_schema is a JSON Schema string describing the expected external payload structure. Used for documentation and inbound validation."
+                },
+                "fields": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.mapping.v1.FieldCorrespondence"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "fields defines the field-level correspondences between external and internal formats."
+                },
+                "inboundComputedFields": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.mapping.v1.ComputedField"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "inbound_computed_fields defines fields computed during inbound (external -\u003e internal) mapping."
+                },
+                "outboundComputedFields": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.mapping.v1.ComputedField"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "outbound_computed_fields defines fields computed during outbound (internal -\u003e external) mapping."
+                },
+                "inboundValidationCel": {
+                    "type": "string",
+                    "description": "inbound_validation_cel is a CEL expression evaluated against the raw external payload before inbound mapping. The expression must return a boolean; false causes rejection. Example: \"has(payload.customer_id) \u0026\u0026 payload.amount \u003e 0\""
+                },
+                "outboundValidationCel": {
+                    "type": "string",
+                    "description": "outbound_validation_cel is a CEL expression evaluated against the mapped internal message before outbound mapping. The expression must return a boolean; false causes rejection."
+                },
+                "createdAt": {
+                    "type": "string",
+                    "description": "created_at is when this mapping definition was created.",
+                    "format": "date-time"
+                },
+                "updatedAt": {
+                    "type": "string",
+                    "description": "updated_at is when this mapping definition was last modified.",
+                    "format": "date-time"
+                },
+                "isBatch": {
+                    "type": "boolean",
+                    "description": "is_batch indicates this mapping handles array payloads. Cross-field validation (enforced at Go service layer): when is_batch is true, batch_target_path must be non-empty."
+                },
+                "batchTargetPath": {
+                    "type": "string",
+                    "description": "batch_target_path is the gjson path expression that selects the array of items to process when is_batch is true. Required when is_batch is true. Example: \"events\", \"data.items\""
+                },
+                "idempotency": {
+                    "$ref": "#/definitions/meridian.mapping.v1.IdempotencyConfig",
+                    "additionalProperties": false,
+                    "description": "idempotency defines how idempotency keys are derived for requests produced by this mapping."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Mapping Definition",
+            "description": "MappingDefinition defines a bidirectional transformation between an external JSON schema and an internal Meridian gRPC service RPC. It supports:   - Field-level correspondence with optional transforms (CEL, enums, date formats)   - Computed fields derived from CEL expressions   - Inbound and outbound CEL validation   - Batch ingestion via gjson array paths   - Idempotency key configuration"
         }
     }
 }

--- a/api/proto/meridian/control_plane/v1/manifest.proto
+++ b/api/proto/meridian/control_plane/v1/manifest.proto
@@ -4,6 +4,7 @@ package meridian.control_plane.v1;
 
 import "buf/validate/validate.proto";
 import "google/protobuf/struct.proto";
+import "meridian/mapping/v1/mapping.proto";
 
 option go_package = "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1;controlplanev1";
 
@@ -50,6 +51,11 @@ message Manifest {
 
   // payment_rails defines external payment provider integrations for this tenant.
   repeated PaymentRails payment_rails = 8;
+
+  // mappings defines the bidirectional field mapping definitions available to this tenant.
+  // Each mapping describes how an external JSON payload is transformed into an internal
+  // Meridian gRPC service call.
+  repeated meridian.mapping.v1.MappingDefinition mappings = 9;
 }
 
 // ========================================

--- a/services/control-plane/internal/differ/manifest_differ.go
+++ b/services/control-plane/internal/differ/manifest_differ.go
@@ -475,9 +475,6 @@ func describeSagaChanges(name string, prev, updated *controlplanev1.SagaDefiniti
 
 func describeMappingChanges(key string, prev, updated *mappingv1.MappingDefinition) string {
 	var changes []string
-	if prev.GetName() != updated.GetName() {
-		changes = append(changes, fmt.Sprintf("name: %q -> %q", prev.GetName(), updated.GetName()))
-	}
 	if prev.GetTargetService() != updated.GetTargetService() {
 		changes = append(changes, fmt.Sprintf("target_service: %q -> %q", prev.GetTargetService(), updated.GetTargetService()))
 	}

--- a/services/control-plane/internal/differ/manifest_differ.go
+++ b/services/control-plane/internal/differ/manifest_differ.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -52,6 +53,7 @@ func (d *ManifestDiffer) Diff(ctx context.Context, lastApplied, newManifest *con
 	d.diffAccountTypes(lastApplied, newManifest, plan)
 	d.diffValuationRules(lastApplied, newManifest, plan)
 	d.diffSagas(lastApplied, newManifest, plan)
+	d.diffMappings(lastApplied, newManifest, plan)
 
 	// Run safety checks on all DELETE actions
 	if err := d.runSafetyChecks(ctx, plan); err != nil {
@@ -279,6 +281,8 @@ func (d *ManifestDiffer) runSafetyChecks(ctx context.Context, plan *DiffPlan) er
 			blocked, err = d.safety.CheckSagaDeletion(ctx, action.ResourceCode)
 		case ResourceValuationRule:
 			// Valuation rules have no downstream dependencies to check
+		case ResourceMapping:
+			// Mappings have no downstream dependencies to check
 		}
 
 		if err != nil {
@@ -289,6 +293,50 @@ func (d *ManifestDiffer) runSafetyChecks(ctx context.Context, plan *DiffPlan) er
 		}
 	}
 	return nil
+}
+
+func (d *ManifestDiffer) diffMappings(lastApplied, newManifest *controlplanev1.Manifest, plan *DiffPlan) {
+	oldMap := mappingMap(getMappings(lastApplied))
+	newMap := mappingMap(newManifest.GetMappings())
+
+	for key, updated := range newMap {
+		prev, exists := oldMap[key]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMapping,
+				ResourceCode: key,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create mapping %s (version: %d)", updated.GetName(), updated.GetVersion()),
+			})
+			continue
+		}
+		if !proto.Equal(prev, updated) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMapping,
+				ResourceCode: key,
+				Action:       ActionUpdate,
+				Description:  describeMappingChanges(key, prev, updated),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMapping,
+				ResourceCode: key,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Mapping %s unchanged", key),
+			})
+		}
+	}
+
+	for key := range oldMap {
+		if _, exists := newMap[key]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMapping,
+				ResourceCode: key,
+				Action:       ActionDelete,
+				Description:  fmt.Sprintf("Delete mapping %s", key),
+			})
+		}
+	}
 }
 
 // Helper functions to safely extract slices from possibly-nil manifests.
@@ -321,6 +369,13 @@ func getSagas(m *controlplanev1.Manifest) []*controlplanev1.SagaDefinition {
 	return m.GetSagas()
 }
 
+func getMappings(m *controlplanev1.Manifest) []*mappingv1.MappingDefinition {
+	if m == nil {
+		return nil
+	}
+	return m.GetMappings()
+}
+
 // Map-building helpers keyed by stable identifiers.
 
 func instrumentMap(instruments []*controlplanev1.InstrumentDefinition) map[string]*controlplanev1.InstrumentDefinition {
@@ -351,6 +406,19 @@ func sagaMap(sagas []*controlplanev1.SagaDefinition) map[string]*controlplanev1.
 	m := make(map[string]*controlplanev1.SagaDefinition, len(sagas))
 	for _, s := range sagas {
 		m[s.GetName()] = s
+	}
+	return m
+}
+
+// mappingKey produces a stable identifier for a mapping definition (name:version).
+func mappingKey(name string, version int32) string {
+	return fmt.Sprintf("%s:%d", name, version)
+}
+
+func mappingMap(mappings []*mappingv1.MappingDefinition) map[string]*mappingv1.MappingDefinition {
+	m := make(map[string]*mappingv1.MappingDefinition, len(mappings))
+	for _, mp := range mappings {
+		m[mappingKey(mp.GetName(), mp.GetVersion())] = mp
 	}
 	return m
 }
@@ -403,4 +471,24 @@ func describeSagaChanges(name string, prev, updated *controlplanev1.SagaDefiniti
 		return fmt.Sprintf("Update saga %s", name)
 	}
 	return fmt.Sprintf("Update saga %s (%s)", name, strings.Join(changes, "; "))
+}
+
+func describeMappingChanges(key string, prev, updated *mappingv1.MappingDefinition) string {
+	var changes []string
+	if prev.GetName() != updated.GetName() {
+		changes = append(changes, fmt.Sprintf("name: %q -> %q", prev.GetName(), updated.GetName()))
+	}
+	if prev.GetTargetService() != updated.GetTargetService() {
+		changes = append(changes, fmt.Sprintf("target_service: %q -> %q", prev.GetTargetService(), updated.GetTargetService()))
+	}
+	if prev.GetTargetRpc() != updated.GetTargetRpc() {
+		changes = append(changes, fmt.Sprintf("target_rpc: %q -> %q", prev.GetTargetRpc(), updated.GetTargetRpc()))
+	}
+	if prev.GetStatus() != updated.GetStatus() {
+		changes = append(changes, fmt.Sprintf("status: %s -> %s", prev.GetStatus(), updated.GetStatus()))
+	}
+	if len(changes) == 0 {
+		return fmt.Sprintf("Update mapping %s", key)
+	}
+	return fmt.Sprintf("Update mapping %s (%s)", key, strings.Join(changes, "; "))
 }

--- a/services/control-plane/internal/differ/manifest_differ_mappings_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_mappings_test.go
@@ -1,0 +1,163 @@
+package differ
+
+import (
+	"context"
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testMapping returns a sample MappingDefinition for testing.
+func testMapping(name string, version int32) *mappingv1.MappingDefinition {
+	return &mappingv1.MappingDefinition{
+		Name:          name,
+		Version:       version,
+		TargetService: "meridian.payment_order.v1.PaymentOrderService",
+		TargetRpc:     "InitiatePaymentOrder",
+		Status:        mappingv1.MappingStatus_MAPPING_STATUS_ACTIVE,
+	}
+}
+
+// testManifestWithMappings returns a manifest containing a single mapping.
+func testManifestWithMappings() *controlplanev1.Manifest {
+	m := testManifest()
+	m.Mappings = []*mappingv1.MappingDefinition{
+		testMapping("stripe_webhook", 1),
+	}
+	return m
+}
+
+func TestDiff_MappingAdded_Create(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+	newManifest := testManifestWithMappings()
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceMapping)
+	assert.Len(t, creates, 1)
+	assert.Equal(t, "stripe_webhook:1", creates[0].ResourceCode)
+	assert.Equal(t, ResourceMapping, creates[0].ResourceType)
+	assert.Contains(t, creates[0].Description, "stripe_webhook")
+}
+
+func TestDiff_MappingRemoved_Delete(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifestWithMappings()
+	newManifest := testManifest()
+	newManifest.Mappings = nil
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourceMapping)
+	assert.Len(t, deletes, 1)
+	assert.Equal(t, "stripe_webhook:1", deletes[0].ResourceCode)
+	assert.True(t, deletes[0].Breaking)
+	assert.True(t, plan.HasBreakingChanges)
+}
+
+func TestDiff_MappingUnchanged_NoChange(t *testing.T) {
+	d := New(nil, nil)
+	manifest := testManifestWithMappings()
+
+	plan, err := d.Diff(context.Background(), manifest, manifest)
+	require.NoError(t, err)
+
+	noChanges := filterActionsByResource(plan.Actions, ActionNoChange, ResourceMapping)
+	assert.Len(t, noChanges, 1)
+	assert.Equal(t, "stripe_webhook:1", noChanges[0].ResourceCode)
+}
+
+func TestDiff_MappingModified_Update(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifestWithMappings()
+
+	newManifest := testManifestWithMappings()
+	newManifest.Mappings[0].TargetRpc = "UpdatePaymentOrder"
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceMapping)
+	assert.Len(t, updates, 1)
+	assert.Equal(t, "stripe_webhook:1", updates[0].ResourceCode)
+	assert.Contains(t, updates[0].Description, "target_rpc")
+}
+
+func TestDiff_MappingModifiedTargetService_DescribesChange(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifestWithMappings()
+
+	newManifest := testManifestWithMappings()
+	newManifest.Mappings[0].TargetService = "meridian.other.v1.OtherService"
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceMapping)
+	assert.Len(t, updates, 1)
+	assert.Contains(t, updates[0].Description, "target_service")
+}
+
+func TestDiff_MappingModifiedStatus_DescribesChange(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifestWithMappings()
+
+	newManifest := testManifestWithMappings()
+	newManifest.Mappings[0].Status = mappingv1.MappingStatus_MAPPING_STATUS_DEPRECATED
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceMapping)
+	assert.Len(t, updates, 1)
+	assert.Contains(t, updates[0].Description, "status")
+}
+
+func TestDiff_MappingKey_NameVersionComposite(t *testing.T) {
+	// Two mappings with same name but different versions are distinct resources
+	d := New(nil, nil)
+	oldManifest := testManifest()
+	oldManifest.Mappings = []*mappingv1.MappingDefinition{
+		testMapping("stripe_webhook", 1),
+	}
+
+	newManifest := testManifest()
+	newManifest.Mappings = []*mappingv1.MappingDefinition{
+		testMapping("stripe_webhook", 1),
+		testMapping("stripe_webhook", 2),
+	}
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceMapping)
+	assert.Len(t, creates, 1)
+	assert.Equal(t, "stripe_webhook:2", creates[0].ResourceCode)
+
+	noChanges := filterActionsByResource(plan.Actions, ActionNoChange, ResourceMapping)
+	assert.Len(t, noChanges, 1)
+	assert.Equal(t, "stripe_webhook:1", noChanges[0].ResourceCode)
+}
+
+func TestDiff_NilLastApplied_MappingCreated(t *testing.T) {
+	d := New(nil, nil)
+	manifest := testManifestWithMappings()
+
+	plan, err := d.Diff(context.Background(), nil, manifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceMapping)
+	assert.Len(t, creates, 1)
+	assert.Equal(t, "stripe_webhook:1", creates[0].ResourceCode)
+}
+
+func TestMappingKey(t *testing.T) {
+	assert.Equal(t, "stripe_webhook:1", mappingKey("stripe_webhook", 1))
+	assert.Equal(t, "my_mapping:42", mappingKey("my_mapping", 42))
+}

--- a/services/control-plane/internal/differ/types.go
+++ b/services/control-plane/internal/differ/types.go
@@ -32,6 +32,7 @@ const (
 	ResourceAccountType   ResourceType = "account_type"
 	ResourceValuationRule ResourceType = "valuation_rule"
 	ResourceSaga          ResourceType = "saga"
+	ResourceMapping       ResourceType = "mapping"
 )
 
 // PlannedAction represents a single action in the diff plan.

--- a/services/control-plane/internal/planner/manifest_planner.go
+++ b/services/control-plane/internal/planner/manifest_planner.go
@@ -99,6 +99,8 @@ func phaseForResource(rt differ.ResourceType) Phase {
 		return PhaseValuationRules
 	case differ.ResourceSaga:
 		return PhaseSagas
+	case differ.ResourceMapping:
+		return PhaseMappings
 	default:
 		return PhaseSeedData
 	}
@@ -142,6 +144,11 @@ var grpcMethodMap = map[methodKey]GRPCMethod{
 	{differ.ResourceSaga, differ.ActionCreate}: MethodCreateSagaDraft,
 	{differ.ResourceSaga, differ.ActionUpdate}: MethodUpdateSagaDefinition,
 	{differ.ResourceSaga, differ.ActionDelete}: MethodDeprecateSaga,
+
+	// Mappings
+	{differ.ResourceMapping, differ.ActionCreate}: MethodCreateMapping,
+	{differ.ResourceMapping, differ.ActionUpdate}: MethodUpdateMapping,
+	{differ.ResourceMapping, differ.ActionDelete}: MethodDeprecateMapping,
 }
 
 // GenerateIdempotencyKey produces a deterministic SHA-256 based idempotency key.

--- a/services/control-plane/internal/planner/manifest_planner_mappings_test.go
+++ b/services/control-plane/internal/planner/manifest_planner_mappings_test.go
@@ -1,0 +1,84 @@
+package planner
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/services/control-plane/internal/differ"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlan_MappingsInPhase5(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceMapping, ResourceCode: "stripe_webhook:1", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+	assert.Equal(t, PhaseMappings, plan.Calls[0].Phase)
+}
+
+func TestPlan_MappingsAfterSagas(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceMapping, ResourceCode: "stripe_webhook:1", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceSaga, ResourceCode: "process_payment", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 3)
+
+	// Instruments (1) < Sagas (4) < Mappings (5)
+	for i := 1; i < len(plan.Calls); i++ {
+		assert.LessOrEqual(t, int(plan.Calls[i-1].Phase), int(plan.Calls[i].Phase),
+			"calls should be sorted by phase")
+	}
+}
+
+func TestPlan_GRPCMethodMapping_Mappings(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceMapping, ResourceCode: "stripe_webhook:1", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceMapping, ResourceCode: "shopify_order:2", Action: differ.ActionUpdate},
+			{ResourceType: differ.ResourceMapping, ResourceCode: "old_mapping:1", Action: differ.ActionDelete},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+
+	callsByCode := indexCallsByResourceID(plan.Calls)
+	assert.Equal(t, MethodCreateMapping, callsByCode["stripe_webhook:1"].GRPCMethod)
+	assert.Equal(t, MethodUpdateMapping, callsByCode["shopify_order:2"].GRPCMethod)
+	assert.Equal(t, MethodDeprecateMapping, callsByCode["old_mapping:1"].GRPCMethod)
+}
+
+func TestPhaseLabel_Mappings(t *testing.T) {
+	assert.Equal(t, "Mapping Definitions", PhaseLabel(PhaseMappings))
+}
+
+func TestPlan_MappingsPhaseIs5(t *testing.T) {
+	// Verify PhaseMappings constant has value 5 (between Sagas=4 and SeedData=6)
+	assert.Equal(t, Phase(5), PhaseMappings)
+	assert.Equal(t, Phase(6), PhaseSeedData)
+	assert.Less(t, int(PhaseSagas), int(PhaseMappings))
+	assert.Less(t, int(PhaseMappings), int(PhaseSeedData))
+}
+
+func TestPlan_MappingPhaseLabel(t *testing.T) {
+	assert.Equal(t, "Instruments", PhaseLabel(PhaseInstruments))
+	assert.Equal(t, "Account Types", PhaseLabel(PhaseAccountTypes))
+	assert.Equal(t, "Valuation Rules", PhaseLabel(PhaseValuationRules))
+	assert.Equal(t, "Saga Definitions", PhaseLabel(PhaseSagas))
+	assert.Equal(t, "Mapping Definitions", PhaseLabel(PhaseMappings))
+	assert.Equal(t, "Seed Data", PhaseLabel(PhaseSeedData))
+}

--- a/services/control-plane/internal/planner/manifest_planner_mappings_test.go
+++ b/services/control-plane/internal/planner/manifest_planner_mappings_test.go
@@ -36,11 +36,11 @@ func TestPlan_MappingsAfterSagas(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, plan.Calls, 3)
 
-	// Instruments (1) < Sagas (4) < Mappings (5)
-	for i := 1; i < len(plan.Calls); i++ {
-		assert.LessOrEqual(t, int(plan.Calls[i-1].Phase), int(plan.Calls[i].Phase),
-			"calls should be sorted by phase")
-	}
+	// Verify each resource is assigned to its exact expected phase.
+	callsByCode := indexCallsByResourceID(plan.Calls)
+	assert.Equal(t, PhaseInstruments, callsByCode["GBP"].Phase, "instrument should be in phase 1")
+	assert.Equal(t, PhaseSagas, callsByCode["process_payment"].Phase, "saga should be in phase 4")
+	assert.Equal(t, PhaseMappings, callsByCode["stripe_webhook:1"].Phase, "mapping should be in phase 5")
 }
 
 func TestPlan_GRPCMethodMapping_Mappings(t *testing.T) {

--- a/services/control-plane/internal/planner/manifest_planner_mappings_test.go
+++ b/services/control-plane/internal/planner/manifest_planner_mappings_test.go
@@ -62,10 +62,6 @@ func TestPlan_GRPCMethodMapping_Mappings(t *testing.T) {
 	assert.Equal(t, MethodDeprecateMapping, callsByCode["old_mapping:1"].GRPCMethod)
 }
 
-func TestPhaseLabel_Mappings(t *testing.T) {
-	assert.Equal(t, "Mapping Definitions", PhaseLabel(PhaseMappings))
-}
-
 func TestPlan_MappingsPhaseIs5(t *testing.T) {
 	// Verify PhaseMappings constant has value 5 (between Sagas=4 and SeedData=6)
 	assert.Equal(t, Phase(5), PhaseMappings)

--- a/services/control-plane/internal/planner/types.go
+++ b/services/control-plane/internal/planner/types.go
@@ -28,9 +28,12 @@ const (
 	// PhaseSagas registers saga definitions with the Saga Registry
 	// (depends on account types and instruments being registered first).
 	PhaseSagas Phase = 4
+	// PhaseMappings registers mapping definitions with Reference Data
+	// (can be registered after instruments and account types are provisioned).
+	PhaseMappings Phase = 5
 	// PhaseSeedData provisions seed data via various service calls
 	// (depends on all above being registered first).
-	PhaseSeedData Phase = 5
+	PhaseSeedData Phase = 6
 )
 
 // PhaseLabel returns a human-readable label for a phase.
@@ -44,6 +47,8 @@ func PhaseLabel(p Phase) string {
 		return "Valuation Rules"
 	case PhaseSagas:
 		return "Saga Definitions"
+	case PhaseMappings:
+		return "Mapping Definitions"
 	case PhaseSeedData:
 		return "Seed Data"
 	default:
@@ -70,6 +75,11 @@ const (
 	MethodUpdateSagaDefinition GRPCMethod = "meridian.saga.v1.SagaRegistryService/UpdateSagaDefinition"
 	MethodDeprecateSaga        GRPCMethod = "meridian.saga.v1.SagaRegistryService/DeprecateSaga"
 	MethodActivateSaga         GRPCMethod = "meridian.saga.v1.SagaRegistryService/ActivateSaga"
+
+	// Mapping Service (Reference Data)
+	MethodCreateMapping    GRPCMethod = "meridian.mapping.v1.MappingService/CreateMapping"
+	MethodUpdateMapping    GRPCMethod = "meridian.mapping.v1.MappingService/UpdateMapping"
+	MethodDeprecateMapping GRPCMethod = "meridian.mapping.v1.MappingService/DeprecateMapping"
 )
 
 // PlannedCall represents a single gRPC call in the execution plan.
@@ -173,7 +183,7 @@ func (p *ExecutionPlan) Visualize() string {
 	fmt.Fprintf(&b, "Total calls: %d\n\n", len(p.Calls))
 
 	byPhase := p.ByPhase()
-	for phase := PhaseInstruments; phase <= PhaseSeedData; phase++ {
+	for phase := PhaseInstruments; phase <= PhaseSeedData; phase++ { //nolint:intrange
 		calls, ok := byPhase[phase]
 		if !ok {
 			continue

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -567,6 +567,7 @@ func (v *ManifestValidator) validateSingleMapping(
 	v.validateMappingComputedFields(mp, basePath, result)
 	v.validateMappingBatch(mp, basePath, result)
 	v.validateMappingStatus(mp, basePath, result)
+	v.validateMappingIdempotency(mp, basePath, result)
 }
 
 // validateMappingCELExpressions validates inbound/outbound CEL validation expressions.
@@ -642,6 +643,9 @@ func (v *ManifestValidator) validateMappingBatch(
 	}
 }
 
+// mappingCELAvailableFields lists the variables available in mapping CEL expressions.
+var mappingCELAvailableFields = []string{"payload", "value"}
+
 // validateMappingCELExpression compiles a single CEL expression for mapping contexts.
 // Uses a simplified CEL environment with payload and value variables.
 func (v *ManifestValidator) validateMappingCELExpression(
@@ -664,11 +668,33 @@ func (v *ManifestValidator) validateMappingCELExpression(
 		return
 	}
 
+	errMsg := issues.Err().Error()
+
+	// Check for undeclared reference errors to provide field suggestions.
+	if strings.Contains(errMsg, "undeclared reference") {
+		undeclaredField := extractUndeclaredReference(errMsg)
+		suggestion := ""
+		if undeclaredField != "" {
+			if match := findClosestMatch(undeclaredField, mappingCELAvailableFields); match != "" {
+				suggestion = fmt.Sprintf("Did you mean %q?", match)
+			}
+		}
+		addError(result, ValidationError{
+			Severity:        SeverityError,
+			Path:            path,
+			Code:            "CEL_UNDECLARED_REFERENCE",
+			Message:         errMsg,
+			Suggestion:      suggestion,
+			AvailableFields: mappingCELAvailableFields,
+		})
+		return
+	}
+
 	addError(result, ValidationError{
 		Severity: SeverityError,
 		Path:     path,
 		Code:     "CEL_COMPILATION_ERROR",
-		Message:  issues.Err().Error(),
+		Message:  errMsg,
 	})
 }
 
@@ -685,6 +711,37 @@ func (v *ManifestValidator) validateMappingStatus(
 			Path:     basePath + ".status",
 			Code:     "INVALID_MAPPING_STATUS",
 			Message:  "mapping status must be specified (DRAFT, ACTIVE, or DEPRECATED)",
+		})
+	}
+}
+
+// validateMappingIdempotency enforces cross-field constraints on IdempotencyConfig.
+// When use_content_hash is false, source_selector must be non-empty.
+// When use_content_hash is true, content_hash_fields must have at least one entry.
+func (v *ManifestValidator) validateMappingIdempotency(
+	mp *mappingv1.MappingDefinition,
+	basePath string,
+	result *ValidationResult,
+) {
+	cfg := mp.GetIdempotency()
+	if cfg == nil {
+		return
+	}
+	idemPath := basePath + ".idempotency"
+	if !cfg.GetUseContentHash() && cfg.GetSourceSelector() == "" {
+		addError(result, ValidationError{
+			Severity: SeverityError,
+			Path:     idemPath + ".source_selector",
+			Code:     "IDEMPOTENCY_SOURCE_REQUIRED",
+			Message:  "source_selector is required when use_content_hash is false",
+		})
+	}
+	if cfg.GetUseContentHash() && len(cfg.GetContentHashFields()) == 0 {
+		addError(result, ValidationError{
+			Severity: SeverityError,
+			Path:     idemPath + ".content_hash_fields",
+			Code:     "IDEMPOTENCY_HASH_FIELDS_REQUIRED",
+			Message:  "content_hash_fields must have at least one entry when use_content_hash is true",
 		})
 	}
 }

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -15,6 +15,7 @@ import (
 	"buf.build/go/protovalidate"
 	"github.com/google/cel-go/cel"
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
 	"github.com/shopspring/decimal"
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
@@ -145,6 +146,7 @@ type ManifestValidator struct {
 	protoValidator protovalidate.Validator
 	celEnv         *cel.Env
 	bucketCelEnv   *cel.Env
+	mappingCelEnv  *cel.Env
 }
 
 // New creates a new ManifestValidator.
@@ -178,10 +180,21 @@ func New() (*ManifestValidator, error) {
 		return nil, fmt.Errorf("failed to create bucket CEL environment: %w", err)
 	}
 
+	// CEL environment for mapping validation/transformation expressions.
+	// These expressions operate on arbitrary payload fields.
+	mappingCelEnv, err := cel.NewEnv(
+		cel.Variable("payload", cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable("value", cel.DynType),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mapping CEL environment: %w", err)
+	}
+
 	return &ManifestValidator{
 		protoValidator: pv,
 		celEnv:         celEnv,
 		bucketCelEnv:   bucketCelEnv,
+		mappingCelEnv:  mappingCelEnv,
 	}, nil
 }
 
@@ -211,7 +224,10 @@ func (v *ManifestValidator) Validate(
 	// 6. Payment rails validation
 	v.validatePaymentRails(manifest, result)
 
-	// 7. Immutability checks
+	// 7. Mappings validation
+	v.validateMappings(manifest, result)
+
+	// 8. Immutability checks
 	if previousManifest != nil {
 		v.validateImmutability(manifest, previousManifest, result)
 	}
@@ -307,6 +323,26 @@ func (v *ManifestValidator) validateDuplicates(
 			})
 		} else {
 			sagaNames[saga.GetName()] = i
+		}
+	}
+
+	// Check duplicate mapping (name, version) pairs
+	type mappingKey struct {
+		name    string
+		version int32
+	}
+	mappingKeys := make(map[mappingKey]int)
+	for i, mp := range manifest.GetMappings() {
+		key := mappingKey{name: mp.GetName(), version: mp.GetVersion()}
+		if prev, exists := mappingKeys[key]; exists {
+			addError(result, ValidationError{
+				Severity: SeverityError,
+				Path:     fmt.Sprintf("mappings[%d]", i),
+				Code:     "DUPLICATE_MAPPING",
+				Message:  fmt.Sprintf("duplicate mapping name=%q version=%d (first defined at mappings[%d])", mp.GetName(), mp.GetVersion(), prev),
+			})
+		} else {
+			mappingKeys[key] = i
 		}
 	}
 }
@@ -505,6 +541,151 @@ func (v *ManifestValidator) validateCrossReferences(
 			fmt.Sprintf("valuation_rules[%d].to_instrument", i),
 			result,
 		)
+	}
+}
+
+// validateMappings validates all MappingDefinition entries in the manifest.
+// It enforces no duplicate (name, version) pairs, valid CEL expressions,
+// and valid status.
+func (v *ManifestValidator) validateMappings(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	for i, mp := range manifest.GetMappings() {
+		v.validateSingleMapping(mp, fmt.Sprintf("mappings[%d]", i), result)
+	}
+}
+
+// validateSingleMapping validates one MappingDefinition entry.
+func (v *ManifestValidator) validateSingleMapping(
+	mp *mappingv1.MappingDefinition,
+	basePath string,
+	result *ValidationResult,
+) {
+	v.validateMappingCELExpressions(mp, basePath, result)
+	v.validateMappingFields(mp, basePath, result)
+	v.validateMappingComputedFields(mp, basePath, result)
+	v.validateMappingBatch(mp, basePath, result)
+	v.validateMappingStatus(mp, basePath, result)
+}
+
+// validateMappingCELExpressions validates inbound/outbound CEL validation expressions.
+func (v *ManifestValidator) validateMappingCELExpressions(
+	mp *mappingv1.MappingDefinition,
+	basePath string,
+	result *ValidationResult,
+) {
+	if expr := mp.GetInboundValidationCel(); expr != "" {
+		v.validateMappingCELExpression(expr, basePath+".inbound_validation_cel", result)
+	}
+	if expr := mp.GetOutboundValidationCel(); expr != "" {
+		v.validateMappingCELExpression(expr, basePath+".outbound_validation_cel", result)
+	}
+}
+
+// validateMappingFields validates CEL transforms on field correspondences.
+func (v *ManifestValidator) validateMappingFields(
+	mp *mappingv1.MappingDefinition,
+	basePath string,
+	result *ValidationResult,
+) {
+	for j, field := range mp.GetFields() {
+		ft := field.GetTransform()
+		if ft == nil {
+			continue
+		}
+		celT := ft.GetCel()
+		if celT == nil {
+			continue
+		}
+		fieldPath := fmt.Sprintf("%s.fields[%d].transform.cel", basePath, j)
+		if expr := celT.GetInboundCel(); expr != "" {
+			v.validateMappingCELExpression(expr, fieldPath+".inbound_cel", result)
+		}
+		if expr := celT.GetOutboundCel(); expr != "" {
+			v.validateMappingCELExpression(expr, fieldPath+".outbound_cel", result)
+		}
+	}
+}
+
+// validateMappingComputedFields validates CEL expressions on computed fields.
+func (v *ManifestValidator) validateMappingComputedFields(
+	mp *mappingv1.MappingDefinition,
+	basePath string,
+	result *ValidationResult,
+) {
+	for j, cf := range mp.GetInboundComputedFields() {
+		if expr := cf.GetCelExpression(); expr != "" {
+			v.validateMappingCELExpression(expr, fmt.Sprintf("%s.inbound_computed_fields[%d].cel_expression", basePath, j), result)
+		}
+	}
+	for j, cf := range mp.GetOutboundComputedFields() {
+		if expr := cf.GetCelExpression(); expr != "" {
+			v.validateMappingCELExpression(expr, fmt.Sprintf("%s.outbound_computed_fields[%d].cel_expression", basePath, j), result)
+		}
+	}
+}
+
+// validateMappingBatch checks batch consistency (is_batch requires batch_target_path).
+func (v *ManifestValidator) validateMappingBatch(
+	mp *mappingv1.MappingDefinition,
+	basePath string,
+	result *ValidationResult,
+) {
+	if mp.GetIsBatch() && mp.GetBatchTargetPath() == "" {
+		addError(result, ValidationError{
+			Severity: SeverityError,
+			Path:     basePath + ".batch_target_path",
+			Code:     "MAPPING_BATCH_TARGET_REQUIRED",
+			Message:  "batch_target_path must be set when is_batch is true",
+		})
+	}
+}
+
+// validateMappingCELExpression compiles a single CEL expression for mapping contexts.
+// Uses a simplified CEL environment with payload and value variables.
+func (v *ManifestValidator) validateMappingCELExpression(
+	expression string,
+	path string,
+	result *ValidationResult,
+) {
+	if len(expression) > 2048 {
+		addError(result, ValidationError{
+			Severity: SeverityError,
+			Path:     path,
+			Code:     "CEL_EXPRESSION_TOO_LONG",
+			Message:  fmt.Sprintf("CEL expression exceeds maximum length of 2048 bytes (got %d)", len(expression)),
+		})
+		return
+	}
+
+	_, issues := v.mappingCelEnv.Compile(expression)
+	if issues == nil || issues.Err() == nil {
+		return
+	}
+
+	addError(result, ValidationError{
+		Severity: SeverityError,
+		Path:     path,
+		Code:     "CEL_COMPILATION_ERROR",
+		Message:  issues.Err().Error(),
+	})
+}
+
+// validateMappingStatus checks that status is a defined, non-unspecified value.
+func (v *ManifestValidator) validateMappingStatus(
+	mp *mappingv1.MappingDefinition,
+	basePath string,
+	result *ValidationResult,
+) {
+	status := mp.GetStatus()
+	if status == mappingv1.MappingStatus_MAPPING_STATUS_UNSPECIFIED {
+		addError(result, ValidationError{
+			Severity: SeverityError,
+			Path:     basePath + ".status",
+			Code:     "INVALID_MAPPING_STATUS",
+			Message:  "mapping status must be specified (DRAFT, ACTIVE, or DEPRECATED)",
+		})
 	}
 }
 

--- a/services/control-plane/internal/validator/manifest_validator_mappings_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_mappings_test.go
@@ -451,3 +451,122 @@ func TestValidateMappings_FullRoundTrip(t *testing.T) {
 		t.Logf("warnings (not failures): %v", result.Warnings)
 	}
 }
+
+func TestValidateMappings_IdempotencyNoHashRequiresSourceSelector(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.Idempotency = &mappingv1.IdempotencyConfig{
+		UseContentHash: false,
+		SourceSelector: "", // Missing required field
+	}
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for idempotency without source_selector")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "IDEMPOTENCY_SOURCE_REQUIRED" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected IDEMPOTENCY_SOURCE_REQUIRED error, got: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_IdempotencyContentHashRequiresFields(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.Idempotency = &mappingv1.IdempotencyConfig{
+		UseContentHash:    true,
+		ContentHashFields: nil, // Missing required fields
+	}
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for content hash idempotency without hash fields")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "IDEMPOTENCY_HASH_FIELDS_REQUIRED" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected IDEMPOTENCY_HASH_FIELDS_REQUIRED error, got: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_IdempotencyWithSourceSelector_Valid(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.Idempotency = &mappingv1.IdempotencyConfig{
+		UseContentHash: false,
+		SourceSelector: "header.idempotency_key",
+	}
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with idempotency source_selector, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_IdempotencyWithContentHash_Valid(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.Idempotency = &mappingv1.IdempotencyConfig{
+		UseContentHash:    true,
+		ContentHashFields: []string{"transaction.id", "transaction.amount"},
+	}
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with idempotency content hash fields, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_NoIdempotencyConfig_Valid(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	// No idempotency config - should be valid
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest without idempotency config, got errors: %v", result.Errors)
+	}
+}

--- a/services/control-plane/internal/validator/manifest_validator_mappings_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_mappings_test.go
@@ -1,0 +1,453 @@
+package validator
+
+import (
+	"strings"
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+)
+
+// validMapping returns a fully valid MappingDefinition for testing.
+// Includes required id and tenant_id UUIDs to satisfy proto validation.
+func validMapping() *mappingv1.MappingDefinition {
+	return &mappingv1.MappingDefinition{
+		Id:            "00000000-0000-0000-0000-000000000001",
+		TenantId:      "00000000-0000-0000-0000-000000000002",
+		Name:          "stripe_webhook",
+		TargetService: "meridian.payment_order.v1.PaymentOrderService",
+		TargetRpc:     "InitiatePaymentOrder",
+		Version:       1,
+		Status:        mappingv1.MappingStatus_MAPPING_STATUS_ACTIVE,
+	}
+}
+
+func TestValidateMappings_ValidSingleMapping(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.Mappings = []*mappingv1.MappingDefinition{validMapping()}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with mapping, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_NoMappings(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	// No mappings - should still be valid
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest without mappings, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_DuplicateNameVersion(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	mp2 := validMapping()
+	mp2.Id = "00000000-0000-0000-0000-000000000003" // Different ID, same (name, version)
+
+	m := validManifest()
+	m.Mappings = []*mappingv1.MappingDefinition{
+		validMapping(),
+		mp2, // Duplicate (name="stripe_webhook", version=1)
+	}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for duplicate mapping (name, version)")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "DUPLICATE_MAPPING" {
+			found = true
+			if !strings.Contains(e.Message, "stripe_webhook") {
+				t.Errorf("expected message to mention name, got: %s", e.Message)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected DUPLICATE_MAPPING error, got: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_SameNameDifferentVersion_Valid(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp2 := validMapping()
+	mp2.Id = "00000000-0000-0000-0000-000000000003"
+	mp2.Version = 2
+	m.Mappings = []*mappingv1.MappingDefinition{
+		validMapping(),
+		mp2, // Same name, different version - this is valid
+	}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with same name but different versions, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_UnspecifiedStatus(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.Status = mappingv1.MappingStatus_MAPPING_STATUS_UNSPECIFIED
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for unspecified mapping status")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_MAPPING_STATUS" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected INVALID_MAPPING_STATUS error, got: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_DraftStatus_Valid(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.Status = mappingv1.MappingStatus_MAPPING_STATUS_DRAFT
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with DRAFT status, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_DeprecatedStatus_Valid(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.Status = mappingv1.MappingStatus_MAPPING_STATUS_DEPRECATED
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with DEPRECATED status, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_BatchTrueWithoutPath(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.IsBatch = true
+	mp.BatchTargetPath = "" // Missing required path
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for batch=true without batch_target_path")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "MAPPING_BATCH_TARGET_REQUIRED" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected MAPPING_BATCH_TARGET_REQUIRED error, got: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_BatchTrueWithPath_Valid(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.IsBatch = true
+	mp.BatchTargetPath = "data.events"
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest for batch=true with batch_target_path, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_ValidInboundCEL(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.InboundValidationCel = "payload.size() > 0"
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with inbound CEL, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_InvalidInboundCEL(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.InboundValidationCel = "invalid $$$ expression"
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for bad inbound CEL expression")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "CEL_COMPILATION_ERROR" && strings.Contains(e.Path, "inbound_validation_cel") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected CEL_COMPILATION_ERROR for inbound_validation_cel, got: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_InvalidOutboundCEL(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.OutboundValidationCel = "invalid @@@ expression"
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for bad outbound CEL expression")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "CEL_COMPILATION_ERROR" && strings.Contains(e.Path, "outbound_validation_cel") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected CEL_COMPILATION_ERROR for outbound_validation_cel, got: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_EmptyCELExpressions_Valid(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.InboundValidationCel = ""
+	mp.OutboundValidationCel = ""
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with empty CEL expressions, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_WithFields_ValidCELTransform(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.Fields = []*mappingv1.FieldCorrespondence{
+		{
+			ExternalPath: "customer.name",
+			InternalPath: "customer_name",
+			Transform: &mappingv1.FieldTransform{
+				Transform: &mappingv1.FieldTransform_Cel{
+					Cel: &mappingv1.CelTransform{
+						// Use simple expressions that work in standard CEL
+						InboundCel:  "string(value)",
+						OutboundCel: "string(value)",
+					},
+				},
+			},
+		},
+	}
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with CEL field transform, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_MultipleErrors(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.Status = mappingv1.MappingStatus_MAPPING_STATUS_UNSPECIFIED
+	mp.IsBatch = true
+	mp.BatchTargetPath = ""
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest with multiple mapping errors")
+	}
+	if len(result.Errors) < 2 {
+		t.Errorf("expected at least 2 errors, got %d: %v", len(result.Errors), result.Errors)
+	}
+}
+
+func TestValidateMappings_ValidManifestUnchangedByMappings(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	// Existing valid manifest without mappings should still pass
+	m := validManifest()
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest unchanged by mapping validation, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_MappingWithComputedFields_Valid(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	mp := validMapping()
+	mp.InboundComputedFields = []*mappingv1.ComputedField{
+		{
+			TargetPath:    "created_at",
+			CelExpression: "payload.size() > 0",
+		},
+	}
+	m.Mappings = []*mappingv1.MappingDefinition{mp}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with computed fields, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateMappings_CompatibilityWithExistingManifest(t *testing.T) {
+	// Verify existing manifest test helper still works with the new mapping section
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.Mappings = []*mappingv1.MappingDefinition{
+		{
+			Id:             "00000000-0000-0000-0000-000000000001",
+			TenantId:       "00000000-0000-0000-0000-000000000002",
+			Name:           "webhook_v1",
+			TargetService:  "meridian.payment_order.v1.PaymentOrderService",
+			TargetRpc:      "InitiatePaymentOrder",
+			Version:        1,
+			Status:         mappingv1.MappingStatus_MAPPING_STATUS_ACTIVE,
+			ExternalSchema: `{"type": "object", "properties": {"amount": {"type": "number"}}}`,
+		},
+	}
+
+	result := v.Validate(m, nil)
+	// ExternalSchema is just a string; validation doesn't parse it
+	if !result.Valid {
+		// Check if errors are from mapping section
+		for _, e := range result.Errors {
+			if strings.Contains(e.Path, "mappings") {
+				t.Errorf("unexpected mapping validation error: %v", e)
+			}
+		}
+	}
+}
+
+// validManifestWithMapping returns a manifest with a single valid mapping.
+func validManifestWithMapping() *controlplanev1.Manifest {
+	m := validManifest()
+	m.Mappings = []*mappingv1.MappingDefinition{validMapping()}
+	return m
+}
+
+func TestValidateMappings_FullRoundTrip(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifestWithMapping()
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid full manifest with mapping, got errors: %v", result.Errors)
+	}
+	if len(result.Warnings) > 0 {
+		t.Logf("warnings (not failures): %v", result.Warnings)
+	}
+}


### PR DESCRIPTION
## Summary

- Extends Manifest proto with `repeated meridian.mapping.v1.MappingDefinition mappings = 9`
- Implements `diffMappings()` in the differ, keyed by composite `(name, version)` to support versioned mapping definitions
- Adds `PhaseMappings` (phase 5, between sagas and seed data) to the planner with `CreateMapping`, `UpdateMapping`, and `DeprecateMapping` gRPC method mappings
- Adds `validateMappings()` to the validator covering: duplicate `(name, version)` detection, unspecified status rejection, batch consistency check, and CEL expression compilation for inbound/outbound validation and field transforms

## Test plan

- [x] Differ identifies added/modified/removed mappings keyed by `name:version`
- [x] Differ describes target_rpc, target_service, and status changes
- [x] Differ handles concurrent versioning (same name, different version = distinct resources)
- [x] Planner assigns mappings to PhaseMappings (phase 5, after sagas)
- [x] Planner generates CreateMapping/UpdateMapping/DeprecateMapping gRPC calls
- [x] Validator rejects duplicate (name, version) pairs
- [x] Validator rejects unspecified status
- [x] Validator rejects is_batch=true without batch_target_path
- [x] Validator catches invalid CEL expressions in inbound/outbound validation, field transforms, and computed fields
- [x] All existing control-plane tests pass unchanged