### PR TITLE
feat: Add batch support to mapping engine

### DIFF
--- a/services/gateway/internal/mapping/engine_batch.go
+++ b/services/gateway/internal/mapping/engine_batch.go
@@ -1,0 +1,146 @@
+package mapping
+
+import (
+	"fmt"
+
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// TransformInboundBatch handles batch inbound transformation when mapping.IsBatch is true.
+//
+// externalJSON must be a JSON array. Each element is transformed individually using the
+// existing per-element mapping logic. The transformed element is wrapped at
+// mapping.BatchTargetPath in its own proto JSON envelope.
+//
+// Idempotency keys (when configured) are derived per element: the base key is computed
+// from each element, then the element index is appended as ":<index>".
+//
+// On per-element failure, the error wraps the element index for diagnostics.
+func (e *Engine) TransformInboundBatch(mapping *mappingv1.MappingDefinition, externalJSON []byte) ([]*InboundResult, error) {
+	if !gjson.ValidBytes(externalJSON) {
+		return nil, ErrInvalidJSON
+	}
+
+	parsed := gjson.ParseBytes(externalJSON)
+	if !parsed.IsArray() {
+		return nil, fmt.Errorf("%w: batch mode requires a JSON array as input", ErrInvalidJSON)
+	}
+
+	var elements []gjson.Result
+	parsed.ForEach(func(_, v gjson.Result) bool {
+		elements = append(elements, v)
+		return true
+	})
+
+	if len(elements) == 0 {
+		return nil, nil
+	}
+
+	results := make([]*InboundResult, 0, len(elements))
+	for i, elem := range elements {
+		elemJSON := []byte(elem.Raw)
+
+		transformed, err := e.applyInboundFields(mapping.GetFields(), elemJSON)
+		if err != nil {
+			return nil, fmt.Errorf("element %d: %w", i, err)
+		}
+
+		transformed, err = e.applyComputedFields(mapping.GetInboundComputedFields(), elemJSON, transformed)
+		if err != nil {
+			return nil, fmt.Errorf("element %d: %w", i, err)
+		}
+
+		// Wrap the single transformed element as a one-element array at batch_target_path.
+		var elemInterface any
+		if gjson.Valid(transformed) {
+			elemInterface = gjsonToInterface(gjson.Parse(transformed))
+		}
+
+		protoOutput := "{}"
+		protoOutput, err = sjson.Set(protoOutput, mapping.GetBatchTargetPath(), []any{elemInterface})
+		if err != nil {
+			return nil, fmt.Errorf("%w: element %d: wrapping at %s: %w", ErrFieldExtraction, i, mapping.GetBatchTargetPath(), err)
+		}
+
+		idempotencyKey, err := e.deriveElementIdempotencyKey(mapping.GetIdempotency(), elemJSON, i)
+		if err != nil {
+			return nil, fmt.Errorf("element %d: %w", i, err)
+		}
+
+		results = append(results, &InboundResult{
+			ProtoJSON:      []byte(protoOutput),
+			IdempotencyKey: idempotencyKey,
+		})
+	}
+
+	return results, nil
+}
+
+// TransformOutboundBatch handles batch outbound transformation when mapping.IsBatch is true.
+//
+// protoJSON must be a JSON object containing an array at mapping.BatchTargetPath.
+// Each element in the array is transformed individually using the reverse mapping logic.
+// The result is a plain JSON array.
+func (e *Engine) TransformOutboundBatch(mapping *mappingv1.MappingDefinition, protoJSON []byte) ([]byte, error) {
+	if !gjson.ValidBytes(protoJSON) {
+		return nil, ErrInvalidJSON
+	}
+
+	arrayVal := gjson.GetBytes(protoJSON, mapping.GetBatchTargetPath())
+	if !arrayVal.Exists() || !arrayVal.IsArray() {
+		// Return empty array when path is absent or not an array.
+		return []byte("[]"), nil
+	}
+
+	var elements []gjson.Result
+	arrayVal.ForEach(func(_, v gjson.Result) bool {
+		elements = append(elements, v)
+		return true
+	})
+
+	results := make([]any, 0, len(elements))
+	for i, elem := range elements {
+		elemJSON := []byte(elem.Raw)
+
+		transformed, err := e.applyOutboundFields(mapping.GetFields(), elemJSON)
+		if err != nil {
+			return nil, fmt.Errorf("element %d: %w", i, err)
+		}
+
+		transformed, err = e.applyComputedFields(mapping.GetOutboundComputedFields(), elemJSON, transformed)
+		if err != nil {
+			return nil, fmt.Errorf("element %d: %w", i, err)
+		}
+
+		results = append(results, gjsonToInterface(gjson.Parse(transformed)))
+	}
+
+	output, err := sjson.Set("", "arr", results)
+	if err != nil {
+		return nil, fmt.Errorf("%w: marshaling batch output: %w", ErrTransform, err)
+	}
+	// sjson wraps in an object; extract just the array.
+	arr := gjson.Get(output, "arr")
+	if !arr.Exists() {
+		return []byte("[]"), nil
+	}
+	return []byte(arr.Raw), nil
+}
+
+// deriveElementIdempotencyKey derives the idempotency key for a single batch element.
+// The base key is computed from the element JSON, then the element index is appended as ":<index>".
+// If no idempotency config is set, returns an empty string.
+func (e *Engine) deriveElementIdempotencyKey(config *mappingv1.IdempotencyConfig, elemJSON []byte, index int) (string, error) {
+	if config == nil {
+		return "", nil
+	}
+
+	baseKey, err := e.deriveIdempotencyKey(config, elemJSON)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s:%d", baseKey, index), nil
+}

--- a/services/gateway/internal/mapping/engine_batch.go
+++ b/services/gateway/internal/mapping/engine_batch.go
@@ -42,6 +42,10 @@ func (e *Engine) TransformInboundBatch(mapping *mappingv1.MappingDefinition, ext
 	for i, elem := range elements {
 		elemJSON := []byte(elem.Raw)
 
+		if err := e.runValidationCEL(mapping.GetInboundValidationCel(), elemJSON); err != nil {
+			return nil, fmt.Errorf("element %d: %w", i, err)
+		}
+
 		transformed, err := e.applyInboundFields(mapping.GetFields(), elemJSON)
 		if err != nil {
 			return nil, fmt.Errorf("element %d: %w", i, err)
@@ -103,6 +107,10 @@ func (e *Engine) TransformOutboundBatch(mapping *mappingv1.MappingDefinition, pr
 	results := make([]any, 0, len(elements))
 	for i, elem := range elements {
 		elemJSON := []byte(elem.Raw)
+
+		if err := e.runValidationCEL(mapping.GetOutboundValidationCel(), elemJSON); err != nil {
+			return nil, fmt.Errorf("element %d: %w", i, err)
+		}
 
 		transformed, err := e.applyOutboundFields(mapping.GetFields(), elemJSON)
 		if err != nil {

--- a/services/gateway/internal/mapping/engine_batch_test.go
+++ b/services/gateway/internal/mapping/engine_batch_test.go
@@ -1,0 +1,390 @@
+package mapping
+
+import (
+	"encoding/json"
+	"testing"
+
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// batchMapping returns a MappingDefinition with is_batch=true and the given batch_target_path.
+func batchMapping(batchTargetPath string, fields []*mappingv1.FieldCorrespondence) *mappingv1.MappingDefinition {
+	return &mappingv1.MappingDefinition{
+		IsBatch:         true,
+		BatchTargetPath: batchTargetPath,
+		Fields:          fields,
+	}
+}
+
+// --- Inbound batch ---
+
+func TestTransformInbound_Batch_MultiElement(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := batchMapping("items", []*mappingv1.FieldCorrespondence{
+		{ExternalPath: "name", InternalPath: "full_name"},
+		{ExternalPath: "amount", InternalPath: "total"},
+	})
+
+	input := []byte(`[{"name":"Alice","amount":100},{"name":"Bob","amount":200}]`)
+
+	result, err := eng.TransformInboundBatch(mapping, input)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	// Element 0
+	var out0 map[string]any
+	require.NoError(t, json.Unmarshal(result[0].ProtoJSON, &out0))
+	items0 := out0["items"].([]any)
+	require.Len(t, items0, 1)
+	elem0 := items0[0].(map[string]any)
+	assert.Equal(t, "Alice", elem0["full_name"])
+	assert.Equal(t, float64(100), elem0["total"])
+
+	// Element 1
+	var out1 map[string]any
+	require.NoError(t, json.Unmarshal(result[1].ProtoJSON, &out1))
+	items1 := out1["items"].([]any)
+	require.Len(t, items1, 1)
+	elem1 := items1[0].(map[string]any)
+	assert.Equal(t, "Bob", elem1["full_name"])
+	assert.Equal(t, float64(200), elem1["total"])
+}
+
+func TestTransformInbound_Batch_SingleElement(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := batchMapping("events", []*mappingv1.FieldCorrespondence{
+		{ExternalPath: "id", InternalPath: "event_id"},
+	})
+
+	input := []byte(`[{"id":"evt-1"}]`)
+
+	result, err := eng.TransformInboundBatch(mapping, input)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(result[0].ProtoJSON, &out))
+	events := out["events"].([]any)
+	require.Len(t, events, 1)
+	assert.Equal(t, "evt-1", events[0].(map[string]any)["event_id"])
+}
+
+func TestTransformInbound_Batch_EmptyArray(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := batchMapping("items", []*mappingv1.FieldCorrespondence{
+		{ExternalPath: "name", InternalPath: "name"},
+	})
+
+	input := []byte(`[]`)
+
+	result, err := eng.TransformInboundBatch(mapping, input)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestTransformInbound_Batch_NotAnArray_Error(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := batchMapping("items", []*mappingv1.FieldCorrespondence{
+		{ExternalPath: "name", InternalPath: "name"},
+	})
+
+	// Input is an object, not an array.
+	input := []byte(`{"name":"Alice"}`)
+
+	_, err := eng.TransformInboundBatch(mapping, input)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidJSON)
+}
+
+func TestTransformInbound_Batch_InvalidJSON_Error(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := batchMapping("items", []*mappingv1.FieldCorrespondence{
+		{ExternalPath: "name", InternalPath: "name"},
+	})
+
+	_, err := eng.TransformInboundBatch(mapping, []byte(`[invalid`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidJSON)
+}
+
+func TestTransformInbound_Batch_ElementError_IncludesIndex(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := batchMapping("items", []*mappingv1.FieldCorrespondence{
+		{
+			ExternalPath: "status",
+			InternalPath: "status",
+			Transform: &mappingv1.FieldTransform{
+				Transform: &mappingv1.FieldTransform_EnumMapping{
+					EnumMapping: &mappingv1.EnumMapping{
+						Values: map[string]string{"active": "ACTIVE"},
+						// No fallback - unmapped value causes error.
+					},
+				},
+			},
+		},
+	})
+
+	// Second element has an unmapped status value.
+	input := []byte(`[{"status":"active"},{"status":"unknown"}]`)
+
+	_, err := eng.TransformInboundBatch(mapping, input)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEnumNotMapped)
+	assert.Contains(t, err.Error(), "element 1")
+}
+
+// --- Inbound batch idempotency ---
+
+func TestTransformInbound_Batch_IdempotencyKey_SourceSelector(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		IsBatch:         true,
+		BatchTargetPath: "items",
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "ref", InternalPath: "ref"},
+		},
+		Idempotency: &mappingv1.IdempotencyConfig{
+			SourceSelector: "ref",
+		},
+	}
+
+	input := []byte(`[{"ref":"ref-001"},{"ref":"ref-002"}]`)
+
+	result, err := eng.TransformInboundBatch(mapping, input)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	// Keys should be base_key + index suffix.
+	assert.Equal(t, "ref-001:0", result[0].IdempotencyKey)
+	assert.Equal(t, "ref-002:1", result[1].IdempotencyKey)
+}
+
+func TestTransformInbound_Batch_IdempotencyKey_ContentHash(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		IsBatch:         true,
+		BatchTargetPath: "items",
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "amount", InternalPath: "amount"},
+		},
+		Idempotency: &mappingv1.IdempotencyConfig{
+			UseContentHash:    true,
+			ContentHashFields: []string{"amount"},
+		},
+	}
+
+	input := []byte(`[{"amount":100},{"amount":200}]`)
+
+	result, err := eng.TransformInboundBatch(mapping, input)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	// Content hash keys should differ (different amounts) and each include index suffix.
+	assert.NotEmpty(t, result[0].IdempotencyKey)
+	assert.NotEmpty(t, result[1].IdempotencyKey)
+	assert.NotEqual(t, result[0].IdempotencyKey, result[1].IdempotencyKey)
+	assert.Contains(t, result[0].IdempotencyKey, ":0")
+	assert.Contains(t, result[1].IdempotencyKey, ":1")
+}
+
+func TestTransformInbound_Batch_IdempotencyKey_NoConfig(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := batchMapping("items", []*mappingv1.FieldCorrespondence{
+		{ExternalPath: "name", InternalPath: "name"},
+	})
+
+	input := []byte(`[{"name":"Alice"}]`)
+
+	result, err := eng.TransformInboundBatch(mapping, input)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Empty(t, result[0].IdempotencyKey)
+}
+
+// --- Outbound batch ---
+
+func TestTransformOutbound_Batch_MultiElement(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := batchMapping("items", []*mappingv1.FieldCorrespondence{
+		{ExternalPath: "name", InternalPath: "full_name"},
+		{ExternalPath: "amount", InternalPath: "total"},
+	})
+
+	// Proto JSON with items array at batch_target_path.
+	protoJSON := []byte(`{"items":[{"full_name":"Alice","total":100},{"full_name":"Bob","total":200}]}`)
+
+	result, err := eng.TransformOutboundBatch(mapping, protoJSON)
+	require.NoError(t, err)
+
+	// Should return a plain JSON array.
+	var arr []any
+	require.NoError(t, json.Unmarshal(result, &arr))
+	require.Len(t, arr, 2)
+
+	elem0 := arr[0].(map[string]any)
+	assert.Equal(t, "Alice", elem0["name"])
+	assert.Equal(t, float64(100), elem0["amount"])
+
+	elem1 := arr[1].(map[string]any)
+	assert.Equal(t, "Bob", elem1["name"])
+	assert.Equal(t, float64(200), elem1["amount"])
+}
+
+func TestTransformOutbound_Batch_SingleElement(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := batchMapping("events", []*mappingv1.FieldCorrespondence{
+		{ExternalPath: "id", InternalPath: "event_id"},
+	})
+
+	protoJSON := []byte(`{"events":[{"event_id":"evt-1"}]}`)
+
+	result, err := eng.TransformOutboundBatch(mapping, protoJSON)
+	require.NoError(t, err)
+
+	var arr []any
+	require.NoError(t, json.Unmarshal(result, &arr))
+	require.Len(t, arr, 1)
+	assert.Equal(t, "evt-1", arr[0].(map[string]any)["id"])
+}
+
+func TestTransformOutbound_Batch_EmptyArray(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := batchMapping("items", []*mappingv1.FieldCorrespondence{
+		{ExternalPath: "name", InternalPath: "name"},
+	})
+
+	protoJSON := []byte(`{"items":[]}`)
+
+	result, err := eng.TransformOutboundBatch(mapping, protoJSON)
+	require.NoError(t, err)
+
+	var arr []any
+	require.NoError(t, json.Unmarshal(result, &arr))
+	assert.Empty(t, arr)
+}
+
+func TestTransformOutbound_Batch_InvalidJSON_Error(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := batchMapping("items", []*mappingv1.FieldCorrespondence{
+		{ExternalPath: "name", InternalPath: "name"},
+	})
+
+	_, err := eng.TransformOutboundBatch(mapping, []byte(`{invalid`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidJSON)
+}
+
+func TestTransformOutbound_Batch_MissingTargetPath_ReturnsEmpty(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := batchMapping("items", []*mappingv1.FieldCorrespondence{
+		{ExternalPath: "name", InternalPath: "name"},
+	})
+
+	// Proto JSON does not contain "items".
+	protoJSON := []byte(`{"other":"data"}`)
+
+	result, err := eng.TransformOutboundBatch(mapping, protoJSON)
+	require.NoError(t, err)
+
+	var arr []any
+	require.NoError(t, json.Unmarshal(result, &arr))
+	assert.Empty(t, arr)
+}
+
+// --- Batch round-trip ---
+
+func TestRoundTrip_Batch_EnumMapping(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		IsBatch:         true,
+		BatchTargetPath: "orders",
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "id", InternalPath: "order_id"},
+			{
+				ExternalPath: "status",
+				InternalPath: "order_status",
+				Transform: &mappingv1.FieldTransform{
+					Transform: &mappingv1.FieldTransform_EnumMapping{
+						EnumMapping: &mappingv1.EnumMapping{
+							Values: map[string]string{
+								"active":   "STATUS_ACTIVE",
+								"inactive": "STATUS_INACTIVE",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	original := []byte(`[{"id":"o1","status":"active"},{"id":"o2","status":"inactive"}]`)
+
+	// Inbound: each element gets its own InboundResult with the element wrapped at batch_target_path.
+	inResults, err := eng.TransformInboundBatch(mapping, original)
+	require.NoError(t, err)
+	require.Len(t, inResults, 2)
+
+	// Outbound: rebuild array from individual protos, then call TransformOutboundBatch.
+	// In practice the caller would pass the assembled proto JSON; here we build one from the first result.
+	var out0 map[string]any
+	require.NoError(t, json.Unmarshal(inResults[0].ProtoJSON, &out0))
+	orders0 := out0["orders"].([]any)
+	assert.Equal(t, "o1", orders0[0].(map[string]any)["order_id"])
+	assert.Equal(t, "STATUS_ACTIVE", orders0[0].(map[string]any)["order_status"])
+
+	// Outbound reverse: build a proto with both elements.
+	combinedProto := []byte(`{"orders":[{"order_id":"o1","order_status":"STATUS_ACTIVE"},{"order_id":"o2","order_status":"STATUS_INACTIVE"}]}`)
+	outResult, err := eng.TransformOutboundBatch(mapping, combinedProto)
+	require.NoError(t, err)
+
+	var arr []any
+	require.NoError(t, json.Unmarshal(outResult, &arr))
+	require.Len(t, arr, 2)
+	assert.Equal(t, "o1", arr[0].(map[string]any)["id"])
+	assert.Equal(t, "active", arr[0].(map[string]any)["status"])
+	assert.Equal(t, "o2", arr[1].(map[string]any)["id"])
+	assert.Equal(t, "inactive", arr[1].(map[string]any)["status"])
+}
+
+// --- Nested batch_target_path ---
+
+func TestTransformInbound_Batch_NestedTargetPath(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := batchMapping("data.items", []*mappingv1.FieldCorrespondence{
+		{ExternalPath: "id", InternalPath: "item_id"},
+	})
+
+	input := []byte(`[{"id":"a"},{"id":"b"}]`)
+
+	result, err := eng.TransformInboundBatch(mapping, input)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	var out0 map[string]any
+	require.NoError(t, json.Unmarshal(result[0].ProtoJSON, &out0))
+
+	data, ok := out0["data"].(map[string]any)
+	require.True(t, ok, "expected data to be an object, got %T", out0["data"])
+	items, ok := data["items"].([]any)
+	require.True(t, ok, "expected items to be an array, got %T", data["items"])
+	require.Len(t, items, 1)
+	assert.Equal(t, "a", items[0].(map[string]any)["item_id"])
+}

--- a/services/gateway/internal/mapping/engine_batch_test.go
+++ b/services/gateway/internal/mapping/engine_batch_test.go
@@ -363,6 +363,69 @@ func TestRoundTrip_Batch_EnumMapping(t *testing.T) {
 	assert.Equal(t, "inactive", arr[1].(map[string]any)["status"])
 }
 
+// --- Per-element validation CEL ---
+
+func TestTransformInbound_Batch_ValidationCEL_PerElement_Pass(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		IsBatch:              true,
+		BatchTargetPath:      "items",
+		InboundValidationCel: `has(payload.amount) && payload.amount > 0`,
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "amount", InternalPath: "amount"},
+		},
+	}
+
+	input := []byte(`[{"amount":10},{"amount":20}]`)
+
+	result, err := eng.TransformInboundBatch(mapping, input)
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+}
+
+func TestTransformInbound_Batch_ValidationCEL_PerElement_Fail(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		IsBatch:              true,
+		BatchTargetPath:      "items",
+		InboundValidationCel: `has(payload.amount) && payload.amount > 0`,
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "amount", InternalPath: "amount"},
+		},
+	}
+
+	// Second element has amount=0, which fails validation.
+	input := []byte(`[{"amount":10},{"amount":0}]`)
+
+	_, err := eng.TransformInboundBatch(mapping, input)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrValidation)
+	assert.Contains(t, err.Error(), "element 1")
+}
+
+func TestTransformOutbound_Batch_ValidationCEL_PerElement_Fail(t *testing.T) {
+	eng := newTestEngine(t)
+
+	mapping := &mappingv1.MappingDefinition{
+		IsBatch:               true,
+		BatchTargetPath:       "items",
+		OutboundValidationCel: `has(payload.amount)`,
+		Fields: []*mappingv1.FieldCorrespondence{
+			{ExternalPath: "amount", InternalPath: "amount"},
+		},
+	}
+
+	// Second element missing "amount".
+	protoJSON := []byte(`{"items":[{"amount":10},{"name":"no-amount"}]}`)
+
+	_, err := eng.TransformOutboundBatch(mapping, protoJSON)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrValidation)
+	assert.Contains(t, err.Error(), "element 1")
+}
+
 // --- Nested batch_target_path ---
 
 func TestTransformInbound_Batch_NestedTargetPath(t *testing.T) {


### PR DESCRIPTION
## Summary
- Extends mapping engine to handle batch (array) inputs via `TransformInboundBatch` and `TransformOutboundBatch`
- Per-element transformation with index-aware error reporting (`element N: ...`)
- Wraps each element at `batch_target_path` on inbound, unwraps on outbound
- Per-element idempotency key derivation: base key appended with `:<index>` suffix

## Changes Made

**`services/gateway/internal/mapping/engine_batch.go`** (new file):
- `TransformInboundBatch`: validates input is JSON array, transforms each element using existing field mapping + computed field logic, wraps single element array at `batch_target_path`, derives per-element idempotency keys
- `TransformOutboundBatch`: extracts array from proto JSON at `batch_target_path`, reverse-transforms each element, returns plain JSON array
- `deriveElementIdempotencyKey`: delegates to existing `deriveIdempotencyKey` then appends `:<index>` suffix

**`services/gateway/internal/mapping/engine_batch_test.go`** (new file):
- 16 tests covering all batch scenarios

## Test plan
- [x] Multi-element batch transforms correctly (inbound and outbound)
- [x] Single-element and empty arrays handled
- [x] Element-level errors include index (`element N: ...`)
- [x] Outbound unwrapping returns plain JSON array
- [x] Idempotency keys: source_selector and content_hash modes with index suffix
- [x] Nested `batch_target_path` (e.g. `data.items`)
- [x] Missing target path on outbound returns empty array
- [x] Non-array input on inbound returns ErrInvalidJSON
- [x] All existing engine tests pass (no regressions)