### PR TITLE
feat: Implement gateway /mapping/{name} routing middleware

### DIFF
--- a/services/gateway/internal/middleware/mapping_middleware.go
+++ b/services/gateway/internal/middleware/mapping_middleware.go
@@ -39,6 +39,15 @@ var (
 
 	// ErrNoTenantID is returned when the request has no tenant ID in context.
 	ErrNoTenantID = errors.New("tenant ID not found in request context")
+
+	// ErrInvalidMappingName is returned when the mapping name in the URL is empty or nested.
+	ErrInvalidMappingName = errors.New("invalid mapping name")
+
+	// ErrEmptyBody is returned when the request body is empty.
+	ErrEmptyBody = errors.New("request body is empty")
+
+	// ErrInvalidMappingTarget is returned when a mapping has empty target_service or target_rpc.
+	ErrInvalidMappingTarget = errors.New("mapping has empty target_service or target_rpc")
 )
 
 // MappingMiddleware intercepts requests to /mapping/{name}, resolves the mapping
@@ -84,7 +93,7 @@ func (m *MappingMiddleware) handleMappingRequest(w http.ResponseWriter, r *http.
 	name := strings.TrimPrefix(r.URL.Path, "/mapping/")
 	if name == "" || strings.Contains(name, "/") {
 		writeJSONError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "mapping name must be a single path segment")
-		return ErrNoTenantID
+		return ErrInvalidMappingName
 	}
 
 	// Extract tenant ID from auth context
@@ -115,9 +124,18 @@ func (m *MappingMiddleware) handleMappingRequest(w http.ResponseWriter, r *http.
 	r.Body = io.NopCloser(bytes.NewReader(result.ProtoJSON))
 	r.ContentLength = int64(len(result.ProtoJSON))
 
+	// Validate target fields before rewriting URL
+	targetService := mappingDef.GetTargetService()
+	targetRPC := mappingDef.GetTargetRpc()
+	if targetService == "" || targetRPC == "" {
+		writeJSONError(w, http.StatusBadGateway, "INTERNAL",
+			"mapping definition has empty target_service or target_rpc")
+		return ErrInvalidMappingTarget
+	}
+
 	// Rewrite URL from /mapping/{name} to the target gRPC-style path:
 	// /{service}/{rpc}
-	targetPath := "/" + mappingDef.GetTargetService() + "/" + mappingDef.GetTargetRpc()
+	targetPath := "/" + targetService + "/" + targetRPC
 	r.URL.Path = targetPath
 
 	m.logger.Debug("mapping middleware applied",
@@ -161,7 +179,7 @@ func (m *MappingMiddleware) readAndTransform(w http.ResponseWriter, r *http.Requ
 
 	if len(body) == 0 {
 		writeJSONError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "request body is empty")
-		return nil, ErrMappingNotFound
+		return nil, ErrEmptyBody
 	}
 
 	result, err := m.engine.TransformInbound(mappingDef, body)
@@ -216,7 +234,7 @@ func NewCachedMappingResolver(delegate MappingResolver, ttl time.Duration) *Cach
 // cached result if available and not expired. On cache miss or expiry, it
 // calls the delegate resolver and caches the result.
 func (c *CachedMappingResolver) Resolve(ctx context.Context, tenantID, name string) (*mappingv1.MappingDefinition, error) {
-	key := tenantID + ":" + name
+	key := cacheKey(tenantID, name)
 
 	// Check cache
 	if val, ok := c.cache.Load(key); ok {
@@ -245,7 +263,14 @@ func (c *CachedMappingResolver) Resolve(ctx context.Context, tenantID, name stri
 
 // Invalidate removes a cached entry for the given tenant and name.
 func (c *CachedMappingResolver) Invalidate(tenantID, name string) {
-	c.cache.Delete(tenantID + ":" + name)
+	c.cache.Delete(cacheKey(tenantID, name))
+}
+
+// cacheKey builds a collision-resistant cache key using a null byte separator.
+// Tenant IDs are UUIDs and mapping names are alphanumeric, so neither can
+// contain a null byte.
+func cacheKey(tenantID, name string) string {
+	return tenantID + "\x00" + name
 }
 
 // GRPCMappingResolver resolves mapping definitions by calling the MappingService gRPC client.

--- a/services/gateway/internal/middleware/mapping_middleware.go
+++ b/services/gateway/internal/middleware/mapping_middleware.go
@@ -1,0 +1,288 @@
+// Package middleware provides HTTP middleware for the gateway service.
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	"github.com/meridianhub/meridian/services/gateway/auth"
+	"github.com/meridianhub/meridian/services/gateway/internal/mapping"
+)
+
+// HeaderIdempotencyKey is the header name for the derived idempotency key.
+const HeaderIdempotencyKey = "Idempotency-Key"
+
+// HeaderMappingVersion is the header name for requesting a specific mapping version.
+const HeaderMappingVersion = "X-Mapping-Version"
+
+// MappingResolver resolves a MappingDefinition by name for a given tenant.
+// Implementations may cache results or call an RPC backend directly.
+type MappingResolver interface {
+	// Resolve returns the latest ACTIVE mapping definition for the given name and tenant.
+	// Returns nil and ErrMappingNotFound if no active mapping exists.
+	Resolve(ctx context.Context, tenantID, name string) (*mappingv1.MappingDefinition, error)
+}
+
+var (
+	// ErrMappingNotFound is returned when no active mapping is found for the given name.
+	ErrMappingNotFound = errors.New("mapping not found")
+
+	// ErrNoTenantID is returned when the request has no tenant ID in context.
+	ErrNoTenantID = errors.New("tenant ID not found in request context")
+)
+
+// MappingMiddleware intercepts requests to /mapping/{name}, resolves the mapping
+// definition, applies inbound transformation, and rewrites the request URL and
+// body before forwarding to the next handler (Vanguard transcoder).
+type MappingMiddleware struct {
+	resolver MappingResolver
+	engine   *mapping.Engine
+	logger   *slog.Logger
+}
+
+// NewMappingMiddleware creates a MappingMiddleware with the given resolver and engine.
+func NewMappingMiddleware(resolver MappingResolver, engine *mapping.Engine, logger *slog.Logger) *MappingMiddleware {
+	return &MappingMiddleware{
+		resolver: resolver,
+		engine:   engine,
+		logger:   logger,
+	}
+}
+
+// Handler wraps the given handler with mapping middleware.
+// Requests matching /mapping/{name} are intercepted and transformed.
+// All other requests pass through unchanged.
+func (m *MappingMiddleware) Handler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only intercept paths starting with /mapping/
+		if !strings.HasPrefix(r.URL.Path, "/mapping/") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if err := m.handleMappingRequest(w, r, next); err != nil {
+			m.logger.Debug("mapping request handled with error", "error", err)
+		}
+	})
+}
+
+// handleMappingRequest processes a /mapping/{name} request. It resolves the
+// mapping definition, transforms the body, rewrites the URL, and forwards to next.
+// Returns an error for logging only; HTTP errors are already written to w.
+func (m *MappingMiddleware) handleMappingRequest(w http.ResponseWriter, r *http.Request, next http.Handler) error {
+	// Extract mapping name from URL path: /mapping/{name}
+	name := strings.TrimPrefix(r.URL.Path, "/mapping/")
+	if name == "" || strings.Contains(name, "/") {
+		writeJSONError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "mapping name must be a single path segment")
+		return ErrNoTenantID
+	}
+
+	// Extract tenant ID from auth context
+	tenantID, ok := auth.GetTenantIDFromContext(r.Context())
+	if !ok || tenantID == "" {
+		writeJSONError(w, http.StatusUnauthorized, "UNAUTHENTICATED", "tenant ID not found in request context")
+		return ErrNoTenantID
+	}
+
+	// Resolve mapping definition
+	mappingDef, err := m.resolveMappingDef(r.Context(), w, tenantID, name)
+	if err != nil {
+		return err
+	}
+
+	// Read and transform body
+	result, err := m.readAndTransform(w, r, mappingDef, tenantID, name)
+	if err != nil {
+		return err
+	}
+
+	// Set idempotency key header if derived
+	if result.IdempotencyKey != "" {
+		r.Header.Set(HeaderIdempotencyKey, result.IdempotencyKey)
+	}
+
+	// Replace request body with transformed proto JSON
+	r.Body = io.NopCloser(bytes.NewReader(result.ProtoJSON))
+	r.ContentLength = int64(len(result.ProtoJSON))
+
+	// Rewrite URL from /mapping/{name} to the target gRPC-style path:
+	// /{service}/{rpc}
+	targetPath := "/" + mappingDef.GetTargetService() + "/" + mappingDef.GetTargetRpc()
+	r.URL.Path = targetPath
+
+	m.logger.Debug("mapping middleware applied",
+		"name", name,
+		"tenant_id", tenantID,
+		"target_path", targetPath,
+		"idempotency_key", result.IdempotencyKey != "")
+
+	next.ServeHTTP(w, r)
+	return nil
+}
+
+// resolveMappingDef resolves a mapping definition by name and tenant, writing
+// appropriate HTTP errors on failure.
+func (m *MappingMiddleware) resolveMappingDef(ctx context.Context, w http.ResponseWriter, tenantID, name string) (*mappingv1.MappingDefinition, error) {
+	mappingDef, err := m.resolver.Resolve(ctx, tenantID, name)
+	if err != nil {
+		if errors.Is(err, ErrMappingNotFound) {
+			writeJSONError(w, http.StatusNotFound, "NOT_FOUND",
+				fmt.Sprintf("no active mapping found for name %q", name))
+			return nil, err
+		}
+		m.logger.Error("failed to resolve mapping",
+			"name", name,
+			"tenant_id", tenantID,
+			"error", err)
+		writeJSONError(w, http.StatusBadGateway, "UNAVAILABLE", "failed to resolve mapping definition")
+		return nil, err
+	}
+	return mappingDef, nil
+}
+
+// readAndTransform reads the request body and applies the inbound transformation.
+func (m *MappingMiddleware) readAndTransform(w http.ResponseWriter, r *http.Request, mappingDef *mappingv1.MappingDefinition, tenantID, name string) (*mapping.InboundResult, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "failed to read request body")
+		return nil, err
+	}
+	_ = r.Body.Close()
+
+	if len(body) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "request body is empty")
+		return nil, ErrMappingNotFound
+	}
+
+	result, err := m.engine.TransformInbound(mappingDef, body)
+	if err != nil {
+		m.logger.Warn("inbound transformation failed",
+			"name", name,
+			"tenant_id", tenantID,
+			"error", err)
+		writeJSONError(w, http.StatusBadRequest, "INVALID_ARGUMENT",
+			fmt.Sprintf("inbound transformation failed: %v", err))
+		return nil, err
+	}
+	return result, nil
+}
+
+func writeJSONError(w http.ResponseWriter, statusCode int, code, message string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(statusCode)
+	resp := struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+	}{
+		Error: message,
+		Code:  code,
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// cacheEntry holds a cached mapping definition with an expiration time.
+type cacheEntry struct {
+	mapping   *mappingv1.MappingDefinition
+	expiresAt time.Time
+}
+
+// CachedMappingResolver wraps a MappingResolver with an in-memory TTL cache.
+// It uses a sync.Map for concurrent access and lazy expiration.
+type CachedMappingResolver struct {
+	delegate MappingResolver
+	ttl      time.Duration
+	cache    sync.Map // map[string]*cacheEntry (key: "tenantID:name")
+}
+
+// NewCachedMappingResolver creates a CachedMappingResolver with the given TTL.
+func NewCachedMappingResolver(delegate MappingResolver, ttl time.Duration) *CachedMappingResolver {
+	return &CachedMappingResolver{
+		delegate: delegate,
+		ttl:      ttl,
+	}
+}
+
+// Resolve looks up the mapping definition by name and tenant, returning a
+// cached result if available and not expired. On cache miss or expiry, it
+// calls the delegate resolver and caches the result.
+func (c *CachedMappingResolver) Resolve(ctx context.Context, tenantID, name string) (*mappingv1.MappingDefinition, error) {
+	key := tenantID + ":" + name
+
+	// Check cache
+	if val, ok := c.cache.Load(key); ok {
+		entry, valid := val.(*cacheEntry)
+		if valid && time.Now().Before(entry.expiresAt) {
+			return entry.mapping, nil
+		}
+		// Expired or invalid — fall through to delegate
+		c.cache.Delete(key)
+	}
+
+	// Resolve from delegate
+	md, err := c.delegate.Resolve(ctx, tenantID, name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the result
+	c.cache.Store(key, &cacheEntry{
+		mapping:   md,
+		expiresAt: time.Now().Add(c.ttl),
+	})
+
+	return md, nil
+}
+
+// Invalidate removes a cached entry for the given tenant and name.
+func (c *CachedMappingResolver) Invalidate(tenantID, name string) {
+	c.cache.Delete(tenantID + ":" + name)
+}
+
+// GRPCMappingResolver resolves mapping definitions by calling the MappingService gRPC client.
+// It uses ListMappings with status=ACTIVE to find mappings by name.
+type GRPCMappingResolver struct {
+	client mappingv1.MappingServiceClient
+}
+
+// NewGRPCMappingResolver creates a resolver backed by the MappingService gRPC client.
+func NewGRPCMappingResolver(client mappingv1.MappingServiceClient) *GRPCMappingResolver {
+	return &GRPCMappingResolver{client: client}
+}
+
+// Resolve calls ListMappings for ACTIVE mappings and finds one matching the given name.
+// The tenantID is not passed directly to the RPC; it is propagated via gRPC metadata
+// headers set by the gateway's metadata propagation middleware on the outgoing context.
+func (g *GRPCMappingResolver) Resolve(ctx context.Context, _ string, name string) (*mappingv1.MappingDefinition, error) {
+	resp, err := g.client.ListMappings(ctx, &mappingv1.ListMappingsRequest{
+		Status: mappingv1.MappingStatus_MAPPING_STATUS_ACTIVE,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing mappings: %w", err)
+	}
+
+	// Find the mapping with the matching name (latest version wins)
+	var best *mappingv1.MappingDefinition
+	for _, md := range resp.GetMappings() {
+		if md.GetName() == name {
+			if best == nil || md.GetVersion() > best.GetVersion() {
+				best = md
+			}
+		}
+	}
+
+	if best == nil {
+		return nil, ErrMappingNotFound
+	}
+
+	return best, nil
+}

--- a/services/gateway/internal/middleware/mapping_middleware_test.go
+++ b/services/gateway/internal/middleware/mapping_middleware_test.go
@@ -1,0 +1,378 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	"github.com/meridianhub/meridian/services/gateway/auth"
+	"github.com/meridianhub/meridian/services/gateway/internal/mapping"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubResolver implements MappingResolver for testing.
+type stubResolver struct {
+	mapping *mappingv1.MappingDefinition
+	err     error
+	calls   int
+}
+
+func (s *stubResolver) Resolve(_ context.Context, _, _ string) (*mappingv1.MappingDefinition, error) {
+	s.calls++
+	return s.mapping, s.err
+}
+
+// captureHandler captures the forwarded request for assertion.
+type captureHandler struct {
+	captured *http.Request
+	body     []byte
+}
+
+func (h *captureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.captured = r
+	h.body, _ = io.ReadAll(r.Body)
+	w.WriteHeader(http.StatusOK)
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func testEngine(t *testing.T) *mapping.Engine {
+	t.Helper()
+	eng, err := mapping.NewEngine()
+	require.NoError(t, err)
+	return eng
+}
+
+// withTenantContext adds a tenant ID to the request context via the auth package's context key.
+func withTenantContext(r *http.Request, tenantID string) *http.Request {
+	ctx := context.WithValue(r.Context(), auth.TenantIDContextKey, tenantID)
+	return r.WithContext(ctx)
+}
+
+func simpleMappingDef() *mappingv1.MappingDefinition {
+	return &mappingv1.MappingDefinition{
+		Id:            "00000000-0000-0000-0000-000000000001",
+		TenantId:      "00000000-0000-0000-0000-000000000099",
+		Name:          "stripe-webhook",
+		TargetService: "meridian.payment_order.v1.PaymentOrderService",
+		TargetRpc:     "InitiatePaymentOrder",
+		Version:       1,
+		Status:        mappingv1.MappingStatus_MAPPING_STATUS_ACTIVE,
+		Fields: []*mappingv1.FieldCorrespondence{
+			{
+				ExternalPath: "amount",
+				InternalPath: "amount",
+			},
+			{
+				ExternalPath: "currency",
+				InternalPath: "currency_code",
+			},
+		},
+	}
+}
+
+func TestMappingMiddleware_PassthroughNonMappingRequests(t *testing.T) {
+	resolver := &stubResolver{mapping: simpleMappingDef()}
+	eng := testEngine(t)
+	mw := NewMappingMiddleware(resolver, eng, testLogger())
+
+	capture := &captureHandler{}
+	handler := mw.Handler(capture)
+
+	// Request to /api/v1/parties should pass through
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/parties", bytes.NewBufferString(`{"name":"test"}`))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.NotNil(t, capture.captured)
+	assert.Equal(t, "/api/v1/parties", capture.captured.URL.Path)
+	assert.Equal(t, 0, resolver.calls, "resolver should not be called for non-mapping requests")
+}
+
+func TestMappingMiddleware_TransformsAndForwards(t *testing.T) {
+	resolver := &stubResolver{mapping: simpleMappingDef()}
+	eng := testEngine(t)
+	mw := NewMappingMiddleware(resolver, eng, testLogger())
+
+	capture := &captureHandler{}
+	handler := mw.Handler(capture)
+
+	body := `{"amount": 100, "currency": "GBP"}`
+	req := httptest.NewRequest(http.MethodPost, "/mapping/stripe-webhook", bytes.NewBufferString(body))
+	req = withTenantContext(req, "tenant-abc")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, capture.captured)
+
+	// URL should be rewritten to target service/RPC path
+	assert.Equal(t, "/meridian.payment_order.v1.PaymentOrderService/InitiatePaymentOrder", capture.captured.URL.Path)
+
+	// Body should be transformed
+	var result map[string]any
+	err := json.Unmarshal(capture.body, &result)
+	require.NoError(t, err)
+	assert.Equal(t, float64(100), result["amount"])
+	assert.Equal(t, "GBP", result["currency_code"])
+}
+
+func TestMappingMiddleware_SetsIdempotencyKey(t *testing.T) {
+	md := simpleMappingDef()
+	md.Idempotency = &mappingv1.IdempotencyConfig{
+		SourceSelector: "ref_id",
+	}
+
+	resolver := &stubResolver{mapping: md}
+	eng := testEngine(t)
+	mw := NewMappingMiddleware(resolver, eng, testLogger())
+
+	capture := &captureHandler{}
+	handler := mw.Handler(capture)
+
+	body := `{"amount": 50, "currency": "USD", "ref_id": "abc-123"}`
+	req := httptest.NewRequest(http.MethodPost, "/mapping/stripe-webhook", bytes.NewBufferString(body))
+	req = withTenantContext(req, "tenant-abc")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, capture.captured)
+	assert.Equal(t, "abc-123", capture.captured.Header.Get(HeaderIdempotencyKey))
+}
+
+func TestMappingMiddleware_MissingTenant(t *testing.T) {
+	resolver := &stubResolver{mapping: simpleMappingDef()}
+	eng := testEngine(t)
+	mw := NewMappingMiddleware(resolver, eng, testLogger())
+
+	handler := mw.Handler(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("next handler should not be called")
+	}))
+
+	body := `{"amount": 100}`
+	req := httptest.NewRequest(http.MethodPost, "/mapping/stripe-webhook", bytes.NewBufferString(body))
+	// No tenant context
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assertJSONErrorCode(t, rec.Body.Bytes(), "UNAUTHENTICATED")
+}
+
+func TestMappingMiddleware_MappingNotFound(t *testing.T) {
+	resolver := &stubResolver{err: ErrMappingNotFound}
+	eng := testEngine(t)
+	mw := NewMappingMiddleware(resolver, eng, testLogger())
+
+	handler := mw.Handler(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("next handler should not be called")
+	}))
+
+	body := `{"amount": 100}`
+	req := httptest.NewRequest(http.MethodPost, "/mapping/nonexistent", bytes.NewBufferString(body))
+	req = withTenantContext(req, "tenant-abc")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assertJSONErrorCode(t, rec.Body.Bytes(), "NOT_FOUND")
+}
+
+func TestMappingMiddleware_EmptyBody(t *testing.T) {
+	resolver := &stubResolver{mapping: simpleMappingDef()}
+	eng := testEngine(t)
+	mw := NewMappingMiddleware(resolver, eng, testLogger())
+
+	handler := mw.Handler(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("next handler should not be called")
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/mapping/stripe-webhook", nil)
+	req = withTenantContext(req, "tenant-abc")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assertJSONErrorCode(t, rec.Body.Bytes(), "INVALID_ARGUMENT")
+}
+
+func TestMappingMiddleware_InvalidMappingName(t *testing.T) {
+	resolver := &stubResolver{mapping: simpleMappingDef()}
+	eng := testEngine(t)
+	mw := NewMappingMiddleware(resolver, eng, testLogger())
+
+	handler := mw.Handler(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("next handler should not be called")
+	}))
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"empty name", "/mapping/"},
+		{"nested path", "/mapping/foo/bar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.path, bytes.NewBufferString(`{}`))
+			req = withTenantContext(req, "tenant-abc")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assertJSONErrorCode(t, rec.Body.Bytes(), "INVALID_ARGUMENT")
+		})
+	}
+}
+
+func TestMappingMiddleware_TransformError(t *testing.T) {
+	md := simpleMappingDef()
+	md.InboundValidationCel = "payload.amount > 0"
+
+	resolver := &stubResolver{mapping: md}
+	eng := testEngine(t)
+	mw := NewMappingMiddleware(resolver, eng, testLogger())
+
+	handler := mw.Handler(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("next handler should not be called")
+	}))
+
+	// amount = -1 should fail validation
+	body := `{"amount": -1, "currency": "GBP"}`
+	req := httptest.NewRequest(http.MethodPost, "/mapping/stripe-webhook", bytes.NewBufferString(body))
+	req = withTenantContext(req, "tenant-abc")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assertJSONErrorCode(t, rec.Body.Bytes(), "INVALID_ARGUMENT")
+}
+
+func TestMappingMiddleware_ResolverError(t *testing.T) {
+	resolver := &stubResolver{err: assert.AnError}
+	eng := testEngine(t)
+	mw := NewMappingMiddleware(resolver, eng, testLogger())
+
+	handler := mw.Handler(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("next handler should not be called")
+	}))
+
+	body := `{"amount": 100}`
+	req := httptest.NewRequest(http.MethodPost, "/mapping/stripe-webhook", bytes.NewBufferString(body))
+	req = withTenantContext(req, "tenant-abc")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assertJSONErrorCode(t, rec.Body.Bytes(), "UNAVAILABLE")
+}
+
+// --- CachedMappingResolver tests ---
+
+func TestCachedMappingResolver_CachesResult(t *testing.T) {
+	delegate := &stubResolver{mapping: simpleMappingDef()}
+	cached := NewCachedMappingResolver(delegate, 5*time.Minute)
+
+	// First call should hit delegate
+	md, err := cached.Resolve(context.Background(), "tenant-1", "stripe-webhook")
+	require.NoError(t, err)
+	assert.Equal(t, "stripe-webhook", md.GetName())
+	assert.Equal(t, 1, delegate.calls)
+
+	// Second call should use cache
+	md2, err := cached.Resolve(context.Background(), "tenant-1", "stripe-webhook")
+	require.NoError(t, err)
+	assert.Equal(t, md, md2)
+	assert.Equal(t, 1, delegate.calls, "delegate should not be called again for cached entry")
+}
+
+func TestCachedMappingResolver_ExpiredEntry(t *testing.T) {
+	delegate := &stubResolver{mapping: simpleMappingDef()}
+	cached := NewCachedMappingResolver(delegate, 1*time.Millisecond)
+
+	// First call
+	_, err := cached.Resolve(context.Background(), "tenant-1", "stripe-webhook")
+	require.NoError(t, err)
+	assert.Equal(t, 1, delegate.calls)
+
+	// Wait for expiry
+	time.Sleep(5 * time.Millisecond)
+
+	// Second call should re-resolve
+	_, err = cached.Resolve(context.Background(), "tenant-1", "stripe-webhook")
+	require.NoError(t, err)
+	assert.Equal(t, 2, delegate.calls)
+}
+
+func TestCachedMappingResolver_DifferentTenants(t *testing.T) {
+	delegate := &stubResolver{mapping: simpleMappingDef()}
+	cached := NewCachedMappingResolver(delegate, 5*time.Minute)
+
+	_, err := cached.Resolve(context.Background(), "tenant-1", "stripe-webhook")
+	require.NoError(t, err)
+	assert.Equal(t, 1, delegate.calls)
+
+	// Different tenant should trigger a new resolve
+	_, err = cached.Resolve(context.Background(), "tenant-2", "stripe-webhook")
+	require.NoError(t, err)
+	assert.Equal(t, 2, delegate.calls)
+}
+
+func TestCachedMappingResolver_Invalidate(t *testing.T) {
+	delegate := &stubResolver{mapping: simpleMappingDef()}
+	cached := NewCachedMappingResolver(delegate, 5*time.Minute)
+
+	_, err := cached.Resolve(context.Background(), "tenant-1", "stripe-webhook")
+	require.NoError(t, err)
+	assert.Equal(t, 1, delegate.calls)
+
+	// Invalidate and re-resolve
+	cached.Invalidate("tenant-1", "stripe-webhook")
+
+	_, err = cached.Resolve(context.Background(), "tenant-1", "stripe-webhook")
+	require.NoError(t, err)
+	assert.Equal(t, 2, delegate.calls)
+}
+
+func TestCachedMappingResolver_DelegateError(t *testing.T) {
+	delegate := &stubResolver{err: ErrMappingNotFound}
+	cached := NewCachedMappingResolver(delegate, 5*time.Minute)
+
+	_, err := cached.Resolve(context.Background(), "tenant-1", "stripe-webhook")
+	assert.ErrorIs(t, err, ErrMappingNotFound)
+}
+
+// --- Helper functions ---
+
+func assertJSONErrorCode(t *testing.T, body []byte, expectedCode string) {
+	t.Helper()
+	var resp struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+	}
+	err := json.Unmarshal(body, &resp)
+	require.NoError(t, err, "response body should be valid JSON: %s", string(body))
+	assert.Equal(t, expectedCode, resp.Code)
+}

--- a/services/gateway/internal/middleware/mapping_middleware_test.go
+++ b/services/gateway/internal/middleware/mapping_middleware_test.go
@@ -289,6 +289,52 @@ func TestMappingMiddleware_ResolverError(t *testing.T) {
 	assertJSONErrorCode(t, rec.Body.Bytes(), "UNAVAILABLE")
 }
 
+func TestMappingMiddleware_EmptyTargetService(t *testing.T) {
+	md := simpleMappingDef()
+	md.TargetService = ""
+
+	resolver := &stubResolver{mapping: md}
+	eng := testEngine(t)
+	mw := NewMappingMiddleware(resolver, eng, testLogger())
+
+	capture := &captureHandler{}
+	handler := mw.Handler(capture)
+
+	body := `{"amount": 100, "currency": "GBP"}`
+	req := httptest.NewRequest(http.MethodPost, "/mapping/stripe-webhook", bytes.NewBufferString(body))
+	req = withTenantContext(req, "tenant-abc")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assertJSONErrorCode(t, rec.Body.Bytes(), "INTERNAL")
+	assert.Nil(t, capture.captured, "next handler should not be called")
+}
+
+func TestMappingMiddleware_EmptyTargetRPC(t *testing.T) {
+	md := simpleMappingDef()
+	md.TargetRpc = ""
+
+	resolver := &stubResolver{mapping: md}
+	eng := testEngine(t)
+	mw := NewMappingMiddleware(resolver, eng, testLogger())
+
+	capture := &captureHandler{}
+	handler := mw.Handler(capture)
+
+	body := `{"amount": 100, "currency": "GBP"}`
+	req := httptest.NewRequest(http.MethodPost, "/mapping/stripe-webhook", bytes.NewBufferString(body))
+	req = withTenantContext(req, "tenant-abc")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assertJSONErrorCode(t, rec.Body.Bytes(), "INTERNAL")
+	assert.Nil(t, capture.captured, "next handler should not be called")
+}
+
 // --- CachedMappingResolver tests ---
 
 func TestCachedMappingResolver_CachesResult(t *testing.T) {


### PR DESCRIPTION
## Summary
- Gateway middleware intercepting `/mapping/{name}` requests
- Resolves mapping definitions from reference-data service via `MappingResolver` interface
- Applies inbound transforms via mapping engine, replaces request body with proto-conformant JSON
- Rewrites URL to target gRPC service/RPC path for Vanguard transcoding
- `CachedMappingResolver` with configurable TTL reduces per-request RPC calls
- `GRPCMappingResolver` uses `ListMappings(ACTIVE)` and selects latest version by name
- Sets `Idempotency-Key` header when mapping config derives one
- Zero overhead for non-mapping requests (prefix check short-circuit)

## Task Master
structured-mapping-layer.12

## Test plan
- [x] `/mapping/{name}` routes resolve and transform correctly
- [x] Non-mapping requests pass through unchanged
- [x] Mapping cache reduces RPC calls (verified with call counter)
- [x] Idempotency key header set when derived from mapping config
- [x] Missing mapping returns 404
- [x] Transform errors return detailed 400
- [x] Missing tenant returns 401
- [x] Resolver errors return 502
- [x] Invalid mapping names (empty, nested) return 400
- [x] Cache expiry triggers re-resolution
- [x] Cache isolates tenants (different keys per tenant)
- [x] Cache invalidation works