### PR TITLE
feat: Add reference mapping examples and E2E tests

### DIFF
--- a/docs/mapping-layer/README.md
+++ b/docs/mapping-layer/README.md
@@ -131,7 +131,7 @@ double(payload.min_amount) > 0
 The engine supports dry-run execution that returns field-level traces without side effects:
 
 ```go
-result, err := engine.DryRunInbound(def, inputJSON)
+result := engine.DryRunInbound(def, inputJSON)
 // result.TransformedJSON  - the output
 // result.ValidationPassed - true/false
 // result.FieldTraces      - per-field transformation details

--- a/docs/mapping-layer/README.md
+++ b/docs/mapping-layer/README.md
@@ -1,0 +1,145 @@
+# Mapping Layer
+
+The Mapping Layer provides a configuration-driven JSON transformation engine that bridges
+external partner schemas to Meridian's internal proto-based service contracts. It handles
+field renaming, type coercion, enum mapping, CEL-based validation, computed fields, and
+attribute flattening — all defined in declarative JSON files with no code changes required.
+
+## Quick Start
+
+1. Create a mapping definition JSON file in `services/reference-data/examples/`.
+2. Register it via the Reference Data Service API.
+3. Post payloads to `POST /mapping/{name}` on the Gateway.
+
+## Architecture
+
+```text
+External Partner
+       |
+       v
+  Gateway HTTP
+       |
+  MappingMiddleware  <- reads MappingDefinition from Reference Data Service
+       |
+  shared/pkg/mapping.Engine
+       |
+  TransformInbound / TransformOutbound / TransformInboundBatch
+       |
+  Downstream gRPC Service
+```
+
+### Components
+
+| Component | Location | Responsibility |
+|-----------|----------|----------------|
+| Mapping Engine | `shared/pkg/mapping/` | JSON transform via gjson/sjson + CEL |
+| Gateway Middleware | `services/gateway/internal/middleware/` | HTTP integration |
+| Reference Data Service | `services/reference-data/` | Stores MappingDefinition records |
+| Proto Definition | `api/proto/meridian/mapping/v1/mapping.proto` | Wire contract |
+| Example Definitions | `services/reference-data/examples/` | Reference JSON files |
+
+## Mapping Definition Schema
+
+A mapping definition is a JSON document with the following top-level fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Unique identifier — used as the URL path segment |
+| `target_service` | string | Fully-qualified gRPC service name |
+| `target_rpc` | string | RPC method name |
+| `version` | int | Definition schema version |
+| `inbound_validation_cel` | string | CEL expression evaluated before transform |
+| `outbound_validation_cel` | string | CEL expression evaluated on outbound response |
+| `is_batch` | bool | If `true`, expects a JSON array as input |
+| `batch_target_path` | string | Target path for the batch array in the output |
+| `fields` | array | Field correspondence rules |
+| `inbound_computed_fields` | array | CEL-computed fields added to inbound output |
+| `outbound_computed_fields` | array | CEL-computed fields added to outbound output |
+| `idempotency` | object | Idempotency key derivation config |
+
+### Field Correspondence
+
+```json
+{
+  "external_path": "full_name",
+  "internal_path": "legal_name",
+  "transform": { }
+}
+```
+
+A `transform` block supports exactly one of:
+
+| Transform | Description |
+|-----------|-------------|
+| `enum_mapping` | Map string values; optional `fallback` |
+| `date_format` | Parse/format dates using Go time layout strings |
+| `attribute_flatten` | Collect named fields into `[{key, value}]` list |
+
+### Computed Fields
+
+```json
+{
+  "target_path": "display_name",
+  "cel_expression": "has(input.first_name) ? input.first_name : input.full_name"
+}
+```
+
+CEL variables available during inbound transform:
+
+| Variable | Description |
+|----------|-------------|
+| `input` | The raw external JSON as a `map<string, dyn>` |
+| `mapped` | Fields already mapped by the field rules |
+| `payload` | Same as `input` (available in validation expressions) |
+
+### Idempotency
+
+```json
+{
+  "idempotency": {
+    "source_selector": "govt_id"
+  }
+}
+```
+
+Or use a content hash over specific fields:
+
+```json
+{
+  "idempotency": {
+    "use_content_hash": true,
+    "content_hash_fields": ["meter_id", "timestamp"]
+  }
+}
+```
+
+## CEL Type Safety
+
+CEL is strongly typed. When calling `double()` on a numeric field, always compare
+against float literals:
+
+```cel
+# CORRECT
+double(payload.min_amount) > 0.0
+
+# WRONG - CEL has no overload for double > int
+double(payload.min_amount) > 0
+```
+
+## DryRun API
+
+The engine supports dry-run execution that returns field-level traces without side effects:
+
+```go
+result, err := engine.DryRunInbound(def, inputJSON)
+// result.TransformedJSON  - the output
+// result.ValidationPassed - true/false
+// result.FieldTraces      - per-field transformation details
+// result.ExecutionTimeMs  - wall-clock transform time
+```
+
+See `services/reference-data/e2e/mapping_dry_run_test.go` for usage examples.
+
+## Reference Examples
+
+See [examples.md](./examples.md) for annotated walkthroughs of each reference definition.

--- a/docs/mapping-layer/examples.md
+++ b/docs/mapping-layer/examples.md
@@ -1,0 +1,176 @@
+# Mapping Layer — Reference Examples
+
+Three reference mapping definitions are provided in `services/reference-data/examples/`.
+Each demonstrates a distinct integration pattern.
+
+---
+
+## 1. Bank Party Onboarding (`bank-x-party-onboarding.json`)
+
+**Pattern**: Field renaming + enum mapping + conditional computed field + bidirectional
+
+### Use case
+
+A bank sends party data in its own schema. Meridian maps it to the internal `RegisterParty`
+RPC, translating enum values and deriving `display_name` from `first_name` when present.
+
+### Key features
+
+- `enum_mapping`: maps `"individual"` to `"PARTY_TYPE_PERSON"`,
+  `"corporate"` to `"PARTY_TYPE_ORGANIZATION"`
+- `date_format`: parses `date_of_birth` using Go layout `"2006-01-02"`
+- Nested target path: `"govt_id"` maps to `"reference.government_id"`
+- Inbound computed: `display_name` = `first_name` if present, else `full_name`
+- Outbound computed: reconstructs `full_name` from `legal_name`
+- Idempotency via `govt_id`
+
+### Sample input
+
+```json
+{
+  "party_type": "individual",
+  "full_name": "Jane Smith",
+  "first_name": "Jane",
+  "date_of_birth": "1990-05-15",
+  "govt_id": "UK-12345",
+  "email": "jane@example.com",
+  "phone": "+44-7700-900000"
+}
+```
+
+### Sample output
+
+```json
+{
+  "party_type": "PARTY_TYPE_PERSON",
+  "legal_name": "Jane Smith",
+  "date_of_birth": "1990-05-15",
+  "reference": {"government_id": "UK-12345"},
+  "contact": {"email": "jane@example.com", "phone": "+44-7700-900000"},
+  "display_name": "Jane"
+}
+```
+
+### Validation rule
+
+```cel
+has(payload.party_type) && has(payload.full_name) && size(payload.full_name) > 0
+```
+
+---
+
+## 2. Energy Metering Feed (`energy-metering-feed.json`)
+
+**Pattern**: Batch transform + attribute flattening + quality enum + computed idempotency key
+
+### Use case
+
+A utility sends arrays of meter readings. Meridian batches them into
+`RecordObservationBatch`, normalising the quality enum and collecting `tenor` and
+`settlement_date` into a structured attributes list.
+
+### Key features
+
+- `is_batch: true`: input is a JSON array; each element is transformed independently
+- `batch_target_path`: output array is placed at `"observations"` in the request body
+- `attribute_flatten`: collects `tenor` and `settlement_date` into `[{key, value}]` pairs
+- Inbound computed: `resolution_key_value` = `meter_id + ':' + timestamp`
+- Content-hash idempotency over `meter_id` + `timestamp`
+
+### Sample input (single element in array)
+
+```json
+[
+  {
+    "meter_id": "METER-001",
+    "timestamp": "2024-01-15T10:00:00Z",
+    "value_kwh": 42.5,
+    "quality": "actual",
+    "tenor": "DAY_AHEAD",
+    "settlement_date": "2024-01-16"
+  }
+]
+```
+
+### Sample output
+
+```json
+{
+  "observations": [
+    {
+      "source_id": "METER-001",
+      "observed_at": "2024-01-15T10:00:00Z",
+      "quantity": 42.5,
+      "data_quality": "DATA_QUALITY_ACTUAL",
+      "attributes": [
+        {"key": "tenor", "value": "DAY_AHEAD"},
+        {"key": "settlement_date", "value": "2024-01-16"}
+      ],
+      "resolution_key_value": "METER-001:2024-01-15T10:00:00Z"
+    }
+  ]
+}
+```
+
+### Validation rule
+
+```cel
+has(payload.meter_id) && has(payload.value_kwh) && double(payload.value_kwh) >= 0.0
+```
+
+---
+
+## 3. Verra Carbon Credit (`verra-carbon-credit.json`)
+
+**Pattern**: Attribute flattening + computed dimension + singleton idempotency
+
+### Use case
+
+A carbon registry posts VCS project data. Meridian maps it to `RegisterInstrument`,
+collecting project metadata into attributes and injecting the asset dimension `"Carbon"`
+automatically.
+
+### Key features
+
+- `attribute_flatten`: collects `registry`, `vintage_year`, `methodology` into
+  attributes list
+- `date_format`: parses `validation_date` with layout `"2006-01-02"`
+- Inbound computed: `dimension` = `'Carbon'` (literal CEL string)
+- Idempotency via `vcs_id`
+
+### Sample input
+
+```json
+{
+  "vcs_id": "VCS-2845",
+  "project_name": "Kariba REDD+ Project",
+  "vintage_year": 2023,
+  "methodology": "VM0009",
+  "registry": "Verra",
+  "min_amount": 1.0,
+  "validation_date": "2024-03-01"
+}
+```
+
+### Sample output
+
+```json
+{
+  "code": "VCS-2845",
+  "display_name": "Kariba REDD+ Project",
+  "validation_date": "2024-03-01",
+  "min_amount": 1.0,
+  "attributes": [
+    {"key": "registry", "value": "Verra"},
+    {"key": "vintage_year", "value": "2023"},
+    {"key": "methodology", "value": "VM0009"}
+  ],
+  "dimension": "Carbon"
+}
+```
+
+### Validation rule
+
+```cel
+has(payload.vcs_id) && has(payload.min_amount) && double(payload.min_amount) > 0.0
+```

--- a/docs/mapping-layer/troubleshooting.md
+++ b/docs/mapping-layer/troubleshooting.md
@@ -1,0 +1,113 @@
+# Mapping Layer — Troubleshooting
+
+## CEL Compilation Errors
+
+### "found no matching overload for '_>_' applied to '(double, int)'"
+
+**Cause**: CEL is strongly typed. `double()` returns a `double`, and `0` is an `int`.
+There is no built-in `double > int` overload.
+
+**Fix**: Use a float literal.
+
+```cel
+# WRONG
+double(payload.amount) > 0
+
+# CORRECT
+double(payload.amount) > 0.0
+```
+
+### "undeclared reference to 'input'"
+
+**Cause**: In `inbound_validation_cel`, the variable is `payload`, not `input`.
+The `input` variable is only available inside computed field `cel_expression` strings.
+
+```cel
+# Validation expression - use 'payload'
+has(payload.party_type) && size(payload.full_name) > 0
+
+# Computed field expression - use 'input'
+has(input.first_name) ? input.first_name : input.full_name
+```
+
+### "no such key" at runtime
+
+**Cause**: Accessing a field that may not be present without a `has()` guard.
+
+**Fix**: Guard with `has()` before accessing:
+
+```cel
+has(input.middle_name) ? input.middle_name : ''
+```
+
+## Transform Errors
+
+### Enum value not mapped
+
+If an incoming enum value has no entry in `enum_mapping.values` and no `fallback` is
+set, the transform returns an error. Either add the value to the map or add a `fallback`:
+
+```json
+{
+  "transform": {
+    "enum_mapping": {
+      "values": {
+        "individual": "PARTY_TYPE_PERSON"
+      },
+      "fallback": "PARTY_TYPE_UNSPECIFIED"
+    }
+  }
+}
+```
+
+### Date parse failure
+
+`date_format` uses Go time layout strings. The most common layouts:
+
+| Format | Go Layout |
+|--------|-----------|
+| ISO date | `2006-01-02` |
+| ISO datetime UTC | `2006-01-02T15:04:05Z` |
+| ISO datetime with zone | `2006-01-02T15:04:05Z07:00` |
+
+If the incoming value does not match the layout exactly, the transform returns an error.
+Use `DryRunInbound` to test layouts before registering the definition.
+
+### Attribute flatten produces empty list
+
+`attribute_flatten` only includes keys that are present in the input. If all
+`source_keys` are absent, the output list is empty (not an error). This is expected
+behaviour — add required-field validation in `inbound_validation_cel` if at least one
+key must be present.
+
+## Batch Transform Errors
+
+### "input must be a JSON array"
+
+Batch mappings (`is_batch: true`) require the HTTP body to be a JSON array `[...]`.
+A single object `{...}` will be rejected.
+
+### Per-element validation failure
+
+When a batch item fails validation, the entire batch request is rejected with a 400
+status. The error message includes the index of the failing element.
+
+## DryRun Debugging
+
+Use `DryRunInbound` to inspect transforms before registering:
+
+```go
+result, err := engine.DryRunInbound(def, inputJSON)
+if err != nil {
+    // CEL compilation or parse error
+}
+if !result.ValidationPassed {
+    fmt.Println("Validation errors:", result.ValidationErrors)
+}
+for _, trace := range result.FieldTraces {
+    fmt.Printf("%s -> %s: %v\n", trace.ExternalPath, trace.InternalPath, trace.OutputValue)
+}
+```
+
+The `FieldTraces` slice shows each field that was processed, making it straightforward
+to identify which field rules are not behaving as expected.

--- a/docs/mapping-layer/troubleshooting.md
+++ b/docs/mapping-layer/troubleshooting.md
@@ -97,8 +97,8 @@ status. The error message includes the index of the failing element.
 Use `DryRunInbound` to inspect transforms before registering:
 
 ```go
-result, err := engine.DryRunInbound(def, inputJSON)
-if err != nil {
+result := engine.DryRunInbound(def, inputJSON)
+if result.TransformError != nil {
     // CEL compilation or parse error
 }
 if !result.ValidationPassed {

--- a/services/gateway/integration_test/mapping_e2e_test.go
+++ b/services/gateway/integration_test/mapping_e2e_test.go
@@ -1,0 +1,548 @@
+//go:build integration
+
+// Package integration_test provides end-to-end tests for the gateway mapping layer.
+// These tests verify that the reference mapping examples transform correctly through
+// the full inbound and outbound pipeline.
+package integration_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	"github.com/meridianhub/meridian/services/gateway/auth"
+	gatewaymapping "github.com/meridianhub/meridian/services/gateway/internal/mapping"
+	"github.com/meridianhub/meridian/services/gateway/internal/middleware"
+)
+
+// ============================================================================
+// JSON example structs (mirrors the snake_case format in examples/ directory)
+// ============================================================================
+
+type exFieldTransform struct {
+	EnumMapping      *exEnumMapping      `json:"enum_mapping,omitempty"`
+	DateFormat       string              `json:"date_format,omitempty"`
+	DefaultValue     string              `json:"default_value,omitempty"`
+	AttributeFlatten *exAttributeFlatten `json:"attribute_flatten,omitempty"`
+	CEL              *exCelTransform     `json:"cel,omitempty"`
+}
+
+type exEnumMapping struct {
+	Values           map[string]string `json:"values"`
+	Fallback         string            `json:"fallback,omitempty"`
+	OutboundFallback string            `json:"outbound_fallback,omitempty"`
+}
+
+type exAttributeFlatten struct {
+	SourceKeys  []string `json:"source_keys"`
+	TargetField string   `json:"target_field"`
+}
+
+type exCelTransform struct {
+	InboundCEL  string `json:"inbound_cel,omitempty"`
+	OutboundCEL string `json:"outbound_cel,omitempty"`
+}
+
+type exFieldCorrespondence struct {
+	ExternalPath string            `json:"external_path"`
+	InternalPath string            `json:"internal_path"`
+	Transform    *exFieldTransform `json:"transform,omitempty"`
+}
+
+type exComputedField struct {
+	TargetPath    string `json:"target_path"`
+	CELExpression string `json:"cel_expression"`
+}
+
+type exIdempotencyConfig struct {
+	SourceSelector    string   `json:"source_selector,omitempty"`
+	UseContentHash    bool     `json:"use_content_hash,omitempty"`
+	ContentHashFields []string `json:"content_hash_fields,omitempty"`
+}
+
+type exMappingDefinition struct {
+	Name                  string                  `json:"name"`
+	TargetService         string                  `json:"target_service"`
+	TargetRPC             string                  `json:"target_rpc"`
+	Version               int                     `json:"version"`
+	InboundValidationCEL  string                  `json:"inbound_validation_cel,omitempty"`
+	OutboundValidationCEL string                  `json:"outbound_validation_cel,omitempty"`
+	IsBatch               bool                    `json:"is_batch,omitempty"`
+	BatchTargetPath       string                  `json:"batch_target_path,omitempty"`
+	Fields                []exFieldCorrespondence `json:"fields,omitempty"`
+	InboundComputed       []exComputedField       `json:"inbound_computed_fields,omitempty"`
+	OutboundComputed      []exComputedField       `json:"outbound_computed_fields,omitempty"`
+	Idempotency           *exIdempotencyConfig    `json:"idempotency,omitempty"`
+}
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+// examplesDir returns the absolute path to services/reference-data/examples/.
+func examplesDir(t *testing.T) string {
+	t.Helper()
+	_, callerFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller failed")
+	return filepath.Join(filepath.Dir(callerFile), "..", "..", "reference-data", "examples")
+}
+
+// loadProtoMapping reads an example JSON file and converts it to a proto MappingDefinition.
+func loadProtoMapping(t *testing.T, filename string) *mappingv1.MappingDefinition {
+	t.Helper()
+	path := filepath.Join(examplesDir(t), filename)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "reading %s", filename)
+
+	var ex exMappingDefinition
+	require.NoError(t, json.Unmarshal(data, &ex), "unmarshaling %s", filename)
+	return exToProto(&ex)
+}
+
+func exToProto(ex *exMappingDefinition) *mappingv1.MappingDefinition {
+	proto := &mappingv1.MappingDefinition{
+		Name:                  ex.Name,
+		TargetService:         ex.TargetService,
+		TargetRpc:             ex.TargetRPC,
+		Version:               int32(ex.Version),
+		InboundValidationCel:  ex.InboundValidationCEL,
+		OutboundValidationCel: ex.OutboundValidationCEL,
+		IsBatch:               ex.IsBatch,
+		BatchTargetPath:       ex.BatchTargetPath,
+	}
+	for _, f := range ex.Fields {
+		pc := &mappingv1.FieldCorrespondence{
+			ExternalPath: f.ExternalPath,
+			InternalPath: f.InternalPath,
+		}
+		if f.Transform != nil {
+			pc.Transform = exTransformToProto(f.Transform)
+		}
+		proto.Fields = append(proto.Fields, pc)
+	}
+	for _, cf := range ex.InboundComputed {
+		proto.InboundComputedFields = append(proto.InboundComputedFields, &mappingv1.ComputedField{
+			TargetPath:    cf.TargetPath,
+			CelExpression: cf.CELExpression,
+		})
+	}
+	for _, cf := range ex.OutboundComputed {
+		proto.OutboundComputedFields = append(proto.OutboundComputedFields, &mappingv1.ComputedField{
+			TargetPath:    cf.TargetPath,
+			CelExpression: cf.CELExpression,
+		})
+	}
+	if ex.Idempotency != nil {
+		proto.Idempotency = &mappingv1.IdempotencyConfig{
+			SourceSelector:    ex.Idempotency.SourceSelector,
+			UseContentHash:    ex.Idempotency.UseContentHash,
+			ContentHashFields: ex.Idempotency.ContentHashFields,
+		}
+	}
+	return proto
+}
+
+func exTransformToProto(t *exFieldTransform) *mappingv1.FieldTransform {
+	if t == nil {
+		return nil
+	}
+	ft := &mappingv1.FieldTransform{}
+	switch {
+	case t.CEL != nil:
+		ft.Transform = &mappingv1.FieldTransform_Cel{Cel: &mappingv1.CelTransform{
+			InboundCel: t.CEL.InboundCEL, OutboundCel: t.CEL.OutboundCEL,
+		}}
+	case t.EnumMapping != nil:
+		ft.Transform = &mappingv1.FieldTransform_EnumMapping{EnumMapping: &mappingv1.EnumMapping{
+			Values: t.EnumMapping.Values, Fallback: t.EnumMapping.Fallback, OutboundFallback: t.EnumMapping.OutboundFallback,
+		}}
+	case t.DateFormat != "":
+		ft.Transform = &mappingv1.FieldTransform_DateFormat{DateFormat: t.DateFormat}
+	case t.DefaultValue != "":
+		ft.Transform = &mappingv1.FieldTransform_DefaultValue{DefaultValue: t.DefaultValue}
+	case t.AttributeFlatten != nil:
+		ft.Transform = &mappingv1.FieldTransform_AttributeFlatten{AttributeFlatten: &mappingv1.AttributeFlatten{
+			SourceKeys: t.AttributeFlatten.SourceKeys, TargetField: t.AttributeFlatten.TargetField,
+		}}
+	}
+	return ft
+}
+
+// staticResolver returns a fixed mapping definition for all Resolve calls.
+type staticResolver struct {
+	def *mappingv1.MappingDefinition
+}
+
+func (s *staticResolver) Resolve(_ context.Context, _, _ string) (*mappingv1.MappingDefinition, error) {
+	return s.def, nil
+}
+
+// echoJSONHandler captures the transformed body and echoes it back as the "response".
+// It serves as the downstream Vanguard transcoder stub.
+type echoJSONHandler struct {
+	body []byte
+}
+
+func (h *echoJSONHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.body, _ = io.ReadAll(r.Body)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	// Echo back the received body so outbound transform has something to work with
+	_, _ = w.Write(h.body)
+}
+
+func newMappingMiddleware(t *testing.T, def *mappingv1.MappingDefinition) *middleware.MappingMiddleware {
+	t.Helper()
+	eng, err := gatewaymapping.NewEngine()
+	require.NoError(t, err)
+	resolver := &staticResolver{def: def}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return middleware.NewMappingMiddleware(resolver, eng, logger)
+}
+
+// requestWithTenant creates an HTTP request with tenant ID in context.
+func requestWithTenant(method, path string, body []byte, tenantID string) *http.Request {
+	r := httptest.NewRequest(method, path, bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	ctx := context.WithValue(r.Context(), auth.TenantIDContextKey, tenantID)
+	return r.WithContext(ctx)
+}
+
+// ============================================================================
+// E2E Test: Bank Party Onboarding
+// ============================================================================
+
+func TestE2E_BankPartyOnboarding_InboundTransform(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	def := loadProtoMapping(t, "bank-x-party-onboarding.json")
+	mw := newMappingMiddleware(t, def)
+	echo := &echoJSONHandler{}
+
+	externalPayload := []byte(`{
+		"party_type": "individual",
+		"full_name": "Jane Smith",
+		"first_name": "Jane",
+		"date_of_birth": "1985-03-15",
+		"govt_id": "GB-NI-123456",
+		"email": "jane.smith@example.com"
+	}`)
+
+	req := requestWithTenant(http.MethodPost, "/mapping/bank-x-party-onboarding", externalPayload, "tenant-001")
+	rr := httptest.NewRecorder()
+	mw.Handler(echo).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// The echo body contains the inbound-transformed payload (forwarded to Vanguard)
+	var forwarded map[string]any
+	require.NoError(t, json.Unmarshal(echo.body, &forwarded))
+
+	assert.Equal(t, "PARTY_TYPE_PERSON", forwarded["party_type"])
+	assert.Equal(t, "Jane Smith", forwarded["legal_name"])
+	assert.Equal(t, "Jane", forwarded["display_name"])
+
+	// Idempotency key header must be set
+	assert.Equal(t, "GB-NI-123456", req.Header.Get(middleware.HeaderIdempotencyKey))
+}
+
+func TestE2E_BankPartyOnboarding_InvalidJSON_Returns400(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	def := loadProtoMapping(t, "bank-x-party-onboarding.json")
+	mw := newMappingMiddleware(t, def)
+	echo := &echoJSONHandler{}
+
+	req := requestWithTenant(http.MethodPost, "/mapping/bank-x-party-onboarding", []byte(`{bad json`), "tenant-001")
+	rr := httptest.NewRecorder()
+	mw.Handler(echo).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestE2E_BankPartyOnboarding_EmptyBody_Returns400(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	def := loadProtoMapping(t, "bank-x-party-onboarding.json")
+	mw := newMappingMiddleware(t, def)
+	echo := &echoJSONHandler{}
+
+	req := requestWithTenant(http.MethodPost, "/mapping/bank-x-party-onboarding", []byte{}, "tenant-001")
+	rr := httptest.NewRecorder()
+	mw.Handler(echo).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestE2E_BankPartyOnboarding_ValidationFails_Returns400(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	def := loadProtoMapping(t, "bank-x-party-onboarding.json")
+	mw := newMappingMiddleware(t, def)
+	echo := &echoJSONHandler{}
+
+	// Missing full_name (required by inbound CEL validation)
+	payload := []byte(`{"party_type":"individual"}`)
+	req := requestWithTenant(http.MethodPost, "/mapping/bank-x-party-onboarding", payload, "tenant-001")
+	rr := httptest.NewRecorder()
+	mw.Handler(echo).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestE2E_BankPartyOnboarding_UnmappedEnum_Returns400(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	def := loadProtoMapping(t, "bank-x-party-onboarding.json")
+	mw := newMappingMiddleware(t, def)
+	echo := &echoJSONHandler{}
+
+	// party_type value not in enum mapping and no fallback defined
+	payload := []byte(`{"party_type":"partnership","full_name":"Some Firm"}`)
+	req := requestWithTenant(http.MethodPost, "/mapping/bank-x-party-onboarding", payload, "tenant-001")
+	rr := httptest.NewRecorder()
+	mw.Handler(echo).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestE2E_BankPartyOnboarding_MissingTenantID_Returns401(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	def := loadProtoMapping(t, "bank-x-party-onboarding.json")
+	mw := newMappingMiddleware(t, def)
+	echo := &echoJSONHandler{}
+
+	payload := []byte(`{"party_type":"individual","full_name":"Jane"}`)
+	// No tenant context
+	req := httptest.NewRequest(http.MethodPost, "/mapping/bank-x-party-onboarding", bytes.NewReader(payload))
+	rr := httptest.NewRecorder()
+	mw.Handler(echo).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+// ============================================================================
+// E2E Test: Energy Metering Feed (Batch)
+// ============================================================================
+
+func TestE2E_EnergyMeteringFeed_InboundBatchTransform(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	def := loadProtoMapping(t, "energy-metering-feed.json")
+	eng, err := gatewaymapping.NewEngine()
+	require.NoError(t, err)
+
+	batchInput := []byte(`[
+		{
+			"meter_id": "METER-001",
+			"timestamp": "2024-01-15T10:00:00Z",
+			"value_kwh": 100.5,
+			"quality": "actual",
+			"tenor": "1H",
+			"settlement_date": "2024-01-16"
+		},
+		{
+			"meter_id": "METER-002",
+			"timestamp": "2024-01-15T10:00:00Z",
+			"value_kwh": 75.0,
+			"quality": "estimated"
+		}
+	]`)
+
+	results, err := eng.TransformInboundBatch(def, batchInput)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	// First element
+	var obs0 map[string]any
+	require.NoError(t, json.Unmarshal(results[0].ProtoJSON, &obs0))
+	obs0List, ok := obs0["observations"].([]any)
+	require.True(t, ok, "observations must be an array")
+	require.Len(t, obs0List, 1)
+	item0 := obs0List[0].(map[string]any)
+	assert.Equal(t, "METER-001", item0["source_id"])
+	assert.Equal(t, "DATA_QUALITY_ACTUAL", item0["data_quality"])
+	assert.NotEmpty(t, results[0].IdempotencyKey)
+
+	// Second element
+	var obs1 map[string]any
+	require.NoError(t, json.Unmarshal(results[1].ProtoJSON, &obs1))
+	obs1List := obs1["observations"].([]any)
+	item1 := obs1List[0].(map[string]any)
+	assert.Equal(t, "METER-002", item1["source_id"])
+	assert.Equal(t, "DATA_QUALITY_ESTIMATE", item1["data_quality"])
+
+	// Idempotency keys should be different per element
+	assert.NotEqual(t, results[0].IdempotencyKey, results[1].IdempotencyKey)
+}
+
+func TestE2E_EnergyMeteringFeed_BatchValidationFails_NegativeValue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	def := loadProtoMapping(t, "energy-metering-feed.json")
+	eng, err := gatewaymapping.NewEngine()
+	require.NoError(t, err)
+
+	batchInput := []byte(`[
+		{"meter_id": "METER-001", "timestamp": "2024-01-15T10:00:00Z", "value_kwh": -10.0, "quality": "actual"}
+	]`)
+
+	_, err = eng.TransformInboundBatch(def, batchInput)
+	assert.Error(t, err, "batch with negative value_kwh should fail validation")
+}
+
+func TestE2E_EnergyMeteringFeed_BatchNotArray_Fails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	def := loadProtoMapping(t, "energy-metering-feed.json")
+	eng, err := gatewaymapping.NewEngine()
+	require.NoError(t, err)
+
+	// Not an array
+	_, err = eng.TransformInboundBatch(def, []byte(`{"meter_id":"METER-001"}`))
+	assert.Error(t, err)
+}
+
+// ============================================================================
+// E2E Test: Verra Carbon Credit
+// ============================================================================
+
+func TestE2E_VerraCarbonCredit_InboundTransform(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	def := loadProtoMapping(t, "verra-carbon-credit.json")
+	mw := newMappingMiddleware(t, def)
+	echo := &echoJSONHandler{}
+
+	payload := []byte(`{
+		"vcs_id": "VCS-2845",
+		"project_name": "Rimba Raya Biodiversity Reserve",
+		"vintage_year": 2022,
+		"methodology": "VM0009",
+		"registry": "Verra",
+		"min_amount": 1.0,
+		"validation_date": "2023-06-01"
+	}`)
+
+	req := requestWithTenant(http.MethodPost, "/mapping/verra-carbon-credit", payload, "tenant-001")
+	rr := httptest.NewRecorder()
+	mw.Handler(echo).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var forwarded map[string]any
+	require.NoError(t, json.Unmarshal(echo.body, &forwarded))
+
+	assert.Equal(t, "VCS-2845", forwarded["code"])
+	assert.Equal(t, "Rimba Raya Biodiversity Reserve", forwarded["display_name"])
+	assert.Equal(t, "Carbon", forwarded["dimension"])
+
+	// Idempotency key is the vcs_id
+	assert.Equal(t, "VCS-2845", req.Header.Get(middleware.HeaderIdempotencyKey))
+}
+
+func TestE2E_VerraCarbonCredit_ValidationFails_ZeroMinAmount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	def := loadProtoMapping(t, "verra-carbon-credit.json")
+	mw := newMappingMiddleware(t, def)
+	echo := &echoJSONHandler{}
+
+	payload := []byte(`{
+		"vcs_id": "VCS-0000",
+		"project_name": "Test",
+		"vintage_year": 2022,
+		"methodology": "VM0001",
+		"min_amount": 0
+	}`)
+
+	req := requestWithTenant(http.MethodPost, "/mapping/verra-carbon-credit", payload, "tenant-001")
+	rr := httptest.NewRecorder()
+	mw.Handler(echo).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestE2E_VerraCarbonCredit_ValidationFails_MissingVcsID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	def := loadProtoMapping(t, "verra-carbon-credit.json")
+	mw := newMappingMiddleware(t, def)
+	echo := &echoJSONHandler{}
+
+	payload := []byte(`{
+		"project_name": "No ID Project",
+		"vintage_year": 2022,
+		"methodology": "VM0001",
+		"min_amount": 5.0
+	}`)
+
+	req := requestWithTenant(http.MethodPost, "/mapping/verra-carbon-credit", payload, "tenant-001")
+	rr := httptest.NewRecorder()
+	mw.Handler(echo).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// ============================================================================
+// E2E Test: Non-mapping paths pass through unchanged
+// ============================================================================
+
+func TestE2E_NonMappingPath_PassThrough(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	def := loadProtoMapping(t, "bank-x-party-onboarding.json")
+	mw := newMappingMiddleware(t, def)
+
+	called := false
+	passthrough := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := requestWithTenant(http.MethodPost, "/v1/parties", []byte(`{}`), "tenant-001")
+	rr := httptest.NewRecorder()
+	mw.Handler(passthrough).ServeHTTP(rr, req)
+
+	assert.True(t, called, "request to non-mapping path should pass through")
+	assert.Equal(t, http.StatusOK, rr.Code)
+}

--- a/services/reference-data/e2e/mapping_dry_run_test.go
+++ b/services/reference-data/e2e/mapping_dry_run_test.go
@@ -1,0 +1,552 @@
+//go:build integration
+
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	sharedmapping "github.com/meridianhub/meridian/shared/pkg/mapping"
+)
+
+// ============================================================================
+// JSON example file helpers
+// These structs mirror the snake_case JSON format used in the examples/ directory.
+// ============================================================================
+
+type exampleFieldTransform struct {
+	EnumMapping      *exampleEnumMapping      `json:"enum_mapping,omitempty"`
+	DateFormat       string                   `json:"date_format,omitempty"`
+	DefaultValue     string                   `json:"default_value,omitempty"`
+	AttributeFlatten *exampleAttributeFlatten `json:"attribute_flatten,omitempty"`
+	CEL              *exampleCelTransform     `json:"cel,omitempty"`
+}
+
+type exampleEnumMapping struct {
+	Values           map[string]string `json:"values"`
+	Fallback         string            `json:"fallback,omitempty"`
+	OutboundFallback string            `json:"outbound_fallback,omitempty"`
+}
+
+type exampleAttributeFlatten struct {
+	SourceKeys  []string `json:"source_keys"`
+	TargetField string   `json:"target_field"`
+}
+
+type exampleCelTransform struct {
+	InboundCEL  string `json:"inbound_cel,omitempty"`
+	OutboundCEL string `json:"outbound_cel,omitempty"`
+}
+
+type exampleFieldCorrespondence struct {
+	ExternalPath string                 `json:"external_path"`
+	InternalPath string                 `json:"internal_path"`
+	Transform    *exampleFieldTransform `json:"transform,omitempty"`
+}
+
+type exampleComputedField struct {
+	TargetPath    string `json:"target_path"`
+	CELExpression string `json:"cel_expression"`
+}
+
+type exampleIdempotencyConfig struct {
+	SourceSelector    string   `json:"source_selector,omitempty"`
+	UseContentHash    bool     `json:"use_content_hash,omitempty"`
+	ContentHashFields []string `json:"content_hash_fields,omitempty"`
+}
+
+type exampleMappingDefinition struct {
+	Name                  string                       `json:"name"`
+	TargetService         string                       `json:"target_service"`
+	TargetRPC             string                       `json:"target_rpc"`
+	Version               int                          `json:"version"`
+	ExternalSchema        string                       `json:"external_schema,omitempty"`
+	InboundValidationCEL  string                       `json:"inbound_validation_cel,omitempty"`
+	OutboundValidationCEL string                       `json:"outbound_validation_cel,omitempty"`
+	IsBatch               bool                         `json:"is_batch,omitempty"`
+	BatchTargetPath       string                       `json:"batch_target_path,omitempty"`
+	Fields                []exampleFieldCorrespondence `json:"fields,omitempty"`
+	InboundComputed       []exampleComputedField       `json:"inbound_computed_fields,omitempty"`
+	OutboundComputed      []exampleComputedField       `json:"outbound_computed_fields,omitempty"`
+	Idempotency           *exampleIdempotencyConfig    `json:"idempotency,omitempty"`
+}
+
+// loadExampleProtoMapping reads a mapping JSON file from the examples directory
+// and converts it to a proto MappingDefinition ready for the mapping engine.
+func loadExampleProtoMapping(t *testing.T, filename string) *mappingv1.MappingDefinition {
+	t.Helper()
+
+	_, callerFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller failed")
+
+	examplesDir := filepath.Join(filepath.Dir(callerFile), "..", "examples")
+	path := filepath.Join(examplesDir, filename)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "reading example file %s", filename)
+
+	var ex exampleMappingDefinition
+	require.NoError(t, json.Unmarshal(data, &ex), "unmarshaling %s", filename)
+
+	return exampleToProtoMapping(&ex)
+}
+
+func exampleToProtoMapping(ex *exampleMappingDefinition) *mappingv1.MappingDefinition {
+	proto := &mappingv1.MappingDefinition{
+		Name:                  ex.Name,
+		TargetService:         ex.TargetService,
+		TargetRpc:             ex.TargetRPC,
+		Version:               int32(ex.Version),
+		InboundValidationCel:  ex.InboundValidationCEL,
+		OutboundValidationCel: ex.OutboundValidationCEL,
+		IsBatch:               ex.IsBatch,
+		BatchTargetPath:       ex.BatchTargetPath,
+	}
+
+	for _, f := range ex.Fields {
+		pc := &mappingv1.FieldCorrespondence{
+			ExternalPath: f.ExternalPath,
+			InternalPath: f.InternalPath,
+		}
+		if f.Transform != nil {
+			pc.Transform = exampleTransformToProto(f.Transform)
+		}
+		proto.Fields = append(proto.Fields, pc)
+	}
+
+	for _, cf := range ex.InboundComputed {
+		proto.InboundComputedFields = append(proto.InboundComputedFields, &mappingv1.ComputedField{
+			TargetPath:    cf.TargetPath,
+			CelExpression: cf.CELExpression,
+		})
+	}
+	for _, cf := range ex.OutboundComputed {
+		proto.OutboundComputedFields = append(proto.OutboundComputedFields, &mappingv1.ComputedField{
+			TargetPath:    cf.TargetPath,
+			CelExpression: cf.CELExpression,
+		})
+	}
+
+	if ex.Idempotency != nil {
+		proto.Idempotency = &mappingv1.IdempotencyConfig{
+			SourceSelector:    ex.Idempotency.SourceSelector,
+			UseContentHash:    ex.Idempotency.UseContentHash,
+			ContentHashFields: ex.Idempotency.ContentHashFields,
+		}
+	}
+
+	return proto
+}
+
+func exampleTransformToProto(t *exampleFieldTransform) *mappingv1.FieldTransform {
+	if t == nil {
+		return nil
+	}
+	ft := &mappingv1.FieldTransform{}
+	switch {
+	case t.CEL != nil:
+		ft.Transform = &mappingv1.FieldTransform_Cel{Cel: &mappingv1.CelTransform{
+			InboundCel: t.CEL.InboundCEL, OutboundCel: t.CEL.OutboundCEL,
+		}}
+	case t.EnumMapping != nil:
+		ft.Transform = &mappingv1.FieldTransform_EnumMapping{EnumMapping: &mappingv1.EnumMapping{
+			Values: t.EnumMapping.Values, Fallback: t.EnumMapping.Fallback, OutboundFallback: t.EnumMapping.OutboundFallback,
+		}}
+	case t.DateFormat != "":
+		ft.Transform = &mappingv1.FieldTransform_DateFormat{DateFormat: t.DateFormat}
+	case t.DefaultValue != "":
+		ft.Transform = &mappingv1.FieldTransform_DefaultValue{DefaultValue: t.DefaultValue}
+	case t.AttributeFlatten != nil:
+		ft.Transform = &mappingv1.FieldTransform_AttributeFlatten{AttributeFlatten: &mappingv1.AttributeFlatten{
+			SourceKeys: t.AttributeFlatten.SourceKeys, TargetField: t.AttributeFlatten.TargetField,
+		}}
+	}
+	return ft
+}
+
+// newTestMappingEngine creates a mapping engine for dry run tests.
+func newTestMappingEngine(t *testing.T) *sharedmapping.Engine {
+	t.Helper()
+	eng, err := sharedmapping.NewEngine()
+	require.NoError(t, err)
+	return eng
+}
+
+// ============================================================================
+// Dry Run Tests: Bank Party Onboarding
+// ============================================================================
+
+func TestDryRun_BankPartyOnboarding_Inbound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	eng := newTestMappingEngine(t)
+	def := loadExampleProtoMapping(t, "bank-x-party-onboarding.json")
+
+	sampleJSON := []byte(`{
+		"party_type": "individual",
+		"full_name": "Jane Smith",
+		"first_name": "Jane",
+		"date_of_birth": "1985-03-15",
+		"govt_id": "GB-NI-123456",
+		"email": "jane.smith@example.com",
+		"phone": "+44 7700 900123"
+	}`)
+
+	result := eng.DryRunInbound(def, sampleJSON)
+
+	assert.True(t, result.ValidationPassed, "validation should pass: %v", result.ValidationErrors)
+	assert.Empty(t, result.TransformError)
+	assert.NotEmpty(t, result.TransformedJSON)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.TransformedJSON), &out))
+	assert.Equal(t, "PARTY_TYPE_PERSON", out["party_type"])
+	assert.Equal(t, "Jane Smith", out["legal_name"])
+	assert.Equal(t, "Jane", out["display_name"])
+	assert.Equal(t, "GB-NI-123456", result.IdempotencyKey)
+
+	// Verify traces contain all mapped fields
+	assert.NotEmpty(t, result.FieldTraces)
+	traceTypes := make(map[string]string)
+	for _, tr := range result.FieldTraces {
+		traceTypes[tr.SourcePath] = tr.TransformType
+	}
+	assert.Equal(t, "enum_mapping", traceTypes["party_type"])
+	assert.Equal(t, "date_format", traceTypes["date_of_birth"])
+}
+
+func TestDryRun_BankPartyOnboarding_Inbound_Corporate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	eng := newTestMappingEngine(t)
+	def := loadExampleProtoMapping(t, "bank-x-party-onboarding.json")
+
+	sampleJSON := []byte(`{
+		"party_type": "corporate",
+		"full_name": "Acme Corp Ltd",
+		"govt_id": "UK-CRN-12345678"
+	}`)
+
+	result := eng.DryRunInbound(def, sampleJSON)
+
+	assert.True(t, result.ValidationPassed)
+	assert.Empty(t, result.TransformError)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.TransformedJSON), &out))
+	assert.Equal(t, "PARTY_TYPE_ORGANIZATION", out["party_type"])
+	assert.Equal(t, "Acme Corp Ltd", out["legal_name"])
+	// display_name falls back to full_name when first_name absent
+	assert.Equal(t, "Acme Corp Ltd", out["display_name"])
+}
+
+func TestDryRun_BankPartyOnboarding_Inbound_ValidationFails_MissingFullName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	eng := newTestMappingEngine(t)
+	def := loadExampleProtoMapping(t, "bank-x-party-onboarding.json")
+
+	// Missing required full_name field
+	sampleJSON := []byte(`{"party_type": "individual"}`)
+
+	result := eng.DryRunInbound(def, sampleJSON)
+
+	assert.False(t, result.ValidationPassed)
+	assert.NotEmpty(t, result.ValidationErrors)
+	assert.Empty(t, result.TransformedJSON)
+}
+
+func TestDryRun_BankPartyOnboarding_Outbound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	eng := newTestMappingEngine(t)
+	def := loadExampleProtoMapping(t, "bank-x-party-onboarding.json")
+
+	// Internal proto JSON (what the service would return)
+	internalJSON := []byte(`{
+		"party_type": "PARTY_TYPE_PERSON",
+		"legal_name": "Jane Smith",
+		"display_name": "Jane",
+		"reference": {"government_id": "GB-NI-123456"},
+		"contact": {"email": "jane.smith@example.com"}
+	}`)
+
+	result := eng.DryRunOutbound(def, internalJSON)
+
+	assert.True(t, result.ValidationPassed)
+	assert.Empty(t, result.TransformError)
+	assert.NotEmpty(t, result.TransformedJSON)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.TransformedJSON), &out))
+	// Internal field party_type maps to external party_type (via reverse enum)
+	assert.Equal(t, "individual", out["party_type"])
+}
+
+// ============================================================================
+// Dry Run Tests: Energy Metering Feed (Batch)
+// ============================================================================
+
+func TestDryRun_EnergyMeteringFeed_Inbound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	eng := newTestMappingEngine(t)
+	def := loadExampleProtoMapping(t, "energy-metering-feed.json")
+
+	sampleJSON := []byte(`{
+		"meter_id": "METER-UK-001",
+		"timestamp": "2024-01-15T10:30:00Z",
+		"value_kwh": 125.5,
+		"quality": "actual",
+		"tenor": "1H",
+		"settlement_date": "2024-01-16"
+	}`)
+
+	result := eng.DryRunInbound(def, sampleJSON)
+
+	assert.True(t, result.ValidationPassed, "validation should pass: %v", result.ValidationErrors)
+	assert.Empty(t, result.TransformError)
+	assert.NotEmpty(t, result.TransformedJSON)
+
+	// Verify trace includes attribute_flatten transform
+	traceTypes := make(map[string]string)
+	for _, tr := range result.FieldTraces {
+		traceTypes[tr.SourcePath] = tr.TransformType
+	}
+	assert.Equal(t, "enum_mapping", traceTypes["quality"])
+	assert.Equal(t, "date_format", traceTypes["timestamp"])
+	assert.Equal(t, "attribute_flatten", traceTypes["attributes"])
+
+	// Content hash should be derived
+	assert.NotEmpty(t, result.IdempotencyKey)
+}
+
+func TestDryRun_EnergyMeteringFeed_Inbound_ValidationFails_NegativeValue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	eng := newTestMappingEngine(t)
+	def := loadExampleProtoMapping(t, "energy-metering-feed.json")
+
+	sampleJSON := []byte(`{
+		"meter_id": "METER-UK-001",
+		"timestamp": "2024-01-15T10:30:00Z",
+		"value_kwh": -5.0,
+		"quality": "actual"
+	}`)
+
+	result := eng.DryRunInbound(def, sampleJSON)
+
+	assert.False(t, result.ValidationPassed)
+	assert.NotEmpty(t, result.ValidationErrors)
+}
+
+func TestDryRun_EnergyMeteringFeed_Outbound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	eng := newTestMappingEngine(t)
+	def := loadExampleProtoMapping(t, "energy-metering-feed.json")
+
+	// Internal proto JSON
+	internalJSON := []byte(`{
+		"source_id": "METER-UK-001",
+		"observed_at": "2024-01-15T10:30:00Z",
+		"quantity": 125.5,
+		"data_quality": "DATA_QUALITY_ACTUAL",
+		"resolution_key_value": "METER-UK-001:2024-01-15T10:30:00Z"
+	}`)
+
+	result := eng.DryRunOutbound(def, internalJSON)
+
+	assert.True(t, result.ValidationPassed)
+	assert.Empty(t, result.TransformError)
+	assert.NotEmpty(t, result.TransformedJSON)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.TransformedJSON), &out))
+	assert.Equal(t, "METER-UK-001", out["meter_id"])
+	// Enum reverse-maps DATA_QUALITY_ACTUAL -> actual
+	assert.Equal(t, "actual", out["quality"])
+}
+
+// ============================================================================
+// Dry Run Tests: Verra Carbon Credit
+// ============================================================================
+
+func TestDryRun_VerraCarbonCredit_Inbound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	eng := newTestMappingEngine(t)
+	def := loadExampleProtoMapping(t, "verra-carbon-credit.json")
+
+	sampleJSON := []byte(`{
+		"vcs_id": "VCS-2845",
+		"project_name": "Rimba Raya Biodiversity Reserve",
+		"vintage_year": 2022,
+		"methodology": "VM0009",
+		"registry": "Verra",
+		"min_amount": 1.0,
+		"validation_date": "2023-06-01"
+	}`)
+
+	result := eng.DryRunInbound(def, sampleJSON)
+
+	assert.True(t, result.ValidationPassed, "validation should pass: %v", result.ValidationErrors)
+	assert.Empty(t, result.TransformError)
+	assert.NotEmpty(t, result.TransformedJSON)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.TransformedJSON), &out))
+	assert.Equal(t, "VCS-2845", out["code"])
+	assert.Equal(t, "Rimba Raya Biodiversity Reserve", out["display_name"])
+	assert.Equal(t, "Carbon", out["dimension"])
+	assert.Equal(t, "VCS-2845", result.IdempotencyKey)
+
+	// Verify attribute_flatten trace
+	traceTypes := make(map[string]string)
+	for _, tr := range result.FieldTraces {
+		traceTypes[tr.SourcePath] = tr.TransformType
+	}
+	assert.Equal(t, "attribute_flatten", traceTypes["attributes"])
+	assert.Equal(t, "date_format", traceTypes["validation_date"])
+}
+
+func TestDryRun_VerraCarbonCredit_Inbound_ValidationFails_ZeroMinAmount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	eng := newTestMappingEngine(t)
+	def := loadExampleProtoMapping(t, "verra-carbon-credit.json")
+
+	sampleJSON := []byte(`{
+		"vcs_id": "VCS-0000",
+		"project_name": "Test Project",
+		"vintage_year": 2022,
+		"methodology": "VM0001",
+		"min_amount": 0
+	}`)
+
+	result := eng.DryRunInbound(def, sampleJSON)
+
+	assert.False(t, result.ValidationPassed)
+	assert.NotEmpty(t, result.ValidationErrors)
+}
+
+func TestDryRun_VerraCarbonCredit_Inbound_ValidationFails_MissingVcsID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	eng := newTestMappingEngine(t)
+	def := loadExampleProtoMapping(t, "verra-carbon-credit.json")
+
+	sampleJSON := []byte(`{
+		"project_name": "No ID Project",
+		"vintage_year": 2022,
+		"methodology": "VM0001",
+		"min_amount": 5.0
+	}`)
+
+	result := eng.DryRunInbound(def, sampleJSON)
+
+	assert.False(t, result.ValidationPassed)
+	assert.NotEmpty(t, result.ValidationErrors)
+}
+
+func TestDryRun_VerraCarbonCredit_Outbound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	eng := newTestMappingEngine(t)
+	def := loadExampleProtoMapping(t, "verra-carbon-credit.json")
+
+	internalJSON := []byte(`{
+		"code": "VCS-2845",
+		"display_name": "Rimba Raya Biodiversity Reserve",
+		"dimension": "Carbon",
+		"min_amount": 1.0,
+		"validation_date": "2023-06-01T00:00:00Z"
+	}`)
+
+	result := eng.DryRunOutbound(def, internalJSON)
+
+	assert.True(t, result.ValidationPassed)
+	assert.Empty(t, result.TransformError)
+	assert.NotEmpty(t, result.TransformedJSON)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.TransformedJSON), &out))
+	// code maps back to vcs_id
+	assert.Equal(t, "VCS-2845", out["vcs_id"])
+	assert.Equal(t, "Rimba Raya Biodiversity Reserve", out["project_name"])
+}
+
+// ============================================================================
+// Dry Run Tests: Execution Time Reporting
+// ============================================================================
+
+func TestDryRun_ExecutionTimeIsReported(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	eng := newTestMappingEngine(t)
+	def := loadExampleProtoMapping(t, "bank-x-party-onboarding.json")
+
+	sampleJSON := []byte(`{
+		"party_type": "individual",
+		"full_name": "Test User",
+		"govt_id": "TEST-001"
+	}`)
+
+	result := eng.DryRunInbound(def, sampleJSON)
+
+	// ExecutionTimeMs must be non-negative (may be 0 for very fast runs)
+	assert.GreaterOrEqual(t, result.ExecutionTimeMs, int64(0))
+}
+
+// ============================================================================
+// Dry Run Tests: Invalid JSON
+// ============================================================================
+
+func TestDryRun_InvalidJSON_Inbound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	eng := newTestMappingEngine(t)
+	def := loadExampleProtoMapping(t, "bank-x-party-onboarding.json")
+
+	// Malformed JSON - DryRunInbound internally calls TransformInbound which
+	// returns ErrInvalidJSON; the DryRunResult will have either a transform error
+	// or a validation error depending on whether the CEL validation ran.
+	result := eng.DryRunInbound(def, []byte(`{not valid json`))
+
+	// The transform must have failed (either validation could not run, or transform errored)
+	failed := !result.ValidationPassed || result.TransformError != ""
+	assert.True(t, failed, "invalid JSON should produce a failure in validation or transform")
+}

--- a/services/reference-data/examples/bank-x-party-onboarding.json
+++ b/services/reference-data/examples/bank-x-party-onboarding.json
@@ -1,0 +1,60 @@
+{
+  "name": "bank-x-party-onboarding",
+  "target_service": "meridian.party.v1.PartyService",
+  "target_rpc": "RegisterParty",
+  "version": 1,
+  "external_schema": "{\"type\":\"object\",\"required\":[\"party_type\",\"full_name\"],\"properties\":{\"party_type\":{\"type\":\"string\",\"enum\":[\"individual\",\"corporate\"]},\"full_name\":{\"type\":\"string\"},\"first_name\":{\"type\":\"string\"},\"date_of_birth\":{\"type\":\"string\",\"format\":\"date\"},\"govt_id\":{\"type\":\"string\"},\"email\":{\"type\":\"string\",\"format\":\"email\"},\"phone\":{\"type\":\"string\"}}}",
+  "inbound_validation_cel": "has(payload.party_type) && has(payload.full_name) && size(payload.full_name) > 0",
+  "fields": [
+    {
+      "external_path": "party_type",
+      "internal_path": "party_type",
+      "transform": {
+        "enum_mapping": {
+          "values": {
+            "individual": "PARTY_TYPE_PERSON",
+            "corporate": "PARTY_TYPE_ORGANIZATION"
+          }
+        }
+      }
+    },
+    {
+      "external_path": "full_name",
+      "internal_path": "legal_name"
+    },
+    {
+      "external_path": "date_of_birth",
+      "internal_path": "date_of_birth",
+      "transform": {
+        "date_format": "2006-01-02"
+      }
+    },
+    {
+      "external_path": "govt_id",
+      "internal_path": "reference.government_id"
+    },
+    {
+      "external_path": "email",
+      "internal_path": "contact.email"
+    },
+    {
+      "external_path": "phone",
+      "internal_path": "contact.phone"
+    }
+  ],
+  "inbound_computed_fields": [
+    {
+      "target_path": "display_name",
+      "cel_expression": "has(input.first_name) ? input.first_name : input.full_name"
+    }
+  ],
+  "outbound_computed_fields": [
+    {
+      "target_path": "full_name",
+      "cel_expression": "has(input.legal_name) ? input.legal_name : ''"
+    }
+  ],
+  "idempotency": {
+    "source_selector": "govt_id"
+  }
+}

--- a/services/reference-data/examples/energy-metering-feed.json
+++ b/services/reference-data/examples/energy-metering-feed.json
@@ -1,0 +1,62 @@
+{
+  "name": "energy-metering-feed",
+  "target_service": "meridian.market_information.v1.MarketInformationService",
+  "target_rpc": "RecordObservationBatch",
+  "version": 1,
+  "external_schema": "{\"type\":\"array\",\"items\":{\"type\":\"object\",\"required\":[\"meter_id\",\"timestamp\",\"value_kwh\",\"quality\"],\"properties\":{\"meter_id\":{\"type\":\"string\"},\"timestamp\":{\"type\":\"string\",\"format\":\"date-time\"},\"value_kwh\":{\"type\":\"number\"},\"quality\":{\"type\":\"string\",\"enum\":[\"estimated\",\"coefficient\",\"actual\",\"revised\"]},\"tenor\":{\"type\":\"string\"},\"settlement_date\":{\"type\":\"string\",\"format\":\"date\"}}}}",
+  "inbound_validation_cel": "has(payload.meter_id) && has(payload.value_kwh) && double(payload.value_kwh) >= 0.0",
+  "is_batch": true,
+  "batch_target_path": "observations",
+  "fields": [
+    {
+      "external_path": "meter_id",
+      "internal_path": "source_id"
+    },
+    {
+      "external_path": "timestamp",
+      "internal_path": "observed_at",
+      "transform": {
+        "date_format": "2006-01-02T15:04:05Z07:00"
+      }
+    },
+    {
+      "external_path": "value_kwh",
+      "internal_path": "quantity"
+    },
+    {
+      "external_path": "quality",
+      "internal_path": "data_quality",
+      "transform": {
+        "enum_mapping": {
+          "values": {
+            "estimated": "DATA_QUALITY_ESTIMATE",
+            "coefficient": "DATA_QUALITY_COEFFICIENT",
+            "actual": "DATA_QUALITY_ACTUAL",
+            "revised": "DATA_QUALITY_REVISED"
+          },
+          "fallback": "DATA_QUALITY_ESTIMATE"
+        }
+      }
+    },
+    {
+      "external_path": "attributes",
+      "internal_path": "attributes",
+      "transform": {
+        "attribute_flatten": {
+          "source_keys": ["tenor", "settlement_date"],
+          "target_field": "attributes"
+        }
+      }
+    }
+  ],
+  "inbound_computed_fields": [
+    {
+      "target_path": "resolution_key_value",
+      "cel_expression": "input.meter_id + ':' + input.timestamp"
+    }
+  ],
+  "idempotency": {
+    "use_content_hash": true,
+    "content_hash_fields": ["meter_id", "timestamp"]
+  }
+}

--- a/services/reference-data/examples/verra-carbon-credit.json
+++ b/services/reference-data/examples/verra-carbon-credit.json
@@ -1,0 +1,48 @@
+{
+  "name": "verra-carbon-credit",
+  "target_service": "meridian.reference_data.v1.ReferenceDataService",
+  "target_rpc": "RegisterInstrument",
+  "version": 1,
+  "external_schema": "{\"type\":\"object\",\"required\":[\"vcs_id\",\"project_name\",\"vintage_year\",\"methodology\",\"min_amount\"],\"properties\":{\"vcs_id\":{\"type\":\"string\"},\"project_name\":{\"type\":\"string\"},\"vintage_year\":{\"type\":\"integer\"},\"methodology\":{\"type\":\"string\"},\"registry\":{\"type\":\"string\"},\"min_amount\":{\"type\":\"number\"},\"validation_date\":{\"type\":\"string\",\"format\":\"date\"}}}",
+  "inbound_validation_cel": "has(payload.vcs_id) && has(payload.min_amount) && double(payload.min_amount) > 0.0",
+  "fields": [
+    {
+      "external_path": "vcs_id",
+      "internal_path": "code"
+    },
+    {
+      "external_path": "project_name",
+      "internal_path": "display_name"
+    },
+    {
+      "external_path": "validation_date",
+      "internal_path": "validation_date",
+      "transform": {
+        "date_format": "2006-01-02"
+      }
+    },
+    {
+      "external_path": "min_amount",
+      "internal_path": "min_amount"
+    },
+    {
+      "external_path": "attributes",
+      "internal_path": "attributes",
+      "transform": {
+        "attribute_flatten": {
+          "source_keys": ["registry", "vintage_year", "methodology"],
+          "target_field": "attributes"
+        }
+      }
+    }
+  ],
+  "inbound_computed_fields": [
+    {
+      "target_path": "dimension",
+      "cel_expression": "'Carbon'"
+    }
+  ],
+  "idempotency": {
+    "source_selector": "vcs_id"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds three reference mapping JSON definitions in `services/reference-data/examples/` covering party onboarding, energy metering feed (batch), and carbon credit registration
- Adds 13 DryRun integration tests in `services/reference-data/e2e/` validating inbound/outbound transforms and validation failure paths
- Adds 13 gateway HTTP integration tests in `services/gateway/integration_test/` covering full request lifecycle including error cases
- Adds mapping layer documentation (`docs/mapping-layer/README.md`, `examples.md`, `troubleshooting.md`)

## Changes Made

### Reference Mapping Definitions

| File | Pattern | Key features |
|------|---------|-------------|
| `bank-x-party-onboarding.json` | Field rename + enum map + bidirectional | `individual`→`PARTY_TYPE_PERSON`, computed `display_name` from `first_name`, idempotency via `govt_id` |
| `energy-metering-feed.json` | Batch + attribute flatten | `is_batch: true`, `attribute_flatten` for tenor/settlement_date, content-hash idempotency |
| `verra-carbon-credit.json` | Attribute flatten + computed dimension | `dimension = 'Carbon'` literal CEL, registry/vintage/methodology into attributes |

### Test Coverage

**DryRun tests** (`services/reference-data/e2e/mapping_dry_run_test.go`):
- Inbound and outbound transform correctness for each example
- Validation failure paths (missing required fields, out-of-range values)
- Execution time reported in DryRunResult
- Invalid JSON input handling

**Gateway E2E tests** (`services/gateway/integration_test/mapping_e2e_test.go`):
- Happy path inbound transform through MappingMiddleware
- Missing tenant ID returns 401
- Invalid/empty JSON body returns 400
- Validation failure returns 400
- Unmapped enum value returns 400
- Batch transform with array input
- Non-mapping path passes through unchanged

## Technical Details

- Uses local `exMappingDefinition` structs with snake_case JSON tags to correctly parse the example files (the domain `mapping.Definition` struct has untagged exported fields)
- Tests use `//go:build integration` tag and `testing.Short()` skip pattern consistent with the codebase
- Gateway tests use a `staticResolver` stub that serves any mapping name, and an `echoJSONHandler` that echoes request body as response

## Testing

All tests pass locally:

```
ok  github.com/meridianhub/meridian/services/reference-data/e2e  (13 tests)
ok  github.com/meridianhub/meridian/services/gateway/integration_test  (13 tests)
```

Run with:

```bash
go test -tags integration -run "TestDryRun" ./services/reference-data/e2e/...
go test -tags integration -run "TestE2E" ./services/gateway/integration_test/...
```

## Risk Assessment

- No production code changes — new test and example files only
- Example JSON files are not loaded at service startup; they are used by tests and as documentation
- Integration tests are opt-in via build tag

## Related

Implements structured-mapping-layer.15.