### PR TITLE
feat: Add channel normalization and glob matching utilities

### DIFF
--- a/services/gateway/eventstream/channel.go
+++ b/services/gateway/eventstream/channel.go
@@ -1,0 +1,67 @@
+package eventstream
+
+// DeriveChannel converts a Kafka topic to a logical channel name by stripping
+// trailing version suffixes of the form ".vN" where N is one or more digits.
+//
+// Examples:
+//
+//	"payment-order.reserved.v1"          → "payment-order.reserved"
+//	"audit.events.current-account.v1"    → "audit.events.current-account"
+//	"payment-order.reserved"             → "payment-order.reserved"
+//	"events"                             → "events"
+//
+// Returns ErrEmptyTopic if topic is empty.
+func DeriveChannel(topic string) (string, error) {
+	if topic == "" {
+		return "", ErrEmptyTopic
+	}
+	return deriveChannel(topic), nil
+}
+
+// ValidateChannelPattern checks that a channel pattern is non-empty and that
+// any wildcard character appears only as the last character.
+//
+// Returns ErrEmptyChannelPattern if pattern is empty.
+// Returns ErrInvalidChannelPattern if the wildcard is not in trailing position.
+func ValidateChannelPattern(pattern string) error {
+	return validateChannelPattern(ChannelPattern(pattern))
+}
+
+// ChannelMatcher holds a set of ChannelPattern values and can test whether a
+// given channel name satisfies at least one of them.
+//
+// The zero value is usable and matches nothing. Use NewChannelMatcher or
+// NewChannelMatcherFromSubscription to construct with an initial set of patterns.
+type ChannelMatcher struct {
+	patterns []ChannelPattern
+}
+
+// NewChannelMatcher returns a ChannelMatcher initialized with the given patterns.
+func NewChannelMatcher(patterns ...ChannelPattern) *ChannelMatcher {
+	p := make([]ChannelPattern, len(patterns))
+	copy(p, patterns)
+	return &ChannelMatcher{patterns: p}
+}
+
+// NewChannelMatcherFromSubscription returns a ChannelMatcher seeded from the
+// channel patterns in the given Subscription.
+func NewChannelMatcherFromSubscription(sub Subscription) *ChannelMatcher {
+	return NewChannelMatcher(sub.Channels...)
+}
+
+// Add appends a pattern to the matcher. Duplicate patterns are retained but
+// harmless — Matches short-circuits on the first hit.
+func (m *ChannelMatcher) Add(pattern ChannelPattern) {
+	m.patterns = append(m.patterns, pattern)
+}
+
+// Matches reports whether channel satisfies at least one of the stored patterns.
+// Returns false when no patterns have been added.
+func (m *ChannelMatcher) Matches(channel string) bool {
+	for _, p := range m.patterns {
+		if p.Matches(channel) {
+			return true
+		}
+	}
+	return false
+}

--- a/services/gateway/eventstream/channel.go
+++ b/services/gateway/eventstream/channel.go
@@ -32,6 +32,10 @@ func ValidateChannelPattern(pattern string) error {
 //
 // The zero value is usable and matches nothing. Use NewChannelMatcher or
 // NewChannelMatcherFromSubscription to construct with an initial set of patterns.
+//
+// ChannelMatcher is not safe for concurrent use. Callers that share a
+// ChannelMatcher across goroutines must synchronize all calls to Add and
+// Matches themselves.
 type ChannelMatcher struct {
 	patterns []ChannelPattern
 }

--- a/services/gateway/eventstream/channel_test.go
+++ b/services/gateway/eventstream/channel_test.go
@@ -1,0 +1,269 @@
+package eventstream_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/gateway/eventstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- DeriveChannel ---
+
+func TestDeriveChannel(t *testing.T) {
+	tests := []struct {
+		name            string
+		topic           string
+		expectedChannel string
+		wantErr         error
+	}{
+		// Version suffix stripping
+		{
+			name:            "strips .v1 suffix",
+			topic:           "payment-order.reserved.v1",
+			expectedChannel: "payment-order.reserved",
+		},
+		{
+			name:            "strips .v2 suffix",
+			topic:           "position-keeping.transaction-updated.v2",
+			expectedChannel: "position-keeping.transaction-updated",
+		},
+		{
+			name:            "strips .v10 suffix",
+			topic:           "current-account.events.v10",
+			expectedChannel: "current-account.events",
+		},
+		{
+			name:            "no version suffix preserved as-is",
+			topic:           "payment-order.reserved",
+			expectedChannel: "payment-order.reserved",
+		},
+		// Audit topics
+		{
+			name:            "audit topic strips version suffix",
+			topic:           "audit.events.current-account.v1",
+			expectedChannel: "audit.events.current-account",
+		},
+		{
+			name:            "audit topic without version",
+			topic:           "audit.events.payment-order",
+			expectedChannel: "audit.events.payment-order",
+		},
+		// Single segment (no dots)
+		{
+			name:            "single segment no dot",
+			topic:           "events",
+			expectedChannel: "events",
+		},
+		// Non-version suffix preserved
+		{
+			name:            "non-version suffix preserved",
+			topic:           "payment-order.beta",
+			expectedChannel: "payment-order.beta",
+		},
+		// Error cases
+		{
+			name:    "empty topic returns error",
+			topic:   "",
+			wantErr: eventstream.ErrEmptyTopic,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := eventstream.DeriveChannel(tc.topic)
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tc.wantErr))
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedChannel, got)
+		})
+	}
+}
+
+// --- ValidateChannelPattern ---
+
+func TestValidateChannelPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		wantErr error
+	}{
+		{
+			name:    "exact match pattern is valid",
+			pattern: "payment-order.reserved",
+		},
+		{
+			name:    "service wildcard is valid",
+			pattern: "payment-order.*",
+		},
+		{
+			name:    "prefix wildcard with hyphen is valid",
+			pattern: "position-keeping.transaction-*",
+		},
+		{
+			name:    "firehose wildcard is valid",
+			pattern: "*",
+		},
+		{
+			name:    "empty pattern returns error",
+			pattern: "",
+			wantErr: eventstream.ErrEmptyChannelPattern,
+		},
+		{
+			name:    "wildcard in middle returns error",
+			pattern: "foo*bar",
+			wantErr: eventstream.ErrInvalidChannelPattern,
+		},
+		{
+			name:    "wildcard at start not end returns error",
+			pattern: "*bar",
+			wantErr: eventstream.ErrInvalidChannelPattern,
+		},
+		{
+			name:    "wildcard not at end returns error",
+			pattern: "foo*.bar",
+			wantErr: eventstream.ErrInvalidChannelPattern,
+		},
+		{
+			name:    "double wildcard returns error",
+			pattern: "foo**",
+			wantErr: eventstream.ErrInvalidChannelPattern,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := eventstream.ValidateChannelPattern(tc.pattern)
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tc.wantErr))
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// --- ChannelMatcher ---
+
+func TestChannelMatcher_Matches(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []eventstream.ChannelPattern
+		channel  string
+		want     bool
+	}{
+		{
+			name:     "exact match",
+			patterns: []eventstream.ChannelPattern{"payment-order.reserved"},
+			channel:  "payment-order.reserved",
+			want:     true,
+		},
+		{
+			name:     "exact match - no match on different channel",
+			patterns: []eventstream.ChannelPattern{"payment-order.reserved"},
+			channel:  "payment-order.initiated",
+			want:     false,
+		},
+		{
+			name:     "service wildcard matches",
+			patterns: []eventstream.ChannelPattern{"payment-order.*"},
+			channel:  "payment-order.initiated",
+			want:     true,
+		},
+		{
+			name:     "service wildcard does not match different service",
+			patterns: []eventstream.ChannelPattern{"payment-order.*"},
+			channel:  "position-keeping.created",
+			want:     false,
+		},
+		{
+			name:     "prefix wildcard with hyphen matches",
+			patterns: []eventstream.ChannelPattern{"position-keeping.transaction-*"},
+			channel:  "position-keeping.transaction-updated",
+			want:     true,
+		},
+		{
+			name:     "prefix wildcard with hyphen does not match different prefix",
+			patterns: []eventstream.ChannelPattern{"position-keeping.transaction-*"},
+			channel:  "position-keeping.account-updated",
+			want:     false,
+		},
+		{
+			name:     "firehose matches everything",
+			patterns: []eventstream.ChannelPattern{"*"},
+			channel:  "any.channel.at.all",
+			want:     true,
+		},
+		{
+			name:     "firehose matches empty channel",
+			patterns: []eventstream.ChannelPattern{"*"},
+			channel:  "",
+			want:     true,
+		},
+		{
+			name:     "multiple patterns - first matches",
+			patterns: []eventstream.ChannelPattern{"payment-order.*", "position-keeping.*"},
+			channel:  "payment-order.reserved",
+			want:     true,
+		},
+		{
+			name:     "multiple patterns - second matches",
+			patterns: []eventstream.ChannelPattern{"payment-order.*", "position-keeping.*"},
+			channel:  "position-keeping.updated",
+			want:     true,
+		},
+		{
+			name:     "multiple patterns - none match",
+			patterns: []eventstream.ChannelPattern{"payment-order.*", "position-keeping.*"},
+			channel:  "current-account.created",
+			want:     false,
+		},
+		{
+			name:     "empty patterns - never matches",
+			patterns: []eventstream.ChannelPattern{},
+			channel:  "payment-order.reserved",
+			want:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			matcher := eventstream.NewChannelMatcher(tc.patterns...)
+			got := matcher.Matches(tc.channel)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestChannelMatcher_Add(t *testing.T) {
+	matcher := eventstream.NewChannelMatcher("payment-order.*")
+
+	// Does not match before adding
+	assert.False(t, matcher.Matches("position-keeping.created"))
+
+	// Add a new pattern
+	matcher.Add("position-keeping.*")
+
+	// Now matches
+	assert.True(t, matcher.Matches("position-keeping.created"))
+}
+
+func TestChannelMatcher_MatchesSubscription(t *testing.T) {
+	sub, err := eventstream.NewSubscription(
+		"sub-1",
+		[]eventstream.ChannelPattern{"payment-order.*", "position-keeping.*"},
+		eventstream.SubscriptionFilters{},
+	)
+	require.NoError(t, err)
+
+	matcher := eventstream.NewChannelMatcherFromSubscription(sub)
+
+	assert.True(t, matcher.Matches("payment-order.reserved"))
+	assert.True(t, matcher.Matches("position-keeping.updated"))
+	assert.False(t, matcher.Matches("current-account.created"))
+}


### PR DESCRIPTION
## Summary

- Adds `DeriveChannel(topic string) (string, error)` — public wrapper around the private `deriveChannel` helper with an `ErrEmptyTopic` guard
- Adds `ValidateChannelPattern(pattern string) error` — public wrapper around `validateChannelPattern` for use outside the package
- Adds `ChannelMatcher` type — aggregates multiple `ChannelPattern` values and short-circuits on the first match
- Adds `NewChannelMatcher(patterns ...ChannelPattern)` and `NewChannelMatcherFromSubscription(sub Subscription)` constructors

## Changes Made

- `services/gateway/eventstream/channel.go` — new file with all three public APIs
- `services/gateway/eventstream/channel_test.go` — table-driven tests (TDD: tests written first)

## Technical Details

`DeriveChannel` delegates to the existing `deriveChannel` private function after validating the input is non-empty. This keeps the derivation logic in one place (`domain.go`) while exposing it publicly for use by adapters (e.g. Kafka consumer).

`ChannelMatcher` wraps `[]ChannelPattern` and iterates with short-circuit semantics. `NewChannelMatcherFromSubscription` seeds it from a `Subscription`'s channel list, enabling adapters to evaluate a subscription against an incoming channel without exposing pattern internals.

## Testing

Table-driven tests cover:
- `DeriveChannel`: version suffix stripping (.v1/.v2/.v10), audit topics, single-segment topics, non-version suffixes, empty input error
- `ValidateChannelPattern`: exact patterns, trailing wildcards, prefix wildcards, firehose, empty input, invalid wildcard positions
- `ChannelMatcher.Matches`: exact match, service wildcard, prefix wildcard with hyphens, firehose, multi-pattern (first/second/none), empty patterns
- `ChannelMatcher.Add`: dynamic pattern addition
- `NewChannelMatcherFromSubscription`: round-trip from Subscription channels

## Risk Assessment

Low risk. This PR adds new public functions and a new type; it does not modify any existing types, functions, or error values.

## Deployment Notes

No migration or configuration changes required.