### PR TITLE
feat: Implement WebSocket protocol messages

### DIFF
--- a/services/gateway/eventstream/domain.go
+++ b/services/gateway/eventstream/domain.go
@@ -187,10 +187,10 @@ func validateChannelPattern(p ChannelPattern) error {
 // subscription receives. An empty filter matches all events on the subscribed channels.
 type SubscriptionFilters struct {
 	// AggregateID, when non-empty, restricts delivery to events from this aggregate.
-	AggregateID string
+	AggregateID string `json:"aggregate_id,omitempty"`
 
 	// CorrelationID, when non-empty, restricts delivery to events with this correlation ID.
-	CorrelationID string
+	CorrelationID string `json:"correlation_id,omitempty"`
 }
 
 // Subscription describes a client's interest in one or more event channels.

--- a/services/gateway/eventstream/protocol.go
+++ b/services/gateway/eventstream/protocol.go
@@ -1,0 +1,173 @@
+package eventstream
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrEmptyClientMessage is returned by ParseClientMessage when the input is nil or empty.
+var ErrEmptyClientMessage = errors.New("eventstream: cannot parse empty client message")
+
+// ClientMessageType identifies the type of a message sent from the client to the server.
+type ClientMessageType string
+
+const (
+	// ClientMessageTypeSubscribe requests a new subscription on one or more channels.
+	ClientMessageTypeSubscribe ClientMessageType = "subscribe"
+
+	// ClientMessageTypeUnsubscribe cancels an existing subscription identified by ID.
+	ClientMessageTypeUnsubscribe ClientMessageType = "unsubscribe"
+)
+
+// ServerMessageType identifies the type of a message sent from the server to the client.
+type ServerMessageType string
+
+const (
+	// ServerMessageTypeEvent delivers a domain event to the client.
+	ServerMessageTypeEvent ServerMessageType = "event"
+
+	// ServerMessageTypeSubscribed confirms that a subscription was created.
+	ServerMessageTypeSubscribed ServerMessageType = "subscribed"
+
+	// ServerMessageTypeError reports an error related to a client request.
+	ServerMessageTypeError ServerMessageType = "error"
+
+	// ServerMessageTypeSystem carries informational messages from the server (e.g. connection state).
+	ServerMessageTypeSystem ServerMessageType = "system"
+)
+
+// ErrorCode is a machine-readable code sent in error messages.
+type ErrorCode string
+
+const (
+	// ErrorCodeInvalidChannel is returned when a channel pattern is syntactically invalid.
+	ErrorCodeInvalidChannel ErrorCode = "INVALID_CHANNEL"
+
+	// ErrorCodeUnauthorizedChannel is returned when the client is not permitted to subscribe
+	// to the requested channel.
+	ErrorCodeUnauthorizedChannel ErrorCode = "UNAUTHORIZED_CHANNEL"
+
+	// ErrorCodeBufferOverflow is returned when the server's delivery buffer for the client
+	// is full and events cannot be queued.
+	ErrorCodeBufferOverflow ErrorCode = "BUFFER_OVERFLOW"
+
+	// ErrorCodeSubscriptionLimitExceeded is returned when the client has reached the
+	// maximum number of concurrent subscriptions.
+	ErrorCodeSubscriptionLimitExceeded ErrorCode = "SUBSCRIPTION_LIMIT_EXCEEDED"
+)
+
+// ClientMessage is a message sent from the WebSocket client to the gateway.
+type ClientMessage struct {
+	// Type identifies the action the client is requesting.
+	Type ClientMessageType `json:"type"`
+
+	// ID is an opaque identifier chosen by the client to correlate responses.
+	ID string `json:"id"`
+
+	// Channels lists the channel patterns the client wishes to subscribe to.
+	// Only applicable for subscribe messages.
+	Channels []ChannelPattern `json:"channels,omitempty"`
+
+	// Filters optionally narrows which events are delivered within the subscribed channels.
+	// Only applicable for subscribe messages.
+	Filters SubscriptionFilters `json:"filters,omitempty"`
+}
+
+// ParseClientMessage deserialises a raw WebSocket frame into a ClientMessage.
+// Returns an error if data is nil, empty, or not valid JSON.
+func ParseClientMessage(data []byte) (ClientMessage, error) {
+	if len(data) == 0 {
+		return ClientMessage{}, ErrEmptyClientMessage
+	}
+	var msg ClientMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return ClientMessage{}, fmt.Errorf("eventstream: malformed client message: %w", err)
+	}
+	return msg, nil
+}
+
+// EventPayload is the event body carried inside a ServerMessage of type "event".
+// Timestamp is serialized as an ISO 8601 / RFC 3339 string.
+type EventPayload struct {
+	// EventID is the globally unique identifier for this event instance.
+	EventID string `json:"event_id"`
+
+	// EventType identifies the event schema (e.g. "payment_order.created.v1").
+	EventType string `json:"event_type"`
+
+	// AggregateID is the ID of the aggregate that produced this event.
+	AggregateID string `json:"aggregate_id,omitempty"`
+
+	// AggregateType is the type of aggregate (e.g. "PaymentOrder").
+	AggregateType string `json:"aggregate_type,omitempty"`
+
+	// TenantID identifies the tenant that owns this event.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// CorrelationID links related events across services.
+	CorrelationID string `json:"correlation_id,omitempty"`
+
+	// CausationID identifies the event or command that caused this event.
+	CausationID string `json:"causation_id,omitempty"`
+
+	// Timestamp is when the event occurred, serialized as ISO 8601 UTC.
+	Timestamp time.Time `json:"timestamp"`
+
+	// Payload is the JSON-encoded event body, embedded verbatim in the wire message.
+	Payload json.RawMessage `json:"payload,omitempty"`
+}
+
+// NewEventPayload constructs an EventPayload from a DomainEvent, mapping
+// all fields across without transformation.
+func NewEventPayload(event DomainEvent) EventPayload {
+	return EventPayload{
+		EventID:       event.EventID,
+		EventType:     event.EventType,
+		AggregateID:   event.AggregateID,
+		AggregateType: event.AggregateType,
+		TenantID:      event.TenantID,
+		CorrelationID: event.CorrelationID,
+		CausationID:   event.CausationID,
+		Timestamp:     event.Timestamp,
+		Payload:       json.RawMessage(event.Payload),
+	}
+}
+
+// ServerMessage is a message sent from the gateway to the WebSocket client.
+// Fields not relevant to the message type are omitted from the JSON output.
+type ServerMessage struct {
+	// Type identifies the nature of this server message.
+	Type ServerMessageType `json:"type"`
+
+	// SubscriptionID is the ID of the subscription this message relates to.
+	// Present on "event" and "subscribed" messages.
+	SubscriptionID string `json:"subscription_id,omitempty"`
+
+	// Channel is the logical event channel on which the event was received.
+	// Present on "event" messages.
+	Channel string `json:"channel,omitempty"`
+
+	// Event carries the domain event payload. Present on "event" messages.
+	Event *EventPayload `json:"event,omitempty"`
+
+	// ErrorCode is a machine-readable error identifier. Present on "error" messages.
+	ErrorCode ErrorCode `json:"error_code,omitempty"`
+
+	// ErrorMessage is a human-readable description of the error. Present on "error" messages.
+	ErrorMessage string `json:"error_message,omitempty"`
+
+	// SystemMessage is an informational message from the server. Present on "system" messages.
+	SystemMessage string `json:"system_message,omitempty"`
+}
+
+// Serialize encodes the ServerMessage to JSON for transmission over the WebSocket connection.
+// Returns an error if JSON marshaling fails.
+func (m ServerMessage) Serialize() ([]byte, error) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("eventstream: failed to serialize server message: %w", err)
+	}
+	return data, nil
+}

--- a/services/gateway/eventstream/protocol.go
+++ b/services/gateway/eventstream/protocol.go
@@ -104,7 +104,8 @@ type EventPayload struct {
 	AggregateType string `json:"aggregate_type,omitempty"`
 
 	// TenantID identifies the tenant that owns this event.
-	TenantID string `json:"tenant_id,omitempty"`
+	// Always present: domain.NewDomainEvent enforces a non-empty tenant ID.
+	TenantID string `json:"tenant_id"`
 
 	// CorrelationID links related events across services.
 	CorrelationID string `json:"correlation_id,omitempty"`

--- a/services/gateway/eventstream/protocol_test.go
+++ b/services/gateway/eventstream/protocol_test.go
@@ -1,0 +1,336 @@
+package eventstream_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/gateway/eventstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- ParseClientMessage ---
+
+func TestParseClientMessage_Subscribe(t *testing.T) {
+	raw := `{
+		"type": "subscribe",
+		"id": "req-001",
+		"channels": ["payment-order.*", "position-keeping.*"],
+		"filters": {
+			"aggregate_id": "agg-123",
+			"correlation_id": "corr-456"
+		}
+	}`
+
+	msg, err := eventstream.ParseClientMessage([]byte(raw))
+	require.NoError(t, err)
+	assert.Equal(t, eventstream.ClientMessageTypeSubscribe, msg.Type)
+	assert.Equal(t, "req-001", msg.ID)
+	assert.Equal(t, []eventstream.ChannelPattern{"payment-order.*", "position-keeping.*"}, msg.Channels)
+	assert.Equal(t, "agg-123", msg.Filters.AggregateID)
+	assert.Equal(t, "corr-456", msg.Filters.CorrelationID)
+}
+
+func TestParseClientMessage_Unsubscribe(t *testing.T) {
+	raw := `{"type": "unsubscribe", "id": "req-002"}`
+
+	msg, err := eventstream.ParseClientMessage([]byte(raw))
+	require.NoError(t, err)
+	assert.Equal(t, eventstream.ClientMessageTypeUnsubscribe, msg.Type)
+	assert.Equal(t, "req-002", msg.ID)
+	assert.Empty(t, msg.Channels)
+}
+
+func TestParseClientMessage_MissingOptionalFields(t *testing.T) {
+	raw := `{"type": "subscribe", "id": "req-003", "channels": ["*"]}`
+
+	msg, err := eventstream.ParseClientMessage([]byte(raw))
+	require.NoError(t, err)
+	assert.Equal(t, eventstream.ClientMessageTypeSubscribe, msg.Type)
+	assert.Equal(t, []eventstream.ChannelPattern{"*"}, msg.Channels)
+	assert.Empty(t, msg.Filters.AggregateID)
+	assert.Empty(t, msg.Filters.CorrelationID)
+}
+
+func TestParseClientMessage_MalformedJSON(t *testing.T) {
+	_, err := eventstream.ParseClientMessage([]byte(`{not valid json}`))
+	require.Error(t, err)
+}
+
+func TestParseClientMessage_EmptyInput(t *testing.T) {
+	_, err := eventstream.ParseClientMessage([]byte(``))
+	require.Error(t, err)
+}
+
+func TestParseClientMessage_NullInput(t *testing.T) {
+	_, err := eventstream.ParseClientMessage(nil)
+	require.Error(t, err)
+}
+
+func TestParseClientMessage_JSONRoundTrip(t *testing.T) {
+	original := eventstream.ClientMessage{
+		Type:     eventstream.ClientMessageTypeSubscribe,
+		ID:       "req-999",
+		Channels: []eventstream.ChannelPattern{"payment-order.*"},
+		Filters: eventstream.SubscriptionFilters{
+			AggregateID:   "agg-1",
+			CorrelationID: "corr-1",
+		},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	parsed, err := eventstream.ParseClientMessage(data)
+	require.NoError(t, err)
+	assert.Equal(t, original.Type, parsed.Type)
+	assert.Equal(t, original.ID, parsed.ID)
+	assert.Equal(t, original.Channels, parsed.Channels)
+	assert.Equal(t, original.Filters, parsed.Filters)
+}
+
+// --- ServerMessage.Serialize ---
+
+func TestServerMessage_Serialize_EventMessage(t *testing.T) {
+	ts := time.Date(2026, 2, 22, 12, 0, 0, 0, time.UTC)
+	payload := json.RawMessage(`{"amount":"100.00"}`)
+
+	msg := eventstream.ServerMessage{
+		Type:           eventstream.ServerMessageTypeEvent,
+		SubscriptionID: "sub-001",
+		Channel:        "payment-order.created",
+		Event: &eventstream.EventPayload{
+			EventID:       "evt-123",
+			EventType:     "payment_order.created.v1",
+			AggregateID:   "agg-456",
+			AggregateType: "PaymentOrder",
+			TenantID:      "tenant-abc",
+			CorrelationID: "corr-789",
+			CausationID:   "cause-000",
+			Timestamp:     ts,
+			Payload:       payload,
+		},
+	}
+
+	data, err := msg.Serialize()
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	assert.Equal(t, "event", raw["type"])
+	assert.Equal(t, "sub-001", raw["subscription_id"])
+	assert.Equal(t, "payment-order.created", raw["channel"])
+
+	event, ok := raw["event"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "evt-123", event["event_id"])
+	assert.Equal(t, "payment_order.created.v1", event["event_type"])
+	assert.Equal(t, "agg-456", event["aggregate_id"])
+	assert.Equal(t, "PaymentOrder", event["aggregate_type"])
+	assert.Equal(t, "tenant-abc", event["tenant_id"])
+	assert.Equal(t, "corr-789", event["correlation_id"])
+	assert.Equal(t, "cause-000", event["causation_id"])
+
+	// Timestamp must be ISO 8601
+	tsStr, ok := event["timestamp"].(string)
+	require.True(t, ok)
+	assert.Equal(t, "2026-02-22T12:00:00Z", tsStr)
+}
+
+func TestServerMessage_Serialize_SubscribedMessage(t *testing.T) {
+	msg := eventstream.ServerMessage{
+		Type:           eventstream.ServerMessageTypeSubscribed,
+		SubscriptionID: "sub-001",
+	}
+
+	data, err := msg.Serialize()
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	assert.Equal(t, "subscribed", raw["type"])
+	assert.Equal(t, "sub-001", raw["subscription_id"])
+	_, hasEvent := raw["event"]
+	assert.False(t, hasEvent, "subscribed message should not include event field")
+	_, hasError := raw["error"]
+	assert.False(t, hasError, "subscribed message should not include error field")
+}
+
+func TestServerMessage_Serialize_ErrorMessage(t *testing.T) {
+	msg := eventstream.ServerMessage{
+		Type:         eventstream.ServerMessageTypeError,
+		ErrorCode:    eventstream.ErrorCodeInvalidChannel,
+		ErrorMessage: "channel pattern 'foo*bar' is invalid",
+	}
+
+	data, err := msg.Serialize()
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	assert.Equal(t, "error", raw["type"])
+	assert.Equal(t, "INVALID_CHANNEL", raw["error_code"])
+	assert.Equal(t, "channel pattern 'foo*bar' is invalid", raw["error_message"])
+}
+
+func TestServerMessage_Serialize_SystemMessage(t *testing.T) {
+	msg := eventstream.ServerMessage{
+		Type:          eventstream.ServerMessageTypeSystem,
+		SystemMessage: "Connection established. Awaiting subscriptions.",
+	}
+
+	data, err := msg.Serialize()
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	assert.Equal(t, "system", raw["type"])
+	assert.Equal(t, "Connection established. Awaiting subscriptions.", raw["system_message"])
+}
+
+func TestServerMessage_Serialize_JSONRoundTrip(t *testing.T) {
+	ts := time.Now().UTC().Truncate(time.Second)
+	payload := json.RawMessage(`{"key":"value"}`)
+
+	original := eventstream.ServerMessage{
+		Type:           eventstream.ServerMessageTypeEvent,
+		SubscriptionID: "sub-roundtrip",
+		Channel:        "some.channel",
+		Event: &eventstream.EventPayload{
+			EventID:       "evt-rt-1",
+			EventType:     "some.event.v1",
+			AggregateID:   "agg-rt",
+			AggregateType: "SomeAggregate",
+			TenantID:      "tenant-rt",
+			CorrelationID: "corr-rt",
+			CausationID:   "cause-rt",
+			Timestamp:     ts,
+			Payload:       payload,
+		},
+	}
+
+	data, err := original.Serialize()
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.Equal(t, "event", raw["type"])
+	assert.Equal(t, "sub-roundtrip", raw["subscription_id"])
+}
+
+// --- Error codes ---
+
+func TestErrorCodes_Values(t *testing.T) {
+	assert.Equal(t, "INVALID_CHANNEL", string(eventstream.ErrorCodeInvalidChannel))
+	assert.Equal(t, "UNAUTHORIZED_CHANNEL", string(eventstream.ErrorCodeUnauthorizedChannel))
+	assert.Equal(t, "BUFFER_OVERFLOW", string(eventstream.ErrorCodeBufferOverflow))
+	assert.Equal(t, "SUBSCRIPTION_LIMIT_EXCEEDED", string(eventstream.ErrorCodeSubscriptionLimitExceeded))
+}
+
+// --- EventPayload from DomainEvent ---
+
+func TestNewEventPayload_FromDomainEvent(t *testing.T) {
+	ts := time.Date(2026, 1, 15, 8, 30, 0, 0, time.UTC)
+	event := eventstream.DomainEvent{
+		EventID:       "evt-from-domain",
+		EventType:     "payment_order.settled.v2",
+		Channel:       "payment-order.settled",
+		AggregateID:   "agg-domain",
+		AggregateType: "PaymentOrder",
+		TenantID:      "tenant-domain",
+		CorrelationID: "corr-domain",
+		CausationID:   "cause-domain",
+		Timestamp:     ts,
+		Payload:       []byte(`{"status":"settled"}`),
+	}
+
+	payload := eventstream.NewEventPayload(event)
+
+	assert.Equal(t, "evt-from-domain", payload.EventID)
+	assert.Equal(t, "payment_order.settled.v2", payload.EventType)
+	assert.Equal(t, "agg-domain", payload.AggregateID)
+	assert.Equal(t, "PaymentOrder", payload.AggregateType)
+	assert.Equal(t, "tenant-domain", payload.TenantID)
+	assert.Equal(t, "corr-domain", payload.CorrelationID)
+	assert.Equal(t, "cause-domain", payload.CausationID)
+	assert.Equal(t, ts, payload.Timestamp)
+	assert.JSONEq(t, `{"status":"settled"}`, string(payload.Payload))
+}
+
+// --- ISO 8601 timestamp serialization ---
+
+func TestEventPayload_TimestampSerializesAsISO8601(t *testing.T) {
+	ts := time.Date(2026, 3, 14, 15, 9, 26, 535897932, time.UTC)
+	payload := eventstream.EventPayload{
+		EventID:   "ts-test",
+		EventType: "test.event",
+		Timestamp: ts,
+		Payload:   json.RawMessage(`{}`),
+	}
+
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	tsStr, ok := raw["timestamp"].(string)
+	require.True(t, ok)
+
+	// Must parse as RFC3339 (ISO 8601)
+	parsed, err := time.Parse(time.RFC3339Nano, tsStr)
+	require.NoError(t, err, "timestamp must be valid ISO 8601 / RFC3339")
+	assert.Equal(t, ts.Unix(), parsed.Unix())
+}
+
+// --- Client message type constants ---
+
+func TestClientMessageType_Values(t *testing.T) {
+	assert.Equal(t, "subscribe", string(eventstream.ClientMessageTypeSubscribe))
+	assert.Equal(t, "unsubscribe", string(eventstream.ClientMessageTypeUnsubscribe))
+}
+
+// --- Server message type constants ---
+
+func TestServerMessageType_Values(t *testing.T) {
+	assert.Equal(t, "event", string(eventstream.ServerMessageTypeEvent))
+	assert.Equal(t, "subscribed", string(eventstream.ServerMessageTypeSubscribed))
+	assert.Equal(t, "error", string(eventstream.ServerMessageTypeError))
+	assert.Equal(t, "system", string(eventstream.ServerMessageTypeSystem))
+}
+
+// --- OmitEmpty behavior ---
+
+func TestServerMessage_Serialize_OmitsEmptyOptionalFields(t *testing.T) {
+	// A "subscribed" message should not emit null/empty channel, event, error fields.
+	msg := eventstream.ServerMessage{
+		Type:           eventstream.ServerMessageTypeSubscribed,
+		SubscriptionID: "sub-omit",
+	}
+
+	data, err := msg.Serialize()
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	_, hasChannel := raw["channel"]
+	assert.False(t, hasChannel, "channel should be omitted when empty")
+
+	_, hasEvent := raw["event"]
+	assert.False(t, hasEvent, "event should be omitted when nil")
+
+	_, hasErrorCode := raw["error_code"]
+	assert.False(t, hasErrorCode, "error_code should be omitted when empty")
+
+	_, hasErrorMsg := raw["error_message"]
+	assert.False(t, hasErrorMsg, "error_message should be omitted when empty")
+
+	_, hasSysMsg := raw["system_message"]
+	assert.False(t, hasSysMsg, "system_message should be omitted when empty")
+}


### PR DESCRIPTION
## Summary

- Add `protocol.go` with `ClientMessage`, `ServerMessage`, `EventPayload`, `ClientMessageType`, `ServerMessageType`, and `ErrorCode` types
- Implement `ParseClientMessage(data []byte)` for deserializing client WebSocket frames
- Implement `ServerMessage.Serialize()` for serializing server messages to JSON
- Add `NewEventPayload(DomainEvent)` helper to map domain events to wire format
- Add JSON tags to `SubscriptionFilters` (in `domain.go`) to enable wire serialization of filters
- Add `ErrEmptyClientMessage` sentinel error (err113 compliance)

## Changes Made

### `services/gateway/eventstream/protocol.go` (new)
- `ClientMessageType`: `subscribe` / `unsubscribe` constants
- `ServerMessageType`: `event` / `subscribed` / `error` / `system` constants
- `ErrorCode`: `INVALID_CHANNEL`, `UNAUTHORIZED_CHANNEL`, `BUFFER_OVERFLOW`, `SUBSCRIPTION_LIMIT_EXCEEDED`
- `ClientMessage`: client→server wire type with `type`, `id`, `channels`, `filters`
- `EventPayload`: event envelope with ISO 8601 timestamp via `time.Time` (RFC3339 marshaling)
- `ServerMessage`: server→client wire type with `omitempty` on all optional fields
- `ParseClientMessage`: validates non-empty input, wraps JSON errors
- `ServerMessage.Serialize`: wraps `json.Marshal` with descriptive error

### `services/gateway/eventstream/domain.go` (modified)
- Added `json:"aggregate_id,omitempty"` and `json:"correlation_id,omitempty"` to `SubscriptionFilters` fields to support wire serialization of subscription filters

## Testing

- JSON round-trip for `ClientMessage` and `ServerMessage`
- All four `ServerMessageType` variants serialized and verified
- All four `ErrorCode` string values asserted
- `omitempty` behavior: `subscribed` message emits no `channel`, `event`, `error_code`, `error_message`, or `system_message` fields
- ISO 8601 / RFC3339 timestamp serialization verified via `time.Parse`
- Malformed JSON, empty input, nil input error paths
- `NewEventPayload` field mapping from `DomainEvent`

## Task Master

025-real-time-event-streaming.3