### PR TITLE
feat: Implement LocalFanOut adapter

### DIFF
--- a/services/gateway/eventstream/adapters/local_fanout.go
+++ b/services/gateway/eventstream/adapters/local_fanout.go
@@ -1,0 +1,132 @@
+// Package adapters provides concrete implementations of the eventstream port
+// interfaces defined in the parent package.
+package adapters
+
+import (
+	"context"
+	"sync"
+
+	"github.com/meridianhub/meridian/services/gateway/eventstream"
+)
+
+// LocalFanOut is an in-process FanOut implementation that routes DomainEvents to
+// subscribed handlers via buffered channels. It is used as the default fan-out
+// backend when no external pub/sub system (e.g. Redis) is configured.
+//
+// Each tenantID maps to exactly one subscriber. Registering a new subscriber for a
+// tenantID that already has one replaces the previous subscription by closing its
+// channel, which causes its event loop to return.
+//
+// Publish is non-blocking: if the subscriber's channel is full the event is dropped.
+// LocalFanOut is safe for concurrent use from multiple goroutines.
+type LocalFanOut struct {
+	mu          sync.RWMutex
+	subscribers map[string]chan eventstream.DomainEvent
+	bufferSize  int
+}
+
+// NewLocalFanOut returns a LocalFanOut with the given per-subscriber channel buffer
+// size. A bufferSize of 0 creates unbuffered channels (every Publish blocks until
+// the handler processes the event — suitable only for tests).
+func NewLocalFanOut(bufferSize int) *LocalFanOut {
+	return &LocalFanOut{
+		subscribers: make(map[string]chan eventstream.DomainEvent),
+		bufferSize:  bufferSize,
+	}
+}
+
+// Publish delivers event to the handler subscribed for event.TenantID.
+// If no subscriber is registered the event is silently dropped.
+// If the subscriber's buffer is full the event is dropped without blocking.
+// Returns ErrEmptyTenantID if event.TenantID is empty.
+func (f *LocalFanOut) Publish(_ context.Context, event eventstream.DomainEvent) error {
+	if event.TenantID == "" {
+		return eventstream.ErrEmptyTenantID
+	}
+
+	// Hold the read lock for the entire send to prevent concurrent Unsubscribe
+	// from closing the channel while we are trying to send into it.
+	f.mu.RLock()
+	ch, ok := f.subscribers[event.TenantID]
+	if ok {
+		// Non-blocking send: drop on full buffer.
+		select {
+		case ch <- event:
+		default:
+		}
+	}
+	f.mu.RUnlock()
+
+	return nil
+}
+
+// Subscribe registers handler to receive events for tenantID and blocks until
+// ctx is cancelled or the subscription is replaced by a subsequent call to
+// Subscribe with the same tenantID or Unsubscribe is called.
+//
+// If a handler is already registered for tenantID it is replaced: the previous
+// event loop is terminated by closing its channel.
+//
+// Returns ErrEmptyTenantID if tenantID is empty.
+// Returns nil when the event loop exits cleanly.
+func (f *LocalFanOut) Subscribe(ctx context.Context, tenantID string, handler eventstream.EventHandler) error {
+	if tenantID == "" {
+		return eventstream.ErrEmptyTenantID
+	}
+
+	ch := make(chan eventstream.DomainEvent, f.bufferSize)
+
+	f.mu.Lock()
+	if existing, ok := f.subscribers[tenantID]; ok {
+		close(existing)
+	}
+	f.subscribers[tenantID] = ch
+	f.mu.Unlock()
+
+	// Event loop: forward channel events to handler until channel is closed or
+	// context is cancelled.
+	for {
+		select {
+		case event, ok := <-ch:
+			if !ok {
+				// Channel was closed (replaced or unsubscribed).
+				return nil
+			}
+			// Handler errors are intentionally ignored at this layer; callers
+			// that need error propagation should wrap handler with their own
+			// error-handling decorator.
+			_ = handler(ctx, event)
+		case <-ctx.Done():
+			// Remove our channel from the map if it is still registered.
+			f.mu.Lock()
+			if current, ok := f.subscribers[tenantID]; ok && current == ch {
+				delete(f.subscribers, tenantID)
+			}
+			f.mu.Unlock()
+			return nil
+		}
+	}
+}
+
+// Unsubscribe removes the handler registered for tenantID and causes the blocked
+// Subscribe call (if any) to return nil.
+//
+// It is not an error to call Unsubscribe for a tenantID that has no registered
+// handler.
+//
+// Returns ErrEmptyTenantID if tenantID is empty.
+func (f *LocalFanOut) Unsubscribe(_ context.Context, tenantID string) error {
+	if tenantID == "" {
+		return eventstream.ErrEmptyTenantID
+	}
+
+	f.mu.Lock()
+	ch, ok := f.subscribers[tenantID]
+	if ok {
+		delete(f.subscribers, tenantID)
+		close(ch)
+	}
+	f.mu.Unlock()
+
+	return nil
+}

--- a/services/gateway/eventstream/adapters/local_fanout.go
+++ b/services/gateway/eventstream/adapters/local_fanout.go
@@ -4,10 +4,15 @@ package adapters
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/meridianhub/meridian/services/gateway/eventstream"
 )
+
+// ErrNegativeBufferSize is returned when NewLocalFanOutE is called with a
+// negative buffer size.
+var ErrNegativeBufferSize = errors.New("buffer size must be non-negative")
 
 // LocalFanOut is an in-process FanOut implementation that routes DomainEvents to
 // subscribed handlers via buffered channels. It is used as the default fan-out
@@ -25,14 +30,29 @@ type LocalFanOut struct {
 	bufferSize  int
 }
 
-// NewLocalFanOut returns a LocalFanOut with the given per-subscriber channel buffer
-// size. A bufferSize of 0 creates unbuffered channels (every Publish blocks until
-// the handler processes the event — suitable only for tests).
+// NewLocalFanOut returns a LocalFanOut with the given per-subscriber channel
+// buffer size. It panics if bufferSize is negative. Use NewLocalFanOutE when
+// the buffer size is derived from user-supplied configuration.
 func NewLocalFanOut(bufferSize int) *LocalFanOut {
+	fo, err := NewLocalFanOutE(bufferSize)
+	if err != nil {
+		panic(err)
+	}
+	return fo
+}
+
+// NewLocalFanOutE returns a LocalFanOut with the given per-subscriber channel
+// buffer size, or ErrNegativeBufferSize if bufferSize is negative.
+// A bufferSize of 0 creates unbuffered channels (every Publish blocks until
+// the handler processes the event — suitable only for tests).
+func NewLocalFanOutE(bufferSize int) (*LocalFanOut, error) {
+	if bufferSize < 0 {
+		return nil, ErrNegativeBufferSize
+	}
 	return &LocalFanOut{
 		subscribers: make(map[string]chan eventstream.DomainEvent),
 		bufferSize:  bufferSize,
-	}
+	}, nil
 }
 
 // Publish delivers event to the handler subscribed for event.TenantID.

--- a/services/gateway/eventstream/adapters/local_fanout_test.go
+++ b/services/gateway/eventstream/adapters/local_fanout_test.go
@@ -46,7 +46,10 @@ func subscribeReady(t *testing.T, fo *adapters.LocalFanOut, tenantID string, han
 	}()
 
 	// Probe: publish events until the handler is reached, confirming registration.
+	// A distinct EventID prevents the probe from being confused with test events
+	// that share the same EventID produced by makeEvent.
 	probeEvent := makeEvent(tenantID)
+	probeEvent.EventID = "probe-ready"
 	probeErr := await.New().
 		AtMost(time.Second).
 		PollInterval(5 * time.Millisecond).

--- a/services/gateway/eventstream/adapters/local_fanout_test.go
+++ b/services/gateway/eventstream/adapters/local_fanout_test.go
@@ -1,0 +1,370 @@
+package adapters_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/gateway/eventstream"
+	"github.com/meridianhub/meridian/services/gateway/eventstream/adapters"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeEvent(tenantID string) eventstream.DomainEvent {
+	return eventstream.DomainEvent{
+		EventID:   "evt-001",
+		EventType: "payment.created.v1",
+		Topic:     "payment.events.v1",
+		Channel:   "payment.events",
+		TenantID:  tenantID,
+		Timestamp: time.Now().UTC(),
+	}
+}
+
+// TestLocalFanOut_Publish_EmptyTenantID verifies that publishing an event with
+// an empty TenantID returns ErrEmptyTenantID.
+func TestLocalFanOut_Publish_EmptyTenantID(t *testing.T) {
+	fo := adapters.NewLocalFanOut(10)
+	event := makeEvent("")
+
+	err := fo.Publish(context.Background(), event)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, eventstream.ErrEmptyTenantID))
+}
+
+// TestLocalFanOut_Subscribe_EmptyTenantID verifies that subscribing with an
+// empty tenantID returns ErrEmptyTenantID.
+func TestLocalFanOut_Subscribe_EmptyTenantID(t *testing.T) {
+	fo := adapters.NewLocalFanOut(10)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := fo.Subscribe(ctx, "", func(_ context.Context, _ eventstream.DomainEvent) error { return nil })
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, eventstream.ErrEmptyTenantID))
+}
+
+// TestLocalFanOut_Unsubscribe_EmptyTenantID verifies that unsubscribing with an
+// empty tenantID returns ErrEmptyTenantID.
+func TestLocalFanOut_Unsubscribe_EmptyTenantID(t *testing.T) {
+	fo := adapters.NewLocalFanOut(10)
+
+	err := fo.Unsubscribe(context.Background(), "")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, eventstream.ErrEmptyTenantID))
+}
+
+// TestLocalFanOut_Unsubscribe_NoopWhenNotSubscribed verifies that unsubscribing
+// a tenantID that has no registered handler is not an error.
+func TestLocalFanOut_Unsubscribe_NoopWhenNotSubscribed(t *testing.T) {
+	fo := adapters.NewLocalFanOut(10)
+
+	err := fo.Unsubscribe(context.Background(), "tenant-x")
+	require.NoError(t, err)
+}
+
+// TestLocalFanOut_Publish_DeliveredToSubscriber verifies that a published event
+// is forwarded to the subscribed handler.
+func TestLocalFanOut_Publish_DeliveredToSubscriber(t *testing.T) {
+	fo := adapters.NewLocalFanOut(10)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	received := make(chan eventstream.DomainEvent, 1)
+	subscribeErr := make(chan error, 1)
+
+	go func() {
+		err := fo.Subscribe(ctx, "tenant-a", func(_ context.Context, ev eventstream.DomainEvent) error {
+			received <- ev
+			return nil
+		})
+		subscribeErr <- err
+	}()
+
+	// Give Subscribe goroutine time to register
+	time.Sleep(10 * time.Millisecond)
+
+	event := makeEvent("tenant-a")
+	require.NoError(t, fo.Publish(context.Background(), event))
+
+	select {
+	case got := <-received:
+		assert.Equal(t, event.EventID, got.EventID)
+		assert.Equal(t, event.TenantID, got.TenantID)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event delivery")
+	}
+
+	cancel()
+	select {
+	case err := <-subscribeErr:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe did not return after context cancellation")
+	}
+}
+
+// TestLocalFanOut_Publish_NoSubscriber verifies that publishing to a tenantID
+// with no subscriber succeeds silently (drop).
+func TestLocalFanOut_Publish_NoSubscriber(t *testing.T) {
+	fo := adapters.NewLocalFanOut(10)
+
+	event := makeEvent("tenant-nobody")
+	err := fo.Publish(context.Background(), event)
+	require.NoError(t, err)
+}
+
+// TestLocalFanOut_Publish_TenantIsolation verifies that events for tenant-a
+// are not delivered to tenant-b's subscriber.
+func TestLocalFanOut_Publish_TenantIsolation(t *testing.T) {
+	fo := adapters.NewLocalFanOut(10)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	receivedB := make(chan eventstream.DomainEvent, 5)
+
+	go func() {
+		_ = fo.Subscribe(ctx, "tenant-b", func(_ context.Context, ev eventstream.DomainEvent) error {
+			receivedB <- ev
+			return nil
+		})
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	// Publish to tenant-a only
+	require.NoError(t, fo.Publish(context.Background(), makeEvent("tenant-a")))
+
+	// tenant-b should receive nothing
+	select {
+	case got := <-receivedB:
+		t.Fatalf("tenant-b unexpectedly received event: %+v", got)
+	case <-time.After(50 * time.Millisecond):
+		// expected: no delivery
+	}
+}
+
+// TestLocalFanOut_Publish_BufferFull_DropWithoutBlocking verifies that when the
+// subscriber channel is full, Publish drops the event and returns without blocking.
+func TestLocalFanOut_Publish_BufferFull_DropWithoutBlocking(t *testing.T) {
+	bufferSize := 2
+	fo := adapters.NewLocalFanOut(bufferSize)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Slow handler that blocks after being called the first time, simulating a
+	// slow consumer that causes the channel to fill up.
+	started := make(chan struct{})
+	var startOnce sync.Once
+	go func() {
+		_ = fo.Subscribe(ctx, "tenant-slow", func(_ context.Context, _ eventstream.DomainEvent) error {
+			startOnce.Do(func() { close(started) })
+			// block until context cancelled to stop the channel from draining
+			<-ctx.Done()
+			return nil
+		})
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	event := makeEvent("tenant-slow")
+
+	// Fill the buffer (bufferSize events), then one more to trigger the slow handler
+	for i := 0; i < bufferSize+1; i++ {
+		require.NoError(t, fo.Publish(context.Background(), event))
+	}
+
+	// Wait for handler to start blocking
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("handler never started")
+	}
+
+	// These publishes should return immediately (buffer full, events dropped)
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 5; i++ {
+			_ = fo.Publish(context.Background(), event)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// good - did not block
+	case <-time.After(time.Second):
+		t.Fatal("Publish blocked on full channel")
+	}
+}
+
+// TestLocalFanOut_Subscribe_ContextCancellation verifies that Subscribe returns
+// nil when its context is cancelled.
+func TestLocalFanOut_Subscribe_ContextCancellation(t *testing.T) {
+	fo := adapters.NewLocalFanOut(10)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- fo.Subscribe(ctx, "tenant-cancel", func(_ context.Context, _ eventstream.DomainEvent) error {
+			return nil
+		})
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe did not return after context cancellation")
+	}
+}
+
+// TestLocalFanOut_Unsubscribe_StopsDelivery verifies that after Unsubscribe is
+// called, events for that tenantID are no longer delivered.
+func TestLocalFanOut_Unsubscribe_StopsDelivery(t *testing.T) {
+	fo := adapters.NewLocalFanOut(10)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	count := 0
+	var mu sync.Mutex
+
+	subscribeErr := make(chan error, 1)
+	go func() {
+		subscribeErr <- fo.Subscribe(ctx, "tenant-unsub", func(_ context.Context, _ eventstream.DomainEvent) error {
+			mu.Lock()
+			count++
+			mu.Unlock()
+			return nil
+		})
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	// Deliver one event before unsubscribe
+	require.NoError(t, fo.Publish(context.Background(), makeEvent("tenant-unsub")))
+	time.Sleep(20 * time.Millisecond)
+
+	// Unsubscribe (this should cause Subscribe to return)
+	require.NoError(t, fo.Unsubscribe(context.Background(), "tenant-unsub"))
+
+	select {
+	case err := <-subscribeErr:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe did not return after Unsubscribe")
+	}
+
+	mu.Lock()
+	countBefore := count
+	mu.Unlock()
+
+	// Any further publishes should be no-ops (no subscriber)
+	require.NoError(t, fo.Publish(context.Background(), makeEvent("tenant-unsub")))
+	time.Sleep(20 * time.Millisecond)
+
+	mu.Lock()
+	countAfter := count
+	mu.Unlock()
+
+	assert.Equal(t, countBefore, countAfter, "events should not be delivered after unsubscribe")
+}
+
+// TestLocalFanOut_Subscribe_ReplacesExisting verifies that subscribing twice
+// for the same tenantID replaces the previous subscription.
+func TestLocalFanOut_Subscribe_ReplacesExisting(t *testing.T) {
+	fo := adapters.NewLocalFanOut(10)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	firstReceived := make(chan struct{}, 5)
+	secondReceived := make(chan struct{}, 5)
+
+	// First subscription (runs until replaced)
+	go func() {
+		_ = fo.Subscribe(ctx, "tenant-dup", func(_ context.Context, _ eventstream.DomainEvent) error {
+			firstReceived <- struct{}{}
+			return nil
+		})
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	// Second subscription replaces the first
+	go func() {
+		_ = fo.Subscribe(ctx, "tenant-dup", func(_ context.Context, _ eventstream.DomainEvent) error {
+			secondReceived <- struct{}{}
+			return nil
+		})
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	require.NoError(t, fo.Publish(context.Background(), makeEvent("tenant-dup")))
+
+	select {
+	case <-secondReceived:
+		// second handler received the event - correct
+	case <-time.After(time.Second):
+		t.Fatal("second subscriber did not receive event")
+	}
+}
+
+// TestLocalFanOut_ConcurrentSubscribeUnsubscribePublish verifies that the
+// implementation is safe for concurrent use.
+func TestLocalFanOut_ConcurrentSubscribeUnsubscribePublish(t *testing.T) {
+	t.Parallel()
+
+	fo := adapters.NewLocalFanOut(50)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	tenants := []string{"t1", "t2", "t3", "t4", "t5"}
+
+	// Concurrent subscribers
+	for _, tenant := range tenants {
+		tenant := tenant
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = fo.Subscribe(ctx, tenant, func(_ context.Context, _ eventstream.DomainEvent) error {
+				return nil
+			})
+		}()
+	}
+
+	// Concurrent publishers
+	for _, tenant := range tenants {
+		tenant := tenant
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 10; i++ {
+				_ = fo.Publish(context.Background(), makeEvent(tenant))
+			}
+		}()
+	}
+
+	// Concurrent unsubscribers
+	for _, tenant := range tenants {
+		tenant := tenant
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(20 * time.Millisecond)
+			_ = fo.Unsubscribe(context.Background(), tenant)
+		}()
+	}
+
+	// Let everything run, then cancel to unblock remaining subscribers
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	wg.Wait()
+}

--- a/services/gateway/eventstream/adapters/local_fanout_test.go
+++ b/services/gateway/eventstream/adapters/local_fanout_test.go
@@ -126,7 +126,7 @@ func TestLocalFanOut_Publish_DeliveredToSubscriber(t *testing.T) {
 	event := makeEvent("tenant-a")
 	require.NoError(t, fo.Publish(context.Background(), event))
 
-	// Drain probe events; wait for the real event (same EventID in this test).
+	// Drain probe events (EventID "probe-ready"); wait for the real event.
 	err := await.New().
 		AtMost(time.Second).
 		Until(func() bool {

--- a/services/gateway/eventstream/adapters/local_fanout_test.go
+++ b/services/gateway/eventstream/adapters/local_fanout_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/meridianhub/meridian/services/gateway/eventstream"
 	"github.com/meridianhub/meridian/services/gateway/eventstream/adapters"
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,6 +24,46 @@ func makeEvent(tenantID string) eventstream.DomainEvent {
 		TenantID:  tenantID,
 		Timestamp: time.Now().UTC(),
 	}
+}
+
+// subscribeReady starts a Subscribe goroutine and waits until the subscriber is
+// registered by publishing a probe event and waiting for the handler to be
+// invoked at least once. The returned cancel stops the subscription and the
+// errCh carries the Subscribe return value.
+func subscribeReady(t *testing.T, fo *adapters.LocalFanOut, tenantID string, handler eventstream.EventHandler) (cancel context.CancelFunc, errCh <-chan error) {
+	t.Helper()
+
+	var called atomic.Bool
+	wrappedHandler := func(ctx context.Context, ev eventstream.DomainEvent) error {
+		called.Store(true)
+		return handler(ctx, ev)
+	}
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	ch := make(chan error, 1)
+	go func() {
+		ch <- fo.Subscribe(ctx, tenantID, wrappedHandler)
+	}()
+
+	// Probe: publish events until the handler is reached, confirming registration.
+	probeEvent := makeEvent(tenantID)
+	probeErr := await.New().
+		AtMost(time.Second).
+		PollInterval(5 * time.Millisecond).
+		Until(func() bool {
+			_ = fo.Publish(context.Background(), probeEvent)
+			return called.Load()
+		})
+	require.NoError(t, probeErr, "subscriber for %q did not become ready", tenantID)
+
+	return cancelFn, ch
+}
+
+// TestLocalFanOut_NewLocalFanOut_NegativeBufferSize verifies that constructing
+// a LocalFanOut with a negative buffer size returns an error.
+func TestLocalFanOut_NewLocalFanOut_NegativeBufferSize(t *testing.T) {
+	_, err := adapters.NewLocalFanOutE(-1)
+	require.Error(t, err)
 }
 
 // TestLocalFanOut_Publish_EmptyTenantID verifies that publishing an event with
@@ -70,33 +112,31 @@ func TestLocalFanOut_Unsubscribe_NoopWhenNotSubscribed(t *testing.T) {
 // is forwarded to the subscribed handler.
 func TestLocalFanOut_Publish_DeliveredToSubscriber(t *testing.T) {
 	fo := adapters.NewLocalFanOut(10)
-	ctx, cancel := context.WithCancel(context.Background())
+
+	received := make(chan eventstream.DomainEvent, 10)
+	cancel, subscribeErr := subscribeReady(t, fo, "tenant-a", func(_ context.Context, ev eventstream.DomainEvent) error {
+		received <- ev
+		return nil
+	})
 	defer cancel()
-
-	received := make(chan eventstream.DomainEvent, 1)
-	subscribeErr := make(chan error, 1)
-
-	go func() {
-		err := fo.Subscribe(ctx, "tenant-a", func(_ context.Context, ev eventstream.DomainEvent) error {
-			received <- ev
-			return nil
-		})
-		subscribeErr <- err
-	}()
-
-	// Give Subscribe goroutine time to register
-	time.Sleep(10 * time.Millisecond)
 
 	event := makeEvent("tenant-a")
 	require.NoError(t, fo.Publish(context.Background(), event))
 
-	select {
-	case got := <-received:
-		assert.Equal(t, event.EventID, got.EventID)
-		assert.Equal(t, event.TenantID, got.TenantID)
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for event delivery")
-	}
+	// Drain probe events; wait for the real event (same EventID in this test).
+	err := await.New().
+		AtMost(time.Second).
+		Until(func() bool {
+			select {
+			case got := <-received:
+				if got.EventID == event.EventID {
+					return true
+				}
+			default:
+			}
+			return false
+		})
+	require.NoError(t, err, "event was not delivered to subscriber")
 
 	cancel()
 	select {
@@ -121,30 +161,43 @@ func TestLocalFanOut_Publish_NoSubscriber(t *testing.T) {
 // are not delivered to tenant-b's subscriber.
 func TestLocalFanOut_Publish_TenantIsolation(t *testing.T) {
 	fo := adapters.NewLocalFanOut(10)
-	ctx, cancel := context.WithCancel(context.Background())
+
+	// Use a counter so we can observe the count at a known point in time and
+	// verify it does not increase after a tenant-a publish.
+	var tenantBCount atomic.Int64
+	cancel, _ := subscribeReady(t, fo, "tenant-b", func(_ context.Context, _ eventstream.DomainEvent) error {
+		tenantBCount.Add(1)
+		return nil
+	})
 	defer cancel()
 
-	receivedB := make(chan eventstream.DomainEvent, 5)
-
-	go func() {
-		_ = fo.Subscribe(ctx, "tenant-b", func(_ context.Context, ev eventstream.DomainEvent) error {
-			receivedB <- ev
-			return nil
+	// Drain: wait until all probe events have been processed by waiting for the
+	// count to stabilize (no new increments over a short window).
+	var stable int64
+	err := await.New().
+		AtMost(time.Second).
+		PollInterval(20 * time.Millisecond).
+		Until(func() bool {
+			current := tenantBCount.Load()
+			if current != stable {
+				stable = current
+				return false // still draining
+			}
+			return true // stable
 		})
-	}()
+	require.NoError(t, err, "probe events did not drain in time")
 
-	time.Sleep(10 * time.Millisecond)
+	countAfterDrain := tenantBCount.Load()
 
-	// Publish to tenant-a only
+	// Publish to tenant-a only.
 	require.NoError(t, fo.Publish(context.Background(), makeEvent("tenant-a")))
 
-	// tenant-b should receive nothing
-	select {
-	case got := <-receivedB:
-		t.Fatalf("tenant-b unexpectedly received event: %+v", got)
-	case <-time.After(50 * time.Millisecond):
-		// expected: no delivery
-	}
+	// tenant-b should receive nothing within a reasonable window.
+	err = await.New().
+		AtMost(100 * time.Millisecond).
+		PollInterval(10 * time.Millisecond).
+		Until(func() bool { return tenantBCount.Load() > countAfterDrain })
+	assert.Error(t, err, "tenant-b should not have received an event for tenant-a")
 }
 
 // TestLocalFanOut_Publish_BufferFull_DropWithoutBlocking verifies that when the
@@ -162,29 +215,31 @@ func TestLocalFanOut_Publish_BufferFull_DropWithoutBlocking(t *testing.T) {
 	go func() {
 		_ = fo.Subscribe(ctx, "tenant-slow", func(_ context.Context, _ eventstream.DomainEvent) error {
 			startOnce.Do(func() { close(started) })
-			// block until context cancelled to stop the channel from draining
+			// Block until context cancelled to prevent channel from draining.
 			<-ctx.Done()
 			return nil
 		})
 	}()
 
-	time.Sleep(10 * time.Millisecond)
+	// Wait until the subscriber is registered. The subscriber map is private,
+	// so we use a short sleep; 20ms is well within CI tolerances.
+	time.Sleep(20 * time.Millisecond) //nolint:forbidigo // no observable state to poll before first event
 
 	event := makeEvent("tenant-slow")
 
-	// Fill the buffer (bufferSize events), then one more to trigger the slow handler
+	// Fill buffer (bufferSize events), then one more to start the blocking handler.
 	for i := 0; i < bufferSize+1; i++ {
 		require.NoError(t, fo.Publish(context.Background(), event))
 	}
 
-	// Wait for handler to start blocking
+	// Wait for handler to start blocking.
 	select {
 	case <-started:
 	case <-time.After(time.Second):
 		t.Fatal("handler never started")
 	}
 
-	// These publishes should return immediately (buffer full, events dropped)
+	// These publishes should return immediately (buffer full, events dropped).
 	done := make(chan struct{})
 	go func() {
 		for i := 0; i < 5; i++ {
@@ -214,7 +269,7 @@ func TestLocalFanOut_Subscribe_ContextCancellation(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond) //nolint:forbidigo // no observable state to poll before cancellation
 	cancel()
 
 	select {
@@ -229,29 +284,24 @@ func TestLocalFanOut_Subscribe_ContextCancellation(t *testing.T) {
 // called, events for that tenantID are no longer delivered.
 func TestLocalFanOut_Unsubscribe_StopsDelivery(t *testing.T) {
 	fo := adapters.NewLocalFanOut(10)
-	ctx, cancel := context.WithCancel(context.Background())
+
+	var count atomic.Int64
+	cancel, subscribeErr := subscribeReady(t, fo, "tenant-unsub", func(_ context.Context, _ eventstream.DomainEvent) error {
+		count.Add(1)
+		return nil
+	})
 	defer cancel()
 
-	count := 0
-	var mu sync.Mutex
+	countAfterProbe := count.Load()
 
-	subscribeErr := make(chan error, 1)
-	go func() {
-		subscribeErr <- fo.Subscribe(ctx, "tenant-unsub", func(_ context.Context, _ eventstream.DomainEvent) error {
-			mu.Lock()
-			count++
-			mu.Unlock()
-			return nil
-		})
-	}()
-
-	time.Sleep(10 * time.Millisecond)
-
-	// Deliver one event before unsubscribe
+	// Deliver one extra event and wait for it to land.
 	require.NoError(t, fo.Publish(context.Background(), makeEvent("tenant-unsub")))
-	time.Sleep(20 * time.Millisecond)
+	err := await.New().
+		AtMost(time.Second).
+		Until(func() bool { return count.Load() > countAfterProbe })
+	require.NoError(t, err, "event should have been delivered before unsubscribe")
 
-	// Unsubscribe (this should cause Subscribe to return)
+	// Unsubscribe should cause Subscribe to return.
 	require.NoError(t, fo.Unsubscribe(context.Background(), "tenant-unsub"))
 
 	select {
@@ -261,59 +311,44 @@ func TestLocalFanOut_Unsubscribe_StopsDelivery(t *testing.T) {
 		t.Fatal("Subscribe did not return after Unsubscribe")
 	}
 
-	mu.Lock()
-	countBefore := count
-	mu.Unlock()
+	countBeforeExtra := count.Load()
 
-	// Any further publishes should be no-ops (no subscriber)
+	// Further publishes should be no-ops.
 	require.NoError(t, fo.Publish(context.Background(), makeEvent("tenant-unsub")))
-	time.Sleep(20 * time.Millisecond)
 
-	mu.Lock()
-	countAfter := count
-	mu.Unlock()
-
-	assert.Equal(t, countBefore, countAfter, "events should not be delivered after unsubscribe")
+	err = await.New().
+		AtMost(50 * time.Millisecond).
+		PollInterval(5 * time.Millisecond).
+		Until(func() bool { return count.Load() > countBeforeExtra })
+	assert.Error(t, err, "events should not be delivered after unsubscribe")
 }
 
 // TestLocalFanOut_Subscribe_ReplacesExisting verifies that subscribing twice
 // for the same tenantID replaces the previous subscription.
 func TestLocalFanOut_Subscribe_ReplacesExisting(t *testing.T) {
 	fo := adapters.NewLocalFanOut(10)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
-	firstReceived := make(chan struct{}, 5)
-	secondReceived := make(chan struct{}, 5)
+	// First subscription — just a placeholder handler.
+	cancel1, _ := subscribeReady(t, fo, "tenant-dup", func(_ context.Context, _ eventstream.DomainEvent) error {
+		return nil
+	})
+	defer cancel1()
 
-	// First subscription (runs until replaced)
-	go func() {
-		_ = fo.Subscribe(ctx, "tenant-dup", func(_ context.Context, _ eventstream.DomainEvent) error {
-			firstReceived <- struct{}{}
-			return nil
-		})
-	}()
+	var secondReceived atomic.Bool
 
-	time.Sleep(10 * time.Millisecond)
-
-	// Second subscription replaces the first
-	go func() {
-		_ = fo.Subscribe(ctx, "tenant-dup", func(_ context.Context, _ eventstream.DomainEvent) error {
-			secondReceived <- struct{}{}
-			return nil
-		})
-	}()
-
-	time.Sleep(10 * time.Millisecond)
+	// Second subscription replaces the first via a new context.
+	cancel2, _ := subscribeReady(t, fo, "tenant-dup", func(_ context.Context, _ eventstream.DomainEvent) error {
+		secondReceived.Store(true)
+		return nil
+	})
+	defer cancel2()
 
 	require.NoError(t, fo.Publish(context.Background(), makeEvent("tenant-dup")))
 
-	select {
-	case <-secondReceived:
-		// second handler received the event - correct
-	case <-time.After(time.Second):
-		t.Fatal("second subscriber did not receive event")
-	}
+	err := await.New().
+		AtMost(time.Second).
+		Until(func() bool { return secondReceived.Load() })
+	require.NoError(t, err, "second subscriber should have received the event")
 }
 
 // TestLocalFanOut_ConcurrentSubscribeUnsubscribePublish verifies that the
@@ -363,7 +398,7 @@ func TestLocalFanOut_ConcurrentSubscribeUnsubscribePublish(t *testing.T) {
 		}()
 	}
 
-	// Let everything run, then cancel to unblock remaining subscribers
+	// Let everything run, then cancel to unblock remaining subscribers.
 	time.Sleep(100 * time.Millisecond)
 	cancel()
 	wg.Wait()


### PR DESCRIPTION
## Summary

- Adds `services/gateway/eventstream/adapters/LocalFanOut`, the default in-process `FanOut` implementation used when Redis is not configured.
- Each tenantID maps to a dedicated buffered channel; `Publish` routes events by `event.TenantID` (no separate caller-supplied key).
- `Publish` is non-blocking: events are dropped silently when the subscriber channel is full.
- A `sync.RWMutex` guards the subscriber map. `Publish` holds the read lock for the entire non-blocking channel send, preventing `Unsubscribe` from closing the channel mid-send.
- `Subscribe` blocks in an event loop until context cancellation or channel closure (caused by `Unsubscribe` or a replacement `Subscribe` for the same tenantID).

## Changes Made

- `services/gateway/eventstream/adapters/local_fanout.go` — `LocalFanOut` struct and `NewLocalFanOut` constructor implementing `eventstream.FanOut`.
- `services/gateway/eventstream/adapters/local_fanout_test.go` — 12 unit tests covering all specified behaviours.

## Technical Details

**Race-safe publish pattern**: The read lock is held for the full non-blocking send (not just the lookup), preventing a window where `Unsubscribe` closes the channel between the lookup and the send.

**Subscriber replacement**: When `Subscribe` is called for a tenantID that already has a registered handler, the existing channel is closed before the new channel is stored. The previous event loop goroutine observes the closed channel and returns `nil`.

## Testing

- `go test -race -count=5` passes cleanly across all 12 tests.
- Tests cover: empty-ID validation, event delivery, tenant isolation, buffer-full drop-without-block, context cancellation, unsubscribe stops delivery, subscriber replacement, and concurrent subscribe/unsubscribe/publish under the race detector.

## Risk Assessment

Low. `LocalFanOut` is a new, self-contained type with no dependencies on existing production code paths. It implements an existing interface; callers must explicitly wire it in.

## Deployment Notes

No configuration changes required. `LocalFanOut` is opt-in via dependency injection in the gateway composition root.