### PR TITLE
feat: Implement RedisFanOut adapter

### DIFF
--- a/services/gateway/eventstream/adapters/redis_fanout.go
+++ b/services/gateway/eventstream/adapters/redis_fanout.go
@@ -31,7 +31,7 @@ type RedisFanOut struct {
 	client        *redis.Client
 	subscriptions map[string]*subscription
 	logger        *slog.Logger
-	mu            sync.RWMutex
+	mu            sync.Mutex
 }
 
 // Compile-time interface compliance check.

--- a/services/gateway/eventstream/adapters/redis_fanout.go
+++ b/services/gateway/eventstream/adapters/redis_fanout.go
@@ -24,7 +24,7 @@ type subscription struct {
 
 // RedisFanOut implements eventstream.FanOut using Redis pub/sub.
 // Each tenant is assigned a dedicated channel: meridian:events:{tenant_id}.
-// Events are JSON-marshaled before publishing and unmarshaled on receipt.
+// Events are JSON-marshaled on publish and unmarshaled on receipt.
 //
 // Implementations are safe for concurrent use from multiple goroutines.
 type RedisFanOut struct {
@@ -88,39 +88,44 @@ func (f *RedisFanOut) Subscribe(ctx context.Context, tenantID string, handler ev
 	}
 
 	subCtx, cancel := context.WithCancel(ctx)
-	f.subscriptions[tenantID] = &subscription{
+	sub := &subscription{
 		cancel:  cancel,
 		handler: handler,
 	}
+	f.subscriptions[tenantID] = sub
 	f.mu.Unlock()
 
 	ch := channel(tenantID)
 	pubsub := f.client.Subscribe(subCtx, ch)
 
-	go f.receiveLoop(subCtx, tenantID, pubsub, handler)
+	// Wait for Redis to acknowledge the subscription before returning.
+	// This prevents messages published immediately after Subscribe from being lost.
+	if _, err := pubsub.Receive(subCtx); err != nil {
+		cancel()
+		_ = pubsub.Close()
+		f.mu.Lock()
+		if cur, ok := f.subscriptions[tenantID]; ok && cur == sub {
+			delete(f.subscriptions, tenantID)
+		}
+		f.mu.Unlock()
+		return fmt.Errorf("redis subscribe to %s: %w", ch, err)
+	}
+
+	go f.receiveLoop(subCtx, tenantID, pubsub, sub)
 
 	f.logger.Debug("subscribed", "tenant_id", tenantID, "channel", ch)
 	return nil
 }
 
 // receiveLoop processes messages from the Redis pub/sub channel until the context is done.
-// On exit it closes the pubsub subscription and removes the entry from the subscription map.
-func (f *RedisFanOut) receiveLoop(ctx context.Context, tenantID string, pubsub *redis.PubSub, handler eventstream.EventHandler) {
+// On exit it closes the pubsub subscription and removes the entry from the subscription map,
+// but only if the map entry still points to this subscription (identity check).
+func (f *RedisFanOut) receiveLoop(ctx context.Context, tenantID string, pubsub *redis.PubSub, sub *subscription) {
 	defer func() {
 		_ = pubsub.Close()
-		// Clean up the subscription map entry only if it still points to this subscription
-		// (a Replace may have already installed a new one).
 		f.mu.Lock()
-		if sub, ok := f.subscriptions[tenantID]; ok {
-			// Compare by checking whether the context is the one we own.
-			// The simplest safe check: if context is done, remove the entry.
-			select {
-			case <-ctx.Done():
-				delete(f.subscriptions, tenantID)
-			default:
-				// A new subscription replaced us; leave the map alone.
-				_ = sub
-			}
+		if cur, ok := f.subscriptions[tenantID]; ok && cur == sub {
+			delete(f.subscriptions, tenantID)
 		}
 		f.mu.Unlock()
 
@@ -136,7 +141,7 @@ func (f *RedisFanOut) receiveLoop(ctx context.Context, tenantID string, pubsub *
 			if !ok {
 				return
 			}
-			f.handleMessage(ctx, tenantID, msg.Payload, handler)
+			f.handleMessage(ctx, tenantID, msg.Payload, sub.handler)
 		}
 	}
 }

--- a/services/gateway/eventstream/adapters/redis_fanout.go
+++ b/services/gateway/eventstream/adapters/redis_fanout.go
@@ -4,6 +4,7 @@ package adapters
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -15,6 +16,9 @@ import (
 
 // channelPrefix is the Redis pub/sub channel namespace for tenant events.
 const channelPrefix = "meridian:events:"
+
+// ErrNilHandler is returned by Subscribe when a nil handler is provided.
+var ErrNilHandler = errors.New("handler cannot be nil")
 
 // subscription holds the state for a single tenant subscription.
 type subscription struct {
@@ -76,9 +80,13 @@ func (f *RedisFanOut) Publish(ctx context.Context, event eventstream.DomainEvent
 // If a subscription already exists for tenantID, it is replaced (the prior
 // subscription's goroutine is stopped before the new one starts).
 // Returns eventstream.ErrEmptyTenantID if tenantID is empty.
+// Returns ErrNilHandler if handler is nil.
 func (f *RedisFanOut) Subscribe(ctx context.Context, tenantID string, handler eventstream.EventHandler) error {
 	if tenantID == "" {
 		return eventstream.ErrEmptyTenantID
+	}
+	if handler == nil {
+		return ErrNilHandler
 	}
 
 	// Cancel any existing subscription for this tenant.

--- a/services/gateway/eventstream/adapters/redis_fanout.go
+++ b/services/gateway/eventstream/adapters/redis_fanout.go
@@ -1,0 +1,177 @@
+// Package adapters provides infrastructure adapters for the eventstream ports.
+package adapters
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/meridianhub/meridian/services/gateway/eventstream"
+)
+
+// channelPrefix is the Redis pub/sub channel namespace for tenant events.
+const channelPrefix = "meridian:events:"
+
+// subscription holds the state for a single tenant subscription.
+type subscription struct {
+	cancel  context.CancelFunc
+	handler eventstream.EventHandler
+}
+
+// RedisFanOut implements eventstream.FanOut using Redis pub/sub.
+// Each tenant is assigned a dedicated channel: meridian:events:{tenant_id}.
+// Events are JSON-marshaled before publishing and unmarshaled on receipt.
+//
+// Implementations are safe for concurrent use from multiple goroutines.
+type RedisFanOut struct {
+	client        *redis.Client
+	subscriptions map[string]*subscription
+	logger        *slog.Logger
+	mu            sync.RWMutex
+}
+
+// Compile-time interface compliance check.
+var _ eventstream.FanOut = (*RedisFanOut)(nil)
+
+// NewRedisFanOut creates a new RedisFanOut backed by the provided Redis client.
+func NewRedisFanOut(client *redis.Client, logger *slog.Logger) *RedisFanOut {
+	return &RedisFanOut{
+		client:        client,
+		subscriptions: make(map[string]*subscription),
+		logger:        logger,
+	}
+}
+
+// channel returns the Redis pub/sub channel name for a tenant.
+func channel(tenantID string) string {
+	return channelPrefix + tenantID
+}
+
+// Publish marshals event to JSON and publishes it to the tenant's Redis pub/sub channel.
+// Returns eventstream.ErrEmptyTenantID if event.TenantID is empty.
+func (f *RedisFanOut) Publish(ctx context.Context, event eventstream.DomainEvent) error {
+	if event.TenantID == "" {
+		return eventstream.ErrEmptyTenantID
+	}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal event: %w", err)
+	}
+
+	ch := channel(event.TenantID)
+	if err := f.client.Publish(ctx, ch, data).Err(); err != nil {
+		return fmt.Errorf("redis publish to %s: %w", ch, err)
+	}
+
+	f.logger.Debug("published event", "tenant_id", event.TenantID, "event_id", event.EventID, "channel", ch)
+	return nil
+}
+
+// Subscribe registers handler to receive events for tenantID via Redis pub/sub.
+// If a subscription already exists for tenantID, it is replaced (the prior
+// subscription's goroutine is stopped before the new one starts).
+// Returns eventstream.ErrEmptyTenantID if tenantID is empty.
+func (f *RedisFanOut) Subscribe(ctx context.Context, tenantID string, handler eventstream.EventHandler) error {
+	if tenantID == "" {
+		return eventstream.ErrEmptyTenantID
+	}
+
+	// Cancel any existing subscription for this tenant.
+	f.mu.Lock()
+	if existing, ok := f.subscriptions[tenantID]; ok {
+		existing.cancel()
+	}
+
+	subCtx, cancel := context.WithCancel(ctx)
+	f.subscriptions[tenantID] = &subscription{
+		cancel:  cancel,
+		handler: handler,
+	}
+	f.mu.Unlock()
+
+	ch := channel(tenantID)
+	pubsub := f.client.Subscribe(subCtx, ch)
+
+	go f.receiveLoop(subCtx, tenantID, pubsub, handler)
+
+	f.logger.Debug("subscribed", "tenant_id", tenantID, "channel", ch)
+	return nil
+}
+
+// receiveLoop processes messages from the Redis pub/sub channel until the context is done.
+// On exit it closes the pubsub subscription and removes the entry from the subscription map.
+func (f *RedisFanOut) receiveLoop(ctx context.Context, tenantID string, pubsub *redis.PubSub, handler eventstream.EventHandler) {
+	defer func() {
+		_ = pubsub.Close()
+		// Clean up the subscription map entry only if it still points to this subscription
+		// (a Replace may have already installed a new one).
+		f.mu.Lock()
+		if sub, ok := f.subscriptions[tenantID]; ok {
+			// Compare by checking whether the context is the one we own.
+			// The simplest safe check: if context is done, remove the entry.
+			select {
+			case <-ctx.Done():
+				delete(f.subscriptions, tenantID)
+			default:
+				// A new subscription replaced us; leave the map alone.
+				_ = sub
+			}
+		}
+		f.mu.Unlock()
+
+		f.logger.Debug("subscription stopped", "tenant_id", tenantID)
+	}()
+
+	msgCh := pubsub.Channel()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-msgCh:
+			if !ok {
+				return
+			}
+			f.handleMessage(ctx, tenantID, msg.Payload, handler)
+		}
+	}
+}
+
+// handleMessage unmarshals a Redis pub/sub message and invokes the handler.
+func (f *RedisFanOut) handleMessage(ctx context.Context, tenantID, payload string, handler eventstream.EventHandler) {
+	var event eventstream.DomainEvent
+	if err := json.Unmarshal([]byte(payload), &event); err != nil {
+		f.logger.Error("failed to unmarshal event", "tenant_id", tenantID, "error", err)
+		return
+	}
+
+	if err := handler(ctx, event); err != nil {
+		f.logger.Error("event handler returned error", "tenant_id", tenantID, "event_id", event.EventID, "error", err)
+	}
+}
+
+// Unsubscribe removes the handler registered for tenantID and stops the subscription goroutine.
+// It is not an error to call Unsubscribe for a tenantID with no active subscription.
+// Returns eventstream.ErrEmptyTenantID if tenantID is empty.
+func (f *RedisFanOut) Unsubscribe(_ context.Context, tenantID string) error {
+	if tenantID == "" {
+		return eventstream.ErrEmptyTenantID
+	}
+
+	f.mu.Lock()
+	sub, ok := f.subscriptions[tenantID]
+	if ok {
+		sub.cancel()
+		delete(f.subscriptions, tenantID)
+	}
+	f.mu.Unlock()
+
+	if ok {
+		f.logger.Debug("unsubscribed", "tenant_id", tenantID)
+	}
+	return nil
+}

--- a/services/gateway/eventstream/adapters/redis_fanout_test.go
+++ b/services/gateway/eventstream/adapters/redis_fanout_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/meridianhub/meridian/services/gateway/eventstream"
 	"github.com/meridianhub/meridian/services/gateway/eventstream/adapters"
+	"github.com/meridianhub/meridian/shared/platform/await"
 )
 
 func setupMiniredis(t *testing.T) (*miniredis.Miniredis, *redis.Client) {
@@ -101,17 +102,14 @@ func TestRedisFanOut_PubSub_Flow(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	// Subscribe first
+	// Subscribe first; Subscribe blocks until Redis acknowledges the subscription.
 	err := fanOut.Subscribe(ctx, tenantID, func(_ context.Context, event eventstream.DomainEvent) error {
 		received <- event
 		return nil
 	})
 	require.NoError(t, err)
 
-	// Give subscription goroutine time to start
-	time.Sleep(50 * time.Millisecond)
-
-	// Publish an event
+	// Publish an event - subscription is confirmed so no missed messages.
 	evt := newTestEvent(tenantID)
 	err = fanOut.Publish(context.Background(), evt)
 	require.NoError(t, err)
@@ -153,14 +151,16 @@ func TestRedisFanOut_Subscribe_ReplacesExistingHandler(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	time.Sleep(50 * time.Millisecond)
-
 	// Publish
 	evt := newTestEvent(tenantID)
 	err = fanOut.Publish(context.Background(), evt)
 	require.NoError(t, err)
 
-	time.Sleep(100 * time.Millisecond)
+	// Wait until the second handler has received the event.
+	err = await.AtMost(3 * time.Second).Until(func() bool {
+		return secondCount.Load() == 1
+	})
+	require.NoError(t, err, "timed out waiting for second handler to receive event")
 
 	// Only second handler should be active
 	assert.Equal(t, int32(0), firstCount.Load(), "first handler should not receive events after replacement")
@@ -183,21 +183,23 @@ func TestRedisFanOut_Unsubscribe_StopsDelivery(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	time.Sleep(50 * time.Millisecond)
-
 	// Unsubscribe
 	err = fanOut.Unsubscribe(ctx, tenantID)
 	require.NoError(t, err)
 
-	time.Sleep(50 * time.Millisecond)
-
-	// Publish after unsubscribe
+	// Publish after unsubscribe; count should stay 0.
 	evt := newTestEvent(tenantID)
 	err = fanOut.Publish(ctx, evt)
 	require.NoError(t, err)
 
-	time.Sleep(100 * time.Millisecond)
-
+	// Allow a brief window for any stray delivery.
+	err = await.AtMost(300 * time.Millisecond).
+		PollInterval(10 * time.Millisecond).
+		Until(func() bool {
+			// We expect zero events; we wait the full window.
+			return false
+		})
+	assert.ErrorIs(t, err, await.ErrTimeout, "expected timeout (no events delivered)")
 	assert.Equal(t, int32(0), count.Load(), "handler should not receive events after unsubscribe")
 }
 
@@ -223,14 +225,16 @@ func TestRedisFanOut_TenantIsolation(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	time.Sleep(50 * time.Millisecond)
-
 	// Publish to tenant-A only
 	evt := newTestEvent("tenant-A")
 	err = fanOut.Publish(ctx, evt)
 	require.NoError(t, err)
 
-	time.Sleep(100 * time.Millisecond)
+	// Wait for tenant-A to receive the event
+	err = await.AtMost(3 * time.Second).Until(func() bool {
+		return countA.Load() == 1
+	})
+	require.NoError(t, err, "timed out waiting for tenant-A handler")
 
 	assert.Equal(t, int32(1), countA.Load(), "tenant-A handler should receive 1 event")
 	assert.Equal(t, int32(0), countB.Load(), "tenant-B handler should not receive tenant-A events")
@@ -250,15 +254,11 @@ func TestRedisFanOut_ContextCancellation_StopsSubscription(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	time.Sleep(50 * time.Millisecond)
-
 	// Cancel context
 	cancel()
 
-	time.Sleep(100 * time.Millisecond)
-
-	// After context cancel, the subscription map entry should be cleaned up
-	// We verify by checking that unsubscribing is a no-op (no double-cancel)
+	// After context cancel, the subscription map entry should be cleaned up.
+	// We verify by checking that unsubscribing is a no-op (no double-cancel).
 	err = fanOut.Unsubscribe(context.Background(), tenantID)
 	assert.NoError(t, err)
 }
@@ -281,8 +281,6 @@ func TestRedisFanOut_ConcurrentPublish(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	time.Sleep(50 * time.Millisecond)
-
 	var wg sync.WaitGroup
 	for i := 0; i < numEvents; i++ {
 		wg.Add(1)
@@ -295,13 +293,10 @@ func TestRedisFanOut_ConcurrentPublish(t *testing.T) {
 	wg.Wait()
 
 	// Wait for all deliveries
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		if count.Load() == numEvents {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
+	err = await.AtMost(5 * time.Second).Until(func() bool {
+		return count.Load() == numEvents
+	})
+	require.NoError(t, err, "timed out waiting for all events to be delivered")
 
 	assert.Equal(t, int32(numEvents), count.Load())
 }

--- a/services/gateway/eventstream/adapters/redis_fanout_test.go
+++ b/services/gateway/eventstream/adapters/redis_fanout_test.go
@@ -1,0 +1,307 @@
+package adapters_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/gateway/eventstream"
+	"github.com/meridianhub/meridian/services/gateway/eventstream/adapters"
+)
+
+func setupMiniredis(t *testing.T) (*miniredis.Miniredis, *redis.Client) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+	return mr, client
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func newTestEvent(tenantID string) eventstream.DomainEvent {
+	evt, err := eventstream.NewDomainEvent(
+		"payment_order.created.v1",
+		"payment_order.v1",
+		"agg-001",
+		"PaymentOrder",
+		tenantID,
+		"corr-001",
+		"cause-001",
+		[]byte(`{"amount":"100.00"}`),
+	)
+	if err != nil {
+		panic(err)
+	}
+	return evt
+}
+
+// TestRedisFanOut_Publish_EmptyTenantID verifies that publishing with an empty TenantID returns ErrEmptyTenantID.
+func TestRedisFanOut_Publish_EmptyTenantID(t *testing.T) {
+	_, client := setupMiniredis(t)
+	fanOut := adapters.NewRedisFanOut(client, testLogger())
+
+	evt := eventstream.DomainEvent{TenantID: ""}
+	err := fanOut.Publish(context.Background(), evt)
+	assert.ErrorIs(t, err, eventstream.ErrEmptyTenantID)
+}
+
+// TestRedisFanOut_Subscribe_EmptyTenantID verifies that subscribing with an empty tenantID returns ErrEmptyTenantID.
+func TestRedisFanOut_Subscribe_EmptyTenantID(t *testing.T) {
+	_, client := setupMiniredis(t)
+	fanOut := adapters.NewRedisFanOut(client, testLogger())
+
+	err := fanOut.Subscribe(context.Background(), "", func(_ context.Context, _ eventstream.DomainEvent) error {
+		return nil
+	})
+	assert.ErrorIs(t, err, eventstream.ErrEmptyTenantID)
+}
+
+// TestRedisFanOut_Unsubscribe_EmptyTenantID verifies that unsubscribing with an empty tenantID returns ErrEmptyTenantID.
+func TestRedisFanOut_Unsubscribe_EmptyTenantID(t *testing.T) {
+	_, client := setupMiniredis(t)
+	fanOut := adapters.NewRedisFanOut(client, testLogger())
+
+	err := fanOut.Unsubscribe(context.Background(), "")
+	assert.ErrorIs(t, err, eventstream.ErrEmptyTenantID)
+}
+
+// TestRedisFanOut_Unsubscribe_NotSubscribed verifies that unsubscribing a tenant with no subscription is not an error.
+func TestRedisFanOut_Unsubscribe_NotSubscribed(t *testing.T) {
+	_, client := setupMiniredis(t)
+	fanOut := adapters.NewRedisFanOut(client, testLogger())
+
+	err := fanOut.Unsubscribe(context.Background(), "tenant-999")
+	assert.NoError(t, err)
+}
+
+// TestRedisFanOut_PubSub_Flow verifies publish → subscribe → handler delivery.
+func TestRedisFanOut_PubSub_Flow(t *testing.T) {
+	_, client := setupMiniredis(t)
+	fanOut := adapters.NewRedisFanOut(client, testLogger())
+
+	tenantID := "tenant-abc"
+	received := make(chan eventstream.DomainEvent, 1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Subscribe first
+	err := fanOut.Subscribe(ctx, tenantID, func(_ context.Context, event eventstream.DomainEvent) error {
+		received <- event
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Give subscription goroutine time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish an event
+	evt := newTestEvent(tenantID)
+	err = fanOut.Publish(context.Background(), evt)
+	require.NoError(t, err)
+
+	// Verify delivery
+	select {
+	case got := <-received:
+		assert.Equal(t, evt.EventID, got.EventID)
+		assert.Equal(t, evt.TenantID, got.TenantID)
+		assert.Equal(t, evt.EventType, got.EventType)
+		assert.Equal(t, string(evt.Payload), string(got.Payload))
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for event delivery")
+	}
+}
+
+// TestRedisFanOut_Subscribe_ReplacesExistingHandler verifies that re-subscribing replaces the handler.
+func TestRedisFanOut_Subscribe_ReplacesExistingHandler(t *testing.T) {
+	_, client := setupMiniredis(t)
+	fanOut := adapters.NewRedisFanOut(client, testLogger())
+
+	tenantID := "tenant-replace"
+	var firstCount, secondCount atomic.Int32
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Subscribe with first handler
+	err := fanOut.Subscribe(ctx, tenantID, func(_ context.Context, _ eventstream.DomainEvent) error {
+		firstCount.Add(1)
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Replace with second handler
+	err = fanOut.Subscribe(ctx, tenantID, func(_ context.Context, _ eventstream.DomainEvent) error {
+		secondCount.Add(1)
+		return nil
+	})
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish
+	evt := newTestEvent(tenantID)
+	err = fanOut.Publish(context.Background(), evt)
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Only second handler should be active
+	assert.Equal(t, int32(0), firstCount.Load(), "first handler should not receive events after replacement")
+	assert.Equal(t, int32(1), secondCount.Load(), "second handler should receive the event")
+}
+
+// TestRedisFanOut_Unsubscribe_StopsDelivery verifies that after unsubscribing, events are no longer delivered.
+func TestRedisFanOut_Unsubscribe_StopsDelivery(t *testing.T) {
+	_, client := setupMiniredis(t)
+	fanOut := adapters.NewRedisFanOut(client, testLogger())
+
+	tenantID := "tenant-unsub"
+	var count atomic.Int32
+
+	ctx := context.Background()
+
+	err := fanOut.Subscribe(ctx, tenantID, func(_ context.Context, _ eventstream.DomainEvent) error {
+		count.Add(1)
+		return nil
+	})
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Unsubscribe
+	err = fanOut.Unsubscribe(ctx, tenantID)
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish after unsubscribe
+	evt := newTestEvent(tenantID)
+	err = fanOut.Publish(ctx, evt)
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, int32(0), count.Load(), "handler should not receive events after unsubscribe")
+}
+
+// TestRedisFanOut_TenantIsolation verifies events are only delivered to matching tenant.
+func TestRedisFanOut_TenantIsolation(t *testing.T) {
+	_, client := setupMiniredis(t)
+	fanOut := adapters.NewRedisFanOut(client, testLogger())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var countA, countB atomic.Int32
+
+	err := fanOut.Subscribe(ctx, "tenant-A", func(_ context.Context, _ eventstream.DomainEvent) error {
+		countA.Add(1)
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = fanOut.Subscribe(ctx, "tenant-B", func(_ context.Context, _ eventstream.DomainEvent) error {
+		countB.Add(1)
+		return nil
+	})
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish to tenant-A only
+	evt := newTestEvent("tenant-A")
+	err = fanOut.Publish(ctx, evt)
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, int32(1), countA.Load(), "tenant-A handler should receive 1 event")
+	assert.Equal(t, int32(0), countB.Load(), "tenant-B handler should not receive tenant-A events")
+}
+
+// TestRedisFanOut_ContextCancellation_StopsSubscription verifies subscription goroutine exits when context is cancelled.
+func TestRedisFanOut_ContextCancellation_StopsSubscription(t *testing.T) {
+	_, client := setupMiniredis(t)
+	fanOut := adapters.NewRedisFanOut(client, testLogger())
+
+	tenantID := "tenant-ctx-cancel"
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	err := fanOut.Subscribe(ctx, tenantID, func(_ context.Context, _ eventstream.DomainEvent) error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel context
+	cancel()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// After context cancel, the subscription map entry should be cleaned up
+	// We verify by checking that unsubscribing is a no-op (no double-cancel)
+	err = fanOut.Unsubscribe(context.Background(), tenantID)
+	assert.NoError(t, err)
+}
+
+// TestRedisFanOut_ConcurrentPublish verifies concurrent publishes are handled correctly.
+func TestRedisFanOut_ConcurrentPublish(t *testing.T) {
+	_, client := setupMiniredis(t)
+	fanOut := adapters.NewRedisFanOut(client, testLogger())
+
+	tenantID := "tenant-concurrent"
+	var count atomic.Int32
+	const numEvents = 20
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := fanOut.Subscribe(ctx, tenantID, func(_ context.Context, _ eventstream.DomainEvent) error {
+		count.Add(1)
+		return nil
+	})
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	var wg sync.WaitGroup
+	for i := 0; i < numEvents; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			evt := newTestEvent(tenantID)
+			_ = fanOut.Publish(context.Background(), evt)
+		}()
+	}
+	wg.Wait()
+
+	// Wait for all deliveries
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if count.Load() == numEvents {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	assert.Equal(t, int32(numEvents), count.Load())
+}

--- a/services/gateway/eventstream/adapters/redis_fanout_test.go
+++ b/services/gateway/eventstream/adapters/redis_fanout_test.go
@@ -73,6 +73,15 @@ func TestRedisFanOut_Subscribe_EmptyTenantID(t *testing.T) {
 	assert.ErrorIs(t, err, eventstream.ErrEmptyTenantID)
 }
 
+// TestRedisFanOut_Subscribe_NilHandler verifies that subscribing with a nil handler returns ErrNilHandler.
+func TestRedisFanOut_Subscribe_NilHandler(t *testing.T) {
+	_, client := setupMiniredis(t)
+	fanOut := adapters.NewRedisFanOut(client, testLogger())
+
+	err := fanOut.Subscribe(context.Background(), "tenant-123", nil)
+	assert.ErrorIs(t, err, adapters.ErrNilHandler)
+}
+
 // TestRedisFanOut_Unsubscribe_EmptyTenantID verifies that unsubscribing with an empty tenantID returns ErrEmptyTenantID.
 func TestRedisFanOut_Unsubscribe_EmptyTenantID(t *testing.T) {
 	_, client := setupMiniredis(t)


### PR DESCRIPTION
## Summary

- Implements the `FanOut` port interface (`eventstream.FanOut`) using Redis pub/sub
- Each tenant is assigned a dedicated channel: `meridian:events:{tenant_id}`
- Events are JSON-marshaled on publish and unmarshaled on receipt
- Safe for concurrent use from multiple goroutines

## Changes Made

**New file: `services/gateway/eventstream/adapters/redis_fanout.go`**
- `RedisFanOut` struct backed by `*redis.Client` (go-redis/v9)
- `Publish`: validates non-empty `TenantID`, marshals to JSON, publishes to per-tenant Redis channel
- `Subscribe`: creates a Redis pub/sub subscription goroutine per tenant; replaces existing handler if present
- `Unsubscribe`: cancels subscription context and removes entry from map; no-op if not subscribed
- Subscription goroutine cleans itself up on context cancellation

**New file: `services/gateway/eventstream/adapters/redis_fanout_test.go`**
- Uses `miniredis` (consistent with existing test patterns in the codebase)
- Tests: empty tenant ID validation for all three methods, pub/sub flow, handler replacement, tenant isolation, unsubscribe stops delivery, context cancellation, concurrent publishes

## Technical Details

Channel naming: `meridian:events:{tenant_id}`

The subscription lifecycle:
1. `Subscribe` cancels any existing subscription for the tenant, creates a new context, starts a goroutine
2. The goroutine reads from `pubsub.Channel()` and dispatches to the handler
3. On context cancellation (from `Unsubscribe` or parent context), goroutine exits and removes the map entry

## Testing

All 9 unit tests pass using miniredis (in-process Redis, consistent with codebase convention):
- `TestRedisFanOut_Publish_EmptyTenantID`
- `TestRedisFanOut_Subscribe_EmptyTenantID`
- `TestRedisFanOut_Unsubscribe_EmptyTenantID`
- `TestRedisFanOut_Unsubscribe_NotSubscribed`
- `TestRedisFanOut_PubSub_Flow`
- `TestRedisFanOut_Subscribe_ReplacesExistingHandler`
- `TestRedisFanOut_Unsubscribe_StopsDelivery`
- `TestRedisFanOut_TenantIsolation`
- `TestRedisFanOut_ContextCancellation_StopsSubscription`
- `TestRedisFanOut_ConcurrentPublish`

## Risk Assessment

Low risk: new package with no modifications to existing code. The adapter is not yet wired into the service startup (`main.go`), so it has no production impact until a subsequent task integrates it.

## Deployment Notes

No migration or configuration changes required. The Redis client is already provisioned in the gateway service (`cmd/main.go`).

Implements task 025-real-time-event-streaming.10.