### PR TITLE
feat: Implement KafkaEventSource adapter

### DIFF
--- a/services/gateway/eventstream/adapters/kafka_source.go
+++ b/services/gateway/eventstream/adapters/kafka_source.go
@@ -77,7 +77,16 @@ func NewKafkaEventSource(
 		logger = slog.Default()
 	}
 
-	brokers := strings.Split(bootstrapServers, ",")
+	rawBrokers := strings.Split(bootstrapServers, ",")
+	brokers := make([]string, 0, len(rawBrokers))
+	for _, b := range rawBrokers {
+		if b = strings.TrimSpace(b); b != "" {
+			brokers = append(brokers, b)
+		}
+	}
+	if len(brokers) == 0 {
+		return nil, ErrEmptyBootstrapServers
+	}
 
 	opts := []kgo.Opt{
 		kgo.SeedBrokers(brokers...),
@@ -182,7 +191,10 @@ func (s *KafkaEventSource) recordToDomainEvent(record *kgo.Record) (eventstream.
 		ts = time.Now().UTC()
 	}
 
-	channel, _ := eventstream.DeriveChannel(record.Topic)
+	channel, err := eventstream.DeriveChannel(record.Topic)
+	if err != nil {
+		return eventstream.DomainEvent{}, fmt.Errorf("failed to derive channel from topic %q: %w", record.Topic, err)
+	}
 
 	// Build the event ID from the header if present; otherwise leave it for
 	// NewDomainEvent to generate a fresh UUID via NewDomainEvent.

--- a/services/gateway/eventstream/adapters/kafka_source.go
+++ b/services/gateway/eventstream/adapters/kafka_source.go
@@ -1,0 +1,252 @@
+// Package adapters provides EventSource adapters for the gateway event streaming pipeline.
+package adapters
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/meridianhub/meridian/services/gateway/eventstream"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// Kafka header key constants for event metadata.
+const (
+	headerEventID       = "event_id"
+	headerEventType     = "event_type"
+	headerAggregateType = "aggregate_type"
+	headerAggregateID   = "aggregate_id"
+	headerCorrelationID = "correlation_id"
+	headerCausationID   = "causation_id"
+
+	consumerGroupID = "ops-console-events"
+)
+
+// Sentinel errors returned by KafkaEventSource constructors.
+var (
+	// ErrEmptyBootstrapServers is returned when bootstrapServers is empty.
+	ErrEmptyBootstrapServers = errors.New("bootstrapServers cannot be empty")
+
+	// ErrEmptyTopics is returned when the topics slice is empty.
+	ErrEmptyTopics = errors.New("topics cannot be empty")
+
+	// ErrMissingEventTypeHeader is returned when the event_type header is absent.
+	ErrMissingEventTypeHeader = errors.New("missing required header \"event_type\"")
+
+	// ErrMissingHeader is returned when a required Kafka record header is absent.
+	ErrMissingHeader = errors.New("required header not found")
+)
+
+// KafkaEventSource implements EventSource by consuming from one or more Kafka topics.
+// It uses a dedicated consumer group ("ops-console-events") and starts consuming
+// from the latest offset so only events produced after startup are delivered.
+//
+// Payload conversion: protobuf bytes are JSON-encoded using base64 when the raw bytes
+// are not valid JSON (binary protobuf), or passed through verbatim when already JSON.
+// This keeps the gateway format-agnostic while preserving the payload faithfully.
+type KafkaEventSource struct {
+	client *kgo.Client
+	topics []string
+	logger *slog.Logger
+}
+
+// NewKafkaEventSource creates a KafkaEventSource that consumes the given topics from
+// the specified bootstrap servers. The consumer group is fixed to "ops-console-events"
+// and offsets start at the end so only new events are delivered to gateway clients.
+//
+// Returns an error if bootstrapServers is empty, topics is empty, or the underlying
+// Kafka client cannot be initialized.
+func NewKafkaEventSource(
+	bootstrapServers string,
+	topics []string,
+	logger *slog.Logger,
+) (*KafkaEventSource, error) {
+	if bootstrapServers == "" {
+		return nil, ErrEmptyBootstrapServers
+	}
+	if len(topics) == 0 {
+		return nil, ErrEmptyTopics
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	brokers := strings.Split(bootstrapServers, ",")
+
+	opts := []kgo.Opt{
+		kgo.SeedBrokers(brokers...),
+		kgo.ConsumerGroup(consumerGroupID),
+		kgo.ConsumeTopics(topics...),
+		kgo.ConsumeResetOffset(kgo.NewOffset().AtEnd()),
+		kgo.BlockRebalanceOnPoll(),
+	}
+
+	client, err := kgo.NewClient(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kafka client: %w", err)
+	}
+
+	return &KafkaEventSource{
+		client: client,
+		topics: topics,
+		logger: logger,
+	}, nil
+}
+
+// Start consumes events from the configured Kafka topics and delivers each one to handler.
+// It blocks until ctx is cancelled or a fatal error occurs. On context cancellation it
+// flushes pending work, closes the client, and returns nil.
+//
+// handler is called synchronously in the poll goroutine. Handlers that are slow should
+// dispatch work asynchronously to avoid blocking the consumer loop.
+func (s *KafkaEventSource) Start(ctx context.Context, handler eventstream.EventHandler) error {
+	defer s.client.Close()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		fetches := s.client.PollFetches(ctx)
+
+		if errs := fetches.Errors(); len(errs) > 0 {
+			for _, fe := range errs {
+				if errors.Is(fe.Err, context.Canceled) || errors.Is(fe.Err, context.DeadlineExceeded) {
+					continue
+				}
+				s.logger.Warn("kafka fetch error",
+					"topic", fe.Topic,
+					"partition", fe.Partition,
+					"error", fe.Err)
+			}
+		}
+
+		fetches.EachRecord(func(record *kgo.Record) {
+			event, err := s.recordToDomainEvent(record)
+			if err != nil {
+				s.logger.Error("failed to convert kafka record to domain event",
+					"topic", record.Topic,
+					"partition", record.Partition,
+					"offset", record.Offset,
+					"error", err)
+				return
+			}
+
+			if err := handler(ctx, event); err != nil {
+				s.logger.Error("event handler error",
+					"topic", record.Topic,
+					"event_id", event.EventID,
+					"event_type", event.EventType,
+					"error", err)
+			}
+		})
+
+		s.client.AllowRebalance()
+	}
+}
+
+// recordToDomainEvent converts a raw Kafka record to a DomainEvent by:
+//  1. Extracting the tenant ID from the "x-tenant-id" header.
+//  2. Extracting event metadata from well-known headers.
+//  3. Converting the protobuf payload to a JSON-safe representation.
+func (s *KafkaEventSource) recordToDomainEvent(record *kgo.Record) (eventstream.DomainEvent, error) {
+	// Extract tenant ID — required for downstream routing.
+	tenantID, err := extractHeader(record, tenant.TenantIDKey)
+	if err != nil {
+		return eventstream.DomainEvent{}, fmt.Errorf("missing required header %q: %w", tenant.TenantIDKey, err)
+	}
+
+	eventType := extractHeaderValue(record, headerEventType)
+	if eventType == "" {
+		return eventstream.DomainEvent{}, ErrMissingEventTypeHeader
+	}
+
+	eventID := extractHeaderValue(record, headerEventID)
+	aggregateType := extractHeaderValue(record, headerAggregateType)
+	aggregateID := extractHeaderValue(record, headerAggregateID)
+	correlationID := extractHeaderValue(record, headerCorrelationID)
+	causationID := extractHeaderValue(record, headerCausationID)
+
+	payload := encodePayload(record.Value)
+
+	ts := record.Timestamp
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+
+	channel, _ := eventstream.DeriveChannel(record.Topic)
+
+	// Build the event ID from the header if present; otherwise leave it for
+	// NewDomainEvent to generate a fresh UUID via NewDomainEvent.
+	// We prefer the original event_id from the producer for idempotency.
+	event, err := eventstream.NewDomainEvent(
+		eventType,
+		record.Topic,
+		aggregateID,
+		aggregateType,
+		tenantID,
+		correlationID,
+		causationID,
+		payload,
+	)
+	if err != nil {
+		return eventstream.DomainEvent{}, fmt.Errorf("failed to build domain event: %w", err)
+	}
+
+	// Override EventID and Channel with values from the record.
+	// NewDomainEvent generates a new UUID; we want the producer's original ID.
+	if eventID != "" {
+		event.EventID = eventID
+	}
+	event.Channel = channel
+	event.Timestamp = ts.UTC()
+
+	return event, nil
+}
+
+// extractHeader returns the value of the first header matching key, or ErrMissingHeader if absent.
+func extractHeader(record *kgo.Record, key string) (string, error) {
+	v := extractHeaderValue(record, key)
+	if v == "" {
+		return "", fmt.Errorf("%w: %q", ErrMissingHeader, key)
+	}
+	return v, nil
+}
+
+// extractHeaderValue returns the value of the first header matching key, or "" if absent.
+func extractHeaderValue(record *kgo.Record, key string) string {
+	for _, h := range record.Headers {
+		if h.Key == key {
+			return string(h.Value)
+		}
+	}
+	return ""
+}
+
+// encodePayload converts raw bytes to a JSON-safe representation.
+// If the bytes are valid JSON they are embedded verbatim; otherwise they are
+// base64-encoded and wrapped in a JSON string to preserve the binary content.
+func encodePayload(raw []byte) []byte {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	// If already valid JSON, embed as-is (services that serialize to JSON directly).
+	if json.Valid(raw) {
+		return raw
+	}
+
+	// Binary protobuf: encode as base64 JSON string so the gateway can forward
+	// without losing data. Clients that understand the proto schema can decode.
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	quoted, _ := json.Marshal(encoded)
+	return quoted
+}

--- a/services/gateway/eventstream/adapters/kafka_source_test.go
+++ b/services/gateway/eventstream/adapters/kafka_source_test.go
@@ -1,0 +1,509 @@
+package adapters
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/gateway/eventstream"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/testcontainers/testcontainers-go/modules/kafka"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// ─── unit tests ────────────────────────────────────────────────────────────────
+
+func TestNewKafkaEventSource_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		brokers string
+		topics  []string
+		wantErr bool
+	}{
+		{
+			name:    "empty bootstrap servers",
+			brokers: "",
+			topics:  []string{"t.v1"},
+			wantErr: true,
+		},
+		{
+			name:    "empty topics",
+			brokers: "localhost:9092",
+			topics:  []string{},
+			wantErr: true,
+		},
+		{
+			name:    "nil topics",
+			brokers: "localhost:9092",
+			topics:  nil,
+			wantErr: true,
+		},
+		{
+			name:    "valid args creates client without error",
+			brokers: "localhost:9092",
+			topics:  []string{"events.v1"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src, err := NewKafkaEventSource(tt.brokers, tt.topics, nil)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewKafkaEventSource() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if src != nil {
+				// Close immediately to release resources.
+				src.client.Close()
+			}
+		})
+	}
+}
+
+func TestExtractHeaderValue(t *testing.T) {
+	record := &kgo.Record{
+		Headers: []kgo.RecordHeader{
+			{Key: "a", Value: []byte("v-a")},
+			{Key: "b", Value: []byte("v-b")},
+		},
+	}
+
+	if got := extractHeaderValue(record, "a"); got != "v-a" {
+		t.Errorf("extractHeaderValue(a) = %q, want %q", got, "v-a")
+	}
+	if got := extractHeaderValue(record, "b"); got != "v-b" {
+		t.Errorf("extractHeaderValue(b) = %q, want %q", got, "v-b")
+	}
+	if got := extractHeaderValue(record, "missing"); got != "" {
+		t.Errorf("extractHeaderValue(missing) = %q, want %q", got, "")
+	}
+}
+
+func TestExtractHeader_Missing(t *testing.T) {
+	record := &kgo.Record{}
+	_, err := extractHeader(record, "not-there")
+	if err == nil {
+		t.Fatal("expected error for missing header")
+	}
+}
+
+func TestEncodePayload(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		if got := encodePayload(nil); got != nil {
+			t.Fatalf("encodePayload(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("empty input returns nil", func(t *testing.T) {
+		if got := encodePayload([]byte{}); got != nil {
+			t.Fatalf("encodePayload([]) = %v, want nil", got)
+		}
+	})
+
+	t.Run("valid JSON passes through verbatim", func(t *testing.T) {
+		input := []byte(`{"foo":"bar"}`)
+		got := encodePayload(input)
+		if string(got) != string(input) {
+			t.Fatalf("encodePayload(%q) = %q, want %q", input, got, input)
+		}
+	})
+
+	t.Run("binary bytes are base64-encoded JSON string", func(t *testing.T) {
+		// Simulate binary protobuf: non-JSON bytes.
+		input := []byte{0x0a, 0x05, 0x68, 0x65, 0x6c, 0x6c, 0x6f}
+		got := encodePayload(input)
+
+		// Must be valid JSON.
+		if !json.Valid(got) {
+			t.Fatalf("encodePayload returned invalid JSON: %s", got)
+		}
+
+		// Unwrap the JSON string to recover the base64 value.
+		var encoded string
+		if err := json.Unmarshal(got, &encoded); err != nil {
+			t.Fatalf("json.Unmarshal: %v", err)
+		}
+
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			t.Fatalf("base64.Decode: %v", err)
+		}
+		if string(decoded) != string(input) {
+			t.Fatalf("round-trip mismatch: got %v, want %v", decoded, input)
+		}
+	})
+}
+
+func TestRecordToDomainEvent(t *testing.T) {
+	src := &KafkaEventSource{logger: newDiscardLogger()}
+
+	t.Run("happy path", func(t *testing.T) {
+		payload := []byte(`{"amount":"100.00"}`)
+		record := &kgo.Record{
+			Topic:     "payment-order.created.v1",
+			Timestamp: time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC),
+			Value:     payload,
+			Headers: []kgo.RecordHeader{
+				{Key: tenant.TenantIDKey, Value: []byte("acme_bank")},
+				{Key: "event_id", Value: []byte("evt-123")},
+				{Key: "event_type", Value: []byte("payment_order.created.v1")},
+				{Key: "aggregate_type", Value: []byte("PaymentOrder")},
+				{Key: "aggregate_id", Value: []byte("po-456")},
+				{Key: "correlation_id", Value: []byte("corr-789")},
+				{Key: "causation_id", Value: []byte("cause-000")},
+			},
+		}
+
+		event, err := src.recordToDomainEvent(record)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assertString(t, "EventID", event.EventID, "evt-123")
+		assertString(t, "EventType", event.EventType, "payment_order.created.v1")
+		assertString(t, "Topic", event.Topic, "payment-order.created.v1")
+		assertString(t, "Channel", event.Channel, "payment-order.created")
+		assertString(t, "AggregateType", event.AggregateType, "PaymentOrder")
+		assertString(t, "AggregateID", event.AggregateID, "po-456")
+		assertString(t, "TenantID", event.TenantID, "acme_bank")
+		assertString(t, "CorrelationID", event.CorrelationID, "corr-789")
+		assertString(t, "CausationID", event.CausationID, "cause-000")
+
+		if !event.Timestamp.Equal(record.Timestamp.UTC()) {
+			t.Errorf("Timestamp = %v, want %v", event.Timestamp, record.Timestamp.UTC())
+		}
+
+		if string(event.Payload) != string(payload) {
+			t.Errorf("Payload = %q, want %q", event.Payload, payload)
+		}
+	})
+
+	t.Run("missing tenant header returns error", func(t *testing.T) {
+		record := &kgo.Record{
+			Topic: "events.v1",
+			Headers: []kgo.RecordHeader{
+				{Key: "event_type", Value: []byte("some.event")},
+			},
+		}
+		_, err := src.recordToDomainEvent(record)
+		if err == nil {
+			t.Fatal("expected error for missing tenant header")
+		}
+	})
+
+	t.Run("missing event_type header returns error", func(t *testing.T) {
+		record := &kgo.Record{
+			Topic: "events.v1",
+			Headers: []kgo.RecordHeader{
+				{Key: tenant.TenantIDKey, Value: []byte("acme_bank")},
+			},
+		}
+		_, err := src.recordToDomainEvent(record)
+		if err == nil {
+			t.Fatal("expected error for missing event_type header")
+		}
+	})
+
+	t.Run("zero timestamp defaults to now", func(t *testing.T) {
+		before := time.Now().UTC().Add(-time.Second)
+		record := &kgo.Record{
+			Topic:     "events.v1",
+			Timestamp: time.Time{}, // zero
+			Headers: []kgo.RecordHeader{
+				{Key: tenant.TenantIDKey, Value: []byte("acme_bank")},
+				{Key: "event_type", Value: []byte("some.event")},
+			},
+		}
+
+		event, err := src.recordToDomainEvent(record)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if event.Timestamp.Before(before) {
+			t.Errorf("Timestamp %v is before test start %v", event.Timestamp, before)
+		}
+	})
+
+	t.Run("no event_id header generates uuid", func(t *testing.T) {
+		record := &kgo.Record{
+			Topic: "events.v1",
+			Headers: []kgo.RecordHeader{
+				{Key: tenant.TenantIDKey, Value: []byte("acme_bank")},
+				{Key: "event_type", Value: []byte("some.event")},
+				// no event_id header
+			},
+		}
+
+		event, err := src.recordToDomainEvent(record)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if event.EventID == "" {
+			t.Error("EventID should not be empty when header is absent")
+		}
+	})
+
+	t.Run("binary protobuf payload is base64 encoded", func(t *testing.T) {
+		binaryPayload := []byte{0x0a, 0x05, 0x68, 0x65, 0x6c, 0x6c, 0x6f}
+		record := &kgo.Record{
+			Topic: "events.v1",
+			Value: binaryPayload,
+			Headers: []kgo.RecordHeader{
+				{Key: tenant.TenantIDKey, Value: []byte("acme_bank")},
+				{Key: "event_type", Value: []byte("some.event")},
+			},
+		}
+
+		event, err := src.recordToDomainEvent(record)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !json.Valid(event.Payload) {
+			t.Errorf("Payload is not valid JSON: %s", event.Payload)
+		}
+	})
+}
+
+// ─── integration tests (require Kafka testcontainer) ───────────────────────────
+
+func TestKafkaEventSource_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Kafka integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	kafkaContainer, err := kafka.Run(ctx,
+		"confluentinc/confluent-local:7.5.0",
+		kafka.WithClusterID("test-cluster"),
+	)
+	if err != nil {
+		t.Fatalf("failed to start Kafka container: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := kafkaContainer.Terminate(ctx); err != nil {
+			t.Logf("failed to terminate Kafka container: %v", err)
+		}
+	})
+
+	brokers, err := kafkaContainer.Brokers(ctx)
+	if err != nil {
+		t.Fatalf("failed to get brokers: %v", err)
+	}
+
+	const topic = "test-events.v1"
+	brokerAddr := brokers[0]
+
+	// Create topics before tests run so producers don't get UNKNOWN_TOPIC_OR_PARTITION.
+	mustCreateTopics(t, ctx, brokerAddr, topic, "test-cg-events.v1")
+
+	t.Run("publishes event to handler and derives channel", func(t *testing.T) {
+		src, err := NewKafkaEventSource(brokerAddr, []string{topic}, newDiscardLogger())
+		if err != nil {
+			t.Fatalf("NewKafkaEventSource: %v", err)
+		}
+
+		// Produce a test record before starting the consumer (source starts at latest).
+		producer, err := kgo.NewClient(kgo.SeedBrokers(brokerAddr))
+		if err != nil {
+			t.Fatalf("failed to create producer: %v", err)
+		}
+		defer producer.Close()
+
+		// Give the consumer group a chance to join before we produce.
+		consumeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+
+		received := make(chan eventstream.DomainEvent, 1)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := src.Start(consumeCtx, func(_ context.Context, ev eventstream.DomainEvent) error {
+				select {
+				case received <- ev:
+				default:
+				}
+				return nil
+			})
+			if err != nil && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+				t.Errorf("Start returned unexpected error: %v", err)
+			}
+		}()
+
+		// Brief pause to let the consumer join the group and reach the end offset.
+		time.Sleep(2 * time.Second)
+
+		// Produce a record now that the consumer is at the end.
+		record := &kgo.Record{
+			Topic: topic,
+			Value: []byte(`{"amount":"99.00"}`),
+			Headers: []kgo.RecordHeader{
+				{Key: tenant.TenantIDKey, Value: []byte("acme_bank")},
+				{Key: "event_id", Value: []byte("evt-integration-1")},
+				{Key: "event_type", Value: []byte("test.created.v1")},
+				{Key: "aggregate_type", Value: []byte("Test")},
+				{Key: "aggregate_id", Value: []byte("test-agg-1")},
+			},
+		}
+		results := producer.ProduceSync(ctx, record)
+		if err := results.FirstErr(); err != nil {
+			t.Fatalf("ProduceSync: %v", err)
+		}
+
+		// Wait for the event to arrive.
+		select {
+		case ev := <-received:
+			assertString(t, "EventID", ev.EventID, "evt-integration-1")
+			assertString(t, "TenantID", ev.TenantID, "acme_bank")
+			assertString(t, "Topic", ev.Topic, topic)
+			assertString(t, "Channel", ev.Channel, "test-events")
+			if !json.Valid(ev.Payload) {
+				t.Errorf("Payload is not valid JSON: %s", ev.Payload)
+			}
+		case <-consumeCtx.Done():
+			t.Fatal("timed out waiting for event")
+		}
+
+		cancel()
+		wg.Wait()
+	})
+
+	t.Run("graceful shutdown on context cancel", func(t *testing.T) {
+		src, err := NewKafkaEventSource(brokerAddr, []string{topic}, newDiscardLogger())
+		if err != nil {
+			t.Fatalf("NewKafkaEventSource: %v", err)
+		}
+
+		ctx2, cancel2 := context.WithCancel(ctx)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- src.Start(ctx2, func(_ context.Context, _ eventstream.DomainEvent) error {
+				return nil
+			})
+		}()
+
+		// Let it run briefly then cancel.
+		time.Sleep(200 * time.Millisecond)
+		cancel2()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("Start returned non-nil error after cancel: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("Start did not return after context cancel")
+		}
+	})
+
+	t.Run("consumer group management — second consumer sees same events", func(t *testing.T) {
+		const topic2 = "test-cg-events.v1"
+
+		// Produce one record to the topic before consumers join.
+		producer, err := kgo.NewClient(kgo.SeedBrokers(brokerAddr))
+		if err != nil {
+			t.Fatalf("producer: %v", err)
+		}
+		defer producer.Close()
+
+		// Both sources share the same consumer group; each will get a partition subset.
+		src1, err := NewKafkaEventSource(brokerAddr, []string{topic2}, newDiscardLogger())
+		if err != nil {
+			t.Fatalf("src1: %v", err)
+		}
+		src2, err := NewKafkaEventSource(brokerAddr, []string{topic2}, newDiscardLogger())
+		if err != nil {
+			t.Fatalf("src2: %v", err)
+		}
+
+		ctx3, cancel3 := context.WithTimeout(ctx, 20*time.Second)
+		defer cancel3()
+
+		received := make(chan struct{}, 2)
+		handler := func(_ context.Context, _ eventstream.DomainEvent) error {
+			received <- struct{}{}
+			return nil
+		}
+
+		var wg2 sync.WaitGroup
+		wg2.Add(2)
+		go func() { defer wg2.Done(); _ = src1.Start(ctx3, handler) }()
+		go func() { defer wg2.Done(); _ = src2.Start(ctx3, handler) }()
+
+		// Give both consumers time to join the group and reach the end.
+		time.Sleep(3 * time.Second)
+
+		// Produce a record — only one consumer will receive it (partition assignment).
+		r := &kgo.Record{
+			Topic: topic2,
+			Value: []byte(`{}`),
+			Headers: []kgo.RecordHeader{
+				{Key: tenant.TenantIDKey, Value: []byte("tenant_a")},
+				{Key: "event_type", Value: []byte("cg.test.v1")},
+			},
+		}
+		if err := producer.ProduceSync(ctx, r).FirstErr(); err != nil {
+			t.Fatalf("ProduceSync: %v", err)
+		}
+
+		select {
+		case <-received:
+			// At least one consumer received the event — group is working.
+		case <-ctx3.Done():
+			t.Fatal("timed out: no consumer received the event")
+		}
+
+		cancel3()
+		wg2.Wait()
+	})
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────────────
+
+func assertString(t *testing.T, field, got, want string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s = %q, want %q", field, got, want)
+	}
+}
+
+func newDiscardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// mustCreateTopics creates the given topics in the Kafka broker using kadm,
+// failing the test if any creation fails (ignoring "topic already exists" errors).
+func mustCreateTopics(t *testing.T, ctx context.Context, broker string, topics ...string) {
+	t.Helper()
+
+	client, err := kgo.NewClient(kgo.SeedBrokers(broker))
+	if err != nil {
+		t.Fatalf("mustCreateTopics: failed to create kgo client: %v", err)
+	}
+	defer client.Close()
+
+	admin := kadm.NewClient(client)
+	resp, err := admin.CreateTopics(ctx, 1, 1, nil, topics...)
+	if err != nil {
+		t.Fatalf("mustCreateTopics: CreateTopics failed: %v", err)
+	}
+	for _, tr := range resp {
+		if tr.Err != nil {
+			// "topic already exists" is fine.
+			if tr.ErrMessage == "Topic already exists." {
+				continue
+			}
+			t.Fatalf("mustCreateTopics: error for topic %q: %v (%s)", tr.Topic, tr.Err, tr.ErrMessage)
+		}
+	}
+}

--- a/services/gateway/eventstream/adapters/kafka_source_test.go
+++ b/services/gateway/eventstream/adapters/kafka_source_test.go
@@ -61,7 +61,7 @@ func TestNewKafkaEventSource_Validation(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("NewKafkaEventSource() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if src != nil {
+			if src != nil && src.client != nil {
 				// Close immediately to release resources.
 				src.client.Close()
 			}
@@ -298,6 +298,9 @@ func TestKafkaEventSource_Integration(t *testing.T) {
 	brokers, err := kafkaContainer.Brokers(ctx)
 	if err != nil {
 		t.Fatalf("failed to get brokers: %v", err)
+	}
+	if len(brokers) == 0 {
+		t.Fatal("kafka container returned no brokers")
 	}
 
 	const topic = "test-events.v1"

--- a/services/gateway/eventstream/adapters/kafka_source_test.go
+++ b/services/gateway/eventstream/adapters/kafka_source_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"sync"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/meridianhub/meridian/services/gateway/eventstream"
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/testcontainers/testcontainers-go/modules/kafka"
 	"github.com/twmb/franz-go/pkg/kadm"
@@ -339,8 +341,15 @@ func TestKafkaEventSource_Integration(t *testing.T) {
 			}
 		}()
 
-		// Brief pause to let the consumer join the group and reach the end offset.
-		time.Sleep(2 * time.Second)
+		// Poll until the consumer group has at least one active member.
+		if err := await.New().
+			AtMost(10 * time.Second).
+			PollInterval(200 * time.Millisecond).
+			UntilNoError(func() error {
+				return consumerGroupActive(ctx, brokerAddr, consumerGroupID)
+			}); err != nil {
+			t.Fatalf("consumer group did not become active: %v", err)
+		}
 
 		// Produce a record now that the consumer is at the end.
 		record := &kgo.Record{
@@ -392,8 +401,15 @@ func TestKafkaEventSource_Integration(t *testing.T) {
 			})
 		}()
 
-		// Let it run briefly then cancel.
-		time.Sleep(200 * time.Millisecond)
+		// Wait for the consumer to start polling before cancelling.
+		if err := await.New().
+			AtMost(5 * time.Second).
+			PollInterval(100 * time.Millisecond).
+			UntilNoError(func() error {
+				return consumerGroupActive(ctx, brokerAddr, consumerGroupID)
+			}); err != nil {
+			t.Logf("consumer group may not be fully active: %v (continuing)", err)
+		}
 		cancel2()
 
 		select {
@@ -440,8 +456,15 @@ func TestKafkaEventSource_Integration(t *testing.T) {
 		go func() { defer wg2.Done(); _ = src1.Start(ctx3, handler) }()
 		go func() { defer wg2.Done(); _ = src2.Start(ctx3, handler) }()
 
-		// Give both consumers time to join the group and reach the end.
-		time.Sleep(3 * time.Second)
+		// Poll until at least one consumer has joined the group.
+		if err := await.New().
+			AtMost(15 * time.Second).
+			PollInterval(200 * time.Millisecond).
+			UntilNoError(func() error {
+				return consumerGroupActive(ctx3, brokerAddr, consumerGroupID)
+			}); err != nil {
+			t.Fatalf("consumer group did not become active: %v", err)
+		}
 
 		// Produce a record — only one consumer will receive it (partition assignment).
 		r := &kgo.Record{
@@ -479,6 +502,28 @@ func assertString(t *testing.T, field, got, want string) {
 
 func newDiscardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// consumerGroupActive returns nil when the ops-console-events consumer group has at
+// least one active member, or a non-nil error if it is empty or does not exist.
+// Used with await.UntilNoError to replace time.Sleep in integration tests.
+func consumerGroupActive(ctx context.Context, broker, groupID string) error {
+	client, err := kgo.NewClient(kgo.SeedBrokers(broker))
+	if err != nil {
+		return fmt.Errorf("create client: %w", err)
+	}
+	defer client.Close()
+
+	admin := kadm.NewClient(client)
+	described, err := admin.DescribeGroups(ctx, groupID)
+	if err != nil {
+		return fmt.Errorf("describe groups: %w", err)
+	}
+	grp, ok := described[groupID]
+	if !ok || grp.Err != nil || len(grp.Members) == 0 {
+		return fmt.Errorf("group %q has no active members", groupID)
+	}
+	return nil
 }
 
 // mustCreateTopics creates the given topics in the Kafka broker using kadm,


### PR DESCRIPTION
## Summary

- Add `services/gateway/eventstream/adapters/kafka_source.go` implementing the `EventSource` port interface
- Uses franz-go (`twmb/franz-go/pkg/kgo`) with consumer group `ops-console-events` starting at latest offset
- Extracts tenant ID from `x-tenant-id` header and event metadata (`event_id`, `event_type`, `aggregate_type`, `aggregate_id`, `correlation_id`, `causation_id`) from Kafka record headers
- Converts payloads to JSON: valid JSON passes through verbatim; binary protobuf is base64-encoded as a JSON string to preserve binary content without losing data
- Derives the logical channel from the topic using `eventstream.DeriveChannel` (strips `.vN` suffixes)

## Changes Made

- `services/gateway/eventstream/adapters/kafka_source.go` — `KafkaEventSource` struct, `NewKafkaEventSource` constructor, `Start` consumer loop, `recordToDomainEvent` conversion, payload encoding helpers
- `services/gateway/eventstream/adapters/kafka_source_test.go` — unit tests for validation, header extraction, payload encoding, and record conversion; integration tests with Kafka testcontainer

## Technical Details

- Consumer group: `ops-console-events` (fixed, not configurable — gateway always uses this group)
- Offset strategy: `AtEnd` — only new events produced after startup are delivered
- Graceful shutdown: `Start` returns `nil` when context is cancelled; `client.Close()` is called via `defer`
- Payload encoding: `encodePayload` first checks `json.Valid`; if false, base64-encodes and wraps in a JSON string literal

## Testing

- Unit tests (no external dependencies): `TestNewKafkaEventSource_Validation`, `TestExtractHeaderValue`, `TestExtractHeader_Missing`, `TestEncodePayload`, `TestRecordToDomainEvent` — all passing
- Integration tests with Kafka testcontainer (`confluentinc/confluent-local:7.5.0`): event delivery + channel derivation, graceful shutdown, consumer group management — all passing
- Run with `go test -short` to skip integration tests, or without `-short` for full coverage

## Task

025-real-time-event-streaming.9