### PR TITLE
feat: Implement OutboxEventSource adapter

### DIFF
--- a/services/gateway/eventstream/adapters/outbox_source.go
+++ b/services/gateway/eventstream/adapters/outbox_source.go
@@ -1,0 +1,229 @@
+// Package adapters provides concrete implementations of the eventstream ports.
+//
+// ADR-0002 constraint: The OutboxEventSource adapter is for dev/CI mode only.
+// Cross-service database access is forbidden in production. This adapter reads
+// event_outbox tables from a shared CockroachDB instance, which is only available
+// in local/dev/CI environments where all services share a single database.
+// Production deployments MUST use the KafkaEventSource adapter instead.
+package adapters
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/gateway/eventstream"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"gorm.io/gorm"
+)
+
+const (
+	// DefaultPollInterval is the default interval between outbox polls.
+	DefaultPollInterval = 500 * time.Millisecond
+
+	// DefaultBatchSize is the default maximum number of entries fetched per poll.
+	DefaultBatchSize = 100
+)
+
+// OutboxEventSource polls the event_outbox table for completed entries and
+// delivers them to the event streaming pipeline. It implements EventSource
+// using high-water mark tracking per service to avoid duplicate delivery.
+//
+// This adapter is intended for dev/CI mode only (KAFKA_ENABLED=false).
+// See ADR-0002 for the constraint on cross-service database access.
+type OutboxEventSource struct {
+	db           *gorm.DB
+	pollInterval time.Duration
+	batchSize    int
+	logger       *slog.Logger
+
+	mu            sync.Mutex
+	highWaterMark map[string]waterMark // service -> last seen position
+}
+
+// waterMark tracks the last processed position for a service's outbox entries.
+// Using both time and ID avoids reprocessing when multiple entries share the
+// same created_at timestamp.
+type waterMark struct {
+	createdAt time.Time
+	id        uuid.UUID
+}
+
+// NewOutboxEventSource constructs an OutboxEventSource with the given database
+// connection and options. The logger must not be nil.
+func NewOutboxEventSource(
+	db *gorm.DB,
+	pollInterval time.Duration,
+	logger *slog.Logger,
+) *OutboxEventSource {
+	if pollInterval <= 0 {
+		pollInterval = DefaultPollInterval
+	}
+	return &OutboxEventSource{
+		db:            db,
+		pollInterval:  pollInterval,
+		batchSize:     DefaultBatchSize,
+		logger:        logger,
+		highWaterMark: make(map[string]waterMark),
+	}
+}
+
+// WithBatchSize sets the maximum number of outbox entries fetched per poll cycle.
+// Returns the receiver for method chaining.
+func (s *OutboxEventSource) WithBatchSize(n int) *OutboxEventSource {
+	if n > 0 {
+		s.batchSize = n
+	}
+	return s
+}
+
+// Start begins polling the event_outbox table at the configured interval,
+// delivering each completed entry to handler as a DomainEvent.
+//
+// Start blocks until ctx is cancelled, then returns nil. Handler errors are
+// logged but do not stop the polling loop.
+func (s *OutboxEventSource) Start(ctx context.Context, handler eventstream.EventHandler) error {
+	s.logger.Info("outbox event source starting",
+		"poll_interval", s.pollInterval,
+		"batch_size", s.batchSize,
+	)
+
+	ticker := time.NewTicker(s.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Info("outbox event source stopped")
+			return nil
+		case <-ticker.C:
+			if err := s.pollEvents(ctx, handler); err != nil {
+				s.logger.Warn("outbox poll error", "error", err)
+			}
+		}
+	}
+}
+
+// pollEvents queries the event_outbox table for completed entries that have not
+// yet been seen (based on the per-service high-water mark) and calls handler
+// for each one.
+func (s *OutboxEventSource) pollEvents(ctx context.Context, handler eventstream.EventHandler) error {
+	// Snapshot the current high-water marks under the lock so we can release
+	// the lock before issuing the (potentially slow) database query.
+	s.mu.Lock()
+	hwm := make(map[string]waterMark, len(s.highWaterMark))
+	for k, v := range s.highWaterMark {
+		hwm[k] = v
+	}
+	s.mu.Unlock()
+
+	// Fetch completed outbox entries ordered by (created_at, id) so delivery
+	// is deterministic and the high-water mark advances monotonically.
+	//
+	// We use a single query across all services. Per-service high-water mark
+	// filtering happens in application code after fetching because CockroachDB
+	// cannot efficiently express "WHERE (service_name, created_at) > (?, ?)"
+	// across multiple services in a single parameterised query.
+	var entries []events.EventOutbox
+	if err := s.db.WithContext(ctx).
+		Where("status = ?", events.StatusCompleted).
+		Order("created_at ASC, id ASC").
+		Limit(s.batchSize).
+		Find(&entries).Error; err != nil {
+		return err
+	}
+
+	if len(entries) == 0 {
+		return nil
+	}
+
+	// Track the new high-water marks accumulated during this batch before
+	// invoking any handlers so that a handler error does not prevent the mark
+	// from advancing on the next poll.
+	newMarks := make(map[string]waterMark)
+
+	for _, entry := range entries {
+		mark, seen := hwm[entry.ServiceName]
+		if seen {
+			// Skip entries at or before the high-water mark for this service.
+			if entry.CreatedAt.Before(mark.createdAt) ||
+				(entry.CreatedAt.Equal(mark.createdAt) && entry.ID == mark.id) {
+				continue
+			}
+			// Same timestamp but different ID — only skip if we've already
+			// advanced past this ID. UUIDs are not monotonic so we skip any ID
+			// equal to the last seen one; entries with a greater created_at always pass.
+		}
+
+		event := s.outboxToDomainEvent(entry)
+
+		if err := handler(ctx, event); err != nil {
+			s.logger.Error("event handler error",
+				"error", err,
+				"outbox_id", entry.ID,
+				"event_type", entry.EventType,
+				"service", entry.ServiceName,
+			)
+			// Do not advance the high-water mark for this service on error;
+			// the next poll will retry from the same position.
+			continue
+		}
+
+		// Advance the high-water mark for this service.
+		newMarks[entry.ServiceName] = waterMark{
+			createdAt: entry.CreatedAt,
+			id:        entry.ID,
+		}
+	}
+
+	// Commit the new high-water marks under the lock.
+	if len(newMarks) > 0 {
+		s.mu.Lock()
+		for svc, mark := range newMarks {
+			current, exists := s.highWaterMark[svc]
+			if !exists || mark.createdAt.After(current.createdAt) ||
+				(mark.createdAt.Equal(current.createdAt) && mark.id != current.id) {
+				s.highWaterMark[svc] = mark
+			}
+		}
+		s.mu.Unlock()
+	}
+
+	return nil
+}
+
+// outboxToDomainEvent converts an EventOutbox entry to a DomainEvent.
+//
+// Note: EventOutbox does not carry a TenantID field. In dev/CI mode all
+// services share a single CockroachDB instance and tenant context is not
+// stored directly in the outbox. TenantID is left empty; callers that require
+// tenant-scoped delivery must populate it from the payload or application context.
+// This is an acceptable limitation for the dev/CI adapter.
+func (s *OutboxEventSource) outboxToDomainEvent(entry events.EventOutbox) eventstream.DomainEvent {
+	channel, err := eventstream.DeriveChannel(entry.Topic)
+	if err != nil {
+		// DeriveChannel only errors on empty topic; Topic is required by the
+		// outbox schema, so this path is unreachable in practice.
+		s.logger.Warn("outbox entry has empty topic, using event_type as channel",
+			"outbox_id", entry.ID,
+			"event_type", entry.EventType,
+		)
+		channel = entry.EventType
+	}
+
+	return eventstream.DomainEvent{
+		EventID:       entry.ID.String(),
+		EventType:     entry.EventType,
+		Topic:         entry.Topic,
+		Channel:       channel,
+		AggregateID:   entry.AggregateID,
+		AggregateType: entry.AggregateType,
+		TenantID:      "", // Not stored in EventOutbox; see function comment.
+		CorrelationID: entry.CorrelationID,
+		CausationID:   entry.CausationID,
+		Timestamp:     entry.CreatedAt.UTC(),
+		Payload:       entry.EventPayload,
+	}
+}

--- a/services/gateway/eventstream/adapters/outbox_source.go
+++ b/services/gateway/eventstream/adapters/outbox_source.go
@@ -125,13 +125,29 @@ func (s *OutboxEventSource) pollEvents(ctx context.Context, handler eventstream.
 	// Fetch completed outbox entries ordered by (created_at, id) so delivery
 	// is deterministic and the high-water mark advances monotonically.
 	//
-	// We use a single query across all services. Per-service high-water mark
-	// filtering happens in application code after fetching because CockroachDB
-	// cannot efficiently express "WHERE (service_name, created_at) > (?, ?)"
-	// across multiple services in a single parameterised query.
+	// We apply a global minimum HWM as a SQL lower bound so the query window
+	// advances as entries are processed. Without this, Limit(batchSize) would
+	// repeatedly fetch the same oldest rows once the table has more than
+	// batchSize completed entries, causing newer rows to be permanently
+	// unreachable.
+	//
+	// The minimum across all service HWMs is used rather than per-service
+	// bounds because CockroachDB cannot efficiently express
+	// "WHERE (service_name, created_at) > (?, ?)" across multiple services.
+	// In-memory per-service filtering below handles the fine-grained dedup.
+	query := s.db.WithContext(ctx).Where("status = ?", events.StatusCompleted)
+	if len(hwm) > 0 {
+		var minTime time.Time
+		for _, m := range hwm {
+			if minTime.IsZero() || m.createdAt.Before(minTime) {
+				minTime = m.createdAt
+			}
+		}
+		query = query.Where("created_at >= ?", minTime)
+	}
+
 	var entries []events.EventOutbox
-	if err := s.db.WithContext(ctx).
-		Where("status = ?", events.StatusCompleted).
+	if err := query.
 		Order("created_at ASC, id ASC").
 		Limit(s.batchSize).
 		Find(&entries).Error; err != nil {
@@ -142,12 +158,19 @@ func (s *OutboxEventSource) pollEvents(ctx context.Context, handler eventstream.
 		return nil
 	}
 
-	// Track the new high-water marks accumulated during this batch before
-	// invoking any handlers so that a handler error does not prevent the mark
-	// from advancing on the next poll.
+	// blocked tracks services where a handler error occurred in this batch.
+	// Once a service is blocked, remaining entries for that service are skipped
+	// so the high-water mark does not advance past the failed entry, preserving
+	// at-least-once retry semantics across polls.
+	blocked := make(map[string]struct{})
 	newMarks := make(map[string]waterMark)
 
 	for _, entry := range entries {
+		// Skip any further entries for a service that failed earlier in this batch.
+		if _, isBlocked := blocked[entry.ServiceName]; isBlocked {
+			continue
+		}
+
 		mark, seen := hwm[entry.ServiceName]
 		if seen {
 			// Skip entries at or before the high-water mark for this service.
@@ -173,8 +196,9 @@ func (s *OutboxEventSource) pollEvents(ctx context.Context, handler eventstream.
 				"event_type", entry.EventType,
 				"service", entry.ServiceName,
 			)
-			// Do not advance the high-water mark for this service on error;
-			// the next poll will retry from the same position.
+			// Block this service for the remainder of the batch so no later
+			// entries overwrite newMarks and skip past the failed position.
+			blocked[entry.ServiceName] = struct{}{}
 			continue
 		}
 

--- a/services/gateway/eventstream/adapters/outbox_source.go
+++ b/services/gateway/eventstream/adapters/outbox_source.go
@@ -52,12 +52,15 @@ type waterMark struct {
 }
 
 // NewOutboxEventSource constructs an OutboxEventSource with the given database
-// connection and options. The logger must not be nil.
+// connection and options. Panics if logger is nil.
 func NewOutboxEventSource(
 	db *gorm.DB,
 	pollInterval time.Duration,
 	logger *slog.Logger,
 ) *OutboxEventSource {
+	if logger == nil {
+		panic("outbox: logger must not be nil")
+	}
 	if pollInterval <= 0 {
 		pollInterval = DefaultPollInterval
 	}
@@ -148,13 +151,17 @@ func (s *OutboxEventSource) pollEvents(ctx context.Context, handler eventstream.
 		mark, seen := hwm[entry.ServiceName]
 		if seen {
 			// Skip entries at or before the high-water mark for this service.
-			if entry.CreatedAt.Before(mark.createdAt) ||
-				(entry.CreatedAt.Equal(mark.createdAt) && entry.ID == mark.id) {
+			// The query orders by (created_at ASC, id ASC). We use lexicographic
+			// UUID string comparison for same-timestamp entries because UUIDs are
+			// not time-ordered, but the ORDER BY clause makes the sort stable and
+			// consistent across polls. Any entry whose (createdAt, id) position is
+			// at or before the mark has already been delivered.
+			if entry.CreatedAt.Before(mark.createdAt) {
 				continue
 			}
-			// Same timestamp but different ID — only skip if we've already
-			// advanced past this ID. UUIDs are not monotonic so we skip any ID
-			// equal to the last seen one; entries with a greater created_at always pass.
+			if entry.CreatedAt.Equal(mark.createdAt) && entry.ID.String() <= mark.id.String() {
+				continue
+			}
 		}
 
 		event := s.outboxToDomainEvent(entry)
@@ -179,12 +186,14 @@ func (s *OutboxEventSource) pollEvents(ctx context.Context, handler eventstream.
 	}
 
 	// Commit the new high-water marks under the lock.
+	// Use the same lexicographic UUID comparison as the skip logic above to
+	// ensure the mark only ever advances forward.
 	if len(newMarks) > 0 {
 		s.mu.Lock()
 		for svc, mark := range newMarks {
 			current, exists := s.highWaterMark[svc]
 			if !exists || mark.createdAt.After(current.createdAt) ||
-				(mark.createdAt.Equal(current.createdAt) && mark.id != current.id) {
+				(mark.createdAt.Equal(current.createdAt) && mark.id.String() > current.id.String()) {
 				s.highWaterMark[svc] = mark
 			}
 		}

--- a/services/gateway/eventstream/adapters/outbox_source_test.go
+++ b/services/gateway/eventstream/adapters/outbox_source_test.go
@@ -216,6 +216,39 @@ func TestOutboxSource_HighWaterMark_PerServiceTracking(t *testing.T) {
 	assert.Equal(t, 1, received["svc-b.event.v1"], "service-b event delivered once")
 }
 
+func TestOutboxSource_HighWaterMark_SameTimestampNoDuplicates(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Insert 3 entries with the same created_at timestamp, simulating a bulk insert.
+	sameTime := time.Now().UTC().Add(-time.Second).Truncate(time.Millisecond)
+	for i := 0; i < 3; i++ {
+		e := newCompletedEntry("svc", "same-ts.event.v1", "svc.same-ts.v1")
+		e.CreatedAt = sameTime
+		insertOutboxEntry(t, db, e)
+	}
+
+	source := adapters.NewOutboxEventSource(db, 50*time.Millisecond, newTestLogger(t))
+
+	var mu sync.Mutex
+	var count int
+
+	// Run for enough time to allow multiple polls.
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+
+	_ = source.Start(ctx, func(_ context.Context, _ eventstream.DomainEvent) error {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		return nil
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 3, count, "all 3 same-timestamp entries should be delivered exactly once")
+}
+
 // --- Batch size limiting ---
 
 func TestOutboxSource_BatchSize_LimitsEntriesPerPoll(t *testing.T) {

--- a/services/gateway/eventstream/adapters/outbox_source_test.go
+++ b/services/gateway/eventstream/adapters/outbox_source_test.go
@@ -1,0 +1,364 @@
+package adapters_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/gateway/eventstream"
+	"github.com/meridianhub/meridian/services/gateway/eventstream/adapters"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func newTestLogger(t *testing.T) *slog.Logger {
+	t.Helper()
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// setupTestDB starts a CockroachDB testcontainer with the event_outbox schema.
+func setupTestDB(t *testing.T) (*gorm.DB, func()) {
+	t.Helper()
+	return testdb.SetupCockroachDB(t, []interface{}{&events.EventOutbox{}})
+}
+
+// insertOutboxEntry inserts an EventOutbox row directly for test setup.
+func insertOutboxEntry(t *testing.T, db *gorm.DB, entry events.EventOutbox) {
+	t.Helper()
+	if entry.ID == uuid.Nil {
+		entry.ID = uuid.New()
+	}
+	if entry.CreatedAt.IsZero() {
+		entry.CreatedAt = time.Now().UTC()
+	}
+	require.NoError(t, db.Create(&entry).Error)
+}
+
+func newCompletedEntry(serviceName, eventType, topic string) events.EventOutbox {
+	return events.EventOutbox{
+		ID:            uuid.New(),
+		EventType:     eventType,
+		AggregateID:   uuid.New().String(),
+		AggregateType: "TestAggregate",
+		EventPayload:  []byte(`{"test":"payload"}`),
+		Topic:         topic,
+		ServiceName:   serviceName,
+		Status:        events.StatusCompleted,
+		CreatedAt:     time.Now().UTC(),
+	}
+}
+
+// --- outboxToDomainEvent conversion ---
+
+func TestOutboxToDomainEvent_FieldMapping(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	payload := []byte(`{"amount":100}`)
+	entry := events.EventOutbox{
+		ID:            uuid.New(),
+		EventType:     "payment_order.reserved.v1",
+		AggregateID:   "agg-123",
+		AggregateType: "PaymentOrder",
+		EventPayload:  payload,
+		Topic:         "payment-order.reserved.v1",
+		ServiceName:   "payment-order",
+		CorrelationID: "corr-456",
+		CausationID:   "cause-789",
+		Status:        events.StatusCompleted,
+		CreatedAt:     time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC),
+	}
+	insertOutboxEntry(t, db, entry)
+
+	source := adapters.NewOutboxEventSource(db, 50*time.Millisecond, newTestLogger(t))
+
+	var received []eventstream.DomainEvent
+	var mu sync.Mutex
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	go func() {
+		_ = source.Start(ctx, func(_ context.Context, ev eventstream.DomainEvent) error {
+			mu.Lock()
+			received = append(received, ev)
+			mu.Unlock()
+			cancel() // stop after first event
+			return nil
+		})
+	}()
+
+	<-ctx.Done()
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Len(t, received, 1)
+	got := received[0]
+
+	assert.Equal(t, entry.ID.String(), got.EventID)
+	assert.Equal(t, "payment_order.reserved.v1", got.EventType)
+	assert.Equal(t, "payment-order.reserved.v1", got.Topic)
+	assert.Equal(t, "payment-order.reserved", got.Channel) // .v1 stripped
+	assert.Equal(t, "agg-123", got.AggregateID)
+	assert.Equal(t, "PaymentOrder", got.AggregateType)
+	assert.Equal(t, "corr-456", got.CorrelationID)
+	assert.Equal(t, "cause-789", got.CausationID)
+	assert.Equal(t, payload, got.Payload)
+	assert.Equal(t, entry.CreatedAt.UTC(), got.Timestamp)
+	assert.Empty(t, got.TenantID, "TenantID is not stored in EventOutbox")
+}
+
+func TestOutboxToDomainEvent_ChannelDerivation(t *testing.T) {
+	tests := []struct {
+		topic           string
+		expectedChannel string
+	}{
+		{"payment-order.reserved.v1", "payment-order.reserved"},
+		{"position-keeping.transaction-captured.v1", "position-keeping.transaction-captured"},
+		{"audit.events.current-account.v1", "audit.events.current-account"},
+		{"no-version-suffix", "no-version-suffix"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.topic, func(t *testing.T) {
+			entry := newCompletedEntry("svc", "evt.v1", tc.topic)
+			db2, cleanup2 := setupTestDB(t)
+			defer cleanup2()
+			insertOutboxEntry(t, db2, entry)
+
+			source := adapters.NewOutboxEventSource(db2, 50*time.Millisecond, newTestLogger(t))
+
+			var got eventstream.DomainEvent
+			var once sync.Once
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+
+			go func() {
+				_ = source.Start(ctx, func(_ context.Context, ev eventstream.DomainEvent) error {
+					once.Do(func() { got = ev; cancel() })
+					return nil
+				})
+			}()
+			<-ctx.Done()
+			assert.Equal(t, tc.expectedChannel, got.Channel)
+		})
+	}
+}
+
+// --- High-water mark deduplication ---
+
+func TestOutboxSource_HighWaterMark_PreventsDuplicateDelivery(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	entry := newCompletedEntry("position-keeping", "pk.transaction-captured.v1", "position-keeping.transaction-captured.v1")
+	insertOutboxEntry(t, db, entry)
+
+	source := adapters.NewOutboxEventSource(db, 50*time.Millisecond, newTestLogger(t))
+
+	var mu sync.Mutex
+	var count int
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	_ = source.Start(ctx, func(_ context.Context, _ eventstream.DomainEvent) error {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		return nil
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, count, "each outbox entry should be delivered exactly once")
+}
+
+func TestOutboxSource_HighWaterMark_PerServiceTracking(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Two entries from different services inserted at slightly different times.
+	base := time.Now().UTC().Add(-time.Second) // ensure they're in the past
+	entry1 := newCompletedEntry("service-a", "svc-a.event.v1", "service-a.event.v1")
+	entry1.CreatedAt = base
+	entry2 := newCompletedEntry("service-b", "svc-b.event.v1", "service-b.event.v1")
+	entry2.CreatedAt = base.Add(10 * time.Millisecond)
+
+	insertOutboxEntry(t, db, entry1)
+	insertOutboxEntry(t, db, entry2)
+
+	source := adapters.NewOutboxEventSource(db, 50*time.Millisecond, newTestLogger(t))
+
+	var mu sync.Mutex
+	received := make(map[string]int)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	_ = source.Start(ctx, func(_ context.Context, ev eventstream.DomainEvent) error {
+		mu.Lock()
+		received[ev.EventType]++
+		mu.Unlock()
+		return nil
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, received["svc-a.event.v1"], "service-a event delivered once")
+	assert.Equal(t, 1, received["svc-b.event.v1"], "service-b event delivered once")
+}
+
+// --- Batch size limiting ---
+
+func TestOutboxSource_BatchSize_LimitsEntriesPerPoll(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Insert 10 entries.
+	base := time.Now().UTC().Add(-10 * time.Second)
+	for i := 0; i < 10; i++ {
+		entry := newCompletedEntry("svc", "evt.v1", "svc.event.v1")
+		entry.CreatedAt = base.Add(time.Duration(i) * time.Millisecond)
+		insertOutboxEntry(t, db, entry)
+	}
+
+	var mu sync.Mutex
+	var count int
+
+	// Run a single poll by starting with a very short-lived context that expires
+	// after the first tick fires.
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	// Use a shorter poll interval so the first tick fires within the timeout.
+	sourceShort := adapters.NewOutboxEventSource(db, 50*time.Millisecond, newTestLogger(t)).
+		WithBatchSize(3)
+
+	_ = sourceShort.Start(ctx, func(_ context.Context, _ eventstream.DomainEvent) error {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		return nil
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	// After one poll cycle with batch 3, we expect exactly 3.
+	// The context expires after 150ms; with 50ms poll interval there may be up to 2 polls.
+	// We assert at most 6 (2 polls × 3) and at least 3.
+	assert.GreaterOrEqual(t, count, 3, "at least one batch of 3 should be delivered")
+	assert.LessOrEqual(t, count, 6, "at most 2 batch polls in 150ms window")
+}
+
+// --- Polling only completed entries ---
+
+func TestOutboxSource_OnlyDeliversCompletedEntries(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	completed := newCompletedEntry("svc", "completed.event.v1", "svc.completed.v1")
+	pending := newCompletedEntry("svc", "pending.event.v1", "svc.pending.v1")
+	pending.Status = events.StatusPending
+	processing := newCompletedEntry("svc", "processing.event.v1", "svc.processing.v1")
+	processing.Status = events.StatusProcessing
+	failed := newCompletedEntry("svc", "failed.event.v1", "svc.failed.v1")
+	failed.Status = events.StatusFailed
+
+	insertOutboxEntry(t, db, completed)
+	insertOutboxEntry(t, db, pending)
+	insertOutboxEntry(t, db, processing)
+	insertOutboxEntry(t, db, failed)
+
+	source := adapters.NewOutboxEventSource(db, 50*time.Millisecond, newTestLogger(t))
+
+	var mu sync.Mutex
+	var received []string
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	_ = source.Start(ctx, func(_ context.Context, ev eventstream.DomainEvent) error {
+		mu.Lock()
+		received = append(received, ev.EventType)
+		mu.Unlock()
+		return nil
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"completed.event.v1"}, received,
+		"only completed outbox entries should be delivered")
+}
+
+// --- Start returns nil on context cancellation ---
+
+func TestOutboxSource_Start_ReturnsNilOnContextCancel(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	source := adapters.NewOutboxEventSource(db, 50*time.Millisecond, newTestLogger(t))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	err := source.Start(ctx, func(_ context.Context, _ eventstream.DomainEvent) error {
+		return nil
+	})
+	assert.NoError(t, err)
+}
+
+// --- New entries are picked up after high-water mark advance ---
+
+func TestOutboxSource_PicksUpNewEntriesAfterFirstPoll(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Insert first entry.
+	entry1 := newCompletedEntry("svc", "first.event.v1", "svc.first.v1")
+	entry1.CreatedAt = time.Now().UTC().Add(-100 * time.Millisecond)
+	insertOutboxEntry(t, db, entry1)
+
+	source := adapters.NewOutboxEventSource(db, 50*time.Millisecond, newTestLogger(t))
+
+	var mu sync.Mutex
+	var received []string
+
+	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
+	defer cancel()
+
+	go func() {
+		_ = source.Start(ctx, func(_ context.Context, ev eventstream.DomainEvent) error {
+			mu.Lock()
+			received = append(received, ev.EventType)
+			mu.Unlock()
+			return nil
+		})
+	}()
+
+	// Wait for first poll to complete, then insert a second entry.
+	time.Sleep(150 * time.Millisecond)
+
+	entry2 := newCompletedEntry("svc", "second.event.v1", "svc.second.v1")
+	entry2.CreatedAt = time.Now().UTC()
+	insertOutboxEntry(t, db, entry2)
+
+	// Wait for another poll to pick up the second entry.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	<-ctx.Done()
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Contains(t, received, "first.event.v1")
+	assert.Contains(t, received, "second.event.v1")
+	assert.Equal(t, 2, len(received), "should receive exactly 2 distinct events")
+}

--- a/services/gateway/eventstream/adapters/outbox_source_test.go
+++ b/services/gateway/eventstream/adapters/outbox_source_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/gateway/eventstream"
 	"github.com/meridianhub/meridian/services/gateway/eventstream/adapters"
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/meridianhub/meridian/shared/platform/events"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
@@ -363,8 +364,13 @@ func TestOutboxSource_PicksUpNewEntriesAfterFirstPoll(t *testing.T) {
 
 	var mu sync.Mutex
 	var received []string
+	countReceived := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(received)
+	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	go func() {
@@ -376,18 +382,20 @@ func TestOutboxSource_PicksUpNewEntriesAfterFirstPoll(t *testing.T) {
 		})
 	}()
 
-	// Wait for first poll to complete, then insert a second entry.
-	time.Sleep(150 * time.Millisecond)
+	// Wait until the first entry is delivered, then insert a second entry.
+	err := await.New().AtMost(5 * time.Second).PollInterval(20 * time.Millisecond).
+		Until(func() bool { return countReceived() >= 1 })
+	require.NoError(t, err, "first entry should have been delivered")
 
 	entry2 := newCompletedEntry("svc", "second.event.v1", "svc.second.v1")
 	entry2.CreatedAt = time.Now().UTC()
 	insertOutboxEntry(t, db, entry2)
 
-	// Wait for another poll to pick up the second entry.
-	time.Sleep(200 * time.Millisecond)
+	// Wait until the second entry is also delivered.
+	err = await.New().AtMost(5 * time.Second).PollInterval(20 * time.Millisecond).
+		Until(func() bool { return countReceived() >= 2 })
+	require.NoError(t, err, "second entry should have been delivered")
 	cancel()
-
-	<-ctx.Done()
 
 	mu.Lock()
 	defer mu.Unlock()


### PR DESCRIPTION
## Summary

- Adds `services/gateway/eventstream/adapters/OutboxEventSource` implementing the `EventSource` port
- Polls `event_outbox` for `status = 'completed'` entries at a configurable interval (default 500ms)
- Tracks a per-service high-water mark (created_at + ID) to prevent duplicate delivery across polls
- Converts `EventOutbox` entries to `DomainEvent` using `DeriveChannel` for topic → channel normalization
- Guarded by ADR-0002 constraint: intended for dev/CI only (KAFKA_ENABLED=false)

## Changes Made

- `services/gateway/eventstream/adapters/outbox_source.go`: `OutboxEventSource` struct, `Start` polling loop, `pollEvents` GORM query with high-water mark filtering, `outboxToDomainEvent` conversion
- `services/gateway/eventstream/adapters/outbox_source_test.go`: Integration tests with CockroachDB testcontainer

## Technical Details

**High-water mark design**: Uses `(created_at, id)` tuple per service to handle multiple entries with the same timestamp without requiring a monotonic sequence. The mark advances only after a successful handler call, so transient handler errors are retried on the next poll.

**TenantID caveat**: `EventOutbox` has no `tenant_id` column. `DomainEvent.TenantID` is left empty and documented. This is acceptable for the dev/CI use case per ADR-0002 — production uses the Kafka adapter which carries tenant context in message headers.

## Test plan

- [x] Field mapping: all `EventOutbox` fields correctly mapped to `DomainEvent`
- [x] Channel derivation: `.v1` suffix stripped by `DeriveChannel`
- [x] High-water mark deduplication: single entry delivered exactly once across multiple polls
- [x] Per-service tracking: each service tracked independently
- [x] Batch size limiting: `WithBatchSize(n)` caps entries per poll cycle
- [x] Status filtering: only `completed` entries delivered
- [x] Context cancellation: `Start` returns `nil` on cancel
- [x] Incremental pickup: new entries inserted after first poll are delivered in subsequent polls

## Deployment Notes

This adapter is only activated when `KAFKA_ENABLED=false`. No migration required — reads the existing `event_outbox` table.