### PR TITLE
feat: Add platform-admin gateway bypass for cross-tenant access

### DIFF
--- a/services/gateway/auth/combined_middleware.go
+++ b/services/gateway/auth/combined_middleware.go
@@ -199,8 +199,10 @@ func (m *CombinedAuthMiddleware) handleLegacyAPIKeyAuth(w http.ResponseWriter, r
 // auth → tenant → tenant_authorization → proxy
 //
 // Authorization rules:
-// - JWT: tenant ID in JWT claims must match resolved tenant ID (403 if mismatch)
-// - API key: API keys are authorized for all tenants (service-to-service)
+//   - JWT: tenant ID in JWT claims must match resolved tenant ID (403 if mismatch)
+//   - JWT with platform-admin/super-admin role and no tenant claim: bypass comparison,
+//     allow access to any tenant resolved from subdomain (cross-tenant access is logged)
+//   - API key: API keys are authorized for all tenants (service-to-service)
 type TenantAuthorizationMiddleware struct {
 	logger *slog.Logger
 }
@@ -251,6 +253,24 @@ func (m *TenantAuthorizationMiddleware) Handler(next http.Handler) http.Handler 
 			return
 		}
 
+		// Platform-admin/super-admin bypass: when JWT has no tenant claim but has
+		// elevated platform role, allow cross-tenant access via subdomain resolution.
+		if jwtTenantID == "" {
+			claims, hasClaims := GetClaimsFromContext(ctx)
+			if hasClaims && hasPlatformAdminRole(claims) {
+				m.logger.Info("platform admin cross-tenant access",
+					slog.String("user_id", claims.UserID),
+					slog.String("resolved_tenant", resolvedTenant.String()),
+					slog.String("path", r.URL.Path),
+				)
+				next.ServeHTTP(w, r)
+				return
+			}
+			// No tenant claim and not a platform admin
+			writeForbidden(w, "missing tenant claim in token")
+			return
+		}
+
 		// Compare JWT tenant with resolved tenant
 		if !tenantsMatch(jwtTenantID, resolvedTenant) {
 			m.logger.Warn("JWT tenant does not match resolved tenant",
@@ -268,6 +288,14 @@ func (m *TenantAuthorizationMiddleware) Handler(next http.Handler) http.Handler 
 		)
 		next.ServeHTTP(w, r)
 	})
+}
+
+// hasPlatformAdminRole returns true if claims contain platform-admin or super-admin role.
+func hasPlatformAdminRole(claims *platformauth.Claims) bool {
+	if claims == nil {
+		return false
+	}
+	return claims.HasRole(platformauth.RolePlatformAdmin) || claims.HasRole(platformauth.RoleSuperAdmin)
 }
 
 // tenantsMatch compares JWT tenant ID (string) with resolved tenant ID.

--- a/services/gateway/auth/combined_middleware_test.go
+++ b/services/gateway/auth/combined_middleware_test.go
@@ -396,6 +396,169 @@ func TestTenantAuthorizationMiddleware(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, rr.Code)
 		assert.Contains(t, rr.Body.String(), "tenant context not resolved")
 	})
+
+	t.Run("platform-admin without tenant claim accesses tenant via subdomain", func(t *testing.T) {
+		middleware := NewTenantAuthorizationMiddleware(logger)
+
+		var capturedCtx context.Context
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+		})
+
+		handler := middleware.Handler(nextHandler)
+
+		// JWT has platform-admin role but no tenant ID claim
+		claims := &platformauth.Claims{
+			UserID: "admin-user",
+			Roles:  []string{"platform-admin"},
+		}
+		ctx := injectClaimsToContext(context.Background(), claims)
+		// Tenant middleware resolved the tenant from subdomain
+		ctx = tenant.WithTenant(ctx, tenant.MustNewTenantID("acme_corp"))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req = req.WithContext(ctx)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		// Resolved tenant must still be in context for downstream handlers
+		resolvedTenant, hasTenant := tenant.FromContext(capturedCtx)
+		assert.True(t, hasTenant)
+		assert.Equal(t, "acme_corp", resolvedTenant.String())
+	})
+
+	t.Run("super-admin without tenant claim accesses tenant via subdomain", func(t *testing.T) {
+		middleware := NewTenantAuthorizationMiddleware(logger)
+
+		var nextCalled bool
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		})
+
+		handler := middleware.Handler(nextHandler)
+
+		// JWT has super-admin role but no tenant ID claim
+		claims := &platformauth.Claims{
+			UserID: "super-user",
+			Roles:  []string{"super-admin"},
+		}
+		ctx := injectClaimsToContext(context.Background(), claims)
+		ctx = tenant.WithTenant(ctx, tenant.MustNewTenantID("some_corp"))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req = req.WithContext(ctx)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.True(t, nextCalled)
+	})
+
+	t.Run("regular tenant admin denied cross-tenant access", func(t *testing.T) {
+		middleware := NewTenantAuthorizationMiddleware(logger)
+
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			t.Error("next handler should not be called")
+		})
+
+		handler := middleware.Handler(nextHandler)
+
+		// JWT has admin role scoped to acme_corp but subdomain resolves other_corp
+		claims := &platformauth.Claims{
+			UserID:   "tenant-admin",
+			TenantID: "acme_corp",
+			Roles:    []string{"admin"},
+		}
+		ctx := injectClaimsToContext(context.Background(), claims)
+		ctx = tenant.WithTenant(ctx, tenant.MustNewTenantID("other_corp"))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req = req.WithContext(ctx)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+		assert.Contains(t, rr.Body.String(), "not authorized for this tenant")
+	})
+
+	t.Run("platform-admin with tenant claim uses normal tenant matching", func(t *testing.T) {
+		middleware := NewTenantAuthorizationMiddleware(logger)
+
+		var nextCalled bool
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		})
+
+		handler := middleware.Handler(nextHandler)
+
+		// JWT has platform-admin role AND a tenant ID claim - treated as normal tenant matching
+		claims := &platformauth.Claims{
+			UserID:   "admin-user",
+			TenantID: "acme_corp",
+			Roles:    []string{"platform-admin"},
+		}
+		ctx := injectClaimsToContext(context.Background(), claims)
+		ctx = tenant.WithTenant(ctx, tenant.MustNewTenantID("acme_corp"))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req = req.WithContext(ctx)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.True(t, nextCalled)
+	})
+}
+
+func TestHasPlatformAdminRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   *platformauth.Claims
+		expected bool
+	}{
+		{
+			name:     "platform-admin role returns true",
+			claims:   &platformauth.Claims{Roles: []string{"platform-admin"}},
+			expected: true,
+		},
+		{
+			name:     "super-admin role returns true",
+			claims:   &platformauth.Claims{Roles: []string{"super-admin"}},
+			expected: true,
+		},
+		{
+			name:     "both roles returns true",
+			claims:   &platformauth.Claims{Roles: []string{"platform-admin", "super-admin"}},
+			expected: true,
+		},
+		{
+			name:     "admin role returns false",
+			claims:   &platformauth.Claims{Roles: []string{"admin"}},
+			expected: false,
+		},
+		{
+			name:     "no roles returns false",
+			claims:   &platformauth.Claims{Roles: []string{}},
+			expected: false,
+		},
+		{
+			name:     "nil claims returns false",
+			claims:   nil,
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := hasPlatformAdminRole(tc.claims)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
 }
 
 func TestMiddlewareChainOrder(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds platform-admin/super-admin role bypass to `TenantAuthorizationMiddleware`
- JWT holders with these roles and no `x-tenant-id` claim can access any tenant-scoped service via subdomain resolution
- Cross-tenant access is logged at INFO level for audit trail
- Regular tenant admins remain restricted to their own tenant

## Changes Made

**`services/gateway/auth/combined_middleware.go`**
- Added `hasPlatformAdminRole` helper function checking for `platform-admin` or `super-admin` roles
- Updated `TenantAuthorizationMiddleware.Handler` to bypass tenant comparison when JWT has no tenant claim but carries a platform admin role
- Resolved tenant from subdomain is preserved in context for downstream handlers
- Updated struct docstring to document the new bypass rule

## Technical Details

The middleware chain is: `auth → tenant → tenant_authz → proxy`

Previously, a platform-admin JWT with no `x-tenant-id` claim would hit the tenant comparison with an empty JWT tenant ID, resulting in a 403. The fix adds a check before the comparison: when `jwtTenantID == ""` and claims contain `platform-admin` or `super-admin`, the request proceeds with the subdomain-resolved tenant in context.

The bypass uses `GetClaimsFromContext` (requires full claims in context, set by JWT middleware) rather than just the roles slice to ensure claims were properly validated before the bypass applies.

## Testing

- `TestTenantAuthorizationMiddleware/platform-admin_without_tenant_claim_accesses_tenant_via_subdomain` - bypass works, resolved tenant in context
- `TestTenantAuthorizationMiddleware/super-admin_without_tenant_claim_accesses_tenant_via_subdomain` - super-admin also bypasses
- `TestTenantAuthorizationMiddleware/regular_tenant_admin_denied_cross-tenant_access` - tenant-scoped admin cannot cross tenants
- `TestTenantAuthorizationMiddleware/platform-admin_with_tenant_claim_uses_normal_tenant_matching` - platform-admin with tenant claim uses normal matching
- `TestHasPlatformAdminRole` - 6 cases covering all role combinations

All existing tests continue to pass.

## Risk Assessment

Low risk: the bypass only activates when both conditions are true:
1. JWT has no `x-tenant-id` claim
2. JWT has `platform-admin` or `super-admin` role

Regular tenant JWTs always have a tenant claim, so are unaffected.

## Task Master

Task: 026-operations-console.1