### PR TITLE
feat: Implement tenant-partitioned event router

### DIFF
--- a/services/gateway/eventstream/router.go
+++ b/services/gateway/eventstream/router.go
@@ -1,0 +1,322 @@
+package eventstream
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// ConnectionSender is the interface the Router uses to interact with a client
+// connection. It is satisfied by *Connection and by test doubles.
+type ConnectionSender interface {
+	// ID returns the connection identifier.
+	ID() string
+	// TenantID returns the tenant that owns this connection.
+	TenantID() string
+	// Send enqueues a ServerMessage for delivery. Returns false if the buffer is full.
+	Send(msg ServerMessage) bool
+	// MatchesEvent returns the subscription IDs that match the given event.
+	// Returns nil if no subscriptions match.
+	MatchesEvent(event DomainEvent) []string
+}
+
+// ConnectionRegistry stores active connections indexed by tenant and connection ID.
+// It is safe for concurrent use from multiple goroutines.
+type ConnectionRegistry struct {
+	mu       sync.RWMutex
+	byTenant map[string]map[string]ConnectionSender
+	byID     map[string]ConnectionSender
+}
+
+// NewConnectionRegistry creates an empty ConnectionRegistry.
+func NewConnectionRegistry() *ConnectionRegistry {
+	return &ConnectionRegistry{
+		byTenant: make(map[string]map[string]ConnectionSender),
+		byID:     make(map[string]ConnectionSender),
+	}
+}
+
+// Register adds conn to the registry, indexed by its tenant and ID.
+// If a connection with the same ID is already registered it is replaced.
+func (r *ConnectionRegistry) Register(conn ConnectionSender) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Remove previous registration for this ID if it exists.
+	if existing, ok := r.byID[conn.ID()]; ok {
+		tenantMap := r.byTenant[existing.TenantID()]
+		delete(tenantMap, existing.ID())
+		if len(tenantMap) == 0 {
+			delete(r.byTenant, existing.TenantID())
+		}
+	}
+
+	r.byID[conn.ID()] = conn
+
+	tenantMap, ok := r.byTenant[conn.TenantID()]
+	if !ok {
+		tenantMap = make(map[string]ConnectionSender)
+		r.byTenant[conn.TenantID()] = tenantMap
+	}
+	tenantMap[conn.ID()] = conn
+}
+
+// Unregister removes the connection with connID from the registry.
+// It is a no-op if connID is not registered.
+func (r *ConnectionRegistry) Unregister(connID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	conn, ok := r.byID[connID]
+	if !ok {
+		return
+	}
+
+	delete(r.byID, connID)
+
+	tenantMap := r.byTenant[conn.TenantID()]
+	delete(tenantMap, connID)
+	if len(tenantMap) == 0 {
+		delete(r.byTenant, conn.TenantID())
+	}
+}
+
+// GetByID returns the connection with the given ID, or nil if not found.
+func (r *ConnectionRegistry) GetByID(connID string) ConnectionSender {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.byID[connID]
+}
+
+// GetByTenant returns a snapshot of all connections for tenantID.
+// Returns nil if no connections exist for the tenant.
+func (r *ConnectionRegistry) GetByTenant(tenantID string) []ConnectionSender {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	tenantMap, ok := r.byTenant[tenantID]
+	if !ok {
+		return nil
+	}
+
+	result := make([]ConnectionSender, 0, len(tenantMap))
+	for _, conn := range tenantMap {
+		result = append(result, conn)
+	}
+	return result
+}
+
+// InProcessFanOut is a FanOut backed by direct in-process handler dispatch.
+// It is used for single-instance deployments and for testing. Each tenant maps
+// to exactly one handler. Concurrent Publish calls are safe.
+type InProcessFanOut struct {
+	mu       sync.RWMutex
+	handlers map[string]EventHandler
+}
+
+// NewInProcessFanOut returns an empty InProcessFanOut.
+func NewInProcessFanOut() *InProcessFanOut {
+	return &InProcessFanOut{
+		handlers: make(map[string]EventHandler),
+	}
+}
+
+// Compile-time assertion.
+var _ FanOut = (*InProcessFanOut)(nil)
+
+// Publish delivers event to the handler registered for event.TenantID.
+// Returns ErrEmptyTenantID if event.TenantID is empty.
+// If no handler is registered the event is silently dropped.
+func (f *InProcessFanOut) Publish(ctx context.Context, event DomainEvent) error {
+	if event.TenantID == "" {
+		return ErrEmptyTenantID
+	}
+
+	f.mu.RLock()
+	h, ok := f.handlers[event.TenantID]
+	f.mu.RUnlock()
+
+	if ok {
+		_ = h(ctx, event)
+	}
+	return nil
+}
+
+// Subscribe registers handler for tenantID. Replaces any existing handler.
+// Returns ErrEmptyTenantID if tenantID is empty.
+func (f *InProcessFanOut) Subscribe(_ context.Context, tenantID string, handler EventHandler) error {
+	if tenantID == "" {
+		return ErrEmptyTenantID
+	}
+
+	f.mu.Lock()
+	f.handlers[tenantID] = handler
+	f.mu.Unlock()
+	return nil
+}
+
+// Unsubscribe removes the handler for tenantID.
+// Returns ErrEmptyTenantID if tenantID is empty.
+func (f *InProcessFanOut) Unsubscribe(_ context.Context, tenantID string) error {
+	if tenantID == "" {
+		return ErrEmptyTenantID
+	}
+
+	f.mu.Lock()
+	delete(f.handlers, tenantID)
+	f.mu.Unlock()
+	return nil
+}
+
+// Router orchestrates event delivery from an EventSource to registered connections
+// via a FanOut. It maintains a ConnectionRegistry partitioned by tenant.
+//
+// Flow:
+//  1. Start consumes events from EventSource and publishes them to FanOut.
+//  2. When a connection is Registered, the Router subscribes to the FanOut for
+//     that tenant (if not already subscribed).
+//  3. The FanOut calls the per-tenant handler, which fans the event out to all
+//     matching connections for that tenant.
+//
+// Router is safe for concurrent use from multiple goroutines.
+type Router struct {
+	source   EventSource
+	fanOut   FanOut
+	registry *ConnectionRegistry
+
+	mu              sync.Mutex
+	tenantSubCounts map[string]int // reference counts for FanOut subscriptions
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	logger *slog.Logger
+}
+
+// NewRouter creates a Router backed by the given EventSource and FanOut.
+func NewRouter(source EventSource, fanOut FanOut) *Router {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Router{
+		source:          source,
+		fanOut:          fanOut,
+		registry:        NewConnectionRegistry(),
+		tenantSubCounts: make(map[string]int),
+		ctx:             ctx,
+		cancel:          cancel,
+		logger:          slog.Default(),
+	}
+}
+
+// RegisterConnection adds conn to the registry and ensures a FanOut subscription
+// exists for the connection's tenant.
+func (r *Router) RegisterConnection(conn ConnectionSender) {
+	r.registry.Register(conn)
+
+	tenantID := conn.TenantID()
+	r.mu.Lock()
+	count := r.tenantSubCounts[tenantID]
+	r.tenantSubCounts[tenantID] = count + 1
+	isFirst := count == 0
+	r.mu.Unlock()
+
+	if isFirst {
+		_ = r.fanOut.Subscribe(r.ctx, tenantID, r.makeTenantHandler(tenantID))
+	}
+}
+
+// UnregisterConnection removes the connection with connID from the registry and
+// unsubscribes from the FanOut when the last connection for a tenant departs.
+func (r *Router) UnregisterConnection(connID string) {
+	// Look up the connection's tenant before removing it.
+	existing := r.registry.GetByID(connID)
+	if existing == nil {
+		return
+	}
+	tenantID := existing.TenantID()
+
+	r.registry.Unregister(connID)
+
+	r.mu.Lock()
+	count := r.tenantSubCounts[tenantID]
+	if count > 0 {
+		count--
+		r.tenantSubCounts[tenantID] = count
+	}
+	isLast := count == 0
+	if isLast {
+		delete(r.tenantSubCounts, tenantID)
+	}
+	r.mu.Unlock()
+
+	if isLast {
+		_ = r.fanOut.Unsubscribe(r.ctx, tenantID)
+	}
+}
+
+// GetConnectionsByTenant returns a snapshot of all connections for tenantID.
+func (r *Router) GetConnectionsByTenant(tenantID string) []ConnectionSender {
+	return r.registry.GetByTenant(tenantID)
+}
+
+// HandleEvent delivers event to all matching connections for the event's tenant.
+func (r *Router) HandleEvent(_ context.Context, event DomainEvent) error {
+	conns := r.registry.GetByTenant(event.TenantID)
+	for _, conn := range conns {
+		subIDs := conn.MatchesEvent(event)
+		if len(subIDs) == 0 {
+			continue
+		}
+
+		payload := NewEventPayload(event)
+		for _, subID := range subIDs {
+			msg := ServerMessage{
+				Type:           ServerMessageTypeEvent,
+				SubscriptionID: subID,
+				Channel:        event.Channel,
+				Event:          &payload,
+			}
+			if !conn.Send(msg) {
+				r.logger.Warn("dropped event: connection buffer full",
+					slog.String("conn_id", conn.ID()),
+					slog.String("tenant_id", event.TenantID),
+					slog.String("event_id", event.EventID),
+				)
+			}
+		}
+	}
+	return nil
+}
+
+// Start begins consuming events from the EventSource and publishing them to the
+// FanOut. It blocks until ctx is cancelled or a fatal error from the EventSource
+// occurs. The EventSource handler publishes each event to the FanOut.
+func (r *Router) Start(ctx context.Context) error {
+	// Merge external cancellation with internal lifecycle.
+	go func() {
+		select {
+		case <-ctx.Done():
+			r.cancel()
+		case <-r.ctx.Done():
+		}
+	}()
+
+	return r.source.Start(r.ctx, func(handlerCtx context.Context, event DomainEvent) error { //nolint:contextcheck // r.ctx merges the external ctx via the goroutine above
+		return r.fanOut.Publish(handlerCtx, event)
+	})
+}
+
+// Shutdown performs a graceful shutdown of the Router. It cancels internal
+// operations and waits for the EventSource to drain. The provided ctx controls
+// the maximum wait duration.
+func (r *Router) Shutdown(_ context.Context) error {
+	r.cancel()
+	return nil
+}
+
+// makeTenantHandler returns an EventHandler that fans an event out to all
+// matching connections for the tenant.
+func (r *Router) makeTenantHandler(_ string) EventHandler {
+	return func(ctx context.Context, event DomainEvent) error {
+		return r.HandleEvent(ctx, event)
+	}
+}

--- a/services/gateway/eventstream/router.go
+++ b/services/gateway/eventstream/router.go
@@ -220,7 +220,12 @@ func (r *Router) RegisterConnection(conn ConnectionSender) {
 	r.mu.Unlock()
 
 	if isFirst {
-		_ = r.fanOut.Subscribe(r.ctx, tenantID, r.makeTenantHandler(tenantID))
+		if err := r.fanOut.Subscribe(r.ctx, tenantID, r.makeTenantHandler(tenantID)); err != nil {
+			r.logger.Error("failed to subscribe to fanout for tenant",
+				slog.String("tenant_id", tenantID),
+				slog.String("error", err.Error()),
+			)
+		}
 	}
 }
 
@@ -249,7 +254,12 @@ func (r *Router) UnregisterConnection(connID string) {
 	r.mu.Unlock()
 
 	if isLast {
-		_ = r.fanOut.Unsubscribe(r.ctx, tenantID)
+		if err := r.fanOut.Unsubscribe(r.ctx, tenantID); err != nil {
+			r.logger.Error("failed to unsubscribe from fanout for tenant",
+				slog.String("tenant_id", tenantID),
+				slog.String("error", err.Error()),
+			)
+		}
 	}
 }
 
@@ -305,9 +315,8 @@ func (r *Router) Start(ctx context.Context) error {
 	})
 }
 
-// Shutdown performs a graceful shutdown of the Router. It cancels internal
-// operations and waits for the EventSource to drain. The provided ctx controls
-// the maximum wait duration.
+// Shutdown cancels internal operations, causing Start to return once the
+// EventSource acknowledges cancellation.
 func (r *Router) Shutdown(_ context.Context) error {
 	r.cancel()
 	return nil

--- a/services/gateway/eventstream/router.go
+++ b/services/gateway/eventstream/router.go
@@ -81,11 +81,26 @@ func (r *ConnectionRegistry) Unregister(connID string) {
 	}
 }
 
-// GetByID returns the connection with the given ID, or nil if not found.
-func (r *ConnectionRegistry) GetByID(connID string) ConnectionSender {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.byID[connID]
+// UnregisterByID atomically removes and returns the connection with connID.
+// Returns nil if connID is not registered. Using a single lock acquisition
+// avoids the TOCTOU race between lookup and removal.
+func (r *ConnectionRegistry) UnregisterByID(connID string) ConnectionSender {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	conn, ok := r.byID[connID]
+	if !ok {
+		return nil
+	}
+
+	delete(r.byID, connID)
+
+	tenantMap := r.byTenant[conn.TenantID()]
+	delete(tenantMap, connID)
+	if len(tenantMap) == 0 {
+		delete(r.byTenant, conn.TenantID())
+	}
+	return conn
 }
 
 // GetByTenant returns a snapshot of all connections for tenantID.
@@ -137,7 +152,13 @@ func (f *InProcessFanOut) Publish(ctx context.Context, event DomainEvent) error 
 	f.mu.RUnlock()
 
 	if ok {
-		_ = h(ctx, event)
+		if err := h(ctx, event); err != nil {
+			slog.Warn("fan-out handler returned error",
+				slog.String("tenant_id", event.TenantID),
+				slog.String("event_id", event.EventID),
+				slog.Any("error", err),
+			)
+		}
 	}
 	return nil
 }
@@ -232,14 +253,12 @@ func (r *Router) RegisterConnection(conn ConnectionSender) {
 // UnregisterConnection removes the connection with connID from the registry and
 // unsubscribes from the FanOut when the last connection for a tenant departs.
 func (r *Router) UnregisterConnection(connID string) {
-	// Look up the connection's tenant before removing it.
-	existing := r.registry.GetByID(connID)
+	// Atomically remove the connection and get its tenant in one lock acquisition.
+	existing := r.registry.UnregisterByID(connID)
 	if existing == nil {
 		return
 	}
 	tenantID := existing.TenantID()
-
-	r.registry.Unregister(connID)
 
 	r.mu.Lock()
 	count := r.tenantSubCounts[tenantID]

--- a/services/gateway/eventstream/router_test.go
+++ b/services/gateway/eventstream/router_test.go
@@ -1,0 +1,475 @@
+package eventstream_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/gateway/eventstream"
+	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- ConnectionRegistry tests ---
+
+func TestConnectionRegistry_RegisterAndGet(t *testing.T) {
+	reg := eventstream.NewConnectionRegistry()
+	conn := newTestConnection(t, "conn-1", "tenant-A")
+
+	reg.Register(conn)
+
+	conns := reg.GetByTenant("tenant-A")
+	require.Len(t, conns, 1)
+	assert.Equal(t, "conn-1", conns[0].ID())
+}
+
+func TestConnectionRegistry_GetByTenant_IsolatesTenants(t *testing.T) {
+	reg := eventstream.NewConnectionRegistry()
+	connA := newTestConnection(t, "conn-a", "tenant-A")
+	connB := newTestConnection(t, "conn-b", "tenant-B")
+
+	reg.Register(connA)
+	reg.Register(connB)
+
+	connsA := reg.GetByTenant("tenant-A")
+	require.Len(t, connsA, 1)
+	assert.Equal(t, "conn-a", connsA[0].ID())
+
+	connsB := reg.GetByTenant("tenant-B")
+	require.Len(t, connsB, 1)
+	assert.Equal(t, "conn-b", connsB[0].ID())
+}
+
+func TestConnectionRegistry_GetByTenant_UnknownTenant_ReturnsNil(t *testing.T) {
+	reg := eventstream.NewConnectionRegistry()
+	conns := reg.GetByTenant("nonexistent")
+	assert.Empty(t, conns)
+}
+
+func TestConnectionRegistry_Unregister(t *testing.T) {
+	reg := eventstream.NewConnectionRegistry()
+	conn := newTestConnection(t, "conn-1", "tenant-A")
+
+	reg.Register(conn)
+	assert.Len(t, reg.GetByTenant("tenant-A"), 1)
+
+	reg.Unregister("conn-1")
+	assert.Empty(t, reg.GetByTenant("tenant-A"))
+}
+
+func TestConnectionRegistry_Unregister_NonExistent_NoPanic(t *testing.T) { //nolint:revive
+	reg := eventstream.NewConnectionRegistry()
+	// Should not panic
+	reg.Unregister("nonexistent-conn-id")
+}
+
+func TestConnectionRegistry_MultipleSameTenant(t *testing.T) {
+	reg := eventstream.NewConnectionRegistry()
+	conn1 := newTestConnection(t, "conn-1", "tenant-A")
+	conn2 := newTestConnection(t, "conn-2", "tenant-A")
+
+	reg.Register(conn1)
+	reg.Register(conn2)
+
+	conns := reg.GetByTenant("tenant-A")
+	assert.Len(t, conns, 2)
+}
+
+func TestConnectionRegistry_UnregisterOneOfMany(t *testing.T) {
+	reg := eventstream.NewConnectionRegistry()
+	conn1 := newTestConnection(t, "conn-1", "tenant-A")
+	conn2 := newTestConnection(t, "conn-2", "tenant-A")
+
+	reg.Register(conn1)
+	reg.Register(conn2)
+
+	reg.Unregister("conn-1")
+
+	conns := reg.GetByTenant("tenant-A")
+	require.Len(t, conns, 1)
+	assert.Equal(t, "conn-2", conns[0].ID())
+}
+
+func TestConnectionRegistry_ConcurrentAccess(t *testing.T) { //nolint:revive
+	reg := eventstream.NewConnectionRegistry()
+
+	var wg sync.WaitGroup
+
+	// Concurrent registers
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			connID := "conn-" + string(rune('A'+idx%26))
+			tenantID := "tenant-" + string(rune('A'+idx%5))
+			conn := newTestConnection(t, connID, tenantID)
+			reg.Register(conn)
+		}(i)
+	}
+
+	// Concurrent unregisters
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			connID := "conn-" + string(rune('A'+idx%26))
+			reg.Unregister(connID)
+		}(i)
+	}
+
+	// Concurrent reads
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			tenantID := "tenant-" + string(rune('A'+idx%5))
+			reg.GetByTenant(tenantID)
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// --- Router tests ---
+
+func TestRouter_HandleEvent_DeliveredToMatchingTenant(t *testing.T) {
+	fanOut, router := newTestRouter(t)
+	conn := newTestConnectionWithSub(t, "conn-1", "tenant-A", "sub-1", "payment-order.*")
+
+	router.RegisterConnection(conn)
+
+	event := eventstream.DomainEvent{
+		EventID:   "evt-1",
+		EventType: "payment_order.created.v1",
+		Channel:   "payment-order.created",
+		TenantID:  "tenant-A",
+	}
+
+	// Publish via the mock EventSource's handler
+	err := fanOut.Publish(context.Background(), event)
+	require.NoError(t, err)
+
+	// The connection should receive a ServerMessage
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return conn.ReceivedCount() > 0
+	})
+	require.NoError(t, err, "connection should have received a message")
+}
+
+func TestRouter_HandleEvent_TenantIsolation(t *testing.T) {
+	fanOut, router := newTestRouter(t)
+
+	connA := newTestConnectionWithSub(t, "conn-a", "tenant-A", "sub-1", "*")
+	connB := newTestConnectionWithSub(t, "conn-b", "tenant-B", "sub-1", "*")
+
+	router.RegisterConnection(connA)
+	router.RegisterConnection(connB)
+
+	// Publish event for tenant-A only
+	eventA := eventstream.DomainEvent{
+		EventID:   "evt-a",
+		EventType: "payment_order.created.v1",
+		Channel:   "payment-order.created",
+		TenantID:  "tenant-A",
+	}
+
+	err := fanOut.Publish(context.Background(), eventA)
+	require.NoError(t, err)
+
+	// Only tenant-A connection should receive the event
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return connA.ReceivedCount() > 0
+	})
+	require.NoError(t, err, "tenant-A connection should have received event")
+
+	// Give some time to ensure tenant-B doesn't receive anything
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, 0, connB.ReceivedCount(), "tenant-B connection must not receive tenant-A's event")
+}
+
+func TestRouter_HandleEvent_NoConnectionsForTenant(t *testing.T) {
+	fanOut, _ := newTestRouter(t)
+
+	event := eventstream.DomainEvent{
+		EventID:   "evt-1",
+		EventType: "payment_order.created.v1",
+		Channel:   "payment-order.created",
+		TenantID:  "tenant-nobody",
+	}
+
+	// Should not error even when no connections exist for the tenant
+	err := fanOut.Publish(context.Background(), event)
+	require.NoError(t, err)
+}
+
+func TestRouter_HandleEvent_SubscriptionFilterMatch(t *testing.T) {
+	fanOut, router := newTestRouter(t)
+
+	// Connection subscribed to payment-order.* but event is for position-keeping
+	conn := newTestConnectionWithSub(t, "conn-1", "tenant-A", "sub-1", "payment-order.*")
+	router.RegisterConnection(conn)
+
+	nonMatchingEvent := eventstream.DomainEvent{
+		EventID:   "evt-1",
+		EventType: "position_keeping.updated.v1",
+		Channel:   "position-keeping.updated",
+		TenantID:  "tenant-A",
+	}
+
+	err := fanOut.Publish(context.Background(), nonMatchingEvent)
+	require.NoError(t, err)
+
+	// Give time to confirm no delivery
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, 0, conn.ReceivedCount(), "connection should not receive non-matching channel event")
+}
+
+func TestRouter_HandleEvent_MultipleConnectionsSameTenant(t *testing.T) {
+	fanOut, router := newTestRouter(t)
+
+	conn1 := newTestConnectionWithSub(t, "conn-1", "tenant-A", "sub-1", "*")
+	conn2 := newTestConnectionWithSub(t, "conn-2", "tenant-A", "sub-2", "*")
+
+	router.RegisterConnection(conn1)
+	router.RegisterConnection(conn2)
+
+	event := eventstream.DomainEvent{
+		EventID:   "evt-1",
+		EventType: "payment_order.created.v1",
+		Channel:   "payment-order.created",
+		TenantID:  "tenant-A",
+	}
+
+	err := fanOut.Publish(context.Background(), event)
+	require.NoError(t, err)
+
+	// Both connections should receive the event
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return conn1.ReceivedCount() > 0 && conn2.ReceivedCount() > 0
+	})
+	require.NoError(t, err, "both connections should receive the event")
+}
+
+func TestRouter_UnregisterConnection_StopsDelivery(t *testing.T) {
+	fanOut, router := newTestRouter(t)
+
+	conn := newTestConnectionWithSub(t, "conn-1", "tenant-A", "sub-1", "*")
+	router.RegisterConnection(conn)
+
+	// Unregister before publishing
+	router.UnregisterConnection("conn-1")
+
+	event := eventstream.DomainEvent{
+		EventID:   "evt-1",
+		EventType: "payment_order.created.v1",
+		Channel:   "payment-order.created",
+		TenantID:  "tenant-A",
+	}
+
+	err := fanOut.Publish(context.Background(), event)
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, 0, conn.ReceivedCount(), "unregistered connection should not receive events")
+}
+
+func TestRouter_GetConnectionsByTenant(t *testing.T) {
+	_, router := newTestRouter(t)
+
+	conn1 := newTestConnection(t, "conn-1", "tenant-A")
+	conn2 := newTestConnection(t, "conn-2", "tenant-A")
+	conn3 := newTestConnection(t, "conn-3", "tenant-B")
+
+	router.RegisterConnection(conn1)
+	router.RegisterConnection(conn2)
+	router.RegisterConnection(conn3)
+
+	connsA := router.GetConnectionsByTenant("tenant-A")
+	assert.Len(t, connsA, 2)
+
+	connsB := router.GetConnectionsByTenant("tenant-B")
+	assert.Len(t, connsB, 1)
+
+	connsC := router.GetConnectionsByTenant("tenant-C")
+	assert.Empty(t, connsC)
+}
+
+func TestRouter_Start_ConsumesFromEventSource(t *testing.T) {
+	src := &mockEventSource{}
+	fanOut := eventstream.NewInProcessFanOut()
+	router := eventstream.NewRouter(src, fanOut)
+
+	conn := newTestConnectionWithSub(t, "conn-1", "tenant-A", "sub-1", "*")
+	router.RegisterConnection(conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	startDone := make(chan struct{})
+	go func() {
+		defer close(startDone)
+		_ = router.Start(ctx)
+	}()
+
+	// Wait for Start to call EventSource.Start
+	err := await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return src.IsStarted()
+	})
+	require.NoError(t, err, "EventSource.Start should be called")
+
+	// Deliver an event via the mock source handler
+	event := eventstream.DomainEvent{
+		EventID:   "evt-1",
+		EventType: "payment_order.created.v1",
+		Channel:   "payment-order.created",
+		TenantID:  "tenant-A",
+	}
+	src.EmitEvent(context.Background(), event)
+
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return conn.ReceivedCount() > 0
+	})
+	require.NoError(t, err, "connection should receive event from EventSource")
+
+	cancel()
+	<-startDone
+}
+
+func TestRouter_Shutdown_GracefulStop(t *testing.T) {
+	src := &mockEventSource{}
+	fanOut := eventstream.NewInProcessFanOut()
+	router := eventstream.NewRouter(src, fanOut)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	startDone := make(chan struct{})
+	go func() {
+		defer close(startDone)
+		_ = router.Start(ctx)
+	}()
+
+	err := await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return src.IsStarted()
+	})
+	require.NoError(t, err)
+
+	// Shutdown should stop the router
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer shutdownCancel()
+	err = router.Shutdown(shutdownCtx)
+	require.NoError(t, err)
+
+	select {
+	case <-startDone:
+		// expected: Start returned after shutdown
+	case <-time.After(2 * time.Second):
+		t.Fatal("router.Start did not return after Shutdown")
+	}
+}
+
+// --- helpers ---
+
+// testConn is a lightweight test double for Connection that satisfies the
+// ConnectionSender interface used by the router's fan-out handler.
+type testConn struct {
+	id       string
+	tenantID string
+	subs     []eventstream.Subscription
+	received atomic.Int64
+}
+
+func (c *testConn) ID() string       { return c.id }
+func (c *testConn) TenantID() string { return c.tenantID }
+func (c *testConn) Send(_ eventstream.ServerMessage) bool {
+	c.received.Add(1)
+	return true
+}
+
+func (c *testConn) MatchesEvent(event eventstream.DomainEvent) []string {
+	var matched []string
+	for _, sub := range c.subs {
+		if sub.Matches(event) {
+			matched = append(matched, sub.ID)
+		}
+	}
+	return matched
+}
+func (c *testConn) ReceivedCount() int { return int(c.received.Load()) }
+
+func newTestConnection(t *testing.T, id, tenantID string) *testConn {
+	t.Helper()
+	return &testConn{id: id, tenantID: tenantID}
+}
+
+func newTestConnectionWithSub(t *testing.T, id, tenantID, subID string, pattern eventstream.ChannelPattern) *testConn {
+	t.Helper()
+	sub, err := eventstream.NewSubscription(subID, []eventstream.ChannelPattern{pattern}, eventstream.SubscriptionFilters{})
+	require.NoError(t, err)
+	return &testConn{
+		id:       id,
+		tenantID: tenantID,
+		subs:     []eventstream.Subscription{sub},
+	}
+}
+
+// newTestRouter creates an InProcessFanOut-backed router, starts its fanout
+// subscription in the background, and returns both for direct publishing in tests.
+func newTestRouter(t *testing.T) (*eventstream.InProcessFanOut, *eventstream.Router) {
+	t.Helper()
+
+	src := &mockEventSource{}
+	fanOut := eventstream.NewInProcessFanOut()
+	router := eventstream.NewRouter(src, fanOut)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	go func() {
+		_ = router.Start(ctx)
+	}()
+
+	// Wait for the router to start
+	err := await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return src.IsStarted()
+	})
+	if err != nil {
+		t.Fatalf("router did not start in time: %v", err)
+	}
+
+	return fanOut, router
+}
+
+// mockEventSource is a test EventSource that captures the handler and allows
+// manual event emission.
+type mockEventSource struct {
+	mu      sync.Mutex
+	handler eventstream.EventHandler
+	started atomic.Bool
+}
+
+func (m *mockEventSource) Start(ctx context.Context, handler eventstream.EventHandler) error {
+	m.mu.Lock()
+	m.handler = handler
+	m.mu.Unlock()
+	m.started.Store(true)
+
+	<-ctx.Done()
+	return nil
+}
+
+func (m *mockEventSource) IsStarted() bool {
+	return m.started.Load()
+}
+
+func (m *mockEventSource) EmitEvent(ctx context.Context, event eventstream.DomainEvent) {
+	m.mu.Lock()
+	h := m.handler
+	m.mu.Unlock()
+	if h != nil {
+		_ = h(ctx, event)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `ConnectionRegistry` — a thread-safe, tenant-partitioned store indexed by both `tenantID` and `connID`, providing O(1) lookups in both directions.
- Adds `ConnectionSender` interface so the router is decoupled from the concrete `*Connection` type and testable with lightweight doubles.
- Adds `InProcessFanOut` — a simple in-process `FanOut` for single-instance deployments and testing, complementing the existing `LocalFanOut` and `RedisFanOut` adapters.
- Adds `Router` — orchestrates the full pipeline: `EventSource` → `FanOut` → `ConnectionRegistry` → per-connection `Send`. Tenant isolation is enforced at the registry level; events for tenant A are never delivered to connections belonging to tenant B. FanOut subscriptions are reference-counted per tenant (subscribe on first connection, unsubscribe when last connection departs).

## Changes

- `services/gateway/eventstream/router.go` — `ConnectionSender`, `ConnectionRegistry`, `InProcessFanOut`, `Router`
- `services/gateway/eventstream/router_test.go` — 17 tests

## Testing

- Tenant isolation: event for tenant A does not reach tenant B connections
- Connection registration and unregistration
- Subscription filter matching (channel pattern, no match)
- Multi-connection fan-out within same tenant
- EventSource integration via mock (Start, EmitEvent)
- Graceful shutdown (router.Start returns after Shutdown)
- Concurrent registry access (race detector clean)

All tests pass with `go test ./services/gateway/eventstream/...`.

## Risk Assessment

- No changes to existing types or interfaces — purely additive
- `InProcessFanOut` is bounded to in-process only; multi-instance deployments continue to use `RedisFanOut`
- `ConnectionRegistry.GetByTenant` returns a snapshot slice, preventing long-held lock contention during fan-out

## Deployment Notes

No migration or configuration changes required.