### PR TITLE
feat: Configure TanStack Query with React Query DevTools

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "meridian-console",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.90.21",
+        "@tanstack/react-query-devtools": "^5.91.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -1589,6 +1591,59 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.93.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.93.0.tgz",
+      "integrity": "sha512-+kpsx1NQnOFTZsw6HAFCW3HkKg0+2cepGtAWXjiiSOJJ1CtQpt72EE2nyZb+AjAbLRPoeRmPJ8MtQd8r8gsPdg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
+      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.91.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.91.3.tgz",
+      "integrity": "sha512-nlahjMtd/J1h7IzOOfqeyDh5LNfG0eULwlltPEonYy0QL+nqrBB+nyzJfULV+moL7sZyxc2sHdNJki+vLA9BSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.93.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.90.20",
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,11 +14,16 @@
     "generate": "buf generate"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.90.21",
+    "@tanstack/react-query-devtools": "^5.91.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
@@ -34,9 +39,6 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1",
-    "vitest": "^3.2.4",
-    "@testing-library/react": "^16.3.0",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/user-event": "^14.6.1"
+    "vitest": "^3.2.4"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,15 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { queryClient } from '@/lib/query-client'
+
 function App() {
   return (
-    <div>
-      <h1>Meridian Operations Console</h1>
-    </div>
+    <QueryClientProvider client={queryClient}>
+      <div>
+        <h1>Meridian Operations Console</h1>
+      </div>
+      {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+    </QueryClientProvider>
   )
 }
 

--- a/frontend/src/lib/query-client.ts
+++ b/frontend/src/lib/query-client.ts
@@ -1,0 +1,15 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      gcTime: 5 * 60 * 1000,
+      retry: 2,
+      retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 10_000),
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+    },
+    mutations: { retry: 0 },
+  },
+})

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -1,0 +1,36 @@
+/**
+ * Query key factories for TanStack Query.
+ *
+ * Tenant-scoped keys include the tenantId to ensure cache isolation between tenants.
+ * Platform-scoped keys are for platform-level data not tied to a specific tenant.
+ */
+
+export const tenantKeys = {
+  all: (tenantId: string) => ['tenants', tenantId] as const,
+
+  accounts: (tenantId: string) =>
+    [...tenantKeys.all(tenantId), 'accounts'] as const,
+  account: (tenantId: string, accountId: string) =>
+    [...tenantKeys.accounts(tenantId), accountId] as const,
+
+  transactions: (tenantId: string) =>
+    [...tenantKeys.all(tenantId), 'transactions'] as const,
+  transaction: (tenantId: string, transactionId: string) =>
+    [...tenantKeys.transactions(tenantId), transactionId] as const,
+
+  sagas: (tenantId: string) =>
+    [...tenantKeys.all(tenantId), 'sagas'] as const,
+  saga: (tenantId: string, sagaId: string) =>
+    [...tenantKeys.sagas(tenantId), sagaId] as const,
+} as const
+
+export const platformKeys = {
+  all: ['platform'] as const,
+
+  tenants: () => [...platformKeys.all, 'tenants'] as const,
+  tenant: (tenantId: string) => [...platformKeys.tenants(), tenantId] as const,
+
+  health: () => [...platformKeys.all, 'health'] as const,
+
+  metrics: () => [...platformKeys.all, 'metrics'] as const,
+} as const

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -9,4 +9,9 @@ describe('App', () => {
       'Meridian Operations Console',
     )
   })
+
+  it('renders without crashing with QueryClientProvider', () => {
+    const { container } = render(<App />)
+    expect(container).toBeTruthy()
+  })
 })

--- a/frontend/src/test/query-client.test.ts
+++ b/frontend/src/test/query-client.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { queryClient } from '@/lib/query-client'
+import { QueryClient } from '@tanstack/react-query'
+
+describe('queryClient', () => {
+  it('is a QueryClient instance', () => {
+    expect(queryClient).toBeInstanceOf(QueryClient)
+  })
+
+  it('has correct staleTime default', () => {
+    const options = queryClient.getDefaultOptions()
+    expect(options.queries?.staleTime).toBe(30_000)
+  })
+
+  it('has correct gcTime default', () => {
+    const options = queryClient.getDefaultOptions()
+    expect(options.queries?.gcTime).toBe(5 * 60 * 1000)
+  })
+
+  it('has correct retry count for queries', () => {
+    const options = queryClient.getDefaultOptions()
+    expect(options.queries?.retry).toBe(2)
+  })
+
+  it('has no retry for mutations', () => {
+    const options = queryClient.getDefaultOptions()
+    expect(options.mutations?.retry).toBe(0)
+  })
+
+  it('has refetchOnWindowFocus enabled', () => {
+    const options = queryClient.getDefaultOptions()
+    expect(options.queries?.refetchOnWindowFocus).toBe(true)
+  })
+
+  it('has refetchOnReconnect enabled', () => {
+    const options = queryClient.getDefaultOptions()
+    expect(options.queries?.refetchOnReconnect).toBe(true)
+  })
+
+  it('retryDelay uses exponential backoff capped at 10s', () => {
+    const options = queryClient.getDefaultOptions()
+    const retryDelay = options.queries?.retryDelay as (attempt: number) => number
+    expect(retryDelay(0)).toBe(1000)
+    expect(retryDelay(1)).toBe(2000)
+    expect(retryDelay(2)).toBe(4000)
+    expect(retryDelay(10)).toBe(10_000)
+  })
+})

--- a/frontend/src/test/query-keys.test.ts
+++ b/frontend/src/test/query-keys.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { tenantKeys, platformKeys } from '@/lib/query-keys'
+
+describe('tenantKeys', () => {
+  const tenantId = 'tenant-abc'
+
+  it('all includes tenantId', () => {
+    expect(tenantKeys.all(tenantId)).toEqual(['tenants', tenantId])
+  })
+
+  it('accounts is scoped under tenant', () => {
+    expect(tenantKeys.accounts(tenantId)).toEqual(['tenants', tenantId, 'accounts'])
+  })
+
+  it('account includes accountId', () => {
+    expect(tenantKeys.account(tenantId, 'acc-1')).toEqual([
+      'tenants',
+      tenantId,
+      'accounts',
+      'acc-1',
+    ])
+  })
+
+  it('transactions is scoped under tenant', () => {
+    expect(tenantKeys.transactions(tenantId)).toEqual([
+      'tenants',
+      tenantId,
+      'transactions',
+    ])
+  })
+
+  it('transaction includes transactionId', () => {
+    expect(tenantKeys.transaction(tenantId, 'tx-1')).toEqual([
+      'tenants',
+      tenantId,
+      'transactions',
+      'tx-1',
+    ])
+  })
+
+  it('sagas is scoped under tenant', () => {
+    expect(tenantKeys.sagas(tenantId)).toEqual(['tenants', tenantId, 'sagas'])
+  })
+
+  it('saga includes sagaId', () => {
+    expect(tenantKeys.saga(tenantId, 'saga-1')).toEqual([
+      'tenants',
+      tenantId,
+      'sagas',
+      'saga-1',
+    ])
+  })
+
+  it('keys for different tenants do not overlap', () => {
+    const keyA = tenantKeys.accounts('tenant-a')
+    const keyB = tenantKeys.accounts('tenant-b')
+    expect(keyA).not.toEqual(keyB)
+  })
+})
+
+describe('platformKeys', () => {
+  it('all is the base platform key', () => {
+    expect(platformKeys.all).toEqual(['platform'])
+  })
+
+  it('tenants is scoped under platform', () => {
+    expect(platformKeys.tenants()).toEqual(['platform', 'tenants'])
+  })
+
+  it('tenant includes tenantId', () => {
+    expect(platformKeys.tenant('t-1')).toEqual(['platform', 'tenants', 't-1'])
+  })
+
+  it('health is scoped under platform', () => {
+    expect(platformKeys.health()).toEqual(['platform', 'health'])
+  })
+
+  it('metrics is scoped under platform', () => {
+    expect(platformKeys.metrics()).toEqual(['platform', 'metrics'])
+  })
+})


### PR DESCRIPTION
## Summary

- Install `@tanstack/react-query` v5 and `@tanstack/react-query-devtools`
- Create `QueryClient` with production-ready default options
- Create query key factories for tenant-scoped and platform-scoped queries
- Wrap `App` in `QueryClientProvider` with DevTools enabled in development mode only

## Changes Made

### `frontend/src/lib/query-client.ts`
Singleton `QueryClient` with:
- `staleTime: 30_000` — data considered fresh for 30 seconds
- `gcTime: 5 * 60 * 1000` — cache held for 5 minutes after last use
- `retry: 2` with exponential backoff capped at 10 seconds
- `refetchOnWindowFocus: true` and `refetchOnReconnect: true` for active data freshness
- `mutations.retry: 0` — mutations fail fast, no silent retries

### `frontend/src/lib/query-keys.ts`
Typed query key factories:
- `tenantKeys` — tenant-scoped hierarchical keys (accounts, transactions, sagas)
- `platformKeys` — platform-level keys (tenants, health, metrics)
- Hierarchical structure enables targeted cache invalidation at any level

### `frontend/src/App.tsx`
Wraps application in `QueryClientProvider` with `ReactQueryDevtools` rendered only when `import.meta.env.DEV` is true.

## Testing

- 23 tests passing across 3 test files
- Tests cover: QueryClient configuration, retry delay calculation, query key structure and tenant isolation
- TypeScript typecheck passes with no errors
- ESLint passes with no warnings

## Technical Details

Query key hierarchy enables targeted invalidation:
```typescript
// Invalidate all data for a tenant
queryClient.invalidateQueries({ queryKey: tenantKeys.all('tenant-123') })

// Invalidate only accounts for a tenant
queryClient.invalidateQueries({ queryKey: tenantKeys.accounts('tenant-123') })

// Invalidate a specific account
queryClient.invalidateQueries({ queryKey: tenantKeys.account('tenant-123', 'acc-456') })
```

DevTools only included in development builds — zero production bundle impact.

Closes 026-operations-console.5