### PR TITLE
feat: Create StatusBadge component with status color mapping

### DIFF
--- a/frontend/src/components/shared/status-badge.tsx
+++ b/frontend/src/components/shared/status-badge.tsx
@@ -1,0 +1,72 @@
+import { cn } from '@/lib/utils'
+
+type StatusVariant = 'success' | 'warning' | 'error' | 'info' | 'neutral'
+
+const STATUS_MAP: Record<string, StatusVariant> = {
+  // Account statuses
+  ACTIVE: 'success',
+  FROZEN: 'warning',
+  CLOSED: 'neutral',
+  SUSPENDED: 'error',
+  // Payment order statuses
+  INITIATED: 'info',
+  RESERVED: 'info',
+  EXECUTING: 'warning',
+  COMPLETED: 'success',
+  FAILED: 'error',
+  CANCELLED: 'neutral',
+  REVERSED: 'neutral',
+  // Saga statuses
+  DRAFT: 'neutral',
+  DEPRECATED: 'warning',
+  // Reconciliation statuses
+  RUNNING: 'warning',
+  // Tenant statuses
+  PROVISIONING: 'info',
+  PROVISIONING_PENDING: 'info',
+  PROVISIONING_FAILED: 'error',
+  DEPROVISIONED: 'neutral',
+  // Position quality ladder
+  ESTIMATE: 'warning',
+  COEFFICIENT: 'info',
+  ACTUAL: 'success',
+  REVISED: 'info',
+}
+
+const VARIANT_STYLES: Record<StatusVariant, string> = {
+  success: 'bg-green-100 text-green-800 border-green-200',
+  warning: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+  error: 'bg-red-100 text-red-800 border-red-200',
+  info: 'bg-blue-100 text-blue-800 border-blue-200',
+  neutral: 'bg-gray-100 text-gray-800 border-gray-200',
+}
+
+interface StatusBadgeProps {
+  status: string
+  loading?: boolean
+}
+
+export function StatusBadge({ status, loading }: StatusBadgeProps) {
+  if (loading) {
+    return (
+      <span
+        data-testid="status-badge-skeleton"
+        className="inline-flex h-5 w-16 animate-pulse rounded-full bg-gray-200"
+      />
+    )
+  }
+
+  const variant = STATUS_MAP[status] ?? 'neutral'
+  const displayText = status.replace(/_/g, ' ')
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs font-medium whitespace-nowrap',
+        VARIANT_STYLES[variant],
+      )}
+    >
+      {displayText}
+    </span>
+  )
+}

--- a/frontend/src/test/status-badge.test.tsx
+++ b/frontend/src/test/status-badge.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { StatusBadge } from '@/components/shared/status-badge'
+
+describe('StatusBadge', () => {
+  describe('status text formatting', () => {
+    it('replaces underscores with spaces', () => {
+      render(<StatusBadge status="PROVISIONING_PENDING" />)
+      expect(screen.getByText('PROVISIONING PENDING')).toBeInTheDocument()
+    })
+
+    it('renders simple status without modification', () => {
+      render(<StatusBadge status="ACTIVE" />)
+      expect(screen.getByText('ACTIVE')).toBeInTheDocument()
+    })
+  })
+
+  describe('status variant mapping', () => {
+    it('maps ACTIVE to success variant', () => {
+      render(<StatusBadge status="ACTIVE" />)
+      const badge = screen.getByText('ACTIVE')
+      expect(badge.className).toMatch(/green/)
+    })
+
+    it('maps FROZEN to warning variant', () => {
+      render(<StatusBadge status="FROZEN" />)
+      const badge = screen.getByText('FROZEN')
+      expect(badge.className).toMatch(/yellow/)
+    })
+
+    it('maps FAILED to error variant', () => {
+      render(<StatusBadge status="FAILED" />)
+      const badge = screen.getByText('FAILED')
+      expect(badge.className).toMatch(/red/)
+    })
+
+    it('maps INITIATED to info variant', () => {
+      render(<StatusBadge status="INITIATED" />)
+      const badge = screen.getByText('INITIATED')
+      expect(badge.className).toMatch(/blue/)
+    })
+
+    it('maps CLOSED to neutral variant', () => {
+      render(<StatusBadge status="CLOSED" />)
+      const badge = screen.getByText('CLOSED')
+      expect(badge.className).toMatch(/gray/)
+    })
+
+    it('maps unknown status to neutral variant', () => {
+      render(<StatusBadge status="UNKNOWN_STATUS" />)
+      const badge = screen.getByText('UNKNOWN STATUS')
+      expect(badge.className).toMatch(/gray/)
+    })
+  })
+
+  describe('account statuses', () => {
+    it.each([
+      ['ACTIVE', 'green'],
+      ['FROZEN', 'yellow'],
+      ['CLOSED', 'gray'],
+      ['SUSPENDED', 'red'],
+    ])('maps account status %s to correct color', (status, color) => {
+      render(<StatusBadge status={status} />)
+      const badge = screen.getByText(status.replace(/_/g, ' '))
+      expect(badge.className).toMatch(new RegExp(color))
+    })
+  })
+
+  describe('payment order statuses', () => {
+    it.each([
+      ['INITIATED', 'blue'],
+      ['RESERVED', 'blue'],
+      ['EXECUTING', 'yellow'],
+      ['COMPLETED', 'green'],
+      ['FAILED', 'red'],
+      ['CANCELLED', 'gray'],
+      ['REVERSED', 'gray'],
+    ])('maps payment status %s to correct color', (status, color) => {
+      render(<StatusBadge status={status} />)
+      const badge = screen.getByText(status.replace(/_/g, ' '))
+      expect(badge.className).toMatch(new RegExp(color))
+    })
+  })
+
+  describe('saga statuses', () => {
+    it.each([
+      ['DRAFT', 'gray'],
+      ['DEPRECATED', 'yellow'],
+    ])('maps saga status %s to correct color', (status, color) => {
+      render(<StatusBadge status={status} />)
+      const badge = screen.getByText(status.replace(/_/g, ' '))
+      expect(badge.className).toMatch(new RegExp(color))
+    })
+  })
+
+  describe('tenant statuses', () => {
+    it.each([
+      ['PROVISIONING', 'blue'],
+      ['PROVISIONING_PENDING', 'blue'],
+      ['PROVISIONING_FAILED', 'red'],
+      ['DEPROVISIONED', 'gray'],
+    ])('maps tenant status %s to correct color', (status, color) => {
+      render(<StatusBadge status={status} />)
+      const badge = screen.getByText(status.replace(/_/g, ' '))
+      expect(badge.className).toMatch(new RegExp(color))
+    })
+  })
+
+  describe('reconciliation statuses', () => {
+    it('maps RUNNING to warning variant', () => {
+      render(<StatusBadge status="RUNNING" />)
+      const badge = screen.getByText('RUNNING')
+      expect(badge.className).toMatch(/yellow/)
+    })
+  })
+
+  describe('position quality ladder', () => {
+    it.each([
+      ['ESTIMATE', 'yellow'],
+      ['COEFFICIENT', 'blue'],
+      ['ACTUAL', 'green'],
+      ['REVISED', 'blue'],
+    ])('maps quality ladder %s to correct color', (status, color) => {
+      render(<StatusBadge status={status} />)
+      const badge = screen.getByText(status.replace(/_/g, ' '))
+      expect(badge.className).toMatch(new RegExp(color))
+    })
+  })
+
+  describe('loading state', () => {
+    it('renders skeleton when loading is true', () => {
+      const { container } = render(<StatusBadge status="ACTIVE" loading />)
+      const skeleton = container.querySelector('[data-testid="status-badge-skeleton"]')
+      expect(skeleton).toBeInTheDocument()
+    })
+
+    it('does not render status text when loading', () => {
+      render(<StatusBadge status="ACTIVE" loading />)
+      expect(screen.queryByText('ACTIVE')).not.toBeInTheDocument()
+    })
+
+    it('renders status badge when loading is false', () => {
+      render(<StatusBadge status="ACTIVE" loading={false} />)
+      expect(screen.getByText('ACTIVE')).toBeInTheDocument()
+    })
+  })
+
+  describe('WCAG AA color contrast', () => {
+    it('success variant uses dark text on light background', () => {
+      render(<StatusBadge status="ACTIVE" />)
+      const badge = screen.getByText('ACTIVE')
+      // green-800 on green-100: contrast ratio ~7:1, exceeds AA requirement
+      expect(badge.className).toMatch(/text-green-800/)
+      expect(badge.className).toMatch(/bg-green-100/)
+    })
+
+    it('warning variant uses dark text on light background', () => {
+      render(<StatusBadge status="FROZEN" />)
+      const badge = screen.getByText('FROZEN')
+      // yellow-800 on yellow-100: contrast ratio ~7:1, exceeds AA requirement
+      expect(badge.className).toMatch(/text-yellow-800/)
+      expect(badge.className).toMatch(/bg-yellow-100/)
+    })
+
+    it('error variant uses dark text on light background', () => {
+      render(<StatusBadge status="FAILED" />)
+      const badge = screen.getByText('FAILED')
+      // red-800 on red-100: contrast ratio ~7:1, exceeds AA requirement
+      expect(badge.className).toMatch(/text-red-800/)
+      expect(badge.className).toMatch(/bg-red-100/)
+    })
+
+    it('info variant uses dark text on light background', () => {
+      render(<StatusBadge status="INITIATED" />)
+      const badge = screen.getByText('INITIATED')
+      // blue-800 on blue-100: contrast ratio ~7:1, exceeds AA requirement
+      expect(badge.className).toMatch(/text-blue-800/)
+      expect(badge.className).toMatch(/bg-blue-100/)
+    })
+
+    it('neutral variant uses dark text on light background', () => {
+      render(<StatusBadge status="CLOSED" />)
+      const badge = screen.getByText('CLOSED')
+      // gray-800 on gray-100: contrast ratio ~7:1, exceeds AA requirement
+      expect(badge.className).toMatch(/text-gray-800/)
+      expect(badge.className).toMatch(/bg-gray-100/)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Implements `StatusBadge` component at `frontend/src/components/shared/status-badge.tsx`
- Maps 20 status values across account, payment order, saga, tenant, reconciliation, and position quality ladder domains to 5 variants (success, warning, error, info, neutral)
- Loading skeleton with pulse animation via `data-testid="status-badge-skeleton"`
- WCAG AA compliant color contrast: dark text (x-800) on light backgrounds (x-100) for all variants
- Unknown statuses default to neutral variant
- Status text formatting: underscores replaced with spaces

## Changes Made

- `frontend/src/components/shared/status-badge.tsx` - StatusBadge component with STATUS_MAP and VARIANT_STYLES
- `frontend/src/test/status-badge.test.tsx` - 38 unit tests covering all status mappings, loading state, text formatting, and WCAG AA contrast

## Test plan

- [x] All 38 StatusBadge tests pass
- [x] Full suite (61 tests) passes with no regressions
- [x] Each status value maps to correct color variant
- [x] Unknown status defaults to neutral (gray)
- [x] Loading state renders skeleton, hides text
- [x] WCAG AA contrast verified via class assertions (dark-on-light pattern)

## Task Master

026-operations-console.12