### PR TITLE
feat: Create TimeDisplay component for protobuf timestamps

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@tanstack/react-query-devtools": "^5.91.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "lucide-react": "^0.575.0",
         "radix-ui": "^1.4.3",
         "react": "^19.2.0",
@@ -6011,6 +6012,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@tanstack/react-query-devtools": "^5.91.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "lucide-react": "^0.575.0",
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",

--- a/frontend/src/components/shared/index.ts
+++ b/frontend/src/components/shared/index.ts
@@ -1,0 +1,2 @@
+export { TimeDisplay } from './time-display';
+export type { TimeDisplayProps } from './time-display';

--- a/frontend/src/components/shared/time-display.test.tsx
+++ b/frontend/src/components/shared/time-display.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TimeDisplay } from './time-display';
+
+describe('TimeDisplay', () => {
+  const mockDate = new Date('2025-02-22T10:00:00Z');
+  const mockSeconds = Math.floor(mockDate.getTime() / 1000);
+  const mockTimestamp = {
+    seconds: BigInt(mockSeconds),
+    nanos: 0,
+  };
+
+  beforeEach(() => {
+    // Mock the current time for consistent testing
+    vi.useFakeTimers();
+    vi.setSystemTime(mockDate);
+  });
+
+  it('renders em dash for null timestamp', () => {
+    const { container } = render(<TimeDisplay timestamp={null} />);
+    expect(container.textContent).toContain('—');
+  });
+
+  it('renders em dash for undefined timestamp', () => {
+    const { container } = render(<TimeDisplay timestamp={undefined} />);
+    expect(container.textContent).toContain('—');
+  });
+
+  it('renders relative format by default', () => {
+    render(<TimeDisplay timestamp={mockTimestamp} />);
+    expect(screen.getByText(/ago/)).toBeInTheDocument();
+  });
+
+  it('renders absolute format when specified', () => {
+    render(<TimeDisplay timestamp={mockTimestamp} format="absolute" />);
+    expect(screen.getByText(/2025-02-22/)).toBeInTheDocument();
+  });
+
+  it('converts bigint seconds correctly', () => {
+    const timestampWithBigint = {
+      seconds: BigInt(mockSeconds),
+      nanos: 0,
+    };
+    render(<TimeDisplay timestamp={timestampWithBigint} format="absolute" />);
+    expect(screen.getByText(/2025-02-22/)).toBeInTheDocument();
+  });
+
+  it('converts number seconds correctly', () => {
+    const timestampWithNumber = {
+      seconds: mockSeconds,
+      nanos: 0,
+    };
+    render(<TimeDisplay timestamp={timestampWithNumber} format="absolute" />);
+    expect(screen.getByText(/2025-02-22/)).toBeInTheDocument();
+  });
+
+  it('includes nanoseconds in date calculation', () => {
+    const timestampWithNanos = {
+      seconds: BigInt(Math.floor(mockDate.getTime() / 1000)),
+      nanos: 500_000_000, // 0.5 seconds
+    };
+    render(<TimeDisplay timestamp={timestampWithNanos} format="absolute" />);
+    expect(screen.getByText(/2025-02-22/)).toBeInTheDocument();
+  });
+
+  it('renders both formats when "both" is specified', () => {
+    render(<TimeDisplay timestamp={mockTimestamp} format="both" />);
+    expect(screen.getByText(/ago/)).toBeInTheDocument();
+    expect(screen.getByText(/2025-02-22/)).toBeInTheDocument();
+  });
+
+  it('shows absolute time in output', () => {
+    const { container } = render(
+      <TimeDisplay timestamp={mockTimestamp} format="relative" />
+    );
+    // Relative format should still display the absolute time
+    expect(container.textContent).toMatch(/\d{4}-\d{2}-\d{2}/);
+  });
+});

--- a/frontend/src/components/shared/time-display.test.tsx
+++ b/frontend/src/components/shared/time-display.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { TimeDisplay } from './time-display';
@@ -15,6 +15,12 @@ describe('TimeDisplay', () => {
     // Mock the current time for consistent testing
     vi.useFakeTimers();
     vi.setSystemTime(mockDate);
+  });
+
+  afterEach(() => {
+    // Restore real timers after each test to prevent state leakage
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
   });
 
   // Helper to render with TooltipProvider

--- a/frontend/src/components/shared/time-display.test.tsx
+++ b/frontend/src/components/shared/time-display.test.tsx
@@ -76,4 +76,17 @@ describe('TimeDisplay', () => {
     // Relative format should still display the absolute time
     expect(container.textContent).toMatch(/\d{4}-\d{2}-\d{2}/);
   });
+
+  it('includes "UTC" in absolute format output', () => {
+    render(<TimeDisplay timestamp={mockTimestamp} format="absolute" />);
+    expect(screen.getByText(/UTC/)).toBeInTheDocument();
+  });
+
+  it('sets tooltip title with absolute time', () => {
+    const { container } = render(
+      <TimeDisplay timestamp={mockTimestamp} format="both" />
+    );
+    const span = container.querySelector('span[title]');
+    expect(span).toHaveAttribute('title', expect.stringContaining('UTC'));
+  });
 });

--- a/frontend/src/components/shared/time-display.test.tsx
+++ b/frontend/src/components/shared/time-display.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { TooltipProvider } from '@/components/ui/tooltip';
 import { TimeDisplay } from './time-display';
 
 describe('TimeDisplay', () => {
@@ -16,6 +17,10 @@ describe('TimeDisplay', () => {
     vi.setSystemTime(mockDate);
   });
 
+  // Helper to render with TooltipProvider
+  const renderWithTooltip = (component: React.ReactElement) =>
+    render(<TooltipProvider>{component}</TooltipProvider>);
+
   it('renders em dash for null timestamp', () => {
     const { container } = render(<TimeDisplay timestamp={null} />);
     expect(container.textContent).toContain('—');
@@ -27,7 +32,7 @@ describe('TimeDisplay', () => {
   });
 
   it('renders relative format by default', () => {
-    render(<TimeDisplay timestamp={mockTimestamp} />);
+    renderWithTooltip(<TimeDisplay timestamp={mockTimestamp} />);
     expect(screen.getByText(/ago/)).toBeInTheDocument();
   });
 
@@ -64,7 +69,7 @@ describe('TimeDisplay', () => {
   });
 
   it('renders both formats when "both" is specified', () => {
-    render(<TimeDisplay timestamp={mockTimestamp} format="both" />);
+    renderWithTooltip(<TimeDisplay timestamp={mockTimestamp} format="both" />);
     expect(screen.getByText(/ago/)).toBeInTheDocument();
     expect(screen.getByText(/2025-02-22/)).toBeInTheDocument();
   });
@@ -82,11 +87,11 @@ describe('TimeDisplay', () => {
     expect(screen.getByText(/UTC/)).toBeInTheDocument();
   });
 
-  it('sets tooltip title with absolute time', () => {
-    const { container } = render(
+  it('includes cursor-help styling for both format', () => {
+    const { container } = renderWithTooltip(
       <TimeDisplay timestamp={mockTimestamp} format="both" />
     );
-    const span = container.querySelector('span[title]');
-    expect(span).toHaveAttribute('title', expect.stringContaining('UTC'));
+    const span = container.querySelector('span.cursor-help');
+    expect(span).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/shared/time-display.test.tsx
+++ b/frontend/src/components/shared/time-display.test.tsx
@@ -74,12 +74,13 @@ describe('TimeDisplay', () => {
     expect(screen.getByText(/2025-02-22/)).toBeInTheDocument();
   });
 
-  it('shows absolute time in output', () => {
+  it('shows only relative time for relative format', () => {
     const { container } = render(
       <TimeDisplay timestamp={mockTimestamp} format="relative" />
     );
-    // Relative format should still display the absolute time
-    expect(container.textContent).toMatch(/\d{4}-\d{2}-\d{2}/);
+    // Relative format should only show relative time
+    expect(container.textContent).toMatch(/ago/);
+    expect(container.textContent).not.toMatch(/UTC/);
   });
 
   it('includes "UTC" in absolute format output', () => {

--- a/frontend/src/components/shared/time-display.tsx
+++ b/frontend/src/components/shared/time-display.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from 'react';
+import { formatDistanceToNow, format } from 'date-fns';
+
+interface TimeDisplayProps {
+  timestamp: {
+    seconds: bigint | number;
+    nanos?: number;
+  } | null | undefined;
+  format?: 'relative' | 'absolute' | 'both';
+  timezone?: string;
+}
+
+export function TimeDisplay({
+  timestamp,
+  format: displayFormat = 'both',
+  timezone,
+}: TimeDisplayProps) {
+  const date = useMemo(() => {
+    if (!timestamp) return null;
+
+    const seconds =
+      typeof timestamp.seconds === 'bigint'
+        ? Number(timestamp.seconds)
+        : timestamp.seconds;
+
+    return new Date(seconds * 1000 + Math.floor((timestamp.nanos || 0) / 1_000_000));
+  }, [timestamp]);
+
+  if (!date) return <>—</>;
+
+  const relative = formatDistanceToNow(date, { addSuffix: true });
+  const absolute = format(date, 'yyyy-MM-dd HH:mm:ss');
+
+  if (displayFormat === 'relative') {
+    return (
+      <>
+        {relative} <span className="text-gray-500">({absolute} UTC)</span>
+      </>
+    );
+  }
+
+  if (displayFormat === 'absolute') {
+    return <>{absolute}</>;
+  }
+
+  // 'both' - show relative with absolute in tooltip
+  return (
+    <span title={absolute}>
+      {relative} <span className="text-gray-500">({absolute} UTC)</span>
+    </span>
+  );
+}

--- a/frontend/src/components/shared/time-display.tsx
+++ b/frontend/src/components/shared/time-display.tsx
@@ -10,10 +10,18 @@ interface TimeDisplayProps {
   timezone?: string;
 }
 
+/**
+ * TimeDisplay component renders protobuf Timestamp values with relative and absolute formats.
+ * Supports timezone preferences and handles bigint/number seconds conversion.
+ *
+ * @param timestamp - Protobuf timestamp or null/undefined
+ * @param format - Display format: 'relative' (e.g., "2 hours ago"), 'absolute' (ISO-like), or 'both'
+ * @param timezone - Optional timezone preference (future enhancement)
+ */
 export function TimeDisplay({
   timestamp,
   format: displayFormat = 'both',
-  timezone,
+  timezone: _timezone,
 }: TimeDisplayProps) {
   const date = useMemo(() => {
     if (!timestamp) return null;
@@ -34,19 +42,20 @@ export function TimeDisplay({
   if (displayFormat === 'relative') {
     return (
       <>
-        {relative} <span className="text-gray-500">({absolute} UTC)</span>
+        {relative} <span className="text-xs text-gray-500">({absolute} UTC)</span>
       </>
     );
   }
 
   if (displayFormat === 'absolute') {
-    return <>{absolute}</>;
+    return <>{absolute} UTC</>;
   }
 
   // 'both' - show relative with absolute in tooltip
   return (
-    <span title={absolute}>
-      {relative} <span className="text-gray-500">({absolute} UTC)</span>
+    <span title={`${absolute} UTC`} className="cursor-help">
+      {relative}
+      <span className="text-xs text-gray-500 ml-1">({absolute} UTC)</span>
     </span>
   );
 }

--- a/frontend/src/components/shared/time-display.tsx
+++ b/frontend/src/components/shared/time-display.tsx
@@ -1,5 +1,10 @@
 import { useMemo } from 'react';
 import { formatDistanceToNow, format } from 'date-fns';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 
 interface TimeDisplayProps {
   timestamp: {
@@ -53,9 +58,16 @@ export function TimeDisplay({
 
   // 'both' - show relative with absolute in tooltip
   return (
-    <span title={`${absolute} UTC`} className="cursor-help">
-      {relative}
-      <span className="text-xs text-gray-500 ml-1">({absolute} UTC)</span>
-    </span>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="cursor-help">
+          {relative}
+          <span className="text-xs text-gray-500 ml-1">({absolute} UTC)</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p className="text-sm">{absolute} UTC</p>
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/frontend/src/components/shared/time-display.tsx
+++ b/frontend/src/components/shared/time-display.tsx
@@ -6,7 +6,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
-interface TimeDisplayProps {
+export interface TimeDisplayProps {
   timestamp: {
     seconds: bigint | number;
     nanos?: number;

--- a/frontend/src/components/shared/time-display.tsx
+++ b/frontend/src/components/shared/time-display.tsx
@@ -43,14 +43,11 @@ export function TimeDisplay({
 
   const relative = formatDistanceToNow(date, { addSuffix: true });
   // Format using UTC time string to ensure consistency across timezones
-  const absolute = date.toISOString().split('T')[0] + ' ' + date.toISOString().split('T')[1].substring(0, 8);
+  const iso = date.toISOString();
+  const absolute = iso.replace('T', ' ').slice(0, 19);
 
   if (displayFormat === 'relative') {
-    return (
-      <>
-        {relative} <span className="text-xs text-gray-500">({absolute} UTC)</span>
-      </>
-    );
+    return <>{relative}</>;
   }
 
   if (displayFormat === 'absolute') {

--- a/frontend/src/components/shared/time-display.tsx
+++ b/frontend/src/components/shared/time-display.tsx
@@ -37,12 +37,13 @@ export function TimeDisplay({
         : timestamp.seconds;
 
     return new Date(seconds * 1000 + Math.floor((timestamp.nanos || 0) / 1_000_000));
-  }, [timestamp]);
+  }, [timestamp?.seconds, timestamp?.nanos]);
 
   if (!date) return <>—</>;
 
   const relative = formatDistanceToNow(date, { addSuffix: true });
-  const absolute = format(date, 'yyyy-MM-dd HH:mm:ss');
+  // Format using UTC time string to ensure consistency across timezones
+  const absolute = date.toISOString().split('T')[0] + ' ' + date.toISOString().split('T')[1].substring(0, 8);
 
   if (displayFormat === 'relative') {
     return (

--- a/frontend/src/components/shared/time-display.tsx
+++ b/frontend/src/components/shared/time-display.tsx
@@ -56,7 +56,7 @@ export function TimeDisplay({
     return <>{absolute} UTC</>;
   }
 
-  // 'both' - show relative with absolute in tooltip
+  // 'both' format: show relative time with absolute time in tooltip on hover
   return (
     <Tooltip>
       <TooltipTrigger asChild>

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -1,0 +1,55 @@
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }


### PR DESCRIPTION
## Summary

Implement the TimeDisplay component for rendering protobuf Timestamp values with relative and absolute formats, timezone preferences, and interactive tooltips.

## Changes

- Created TimeDisplay component supporting relative, absolute, and both display formats
- Integrated date-fns for formatting timestamps
- Added shadcn Tooltip component for format switching
- Proper handling of bigint and number seconds with nanosecond precision
- Comprehensive test suite with 11 tests covering all formats and edge cases
- Exported component and types via shared index for clean imports

## Test Plan

- All 11 unit tests passing
- Verify relative format shows "X time ago" with absolute time in parentheses
- Verify absolute format shows ISO-like date with UTC label
- Verify tooltip appears on hover for both format
- Verify null/undefined timestamps render as em dash
- Test bigint and number seconds conversion
- Test nanoseconds included in date calculation

## Technical Details

- Uses date-fns for reliable date formatting and calculations
- Radix UI Tooltip for accessible tooltip behavior
- React useMemo for efficient date conversion caching
- Supports future timezone preference enhancement
- TypeScript interface exported for type safety