### PR TITLE
feat: Implement TenantContext for platform admin tenant switching

### DIFF
--- a/frontend/src/contexts/tenant-context.test.tsx
+++ b/frontend/src/contexts/tenant-context.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen, act, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { TenantProvider, useTenantContext } from '@/contexts/tenant-context'

--- a/frontend/src/contexts/tenant-context.test.tsx
+++ b/frontend/src/contexts/tenant-context.test.tsx
@@ -1,0 +1,353 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TenantProvider, useTenantContext } from '@/contexts/tenant-context'
+import { AuthProvider } from '@/contexts/auth-context'
+import {
+  createPlatformAdminToken,
+  createTenantUserToken,
+  createSuperAdminToken,
+} from '@/test/jwt-helpers'
+
+interface Tenant {
+  id: string
+  slug: string
+  name: string
+}
+
+function createTestTenant(overrides?: Partial<Tenant>): Tenant {
+  return {
+    id: 'tenant-id-1',
+    slug: 'acme-corp',
+    name: 'Acme Corp',
+    ...overrides,
+  }
+}
+
+function createWrapper(token?: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <AuthProvider initialToken={token}>
+        <QueryClientProvider client={queryClient}>
+          <TenantProvider>{children}</TenantProvider>
+        </QueryClientProvider>
+      </AuthProvider>
+    )
+  }
+}
+
+describe('TenantProvider - platform admin', () => {
+  it('starts with no selected tenant for platform admin', async () => {
+    const token = createPlatformAdminToken()
+    const Wrapper = createWrapper(token)
+
+    const TestComponent = () => {
+      const { currentTenant, tenantSlug, isPlatformAdmin } = useTenantContext()
+      return (
+        <div>
+          <span data-testid="tenant">{currentTenant ? currentTenant.slug : 'none'}</span>
+          <span data-testid="slug">{tenantSlug ?? 'none'}</span>
+          <span data-testid="isPlatformAdmin">{String(isPlatformAdmin)}</span>
+        </div>
+      )
+    }
+
+    await act(async () => {
+      render(<TestComponent />, { wrapper: Wrapper })
+    })
+
+    expect(screen.getByTestId('tenant').textContent).toBe('none')
+    expect(screen.getByTestId('slug').textContent).toBe('none')
+    expect(screen.getByTestId('isPlatformAdmin').textContent).toBe('true')
+  })
+
+  it('allows platform admin to switch tenants', async () => {
+    const token = createPlatformAdminToken()
+    const Wrapper = createWrapper(token)
+    const tenant = createTestTenant()
+
+    let switchFn: ((t: Tenant) => void) | null = null
+
+    const TestComponent = () => {
+      const { currentTenant, tenantSlug, switchTenant } = useTenantContext()
+      switchFn = switchTenant
+      return (
+        <div>
+          <span data-testid="tenant">{currentTenant ? currentTenant.slug : 'none'}</span>
+          <span data-testid="slug">{tenantSlug ?? 'none'}</span>
+        </div>
+      )
+    }
+
+    await act(async () => {
+      render(<TestComponent />, { wrapper: Wrapper })
+    })
+
+    expect(screen.getByTestId('tenant').textContent).toBe('none')
+
+    await act(async () => {
+      switchFn!(tenant)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tenant').textContent).toBe('acme-corp')
+      expect(screen.getByTestId('slug').textContent).toBe('acme-corp')
+    })
+  })
+
+  it('allows platform admin to clear tenant selection', async () => {
+    const token = createPlatformAdminToken()
+    const Wrapper = createWrapper(token)
+    const tenant = createTestTenant()
+
+    let switchFn: ((t: Tenant) => void) | null = null
+    let clearFn: (() => void) | null = null
+
+    const TestComponent = () => {
+      const { currentTenant, switchTenant, clearTenant } = useTenantContext()
+      switchFn = switchTenant
+      clearFn = clearTenant
+      return (
+        <span data-testid="tenant">{currentTenant ? currentTenant.slug : 'none'}</span>
+      )
+    }
+
+    await act(async () => {
+      render(<TestComponent />, { wrapper: Wrapper })
+    })
+
+    await act(async () => {
+      switchFn!(tenant)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tenant').textContent).toBe('acme-corp')
+    })
+
+    await act(async () => {
+      clearFn!()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tenant').textContent).toBe('none')
+    })
+  })
+
+  it('clears tenant-scoped queries when switching tenants', async () => {
+    const token = createPlatformAdminToken()
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const removeQueriesSpy = vi.spyOn(queryClient, 'removeQueries')
+
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthProvider initialToken={token}>
+        <QueryClientProvider client={queryClient}>
+          <TenantProvider>{children}</TenantProvider>
+        </QueryClientProvider>
+      </AuthProvider>
+    )
+
+    const tenantA = createTestTenant({ id: 'id-a', slug: 'tenant-a', name: 'Tenant A' })
+    const tenantB = createTestTenant({ id: 'id-b', slug: 'tenant-b', name: 'Tenant B' })
+
+    let switchFn: ((t: Tenant) => void) | null = null
+
+    const TestComponent = () => {
+      const { switchTenant } = useTenantContext()
+      switchFn = switchTenant
+      return null
+    }
+
+    await act(async () => {
+      render(<TestComponent />, { wrapper: Wrapper })
+    })
+
+    // Switch to first tenant
+    await act(async () => {
+      switchFn!(tenantA)
+    })
+
+    // Switch to second tenant - should remove queries scoped to tenantA
+    await act(async () => {
+      switchFn!(tenantB)
+    })
+
+    expect(removeQueriesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ predicate: expect.any(Function) }),
+    )
+  })
+
+  it('preserves platform-scoped queries when switching tenants', async () => {
+    const token = createPlatformAdminToken()
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const removeQueriesSpy = vi.spyOn(queryClient, 'removeQueries')
+
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthProvider initialToken={token}>
+        <QueryClientProvider client={queryClient}>
+          <TenantProvider>{children}</TenantProvider>
+        </QueryClientProvider>
+      </AuthProvider>
+    )
+
+    const tenantA = createTestTenant({ id: 'id-a', slug: 'tenant-a', name: 'Tenant A' })
+    const tenantB = createTestTenant({ id: 'id-b', slug: 'tenant-b', name: 'Tenant B' })
+
+    let switchFn: ((t: Tenant) => void) | null = null
+
+    const TestComponent = () => {
+      const { switchTenant } = useTenantContext()
+      switchFn = switchTenant
+      return null
+    }
+
+    await act(async () => {
+      render(<TestComponent />, { wrapper: Wrapper })
+    })
+
+    await act(async () => {
+      switchFn!(tenantA)
+    })
+
+    await act(async () => {
+      switchFn!(tenantB)
+    })
+
+    // Verify platform-scoped queries (those without tenant slug at index 1) are NOT removed
+    const predicate = removeQueriesSpy.mock.calls[0]?.[0]?.predicate
+    expect(predicate).toBeDefined()
+    if (predicate) {
+      // Platform-scoped query key (no tenant slug)
+      const platformQuery = { queryKey: ['platform', 'tenants'] } as Parameters<typeof predicate>[0]
+      expect(predicate(platformQuery)).toBe(false)
+
+      // Tenant-scoped query key with the previous tenant slug
+      const tenantQuery = { queryKey: ['tenant', 'tenant-a', 'accounts'] } as Parameters<typeof predicate>[0]
+      expect(predicate(tenantQuery)).toBe(true)
+
+      // Query with different tenant slug should NOT be removed
+      const otherTenantQuery = { queryKey: ['tenant', 'other-tenant', 'accounts'] } as Parameters<typeof predicate>[0]
+      expect(predicate(otherTenantQuery)).toBe(false)
+    }
+  })
+})
+
+describe('TenantProvider - super admin', () => {
+  it('treats super-admin as platform admin with switching capability', async () => {
+    const token = createSuperAdminToken()
+    const Wrapper = createWrapper(token)
+
+    const TestComponent = () => {
+      const { isPlatformAdmin } = useTenantContext()
+      return <span data-testid="isPlatformAdmin">{String(isPlatformAdmin)}</span>
+    }
+
+    await act(async () => {
+      render(<TestComponent />, { wrapper: Wrapper })
+    })
+
+    expect(screen.getByTestId('isPlatformAdmin').textContent).toBe('true')
+  })
+})
+
+describe('TenantProvider - tenant admin', () => {
+  it('returns fixed tenant from JWT for tenant admin', async () => {
+    const token = createTenantUserToken('acme-corp')
+    const Wrapper = createWrapper(token)
+
+    const TestComponent = () => {
+      const { currentTenant, tenantSlug, isPlatformAdmin } = useTenantContext()
+      return (
+        <div>
+          <span data-testid="tenant">{currentTenant ? currentTenant.slug : 'none'}</span>
+          <span data-testid="slug">{tenantSlug ?? 'none'}</span>
+          <span data-testid="isPlatformAdmin">{String(isPlatformAdmin)}</span>
+        </div>
+      )
+    }
+
+    await act(async () => {
+      render(<TestComponent />, { wrapper: Wrapper })
+    })
+
+    expect(screen.getByTestId('slug').textContent).toBe('acme-corp')
+    expect(screen.getByTestId('isPlatformAdmin').textContent).toBe('false')
+  })
+
+  it('tenant admin cannot switch tenants - switchTenant is a no-op', async () => {
+    const token = createTenantUserToken('acme-corp')
+    const Wrapper = createWrapper(token)
+    const anotherTenant = createTestTenant({ id: 'id-2', slug: 'other-corp', name: 'Other Corp' })
+
+    let switchFn: ((t: Tenant) => void) | null = null
+
+    const TestComponent = () => {
+      const { tenantSlug, switchTenant } = useTenantContext()
+      switchFn = switchTenant
+      return <span data-testid="slug">{tenantSlug ?? 'none'}</span>
+    }
+
+    await act(async () => {
+      render(<TestComponent />, { wrapper: Wrapper })
+    })
+
+    expect(screen.getByTestId('slug').textContent).toBe('acme-corp')
+
+    await act(async () => {
+      switchFn!(anotherTenant)
+    })
+
+    // Should NOT change - tenant admin cannot switch
+    expect(screen.getByTestId('slug').textContent).toBe('acme-corp')
+  })
+
+  it('tenant admin clearTenant is a no-op', async () => {
+    const token = createTenantUserToken('acme-corp')
+    const Wrapper = createWrapper(token)
+
+    let clearFn: (() => void) | null = null
+
+    const TestComponent = () => {
+      const { tenantSlug, clearTenant } = useTenantContext()
+      clearFn = clearTenant
+      return <span data-testid="slug">{tenantSlug ?? 'none'}</span>
+    }
+
+    await act(async () => {
+      render(<TestComponent />, { wrapper: Wrapper })
+    })
+
+    expect(screen.getByTestId('slug').textContent).toBe('acme-corp')
+
+    await act(async () => {
+      clearFn!()
+    })
+
+    // Should NOT change - tenant admin cannot clear
+    expect(screen.getByTestId('slug').textContent).toBe('acme-corp')
+  })
+})
+
+describe('useTenantContext - safety checks', () => {
+  it('throws when used outside TenantProvider', () => {
+    const TestComponent = () => {
+      useTenantContext()
+      return null
+    }
+
+    // Suppress expected error output
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    expect(() => render(<TestComponent />)).toThrow(
+      'useTenantContext must be used within a TenantProvider',
+    )
+
+    consoleSpy.mockRestore()
+  })
+})

--- a/frontend/src/contexts/tenant-context.tsx
+++ b/frontend/src/contexts/tenant-context.tsx
@@ -1,0 +1,73 @@
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useAuth } from '@/contexts/auth-context'
+
+export interface Tenant {
+  id: string
+  slug: string
+  name: string
+}
+
+export interface TenantContextValue {
+  currentTenant: Tenant | null
+  tenantSlug: string | null
+  isPlatformAdmin: boolean
+  switchTenant: (tenant: Tenant) => void
+  clearTenant: () => void
+}
+
+const TenantContext = createContext<TenantContextValue | null>(null)
+
+export function TenantProvider({ children }: { children: ReactNode }) {
+  const { claims, lens } = useAuth()
+  const queryClient = useQueryClient()
+  const [selectedTenant, setSelectedTenant] = useState<Tenant | null>(null)
+
+  const isPlatformAdmin = lens === 'platform'
+
+  const switchTenant = useCallback(
+    (tenant: Tenant) => {
+      if (!isPlatformAdmin) return
+
+      const previousSlug = selectedTenant?.slug
+      setSelectedTenant(tenant)
+
+      // Clear tenant-scoped queries for previous tenant
+      if (previousSlug) {
+        queryClient.removeQueries({
+          predicate: (query) => {
+            const key = query.queryKey
+            return Array.isArray(key) && key[1] === previousSlug
+          },
+        })
+      }
+    },
+    [isPlatformAdmin, selectedTenant, queryClient],
+  )
+
+  const clearTenant = useCallback(() => {
+    if (!isPlatformAdmin) return
+    setSelectedTenant(null)
+  }, [isPlatformAdmin])
+
+  // For tenant admins, tenant slug is fixed from JWT claims
+  const tenantSlug = isPlatformAdmin ? selectedTenant?.slug ?? null : claims?.tenantId ?? null
+
+  const value: TenantContextValue = {
+    currentTenant: isPlatformAdmin ? selectedTenant : null,
+    tenantSlug,
+    isPlatformAdmin,
+    switchTenant,
+    clearTenant,
+  }
+
+  return <TenantContext.Provider value={value}>{children}</TenantContext.Provider>
+}
+
+export function useTenantContext(): TenantContextValue {
+  const ctx = useContext(TenantContext)
+  if (!ctx) {
+    throw new Error('useTenantContext must be used within a TenantProvider')
+  }
+  return ctx
+}

--- a/frontend/src/hooks/use-tenant-context.ts
+++ b/frontend/src/hooks/use-tenant-context.ts
@@ -1,0 +1,21 @@
+import { useTenantContext } from '@/contexts/tenant-context'
+
+export function useCurrentTenant() {
+  return useTenantContext().currentTenant
+}
+
+export function useTenantSlug() {
+  return useTenantContext().tenantSlug
+}
+
+export function useIsPlatformAdmin() {
+  return useTenantContext().isPlatformAdmin
+}
+
+export function useSwitchTenant() {
+  return useTenantContext().switchTenant
+}
+
+export function useClearTenant() {
+  return useTenantContext().clearTenant
+}


### PR DESCRIPTION
## Summary

- Adds `TenantProvider` and `TenantContext` for managing the active tenant in the Operations Console
- Platform admins can switch between tenants; regular tenant users have a fixed tenant from their JWT
- Switching tenants clears tenant-scoped React Query cache entries while preserving platform-scoped queries

## Changes Made

**New files:**
- `frontend/src/contexts/tenant-context.tsx` — `TenantProvider`, `useTenantContext`, `Tenant` type
- `frontend/src/contexts/tenant-context.test.tsx` — 10 tests covering all scenarios
- `frontend/src/hooks/use-tenant-context.ts` — convenience hooks (`useCurrentTenant`, `useTenantSlug`, `useIsPlatformAdmin`, `useSwitchTenant`, `useClearTenant`)

## Technical Details

**Platform admin behaviour:**
- `isPlatformAdmin: true` when JWT `lens === 'platform'`
- `switchTenant(tenant)` updates `selectedTenant` and removes queries where `queryKey[1] === previousSlug`
- `clearTenant()` resets `selectedTenant` to null
- `tenantSlug` reflects the selected tenant's slug

**Tenant admin behaviour:**
- `isPlatformAdmin: false`
- `switchTenant` and `clearTenant` are no-ops (tenant is immutable)
- `tenantSlug` is sourced directly from `claims.tenantId` in JWT

**Query cache invalidation strategy:**
- Only queries with `queryKey[1] === previousTenantSlug` are removed on switch
- Platform-scoped queries (e.g. `['platform', 'tenants']`) are preserved

## Testing

- All 67 tests pass (`npm test`)
- TypeScript compiles cleanly (`tsc --noEmit`)
- TDD approach: tests written first, implementation followed

## Task Master

026-operations-console.8