### PR TITLE
feat: Create DataTable component with React Query pagination

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@connectrpc/connect-web": "^2.1.1",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-query-devtools": "^5.91.3",
+        "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.575.0",
@@ -4440,6 +4441,39 @@
       "peerDependencies": {
         "@tanstack/react-query": "^5.90.20",
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@connectrpc/connect-web": "^2.1.1",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-query-devtools": "^5.91.3",
+    "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",

--- a/frontend/src/components/shared/data-table.tsx
+++ b/frontend/src/components/shared/data-table.tsx
@@ -135,6 +135,7 @@ function FilterBar({
         return (
           <Input
             key={f.field}
+            aria-label={f.label}
             placeholder={`Filter by ${f.label}`}
             value={values[f.field] ?? ''}
             onChange={(e) => onChange(f.field, e.target.value)}

--- a/frontend/src/components/shared/data-table.tsx
+++ b/frontend/src/components/shared/data-table.tsx
@@ -4,9 +4,8 @@ import {
   getCoreRowModel,
   useReactTable,
   type ColumnDef,
-  type QueryKey,
 } from '@tanstack/react-table'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, type QueryKey } from '@tanstack/react-query'
 import {
   Table,
   TableBody,
@@ -25,7 +24,8 @@ export interface FilterOption {
 }
 
 export interface FilterConfig {
-  key: string
+  /** RPC request field this filter maps to */
+  field: string
   label: string
   type: 'text' | 'select'
   options?: FilterOption[]
@@ -106,16 +106,16 @@ function FilterBar({
       {filters.map((f) => {
         if (f.type === 'select' && f.options) {
           return (
-            <div key={f.key} className="flex flex-col gap-1">
-              <label htmlFor={`filter-${f.key}`} className="sr-only">
+            <div key={f.field} className="flex flex-col gap-1">
+              <label htmlFor={`filter-${f.field}`} className="sr-only">
                 {f.label}
               </label>
               <select
-                id={`filter-${f.key}`}
+                id={`filter-${f.field}`}
                 aria-label={f.label}
                 role="combobox"
-                value={values[f.key] ?? ''}
-                onChange={(e) => onChange(f.key, e.target.value)}
+                value={values[f.field] ?? ''}
+                onChange={(e) => onChange(f.field, e.target.value)}
                 className={cn(
                   'h-9 min-w-[140px] rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none',
                   'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
@@ -134,10 +134,10 @@ function FilterBar({
 
         return (
           <Input
-            key={f.key}
+            key={f.field}
             placeholder={`Filter by ${f.label}`}
-            value={values[f.key] ?? ''}
-            onChange={(e) => onChange(f.key, e.target.value)}
+            value={values[f.field] ?? ''}
+            onChange={(e) => onChange(f.field, e.target.value)}
             className="h-9 w-[200px]"
           />
         )

--- a/frontend/src/components/shared/data-table.tsx
+++ b/frontend/src/components/shared/data-table.tsx
@@ -1,0 +1,288 @@
+import * as React from 'react'
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+  type QueryKey,
+} from '@tanstack/react-table'
+import { useQuery } from '@tanstack/react-query'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+export interface FilterOption {
+  label: string
+  value: string
+}
+
+export interface FilterConfig {
+  key: string
+  label: string
+  type: 'text' | 'select'
+  options?: FilterOption[]
+}
+
+export interface DataTableQueryParams {
+  pageToken?: string
+  pageSize: number
+  filters?: Record<string, string>
+}
+
+export interface DataTableResult<T> {
+  items: T[]
+  nextPageToken?: string
+}
+
+export interface DataTableProps<T> {
+  queryKey: QueryKey
+  queryFn: (params: DataTableQueryParams) => Promise<DataTableResult<T>>
+  columns: ColumnDef<T>[]
+  pageSize?: number
+  filters?: FilterConfig[]
+  onRowClick?: (row: T) => void
+  className?: string
+}
+
+function SkeletonRow({ colCount }: { colCount: number }) {
+  return (
+    <TableRow data-testid="skeleton-row">
+      {Array.from({ length: colCount }).map((_, i) => (
+        <TableCell key={i}>
+          <div className="h-4 w-full animate-pulse rounded bg-muted" />
+        </TableCell>
+      ))}
+    </TableRow>
+  )
+}
+
+function EmptyState() {
+  return (
+    <TableRow>
+      <TableCell colSpan={99} className="h-32 text-center">
+        <div data-testid="empty-state" className="flex flex-col items-center gap-2 text-muted-foreground">
+          <span className="text-sm font-medium">No results</span>
+          <span className="text-xs">Try adjusting your filters.</span>
+        </div>
+      </TableCell>
+    </TableRow>
+  )
+}
+
+function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <TableRow>
+      <TableCell colSpan={99} className="h-32 text-center">
+        <div className="flex flex-col items-center gap-3 text-destructive">
+          <span className="text-sm font-medium">Failed to load data</span>
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            Retry
+          </Button>
+        </div>
+      </TableCell>
+    </TableRow>
+  )
+}
+
+function FilterBar({
+  filters,
+  values,
+  onChange,
+}: {
+  filters: FilterConfig[]
+  values: Record<string, string>
+  onChange: (key: string, value: string) => void
+}) {
+  return (
+    <div className="flex flex-wrap gap-2 pb-3">
+      {filters.map((f) => {
+        if (f.type === 'select' && f.options) {
+          return (
+            <div key={f.key} className="flex flex-col gap-1">
+              <label htmlFor={`filter-${f.key}`} className="sr-only">
+                {f.label}
+              </label>
+              <select
+                id={`filter-${f.key}`}
+                aria-label={f.label}
+                role="combobox"
+                value={values[f.key] ?? ''}
+                onChange={(e) => onChange(f.key, e.target.value)}
+                className={cn(
+                  'h-9 min-w-[140px] rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none',
+                  'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+                )}
+              >
+                <option value="">All {f.label}</option>
+                {f.options.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )
+        }
+
+        return (
+          <Input
+            key={f.key}
+            placeholder={`Filter by ${f.label}`}
+            value={values[f.key] ?? ''}
+            onChange={(e) => onChange(f.key, e.target.value)}
+            className="h-9 w-[200px]"
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+function PaginationBar({
+  hasNext,
+  hasPrev,
+  onNext,
+  onPrev,
+}: {
+  hasNext: boolean
+  hasPrev: boolean
+  onNext: () => void
+  onPrev: () => void
+}) {
+  if (!hasNext && !hasPrev) return null
+
+  return (
+    <div className="flex items-center justify-end gap-2 pt-3">
+      {hasPrev && (
+        <Button variant="outline" size="sm" onClick={onPrev}>
+          Previous
+        </Button>
+      )}
+      {hasNext && (
+        <Button variant="outline" size="sm" onClick={onNext}>
+          Next
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export function DataTable<T>({
+  queryKey,
+  queryFn,
+  columns,
+  pageSize = 25,
+  filters,
+  onRowClick,
+  className,
+}: DataTableProps<T>) {
+  const [activeFilters, setActiveFilters] = React.useState<Record<string, string>>({})
+  const [pageToken, setPageToken] = React.useState<string | undefined>(undefined)
+  const [hasPrev, setHasPrev] = React.useState(false)
+
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: [...(queryKey as unknown[]), { pageToken, ...activeFilters }],
+    queryFn: () => queryFn({ pageToken, pageSize, filters: activeFilters }),
+  })
+
+  const table = useReactTable({
+    data: data?.items ?? [],
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+  })
+
+  function handleFilterChange(key: string, value: string) {
+    setActiveFilters((prev) => {
+      const next = { ...prev }
+      if (value) {
+        next[key] = value
+      } else {
+        delete next[key]
+      }
+      return next
+    })
+    // Reset pagination on filter change
+    setPageToken(undefined)
+    setHasPrev(false)
+  }
+
+  function handleNextPage() {
+    if (data?.nextPageToken) {
+      setPageToken(data.nextPageToken)
+      setHasPrev(true)
+    }
+  }
+
+  function handlePrevPage() {
+    setPageToken(undefined)
+    setHasPrev(false)
+  }
+
+  const rows = table.getRowModel().rows
+
+  return (
+    <div className={cn('w-full', className)}>
+      {filters && filters.length > 0 && (
+        <FilterBar filters={filters} values={activeFilters} onChange={handleFilterChange} />
+      )}
+
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableHead key={header.id}>
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(header.column.columnDef.header, header.getContext())}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+
+        <TableBody>
+          {isLoading ? (
+            Array.from({ length: pageSize }).map((_, i) => (
+              <SkeletonRow key={i} colCount={columns.length} />
+            ))
+          ) : isError ? (
+            <ErrorState onRetry={() => void refetch()} />
+          ) : rows.length === 0 ? (
+            <EmptyState />
+          ) : (
+            rows.map((row) => (
+              <TableRow
+                key={row.id}
+                onClick={() => onRowClick?.(row.original)}
+                className={onRowClick ? 'cursor-pointer' : undefined}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+
+      <PaginationBar
+        hasNext={!!data?.nextPageToken}
+        hasPrev={hasPrev}
+        onNext={handleNextPage}
+        onPrev={handlePrevPage}
+      />
+    </div>
+  )
+}

--- a/frontend/src/test/data-table.test.tsx
+++ b/frontend/src/test/data-table.test.tsx
@@ -1,0 +1,443 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ColumnDef } from '@tanstack/react-table'
+import { DataTable } from '@/components/shared/data-table'
+
+type TestRow = { id: string; name: string; status: string }
+
+const columns: ColumnDef<TestRow>[] = [
+  { accessorKey: 'id', header: 'ID' },
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'status', header: 'Status' },
+]
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+    },
+  })
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = makeQueryClient()
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
+
+describe('DataTable - loading state', () => {
+  it('renders skeleton rows matching pageSize while loading', async () => {
+    const queryFn = vi.fn(() => new Promise(() => {})) // never resolves
+
+    render(
+      <Wrapper>
+        <DataTable
+          queryKey={['test']}
+          queryFn={queryFn}
+          columns={columns}
+          pageSize={5}
+        />
+      </Wrapper>,
+    )
+
+    const skeletons = screen.getAllByTestId('skeleton-row')
+    expect(skeletons).toHaveLength(5)
+  })
+})
+
+describe('DataTable - error state', () => {
+  it('renders error message and retry button on failure', async () => {
+    const queryFn = vi.fn().mockRejectedValue(new Error('Network error'))
+    const { rerender } = render(
+      <Wrapper>
+        <DataTable queryKey={['test-err']} queryFn={queryFn} columns={columns} />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    })
+    expect(screen.getByText(/failed to load data/i)).toBeInTheDocument()
+    rerender(<div />)
+  })
+
+  it('retry button calls refetch', async () => {
+    const queryFn = vi.fn().mockRejectedValue(new Error('fail'))
+    render(
+      <Wrapper>
+        <DataTable queryKey={['test-err2']} queryFn={queryFn} columns={columns} />
+      </Wrapper>,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument(),
+    )
+
+    const retryButton = screen.getByRole('button', { name: /retry/i })
+    await userEvent.click(retryButton)
+
+    await waitFor(() => {
+      expect(queryFn).toHaveBeenCalledTimes(2)
+    })
+  })
+})
+
+describe('DataTable - empty state', () => {
+  it('renders empty state when items array is empty', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ items: [] })
+
+    render(
+      <Wrapper>
+        <DataTable queryKey={['test-empty']} queryFn={queryFn} columns={columns} />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument()
+    })
+  })
+
+  it('shows "No results" text in empty state', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ items: [] })
+
+    render(
+      <Wrapper>
+        <DataTable queryKey={['test-empty2']} queryFn={queryFn} columns={columns} />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/no results/i)).toBeInTheDocument()
+    })
+  })
+})
+
+describe('DataTable - data rendering', () => {
+  const rows: TestRow[] = [
+    { id: 'r1', name: 'Alice', status: 'active' },
+    { id: 'r2', name: 'Bob', status: 'inactive' },
+  ]
+
+  it('renders column headers', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ items: rows })
+
+    render(
+      <Wrapper>
+        <DataTable queryKey={['test-cols']} queryFn={queryFn} columns={columns} />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: 'ID' })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('columnheader', { name: 'Status' }),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('renders data rows', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ items: rows })
+
+    render(
+      <Wrapper>
+        <DataTable queryKey={['test-rows']} queryFn={queryFn} columns={columns} />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice')).toBeInTheDocument()
+      expect(screen.getByText('Bob')).toBeInTheDocument()
+    })
+  })
+
+  it('calls onRowClick with row data when a row is clicked', async () => {
+    const onRowClick = vi.fn()
+    const queryFn = vi.fn().mockResolvedValue({ items: rows })
+
+    render(
+      <Wrapper>
+        <DataTable
+          queryKey={['test-click']}
+          queryFn={queryFn}
+          columns={columns}
+          onRowClick={onRowClick}
+        />
+      </Wrapper>,
+    )
+
+    await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('Alice'))
+
+    expect(onRowClick).toHaveBeenCalledWith(rows[0])
+  })
+
+  it('renders custom cell renderer when provided', async () => {
+    const customColumns: ColumnDef<TestRow>[] = [
+      {
+        accessorKey: 'status',
+        header: 'Status',
+        cell: ({ row }) => (
+          <span data-testid="custom-cell">{row.original.status.toUpperCase()}</span>
+        ),
+      },
+    ]
+    const queryFn = vi.fn().mockResolvedValue({ items: rows })
+
+    render(
+      <Wrapper>
+        <DataTable queryKey={['test-custom']} queryFn={queryFn} columns={customColumns} />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      const cells = screen.getAllByTestId('custom-cell')
+      expect(cells[0]).toHaveTextContent('ACTIVE')
+    })
+  })
+
+  it('has proper table semantics (role=table, columnheader, cell)', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ items: rows })
+
+    render(
+      <Wrapper>
+        <DataTable queryKey={['test-a11y']} queryFn={queryFn} columns={columns} />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument()
+    })
+    expect(screen.getAllByRole('columnheader')).toHaveLength(3)
+    expect(screen.getAllByRole('cell').length).toBeGreaterThan(0)
+  })
+})
+
+describe('DataTable - cursor-based pagination', () => {
+  it('does not show next button when no nextPageToken', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ items: [{ id: '1', name: 'A', status: 's' }] })
+
+    render(
+      <Wrapper>
+        <DataTable queryKey={['test-pg1']} queryFn={queryFn} columns={columns} />
+      </Wrapper>,
+    )
+
+    await waitFor(() => expect(screen.getByText('A')).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: /next/i })).not.toBeInTheDocument()
+  })
+
+  it('shows next page button when nextPageToken is present', async () => {
+    const queryFn = vi
+      .fn()
+      .mockResolvedValue({ items: [{ id: '1', name: 'A', status: 's' }], nextPageToken: 'tok1' })
+
+    render(
+      <Wrapper>
+        <DataTable queryKey={['test-pg2']} queryFn={queryFn} columns={columns} />
+      </Wrapper>,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument(),
+    )
+  })
+
+  it('passes pageToken to queryFn when next page clicked', async () => {
+    const queryFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        items: [{ id: '1', name: 'A', status: 's' }],
+        nextPageToken: 'tok1',
+      })
+      .mockResolvedValueOnce({ items: [{ id: '2', name: 'B', status: 's' }] })
+
+    render(
+      <Wrapper>
+        <DataTable queryKey={['test-pg3']} queryFn={queryFn} columns={columns} pageSize={25} />
+      </Wrapper>,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument(),
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: /next/i }))
+
+    await waitFor(() => {
+      expect(queryFn).toHaveBeenCalledWith(
+        expect.objectContaining({ pageToken: 'tok1', pageSize: 25 }),
+      )
+    })
+  })
+
+  it('shows previous page button after navigating to page 2', async () => {
+    const queryFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        items: [{ id: '1', name: 'A', status: 's' }],
+        nextPageToken: 'tok1',
+      })
+      .mockResolvedValueOnce({ items: [{ id: '2', name: 'B', status: 's' }] })
+
+    render(
+      <Wrapper>
+        <DataTable queryKey={['test-pg4']} queryFn={queryFn} columns={columns} />
+      </Wrapper>,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument(),
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: /next/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /previous/i })).toBeInTheDocument(),
+    )
+  })
+
+  it('previous page resets to first page (cursor pagination)', async () => {
+    const queryFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        items: [{ id: '1', name: 'A', status: 's' }],
+        nextPageToken: 'tok1',
+      })
+      .mockResolvedValueOnce({ items: [{ id: '2', name: 'B', status: 's' }] })
+
+    render(
+      <Wrapper>
+        <DataTable queryKey={['test-pg5']} queryFn={queryFn} columns={columns} />
+      </Wrapper>,
+    )
+
+    // First page: A is shown, next button is visible
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument(),
+    )
+    expect(screen.getByText('A')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /next/i }))
+
+    // Second page: B is shown, previous button is visible
+    await waitFor(() => expect(screen.getByText('B')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: /previous/i })).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /previous/i }))
+
+    // After going back: previous button disappears (we're on first page again)
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /previous/i })).not.toBeInTheDocument(),
+    )
+
+    // First page data is restored (from cache)
+    expect(screen.getByText('A')).toBeInTheDocument()
+  })
+})
+
+describe('DataTable - filter system', () => {
+  it('renders filter inputs when filters config is provided', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ items: [] })
+
+    render(
+      <Wrapper>
+        <DataTable
+          queryKey={['test-filter1']}
+          queryFn={queryFn}
+          columns={columns}
+          filters={[{ key: 'status', label: 'Status', type: 'text' }]}
+        />
+      </Wrapper>,
+    )
+
+    expect(screen.getByPlaceholderText(/filter by status/i)).toBeInTheDocument()
+  })
+
+  it('passes active filters to queryFn', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ items: [] })
+
+    render(
+      <Wrapper>
+        <DataTable
+          queryKey={['test-filter2']}
+          queryFn={queryFn}
+          columns={columns}
+          filters={[{ key: 'status', label: 'Status', type: 'text' }]}
+        />
+      </Wrapper>,
+    )
+
+    await waitFor(() => expect(queryFn).toHaveBeenCalledTimes(1))
+
+    const input = screen.getByPlaceholderText(/filter by status/i)
+    await userEvent.type(input, 'active')
+
+    await waitFor(() => {
+      const lastCall = queryFn.mock.calls[queryFn.mock.calls.length - 1][0]
+      expect(lastCall.filters).toMatchObject({ status: 'active' })
+    })
+  })
+
+  it('resets pagination when filters change', async () => {
+    const queryFn = vi
+      .fn()
+      .mockResolvedValue({ items: [{ id: '1', name: 'A', status: 's' }], nextPageToken: 'tok1' })
+
+    render(
+      <Wrapper>
+        <DataTable
+          queryKey={['test-filter3']}
+          queryFn={queryFn}
+          columns={columns}
+          filters={[{ key: 'name', label: 'Name', type: 'text' }]}
+        />
+      </Wrapper>,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument(),
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: /next/i }))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /previous/i })).toBeInTheDocument(),
+    )
+
+    // Changing filter should reset pagination
+    const input = screen.getByPlaceholderText(/filter by name/i)
+    await userEvent.type(input, 'A')
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /previous/i })).not.toBeInTheDocument()
+    })
+  })
+
+  it('renders select filter type', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ items: [] })
+
+    render(
+      <Wrapper>
+        <DataTable
+          queryKey={['test-filter4']}
+          queryFn={queryFn}
+          columns={columns}
+          filters={[
+            {
+              key: 'status',
+              label: 'Status',
+              type: 'select',
+              options: [
+                { label: 'Active', value: 'active' },
+                { label: 'Inactive', value: 'inactive' },
+              ],
+            },
+          ]}
+        />
+      </Wrapper>,
+    )
+
+    expect(screen.getByRole('combobox', { name: /status/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/data-table.test.tsx
+++ b/frontend/src/test/data-table.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -347,7 +347,7 @@ describe('DataTable - filter system', () => {
           queryKey={['test-filter1']}
           queryFn={queryFn}
           columns={columns}
-          filters={[{ key: 'status', label: 'Status', type: 'text' }]}
+          filters={[{ field: 'status', label: 'Status', type: 'text' }]}
         />
       </Wrapper>,
     )
@@ -364,7 +364,7 @@ describe('DataTable - filter system', () => {
           queryKey={['test-filter2']}
           queryFn={queryFn}
           columns={columns}
-          filters={[{ key: 'status', label: 'Status', type: 'text' }]}
+          filters={[{ field: 'status', label: 'Status', type: 'text' }]}
         />
       </Wrapper>,
     )
@@ -391,7 +391,7 @@ describe('DataTable - filter system', () => {
           queryKey={['test-filter3']}
           queryFn={queryFn}
           columns={columns}
-          filters={[{ key: 'name', label: 'Name', type: 'text' }]}
+          filters={[{ field: 'name', label: 'Name', type: 'text' }]}
         />
       </Wrapper>,
     )
@@ -425,7 +425,7 @@ describe('DataTable - filter system', () => {
           columns={columns}
           filters={[
             {
-              key: 'status',
+              field: 'status',
               label: 'Status',
               type: 'select',
               options: [


### PR DESCRIPTION
## Summary

- Implement reusable `DataTable` component using shadcn Table and TanStack Table v8
- Install `@tanstack/react-table` for column definitions and row model management
- Cursor-based pagination with `pageToken` state (next/previous navigation)
- Filter system supporting `text` and `select` filter types with automatic pagination reset on filter change
- Loading, error, and empty states with skeleton rows, retry button, and no-results message

## Changes Made

### `frontend/src/components/shared/data-table.tsx`
- `DataTable<T>` generic component accepting `queryKey`, `queryFn`, `columns`, `pageSize`, `filters`, `onRowClick`
- `FilterBar` sub-component renders text inputs and select dropdowns from `FilterConfig[]`
- `PaginationBar` sub-component with Next/Previous buttons driven by `nextPageToken`
- `SkeletonRow` renders animated placeholder rows while loading
- `ErrorState` shows error message and Retry button that calls `refetch()`
- `EmptyState` shows "No results" when items array is empty

### `frontend/src/test/data-table.test.tsx`
- 19 tests across loading, error, empty, data rendering, pagination, and filter scenarios
- Tests cover: skeleton count matches pageSize, retry calls refetch, row click callback, custom cell renderers, table semantic roles, next/previous pagination flow, filter→queryFn parameter passing, filter change resets pagination

## Technical Details

Cursor-based pagination uses a token stack pattern: navigating forward sets `pageToken` to `nextPageToken`; navigating backward resets `pageToken` to `undefined` (returns to first page). This matches the gRPC ListResponse pattern used in Meridian's APIs.

Filters are debounce-free by design - each keystroke triggers a query key update, letting TanStack Query cache intermediate results. Pagination resets on any filter change to avoid stale cursor state.

## Testing

All 42 tests pass (19 new + 23 existing):

```
✓ src/test/query-keys.test.ts (13 tests)
✓ src/test/query-client.test.ts (8 tests)
✓ src/test/App.test.tsx (2 tests)
✓ src/test/data-table.test.tsx (19 tests)
```

TypeScript: clean (`tsc --noEmit` passes with strict mode).

## Task Master

Implements 026-operations-console.13 (subtasks 13.1, 13.2, 13.3).