### PR TITLE
feat: Set up Connect-ES transport with tenant-aware base URL

### DIFF
--- a/frontend/buf.gen.yaml
+++ b/frontend/buf.gen.yaml
@@ -6,3 +6,5 @@ plugins:
     opt:
       - target=ts
       - import_extension=none
+    include_imports: true
+    include_wkt: true

--- a/frontend/src/api/clients.ts
+++ b/frontend/src/api/clients.ts
@@ -1,0 +1,37 @@
+import { createClient } from '@connectrpc/connect'
+import type { Transport } from '@connectrpc/connect'
+import { CurrentAccountService } from './gen/meridian/current_account/v1/current_account_pb'
+import { PaymentOrderService } from './gen/meridian/payment_order/v1/payment_order_pb'
+import { FinancialAccountingService } from './gen/meridian/financial_accounting/v1/financial_accounting_pb'
+import { PositionKeepingService } from './gen/meridian/position_keeping/v1/position_keeping_pb'
+import { AccountReconciliationService } from './gen/meridian/reconciliation/v1/reconciliation_pb'
+import { PartyService } from './gen/meridian/party/v1/party_pb'
+import { TenantService } from './gen/meridian/tenant/v1/tenant_pb'
+import { SagaRegistryService } from './gen/meridian/saga/v1/saga_registry_pb'
+import { SagaAdminService } from './gen/meridian/saga/v1/saga_admin_pb'
+import { ReferenceDataService } from './gen/meridian/reference_data/v1/instrument_pb'
+import { AccountTypeRegistryService } from './gen/meridian/reference_data/v1/account_type_pb'
+import { NodeService } from './gen/meridian/reference_data/v1/node_pb'
+import { InternalBankAccountService } from './gen/meridian/internal_bank_account/v1/internal_bank_account_pb'
+import { MarketInformationService } from './gen/meridian/market_information/v1/market_information_pb'
+
+export function createServiceClients(transport: Transport) {
+  return {
+    currentAccount: createClient(CurrentAccountService, transport),
+    paymentOrder: createClient(PaymentOrderService, transport),
+    financialAccounting: createClient(FinancialAccountingService, transport),
+    positionKeeping: createClient(PositionKeepingService, transport),
+    accountReconciliation: createClient(AccountReconciliationService, transport),
+    party: createClient(PartyService, transport),
+    tenant: createClient(TenantService, transport),
+    sagaRegistry: createClient(SagaRegistryService, transport),
+    sagaAdmin: createClient(SagaAdminService, transport),
+    referenceData: createClient(ReferenceDataService, transport),
+    accountTypeRegistry: createClient(AccountTypeRegistryService, transport),
+    node: createClient(NodeService, transport),
+    internalBankAccount: createClient(InternalBankAccountService, transport),
+    marketInformation: createClient(MarketInformationService, transport),
+  }
+}
+
+export type ServiceClients = ReturnType<typeof createServiceClients>

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -1,0 +1,30 @@
+const DEFAULT_API_BASE_URL = 'http://localhost:8080'
+
+function getApiBaseUrl(): string {
+  const url = import.meta.env.VITE_API_BASE_URL
+  if (!url) {
+    return DEFAULT_API_BASE_URL
+  }
+  try {
+    new URL(url)
+    return url
+  } catch {
+    console.warn(`Invalid VITE_API_BASE_URL: "${url}", falling back to default`)
+    return DEFAULT_API_BASE_URL
+  }
+}
+
+export const apiConfig = {
+  baseUrl: getApiBaseUrl(),
+  useBinaryFormat: import.meta.env.PROD,
+} as const
+
+export function buildTenantBaseUrl(tenantSlug: string): string {
+  const base = import.meta.env.VITE_API_BASE_URL
+  if (base && base !== DEFAULT_API_BASE_URL) {
+    const parsed = new URL(base)
+    parsed.hostname = `${tenantSlug}.${parsed.hostname}`
+    return parsed.toString().replace(/\/$/, '')
+  }
+  return `https://${tenantSlug}.api.meridian.io`
+}

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -20,7 +20,7 @@ export const apiConfig = {
 } as const
 
 export function buildTenantBaseUrl(tenantSlug: string): string {
-  const base = import.meta.env.VITE_API_BASE_URL
+  const base = apiConfig.baseUrl
   if (base && base !== DEFAULT_API_BASE_URL) {
     const parsed = new URL(base)
     parsed.hostname = `${tenantSlug}.${parsed.hostname}`

--- a/frontend/src/api/context.tsx
+++ b/frontend/src/api/context.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react'
+import { createTenantTransport } from './transport'
+import { createServiceClients, type ServiceClients } from './clients'
+import type { TokenGetter } from './interceptors/auth-interceptor'
+
+interface ApiClientContextValue {
+  clients: ServiceClients
+}
+
+const ApiClientContext = createContext<ApiClientContextValue | null>(null)
+
+interface ApiClientProviderProps {
+  tenantSlug: string | null
+  getToken: TokenGetter
+  children: ReactNode
+}
+
+export function ApiClientProvider({
+  tenantSlug,
+  getToken,
+  children,
+}: ApiClientProviderProps) {
+  const clients = useMemo(() => {
+    const transport = createTenantTransport(tenantSlug, getToken)
+    return createServiceClients(transport)
+  }, [tenantSlug, getToken])
+
+  return (
+    <ApiClientContext.Provider value={{ clients }}>
+      {children}
+    </ApiClientContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useApiClients(): ServiceClients {
+  const ctx = useContext(ApiClientContext)
+  if (!ctx) {
+    throw new Error('useApiClients must be used within an ApiClientProvider')
+  }
+  return ctx.clients
+}

--- a/frontend/src/api/interceptors/auth-interceptor.ts
+++ b/frontend/src/api/interceptors/auth-interceptor.ts
@@ -1,0 +1,13 @@
+import type { Interceptor } from '@connectrpc/connect'
+
+export type TokenGetter = () => string | null | undefined
+
+export function createAuthInterceptor(getToken: TokenGetter): Interceptor {
+  return (next) => async (req) => {
+    const token = getToken()
+    if (token) {
+      req.header.set('Authorization', `Bearer ${token}`)
+    }
+    return next(req)
+  }
+}

--- a/frontend/src/api/transport.ts
+++ b/frontend/src/api/transport.ts
@@ -1,0 +1,17 @@
+import { createConnectTransport } from '@connectrpc/connect-web'
+import type { Transport } from '@connectrpc/connect'
+import { createAuthInterceptor, type TokenGetter } from './interceptors/auth-interceptor'
+import { apiConfig, buildTenantBaseUrl } from './config'
+
+export function createTenantTransport(
+  tenantSlug: string | null,
+  getToken: TokenGetter,
+): Transport {
+  const baseUrl = tenantSlug ? buildTenantBaseUrl(tenantSlug) : apiConfig.baseUrl
+
+  return createConnectTransport({
+    baseUrl,
+    interceptors: [createAuthInterceptor(getToken)],
+    useBinaryFormat: apiConfig.useBinaryFormat,
+  })
+}

--- a/frontend/src/test/api/auth-interceptor.test.ts
+++ b/frontend/src/test/api/auth-interceptor.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createAuthInterceptor } from '@/api/interceptors/auth-interceptor'
+import type { UnaryRequest } from '@connectrpc/connect'
+
+function makeRequest(headers: Headers = new Headers()): UnaryRequest {
+  return {
+    header: headers,
+    url: 'https://example.com/test',
+    init: {},
+    signal: new AbortController().signal,
+    service: {} as UnaryRequest['service'],
+    method: {} as UnaryRequest['method'],
+    message: {},
+    contextValues: undefined as unknown as UnaryRequest['contextValues'],
+  }
+}
+
+describe('createAuthInterceptor', () => {
+  it('adds Authorization header when token is present', async () => {
+    const getToken = vi.fn(() => 'test-token-123')
+    const interceptor = createAuthInterceptor(getToken)
+    const req = makeRequest()
+    const next = vi.fn(async (_r: UnaryRequest) => ({ header: new Headers(), message: {} } as never))
+
+    await interceptor(next)(req)
+
+    expect(req.header.get('Authorization')).toBe('Bearer test-token-123')
+    expect(next).toHaveBeenCalledOnce()
+  })
+
+  it('does not add Authorization header when token is null', async () => {
+    const getToken = vi.fn(() => null)
+    const interceptor = createAuthInterceptor(getToken)
+    const req = makeRequest()
+    const next = vi.fn(async (_r: UnaryRequest) => ({ header: new Headers(), message: {} } as never))
+
+    await interceptor(next)(req)
+
+    expect(req.header.get('Authorization')).toBeNull()
+  })
+
+  it('does not add Authorization header when token is undefined', async () => {
+    const getToken = vi.fn(() => undefined)
+    const interceptor = createAuthInterceptor(getToken)
+    const req = makeRequest()
+    const next = vi.fn(async (_r: UnaryRequest) => ({ header: new Headers(), message: {} } as never))
+
+    await interceptor(next)(req)
+
+    expect(req.header.get('Authorization')).toBeNull()
+  })
+
+  it('calls next with the modified request', async () => {
+    const getToken = vi.fn(() => 'my-token')
+    const interceptor = createAuthInterceptor(getToken)
+    const req = makeRequest()
+    const mockResponse = { header: new Headers(), message: {} }
+    const next = vi.fn(async () => mockResponse as never)
+
+    const result = await interceptor(next)(req)
+
+    expect(next).toHaveBeenCalledWith(req)
+    expect(result).toBe(mockResponse)
+  })
+
+  it('uses Bearer prefix for the token', async () => {
+    const getToken = vi.fn(() => 'eyJhbGciOiJSUzI1NiJ9.payload.signature')
+    const interceptor = createAuthInterceptor(getToken)
+    const req = makeRequest()
+    const next = vi.fn(async () => ({ header: new Headers(), message: {} } as never))
+
+    await interceptor(next)(req)
+
+    expect(req.header.get('Authorization')).toBe(
+      'Bearer eyJhbGciOiJSUzI1NiJ9.payload.signature',
+    )
+  })
+})

--- a/frontend/src/test/api/clients.test.ts
+++ b/frontend/src/test/api/clients.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createServiceClients } from '@/api/clients'
+import type { Transport } from '@connectrpc/connect'
+
+vi.mock('@connectrpc/connect', () => ({
+  createClient: vi.fn((service, transport) => ({
+    __service: service.typeName,
+    __transport: transport,
+  })),
+}))
+
+import { createClient } from '@connectrpc/connect'
+
+function makeTransport(): Transport {
+  return {} as Transport
+}
+
+describe('createServiceClients', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns an object with all 14 service clients', () => {
+    const transport = makeTransport()
+    const clients = createServiceClients(transport)
+
+    expect(Object.keys(clients)).toHaveLength(14)
+  })
+
+  it('creates clients for all expected services', () => {
+    const transport = makeTransport()
+    const clients = createServiceClients(transport)
+
+    expect(clients).toHaveProperty('currentAccount')
+    expect(clients).toHaveProperty('paymentOrder')
+    expect(clients).toHaveProperty('financialAccounting')
+    expect(clients).toHaveProperty('positionKeeping')
+    expect(clients).toHaveProperty('accountReconciliation')
+    expect(clients).toHaveProperty('party')
+    expect(clients).toHaveProperty('tenant')
+    expect(clients).toHaveProperty('sagaRegistry')
+    expect(clients).toHaveProperty('sagaAdmin')
+    expect(clients).toHaveProperty('referenceData')
+    expect(clients).toHaveProperty('accountTypeRegistry')
+    expect(clients).toHaveProperty('node')
+    expect(clients).toHaveProperty('internalBankAccount')
+    expect(clients).toHaveProperty('marketInformation')
+  })
+
+  it('calls createClient for each service with the provided transport', () => {
+    const transport = makeTransport()
+    createServiceClients(transport)
+
+    expect(createClient).toHaveBeenCalledTimes(14)
+    vi.mocked(createClient).mock.calls.forEach(([, t]) => {
+      expect(t).toBe(transport)
+    })
+  })
+
+  it('returns different client instances for different transports', () => {
+    const transport1 = makeTransport()
+    const transport2 = makeTransport()
+
+    const clients1 = createServiceClients(transport1)
+    const clients2 = createServiceClients(transport2)
+
+    expect(clients1.currentAccount).not.toBe(clients2.currentAccount)
+  })
+})

--- a/frontend/src/test/api/config.test.ts
+++ b/frontend/src/test/api/config.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { buildTenantBaseUrl } from '@/api/config'
+
+describe('buildTenantBaseUrl', () => {
+  it('builds a tenant-scoped URL for a given slug', () => {
+    const url = buildTenantBaseUrl('acme')
+    expect(url).toContain('acme')
+  })
+
+  it('returns a valid URL string', () => {
+    const url = buildTenantBaseUrl('my-tenant')
+    expect(() => new URL(url)).not.toThrow()
+  })
+
+  it('does not end with a trailing slash', () => {
+    const url = buildTenantBaseUrl('acme')
+    expect(url).not.toMatch(/\/$/)
+  })
+
+  it('includes the tenant slug in the hostname', () => {
+    const url = buildTenantBaseUrl('my-org')
+    const parsed = new URL(url)
+    expect(parsed.hostname).toContain('my-org')
+  })
+})
+
+describe('apiConfig', () => {
+  it('exports a baseUrl string', async () => {
+    const { apiConfig } = await import('@/api/config')
+    expect(typeof apiConfig.baseUrl).toBe('string')
+    expect(apiConfig.baseUrl.length).toBeGreaterThan(0)
+  })
+
+  it('exports useBinaryFormat boolean', async () => {
+    const { apiConfig } = await import('@/api/config')
+    expect(typeof apiConfig.useBinaryFormat).toBe('boolean')
+  })
+})

--- a/frontend/src/test/api/context.test.tsx
+++ b/frontend/src/test/api/context.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, renderHook } from '@testing-library/react'
+import { ApiClientProvider, useApiClients } from '@/api/context'
+import type { ReactNode } from 'react'
+
+vi.mock('@/api/transport', () => ({
+  createTenantTransport: vi.fn(() => ({ __type: 'mock-transport' })),
+}))
+
+vi.mock('@/api/clients', () => ({
+  createServiceClients: vi.fn((transport) => ({
+    currentAccount: { __transport: transport },
+    paymentOrder: { __transport: transport },
+    financialAccounting: { __transport: transport },
+    positionKeeping: { __transport: transport },
+    accountReconciliation: { __transport: transport },
+    party: { __transport: transport },
+    tenant: { __transport: transport },
+    sagaRegistry: { __transport: transport },
+    sagaAdmin: { __transport: transport },
+    referenceData: { __transport: transport },
+    accountTypeRegistry: { __transport: transport },
+    node: { __transport: transport },
+    internalBankAccount: { __transport: transport },
+    marketInformation: { __transport: transport },
+  })),
+}))
+
+import { createTenantTransport } from '@/api/transport'
+import { createServiceClients } from '@/api/clients'
+
+describe('ApiClientProvider and useApiClients', () => {
+  const getToken = vi.fn(() => 'test-token')
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('provides service clients to children via hook', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ApiClientProvider tenantSlug="acme" getToken={getToken}>
+        {children}
+      </ApiClientProvider>
+    )
+
+    const { result } = renderHook(() => useApiClients(), { wrapper })
+
+    expect(result.current).toHaveProperty('currentAccount')
+    expect(result.current).toHaveProperty('paymentOrder')
+  })
+
+  it('throws when used outside ApiClientProvider', () => {
+    expect(() => renderHook(() => useApiClients())).toThrow(
+      'useApiClients must be used within an ApiClientProvider',
+    )
+  })
+
+  it('creates transport with tenant slug', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ApiClientProvider tenantSlug="acme" getToken={getToken}>
+        {children}
+      </ApiClientProvider>
+    )
+
+    renderHook(() => useApiClients(), { wrapper })
+
+    expect(createTenantTransport).toHaveBeenCalledWith('acme', getToken)
+  })
+
+  it('creates transport with null when no tenant slug', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ApiClientProvider tenantSlug={null} getToken={getToken}>
+        {children}
+      </ApiClientProvider>
+    )
+
+    renderHook(() => useApiClients(), { wrapper })
+
+    expect(createTenantTransport).toHaveBeenCalledWith(null, getToken)
+  })
+
+  it('recreates clients when tenant slug changes', () => {
+    const { rerender } = renderHook(() => useApiClients(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <ApiClientProvider tenantSlug="acme" getToken={getToken}>
+          {children}
+        </ApiClientProvider>
+      ),
+    })
+
+    expect(createServiceClients).toHaveBeenCalledTimes(1)
+
+    rerender()
+
+    // Same tenant - no recreation
+    expect(createServiceClients).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders children', () => {
+    const { getByText } = render(
+      <ApiClientProvider tenantSlug="acme" getToken={getToken}>
+        <span>test child</span>
+      </ApiClientProvider>,
+    )
+
+    expect(getByText('test child')).toBeDefined()
+  })
+})

--- a/frontend/src/test/api/transport.test.ts
+++ b/frontend/src/test/api/transport.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createTenantTransport } from '@/api/transport'
+
+vi.mock('@connectrpc/connect-web', () => ({
+  createConnectTransport: vi.fn((opts) => ({ __type: 'transport', opts })),
+}))
+
+vi.mock('@/api/config', () => ({
+  apiConfig: {
+    baseUrl: 'http://localhost:8080',
+    useBinaryFormat: false,
+  },
+  buildTenantBaseUrl: vi.fn((slug: string) => `https://${slug}.api.meridian.io`),
+}))
+
+import { createConnectTransport } from '@connectrpc/connect-web'
+import { buildTenantBaseUrl, apiConfig } from '@/api/config'
+
+describe('createTenantTransport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses apiConfig.baseUrl when tenantSlug is null', () => {
+    const getToken = vi.fn(() => 'token')
+    createTenantTransport(null, getToken)
+
+    expect(createConnectTransport).toHaveBeenCalledWith(
+      expect.objectContaining({ baseUrl: apiConfig.baseUrl }),
+    )
+  })
+
+  it('uses tenant-specific URL when tenantSlug is provided', () => {
+    const getToken = vi.fn(() => 'token')
+    createTenantTransport('acme', getToken)
+
+    expect(buildTenantBaseUrl).toHaveBeenCalledWith('acme')
+    expect(createConnectTransport).toHaveBeenCalledWith(
+      expect.objectContaining({ baseUrl: 'https://acme.api.meridian.io' }),
+    )
+  })
+
+  it('includes auth interceptor in transport config', () => {
+    const getToken = vi.fn(() => 'token')
+    createTenantTransport(null, getToken)
+
+    const callArgs = vi.mocked(createConnectTransport).mock.calls[0][0]
+    expect(callArgs.interceptors).toHaveLength(1)
+  })
+
+  it('passes useBinaryFormat from apiConfig', () => {
+    const getToken = vi.fn(() => null)
+    createTenantTransport(null, getToken)
+
+    expect(createConnectTransport).toHaveBeenCalledWith(
+      expect.objectContaining({ useBinaryFormat: false }),
+    )
+  })
+})

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL: string
+  readonly VITE_AUTH_AUDIENCE: string
+  readonly VITE_AUTH_CLIENT_ID: string
+  readonly VITE_AUTH_DOMAIN: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary

- Implements Connect-ES transport layer with tenant-aware base URL construction
- Auth interceptor injects Bearer tokens via a `TokenGetter` function (decoupled from AuthContext for parallel development)
- Service client factory creates typed clients for all 14 Meridian services
- `ApiClientProvider` React context recreates transport/clients when tenant slug changes
- Updates `buf.gen.yaml` to include dependency files (`include_imports: true`, `include_wkt: true`) required for generated service code to compile

## Changes

| File | Purpose |
|------|---------|
| `frontend/src/api/interceptors/auth-interceptor.ts` | Auth interceptor factory (subtask 6.1) |
| `frontend/src/api/transport.ts` | Tenant-aware transport factory (subtask 6.2) |
| `frontend/src/api/clients.ts` | Service client factory for 14 services (subtask 6.3) |
| `frontend/src/api/context.tsx` | React context + `useApiClients` hook (subtask 6.4) |
| `frontend/src/api/config.ts` | Environment config with URL validation (subtask 6.5) |
| `frontend/src/vite-env.d.ts` | TypeScript declarations for Vite env vars (subtask 6.5) |
| `frontend/buf.gen.yaml` | Add `include_imports`/`include_wkt` for dependency generation |

## Services Included (14)

`currentAccount`, `paymentOrder`, `financialAccounting`, `positionKeeping`, `accountReconciliation`, `party`, `tenant`, `sagaRegistry`, `sagaAdmin`, `referenceData`, `accountTypeRegistry`, `node`, `internalBankAccount`, `marketInformation`

## Testing

- 48 unit tests across 8 test files, all passing
- TypeScript compilation clean (`tsc --noEmit`)
- ESLint clean on new files

## Notes

- The `TokenGetter` type decouples the interceptor from `AuthContext` (task 026-operations-console.7), enabling parallel development. `ApiClientProvider` accepts `getToken` as a prop.
- Remaining pre-existing ESLint warnings in `src/components/ui/` are from task 4 (shadcn/ui generation) and are not introduced by this PR.

## Task Master

Implements 026-operations-console.6 (subtasks 6.1-6.5)