### PR TITLE
feat: Create AppShell layout component with two-lens navigation

### DIFF
--- a/frontend/src/components/layout/app-shell.test.tsx
+++ b/frontend/src/components/layout/app-shell.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, act } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AppShell } from '@/components/layout/app-shell'

--- a/frontend/src/components/layout/app-shell.test.tsx
+++ b/frontend/src/components/layout/app-shell.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { AppShell } from '@/components/layout/app-shell'
+import { AuthProvider } from '@/contexts/auth-context'
+import { TenantProvider } from '@/contexts/tenant-context'
+import { createPlatformAdminToken, createTenantUserToken } from '@/test/jwt-helpers'
+
+function renderWithProviders(ui: React.ReactElement, token?: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider initialToken={token}>
+        <TenantProvider>
+          {ui}
+        </TenantProvider>
+      </AuthProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('AppShell', () => {
+  describe('layout structure', () => {
+    it('renders children in the main content area', () => {
+      const token = createTenantUserToken()
+      renderWithProviders(
+        <AppShell>
+          <div data-testid="content">Page Content</div>
+        </AppShell>,
+        token
+      )
+
+      expect(screen.getByTestId('content')).toBeInTheDocument()
+      expect(screen.getByText('Page Content')).toBeInTheDocument()
+    })
+
+    it('renders the sidebar', () => {
+      const token = createTenantUserToken()
+      renderWithProviders(
+        <AppShell>
+          <div>Content</div>
+        </AppShell>,
+        token
+      )
+
+      expect(screen.getByRole('navigation')).toBeInTheDocument()
+    })
+
+    it('renders the header', () => {
+      const token = createTenantUserToken()
+      renderWithProviders(
+        <AppShell>
+          <div>Content</div>
+        </AppShell>,
+        token
+      )
+
+      expect(screen.getByRole('banner')).toBeInTheDocument()
+    })
+
+    it('renders main content region', () => {
+      const token = createTenantUserToken()
+      renderWithProviders(
+        <AppShell>
+          <div>Content</div>
+        </AppShell>,
+        token
+      )
+
+      expect(screen.getByRole('main')).toBeInTheDocument()
+    })
+  })
+
+  describe('two-lens navigation for tenant user', () => {
+    it('shows only tenant nav items for tenant user', () => {
+      const token = createTenantUserToken()
+      renderWithProviders(
+        <AppShell>
+          <div>Content</div>
+        </AppShell>,
+        token
+      )
+
+      expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: /tenant management/i })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('two-lens navigation for platform admin', () => {
+    it('shows both tenant and platform nav items for platform admin', () => {
+      const token = createPlatformAdminToken()
+      renderWithProviders(
+        <AppShell>
+          <div>Content</div>
+        </AppShell>,
+        token
+      )
+
+      expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: /tenant management/i })).toBeInTheDocument()
+    })
+
+    it('shows TenantSelector in header for platform admin', () => {
+      const token = createPlatformAdminToken()
+      renderWithProviders(
+        <AppShell>
+          <div>Content</div>
+        </AppShell>,
+        token
+      )
+
+      expect(screen.getByTestId('tenant-selector')).toBeInTheDocument()
+    })
+
+    it('hides TenantSelector in header for tenant user', () => {
+      const token = createTenantUserToken()
+      renderWithProviders(
+        <AppShell>
+          <div>Content</div>
+        </AppShell>,
+        token
+      )
+
+      expect(screen.queryByTestId('tenant-selector')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('mobile nav toggle', () => {
+    it('toggles sidebar open/closed when menu button is clicked', async () => {
+      const user = userEvent.setup()
+      const token = createTenantUserToken()
+      const { container } = renderWithProviders(
+        <AppShell>
+          <div>Content</div>
+        </AppShell>,
+        token
+      )
+
+      // Initially sidebar is closed on mobile (data-open="false")
+      const sidebar = container.querySelector('[data-open]')
+      expect(sidebar).toHaveAttribute('data-open', 'false')
+
+      // Click menu toggle
+      const menuButton = screen.getByRole('button', { name: /toggle.*menu|menu.*toggle|open.*sidebar|close.*sidebar/i })
+      await user.click(menuButton)
+
+      expect(sidebar).toHaveAttribute('data-open', 'true')
+    })
+
+    it('closes sidebar when menu button is clicked again', async () => {
+      const user = userEvent.setup()
+      const token = createTenantUserToken()
+      const { container } = renderWithProviders(
+        <AppShell>
+          <div>Content</div>
+        </AppShell>,
+        token
+      )
+
+      const sidebar = container.querySelector('[data-open]')
+      const menuButton = screen.getByRole('button', { name: /toggle.*menu|menu.*toggle|open.*sidebar|close.*sidebar/i })
+
+      await user.click(menuButton) // open
+      expect(sidebar).toHaveAttribute('data-open', 'true')
+
+      await user.click(menuButton) // close
+      expect(sidebar).toHaveAttribute('data-open', 'false')
+    })
+  })
+})

--- a/frontend/src/components/layout/app-shell.tsx
+++ b/frontend/src/components/layout/app-shell.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+import { Sidebar } from '@/components/layout/sidebar'
+import { Header } from '@/components/layout/header'
+import { useAuth } from '@/contexts/auth-context'
+
+interface AppShellProps {
+  children: React.ReactNode
+  currentPath?: string
+}
+
+export function AppShell({ children, currentPath = '/' }: AppShellProps) {
+  const { lens } = useAuth()
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-gray-100">
+      <Sidebar
+        lens={lens}
+        currentPath={currentPath}
+        isOpen={sidebarOpen}
+      />
+
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <Header onMenuToggle={() => setSidebarOpen((prev) => !prev)} />
+        <main className="flex-1 overflow-y-auto p-4">
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/app-shell.tsx
+++ b/frontend/src/components/layout/app-shell.tsx
@@ -3,6 +3,8 @@ import { Sidebar } from '@/components/layout/sidebar'
 import { Header } from '@/components/layout/header'
 import { useAuth } from '@/contexts/auth-context'
 
+const SIDEBAR_ID = 'app-sidebar'
+
 interface AppShellProps {
   children: React.ReactNode
   currentPath?: string
@@ -15,13 +17,18 @@ export function AppShell({ children, currentPath = '/' }: AppShellProps) {
   return (
     <div className="flex h-screen overflow-hidden bg-gray-100">
       <Sidebar
+        id={SIDEBAR_ID}
         lens={lens}
         currentPath={currentPath}
         isOpen={sidebarOpen}
       />
 
       <div className="flex flex-1 flex-col overflow-hidden">
-        <Header onMenuToggle={() => setSidebarOpen((prev) => !prev)} />
+        <Header
+          onMenuToggle={() => setSidebarOpen((prev) => !prev)}
+          sidebarOpen={sidebarOpen}
+          sidebarId={SIDEBAR_ID}
+        />
         <main className="flex-1 overflow-y-auto p-4">
           {children}
         </main>

--- a/frontend/src/components/layout/header.test.tsx
+++ b/frontend/src/components/layout/header.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Header } from '@/components/layout/header'
+import { AuthProvider } from '@/contexts/auth-context'
+import { TenantProvider } from '@/contexts/tenant-context'
+import { createPlatformAdminToken, createTenantUserToken } from '@/test/jwt-helpers'
+
+function renderWithProviders(ui: React.ReactElement, token?: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider initialToken={token}>
+        <TenantProvider>
+          {ui}
+        </TenantProvider>
+      </AuthProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('Header', () => {
+  describe('basic rendering', () => {
+    it('renders the Meridian logo/brand text', () => {
+      const token = createTenantUserToken()
+      renderWithProviders(<Header onMenuToggle={() => {}} />, token)
+
+      expect(screen.getByText(/meridian/i)).toBeInTheDocument()
+    })
+
+    it('renders a menu toggle button', () => {
+      const token = createTenantUserToken()
+      renderWithProviders(<Header onMenuToggle={() => {}} />, token)
+
+      expect(screen.getByRole('button', { name: /toggle.*menu|menu.*toggle|open.*sidebar|close.*sidebar/i })).toBeInTheDocument()
+    })
+
+    it('calls onMenuToggle when menu button is clicked', async () => {
+      const user = userEvent.setup()
+      const onMenuToggle = vi.fn()
+      const token = createTenantUserToken()
+      renderWithProviders(<Header onMenuToggle={onMenuToggle} />, token)
+
+      const menuButton = screen.getByRole('button', { name: /toggle.*menu|menu.*toggle|open.*sidebar|close.*sidebar/i })
+      await user.click(menuButton)
+
+      expect(onMenuToggle).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('TenantSelector visibility', () => {
+    it('shows TenantSelector for platform admin', () => {
+      const token = createPlatformAdminToken()
+      renderWithProviders(<Header onMenuToggle={() => {}} />, token)
+
+      // Platform admin should see tenant selector
+      expect(screen.getByTestId('tenant-selector')).toBeInTheDocument()
+    })
+
+    it('hides TenantSelector for tenant user', () => {
+      const token = createTenantUserToken()
+      renderWithProviders(<Header onMenuToggle={() => {}} />, token)
+
+      expect(screen.queryByTestId('tenant-selector')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('user menu', () => {
+    it('renders user menu trigger', () => {
+      const token = createTenantUserToken()
+      renderWithProviders(<Header onMenuToggle={() => {}} />, token)
+
+      expect(screen.getByRole('button', { name: /user.*menu|account|profile/i })).toBeInTheDocument()
+    })
+
+    it('shows logout option in user menu when opened', async () => {
+      const user = userEvent.setup()
+      const token = createTenantUserToken()
+      renderWithProviders(<Header onMenuToggle={() => {}} />, token)
+
+      const userMenuButton = screen.getByRole('button', { name: /user.*menu|account|profile/i })
+      await user.click(userMenuButton)
+
+      expect(screen.getByRole('menuitem', { name: /log.*out|sign.*out/i })).toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has a banner landmark role', () => {
+      const token = createTenantUserToken()
+      renderWithProviders(<Header onMenuToggle={() => {}} />, token)
+
+      expect(screen.getByRole('banner')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -1,0 +1,68 @@
+import { Menu, User, LogOut } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { useAuth } from '@/contexts/auth-context'
+import { useTenantContext } from '@/contexts/tenant-context'
+
+interface TenantSelectorProps {
+  // Placeholder component for TenantSelector - will be replaced with full implementation
+  // once Task 10 (TenantSelector) is complete
+}
+
+function TenantSelectorPlaceholder(_props: TenantSelectorProps) {
+  return (
+    <div data-testid="tenant-selector" className="flex items-center gap-2 text-sm text-gray-300">
+      <span>Select Tenant</span>
+    </div>
+  )
+}
+
+interface HeaderProps {
+  onMenuToggle: () => void
+}
+
+export function Header({ onMenuToggle }: HeaderProps) {
+  const { logout } = useAuth()
+  const { isPlatformAdmin } = useTenantContext()
+
+  return (
+    <header className="flex h-14 items-center gap-4 border-b bg-white px-4 shadow-sm">
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label="Toggle menu"
+        onClick={onMenuToggle}
+        className="shrink-0"
+      >
+        <Menu className="size-5" />
+      </Button>
+
+      <div className="flex items-center gap-2">
+        <span className="font-semibold text-gray-900">Meridian</span>
+      </div>
+
+      <div className="ml-auto flex items-center gap-4">
+        {isPlatformAdmin && <TenantSelectorPlaceholder />}
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" aria-label="User menu">
+              <User className="size-5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => logout()}>
+              <LogOut className="mr-2 size-4" />
+              Log out
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </header>
+  )
+}

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -24,9 +24,11 @@ function TenantSelectorPlaceholder(_props: TenantSelectorProps) {
 
 interface HeaderProps {
   onMenuToggle: () => void
+  sidebarOpen?: boolean
+  sidebarId?: string
 }
 
-export function Header({ onMenuToggle }: HeaderProps) {
+export function Header({ onMenuToggle, sidebarOpen, sidebarId }: HeaderProps) {
   const { logout } = useAuth()
   const { isPlatformAdmin } = useTenantContext()
 
@@ -36,6 +38,8 @@ export function Header({ onMenuToggle }: HeaderProps) {
         variant="ghost"
         size="icon"
         aria-label="Toggle menu"
+        aria-expanded={sidebarOpen}
+        aria-controls={sidebarId}
         onClick={onMenuToggle}
         className="shrink-0"
       >

--- a/frontend/src/components/layout/index.ts
+++ b/frontend/src/components/layout/index.ts
@@ -1,0 +1,3 @@
+export { AppShell } from '@/components/layout/app-shell'
+export { Sidebar } from '@/components/layout/sidebar'
+export { Header } from '@/components/layout/header'

--- a/frontend/src/components/layout/sidebar.test.tsx
+++ b/frontend/src/components/layout/sidebar.test.tsx
@@ -1,6 +1,5 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { Sidebar } from '@/components/layout/sidebar'
 
 describe('Sidebar', () => {

--- a/frontend/src/components/layout/sidebar.test.tsx
+++ b/frontend/src/components/layout/sidebar.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Sidebar } from '@/components/layout/sidebar'
+
+describe('Sidebar', () => {
+  describe('tenant lens', () => {
+    it('renders all tenant nav items', () => {
+      render(<Sidebar lens="tenant" />)
+
+      expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Accounts' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Internal Accounts' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Payments' })).toBeInTheDocument()
+    })
+
+    it('does not render platform-only nav items', () => {
+      render(<Sidebar lens="tenant" />)
+
+      expect(screen.queryByRole('link', { name: /tenant management/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: /platform monitoring/i })).not.toBeInTheDocument()
+    })
+
+    it('does not render separator between tenant and platform sections', () => {
+      const { container } = render(<Sidebar lens="tenant" />)
+      // No separator role element should appear
+      expect(container.querySelector('[role="separator"]')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('platform lens', () => {
+    it('renders all tenant nav items', () => {
+      render(<Sidebar lens="platform" />)
+
+      expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Accounts' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Internal Accounts' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Payments' })).toBeInTheDocument()
+    })
+
+    it('renders platform-only nav items', () => {
+      render(<Sidebar lens="platform" />)
+
+      expect(screen.getByRole('link', { name: /tenant management/i })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: /platform monitoring/i })).toBeInTheDocument()
+    })
+
+    it('renders separator between tenant and platform sections', () => {
+      const { container } = render(<Sidebar lens="platform" />)
+      expect(container.querySelector('[role="separator"]')).toBeInTheDocument()
+    })
+  })
+
+  describe('active state', () => {
+    it('marks the current path link as active', () => {
+      render(<Sidebar lens="tenant" currentPath="/" />)
+
+      const dashboardLink = screen.getByRole('link', { name: /dashboard/i })
+      expect(dashboardLink).toHaveAttribute('aria-current', 'page')
+    })
+
+    it('does not mark non-current links as active', () => {
+      render(<Sidebar lens="tenant" currentPath="/" />)
+
+      const accountsLink = screen.getByRole('link', { name: 'Accounts' })
+      expect(accountsLink).not.toHaveAttribute('aria-current', 'page')
+    })
+
+    it('marks accounts link active when on /accounts path', () => {
+      render(<Sidebar lens="tenant" currentPath="/accounts" />)
+
+      const accountsLink = screen.getByRole('link', { name: 'Accounts' })
+      expect(accountsLink).toHaveAttribute('aria-current', 'page')
+    })
+  })
+
+  describe('mobile collapsed state', () => {
+    it('accepts isOpen prop and renders with open state', () => {
+      const { container } = render(<Sidebar lens="tenant" isOpen={true} />)
+      expect(container.firstChild).toHaveAttribute('data-open', 'true')
+    })
+
+    it('renders with closed state when isOpen is false', () => {
+      const { container } = render(<Sidebar lens="tenant" isOpen={false} />)
+      expect(container.firstChild).toHaveAttribute('data-open', 'false')
+    })
+  })
+
+  describe('keyboard navigation', () => {
+    it('nav links are keyboard focusable', async () => {
+      render(<Sidebar lens="tenant" />)
+
+      const dashboardLink = screen.getByRole('link', { name: /dashboard/i })
+      dashboardLink.focus()
+      expect(dashboardLink).toHaveFocus()
+    })
+  })
+
+  describe('navigation label', () => {
+    it('has an accessible nav landmark', () => {
+      render(<Sidebar lens="tenant" />)
+      expect(screen.getByRole('navigation')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -34,13 +34,15 @@ interface SidebarProps {
   lens: 'platform' | 'tenant'
   currentPath?: string
   isOpen?: boolean
+  id?: string
 }
 
-export function Sidebar({ lens, currentPath = '/', isOpen = false }: SidebarProps) {
+export function Sidebar({ lens, currentPath = '/', isOpen = false, id }: SidebarProps) {
   const showPlatformItems = lens === 'platform'
 
   return (
     <aside
+      id={id}
       data-open={String(isOpen)}
       className={cn(
         'flex h-full w-64 flex-col bg-gray-900 text-white transition-transform duration-200',

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -1,0 +1,104 @@
+import {
+  LayoutDashboard,
+  Wallet,
+  Building,
+  ArrowLeftRight,
+  FileText,
+  BarChart2,
+  Building2,
+  Activity,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface NavItem {
+  label: string
+  href: string
+  icon: React.ComponentType<{ className?: string }>
+}
+
+const TENANT_NAV_ITEMS: NavItem[] = [
+  { label: 'Dashboard', href: '/', icon: LayoutDashboard },
+  { label: 'Accounts', href: '/accounts', icon: Wallet },
+  { label: 'Internal Accounts', href: '/internal-accounts', icon: Building },
+  { label: 'Payments', href: '/payments', icon: ArrowLeftRight },
+  { label: 'Transactions', href: '/transactions', icon: FileText },
+  { label: 'Reports', href: '/reports', icon: BarChart2 },
+]
+
+const PLATFORM_NAV_ITEMS: NavItem[] = [
+  { label: 'Tenant Management', href: '/tenants', icon: Building2 },
+  { label: 'Platform Monitoring', href: '/platform', icon: Activity },
+]
+
+interface SidebarProps {
+  lens: 'platform' | 'tenant'
+  currentPath?: string
+  isOpen?: boolean
+}
+
+export function Sidebar({ lens, currentPath = '/', isOpen = false }: SidebarProps) {
+  const showPlatformItems = lens === 'platform'
+
+  return (
+    <aside
+      data-open={String(isOpen)}
+      className={cn(
+        'flex h-full w-64 flex-col bg-gray-900 text-white transition-transform duration-200',
+        !isOpen && 'max-md:-translate-x-full',
+      )}
+    >
+      <nav aria-label="Main navigation" className="flex-1 overflow-y-auto py-4">
+        <ul role="list" className="space-y-1 px-2">
+          {TENANT_NAV_ITEMS.map((item) => {
+            const Icon = item.icon
+            const isActive = currentPath === item.href
+            return (
+              <li key={item.href}>
+                <a
+                  href={item.href}
+                  aria-current={isActive ? 'page' : undefined}
+                  className={cn(
+                    'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                    isActive
+                      ? 'bg-gray-700 text-white'
+                      : 'text-gray-300 hover:bg-gray-700 hover:text-white',
+                  )}
+                >
+                  <Icon className="size-4 shrink-0" />
+                  {item.label}
+                </a>
+              </li>
+            )
+          })}
+
+          {showPlatformItems && (
+            <>
+              <li role="separator" className="my-2 border-t border-gray-700" />
+              {PLATFORM_NAV_ITEMS.map((item) => {
+                const Icon = item.icon
+                const isActive = currentPath === item.href
+                return (
+                  <li key={item.href}>
+                    <a
+                      href={item.href}
+                      aria-current={isActive ? 'page' : undefined}
+                      className={cn(
+                        'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                        isActive
+                          ? 'bg-gray-700 text-white'
+                          : 'text-gray-300 hover:bg-gray-700 hover:text-white',
+                      )}
+                    >
+                      <Icon className="size-4 shrink-0" />
+                      {item.label}
+                    </a>
+                  </li>
+                )
+              })}
+            </>
+          )}
+        </ul>
+      </nav>
+    </aside>
+  )
+}


### PR DESCRIPTION
## Summary

- Implements task 026-operations-console.9: AppShell layout with two-lens navigation
- Unblocks task 17 (Router integration) which unblocks all page-level tasks

## Changes Made

### New Components (`frontend/src/components/layout/`)

**`sidebar.tsx`**
- `TENANT_NAV_ITEMS`: Dashboard, Accounts, Internal Accounts, Payments, Transactions, Reports
- `PLATFORM_NAV_ITEMS`: Tenant Management, Platform Monitoring
- Platform lens renders both sets with a separator between them
- Tenant lens renders only tenant items
- `aria-current="page"` on active nav item based on `currentPath` prop
- `data-open` attribute for mobile toggle state

**`header.tsx`**
- Menu toggle button with `aria-label="Toggle menu"`
- Meridian brand text
- `TenantSelectorPlaceholder` (with `data-testid="tenant-selector"`) shown only for platform admins — placeholder until Task 10 (TenantSelector) is complete
- User menu dropdown with Log out option

**`app-shell.tsx`**
- Composes Sidebar + Header + `<main>` content area
- `sidebarOpen` state managed via Header's `onMenuToggle` callback
- Reads `lens` from `useAuth()` to pass to Sidebar

**`index.ts`**
- Barrel export for all three layout components

## Testing

31 tests across 3 test files, all passing:

- `sidebar.test.tsx` (13 tests): tenant/platform lens rendering, separator presence, active state via `aria-current`, mobile open/closed state, keyboard focusability, nav landmark
- `header.test.tsx` (8 tests): brand text, menu toggle button, click callback, TenantSelector visibility per lens, user menu trigger, logout menu item, banner landmark
- `app-shell.test.tsx` (10 tests): children rendering, sidebar/header/main presence, two-lens nav items, TenantSelector conditional, mobile toggle open/close

Full suite: 163 tests passing (0 failures).

## Technical Details

- `TenantSelectorPlaceholder` is a stub with `data-testid="tenant-selector"` to satisfy tests and unblock this task; it will be replaced when Task 10 delivers the real `TenantSelector` component
- No router integration in AppShell itself; Task 17 will wire the router and pass `currentPath`
- Sidebar uses `aria-current="page"` per WCAG navigation pattern
- Header uses `role="banner"` (implicit from `<header>`), Sidebar uses `role="navigation"` (implicit from `<nav>`)