### PR TITLE
feat: Set up Vitest with React Testing Library and MSW

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,6 +40,7 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "jsdom": "^26.1.0",
+        "msw": "^2.12.10",
         "prettier": "^3.5.3",
         "shadcn": "^3.8.5",
         "tailwindcss": "^4.2.0",
@@ -47,7 +48,8 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1",
-        "vitest": "^3.2.4"
+        "vitest": "^3.2.4",
+        "vitest-axe": "^0.1.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -5403,6 +5405,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/axe-core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -6174,8 +6186,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -8328,6 +8339,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -11171,6 +11189,37 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest-axe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.0.0",
+        "axe-core": "^4.4.2",
+        "chalk": "^5.0.1",
+        "dom-accessibility-api": "^0.5.14",
+        "lodash-es": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.16.0"
+      }
+    },
+    "node_modules/vitest-axe/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "jsdom": "^26.1.0",
+    "msw": "^2.12.10",
     "prettier": "^3.5.3",
     "shadcn": "^3.8.5",
     "tailwindcss": "^4.2.0",
@@ -53,6 +54,7 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "vitest-axe": "^0.1.0"
   }
 }

--- a/frontend/src/test/msw-handlers.ts
+++ b/frontend/src/test/msw-handlers.ts
@@ -1,0 +1,55 @@
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+
+/**
+ * MSW handlers for Connect-ES service endpoints.
+ *
+ * Connect-ES in JSON mode uses HTTP POST requests with the path pattern:
+ *   /<package>.<ServiceName>/<MethodName>
+ *
+ * The wildcard handlers here catch all methods for each service, allowing
+ * individual tests to override with specific handlers using server.use().
+ */
+export const handlers = [
+  // CurrentAccountService - account lifecycle and operations
+  http.post('*/meridian.current_account.v1.CurrentAccountService/*', () => {
+    return HttpResponse.json({})
+  }),
+
+  // TenantService - platform tenant management
+  http.post('*/meridian.tenant.v1.TenantService/*', () => {
+    return HttpResponse.json({})
+  }),
+
+  // PaymentOrderService - payment order lifecycle
+  http.post('*/meridian.payment_order.v1.PaymentOrderService/*', () => {
+    return HttpResponse.json({})
+  }),
+
+  // SagaRegistryService - saga definition management
+  http.post('*/meridian.saga.v1.SagaRegistryService/*', () => {
+    return HttpResponse.json({})
+  }),
+
+  // SagaAdminService - saga execution management
+  http.post('*/meridian.saga.v1.SagaAdminService/*', () => {
+    return HttpResponse.json({})
+  }),
+
+  // HealthService - service health checks
+  http.post('*/meridian.common.v1.HealthService/*', () => {
+    return HttpResponse.json({ status: 'SERVING' })
+  }),
+
+  // AuthService - authentication
+  http.post('*/meridian.control_plane.v1.AuthService/*', () => {
+    return HttpResponse.json({})
+  }),
+
+  // REST auth refresh endpoint used by AuthContext
+  http.post('/api/auth/refresh', () => {
+    return HttpResponse.json({}, { status: 401 })
+  }),
+]
+
+export const server = setupServer(...handlers)

--- a/frontend/src/test/msw-integration.test.tsx
+++ b/frontend/src/test/msw-integration.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Integration tests verifying the MSW + RTL + vitest-axe test infrastructure.
+ *
+ * These tests confirm:
+ * 1. MSW intercepts Connect-ES JSON mode HTTP calls correctly
+ * 2. Custom renderWithProviders wraps components in all providers
+ * 3. vitest-axe accessibility audits run successfully
+ */
+import { describe, it, expect } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { server } from './msw-handlers'
+import { axe, renderWithProviders } from './test-utils'
+import { createPlatformAdminToken, createTenantUserToken } from './jwt-helpers'
+
+// Simple test component that makes a Connect-ES style fetch call
+function ConnectCallerComponent() {
+  return <div role="main" aria-label="Test component">Connect caller</div>
+}
+
+describe('MSW infrastructure', () => {
+  it('intercepts Connect-ES POST calls and returns default empty response', async () => {
+    let intercepted = false
+
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () => {
+        intercepted = true
+        return HttpResponse.json({ account: { id: 'acct-001', status: 'ACTIVE' } })
+      }),
+    )
+
+    const response = await fetch(
+      '/api/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ accountId: 'acct-001' }),
+      },
+    )
+
+    expect(intercepted).toBe(true)
+    expect(response.ok).toBe(true)
+    const body = await response.json() as { account: { id: string; status: string } }
+    expect(body.account.id).toBe('acct-001')
+    expect(body.account.status).toBe('ACTIVE')
+  })
+
+  it('resets handlers between tests so previous overrides do not bleed through', async () => {
+    // The handler from the previous test was reset by afterEach server.resetHandlers()
+    const response = await fetch(
+      '/api/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ accountId: 'acct-002' }),
+      },
+    )
+
+    expect(response.ok).toBe(true)
+    const body = await response.json() as Record<string, unknown>
+    // Falls back to default handler which returns empty object
+    expect(body).toEqual({})
+  })
+})
+
+describe('renderWithProviders', () => {
+  it('renders component with all provider context available', async () => {
+    const token = createPlatformAdminToken()
+
+    renderWithProviders(<ConnectCallerComponent />, { initialToken: token })
+
+    await waitFor(() => {
+      expect(screen.getByRole('main')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Connect caller')).toBeInTheDocument()
+  })
+
+  it('renders for tenant user token', async () => {
+    const token = createTenantUserToken('tenant-001')
+
+    renderWithProviders(<ConnectCallerComponent />, { initialToken: token })
+
+    expect(screen.getByRole('main')).toBeInTheDocument()
+  })
+
+  it('renders without token for unauthenticated state', () => {
+    renderWithProviders(<ConnectCallerComponent />)
+
+    expect(screen.getByRole('main')).toBeInTheDocument()
+  })
+})
+
+describe('vitest-axe accessibility audit', () => {
+  it('runs accessibility audit on a simple component and finds no violations', async () => {
+    const { container } = renderWithProviders(
+      <div>
+        <h1>Test Page</h1>
+        <nav aria-label="Main navigation">
+          <a href="/home">Home</a>
+        </nav>
+        <main>
+          <p>Page content</p>
+        </main>
+      </div>,
+    )
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('detects accessibility violations on non-compliant markup', async () => {
+    const { container } = renderWithProviders(
+      // img without alt attribute - deliberate accessibility violation for test
+      <div>
+        <img src="test.png" />
+      </div>,
+    )
+
+    const results = await axe(container)
+    // This should have violations (missing alt attribute)
+    expect(results.violations.length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,14 @@
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom/vitest'
+import { afterAll, afterEach, beforeAll, expect } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { toHaveNoViolations } from 'vitest-axe/matchers'
+import { server } from './msw-handlers'
+
+expect.extend({ toHaveNoViolations })
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => {
+  cleanup()
+  server.resetHandlers()
+})
+afterAll(() => server.close())

--- a/frontend/src/test/test-utils.tsx
+++ b/frontend/src/test/test-utils.tsx
@@ -1,0 +1,84 @@
+import { type ReactNode } from 'react'
+import { render, type RenderOptions, type RenderResult } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { configureAxe } from 'vitest-axe'
+import { AuthProvider } from '@/contexts/auth-context'
+import { TenantProvider } from '@/contexts/tenant-context'
+
+/**
+ * Pre-configured axe instance that skips color-contrast checks.
+ * Color contrast requires HTMLCanvasElement which is not available in jsdom.
+ * All other WCAG 2.1 AA rules remain active.
+ */
+export const axe = configureAxe({ rules: { 'color-contrast': { enabled: false } } })
+
+/**
+ * Creates a fresh QueryClient for each test to prevent cache pollution.
+ * Retries and error logging are disabled to keep test output clean.
+ */
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+        staleTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+    logger: {
+      log: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+  })
+}
+
+interface AllProvidersProps {
+  children: ReactNode
+  initialToken?: string
+  queryClient?: QueryClient
+}
+
+function AllProviders({ children, initialToken, queryClient }: AllProvidersProps) {
+  const client = queryClient ?? createTestQueryClient()
+  return (
+    <QueryClientProvider client={client}>
+      <AuthProvider initialToken={initialToken}>
+        <TenantProvider>{children}</TenantProvider>
+      </AuthProvider>
+    </QueryClientProvider>
+  )
+}
+
+interface CustomRenderOptions extends Omit<RenderOptions, 'wrapper'> {
+  initialToken?: string
+  queryClient?: QueryClient
+}
+
+/**
+ * Custom render function that wraps components in all application providers.
+ * Use this for integration tests that need the full provider tree.
+ *
+ * @example
+ * const { getByText } = renderWithProviders(<MyComponent />, {
+ *   initialToken: createTestToken({ userId: 'user-123' })
+ * })
+ */
+export function renderWithProviders(
+  ui: React.ReactElement,
+  { initialToken, queryClient, ...renderOptions }: CustomRenderOptions = {},
+): RenderResult {
+  return render(ui, {
+    wrapper: ({ children }) => (
+      <AllProviders initialToken={initialToken} queryClient={queryClient}>
+        {children}
+      </AllProviders>
+    ),
+    ...renderOptions,
+  })
+}
+
+export * from '@testing-library/react'

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
@@ -13,16 +12,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
-    },
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./src/test/setup.ts'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-      exclude: ['node_modules/', 'src/api/gen/', 'src/test/'],
     },
   },
 })

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    globals: true,
+    css: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'src/api/gen/', 'src/test/'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary

- Installs `msw@2` and `vitest-axe` as devDependencies
- Creates dedicated `vitest.config.ts` (jsdom environment, path aliases, coverage config) separate from `vite.config.ts`
- Creates `src/test/msw-handlers.ts` with MSW node server and wildcard Connect-ES JSON mode handlers for all meridian services (`CurrentAccountService`, `TenantService`, `PaymentOrderService`, `SagaRegistryService`, `SagaAdminService`, `HealthService`, `AuthService`)
- Updates `src/test/setup.ts` to add MSW server lifecycle hooks and registers `toHaveNoViolations` matcher from vitest-axe
- Creates `src/test/test-utils.tsx` with `renderWithProviders` (wraps `QueryClient`, `AuthProvider`, `TenantProvider`) and a pre-configured `axe` instance (color-contrast disabled for jsdom compatibility)
- Creates `src/test/msw-integration.test.tsx` with 7 tests verifying MSW interception, handler reset isolation, provider rendering, and accessibility audits

## Test plan

- [x] All 139 tests pass (`npm test -- --run`)
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] MSW intercepts Connect-ES POST calls and returns mock responses
- [x] Handler reset between tests verified (no bleed-through)
- [x] `renderWithProviders` wraps components with QueryClient, AuthProvider, TenantProvider
- [x] vitest-axe `toHaveNoViolations` matcher registered and working
- [x] Accessibility violations detected on non-compliant markup

## Technical notes

- `vitest-axe/dist/extend-expect.js` is empty in v0.1.0; matcher registration via `expect.extend({ toHaveNoViolations })` in setup.ts instead
- axe-core color-contrast rule disabled in test `axe` instance — requires `HTMLCanvasElement.getContext` which jsdom does not implement
- Note: basic vitest setup already existed from task 2 scaffolding; this task adds RTL and MSW integration as specified

Implements 026-operations-console.18