### PR TITLE
feat: Implement gRPC error handling with user-friendly messages

### DIFF
--- a/frontend/src/lib/error-handling.ts
+++ b/frontend/src/lib/error-handling.ts
@@ -1,0 +1,175 @@
+import { Code, ConnectError } from '@connectrpc/connect'
+import { useCallback } from 'react'
+
+/**
+ * Structured result from handling a ConnectError.
+ */
+export interface ConnectErrorResult {
+  /** User-friendly error message */
+  message: string
+  /** The gRPC/Connect status code */
+  code: Code
+  /** Field-level validation errors extracted from google.rpc.BadRequest details */
+  fieldErrors: Record<string, string>
+  /** Whether the caller should retry the operation */
+  shouldRetry: boolean
+  /** Path to redirect to, if applicable (e.g. /login for Unauthenticated) */
+  redirectTo?: string
+  /** The original error */
+  originalError: unknown
+}
+
+const ERROR_MESSAGES: Record<number, string> = {
+  [Code.Canceled]: 'The operation was canceled.',
+  [Code.Unknown]: 'An unexpected error occurred. Please try again.',
+  [Code.InvalidArgument]: 'The request contains invalid data.',
+  [Code.DeadlineExceeded]: 'The request timed out. Please try again.',
+  [Code.NotFound]: 'The requested resource was not found.',
+  [Code.AlreadyExists]: 'This resource already exists.',
+  [Code.PermissionDenied]: 'You do not have permission to perform this action.',
+  [Code.ResourceExhausted]: 'Rate limit exceeded. Please slow down and try again.',
+  [Code.FailedPrecondition]: 'The operation cannot be performed in the current state.',
+  [Code.Aborted]: 'The operation was aborted. Please try again.',
+  [Code.OutOfRange]: 'The provided value is out of the allowed range.',
+  [Code.Unimplemented]: 'This feature is not yet available.',
+  [Code.Internal]: 'An internal server error occurred. Please contact support if the problem persists.',
+  [Code.Unavailable]: 'The service is temporarily unavailable. Please try again shortly.',
+  [Code.DataLoss]: 'A data integrity error occurred. Please contact support.',
+  [Code.Unauthenticated]: 'Your session has expired. Please sign in again.',
+}
+
+type IncomingDetail = {
+  type: string
+  value: Uint8Array
+  debug?: unknown
+}
+
+interface BadRequestFieldViolation {
+  field: string
+  description: string
+}
+
+interface BadRequestDebug {
+  fieldViolations?: BadRequestFieldViolation[]
+}
+
+/**
+ * Extracts field-level errors from google.rpc.BadRequest error details.
+ */
+function extractFieldErrors(details: (IncomingDetail | object)[]): Record<string, string> {
+  const fieldErrors: Record<string, string> = {}
+
+  for (const detail of details) {
+    const d = detail as IncomingDetail
+    if (d.type !== 'google.rpc.BadRequest') continue
+
+    const debugData = d.debug as BadRequestDebug | null | undefined
+    const violations = debugData?.fieldViolations
+    if (!Array.isArray(violations)) continue
+
+    for (const violation of violations) {
+      if (
+        violation &&
+        typeof violation === 'object' &&
+        typeof (violation as BadRequestFieldViolation).field === 'string' &&
+        typeof (violation as BadRequestFieldViolation).description === 'string'
+      ) {
+        fieldErrors[(violation as BadRequestFieldViolation).field] =
+          (violation as BadRequestFieldViolation).description
+      }
+    }
+  }
+
+  return fieldErrors
+}
+
+export interface HandleConnectErrorOptions {
+  /** When provided, sets redirectTo to this path for NotFound errors */
+  navigateToParent?: string
+}
+
+/**
+ * Maps a ConnectError (or any thrown value) to a structured ConnectErrorResult.
+ *
+ * - Unauthenticated → redirectTo: '/login'
+ * - NotFound + navigateToParent option → redirectTo: navigateToParent
+ * - InvalidArgument → extracts field errors from google.rpc.BadRequest details
+ * - Unavailable → shouldRetry: true
+ */
+export function handleConnectError(
+  error: unknown,
+  options: HandleConnectErrorOptions = {},
+): ConnectErrorResult {
+  const connectError = ConnectError.from(error)
+  const code = connectError.code
+  const message =
+    ERROR_MESSAGES[code] ?? 'An unexpected error occurred. Please try again.'
+
+  const fieldErrors =
+    code === Code.InvalidArgument
+      ? extractFieldErrors(connectError.details)
+      : {}
+
+  let redirectTo: string | undefined
+  if (code === Code.Unauthenticated) {
+    redirectTo = '/login'
+  } else if (code === Code.NotFound && options.navigateToParent) {
+    redirectTo = options.navigateToParent
+  }
+
+  const shouldRetry = code === Code.Unavailable
+
+  return {
+    message,
+    code,
+    fieldErrors,
+    shouldRetry,
+    redirectTo,
+    originalError: error,
+  }
+}
+
+export interface WithErrorHandlingOptions extends HandleConnectErrorOptions {
+  /** Called with the structured error result */
+  onError: (result: ConnectErrorResult) => void
+  /** Called with the redirect path when a redirect is required */
+  onRedirect?: (path: string) => void
+}
+
+/**
+ * Creates a React Query mutation onError handler that maps gRPC errors
+ * to structured ConnectErrorResult values.
+ *
+ * Usage:
+ *   useMutation({
+ *     ...withErrorHandling({
+ *       onError: (result) => setError(result.message),
+ *       onRedirect: (path) => navigate(path),
+ *     })
+ *   })
+ */
+export function withErrorHandling(options: WithErrorHandlingOptions) {
+  const { onError, onRedirect, ...handlerOptions } = options
+
+  return {
+    onError(error: unknown) {
+      const result = handleConnectError(error, handlerOptions)
+      onError(result)
+      if (result.redirectTo && onRedirect) {
+        onRedirect(result.redirectTo)
+      }
+    },
+  }
+}
+
+/**
+ * React hook that returns a stable handleConnectError function bound to
+ * the provided options.
+ */
+export function useErrorHandler(options: HandleConnectErrorOptions = {}) {
+  return useCallback(
+    (error: unknown) => handleConnectError(error, options),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [options.navigateToParent],
+  )
+}

--- a/frontend/src/test/lib/error-handling.test.ts
+++ b/frontend/src/test/lib/error-handling.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Code, ConnectError } from '@connectrpc/connect'
+import {
+  handleConnectError,
+  withErrorHandling,
+  useErrorHandler,
+  type ConnectErrorResult,
+} from '@/lib/error-handling'
+
+// Helper to create a ConnectError with debug details (simulating wire format)
+function makeConnectError(
+  message: string,
+  code: Code,
+  details?: Array<{ type: string; debug: unknown }>,
+): ConnectError {
+  const err = new ConnectError(message, code)
+  if (details) {
+    // Simulate IncomingDetail format as received from wire
+    err.details = details.map((d) => ({
+      type: d.type,
+      value: new Uint8Array(),
+      debug: d.debug,
+    }))
+  }
+  return err
+}
+
+describe('handleConnectError', () => {
+  describe('error message mapping', () => {
+    it('maps Canceled to user-friendly message', () => {
+      const err = makeConnectError('operation canceled', Code.Canceled)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('The operation was canceled.')
+    })
+
+    it('maps Unknown to user-friendly message', () => {
+      const err = makeConnectError('unknown error', Code.Unknown)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('An unexpected error occurred. Please try again.')
+    })
+
+    it('maps InvalidArgument to user-friendly message', () => {
+      const err = makeConnectError('bad field', Code.InvalidArgument)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('The request contains invalid data.')
+    })
+
+    it('maps DeadlineExceeded to user-friendly message', () => {
+      const err = makeConnectError('timed out', Code.DeadlineExceeded)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('The request timed out. Please try again.')
+    })
+
+    it('maps NotFound to user-friendly message', () => {
+      const err = makeConnectError('not found', Code.NotFound)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('The requested resource was not found.')
+    })
+
+    it('maps AlreadyExists to user-friendly message', () => {
+      const err = makeConnectError('already exists', Code.AlreadyExists)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('This resource already exists.')
+    })
+
+    it('maps PermissionDenied to user-friendly message', () => {
+      const err = makeConnectError('forbidden', Code.PermissionDenied)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('You do not have permission to perform this action.')
+    })
+
+    it('maps ResourceExhausted to user-friendly message', () => {
+      const err = makeConnectError('rate limited', Code.ResourceExhausted)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('Rate limit exceeded. Please slow down and try again.')
+    })
+
+    it('maps FailedPrecondition to user-friendly message', () => {
+      const err = makeConnectError('precondition failed', Code.FailedPrecondition)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('The operation cannot be performed in the current state.')
+    })
+
+    it('maps Aborted to user-friendly message', () => {
+      const err = makeConnectError('aborted', Code.Aborted)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('The operation was aborted. Please try again.')
+    })
+
+    it('maps OutOfRange to user-friendly message', () => {
+      const err = makeConnectError('out of range', Code.OutOfRange)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('The provided value is out of the allowed range.')
+    })
+
+    it('maps Unimplemented to user-friendly message', () => {
+      const err = makeConnectError('not implemented', Code.Unimplemented)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('This feature is not yet available.')
+    })
+
+    it('maps Internal to user-friendly message', () => {
+      const err = makeConnectError('internal error', Code.Internal)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('An internal server error occurred. Please contact support if the problem persists.')
+    })
+
+    it('maps Unavailable to user-friendly message', () => {
+      const err = makeConnectError('service down', Code.Unavailable)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('The service is temporarily unavailable. Please try again shortly.')
+    })
+
+    it('maps DataLoss to user-friendly message', () => {
+      const err = makeConnectError('data lost', Code.DataLoss)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('A data integrity error occurred. Please contact support.')
+    })
+
+    it('maps Unauthenticated to user-friendly message', () => {
+      const err = makeConnectError('not authenticated', Code.Unauthenticated)
+      const result = handleConnectError(err)
+      expect(result.message).toBe('Your session has expired. Please sign in again.')
+    })
+
+    it('falls back to raw message for unrecognized codes', () => {
+      const err = makeConnectError('some unknown message', Code.Unknown)
+      // Override to simulate an unexpected code scenario
+      ;(err as unknown as { code: number }).code = 999
+      const result = handleConnectError(err)
+      expect(result.message).toBe('An unexpected error occurred. Please try again.')
+    })
+  })
+
+  describe('result structure', () => {
+    it('includes the original error', () => {
+      const err = makeConnectError('test', Code.Internal)
+      const result = handleConnectError(err)
+      expect(result.originalError).toBe(err)
+    })
+
+    it('includes the code', () => {
+      const err = makeConnectError('test', Code.NotFound)
+      const result = handleConnectError(err)
+      expect(result.code).toBe(Code.NotFound)
+    })
+
+    it('includes empty fieldErrors when no details', () => {
+      const err = makeConnectError('test', Code.InvalidArgument)
+      const result = handleConnectError(err)
+      expect(result.fieldErrors).toEqual({})
+    })
+
+    it('sets shouldRetry false by default', () => {
+      const err = makeConnectError('test', Code.Internal)
+      const result = handleConnectError(err)
+      expect(result.shouldRetry).toBe(false)
+    })
+
+    it('sets redirectTo undefined by default', () => {
+      const err = makeConnectError('test', Code.Internal)
+      const result = handleConnectError(err)
+      expect(result.redirectTo).toBeUndefined()
+    })
+  })
+
+  describe('Unauthenticated handling', () => {
+    it('sets redirectTo /login for Unauthenticated errors', () => {
+      const err = makeConnectError('session expired', Code.Unauthenticated)
+      const result = handleConnectError(err)
+      expect(result.redirectTo).toBe('/login')
+    })
+
+    it('does not set redirectTo for other error codes', () => {
+      const err = makeConnectError('forbidden', Code.PermissionDenied)
+      const result = handleConnectError(err)
+      expect(result.redirectTo).toBeUndefined()
+    })
+  })
+
+  describe('InvalidArgument field error extraction', () => {
+    it('extracts field violations from google.rpc.BadRequest details', () => {
+      const err = makeConnectError('validation failed', Code.InvalidArgument, [
+        {
+          type: 'google.rpc.BadRequest',
+          debug: {
+            fieldViolations: [
+              { field: 'amount', description: 'must be positive' },
+              { field: 'currency', description: 'is not supported' },
+            ],
+          },
+        },
+      ])
+      const result = handleConnectError(err)
+      expect(result.fieldErrors).toEqual({
+        amount: 'must be positive',
+        currency: 'is not supported',
+      })
+    })
+
+    it('handles multiple violations for the same field by using last one', () => {
+      const err = makeConnectError('validation failed', Code.InvalidArgument, [
+        {
+          type: 'google.rpc.BadRequest',
+          debug: {
+            fieldViolations: [
+              { field: 'amount', description: 'must be positive' },
+              { field: 'amount', description: 'must be less than 1000000' },
+            ],
+          },
+        },
+      ])
+      const result = handleConnectError(err)
+      expect(result.fieldErrors['amount']).toBe('must be less than 1000000')
+    })
+
+    it('returns empty fieldErrors when BadRequest has no violations', () => {
+      const err = makeConnectError('validation failed', Code.InvalidArgument, [
+        {
+          type: 'google.rpc.BadRequest',
+          debug: { fieldViolations: [] },
+        },
+      ])
+      const result = handleConnectError(err)
+      expect(result.fieldErrors).toEqual({})
+    })
+
+    it('returns empty fieldErrors for non-BadRequest detail types', () => {
+      const err = makeConnectError('validation failed', Code.InvalidArgument, [
+        {
+          type: 'google.rpc.ErrorInfo',
+          debug: { reason: 'QUOTA_EXCEEDED' },
+        },
+      ])
+      const result = handleConnectError(err)
+      expect(result.fieldErrors).toEqual({})
+    })
+
+    it('returns empty fieldErrors when details is empty', () => {
+      const err = makeConnectError('validation failed', Code.InvalidArgument)
+      const result = handleConnectError(err)
+      expect(result.fieldErrors).toEqual({})
+    })
+
+    it('ignores malformed BadRequest details gracefully', () => {
+      const err = makeConnectError('validation failed', Code.InvalidArgument, [
+        {
+          type: 'google.rpc.BadRequest',
+          debug: { notFieldViolations: 'garbage' },
+        },
+      ])
+      const result = handleConnectError(err)
+      expect(result.fieldErrors).toEqual({})
+    })
+  })
+
+  describe('NotFound handling', () => {
+    it('does not set redirectTo for NotFound by default', () => {
+      const err = makeConnectError('not found', Code.NotFound)
+      const result = handleConnectError(err)
+      expect(result.redirectTo).toBeUndefined()
+    })
+
+    it('sets redirectTo when navigateToParent option is provided', () => {
+      const err = makeConnectError('not found', Code.NotFound)
+      const result = handleConnectError(err, { navigateToParent: '/accounts' })
+      expect(result.redirectTo).toBe('/accounts')
+    })
+  })
+
+  describe('Unavailable handling', () => {
+    it('sets shouldRetry to true for Unavailable errors', () => {
+      const err = makeConnectError('service down', Code.Unavailable)
+      const result = handleConnectError(err)
+      expect(result.shouldRetry).toBe(true)
+    })
+
+    it('does not set shouldRetry for other error codes', () => {
+      const err = makeConnectError('internal error', Code.Internal)
+      const result = handleConnectError(err)
+      expect(result.shouldRetry).toBe(false)
+    })
+  })
+
+  describe('non-ConnectError input', () => {
+    it('handles plain Error objects', () => {
+      const err = new Error('plain error')
+      const result = handleConnectError(err)
+      expect(result.message).toBe('An unexpected error occurred. Please try again.')
+      expect(result.code).toBe(Code.Unknown)
+    })
+
+    it('handles string errors', () => {
+      const result = handleConnectError('something went wrong')
+      expect(result.message).toBe('An unexpected error occurred. Please try again.')
+    })
+
+    it('handles null', () => {
+      const result = handleConnectError(null)
+      expect(result.message).toBe('An unexpected error occurred. Please try again.')
+    })
+  })
+})
+
+describe('withErrorHandling', () => {
+  it('returns onError handler that calls handleConnectError', () => {
+    const onError = vi.fn()
+    const handler = withErrorHandling({ onError })
+    const err = makeConnectError('test error', Code.NotFound)
+
+    handler.onError(err)
+
+    expect(onError).toHaveBeenCalledOnce()
+    const result: ConnectErrorResult = onError.mock.calls[0][0]
+    expect(result.code).toBe(Code.NotFound)
+    expect(result.message).toBe('The requested resource was not found.')
+  })
+
+  it('passes options to handleConnectError', () => {
+    const onError = vi.fn()
+    const handler = withErrorHandling({ onError, navigateToParent: '/items' })
+    const err = makeConnectError('not found', Code.NotFound)
+
+    handler.onError(err)
+
+    const result: ConnectErrorResult = onError.mock.calls[0][0]
+    expect(result.redirectTo).toBe('/items')
+  })
+
+  it('calls onRedirect when redirectTo is set and onRedirect provided', () => {
+    const onError = vi.fn()
+    const onRedirect = vi.fn()
+    const handler = withErrorHandling({ onError, onRedirect })
+    const err = makeConnectError('session expired', Code.Unauthenticated)
+
+    handler.onError(err)
+
+    expect(onRedirect).toHaveBeenCalledWith('/login')
+  })
+
+  it('does not call onRedirect when redirectTo is not set', () => {
+    const onError = vi.fn()
+    const onRedirect = vi.fn()
+    const handler = withErrorHandling({ onError, onRedirect })
+    const err = makeConnectError('internal error', Code.Internal)
+
+    handler.onError(err)
+
+    expect(onRedirect).not.toHaveBeenCalled()
+  })
+})
+
+describe('useErrorHandler', () => {
+  it('is exported and is a function', () => {
+    expect(typeof useErrorHandler).toBe('function')
+  })
+})

--- a/frontend/src/test/lib/error-handling.test.ts
+++ b/frontend/src/test/lib/error-handling.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { Code, ConnectError } from '@connectrpc/connect'
 import {
   handleConnectError,


### PR DESCRIPTION
## Summary

- Creates `frontend/src/lib/error-handling.ts` with utilities for mapping ConnectError status codes to user-friendly messages
- Implements field-level error extraction from `google.rpc.BadRequest` error details
- Provides special handling for Unauthenticated (redirect to /login), NotFound (optional parent navigation), and Unavailable (shouldRetry flag)
- Adds `withErrorHandling` wrapper for React Query mutations and `useErrorHandler` React hook

## Changes Made

**New files:**
- `frontend/src/lib/error-handling.ts` — Core error handling utilities
- `frontend/src/test/lib/error-handling.test.ts` — 42 tests covering all code paths

**Key exports:**
- `handleConnectError(error, options?)` — Maps any thrown value to a structured `ConnectErrorResult`
- `withErrorHandling(options)` — React Query mutation `onError` handler factory
- `useErrorHandler(options?)` — React hook returning a stable error handler function
- `ConnectErrorResult` — Typed result with `message`, `code`, `fieldErrors`, `shouldRetry`, `redirectTo`

## Technical Details

- Uses `ConnectError.from()` to normalise any thrown value to a ConnectError
- Extracts `google.rpc.BadRequest` field violations from the `debug` JSON in `IncomingDetail` (no generated proto types required)
- All 16 gRPC status codes mapped to human-readable messages
- `Unavailable` → `shouldRetry: true`; `Unauthenticated` → `redirectTo: '/login'`

## Testing

- 42 unit tests covering: all code mappings, field error extraction, special case handlers, withErrorHandling wrapper, and non-ConnectError inputs
- TDD approach: tests written first, all passing

## Risk Assessment

Low risk — new utility file with no side effects; no existing code modified.

## Task Reference

026-operations-console.38