### PR TITLE
feat: Set up React Router with route configuration

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "radix-ui": "^1.4.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-router-dom": "^7.13.0",
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
@@ -9747,6 +9748,57 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
+      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -10064,6 +10116,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-router-dom": "^7.13.0",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { queryClient } from '@/lib/query-client'
@@ -113,8 +113,6 @@ export function App() {
                     </ProtectedRoute>
                   }
                 />
-                {/* Redirect root to dashboard if somehow missed */}
-                <Route path="*" element={<Navigate to="/" replace />} />
               </Routes>
             </BrowserRouter>
           </TenantProvider>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,124 @@
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { queryClient } from '@/lib/query-client'
 import { PageErrorBoundary } from '@/components/error-boundary'
+import { AuthProvider } from '@/contexts/auth-context'
+import { TenantProvider } from '@/contexts/tenant-context'
+import { ProtectedRoute, PlatformOnlyRoute } from '@/components/routing'
+import { AppShell } from '@/components/layout/app-shell'
 
-function App() {
+// Placeholder page components - replaced as each page task is implemented
+function PlaceholderPage({ title }: { title: string }) {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold">{title}</h1>
+      <p className="mt-2 text-muted-foreground">Coming soon.</p>
+    </div>
+  )
+}
+
+function LoginPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="text-center">
+        <h1 className="text-2xl font-semibold">Meridian Operations Console</h1>
+        <p className="mt-2 text-muted-foreground">Please sign in to continue.</p>
+      </div>
+    </div>
+  )
+}
+
+function NotFoundPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold">404 - Page Not Found</h1>
+      <p className="mt-2 text-muted-foreground">The page you are looking for does not exist.</p>
+    </div>
+  )
+}
+
+/**
+ * Layout wrapper that reads the current path from React Router
+ * and passes it to AppShell for active nav highlighting.
+ */
+function AppShellLayout() {
+  const { pathname } = useLocation()
+  return (
+    <AppShell currentPath={pathname}>
+      <Routes>
+        {/* Tenant-scoped routes */}
+        <Route path="/" element={<PlaceholderPage title="Dashboard" />} />
+        <Route path="/accounts" element={<PlaceholderPage title="Accounts" />} />
+        <Route
+          path="/internal-accounts"
+          element={<PlaceholderPage title="Internal Accounts" />}
+        />
+        <Route path="/payments" element={<PlaceholderPage title="Payments" />} />
+        <Route path="/transactions" element={<PlaceholderPage title="Transactions" />} />
+        <Route path="/positions" element={<PlaceholderPage title="Positions" />} />
+        <Route path="/ledger" element={<PlaceholderPage title="Ledger" />} />
+        <Route path="/parties" element={<PlaceholderPage title="Parties" />} />
+        <Route path="/reconciliation" element={<PlaceholderPage title="Reconciliation" />} />
+        <Route
+          path="/starlark-config"
+          element={<PlaceholderPage title="Starlark Configuration" />}
+        />
+        <Route path="/reference-data" element={<PlaceholderPage title="Reference Data" />} />
+        <Route
+          path="/gateway-mappings"
+          element={<PlaceholderPage title="Gateway Mappings" />}
+        />
+        <Route path="/audit-log" element={<PlaceholderPage title="Audit Log" />} />
+
+        {/* Platform-only routes */}
+        <Route
+          path="/tenants"
+          element={
+            <PlatformOnlyRoute>
+              <PlaceholderPage title="Tenant Management" />
+            </PlatformOnlyRoute>
+          }
+        />
+        <Route
+          path="/platform"
+          element={
+            <PlatformOnlyRoute>
+              <PlaceholderPage title="Platform Monitoring" />
+            </PlatformOnlyRoute>
+          }
+        />
+
+        {/* 404 */}
+        <Route path="*" element={<NotFoundPage />} />
+      </Routes>
+    </AppShell>
+  )
+}
+
+export function App() {
   return (
     <PageErrorBoundary>
       <QueryClientProvider client={queryClient}>
-        <div>
-          <h1>Meridian Operations Console</h1>
-        </div>
+        <AuthProvider>
+          <TenantProvider>
+            <BrowserRouter>
+              <Routes>
+                <Route path="/login" element={<LoginPage />} />
+                <Route
+                  path="/*"
+                  element={
+                    <ProtectedRoute>
+                      <AppShellLayout />
+                    </ProtectedRoute>
+                  }
+                />
+                {/* Redirect root to dashboard if somehow missed */}
+                <Route path="*" element={<Navigate to="/" replace />} />
+              </Routes>
+            </BrowserRouter>
+          </TenantProvider>
+        </AuthProvider>
         {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
       </QueryClientProvider>
     </PageErrorBoundary>

--- a/frontend/src/components/routing.tsx
+++ b/frontend/src/components/routing.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react'
+import { Navigate } from 'react-router-dom'
+import { useAuth } from '@/contexts/auth-context'
+
+interface ProtectedRouteProps {
+  children: ReactNode
+}
+
+/**
+ * Redirects unauthenticated users to /login.
+ * Wrap any route that requires authentication.
+ */
+export function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const { isAuthenticated } = useAuth()
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />
+  }
+  return <>{children}</>
+}
+
+interface PlatformOnlyRouteProps {
+  children: ReactNode
+}
+
+/**
+ * Redirects non-platform users to /.
+ * Wrap any route that requires platform-admin or super-admin lens.
+ */
+export function PlatformOnlyRoute({ children }: PlatformOnlyRouteProps) {
+  const { lens } = useAuth()
+  if (lens !== 'platform') {
+    return <Navigate to="/" replace />
+  }
+  return <>{children}</>
+}

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -7,10 +7,48 @@ export interface Route {
 }
 
 const routes: Route[] = [
+  { path: '/', name: 'Dashboard', component: () => <div>Dashboard</div> },
+  { path: '/accounts', name: 'Accounts', component: () => <div>Accounts</div> },
   {
-    path: '/',
-    name: 'Dashboard',
-    component: () => <div>Dashboard</div>,
+    path: '/internal-accounts',
+    name: 'Internal Accounts',
+    component: () => <div>Internal Accounts</div>,
+  },
+  { path: '/payments', name: 'Payments', component: () => <div>Payments</div> },
+  { path: '/transactions', name: 'Transactions', component: () => <div>Transactions</div> },
+  { path: '/positions', name: 'Positions', component: () => <div>Positions</div> },
+  { path: '/ledger', name: 'Ledger', component: () => <div>Ledger</div> },
+  { path: '/parties', name: 'Parties', component: () => <div>Parties</div> },
+  {
+    path: '/reconciliation',
+    name: 'Reconciliation',
+    component: () => <div>Reconciliation</div>,
+  },
+  {
+    path: '/starlark-config',
+    name: 'Starlark Configuration',
+    component: () => <div>Starlark Configuration</div>,
+  },
+  {
+    path: '/reference-data',
+    name: 'Reference Data',
+    component: () => <div>Reference Data</div>,
+  },
+  {
+    path: '/gateway-mappings',
+    name: 'Gateway Mappings',
+    component: () => <div>Gateway Mappings</div>,
+  },
+  { path: '/audit-log', name: 'Audit Log', component: () => <div>Audit Log</div> },
+  {
+    path: '/tenants',
+    name: 'Tenant Management',
+    component: () => <div>Tenant Management</div>,
+  },
+  {
+    path: '/platform',
+    name: 'Platform Monitoring',
+    component: () => <div>Platform Monitoring</div>,
   },
 ]
 
@@ -18,9 +56,7 @@ export function getRoutes(): Route[] {
   return routes
 }
 
-export function wrapRouteWithErrorBoundary(
-  component: React.ComponentType
-): React.ComponentType {
+export function wrapRouteWithErrorBoundary(component: React.ComponentType): React.ComponentType {
   return function WrappedRoute() {
     const Component = component
     return (
@@ -32,7 +68,7 @@ export function wrapRouteWithErrorBoundary(
 }
 
 export function createRouteHandler(
-  route: Route
+  route: Route,
 ): { path: string; name: string; component: React.ComponentType } {
   return {
     path: route.path,

--- a/frontend/src/test/app-routing.test.tsx
+++ b/frontend/src/test/app-routing.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { AuthProvider } from '@/contexts/auth-context'
+import { TenantProvider } from '@/contexts/tenant-context'
+import { ProtectedRoute, PlatformOnlyRoute } from '@/components/routing'
+import {
+  createTestToken,
+  createPlatformAdminToken,
+  createTenantUserToken,
+} from './jwt-helpers'
+import { createTestQueryClient } from './test-utils'
+
+function TestWrapper({
+  children,
+  initialToken,
+  initialPath = '/',
+}: {
+  children: React.ReactNode
+  initialToken?: string
+  initialPath?: string
+}) {
+  const queryClient = createTestQueryClient()
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider initialToken={initialToken}>
+        <TenantProvider>
+          <MemoryRouter initialEntries={[initialPath]}>{children}</MemoryRouter>
+        </TenantProvider>
+      </AuthProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('ProtectedRoute', () => {
+  it('redirects to /login when unauthenticated', () => {
+    render(
+      <TestWrapper>
+        <Routes>
+          <Route path="/login" element={<div>Login Page</div>} />
+          <Route
+            path="/"
+            element={
+              <ProtectedRoute>
+                <div>Protected Content</div>
+              </ProtectedRoute>
+            }
+          />
+        </Routes>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByText('Login Page')).toBeInTheDocument()
+    expect(screen.queryByText('Protected Content')).not.toBeInTheDocument()
+  })
+
+  it('renders children when authenticated', () => {
+    const token = createTenantUserToken()
+    render(
+      <TestWrapper initialToken={token}>
+        <Routes>
+          <Route path="/login" element={<div>Login Page</div>} />
+          <Route
+            path="/"
+            element={
+              <ProtectedRoute>
+                <div>Protected Content</div>
+              </ProtectedRoute>
+            }
+          />
+        </Routes>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByText('Protected Content')).toBeInTheDocument()
+    expect(screen.queryByText('Login Page')).not.toBeInTheDocument()
+  })
+
+  it('redirects to /login with expired token', () => {
+    // Expired token - create one that's already expired
+    const expiredToken = createTestToken({
+      userId: 'user-123',
+      exp: Math.floor(Date.now() / 1000) - 3600,
+      tenantId: 'tenant-abc',
+    })
+    render(
+      <TestWrapper initialToken={expiredToken}>
+        <Routes>
+          <Route path="/login" element={<div>Login Page</div>} />
+          <Route
+            path="/"
+            element={
+              <ProtectedRoute>
+                <div>Protected Content</div>
+              </ProtectedRoute>
+            }
+          />
+        </Routes>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByText('Login Page')).toBeInTheDocument()
+    expect(screen.queryByText('Protected Content')).not.toBeInTheDocument()
+  })
+})
+
+describe('PlatformOnlyRoute', () => {
+  it('redirects to / when user is tenant admin', () => {
+    const token = createTenantUserToken()
+    render(
+      <TestWrapper initialToken={token} initialPath="/tenants">
+        <Routes>
+          <Route path="/" element={<div>Dashboard</div>} />
+          <Route
+            path="/tenants"
+            element={
+              <PlatformOnlyRoute>
+                <div>Tenant Management</div>
+              </PlatformOnlyRoute>
+            }
+          />
+        </Routes>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(screen.queryByText('Tenant Management')).not.toBeInTheDocument()
+  })
+
+  it('renders children when user is platform admin', () => {
+    const token = createPlatformAdminToken()
+    render(
+      <TestWrapper initialToken={token} initialPath="/tenants">
+        <Routes>
+          <Route path="/" element={<div>Dashboard</div>} />
+          <Route
+            path="/tenants"
+            element={
+              <PlatformOnlyRoute>
+                <div>Tenant Management</div>
+              </PlatformOnlyRoute>
+            }
+          />
+        </Routes>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByText('Tenant Management')).toBeInTheDocument()
+    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument()
+  })
+
+  it('redirects to / when unauthenticated', () => {
+    render(
+      <TestWrapper initialPath="/tenants">
+        <Routes>
+          <Route path="/" element={<div>Dashboard</div>} />
+          <Route
+            path="/tenants"
+            element={
+              <PlatformOnlyRoute>
+                <div>Tenant Management</div>
+              </PlatformOnlyRoute>
+            }
+          />
+        </Routes>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(screen.queryByText('Tenant Management')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- Install react-router-dom v7 and configure BrowserRouter in App.tsx
- Add `ProtectedRoute` component that redirects unauthenticated users to `/login`
- Add `PlatformOnlyRoute` component that redirects non-platform users to `/`
- Integrate AppShell layout with `useLocation` for active nav path highlighting
- Define all 15 routes (tenant-scoped and platform-only) with placeholder pages
- Expand `lib/router.tsx` route registry with full route definitions

## Changes Made

- `frontend/package.json` — add react-router-dom v7 dependency
- `frontend/src/App.tsx` — full BrowserRouter setup with AuthProvider, TenantProvider, route guards, AppShell layout integration
- `frontend/src/components/routing.tsx` — `ProtectedRoute` and `PlatformOnlyRoute` guard components
- `frontend/src/lib/router.tsx` — expanded route registry (15 routes)
- `frontend/src/test/app-routing.test.tsx` — 6 tests covering auth redirects and role-based access

## Test plan

- [ ] Unauthenticated access to `/` redirects to `/login`
- [ ] Authenticated tenant user can access tenant-scoped routes
- [ ] Tenant user accessing `/tenants` redirects to `/`
- [ ] Platform admin can access `/tenants` and `/platform`
- [ ] 404 page renders for unknown routes
- [ ] All 264 existing tests continue to pass
- [ ] TypeScript compiles with no errors

## Technical Details

Task 026-operations-console.17. All page tasks (20-27, 30-36) depend on this router setup. Placeholder pages are in place; each page task will replace them with real implementations.

Route guards compose:
- `ProtectedRoute` wraps all non-login routes
- `PlatformOnlyRoute` wraps `/tenants` and `/platform` inside the protected tree

AppShell receives `currentPath` from `useLocation()` via `AppShellLayout` wrapper component, preserving the existing AppShell API.