### PR TITLE
feat: Create AuditTrail shared component

### DIFF
--- a/frontend/src/components/shared/audit-trail.test.tsx
+++ b/frontend/src/components/shared/audit-trail.test.tsx
@@ -136,7 +136,7 @@ describe('AuditTrail', () => {
   });
 
   describe('stub fallback', () => {
-    it('renders stub banner when audit service is unavailable', async () => {
+    it('renders stub banner when audit service is unavailable (501)', async () => {
       server.use(
         http.post('*/meridian.audit.v1.AuditService/*', () =>
           HttpResponse.json({}, { status: 501 }),
@@ -147,6 +147,18 @@ describe('AuditTrail', () => {
         expect(screen.getByTestId('audit-trail-stub')).toBeInTheDocument(),
       );
     });
+
+    it('renders error state for non-stub failures (500)', async () => {
+      server.use(
+        http.post('*/meridian.audit.v1.AuditService/*', () =>
+          HttpResponse.json({}, { status: 500 }),
+        ),
+      );
+      renderWithQuery(<AuditTrail entityType="customers" entityId="id-1" />);
+      await waitFor(() =>
+        expect(screen.getByTestId('audit-trail-error')).toBeInTheDocument(),
+      );
+    });
   });
 
   describe('query cache', () => {
@@ -154,12 +166,20 @@ describe('AuditTrail', () => {
       // We verify this by checking that the component issues a request on each
       // mount even when data might be cached. MSW intercepts all calls so we
       // can count them via a spy.
+      //
+      // We must use a non-zero gcTime so the cache persists across unmount/remount.
+      // With gcTime: 0, the cache is evicted immediately on unmount regardless of
+      // staleTime, which would make this test pass even if staleTime were Infinity.
       const fetchSpy = vi.fn(() => HttpResponse.json({ entries: [] }));
       server.use(
         http.post('*/meridian.audit.v1.AuditService/*', fetchSpy),
       );
 
-      const qc = makeQueryClient();
+      const qc = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false, gcTime: 5 * 60 * 1000, staleTime: 0 },
+        },
+      });
 
       const { unmount } = renderWithQuery(
         <AuditTrail entityType="customers" entityId="id-1" />,
@@ -169,7 +189,8 @@ describe('AuditTrail', () => {
       await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
       unmount();
 
-      // Second mount — staleTime: 0 means data is immediately stale, refetch triggered
+      // Second mount — cache entry is present but staleTime: 0 means it's
+      // immediately stale, so the component triggers a refetch on mount.
       renderWithQuery(<AuditTrail entityType="customers" entityId="id-1" />, qc);
       await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
     });

--- a/frontend/src/components/shared/audit-trail.test.tsx
+++ b/frontend/src/components/shared/audit-trail.test.tsx
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/msw-handlers';
+import { AuditTrail } from './audit-trail';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+    },
+  });
+}
+
+function renderWithQuery(ui: React.ReactElement, queryClient = makeQueryClient()) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>{ui}</TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// Minimal audit entry shape matching our stub types.
+// Timestamps use plain numbers (not BigInt) because MSW uses JSON.stringify
+// under the hood and BigInt is not JSON-serializable.
+const INSERT_ENTRY = {
+  entryId: 'id-1',
+  operation: 'INSERT',
+  changedBy: 'alice',
+  timestamp: { seconds: 1_700_000_000, nanos: 0 },
+  oldValues: null,
+  newValues: { id: 'abc', name: 'Test', status: 'ACTIVE' },
+};
+
+const UPDATE_ENTRY = {
+  entryId: 'id-2',
+  operation: 'UPDATE',
+  changedBy: 'bob',
+  timestamp: { seconds: 1_700_001_000, nanos: 0 },
+  oldValues: { id: 'abc', name: 'Test', status: 'ACTIVE' },
+  newValues: { id: 'abc', name: 'Test', status: 'FROZEN' },
+};
+
+const DELETE_ENTRY = {
+  entryId: 'id-3',
+  operation: 'DELETE',
+  changedBy: 'charlie',
+  timestamp: { seconds: 1_700_002_000, nanos: 0 },
+  oldValues: { id: 'abc', name: 'Test', status: 'FROZEN' },
+  newValues: null,
+};
+
+// ---------------------------------------------------------------------------
+// AuditTrail component tests
+// ---------------------------------------------------------------------------
+
+describe('AuditTrail', () => {
+  describe('loading state', () => {
+    it('renders loading skeleton while fetching', () => {
+      // MSW will hold the request open — we just check initial render
+      renderWithQuery(<AuditTrail entityType="customers" entityId="id-1" />);
+      expect(screen.getByTestId('audit-trail-skeleton')).toBeInTheDocument();
+    });
+  });
+
+  describe('empty state', () => {
+    beforeEach(() => {
+      server.use(
+        http.post('*/meridian.audit.v1.AuditService/*', () =>
+          HttpResponse.json({ entries: [] }),
+        ),
+      );
+    });
+
+    it('renders empty state when no entries exist', async () => {
+      renderWithQuery(<AuditTrail entityType="customers" entityId="id-1" />);
+      await waitFor(() =>
+        expect(screen.getByTestId('audit-trail-empty')).toBeInTheDocument(),
+      );
+    });
+
+    it('empty state shows descriptive message', async () => {
+      renderWithQuery(<AuditTrail entityType="customers" entityId="id-1" />);
+      await waitFor(() =>
+        expect(screen.getByRole('heading', { name: /no audit/i })).toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe('entry rendering', () => {
+    beforeEach(() => {
+      server.use(
+        http.post('*/meridian.audit.v1.AuditService/*', () =>
+          HttpResponse.json({ entries: [INSERT_ENTRY, UPDATE_ENTRY, DELETE_ENTRY] }),
+        ),
+      );
+    });
+
+    it('renders entries in timeline order (most-recent first)', async () => {
+      renderWithQuery(<AuditTrail entityType="customers" entityId="id-1" />);
+      await waitFor(() =>
+        expect(screen.getAllByTestId('audit-entry')).toHaveLength(3),
+      );
+      const entries = screen.getAllByTestId('audit-entry');
+      // DELETE_ENTRY has the latest timestamp — should be first
+      expect(entries[0]).toHaveTextContent(/delete/i);
+      expect(entries[1]).toHaveTextContent(/update/i);
+      expect(entries[2]).toHaveTextContent(/insert/i);
+    });
+
+    it('shows operation type for each entry', async () => {
+      renderWithQuery(<AuditTrail entityType="customers" entityId="id-1" />);
+      await waitFor(() =>
+        expect(screen.getAllByTestId('audit-entry')).toHaveLength(3),
+      );
+      expect(screen.getByText(/insert/i)).toBeInTheDocument();
+      expect(screen.getByText(/update/i)).toBeInTheDocument();
+      expect(screen.getByText(/delete/i)).toBeInTheDocument();
+    });
+
+    it('shows changedBy for each entry', async () => {
+      renderWithQuery(<AuditTrail entityType="customers" entityId="id-1" />);
+      await waitFor(() =>
+        expect(screen.getAllByTestId('audit-entry')).toHaveLength(3),
+      );
+      expect(screen.getByText(/alice/i)).toBeInTheDocument();
+      expect(screen.getByText(/bob/i)).toBeInTheDocument();
+      expect(screen.getByText(/charlie/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('stub fallback', () => {
+    it('renders stub banner when audit service is unavailable', async () => {
+      server.use(
+        http.post('*/meridian.audit.v1.AuditService/*', () =>
+          HttpResponse.json({}, { status: 501 }),
+        ),
+      );
+      renderWithQuery(<AuditTrail entityType="customers" entityId="id-1" />);
+      await waitFor(() =>
+        expect(screen.getByTestId('audit-trail-stub')).toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe('query cache', () => {
+    it('uses staleTime: 0 to always refetch audit logs', async () => {
+      // We verify this by checking that the component issues a request on each
+      // mount even when data might be cached. MSW intercepts all calls so we
+      // can count them via a spy.
+      const fetchSpy = vi.fn(() => HttpResponse.json({ entries: [] }));
+      server.use(
+        http.post('*/meridian.audit.v1.AuditService/*', fetchSpy),
+      );
+
+      const qc = makeQueryClient();
+
+      const { unmount } = renderWithQuery(
+        <AuditTrail entityType="customers" entityId="id-1" />,
+        qc,
+      );
+      // Wait for first fetch to complete
+      await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+      unmount();
+
+      // Second mount — staleTime: 0 means data is immediately stale, refetch triggered
+      renderWithQuery(<AuditTrail entityType="customers" entityId="id-1" />, qc);
+      await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JsonDiffViewer sub-component tests (exported for direct testing)
+// ---------------------------------------------------------------------------
+
+import { JsonDiffViewer } from './audit-trail';
+
+describe('JsonDiffViewer', () => {
+  it('shows inserted values in green for INSERT (null oldValue, object newValue)', () => {
+    const { container } = render(
+      <JsonDiffViewer oldValue={null} newValue={{ id: 'abc', status: 'ACTIVE' }} />,
+    );
+    expect(screen.getByTestId('diff-inserted')).toBeInTheDocument();
+    // Green styling
+    const inserted = container.querySelector('[data-testid="diff-inserted"]');
+    expect(inserted?.className).toMatch(/green/i);
+  });
+
+  it('shows deleted values in red for DELETE (object oldValue, null newValue)', () => {
+    const { container } = render(
+      <JsonDiffViewer oldValue={{ id: 'abc', status: 'ACTIVE' }} newValue={null} />,
+    );
+    expect(screen.getByTestId('diff-deleted')).toBeInTheDocument();
+    const deleted = container.querySelector('[data-testid="diff-deleted"]');
+    expect(deleted?.className).toMatch(/red/i);
+  });
+
+  it('shows before/after diff for UPDATE (both oldValue and newValue present)', () => {
+    render(
+      <JsonDiffViewer
+        oldValue={{ id: 'abc', status: 'ACTIVE' }}
+        newValue={{ id: 'abc', status: 'FROZEN' }}
+      />,
+    );
+    expect(screen.getByTestId('diff-before')).toBeInTheDocument();
+    expect(screen.getByTestId('diff-after')).toBeInTheDocument();
+  });
+
+  it('renders JSON content of inserted values', () => {
+    render(
+      <JsonDiffViewer oldValue={null} newValue={{ id: 'abc', status: 'ACTIVE' }} />,
+    );
+    expect(screen.getByTestId('diff-inserted')).toHaveTextContent('ACTIVE');
+  });
+
+  it('renders JSON content of deleted values', () => {
+    render(
+      <JsonDiffViewer oldValue={{ id: 'abc', status: 'FROZEN' }} newValue={null} />,
+    );
+    expect(screen.getByTestId('diff-deleted')).toHaveTextContent('FROZEN');
+  });
+
+  it('shows old and new JSON content in UPDATE diff', () => {
+    render(
+      <JsonDiffViewer
+        oldValue={{ id: 'abc', status: 'ACTIVE' }}
+        newValue={{ id: 'abc', status: 'FROZEN' }}
+      />,
+    );
+    expect(screen.getByTestId('diff-before')).toHaveTextContent('ACTIVE');
+    expect(screen.getByTestId('diff-after')).toHaveTextContent('FROZEN');
+  });
+
+  it('handles null/null gracefully without crashing', () => {
+    expect(() =>
+      render(<JsonDiffViewer oldValue={null} newValue={null} />),
+    ).not.toThrow();
+  });
+});

--- a/frontend/src/components/shared/audit-trail.tsx
+++ b/frontend/src/components/shared/audit-trail.tsx
@@ -32,8 +32,8 @@ export interface AuditTrailProps {
 // Stub audit client
 //
 // The audit query RPC (ListAuditEntries) does not exist yet (Open Item #1).
-// This stub tries to call the service and returns an empty list on 501/503
-// or any network failure, keeping the UI functional while the backend is built.
+// This stub calls the service and throws StubError on 501/503 responses so the
+// UI can show a "coming soon" banner while the backend is built.
 // ---------------------------------------------------------------------------
 
 async function fetchAuditEntries(
@@ -242,15 +242,28 @@ export function AuditTrail({ entityType, entityId }: AuditTrailProps) {
     return <AuditTrailSkeleton />;
   }
 
-  // Stub fallback: audit service not yet implemented
-  if (isError && isStubError(error)) {
+  if (isError) {
+    if (isStubError(error)) {
+      // Stub fallback: audit service not yet implemented (Open Item #1)
+      return (
+        <div
+          data-testid="audit-trail-stub"
+          className="rounded-lg border border-dashed p-6 text-center"
+        >
+          <p className="text-sm text-muted-foreground">
+            Audit log coming soon — the audit query service is not yet available.
+          </p>
+        </div>
+      );
+    }
+    // Generic error state for non-stub failures (500, network, parse errors)
     return (
       <div
-        data-testid="audit-trail-stub"
+        data-testid="audit-trail-error"
         className="rounded-lg border border-dashed p-6 text-center"
       >
         <p className="text-sm text-muted-foreground">
-          Audit log coming soon — the audit query service is not yet available.
+          Unable to load audit history. Please try again.
         </p>
       </div>
     );

--- a/frontend/src/components/shared/audit-trail.tsx
+++ b/frontend/src/components/shared/audit-trail.tsx
@@ -1,0 +1,294 @@
+import { useQuery } from '@tanstack/react-query';
+import { ClockIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { TimeDisplay } from './time-display';
+import { EmptyState } from '@/components/ui/empty-state';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AuditOperation = 'INSERT' | 'UPDATE' | 'DELETE';
+
+export interface AuditEntry {
+  entryId: string;
+  operation: AuditOperation;
+  changedBy: string;
+  timestamp: { seconds: bigint | number; nanos?: number } | null | undefined;
+  oldValues: object | null;
+  newValues: object | null;
+}
+
+export interface AuditEntriesResponse {
+  entries: AuditEntry[];
+}
+
+export interface AuditTrailProps {
+  entityType: string;
+  entityId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Stub audit client
+//
+// The audit query RPC (ListAuditEntries) does not exist yet (Open Item #1).
+// This stub tries to call the service and returns an empty list on 501/503
+// or any network failure, keeping the UI functional while the backend is built.
+// ---------------------------------------------------------------------------
+
+async function fetchAuditEntries(
+  entityType: string,
+  entityId: string,
+): Promise<AuditEntriesResponse> {
+  const response = await fetch(
+    '/meridian.audit.v1.AuditService/ListAuditEntries',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ entityType, entityId }),
+    },
+  );
+
+  if (!response.ok) {
+    if (response.status === 501 || response.status === 503) {
+      throw new StubError('Audit service not yet implemented');
+    }
+    throw new Error(`Audit request failed: ${response.status}`);
+  }
+
+  return response.json() as Promise<AuditEntriesResponse>;
+}
+
+class StubError extends Error {
+  readonly isStub = true;
+}
+
+function isStubError(err: unknown): boolean {
+  return err instanceof StubError || (err instanceof Error && err.message.includes('Audit service not yet implemented'));
+}
+
+// ---------------------------------------------------------------------------
+// JsonDiffViewer
+// ---------------------------------------------------------------------------
+
+interface JsonDiffViewerProps {
+  oldValue: object | null;
+  newValue: object | null;
+}
+
+export function JsonDiffViewer({ oldValue, newValue }: JsonDiffViewerProps) {
+  if (!oldValue && newValue) {
+    // INSERT - show new values in green
+    return (
+      <pre
+        data-testid="diff-inserted"
+        className={cn(
+          'rounded-md bg-green-50 p-3 text-xs text-green-800',
+          'max-h-48 overflow-auto whitespace-pre-wrap break-all',
+        )}
+      >
+        {JSON.stringify(newValue, null, 2)}
+      </pre>
+    );
+  }
+
+  if (oldValue && !newValue) {
+    // DELETE - show old values in red
+    return (
+      <pre
+        data-testid="diff-deleted"
+        className={cn(
+          'rounded-md bg-red-50 p-3 text-xs text-red-800',
+          'max-h-48 overflow-auto whitespace-pre-wrap break-all',
+        )}
+      >
+        {JSON.stringify(oldValue, null, 2)}
+      </pre>
+    );
+  }
+
+  if (oldValue && newValue) {
+    // UPDATE - show side-by-side before/after
+    return (
+      <div className="grid grid-cols-2 gap-2">
+        <div>
+          <p className="mb-1 text-xs font-medium text-muted-foreground">Before</p>
+          <pre
+            data-testid="diff-before"
+            className={cn(
+              'rounded-md bg-red-50 p-3 text-xs text-red-800',
+              'max-h-48 overflow-auto whitespace-pre-wrap break-all',
+            )}
+          >
+            {JSON.stringify(oldValue, null, 2)}
+          </pre>
+        </div>
+        <div>
+          <p className="mb-1 text-xs font-medium text-muted-foreground">After</p>
+          <pre
+            data-testid="diff-after"
+            className={cn(
+              'rounded-md bg-green-50 p-3 text-xs text-green-800',
+              'max-h-48 overflow-auto whitespace-pre-wrap break-all',
+            )}
+          >
+            {JSON.stringify(newValue, null, 2)}
+          </pre>
+        </div>
+      </div>
+    );
+  }
+
+  // null/null — no changes to display
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Operation badge
+// ---------------------------------------------------------------------------
+
+const OPERATION_STYLES: Record<AuditOperation, string> = {
+  INSERT: 'bg-green-100 text-green-800 border-green-200',
+  UPDATE: 'bg-blue-100 text-blue-800 border-blue-200',
+  DELETE: 'bg-red-100 text-red-800 border-red-200',
+};
+
+function OperationBadge({ operation }: { operation: string }) {
+  const style = OPERATION_STYLES[operation as AuditOperation] ?? 'bg-gray-100 text-gray-800 border-gray-200';
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium',
+        style,
+      )}
+    >
+      {operation}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AuditTrailSkeleton
+// ---------------------------------------------------------------------------
+
+export function AuditTrailSkeleton() {
+  return (
+    <div data-testid="audit-trail-skeleton" className="space-y-4">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="flex gap-4">
+          <div className="h-3 w-3 shrink-0 animate-pulse rounded-full bg-muted mt-1.5" />
+          <div className="flex-1 space-y-2 rounded-lg border p-4">
+            <div className="flex items-center gap-2">
+              <div className="h-5 w-14 animate-pulse rounded-full bg-muted" />
+              <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+              <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+            </div>
+            <div className="h-16 w-full animate-pulse rounded-md bg-muted" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AuditEntry item
+// ---------------------------------------------------------------------------
+
+function AuditEntryItem({ entry }: { entry: AuditEntry }) {
+  return (
+    <div
+      data-testid="audit-entry"
+      className="flex gap-4"
+    >
+      {/* Timeline dot */}
+      <div
+        className="mt-5 h-2.5 w-2.5 shrink-0 rounded-full border-2 border-primary bg-background"
+        aria-hidden="true"
+      />
+
+      <div className="flex-1 rounded-lg border p-4">
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <OperationBadge operation={entry.operation} />
+          <span className="text-muted-foreground">by</span>
+          <span className="font-medium">{entry.changedBy}</span>
+          <span className="text-muted-foreground">
+            <TimeDisplay timestamp={entry.timestamp} format="both" />
+          </span>
+        </div>
+
+        {(entry.oldValues !== null || entry.newValues !== null) && (
+          <div className="mt-3">
+            <JsonDiffViewer oldValue={entry.oldValues} newValue={entry.newValues} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AuditTrail (main component)
+// ---------------------------------------------------------------------------
+
+export function AuditTrail({ entityType, entityId }: AuditTrailProps) {
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['audit', entityType, entityId],
+    queryFn: () => fetchAuditEntries(entityType, entityId),
+    staleTime: 0, // Always refetch audit logs
+  });
+
+  if (isLoading) {
+    return <AuditTrailSkeleton />;
+  }
+
+  // Stub fallback: audit service not yet implemented
+  if (isError && isStubError(error)) {
+    return (
+      <div
+        data-testid="audit-trail-stub"
+        className="rounded-lg border border-dashed p-6 text-center"
+      >
+        <p className="text-sm text-muted-foreground">
+          Audit log coming soon — the audit query service is not yet available.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data?.entries.length) {
+    return (
+      <div data-testid="audit-trail-empty">
+        <EmptyState
+          icon={ClockIcon}
+          title="No audit history"
+          description="No audit entries have been recorded for this entity yet."
+        />
+      </div>
+    );
+  }
+
+  // Sort most-recent first
+  const sorted = [...data.entries].sort((a, b) => {
+    const aTime = typeof a.timestamp?.seconds === 'bigint'
+      ? Number(a.timestamp.seconds)
+      : (a.timestamp?.seconds ?? 0);
+    const bTime = typeof b.timestamp?.seconds === 'bigint'
+      ? Number(b.timestamp.seconds)
+      : (b.timestamp?.seconds ?? 0);
+    return bTime - aTime;
+  });
+
+  return (
+    <div className="relative space-y-2">
+      {/* Vertical timeline line */}
+      <div
+        className="absolute left-[5px] top-6 bottom-6 w-px bg-border"
+        aria-hidden="true"
+      />
+      {sorted.map((entry) => (
+        <AuditEntryItem key={entry.entryId} entry={entry} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/shared/index.ts
+++ b/frontend/src/components/shared/index.ts
@@ -1,2 +1,5 @@
 export { TimeDisplay } from './time-display';
 export type { TimeDisplayProps } from './time-display';
+
+export { AuditTrail, AuditTrailSkeleton, JsonDiffViewer } from './audit-trail';
+export type { AuditTrailProps, AuditEntry, AuditEntriesResponse, AuditOperation } from './audit-trail';

--- a/frontend/src/test/msw-handlers.ts
+++ b/frontend/src/test/msw-handlers.ts
@@ -46,6 +46,11 @@ export const handlers = [
     return HttpResponse.json({})
   }),
 
+  // AuditService - audit log queries (stub: returns 501 until RPC is implemented)
+  http.post('*/meridian.audit.v1.AuditService/*', () => {
+    return HttpResponse.json({}, { status: 501 })
+  }),
+
   // REST auth refresh endpoint used by AuthContext
   http.post('/api/auth/refresh', () => {
     return HttpResponse.json({}, { status: 401 })


### PR DESCRIPTION
## Summary

- Implements `AuditTrail` component (`src/components/shared/audit-trail.tsx`) with timeline view displaying audit history for any entity
- Adds `JsonDiffViewer` sub-component: INSERT shows green inserted values, DELETE shows red deleted values, UPDATE shows side-by-side before/after diff
- Adds `AuditTrailSkeleton` for loading state with animated placeholder rows
- Includes stub fallback banner when audit query RPC returns 501 (Open Item #1 — audit query RPC not yet implemented)
- Uses `staleTime: 0` to always refetch audit entries (compliance requirement)
- Exports all components and types from `@/components/shared`
- Adds `AuditService` wildcard handler to MSW test server for test isolation

## Changes Made

| File | Change |
|------|--------|
| `frontend/src/components/shared/audit-trail.tsx` | New component |
| `frontend/src/components/shared/audit-trail.test.tsx` | 15 tests (TDD) |
| `frontend/src/components/shared/index.ts` | Export new component |
| `frontend/src/test/msw-handlers.ts` | Register AuditService handler |

## Testing

- 15 new tests covering: loading skeleton, empty state, timeline ordering (most-recent first), INSERT/UPDATE/DELETE rendering, stub fallback, staleTime: 0 behavior
- All 273 existing tests continue to pass
- TypeScript check passes

## Notes

The audit query RPC (`ListAuditEntries`) does not yet exist (Open Item #1). The component falls back gracefully with a "coming soon" stub banner on 501 responses.

Closes 026-operations-console.34