### PR TITLE
feat: Implement TenantSelector component for platform admins

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.575.0",
         "radix-ui": "^1.4.3",
@@ -5838,6 +5839,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/code-block-writer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.575.0",
     "radix-ui": "^1.4.3",

--- a/frontend/src/components/layout/app-shell.test.tsx
+++ b/frontend/src/components/layout/app-shell.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -6,6 +6,13 @@ import { AppShell } from '@/components/layout/app-shell'
 import { AuthProvider } from '@/contexts/auth-context'
 import { TenantProvider } from '@/contexts/tenant-context'
 import { createPlatformAdminToken, createTenantUserToken } from '@/test/jwt-helpers'
+
+// Mock TenantSelector to avoid dependency on ungenerated proto clients
+vi.mock('@/components/layout/tenant-selector', () => ({
+  TenantSelector: () => (
+    <div data-testid="tenant-selector" aria-label="Select tenant">Select Tenant</div>
+  ),
+}))
 
 function renderWithProviders(ui: React.ReactElement, token?: string) {
   const queryClient = new QueryClient({

--- a/frontend/src/components/layout/header.test.tsx
+++ b/frontend/src/components/layout/header.test.tsx
@@ -7,6 +7,13 @@ import { AuthProvider } from '@/contexts/auth-context'
 import { TenantProvider } from '@/contexts/tenant-context'
 import { createPlatformAdminToken, createTenantUserToken } from '@/test/jwt-helpers'
 
+// Mock TenantSelector to avoid dependency on ungenerated proto clients
+vi.mock('@/components/layout/tenant-selector', () => ({
+  TenantSelector: () => (
+    <div data-testid="tenant-selector" aria-label="Select tenant">Select Tenant</div>
+  ),
+}))
+
 function renderWithProviders(ui: React.ReactElement, token?: string) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -8,19 +8,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { useAuth } from '@/contexts/auth-context'
 import { useTenantContext } from '@/contexts/tenant-context'
-
-interface TenantSelectorProps {
-  // Placeholder component for TenantSelector - will be replaced with full implementation
-  // once Task 10 (TenantSelector) is complete
-}
-
-function TenantSelectorPlaceholder(_props: TenantSelectorProps) {
-  return (
-    <div data-testid="tenant-selector" className="flex items-center gap-2 text-sm text-gray-300">
-      <span>Select Tenant</span>
-    </div>
-  )
-}
+import { TenantSelector } from '@/components/layout/tenant-selector'
 
 interface HeaderProps {
   onMenuToggle: () => void
@@ -51,7 +39,7 @@ export function Header({ onMenuToggle, sidebarOpen, sidebarId }: HeaderProps) {
       </div>
 
       <div className="ml-auto flex items-center gap-4">
-        {isPlatformAdmin && <TenantSelectorPlaceholder />}
+        {isPlatformAdmin && <TenantSelector />}
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/frontend/src/components/layout/index.ts
+++ b/frontend/src/components/layout/index.ts
@@ -1,3 +1,4 @@
 export { AppShell } from '@/components/layout/app-shell'
 export { Sidebar } from '@/components/layout/sidebar'
 export { Header } from '@/components/layout/header'
+export { TenantSelector } from '@/components/layout/tenant-selector'

--- a/frontend/src/components/layout/tenant-selector.test.tsx
+++ b/frontend/src/components/layout/tenant-selector.test.tsx
@@ -1,0 +1,365 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders, axe } from '@/test/test-utils'
+import { createPlatformAdminToken } from '@/test/jwt-helpers'
+import { TenantSelector } from './tenant-selector'
+
+// Mock useTenants so we control what data is returned
+vi.mock('@/hooks/use-tenants', () => ({
+  useTenants: vi.fn(),
+}))
+
+// Mock useTenantContext so we control currentTenant and switchTenant
+vi.mock('@/contexts/tenant-context', () => ({
+  useTenantContext: vi.fn(),
+  TenantProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+import { useTenants } from '@/hooks/use-tenants'
+import { useTenantContext } from '@/contexts/tenant-context'
+
+const mockTenants = [
+  {
+    tenantId: 'acme_corp',
+    slug: 'acme-bank',
+    displayName: 'Acme Bank',
+    status: 1,
+    settlementAsset: 'GBP',
+    subdomain: '',
+    partyId: '',
+    errorMessage: '',
+    version: 1,
+    createdAt: undefined,
+    deprovisionedAt: undefined,
+    metadata: undefined,
+  },
+  {
+    tenantId: 'beta_corp',
+    slug: 'beta-financial',
+    displayName: 'Beta Financial',
+    status: 1,
+    settlementAsset: 'USD',
+    subdomain: '',
+    partyId: '',
+    errorMessage: '',
+    version: 1,
+    createdAt: undefined,
+    deprovisionedAt: undefined,
+    metadata: undefined,
+  },
+  {
+    tenantId: 'gamma_inc',
+    slug: 'gamma-energy',
+    displayName: 'Gamma Energy',
+    status: 1,
+    settlementAsset: 'EUR',
+    subdomain: '',
+    partyId: '',
+    errorMessage: '',
+    version: 1,
+    createdAt: undefined,
+    deprovisionedAt: undefined,
+    metadata: undefined,
+  },
+]
+
+const mockSwitchTenant = vi.fn()
+
+function setupMocks(overrides: {
+  tenants?: typeof mockTenants
+  isLoading?: boolean
+  currentTenantSlug?: string | null
+} = {}) {
+  const { tenants = mockTenants, isLoading = false, currentTenantSlug = null } = overrides
+
+  vi.mocked(useTenants).mockReturnValue({
+    data: isLoading ? undefined : tenants,
+    isLoading,
+    isError: false,
+    error: null,
+  } as unknown as ReturnType<typeof useTenants>)
+
+  vi.mocked(useTenantContext).mockReturnValue({
+    tenantSlug: currentTenantSlug,
+    currentTenant: currentTenantSlug
+      ? tenants.find((t) => t.slug === currentTenantSlug) ?? null
+      : null,
+    isPlatformAdmin: true,
+    switchTenant: mockSwitchTenant,
+    clearTenant: vi.fn(),
+  })
+}
+
+describe('TenantSelector', () => {
+  const token = createPlatformAdminToken()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('rendering', () => {
+    it('renders with data-testid tenant-selector', () => {
+      setupMocks()
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      expect(screen.getByTestId('tenant-selector')).toBeInTheDocument()
+    })
+
+    it('shows "Select tenant..." placeholder when no tenant is selected', () => {
+      setupMocks({ currentTenantSlug: null })
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      expect(screen.getByText(/select tenant/i)).toBeInTheDocument()
+    })
+
+    it('shows current tenant display name when a tenant is selected', () => {
+      setupMocks({ currentTenantSlug: 'acme-bank' })
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      expect(screen.getByText('Acme Bank')).toBeInTheDocument()
+    })
+
+    it('shows loading state when tenants are loading', () => {
+      setupMocks({ isLoading: true })
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      expect(screen.getByTestId('tenant-selector-loading')).toBeInTheDocument()
+    })
+  })
+
+  describe('interaction', () => {
+    it('opens dropdown when button is clicked', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const button = screen.getByRole('combobox')
+      await user.click(button)
+
+      await waitFor(() => {
+        expect(screen.getByRole('listbox')).toBeInTheDocument()
+      })
+    })
+
+    it('lists all tenants in the dropdown', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const button = screen.getByRole('combobox')
+      await user.click(button)
+
+      await waitFor(() => {
+        expect(screen.getByText('Acme Bank')).toBeInTheDocument()
+        expect(screen.getByText('Beta Financial')).toBeInTheDocument()
+        expect(screen.getByText('Gamma Energy')).toBeInTheDocument()
+      })
+    })
+
+    it('shows tenant slugs in the dropdown', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const button = screen.getByRole('combobox')
+      await user.click(button)
+
+      await waitFor(() => {
+        expect(screen.getByText('acme-bank')).toBeInTheDocument()
+      })
+    })
+
+    it('calls switchTenant with the correct tenant object when a tenant is selected', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const button = screen.getByRole('combobox')
+      await user.click(button)
+
+      await waitFor(() => {
+        expect(screen.getByText('Acme Bank')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByText('Acme Bank'))
+
+      expect(mockSwitchTenant).toHaveBeenCalledWith({
+        id: 'acme_corp',
+        slug: 'acme-bank',
+        name: 'Acme Bank',
+      })
+    })
+
+    it('closes dropdown after tenant selection', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const button = screen.getByRole('combobox')
+      await user.click(button)
+
+      await waitFor(() => {
+        expect(screen.getByText('Acme Bank')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByText('Acme Bank'))
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+      })
+    })
+
+    it('shows checkmark next to currently selected tenant', async () => {
+      const user = userEvent.setup()
+      setupMocks({ currentTenantSlug: 'acme-bank' })
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const button = screen.getByRole('combobox')
+      await user.click(button)
+
+      await waitFor(() => {
+        // The selected tenant item should have aria-selected=true
+        const selectedItem = screen.getByRole('option', { name: /acme bank/i })
+        expect(selectedItem).toHaveAttribute('aria-selected', 'true')
+      })
+    })
+  })
+
+  describe('search', () => {
+    it('filters tenants by display name', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const button = screen.getByRole('combobox')
+      await user.click(button)
+
+      const searchInput = await screen.findByPlaceholderText(/search tenants/i)
+      await user.type(searchInput, 'acme')
+
+      await waitFor(() => {
+        expect(screen.getByText('Acme Bank')).toBeInTheDocument()
+        expect(screen.queryByText('Beta Financial')).not.toBeInTheDocument()
+        expect(screen.queryByText('Gamma Energy')).not.toBeInTheDocument()
+      })
+    })
+
+    it('filters tenants by slug', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const button = screen.getByRole('combobox')
+      await user.click(button)
+
+      const searchInput = await screen.findByPlaceholderText(/search tenants/i)
+      await user.type(searchInput, 'beta-financial')
+
+      await waitFor(() => {
+        expect(screen.getByText('Beta Financial')).toBeInTheDocument()
+        expect(screen.queryByText('Acme Bank')).not.toBeInTheDocument()
+      })
+    })
+
+    it('shows empty state when no tenants match search', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const button = screen.getByRole('combobox')
+      await user.click(button)
+
+      const searchInput = await screen.findByPlaceholderText(/search tenants/i)
+      await user.type(searchInput, 'nonexistent-tenant-xyz')
+
+      await waitFor(() => {
+        expect(screen.getByText(/no tenants found/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('keyboard navigation', () => {
+    it('opens dropdown on Enter key', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const button = screen.getByRole('combobox')
+      button.focus()
+      await user.keyboard('{Enter}')
+
+      await waitFor(() => {
+        expect(screen.getByRole('listbox')).toBeInTheDocument()
+      })
+    })
+
+    it('closes dropdown on Escape key', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const button = screen.getByRole('combobox')
+      await user.click(button)
+
+      await waitFor(() => {
+        expect(screen.getByRole('listbox')).toBeInTheDocument()
+      })
+
+      await user.keyboard('{Escape}')
+
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('empty state', () => {
+    it('shows empty state when no tenants exist', async () => {
+      const user = userEvent.setup()
+      setupMocks({ tenants: [] })
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const button = screen.getByRole('combobox')
+      await user.click(button)
+
+      await waitFor(() => {
+        expect(screen.getByText(/no tenants found/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has no accessibility violations in closed state', async () => {
+      setupMocks()
+      const { container } = renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+
+    it('trigger button has accessible label', () => {
+      setupMocks()
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const button = screen.getByRole('combobox')
+      expect(button).toHaveAccessibleName()
+    })
+
+    it('announces selection changes to screen readers', async () => {
+      const user = userEvent.setup()
+      setupMocks()
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const button = screen.getByRole('combobox')
+      await user.click(button)
+
+      await waitFor(() => {
+        expect(screen.getByRole('listbox')).toBeInTheDocument()
+      })
+
+      // The listbox should have aria-label
+      expect(screen.getByRole('listbox')).toHaveAccessibleName()
+    })
+  })
+})

--- a/frontend/src/components/layout/tenant-selector.test.tsx
+++ b/frontend/src/components/layout/tenant-selector.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders, axe } from '@/test/test-utils'
 import { createPlatformAdminToken } from '@/test/jwt-helpers'

--- a/frontend/src/components/layout/tenant-selector.tsx
+++ b/frontend/src/components/layout/tenant-selector.tsx
@@ -21,9 +21,10 @@ import { useTenantContext } from '@/contexts/tenant-context'
 export function TenantSelector() {
   const [open, setOpen] = React.useState(false)
   const { data: tenants, isLoading } = useTenants()
-  const { tenantSlug, switchTenant } = useTenantContext()
+  const { tenantSlug, currentTenant: contextTenant, switchTenant } = useTenantContext()
 
-  const currentTenant = tenants?.find((t) => t.slug === tenantSlug)
+  // Use the loaded tenant data first, fall back to context (e.g., on error or partial data)
+  const resolvedTenant = tenants?.find((t) => t.slug === tenantSlug) ?? contextTenant
 
   if (isLoading) {
     return (
@@ -52,7 +53,7 @@ export function TenantSelector() {
             className="w-[200px] justify-between"
           >
             <span className="truncate">
-              {currentTenant ? currentTenant.displayName : 'Select tenant...'}
+              {resolvedTenant ? resolvedTenant.displayName ?? resolvedTenant.name : 'Select tenant...'}
             </span>
             <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
           </Button>

--- a/frontend/src/components/layout/tenant-selector.tsx
+++ b/frontend/src/components/layout/tenant-selector.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react'
+import { Check, ChevronsUpDown } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { useTenants } from '@/hooks/use-tenants'
+import { useTenantContext } from '@/contexts/tenant-context'
+
+export function TenantSelector() {
+  const [open, setOpen] = React.useState(false)
+  const { data: tenants, isLoading } = useTenants()
+  const { tenantSlug, switchTenant } = useTenantContext()
+
+  const currentTenant = tenants?.find((t) => t.slug === tenantSlug)
+
+  if (isLoading) {
+    return (
+      <div
+        data-testid="tenant-selector-loading"
+        className="flex h-9 w-[200px] items-center justify-between rounded-md border px-3 py-2 text-sm opacity-50"
+        aria-busy="true"
+        aria-label="Loading tenants"
+      >
+        <span className="text-muted-foreground">Loading...</span>
+        <ChevronsUpDown className="size-4 shrink-0 opacity-50" />
+      </div>
+    )
+  }
+
+  return (
+    <div data-testid="tenant-selector">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            aria-label="Select tenant"
+            aria-haspopup="listbox"
+            className="w-[200px] justify-between"
+          >
+            <span className="truncate">
+              {currentTenant ? currentTenant.displayName : 'Select tenant...'}
+            </span>
+            <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[200px] p-0">
+          <Command>
+            <CommandInput placeholder="Search tenants..." />
+            <CommandList
+              role="listbox"
+              aria-label="Available tenants"
+            >
+              <CommandEmpty>No tenants found.</CommandEmpty>
+              <CommandGroup>
+                {tenants?.map((tenant) => (
+                  <CommandItem
+                    key={tenant.tenantId}
+                    value={`${tenant.displayName} ${tenant.slug}`}
+                    role="option"
+                    aria-selected={tenant.slug === tenantSlug}
+                    onSelect={() => {
+                      switchTenant({
+                        id: tenant.tenantId,
+                        slug: tenant.slug,
+                        name: tenant.displayName,
+                      })
+                      setOpen(false)
+                    }}
+                  >
+                    <Check
+                      className={cn(
+                        'mr-2 size-4',
+                        tenant.slug === tenantSlug ? 'opacity-100' : 'opacity-0',
+                      )}
+                    />
+                    <div className="flex flex-col">
+                      <span>{tenant.displayName}</span>
+                      <span className="text-xs text-muted-foreground">{tenant.slug}</span>
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { SearchIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("bg-border -mx-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,87 @@
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/frontend/src/hooks/use-tenants.test.tsx
+++ b/frontend/src/hooks/use-tenants.test.tsx
@@ -131,4 +131,25 @@ describe('useTenants', () => {
 
     expect(result.current.data).toEqual([])
   })
+
+  it('fetches all pages when nextPageToken is present', async () => {
+    const page1Tenants = [mockTenants[0]]
+    const page2Tenants = [mockTenants[1]]
+    const listTenants = vi.fn()
+      .mockResolvedValueOnce({ tenants: page1Tenants, nextPageToken: 'token-page-2' })
+      .mockResolvedValueOnce({ tenants: page2Tenants, nextPageToken: '' })
+
+    vi.mocked(useApiClients).mockReturnValue({
+      tenant: { listTenants },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useTenants(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(listTenants).toHaveBeenCalledTimes(2)
+    expect(listTenants).toHaveBeenNthCalledWith(1, {})
+    expect(listTenants).toHaveBeenNthCalledWith(2, { pageToken: 'token-page-2' })
+    expect(result.current.data).toEqual([...page1Tenants, ...page2Tenants])
+  })
 })

--- a/frontend/src/hooks/use-tenants.test.tsx
+++ b/frontend/src/hooks/use-tenants.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+
+// Mock useApiClients so we don't need a real transport
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+}))
+
+import { useApiClients } from '@/api/context'
+import { useTenants } from './use-tenants'
+
+const mockTenants = [
+  {
+    tenantId: 'acme_corp',
+    slug: 'acme-bank',
+    displayName: 'Acme Bank',
+    status: 1,
+    settlementAsset: 'GBP',
+    subdomain: '',
+    partyId: '',
+    errorMessage: '',
+    version: 1,
+    createdAt: undefined,
+    deprovisionedAt: undefined,
+    metadata: undefined,
+  },
+  {
+    tenantId: 'beta_corp',
+    slug: 'beta-financial',
+    displayName: 'Beta Financial',
+    status: 1,
+    settlementAsset: 'USD',
+    subdomain: '',
+    partyId: '',
+    errorMessage: '',
+    version: 1,
+    createdAt: undefined,
+    deprovisionedAt: undefined,
+    metadata: undefined,
+  },
+]
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useTenants', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns tenants from API on success', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      tenant: {
+        listTenants: vi.fn().mockResolvedValue({ tenants: mockTenants, nextPageToken: '' }),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useTenants(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual(mockTenants)
+  })
+
+  it('returns error state when API fails', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      tenant: {
+        listTenants: vi.fn().mockRejectedValue(new Error('Network error')),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useTenants(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    expect(result.current.error).toBeInstanceOf(Error)
+  })
+
+  it('returns loading state initially', () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      tenant: {
+        listTenants: vi.fn().mockReturnValue(new Promise(() => {})),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useTenants(), { wrapper: makeWrapper() })
+
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('uses platform query key for caching', async () => {
+    const listTenants = vi.fn().mockResolvedValue({ tenants: mockTenants, nextPageToken: '' })
+    vi.mocked(useApiClients).mockReturnValue({
+      tenant: { listTenants },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    })
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useTenants(), { wrapper })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    // Should be cached under platform.tenants key
+    const cached = queryClient.getQueryData(['platform', 'tenants'])
+    expect(cached).toEqual(mockTenants)
+  })
+
+  it('returns empty array when API returns no tenants', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      tenant: {
+        listTenants: vi.fn().mockResolvedValue({ tenants: [], nextPageToken: '' }),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useTenants(), { wrapper: makeWrapper() })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual([])
+  })
+})

--- a/frontend/src/hooks/use-tenants.ts
+++ b/frontend/src/hooks/use-tenants.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
+import { platformKeys } from '@/lib/query-keys'
+
+/**
+ * Fetches the list of tenants from the TenantService.
+ * Only meaningful for platform admins - tenant users should not call this.
+ *
+ * Caches for 5 minutes under the platform.tenants query key.
+ */
+export function useTenants() {
+  const { tenant } = useApiClients()
+
+  return useQuery({
+    queryKey: platformKeys.tenants(),
+    queryFn: async () => {
+      const response = await tenant.listTenants({})
+      return response.tenants
+    },
+    staleTime: 5 * 60_000,
+  })
+}

--- a/frontend/src/hooks/use-tenants.ts
+++ b/frontend/src/hooks/use-tenants.ts
@@ -14,8 +14,15 @@ export function useTenants() {
   return useQuery({
     queryKey: platformKeys.tenants(),
     queryFn: async () => {
-      const response = await tenant.listTenants({})
-      return response.tenants
+      const first = await tenant.listTenants({})
+      let all = first.tenants ?? []
+      let pageToken = first.nextPageToken
+      while (pageToken) {
+        const page = await tenant.listTenants({ pageToken })
+        all = all.concat(page.tenants ?? [])
+        pageToken = page.nextPageToken
+      }
+      return all
     },
     staleTime: 5 * 60_000,
   })

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -6,6 +6,16 @@ import { server } from './msw-handlers'
 
 expect.extend({ toHaveNoViolations })
 
+// Polyfill ResizeObserver for cmdk and other components that use it in jsdom
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// Polyfill scrollIntoView for cmdk keyboard navigation in jsdom
+Element.prototype.scrollIntoView = function () {}
+
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 afterEach(() => {
   cleanup()


### PR DESCRIPTION
## Summary

- Adds `TenantSelector` combobox component for platform admins to switch between tenants in the header
- Adds `useTenants` React Query hook that calls `TenantService.ListTenants` with 5-minute stale cache
- Installs and configures shadcn `Command` and `Popover` UI primitives (backed by `cmdk` + `radix-ui`)
- Replaces the `TenantSelectorPlaceholder` in `header.tsx` with the real `TenantSelector`

## Changes Made

| File | Change |
|------|--------|
| `src/components/layout/tenant-selector.tsx` | New: combobox with search, selection, loading state |
| `src/components/layout/tenant-selector.test.tsx` | New: 19 tests covering render, interaction, search, keyboard, a11y |
| `src/hooks/use-tenants.ts` | New: TanStack Query hook for ListTenants RPC |
| `src/hooks/use-tenants.test.tsx` | New: 5 tests covering success, error, loading, cache key |
| `src/components/ui/command.tsx` | New: shadcn Command component (cmdk-based) |
| `src/components/ui/popover.tsx` | New: shadcn Popover component (radix-based) |
| `src/components/layout/header.tsx` | Updated: uses real `TenantSelector` instead of placeholder |
| `src/components/layout/index.ts` | Updated: exports `TenantSelector` |
| `src/components/layout/header.test.tsx` | Updated: mocks `TenantSelector` to isolate from proto deps |
| `src/components/layout/app-shell.test.tsx` | Updated: mocks `TenantSelector` to isolate from proto deps |
| `src/test/setup.ts` | Updated: adds `ResizeObserver` and `scrollIntoView` polyfills for `cmdk` in jsdom |

## Technical Details

- `TenantSelector` uses `Popover` + `Command` for a searchable combobox pattern
- Search filters on both `displayName` and `slug` fields
- `switchTenant` maps proto `Tenant` fields (`tenantId`, `slug`, `displayName`) to the `Tenant` type expected by `TenantContext` (`id`, `slug`, `name`)
- Loading state renders a disabled placeholder with `aria-busy` and `data-testid="tenant-selector-loading"`
- Selected tenant shown with checkmark icon; unselected shows "Select tenant..." placeholder
- Dropdown closes automatically after selection

## Testing

- 282 tests pass (24 of 25 test files pass)
- The 1 pre-existing failure is `src/test/api/clients.test.ts` which fails because proto-generated files are not committed to the repo (generated at build time) — this failure exists on `develop` and is unrelated to this PR

## Accessibility

- `combobox` role on trigger button with `aria-expanded` and `aria-haspopup="listbox"`
- `listbox` role on the dropdown with `aria-label="Available tenants"`
- `option` role on each tenant item with `aria-selected`
- No axe violations in closed state (verified by test)