### PR TITLE
feat: Create Dashboard page with stat cards and activity feed

### DIFF
--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -1,4 +1,5 @@
 import { PageErrorBoundary } from '@/components/error-boundary'
+import { DashboardPage } from '@/pages/dashboard'
 
 export interface Route {
   path: string
@@ -10,7 +11,7 @@ const routes: Route[] = [
   {
     path: '/',
     name: 'Dashboard',
-    component: () => <div>Dashboard</div>,
+    component: DashboardPage,
   },
 ]
 

--- a/frontend/src/pages/dashboard/activity-feed.test.tsx
+++ b/frontend/src/pages/dashboard/activity-feed.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ActivityFeed, type ActivityItem } from './activity-feed'
+
+const mockItems: ActivityItem[] = [
+  {
+    id: '1',
+    type: 'payment',
+    title: 'Payment order created',
+    description: 'PO-001 for £100.00',
+    timestamp: { seconds: BigInt(1700000000), nanos: 0 },
+    status: 'INITIATED',
+  },
+  {
+    id: '2',
+    type: 'account',
+    title: 'Account opened',
+    description: 'Current account ACC-001',
+    timestamp: { seconds: BigInt(1699999000), nanos: 0 },
+    status: 'ACTIVE',
+  },
+]
+
+describe('ActivityFeed', () => {
+  it('renders empty state when no items', () => {
+    render(<ActivityFeed items={[]} />)
+
+    expect(screen.getByText('No recent activity')).toBeInTheDocument()
+  })
+
+  it('renders activity items', () => {
+    render(<ActivityFeed items={mockItems} />)
+
+    expect(screen.getByText('Payment order created')).toBeInTheDocument()
+    expect(screen.getByText('Account opened')).toBeInTheDocument()
+  })
+
+  it('renders item descriptions', () => {
+    render(<ActivityFeed items={mockItems} />)
+
+    expect(screen.getByText('PO-001 for £100.00')).toBeInTheDocument()
+    expect(screen.getByText('Current account ACC-001')).toBeInTheDocument()
+  })
+
+  it('renders loading skeleton when isLoading is true', () => {
+    render(<ActivityFeed items={[]} isLoading />)
+
+    expect(screen.getAllByTestId('activity-skeleton')).toHaveLength(5)
+  })
+
+  it('renders status badges for items', () => {
+    render(<ActivityFeed items={mockItems} />)
+
+    expect(screen.getByText('INITIATED')).toBeInTheDocument()
+    expect(screen.getByText('ACTIVE')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/dashboard/activity-feed.tsx
+++ b/frontend/src/pages/dashboard/activity-feed.tsx
@@ -1,0 +1,86 @@
+import { StatusBadge } from '@/components/shared/status-badge'
+import { TimeDisplay } from '@/components/shared/time-display'
+import { cn } from '@/lib/utils'
+
+export interface ActivityItem {
+  id: string
+  type: 'payment' | 'account' | 'reconciliation' | 'saga' | 'system'
+  title: string
+  description?: string
+  timestamp: { seconds: bigint | number; nanos?: number } | null | undefined
+  status?: string
+}
+
+interface ActivityFeedProps {
+  items: ActivityItem[]
+  isLoading?: boolean
+  className?: string
+}
+
+function ActivitySkeleton() {
+  return (
+    <div data-testid="activity-skeleton" className="flex items-start gap-3 py-3">
+      <div className="mt-1 h-2 w-2 animate-pulse rounded-full bg-muted" />
+      <div className="flex-1 space-y-1">
+        <div className="h-4 w-48 animate-pulse rounded bg-muted" />
+        <div className="h-3 w-32 animate-pulse rounded bg-muted" />
+      </div>
+      <div className="h-3 w-16 animate-pulse rounded bg-muted" />
+    </div>
+  )
+}
+
+const TYPE_COLORS: Record<ActivityItem['type'], string> = {
+  payment: 'bg-blue-400',
+  account: 'bg-green-400',
+  reconciliation: 'bg-yellow-400',
+  saga: 'bg-purple-400',
+  system: 'bg-gray-400',
+}
+
+export function ActivityFeed({ items, isLoading, className }: ActivityFeedProps) {
+  if (isLoading) {
+    return (
+      <div className={cn('divide-y', className)}>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <ActivitySkeleton key={i} />
+        ))}
+      </div>
+    )
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className={cn('py-8 text-center text-sm text-muted-foreground', className)}>
+        No recent activity
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn('divide-y', className)}>
+      {items.map((item) => (
+        <div key={item.id} className="flex items-start gap-3 py-3">
+          <div
+            className={cn(
+              'mt-2 h-2 w-2 flex-shrink-0 rounded-full',
+              TYPE_COLORS[item.type] ?? 'bg-gray-400',
+            )}
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="truncate text-sm font-medium">{item.title}</span>
+              {item.status && <StatusBadge status={item.status} />}
+            </div>
+            {item.description && (
+              <p className="mt-0.5 truncate text-xs text-muted-foreground">{item.description}</p>
+            )}
+          </div>
+          <div className="flex-shrink-0 text-xs text-muted-foreground">
+            <TimeDisplay timestamp={item.timestamp} format="relative" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/pages/dashboard/index.test.tsx
+++ b/frontend/src/pages/dashboard/index.test.tsx
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/msw-handlers'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { DashboardPage } from './index'
+
+// Mock the transport and clients modules to avoid importing proto generated files
+vi.mock('@/api/transport', () => ({
+  createTenantTransport: vi.fn(() => ({ __type: 'mock-transport' })),
+}))
+
+vi.mock('@/api/clients', () => ({
+  createServiceClients: vi.fn(() => ({
+    currentAccount: {},
+    paymentOrder: {
+      listPaymentOrders: vi.fn(),
+    },
+    financialAccounting: {
+      listFinancialBookingLogs: vi.fn(),
+      listLedgerPostings: vi.fn(),
+    },
+    positionKeeping: {},
+    accountReconciliation: {},
+    party: {},
+    tenant: {},
+    sagaRegistry: {},
+    sagaAdmin: {},
+    referenceData: {},
+    accountTypeRegistry: {},
+    node: {},
+    internalBankAccount: {},
+    marketInformation: {},
+  })),
+}))
+
+import { createServiceClients } from '@/api/clients'
+
+function setupMockClients({
+  paymentOrdersResult,
+  bookingLogsResult,
+  ledgerPostingsResult,
+}: {
+  paymentOrdersResult?: object | Error
+  bookingLogsResult?: object | Error
+  ledgerPostingsResult?: object | Error
+} = {}) {
+  const mockPaymentOrders = vi.fn()
+  const mockBookingLogs = vi.fn()
+  const mockLedgerPostings = vi.fn()
+
+  if (paymentOrdersResult instanceof Error) {
+    mockPaymentOrders.mockRejectedValue(paymentOrdersResult)
+  } else if (paymentOrdersResult) {
+    mockPaymentOrders.mockResolvedValue(paymentOrdersResult)
+  } else {
+    mockPaymentOrders.mockResolvedValue({
+      paymentOrders: [],
+      pagination: { totalCount: BigInt(0), nextPageToken: '' },
+    })
+  }
+
+  if (bookingLogsResult instanceof Error) {
+    mockBookingLogs.mockRejectedValue(bookingLogsResult)
+  } else if (bookingLogsResult) {
+    mockBookingLogs.mockResolvedValue(bookingLogsResult)
+  } else {
+    mockBookingLogs.mockResolvedValue({
+      financialBookingLogs: [],
+      pagination: { totalCount: BigInt(0), nextPageToken: '' },
+    })
+  }
+
+  if (ledgerPostingsResult instanceof Error) {
+    mockLedgerPostings.mockRejectedValue(ledgerPostingsResult)
+  } else if (ledgerPostingsResult) {
+    mockLedgerPostings.mockResolvedValue(ledgerPostingsResult)
+  } else {
+    mockLedgerPostings.mockResolvedValue({
+      ledgerPostings: [],
+      pagination: { totalCount: BigInt(0), nextPageToken: '' },
+    })
+  }
+
+  vi.mocked(createServiceClients).mockReturnValue({
+    currentAccount: {} as never,
+    paymentOrder: { listPaymentOrders: mockPaymentOrders } as never,
+    financialAccounting: {
+      listFinancialBookingLogs: mockBookingLogs,
+      listLedgerPostings: mockLedgerPostings,
+    } as never,
+    positionKeeping: {} as never,
+    accountReconciliation: {} as never,
+    party: {} as never,
+    tenant: {} as never,
+    sagaRegistry: {} as never,
+    sagaAdmin: {} as never,
+    referenceData: {} as never,
+    accountTypeRegistry: {} as never,
+    node: {} as never,
+    internalBankAccount: {} as never,
+    marketInformation: {} as never,
+  })
+}
+
+describe('DashboardPage', () => {
+  it('renders dashboard heading', () => {
+    setupMockClients()
+    renderWithProviders(<DashboardPage />, {
+      initialToken: createTenantUserToken('tenant-001'),
+    })
+
+    expect(screen.getByRole('heading', { name: /dashboard/i })).toBeInTheDocument()
+  })
+
+  it('renders stat card titles', () => {
+    setupMockClients()
+    renderWithProviders(<DashboardPage />, {
+      initialToken: createTenantUserToken('tenant-001'),
+    })
+
+    expect(screen.getByText('Payment Orders')).toBeInTheDocument()
+    expect(screen.getByText('Booking Logs')).toBeInTheDocument()
+    expect(screen.getByText('Ledger Postings')).toBeInTheDocument()
+  })
+
+  it('shows loading skeletons initially', () => {
+    // Use a never-resolving mock to keep loading state
+    vi.mocked(createServiceClients).mockReturnValue({
+      currentAccount: {} as never,
+      paymentOrder: { listPaymentOrders: vi.fn(() => new Promise(() => {})) } as never,
+      financialAccounting: {
+        listFinancialBookingLogs: vi.fn(() => new Promise(() => {})),
+        listLedgerPostings: vi.fn(() => new Promise(() => {})),
+      } as never,
+      positionKeeping: {} as never,
+      accountReconciliation: {} as never,
+      party: {} as never,
+      tenant: {} as never,
+      sagaRegistry: {} as never,
+      sagaAdmin: {} as never,
+      referenceData: {} as never,
+      accountTypeRegistry: {} as never,
+      node: {} as never,
+      internalBankAccount: {} as never,
+      marketInformation: {} as never,
+    })
+
+    renderWithProviders(<DashboardPage />, {
+      initialToken: createTenantUserToken('tenant-001'),
+    })
+
+    const skeletons = screen.getAllByTestId('stat-card-skeleton')
+    expect(skeletons.length).toBeGreaterThan(0)
+  })
+
+  it('renders stat card values after data loads', async () => {
+    setupMockClients({
+      paymentOrdersResult: {
+        paymentOrders: [],
+        pagination: { totalCount: BigInt(5), nextPageToken: '' },
+      },
+      bookingLogsResult: {
+        financialBookingLogs: [],
+        pagination: { totalCount: BigInt(12), nextPageToken: '' },
+      },
+      ledgerPostingsResult: {
+        ledgerPostings: [],
+        pagination: { totalCount: BigInt(42), nextPageToken: '' },
+      },
+    })
+
+    renderWithProviders(<DashboardPage />, {
+      initialToken: createTenantUserToken('tenant-001'),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('5')).toBeInTheDocument()
+    })
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.getByText('42')).toBeInTheDocument()
+  })
+
+  it('error in one stat card does not break others', async () => {
+    setupMockClients({
+      paymentOrdersResult: new Error('Network error'),
+      bookingLogsResult: {
+        financialBookingLogs: [],
+        pagination: { totalCount: BigInt(7), nextPageToken: '' },
+      },
+      ledgerPostingsResult: {
+        ledgerPostings: [],
+        pagination: { totalCount: BigInt(3), nextPageToken: '' },
+      },
+    })
+
+    renderWithProviders(<DashboardPage />, {
+      initialToken: createTenantUserToken('tenant-001'),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('7')).toBeInTheDocument()
+    })
+    expect(screen.getByText('3')).toBeInTheDocument()
+    // Error state shows dash
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('renders recent activity section', () => {
+    setupMockClients()
+    renderWithProviders(<DashboardPage />, {
+      initialToken: createTenantUserToken('tenant-001'),
+    })
+
+    expect(screen.getByText('Recent Activity')).toBeInTheDocument()
+  })
+
+  it('renders quick actions section', () => {
+    setupMockClients()
+    renderWithProviders(<DashboardPage />, {
+      initialToken: createTenantUserToken('tenant-001'),
+    })
+
+    expect(screen.getByText('Quick Actions')).toBeInTheDocument()
+  })
+
+  it('shows "recent" qualifier when totalCount is -1 (unknown)', async () => {
+    setupMockClients({
+      paymentOrdersResult: {
+        paymentOrders: [{ id: 'po1' }, { id: 'po2' }],
+        pagination: { totalCount: BigInt(-1), nextPageToken: '' },
+      },
+      bookingLogsResult: {
+        financialBookingLogs: [],
+        pagination: { totalCount: BigInt(-1), nextPageToken: '' },
+      },
+      ledgerPostingsResult: {
+        ledgerPostings: [],
+        pagination: { totalCount: BigInt(-1), nextPageToken: '' },
+      },
+    })
+
+    renderWithProviders(<DashboardPage />, {
+      initialToken: createTenantUserToken('tenant-001'),
+    })
+
+    await waitFor(() => {
+      const recentLabels = screen.getAllByText('recent')
+      expect(recentLabels.length).toBeGreaterThan(0)
+    })
+  })
+
+  it('renders without crashing when no tenant context', () => {
+    setupMockClients()
+    renderWithProviders(<DashboardPage />)
+
+    expect(screen.getByRole('heading', { name: /dashboard/i })).toBeInTheDocument()
+  })
+
+  it('does not make queries when no tenantSlug', () => {
+    const mockListPayments = vi.fn()
+    vi.mocked(createServiceClients).mockReturnValue({
+      currentAccount: {} as never,
+      paymentOrder: { listPaymentOrders: mockListPayments } as never,
+      financialAccounting: {
+        listFinancialBookingLogs: vi.fn(),
+        listLedgerPostings: vi.fn(),
+      } as never,
+      positionKeeping: {} as never,
+      accountReconciliation: {} as never,
+      party: {} as never,
+      tenant: {} as never,
+      sagaRegistry: {} as never,
+      sagaAdmin: {} as never,
+      referenceData: {} as never,
+      accountTypeRegistry: {} as never,
+      node: {} as never,
+      internalBankAccount: {} as never,
+      marketInformation: {} as never,
+    })
+
+    // Render without token (no tenant)
+    renderWithProviders(<DashboardPage />)
+
+    // Queries should not be called with no tenant
+    expect(mockListPayments).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/dashboard/index.test.tsx
+++ b/frontend/src/pages/dashboard/index.test.tsx
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
-import { http, HttpResponse } from 'msw'
-import { server } from '@/test/msw-handlers'
 import { renderWithProviders } from '@/test/test-utils'
 import { createTenantUserToken } from '@/test/jwt-helpers'
 import { DashboardPage } from './index'

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -1,0 +1,198 @@
+import { useQuery } from '@tanstack/react-query'
+import { CreditCard, FileText, BarChart3, ArrowRight } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useApiClients } from '@/api/context'
+import { useTenantContext } from '@/contexts/tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import { StatCard } from './stat-card'
+import { ActivityFeed, type ActivityItem } from './activity-feed'
+import { QuickActions, type QuickAction } from './quick-actions'
+
+function useDashboardStats(tenantSlug: string | null) {
+  const clients = useApiClients()
+
+  const paymentsQuery = useQuery({
+    queryKey: [...tenantKeys.all(tenantSlug ?? ''), 'dashboard', 'payments'],
+    queryFn: () =>
+      clients.paymentOrder.listPaymentOrders({
+        pagination: { pageSize: 1, pageToken: '' },
+      }),
+    enabled: !!tenantSlug,
+  })
+
+  const bookingLogsQuery = useQuery({
+    queryKey: [...tenantKeys.all(tenantSlug ?? ''), 'dashboard', 'bookingLogs'],
+    queryFn: () =>
+      clients.financialAccounting.listFinancialBookingLogs({
+        pagination: { pageSize: 1, pageToken: '' },
+      }),
+    enabled: !!tenantSlug,
+  })
+
+  const ledgerPostingsQuery = useQuery({
+    queryKey: [...tenantKeys.all(tenantSlug ?? ''), 'dashboard', 'ledgerPostings'],
+    queryFn: () =>
+      clients.financialAccounting.listLedgerPostings({
+        pagination: { pageSize: 1, pageToken: '' },
+      }),
+    enabled: !!tenantSlug,
+  })
+
+  return { paymentsQuery, bookingLogsQuery, ledgerPostingsQuery }
+}
+
+function getCountFromPagination(
+  pagination: { totalCount?: bigint | string | number | null } | null | undefined,
+  fallbackLength: number,
+): { count: number; isEstimate: boolean } {
+  if (!pagination) return { count: fallbackLength, isEstimate: true }
+
+  const total =
+    typeof pagination.totalCount === 'bigint'
+      ? Number(pagination.totalCount)
+      : typeof pagination.totalCount === 'string'
+        ? parseInt(pagination.totalCount, 10)
+        : (pagination.totalCount ?? -1)
+
+  if (total === -1 || total === null || total === undefined || isNaN(total as number)) {
+    return { count: fallbackLength, isEstimate: true }
+  }
+  return { count: total as number, isEstimate: false }
+}
+
+export function DashboardPage() {
+  const { tenantSlug } = useTenantContext()
+  const { paymentsQuery, bookingLogsQuery, ledgerPostingsQuery } = useDashboardStats(tenantSlug)
+
+  const paymentsCount = paymentsQuery.data
+    ? getCountFromPagination(
+        paymentsQuery.data.pagination,
+        paymentsQuery.data.paymentOrders.length,
+      )
+    : null
+
+  const bookingLogsCount = bookingLogsQuery.data
+    ? getCountFromPagination(
+        bookingLogsQuery.data.pagination,
+        bookingLogsQuery.data.financialBookingLogs.length,
+      )
+    : null
+
+  const ledgerPostingsCount = ledgerPostingsQuery.data
+    ? getCountFromPagination(
+        ledgerPostingsQuery.data.pagination,
+        ledgerPostingsQuery.data.ledgerPostings.length,
+      )
+    : null
+
+  // Build recent activity feed from payment orders data
+  const activityItems: ActivityItem[] = (paymentsQuery.data?.paymentOrders ?? [])
+    .slice(0, 10)
+    .map((po) => ({
+      id: po.id ?? String(Math.random()),
+      type: 'payment' as const,
+      title: `Payment order ${po.id ?? ''}`,
+      description: po.id ? `ID: ${po.id}` : undefined,
+      timestamp: po.createdAt ?? null,
+      status: po.status?.toString(),
+    }))
+
+  const quickActions: QuickAction[] = [
+    {
+      id: 'view-payments',
+      label: 'View Payment Orders',
+      description: 'Browse all payment orders',
+      icon: <CreditCard className="h-4 w-4" />,
+      onClick: () => {},
+    },
+    {
+      id: 'view-booking-logs',
+      label: 'View Booking Logs',
+      description: 'Browse financial booking logs',
+      icon: <FileText className="h-4 w-4" />,
+      onClick: () => {},
+    },
+    {
+      id: 'view-ledger',
+      label: 'View Ledger Postings',
+      description: 'Browse double-entry ledger',
+      icon: <BarChart3 className="h-4 w-4" />,
+      onClick: () => {},
+    },
+    {
+      id: 'view-reconciliations',
+      label: 'Reconciliations',
+      description: 'Check reconciliation status',
+      icon: <ArrowRight className="h-4 w-4" />,
+      onClick: () => {},
+    },
+  ]
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Dashboard</h1>
+        <p className="text-muted-foreground">
+          {tenantSlug ? `Overview for ${tenantSlug}` : 'Tenant overview'}
+        </p>
+      </div>
+
+      {/* Stat Cards */}
+      <div className="grid gap-4 md:grid-cols-3">
+        <StatCard
+          title="Payment Orders"
+          value={paymentsCount?.count}
+          isLoading={paymentsQuery.isLoading}
+          error={paymentsQuery.isError}
+          showRecentQualifier={!!(paymentsCount?.isEstimate && !paymentsQuery.isLoading && !paymentsQuery.isError)}
+          description="Active payment orders"
+          icon={<CreditCard className="h-4 w-4" />}
+        />
+        <StatCard
+          title="Booking Logs"
+          value={bookingLogsCount?.count}
+          isLoading={bookingLogsQuery.isLoading}
+          error={bookingLogsQuery.isError}
+          showRecentQualifier={!!(bookingLogsCount?.isEstimate && !bookingLogsQuery.isLoading && !bookingLogsQuery.isError)}
+          description="Financial booking logs"
+          icon={<FileText className="h-4 w-4" />}
+        />
+        <StatCard
+          title="Ledger Postings"
+          value={ledgerPostingsCount?.count}
+          isLoading={ledgerPostingsQuery.isLoading}
+          error={ledgerPostingsQuery.isError}
+          showRecentQualifier={!!(ledgerPostingsCount?.isEstimate && !ledgerPostingsQuery.isLoading && !ledgerPostingsQuery.isError)}
+          description="Double-entry postings"
+          icon={<BarChart3 className="h-4 w-4" />}
+        />
+      </div>
+
+      {/* Main content area */}
+      <div className="grid gap-4 md:grid-cols-3">
+        {/* Recent Activity - takes 2/3 width */}
+        <Card className="md:col-span-2">
+          <CardHeader>
+            <CardTitle>Recent Activity</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ActivityFeed
+              items={activityItems}
+              isLoading={paymentsQuery.isLoading}
+            />
+          </CardContent>
+        </Card>
+
+        {/* Quick Actions - takes 1/3 width */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Quick Actions</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <QuickActions actions={quickActions} />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -105,8 +105,8 @@ export function DashboardPage() {
     : null
 
   // Build recent activity feed from dedicated activity query (pageSize: 10)
-  const activityItems: ActivityItem[] = (activityQuery.data?.paymentOrders ?? []).map((po) => ({
-    id: po.id ?? String(Math.random()),
+  const activityItems: ActivityItem[] = (activityQuery.data?.paymentOrders ?? []).map((po, idx) => ({
+    id: po.id ?? `activity-${idx}`,
     type: 'payment' as const,
     title: `Payment order ${po.id ?? ''}`,
     description: po.id ? `ID: ${po.id}` : undefined,

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -8,9 +8,13 @@ import { StatCard } from './stat-card'
 import { ActivityFeed, type ActivityItem } from './activity-feed'
 import { QuickActions, type QuickAction } from './quick-actions'
 
+// Cache dashboard stats for 60s to reduce unnecessary refetches on navigation
+const DASHBOARD_STALE_TIME = 60_000
+
 function useDashboardStats(tenantSlug: string | null) {
   const clients = useApiClients()
 
+  // pageSize: 1 for stat queries — we only need totalCount from pagination metadata
   const paymentsQuery = useQuery({
     queryKey: [...tenantKeys.all(tenantSlug ?? ''), 'dashboard', 'payments'],
     queryFn: () =>
@@ -18,6 +22,7 @@ function useDashboardStats(tenantSlug: string | null) {
         pagination: { pageSize: 1, pageToken: '' },
       }),
     enabled: !!tenantSlug,
+    staleTime: DASHBOARD_STALE_TIME,
   })
 
   const bookingLogsQuery = useQuery({
@@ -27,6 +32,7 @@ function useDashboardStats(tenantSlug: string | null) {
         pagination: { pageSize: 1, pageToken: '' },
       }),
     enabled: !!tenantSlug,
+    staleTime: DASHBOARD_STALE_TIME,
   })
 
   const ledgerPostingsQuery = useQuery({
@@ -36,9 +42,21 @@ function useDashboardStats(tenantSlug: string | null) {
         pagination: { pageSize: 1, pageToken: '' },
       }),
     enabled: !!tenantSlug,
+    staleTime: DASHBOARD_STALE_TIME,
   })
 
-  return { paymentsQuery, bookingLogsQuery, ledgerPostingsQuery }
+  // Separate query for activity feed — uses larger page to populate the list
+  const activityQuery = useQuery({
+    queryKey: [...tenantKeys.all(tenantSlug ?? ''), 'dashboard', 'activity'],
+    queryFn: () =>
+      clients.paymentOrder.listPaymentOrders({
+        pagination: { pageSize: 10, pageToken: '' },
+      }),
+    enabled: !!tenantSlug,
+    staleTime: DASHBOARD_STALE_TIME,
+  })
+
+  return { paymentsQuery, bookingLogsQuery, ledgerPostingsQuery, activityQuery }
 }
 
 function getCountFromPagination(
@@ -62,7 +80,8 @@ function getCountFromPagination(
 
 export function DashboardPage() {
   const { tenantSlug } = useTenantContext()
-  const { paymentsQuery, bookingLogsQuery, ledgerPostingsQuery } = useDashboardStats(tenantSlug)
+  const { paymentsQuery, bookingLogsQuery, ledgerPostingsQuery, activityQuery } =
+    useDashboardStats(tenantSlug)
 
   const paymentsCount = paymentsQuery.data
     ? getCountFromPagination(
@@ -85,18 +104,18 @@ export function DashboardPage() {
       )
     : null
 
-  // Build recent activity feed from payment orders data
-  const activityItems: ActivityItem[] = (paymentsQuery.data?.paymentOrders ?? [])
-    .slice(0, 10)
-    .map((po) => ({
-      id: po.id ?? String(Math.random()),
-      type: 'payment' as const,
-      title: `Payment order ${po.id ?? ''}`,
-      description: po.id ? `ID: ${po.id}` : undefined,
-      timestamp: po.createdAt ?? null,
-      status: po.status?.toString(),
-    }))
+  // Build recent activity feed from dedicated activity query (pageSize: 10)
+  const activityItems: ActivityItem[] = (activityQuery.data?.paymentOrders ?? []).map((po) => ({
+    id: po.id ?? String(Math.random()),
+    type: 'payment' as const,
+    title: `Payment order ${po.id ?? ''}`,
+    description: po.id ? `ID: ${po.id}` : undefined,
+    timestamp: po.createdAt ?? null,
+    status: po.status?.toString(),
+  }))
 
+  // Quick actions will navigate to dedicated pages once routes are implemented.
+  // Disabled until routing infrastructure is wired (task 026-operations-console.17).
   const quickActions: QuickAction[] = [
     {
       id: 'view-payments',
@@ -104,6 +123,7 @@ export function DashboardPage() {
       description: 'Browse all payment orders',
       icon: <CreditCard className="h-4 w-4" />,
       onClick: () => {},
+      disabled: true,
     },
     {
       id: 'view-booking-logs',
@@ -111,6 +131,7 @@ export function DashboardPage() {
       description: 'Browse financial booking logs',
       icon: <FileText className="h-4 w-4" />,
       onClick: () => {},
+      disabled: true,
     },
     {
       id: 'view-ledger',
@@ -118,6 +139,7 @@ export function DashboardPage() {
       description: 'Browse double-entry ledger',
       icon: <BarChart3 className="h-4 w-4" />,
       onClick: () => {},
+      disabled: true,
     },
     {
       id: 'view-reconciliations',
@@ -125,6 +147,7 @@ export function DashboardPage() {
       description: 'Check reconciliation status',
       icon: <ArrowRight className="h-4 w-4" />,
       onClick: () => {},
+      disabled: true,
     },
   ]
 
@@ -176,10 +199,7 @@ export function DashboardPage() {
             <CardTitle>Recent Activity</CardTitle>
           </CardHeader>
           <CardContent>
-            <ActivityFeed
-              items={activityItems}
-              isLoading={paymentsQuery.isLoading}
-            />
+            <ActivityFeed items={activityItems} isLoading={activityQuery.isLoading} />
           </CardContent>
         </Card>
 

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -199,7 +199,13 @@ export function DashboardPage() {
             <CardTitle>Recent Activity</CardTitle>
           </CardHeader>
           <CardContent>
-            <ActivityFeed items={activityItems} isLoading={activityQuery.isLoading} />
+            {activityQuery.isError ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">
+                Failed to load recent activity
+              </div>
+            ) : (
+              <ActivityFeed items={activityItems} isLoading={activityQuery.isLoading} />
+            )}
           </CardContent>
         </Card>
 

--- a/frontend/src/pages/dashboard/quick-actions.test.tsx
+++ b/frontend/src/pages/dashboard/quick-actions.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QuickActions, type QuickAction } from './quick-actions'
+
+const mockActions: QuickAction[] = [
+  {
+    id: 'new-payment',
+    label: 'New Payment',
+    description: 'Create a payment order',
+    onClick: vi.fn(),
+  },
+  {
+    id: 'view-accounts',
+    label: 'View Accounts',
+    description: 'Browse all accounts',
+    onClick: vi.fn(),
+  },
+]
+
+describe('QuickActions', () => {
+  it('renders all action buttons', () => {
+    render(<QuickActions actions={mockActions} />)
+
+    expect(screen.getByText('New Payment')).toBeInTheDocument()
+    expect(screen.getByText('View Accounts')).toBeInTheDocument()
+  })
+
+  it('renders action descriptions', () => {
+    render(<QuickActions actions={mockActions} />)
+
+    expect(screen.getByText('Create a payment order')).toBeInTheDocument()
+    expect(screen.getByText('Browse all accounts')).toBeInTheDocument()
+  })
+
+  it('calls onClick handler when button clicked', async () => {
+    const user = userEvent.setup()
+    render(<QuickActions actions={mockActions} />)
+
+    await user.click(screen.getByText('New Payment'))
+
+    expect(mockActions[0].onClick).toHaveBeenCalledOnce()
+  })
+
+  it('renders empty state when no actions provided', () => {
+    render(<QuickActions actions={[]} />)
+
+    expect(screen.getByText('No quick actions available')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/dashboard/quick-actions.tsx
+++ b/frontend/src/pages/dashboard/quick-actions.tsx
@@ -1,0 +1,50 @@
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+export interface QuickAction {
+  id: string
+  label: string
+  description?: string
+  icon?: React.ReactNode
+  onClick: () => void
+  disabled?: boolean
+}
+
+interface QuickActionsProps {
+  actions: QuickAction[]
+  className?: string
+}
+
+export function QuickActions({ actions, className }: QuickActionsProps) {
+  if (actions.length === 0) {
+    return (
+      <div className={cn('py-4 text-center text-sm text-muted-foreground', className)}>
+        No quick actions available
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn('grid gap-2', className)}>
+      {actions.map((action) => (
+        <Button
+          key={action.id}
+          variant="outline"
+          className="h-auto w-full justify-start gap-3 px-4 py-3 text-left"
+          onClick={action.onClick}
+          disabled={action.disabled}
+        >
+          {action.icon && (
+            <span className="flex-shrink-0 text-muted-foreground">{action.icon}</span>
+          )}
+          <div className="min-w-0">
+            <div className="text-sm font-medium">{action.label}</div>
+            {action.description && (
+              <div className="text-xs text-muted-foreground">{action.description}</div>
+            )}
+          </div>
+        </Button>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/pages/dashboard/stat-card.test.tsx
+++ b/frontend/src/pages/dashboard/stat-card.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { StatCard } from './stat-card'
+
+describe('StatCard', () => {
+  it('renders loading skeleton when isLoading is true', () => {
+    render(<StatCard title="Accounts" isLoading />)
+
+    expect(screen.getByTestId('stat-card-skeleton')).toBeInTheDocument()
+    expect(screen.getByText('Accounts')).toBeInTheDocument()
+  })
+
+  it('renders value when loaded', () => {
+    render(<StatCard title="Accounts" value={42} />)
+
+    expect(screen.getByText('42')).toBeInTheDocument()
+    expect(screen.getByText('Accounts')).toBeInTheDocument()
+  })
+
+  it('renders zero value correctly', () => {
+    render(<StatCard title="Payments" value={0} />)
+
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+
+  it('renders with "recent" qualifier when showRecentQualifier is true', () => {
+    render(<StatCard title="Accounts" value={5} showRecentQualifier />)
+
+    expect(screen.getByText('Accounts')).toBeInTheDocument()
+    expect(screen.getByText('recent')).toBeInTheDocument()
+  })
+
+  it('does not render "recent" qualifier by default', () => {
+    render(<StatCard title="Accounts" value={5} />)
+
+    expect(screen.queryByText('recent')).not.toBeInTheDocument()
+  })
+
+  it('renders description when provided', () => {
+    render(<StatCard title="Accounts" value={10} description="Active accounts" />)
+
+    expect(screen.getByText('Active accounts')).toBeInTheDocument()
+  })
+
+  it('renders error state when error is true', () => {
+    render(<StatCard title="Accounts" error />)
+
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('renders icon when provided', () => {
+    const icon = <span data-testid="test-icon">icon</span>
+    render(<StatCard title="Accounts" value={5} icon={icon} />)
+
+    expect(screen.getByTestId('test-icon')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/dashboard/stat-card.tsx
+++ b/frontend/src/pages/dashboard/stat-card.tsx
@@ -1,0 +1,58 @@
+import { type ReactNode } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+interface StatCardProps {
+  title: string
+  value?: number
+  description?: string
+  icon?: ReactNode
+  isLoading?: boolean
+  error?: boolean
+  showRecentQualifier?: boolean
+  className?: string
+}
+
+export function StatCard({
+  title,
+  value,
+  description,
+  icon,
+  isLoading,
+  error,
+  showRecentQualifier,
+  className,
+}: StatCardProps) {
+  return (
+    <Card className={cn('', className)}>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        {icon && <div className="text-muted-foreground">{icon}</div>}
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div
+            data-testid="stat-card-skeleton"
+            className="h-8 w-24 animate-pulse rounded bg-muted"
+          />
+        ) : (
+          <div className="text-2xl font-bold">
+            {error ? (
+              <span className="text-muted-foreground">—</span>
+            ) : (
+              <>
+                {value ?? 0}
+                {showRecentQualifier && (
+                  <span className="ml-1 text-xs font-normal text-muted-foreground">recent</span>
+                )}
+              </>
+            )}
+          </div>
+        )}
+        {description && (
+          <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/test/router.test.tsx
+++ b/frontend/src/test/router.test.tsx
@@ -7,6 +7,15 @@ import {
   getRouteHandlers,
 } from '@/lib/router'
 
+// Mock api modules so router can import DashboardPage without generated proto files
+vi.mock('@/api/transport', () => ({
+  createTenantTransport: vi.fn(() => ({ __type: 'mock-transport' })),
+}))
+
+vi.mock('@/api/clients', () => ({
+  createServiceClients: vi.fn(() => ({})),
+}))
+
 // Mock component that throws an error
 function ErrorComponent() {
   throw new Error('Route error')

--- a/frontend/src/test/test-utils.tsx
+++ b/frontend/src/test/test-utils.tsx
@@ -2,8 +2,9 @@ import { type ReactNode } from 'react'
 import { render, type RenderOptions, type RenderResult } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { configureAxe } from 'vitest-axe'
-import { AuthProvider } from '@/contexts/auth-context'
-import { TenantProvider } from '@/contexts/tenant-context'
+import { AuthProvider, useAuth } from '@/contexts/auth-context'
+import { TenantProvider, useTenantContext } from '@/contexts/tenant-context'
+import { ApiClientProvider } from '@/api/context'
 
 /**
  * Pre-configured axe instance that skips color-contrast checks.
@@ -42,12 +43,25 @@ interface AllProvidersProps {
   queryClient?: QueryClient
 }
 
+function ApiClientBridge({ children }: { children: ReactNode }) {
+  const { accessToken } = useAuth()
+  const { tenantSlug } = useTenantContext()
+  const getToken = () => Promise.resolve(accessToken ?? '')
+  return (
+    <ApiClientProvider tenantSlug={tenantSlug} getToken={getToken}>
+      {children}
+    </ApiClientProvider>
+  )
+}
+
 function AllProviders({ children, initialToken, queryClient }: AllProvidersProps) {
   const client = queryClient ?? createTestQueryClient()
   return (
     <QueryClientProvider client={client}>
       <AuthProvider initialToken={initialToken}>
-        <TenantProvider>{children}</TenantProvider>
+        <TenantProvider>
+          <ApiClientBridge>{children}</ApiClientBridge>
+        </TenantProvider>
       </AuthProvider>
     </QueryClientProvider>
   )


### PR DESCRIPTION
## Summary

- Implements task 026-operations-console.19: Dashboard page with stat cards and activity feed
- Adds `StatCard`, `ActivityFeed`, and `QuickActions` sub-components to `frontend/src/pages/dashboard/`
- `DashboardPage` runs parallel TanStack Query requests for payment orders, booking logs, and ledger postings
- Stat cards show loading skeletons during fetch and display a 'recent' qualifier when the API returns `-1` (unknown) as `totalCount`
- Registers the `DashboardPage` component at the `'/'` route in `router.tsx`
- Adds `ApiClientBridge` to the shared `renderWithProviders` test utility so future page-level tests have full provider coverage

## Changes Made

- `frontend/src/pages/dashboard/stat-card.tsx` — StatCard with loading skeleton and conditional 'recent' qualifier
- `frontend/src/pages/dashboard/activity-feed.tsx` — ActivityFeed with timeline display, StatusBadge, TimeDisplay integration
- `frontend/src/pages/dashboard/quick-actions.tsx` — QuickActions with button grid for common navigation
- `frontend/src/pages/dashboard/index.tsx` — DashboardPage with three parallel queries (payment orders, booking logs, ledger postings)
- `frontend/src/lib/router.tsx` — Route `'/'` now points to `DashboardPage` instead of placeholder
- `frontend/src/test/test-utils.tsx` — Added `ApiClientBridge` wrapper so `renderWithProviders` includes `ApiClientProvider`
- `frontend/src/test/router.test.tsx` — Added api module mocks to prevent missing generated proto file errors

## Testing

- 27 new tests covering all components and the DashboardPage
- Tests verify: loading skeletons, data display, error isolation (one failing stat card does not break others), 'recent' qualifier when totalCount is unknown, quick actions rendering, and no-tenant guard
- All 278 tests pass; 2 pre-existing failures (missing generated proto files in `clients.test.ts` and `msw-integration.test.tsx`) are unchanged

## Technical Details

Since `ListCurrentAccounts` does not exist in the proto schema, the dashboard queries `listPaymentOrders`, `listFinancialBookingLogs`, and `listLedgerPostings` — all of which return `PaginationResponse.totalCount` (with `-1` indicating unknown). When the count is unknown, the stat card shows a 'recent' qualifier per the PRD requirement.