### PR TITLE
feat: Create CELEditor component for expression editing

### DIFF
--- a/frontend/src/components/shared/cel-editor.test.tsx
+++ b/frontend/src/components/shared/cel-editor.test.tsx
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CELEditor, CONTEXT_VARIABLES, type CELEditorProps } from './cel-editor'
+
+// CodeMirror uses DOM APIs not available in jsdom. Mock the EditorView at module level.
+vi.mock('codemirror', () => ({
+  basicSetup: [],
+}))
+
+const mockDispatch = vi.fn()
+
+vi.mock('@codemirror/view', () => ({
+  EditorView: class MockEditorView {
+    static editable = { of: vi.fn(() => ({})) }
+    static updateListener = { of: vi.fn(() => ({})) }
+    dom: HTMLElement
+    state: { doc: { toString: () => string } }
+    dispatch = mockDispatch
+
+    constructor(config: {
+      doc?: string
+      extensions?: unknown[]
+      parent?: HTMLElement
+    }) {
+      this.dom = document.createElement('div')
+      this.dom.className = 'cm-editor'
+      this.dom.setAttribute('data-testid', 'codemirror-editor')
+      this.state = { doc: { toString: () => config.doc ?? '' } }
+      if (config.parent) {
+        config.parent.appendChild(this.dom)
+      }
+    }
+
+    destroy() {
+      this.dom.remove()
+    }
+  },
+  keymap: { of: vi.fn(() => ({})) },
+}))
+
+vi.mock('@codemirror/state', () => ({
+  Compartment: class {
+    of(value: unknown) {
+      return value
+    }
+    reconfigure(value: unknown) {
+      return value
+    }
+  },
+  EditorState: {
+    create: vi.fn(() => ({})),
+    readOnly: { of: vi.fn(() => ({})) },
+  },
+  Transaction: {
+    userEvent: 'userEvent',
+  },
+}))
+
+vi.mock('@codemirror/lang-python', () => ({
+  python: vi.fn(() => ({})),
+}))
+
+vi.mock('@codemirror/lint', () => ({
+  linter: vi.fn((fn: () => unknown) => fn),
+  lintGutter: vi.fn(() => ({})),
+}))
+
+describe('CELEditor', () => {
+  const defaultProps: CELEditorProps = {
+    value: 'amount > 0',
+    onChange: vi.fn(),
+    context: 'validation',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('basic rendering', () => {
+    it('renders the editor container', () => {
+      const { container } = render(<CELEditor {...defaultProps} />)
+      expect(container.querySelector('[data-testid="cel-editor"]')).toBeTruthy()
+    })
+
+    it('mounts CodeMirror editor into the DOM', () => {
+      const { container } = render(<CELEditor {...defaultProps} />)
+      expect(container.querySelector('.cm-editor')).toBeTruthy()
+    })
+
+    it('renders security constraints display', () => {
+      render(<CELEditor {...defaultProps} />)
+      expect(screen.getByTestId('security-constraints')).toBeTruthy()
+    })
+
+    it('displays max bytes constraint', () => {
+      render(<CELEditor {...defaultProps} />)
+      expect(screen.getByText(/4[,.]?096\s*bytes/i)).toBeTruthy()
+    })
+
+    it('displays max nesting depth constraint', () => {
+      render(<CELEditor {...defaultProps} />)
+      expect(screen.getByText(/nesting depth\s*10/i)).toBeTruthy()
+    })
+
+    it('displays cost limit constraint', () => {
+      render(<CELEditor {...defaultProps} />)
+      expect(screen.getByText(/cost limit\s*10[,.]?000/i)).toBeTruthy()
+    })
+  })
+
+  describe('context-aware variables', () => {
+    it('shows variables panel by default', () => {
+      render(<CELEditor {...defaultProps} />)
+      expect(screen.getByTestId('variables-panel')).toBeTruthy()
+    })
+
+    it('hides variables panel when showVariables is false', () => {
+      render(<CELEditor {...defaultProps} showVariables={false} />)
+      expect(screen.queryByTestId('variables-panel')).toBeNull()
+    })
+
+    it('shows validation context variables', () => {
+      render(<CELEditor {...defaultProps} context="validation" />)
+      const panel = screen.getByTestId('variables-panel')
+      expect(panel.textContent).toContain('amount')
+      expect(panel.textContent).toContain('attributes')
+    })
+
+    it('shows bucketKey context variables', () => {
+      render(<CELEditor {...defaultProps} context="bucketKey" />)
+      const panel = screen.getByTestId('variables-panel')
+      expect(panel.textContent).toContain('attributes')
+    })
+
+    it('shows eligibility context variables', () => {
+      render(<CELEditor {...defaultProps} context="eligibility" />)
+      const panel = screen.getByTestId('variables-panel')
+      expect(panel.textContent).toContain('party.type')
+      expect(panel.textContent).toContain('party.status')
+    })
+
+    it('shows value context variables', () => {
+      render(<CELEditor {...defaultProps} context="value" />)
+      const panel = screen.getByTestId('variables-panel')
+      expect(panel.textContent).toContain('amount')
+      expect(panel.textContent).toContain('valid_from')
+    })
+
+    it('does not show eligibility-specific variables in validation context', () => {
+      render(<CELEditor {...defaultProps} context="validation" />)
+      const panel = screen.getByTestId('variables-panel')
+      expect(panel.textContent).not.toContain('party.type')
+    })
+  })
+
+  describe('error display', () => {
+    it('does not render error panel when no errors', () => {
+      render(<CELEditor {...defaultProps} errors={[]} />)
+      expect(screen.queryByTestId('error-panel')).toBeNull()
+    })
+
+    it('renders error panel when errors are provided', () => {
+      const errors = [{ message: 'Invalid expression' }]
+      render(<CELEditor {...defaultProps} errors={errors} />)
+      expect(screen.getByTestId('error-panel')).toBeTruthy()
+    })
+
+    it('displays error message', () => {
+      const errors = [{ message: 'Undefined variable: foo' }]
+      render(<CELEditor {...defaultProps} errors={errors} />)
+      expect(screen.getByText('Undefined variable: foo')).toBeTruthy()
+    })
+
+    it('displays multiple errors', () => {
+      const errors = [
+        { message: 'Error one' },
+        { message: 'Error two' },
+      ]
+      render(<CELEditor {...defaultProps} errors={errors} />)
+      expect(screen.getByText('Error one')).toBeTruthy()
+      expect(screen.getByText('Error two')).toBeTruthy()
+    })
+
+    it('displays error with line number when provided', () => {
+      const errors = [{ message: 'Syntax error', line: 3 }]
+      render(<CELEditor {...defaultProps} errors={errors} />)
+      expect(screen.getByText(/3/)).toBeTruthy()
+      expect(screen.getByText('Syntax error')).toBeTruthy()
+    })
+
+    it('displays error count in panel header', () => {
+      const errors = [
+        { message: 'Error one' },
+        { message: 'Error two' },
+      ]
+      render(<CELEditor {...defaultProps} errors={errors} />)
+      expect(screen.getByText(/2 (issue|error)/i)).toBeTruthy()
+    })
+
+    it('displays single error with singular label', () => {
+      const errors = [{ message: 'One error' }]
+      render(<CELEditor {...defaultProps} errors={errors} />)
+      expect(screen.getByText(/1 (issue|error)/i)).toBeTruthy()
+    })
+  })
+
+  describe('onChange', () => {
+    it('calls onChange when value changes', () => {
+      const onChange = vi.fn()
+      render(<CELEditor {...defaultProps} onChange={onChange} />)
+      // onChange is wired via EditorView updateListener
+      // The mock doesn't trigger onChange but the prop is passed
+      expect(onChange).not.toHaveBeenCalled() // not called on mount
+    })
+  })
+
+  describe('readOnly mode', () => {
+    it('renders read-only badge when readOnly is true', () => {
+      render(<CELEditor {...defaultProps} readOnly />)
+      expect(screen.getByTestId('readonly-badge')).toBeTruthy()
+    })
+
+    it('does not render read-only badge when readOnly is false', () => {
+      render(<CELEditor {...defaultProps} readOnly={false} />)
+      expect(screen.queryByTestId('readonly-badge')).toBeNull()
+    })
+
+    it('does not render read-only badge by default', () => {
+      render(<CELEditor {...defaultProps} />)
+      expect(screen.queryByTestId('readonly-badge')).toBeNull()
+    })
+  })
+
+  describe('CONTEXT_VARIABLES export', () => {
+    it('exports validation context variables', () => {
+      expect(CONTEXT_VARIABLES.validation).toContain('amount')
+      expect(CONTEXT_VARIABLES.validation).toContain('attributes')
+      expect(CONTEXT_VARIABLES.validation).toContain('valid_from')
+      expect(CONTEXT_VARIABLES.validation).toContain('valid_to')
+      expect(CONTEXT_VARIABLES.validation).toContain('source')
+    })
+
+    it('exports bucketKey context variables', () => {
+      expect(CONTEXT_VARIABLES.bucketKey).toContain('attributes')
+    })
+
+    it('exports eligibility context variables', () => {
+      expect(CONTEXT_VARIABLES.eligibility).toContain('party.type')
+      expect(CONTEXT_VARIABLES.eligibility).toContain('party.status')
+      expect(CONTEXT_VARIABLES.eligibility).toContain('party.external_reference_type')
+      expect(CONTEXT_VARIABLES.eligibility).toContain('attributes')
+    })
+
+    it('exports value context variables', () => {
+      expect(CONTEXT_VARIABLES.value).toContain('attributes')
+      expect(CONTEXT_VARIABLES.value).toContain('amount')
+      expect(CONTEXT_VARIABLES.value).toContain('valid_from')
+      expect(CONTEXT_VARIABLES.value).toContain('valid_to')
+      expect(CONTEXT_VARIABLES.value).toContain('source')
+    })
+  })
+
+  describe('value sync', () => {
+    it('dispatches to sync value when value prop changes externally', () => {
+      const { rerender } = render(
+        <CELEditor {...defaultProps} value="amount > 0" />,
+      )
+      const initialCalls = mockDispatch.mock.calls.length
+      rerender(<CELEditor {...defaultProps} value="amount > 100" />)
+      expect(mockDispatch.mock.calls.length).toBeGreaterThan(initialCalls)
+    })
+
+    it('dispatches to reconfigure read-only when readOnly prop changes', () => {
+      const { rerender } = render(
+        <CELEditor {...defaultProps} readOnly={false} />,
+      )
+      const initialCalls = mockDispatch.mock.calls.length
+      rerender(<CELEditor {...defaultProps} readOnly={true} />)
+      expect(mockDispatch.mock.calls.length).toBeGreaterThan(initialCalls)
+    })
+  })
+
+  describe('className prop', () => {
+    it('accepts optional className prop', () => {
+      const { container } = render(
+        <CELEditor {...defaultProps} className="custom-class" />,
+      )
+      expect(
+        container.querySelector('[data-testid="cel-editor"]')?.classList,
+      ).toContain('custom-class')
+    })
+  })
+})

--- a/frontend/src/components/shared/cel-editor.tsx
+++ b/frontend/src/components/shared/cel-editor.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useRef } from 'react'
+import { EditorView } from '@codemirror/view'
+import { Compartment, Transaction } from '@codemirror/state'
+import { linter, lintGutter, type Diagnostic } from '@codemirror/lint'
+import { basicSetup } from 'codemirror'
+import { cn } from '@/lib/utils'
+
+export type CELContext = 'validation' | 'bucketKey' | 'eligibility' | 'value'
+
+export interface CELError {
+  message: string
+  line?: number
+}
+
+export interface CELEditorProps {
+  value: string
+  onChange: (value: string) => void
+  context: CELContext
+  errors?: CELError[]
+  readOnly?: boolean
+  showVariables?: boolean
+  className?: string
+}
+
+export const CONTEXT_VARIABLES: Record<CELContext, string[]> = {
+  validation: ['attributes', 'amount', 'valid_from', 'valid_to', 'source'],
+  bucketKey: ['attributes'],
+  eligibility: [
+    'party.type',
+    'party.status',
+    'party.external_reference_type',
+    'attributes',
+  ],
+  value: ['attributes', 'amount', 'valid_from', 'valid_to', 'source'],
+}
+
+function getLineOffset(doc: string, line: number): number {
+  const lines = doc.split('\n')
+  let offset = 0
+  for (let i = 0; i < line - 1 && i < lines.length; i++) {
+    offset += lines[i].length + 1
+  }
+  return Math.min(offset, doc.length)
+}
+
+export function CELEditor({
+  value,
+  onChange,
+  context,
+  errors = [],
+  readOnly = false,
+  showVariables = true,
+  className,
+}: CELEditorProps) {
+  const editorRef = useRef<HTMLDivElement>(null)
+  const viewRef = useRef<EditorView | null>(null)
+  const readOnlyCompartment = useRef(new Compartment())
+  const linterCompartment = useRef(new Compartment())
+
+  const errorsRef = useRef(errors)
+  const onChangeRef = useRef(onChange)
+  errorsRef.current = errors
+  onChangeRef.current = onChange
+
+  // Mount editor once
+  useEffect(() => {
+    if (!editorRef.current) return
+
+    const errorLinter = linter((): Diagnostic[] => {
+      const currentErrors = errorsRef.current
+      const currentDoc = viewRef.current?.state.doc.toString() ?? ''
+      return currentErrors
+        .filter((e) => e.line != null)
+        .map((e) => {
+          const from = getLineOffset(currentDoc, e.line!)
+          const to = Math.max(from, Math.min(from + 10, currentDoc.length))
+          return {
+            from,
+            to,
+            severity: 'error' as const,
+            message: e.message,
+          }
+        })
+    })
+
+    const view = new EditorView({
+      doc: value,
+      extensions: [
+        basicSetup,
+        lintGutter(),
+        linterCompartment.current.of(errorLinter),
+        readOnlyCompartment.current.of(EditorView.editable.of(!readOnly)),
+        EditorView.updateListener.of((update) => {
+          if (
+            update.docChanged &&
+            update.transactions.some(
+              (tr) => tr.annotation(Transaction.userEvent) != null,
+            )
+          ) {
+            onChangeRef.current(update.state.doc.toString())
+          }
+        }),
+      ],
+      parent: editorRef.current,
+    })
+
+    viewRef.current = view
+
+    return () => {
+      view.destroy()
+      viewRef.current = null
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Sync external value changes
+  useEffect(() => {
+    const view = viewRef.current
+    if (!view) return
+    const current = view.state.doc.toString()
+    if (current !== value) {
+      view.dispatch({
+        changes: { from: 0, to: current.length, insert: value },
+      })
+    }
+  }, [value])
+
+  // Reconfigure read-only state
+  useEffect(() => {
+    const view = viewRef.current
+    if (!view) return
+    view.dispatch({
+      effects: readOnlyCompartment.current.reconfigure(
+        EditorView.editable.of(!readOnly),
+      ),
+    })
+  }, [readOnly])
+
+  // Force linter to re-run when errors change
+  useEffect(() => {
+    const view = viewRef.current
+    if (!view) return
+
+    const errorLinter = linter((): Diagnostic[] => {
+      const currentErrors = errorsRef.current
+      const currentDoc = view.state.doc.toString()
+      return currentErrors
+        .filter((e) => e.line != null)
+        .map((e) => {
+          const from = getLineOffset(currentDoc, e.line!)
+          const to = Math.max(from, Math.min(from + 10, currentDoc.length))
+          return {
+            from,
+            to,
+            severity: 'error' as const,
+            message: e.message,
+          }
+        })
+    })
+
+    view.dispatch({
+      effects: linterCompartment.current.reconfigure(errorLinter),
+    })
+  }, [errors])
+
+  const variables = CONTEXT_VARIABLES[context]
+
+  return (
+    <div
+      data-testid="cel-editor"
+      className={cn('flex flex-col gap-2', className)}
+    >
+      <div className="relative">
+        {readOnly && (
+          <span
+            data-testid="readonly-badge"
+            className="absolute right-2 top-2 z-10 rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+          >
+            Read only
+          </span>
+        )}
+        <div
+          ref={editorRef}
+          className="min-h-[60px] rounded border border-input bg-background text-sm"
+        />
+      </div>
+
+      <div
+        data-testid="security-constraints"
+        className="flex flex-wrap gap-3 text-xs text-muted-foreground"
+      >
+        <span>Max 4,096 bytes</span>
+        <span>Max nesting depth 10</span>
+        <span>Cost limit 10,000</span>
+      </div>
+
+      {showVariables && variables.length > 0 && (
+        <div
+          data-testid="variables-panel"
+          className="rounded border border-border bg-muted/30 px-3 py-2"
+        >
+          <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+            Available variables
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {variables.map((v) => (
+              <code
+                key={v}
+                className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground"
+              >
+                {v}
+              </code>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {errors.length > 0 && (
+        <div
+          data-testid="error-panel"
+          className="rounded border border-destructive/30 bg-destructive/5"
+        >
+          <div className="border-b border-destructive/20 px-3 py-1.5 text-xs font-medium text-destructive">
+            {errors.length} {errors.length === 1 ? 'issue' : 'issues'}
+          </div>
+          <ul className="divide-y divide-destructive/10 text-xs">
+            {errors.map((error, index) => (
+              <li
+                key={index}
+                data-testid={`error-item-${index}`}
+                className="flex items-start gap-2 px-3 py-1.5 text-destructive"
+              >
+                {error.line != null && (
+                  <span className="shrink-0 font-mono text-muted-foreground">
+                    {error.line}
+                  </span>
+                )}
+                <span>{error.message}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Implements the CELEditor component for inline CEL expression editing with:
- CodeMirror 6 base editor
- Context-aware variable hints panel (validation, bucketKey, eligibility, value contexts)
- Security constraints display (max 4,096 bytes, nesting depth 10, cost limit 10,000)
- Inline error display with optional line numbers
- Read-only mode with badge indicator
- Follows existing StarlarkEditor patterns

## Testing

31 tests passing covering:
- Editor renders correctly
- Context-appropriate variables shown per context type
- Security constraints displayed
- Error panel with count and messages
- Read-only mode
- External value sync via dispatch
- CONTEXT_VARIABLES export structure

## Task

Task: 026-operations-console.29
Dependencies: Task 28 (merged)