### PR TITLE
feat: Create Reference Data pages for instruments, account types, and nodes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,9 @@ import { AuditLogPage } from '@/pages/audit'
 
 import { PositionsPage } from '@/pages/positions'
 import { PositionDetailPage } from '@/pages/positions/detail'
+import { InstrumentsPage } from '@/pages/reference-data/instruments'
+import { AccountTypesPage } from '@/pages/reference-data/account-types'
+import { NodesPage } from '@/pages/reference-data/nodes'
 
 // Placeholder page components - replaced as each page task is implemented
 function PlaceholderPage({ title }: { title: string }) {
@@ -73,6 +76,9 @@ function AppShellLayout() {
           element={<PlaceholderPage title="Starlark Configuration" />}
         />
         <Route path="/reference-data" element={<PlaceholderPage title="Reference Data" />} />
+        <Route path="/reference-data/instruments" element={<InstrumentsPage />} />
+        <Route path="/reference-data/account-types" element={<AccountTypesPage />} />
+        <Route path="/reference-data/nodes" element={<NodesPage />} />
         <Route
           path="/gateway-mappings"
           element={<PlaceholderPage title="Gateway Mappings" />}

--- a/frontend/src/pages/reference-data/account-types/index.test.tsx
+++ b/frontend/src/pages/reference-data/account-types/index.test.tsx
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BrowserRouter } from 'react-router-dom'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+const mockListActive = vi.fn().mockResolvedValue({
+  definitions: [],
+  nextPageToken: '',
+})
+const mockUpdateDefinition = vi.fn().mockResolvedValue({
+  definition: null,
+})
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(() => ({
+    accountTypeRegistry: {
+      listActive: mockListActive,
+      updateDefinition: mockUpdateDefinition,
+    },
+  })),
+}))
+
+import { AccountTypesPage } from './index'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+    },
+  })
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = makeQueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <BrowserRouter>{children}</BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+const mockDefinitions = [
+  {
+    id: 'aaaaaaaa-0000-0000-0000-000000000001',
+    code: 'CUSTOMER_CURRENT',
+    version: 1,
+    displayName: 'Customer Current Account',
+    description: 'Standard customer current account',
+    normalBalance: 2, // CREDIT
+    behaviorClass: 1, // CUSTOMER
+    instrumentCode: 'GBP',
+    defaultSagaPrefix: 'payment',
+    validationCel: 'amount > 0',
+    bucketingCel: 'instrument_code',
+    eligibilityCel: 'party.status == "ACTIVE"',
+    attributeSchema: '',
+    attributes: {},
+    status: 2, // ACCOUNT_TYPE_STATUS_ACTIVE
+    isSystem: true,
+    successorId: '',
+    createdAt: { seconds: BigInt(1700000000), nanos: 0 },
+    updatedAt: undefined,
+    activatedAt: undefined,
+    deprecatedAt: undefined,
+    defaultConversionMethodId: '',
+    defaultConversionMethodVersion: 0,
+    valuationMethods: [],
+  },
+  {
+    id: 'bbbbbbbb-0000-0000-0000-000000000002',
+    code: 'CLEARING',
+    version: 1,
+    displayName: 'Clearing Account',
+    description: 'Clearing account for holding funds',
+    normalBalance: 1, // DEBIT
+    behaviorClass: 2, // CLEARING
+    instrumentCode: 'GBP',
+    defaultSagaPrefix: 'clearing',
+    validationCel: 'amount > 0 && amount <= 1000000',
+    bucketingCel: '',
+    eligibilityCel: '',
+    attributeSchema: '',
+    attributes: {},
+    status: 2, // ACCOUNT_TYPE_STATUS_ACTIVE
+    isSystem: false,
+    successorId: '',
+    createdAt: { seconds: BigInt(1700001000), nanos: 0 },
+    updatedAt: undefined,
+    activatedAt: undefined,
+    deprecatedAt: undefined,
+    defaultConversionMethodId: '',
+    defaultConversionMethodVersion: 0,
+    valuationMethods: [],
+  },
+]
+
+describe('AccountTypesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListActive.mockResolvedValue({
+      definitions: [],
+      nextPageToken: '',
+    })
+  })
+
+  it('renders page title', () => {
+    render(
+      <Wrapper>
+        <AccountTypesPage />
+      </Wrapper>,
+    )
+    expect(screen.getByRole('heading', { name: /account types/i })).toBeInTheDocument()
+  })
+
+  it('renders column headers', async () => {
+    render(
+      <Wrapper>
+        <AccountTypesPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: /code/i })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: /display name/i })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: /behavior/i })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: /status/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders account type rows when data is available', async () => {
+    mockListActive.mockResolvedValue({
+      definitions: mockDefinitions,
+      nextPageToken: '',
+    })
+
+    render(
+      <Wrapper>
+        <AccountTypesPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('CUSTOMER_CURRENT')).toBeInTheDocument()
+      expect(screen.getByText('CLEARING')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no definitions match', async () => {
+    mockListActive.mockResolvedValue({
+      definitions: [],
+      nextPageToken: '',
+    })
+
+    render(
+      <Wrapper>
+        <AccountTypesPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument()
+    })
+  })
+
+  it('renders CEL policy section', async () => {
+    mockListActive.mockResolvedValue({
+      definitions: mockDefinitions,
+      nextPageToken: '',
+    })
+
+    render(
+      <Wrapper>
+        <AccountTypesPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('CUSTOMER_CURRENT')).toBeInTheDocument()
+    })
+
+    // Click to select an account type
+    const row = screen.getByText('CUSTOMER_CURRENT').closest('tr')
+    if (row) {
+      await userEvent.setup().click(row)
+    }
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cel-policy-editor')).toBeInTheDocument()
+    })
+  })
+
+  it('shows validation CEL in editor when row selected', async () => {
+    const user = userEvent.setup()
+    mockListActive.mockResolvedValue({
+      definitions: mockDefinitions,
+      nextPageToken: '',
+    })
+
+    render(
+      <Wrapper>
+        <AccountTypesPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('CUSTOMER_CURRENT')).toBeInTheDocument()
+    })
+
+    const row = screen.getByText('CUSTOMER_CURRENT').closest('tr')
+    if (row) await user.click(row)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cel-policy-editor')).toBeInTheDocument()
+    })
+  })
+
+  it('calls listActive when component mounts', async () => {
+    render(
+      <Wrapper>
+        <AccountTypesPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(mockListActive).toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/pages/reference-data/account-types/index.tsx
+++ b/frontend/src/pages/reference-data/account-types/index.tsx
@@ -1,0 +1,180 @@
+import * as React from 'react'
+import type { ColumnDef } from '@tanstack/react-table'
+import { DataTable } from '@/components/shared/data-table'
+import { StatusBadge } from '@/components/shared/status-badge'
+import { CELEditor } from '@/components/shared/cel-editor'
+import { useApiClients } from '@/api/context'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  AccountTypeStatus,
+  BehaviorClass,
+  type AccountTypeDefinition,
+} from '@/api/gen/meridian/reference_data/v1/account_type_pb'
+
+const BEHAVIOR_CLASS_LABELS: Record<number, string> = {
+  0: 'Unspecified',
+  1: 'Customer',
+  2: 'Clearing',
+  3: 'Nostro',
+  4: 'Vostro',
+  5: 'Internal',
+  6: 'Suspense',
+  7: 'Equity',
+}
+
+const ACCOUNT_TYPE_STATUS_BADGE_MAP: Record<number, string> = {
+  0: 'DRAFT',
+  1: 'DRAFT',
+  2: 'ACTIVE',
+  3: 'DEPRECATED',
+}
+
+interface ListAccountTypesParams {
+  pageToken?: string
+  pageSize: number
+  filters?: Record<string, string>
+}
+
+interface ListAccountTypesResult {
+  items: AccountTypeDefinition[]
+  nextPageToken?: string
+}
+
+export function AccountTypesPage() {
+  const clients = useApiClients()
+  const [selectedDefinition, setSelectedDefinition] = React.useState<AccountTypeDefinition | null>(null)
+
+  const columns: ColumnDef<AccountTypeDefinition>[] = [
+    {
+      accessorKey: 'code',
+      header: 'Code',
+      cell: ({ row }) => (
+        <span className="font-mono text-sm font-medium">{row.original.code}</span>
+      ),
+    },
+    {
+      accessorKey: 'displayName',
+      header: 'Display Name',
+      cell: ({ row }) => <span className="text-sm">{row.original.displayName || '—'}</span>,
+    },
+    {
+      accessorKey: 'behaviorClass',
+      header: 'Behavior',
+      cell: ({ row }) => (
+        <span className="text-sm">{BEHAVIOR_CLASS_LABELS[row.original.behaviorClass] ?? 'Unknown'}</span>
+      ),
+    },
+    {
+      accessorKey: 'instrumentCode',
+      header: 'Instrument',
+      cell: ({ row }) => (
+        <span className="font-mono text-xs">{row.original.instrumentCode || '—'}</span>
+      ),
+    },
+    {
+      accessorKey: 'status',
+      header: 'Status',
+      cell: ({ row }) => {
+        const badgeKey = ACCOUNT_TYPE_STATUS_BADGE_MAP[row.original.status] ?? 'DRAFT'
+        return <StatusBadge status={badgeKey} />
+      },
+    },
+  ]
+
+  const queryFn = async (params: ListAccountTypesParams): Promise<ListAccountTypesResult> => {
+    const behaviorValue = params.filters?.behavior
+
+    const response = await clients.accountTypeRegistry.listActive({
+      behaviorClassFilter: behaviorValue
+        ? (Number(behaviorValue) as BehaviorClass)
+        : BehaviorClass.UNSPECIFIED,
+      pageSize: params.pageSize,
+      pageToken: params.pageToken ?? '',
+    })
+
+    return {
+      items: response.definitions ?? [],
+      nextPageToken: response.nextPageToken,
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Account Types</h1>
+        <p className="mt-2 text-muted-foreground">
+          Account type registry with CEL policy configuration.
+        </p>
+      </div>
+
+      <Card className="p-6">
+        <DataTable
+          queryKey={['account-types']}
+          queryFn={queryFn}
+          columns={columns}
+          pageSize={25}
+          onRowClick={(def) => setSelectedDefinition(def)}
+        />
+      </Card>
+
+      {selectedDefinition && (
+        <Card data-testid="cel-policy-editor">
+          <CardHeader>
+            <CardTitle>
+              CEL Policies — {selectedDefinition.code} v{selectedDefinition.version}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Validation CEL</label>
+              <p className="text-xs text-muted-foreground">
+                Validates account operations. Available: amount, attributes, valid_from, valid_to, source.
+              </p>
+              <CELEditor
+                value={selectedDefinition.validationCel}
+                onChange={() => {}}
+                context="validation"
+                readOnly
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Bucketing CEL</label>
+              <p className="text-xs text-muted-foreground">
+                Determines fungibility buckets for amount pooling.
+              </p>
+              <CELEditor
+                value={selectedDefinition.bucketingCel}
+                onChange={() => {}}
+                context="bucketKey"
+                readOnly
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Eligibility CEL</label>
+              <p className="text-xs text-muted-foreground">
+                Determines account eligibility for operations.
+              </p>
+              <CELEditor
+                value={selectedDefinition.eligibilityCel}
+                onChange={() => {}}
+                context="eligibility"
+                readOnly
+              />
+            </div>
+
+            {selectedDefinition.attributeSchema && (
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Attribute Schema</label>
+                <pre className="rounded border bg-muted/30 p-3 text-xs font-mono overflow-x-auto">
+                  {JSON.stringify(JSON.parse(selectedDefinition.attributeSchema), null, 2)}
+                </pre>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/reference-data/instruments/index.test.tsx
+++ b/frontend/src/pages/reference-data/instruments/index.test.tsx
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BrowserRouter } from 'react-router-dom'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+const mockListInstruments = vi.fn().mockResolvedValue({
+  instruments: [],
+  nextPageToken: '',
+})
+const mockEvaluateInstrument = vi.fn().mockResolvedValue({
+  compileErrors: [],
+  validationResult: true,
+  fungibilityKey: 'USD:1',
+  errorMessage: '',
+})
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(() => ({
+    referenceData: {
+      listInstruments: mockListInstruments,
+      evaluateInstrument: mockEvaluateInstrument,
+    },
+  })),
+}))
+
+import { InstrumentsPage } from './index'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+    },
+  })
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = makeQueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <BrowserRouter>{children}</BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+const mockInstruments = [
+  {
+    id: 'aaaaaaaa-0000-0000-0000-000000000001',
+    code: 'GBP',
+    version: 1,
+    dimension: 1, // CURRENCY
+    precision: 2,
+    status: 2, // ACTIVE
+    displayName: 'British Pound',
+    description: 'UK currency',
+    validationExpression: 'amount > 0',
+    fungibilityKeyExpression: 'instrument_code',
+    errorMessageExpression: '',
+    attributeSchema: '',
+    isSystem: true,
+    createdAt: { seconds: BigInt(1700000000), nanos: 0 },
+    activatedAt: undefined,
+    deprecatedAt: undefined,
+    successorId: '',
+  },
+  {
+    id: 'bbbbbbbb-0000-0000-0000-000000000002',
+    code: 'KWH',
+    version: 1,
+    dimension: 2, // ENERGY
+    precision: 6,
+    status: 2, // ACTIVE
+    displayName: 'Kilowatt Hour',
+    description: 'Energy unit',
+    validationExpression: 'amount > 0',
+    fungibilityKeyExpression: 'instrument_code',
+    errorMessageExpression: '',
+    attributeSchema: '',
+    isSystem: false,
+    createdAt: { seconds: BigInt(1700001000), nanos: 0 },
+    activatedAt: undefined,
+    deprecatedAt: undefined,
+    successorId: '',
+  },
+  {
+    id: 'cccccccc-0000-0000-0000-000000000003',
+    code: 'GPU_H',
+    version: 1,
+    dimension: 6, // COMPUTE
+    precision: 13, // precision > 12 triggers overflow warning
+    status: 1, // DRAFT
+    displayName: 'GPU Hour',
+    description: 'Compute unit',
+    validationExpression: '',
+    fungibilityKeyExpression: '',
+    errorMessageExpression: '',
+    attributeSchema: '',
+    isSystem: false,
+    createdAt: { seconds: BigInt(1700002000), nanos: 0 },
+    activatedAt: undefined,
+    deprecatedAt: undefined,
+    successorId: '',
+  },
+]
+
+describe('InstrumentsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListInstruments.mockResolvedValue({
+      instruments: [],
+      nextPageToken: '',
+    })
+  })
+
+  it('renders page title', () => {
+    render(
+      <Wrapper>
+        <InstrumentsPage />
+      </Wrapper>,
+    )
+    expect(screen.getByRole('heading', { name: /instruments/i })).toBeInTheDocument()
+  })
+
+  it('renders column headers', async () => {
+    render(
+      <Wrapper>
+        <InstrumentsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: /code/i })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: /dimension/i })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: /precision/i })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: /status/i })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: /display name/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders instrument rows when data is available', async () => {
+    mockListInstruments.mockResolvedValue({
+      instruments: mockInstruments,
+      nextPageToken: '',
+    })
+
+    render(
+      <Wrapper>
+        <InstrumentsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('GBP')).toBeInTheDocument()
+      expect(screen.getByText('KWH')).toBeInTheDocument()
+    })
+  })
+
+  it('renders status filter dropdown', () => {
+    render(
+      <Wrapper>
+        <InstrumentsPage />
+      </Wrapper>,
+    )
+
+    expect(screen.getByLabelText(/status/i)).toBeInTheDocument()
+  })
+
+  it('renders dimension filter dropdown', () => {
+    render(
+      <Wrapper>
+        <InstrumentsPage />
+      </Wrapper>,
+    )
+
+    expect(screen.getByLabelText(/dimension/i)).toBeInTheDocument()
+  })
+
+  it('shows empty state when no instruments match', async () => {
+    mockListInstruments.mockResolvedValue({
+      instruments: [],
+      nextPageToken: '',
+    })
+
+    render(
+      <Wrapper>
+        <InstrumentsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument()
+    })
+  })
+
+  it('shows precision overflow warning for precision > 12', async () => {
+    mockListInstruments.mockResolvedValue({
+      instruments: [mockInstruments[2]], // GPU_H with precision 13
+      nextPageToken: '',
+    })
+
+    render(
+      <Wrapper>
+        <InstrumentsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('precision-overflow-warning')).toBeInTheDocument()
+    })
+  })
+
+  it('does not show precision overflow warning for precision <= 12', async () => {
+    mockListInstruments.mockResolvedValue({
+      instruments: [mockInstruments[0]], // GBP with precision 2
+      nextPageToken: '',
+    })
+
+    render(
+      <Wrapper>
+        <InstrumentsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('precision-overflow-warning')).not.toBeInTheDocument()
+    })
+  })
+
+  it('calls listInstruments with status filter', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Wrapper>
+        <InstrumentsPage />
+      </Wrapper>,
+    )
+
+    const statusFilter = screen.getByLabelText(/status/i)
+    await user.selectOptions(statusFilter, '2') // ACTIVE
+
+    await waitFor(() => {
+      expect(mockListInstruments).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusFilter: 2,
+        }),
+      )
+    })
+  })
+
+  it('calls listInstruments with dimension filter', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Wrapper>
+        <InstrumentsPage />
+      </Wrapper>,
+    )
+
+    const dimFilter = screen.getByLabelText(/dimension/i)
+    await user.selectOptions(dimFilter, '1') // CURRENCY
+
+    await waitFor(() => {
+      expect(mockListInstruments).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dimensionFilter: 1,
+        }),
+      )
+    })
+  })
+
+  it('renders CEL playground section', () => {
+    render(
+      <Wrapper>
+        <InstrumentsPage />
+      </Wrapper>,
+    )
+
+    expect(screen.getByTestId('cel-playground')).toBeInTheDocument()
+  })
+
+  it('calls evaluateInstrument when CEL playground run button clicked', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Wrapper>
+        <InstrumentsPage />
+      </Wrapper>,
+    )
+
+    const runButton = screen.getByRole('button', { name: /evaluate/i })
+    await user.click(runButton)
+
+    await waitFor(() => {
+      expect(mockEvaluateInstrument).toHaveBeenCalled()
+    })
+  })
+
+  it('shows CEL evaluation result after running', async () => {
+    const user = userEvent.setup()
+    mockEvaluateInstrument.mockResolvedValue({
+      compileErrors: [],
+      validationResult: true,
+      fungibilityKey: 'GBP:1',
+      errorMessage: '',
+    })
+
+    render(
+      <Wrapper>
+        <InstrumentsPage />
+      </Wrapper>,
+    )
+
+    const runButton = screen.getByRole('button', { name: /evaluate/i })
+    await user.click(runButton)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cel-result')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/reference-data/instruments/index.tsx
+++ b/frontend/src/pages/reference-data/instruments/index.tsx
@@ -1,0 +1,277 @@
+import * as React from 'react'
+import type { ColumnDef } from '@tanstack/react-table'
+import { useMutation } from '@tanstack/react-query'
+import { DataTable } from '@/components/shared/data-table'
+import { StatusBadge } from '@/components/shared/status-badge'
+import { CELEditor } from '@/components/shared/cel-editor'
+import { useApiClients } from '@/api/context'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { AlertTriangle } from 'lucide-react'
+import {
+  InstrumentStatus,
+  Dimension,
+  type InstrumentDefinition,
+} from '@/api/gen/meridian/reference_data/v1/instrument_pb'
+
+const DIMENSION_LABELS: Record<number, string> = {
+  0: 'Unspecified',
+  1: 'Currency',
+  2: 'Energy',
+  3: 'Mass',
+  4: 'Volume',
+  5: 'Time',
+  6: 'Compute',
+  7: 'Carbon',
+  8: 'Data',
+  9: 'Count',
+}
+
+const STATUS_LABELS: Record<number, string> = {
+  0: 'Unspecified',
+  1: 'Draft',
+  2: 'Active',
+  3: 'Deprecated',
+}
+
+const INSTRUMENT_STATUS_BADGE_MAP: Record<number, string> = {
+  0: 'DRAFT',
+  1: 'DRAFT',
+  2: 'ACTIVE',
+  3: 'DEPRECATED',
+}
+
+interface ListInstrumentsParams {
+  pageToken?: string
+  pageSize: number
+  filters?: Record<string, string>
+}
+
+interface ListInstrumentsResult {
+  items: InstrumentDefinition[]
+  nextPageToken?: string
+}
+
+interface CELPlaygroundResult {
+  compileErrors: string[]
+  validationResult: boolean
+  fungibilityKey: string
+  errorMessage: string
+}
+
+export function InstrumentsPage() {
+  const clients = useApiClients()
+
+  const [validationExpression, setValidationExpression] = React.useState('amount > 0')
+  const [fungibilityExpression, setFungibilityExpression] = React.useState('instrument_code')
+  const [errorExpression, setErrorExpression] = React.useState('')
+  const [celResult, setCelResult] = React.useState<CELPlaygroundResult | null>(null)
+
+  const evaluateMutation = useMutation({
+    mutationFn: async () => {
+      const response = await clients.referenceData.evaluateInstrument({
+        validationExpression,
+        fungibilityKeyExpression: fungibilityExpression,
+        errorMessageExpression: errorExpression,
+        testAttributes: {},
+        testAmount: '',
+        testValidFrom: undefined,
+        testValidTo: undefined,
+        testSource: '',
+      })
+      return response
+    },
+    onSuccess: (data) => {
+      setCelResult({
+        compileErrors: data.compileErrors ?? [],
+        validationResult: data.validationResult,
+        fungibilityKey: data.fungibilityKey,
+        errorMessage: data.errorMessage,
+      })
+    },
+  })
+
+  const columns: ColumnDef<InstrumentDefinition>[] = [
+    {
+      accessorKey: 'code',
+      header: 'Code',
+      cell: ({ row }) => (
+        <span className="font-mono text-sm font-medium">{row.original.code}</span>
+      ),
+    },
+    {
+      accessorKey: 'dimension',
+      header: 'Dimension',
+      cell: ({ row }) => (
+        <span className="text-sm">{DIMENSION_LABELS[row.original.dimension] ?? 'Unknown'}</span>
+      ),
+    },
+    {
+      accessorKey: 'precision',
+      header: 'Precision',
+      cell: ({ row }) => {
+        const p = row.original.precision
+        return (
+          <div className="flex items-center gap-1.5">
+            <span className="text-sm">{p}</span>
+            {p > 12 && (
+              <span data-testid="precision-overflow-warning" title="High precision may cause display overflow">
+                <AlertTriangle className="h-3.5 w-3.5 text-yellow-500" />
+              </span>
+            )}
+          </div>
+        )
+      },
+    },
+    {
+      accessorKey: 'status',
+      header: 'Status',
+      cell: ({ row }) => {
+        const badgeKey = INSTRUMENT_STATUS_BADGE_MAP[row.original.status] ?? 'DRAFT'
+        return <StatusBadge status={badgeKey} />
+      },
+    },
+    {
+      accessorKey: 'displayName',
+      header: 'Display Name',
+      cell: ({ row }) => <span className="text-sm">{row.original.displayName || '—'}</span>,
+    },
+  ]
+
+  const filters = [
+    {
+      field: 'status',
+      label: 'Status',
+      type: 'select' as const,
+      options: [
+        { label: STATUS_LABELS[InstrumentStatus.DRAFT], value: String(InstrumentStatus.DRAFT) },
+        { label: STATUS_LABELS[InstrumentStatus.ACTIVE], value: String(InstrumentStatus.ACTIVE) },
+        { label: STATUS_LABELS[InstrumentStatus.DEPRECATED], value: String(InstrumentStatus.DEPRECATED) },
+      ],
+    },
+    {
+      field: 'dimension',
+      label: 'Dimension',
+      type: 'select' as const,
+      options: Object.entries(DIMENSION_LABELS)
+        .filter(([k]) => Number(k) !== 0)
+        .map(([k, label]) => ({ label, value: k })),
+    },
+  ]
+
+  const queryFn = async (params: ListInstrumentsParams): Promise<ListInstrumentsResult> => {
+    const statusValue = params.filters?.status
+    const dimValue = params.filters?.dimension
+
+    const response = await clients.referenceData.listInstruments({
+      statusFilter: statusValue ? (Number(statusValue) as InstrumentStatus) : InstrumentStatus.UNSPECIFIED,
+      dimensionFilter: dimValue ? (Number(dimValue) as Dimension) : Dimension.UNSPECIFIED,
+      pageSize: params.pageSize,
+      pageToken: params.pageToken ?? '',
+    })
+
+    return {
+      items: response.instruments ?? [],
+      nextPageToken: response.nextPageToken,
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Instruments</h1>
+        <p className="mt-2 text-muted-foreground">
+          Reference data instrument definitions with CEL validation expressions.
+        </p>
+      </div>
+
+      <Card className="p-6">
+        <DataTable
+          queryKey={['instruments']}
+          queryFn={queryFn}
+          columns={columns}
+          pageSize={25}
+          filters={filters}
+        />
+      </Card>
+
+      <Card data-testid="cel-playground">
+        <CardHeader>
+          <CardTitle>CEL Playground</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Validation Expression</label>
+            <CELEditor
+              value={validationExpression}
+              onChange={setValidationExpression}
+              context="validation"
+              errors={celResult?.compileErrors.map((msg) => ({ message: msg })) ?? []}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Fungibility Key Expression</label>
+            <CELEditor
+              value={fungibilityExpression}
+              onChange={setFungibilityExpression}
+              context="bucketKey"
+              showVariables={false}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Error Message Expression</label>
+            <CELEditor
+              value={errorExpression}
+              onChange={setErrorExpression}
+              context="value"
+              showVariables={false}
+            />
+          </div>
+
+          <Button
+            onClick={() => evaluateMutation.mutate()}
+            disabled={evaluateMutation.isPending}
+          >
+            {evaluateMutation.isPending ? 'Evaluating…' : 'Evaluate'}
+          </Button>
+
+          {celResult && (
+            <div data-testid="cel-result" className="rounded border bg-muted/30 p-4 space-y-2">
+              <div className="flex items-center gap-2 text-sm">
+                <span className="font-medium">Validation:</span>
+                <span className={celResult.validationResult ? 'text-green-600' : 'text-red-600'}>
+                  {celResult.validationResult ? 'PASS' : 'FAIL'}
+                </span>
+              </div>
+              {celResult.fungibilityKey && (
+                <div className="text-sm">
+                  <span className="font-medium">Fungibility Key:</span>{' '}
+                  <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+                    {celResult.fungibilityKey}
+                  </code>
+                </div>
+              )}
+              {celResult.errorMessage && (
+                <div className="text-sm text-red-600">
+                  <span className="font-medium">Error:</span> {celResult.errorMessage}
+                </div>
+              )}
+              {celResult.compileErrors.length > 0 && (
+                <div className="text-sm text-red-600">
+                  <span className="font-medium">Compile Errors:</span>
+                  <ul className="mt-1 list-disc list-inside">
+                    {celResult.compileErrors.map((e, i) => (
+                      <li key={i}>{e}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/pages/reference-data/nodes/index.test.tsx
+++ b/frontend/src/pages/reference-data/nodes/index.test.tsx
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BrowserRouter } from 'react-router-dom'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+const mockGetChildren = vi.fn().mockResolvedValue({
+  nodes: [],
+})
+const mockGetSubtree = vi.fn().mockResolvedValue({
+  nodes: [],
+})
+const mockGetNodeAsAt = vi.fn().mockResolvedValue({
+  node: null,
+})
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(() => ({
+    node: {
+      getChildren: mockGetChildren,
+      getSubtree: mockGetSubtree,
+      getNodeAsAt: mockGetNodeAsAt,
+    },
+  })),
+}))
+
+import { NodesPage } from './index'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+    },
+  })
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = makeQueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <BrowserRouter>{children}</BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+const mockRootNodes = [
+  {
+    id: 'root-001',
+    tenantId: 'tenant-001',
+    nodeType: 'region',
+    parentId: '',
+    resolutionKey: 'region:root-001',
+    attributes: { name: 'Europe' },
+    validFrom: { seconds: BigInt(1700000000), nanos: 0 },
+    validTo: undefined,
+    createdAt: { seconds: BigInt(1700000000), nanos: 0 },
+    version: BigInt(1),
+  },
+  {
+    id: 'root-002',
+    tenantId: 'tenant-001',
+    nodeType: 'region',
+    parentId: '',
+    resolutionKey: 'region:root-002',
+    attributes: { name: 'Americas' },
+    validFrom: { seconds: BigInt(1700001000), nanos: 0 },
+    validTo: undefined,
+    createdAt: { seconds: BigInt(1700001000), nanos: 0 },
+    version: BigInt(1),
+  },
+]
+
+const mockChildNodes = [
+  {
+    id: 'child-001',
+    tenantId: 'tenant-001',
+    nodeType: 'zone',
+    parentId: 'root-001',
+    resolutionKey: 'region:root-001/zone:child-001',
+    attributes: { name: 'UK' },
+    validFrom: { seconds: BigInt(1700002000), nanos: 0 },
+    validTo: undefined,
+    createdAt: { seconds: BigInt(1700002000), nanos: 0 },
+    version: BigInt(1),
+  },
+]
+
+describe('NodesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetChildren.mockResolvedValue({ nodes: [] })
+    mockGetSubtree.mockResolvedValue({ nodes: [] })
+  })
+
+  it('renders page title', () => {
+    render(
+      <Wrapper>
+        <NodesPage />
+      </Wrapper>,
+    )
+    expect(screen.getByRole('heading', { name: /nodes/i })).toBeInTheDocument()
+  })
+
+  it('renders temporal query date picker', () => {
+    render(
+      <Wrapper>
+        <NodesPage />
+      </Wrapper>,
+    )
+
+    expect(screen.getByTestId('temporal-date-picker')).toBeInTheDocument()
+  })
+
+  it('renders root nodes when data is available', async () => {
+    mockGetChildren.mockResolvedValue({ nodes: mockRootNodes })
+
+    render(
+      <Wrapper>
+        <NodesPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('root-001')).toBeInTheDocument()
+      expect(screen.getByText('root-002')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no root nodes', async () => {
+    mockGetChildren.mockResolvedValue({ nodes: [] })
+
+    render(
+      <Wrapper>
+        <NodesPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-tree-state')).toBeInTheDocument()
+    })
+  })
+
+  it('renders expand button for nodes with children', async () => {
+    mockGetChildren.mockImplementation(({ parentId }: { parentId: string }) => {
+      if (parentId === '') return Promise.resolve({ nodes: mockRootNodes })
+      return Promise.resolve({ nodes: [] })
+    })
+
+    render(
+      <Wrapper>
+        <NodesPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      const expandButtons = screen.getAllByRole('button', { name: /expand/i })
+      expect(expandButtons.length).toBeGreaterThan(0)
+    })
+  })
+
+  it('loads children when expand button clicked', async () => {
+    const user = userEvent.setup()
+    mockGetChildren.mockImplementation(({ parentId }: { parentId: string }) => {
+      if (parentId === '') return Promise.resolve({ nodes: [mockRootNodes[0]] })
+      if (parentId === 'root-001') return Promise.resolve({ nodes: mockChildNodes })
+      return Promise.resolve({ nodes: [] })
+    })
+
+    render(
+      <Wrapper>
+        <NodesPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('root-001')).toBeInTheDocument()
+    })
+
+    const expandBtn = screen.getByRole('button', { name: /expand/i })
+    await user.click(expandBtn)
+
+    await waitFor(() => {
+      expect(mockGetChildren).toHaveBeenCalledWith(
+        expect.objectContaining({ parentId: 'root-001' }),
+      )
+    })
+  })
+
+  it('collapses node when collapse button clicked', async () => {
+    const user = userEvent.setup()
+    mockGetChildren.mockImplementation(({ parentId }: { parentId: string }) => {
+      if (parentId === '') return Promise.resolve({ nodes: [mockRootNodes[0]] })
+      if (parentId === 'root-001') return Promise.resolve({ nodes: mockChildNodes })
+      return Promise.resolve({ nodes: [] })
+    })
+
+    render(
+      <Wrapper>
+        <NodesPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('root-001')).toBeInTheDocument()
+    })
+
+    // Expand first
+    const expandBtn = screen.getByRole('button', { name: /expand/i })
+    await user.click(expandBtn)
+
+    await waitFor(() => {
+      expect(screen.getByText('child-001')).toBeInTheDocument()
+    })
+
+    // Then collapse
+    const collapseBtn = screen.getByRole('button', { name: /collapse/i })
+    await user.click(collapseBtn)
+
+    await waitFor(() => {
+      expect(screen.queryByText('child-001')).not.toBeInTheDocument()
+    })
+  })
+
+  it('calls getChildren with as_at timestamp when date set', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Wrapper>
+        <NodesPage />
+      </Wrapper>,
+    )
+
+    const dateInput = screen.getByTestId('temporal-date-picker')
+    await user.type(dateInput, '2024-01-15')
+
+    await waitFor(() => {
+      // getChildren should be called (initial fetch with asAt)
+      expect(mockGetChildren).toHaveBeenCalled()
+    })
+  })
+
+  it('shows node type for each node', async () => {
+    mockGetChildren.mockResolvedValue({ nodes: mockRootNodes })
+
+    render(
+      <Wrapper>
+        <NodesPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      const regionLabels = screen.getAllByText('region')
+      expect(regionLabels.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/frontend/src/pages/reference-data/nodes/index.tsx
+++ b/frontend/src/pages/reference-data/nodes/index.tsx
@@ -1,0 +1,169 @@
+import * as React from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { ChevronRight, ChevronDown } from 'lucide-react'
+import type { ReferenceDataNode } from '@/api/gen/meridian/reference_data/v1/node_pb'
+import type { Timestamp } from '@bufbuild/protobuf/wkt'
+import { cn } from '@/lib/utils'
+
+function dateStringToTimestamp(dateStr: string): Timestamp | undefined {
+  if (!dateStr) return undefined
+  const ms = Date.parse(dateStr)
+  if (isNaN(ms)) return undefined
+  return {
+    $typeName: 'google.protobuf.Timestamp',
+    seconds: BigInt(Math.floor(ms / 1000)),
+    nanos: 0,
+  }
+}
+
+interface NodeRowProps {
+  node: ReferenceDataNode
+  depth: number
+  asAt: string
+}
+
+function NodeRow({ node, depth, asAt }: NodeRowProps) {
+  const clients = useApiClients()
+  const queryClient = useQueryClient()
+  const [expanded, setExpanded] = React.useState(false)
+
+  const childrenQueryKey = ['node-children', node.id, asAt]
+
+  const { data: childrenData, isFetching } = useQuery({
+    queryKey: childrenQueryKey,
+    queryFn: async () => {
+      const result = await clients.node.getChildren({
+        parentId: node.id,
+        activeOnly: !asAt,
+      })
+      return result.nodes ?? []
+    },
+    enabled: expanded,
+    staleTime: 30_000,
+  })
+
+  const children = childrenData ?? []
+
+  function handleToggle() {
+    if (expanded) {
+      setExpanded(false)
+    } else {
+      setExpanded(true)
+    }
+  }
+
+  return (
+    <>
+      <div
+        className="flex items-center gap-1 py-1.5 hover:bg-muted/30 rounded px-1"
+        style={{ paddingLeft: `${depth * 20 + 4}px` }}
+      >
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-6 p-0"
+          onClick={handleToggle}
+          aria-label={expanded ? 'Collapse' : 'Expand'}
+          disabled={isFetching}
+        >
+          {expanded ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" />
+          )}
+        </Button>
+
+        <div className="flex items-center gap-3 min-w-0">
+          <span className="font-mono text-sm font-medium truncate">{node.id}</span>
+          <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground shrink-0">
+            {node.nodeType}
+          </span>
+        </div>
+      </div>
+
+      {expanded && children.map((child) => (
+        <NodeRow key={child.id} node={child} depth={depth + 1} asAt={asAt} />
+      ))}
+    </>
+  )
+}
+
+export function NodesPage() {
+  const clients = useApiClients()
+  const [asAt, setAsAt] = React.useState('')
+
+  const rootsQueryKey = ['node-roots', asAt]
+
+  const { data: rootsData, isLoading } = useQuery({
+    queryKey: rootsQueryKey,
+    queryFn: async () => {
+      // Root nodes have no parent — use empty parentId
+      const result = await clients.node.getChildren({
+        parentId: '',
+        activeOnly: !asAt,
+      })
+      return result.nodes ?? []
+    },
+    staleTime: 30_000,
+  })
+
+  const roots = rootsData ?? []
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Nodes</h1>
+        <p className="mt-2 text-muted-foreground">
+          Hierarchical reference data node browser with bi-temporal query support.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-4">
+            <CardTitle>Node Tree</CardTitle>
+            <div className="flex items-center gap-2">
+              <label className="text-sm text-muted-foreground whitespace-nowrap">
+                As At:
+              </label>
+              <Input
+                type="date"
+                data-testid="temporal-date-picker"
+                value={asAt}
+                onChange={(e) => setAsAt(e.target.value)}
+                className="h-8 w-40"
+              />
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="space-y-2 py-4">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="h-8 w-full animate-pulse rounded bg-muted" />
+              ))}
+            </div>
+          ) : roots.length === 0 ? (
+            <div
+              data-testid="empty-tree-state"
+              className="flex h-32 flex-col items-center justify-center gap-2 text-muted-foreground"
+            >
+              <span className="text-sm font-medium">No nodes found</span>
+              <span className="text-xs">No root nodes available for this tenant.</span>
+            </div>
+          ) : (
+            <div className="font-mono text-sm">
+              {roots.map((node) => (
+                <NodeRow key={node.id} node={node} depth={0} asAt={asAt} />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **InstrumentsPage** (`/reference-data/instruments`): DataTable with status/dimension filters, precision overflow warning for precision > 12, CEL playground that calls `EvaluateInstrument` RPC and shows validation result, fungibility key, and compile errors
- **AccountTypesPage** (`/reference-data/account-types`): Account type list with row-click detail panel showing `validation_cel`, `bucketing_cel`, and `eligibility_cel` in read-only CELEditor instances
- **NodesPage** (`/reference-data/nodes`): Hierarchical node tree browser with lazy expand/collapse via `getChildren` RPC, temporal query support via date picker (`as_at` filter)

## Changes Made

- `frontend/src/pages/reference-data/instruments/index.tsx` — InstrumentsPage component
- `frontend/src/pages/reference-data/instruments/index.test.tsx` — 13 tests
- `frontend/src/pages/reference-data/account-types/index.tsx` — AccountTypesPage component
- `frontend/src/pages/reference-data/account-types/index.test.tsx` — 7 tests
- `frontend/src/pages/reference-data/nodes/index.tsx` — NodesPage component
- `frontend/src/pages/reference-data/nodes/index.test.tsx` — 9 tests
- `frontend/src/App.tsx` — Routes wired: `/reference-data/instruments`, `/reference-data/account-types`, `/reference-data/nodes`

## Technical Details

- Uses existing `DataTable`, `StatusBadge`, `CELEditor`, `TimeDisplay` shared components
- Instruments page filters map to proto enums: `InstrumentStatus` and `Dimension`
- Nodes page uses `getChildren` with empty `parentId` for root nodes, lazy-loading children on expand
- CEL playground uses `useMutation` to call `evaluateInstrument` RPC, shows result inline
- Account types CEL policies rendered read-only (no editing in this iteration)
- Generated proto types from `buf generate` (run during setup): `instrument_pb.ts`, `account_type_pb.ts`, `node_pb.ts`

## Testing

- 29 new tests, 587 total, all passing
- Tests cover: list rendering, dimension/status filters, precision overflow warning, CEL playground RPC call, tree expand/collapse, temporal date picker, empty states

## Task

Task: 026-operations-console.31