### PR TITLE
feat: Create Gateway Mappings page with dry run playground

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,8 @@ import { AuditLogPage } from '@/pages/audit'
 
 import { PositionsPage } from '@/pages/positions'
 import { PositionDetailPage } from '@/pages/positions/detail'
+import { MappingsPage } from '@/pages/mappings'
+import { MappingDetailPage } from '@/pages/mappings/[mappingId]'
 
 // Placeholder page components - replaced as each page task is implemented
 function PlaceholderPage({ title }: { title: string }) {
@@ -73,10 +75,8 @@ function AppShellLayout() {
           element={<PlaceholderPage title="Starlark Configuration" />}
         />
         <Route path="/reference-data" element={<PlaceholderPage title="Reference Data" />} />
-        <Route
-          path="/gateway-mappings"
-          element={<PlaceholderPage title="Gateway Mappings" />}
-        />
+        <Route path="/gateway-mappings" element={<MappingsPage />} />
+        <Route path="/gateway-mappings/:mappingId" element={<MappingDetailPage />} />
         <Route path="/audit-log" element={<AuditLogPage />} />
 
         {/* Platform-only routes */}

--- a/frontend/src/api/clients.ts
+++ b/frontend/src/api/clients.ts
@@ -14,6 +14,7 @@ import { AccountTypeRegistryService } from './gen/meridian/reference_data/v1/acc
 import { NodeService } from './gen/meridian/reference_data/v1/node_pb'
 import { InternalBankAccountService } from './gen/meridian/internal_bank_account/v1/internal_bank_account_pb'
 import { MarketInformationService } from './gen/meridian/market_information/v1/market_information_pb'
+import { MappingService } from './gen/meridian/mapping/v1/mapping_pb'
 
 export function createServiceClients(transport: Transport) {
   return {
@@ -31,6 +32,7 @@ export function createServiceClients(transport: Transport) {
     node: createClient(NodeService, transport),
     internalBankAccount: createClient(InternalBankAccountService, transport),
     marketInformation: createClient(MarketInformationService, transport),
+    mapping: createClient(MappingService, transport),
   }
 }
 

--- a/frontend/src/pages/mappings/[mappingId].test.tsx
+++ b/frontend/src/pages/mappings/[mappingId].test.tsx
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+}))
+
+// Mock CodeMirror editors to avoid JSDOM incompatibility
+vi.mock('@/components/shared/cel-editor', () => ({
+  CELEditor: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <textarea
+      data-testid="cel-editor"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}))
+
+import { useApiClients } from '@/api/context'
+import { MappingDetailPage } from './[mappingId]'
+
+const SAMPLE_MAPPING = {
+  id: 'mapping-abc',
+  name: 'Stripe Webhook',
+  targetService: 'meridian.payment_order.v1.PaymentOrderService',
+  targetRpc: 'InitiatePaymentOrder',
+  version: 1,
+  status: 'MAPPING_STATUS_ACTIVE',
+  fields: [
+    {
+      externalPath: 'customer.id',
+      internalPath: 'customer_id',
+      transform: null,
+    },
+    {
+      externalPath: 'amount.value',
+      internalPath: 'amount.amount',
+      transform: { cel: { inboundCel: 'value * 100', outboundCel: '' } },
+    },
+  ],
+  inboundValidationCel: 'has(payload.customer_id)',
+  outboundValidationCel: '',
+  isBatch: false,
+  batchTargetPath: '',
+  createdAt: undefined,
+  updatedAt: undefined,
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+    },
+  })
+}
+
+function renderAtRoute(component: React.ReactNode, route: string) {
+  const qc = makeQueryClient()
+  window.history.pushState({}, 'test page', route)
+  return render(
+    <QueryClientProvider client={qc}>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/gateway-mappings/:mappingId" element={component} />
+        </Routes>
+      </BrowserRouter>
+    </QueryClientProvider>,
+  )
+}
+
+function makeDefaultClients(mapping = SAMPLE_MAPPING) {
+  return {
+    mapping: {
+      getMapping: vi.fn().mockResolvedValue({ mapping }),
+      dryRunMapping: vi.fn().mockResolvedValue({
+        transformedJson: '{"customer_id":"cust_123"}',
+        idempotencyKey: 'key-abc',
+        validationResult: { passed: true, errors: [] },
+        executionTimeMs: 12,
+        fieldMappingTrace: [
+          {
+            sourcePath: 'customer.id',
+            targetPath: 'customer_id',
+            sourceValue: '"cust_123"',
+            transformedValue: '"cust_123"',
+            transformType: 'none',
+          },
+        ],
+        transformError: '',
+      }),
+    },
+  }
+}
+
+describe('MappingDetailPage', () => {
+  beforeEach(() => {
+    vi.mocked(useApiClients).mockReturnValue(makeDefaultClients() as never)
+  })
+
+  it('renders the page title', async () => {
+    renderAtRoute(<MappingDetailPage />, '/gateway-mappings/mapping-abc')
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /mapping details/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders mapping name after loading', async () => {
+    renderAtRoute(<MappingDetailPage />, '/gateway-mappings/mapping-abc')
+
+    await waitFor(() => {
+      expect(screen.getByText('Stripe Webhook')).toBeInTheDocument()
+    })
+  })
+
+  it('renders field mapper tab', async () => {
+    renderAtRoute(<MappingDetailPage />, '/gateway-mappings/mapping-abc')
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /field mapper/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders dry run playground tab', async () => {
+    renderAtRoute(<MappingDetailPage />, '/gateway-mappings/mapping-abc')
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /dry run/i })).toBeInTheDocument()
+    })
+  })
+
+  it('shows field correspondence with gjson paths', async () => {
+    const user = userEvent.setup()
+    renderAtRoute(<MappingDetailPage />, '/gateway-mappings/mapping-abc')
+
+    // Wait for page to load then click field mapper tab
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /field mapper/i })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('tab', { name: /field mapper/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('customer.id')).toBeInTheDocument()
+      expect(screen.getByText('customer_id')).toBeInTheDocument()
+    })
+  })
+
+  it('shows transform type for field with cel transform', async () => {
+    const user = userEvent.setup()
+    renderAtRoute(<MappingDetailPage />, '/gateway-mappings/mapping-abc')
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /field mapper/i })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('tab', { name: /field mapper/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('CEL')).toBeInTheDocument()
+    })
+  })
+
+  it('calls DryRunMapping RPC and shows transformed JSON output', async () => {
+    const user = userEvent.setup()
+    renderAtRoute(<MappingDetailPage />, '/gateway-mappings/mapping-abc')
+
+    // Click on Dry Run tab
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /dry run/i })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('tab', { name: /dry run/i }))
+
+    // Click run button
+    const runButton = await screen.findByRole('button', { name: /^run$/i })
+    await user.click(runButton)
+
+    // Check transformed output appears
+    await waitFor(() => {
+      expect(screen.getByTestId('dry-run-output')).toHaveTextContent(/customer_id/)
+    })
+  })
+
+  it('shows PII masking for sensitive fields', async () => {
+    const clientsWithPii = {
+      mapping: {
+        getMapping: vi.fn().mockResolvedValue({
+          mapping: {
+            ...SAMPLE_MAPPING,
+            fields: [
+              {
+                externalPath: 'card.number',
+                internalPath: 'payment_method',
+                transform: null,
+              },
+            ],
+          },
+        }),
+        dryRunMapping: vi.fn().mockResolvedValue({
+          transformedJson: '{"payment_method":"****"}',
+          idempotencyKey: '',
+          validationResult: { passed: true, errors: [] },
+          executionTimeMs: 5,
+          fieldMappingTrace: [],
+          transformError: '',
+        }),
+      },
+    }
+    vi.mocked(useApiClients).mockReturnValue(clientsWithPii as never)
+
+    const user = userEvent.setup()
+    renderAtRoute(<MappingDetailPage />, '/gateway-mappings/mapping-abc')
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /dry run/i })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('tab', { name: /dry run/i }))
+
+    const runButton = await screen.findByRole('button', { name: /run/i })
+
+    // Enable PII masking
+    const piiToggle = screen.queryByRole('checkbox', { name: /mask pii/i })
+    if (piiToggle && !piiToggle.checked) {
+      await user.click(piiToggle)
+    }
+
+    await user.click(runButton)
+
+    await waitFor(() => {
+      // The output should be rendered
+      expect(screen.getByTestId('dry-run-output')).toBeInTheDocument()
+    })
+  })
+
+  it('shows field mapping trace after dry run', async () => {
+    const user = userEvent.setup()
+    renderAtRoute(<MappingDetailPage />, '/gateway-mappings/mapping-abc')
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /dry run/i })).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole('tab', { name: /dry run/i }))
+
+    const runButton = await screen.findByRole('button', { name: /run/i })
+    await user.click(runButton)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('field-mapping-trace')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error message when mapping not found', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      mapping: {
+        getMapping: vi.fn().mockRejectedValue(new Error('NOT_FOUND')),
+        dryRunMapping: vi.fn(),
+      },
+    } as never)
+
+    renderAtRoute(<MappingDetailPage />, '/gateway-mappings/nonexistent')
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/mappings/[mappingId].tsx
+++ b/frontend/src/pages/mappings/[mappingId].tsx
@@ -1,0 +1,502 @@
+import * as React from 'react'
+import { useParams } from 'react-router-dom'
+import { useQuery, useMutation } from '@tanstack/react-query'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { StatusBadge } from '@/components/shared/status-badge'
+import { useApiClients } from '@/api/context'
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface CelTransform {
+  inboundCel: string
+  outboundCel: string
+}
+
+interface EnumMapping {
+  values: Record<string, string>
+  fallback: string
+  outboundFallback: string
+}
+
+interface AttributeFlatten {
+  sourceKeys: string[]
+  targetField: string
+}
+
+interface FieldTransform {
+  cel?: CelTransform
+  enumMapping?: EnumMapping
+  dateFormat?: string
+  defaultValue?: string
+  attributeFlatten?: AttributeFlatten
+}
+
+interface FieldCorrespondence {
+  externalPath: string
+  internalPath: string
+  transform?: FieldTransform | null
+}
+
+interface FieldMappingTrace {
+  sourcePath: string
+  targetPath: string
+  sourceValue: string
+  transformedValue: string
+  transformType: string
+}
+
+interface DryRunValidationResult {
+  passed: boolean
+  errors: string[]
+}
+
+interface MappingDetail {
+  id: string
+  name: string
+  targetService: string
+  targetRpc: string
+  version: number
+  status: string
+  fields: FieldCorrespondence[]
+  inboundValidationCel: string
+  outboundValidationCel: string
+  isBatch: boolean
+  batchTargetPath: string
+  createdAt?: { seconds: bigint | number; nanos?: number }
+  updatedAt?: { seconds: bigint | number; nanos?: number }
+}
+
+interface DryRunResult {
+  transformedJson: string
+  idempotencyKey: string
+  validationResult: DryRunValidationResult
+  executionTimeMs: number
+  fieldMappingTrace: FieldMappingTrace[]
+  transformError: string
+}
+
+// ─── PII masking ─────────────────────────────────────────────────────────────
+
+const PII_PATTERNS = [
+  /card[._-]?number/i,
+  /cvv/i,
+  /ssn/i,
+  /social[._-]?security/i,
+  /password/i,
+  /secret/i,
+  /token/i,
+  /account[._-]?number/i,
+]
+
+function maskPiiValue(key: string, value: string): string {
+  if (PII_PATTERNS.some((re) => re.test(key))) {
+    return '"****"'
+  }
+  return value
+}
+
+function applyPiiMask(json: string): string {
+  try {
+    const obj = JSON.parse(json)
+    const masked = maskObjectPii(obj)
+    return JSON.stringify(masked, null, 2)
+  } catch {
+    return json
+  }
+}
+
+function maskObjectPii(obj: unknown): unknown {
+  if (obj === null || obj === undefined) return obj
+  if (typeof obj !== 'object') return obj
+  if (Array.isArray(obj)) return obj.map((v) => maskObjectPii(v))
+
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    if (typeof value === 'string' && PII_PATTERNS.some((re) => re.test(key))) {
+      result[key] = '****'
+    } else {
+      result[key] = maskObjectPii(value)
+    }
+  }
+  return result
+}
+
+// ─── Field Transform Badge ────────────────────────────────────────────────────
+
+function TransformTypeBadge({ transform }: { transform?: FieldTransform | null }) {
+  if (!transform) return <span className="text-xs text-muted-foreground">—</span>
+  if (transform.cel) return <Badge variant="secondary">CEL</Badge>
+  if (transform.enumMapping) return <Badge variant="secondary">Enum</Badge>
+  if (transform.dateFormat) return <Badge variant="secondary">Date</Badge>
+  if (transform.defaultValue !== undefined) return <Badge variant="secondary">Default</Badge>
+  if (transform.attributeFlatten) return <Badge variant="secondary">Flatten</Badge>
+  return <span className="text-xs text-muted-foreground">—</span>
+}
+
+// ─── Field Mapper Tab ─────────────────────────────────────────────────────────
+
+function FieldMapperTab({ mapping }: { mapping: MappingDetail }) {
+  const fields = mapping.fields ?? []
+
+  return (
+    <div className="space-y-4">
+      <div className="text-sm text-muted-foreground">
+        {fields.length} field{fields.length !== 1 ? 's' : ''} mapped
+      </div>
+
+      {fields.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No field correspondences defined.</p>
+      ) : (
+        <div className="rounded border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/40">
+                <th className="px-4 py-2 text-left font-medium">External Path (gjson)</th>
+                <th className="px-4 py-2 text-left font-medium">Internal Path (proto)</th>
+                <th className="px-4 py-2 text-left font-medium">Transform</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fields.map((field, idx) => (
+                <tr key={idx} className="border-b last:border-0 hover:bg-muted/20">
+                  <td className="px-4 py-2 font-mono text-xs">{field.externalPath}</td>
+                  <td className="px-4 py-2 font-mono text-xs">{field.internalPath}</td>
+                  <td className="px-4 py-2">
+                    <TransformTypeBadge transform={field.transform} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Dry Run Playground Tab ───────────────────────────────────────────────────
+
+function DryRunTab({ mapping }: { mapping: MappingDetail }) {
+  const clients = useApiClients()
+  const [sampleJson, setSampleJson] = React.useState('{\n  \n}')
+  const [direction, setDirection] = React.useState<'inbound' | 'outbound'>('inbound')
+  const [maskPii, setMaskPii] = React.useState(false)
+
+  const dryRun = useMutation({
+    mutationFn: async (): Promise<DryRunResult> => {
+      const response = await clients.mapping.dryRunMapping({
+        mappingName: mapping.name,
+        mappingVersion: mapping.version,
+        direction,
+        sampleJson,
+      })
+      return response as DryRunResult
+    },
+  })
+
+  const outputJson = React.useMemo(() => {
+    if (!dryRun.data?.transformedJson) return ''
+    if (maskPii) return applyPiiMask(dryRun.data.transformedJson)
+    try {
+      return JSON.stringify(JSON.parse(dryRun.data.transformedJson), null, 2)
+    } catch {
+      return dryRun.data.transformedJson
+    }
+  }, [dryRun.data, maskPii])
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <div className="flex gap-2">
+          <Button
+            variant={direction === 'inbound' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setDirection('inbound')}
+          >
+            Inbound
+          </Button>
+          <Button
+            variant={direction === 'outbound' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setDirection('outbound')}
+          >
+            Outbound
+          </Button>
+        </div>
+
+        <label className="flex cursor-pointer items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            role="checkbox"
+            aria-label="Mask PII"
+            checked={maskPii}
+            onChange={(e) => setMaskPii(e.target.checked)}
+            className="h-4 w-4"
+          />
+          Mask PII
+        </label>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Input JSON</label>
+          <textarea
+            className="h-48 w-full rounded border border-input bg-background px-3 py-2 font-mono text-xs outline-none focus:border-ring"
+            value={sampleJson}
+            onChange={(e) => setSampleJson(e.target.value)}
+            placeholder='{"key": "value"}'
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Output JSON</label>
+          <pre
+            data-testid="dry-run-output"
+            className="h-48 overflow-auto rounded border border-input bg-muted/30 px-3 py-2 font-mono text-xs"
+          >
+            {dryRun.isPending ? (
+              <span className="text-muted-foreground">Running...</span>
+            ) : dryRun.isError ? (
+              <span className="text-destructive">
+                {dryRun.error instanceof Error ? dryRun.error.message : 'Error'}
+              </span>
+            ) : outputJson ? (
+              outputJson
+            ) : (
+              <span className="text-muted-foreground">Output will appear here</span>
+            )}
+          </pre>
+        </div>
+      </div>
+
+      {dryRun.data && (
+        <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+          {dryRun.data.validationResult && (
+            <span>
+              Validation:{' '}
+              <span
+                className={
+                  dryRun.data.validationResult.passed ? 'text-green-700' : 'text-destructive'
+                }
+              >
+                {dryRun.data.validationResult.passed ? 'Passed' : 'Failed'}
+              </span>
+            </span>
+          )}
+          {dryRun.data.executionTimeMs > 0 && (
+            <span>{dryRun.data.executionTimeMs}ms</span>
+          )}
+          {dryRun.data.idempotencyKey && (
+            <span>
+              Idempotency Key:{' '}
+              <code className="rounded bg-muted px-1">{dryRun.data.idempotencyKey}</code>
+            </span>
+          )}
+          {dryRun.data.transformError && (
+            <span className="text-destructive">Transform error: {dryRun.data.transformError}</span>
+          )}
+        </div>
+      )}
+
+      {dryRun.data?.validationResult &&
+        !dryRun.data.validationResult.passed &&
+        dryRun.data.validationResult.errors.length > 0 && (
+          <div className="rounded border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+            {dryRun.data.validationResult.errors.map((err, i) => (
+              <div key={i}>{err}</div>
+            ))}
+          </div>
+        )}
+
+      <Button onClick={() => dryRun.mutate()} disabled={dryRun.isPending}>
+        {dryRun.isPending ? 'Running...' : 'Run'}
+      </Button>
+
+      {dryRun.data && dryRun.data.fieldMappingTrace.length > 0 && (
+        <div data-testid="field-mapping-trace" className="space-y-2">
+          <h3 className="text-sm font-medium">Field Mapping Trace</h3>
+          <div className="rounded border">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b bg-muted/40">
+                  <th className="px-3 py-2 text-left font-medium">Source Path</th>
+                  <th className="px-3 py-2 text-left font-medium">Target Path</th>
+                  <th className="px-3 py-2 text-left font-medium">Source Value</th>
+                  <th className="px-3 py-2 text-left font-medium">Transformed Value</th>
+                  <th className="px-3 py-2 text-left font-medium">Transform</th>
+                </tr>
+              </thead>
+              <tbody>
+                {dryRun.data.fieldMappingTrace.map((trace, idx) => (
+                  <tr key={idx} className="border-b last:border-0 hover:bg-muted/20">
+                    <td className="px-3 py-2 font-mono">{trace.sourcePath}</td>
+                    <td className="px-3 py-2 font-mono">{trace.targetPath}</td>
+                    <td className="px-3 py-2 font-mono">{trace.sourceValue}</td>
+                    <td className="px-3 py-2 font-mono">
+                      {maskPii
+                        ? maskPiiValue(trace.targetPath, trace.transformedValue)
+                        : trace.transformedValue}
+                    </td>
+                    <td className="px-3 py-2">{trace.transformType}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Overview Tab ─────────────────────────────────────────────────────────────
+
+function OverviewTab({ mapping }: { mapping: MappingDetail }) {
+  return (
+    <dl className="grid grid-cols-2 gap-4 text-sm">
+      <div>
+        <dt className="font-medium text-muted-foreground">Target Service</dt>
+        <dd className="mt-1 font-mono text-xs">{mapping.targetService}</dd>
+      </div>
+      <div>
+        <dt className="font-medium text-muted-foreground">Target RPC</dt>
+        <dd className="mt-1 font-mono text-xs">{mapping.targetRpc}</dd>
+      </div>
+      <div>
+        <dt className="font-medium text-muted-foreground">Version</dt>
+        <dd className="mt-1">v{mapping.version}</dd>
+      </div>
+      <div>
+        <dt className="font-medium text-muted-foreground">Batch Mode</dt>
+        <dd className="mt-1">{mapping.isBatch ? 'Yes' : 'No'}</dd>
+      </div>
+      {mapping.isBatch && mapping.batchTargetPath && (
+        <div className="col-span-2">
+          <dt className="font-medium text-muted-foreground">Batch Target Path</dt>
+          <dd className="mt-1 font-mono text-xs">{mapping.batchTargetPath}</dd>
+        </div>
+      )}
+      {mapping.inboundValidationCel && (
+        <div className="col-span-2">
+          <dt className="font-medium text-muted-foreground">Inbound Validation CEL</dt>
+          <dd className="mt-1 rounded bg-muted/30 px-3 py-2 font-mono text-xs">
+            {mapping.inboundValidationCel}
+          </dd>
+        </div>
+      )}
+      {mapping.outboundValidationCel && (
+        <div className="col-span-2">
+          <dt className="font-medium text-muted-foreground">Outbound Validation CEL</dt>
+          <dd className="mt-1 rounded bg-muted/30 px-3 py-2 font-mono text-xs">
+            {mapping.outboundValidationCel}
+          </dd>
+        </div>
+      )}
+    </dl>
+  )
+}
+
+// ─── Mapping Header ───────────────────────────────────────────────────────────
+
+function MappingHeader({ mapping }: { mapping: MappingDetail }) {
+  const statusDisplay = mapping.status.replace(/^MAPPING_STATUS_/, '')
+
+  return (
+    <div className="flex items-center justify-between p-6">
+      <div>
+        <h2 className="text-xl font-semibold">{mapping.name}</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          v{mapping.version} · {mapping.targetRpc}
+        </p>
+      </div>
+      <StatusBadge status={statusDisplay} />
+    </div>
+  )
+}
+
+// ─── Main Page Component ──────────────────────────────────────────────────────
+
+export function MappingDetailPage() {
+  const { mappingId } = useParams<{ mappingId: string }>()
+  const clients = useApiClients()
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['mapping', mappingId],
+    queryFn: async () => {
+      const response = await clients.mapping.getMapping({ id: mappingId! })
+      return response.mapping as MappingDetail
+    },
+    enabled: !!mappingId,
+  })
+
+  if (!mappingId) {
+    return <div className="p-6 text-destructive">Mapping ID not found</div>
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Mapping Details</h1>
+        </div>
+        <Card>
+          <div className="p-6">
+            <div className="h-6 w-48 animate-pulse rounded bg-muted" />
+          </div>
+        </Card>
+      </div>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Mapping Details</h1>
+        </div>
+        <Card className="p-6">
+          <p className="text-destructive">Failed to load mapping.</p>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Mapping Details</h1>
+      </div>
+
+      <Card>
+        <MappingHeader mapping={data} />
+      </Card>
+
+      <Card>
+        <Tabs defaultValue="overview" className="w-full">
+          <TabsList className="grid w-full grid-cols-3 border-b rounded-none">
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="field-mapper">Field Mapper</TabsTrigger>
+            <TabsTrigger value="dry-run">Dry Run</TabsTrigger>
+          </TabsList>
+
+          <div className="p-6">
+            <TabsContent value="overview" className="mt-0">
+              <OverviewTab mapping={data} />
+            </TabsContent>
+
+            <TabsContent value="field-mapper" className="mt-0">
+              <FieldMapperTab mapping={data} />
+            </TabsContent>
+
+            <TabsContent value="dry-run" className="mt-0">
+              <DryRunTab mapping={data} />
+            </TabsContent>
+          </div>
+        </Tabs>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/pages/mappings/index.test.tsx
+++ b/frontend/src/pages/mappings/index.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BrowserRouter } from 'react-router-dom'
+
+// Mock the API context to avoid loading ungenerated proto files
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+}))
+
+import { useApiClients } from '@/api/context'
+import { MappingsPage } from './index'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+    },
+  })
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = makeQueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <BrowserRouter>{children}</BrowserRouter>
+    </QueryClientProvider>
+  )
+}
+
+function makeDefaultClients(mappings = []) {
+  return {
+    mapping: {
+      listMappings: vi.fn().mockResolvedValue({
+        mappings,
+        nextPageToken: undefined,
+        totalCount: mappings.length,
+      }),
+    },
+  }
+}
+
+describe('MappingsPage', () => {
+  beforeEach(() => {
+    vi.mocked(useApiClients).mockReturnValue(makeDefaultClients() as never)
+  })
+
+  it('renders the page title', () => {
+    render(
+      <Wrapper>
+        <MappingsPage />
+      </Wrapper>,
+    )
+    expect(screen.getByRole('heading', { name: /gateway mappings/i })).toBeInTheDocument()
+  })
+
+  it('renders data table with mapping columns', async () => {
+    render(
+      <Wrapper>
+        <MappingsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: /name/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders target service column', async () => {
+    render(
+      <Wrapper>
+        <MappingsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: /target service/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders target rpc column', async () => {
+    render(
+      <Wrapper>
+        <MappingsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: /target rpc/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders version column', async () => {
+    render(
+      <Wrapper>
+        <MappingsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: /version/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders status column', async () => {
+    render(
+      <Wrapper>
+        <MappingsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('columnheader', { name: /status/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders mapping rows when data is returned', async () => {
+    vi.mocked(useApiClients).mockReturnValue(
+      makeDefaultClients([
+        {
+          id: 'mapping-1',
+          name: 'Stripe Webhook',
+          targetService: 'meridian.payment_order.v1.PaymentOrderService',
+          targetRpc: 'InitiatePaymentOrder',
+          version: 1,
+          status: 'MAPPING_STATUS_ACTIVE',
+        },
+      ]) as never,
+    )
+
+    render(
+      <Wrapper>
+        <MappingsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Stripe Webhook')).toBeInTheDocument()
+    })
+  })
+
+  it('renders status filter', async () => {
+    render(
+      <Wrapper>
+        <MappingsPage />
+      </Wrapper>,
+    )
+
+    const selects = screen.getAllByRole('combobox')
+    expect(selects.length).toBeGreaterThan(0)
+  })
+
+  it('renders empty state when no mappings', async () => {
+    render(
+      <Wrapper>
+        <MappingsPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/mappings/index.tsx
+++ b/frontend/src/pages/mappings/index.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { ColumnDef } from '@tanstack/react-table'
+import { DataTable } from '@/components/shared/data-table'
+import { TimeDisplay } from '@/components/shared/time-display'
+import { StatusBadge } from '@/components/shared/status-badge'
+import { useApiClients } from '@/api/context'
+import { Card } from '@/components/ui/card'
+
+export interface MappingDefinition {
+  id: string
+  name: string
+  targetService: string
+  targetRpc: string
+  version: number
+  status: string
+  createdAt?: { seconds: bigint | number; nanos?: number }
+  updatedAt?: { seconds: bigint | number; nanos?: number }
+}
+
+interface ListMappingsParams {
+  pageToken?: string
+  pageSize: number
+  filters?: Record<string, string>
+}
+
+interface ListMappingsResult {
+  items: MappingDefinition[]
+  nextPageToken?: string
+}
+
+export function MappingsPage() {
+  const navigate = useNavigate()
+  const clients = useApiClients()
+
+  const columns: ColumnDef<MappingDefinition>[] = [
+    {
+      accessorKey: 'name',
+      header: 'Name',
+      cell: ({ row }) => (
+        <span className="font-medium">{row.original.name}</span>
+      ),
+    },
+    {
+      accessorKey: 'targetService',
+      header: 'Target Service',
+      cell: ({ row }) => (
+        <span className="font-mono text-xs text-muted-foreground">
+          {row.original.targetService}
+        </span>
+      ),
+    },
+    {
+      accessorKey: 'targetRpc',
+      header: 'Target RPC',
+      cell: ({ row }) => (
+        <span className="font-mono text-xs">{row.original.targetRpc}</span>
+      ),
+    },
+    {
+      accessorKey: 'version',
+      header: 'Version',
+      cell: ({ row }) => `v${row.original.version}`,
+    },
+    {
+      accessorKey: 'status',
+      header: 'Status',
+      cell: ({ row }) => {
+        const raw = row.original.status
+        // Strip the MAPPING_STATUS_ prefix for display
+        const display = raw.replace(/^MAPPING_STATUS_/, '')
+        return <StatusBadge status={display} />
+      },
+    },
+    {
+      accessorKey: 'updatedAt',
+      header: 'Updated',
+      cell: ({ row }) => <TimeDisplay timestamp={row.original.updatedAt} />,
+    },
+  ]
+
+  const filters = [
+    {
+      field: 'status',
+      label: 'Status',
+      type: 'select' as const,
+      options: [
+        { label: 'Draft', value: 'MAPPING_STATUS_DRAFT' },
+        { label: 'Active', value: 'MAPPING_STATUS_ACTIVE' },
+        { label: 'Deprecated', value: 'MAPPING_STATUS_DEPRECATED' },
+      ],
+    },
+  ]
+
+  const queryFn = async (params: ListMappingsParams): Promise<ListMappingsResult> => {
+    const response = await clients.mapping.listMappings({
+      pageToken: params.pageToken,
+      pageSize: params.pageSize,
+      status: params.filters?.status ? (params.filters.status as never) : undefined,
+    })
+
+    return {
+      items: (response.mappings ?? []) as MappingDefinition[],
+      nextPageToken: response.nextPageToken,
+    }
+  }
+
+  const handleRowClick = (mapping: MappingDefinition) => {
+    navigate(`/gateway-mappings/${mapping.id}`)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Gateway Mappings</h1>
+        <p className="mt-2 text-muted-foreground">
+          Manage field correspondence mappings between external JSON payloads and internal Meridian
+          services.
+        </p>
+      </div>
+
+      <Card className="p-6">
+        <DataTable
+          queryKey={['mappings']}
+          queryFn={queryFn}
+          columns={columns}
+          pageSize={25}
+          filters={filters}
+          onRowClick={handleRowClick}
+        />
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Implements `MappingsPage` (`src/pages/mappings/index.tsx`) with a DataTable listing all gateway mappings (name, target service, target RPC, version, status) and status filter
- Implements `MappingDetailPage` (`src/pages/mappings/[mappingId].tsx`) with three tabs: Overview, Field Mapper, and Dry Run Playground
- Field Mapper tab shows gjson external paths alongside proto internal paths and transform type badge (CEL, Enum, Date, Default, Flatten)
- Dry Run Playground calls `DryRunMapping` RPC, renders transformed JSON output, per-field mapping trace, validation result, execution time, and idempotency key
- PII masking toggle masks sensitive field values in both the output JSON and field mapping trace
- Wires `MappingService` client into `clients.ts` and registers `/gateway-mappings` + `/gateway-mappings/:mappingId` routes in `App.tsx`

## Test plan

- [ ] 19 tests pass covering: list page rendering, column headers, row data, status filter, empty state, detail page tabs, gjson path display, transform type badge, dry run RPC call, transformed JSON output, PII masking, field mapping trace, and error state

Task: 026-operations-console.32