### PR TITLE
feat: Add account action dialogs for deposit, withdraw, freeze/unfreeze

### DIFF
--- a/frontend/src/pages/accounts/[accountId].tsx
+++ b/frontend/src/pages/accounts/[accountId].tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { ChevronLeftIcon } from 'lucide-react'
@@ -9,6 +10,10 @@ import { TimeDisplay } from '@/components/shared/time-display'
 import { AuditTrail } from '@/components/shared'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
+import { DepositDialog } from './deposit-dialog'
+import { WithdrawDialog } from './withdraw-dialog'
+import { ControlDialog } from './control-dialog'
+import type { ControlAction } from './control-dialog'
 import type { AccountStatus, CurrentAccount, RetrieveCurrentAccountResponse } from './types'
 
 async function retrieveAccount(
@@ -89,29 +94,74 @@ function AccountNotFound() {
 // Action buttons based on account status
 // ---------------------------------------------------------------------------
 
-function AccountActions({ status }: { status: AccountStatus }) {
+interface AccountActionsProps {
+  status: AccountStatus
+  accountId: string
+  currency: string
+}
+
+function AccountActions({ status, accountId, currency }: AccountActionsProps) {
+  const [depositOpen, setDepositOpen] = React.useState(false)
+  const [withdrawOpen, setWithdrawOpen] = React.useState(false)
+  const [controlOpen, setControlOpen] = React.useState(false)
+  const [controlAction, setControlAction] = React.useState<ControlAction>('freeze')
+
   if (status === 'CLOSED' || status === 'SUSPENDED') {
     return null
   }
 
+  function openControl(action: ControlAction) {
+    setControlAction(action)
+    setControlOpen(true)
+  }
+
   return (
-    <div className="flex gap-2">
-      {status === 'ACTIVE' && (
-        <>
-          <Button variant="outline" size="sm">
-            Freeze
+    <>
+      <div className="flex gap-2">
+        {status === 'ACTIVE' && (
+          <>
+            <Button variant="outline" size="sm" onClick={() => setDepositOpen(true)}>
+              Deposit
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => setWithdrawOpen(true)}>
+              Withdraw
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => openControl('freeze')}>
+              Freeze
+            </Button>
+            <Button variant="destructive" size="sm" onClick={() => openControl('close')}>
+              Close Account
+            </Button>
+          </>
+        )}
+        {status === 'FROZEN' && (
+          <Button variant="outline" size="sm" onClick={() => openControl('unfreeze')}>
+            Unfreeze
           </Button>
-          <Button variant="destructive" size="sm">
-            Close Account
-          </Button>
-        </>
-      )}
-      {status === 'FROZEN' && (
-        <Button variant="outline" size="sm">
-          Unfreeze
-        </Button>
-      )}
-    </div>
+        )}
+      </div>
+
+      <DepositDialog
+        open={depositOpen}
+        onOpenChange={setDepositOpen}
+        accountId={accountId}
+        currency={currency}
+      />
+
+      <WithdrawDialog
+        open={withdrawOpen}
+        onOpenChange={setWithdrawOpen}
+        accountId={accountId}
+        currency={currency}
+      />
+
+      <ControlDialog
+        open={controlOpen}
+        onOpenChange={setControlOpen}
+        accountId={accountId}
+        action={controlAction}
+      />
+    </>
   )
 }
 
@@ -174,7 +224,11 @@ export function AccountDetailPage() {
             <p className="mt-1 font-mono text-sm text-muted-foreground">{account.iban}</p>
           )}
         </div>
-        <AccountActions status={account.status} />
+        <AccountActions
+          status={account.status}
+          accountId={account.accountId}
+          currency={account.baseCurrency}
+        />
       </div>
 
       {/* Summary fields */}

--- a/frontend/src/pages/accounts/account-detail.test.tsx
+++ b/frontend/src/pages/accounts/account-detail.test.tsx
@@ -283,6 +283,108 @@ describe('AccountDetailPage - action buttons', () => {
   })
 })
 
+describe('AccountDetailPage - dialog integration', () => {
+  it('opens DepositDialog when Deposit button is clicked', async () => {
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
+        HttpResponse.json({ account: mockAccount }),
+      ),
+    )
+
+    renderDetailPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /deposit/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /deposit/i }))
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/deposit funds/i).length).toBeGreaterThan(0)
+    })
+  })
+
+  it('opens WithdrawDialog when Withdraw button is clicked', async () => {
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
+        HttpResponse.json({ account: mockAccount }),
+      ),
+    )
+
+    renderDetailPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /withdraw/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /withdraw/i }))
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/withdraw/i).length).toBeGreaterThan(1)
+    })
+  })
+
+  it('opens ControlDialog when Freeze button is clicked', async () => {
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
+        HttpResponse.json({ account: mockAccount }),
+      ),
+    )
+
+    renderDetailPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^freeze$/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /^freeze$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+  })
+
+  it('opens ControlDialog when Unfreeze button is clicked', async () => {
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
+        HttpResponse.json({ account: mockFrozenAccount }),
+      ),
+    )
+
+    renderDetailPage('acct-frozen')
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^unfreeze$/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /^unfreeze$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+  })
+
+  it('opens ControlDialog when Close Account button is clicked', async () => {
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
+        HttpResponse.json({ account: mockAccount }),
+      ),
+    )
+
+    renderDetailPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /close account/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /close account/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+  })
+})
+
 describe('AccountDetailPage - back navigation', () => {
   it('renders a back link to accounts list', async () => {
     server.use(

--- a/frontend/src/pages/accounts/account-form-utils.test.ts
+++ b/frontend/src/pages/accounts/account-form-utils.test.ts
@@ -33,6 +33,20 @@ describe('amountToBigInt', () => {
   it('throws on invalid string', () => {
     expect(() => amountToBigInt('abc')).toThrow()
   })
+
+  it('throws on scientific notation (prevents float parsing exploit)', () => {
+    expect(() => amountToBigInt('1e5')).toThrow()
+  })
+
+  it('handles rounding at the third decimal place', () => {
+    // 1.555 with 2dp should round up to 1.56 = BigInt(156)
+    expect(amountToBigInt('1.555')).toBe(BigInt(156))
+  })
+
+  it('truncates without rounding when next digit < 5', () => {
+    // 1.554 with 2dp should stay 1.55 = BigInt(155)
+    expect(amountToBigInt('1.554')).toBe(BigInt(155))
+  })
 })
 
 describe('bigIntToDisplayAmount', () => {

--- a/frontend/src/pages/accounts/account-form-utils.test.ts
+++ b/frontend/src/pages/accounts/account-form-utils.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { amountToBigInt, bigIntToDisplayAmount, formatCurrencyAmount } from './account-form-utils'
+
+describe('amountToBigInt', () => {
+  it('converts a string decimal to BigInt minor units (2 dp default)', () => {
+    expect(amountToBigInt('100.00')).toBe(BigInt(10000))
+  })
+
+  it('converts integer string to BigInt minor units', () => {
+    expect(amountToBigInt('100')).toBe(BigInt(10000))
+  })
+
+  it('converts fractional amounts correctly', () => {
+    expect(amountToBigInt('1.50')).toBe(BigInt(150))
+  })
+
+  it('handles single decimal place', () => {
+    expect(amountToBigInt('1.5')).toBe(BigInt(150))
+  })
+
+  it('handles zero', () => {
+    expect(amountToBigInt('0')).toBe(BigInt(0))
+  })
+
+  it('handles large amounts', () => {
+    expect(amountToBigInt('1000000.00')).toBe(BigInt(100000000))
+  })
+
+  it('throws on negative amount', () => {
+    expect(() => amountToBigInt('-1.00')).toThrow('Amount must be positive')
+  })
+
+  it('throws on invalid string', () => {
+    expect(() => amountToBigInt('abc')).toThrow()
+  })
+})
+
+describe('bigIntToDisplayAmount', () => {
+  it('converts BigInt minor units to decimal string (2 dp default)', () => {
+    expect(bigIntToDisplayAmount(BigInt(10000))).toBe('100.00')
+  })
+
+  it('converts smaller amounts', () => {
+    expect(bigIntToDisplayAmount(BigInt(150))).toBe('1.50')
+  })
+
+  it('converts zero', () => {
+    expect(bigIntToDisplayAmount(BigInt(0))).toBe('0.00')
+  })
+
+  it('converts large amounts', () => {
+    expect(bigIntToDisplayAmount(BigInt(100000000))).toBe('1000000.00')
+  })
+})
+
+describe('formatCurrencyAmount', () => {
+  it('formats amount with currency prefix', () => {
+    expect(formatCurrencyAmount('100.00', 'GBP')).toBe('GBP 100.00')
+  })
+
+  it('formats with different currency', () => {
+    expect(formatCurrencyAmount('50.00', 'USD')).toBe('USD 50.00')
+  })
+
+  it('formats zero', () => {
+    expect(formatCurrencyAmount('0.00', 'GBP')).toBe('GBP 0.00')
+  })
+})

--- a/frontend/src/pages/accounts/account-form-utils.ts
+++ b/frontend/src/pages/accounts/account-form-utils.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared form utilities for account action dialogs.
+ * Handles BigInt conversion (API uses minor units as strings/BigInt)
+ * and currency amount formatting for display.
+ */
+
+/**
+ * Converts a decimal amount string (e.g. "100.50") to BigInt minor units
+ * using the given number of decimal places (default: 2).
+ *
+ * Throws if the amount is negative or not a valid number.
+ */
+export function amountToBigInt(amount: string, decimalPlaces = 2): bigint {
+  const num = parseFloat(amount)
+  if (isNaN(num)) {
+    throw new Error(`Invalid amount: ${amount}`)
+  }
+  if (num < 0) {
+    throw new Error('Amount must be positive')
+  }
+  // Multiply by 10^decimalPlaces to get minor units, round to handle float precision
+  const multiplier = Math.pow(10, decimalPlaces)
+  return BigInt(Math.round(num * multiplier))
+}
+
+/**
+ * Converts a BigInt in minor units back to a display string with the given
+ * number of decimal places (default: 2).
+ *
+ * E.g. BigInt(10050) → "100.50"
+ */
+export function bigIntToDisplayAmount(amount: bigint, decimalPlaces = 2): string {
+  const multiplier = BigInt(Math.pow(10, decimalPlaces))
+  const whole = amount / multiplier
+  const fraction = amount % multiplier
+  return `${whole.toString()}.${fraction.toString().padStart(decimalPlaces, '0')}`
+}
+
+/**
+ * Formats an amount string with a currency code prefix for display.
+ *
+ * E.g. formatCurrencyAmount("100.00", "GBP") → "GBP 100.00"
+ */
+export function formatCurrencyAmount(amount: string, currency: string): string {
+  return `${currency} ${amount}`
+}

--- a/frontend/src/pages/accounts/account-form-utils.ts
+++ b/frontend/src/pages/accounts/account-form-utils.ts
@@ -8,19 +8,31 @@
  * Converts a decimal amount string (e.g. "100.50") to BigInt minor units
  * using the given number of decimal places (default: 2).
  *
- * Throws if the amount is negative or not a valid number.
+ * Uses string-based parsing to avoid IEEE-754 float precision issues.
+ * Throws if the amount is negative, not a valid decimal, or uses scientific notation.
  */
 export function amountToBigInt(amount: string, decimalPlaces = 2): bigint {
-  const num = parseFloat(amount)
-  if (isNaN(num)) {
+  const trimmed = amount.trim()
+  if (!trimmed) {
     throw new Error(`Invalid amount: ${amount}`)
   }
-  if (num < 0) {
+  if (trimmed.startsWith('-')) {
     throw new Error('Amount must be positive')
   }
-  // Multiply by 10^decimalPlaces to get minor units, round to handle float precision
-  const multiplier = Math.pow(10, decimalPlaces)
-  return BigInt(Math.round(num * multiplier))
+  const match = trimmed.match(/^(\d*)(?:\.(\d*))?$/)
+  if (!match || (!match[1] && !match[2])) {
+    throw new Error(`Invalid amount: ${amount}`)
+  }
+  const whole = match[1] || '0'
+  const fractionRaw = match[2] ?? ''
+  const fraction = fractionRaw.slice(0, decimalPlaces).padEnd(decimalPlaces, '0')
+  let value = BigInt(`${whole}${fraction}`)
+  // Round half-up: check the next digit beyond decimalPlaces
+  const nextDigit = fractionRaw[decimalPlaces]
+  if (nextDigit && nextDigit >= '5') {
+    value += 1n
+  }
+  return value
 }
 
 /**

--- a/frontend/src/pages/accounts/control-dialog.test.tsx
+++ b/frontend/src/pages/accounts/control-dialog.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/msw-handlers'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { ControlDialog } from './control-dialog'
+import type { ControlAction } from './control-dialog'
+
+const tenantToken = createTenantUserToken('tenant-test')
+
+function renderControlDialog(props?: {
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  accountId?: string
+  action?: ControlAction
+}) {
+  const {
+    open = true,
+    onOpenChange = vi.fn(),
+    accountId = 'acct-001',
+    action = 'freeze',
+  } = props ?? {}
+  return renderWithProviders(
+    <MemoryRouter>
+      <ControlDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        accountId={accountId}
+        action={action}
+      />
+    </MemoryRouter>,
+    { initialToken: tenantToken },
+  )
+}
+
+describe('ControlDialog - rendering', () => {
+  it('renders dialog when open', () => {
+    renderControlDialog()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('shows freeze title for freeze action', () => {
+    renderControlDialog({ action: 'freeze' })
+    expect(screen.getAllByText(/freeze/i).length).toBeGreaterThan(0)
+  })
+
+  it('shows unfreeze title for unfreeze action', () => {
+    renderControlDialog({ action: 'unfreeze' })
+    expect(screen.getAllByText(/unfreeze/i).length).toBeGreaterThan(0)
+  })
+
+  it('shows close title for close action', () => {
+    renderControlDialog({ action: 'close' })
+    expect(screen.getAllByText(/close/i).length).toBeGreaterThan(0)
+  })
+
+  it('does not render when closed', () => {
+    renderControlDialog({ open: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders confirm and cancel buttons', () => {
+    renderControlDialog()
+    expect(screen.getByRole('button', { name: /confirm/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('shows account id in dialog', () => {
+    renderControlDialog({ accountId: 'acct-xyz' })
+    expect(screen.getAllByText(/acct-xyz/).length).toBeGreaterThan(0)
+  })
+})
+
+describe('ControlDialog - freeze action', () => {
+  it('calls freeze endpoint on confirm', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post(
+        '*/meridian.current_account.v1.CurrentAccountService/FreezeAccount',
+        async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({})
+        },
+      ),
+    )
+
+    renderControlDialog({ action: 'freeze', accountId: 'acct-001' })
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }))
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({ accountId: 'acct-001' })
+    })
+  })
+
+  it('closes dialog on success', async () => {
+    server.use(
+      http.post(
+        '*/meridian.current_account.v1.CurrentAccountService/FreezeAccount',
+        () => HttpResponse.json({}),
+      ),
+    )
+    const onOpenChange = vi.fn()
+    renderControlDialog({ action: 'freeze', onOpenChange })
+
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }))
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('shows error on failure', async () => {
+    server.use(
+      http.post(
+        '*/meridian.current_account.v1.CurrentAccountService/FreezeAccount',
+        () => HttpResponse.json({ message: 'Cannot freeze' }, { status: 400 }),
+      ),
+    )
+
+    renderControlDialog({ action: 'freeze' })
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('ControlDialog - unfreeze action', () => {
+  it('calls unfreeze endpoint on confirm', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post(
+        '*/meridian.current_account.v1.CurrentAccountService/UnfreezeAccount',
+        async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({})
+        },
+      ),
+    )
+
+    renderControlDialog({ action: 'unfreeze', accountId: 'acct-001' })
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }))
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({ accountId: 'acct-001' })
+    })
+  })
+})
+
+describe('ControlDialog - close action', () => {
+  it('calls close endpoint on confirm', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post(
+        '*/meridian.current_account.v1.CurrentAccountService/CloseAccount',
+        async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({})
+        },
+      ),
+    )
+
+    renderControlDialog({ action: 'close', accountId: 'acct-001' })
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }))
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({ accountId: 'acct-001' })
+    })
+  })
+
+  it('uses destructive button variant for close action', () => {
+    renderControlDialog({ action: 'close' })
+    const confirmButton = screen.getByRole('button', { name: /confirm/i })
+    expect(confirmButton).toBeInTheDocument()
+  })
+})
+
+describe('ControlDialog - cancel', () => {
+  it('calls onOpenChange(false) on cancel', async () => {
+    const onOpenChange = vi.fn()
+    renderControlDialog({ onOpenChange })
+
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/frontend/src/pages/accounts/control-dialog.tsx
+++ b/frontend/src/pages/accounts/control-dialog.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { useTenantContext } from '@/contexts/tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+
+export type ControlAction = 'freeze' | 'unfreeze' | 'close'
+
+interface ControlDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  accountId: string
+  action: ControlAction
+}
+
+const ACTION_CONFIG: Record<
+  ControlAction,
+  {
+    title: string
+    description: (accountId: string) => string
+    endpoint: string
+    confirmLabel: string
+    variant: 'default' | 'destructive'
+  }
+> = {
+  freeze: {
+    title: 'Freeze Account',
+    description: (id) => `Are you sure you want to freeze account ${id}? No transactions will be permitted while frozen.`,
+    endpoint: 'FreezeAccount',
+    confirmLabel: 'Confirm Freeze',
+    variant: 'default',
+  },
+  unfreeze: {
+    title: 'Unfreeze Account',
+    description: (id) => `Are you sure you want to unfreeze account ${id}? Transactions will resume normally.`,
+    endpoint: 'UnfreezeAccount',
+    confirmLabel: 'Confirm Unfreeze',
+    variant: 'default',
+  },
+  close: {
+    title: 'Close Account',
+    description: (id) => `Are you sure you want to close account ${id}? This action cannot be undone.`,
+    endpoint: 'CloseAccount',
+    confirmLabel: 'Confirm Close',
+    variant: 'destructive',
+  },
+}
+
+async function performAccountControl(
+  tenantSlug: string,
+  accountId: string,
+  endpoint: string,
+): Promise<void> {
+  const response = await fetch(
+    `/api/meridian.current_account.v1.CurrentAccountService/${endpoint}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Tenant-Slug': tenantSlug,
+      },
+      body: JSON.stringify({ accountId }),
+    },
+  )
+
+  if (!response.ok) {
+    const data = (await response.json().catch(() => ({}))) as { message?: string }
+    throw new Error(data.message ?? `Failed to ${endpoint}: ${response.status}`)
+  }
+}
+
+export function ControlDialog({ open, onOpenChange, accountId, action }: ControlDialogProps) {
+  const { tenantSlug } = useTenantContext()
+  const queryClient = useQueryClient()
+  const [serverError, setServerError] = React.useState<string | null>(null)
+
+  const config = ACTION_CONFIG[action]
+
+  React.useEffect(() => {
+    if (!open) {
+      setServerError(null)
+    }
+  }, [open])
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      performAccountControl(tenantSlug ?? '', accountId, config.endpoint),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: tenantKeys.account(tenantSlug ?? '', accountId),
+      })
+      onOpenChange(false)
+    },
+    onError: (error: Error) => {
+      setServerError(error.message)
+    },
+  })
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{config.title}</DialogTitle>
+          <DialogDescription>{config.description(accountId)}</DialogDescription>
+        </DialogHeader>
+
+        {serverError && (
+          <div role="alert" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+            {serverError}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant={config.variant}
+            type="button"
+            disabled={mutation.isPending}
+            onClick={() => {
+              setServerError(null)
+              mutation.mutate()
+            }}
+          >
+            {mutation.isPending ? 'Processing...' : config.confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/accounts/deposit-dialog.test.tsx
+++ b/frontend/src/pages/accounts/deposit-dialog.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/msw-handlers'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { DepositDialog } from './deposit-dialog'
+
+const tenantToken = createTenantUserToken('tenant-test')
+
+function renderDepositDialog(props: {
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  accountId?: string
+  currency?: string
+}) {
+  const { open = true, onOpenChange = vi.fn(), accountId = 'acct-001', currency = 'GBP' } = props
+  return renderWithProviders(
+    <MemoryRouter>
+      <DepositDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        accountId={accountId}
+        currency={currency}
+      />
+    </MemoryRouter>,
+    { initialToken: tenantToken },
+  )
+}
+
+describe('DepositDialog - rendering', () => {
+  it('renders dialog title when open', () => {
+    renderDepositDialog({})
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getAllByText(/deposit funds/i).length).toBeGreaterThan(0)
+  })
+
+  it('renders amount input', () => {
+    renderDepositDialog({})
+    expect(screen.getByLabelText(/amount/i)).toBeInTheDocument()
+  })
+
+  it('renders currency in dialog', () => {
+    renderDepositDialog({ currency: 'GBP' })
+    expect(screen.getAllByText(/GBP/).length).toBeGreaterThan(0)
+  })
+
+  it('renders deposit and cancel buttons', () => {
+    renderDepositDialog({})
+    expect(screen.getByRole('button', { name: /deposit/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('does not render when closed', () => {
+    renderDepositDialog({ open: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})
+
+describe('DepositDialog - validation', () => {
+  it('shows error when amount is empty', async () => {
+    renderDepositDialog({})
+    await userEvent.click(screen.getByRole('button', { name: /deposit/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/amount is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when amount is zero', async () => {
+    renderDepositDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '0')
+    await userEvent.click(screen.getByRole('button', { name: /deposit/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/amount must be greater than zero/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when amount is negative', async () => {
+    renderDepositDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '-10')
+    await userEvent.click(screen.getByRole('button', { name: /deposit/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/amount must be greater than zero/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when amount is not a valid number', async () => {
+    renderDepositDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), 'abc')
+    await userEvent.click(screen.getByRole('button', { name: /deposit/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/invalid amount/i)).toBeInTheDocument()
+    })
+  })
+})
+
+describe('DepositDialog - submission', () => {
+  beforeEach(() => {
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/DepositFunds', () =>
+        HttpResponse.json({}),
+      ),
+    )
+  })
+
+  it('calls mutation with correct BigInt conversion on submit', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/DepositFunds', async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({})
+      }),
+    )
+
+    renderDepositDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '100.50')
+    await userEvent.click(screen.getByRole('button', { name: /deposit/i }))
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({
+        accountId: 'acct-001',
+        amount: { amount: '10050' },
+      })
+    })
+  })
+
+  it('closes dialog on success', async () => {
+    const onOpenChange = vi.fn()
+    renderDepositDialog({ onOpenChange })
+
+    await userEvent.type(screen.getByLabelText(/amount/i), '100.00')
+    await userEvent.click(screen.getByRole('button', { name: /deposit/i }))
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('shows error message on failure', async () => {
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/DepositFunds', () =>
+        HttpResponse.json({ message: 'Insufficient permissions' }, { status: 400 }),
+      ),
+    )
+
+    renderDepositDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '100.00')
+    await userEvent.click(screen.getByRole('button', { name: /deposit/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+
+  it('disables submit button during submission', async () => {
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/DepositFunds', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        return HttpResponse.json({})
+      }),
+    )
+
+    renderDepositDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '100.00')
+    await userEvent.click(screen.getByRole('button', { name: /deposit/i }))
+
+    expect(screen.getByRole('button', { name: /depositing|deposit/i })).toBeDisabled()
+  })
+})
+
+describe('DepositDialog - cancel', () => {
+  it('calls onOpenChange(false) when cancel clicked', async () => {
+    const onOpenChange = vi.fn()
+    renderDepositDialog({ onOpenChange })
+
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/frontend/src/pages/accounts/deposit-dialog.tsx
+++ b/frontend/src/pages/accounts/deposit-dialog.tsx
@@ -22,9 +22,17 @@ interface DepositDialogProps {
 }
 
 function validateAmount(value: string): string | null {
-  if (!value.trim()) return 'Amount is required'
-  if (isNaN(parseFloat(value))) return 'Invalid amount'
-  if (parseFloat(value) <= 0) return 'Amount must be greater than zero'
+  const trimmed = value.trim()
+  if (!trimmed) return 'Amount is required'
+  try {
+    const minorUnits = amountToBigInt(trimmed)
+    if (minorUnits <= 0n) return 'Amount must be greater than zero'
+  } catch (err) {
+    // amountToBigInt throws 'Amount must be positive' for negative values
+    const msg = err instanceof Error ? err.message : 'Invalid amount'
+    if (msg === 'Amount must be positive') return 'Amount must be greater than zero'
+    return 'Invalid amount'
+  }
   return null
 }
 

--- a/frontend/src/pages/accounts/deposit-dialog.tsx
+++ b/frontend/src/pages/accounts/deposit-dialog.tsx
@@ -1,0 +1,159 @@
+import * as React from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useTenantContext } from '@/contexts/tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import { amountToBigInt } from './account-form-utils'
+
+interface DepositDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  accountId: string
+  currency: string
+}
+
+function validateAmount(value: string): string | null {
+  if (!value.trim()) return 'Amount is required'
+  if (isNaN(parseFloat(value))) return 'Invalid amount'
+  if (parseFloat(value) <= 0) return 'Amount must be greater than zero'
+  return null
+}
+
+async function depositFunds(
+  tenantSlug: string,
+  accountId: string,
+  amountMinorUnits: string,
+): Promise<void> {
+  const response = await fetch(
+    `/api/meridian.current_account.v1.CurrentAccountService/DepositFunds`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Tenant-Slug': tenantSlug,
+      },
+      body: JSON.stringify({
+        accountId,
+        amount: { amount: amountMinorUnits },
+      }),
+    },
+  )
+
+  if (!response.ok) {
+    const data = (await response.json().catch(() => ({}))) as { message?: string }
+    throw new Error(data.message ?? `Failed to deposit: ${response.status}`)
+  }
+}
+
+export function DepositDialog({ open, onOpenChange, accountId, currency }: DepositDialogProps) {
+  const { tenantSlug } = useTenantContext()
+  const queryClient = useQueryClient()
+  const [amount, setAmount] = React.useState('')
+  const [amountError, setAmountError] = React.useState<string | null>(null)
+  const [serverError, setServerError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    if (!open) {
+      setAmount('')
+      setAmountError(null)
+      setServerError(null)
+    }
+  }, [open])
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      const minorUnits = amountToBigInt(amount).toString()
+      return depositFunds(tenantSlug ?? '', accountId, minorUnits)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: tenantKeys.account(tenantSlug ?? '', accountId),
+      })
+      onOpenChange(false)
+    },
+    onError: (error: Error) => {
+      setServerError(error.message)
+    },
+  })
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const error = validateAmount(amount)
+    if (error) {
+      setAmountError(error)
+      return
+    }
+    setAmountError(null)
+    setServerError(null)
+    mutation.mutate()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Deposit Funds</DialogTitle>
+          <DialogDescription>
+            Deposit funds into account {accountId} ({currency})
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="deposit-form">
+          <div className="space-y-4 py-2">
+            <div className="space-y-1">
+              <label htmlFor="deposit-amount" className="text-sm font-medium">
+                Amount ({currency})
+              </label>
+              <Input
+                id="deposit-amount"
+                value={amount}
+                onChange={(e) => {
+                  setAmount(e.target.value)
+                  if (amountError) setAmountError(null)
+                }}
+                placeholder="0.00"
+                type="text"
+                inputMode="decimal"
+                aria-describedby={amountError ? 'deposit-amount-error' : undefined}
+                aria-label="Amount"
+              />
+              {amountError && (
+                <p id="deposit-amount-error" className="text-sm text-destructive">
+                  {amountError}
+                </p>
+              )}
+            </div>
+
+            {serverError && (
+              <div role="alert" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                {serverError}
+              </div>
+            )}
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="deposit-form"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Depositing...' : 'Deposit'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/accounts/withdraw-dialog.test.tsx
+++ b/frontend/src/pages/accounts/withdraw-dialog.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/msw-handlers'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { WithdrawDialog } from './withdraw-dialog'
+
+const tenantToken = createTenantUserToken('tenant-test')
+
+function renderWithdrawDialog(props?: {
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  accountId?: string
+  currency?: string
+}) {
+  const {
+    open = true,
+    onOpenChange = vi.fn(),
+    accountId = 'acct-001',
+    currency = 'GBP',
+  } = props ?? {}
+  return renderWithProviders(
+    <MemoryRouter>
+      <WithdrawDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        accountId={accountId}
+        currency={currency}
+      />
+    </MemoryRouter>,
+    { initialToken: tenantToken },
+  )
+}
+
+describe('WithdrawDialog - rendering', () => {
+  it('renders dialog when open', () => {
+    renderWithdrawDialog()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('renders dialog title', () => {
+    renderWithdrawDialog()
+    expect(screen.getAllByText(/withdraw/i).length).toBeGreaterThan(0)
+  })
+
+  it('renders amount input on step 1', () => {
+    renderWithdrawDialog()
+    expect(screen.getByLabelText(/amount/i)).toBeInTheDocument()
+  })
+
+  it('renders initiate button on step 1', () => {
+    renderWithdrawDialog()
+    expect(screen.getByRole('button', { name: /initiate/i })).toBeInTheDocument()
+  })
+
+  it('does not render when closed', () => {
+    renderWithdrawDialog({ open: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})
+
+describe('WithdrawDialog - step 1 validation', () => {
+  it('shows error when amount is empty', async () => {
+    renderWithdrawDialog()
+    await userEvent.click(screen.getByRole('button', { name: /initiate/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/amount is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when amount is zero', async () => {
+    renderWithdrawDialog()
+    await userEvent.type(screen.getByLabelText(/amount/i), '0')
+    await userEvent.click(screen.getByRole('button', { name: /initiate/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/amount must be greater than zero/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when amount is negative', async () => {
+    renderWithdrawDialog()
+    await userEvent.type(screen.getByLabelText(/amount/i), '-5')
+    await userEvent.click(screen.getByRole('button', { name: /initiate/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/amount must be greater than zero/i)).toBeInTheDocument()
+    })
+  })
+})
+
+describe('WithdrawDialog - two-step flow', () => {
+  beforeEach(() => {
+    server.use(
+      http.post(
+        '*/meridian.current_account.v1.CurrentAccountService/InitiateWithdrawal',
+        () => HttpResponse.json({ withdrawalId: 'wdl-001' }),
+      ),
+      http.post(
+        '*/meridian.current_account.v1.CurrentAccountService/ExecuteWithdrawal',
+        () => HttpResponse.json({}),
+      ),
+    )
+  })
+
+  it('moves to step 2 after successful initiate', async () => {
+    renderWithdrawDialog()
+    await userEvent.type(screen.getByLabelText(/amount/i), '50.00')
+    await userEvent.click(screen.getByRole('button', { name: /initiate/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /confirm/i })).toBeInTheDocument()
+    })
+  })
+
+  it('shows confirmation details on step 2', async () => {
+    renderWithdrawDialog()
+    await userEvent.type(screen.getByLabelText(/amount/i), '50.00')
+    await userEvent.click(screen.getByRole('button', { name: /initiate/i }))
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/50/i).length).toBeGreaterThan(0)
+    })
+  })
+
+  it('calls execute mutation with withdrawalId on confirm', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post(
+        '*/meridian.current_account.v1.CurrentAccountService/InitiateWithdrawal',
+        () => HttpResponse.json({ withdrawalId: 'wdl-123' }),
+      ),
+      http.post(
+        '*/meridian.current_account.v1.CurrentAccountService/ExecuteWithdrawal',
+        async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({})
+        },
+      ),
+    )
+
+    renderWithdrawDialog()
+    await userEvent.type(screen.getByLabelText(/amount/i), '50.00')
+    await userEvent.click(screen.getByRole('button', { name: /initiate/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /confirm/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }))
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({ withdrawalId: 'wdl-123' })
+    })
+  })
+
+  it('closes dialog after successful execute', async () => {
+    const onOpenChange = vi.fn()
+    renderWithdrawDialog({ onOpenChange })
+
+    await userEvent.type(screen.getByLabelText(/amount/i), '50.00')
+    await userEvent.click(screen.getByRole('button', { name: /initiate/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /confirm/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }))
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('shows error when initiate fails', async () => {
+    server.use(
+      http.post(
+        '*/meridian.current_account.v1.CurrentAccountService/InitiateWithdrawal',
+        () => HttpResponse.json({ message: 'Insufficient balance' }, { status: 400 }),
+      ),
+    )
+
+    renderWithdrawDialog()
+    await userEvent.type(screen.getByLabelText(/amount/i), '50.00')
+    await userEvent.click(screen.getByRole('button', { name: /initiate/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('WithdrawDialog - cancel', () => {
+  it('calls onOpenChange(false) when cancel clicked', async () => {
+    const onOpenChange = vi.fn()
+    renderWithdrawDialog({ onOpenChange })
+
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/frontend/src/pages/accounts/withdraw-dialog.tsx
+++ b/frontend/src/pages/accounts/withdraw-dialog.tsx
@@ -1,0 +1,236 @@
+import * as React from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useTenantContext } from '@/contexts/tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import { amountToBigInt } from './account-form-utils'
+
+interface WithdrawDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  accountId: string
+  currency: string
+}
+
+type Step = 'initiate' | 'confirm'
+
+function validateAmount(value: string): string | null {
+  if (!value.trim()) return 'Amount is required'
+  if (isNaN(parseFloat(value))) return 'Invalid amount'
+  if (parseFloat(value) <= 0) return 'Amount must be greater than zero'
+  return null
+}
+
+async function initiateWithdrawal(
+  tenantSlug: string,
+  accountId: string,
+  amountMinorUnits: string,
+): Promise<string> {
+  const response = await fetch(
+    `/api/meridian.current_account.v1.CurrentAccountService/InitiateWithdrawal`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Tenant-Slug': tenantSlug,
+      },
+      body: JSON.stringify({
+        accountId,
+        amount: { amount: amountMinorUnits },
+      }),
+    },
+  )
+
+  if (!response.ok) {
+    const data = (await response.json().catch(() => ({}))) as { message?: string }
+    throw new Error(data.message ?? `Failed to initiate withdrawal: ${response.status}`)
+  }
+
+  const data = (await response.json()) as { withdrawalId: string }
+  return data.withdrawalId
+}
+
+async function executeWithdrawal(tenantSlug: string, withdrawalId: string): Promise<void> {
+  const response = await fetch(
+    `/api/meridian.current_account.v1.CurrentAccountService/ExecuteWithdrawal`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Tenant-Slug': tenantSlug,
+      },
+      body: JSON.stringify({ withdrawalId }),
+    },
+  )
+
+  if (!response.ok) {
+    const data = (await response.json().catch(() => ({}))) as { message?: string }
+    throw new Error(data.message ?? `Failed to execute withdrawal: ${response.status}`)
+  }
+}
+
+export function WithdrawDialog({ open, onOpenChange, accountId, currency }: WithdrawDialogProps) {
+  const { tenantSlug } = useTenantContext()
+  const queryClient = useQueryClient()
+  const [step, setStep] = React.useState<Step>('initiate')
+  const [amount, setAmount] = React.useState('')
+  const [amountError, setAmountError] = React.useState<string | null>(null)
+  const [serverError, setServerError] = React.useState<string | null>(null)
+  const [withdrawalId, setWithdrawalId] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    if (!open) {
+      setStep('initiate')
+      setAmount('')
+      setAmountError(null)
+      setServerError(null)
+      setWithdrawalId(null)
+    }
+  }, [open])
+
+  const initiateMutation = useMutation({
+    mutationFn: () => {
+      const minorUnits = amountToBigInt(amount).toString()
+      return initiateWithdrawal(tenantSlug ?? '', accountId, minorUnits)
+    },
+    onSuccess: (id) => {
+      setWithdrawalId(id)
+      setStep('confirm')
+    },
+    onError: (error: Error) => {
+      setServerError(error.message)
+    },
+  })
+
+  const executeMutation = useMutation({
+    mutationFn: () => {
+      return executeWithdrawal(tenantSlug ?? '', withdrawalId ?? '')
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: tenantKeys.account(tenantSlug ?? '', accountId),
+      })
+      onOpenChange(false)
+    },
+    onError: (error: Error) => {
+      setServerError(error.message)
+    },
+  })
+
+  function handleInitiate(e: React.FormEvent) {
+    e.preventDefault()
+    const error = validateAmount(amount)
+    if (error) {
+      setAmountError(error)
+      return
+    }
+    setAmountError(null)
+    setServerError(null)
+    initiateMutation.mutate()
+  }
+
+  function handleExecute(e: React.FormEvent) {
+    e.preventDefault()
+    setServerError(null)
+    executeMutation.mutate()
+  }
+
+  const isPending = initiateMutation.isPending || executeMutation.isPending
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Withdraw Funds</DialogTitle>
+          <DialogDescription>
+            {step === 'initiate'
+              ? `Initiate a withdrawal from account ${accountId} (${currency})`
+              : `Confirm withdrawal of ${currency} ${amount} from account ${accountId}`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {step === 'initiate' ? (
+          <form onSubmit={(e) => void handleInitiate(e)} id="withdraw-form">
+            <div className="space-y-4 py-2">
+              <div className="space-y-1">
+                <label htmlFor="withdraw-amount" className="text-sm font-medium">
+                  Amount ({currency})
+                </label>
+                <Input
+                  id="withdraw-amount"
+                  value={amount}
+                  onChange={(e) => {
+                    setAmount(e.target.value)
+                    if (amountError) setAmountError(null)
+                  }}
+                  placeholder="0.00"
+                  type="text"
+                  inputMode="decimal"
+                  aria-describedby={amountError ? 'withdraw-amount-error' : undefined}
+                  aria-label="Amount"
+                />
+                {amountError && (
+                  <p id="withdraw-amount-error" className="text-sm text-destructive">
+                    {amountError}
+                  </p>
+                )}
+              </div>
+
+              {serverError && (
+                <div role="alert" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                  {serverError}
+                </div>
+              )}
+            </div>
+          </form>
+        ) : (
+          <form onSubmit={(e) => void handleExecute(e)} id="withdraw-form">
+            <div className="space-y-4 py-2">
+              <p className="text-sm text-muted-foreground">
+                Please confirm the withdrawal details below:
+              </p>
+              <dl className="grid grid-cols-2 gap-2 text-sm">
+                <dt className="font-medium">Amount</dt>
+                <dd>{currency} {amount}</dd>
+                <dt className="font-medium">Account</dt>
+                <dd>{accountId}</dd>
+                <dt className="font-medium">Withdrawal ID</dt>
+                <dd className="font-mono text-xs">{withdrawalId}</dd>
+              </dl>
+
+              {serverError && (
+                <div role="alert" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                  {serverError}
+                </div>
+              )}
+            </div>
+          </form>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="withdraw-form"
+            disabled={isPending}
+          >
+            {step === 'initiate'
+              ? initiateMutation.isPending ? 'Initiating...' : 'Initiate'
+              : executeMutation.isPending ? 'Confirming...' : 'Confirm'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/accounts/withdraw-dialog.tsx
+++ b/frontend/src/pages/accounts/withdraw-dialog.tsx
@@ -24,9 +24,17 @@ interface WithdrawDialogProps {
 type Step = 'initiate' | 'confirm'
 
 function validateAmount(value: string): string | null {
-  if (!value.trim()) return 'Amount is required'
-  if (isNaN(parseFloat(value))) return 'Invalid amount'
-  if (parseFloat(value) <= 0) return 'Amount must be greater than zero'
+  const trimmed = value.trim()
+  if (!trimmed) return 'Amount is required'
+  try {
+    const minorUnits = amountToBigInt(trimmed)
+    if (minorUnits <= 0n) return 'Amount must be greater than zero'
+  } catch (err) {
+    // amountToBigInt throws 'Amount must be positive' for negative values
+    const msg = err instanceof Error ? err.message : 'Invalid amount'
+    if (msg === 'Amount must be positive') return 'Amount must be greater than zero'
+    return 'Invalid amount'
+  }
   return null
 }
 
@@ -84,6 +92,7 @@ async function executeWithdrawal(tenantSlug: string, withdrawalId: string): Prom
 export function WithdrawDialog({ open, onOpenChange, accountId, currency }: WithdrawDialogProps) {
   const { tenantSlug } = useTenantContext()
   const queryClient = useQueryClient()
+  const isOpenRef = React.useRef(open)
   const [step, setStep] = React.useState<Step>('initiate')
   const [amount, setAmount] = React.useState('')
   const [amountError, setAmountError] = React.useState<string | null>(null)
@@ -91,6 +100,7 @@ export function WithdrawDialog({ open, onOpenChange, accountId, currency }: With
   const [withdrawalId, setWithdrawalId] = React.useState<string | null>(null)
 
   React.useEffect(() => {
+    isOpenRef.current = open
     if (!open) {
       setStep('initiate')
       setAmount('')
@@ -106,10 +116,12 @@ export function WithdrawDialog({ open, onOpenChange, accountId, currency }: With
       return initiateWithdrawal(tenantSlug ?? '', accountId, minorUnits)
     },
     onSuccess: (id) => {
+      if (!isOpenRef.current) return
       setWithdrawalId(id)
       setStep('confirm')
     },
     onError: (error: Error) => {
+      if (!isOpenRef.current) return
       setServerError(error.message)
     },
   })
@@ -125,6 +137,7 @@ export function WithdrawDialog({ open, onOpenChange, accountId, currency }: With
       onOpenChange(false)
     },
     onError: (error: Error) => {
+      if (!isOpenRef.current) return
       setServerError(error.message)
     },
   })

--- a/frontend/src/pages/accounts/withdraw-dialog.tsx
+++ b/frontend/src/pages/accounts/withdraw-dialog.tsx
@@ -55,7 +55,10 @@ async function initiateWithdrawal(
     throw new Error(data.message ?? `Failed to initiate withdrawal: ${response.status}`)
   }
 
-  const data = (await response.json()) as { withdrawalId: string }
+  const data = (await response.json()) as { withdrawalId?: string }
+  if (!data.withdrawalId) {
+    throw new Error('Withdrawal ID missing from response')
+  }
   return data.withdrawalId
 }
 
@@ -140,6 +143,10 @@ export function WithdrawDialog({ open, onOpenChange, accountId, currency }: With
 
   function handleExecute(e: React.FormEvent) {
     e.preventDefault()
+    if (!withdrawalId) {
+      setServerError('Withdrawal ID missing. Please re-initiate the withdrawal.')
+      return
+    }
     setServerError(null)
     executeMutation.mutate()
   }
@@ -223,7 +230,7 @@ export function WithdrawDialog({ open, onOpenChange, accountId, currency }: With
           <Button
             type="submit"
             form="withdraw-form"
-            disabled={isPending}
+            disabled={isPending || (step === 'confirm' && !withdrawalId)}
           >
             {step === 'initiate'
               ? initiateMutation.isPending ? 'Initiating...' : 'Initiate'

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -27,6 +27,7 @@ function genStubPlugin(): Plugin {
     export const NodeService = { typeName: 'stub', methods: [] }
     export const InternalBankAccountService = { typeName: 'stub', methods: [] }
     export const MarketInformationService = { typeName: 'stub', methods: [] }
+    export const MappingService = { typeName: 'stub', methods: [] }
     export const ForecastingService = { typeName: 'stub', methods: [] }
     export const TransactionStatus = { UNSPECIFIED: 0, PENDING: 1, POSTED: 2, FAILED: 3, CANCELLED: 4, REVERSED: 5 }
     export const PostingDirection = { UNSPECIFIED: 0, DEBIT: 1, CREDIT: 2 }


### PR DESCRIPTION
## Summary

- Adds `DepositDialog` with amount validation and `DepositFunds` RPC call
- Adds `WithdrawDialog` with two-step initiate/execute flow (`InitiateWithdrawal` → `ExecuteWithdrawal`)
- Adds `ControlDialog` for freeze, unfreeze, and close account control actions
- Adds shared `account-form-utils` for BigInt minor unit conversion and currency formatting
- Integrates all dialogs into `AccountDetailPage` with conditional rendering based on account status

## Changes Made

- `frontend/src/pages/accounts/account-form-utils.ts` — shared utilities: `amountToBigInt`, `bigIntToDisplayAmount`, `formatCurrencyAmount`
- `frontend/src/pages/accounts/deposit-dialog.tsx` — deposit dialog with validation and mutation
- `frontend/src/pages/accounts/withdraw-dialog.tsx` — two-step withdrawal dialog
- `frontend/src/pages/accounts/control-dialog.tsx` — confirmation dialog for freeze/unfreeze/close
- `frontend/src/pages/accounts/[accountId].tsx` — integrates dialogs into `AccountActions` component
- `frontend/vitest.config.ts` — adds missing `MappingService` stub (fixes pre-existing test setup issue)

## Technical Details

**Dialog patterns:**
- Follow existing codebase pattern (tenant dialog pattern from `tenants/index.tsx`)
- Use `React.useState` for form state, manual validation (no zod — not installed)
- `useMutation` from TanStack Query, `invalidateQueries` on success
- `Dialog`, `DialogContent`, `DialogHeader`, `DialogFooter` from shadcn/ui

**API endpoints called:**
- `CurrentAccountService/DepositFunds` — deposit with `{ accountId, amount: { amount: <minor units string> } }`
- `CurrentAccountService/InitiateWithdrawal` — returns `{ withdrawalId }`
- `CurrentAccountService/ExecuteWithdrawal` — executes with `{ withdrawalId }`
- `CurrentAccountService/FreezeAccount` / `UnfreezeAccount` / `CloseAccount` — all take `{ accountId }`

**Conditional rendering:**
- `ACTIVE`: Deposit, Withdraw, Freeze, Close Account
- `FROZEN`: Unfreeze only
- `CLOSED` / `SUSPENDED`: No action buttons

## Testing

- TDD approach: tests written first (red), then implementation (green)
- 88 tests across 6 test files in `src/pages/accounts/`
- Tests cover: validation, mutation calls, BigInt conversion, two-step flow, dialog open/close, error states, disabled state during submission

## Risk Assessment

Low risk — new UI components only, no backend changes. All API calls use existing MSW-interceptable fetch pattern consistent with the rest of the codebase.

## Deployment Notes

No migration or configuration changes required.