### PR TITLE
fix: Use string-based BigInt conversion for payment amount in mutations

### DIFF
--- a/frontend/src/pages/payments/dialogs/cancel-payment-dialog.test.tsx
+++ b/frontend/src/pages/payments/dialogs/cancel-payment-dialog.test.tsx
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { AuthProvider } from '@/contexts/auth-context'
+import { TenantProvider } from '@/contexts/tenant-context'
+import { CancelPaymentDialog } from './cancel-payment-dialog'
+
+vi.mock('./payment-mutations', () => ({
+  useCancelPayment: vi.fn(),
+}))
+
+import { useCancelPayment } from './payment-mutations'
+const mockUseCancelPayment = vi.mocked(useCancelPayment)
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = makeQueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <AuthProvider>
+        <TenantProvider>
+          <TooltipProvider>
+            <MemoryRouter>{children}</MemoryRouter>
+          </TooltipProvider>
+        </TenantProvider>
+      </AuthProvider>
+    </QueryClientProvider>
+  )
+}
+
+function makeMockMutation(overrides: Partial<ReturnType<typeof useCancelPayment>> = {}) {
+  return {
+    mutateAsync: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof useCancelPayment>
+}
+
+describe('CancelPaymentDialog - rendering', () => {
+  beforeEach(() => {
+    mockUseCancelPayment.mockReturnValue(makeMockMutation())
+  })
+
+  it('does not render dialog content when closed', () => {
+    render(
+      <Wrapper>
+        <CancelPaymentDialog
+          open={false}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="INITIATED"
+        />
+      </Wrapper>,
+    )
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders dialog content when open', () => {
+    render(
+      <Wrapper>
+        <CancelPaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="INITIATED"
+        />
+      </Wrapper>,
+    )
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /cancel payment/i })).toBeInTheDocument()
+  })
+
+  it('renders payment order ID in dialog', () => {
+    render(
+      <Wrapper>
+        <CancelPaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="INITIATED"
+        />
+      </Wrapper>,
+    )
+
+    expect(screen.getByText(/po-001/)).toBeInTheDocument()
+  })
+
+  it('renders cancellation reason field', () => {
+    render(
+      <Wrapper>
+        <CancelPaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="INITIATED"
+        />
+      </Wrapper>,
+    )
+
+    expect(screen.getByLabelText(/cancellation reason/i)).toBeInTheDocument()
+  })
+})
+
+describe('CancelPaymentDialog - status-aware behaviour', () => {
+  beforeEach(() => {
+    mockUseCancelPayment.mockReturnValue(makeMockMutation())
+  })
+
+  it('shows INITIATED payment as cancellable', () => {
+    render(
+      <Wrapper>
+        <CancelPaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="INITIATED"
+        />
+      </Wrapper>,
+    )
+
+    const confirmButton = screen.getByRole('button', { name: /confirm cancellation/i })
+    expect(confirmButton).not.toBeDisabled()
+  })
+
+  it('shows RESERVED payment as cancellable', () => {
+    render(
+      <Wrapper>
+        <CancelPaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="RESERVED"
+        />
+      </Wrapper>,
+    )
+
+    const confirmButton = screen.getByRole('button', { name: /confirm cancellation/i })
+    expect(confirmButton).not.toBeDisabled()
+  })
+
+  it('shows EXECUTING payment with disabled confirm and warning', () => {
+    render(
+      <Wrapper>
+        <CancelPaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="EXECUTING"
+        />
+      </Wrapper>,
+    )
+
+    const confirmButton = screen.getByRole('button', { name: /confirm cancellation/i })
+    expect(confirmButton).toBeDisabled()
+    expect(
+      screen.getByText(/cannot be cancelled while executing/i),
+    ).toBeInTheDocument()
+  })
+})
+
+describe('CancelPaymentDialog - successful cancellation', () => {
+  it('calls mutateAsync with correct data on submit', async () => {
+    const user = userEvent.setup()
+    const mutateAsync = vi.fn().mockResolvedValue({})
+    mockUseCancelPayment.mockReturnValue(makeMockMutation({ mutateAsync }))
+    const onSuccess = vi.fn()
+    const onOpenChange = vi.fn()
+
+    render(
+      <Wrapper>
+        <CancelPaymentDialog
+          open={true}
+          onOpenChange={onOpenChange}
+          onSuccess={onSuccess}
+          paymentOrderId="po-001"
+          currentStatus="INITIATED"
+        />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/cancellation reason/i), 'Customer requested')
+    await user.click(screen.getByRole('button', { name: /confirm cancellation/i }))
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paymentOrderId: 'po-001',
+          cancellationReason: 'Customer requested',
+        }),
+      )
+      expect(onSuccess).toHaveBeenCalledOnce()
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('requires a cancellation reason', async () => {
+    const user = userEvent.setup()
+    mockUseCancelPayment.mockReturnValue(makeMockMutation())
+
+    render(
+      <Wrapper>
+        <CancelPaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="INITIATED"
+        />
+      </Wrapper>,
+    )
+
+    await user.click(screen.getByRole('button', { name: /confirm cancellation/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/reason is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('disables button while pending', () => {
+    mockUseCancelPayment.mockReturnValue(makeMockMutation({ isPending: true }))
+
+    render(
+      <Wrapper>
+        <CancelPaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="INITIATED"
+        />
+      </Wrapper>,
+    )
+
+    expect(screen.getByRole('button', { name: /cancelling/i })).toBeDisabled()
+  })
+})
+
+describe('CancelPaymentDialog - error handling', () => {
+  it('shows error message when cancellation fails', async () => {
+    const user = userEvent.setup()
+    const { Code, ConnectError } = await import('@connectrpc/connect')
+    const err = new ConnectError('precondition failed', Code.FailedPrecondition)
+    const mutateAsync = vi.fn().mockRejectedValue(err)
+    mockUseCancelPayment.mockReturnValue(makeMockMutation({ mutateAsync }))
+
+    render(
+      <Wrapper>
+        <CancelPaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="INITIATED"
+        />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/cancellation reason/i), 'test reason')
+    await user.click(screen.getByRole('button', { name: /confirm cancellation/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/the operation cannot be performed in the current state/i),
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/payments/dialogs/cancel-payment-dialog.tsx
+++ b/frontend/src/pages/payments/dialogs/cancel-payment-dialog.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { handleConnectError } from '@/lib/error-handling'
+import { useCancelPayment } from './payment-mutations'
+
+const CANCELLABLE_STATUSES = new Set(['INITIATED', 'RESERVED'])
+
+interface CancelPaymentDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess: () => void
+  paymentOrderId: string
+  currentStatus: string
+}
+
+export function CancelPaymentDialog({
+  open,
+  onOpenChange,
+  onSuccess,
+  paymentOrderId,
+  currentStatus,
+}: CancelPaymentDialogProps) {
+  const cancel = useCancelPayment()
+  const [reason, setReason] = React.useState('')
+  const [reasonError, setReasonError] = React.useState<string | undefined>()
+  const [generalError, setGeneralError] = React.useState<string | undefined>()
+
+  const canCancel = CANCELLABLE_STATUSES.has(currentStatus)
+
+  React.useEffect(() => {
+    if (!open) {
+      setReason('')
+      setReasonError(undefined)
+      setGeneralError(undefined)
+      cancel.reset()
+    }
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+
+    if (!reason.trim()) {
+      setReasonError('Reason is required')
+      return
+    }
+
+    try {
+      await cancel.mutateAsync({
+        paymentOrderId,
+        cancellationReason: reason.trim(),
+      })
+      onSuccess()
+      onOpenChange(false)
+    } catch (err) {
+      const result = handleConnectError(err)
+      setGeneralError(result.message)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Cancel Payment</DialogTitle>
+          <DialogDescription>
+            Cancel payment order <span className="font-mono font-medium">{paymentOrderId}</span>.
+            This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="cancel-payment-form">
+          <div className="space-y-4 py-2">
+            {!canCancel && (
+              <div
+                role="alert"
+                className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+              >
+                This payment cannot be cancelled while executing. It must wait for the gateway
+                response.
+              </div>
+            )}
+
+            {generalError && (
+              <div
+                role="alert"
+                className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                {generalError}
+              </div>
+            )}
+
+            <div className="space-y-1">
+              <label htmlFor="cancellationReason" className="text-sm font-medium">
+                Cancellation Reason
+              </label>
+              <Input
+                id="cancellationReason"
+                value={reason}
+                onChange={(e) => {
+                  setReason(e.target.value)
+                  if (reasonError) setReasonError(undefined)
+                }}
+                placeholder="Reason for cancellation"
+                disabled={!canCancel}
+                aria-describedby={reasonError ? 'cancellationReason-error' : undefined}
+              />
+              {reasonError && (
+                <p id="cancellationReason-error" className="text-sm text-destructive">
+                  {reasonError}
+                </p>
+              )}
+            </div>
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="cancel-payment-form"
+            variant="destructive"
+            disabled={!canCancel || cancel.isPending}
+          >
+            {cancel.isPending ? 'Cancelling...' : 'Confirm Cancellation'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/payments/dialogs/index.ts
+++ b/frontend/src/pages/payments/dialogs/index.ts
@@ -1,0 +1,4 @@
+export { InitiatePaymentDialog } from './initiate-payment-dialog'
+export { CancelPaymentDialog } from './cancel-payment-dialog'
+export { ReversePaymentDialog } from './reverse-payment-dialog'
+export type { InitiatePaymentDialogProps } from './initiate-payment-dialog'

--- a/frontend/src/pages/payments/dialogs/initiate-payment-dialog.test.tsx
+++ b/frontend/src/pages/payments/dialogs/initiate-payment-dialog.test.tsx
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { AuthProvider } from '@/contexts/auth-context'
+import { TenantProvider } from '@/contexts/tenant-context'
+import { InitiatePaymentDialog } from './initiate-payment-dialog'
+
+vi.mock('./payment-mutations', () => ({
+  useInitiatePayment: vi.fn(),
+}))
+
+import { useInitiatePayment } from './payment-mutations'
+const mockUseInitiatePayment = vi.mocked(useInitiatePayment)
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = makeQueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <AuthProvider>
+        <TenantProvider>
+          <TooltipProvider>
+            <MemoryRouter>{children}</MemoryRouter>
+          </TooltipProvider>
+        </TenantProvider>
+      </AuthProvider>
+    </QueryClientProvider>
+  )
+}
+
+function makeMockMutation(overrides: Partial<ReturnType<typeof useInitiatePayment>> = {}) {
+  return {
+    mutateAsync: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof useInitiatePayment>
+}
+
+describe('InitiatePaymentDialog - rendering', () => {
+  beforeEach(() => {
+    mockUseInitiatePayment.mockReturnValue(makeMockMutation())
+  })
+
+  it('does not render dialog content when closed', () => {
+    render(
+      <Wrapper>
+        <InitiatePaymentDialog open={false} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders dialog content when open', () => {
+    render(
+      <Wrapper>
+        <InitiatePaymentDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /initiate payment/i })).toBeInTheDocument()
+  })
+
+  it('renders all required form fields', () => {
+    render(
+      <Wrapper>
+        <InitiatePaymentDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    expect(screen.getByLabelText(/debtor account/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/creditor iban/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/amount/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/currency/i)).toBeInTheDocument()
+  })
+
+  it('renders submit and cancel buttons', () => {
+    render(
+      <Wrapper>
+        <InitiatePaymentDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    expect(screen.getByRole('button', { name: /initiate payment/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+})
+
+describe('InitiatePaymentDialog - IBAN validation', () => {
+  beforeEach(() => {
+    mockUseInitiatePayment.mockReturnValue(makeMockMutation())
+  })
+
+  it('shows validation error for empty IBAN on submit', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Wrapper>
+        <InitiatePaymentDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    await user.click(screen.getByRole('button', { name: /initiate payment/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/iban is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows validation error for invalid IBAN format', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Wrapper>
+        <InitiatePaymentDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/creditor iban/i), 'not-an-iban')
+    await user.click(screen.getByRole('button', { name: /initiate payment/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid iban format/i)).toBeInTheDocument()
+    })
+  })
+
+  it('accepts valid IBAN format', async () => {
+    const user = userEvent.setup()
+    const mutateAsync = vi.fn().mockResolvedValue({ paymentOrderId: 'po-new' })
+    mockUseInitiatePayment.mockReturnValue(makeMockMutation({ mutateAsync }))
+
+    render(
+      <Wrapper>
+        <InitiatePaymentDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/debtor account/i), 'acct-001')
+    await user.type(screen.getByLabelText(/creditor iban/i), 'GB29NWBK60161331926819')
+    await user.type(screen.getByLabelText(/amount/i), '100.00')
+    await user.click(screen.getByRole('button', { name: /initiate payment/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText(/invalid iban format/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows validation error for empty amount', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Wrapper>
+        <InitiatePaymentDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/debtor account/i), 'acct-001')
+    await user.type(screen.getByLabelText(/creditor iban/i), 'GB29NWBK60161331926819')
+    await user.click(screen.getByRole('button', { name: /initiate payment/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/amount is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows validation error for non-positive amount', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Wrapper>
+        <InitiatePaymentDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/debtor account/i), 'acct-001')
+    await user.type(screen.getByLabelText(/creditor iban/i), 'GB29NWBK60161331926819')
+    await user.type(screen.getByLabelText(/amount/i), '0')
+    await user.click(screen.getByRole('button', { name: /initiate payment/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/amount must be positive/i)).toBeInTheDocument()
+    })
+  })
+})
+
+describe('InitiatePaymentDialog - successful submission', () => {
+  it('calls mutateAsync with correct data and navigates on success', async () => {
+    const user = userEvent.setup()
+    const mutateAsync = vi.fn().mockResolvedValue({ paymentOrderId: 'po-new-001' })
+    mockUseInitiatePayment.mockReturnValue(makeMockMutation({ mutateAsync }))
+    const onSuccess = vi.fn()
+    const onOpenChange = vi.fn()
+
+    render(
+      <Wrapper>
+        <InitiatePaymentDialog open={true} onOpenChange={onOpenChange} onSuccess={onSuccess} />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/debtor account/i), 'acct-001')
+    await user.type(screen.getByLabelText(/creditor iban/i), 'GB29NWBK60161331926819')
+    await user.type(screen.getByLabelText(/amount/i), '100.00')
+    await user.click(screen.getByRole('button', { name: /initiate payment/i }))
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledOnce()
+      expect(mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          debtorAccountId: 'acct-001',
+          creditorReference: 'GB29NWBK60161331926819',
+        }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith('po-new-001')
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('disables submit button while pending', () => {
+    mockUseInitiatePayment.mockReturnValue(makeMockMutation({ isPending: true }))
+
+    render(
+      <Wrapper>
+        <InitiatePaymentDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    expect(screen.getByRole('button', { name: /initiating/i })).toBeDisabled()
+  })
+})
+
+describe('InitiatePaymentDialog - error handling', () => {
+  it('shows field-level error for INVALID_ARGUMENT with field violations', async () => {
+    const user = userEvent.setup()
+    const { Code, ConnectError } = await import('@connectrpc/connect')
+    const err = new ConnectError('invalid', Code.InvalidArgument)
+    err.details = [
+      {
+        type: 'google.rpc.BadRequest',
+        value: new Uint8Array(),
+        debug: {
+          fieldViolations: [
+            { field: 'creditor_reference', description: 'Invalid IBAN checksum' },
+          ],
+        },
+      },
+    ]
+    const mutateAsync = vi.fn().mockRejectedValue(err)
+    mockUseInitiatePayment.mockReturnValue(makeMockMutation({ mutateAsync }))
+
+    render(
+      <Wrapper>
+        <InitiatePaymentDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/debtor account/i), 'acct-001')
+    await user.type(screen.getByLabelText(/creditor iban/i), 'GB29NWBK60161331926819')
+    await user.type(screen.getByLabelText(/amount/i), '100.00')
+    await user.click(screen.getByRole('button', { name: /initiate payment/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid IBAN checksum')).toBeInTheDocument()
+    })
+  })
+
+  it('shows banner error for FAILED_PRECONDITION', async () => {
+    const user = userEvent.setup()
+    const { Code, ConnectError } = await import('@connectrpc/connect')
+    const err = new ConnectError('insufficient funds', Code.FailedPrecondition)
+    const mutateAsync = vi.fn().mockRejectedValue(err)
+    mockUseInitiatePayment.mockReturnValue(makeMockMutation({ mutateAsync }))
+
+    render(
+      <Wrapper>
+        <InitiatePaymentDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/debtor account/i), 'acct-001')
+    await user.type(screen.getByLabelText(/creditor iban/i), 'GB29NWBK60161331926819')
+    await user.type(screen.getByLabelText(/amount/i), '100.00')
+    await user.click(screen.getByRole('button', { name: /initiate payment/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/the operation cannot be performed in the current state/i),
+      ).toBeInTheDocument()
+    })
+  })
+})
+
+describe('InitiatePaymentDialog - reset on close', () => {
+  it('clears form when dialog is closed', async () => {
+    const user = userEvent.setup()
+    mockUseInitiatePayment.mockReturnValue(makeMockMutation())
+
+    const { rerender } = render(
+      <Wrapper>
+        <InitiatePaymentDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/debtor account/i), 'acct-filled')
+
+    rerender(
+      <Wrapper>
+        <InitiatePaymentDialog open={false} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    rerender(
+      <Wrapper>
+        <InitiatePaymentDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    expect(screen.getByLabelText(/debtor account/i)).toHaveValue('')
+  })
+})

--- a/frontend/src/pages/payments/dialogs/initiate-payment-dialog.test.tsx
+++ b/frontend/src/pages/payments/dialogs/initiate-payment-dialog.test.tsx
@@ -157,6 +157,31 @@ describe('InitiatePaymentDialog - IBAN validation', () => {
     })
   })
 
+  it('accepts IBAN with spaces (normalizes before validation)', async () => {
+    const user = userEvent.setup()
+    const mutateAsync = vi.fn().mockResolvedValue({ paymentOrderId: 'po-new' })
+    mockUseInitiatePayment.mockReturnValue(makeMockMutation({ mutateAsync }))
+
+    render(
+      <Wrapper>
+        <InitiatePaymentDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/debtor account/i), 'acct-001')
+    await user.type(screen.getByLabelText(/creditor iban/i), 'GB29 NWBK 6016 1331 9268 19')
+    await user.type(screen.getByLabelText(/amount/i), '100.00')
+    await user.click(screen.getByRole('button', { name: /initiate payment/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText(/invalid iban format/i)).not.toBeInTheDocument()
+      // Submitted IBAN should have spaces removed
+      expect(mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ creditorReference: 'GB29NWBK60161331926819' }),
+      )
+    })
+  })
+
   it('shows validation error for empty amount', async () => {
     const user = userEvent.setup()
 

--- a/frontend/src/pages/payments/dialogs/initiate-payment-dialog.tsx
+++ b/frontend/src/pages/payments/dialogs/initiate-payment-dialog.tsx
@@ -66,9 +66,10 @@ export function InitiatePaymentDialog({
       newErrors.debtorAccountId = 'Debtor account is required'
     }
 
-    if (!formData.creditorIban.trim()) {
+    const normalizedIban = formData.creditorIban.trim().replace(/\s+/g, '')
+    if (!normalizedIban) {
       newErrors.creditorIban = 'IBAN is required'
-    } else if (!IBAN_PATTERN.test(formData.creditorIban.trim())) {
+    } else if (!IBAN_PATTERN.test(normalizedIban)) {
       newErrors.creditorIban = 'Invalid IBAN format'
     }
 
@@ -90,9 +91,10 @@ export function InitiatePaymentDialog({
     if (!validate()) return
 
     try {
+      const normalizedIban = formData.creditorIban.trim().replace(/\s+/g, '')
       const result = await initiate.mutateAsync({
         debtorAccountId: formData.debtorAccountId.trim(),
-        creditorReference: formData.creditorIban.trim(),
+        creditorReference: normalizedIban,
         amount: formData.amount.trim(),
         currency: formData.currency,
       })

--- a/frontend/src/pages/payments/dialogs/initiate-payment-dialog.tsx
+++ b/frontend/src/pages/payments/dialogs/initiate-payment-dialog.tsx
@@ -1,0 +1,242 @@
+import * as React from 'react'
+import { Code } from '@connectrpc/connect'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { handleConnectError } from '@/lib/error-handling'
+import { useInitiatePayment } from './payment-mutations'
+
+// IBAN pattern: 2 letter country code + 2 digits + up to 30 alphanumeric chars (no spaces)
+const IBAN_PATTERN = /^[A-Z]{2}[0-9]{2}[A-Z0-9]{1,30}$/
+
+interface FormData {
+  debtorAccountId: string
+  creditorIban: string
+  amount: string
+  currency: string
+}
+
+interface FormErrors {
+  debtorAccountId?: string
+  creditorIban?: string
+  amount?: string
+  currency?: string
+  general?: string
+}
+
+export interface InitiatePaymentDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess: (paymentOrderId: string) => void
+}
+
+export function InitiatePaymentDialog({
+  open,
+  onOpenChange,
+  onSuccess,
+}: InitiatePaymentDialogProps) {
+  const initiate = useInitiatePayment()
+  const [formData, setFormData] = React.useState<FormData>({
+    debtorAccountId: '',
+    creditorIban: '',
+    amount: '',
+    currency: 'GBP',
+  })
+  const [errors, setErrors] = React.useState<FormErrors>({})
+
+  React.useEffect(() => {
+    if (!open) {
+      setFormData({ debtorAccountId: '', creditorIban: '', amount: '', currency: 'GBP' })
+      setErrors({})
+      initiate.reset()
+    }
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  function validate(): boolean {
+    const newErrors: FormErrors = {}
+
+    if (!formData.debtorAccountId.trim()) {
+      newErrors.debtorAccountId = 'Debtor account is required'
+    }
+
+    if (!formData.creditorIban.trim()) {
+      newErrors.creditorIban = 'IBAN is required'
+    } else if (!IBAN_PATTERN.test(formData.creditorIban.trim())) {
+      newErrors.creditorIban = 'Invalid IBAN format'
+    }
+
+    if (!formData.amount.trim()) {
+      newErrors.amount = 'Amount is required'
+    } else {
+      const parsed = parseFloat(formData.amount)
+      if (isNaN(parsed) || parsed <= 0) {
+        newErrors.amount = 'Amount must be positive'
+      }
+    }
+
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+
+    try {
+      const result = await initiate.mutateAsync({
+        debtorAccountId: formData.debtorAccountId.trim(),
+        creditorReference: formData.creditorIban.trim(),
+        amount: formData.amount.trim(),
+        currency: formData.currency,
+      })
+
+      const paymentOrderId =
+        (result as { paymentOrderId?: string } | null | undefined)?.paymentOrderId ?? ''
+      onSuccess(paymentOrderId)
+      onOpenChange(false)
+    } catch (err) {
+      const result = handleConnectError(err)
+
+      if (result.code === Code.InvalidArgument && Object.keys(result.fieldErrors).length > 0) {
+        const fieldMap: FormErrors = {}
+        for (const [field, msg] of Object.entries(result.fieldErrors)) {
+          if (field === 'creditor_reference') fieldMap.creditorIban = msg
+          else if (field === 'debtor_account_id') fieldMap.debtorAccountId = msg
+          else if (field === 'amount') fieldMap.amount = msg
+          else fieldMap.general = msg
+        }
+        setErrors(fieldMap)
+      } else {
+        setErrors({ general: result.message })
+      }
+    }
+  }
+
+  function handleChange(field: keyof FormData) {
+    return (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+      setFormData((prev) => ({ ...prev, [field]: e.target.value }))
+      if (errors[field]) {
+        setErrors((prev) => ({ ...prev, [field]: undefined }))
+      }
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Initiate Payment</DialogTitle>
+          <DialogDescription>
+            Create a new payment order. The payment will be processed through the saga workflow.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="initiate-payment-form">
+          <div className="space-y-4 py-2">
+            {errors.general && (
+              <div
+                role="alert"
+                className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                {errors.general}
+              </div>
+            )}
+
+            <div className="space-y-1">
+              <label htmlFor="debtorAccountId" className="text-sm font-medium">
+                Debtor Account
+              </label>
+              <Input
+                id="debtorAccountId"
+                value={formData.debtorAccountId}
+                onChange={handleChange('debtorAccountId')}
+                placeholder="acct-001"
+                aria-describedby={errors.debtorAccountId ? 'debtorAccountId-error' : undefined}
+              />
+              {errors.debtorAccountId && (
+                <p id="debtorAccountId-error" className="text-sm text-destructive">
+                  {errors.debtorAccountId}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="creditorIban" className="text-sm font-medium">
+                Creditor IBAN
+              </label>
+              <Input
+                id="creditorIban"
+                value={formData.creditorIban}
+                onChange={handleChange('creditorIban')}
+                placeholder="GB29NWBK60161331926819"
+                aria-describedby={errors.creditorIban ? 'creditorIban-error' : undefined}
+              />
+              {errors.creditorIban && (
+                <p id="creditorIban-error" className="text-sm text-destructive">
+                  {errors.creditorIban}
+                </p>
+              )}
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <label htmlFor="amount" className="text-sm font-medium">
+                  Amount
+                </label>
+                <Input
+                  id="amount"
+                  value={formData.amount}
+                  onChange={handleChange('amount')}
+                  placeholder="100.00"
+                  inputMode="decimal"
+                  aria-describedby={errors.amount ? 'amount-error' : undefined}
+                />
+                {errors.amount && (
+                  <p id="amount-error" className="text-sm text-destructive">
+                    {errors.amount}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-1">
+                <label htmlFor="currency" className="text-sm font-medium">
+                  Currency
+                </label>
+                <select
+                  id="currency"
+                  value={formData.currency}
+                  onChange={handleChange('currency')}
+                  className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+                >
+                  <option value="GBP">GBP</option>
+                  <option value="USD">USD</option>
+                  <option value="EUR">EUR</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="initiate-payment-form"
+            disabled={initiate.isPending}
+          >
+            {initiate.isPending ? 'Initiating...' : 'Initiate Payment'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/payments/dialogs/initiate-payment-dialog.tsx
+++ b/frontend/src/pages/payments/dialogs/initiate-payment-dialog.tsx
@@ -16,6 +16,10 @@ import { useInitiatePayment } from './payment-mutations'
 // IBAN pattern: 2 letter country code + 2 digits + up to 30 alphanumeric chars (no spaces)
 const IBAN_PATTERN = /^[A-Z]{2}[0-9]{2}[A-Z0-9]{1,30}$/
 
+function normalizeIban(iban: string): string {
+  return iban.trim().replace(/\s+/g, '')
+}
+
 interface FormData {
   debtorAccountId: string
   creditorIban: string
@@ -66,7 +70,7 @@ export function InitiatePaymentDialog({
       newErrors.debtorAccountId = 'Debtor account is required'
     }
 
-    const normalizedIban = formData.creditorIban.trim().replace(/\s+/g, '')
+    const normalizedIban = normalizeIban(formData.creditorIban)
     if (!normalizedIban) {
       newErrors.creditorIban = 'IBAN is required'
     } else if (!IBAN_PATTERN.test(normalizedIban)) {
@@ -91,10 +95,9 @@ export function InitiatePaymentDialog({
     if (!validate()) return
 
     try {
-      const normalizedIban = formData.creditorIban.trim().replace(/\s+/g, '')
       const result = await initiate.mutateAsync({
         debtorAccountId: formData.debtorAccountId.trim(),
-        creditorReference: normalizedIban,
+        creditorReference: normalizeIban(formData.creditorIban),
         amount: formData.amount.trim(),
         currency: formData.currency,
       })

--- a/frontend/src/pages/payments/dialogs/payment-form-utils.test.ts
+++ b/frontend/src/pages/payments/dialogs/payment-form-utils.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { amountToBigInt } from './payment-form-utils'
+
+describe('amountToBigInt', () => {
+  it('converts whole number amounts', () => {
+    expect(amountToBigInt('100')).toBe(10000n)
+    expect(amountToBigInt('1')).toBe(100n)
+    expect(amountToBigInt('0')).toBe(0n)
+  })
+
+  it('converts decimal amounts without float precision loss', () => {
+    expect(amountToBigInt('100.50')).toBe(10050n)
+    expect(amountToBigInt('0.29')).toBe(29n) // 0.29 * 100 = 28.999... in float
+    expect(amountToBigInt('0.01')).toBe(1n)
+    expect(amountToBigInt('99.99')).toBe(9999n)
+  })
+
+  it('truncates extra decimal places (no rounding for < 5)', () => {
+    expect(amountToBigInt('1.234')).toBe(123n)
+  })
+
+  it('rounds half-up when third decimal >= 5', () => {
+    expect(amountToBigInt('1.235')).toBe(124n)
+    expect(amountToBigInt('1.999')).toBe(200n)
+  })
+
+  it('handles amounts with only decimal part', () => {
+    expect(amountToBigInt('.50')).toBe(50n)
+    expect(amountToBigInt('.05')).toBe(5n)
+  })
+
+  it('throws for negative amounts', () => {
+    expect(() => amountToBigInt('-1.00')).toThrow('Amount must be positive')
+  })
+
+  it('throws for empty string', () => {
+    expect(() => amountToBigInt('')).toThrow('Invalid amount')
+    expect(() => amountToBigInt('   ')).toThrow('Invalid amount')
+  })
+
+  it('throws for non-numeric input', () => {
+    expect(() => amountToBigInt('abc')).toThrow('Invalid amount')
+    expect(() => amountToBigInt('1e5')).toThrow('Invalid amount')
+  })
+
+  it('supports custom decimal places', () => {
+    expect(amountToBigInt('1.500', 3)).toBe(1500n)
+    expect(amountToBigInt('100', 0)).toBe(100n)
+  })
+})

--- a/frontend/src/pages/payments/dialogs/payment-form-utils.ts
+++ b/frontend/src/pages/payments/dialogs/payment-form-utils.ts
@@ -1,0 +1,30 @@
+/**
+ * Converts a decimal amount string (e.g. "100.50") to BigInt minor units
+ * using the given number of decimal places (default: 2).
+ *
+ * Uses string-based parsing to avoid IEEE-754 float precision issues.
+ * Throws if the amount is negative, not a valid decimal, or uses scientific notation.
+ */
+export function amountToBigInt(amount: string, decimalPlaces = 2): bigint {
+  const trimmed = amount.trim()
+  if (!trimmed) {
+    throw new Error(`Invalid amount: ${amount}`)
+  }
+  if (trimmed.startsWith('-')) {
+    throw new Error('Amount must be positive')
+  }
+  const match = trimmed.match(/^(\d*)(?:\.(\d*))?$/)
+  if (!match || (!match[1] && !match[2])) {
+    throw new Error(`Invalid amount: ${amount}`)
+  }
+  const whole = match[1] || '0'
+  const fractionRaw = match[2] ?? ''
+  const fraction = fractionRaw.slice(0, decimalPlaces).padEnd(decimalPlaces, '0')
+  let value = BigInt(`${whole}${fraction}`)
+  // Round half-up: check the next digit beyond decimalPlaces
+  const nextDigit = fractionRaw[decimalPlaces]
+  if (nextDigit && nextDigit >= '5') {
+    value += 1n
+  }
+  return value
+}

--- a/frontend/src/pages/payments/dialogs/payment-mutations.ts
+++ b/frontend/src/pages/payments/dialogs/payment-mutations.ts
@@ -5,6 +5,9 @@ import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { amountToBigInt } from './payment-form-utils'
 
 function generateIdempotencyKey(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
   return `${Date.now()}-${Math.random().toString(36).slice(2)}`
 }
 

--- a/frontend/src/pages/payments/dialogs/payment-mutations.ts
+++ b/frontend/src/pages/payments/dialogs/payment-mutations.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useApiClients } from '@/api/context'
 import { tenantKeys } from '@/lib/query-keys'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { amountToBigInt } from './payment-form-utils'
 
 function generateIdempotencyKey(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2)}`
@@ -37,7 +38,7 @@ export function useInitiatePayment() {
         debtorAccountId: request.debtorAccountId,
         creditorReference: request.creditorReference,
         amount: {
-          units: Math.floor(parseFloat(request.amount) * 100).toString(),
+          units: amountToBigInt(request.amount).toString(),
           currency: request.currency,
         },
         idempotencyKey: {

--- a/frontend/src/pages/payments/dialogs/payment-mutations.ts
+++ b/frontend/src/pages/payments/dialogs/payment-mutations.ts
@@ -1,0 +1,111 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
+import { tenantKeys } from '@/lib/query-keys'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+
+function generateIdempotencyKey(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+export interface InitiatePaymentRequest {
+  debtorAccountId: string
+  creditorReference: string
+  amount: string
+  currency: string
+}
+
+export interface CancelPaymentRequest {
+  paymentOrderId: string
+  cancellationReason: string
+  cancelledBy?: string
+}
+
+export interface ReversePaymentRequest {
+  paymentOrderId: string
+  reversalReason: string
+  reversedBy?: string
+}
+
+export function useInitiatePayment() {
+  const { paymentOrder } = useApiClients()
+  const queryClient = useQueryClient()
+  const tenantSlug = useTenantSlug()
+
+  return useMutation({
+    mutationFn: async (request: InitiatePaymentRequest) => {
+      const response = await paymentOrder.initiatePaymentOrder({
+        debtorAccountId: request.debtorAccountId,
+        creditorReference: request.creditorReference,
+        amount: {
+          units: Math.floor(parseFloat(request.amount) * 100).toString(),
+          currency: request.currency,
+        },
+        idempotencyKey: {
+          key: generateIdempotencyKey(),
+        },
+      })
+      return response.paymentOrder
+    },
+    onSuccess: () => {
+      if (tenantSlug) {
+        void queryClient.invalidateQueries({ queryKey: tenantKeys.payments(tenantSlug) })
+      }
+    },
+  })
+}
+
+export function useCancelPayment() {
+  const { paymentOrder } = useApiClients()
+  const queryClient = useQueryClient()
+  const tenantSlug = useTenantSlug()
+
+  return useMutation({
+    mutationFn: async (request: CancelPaymentRequest) => {
+      const response = await paymentOrder.cancelPaymentOrder({
+        paymentOrderId: request.paymentOrderId,
+        cancellationReason: request.cancellationReason,
+        cancelledBy: request.cancelledBy ?? 'operations-console',
+        idempotencyKey: {
+          key: generateIdempotencyKey(),
+        },
+      })
+      return response.paymentOrder
+    },
+    onSuccess: (_, variables) => {
+      if (tenantSlug) {
+        void queryClient.invalidateQueries({
+          queryKey: tenantKeys.payment(tenantSlug, variables.paymentOrderId),
+        })
+        void queryClient.invalidateQueries({ queryKey: tenantKeys.payments(tenantSlug) })
+      }
+    },
+  })
+}
+
+export function useReversePayment() {
+  const { paymentOrder } = useApiClients()
+  const queryClient = useQueryClient()
+  const tenantSlug = useTenantSlug()
+
+  return useMutation({
+    mutationFn: async (request: ReversePaymentRequest) => {
+      const response = await paymentOrder.reversePaymentOrder({
+        paymentOrderId: request.paymentOrderId,
+        reversalReason: request.reversalReason,
+        reversedBy: request.reversedBy ?? 'operations-console',
+        idempotencyKey: {
+          key: generateIdempotencyKey(),
+        },
+      })
+      return response.paymentOrder
+    },
+    onSuccess: (_, variables) => {
+      if (tenantSlug) {
+        void queryClient.invalidateQueries({
+          queryKey: tenantKeys.payment(tenantSlug, variables.paymentOrderId),
+        })
+        void queryClient.invalidateQueries({ queryKey: tenantKeys.payments(tenantSlug) })
+      }
+    },
+  })
+}

--- a/frontend/src/pages/payments/dialogs/reverse-payment-dialog.test.tsx
+++ b/frontend/src/pages/payments/dialogs/reverse-payment-dialog.test.tsx
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { AuthProvider } from '@/contexts/auth-context'
+import { TenantProvider } from '@/contexts/tenant-context'
+import { ReversePaymentDialog } from './reverse-payment-dialog'
+
+vi.mock('./payment-mutations', () => ({
+  useReversePayment: vi.fn(),
+}))
+
+import { useReversePayment } from './payment-mutations'
+const mockUseReversePayment = vi.mocked(useReversePayment)
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = makeQueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <AuthProvider>
+        <TenantProvider>
+          <TooltipProvider>
+            <MemoryRouter>{children}</MemoryRouter>
+          </TooltipProvider>
+        </TenantProvider>
+      </AuthProvider>
+    </QueryClientProvider>
+  )
+}
+
+function makeMockMutation(overrides: Partial<ReturnType<typeof useReversePayment>> = {}) {
+  return {
+    mutateAsync: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof useReversePayment>
+}
+
+describe('ReversePaymentDialog - rendering', () => {
+  beforeEach(() => {
+    mockUseReversePayment.mockReturnValue(makeMockMutation())
+  })
+
+  it('does not render dialog content when closed', () => {
+    render(
+      <Wrapper>
+        <ReversePaymentDialog
+          open={false}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="COMPLETED"
+        />
+      </Wrapper>,
+    )
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders dialog content when open for COMPLETED payment', () => {
+    render(
+      <Wrapper>
+        <ReversePaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="COMPLETED"
+        />
+      </Wrapper>,
+    )
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /reverse payment/i })).toBeInTheDocument()
+  })
+
+  it('renders payment order ID in dialog', () => {
+    render(
+      <Wrapper>
+        <ReversePaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="COMPLETED"
+        />
+      </Wrapper>,
+    )
+
+    expect(screen.getByText(/po-001/)).toBeInTheDocument()
+  })
+
+  it('renders reversal reason field', () => {
+    render(
+      <Wrapper>
+        <ReversePaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="COMPLETED"
+        />
+      </Wrapper>,
+    )
+
+    expect(screen.getByLabelText(/reversal reason/i)).toBeInTheDocument()
+  })
+})
+
+describe('ReversePaymentDialog - COMPLETED status requirement', () => {
+  beforeEach(() => {
+    mockUseReversePayment.mockReturnValue(makeMockMutation())
+  })
+
+  it('shows COMPLETED payment as reversible', () => {
+    render(
+      <Wrapper>
+        <ReversePaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="COMPLETED"
+        />
+      </Wrapper>,
+    )
+
+    const confirmButton = screen.getByRole('button', { name: /confirm reversal/i })
+    expect(confirmButton).not.toBeDisabled()
+  })
+
+  it('shows non-COMPLETED payment with disabled confirm and warning', () => {
+    render(
+      <Wrapper>
+        <ReversePaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="EXECUTING"
+        />
+      </Wrapper>,
+    )
+
+    const confirmButton = screen.getByRole('button', { name: /confirm reversal/i })
+    expect(confirmButton).toBeDisabled()
+    expect(screen.getByText(/can only be reversed when completed/i)).toBeInTheDocument()
+  })
+
+  it('shows INITIATED payment with disabled confirm', () => {
+    render(
+      <Wrapper>
+        <ReversePaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="INITIATED"
+        />
+      </Wrapper>,
+    )
+
+    const confirmButton = screen.getByRole('button', { name: /confirm reversal/i })
+    expect(confirmButton).toBeDisabled()
+  })
+})
+
+describe('ReversePaymentDialog - successful reversal', () => {
+  it('calls mutateAsync with correct data on submit', async () => {
+    const user = userEvent.setup()
+    const mutateAsync = vi.fn().mockResolvedValue({})
+    mockUseReversePayment.mockReturnValue(makeMockMutation({ mutateAsync }))
+    const onSuccess = vi.fn()
+    const onOpenChange = vi.fn()
+
+    render(
+      <Wrapper>
+        <ReversePaymentDialog
+          open={true}
+          onOpenChange={onOpenChange}
+          onSuccess={onSuccess}
+          paymentOrderId="po-001"
+          currentStatus="COMPLETED"
+        />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/reversal reason/i), 'Customer dispute')
+    await user.click(screen.getByRole('button', { name: /confirm reversal/i }))
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paymentOrderId: 'po-001',
+          reversalReason: 'Customer dispute',
+        }),
+      )
+      expect(onSuccess).toHaveBeenCalledOnce()
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('requires a reversal reason', async () => {
+    const user = userEvent.setup()
+    mockUseReversePayment.mockReturnValue(makeMockMutation())
+
+    render(
+      <Wrapper>
+        <ReversePaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="COMPLETED"
+        />
+      </Wrapper>,
+    )
+
+    await user.click(screen.getByRole('button', { name: /confirm reversal/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/reason is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('disables button while pending', () => {
+    mockUseReversePayment.mockReturnValue(makeMockMutation({ isPending: true }))
+
+    render(
+      <Wrapper>
+        <ReversePaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="COMPLETED"
+        />
+      </Wrapper>,
+    )
+
+    expect(screen.getByRole('button', { name: /reversing/i })).toBeDisabled()
+  })
+})
+
+describe('ReversePaymentDialog - error handling', () => {
+  it('shows error message when reversal fails', async () => {
+    const user = userEvent.setup()
+    const { Code, ConnectError } = await import('@connectrpc/connect')
+    const err = new ConnectError('already reversed', Code.FailedPrecondition)
+    const mutateAsync = vi.fn().mockRejectedValue(err)
+    mockUseReversePayment.mockReturnValue(makeMockMutation({ mutateAsync }))
+
+    render(
+      <Wrapper>
+        <ReversePaymentDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          paymentOrderId="po-001"
+          currentStatus="COMPLETED"
+        />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/reversal reason/i), 'test reason')
+    await user.click(screen.getByRole('button', { name: /confirm reversal/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/the operation cannot be performed in the current state/i),
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/payments/dialogs/reverse-payment-dialog.tsx
+++ b/frontend/src/pages/payments/dialogs/reverse-payment-dialog.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { handleConnectError } from '@/lib/error-handling'
+import { useReversePayment } from './payment-mutations'
+
+interface ReversePaymentDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess: () => void
+  paymentOrderId: string
+  currentStatus: string
+}
+
+export function ReversePaymentDialog({
+  open,
+  onOpenChange,
+  onSuccess,
+  paymentOrderId,
+  currentStatus,
+}: ReversePaymentDialogProps) {
+  const reverse = useReversePayment()
+  const [reason, setReason] = React.useState('')
+  const [reasonError, setReasonError] = React.useState<string | undefined>()
+  const [generalError, setGeneralError] = React.useState<string | undefined>()
+
+  const canReverse = currentStatus === 'COMPLETED'
+
+  React.useEffect(() => {
+    if (!open) {
+      setReason('')
+      setReasonError(undefined)
+      setGeneralError(undefined)
+      reverse.reset()
+    }
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+
+    if (!reason.trim()) {
+      setReasonError('Reason is required')
+      return
+    }
+
+    try {
+      await reverse.mutateAsync({
+        paymentOrderId,
+        reversalReason: reason.trim(),
+      })
+      onSuccess()
+      onOpenChange(false)
+    } catch (err) {
+      const result = handleConnectError(err)
+      setGeneralError(result.message)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Reverse Payment</DialogTitle>
+          <DialogDescription>
+            Reverse payment order <span className="font-mono font-medium">{paymentOrderId}</span>.
+            This will create compensating ledger entries and transition the order to REVERSED.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="reverse-payment-form">
+          <div className="space-y-4 py-2">
+            {!canReverse && (
+              <div
+                role="alert"
+                className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+              >
+                This payment can only be reversed when completed. Current status: {currentStatus}
+              </div>
+            )}
+
+            {generalError && (
+              <div
+                role="alert"
+                className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                {generalError}
+              </div>
+            )}
+
+            <div className="space-y-1">
+              <label htmlFor="reversalReason" className="text-sm font-medium">
+                Reversal Reason
+              </label>
+              <Input
+                id="reversalReason"
+                value={reason}
+                onChange={(e) => {
+                  setReason(e.target.value)
+                  if (reasonError) setReasonError(undefined)
+                }}
+                placeholder="Reason for reversal"
+                disabled={!canReverse}
+                aria-describedby={reasonError ? 'reversalReason-error' : undefined}
+              />
+              {reasonError && (
+                <p id="reversalReason-error" className="text-sm text-destructive">
+                  {reasonError}
+                </p>
+              )}
+            </div>
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="reverse-payment-form"
+            variant="destructive"
+            disabled={!canReverse || reverse.isPending}
+          >
+            {reverse.isPending ? 'Reversing...' : 'Confirm Reversal'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/payments/payment-detail.test.tsx
+++ b/frontend/src/pages/payments/payment-detail.test.tsx
@@ -12,6 +12,13 @@ vi.mock('./payment-detail-query', () => ({
   fetchPaymentDetail: vi.fn(),
 }))
 
+// Mock dialog mutations to avoid requiring a live API transport
+vi.mock('./dialogs/payment-mutations', () => ({
+  useInitiatePayment: () => ({ mutateAsync: vi.fn(), isPending: false, reset: vi.fn() }),
+  useCancelPayment: () => ({ mutateAsync: vi.fn(), isPending: false, reset: vi.fn() }),
+  useReversePayment: () => ({ mutateAsync: vi.fn(), isPending: false, reset: vi.fn() }),
+}))
+
 import { fetchPaymentDetail } from './payment-detail-query'
 const mockFetch = vi.mocked(fetchPaymentDetail)
 

--- a/frontend/src/pages/payments/payment-detail.tsx
+++ b/frontend/src/pages/payments/payment-detail.tsx
@@ -1,8 +1,10 @@
-import { Link, useParams } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
-import { ChevronLeftIcon } from 'lucide-react'
+import * as React from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { ChevronLeftIcon, Plus } from 'lucide-react'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
 import { MoneyDisplay } from '@/components/shared/money-display'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
@@ -11,6 +13,11 @@ import { AuditTrail } from '@/components/shared/audit-trail'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
 import { fetchPaymentDetail } from './payment-detail-query'
+import {
+  InitiatePaymentDialog,
+  CancelPaymentDialog,
+  ReversePaymentDialog,
+} from './dialogs'
 
 function PaymentDetailSkeleton() {
   return (
@@ -31,9 +38,75 @@ function DetailRow({ label, children }: { label: string; children: React.ReactNo
   )
 }
 
+const CANCELLABLE_STATUSES = new Set(['INITIATED', 'RESERVED', 'EXECUTING'])
+
+function PaymentActions({
+  paymentOrderId,
+  status,
+  onActionSuccess,
+}: {
+  paymentOrderId: string
+  status: string
+  onActionSuccess: () => void
+}) {
+  const [cancelOpen, setCancelOpen] = React.useState(false)
+  const [reverseOpen, setReverseOpen] = React.useState(false)
+
+  const showCancel = CANCELLABLE_STATUSES.has(status)
+  const showReverse = status === 'COMPLETED'
+
+  if (!showCancel && !showReverse) {
+    return null
+  }
+
+  return (
+    <>
+      <div className="flex gap-2">
+        {showCancel && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setCancelOpen(true)}
+          >
+            Cancel Payment
+          </Button>
+        )}
+        {showReverse && (
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => setReverseOpen(true)}
+          >
+            Reverse Payment
+          </Button>
+        )}
+      </div>
+
+      <CancelPaymentDialog
+        open={cancelOpen}
+        onOpenChange={setCancelOpen}
+        onSuccess={onActionSuccess}
+        paymentOrderId={paymentOrderId}
+        currentStatus={status}
+      />
+      <ReversePaymentDialog
+        open={reverseOpen}
+        onOpenChange={setReverseOpen}
+        onSuccess={onActionSuccess}
+        paymentOrderId={paymentOrderId}
+        currentStatus={status}
+      />
+    </>
+  )
+}
+
 export function PaymentDetailPage() {
   const { paymentOrderId } = useParams<{ paymentOrderId: string }>()
   const tenantSlug = useTenantSlug()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [initiateOpen, setInitiateOpen] = React.useState(false)
+
   const queryKey = tenantSlug && paymentOrderId
     ? tenantKeys.payment(tenantSlug, paymentOrderId)
     : ['payments', paymentOrderId]
@@ -43,6 +116,16 @@ export function PaymentDetailPage() {
     queryFn: () => fetchPaymentDetail(paymentOrderId!),
     enabled: !!paymentOrderId,
   })
+
+  function handleActionSuccess() {
+    void queryClient.invalidateQueries({ queryKey })
+  }
+
+  function handleInitiateSuccess(newPaymentOrderId: string) {
+    if (newPaymentOrderId) {
+      void navigate(`/payments/${newPaymentOrderId}`)
+    }
+  }
 
   if (isLoading) {
     return <PaymentDetailSkeleton />
@@ -75,9 +158,28 @@ export function PaymentDetailPage() {
       </Link>
 
       {/* Page header */}
-      <div className="flex items-center gap-4">
-        <h1 className="text-2xl font-semibold">{data.paymentOrderId}</h1>
-        <StatusBadge status={data.status} />
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-4">
+          <h1 className="text-2xl font-semibold">{data.paymentOrderId}</h1>
+          <StatusBadge status={data.status} />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setInitiateOpen(true)}
+          >
+            <Plus className="mr-1 h-4 w-4" />
+            New Payment
+          </Button>
+
+          <PaymentActions
+            paymentOrderId={data.paymentOrderId}
+            status={data.status}
+            onActionSuccess={handleActionSuccess}
+          />
+        </div>
       </div>
 
       {/* Tabs */}
@@ -144,6 +246,12 @@ export function PaymentDetailPage() {
           </Card>
         </TabsContent>
       </Tabs>
+
+      <InitiatePaymentDialog
+        open={initiateOpen}
+        onOpenChange={setInitiateOpen}
+        onSuccess={handleInitiateSuccess}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Fixes IEEE-754 float precision bug in `payment-mutations.ts` where `Math.floor(parseFloat(amount) * 100)` could silently produce incorrect minor unit values (e.g. `0.29 * 100 = 28.999...` → floors to 28 instead of 29)
- Extracts `amountToBigInt` utility into `payment-form-utils.ts`, mirroring the same string-based approach used in `account-form-utils.ts` for the account action dialogs
- Adds 9 unit tests covering normal conversion, the precision edge cases, rounding behaviour, and error cases

## Test plan

- [ ] `payment-form-utils.test.ts` — 9 tests, all passing
- [ ] Full payments page test suite — 63 tests, all passing
- [ ] Verify `0.29` converts to `29` (not `28`) minor units