### PR TITLE
Reduce CI feedback loop with test sharding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,12 @@ jobs:
       - name: Generate protobuf files
         run: buf generate
 
+      - name: Verify compilation
+        if: github.event_name == 'pull_request'
+        run: go build ./...
+
       - name: Run tests
+        if: github.event_name != 'pull_request'
         run: make test
 
       - name: Set up Docker Buildx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,12 @@ jobs:
           mkdir -p coverage
           # Split packages across 3 shards via round-robin for parallel execution
           shard_pkgs=$(go list ./... | awk "NR % 3 == ${{ matrix.shard_index }}")
-          pkg_count=$(echo "$shard_pkgs" | wc -l | tr -d ' ')
+          pkg_count=$(printf '%s\n' "$shard_pkgs" | sed '/^\s*$/d' | wc -l | tr -d ' ')
           echo "Shard ${{ matrix.shard_index }}/3: testing $pkg_count packages"
+          if [ -z "$shard_pkgs" ] || [ "$pkg_count" -eq 0 ]; then
+            echo "No packages in this shard, skipping"
+            exit 0
+          fi
           # Use -short flag to skip timing-sensitive tests in CI
           gotestsum --format testdox \
             --junitfile test-results.xml \
@@ -112,7 +116,15 @@ jobs:
       - name: Merge coverage from shards
         run: |
           mkdir -p coverage
-          gocovmerge coverage-shards/coverage-shard-*/coverage.out > coverage/coverage.out
+          shopt -s nullglob
+          cov_files=(coverage-shards/coverage-shard-*/coverage.out)
+          if [ ${#cov_files[@]} -eq 0 ]; then
+            echo "No coverage files found, creating empty profile"
+            echo "mode: atomic" > coverage/coverage.out
+            cp coverage/coverage.out coverage/coverage-filtered.out
+            exit 0
+          fi
+          gocovmerge "${cov_files[@]}" > coverage/coverage.out
           echo "Filtering generated proto files from coverage..."
           grep -v -E '\.pb\.go|\.pb\.validate\.go|_grpc\.pb\.go' coverage/coverage.out > coverage/coverage-filtered.out || true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,12 @@ permissions:
 
 jobs:
   test:
-    name: Run Tests
+    name: "Tests (shard ${{ matrix.shard_index }})"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard_index: [0, 1, 2]
 
     steps:
       - name: Checkout code
@@ -44,15 +48,71 @@ jobs:
           SKIP_KAFKA_TESTS: "1"
         run: |
           mkdir -p coverage
+          # Split packages across 3 shards via round-robin for parallel execution
+          shard_pkgs=$(go list ./... | awk "NR % 3 == ${{ matrix.shard_index }}")
+          pkg_count=$(echo "$shard_pkgs" | wc -l | tr -d ' ')
+          echo "Shard ${{ matrix.shard_index }}/3: testing $pkg_count packages"
           # Use -short flag to skip timing-sensitive tests in CI
-          # These tests validate exponential backoff, jitter, and timeouts which
-          # can be flaky due to CPU scheduler variance in CI environments.
-          # Functional correctness (retry attempts, error handling) is still validated.
-          # Run full test suite locally without -short for complete validation.
           gotestsum --format testdox \
             --junitfile test-results.xml \
             --jsonfile test-results.json \
-            -- -short -race -coverprofile=coverage/coverage.out -covermode=atomic ./...
+            -- -short -race -coverprofile=coverage/coverage.out -covermode=atomic $shard_pkgs
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: coverage-shard-${{ matrix.shard_index }}
+          path: coverage/coverage.out
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: test-results-shard-${{ matrix.shard_index }}
+          path: |
+            test-results.xml
+            test-results.json
+
+      - name: Test summary
+        uses: test-summary/action@v2
+        if: always()
+        with:
+          paths: test-results.xml
+
+      - name: Annotate failures
+        if: failure()
+        run: |
+          jq -r 'select(.Action == "fail" and .Test != null) | "::error file=\(.Package | sub("github.com/meridianhub/meridian/"; "")),line=1::\(.Test) failed"' test-results.json | sort -u || true
+
+  coverage:
+    name: Coverage Report
+    needs: test
+    runs-on: ubuntu-latest
+    if: always() && !cancelled()
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.0'
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v6
+        with:
+          pattern: coverage-shard-*
+          path: coverage-shards
+
+      - name: Install gocovmerge
+        run: go install github.com/wadey/gocovmerge@latest
+
+      - name: Merge coverage from shards
+        run: |
+          mkdir -p coverage
+          gocovmerge coverage-shards/coverage-shard-*/coverage.out > coverage/coverage.out
           echo "Filtering generated proto files from coverage..."
           grep -v -E '\.pb\.go|\.pb\.validate\.go|_grpc\.pb\.go' coverage/coverage.out > coverage/coverage-filtered.out || true
 
@@ -78,35 +138,29 @@ jobs:
 
       - name: Check test coverage threshold
         run: |
-          # Use filtered coverage (excludes generated .pb.go files)
           coverage=$(go tool cover -func=coverage/coverage-filtered.out | grep total | awk '{print $3}' | sed 's/%//')
           echo "Coverage (excluding generated proto files): ${coverage}%"
-          # Threshold for actual code (not including generated proto files)
-          # Raised to 50% after proto implementation with comprehensive tests
           if (( $(echo "$coverage < 50.0" | bc -l) )); then
             echo "❌ Coverage ${coverage}% is below 50% threshold"
             exit 1
           fi
           echo "✅ Coverage ${coverage}% meets threshold"
 
-      - name: Upload test results
-        uses: actions/upload-artifact@v6
-        if: always()
-        with:
-          name: test-results
-          path: |
-            test-results.xml
-            test-results.json
-
-      - name: Test summary
-        uses: test-summary/action@v2
-        if: always()
-        with:
-          paths: test-results.xml
-
-      - name: Annotate failures
-        if: failure()
+  # Gate job preserves the "Run Tests" check name for required status checks
+  test-gate:
+    name: Run Tests
+    needs: [test, coverage]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check results
         run: |
-          # gotestsum --jsonfile produces newline-delimited JSON (one object per line)
-          # Filter for test failures (not package-level) and deduplicate
-          jq -r 'select(.Action == "fail" and .Test != null) | "::error file=\(.Package | sub("github.com/meridianhub/meridian/"; "")),line=1::\(.Test) failed"' test-results.json | sort -u || true
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "Test shards failed"
+            exit 1
+          fi
+          if [ "${{ needs.coverage.result }}" != "success" ]; then
+            echo "Coverage check failed"
+            exit 1
+          fi
+          echo "All tests and coverage checks passed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,18 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26.0'
+          cache: true
+
+      - name: Set up buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate protobuf files
+        run: buf generate
+
+      - name: Download dependencies
+        run: go mod download
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           name: coverage-shard-${{ matrix.shard_index }}
           path: coverage/coverage.out
+          if-no-files-found: ignore
 
       - name: Upload test results
         uses: actions/upload-artifact@v6
@@ -77,10 +78,11 @@ jobs:
           path: |
             test-results.xml
             test-results.json
+          if-no-files-found: ignore
 
       - name: Test summary
         uses: test-summary/action@v2
-        if: always()
+        if: ${{ always() && hashFiles('test-results.xml') != '' }}
         with:
           paths: test-results.xml
 
@@ -123,7 +125,7 @@ jobs:
           path: coverage-shards
 
       - name: Install gocovmerge
-        run: go install github.com/wadey/gocovmerge@latest
+        run: go install github.com/wadey/gocovmerge@b5bfa59
 
       - name: Merge coverage from shards
         run: |


### PR DESCRIPTION
## Summary

- **Shard test.yml into 3 parallel jobs** — splits 230 packages via round-robin, each shard runs ~77 packages concurrently. Expected: ~21 min → ~7-8 min per shard.
- **Remove duplicate tests from build.yml on PRs** — test.yml already runs the full suite, so build.yml now does a compile-only check (`go build ./...`) on PRs. Full tests remain on push to develop/main before Docker image publication.

## What moved off the critical path

| Before | After |
|--------|-------|
| test.yml: 1 job, 230 pkgs, ~21 min | test.yml: 3 shards in parallel, ~7-8 min each |
| build.yml: full `make test` + Docker build on PRs | build.yml: compile check + Docker build on PRs |
| Coverage: inline in test job | Coverage: separate merge job (not on critical path) |

## Design decisions

- **Round-robin sharding** (`NR % 3`): Simple, deterministic, no maintenance. Testcontainer-heavy packages are spread across services alphabetically so distribution should be reasonable.
- **`gocovmerge`** for coverage: Correctly handles overlapping coverage data from shared packages tested across shards.
- **Gate job named "Run Tests"**: Preserves the existing required status check name so no repo settings changes needed.
- **`fail-fast: false`**: All shards complete even if one fails, so you see all failures at once.

## What this doesn't change

- Race detection still runs in all shards (can revisit moving to nightly if sharding alone is sufficient)
- Coverage threshold stays at 50%
- All other workflows (quality, security, proto, CodeQL) unchanged

## Test plan

- [ ] Verify all 3 test shards pass
- [ ] Verify coverage merge produces correct threshold check
- [ ] Verify "Run Tests" gate job reports correct status
- [ ] Verify build.yml skips tests on this PR but still builds Docker
- [ ] Compare total wall-clock time vs previous runs (~21 min baseline)