### PR TITLE
fix: Wire dashboard, update sidebar nav, seed sample parties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -517,7 +517,7 @@ dev-up: proto
 	@echo "  Once ready, services will be available at:"
 	@echo ""
 	@echo "    Meridian Console         http://localhost:5173"
-	@echo "    Gateway (REST/Connect)   http://localhost:8090"
+	@echo "    Gateway (REST/Connect)   localhost:8090 (API only, no web UI)"
 	@echo "    gRPC                     localhost:50051"
 	@echo "    CockroachDB UI           http://localhost:8080"
 	@echo "    CockroachDB SQL          postgresql://root@localhost:26257/defaultdb?sslmode=disable"

--- a/api/openapi/swagger-ui.html
+++ b/api/openapi/swagger-ui.html
@@ -88,40 +88,32 @@
       }
     }
 
-    // Initialize Swagger UI
-    function loadSwagger(specUrl) {
-      SwaggerUIBundle({
-        url: specUrl,
-        dom_id: '#swagger-ui',
-        deepLinking: true,
-        presets: [
-          SwaggerUIBundle.presets.apis,
-          SwaggerUIBundle.SwaggerUIStandalonePreset
-        ],
-        layout: 'BaseLayout',
-        defaultModelsExpandDepth: 0,
-        docExpansion: 'list',
-        filter: true,
-        requestInterceptor: (req) => {
-          // Leave spec/catalog fetches alone — they're served by the local python server
-          if (req.url.includes('.json') || req.url.includes(':8091')) {
-            return req;
-          }
-          // Redirect API calls to the local gateway
-          try {
-            const url = new URL(req.url);
-            if (url.host !== 'localhost:8090') {
-              url.host = 'localhost:8090';
-              url.protocol = 'http:';
-              req.url = url.toString();
-            }
-          } catch {
-            // Relative URL — prefix with gateway
-            req.url = GATEWAY_URL + '/' + req.url.replace(/^\//, '');
-          }
-          return req;
-        }
-      });
+    // Fetch spec, patch host/schemes, then render Swagger UI
+    async function loadSwagger(specUrl) {
+      try {
+        const resp = await fetch(specUrl);
+        const spec = await resp.json();
+        // Point "Try it out" at the local gateway
+        spec.host = 'localhost:8090';
+        spec.schemes = ['http'];
+
+        SwaggerUIBundle({
+          spec: spec,
+          dom_id: '#swagger-ui',
+          deepLinking: true,
+          presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIBundle.SwaggerUIStandalonePreset
+          ],
+          layout: 'BaseLayout',
+          defaultModelsExpandDepth: 0,
+          docExpansion: 'list',
+          filter: true,
+        });
+      } catch (e) {
+        document.getElementById('swagger-ui').innerHTML =
+          '<div style="padding:24px;color:#e55">Failed to load spec: ' + specUrl + '<br>' + e.message + '</div>';
+      }
     }
 
     // Wire up service selector

--- a/api/openapi/swagger-ui.html
+++ b/api/openapi/swagger-ui.html
@@ -103,18 +103,21 @@
         docExpansion: 'list',
         filter: true,
         requestInterceptor: (req) => {
-          // Rewrite requests to go through the local gateway
-          if (req.url && !req.url.startsWith('http')) {
-            req.url = GATEWAY_URL + req.url;
+          // Leave spec/catalog fetches alone — they're served by the local python server
+          if (req.url.includes('.json') || req.url.includes(':8091')) {
+            return req;
           }
-          // Redirect API calls (not swagger spec fetches) to the local gateway
-          if (!req.url.includes('swagger') && !req.url.includes(':8091')) {
+          // Redirect API calls to the local gateway
+          try {
             const url = new URL(req.url);
             if (url.host !== 'localhost:8090') {
               url.host = 'localhost:8090';
               url.protocol = 'http:';
               req.url = url.toString();
             }
+          } catch {
+            // Relative URL — prefix with gateway
+            req.url = GATEWAY_URL + '/' + req.url.replace(/^\//, '');
           }
           return req;
         }

--- a/api/openapi/swagger-ui.html
+++ b/api/openapi/swagger-ui.html
@@ -92,6 +92,9 @@
     async function loadSwagger(specUrl) {
       try {
         const resp = await fetch(specUrl);
+        if (!resp.ok) {
+          throw new Error(`HTTP ${resp.status}`);
+        }
         const spec = await resp.json();
         // Point "Try it out" at the local gateway
         spec.host = 'localhost:8090';

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ import { LedgerPage } from '@/pages/ledger'
 import { BookingLogDetailPage } from '@/pages/ledger/booking-log-detail'
 import { ReconciliationPage } from '@/pages/reconciliation'
 import { ReconciliationDetailPage } from '@/pages/reconciliation/detail'
+import { DashboardPage } from '@/pages/dashboard'
 
 // Placeholder page components - replaced as each page task is implemented
 function PlaceholderPage({ title }: { title: string }) {
@@ -127,7 +128,7 @@ function AppShellLayout() {
     <AppShell currentPath={pathname}>
       <Routes>
         {/* Tenant-scoped routes */}
-        <Route path="/" element={<PlaceholderPage title="Dashboard" />} />
+        <Route path="/" element={<DashboardPage />} />
         <Route path="/accounts" element={<AccountsPage />} />
         <Route path="/accounts/:accountId" element={<AccountDetailPage />} />
         <Route path="/internal-accounts" element={<InternalAccountsPage />} />

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -5,9 +5,18 @@ import {
   Building,
   ArrowLeftRight,
   FileText,
-  BarChart2,
   Building2,
   Activity,
+  Users,
+  TrendingUp,
+  BookOpen,
+  Code,
+  LineChart,
+  BarChart3,
+  Database,
+  Map,
+  ClipboardList,
+  CheckSquare,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
@@ -22,8 +31,16 @@ const TENANT_NAV_ITEMS: NavItem[] = [
   { label: 'Accounts', href: '/accounts', icon: Wallet },
   { label: 'Internal Accounts', href: '/internal-accounts', icon: Building },
   { label: 'Payments', href: '/payments', icon: ArrowLeftRight },
-  { label: 'Transactions', href: '/transactions', icon: FileText },
-  { label: 'Reports', href: '/reports', icon: BarChart2 },
+  { label: 'Positions', href: '/positions', icon: TrendingUp },
+  { label: 'Ledger', href: '/ledger', icon: BookOpen },
+  { label: 'Parties', href: '/parties', icon: Users },
+  { label: 'Reconciliation', href: '/reconciliation', icon: CheckSquare },
+  { label: 'Starlark Config', href: '/starlark-config', icon: Code },
+  { label: 'Market Data', href: '/market-data', icon: LineChart },
+  { label: 'Forecasting', href: '/forecasting', icon: BarChart3 },
+  { label: 'Reference Data', href: '/reference-data', icon: Database },
+  { label: 'Gateway Mappings', href: '/gateway-mappings', icon: Map },
+  { label: 'Audit Log', href: '/audit-log', icon: ClipboardList },
 ]
 
 const PLATFORM_NAV_ITEMS: NavItem[] = [

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -4,7 +4,6 @@ import {
   Wallet,
   Building,
   ArrowLeftRight,
-  FileText,
   Building2,
   Activity,
   Users,

--- a/frontend/src/pages/dashboard/index.test.tsx
+++ b/frontend/src/pages/dashboard/index.test.tsx
@@ -1,8 +1,17 @@
 import { describe, it, expect, vi } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { renderWithProviders } from '@/test/test-utils'
 import { createTenantUserToken } from '@/test/jwt-helpers'
 import { DashboardPage } from './index'
+
+function DashboardWithRouter() {
+  return (
+    <MemoryRouter>
+      <DashboardPage />
+    </MemoryRouter>
+  )
+}
 
 // Mock the transport and clients modules to avoid importing proto generated files
 vi.mock('@/api/transport', () => ({
@@ -105,7 +114,7 @@ function setupMockClients({
 describe('DashboardPage', () => {
   it('renders dashboard heading', () => {
     setupMockClients()
-    renderWithProviders(<DashboardPage />, {
+    renderWithProviders(<DashboardWithRouter />, {
       initialToken: createTenantUserToken('tenant-001'),
     })
 
@@ -114,7 +123,7 @@ describe('DashboardPage', () => {
 
   it('renders stat card titles', () => {
     setupMockClients()
-    renderWithProviders(<DashboardPage />, {
+    renderWithProviders(<DashboardWithRouter />, {
       initialToken: createTenantUserToken('tenant-001'),
     })
 
@@ -145,7 +154,7 @@ describe('DashboardPage', () => {
       marketInformation: {} as never,
     })
 
-    renderWithProviders(<DashboardPage />, {
+    renderWithProviders(<DashboardWithRouter />, {
       initialToken: createTenantUserToken('tenant-001'),
     })
 
@@ -169,7 +178,7 @@ describe('DashboardPage', () => {
       },
     })
 
-    renderWithProviders(<DashboardPage />, {
+    renderWithProviders(<DashboardWithRouter />, {
       initialToken: createTenantUserToken('tenant-001'),
     })
 
@@ -193,7 +202,7 @@ describe('DashboardPage', () => {
       },
     })
 
-    renderWithProviders(<DashboardPage />, {
+    renderWithProviders(<DashboardWithRouter />, {
       initialToken: createTenantUserToken('tenant-001'),
     })
 
@@ -207,7 +216,7 @@ describe('DashboardPage', () => {
 
   it('renders recent activity section', () => {
     setupMockClients()
-    renderWithProviders(<DashboardPage />, {
+    renderWithProviders(<DashboardWithRouter />, {
       initialToken: createTenantUserToken('tenant-001'),
     })
 
@@ -216,7 +225,7 @@ describe('DashboardPage', () => {
 
   it('renders quick actions section', () => {
     setupMockClients()
-    renderWithProviders(<DashboardPage />, {
+    renderWithProviders(<DashboardWithRouter />, {
       initialToken: createTenantUserToken('tenant-001'),
     })
 
@@ -239,7 +248,7 @@ describe('DashboardPage', () => {
       },
     })
 
-    renderWithProviders(<DashboardPage />, {
+    renderWithProviders(<DashboardWithRouter />, {
       initialToken: createTenantUserToken('tenant-001'),
     })
 
@@ -251,7 +260,7 @@ describe('DashboardPage', () => {
 
   it('renders without crashing when no tenant context', () => {
     setupMockClients()
-    renderWithProviders(<DashboardPage />)
+    renderWithProviders(<DashboardWithRouter />)
 
     expect(screen.getByRole('heading', { name: /dashboard/i })).toBeInTheDocument()
   })
@@ -279,7 +288,7 @@ describe('DashboardPage', () => {
     })
 
     // Render without token (no tenant)
-    renderWithProviders(<DashboardPage />)
+    renderWithProviders(<DashboardWithRouter />)
 
     // Queries should not be called with no tenant
     expect(mockListPayments).not.toHaveBeenCalled()

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
 import { CreditCard, FileText, BarChart3, ArrowRight } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useApiClients } from '@/api/context'
@@ -79,6 +80,7 @@ function getCountFromPagination(
 }
 
 export function DashboardPage() {
+  const navigate = useNavigate()
   const { tenantSlug } = useTenantContext()
   const { paymentsQuery, bookingLogsQuery, ledgerPostingsQuery, activityQuery } =
     useDashboardStats(tenantSlug)
@@ -114,40 +116,34 @@ export function DashboardPage() {
     status: po.status?.toString(),
   }))
 
-  // Quick actions will navigate to dedicated pages once routes are implemented.
-  // Disabled until routing infrastructure is wired (task 026-operations-console.17).
   const quickActions: QuickAction[] = [
     {
       id: 'view-payments',
       label: 'View Payment Orders',
       description: 'Browse all payment orders',
       icon: <CreditCard className="h-4 w-4" />,
-      onClick: () => {},
-      disabled: true,
+      onClick: () => navigate('/payments'),
     },
     {
       id: 'view-booking-logs',
       label: 'View Booking Logs',
       description: 'Browse financial booking logs',
       icon: <FileText className="h-4 w-4" />,
-      onClick: () => {},
-      disabled: true,
+      onClick: () => navigate('/ledger'),
     },
     {
       id: 'view-ledger',
       label: 'View Ledger Postings',
       description: 'Browse double-entry ledger',
       icon: <BarChart3 className="h-4 w-4" />,
-      onClick: () => {},
-      disabled: true,
+      onClick: () => navigate('/ledger'),
     },
     {
       id: 'view-reconciliations',
       label: 'Reconciliations',
       description: 'Check reconciliation status',
       icon: <ArrowRight className="h-4 w-4" />,
-      onClick: () => {},
-      disabled: true,
+      onClick: () => navigate('/reconciliation'),
     },
   ]
 

--- a/scripts/seed-dev-tenant.sh
+++ b/scripts/seed-dev-tenant.sh
@@ -63,4 +63,72 @@ case "$HTTP_CODE" in
 esac
 
 rm -f /tmp/seed-response.json
+
+# --- Seed sample party (organization) ---
+
+echo "Creating sample organization ..."
+
+HTTP_CODE=$(curl -s -o /tmp/seed-response.json -w "%{http_code}" \
+  -X POST "${GATEWAY_URL}/meridian.party.v1.PartyService/RegisterParty" \
+  -H "Content-Type: application/json" \
+  -H "X-Tenant-Slug: dev-tenant" \
+  -d '{
+    "partyType": "PARTY_TYPE_ORGANIZATION",
+    "legalName": "Acme Energy Ltd",
+    "displayName": "Acme Energy",
+    "externalReference": "acme-001"
+  }')
+
+BODY=$(cat /tmp/seed-response.json 2>/dev/null || echo "")
+
+case "$HTTP_CODE" in
+  200)
+    if echo "$BODY" | grep -qi "already.exist"; then
+      echo "Sample organization already exists."
+    else
+      echo "Sample organization created."
+    fi
+    ;;
+  409)
+    echo "Sample organization already exists."
+    ;;
+  *)
+    echo "WARNING: Could not create sample organization (HTTP ${HTTP_CODE}): ${BODY}"
+    ;;
+esac
+
+# --- Seed sample party (person) ---
+
+echo "Creating sample person ..."
+
+HTTP_CODE=$(curl -s -o /tmp/seed-response.json -w "%{http_code}" \
+  -X POST "${GATEWAY_URL}/meridian.party.v1.PartyService/RegisterParty" \
+  -H "Content-Type: application/json" \
+  -H "X-Tenant-Slug: dev-tenant" \
+  -d '{
+    "partyType": "PARTY_TYPE_PERSON",
+    "legalName": "Jane Smith",
+    "displayName": "Jane Smith",
+    "externalReference": "person-001"
+  }')
+
+BODY=$(cat /tmp/seed-response.json 2>/dev/null || echo "")
+
+case "$HTTP_CODE" in
+  200)
+    if echo "$BODY" | grep -qi "already.exist"; then
+      echo "Sample person already exists."
+    else
+      echo "Sample person created."
+    fi
+    ;;
+  409)
+    echo "Sample person already exists."
+    ;;
+  *)
+    echo "WARNING: Could not create sample person (HTTP ${HTTP_CODE}): ${BODY}"
+    ;;
+esac
+
+rm -f /tmp/seed-response.json
 echo "Seed complete."


### PR DESCRIPTION
## Summary

- Wire `DashboardPage` into the `/` route (was still using `PlaceholderPage`)
- Enable dashboard quick action buttons to navigate to Payments, Ledger, and Reconciliation
- Update sidebar to show all 14 tenant pages that have routes (was only showing 6, including non-existent Reports and Transactions)
- Clarify gateway line in `make dev-up` output (API only, no web UI)
- Extend seed script to create a sample organization and person so the Parties page has data

## Test plan

- [x] All 992 frontend tests pass
- [ ] `make dev-up` → verify seed creates tenant + parties
- [ ] Dashboard renders stat cards and quick actions navigate correctly
- [ ] Sidebar shows all pages and highlights active route
- [ ] Parties page lists seeded organization and person