### PR TITLE
test: Add coverage for payment mutation hooks and query functions

### DIFF
--- a/frontend/src/pages/payments/dialogs/payment-mutations.test.tsx
+++ b/frontend/src/pages/payments/dialogs/payment-mutations.test.tsx
@@ -1,0 +1,479 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: vi.fn(),
+}))
+
+import { useApiClients } from '@/api/context'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { useInitiatePayment, useCancelPayment, useReversePayment } from './payment-mutations'
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+const mockPaymentOrder = {
+  paymentOrderId: 'po-123',
+  debtorAccountId: 'acc-456',
+  creditorIban: 'GB29NWBK60161331926819',
+  amount: '10000',
+  currency: 'GBP',
+  status: 'COMPLETED',
+  createdAt: { seconds: BigInt(1700000000), nanos: 0 },
+}
+
+describe('useInitiatePayment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useTenantSlug).mockReturnValue('acme-bank')
+  })
+
+  it('calls initiatePaymentOrder with correct params and returns paymentOrder', async () => {
+    const initiatePaymentOrder = vi.fn().mockResolvedValue({ paymentOrder: mockPaymentOrder })
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { initiatePaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useInitiatePayment(), { wrapper: makeWrapper() })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        debtorAccountId: 'acc-456',
+        creditorReference: 'cred-ref-001',
+        amount: '100.00',
+        currency: 'GBP',
+      })
+    })
+
+    expect(initiatePaymentOrder).toHaveBeenCalledOnce()
+    const callArg = initiatePaymentOrder.mock.calls[0][0]
+    expect(callArg.debtorAccountId).toBe('acc-456')
+    expect(callArg.creditorReference).toBe('cred-ref-001')
+    expect(callArg.amount.units).toBe('10000')
+    expect(callArg.amount.currency).toBe('GBP')
+    expect(callArg.idempotencyKey.key).toBeDefined()
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual(mockPaymentOrder)
+  })
+
+  it('converts amount string to BigInt minor units', async () => {
+    const initiatePaymentOrder = vi.fn().mockResolvedValue({ paymentOrder: mockPaymentOrder })
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { initiatePaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useInitiatePayment(), { wrapper: makeWrapper() })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        debtorAccountId: 'acc-456',
+        creditorReference: 'cred-ref-001',
+        amount: '250.75',
+        currency: 'USD',
+      })
+    })
+
+    const callArg = initiatePaymentOrder.mock.calls[0][0]
+    expect(callArg.amount.units).toBe('25075')
+    expect(callArg.amount.currency).toBe('USD')
+  })
+
+  it('generates unique idempotency keys on each call', async () => {
+    const initiatePaymentOrder = vi.fn().mockResolvedValue({ paymentOrder: mockPaymentOrder })
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { initiatePaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useInitiatePayment(), { wrapper: makeWrapper() })
+
+    const request = {
+      debtorAccountId: 'acc-456',
+      creditorReference: 'cred-ref-001',
+      amount: '100.00',
+      currency: 'GBP',
+    }
+
+    await act(async () => {
+      await result.current.mutateAsync(request)
+    })
+    await act(async () => {
+      await result.current.mutateAsync(request)
+    })
+
+    const key1 = initiatePaymentOrder.mock.calls[0][0].idempotencyKey.key
+    const key2 = initiatePaymentOrder.mock.calls[1][0].idempotencyKey.key
+    expect(key1).toBeDefined()
+    expect(key2).toBeDefined()
+    expect(key1).not.toBe(key2)
+  })
+
+  it('enters error state when API fails', async () => {
+    const initiatePaymentOrder = vi.fn().mockRejectedValue(new Error('Network error'))
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { initiatePaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useInitiatePayment(), { wrapper: makeWrapper() })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        debtorAccountId: 'acc-456',
+        creditorReference: 'cred-ref-001',
+        amount: '100.00',
+        currency: 'GBP',
+      }).catch(() => {})
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeInstanceOf(Error)
+  })
+
+  it('invalidates payments query on success when tenantSlug is set', async () => {
+    const initiatePaymentOrder = vi.fn().mockResolvedValue({ paymentOrder: mockPaymentOrder })
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { initiatePaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    })
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useInitiatePayment(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        debtorAccountId: 'acc-456',
+        creditorReference: 'cred-ref-001',
+        amount: '100.00',
+        currency: 'GBP',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(invalidateQueries).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: expect.arrayContaining(['tenants', 'acme-bank', 'payments']) }),
+    )
+  })
+
+  it('does not invalidate queries when tenantSlug is null', async () => {
+    vi.mocked(useTenantSlug).mockReturnValue(null)
+    const initiatePaymentOrder = vi.fn().mockResolvedValue({ paymentOrder: mockPaymentOrder })
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { initiatePaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    })
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useInitiatePayment(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        debtorAccountId: 'acc-456',
+        creditorReference: 'cred-ref-001',
+        amount: '100.00',
+        currency: 'GBP',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(invalidateQueries).not.toHaveBeenCalled()
+  })
+})
+
+describe('useCancelPayment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useTenantSlug).mockReturnValue('acme-bank')
+  })
+
+  it('calls cancelPaymentOrder with correct params and returns paymentOrder', async () => {
+    const cancelPaymentOrder = vi.fn().mockResolvedValue({ paymentOrder: mockPaymentOrder })
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { cancelPaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useCancelPayment(), { wrapper: makeWrapper() })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        paymentOrderId: 'po-123',
+        cancellationReason: 'Customer request',
+        cancelledBy: 'admin-user',
+      })
+    })
+
+    expect(cancelPaymentOrder).toHaveBeenCalledOnce()
+    const callArg = cancelPaymentOrder.mock.calls[0][0]
+    expect(callArg.paymentOrderId).toBe('po-123')
+    expect(callArg.cancellationReason).toBe('Customer request')
+    expect(callArg.cancelledBy).toBe('admin-user')
+    expect(callArg.idempotencyKey.key).toBeDefined()
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual(mockPaymentOrder)
+  })
+
+  it('defaults cancelledBy to "operations-console" when not provided', async () => {
+    const cancelPaymentOrder = vi.fn().mockResolvedValue({ paymentOrder: mockPaymentOrder })
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { cancelPaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useCancelPayment(), { wrapper: makeWrapper() })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        paymentOrderId: 'po-123',
+        cancellationReason: 'Test reason',
+      })
+    })
+
+    const callArg = cancelPaymentOrder.mock.calls[0][0]
+    expect(callArg.cancelledBy).toBe('operations-console')
+  })
+
+  it('enters error state when API fails', async () => {
+    const cancelPaymentOrder = vi.fn().mockRejectedValue(new Error('Cancel failed'))
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { cancelPaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useCancelPayment(), { wrapper: makeWrapper() })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        paymentOrderId: 'po-123',
+        cancellationReason: 'Test',
+      }).catch(() => {})
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeInstanceOf(Error)
+  })
+
+  it('invalidates both payment and payments queries on success', async () => {
+    const cancelPaymentOrder = vi.fn().mockResolvedValue({ paymentOrder: mockPaymentOrder })
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { cancelPaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    })
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useCancelPayment(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        paymentOrderId: 'po-123',
+        cancellationReason: 'Test',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(invalidateQueries).toHaveBeenCalledTimes(2)
+    expect(invalidateQueries).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: expect.arrayContaining(['tenants', 'acme-bank', 'payments', 'po-123']) }),
+    )
+    expect(invalidateQueries).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: expect.arrayContaining(['tenants', 'acme-bank', 'payments']) }),
+    )
+  })
+
+  it('does not invalidate queries when tenantSlug is null', async () => {
+    vi.mocked(useTenantSlug).mockReturnValue(null)
+    const cancelPaymentOrder = vi.fn().mockResolvedValue({ paymentOrder: mockPaymentOrder })
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { cancelPaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    })
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useCancelPayment(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        paymentOrderId: 'po-123',
+        cancellationReason: 'Test',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(invalidateQueries).not.toHaveBeenCalled()
+  })
+})
+
+describe('useReversePayment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useTenantSlug).mockReturnValue('acme-bank')
+  })
+
+  it('calls reversePaymentOrder with correct params and returns paymentOrder', async () => {
+    const reversePaymentOrder = vi.fn().mockResolvedValue({ paymentOrder: mockPaymentOrder })
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { reversePaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useReversePayment(), { wrapper: makeWrapper() })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        paymentOrderId: 'po-123',
+        reversalReason: 'Duplicate payment',
+        reversedBy: 'admin-user',
+      })
+    })
+
+    expect(reversePaymentOrder).toHaveBeenCalledOnce()
+    const callArg = reversePaymentOrder.mock.calls[0][0]
+    expect(callArg.paymentOrderId).toBe('po-123')
+    expect(callArg.reversalReason).toBe('Duplicate payment')
+    expect(callArg.reversedBy).toBe('admin-user')
+    expect(callArg.idempotencyKey.key).toBeDefined()
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual(mockPaymentOrder)
+  })
+
+  it('defaults reversedBy to "operations-console" when not provided', async () => {
+    const reversePaymentOrder = vi.fn().mockResolvedValue({ paymentOrder: mockPaymentOrder })
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { reversePaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useReversePayment(), { wrapper: makeWrapper() })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        paymentOrderId: 'po-123',
+        reversalReason: 'Test reason',
+      })
+    })
+
+    const callArg = reversePaymentOrder.mock.calls[0][0]
+    expect(callArg.reversedBy).toBe('operations-console')
+  })
+
+  it('enters error state when API fails', async () => {
+    const reversePaymentOrder = vi.fn().mockRejectedValue(new Error('Reversal failed'))
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { reversePaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const { result } = renderHook(() => useReversePayment(), { wrapper: makeWrapper() })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        paymentOrderId: 'po-123',
+        reversalReason: 'Test',
+      }).catch(() => {})
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeInstanceOf(Error)
+  })
+
+  it('invalidates both payment and payments queries on success', async () => {
+    const reversePaymentOrder = vi.fn().mockResolvedValue({ paymentOrder: mockPaymentOrder })
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { reversePaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    })
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useReversePayment(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        paymentOrderId: 'po-123',
+        reversalReason: 'Test',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(invalidateQueries).toHaveBeenCalledTimes(2)
+    expect(invalidateQueries).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: expect.arrayContaining(['tenants', 'acme-bank', 'payments', 'po-123']) }),
+    )
+    expect(invalidateQueries).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: expect.arrayContaining(['tenants', 'acme-bank', 'payments']) }),
+    )
+  })
+
+  it('does not invalidate queries when tenantSlug is null', async () => {
+    vi.mocked(useTenantSlug).mockReturnValue(null)
+    const reversePaymentOrder = vi.fn().mockResolvedValue({ paymentOrder: mockPaymentOrder })
+    vi.mocked(useApiClients).mockReturnValue({
+      paymentOrder: { reversePaymentOrder },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    })
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useReversePayment(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        paymentOrderId: 'po-123',
+        reversalReason: 'Test',
+      })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(invalidateQueries).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/payments/payment-detail-query.test.ts
+++ b/frontend/src/pages/payments/payment-detail-query.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { fetchPaymentDetail } from './payment-detail-query'
+
+const mockPaymentOrder = {
+  paymentOrderId: 'po-123',
+  debtorAccountId: 'acc-456',
+  creditorIban: 'GB29NWBK60161331926819',
+  amount: '10000',
+  currency: 'GBP',
+  status: 'COMPLETED',
+  reference: 'REF-001',
+  createdAt: { seconds: 1700000000, nanos: 0 },
+  sagaSteps: [],
+  compensationSteps: [],
+}
+
+describe('fetchPaymentDetail', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('fetches payment detail and returns paymentOrder', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ paymentOrder: mockPaymentOrder }),
+    } as Response)
+
+    const result = await fetchPaymentDetail('po-123')
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/meridian.payment_order.v1.PaymentOrderService/RetrievePaymentOrder',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ paymentOrderId: 'po-123' }),
+      },
+    )
+    expect(result).toEqual(mockPaymentOrder)
+  })
+
+  it('throws when response is not ok', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({}),
+    } as Response)
+
+    await expect(fetchPaymentDetail('po-missing')).rejects.toThrow(
+      'Failed to fetch payment order: 404',
+    )
+  })
+
+  it('throws when paymentOrder is absent in response', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    } as Response)
+
+    await expect(fetchPaymentDetail('po-123')).rejects.toThrow('Payment order not found')
+  })
+
+  it('throws when response has 500 status', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    } as Response)
+
+    await expect(fetchPaymentDetail('po-123')).rejects.toThrow(
+      'Failed to fetch payment order: 500',
+    )
+  })
+
+  it('propagates network errors from fetch', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('Network failure'))
+
+    await expect(fetchPaymentDetail('po-123')).rejects.toThrow('Network failure')
+  })
+
+  it('sends paymentOrderId in request body', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ paymentOrder: mockPaymentOrder }),
+    } as Response)
+
+    await fetchPaymentDetail('specific-order-id-999')
+
+    const callArgs = vi.mocked(fetch).mock.calls[0]
+    const body = JSON.parse(callArgs[1]?.body as string)
+    expect(body).toEqual({ paymentOrderId: 'specific-order-id-999' })
+  })
+
+  it('returns payment order with sagaSteps and compensationSteps', async () => {
+    const orderWithSteps = {
+      ...mockPaymentOrder,
+      sagaSteps: [{ stepId: 'step-1', status: 'COMPLETED', description: 'Debit account' }],
+      compensationSteps: [{ stepId: 'comp-1', status: 'PENDING', description: 'Reverse debit' }],
+    }
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ paymentOrder: orderWithSteps }),
+    } as Response)
+
+    const result = await fetchPaymentDetail('po-123')
+
+    expect(result.sagaSteps).toHaveLength(1)
+    expect(result.compensationSteps).toHaveLength(1)
+  })
+})

--- a/frontend/src/pages/payments/payments-query.test.ts
+++ b/frontend/src/pages/payments/payments-query.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { fetchPayments } from './payments-query'
+import type { DataTableQueryParams } from '@/components/shared/data-table'
+
+const mockPaymentOrders = [
+  {
+    paymentOrderId: 'po-001',
+    debtorAccountId: 'acc-100',
+    creditorIban: 'GB29NWBK60161331926819',
+    amount: '5000',
+    currency: 'GBP',
+    status: 'COMPLETED',
+    createdAt: { seconds: 1700000000, nanos: 0 },
+  },
+  {
+    paymentOrderId: 'po-002',
+    debtorAccountId: 'acc-200',
+    creditorIban: 'DE89370400440532013000',
+    amount: '15000',
+    currency: 'EUR',
+    status: 'PENDING',
+    createdAt: { seconds: 1700001000, nanos: 0 },
+  },
+]
+
+describe('fetchPayments', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('fetches payments and returns items with nextPageToken', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ paymentOrders: mockPaymentOrders, nextPageToken: 'token-2' }),
+    } as Response)
+
+    const params: DataTableQueryParams = { pageSize: 20 }
+    const result = await fetchPayments(params)
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/meridian.payment_order.v1.PaymentOrderService/ListPaymentOrders',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pageSize: 20 }),
+      },
+    )
+    expect(result.items).toEqual(mockPaymentOrders)
+    expect(result.nextPageToken).toBe('token-2')
+  })
+
+  it('includes pageToken in request body when provided', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ paymentOrders: [], nextPageToken: undefined }),
+    } as Response)
+
+    const params: DataTableQueryParams = { pageSize: 10, pageToken: 'cursor-abc' }
+    await fetchPayments(params)
+
+    const callArgs = vi.mocked(fetch).mock.calls[0]
+    const body = JSON.parse(callArgs[1]?.body as string)
+    expect(body.pageToken).toBe('cursor-abc')
+  })
+
+  it('does not include pageToken when not provided', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ paymentOrders: [] }),
+    } as Response)
+
+    const params: DataTableQueryParams = { pageSize: 10 }
+    await fetchPayments(params)
+
+    const callArgs = vi.mocked(fetch).mock.calls[0]
+    const body = JSON.parse(callArgs[1]?.body as string)
+    expect(body).not.toHaveProperty('pageToken')
+  })
+
+  it('includes status filter in request body when provided', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ paymentOrders: [] }),
+    } as Response)
+
+    const params: DataTableQueryParams = { pageSize: 10, filters: { status: 'COMPLETED' } }
+    await fetchPayments(params)
+
+    const callArgs = vi.mocked(fetch).mock.calls[0]
+    const body = JSON.parse(callArgs[1]?.body as string)
+    expect(body.status).toBe('COMPLETED')
+  })
+
+  it('does not include status in request body when filters is absent', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ paymentOrders: [] }),
+    } as Response)
+
+    const params: DataTableQueryParams = { pageSize: 10 }
+    await fetchPayments(params)
+
+    const callArgs = vi.mocked(fetch).mock.calls[0]
+    const body = JSON.parse(callArgs[1]?.body as string)
+    expect(body).not.toHaveProperty('status')
+  })
+
+  it('does not include status when filters.status is absent', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ paymentOrders: [] }),
+    } as Response)
+
+    const params: DataTableQueryParams = { pageSize: 10, filters: { otherFilter: 'value' } }
+    await fetchPayments(params)
+
+    const callArgs = vi.mocked(fetch).mock.calls[0]
+    const body = JSON.parse(callArgs[1]?.body as string)
+    expect(body).not.toHaveProperty('status')
+  })
+
+  it('returns empty items array when paymentOrders is absent', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    } as Response)
+
+    const params: DataTableQueryParams = { pageSize: 20 }
+    const result = await fetchPayments(params)
+
+    expect(result.items).toEqual([])
+    expect(result.nextPageToken).toBeUndefined()
+  })
+
+  it('throws when response is not ok', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({}),
+    } as Response)
+
+    const params: DataTableQueryParams = { pageSize: 20 }
+    await expect(fetchPayments(params)).rejects.toThrow('Failed to fetch payments: 403')
+  })
+
+  it('throws when response has 500 status', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    } as Response)
+
+    const params: DataTableQueryParams = { pageSize: 20 }
+    await expect(fetchPayments(params)).rejects.toThrow('Failed to fetch payments: 500')
+  })
+
+  it('propagates network errors from fetch', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('Network failure'))
+
+    const params: DataTableQueryParams = { pageSize: 20 }
+    await expect(fetchPayments(params)).rejects.toThrow('Network failure')
+  })
+
+  it('returns undefined nextPageToken when not in response', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ paymentOrders: mockPaymentOrders }),
+    } as Response)
+
+    const params: DataTableQueryParams = { pageSize: 20 }
+    const result = await fetchPayments(params)
+
+    expect(result.nextPageToken).toBeUndefined()
+  })
+
+  it('passes pageSize correctly in request body', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ paymentOrders: [] }),
+    } as Response)
+
+    const params: DataTableQueryParams = { pageSize: 50 }
+    await fetchPayments(params)
+
+    const callArgs = vi.mocked(fetch).mock.calls[0]
+    const body = JSON.parse(callArgs[1]?.body as string)
+    expect(body.pageSize).toBe(50)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds 35 tests across three new test files covering the payment mutations and query functions that had 0-9% coverage
- Tests `useInitiatePayment`, `useCancelPayment`, and `useReversePayment` hooks including happy path, error handling, BigInt amount conversion, idempotency key generation, and cache invalidation behaviour
- Tests `fetchPaymentDetail` and `fetchPayments` including HTTP error codes, missing data, filter/pagination params, and network failures

## Changes Made

| File | Tests |
|------|-------|
| `frontend/src/pages/payments/dialogs/payment-mutations.test.tsx` | 15 tests — three mutation hooks |
| `frontend/src/pages/payments/payment-detail-query.test.ts` | 7 tests — `fetchPaymentDetail` |
| `frontend/src/pages/payments/payments-query.test.ts` | 13 tests — `fetchPayments` |

## Test plan

- [x] All 35 tests pass locally with `npx vitest run`
- [x] Tests follow established patterns from `use-tenants.test.tsx` and `context.test.tsx`
- [x] Mocks `@/api/context` and `@/hooks/use-tenant-context` as required
- [x] Uses `renderHook` with `QueryClientProvider` wrapper for mutation hooks
- [x] Tests both success and error paths for all functions