### PR TITLE
test: Set up Playwright E2E infrastructure with dev-mode auth fixtures

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -28,3 +28,7 @@ src/api/gen
 
 # Coverage reports
 coverage
+
+# Playwright
+playwright-report
+test-results

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -11,16 +11,11 @@ import { test, expect } from './fixtures'
  */
 test.describe('Dashboard smoke test', () => {
   test('renders dashboard heading after platform-admin login', async ({ platformAdminPage }) => {
-    // Auth injection navigates to '/' which redirects to ProtectedRoute -> dashboard
-    await platformAdminPage.waitForURL('/')
-
-    // Dashboard heading is the primary landmark
+    // Wait on the UI landmark rather than URL to avoid redirect path mismatches
     await expect(platformAdminPage.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
   })
 
   test('renders stat card section', async ({ platformAdminPage }) => {
-    await platformAdminPage.waitForURL('/')
-
     // Stat cards are always rendered (loading or data states)
     await expect(platformAdminPage.getByText('Payment Orders')).toBeVisible()
     await expect(platformAdminPage.getByText('Booking Logs')).toBeVisible()
@@ -28,8 +23,6 @@ test.describe('Dashboard smoke test', () => {
   })
 
   test('renders quick actions panel', async ({ platformAdminPage }) => {
-    await platformAdminPage.waitForURL('/')
-
     await expect(platformAdminPage.getByText('Quick Actions')).toBeVisible()
   })
 })

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from './fixtures'
+
+/**
+ * Smoke test: verify the dashboard renders after dev-mode authentication.
+ *
+ * NOTE: This test requires the Vite dev server (npm run dev) to be running.
+ * It does NOT require the Meridian backend - API calls will fail gracefully
+ * and the dashboard will render with loading/error states.
+ *
+ * For full integration testing with live backend, see task 45 (CI E2E workflow).
+ */
+test.describe('Dashboard smoke test', () => {
+  test('renders dashboard heading after platform-admin login', async ({ platformAdminPage }) => {
+    // Auth injection navigates to '/' which redirects to ProtectedRoute -> dashboard
+    await platformAdminPage.waitForURL('/')
+
+    // Dashboard heading is the primary landmark
+    await expect(platformAdminPage.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
+  })
+
+  test('renders stat card section', async ({ platformAdminPage }) => {
+    await platformAdminPage.waitForURL('/')
+
+    // Stat cards are always rendered (loading or data states)
+    await expect(platformAdminPage.getByText('Payment Orders')).toBeVisible()
+    await expect(platformAdminPage.getByText('Booking Logs')).toBeVisible()
+    await expect(platformAdminPage.getByText('Ledger Postings')).toBeVisible()
+  })
+
+  test('renders quick actions panel', async ({ platformAdminPage }) => {
+    await platformAdminPage.waitForURL('/')
+
+    await expect(platformAdminPage.getByText('Quick Actions')).toBeVisible()
+  })
+})

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,0 +1,53 @@
+import { test as base, type Page } from '@playwright/test'
+
+/**
+ * Build a dev-mode JWT that satisfies the AuthProvider's parseJWT validation.
+ * These tokens are only accepted in DEV mode (import.meta.env.DEV).
+ */
+function buildDevToken(role: 'platform-admin' | 'tenant-user'): string {
+  const header = btoa(JSON.stringify({ alg: 'none', typ: 'JWT' }))
+  const payload = btoa(
+    JSON.stringify({
+      userId: 'e2e-user',
+      tenantId: role === 'tenant-user' ? 'dev-tenant' : undefined,
+      roles: [role],
+      scopes: ['read', 'write'],
+      // 24 hours from now
+      exp: Math.floor(Date.now() / 1000) + 86_400,
+      iss: 'meridian-dev',
+      aud: 'meridian-console',
+      sub: 'e2e-user',
+    }),
+  )
+  return `${header}.${payload}.e2e-signature`
+}
+
+/**
+ * Inject a dev auth token via window.__DEV_LOGIN__ exposed by AuthProvider in DEV mode.
+ */
+async function injectDevAuth(page: Page, role: 'platform-admin' | 'tenant-user') {
+  const token = buildDevToken(role)
+  await page.goto('/')
+  await page.waitForFunction(() => typeof (window as Record<string, unknown>).__DEV_LOGIN__ === 'function')
+  await page.evaluate((t) => {
+    ;(window as Record<string, unknown>).__DEV_LOGIN__(t)
+  }, token)
+}
+
+type Fixtures = {
+  authenticatedPage: Page
+  platformAdminPage: Page
+}
+
+export const test = base.extend<Fixtures>({
+  authenticatedPage: async ({ page }, use) => {
+    await injectDevAuth(page, 'tenant-user')
+    await use(page)
+  },
+  platformAdminPage: async ({ page }, use) => {
+    await injectDevAuth(page, 'platform-admin')
+    await use(page)
+  },
+})
+
+export { expect } from '@playwright/test'

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -26,4 +26,12 @@ export default defineConfig([
       '@typescript-eslint/consistent-type-imports': 'error',
     },
   },
+  // E2E test files are not React code - disable React-specific rules
+  {
+    files: ['e2e/**/*.{ts,tsx}'],
+    rules: {
+      'react-hooks/rules-of-hooks': 'off',
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 ])

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,6 +35,7 @@
         "@bufbuild/buf": "^1.65.0",
         "@bufbuild/protoc-gen-es": "^2.11.0",
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/vite": "^4.2.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -60,6 +61,9 @@
         "vite": "^7.3.1",
         "vitest": "^3.2.4",
         "vitest-axe": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2387,6 +2391,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -9506,6 +9526,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,9 @@
     "test": "vitest",
     "test:coverage": "vitest --coverage",
     "typecheck": "tsc --noEmit",
-    "generate": "buf generate --template buf.gen.yaml ../api/proto"
+    "generate": "buf generate --template buf.gen.yaml ../api/proto",
+    "e2e": "playwright test",
+    "e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
@@ -44,6 +46,7 @@
     "@bufbuild/buf": "^1.65.0",
     "@bufbuild/protoc-gen-es": "^2.11.0",
     "@eslint/js": "^9.39.1",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/vite": "^4.2.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -191,6 +191,16 @@ export function AuthProvider({ children, initialToken }: AuthProviderProps) {
   const lens = getUserLens(claims)
   const isAuthenticated = claims !== null && !isTokenExpired(claims)
 
+  // Expose dev-only login bypass for E2E testing
+  useEffect(() => {
+    if (import.meta.env.DEV) {
+      ;(window as unknown as Record<string, unknown>).__DEV_LOGIN__ = login
+      return () => {
+        delete (window as unknown as Record<string, unknown>).__DEV_LOGIN__
+      }
+    }
+  }, [login])
+
   const value: AuthContextValue = {
     isAuthenticated,
     claims,

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -77,10 +77,12 @@ export default defineConfig({
     setupFiles: ['./src/test/setup.ts'],
     globals: true,
     css: true,
+    // Exclude Playwright E2E tests - they are run separately via `npm run e2e`
+    exclude: ['node_modules/**', 'e2e/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
-      exclude: ['node_modules/', 'src/api/gen/', 'src/test/'],
+      exclude: ['node_modules/', 'src/api/gen/', 'src/test/', 'e2e/'],
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

- Installs `@playwright/test` as a dev dependency
- Creates `frontend/playwright.config.ts` targeting Chromium on port 5173 with trace-on-first-retry and screenshot-on-failure
- Exposes `window.__DEV_LOGIN__` in `AuthProvider` (DEV mode only) for E2E auth injection without a real backend
- Creates `frontend/e2e/fixtures.ts` with `authenticatedPage` (tenant-user) and `platformAdminPage` (platform-admin) fixtures
- Creates `frontend/e2e/dashboard.spec.ts` smoke test verifying the dashboard heading and key UI sections render after auth
- Adds `e2e` and `e2e:headed` npm scripts
- Excludes `playwright-report/` and `test-results/` from git

## Notes

- Browser binaries are NOT installed here — the CI E2E workflow (task 45) handles `playwright install`
- The smoke test works against the Vite dev server only; backend API calls fail gracefully and render loading/error states
- `window.__DEV_LOGIN__` is only exposed when `import.meta.env.DEV` is true, so it is stripped from production builds

## Test plan

- [ ] `cd frontend && npm run e2e` runs smoke tests locally (requires `npm run dev` running or Playwright webServer starts it)
- [ ] `npm run typecheck` passes with no errors
- [ ] `npm run lint` passes with no errors
- [ ] Dashboard heading visible after platform-admin auth injection
- [ ] Stat card titles visible (Payment Orders, Booking Logs, Ledger Postings)
- [ ] Quick Actions panel visible