### PR TITLE
test: Add coverage for Party detail tab components

### DIFF
--- a/frontend/src/pages/parties/tabs/associations-tab.test.tsx
+++ b/frontend/src/pages/parties/tabs/associations-tab.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('@/api/context', () => ({
+  useClients: vi.fn(),
+}))
+
+import { useClients } from '@/api/context'
+import { AssociationsTab } from './associations-tab'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+    },
+  })
+}
+
+function renderTab(partyId = 'party-001') {
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <AssociationsTab partyId={partyId} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('AssociationsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('loading state', () => {
+    it('renders skeletons while loading', () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getAssociations: vi.fn(() => new Promise(() => {})),
+        },
+      } as ReturnType<typeof useClients>)
+
+      const { container } = renderTab()
+
+      const skeletons = container.querySelectorAll('.animate-pulse')
+      expect(skeletons.length).toBeGreaterThan(0)
+    })
+
+    it('does not render empty state while loading', () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getAssociations: vi.fn(() => new Promise(() => {})),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      expect(screen.queryByRole('heading', { name: /associations/i })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('empty state', () => {
+    it('renders empty state heading after data loads', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getAssociations: vi.fn().mockResolvedValue({}),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /associations/i })).toBeInTheDocument()
+      })
+    })
+
+    it('renders descriptive message', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getAssociations: vi.fn().mockResolvedValue({}),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByText(/no associations information available/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('query key', () => {
+    it('calls getAssociations with the provided partyId', async () => {
+      const getAssociations = vi.fn().mockResolvedValue({})
+      vi.mocked(useClients).mockReturnValue({
+        party: { getAssociations },
+      } as ReturnType<typeof useClients>)
+
+      renderTab('party-abc')
+
+      await waitFor(() => {
+        expect(getAssociations).toHaveBeenCalledWith({ partyId: 'party-abc' })
+      })
+    })
+  })
+})

--- a/frontend/src/pages/parties/tabs/audit-trail-tab.test.tsx
+++ b/frontend/src/pages/parties/tabs/audit-trail-tab.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+// Mock the AuditTrail component to isolate tab behaviour
+vi.mock('@/components/shared/audit-trail', () => ({
+  AuditTrail: vi.fn(({ entityType, entityId }: { entityType: string; entityId: string }) => (
+    <div data-testid="mock-audit-trail" data-entity-type={entityType} data-entity-id={entityId} />
+  )),
+}))
+
+import { AuditTrailTab } from './audit-trail-tab'
+
+describe('AuditTrailTab', () => {
+  it('renders AuditTrail with entityType PARTY', () => {
+    const { getByTestId } = render(<AuditTrailTab partyId="party-001" />)
+    const auditTrail = getByTestId('mock-audit-trail')
+    expect(auditTrail).toBeInTheDocument()
+    expect(auditTrail).toHaveAttribute('data-entity-type', 'PARTY')
+  })
+
+  it('passes partyId as entityId to AuditTrail', () => {
+    const { getByTestId } = render(<AuditTrailTab partyId="party-abc-123" />)
+    const auditTrail = getByTestId('mock-audit-trail')
+    expect(auditTrail).toHaveAttribute('data-entity-id', 'party-abc-123')
+  })
+
+  it('passes a different partyId correctly', () => {
+    const { getByTestId } = render(<AuditTrailTab partyId="another-party" />)
+    const auditTrail = getByTestId('mock-audit-trail')
+    expect(auditTrail).toHaveAttribute('data-entity-id', 'another-party')
+  })
+
+  it('renders without crashing', () => {
+    expect(() => render(<AuditTrailTab partyId="any-id" />)).not.toThrow()
+  })
+})

--- a/frontend/src/pages/parties/tabs/bank-relations-tab.test.tsx
+++ b/frontend/src/pages/parties/tabs/bank-relations-tab.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('@/api/context', () => ({
+  useClients: vi.fn(),
+}))
+
+import { useClients } from '@/api/context'
+import { BankRelationsTab } from './bank-relations-tab'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+    },
+  })
+}
+
+function renderTab(partyId = 'party-001') {
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <BankRelationsTab partyId={partyId} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('BankRelationsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('loading state', () => {
+    it('renders skeletons while loading', () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getBankRelations: vi.fn(() => new Promise(() => {})),
+        },
+      } as ReturnType<typeof useClients>)
+
+      const { container } = renderTab()
+
+      const skeletons = container.querySelectorAll('.animate-pulse')
+      expect(skeletons.length).toBeGreaterThan(0)
+    })
+
+    it('does not render empty state while loading', () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getBankRelations: vi.fn(() => new Promise(() => {})),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      expect(screen.queryByRole('heading', { name: /bank relations/i })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('empty state', () => {
+    it('renders empty state heading after data loads', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getBankRelations: vi.fn().mockResolvedValue({}),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /bank relations/i })).toBeInTheDocument()
+      })
+    })
+
+    it('renders descriptive message', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getBankRelations: vi.fn().mockResolvedValue({}),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByText(/no bank relations information available/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('query key', () => {
+    it('calls getBankRelations with the provided partyId', async () => {
+      const getBankRelations = vi.fn().mockResolvedValue({})
+      vi.mocked(useClients).mockReturnValue({
+        party: { getBankRelations },
+      } as ReturnType<typeof useClients>)
+
+      renderTab('party-xyz')
+
+      await waitFor(() => {
+        expect(getBankRelations).toHaveBeenCalledWith({ partyId: 'party-xyz' })
+      })
+    })
+  })
+})

--- a/frontend/src/pages/parties/tabs/demographics-tab.test.tsx
+++ b/frontend/src/pages/parties/tabs/demographics-tab.test.tsx
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('@/api/context', () => ({
+  useClients: vi.fn(),
+}))
+
+import { useClients } from '@/api/context'
+import { DemographicsTab } from './demographics-tab'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function renderTab(partyId = 'party-001') {
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <DemographicsTab partyId={partyId} />
+    </QueryClientProvider>,
+  )
+}
+
+const mockDemographics = {
+  partyId: 'party-001',
+  email: 'contact@acme.com',
+  phoneNumber: '+44 20 1234 5678',
+  businessName: 'Acme Corp',
+  businessRegistration: 'BRN-12345',
+  legalName: 'Acme Corporation Ltd',
+  nationality: 'GB',
+  taxId: 'TAX-9876',
+  website: 'https://acme.com',
+  streetAddress: '123 Main Street',
+  city: 'London',
+  state: 'England',
+  postalCode: 'SW1A 1AA',
+  country: 'GB',
+}
+
+describe('DemographicsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('loading state', () => {
+    it('renders skeletons while loading', () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getParticipant: vi.fn(() => new Promise(() => {})),
+          updateParticipant: vi.fn(),
+        },
+      } as ReturnType<typeof useClients>)
+
+      const { container } = renderTab()
+
+      const skeletons = container.querySelectorAll('.animate-pulse')
+      expect(skeletons.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('empty state', () => {
+    it('renders empty state when no demographics data is returned', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getParticipant: vi.fn().mockResolvedValue(null),
+          updateParticipant: vi.fn(),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByText(/no data/i)).toBeInTheDocument()
+      })
+    })
+
+    it('shows descriptive message in empty state', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getParticipant: vi.fn().mockResolvedValue(null),
+          updateParticipant: vi.fn(),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByText(/demographics information not found/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('view mode (data state)', () => {
+    beforeEach(() => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getParticipant: vi.fn().mockResolvedValue(mockDemographics),
+          updateParticipant: vi.fn(),
+        },
+      } as ReturnType<typeof useClients>)
+    })
+
+    it('renders email', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText('contact@acme.com')).toBeInTheDocument()
+      })
+    })
+
+    it('renders phone number', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText('+44 20 1234 5678')).toBeInTheDocument()
+      })
+    })
+
+    it('renders business name', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText('Acme Corp')).toBeInTheDocument()
+      })
+    })
+
+    it('renders city', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText('London')).toBeInTheDocument()
+      })
+    })
+
+    it('renders country', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getAllByText('GB').length).toBeGreaterThan(0)
+      })
+    })
+
+    it('renders Edit Demographics button', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit demographics/i })).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('edit mode toggle', () => {
+    beforeEach(() => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getParticipant: vi.fn().mockResolvedValue(mockDemographics),
+          updateParticipant: vi.fn().mockResolvedValue({}),
+        },
+      } as ReturnType<typeof useClients>)
+    })
+
+    it('switches to edit mode when Edit Demographics is clicked', async () => {
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit demographics/i })).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByRole('button', { name: /edit demographics/i }))
+
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+    })
+
+    it('shows input fields in edit mode', async () => {
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit demographics/i })).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByRole('button', { name: /edit demographics/i }))
+
+      expect(screen.getByPlaceholderText(/email/i)).toBeInTheDocument()
+      expect(screen.getByPlaceholderText(/phone number/i)).toBeInTheDocument()
+    })
+
+    it('returns to view mode when Cancel is clicked', async () => {
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit demographics/i })).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByRole('button', { name: /edit demographics/i }))
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument()
+
+      await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit demographics/i })).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('form submission', () => {
+    it('calls updateParticipant on save', async () => {
+      const updateParticipant = vi.fn().mockResolvedValue({})
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getParticipant: vi.fn().mockResolvedValue(mockDemographics),
+          updateParticipant,
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit demographics/i })).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByRole('button', { name: /edit demographics/i }))
+      await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+
+      await waitFor(() => {
+        expect(updateParticipant).toHaveBeenCalledWith(
+          expect.objectContaining({ partyId: 'party-001' }),
+        )
+      })
+    })
+
+    it('returns to view mode on successful save', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getParticipant: vi.fn().mockResolvedValue(mockDemographics),
+          updateParticipant: vi.fn().mockResolvedValue({}),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit demographics/i })).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByRole('button', { name: /edit demographics/i }))
+      await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit demographics/i })).toBeInTheDocument()
+      })
+    })
+
+    it('disables Save button while mutation is pending', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getParticipant: vi.fn().mockResolvedValue(mockDemographics),
+          updateParticipant: vi.fn(
+            () => new Promise((resolve) => setTimeout(resolve, 200)),
+          ),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /edit demographics/i })).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByRole('button', { name: /edit demographics/i }))
+      await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeDisabled()
+    })
+  })
+})

--- a/frontend/src/pages/parties/tabs/overview-tab.test.tsx
+++ b/frontend/src/pages/parties/tabs/overview-tab.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+vi.mock('@/api/context', () => ({
+  useClients: vi.fn(),
+}))
+
+import { useClients } from '@/api/context'
+import { OverviewTab } from './overview-tab'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+    },
+  })
+}
+
+function renderTab(partyId = 'party-001') {
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <TooltipProvider>
+        <OverviewTab partyId={partyId} />
+      </TooltipProvider>
+    </QueryClientProvider>,
+  )
+}
+
+const mockParty = {
+  partyId: 'party-001',
+  name: 'Acme Corp',
+  partyType: 'ORGANIZATION',
+  status: 'ACTIVE',
+  externalReference: 'EXT-123',
+  verificationStatus: 'VERIFIED',
+  createdAt: { seconds: 1700000000, nanos: 0 },
+  updatedAt: { seconds: 1700001000, nanos: 0 },
+}
+
+describe('OverviewTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('loading state', () => {
+    it('renders skeletons while loading', () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getParticipant: vi.fn(() => new Promise(() => {})),
+        },
+      } as ReturnType<typeof useClients>)
+
+      const { container } = renderTab()
+
+      const skeletons = container.querySelectorAll('.animate-pulse')
+      expect(skeletons.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('empty state', () => {
+    it('renders empty state when no party data is returned', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getParticipant: vi.fn().mockResolvedValue(null),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByText(/no data/i)).toBeInTheDocument()
+      })
+    })
+
+    it('shows descriptive message in empty state', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getParticipant: vi.fn().mockResolvedValue(null),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByText(/party information not found/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('data state', () => {
+    beforeEach(() => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getParticipant: vi.fn().mockResolvedValue(mockParty),
+        },
+      } as ReturnType<typeof useClients>)
+    })
+
+    it('renders party ID', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText('party-001')).toBeInTheDocument()
+      })
+    })
+
+    it('renders party name', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText('Acme Corp')).toBeInTheDocument()
+      })
+    })
+
+    it('renders party type', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText('ORGANIZATION')).toBeInTheDocument()
+      })
+    })
+
+    it('renders party status', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText('ACTIVE')).toBeInTheDocument()
+      })
+    })
+
+    it('renders external reference', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText('EXT-123')).toBeInTheDocument()
+      })
+    })
+
+    it('renders verification status', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText('VERIFIED')).toBeInTheDocument()
+      })
+    })
+
+    it('renders TimeDisplay for createdAt timestamp', async () => {
+      renderTab()
+      await waitFor(() => {
+        // TimeDisplay renders a time representation; just verify the Created label is present
+        expect(screen.getByText('Created')).toBeInTheDocument()
+      })
+    })
+
+    it('renders TimeDisplay for updatedAt timestamp', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText('Updated')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('missing optional fields', () => {
+    it('renders em dash for missing externalReference', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getParticipant: vi.fn().mockResolvedValue({
+            partyId: 'party-001',
+            name: 'Acme Corp',
+            partyType: 'ORGANIZATION',
+            status: 'ACTIVE',
+          }),
+        },
+      } as ReturnType<typeof useClients>)
+
+      const { getAllByText } = renderTab()
+      await waitFor(() => {
+        expect(getAllByText('—').length).toBeGreaterThan(0)
+      })
+    })
+
+    it('renders em dash for missing timestamps', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getParticipant: vi.fn().mockResolvedValue({
+            partyId: 'party-001',
+            name: 'Acme Corp',
+            partyType: 'ORGANIZATION',
+            status: 'ACTIVE',
+          }),
+        },
+      } as ReturnType<typeof useClients>)
+
+      const { getAllByText } = renderTab()
+      await waitFor(() => {
+        // 4 dashes: externalReference, verificationStatus, createdAt, updatedAt
+        expect(getAllByText('—').length).toBeGreaterThanOrEqual(4)
+      })
+    })
+  })
+})

--- a/frontend/src/pages/parties/tabs/payment-methods-tab.test.tsx
+++ b/frontend/src/pages/parties/tabs/payment-methods-tab.test.tsx
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('@/api/context', () => ({
+  useClients: vi.fn(),
+}))
+
+import { useClients } from '@/api/context'
+import { PaymentMethodsTab } from './payment-methods-tab'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function renderTab(partyId = 'party-001') {
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <PaymentMethodsTab partyId={partyId} />
+    </QueryClientProvider>,
+  )
+}
+
+const mockPaymentMethods = [
+  {
+    paymentMethodId: 'pm-001',
+    type: 'BANK_ACCOUNT',
+    accountNumber: '12345678',
+    routingNumber: '021000021',
+    accountHolderName: 'Acme Corp',
+    isDefault: true,
+  },
+  {
+    paymentMethodId: 'pm-002',
+    type: 'CARD',
+    accountNumber: '4111111111111234',
+    accountHolderName: 'John Doe',
+    isDefault: false,
+  },
+]
+
+describe('PaymentMethodsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('loading state', () => {
+    it('renders skeletons while loading', () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getPaymentMethods: vi.fn(() => new Promise(() => {})),
+          addPaymentMethod: vi.fn(),
+          removePaymentMethod: vi.fn(),
+          setDefaultPaymentMethod: vi.fn(),
+        },
+      } as ReturnType<typeof useClients>)
+
+      const { container } = renderTab()
+
+      const skeletons = container.querySelectorAll('.animate-pulse')
+      expect(skeletons.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('empty state', () => {
+    beforeEach(() => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: [] }),
+          addPaymentMethod: vi.fn(),
+          removePaymentMethod: vi.fn(),
+          setDefaultPaymentMethod: vi.fn(),
+        },
+      } as ReturnType<typeof useClients>)
+    })
+
+    it('renders empty state when no payment methods exist', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText(/no payment methods/i)).toBeInTheDocument()
+      })
+    })
+
+    it('renders Add Payment Method button even when empty', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /add payment method/i })).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('list rendering', () => {
+    beforeEach(() => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: mockPaymentMethods }),
+          addPaymentMethod: vi.fn(),
+          removePaymentMethod: vi.fn(),
+          setDefaultPaymentMethod: vi.fn(),
+        },
+      } as ReturnType<typeof useClients>)
+    })
+
+    it('renders all payment methods', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText('Acme Corp')).toBeInTheDocument()
+        expect(screen.getByText('John Doe')).toBeInTheDocument()
+      })
+    })
+
+    it('shows Default badge on default payment method', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText('Default')).toBeInTheDocument()
+      })
+    })
+
+    it('shows masked account number', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText(/••••5678/)).toBeInTheDocument()
+      })
+    })
+
+    it('shows payment method type', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText(/BANK_ACCOUNT/)).toBeInTheDocument()
+      })
+    })
+
+    it('shows routing number when present', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText(/021000021/)).toBeInTheDocument()
+      })
+    })
+
+    it('renders Remove button for each payment method', async () => {
+      renderTab()
+      await waitFor(() => {
+        const removeButtons = screen.getAllByRole('button', { name: /remove/i })
+        expect(removeButtons).toHaveLength(2)
+      })
+    })
+
+    it('renders Set Default button for non-default methods', async () => {
+      renderTab()
+      await waitFor(() => {
+        const setDefaultButtons = screen.getAllByRole('button', { name: /set default/i })
+        // Only the non-default method gets "Set Default"
+        expect(setDefaultButtons).toHaveLength(1)
+      })
+    })
+
+    it('does not render Set Default for already-default method', async () => {
+      renderTab()
+      await waitFor(() => {
+        expect(screen.getByText('Acme Corp')).toBeInTheDocument()
+      })
+      // The default method (Acme Corp, pm-001) should NOT have Set Default
+      const setDefaultButtons = screen.getAllByRole('button', { name: /set default/i })
+      expect(setDefaultButtons).toHaveLength(1)
+    })
+  })
+
+  describe('add dialog', () => {
+    beforeEach(() => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: [] }),
+          addPaymentMethod: vi.fn().mockResolvedValue({}),
+          removePaymentMethod: vi.fn(),
+          setDefaultPaymentMethod: vi.fn(),
+        },
+      } as ReturnType<typeof useClients>)
+    })
+
+    it('opens add dialog when Add Payment Method is clicked', async () => {
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /add payment method/i })).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByRole('button', { name: /add payment method/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+    })
+
+    it('renders form fields in the dialog', async () => {
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /add payment method/i })).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByRole('button', { name: /add payment method/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+
+      expect(screen.getByPlaceholderText(/account number/i)).toBeInTheDocument()
+      expect(screen.getByPlaceholderText(/routing number/i)).toBeInTheDocument()
+    })
+
+    it('closes dialog when Cancel is clicked in dialog', async () => {
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /add payment method/i })).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByRole('button', { name: /add payment method/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      })
+    })
+
+    it('calls addPaymentMethod on form submit', async () => {
+      const addPaymentMethod = vi.fn().mockResolvedValue({})
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: [] }),
+          addPaymentMethod,
+          removePaymentMethod: vi.fn(),
+          setDefaultPaymentMethod: vi.fn(),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /add payment method/i })).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByRole('button', { name: /add payment method/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument()
+      })
+
+      // Select a type (required field)
+      await userEvent.selectOptions(screen.getByRole('combobox'), 'BANK_ACCOUNT')
+      await userEvent.type(screen.getByPlaceholderText(/account number/i), '987654321')
+      await userEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+      await waitFor(() => {
+        expect(addPaymentMethod).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('remove payment method', () => {
+    it('calls removePaymentMethod when Remove is clicked', async () => {
+      const removePaymentMethod = vi.fn().mockResolvedValue({})
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: mockPaymentMethods }),
+          addPaymentMethod: vi.fn(),
+          removePaymentMethod,
+          setDefaultPaymentMethod: vi.fn(),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('button', { name: /remove/i })).toHaveLength(2)
+      })
+
+      await userEvent.click(screen.getAllByRole('button', { name: /remove/i })[0])
+
+      await waitFor(() => {
+        expect(removePaymentMethod).toHaveBeenCalledWith(
+          expect.objectContaining({ partyId: 'party-001' }),
+        )
+      })
+    })
+  })
+
+  describe('set default payment method', () => {
+    it('calls setDefaultPaymentMethod when Set Default is clicked', async () => {
+      const setDefaultPaymentMethod = vi.fn().mockResolvedValue({})
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: mockPaymentMethods }),
+          addPaymentMethod: vi.fn(),
+          removePaymentMethod: vi.fn(),
+          setDefaultPaymentMethod,
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /set default/i })).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByRole('button', { name: /set default/i }))
+
+      await waitFor(() => {
+        expect(setDefaultPaymentMethod).toHaveBeenCalledWith(
+          expect.objectContaining({ partyId: 'party-001', paymentMethodId: 'pm-002' }),
+        )
+      })
+    })
+  })
+})

--- a/frontend/src/pages/parties/tabs/references-tab.test.tsx
+++ b/frontend/src/pages/parties/tabs/references-tab.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('@/api/context', () => ({
+  useClients: vi.fn(),
+}))
+
+import { useClients } from '@/api/context'
+import { ReferencesTab } from './references-tab'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+    },
+  })
+}
+
+function renderTab(partyId = 'party-001') {
+  return render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <ReferencesTab partyId={partyId} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('ReferencesTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('loading state', () => {
+    it('renders skeletons while loading', () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getReferences: vi.fn(() => new Promise(() => {})),
+        },
+      } as ReturnType<typeof useClients>)
+
+      const { container } = renderTab()
+
+      const skeletons = container.querySelectorAll('.animate-pulse')
+      expect(skeletons.length).toBeGreaterThan(0)
+    })
+
+    it('does not render empty state while loading', () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getReferences: vi.fn(() => new Promise(() => {})),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      expect(screen.queryByRole('heading', { name: /references/i })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('empty state', () => {
+    it('renders empty state heading after data loads', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getReferences: vi.fn().mockResolvedValue({}),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /references/i })).toBeInTheDocument()
+      })
+    })
+
+    it('renders descriptive message', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getReferences: vi.fn().mockResolvedValue({}),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByText(/no references information available/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('query key', () => {
+    it('calls getReferences with the provided partyId', async () => {
+      const getReferences = vi.fn().mockResolvedValue({})
+      vi.mocked(useClients).mockReturnValue({
+        party: { getReferences },
+      } as ReturnType<typeof useClients>)
+
+      renderTab('party-xyz')
+
+      await waitFor(() => {
+        expect(getReferences).toHaveBeenCalledWith({ partyId: 'party-xyz' })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds 64 component tests for all 7 Party detail tab components in `frontend/src/pages/parties/tabs/`
- Achieves 100% statement/line coverage and 95.71% branch coverage (exceeds 80% threshold)
- Tests use `vi.mock('@/api/context')` pattern consistent with the existing `[partyId].test.tsx`

## Changes Made

| File | Coverage |
|------|----------|
| `overview-tab.test.tsx` | loading/empty/data states, TimeDisplay rendering, missing optional fields |
| `demographics-tab.test.tsx` | loading/empty/data states, edit mode toggle, form submission, cancel |
| `references-tab.test.tsx` | loading/empty states, query key verification |
| `associations-tab.test.tsx` | loading/empty states, query key verification |
| `bank-relations-tab.test.tsx` | loading/empty states, query key verification |
| `payment-methods-tab.test.tsx` | loading/empty/list states, add dialog, set default, remove |
| `audit-trail-tab.test.tsx` | passthrough props verification (entityType/entityId) |

## Test plan

- [x] All 64 tests pass locally
- [x] 100% statement coverage, 100% line coverage, 95.71% branch coverage
- [x] Consistent with established test patterns (vi.mock, QueryClient, no MSW for party service)

## Task Master

Task: 026-operations-console.43 - Add tests for Party detail tab components