### PR TITLE
feat: expose /variances endpoint and align frontend Variance type to proto

### DIFF
--- a/api/proto/meridian/reconciliation/v1/reconciliation.proto
+++ b/api/proto/meridian/reconciliation/v1/reconciliation.proto
@@ -796,6 +796,9 @@ service AccountReconciliationService {
   rpc ListReconciliationResults(ListReconciliationResultsRequest) returns (ListReconciliationResultsResponse) {
     option (google.api.http) = {
       get: "/v1/reconciliation/runs/{run_id}/results"
+      additional_bindings: {
+        get: "/v1/reconciliation/runs/{run_id}/variances"
+      }
     };
   }
 

--- a/frontend/src/components/reconciliation/variance-detail.test.tsx
+++ b/frontend/src/components/reconciliation/variance-detail.test.tsx
@@ -4,19 +4,17 @@ import { VarianceDetail, type Variance } from './variance-detail'
 
 const baseVariance: Variance = {
   varianceId: 'var-001',
-  reasonCode: 'AMOUNT_MISMATCH',
-  expected: {
-    amount: '10000',
-    currency: 'GBP',
-    direction: 'DEBIT',
-    entryId: 'entry-exp-1',
-  },
-  actual: {
-    amount: '9500',
-    currency: 'GBP',
-    direction: 'DEBIT',
-    entryId: 'entry-act-1',
-  },
+  runId: 'run-001',
+  snapshotId: 'snap-001',
+  accountId: 'acc-001',
+  instrumentCode: 'GBP',
+  expectedAmount: '100.00',
+  actualAmount: '95.00',
+  varianceAmount: '-5.00',
+  reason: 'VARIANCE_REASON_AMOUNT_MISMATCH',
+  status: 'VARIANCE_STATUS_OPEN',
+  createdAt: '2026-02-23T00:00:00Z',
+  updatedAt: '2026-02-23T00:00:00Z',
 }
 
 describe('VarianceDetail - rendering', () => {
@@ -25,55 +23,53 @@ describe('VarianceDetail - rendering', () => {
     expect(screen.getByText('var-001')).toBeInTheDocument()
   })
 
-  it('renders the reason code badge', () => {
+  it('renders the reason code badge with prefix stripped', () => {
     render(<VarianceDetail variance={baseVariance} />)
     expect(screen.getByText('AMOUNT_MISMATCH')).toBeInTheDocument()
   })
 
-  it('renders Expected and Actual section labels', () => {
+  it('renders the status badge with prefix stripped', () => {
+    render(<VarianceDetail variance={baseVariance} />)
+    expect(screen.getByText('OPEN')).toBeInTheDocument()
+  })
+
+  it('renders Expected, Actual, and Variance section labels', () => {
     render(<VarianceDetail variance={baseVariance} />)
     expect(screen.getByText('Expected')).toBeInTheDocument()
     expect(screen.getByText('Actual')).toBeInTheDocument()
+    expect(screen.getByText('Variance')).toBeInTheDocument()
   })
 
-  it('renders expected side direction', () => {
+  it('renders expected amount', () => {
     render(<VarianceDetail variance={baseVariance} />)
-    const directionTexts = screen.getAllByText(/Direction: DEBIT/)
-    expect(directionTexts.length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('100.00')).toBeInTheDocument()
   })
 
-  it('renders expected side entry ID', () => {
+  it('renders actual amount', () => {
     render(<VarianceDetail variance={baseVariance} />)
-    expect(screen.getByText(/entry-exp-1/)).toBeInTheDocument()
+    expect(screen.getByText('95.00')).toBeInTheDocument()
   })
 
-  it('renders actual side entry ID', () => {
+  it('renders variance amount', () => {
     render(<VarianceDetail variance={baseVariance} />)
-    expect(screen.getByText(/entry-act-1/)).toBeInTheDocument()
+    expect(screen.getByText('-5.00')).toBeInTheDocument()
   })
 
-  it('shows "No entry" when expected is null', () => {
-    const v: Variance = { ...baseVariance, expected: null }
+  it('renders account and instrument', () => {
+    render(<VarianceDetail variance={baseVariance} />)
+    expect(screen.getByText(/acc-001/)).toBeInTheDocument()
+    expect(screen.getByText(/GBP/)).toBeInTheDocument()
+  })
+
+  it('renders resolution note when provided', () => {
+    const v: Variance = { ...baseVariance, resolutionNote: 'Accepted as timing difference' }
     render(<VarianceDetail variance={v} />)
-    expect(screen.getByText('No entry')).toBeInTheDocument()
+    expect(screen.getByText('Accepted as timing difference')).toBeInTheDocument()
   })
 
-  it('shows "No entry" when actual is null', () => {
-    const v: Variance = { ...baseVariance, actual: null }
-    render(<VarianceDetail variance={v} />)
-    expect(screen.getByText('No entry')).toBeInTheDocument()
-  })
-
-  it('renders notes when provided', () => {
-    const v: Variance = { ...baseVariance, notes: 'Investigate this discrepancy' }
-    render(<VarianceDetail variance={v} />)
-    expect(screen.getByText('Investigate this discrepancy')).toBeInTheDocument()
-  })
-
-  it('does not render notes section when notes is absent', () => {
+  it('does not render resolution note section when absent', () => {
     render(<VarianceDetail variance={baseVariance} />)
-    // baseVariance has no notes
-    expect(screen.queryByText(/investigate/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/accepted/i)).not.toBeInTheDocument()
   })
 
   it('has data-testid variance-detail', () => {
@@ -84,22 +80,38 @@ describe('VarianceDetail - rendering', () => {
 
 describe('VarianceDetail - reason codes', () => {
   const reasonCodes = [
-    'AMOUNT_MISMATCH',
-    'MISSING_ENTRY',
-    'DUPLICATE_ENTRY',
-    'TIMING_DIFFERENCE',
-    'CURRENCY_MISMATCH',
-    'DIRECTION_ERROR',
-    'QUALITY_UPGRADE',
-    'EXTERNAL_MISMATCH',
-    'CORRECTION_APPLIED',
+    'VARIANCE_REASON_AMOUNT_MISMATCH',
+    'VARIANCE_REASON_MISSING_ENTRY',
+    'VARIANCE_REASON_DUPLICATE_ENTRY',
+    'VARIANCE_REASON_TIMING_DIFFERENCE',
+    'VARIANCE_REASON_CURRENCY_MISMATCH',
+    'VARIANCE_REASON_DIRECTION_ERROR',
+    'VARIANCE_REASON_OTHER',
   ] as const
 
   for (const code of reasonCodes) {
     it(`renders reason code: ${code}`, () => {
-      const v: Variance = { ...baseVariance, reasonCode: code }
+      const v: Variance = { ...baseVariance, reason: code }
       render(<VarianceDetail variance={v} />)
-      expect(screen.getByText(code)).toBeInTheDocument()
+      expect(screen.getByText(code.replace('VARIANCE_REASON_', ''))).toBeInTheDocument()
+    })
+  }
+})
+
+describe('VarianceDetail - status codes', () => {
+  const statuses = [
+    'VARIANCE_STATUS_OPEN',
+    'VARIANCE_STATUS_INVESTIGATING',
+    'VARIANCE_STATUS_DISPUTED',
+    'VARIANCE_STATUS_RESOLVED',
+    'VARIANCE_STATUS_ACCEPTED',
+  ] as const
+
+  for (const status of statuses) {
+    it(`renders status: ${status}`, () => {
+      const v: Variance = { ...baseVariance, status }
+      render(<VarianceDetail variance={v} />)
+      expect(screen.getByText(status.replace('VARIANCE_STATUS_', ''))).toBeInTheDocument()
     })
   }
 })

--- a/frontend/src/components/reconciliation/variance-detail.tsx
+++ b/frontend/src/components/reconciliation/variance-detail.tsx
@@ -1,63 +1,45 @@
 import { Badge } from '@/components/ui/badge'
-import { MoneyDisplay } from '@/components/shared/money-display'
 
-export const REASON_CODES = [
-  'AMOUNT_MISMATCH',
-  'MISSING_ENTRY',
-  'DUPLICATE_ENTRY',
-  'TIMING_DIFFERENCE',
-  'CURRENCY_MISMATCH',
-  'DIRECTION_ERROR',
-  'QUALITY_UPGRADE',
-  'EXTERNAL_MISMATCH',
-  'CORRECTION_APPLIED',
-] as const
+export type VarianceReason =
+  | 'VARIANCE_REASON_UNSPECIFIED'
+  | 'VARIANCE_REASON_AMOUNT_MISMATCH'
+  | 'VARIANCE_REASON_MISSING_ENTRY'
+  | 'VARIANCE_REASON_DUPLICATE_ENTRY'
+  | 'VARIANCE_REASON_TIMING_DIFFERENCE'
+  | 'VARIANCE_REASON_CURRENCY_MISMATCH'
+  | 'VARIANCE_REASON_DIRECTION_ERROR'
+  | 'VARIANCE_REASON_OTHER'
 
-export type ReasonCode = (typeof REASON_CODES)[number]
-
-export interface VarianceSide {
-  amount: string
-  currency: string
-  direction: string
-  entryId?: string
-}
+export type VarianceStatus =
+  | 'VARIANCE_STATUS_UNSPECIFIED'
+  | 'VARIANCE_STATUS_OPEN'
+  | 'VARIANCE_STATUS_INVESTIGATING'
+  | 'VARIANCE_STATUS_DISPUTED'
+  | 'VARIANCE_STATUS_RESOLVED'
+  | 'VARIANCE_STATUS_ACCEPTED'
 
 export interface Variance {
   varianceId: string
-  reasonCode: ReasonCode
-  expected: VarianceSide | null
-  actual: VarianceSide | null
-  notes?: string
-}
-
-function SideDisplay({ side, label }: { side: VarianceSide | null; label: string }) {
-  return (
-    <div className="flex-1 rounded-md border p-3">
-      <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-        {label}
-      </div>
-      {side ? (
-        <div className="space-y-1">
-          <div className="text-sm font-medium">
-            <MoneyDisplay amount={side.amount} currency={side.currency} showSign={false} />
-          </div>
-          <div className="text-xs text-muted-foreground">
-            Direction: {side.direction}
-          </div>
-          {side.entryId && (
-            <div className="font-mono text-xs text-muted-foreground">
-              Entry: {side.entryId}
-            </div>
-          )}
-        </div>
-      ) : (
-        <div className="text-sm text-muted-foreground italic">No entry</div>
-      )}
-    </div>
-  )
+  runId: string
+  snapshotId: string
+  accountId: string
+  instrumentCode: string
+  expectedAmount: string
+  actualAmount: string
+  varianceAmount: string
+  reason: VarianceReason
+  status: VarianceStatus
+  resolutionNote?: string
+  resolvedBy?: string
+  resolvedAt?: string
+  createdAt: string
+  updatedAt: string
 }
 
 export function VarianceDetail({ variance }: { variance: Variance }) {
+  const reasonLabel = variance.reason.replace('VARIANCE_REASON_', '')
+  const statusLabel = variance.status.replace('VARIANCE_STATUS_', '')
+
   return (
     <div
       data-testid="variance-detail"
@@ -67,14 +49,50 @@ export function VarianceDetail({ variance }: { variance: Variance }) {
         <span className="font-mono text-xs text-muted-foreground">
           {variance.varianceId}
         </span>
-        <Badge variant="outline">{variance.reasonCode}</Badge>
+        <Badge variant="outline">{reasonLabel}</Badge>
+        <Badge
+          variant={
+            variance.status === 'VARIANCE_STATUS_OPEN'
+              ? 'destructive'
+              : variance.status === 'VARIANCE_STATUS_RESOLVED' ||
+                  variance.status === 'VARIANCE_STATUS_ACCEPTED'
+                ? 'secondary'
+                : 'outline'
+          }
+        >
+          {statusLabel}
+        </Badge>
       </div>
+
       <div className="flex gap-3">
-        <SideDisplay side={variance.expected} label="Expected" />
-        <SideDisplay side={variance.actual} label="Actual" />
+        <div className="flex-1 rounded-md border p-3">
+          <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Expected
+          </div>
+          <div className="text-sm font-medium">{variance.expectedAmount}</div>
+        </div>
+        <div className="flex-1 rounded-md border p-3">
+          <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Actual
+          </div>
+          <div className="text-sm font-medium">{variance.actualAmount}</div>
+        </div>
+        <div className="flex-1 rounded-md border p-3">
+          <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Variance
+          </div>
+          <div className="text-sm font-medium">{variance.varianceAmount}</div>
+        </div>
       </div>
-      {variance.notes && (
-        <p className="mt-3 text-sm text-muted-foreground">{variance.notes}</p>
+
+      <div className="mt-2 text-xs text-muted-foreground">
+        Account: {variance.accountId} | Instrument: {variance.instrumentCode}
+      </div>
+
+      {variance.resolutionNote && (
+        <div className="mt-3 rounded-md bg-muted p-2 text-sm text-muted-foreground">
+          {variance.resolutionNote}
+        </div>
       )}
     </div>
   )

--- a/frontend/src/pages/reconciliation/detail.test.tsx
+++ b/frontend/src/pages/reconciliation/detail.test.tsx
@@ -107,15 +107,31 @@ const sampleRun = {
 const sampleVariances = [
   {
     varianceId: 'var-001',
-    reasonCode: 'AMOUNT_MISMATCH',
-    expected: { amount: '10000', currency: 'GBP', direction: 'DEBIT', entryId: 'e1' },
-    actual: { amount: '9500', currency: 'GBP', direction: 'DEBIT', entryId: 'e2' },
+    runId: 'run-001',
+    snapshotId: 'snap-001',
+    accountId: 'acc-001',
+    instrumentCode: 'GBP',
+    expectedAmount: '10000',
+    actualAmount: '9500',
+    varianceAmount: '-500',
+    reason: 'VARIANCE_REASON_AMOUNT_MISMATCH',
+    status: 'VARIANCE_STATUS_OPEN',
+    createdAt: '2026-02-23T00:00:00Z',
+    updatedAt: '2026-02-23T00:00:00Z',
   },
   {
     varianceId: 'var-002',
-    reasonCode: 'MISSING_ENTRY',
-    expected: { amount: '5000', currency: 'GBP', direction: 'CREDIT', entryId: 'e3' },
-    actual: null,
+    runId: 'run-001',
+    snapshotId: 'snap-001',
+    accountId: 'acc-002',
+    instrumentCode: 'GBP',
+    expectedAmount: '5000',
+    actualAmount: '0',
+    varianceAmount: '-5000',
+    reason: 'VARIANCE_REASON_MISSING_ENTRY',
+    status: 'VARIANCE_STATUS_OPEN',
+    createdAt: '2026-02-23T00:00:00Z',
+    updatedAt: '2026-02-23T00:00:00Z',
   },
 ]
 
@@ -153,7 +169,7 @@ function mockFetch(runDetail = sampleRun, variances = sampleVariances, disputes 
   vi.spyOn(globalThis, 'fetch').mockImplementation((input: RequestInfo | URL) => {
     const url = typeof input === 'string' ? input : input.toString()
     if (url.includes('/variances')) {
-      return Promise.resolve(new Response(JSON.stringify({ items: variances }), { status: 200 }))
+      return Promise.resolve(new Response(JSON.stringify({ variances, nextPageToken: '', totalCount: variances.length }), { status: 200 }))
     }
     if (url.includes('/disputes')) {
       return Promise.resolve(new Response(JSON.stringify({ items: disputes }), { status: 200 }))
@@ -397,7 +413,7 @@ describe('ReconciliationDetailPage - disputes tab', () => {
         return Promise.resolve(new Response(null, { status: 200 }))
       }
       if (url.includes('/variances')) {
-        return Promise.resolve(new Response(JSON.stringify({ items: sampleVariances }), { status: 200 }))
+        return Promise.resolve(new Response(JSON.stringify({ variances: sampleVariances, nextPageToken: '', totalCount: sampleVariances.length }), { status: 200 }))
       }
       if (url.includes('/disputes')) {
         return Promise.resolve(new Response(JSON.stringify({ items: sampleDisputes }), { status: 200 }))
@@ -507,7 +523,7 @@ describe('ReconciliationDetailPage - balance assertions tab', () => {
         return Promise.resolve(new Response(null, { status: 200 }))
       }
       if (url.includes('/variances')) {
-        return Promise.resolve(new Response(JSON.stringify({ items: sampleVariances }), { status: 200 }))
+        return Promise.resolve(new Response(JSON.stringify({ variances: sampleVariances, nextPageToken: '', totalCount: sampleVariances.length }), { status: 200 }))
       }
       if (url.includes('/disputes')) {
         return Promise.resolve(new Response(JSON.stringify({ items: sampleDisputes }), { status: 200 }))

--- a/frontend/src/pages/reconciliation/detail.tsx
+++ b/frontend/src/pages/reconciliation/detail.tsx
@@ -62,8 +62,8 @@ async function fetchRunDetail(runId: string): Promise<ReconciliationRunDetail> {
 async function fetchVariances(runId: string): Promise<Variance[]> {
   const res = await fetch(`/api/v1/reconciliation/runs/${runId}/variances`)
   if (!res.ok) throw new Error(`Failed to fetch variances: ${res.status}`)
-  const data = (await res.json()) as { items: Variance[] }
-  return data.items
+  const data = (await res.json()) as { variances: Variance[]; nextPageToken?: string; totalCount?: number }
+  return data.variances ?? []
 }
 
 async function fetchDisputes(runId: string): Promise<Dispute[]> {


### PR DESCRIPTION
## Summary

- Adds `additional_bindings` to `ListReconciliationResults` RPC in `reconciliation.proto` so `GET /v1/reconciliation/runs/{run_id}/variances` routes to the same handler as `/results`
- Aligns frontend `Variance` type in `variance-detail.tsx` to match proto `VarianceDetail` flat structure (replaces nested `expected`/`actual` objects with flat `expectedAmount`, `actualAmount`, `varianceAmount` strings plus `reason`/`status` enum strings)
- Updates `fetchVariances` in `detail.tsx` to read the `variances` response field from `ListReconciliationResultsResponse` (was incorrectly reading `items`)
- Updates all frontend tests to use the new Variance shape

## Changes Made

- `api/proto/meridian/reconciliation/v1/reconciliation.proto`: `additional_bindings` on `ListReconciliationResults`
- `frontend/src/components/reconciliation/variance-detail.tsx`: New flat `Variance` interface + updated `VarianceDetail` component rendering three amount columns (Expected / Actual / Variance)
- `frontend/src/components/reconciliation/variance-detail.test.tsx`: Tests for new flat structure including all reason codes and status values
- `frontend/src/pages/reconciliation/detail.tsx`: `fetchVariances` reads `data.variances` per proto response shape
- `frontend/src/pages/reconciliation/detail.test.tsx`: Updated sample data and mock responses to use new shape

## Test plan

- [x] All 53 frontend unit tests passing (`variance-detail.test.tsx` + `detail.test.tsx`)
- [x] Proto buf lint passes, no breaking changes
- [x] Pre-commit checks pass (gitleaks, buf lint)
- [ ] Verify both `/results` and `/variances` endpoints return identical data when services are running

## Technical Details

The `additional_bindings` pattern is already used elsewhere in the codebase (e.g. `current_account.proto` for `RetrieveWithdrawal`). This approach requires no server-side implementation changes — the gateway registers both URL patterns to the same RPC handler at startup.

The generated `.pb.go` files are gitignored and regenerated via `buf generate`. The OpenAPI spec (`meridian.swagger.json`) is also gitignored but was verified to contain the `/variances` path after generation.