### PR TITLE
feat: Create Manifest Management page in Operations Console

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -5,11 +5,13 @@ on:
     branches: [develop, main]
     paths:
       - 'frontend/**'
+      - 'api/proto/**'
       - '.github/workflows/frontend.yml'
   pull_request:
     branches: [develop, main]
     paths:
       - 'frontend/**'
+      - 'api/proto/**'
       - '.github/workflows/frontend.yml'
 
 permissions:
@@ -36,6 +38,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Generate protobuf TypeScript clients
+        run: npm run generate
 
       - name: Typecheck
         run: npm run typecheck
@@ -85,6 +90,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Generate protobuf TypeScript clients
+        run: npm run generate
 
       - name: Lint
         run: npm run lint

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ import { BookingLogDetailPage } from '@/pages/ledger/booking-log-detail'
 import { ReconciliationPage } from '@/pages/reconciliation'
 import { ReconciliationDetailPage } from '@/pages/reconciliation/detail'
 import { DashboardPage } from '@/pages/dashboard'
+import { ManifestsPage } from '@/pages/manifests'
 
 // Placeholder page components - replaced as each page task is implemented
 function PlaceholderPage({ title }: { title: string }) {
@@ -158,6 +159,7 @@ function AppShellLayout() {
         <Route path="/reference-data/nodes" element={<NodesPage />} />
         <Route path="/gateway-mappings" element={<MappingsPage />} />
         <Route path="/gateway-mappings/:mappingId" element={<MappingDetailPage />} />
+        <Route path="/manifests" element={<ManifestsPage />} />
         <Route path="/audit-log" element={<AuditLogPage />} />
 
         {/* Platform-only routes */}

--- a/frontend/src/api/clients.ts
+++ b/frontend/src/api/clients.ts
@@ -16,6 +16,8 @@ import { InternalBankAccountService } from './gen/meridian/internal_bank_account
 import { MarketInformationService } from './gen/meridian/market_information/v1/market_information_pb'
 import { MappingService } from './gen/meridian/mapping/v1/mapping_pb'
 import { ForecastingService } from './gen/meridian/forecasting/v1/forecasting_pb'
+import { ManifestHistoryService } from './gen/meridian/control_plane/v1/manifest_history_service_pb'
+import { ApplyManifestService } from './gen/meridian/control_plane/v1/apply_manifest_service_pb'
 
 export function createServiceClients(transport: Transport) {
   return {
@@ -35,6 +37,8 @@ export function createServiceClients(transport: Transport) {
     marketInformation: createClient(MarketInformationService, transport),
     mapping: createClient(MappingService, transport),
     forecasting: createClient(ForecastingService, transport),
+    manifestHistory: createClient(ManifestHistoryService, transport),
+    manifestApplier: createClient(ApplyManifestService, transport),
   }
 }
 

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -16,6 +16,7 @@ import {
   Map,
   ClipboardList,
   CheckSquare,
+  FileJson,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
@@ -39,6 +40,7 @@ const TENANT_NAV_ITEMS: NavItem[] = [
   { label: 'Forecasting', href: '/forecasting', icon: BarChart3 },
   { label: 'Reference Data', href: '/reference-data', icon: Database },
   { label: 'Gateway Mappings', href: '/gateway-mappings', icon: Map },
+  { label: 'Manifests', href: '/manifests', icon: FileJson },
   { label: 'Audit Log', href: '/audit-log', icon: ClipboardList },
 ]
 

--- a/frontend/src/components/shared/status-badge.tsx
+++ b/frontend/src/components/shared/status-badge.tsx
@@ -26,6 +26,9 @@ const STATUS_MAP: Record<string, StatusVariant> = {
   PROVISIONING_PENDING: 'info',
   PROVISIONING_FAILED: 'error',
   DEPROVISIONED: 'neutral',
+  // Manifest apply statuses
+  APPLIED: 'success',
+  ROLLED_BACK: 'warning',
   // Position quality ladder
   ESTIMATE: 'warning',
   COEFFICIENT: 'info',

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -39,3 +39,10 @@ export const platformKeys = {
 
   metrics: () => [...platformKeys.all, 'metrics'] as const,
 } as const
+
+export const manifestKeys = {
+  all: ['manifest'] as const,
+  current: () => [...manifestKeys.all, 'current'] as const,
+  history: () => [...manifestKeys.all, 'history'] as const,
+  version: (version: string) => [...manifestKeys.all, 'version', version] as const,
+} as const

--- a/frontend/src/pages/manifests/index.tsx
+++ b/frontend/src/pages/manifests/index.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { ManifestCurrentView } from './manifest-current-view'
+import { ManifestHistoryTable } from './manifest-history-table'
+import { ManifestApplyDialog } from './manifest-apply-dialog'
+import { Button } from '@/components/ui/button'
+import { Plus } from 'lucide-react'
+
+export function ManifestsPage() {
+  const [applyDialogOpen, setApplyDialogOpen] = useState(false)
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Manifest Configuration</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            View and manage tenant manifest configuration
+          </p>
+        </div>
+        <Button onClick={() => setApplyDialogOpen(true)}>
+          <Plus className="mr-2 size-4" />
+          Apply Manifest
+        </Button>
+      </div>
+
+      <Tabs defaultValue="current">
+        <TabsList>
+          <TabsTrigger value="current">Current Manifest</TabsTrigger>
+          <TabsTrigger value="history">Version History</TabsTrigger>
+        </TabsList>
+        <TabsContent value="current">
+          <ManifestCurrentView />
+        </TabsContent>
+        <TabsContent value="history">
+          <ManifestHistoryTable />
+        </TabsContent>
+      </Tabs>
+
+      <ManifestApplyDialog
+        open={applyDialogOpen}
+        onOpenChange={setApplyDialogOpen}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/manifests/manifest-apply-dialog.test.tsx
+++ b/frontend/src/pages/manifests/manifest-apply-dialog.test.tsx
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { ManifestApplyDialog } from './manifest-apply-dialog'
+import { ApplyManifestStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+  ApiClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+import { useApiClients } from '@/api/context'
+
+const mockDryRunResponse = {
+  jobId: 'job-123',
+  status: ApplyManifestStatus.DRY_RUN,
+  stepResults: [
+    { stepName: 'validate', status: 1, message: 'Validation passed', details: {} },
+    { stepName: 'diff', status: 1, message: '2 changes detected', details: {} },
+    { stepName: 'execute', status: 3, message: 'Skipped (dry run)', details: {} },
+  ],
+  snapshot: undefined,
+  validationErrors: [],
+  diffSummary: 'Added 2 instruments, 1 account type',
+}
+
+const mockApplyResponse = {
+  jobId: 'job-456',
+  status: ApplyManifestStatus.APPLIED,
+  stepResults: [],
+  snapshot: undefined,
+  validationErrors: [],
+  diffSummary: 'Applied successfully',
+}
+
+let applyManifestMock: ReturnType<typeof vi.fn>
+
+function mockApiClients() {
+  applyManifestMock = vi.fn()
+  vi.mocked(useApiClients).mockReturnValue({
+    manifestApplier: {
+      applyManifest: applyManifestMock,
+    },
+  } as unknown as ReturnType<typeof useApiClients>)
+}
+
+function renderDialog(open = true) {
+  const onOpenChange = vi.fn()
+  renderWithProviders(
+    <MemoryRouter>
+      <ManifestApplyDialog open={open} onOpenChange={onOpenChange} />
+    </MemoryRouter>,
+    { initialToken: createTenantUserToken() },
+  )
+  return { onOpenChange }
+}
+
+const validManifest = JSON.stringify({
+  version: '1.0',
+  metadata: { name: 'Test', industry: 'test', description: 'Test' },
+  instruments: [],
+  accountTypes: [],
+})
+
+describe('ManifestApplyDialog', () => {
+  beforeEach(() => mockApiClients())
+
+  it('renders dialog when open=true', () => {
+    renderDialog()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('does not render dialog when open=false', () => {
+    renderDialog(false)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders JSON textarea', () => {
+    renderDialog()
+    expect(screen.getByLabelText(/manifest json/i)).toBeInTheDocument()
+  })
+
+  it('Preview button disabled when JSON is empty', () => {
+    renderDialog()
+    const previewBtn = screen.getByRole('button', { name: /preview changes/i })
+    expect(previewBtn).toBeDisabled()
+  })
+
+  it('Apply button disabled until preview succeeds', () => {
+    renderDialog()
+    const applyBtn = screen.getByRole('button', { name: /apply manifest/i })
+    expect(applyBtn).toBeDisabled()
+  })
+
+  it('calls ApplyManifest with dry_run=true on Preview', async () => {
+    applyManifestMock.mockResolvedValue(mockDryRunResponse)
+    renderDialog()
+
+    const textarea = screen.getByLabelText(/manifest json/i)
+    fireEvent.change(textarea, { target: { value: validManifest } })
+
+    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+
+    await waitFor(() => {
+      expect(applyManifestMock).toHaveBeenCalledWith(
+        expect.objectContaining({ dryRun: true }),
+      )
+    })
+  })
+
+  it('displays dry run result panel after preview', async () => {
+    applyManifestMock.mockResolvedValue(mockDryRunResponse)
+    renderDialog()
+
+    const textarea = screen.getByLabelText(/manifest json/i)
+    fireEvent.change(textarea, { target: { value: validManifest } })
+
+    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dry-run-result')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/Added 2 instruments, 1 account type/)).toBeInTheDocument()
+  })
+
+  it('displays step results in dry run panel', async () => {
+    applyManifestMock.mockResolvedValue(mockDryRunResponse)
+    renderDialog()
+
+    const textarea = screen.getByLabelText(/manifest json/i)
+    fireEvent.change(textarea, { target: { value: validManifest } })
+
+    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('validate')).toBeInTheDocument()
+    })
+    expect(screen.getByText('diff')).toBeInTheDocument()
+  })
+
+  it('enables Apply button after successful preview', async () => {
+    applyManifestMock.mockResolvedValue(mockDryRunResponse)
+    renderDialog()
+
+    const textarea = screen.getByLabelText(/manifest json/i)
+    fireEvent.change(textarea, { target: { value: validManifest } })
+
+    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+
+    await waitFor(() => {
+      const applyBtn = screen.getByRole('button', { name: /apply manifest/i })
+      expect(applyBtn).not.toBeDisabled()
+    })
+  })
+
+  it('calls ApplyManifest with dry_run=false on Apply', async () => {
+    applyManifestMock
+      .mockResolvedValueOnce(mockDryRunResponse)
+      .mockResolvedValueOnce(mockApplyResponse)
+
+    renderDialog()
+
+    const textarea = screen.getByLabelText(/manifest json/i)
+    fireEvent.change(textarea, { target: { value: validManifest } })
+
+    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dry-run-result')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /apply manifest/i }))
+
+    await waitFor(() => {
+      expect(applyManifestMock).toHaveBeenCalledWith(
+        expect.objectContaining({ dryRun: false }),
+      )
+    })
+  })
+
+  it('shows parse error for invalid JSON', async () => {
+    applyManifestMock.mockRejectedValue(new Error('Unexpected token'))
+    renderDialog()
+
+    const textarea = screen.getByLabelText(/manifest json/i)
+    fireEvent.change(textarea, { target: { value: 'not-json' } })
+
+    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('parse-error')).toBeInTheDocument()
+    })
+  })
+
+  it('shows validation errors when preview returns VALIDATION_FAILED', async () => {
+    applyManifestMock.mockResolvedValue({
+      ...mockDryRunResponse,
+      status: ApplyManifestStatus.VALIDATION_FAILED,
+      validationErrors: [
+        {
+          severity: 'ERROR',
+          path: 'instruments[0].code',
+          code: 'INVALID_CODE',
+          message: 'Code must be uppercase',
+          suggestion: 'Use GBP',
+        },
+      ],
+    })
+
+    renderDialog()
+
+    const textarea = screen.getByLabelText(/manifest json/i)
+    fireEvent.change(textarea, { target: { value: validManifest } })
+
+    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('validation-errors')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/Code must be uppercase/)).toBeInTheDocument()
+  })
+
+  it('Apply button stays disabled after validation failure', async () => {
+    applyManifestMock.mockResolvedValue({
+      ...mockDryRunResponse,
+      status: ApplyManifestStatus.VALIDATION_FAILED,
+      validationErrors: [
+        { severity: 'ERROR', path: 'instruments[0]', code: 'ERR', message: 'Bad', suggestion: '' },
+      ],
+    })
+
+    renderDialog()
+
+    const textarea = screen.getByLabelText(/manifest json/i)
+    fireEvent.change(textarea, { target: { value: validManifest } })
+
+    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('validation-errors')).toBeInTheDocument()
+    })
+
+    const applyBtn = screen.getByRole('button', { name: /apply manifest/i })
+    expect(applyBtn).toBeDisabled()
+  })
+})

--- a/frontend/src/pages/manifests/manifest-apply-dialog.tsx
+++ b/frontend/src/pages/manifests/manifest-apply-dialog.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { useApiClients } from '@/api/context'
+import { useAuth } from '@/contexts/auth-context'
 import { manifestKeys } from '@/lib/query-keys'
 import {
   ApplyManifestStatus,
@@ -26,15 +27,20 @@ interface ManifestApplyDialogProps {
 
 export function ManifestApplyDialog({ open, onOpenChange }: ManifestApplyDialogProps) {
   const { manifestApplier } = useApiClients()
+  const { claims } = useAuth()
   const queryClient = useQueryClient()
   const [manifestJson, setManifestJson] = useState('')
   const [dryRunResult, setDryRunResult] = useState<ApplyManifestResponse | null>(null)
   const [parseError, setParseError] = useState<string | null>(null)
+  const [applyError, setApplyError] = useState<string | null>(null)
+
+  const appliedBy = claims?.userId ?? 'unknown'
 
   function resetState() {
     setManifestJson('')
     setDryRunResult(null)
     setParseError(null)
+    setApplyError(null)
   }
 
   function handleOpenChange(nextOpen: boolean) {
@@ -49,7 +55,7 @@ export function ManifestApplyDialog({ open, onOpenChange }: ManifestApplyDialogP
       return manifestApplier.applyManifest({
         manifest,
         dryRun: true,
-        appliedBy: 'console-user',
+        appliedBy,
       })
     },
     onSuccess: (result) => {
@@ -69,18 +75,29 @@ export function ManifestApplyDialog({ open, onOpenChange }: ManifestApplyDialogP
       return manifestApplier.applyManifest({
         manifest,
         dryRun: false,
-        appliedBy: 'console-user',
+        appliedBy,
       })
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: manifestKeys.all })
       handleOpenChange(false)
     },
+    onError: (err: Error) => {
+      setApplyError(err.message)
+    },
   })
+
+  function handleJsonChange(value: string) {
+    setManifestJson(value)
+    setDryRunResult(null)
+    setParseError(null)
+    setApplyError(null)
+  }
 
   function handlePreview() {
     setParseError(null)
     setDryRunResult(null)
+    setApplyError(null)
     dryRunMutation.mutate()
   }
 
@@ -108,7 +125,7 @@ export function ManifestApplyDialog({ open, onOpenChange }: ManifestApplyDialogP
             <textarea
               id="manifest-json"
               value={manifestJson}
-              onChange={(e) => setManifestJson(e.target.value)}
+              onChange={(e) => handleJsonChange(e.target.value)}
               className="min-h-[200px] w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm"
               placeholder='{"version": "1.0", "metadata": {...}, "instruments": [...]}'
             />
@@ -121,6 +138,12 @@ export function ManifestApplyDialog({ open, onOpenChange }: ManifestApplyDialogP
           )}
 
           {dryRunResult && <DryRunResultPanel result={dryRunResult} />}
+
+          {applyError && (
+            <div data-testid="apply-error" className="rounded border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+              Apply failed: {applyError}
+            </div>
+          )}
         </div>
 
         <DialogFooter>

--- a/frontend/src/pages/manifests/manifest-apply-dialog.tsx
+++ b/frontend/src/pages/manifests/manifest-apply-dialog.tsx
@@ -1,0 +1,196 @@
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { useApiClients } from '@/api/context'
+import { manifestKeys } from '@/lib/query-keys'
+import {
+  ApplyManifestStatus,
+  type ApplyManifestResponse,
+  type StepResult,
+  type ValidationError,
+} from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+import { create } from '@bufbuild/protobuf'
+import { ManifestSchema } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
+
+interface ManifestApplyDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ManifestApplyDialog({ open, onOpenChange }: ManifestApplyDialogProps) {
+  const { manifestApplier } = useApiClients()
+  const queryClient = useQueryClient()
+  const [manifestJson, setManifestJson] = useState('')
+  const [dryRunResult, setDryRunResult] = useState<ApplyManifestResponse | null>(null)
+  const [parseError, setParseError] = useState<string | null>(null)
+
+  function resetState() {
+    setManifestJson('')
+    setDryRunResult(null)
+    setParseError(null)
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) resetState()
+    onOpenChange(nextOpen)
+  }
+
+  const dryRunMutation = useMutation({
+    mutationFn: async () => {
+      const parsed = JSON.parse(manifestJson) as Record<string, unknown>
+      const manifest = create(ManifestSchema, parsed)
+      return manifestApplier.applyManifest({
+        manifest,
+        dryRun: true,
+        appliedBy: 'console-user',
+      })
+    },
+    onSuccess: (result) => {
+      setDryRunResult(result)
+      setParseError(null)
+    },
+    onError: (err: Error) => {
+      setParseError(err.message)
+      setDryRunResult(null)
+    },
+  })
+
+  const applyMutation = useMutation({
+    mutationFn: async () => {
+      const parsed = JSON.parse(manifestJson) as Record<string, unknown>
+      const manifest = create(ManifestSchema, parsed)
+      return manifestApplier.applyManifest({
+        manifest,
+        dryRun: false,
+        appliedBy: 'console-user',
+      })
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: manifestKeys.all })
+      handleOpenChange(false)
+    },
+  })
+
+  function handlePreview() {
+    setParseError(null)
+    setDryRunResult(null)
+    dryRunMutation.mutate()
+  }
+
+  function handleApply() {
+    applyMutation.mutate()
+  }
+
+  const previewSucceeded =
+    dryRunResult != null &&
+    dryRunResult.status !== ApplyManifestStatus.VALIDATION_FAILED &&
+    dryRunResult.status !== ApplyManifestStatus.FAILED
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Apply Manifest</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <label htmlFor="manifest-json" className="text-sm font-medium">
+              Manifest JSON
+            </label>
+            <textarea
+              id="manifest-json"
+              value={manifestJson}
+              onChange={(e) => setManifestJson(e.target.value)}
+              className="min-h-[200px] w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm"
+              placeholder='{"version": "1.0", "metadata": {...}, "instruments": [...]}'
+            />
+          </div>
+
+          {parseError && (
+            <div data-testid="parse-error" className="rounded border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+              {parseError}
+            </div>
+          )}
+
+          {dryRunResult && <DryRunResultPanel result={dryRunResult} />}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handlePreview}
+            disabled={!manifestJson.trim() || dryRunMutation.isPending}
+          >
+            {dryRunMutation.isPending ? 'Previewing...' : 'Preview Changes'}
+          </Button>
+          <Button
+            type="button"
+            onClick={handleApply}
+            disabled={!previewSucceeded || applyMutation.isPending}
+          >
+            {applyMutation.isPending ? 'Applying...' : 'Apply Manifest'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function DryRunResultPanel({ result }: { result: ApplyManifestResponse }) {
+  const isFailed =
+    result.status === ApplyManifestStatus.VALIDATION_FAILED ||
+    result.status === ApplyManifestStatus.FAILED
+
+  return (
+    <div data-testid="dry-run-result" className="rounded border border-border bg-muted/30 p-3 text-sm">
+      <h4 className="mb-2 font-medium">Preview Results</h4>
+
+      {result.diffSummary && (
+        <p className="mb-2 text-muted-foreground">{result.diffSummary}</p>
+      )}
+
+      {result.stepResults.length > 0 && (
+        <div className="mb-2">
+          <p className="text-xs font-medium text-muted-foreground">Steps:</p>
+          <ul className="mt-1 space-y-1">
+            {result.stepResults.map((step: StepResult, i: number) => (
+              <li key={i} className="flex items-center gap-2 text-xs">
+                <span className="font-mono">{step.stepName}</span>
+                <span className={step.status === 1 ? 'text-green-600' : step.status === 2 ? 'text-red-600' : 'text-muted-foreground'}>
+                  {step.status === 1 ? 'SUCCESS' : step.status === 2 ? 'FAILED' : 'SKIPPED'}
+                </span>
+                {step.message && <span className="text-muted-foreground">- {step.message}</span>}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {isFailed && result.validationErrors.length > 0 && (
+        <div data-testid="validation-errors">
+          <p className="text-xs font-medium text-destructive">Validation Errors:</p>
+          <ul className="mt-1 space-y-1">
+            {result.validationErrors.map((err: ValidationError, i: number) => (
+              <li key={i} className="text-xs text-destructive">
+                <span className="font-mono">{err.path}</span>: {err.message}
+                {err.suggestion && <span className="ml-1 text-muted-foreground">({err.suggestion})</span>}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/manifests/manifest-current-view.test.tsx
+++ b/frontend/src/pages/manifests/manifest-current-view.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { ManifestCurrentView } from './manifest-current-view'
+import { ApplyStatus } from '@/api/gen/meridian/control_plane/v1/manifest_history_service_pb'
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+  ApiClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+import { useApiClients } from '@/api/context'
+
+const mockManifestVersion = {
+  id: 'mv-123',
+  version: '1.0',
+  manifest: {
+    version: '1.0',
+    metadata: {
+      name: 'Acme Energy',
+      industry: 'energy',
+      description: 'Test manifest',
+    },
+    instruments: [
+      {
+        code: 'GBP',
+        name: 'British Pound',
+        type: 1,
+        dimensions: { unit: 'GBP', precision: 2 },
+      },
+      {
+        code: 'KWH',
+        name: 'Kilowatt Hour',
+        type: 2,
+        dimensions: { unit: 'kWh', precision: 4 },
+      },
+    ],
+    accountTypes: [
+      {
+        code: 'CURRENT',
+        name: 'Current Account',
+        normalBalance: 1,
+        allowedInstruments: [],
+        policies: undefined,
+      },
+    ],
+    valuationRules: [],
+    sagas: [
+      {
+        name: 'process_payment',
+        trigger: 'api:/v1/payments',
+        script: 'def main(): pass',
+      },
+    ],
+    seedData: undefined,
+    paymentRails: [],
+    partyTypes: [],
+    mappings: [],
+  },
+  appliedAt: { seconds: BigInt(1700000000), nanos: 0 },
+  appliedBy: 'admin@example.com',
+  applyStatus: ApplyStatus.APPLIED,
+  applyJobId: 'job-456',
+  diffSummary: 'Added 2 instruments',
+  createdAt: { seconds: BigInt(1700000000), nanos: 0 },
+}
+
+function mockApiClients(overrides: Record<string, unknown> = {}) {
+  vi.mocked(useApiClients).mockReturnValue({
+    manifestHistory: {
+      getCurrentManifest: vi.fn().mockResolvedValue({ version: mockManifestVersion }),
+      listManifestVersions: vi.fn(),
+      getManifestVersion: vi.fn(),
+      ...overrides,
+    },
+  } as unknown as ReturnType<typeof useApiClients>)
+}
+
+function renderComponent() {
+  return renderWithProviders(
+    <MemoryRouter>
+      <ManifestCurrentView />
+    </MemoryRouter>,
+    { initialToken: createTenantUserToken() },
+  )
+}
+
+describe('ManifestCurrentView', () => {
+  beforeEach(() => mockApiClients())
+
+  it('renders loading skeleton while query pending', () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: {
+        getCurrentManifest: vi.fn().mockReturnValue(new Promise(() => {})),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderComponent()
+
+    expect(screen.getByTestId('loading-skeleton')).toBeInTheDocument()
+  })
+
+  it('renders current manifest version and status', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('Version 1.0')).toBeInTheDocument()
+    })
+    expect(screen.getByText('APPLIED')).toBeInTheDocument()
+  })
+
+  it('renders appliedBy', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText(/admin@example.com/)).toBeInTheDocument()
+    })
+  })
+
+  it('renders manifest metadata', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('Acme Energy')).toBeInTheDocument()
+    })
+    expect(screen.getByText('(energy)')).toBeInTheDocument()
+  })
+
+  it('renders expandable sections with counts', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Instruments \(2\)/)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/Account Types \(1\)/)).toBeInTheDocument()
+    expect(screen.getByText(/Valuation Rules \(0\)/)).toBeInTheDocument()
+    expect(screen.getByText(/Sagas \(1\)/)).toBeInTheDocument()
+  })
+
+  it('expands instruments section on click', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Instruments \(2\)/)).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByText(/Instruments \(2\)/))
+
+    expect(screen.getByText('GBP')).toBeInTheDocument()
+    expect(screen.getByText('British Pound')).toBeInTheDocument()
+    expect(screen.getByText('KWH')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no manifest applied', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: {
+        getCurrentManifest: vi.fn().mockResolvedValue({ version: undefined }),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error state with retry button when API fails', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: {
+        getCurrentManifest: vi.fn().mockRejectedValue(new Error('Server Error')),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/manifests/manifest-current-view.tsx
+++ b/frontend/src/pages/manifests/manifest-current-view.tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
+import { StatusBadge } from '@/components/shared/status-badge'
+import { TimeDisplay } from '@/components/shared/time-display'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { manifestKeys } from '@/lib/query-keys'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { ApplyStatus } from '@/api/gen/meridian/control_plane/v1/manifest_history_service_pb'
+
+const APPLY_STATUS_LABEL: Record<number, string> = {
+  [ApplyStatus.APPLIED]: 'APPLIED',
+  [ApplyStatus.FAILED]: 'FAILED',
+  [ApplyStatus.ROLLED_BACK]: 'ROLLED_BACK',
+}
+
+function LoadingSkeleton() {
+  return (
+    <div data-testid="loading-skeleton" className="space-y-4">
+      <Skeleton className="h-6 w-48" />
+      <Skeleton className="h-4 w-32" />
+      <Skeleton className="h-24 w-full" />
+    </div>
+  )
+}
+
+function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="flex flex-col items-center gap-3 py-8 text-destructive">
+      <span className="text-sm font-medium">Failed to load current manifest</span>
+      <Button variant="outline" size="sm" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div data-testid="empty-state" className="flex flex-col items-center gap-2 py-8 text-muted-foreground">
+      <span className="text-sm font-medium">No manifest applied</span>
+      <span className="text-xs">Apply a manifest to get started.</span>
+    </div>
+  )
+}
+
+interface ExpandableSectionProps {
+  title: string
+  count: number
+  children: React.ReactNode
+}
+
+function ExpandableSection({ title, count, children }: ExpandableSectionProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="border-b border-border last:border-b-0">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center gap-2 px-4 py-2 text-sm font-medium hover:bg-muted/50"
+        aria-expanded={open}
+      >
+        {open ? <ChevronDown className="size-4" /> : <ChevronRight className="size-4" />}
+        {title} ({count})
+      </button>
+      {open && <div className="px-4 pb-3">{children}</div>}
+    </div>
+  )
+}
+
+export function ManifestCurrentView() {
+  const { manifestHistory } = useApiClients()
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: manifestKeys.current(),
+    queryFn: () => manifestHistory.getCurrentManifest({}),
+  })
+
+  if (isLoading) return <LoadingSkeleton />
+  if (error) return <ErrorState onRetry={() => void refetch()} />
+  if (!data?.version) return <EmptyState />
+
+  const { version, manifest, appliedAt, appliedBy, applyStatus } = data.version
+  const statusLabel = APPLY_STATUS_LABEL[applyStatus] ?? 'UNKNOWN'
+
+  const instruments = manifest?.instruments ?? []
+  const accountTypes = manifest?.accountTypes ?? []
+  const valuationRules = manifest?.valuationRules ?? []
+  const sagas = manifest?.sagas ?? []
+
+  return (
+    <Card className="overflow-hidden">
+      <div className="border-b border-border px-4 py-3">
+        <div className="flex items-center gap-3">
+          <h3 className="text-lg font-semibold">Version {version}</h3>
+          <StatusBadge status={statusLabel} />
+        </div>
+        <div className="mt-1 flex items-center gap-4 text-sm text-muted-foreground">
+          <span>Applied by {appliedBy}</span>
+          <TimeDisplay timestamp={appliedAt} />
+        </div>
+        {manifest?.metadata && (
+          <div className="mt-2 text-sm text-muted-foreground">
+            <span className="font-medium">{manifest.metadata.name}</span>
+            {manifest.metadata.industry && (
+              <span className="ml-2 text-xs">({manifest.metadata.industry})</span>
+            )}
+          </div>
+        )}
+      </div>
+
+      <ExpandableSection title="Instruments" count={instruments.length}>
+        {instruments.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No instruments defined.</p>
+        ) : (
+          <ul className="space-y-1 text-xs">
+            {instruments.map((inst) => (
+              <li key={inst.code} className="flex items-center gap-2">
+                <code className="rounded bg-muted px-1.5 py-0.5 font-mono">{inst.code}</code>
+                <span>{inst.name}</span>
+                <span className="text-muted-foreground">({inst.dimensions?.unit})</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </ExpandableSection>
+
+      <ExpandableSection title="Account Types" count={accountTypes.length}>
+        {accountTypes.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No account types defined.</p>
+        ) : (
+          <ul className="space-y-1 text-xs">
+            {accountTypes.map((at) => (
+              <li key={at.code} className="flex items-center gap-2">
+                <code className="rounded bg-muted px-1.5 py-0.5 font-mono">{at.code}</code>
+                <span>{at.name}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </ExpandableSection>
+
+      <ExpandableSection title="Valuation Rules" count={valuationRules.length}>
+        {valuationRules.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No valuation rules defined.</p>
+        ) : (
+          <ul className="space-y-1 text-xs">
+            {valuationRules.map((rule, i) => (
+              <li key={i} className="flex items-center gap-2">
+                <code className="font-mono">{rule.fromInstrument}</code>
+                <span>-&gt;</span>
+                <code className="font-mono">{rule.toInstrument}</code>
+              </li>
+            ))}
+          </ul>
+        )}
+      </ExpandableSection>
+
+      <ExpandableSection title="Sagas" count={sagas.length}>
+        {sagas.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No sagas defined.</p>
+        ) : (
+          <ul className="space-y-1 text-xs">
+            {sagas.map((saga) => (
+              <li key={saga.name} className="flex items-center gap-2">
+                <code className="rounded bg-muted px-1.5 py-0.5 font-mono">{saga.name}</code>
+                <span className="text-muted-foreground">{saga.trigger}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </ExpandableSection>
+    </Card>
+  )
+}

--- a/frontend/src/pages/manifests/manifest-current-view.tsx
+++ b/frontend/src/pages/manifests/manifest-current-view.tsx
@@ -121,7 +121,9 @@ export function ManifestCurrentView() {
               <li key={inst.code} className="flex items-center gap-2">
                 <code className="rounded bg-muted px-1.5 py-0.5 font-mono">{inst.code}</code>
                 <span>{inst.name}</span>
-                <span className="text-muted-foreground">({inst.dimensions?.unit})</span>
+                {inst.dimensions?.unit && (
+                  <span className="text-muted-foreground">({inst.dimensions.unit})</span>
+                )}
               </li>
             ))}
           </ul>

--- a/frontend/src/pages/manifests/manifest-history-table.test.tsx
+++ b/frontend/src/pages/manifests/manifest-history-table.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { ManifestHistoryTable } from './manifest-history-table'
+import { ApplyStatus } from '@/api/gen/meridian/control_plane/v1/manifest_history_service_pb'
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+  ApiClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+import { useApiClients } from '@/api/context'
+
+const mockVersions = [
+  {
+    id: 'mv-1',
+    version: '1.0',
+    manifest: { version: '1.0', metadata: { name: 'Test' } },
+    appliedAt: { seconds: BigInt(1700000000), nanos: 0 },
+    appliedBy: 'admin@example.com',
+    applyStatus: ApplyStatus.APPLIED,
+    applyJobId: 'job-1',
+    diffSummary: 'Initial manifest',
+    createdAt: { seconds: BigInt(1700000000), nanos: 0 },
+  },
+  {
+    id: 'mv-2',
+    version: '1.1',
+    manifest: { version: '1.1', metadata: { name: 'Test v1.1' } },
+    appliedAt: { seconds: BigInt(1700001000), nanos: 0 },
+    appliedBy: 'ops@example.com',
+    applyStatus: ApplyStatus.FAILED,
+    applyJobId: 'job-2',
+    diffSummary: 'Added instrument',
+    createdAt: { seconds: BigInt(1700001000), nanos: 0 },
+  },
+  {
+    id: 'mv-3',
+    version: '1.2',
+    manifest: { version: '1.2', metadata: { name: 'Test v1.2' } },
+    appliedAt: { seconds: BigInt(1700002000), nanos: 0 },
+    appliedBy: 'dev@example.com',
+    applyStatus: ApplyStatus.ROLLED_BACK,
+    applyJobId: undefined,
+    diffSummary: undefined,
+    createdAt: { seconds: BigInt(1700002000), nanos: 0 },
+  },
+]
+
+function mockApiClients(overrides: Record<string, unknown> = {}) {
+  vi.mocked(useApiClients).mockReturnValue({
+    manifestHistory: {
+      getCurrentManifest: vi.fn(),
+      listManifestVersions: vi.fn().mockResolvedValue({
+        versions: mockVersions,
+        totalCount: 3,
+      }),
+      getManifestVersion: vi.fn(),
+      ...overrides,
+    },
+  } as unknown as ReturnType<typeof useApiClients>)
+}
+
+function renderComponent() {
+  return renderWithProviders(
+    <MemoryRouter>
+      <ManifestHistoryTable />
+    </MemoryRouter>,
+    { initialToken: createTenantUserToken() },
+  )
+}
+
+describe('ManifestHistoryTable', () => {
+  beforeEach(() => mockApiClients())
+
+  it('renders table with version column', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('1.0')).toBeInTheDocument()
+    })
+    expect(screen.getByText('1.1')).toBeInTheDocument()
+    expect(screen.getByText('1.2')).toBeInTheDocument()
+  })
+
+  it('renders appliedBy column', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('admin@example.com')).toBeInTheDocument()
+    })
+    expect(screen.getByText('ops@example.com')).toBeInTheDocument()
+  })
+
+  it('renders status badges', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('APPLIED')).toBeInTheDocument()
+    })
+    expect(screen.getByText('FAILED')).toBeInTheDocument()
+    expect(screen.getByText('ROLLED BACK')).toBeInTheDocument()
+  })
+
+  it('renders diff summary', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('Initial manifest')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Added instrument')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no versions exist', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: {
+        listManifestVersions: vi.fn().mockResolvedValue({ versions: [], totalCount: 0 }),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error state with retry button when API fails', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: {
+        listManifestVersions: vi.fn().mockRejectedValue(new Error('Server Error')),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    })
+  })
+
+  it('opens detail dialog on row click', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByText('1.0')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByText('1.0'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/Manifest Version 1.0/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/manifests/manifest-history-table.tsx
+++ b/frontend/src/pages/manifests/manifest-history-table.tsx
@@ -58,7 +58,8 @@ export function ManifestHistoryTable() {
   const [selectedVersion, setSelectedVersion] = useState<ManifestVersion | null>(null)
 
   async function fetchVersions(params: DataTableQueryParams): Promise<DataTableResult<ManifestVersion>> {
-    const offset = params.pageToken ? parseInt(params.pageToken, 10) : 0
+    const parsed = params.pageToken ? parseInt(params.pageToken, 10) : 0
+    const offset = Number.isNaN(parsed) ? 0 : parsed
     const response = await manifestHistory.listManifestVersions({
       limit: params.pageSize,
       offset,

--- a/frontend/src/pages/manifests/manifest-history-table.tsx
+++ b/frontend/src/pages/manifests/manifest-history-table.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import type { ColumnDef } from '@tanstack/react-table'
+import { DataTable, type DataTableQueryParams, type DataTableResult } from '@/components/shared/data-table'
+import { useApiClients } from '@/api/context'
+import { StatusBadge } from '@/components/shared/status-badge'
+import { TimeDisplay } from '@/components/shared/time-display'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { manifestKeys } from '@/lib/query-keys'
+import type { ManifestVersion } from '@/api/gen/meridian/control_plane/v1/manifest_history_service_pb'
+import { ApplyStatus } from '@/api/gen/meridian/control_plane/v1/manifest_history_service_pb'
+
+const APPLY_STATUS_LABEL: Record<number, string> = {
+  [ApplyStatus.APPLIED]: 'APPLIED',
+  [ApplyStatus.FAILED]: 'FAILED',
+  [ApplyStatus.ROLLED_BACK]: 'ROLLED_BACK',
+}
+
+const columns: ColumnDef<ManifestVersion>[] = [
+  {
+    accessorKey: 'version',
+    header: 'Version',
+  },
+  {
+    accessorKey: 'appliedAt',
+    header: 'Applied At',
+    cell: ({ row }) => <TimeDisplay timestamp={row.original.appliedAt} />,
+  },
+  {
+    accessorKey: 'appliedBy',
+    header: 'Applied By',
+  },
+  {
+    accessorKey: 'applyStatus',
+    header: 'Status',
+    cell: ({ row }) => {
+      const label = APPLY_STATUS_LABEL[row.original.applyStatus] ?? 'UNKNOWN'
+      return <StatusBadge status={label} />
+    },
+  },
+  {
+    accessorKey: 'diffSummary',
+    header: 'Changes',
+    cell: ({ row }) => (
+      <span className="text-sm text-muted-foreground">
+        {row.original.diffSummary ?? '\u2014'}
+      </span>
+    ),
+  },
+]
+
+export function ManifestHistoryTable() {
+  const { manifestHistory } = useApiClients()
+  const [selectedVersion, setSelectedVersion] = useState<ManifestVersion | null>(null)
+
+  async function fetchVersions(params: DataTableQueryParams): Promise<DataTableResult<ManifestVersion>> {
+    const offset = params.pageToken ? parseInt(params.pageToken, 10) : 0
+    const response = await manifestHistory.listManifestVersions({
+      limit: params.pageSize,
+      offset,
+    })
+    const nextOffset = offset + params.pageSize
+    return {
+      items: response.versions ?? [],
+      nextPageToken: nextOffset < response.totalCount ? String(nextOffset) : undefined,
+    }
+  }
+
+  return (
+    <>
+      <DataTable<ManifestVersion>
+        queryKey={manifestKeys.history()}
+        queryFn={fetchVersions}
+        columns={columns}
+        pageSize={20}
+        onRowClick={setSelectedVersion}
+      />
+
+      <Dialog open={selectedVersion != null} onOpenChange={() => setSelectedVersion(null)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Manifest Version {selectedVersion?.version}</DialogTitle>
+          </DialogHeader>
+          <pre className="max-h-[400px] overflow-auto rounded bg-muted p-3 text-xs font-mono">
+            {JSON.stringify(selectedVersion?.manifest, null, 2)}
+          </pre>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/frontend/src/pages/manifests/manifests-page.test.tsx
+++ b/frontend/src/pages/manifests/manifests-page.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { ManifestsPage } from './index'
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+  ApiClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+import { useApiClients } from '@/api/context'
+
+function mockApiClients() {
+  vi.mocked(useApiClients).mockReturnValue({
+    manifestHistory: {
+      getCurrentManifest: vi.fn().mockResolvedValue({ version: null }),
+      listManifestVersions: vi.fn().mockResolvedValue({ versions: [], totalCount: 0 }),
+      getManifestVersion: vi.fn(),
+    },
+    manifestApplier: {
+      applyManifest: vi.fn(),
+    },
+  } as unknown as ReturnType<typeof useApiClients>)
+}
+
+function renderManifestsPage() {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/manifests']}>
+      <Routes>
+        <Route path="/manifests" element={<ManifestsPage />} />
+      </Routes>
+    </MemoryRouter>,
+    { initialToken: createTenantUserToken() },
+  )
+}
+
+describe('ManifestsPage', () => {
+  beforeEach(() => mockApiClients())
+
+  it('renders page heading', async () => {
+    renderManifestsPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /manifest configuration/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders Apply Manifest button', async () => {
+    renderManifestsPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /apply manifest/i })).toBeInTheDocument()
+    })
+  })
+
+  it('opens ManifestApplyDialog when Apply Manifest is clicked', async () => {
+    renderManifestsPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /apply manifest/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /apply manifest/i }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('renders Current Manifest and Version History tabs', async () => {
+    renderManifestsPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /current manifest/i })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /version history/i })).toBeInTheDocument()
+    })
+  })
+
+  it('defaults to Current Manifest tab', async () => {
+    renderManifestsPage()
+
+    await waitFor(() => {
+      const currentTab = screen.getByRole('tab', { name: /current manifest/i })
+      expect(currentTab).toHaveAttribute('data-state', 'active')
+    })
+  })
+
+  it('switches to Version History tab', async () => {
+    renderManifestsPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /version history/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('tab', { name: /version history/i }))
+
+    const historyTab = screen.getByRole('tab', { name: /version history/i })
+    expect(historyTab).toHaveAttribute('data-state', 'active')
+  })
+})

--- a/frontend/src/test/api/clients.test.ts
+++ b/frontend/src/test/api/clients.test.ts
@@ -20,11 +20,11 @@ describe('createServiceClients', () => {
     vi.clearAllMocks()
   })
 
-  it('returns an object with all 16 service clients', () => {
+  it('returns an object with all 18 service clients', () => {
     const transport = makeTransport()
     const clients = createServiceClients(transport)
 
-    expect(Object.keys(clients)).toHaveLength(16)
+    expect(Object.keys(clients)).toHaveLength(18)
   })
 
   it('creates clients for all expected services', () => {
@@ -47,13 +47,15 @@ describe('createServiceClients', () => {
     expect(clients).toHaveProperty('marketInformation')
     expect(clients).toHaveProperty('mapping')
     expect(clients).toHaveProperty('forecasting')
+    expect(clients).toHaveProperty('manifestHistory')
+    expect(clients).toHaveProperty('manifestApplier')
   })
 
   it('calls createClient for each service with the provided transport', () => {
     const transport = makeTransport()
     createServiceClients(transport)
 
-    expect(createClient).toHaveBeenCalledTimes(16)
+    expect(createClient).toHaveBeenCalledTimes(18)
     vi.mocked(createClient).mock.calls.forEach(([, t]) => {
       expect(t).toBe(transport)
     })


### PR DESCRIPTION
## Summary

- Add `/manifests` route with `ManifestCurrentView`, `ManifestApplyDialog`, and `ManifestHistoryTable` components
- Register `ManifestHistoryService` and `ApplyManifestService` Connect-ES clients in the API layer
- Add sidebar navigation link with `FileJson` icon, manifest query key factory, and `APPLIED`/`ROLLED_BACK` status badge variants
- Include 34 unit tests covering all components: loading/empty/error states, tab switching, dry-run preview workflow, validation error display, and version history browsing

## Changes Made

| File | Change |
|------|--------|
| `frontend/src/api/clients.ts` | Register `manifestHistory` and `manifestApplier` service clients |
| `frontend/src/lib/query-keys.ts` | Add `manifestKeys` factory (all, current, history, version) |
| `frontend/src/components/shared/status-badge.tsx` | Add APPLIED, ROLLED_BACK status variants |
| `frontend/src/components/layout/sidebar.tsx` | Add Manifests nav item with FileJson icon |
| `frontend/src/App.tsx` | Add `/manifests` route pointing to `ManifestsPage` |
| `frontend/src/pages/manifests/index.tsx` | Main page with tabs (Current/History) and Apply button |
| `frontend/src/pages/manifests/manifest-current-view.tsx` | Current manifest display with expandable sections |
| `frontend/src/pages/manifests/manifest-apply-dialog.tsx` | JSON input, dry-run preview, apply workflow |
| `frontend/src/pages/manifests/manifest-history-table.tsx` | Paginated history table with detail dialog |
| `frontend/src/test/api/clients.test.ts` | Update client count from 16 to 18 |
| `frontend/src/pages/manifests/*.test.tsx` | 34 unit tests across 4 test files |

## Task Master

Tag: `026-operations-console`, Task: `50`

## Test plan

- [x] All 34 new manifest page tests pass
- [x] Full test suite (1026 tests across 86 files) passes
- [x] TypeScript compiles without errors
- [ ] CI pipeline passes