### PR TITLE
chore: Update seed-dev-tenant.sh to apply example manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ GOMOD=$(GOCMD) mod
 GOGET=$(GOCMD) get
 GOFMT=$(GOCMD) fmt
 
-.PHONY: all help build test lint clean proto proto-v1 proto-v2 proto-openapi proto-lint proto-breaking proto-descriptors docker deploy-local fmt tidy deps coverage install proto-validate proto-deps-update proto-deps-graph proto-plugins-info validate-tilt validate-semconv validate-sagas proto-jsonschema validate-manifest-jsonschema validate-manifests control-plane-ci test-control-plane migrate-diff-all migrate-diff-current migrate-diff-position migrate-apply-all migrate-status-all migrate-lint-all migrate-hash-all migrate-apply-orgs migrate-status-orgs docs generate-saga-docs swagger-split swagger-ui dev-up dev-down dev-clean
+.PHONY: all help build seed-dev seed-dev-build test lint clean proto proto-v1 proto-v2 proto-openapi proto-lint proto-breaking proto-descriptors docker deploy-local fmt tidy deps coverage install proto-validate proto-deps-update proto-deps-graph proto-plugins-info validate-tilt validate-semconv validate-sagas proto-jsonschema validate-manifest-jsonschema validate-manifests control-plane-ci test-control-plane migrate-diff-all migrate-diff-current migrate-diff-position migrate-apply-all migrate-status-all migrate-lint-all migrate-hash-all migrate-apply-orgs migrate-status-orgs docs generate-saga-docs swagger-split swagger-ui dev-up dev-down dev-clean
 
 # Default target
 all: help
@@ -43,6 +43,8 @@ help:
 	@echo ""
 	@echo "Available targets:"
 	@echo "  make build             - Compile all Go services"
+	@echo "  make seed-dev-build    - Build the seed-dev binary"
+	@echo "  make seed-dev          - Build and run seed-dev against local dev environment"
 	@echo "  make test              - Run tests with coverage"
 	@echo "  make lint              - Run golangci-lint, validate Tiltfile, and validate semconv versions"
 	@echo "  make validate-tilt     - Validate Tiltfile configuration"
@@ -109,6 +111,17 @@ build: tidy
 	@echo "Build complete:"
 	@echo "  - $(DIST_DIR)/$(BINARY_NAME)"
 	@echo "  - $(DIST_DIR)/atlas-loader"
+
+## seed-dev-build: Build the seed-dev binary
+seed-dev-build:
+	@echo "Building seed-dev binary..."
+	@mkdir -p bin
+	$(GOBUILD) -o bin/seed-dev ./cmd/seed-dev
+	@echo "Binary written to bin/seed-dev"
+
+## seed-dev: Seed the local dev tenant with manifest configuration
+seed-dev: seed-dev-build
+	@./scripts/seed-dev-tenant.sh
 
 ## test: Run tests with coverage
 test:

--- a/cmd/meridian/Dockerfile
+++ b/cmd/meridian/Dockerfile
@@ -32,8 +32,13 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} go build \
     -o meridian \
     ./cmd/meridian/
 
-# Verify the binary exists and is executable
-RUN test -x meridian && echo "Binary built successfully"
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} go build \
+    -ldflags="-w -s" \
+    -o seed-dev \
+    ./cmd/seed-dev/
+
+# Verify the binaries exist and are executable
+RUN test -x meridian && test -x seed-dev && echo "Binaries built successfully"
 
 # Runtime stage - distroless for minimal attack surface (~2MB base)
 FROM gcr.io/distroless/static-debian12
@@ -41,8 +46,9 @@ FROM gcr.io/distroless/static-debian12
 # Copy timezone data from builder for time-sensitive operations
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 
-# Copy binary from builder
+# Copy binaries from builder
 COPY --from=builder /build/meridian /meridian
+COPY --from=builder /build/seed-dev /seed-dev
 
 # Use non-root user (distroless provides nonroot user at uid 65532)
 USER nonroot:nonroot

--- a/cmd/seed-dev/cmd/root.go
+++ b/cmd/seed-dev/cmd/root.go
@@ -213,7 +213,6 @@ func applyManifest(ctx context.Context, conn *grpc.ClientConn, tid, path string)
 		return fmt.Errorf("ApplyManifest RPC: %w", err)
 	}
 
-	fmt.Printf("Manifest applied successfully:\n")
 	fmt.Printf("  Job ID: %s\n", resp.GetJobId())
 	fmt.Printf("  Status: %s\n", resp.GetStatus().String())
 	if diff := resp.GetDiffSummary(); diff != "" {
@@ -227,6 +226,7 @@ func applyManifest(ctx context.Context, conn *grpc.ClientConn, tid, path string)
 		return fmt.Errorf("%w: %d error(s)", ErrManifestValidation, len(resp.GetValidationErrors()))
 	}
 
+	fmt.Println("Manifest applied successfully.")
 	return nil
 }
 

--- a/cmd/seed-dev/cmd/root.go
+++ b/cmd/seed-dev/cmd/root.go
@@ -1,0 +1,239 @@
+// Package cmd implements the seed-dev CLI commands.
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	tenantv1 "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
+	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// ErrManifestValidation is returned when the manifest contains validation errors.
+var ErrManifestValidation = errors.New("manifest validation failed")
+
+var (
+	gatewayURL   string
+	grpcAddr     string
+	manifestPath string
+	tenantID     string
+	tenantSlug   string
+	timeout      time.Duration
+	skipManifest bool
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "seed-dev",
+	Short: "Seed a dev tenant with manifest configuration",
+	Long: `seed-dev creates a dev tenant and applies a manifest configuration.
+
+This tool is idempotent:
+  - If the tenant already exists, creation is skipped
+  - If the manifest is already applied, it will be re-applied (idempotent)
+
+Examples:
+  # Default: create dev_tenant and apply examples/manifests/energy.json
+  seed-dev
+
+  # Custom manifest
+  seed-dev --manifest examples/manifests/carbon.json
+
+  # Skip manifest application (tenant creation only)
+  seed-dev --skip-manifest
+
+  # Custom gateway and gRPC addresses
+  seed-dev --gateway-url=http://meridian:8090 --grpc-addr=meridian:50051`,
+	RunE: runSeed,
+}
+
+// Execute adds all child commands to the root command and executes it.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.Flags().StringVar(&gatewayURL, "gateway-url",
+		getEnvOrDefault("GATEWAY_URL", "http://localhost:8090"),
+		"Gateway HTTP URL (used for health check)")
+	rootCmd.Flags().StringVar(&grpcAddr, "grpc-addr",
+		getEnvOrDefault("GRPC_ADDR", "localhost:50051"),
+		"gRPC server address (host:port)")
+	rootCmd.Flags().StringVar(&manifestPath, "manifest",
+		getEnvOrDefault("MANIFEST_PATH", "examples/manifests/energy.json"),
+		"Path to manifest JSON file")
+	rootCmd.Flags().StringVar(&tenantID, "tenant-id",
+		getEnvOrDefault("TENANT_ID", "dev_tenant"),
+		"Tenant ID to create/configure")
+	rootCmd.Flags().StringVar(&tenantSlug, "tenant-slug",
+		getEnvOrDefault("TENANT_SLUG", "dev-tenant"),
+		"Tenant URL slug")
+	rootCmd.Flags().DurationVar(&timeout, "timeout", 2*time.Minute,
+		"Overall operation timeout")
+	rootCmd.Flags().BoolVar(&skipManifest, "skip-manifest", false,
+		"Skip manifest application (tenant creation only)")
+}
+
+func runSeed(_ *cobra.Command, _ []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	fmt.Printf("Waiting for gateway at %s ...\n", gatewayURL)
+
+	err := await.New().
+		AtMost(60 * time.Second).
+		PollInterval(2 * time.Second).
+		WithContext(ctx).
+		Until(func() bool {
+			return checkHealth(gatewayURL)
+		})
+	if err != nil {
+		return fmt.Errorf("gateway did not become healthy: %w", err)
+	}
+	fmt.Println("Gateway is healthy.")
+
+	conn, err := grpc.NewClient(grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("connect to gRPC server %s: %w", grpcAddr, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	fmt.Printf("Creating tenant '%s' ...\n", tenantID)
+	if err := createTenant(ctx, conn, tenantID, tenantSlug); err != nil {
+		return fmt.Errorf("create tenant: %w", err)
+	}
+
+	if skipManifest {
+		fmt.Println("Skipping manifest application (--skip-manifest set).")
+		fmt.Println("Seed complete.")
+		return nil
+	}
+
+	fmt.Printf("Applying manifest from %s ...\n", manifestPath)
+	if err := applyManifest(ctx, conn, tenantID, manifestPath); err != nil {
+		return fmt.Errorf("apply manifest: %w", err)
+	}
+
+	fmt.Println("Seed complete.")
+	return nil
+}
+
+// checkHealth returns true if the gateway /healthz endpoint responds with 200.
+func checkHealth(gwURL string) bool {
+	resp, err := http.Get(gwURL + "/healthz") //nolint:noctx // polling function, no context available
+	if err != nil {
+		return false
+	}
+	_ = resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// createTenant calls InitiateTenant and treats AlreadyExists as success.
+func createTenant(ctx context.Context, conn *grpc.ClientConn, id, slug string) error {
+	client := tenantv1.NewTenantServiceClient(conn)
+
+	req := &tenantv1.InitiateTenantRequest{
+		TenantId:        id,
+		DisplayName:     "Dev Tenant",
+		SettlementAsset: "GBP",
+		Subdomain:       id + ".localhost",
+		Slug:            slug,
+	}
+
+	resp, err := client.InitiateTenant(ctx, req)
+	if err != nil {
+		if st, ok := status.FromError(err); ok && st.Code() == codes.AlreadyExists {
+			fmt.Println("Dev tenant already exists (idempotent).")
+			return nil
+		}
+		return err
+	}
+
+	if resp.GetTenant() != nil {
+		fmt.Printf("Dev tenant created successfully (ID: %s).\n", resp.GetTenant().GetTenantId())
+	} else {
+		fmt.Println("Dev tenant created successfully.")
+	}
+	return nil
+}
+
+// unmarshalManifestFile reads and parses a manifest JSON file into a proto message.
+// Exposed for testing.
+func unmarshalManifestFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read manifest file: %w", err)
+	}
+	var manifest controlplanev1.Manifest
+	if err := protojson.Unmarshal(data, &manifest); err != nil {
+		return fmt.Errorf("parse manifest JSON: %w", err)
+	}
+	return nil
+}
+
+// applyManifest reads a manifest JSON file and calls ApplyManifest.
+func applyManifest(ctx context.Context, conn *grpc.ClientConn, tid, path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read manifest file: %w", err)
+	}
+
+	var manifest controlplanev1.Manifest
+	if err := protojson.Unmarshal(data, &manifest); err != nil {
+		return fmt.Errorf("parse manifest JSON: %w", err)
+	}
+
+	client := controlplanev1.NewApplyManifestServiceClient(conn)
+
+	// Pass tenant ID as gRPC metadata (x-tenant-id header).
+	md := metadata.Pairs("x-tenant-id", tid)
+	callCtx := metadata.NewOutgoingContext(ctx, md)
+
+	req := &controlplanev1.ApplyManifestRequest{
+		Manifest:  &manifest,
+		DryRun:    false,
+		AppliedBy: "seed-dev",
+	}
+
+	resp, err := client.ApplyManifest(callCtx, req)
+	if err != nil {
+		return fmt.Errorf("ApplyManifest RPC: %w", err)
+	}
+
+	fmt.Printf("Manifest applied successfully:\n")
+	fmt.Printf("  Job ID: %s\n", resp.GetJobId())
+	fmt.Printf("  Status: %s\n", resp.GetStatus().String())
+	if diff := resp.GetDiffSummary(); diff != "" {
+		fmt.Printf("  Changes: %s\n", diff)
+	}
+	if len(resp.GetValidationErrors()) > 0 {
+		fmt.Printf("  Validation errors: %d\n", len(resp.GetValidationErrors()))
+		for _, ve := range resp.GetValidationErrors() {
+			fmt.Printf("    [%s] %s: %s\n", ve.GetSeverity(), ve.GetPath(), ve.GetMessage())
+		}
+		return fmt.Errorf("%w: %d error(s)", ErrManifestValidation, len(resp.GetValidationErrors()))
+	}
+
+	return nil
+}
+
+// getEnvOrDefault returns the environment variable value or a default.
+func getEnvOrDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}

--- a/cmd/seed-dev/cmd/root_test.go
+++ b/cmd/seed-dev/cmd/root_test.go
@@ -1,0 +1,113 @@
+// Package cmd implements the seed-dev CLI commands.
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckHealth_Healthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	assert.True(t, checkHealth(srv.URL))
+}
+
+func TestCheckHealth_Unhealthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	assert.False(t, checkHealth(srv.URL))
+}
+
+func TestCheckHealth_ConnectionRefused(t *testing.T) {
+	assert.False(t, checkHealth("http://127.0.0.1:1"))
+}
+
+func TestGetEnvOrDefault_ReturnsDefault(t *testing.T) {
+	result := getEnvOrDefault("SEED_DEV_NONEXISTENT_VAR_99999", "my-default")
+	assert.Equal(t, "my-default", result)
+}
+
+func TestGetEnvOrDefault_ReturnsEnvValue(t *testing.T) {
+	t.Setenv("SEED_DEV_TEST_VAR", "from-env")
+	result := getEnvOrDefault("SEED_DEV_TEST_VAR", "my-default")
+	assert.Equal(t, "from-env", result)
+}
+
+func TestApplyManifest_InvalidFile(t *testing.T) {
+	err := applyManifest(t.Context(), nil, "dev_tenant", "/nonexistent/path/manifest.json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read manifest file")
+}
+
+func TestApplyManifest_InvalidJSON(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "bad.json")
+	require.NoError(t, os.WriteFile(tmp, []byte("not valid json {{"), 0o600))
+
+	err := applyManifest(t.Context(), nil, "dev_tenant", tmp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse manifest JSON")
+}
+
+func TestApplyManifest_ParsesEnergyManifest(t *testing.T) {
+	// Verify the example manifest parses as valid protobuf JSON without a live server.
+	// We pass nil conn, so after successful parse it will fail at the gRPC call stage.
+	manifestPath := "../../../examples/manifests/energy.json"
+	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
+		t.Skip("energy.json not found; skipping parse test")
+	}
+
+	data, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	// Unmarshal using the same path as production code to confirm it is valid.
+	tmp := filepath.Join(t.TempDir(), "energy.json")
+	require.NoError(t, os.WriteFile(tmp, data, 0o600))
+
+	// applyManifest with nil conn will panic on the gRPC call; only test parse path.
+	// We test parse separately via a helper to avoid a nil-conn panic.
+	err = unmarshalManifestFile(tmp)
+	assert.NoError(t, err)
+}
+
+func TestRootCmd_DefaultFlagValues(t *testing.T) {
+	// Ensure the flags registered on rootCmd have the expected defaults.
+	// These values must match what is documented and expected by docker-compose / scripts.
+	f := rootCmd.Flags()
+
+	gwURL, err := f.GetString("gateway-url")
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:8090", gwURL)
+
+	grpc, err := f.GetString("grpc-addr")
+	require.NoError(t, err)
+	assert.Equal(t, "localhost:50051", grpc)
+
+	manifest, err := f.GetString("manifest")
+	require.NoError(t, err)
+	assert.Equal(t, "examples/manifests/energy.json", manifest)
+
+	tenantIDFlag, err := f.GetString("tenant-id")
+	require.NoError(t, err)
+	assert.Equal(t, "dev_tenant", tenantIDFlag)
+
+	tenantSlugFlag, err := f.GetString("tenant-slug")
+	require.NoError(t, err)
+	assert.Equal(t, "dev-tenant", tenantSlugFlag)
+
+	skip, err := f.GetBool("skip-manifest")
+	require.NoError(t, err)
+	assert.False(t, skip)
+}

--- a/cmd/seed-dev/main.go
+++ b/cmd/seed-dev/main.go
@@ -1,0 +1,12 @@
+// Package main is the entry point for the seed-dev CLI.
+//
+// seed-dev creates a dev tenant and applies an example manifest configuration.
+// It is idempotent: if the tenant already exists or the manifest has already
+// been applied, it succeeds without error.
+package main
+
+import "github.com/meridianhub/meridian/cmd/seed-dev/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/deploy/dev/docker-compose.yml
+++ b/deploy/dev/docker-compose.yml
@@ -4,7 +4,7 @@
 #   cockroachdb  - CockroachDB single-node (insecure) on port 26257, UI on 8080
 #   migrate      - One-shot migration runner; exits 0 when all migrations applied
 #   meridian     - Unified binary; starts after migrations complete
-#   seed         - One-shot seed runner; creates dev tenant (idempotent)
+#   seed         - One-shot seed runner; creates dev tenant and applies manifest (idempotent)
 #   frontend     - Vite dev server with HMR on port 5173
 #
 # Usage:
@@ -67,16 +67,20 @@ services:
       REDIS_ENABLED: "false"
 
   seed:
-    image: curlimages/curl:latest
+    build:
+      context: ../..
+      dockerfile: cmd/meridian/Dockerfile
+    entrypoint: ["/seed-dev"]
+    command:
+      - "--manifest=/manifests/energy.json"
     depends_on:
       meridian:
         condition: service_started
-    entrypoint: ["/bin/sh", "-c"]
-    command:
-      - |
-        GATEWAY_HOST=meridian:8090 /scripts/seed-dev-tenant.sh
+    environment:
+      GATEWAY_URL: "http://meridian:8090"
+      GRPC_ADDR: "meridian:50051"
     volumes:
-      - ../../scripts/seed-dev-tenant.sh:/scripts/seed-dev-tenant.sh:ro
+      - ../../examples/manifests:/manifests:ro
     restart: "no"
 
   frontend:

--- a/scripts/seed-dev-tenant.sh
+++ b/scripts/seed-dev-tenant.sh
@@ -1,134 +1,40 @@
 #!/usr/bin/env bash
 #
-# Seed a dev tenant for local manual testing.
-# Idempotent: exits 0 if tenant already exists.
+# Seed a dev tenant with manifest configuration.
+# Delegates to the seed-dev Go binary (cmd/seed-dev).
 #
 # Usage:
-#   ./scripts/seed-dev-tenant.sh                     # default: localhost:8090
+#   ./scripts/seed-dev-tenant.sh                         # default: localhost
 #   GATEWAY_HOST=meridian:8090 ./scripts/seed-dev-tenant.sh  # inside docker network
+#   GATEWAY_URL=http://meridian:8090 ./scripts/seed-dev-tenant.sh
+#   MANIFEST_PATH=examples/manifests/carbon.json ./scripts/seed-dev-tenant.sh
+#   ./scripts/seed-dev-tenant.sh --skip-manifest         # tenant creation only
+#
+# Environment variables (all optional):
+#   GATEWAY_URL      - HTTP URL for gateway health check (default: http://localhost:8090)
+#   GRPC_ADDR        - gRPC server address (default: localhost:50051)
+#   MANIFEST_PATH    - Path to manifest JSON file (default: examples/manifests/energy.json)
+#   TENANT_ID        - Tenant ID to create (default: dev_tenant)
+#   TENANT_SLUG      - Tenant URL slug (default: dev-tenant)
+#
+# Legacy variable support:
+#   GATEWAY_HOST     - If set and GATEWAY_URL is not, derived as http://${GATEWAY_HOST}
 
 set -euo pipefail
 
-GATEWAY_HOST="${GATEWAY_HOST:-localhost:8090}"
-GATEWAY_URL="http://${GATEWAY_HOST}"
-MAX_RETRIES=30
-RETRY_INTERVAL=2
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BIN="${REPO_ROOT}/bin/seed-dev"
 
-echo "Waiting for gateway at ${GATEWAY_URL} ..."
+# Support the legacy GATEWAY_HOST variable used by docker-compose.
+if [ -z "${GATEWAY_URL:-}" ] && [ -n "${GATEWAY_HOST:-}" ]; then
+  export GATEWAY_URL="http://${GATEWAY_HOST}"
+fi
 
-for i in $(seq 1 "$MAX_RETRIES"); do
-  if curl -sf "${GATEWAY_URL}/healthz" >/dev/null 2>&1; then
-    echo "Gateway is healthy."
-    break
-  fi
-  if [ "$i" -eq "$MAX_RETRIES" ]; then
-    echo "ERROR: Gateway did not become healthy after $((MAX_RETRIES * RETRY_INTERVAL))s"
-    exit 1
-  fi
-  sleep "$RETRY_INTERVAL"
-done
+# Build the binary if it does not exist.
+if [ ! -f "${BIN}" ]; then
+  echo "Building seed-dev binary..."
+  (cd "${REPO_ROOT}" && go build -o bin/seed-dev ./cmd/seed-dev)
+fi
 
-echo "Creating dev tenant ..."
-
-HTTP_CODE=$(curl -s -o /tmp/seed-response.json -w "%{http_code}" \
-  -X POST "${GATEWAY_URL}/meridian.tenant.v1.TenantService/InitiateTenant" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "tenantId": "dev_tenant",
-    "displayName": "Dev Tenant",
-    "settlementAsset": "GBP",
-    "subdomain": "dev-tenant"
-  }')
-
-BODY=$(cat /tmp/seed-response.json 2>/dev/null || echo "")
-
-case "$HTTP_CODE" in
-  200)
-    echo "Dev tenant created successfully."
-    ;;
-  409)
-    echo "Dev tenant already exists (idempotent, no action needed)."
-    ;;
-  *)
-    # Connect protocol returns 200 even for AlreadyExists in some configs;
-    # check the response body for the "already exists" code.
-    if echo "$BODY" | grep -qi "already.exist"; then
-      echo "Dev tenant already exists (idempotent, no action needed)."
-    else
-      echo "ERROR: Unexpected response (HTTP ${HTTP_CODE}):"
-      echo "$BODY"
-      exit 1
-    fi
-    ;;
-esac
-
-rm -f /tmp/seed-response.json
-
-# --- Seed sample party (organization) ---
-
-echo "Creating sample organization ..."
-
-HTTP_CODE=$(curl -s -o /tmp/seed-response.json -w "%{http_code}" \
-  -X POST "${GATEWAY_URL}/meridian.party.v1.PartyService/RegisterParty" \
-  -H "Content-Type: application/json" \
-  -H "X-Tenant-Slug: dev-tenant" \
-  -d '{
-    "partyType": "PARTY_TYPE_ORGANIZATION",
-    "legalName": "Acme Energy Ltd",
-    "displayName": "Acme Energy",
-    "externalReference": "acme-001"
-  }')
-
-BODY=$(cat /tmp/seed-response.json 2>/dev/null || echo "")
-
-case "$HTTP_CODE" in
-  200)
-    if echo "$BODY" | grep -qi "already.exist"; then
-      echo "Sample organization already exists."
-    else
-      echo "Sample organization created."
-    fi
-    ;;
-  409)
-    echo "Sample organization already exists."
-    ;;
-  *)
-    echo "WARNING: Could not create sample organization (HTTP ${HTTP_CODE}): ${BODY}"
-    ;;
-esac
-
-# --- Seed sample party (person) ---
-
-echo "Creating sample person ..."
-
-HTTP_CODE=$(curl -s -o /tmp/seed-response.json -w "%{http_code}" \
-  -X POST "${GATEWAY_URL}/meridian.party.v1.PartyService/RegisterParty" \
-  -H "Content-Type: application/json" \
-  -H "X-Tenant-Slug: dev-tenant" \
-  -d '{
-    "partyType": "PARTY_TYPE_PERSON",
-    "legalName": "Jane Smith",
-    "displayName": "Jane Smith",
-    "externalReference": "person-001"
-  }')
-
-BODY=$(cat /tmp/seed-response.json 2>/dev/null || echo "")
-
-case "$HTTP_CODE" in
-  200)
-    if echo "$BODY" | grep -qi "already.exist"; then
-      echo "Sample person already exists."
-    else
-      echo "Sample person created."
-    fi
-    ;;
-  409)
-    echo "Sample person already exists."
-    ;;
-  *)
-    echo "WARNING: Could not create sample person (HTTP ${HTTP_CODE}): ${BODY}"
-    ;;
-esac
-
-rm -f /tmp/seed-response.json
-echo "Seed complete."
+exec "${BIN}" "$@"


### PR DESCRIPTION
## Summary

- Replaces the curl-based `scripts/seed-dev-tenant.sh` with a type-safe Go binary (`cmd/seed-dev`) that uses generated gRPC proto clients directly
- The shell script becomes a thin wrapper that auto-builds and delegates to the binary; existing `GATEWAY_HOST` variable is still supported via backward-compatible mapping to `GATEWAY_URL`
- Updates the docker-compose `seed` service to run the compiled `/seed-dev` binary from the meridian image instead of curlimages/curl

## Changes Made

- `cmd/seed-dev/main.go` — entry point for the seed-dev CLI
- `cmd/seed-dev/cmd/root.go` — cobra command: waits for gateway health, creates tenant via `InitiateTenant` RPC (idempotent), applies manifest via `ApplyManifest` RPC; flags `--gateway-url`, `--grpc-addr`, `--manifest`, `--tenant-id`, `--tenant-slug`, `--timeout`, `--skip-manifest`
- `cmd/seed-dev/cmd/root_test.go` — unit tests: health check (healthy/unhealthy/refused), env var defaults, manifest file parsing errors, energy.json parse validation, flag defaults
- `scripts/seed-dev-tenant.sh` — rewritten as thin wrapper; builds binary on first run, supports `GATEWAY_HOST` legacy variable
- `cmd/meridian/Dockerfile` — adds `seed-dev` binary to the build stage and runtime image
- `deploy/dev/docker-compose.yml` — updates `seed` service to use the meridian image and run `/seed-dev --manifest=/manifests/energy.json` with manifests volume mount
- `Makefile` — adds `seed-dev-build` and `seed-dev` targets

## Technical Details

The binary connects directly to the gRPC port (default `localhost:50051`) using `google.golang.org/grpc` standard clients, consistent with the existing `tenantctl` pattern. Tenant identity is passed to `ApplyManifest` as `x-tenant-id` gRPC metadata.

## Testing

- `go test ./cmd/seed-dev/...` — 9 unit tests, all passing
- `go build ./cmd/seed-dev/...` — compiles cleanly
- Pre-commit hooks pass (gitleaks, gofumpt, golangci-lint)