### PR TITLE
feat: Add Playwright E2E tests for account lifecycle

### DIFF
--- a/frontend/e2e/accounts.spec.ts
+++ b/frontend/e2e/accounts.spec.ts
@@ -77,8 +77,8 @@ test.describe('Accounts page', () => {
     const dialog = authenticatedPage.getByRole('dialog')
     await dialog.getByLabel('IBAN').fill('not-a-valid-iban')
     await dialog.getByLabel('Party ID').fill('party-001')
-    await authenticatedPage.getByRole('button', { name: 'Create Account', exact: true }).click()
-    await expect(authenticatedPage.getByText(/valid IBAN/i)).toBeVisible()
+    await dialog.getByRole('button', { name: 'Create Account', exact: true }).click()
+    await expect(dialog.getByText(/valid IBAN/i)).toBeVisible()
   })
 
   test('Create Account dialog resets fields after cancel and reopen', async ({
@@ -137,7 +137,7 @@ test.describe('Account detail page', () => {
  */
 test.describe('Account lifecycle (requires backend)', () => {
   test.skip(
-    !process.env.MERIDIAN_E2E_BACKEND,
+    process.env.MERIDIAN_E2E_BACKEND !== '1',
     'Set MERIDIAN_E2E_BACKEND=1 to run full lifecycle tests',
   )
 
@@ -160,7 +160,7 @@ test.describe('Account lifecycle (requires backend)', () => {
     await createDialog.getByLabel('IBAN').fill(testIban)
     await createDialog.getByLabel('Currency').selectOption(currency)
     await createDialog.getByLabel('Party ID').fill('dev-party-001')
-    await authenticatedPage.getByRole('button', { name: 'Create Account', exact: true }).click()
+    await createDialog.getByRole('button', { name: 'Create Account', exact: true }).click()
 
     // Step 4: After creation, navigates to account detail page
     await expect(authenticatedPage.getByText(testIban)).toBeVisible({ timeout: 10_000 })
@@ -202,12 +202,15 @@ test.describe('Account lifecycle (requires backend)', () => {
   test('deposit dialog shows error for empty amount', async ({ authenticatedPage }) => {
     // Navigate to an existing active account via accounts list
     await navigateTo(authenticatedPage, '/accounts')
-    // Assumes at least one active account exists with a Deposit button visible in detail
-    // Navigate to detail and verify deposit validation
-    await authenticatedPage.getByRole('button', { name: 'Deposit' }).first().click()
-    await expect(authenticatedPage.getByRole('dialog')).toBeVisible()
+    // Click the first data row to navigate to the account detail page
+    // (nth(0) is the header row, nth(1) is the first data row)
+    await authenticatedPage.getByRole('row').nth(1).click()
+    // Deposit button exists on the account detail page
+    await authenticatedPage.getByRole('button', { name: 'Deposit' }).click()
+    const depositDialog = authenticatedPage.getByRole('dialog')
+    await expect(depositDialog).toBeVisible()
     // Submit with empty amount
-    await authenticatedPage.getByRole('button', { name: 'Deposit', exact: true }).click()
+    await depositDialog.getByRole('button', { name: 'Deposit', exact: true }).click()
     await expect(authenticatedPage.getByText('Amount is required')).toBeVisible()
   })
 })

--- a/frontend/e2e/accounts.spec.ts
+++ b/frontend/e2e/accounts.spec.ts
@@ -1,0 +1,213 @@
+import { test, expect, navigateTo } from './fixtures'
+
+/**
+ * Account lifecycle E2E tests.
+ *
+ * NOTE: These tests require the Vite dev server (npm run dev) to be running.
+ *
+ * Auth tokens are memory-only (not persisted to localStorage). All tests use
+ * navigateTo() for client-side navigation to preserve the in-memory auth state.
+ * page.goto() after authentication would trigger a full-page reload and lose the token.
+ *
+ * Navigation, page structure, and dialog open/close tests do NOT require the
+ * Meridian backend — the accounts page renders with an empty/error state when
+ * no backend is available, and the Create Account dialog is purely client-side.
+ *
+ * Tests that submit forms to create/deposit/withdraw are marked as requiring a
+ * live backend (see task 45 for CI E2E workflow).
+ *
+ * Tests use `authenticatedPage` (tenant-user role) since accounts are
+ * tenant-scoped resources.
+ */
+
+test.describe('Accounts page', () => {
+  test('renders Accounts heading after navigation', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/accounts')
+    await expect(authenticatedPage.getByRole('heading', { name: 'Accounts' })).toBeVisible()
+  })
+
+  test('renders Create Account button', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/accounts')
+    await expect(
+      authenticatedPage.getByRole('button', { name: 'Create Account' }),
+    ).toBeVisible()
+  })
+
+  test('opens Create Account dialog on button click', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/accounts')
+    await authenticatedPage.getByRole('button', { name: 'Create Account' }).click()
+    await expect(authenticatedPage.getByRole('dialog')).toBeVisible()
+    await expect(
+      authenticatedPage.getByRole('heading', { name: 'Create Account' }),
+    ).toBeVisible()
+  })
+
+  test('Create Account dialog contains IBAN, Currency, and Party ID fields', async ({
+    authenticatedPage,
+  }) => {
+    await navigateTo(authenticatedPage, '/accounts')
+    await authenticatedPage.getByRole('button', { name: 'Create Account' }).click()
+    const dialog = authenticatedPage.getByRole('dialog')
+    await expect(dialog.getByLabel('IBAN')).toBeVisible()
+    await expect(dialog.getByLabel('Currency')).toBeVisible()
+    await expect(dialog.getByLabel('Party ID')).toBeVisible()
+  })
+
+  test('Create Account dialog closes on Cancel', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/accounts')
+    await authenticatedPage.getByRole('button', { name: 'Create Account' }).click()
+    await expect(authenticatedPage.getByRole('dialog')).toBeVisible()
+    await authenticatedPage.getByRole('button', { name: 'Cancel' }).click()
+    await expect(authenticatedPage.getByRole('dialog')).not.toBeVisible()
+  })
+
+  test('Create Account dialog validates required fields', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/accounts')
+    await authenticatedPage.getByRole('button', { name: 'Create Account' }).click()
+    const dialog = authenticatedPage.getByRole('dialog')
+    // Submit without filling any fields
+    await dialog.getByRole('button', { name: 'Create Account', exact: true }).click()
+    await expect(dialog.getByText('IBAN is required')).toBeVisible()
+    await expect(dialog.getByText('Party ID is required')).toBeVisible()
+  })
+
+  test('Create Account dialog validates IBAN format', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/accounts')
+    await authenticatedPage.getByRole('button', { name: 'Create Account' }).click()
+    const dialog = authenticatedPage.getByRole('dialog')
+    await dialog.getByLabel('IBAN').fill('not-a-valid-iban')
+    await dialog.getByLabel('Party ID').fill('party-001')
+    await authenticatedPage.getByRole('button', { name: 'Create Account', exact: true }).click()
+    await expect(authenticatedPage.getByText(/valid IBAN/i)).toBeVisible()
+  })
+
+  test('Create Account dialog resets fields after cancel and reopen', async ({
+    authenticatedPage,
+  }) => {
+    await navigateTo(authenticatedPage, '/accounts')
+    // Open and fill the dialog
+    await authenticatedPage.getByRole('button', { name: 'Create Account' }).click()
+    let dialog = authenticatedPage.getByRole('dialog')
+    await dialog.getByLabel('IBAN').fill('GB82WEST12345698765432')
+    await dialog.getByLabel('Party ID').fill('party-001')
+    // Cancel
+    await authenticatedPage.getByRole('button', { name: 'Cancel' }).click()
+    // Reopen - fields should be reset
+    await authenticatedPage.getByRole('button', { name: 'Create Account' }).click()
+    dialog = authenticatedPage.getByRole('dialog')
+    await expect(dialog.getByLabel('IBAN')).toHaveValue('')
+    await expect(dialog.getByLabel('Party ID')).toHaveValue('')
+  })
+
+  test('Currency select defaults to GBP', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/accounts')
+    await authenticatedPage.getByRole('button', { name: 'Create Account' }).click()
+    const dialog = authenticatedPage.getByRole('dialog')
+    await expect(dialog.getByLabel('Currency')).toHaveValue('GBP')
+  })
+})
+
+test.describe('Account detail page', () => {
+  test('renders Account not found for unknown account ID', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/accounts/non-existent-account-id')
+    // Without a backend, the query will fail → AccountNotFound is shown
+    await expect(
+      authenticatedPage.getByText('Account not found'),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('back link on not-found page navigates to Accounts list', async ({
+    authenticatedPage,
+  }) => {
+    await navigateTo(authenticatedPage, '/accounts/non-existent-account-id')
+    await expect(authenticatedPage.getByRole('link', { name: 'Back to Accounts' })).toBeVisible({
+      timeout: 10_000,
+    })
+    await authenticatedPage.getByRole('link', { name: 'Back to Accounts' }).click()
+    await expect(authenticatedPage.getByRole('heading', { name: 'Accounts' })).toBeVisible()
+  })
+})
+
+/**
+ * Full lifecycle tests — require live backend + seeded dev tenant data.
+ * These are annotated with .skip so they pass in smoke-test mode (no backend).
+ * Un-skip when running against a full stack (task 45 CI workflow).
+ *
+ * Party ID: 'dev-party-001' must exist in the dev tenant seed data.
+ */
+test.describe('Account lifecycle (requires backend)', () => {
+  test.skip(
+    !process.env.MERIDIAN_E2E_BACKEND,
+    'Set MERIDIAN_E2E_BACKEND=1 to run full lifecycle tests',
+  )
+
+  test('complete account lifecycle: create, deposit, withdraw, verify balance', async ({
+    authenticatedPage,
+  }) => {
+    const testIban = `GB82WEST${Date.now().toString().slice(-14).padStart(14, '0')}`
+    const currency = 'GBP'
+
+    // Step 1: Navigate to Accounts
+    await navigateTo(authenticatedPage, '/accounts')
+    await expect(authenticatedPage.getByRole('heading', { name: 'Accounts' })).toBeVisible()
+
+    // Step 2: Open Create Account dialog
+    await authenticatedPage.getByRole('button', { name: 'Create Account' }).click()
+    await expect(authenticatedPage.getByRole('dialog')).toBeVisible()
+
+    // Step 3: Fill and submit form (scope to dialog to avoid collision with DataTable filter)
+    const createDialog = authenticatedPage.getByRole('dialog')
+    await createDialog.getByLabel('IBAN').fill(testIban)
+    await createDialog.getByLabel('Currency').selectOption(currency)
+    await createDialog.getByLabel('Party ID').fill('dev-party-001')
+    await authenticatedPage.getByRole('button', { name: 'Create Account', exact: true }).click()
+
+    // Step 4: After creation, navigates to account detail page
+    await expect(authenticatedPage.getByText(testIban)).toBeVisible({ timeout: 10_000 })
+
+    // Capture account detail URL (navigated by onCreated callback)
+    const url = authenticatedPage.url()
+    expect(url).toMatch(/\/accounts\/[a-zA-Z0-9_-]+$/)
+
+    // Step 5: Initial balance is zero
+    await expect(authenticatedPage.getByText('0.00')).toBeVisible({ timeout: 5_000 })
+
+    // Step 6: Deposit funds
+    await authenticatedPage.getByRole('button', { name: 'Deposit' }).click()
+    const depositDialog = authenticatedPage.getByRole('dialog')
+    await expect(depositDialog).toBeVisible()
+    await expect(depositDialog.getByRole('heading', { name: 'Deposit Funds' })).toBeVisible()
+    await depositDialog.getByLabel('Amount').fill('100.00')
+    await depositDialog.getByRole('button', { name: 'Deposit', exact: true }).click()
+    await expect(depositDialog).not.toBeVisible({ timeout: 5_000 })
+    await expect(authenticatedPage.getByText(`${currency} 100.00`)).toBeVisible({ timeout: 5_000 })
+
+    // Step 7: Withdraw funds (two-phase: initiate → confirm)
+    await authenticatedPage.getByRole('button', { name: 'Withdraw' }).click()
+    const withdrawDialog = authenticatedPage.getByRole('dialog')
+    await expect(withdrawDialog).toBeVisible()
+    await expect(withdrawDialog.getByRole('heading', { name: 'Withdraw Funds' })).toBeVisible()
+    await withdrawDialog.getByLabel('Amount').fill('25.00')
+    // Initiate step
+    await withdrawDialog.getByRole('button', { name: 'Initiate', exact: true }).click()
+    // Confirm step — dialog shows confirmation details
+    await expect(withdrawDialog.getByText(/confirm withdrawal/i)).toBeVisible()
+    await withdrawDialog.getByRole('button', { name: 'Confirm', exact: true }).click()
+    await expect(withdrawDialog).not.toBeVisible({ timeout: 5_000 })
+
+    // Step 8: Final balance = 100.00 - 25.00 = 75.00
+    await expect(authenticatedPage.getByText(`${currency} 75.00`)).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('deposit dialog shows error for empty amount', async ({ authenticatedPage }) => {
+    // Navigate to an existing active account via accounts list
+    await navigateTo(authenticatedPage, '/accounts')
+    // Assumes at least one active account exists with a Deposit button visible in detail
+    // Navigate to detail and verify deposit validation
+    await authenticatedPage.getByRole('button', { name: 'Deposit' }).first().click()
+    await expect(authenticatedPage.getByRole('dialog')).toBeVisible()
+    // Submit with empty amount
+    await authenticatedPage.getByRole('button', { name: 'Deposit', exact: true }).click()
+    await expect(authenticatedPage.getByText('Amount is required')).toBeVisible()
+  })
+})

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -24,14 +24,41 @@ function buildDevToken(role: 'platform-admin' | 'tenant-user'): string {
 
 /**
  * Inject a dev auth token via window.__DEV_LOGIN__ exposed by AuthProvider in DEV mode.
+ *
+ * Auth tokens are memory-only (not persisted). After calling this, use
+ * navigateTo() for client-side navigation to preserve the in-memory auth state.
+ * Avoid page.goto() for subsequent navigations.
+ *
+ * After injecting the token, triggers client-side navigation to '/' so
+ * ProtectedRoute renders the authenticated content instead of redirecting to /login.
  */
 async function injectDevAuth(page: Page, role: 'platform-admin' | 'tenant-user') {
   const token = buildDevToken(role)
+  // Start at / which redirects to /login via ProtectedRoute (unauthenticated)
   await page.goto('/')
   await page.waitForFunction(() => typeof (window as Record<string, unknown>).__DEV_LOGIN__ === 'function')
+  // Set the in-memory auth token
   await page.evaluate((t) => {
     ;(window as Record<string, unknown>).__DEV_LOGIN__(t)
   }, token)
+  // Navigate to / via client-side routing so ProtectedRoute renders the authenticated app.
+  // Using history.pushState + popstate event keeps the memory auth state intact.
+  await page.evaluate(() => {
+    window.history.pushState({}, '', '/')
+    window.dispatchEvent(new PopStateEvent('popstate'))
+  })
+}
+
+/**
+ * Navigate to a path using client-side routing (React Router history.pushState).
+ * Use this instead of page.goto() after authentication to preserve memory-only auth tokens.
+ */
+export async function navigateTo(page: Page, path: string) {
+  await page.evaluate((p) => {
+    window.history.pushState({}, '', p)
+    // Dispatch popstate so React Router picks up the new URL
+    window.dispatchEvent(new PopStateEvent('popstate'))
+  }, path)
 }
 
 type Fixtures = {

--- a/frontend/src/pages/accounts/create-account-dialog.tsx
+++ b/frontend/src/pages/accounts/create-account-dialog.tsx
@@ -89,6 +89,10 @@ export function CreateAccountDialog({ open, onOpenChange, onCreated }: CreateAcc
 
   function validate(): FormErrors {
     const next: FormErrors = {}
+    if (!tenantSlug) {
+      next.general = 'No tenant selected'
+      return next
+    }
     const iban = formData.iban.trim().toUpperCase()
     if (!iban) {
       next.iban = 'IBAN is required'

--- a/frontend/src/pages/accounts/create-account-dialog.tsx
+++ b/frontend/src/pages/accounts/create-account-dialog.tsx
@@ -1,0 +1,236 @@
+import * as React from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useTenantContext } from '@/contexts/tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+
+const CURRENCIES = ['GBP', 'USD', 'EUR']
+
+// IBAN pattern: 2 letter country code + 2 digits + up to 30 alphanumeric chars
+const IBAN_PATTERN = /^[A-Z]{2}[0-9]{2}[A-Z0-9]{1,30}$/
+
+interface FormData {
+  iban: string
+  currency: string
+  partyId: string
+}
+
+interface FormErrors {
+  iban?: string
+  partyId?: string
+  general?: string
+}
+
+interface CreateAccountDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onCreated?: (accountId: string) => void
+}
+
+async function createAccount(
+  tenantSlug: string,
+  iban: string,
+  currency: string,
+  partyId: string,
+): Promise<string> {
+  const response = await fetch(
+    `/api/meridian.current_account.v1.CurrentAccountService/InitiateCurrentAccount`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Tenant-Slug': tenantSlug,
+      },
+      body: JSON.stringify({
+        accountIdentification: iban,
+        baseCurrency: currency,
+        partyId,
+      }),
+    },
+  )
+
+  if (!response.ok) {
+    const data = (await response.json().catch(() => ({}))) as { message?: string }
+    throw new Error(data.message ?? `Failed to create account: ${response.status}`)
+  }
+
+  const data = (await response.json()) as { accountId?: string }
+  if (!data.accountId) {
+    throw new Error('Account ID missing from response')
+  }
+  return data.accountId
+}
+
+export function CreateAccountDialog({ open, onOpenChange, onCreated }: CreateAccountDialogProps) {
+  const { tenantSlug } = useTenantContext()
+  const queryClient = useQueryClient()
+  const [formData, setFormData] = React.useState<FormData>({
+    iban: '',
+    currency: 'GBP',
+    partyId: '',
+  })
+  const [errors, setErrors] = React.useState<FormErrors>({})
+
+  React.useEffect(() => {
+    if (!open) {
+      setFormData({ iban: '', currency: 'GBP', partyId: '' })
+      setErrors({})
+    }
+  }, [open])
+
+  function validate(): FormErrors {
+    const next: FormErrors = {}
+    const iban = formData.iban.trim()
+    if (!iban) {
+      next.iban = 'IBAN is required'
+    } else if (!IBAN_PATTERN.test(iban)) {
+      next.iban = 'Enter a valid IBAN (e.g. GB82WEST12345698765432)'
+    }
+    if (!formData.partyId.trim()) {
+      next.partyId = 'Party ID is required'
+    }
+    return next
+  }
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createAccount(
+        tenantSlug ?? '',
+        formData.iban.trim(),
+        formData.currency,
+        formData.partyId.trim(),
+      ),
+    onSuccess: (accountId) => {
+      queryClient.invalidateQueries({
+        queryKey: tenantKeys.accounts(tenantSlug ?? ''),
+      })
+      onOpenChange(false)
+      onCreated?.(accountId)
+    },
+    onError: (error: Error) => {
+      setErrors((prev) => ({ ...prev, general: error.message }))
+    },
+  })
+
+  function handleChange(field: keyof FormData) {
+    return (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+      setFormData((prev) => ({ ...prev, [field]: e.target.value }))
+      if (errors[field as keyof FormErrors]) {
+        setErrors((prev) => ({ ...prev, [field]: undefined }))
+      }
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const next = validate()
+    if (Object.keys(next).length > 0) {
+      setErrors(next)
+      return
+    }
+    setErrors({})
+    mutation.mutate()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create Account</DialogTitle>
+          <DialogDescription>
+            Open a new current account for a party.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="create-account-form">
+          <div className="space-y-4 py-2">
+            <div className="space-y-1">
+              <label htmlFor="account-iban" className="text-sm font-medium">
+                IBAN
+              </label>
+              <Input
+                id="account-iban"
+                value={formData.iban}
+                onChange={handleChange('iban')}
+                placeholder="GB82WEST12345698765432"
+                aria-label="IBAN"
+                aria-describedby={errors.iban ? 'account-iban-error' : undefined}
+              />
+              {errors.iban && (
+                <p id="account-iban-error" className="text-sm text-destructive">
+                  {errors.iban}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="account-currency" className="text-sm font-medium">
+                Currency
+              </label>
+              <select
+                id="account-currency"
+                value={formData.currency}
+                onChange={handleChange('currency')}
+                aria-label="Currency"
+                className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+              >
+                {CURRENCIES.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="account-party-id" className="text-sm font-medium">
+                Party ID
+              </label>
+              <Input
+                id="account-party-id"
+                value={formData.partyId}
+                onChange={handleChange('partyId')}
+                placeholder="party-001"
+                aria-label="Party ID"
+                aria-describedby={errors.partyId ? 'account-party-id-error' : undefined}
+              />
+              {errors.partyId && (
+                <p id="account-party-id-error" className="text-sm text-destructive">
+                  {errors.partyId}
+                </p>
+              )}
+            </div>
+
+            {errors.general && (
+              <div role="alert" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                {errors.general}
+              </div>
+            )}
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="create-account-form"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Creating...' : 'Create Account'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/accounts/create-account-dialog.tsx
+++ b/frontend/src/pages/accounts/create-account-dialog.tsx
@@ -89,7 +89,7 @@ export function CreateAccountDialog({ open, onOpenChange, onCreated }: CreateAcc
 
   function validate(): FormErrors {
     const next: FormErrors = {}
-    const iban = formData.iban.trim()
+    const iban = formData.iban.trim().toUpperCase()
     if (!iban) {
       next.iban = 'IBAN is required'
     } else if (!IBAN_PATTERN.test(iban)) {
@@ -105,7 +105,7 @@ export function CreateAccountDialog({ open, onOpenChange, onCreated }: CreateAcc
     mutationFn: () =>
       createAccount(
         tenantSlug ?? '',
-        formData.iban.trim(),
+        formData.iban.trim().toUpperCase(),
         formData.currency,
         formData.partyId.trim(),
       ),

--- a/frontend/src/pages/accounts/index.tsx
+++ b/frontend/src/pages/accounts/index.tsx
@@ -5,8 +5,10 @@ import { DataTable } from '@/components/shared/data-table'
 import type { DataTableQueryParams, DataTableResult } from '@/components/shared/data-table'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
+import { Button } from '@/components/ui/button'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
+import { CreateAccountDialog } from './create-account-dialog'
 import type { CurrentAccount } from './types'
 
 const STATUS_OPTIONS = [
@@ -89,6 +91,7 @@ interface RawListCurrentAccountsResponse {
 export function AccountsPage() {
   const navigate = useNavigate()
   const { tenantSlug } = useTenantContext()
+  const [createOpen, setCreateOpen] = React.useState(false)
 
   const columns: ColumnDef<CurrentAccount>[] = [
     {
@@ -129,6 +132,7 @@ export function AccountsPage() {
     <div className="p-6">
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Accounts</h1>
+        <Button onClick={() => setCreateOpen(true)}>Create Account</Button>
       </div>
 
       <DataTable
@@ -149,6 +153,12 @@ export function AccountsPage() {
           },
         ]}
         onRowClick={(row) => navigate(`/accounts/${row.accountId}`)}
+      />
+
+      <CreateAccountDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreated={(accountId) => navigate(`/accounts/${accountId}`)}
       />
     </div>
   )


### PR DESCRIPTION
## Summary

- Adds `CreateAccountDialog` component to `frontend/src/pages/accounts/` with form validation, currency selection, and `InitiateCurrentAccount` API mutation
- Integrates Create Account button and dialog into `AccountsPage` with post-creation navigation to the new account detail page
- Adds `frontend/e2e/accounts.spec.ts` with 11 smoke tests (no backend required) and 2 full-lifecycle tests gated behind `MERIDIAN_E2E_BACKEND=1`
- Fixes `frontend/e2e/fixtures.ts` auth injection: adds `navigateTo()` helper for client-side routing that preserves memory-only tokens, and fixes `injectDevAuth` to trigger client-side navigation after token injection so `ProtectedRoute` renders the authenticated app shell

## Changes Made

**New files:**
- `frontend/e2e/accounts.spec.ts` — 11 smoke tests + 2 backend-gated lifecycle tests
- `frontend/src/pages/accounts/create-account-dialog.tsx` — IBAN/currency/partyId form dialog

**Modified files:**
- `frontend/src/pages/accounts/index.tsx` — adds Create Account button and dialog
- `frontend/e2e/fixtures.ts` — adds `navigateTo()` helper and fixes auth propagation timing

## Test plan

- [ ] All 11 smoke tests pass with `npm run dev` and `npx playwright test e2e/accounts.spec.ts`
- [ ] Dashboard smoke tests continue to pass (heading + quick actions)
- [ ] TypeScript compiles without errors (`tsc --noEmit`)
- [ ] Full lifecycle tests execute with `MERIDIAN_E2E_BACKEND=1` against a running stack

## Technical Details

**Auth propagation fix:** Dev-mode auth tokens are memory-only (not persisted to localStorage). The previous `injectDevAuth` called `__DEV_LOGIN__()` but did not navigate away from `/login`, so `ProtectedRoute` never rendered the authenticated content. The fix triggers `history.pushState('/')` + `popstate` event after token injection to route the authenticated app shell into view.

**Strict mode scoping:** The `DataTable` renders an IBAN filter input alongside the page. Dialog field locators are scoped to `getByRole('dialog')` to avoid strict mode violations from duplicate `getByLabel('IBAN')` matches.

**Backend-gated tests:** Full create/deposit/withdraw lifecycle tests are skipped unless `MERIDIAN_E2E_BACKEND=1` is set, designed for integration with the task 026-operations-console.45 CI workflow.