### PR TITLE
test: Add Playwright E2E tests for manifest management flow

### DIFF
--- a/frontend/e2e/manifests.spec.ts
+++ b/frontend/e2e/manifests.spec.ts
@@ -1,0 +1,456 @@
+import { test, expect } from './fixtures'
+import { type Page } from '@playwright/test'
+import * as path from 'path'
+import * as fs from 'fs'
+
+/**
+ * E2E tests for the Manifest Management flow.
+ *
+ * These tests use Playwright route interception to mock Connect-ES API calls,
+ * so they run without a live backend. The Vite dev server must be running.
+ *
+ * Connect-ES in JSON mode uses HTTP POST requests with the path pattern:
+ *   /<package>.<ServiceName>/<MethodName>
+ */
+
+const ENERGY_MANIFEST_PATH = path.resolve(
+  __dirname,
+  '../../examples/manifests/energy.json',
+)
+
+function loadEnergyManifest(): string {
+  return fs.readFileSync(ENERGY_MANIFEST_PATH, 'utf-8')
+}
+
+// ApplyManifestStatus enum values (mirrors proto definition)
+const ApplyManifestStatus = {
+  DRY_RUN: 1,
+  APPLIED: 2,
+  VALIDATION_FAILED: 3,
+  FAILED: 4,
+} as const
+
+// ApplyStatus enum values (mirrors proto definition)
+const ApplyStatus = {
+  APPLIED: 1,
+  FAILED: 2,
+  ROLLED_BACK: 3,
+} as const
+
+const ENERGY_MANIFEST_RESPONSE = {
+  version: '1.0',
+  metadata: {
+    name: 'Acme Energy Trading',
+    industry: 'energy',
+    description: 'Energy trading and settlement platform with kWh and carbon credit support',
+  },
+  instruments: [
+    { code: 'GBP', name: 'British Pound Sterling', type: 'INSTRUMENT_TYPE_FIAT', dimensions: { unit: 'GBP', precision: 2 } },
+    { code: 'KWH', name: 'Kilowatt Hour', type: 'INSTRUMENT_TYPE_COMMODITY', dimensions: { unit: 'kWh', precision: 3 } },
+    { code: 'CARBON_CREDIT', name: 'Carbon Credit', type: 'INSTRUMENT_TYPE_COMMODITY', dimensions: { unit: 'TONNE_CO2E', precision: 4 } },
+  ],
+  accountTypes: [
+    { code: 'ENERGY_TRADING', name: 'Energy Trading Account', normalBalance: 'NORMAL_BALANCE_DEBIT', allowedInstruments: ['GBP', 'KWH'] },
+    { code: 'CARBON_INVENTORY', name: 'Carbon Credit Inventory', normalBalance: 'NORMAL_BALANCE_DEBIT', allowedInstruments: ['CARBON_CREDIT'] },
+    { code: 'SETTLEMENT', name: 'Settlement Account', normalBalance: 'NORMAL_BALANCE_CREDIT', allowedInstruments: ['GBP'] },
+  ],
+  valuationRules: [
+    { fromInstrument: 'KWH', toInstrument: 'GBP', method: 'VALUATION_METHOD_SPOT_RATE', source: 'nordpool_spot' },
+    { fromInstrument: 'CARBON_CREDIT', toInstrument: 'GBP', method: 'VALUATION_METHOD_SPOT_RATE', source: 'ice_eua' },
+  ],
+  sagas: [
+    { name: 'process_energy_settlement', trigger: 'api:/v1/energy/settlements', script: '' },
+  ],
+}
+
+const MANIFEST_HISTORY_ENTRY = {
+  id: 'version-1',
+  version: '1.0',
+  appliedAt: { seconds: '1706745600', nanos: 0 },
+  appliedBy: 'e2e-user',
+  applyStatus: ApplyStatus.APPLIED,
+  diffSummary: 'Added 3 instruments, 3 account types, 2 valuation rules, 1 saga',
+  manifest: ENERGY_MANIFEST_RESPONSE,
+}
+
+/**
+ * Set up route interception for manifest API calls.
+ */
+async function setupManifestRoutes(
+  page: Page,
+  options: {
+    hasCurrentManifest: boolean
+    historyEntries?: typeof MANIFEST_HISTORY_ENTRY[]
+  },
+) {
+  const { hasCurrentManifest, historyEntries = [] } = options
+
+  // ManifestHistoryService.GetCurrentManifest
+  await page.route('**/meridian.control_plane.v1.ManifestHistoryService/GetCurrentManifest', (route) => {
+    if (hasCurrentManifest) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ version: MANIFEST_HISTORY_ENTRY }),
+      })
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    })
+  })
+
+  // ManifestHistoryService.ListManifestVersions
+  await page.route('**/meridian.control_plane.v1.ManifestHistoryService/ListManifestVersions', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        versions: historyEntries,
+        totalCount: historyEntries.length,
+      }),
+    })
+  })
+
+  // ApplyManifestService.ApplyManifest - dry run
+  await page.route('**/meridian.control_plane.v1.ApplyManifestService/ApplyManifest', async (route) => {
+    const request = route.request()
+    const body = await request.postDataJSON().catch(() => ({})) as Record<string, unknown>
+    const isDryRun = body.dryRun === true
+
+    if (isDryRun) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          jobId: 'job-dry-run',
+          status: ApplyManifestStatus.DRY_RUN,
+          diffSummary: 'Added 3 instruments, 3 account types, 2 valuation rules, 1 saga',
+          stepResults: [
+            { stepName: 'validate', status: 1, message: 'Validation passed', details: {} },
+            { stepName: 'diff', status: 1, message: '9 changes detected', details: {} },
+            { stepName: 'execute', status: 3, message: 'Skipped (dry run)', details: {} },
+          ],
+          validationErrors: [],
+        }),
+      })
+    }
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        jobId: 'job-apply',
+        status: ApplyManifestStatus.APPLIED,
+        diffSummary: 'Applied successfully',
+        stepResults: [],
+        validationErrors: [],
+      }),
+    })
+  })
+}
+
+test.describe('Manifest Management Flow', () => {
+  test.describe('Initial State - no manifest applied', () => {
+    test('navigates to /manifests and shows empty state', async ({ platformAdminPage: page }) => {
+      await setupManifestRoutes(page, { hasCurrentManifest: false })
+
+      await page.goto('/manifests')
+      await expect(page.getByRole('heading', { name: 'Manifest Configuration' })).toBeVisible()
+
+      // Verify Apply Manifest button is visible
+      await expect(page.getByRole('button', { name: 'Apply Manifest' })).toBeVisible()
+
+      // Current tab is active by default and shows empty state
+      const emptyState = page.getByTestId('empty-state')
+      await expect(emptyState).toBeVisible()
+      await expect(emptyState).toContainText(/no manifest/i)
+    })
+
+    test('shows Version History tab with empty history', async ({ platformAdminPage: page }) => {
+      await setupManifestRoutes(page, { hasCurrentManifest: false })
+
+      await page.goto('/manifests')
+      await page.getByRole('tab', { name: 'Version History' }).click()
+
+      // History table wrapper should be visible (DataTable shows empty state internally)
+      await expect(page.getByTestId('manifest-history-table')).toBeVisible()
+    })
+  })
+
+  test.describe('Apply Manifest with Dry-Run Preview', () => {
+    test('opens apply dialog when clicking Apply Manifest button', async ({ platformAdminPage: page }) => {
+      await setupManifestRoutes(page, { hasCurrentManifest: false })
+
+      await page.goto('/manifests')
+      await page.getByRole('button', { name: 'Apply Manifest' }).click()
+
+      const dialog = page.getByRole('dialog')
+      await expect(dialog).toBeVisible()
+      await expect(dialog.getByRole('heading', { name: 'Apply Manifest' })).toBeVisible()
+    })
+
+    test('preview changes shows dry-run result with diff summary', async ({ platformAdminPage: page }) => {
+      await setupManifestRoutes(page, { hasCurrentManifest: false })
+
+      const manifestJson = loadEnergyManifest()
+      await page.goto('/manifests')
+      await page.getByRole('button', { name: 'Apply Manifest' }).click()
+
+      const dialog = page.getByRole('dialog')
+      await expect(dialog).toBeVisible()
+
+      // Fill in manifest JSON
+      const textarea = dialog.getByTestId('manifest-json')
+      await textarea.fill(manifestJson)
+
+      // Click Preview Changes
+      await dialog.getByRole('button', { name: 'Preview Changes' }).click()
+
+      // Wait for dry-run result to appear
+      const dryRunResult = dialog.getByTestId('dry-run-result')
+      await expect(dryRunResult).toBeVisible({ timeout: 10_000 })
+
+      // Verify diff summary content
+      await expect(dryRunResult).toContainText('Added 3 instruments')
+    })
+
+    test('preview shows step results including validate, diff, and skipped execute', async ({ platformAdminPage: page }) => {
+      await setupManifestRoutes(page, { hasCurrentManifest: false })
+
+      const manifestJson = loadEnergyManifest()
+      await page.goto('/manifests')
+      await page.getByRole('button', { name: 'Apply Manifest' }).click()
+
+      const dialog = page.getByRole('dialog')
+      const textarea = dialog.getByTestId('manifest-json')
+      await textarea.fill(manifestJson)
+      await dialog.getByRole('button', { name: 'Preview Changes' }).click()
+
+      await expect(dialog.getByTestId('dry-run-result')).toBeVisible({ timeout: 10_000 })
+
+      // Step results should be visible within the dry-run panel
+      await expect(dialog.getByText('validate')).toBeVisible()
+      await expect(dialog.getByText('diff')).toBeVisible()
+    })
+
+    test('Apply Manifest button is enabled after successful preview', async ({ platformAdminPage: page }) => {
+      await setupManifestRoutes(page, { hasCurrentManifest: false })
+
+      const manifestJson = loadEnergyManifest()
+      await page.goto('/manifests')
+      await page.getByRole('button', { name: 'Apply Manifest' }).click()
+
+      const dialog = page.getByRole('dialog')
+      const textarea = dialog.getByTestId('manifest-json')
+      await textarea.fill(manifestJson)
+
+      // Apply button disabled before preview
+      await expect(dialog.getByRole('button', { name: 'Apply Manifest' })).toBeDisabled()
+
+      // After preview succeeds, Apply button becomes enabled
+      await dialog.getByRole('button', { name: 'Preview Changes' }).click()
+      await expect(dialog.getByTestId('dry-run-result')).toBeVisible({ timeout: 10_000 })
+      await expect(dialog.getByRole('button', { name: 'Apply Manifest' })).not.toBeDisabled()
+    })
+
+    test('applies manifest and dialog closes on success', async ({ platformAdminPage: page }) => {
+      await setupManifestRoutes(page, { hasCurrentManifest: false })
+
+      const manifestJson = loadEnergyManifest()
+      await page.goto('/manifests')
+      await page.getByRole('button', { name: 'Apply Manifest' }).click()
+
+      const dialog = page.getByRole('dialog')
+      const textarea = dialog.getByTestId('manifest-json')
+      await textarea.fill(manifestJson)
+
+      // Preview then apply
+      await dialog.getByRole('button', { name: 'Preview Changes' }).click()
+      await expect(dialog.getByTestId('dry-run-result')).toBeVisible({ timeout: 10_000 })
+      await dialog.getByRole('button', { name: 'Apply Manifest' }).click()
+
+      // Dialog should close after successful apply
+      await expect(dialog).not.toBeVisible({ timeout: 15_000 })
+    })
+  })
+
+  test.describe('Current Manifest View', () => {
+    test('displays applied manifest version and metadata', async ({ platformAdminPage: page }) => {
+      await setupManifestRoutes(page, {
+        hasCurrentManifest: true,
+        historyEntries: [MANIFEST_HISTORY_ENTRY],
+      })
+
+      await page.goto('/manifests')
+
+      const currentView = page.getByTestId('manifest-current-view')
+      await expect(currentView).toBeVisible({ timeout: 10_000 })
+
+      // Version and metadata
+      await expect(currentView).toContainText('Version 1.0')
+      await expect(currentView).toContainText('Acme Energy Trading')
+    })
+
+    test('shows APPLIED status badge', async ({ platformAdminPage: page }) => {
+      await setupManifestRoutes(page, {
+        hasCurrentManifest: true,
+        historyEntries: [MANIFEST_HISTORY_ENTRY],
+      })
+
+      await page.goto('/manifests')
+
+      const currentView = page.getByTestId('manifest-current-view')
+      await expect(currentView).toBeVisible({ timeout: 10_000 })
+      await expect(currentView).toContainText('APPLIED')
+    })
+
+    test('instruments section shows GBP, KWH, and CARBON_CREDIT after expand', async ({ platformAdminPage: page }) => {
+      await setupManifestRoutes(page, {
+        hasCurrentManifest: true,
+        historyEntries: [MANIFEST_HISTORY_ENTRY],
+      })
+
+      await page.goto('/manifests')
+
+      const instrumentsSection = page.getByTestId('instruments-section')
+      await expect(instrumentsSection).toBeVisible({ timeout: 10_000 })
+
+      // Expand the instruments section
+      await instrumentsSection.getByRole('button').click()
+
+      await expect(instrumentsSection).toContainText('GBP')
+      await expect(instrumentsSection).toContainText('British Pound Sterling')
+      await expect(instrumentsSection).toContainText('KWH')
+      await expect(instrumentsSection).toContainText('Kilowatt Hour')
+      await expect(instrumentsSection).toContainText('CARBON_CREDIT')
+      await expect(instrumentsSection).toContainText('Carbon Credit')
+    })
+
+    test('account types section shows ENERGY_TRADING, CARBON_INVENTORY, and SETTLEMENT after expand', async ({ platformAdminPage: page }) => {
+      await setupManifestRoutes(page, {
+        hasCurrentManifest: true,
+        historyEntries: [MANIFEST_HISTORY_ENTRY],
+      })
+
+      await page.goto('/manifests')
+
+      const accountTypesSection = page.getByTestId('account-types-section')
+      await expect(accountTypesSection).toBeVisible({ timeout: 10_000 })
+
+      // Expand the account types section
+      await accountTypesSection.getByRole('button').click()
+
+      await expect(accountTypesSection).toContainText('ENERGY_TRADING')
+      await expect(accountTypesSection).toContainText('Energy Trading Account')
+      await expect(accountTypesSection).toContainText('CARBON_INVENTORY')
+      await expect(accountTypesSection).toContainText('Carbon Credit Inventory')
+      await expect(accountTypesSection).toContainText('SETTLEMENT')
+      await expect(accountTypesSection).toContainText('Settlement Account')
+    })
+  })
+
+  test.describe('Version History Table', () => {
+    test('history tab shows applied entry with version and APPLIED status', async ({ platformAdminPage: page }) => {
+      await setupManifestRoutes(page, {
+        hasCurrentManifest: true,
+        historyEntries: [MANIFEST_HISTORY_ENTRY],
+      })
+
+      await page.goto('/manifests')
+
+      // Switch to Version History tab
+      await page.getByRole('tab', { name: 'Version History' }).click()
+
+      const historyTable = page.getByTestId('manifest-history-table')
+      await expect(historyTable).toBeVisible()
+
+      // Verify table content
+      await expect(historyTable).toContainText('1.0')
+      await expect(historyTable).toContainText('APPLIED')
+      await expect(historyTable).toContainText('e2e-user')
+    })
+
+    test('history entry shows diff summary', async ({ platformAdminPage: page }) => {
+      await setupManifestRoutes(page, {
+        hasCurrentManifest: true,
+        historyEntries: [MANIFEST_HISTORY_ENTRY],
+      })
+
+      await page.goto('/manifests')
+      await page.getByRole('tab', { name: 'Version History' }).click()
+
+      const historyTable = page.getByTestId('manifest-history-table')
+      await expect(historyTable).toBeVisible()
+      await expect(historyTable).toContainText('Added 3 instruments')
+    })
+  })
+
+  test.describe('Idempotent Re-Application', () => {
+    test('re-applying same manifest dry-run shows another diff summary', async ({ platformAdminPage: page }) => {
+      // Set up with manifest already applied
+      await setupManifestRoutes(page, {
+        hasCurrentManifest: true,
+        historyEntries: [MANIFEST_HISTORY_ENTRY],
+      })
+
+      const manifestJson = loadEnergyManifest()
+      await page.goto('/manifests')
+
+      // Verify manifest is already shown
+      await expect(page.getByTestId('manifest-current-view')).toBeVisible({ timeout: 10_000 })
+
+      // Open apply dialog and re-apply same manifest
+      await page.getByRole('button', { name: 'Apply Manifest' }).click()
+      const dialog = page.getByRole('dialog')
+      await expect(dialog).toBeVisible()
+
+      const textarea = dialog.getByTestId('manifest-json')
+      await textarea.fill(manifestJson)
+
+      // Preview - will show the same response (mock returns same diff summary)
+      await dialog.getByRole('button', { name: 'Preview Changes' }).click()
+      const dryRunResult = dialog.getByTestId('dry-run-result')
+      await expect(dryRunResult).toBeVisible({ timeout: 10_000 })
+
+      // Dry run succeeded so Apply Manifest button is enabled
+      await expect(dialog.getByRole('button', { name: 'Apply Manifest' })).not.toBeDisabled()
+
+      // Apply the manifest again
+      await dialog.getByRole('button', { name: 'Apply Manifest' }).click()
+      await expect(dialog).not.toBeVisible({ timeout: 15_000 })
+    })
+  })
+
+  test.describe('Error Handling', () => {
+    test('shows parse error for invalid JSON input', async ({ platformAdminPage: page }) => {
+      await setupManifestRoutes(page, { hasCurrentManifest: false })
+
+      await page.goto('/manifests')
+      await page.getByRole('button', { name: 'Apply Manifest' }).click()
+
+      const dialog = page.getByRole('dialog')
+      const textarea = dialog.getByTestId('manifest-json')
+      await textarea.fill('this is not valid json {{{')
+
+      await dialog.getByRole('button', { name: 'Preview Changes' }).click()
+
+      // Parse error should appear
+      await expect(dialog.getByTestId('parse-error')).toBeVisible({ timeout: 10_000 })
+    })
+
+    test('Cancel button closes the dialog', async ({ platformAdminPage: page }) => {
+      await setupManifestRoutes(page, { hasCurrentManifest: false })
+
+      await page.goto('/manifests')
+      await page.getByRole('button', { name: 'Apply Manifest' }).click()
+
+      const dialog = page.getByRole('dialog')
+      await expect(dialog).toBeVisible()
+
+      await dialog.getByRole('button', { name: 'Cancel' }).click()
+      await expect(dialog).not.toBeVisible()
+    })
+  })
+})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "typecheck": "tsc --noEmit",
     "generate": "buf generate --template buf.gen.yaml ../api/proto",
     "e2e": "playwright test",
-    "e2e:headed": "playwright test --headed"
+    "e2e:headed": "playwright test --headed",
+    "e2e:manifests": "playwright test manifests.spec.ts"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",

--- a/frontend/src/pages/manifests/manifest-apply-dialog.test.tsx
+++ b/frontend/src/pages/manifests/manifest-apply-dialog.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { renderWithProviders } from '@/test/test-utils'
 import { createTenantUserToken } from '@/test/jwt-helpers'
@@ -10,6 +9,13 @@ import { ApplyManifestStatus } from '@/api/gen/meridian/control_plane/v1/apply_m
 vi.mock('@/api/context', () => ({
   useApiClients: vi.fn(),
   ApiClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+// The component calls create(ManifestSchema, parsed) before calling applyManifest.
+// In tests, ManifestSchema is a stub that doesn't satisfy @bufbuild/protobuf's create().
+// We mock the entire module to return the parsed object directly.
+vi.mock('@bufbuild/protobuf', () => ({
+  create: (_schema: unknown, data: unknown) => data,
 }))
 
 import { useApiClients } from '@/api/context'
@@ -102,7 +108,8 @@ describe('ManifestApplyDialog', () => {
     const textarea = screen.getByLabelText(/manifest json/i)
     fireEvent.change(textarea, { target: { value: validManifest } })
 
-    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+    // Use fireEvent.click because Radix Dialog sets pointer-events:none on body in jsdom
+    fireEvent.click(screen.getByRole('button', { name: /preview changes/i }))
 
     await waitFor(() => {
       expect(applyManifestMock).toHaveBeenCalledWith(
@@ -118,7 +125,7 @@ describe('ManifestApplyDialog', () => {
     const textarea = screen.getByLabelText(/manifest json/i)
     fireEvent.change(textarea, { target: { value: validManifest } })
 
-    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+    fireEvent.click(screen.getByRole('button', { name: /preview changes/i }))
 
     await waitFor(() => {
       expect(screen.getByTestId('dry-run-result')).toBeInTheDocument()
@@ -133,7 +140,7 @@ describe('ManifestApplyDialog', () => {
     const textarea = screen.getByLabelText(/manifest json/i)
     fireEvent.change(textarea, { target: { value: validManifest } })
 
-    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+    fireEvent.click(screen.getByRole('button', { name: /preview changes/i }))
 
     await waitFor(() => {
       expect(screen.getByText('validate')).toBeInTheDocument()
@@ -148,7 +155,7 @@ describe('ManifestApplyDialog', () => {
     const textarea = screen.getByLabelText(/manifest json/i)
     fireEvent.change(textarea, { target: { value: validManifest } })
 
-    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+    fireEvent.click(screen.getByRole('button', { name: /preview changes/i }))
 
     await waitFor(() => {
       const applyBtn = screen.getByRole('button', { name: /apply manifest/i })
@@ -166,13 +173,13 @@ describe('ManifestApplyDialog', () => {
     const textarea = screen.getByLabelText(/manifest json/i)
     fireEvent.change(textarea, { target: { value: validManifest } })
 
-    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+    fireEvent.click(screen.getByRole('button', { name: /preview changes/i }))
 
     await waitFor(() => {
       expect(screen.getByTestId('dry-run-result')).toBeInTheDocument()
     })
 
-    await userEvent.click(screen.getByRole('button', { name: /apply manifest/i }))
+    fireEvent.click(screen.getByRole('button', { name: /apply manifest/i }))
 
     await waitFor(() => {
       expect(applyManifestMock).toHaveBeenCalledWith(
@@ -188,7 +195,7 @@ describe('ManifestApplyDialog', () => {
     const textarea = screen.getByLabelText(/manifest json/i)
     fireEvent.change(textarea, { target: { value: 'not-json' } })
 
-    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+    fireEvent.click(screen.getByRole('button', { name: /preview changes/i }))
 
     await waitFor(() => {
       expect(screen.getByTestId('parse-error')).toBeInTheDocument()
@@ -215,7 +222,7 @@ describe('ManifestApplyDialog', () => {
     const textarea = screen.getByLabelText(/manifest json/i)
     fireEvent.change(textarea, { target: { value: validManifest } })
 
-    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+    fireEvent.click(screen.getByRole('button', { name: /preview changes/i }))
 
     await waitFor(() => {
       expect(screen.getByTestId('validation-errors')).toBeInTheDocument()
@@ -237,7 +244,7 @@ describe('ManifestApplyDialog', () => {
     const textarea = screen.getByLabelText(/manifest json/i)
     fireEvent.change(textarea, { target: { value: validManifest } })
 
-    await userEvent.click(screen.getByRole('button', { name: /preview changes/i }))
+    fireEvent.click(screen.getByRole('button', { name: /preview changes/i }))
 
     await waitFor(() => {
       expect(screen.getByTestId('validation-errors')).toBeInTheDocument()

--- a/frontend/src/pages/manifests/manifest-apply-dialog.tsx
+++ b/frontend/src/pages/manifests/manifest-apply-dialog.tsx
@@ -124,6 +124,7 @@ export function ManifestApplyDialog({ open, onOpenChange }: ManifestApplyDialogP
             </label>
             <textarea
               id="manifest-json"
+              data-testid="manifest-json"
               value={manifestJson}
               onChange={(e) => handleJsonChange(e.target.value)}
               className="min-h-[200px] w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm"

--- a/frontend/src/pages/manifests/manifest-current-view.tsx
+++ b/frontend/src/pages/manifests/manifest-current-view.tsx
@@ -50,13 +50,14 @@ interface ExpandableSectionProps {
   title: string
   count: number
   children: React.ReactNode
+  'data-testid'?: string
 }
 
-function ExpandableSection({ title, count, children }: ExpandableSectionProps) {
+function ExpandableSection({ title, count, children, 'data-testid': testId }: ExpandableSectionProps) {
   const [open, setOpen] = useState(false)
 
   return (
-    <div className="border-b border-border last:border-b-0">
+    <div className="border-b border-border last:border-b-0" data-testid={testId}>
       <button
         type="button"
         onClick={() => setOpen(!open)}
@@ -92,7 +93,7 @@ export function ManifestCurrentView() {
   const sagas = manifest?.sagas ?? []
 
   return (
-    <Card className="overflow-hidden">
+    <Card className="overflow-hidden" data-testid="manifest-current-view">
       <div className="border-b border-border px-4 py-3">
         <div className="flex items-center gap-3">
           <h3 className="text-lg font-semibold">Version {version}</h3>
@@ -112,7 +113,7 @@ export function ManifestCurrentView() {
         )}
       </div>
 
-      <ExpandableSection title="Instruments" count={instruments.length}>
+      <ExpandableSection title="Instruments" count={instruments.length} data-testid="instruments-section">
         {instruments.length === 0 ? (
           <p className="text-xs text-muted-foreground">No instruments defined.</p>
         ) : (
@@ -130,7 +131,7 @@ export function ManifestCurrentView() {
         )}
       </ExpandableSection>
 
-      <ExpandableSection title="Account Types" count={accountTypes.length}>
+      <ExpandableSection title="Account Types" count={accountTypes.length} data-testid="account-types-section">
         {accountTypes.length === 0 ? (
           <p className="text-xs text-muted-foreground">No account types defined.</p>
         ) : (

--- a/frontend/src/pages/manifests/manifest-history-table.tsx
+++ b/frontend/src/pages/manifests/manifest-history-table.tsx
@@ -73,13 +73,15 @@ export function ManifestHistoryTable() {
 
   return (
     <>
-      <DataTable<ManifestVersion>
-        queryKey={manifestKeys.history()}
-        queryFn={fetchVersions}
-        columns={columns}
-        pageSize={20}
-        onRowClick={setSelectedVersion}
-      />
+      <div data-testid="manifest-history-table">
+        <DataTable<ManifestVersion>
+          queryKey={manifestKeys.history()}
+          queryFn={fetchVersions}
+          columns={columns}
+          pageSize={20}
+          onRowClick={setSelectedVersion}
+        />
+      </div>
 
       <Dialog open={selectedVersion != null} onOpenChange={() => setSelectedVersion(null)}>
         <DialogContent className="max-w-2xl">

--- a/frontend/src/test/gen-stub.ts
+++ b/frontend/src/test/gen-stub.ts
@@ -26,6 +26,9 @@ export const NodeService = serviceStub
 export const InternalBankAccountService = serviceStub
 export const MarketInformationService = serviceStub
 export const ForecastingService = serviceStub
+export const MappingService = serviceStub
+export const ManifestHistoryService = serviceStub
+export const ApplyManifestService = serviceStub
 
 // Enum exports (from types_pb.ts and other shared proto files)
 // Names match what Connect-ES generates from proto enums (short names without prefix).

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -29,6 +29,8 @@ function genStubPlugin(): Plugin {
     export const MarketInformationService = { typeName: 'stub', methods: [] }
     export const MappingService = { typeName: 'stub', methods: [] }
     export const ForecastingService = { typeName: 'stub', methods: [] }
+    export const ManifestHistoryService = { typeName: 'stub', methods: [] }
+    export const ApplyManifestService = { typeName: 'stub', methods: [] }
     export const TransactionStatus = { UNSPECIFIED: 0, PENDING: 1, POSTED: 2, FAILED: 3, CANCELLED: 4, REVERSED: 5 }
     export const PostingDirection = { UNSPECIFIED: 0, DEBIT: 1, CREDIT: 2 }
     export const Currency = { UNSPECIFIED: 0, GBP: 1, USD: 2, EUR: 3 }
@@ -39,6 +41,9 @@ function genStubPlugin(): Plugin {
     export const InstrumentStatus = { UNSPECIFIED: 0, DRAFT: 1, ACTIVE: 2, DEPRECATED: 3 }
     export const Dimension = { UNSPECIFIED: 0, CURRENCY: 1, ENERGY: 2, MASS: 3, VOLUME: 4, TIME: 5, COMPUTE: 6, CARBON: 7, DATA: 8, COUNT: 9 }
     export const BehaviorClass = { UNSPECIFIED: 0, CUSTOMER: 1, CLEARING: 2, NOSTRO: 3, VOSTRO: 4, HOLDING: 5, SUSPENSE: 6, REVENUE: 7, EXPENSE: 8, INVENTORY: 9 }
+    export const ApplyManifestStatus = { UNSPECIFIED: 0, DRY_RUN: 1, APPLIED: 2, VALIDATION_FAILED: 3, FAILED: 4 }
+    export const ApplyStatus = { UNSPECIFIED: 0, APPLIED: 1, FAILED: 2, ROLLED_BACK: 3 }
+    export const ManifestSchema = { typeName: 'meridian.control_plane.v1.Manifest', fields: [] }
     export default {}
   `
   return {


### PR DESCRIPTION
## Summary

- Add `frontend/e2e/manifests.spec.ts` with Playwright E2E tests for the complete manifest management flow, using route interception to mock Connect-ES API calls (no live backend required)
- Fix pre-existing unit test failures in `manifest-apply-dialog.test.tsx` by adding missing proto stubs and working around JSDOM limitations
- Add missing `data-testid` attributes to manifest UI components for E2E selector stability

## Changes Made

**New E2E tests** (`frontend/e2e/manifests.spec.ts`):
- Initial state: empty state display when no manifest is applied
- Apply manifest flow: open dialog, fill JSON, dry-run preview, verify diff summary and step results, apply and verify dialog closes
- Current manifest view: version, metadata, APPLIED status badge, expandable instruments section (GBP, KWH, CARBON_CREDIT), expandable account types section (ENERGY_TRADING, CARBON_INVENTORY, SETTLEMENT)
- Version history table: content with version, status, appliedBy, and diff summary
- Idempotent re-application: re-applying same manifest succeeds
- Error handling: invalid JSON shows parse error, Cancel button closes dialog

**UI component changes** (`data-testid` additions):
- `manifest-current-view.tsx`: `data-testid="manifest-current-view"` on Card, `data-testid="instruments-section"` and `data-testid="account-types-section"` on ExpandableSection
- `manifest-history-table.tsx`: `data-testid="manifest-history-table"` wrapper div around DataTable
- `manifest-apply-dialog.tsx`: `data-testid="manifest-json"` on the textarea

**Unit test fixes** (`manifest-apply-dialog.test.tsx`):
- Add `vi.mock('@bufbuild/protobuf')` to stub `create()` so the mocked `applyManifest` is reachable
- Replace `userEvent.click` with `fireEvent.click` for button interactions within Radix Dialog

**Vitest stub additions** (`vitest.config.ts`, `gen-stub.ts`):
- `ManifestHistoryService`, `ApplyManifestService` service stubs
- `ApplyManifestStatus`, `ApplyStatus` enum stubs
- `ManifestSchema` schema stub

**Package** (`package.json`):
- Add `e2e:manifests` script for running manifest E2E tests in isolation

## Testing

- Unit tests: All 1153 tests pass
- E2E tests: Run with `npm run e2e:manifests` against a running dev server