### PR TITLE
test: Add Playwright E2E tests for Positions, Ledger, and Reconciliation pages

### DIFF
--- a/frontend/e2e/ledger.spec.ts
+++ b/frontend/e2e/ledger.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect, navigateTo } from './fixtures'
+
+/**
+ * Ledger page E2E tests.
+ *
+ * NOTE: These tests require the Vite dev server (npm run dev) to be running.
+ *
+ * Auth tokens are memory-only (not persisted). All tests use navigateTo() for
+ * client-side navigation to preserve in-memory auth state.
+ *
+ * Navigation, page structure, and UI rendering tests do NOT require the
+ * Meridian backend — the ledger page renders with an empty/error state when
+ * no backend is available.
+ *
+ * Tests that require real booking log data (postings table, balance indicator,
+ * row click navigation) are guarded by MERIDIAN_E2E_BACKEND=1.
+ *
+ * Tests use `authenticatedPage` (tenant-user role) since ledger data is
+ * tenant-scoped.
+ */
+
+test.describe('Ledger page', () => {
+  test('renders Ledger heading after navigation', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/ledger')
+    await expect(authenticatedPage.getByRole('heading', { name: 'Ledger' })).toBeVisible()
+  })
+
+  test('renders ledger page subtitle', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/ledger')
+    await expect(
+      authenticatedPage.getByText('Financial booking logs and double-entry postings'),
+    ).toBeVisible()
+  })
+
+  test('renders booking logs table column headers', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/ledger')
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Log ID' })).toBeVisible()
+    await expect(
+      authenticatedPage.getByRole('columnheader', { name: 'Account Type' }),
+    ).toBeVisible()
+    await expect(
+      authenticatedPage.getByRole('columnheader', { name: 'Business Unit' }),
+    ).toBeVisible()
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Currency' })).toBeVisible()
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Status' })).toBeVisible()
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Postings' })).toBeVisible()
+  })
+
+  test('renders Status filter select', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/ledger')
+    await expect(authenticatedPage.getByLabel('Status')).toBeVisible()
+  })
+})
+
+test.describe('Booking log detail page', () => {
+  test('renders error state for unknown booking log ID', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/ledger/non-existent-booking-log-id')
+    // Without a backend, the query fails and the error state renders
+    await expect(
+      authenticatedPage.getByText(/Failed to load booking log/),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('renders Ledger breadcrumb link on error state', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/ledger/non-existent-booking-log-id')
+    // Scope to main content to avoid matching the nav sidebar link
+    const main = authenticatedPage.getByRole('main')
+    await expect(
+      main.getByRole('link', { name: 'Ledger' }),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('Ledger breadcrumb link navigates back to ledger list', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/ledger/non-existent-booking-log-id')
+    // Scope to main content to avoid matching the nav sidebar link
+    const main = authenticatedPage.getByRole('main')
+    await expect(
+      main.getByRole('link', { name: 'Ledger' }),
+    ).toBeVisible({ timeout: 10_000 })
+    await main.getByRole('link', { name: 'Ledger' }).click()
+    await expect(authenticatedPage.getByRole('heading', { name: 'Ledger' })).toBeVisible()
+  })
+})
+
+/**
+ * Full data tests — require live backend with seeded booking log records.
+ * Un-skip when running against a full stack (task 45 CI workflow).
+ */
+test.describe('Ledger page with data (requires backend)', () => {
+  test.skip(
+    process.env.MERIDIAN_E2E_BACKEND !== '1',
+    'Set MERIDIAN_E2E_BACKEND=1 to run data-dependent tests',
+  )
+
+  test('displays booking log rows in the table', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/ledger')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    const rows = authenticatedPage.locator('[data-testid="data-table-row"]')
+    expect(await rows.count()).toBeGreaterThan(0)
+  })
+
+  test('navigates to booking log detail on row click', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/ledger')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await expect(authenticatedPage).toHaveURL(/\/ledger\/[a-zA-Z0-9_-]+/)
+    await expect(authenticatedPage.getByText('Ledger Postings')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('booking log detail shows Ledger Postings card title', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/ledger')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await expect(authenticatedPage.getByText('Ledger Postings')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('booking log detail shows postings table with correct column headers', async ({
+    authenticatedPage,
+  }) => {
+    await navigateTo(authenticatedPage, '/ledger')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await expect(
+      authenticatedPage.getByRole('columnheader', { name: 'Posting ID' }),
+    ).toBeVisible({ timeout: 10_000 })
+    await expect(
+      authenticatedPage.getByRole('columnheader', { name: 'Direction' }),
+    ).toBeVisible()
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Amount' })).toBeVisible()
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Account' })).toBeVisible()
+  })
+
+  test('booking log detail shows BalanceIndicator', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/ledger')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    const balanceIndicator = authenticatedPage.getByTestId('balance-indicator')
+    await expect(balanceIndicator).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('balance indicator shows debit and credit totals', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/ledger')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await expect(authenticatedPage.getByTestId('debit-total')).toBeVisible({ timeout: 10_000 })
+    await expect(authenticatedPage.getByTestId('credit-total')).toBeVisible()
+  })
+
+  test('booking log detail shows DirectionBadge with DEBIT or CREDIT', async ({
+    authenticatedPage,
+  }) => {
+    await navigateTo(authenticatedPage, '/ledger')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await expect(authenticatedPage.getByText('Ledger Postings')).toBeVisible({ timeout: 10_000 })
+    const directionBadges = authenticatedPage.locator('[data-testid="direction-badge"]')
+    const count = await directionBadges.count()
+    expect(count).toBeGreaterThan(0)
+    // Each posting has a DEBIT or CREDIT direction badge
+    const texts = await directionBadges.allTextContents()
+    const validDirections = texts.every(
+      (t) => t.toUpperCase().includes('DEBIT') || t.toUpperCase().includes('CREDIT'),
+    )
+    expect(validDirections).toBe(true)
+  })
+})

--- a/frontend/e2e/positions.spec.ts
+++ b/frontend/e2e/positions.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect, navigateTo } from './fixtures'
+
+/**
+ * Positions page E2E tests.
+ *
+ * NOTE: These tests require the Vite dev server (npm run dev) to be running.
+ *
+ * Auth tokens are memory-only (not persisted). All tests use navigateTo() for
+ * client-side navigation to preserve in-memory auth state.
+ *
+ * Navigation, page structure, and UI rendering tests do NOT require the
+ * Meridian backend — the positions page renders with an empty/error state when
+ * no backend is available.
+ *
+ * Tests that require real position data (quality ladder, row click navigation)
+ * are guarded by MERIDIAN_E2E_BACKEND=1 since they depend on existing records.
+ *
+ * Tests use `authenticatedPage` (tenant-user role) since positions are
+ * tenant-scoped resources.
+ */
+
+test.describe('Positions page', () => {
+  test('renders Positions heading after navigation', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/positions')
+    await expect(authenticatedPage.getByRole('heading', { name: 'Positions' })).toBeVisible()
+  })
+
+  test('renders positions page subtitle', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/positions')
+    await expect(
+      authenticatedPage.getByText('Financial position logs with bi-temporal data quality tracking.'),
+    ).toBeVisible()
+  })
+
+  test('renders positions table column headers', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/positions')
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Log ID' })).toBeVisible()
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Account' })).toBeVisible()
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Status' })).toBeVisible()
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Created' })).toBeVisible()
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Last Updated' })).toBeVisible()
+  })
+
+  test('renders Account ID filter input', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/positions')
+    await expect(authenticatedPage.getByPlaceholder('Account ID')).toBeVisible()
+  })
+
+  test('renders Status filter select', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/positions')
+    await expect(authenticatedPage.getByLabel('Status')).toBeVisible()
+  })
+})
+
+test.describe('Position detail page', () => {
+  test('renders Position Log heading for unknown ID', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/positions/non-existent-log-id')
+    await expect(
+      authenticatedPage.getByRole('heading', { name: 'Position Log' }),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('renders back button on position detail page', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/positions/non-existent-log-id')
+    await expect(
+      authenticatedPage.getByTestId('back-button'),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('back button navigates to positions list', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/positions/non-existent-log-id')
+    await expect(
+      authenticatedPage.getByTestId('back-button'),
+    ).toBeVisible({ timeout: 10_000 })
+    await authenticatedPage.getByTestId('back-button').click()
+    await expect(authenticatedPage.getByRole('heading', { name: 'Positions' })).toBeVisible()
+  })
+})
+
+/**
+ * Full data tests — require live backend with seeded position log records.
+ * Un-skip when running against a full stack (task 45 CI workflow).
+ */
+test.describe('Positions page with data (requires backend)', () => {
+  test.skip(
+    process.env.MERIDIAN_E2E_BACKEND !== '1',
+    'Set MERIDIAN_E2E_BACKEND=1 to run data-dependent tests',
+  )
+
+  test('displays position log rows in the table', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/positions')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    const rows = authenticatedPage.locator('[data-testid="data-table-row"]')
+    expect(await rows.count()).toBeGreaterThan(0)
+  })
+
+  test('navigates to position detail on row click', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/positions')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await expect(authenticatedPage).toHaveURL(/\/positions\/[a-zA-Z0-9_-]+/)
+    await expect(
+      authenticatedPage.getByRole('heading', { name: 'Position Log' }),
+    ).toBeVisible()
+  })
+
+  test('position detail shows balance view with provisional and available balances', async ({
+    authenticatedPage,
+  }) => {
+    await navigateTo(authenticatedPage, '/positions')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await expect(authenticatedPage.getByTestId('provisional-balance')).toBeVisible({ timeout: 10_000 })
+    await expect(authenticatedPage.getByTestId('available-balance')).toBeVisible()
+  })
+
+  test('position detail Measurement History tab renders quality ladder badges', async ({
+    authenticatedPage,
+  }) => {
+    await navigateTo(authenticatedPage, '/positions')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await authenticatedPage.getByRole('tab', { name: 'Measurement History' }).click()
+    const badges = authenticatedPage.locator('[data-testid="quality-ladder-badge"]')
+    await expect(badges.first()).toBeVisible({ timeout: 10_000 })
+    const badgeCount = await badges.count()
+    expect(badgeCount).toBeGreaterThan(0)
+  })
+
+  test('position detail Measurement History tab renders measurement entries', async ({
+    authenticatedPage,
+  }) => {
+    await navigateTo(authenticatedPage, '/positions')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await authenticatedPage.getByRole('tab', { name: 'Measurement History' }).click()
+    const historyTable = authenticatedPage.getByTestId('measurement-history-table')
+    await expect(historyTable).toBeVisible({ timeout: 10_000 })
+    const entries = authenticatedPage.locator('[data-testid="measurement-entry"]')
+    expect(await entries.count()).toBeGreaterThan(0)
+  })
+})

--- a/frontend/e2e/reconciliation.spec.ts
+++ b/frontend/e2e/reconciliation.spec.ts
@@ -1,0 +1,217 @@
+import { test, expect, navigateTo } from './fixtures'
+
+/**
+ * Reconciliation page E2E tests.
+ *
+ * NOTE: These tests require the Vite dev server (npm run dev) to be running.
+ *
+ * Auth tokens are memory-only (not persisted). All tests use navigateTo() for
+ * client-side navigation to preserve in-memory auth state.
+ *
+ * Navigation and page structure tests do NOT require the Meridian backend —
+ * the reconciliation page renders with an empty/error state when no backend is
+ * available.
+ *
+ * Tests that require real reconciliation run data (row click, detail tabs,
+ * disputes UI, balance assertions) are guarded by MERIDIAN_E2E_BACKEND=1.
+ *
+ * Tests use `authenticatedPage` (tenant-user role) since reconciliation data
+ * is tenant-scoped.
+ */
+
+test.describe('Reconciliation page', () => {
+  test('renders Reconciliation heading after navigation', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reconciliation')
+    await expect(
+      authenticatedPage.getByRole('heading', { name: 'Reconciliation' }),
+    ).toBeVisible()
+  })
+
+  test('renders reconciliation page subtitle', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reconciliation')
+    await expect(
+      authenticatedPage.getByText('Settlement runs, variance detection, and dispute resolution.'),
+    ).toBeVisible()
+  })
+
+  test('renders reconciliation table column headers', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reconciliation')
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Run ID' })).toBeVisible()
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Account' })).toBeVisible()
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Scope' })).toBeVisible()
+    await expect(
+      authenticatedPage.getByRole('columnheader', { name: 'Settlement Type' }),
+    ).toBeVisible()
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Status' })).toBeVisible()
+    await expect(
+      authenticatedPage.getByRole('columnheader', { name: 'Variances' }),
+    ).toBeVisible()
+  })
+
+  test('renders Status filter select', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reconciliation')
+    await expect(authenticatedPage.getByLabel('Status')).toBeVisible()
+  })
+
+  test('renders Account ID filter input', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reconciliation')
+    await expect(authenticatedPage.getByPlaceholder('Account ID')).toBeVisible()
+  })
+})
+
+test.describe('Reconciliation detail page', () => {
+  test('renders error state for unknown reconciliation run ID', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reconciliation/non-existent-run-id')
+    await expect(
+      authenticatedPage.getByText(/Failed to load reconciliation run/),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+})
+
+/**
+ * Full data tests — require live backend with seeded reconciliation run records.
+ * Un-skip when running against a full stack (task 45 CI workflow).
+ */
+test.describe('Reconciliation page with data (requires backend)', () => {
+  test.skip(
+    process.env.MERIDIAN_E2E_BACKEND !== '1',
+    'Set MERIDIAN_E2E_BACKEND=1 to run data-dependent tests',
+  )
+
+  test('displays reconciliation run rows or empty state', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reconciliation')
+    // Either data rows or empty state (no rows yet in seed data)
+    const hasRows =
+      (await authenticatedPage.locator('[data-testid="data-table-row"]').count()) > 0
+    const hasEmptyState = await authenticatedPage
+      .getByText(/No data/i)
+      .isVisible()
+      .catch(() => false)
+    expect(hasRows || hasEmptyState).toBe(true)
+  })
+
+  test('navigates to reconciliation detail on row click', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reconciliation')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await expect(authenticatedPage).toHaveURL(/\/reconciliation\/[a-zA-Z0-9_-]+/)
+  })
+
+  test('reconciliation detail shows Variances tab', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reconciliation')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await expect(
+      authenticatedPage.getByRole('tab', { name: 'Variances' }),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('reconciliation detail shows Disputes tab', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reconciliation')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await expect(
+      authenticatedPage.getByRole('tab', { name: 'Disputes' }),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('reconciliation detail shows Balance Assertions tab', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reconciliation')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await expect(
+      authenticatedPage.getByRole('tab', { name: 'Balance Assertions' }),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('Disputes tab shows status filter buttons', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reconciliation')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await authenticatedPage.getByRole('tab', { name: 'Disputes' }).click()
+    const filterGroup = authenticatedPage.getByRole('group', { name: 'Dispute status filter' })
+    await expect(filterGroup).toBeVisible({ timeout: 10_000 })
+    await expect(filterGroup.getByRole('button', { name: 'ALL' })).toBeVisible()
+    await expect(filterGroup.getByRole('button', { name: 'OPEN' })).toBeVisible()
+    await expect(filterGroup.getByRole('button', { name: 'RESOLVED' })).toBeVisible()
+    await expect(filterGroup.getByRole('button', { name: 'REJECTED' })).toBeVisible()
+  })
+
+  test('Disputes tab shows disputes or empty state', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reconciliation')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await authenticatedPage.getByRole('tab', { name: 'Disputes' }).click()
+    // Wait for disputes to load
+    await authenticatedPage.waitForSelector('[data-testid="dispute-skeleton"]', {
+      state: 'hidden',
+      timeout: 10_000,
+    }).catch(() => {})
+    const hasCards =
+      (await authenticatedPage.locator('[data-testid="dispute-card"]').count()) > 0
+    const hasEmpty = await authenticatedPage
+      .getByTestId('disputes-empty')
+      .isVisible()
+      .catch(() => false)
+    expect(hasCards || hasEmpty).toBe(true)
+  })
+
+  test('Balance Assertions tab shows assertion form', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reconciliation')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await authenticatedPage.getByRole('tab', { name: 'Balance Assertions' }).click()
+    // Wait for assertions to load
+    await authenticatedPage.waitForSelector('[data-testid="assertion-skeleton"]', {
+      state: 'hidden',
+      timeout: 10_000,
+    }).catch(() => {})
+    await expect(
+      authenticatedPage.getByTestId('assertion-form'),
+    ).toBeVisible({ timeout: 10_000 })
+    await expect(authenticatedPage.getByLabel('Name')).toBeVisible()
+    await expect(authenticatedPage.getByTestId('save-assertion-btn')).toBeVisible()
+  })
+
+  test('Balance Assertions form validates empty submission', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reconciliation')
+    await authenticatedPage.waitForSelector('[data-testid="data-table-row"]', {
+      state: 'visible',
+      timeout: 10_000,
+    })
+    await authenticatedPage.locator('[data-testid="data-table-row"]').first().click()
+    await authenticatedPage.getByRole('tab', { name: 'Balance Assertions' }).click()
+    await authenticatedPage.waitForSelector('[data-testid="assertion-skeleton"]', {
+      state: 'hidden',
+      timeout: 10_000,
+    }).catch(() => {})
+    await authenticatedPage.getByTestId('save-assertion-btn').click()
+    await expect(
+      authenticatedPage.getByTestId('assertion-error'),
+    ).toBeVisible({ timeout: 5_000 })
+    await expect(
+      authenticatedPage.getByText('Name and expression are required.'),
+    ).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds smoke E2E tests for Positions, Ledger, and Reconciliation pages that run without a live backend (pages render with empty/error states)
- Adds backend-guarded tests (skipped unless `MERIDIAN_E2E_BACKEND=1`) for data-dependent flows: row click navigation, detail page components (quality ladder badges, balance indicator, direction badges, reconciliation tabs)
- Fixes a strict-mode selector issue by scoping the Ledger breadcrumb link to `getByRole('main')` to avoid collision with the nav sidebar

## Test coverage

**Positions (positions.spec.ts) — 8 smoke + 5 backend-guarded:**
- Page heading, subtitle, column headers (Log ID, Account, Status, Created, Last Updated)
- Account ID text filter and Status select filter
- Detail page: Position Log heading, back button renders and navigates to list
- Backend: row click navigation, provisional/available balance view, quality ladder badges, measurement history entries

**Ledger (ledger.spec.ts) — 7 smoke + 6 backend-guarded:**
- Page heading, subtitle, column headers (Log ID, Account Type, Business Unit, Currency, Status, Postings)
- Status select filter
- Detail page: error state, breadcrumb Ledger link (scoped to avoid sidebar nav collision), breadcrumb navigation
- Backend: row click, Ledger Postings card, posting column headers, BalanceIndicator (with debit/credit totals), DirectionBadge DEBIT/CREDIT labels

**Reconciliation (reconciliation.spec.ts) — 6 smoke + 8 backend-guarded:**
- Page heading, subtitle, column headers (Run ID, Account, Scope, Settlement Type, Status, Variances)
- Status select and Account ID text filters
- Detail page: error state for unknown run ID
- Backend: row click navigation, Variances/Disputes/Balance Assertions tabs, dispute filter buttons (ALL/OPEN/RESOLVED/REJECTED), dispute cards or empty state, assertion form (name input, save button), assertion form empty submission validation

## Test plan

- [x] 21 smoke tests passing locally (no backend required)
- [x] 42 total tests discovered (21 smoke + 21 backend-guarded, skipped in smoke mode)
- [ ] Backend-guarded tests verified against live stack (requires `MERIDIAN_E2E_BACKEND=1`)
- [ ] CI E2E workflow (task 026-operations-console.45) integration

## Dependencies

- Depends on task 026-operations-console.47 (Playwright infrastructure) — complete
- Depends on task 026-operations-console.48 (account lifecycle E2E creates test data for backend-guarded tests) — in review