### PR TITLE
test: Add Playwright E2E tests for admin configuration pages

### DIFF
--- a/frontend/e2e/admin-config.spec.ts
+++ b/frontend/e2e/admin-config.spec.ts
@@ -185,7 +185,7 @@ async function setupInstrumentRoutes(page: Page) {
 }
 
 async function setupAccountTypeRoutes(page: Page) {
-  await page.route('**/meridian.reference_data.v1.AccountTypeRegistry/ListActive', (route) => {
+  await page.route('**/meridian.reference_data.v1.AccountTypeRegistryService/ListActive', (route) => {
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -240,14 +240,14 @@ async function setupSagaRoutes(page: Page) {
 }
 
 async function setupMappingRoutes(page: Page) {
-  await page.route('**/meridian.gateway.v1.MappingService/ListMappings', (route) => {
+  await page.route('**/meridian.mapping.v1.MappingService/ListMappings', (route) => {
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({ mappings: MAPPINGS, nextPageToken: '' }),
     })
   })
-  await page.route('**/meridian.gateway.v1.MappingService/GetMapping', (route) => {
+  await page.route('**/meridian.mapping.v1.MappingService/GetMapping', (route) => {
     return route.fulfill({
       status: 200,
       contentType: 'application/json',

--- a/frontend/e2e/admin-config.spec.ts
+++ b/frontend/e2e/admin-config.spec.ts
@@ -1,0 +1,794 @@
+import { test, expect, navigateTo } from './fixtures'
+import { type Page } from '@playwright/test'
+
+/**
+ * E2E tests for admin/configuration pages.
+ *
+ * These tests use Playwright route interception to mock Connect-ES API calls,
+ * so they run without a live backend. The Vite dev server must be running.
+ *
+ * Pages covered:
+ *   - /reference-data/instruments
+ *   - /reference-data/account-types
+ *   - /reference-data/nodes
+ *   - /starlark-config
+ *   - /gateway-mappings
+ *   - /tenants
+ */
+
+// ─── Shared Mock Data ────────────────────────────────────────────────────────
+
+const INSTRUMENTS = [
+  {
+    code: 'GBP',
+    displayName: 'British Pound Sterling',
+    dimension: 1, // Currency
+    precision: 2,
+    status: 2, // Active
+  },
+  {
+    code: 'KWH',
+    displayName: 'Kilowatt Hour',
+    dimension: 2, // Energy
+    precision: 3,
+    status: 2, // Active
+  },
+  {
+    code: 'CARBON_CREDIT',
+    displayName: 'Carbon Credit',
+    dimension: 7, // Carbon
+    precision: 4,
+    status: 2, // Active
+  },
+]
+
+const ACCOUNT_TYPES = [
+  {
+    code: 'ENERGY_TRADING',
+    displayName: 'Energy Trading Account',
+    behaviorClass: 1, // Customer
+    instrumentCode: 'KWH',
+    status: 2, // Active
+    validationCel: 'amount > 0',
+    bucketingCel: 'instrument_code',
+    eligibilityCel: '',
+    attributeSchema: '',
+    version: 1,
+  },
+  {
+    code: 'CARBON_INVENTORY',
+    displayName: 'Carbon Credit Inventory',
+    behaviorClass: 1, // Customer
+    instrumentCode: 'CARBON_CREDIT',
+    status: 2, // Active
+    validationCel: 'amount > 0',
+    bucketingCel: 'instrument_code',
+    eligibilityCel: '',
+    attributeSchema: '',
+    version: 1,
+  },
+  {
+    code: 'SETTLEMENT',
+    displayName: 'Settlement Account',
+    behaviorClass: 2, // Clearing
+    instrumentCode: 'GBP',
+    status: 2, // Active
+    validationCel: 'amount >= 0',
+    bucketingCel: 'instrument_code',
+    eligibilityCel: '',
+    attributeSchema: '',
+    version: 1,
+  },
+]
+
+const SAGAS = [
+  {
+    id: 'saga-001',
+    name: 'process_energy_settlement',
+    displayName: 'Process Energy Settlement',
+    description: 'Handles energy settlement saga',
+    version: 1,
+    status: 2, // ACTIVE
+    isSystem: true,
+    script: '# process_energy_settlement saga\nprint("hello")',
+    updatedAt: { seconds: '1706745600', nanos: 0 },
+  },
+  {
+    id: 'saga-002',
+    name: 'carbon_credit_transfer',
+    displayName: 'Carbon Credit Transfer',
+    description: 'Handles carbon credit transfer',
+    version: 1,
+    status: 1, // DRAFT
+    isSystem: false,
+    script: '# carbon_credit_transfer saga',
+    updatedAt: { seconds: '1706745600', nanos: 0 },
+  },
+]
+
+const MAPPINGS = [
+  {
+    id: 'mapping-001',
+    name: 'energy-settlement-inbound',
+    targetService: 'meridian.settlement.v1.SettlementService',
+    targetRpc: 'CreateSettlement',
+    version: 1,
+    status: 'MAPPING_STATUS_ACTIVE',
+    fields: [],
+    inboundValidationCel: 'amount > 0',
+    outboundValidationCel: '',
+    isBatch: false,
+    batchTargetPath: '',
+    createdAt: { seconds: '1706745600', nanos: 0 },
+    updatedAt: { seconds: '1706745600', nanos: 0 },
+  },
+  {
+    id: 'mapping-002',
+    name: 'carbon-credit-mapping',
+    targetService: 'meridian.carbon.v1.CarbonService',
+    targetRpc: 'TransferCredit',
+    version: 1,
+    status: 'MAPPING_STATUS_DRAFT',
+    fields: [],
+    inboundValidationCel: '',
+    outboundValidationCel: '',
+    isBatch: false,
+    batchTargetPath: '',
+    createdAt: { seconds: '1706745600', nanos: 0 },
+    updatedAt: { seconds: '1706745600', nanos: 0 },
+  },
+]
+
+const TENANTS = [
+  {
+    tenantId: 'acme-corp',
+    displayName: 'ACME Corporation',
+    slug: 'acme-corp',
+    settlementAsset: 'GBP',
+    status: 1, // ACTIVE
+    createdAt: { seconds: '1706745600', nanos: 0 },
+    version: 1,
+  },
+  {
+    tenantId: 'energy-co',
+    displayName: 'Energy Co Ltd',
+    slug: 'energy-co',
+    settlementAsset: 'KWH',
+    status: 1, // ACTIVE
+    createdAt: { seconds: '1706745600', nanos: 0 },
+    version: 1,
+  },
+]
+
+// ─── Route Setup Helpers ─────────────────────────────────────────────────────
+
+async function setupInstrumentRoutes(page: Page) {
+  await page.route('**/meridian.reference_data.v1.ReferenceDataService/ListInstruments', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ instruments: INSTRUMENTS, nextPageToken: '' }),
+    })
+  })
+  await page.route('**/meridian.reference_data.v1.ReferenceDataService/EvaluateInstrument', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        compileErrors: [],
+        validationResult: true,
+        fungibilityKey: 'instrument_code',
+        errorMessage: '',
+      }),
+    })
+  })
+}
+
+async function setupAccountTypeRoutes(page: Page) {
+  await page.route('**/meridian.reference_data.v1.AccountTypeRegistry/ListActive', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ definitions: ACCOUNT_TYPES, nextPageToken: '' }),
+    })
+  })
+}
+
+async function setupNodeRoutes(page: Page, hasNodes = false) {
+  await page.route('**/meridian.reference_data.v1.NodeService/GetChildren', (route) => {
+    if (!hasNodes) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ nodes: [] }),
+      })
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        nodes: [
+          { id: 'root-node', nodeType: 'ENTITY' },
+        ],
+      }),
+    })
+  })
+}
+
+async function setupSagaRoutes(page: Page) {
+  await page.route('**/meridian.saga.v1.SagaRegistryService/ListSagas', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ sagas: SAGAS, nextPageToken: '' }),
+    })
+  })
+  await page.route('**/meridian.saga.v1.SagaRegistryService/GetSaga', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ saga: SAGAS[0] }),
+    })
+  })
+  await page.route('**/meridian.saga.v1.SagaRegistryService/GetActiveSaga', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ saga: SAGAS[0] }),
+    })
+  })
+}
+
+async function setupMappingRoutes(page: Page) {
+  await page.route('**/meridian.gateway.v1.MappingService/ListMappings', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ mappings: MAPPINGS, nextPageToken: '' }),
+    })
+  })
+  await page.route('**/meridian.gateway.v1.MappingService/GetMapping', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ mapping: MAPPINGS[0] }),
+    })
+  })
+}
+
+async function setupTenantRoutes(page: Page) {
+  await page.route('**/meridian.tenant.v1.TenantService/ListTenants', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ tenants: TENANTS, nextPageToken: '' }),
+    })
+  })
+  await page.route('**/meridian.tenant.v1.TenantService/RetrieveTenant', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ tenant: TENANTS[0] }),
+    })
+  })
+  await page.route('**/meridian.tenant.v1.TenantService/InitiateTenant', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ tenant: { tenantId: 'new-tenant', displayName: 'New Tenant', slug: 'new-tenant', settlementAsset: 'GBP', status: 6, version: 1 } }),
+    })
+  })
+  await page.route('**/meridian.tenant.v1.TenantService/GetTenantProvisioningStatus', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ services: [] }),
+    })
+  })
+}
+
+// ─── Reference Data: Instruments ─────────────────────────────────────────────
+
+test.describe('Reference Data - Instruments page', () => {
+  test('renders Instruments heading', async ({ platformAdminPage: page }) => {
+    await setupInstrumentRoutes(page)
+    await navigateTo(page, '/reference-data/instruments')
+    await expect(page.getByRole('heading', { name: 'Instruments' })).toBeVisible()
+  })
+
+  test('shows instruments table with GBP, KWH, CARBON_CREDIT rows', async ({ platformAdminPage: page }) => {
+    await setupInstrumentRoutes(page)
+    await navigateTo(page, '/reference-data/instruments')
+
+    // Wait for data to load
+    await expect(page.getByText('GBP')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('KWH')).toBeVisible()
+    await expect(page.getByText('CARBON_CREDIT')).toBeVisible()
+  })
+
+  test('shows instrument display names', async ({ platformAdminPage: page }) => {
+    await setupInstrumentRoutes(page)
+    await navigateTo(page, '/reference-data/instruments')
+
+    await expect(page.getByText('British Pound Sterling')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('Kilowatt Hour')).toBeVisible()
+    await expect(page.getByText('Carbon Credit')).toBeVisible()
+  })
+
+  test('shows dimension labels for instruments', async ({ platformAdminPage: page }) => {
+    await setupInstrumentRoutes(page)
+    await navigateTo(page, '/reference-data/instruments')
+
+    await expect(page.getByText('Currency')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('Energy')).toBeVisible()
+    await expect(page.getByText('Carbon')).toBeVisible()
+  })
+
+  test('shows CEL Playground section', async ({ platformAdminPage: page }) => {
+    await setupInstrumentRoutes(page)
+    await navigateTo(page, '/reference-data/instruments')
+
+    await expect(page.getByTestId('cel-playground')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'CEL Playground' })).toBeVisible()
+  })
+
+  test('CEL Playground Evaluate button submits expression', async ({ platformAdminPage: page }) => {
+    await setupInstrumentRoutes(page)
+    await navigateTo(page, '/reference-data/instruments')
+
+    // Click Evaluate button
+    await page.getByRole('button', { name: 'Evaluate' }).click()
+
+    // Result should appear
+    await expect(page.getByTestId('cel-result')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('cel-result')).toContainText('PASS')
+  })
+})
+
+// ─── Reference Data: Account Types ───────────────────────────────────────────
+
+test.describe('Reference Data - Account Types page', () => {
+  test('renders Account Types heading', async ({ platformAdminPage: page }) => {
+    await setupAccountTypeRoutes(page)
+    await navigateTo(page, '/reference-data/account-types')
+    await expect(page.getByRole('heading', { name: 'Account Types' })).toBeVisible()
+  })
+
+  test('shows account type codes in the table', async ({ platformAdminPage: page }) => {
+    await setupAccountTypeRoutes(page)
+    await navigateTo(page, '/reference-data/account-types')
+
+    await expect(page.getByText('ENERGY_TRADING')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('CARBON_INVENTORY')).toBeVisible()
+    await expect(page.getByText('SETTLEMENT')).toBeVisible()
+  })
+
+  test('shows account type display names', async ({ platformAdminPage: page }) => {
+    await setupAccountTypeRoutes(page)
+    await navigateTo(page, '/reference-data/account-types')
+
+    await expect(page.getByText('Energy Trading Account')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('Carbon Credit Inventory')).toBeVisible()
+    await expect(page.getByText('Settlement Account')).toBeVisible()
+  })
+
+  test('shows behavior class labels', async ({ platformAdminPage: page }) => {
+    await setupAccountTypeRoutes(page)
+    await navigateTo(page, '/reference-data/account-types')
+
+    // behaviorClass 1 = Customer, 2 = Clearing
+    await expect(page.getByText('Customer').first()).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('Clearing')).toBeVisible()
+  })
+
+  test('shows CEL policy editor when row is clicked', async ({ platformAdminPage: page }) => {
+    await setupAccountTypeRoutes(page)
+    await navigateTo(page, '/reference-data/account-types')
+
+    // Wait for table to load then click first row
+    await expect(page.getByText('ENERGY_TRADING')).toBeVisible({ timeout: 10_000 })
+    await page.getByText('ENERGY_TRADING').click()
+
+    // CEL policy editor should appear
+    await expect(page.getByTestId('cel-policy-editor')).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText(/CEL Policies — ENERGY_TRADING/)).toBeVisible()
+  })
+})
+
+// ─── Reference Data: Nodes ────────────────────────────────────────────────────
+
+test.describe('Reference Data - Nodes page', () => {
+  test('renders Nodes heading', async ({ platformAdminPage: page }) => {
+    await setupNodeRoutes(page, false)
+    await navigateTo(page, '/reference-data/nodes')
+    await expect(page.getByRole('heading', { name: 'Nodes' })).toBeVisible()
+  })
+
+  test('shows Node Tree card', async ({ platformAdminPage: page }) => {
+    await setupNodeRoutes(page, false)
+    await navigateTo(page, '/reference-data/nodes')
+    await expect(page.getByText('Node Tree')).toBeVisible()
+  })
+
+  test('shows temporal date picker', async ({ platformAdminPage: page }) => {
+    await setupNodeRoutes(page, false)
+    await navigateTo(page, '/reference-data/nodes')
+    await expect(page.getByTestId('temporal-date-picker')).toBeVisible()
+  })
+
+  test('shows empty state when no nodes exist', async ({ platformAdminPage: page }) => {
+    await setupNodeRoutes(page, false)
+    await navigateTo(page, '/reference-data/nodes')
+
+    await expect(page.getByTestId('empty-tree-state')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('empty-tree-state')).toContainText('No nodes found')
+  })
+
+  test('shows root nodes when available', async ({ platformAdminPage: page }) => {
+    await setupNodeRoutes(page, true)
+    await navigateTo(page, '/reference-data/nodes')
+
+    await expect(page.getByText('root-node')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('ENTITY')).toBeVisible()
+  })
+
+  test('As At date picker updates node query', async ({ platformAdminPage: page }) => {
+    await setupNodeRoutes(page, false)
+    await navigateTo(page, '/reference-data/nodes')
+
+    // Fill in a date
+    await page.getByTestId('temporal-date-picker').fill('2024-01-01')
+
+    // Empty state should still be shown (no nodes for that date in mock)
+    await expect(page.getByTestId('empty-tree-state')).toBeVisible({ timeout: 10_000 })
+  })
+})
+
+// ─── Starlark Configuration ───────────────────────────────────────────────────
+
+test.describe('Starlark Configuration page', () => {
+  test('renders Starlark Configuration heading', async ({ platformAdminPage: page }) => {
+    await setupSagaRoutes(page)
+    await navigateTo(page, '/starlark-config')
+    await expect(page.getByRole('heading', { name: 'Starlark Configuration' })).toBeVisible()
+  })
+
+  test('shows saga names in the table', async ({ platformAdminPage: page }) => {
+    await setupSagaRoutes(page)
+    await navigateTo(page, '/starlark-config')
+
+    await expect(page.getByText('process_energy_settlement')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('carbon_credit_transfer')).toBeVisible()
+  })
+
+  test('shows ACTIVE status badge for active saga', async ({ platformAdminPage: page }) => {
+    await setupSagaRoutes(page)
+    await navigateTo(page, '/starlark-config')
+
+    await expect(page.getByText('process_energy_settlement')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('ACTIVE').first()).toBeVisible()
+  })
+
+  test('shows DRAFT status badge for draft saga', async ({ platformAdminPage: page }) => {
+    await setupSagaRoutes(page)
+    await navigateTo(page, '/starlark-config')
+
+    await expect(page.getByText('carbon_credit_transfer')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('DRAFT')).toBeVisible()
+  })
+
+  test('saga names render as clickable links', async ({ platformAdminPage: page }) => {
+    await setupSagaRoutes(page)
+    await navigateTo(page, '/starlark-config')
+
+    await expect(page.getByText('process_energy_settlement')).toBeVisible({ timeout: 10_000 })
+    const link = page.getByRole('link', { name: 'process_energy_settlement' })
+    await expect(link).toBeVisible()
+    await expect(link).toHaveAttribute('href', /\/starlark-config\/saga-001/)
+  })
+})
+
+// ─── Starlark Configuration Detail ───────────────────────────────────────────
+
+test.describe('Starlark Configuration detail page', () => {
+  test('renders saga name and ACTIVE status on detail page', async ({ platformAdminPage: page }) => {
+    await setupSagaRoutes(page)
+    await navigateTo(page, '/starlark-config/saga-001')
+
+    await expect(page.getByText('process_energy_settlement')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('ACTIVE')).toBeVisible()
+  })
+
+  test('shows the saga script in the editor', async ({ platformAdminPage: page }) => {
+    await setupSagaRoutes(page)
+    await navigateTo(page, '/starlark-config/saga-001')
+
+    await expect(page.getByText('process_energy_settlement')).toBeVisible({ timeout: 10_000 })
+    // The editor loads with the saga script
+    await expect(page.getByText('# process_energy_settlement saga')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('shows not found message for missing saga', async ({ platformAdminPage: page }) => {
+    // Override to return no saga
+    await page.route('**/meridian.saga.v1.SagaRegistryService/GetSaga', (route) => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ saga: null }),
+      })
+    })
+    await navigateTo(page, '/starlark-config/non-existent')
+
+    await expect(page.getByText(/not found/i)).toBeVisible({ timeout: 10_000 })
+  })
+})
+
+// ─── Gateway Mappings ─────────────────────────────────────────────────────────
+
+test.describe('Gateway Mappings page', () => {
+  test('renders Gateway Mappings heading', async ({ platformAdminPage: page }) => {
+    await setupMappingRoutes(page)
+    await navigateTo(page, '/gateway-mappings')
+    await expect(page.getByRole('heading', { name: 'Gateway Mappings' })).toBeVisible()
+  })
+
+  test('shows mapping names in the table', async ({ platformAdminPage: page }) => {
+    await setupMappingRoutes(page)
+    await navigateTo(page, '/gateway-mappings')
+
+    await expect(page.getByText('energy-settlement-inbound')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('carbon-credit-mapping')).toBeVisible()
+  })
+
+  test('shows target service and RPC columns', async ({ platformAdminPage: page }) => {
+    await setupMappingRoutes(page)
+    await navigateTo(page, '/gateway-mappings')
+
+    await expect(page.getByText('CreateSettlement')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('TransferCredit')).toBeVisible()
+  })
+
+  test('shows ACTIVE and DRAFT status badges', async ({ platformAdminPage: page }) => {
+    await setupMappingRoutes(page)
+    await navigateTo(page, '/gateway-mappings')
+
+    await expect(page.getByText('energy-settlement-inbound')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('ACTIVE').first()).toBeVisible()
+    await expect(page.getByText('DRAFT')).toBeVisible()
+  })
+
+  test('row click navigates to mapping detail', async ({ platformAdminPage: page }) => {
+    await setupMappingRoutes(page)
+    await navigateTo(page, '/gateway-mappings')
+
+    await expect(page.getByText('energy-settlement-inbound')).toBeVisible({ timeout: 10_000 })
+    await page.getByText('energy-settlement-inbound').click()
+
+    // Should navigate to detail page
+    await expect(page.getByRole('heading', { name: 'Mapping Details' })).toBeVisible({ timeout: 10_000 })
+  })
+})
+
+// ─── Gateway Mapping Detail ───────────────────────────────────────────────────
+
+test.describe('Gateway Mapping detail page', () => {
+  test('renders Mapping Details heading', async ({ platformAdminPage: page }) => {
+    await setupMappingRoutes(page)
+    await navigateTo(page, '/gateway-mappings/mapping-001')
+
+    await expect(page.getByRole('heading', { name: 'Mapping Details' })).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('shows mapping name and status in header', async ({ platformAdminPage: page }) => {
+    await setupMappingRoutes(page)
+    await navigateTo(page, '/gateway-mappings/mapping-001')
+
+    await expect(page.getByText('energy-settlement-inbound')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('ACTIVE')).toBeVisible()
+  })
+
+  test('shows Overview, Field Mapper, and Dry Run tabs', async ({ platformAdminPage: page }) => {
+    await setupMappingRoutes(page)
+    await navigateTo(page, '/gateway-mappings/mapping-001')
+
+    await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByRole('tab', { name: 'Field Mapper' })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Dry Run' })).toBeVisible()
+  })
+
+  test('Overview tab shows target service and RPC', async ({ platformAdminPage: page }) => {
+    await setupMappingRoutes(page)
+    await navigateTo(page, '/gateway-mappings/mapping-001')
+
+    await expect(page.getByText('meridian.settlement.v1.SettlementService')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('CreateSettlement')).toBeVisible()
+  })
+
+  test('Field Mapper tab shows no fields message when empty', async ({ platformAdminPage: page }) => {
+    await setupMappingRoutes(page)
+    await navigateTo(page, '/gateway-mappings/mapping-001')
+
+    await page.getByRole('tab', { name: 'Field Mapper' }).click()
+    await expect(page.getByText('No field correspondences defined.')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('Dry Run tab shows Inbound and Outbound direction buttons', async ({ platformAdminPage: page }) => {
+    await setupMappingRoutes(page)
+    await navigateTo(page, '/gateway-mappings/mapping-001')
+
+    await page.getByRole('tab', { name: 'Dry Run' }).click()
+    await expect(page.getByRole('button', { name: 'Inbound' })).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByRole('button', { name: 'Outbound' })).toBeVisible()
+  })
+
+  test('shows error state for unknown mapping', async ({ platformAdminPage: page }) => {
+    await page.route('**/meridian.mapping.v1.MappingService/GetMapping', (route) => {
+      return route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'not found' }),
+      })
+    })
+    await navigateTo(page, '/gateway-mappings/non-existent')
+
+    await expect(page.getByText('Failed to load mapping.')).toBeVisible({ timeout: 10_000 })
+  })
+})
+
+// ─── Tenant Management ────────────────────────────────────────────────────────
+
+test.describe('Tenant Management page', () => {
+  test('renders Tenant Management heading', async ({ platformAdminPage: page }) => {
+    await setupTenantRoutes(page)
+    await navigateTo(page, '/tenants')
+    await expect(page.getByRole('heading', { name: 'Tenant Management' })).toBeVisible()
+  })
+
+  test('shows New Tenant button', async ({ platformAdminPage: page }) => {
+    await setupTenantRoutes(page)
+    await navigateTo(page, '/tenants')
+    await expect(page.getByRole('button', { name: 'New Tenant' })).toBeVisible()
+  })
+
+  test('shows tenant IDs in the table', async ({ platformAdminPage: page }) => {
+    await setupTenantRoutes(page)
+    await navigateTo(page, '/tenants')
+
+    await expect(page.getByText('acme-corp')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('energy-co')).toBeVisible()
+  })
+
+  test('shows tenant display names', async ({ platformAdminPage: page }) => {
+    await setupTenantRoutes(page)
+    await navigateTo(page, '/tenants')
+
+    await expect(page.getByText('ACME Corporation')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('Energy Co Ltd')).toBeVisible()
+  })
+
+  test('shows ACTIVE status badges for tenants', async ({ platformAdminPage: page }) => {
+    await setupTenantRoutes(page)
+    await navigateTo(page, '/tenants')
+
+    await expect(page.getByText('acme-corp')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('ACTIVE').first()).toBeVisible()
+  })
+
+  test('opens Initiate Tenant dialog on New Tenant click', async ({ platformAdminPage: page }) => {
+    await setupTenantRoutes(page)
+    await navigateTo(page, '/tenants')
+    await page.getByRole('button', { name: 'New Tenant' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByRole('heading', { name: 'Initiate Tenant' })).toBeVisible()
+  })
+
+  test('Initiate Tenant dialog has Tenant ID, Display Name, and Settlement Asset fields', async ({ platformAdminPage: page }) => {
+    await setupTenantRoutes(page)
+    await navigateTo(page, '/tenants')
+    await page.getByRole('button', { name: 'New Tenant' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog.getByLabel('Tenant ID')).toBeVisible()
+    await expect(dialog.getByLabel('Display Name')).toBeVisible()
+    await expect(dialog.getByLabel('Settlement Asset')).toBeVisible()
+    await expect(dialog.getByLabel('Slug (optional)')).toBeVisible()
+  })
+
+  test('Initiate Tenant dialog validates required fields', async ({ platformAdminPage: page }) => {
+    await setupTenantRoutes(page)
+    await navigateTo(page, '/tenants')
+    await page.getByRole('button', { name: 'New Tenant' }).click()
+
+    const dialog = page.getByRole('dialog')
+    // Submit without filling required fields
+    await dialog.getByRole('button', { name: 'Initiate Tenant' }).click()
+
+    await expect(dialog.getByText('Tenant ID is required')).toBeVisible()
+    await expect(dialog.getByText('Display Name is required')).toBeVisible()
+    await expect(dialog.getByText('Settlement Asset is required')).toBeVisible()
+  })
+
+  test('Initiate Tenant dialog closes on Cancel', async ({ platformAdminPage: page }) => {
+    await setupTenantRoutes(page)
+    await navigateTo(page, '/tenants')
+    await page.getByRole('button', { name: 'New Tenant' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click()
+    await expect(dialog).not.toBeVisible()
+  })
+
+  test('Initiate Tenant dialog submits and closes on success', async ({ platformAdminPage: page }) => {
+    await setupTenantRoutes(page)
+    await navigateTo(page, '/tenants')
+    await page.getByRole('button', { name: 'New Tenant' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await dialog.getByLabel('Tenant ID').fill('new-tenant-001')
+    await dialog.getByLabel('Display Name').fill('New Tenant Corp')
+    await dialog.getByLabel('Settlement Asset').fill('GBP')
+
+    await dialog.getByRole('button', { name: 'Initiate Tenant' }).click()
+
+    // Dialog should close after successful submission
+    await expect(dialog).not.toBeVisible({ timeout: 10_000 })
+  })
+})
+
+// ─── Tenant Detail ────────────────────────────────────────────────────────────
+
+test.describe('Tenant detail page', () => {
+  test('renders tenant display name and ID', async ({ platformAdminPage: page }) => {
+    await setupTenantRoutes(page)
+    await navigateTo(page, '/tenants/acme-corp')
+
+    await expect(page.getByText('ACME Corporation')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('acme-corp').first()).toBeVisible()
+  })
+
+  test('shows Tenant Details card with settlement asset', async ({ platformAdminPage: page }) => {
+    await setupTenantRoutes(page)
+    await navigateTo(page, '/tenants/acme-corp')
+
+    await expect(page.getByText('Tenant Details')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('GBP')).toBeVisible()
+  })
+
+  test('shows Back to Tenants link', async ({ platformAdminPage: page }) => {
+    await setupTenantRoutes(page)
+    await navigateTo(page, '/tenants/acme-corp')
+
+    await expect(page.getByRole('link', { name: 'Back to Tenants' })).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('shows Provisioning Status card', async ({ platformAdminPage: page }) => {
+    await setupTenantRoutes(page)
+    await navigateTo(page, '/tenants/acme-corp')
+
+    await expect(page.getByText('Provisioning Status')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('shows not found when tenant does not exist', async ({ platformAdminPage: page }) => {
+    await page.route('**/meridian.tenant.v1.TenantService/RetrieveTenant', (route) => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ tenant: null }),
+      })
+    })
+    await page.route('**/meridian.tenant.v1.TenantService/GetTenantProvisioningStatus', (route) => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ services: [] }),
+      })
+    })
+    await navigateTo(page, '/tenants/non-existent')
+
+    await expect(page.getByText('Tenant not found.')).toBeVisible({ timeout: 10_000 })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `admin-config.spec.ts` covering 6 admin/configuration pages with route-intercepted mocks
- All tests use `platformAdminPage` fixture (platform-admin JWT) and `navigateTo()` for client-side navigation to preserve in-memory auth state
- No live backend required: Connect-ES API calls are intercepted at the Playwright layer

## Changes Made

**New file**: `frontend/e2e/admin-config.spec.ts`

Covers pages and scenarios:
- **Reference Data - Instruments**: table shows GBP/KWH/CARBON_CREDIT with dimension labels; CEL Playground evaluates expressions
- **Reference Data - Account Types**: table shows ENERGY_TRADING/CARBON_INVENTORY/SETTLEMENT; CEL policy editor appears on row click
- **Reference Data - Nodes**: temporal date picker, empty tree state, root node display
- **Starlark Configuration (list)**: saga names, ACTIVE/DRAFT status badges, clickable links to detail
- **Starlark Configuration (detail)**: saga name/status, script in editor, not-found state
- **Gateway Mappings (list)**: names, target service/RPC columns, status badges, row-click navigation
- **Gateway Mapping (detail)**: Overview/Field Mapper/Dry Run tabs, error state for unknown ID
- **Tenant Management (list)**: tenant IDs/names/status, New Tenant button, Initiate Tenant dialog with validation
- **Tenant Detail**: display name, Tenant Details card, Back link, Provisioning Status card, not-found state

## Technical Details

- Route interception patterns follow Connect-ES JSON mode: `**/meridian.<pkg>.<ServiceName>/<MethodName>`
- Verified service names against generated proto files: `ReferenceDataService`, `AccountTypeRegistryService`, `NodeService`, `SagaRegistryService`, `MappingService`, `TenantService`
- Correct RPC method: `RetrieveTenant` (not `GetTenant`) per hook implementation

## Testing

Tests run against Vite dev server without a backend. Run with:
```
cd frontend && npx playwright test e2e/admin-config.spec.ts
```