### PR TITLE
ci: Add GitHub Actions deploy demo workflow for DigitalOcean

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,108 @@
+name: Deploy Demo
+
+on:
+  push:
+    branches: [demo]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-demo
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_TAG: demo
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.0'
+          cache: true
+
+      - name: Set up buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate protobuf files
+        run: buf generate
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./cmd/meridian/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+
+  deploy:
+    name: Deploy to Demo Droplet
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    environment:
+      name: demo
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: root
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            cd /opt/meridian
+            docker compose pull
+            docker compose up -d --remove-orphans
+            docker image prune -f
+
+      - name: Verify deployment health
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: root
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            max_attempts=30
+            attempt=0
+            until [ $attempt -ge $max_attempts ]; do
+              attempt=$((attempt+1))
+              echo "Health check attempt $attempt/$max_attempts"
+              if curl -sf http://localhost:8090/healthz > /dev/null 2>&1; then
+                echo "Service is healthy"
+                exit 0
+              fi
+              sleep 5
+            done
+            echo "Health check failed after $max_attempts attempts"
+            docker compose logs --tail=50
+            exit 1

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -63,7 +63,7 @@ jobs:
           build-args: |
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha }}
-            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp || github.event.repository.updated_at }}
 
   deploy:
     name: Deploy to Demo Droplet
@@ -104,5 +104,5 @@ jobs:
               sleep 5
             done
             echo "Health check failed after $max_attempts attempts"
-            docker compose logs --tail=50
+            cd /opt/meridian && docker compose logs --tail=50
             exit 1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-demo.yml` for automated deployment to a DigitalOcean Droplet
- Triggers on pushes to the `demo` branch and via `workflow_dispatch` for manual runs
- Builds unified meridian Docker image using `cmd/meridian/Dockerfile` and pushes to `ghcr.io`
- Deploys via SSH using `appleboy/ssh-action`, running `docker compose pull` then `docker compose up -d`
- Includes post-deploy health check against `/healthz` endpoint with 30 retry attempts
- Uses `concurrency: cancel-in-progress: false` to prevent simultaneous deployments

## Required Secrets

Configure in repository Settings → Secrets and variables → Actions:

- `DROPLET_IP` — IP address of the DigitalOcean Droplet
- `DEPLOY_SSH_KEY` — Private SSH key for Droplet access (full key content including headers)

The Droplet must have Docker installed and a `docker-compose.yml` at `/opt/meridian/` referencing the `ghcr.io/meridianhub/meridian:demo` image.

## Test plan

- [ ] Workflow YAML syntax is valid
- [ ] Creating a `demo` branch triggers the workflow automatically
- [ ] `workflow_dispatch` manual trigger works
- [ ] Docker image is built with `cmd/meridian/Dockerfile` and pushed as `:demo` tag
- [ ] SSH deploy step connects with `DEPLOY_SSH_KEY` and runs `docker compose pull && up`
- [ ] Health check passes once service is running at `http://localhost:8090/healthz`
- [ ] Health check logs `docker compose logs` output on failure before exiting non-zero