### PR TITLE
ci: improve deploy-demo workflow with sha tag and concurrency controls

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,5 +1,9 @@
 name: Deploy Demo
 
+# Required secrets:
+#   DEPLOY_SSH_KEY  - Private SSH key (Ed25519 or RSA 4096+) for the root user on the Droplet
+#   DROPLET_IP      - IP address of the DigitalOcean Droplet (e.g. 143.198.xxx.xxx)
+
 on:
   push:
     branches: [demo]
@@ -7,7 +11,7 @@ on:
 
 concurrency:
   group: deploy-demo
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -16,7 +20,6 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  IMAGE_TAG: demo
 
 jobs:
   build-and-push:
@@ -51,13 +54,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=demo
+            type=sha,prefix=demo-,format=short
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./cmd/meridian/Dockerfile
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -71,6 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: demo
+      url: https://demo.meridianhub.cloud
 
     steps:
       - name: Deploy via SSH


### PR DESCRIPTION
## Summary

Improves the existing `deploy-demo.yml` GitHub Actions workflow to fully meet demo deployment requirements:

- **SHA-tagged images**: Adds `demo-<sha>` tag alongside `demo` using `docker/metadata-action`, enabling immutable references to each deployed revision
- **Concurrency fix**: Changes `cancel-in-progress` from `false` to `true` so rapid pushes to `demo` branch cancel superseded in-flight deploys instead of queuing them
- **Deployment URL**: Adds `url: https://demo.meridianhub.cloud` to the GitHub environment for deployment tracking in the UI
- **Secret documentation**: Adds inline comments documenting required secrets (`DEPLOY_SSH_KEY`, `DROPLET_IP`)
- **Cleanup**: Removes unused `IMAGE_TAG` env var; image tags now managed entirely by metadata-action

## Changes Made

- `.github/workflows/deploy-demo.yml` — workflow improvements

## Required Secrets

Configure in Settings → Secrets and variables → Actions:

| Secret | Description |
|--------|-------------|
| `DEPLOY_SSH_KEY` | Private SSH key (Ed25519 or RSA 4096+) for root user on the Droplet |
| `DROPLET_IP` | IP address of the DigitalOcean Droplet |

## Workflow Behaviour

1. **Trigger**: Push to `demo` branch (or manual `workflow_dispatch`)
2. **Concurrency**: New push cancels any in-progress deploy for the same branch
3. **Build**: Generates protobuf, builds unified binary image via `cmd/meridian/Dockerfile`
4. **Tags**: Pushes `ghcr.io/meridianhub/meridian:demo` and `ghcr.io/meridianhub/meridian:demo-<sha>`
5. **Deploy**: SSH to Droplet → `docker compose pull && docker compose up -d`
6. **Health check**: Polls `http://localhost:8090/healthz` up to 30 times (150s total)
7. **Environment**: GitHub deployment URL links to `https://demo.meridianhub.cloud`

## Part of

do-demo-deployment.4 — Create GitHub Actions deploy workflow