### PR TITLE
chore: add Droplet provisioning script for demo environment

### DIFF
--- a/deploy/demo/.env.demo.example
+++ b/deploy/demo/.env.demo.example
@@ -27,10 +27,10 @@ MERIDIAN_IMAGE=ghcr.io/meridianhub/meridian:demo
 DATABASE_URL=postgres://root@cockroachdb:26257/defaultdb?sslmode=disable
 
 # [OPTIONAL] GORM database connection pool settings.
-DB_MAX_OPEN_CONNS=25
-DB_MAX_IDLE_CONNS=5
-DB_CONN_MAX_LIFETIME=5m
 DB_CONN_MAX_IDLE_TIME=10m
+DB_CONN_MAX_LIFETIME=5m
+DB_MAX_IDLE_CONNS=5
+DB_MAX_OPEN_CONNS=25
 
 # ---------------------------------------------------------------------------
 # Application Runtime

--- a/deploy/demo/.env.demo.example
+++ b/deploy/demo/.env.demo.example
@@ -1,0 +1,131 @@
+# Meridian Demo Environment — Example Configuration
+#
+# Copy this file to /opt/meridian/.env on the Droplet and fill in all required values.
+# Lines marked [REQUIRED] must be set before starting the stack.
+# Lines marked [OPTIONAL] have working defaults for the demo environment.
+#
+# Usage:
+#   cp deploy/demo/.env.demo.example /opt/meridian/.env
+#   # Edit /opt/meridian/.env with actual values
+#   cd /opt/meridian && docker compose up -d
+
+# ---------------------------------------------------------------------------
+# Container Image
+# ---------------------------------------------------------------------------
+
+# [REQUIRED] Container registry image for the Meridian unified binary.
+# Updated automatically by the deploy-demo GitHub Actions workflow.
+MERIDIAN_IMAGE=ghcr.io/meridianhub/meridian:demo
+
+# ---------------------------------------------------------------------------
+# Database (CockroachDB)
+# ---------------------------------------------------------------------------
+
+# [REQUIRED] CockroachDB connection string used by the application.
+# For a single-node demo cluster running alongside Meridian, the
+# cockroachdb service in docker-compose resolves by hostname.
+DATABASE_URL=postgres://root@cockroachdb:26257/defaultdb?sslmode=disable
+
+# [OPTIONAL] GORM database connection pool settings.
+DB_MAX_OPEN_CONNS=25
+DB_MAX_IDLE_CONNS=5
+DB_CONN_MAX_LIFETIME=5m
+DB_CONN_MAX_IDLE_TIME=10m
+
+# ---------------------------------------------------------------------------
+# Application Runtime
+# ---------------------------------------------------------------------------
+
+# [OPTIONAL] Runtime environment label (development | staging | production).
+ENVIRONMENT=demo
+
+# [OPTIONAL] Log verbosity (debug | info | warn | error).
+LOG_LEVEL=info
+
+# [OPTIONAL] gRPC server listen port (inside the container).
+GRPC_PORT=50051
+
+# [OPTIONAL] HTTP gateway listen port (inside the container).
+HTTP_PORT=8090
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+
+# [OPTIONAL] Authentication mode.
+# Set to "disabled" for an open demo. Set to "jwt" to enable JWKS validation.
+AUTH_MODE=disabled
+
+# [OPTIONAL — required when AUTH_MODE=jwt] JWKS endpoint for JWT validation.
+# Example: https://your-auth-provider.com/.well-known/jwks.json
+#AUTH_JWKS_URL=
+
+# [OPTIONAL] Interval to refresh JWKS signing keys (default: 30m).
+#AUTH_JWKS_REFRESH_TTL=30m
+
+# [OPTIONAL] Timeout for HTTP requests to the JWKS endpoint (default: 30s).
+#AUTH_HTTP_TIMEOUT=30s
+
+# ---------------------------------------------------------------------------
+# Billing
+# ---------------------------------------------------------------------------
+
+# [OPTIONAL] Enable metered billing integration (true | false).
+BILLING_ENABLED=false
+
+# ---------------------------------------------------------------------------
+# Redis
+# ---------------------------------------------------------------------------
+
+# [OPTIONAL] Enable Redis for idempotency key storage.
+# When false, Postgres-backed idempotency is used instead.
+REDIS_ENABLED=false
+
+# [OPTIONAL — required when REDIS_ENABLED=true] Redis connection URL.
+#REDIS_URL=redis://redis:6379
+
+# [OPTIONAL] Redis password (overrides any password in REDIS_URL).
+#REDIS_PASSWORD=
+
+# [OPTIONAL] Redis database index (default: 0).
+#REDIS_DB=0
+
+# [OPTIONAL] Redis connection pool size (default: 10).
+#REDIS_POOL_SIZE=10
+
+# [OPTIONAL] Minimum idle Redis connections (default: 2).
+#REDIS_MIN_IDLE_CONNS=2
+
+# ---------------------------------------------------------------------------
+# Kafka / Event Streaming
+# ---------------------------------------------------------------------------
+
+# [OPTIONAL] Enable Kafka event publishing (true | false).
+# When false, a no-op publisher is used — events are not durably streamed.
+KAFKA_ENABLED=false
+
+# [OPTIONAL — required when KAFKA_ENABLED=true] Kafka bootstrap servers.
+#KAFKA_BROKERS=kafka:9092
+
+# ---------------------------------------------------------------------------
+# Multi-Tenancy
+# ---------------------------------------------------------------------------
+
+# [OPTIONAL] Internal master tenant identifier used by the market-information service.
+MASTER_TENANT_ID=meridian_master
+
+# ---------------------------------------------------------------------------
+# Observability (OpenTelemetry)
+# ---------------------------------------------------------------------------
+
+# [OPTIONAL] OTLP collector endpoint for distributed tracing.
+# Leave empty to disable tracing.
+#OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+
+# ---------------------------------------------------------------------------
+# Frontend
+# ---------------------------------------------------------------------------
+
+# [REQUIRED] Public-facing base URL of the HTTP gateway, as seen by the browser.
+# Set to your Cloudflare proxied domain or the Droplet's public IP.
+VITE_API_BASE_URL=https://demo.meridian.example.com

--- a/deploy/demo/provision.sh
+++ b/deploy/demo/provision.sh
@@ -284,7 +284,7 @@ done < "${CF_RULES_FILE}"
 ufw reload
 echo "$(date '+%Y-%m-%d %H:%M:%S') Cloudflare UFW rules updated (${RANGE_COUNT} ranges)."
 SCRIPT
-chmod 755 /opt/meridian/scripts/update-cloudflare-ufw.sh
+chmod 755 "${MERIDIAN_DIR}/scripts/update-cloudflare-ufw.sh"
 
 # ---------------------------------------------------------------------------
 # 5. Meridian directory structure

--- a/deploy/demo/provision.sh
+++ b/deploy/demo/provision.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+# provision.sh — Provision a DigitalOcean Droplet for the Meridian demo environment.
+#
+# Requirements:
+#   - Ubuntu 22.04+ fresh Droplet (run as root)
+#   - Internet access for package installation
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/meridianhub/meridian/demo/deploy/demo/provision.sh | bash
+#   # or:
+#   bash provision.sh [--ssh-authorized-keys "ssh-ed25519 AAAA..."]
+#
+# The script is idempotent — safe to run multiple times.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration (override via environment variables before running)
+# ---------------------------------------------------------------------------
+
+# Space-separated list of IPs allowed to SSH in (empty = allow from anywhere)
+SSH_ALLOWED_IPS="${SSH_ALLOWED_IPS:-}"
+
+# SSH public key(s) to add to the deploy user's authorized_keys
+# Can also be passed via --ssh-authorized-keys flag
+SSH_AUTHORIZED_KEYS="${SSH_AUTHORIZED_KEYS:-}"
+
+# Username for the non-root deploy user
+DEPLOY_USER="${DEPLOY_USER:-deploy}"
+
+# Base directory for Meridian on the host
+MERIDIAN_DIR="${MERIDIAN_DIR:-/opt/meridian}"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --ssh-authorized-keys)
+      SSH_AUTHORIZED_KEYS="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
+
+# UFW rule helper — adds the rule only if it is not already present.
+ufw_allow_if_missing() {
+  local rule="$*"
+  if ! ufw status verbose | grep -qF "$rule"; then
+    # shellcheck disable=SC2086
+    ufw allow $rule
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 1. System updates and essential packages
+# ---------------------------------------------------------------------------
+
+log "1/7 — Updating system packages..."
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -q
+apt-get upgrade -y -q \
+  -o Dpkg::Options::="--force-confdef" \
+  -o Dpkg::Options::="--force-confold"
+
+apt-get install -y -q \
+  ca-certificates \
+  curl \
+  gnupg \
+  lsb-release \
+  ufw \
+  unattended-upgrades \
+  apt-transport-https \
+  software-properties-common \
+  jq \
+  git \
+  htop
+
+# ---------------------------------------------------------------------------
+# 2. Docker CE
+# ---------------------------------------------------------------------------
+
+log "2/7 — Installing Docker CE..."
+
+if ! command -v docker &>/dev/null; then
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    -o /etc/apt/keyrings/docker.asc
+  chmod a+r /etc/apt/keyrings/docker.asc
+
+  echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+    https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "${VERSION_CODENAME}") stable" \
+    > /etc/apt/sources.list.d/docker.list
+
+  apt-get update -q
+  apt-get install -y -q \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin
+
+  systemctl enable --now docker
+  log "  Docker installed."
+else
+  log "  Docker already installed, skipping."
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Deploy user
+# ---------------------------------------------------------------------------
+
+log "3/7 — Configuring deploy user '${DEPLOY_USER}'..."
+
+if ! id "${DEPLOY_USER}" &>/dev/null; then
+  useradd --create-home --shell /bin/bash --groups docker "${DEPLOY_USER}"
+  log "  User '${DEPLOY_USER}' created."
+else
+  # Ensure user is in the docker group even if created previously
+  usermod -aG docker "${DEPLOY_USER}"
+  log "  User '${DEPLOY_USER}' already exists, ensured docker group membership."
+fi
+
+# Set up SSH authorized_keys for the deploy user
+DEPLOY_HOME=$(getent passwd "${DEPLOY_USER}" | cut -d: -f6)
+DEPLOY_SSH_DIR="${DEPLOY_HOME}/.ssh"
+install -d -m 700 -o "${DEPLOY_USER}" -g "${DEPLOY_USER}" "${DEPLOY_SSH_DIR}"
+AUTHORIZED_KEYS_FILE="${DEPLOY_SSH_DIR}/authorized_keys"
+
+if [[ -n "${SSH_AUTHORIZED_KEYS}" ]]; then
+  # Add key if not already present
+  if ! grep -qF "${SSH_AUTHORIZED_KEYS}" "${AUTHORIZED_KEYS_FILE}" 2>/dev/null; then
+    echo "${SSH_AUTHORIZED_KEYS}" >> "${AUTHORIZED_KEYS_FILE}"
+    log "  SSH authorized key added for '${DEPLOY_USER}'."
+  else
+    log "  SSH authorized key already present for '${DEPLOY_USER}'."
+  fi
+fi
+
+chmod 600 "${AUTHORIZED_KEYS_FILE}" 2>/dev/null || true
+chown "${DEPLOY_USER}:${DEPLOY_USER}" "${AUTHORIZED_KEYS_FILE}" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# 4. Firewall (UFW) — restrict inbound to SSH (specific IPs) + Cloudflare only
+# ---------------------------------------------------------------------------
+
+log "4/7 — Configuring UFW firewall..."
+
+ufw --force reset
+
+# Default policies
+ufw default deny incoming
+ufw default allow outgoing
+
+# SSH: allow from specific IPs only, or from anywhere if none configured
+if [[ -n "${SSH_ALLOWED_IPS}" ]]; then
+  for ip in ${SSH_ALLOWED_IPS}; do
+    log "  Allowing SSH from ${ip}"
+    ufw allow from "${ip}" to any port 22 proto tcp
+  done
+else
+  log "  No SSH_ALLOWED_IPS configured — allowing SSH from anywhere (consider restricting)"
+  ufw allow 22/tcp
+fi
+
+# Fetch Cloudflare IPv4 and IPv6 ranges and allow HTTP/HTTPS from them
+update_cloudflare_rules() {
+  log "  Fetching Cloudflare IP ranges..."
+
+  local cf_ipv4
+  cf_ipv4=$(curl -fsSL https://www.cloudflare.com/ips-v4 2>/dev/null || true)
+  local cf_ipv6
+  cf_ipv6=$(curl -fsSL https://www.cloudflare.com/ips-v6 2>/dev/null || true)
+
+  if [[ -z "${cf_ipv4}" && -z "${cf_ipv6}" ]]; then
+    log "  WARNING: Failed to fetch Cloudflare IPs. HTTP/HTTPS rules NOT updated."
+    return 1
+  fi
+
+  # Remove existing Cloudflare-added HTTP/HTTPS rules (comment-based identification)
+  # UFW does not support comments natively, so we track ranges in a file and
+  # delete/re-add when updating.
+  local cf_rules_file="/etc/ufw/cloudflare_ranges.txt"
+
+  if [[ -f "${cf_rules_file}" ]]; then
+    log "  Removing stale Cloudflare rules..."
+    while IFS= read -r range; do
+      [[ -z "${range}" ]] && continue
+      ufw delete allow from "${range}" to any port 80  2>/dev/null || true
+      ufw delete allow from "${range}" to any port 443 2>/dev/null || true
+    done < "${cf_rules_file}"
+  fi
+
+  # Write fresh range list
+  printf '%s\n%s' "${cf_ipv4}" "${cf_ipv6}" > "${cf_rules_file}"
+
+  # Add updated rules
+  while IFS= read -r range; do
+    [[ -z "${range}" ]] && continue
+    ufw allow from "${range}" to any port 80  proto tcp
+    ufw allow from "${range}" to any port 443 proto tcp
+  done < "${cf_rules_file}"
+
+  log "  Cloudflare HTTP/HTTPS rules updated."
+}
+
+update_cloudflare_rules
+
+ufw --force enable
+log "  UFW enabled."
+
+# Cron job to refresh Cloudflare IPs weekly (runs as root, every Sunday at 03:00)
+CRON_MARKER="# meridian-cloudflare-ufw"
+CRON_CMD="0 3 * * 0 root /opt/meridian/scripts/update-cloudflare-ufw.sh >> /var/log/cloudflare-ufw.log 2>&1 ${CRON_MARKER}"
+if ! grep -qF "${CRON_MARKER}" /etc/cron.d/meridian-cloudflare 2>/dev/null; then
+  cat > /etc/cron.d/meridian-cloudflare <<EOF
+${CRON_CMD}
+EOF
+  chmod 644 /etc/cron.d/meridian-cloudflare
+  log "  Cloudflare UFW refresh cron job installed."
+fi
+
+# Install the update script itself so the cron job can call it
+install -d -m 755 /opt/meridian/scripts
+cat > /opt/meridian/scripts/update-cloudflare-ufw.sh <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+CF_RULES_FILE="/etc/ufw/cloudflare_ranges.txt"
+
+CF_IPV4=$(curl -fsSL https://www.cloudflare.com/ips-v4)
+CF_IPV6=$(curl -fsSL https://www.cloudflare.com/ips-v6)
+
+if [[ -f "${CF_RULES_FILE}" ]]; then
+  while IFS= read -r range; do
+    [[ -z "${range}" ]] && continue
+    ufw delete allow from "${range}" to any port 80  2>/dev/null || true
+    ufw delete allow from "${range}" to any port 443 2>/dev/null || true
+  done < "${CF_RULES_FILE}"
+fi
+
+printf '%s\n%s' "${CF_IPV4}" "${CF_IPV6}" > "${CF_RULES_FILE}"
+
+while IFS= read -r range; do
+  [[ -z "${range}" ]] && continue
+  ufw allow from "${range}" to any port 80  proto tcp
+  ufw allow from "${range}" to any port 443 proto tcp
+done < "${CF_RULES_FILE}"
+
+ufw reload
+echo "$(date '+%Y-%m-%d %H:%M:%S') Cloudflare UFW rules updated."
+SCRIPT
+chmod 755 /opt/meridian/scripts/update-cloudflare-ufw.sh
+
+# ---------------------------------------------------------------------------
+# 5. Meridian directory structure
+# ---------------------------------------------------------------------------
+
+log "5/7 — Creating Meridian directory structure..."
+
+install -d -m 750 "${MERIDIAN_DIR}"
+install -d -m 700 "${MERIDIAN_DIR}/certs"
+install -d -m 750 "${MERIDIAN_DIR}/data"
+install -d -m 755 "${MERIDIAN_DIR}/scripts"
+
+chown -R "${DEPLOY_USER}:${DEPLOY_USER}" "${MERIDIAN_DIR}"
+log "  Created ${MERIDIAN_DIR}/{certs,data,scripts}"
+
+# ---------------------------------------------------------------------------
+# 6. SSH hardening
+# ---------------------------------------------------------------------------
+
+log "6/7 — Hardening SSH configuration..."
+
+SSHD_CONFIG="/etc/ssh/sshd_config"
+SSHD_CUSTOM="/etc/ssh/sshd_config.d/99-meridian-hardening.conf"
+
+# Write a drop-in config so we don't patch sshd_config directly
+cat > "${SSHD_CUSTOM}" <<'EOF'
+# Meridian demo hardening — managed by provision.sh
+PasswordAuthentication no
+ChallengeResponseAuthentication no
+PermitRootLogin prohibit-password
+PubkeyAuthentication yes
+AuthorizedKeysFile .ssh/authorized_keys
+PermitEmptyPasswords no
+X11Forwarding no
+AllowTcpForwarding no
+EOF
+
+chmod 644 "${SSHD_CUSTOM}"
+
+# Validate and reload
+sshd -t
+systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null || true
+log "  SSH hardening applied."
+
+# ---------------------------------------------------------------------------
+# 7. Unattended security upgrades
+# ---------------------------------------------------------------------------
+
+log "7/7 — Enabling unattended security upgrades..."
+
+cat > /etc/apt/apt.conf.d/20auto-upgrades <<'EOF'
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Download-Upgradeable-Packages "1";
+APT::Periodic::AutocleanInterval "7";
+APT::Periodic::Unattended-Upgrade "1";
+EOF
+
+cat > /etc/apt/apt.conf.d/50unattended-upgrades <<'EOF'
+Unattended-Upgrade::Allowed-Origins {
+    "${distro_id}:${distro_codename}-security";
+    "${distro_id}ESMApps:${distro_codename}-apps-security";
+    "${distro_id}ESM:${distro_codename}-infra-security";
+};
+Unattended-Upgrade::AutoFixInterruptedDpkg "true";
+Unattended-Upgrade::MinimalSteps "true";
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+Unattended-Upgrade::Remove-New-Unused-Dependencies "true";
+Unattended-Upgrade::Automatic-Reboot "false";
+EOF
+
+systemctl enable --now unattended-upgrades
+log "  Unattended upgrades enabled."
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+
+log ""
+log "Provisioning complete."
+log ""
+log "Summary:"
+log "  Droplet user : ${DEPLOY_USER}"
+log "  Meridian dir : ${MERIDIAN_DIR}"
+log "  Firewall     : UFW active — SSH + Cloudflare HTTP/HTTPS only"
+log "  SSH          : password auth disabled, root login restricted"
+log ""
+log "Next steps:"
+log "  1. Copy deploy/demo/docker-compose.yml to ${MERIDIAN_DIR}/docker-compose.yml"
+log "  2. Copy .env.demo to ${MERIDIAN_DIR}/.env (fill in secrets)"
+log "  3. Log in as '${DEPLOY_USER}' and run: cd ${MERIDIAN_DIR} && docker compose up -d"

--- a/deploy/demo/provision.sh
+++ b/deploy/demo/provision.sh
@@ -58,15 +58,6 @@ done
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
 
-# UFW rule helper — adds the rule only if it is not already present.
-ufw_allow_if_missing() {
-  local rule="$*"
-  if ! ufw status verbose | grep -qF "$rule"; then
-    # shellcheck disable=SC2086
-    ufw allow $rule
-  fi
-}
-
 # ---------------------------------------------------------------------------
 # 1. System updates and essential packages
 # ---------------------------------------------------------------------------
@@ -306,7 +297,6 @@ log "  Created ${MERIDIAN_DIR}/{certs,data,scripts}"
 
 log "6/7 — Hardening SSH configuration..."
 
-SSHD_CONFIG="/etc/ssh/sshd_config"
 SSHD_CUSTOM="/etc/ssh/sshd_config.d/99-meridian-hardening.conf"
 
 # Write a drop-in config so we don't patch sshd_config directly

--- a/deploy/demo/provision.sh
+++ b/deploy/demo/provision.sh
@@ -38,6 +38,10 @@ MERIDIAN_DIR="${MERIDIAN_DIR:-/opt/meridian}"
 while [[ $# -gt 0 ]]; do
   case $1 in
     --ssh-authorized-keys)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "error: --ssh-authorized-keys requires a value" >&2
+        exit 1
+      fi
       SSH_AUTHORIZED_KEYS="$2"
       shift 2
       ;;
@@ -188,7 +192,7 @@ update_cloudflare_rules() {
 
   if [[ -z "${cf_ipv4}" && -z "${cf_ipv6}" ]]; then
     log "  WARNING: Failed to fetch Cloudflare IPs. HTTP/HTTPS rules NOT updated."
-    return 1
+    return 0
   fi
 
   # Remove existing Cloudflare-added HTTP/HTTPS rules (comment-based identification)
@@ -225,7 +229,7 @@ log "  UFW enabled."
 
 # Cron job to refresh Cloudflare IPs weekly (runs as root, every Sunday at 03:00)
 CRON_MARKER="# meridian-cloudflare-ufw"
-CRON_CMD="0 3 * * 0 root /opt/meridian/scripts/update-cloudflare-ufw.sh >> /var/log/cloudflare-ufw.log 2>&1 ${CRON_MARKER}"
+CRON_CMD="0 3 * * 0 root ${MERIDIAN_DIR}/scripts/update-cloudflare-ufw.sh >> /var/log/cloudflare-ufw.log 2>&1 ${CRON_MARKER}"
 if ! grep -qF "${CRON_MARKER}" /etc/cron.d/meridian-cloudflare 2>/dev/null; then
   cat > /etc/cron.d/meridian-cloudflare <<EOF
 ${CRON_CMD}
@@ -235,16 +239,32 @@ EOF
 fi
 
 # Install the update script itself so the cron job can call it
-install -d -m 755 /opt/meridian/scripts
-cat > /opt/meridian/scripts/update-cloudflare-ufw.sh <<'SCRIPT'
+install -d -m 755 "${MERIDIAN_DIR}/scripts"
+cat > "${MERIDIAN_DIR}/scripts/update-cloudflare-ufw.sh" <<'SCRIPT'
 #!/usr/bin/env bash
 set -euo pipefail
 
 CF_RULES_FILE="/etc/ufw/cloudflare_ranges.txt"
 
-CF_IPV4=$(curl -fsSL https://www.cloudflare.com/ips-v4)
-CF_IPV6=$(curl -fsSL https://www.cloudflare.com/ips-v6)
+CF_IPV4=$(curl -fsSL https://www.cloudflare.com/ips-v4 2>/dev/null || true)
+CF_IPV6=$(curl -fsSL https://www.cloudflare.com/ips-v6 2>/dev/null || true)
 
+# Abort if both lists are empty — do not wipe existing rules
+if [[ -z "${CF_IPV4}" && -z "${CF_IPV6}" ]]; then
+  echo "$(date '+%Y-%m-%d %H:%M:%S') ERROR: Failed to fetch Cloudflare IP ranges. Existing rules unchanged." >&2
+  exit 1
+fi
+
+NEW_RANGES=$(printf '%s\n%s' "${CF_IPV4}" "${CF_IPV6}")
+
+# Guard: refuse to wipe if the new range list is suspiciously short
+RANGE_COUNT=$(echo "${NEW_RANGES}" | grep -c '[0-9]' || true)
+if [[ "${RANGE_COUNT}" -lt 5 ]]; then
+  echo "$(date '+%Y-%m-%d %H:%M:%S') ERROR: Cloudflare IP list has only ${RANGE_COUNT} entries; aborting to avoid wiping rules." >&2
+  exit 1
+fi
+
+# Remove stale rules
 if [[ -f "${CF_RULES_FILE}" ]]; then
   while IFS= read -r range; do
     [[ -z "${range}" ]] && continue
@@ -253,7 +273,7 @@ if [[ -f "${CF_RULES_FILE}" ]]; then
   done < "${CF_RULES_FILE}"
 fi
 
-printf '%s\n%s' "${CF_IPV4}" "${CF_IPV6}" > "${CF_RULES_FILE}"
+echo "${NEW_RANGES}" > "${CF_RULES_FILE}"
 
 while IFS= read -r range; do
   [[ -z "${range}" ]] && continue
@@ -262,7 +282,7 @@ while IFS= read -r range; do
 done < "${CF_RULES_FILE}"
 
 ufw reload
-echo "$(date '+%Y-%m-%d %H:%M:%S') Cloudflare UFW rules updated."
+echo "$(date '+%Y-%m-%d %H:%M:%S') Cloudflare UFW rules updated (${RANGE_COUNT} ranges)."
 SCRIPT
 chmod 755 /opt/meridian/scripts/update-cloudflare-ufw.sh
 
@@ -353,5 +373,5 @@ log "  SSH          : password auth disabled, root login restricted"
 log ""
 log "Next steps:"
 log "  1. Copy deploy/demo/docker-compose.yml to ${MERIDIAN_DIR}/docker-compose.yml"
-log "  2. Copy .env.demo to ${MERIDIAN_DIR}/.env (fill in secrets)"
+log "  2. Copy deploy/demo/.env.demo.example to ${MERIDIAN_DIR}/.env and fill in secrets"
 log "  3. Log in as '${DEPLOY_USER}' and run: cd ${MERIDIAN_DIR} && docker compose up -d"


### PR DESCRIPTION
## Summary

- Adds `deploy/demo/provision.sh` — an idempotent bash script to configure a fresh Ubuntu 22.04+ DigitalOcean Droplet for the Meridian demo stack
- Adds `deploy/demo/.env.demo.example` documenting all environment variables consumed by the demo stack

## Changes Made

### `deploy/demo/provision.sh`

Covers all provisioning steps in a single idempotent script (safe to re-run):

1. **System packages** — `apt update/upgrade` plus essentials (`curl`, `jq`, `ufw`, `unattended-upgrades`, etc.)
2. **Docker CE** — installs via the official Docker upstream APT repository with the Compose plugin; skips if already installed
3. **Deploy user** — creates a non-root `deploy` user in the `docker` group; injects SSH authorized keys via `--ssh-authorized-keys` flag or `SSH_AUTHORIZED_KEYS` env var
4. **Firewall (UFW)** — default-deny inbound; SSH from `SSH_ALLOWED_IPS` only (falls back to allow-all with a warning); HTTP/HTTPS from Cloudflare IP ranges only (fetched from `cloudflare.com/ips-v4` and `cloudflare.com/ips-v6`); weekly cron job (`/etc/cron.d/meridian-cloudflare`) refreshes rules via `/opt/meridian/scripts/update-cloudflare-ufw.sh`
5. **Directory structure** — creates `/opt/meridian/{certs,data,scripts}` owned by the deploy user
6. **SSH hardening** — drop-in at `/etc/ssh/sshd_config.d/99-meridian-hardening.conf`; disables password auth, restricts root login; validates with `sshd -t` before reloading
7. **Unattended upgrades** — enables security-only auto-updates

### `deploy/demo/.env.demo.example`

Documents every environment variable used by the Meridian unified binary and demo docker-compose stack, grouped by concern:

- Database (`DATABASE_URL`, pool tuning)
- Application runtime (`ENVIRONMENT`, `LOG_LEVEL`, ports)
- Authentication (`AUTH_MODE`, `AUTH_JWKS_URL`)
- Billing, Redis, Kafka (all disabled by default for demo)
- Multi-tenancy (`MASTER_TENANT_ID`)
- Observability (OTLP endpoint)
- Frontend (`VITE_API_BASE_URL`)

## Technical Details

- Script uses `set -euo pipefail` for strict error handling
- All destructive UFW steps (reset, rule additions) are idempotent via rule file tracking at `/etc/ufw/cloudflare_ranges.txt`
- SSH hardening uses a drop-in config file rather than patching `sshd_config` directly
- Cloudflare rule update script is installed at provisioning time so the weekly cron job has a stable target

## Testing

- [ ] Run `bash -n deploy/demo/provision.sh` to verify no syntax errors
- [ ] Apply to a fresh Ubuntu 22.04 Droplet and verify all 7 steps complete successfully
- [ ] Re-run on the same Droplet and verify idempotency (no errors, no duplicate rules)
- [ ] Confirm UFW blocks direct HTTP/HTTPS from non-Cloudflare IPs after provisioning

## Risk Assessment

Low — this script runs once at Droplet setup time and does not touch any running application code or data.

## Deployment Notes

Run on the Droplet as root:

```bash
SSH_ALLOWED_IPS="<your-ci-ip> <your-admin-ip>" \
SSH_AUTHORIZED_KEYS="ssh-ed25519 AAAA..." \
bash deploy/demo/provision.sh
```

Then copy `deploy/demo/.env.demo.example` to `/opt/meridian/.env` and fill in required values before starting the stack.

---

Task Master: do-demo-deployment.5