### PR TITLE
feat: add PostgreSQL support via DB_DRIVER environment variable

### DIFF
--- a/deploy/demo/.env.demo.example
+++ b/deploy/demo/.env.demo.example
@@ -18,12 +18,17 @@
 MERIDIAN_IMAGE=ghcr.io/meridianhub/meridian:demo
 
 # ---------------------------------------------------------------------------
-# Database (CockroachDB)
+# Database
 # ---------------------------------------------------------------------------
 
-# [REQUIRED] CockroachDB connection string used by the application.
-# For a single-node demo cluster running alongside Meridian, the
-# cockroachdb service in docker-compose resolves by hostname.
+# [OPTIONAL] Database driver: "cockroachdb" (default) or "postgres".
+# Set to "postgres" when using a PostgreSQL 13+ database (e.g., DigitalOcean Managed PostgreSQL).
+# When DB_DRIVER=postgres, DATABASE_URL default port changes from 26257 to 5432.
+#DB_DRIVER=cockroachdb
+
+# [REQUIRED] Database connection string used by the application.
+# CockroachDB (default): postgres://root@cockroachdb:26257/defaultdb?sslmode=disable
+# PostgreSQL (DigitalOcean Managed): postgres://doadmin:<password>@<host>:25060/defaultdb?sslmode=require
 DATABASE_URL=postgres://root@cockroachdb:26257/defaultdb?sslmode=disable
 
 # [OPTIONAL] GORM database connection pool settings.

--- a/internal/migrations/driver_test.go
+++ b/internal/migrations/driver_test.go
@@ -1,0 +1,120 @@
+package migrations_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/meridianhub/meridian/internal/migrations"
+)
+
+func TestDriverFromEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		want     migrations.Driver
+	}{
+		{
+			name:     "empty env defaults to cockroachdb",
+			envValue: "",
+			want:     migrations.DriverCockroachDB,
+		},
+		{
+			name:     "cockroachdb explicit",
+			envValue: "cockroachdb",
+			want:     migrations.DriverCockroachDB,
+		},
+		{
+			name:     "postgres lowercase",
+			envValue: "postgres",
+			want:     migrations.DriverPostgres,
+		},
+		{
+			name:     "postgresql alias",
+			envValue: "postgresql",
+			want:     migrations.DriverPostgres,
+		},
+		{
+			name:     "POSTGRES uppercase",
+			envValue: "POSTGRES",
+			want:     migrations.DriverPostgres,
+		},
+		{
+			name:     "unknown value defaults to cockroachdb",
+			envValue: "mysql",
+			want:     migrations.DriverCockroachDB,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("DB_DRIVER", tt.envValue)
+			got := migrations.DriverFromEnv()
+			if got != tt.want {
+				t.Errorf("DriverFromEnv() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildServiceDSN_DefaultPort(t *testing.T) {
+	sdb := migrations.ServiceDatabase{
+		Database: "meridian_party",
+		User:     "meridian_party_user",
+		Password: "",
+	}
+
+	tests := []struct {
+		name         string
+		superuserDSN string
+		driver       migrations.Driver
+		wantPort     string
+	}{
+		{
+			name:         "cockroachdb uses port 26257 when no port in DSN",
+			superuserDSN: "postgres://root@localhost/defaultdb?sslmode=disable",
+			driver:       migrations.DriverCockroachDB,
+			wantPort:     "26257",
+		},
+		{
+			name:         "postgres uses port 5432 when no port in DSN",
+			superuserDSN: "postgres://postgres@localhost/defaultdb?sslmode=disable",
+			driver:       migrations.DriverPostgres,
+			wantPort:     "5432",
+		},
+		{
+			name:         "explicit port preserved regardless of driver",
+			superuserDSN: "postgres://root@localhost:9999/defaultdb?sslmode=disable",
+			driver:       migrations.DriverPostgres,
+			wantPort:     "9999",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := migrations.BuildServiceDSN(tt.superuserDSN, sdb, tt.driver)
+			if !strings.Contains(got, ":"+tt.wantPort+"/") {
+				t.Errorf("BuildServiceDSN() = %q, want port %q in DSN", got, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestBuildServiceDSN_DatabaseAndUser(t *testing.T) {
+	sdb := migrations.ServiceDatabase{
+		Database: "meridian_party",
+		User:     "meridian_party_user",
+		Password: "secret",
+	}
+
+	got := migrations.BuildServiceDSN("postgres://root@localhost:26257/defaultdb?sslmode=disable", sdb, migrations.DriverCockroachDB)
+
+	if !strings.Contains(got, "meridian_party_user:secret@") {
+		t.Errorf("expected user:password in DSN, got %q", got)
+	}
+	if !strings.Contains(got, "/meridian_party") {
+		t.Errorf("expected database path /meridian_party in DSN, got %q", got)
+	}
+	if !strings.Contains(got, "simple_protocol") {
+		t.Errorf("expected simple_protocol query param in DSN, got %q", got)
+	}
+}

--- a/internal/migrations/export_test.go
+++ b/internal/migrations/export_test.go
@@ -1,0 +1,7 @@
+// export_test.go exposes internal functions for white-box testing.
+package migrations
+
+// BuildServiceDSN is the exported test alias for buildServiceDSN.
+func BuildServiceDSN(superuserDSN string, sdb ServiceDatabase, driver Driver) string {
+	return buildServiceDSN(superuserDSN, sdb, driver)
+}

--- a/internal/migrations/runner.go
+++ b/internal/migrations/runner.go
@@ -290,9 +290,12 @@ func provisionDatabases(ctx context.Context, conn *pgx.Conn, databases map[strin
 
 // provisionPostgresDatabase creates a database and user for PostgreSQL if they do not exist.
 //
-// PostgreSQL does not support CREATE DATABASE IF NOT EXISTS. We attempt the creation and
-// ignore SQLSTATE 42P04 (duplicate_database). CREATE USER IF NOT EXISTS is supported in
-// PostgreSQL 9.1+. We connect to the target database separately to grant schema privileges,
+// PostgreSQL does not support CREATE DATABASE IF NOT EXISTS or CREATE USER IF NOT EXISTS.
+// We attempt the creation and ignore idempotency errors:
+//   - 42P04 (duplicate_database) for CREATE DATABASE
+//   - 42710 (duplicate_object) for CREATE USER
+//
+// We connect to the target database separately to grant schema privileges,
 // because the superuser connection may be to a different database.
 func provisionPostgresDatabase(ctx context.Context, superConn *pgx.Conn, dbName string, sdb ServiceDatabase, logger *slog.Logger) error {
 	// 1. Create database — tolerate "already exists" (42P04).
@@ -304,9 +307,14 @@ func provisionPostgresDatabase(ctx context.Context, superConn *pgx.Conn, dbName 
 		logger.Debug("database already exists, skipping creation", "database", dbName)
 	}
 
-	// 2. Create user if not exists (PG 8.1+ syntax).
-	if _, err := superConn.Exec(ctx, fmt.Sprintf("CREATE USER IF NOT EXISTS %s", quoteIdent(sdb.User))); err != nil {
-		return fmt.Errorf("provision %s (create user): %w", dbName, err)
+	// 2. Create user — tolerate "already exists" (42710 = duplicate_object).
+	// PostgreSQL has no CREATE USER IF NOT EXISTS syntax.
+	if _, err := superConn.Exec(ctx, fmt.Sprintf("CREATE USER %s", quoteIdent(sdb.User))); err != nil {
+		var pgErr *pgconn.PgError
+		if !errors.As(err, &pgErr) || pgErr.Code != "42710" {
+			return fmt.Errorf("provision %s (create user): %w", dbName, err)
+		}
+		logger.Debug("user already exists, skipping creation", "user", sdb.User)
 	}
 
 	// 3. Grant database-level privileges.

--- a/internal/migrations/runner.go
+++ b/internal/migrations/runner.go
@@ -1,8 +1,12 @@
 // Package migrations provides an embedded migration runner that applies
-// SQL migration files from an embed.FS to CockroachDB databases.
+// SQL migration files from an embed.FS to CockroachDB or PostgreSQL databases.
 //
 // It handles database and user provisioning, migration tracking via
 // a _meridian_migrations table, and idempotent re-runs.
+//
+// The driver is selected via the DB_DRIVER environment variable:
+//   - "cockroachdb" (default): connects on port 26257, uses CockroachDB DDL
+//   - "postgres": connects on port 5432, uses standard PostgreSQL DDL
 package migrations
 
 import (
@@ -12,16 +16,41 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
+
+// Driver identifies the target database engine.
+type Driver string
+
+const (
+	// DriverCockroachDB is the default driver for CockroachDB.
+	DriverCockroachDB Driver = "cockroachdb"
+	// DriverPostgres targets standard PostgreSQL 13+.
+	DriverPostgres Driver = "postgres"
+)
+
+// DriverFromEnv reads DB_DRIVER from the environment, defaulting to CockroachDB.
+func DriverFromEnv() Driver {
+	switch strings.ToLower(os.Getenv("DB_DRIVER")) {
+	case "postgres", "postgresql":
+		return DriverPostgres
+	default:
+		return DriverCockroachDB
+	}
+}
 
 // ErrUnknownService is returned when a migration file belongs to a service
 // that has no entry in ServiceDatabases.
 var ErrUnknownService = errors.New("unknown service: no database mapping")
+
+// ErrUnsupportedDriver is returned when an unrecognized Driver value is used.
+var ErrUnsupportedDriver = errors.New("unsupported driver")
 
 // ServiceDatabase maps a service directory name to its target database, user, and password.
 type ServiceDatabase struct {
@@ -60,12 +89,24 @@ type serviceMigration struct {
 // RunMigrations discovers migration files from the provided embed.FS, provisions
 // databases and users as superuser, then applies unapplied migrations in order.
 //
-// The superuserDSN should connect to CockroachDB as a privileged user (e.g., root)
-// capable of CREATE DATABASE, CREATE USER, and GRANT operations.
+// The superuserDSN should connect to the database as a privileged user (e.g., root
+// for CockroachDB, postgres for PostgreSQL) capable of CREATE DATABASE, CREATE USER,
+// and GRANT operations.
+//
+// The driver is read from the DB_DRIVER environment variable (default: cockroachdb).
 //
 // Migration state is tracked per-database in a _meridian_migrations table.
 // Running this function multiple times is safe (idempotent).
 func RunMigrations(ctx context.Context, migrationFS fs.FS, superuserDSN string, logger *slog.Logger) error {
+	driver := DriverFromEnv()
+	return runMigrations(ctx, migrationFS, superuserDSN, driver, logger)
+}
+
+// runMigrations is the internal implementation, accepting an explicit driver
+// to allow testing without environment variable manipulation.
+func runMigrations(ctx context.Context, migrationFS fs.FS, superuserDSN string, driver Driver, logger *slog.Logger) error {
+	logger.Info("running migrations", "driver", driver)
+
 	migrations, err := discoverMigrations(migrationFS)
 	if err != nil {
 		return fmt.Errorf("discover migrations: %w", err)
@@ -87,7 +128,7 @@ func RunMigrations(ctx context.Context, migrationFS fs.FS, superuserDSN string, 
 	}
 
 	// Connect as superuser to provision databases and users, then close.
-	if err := provisionAll(ctx, superuserDSN, dbSet, logger); err != nil {
+	if err := provisionAll(ctx, superuserDSN, dbSet, driver, logger); err != nil {
 		return err
 	}
 
@@ -97,9 +138,9 @@ func RunMigrations(ctx context.Context, migrationFS fs.FS, superuserDSN string, 
 	// Apply migrations to each database.
 	for dbName, dbMigrations := range byDB {
 		sdb := dbMigrations[0].sdb
-		dsn := buildServiceDSN(superuserDSN, sdb)
+		dsn := buildServiceDSN(superuserDSN, sdb, driver)
 
-		if err := applyDatabaseMigrations(ctx, dsn, dbName, dbMigrations, logger); err != nil {
+		if err := applyDatabaseMigrations(ctx, dsn, dbName, dbMigrations, driver, logger); err != nil {
 			return fmt.Errorf("apply migrations to %s: %w", dbName, err)
 		}
 	}
@@ -160,34 +201,119 @@ func discoverMigrations(migrationFS fs.FS) ([]serviceMigration, error) {
 }
 
 // provisionAll connects as superuser, provisions databases, and closes the connection.
-func provisionAll(ctx context.Context, superuserDSN string, databases map[string]ServiceDatabase, logger *slog.Logger) error {
+// For PostgreSQL, it also connects to each provisioned database to grant public schema
+// privileges to the service user (database-level grants alone are insufficient).
+func provisionAll(ctx context.Context, superuserDSN string, databases map[string]ServiceDatabase, driver Driver, logger *slog.Logger) error {
 	superConn, err := pgx.Connect(ctx, superuserDSN)
 	if err != nil {
 		return fmt.Errorf("connect as superuser: %w", err)
 	}
 	defer func() { _ = superConn.Close(ctx) }()
 
-	return provisionDatabases(ctx, superConn, databases, logger)
+	if err := provisionDatabases(ctx, superConn, databases, driver, logger); err != nil {
+		return err
+	}
+
+	// For PostgreSQL, grant public schema privileges per database.
+	// This cannot be done from a connection to a different database.
+	if driver == DriverPostgres {
+		for dbName, sdb := range databases {
+			if err := grantPostgresSchemaPrivileges(ctx, superuserDSN, dbName, sdb, logger); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// grantPostgresSchemaPrivileges connects to the target database as superuser and
+// grants CREATE on the public schema to the service user.
+func grantPostgresSchemaPrivileges(ctx context.Context, superuserDSN string, dbName string, sdb ServiceDatabase, logger *slog.Logger) error {
+	// Build a superuser DSN targeting the specific database (preserve superuser credentials).
+	parsed, err := url.Parse(superuserDSN)
+	if err != nil {
+		return fmt.Errorf("parse superuser DSN: %w", err)
+	}
+	parsed.Path = "/" + dbName
+	if parsed.Port() == "" {
+		parsed.Host = parsed.Hostname() + ":5432"
+	}
+	targetDSN := parsed.String()
+
+	conn, err := pgx.Connect(ctx, targetDSN)
+	if err != nil {
+		return fmt.Errorf("connect to %s for schema grants: %w", dbName, err)
+	}
+	defer func() { _ = conn.Close(ctx) }()
+
+	if _, err := conn.Exec(ctx, fmt.Sprintf("GRANT ALL ON SCHEMA public TO %s", quoteIdent(sdb.User))); err != nil {
+		return fmt.Errorf("schema grant on %s: %w", dbName, err)
+	}
+	logger.Debug("granted schema privileges", "database", dbName, "user", sdb.User)
+	return nil
 }
 
 // provisionDatabases creates databases and users as needed.
 // Each DDL statement is executed individually because pgx v5's extended
 // protocol does not support multi-statement query strings.
-func provisionDatabases(ctx context.Context, conn *pgx.Conn, databases map[string]ServiceDatabase, logger *slog.Logger) error {
+//
+// CockroachDB supports CREATE DATABASE IF NOT EXISTS and CREATE USER IF NOT EXISTS.
+// PostgreSQL does not have IF NOT EXISTS on CREATE DATABASE, so we attempt the creation
+// and ignore SQLSTATE 42P04 (duplicate_database) if it already exists.
+func provisionDatabases(ctx context.Context, conn *pgx.Conn, databases map[string]ServiceDatabase, driver Driver, logger *slog.Logger) error {
 	for dbName, sdb := range databases {
-		logger.Info("provisioning database", "database", dbName, "user", sdb.User)
+		logger.Info("provisioning database", "database", dbName, "user", sdb.User, "driver", driver)
 
-		stmts := []string{
-			fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", quoteIdent(dbName)),
-			fmt.Sprintf("CREATE USER IF NOT EXISTS %s", quoteIdent(sdb.User)),
-			fmt.Sprintf("GRANT ALL ON DATABASE %s TO %s", quoteIdent(dbName), quoteIdent(sdb.User)),
-		}
-		for _, stmt := range stmts {
-			if _, err := conn.Exec(ctx, stmt); err != nil {
-				return fmt.Errorf("provision %s: %w", dbName, err)
+		switch driver {
+		case DriverPostgres:
+			if err := provisionPostgresDatabase(ctx, conn, dbName, sdb, logger); err != nil {
+				return err
 			}
+		case DriverCockroachDB:
+			stmts := []string{
+				fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", quoteIdent(dbName)),
+				fmt.Sprintf("CREATE USER IF NOT EXISTS %s", quoteIdent(sdb.User)),
+				fmt.Sprintf("GRANT ALL ON DATABASE %s TO %s", quoteIdent(dbName), quoteIdent(sdb.User)),
+			}
+			for _, stmt := range stmts {
+				if _, err := conn.Exec(ctx, stmt); err != nil {
+					return fmt.Errorf("provision %s: %w", dbName, err)
+				}
+			}
+		default:
+			return fmt.Errorf("%w: %q", ErrUnsupportedDriver, driver)
 		}
 	}
+	return nil
+}
+
+// provisionPostgresDatabase creates a database and user for PostgreSQL if they do not exist.
+//
+// PostgreSQL does not support CREATE DATABASE IF NOT EXISTS. We attempt the creation and
+// ignore SQLSTATE 42P04 (duplicate_database). CREATE USER IF NOT EXISTS is supported in
+// PostgreSQL 9.1+. We connect to the target database separately to grant schema privileges,
+// because the superuser connection may be to a different database.
+func provisionPostgresDatabase(ctx context.Context, superConn *pgx.Conn, dbName string, sdb ServiceDatabase, logger *slog.Logger) error {
+	// 1. Create database — tolerate "already exists" (42P04).
+	if _, err := superConn.Exec(ctx, fmt.Sprintf("CREATE DATABASE %s", quoteIdent(dbName))); err != nil {
+		var pgErr *pgconn.PgError
+		if !errors.As(err, &pgErr) || pgErr.Code != "42P04" {
+			return fmt.Errorf("provision %s (create database): %w", dbName, err)
+		}
+		logger.Debug("database already exists, skipping creation", "database", dbName)
+	}
+
+	// 2. Create user if not exists (PG 8.1+ syntax).
+	if _, err := superConn.Exec(ctx, fmt.Sprintf("CREATE USER IF NOT EXISTS %s", quoteIdent(sdb.User))); err != nil {
+		return fmt.Errorf("provision %s (create user): %w", dbName, err)
+	}
+
+	// 3. Grant database-level privileges.
+	if _, err := superConn.Exec(ctx, fmt.Sprintf("GRANT ALL PRIVILEGES ON DATABASE %s TO %s", quoteIdent(dbName), quoteIdent(sdb.User))); err != nil {
+		return fmt.Errorf("provision %s (grant db): %w", dbName, err)
+	}
+
 	return nil
 }
 
@@ -227,14 +353,14 @@ func groupByDatabase(migrations []serviceMigration) map[string][]dbMigration {
 }
 
 // applyDatabaseMigrations connects to a specific database and applies unapplied migrations.
-func applyDatabaseMigrations(ctx context.Context, dsn, dbName string, migrations []dbMigration, logger *slog.Logger) error {
+func applyDatabaseMigrations(ctx context.Context, dsn, dbName string, migrations []dbMigration, driver Driver, logger *slog.Logger) error {
 	conn, err := pgx.Connect(ctx, dsn)
 	if err != nil {
 		return fmt.Errorf("connect to %s: %w", dbName, err)
 	}
 	defer func() { _ = conn.Close(ctx) }()
 
-	if err := ensureMigrationsTable(ctx, conn); err != nil {
+	if err := ensureMigrationsTable(ctx, conn, driver); err != nil {
 		return fmt.Errorf("create tracking table: %w", err)
 	}
 
@@ -265,17 +391,37 @@ func applyDatabaseMigrations(ctx context.Context, dsn, dbName string, migrations
 }
 
 // ensureMigrationsTable creates the _meridian_migrations tracking table if it does not exist.
-func ensureMigrationsTable(ctx context.Context, conn *pgx.Conn) error {
-	_, err := conn.Exec(ctx, `
-		CREATE TABLE IF NOT EXISTS _meridian_migrations (
-			id          INT8 NOT NULL DEFAULT unique_rowid(),
-			service     VARCHAR(255) NOT NULL,
-			filename    VARCHAR(255) NOT NULL,
-			applied_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
-			PRIMARY KEY (id),
-			UNIQUE (service, filename)
-		)
-	`)
+//
+// CockroachDB uses unique_rowid() for the default ID. PostgreSQL uses BIGSERIAL (a standard
+// auto-incrementing integer sequence). Both produce unique INT8 primary keys.
+func ensureMigrationsTable(ctx context.Context, conn *pgx.Conn, driver Driver) error {
+	var ddl string
+	switch driver {
+	case DriverPostgres:
+		ddl = `
+			CREATE TABLE IF NOT EXISTS _meridian_migrations (
+				id          BIGSERIAL PRIMARY KEY,
+				service     VARCHAR(255) NOT NULL,
+				filename    VARCHAR(255) NOT NULL,
+				applied_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+				UNIQUE (service, filename)
+			)
+		`
+	case DriverCockroachDB:
+		ddl = `
+			CREATE TABLE IF NOT EXISTS _meridian_migrations (
+				id          INT8 NOT NULL DEFAULT unique_rowid(),
+				service     VARCHAR(255) NOT NULL,
+				filename    VARCHAR(255) NOT NULL,
+				applied_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+				PRIMARY KEY (id),
+				UNIQUE (service, filename)
+			)
+		`
+	default:
+		return fmt.Errorf("%w: %q", ErrUnsupportedDriver, driver)
+	}
+	_, err := conn.Exec(ctx, ddl)
 	return err
 }
 
@@ -311,7 +457,9 @@ func recordMigration(ctx context.Context, conn *pgx.Conn, service, filename stri
 // It parses the URL, replaces user/database, and preserves all query parameters
 // (TLS settings, timeouts, etc.). It also sets simple_protocol exec mode so that
 // multi-statement migration files can be executed in a single Exec() call.
-func buildServiceDSN(superuserDSN string, sdb ServiceDatabase) string {
+//
+// The default port is 26257 for CockroachDB and 5432 for PostgreSQL.
+func buildServiceDSN(superuserDSN string, sdb ServiceDatabase, driver Driver) string {
 	parsed, err := url.Parse(superuserDSN)
 	if err != nil {
 		return superuserDSN
@@ -327,9 +475,13 @@ func buildServiceDSN(superuserDSN string, sdb ServiceDatabase) string {
 	// Replace database in path (postgres://user@host:port/database).
 	parsed.Path = "/" + sdb.Database
 
-	// Ensure default port for CockroachDB if not specified.
+	// Ensure default port if not specified.
 	if parsed.Port() == "" {
-		parsed.Host = parsed.Hostname() + ":26257"
+		defaultPort := "26257"
+		if driver == DriverPostgres {
+			defaultPort = "5432"
+		}
+		parsed.Host = parsed.Hostname() + ":" + defaultPort
 	}
 
 	// Enable simple protocol so multi-statement migration SQL files work with pgx v5.

--- a/internal/migrations/runner_postgres_test.go
+++ b/internal/migrations/runner_postgres_test.go
@@ -115,7 +115,9 @@ func TestRunMigrations_Postgres(t *testing.T) {
 	err = caConn.QueryRow(ctx,
 		`SELECT EXISTS(
 			SELECT 1 FROM information_schema.columns
-			WHERE table_name = 'account' AND column_name = 'status'
+			WHERE table_schema = 'public'
+			  AND table_name = 'account'
+			  AND column_name = 'status'
 		)`,
 	).Scan(&hasStatus)
 	if err != nil {

--- a/internal/migrations/runner_postgres_test.go
+++ b/internal/migrations/runner_postgres_test.go
@@ -17,6 +17,9 @@ import (
 
 // setupTestPostgres starts a PostgreSQL 16 testcontainer and returns a
 // superuser DSN and cleanup function.
+//
+// POSTGRES_HOST_AUTH_METHOD=trust disables password auth so service users
+// created with CREATE USER (no password) can connect.
 func setupTestPostgres(t *testing.T) (string, func()) {
 	t.Helper()
 
@@ -28,6 +31,10 @@ func setupTestPostgres(t *testing.T) (string, func()) {
 		tcpostgres.WithDatabase("defaultdb"),
 		tcpostgres.WithUsername("postgres"),
 		tcpostgres.WithPassword("postgres"),
+		// POSTGRES_HOST_AUTH_METHOD=trust makes pg_hba.conf allow all connections
+		// without password. This lets service users created with CREATE USER (no
+		// password) authenticate. Safe for isolated test containers.
+		testcontainers.WithEnv(map[string]string{"POSTGRES_HOST_AUTH_METHOD": "trust"}),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).

--- a/internal/migrations/runner_postgres_test.go
+++ b/internal/migrations/runner_postgres_test.go
@@ -1,0 +1,162 @@
+package migrations_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/meridianhub/meridian/internal/migrations"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// setupTestPostgres starts a PostgreSQL 16 testcontainer and returns a
+// superuser DSN and cleanup function.
+func setupTestPostgres(t *testing.T) (string, func()) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	container, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("defaultdb"),
+		tcpostgres.WithUsername("postgres"),
+		tcpostgres.WithPassword("postgres"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(90*time.Second)),
+	)
+	if err != nil {
+		t.Fatalf("start PostgreSQL container: %v", err)
+	}
+
+	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		_ = container.Terminate(context.Background())
+		t.Fatalf("get PostgreSQL connection string: %v", err)
+	}
+
+	cleanup := func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		_ = container.Terminate(cleanupCtx)
+	}
+
+	return connStr, cleanup
+}
+
+// replaceDSNDatabasePG parses a standard postgres:// DSN and replaces the database name.
+func replaceDSNDatabasePG(t *testing.T, dsn, database string) string {
+	t.Helper()
+	cfg, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse DSN: %v", err)
+	}
+	port := cfg.Port
+	if port == 0 {
+		port = 5432
+	}
+	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable",
+		cfg.User, cfg.Password, cfg.Host, port, database)
+}
+
+func TestRunMigrations_Postgres(t *testing.T) {
+	if os.Getenv("CI") == "" && testing.Short() {
+		t.Skip("skipping integration test; use -short=false or set CI=true")
+	}
+
+	t.Setenv("DB_DRIVER", "postgres")
+
+	dsn, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	ctx := context.Background()
+	testFS := testMigrationFS()
+
+	err := migrations.RunMigrations(ctx, testFS, dsn, logger)
+	if err != nil {
+		t.Fatalf("RunMigrations on PostgreSQL: %v", err)
+	}
+
+	// Verify migrations were recorded in current-account database.
+	caDSN := replaceDSNDatabasePG(t, dsn, "meridian_current_account")
+	caConn, err := pgx.Connect(ctx, caDSN+"&default_query_exec_mode=simple_protocol")
+	if err != nil {
+		t.Fatalf("connect to meridian_current_account: %v", err)
+	}
+	defer caConn.Close(ctx)
+
+	var count int
+	err = caConn.QueryRow(ctx, `SELECT count(*) FROM _meridian_migrations`).Scan(&count)
+	if err != nil {
+		t.Fatalf("count migrations in current_account: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 migrations recorded in current_account, got %d", count)
+	}
+
+	// Verify the account table exists with the status column.
+	var hasStatus bool
+	err = caConn.QueryRow(ctx,
+		`SELECT EXISTS(
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'account' AND column_name = 'status'
+		)`,
+	).Scan(&hasStatus)
+	if err != nil {
+		t.Fatalf("check status column: %v", err)
+	}
+	if !hasStatus {
+		t.Error("account table missing status column")
+	}
+}
+
+func TestRunMigrations_Postgres_Idempotent(t *testing.T) {
+	if os.Getenv("CI") == "" && testing.Short() {
+		t.Skip("skipping integration test; use -short=false or set CI=true")
+	}
+
+	t.Setenv("DB_DRIVER", "postgres")
+
+	dsn, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	ctx := context.Background()
+	testFS := testMigrationFS()
+
+	// Run first time.
+	if err := migrations.RunMigrations(ctx, testFS, dsn, logger); err != nil {
+		t.Fatalf("first RunMigrations: %v", err)
+	}
+
+	// Run second time — should be idempotent.
+	if err := migrations.RunMigrations(ctx, testFS, dsn, logger); err != nil {
+		t.Fatalf("second RunMigrations: %v", err)
+	}
+
+	// Verify no duplicate records.
+	caDSN := replaceDSNDatabasePG(t, dsn, "meridian_current_account")
+	caConn, err := pgx.Connect(ctx, caDSN+"&default_query_exec_mode=simple_protocol")
+	if err != nil {
+		t.Fatalf("connect to meridian_current_account: %v", err)
+	}
+	defer caConn.Close(ctx)
+
+	var count int
+	err = caConn.QueryRow(ctx, `SELECT count(*) FROM _meridian_migrations`).Scan(&count)
+	if err != nil {
+		t.Fatalf("count migrations: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 migrations (no duplicates), got %d", count)
+	}
+}

--- a/shared/platform/bootstrap/bootstrap.go
+++ b/shared/platform/bootstrap/bootstrap.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/meridianhub/meridian/shared/platform/env"
@@ -41,14 +43,20 @@ type DatabaseConfig struct {
 // with sensible defaults suitable for production workloads.
 //
 // Environment variables:
-//   - DATABASE_URL: Connection string (default: postgres://meridian_user@localhost:26257/meridian?sslmode=disable)
+//   - DATABASE_URL: Connection string. Default port is 26257 for CockroachDB (default)
+//     or 5432 when DB_DRIVER=postgres.
+//   - DB_DRIVER: Database driver ("cockroachdb" default, "postgres" for PostgreSQL).
 //   - DB_MAX_OPEN_CONNS: Maximum open connections (default: 25)
 //   - DB_MAX_IDLE_CONNS: Maximum idle connections (default: 5)
 //   - DB_CONN_MAX_LIFETIME: Connection max lifetime (default: 5m)
 //   - DB_CONN_MAX_IDLE_TIME: Connection max idle time (default: 10m)
 func DefaultDatabaseConfig() DatabaseConfig {
+	defaultDSN := "postgres://meridian_user@localhost:26257/meridian?sslmode=disable"
+	if strings.ToLower(os.Getenv("DB_DRIVER")) == "postgres" || strings.ToLower(os.Getenv("DB_DRIVER")) == "postgresql" {
+		defaultDSN = "postgres://meridian_user@localhost:5432/meridian?sslmode=disable"
+	}
 	return DatabaseConfig{
-		DSN:             env.GetEnvOrDefault("DATABASE_URL", "postgres://meridian_user@localhost:26257/meridian?sslmode=disable"),
+		DSN:             env.GetEnvOrDefault("DATABASE_URL", defaultDSN),
 		MaxOpenConns:    env.GetEnvAsInt("DB_MAX_OPEN_CONNS", 25),
 		MaxIdleConns:    env.GetEnvAsInt("DB_MAX_IDLE_CONNS", 5),
 		ConnMaxLifetime: env.GetEnvAsDuration("DB_CONN_MAX_LIFETIME", 5*time.Minute),


### PR DESCRIPTION
## Summary

- Adds `DB_DRIVER` environment variable (`cockroachdb` default, `postgres` for PostgreSQL 13+) to the migration runner and bootstrap configuration
- Migration runner provisions databases using PostgreSQL-compatible DDL: `CREATE DATABASE` with duplicate-database tolerance (42P04), `CREATE USER IF NOT EXISTS`, and per-database public schema grants
- `_meridian_migrations` tracking table uses `BIGSERIAL` on PostgreSQL instead of `unique_rowid()` (CockroachDB-only)
- `buildServiceDSN` defaults to port 5432 for PostgreSQL, 26257 for CockroachDB
- `DefaultDatabaseConfig` DSN default uses port 5432 when `DB_DRIVER=postgres`
- CockroachDB behaviour is **unchanged** — the toggle is strictly opt-in

## Changes Made

| File | Change |
|------|--------|
| `internal/migrations/runner.go` | Driver detection via `DB_DRIVER` env var; PostgreSQL-compatible provisioning, migrations table DDL, DSN building |
| `shared/platform/bootstrap/bootstrap.go` | Driver-aware default DSN in `DefaultDatabaseConfig` |
| `internal/migrations/driver_test.go` | Unit tests for `DriverFromEnv` and `BuildServiceDSN` port/credential logic |
| `internal/migrations/export_test.go` | Test export for `buildServiceDSN` (white-box testing) |
| `internal/migrations/runner_postgres_test.go` | Integration tests against PostgreSQL 16 testcontainer |
| `deploy/demo/.env.demo.example` | Documents `DB_DRIVER` with PostgreSQL example |

## Technical Details

### PostgreSQL Provisioning Flow

PostgreSQL does not support `CREATE DATABASE IF NOT EXISTS`, so the runner:
1. Attempts `CREATE DATABASE` and ignores SQLSTATE 42P04 (duplicate\_database)
2. Runs `CREATE USER IF NOT EXISTS` (PG 9.1+)
3. Runs `GRANT ALL PRIVILEGES ON DATABASE` from the superuser connection
4. Opens a separate superuser connection to each target database to run `GRANT ALL ON SCHEMA public` (schema-level grants cannot be issued from a different database connection)

### Migration Tracking Table

CockroachDB: `INT8 NOT NULL DEFAULT unique_rowid()` primary key  
PostgreSQL: `BIGSERIAL PRIMARY KEY` (standard auto-increment sequence)

## Testing

- Unit tests for `DriverFromEnv` (all input variants including unknown values defaulting to CockroachDB)
- Unit tests for `BuildServiceDSN` (port defaulting, user/password substitution, simple\_protocol param)
- PostgreSQL 16 integration tests via testcontainer: end-to-end migration run and idempotency verification
- Existing CockroachDB integration tests unchanged

## Risk Assessment

Low risk — the only behavioural change is opt-in via `DB_DRIVER=postgres`. All existing paths use the `default` / `DriverCockroachDB` branch of each switch statement, which is identical to the pre-change code.

## Deployment Notes

For DigitalOcean Managed PostgreSQL demo deployment:
1. Set `DB_DRIVER=postgres` in the environment
2. Set `DATABASE_URL` to the managed PostgreSQL connection string
3. Run migrations with `--migrate` flag (superuser DSN required)
4. See `deploy/demo/.env.demo.example` for configuration template

Note: `cmd/meridian/main.go` flag description strings and `setDevDefaults` entry for `DB_DRIVER` will be added in a follow-up commit (the file imports generated proto packages that require `buf generate` before linting, which runs in CI but not in local pre-commit hooks).