### PR TITLE
feat: Wire gateway auth middleware and add Keycloak to demo stack

### DIFF
--- a/cmd/meridian/gateway_test.go
+++ b/cmd/meridian/gateway_test.go
@@ -23,7 +23,8 @@ func TestWireGateway_Config(t *testing.T) {
 	databaseURL := "postgres://root@localhost:26257/defaultdb?sslmode=disable"
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	srv := wireGateway(grpcPort, httpPort, databaseURL, logger)
+	srv, err := wireGateway(grpcPort, httpPort, databaseURL, logger)
+	require.NoError(t, err)
 	require.NotNil(t, srv)
 
 	// Start the gateway server

--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -650,11 +650,14 @@ var serviceNames = []string{
 func wireGateway(grpcPort, httpPort int, databaseURL string, logger *slog.Logger) *gateway.Server {
 	grpcTarget := fmt.Sprintf("localhost:%d", grpcPort)
 
+	authConfig := gateway.LoadAuthConfig()
+
 	config := &gateway.Config{
 		Port:         httpPort,
-		BaseDomain:   "localhost",
-		LocalDevMode: true,
+		BaseDomain:   env.GetEnvOrDefault("BASE_DOMAIN", "localhost"),
+		LocalDevMode: env.GetEnvAsBool("LOCAL_DEV_MODE", true),
 		DatabaseURL:  databaseURL,
+		Auth:         authConfig,
 	}
 
 	// Build per-service backends pointing at the shared loopback gRPC server.
@@ -676,6 +679,17 @@ func wireGateway(grpcPort, httpPort int, databaseURL string, logger *slog.Logger
 			"error", err)
 	} else {
 		opts = append(opts, gateway.WithTranscoder(transcoder))
+	}
+
+	// Wire auth middleware if enabled
+	if authConfig.Enabled {
+		authMiddleware, err := gateway.BuildAuthMiddleware(authConfig, logger)
+		if err != nil {
+			logger.Error("failed to build auth middleware; API routes will be unauthenticated",
+				"error", err)
+		} else if authMiddleware != nil {
+			opts = append(opts, gateway.WithAuthMiddleware(authMiddleware))
+		}
 	}
 
 	return gateway.NewServer(config, logger, nil, opts...)

--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -155,6 +155,19 @@ func setDevDefaults() {
 	}
 }
 
+func connectPgxPool(ctx context.Context, dsn string, logger *slog.Logger) (*pgxpool.Pool, error) {
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("pgxpool: %w", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("pgxpool ping: %w", err)
+	}
+	logger.Info("pgxpool connection established")
+	return pool, nil
+}
+
 func run(logger *slog.Logger, grpcPort, httpPort int) error {
 	ctx := context.Background()
 
@@ -177,15 +190,11 @@ func run(logger *slog.Logger, grpcPort, httpPort int) error {
 	// pgxpool connection (used by reference-data, market-information, forecasting)
 	pgxDSN := env.GetEnvOrDefault("DATABASE_URL",
 		"postgres://meridian_user@localhost:26257/meridian?sslmode=disable")
-	pgxPool, err := pgxpool.New(ctx, pgxDSN)
+	pgxPool, err := connectPgxPool(ctx, pgxDSN, logger)
 	if err != nil {
-		return fmt.Errorf("pgxpool: %w", err)
+		return err
 	}
 	defer pgxPool.Close()
-	if err := pgxPool.Ping(ctx); err != nil {
-		return fmt.Errorf("pgxpool ping: %w", err)
-	}
-	logger.Info("pgxpool connection established")
 
 	// No-op tracer (tracing disabled in unified dev mode)
 	tracer, err := observability.NewTracer(ctx, observability.TracerConfig{
@@ -249,7 +258,10 @@ func run(logger *slog.Logger, grpcPort, httpPort int) error {
 
 	// ─── Start Gateway HTTP Server ───────────────────────────────────────
 
-	gwServer := wireGateway(grpcPort, httpPort, pgxDSN, logger)
+	gwServer, err := wireGateway(grpcPort, httpPort, pgxDSN, logger)
+	if err != nil {
+		return fmt.Errorf("gateway init: %w", err)
+	}
 
 	gatewayErrors := make(chan error, 1)
 	go func() {
@@ -647,7 +659,7 @@ var serviceNames = []string{
 // wireGateway creates the gateway HTTP server with the Vanguard transcoder
 // routing REST/JSON, Connect, and gRPC-Web requests to the shared gRPC server
 // running on grpcPort.
-func wireGateway(grpcPort, httpPort int, databaseURL string, logger *slog.Logger) *gateway.Server {
+func wireGateway(grpcPort, httpPort int, databaseURL string, logger *slog.Logger) (*gateway.Server, error) {
 	grpcTarget := fmt.Sprintf("localhost:%d", grpcPort)
 
 	authConfig := gateway.LoadAuthConfig()
@@ -681,18 +693,16 @@ func wireGateway(grpcPort, httpPort int, databaseURL string, logger *slog.Logger
 		opts = append(opts, gateway.WithTranscoder(transcoder))
 	}
 
-	// Wire auth middleware if enabled
+	// Wire auth middleware if enabled — fail fast if misconfigured
 	if authConfig.Enabled {
 		authMiddleware, err := gateway.BuildAuthMiddleware(authConfig, logger)
 		if err != nil {
-			logger.Error("failed to build auth middleware; API routes will be unauthenticated",
-				"error", err)
-		} else if authMiddleware != nil {
-			opts = append(opts, gateway.WithAuthMiddleware(authMiddleware))
+			return nil, fmt.Errorf("failed to build auth middleware: %w", err)
 		}
+		opts = append(opts, gateway.WithAuthMiddleware(authMiddleware))
 	}
 
-	return gateway.NewServer(config, logger, nil, opts...)
+	return gateway.NewServer(config, logger, nil, opts...), nil
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/deploy/demo/.env.demo.example
+++ b/deploy/demo/.env.demo.example
@@ -64,22 +64,39 @@ GRPC_PORT=50051
 HTTP_PORT=8090
 
 # ---------------------------------------------------------------------------
-# Authentication
+# Authentication (Keycloak OIDC)
 # ---------------------------------------------------------------------------
 
-# [OPTIONAL] Authentication mode.
-# Set to "disabled" for an open demo. Set to "jwt" to enable JWKS validation.
-AUTH_MODE=disabled
+# [OPTIONAL] Enable JWT authentication on the gateway (default: true with Keycloak).
+# Set to "false" to disable auth and leave the API completely open.
+AUTH_ENABLED=true
 
-# [OPTIONAL — required when AUTH_MODE=jwt] JWKS endpoint for JWT validation.
-# Example: https://your-auth-provider.com/.well-known/jwks.json
-#AUTH_JWKS_URL=
+# [OPTIONAL] JWKS endpoint for JWT validation.
+# Default points to the bundled Keycloak container's meridian realm.
+JWKS_URL=http://keycloak:8080/realms/meridian/protocol/openid-connect/certs
 
-# [OPTIONAL] Interval to refresh JWKS signing keys (default: 30m).
-#AUTH_JWKS_REFRESH_TTL=30m
+# [OPTIONAL] Cache duration for JWKS keys (default: 24h).
+#JWKS_CACHE_TTL=24h
 
-# [OPTIONAL] Timeout for HTTP requests to the JWKS endpoint (default: 30s).
-#AUTH_HTTP_TIMEOUT=30s
+# [OPTIONAL] Background refresh interval for JWKS keys (default: 1h).
+#JWKS_REFRESH_TTL=1h
+
+# [OPTIONAL] Expected JWT issuer for validation (leave empty to skip issuer check).
+#JWT_ISSUER=
+
+# [OPTIONAL] Expected JWT audience for validation (leave empty to skip audience check).
+#JWT_AUDIENCE=
+
+# [OPTIONAL] Comma-separated API keys for service-to-service auth (format: "key:identity").
+# Example: "sk_demo_abc123:demo-client,sk_test_def456:test-runner"
+#API_KEYS=
+
+# [OPTIONAL] Keycloak admin credentials for the bundled container.
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=admin
+
+# [OPTIONAL] Gateway base domain for subdomain-based tenant resolution.
+BASE_DOMAIN=demo.meridianhub.cloud
 
 # ---------------------------------------------------------------------------
 # Billing

--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       KC_HOSTNAME_STRICT_HTTPS: "false"
       KC_HEALTH_ENABLED: "true"
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9000 && echo -e 'GET /health/ready HTTP/1.1\r\nHost: localhost\r\n\r\n' >&3 && cat <&3 | grep -q UP"]
+      test: ["CMD", "bash", "-lc", "{ printf 'HEAD /health/ready HTTP/1.0\r\n\r\n' >&0; grep -q 'HTTP/1.0 200'; } 0<>/dev/tcp/localhost/9000"]
       interval: 10s
       timeout: 5s
       retries: 12
@@ -59,7 +59,7 @@ services:
     #   ports: ["18080:8080"]
 
   keycloak-setup:
-    image: curlimages/curl:latest
+    image: curlimages/curl:8.12.1
     depends_on:
       keycloak:
         condition: service_healthy
@@ -147,7 +147,7 @@ services:
       AUTH_ENABLED: ${AUTH_ENABLED:-true}
       JWKS_URL: ${JWKS_URL:-http://keycloak:8080/realms/meridian/protocol/openid-connect/certs}
       BASE_DOMAIN: ${BASE_DOMAIN:-demo.meridianhub.cloud}
-      LOCAL_DEV_MODE: "false"
+      LOCAL_DEV_MODE: ${LOCAL_DEV_MODE:-false}
 
       # --- Feature flags ---
       BILLING_ENABLED: ${BILLING_ENABLED:-false}

--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -1,9 +1,11 @@
 # Meridian demo deployment stack
 #
 # Services:
-#   postgres  - PostgreSQL 16 (internal only, not exposed to host)
-#   meridian  - Unified binary; starts after postgres is healthy
-#   caddy     - Reverse proxy; exposes 80/443, terminates TLS via Cloudflare Origin Certificate
+#   postgres        - PostgreSQL 16 (internal only, not exposed to host)
+#   keycloak        - Identity provider (OAuth 2.0 / OIDC)
+#   keycloak-setup  - One-shot init container that configures Keycloak realm/client/user
+#   meridian        - Unified binary; starts after postgres + keycloak are healthy
+#   caddy           - Reverse proxy; exposes 80/443, terminates TLS via Cloudflare Origin Certificate
 #
 # Usage:
 #   cp deploy/demo/.env.demo.example /opt/meridian/.env
@@ -35,11 +37,91 @@ services:
       start_period: 10s
     # Not exposed to host — accessed only by meridian on the internal network
 
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    restart: unless-stopped
+    command: ["start-dev", "--http-port=8080"]
+    environment:
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+      KC_HTTP_RELATIVE_PATH: /
+      KC_HOSTNAME_STRICT: "false"
+      KC_HOSTNAME_STRICT_HTTPS: "false"
+      KC_HEALTH_ENABLED: "true"
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9000 && echo -e 'GET /health/ready HTTP/1.1\r\nHost: localhost\r\n\r\n' >&3 && cat <&3 | grep -q UP"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+    # Not exposed to host — accessed by meridian on the internal network.
+    # Expose port 18080 on the host for local token acquisition during development:
+    #   ports: ["18080:8080"]
+
+  keycloak-setup:
+    image: curlimages/curl:latest
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        KEYCLOAK_URL="http://keycloak:8080"
+        ADMIN_USER="$${KEYCLOAK_ADMIN:-admin}"
+        ADMIN_PASSWORD="$${KEYCLOAK_ADMIN_PASSWORD:-admin}"
+        REALM="meridian"
+        CLIENT_ID="meridian-service"
+        TEST_USER="developer@meridian.local"
+        TEST_PASSWORD="developer"
+
+        echo "Getting admin token..."
+        TOKEN=$$(curl -sf -X POST "$$KEYCLOAK_URL/realms/master/protocol/openid-connect/token" \
+          -d "username=$$ADMIN_USER" -d "password=$$ADMIN_PASSWORD" \
+          -d "grant_type=password" -d "client_id=admin-cli" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+
+        if [ -z "$$TOKEN" ]; then echo "Failed to get admin token"; exit 1; fi
+
+        echo "Creating realm..."
+        curl -sf -o /dev/null -w "%{http_code}" -X POST "$$KEYCLOAK_URL/admin/realms" \
+          -H "Authorization: Bearer $$TOKEN" -H "Content-Type: application/json" \
+          -d '{"realm":"'"$$REALM"'","enabled":true,"displayName":"Meridian","accessTokenLifespan":3600}' || true
+
+        echo "Creating roles..."
+        curl -sf -o /dev/null -X POST "$$KEYCLOAK_URL/admin/realms/$$REALM/roles" \
+          -H "Authorization: Bearer $$TOKEN" -H "Content-Type: application/json" \
+          -d '{"name":"user","description":"Standard user role"}' 2>/dev/null || true
+        curl -sf -o /dev/null -X POST "$$KEYCLOAK_URL/admin/realms/$$REALM/roles" \
+          -H "Authorization: Bearer $$TOKEN" -H "Content-Type: application/json" \
+          -d '{"name":"admin","description":"Administrator role"}' 2>/dev/null || true
+
+        echo "Creating client..."
+        curl -sf -o /dev/null -X POST "$$KEYCLOAK_URL/admin/realms/$$REALM/clients" \
+          -H "Authorization: Bearer $$TOKEN" -H "Content-Type: application/json" \
+          -d '{"clientId":"'"$$CLIENT_ID"'","enabled":true,"publicClient":true,"directAccessGrantsEnabled":true,"standardFlowEnabled":true,"redirectUris":["http://localhost:*","https://*.meridianhub.cloud/*"],"webOrigins":["+"]}' 2>/dev/null || true
+
+        echo "Creating test user..."
+        curl -sf -o /dev/null -X POST "$$KEYCLOAK_URL/admin/realms/$$REALM/users" \
+          -H "Authorization: Bearer $$TOKEN" -H "Content-Type: application/json" \
+          -d '{"username":"'"$$TEST_USER"'","email":"'"$$TEST_USER"'","emailVerified":true,"enabled":true,"firstName":"Developer","lastName":"User","credentials":[{"type":"password","value":"'"$$TEST_PASSWORD"'","temporary":false}]}' 2>/dev/null || true
+
+        echo "Keycloak setup complete!"
+        echo "  Realm:     $$REALM"
+        echo "  Client:    $$CLIENT_ID"
+        echo "  User:      $$TEST_USER / $$TEST_PASSWORD"
+        echo "  JWKS:      $$KEYCLOAK_URL/realms/$$REALM/protocol/openid-connect/certs"
+    environment:
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+    restart: "no"
+
   meridian:
     image: ${MERIDIAN_IMAGE:-ghcr.io/meridianhub/meridian:demo}
     restart: unless-stopped
     depends_on:
       postgres:
+        condition: service_healthy
+      keycloak:
         condition: service_healthy
     environment:
       # --- Application ---
@@ -61,8 +143,11 @@ services:
       MARKET_INFORMATION_DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-meridian}?sslmode=disable
       REFERENCE_DATA_DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-meridian}?sslmode=disable
 
-      # --- Authentication ---
-      AUTH_MODE: ${AUTH_MODE:-disabled}
+      # --- Authentication (Keycloak OIDC) ---
+      AUTH_ENABLED: ${AUTH_ENABLED:-true}
+      JWKS_URL: ${JWKS_URL:-http://keycloak:8080/realms/meridian/protocol/openid-connect/certs}
+      BASE_DOMAIN: ${BASE_DOMAIN:-demo.meridianhub.cloud}
+      LOCAL_DEV_MODE: "false"
 
       # --- Feature flags ---
       BILLING_ENABLED: ${BILLING_ENABLED:-false}

--- a/services/gateway/auth_builder.go
+++ b/services/gateway/auth_builder.go
@@ -1,0 +1,62 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/meridianhub/meridian/services/gateway/auth"
+	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
+)
+
+// BuildAuthMiddleware creates a CombinedAuthMiddleware from the gateway AuthConfig.
+// The caller should only invoke this when config.Enabled is true.
+//
+// The caller is responsible for calling Close() on the returned middleware
+// during shutdown to release JWKS provider resources.
+func BuildAuthMiddleware(config AuthConfig, logger *slog.Logger) (*auth.CombinedAuthMiddleware, error) {
+	// Create JWKS provider for JWT validation
+	provider, err := platformauth.NewJWKSProvider(context.Background(), &platformauth.JWKSProviderConfig{
+		URL:        config.JWKSURL,
+		Client:     &http.Client{Timeout: 30 * time.Second},
+		CacheTTL:   config.JWKSCacheTTL,
+		RefreshTTL: config.JWKSRefreshTTL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWKS provider: %w", err)
+	}
+
+	// Create JWT validator
+	jwtValidator, err := platformauth.NewJWTValidatorWithJWKS(provider)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWT validator: %w", err)
+	}
+
+	// Wrap in context adapter for the gateway middleware interface
+	validatorAdapter := auth.NewJWTValidatorWithContext(jwtValidator)
+
+	// Build API key config
+	apiKeyConfig := auth.APIKeyConfig{
+		APIKeys:            config.APIKeys,
+		RateLimitPerSecond: config.RateLimitPerSecond,
+		RateLimitBurst:     config.RateLimitBurst,
+	}
+
+	// Create combined middleware
+	middleware, err := auth.NewCombinedAuthMiddleware(auth.CombinedAuthConfig{
+		JWTValidator: validatorAdapter,
+		APIKeyConfig: apiKeyConfig,
+		Logger:       logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create auth middleware: %w", err)
+	}
+
+	logger.Info("auth middleware initialized",
+		"jwks_url", config.JWKSURL,
+		"api_keys_configured", len(config.APIKeys) > 0)
+
+	return middleware, nil
+}

--- a/services/gateway/cmd/main.go
+++ b/services/gateway/cmd/main.go
@@ -123,6 +123,17 @@ func run(logger *slog.Logger) error {
 		gateway.WithHealthChecker(healthChecker),
 	}
 
+	// Wire auth middleware if enabled
+	if config.Auth.Enabled {
+		authMiddleware, err := gateway.BuildAuthMiddleware(config.Auth, logger)
+		if err != nil {
+			return bootstrap.Permanent(fmt.Errorf("failed to build auth middleware: %w", err))
+		}
+		if authMiddleware != nil {
+			serverOpts = append(serverOpts, gateway.WithAuthMiddleware(authMiddleware))
+		}
+	}
+
 	// Wire event streaming if enabled
 	var eventRouter *eventstream.Router
 	if config.EventStream.Enabled {

--- a/services/gateway/config.go
+++ b/services/gateway/config.go
@@ -173,7 +173,7 @@ func LoadConfig() (*Config, error) {
 	}
 
 	// Load auth configuration
-	config.Auth = loadAuthConfig()
+	config.Auth = LoadAuthConfig()
 
 	// Load event stream configuration
 	config.EventStream = loadEventStreamConfig()
@@ -186,7 +186,7 @@ func LoadConfig() (*Config, error) {
 	return config, nil
 }
 
-// loadAuthConfig loads authentication configuration from environment variables.
+// LoadAuthConfig loads authentication configuration from environment variables.
 //
 // Environment variables:
 //   - AUTH_ENABLED: Enable authentication (default: false)
@@ -198,7 +198,7 @@ func LoadConfig() (*Config, error) {
 //   - API_KEYS: Comma-separated list of "key:identity" pairs
 //   - API_KEY_RATE_LIMIT_PER_SECOND: Requests per second per key (default: 100)
 //   - API_KEY_RATE_LIMIT_BURST: Burst size for rate limiting (default: 200)
-func loadAuthConfig() AuthConfig {
+func LoadAuthConfig() AuthConfig {
 	config := AuthConfig{
 		Enabled:            env.GetEnvAsBool("AUTH_ENABLED", false),
 		JWKSURL:            os.Getenv("JWKS_URL"),

--- a/services/gateway/config_test.go
+++ b/services/gateway/config_test.go
@@ -517,7 +517,7 @@ func TestLoadAuthConfig_Defaults(t *testing.T) {
 		os.Unsetenv(key)
 	}
 
-	config := loadAuthConfig()
+	config := LoadAuthConfig()
 
 	assert.False(t, config.Enabled)
 	assert.Empty(t, config.JWKSURL)
@@ -545,7 +545,7 @@ func TestLoadAuthConfig_FullConfiguration(t *testing.T) {
 	})
 	defer cleanup()
 
-	config := loadAuthConfig()
+	config := LoadAuthConfig()
 
 	assert.True(t, config.Enabled)
 	assert.Equal(t, "https://auth.example.com/.well-known/jwks.json", config.JWKSURL)


### PR DESCRIPTION
## Summary

- Wire up the gateway's existing JWT/JWKS and API key auth middleware that was fully implemented but never connected — both `main.go` entry points were passing `nil` for the auth middleware
- Add Keycloak identity provider to the demo docker-compose stack with automated realm/client/user setup
- Align `.env.demo.example` env var names with actual gateway config code (`AUTH_ENABLED`, `JWKS_URL` instead of the previously incorrect `AUTH_MODE`, `AUTH_JWKS_URL`)

## Changes

### Gateway auth wiring
- **`services/gateway/config.go`**: Export `LoadAuthConfig()` so the unified binary can reuse it
- **`services/gateway/auth_builder.go`**: New `BuildAuthMiddleware()` helper — creates `CombinedAuthMiddleware` from `AuthConfig` (JWKS provider + JWT validator + API key support)
- **`services/gateway/cmd/main.go`**: When `AUTH_ENABLED=true`, build and attach auth middleware via `WithAuthMiddleware()`
- **`cmd/meridian/main.go`**: Same wiring for the unified binary; also reads `BASE_DOMAIN` and `LOCAL_DEV_MODE` from env (previously hardcoded)

### Demo stack auth
- **`deploy/demo/docker-compose.yml`**: Add `keycloak` service (quay.io/keycloak/keycloak:26.0, start-dev mode with health check) and `keycloak-setup` one-shot init container that creates the meridian realm, client, roles, and test user using curl (no jq dependency)
- **`deploy/demo/.env.demo.example`**: Replace stale `AUTH_MODE`/`AUTH_JWKS_URL` with `AUTH_ENABLED`/`JWKS_URL`/`JWKS_CACHE_TTL`/`JWKS_REFRESH_TTL`/`JWT_ISSUER`/`JWT_AUDIENCE`/`API_KEYS` matching the gateway config, plus `KEYCLOAK_ADMIN`/`KEYCLOAK_ADMIN_PASSWORD` and `BASE_DOMAIN`

### Auth flow (demo)
```
Browser → Caddy (443) → Meridian gateway (8090)
                              │
                              ├─ /health, /ready → no auth (K8s probes)
                              └─ /api/* → auth middleware → tenant resolver → backend
                                    │
                                    ├─ Authorization: Bearer <JWT> → validate via JWKS from Keycloak
                                    └─ X-API-Key: <key> → validate against API_KEYS env var

Keycloak JWKS endpoint: http://keycloak:8080/realms/meridian/protocol/openid-connect/certs
```

### Getting a test token
```bash
curl -X POST 'http://keycloak:8080/realms/meridian/protocol/openid-connect/token' \
  -d 'grant_type=password' \
  -d 'client_id=meridian-service' \
  -d 'username=developer@meridian.local' \
  -d 'password=developer'
```

## Test plan

- [ ] Gateway config tests pass (updated `loadAuthConfig` → `LoadAuthConfig` references)
- [ ] Gateway auth tests pass (unchanged — middleware was already tested)
- [ ] Unified binary compiles with auth wiring
- [ ] `AUTH_ENABLED=false` (default for local dev / Tilt) leaves auth disabled — no behavior change
- [ ] `AUTH_ENABLED=true` + `JWKS_URL` creates middleware and attaches to server
- [ ] Demo docker-compose starts with Keycloak, setup container configures realm, meridian connects to JWKS