### PR TITLE
fix: Route deploy health check through Caddy

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -111,7 +111,7 @@ jobs:
             until [ $attempt -ge $max_attempts ]; do
               attempt=$((attempt+1))
               echo "Health check attempt $attempt/$max_attempts"
-              if curl -sf http://localhost:8090/healthz > /dev/null 2>&1; then
+              if curl -sf http://localhost:80/healthz -H 'Host: demo.meridianhub.cloud' > /dev/null 2>&1; then
                 echo "Service is healthy"
                 exit 0
               fi


### PR DESCRIPTION
## Summary

- Health check in the deploy workflow was hitting `localhost:8090`, but Meridian's HTTP port is only exposed within the Docker network (not mapped to the host)
- Updated to hit Caddy on port 80 with the correct `Host` header, which reverse proxies to Meridian

## Test plan

- [x] Verified `curl -sf http://localhost:80/healthz -H 'Host: demo.meridianhub.cloud'` returns 200 on the droplet
- [x] Verified `https://demo.meridianhub.cloud/healthz` returns 200 externally