### PR TITLE
feat: Deploy frontend SPA to demo environment

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -78,15 +78,74 @@ jobs:
             COMMIT=${{ github.sha }}
             BUILD_DATE=${{ github.event.head_commit.timestamp || github.event.repository.updated_at }}
 
+  build-frontend:
+    name: Build Frontend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Set up buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate protobuf TypeScript clients
+        working-directory: frontend
+        run: npx buf generate --template buf.gen.yaml ../api/proto
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        env:
+          VITE_API_BASE_URL: https://demo.meridianhub.cloud
+          VITE_DEMO_MODE: "true"
+        run: npm run build
+
+      - name: Upload frontend artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist/
+          retention-days: 1
+
   deploy:
     name: Deploy to Demo Droplet
-    needs: build-and-push
+    needs: [build-and-push, build-frontend]
     runs-on: ubuntu-latest
     environment:
       name: demo
       url: https://demo.meridianhub.cloud
 
     steps:
+      - name: Download frontend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend-dist/
+
+      - name: Deploy frontend via SCP
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: root
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: "frontend-dist/*"
+          target: /opt/meridian/frontend/
+          strip_components: 1
+          overwrite: true
+
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.2.5
         with:

--- a/deploy/demo/.env.demo.example
+++ b/deploy/demo/.env.demo.example
@@ -67,9 +67,10 @@ HTTP_PORT=8090
 # Authentication (Dex OIDC)
 # ---------------------------------------------------------------------------
 
-# [OPTIONAL] Enable JWT authentication on the gateway (default: true with Dex).
-# Set to "false" to disable auth and leave the API completely open.
-AUTH_ENABLED=true
+# [OPTIONAL] Enable JWT authentication on the gateway.
+# Set to "false" for demo mode (API open, frontend uses local JWT for UI routing).
+# Set to "true" when Dex OIDC is fully configured with real credentials.
+AUTH_ENABLED=false
 
 # [OPTIONAL] JWKS endpoint for JWT validation.
 # Default points to the bundled Dex container.
@@ -154,6 +155,11 @@ MASTER_TENANT_ID=meridian_master
 # Frontend
 # ---------------------------------------------------------------------------
 
-# [REQUIRED] Public-facing base URL of the HTTP gateway, as seen by the browser.
-# Set to your Cloudflare proxied domain or the Droplet's public IP.
-VITE_API_BASE_URL=https://demo.meridian.example.com
+# The frontend SPA is built by CI and deployed to /opt/meridian/frontend/.
+# Caddy serves it as static files with SPA fallback (try_files → /index.html).
+# Vite-hashed assets (/assets/*) get immutable Cache-Control headers, which
+# Cloudflare CDN caches at the edge automatically via the proxied DNS record.
+#
+# VITE_API_BASE_URL is baked into the frontend at build time by CI.
+# VITE_DEMO_MODE enables demo login buttons on the login page.
+# No .env changes are needed on the droplet for the frontend itself.

--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -1,4 +1,26 @@
 demo.meridianhub.cloud, *.demo.meridianhub.cloud {
 	tls /etc/caddy/certs/origin-cert.pem /etc/caddy/certs/origin-key.pem
-	reverse_proxy meridian:8090
+
+	# Dex OIDC endpoints
+	handle /dex/* {
+		reverse_proxy dex:5556
+	}
+
+	# API: ConnectRPC + health probes
+	@api {
+		path /meridian.* /grpc.*
+		path /healthz /readyz
+	}
+	handle @api {
+		reverse_proxy meridian:8090
+	}
+
+	# Frontend: static files with SPA fallback
+	handle {
+		root * /var/www/html
+		@hashed path /assets/*
+		header @hashed Cache-Control "public, max-age=31536000, immutable"
+		try_files {path} /index.html
+		file_server
+	}
 }

--- a/deploy/demo/dex.yaml
+++ b/deploy/demo/dex.yaml
@@ -11,7 +11,7 @@
 #     -d "username=developer@meridian.local" \
 #     -d "password=<your-password>"
 
-issuer: http://dex:5556/dex
+issuer: https://demo.meridianhub.cloud/dex
 
 storage:
   type: sqlite3

--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -15,6 +15,7 @@
 #   /opt/meridian/.env            - Filled-in environment file
 #   /opt/meridian/Caddyfile       - Caddy configuration
 #   /opt/meridian/dex.yaml        - Dex OIDC configuration
+#   /opt/meridian/frontend/       - Built frontend static files (deployed by CI)
 #   /opt/meridian/certs/          - Cloudflare Origin Certificate files
 #     origin-cert.pem
 #     origin-key.pem
@@ -124,6 +125,7 @@ services:
     volumes:
       - /opt/meridian/Caddyfile:/etc/caddy/Caddyfile:ro
       - /opt/meridian/certs:/etc/caddy/certs:ro
+      - /opt/meridian/frontend:/var/www/html:ro
       - caddy_data:/data
       - caddy_config:/config
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -81,10 +81,10 @@ function LoginPage() {
           <h1 className="text-2xl font-semibold">Meridian Operations Console</h1>
           <p className="mt-2 text-muted-foreground">Please sign in to continue.</p>
         </div>
-        {import.meta.env.DEV && (
+        {(import.meta.env.DEV || import.meta.env.VITE_DEMO_MODE === 'true') && (
           <div className="space-y-2">
             <p className="text-xs text-muted-foreground uppercase tracking-wider">
-              Development Login
+              {import.meta.env.DEV ? 'Development Login' : 'Demo Login'}
             </p>
             <div className="flex gap-2 justify-center">
               <button
@@ -248,7 +248,7 @@ function AuthenticatedApp() {
   return (
     <TenantProvider>
       <ApiClientBridge>
-        {import.meta.env.DEV && <DevTenantAutoSelector />}
+        {(import.meta.env.DEV || import.meta.env.VITE_DEMO_MODE === 'true') && <DevTenantAutoSelector />}
         <TooltipProvider>
           <BrowserRouter>
             <Routes>

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_AUTH_AUDIENCE: string
   readonly VITE_AUTH_CLIENT_ID: string
   readonly VITE_AUTH_DOMAIN: string
+  readonly VITE_DEMO_MODE: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

- Caddy serves the React SPA as static files with SPA fallback, routing `/dex/*` to Dex and `/meridian.*`, `/grpc.*`, `/healthz`, `/readyz` to the API backend
- CI builds the frontend in a parallel `build-frontend` job (Node 22 + buf + Vite) and SCPs `dist/` to the droplet
- Demo login buttons enabled via `VITE_DEMO_MODE` env var baked at build time, with `AUTH_ENABLED=false` on the backend
- Dex issuer updated to public URL (`https://demo.meridianhub.cloud/dex`) so tokens are valid when accessed externally
- Vite-hashed assets (`/assets/*`) get immutable `Cache-Control` headers, automatically cached by Cloudflare CDN

## Changes

| File | Change |
|------|--------|
| `deploy/demo/Caddyfile` | Route API/Dex to backends, serve frontend with SPA fallback + immutable cache headers |
| `deploy/demo/docker-compose.yml` | Mount `/opt/meridian/frontend` into Caddy |
| `.github/workflows/deploy-demo.yml` | Add `build-frontend` job, SCP artifact to droplet |
| `deploy/demo/.env.demo.example` | `AUTH_ENABLED=false`, updated frontend docs |
| `deploy/demo/dex.yaml` | Issuer → `https://demo.meridianhub.cloud/dex` |
| `frontend/src/App.tsx` | Show login buttons when `VITE_DEMO_MODE=true` |
| `frontend/src/vite-env.d.ts` | Add `VITE_DEMO_MODE` type |

## Test plan

- [ ] Push to `demo` branch — workflow builds frontend + backend in parallel, deploys both
- [ ] `https://demo.meridianhub.cloud` serves React SPA (login page)
- [ ] Click "Platform Admin" demo login — navigates to dashboard
- [ ] Dashboard API calls to `/meridian.*` proxied to backend
- [ ] `/healthz` returns 200
- [ ] Check Cloudflare analytics for `CF-Cache-Status: HIT` on `/assets/*`
- [ ] `/dex/.well-known/openid-configuration` returns Dex discovery doc