### PR TITLE
feat: Deploy config files via CI to prevent drift

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -108,7 +108,6 @@ jobs:
           export PATH="$PWD/node_modules/.bin:$PATH"
           buf generate --template buf.gen.yaml ../api/proto
 
-
       - name: Build frontend
         working-directory: frontend
         env:
@@ -132,6 +131,9 @@ jobs:
       url: https://demo.meridianhub.cloud
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Download frontend artifact
         uses: actions/download-artifact@v4
         with:
@@ -147,6 +149,17 @@ jobs:
           source: "frontend-dist/*"
           target: /opt/meridian/frontend/
           strip_components: 1
+          overwrite: true
+
+      - name: Deploy config files via SCP
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: root
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: "deploy/demo/Caddyfile,deploy/demo/docker-compose.yml,deploy/demo/dex.yaml"
+          target: /opt/meridian/
+          strip_components: 2
           overwrite: true
 
       - name: Deploy via SSH


### PR DESCRIPTION
## Summary

- Config files on the droplet (Caddyfile, docker-compose.yml, dex.yaml) were previously placed manually and would drift from the repo
- The deploy job now checks out the code and SCPs these three files to `/opt/meridian/` before restarting services
- Ensures config changes in the repo are applied automatically on deploy

## Changes

| File | Change |
|------|--------|
| `.github/workflows/deploy-demo.yml` | Add checkout step + SCP config files step in deploy job |

## Test plan

- [ ] Merge to develop, push to demo
- [ ] Verify `Caddyfile`, `docker-compose.yml`, `dex.yaml` on droplet match repo versions
- [ ] Health check passes, frontend still served correctly