### PR TITLE
feat: extend query key factories for new entity dialogs

### DIFF
--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -3,6 +3,7 @@
  *
  * Tenant-scoped keys include the tenantId to ensure cache isolation between tenants.
  * Platform-scoped keys are for platform-level data not tied to a specific tenant.
+ * Reference keys are for non-tenant-scoped reference/configuration data.
  */
 
 export const tenantKeys = {
@@ -27,6 +28,31 @@ export const tenantKeys = {
     [...tenantKeys.all(tenantId), 'payments'] as const,
   payment: (tenantId: string, paymentOrderId: string) =>
     [...tenantKeys.payments(tenantId), paymentOrderId] as const,
+
+  parties: (tenantId: string) =>
+    [...tenantKeys.all(tenantId), 'parties'] as const,
+  party: (tenantId: string, partyId: string) =>
+    [...tenantKeys.parties(tenantId), partyId] as const,
+  partyAssociations: (tenantId: string, partyId: string) =>
+    [...tenantKeys.party(tenantId, partyId), 'associations'] as const,
+
+  internalAccounts: (tenantId: string) =>
+    [...tenantKeys.all(tenantId), 'internal-accounts'] as const,
+  internalAccount: (tenantId: string, accountId: string) =>
+    [...tenantKeys.internalAccounts(tenantId), accountId] as const,
+
+  accountLiens: (tenantId: string, accountId: string) =>
+    [...tenantKeys.all(tenantId), 'liens', accountId] as const,
+
+  marketDataSets: (tenantId: string) =>
+    [...tenantKeys.all(tenantId), 'market-data', 'datasets'] as const,
+  marketDataSet: (tenantId: string, datasetCode: string) =>
+    [...tenantKeys.marketDataSets(tenantId), datasetCode] as const,
+
+  reconciliationRuns: (tenantId: string) =>
+    [...tenantKeys.all(tenantId), 'reconciliation-runs'] as const,
+  reconciliationRun: (tenantId: string, runId: string) =>
+    [...tenantKeys.reconciliationRuns(tenantId), runId] as const,
 } as const
 
 export const platformKeys = {
@@ -45,4 +71,24 @@ export const manifestKeys = {
   current: () => [...manifestKeys.all, 'current'] as const,
   history: () => [...manifestKeys.all, 'history'] as const,
   version: (version: string) => [...manifestKeys.all, 'version', version] as const,
+} as const
+
+export const referenceKeys = {
+  all: ['reference'] as const,
+
+  partyTypes: () => [...referenceKeys.all, 'party-types'] as const,
+
+  instruments: () => [...referenceKeys.all, 'instruments'] as const,
+
+  accountTypes: () => [...referenceKeys.all, 'account-types'] as const,
+
+  nodes: () => [...referenceKeys.all, 'nodes'] as const,
+  nodeChildren: (parentId: string) =>
+    [...referenceKeys.nodes(), 'children', parentId] as const,
+
+  sagas: () => [...referenceKeys.all, 'sagas'] as const,
+  saga: (sagaId: string) => [...referenceKeys.sagas(), sagaId] as const,
+
+  mappings: () => [...referenceKeys.all, 'mappings'] as const,
+  mapping: (mappingId: string) => [...referenceKeys.mappings(), mappingId] as const,
 } as const

--- a/frontend/src/test/query-keys.test.ts
+++ b/frontend/src/test/query-keys.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { tenantKeys, platformKeys } from '@/lib/query-keys'
+import { tenantKeys, platformKeys, referenceKeys } from '@/lib/query-keys'
 
 describe('tenantKeys', () => {
   const tenantId = 'tenant-abc'
@@ -56,6 +56,96 @@ describe('tenantKeys', () => {
     const keyB = tenantKeys.accounts('tenant-b')
     expect(keyA).not.toEqual(keyB)
   })
+
+  // Parties
+  it('parties is scoped under tenant', () => {
+    expect(tenantKeys.parties(tenantId)).toEqual(['tenants', tenantId, 'parties'])
+  })
+
+  it('party includes partyId', () => {
+    expect(tenantKeys.party(tenantId, 'party-1')).toEqual([
+      'tenants',
+      tenantId,
+      'parties',
+      'party-1',
+    ])
+  })
+
+  it('partyAssociations is scoped under party', () => {
+    expect(tenantKeys.partyAssociations(tenantId, 'party-1')).toEqual([
+      'tenants',
+      tenantId,
+      'parties',
+      'party-1',
+      'associations',
+    ])
+  })
+
+  // Internal Accounts
+  it('internalAccounts is scoped under tenant', () => {
+    expect(tenantKeys.internalAccounts(tenantId)).toEqual([
+      'tenants',
+      tenantId,
+      'internal-accounts',
+    ])
+  })
+
+  it('internalAccount includes accountId', () => {
+    expect(tenantKeys.internalAccount(tenantId, 'ia-1')).toEqual([
+      'tenants',
+      tenantId,
+      'internal-accounts',
+      'ia-1',
+    ])
+  })
+
+  // Liens
+  it('accountLiens is scoped under tenant with accountId', () => {
+    expect(tenantKeys.accountLiens(tenantId, 'acc-1')).toEqual([
+      'tenants',
+      tenantId,
+      'liens',
+      'acc-1',
+    ])
+  })
+
+  // Market Data
+  it('marketDataSets is scoped under tenant', () => {
+    expect(tenantKeys.marketDataSets(tenantId)).toEqual([
+      'tenants',
+      tenantId,
+      'market-data',
+      'datasets',
+    ])
+  })
+
+  it('marketDataSet includes datasetCode', () => {
+    expect(tenantKeys.marketDataSet(tenantId, 'ds-1')).toEqual([
+      'tenants',
+      tenantId,
+      'market-data',
+      'datasets',
+      'ds-1',
+    ])
+  })
+
+  // Reconciliation Runs
+  it('reconciliationRuns is scoped under tenant', () => {
+    expect(tenantKeys.reconciliationRuns(tenantId)).toEqual([
+      'tenants',
+      tenantId,
+      'reconciliation-runs',
+    ])
+  })
+
+  it('reconciliationRun includes runId', () => {
+    expect(tenantKeys.reconciliationRun(tenantId, 'run-1')).toEqual([
+      'tenants',
+      tenantId,
+      'reconciliation-runs',
+      'run-1',
+    ])
+  })
 })
 
 describe('platformKeys', () => {
@@ -77,5 +167,52 @@ describe('platformKeys', () => {
 
   it('metrics is scoped under platform', () => {
     expect(platformKeys.metrics()).toEqual(['platform', 'metrics'])
+  })
+})
+
+describe('referenceKeys', () => {
+  it('all is the base reference key', () => {
+    expect(referenceKeys.all).toEqual(['reference'])
+  })
+
+  it('partyTypes is scoped under reference', () => {
+    expect(referenceKeys.partyTypes()).toEqual(['reference', 'party-types'])
+  })
+
+  it('instruments is scoped under reference', () => {
+    expect(referenceKeys.instruments()).toEqual(['reference', 'instruments'])
+  })
+
+  it('accountTypes is scoped under reference', () => {
+    expect(referenceKeys.accountTypes()).toEqual(['reference', 'account-types'])
+  })
+
+  it('nodes is scoped under reference', () => {
+    expect(referenceKeys.nodes()).toEqual(['reference', 'nodes'])
+  })
+
+  it('nodeChildren includes parentId', () => {
+    expect(referenceKeys.nodeChildren('parent-1')).toEqual([
+      'reference',
+      'nodes',
+      'children',
+      'parent-1',
+    ])
+  })
+
+  it('sagas is scoped under reference', () => {
+    expect(referenceKeys.sagas()).toEqual(['reference', 'sagas'])
+  })
+
+  it('saga includes sagaId', () => {
+    expect(referenceKeys.saga('saga-1')).toEqual(['reference', 'sagas', 'saga-1'])
+  })
+
+  it('mappings is scoped under reference', () => {
+    expect(referenceKeys.mappings()).toEqual(['reference', 'mappings'])
+  })
+
+  it('mapping includes mappingId', () => {
+    expect(referenceKeys.mapping('map-1')).toEqual(['reference', 'mappings', 'map-1'])
   })
 })


### PR DESCRIPTION
## Summary

- Adds tenant-scoped query key factories for parties, party associations, internal accounts, liens, market data sets, and reconciliation runs to `tenantKeys`
- Introduces a new `referenceKeys` export for non-tenant-scoped reference data: party types, instruments, account types, nodes (with children), sagas, and mappings
- Adds 20 new unit tests covering all new key factories (33 total, all passing)

## Changes Made

**`frontend/src/lib/query-keys.ts`**
- Extended `tenantKeys` with: `parties`, `party`, `partyAssociations`, `internalAccounts`, `internalAccount`, `accountLiens`, `marketDataSets`, `marketDataSet`, `reconciliationRuns`, `reconciliationRun`
- Added new `referenceKeys` export with: `all`, `partyTypes`, `instruments`, `accountTypes`, `nodes`, `nodeChildren`, `sagas`, `saga`, `mappings`, `mapping`

**`frontend/src/test/query-keys.test.ts`**
- Added tests for all new tenant-scoped key factories
- Added `referenceKeys` describe block with tests for all reference key factories

## Test plan

- [x] All 33 query-key unit tests pass
- [x] Full test suite passes (1173 tests across 97 files)
- [x] Key hierarchy verified: tenant isolation confirmed (different tenantIds produce different keys)