### PR TITLE
feat: add structured error formatter for MCP server

### DIFF
--- a/services/mcp-server/internal/errors/formatter.go
+++ b/services/mcp-server/internal/errors/formatter.go
@@ -1,0 +1,338 @@
+// Package mcperrors provides structured error formatting for the MCP server.
+// It transforms gRPC errors and validation failures into structured JSON with
+// line numbers, suggestions, and actionable feedback for the Write-Validate-Fix loop.
+package mcperrors
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"google.golang.org/grpc/status"
+)
+
+// Error type constants identify the source of a formatted error.
+const (
+	// TypeCELCompilation is produced by CEL expression compilation failures.
+	TypeCELCompilation = "cel_compilation"
+	// TypeStarlarkSyntax is produced by Starlark script parsing or execution failures.
+	TypeStarlarkSyntax = "starlark_syntax"
+	// TypeManifestValidation is produced by manifest structural or proto validation.
+	TypeManifestValidation = "manifest_validation"
+	// TypeProtoValidation is produced by protovalidate field constraint violations.
+	TypeProtoValidation = "proto_validation"
+	// TypeGeneric is used when the error type cannot be determined.
+	TypeGeneric = "generic"
+)
+
+// ErrorDetail describes a single error with structured location and suggestion data.
+type ErrorDetail struct {
+	// Type categorizes the error source (cel_compilation, starlark_syntax, etc.).
+	Type string `json:"type"`
+	// Line is the 1-based source line number, when available.
+	Line int `json:"line,omitempty"`
+	// Column is the 1-based source column number, when available.
+	Column int `json:"column,omitempty"`
+	// Message is a human-readable description of the issue.
+	Message string `json:"message"`
+	// Suggestion is an optional "Did you mean...?" hint for typos.
+	Suggestion string `json:"suggestion,omitempty"`
+	// Path is the dotted field path within a manifest (e.g., "instruments[0].code").
+	Path string `json:"path,omitempty"`
+}
+
+// FormattedError is the top-level response returned by FormatGRPCError.
+type FormattedError struct {
+	// Valid is true when there are no errors.
+	Valid bool `json:"valid"`
+	// Errors contains all extracted error details.
+	Errors []ErrorDetail `json:"errors,omitempty"`
+}
+
+// knownServiceBindings lists Starlark service modules injected by the saga runtime.
+var knownServiceBindings = []string{
+	"position_keeping",
+	"financial_accounting",
+	"current_account",
+	"valuation_engine",
+	"repository",
+	"notification",
+	"payment_order",
+	"reconciliation",
+	"reference_data",
+}
+
+// knownStarlarkBuiltins lists the top-level names available in saga Starlark scripts.
+var knownStarlarkBuiltins = []string{
+	"input_data",
+	"invoke_handler",
+	"party_scope",
+	"Decimal",
+	"print",
+	"len",
+	"range",
+	"str",
+	"int",
+	"float",
+	"bool",
+	"list",
+	"dict",
+	"tuple",
+	"type",
+	"True",
+	"False",
+	"None",
+	"hasattr",
+	"getattr",
+	"enumerate",
+	"zip",
+	"sorted",
+	"reversed",
+	"min",
+	"max",
+	"any",
+	"all",
+	"hash",
+	"repr",
+	"fail",
+}
+
+// celAvailableFields lists the CEL variable names commonly available in account-type policy expressions.
+var celAvailableFields = []string{
+	"quantity",
+	"instrument",
+	"bucket_id",
+	"as_of",
+	"amount",
+	"instrument_code",
+	"attributes",
+	"payload",
+	"value",
+	"party_type",
+}
+
+// celErrorPattern matches CEL error messages like "ERROR: :1:15: message".
+// Group 1 = line, Group 2 = column, Group 3 = message.
+var celErrorPattern = regexp.MustCompile(`ERROR:\s*[^:]*:(\d+):(\d+):\s*(.+)`)
+
+// starlarkErrorPattern matches Starlark error locations like "file.star:5:10: message".
+// Group 1 = line, Group 2 = column, Group 3 = message.
+var starlarkErrorPattern = regexp.MustCompile(`[^:]*\.star:(\d+):(\d+):\s*(.+)`)
+
+// undeclaredReferencePattern matches "undeclared reference to 'name'".
+var undeclaredReferencePattern = regexp.MustCompile(`undeclared reference to '([^']+)'`)
+
+// undefinedNamePattern matches "undefined: name".
+var undefinedNamePattern = regexp.MustCompile(`undefined:\s*(\S+)`)
+
+// validationJSONPattern matches the JSON array embedded in manifest validation error messages.
+// The control-plane grpc_handler embeds validation errors as JSON in the message.
+var validationJSONPattern = regexp.MustCompile(`\[(\{.+})\]`)
+
+// manifestValidationEntry is used to deserialise JSON embedded in manifest validation errors.
+type manifestValidationEntry struct {
+	Severity   string `json:"severity"`
+	Path       string `json:"path"`
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	Suggestion string `json:"suggestion,omitempty"`
+}
+
+// FormatGRPCError formats a gRPC (or plain) error into a structured FormattedError.
+// It detects the error type from the message content and delegates to the
+// appropriate parser, enriching the result with line numbers and suggestions.
+func FormatGRPCError(err error) FormattedError {
+	if err == nil {
+		return FormattedError{Valid: true}
+	}
+
+	msg := extractMessage(err)
+
+	switch {
+	case isCELError(msg):
+		return FormattedError{Valid: false, Errors: parseCELError(msg)}
+	case isStarlarkError(msg):
+		return FormattedError{Valid: false, Errors: parseStarlarkError(msg)}
+	case isManifestValidationError(msg):
+		return FormattedError{Valid: false, Errors: parseManifestValidationError(msg)}
+	default:
+		return FormattedError{
+			Valid: false,
+			Errors: []ErrorDetail{
+				{Type: TypeGeneric, Message: msg},
+			},
+		}
+	}
+}
+
+// extractMessage returns the underlying error message regardless of whether
+// the error is a gRPC status error or a plain error.
+func extractMessage(err error) string {
+	if st, ok := status.FromError(err); ok {
+		return st.Message()
+	}
+	return err.Error()
+}
+
+// isCELError returns true when the message looks like a CEL compilation error.
+func isCELError(msg string) bool {
+	lower := strings.ToLower(msg)
+	return strings.Contains(lower, "cel") && strings.Contains(msg, "ERROR:")
+}
+
+// isStarlarkError returns true when the message looks like a Starlark error.
+func isStarlarkError(msg string) bool {
+	lower := strings.ToLower(msg)
+	return strings.Contains(lower, "starlark") || strings.Contains(msg, ".star:")
+}
+
+// isManifestValidationError returns true when the message embeds a JSON validation array.
+func isManifestValidationError(msg string) bool {
+	return strings.Contains(msg, "manifest validation") ||
+		validationJSONPattern.MatchString(msg)
+}
+
+// parseCELError parses a CEL compilation error message.
+// CEL errors look like: "cel compilation failed: ERROR: :1:15: undeclared reference to 'atributes'"
+func parseCELError(msg string) []ErrorDetail {
+	detail := ErrorDetail{Type: TypeCELCompilation, Message: msg}
+
+	if m := celErrorPattern.FindStringSubmatch(msg); m != nil {
+		detail.Line, _ = strconv.Atoi(m[1])
+		detail.Column, _ = strconv.Atoi(m[2])
+		detail.Message = strings.TrimSpace(m[3])
+	}
+
+	// Typo suggestion for undeclared references.
+	if m := undeclaredReferencePattern.FindStringSubmatch(msg); m != nil {
+		if suggestion := findClosestMatch(m[1], celAvailableFields); suggestion != "" {
+			detail.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+		}
+	}
+
+	return []ErrorDetail{detail}
+}
+
+// parseStarlarkError parses a Starlark compilation or execution error.
+// Starlark errors look like: "transfer.star:5:10: got end of file, want expression"
+func parseStarlarkError(msg string) []ErrorDetail {
+	detail := ErrorDetail{Type: TypeStarlarkSyntax, Message: msg}
+
+	if m := starlarkErrorPattern.FindStringSubmatch(msg); m != nil {
+		detail.Line, _ = strconv.Atoi(m[1])
+		detail.Column, _ = strconv.Atoi(m[2])
+		detail.Message = strings.TrimSpace(m[3])
+	}
+
+	// Suggestion for undefined names.
+	if m := undefinedNamePattern.FindStringSubmatch(msg); m != nil {
+		allNames := make([]string, 0, len(knownServiceBindings)+len(knownStarlarkBuiltins))
+		allNames = append(allNames, knownServiceBindings...)
+		allNames = append(allNames, knownStarlarkBuiltins...)
+		if suggestion := findClosestMatch(m[1], allNames); suggestion != "" {
+			detail.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+		}
+	}
+
+	return []ErrorDetail{detail}
+}
+
+// parseManifestValidationError extracts structured validation errors embedded as JSON
+// in the gRPC error message by the control-plane ApplyManifestHandler.
+func parseManifestValidationError(msg string) []ErrorDetail {
+	// Try to extract JSON array from the message.
+	if m := validationJSONPattern.FindStringSubmatch(msg); m != nil {
+		jsonBytes := []byte("[" + m[1] + "]")
+		var entries []manifestValidationEntry
+		if err := json.Unmarshal(jsonBytes, &entries); err == nil && len(entries) > 0 {
+			details := make([]ErrorDetail, 0, len(entries))
+			for _, e := range entries {
+				detail := ErrorDetail{
+					Type:       TypeManifestValidation,
+					Message:    e.Message,
+					Path:       e.Path,
+					Suggestion: e.Suggestion,
+				}
+				details = append(details, detail)
+			}
+			return details
+		}
+	}
+
+	// Fallback: return as a single generic manifest validation error.
+	return []ErrorDetail{
+		{Type: TypeManifestValidation, Message: msg},
+	}
+}
+
+// findClosestMatch returns the candidate from candidates that has the smallest
+// Levenshtein distance to target, provided the distance is within half of
+// the target length. Returns empty string if no suitable match is found.
+func findClosestMatch(target string, candidates []string) string {
+	if len(candidates) == 0 || target == "" {
+		return ""
+	}
+
+	bestMatch := ""
+	threshold := len(target)/2 + 1
+
+	for _, candidate := range candidates {
+		dist := levenshteinDistance(strings.ToLower(target), strings.ToLower(candidate))
+		if dist < threshold {
+			threshold = dist
+			bestMatch = candidate
+		}
+	}
+
+	return bestMatch
+}
+
+// levenshteinDistance computes the edit distance between two strings.
+func levenshteinDistance(a, b string) int {
+	la := len(a)
+	lb := len(b)
+
+	if la > lb {
+		a, b = b, a
+		la, lb = lb, la
+	}
+
+	prev := make([]int, la+1)
+	curr := make([]int, la+1)
+
+	for i := range prev {
+		prev[i] = i
+	}
+
+	for j := 1; j <= lb; j++ {
+		curr[0] = j
+		for i := 1; i <= la; i++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			del := prev[i] + 1
+			ins := curr[i-1] + 1
+			sub := prev[i-1] + cost
+			curr[i] = min3(del, ins, sub)
+		}
+		prev, curr = curr, prev
+	}
+
+	return prev[la]
+}
+
+func min3(a, b, c int) int {
+	if a < b {
+		if a < c {
+			return a
+		}
+		return c
+	}
+	if b < c {
+		return b
+	}
+	return c
+}

--- a/services/mcp-server/internal/errors/formatter.go
+++ b/services/mcp-server/internal/errors/formatter.go
@@ -286,13 +286,14 @@ func findClosestMatch(target string, candidates []string) string {
 		return ""
 	}
 
+	maxAllowed := len(target)/2 + 1
+	bestDist := maxAllowed
 	bestMatch := ""
-	threshold := len(target)/2 + 1
 
 	for _, candidate := range candidates {
 		dist := levenshteinDistance(strings.ToLower(target), strings.ToLower(candidate))
-		if dist < threshold {
-			threshold = dist
+		if dist < bestDist {
+			bestDist = dist
 			bestMatch = candidate
 		}
 	}
@@ -327,23 +328,10 @@ func levenshteinDistance(a, b string) int {
 			del := prev[i] + 1
 			ins := curr[i-1] + 1
 			sub := prev[i-1] + cost
-			curr[i] = min3(del, ins, sub)
+			curr[i] = min(del, min(ins, sub))
 		}
 		prev, curr = curr, prev
 	}
 
 	return prev[la]
-}
-
-func min3(a, b, c int) int {
-	if a < b {
-		if a < c {
-			return a
-		}
-		return c
-	}
-	if b < c {
-		return b
-	}
-	return c
 }

--- a/services/mcp-server/internal/errors/formatter.go
+++ b/services/mcp-server/internal/errors/formatter.go
@@ -21,8 +21,6 @@ const (
 	TypeStarlarkSyntax = "starlark_syntax"
 	// TypeManifestValidation is produced by manifest structural or proto validation.
 	TypeManifestValidation = "manifest_validation"
-	// TypeProtoValidation is produced by protovalidate field constraint violations.
-	TypeProtoValidation = "proto_validation"
 	// TypeGeneric is used when the error type cannot be determined.
 	TypeGeneric = "generic"
 )
@@ -99,7 +97,7 @@ var knownStarlarkBuiltins = []string{
 	"fail",
 }
 
-// celAvailableFields lists the CEL variable names commonly available in account-type policy expressions.
+// celAvailableFields lists the CEL variable names commonly available in policy expressions.
 var celAvailableFields = []string{
 	"quantity",
 	"instrument",
@@ -113,9 +111,9 @@ var celAvailableFields = []string{
 	"party_type",
 }
 
-// celErrorPattern matches CEL error messages like "ERROR: :1:15: message".
-// Group 1 = line, Group 2 = column, Group 3 = message.
-var celErrorPattern = regexp.MustCompile(`ERROR:\s*[^:]*:(\d+):(\d+):\s*(.+)`)
+// celErrorPattern matches a single CEL error line: "ERROR: :1:15: message".
+// Group 1 = line, Group 2 = column, Group 3 = message (to end of line).
+var celErrorPattern = regexp.MustCompile(`ERROR:\s*[^:]*:(\d+):(\d+):\s*([^\n]+)`)
 
 // starlarkErrorPattern matches Starlark error locations like "file.star:5:10: message".
 // Group 1 = line, Group 2 = column, Group 3 = message.
@@ -127,9 +125,9 @@ var undeclaredReferencePattern = regexp.MustCompile(`undeclared reference to '([
 // undefinedNamePattern matches "undefined: name".
 var undefinedNamePattern = regexp.MustCompile(`undefined:\s*(\S+)`)
 
-// validationJSONPattern matches the JSON array embedded in manifest validation error messages.
-// The control-plane grpc_handler embeds validation errors as JSON in the message.
-var validationJSONPattern = regexp.MustCompile(`\[(\{.+})\]`)
+// validationJSONArrayPattern matches a JSON array at the end of a validation error message.
+// It looks for a top-level JSON array starting at '[' and captures everything to the end.
+var validationJSONArrayPattern = regexp.MustCompile(`(\[[\s\S]*\])$`)
 
 // manifestValidationEntry is used to deserialise JSON embedded in manifest validation errors.
 type manifestValidationEntry struct {
@@ -177,9 +175,14 @@ func extractMessage(err error) string {
 }
 
 // isCELError returns true when the message looks like a CEL compilation error.
+// It requires both a CEL-context keyword and the canonical "ERROR:" marker that
+// the CEL library emits, avoiding false positives from words like "cancel".
 func isCELError(msg string) bool {
 	lower := strings.ToLower(msg)
-	return strings.Contains(lower, "cel") && strings.Contains(msg, "ERROR:")
+	hasCELContext := strings.Contains(lower, "cel compilation") ||
+		strings.Contains(lower, "cel expression") ||
+		strings.Contains(lower, "cel error")
+	return hasCELContext && strings.Contains(msg, "ERROR:")
 }
 
 // isStarlarkError returns true when the message looks like a Starlark error.
@@ -190,29 +193,39 @@ func isStarlarkError(msg string) bool {
 
 // isManifestValidationError returns true when the message embeds a JSON validation array.
 func isManifestValidationError(msg string) bool {
-	return strings.Contains(msg, "manifest validation") ||
-		validationJSONPattern.MatchString(msg)
+	lower := strings.ToLower(msg)
+	return strings.Contains(lower, "manifest validation") ||
+		validationJSONArrayPattern.MatchString(msg)
 }
 
-// parseCELError parses a CEL compilation error message.
-// CEL errors look like: "cel compilation failed: ERROR: :1:15: undeclared reference to 'atributes'"
+// parseCELError parses a CEL compilation error message, extracting all error occurrences.
+// CEL errors look like: "cel compilation failed: ERROR: :1:15: undeclared reference to 'x'"
+// Multiple errors may appear on separate lines (one ERROR: prefix per error).
 func parseCELError(msg string) []ErrorDetail {
-	detail := ErrorDetail{Type: TypeCELCompilation, Message: msg}
+	matches := celErrorPattern.FindAllStringSubmatch(msg, -1)
+	if len(matches) == 0 {
+		// No structured CEL error found: return raw message.
+		return []ErrorDetail{{Type: TypeCELCompilation, Message: msg}}
+	}
 
-	if m := celErrorPattern.FindStringSubmatch(msg); m != nil {
+	details := make([]ErrorDetail, 0, len(matches))
+	for _, m := range matches {
+		detail := ErrorDetail{
+			Type:    TypeCELCompilation,
+			Message: strings.TrimSpace(m[3]),
+		}
 		detail.Line, _ = strconv.Atoi(m[1])
 		detail.Column, _ = strconv.Atoi(m[2])
-		detail.Message = strings.TrimSpace(m[3])
-	}
 
-	// Typo suggestion for undeclared references.
-	if m := undeclaredReferencePattern.FindStringSubmatch(msg); m != nil {
-		if suggestion := findClosestMatch(m[1], celAvailableFields); suggestion != "" {
-			detail.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+		// Typo suggestion scoped to this error's message fragment.
+		if ref := undeclaredReferencePattern.FindStringSubmatch(m[3]); ref != nil {
+			if suggestion := findClosestMatch(ref[1], celAvailableFields); suggestion != "" {
+				detail.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+			}
 		}
+		details = append(details, detail)
 	}
-
-	return []ErrorDetail{detail}
+	return details
 }
 
 // parseStarlarkError parses a Starlark compilation or execution error.
@@ -242,26 +255,24 @@ func parseStarlarkError(msg string) []ErrorDetail {
 // parseManifestValidationError extracts structured validation errors embedded as JSON
 // in the gRPC error message by the control-plane ApplyManifestHandler.
 func parseManifestValidationError(msg string) []ErrorDetail {
-	// Try to extract JSON array from the message.
-	if m := validationJSONPattern.FindStringSubmatch(msg); m != nil {
-		jsonBytes := []byte("[" + m[1] + "]")
+	// Try to extract the trailing JSON array from the message.
+	if m := validationJSONArrayPattern.FindString(msg); m != "" {
 		var entries []manifestValidationEntry
-		if err := json.Unmarshal(jsonBytes, &entries); err == nil && len(entries) > 0 {
+		if err := json.Unmarshal([]byte(m), &entries); err == nil && len(entries) > 0 {
 			details := make([]ErrorDetail, 0, len(entries))
 			for _, e := range entries {
-				detail := ErrorDetail{
+				details = append(details, ErrorDetail{
 					Type:       TypeManifestValidation,
 					Message:    e.Message,
 					Path:       e.Path,
 					Suggestion: e.Suggestion,
-				}
-				details = append(details, detail)
+				})
 			}
 			return details
 		}
 	}
 
-	// Fallback: return as a single generic manifest validation error.
+	// Fallback: return as a single manifest validation error.
 	return []ErrorDetail{
 		{Type: TypeManifestValidation, Message: msg},
 	}

--- a/services/mcp-server/internal/errors/formatter_test.go
+++ b/services/mcp-server/internal/errors/formatter_test.go
@@ -40,26 +40,6 @@ func TestFormatGRPCError_CELCompilationError(t *testing.T) {
 	}
 }
 
-// TestFormatGRPCError_CELTypo verifies that a typo in CEL produces a suggestion.
-func TestFormatGRPCError_CELTypo(t *testing.T) {
-	grpcErr := status.Errorf(codes.InvalidArgument,
-		"cel compilation failed: ERROR: :1:1: undeclared reference to 'ammount'")
-
-	result := mcperrors.FormatGRPCError(grpcErr)
-
-	if result.Valid {
-		t.Fatal("expected Valid=false")
-	}
-	if len(result.Errors) == 0 {
-		t.Fatal("expected at least one error")
-	}
-
-	detail := result.Errors[0]
-	if detail.Suggestion == "" {
-		t.Error("expected a typo suggestion for 'ammount'")
-	}
-}
-
 // TestFormatGRPCError_StarlarkSyntaxError verifies Starlark syntax errors are parsed.
 func TestFormatGRPCError_StarlarkSyntaxError(t *testing.T) {
 	grpcErr := status.Errorf(codes.InvalidArgument,
@@ -149,8 +129,10 @@ func TestFormatGRPCError_TypoSuggestions(t *testing.T) {
 		typo       string
 		suggestion string
 	}{
-		{"atributes", "attributes"}, //nolint:misspell // intentional typo for testing
-		{"ammount", "amount"},       //nolint:misspell // intentional typo for testing
+		{"atributes", "attributes"},   //nolint:misspell // intentional typo for testing
+		{"ammount", "amount"},         //nolint:misspell // intentional typo for testing
+		{"instruement", "instrument"}, //nolint:misspell // intentional typo for testing
+		{"bukket_id", "bucket_id"},    //nolint:misspell // intentional typo for testing
 	}
 
 	for _, tc := range tests {
@@ -228,7 +210,7 @@ func TestFormatGRPCError_MultipleCELErrors(t *testing.T) {
 	}
 }
 
-// TestFormatError_PlainError verifies that a plain (non-gRPC) error is also handled.
+// TestFormatError_PlainError verifies that a plain (non-gRPC) error is handled as TypeGeneric.
 func TestFormatError_PlainError(t *testing.T) {
 	err := fmt.Errorf("some plain error")
 
@@ -239,5 +221,9 @@ func TestFormatError_PlainError(t *testing.T) {
 	}
 	if len(result.Errors) == 0 {
 		t.Fatal("expected at least one error")
+	}
+	detail := result.Errors[0]
+	if detail.Type != mcperrors.TypeGeneric {
+		t.Errorf("expected type %q for plain error, got %q", mcperrors.TypeGeneric, detail.Type)
 	}
 }

--- a/services/mcp-server/internal/errors/formatter_test.go
+++ b/services/mcp-server/internal/errors/formatter_test.go
@@ -1,0 +1,221 @@
+package mcperrors_test
+
+import (
+	"fmt"
+	"testing"
+
+	mcperrors "github.com/meridianhub/meridian/services/mcp-server/internal/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestFormatGRPCError_CELCompilationError verifies that a gRPC error carrying
+// a CEL compilation message is parsed and line/column are extracted.
+func TestFormatGRPCError_CELCompilationError(t *testing.T) {
+	// CEL errors have the format: "ERROR: :1:15: undeclared reference to 'atributes'\n | ...\n | ..."
+	grpcErr := status.Errorf(codes.InvalidArgument,
+		"cel compilation failed: ERROR: :1:15: undeclared reference to 'atributes'")
+
+	result := mcperrors.FormatGRPCError(grpcErr)
+
+	if result.Valid {
+		t.Fatal("expected Valid=false for error response")
+	}
+	if len(result.Errors) == 0 {
+		t.Fatal("expected at least one error detail")
+	}
+
+	detail := result.Errors[0]
+	if detail.Type != mcperrors.TypeCELCompilation {
+		t.Errorf("expected type %q, got %q", mcperrors.TypeCELCompilation, detail.Type)
+	}
+	if detail.Line != 1 {
+		t.Errorf("expected Line=1, got %d", detail.Line)
+	}
+	if detail.Column != 15 {
+		t.Errorf("expected Column=15, got %d", detail.Column)
+	}
+	if detail.Message == "" {
+		t.Error("expected non-empty message")
+	}
+}
+
+// TestFormatGRPCError_CELTypo verifies that a typo in CEL produces a suggestion.
+func TestFormatGRPCError_CELTypo(t *testing.T) {
+	grpcErr := status.Errorf(codes.InvalidArgument,
+		"cel compilation failed: ERROR: :1:1: undeclared reference to 'ammount'")
+
+	result := mcperrors.FormatGRPCError(grpcErr)
+
+	if result.Valid {
+		t.Fatal("expected Valid=false")
+	}
+	if len(result.Errors) == 0 {
+		t.Fatal("expected at least one error")
+	}
+
+	detail := result.Errors[0]
+	if detail.Suggestion == "" {
+		t.Error("expected a typo suggestion for 'ammount'")
+	}
+}
+
+// TestFormatGRPCError_StarlarkSyntaxError verifies Starlark syntax errors are parsed.
+func TestFormatGRPCError_StarlarkSyntaxError(t *testing.T) {
+	grpcErr := status.Errorf(codes.InvalidArgument,
+		"starlark compilation failed: transfer.star:5:10: got end of file, want expression")
+
+	result := mcperrors.FormatGRPCError(grpcErr)
+
+	if result.Valid {
+		t.Fatal("expected Valid=false")
+	}
+	if len(result.Errors) == 0 {
+		t.Fatal("expected at least one error")
+	}
+
+	detail := result.Errors[0]
+	if detail.Type != mcperrors.TypeStarlarkSyntax {
+		t.Errorf("expected type %q, got %q", mcperrors.TypeStarlarkSyntax, detail.Type)
+	}
+	if detail.Line != 5 {
+		t.Errorf("expected Line=5, got %d", detail.Line)
+	}
+	if detail.Column != 10 {
+		t.Errorf("expected Column=10, got %d", detail.Column)
+	}
+}
+
+// TestFormatGRPCError_ManifestValidation verifies protovalidate/manifest errors are parsed.
+func TestFormatGRPCError_ManifestValidation(t *testing.T) {
+	grpcErr := status.Errorf(codes.InvalidArgument,
+		`manifest validation failed: [{"severity":"error","path":"instruments[0].code","code":"PROTO_VALIDATION","message":"value is required"}]`)
+
+	result := mcperrors.FormatGRPCError(grpcErr)
+
+	if result.Valid {
+		t.Fatal("expected Valid=false")
+	}
+	if len(result.Errors) == 0 {
+		t.Fatal("expected at least one error")
+	}
+
+	detail := result.Errors[0]
+	if detail.Type != mcperrors.TypeManifestValidation {
+		t.Errorf("expected type %q, got %q", mcperrors.TypeManifestValidation, detail.Type)
+	}
+	if detail.Path != "instruments[0].code" {
+		t.Errorf("expected path %q, got %q", "instruments[0].code", detail.Path)
+	}
+}
+
+// TestFormatGRPCError_UnknownError verifies that an unrecognized error returns a generic structure.
+func TestFormatGRPCError_UnknownError(t *testing.T) {
+	grpcErr := status.Errorf(codes.Internal, "something went wrong internally")
+
+	result := mcperrors.FormatGRPCError(grpcErr)
+
+	if result.Valid {
+		t.Fatal("expected Valid=false")
+	}
+	if len(result.Errors) == 0 {
+		t.Fatal("expected at least one error")
+	}
+
+	detail := result.Errors[0]
+	if detail.Type != mcperrors.TypeGeneric {
+		t.Errorf("expected type %q, got %q", mcperrors.TypeGeneric, detail.Type)
+	}
+	if detail.Message == "" {
+		t.Error("expected non-empty message")
+	}
+}
+
+// TestFormatGRPCError_NilError verifies that a nil error returns a valid result.
+func TestFormatGRPCError_NilError(t *testing.T) {
+	result := mcperrors.FormatGRPCError(nil)
+
+	if !result.Valid {
+		t.Fatal("expected Valid=true for nil error")
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("expected no errors, got %d", len(result.Errors))
+	}
+}
+
+// TestFormatGRPCError_TypoSuggestions verifies common typo suggestions are produced.
+func TestFormatGRPCError_TypoSuggestions(t *testing.T) {
+	tests := []struct {
+		typo       string
+		suggestion string
+	}{
+		{"atributes", "attributes"}, //nolint:misspell // intentional typo for testing
+		{"ammount", "amount"},       //nolint:misspell // intentional typo for testing
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.typo, func(t *testing.T) {
+			msg := fmt.Sprintf("cel compilation failed: ERROR: :1:1: undeclared reference to '%s'", tc.typo)
+			grpcErr := status.Error(codes.InvalidArgument, msg)
+
+			result := mcperrors.FormatGRPCError(grpcErr)
+			if len(result.Errors) == 0 {
+				t.Fatal("expected at least one error")
+			}
+			detail := result.Errors[0]
+			if detail.Suggestion == "" {
+				t.Errorf("expected suggestion for typo %q", tc.typo)
+			}
+		})
+	}
+}
+
+// TestFormatGRPCError_MultipleErrors verifies that multiple validation errors
+// in a JSON array are all extracted and returned.
+func TestFormatGRPCError_MultipleErrors(t *testing.T) {
+	grpcErr := status.Errorf(codes.InvalidArgument,
+		`manifest validation failed: [{"severity":"error","path":"instruments[0].code","code":"PROTO_VALIDATION","message":"value is required"},{"severity":"error","path":"account_types[0].code","code":"PROTO_VALIDATION","message":"value is required"}]`)
+
+	result := mcperrors.FormatGRPCError(grpcErr)
+
+	if result.Valid {
+		t.Fatal("expected Valid=false")
+	}
+	if len(result.Errors) != 2 {
+		t.Errorf("expected 2 errors, got %d", len(result.Errors))
+	}
+}
+
+// TestFormatGRPCError_StarlarkUndefinedName verifies undefined Starlark names produce suggestions.
+func TestFormatGRPCError_StarlarkUndefinedName(t *testing.T) {
+	grpcErr := status.Errorf(codes.InvalidArgument,
+		"starlark compilation failed: transfer.star:3:1: undefined: position_keepin")
+
+	result := mcperrors.FormatGRPCError(grpcErr)
+
+	if result.Valid {
+		t.Fatal("expected Valid=false")
+	}
+	if len(result.Errors) == 0 {
+		t.Fatal("expected at least one error")
+	}
+
+	detail := result.Errors[0]
+	if detail.Suggestion == "" {
+		t.Errorf("expected a suggestion for 'position_keepin'")
+	}
+}
+
+// TestFormatError_PlainError verifies that a plain (non-gRPC) error is also handled.
+func TestFormatError_PlainError(t *testing.T) {
+	err := fmt.Errorf("some plain error")
+
+	result := mcperrors.FormatGRPCError(err)
+
+	if result.Valid {
+		t.Fatal("expected Valid=false")
+	}
+	if len(result.Errors) == 0 {
+		t.Fatal("expected at least one error")
+	}
+}

--- a/services/mcp-server/internal/errors/formatter_test.go
+++ b/services/mcp-server/internal/errors/formatter_test.go
@@ -206,6 +206,28 @@ func TestFormatGRPCError_StarlarkUndefinedName(t *testing.T) {
 	}
 }
 
+// TestFormatGRPCError_MultipleCELErrors verifies that multiple CEL errors on separate
+// lines are all extracted rather than just the first one.
+func TestFormatGRPCError_MultipleCELErrors(t *testing.T) {
+	grpcErr := status.Error(codes.InvalidArgument,
+		"cel compilation failed: ERROR: :1:5: undeclared reference to 'ammount'\nERROR: :2:3: undeclared reference to 'atributes'")
+
+	result := mcperrors.FormatGRPCError(grpcErr)
+
+	if result.Valid {
+		t.Fatal("expected Valid=false")
+	}
+	if len(result.Errors) != 2 {
+		t.Errorf("expected 2 CEL errors, got %d", len(result.Errors))
+	}
+	if result.Errors[0].Line != 1 {
+		t.Errorf("expected first error Line=1, got %d", result.Errors[0].Line)
+	}
+	if result.Errors[1].Line != 2 {
+		t.Errorf("expected second error Line=2, got %d", result.Errors[1].Line)
+	}
+}
+
 // TestFormatError_PlainError verifies that a plain (non-gRPC) error is also handled.
 func TestFormatError_PlainError(t *testing.T) {
 	err := fmt.Errorf("some plain error")


### PR DESCRIPTION
## Summary

- Adds `services/mcp-server/internal/errors/` package (`mcperrors`) providing structured error formatting for the MCP server Write-Validate-Fix loop
- Transforms gRPC status errors and plain errors into `FormattedError{Valid, Errors[]ErrorDetail}` JSON with line/column numbers, field paths, and typo suggestions
- Standalone utility package with no dependencies on other mcp-server packages — consumed by tool handlers later

## Changes Made

**`services/mcp-server/internal/errors/formatter.go`**
- `FormattedError` and `ErrorDetail` structs with full JSON serialization
- `FormatGRPCError(err error) FormattedError` dispatcher: detects CEL, Starlark, manifest validation, or generic errors from message content
- CEL parser: extracts line/column from `ERROR: :line:col: message` format; Levenshtein-based typo suggestions against known CEL field names
- Starlark parser: extracts line/column from `file.star:line:col: message` format; suggestions against known service bindings and builtins
- Manifest validation parser: deserialises embedded JSON error arrays produced by the control-plane `ApplyManifestHandler`
- Levenshtein distance implementation for typo matching

**`services/mcp-server/internal/errors/formatter_test.go`**
- 10 unit tests covering all error types, typo suggestions, multiple errors, nil error, and plain error handling

## Technical Details

The package name is `mcperrors` (not `errors`) to avoid collision with the stdlib `errors` package. Error type constants are exported (`TypeCELCompilation`, `TypeStarlarkSyntax`, `TypeManifestValidation`, `TypeGeneric`) for use by tool handler tests.

Relates to Task Master mcp-server.5.