### PR TITLE
feat: add MCP server skeleton with transport layer

### DIFF
--- a/services/mcp-server/cmd/Dockerfile
+++ b/services/mcp-server/cmd/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /build
 
 # Copy go mod files first for better caching
-COPY go.mod go.sum* ./
+COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 
 # Copy source code

--- a/services/mcp-server/cmd/Dockerfile
+++ b/services/mcp-server/cmd/Dockerfile
@@ -1,0 +1,54 @@
+# MCP Server - Multi-Stage Dockerfile
+# Provides MCP (Model Context Protocol) interface for AI agent integration
+# Uses distroless base image for minimal attack surface
+
+# Build stage
+FROM golang:1.26.0-bookworm AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum* ./
+RUN go mod download && go mod verify
+
+# Copy source code
+COPY . .
+
+# Build static binary (no CGO required)
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} go build \
+    -ldflags="-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildDate=${BUILD_DATE}" \
+    -o mcp-server \
+    ./services/mcp-server/cmd
+
+# Verify the binary exists and is executable
+RUN test -x mcp-server && echo "Binary built successfully"
+
+# Runtime stage - distroless for minimal attack surface (~2MB base)
+FROM gcr.io/distroless/static-debian12
+
+# Copy timezone data from builder for time-sensitive operations
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Copy binary from builder
+COPY --from=builder /build/mcp-server /mcp-server
+
+# Use non-root user (distroless provides nonroot user at uid 65532)
+USER nonroot:nonroot
+
+# Expose SSE port (only used when MCP_TRANSPORT=sse)
+EXPOSE 8090
+
+# Run the binary
+ENTRYPOINT ["/mcp-server"]

--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -1,0 +1,156 @@
+// Package main is the entry point for the MCP server.
+// It supports stdio and SSE transports for Model Context Protocol communication.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/server"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/transport"
+	"github.com/meridianhub/meridian/shared/platform/bootstrap"
+	"github.com/meridianhub/meridian/shared/platform/env"
+)
+
+var errUnknownTransport = errors.New("unknown transport")
+
+// Build information set via ldflags during compilation.
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)
+
+func main() {
+	logLevel := parseLogLevel(os.Getenv("LOG_LEVEL"))
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevel,
+	}))
+	slog.SetDefault(logger)
+
+	logger.Info("starting mcp-server",
+		"version", Version,
+		"commit", Commit,
+		"build_date", BuildDate)
+
+	if err := run(logger); err != nil {
+		logger.Error("service failed", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("service stopped gracefully")
+}
+
+func run(logger *slog.Logger) error {
+	transportMode := env.GetEnvOrDefault("MCP_TRANSPORT", "stdio")
+	serverName := env.GetEnvOrDefault("MCP_SERVER_NAME", "meridian-mcp")
+
+	cfg := server.Config{
+		ServerName:    serverName,
+		ServerVersion: Version,
+	}
+
+	switch transportMode {
+	case "stdio":
+		return runStdio(logger, cfg)
+	case "sse":
+		return runSSE(logger, cfg)
+	default:
+		return bootstrap.Permanent(fmt.Errorf("%w: %s (expected stdio or sse)", errUnknownTransport, transportMode))
+	}
+}
+
+func runStdio(logger *slog.Logger, cfg server.Config) error {
+	logger.Info("using stdio transport")
+
+	tr := transport.NewStdioTransport(os.Stdin, os.Stdout)
+	defer tr.Close()
+
+	srv := server.New(tr, cfg, logger)
+
+	// For stdio, we run until stdin closes or we receive a signal.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigChan, signalCleanup := bootstrap.SignalHandler()
+	defer signalCleanup()
+
+	go func() {
+		<-sigChan
+		logger.Info("received shutdown signal")
+		cancel()
+	}()
+
+	return srv.Run(ctx)
+}
+
+func runSSE(logger *slog.Logger, cfg server.Config) error {
+	port := env.GetEnvOrDefault("MCP_SSE_PORT", "8090")
+	addr := fmt.Sprintf(":%s", port)
+
+	logger.Info("using SSE transport", "address", addr)
+
+	sseTr := transport.NewSSETransport(logger)
+	defer sseTr.Close()
+
+	srv := server.New(sseTr, cfg, logger)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sse", sseTr.HandleSSE)
+	mux.HandleFunc("/message", sseTr.HandleMessage)
+
+	httpServer := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+
+	// Start MCP server loop in background
+	serverErrors := bootstrap.ServerErrorChannel(2)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		if err := srv.Run(ctx); err != nil {
+			serverErrors <- fmt.Errorf("mcp server: %w", err)
+		}
+	}()
+
+	go func() {
+		logger.Info("HTTP server starting", "address", addr)
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErrors <- fmt.Errorf("http server: %w", err)
+		}
+	}()
+
+	// Wait for signal or error
+	sigChan, signalCleanup := bootstrap.SignalHandler()
+	defer signalCleanup()
+
+	if err := bootstrap.WaitForShutdownSignal(sigChan, serverErrors, logger); err != nil {
+		cancel()
+		_ = bootstrap.GracefulShutdown(context.Background(), logger, httpServer)
+		return err
+	}
+
+	cancel()
+	return bootstrap.GracefulShutdown(context.Background(), logger, httpServer)
+}
+
+// parseLogLevel converts a string log level to slog.Level.
+func parseLogLevel(levelStr string) slog.Level {
+	switch strings.ToLower(levelStr) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -84,9 +84,12 @@ func runStdio(logger *slog.Logger, cfg server.Config) error {
 	defer signalCleanup()
 
 	go func() {
-		<-sigChan
-		logger.Info("received shutdown signal")
-		cancel()
+		select {
+		case <-sigChan:
+			logger.Info("received shutdown signal")
+			cancel()
+		case <-ctx.Done():
+		}
 	}()
 
 	return srv.Run(ctx)
@@ -146,17 +149,16 @@ func runSSE(logger *slog.Logger, cfg server.Config) error {
 	sigChan, signalCleanup := bootstrap.SignalHandler()
 	defer signalCleanup()
 
+	serverErr := bootstrap.WaitForShutdownSignal(sigChan, serverErrors, logger)
+
+	// Create the shutdown context AFTER the signal/error arrives so the full
+	// timeout window is available for graceful drain.
+	cancel()
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer shutdownCancel()
 
-	if err := bootstrap.WaitForShutdownSignal(sigChan, serverErrors, logger); err != nil {
-		cancel()
-		_ = bootstrap.GracefulShutdown(shutdownCtx, logger, httpServer)
-		return err
-	}
-
-	cancel()
-	return bootstrap.GracefulShutdown(shutdownCtx, logger, httpServer)
+	_ = bootstrap.GracefulShutdown(shutdownCtx, logger, httpServer)
+	return serverErr
 }
 
 // parseLogLevel converts a string log level to slog.Level.

--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/meridianhub/meridian/services/mcp-server/internal/server"
 	"github.com/meridianhub/meridian/services/mcp-server/internal/transport"
@@ -89,6 +90,14 @@ func runStdio(logger *slog.Logger, cfg server.Config) error {
 	return srv.Run(ctx)
 }
 
+const (
+	httpReadHeaderTimeout = 10 * time.Second
+	httpReadTimeout       = 30 * time.Second
+	httpWriteTimeout      = 0 // SSE requires no write timeout (long-lived streams)
+	httpIdleTimeout       = 120 * time.Second
+	shutdownTimeout       = 30 * time.Second
+)
+
 func runSSE(logger *slog.Logger, cfg server.Config) error {
 	port := env.GetEnvOrDefault("MCP_SSE_PORT", "8090")
 	addr := fmt.Sprintf(":%s", port)
@@ -105,8 +114,12 @@ func runSSE(logger *slog.Logger, cfg server.Config) error {
 	mux.HandleFunc("/message", sseTr.HandleMessage)
 
 	httpServer := &http.Server{
-		Addr:    addr,
-		Handler: mux,
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: httpReadHeaderTimeout,
+		ReadTimeout:       httpReadTimeout,
+		WriteTimeout:      httpWriteTimeout,
+		IdleTimeout:       httpIdleTimeout,
 	}
 
 	// Start MCP server loop in background
@@ -131,14 +144,17 @@ func runSSE(logger *slog.Logger, cfg server.Config) error {
 	sigChan, signalCleanup := bootstrap.SignalHandler()
 	defer signalCleanup()
 
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer shutdownCancel()
+
 	if err := bootstrap.WaitForShutdownSignal(sigChan, serverErrors, logger); err != nil {
 		cancel()
-		_ = bootstrap.GracefulShutdown(context.Background(), logger, httpServer)
+		_ = bootstrap.GracefulShutdown(shutdownCtx, logger, httpServer)
 		return err
 	}
 
 	cancel()
-	return bootstrap.GracefulShutdown(context.Background(), logger, httpServer)
+	return bootstrap.GracefulShutdown(shutdownCtx, logger, httpServer)
 }
 
 // parseLogLevel converts a string log level to slog.Level.

--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -28,8 +28,10 @@ var (
 )
 
 func main() {
-	logLevel := parseLogLevel(os.Getenv("LOG_LEVEL"))
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	// Log to stderr: in stdio mode, stdout is the JSON-RPC wire protocol channel.
+	// Logging to stdout would corrupt the protocol for MCP clients.
+	logLevel := parseLogLevel(env.GetEnvOrDefault("LOG_LEVEL", ""))
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 		Level: logLevel,
 	}))
 	slog.SetDefault(logger)

--- a/services/mcp-server/internal/server/server.go
+++ b/services/mcp-server/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 
 	"github.com/meridianhub/meridian/services/mcp-server/internal/transport"
 )
@@ -97,7 +98,8 @@ func New(t transport.Transport, cfg Config, logger *slog.Logger) *MCPServer {
 	}
 }
 
-// RegisterTool registers a tool with the server.
+// RegisterTool registers a tool with the server. It must be called before Run;
+// calling it concurrently with Run is not safe.
 func (s *MCPServer) RegisterTool(tool Tool, handler ToolHandler) {
 	s.tools[tool.Name] = tool
 	s.handlers[tool.Name] = handler
@@ -180,6 +182,7 @@ func (s *MCPServer) handleToolsList(msg *transport.JSONRPCMessage) *transport.JS
 	for _, tool := range s.tools {
 		tools = append(tools, tool)
 	}
+	sort.Slice(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
 
 	result := ToolsListResult{Tools: tools}
 	resp, err := transport.NewResponse(msg.ID, result)

--- a/services/mcp-server/internal/server/server.go
+++ b/services/mcp-server/internal/server/server.go
@@ -1,0 +1,215 @@
+// Package server implements the MCP protocol handler, dispatching JSON-RPC 2.0
+// method calls to the appropriate handlers.
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/transport"
+)
+
+// ProtocolVersion is the MCP protocol version this server implements.
+const ProtocolVersion = "2024-11-05"
+
+// Info contains metadata about the MCP server.
+type Info struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// Capabilities describes the server's MCP capabilities.
+type Capabilities struct {
+	Tools *ToolsCapability `json:"tools,omitempty"`
+}
+
+// ToolsCapability describes the server's tool-related capabilities.
+type ToolsCapability struct {
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+// InitializeResult is the response to the initialize method.
+type InitializeResult struct {
+	ProtocolVersion string       `json:"protocolVersion"`
+	Capabilities    Capabilities `json:"capabilities"`
+	Info            Info         `json:"serverInfo"`
+}
+
+// Tool describes an MCP tool available for invocation.
+type Tool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+// ToolsListResult is the response to the tools/list method.
+type ToolsListResult struct {
+	Tools []Tool `json:"tools"`
+}
+
+// ToolCallParams are the parameters for the tools/call method.
+type ToolCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+// ToolCallResult is the response to the tools/call method.
+type ToolCallResult struct {
+	Content []ContentBlock `json:"content"`
+	IsError bool           `json:"isError,omitempty"`
+}
+
+// ContentBlock represents a content block in a tool result.
+type ContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+// ToolHandler is a function that handles a tool invocation.
+type ToolHandler func(ctx context.Context, arguments json.RawMessage) (*ToolCallResult, error)
+
+// Config holds configuration for the MCP server.
+type Config struct {
+	ServerName    string
+	ServerVersion string
+}
+
+// MCPServer implements the MCP protocol over a given transport.
+type MCPServer struct {
+	transport transport.Transport
+	config    Config
+	logger    *slog.Logger
+	tools     map[string]Tool
+	handlers  map[string]ToolHandler
+}
+
+// New creates a new MCPServer.
+func New(t transport.Transport, cfg Config, logger *slog.Logger) *MCPServer {
+	return &MCPServer{
+		transport: t,
+		config:    cfg,
+		logger:    logger,
+		tools:     make(map[string]Tool),
+		handlers:  make(map[string]ToolHandler),
+	}
+}
+
+// RegisterTool registers a tool with the server.
+func (s *MCPServer) RegisterTool(tool Tool, handler ToolHandler) {
+	s.tools[tool.Name] = tool
+	s.handlers[tool.Name] = handler
+}
+
+// Run starts the server's message processing loop. It blocks until the context
+// is cancelled or an unrecoverable error occurs.
+func (s *MCPServer) Run(ctx context.Context) error {
+	s.logger.Info("MCP server started", "name", s.config.ServerName, "version", s.config.ServerVersion)
+
+	for {
+		msg, err := s.transport.ReadMessage(ctx)
+		if err != nil {
+			// Context cancellation during read is a graceful shutdown.
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				s.logger.Info("MCP server shutting down")
+				return nil
+			}
+			return fmt.Errorf("read message: %w", err)
+		}
+
+		if msg.IsNotification() {
+			s.handleNotification(msg)
+			continue
+		}
+
+		if !msg.IsRequest() {
+			s.logger.Warn("ignoring non-request message")
+			continue
+		}
+
+		response := s.handleRequest(ctx, msg)
+		if err := s.transport.WriteMessage(ctx, response); err != nil {
+			s.logger.Error("failed to write response", "error", err)
+		}
+	}
+}
+
+func (s *MCPServer) handleNotification(msg *transport.JSONRPCMessage) {
+	s.logger.Debug("received notification", "method", msg.Method)
+}
+
+func (s *MCPServer) handleRequest(ctx context.Context, msg *transport.JSONRPCMessage) *transport.JSONRPCMessage {
+	s.logger.Debug("handling request", "method", msg.Method, "id", string(msg.ID))
+
+	switch msg.Method {
+	case "initialize":
+		return s.handleInitialize(msg)
+	case "tools/list":
+		return s.handleToolsList(msg)
+	case "tools/call":
+		return s.handleToolsCall(ctx, msg)
+	default:
+		return transport.NewErrorResponse(msg.ID, transport.CodeMethodNotFound,
+			fmt.Sprintf("method not found: %s", msg.Method))
+	}
+}
+
+func (s *MCPServer) handleInitialize(msg *transport.JSONRPCMessage) *transport.JSONRPCMessage {
+	result := InitializeResult{
+		ProtocolVersion: ProtocolVersion,
+		Capabilities: Capabilities{
+			Tools: &ToolsCapability{},
+		},
+		Info: Info{
+			Name:    s.config.ServerName,
+			Version: s.config.ServerVersion,
+		},
+	}
+
+	resp, err := transport.NewResponse(msg.ID, result)
+	if err != nil {
+		return transport.NewErrorResponse(msg.ID, transport.CodeInternalError, "failed to marshal response")
+	}
+	return resp
+}
+
+func (s *MCPServer) handleToolsList(msg *transport.JSONRPCMessage) *transport.JSONRPCMessage {
+	tools := make([]Tool, 0, len(s.tools))
+	for _, tool := range s.tools {
+		tools = append(tools, tool)
+	}
+
+	result := ToolsListResult{Tools: tools}
+	resp, err := transport.NewResponse(msg.ID, result)
+	if err != nil {
+		return transport.NewErrorResponse(msg.ID, transport.CodeInternalError, "failed to marshal response")
+	}
+	return resp
+}
+
+func (s *MCPServer) handleToolsCall(ctx context.Context, msg *transport.JSONRPCMessage) *transport.JSONRPCMessage {
+	var params ToolCallParams
+	if err := json.Unmarshal(msg.Params, &params); err != nil {
+		return transport.NewErrorResponse(msg.ID, transport.CodeInvalidParams, "invalid tool call params")
+	}
+
+	handler, exists := s.handlers[params.Name]
+	if !exists {
+		return transport.NewErrorResponse(msg.ID, transport.CodeInvalidParams,
+			fmt.Sprintf("unknown tool: %s", params.Name))
+	}
+
+	result, err := handler(ctx, params.Arguments)
+	if err != nil {
+		return transport.NewErrorResponse(msg.ID, transport.CodeInternalError,
+			fmt.Sprintf("tool execution failed: %v", err))
+	}
+
+	resp, err := transport.NewResponse(msg.ID, result)
+	if err != nil {
+		return transport.NewErrorResponse(msg.ID, transport.CodeInternalError, "failed to marshal response")
+	}
+	return resp
+}

--- a/services/mcp-server/internal/server/server_test.go
+++ b/services/mcp-server/internal/server/server_test.go
@@ -1,0 +1,304 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/transport"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewJSONHandler(io.Discard, nil))
+}
+
+// sendAndReceive sends a JSON-RPC request via stdio transport and reads the response.
+func sendAndReceive(t *testing.T, s *MCPServer, request *transport.JSONRPCMessage) *transport.JSONRPCMessage {
+	t.Helper()
+
+	// Encode request
+	reqData, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	reqData = append(reqData, '\n')
+
+	reader := bytes.NewReader(reqData)
+	writer := &bytes.Buffer{}
+	tr := transport.NewStdioTransport(reader, writer)
+
+	srv := New(tr, s.config, s.logger)
+	// Copy registered tools
+	for name, tool := range s.tools {
+		srv.tools[name] = tool
+		srv.handlers[name] = s.handlers[name]
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// Run server - it will read one message, process it, write response, then fail on next read (EOF)
+	_ = srv.Run(ctx)
+
+	// Parse response
+	output := writer.String()
+	if output == "" {
+		t.Fatal("no response written")
+	}
+
+	var resp transport.JSONRPCMessage
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v (output: %s)", err, output)
+	}
+	return &resp
+}
+
+func TestMCPServer_Initialize(t *testing.T) {
+	srv := New(nil, Config{ServerName: "test-mcp", ServerVersion: "0.1.0"}, testLogger())
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+	}
+
+	resp := sendAndReceive(t, srv, request)
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+
+	var result InitializeResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if result.ProtocolVersion != ProtocolVersion {
+		t.Errorf("expected protocolVersion=%s, got %s", ProtocolVersion, result.ProtocolVersion)
+	}
+	if result.Info.Name != "test-mcp" {
+		t.Errorf("expected server name=test-mcp, got %s", result.Info.Name)
+	}
+	if result.Info.Version != "0.1.0" {
+		t.Errorf("expected server version=0.1.0, got %s", result.Info.Version)
+	}
+	if result.Capabilities.Tools == nil {
+		t.Error("expected tools capability to be advertised")
+	}
+}
+
+func TestMCPServer_ToolsList_Empty(t *testing.T) {
+	srv := New(nil, Config{ServerName: "test-mcp", ServerVersion: "0.1.0"}, testLogger())
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`2`),
+		Method:  "tools/list",
+	}
+
+	resp := sendAndReceive(t, srv, request)
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+
+	var result ToolsListResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if len(result.Tools) != 0 {
+		t.Errorf("expected 0 tools, got %d", len(result.Tools))
+	}
+}
+
+func TestMCPServer_ToolsList_WithRegisteredTool(t *testing.T) {
+	srv := New(nil, Config{ServerName: "test-mcp", ServerVersion: "0.1.0"}, testLogger())
+
+	srv.RegisterTool(Tool{
+		Name:        "echo",
+		Description: "Echoes input back",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"message": map[string]any{"type": "string"},
+			},
+		},
+	}, func(_ context.Context, args json.RawMessage) (*ToolCallResult, error) {
+		return &ToolCallResult{
+			Content: []ContentBlock{{Type: "text", Text: string(args)}},
+		}, nil
+	})
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`3`),
+		Method:  "tools/list",
+	}
+
+	resp := sendAndReceive(t, srv, request)
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+
+	var result ToolsListResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if len(result.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(result.Tools))
+	}
+	if result.Tools[0].Name != "echo" {
+		t.Errorf("expected tool name=echo, got %s", result.Tools[0].Name)
+	}
+}
+
+func TestMCPServer_ToolsCall(t *testing.T) {
+	srv := New(nil, Config{ServerName: "test-mcp", ServerVersion: "0.1.0"}, testLogger())
+
+	srv.RegisterTool(Tool{
+		Name:        "greet",
+		Description: "Returns a greeting",
+		InputSchema: map[string]any{"type": "object"},
+	}, func(_ context.Context, args json.RawMessage) (*ToolCallResult, error) {
+		var params struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(args, &params); err != nil {
+			return nil, err
+		}
+		return &ToolCallResult{
+			Content: []ContentBlock{{Type: "text", Text: "Hello, " + params.Name}},
+		}, nil
+	})
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`4`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"greet","arguments":{"name":"World"}}`),
+	}
+
+	resp := sendAndReceive(t, srv, request)
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+
+	var result ToolCallResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if len(result.Content) != 1 {
+		t.Fatalf("expected 1 content block, got %d", len(result.Content))
+	}
+	if result.Content[0].Text != "Hello, World" {
+		t.Errorf("expected text='Hello, World', got %q", result.Content[0].Text)
+	}
+}
+
+func TestMCPServer_ToolsCall_UnknownTool(t *testing.T) {
+	srv := New(nil, Config{ServerName: "test-mcp", ServerVersion: "0.1.0"}, testLogger())
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`5`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"nonexistent"}`),
+	}
+
+	resp := sendAndReceive(t, srv, request)
+
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+	if resp.Error.Code != transport.CodeInvalidParams {
+		t.Errorf("expected error code %d, got %d", transport.CodeInvalidParams, resp.Error.Code)
+	}
+}
+
+func TestMCPServer_MethodNotFound(t *testing.T) {
+	srv := New(nil, Config{ServerName: "test-mcp", ServerVersion: "0.1.0"}, testLogger())
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`6`),
+		Method:  "unknown/method",
+	}
+
+	resp := sendAndReceive(t, srv, request)
+
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown method")
+	}
+	if resp.Error.Code != transport.CodeMethodNotFound {
+		t.Errorf("expected error code %d, got %d", transport.CodeMethodNotFound, resp.Error.Code)
+	}
+}
+
+func TestMCPServer_Run_ContextCancellation(t *testing.T) {
+	// Create a transport that blocks on read
+	reader := &blockingReader{ch: make(chan struct{})}
+	writer := &bytes.Buffer{}
+	tr := transport.NewStdioTransport(reader, writer)
+
+	srv := New(tr, Config{ServerName: "test-mcp", ServerVersion: "0.1.0"}, testLogger())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := srv.Run(ctx)
+	if err != nil {
+		t.Errorf("expected nil error on context cancellation, got %v", err)
+	}
+}
+
+type blockingReader struct {
+	ch chan struct{}
+}
+
+func (r *blockingReader) Read([]byte) (int, error) {
+	<-r.ch
+	return 0, nil
+}
+
+func TestMCPServer_Notification_DoesNotRespond(t *testing.T) {
+	// Send a notification followed by a request, verify only request gets a response
+	input := `{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n" +
+		`{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n"
+
+	reader := strings.NewReader(input)
+	writer := &bytes.Buffer{}
+	tr := transport.NewStdioTransport(reader, writer)
+
+	srv := New(tr, Config{ServerName: "test-mcp", ServerVersion: "0.1.0"}, testLogger())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_ = srv.Run(ctx)
+
+	// Should have exactly one response line (for the initialize request)
+	output := strings.TrimSpace(writer.String())
+	lines := strings.Split(output, "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected 1 response line, got %d: %v", len(lines), lines)
+	}
+
+	var resp transport.JSONRPCMessage
+	if err := json.Unmarshal([]byte(lines[0]), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+}

--- a/services/mcp-server/internal/transport/message.go
+++ b/services/mcp-server/internal/transport/message.go
@@ -1,0 +1,74 @@
+// Package transport defines the Transport interface and JSON-RPC 2.0 message types
+// for the MCP server's communication layer.
+package transport
+
+import "encoding/json"
+
+// JSONRPCVersion is the JSON-RPC protocol version string.
+const JSONRPCVersion = "2.0"
+
+// JSONRPCMessage represents a JSON-RPC 2.0 message (request, response, or notification).
+type JSONRPCMessage struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *JSONRPCError   `json:"error,omitempty"`
+}
+
+// JSONRPCError represents a JSON-RPC 2.0 error object.
+type JSONRPCError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+// Standard JSON-RPC 2.0 error codes.
+const (
+	CodeParseError     = -32700
+	CodeInvalidRequest = -32600
+	CodeMethodNotFound = -32601
+	CodeInvalidParams  = -32602
+	CodeInternalError  = -32603
+)
+
+// IsRequest returns true if the message is a JSON-RPC request (has method and id).
+func (m *JSONRPCMessage) IsRequest() bool {
+	return m.Method != "" && m.ID != nil
+}
+
+// IsNotification returns true if the message is a JSON-RPC notification (has method, no id).
+func (m *JSONRPCMessage) IsNotification() bool {
+	return m.Method != "" && m.ID == nil
+}
+
+// IsResponse returns true if the message is a JSON-RPC response (has result or error, no method).
+func (m *JSONRPCMessage) IsResponse() bool {
+	return m.Method == "" && (m.Result != nil || m.Error != nil)
+}
+
+// NewResponse creates a JSON-RPC 2.0 response message with the given id and result.
+func NewResponse(id json.RawMessage, result any) (*JSONRPCMessage, error) {
+	data, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+	return &JSONRPCMessage{
+		JSONRPC: JSONRPCVersion,
+		ID:      id,
+		Result:  data,
+	}, nil
+}
+
+// NewErrorResponse creates a JSON-RPC 2.0 error response message.
+func NewErrorResponse(id json.RawMessage, code int, message string) *JSONRPCMessage {
+	return &JSONRPCMessage{
+		JSONRPC: JSONRPCVersion,
+		ID:      id,
+		Error: &JSONRPCError{
+			Code:    code,
+			Message: message,
+		},
+	}
+}

--- a/services/mcp-server/internal/transport/message_test.go
+++ b/services/mcp-server/internal/transport/message_test.go
@@ -1,0 +1,122 @@
+package transport
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestJSONRPCMessage_IsRequest(t *testing.T) {
+	msg := &JSONRPCMessage{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+	}
+	if !msg.IsRequest() {
+		t.Error("expected IsRequest to return true for message with method and id")
+	}
+	if msg.IsNotification() {
+		t.Error("expected IsNotification to return false for request")
+	}
+	if msg.IsResponse() {
+		t.Error("expected IsResponse to return false for request")
+	}
+}
+
+func TestJSONRPCMessage_IsNotification(t *testing.T) {
+	msg := &JSONRPCMessage{
+		JSONRPC: JSONRPCVersion,
+		Method:  "notifications/initialized",
+	}
+	if !msg.IsNotification() {
+		t.Error("expected IsNotification to return true for message with method and no id")
+	}
+	if msg.IsRequest() {
+		t.Error("expected IsRequest to return false for notification")
+	}
+}
+
+func TestJSONRPCMessage_IsResponse(t *testing.T) {
+	msg := &JSONRPCMessage{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Result:  json.RawMessage(`{}`),
+	}
+	if !msg.IsResponse() {
+		t.Error("expected IsResponse to return true for message with result")
+	}
+	if msg.IsRequest() {
+		t.Error("expected IsRequest to return false for response")
+	}
+}
+
+func TestNewResponse(t *testing.T) {
+	id := json.RawMessage(`42`)
+	result := map[string]string{"status": "ok"}
+
+	msg, err := NewResponse(id, result)
+	if err != nil {
+		t.Fatalf("NewResponse error: %v", err)
+	}
+
+	if msg.JSONRPC != JSONRPCVersion {
+		t.Errorf("expected jsonrpc=%q, got %q", JSONRPCVersion, msg.JSONRPC)
+	}
+	if string(msg.ID) != `42` {
+		t.Errorf("expected id=42, got %s", msg.ID)
+	}
+
+	var parsed map[string]string
+	if err := json.Unmarshal(msg.Result, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if parsed["status"] != "ok" {
+		t.Errorf("expected status=ok, got %s", parsed["status"])
+	}
+}
+
+func TestNewErrorResponse(t *testing.T) {
+	id := json.RawMessage(`1`)
+	msg := NewErrorResponse(id, CodeMethodNotFound, "method not found")
+
+	if msg.JSONRPC != JSONRPCVersion {
+		t.Errorf("expected jsonrpc=%q, got %q", JSONRPCVersion, msg.JSONRPC)
+	}
+	if msg.Error == nil {
+		t.Fatal("expected error to be set")
+	}
+	if msg.Error.Code != CodeMethodNotFound {
+		t.Errorf("expected code=%d, got %d", CodeMethodNotFound, msg.Error.Code)
+	}
+	if msg.Error.Message != "method not found" {
+		t.Errorf("expected message=%q, got %q", "method not found", msg.Error.Message)
+	}
+}
+
+func TestJSONRPCMessage_RoundTrip(t *testing.T) {
+	original := &JSONRPCMessage{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/list",
+		Params:  json.RawMessage(`{}`),
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var decoded JSONRPCMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if decoded.JSONRPC != original.JSONRPC {
+		t.Errorf("jsonrpc mismatch: %q vs %q", decoded.JSONRPC, original.JSONRPC)
+	}
+	if decoded.Method != original.Method {
+		t.Errorf("method mismatch: %q vs %q", decoded.Method, original.Method)
+	}
+	if string(decoded.ID) != string(original.ID) {
+		t.Errorf("id mismatch: %s vs %s", decoded.ID, original.ID)
+	}
+}

--- a/services/mcp-server/internal/transport/sse.go
+++ b/services/mcp-server/internal/transport/sse.go
@@ -1,0 +1,188 @@
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/google/uuid"
+)
+
+// SSETransport implements the Transport interface using HTTP Server-Sent Events.
+// Clients connect via GET to receive SSE events, and POST JSON-RPC messages
+// to a separate endpoint.
+type SSETransport struct {
+	logger  *slog.Logger
+	inbox   chan *JSONRPCMessage
+	clients map[string]*sseClient
+	mu      sync.RWMutex
+	closed  atomic.Bool
+}
+
+type sseClient struct {
+	id     string
+	events chan []byte
+	done   chan struct{}
+}
+
+// NewSSETransport creates a new SSE transport.
+func NewSSETransport(logger *slog.Logger) *SSETransport {
+	return &SSETransport{
+		logger:  logger,
+		inbox:   make(chan *JSONRPCMessage, 64),
+		clients: make(map[string]*sseClient),
+	}
+}
+
+// ReadMessage reads the next JSON-RPC message received via HTTP POST.
+func (t *SSETransport) ReadMessage(ctx context.Context) (*JSONRPCMessage, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case msg, ok := <-t.inbox:
+		if !ok {
+			return nil, io.EOF
+		}
+		return msg, nil
+	}
+}
+
+// WriteMessage broadcasts a JSON-RPC message to all connected SSE clients.
+func (t *SSETransport) WriteMessage(_ context.Context, msg *JSONRPCMessage) error {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("marshal message: %w", err)
+	}
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	for _, client := range t.clients {
+		select {
+		case client.events <- data:
+		default:
+			t.logger.Warn("dropping message for slow SSE client", "client_id", client.id)
+		}
+	}
+
+	return nil
+}
+
+// Close shuts down the SSE transport, disconnecting all clients.
+func (t *SSETransport) Close() error {
+	if !t.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+
+	close(t.inbox)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for id, client := range t.clients {
+		close(client.done)
+		delete(t.clients, id)
+	}
+
+	return nil
+}
+
+// HandleSSE is the HTTP handler for SSE client connections (GET /sse).
+func (t *SSETransport) HandleSSE(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	client := &sseClient{
+		id:     uuid.New().String(),
+		events: make(chan []byte, 64),
+		done:   make(chan struct{}),
+	}
+
+	t.mu.Lock()
+	t.clients[client.id] = client
+	t.mu.Unlock()
+
+	t.logger.Info("SSE client connected", "client_id", client.id)
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	// Send the endpoint event so the client knows where to POST messages
+	_, _ = fmt.Fprintf(w, "event: endpoint\ndata: /message?sessionId=%s\n\n", client.id)
+	flusher.Flush()
+
+	defer func() {
+		t.mu.Lock()
+		delete(t.clients, client.id)
+		t.mu.Unlock()
+		t.logger.Info("SSE client disconnected", "client_id", client.id)
+	}()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-client.done:
+			return
+		case data, ok := <-client.events:
+			if !ok {
+				return
+			}
+			_, _ = fmt.Fprintf(w, "event: message\ndata: %s\n\n", data)
+			flusher.Flush()
+		}
+	}
+}
+
+// HandleMessage is the HTTP handler for incoming JSON-RPC messages (POST /message).
+func (t *SSETransport) HandleMessage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	sessionID := r.URL.Query().Get("sessionId")
+	if sessionID == "" {
+		http.Error(w, "missing sessionId parameter", http.StatusBadRequest)
+		return
+	}
+
+	t.mu.RLock()
+	_, exists := t.clients[sessionID]
+	t.mu.RUnlock()
+
+	if !exists {
+		http.Error(w, "unknown session", http.StatusNotFound)
+		return
+	}
+
+	var msg JSONRPCMessage
+	if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	if t.closed.Load() {
+		http.Error(w, "transport closed", http.StatusServiceUnavailable)
+		return
+	}
+
+	t.inbox <- &msg
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// ClientCount returns the number of connected SSE clients.
+func (t *SSETransport) ClientCount() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return len(t.clients)
+}

--- a/services/mcp-server/internal/transport/sse.go
+++ b/services/mcp-server/internal/transport/sse.go
@@ -79,21 +79,26 @@ func (t *SSETransport) Close() error {
 		return nil
 	}
 
-	close(t.inbox)
-
+	// Close inbox under the write lock to prevent the race with HandleMessage.
 	t.mu.Lock()
-	defer t.mu.Unlock()
+	close(t.inbox)
 
 	for id, client := range t.clients {
 		close(client.done)
 		delete(t.clients, id)
 	}
+	t.mu.Unlock()
 
 	return nil
 }
 
 // HandleSSE is the HTTP handler for SSE client connections (GET /sse).
 func (t *SSETransport) HandleSSE(w http.ResponseWriter, r *http.Request) {
+	if t.closed.Load() {
+		http.Error(w, "transport closed", http.StatusServiceUnavailable)
+		return
+	}
+
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming not supported", http.StatusInternalServerError)
@@ -156,23 +161,25 @@ func (t *SSETransport) HandleMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	t.mu.RLock()
-	_, exists := t.clients[sessionID]
-	t.mu.RUnlock()
-
-	if !exists {
-		http.Error(w, "unknown session", http.StatusNotFound)
-		return
-	}
-
 	var msg JSONRPCMessage
 	if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
 		return
 	}
 
+	// Hold the read lock across both the session check and inbox send.
+	// Close() holds the write lock when closing the inbox, so this
+	// prevents the race between Close and send-on-closed-channel.
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
 	if t.closed.Load() {
 		http.Error(w, "transport closed", http.StatusServiceUnavailable)
+		return
+	}
+
+	if _, exists := t.clients[sessionID]; !exists {
+		http.Error(w, "unknown session", http.StatusNotFound)
 		return
 	}
 

--- a/services/mcp-server/internal/transport/sse.go
+++ b/services/mcp-server/internal/transport/sse.go
@@ -85,6 +85,7 @@ func (t *SSETransport) Close() error {
 
 	for id, client := range t.clients {
 		close(client.done)
+		close(client.events)
 		delete(t.clients, id)
 	}
 	t.mu.Unlock()
@@ -183,8 +184,12 @@ func (t *SSETransport) HandleMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	t.inbox <- &msg
-	w.WriteHeader(http.StatusAccepted)
+	select {
+	case t.inbox <- &msg:
+		w.WriteHeader(http.StatusAccepted)
+	default:
+		http.Error(w, "server busy", http.StatusServiceUnavailable)
+	}
 }
 
 // ClientCount returns the number of connected SSE clients.

--- a/services/mcp-server/internal/transport/sse.go
+++ b/services/mcp-server/internal/transport/sse.go
@@ -95,11 +95,6 @@ func (t *SSETransport) Close() error {
 
 // HandleSSE is the HTTP handler for SSE client connections (GET /sse).
 func (t *SSETransport) HandleSSE(w http.ResponseWriter, r *http.Request) {
-	if t.closed.Load() {
-		http.Error(w, "transport closed", http.StatusServiceUnavailable)
-		return
-	}
-
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming not supported", http.StatusInternalServerError)
@@ -112,7 +107,14 @@ func (t *SSETransport) HandleSSE(w http.ResponseWriter, r *http.Request) {
 		done:   make(chan struct{}),
 	}
 
+	// Check closed and register atomically under the write lock to prevent
+	// a race where Close() runs between the check and registration.
 	t.mu.Lock()
+	if t.closed.Load() {
+		t.mu.Unlock()
+		http.Error(w, "transport closed", http.StatusServiceUnavailable)
+		return
+	}
 	t.clients[client.id] = client
 	t.mu.Unlock()
 

--- a/services/mcp-server/internal/transport/sse_test.go
+++ b/services/mcp-server/internal/transport/sse_test.go
@@ -1,0 +1,300 @@
+package transport
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewJSONHandler(io.Discard, nil))
+}
+
+func TestSSETransport_HandleMessage_PostsToInbox(t *testing.T) {
+	tr := NewSSETransport(testLogger())
+	defer tr.Close()
+
+	// Simulate a connected client
+	tr.mu.Lock()
+	tr.clients["test-session"] = &sseClient{
+		id:     "test-session",
+		events: make(chan []byte, 64),
+		done:   make(chan struct{}),
+	}
+	tr.mu.Unlock()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize"}`
+	req := httptest.NewRequest(http.MethodPost, "/message?sessionId=test-session", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	tr.HandleMessage(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Errorf("expected status %d, got %d", http.StatusAccepted, rec.Code)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	msg, err := tr.ReadMessage(ctx)
+	if err != nil {
+		t.Fatalf("ReadMessage error: %v", err)
+	}
+	if msg.Method != "initialize" {
+		t.Errorf("expected method=initialize, got %s", msg.Method)
+	}
+}
+
+func TestSSETransport_HandleMessage_RejectsUnknownSession(t *testing.T) {
+	tr := NewSSETransport(testLogger())
+	defer tr.Close()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize"}`
+	req := httptest.NewRequest(http.MethodPost, "/message?sessionId=nonexistent", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	tr.HandleMessage(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status %d, got %d", http.StatusNotFound, rec.Code)
+	}
+}
+
+func TestSSETransport_HandleMessage_RejectsMissingSessionId(t *testing.T) {
+	tr := NewSSETransport(testLogger())
+	defer tr.Close()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize"}`
+	req := httptest.NewRequest(http.MethodPost, "/message", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	tr.HandleMessage(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+	}
+}
+
+func TestSSETransport_HandleMessage_RejectsGetMethod(t *testing.T) {
+	tr := NewSSETransport(testLogger())
+	defer tr.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/message?sessionId=test", nil)
+	rec := httptest.NewRecorder()
+
+	tr.HandleMessage(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, rec.Code)
+	}
+}
+
+func TestSSETransport_HandleMessage_RejectsInvalidJSON(t *testing.T) {
+	tr := NewSSETransport(testLogger())
+	defer tr.Close()
+
+	tr.mu.Lock()
+	tr.clients["test-session"] = &sseClient{
+		id:     "test-session",
+		events: make(chan []byte, 64),
+		done:   make(chan struct{}),
+	}
+	tr.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodPost, "/message?sessionId=test-session", strings.NewReader("not json"))
+	rec := httptest.NewRecorder()
+
+	tr.HandleMessage(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+	}
+}
+
+func TestSSETransport_WriteMessage_BroadcastsToClients(t *testing.T) {
+	tr := NewSSETransport(testLogger())
+	defer tr.Close()
+
+	events := make(chan []byte, 64)
+	tr.mu.Lock()
+	tr.clients["client-1"] = &sseClient{
+		id:     "client-1",
+		events: events,
+		done:   make(chan struct{}),
+	}
+	tr.mu.Unlock()
+
+	msg := &JSONRPCMessage{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Result:  json.RawMessage(`{"status":"ok"}`),
+	}
+
+	if err := tr.WriteMessage(context.Background(), msg); err != nil {
+		t.Fatalf("WriteMessage error: %v", err)
+	}
+
+	select {
+	case data := <-events:
+		var decoded JSONRPCMessage
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("failed to decode broadcast: %v", err)
+		}
+		if decoded.JSONRPC != "2.0" {
+			t.Errorf("expected jsonrpc=2.0, got %s", decoded.JSONRPC)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for broadcast")
+	}
+}
+
+func TestSSETransport_ClientCount(t *testing.T) {
+	tr := NewSSETransport(testLogger())
+	defer tr.Close()
+
+	if tr.ClientCount() != 0 {
+		t.Errorf("expected 0 clients, got %d", tr.ClientCount())
+	}
+
+	tr.mu.Lock()
+	tr.clients["a"] = &sseClient{id: "a", events: make(chan []byte, 1), done: make(chan struct{})}
+	tr.clients["b"] = &sseClient{id: "b", events: make(chan []byte, 1), done: make(chan struct{})}
+	tr.mu.Unlock()
+
+	if tr.ClientCount() != 2 {
+		t.Errorf("expected 2 clients, got %d", tr.ClientCount())
+	}
+}
+
+func TestSSETransport_ReadMessage_ContextCancelled(t *testing.T) {
+	tr := NewSSETransport(testLogger())
+	defer tr.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := tr.ReadMessage(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestSSETransport_HandleSSE_StreamsEvents(t *testing.T) {
+	tr := NewSSETransport(testLogger())
+	defer tr.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sse", tr.HandleSSE)
+	mux.HandleFunc("/message", tr.HandleMessage)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// Connect SSE client with context
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/sse", nil)
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("SSE connect error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.Header.Get("Content-Type") != "text/event-stream" {
+		t.Errorf("expected Content-Type=text/event-stream, got %s", resp.Header.Get("Content-Type"))
+	}
+
+	// Read the endpoint event
+	buf := make([]byte, 4096)
+	n, err := resp.Body.Read(buf)
+	if err != nil {
+		t.Fatalf("failed to read SSE endpoint event: %v", err)
+	}
+	endpointEvent := string(buf[:n])
+	if !strings.Contains(endpointEvent, "event: endpoint") {
+		t.Errorf("expected endpoint event, got: %s", endpointEvent)
+	}
+	if !strings.Contains(endpointEvent, "/message?sessionId=") {
+		t.Errorf("expected sessionId in endpoint data, got: %s", endpointEvent)
+	}
+
+	// Extract session ID from the endpoint event
+	sessionID := ""
+	for _, line := range strings.Split(endpointEvent, "\n") {
+		if strings.HasPrefix(line, "data: /message?sessionId=") {
+			sessionID = strings.TrimPrefix(line, "data: /message?sessionId=")
+			break
+		}
+	}
+	if sessionID == "" {
+		t.Fatal("failed to extract sessionId from endpoint event")
+	}
+
+	// Post a message to the session
+	msgBody := `{"jsonrpc":"2.0","id":1,"method":"test"}`
+	postReq, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/message?sessionId="+sessionID, bytes.NewReader([]byte(msgBody)))
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+	postReq.Header.Set("Content-Type", "application/json")
+
+	postResp, err := http.DefaultClient.Do(postReq)
+	if err != nil {
+		t.Fatalf("POST /message error: %v", err)
+	}
+	postResp.Body.Close()
+
+	if postResp.StatusCode != http.StatusAccepted {
+		t.Errorf("expected POST status %d, got %d", http.StatusAccepted, postResp.StatusCode)
+	}
+
+	// Verify the message arrived in the inbox
+	readCtx, readCancel := context.WithTimeout(context.Background(), time.Second)
+	defer readCancel()
+
+	msg, err := tr.ReadMessage(readCtx)
+	if err != nil {
+		t.Fatalf("ReadMessage error: %v", err)
+	}
+	if msg.Method != "test" {
+		t.Errorf("expected method=test, got %s", msg.Method)
+	}
+}
+
+func TestSSETransport_Close_DisconnectsClients(t *testing.T) {
+	tr := NewSSETransport(testLogger())
+
+	done := make(chan struct{})
+	tr.mu.Lock()
+	tr.clients["c1"] = &sseClient{id: "c1", events: make(chan []byte, 1), done: done}
+	tr.mu.Unlock()
+
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close error: %v", err)
+	}
+
+	// Verify done channel was closed
+	select {
+	case <-done:
+		// expected
+	default:
+		t.Error("expected client done channel to be closed")
+	}
+
+	if tr.ClientCount() != 0 {
+		t.Errorf("expected 0 clients after close, got %d", tr.ClientCount())
+	}
+}

--- a/services/mcp-server/internal/transport/sse_test.go
+++ b/services/mcp-server/internal/transport/sse_test.go
@@ -235,7 +235,7 @@ func TestSSETransport_HandleSSE_StreamsEvents(t *testing.T) {
 	sessionID := ""
 	for _, line := range strings.Split(endpointEvent, "\n") {
 		if strings.HasPrefix(line, "data: /message?sessionId=") {
-			sessionID = strings.TrimPrefix(line, "data: /message?sessionId=")
+			sessionID = strings.TrimSpace(strings.TrimPrefix(line, "data: /message?sessionId="))
 			break
 		}
 	}

--- a/services/mcp-server/internal/transport/stdio.go
+++ b/services/mcp-server/internal/transport/stdio.go
@@ -9,13 +9,23 @@ import (
 	"sync"
 )
 
+// readResult carries a parsed message or an error from the background reader.
+type readResult struct {
+	msg *JSONRPCMessage
+	err error
+}
+
 // StdioTransport implements the Transport interface over stdin/stdout.
 // Each JSON-RPC message is a single line of JSON terminated by a newline.
+// A single background goroutine reads from the reader, preventing goroutine
+// leaks on context cancellation.
 type StdioTransport struct {
 	reader  *bufio.Reader
 	writer  io.Writer
 	writeMu sync.Mutex
 	closer  io.Closer
+	msgs    chan readResult
+	once    sync.Once
 }
 
 // NewStdioTransport creates a new stdio transport reading from r and writing to w.
@@ -25,42 +35,49 @@ func NewStdioTransport(r io.Reader, w io.Writer) *StdioTransport {
 	if c, ok := r.(io.Closer); ok {
 		closer = c
 	}
-	return &StdioTransport{
+	t := &StdioTransport{
 		reader: bufio.NewReader(r),
 		writer: w,
 		closer: closer,
+		msgs:   make(chan readResult, 1),
+	}
+	// Start the single reader goroutine that lives for the transport's lifetime.
+	go t.readLoop()
+	return t
+}
+
+// readLoop continuously reads newline-delimited JSON from the reader and
+// sends parsed messages (or errors) to the msgs channel. It exits when
+// the reader returns an error (e.g. EOF or the underlying reader is closed).
+func (t *StdioTransport) readLoop() {
+	defer close(t.msgs)
+	for {
+		line, err := t.reader.ReadBytes('\n')
+		if err != nil {
+			t.msgs <- readResult{err: fmt.Errorf("read stdin: %w", err)}
+			return
+		}
+
+		var msg JSONRPCMessage
+		if err := json.Unmarshal(line, &msg); err != nil {
+			t.msgs <- readResult{err: fmt.Errorf("unmarshal message: %w", err)}
+			return
+		}
+
+		t.msgs <- readResult{msg: &msg}
 	}
 }
 
 // ReadMessage reads a single JSON-RPC message from stdin.
 // Each message must be a single line of valid JSON.
 func (t *StdioTransport) ReadMessage(ctx context.Context) (*JSONRPCMessage, error) {
-	type result struct {
-		msg *JSONRPCMessage
-		err error
-	}
-
-	ch := make(chan result, 1)
-	go func() {
-		line, err := t.reader.ReadBytes('\n')
-		if err != nil {
-			ch <- result{err: fmt.Errorf("read stdin: %w", err)}
-			return
-		}
-
-		var msg JSONRPCMessage
-		if err := json.Unmarshal(line, &msg); err != nil {
-			ch <- result{err: fmt.Errorf("unmarshal message: %w", err)}
-			return
-		}
-
-		ch <- result{msg: &msg}
-	}()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
-	case r := <-ch:
+	case r, ok := <-t.msgs:
+		if !ok {
+			return nil, io.EOF
+		}
 		return r.msg, r.err
 	}
 }
@@ -84,9 +101,13 @@ func (t *StdioTransport) WriteMessage(_ context.Context, msg *JSONRPCMessage) er
 }
 
 // Close closes the underlying reader if it implements io.Closer.
+// This also terminates the background reader goroutine.
 func (t *StdioTransport) Close() error {
-	if t.closer != nil {
-		return t.closer.Close()
-	}
-	return nil
+	var closeErr error
+	t.once.Do(func() {
+		if t.closer != nil {
+			closeErr = t.closer.Close()
+		}
+	})
+	return closeErr
 }

--- a/services/mcp-server/internal/transport/stdio.go
+++ b/services/mcp-server/internal/transport/stdio.go
@@ -1,0 +1,92 @@
+package transport
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// StdioTransport implements the Transport interface over stdin/stdout.
+// Each JSON-RPC message is a single line of JSON terminated by a newline.
+type StdioTransport struct {
+	reader  *bufio.Reader
+	writer  io.Writer
+	writeMu sync.Mutex
+	closer  io.Closer
+}
+
+// NewStdioTransport creates a new stdio transport reading from r and writing to w.
+// If r implements io.Closer, it will be closed when Close is called.
+func NewStdioTransport(r io.Reader, w io.Writer) *StdioTransport {
+	var closer io.Closer
+	if c, ok := r.(io.Closer); ok {
+		closer = c
+	}
+	return &StdioTransport{
+		reader: bufio.NewReader(r),
+		writer: w,
+		closer: closer,
+	}
+}
+
+// ReadMessage reads a single JSON-RPC message from stdin.
+// Each message must be a single line of valid JSON.
+func (t *StdioTransport) ReadMessage(ctx context.Context) (*JSONRPCMessage, error) {
+	type result struct {
+		msg *JSONRPCMessage
+		err error
+	}
+
+	ch := make(chan result, 1)
+	go func() {
+		line, err := t.reader.ReadBytes('\n')
+		if err != nil {
+			ch <- result{err: fmt.Errorf("read stdin: %w", err)}
+			return
+		}
+
+		var msg JSONRPCMessage
+		if err := json.Unmarshal(line, &msg); err != nil {
+			ch <- result{err: fmt.Errorf("unmarshal message: %w", err)}
+			return
+		}
+
+		ch <- result{msg: &msg}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case r := <-ch:
+		return r.msg, r.err
+	}
+}
+
+// WriteMessage writes a single JSON-RPC message to stdout as a newline-delimited JSON line.
+func (t *StdioTransport) WriteMessage(_ context.Context, msg *JSONRPCMessage) error {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("marshal message: %w", err)
+	}
+
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+
+	data = append(data, '\n')
+	if _, err := t.writer.Write(data); err != nil {
+		return fmt.Errorf("write stdout: %w", err)
+	}
+
+	return nil
+}
+
+// Close closes the underlying reader if it implements io.Closer.
+func (t *StdioTransport) Close() error {
+	if t.closer != nil {
+		return t.closer.Close()
+	}
+	return nil
+}

--- a/services/mcp-server/internal/transport/stdio_test.go
+++ b/services/mcp-server/internal/transport/stdio_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -35,7 +36,7 @@ func TestStdioTransport_ReadMessage(t *testing.T) {
 }
 
 func TestStdioTransport_WriteMessage(t *testing.T) {
-	reader := strings.NewReader("")
+	reader := strings.NewReader("\n") // needs valid input to avoid blocking
 	writer := &bytes.Buffer{}
 
 	tr := NewStdioTransport(reader, writer)
@@ -66,10 +67,12 @@ func TestStdioTransport_WriteMessage(t *testing.T) {
 }
 
 func TestStdioTransport_ReadWriteRoundTrip(t *testing.T) {
-	// Pipe: write to one end, read from the other
+	// Write a message, then read it back via a new transport.
 	buf := &bytes.Buffer{}
 
-	writerTransport := NewStdioTransport(strings.NewReader(""), buf)
+	// Write using a transport that has a dummy reader
+	writerTransport := NewStdioTransport(strings.NewReader("\n"), buf)
+	defer writerTransport.Close()
 
 	request := &JSONRPCMessage{
 		JSONRPC: JSONRPCVersion,
@@ -81,7 +84,9 @@ func TestStdioTransport_ReadWriteRoundTrip(t *testing.T) {
 		t.Fatalf("WriteMessage error: %v", err)
 	}
 
-	readerTransport := NewStdioTransport(buf, &bytes.Buffer{})
+	// Read via a new transport using the buffer's bytes
+	readerTransport := NewStdioTransport(strings.NewReader(buf.String()), &bytes.Buffer{})
+	defer readerTransport.Close()
 
 	msg, err := readerTransport.ReadMessage(context.Background())
 	if err != nil {
@@ -97,8 +102,9 @@ func TestStdioTransport_ReadWriteRoundTrip(t *testing.T) {
 }
 
 func TestStdioTransport_ReadMessage_ContextCancelled(t *testing.T) {
-	// Use a reader that blocks forever (no data)
-	pr, _ := blockingPipe()
+	// Use a pipe: the read end blocks because nothing is written
+	pr, pw := io.Pipe()
+	defer pw.Close()
 
 	tr := NewStdioTransport(pr, &bytes.Buffer{})
 	defer tr.Close()
@@ -150,16 +156,15 @@ func TestStdioTransport_ReadMessage_MultipleMessages(t *testing.T) {
 	}
 }
 
-// blockingPipe returns an io.Reader that blocks forever on reads.
-func blockingPipe() (*blockingReader, struct{}) {
-	return &blockingReader{ch: make(chan struct{})}, struct{}{}
-}
+func TestStdioTransport_ReadMessage_EOF(t *testing.T) {
+	// Empty reader = immediate EOF
+	reader := strings.NewReader("")
 
-type blockingReader struct {
-	ch chan struct{}
-}
+	tr := NewStdioTransport(reader, &bytes.Buffer{})
+	defer tr.Close()
 
-func (r *blockingReader) Read([]byte) (int, error) {
-	<-r.ch // blocks forever
-	return 0, nil
+	_, err := tr.ReadMessage(context.Background())
+	if err == nil {
+		t.Error("expected error on empty reader, got nil")
+	}
 }

--- a/services/mcp-server/internal/transport/stdio_test.go
+++ b/services/mcp-server/internal/transport/stdio_test.go
@@ -1,0 +1,165 @@
+package transport
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStdioTransport_ReadMessage(t *testing.T) {
+	input := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}` + "\n"
+	reader := strings.NewReader(input)
+	writer := &bytes.Buffer{}
+
+	tr := NewStdioTransport(reader, writer)
+	defer tr.Close()
+
+	msg, err := tr.ReadMessage(context.Background())
+	if err != nil {
+		t.Fatalf("ReadMessage error: %v", err)
+	}
+
+	if msg.JSONRPC != "2.0" {
+		t.Errorf("expected jsonrpc=2.0, got %s", msg.JSONRPC)
+	}
+	if msg.Method != "initialize" {
+		t.Errorf("expected method=initialize, got %s", msg.Method)
+	}
+	if string(msg.ID) != "1" {
+		t.Errorf("expected id=1, got %s", msg.ID)
+	}
+}
+
+func TestStdioTransport_WriteMessage(t *testing.T) {
+	reader := strings.NewReader("")
+	writer := &bytes.Buffer{}
+
+	tr := NewStdioTransport(reader, writer)
+	defer tr.Close()
+
+	msg := &JSONRPCMessage{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Result:  json.RawMessage(`{"capabilities":{}}`),
+	}
+
+	if err := tr.WriteMessage(context.Background(), msg); err != nil {
+		t.Fatalf("WriteMessage error: %v", err)
+	}
+
+	output := writer.String()
+	if !strings.HasSuffix(output, "\n") {
+		t.Error("expected output to end with newline")
+	}
+
+	var decoded JSONRPCMessage
+	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+		t.Fatalf("failed to decode written message: %v", err)
+	}
+	if decoded.JSONRPC != "2.0" {
+		t.Errorf("expected jsonrpc=2.0 in output, got %s", decoded.JSONRPC)
+	}
+}
+
+func TestStdioTransport_ReadWriteRoundTrip(t *testing.T) {
+	// Pipe: write to one end, read from the other
+	buf := &bytes.Buffer{}
+
+	writerTransport := NewStdioTransport(strings.NewReader(""), buf)
+
+	request := &JSONRPCMessage{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`42`),
+		Method:  "tools/list",
+	}
+
+	if err := writerTransport.WriteMessage(context.Background(), request); err != nil {
+		t.Fatalf("WriteMessage error: %v", err)
+	}
+
+	readerTransport := NewStdioTransport(buf, &bytes.Buffer{})
+
+	msg, err := readerTransport.ReadMessage(context.Background())
+	if err != nil {
+		t.Fatalf("ReadMessage error: %v", err)
+	}
+
+	if msg.Method != "tools/list" {
+		t.Errorf("expected method=tools/list, got %s", msg.Method)
+	}
+	if string(msg.ID) != "42" {
+		t.Errorf("expected id=42, got %s", msg.ID)
+	}
+}
+
+func TestStdioTransport_ReadMessage_ContextCancelled(t *testing.T) {
+	// Use a reader that blocks forever (no data)
+	pr, _ := blockingPipe()
+
+	tr := NewStdioTransport(pr, &bytes.Buffer{})
+	defer tr.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := tr.ReadMessage(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestStdioTransport_ReadMessage_InvalidJSON(t *testing.T) {
+	input := "not valid json\n"
+	reader := strings.NewReader(input)
+
+	tr := NewStdioTransport(reader, &bytes.Buffer{})
+	defer tr.Close()
+
+	_, err := tr.ReadMessage(context.Background())
+	if err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestStdioTransport_ReadMessage_MultipleMessages(t *testing.T) {
+	input := `{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n" +
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list"}` + "\n"
+	reader := strings.NewReader(input)
+
+	tr := NewStdioTransport(reader, &bytes.Buffer{})
+	defer tr.Close()
+
+	msg1, err := tr.ReadMessage(context.Background())
+	if err != nil {
+		t.Fatalf("ReadMessage 1 error: %v", err)
+	}
+	if msg1.Method != "initialize" {
+		t.Errorf("msg1: expected method=initialize, got %s", msg1.Method)
+	}
+
+	msg2, err := tr.ReadMessage(context.Background())
+	if err != nil {
+		t.Fatalf("ReadMessage 2 error: %v", err)
+	}
+	if msg2.Method != "tools/list" {
+		t.Errorf("msg2: expected method=tools/list, got %s", msg2.Method)
+	}
+}
+
+// blockingPipe returns an io.Reader that blocks forever on reads.
+func blockingPipe() (*blockingReader, struct{}) {
+	return &blockingReader{ch: make(chan struct{})}, struct{}{}
+}
+
+type blockingReader struct {
+	ch chan struct{}
+}
+
+func (r *blockingReader) Read([]byte) (int, error) {
+	<-r.ch // blocks forever
+	return 0, nil
+}

--- a/services/mcp-server/internal/transport/transport.go
+++ b/services/mcp-server/internal/transport/transport.go
@@ -1,0 +1,18 @@
+package transport
+
+import "context"
+
+// Transport defines the interface for MCP server communication.
+// Implementations handle reading and writing JSON-RPC 2.0 messages
+// over different transport mechanisms (stdio, SSE).
+type Transport interface {
+	// ReadMessage reads the next JSON-RPC message from the transport.
+	// It blocks until a message is available or the context is cancelled.
+	ReadMessage(ctx context.Context) (*JSONRPCMessage, error)
+
+	// WriteMessage writes a JSON-RPC message to the transport.
+	WriteMessage(ctx context.Context, msg *JSONRPCMessage) error
+
+	// Close releases any resources held by the transport.
+	Close() error
+}


### PR DESCRIPTION
## Summary

Implements the core MCP (Model Context Protocol) server binary with dual transport support, providing the foundation for AI agent integration with Meridian services.

- Stdio transport: newline-delimited JSON-RPC 2.0 over stdin/stdout for local agent use
- SSE transport: HTTP Server-Sent Events with session management for networked clients
- MCP protocol handler: `initialize`, `tools/list`, `tools/call` method dispatch
- Tool registration interface for downstream tasks to plug in capabilities
- Multi-stage Dockerfile with distroless runtime image

**Task Master**: mcp-server.1

## Test plan

- [x] Unit tests: JSON-RPC message type classification and serialization (6 tests)
- [x] Unit tests: stdio transport read/write/roundtrip/context cancellation/invalid JSON (6 tests)
- [x] Unit tests: SSE transport message posting, session validation, broadcasts, close (10 tests)
- [x] Unit tests: MCP server initialize, tools/list (empty + registered), tools/call, unknown method, notification handling, context cancellation (8 tests)
- [x] Integration test: SSE endpoint discovery + POST message flow via httptest
- [x] Binary builds successfully with `go build`
- [ ] CI checks pass