### PR TITLE
feat: Create Lien dialog for current and internal accounts

### DIFF
--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -13,6 +13,9 @@ export const tenantKeys = {
   account: (tenantId: string, accountId: string) =>
     [...tenantKeys.accounts(tenantId), accountId] as const,
 
+  liens: (tenantId: string, accountId: string) =>
+    [...tenantKeys.account(tenantId, accountId), 'liens'] as const,
+
   transactions: (tenantId: string) =>
     [...tenantKeys.all(tenantId), 'transactions'] as const,
   transaction: (tenantId: string, transactionId: string) =>

--- a/frontend/src/pages/accounts/[accountId].tsx
+++ b/frontend/src/pages/accounts/[accountId].tsx
@@ -14,6 +14,7 @@ import { DepositDialog } from './deposit-dialog'
 import { WithdrawDialog } from './withdraw-dialog'
 import { ControlDialog } from './control-dialog'
 import type { ControlAction } from './control-dialog'
+import { CreateLienDialog } from './create-lien-dialog'
 import type { AccountStatus, CurrentAccount, RetrieveCurrentAccountResponse } from './types'
 
 async function retrieveAccount(
@@ -103,6 +104,7 @@ interface AccountActionsProps {
 function AccountActions({ status, accountId, currency }: AccountActionsProps) {
   const [depositOpen, setDepositOpen] = React.useState(false)
   const [withdrawOpen, setWithdrawOpen] = React.useState(false)
+  const [lienOpen, setLienOpen] = React.useState(false)
   const [controlOpen, setControlOpen] = React.useState(false)
   const [controlAction, setControlAction] = React.useState<ControlAction>('freeze')
 
@@ -125,6 +127,9 @@ function AccountActions({ status, accountId, currency }: AccountActionsProps) {
             </Button>
             <Button variant="outline" size="sm" onClick={() => setWithdrawOpen(true)}>
               Withdraw
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => setLienOpen(true)}>
+              Create Lien
             </Button>
             <Button variant="outline" size="sm" onClick={() => openControl('freeze')}>
               Freeze
@@ -153,6 +158,14 @@ function AccountActions({ status, accountId, currency }: AccountActionsProps) {
         onOpenChange={setWithdrawOpen}
         accountId={accountId}
         currency={currency}
+      />
+
+      <CreateLienDialog
+        open={lienOpen}
+        onOpenChange={setLienOpen}
+        accountId={accountId}
+        instrumentCode={currency}
+        accountType="current"
       />
 
       <ControlDialog

--- a/frontend/src/pages/accounts/create-lien-dialog.test.tsx
+++ b/frontend/src/pages/accounts/create-lien-dialog.test.tsx
@@ -1,0 +1,409 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/msw-handlers'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { CreateLienDialog } from './create-lien-dialog'
+
+const tenantToken = createTenantUserToken('tenant-test')
+
+function renderCurrentAccountDialog(props: {
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  accountId?: string
+  instrumentCode?: string
+  decimalPlaces?: number
+}) {
+  const {
+    open = true,
+    onOpenChange = vi.fn(),
+    accountId = 'acct-001',
+    instrumentCode = 'GBP',
+    decimalPlaces = 2,
+  } = props
+  return renderWithProviders(
+    <MemoryRouter>
+      <CreateLienDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        accountId={accountId}
+        instrumentCode={instrumentCode}
+        accountType="current"
+        decimalPlaces={decimalPlaces}
+      />
+    </MemoryRouter>,
+    { initialToken: tenantToken },
+  )
+}
+
+function renderInternalAccountDialog(props: {
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  accountId?: string
+  instrumentCode?: string
+  decimalPlaces?: number
+}) {
+  const {
+    open = true,
+    onOpenChange = vi.fn(),
+    accountId = 'internal-acct-001',
+    instrumentCode = 'GBP',
+    decimalPlaces = 2,
+  } = props
+  return renderWithProviders(
+    <MemoryRouter>
+      <CreateLienDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        accountId={accountId}
+        instrumentCode={instrumentCode}
+        accountType="internal"
+        decimalPlaces={decimalPlaces}
+      />
+    </MemoryRouter>,
+    { initialToken: tenantToken },
+  )
+}
+
+describe('CreateLienDialog - rendering', () => {
+  it('renders dialog when open', () => {
+    renderCurrentAccountDialog({})
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getAllByText(/create lien/i).length).toBeGreaterThan(0)
+  })
+
+  it('does not render when closed', () => {
+    renderCurrentAccountDialog({ open: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders amount input with instrument code label', () => {
+    renderCurrentAccountDialog({ instrumentCode: 'GBP' })
+    expect(screen.getByLabelText(/amount/i)).toBeInTheDocument()
+    expect(screen.getByText(/Amount \(GBP\)/i)).toBeInTheDocument()
+  })
+
+  it('renders reason input', () => {
+    renderCurrentAccountDialog({})
+    expect(screen.getByLabelText(/reason/i)).toBeInTheDocument()
+  })
+
+  it('renders expiry input', () => {
+    renderCurrentAccountDialog({})
+    expect(screen.getByLabelText(/expiry/i)).toBeInTheDocument()
+  })
+
+  it('renders create lien and cancel buttons', () => {
+    renderCurrentAccountDialog({})
+    expect(screen.getByRole('button', { name: /create lien/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('shows instrument code in description', () => {
+    renderCurrentAccountDialog({ instrumentCode: 'kWh' })
+    expect(screen.getAllByText(/kWh/).length).toBeGreaterThan(0)
+  })
+})
+
+describe('CreateLienDialog - validation', () => {
+  it('shows error when amount is empty on submit', async () => {
+    renderCurrentAccountDialog({})
+    await userEvent.type(screen.getByLabelText(/reason/i), 'pay-ref-001')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/amount is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when amount is zero', async () => {
+    renderCurrentAccountDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '0')
+    await userEvent.type(screen.getByLabelText(/reason/i), 'pay-ref-001')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/amount must be greater than zero/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when amount is negative', async () => {
+    renderCurrentAccountDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '-10')
+    await userEvent.type(screen.getByLabelText(/reason/i), 'pay-ref-001')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/amount must be greater than zero/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when amount is invalid', async () => {
+    renderCurrentAccountDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), 'abc')
+    await userEvent.type(screen.getByLabelText(/reason/i), 'pay-ref-001')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/invalid amount/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when reason is empty', async () => {
+    renderCurrentAccountDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '100.00')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/reason is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when expiry is in the past', async () => {
+    renderCurrentAccountDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '100.00')
+    await userEvent.type(screen.getByLabelText(/reason/i), 'pay-ref-001')
+    // Set expiry to past date
+    const expiryInput = screen.getByLabelText(/expiry/i)
+    await userEvent.type(expiryInput, '2020-01-01T00:00')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/expiry must be in the future/i)).toBeInTheDocument()
+    })
+  })
+
+  it('accepts valid future expiry date', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/InitiateLien', async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({ lien: { lienId: 'lien-abc' } })
+      }),
+    )
+
+    renderCurrentAccountDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '100.00')
+    await userEvent.type(screen.getByLabelText(/reason/i), 'pay-ref-001')
+    const expiryInput = screen.getByLabelText(/expiry/i)
+    await userEvent.type(expiryInput, '2099-12-31T23:59')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({
+        expiresAt: expect.objectContaining({ seconds: expect.any(String) }),
+      })
+    })
+  })
+})
+
+describe('CreateLienDialog - current account API', () => {
+  beforeEach(() => {
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/InitiateLien', () =>
+        HttpResponse.json({ lien: { lienId: 'lien-001' } }),
+      ),
+    )
+  })
+
+  it('calls CurrentAccountService with amount and paymentOrderReference', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/InitiateLien', async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({ lien: { lienId: 'lien-001' } })
+      }),
+    )
+
+    renderCurrentAccountDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '100.50')
+    await userEvent.type(screen.getByLabelText(/reason/i), 'pay-ref-001')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({
+        accountId: 'acct-001',
+        amount: { amount: '10050' },
+        paymentOrderReference: 'pay-ref-001',
+      })
+    })
+  })
+
+  it('shows lien ID on success', async () => {
+    renderCurrentAccountDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '100.00')
+    await userEvent.type(screen.getByLabelText(/reason/i), 'pay-ref-001')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lien-id')).toHaveTextContent('lien-001')
+    })
+  })
+
+  it('shows server error on failure', async () => {
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/InitiateLien', () =>
+        HttpResponse.json({ message: 'Insufficient funds' }, { status: 400 }),
+      ),
+    )
+
+    renderCurrentAccountDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '100.00')
+    await userEvent.type(screen.getByLabelText(/reason/i), 'pay-ref-001')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+
+  it('disables submit button during submission', async () => {
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/InitiateLien', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        return HttpResponse.json({ lien: { lienId: 'lien-001' } })
+      }),
+    )
+
+    renderCurrentAccountDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '100.00')
+    await userEvent.type(screen.getByLabelText(/reason/i), 'pay-ref-001')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+
+    expect(screen.getByRole('button', { name: /creating|create lien/i })).toBeDisabled()
+  })
+})
+
+describe('CreateLienDialog - internal account API', () => {
+  it('calls InternalBankAccountService with input field instead of amount', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post(
+        '*/meridian.internal_bank_account.v1.InternalBankAccountService/InitiateLien',
+        async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({ lien: { lienId: 'lien-internal-001' } })
+        },
+      ),
+    )
+
+    renderInternalAccountDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '250.00')
+    await userEvent.type(screen.getByLabelText(/reason/i), 'internal-ref-001')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({
+        accountId: 'internal-acct-001',
+        input: { amount: '25000' },
+        paymentOrderReference: 'internal-ref-001',
+      })
+    })
+  })
+
+  it('does not include amount field for internal accounts', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post(
+        '*/meridian.internal_bank_account.v1.InternalBankAccountService/InitiateLien',
+        async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({ lien: { lienId: 'lien-internal-001' } })
+        },
+      ),
+    )
+
+    renderInternalAccountDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '100.00')
+    await userEvent.type(screen.getByLabelText(/reason/i), 'internal-ref-001')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+
+    await waitFor(() => {
+      const body = capturedBody as Record<string, unknown>
+      expect(body.amount).toBeUndefined()
+      expect(body.input).toBeDefined()
+    })
+  })
+
+  it('shows lien ID on success for internal accounts', async () => {
+    server.use(
+      http.post(
+        '*/meridian.internal_bank_account.v1.InternalBankAccountService/InitiateLien',
+        () => HttpResponse.json({ lien: { lienId: 'lien-internal-001' } }),
+      ),
+    )
+
+    renderInternalAccountDialog({})
+    await userEvent.type(screen.getByLabelText(/amount/i), '100.00')
+    await userEvent.type(screen.getByLabelText(/reason/i), 'internal-ref-001')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lien-id')).toHaveTextContent('lien-internal-001')
+    })
+  })
+})
+
+describe('CreateLienDialog - decimal places', () => {
+  it('converts amount using custom decimal places', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post('*/meridian.current_account.v1.CurrentAccountService/InitiateLien', async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({ lien: { lienId: 'lien-001' } })
+      }),
+    )
+
+    renderCurrentAccountDialog({ instrumentCode: 'kWh', decimalPlaces: 3 })
+    await userEvent.type(screen.getByLabelText(/amount/i), '1.500')
+    await userEvent.type(screen.getByLabelText(/reason/i), 'energy-ref-001')
+    await userEvent.click(screen.getByRole('button', { name: /create lien/i }))
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({
+        amount: { amount: '1500' },
+      })
+    })
+  })
+})
+
+describe('CreateLienDialog - cancel', () => {
+  it('calls onOpenChange(false) when cancel clicked', async () => {
+    const onOpenChange = vi.fn()
+    renderCurrentAccountDialog({ onOpenChange })
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})
+
+describe('CreateLienDialog - reset on close', () => {
+  it('clears form when dialog closes and reopens', () => {
+    const { rerender } = renderCurrentAccountDialog({ open: true })
+
+    // Close dialog
+    rerender(
+      <MemoryRouter>
+        <CreateLienDialog
+          open={false}
+          onOpenChange={vi.fn()}
+          accountId="acct-001"
+          instrumentCode="GBP"
+          accountType="current"
+        />
+      </MemoryRouter>,
+    )
+
+    // Reopen dialog
+    rerender(
+      <MemoryRouter>
+        <CreateLienDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          accountId="acct-001"
+          instrumentCode="GBP"
+          accountType="current"
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByLabelText(/amount/i)).toHaveValue('')
+    expect(screen.getByLabelText(/reason/i)).toHaveValue('')
+  })
+})

--- a/frontend/src/pages/accounts/create-lien-dialog.tsx
+++ b/frontend/src/pages/accounts/create-lien-dialog.tsx
@@ -44,9 +44,18 @@ function validateReason(value: string): string | null {
   return null
 }
 
+/**
+ * Parses a datetime-local string (YYYY-MM-DDTHH:mm) as UTC.
+ * The datetime-local input produces a timezone-naive string; treating it as
+ * UTC ensures consistent behaviour regardless of the operator's local timezone.
+ */
+function parseDatetimeLocalAsUtc(value: string): Date {
+  return new Date(value + ':00Z')
+}
+
 function validateExpiry(value: string): string | null {
   if (!value) return null
-  const date = new Date(value)
+  const date = parseDatetimeLocalAsUtc(value)
   if (isNaN(date.getTime())) return 'Invalid date'
   if (date <= new Date()) return 'Expiry must be in the future'
   return null
@@ -139,7 +148,7 @@ export function CreateLienDialog({
     mutationFn: () => {
       const minorUnits = amountToBigInt(amount, decimalPlaces).toString()
       const expiresAtSeconds = expiry
-        ? Math.floor(new Date(expiry).getTime() / 1000).toString()
+        ? Math.floor(parseDatetimeLocalAsUtc(expiry).getTime() / 1000).toString()
         : undefined
       return initiateLien(
         tenantSlug ?? '',

--- a/frontend/src/pages/accounts/create-lien-dialog.tsx
+++ b/frontend/src/pages/accounts/create-lien-dialog.tsx
@@ -1,0 +1,307 @@
+import * as React from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useTenantContext } from '@/contexts/tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import { amountToBigInt } from './account-form-utils'
+
+export interface CreateLienDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  accountId: string
+  instrumentCode: string
+  accountType: 'current' | 'internal'
+  decimalPlaces?: number
+}
+
+function validateAmount(value: string, decimalPlaces: number): string | null {
+  const trimmed = value.trim()
+  if (!trimmed) return 'Amount is required'
+  try {
+    const minorUnits = amountToBigInt(trimmed, decimalPlaces)
+    if (minorUnits <= 0n) return 'Amount must be greater than zero'
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Invalid amount'
+    if (msg === 'Amount must be positive') return 'Amount must be greater than zero'
+    return 'Invalid amount'
+  }
+  return null
+}
+
+function validateReason(value: string): string | null {
+  const trimmed = value.trim()
+  if (!trimmed) return 'Reason is required'
+  if (trimmed.length > 255) return 'Reason must be 255 characters or fewer'
+  return null
+}
+
+function validateExpiry(value: string): string | null {
+  if (!value) return null
+  const date = new Date(value)
+  if (isNaN(date.getTime())) return 'Invalid date'
+  if (date <= new Date()) return 'Expiry must be in the future'
+  return null
+}
+
+async function initiateLien(
+  tenantSlug: string,
+  accountId: string,
+  accountType: 'current' | 'internal',
+  amountMinorUnits: string,
+  reason: string,
+  expiresAtSeconds?: string,
+): Promise<string> {
+  const serviceName =
+    accountType === 'current'
+      ? 'meridian.current_account.v1.CurrentAccountService'
+      : 'meridian.internal_bank_account.v1.InternalBankAccountService'
+
+  const body: Record<string, unknown> = {
+    accountId,
+    paymentOrderReference: reason,
+  }
+
+  if (accountType === 'current') {
+    body.amount = { amount: amountMinorUnits }
+  } else {
+    body.input = { amount: amountMinorUnits }
+  }
+
+  if (expiresAtSeconds) {
+    body.expiresAt = { seconds: expiresAtSeconds }
+  }
+
+  const response = await fetch(`/api/${serviceName}/InitiateLien`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Tenant-Slug': tenantSlug,
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    const data = (await response.json().catch(() => ({}))) as { message?: string }
+    throw new Error(data.message ?? `Failed to create lien: ${response.status}`)
+  }
+
+  const data = (await response.json()) as { lien?: { lienId?: string } }
+  const lienId = data.lien?.lienId ?? ''
+  if (!lienId) {
+    throw new Error('Lien ID missing from response')
+  }
+  return lienId
+}
+
+export function CreateLienDialog({
+  open,
+  onOpenChange,
+  accountId,
+  instrumentCode,
+  accountType,
+  decimalPlaces = 2,
+}: CreateLienDialogProps) {
+  const { tenantSlug } = useTenantContext()
+  const queryClient = useQueryClient()
+
+  const [amount, setAmount] = React.useState('')
+  const [reason, setReason] = React.useState('')
+  const [expiry, setExpiry] = React.useState('')
+  const [amountError, setAmountError] = React.useState<string | null>(null)
+  const [reasonError, setReasonError] = React.useState<string | null>(null)
+  const [expiryError, setExpiryError] = React.useState<string | null>(null)
+  const [serverError, setServerError] = React.useState<string | null>(null)
+  const [successLienId, setSuccessLienId] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    if (!open) {
+      setAmount('')
+      setReason('')
+      setExpiry('')
+      setAmountError(null)
+      setReasonError(null)
+      setExpiryError(null)
+      setServerError(null)
+      setSuccessLienId(null)
+    }
+  }, [open])
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      const minorUnits = amountToBigInt(amount, decimalPlaces).toString()
+      const expiresAtSeconds = expiry
+        ? Math.floor(new Date(expiry).getTime() / 1000).toString()
+        : undefined
+      return initiateLien(
+        tenantSlug ?? '',
+        accountId,
+        accountType,
+        minorUnits,
+        reason.trim(),
+        expiresAtSeconds,
+      )
+    },
+    onSuccess: (lienId) => {
+      queryClient.invalidateQueries({
+        queryKey: tenantKeys.account(tenantSlug ?? '', accountId),
+      })
+      queryClient.invalidateQueries({
+        queryKey: tenantKeys.liens(tenantSlug ?? '', accountId),
+      })
+      setSuccessLienId(lienId)
+    },
+    onError: (error: Error) => {
+      setServerError(error.message)
+    },
+  })
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+
+    const amtErr = validateAmount(amount, decimalPlaces)
+    const rsnErr = validateReason(reason)
+    const expErr = validateExpiry(expiry)
+
+    setAmountError(amtErr)
+    setReasonError(rsnErr)
+    setExpiryError(expErr)
+
+    if (amtErr || rsnErr || expErr) return
+
+    setServerError(null)
+    mutation.mutate()
+  }
+
+  if (successLienId) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Lien Created</DialogTitle>
+            <DialogDescription>
+              The lien has been successfully created on account {accountId}.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="py-2">
+            <p className="text-sm text-muted-foreground">Lien ID</p>
+            <p className="font-mono text-sm" data-testid="lien-id">{successLienId}</p>
+          </div>
+          <DialogFooter>
+            <Button onClick={() => onOpenChange(false)}>Close</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create Lien</DialogTitle>
+          <DialogDescription>
+            Reserve funds on account {accountId} ({instrumentCode})
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="create-lien-form">
+          <div className="space-y-4 py-2">
+            <div className="space-y-1">
+              <label htmlFor="lien-amount" className="text-sm font-medium">
+                Amount ({instrumentCode})
+              </label>
+              <Input
+                id="lien-amount"
+                value={amount}
+                onChange={(e) => {
+                  setAmount(e.target.value)
+                  if (amountError) setAmountError(null)
+                }}
+                placeholder="0.00"
+                type="text"
+                inputMode="decimal"
+                aria-describedby={amountError ? 'lien-amount-error' : undefined}
+                aria-label="Amount"
+              />
+              {amountError && (
+                <p id="lien-amount-error" className="text-sm text-destructive">
+                  {amountError}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="lien-reason" className="text-sm font-medium">
+                Reason
+              </label>
+              <Input
+                id="lien-reason"
+                value={reason}
+                onChange={(e) => {
+                  setReason(e.target.value)
+                  if (reasonError) setReasonError(null)
+                }}
+                placeholder="e.g. payment-order-123"
+                aria-describedby={reasonError ? 'lien-reason-error' : undefined}
+              />
+              {reasonError && (
+                <p id="lien-reason-error" className="text-sm text-destructive">
+                  {reasonError}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="lien-expiry" className="text-sm font-medium">
+                Expiry (optional)
+              </label>
+              <Input
+                id="lien-expiry"
+                value={expiry}
+                onChange={(e) => {
+                  setExpiry(e.target.value)
+                  if (expiryError) setExpiryError(null)
+                }}
+                type="datetime-local"
+                aria-describedby={expiryError ? 'lien-expiry-error' : undefined}
+              />
+              {expiryError && (
+                <p id="lien-expiry-error" className="text-sm text-destructive">
+                  {expiryError}
+                </p>
+              )}
+            </div>
+
+            {serverError && (
+              <div role="alert" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                {serverError}
+              </div>
+            )}
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="create-lien-form"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Creating...' : 'Create Lien'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `CreateLienDialog` component shared between customer account and internal account pages
- Adds `tenantKeys.liens()` query key factory for cache invalidation
- Integrates **Create Lien** button into `AccountDetailPage` (active accounts only)

## Changes

### `frontend/src/lib/query-keys.ts`
- Adds `liens(tenantId, accountId)` key factory nested under `account`

### `frontend/src/pages/accounts/create-lien-dialog.tsx`
- `CreateLienDialogProps`: `open`, `onOpenChange`, `accountId`, `instrumentCode`, `accountType`, `decimalPlaces`
- Form fields: amount (required), reason → `paymentOrderReference` (required, 1-255 chars), expiry (optional, future-only datetime)
- Conditional API routing: `CurrentAccountService/InitiateLien` vs `InternalBankAccountService/InitiateLien`
- Uses `amountToBigInt()` with configurable `decimalPlaces` (default 2) for non-currency instruments
- On success: invalidates account detail and liens query keys, shows lien ID in success view
- On failure: shows server error alert

### `frontend/src/pages/accounts/[accountId].tsx`
- Adds **Create Lien** button to `AccountActions` (visible when account is ACTIVE)

### `frontend/src/pages/accounts/create-lien-dialog.test.tsx`
- 24 tests covering rendering, validation (amount, reason, expiry), API routing, decimal places, and cancel behaviour

## Test plan

- [x] All 24 new tests pass
- [x] All 1177 existing tests continue to pass
- [x] Current account API path: `CurrentAccountService/InitiateLien` with `amount` field
- [x] Internal account API path: `InternalBankAccountService/InitiateLien` with `input` field
- [x] Amount validation (empty, zero, negative, invalid)
- [x] Reason validation (empty, max length)
- [x] Expiry validation (past date rejected)
- [x] Success displays lien ID
- [x] Custom decimal places (e.g. `kWh` with 3 decimal places)