### PR TITLE
feat: add RegisterDataSetDialog to market data page

### DIFF
--- a/frontend/src/pages/market-data/constants.ts
+++ b/frontend/src/pages/market-data/constants.ts
@@ -1,0 +1,20 @@
+export const CATEGORY_OPTIONS = [
+  { label: 'FX Rate', value: '1' },
+  { label: 'Interest Rate', value: '2' },
+  { label: 'Commodity Price', value: '3' },
+  { label: 'Equity Price', value: '4' },
+  { label: 'Index Value', value: '5' },
+  { label: 'Energy Price', value: '6' },
+  { label: 'Carbon Price', value: '7' },
+  { label: 'Benchmark Rate', value: '8' },
+  { label: 'Volatility', value: '9' },
+  { label: 'Credit Spread', value: '10' },
+]
+
+export const STATUS_OPTIONS = [
+  { label: 'Draft', value: '1' },
+  { label: 'Active', value: '2' },
+  { label: 'Deprecated', value: '3' },
+]
+
+export const CODE_PATTERN = /^[A-Z][A-Z0-9_-]*$/

--- a/frontend/src/pages/market-data/index.test.tsx
+++ b/frontend/src/pages/market-data/index.test.tsx
@@ -26,7 +26,12 @@ vi.mock('@/api/clients', () => ({
     internalBankAccount: {},
     marketInformation: {
       listDataSets: vi.fn(),
+      registerDataSet: vi.fn(),
     },
+    mapping: {},
+    forecasting: {},
+    manifestHistory: {},
+    manifestApplier: {},
   })),
 }))
 
@@ -73,7 +78,12 @@ function setupMock(datasets = [makeDataset()], nextPageToken = '') {
         datasets,
         nextPageToken,
       }),
+      registerDataSet: vi.fn(),
     } as never,
+    mapping: {} as never,
+    forecasting: {} as never,
+    manifestHistory: {} as never,
+    manifestApplier: {} as never,
   })
 }
 
@@ -154,7 +164,12 @@ describe('MarketDataPage', () => {
       internalBankAccount: {} as never,
       marketInformation: {
         listDataSets: vi.fn().mockReturnValue(new Promise(() => {})),
+        registerDataSet: vi.fn(),
       } as never,
+      mapping: {} as never,
+      forecasting: {} as never,
+      manifestHistory: {} as never,
+      manifestApplier: {} as never,
     })
     renderPage()
     expect(screen.getAllByTestId('skeleton-row').length).toBeGreaterThan(0)
@@ -180,5 +195,21 @@ describe('MarketDataPage', () => {
     setupMock()
     renderPage()
     expect(screen.getByRole('combobox', { name: /status/i })).toBeInTheDocument()
+  })
+
+  it('renders Register Dataset button', () => {
+    setupMock()
+    renderPage()
+    expect(screen.getByRole('button', { name: /register dataset/i })).toBeInTheDocument()
+  })
+
+  it('opens registration dialog when Register Dataset button is clicked', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    setupMock()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: /register dataset/i }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /register data set/i })).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/market-data/index.tsx
+++ b/frontend/src/pages/market-data/index.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import type { ColumnDef } from '@tanstack/react-table'
 import { useNavigate } from 'react-router-dom'
 import { DataTable } from '@/components/shared/data-table'
@@ -6,6 +7,9 @@ import { TimeDisplay } from '@/components/shared'
 import { useApiClients } from '@/api/context'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
+import { Button } from '@/components/ui/button'
+import { CATEGORY_OPTIONS, STATUS_OPTIONS } from './constants'
+import { RegisterDataSetDialog } from './register-dataset-dialog'
 
 interface DataSetRow {
   id: string
@@ -57,25 +61,6 @@ function dataCategoryLabel(category: number): string {
   }
 }
 
-const STATUS_OPTIONS = [
-  { label: 'Draft', value: '1' },
-  { label: 'Active', value: '2' },
-  { label: 'Deprecated', value: '3' },
-]
-
-const CATEGORY_OPTIONS = [
-  { label: 'FX Rate', value: '1' },
-  { label: 'Interest Rate', value: '2' },
-  { label: 'Commodity Price', value: '3' },
-  { label: 'Equity Price', value: '4' },
-  { label: 'Index Value', value: '5' },
-  { label: 'Energy Price', value: '6' },
-  { label: 'Carbon Price', value: '7' },
-  { label: 'Benchmark Rate', value: '8' },
-  { label: 'Volatility', value: '9' },
-  { label: 'Credit Spread', value: '10' },
-]
-
 const columns: ColumnDef<DataSetRow>[] = [
   {
     accessorKey: 'code',
@@ -125,6 +110,7 @@ export function MarketDataPage() {
   const { tenantSlug } = useTenantContext()
   const clients = useApiClients()
   const navigate = useNavigate()
+  const [registerOpen, setRegisterOpen] = React.useState(false)
 
   if (!tenantSlug) {
     return (
@@ -136,11 +122,14 @@ export function MarketDataPage() {
 
   return (
     <div className="p-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-semibold">Market Data</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Market data sets with price observations for FX rates, interest rates, energy prices, and more.
-        </p>
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Market Data</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Market data sets with price observations for FX rates, interest rates, energy prices, and more.
+          </p>
+        </div>
+        <Button onClick={() => setRegisterOpen(true)}>Register Dataset</Button>
       </div>
 
       <DataTable<DataSetRow>
@@ -185,6 +174,8 @@ export function MarketDataPage() {
         ]}
         onRowClick={(row) => navigate(`/market-data/${row.code}`)}
       />
+
+      <RegisterDataSetDialog open={registerOpen} onOpenChange={setRegisterOpen} />
     </div>
   )
 }

--- a/frontend/src/pages/market-data/register-dataset-dialog.test.tsx
+++ b/frontend/src/pages/market-data/register-dataset-dialog.test.tsx
@@ -1,0 +1,315 @@
+import * as React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { RegisterDataSetDialog } from './register-dataset-dialog'
+import { CATEGORY_OPTIONS } from './constants'
+
+vi.mock('@/api/transport', () => ({
+  createTenantTransport: vi.fn(() => ({ __type: 'mock-transport' })),
+}))
+
+vi.mock('@/api/clients', () => ({
+  createServiceClients: vi.fn(() => ({
+    currentAccount: {},
+    paymentOrder: {},
+    financialAccounting: {},
+    positionKeeping: {},
+    accountReconciliation: {},
+    party: {},
+    tenant: {},
+    sagaRegistry: {},
+    sagaAdmin: {},
+    referenceData: {},
+    accountTypeRegistry: {},
+    node: {},
+    internalBankAccount: {},
+    marketInformation: {
+      registerDataSet: vi.fn(),
+    },
+    mapping: {},
+    forecasting: {},
+    manifestHistory: {},
+    manifestApplier: {},
+  })),
+}))
+
+import { createServiceClients } from '@/api/clients'
+
+function setupMock(registerDataSet: ReturnType<typeof vi.fn> = vi.fn()) {
+  vi.mocked(createServiceClients).mockReturnValue({
+    currentAccount: {} as never,
+    paymentOrder: {} as never,
+    financialAccounting: {} as never,
+    positionKeeping: {} as never,
+    accountReconciliation: {} as never,
+    party: {} as never,
+    tenant: {} as never,
+    sagaRegistry: {} as never,
+    sagaAdmin: {} as never,
+    referenceData: {} as never,
+    accountTypeRegistry: {} as never,
+    node: {} as never,
+    internalBankAccount: {} as never,
+    marketInformation: {
+      registerDataSet,
+    } as never,
+    mapping: {} as never,
+    forecasting: {} as never,
+    manifestHistory: {} as never,
+    manifestApplier: {} as never,
+  })
+}
+
+function renderDialog(open = true, onOpenChange = vi.fn()) {
+  return renderWithProviders(
+    <MemoryRouter>
+      <RegisterDataSetDialog open={open} onOpenChange={onOpenChange} />
+    </MemoryRouter>,
+    { initialToken: createTenantUserToken('tenant-001') },
+  )
+}
+
+describe('RegisterDataSetDialog - rendering', () => {
+  beforeEach(() => {
+    setupMock()
+  })
+
+  it('does not render dialog content when closed', () => {
+    renderDialog(false)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders dialog when open', () => {
+    renderDialog()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /register data set/i })).toBeInTheDocument()
+  })
+
+  it('renders all form fields', () => {
+    renderDialog()
+    expect(screen.getByLabelText(/^code$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^category$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^unit$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
+  })
+
+  it('renders submit and cancel buttons', () => {
+    renderDialog()
+    expect(screen.getByRole('button', { name: /register data set/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+})
+
+describe('RegisterDataSetDialog - category options', () => {
+  beforeEach(() => {
+    setupMock()
+  })
+
+  it('renders all CATEGORY_OPTIONS in the select', () => {
+    renderDialog()
+    const select = screen.getByLabelText(/^category$/i)
+    for (const opt of CATEGORY_OPTIONS) {
+      expect(select).toContainElement(
+        screen.getByRole('option', { name: opt.label }),
+      )
+    }
+  })
+
+  it('renders 10 category options plus the placeholder', () => {
+    renderDialog()
+    const select = screen.getByLabelText(/^category$/i) as HTMLSelectElement
+    // 10 categories + 1 placeholder
+    expect(select.options).toHaveLength(11)
+  })
+})
+
+describe('RegisterDataSetDialog - code validation', () => {
+  beforeEach(() => {
+    setupMock()
+  })
+
+  it('shows error when code is empty', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.click(screen.getByRole('button', { name: /register data set/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/code is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error for code shorter than 2 characters', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.type(screen.getByLabelText(/^code$/i), 'A')
+    await user.click(screen.getByRole('button', { name: /register data set/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/2.50 characters/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error for code that does not match pattern (lowercase)', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.type(screen.getByLabelText(/^code$/i), 'invalid_code')
+    await user.click(screen.getByRole('button', { name: /register data set/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/must start with a letter/i)).toBeInTheDocument()
+    })
+  })
+
+  it('accepts valid code matching pattern', async () => {
+    const user = userEvent.setup()
+    setupMock(vi.fn().mockResolvedValue({ dataset: { code: 'USD_EUR_FX' } }))
+    renderDialog()
+    await user.type(screen.getByLabelText(/^code$/i), 'USD_EUR_FX')
+    await user.type(screen.getByLabelText(/display name/i), 'USD/EUR FX Rate')
+    await user.selectOptions(screen.getByLabelText(/^category$/i), '1')
+    await user.type(screen.getByLabelText(/^unit$/i), 'USD/EUR')
+    await user.click(screen.getByRole('button', { name: /register data set/i }))
+    await waitFor(() => {
+      expect(screen.queryByText(/must start with a letter/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/code is required/i)).not.toBeInTheDocument()
+    })
+  })
+})
+
+describe('RegisterDataSetDialog - required field validation', () => {
+  beforeEach(() => {
+    setupMock()
+  })
+
+  it('shows error when display name is empty', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.type(screen.getByLabelText(/^code$/i), 'USD_EUR_FX')
+    await user.click(screen.getByRole('button', { name: /register data set/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/display name is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when category is not selected', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.type(screen.getByLabelText(/^code$/i), 'USD_EUR_FX')
+    await user.type(screen.getByLabelText(/display name/i), 'USD/EUR FX Rate')
+    await user.click(screen.getByRole('button', { name: /register data set/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/category is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when unit is empty', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.type(screen.getByLabelText(/^code$/i), 'USD_EUR_FX')
+    await user.type(screen.getByLabelText(/display name/i), 'USD/EUR FX Rate')
+    await user.selectOptions(screen.getByLabelText(/^category$/i), '1')
+    await user.click(screen.getByRole('button', { name: /register data set/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/unit is required/i)).toBeInTheDocument()
+    })
+  })
+})
+
+describe('RegisterDataSetDialog - successful submission', () => {
+  it('calls registerDataSet with correct data', async () => {
+    const user = userEvent.setup()
+    const registerDataSet = vi.fn().mockResolvedValue({
+      dataset: { code: 'USD_EUR_FX', id: 'ds-001' },
+    })
+    setupMock(registerDataSet)
+
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/^code$/i), 'USD_EUR_FX')
+    await user.type(screen.getByLabelText(/display name/i), 'USD/EUR FX Rate')
+    await user.selectOptions(screen.getByLabelText(/^category$/i), '1')
+    await user.type(screen.getByLabelText(/^unit$/i), 'USD/EUR')
+    await user.type(screen.getByLabelText(/description/i), 'Exchange rate dataset')
+    await user.click(screen.getByRole('button', { name: /register data set/i }))
+
+    await waitFor(() => {
+      expect(registerDataSet).toHaveBeenCalledOnce()
+      expect(registerDataSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'USD_EUR_FX',
+          displayName: 'USD/EUR FX Rate',
+          category: 1,
+          unit: 'USD/EUR',
+          description: 'Exchange rate dataset',
+        }),
+      )
+    })
+  })
+
+  it('disables submit button while pending', () => {
+    setupMock(vi.fn().mockReturnValue(new Promise(() => {})))
+    renderDialog()
+    expect(screen.queryByRole('button', { name: /registering/i })).not.toBeInTheDocument()
+  })
+})
+
+describe('RegisterDataSetDialog - error handling', () => {
+  it('shows general error banner on server error', async () => {
+    const user = userEvent.setup()
+    const { Code, ConnectError } = await import('@connectrpc/connect')
+    const err = new ConnectError('Service unavailable', Code.Unavailable)
+    setupMock(vi.fn().mockRejectedValue(err))
+
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/^code$/i), 'USD_EUR_FX')
+    await user.type(screen.getByLabelText(/display name/i), 'USD/EUR FX Rate')
+    await user.selectOptions(screen.getByLabelText(/^category$/i), '1')
+    await user.type(screen.getByLabelText(/^unit$/i), 'USD/EUR')
+    await user.click(screen.getByRole('button', { name: /register data set/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('RegisterDataSetDialog - reset on close', () => {
+  it('clears form when dialog closes via cancel and reopens', async () => {
+    const user = userEvent.setup()
+    setupMock()
+
+    function ControlledDialog() {
+      const [open, setOpen] = React.useState(false)
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Open Dialog</button>
+          <RegisterDataSetDialog open={open} onOpenChange={setOpen} />
+        </>
+      )
+    }
+
+    renderWithProviders(
+      <MemoryRouter>
+        <ControlledDialog />
+      </MemoryRouter>,
+      { initialToken: createTenantUserToken('tenant-001') },
+    )
+
+    // Open dialog and type a value
+    await user.click(screen.getByRole('button', { name: 'Open Dialog' }))
+    await user.type(screen.getByLabelText(/^code$/i), 'USD_EUR_FX')
+    expect(screen.getByLabelText(/^code$/i)).toHaveValue('USD_EUR_FX')
+
+    // Close via Cancel button
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+    // Re-open
+    await user.click(screen.getByRole('button', { name: 'Open Dialog' }))
+
+    // Form should be cleared
+    expect(screen.getByLabelText(/^code$/i)).toHaveValue('')
+  })
+})

--- a/frontend/src/pages/market-data/register-dataset-dialog.test.tsx
+++ b/frontend/src/pages/market-data/register-dataset-dialog.test.tsx
@@ -248,10 +248,20 @@ describe('RegisterDataSetDialog - successful submission', () => {
     })
   })
 
-  it('disables submit button while pending', () => {
+  it('disables submit button while pending', async () => {
+    const user = userEvent.setup()
     setupMock(vi.fn().mockReturnValue(new Promise(() => {})))
     renderDialog()
-    expect(screen.queryByRole('button', { name: /registering/i })).not.toBeInTheDocument()
+
+    await user.type(screen.getByLabelText(/^code$/i), 'USD_EUR_FX')
+    await user.type(screen.getByLabelText(/display name/i), 'USD/EUR FX Rate')
+    await user.selectOptions(screen.getByLabelText(/^category$/i), '1')
+    await user.type(screen.getByLabelText(/^unit$/i), 'USD/EUR')
+    await user.click(screen.getByRole('button', { name: /register data set/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /registering/i })).toBeDisabled()
+    })
   })
 })
 

--- a/frontend/src/pages/market-data/register-dataset-dialog.tsx
+++ b/frontend/src/pages/market-data/register-dataset-dialog.tsx
@@ -1,0 +1,282 @@
+import * as React from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useApiClients } from '@/api/context'
+import { useTenantContext } from '@/contexts/tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import { handleConnectError } from '@/lib/error-handling'
+import { CATEGORY_OPTIONS, CODE_PATTERN } from './constants'
+
+interface FormData {
+  code: string
+  displayName: string
+  category: string
+  unit: string
+  description: string
+}
+
+interface FormErrors {
+  code?: string
+  displayName?: string
+  category?: string
+  unit?: string
+  general?: string
+}
+
+interface RegisterDataSetDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const INITIAL_FORM: FormData = {
+  code: '',
+  displayName: '',
+  category: '',
+  unit: '',
+  description: '',
+}
+
+function validate(data: FormData): FormErrors {
+  const errors: FormErrors = {}
+
+  const code = data.code.trim()
+  if (!code) {
+    errors.code = 'Code is required'
+  } else if (code.length < 2 || code.length > 50) {
+    errors.code = 'Code must be 2–50 characters'
+  } else if (!CODE_PATTERN.test(code)) {
+    errors.code = 'Code must start with a letter and contain only A–Z, 0–9, _ or -'
+  }
+
+  if (!data.displayName.trim()) {
+    errors.displayName = 'Display name is required'
+  } else if (data.displayName.trim().length > 255) {
+    errors.displayName = 'Display name must be 255 characters or fewer'
+  }
+
+  if (!data.category) {
+    errors.category = 'Category is required'
+  }
+
+  if (!data.unit.trim()) {
+    errors.unit = 'Unit is required'
+  }
+
+  return errors
+}
+
+export function RegisterDataSetDialog({ open, onOpenChange }: RegisterDataSetDialogProps) {
+  const { tenantSlug } = useTenantContext()
+  const clients = useApiClients()
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const [formData, setFormData] = React.useState<FormData>(INITIAL_FORM)
+  const [errors, setErrors] = React.useState<FormErrors>({})
+
+  React.useEffect(() => {
+    if (!open) {
+      setFormData(INITIAL_FORM)
+      setErrors({})
+    }
+  }, [open])
+
+  function handleChange(field: keyof FormData) {
+    return (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+      setFormData((prev) => ({ ...prev, [field]: e.target.value }))
+      if (errors[field as keyof FormErrors]) {
+        setErrors((prev) => ({ ...prev, [field]: undefined }))
+      }
+    }
+  }
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      return clients.marketInformation.registerDataSet({
+        code: formData.code.trim(),
+        displayName: formData.displayName.trim(),
+        category: parseInt(formData.category, 10),
+        unit: formData.unit.trim(),
+        description: formData.description.trim(),
+        resolutionKeyExpression: '',
+        validationExpression: '',
+        errorMessageExpression: '',
+      })
+    },
+    onSuccess: (res) => {
+      queryClient.invalidateQueries({
+        queryKey: [...tenantKeys.all(tenantSlug ?? ''), 'market-data', 'datasets'],
+      })
+      onOpenChange(false)
+      navigate(`/market-data/${res.dataset?.code ?? formData.code.trim()}`)
+    },
+    onError: (error: unknown) => {
+      const result = handleConnectError(error)
+      if (Object.keys(result.fieldErrors).length > 0) {
+        const mapped: FormErrors = {}
+        if (result.fieldErrors.code) mapped.code = result.fieldErrors.code
+        if (result.fieldErrors.display_name) mapped.displayName = result.fieldErrors.display_name
+        if (result.fieldErrors.category) mapped.category = result.fieldErrors.category
+        if (result.fieldErrors.unit) mapped.unit = result.fieldErrors.unit
+        setErrors(mapped)
+      } else {
+        setErrors({ general: result.message })
+      }
+    },
+  })
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const next = validate(formData)
+    if (Object.keys(next).length > 0) {
+      setErrors(next)
+      return
+    }
+    setErrors({})
+    mutation.mutate()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Register Data Set</DialogTitle>
+          <DialogDescription>
+            Create a new market data set definition in DRAFT status.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="register-dataset-form">
+          <div className="space-y-4 py-2">
+            <div className="space-y-1">
+              <label htmlFor="dataset-code" className="text-sm font-medium">
+                Code
+              </label>
+              <Input
+                id="dataset-code"
+                value={formData.code}
+                onChange={handleChange('code')}
+                placeholder="USD_EUR_FX"
+                aria-label="Code"
+                aria-describedby={errors.code ? 'dataset-code-error' : undefined}
+              />
+              {errors.code && (
+                <p id="dataset-code-error" className="text-sm text-destructive">
+                  {errors.code}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="dataset-display-name" className="text-sm font-medium">
+                Display Name
+              </label>
+              <Input
+                id="dataset-display-name"
+                value={formData.displayName}
+                onChange={handleChange('displayName')}
+                placeholder="USD/EUR FX Rate"
+                aria-label="Display Name"
+                aria-describedby={errors.displayName ? 'dataset-display-name-error' : undefined}
+              />
+              {errors.displayName && (
+                <p id="dataset-display-name-error" className="text-sm text-destructive">
+                  {errors.displayName}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="dataset-category" className="text-sm font-medium">
+                Category
+              </label>
+              <select
+                id="dataset-category"
+                value={formData.category}
+                onChange={handleChange('category')}
+                aria-label="Category"
+                aria-describedby={errors.category ? 'dataset-category-error' : undefined}
+                className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+              >
+                <option value="">Select a category</option>
+                {CATEGORY_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+              {errors.category && (
+                <p id="dataset-category-error" className="text-sm text-destructive">
+                  {errors.category}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="dataset-unit" className="text-sm font-medium">
+                Unit
+              </label>
+              <Input
+                id="dataset-unit"
+                value={formData.unit}
+                onChange={handleChange('unit')}
+                placeholder="USD/EUR"
+                aria-label="Unit"
+                aria-describedby={errors.unit ? 'dataset-unit-error' : undefined}
+              />
+              {errors.unit && (
+                <p id="dataset-unit-error" className="text-sm text-destructive">
+                  {errors.unit}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="dataset-description" className="text-sm font-medium">
+                Description <span className="font-normal text-muted-foreground">(optional)</span>
+              </label>
+              <textarea
+                id="dataset-description"
+                value={formData.description}
+                onChange={handleChange('description')}
+                placeholder="Describe this market data set..."
+                maxLength={1000}
+                rows={3}
+                aria-label="Description"
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            </div>
+
+            {errors.general && (
+              <div role="alert" className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                {errors.general}
+              </div>
+            )}
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="register-dataset-form"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Registering...' : 'Register Data Set'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `RegisterDataSetDialog` component for creating new market data sets in DRAFT status
- Extracts shared `CATEGORY_OPTIONS`, `STATUS_OPTIONS`, and `CODE_PATTERN` to `constants.ts` (consumed by both list page and dialog)
- Adds a **Register Dataset** button to the `MarketDataPage` header that opens the dialog

## Changes Made

**New files:**
- `frontend/src/pages/market-data/constants.ts` — shared constants extracted from `index.tsx`
- `frontend/src/pages/market-data/register-dataset-dialog.tsx` — dialog component
- `frontend/src/pages/market-data/register-dataset-dialog.test.tsx` — 17 tests covering rendering, validation, submission, error handling, and form reset

**Modified files:**
- `frontend/src/pages/market-data/index.tsx` — imports from constants, adds Register Dataset button + dialog state
- `frontend/src/pages/market-data/index.test.tsx` — updated mock setup, adds 2 new tests for the Register Dataset button

## Form Fields

| Field | Validation |
|-------|-----------|
| Code (required) | `^[A-Z][A-Z0-9_-]*$`, 2–50 chars |
| Display Name (required) | 1–255 chars |
| Category (required) | Select from `CATEGORY_OPTIONS` |
| Unit (required) | Non-empty string |
| Description (optional) | Textarea, max 1000 chars |

## On Success

- Invalidates `[tenantKeys.all(slug), 'market-data', 'datasets']` query
- Navigates to `/market-data/{code}` detail page

## Test Plan

- [x] All 1172 existing tests continue to pass
- [x] 17 new dialog tests: rendering, category options match constants, code pattern validation, required field validation, successful submission payload, error banner on server error, form reset on close/reopen
- [x] 2 new page tests: Register Dataset button renders, clicking it opens dialog