### PR TITLE
feat: add CreateInternalAccountDialog for internal bank accounts

### DIFF
--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -27,6 +27,11 @@ export const tenantKeys = {
     [...tenantKeys.all(tenantId), 'payments'] as const,
   payment: (tenantId: string, paymentOrderId: string) =>
     [...tenantKeys.payments(tenantId), paymentOrderId] as const,
+
+  internalAccounts: (tenantId: string) =>
+    [...tenantKeys.all(tenantId), 'internal-accounts'] as const,
+  internalAccount: (tenantId: string, accountId: string) =>
+    [...tenantKeys.internalAccounts(tenantId), accountId] as const,
 } as const
 
 export const platformKeys = {

--- a/frontend/src/pages/internal-accounts/create-internal-account-dialog.test.tsx
+++ b/frontend/src/pages/internal-accounts/create-internal-account-dialog.test.tsx
@@ -19,8 +19,8 @@ const mockListActive = vi.fn()
 const mockListInstruments = vi.fn()
 const mockInvalidateQueries = vi.fn()
 
-vi.mock('@/api/context', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/api/context')>()
+vi.mock('@/api/context', async () => {
+  const actual = await vi.importActual('@/api/context')
   return {
     ...actual,
     useApiClients: vi.fn(() => ({

--- a/frontend/src/pages/internal-accounts/create-internal-account-dialog.test.tsx
+++ b/frontend/src/pages/internal-accounts/create-internal-account-dialog.test.tsx
@@ -1,0 +1,502 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { CreateInternalAccountDialog } from './create-internal-account-dialog'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+const mockInitiateInternalBankAccount = vi.fn()
+const mockListActive = vi.fn()
+const mockListInstruments = vi.fn()
+const mockInvalidateQueries = vi.fn()
+
+vi.mock('@/api/context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/context')>()
+  return {
+    ...actual,
+    useApiClients: vi.fn(() => ({
+      internalBankAccount: {
+        initiateInternalBankAccount: mockInitiateInternalBankAccount,
+      },
+      accountTypeRegistry: {
+        listActive: mockListActive,
+      },
+      referenceData: {
+        listInstruments: mockListInstruments,
+      },
+    })),
+    useClients: vi.fn(() => ({
+      internalBankAccount: {
+        initiateInternalBankAccount: mockInitiateInternalBankAccount,
+      },
+      accountTypeRegistry: {
+        listActive: mockListActive,
+      },
+      referenceData: {
+        listInstruments: mockListInstruments,
+      },
+    })),
+  }
+})
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query')
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: mockInvalidateQueries,
+    }),
+  }
+})
+
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: () => 'test-tenant',
+}))
+
+// Internal account types: behaviorClass 1 = Customer (excluded), 2+ = internal
+const mockAccountTypes = [
+  { id: 'at-1', code: 'CLEARING_GBP', displayName: 'GBP Clearing', behaviorClass: 2, status: 2 },
+  { id: 'at-2', code: 'NOSTRO_USD', displayName: 'USD Nostro', behaviorClass: 3, status: 2 },
+  { id: 'at-3', code: 'CUSTOMER_CURRENT', displayName: 'Customer Current', behaviorClass: 1, status: 2 },
+  { id: 'at-4', code: 'SUSPENSE_GBP', displayName: 'GBP Suspense', behaviorClass: 6, status: 2 },
+]
+
+const mockInstruments = [
+  { code: 'GBP', displayName: 'British Pound' },
+  { code: 'USD', displayName: 'US Dollar' },
+  { code: 'EUR', displayName: 'Euro' },
+]
+
+function renderDialog(props: { open?: boolean; onOpenChange?: (open: boolean) => void } = {}) {
+  const { open = true, onOpenChange = vi.fn() } = props
+  return renderWithProviders(
+    <MemoryRouter>
+      <CreateInternalAccountDialog open={open} onOpenChange={onOpenChange} />
+    </MemoryRouter>,
+  )
+}
+
+describe('CreateInternalAccountDialog - rendering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListActive.mockResolvedValue({ definitions: mockAccountTypes })
+    mockListInstruments.mockResolvedValue({ instruments: mockInstruments })
+    mockInitiateInternalBankAccount.mockResolvedValue({ accountId: 'acc-new-123' })
+  })
+
+  it('does not render dialog content when closed', () => {
+    renderDialog({ open: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders dialog content when open', () => {
+    renderDialog()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /new internal account/i })).toBeInTheDocument()
+  })
+
+  it('renders all required form fields', () => {
+    renderDialog()
+    expect(screen.getByLabelText(/account name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/account code/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/account type/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/instrument/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
+  })
+
+  it('renders submit and cancel buttons', () => {
+    renderDialog()
+    expect(screen.getByRole('button', { name: /create account/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+})
+
+describe('CreateInternalAccountDialog - account type filtering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListInstruments.mockResolvedValue({ instruments: mockInstruments })
+  })
+
+  it('filters out customer behavior class (1), shows only internal classes', async () => {
+    mockListActive.mockResolvedValue({ definitions: mockAccountTypes })
+    renderDialog()
+
+    await waitFor(() => {
+      const select = screen.getByLabelText(/account type/i) as HTMLSelectElement
+      const options = Array.from(select.options).map((o) => o.value)
+      expect(options).toContain('CLEARING_GBP')
+      expect(options).toContain('NOSTRO_USD')
+      expect(options).toContain('SUSPENSE_GBP')
+      expect(options).not.toContain('CUSTOMER_CURRENT')
+    })
+  })
+
+  it('shows helper message when no internal account types are configured', async () => {
+    mockListActive.mockResolvedValue({ definitions: [] })
+    renderDialog()
+
+    await waitFor(() => {
+      expect(screen.getByText(/no internal account types have been configured/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows loading state while fetching account types', () => {
+    mockListActive.mockReturnValue(new Promise(() => {}))
+    renderDialog()
+
+    const select = screen.getByLabelText(/account type/i) as HTMLSelectElement
+    expect(select).toBeDisabled()
+    expect(screen.getByText(/loading account types/i)).toBeInTheDocument()
+  })
+})
+
+describe('CreateInternalAccountDialog - instruments query', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListActive.mockResolvedValue({ definitions: mockAccountTypes })
+  })
+
+  it('populates instrument select with active instruments', async () => {
+    mockListInstruments.mockResolvedValue({ instruments: mockInstruments })
+    renderDialog()
+
+    await waitFor(() => {
+      const select = screen.getByLabelText(/instrument/i) as HTMLSelectElement
+      const options = Array.from(select.options).map((o) => o.value)
+      expect(options).toContain('GBP')
+      expect(options).toContain('USD')
+      expect(options).toContain('EUR')
+    })
+  })
+
+  it('calls listInstruments with status filter 2 (ACTIVE)', async () => {
+    mockListInstruments.mockResolvedValue({ instruments: mockInstruments })
+    renderDialog()
+
+    await waitFor(() => {
+      expect(mockListInstruments).toHaveBeenCalledWith({ statusFilter: 2 })
+    })
+  })
+
+  it('shows loading state while fetching instruments', () => {
+    mockListInstruments.mockReturnValue(new Promise(() => {}))
+    renderDialog()
+
+    const select = screen.getByLabelText(/instrument/i) as HTMLSelectElement
+    expect(select).toBeDisabled()
+    expect(screen.getByText(/loading instruments/i)).toBeInTheDocument()
+  })
+})
+
+describe('CreateInternalAccountDialog - validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListActive.mockResolvedValue({ definitions: mockAccountTypes })
+    mockListInstruments.mockResolvedValue({ instruments: mockInstruments })
+  })
+
+  it('shows error when account name is empty on submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/account name is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when account code is empty on submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/account name/i), 'Test Account')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/account code is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when account type is not selected on submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: /account type/i })).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByLabelText(/account name/i), 'Test Account')
+    await user.type(screen.getByLabelText(/account code/i), 'CLR-TEST-001')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/account type is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when instrument is not selected on submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(2)
+    })
+
+    await user.type(screen.getByLabelText(/account name/i), 'Test Account')
+    await user.type(screen.getByLabelText(/account code/i), 'CLR-TEST-001')
+    await user.selectOptions(screen.getByLabelText(/account type/i), 'CLEARING_GBP')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/instrument is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error for invalid account code format (lowercase)', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/account name/i), 'Test Account')
+    await user.type(screen.getByLabelText(/account code/i), 'clr-test-001')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/uppercase letters, digits, underscores, or hyphens/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when description exceeds 1000 characters', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(2)
+    })
+
+    await user.type(screen.getByLabelText(/account name/i), 'Test Account')
+    await user.type(screen.getByLabelText(/account code/i), 'CLR-TEST-001')
+    await user.selectOptions(screen.getByLabelText(/account type/i), 'CLEARING_GBP')
+    await user.selectOptions(screen.getByLabelText(/instrument/i), 'GBP')
+
+    // Use fireEvent to avoid slow typing of 1001 chars
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: 'x'.repeat(1001) },
+    })
+
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/1000 characters or fewer/i)).toBeInTheDocument()
+    })
+  })
+})
+
+describe('CreateInternalAccountDialog - successful submission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListActive.mockResolvedValue({ definitions: mockAccountTypes })
+    mockListInstruments.mockResolvedValue({ instruments: mockInstruments })
+    mockInitiateInternalBankAccount.mockResolvedValue({ accountId: 'acc-new-123' })
+  })
+
+  it('submits form and navigates to account detail page on success', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    renderDialog({ onOpenChange })
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(2)
+    })
+
+    await user.type(screen.getByLabelText(/account name/i), 'GBP Clearing')
+    await user.type(screen.getByLabelText(/account code/i), 'CLR-GBP-001')
+    await user.selectOptions(screen.getByLabelText(/account type/i), 'CLEARING_GBP')
+    await user.selectOptions(screen.getByLabelText(/instrument/i), 'GBP')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(mockInitiateInternalBankAccount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'GBP Clearing',
+          accountCode: 'CLR-GBP-001',
+          productTypeCode: 'CLEARING_GBP',
+          instrumentCode: 'GBP',
+        }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: expect.arrayContaining(['internal-accounts']),
+        }),
+      )
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+      expect(mockNavigate).toHaveBeenCalledWith('/internal-accounts/acc-new-123')
+    })
+  })
+
+  it('disables submit button while pending', async () => {
+    mockInitiateInternalBankAccount.mockImplementation(() => new Promise(() => {}))
+    const user = userEvent.setup()
+    renderDialog()
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(2)
+    })
+
+    await user.type(screen.getByLabelText(/account name/i), 'GBP Clearing')
+    await user.type(screen.getByLabelText(/account code/i), 'CLR-GBP-001')
+    await user.selectOptions(screen.getByLabelText(/account type/i), 'CLEARING_GBP')
+    await user.selectOptions(screen.getByLabelText(/instrument/i), 'GBP')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /creating/i })).toBeDisabled()
+    })
+  })
+})
+
+describe('CreateInternalAccountDialog - error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListActive.mockResolvedValue({ definitions: mockAccountTypes })
+    mockListInstruments.mockResolvedValue({ instruments: mockInstruments })
+  })
+
+  it('shows field-level error for INVALID_ARGUMENT with field violations', async () => {
+    const user = userEvent.setup()
+    const { Code, ConnectError } = await import('@connectrpc/connect')
+    const err = new ConnectError('invalid', Code.InvalidArgument)
+    err.details = [
+      {
+        type: 'google.rpc.BadRequest',
+        value: new Uint8Array(),
+        debug: {
+          fieldViolations: [{ field: 'account_code', description: 'Account code already exists' }],
+        },
+      },
+    ]
+    mockInitiateInternalBankAccount.mockRejectedValue(err)
+
+    renderDialog()
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(2)
+    })
+
+    await user.type(screen.getByLabelText(/account name/i), 'GBP Clearing')
+    await user.type(screen.getByLabelText(/account code/i), 'CLR-GBP-001')
+    await user.selectOptions(screen.getByLabelText(/account type/i), 'CLEARING_GBP')
+    await user.selectOptions(screen.getByLabelText(/instrument/i), 'GBP')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Account code already exists')).toBeInTheDocument()
+    })
+  })
+
+  it('shows banner error for general server errors', async () => {
+    const user = userEvent.setup()
+    const { Code, ConnectError } = await import('@connectrpc/connect')
+    const err = new ConnectError('server error', Code.Internal)
+    mockInitiateInternalBankAccount.mockRejectedValue(err)
+
+    renderDialog()
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(2)
+    })
+
+    await user.type(screen.getByLabelText(/account name/i), 'GBP Clearing')
+    await user.type(screen.getByLabelText(/account code/i), 'CLR-GBP-001')
+    await user.selectOptions(screen.getByLabelText(/account type/i), 'CLEARING_GBP')
+    await user.selectOptions(screen.getByLabelText(/instrument/i), 'GBP')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('CreateInternalAccountDialog - cache invalidation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListActive.mockResolvedValue({ definitions: mockAccountTypes })
+    mockListInstruments.mockResolvedValue({ instruments: mockInstruments })
+    mockInitiateInternalBankAccount.mockResolvedValue({ accountId: 'acc-new-456' })
+  })
+
+  it('invalidates internal-accounts query key on success', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(2)
+    })
+
+    await user.type(screen.getByLabelText(/account name/i), 'GBP Clearing')
+    await user.type(screen.getByLabelText(/account code/i), 'CLR-GBP-001')
+    await user.selectOptions(screen.getByLabelText(/account type/i), 'CLEARING_GBP')
+    await user.selectOptions(screen.getByLabelText(/instrument/i), 'GBP')
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: expect.arrayContaining(['internal-accounts']),
+        }),
+      )
+    })
+  })
+})
+
+describe('CreateInternalAccountDialog - reset on close', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListActive.mockResolvedValue({ definitions: mockAccountTypes })
+    mockListInstruments.mockResolvedValue({ instruments: mockInstruments })
+  })
+
+  it('clears form when dialog is closed', async () => {
+    const user = userEvent.setup()
+    const { rerender } = renderDialog()
+
+    await user.type(screen.getByLabelText(/account name/i), 'Filled In')
+
+    rerender(
+      <MemoryRouter>
+        <CreateInternalAccountDialog open={false} onOpenChange={vi.fn()} />
+      </MemoryRouter>,
+    )
+
+    rerender(
+      <MemoryRouter>
+        <CreateInternalAccountDialog open={true} onOpenChange={vi.fn()} />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByLabelText(/account name/i)).toHaveValue('')
+  })
+
+  it('closes dialog when cancel is clicked', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    renderDialog({ onOpenChange })
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/frontend/src/pages/internal-accounts/create-internal-account-dialog.tsx
+++ b/frontend/src/pages/internal-accounts/create-internal-account-dialog.tsx
@@ -1,0 +1,363 @@
+import * as React from 'react'
+import { Code } from '@connectrpc/connect'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useApiClients } from '@/api/context'
+import { handleConnectError } from '@/lib/error-handling'
+import { tenantKeys } from '@/lib/query-keys'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+
+// Behavior classes that are considered internal (excludes CUSTOMER = 1)
+const INTERNAL_BEHAVIOR_CLASSES = [2, 3, 4, 5, 6, 7, 8, 9]
+
+// Account code pattern: uppercase letters, digits, underscores, hyphens
+const ACCOUNT_CODE_PATTERN = /^[A-Z0-9_-]+$/
+
+interface FormData {
+  accountName: string
+  accountCode: string
+  accountType: string
+  instrumentCode: string
+  description: string
+}
+
+interface FormErrors {
+  accountName?: string
+  accountCode?: string
+  accountType?: string
+  instrumentCode?: string
+  description?: string
+  general?: string
+}
+
+export interface CreateInternalAccountDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const initialFormData: FormData = {
+  accountName: '',
+  accountCode: '',
+  accountType: '',
+  instrumentCode: '',
+  description: '',
+}
+
+export function CreateInternalAccountDialog({ open, onOpenChange }: CreateInternalAccountDialogProps) {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+
+  const [formData, setFormData] = React.useState<FormData>(initialFormData)
+  const [errors, setErrors] = React.useState<FormErrors>({})
+
+  React.useEffect(() => {
+    if (!open) {
+      setFormData(initialFormData)
+      setErrors({})
+    }
+  }, [open])
+
+  const { data: accountTypesData, isLoading: accountTypesLoading } = useQuery({
+    queryKey: ['account-types-internal'],
+    queryFn: async () => {
+      const res = await clients.accountTypeRegistry.listActive({})
+      return res.definitions?.filter((d) => INTERNAL_BEHAVIOR_CLASSES.includes(d.behaviorClass)) ?? []
+    },
+    enabled: open,
+  })
+
+  const { data: instrumentsData, isLoading: instrumentsLoading } = useQuery({
+    queryKey: ['instruments-active'],
+    queryFn: async () => {
+      const res = await clients.referenceData.listInstruments({ statusFilter: 2 })
+      return res.instruments ?? []
+    },
+    enabled: open,
+  })
+
+  const accountTypes = accountTypesData ?? []
+  const instruments = instrumentsData ?? []
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      return clients.internalBankAccount.initiateInternalBankAccount({
+        name: formData.accountName.trim(),
+        accountCode: formData.accountCode.trim(),
+        productTypeCode: formData.accountType,
+        instrumentCode: formData.instrumentCode,
+        description: formData.description.trim(),
+      })
+    },
+    onSuccess: (data) => {
+      const accountId = (data as { accountId?: string }).accountId ?? ''
+      queryClient.invalidateQueries({ queryKey: tenantKeys.internalAccounts(tenantSlug ?? '') })
+      onOpenChange(false)
+      if (accountId) {
+        navigate(`/internal-accounts/${accountId}`)
+      }
+    },
+    onError: (err) => {
+      const result = handleConnectError(err)
+      if (result.code === Code.InvalidArgument && Object.keys(result.fieldErrors).length > 0) {
+        const fieldMap: FormErrors = {}
+        for (const [field, msg] of Object.entries(result.fieldErrors)) {
+          if (field === 'name') fieldMap.accountName = msg
+          else if (field === 'account_code') fieldMap.accountCode = msg
+          else if (field === 'product_type_code') fieldMap.accountType = msg
+          else if (field === 'instrument_code') fieldMap.instrumentCode = msg
+          else if (field === 'description') fieldMap.description = msg
+          else fieldMap.general = msg
+        }
+        setErrors(fieldMap)
+      } else {
+        setErrors({ general: result.message })
+      }
+    },
+  })
+
+  function validate(): boolean {
+    const newErrors: FormErrors = {}
+
+    if (!formData.accountName.trim()) {
+      newErrors.accountName = 'Account name is required'
+    } else if (formData.accountName.trim().length > 255) {
+      newErrors.accountName = 'Account name must be 255 characters or fewer'
+    }
+
+    if (!formData.accountCode.trim()) {
+      newErrors.accountCode = 'Account code is required'
+    } else if (formData.accountCode.trim().length > 50) {
+      newErrors.accountCode = 'Account code must be 50 characters or fewer'
+    } else if (!ACCOUNT_CODE_PATTERN.test(formData.accountCode.trim())) {
+      newErrors.accountCode = 'Account code must contain only uppercase letters, digits, underscores, or hyphens'
+    }
+
+    if (!formData.accountType) {
+      newErrors.accountType = 'Account type is required'
+    }
+
+    if (!formData.instrumentCode) {
+      newErrors.instrumentCode = 'Instrument is required'
+    }
+
+    if (formData.description.trim().length > 1000) {
+      newErrors.description = 'Description must be 1000 characters or fewer'
+    }
+
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+    mutation.mutate()
+  }
+
+  function handleChange(field: keyof FormData) {
+    return (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+      setFormData((prev) => ({ ...prev, [field]: e.target.value }))
+      if (errors[field]) {
+        setErrors((prev) => ({ ...prev, [field]: undefined }))
+      }
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New Internal Account</DialogTitle>
+          <DialogDescription>
+            Create a new internal bank account such as a clearing, nostro, vostro, or suspense account.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="create-internal-account-form">
+          <div className="space-y-4 py-2">
+            {errors.general && (
+              <div
+                role="alert"
+                className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                {errors.general}
+              </div>
+            )}
+
+            <div className="space-y-1">
+              <label htmlFor="accountName" className="text-sm font-medium">
+                Account Name <span aria-hidden="true">*</span>
+              </label>
+              <Input
+                id="accountName"
+                value={formData.accountName}
+                onChange={handleChange('accountName')}
+                placeholder="GBP Clearing Account"
+                aria-describedby={errors.accountName ? 'accountName-error' : undefined}
+                aria-required="true"
+              />
+              {errors.accountName && (
+                <p id="accountName-error" className="text-sm text-destructive">
+                  {errors.accountName}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="accountCode" className="text-sm font-medium">
+                Account Code <span aria-hidden="true">*</span>
+              </label>
+              <Input
+                id="accountCode"
+                value={formData.accountCode}
+                onChange={handleChange('accountCode')}
+                placeholder="CLR-GBP-001"
+                aria-describedby={errors.accountCode ? 'accountCode-error' : undefined}
+                aria-required="true"
+              />
+              {errors.accountCode && (
+                <p id="accountCode-error" className="text-sm text-destructive">
+                  {errors.accountCode}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="accountType" className="text-sm font-medium">
+                Account Type <span aria-hidden="true">*</span>
+              </label>
+              {accountTypesLoading ? (
+                <select
+                  id="accountType"
+                  disabled
+                  className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+                  aria-busy="true"
+                >
+                  <option value="">Loading account types...</option>
+                </select>
+              ) : accountTypes.length === 0 ? (
+                <div>
+                  <select
+                    id="accountType"
+                    value={formData.accountType}
+                    onChange={handleChange('accountType')}
+                    className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+                    aria-describedby={errors.accountType ? 'accountType-error' : 'accountType-hint'}
+                  >
+                    <option value="">No internal account types configured</option>
+                  </select>
+                  <p id="accountType-hint" className="mt-1 text-sm text-muted-foreground">
+                    No internal account types have been configured for this tenant. Please configure account types first.
+                  </p>
+                </div>
+              ) : (
+                <select
+                  id="accountType"
+                  value={formData.accountType}
+                  onChange={handleChange('accountType')}
+                  className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+                  aria-describedby={errors.accountType ? 'accountType-error' : undefined}
+                  aria-required="true"
+                >
+                  <option value="">Select an account type</option>
+                  {accountTypes.map((def) => (
+                    <option key={def.id} value={def.code}>
+                      {def.displayName || def.code}
+                    </option>
+                  ))}
+                </select>
+              )}
+              {errors.accountType && (
+                <p id="accountType-error" className="text-sm text-destructive">
+                  {errors.accountType}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="instrumentCode" className="text-sm font-medium">
+                Instrument <span aria-hidden="true">*</span>
+              </label>
+              {instrumentsLoading ? (
+                <select
+                  id="instrumentCode"
+                  disabled
+                  className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+                  aria-busy="true"
+                >
+                  <option value="">Loading instruments...</option>
+                </select>
+              ) : (
+                <select
+                  id="instrumentCode"
+                  value={formData.instrumentCode}
+                  onChange={handleChange('instrumentCode')}
+                  className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+                  aria-describedby={errors.instrumentCode ? 'instrumentCode-error' : undefined}
+                  aria-required="true"
+                >
+                  <option value="">Select an instrument</option>
+                  {instruments.map((inst) => (
+                    <option key={inst.code} value={inst.code}>
+                      {inst.code}{inst.displayName ? ` — ${inst.displayName}` : ''}
+                    </option>
+                  ))}
+                </select>
+              )}
+              {errors.instrumentCode && (
+                <p id="instrumentCode-error" className="text-sm text-destructive">
+                  {errors.instrumentCode}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="description" className="text-sm font-medium">
+                Description
+              </label>
+              <textarea
+                id="description"
+                value={formData.description}
+                onChange={handleChange('description')}
+                placeholder="Optional description of this account's purpose"
+                rows={3}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-none"
+                aria-describedby={errors.description ? 'description-error' : undefined}
+              />
+              {errors.description && (
+                <p id="description-error" className="text-sm text-destructive">
+                  {errors.description}
+                </p>
+              )}
+            </div>
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="create-internal-account-form"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Creating...' : 'Create Account'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/internal-accounts/create-internal-account-dialog.tsx
+++ b/frontend/src/pages/internal-accounts/create-internal-account-dialog.tsx
@@ -70,21 +70,25 @@ export function CreateInternalAccountDialog({ open, onOpenChange }: CreateIntern
   }, [open])
 
   const { data: accountTypesData, isLoading: accountTypesLoading } = useQuery({
-    queryKey: ['account-types-internal'],
+    queryKey: tenantSlug
+      ? [...tenantKeys.all(tenantSlug), 'account-types-internal']
+      : ['account-types-internal'],
     queryFn: async () => {
       const res = await clients.accountTypeRegistry.listActive({})
       return res.definitions?.filter((d) => INTERNAL_BEHAVIOR_CLASSES.includes(d.behaviorClass)) ?? []
     },
-    enabled: open,
+    enabled: open && !!tenantSlug,
   })
 
   const { data: instrumentsData, isLoading: instrumentsLoading } = useQuery({
-    queryKey: ['instruments-active'],
+    queryKey: tenantSlug
+      ? [...tenantKeys.all(tenantSlug), 'instruments-active']
+      : ['instruments-active'],
     queryFn: async () => {
       const res = await clients.referenceData.listInstruments({ statusFilter: 2 })
       return res.instruments ?? []
     },
-    enabled: open,
+    enabled: open && !!tenantSlug,
   })
 
   const accountTypes = accountTypesData ?? []

--- a/frontend/src/pages/internal-accounts/index.tsx
+++ b/frontend/src/pages/internal-accounts/index.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import type { ColumnDef } from '@tanstack/react-table'
 import { useNavigate } from 'react-router-dom'
 import { DataTable } from '@/components/shared/data-table'
@@ -6,6 +7,8 @@ import { TimeDisplay } from '@/components/shared'
 import { useApiClients } from '@/api/context'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
+import { Button } from '@/components/ui/button'
+import { CreateInternalAccountDialog } from './create-internal-account-dialog'
 
 interface InternalAccountRow {
   accountId: string
@@ -90,6 +93,7 @@ export function InternalAccountsPage() {
   const { tenantSlug } = useTenantContext()
   const clients = useApiClients()
   const navigate = useNavigate()
+  const [createDialogOpen, setCreateDialogOpen] = React.useState(false)
 
   if (!tenantSlug) {
     return (
@@ -101,12 +105,20 @@ export function InternalAccountsPage() {
 
   return (
     <div className="p-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-semibold">Internal Accounts</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Operational accounts including clearing, nostro, vostro, and holding accounts.
-        </p>
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Internal Accounts</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Operational accounts including clearing, nostro, vostro, and holding accounts.
+          </p>
+        </div>
+        <Button onClick={() => setCreateDialogOpen(true)}>New Internal Account</Button>
       </div>
+
+      <CreateInternalAccountDialog
+        open={createDialogOpen}
+        onOpenChange={setCreateDialogOpen}
+      />
 
       <DataTable<InternalAccountRow>
         queryKey={[...tenantKeys.all(tenantSlug), 'internal-accounts']}

--- a/frontend/src/pages/internal-accounts/index.tsx
+++ b/frontend/src/pages/internal-accounts/index.tsx
@@ -121,7 +121,7 @@ export function InternalAccountsPage() {
       />
 
       <DataTable<InternalAccountRow>
-        queryKey={[...tenantKeys.all(tenantSlug), 'internal-accounts']}
+        queryKey={tenantKeys.internalAccounts(tenantSlug)}
         queryFn={async ({ pageToken, pageSize, filters }) => {
           const statusFilter = filters?.status ? parseInt(filters.status, 10) : 0
           const res = await clients.internalBankAccount.listInternalBankAccounts({


### PR DESCRIPTION
## Summary

- Add `internalAccounts` and `internalAccount` query key factories to `tenantKeys` in `query-keys.ts`
- Create `CreateInternalAccountDialog` in `pages/internal-accounts/` with form fields: account name, account code, account type (filtered to internal behavior classes), instrument (active only), and optional description
- Integrate dialog into `InternalAccountsPage` with a "New Internal Account" button in the page header
- Navigate to `/internal-accounts/{accountId}` on success and invalidate the internal accounts cache

## Changes Made

- `frontend/src/lib/query-keys.ts` — add `internalAccounts(tenantId)` and `internalAccount(tenantId, accountId)` factories
- `frontend/src/pages/internal-accounts/create-internal-account-dialog.tsx` — new dialog component
- `frontend/src/pages/internal-accounts/create-internal-account-dialog.test.tsx` — 23 tests
- `frontend/src/pages/internal-accounts/index.tsx` — integrate dialog with trigger button

## Technical Details

- Account types loaded via `accountTypeRegistry.listActive({})` filtered to behavior classes 2–9 (excludes Customer = 1)
- Instruments loaded via `referenceData.listInstruments({ statusFilter: 2 })` (ACTIVE only)
- Mutation uses `internalBankAccount.initiateInternalBankAccount()` with `productTypeCode` from selected account type
- Error handling via `handleConnectError` maps field violations to per-field errors
- Form state reset on close via `useEffect`

## Testing

- 23 tests: account type filtering by behavior class, instrument loading, validation (required fields, code format, description length), successful submission with navigation and cache invalidation, error handling (field-level and general), form reset on close
- All 1176 existing tests continue to pass

## Task Reference

Task: 026-operations-console.81 — Create Internal Bank Account Dialog