### PR TITLE
feat: Create Reference Data Node Dialog

### DIFF
--- a/frontend/src/pages/reference-data/nodes/create-node-dialog.test.tsx
+++ b/frontend/src/pages/reference-data/nodes/create-node-dialog.test.tsx
@@ -1,0 +1,405 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BrowserRouter } from 'react-router-dom'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import type { ReactNode } from 'react'
+
+const mockCreateNode = vi.fn()
+const mockGetChildren = vi.fn().mockResolvedValue({ nodes: [] })
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(() => ({
+    node: {
+      createNode: mockCreateNode,
+      getChildren: mockGetChildren,
+    },
+  })),
+}))
+
+import { CreateNodeDialog } from './create-node-dialog'
+
+const mockRootNodes = [
+  {
+    id: 'parent-001',
+    tenantId: 'tenant-001',
+    nodeType: 'region',
+    parentId: '',
+    resolutionKey: 'region:parent-001',
+    attributes: {},
+    version: BigInt(1),
+  },
+]
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function Wrapper({ children, queryClient }: { children: ReactNode; queryClient?: QueryClient }) {
+  const qc = queryClient ?? makeQueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <BrowserRouter>{children}</BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+function renderDialog(props: Partial<{
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  defaultParentId: string
+  queryClient: QueryClient
+}> = {}) {
+  const {
+    open = true,
+    onOpenChange = vi.fn(),
+    defaultParentId,
+    queryClient,
+  } = props
+
+  const { render } = require('@testing-library/react')
+  return render(
+    <Wrapper queryClient={queryClient}>
+      <CreateNodeDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        defaultParentId={defaultParentId}
+      />
+    </Wrapper>,
+  )
+}
+
+describe('CreateNodeDialog - rendering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetChildren.mockResolvedValue({ nodes: [] })
+    mockCreateNode.mockResolvedValue({ node: { id: 'new-node-id' } })
+  })
+
+  it('renders dialog when open', () => {
+    renderDialog()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /create node/i })).toBeInTheDocument()
+  })
+
+  it('does not render when closed', () => {
+    renderDialog({ open: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders all form fields', () => {
+    renderDialog()
+    expect(screen.getByLabelText(/^Code/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/node type/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/parent node/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
+    expect(screen.getByTestId('key-value-editor')).toBeInTheDocument()
+  })
+
+  it('renders cancel and create buttons', () => {
+    renderDialog()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /create node/i })).toBeInTheDocument()
+  })
+
+  it('parent node select has (Root Level) option', () => {
+    renderDialog()
+    expect(screen.getByRole('option', { name: /root level/i })).toBeInTheDocument()
+  })
+})
+
+describe('CreateNodeDialog - validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetChildren.mockResolvedValue({ nodes: [] })
+    mockCreateNode.mockResolvedValue({ node: { id: 'new-node-id' } })
+  })
+
+  it('shows error when code is empty', async () => {
+    renderDialog()
+    await userEvent.click(screen.getByRole('button', { name: /create node/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/code is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when code is too short', async () => {
+    renderDialog()
+    await userEvent.type(screen.getByLabelText(/^Code/i), 'A')
+    await userEvent.click(screen.getByRole('button', { name: /create node/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/at least 2 characters/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when code has invalid pattern - lowercase', async () => {
+    renderDialog()
+    await userEvent.type(screen.getByLabelText(/^Code/i), 'lowercase')
+    await userEvent.click(screen.getByRole('button', { name: /create node/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/must start with an uppercase letter/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when code has invalid pattern - starts with digit', async () => {
+    renderDialog()
+    await userEvent.type(screen.getByLabelText(/^Code/i), '1INVALID')
+    await userEvent.click(screen.getByRole('button', { name: /create node/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/must start with an uppercase letter/i)).toBeInTheDocument()
+    })
+  })
+
+  it('accepts valid code patterns with dots and hyphens', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    renderDialog({ onOpenChange })
+
+    await user.type(screen.getByLabelText(/^Code/i), 'EU.WEST-1')
+    await user.type(screen.getByLabelText(/display name/i), 'EU West 1')
+    await user.click(screen.getByRole('button', { name: /create node/i }))
+
+    await waitFor(() => {
+      // No validation errors about pattern
+      expect(screen.queryByText(/must start with an uppercase letter/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows error when display name is empty', async () => {
+    renderDialog()
+    await userEvent.type(screen.getByLabelText(/^Code/i), 'REGION_EU')
+    await userEvent.click(screen.getByRole('button', { name: /create node/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/display name is required/i)).toBeInTheDocument()
+    })
+  })
+})
+
+describe('CreateNodeDialog - parent node selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateNode.mockResolvedValue({ node: { id: 'new-node-id' } })
+  })
+
+  it('pre-selects parent node from defaultParentId prop', async () => {
+    mockGetChildren.mockResolvedValue({ nodes: mockRootNodes })
+    renderDialog({ defaultParentId: 'parent-001' })
+
+    // Wait for the option to appear in the list
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: /parent-001/i })).toBeInTheDocument()
+    })
+
+    const select = screen.getByLabelText(/parent node/i) as HTMLSelectElement
+    expect(select.value).toBe('parent-001')
+  })
+
+  it('shows (Root Level) option selected by default', () => {
+    renderDialog()
+    const select = screen.getByLabelText(/parent node/i) as HTMLSelectElement
+    expect(select.value).toBe('')
+  })
+
+  it('shows root nodes as options when loaded', async () => {
+    mockGetChildren.mockResolvedValue({ nodes: mockRootNodes })
+    renderDialog()
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: /parent-001/i })).toBeInTheDocument()
+    })
+  })
+
+  it('can deselect parent by choosing Root Level', async () => {
+    const user = userEvent.setup()
+    mockGetChildren.mockResolvedValue({ nodes: mockRootNodes })
+    renderDialog({ defaultParentId: 'parent-001' })
+    const select = screen.getByLabelText(/parent node/i)
+    await user.selectOptions(select, '')
+    expect((select as HTMLSelectElement).value).toBe('')
+  })
+})
+
+describe('CreateNodeDialog - key-value editor integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetChildren.mockResolvedValue({ nodes: [] })
+    mockCreateNode.mockResolvedValue({ node: { id: 'new-node-id' } })
+  })
+
+  it('renders key-value editor component', () => {
+    renderDialog()
+    expect(screen.getByTestId('key-value-editor')).toBeInTheDocument()
+  })
+
+  it('can add attributes via key-value editor', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.click(screen.getByRole('button', { name: /add attribute/i }))
+    await user.type(screen.getByLabelText(/attribute key 1/i), 'zone')
+    await user.type(screen.getByLabelText(/attribute value 1/i), 'UK')
+    expect(screen.getByDisplayValue('zone')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('UK')).toBeInTheDocument()
+  })
+
+  it('can remove attributes via key-value editor', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.click(screen.getByRole('button', { name: /add attribute/i }))
+    await user.click(screen.getByRole('button', { name: /remove attribute 1/i }))
+    expect(screen.queryByLabelText(/attribute key 1/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('CreateNodeDialog - submission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetChildren.mockResolvedValue({ nodes: [] })
+    mockCreateNode.mockResolvedValue({ node: { id: 'new-node-id' } })
+  })
+
+  it('calls createNode with code and displayName in attributes', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/^Code/i), 'REGION_EU')
+    await user.type(screen.getByLabelText(/display name/i), 'Europe')
+    await user.click(screen.getByRole('button', { name: /create node/i }))
+
+    await waitFor(() => {
+      expect(mockCreateNode).toHaveBeenCalledOnce()
+    })
+
+    const callArgs = mockCreateNode.mock.calls[0][0]
+    expect(callArgs).toMatchObject({
+      nodeType: undefined,
+      parentId: undefined,
+    })
+    // attributes should include code and displayName
+    expect(callArgs.attributes).toBeDefined()
+  })
+
+  it('includes nodeType when provided', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/^Code/i), 'REGION_EU')
+    await user.type(screen.getByLabelText(/display name/i), 'Europe')
+    await user.type(screen.getByLabelText(/node type/i), 'region')
+    await user.click(screen.getByRole('button', { name: /create node/i }))
+
+    await waitFor(() => {
+      expect(mockCreateNode).toHaveBeenCalledOnce()
+    })
+
+    const callArgs = mockCreateNode.mock.calls[0][0]
+    expect(callArgs.nodeType).toBe('region')
+  })
+
+  it('includes parentId when parent selected', async () => {
+    const user = userEvent.setup()
+    mockGetChildren.mockResolvedValue({ nodes: mockRootNodes })
+    renderDialog()
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: /parent-001/i })).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByLabelText(/^Code/i), 'REGION_EU')
+    await user.type(screen.getByLabelText(/display name/i), 'Europe')
+    await user.selectOptions(screen.getByLabelText(/parent node/i), 'parent-001')
+    await user.click(screen.getByRole('button', { name: /create node/i }))
+
+    await waitFor(() => {
+      expect(mockCreateNode).toHaveBeenCalledOnce()
+    })
+
+    const callArgs = mockCreateNode.mock.calls[0][0]
+    expect(callArgs.parentId).toBe('parent-001')
+  })
+
+  it('closes dialog on successful submission', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    renderDialog({ onOpenChange })
+
+    await user.type(screen.getByLabelText(/^Code/i), 'REGION_EU')
+    await user.type(screen.getByLabelText(/display name/i), 'Europe')
+    await user.click(screen.getByRole('button', { name: /create node/i }))
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('shows error alert on server failure', async () => {
+    const user = userEvent.setup()
+    mockCreateNode.mockRejectedValue(new Error('AlreadyExists: node already exists'))
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/^Code/i), 'REGION_EU')
+    await user.type(screen.getByLabelText(/display name/i), 'Europe')
+    await user.click(screen.getByRole('button', { name: /create node/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+
+  it('invalidates node-roots query on success', async () => {
+    const user = userEvent.setup()
+    const qc = makeQueryClient()
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
+    renderDialog({ queryClient: qc })
+
+    await user.type(screen.getByLabelText(/^Code/i), 'REGION_EU')
+    await user.type(screen.getByLabelText(/display name/i), 'Europe')
+    await user.click(screen.getByRole('button', { name: /create node/i }))
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['node-roots'] }),
+      )
+    })
+  })
+
+  it('invalidates node-children query for parent on success', async () => {
+    const user = userEvent.setup()
+    mockGetChildren.mockResolvedValue({ nodes: mockRootNodes })
+    const qc = makeQueryClient()
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
+    renderDialog({ defaultParentId: 'parent-001', queryClient: qc })
+
+    await user.type(screen.getByLabelText(/^Code/i), 'ZONE_UK')
+    await user.type(screen.getByLabelText(/display name/i), 'UK')
+    await user.click(screen.getByRole('button', { name: /create node/i }))
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['node-children', 'parent-001'] }),
+      )
+    })
+  })
+})
+
+describe('CreateNodeDialog - cancel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetChildren.mockResolvedValue({ nodes: [] })
+    mockCreateNode.mockResolvedValue({ node: { id: 'new-node-id' } })
+  })
+
+  it('calls onOpenChange(false) when cancel clicked', async () => {
+    const onOpenChange = vi.fn()
+    renderDialog({ onOpenChange })
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/frontend/src/pages/reference-data/nodes/create-node-dialog.test.tsx
+++ b/frontend/src/pages/reference-data/nodes/create-node-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter } from 'react-router-dom'
@@ -65,7 +65,6 @@ function renderDialog(props: Partial<{
     queryClient,
   } = props
 
-  const { render } = require('@testing-library/react')
   return render(
     <Wrapper queryClient={queryClient}>
       <CreateNodeDialog

--- a/frontend/src/pages/reference-data/nodes/create-node-dialog.test.tsx
+++ b/frontend/src/pages/reference-data/nodes/create-node-dialog.test.tsx
@@ -281,8 +281,9 @@ describe('CreateNodeDialog - submission', () => {
       nodeType: undefined,
       parentId: undefined,
     })
-    // attributes should include code and displayName
-    expect(callArgs.attributes).toBeDefined()
+    // attributes should include code and displayName as protobuf Struct string values
+    expect(callArgs.attributes?.fields?.code?.kind?.value).toBe('REGION_EU')
+    expect(callArgs.attributes?.fields?.displayName?.kind?.value).toBe('Europe')
   })
 
   it('includes nodeType when provided', async () => {

--- a/frontend/src/pages/reference-data/nodes/create-node-dialog.tsx
+++ b/frontend/src/pages/reference-data/nodes/create-node-dialog.tsx
@@ -103,10 +103,12 @@ export function CreateNodeDialog({ open, onOpenChange, defaultParentId }: Create
 
   const mutation = useMutation({
     mutationFn: async () => {
+      // User-provided extra attributes are merged first; code, displayName, and
+      // description always win to prevent the KeyValueEditor from overriding them.
       const attrs: Record<string, unknown> = {
+        ...formData.attributes,
         code: formData.code.trim(),
         displayName: formData.displayName.trim(),
-        ...formData.attributes,
       }
       if (formData.description.trim()) {
         attrs.description = formData.description.trim()

--- a/frontend/src/pages/reference-data/nodes/create-node-dialog.tsx
+++ b/frontend/src/pages/reference-data/nodes/create-node-dialog.tsx
@@ -1,0 +1,296 @@
+import * as React from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useApiClients } from '@/api/context'
+import { handleConnectError } from '@/lib/error-handling'
+import { KeyValueEditor } from './key-value-editor'
+
+// Pattern: starts with uppercase letter, then uppercase letters, digits, underscore, dot, or hyphen
+const CODE_PATTERN = /^[A-Z][A-Z0-9_.-]*$/
+
+interface FormData {
+  code: string
+  displayName: string
+  nodeType: string
+  parentNodeId: string
+  description: string
+  attributes: Record<string, string>
+}
+
+interface FormErrors {
+  code?: string
+  displayName?: string
+  nodeType?: string
+  general?: string
+}
+
+export interface CreateNodeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Pre-select parent when adding child */
+  defaultParentId?: string
+}
+
+function emptyForm(defaultParentId?: string): FormData {
+  return {
+    code: '',
+    displayName: '',
+    nodeType: '',
+    parentNodeId: defaultParentId ?? '',
+    description: '',
+    attributes: {},
+  }
+}
+
+function validate(formData: FormData): FormErrors {
+  const errors: FormErrors = {}
+  const code = formData.code.trim()
+  if (!code) {
+    errors.code = 'Code is required'
+  } else if (code.length < 2) {
+    errors.code = 'Code must be at least 2 characters'
+  } else if (code.length > 100) {
+    errors.code = 'Code must be at most 100 characters'
+  } else if (!CODE_PATTERN.test(code)) {
+    errors.code = 'Code must start with an uppercase letter and contain only uppercase letters, digits, underscores, dots, or hyphens'
+  }
+  const displayName = formData.displayName.trim()
+  if (!displayName) {
+    errors.displayName = 'Display name is required'
+  } else if (displayName.length > 255) {
+    errors.displayName = 'Display name must be at most 255 characters'
+  }
+  return errors
+}
+
+export function CreateNodeDialog({ open, onOpenChange, defaultParentId }: CreateNodeDialogProps) {
+  const clients = useApiClients()
+  const queryClient = useQueryClient()
+  const [formData, setFormData] = React.useState<FormData>(() => emptyForm(defaultParentId))
+  const [errors, setErrors] = React.useState<FormErrors>({})
+
+  // Reset form when dialog opens/closes or defaultParentId changes
+  React.useEffect(() => {
+    if (!open) {
+      setFormData(emptyForm(defaultParentId))
+      setErrors({})
+    } else {
+      setFormData(emptyForm(defaultParentId))
+    }
+  }, [open, defaultParentId])
+
+  // Fetch root nodes for parent selection
+  const { data: rootsData } = useQuery({
+    queryKey: ['node-roots', ''],
+    queryFn: async () => {
+      const result = await clients.node.getChildren({ parentId: '', activeOnly: true })
+      return result.nodes ?? []
+    },
+    enabled: open,
+    staleTime: 30_000,
+  })
+
+  const roots = rootsData ?? []
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const attrs: Record<string, unknown> = {
+        code: formData.code.trim(),
+        displayName: formData.displayName.trim(),
+        ...formData.attributes,
+      }
+      if (formData.description.trim()) {
+        attrs.description = formData.description.trim()
+      }
+
+      return clients.node.createNode({
+        nodeType: formData.nodeType.trim() || undefined,
+        parentId: formData.parentNodeId.trim() || undefined,
+        attributes: { fields: Object.fromEntries(
+          Object.entries(attrs).map(([k, v]) => [k, { kind: { case: 'stringValue', value: String(v) } }])
+        ) },
+      })
+    },
+    onSuccess: (_result) => {
+      // Invalidate root nodes and the parent's children
+      void queryClient.invalidateQueries({ queryKey: ['node-roots'] })
+      if (formData.parentNodeId.trim()) {
+        void queryClient.invalidateQueries({
+          queryKey: ['node-children', formData.parentNodeId.trim()],
+        })
+      }
+      onOpenChange(false)
+    },
+    onError: (error: unknown) => {
+      const result = handleConnectError(error)
+      setErrors({ general: result.message })
+    },
+  })
+
+  function handleChange<K extends keyof FormData>(field: K, value: FormData[K]) {
+    setFormData((prev) => ({ ...prev, [field]: value }))
+    if (field in errors && errors[field as keyof FormErrors]) {
+      setErrors((prev) => ({ ...prev, [field]: undefined }))
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const validationErrors = validate(formData)
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors)
+      return
+    }
+    setErrors({})
+    mutation.mutate()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Create Node</DialogTitle>
+          <DialogDescription>
+            Create a new reference data node. Nodes form hierarchical trees for region, zone, meter, and other classifications.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="create-node-form">
+          <div className="space-y-4 py-2">
+            {errors.general && (
+              <div
+                role="alert"
+                className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                {errors.general}
+              </div>
+            )}
+
+            <div className="space-y-1">
+              <label htmlFor="node-code" className="text-sm font-medium">
+                Code <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="node-code"
+                value={formData.code}
+                onChange={(e) => handleChange('code', e.target.value)}
+                placeholder="REGION_EU"
+                aria-describedby={errors.code ? 'node-code-error' : undefined}
+                aria-label="Code"
+              />
+              {errors.code && (
+                <p id="node-code-error" className="text-sm text-destructive">
+                  {errors.code}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="node-display-name" className="text-sm font-medium">
+                Display Name <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="node-display-name"
+                value={formData.displayName}
+                onChange={(e) => handleChange('displayName', e.target.value)}
+                placeholder="Europe Region"
+                aria-describedby={errors.displayName ? 'node-display-name-error' : undefined}
+                aria-label="Display Name"
+              />
+              {errors.displayName && (
+                <p id="node-display-name-error" className="text-sm text-destructive">
+                  {errors.displayName}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="node-type" className="text-sm font-medium">
+                Node Type
+              </label>
+              <Input
+                id="node-type"
+                value={formData.nodeType}
+                onChange={(e) => handleChange('nodeType', e.target.value)}
+                placeholder="region"
+                aria-label="Node Type"
+              />
+              <p className="text-xs text-muted-foreground">
+                Classification tag (e.g. region, zone, meter)
+              </p>
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="node-parent" className="text-sm font-medium">
+                Parent Node
+              </label>
+              <select
+                id="node-parent"
+                value={formData.parentNodeId}
+                onChange={(e) => handleChange('parentNodeId', e.target.value)}
+                aria-label="Parent Node"
+                className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+              >
+                <option value="">(Root Level)</option>
+                {roots.map((node) => (
+                  <option key={node.id} value={node.id}>
+                    {node.id} {node.nodeType ? `[${node.nodeType}]` : ''}
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs text-muted-foreground">
+                Leave empty to create a root-level node.
+              </p>
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="node-description" className="text-sm font-medium">
+                Description
+              </label>
+              <textarea
+                id="node-description"
+                value={formData.description}
+                onChange={(e) => handleChange('description', e.target.value)}
+                placeholder="Optional description..."
+                maxLength={1000}
+                aria-label="Description"
+                rows={3}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs resize-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            </div>
+
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Additional Attributes</label>
+              <KeyValueEditor
+                value={formData.attributes}
+                onChange={(attrs) => handleChange('attributes', attrs)}
+              />
+            </div>
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="create-node-form"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Creating...' : 'Create Node'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/reference-data/nodes/index.tsx
+++ b/frontend/src/pages/reference-data/nodes/index.tsx
@@ -75,7 +75,7 @@ function NodeRow({ node, depth, asAt, onAddChild }: NodeRowProps) {
         <Button
           variant="ghost"
           size="sm"
-          className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 shrink-0"
+          className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 shrink-0"
           onClick={() => onAddChild(node.id)}
           aria-label={`Add child to ${node.id}`}
         >

--- a/frontend/src/pages/reference-data/nodes/index.tsx
+++ b/frontend/src/pages/reference-data/nodes/index.tsx
@@ -4,16 +4,18 @@ import { useApiClients } from '@/api/context'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { ChevronRight, ChevronDown } from 'lucide-react'
+import { ChevronRight, ChevronDown, Plus } from 'lucide-react'
 import type { ReferenceDataNode } from '@/api/gen/meridian/reference_data/v1/node_pb'
+import { CreateNodeDialog } from './create-node-dialog'
 
 interface NodeRowProps {
   node: ReferenceDataNode
   depth: number
   asAt: string
+  onAddChild: (parentId: string) => void
 }
 
-function NodeRow({ node, depth, asAt }: NodeRowProps) {
+function NodeRow({ node, depth, asAt, onAddChild }: NodeRowProps) {
   const clients = useApiClients()
   const [expanded, setExpanded] = React.useState(false)
 
@@ -45,7 +47,7 @@ function NodeRow({ node, depth, asAt }: NodeRowProps) {
   return (
     <>
       <div
-        className="flex items-center gap-1 py-1.5 hover:bg-muted/30 rounded px-1"
+        className="group flex items-center gap-1 py-1.5 hover:bg-muted/30 rounded px-1"
         style={{ paddingLeft: `${depth * 20 + 4}px` }}
       >
         <Button
@@ -63,16 +65,26 @@ function NodeRow({ node, depth, asAt }: NodeRowProps) {
           )}
         </Button>
 
-        <div className="flex items-center gap-3 min-w-0">
+        <div className="flex items-center gap-3 min-w-0 flex-1">
           <span className="font-mono text-sm font-medium truncate">{node.id}</span>
           <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground shrink-0">
             {node.nodeType}
           </span>
         </div>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 shrink-0"
+          onClick={() => onAddChild(node.id)}
+          aria-label={`Add child to ${node.id}`}
+        >
+          <Plus className="h-3 w-3" />
+        </Button>
       </div>
 
       {expanded && children.map((child) => (
-        <NodeRow key={child.id} node={child} depth={depth + 1} asAt={asAt} />
+        <NodeRow key={child.id} node={child} depth={depth + 1} asAt={asAt} onAddChild={onAddChild} />
       ))}
     </>
   )
@@ -81,6 +93,8 @@ function NodeRow({ node, depth, asAt }: NodeRowProps) {
 export function NodesPage() {
   const clients = useApiClients()
   const [asAt, setAsAt] = React.useState('')
+  const [createDialogOpen, setCreateDialogOpen] = React.useState(false)
+  const [createDialogParentId, setCreateDialogParentId] = React.useState<string | undefined>(undefined)
 
   const rootsQueryKey = ['node-roots', asAt]
 
@@ -99,14 +113,36 @@ export function NodesPage() {
 
   const roots = rootsData ?? []
 
+  function handleAddChildNode(parentId: string) {
+    setCreateDialogParentId(parentId)
+    setCreateDialogOpen(true)
+  }
+
+  function handleAddRootNode() {
+    setCreateDialogParentId(undefined)
+    setCreateDialogOpen(true)
+  }
+
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Nodes</h1>
-        <p className="mt-2 text-muted-foreground">
-          Hierarchical reference data node browser with bi-temporal query support.
-        </p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Nodes</h1>
+          <p className="mt-2 text-muted-foreground">
+            Hierarchical reference data node browser with bi-temporal query support.
+          </p>
+        </div>
+        <Button onClick={handleAddRootNode} aria-label="Add Node">
+          <Plus className="h-4 w-4 mr-1" />
+          Add Node
+        </Button>
       </div>
+
+      <CreateNodeDialog
+        open={createDialogOpen}
+        onOpenChange={setCreateDialogOpen}
+        defaultParentId={createDialogParentId}
+      />
 
       <Card>
         <CardHeader>
@@ -144,7 +180,7 @@ export function NodesPage() {
           ) : (
             <div className="font-mono text-sm">
               {roots.map((node) => (
-                <NodeRow key={node.id} node={node} depth={0} asAt={asAt} />
+                <NodeRow key={node.id} node={node} depth={0} asAt={asAt} onAddChild={handleAddChildNode} />
               ))}
             </div>
           )}

--- a/frontend/src/pages/reference-data/nodes/key-value-editor.test.tsx
+++ b/frontend/src/pages/reference-data/nodes/key-value-editor.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { KeyValueEditor } from './key-value-editor'
+
+function renderEditor(
+  value: Record<string, string> = {},
+  onChange = vi.fn(),
+) {
+  return render(<KeyValueEditor value={value} onChange={onChange} />)
+}
+
+describe('KeyValueEditor', () => {
+  it('renders add attribute button', () => {
+    renderEditor()
+    expect(screen.getByRole('button', { name: /add attribute/i })).toBeInTheDocument()
+  })
+
+  it('adds a new row when Add Attribute clicked', async () => {
+    const user = userEvent.setup()
+    renderEditor()
+    await user.click(screen.getByRole('button', { name: /add attribute/i }))
+    expect(screen.getByLabelText(/attribute key 1/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/attribute value 1/i)).toBeInTheDocument()
+  })
+
+  it('removes a row when Remove clicked', async () => {
+    const user = userEvent.setup()
+    renderEditor()
+    await user.click(screen.getByRole('button', { name: /add attribute/i }))
+    await user.click(screen.getByRole('button', { name: /remove attribute 1/i }))
+    expect(screen.queryByLabelText(/attribute key 1/i)).not.toBeInTheDocument()
+  })
+
+  it('calls onChange with key-value record when key typed', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    renderEditor({}, onChange)
+    await user.click(screen.getByRole('button', { name: /add attribute/i }))
+    await user.type(screen.getByLabelText(/attribute key 1/i), 'region')
+    // Last call should include { region: '' }
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0] as Record<string, string>
+    expect(lastCall).toMatchObject({ region: '' })
+  })
+
+  it('calls onChange with key-value record when value typed', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    renderEditor({}, onChange)
+    await user.click(screen.getByRole('button', { name: /add attribute/i }))
+    await user.type(screen.getByLabelText(/attribute key 1/i), 'k')
+    await user.type(screen.getByLabelText(/attribute value 1/i), 'v')
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0] as Record<string, string>
+    expect(lastCall).toMatchObject({ k: 'v' })
+  })
+
+  it('shows duplicate key warning for repeated keys', async () => {
+    const user = userEvent.setup()
+    renderEditor()
+    // Add two rows and give them the same key
+    await user.click(screen.getByRole('button', { name: /add attribute/i }))
+    await user.click(screen.getByRole('button', { name: /add attribute/i }))
+    await user.type(screen.getByLabelText(/attribute key 1/i), 'dup')
+    await user.type(screen.getByLabelText(/attribute key 2/i), 'dup')
+    expect(screen.getAllByText(/duplicate key/i).length).toBeGreaterThan(0)
+  })
+
+  it('renders pre-populated key-value pairs from value prop', () => {
+    renderEditor({ name: 'Europe', code: 'EU' })
+    expect(screen.getByDisplayValue('name')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Europe')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('code')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('EU')).toBeInTheDocument()
+  })
+
+  it('excludes rows with empty keys from onChange output', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    renderEditor({}, onChange)
+    await user.click(screen.getByRole('button', { name: /add attribute/i }))
+    // Don't type a key - value only
+    await user.type(screen.getByLabelText(/attribute value 1/i), 'orphan')
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0] as Record<string, string>
+    expect(Object.keys(lastCall)).toHaveLength(0)
+  })
+})

--- a/frontend/src/pages/reference-data/nodes/key-value-editor.tsx
+++ b/frontend/src/pages/reference-data/nodes/key-value-editor.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Plus, Trash2 } from 'lucide-react'
+
+export interface KeyValueEditorProps {
+  value: Record<string, string>
+  onChange: (value: Record<string, string>) => void
+}
+
+interface KVPair {
+  id: number
+  key: string
+  val: string
+}
+
+function pairsFromRecord(record: Record<string, string>): KVPair[] {
+  return Object.entries(record).map(([key, val], i) => ({ id: i, key, val }))
+}
+
+let nextId = 0
+
+export function KeyValueEditor({ value, onChange }: KeyValueEditorProps) {
+  const [pairs, setPairs] = React.useState<KVPair[]>(() => pairsFromRecord(value))
+
+  function emit(updated: KVPair[]) {
+    const record: Record<string, string> = {}
+    for (const p of updated) {
+      if (p.key.trim()) {
+        record[p.key.trim()] = p.val
+      }
+    }
+    onChange(record)
+  }
+
+  function handleAdd() {
+    const updated = [...pairs, { id: ++nextId, key: '', val: '' }]
+    setPairs(updated)
+    emit(updated)
+  }
+
+  function handleRemove(id: number) {
+    const updated = pairs.filter((p) => p.id !== id)
+    setPairs(updated)
+    emit(updated)
+  }
+
+  function handleKeyChange(id: number, key: string) {
+    const updated = pairs.map((p) => (p.id === id ? { ...p, key } : p))
+    setPairs(updated)
+    emit(updated)
+  }
+
+  function handleValChange(id: number, val: string) {
+    const updated = pairs.map((p) => (p.id === id ? { ...p, val } : p))
+    setPairs(updated)
+    emit(updated)
+  }
+
+  // Detect duplicate keys
+  const keyCounts: Record<string, number> = {}
+  for (const p of pairs) {
+    const k = p.key.trim()
+    if (k) keyCounts[k] = (keyCounts[k] ?? 0) + 1
+  }
+
+  return (
+    <div className="space-y-2" data-testid="key-value-editor">
+      {pairs.map((p, index) => {
+        const isDuplicate = p.key.trim() && (keyCounts[p.key.trim()] ?? 0) > 1
+        return (
+          <div key={p.id} className="flex items-center gap-2">
+            <div className="flex-1 space-y-0.5">
+              <Input
+                value={p.key}
+                onChange={(e) => handleKeyChange(p.id, e.target.value)}
+                placeholder="key"
+                aria-label={`Attribute key ${index + 1}`}
+                className={isDuplicate ? 'border-destructive' : ''}
+              />
+              {isDuplicate && (
+                <p className="text-xs text-destructive">Duplicate key</p>
+              )}
+            </div>
+            <Input
+              value={p.val}
+              onChange={(e) => handleValChange(p.id, e.target.value)}
+              placeholder="value"
+              aria-label={`Attribute value ${index + 1}`}
+              className="flex-1"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-9 w-9 p-0 shrink-0"
+              onClick={() => handleRemove(p.id)}
+              aria-label={`Remove attribute ${index + 1}`}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        )
+      })}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={handleAdd}
+        aria-label="Add attribute"
+        className="flex items-center gap-1"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        Add Attribute
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/pages/reference-data/nodes/key-value-editor.tsx
+++ b/frontend/src/pages/reference-data/nodes/key-value-editor.tsx
@@ -9,13 +9,18 @@ export interface KeyValueEditorProps {
 }
 
 interface KVPair {
-  id: number
   key: string
   val: string
+  /** Stable identity for React key - set once on creation, never changes */
+  uid: string
 }
 
-function pairsFromRecord(record: Record<string, string>, startId: number): KVPair[] {
-  return Object.entries(record).map(([key, val], i) => ({ id: startId + i, key, val }))
+function pairsFromRecord(record: Record<string, string>): KVPair[] {
+  return Object.entries(record).map(([key, val], i) => ({
+    uid: `init-${i}-${key}`,
+    key,
+    val,
+  }))
 }
 
 function toRecord(pairs: KVPair[]): Record<string, string> {
@@ -28,53 +33,50 @@ function toRecord(pairs: KVPair[]): Record<string, string> {
   return record
 }
 
+let globalUid = 0
+function nextUid(): string {
+  return `kve-${++globalUid}`
+}
+
 export function KeyValueEditor({ value, onChange }: KeyValueEditorProps) {
-  const nextIdRef = React.useRef(0)
+  const [pairs, setPairs] = React.useState<KVPair[]>(() => pairsFromRecord(value))
 
-  const [pairs, setPairs] = React.useState<KVPair[]>(() => {
-    const initial = pairsFromRecord(value, nextIdRef.current)
-    nextIdRef.current += initial.length
-    return initial
-  })
-
-  // Sync pairs when external value is reset (e.g., dialog reset)
+  // Sync pairs when external value prop reference changes (e.g., dialog reset).
+  // We use the value reference as the trigger and do a functional update to
+  // avoid listing `pairs` as a dependency (which would cause infinite loops).
   const prevValueRef = React.useRef(value)
   React.useEffect(() => {
     if (prevValueRef.current !== value) {
       prevValueRef.current = value
-      // Only reset if the external value is structurally different from current internal state
-      const currentRecord = toRecord(pairs)
-      const currentJson = JSON.stringify(currentRecord, Object.keys(currentRecord).sort())
-      const newJson = JSON.stringify(value, Object.keys(value).sort())
-      if (currentJson !== newJson) {
-        const newPairs = pairsFromRecord(value, nextIdRef.current)
-        nextIdRef.current += newPairs.length
-        setPairs(newPairs)
-      }
+      setPairs((currentPairs) => {
+        const currentJson = JSON.stringify(toRecord(currentPairs), Object.keys(toRecord(currentPairs)).sort())
+        const newJson = JSON.stringify(value, Object.keys(value).sort())
+        return currentJson === newJson ? currentPairs : pairsFromRecord(value)
+      })
     }
-  })
+  }, [value])
 
   function handleAdd() {
-    const id = nextIdRef.current++
-    const updated = [...pairs, { id, key: '', val: '' }]
+    const uid = nextUid()
+    const updated = [...pairs, { uid, key: '', val: '' }]
     setPairs(updated)
     onChange(toRecord(updated))
   }
 
-  function handleRemove(id: number) {
-    const updated = pairs.filter((p) => p.id !== id)
+  function handleRemove(uid: string) {
+    const updated = pairs.filter((p) => p.uid !== uid)
     setPairs(updated)
     onChange(toRecord(updated))
   }
 
-  function handleKeyChange(id: number, key: string) {
-    const updated = pairs.map((p) => (p.id === id ? { ...p, key } : p))
+  function handleKeyChange(uid: string, key: string) {
+    const updated = pairs.map((p) => (p.uid === uid ? { ...p, key } : p))
     setPairs(updated)
     onChange(toRecord(updated))
   }
 
-  function handleValChange(id: number, val: string) {
-    const updated = pairs.map((p) => (p.id === id ? { ...p, val } : p))
+  function handleValChange(uid: string, val: string) {
+    const updated = pairs.map((p) => (p.uid === uid ? { ...p, val } : p))
     setPairs(updated)
     onChange(toRecord(updated))
   }
@@ -91,11 +93,11 @@ export function KeyValueEditor({ value, onChange }: KeyValueEditorProps) {
       {pairs.map((p, index) => {
         const isDuplicate = p.key.trim() && (keyCounts[p.key.trim()] ?? 0) > 1
         return (
-          <div key={p.id} className="flex items-center gap-2">
+          <div key={p.uid} className="flex items-center gap-2">
             <div className="flex-1 space-y-0.5">
               <Input
                 value={p.key}
-                onChange={(e) => handleKeyChange(p.id, e.target.value)}
+                onChange={(e) => handleKeyChange(p.uid, e.target.value)}
                 placeholder="key"
                 aria-label={`Attribute key ${index + 1}`}
                 className={isDuplicate ? 'border-destructive' : ''}
@@ -106,7 +108,7 @@ export function KeyValueEditor({ value, onChange }: KeyValueEditorProps) {
             </div>
             <Input
               value={p.val}
-              onChange={(e) => handleValChange(p.id, e.target.value)}
+              onChange={(e) => handleValChange(p.uid, e.target.value)}
               placeholder="value"
               aria-label={`Attribute value ${index + 1}`}
               className="flex-1"
@@ -116,7 +118,7 @@ export function KeyValueEditor({ value, onChange }: KeyValueEditorProps) {
               variant="ghost"
               size="sm"
               className="h-9 w-9 p-0 shrink-0"
-              onClick={() => handleRemove(p.id)}
+              onClick={() => handleRemove(p.uid)}
               aria-label={`Remove attribute ${index + 1}`}
             >
               <Trash2 className="h-4 w-4" />

--- a/frontend/src/pages/reference-data/nodes/key-value-editor.tsx
+++ b/frontend/src/pages/reference-data/nodes/key-value-editor.tsx
@@ -14,47 +14,69 @@ interface KVPair {
   val: string
 }
 
-function pairsFromRecord(record: Record<string, string>): KVPair[] {
-  return Object.entries(record).map(([key, val], i) => ({ id: i, key, val }))
+function pairsFromRecord(record: Record<string, string>, startId: number): KVPair[] {
+  return Object.entries(record).map(([key, val], i) => ({ id: startId + i, key, val }))
 }
 
-let nextId = 0
+function toRecord(pairs: KVPair[]): Record<string, string> {
+  const record: Record<string, string> = {}
+  for (const p of pairs) {
+    if (p.key.trim()) {
+      record[p.key.trim()] = p.val
+    }
+  }
+  return record
+}
 
 export function KeyValueEditor({ value, onChange }: KeyValueEditorProps) {
-  const [pairs, setPairs] = React.useState<KVPair[]>(() => pairsFromRecord(value))
+  const nextIdRef = React.useRef(0)
 
-  function emit(updated: KVPair[]) {
-    const record: Record<string, string> = {}
-    for (const p of updated) {
-      if (p.key.trim()) {
-        record[p.key.trim()] = p.val
+  const [pairs, setPairs] = React.useState<KVPair[]>(() => {
+    const initial = pairsFromRecord(value, nextIdRef.current)
+    nextIdRef.current += initial.length
+    return initial
+  })
+
+  // Sync pairs when external value is reset (e.g., dialog reset)
+  const prevValueRef = React.useRef(value)
+  React.useEffect(() => {
+    if (prevValueRef.current !== value) {
+      prevValueRef.current = value
+      // Only reset if the external value is structurally different from current internal state
+      const currentRecord = toRecord(pairs)
+      const currentJson = JSON.stringify(currentRecord, Object.keys(currentRecord).sort())
+      const newJson = JSON.stringify(value, Object.keys(value).sort())
+      if (currentJson !== newJson) {
+        const newPairs = pairsFromRecord(value, nextIdRef.current)
+        nextIdRef.current += newPairs.length
+        setPairs(newPairs)
       }
     }
-    onChange(record)
-  }
+  })
 
   function handleAdd() {
-    const updated = [...pairs, { id: ++nextId, key: '', val: '' }]
+    const id = nextIdRef.current++
+    const updated = [...pairs, { id, key: '', val: '' }]
     setPairs(updated)
-    emit(updated)
+    onChange(toRecord(updated))
   }
 
   function handleRemove(id: number) {
     const updated = pairs.filter((p) => p.id !== id)
     setPairs(updated)
-    emit(updated)
+    onChange(toRecord(updated))
   }
 
   function handleKeyChange(id: number, key: string) {
     const updated = pairs.map((p) => (p.id === id ? { ...p, key } : p))
     setPairs(updated)
-    emit(updated)
+    onChange(toRecord(updated))
   }
 
   function handleValChange(id: number, val: string) {
     const updated = pairs.map((p) => (p.id === id ? { ...p, val } : p))
     setPairs(updated)
-    emit(updated)
+    onChange(toRecord(updated))
   }
 
   // Detect duplicate keys


### PR DESCRIPTION
## Summary

- Adds `CreateNodeDialog` component for creating reference data nodes with full form validation
- Adds `KeyValueEditor` component for managing key-value attribute pairs
- Integrates dialog into `NodesPage` with Add Node header button and Add Child context action on tree rows

## Changes Made

**`frontend/src/pages/reference-data/nodes/create-node-dialog.tsx`**
- Dialog with fields: code (required, pattern `^[A-Z][A-Z0-9_.-]*$`, 2–100 chars), displayName (required, max 255 chars), nodeType (optional), parentNodeId (searchable select of root nodes, defaults to root level), description (optional, max 1000 chars), additional attributes via KeyValueEditor
- Calls `clients.node.createNode()` via Connect-ES
- On success: invalidates `['node-roots']` and `['node-children', parentId]` query caches
- Supports `defaultParentId` prop to pre-select parent when opened from a tree node's Add Child action
- Resets form on open/close
- Error handling via `handleConnectError`

**`frontend/src/pages/reference-data/nodes/key-value-editor.tsx`**
- Dynamic key-value pair editor with add/remove controls
- Duplicate key detection with inline warning
- Serializes to `Record<string, string>`, excludes rows with empty keys

**`frontend/src/pages/reference-data/nodes/index.tsx`**
- Add Node button in page header opens dialog for root node creation
- Add Child ghost button on each tree row (visible on hover) opens dialog with pre-selected parent

## Technical Details

- `code` and `displayName` are stored as attributes in the protobuf `Struct` field
- `nodeType` maps to the proto `node_type` field
- `parentNodeId` maps to proto `parent_id` (empty string → root node)
- Form validation is client-side; server errors surfaced via `handleConnectError`

## Testing

- 43 tests across 3 files (26 dialog, 8 key-value editor, 9 existing NodesPage)
- Full test suite: 1187 tests passing across 99 files
- Coverage: validation (code pattern, display name), parent selection/deselection, attributes CRUD, submission success/failure, query invalidation, cancel behavior

## Risk Assessment

Low risk: additive changes only. Existing NodesPage tests unaffected; new components are self-contained.