### PR TITLE
feat: add Register Party Type dialog to Operations Console

### DIFF
--- a/frontend/e2e/specs/parties.spec.ts
+++ b/frontend/e2e/specs/parties.spec.ts
@@ -41,11 +41,10 @@ test.describe('Parties list', () => {
 
   test('renders Party Type filter with correct options', async ({ authenticatedPage: page }) => {
     await navigateTo(page, '/parties')
-    // The filter renders as a button (combobox trigger) in the filter bar.
-    // Use role-based locator to avoid matching the column header with the same text.
-    await expect(page.getByRole('button', { name: /party type/i }).or(
-      page.getByRole('combobox', { name: /party type/i })
-    )).toBeVisible()
+    // The filter renders as a combobox (select) in the filter bar.
+    // Use getByRole('combobox') to target the filter select specifically,
+    // avoiding the "Add Party Type" action button which also matches /party type/i.
+    await expect(page.getByRole('combobox', { name: /party type/i })).toBeVisible()
   })
 
   test('renders Status filter', async ({ authenticatedPage: page }) => {

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -27,6 +27,14 @@ export const tenantKeys = {
     [...tenantKeys.all(tenantId), 'payments'] as const,
   payment: (tenantId: string, paymentOrderId: string) =>
     [...tenantKeys.payments(tenantId), paymentOrderId] as const,
+
+  parties: (tenantId: string) =>
+    [...tenantKeys.all(tenantId), 'parties'] as const,
+  party: (tenantId: string, partyId: string) =>
+    [...tenantKeys.parties(tenantId), partyId] as const,
+
+  partyTypes: (tenantId: string) =>
+    [...tenantKeys.all(tenantId), 'party-types'] as const,
 } as const
 
 export const platformKeys = {

--- a/frontend/src/pages/parties/dialogs/register-party-type-dialog.test.tsx
+++ b/frontend/src/pages/parties/dialogs/register-party-type-dialog.test.tsx
@@ -1,0 +1,357 @@
+import * as React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithProviders } from '@/test/test-utils'
+import { RegisterPartyTypeDialog } from './register-party-type-dialog'
+
+const mockRegisterPartyType = vi.fn()
+const mockInvalidateQueries = vi.fn()
+
+vi.mock('@/api/context', () => ({
+  ApiClientProvider: ({ children }: { children: React.ReactNode }) => children,
+  useApiClients: vi.fn(() => ({
+    party: {
+      registerPartyType: mockRegisterPartyType,
+    },
+  })),
+  useClients: vi.fn(() => ({
+    party: {
+      registerPartyType: mockRegisterPartyType,
+    },
+  })),
+}))
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query')
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: mockInvalidateQueries,
+    }),
+  }
+})
+
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: () => 'test-tenant',
+}))
+
+function renderDialog(props: { open?: boolean; onOpenChange?: (open: boolean) => void } = {}) {
+  const { open = true, onOpenChange = vi.fn() } = props
+  return renderWithProviders(
+    <RegisterPartyTypeDialog open={open} onOpenChange={onOpenChange} />,
+  )
+}
+
+describe('RegisterPartyTypeDialog - rendering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRegisterPartyType.mockResolvedValue({ partyTypeDefinition: { id: 'pt-1', partyType: 'INDIVIDUAL' } })
+  })
+
+  it('does not render dialog content when closed', () => {
+    renderDialog({ open: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders dialog content when open', () => {
+    renderDialog()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /add party type/i })).toBeInTheDocument()
+  })
+
+  it('renders code and description fields', () => {
+    renderDialog()
+    expect(screen.getByLabelText(/code/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
+  })
+
+  it('renders submit and cancel buttons', () => {
+    renderDialog()
+    expect(screen.getByRole('button', { name: /add party type/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('shows code pattern hint text', () => {
+    renderDialog()
+    expect(screen.getByText(/uppercase letters, numbers, underscores/i)).toBeInTheDocument()
+  })
+})
+
+describe('RegisterPartyTypeDialog - code auto-uppercase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRegisterPartyType.mockResolvedValue({ partyTypeDefinition: { id: 'pt-1', partyType: 'INDIVIDUAL' } })
+  })
+
+  it('transforms input to uppercase', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    const codeInput = screen.getByLabelText(/code/i)
+    await user.type(codeInput, 'individual')
+
+    expect(codeInput).toHaveValue('INDIVIDUAL')
+  })
+
+  it('transforms mixed case to uppercase', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    const codeInput = screen.getByLabelText(/code/i)
+    await user.type(codeInput, 'Corp_Entity')
+
+    expect(codeInput).toHaveValue('CORP_ENTITY')
+  })
+})
+
+describe('RegisterPartyTypeDialog - code pattern validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRegisterPartyType.mockResolvedValue({ partyTypeDefinition: { id: 'pt-1', partyType: 'INDIVIDUAL' } })
+  })
+
+  it('shows error when code is empty on submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /add party type/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/code is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when code is less than 2 characters', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/code/i), 'A')
+    await user.click(screen.getByRole('button', { name: /add party type/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/at least 2 characters/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error for code starting with digit (e.g. 1ABC)', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    // Type lowercase so we can test the digit prefix after uppercase
+    await user.type(screen.getByLabelText(/code/i), '1ABC')
+    await user.click(screen.getByRole('button', { name: /add party type/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/must start with.*uppercase letter/i)).toBeInTheDocument()
+    })
+  })
+
+  it('accepts valid code INDIVIDUAL without validation error', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/code/i), 'INDIVIDUAL')
+    await user.click(screen.getByRole('button', { name: /add party type/i }))
+
+    // The mutation should be called (no validation error)
+    await waitFor(() => {
+      expect(mockRegisterPartyType).toHaveBeenCalled()
+    })
+    expect(screen.queryByText(/code is required/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('accepts valid code CORP_ENTITY without validation error', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/code/i), 'corp_entity')
+    await user.click(screen.getByRole('button', { name: /add party type/i }))
+
+    // The mutation should be called (no validation error)
+    await waitFor(() => {
+      expect(mockRegisterPartyType).toHaveBeenCalled()
+    })
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})
+
+describe('RegisterPartyTypeDialog - description character limit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRegisterPartyType.mockResolvedValue({ partyTypeDefinition: { id: 'pt-1', partyType: 'INDIVIDUAL' } })
+  })
+
+  it('shows character count for description', () => {
+    renderDialog()
+    expect(screen.getByText('0/1000')).toBeInTheDocument()
+  })
+
+  it('updates character count as user types', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/description/i), 'Hello')
+
+    expect(screen.getByText('5/1000')).toBeInTheDocument()
+  })
+})
+
+describe('RegisterPartyTypeDialog - successful submission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRegisterPartyType.mockResolvedValue({ partyTypeDefinition: { id: 'pt-1', partyType: 'INDIVIDUAL' } })
+  })
+
+  it('submits with correct partyType value', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    renderDialog({ onOpenChange })
+
+    await user.type(screen.getByLabelText(/code/i), 'individual')
+    await user.click(screen.getByRole('button', { name: /add party type/i }))
+
+    await waitFor(() => {
+      expect(mockRegisterPartyType).toHaveBeenCalledWith(
+        expect.objectContaining({
+          partyType: 'INDIVIDUAL',
+        }),
+      )
+    })
+  })
+
+  it('invalidates party-types query on success', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/code/i), 'INDIVIDUAL')
+    await user.click(screen.getByRole('button', { name: /add party type/i }))
+
+    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: expect.arrayContaining(['party-types']),
+        }),
+      )
+    })
+  })
+
+  it('closes dialog on success', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    renderDialog({ onOpenChange })
+
+    await user.type(screen.getByLabelText(/code/i), 'INDIVIDUAL')
+    await user.click(screen.getByRole('button', { name: /add party type/i }))
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('disables submit button while pending', async () => {
+    mockRegisterPartyType.mockImplementation(() => new Promise(() => {}))
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/code/i), 'INDIVIDUAL')
+    await user.click(screen.getByRole('button', { name: /add party type/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /adding/i })).toBeDisabled()
+    })
+  })
+})
+
+describe('RegisterPartyTypeDialog - error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows field-level error for INVALID_ARGUMENT on party_type field', async () => {
+    const user = userEvent.setup()
+    const { Code, ConnectError } = await import('@connectrpc/connect')
+    const err = new ConnectError('invalid', Code.InvalidArgument)
+    err.details = [
+      {
+        type: 'google.rpc.BadRequest',
+        value: new Uint8Array(),
+        debug: {
+          fieldViolations: [{ field: 'party_type', description: 'Party type code is reserved' }],
+        },
+      },
+    ]
+    mockRegisterPartyType.mockRejectedValue(err)
+
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/code/i), 'RESERVED')
+    await user.click(screen.getByRole('button', { name: /add party type/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Party type code is reserved')).toBeInTheDocument()
+    })
+  })
+
+  it('shows duplicate code error for ALREADY_EXISTS', async () => {
+    const user = userEvent.setup()
+    const { Code, ConnectError } = await import('@connectrpc/connect')
+    const err = new ConnectError('already exists', Code.AlreadyExists)
+    mockRegisterPartyType.mockRejectedValue(err)
+
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/code/i), 'INDIVIDUAL')
+    await user.click(screen.getByRole('button', { name: /add party type/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/already exists/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows general error banner for server errors', async () => {
+    const user = userEvent.setup()
+    const { Code, ConnectError } = await import('@connectrpc/connect')
+    const err = new ConnectError('server error', Code.Internal)
+    mockRegisterPartyType.mockRejectedValue(err)
+
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/code/i), 'INDIVIDUAL')
+    await user.click(screen.getByRole('button', { name: /add party type/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('RegisterPartyTypeDialog - reset on close', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRegisterPartyType.mockResolvedValue({ partyTypeDefinition: { id: 'pt-1', partyType: 'INDIVIDUAL' } })
+  })
+
+  it('clears form when dialog is closed', async () => {
+    const user = userEvent.setup()
+    const { rerender } = renderDialog()
+
+    await user.type(screen.getByLabelText(/code/i), 'INDIVIDUAL')
+
+    rerender(<RegisterPartyTypeDialog open={false} onOpenChange={vi.fn()} />)
+    rerender(<RegisterPartyTypeDialog open={true} onOpenChange={vi.fn()} />)
+
+    expect(screen.getByLabelText(/code/i)).toHaveValue('')
+  })
+
+  it('closes dialog when cancel is clicked', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    renderDialog({ onOpenChange })
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/frontend/src/pages/parties/dialogs/register-party-type-dialog.tsx
+++ b/frontend/src/pages/parties/dialogs/register-party-type-dialog.tsx
@@ -1,0 +1,232 @@
+import * as React from 'react'
+import { Code } from '@connectrpc/connect'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useApiClients } from '@/api/context'
+import { handleConnectError } from '@/lib/error-handling'
+import { tenantKeys } from '@/lib/query-keys'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+
+// Pattern: uppercase letter followed by uppercase letters, digits, underscores
+const PARTY_TYPE_CODE_PATTERN = /^[A-Z][A-Z0-9_]*$/
+
+interface FormData {
+  code: string
+  description: string
+}
+
+interface FormErrors {
+  code?: string
+  description?: string
+  general?: string
+}
+
+const initialFormData: FormData = {
+  code: '',
+  description: '',
+}
+
+export interface RegisterPartyTypeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function RegisterPartyTypeDialog({ open, onOpenChange }: RegisterPartyTypeDialogProps) {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+  const queryClient = useQueryClient()
+
+  const [formData, setFormData] = React.useState<FormData>(initialFormData)
+  const [errors, setErrors] = React.useState<FormErrors>({})
+
+  React.useEffect(() => {
+    if (!open) {
+      setFormData(initialFormData)
+      setErrors({})
+    }
+  }, [open])
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      return clients.party.registerPartyType({
+        partyType: formData.code.trim(),
+        attributeSchema: formData.description.trim()
+          ? JSON.stringify({ description: formData.description.trim() })
+          : '',
+        validationCel: '',
+        eligibilityCel: '',
+        errorMessageCel: '',
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tenantKeys.partyTypes(tenantSlug ?? '') })
+      onOpenChange(false)
+    },
+    onError: (err) => {
+      const result = handleConnectError(err)
+      if (result.code === Code.InvalidArgument && Object.keys(result.fieldErrors).length > 0) {
+        const fieldMap: FormErrors = {}
+        for (const [field, msg] of Object.entries(result.fieldErrors)) {
+          if (field === 'party_type') fieldMap.code = msg
+          else fieldMap.general = msg
+        }
+        setErrors(fieldMap)
+      } else if (result.code === Code.AlreadyExists) {
+        setErrors({ code: 'A party type with this code already exists' })
+      } else {
+        setErrors({ general: result.message })
+      }
+    },
+  })
+
+  function validate(): boolean {
+    const newErrors: FormErrors = {}
+
+    const code = formData.code.trim()
+    if (!code) {
+      newErrors.code = 'Code is required'
+    } else if (code.length < 2) {
+      newErrors.code = 'Code must be at least 2 characters'
+    } else if (code.length > 50) {
+      newErrors.code = 'Code must be 50 characters or fewer'
+    } else if (!PARTY_TYPE_CODE_PATTERN.test(code)) {
+      newErrors.code = 'Code must start with an uppercase letter and contain only uppercase letters, numbers, and underscores'
+    }
+
+    if (formData.description.trim().length > 1000) {
+      newErrors.description = 'Description must be 1000 characters or fewer'
+    }
+
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+    mutation.mutate()
+  }
+
+  function handleCodeChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const upper = e.target.value.toUpperCase()
+    setFormData((prev) => ({ ...prev, code: upper }))
+    if (errors.code) {
+      setErrors((prev) => ({ ...prev, code: undefined }))
+    }
+  }
+
+  function handleDescriptionChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    setFormData((prev) => ({ ...prev, description: e.target.value }))
+    if (errors.description) {
+      setErrors((prev) => ({ ...prev, description: undefined }))
+    }
+  }
+
+  const descriptionLength = formData.description.length
+  const descriptionMax = 1000
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Party Type</DialogTitle>
+          <DialogDescription>
+            Define a new party type for this tenant. The code uniquely identifies the type.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="register-party-type-form">
+          <div className="space-y-4 py-2">
+            {errors.general && (
+              <div
+                role="alert"
+                className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                {errors.general}
+              </div>
+            )}
+
+            <div className="space-y-1">
+              <label htmlFor="partyTypeCode" className="text-sm font-medium">
+                Code <span aria-hidden="true">*</span>
+              </label>
+              <Input
+                id="partyTypeCode"
+                value={formData.code}
+                onChange={handleCodeChange}
+                placeholder="INDIVIDUAL"
+                aria-describedby={
+                  errors.code ? 'partyTypeCode-error' : 'partyTypeCode-hint'
+                }
+                aria-required="true"
+              />
+              <p id="partyTypeCode-hint" className="text-xs text-muted-foreground">
+                Uppercase letters, numbers, underscores. Must start with a letter. (2–50 chars)
+              </p>
+              {errors.code && (
+                <p id="partyTypeCode-error" role="alert" className="text-sm text-destructive">
+                  {errors.code}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="partyTypeDescription" className="text-sm font-medium">
+                Description
+              </label>
+              <textarea
+                id="partyTypeDescription"
+                value={formData.description}
+                onChange={handleDescriptionChange}
+                placeholder="Optional description of this party type"
+                rows={3}
+                maxLength={descriptionMax}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                aria-describedby={
+                  errors.description
+                    ? 'partyTypeDescription-error partyTypeDescription-count'
+                    : 'partyTypeDescription-count'
+                }
+              />
+              <p
+                id="partyTypeDescription-count"
+                className="text-xs text-muted-foreground"
+                aria-live="polite"
+                aria-label={`${descriptionLength} of ${descriptionMax} characters used`}
+              >
+                {descriptionLength}/{descriptionMax}
+              </p>
+              {errors.description && (
+                <p id="partyTypeDescription-error" role="alert" className="text-sm text-destructive">
+                  {errors.description}
+                </p>
+              )}
+            </div>
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="register-party-type-form"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Adding...' : 'Add Party Type'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/parties/index.test.tsx
+++ b/frontend/src/pages/parties/index.test.tsx
@@ -1,19 +1,27 @@
+import * as React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter } from 'react-router-dom'
 
 // Mock the API context to avoid loading ungenerated proto files
+const mockPartyClient = {
+  listParties: vi.fn().mockResolvedValue({
+    parties: [],
+    nextPageToken: '',
+    totalCount: 0n,
+  }),
+  registerPartyType: vi.fn().mockResolvedValue({}),
+}
+
 vi.mock('@/api/context', () => ({
-  useClients: vi.fn(() => ({
-    party: {
-      listParties: vi.fn().mockResolvedValue({
-        parties: [],
-        nextPageToken: '',
-        totalCount: 0n,
-      }),
-    },
-  })),
+  ApiClientProvider: ({ children }: { children: React.ReactNode }) => children,
+  useClients: vi.fn(() => ({ party: mockPartyClient })),
+  useApiClients: vi.fn(() => ({ party: mockPartyClient })),
+}))
+
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: () => 'test-tenant',
 }))
 
 import { PartiesPage } from './index'

--- a/frontend/src/pages/parties/index.tsx
+++ b/frontend/src/pages/parties/index.tsx
@@ -6,6 +6,8 @@ import { TimeDisplay } from '@/components/shared/time-display'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { useClients } from '@/api/context'
 import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { RegisterPartyTypeDialog } from './dialogs/register-party-type-dialog'
 
 export interface Party {
   partyId: string
@@ -30,6 +32,7 @@ interface ListPartiesResult {
 export function PartiesPage() {
   const navigate = useNavigate()
   const clients = useClients()
+  const [addPartyTypeOpen, setAddPartyTypeOpen] = React.useState(false)
 
   const columns: ColumnDef<Party>[] = [
     {
@@ -120,12 +123,22 @@ export function PartiesPage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Parties</h1>
-        <p className="mt-2 text-muted-foreground">
-          Manage parties, their demographics, and linked accounts.
-        </p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Parties</h1>
+          <p className="mt-2 text-muted-foreground">
+            Manage parties, their demographics, and linked accounts.
+          </p>
+        </div>
+        <Button variant="outline" onClick={() => setAddPartyTypeOpen(true)}>
+          Add Party Type
+        </Button>
       </div>
+
+      <RegisterPartyTypeDialog
+        open={addPartyTypeOpen}
+        onOpenChange={setAddPartyTypeOpen}
+      />
 
       <Card className="p-6">
         <DataTable


### PR DESCRIPTION
## Summary

- Adds `RegisterPartyTypeDialog` component at `frontend/src/pages/parties/dialogs/register-party-type-dialog.tsx`
- Adds an 'Add Party Type' button to `PartiesPage` header that opens the dialog
- Adds `parties` and `partyTypes` query key factories to `tenantKeys` in `query-keys.ts`

## Changes Made

**New files:**
- `frontend/src/pages/parties/dialogs/register-party-type-dialog.tsx` — Dialog component with `partyType` code field and optional description textarea
- `frontend/src/pages/parties/dialogs/register-party-type-dialog.test.tsx` — 23 unit tests

**Modified files:**
- `frontend/src/lib/query-keys.ts` — Add `parties` and `partyTypes` factories to `tenantKeys`
- `frontend/src/pages/parties/index.tsx` — Add 'Add Party Type' button and wire up dialog
- `frontend/src/pages/parties/index.test.tsx` — Update mock to include `useApiClients` and `registerPartyType`

## Technical Details

The dialog calls `clients.party.registerPartyType()` with the following fields from the proto API:
- `partyType`: the code identifier (required; validated against `^[A-Z][A-Z0-9_]*$`, 2–50 chars; auto-uppercased on input)
- `attributeSchema`: populated from the optional description field when provided

On success: invalidates `tenantKeys.partyTypes(tenantSlug)` so the party type dropdown in `RegisterPartyDialog` refreshes automatically.

Error handling covers: `AlreadyExists` (code-level message), `InvalidArgument` with `party_type` field violations, and general server errors (alert banner).

## Testing

- 1176/1176 tests passing
- 23 new tests covering: rendering, auto-uppercase, code pattern validation, description character counter, successful submission, error handling (field-level and general), reset-on-close