### PR TITLE
feat: add RegisterInstrumentDialog to instruments page

### DIFF
--- a/frontend/src/pages/reference-data/instruments/index.test.tsx
+++ b/frontend/src/pages/reference-data/instruments/index.test.tsx
@@ -15,12 +15,16 @@ const mockEvaluateInstrument = vi.fn().mockResolvedValue({
   fungibilityKey: 'USD:1',
   errorMessage: '',
 })
+const mockRegisterInstrument = vi.fn().mockResolvedValue({
+  instrument: { id: 'test-id', code: 'KWH', version: 1, dimension: 2, precision: 6, status: 1 },
+})
 
 vi.mock('@/api/context', () => ({
   useApiClients: vi.fn(() => ({
     referenceData: {
       listInstruments: mockListInstruments,
       evaluateInstrument: mockEvaluateInstrument,
+      registerInstrument: mockRegisterInstrument,
     },
   })),
 }))
@@ -318,6 +322,31 @@ describe('InstrumentsPage', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('cel-result')).toBeInTheDocument()
+    })
+  })
+
+  it('renders Register Instrument button in the header', () => {
+    render(
+      <Wrapper>
+        <InstrumentsPage />
+      </Wrapper>,
+    )
+    expect(screen.getByRole('button', { name: /register instrument/i })).toBeInTheDocument()
+  })
+
+  it('opens RegisterInstrumentDialog when Register Instrument button is clicked', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Wrapper>
+        <InstrumentsPage />
+      </Wrapper>,
+    )
+
+    await user.click(screen.getByRole('button', { name: /register instrument/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/pages/reference-data/instruments/index.tsx
+++ b/frontend/src/pages/reference-data/instruments/index.tsx
@@ -8,11 +8,13 @@ import { useApiClients } from '@/api/context'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { AlertTriangle } from 'lucide-react'
+import { referenceKeys } from '@/lib/query-keys'
 import {
   InstrumentStatus,
   Dimension,
   type InstrumentDefinition,
 } from '@/api/gen/meridian/reference_data/v1/instrument_pb'
+import { RegisterInstrumentDialog } from './register-instrument-dialog'
 
 const DIMENSION_LABELS: Record<number, string> = {
   0: 'Unspecified',
@@ -61,6 +63,7 @@ interface CELPlaygroundResult {
 
 export function InstrumentsPage() {
   const clients = useApiClients()
+  const [registerDialogOpen, setRegisterDialogOpen] = React.useState(false)
 
   const [validationExpression, setValidationExpression] = React.useState('amount > 0')
   const [fungibilityExpression, setFungibilityExpression] = React.useState('instrument_code')
@@ -178,16 +181,26 @@ export function InstrumentsPage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Instruments</h1>
-        <p className="mt-2 text-muted-foreground">
-          Reference data instrument definitions with CEL validation expressions.
-        </p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Instruments</h1>
+          <p className="mt-2 text-muted-foreground">
+            Reference data instrument definitions with CEL validation expressions.
+          </p>
+        </div>
+        <Button onClick={() => setRegisterDialogOpen(true)}>
+          Register Instrument
+        </Button>
       </div>
+
+      <RegisterInstrumentDialog
+        open={registerDialogOpen}
+        onOpenChange={setRegisterDialogOpen}
+      />
 
       <Card className="p-6">
         <DataTable
-          queryKey={['instruments']}
+          queryKey={referenceKeys.instruments()}
           queryFn={queryFn}
           columns={columns}
           pageSize={25}

--- a/frontend/src/pages/reference-data/instruments/register-instrument-dialog.test.tsx
+++ b/frontend/src/pages/reference-data/instruments/register-instrument-dialog.test.tsx
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BrowserRouter } from 'react-router-dom'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+const mockRegisterInstrument = vi.fn().mockResolvedValue({
+  instrument: {
+    id: 'aaaaaaaa-0000-0000-0000-000000000001',
+    code: 'KWH',
+    version: 1,
+    dimension: 2,
+    precision: 6,
+    status: 1,
+    displayName: 'Kilowatt Hour',
+    description: '',
+  },
+})
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(() => ({
+    referenceData: {
+      registerInstrument: mockRegisterInstrument,
+    },
+  })),
+}))
+
+import { RegisterInstrumentDialog } from './register-instrument-dialog'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = makeQueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <BrowserRouter>{children}</BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+function renderDialog(props: { open?: boolean; onOpenChange?: (open: boolean) => void } = {}) {
+  const onOpenChange = props.onOpenChange ?? vi.fn()
+  render(
+    <Wrapper>
+      <RegisterInstrumentDialog open={props.open ?? true} onOpenChange={onOpenChange} />
+    </Wrapper>,
+  )
+  return { onOpenChange }
+}
+
+describe('RegisterInstrumentDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders dialog title when open', () => {
+    renderDialog()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /register instrument/i })).toBeInTheDocument()
+  })
+
+  it('does not render when closed', () => {
+    renderDialog({ open: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders all required form fields', () => {
+    renderDialog()
+    expect(screen.getByLabelText(/code/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/dimension/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/decimal places/i)).toBeInTheDocument()
+  })
+
+  it('renders optional form fields', () => {
+    renderDialog()
+    expect(screen.getByLabelText(/symbol/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
+  })
+
+  it('renders Cancel and Register buttons', () => {
+    renderDialog()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /register instrument/i })).toBeInTheDocument()
+  })
+
+  it('auto-uppercases code field input', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    const codeInput = screen.getByLabelText(/code/i)
+    await user.type(codeInput, 'kwh')
+    expect(codeInput).toHaveValue('KWH')
+  })
+
+  it('validates code is required on submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.click(screen.getByRole('button', { name: /register instrument/i }))
+    expect(await screen.findByText(/code is required/i)).toBeInTheDocument()
+  })
+
+  it('validates code pattern - must match ^[A-Z][A-Z0-9_]*$', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    const codeInput = screen.getByLabelText(/code/i)
+    // Type lowercase then blur (auto-uppercase won't help if we set directly)
+    await user.type(codeInput, '1INVALID')
+    await user.click(screen.getByRole('button', { name: /register instrument/i }))
+    expect(await screen.findByText(/invalid code format/i)).toBeInTheDocument()
+  })
+
+  it('validates display name is required on submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    const codeInput = screen.getByLabelText(/code/i)
+    await user.type(codeInput, 'KWH')
+    await user.click(screen.getByRole('button', { name: /register instrument/i }))
+    expect(await screen.findByText(/display name is required/i)).toBeInTheDocument()
+  })
+
+  it('validates dimension is required on submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    const codeInput = screen.getByLabelText(/code/i)
+    await user.type(codeInput, 'KWH')
+    const displayNameInput = screen.getByLabelText(/display name/i)
+    await user.type(displayNameInput, 'Kilowatt Hour')
+    await user.click(screen.getByRole('button', { name: /register instrument/i }))
+    expect(await screen.findByText(/dimension is required/i)).toBeInTheDocument()
+  })
+
+  it('validates decimal places range 0-18', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    const decimalInput = screen.getByLabelText(/decimal places/i)
+    await user.clear(decimalInput)
+    await user.type(decimalInput, '19')
+    await user.click(screen.getByRole('button', { name: /register instrument/i }))
+    expect(await screen.findByText(/decimal places must be between 0 and 18/i)).toBeInTheDocument()
+  })
+
+  it('renders all dimension options in the select', () => {
+    renderDialog()
+    const dimensionSelect = screen.getByLabelText(/dimension/i)
+    const options = Array.from(dimensionSelect.querySelectorAll('option')).map((o) => o.textContent)
+    expect(options).toContain('Currency')
+    expect(options).toContain('Energy')
+    expect(options).toContain('Mass')
+    expect(options).toContain('Volume')
+    expect(options).toContain('Time')
+    expect(options).toContain('Compute')
+    expect(options).toContain('Carbon')
+    expect(options).toContain('Data')
+    expect(options).toContain('Count')
+  })
+
+  it('calls registerInstrument with correct data on valid submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/code/i), 'KWH')
+    await user.type(screen.getByLabelText(/display name/i), 'Kilowatt Hour')
+    await user.selectOptions(screen.getByLabelText(/dimension/i), '2') // Energy
+    const decimalInput = screen.getByLabelText(/decimal places/i)
+    await user.clear(decimalInput)
+    await user.type(decimalInput, '6')
+    await user.click(screen.getByRole('button', { name: /register instrument/i }))
+
+    await waitFor(() => {
+      expect(mockRegisterInstrument).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'KWH',
+          displayName: 'Kilowatt Hour',
+          dimension: 2,
+          precision: 6,
+        }),
+      )
+    })
+  })
+
+  it('shows DRAFT status notification after successful registration', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/code/i), 'KWH')
+    await user.type(screen.getByLabelText(/display name/i), 'Kilowatt Hour')
+    await user.selectOptions(screen.getByLabelText(/dimension/i), '2')
+    await user.click(screen.getByRole('button', { name: /register instrument/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/instrument created in draft status/i),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('closes dialog on Cancel button click', async () => {
+    const user = userEvent.setup()
+    const { onOpenChange } = renderDialog()
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('shows general error on API failure', async () => {
+    mockRegisterInstrument.mockRejectedValueOnce(new Error('Server error'))
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/code/i), 'KWH')
+    await user.type(screen.getByLabelText(/display name/i), 'Kilowatt Hour')
+    await user.selectOptions(screen.getByLabelText(/dimension/i), '2')
+    await user.click(screen.getByRole('button', { name: /register instrument/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+
+  it('resets form when dialog is closed and reopened', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    const { rerender } = render(
+      <Wrapper>
+        <RegisterInstrumentDialog open={true} onOpenChange={onOpenChange} />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/code/i), 'KWH')
+    expect(screen.getByLabelText(/code/i)).toHaveValue('KWH')
+
+    rerender(
+      <Wrapper>
+        <RegisterInstrumentDialog open={false} onOpenChange={onOpenChange} />
+      </Wrapper>,
+    )
+    rerender(
+      <Wrapper>
+        <RegisterInstrumentDialog open={true} onOpenChange={onOpenChange} />
+      </Wrapper>,
+    )
+
+    expect(screen.getByLabelText(/code/i)).toHaveValue('')
+  })
+})

--- a/frontend/src/pages/reference-data/instruments/register-instrument-dialog.test.tsx
+++ b/frontend/src/pages/reference-data/instruments/register-instrument-dialog.test.tsx
@@ -82,9 +82,8 @@ describe('RegisterInstrumentDialog', () => {
     expect(screen.getByLabelText(/decimal places/i)).toBeInTheDocument()
   })
 
-  it('renders optional form fields', () => {
+  it('renders optional description field', () => {
     renderDialog()
-    expect(screen.getByLabelText(/symbol/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
   })
 

--- a/frontend/src/pages/reference-data/instruments/register-instrument-dialog.test.tsx
+++ b/frontend/src/pages/reference-data/instruments/register-instrument-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter } from 'react-router-dom'

--- a/frontend/src/pages/reference-data/instruments/register-instrument-dialog.test.tsx
+++ b/frontend/src/pages/reference-data/instruments/register-instrument-dialog.test.tsx
@@ -5,18 +5,20 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter } from 'react-router-dom'
 import { TooltipProvider } from '@/components/ui/tooltip'
 
-const mockRegisterInstrument = vi.fn().mockResolvedValue({
-  instrument: {
-    id: 'aaaaaaaa-0000-0000-0000-000000000001',
-    code: 'KWH',
-    version: 1,
-    dimension: 2,
-    precision: 6,
-    status: 1,
-    displayName: 'Kilowatt Hour',
-    description: '',
-  },
-})
+const mockRegisterInstrument = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    instrument: {
+      id: 'aaaaaaaa-0000-0000-0000-000000000001',
+      code: 'KWH',
+      version: 1,
+      dimension: 2,
+      precision: 6,
+      status: 1,
+      displayName: 'Kilowatt Hour',
+      description: '',
+    },
+  }),
+)
 
 vi.mock('@/api/context', () => ({
   useApiClients: vi.fn(() => ({
@@ -218,6 +220,33 @@ describe('RegisterInstrumentDialog', () => {
 
     expect(screen.getByLabelText(/code/i)).toHaveValue('')
     expect(screen.getByLabelText(/display name/i)).toHaveValue('')
+  })
+
+  it('invalidates instruments query after successful registration', async () => {
+    const user = userEvent.setup()
+    const qc = makeQueryClient()
+    vi.spyOn(qc, 'invalidateQueries')
+
+    render(
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <BrowserRouter>
+            <RegisterInstrumentDialog open={true} onOpenChange={vi.fn()} />
+          </BrowserRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    )
+
+    await user.type(screen.getByLabelText(/code/i), 'KWH')
+    await user.type(screen.getByLabelText(/display name/i), 'Kilowatt Hour')
+    await user.selectOptions(screen.getByLabelText(/dimension/i), '2')
+    await user.click(screen.getByRole('button', { name: /register instrument/i }))
+
+    await waitFor(() => {
+      expect(qc.invalidateQueries).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: expect.arrayContaining(['reference', 'instruments']) }),
+      )
+    })
   })
 
   it('closes dialog on Cancel button click', async () => {

--- a/frontend/src/pages/reference-data/instruments/register-instrument-dialog.test.tsx
+++ b/frontend/src/pages/reference-data/instruments/register-instrument-dialog.test.tsx
@@ -203,6 +203,23 @@ describe('RegisterInstrumentDialog', () => {
     })
   })
 
+  it('clears form fields after successful registration', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/code/i), 'KWH')
+    await user.type(screen.getByLabelText(/display name/i), 'Kilowatt Hour')
+    await user.selectOptions(screen.getByLabelText(/dimension/i), '2')
+    await user.click(screen.getByRole('button', { name: /register instrument/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/instrument created in draft status/i)).toBeInTheDocument()
+    })
+
+    expect(screen.getByLabelText(/code/i)).toHaveValue('')
+    expect(screen.getByLabelText(/display name/i)).toHaveValue('')
+  })
+
   it('closes dialog on Cancel button click', async () => {
     const user = userEvent.setup()
     const { onOpenChange } = renderDialog()

--- a/frontend/src/pages/reference-data/instruments/register-instrument-dialog.tsx
+++ b/frontend/src/pages/reference-data/instruments/register-instrument-dialog.tsx
@@ -34,7 +34,6 @@ interface FormData {
   displayName: string
   dimension: string
   decimalPlaces: string
-  symbol: string
   description: string
 }
 
@@ -43,7 +42,6 @@ interface FormErrors {
   displayName?: string
   dimension?: string
   decimalPlaces?: string
-  symbol?: string
   description?: string
   general?: string
 }
@@ -58,7 +56,6 @@ const INITIAL_FORM: FormData = {
   displayName: '',
   dimension: '',
   decimalPlaces: '0',
-  symbol: '',
   description: '',
 }
 
@@ -138,10 +135,6 @@ export function RegisterInstrumentDialog({ open, onOpenChange }: RegisterInstrum
       next.decimalPlaces = 'Decimal places must be a whole number'
     } else if (dp < 0 || dp > 18) {
       next.decimalPlaces = 'Decimal places must be between 0 and 18'
-    }
-
-    if (formData.symbol && (formData.symbol.length < 1 || formData.symbol.length > 5)) {
-      next.symbol = 'Symbol must be between 1 and 5 characters'
     }
 
     if (formData.description && formData.description.length > 1000) {
@@ -288,26 +281,6 @@ export function RegisterInstrumentDialog({ open, onOpenChange }: RegisterInstrum
               {errors.decimalPlaces && (
                 <p id="instrument-decimal-places-error" className="text-sm text-destructive">
                   {errors.decimalPlaces}
-                </p>
-              )}
-            </div>
-
-            <div className="space-y-1">
-              <label htmlFor="instrument-symbol" className="text-sm font-medium">
-                Symbol
-              </label>
-              <Input
-                id="instrument-symbol"
-                value={formData.symbol}
-                onChange={handleChange('symbol')}
-                placeholder="$ or kWh"
-                aria-label="Symbol"
-                aria-describedby={errors.symbol ? 'instrument-symbol-error' : undefined}
-                maxLength={5}
-              />
-              {errors.symbol && (
-                <p id="instrument-symbol-error" className="text-sm text-destructive">
-                  {errors.symbol}
                 </p>
               )}
             </div>

--- a/frontend/src/pages/reference-data/instruments/register-instrument-dialog.tsx
+++ b/frontend/src/pages/reference-data/instruments/register-instrument-dialog.tsx
@@ -69,6 +69,40 @@ export function RegisterInstrumentDialog({ open, onOpenChange }: RegisterInstrum
   const [errors, setErrors] = React.useState<FormErrors>({})
   const [successMessage, setSuccessMessage] = React.useState<string | null>(null)
 
+  const mutation = useMutation({
+    mutationFn: () =>
+      clients.referenceData.registerInstrument({
+        code: formData.code.trim(),
+        displayName: formData.displayName.trim(),
+        dimension: Number(formData.dimension),
+        precision: Number(formData.decimalPlaces),
+        description: formData.description.trim(),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: referenceKeys.instruments() })
+      setSuccessMessage(
+        'Instrument created in DRAFT status. Activation required via manifest or API.',
+      )
+    },
+    onError: (err) => {
+      const result = handleConnectError(err)
+      if (result.code === Code.InvalidArgument && Object.keys(result.fieldErrors).length > 0) {
+        const fieldMap: FormErrors = {}
+        for (const [field, msg] of Object.entries(result.fieldErrors)) {
+          if (field === 'code') fieldMap.code = msg
+          else if (field === 'display_name') fieldMap.displayName = msg
+          else if (field === 'dimension') fieldMap.dimension = msg
+          else if (field === 'precision') fieldMap.decimalPlaces = msg
+          else if (field === 'description') fieldMap.description = msg
+          else fieldMap.general = msg
+        }
+        setErrors(fieldMap)
+      } else {
+        setErrors({ general: result.message })
+      }
+    },
+  })
+
   React.useEffect(() => {
     if (!open) {
       setFormData(INITIAL_FORM)
@@ -117,40 +151,6 @@ export function RegisterInstrumentDialog({ open, onOpenChange }: RegisterInstrum
     setErrors(next)
     return Object.keys(next).length === 0
   }
-
-  const mutation = useMutation({
-    mutationFn: () =>
-      clients.referenceData.registerInstrument({
-        code: formData.code.trim(),
-        displayName: formData.displayName.trim(),
-        dimension: Number(formData.dimension),
-        precision: Number(formData.decimalPlaces),
-        description: formData.description.trim(),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: referenceKeys.instruments() })
-      setSuccessMessage(
-        'Instrument created in DRAFT status. Activation required via manifest or API.',
-      )
-    },
-    onError: (err) => {
-      const result = handleConnectError(err)
-      if (result.code === Code.InvalidArgument && Object.keys(result.fieldErrors).length > 0) {
-        const fieldMap: FormErrors = {}
-        for (const [field, msg] of Object.entries(result.fieldErrors)) {
-          if (field === 'code') fieldMap.code = msg
-          else if (field === 'display_name') fieldMap.displayName = msg
-          else if (field === 'dimension') fieldMap.dimension = msg
-          else if (field === 'precision') fieldMap.decimalPlaces = msg
-          else if (field === 'description') fieldMap.description = msg
-          else fieldMap.general = msg
-        }
-        setErrors(fieldMap)
-      } else {
-        setErrors({ general: result.message })
-      }
-    },
-  })
 
   function handleCodeChange(e: React.ChangeEvent<HTMLInputElement>) {
     const upper = e.target.value.toUpperCase()

--- a/frontend/src/pages/reference-data/instruments/register-instrument-dialog.tsx
+++ b/frontend/src/pages/reference-data/instruments/register-instrument-dialog.tsx
@@ -77,6 +77,8 @@ export function RegisterInstrumentDialog({ open, onOpenChange }: RegisterInstrum
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: referenceKeys.instruments() })
+      setFormData(INITIAL_FORM)
+      setErrors({})
       setSuccessMessage(
         'Instrument created in DRAFT status. Activation required via manifest or API.',
       )

--- a/frontend/src/pages/reference-data/instruments/register-instrument-dialog.tsx
+++ b/frontend/src/pages/reference-data/instruments/register-instrument-dialog.tsx
@@ -1,0 +1,354 @@
+import * as React from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useApiClients } from '@/api/context'
+import { handleConnectError } from '@/lib/error-handling'
+import { referenceKeys } from '@/lib/query-keys'
+import { Code } from '@connectrpc/connect'
+
+const CODE_PATTERN = /^[A-Z][A-Z0-9_]*$/
+
+const DIMENSION_OPTIONS = [
+  { label: 'Currency', value: 1 },
+  { label: 'Energy', value: 2 },
+  { label: 'Mass', value: 3 },
+  { label: 'Volume', value: 4 },
+  { label: 'Time', value: 5 },
+  { label: 'Compute', value: 6 },
+  { label: 'Carbon', value: 7 },
+  { label: 'Data', value: 8 },
+  { label: 'Count', value: 9 },
+]
+
+interface FormData {
+  code: string
+  displayName: string
+  dimension: string
+  decimalPlaces: string
+  symbol: string
+  description: string
+}
+
+interface FormErrors {
+  code?: string
+  displayName?: string
+  dimension?: string
+  decimalPlaces?: string
+  symbol?: string
+  description?: string
+  general?: string
+}
+
+export interface RegisterInstrumentDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const INITIAL_FORM: FormData = {
+  code: '',
+  displayName: '',
+  dimension: '',
+  decimalPlaces: '0',
+  symbol: '',
+  description: '',
+}
+
+export function RegisterInstrumentDialog({ open, onOpenChange }: RegisterInstrumentDialogProps) {
+  const clients = useApiClients()
+  const queryClient = useQueryClient()
+  const [formData, setFormData] = React.useState<FormData>(INITIAL_FORM)
+  const [errors, setErrors] = React.useState<FormErrors>({})
+  const [successMessage, setSuccessMessage] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    if (!open) {
+      setFormData(INITIAL_FORM)
+      setErrors({})
+      setSuccessMessage(null)
+      mutation.reset()
+    }
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  function validate(): boolean {
+    const next: FormErrors = {}
+
+    if (!formData.code.trim()) {
+      next.code = 'Code is required'
+    } else if (!CODE_PATTERN.test(formData.code.trim())) {
+      next.code = 'Invalid code format — must start with a letter, uppercase letters, digits, and underscores only'
+    } else if (formData.code.trim().length < 2 || formData.code.trim().length > 20) {
+      next.code = 'Code must be between 2 and 20 characters'
+    }
+
+    if (!formData.displayName.trim()) {
+      next.displayName = 'Display name is required'
+    } else if (formData.displayName.trim().length > 255) {
+      next.displayName = 'Display name must be 255 characters or fewer'
+    }
+
+    if (!formData.dimension) {
+      next.dimension = 'Dimension is required'
+    }
+
+    const dp = Number(formData.decimalPlaces)
+    if (formData.decimalPlaces === '' || isNaN(dp) || !Number.isInteger(dp)) {
+      next.decimalPlaces = 'Decimal places must be a whole number'
+    } else if (dp < 0 || dp > 18) {
+      next.decimalPlaces = 'Decimal places must be between 0 and 18'
+    }
+
+    if (formData.symbol && (formData.symbol.length < 1 || formData.symbol.length > 5)) {
+      next.symbol = 'Symbol must be between 1 and 5 characters'
+    }
+
+    if (formData.description && formData.description.length > 1000) {
+      next.description = 'Description must be 1000 characters or fewer'
+    }
+
+    setErrors(next)
+    return Object.keys(next).length === 0
+  }
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      clients.referenceData.registerInstrument({
+        code: formData.code.trim(),
+        displayName: formData.displayName.trim(),
+        dimension: Number(formData.dimension),
+        precision: Number(formData.decimalPlaces),
+        description: formData.description.trim(),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: referenceKeys.instruments() })
+      setSuccessMessage(
+        'Instrument created in DRAFT status. Activation required via manifest or API.',
+      )
+    },
+    onError: (err) => {
+      const result = handleConnectError(err)
+      if (result.code === Code.InvalidArgument && Object.keys(result.fieldErrors).length > 0) {
+        const fieldMap: FormErrors = {}
+        for (const [field, msg] of Object.entries(result.fieldErrors)) {
+          if (field === 'code') fieldMap.code = msg
+          else if (field === 'display_name') fieldMap.displayName = msg
+          else if (field === 'dimension') fieldMap.dimension = msg
+          else if (field === 'precision') fieldMap.decimalPlaces = msg
+          else if (field === 'description') fieldMap.description = msg
+          else fieldMap.general = msg
+        }
+        setErrors(fieldMap)
+      } else {
+        setErrors({ general: result.message })
+      }
+    },
+  })
+
+  function handleCodeChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const upper = e.target.value.toUpperCase()
+    setFormData((prev) => ({ ...prev, code: upper }))
+    if (errors.code) setErrors((prev) => ({ ...prev, code: undefined }))
+  }
+
+  function handleChange(field: keyof FormData) {
+    return (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+      setFormData((prev) => ({ ...prev, [field]: e.target.value }))
+      if (errors[field]) setErrors((prev) => ({ ...prev, [field]: undefined }))
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+    setSuccessMessage(null)
+    mutation.mutate()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Register Instrument</DialogTitle>
+          <DialogDescription>
+            Create a new instrument definition. It will be created in DRAFT status and must be
+            activated before it can be used.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="register-instrument-form">
+          <div className="space-y-4 py-2">
+            {errors.general && (
+              <div
+                role="alert"
+                className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                {errors.general}
+              </div>
+            )}
+
+            {successMessage && (
+              <div
+                role="status"
+                className="rounded-md border border-green-500/50 bg-green-50 px-3 py-2 text-sm text-green-800 dark:bg-green-950/30 dark:text-green-300"
+              >
+                {successMessage}
+              </div>
+            )}
+
+            <div className="space-y-1">
+              <label htmlFor="instrument-code" className="text-sm font-medium">
+                Code <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="instrument-code"
+                value={formData.code}
+                onChange={handleCodeChange}
+                placeholder="KWH"
+                aria-label="Code"
+                aria-describedby={errors.code ? 'instrument-code-error' : undefined}
+                maxLength={20}
+              />
+              {errors.code && (
+                <p id="instrument-code-error" className="text-sm text-destructive">
+                  {errors.code}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="instrument-display-name" className="text-sm font-medium">
+                Display Name <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="instrument-display-name"
+                value={formData.displayName}
+                onChange={handleChange('displayName')}
+                placeholder="Kilowatt Hour"
+                aria-label="Display Name"
+                aria-describedby={errors.displayName ? 'instrument-display-name-error' : undefined}
+                maxLength={255}
+              />
+              {errors.displayName && (
+                <p id="instrument-display-name-error" className="text-sm text-destructive">
+                  {errors.displayName}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="instrument-dimension" className="text-sm font-medium">
+                Dimension <span className="text-destructive">*</span>
+              </label>
+              <select
+                id="instrument-dimension"
+                value={formData.dimension}
+                onChange={handleChange('dimension')}
+                aria-label="Dimension"
+                aria-describedby={errors.dimension ? 'instrument-dimension-error' : undefined}
+                className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+              >
+                <option value="">Select a dimension…</option>
+                {DIMENSION_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+              {errors.dimension && (
+                <p id="instrument-dimension-error" className="text-sm text-destructive">
+                  {errors.dimension}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="instrument-decimal-places" className="text-sm font-medium">
+                Decimal Places <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="instrument-decimal-places"
+                inputMode="numeric"
+                value={formData.decimalPlaces}
+                onChange={handleChange('decimalPlaces')}
+                placeholder="0"
+                aria-label="Decimal Places"
+                aria-describedby={errors.decimalPlaces ? 'instrument-decimal-places-error' : 'instrument-decimal-places-hint'}
+              />
+              <p id="instrument-decimal-places-hint" className="text-xs text-muted-foreground">
+                Controls the precision for amounts (0 = whole numbers, 18 = maximum precision).
+              </p>
+              {errors.decimalPlaces && (
+                <p id="instrument-decimal-places-error" className="text-sm text-destructive">
+                  {errors.decimalPlaces}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="instrument-symbol" className="text-sm font-medium">
+                Symbol
+              </label>
+              <Input
+                id="instrument-symbol"
+                value={formData.symbol}
+                onChange={handleChange('symbol')}
+                placeholder="$ or kWh"
+                aria-label="Symbol"
+                aria-describedby={errors.symbol ? 'instrument-symbol-error' : undefined}
+                maxLength={5}
+              />
+              {errors.symbol && (
+                <p id="instrument-symbol-error" className="text-sm text-destructive">
+                  {errors.symbol}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="instrument-description" className="text-sm font-medium">
+                Description
+              </label>
+              <textarea
+                id="instrument-description"
+                value={formData.description}
+                onChange={handleChange('description')}
+                placeholder="Optional description of this instrument"
+                aria-label="Description"
+                aria-describedby={errors.description ? 'instrument-description-error' : undefined}
+                maxLength={1000}
+                rows={3}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs resize-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+              {errors.description && (
+                <p id="instrument-description-error" className="text-sm text-destructive">
+                  {errors.description}
+                </p>
+              )}
+            </div>
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="register-instrument-form"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Registering…' : 'Register Instrument'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `RegisterInstrumentDialog` component to `/reference-data/instruments` page
- Form fields: code (auto-uppercase, pattern validated), display name, dimension select, decimal places (0-18), symbol (optional), description (optional)
- Calls `clients.referenceData.registerInstrument()` on submit
- Shows inline DRAFT status notification on success: "Instrument created in DRAFT status. Activation required via manifest or API."
- Invalidates `['instruments']` query key on success to refresh the list
- Adds `referenceKeys` factory to `query-keys.ts`

## Changes Made

- `frontend/src/pages/reference-data/instruments/register-instrument-dialog.tsx` — new dialog component
- `frontend/src/pages/reference-data/instruments/register-instrument-dialog.test.tsx` — 17 tests
- `frontend/src/pages/reference-data/instruments/index.tsx` — integrates dialog with header button
- `frontend/src/pages/reference-data/instruments/index.test.tsx` — 2 new tests for button + dialog integration
- `frontend/src/lib/query-keys.ts` — adds `referenceKeys` factory

## Test plan

- [ ] 32 tests pass: `npx vitest run src/pages/reference-data/instruments/`
- [ ] Code auto-uppercases on input
- [ ] Code pattern validation rejects codes not matching `^[A-Z][A-Z0-9_]*$`
- [ ] Decimal places validation rejects values outside 0-18
- [ ] All 9 dimension options present in select
- [ ] DRAFT status notification shown after successful registration
- [ ] Query invalidation refreshes instrument list
- [ ] General error shown on API failure
- [ ] Form resets when dialog closes and reopens

## Task Master

026-operations-console.83 — Create Register Instrument Dialog