### PR TITLE
feat: add tool registration framework with JSON schema validation

### DIFF
--- a/services/mcp-server/internal/tools/registry.go
+++ b/services/mcp-server/internal/tools/registry.go
@@ -1,0 +1,161 @@
+// Package tools provides the tool registry for the MCP server.
+// It manages tool registration, JSON schema validation, and dispatch to
+// handler functions.
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+// ErrToolNotFound is returned when a tool name is not registered.
+var ErrToolNotFound = errors.New("unknown tool")
+
+// ToolCategory classifies the operational intent of a tool.
+// Clients can use this to apply policies (e.g., require confirmation for writes).
+type ToolCategory int
+
+const (
+	// CategoryRead tools query state without side effects.
+	CategoryRead ToolCategory = iota
+	// CategorySimulate tools compute or preview without persisting changes.
+	CategorySimulate
+	// CategoryWrite tools mutate state in the system.
+	CategoryWrite
+)
+
+// ToolHandler is a function invoked to execute a tool call.
+// params contains the validated JSON arguments.
+type ToolHandler func(ctx context.Context, params json.RawMessage) (interface{}, error)
+
+// Tool describes an MCP tool with its metadata, schema, and handler.
+// Handler is excluded from JSON serialization; callers use List() to get
+// metadata suitable for the tools/list response.
+type Tool struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description,omitempty"`
+	InputSchema map[string]interface{} `json:"inputSchema"`
+	Category    ToolCategory           `json:"-"`
+	Handler     ToolHandler            `json:"-"`
+	validator   *jsonschema.Schema
+}
+
+// Registry is a thread-safe collection of MCP tools.
+// JSON schemas are compiled once at registration time and reused per call.
+type Registry struct {
+	mu    sync.RWMutex
+	tools map[string]*Tool
+}
+
+// NewRegistry returns an empty, ready-to-use Registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		tools: make(map[string]*Tool),
+	}
+}
+
+// Register adds a tool to the registry, compiling its JSON schema.
+// Returns an error if the schema is invalid or compilation fails.
+// Registering a tool with a name that already exists overwrites the previous entry.
+func (r *Registry) Register(tool Tool) error {
+	compiled, err := compileSchema(tool.InputSchema)
+	if err != nil {
+		return fmt.Errorf("compile schema for tool %q: %w", tool.Name, err)
+	}
+	tool.validator = compiled
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tools[tool.Name] = &tool
+	return nil
+}
+
+// Call looks up the named tool, validates params against its JSON schema,
+// and invokes the handler. Returns an error if the tool is not found,
+// validation fails, or the handler returns an error.
+func (r *Registry) Call(ctx context.Context, name string, params json.RawMessage) (interface{}, error) {
+	r.mu.RLock()
+	tool, ok := r.tools[name]
+	r.mu.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrToolNotFound, name)
+	}
+
+	if err := validateParams(tool.validator, params); err != nil {
+		return nil, fmt.Errorf("validation failed for tool %q: %w", name, err)
+	}
+
+	return tool.Handler(ctx, params)
+}
+
+// List returns a snapshot of registered tool metadata (without handlers or
+// compiled validators). The slice is sorted by tool name for stable output.
+func (r *Registry) List() []Tool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]Tool, 0, len(r.tools))
+	for _, t := range r.tools {
+		result = append(result, Tool{
+			Name:        t.Name,
+			Description: t.Description,
+			InputSchema: t.InputSchema,
+			Category:    t.Category,
+		})
+	}
+
+	// Stable sort by name.
+	for i := 1; i < len(result); i++ {
+		for j := i; j > 0 && result[j].Name < result[j-1].Name; j-- {
+			result[j], result[j-1] = result[j-1], result[j]
+		}
+	}
+
+	return result
+}
+
+// compileSchema compiles a JSON Schema from a Go map.
+// The schema is serialized to JSON and compiled via the jsonschema library.
+func compileSchema(schema map[string]interface{}) (*jsonschema.Schema, error) {
+	schemaBytes, err := json.Marshal(schema)
+	if err != nil {
+		return nil, fmt.Errorf("marshal schema: %w", err)
+	}
+
+	compiler := jsonschema.NewCompiler()
+	compiler.Draft = jsonschema.Draft7
+
+	const schemaURL = "schema.json"
+	if err := compiler.AddResource(schemaURL, bytes.NewReader(schemaBytes)); err != nil {
+		return nil, fmt.Errorf("add schema resource: %w", err)
+	}
+
+	compiled, err := compiler.Compile(schemaURL)
+	if err != nil {
+		return nil, fmt.Errorf("compile: %w", err)
+	}
+
+	return compiled, nil
+}
+
+// validateParams validates raw JSON params against the compiled schema.
+func validateParams(validator *jsonschema.Schema, params json.RawMessage) error {
+	// Treat nil/empty params as an empty object for schema validation.
+	if len(params) == 0 {
+		params = json.RawMessage(`{}`)
+	}
+
+	var v interface{}
+	if err := json.Unmarshal(params, &v); err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	return validator.Validate(v)
+}

--- a/services/mcp-server/internal/tools/registry.go
+++ b/services/mcp-server/internal/tools/registry.go
@@ -17,6 +17,12 @@ import (
 // ErrToolNotFound is returned when a tool name is not registered.
 var ErrToolNotFound = errors.New("unknown tool")
 
+// ErrToolNameRequired is returned when a tool is registered without a name.
+var ErrToolNameRequired = errors.New("tool name is required")
+
+// ErrToolHandlerRequired is returned when a tool is registered without a handler.
+var ErrToolHandlerRequired = errors.New("tool handler is required")
+
 // ToolCategory classifies the operational intent of a tool.
 // Clients can use this to apply policies (e.g., require confirmation for writes).
 type ToolCategory int
@@ -61,9 +67,21 @@ func NewRegistry() *Registry {
 }
 
 // Register adds a tool to the registry, compiling its JSON schema.
-// Returns an error if the schema is invalid or compilation fails.
-// Registering a tool with a name that already exists overwrites the previous entry.
+// Returns an error if the tool name or handler is missing, the schema is invalid,
+// or compilation fails. Registering a tool with an existing name overwrites the
+// previous entry.
 func (r *Registry) Register(tool Tool) error {
+	if tool.Name == "" {
+		return ErrToolNameRequired
+	}
+	if tool.Handler == nil {
+		return ErrToolHandlerRequired
+	}
+
+	// Deep-copy InputSchema so external mutations after Register cannot affect
+	// registry state or drift metadata from the compiled validator.
+	tool.InputSchema = deepCopySchema(tool.InputSchema)
+
 	compiled, err := compileSchema(tool.InputSchema)
 	if err != nil {
 		return fmt.Errorf("compile schema for tool %q: %w", tool.Name, err)
@@ -88,11 +106,19 @@ func (r *Registry) Call(ctx context.Context, name string, params json.RawMessage
 		return nil, fmt.Errorf("%w: %q", ErrToolNotFound, name)
 	}
 
-	if err := validateParams(tool.validator, params); err != nil {
+	// Normalize empty params to {} so validation and handler both receive the
+	// same payload, avoiding an unmarshal failure in handlers after successful
+	// schema validation.
+	normalized := params
+	if len(normalized) == 0 {
+		normalized = json.RawMessage(`{}`)
+	}
+
+	if err := validateParams(tool.validator, normalized); err != nil {
 		return nil, fmt.Errorf("validation failed for tool %q: %w", name, err)
 	}
 
-	return tool.Handler(ctx, params)
+	return tool.Handler(ctx, normalized)
 }
 
 // List returns a snapshot of registered tool metadata (without handlers or
@@ -106,7 +132,7 @@ func (r *Registry) List() []Tool {
 		result = append(result, Tool{
 			Name:        t.Name,
 			Description: t.Description,
-			InputSchema: t.InputSchema,
+			InputSchema: deepCopySchema(t.InputSchema),
 			Category:    t.Category,
 		})
 	}
@@ -147,15 +173,29 @@ func compileSchema(schema map[string]interface{}) (*jsonschema.Schema, error) {
 
 // validateParams validates raw JSON params against the compiled schema.
 func validateParams(validator *jsonschema.Schema, params json.RawMessage) error {
-	// Treat nil/empty params as an empty object for schema validation.
-	if len(params) == 0 {
-		params = json.RawMessage(`{}`)
-	}
-
 	var v interface{}
 	if err := json.Unmarshal(params, &v); err != nil {
 		return fmt.Errorf("invalid JSON: %w", err)
 	}
 
 	return validator.Validate(v)
+}
+
+// deepCopySchema returns a deep copy of a JSON schema map via JSON round-trip.
+// This prevents external mutations from affecting registry state.
+func deepCopySchema(schema map[string]interface{}) map[string]interface{} {
+	if schema == nil {
+		return nil
+	}
+	b, err := json.Marshal(schema)
+	if err != nil {
+		// Schema was already marshaled successfully during compileSchema;
+		// this path is unreachable in practice.
+		return schema
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal(b, &result); err != nil {
+		return schema
+	}
+	return result
 }

--- a/services/mcp-server/internal/tools/registry_test.go
+++ b/services/mcp-server/internal/tools/registry_test.go
@@ -33,6 +33,105 @@ func TestRegistry_Register_ValidSchema(t *testing.T) {
 	}
 }
 
+func TestRegistry_Register_EmptyName(t *testing.T) {
+	r := tools.NewRegistry()
+	tool := tools.Tool{
+		Name:        "",
+		InputSchema: map[string]interface{}{"type": "object"},
+		Category:    tools.CategoryRead,
+		Handler: func(_ context.Context, _ json.RawMessage) (interface{}, error) {
+			return nil, nil
+		},
+	}
+
+	err := r.Register(tool)
+	if err == nil {
+		t.Fatal("expected error for empty tool name, got nil")
+	}
+	if !errors.Is(err, tools.ErrToolNameRequired) {
+		t.Errorf("expected ErrToolNameRequired, got %v", err)
+	}
+}
+
+func TestRegistry_Register_NilHandler(t *testing.T) {
+	r := tools.NewRegistry()
+	tool := tools.Tool{
+		Name:        "no.handler",
+		InputSchema: map[string]interface{}{"type": "object"},
+		Category:    tools.CategoryRead,
+		Handler:     nil,
+	}
+
+	err := r.Register(tool)
+	if err == nil {
+		t.Fatal("expected error for nil handler, got nil")
+	}
+	if !errors.Is(err, tools.ErrToolHandlerRequired) {
+		t.Errorf("expected ErrToolHandlerRequired, got %v", err)
+	}
+}
+
+func TestRegistry_Register_SchemaDeepCopy(t *testing.T) {
+	r := tools.NewRegistry()
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"id": map[string]interface{}{"type": "string"},
+		},
+	}
+	tool := tools.Tool{
+		Name:        "isolated.tool",
+		InputSchema: schema,
+		Category:    tools.CategoryRead,
+		Handler: func(_ context.Context, _ json.RawMessage) (interface{}, error) {
+			return nil, nil
+		},
+	}
+
+	if err := r.Register(tool); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	// Mutate the original schema after registration — should not affect registry.
+	schema["type"] = "string"
+
+	listed := r.List()
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(listed))
+	}
+	if listed[0].InputSchema["type"] != "object" {
+		t.Errorf("registry schema was mutated by external change: got type=%v", listed[0].InputSchema["type"])
+	}
+}
+
+func TestRegistry_Call_NilParamsNormalized(t *testing.T) {
+	r := tools.NewRegistry()
+	var receivedParams json.RawMessage
+	tool := tools.Tool{
+		Name:        "empty.params",
+		InputSchema: map[string]interface{}{"type": "object"},
+		Category:    tools.CategoryRead,
+		Handler: func(_ context.Context, params json.RawMessage) (interface{}, error) {
+			receivedParams = params
+			return nil, nil
+		},
+	}
+
+	if err := r.Register(tool); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	// Call with nil params — handler should receive "{}" not nil.
+	if _, err := r.Call(context.Background(), "empty.params", nil); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+
+	var v map[string]interface{}
+	if err := json.Unmarshal(receivedParams, &v); err != nil {
+		t.Errorf("handler received non-unmarshalable params: %v (got %q)", err, string(receivedParams))
+	}
+}
+
 func TestRegistry_Register_InvalidSchema(t *testing.T) {
 	r := tools.NewRegistry()
 	tool := tools.Tool{

--- a/services/mcp-server/internal/tools/registry_test.go
+++ b/services/mcp-server/internal/tools/registry_test.go
@@ -1,0 +1,273 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+)
+
+func TestRegistry_Register_ValidSchema(t *testing.T) {
+	r := tools.NewRegistry()
+	tool := tools.Tool{
+		Name:        "test.read",
+		Description: "A test read tool",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"id": map[string]interface{}{"type": "string"},
+			},
+			"required": []interface{}{"id"},
+		},
+		Category: tools.CategoryRead,
+		Handler: func(_ context.Context, _ json.RawMessage) (interface{}, error) {
+			return "ok", nil
+		},
+	}
+
+	if err := r.Register(tool); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestRegistry_Register_InvalidSchema(t *testing.T) {
+	r := tools.NewRegistry()
+	tool := tools.Tool{
+		Name: "bad.tool",
+		InputSchema: map[string]interface{}{
+			"type": "invalid-type-value",
+		},
+		Category: tools.CategoryRead,
+		Handler: func(_ context.Context, _ json.RawMessage) (interface{}, error) {
+			return nil, nil
+		},
+	}
+
+	if err := r.Register(tool); err == nil {
+		t.Fatal("expected error for invalid schema, got nil")
+	}
+}
+
+func TestRegistry_Call_ValidInput(t *testing.T) {
+	r := tools.NewRegistry()
+	called := false
+	tool := tools.Tool{
+		Name: "account.get",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"accountId": map[string]interface{}{"type": "string"},
+			},
+			"required": []interface{}{"accountId"},
+		},
+		Category: tools.CategoryRead,
+		Handler: func(_ context.Context, params json.RawMessage) (interface{}, error) {
+			called = true
+			var p map[string]string
+			if err := json.Unmarshal(params, &p); err != nil {
+				return nil, err
+			}
+			return map[string]string{"id": p["accountId"]}, nil
+		},
+	}
+
+	if err := r.Register(tool); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	params := json.RawMessage(`{"accountId": "acc-123"}`)
+	result, err := r.Call(context.Background(), "account.get", params)
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if !called {
+		t.Fatal("expected handler to be called")
+	}
+	_ = result
+}
+
+func TestRegistry_Call_MissingRequiredField(t *testing.T) {
+	r := tools.NewRegistry()
+	tool := tools.Tool{
+		Name: "account.get",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"accountId": map[string]interface{}{"type": "string"},
+			},
+			"required": []interface{}{"accountId"},
+		},
+		Category: tools.CategoryRead,
+		Handler: func(_ context.Context, _ json.RawMessage) (interface{}, error) {
+			t.Fatal("handler should not be called for invalid input")
+			return nil, nil
+		},
+	}
+
+	if err := r.Register(tool); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	// Missing required "accountId" field
+	params := json.RawMessage(`{}`)
+	_, err := r.Call(context.Background(), "account.get", params)
+	if err == nil {
+		t.Fatal("expected validation error for missing required field")
+	}
+}
+
+func TestRegistry_Call_WrongType(t *testing.T) {
+	r := tools.NewRegistry()
+	tool := tools.Tool{
+		Name: "account.get",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"amount": map[string]interface{}{"type": "number"},
+			},
+			"required": []interface{}{"amount"},
+		},
+		Category: tools.CategorySimulate,
+		Handler: func(_ context.Context, _ json.RawMessage) (interface{}, error) {
+			t.Fatal("handler should not be called for invalid input")
+			return nil, nil
+		},
+	}
+
+	if err := r.Register(tool); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	// Wrong type: string instead of number
+	params := json.RawMessage(`{"amount": "not-a-number"}`)
+	_, err := r.Call(context.Background(), "account.get", params)
+	if err == nil {
+		t.Fatal("expected validation error for wrong type")
+	}
+}
+
+func TestRegistry_Call_UnknownTool(t *testing.T) {
+	r := tools.NewRegistry()
+
+	_, err := r.Call(context.Background(), "nonexistent.tool", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+	if !errors.Is(err, tools.ErrToolNotFound) {
+		t.Errorf("expected ErrToolNotFound, got %v", err)
+	}
+}
+
+func TestRegistry_List_ReturnsToolMetadata(t *testing.T) {
+	r := tools.NewRegistry()
+
+	tools1 := []tools.Tool{
+		{
+			Name:        "alpha.read",
+			Description: "Alpha read",
+			InputSchema: map[string]interface{}{"type": "object"},
+			Category:    tools.CategoryRead,
+			Handler: func(_ context.Context, _ json.RawMessage) (interface{}, error) {
+				return nil, nil
+			},
+		},
+		{
+			Name:        "beta.write",
+			Description: "Beta write",
+			InputSchema: map[string]interface{}{"type": "object"},
+			Category:    tools.CategoryWrite,
+			Handler: func(_ context.Context, _ json.RawMessage) (interface{}, error) {
+				return nil, nil
+			},
+		},
+	}
+
+	for _, tool := range tools1 {
+		if err := r.Register(tool); err != nil {
+			t.Fatalf("register %s: %v", tool.Name, err)
+		}
+	}
+
+	listed := r.List()
+	if len(listed) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(listed))
+	}
+
+	// Verify handler is not exposed in listing (Tool metadata only)
+	nameSet := map[string]bool{}
+	for _, tool := range listed {
+		nameSet[tool.Name] = true
+		if tool.Handler != nil {
+			t.Errorf("tool %s should not expose Handler in listing", tool.Name)
+		}
+	}
+
+	if !nameSet["alpha.read"] || !nameSet["beta.write"] {
+		t.Errorf("expected both tools in list, got names: %v", nameSet)
+	}
+}
+
+func TestRegistry_Concurrent_RegisterAndCall(t *testing.T) {
+	r := tools.NewRegistry()
+
+	// Pre-register a tool that will be called concurrently
+	baseTool := tools.Tool{
+		Name: "concurrent.read",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+		},
+		Category: tools.CategoryRead,
+		Handler: func(_ context.Context, _ json.RawMessage) (interface{}, error) {
+			return "result", nil
+		},
+	}
+	if err := r.Register(baseTool); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errors := make(chan error, 100)
+
+	// Concurrent calls
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := r.Call(context.Background(), "concurrent.read", json.RawMessage(`{}`))
+			if err != nil {
+				errors <- err
+			}
+		}()
+	}
+
+	// Concurrent registrations of new tools
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		idx := i
+		go func() {
+			defer wg.Done()
+			newTool := tools.Tool{
+				Name:        "dynamic.tool." + string(rune('a'+idx)),
+				Description: "Dynamic tool",
+				InputSchema: map[string]interface{}{"type": "object"},
+				Category:    tools.CategoryRead,
+				Handler: func(_ context.Context, _ json.RawMessage) (interface{}, error) {
+					return nil, nil
+				},
+			}
+			if err := r.Register(newTool); err != nil {
+				errors <- err
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errors)
+
+	for err := range errors {
+		t.Errorf("concurrent error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `services/mcp-server/internal/tools` package with thread-safe tool registry
- JSON schemas are compiled once at registration time via `santhosh-tekuri/jsonschema/v5` and validated at call time
- `ToolCategory` (Read, Simulate, Write) classifies operational intent for policy enforcement
- `ErrToolNotFound` sentinel error enables callers to use `errors.Is` for unknown tool detection
- `List()` returns tool metadata (name, description, schema, category) without exposing handlers or compiled validators

## Changes Made

**New files:**
- `services/mcp-server/internal/tools/registry.go` — Core registry implementation
- `services/mcp-server/internal/tools/registry_test.go` — 8 unit tests

**Key design decisions:**
- Registry does NOT hold MeridianClients — handlers are closures capturing their own dependencies
- Thread-safe via `sync.RWMutex` (concurrent reads, exclusive writes)
- Schema compiled at registration time, not at call time, so invalid schemas fail fast

## Test plan

- [x] Register tool with valid JSON schema passes
- [x] Register tool with invalid schema returns error
- [x] Call tool with valid input dispatches to handler
- [x] Call tool with missing required field returns validation error (handler not called)
- [x] Call tool with wrong type returns validation error (handler not called)
- [x] Call unknown tool returns `ErrToolNotFound`
- [x] List returns tool metadata without Handler or compiled validator
- [x] Concurrent Register + Call operations are safe under race detector