### PR TITLE
feat: add authentication middleware and gRPC client wiring for MCP server

### DIFF
--- a/services/mcp-server/internal/auth/auth.go
+++ b/services/mcp-server/internal/auth/auth.go
@@ -1,0 +1,67 @@
+// Package auth provides API key extraction and gRPC client authentication
+// for the MCP server. It reads the API key from environment variables and
+// supplies a gRPC UnaryClientInterceptor that injects an Authorization header
+// into every outgoing request.
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	// EnvAPIKey is the environment variable name for the Meridian API key.
+	EnvAPIKey = "MERIDIAN_API_KEY"
+	// EnvAPIURL is the environment variable name for the Meridian gateway URL.
+	EnvAPIURL = "MERIDIAN_API_URL"
+)
+
+// ErrMissingAPIKey is returned when the API key environment variable is not set.
+var ErrMissingAPIKey = errors.New("MERIDIAN_API_KEY environment variable is required")
+
+// Config holds the API key and gateway URL used to authenticate outgoing
+// gRPC calls from the MCP server to Meridian Core services.
+type Config struct {
+	// APIKey is the bearer token sent in the Authorization header.
+	APIKey string
+	// APIUrl is the address of the Meridian gateway (host:port).
+	APIUrl string
+}
+
+// LoadFromEnv reads Config from environment variables.
+// It returns ErrMissingAPIKey when MERIDIAN_API_KEY is absent or blank.
+func LoadFromEnv() (*Config, error) {
+	apiKey := strings.TrimSpace(os.Getenv(EnvAPIKey))
+	if apiKey == "" {
+		return nil, fmt.Errorf("load auth config: %w", ErrMissingAPIKey)
+	}
+
+	apiURL := strings.TrimSpace(os.Getenv(EnvAPIURL))
+
+	return &Config{
+		APIKey: apiKey,
+		APIUrl: apiURL,
+	}, nil
+}
+
+// UnaryInterceptor returns a gRPC UnaryClientInterceptor that injects the API
+// key as a Bearer token in the outgoing metadata of every request.
+func (a *Config) UnaryInterceptor() grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+a.APIKey)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}

--- a/services/mcp-server/internal/auth/auth.go
+++ b/services/mcp-server/internal/auth/auth.go
@@ -22,8 +22,12 @@ const (
 	EnvAPIURL = "MERIDIAN_API_URL"
 )
 
-// ErrMissingAPIKey is returned when the API key environment variable is not set.
-var ErrMissingAPIKey = errors.New("MERIDIAN_API_KEY environment variable is required")
+var (
+	// ErrMissingAPIKey is returned when the API key environment variable is not set.
+	ErrMissingAPIKey = errors.New("MERIDIAN_API_KEY environment variable is required")
+	// ErrMissingAPIURL is returned when the gateway URL environment variable is not set.
+	ErrMissingAPIURL = errors.New("MERIDIAN_API_URL environment variable is required")
+)
 
 // Config holds the API key and gateway URL used to authenticate outgoing
 // gRPC calls from the MCP server to Meridian Core services.
@@ -34,8 +38,15 @@ type Config struct {
 	APIUrl string
 }
 
+// String returns a safe representation of Config that redacts the API key,
+// preventing accidental secret leakage via fmt.Printf or structured loggers.
+func (a Config) String() string {
+	return fmt.Sprintf("Config{APIKey: [REDACTED], APIUrl: %q}", a.APIUrl)
+}
+
 // LoadFromEnv reads Config from environment variables.
-// It returns ErrMissingAPIKey when MERIDIAN_API_KEY is absent or blank.
+// It returns ErrMissingAPIKey when MERIDIAN_API_KEY is absent or blank,
+// and ErrMissingAPIURL when MERIDIAN_API_URL is absent or blank.
 func LoadFromEnv() (*Config, error) {
 	apiKey := strings.TrimSpace(os.Getenv(EnvAPIKey))
 	if apiKey == "" {
@@ -43,6 +54,9 @@ func LoadFromEnv() (*Config, error) {
 	}
 
 	apiURL := strings.TrimSpace(os.Getenv(EnvAPIURL))
+	if apiURL == "" {
+		return nil, fmt.Errorf("load auth config: %w", ErrMissingAPIURL)
+	}
 
 	return &Config{
 		APIKey: apiKey,

--- a/services/mcp-server/internal/auth/auth_test.go
+++ b/services/mcp-server/internal/auth/auth_test.go
@@ -1,0 +1,150 @@
+package auth_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/interop/grpc_testing"
+	"google.golang.org/grpc/metadata"
+)
+
+// TestLoadFromEnv_MissingKey verifies ErrMissingAPIKey is returned when the
+// env var is absent.
+func TestLoadFromEnv_MissingKey(t *testing.T) {
+	t.Setenv(auth.EnvAPIKey, "")
+
+	_, err := auth.LoadFromEnv()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, auth.ErrMissingAPIKey)
+}
+
+// TestLoadFromEnv_WithKey verifies successful loading when the env var is set.
+func TestLoadFromEnv_WithKey(t *testing.T) {
+	t.Setenv(auth.EnvAPIKey, "test-key-123")
+	t.Setenv(auth.EnvAPIURL, "gateway:443")
+
+	cfg, err := auth.LoadFromEnv()
+	require.NoError(t, err)
+	assert.Equal(t, "test-key-123", cfg.APIKey)
+	assert.Equal(t, "gateway:443", cfg.APIUrl)
+}
+
+// TestLoadFromEnv_WhitespaceKey verifies that a whitespace-only key is treated as missing.
+func TestLoadFromEnv_WhitespaceKey(t *testing.T) {
+	t.Setenv(auth.EnvAPIKey, "   ")
+
+	_, err := auth.LoadFromEnv()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, auth.ErrMissingAPIKey)
+}
+
+// TestLoadFromEnv_NoURL verifies that the URL field is optional.
+func TestLoadFromEnv_NoURL(t *testing.T) {
+	t.Setenv(auth.EnvAPIKey, "my-key")
+	t.Setenv(auth.EnvAPIURL, "")
+
+	cfg, err := auth.LoadFromEnv()
+	require.NoError(t, err)
+	assert.Equal(t, "my-key", cfg.APIKey)
+	assert.Equal(t, "", cfg.APIUrl)
+}
+
+// capturedMetadataServer captures the incoming metadata from gRPC calls for
+// inspection in tests.
+type capturedMetadataServer struct {
+	grpc_testing.UnimplementedTestServiceServer
+	captured metadata.MD
+}
+
+// EmptyCall captures metadata on an empty call.
+func (s *capturedMetadataServer) EmptyCall(ctx context.Context, _ *grpc_testing.Empty) (*grpc_testing.Empty, error) {
+	md, _ := metadata.FromIncomingContext(ctx)
+	s.captured = md.Copy()
+	return &grpc_testing.Empty{}, nil
+}
+
+// listenTCP creates a TCP listener on a random local port using ListenConfig
+// to satisfy the noctx linter requirement.
+func listenTCP(t *testing.T) net.Listener {
+	t.Helper()
+	lc := net.ListenConfig{}
+	lis, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	return lis
+}
+
+// TestUnaryInterceptor_InjectsAuthorizationHeader verifies that the interceptor
+// adds the Bearer token to outgoing gRPC metadata.
+func TestUnaryInterceptor_InjectsAuthorizationHeader(t *testing.T) {
+	apiKey := "super-secret-key"
+
+	lis := listenTCP(t)
+
+	captured := &capturedMetadataServer{}
+	srv := grpc.NewServer()
+	grpc_testing.RegisterTestServiceServer(srv, captured)
+
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	cfg := &auth.Config{APIKey: apiKey}
+	conn, err := grpc.NewClient(
+		lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(cfg.UnaryInterceptor()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client := grpc_testing.NewTestServiceClient(conn)
+	_, err = client.EmptyCall(context.Background(), &grpc_testing.Empty{})
+	require.NoError(t, err)
+
+	authVals := captured.captured.Get("authorization")
+	require.Len(t, authVals, 1, "expected exactly one authorization header")
+	assert.Equal(t, "Bearer "+apiKey, authVals[0])
+}
+
+// TestUnaryInterceptor_ExistingMetadataPreserved verifies that pre-existing
+// outgoing metadata is preserved alongside the injected Authorization header.
+func TestUnaryInterceptor_ExistingMetadataPreserved(t *testing.T) {
+	apiKey := "key-abc"
+
+	lis := listenTCP(t)
+
+	captured := &capturedMetadataServer{}
+	srv := grpc.NewServer()
+	grpc_testing.RegisterTestServiceServer(srv, captured)
+
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	cfg := &auth.Config{APIKey: apiKey}
+	conn, err := grpc.NewClient(
+		lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(cfg.UnaryInterceptor()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "x-request-id", "req-42")
+
+	client := grpc_testing.NewTestServiceClient(conn)
+	_, err = client.EmptyCall(ctx, &grpc_testing.Empty{})
+	require.NoError(t, err)
+
+	authVals := captured.captured.Get("authorization")
+	require.Len(t, authVals, 1)
+	assert.Equal(t, "Bearer "+apiKey, authVals[0])
+
+	reqIDVals := captured.captured.Get("x-request-id")
+	require.Len(t, reqIDVals, 1)
+	assert.Equal(t, "req-42", reqIDVals[0])
+}

--- a/services/mcp-server/internal/auth/auth_test.go
+++ b/services/mcp-server/internal/auth/auth_test.go
@@ -44,15 +44,36 @@ func TestLoadFromEnv_WhitespaceKey(t *testing.T) {
 	assert.ErrorIs(t, err, auth.ErrMissingAPIKey)
 }
 
-// TestLoadFromEnv_NoURL verifies that the URL field is optional.
-func TestLoadFromEnv_NoURL(t *testing.T) {
+// TestLoadFromEnv_MissingURL verifies ErrMissingAPIURL is returned when the
+// URL env var is absent.
+func TestLoadFromEnv_MissingURL(t *testing.T) {
 	t.Setenv(auth.EnvAPIKey, "my-key")
 	t.Setenv(auth.EnvAPIURL, "")
 
-	cfg, err := auth.LoadFromEnv()
-	require.NoError(t, err)
-	assert.Equal(t, "my-key", cfg.APIKey)
-	assert.Equal(t, "", cfg.APIUrl)
+	_, err := auth.LoadFromEnv()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, auth.ErrMissingAPIURL)
+}
+
+// TestLoadFromEnv_WhitespaceURL verifies that a whitespace-only URL is treated as missing.
+func TestLoadFromEnv_WhitespaceURL(t *testing.T) {
+	t.Setenv(auth.EnvAPIKey, "my-key")
+	t.Setenv(auth.EnvAPIURL, "   ")
+
+	_, err := auth.LoadFromEnv()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, auth.ErrMissingAPIURL)
+}
+
+// TestConfig_String_RedactsAPIKey verifies the String() method does not expose
+// the raw API key, protecting against accidental logging of secrets.
+func TestConfig_String_RedactsAPIKey(t *testing.T) {
+	cfg := auth.Config{APIKey: "super-secret", APIUrl: "gateway:443"}
+	s := cfg.String()
+
+	assert.NotContains(t, s, "super-secret", "API key must not appear in String() output")
+	assert.Contains(t, s, "[REDACTED]")
+	assert.Contains(t, s, "gateway:443")
 }
 
 // capturedMetadataServer captures the incoming metadata from gRPC calls for

--- a/services/mcp-server/internal/clients/clients.go
+++ b/services/mcp-server/internal/clients/clients.go
@@ -1,0 +1,91 @@
+// Package clients creates typed gRPC client stubs for all Meridian Core
+// services and manages the underlying connection lifecycle.
+package clients
+
+import (
+	"errors"
+	"fmt"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/auth"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+var (
+	// ErrNilAuthConfig is returned when New is called with a nil auth.Config.
+	ErrNilAuthConfig = errors.New("auth config must not be nil")
+	// ErrMissingAPIURL is returned when the gateway URL is empty.
+	ErrMissingAPIURL = errors.New("MERIDIAN_API_URL is required")
+)
+
+// MeridianClients holds typed gRPC clients for all Meridian Core services.
+// All clients share a single connection to the gateway.
+type MeridianClients struct {
+	// ApplyManifest submits and validates tenant manifests.
+	ApplyManifest controlplanev1.ApplyManifestServiceClient
+	// ManifestHistory retrieves previously applied manifest versions.
+	ManifestHistory controlplanev1.ManifestHistoryServiceClient
+	// ReferenceData provides instrument and node metadata.
+	ReferenceData referencedatav1.ReferenceDataServiceClient
+	// PositionKeeping logs and queries financial positions.
+	PositionKeeping positionkeepingv1.PositionKeepingServiceClient
+	// Accounting records and queries financial accounting entries.
+	Accounting financialaccountingv1.FinancialAccountingServiceClient
+	// Reconciliation queries account reconciliation state.
+	Reconciliation reconciliationv1.AccountReconciliationServiceClient
+	// MarketInfo retrieves market price and rate data.
+	MarketInfo marketinformationv1.MarketInformationServiceClient
+	// Health allows the MCP server to check gateway liveness.
+	Health grpc_health_v1.HealthClient
+
+	// conn is the underlying connection; callers must call Close when done.
+	conn *grpc.ClientConn
+}
+
+// New dials the Meridian gateway and returns fully-wired MeridianClients.
+// The auth.Config interceptor is applied to every outgoing unary RPC so that
+// each call carries the API key as a Bearer token.
+//
+// The caller is responsible for calling Close() when the clients are no longer
+// needed to release the underlying connection.
+func New(cfg *auth.Config) (*MeridianClients, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("clients.New: %w", ErrNilAuthConfig)
+	}
+	if cfg.APIUrl == "" {
+		return nil, fmt.Errorf("clients.New: %w", ErrMissingAPIURL)
+	}
+
+	conn, err := grpc.NewClient(
+		cfg.APIUrl,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(cfg.UnaryInterceptor()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("clients.New: dial %s: %w", cfg.APIUrl, err)
+	}
+
+	return &MeridianClients{
+		ApplyManifest:   controlplanev1.NewApplyManifestServiceClient(conn),
+		ManifestHistory: controlplanev1.NewManifestHistoryServiceClient(conn),
+		ReferenceData:   referencedatav1.NewReferenceDataServiceClient(conn),
+		PositionKeeping: positionkeepingv1.NewPositionKeepingServiceClient(conn),
+		Accounting:      financialaccountingv1.NewFinancialAccountingServiceClient(conn),
+		Reconciliation:  reconciliationv1.NewAccountReconciliationServiceClient(conn),
+		MarketInfo:      marketinformationv1.NewMarketInformationServiceClient(conn),
+		Health:          grpc_health_v1.NewHealthClient(conn),
+		conn:            conn,
+	}, nil
+}
+
+// Close releases the underlying gRPC connection.
+func (m *MeridianClients) Close() error {
+	return m.conn.Close()
+}

--- a/services/mcp-server/internal/clients/clients.go
+++ b/services/mcp-server/internal/clients/clients.go
@@ -18,12 +18,8 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
-var (
-	// ErrNilAuthConfig is returned when New is called with a nil auth.Config.
-	ErrNilAuthConfig = errors.New("auth config must not be nil")
-	// ErrMissingAPIURL is returned when the gateway URL is empty.
-	ErrMissingAPIURL = errors.New("MERIDIAN_API_URL is required")
-)
+// ErrNilAuthConfig is returned when New is called with a nil auth.Config.
+var ErrNilAuthConfig = errors.New("auth config must not be nil")
 
 // MeridianClients holds typed gRPC clients for all Meridian Core services.
 // All clients share a single connection to the gateway.
@@ -60,9 +56,13 @@ func New(cfg *auth.Config) (*MeridianClients, error) {
 		return nil, fmt.Errorf("clients.New: %w", ErrNilAuthConfig)
 	}
 	if cfg.APIUrl == "" {
-		return nil, fmt.Errorf("clients.New: %w", ErrMissingAPIURL)
+		return nil, fmt.Errorf("clients.New: %w", auth.ErrMissingAPIURL)
 	}
 
+	// insecure.NewCredentials() is intentional: TLS termination is handled at the
+	// infrastructure layer (Kubernetes service mesh / Envoy sidecar). The Bearer
+	// token carried by the auth interceptor is protected by the mesh mTLS tunnel
+	// between pods, consistent with every other service client in this repository.
 	conn, err := grpc.NewClient(
 		cfg.APIUrl,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/services/mcp-server/internal/clients/clients_test.go
+++ b/services/mcp-server/internal/clients/clients_test.go
@@ -17,6 +17,7 @@ func TestNew_NilAuthConfig(t *testing.T) {
 }
 
 // TestNew_MissingAPIURL verifies that an empty APIUrl is rejected.
+// ErrMissingAPIURL lives in the auth package since LoadFromEnv now also validates it.
 func TestNew_MissingAPIURL(t *testing.T) {
 	cfg := &auth.Config{
 		APIKey: "key",
@@ -24,7 +25,7 @@ func TestNew_MissingAPIURL(t *testing.T) {
 	}
 	_, err := clients.New(cfg)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, clients.ErrMissingAPIURL)
+	assert.ErrorIs(t, err, auth.ErrMissingAPIURL)
 }
 
 // TestNew_AllClientsInitialized verifies that all service clients are

--- a/services/mcp-server/internal/clients/clients_test.go
+++ b/services/mcp-server/internal/clients/clients_test.go
@@ -1,0 +1,51 @@
+package clients_test
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/auth"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/clients"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNew_NilAuthConfig verifies that nil config is rejected.
+func TestNew_NilAuthConfig(t *testing.T) {
+	_, err := clients.New(nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, clients.ErrNilAuthConfig)
+}
+
+// TestNew_MissingAPIURL verifies that an empty APIUrl is rejected.
+func TestNew_MissingAPIURL(t *testing.T) {
+	cfg := &auth.Config{
+		APIKey: "key",
+		APIUrl: "",
+	}
+	_, err := clients.New(cfg)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, clients.ErrMissingAPIURL)
+}
+
+// TestNew_AllClientsInitialized verifies that all service clients are
+// non-nil after successful construction. We use a dummy address because
+// grpc.NewClient is lazy — it does not attempt a connection until the first RPC.
+func TestNew_AllClientsInitialized(t *testing.T) {
+	cfg := &auth.Config{
+		APIKey: "test-key",
+		APIUrl: "localhost:9999",
+	}
+
+	mc, err := clients.New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mc.Close() })
+
+	assert.NotNil(t, mc.ApplyManifest, "ApplyManifest client must not be nil")
+	assert.NotNil(t, mc.ManifestHistory, "ManifestHistory client must not be nil")
+	assert.NotNil(t, mc.ReferenceData, "ReferenceData client must not be nil")
+	assert.NotNil(t, mc.PositionKeeping, "PositionKeeping client must not be nil")
+	assert.NotNil(t, mc.Accounting, "Accounting client must not be nil")
+	assert.NotNil(t, mc.Reconciliation, "Reconciliation client must not be nil")
+	assert.NotNil(t, mc.MarketInfo, "MarketInfo client must not be nil")
+	assert.NotNil(t, mc.Health, "Health client must not be nil")
+}


### PR DESCRIPTION
## Summary

- Implements `internal/auth`: `auth.Config` reads `MERIDIAN_API_KEY` / `MERIDIAN_API_URL` from environment variables; `Config.UnaryInterceptor()` injects a `Bearer` token into outgoing gRPC metadata on every call
- Implements `internal/clients`: `clients.MeridianClients` wires typed stubs for all seven Meridian Core services (ApplyManifest, ManifestHistory, ReferenceData, PositionKeeping, Accounting, Reconciliation, MarketInfo) plus a health check client, all sharing a single connection with the auth interceptor applied
- Sentinel errors (`ErrNilAuthConfig`, `ErrMissingAPIURL`, `ErrMissingAPIKey`) let callers use `errors.Is` for precise error handling

## Changes Made

- `services/mcp-server/internal/auth/auth.go` — `Config` struct, `LoadFromEnv()`, `UnaryInterceptor()`
- `services/mcp-server/internal/auth/auth_test.go` — env loading tests and gRPC interceptor integration tests using a live local server
- `services/mcp-server/internal/clients/clients.go` — `MeridianClients` factory, `New()`, `Close()`
- `services/mcp-server/internal/clients/clients_test.go` — nil config, missing URL, and all-clients-initialized tests

## Test plan

- [ ] `go test ./services/mcp-server/internal/auth/...` — 6 tests covering env loading and header injection
- [ ] `go test ./services/mcp-server/internal/clients/...` — 3 tests covering validation and client initialization
- [ ] `go test ./services/mcp-server/...` — all 40 tests across the service pass

## Risk Assessment

Low. This change is additive only — new packages with no modifications to existing code. The `clients.MeridianClients` struct is not yet wired into `cmd/main.go`; that wiring happens in a subsequent task.