### PR TITLE
feat: Auto-create per-service databases on demo Postgres boot

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -157,7 +157,7 @@ jobs:
           host: ${{ secrets.DROPLET_IP }}
           username: root
           key: ${{ secrets.DEPLOY_SSH_KEY }}
-          source: "deploy/demo/Caddyfile,deploy/demo/docker-compose.yml,deploy/demo/dex.yaml"
+          source: "deploy/demo/Caddyfile,deploy/demo/docker-compose.yml,deploy/demo/dex.yaml,deploy/demo/init-databases.sql"
           target: /opt/meridian/
           strip_components: 2
           overwrite: true

--- a/deploy/demo/.env.demo.example
+++ b/deploy/demo/.env.demo.example
@@ -36,9 +36,9 @@ POSTGRES_DB=meridian
 # [OPTIONAL] Database driver — always "postgres" for the demo stack.
 DB_DRIVER=postgres
 
-# DATABASE_URL and per-service URLs are constructed automatically by docker-compose
-# from POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB above.
-# Override here only if pointing at an external database instead of the bundled container.
+# DATABASE_URL is constructed by docker-compose from POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB.
+# The unified binary derives per-service database names automatically (e.g. meridian_party).
+# Per-service databases are created by init-databases.sql on first Postgres boot.
 #DATABASE_URL=postgres://meridian:<password>@postgres:5432/meridian?sslmode=disable
 
 # [OPTIONAL] GORM database connection pool settings.

--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -8,8 +8,7 @@ demo.meridianhub.cloud, *.demo.meridianhub.cloud {
 
 	# API: ConnectRPC + health probes
 	@api {
-		path /meridian.* /grpc.*
-		path /healthz /readyz
+		path /meridian.* /grpc.* /healthz /readyz
 	}
 	handle @api {
 		reverse_proxy meridian:8090

--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -15,6 +15,7 @@
 #   /opt/meridian/.env            - Filled-in environment file
 #   /opt/meridian/Caddyfile       - Caddy configuration
 #   /opt/meridian/dex.yaml        - Dex OIDC configuration
+#   /opt/meridian/init-databases.sql - Per-service database init (runs on first Postgres boot)
 #   /opt/meridian/frontend/       - Built frontend static files (deployed by CI)
 #   /opt/meridian/certs/          - Cloudflare Origin Certificate files
 #     origin-cert.pem
@@ -30,6 +31,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-meridian}
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - /opt/meridian/init-databases.sql:/docker-entrypoint-initdb.d/init-databases.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-meridian} -d ${POSTGRES_DB:-meridian}"]
       interval: 5s
@@ -71,17 +73,10 @@ services:
       # --- Database driver ---
       DB_DRIVER: postgres
 
-      # --- Database URLs (all services share the same PostgreSQL instance in demo) ---
+      # --- Database ---
+      # The unified binary derives per-service database names from a single base DSN.
+      # Per-service databases are created by init-databases.sql on first Postgres boot.
       DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-meridian}?sslmode=disable
-      PLATFORM_DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-meridian}?sslmode=disable
-      CURRENT_ACCOUNT_DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-meridian}?sslmode=disable
-      FINANCIAL_ACCOUNTING_DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-meridian}?sslmode=disable
-      POSITION_KEEPING_DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-meridian}?sslmode=disable
-      PAYMENT_ORDER_DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-meridian}?sslmode=disable
-      PARTY_DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-meridian}?sslmode=disable
-      INTERNAL_BANK_ACCOUNT_DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-meridian}?sslmode=disable
-      MARKET_INFORMATION_DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-meridian}?sslmode=disable
-      REFERENCE_DATA_DATABASE_URL: postgres://${POSTGRES_USER:-meridian}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in the env file}@postgres:5432/${POSTGRES_DB:-meridian}?sslmode=disable
 
       # --- Authentication (Dex OIDC) ---
       AUTH_ENABLED: ${AUTH_ENABLED:-true}

--- a/deploy/demo/init-databases.sql
+++ b/deploy/demo/init-databases.sql
@@ -1,0 +1,15 @@
+-- Create per-service databases for the Meridian unified binary.
+-- Postgres docker-entrypoint-initdb.d runs this on first initialisation only.
+-- The list must match internal/migrations/runner.go ServiceDatabases.
+
+CREATE DATABASE meridian_platform;
+CREATE DATABASE meridian_current_account;
+CREATE DATABASE meridian_financial_accounting;
+CREATE DATABASE meridian_position_keeping;
+CREATE DATABASE meridian_payment_order;
+CREATE DATABASE meridian_party;
+CREATE DATABASE meridian_internal_bank_account;
+CREATE DATABASE meridian_market_information;
+CREATE DATABASE meridian_reconciliation;
+CREATE DATABASE meridian_forecasting;
+CREATE DATABASE meridian_reference_data;


### PR DESCRIPTION
## Summary

- Add `init-databases.sql` that creates all 11 per-service databases on first Postgres boot via `docker-entrypoint-initdb.d`
- Remove unused per-service `DATABASE_URL` env vars from docker-compose (the unified binary derives DB names from a single `DATABASE_URL`)
- Fix Caddyfile `@api` matcher — multiple `path` directives are AND'd, not OR'd; combine on one line for OR semantics
- Add `init-databases.sql` to the CI config deploy SCP step

## Changes

| File | Change |
|------|--------|
| `deploy/demo/init-databases.sql` | New: creates 11 per-service databases |
| `deploy/demo/docker-compose.yml` | Mount init script, remove unused per-service DB URLs |
| `deploy/demo/Caddyfile` | Fix `@api` matcher (OR, not AND) |
| `deploy/demo/.env.demo.example` | Update DB config docs |
| `.github/workflows/deploy-demo.yml` | Add init-databases.sql to config SCP |

## Context

The unified binary uses `replaceDSNDatabase()` to swap the database name in `DATABASE_URL` for each service (defined in `internal/migrations/runner.go:ServiceDatabases`). Fresh Postgres instances only have the default `meridian` database — the per-service databases must be created before the binary starts.

## Test plan

- [ ] On fresh deploy: Postgres creates per-service databases automatically
- [ ] Meridian starts without "database does not exist" errors
- [ ] `/healthz` returns 200 (not SPA fallback)
- [ ] Existing deployments (databases already exist) are unaffected — `docker-entrypoint-initdb.d` only runs on first init