### PR TITLE
feat: add session state management with plan cache and rate limiter

### DIFF
--- a/services/mcp-server/internal/session/plan_cache.go
+++ b/services/mcp-server/internal/session/plan_cache.go
@@ -24,7 +24,12 @@ type PlanCache struct {
 }
 
 // NewPlanCache returns a PlanCache with the given TTL for each stored plan.
+// Panics if ttl is non-positive to prevent silent misconfiguration where
+// entries would be immediately invalid.
 func NewPlanCache(ttl time.Duration) *PlanCache {
+	if ttl <= 0 {
+		panic("session: PlanCache TTL must be positive")
+	}
 	return &PlanCache{
 		entries: make(map[string]planEntry),
 		ttl:     ttl,

--- a/services/mcp-server/internal/session/plan_cache.go
+++ b/services/mcp-server/internal/session/plan_cache.go
@@ -1,0 +1,80 @@
+// Package session provides session-scoped state for the MCP server,
+// including plan caching and request rate limiting.
+package session
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// planEntry holds a cached plan with its expiration time.
+type planEntry struct {
+	expiresAt time.Time
+}
+
+// PlanCache stores manifest hashes with TTL-based expiry.
+// It enforces the plan-before-apply workflow: a plan must be stored
+// before an apply operation referencing that plan hash is permitted.
+type PlanCache struct {
+	mu      sync.Mutex
+	entries map[string]planEntry
+	ttl     time.Duration
+}
+
+// NewPlanCache returns a PlanCache with the given TTL for each stored plan.
+func NewPlanCache(ttl time.Duration) *PlanCache {
+	return &PlanCache{
+		entries: make(map[string]planEntry),
+		ttl:     ttl,
+	}
+}
+
+// Store hashes the manifest with SHA256, records it with the configured TTL,
+// and returns the hex-encoded hash. Storing the same manifest again resets its TTL.
+func (c *PlanCache) Store(manifest []byte) string {
+	hash := hashManifest(manifest)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries[hash] = planEntry{expiresAt: time.Now().Add(c.ttl)}
+	return hash
+}
+
+// Exists returns true when the hash is present and has not expired.
+func (c *PlanCache) Exists(hash string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[hash]
+	if !ok {
+		return false
+	}
+	if time.Now().After(entry.expiresAt) {
+		delete(c.entries, hash)
+		return false
+	}
+	return true
+}
+
+// Cleanup removes all expired entries from the cache.
+func (c *PlanCache) Cleanup() {
+	now := time.Now()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for hash, entry := range c.entries {
+		if now.After(entry.expiresAt) {
+			delete(c.entries, hash)
+		}
+	}
+}
+
+// hashManifest returns the SHA256 hex digest of the manifest bytes.
+func hashManifest(manifest []byte) string {
+	sum := sha256.Sum256(manifest)
+	return hex.EncodeToString(sum[:])
+}

--- a/services/mcp-server/internal/session/plan_cache_test.go
+++ b/services/mcp-server/internal/session/plan_cache_test.go
@@ -1,0 +1,98 @@
+package session_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/session"
+)
+
+func TestPlanCache_StoreAndRetrieve(t *testing.T) {
+	cache := session.NewPlanCache(5 * time.Minute)
+
+	manifest := []byte(`{"instruments":[{"code":"GBP"}]}`)
+	hash := cache.Store(manifest)
+
+	if hash == "" {
+		t.Fatal("expected non-empty hash")
+	}
+
+	ok := cache.Exists(hash)
+	if !ok {
+		t.Error("expected plan to exist after store")
+	}
+}
+
+func TestPlanCache_DifferentManifestsDifferentHashes(t *testing.T) {
+	cache := session.NewPlanCache(5 * time.Minute)
+
+	manifest1 := []byte(`{"instruments":[{"code":"GBP"}]}`)
+	manifest2 := []byte(`{"instruments":[{"code":"USD"}]}`)
+
+	hash1 := cache.Store(manifest1)
+	hash2 := cache.Store(manifest2)
+
+	if hash1 == hash2 {
+		t.Error("different manifests should produce different hashes")
+	}
+}
+
+func TestPlanCache_SameManifestSameHash(t *testing.T) {
+	cache := session.NewPlanCache(5 * time.Minute)
+
+	manifest := []byte(`{"instruments":[{"code":"GBP"}]}`)
+
+	hash1 := cache.Store(manifest)
+	hash2 := cache.Store(manifest)
+
+	if hash1 != hash2 {
+		t.Error("same manifest should produce same hash")
+	}
+}
+
+func TestPlanCache_TTLExpiry(t *testing.T) {
+	cache := session.NewPlanCache(50 * time.Millisecond)
+
+	manifest := []byte(`{"instruments":[{"code":"GBP"}]}`)
+	hash := cache.Store(manifest)
+
+	if !cache.Exists(hash) {
+		t.Fatal("expected plan to exist immediately after store")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	if cache.Exists(hash) {
+		t.Error("expected plan to be expired after TTL")
+	}
+}
+
+func TestPlanCache_MissingHash(t *testing.T) {
+	cache := session.NewPlanCache(5 * time.Minute)
+
+	ok := cache.Exists("nonexistent-hash")
+	if ok {
+		t.Error("expected Exists to return false for unknown hash")
+	}
+}
+
+func TestPlanCache_Cleanup(t *testing.T) {
+	cache := session.NewPlanCache(50 * time.Millisecond)
+
+	for i := 0; i < 5; i++ {
+		manifest := []byte{byte(i)}
+		cache.Store(manifest)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	cache.Cleanup()
+
+	// All entries should be expired and cleaned up.
+	// We can't directly inspect internal state, but we verify that storing a
+	// new entry after cleanup still works correctly.
+	newManifest := []byte(`{"post":"cleanup"}`)
+	hash := cache.Store(newManifest)
+	if !cache.Exists(hash) {
+		t.Error("expected newly stored entry to exist after cleanup")
+	}
+}

--- a/services/mcp-server/internal/session/plan_cache_test.go
+++ b/services/mcp-server/internal/session/plan_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/meridianhub/meridian/services/mcp-server/internal/session"
+	"github.com/meridianhub/meridian/shared/platform/await"
 )
 
 func TestPlanCache_StoreAndRetrieve(t *testing.T) {
@@ -60,9 +61,11 @@ func TestPlanCache_TTLExpiry(t *testing.T) {
 		t.Fatal("expected plan to exist immediately after store")
 	}
 
-	time.Sleep(100 * time.Millisecond)
-
-	if cache.Exists(hash) {
+	err := await.New().
+		AtMost(500 * time.Millisecond).
+		PollInterval(10 * time.Millisecond).
+		Until(func() bool { return !cache.Exists(hash) })
+	if err != nil {
 		t.Error("expected plan to be expired after TTL")
 	}
 }
@@ -79,12 +82,27 @@ func TestPlanCache_MissingHash(t *testing.T) {
 func TestPlanCache_Cleanup(t *testing.T) {
 	cache := session.NewPlanCache(50 * time.Millisecond)
 
+	hashes := make([]string, 5)
 	for i := 0; i < 5; i++ {
-		manifest := []byte{byte(i)}
-		cache.Store(manifest)
+		hashes[i] = cache.Store([]byte{byte(i)})
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	// Wait for all entries to expire before cleaning up.
+	err := await.New().
+		AtMost(500 * time.Millisecond).
+		PollInterval(10 * time.Millisecond).
+		Until(func() bool {
+			for _, h := range hashes {
+				if cache.Exists(h) {
+					return false
+				}
+			}
+			return true
+		})
+	if err != nil {
+		t.Fatal("entries did not expire in time")
+	}
+
 	cache.Cleanup()
 
 	// All entries should be expired and cleaned up.

--- a/services/mcp-server/internal/session/rate_limiter.go
+++ b/services/mcp-server/internal/session/rate_limiter.go
@@ -1,0 +1,86 @@
+package session
+
+import (
+	"sync"
+	"time"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+)
+
+// CategoryLimit defines the maximum number of requests allowed within a time window
+// for a specific tool category.
+type CategoryLimit struct {
+	MaxRequests int
+	Window      time.Duration
+}
+
+// windowState tracks the fixed-window counter for a single category.
+type windowState struct {
+	count       int
+	windowStart time.Time
+}
+
+// RateLimiter enforces per-category fixed-window rate limits.
+// Each category maintains an independent counter that resets when its window expires.
+type RateLimiter struct {
+	mu     sync.Mutex
+	limits map[tools.ToolCategory]CategoryLimit
+	state  map[tools.ToolCategory]*windowState
+}
+
+// NewRateLimiter returns a RateLimiter with the given per-category limits.
+// Categories not present in limits are always allowed.
+func NewRateLimiter(limits map[tools.ToolCategory]CategoryLimit) *RateLimiter {
+	state := make(map[tools.ToolCategory]*windowState, len(limits))
+	for cat := range limits {
+		state[cat] = &windowState{windowStart: time.Now()}
+	}
+	return &RateLimiter{
+		limits: limits,
+		state:  state,
+	}
+}
+
+// DefaultLimits returns the standard rate limits for the MCP server:
+//   - Read:     60 requests/minute
+//   - Simulate: 30 requests/minute
+//   - Write:    5 requests/minute
+func DefaultLimits() map[tools.ToolCategory]CategoryLimit {
+	return map[tools.ToolCategory]CategoryLimit{
+		tools.CategoryRead:     {MaxRequests: 60, Window: time.Minute},
+		tools.CategorySimulate: {MaxRequests: 30, Window: time.Minute},
+		tools.CategoryWrite:    {MaxRequests: 5, Window: time.Minute},
+	}
+}
+
+// Allow returns true and increments the counter when the category is within its limit.
+// Returns false when the limit has been exceeded for the current window.
+// Categories without a configured limit always return true.
+func (r *RateLimiter) Allow(category tools.ToolCategory) bool {
+	limit, ok := r.limits[category]
+	if !ok {
+		return true
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	ws, ok := r.state[category]
+	if !ok {
+		ws = &windowState{windowStart: time.Now()}
+		r.state[category] = ws
+	}
+
+	now := time.Now()
+	if now.Sub(ws.windowStart) >= limit.Window {
+		ws.windowStart = now
+		ws.count = 0
+	}
+
+	if ws.count >= limit.MaxRequests {
+		return false
+	}
+
+	ws.count++
+	return true
+}

--- a/services/mcp-server/internal/session/rate_limiter.go
+++ b/services/mcp-server/internal/session/rate_limiter.go
@@ -30,13 +30,24 @@ type RateLimiter struct {
 
 // NewRateLimiter returns a RateLimiter with the given per-category limits.
 // Categories not present in limits are always allowed.
+// Panics if any limit has a non-positive Window or non-positive MaxRequests,
+// to prevent accidental unlimited-request bypass through misconfiguration.
 func NewRateLimiter(limits map[tools.ToolCategory]CategoryLimit) *RateLimiter {
+	copiedLimits := make(map[tools.ToolCategory]CategoryLimit, len(limits))
 	state := make(map[tools.ToolCategory]*windowState, len(limits))
-	for cat := range limits {
-		state[cat] = &windowState{windowStart: time.Now()}
+	now := time.Now()
+	for cat, limit := range limits {
+		if limit.Window <= 0 {
+			panic("session: RateLimiter Window must be positive")
+		}
+		if limit.MaxRequests <= 0 {
+			panic("session: RateLimiter MaxRequests must be positive")
+		}
+		copiedLimits[cat] = limit
+		state[cat] = &windowState{windowStart: now}
 	}
 	return &RateLimiter{
-		limits: limits,
+		limits: copiedLimits,
 		state:  state,
 	}
 }

--- a/services/mcp-server/internal/session/rate_limiter_test.go
+++ b/services/mcp-server/internal/session/rate_limiter_test.go
@@ -1,0 +1,118 @@
+package session_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/session"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+)
+
+func TestRateLimiter_AllowWithinLimit(t *testing.T) {
+	limits := session.DefaultLimits()
+	rl := session.NewRateLimiter(limits)
+
+	// CategoryRead allows 60/min; well within limit.
+	for i := 0; i < 10; i++ {
+		if !rl.Allow(tools.CategoryRead) {
+			t.Fatalf("expected Allow to return true on call %d", i+1)
+		}
+	}
+}
+
+func TestRateLimiter_BlockWhenExceeded(t *testing.T) {
+	limits := map[tools.ToolCategory]session.CategoryLimit{
+		tools.CategoryRead: {MaxRequests: 3, Window: time.Minute},
+	}
+	rl := session.NewRateLimiter(limits)
+
+	for i := 0; i < 3; i++ {
+		if !rl.Allow(tools.CategoryRead) {
+			t.Fatalf("expected Allow true on call %d", i+1)
+		}
+	}
+
+	if rl.Allow(tools.CategoryRead) {
+		t.Error("expected Allow to return false when limit exceeded")
+	}
+}
+
+func TestRateLimiter_ResetAfterWindow(t *testing.T) {
+	limits := map[tools.ToolCategory]session.CategoryLimit{
+		tools.CategoryRead: {MaxRequests: 2, Window: 50 * time.Millisecond},
+	}
+	rl := session.NewRateLimiter(limits)
+
+	rl.Allow(tools.CategoryRead)
+	rl.Allow(tools.CategoryRead)
+
+	if rl.Allow(tools.CategoryRead) {
+		t.Error("expected Allow false when limit reached")
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	if !rl.Allow(tools.CategoryRead) {
+		t.Error("expected Allow true after window reset")
+	}
+}
+
+func TestRateLimiter_IndependentCategories(t *testing.T) {
+	limits := map[tools.ToolCategory]session.CategoryLimit{
+		tools.CategoryRead:     {MaxRequests: 1, Window: time.Minute},
+		tools.CategorySimulate: {MaxRequests: 5, Window: time.Minute},
+		tools.CategoryWrite:    {MaxRequests: 1, Window: time.Minute},
+	}
+	rl := session.NewRateLimiter(limits)
+
+	// Exhaust Read.
+	rl.Allow(tools.CategoryRead)
+	if rl.Allow(tools.CategoryRead) {
+		t.Error("CategoryRead should be exhausted")
+	}
+
+	// Simulate should still work.
+	if !rl.Allow(tools.CategorySimulate) {
+		t.Error("CategorySimulate should still be available")
+	}
+
+	// Write should still work on first call.
+	if !rl.Allow(tools.CategoryWrite) {
+		t.Error("CategoryWrite first call should succeed")
+	}
+}
+
+func TestRateLimiter_DefaultLimits(t *testing.T) {
+	limits := session.DefaultLimits()
+
+	if _, ok := limits[tools.CategoryRead]; !ok {
+		t.Error("DefaultLimits should include CategoryRead")
+	}
+	if _, ok := limits[tools.CategorySimulate]; !ok {
+		t.Error("DefaultLimits should include CategorySimulate")
+	}
+	if _, ok := limits[tools.CategoryWrite]; !ok {
+		t.Error("DefaultLimits should include CategoryWrite")
+	}
+
+	if limits[tools.CategoryRead].MaxRequests != 60 {
+		t.Errorf("CategoryRead MaxRequests = %d, want 60", limits[tools.CategoryRead].MaxRequests)
+	}
+	if limits[tools.CategorySimulate].MaxRequests != 30 {
+		t.Errorf("CategorySimulate MaxRequests = %d, want 30", limits[tools.CategorySimulate].MaxRequests)
+	}
+	if limits[tools.CategoryWrite].MaxRequests != 5 {
+		t.Errorf("CategoryWrite MaxRequests = %d, want 5", limits[tools.CategoryWrite].MaxRequests)
+	}
+}
+
+func TestRateLimiter_UnknownCategoryAlwaysAllowed(t *testing.T) {
+	rl := session.NewRateLimiter(map[tools.ToolCategory]session.CategoryLimit{})
+
+	// An unconfigured category should not block.
+	for i := 0; i < 100; i++ {
+		if !rl.Allow(tools.CategoryWrite) {
+			t.Fatalf("unconfigured category should always be allowed (call %d)", i+1)
+		}
+	}
+}

--- a/services/mcp-server/internal/session/rate_limiter_test.go
+++ b/services/mcp-server/internal/session/rate_limiter_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/meridianhub/meridian/services/mcp-server/internal/session"
 	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+	"github.com/meridianhub/meridian/shared/platform/await"
 )
 
 func TestRateLimiter_AllowWithinLimit(t *testing.T) {
@@ -50,9 +51,12 @@ func TestRateLimiter_ResetAfterWindow(t *testing.T) {
 		t.Error("expected Allow false when limit reached")
 	}
 
-	time.Sleep(60 * time.Millisecond)
-
-	if !rl.Allow(tools.CategoryRead) {
+	// Wait for the window to reset.
+	err := await.New().
+		AtMost(500 * time.Millisecond).
+		PollInterval(10 * time.Millisecond).
+		Until(func() bool { return rl.Allow(tools.CategoryRead) })
+	if err != nil {
 		t.Error("expected Allow true after window reset")
 	}
 }

--- a/services/mcp-server/internal/session/session.go
+++ b/services/mcp-server/internal/session/session.go
@@ -1,0 +1,62 @@
+package session
+
+import (
+	"time"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+)
+
+// Config holds configuration for a Session.
+type Config struct {
+	// PlanTTL is the duration a stored plan hash remains valid.
+	PlanTTL time.Duration
+	// Limits defines per-category rate limits.
+	Limits map[tools.ToolCategory]CategoryLimit
+}
+
+// Session combines plan caching and rate limiting for a single MCP session.
+// It is safe for concurrent use.
+type Session struct {
+	cache   *PlanCache
+	limiter *RateLimiter
+}
+
+// New returns a Session configured with the provided Config.
+func New(cfg Config) *Session {
+	return &Session{
+		cache:   NewPlanCache(cfg.PlanTTL),
+		limiter: NewRateLimiter(cfg.Limits),
+	}
+}
+
+// NewDefault returns a Session with production-ready defaults:
+//   - Plan TTL: 30 minutes
+//   - Rate limits: Read 60/min, Simulate 30/min, Write 5/min
+func NewDefault() *Session {
+	return New(Config{
+		PlanTTL: 30 * time.Minute,
+		Limits:  DefaultLimits(),
+	})
+}
+
+// StorePlan hashes the manifest and records it in the plan cache.
+// Returns the hex-encoded SHA256 hash that must be provided to ValidatePlan.
+func (s *Session) StorePlan(manifest []byte) string {
+	return s.cache.Store(manifest)
+}
+
+// ValidatePlan returns true when a plan with the given hash exists and has not expired.
+// This enforces the plan-before-apply workflow.
+func (s *Session) ValidatePlan(hash string) bool {
+	return s.cache.Exists(hash)
+}
+
+// Allow returns true when the category has capacity within its rate limit window.
+func (s *Session) Allow(category tools.ToolCategory) bool {
+	return s.limiter.Allow(category)
+}
+
+// Cleanup removes expired plan cache entries. Call periodically to reclaim memory.
+func (s *Session) Cleanup() {
+	s.cache.Cleanup()
+}

--- a/services/mcp-server/internal/session/session_test.go
+++ b/services/mcp-server/internal/session/session_test.go
@@ -1,0 +1,83 @@
+package session_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/session"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+)
+
+func TestSession_PlanBeforeApply(t *testing.T) {
+	s := session.New(session.Config{
+		PlanTTL: 5 * time.Minute,
+		Limits:  session.DefaultLimits(),
+	})
+
+	manifest := []byte(`{"instruments":[{"code":"GBP"}]}`)
+
+	// Apply without a plan should fail.
+	if s.ValidatePlan("nonexistent-hash") {
+		t.Error("expected ValidatePlan to return false for missing plan")
+	}
+
+	// Store plan then apply should succeed.
+	hash := s.StorePlan(manifest)
+	if !s.ValidatePlan(hash) {
+		t.Error("expected ValidatePlan to return true after storing plan")
+	}
+}
+
+func TestSession_RateLimit(t *testing.T) {
+	s := session.New(session.Config{
+		PlanTTL: 5 * time.Minute,
+		Limits: map[tools.ToolCategory]session.CategoryLimit{
+			tools.CategoryWrite: {MaxRequests: 2, Window: time.Minute},
+		},
+	})
+
+	if !s.Allow(tools.CategoryWrite) {
+		t.Error("expected first call to be allowed")
+	}
+	if !s.Allow(tools.CategoryWrite) {
+		t.Error("expected second call to be allowed")
+	}
+	if s.Allow(tools.CategoryWrite) {
+		t.Error("expected third call to be blocked")
+	}
+}
+
+func TestSession_CleanupExpiredPlans(t *testing.T) {
+	s := session.New(session.Config{
+		PlanTTL: 50 * time.Millisecond,
+		Limits:  session.DefaultLimits(),
+	})
+
+	manifest := []byte(`{"test":"cleanup"}`)
+	hash := s.StorePlan(manifest)
+
+	if !s.ValidatePlan(hash) {
+		t.Fatal("expected plan to exist before expiry")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	s.Cleanup()
+
+	if s.ValidatePlan(hash) {
+		t.Error("expected expired plan to be gone after cleanup")
+	}
+}
+
+func TestSession_NewWithDefaultConfig(t *testing.T) {
+	s := session.NewDefault()
+
+	if s == nil {
+		t.Fatal("expected non-nil session from NewDefault")
+	}
+
+	// Verify it operates: store a plan and validate.
+	hash := s.StorePlan([]byte(`{"default":"config"}`))
+	if !s.ValidatePlan(hash) {
+		t.Error("expected ValidatePlan to return true with default config")
+	}
+}

--- a/services/mcp-server/internal/session/session_test.go
+++ b/services/mcp-server/internal/session/session_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/meridianhub/meridian/services/mcp-server/internal/session"
 	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+	"github.com/meridianhub/meridian/shared/platform/await"
 )
 
 func TestSession_PlanBeforeApply(t *testing.T) {
@@ -60,7 +61,15 @@ func TestSession_CleanupExpiredPlans(t *testing.T) {
 		t.Fatal("expected plan to exist before expiry")
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	// Wait for the plan to expire before cleaning up.
+	err := await.New().
+		AtMost(500 * time.Millisecond).
+		PollInterval(10 * time.Millisecond).
+		Until(func() bool { return !s.ValidatePlan(hash) })
+	if err != nil {
+		t.Fatal("plan did not expire in time")
+	}
+
 	s.Cleanup()
 
 	if s.ValidatePlan(hash) {


### PR DESCRIPTION
## Summary

- Implements `internal/session` package for mcp-server task 4
- `PlanCache`: SHA256 manifest hashing with configurable TTL expiry and periodic cleanup
- `RateLimiter`: fixed-window per-category limits (Read 60/min, Simulate 30/min, Write 5/min)
- `Session`: composes both components, exposes `StorePlan`/`ValidatePlan` (plan-before-apply) and `Allow` (rate limiting) APIs

## Changes Made

- `services/mcp-server/internal/session/plan_cache.go` — PlanCache with SHA256 hashing and TTL
- `services/mcp-server/internal/session/rate_limiter.go` — RateLimiter with independent per-category fixed windows
- `services/mcp-server/internal/session/session.go` — Session composing both, with `NewDefault()` for production config
- Corresponding `_test.go` files for all three components

## Technical Details

- `PlanCache.Store()` returns a hex-encoded SHA256 digest; calling again with the same manifest resets the TTL
- `RateLimiter.Allow()` returns true for unconfigured categories (safe default)
- `Session.Cleanup()` delegates to `PlanCache.Cleanup()` for periodic eviction of expired entries
- Zero external dependencies beyond standard library and `internal/tools` (for `ToolCategory`)

## Testing

16 tests covering:
- Store/retrieve and hash determinism
- TTL expiry and cleanup
- Rate limit enforcement, window reset after expiry
- Independent category counters
- Plan-before-apply integration workflow
- Default configuration

All existing mcp-server tests pass with no regressions.

## Risk Assessment

No changes to existing packages. New package is additive and isolated within `internal/session/`.