### PR TITLE
feat(mcp-server): add reference data tools

### DIFF
--- a/services/mcp-server/internal/tools/refdata.go
+++ b/services/mcp-server/internal/tools/refdata.go
@@ -340,11 +340,15 @@ func buildSagaDescribeTool(client SagaRegistryClient) Tool {
 				return formatError("either id or name is required"), nil
 			}
 
-			resp, err := client.GetSaga(ctx, &sagav1.GetSagaRequest{
-				Id:      p.ID,
-				Name:    p.Name,
-				Version: p.Version,
-			})
+			req := &sagav1.GetSagaRequest{}
+			if p.ID != "" {
+				req.Id = p.ID
+			} else {
+				req.Name = p.Name
+				req.Version = p.Version
+			}
+
+			resp, err := client.GetSaga(ctx, req)
 			if err != nil {
 				fe := mcperrors.FormatGRPCError(err)
 				return fe, nil

--- a/services/mcp-server/internal/tools/refdata.go
+++ b/services/mcp-server/internal/tools/refdata.go
@@ -1,0 +1,869 @@
+// Package tools provides the tool registry for the MCP server.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	mcperrors "github.com/meridianhub/meridian/services/mcp-server/internal/errors"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
+)
+
+// Status filter constants used across tool parameter parsing.
+const (
+	statusActive     = "ACTIVE"
+	statusDraft      = "DRAFT"
+	statusDeprecated = "DEPRECATED"
+)
+
+// ManifestHistoryClient is the interface used by reference data tools to retrieve manifests.
+// Defined as an interface so tests can inject mocks.
+type ManifestHistoryClient interface {
+	GetCurrentManifest(ctx context.Context, req *controlplanev1.GetCurrentManifestRequest) (*controlplanev1.GetCurrentManifestResponse, error)
+}
+
+// ReferenceDataClient is the interface used by reference data tools to query instrument definitions.
+type ReferenceDataClient interface {
+	ListInstruments(ctx context.Context, req *referencedatav1.ListInstrumentsRequest) (*referencedatav1.ListInstrumentsResponse, error)
+	RetrieveInstrument(ctx context.Context, req *referencedatav1.RetrieveInstrumentRequest) (*referencedatav1.RetrieveInstrumentResponse, error)
+}
+
+// SagaRegistryClient is the interface used by reference data tools to query saga definitions.
+type SagaRegistryClient interface {
+	ListSagas(ctx context.Context, req *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error)
+	GetSaga(ctx context.Context, req *sagav1.GetSagaRequest) (*sagav1.GetSagaResponse, error)
+}
+
+// MarketInformationClient is the interface used by reference data tools to query market data.
+type MarketInformationClient interface {
+	ListDataSets(ctx context.Context, req *marketinformationv1.ListDataSetsRequest) (*marketinformationv1.ListDataSetsResponse, error)
+	ListObservations(ctx context.Context, req *marketinformationv1.ListObservationsRequest) (*marketinformationv1.ListObservationsResponse, error)
+}
+
+// ReferenceDataDeps holds all service clients used by reference data tools.
+type ReferenceDataDeps struct {
+	ManifestHistory   ManifestHistoryClient
+	ReferenceData     ReferenceDataClient
+	SagaRegistry      SagaRegistryClient
+	MarketInformation MarketInformationClient
+}
+
+// RegisterReferenceDataTools registers all reference data query tools into the registry.
+// All tools are read-only (CategoryRead) and query gRPC services for reference data.
+func RegisterReferenceDataTools(registry *Registry, deps ReferenceDataDeps) error {
+	allTools := []Tool{
+		buildEconomyStructureTool(deps.ManifestHistory),
+		buildInstrumentsListTool(deps.ReferenceData),
+		buildInstrumentDescribeTool(deps.ReferenceData),
+		buildSagasListTool(deps.SagaRegistry),
+		buildSagaDescribeTool(deps.SagaRegistry),
+		buildHandlersDescribeTool(deps.ManifestHistory),
+		buildMarketDataQueryTool(deps.MarketInformation),
+	}
+
+	for _, t := range allTools {
+		if err := registry.Register(t); err != nil {
+			return fmt.Errorf("register tool %q: %w", t.Name, err)
+		}
+	}
+	return nil
+}
+
+// buildEconomyStructureTool creates the meridian_economy_structure tool.
+// It retrieves the current manifest and returns a hierarchical summary of the tenant's economy.
+func buildEconomyStructureTool(client ManifestHistoryClient) Tool {
+	return Tool{
+		Name:        "meridian_economy_structure",
+		Description: "Returns a hierarchical summary of the tenant's economy: instruments, account types, valuation rules, sagas, and payment rails from the current manifest.",
+		Category:    CategoryRead,
+		InputSchema: map[string]interface{}{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties":           map[string]interface{}{},
+		},
+		Handler: func(ctx context.Context, _ json.RawMessage) (interface{}, error) {
+			if client == nil {
+				return formatError("manifest_history client not configured"), nil
+			}
+
+			resp, err := client.GetCurrentManifest(ctx, &controlplanev1.GetCurrentManifestRequest{})
+			if err != nil {
+				fe := mcperrors.FormatGRPCError(err)
+				return fe, nil
+			}
+
+			if resp.GetVersion() == nil || resp.GetVersion().GetManifest() == nil {
+				return map[string]interface{}{
+					"status":  "no_manifest",
+					"message": "no manifest has been applied for this tenant",
+				}, nil
+			}
+
+			m := resp.GetVersion().GetManifest()
+			return buildManifestSummary(resp.GetVersion().GetVersion(), m), nil
+		},
+	}
+}
+
+// buildInstrumentsListTool creates the meridian_instruments_list tool.
+func buildInstrumentsListTool(client ReferenceDataClient) Tool {
+	return Tool{
+		Name:        "meridian_instruments_list",
+		Description: "Lists instrument definitions registered for the tenant. Supports optional status filter (ACTIVE, DRAFT, DEPRECATED).",
+		Category:    CategoryRead,
+		InputSchema: map[string]interface{}{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]interface{}{
+				"status_filter": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter by status: ACTIVE, DRAFT, or DEPRECATED. Omit to return all.",
+					"enum":        []interface{}{statusActive, statusDraft, statusDeprecated},
+				},
+				"page_size": map[string]interface{}{
+					"type":        "integer",
+					"description": "Maximum number of results to return (1-100).",
+					"minimum":     1,
+					"maximum":     100,
+				},
+			},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			if client == nil {
+				return formatError("reference_data client not configured"), nil
+			}
+
+			var p struct {
+				StatusFilter string `json:"status_filter"`
+				PageSize     int32  `json:"page_size"`
+			}
+			unmarshalErr := json.Unmarshal(params, &p)
+			if unmarshalErr != nil {
+				return formatError("invalid parameters: " + unmarshalErr.Error()), nil //nolint:nilerr // tool errors are returned in the result, not as Go errors
+			}
+
+			req := &referencedatav1.ListInstrumentsRequest{
+				PageSize: p.PageSize,
+			}
+			if p.StatusFilter != "" {
+				req.StatusFilter = parseInstrumentStatus(p.StatusFilter)
+			}
+
+			resp, err := client.ListInstruments(ctx, req)
+			if err != nil {
+				fe := mcperrors.FormatGRPCError(err)
+				return fe, nil
+			}
+
+			instruments := make([]map[string]interface{}, 0, len(resp.GetInstruments()))
+			for _, inst := range resp.GetInstruments() {
+				instruments = append(instruments, summarizeInstrument(inst))
+			}
+
+			return map[string]interface{}{
+				"instruments":     instruments,
+				"count":           len(instruments),
+				"next_page_token": resp.GetNextPageToken(),
+			}, nil
+		},
+	}
+}
+
+// buildInstrumentDescribeTool creates the meridian_instrument_describe tool.
+func buildInstrumentDescribeTool(client ReferenceDataClient) Tool {
+	return Tool{
+		Name:        "meridian_instrument_describe",
+		Description: "Returns full details for a specific instrument definition by code. Optionally specify a version; defaults to latest active.",
+		Category:    CategoryRead,
+		InputSchema: map[string]interface{}{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]interface{}{
+				"code": map[string]interface{}{
+					"type":        "string",
+					"description": "Instrument code (e.g., USD, KWH, CARBON_CREDIT).",
+				},
+				"version": map[string]interface{}{
+					"type":        "integer",
+					"description": "Specific version to retrieve. If 0 or omitted, returns the latest active version.",
+					"minimum":     0,
+				},
+			},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			if client == nil {
+				return formatError("reference_data client not configured"), nil
+			}
+
+			var p struct {
+				Code    string `json:"code"`
+				Version int32  `json:"version"`
+			}
+			unmarshalErr := json.Unmarshal(params, &p)
+			if unmarshalErr != nil {
+				return formatError("invalid parameters: " + unmarshalErr.Error()), nil //nolint:nilerr // tool errors are returned in the result, not as Go errors
+			}
+			if p.Code == "" {
+				return formatError("code is required"), nil
+			}
+
+			resp, err := client.RetrieveInstrument(ctx, &referencedatav1.RetrieveInstrumentRequest{
+				Code:    p.Code,
+				Version: p.Version,
+			})
+			if err != nil {
+				fe := mcperrors.FormatGRPCError(err)
+				return fe, nil
+			}
+
+			return detailInstrument(resp.GetInstrument()), nil
+		},
+	}
+}
+
+// buildSagasListTool creates the meridian_sagas_list tool.
+func buildSagasListTool(client SagaRegistryClient) Tool {
+	return Tool{
+		Name:        "meridian_sagas_list",
+		Description: "Lists saga workflow definitions registered for the tenant. Supports optional status filter (ACTIVE, DRAFT, DEPRECATED) and system saga inclusion.",
+		Category:    CategoryRead,
+		InputSchema: map[string]interface{}{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]interface{}{
+				"status_filter": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter by status: ACTIVE, DRAFT, or DEPRECATED. Omit to return all.",
+					"enum":        []interface{}{statusActive, statusDraft, statusDeprecated},
+				},
+				"exclude_system": map[string]interface{}{
+					"type":        "boolean",
+					"description": "If true, excludes system sagas from the response.",
+				},
+				"page_size": map[string]interface{}{
+					"type":        "integer",
+					"description": "Maximum number of results to return (1-100).",
+					"minimum":     1,
+					"maximum":     100,
+				},
+			},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			if client == nil {
+				return formatError("saga_registry client not configured"), nil
+			}
+
+			var p struct {
+				StatusFilter  string `json:"status_filter"`
+				ExcludeSystem bool   `json:"exclude_system"`
+				PageSize      int32  `json:"page_size"`
+			}
+			unmarshalErr := json.Unmarshal(params, &p)
+			if unmarshalErr != nil {
+				return formatError("invalid parameters: " + unmarshalErr.Error()), nil //nolint:nilerr // tool errors are returned in the result, not as Go errors
+			}
+
+			req := &sagav1.ListSagasRequest{
+				ExcludeSystem: p.ExcludeSystem,
+				PageSize:      p.PageSize,
+			}
+			if p.StatusFilter != "" {
+				req.StatusFilter = parseSagaStatus(p.StatusFilter)
+			}
+
+			resp, err := client.ListSagas(ctx, req)
+			if err != nil {
+				fe := mcperrors.FormatGRPCError(err)
+				return fe, nil
+			}
+
+			sagas := make([]map[string]interface{}, 0, len(resp.GetSagas()))
+			for _, s := range resp.GetSagas() {
+				sagas = append(sagas, summarizeSaga(s))
+			}
+
+			return map[string]interface{}{
+				"sagas":           sagas,
+				"count":           len(sagas),
+				"next_page_token": resp.GetNextPageToken(),
+			}, nil
+		},
+	}
+}
+
+// buildSagaDescribeTool creates the meridian_saga_describe tool.
+func buildSagaDescribeTool(client SagaRegistryClient) Tool {
+	return Tool{
+		Name:        "meridian_saga_describe",
+		Description: "Returns full details for a specific saga definition including its Starlark script. Lookup by saga ID (UUID) or by name with optional version.",
+		Category:    CategoryRead,
+		InputSchema: map[string]interface{}{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]interface{}{
+				"id": map[string]interface{}{
+					"type":        "string",
+					"description": "Saga UUID. If provided, name and version are ignored.",
+				},
+				"name": map[string]interface{}{
+					"type":        "string",
+					"description": "Saga name (e.g., current_account_withdrawal). Used when id is not provided.",
+				},
+				"version": map[string]interface{}{
+					"type":        "integer",
+					"description": "Specific version. If 0 or omitted with name, returns the active version.",
+					"minimum":     0,
+				},
+			},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			if client == nil {
+				return formatError("saga_registry client not configured"), nil
+			}
+
+			var p struct {
+				ID      string `json:"id"`
+				Name    string `json:"name"`
+				Version int32  `json:"version"`
+			}
+			unmarshalErr := json.Unmarshal(params, &p)
+			if unmarshalErr != nil {
+				return formatError("invalid parameters: " + unmarshalErr.Error()), nil //nolint:nilerr // tool errors are returned in the result, not as Go errors
+			}
+			if p.ID == "" && p.Name == "" {
+				return formatError("either id or name is required"), nil
+			}
+
+			resp, err := client.GetSaga(ctx, &sagav1.GetSagaRequest{
+				Id:      p.ID,
+				Name:    p.Name,
+				Version: p.Version,
+			})
+			if err != nil {
+				fe := mcperrors.FormatGRPCError(err)
+				return fe, nil
+			}
+
+			return detailSaga(resp.GetSaga()), nil
+		},
+	}
+}
+
+// buildHandlersDescribeTool creates the meridian_handlers_describe tool.
+// It reads handler definitions from the manifest's saga definitions and account type policies.
+func buildHandlersDescribeTool(client ManifestHistoryClient) Tool {
+	return Tool{
+		Name:        "meridian_handlers_describe",
+		Description: "Returns the tenant's available saga triggers and account type policies from the current manifest. Shows which handlers are wired to API endpoints, webhooks, and scheduled jobs.",
+		Category:    CategoryRead,
+		InputSchema: map[string]interface{}{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]interface{}{
+				"trigger_prefix": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter saga triggers by prefix: api, webhook, or scheduled. Omit to return all.",
+					"enum":        []interface{}{"api", "webhook", "scheduled"},
+				},
+			},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			if client == nil {
+				return formatError("manifest_history client not configured"), nil
+			}
+
+			var p struct {
+				TriggerPrefix string `json:"trigger_prefix"`
+			}
+			unmarshalErr := json.Unmarshal(params, &p)
+			if unmarshalErr != nil {
+				return formatError("invalid parameters: " + unmarshalErr.Error()), nil //nolint:nilerr // tool errors are returned in the result, not as Go errors
+			}
+
+			resp, err := client.GetCurrentManifest(ctx, &controlplanev1.GetCurrentManifestRequest{})
+			if err != nil {
+				fe := mcperrors.FormatGRPCError(err)
+				return fe, nil
+			}
+
+			if resp.GetVersion() == nil || resp.GetVersion().GetManifest() == nil {
+				return map[string]interface{}{
+					"status":  "no_manifest",
+					"message": "no manifest has been applied for this tenant",
+				}, nil
+			}
+
+			m := resp.GetVersion().GetManifest()
+			triggers := extractSagaTriggers(m.GetSagas(), p.TriggerPrefix)
+			policies := extractAccountTypePolicies(m.GetAccountTypes())
+
+			return map[string]interface{}{
+				"saga_triggers":         triggers,
+				"saga_trigger_count":    len(triggers),
+				"account_type_policies": policies,
+				"policy_count":          len(policies),
+			}, nil
+		},
+	}
+}
+
+// triggerEntry describes a saga trigger mapping.
+type triggerEntry struct {
+	SagaName    string `json:"saga_name"`
+	TriggerType string `json:"trigger_type"`
+	TriggerPath string `json:"trigger_path"`
+}
+
+// policyEntry describes CEL policies attached to an account type.
+type policyEntry struct {
+	AccountTypeCode string `json:"account_type_code"`
+	Validation      string `json:"validation,omitempty"`
+	Bucketing       string `json:"bucketing,omitempty"`
+}
+
+// extractSagaTriggers converts manifest saga definitions into trigger entries.
+// If prefix is non-empty, only triggers with that prefix (e.g., "api:") are returned.
+func extractSagaTriggers(sagas []*controlplanev1.SagaDefinition, prefix string) []triggerEntry {
+	result := make([]triggerEntry, 0, len(sagas))
+	for _, saga := range sagas {
+		if prefix != "" && !strings.HasPrefix(saga.GetTrigger(), prefix+":") {
+			continue
+		}
+		parts := strings.SplitN(saga.GetTrigger(), ":", 2)
+		triggerType := saga.GetTrigger()
+		triggerPath := ""
+		if len(parts) == 2 {
+			triggerType = parts[0]
+			triggerPath = parts[1]
+		}
+		result = append(result, triggerEntry{
+			SagaName:    saga.GetName(),
+			TriggerType: triggerType,
+			TriggerPath: triggerPath,
+		})
+	}
+	return result
+}
+
+// extractAccountTypePolicies converts manifest account type definitions into policy entries.
+// Account types without CEL policies are excluded.
+func extractAccountTypePolicies(accountTypes []*controlplanev1.AccountTypeDefinition) []policyEntry {
+	result := make([]policyEntry, 0, len(accountTypes))
+	for _, at := range accountTypes {
+		if at.GetPolicies() == nil {
+			continue
+		}
+		if at.GetPolicies().GetValidation() == "" && at.GetPolicies().GetBucketing() == "" {
+			continue
+		}
+		result = append(result, policyEntry{
+			AccountTypeCode: at.GetCode(),
+			Validation:      at.GetPolicies().GetValidation(),
+			Bucketing:       at.GetPolicies().GetBucketing(),
+		})
+	}
+	return result
+}
+
+// buildMarketDataQueryTool creates the meridian_market_data_query tool.
+func buildMarketDataQueryTool(client MarketInformationClient) Tool {
+	return Tool{
+		Name:        "meridian_market_data_query",
+		Description: "Lists market data sets or queries observations for a specific dataset. Use dataset_code to query observations for a specific set.",
+		Category:    CategoryRead,
+		InputSchema: map[string]interface{}{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]interface{}{
+				"dataset_code": map[string]interface{}{
+					"type":        "string",
+					"description": "Dataset code to retrieve observations for (e.g., USD_EUR_FX). Omit to list all datasets.",
+				},
+				"status_filter": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter datasets by status: ACTIVE, DRAFT, or DEPRECATED. Only used when dataset_code is omitted.",
+					"enum":        []interface{}{statusActive, statusDraft, statusDeprecated},
+				},
+				"page_size": map[string]interface{}{
+					"type":        "integer",
+					"description": "Maximum number of results to return (1-100).",
+					"minimum":     1,
+					"maximum":     100,
+				},
+			},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			if client == nil {
+				return formatError("market_information client not configured"), nil
+			}
+
+			var p struct {
+				DatasetCode  string `json:"dataset_code"`
+				StatusFilter string `json:"status_filter"`
+				PageSize     int32  `json:"page_size"`
+			}
+			unmarshalErr := json.Unmarshal(params, &p)
+			if unmarshalErr != nil {
+				return formatError("invalid parameters: " + unmarshalErr.Error()), nil //nolint:nilerr // tool errors are returned in the result, not as Go errors
+			}
+
+			if p.DatasetCode != "" {
+				return queryObservations(ctx, client, p.DatasetCode, p.PageSize)
+			}
+			return queryDatasets(ctx, client, p.StatusFilter, p.PageSize)
+		},
+	}
+}
+
+// queryObservations lists observations for a specific dataset code.
+func queryObservations(ctx context.Context, client MarketInformationClient, datasetCode string, pageSize int32) (interface{}, error) {
+	req := &marketinformationv1.ListObservationsRequest{
+		DatasetCode: datasetCode,
+		PageSize:    pageSize,
+	}
+	resp, err := client.ListObservations(ctx, req)
+	if err != nil {
+		fe := mcperrors.FormatGRPCError(err)
+		return fe, nil
+	}
+
+	observations := make([]map[string]interface{}, 0, len(resp.GetObservations()))
+	for _, obs := range resp.GetObservations() {
+		observations = append(observations, summarizeObservation(obs))
+	}
+
+	return map[string]interface{}{
+		"dataset_code":    datasetCode,
+		"observations":    observations,
+		"count":           len(observations),
+		"next_page_token": resp.GetNextPageToken(),
+	}, nil
+}
+
+// queryDatasets lists all datasets with an optional status filter.
+func queryDatasets(ctx context.Context, client MarketInformationClient, statusFilter string, pageSize int32) (interface{}, error) {
+	req := &marketinformationv1.ListDataSetsRequest{
+		PageSize: pageSize,
+	}
+	if statusFilter != "" {
+		req.StatusFilter = parseDataSetStatus(statusFilter)
+	}
+
+	resp, err := client.ListDataSets(ctx, req)
+	if err != nil {
+		fe := mcperrors.FormatGRPCError(err)
+		return fe, nil
+	}
+
+	datasets := make([]map[string]interface{}, 0, len(resp.GetDatasets()))
+	for _, ds := range resp.GetDatasets() {
+		datasets = append(datasets, summarizeDataSet(ds))
+	}
+
+	return map[string]interface{}{
+		"datasets":        datasets,
+		"count":           len(datasets),
+		"next_page_token": resp.GetNextPageToken(),
+	}, nil
+}
+
+// ---- helpers ----
+
+// formatError returns a structured error result for use in tool responses.
+func formatError(msg string) map[string]interface{} {
+	return map[string]interface{}{
+		"valid":  false,
+		"errors": []map[string]interface{}{{"type": "generic", "message": msg}},
+	}
+}
+
+// buildManifestSummary converts a Manifest into a hierarchical summary map.
+func buildManifestSummary(version string, m *controlplanev1.Manifest) map[string]interface{} {
+	instruments := make([]map[string]interface{}, 0, len(m.GetInstruments()))
+	for _, inst := range m.GetInstruments() {
+		instruments = append(instruments, map[string]interface{}{
+			"code": inst.GetCode(),
+			"name": inst.GetName(),
+			"type": inst.GetType().String(),
+			"unit": func() string {
+				if inst.GetDimensions() != nil {
+					return inst.GetDimensions().GetUnit()
+				}
+				return ""
+			}(),
+			"precision": func() int32 {
+				if inst.GetDimensions() != nil {
+					return inst.GetDimensions().GetPrecision()
+				}
+				return 0
+			}(),
+		})
+	}
+
+	accountTypes := make([]map[string]interface{}, 0, len(m.GetAccountTypes()))
+	for _, at := range m.GetAccountTypes() {
+		entry := map[string]interface{}{
+			"code":           at.GetCode(),
+			"name":           at.GetName(),
+			"normal_balance": at.GetNormalBalance().String(),
+		}
+		if len(at.GetAllowedInstruments()) > 0 {
+			entry["allowed_instruments"] = at.GetAllowedInstruments()
+		}
+		accountTypes = append(accountTypes, entry)
+	}
+
+	valuationRules := make([]map[string]interface{}, 0, len(m.GetValuationRules()))
+	for _, vr := range m.GetValuationRules() {
+		valuationRules = append(valuationRules, map[string]interface{}{
+			"from_instrument": vr.GetFromInstrument(),
+			"to_instrument":   vr.GetToInstrument(),
+			"method":          vr.GetMethod().String(),
+			"source":          vr.GetSource(),
+		})
+	}
+
+	sagas := make([]map[string]interface{}, 0, len(m.GetSagas()))
+	for _, s := range m.GetSagas() {
+		sagas = append(sagas, map[string]interface{}{
+			"name":    s.GetName(),
+			"trigger": s.GetTrigger(),
+		})
+	}
+
+	paymentRails := make([]map[string]interface{}, 0, len(m.GetPaymentRails()))
+	for _, pr := range m.GetPaymentRails() {
+		paymentRails = append(paymentRails, map[string]interface{}{
+			"provider": pr.GetProvider(),
+			"mode":     pr.GetMode().String(),
+		})
+	}
+
+	result := map[string]interface{}{
+		"version": version,
+		"economy": map[string]interface{}{
+			"instruments": map[string]interface{}{
+				"count": len(instruments),
+				"items": instruments,
+			},
+			"account_types": map[string]interface{}{
+				"count": len(accountTypes),
+				"items": accountTypes,
+			},
+			"valuation_rules": map[string]interface{}{
+				"count": len(valuationRules),
+				"items": valuationRules,
+			},
+			"sagas": map[string]interface{}{
+				"count": len(sagas),
+				"items": sagas,
+			},
+			"payment_rails": map[string]interface{}{
+				"count": len(paymentRails),
+				"items": paymentRails,
+			},
+		},
+	}
+
+	if m.GetMetadata() != nil {
+		result["metadata"] = map[string]interface{}{
+			"name":        m.GetMetadata().GetName(),
+			"industry":    m.GetMetadata().GetIndustry(),
+			"description": m.GetMetadata().GetDescription(),
+		}
+	}
+
+	return result
+}
+
+// summarizeInstrument returns a concise map of key instrument fields for listing.
+func summarizeInstrument(inst *referencedatav1.InstrumentDefinition) map[string]interface{} {
+	if inst == nil {
+		return nil
+	}
+	return map[string]interface{}{
+		"id":           inst.GetId(),
+		"code":         inst.GetCode(),
+		"version":      inst.GetVersion(),
+		"dimension":    inst.GetDimension().String(),
+		"precision":    inst.GetPrecision(),
+		"status":       inst.GetStatus().String(),
+		"display_name": inst.GetDisplayName(),
+		"is_system":    inst.GetIsSystem(),
+	}
+}
+
+// detailInstrument returns a full map of all instrument fields.
+func detailInstrument(inst *referencedatav1.InstrumentDefinition) map[string]interface{} {
+	if inst == nil {
+		return nil
+	}
+	result := map[string]interface{}{
+		"id":                         inst.GetId(),
+		"code":                       inst.GetCode(),
+		"version":                    inst.GetVersion(),
+		"dimension":                  inst.GetDimension().String(),
+		"precision":                  inst.GetPrecision(),
+		"status":                     inst.GetStatus().String(),
+		"display_name":               inst.GetDisplayName(),
+		"description":                inst.GetDescription(),
+		"is_system":                  inst.GetIsSystem(),
+		"validation_expression":      inst.GetValidationExpression(),
+		"fungibility_key_expression": inst.GetFungibilityKeyExpression(),
+		"error_message_expression":   inst.GetErrorMessageExpression(),
+		"attribute_schema":           inst.GetAttributeSchema(),
+	}
+	if inst.GetSuccessorId() != "" {
+		result["successor_id"] = inst.GetSuccessorId()
+	}
+	if inst.GetCreatedAt() != nil {
+		result["created_at"] = inst.GetCreatedAt().AsTime().Format("2006-01-02T15:04:05Z07:00")
+	}
+	if inst.GetActivatedAt() != nil {
+		result["activated_at"] = inst.GetActivatedAt().AsTime().Format("2006-01-02T15:04:05Z07:00")
+	}
+	if inst.GetDeprecatedAt() != nil {
+		result["deprecated_at"] = inst.GetDeprecatedAt().AsTime().Format("2006-01-02T15:04:05Z07:00")
+	}
+	return result
+}
+
+// summarizeSaga returns a concise map for saga listing.
+func summarizeSaga(s *sagav1.SagaDefinition) map[string]interface{} {
+	if s == nil {
+		return nil
+	}
+	return map[string]interface{}{
+		"id":           s.GetId(),
+		"name":         s.GetName(),
+		"version":      s.GetVersion(),
+		"status":       s.GetStatus().String(),
+		"is_system":    s.GetIsSystem(),
+		"display_name": s.GetDisplayName(),
+		"description":  s.GetDescription(),
+	}
+}
+
+// detailSaga returns a full map of all saga fields.
+func detailSaga(s *sagav1.SagaDefinition) map[string]interface{} {
+	if s == nil {
+		return nil
+	}
+	result := map[string]interface{}{
+		"id":                       s.GetId(),
+		"name":                     s.GetName(),
+		"version":                  s.GetVersion(),
+		"status":                   s.GetStatus().String(),
+		"is_system":                s.GetIsSystem(),
+		"display_name":             s.GetDisplayName(),
+		"description":              s.GetDescription(),
+		"script":                   s.GetScript(),
+		"preconditions_expression": s.GetPreconditionsExpression(),
+	}
+	if s.GetSuccessorId() != "" {
+		result["successor_id"] = s.GetSuccessorId()
+	}
+	if s.GetCreatedAt() != nil {
+		result["created_at"] = s.GetCreatedAt().AsTime().Format("2006-01-02T15:04:05Z07:00")
+	}
+	if s.GetUpdatedAt() != nil {
+		result["updated_at"] = s.GetUpdatedAt().AsTime().Format("2006-01-02T15:04:05Z07:00")
+	}
+	if s.GetActivatedAt() != nil {
+		result["activated_at"] = s.GetActivatedAt().AsTime().Format("2006-01-02T15:04:05Z07:00")
+	}
+	if s.GetDeprecatedAt() != nil {
+		result["deprecated_at"] = s.GetDeprecatedAt().AsTime().Format("2006-01-02T15:04:05Z07:00")
+	}
+	return result
+}
+
+// summarizeDataSet returns a concise map for dataset listing.
+func summarizeDataSet(ds *marketinformationv1.DataSetDefinition) map[string]interface{} {
+	if ds == nil {
+		return nil
+	}
+	return map[string]interface{}{
+		"id":           ds.GetId(),
+		"code":         ds.GetCode(),
+		"version":      ds.GetVersion(),
+		"category":     ds.GetCategory().String(),
+		"unit":         ds.GetUnit(),
+		"status":       ds.GetStatus().String(),
+		"display_name": ds.GetDisplayName(),
+		"description":  ds.GetDescription(),
+	}
+}
+
+// summarizeObservation returns a concise map for observation listing.
+func summarizeObservation(obs *marketinformationv1.MarketPriceObservation) map[string]interface{} {
+	if obs == nil {
+		return nil
+	}
+	result := map[string]interface{}{
+		"id":              obs.GetId(),
+		"dataset_code":    obs.GetDatasetCode(),
+		"dataset_version": obs.GetDatasetVersion(),
+		"resolution_key":  obs.GetResolutionKeyValue(),
+		"value":           obs.GetValue(),
+		"quality":         obs.GetQuality().String(),
+	}
+	if obs.GetObservedAt() != nil {
+		result["observed_at"] = obs.GetObservedAt().AsTime().Format("2006-01-02T15:04:05Z07:00")
+	}
+	if obs.GetValidFrom() != nil {
+		result["valid_from"] = obs.GetValidFrom().AsTime().Format("2006-01-02T15:04:05Z07:00")
+	}
+	if obs.GetValidTo() != nil {
+		result["valid_to"] = obs.GetValidTo().AsTime().Format("2006-01-02T15:04:05Z07:00")
+	}
+	return result
+}
+
+// parseInstrumentStatus converts a string to a referencedatav1.InstrumentStatus.
+func parseInstrumentStatus(s string) referencedatav1.InstrumentStatus {
+	switch strings.ToUpper(s) {
+	case statusActive:
+		return referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE
+	case statusDraft:
+		return referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_DRAFT
+	case statusDeprecated:
+		return referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_DEPRECATED
+	default:
+		return referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_UNSPECIFIED
+	}
+}
+
+// parseSagaStatus converts a string to a sagav1.SagaStatus.
+func parseSagaStatus(s string) sagav1.SagaStatus {
+	switch strings.ToUpper(s) {
+	case statusActive:
+		return sagav1.SagaStatus_SAGA_STATUS_ACTIVE
+	case statusDraft:
+		return sagav1.SagaStatus_SAGA_STATUS_DRAFT
+	case statusDeprecated:
+		return sagav1.SagaStatus_SAGA_STATUS_DEPRECATED
+	default:
+		return sagav1.SagaStatus_SAGA_STATUS_UNSPECIFIED
+	}
+}
+
+// parseDataSetStatus converts a string to a marketinformationv1.DataSetStatus.
+func parseDataSetStatus(s string) marketinformationv1.DataSetStatus {
+	switch strings.ToUpper(s) {
+	case statusActive:
+		return marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE
+	case statusDraft:
+		return marketinformationv1.DataSetStatus_DATA_SET_STATUS_DRAFT
+	case statusDeprecated:
+		return marketinformationv1.DataSetStatus_DATA_SET_STATUS_DEPRECATED
+	default:
+		return marketinformationv1.DataSetStatus_DATA_SET_STATUS_UNSPECIFIED
+	}
+}

--- a/services/mcp-server/internal/tools/refdata_test.go
+++ b/services/mcp-server/internal/tools/refdata_test.go
@@ -1,0 +1,707 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
+	mcperrors "github.com/meridianhub/meridian/services/mcp-server/internal/errors"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// ---- mock clients ----
+
+type mockManifestHistoryClient struct {
+	resp *controlplanev1.GetCurrentManifestResponse
+	err  error
+}
+
+func (m *mockManifestHistoryClient) GetCurrentManifest(_ context.Context, _ *controlplanev1.GetCurrentManifestRequest) (*controlplanev1.GetCurrentManifestResponse, error) {
+	return m.resp, m.err
+}
+
+type mockReferenceDataClient struct {
+	listResp     *referencedatav1.ListInstrumentsResponse
+	listErr      error
+	retrieveResp *referencedatav1.RetrieveInstrumentResponse
+	retrieveErr  error
+}
+
+func (m *mockReferenceDataClient) ListInstruments(_ context.Context, _ *referencedatav1.ListInstrumentsRequest) (*referencedatav1.ListInstrumentsResponse, error) {
+	return m.listResp, m.listErr
+}
+
+func (m *mockReferenceDataClient) RetrieveInstrument(_ context.Context, _ *referencedatav1.RetrieveInstrumentRequest) (*referencedatav1.RetrieveInstrumentResponse, error) {
+	return m.retrieveResp, m.retrieveErr
+}
+
+type mockSagaRegistryClient struct {
+	listResp *sagav1.ListSagasResponse
+	listErr  error
+	getResp  *sagav1.GetSagaResponse
+	getErr   error
+}
+
+func (m *mockSagaRegistryClient) ListSagas(_ context.Context, _ *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error) {
+	return m.listResp, m.listErr
+}
+
+func (m *mockSagaRegistryClient) GetSaga(_ context.Context, _ *sagav1.GetSagaRequest) (*sagav1.GetSagaResponse, error) {
+	return m.getResp, m.getErr
+}
+
+type mockMarketInformationClient struct {
+	listDataSetsResp     *marketinformationv1.ListDataSetsResponse
+	listDataSetsErr      error
+	listObservationsResp *marketinformationv1.ListObservationsResponse
+	listObservationsErr  error
+}
+
+func (m *mockMarketInformationClient) ListDataSets(_ context.Context, _ *marketinformationv1.ListDataSetsRequest) (*marketinformationv1.ListDataSetsResponse, error) {
+	return m.listDataSetsResp, m.listDataSetsErr
+}
+
+func (m *mockMarketInformationClient) ListObservations(_ context.Context, _ *marketinformationv1.ListObservationsRequest) (*marketinformationv1.ListObservationsResponse, error) {
+	return m.listObservationsResp, m.listObservationsErr
+}
+
+// ---- helpers ----
+
+func mustRegisterRefdata(t *testing.T, deps tools.ReferenceDataDeps) *tools.Registry {
+	t.Helper()
+	r := tools.NewRegistry()
+	if err := tools.RegisterReferenceDataTools(r, deps); err != nil {
+		t.Fatalf("RegisterReferenceDataTools: %v", err)
+	}
+	return r
+}
+
+func callTool(t *testing.T, r *tools.Registry, name string, params string) interface{} {
+	t.Helper()
+	result, err := r.Call(context.Background(), name, json.RawMessage(params))
+	if err != nil {
+		t.Fatalf("Call(%q): %v", name, err)
+	}
+	return result
+}
+
+func resultMap(t *testing.T, result interface{}) map[string]interface{} {
+	t.Helper()
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map[string]interface{}, got %T", result)
+	}
+	return m
+}
+
+// assertErrorResult asserts that the result represents an error response.
+// It accepts either a map[string]interface{} with valid=false, or a mcperrors.FormattedError.
+func assertErrorResult(t *testing.T, result interface{}) {
+	t.Helper()
+	switch v := result.(type) {
+	case map[string]interface{}:
+		valid, _ := v["valid"].(bool)
+		if valid {
+			t.Error("expected valid=false, got valid=true in map result")
+		}
+	case mcperrors.FormattedError:
+		if v.Valid {
+			t.Error("expected Valid=false, got Valid=true in FormattedError")
+		}
+	default:
+		t.Errorf("expected error result (map or FormattedError), got %T", result)
+	}
+}
+
+func buildTestManifest() *controlplanev1.Manifest {
+	return &controlplanev1.Manifest{
+		Version: "1.0",
+		Metadata: &controlplanev1.ManifestMetadata{
+			Name:        "Test Economy",
+			Industry:    "energy",
+			Description: "Test manifest",
+		},
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{
+				Code: "GBP",
+				Name: "British Pound",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "GBP",
+					Precision: 2,
+				},
+			},
+			{
+				Code: "KWH",
+				Name: "Kilowatt Hour",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "kWh",
+					Precision: 3,
+				},
+			},
+		},
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{
+				Code:          "CURRENT",
+				Name:          "Current Account",
+				NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_CREDIT,
+				Policies: &controlplanev1.AccountTypePolicies{
+					Validation: "amount > 0",
+					Bucketing:  "instrument_code",
+				},
+			},
+		},
+		ValuationRules: []*controlplanev1.ValuationRule{
+			{
+				FromInstrument: "KWH",
+				ToInstrument:   "GBP",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_SPOT_RATE,
+				Source:         "nordpool",
+			},
+		},
+		Sagas: []*controlplanev1.SagaDefinition{
+			{
+				Name:    "process_payment",
+				Trigger: "api:/v1/payments",
+				Script:  "# saga script",
+			},
+			{
+				Name:    "daily_reconcile",
+				Trigger: "scheduled:daily_reconciliation",
+				Script:  "# reconcile script",
+			},
+		},
+	}
+}
+
+// ---- RegisterReferenceDataTools ----
+
+func TestRegisterReferenceDataTools_RegistersAllTools(t *testing.T) {
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{})
+	listed := r.List()
+
+	expectedNames := []string{
+		"meridian_economy_structure",
+		"meridian_instrument_describe",
+		"meridian_instruments_list",
+		"meridian_market_data_query",
+		"meridian_saga_describe",
+		"meridian_sagas_list",
+		"meridian_handlers_describe",
+	}
+	nameSet := make(map[string]bool, len(listed))
+	for _, t := range listed {
+		nameSet[t.Name] = true
+	}
+	for _, name := range expectedNames {
+		if !nameSet[name] {
+			t.Errorf("expected tool %q to be registered", name)
+		}
+	}
+}
+
+func TestRegisterReferenceDataTools_AllCategoryRead(t *testing.T) {
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{})
+	for _, tool := range r.List() {
+		if tool.Category != tools.CategoryRead {
+			t.Errorf("tool %q has category %v, want CategoryRead", tool.Name, tool.Category)
+		}
+	}
+}
+
+// ---- meridian_economy_structure ----
+
+func TestEconomyStructure_ValidManifest(t *testing.T) {
+	manifest := buildTestManifest()
+	client := &mockManifestHistoryClient{
+		resp: &controlplanev1.GetCurrentManifestResponse{
+			Version: &controlplanev1.ManifestVersion{
+				Version:  "1.0",
+				Manifest: manifest,
+			},
+		},
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{ManifestHistory: client})
+
+	result := callTool(t, r, "meridian_economy_structure", `{}`)
+	m := resultMap(t, result)
+
+	if m["version"] != "1.0" {
+		t.Errorf("expected version 1.0, got %v", m["version"])
+	}
+
+	economy, ok := m["economy"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected economy map")
+	}
+
+	instruments, ok := economy["instruments"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected instruments map in economy")
+	}
+	if instruments["count"] != 2 {
+		t.Errorf("expected 2 instruments, got %v", instruments["count"])
+	}
+
+	sagas, ok := economy["sagas"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected sagas map in economy")
+	}
+	if sagas["count"] != 2 {
+		t.Errorf("expected 2 sagas, got %v", sagas["count"])
+	}
+}
+
+func TestEconomyStructure_NoManifest(t *testing.T) {
+	client := &mockManifestHistoryClient{
+		resp: &controlplanev1.GetCurrentManifestResponse{},
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{ManifestHistory: client})
+
+	result := callTool(t, r, "meridian_economy_structure", `{}`)
+	m := resultMap(t, result)
+
+	if m["status"] != "no_manifest" {
+		t.Errorf("expected status no_manifest, got %v", m["status"])
+	}
+}
+
+func TestEconomyStructure_GRPCError(t *testing.T) {
+	client := &mockManifestHistoryClient{
+		err: errors.New("rpc error: connection refused"),
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{ManifestHistory: client})
+
+	result := callTool(t, r, "meridian_economy_structure", `{}`)
+	assertErrorResult(t, result)
+}
+
+func TestEconomyStructure_NilClient(t *testing.T) {
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{ManifestHistory: nil})
+
+	result := callTool(t, r, "meridian_economy_structure", `{}`)
+	assertErrorResult(t, result)
+}
+
+// ---- meridian_instruments_list ----
+
+func TestInstrumentsList_ValidQuery(t *testing.T) {
+	client := &mockReferenceDataClient{
+		listResp: &referencedatav1.ListInstrumentsResponse{
+			Instruments: []*referencedatav1.InstrumentDefinition{
+				{
+					Id:          "uuid-1",
+					Code:        "USD",
+					Version:     1,
+					Dimension:   referencedatav1.Dimension_DIMENSION_CURRENCY,
+					Precision:   2,
+					Status:      referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+					DisplayName: "US Dollar",
+					IsSystem:    true,
+				},
+				{
+					Id:          "uuid-2",
+					Code:        "KWH",
+					Version:     1,
+					Dimension:   referencedatav1.Dimension_DIMENSION_ENERGY,
+					Precision:   3,
+					Status:      referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+					DisplayName: "Kilowatt Hour",
+				},
+			},
+		},
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{ReferenceData: client})
+
+	result := callTool(t, r, "meridian_instruments_list", `{}`)
+	m := resultMap(t, result)
+
+	if m["count"] != 2 {
+		t.Errorf("expected count=2, got %v", m["count"])
+	}
+
+	instruments, ok := m["instruments"].([]map[string]interface{})
+	if !ok {
+		t.Fatal("expected instruments slice")
+	}
+	if instruments[0]["code"] != "USD" {
+		t.Errorf("expected first instrument code USD, got %v", instruments[0]["code"])
+	}
+}
+
+func TestInstrumentsList_WithStatusFilter(t *testing.T) {
+	client := &mockReferenceDataClient{
+		listResp: &referencedatav1.ListInstrumentsResponse{
+			Instruments: []*referencedatav1.InstrumentDefinition{},
+		},
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{ReferenceData: client})
+
+	// Valid status filter does not error
+	result := callTool(t, r, "meridian_instruments_list", `{"status_filter":"ACTIVE"}`)
+	m := resultMap(t, result)
+	if m["count"] != 0 {
+		t.Errorf("expected count=0, got %v", m["count"])
+	}
+}
+
+func TestInstrumentsList_InvalidParams(t *testing.T) {
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{})
+
+	// Invalid JSON params should return validation error from registry (not reach handler)
+	_, err := r.Call(context.Background(), "meridian_instruments_list", json.RawMessage(`{invalid json`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON params")
+	}
+}
+
+func TestInstrumentsList_GRPCError(t *testing.T) {
+	client := &mockReferenceDataClient{
+		listErr: errors.New("rpc error: unavailable"),
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{ReferenceData: client})
+
+	result := callTool(t, r, "meridian_instruments_list", `{}`)
+	assertErrorResult(t, result)
+}
+
+// ---- meridian_instrument_describe ----
+
+func TestInstrumentDescribe_ValidRequest(t *testing.T) {
+	now := timestamppb.Now()
+	client := &mockReferenceDataClient{
+		retrieveResp: &referencedatav1.RetrieveInstrumentResponse{
+			Instrument: &referencedatav1.InstrumentDefinition{
+				Id:                       "uuid-123",
+				Code:                     "USD",
+				Version:                  1,
+				Dimension:                referencedatav1.Dimension_DIMENSION_CURRENCY,
+				Precision:                2,
+				Status:                   referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+				DisplayName:              "US Dollar",
+				Description:              "United States Dollar",
+				ValidationExpression:     "amount > 0",
+				FungibilityKeyExpression: "instrument_code",
+				ErrorMessageExpression:   "'invalid amount'",
+				AttributeSchema:          `{"type":"object"}`,
+				IsSystem:                 true,
+				CreatedAt:                now,
+				ActivatedAt:              now,
+			},
+		},
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{ReferenceData: client})
+
+	result := callTool(t, r, "meridian_instrument_describe", `{"code":"USD"}`)
+	m := resultMap(t, result)
+
+	if m["code"] != "USD" {
+		t.Errorf("expected code=USD, got %v", m["code"])
+	}
+	if m["validation_expression"] != "amount > 0" {
+		t.Errorf("expected validation_expression set, got %v", m["validation_expression"])
+	}
+	if m["created_at"] == "" || m["created_at"] == nil {
+		t.Error("expected created_at to be set")
+	}
+}
+
+func TestInstrumentDescribe_MissingCode(t *testing.T) {
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{})
+
+	result := callTool(t, r, "meridian_instrument_describe", `{}`)
+	assertErrorResult(t, result)
+}
+
+func TestInstrumentDescribe_GRPCError(t *testing.T) {
+	client := &mockReferenceDataClient{
+		retrieveErr: errors.New("rpc error: not found"),
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{ReferenceData: client})
+
+	result := callTool(t, r, "meridian_instrument_describe", `{"code":"NONEXISTENT"}`)
+	assertErrorResult(t, result)
+}
+
+// ---- meridian_sagas_list ----
+
+func TestSagasList_ValidQuery(t *testing.T) {
+	client := &mockSagaRegistryClient{
+		listResp: &sagav1.ListSagasResponse{
+			Sagas: []*sagav1.SagaDefinition{
+				{
+					Id:          "saga-uuid-1",
+					Name:        "process_payment",
+					Version:     1,
+					Status:      sagav1.SagaStatus_SAGA_STATUS_ACTIVE,
+					IsSystem:    false,
+					DisplayName: "Process Payment",
+					Description: "Handles payment processing",
+				},
+			},
+		},
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{SagaRegistry: client})
+
+	result := callTool(t, r, "meridian_sagas_list", `{}`)
+	m := resultMap(t, result)
+
+	if m["count"] != 1 {
+		t.Errorf("expected count=1, got %v", m["count"])
+	}
+
+	sagas, ok := m["sagas"].([]map[string]interface{})
+	if !ok {
+		t.Fatal("expected sagas slice")
+	}
+	if sagas[0]["name"] != "process_payment" {
+		t.Errorf("expected saga name process_payment, got %v", sagas[0]["name"])
+	}
+}
+
+func TestSagasList_GRPCError(t *testing.T) {
+	client := &mockSagaRegistryClient{
+		listErr: errors.New("rpc error: unavailable"),
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{SagaRegistry: client})
+
+	result := callTool(t, r, "meridian_sagas_list", `{}`)
+	assertErrorResult(t, result)
+}
+
+// ---- meridian_saga_describe ----
+
+func TestSagaDescribe_ByID(t *testing.T) {
+	now := timestamppb.Now()
+	client := &mockSagaRegistryClient{
+		getResp: &sagav1.GetSagaResponse{
+			Saga: &sagav1.SagaDefinition{
+				Id:          "saga-uuid-1",
+				Name:        "process_payment",
+				Version:     1,
+				Status:      sagav1.SagaStatus_SAGA_STATUS_ACTIVE,
+				Script:      "def run():\n  pass",
+				DisplayName: "Process Payment",
+				CreatedAt:   now,
+				ActivatedAt: now,
+			},
+		},
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{SagaRegistry: client})
+
+	result := callTool(t, r, "meridian_saga_describe", `{"id":"saga-uuid-1"}`)
+	m := resultMap(t, result)
+
+	if m["name"] != "process_payment" {
+		t.Errorf("expected name process_payment, got %v", m["name"])
+	}
+	if m["script"] != "def run():\n  pass" {
+		t.Errorf("expected script to be set, got %v", m["script"])
+	}
+}
+
+func TestSagaDescribe_ByName(t *testing.T) {
+	client := &mockSagaRegistryClient{
+		getResp: &sagav1.GetSagaResponse{
+			Saga: &sagav1.SagaDefinition{
+				Id:     "saga-uuid-1",
+				Name:   "process_payment",
+				Status: sagav1.SagaStatus_SAGA_STATUS_ACTIVE,
+			},
+		},
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{SagaRegistry: client})
+
+	result := callTool(t, r, "meridian_saga_describe", `{"name":"process_payment"}`)
+	m := resultMap(t, result)
+
+	if m["name"] != "process_payment" {
+		t.Errorf("expected saga name, got %v", m["name"])
+	}
+}
+
+func TestSagaDescribe_MissingIDAndName(t *testing.T) {
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{})
+
+	result := callTool(t, r, "meridian_saga_describe", `{}`)
+	assertErrorResult(t, result)
+}
+
+func TestSagaDescribe_GRPCError(t *testing.T) {
+	client := &mockSagaRegistryClient{
+		getErr: errors.New("rpc error: not found"),
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{SagaRegistry: client})
+
+	result := callTool(t, r, "meridian_saga_describe", `{"name":"nonexistent"}`)
+	assertErrorResult(t, result)
+}
+
+// ---- meridian_handlers_describe ----
+
+func TestHandlersDescribe_ValidManifest(t *testing.T) {
+	manifest := buildTestManifest()
+	client := &mockManifestHistoryClient{
+		resp: &controlplanev1.GetCurrentManifestResponse{
+			Version: &controlplanev1.ManifestVersion{
+				Version:  "1.0",
+				Manifest: manifest,
+			},
+		},
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{ManifestHistory: client})
+
+	result := callTool(t, r, "meridian_handlers_describe", `{}`)
+	m := resultMap(t, result)
+
+	triggerCount, _ := m["saga_trigger_count"].(int)
+	if triggerCount != 2 {
+		t.Errorf("expected 2 saga triggers, got %v", m["saga_trigger_count"])
+	}
+
+	policyCount, _ := m["policy_count"].(int)
+	if policyCount != 1 {
+		t.Errorf("expected 1 account type policy, got %v", m["policy_count"])
+	}
+}
+
+func TestHandlersDescribe_TriggerFilter(t *testing.T) {
+	manifest := buildTestManifest()
+	client := &mockManifestHistoryClient{
+		resp: &controlplanev1.GetCurrentManifestResponse{
+			Version: &controlplanev1.ManifestVersion{
+				Version:  "1.0",
+				Manifest: manifest,
+			},
+		},
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{ManifestHistory: client})
+
+	// Filter by "api" trigger only - should return 1 of the 2 sagas
+	result := callTool(t, r, "meridian_handlers_describe", `{"trigger_prefix":"api"}`)
+	m := resultMap(t, result)
+
+	triggerCount, _ := m["saga_trigger_count"].(int)
+	if triggerCount != 1 {
+		t.Errorf("expected 1 api saga trigger, got %v", m["saga_trigger_count"])
+	}
+}
+
+func TestHandlersDescribe_GRPCError(t *testing.T) {
+	client := &mockManifestHistoryClient{
+		err: errors.New("rpc error: unavailable"),
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{ManifestHistory: client})
+
+	result := callTool(t, r, "meridian_handlers_describe", `{}`)
+	assertErrorResult(t, result)
+}
+
+// ---- meridian_market_data_query ----
+
+func TestMarketDataQuery_ListDatasets(t *testing.T) {
+	client := &mockMarketInformationClient{
+		listDataSetsResp: &marketinformationv1.ListDataSetsResponse{
+			Datasets: []*marketinformationv1.DataSetDefinition{
+				{
+					Id:          "ds-uuid-1",
+					Code:        "USD_EUR_FX",
+					Version:     1,
+					Category:    marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+					Unit:        "USD/EUR",
+					Status:      marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+					DisplayName: "USD to EUR FX Rate",
+				},
+			},
+		},
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{MarketInformation: client})
+
+	result := callTool(t, r, "meridian_market_data_query", `{}`)
+	m := resultMap(t, result)
+
+	if m["count"] != 1 {
+		t.Errorf("expected count=1, got %v", m["count"])
+	}
+
+	datasets, ok := m["datasets"].([]map[string]interface{})
+	if !ok {
+		t.Fatal("expected datasets slice")
+	}
+	if datasets[0]["code"] != "USD_EUR_FX" {
+		t.Errorf("expected dataset code USD_EUR_FX, got %v", datasets[0]["code"])
+	}
+}
+
+func TestMarketDataQuery_ListObservations(t *testing.T) {
+	now := timestamppb.Now()
+	client := &mockMarketInformationClient{
+		listObservationsResp: &marketinformationv1.ListObservationsResponse{
+			Observations: []*marketinformationv1.MarketPriceObservation{
+				{
+					Id:                 "obs-uuid-1",
+					DatasetCode:        "USD_EUR_FX",
+					DatasetVersion:     1,
+					ResolutionKeyValue: "spot",
+					Value:              "1.0823",
+					Quality:            marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+					ObservedAt:         now,
+					ValidFrom:          now,
+				},
+			},
+		},
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{MarketInformation: client})
+
+	result := callTool(t, r, "meridian_market_data_query", `{"dataset_code":"USD_EUR_FX"}`)
+	m := resultMap(t, result)
+
+	if m["dataset_code"] != "USD_EUR_FX" {
+		t.Errorf("expected dataset_code=USD_EUR_FX, got %v", m["dataset_code"])
+	}
+	if m["count"] != 1 {
+		t.Errorf("expected count=1, got %v", m["count"])
+	}
+
+	observations, ok := m["observations"].([]map[string]interface{})
+	if !ok {
+		t.Fatal("expected observations slice")
+	}
+	if observations[0]["value"] != "1.0823" {
+		t.Errorf("expected value=1.0823, got %v", observations[0]["value"])
+	}
+}
+
+func TestMarketDataQuery_GRPCErrorListDatasets(t *testing.T) {
+	client := &mockMarketInformationClient{
+		listDataSetsErr: errors.New("rpc error: unavailable"),
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{MarketInformation: client})
+
+	result := callTool(t, r, "meridian_market_data_query", `{}`)
+	assertErrorResult(t, result)
+}
+
+func TestMarketDataQuery_GRPCErrorListObservations(t *testing.T) {
+	client := &mockMarketInformationClient{
+		listObservationsErr: errors.New("rpc error: not found"),
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{MarketInformation: client})
+
+	result := callTool(t, r, "meridian_market_data_query", `{"dataset_code":"USD_EUR_FX"}`)
+	assertErrorResult(t, result)
+}
+
+func TestMarketDataQuery_NilClient(t *testing.T) {
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{MarketInformation: nil})
+
+	result := callTool(t, r, "meridian_market_data_query", `{}`)
+	assertErrorResult(t, result)
+}

--- a/services/mcp-server/internal/tools/refdata_test.go
+++ b/services/mcp-server/internal/tools/refdata_test.go
@@ -106,9 +106,17 @@ func assertErrorResult(t *testing.T, result interface{}) {
 	t.Helper()
 	switch v := result.(type) {
 	case map[string]interface{}:
-		valid, _ := v["valid"].(bool)
-		if valid {
-			t.Error("expected valid=false, got valid=true in map result")
+		validRaw, exists := v["valid"]
+		if !exists {
+			t.Error("expected error map to include 'valid' key")
+			return
+		}
+		valid, ok := validRaw.(bool)
+		if !ok || valid {
+			t.Error("expected valid=false in map result")
+		}
+		if _, ok := v["errors"]; !ok {
+			t.Error("expected error map to include 'errors' key")
 		}
 	case mcperrors.FormattedError:
 		if v.Valid {
@@ -324,12 +332,15 @@ func TestInstrumentsList_ValidQuery(t *testing.T) {
 	m := resultMap(t, result)
 
 	if m["count"] != 2 {
-		t.Errorf("expected count=2, got %v", m["count"])
+		t.Fatalf("expected count=2, got %v", m["count"])
 	}
 
 	instruments, ok := m["instruments"].([]map[string]interface{})
 	if !ok {
 		t.Fatal("expected instruments slice")
+	}
+	if len(instruments) == 0 {
+		t.Fatal("expected at least one instrument")
 	}
 	if instruments[0]["code"] != "USD" {
 		t.Errorf("expected first instrument code USD, got %v", instruments[0]["code"])


### PR DESCRIPTION
## Summary

- Implements `RegisterReferenceDataTools` in `services/mcp-server/internal/tools/refdata.go`
- Adds 7 read-only MCP tools for querying reference data via gRPC service clients
- All tools registered under `CategoryRead` with JSON Schema input validation

## Changes Made

**New file: `services/mcp-server/internal/tools/refdata.go`**
- `ManifestHistoryClient`, `ReferenceDataClient`, `SagaRegistryClient`, `MarketInformationClient` interfaces for gRPC dependency injection
- `ReferenceDataDeps` struct collecting all four clients
- `RegisterReferenceDataTools(registry *Registry, deps ReferenceDataDeps) error`
- 7 tool builders:
  - `meridian_economy_structure` — tenant economy layout from current manifest
  - `meridian_instruments_list` — list instruments with optional status/page_size filter
  - `meridian_instrument_describe` — full instrument details by code + optional version
  - `meridian_sagas_list` — list sagas with status, exclude_system, page_size filters
  - `meridian_saga_describe` — full saga details by ID or name + optional version
  - `meridian_handlers_describe` — saga triggers and account type CEL policies from manifest
  - `meridian_market_data_query` — list datasets or observations for a specific dataset

**New file: `services/mcp-server/internal/tools/refdata_test.go`**
- Mock implementations for all 4 client interfaces
- Tests for each tool: happy path, nil client, gRPC error, invalid/missing parameters

## Technical Details

- Tool errors are returned as structured results (`map[string]interface{}` or `mcperrors.FormattedError`), not Go errors — consistent with MCP handler contract
- JSON unmarshal errors suppressed as Go errors via `//nolint:nilerr` (encoded in result)
- Helper functions extracted (`extractSagaTriggers`, `extractAccountTypePolicies`, `queryObservations`, `queryDatasets`) to keep cognitive complexity within linter limits
- Status constants (`statusActive`, `statusDraft`, `statusDeprecated`) used throughout to satisfy `goconst`

## Testing

All 40 tests pass (27 new + 13 existing registry tests):

```
ok  github.com/meridianhub/meridian/services/mcp-server/internal/tools  0.709s
```