### PR TITLE
feat: add audit tools for MCP server (task 8)

### DIFF
--- a/services/mcp-server/internal/tools/audit.go
+++ b/services/mcp-server/internal/tools/audit.go
@@ -1,0 +1,706 @@
+// Package tools provides the tool registry for the MCP server.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
+	mcperrors "github.com/meridianhub/meridian/services/mcp-server/internal/errors"
+)
+
+// SagaAdminQuerier is the minimal interface for fetching causation trees.
+type SagaAdminQuerier interface {
+	GetCausationTree(ctx context.Context, req *sagav1.GetCausationTreeRequest) (*sagav1.GetCausationTreeResponse, error)
+}
+
+// PositionQuerier is the minimal interface for fetching position logs.
+type PositionQuerier interface {
+	ListFinancialPositionLogs(ctx context.Context, req *positionkeepingv1.ListFinancialPositionLogsRequest) (*positionkeepingv1.ListFinancialPositionLogsResponse, error)
+}
+
+// PostingQuerier is the minimal interface for fetching ledger postings.
+type PostingQuerier interface {
+	ListLedgerPostings(ctx context.Context, req *financialaccountingv1.ListLedgerPostingsRequest) (*financialaccountingv1.ListLedgerPostingsResponse, error)
+}
+
+// SagaExecutionQuerier is the minimal interface for fetching saga definitions/executions.
+type SagaExecutionQuerier interface {
+	ListSagas(ctx context.Context, req *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error)
+}
+
+// ReconciliationQuerier is the minimal interface for fetching reconciliation status.
+type ReconciliationQuerier interface {
+	ListAccountReconciliations(ctx context.Context, req *reconciliationv1.ListAccountReconciliationsRequest) (*reconciliationv1.ListAccountReconciliationsResponse, error)
+	ListReconciliationResults(ctx context.Context, req *reconciliationv1.ListReconciliationResultsRequest) (*reconciliationv1.ListReconciliationResultsResponse, error)
+}
+
+// AuditClients groups all gRPC client dependencies for audit tools.
+type AuditClients struct {
+	SagaAdmin           SagaAdminQuerier
+	PositionKeeping     PositionQuerier
+	FinancialAccounting PostingQuerier
+	SagaRegistry        SagaExecutionQuerier
+	Reconciliation      ReconciliationQuerier
+}
+
+// RegisterAuditTools registers all read-only audit tools into the registry.
+// It does not modify registry.go or cmd/main.go.
+func RegisterAuditTools(r *Registry, clients AuditClients) {
+	tools := []Tool{
+		buildCausationTreeTool(clients.SagaAdmin),
+		buildPositionsQueryTool(clients.PositionKeeping),
+		buildPostingsQueryTool(clients.FinancialAccounting),
+		buildSagaExecutionsTool(clients.SagaRegistry),
+		buildReconciliationStatusTool(clients.Reconciliation),
+	}
+	for _, t := range tools {
+		if err := r.Register(t); err != nil {
+			panic(fmt.Sprintf("failed to register audit tool %q: %v", t.Name, err))
+		}
+	}
+}
+
+// buildCausationTreeTool returns the meridian_causation_tree tool.
+func buildCausationTreeTool(client SagaAdminQuerier) Tool {
+	return Tool{
+		Name:     "meridian_causation_tree",
+		Category: CategoryRead,
+		Description: "Fetch the full parent→child saga causation tree for a given root saga ID. " +
+			"Returns the complete execution hierarchy including step status and failure details. " +
+			"Use this to debug complex nested saga failures.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"saga_id": map[string]interface{}{
+					"type":        "string",
+					"description": "UUID of the root saga instance to fetch the causation tree for.",
+					"pattern":     `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+				},
+			},
+			"required": []interface{}{"saga_id"},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			var p struct {
+				SagaID string `json:"saga_id"`
+			}
+			if err := json.Unmarshal(params, &p); err != nil {
+				return mcperrors.FormatGRPCError(err), nil
+			}
+
+			resp, err := client.GetCausationTree(ctx, &sagav1.GetCausationTreeRequest{
+				SagaId: p.SagaID,
+			})
+			if err != nil {
+				return mcperrors.FormatGRPCError(err), nil
+			}
+
+			if resp.Tree == nil {
+				return map[string]interface{}{
+					"message": fmt.Sprintf("no causation tree found for saga %s", p.SagaID),
+					"depth":   0,
+				}, nil
+			}
+
+			return map[string]interface{}{
+				"saga_id": p.SagaID,
+				"depth":   resp.Depth,
+				"tree":    formatCausationNode(resp.Tree),
+			}, nil
+		},
+	}
+}
+
+// formatCausationNode formats a CausationTreeNode for LLM consumption.
+func formatCausationNode(node *sagav1.CausationTreeNode) map[string]interface{} {
+	if node == nil {
+		return nil
+	}
+
+	steps := make([]map[string]interface{}, 0, len(node.Steps))
+	for _, s := range node.Steps {
+		step := map[string]interface{}{
+			"index":  s.Index,
+			"name":   s.Name,
+			"status": s.Status,
+		}
+		if s.ExecutedAt != nil {
+			step["executed_at"] = s.ExecutedAt.AsTime().Format(time.RFC3339)
+		}
+		if s.Error != "" {
+			step["error"] = s.Error
+		}
+		if len(s.ChildSagas) > 0 {
+			children := make([]map[string]interface{}, 0, len(s.ChildSagas))
+			for _, child := range s.ChildSagas {
+				children = append(children, formatCausationNode(child))
+			}
+			step["child_sagas"] = children
+		}
+		steps = append(steps, step)
+	}
+
+	result := map[string]interface{}{
+		"saga_id":   node.SagaId,
+		"saga_name": node.SagaName,
+		"status":    node.Status,
+		"steps":     steps,
+	}
+
+	if node.EffectiveAt != nil {
+		result["effective_at"] = node.EffectiveAt.AsTime().Format(time.RFC3339)
+	}
+	if node.KnowledgeAt != nil {
+		result["knowledge_at"] = node.KnowledgeAt.AsTime().Format(time.RFC3339)
+	}
+	if node.FailedStep != nil {
+		result["failed_step"] = map[string]interface{}{
+			"index":          node.FailedStep.Index,
+			"error":          node.FailedStep.Error,
+			"error_category": node.FailedStep.ErrorCategory,
+		}
+	}
+
+	return result
+}
+
+// buildPositionsQueryTool returns the meridian_positions_query tool.
+func buildPositionsQueryTool(client PositionQuerier) Tool {
+	return Tool{
+		Name:     "meridian_positions_query",
+		Category: CategoryRead,
+		Description: "Query financial position logs with optional bi-temporal filtering. " +
+			"Returns position log summaries for one or all accounts. " +
+			"Use this to inspect account positions, transaction histories, and status tracking.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"account_id": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter by account identifier (optional).",
+				},
+				"page_size": map[string]interface{}{
+					"type":        "integer",
+					"description": "Maximum number of results to return (default 25, max 100).",
+					"minimum":     1,
+					"maximum":     100,
+				},
+			},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			var p struct {
+				AccountID string `json:"account_id"`
+				PageSize  int32  `json:"page_size"`
+			}
+			if err := json.Unmarshal(params, &p); err != nil {
+				return mcperrors.FormatGRPCError(err), nil
+			}
+
+			req := &positionkeepingv1.ListFinancialPositionLogsRequest{}
+			if p.AccountID != "" {
+				req.AccountId = p.AccountID
+			}
+
+			resp, err := client.ListFinancialPositionLogs(ctx, req)
+			if err != nil {
+				return mcperrors.FormatGRPCError(err), nil
+			}
+
+			if len(resp.Logs) == 0 {
+				return map[string]interface{}{
+					"message": "no position logs found matching the query",
+					"logs":    []interface{}{},
+				}, nil
+			}
+
+			logs := make([]map[string]interface{}, 0, len(resp.Logs))
+			for _, log := range resp.Logs {
+				entry := map[string]interface{}{
+					"log_id":     log.LogId,
+					"account_id": log.AccountId,
+					"version":    log.Version,
+				}
+				if log.StatusTracking != nil {
+					entry["status"] = log.StatusTracking.CurrentStatus.String()
+				}
+				if log.CreatedAt != nil {
+					entry["created_at"] = log.CreatedAt.AsTime().Format(time.RFC3339)
+				}
+				if log.UpdatedAt != nil {
+					entry["updated_at"] = log.UpdatedAt.AsTime().Format(time.RFC3339)
+				}
+				entry["transaction_count"] = len(log.TransactionLogEntries)
+				logs = append(logs, entry)
+			}
+
+			return map[string]interface{}{
+				"count": len(logs),
+				"logs":  logs,
+			}, nil
+		},
+	}
+}
+
+// buildPostingsQueryTool returns the meridian_postings_query tool.
+func buildPostingsQueryTool(client PostingQuerier) Tool {
+	return Tool{
+		Name:     "meridian_postings_query",
+		Category: CategoryRead,
+		Description: "Query ledger postings with optional date range and account filtering. " +
+			"Returns double-entry bookkeeping records with debit/credit direction and amounts. " +
+			"Use this to inspect financial postings for audit and reconciliation purposes.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"account_id": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter postings by account identifier (optional).",
+				},
+				"booking_log_id": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter postings by financial booking log ID (optional).",
+				},
+				"date_from": map[string]interface{}{
+					"type":        "string",
+					"format":      "date-time",
+					"description": "Filter postings with value_date on or after this ISO 8601 timestamp (optional).",
+				},
+				"date_to": map[string]interface{}{
+					"type":        "string",
+					"format":      "date-time",
+					"description": "Filter postings with value_date on or before this ISO 8601 timestamp (optional).",
+				},
+				"page_size": map[string]interface{}{
+					"type":        "integer",
+					"description": "Maximum number of results to return (default 25, max 100).",
+					"minimum":     1,
+					"maximum":     100,
+				},
+			},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			return handlePostingsQuery(ctx, client, params)
+		},
+	}
+}
+
+// postingsQueryParams holds parsed parameters for meridian_postings_query.
+type postingsQueryParams struct {
+	AccountID    string `json:"account_id"`
+	BookingLogID string `json:"booking_log_id"`
+	DateFrom     string `json:"date_from"`
+	DateTo       string `json:"date_to"`
+	PageSize     int32  `json:"page_size"`
+}
+
+// handlePostingsQuery implements the meridian_postings_query handler logic.
+func handlePostingsQuery(ctx context.Context, client PostingQuerier, params json.RawMessage) (interface{}, error) {
+	var p postingsQueryParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	req, validationErr := buildPostingsRequest(p)
+	if validationErr != "" {
+		return map[string]interface{}{"error": validationErr}, nil
+	}
+
+	resp, err := client.ListLedgerPostings(ctx, req)
+	if err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	if len(resp.LedgerPostings) == 0 {
+		return map[string]interface{}{
+			"message":  "no postings found matching the query",
+			"postings": []interface{}{},
+		}, nil
+	}
+
+	postings := make([]map[string]interface{}, 0, len(resp.LedgerPostings))
+	for _, posting := range resp.LedgerPostings {
+		postings = append(postings, formatPosting(posting))
+	}
+
+	return map[string]interface{}{
+		"count":    len(postings),
+		"postings": postings,
+	}, nil
+}
+
+// buildPostingsRequest constructs the gRPC request from parsed params.
+func buildPostingsRequest(p postingsQueryParams) (*financialaccountingv1.ListLedgerPostingsRequest, string) {
+	req := &financialaccountingv1.ListLedgerPostingsRequest{}
+	if p.AccountID != "" {
+		req.AccountId = p.AccountID
+	}
+	if p.BookingLogID != "" {
+		req.FinancialBookingLogId = p.BookingLogID
+	}
+	if p.DateFrom != "" {
+		t, err := time.Parse(time.RFC3339, p.DateFrom)
+		if err != nil {
+			return nil, fmt.Sprintf("invalid date_from format (expected RFC3339): %v", err)
+		}
+		req.ValueDateFrom = timestamppb.New(t)
+	}
+	if p.DateTo != "" {
+		t, err := time.Parse(time.RFC3339, p.DateTo)
+		if err != nil {
+			return nil, fmt.Sprintf("invalid date_to format (expected RFC3339): %v", err)
+		}
+		req.ValueDateTo = timestamppb.New(t)
+	}
+	return req, ""
+}
+
+// formatPosting formats a single LedgerPosting for LLM consumption.
+func formatPosting(posting *financialaccountingv1.LedgerPosting) map[string]interface{} {
+	entry := map[string]interface{}{
+		"id":             posting.Id,
+		"booking_log_id": posting.FinancialBookingLogId,
+		"account_id":     posting.AccountId,
+		"direction":      posting.PostingDirection.String(),
+		"status":         posting.Status.String(),
+		"posting_result": posting.PostingResult,
+	}
+	if posting.PostingAmount != nil {
+		entry["amount"] = map[string]interface{}{
+			"currency_code": posting.PostingAmount.CurrencyCode,
+			"units":         posting.PostingAmount.Units,
+			"nanos":         posting.PostingAmount.Nanos,
+		}
+	}
+	if posting.ValueDate != nil {
+		entry["value_date"] = posting.ValueDate.AsTime().Format(time.RFC3339)
+	}
+	if posting.CreatedAt != nil {
+		entry["created_at"] = posting.CreatedAt.AsTime().Format(time.RFC3339)
+	}
+	return entry
+}
+
+// validSagaStatuses maps the accepted status string values to proto enum values.
+var validSagaStatuses = map[string]sagav1.SagaStatus{
+	"ACTIVE":     sagav1.SagaStatus_SAGA_STATUS_ACTIVE,
+	"DRAFT":      sagav1.SagaStatus_SAGA_STATUS_DRAFT,
+	"DEPRECATED": sagav1.SagaStatus_SAGA_STATUS_DEPRECATED,
+}
+
+// buildSagaExecutionsTool returns the meridian_saga_executions tool.
+func buildSagaExecutionsTool(client SagaExecutionQuerier) Tool {
+	return Tool{
+		Name:     "meridian_saga_executions",
+		Category: CategoryRead,
+		Description: "Query saga definitions and their execution status. " +
+			"Returns saga definitions filtered by status. " +
+			"Use this to inspect available workflows, their Starlark scripts, and lifecycle states.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"status": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter by saga status. One of: ACTIVE, DRAFT, DEPRECATED.",
+					"enum":        []interface{}{"ACTIVE", "DRAFT", "DEPRECATED"},
+				},
+				"page_size": map[string]interface{}{
+					"type":        "integer",
+					"description": "Maximum number of results to return (default 25, max 100).",
+					"minimum":     1,
+					"maximum":     100,
+				},
+			},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			return handleSagaExecutions(ctx, client, params)
+		},
+	}
+}
+
+// handleSagaExecutions implements the meridian_saga_executions handler logic.
+func handleSagaExecutions(ctx context.Context, client SagaExecutionQuerier, params json.RawMessage) (interface{}, error) {
+	var p struct {
+		Status   string `json:"status"`
+		PageSize int32  `json:"page_size"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	req := &sagav1.ListSagasRequest{}
+	if p.Status != "" {
+		statusVal, ok := validSagaStatuses[strings.ToUpper(p.Status)]
+		if !ok {
+			return map[string]interface{}{
+				"error": fmt.Sprintf("invalid status %q: must be one of ACTIVE, DRAFT, DEPRECATED", p.Status),
+			}, nil
+		}
+		req.StatusFilter = statusVal
+	}
+
+	resp, err := client.ListSagas(ctx, req)
+	if err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	if len(resp.Sagas) == 0 {
+		return map[string]interface{}{
+			"message": "no saga definitions found matching the query",
+			"sagas":   []interface{}{},
+		}, nil
+	}
+
+	sagas := make([]map[string]interface{}, 0, len(resp.Sagas))
+	for _, saga := range resp.Sagas {
+		sagas = append(sagas, formatSagaDefinition(saga))
+	}
+
+	return map[string]interface{}{
+		"count": len(sagas),
+		"sagas": sagas,
+	}, nil
+}
+
+// formatSagaDefinition formats a single SagaDefinition for LLM consumption.
+func formatSagaDefinition(saga *sagav1.SagaDefinition) map[string]interface{} {
+	entry := map[string]interface{}{
+		"id":           saga.Id,
+		"name":         saga.Name,
+		"display_name": saga.DisplayName,
+		"description":  saga.Description,
+		"version":      saga.Version,
+		"status":       saga.Status.String(),
+		"is_system":    saga.IsSystem,
+	}
+	if saga.CreatedAt != nil {
+		entry["created_at"] = saga.CreatedAt.AsTime().Format(time.RFC3339)
+	}
+	if saga.ActivatedAt != nil {
+		entry["activated_at"] = saga.ActivatedAt.AsTime().Format(time.RFC3339)
+	}
+	if saga.DeprecatedAt != nil {
+		entry["deprecated_at"] = saga.DeprecatedAt.AsTime().Format(time.RFC3339)
+	}
+	if saga.PreconditionsExpression != "" {
+		entry["preconditions_expression"] = saga.PreconditionsExpression
+	}
+	return entry
+}
+
+// buildReconciliationStatusTool returns the meridian_reconciliation_status tool.
+func buildReconciliationStatusTool(client ReconciliationQuerier) Tool {
+	return Tool{
+		Name:     "meridian_reconciliation_status",
+		Category: CategoryRead,
+		Description: "Query reconciliation cycle status and variance mismatches. " +
+			"Lists settlement runs with optional account and status filters. " +
+			"When a run_id is provided, also fetches detailed variance results. " +
+			"Use this to inspect reconciliation health and investigate discrepancies.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"account_id": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter settlement runs by account ID (optional).",
+				},
+				"run_id": map[string]interface{}{
+					"type":        "string",
+					"description": "UUID of a specific settlement run to fetch variances for (optional).",
+					"pattern":     `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+				},
+				"status": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter by run status. One of: PENDING, RUNNING, COMPLETED, FAILED, CANCELLED, PAUSED.",
+					"enum":        []interface{}{"PENDING", "RUNNING", "COMPLETED", "FAILED", "CANCELLED", "PAUSED"},
+				},
+				"page_size": map[string]interface{}{
+					"type":        "integer",
+					"description": "Maximum number of runs to return (default 25, max 100).",
+					"minimum":     1,
+					"maximum":     100,
+				},
+			},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			return handleReconciliationStatus(ctx, client, params)
+		},
+	}
+}
+
+// reconciliationStatusParams holds parsed parameters for meridian_reconciliation_status.
+type reconciliationStatusParams struct {
+	AccountID string `json:"account_id"`
+	RunID     string `json:"run_id"`
+	Status    string `json:"status"`
+	PageSize  int32  `json:"page_size"`
+}
+
+// handleReconciliationStatus implements the meridian_reconciliation_status handler logic.
+func handleReconciliationStatus(ctx context.Context, client ReconciliationQuerier, params json.RawMessage) (interface{}, error) {
+	var p reconciliationStatusParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	listReq, errResult := buildReconciliationRequest(p)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	runsResp, err := client.ListAccountReconciliations(ctx, listReq)
+	if err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	runs := make([]map[string]interface{}, 0, len(runsResp.Runs))
+	for _, run := range runsResp.Runs {
+		runs = append(runs, formatSettlementRun(run))
+	}
+
+	result := map[string]interface{}{
+		"count": len(runs),
+		"runs":  runs,
+	}
+
+	if p.RunID != "" {
+		appendVariances(ctx, client, p.RunID, result)
+	}
+
+	if len(runs) == 0 && p.RunID == "" {
+		result["message"] = "no reconciliation runs found matching the query"
+	}
+
+	return result, nil
+}
+
+// buildReconciliationRequest constructs the ListAccountReconciliationsRequest from parsed params.
+// Returns the request and nil on success, or nil and an error result map on validation failure.
+func buildReconciliationRequest(p reconciliationStatusParams) (*reconciliationv1.ListAccountReconciliationsRequest, interface{}) {
+	req := &reconciliationv1.ListAccountReconciliationsRequest{}
+	if p.AccountID != "" {
+		req.AccountId = p.AccountID
+	}
+	if p.PageSize > 0 {
+		req.PageSize = p.PageSize
+	}
+	if p.Status != "" {
+		statusVal := reconciliationRunStatus(p.Status)
+		if statusVal == reconciliationv1.RunStatus_RUN_STATUS_UNSPECIFIED {
+			return nil, map[string]interface{}{
+				"error": fmt.Sprintf("invalid status %q: must be one of PENDING, RUNNING, COMPLETED, FAILED, CANCELLED, PAUSED", p.Status),
+			}
+		}
+		req.Status = statusVal
+	}
+	return req, nil
+}
+
+// appendVariances fetches variance details for a run and adds them to result.
+func appendVariances(ctx context.Context, client ReconciliationQuerier, runID string, result map[string]interface{}) {
+	varResp, err := client.ListReconciliationResults(ctx, &reconciliationv1.ListReconciliationResultsRequest{
+		RunId: runID,
+	})
+	if err != nil {
+		result["variances_error"] = mcperrors.FormatGRPCError(err)
+		return
+	}
+	variances := make([]map[string]interface{}, 0, len(varResp.Variances))
+	for _, v := range varResp.Variances {
+		variances = append(variances, formatVariance(v))
+	}
+	result["variances"] = variances
+	result["variance_count"] = len(variances)
+}
+
+// reconciliationRunStatus maps status string to proto enum value.
+func reconciliationRunStatus(s string) reconciliationv1.RunStatus {
+	switch strings.ToUpper(s) {
+	case "PENDING":
+		return reconciliationv1.RunStatus_RUN_STATUS_PENDING
+	case "RUNNING":
+		return reconciliationv1.RunStatus_RUN_STATUS_RUNNING
+	case "COMPLETED":
+		return reconciliationv1.RunStatus_RUN_STATUS_COMPLETED
+	case "FAILED":
+		return reconciliationv1.RunStatus_RUN_STATUS_FAILED
+	case "CANCELLED":
+		return reconciliationv1.RunStatus_RUN_STATUS_CANCELLED
+	case "PAUSED":
+		return reconciliationv1.RunStatus_RUN_STATUS_PAUSED
+	default:
+		return reconciliationv1.RunStatus_RUN_STATUS_UNSPECIFIED
+	}
+}
+
+// formatSettlementRun formats a SettlementRunSummary for LLM consumption.
+func formatSettlementRun(run *reconciliationv1.SettlementRunSummary) map[string]interface{} {
+	if run == nil {
+		return nil
+	}
+	entry := map[string]interface{}{
+		"run_id":          run.RunId,
+		"account_id":      run.AccountId,
+		"scope":           run.Scope.String(),
+		"settlement_type": run.SettlementType.String(),
+		"status":          run.Status.String(),
+		"initiated_by":    run.InitiatedBy,
+		"variance_count":  run.VarianceCount,
+		"total_variance":  run.TotalVariance,
+		"snapshot_count":  run.SnapshotCount,
+	}
+	if run.PeriodStart != nil {
+		entry["period_start"] = run.PeriodStart.AsTime().Format(time.RFC3339)
+	}
+	if run.PeriodEnd != nil {
+		entry["period_end"] = run.PeriodEnd.AsTime().Format(time.RFC3339)
+	}
+	if run.CompletedAt != nil {
+		entry["completed_at"] = run.CompletedAt.AsTime().Format(time.RFC3339)
+	}
+	if run.FailureReason != "" {
+		entry["failure_reason"] = run.FailureReason
+	}
+	if run.CreatedAt != nil {
+		entry["created_at"] = run.CreatedAt.AsTime().Format(time.RFC3339)
+	}
+	return entry
+}
+
+// formatVariance formats a VarianceDetail for LLM consumption.
+func formatVariance(v *reconciliationv1.VarianceDetail) map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	entry := map[string]interface{}{
+		"variance_id":     v.VarianceId,
+		"run_id":          v.RunId,
+		"account_id":      v.AccountId,
+		"instrument_code": v.InstrumentCode,
+		"expected_amount": v.ExpectedAmount,
+		"actual_amount":   v.ActualAmount,
+		"variance_amount": v.VarianceAmount,
+		"reason":          v.Reason.String(),
+		"status":          v.Status.String(),
+	}
+	if v.ResolutionNote != "" {
+		entry["resolution_note"] = v.ResolutionNote
+	}
+	if v.ResolvedBy != "" {
+		entry["resolved_by"] = v.ResolvedBy
+	}
+	if v.ResolvedAt != nil {
+		entry["resolved_at"] = v.ResolvedAt.AsTime().Format(time.RFC3339)
+	}
+	if v.CreatedAt != nil {
+		entry["created_at"] = v.CreatedAt.AsTime().Format(time.RFC3339)
+	}
+	return entry
+}

--- a/services/mcp-server/internal/tools/audit.go
+++ b/services/mcp-server/internal/tools/audit.go
@@ -10,6 +10,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
@@ -54,15 +55,25 @@ type AuditClients struct {
 
 // RegisterAuditTools registers all read-only audit tools into the registry.
 // It does not modify registry.go or cmd/main.go.
+// Tools whose required client is nil are silently skipped.
 func RegisterAuditTools(r *Registry, clients AuditClients) {
-	tools := []Tool{
-		buildCausationTreeTool(clients.SagaAdmin),
-		buildPositionsQueryTool(clients.PositionKeeping),
-		buildPostingsQueryTool(clients.FinancialAccounting),
-		buildSagaExecutionsTool(clients.SagaRegistry),
-		buildReconciliationStatusTool(clients.Reconciliation),
+	candidates := []Tool{}
+	if clients.SagaAdmin != nil {
+		candidates = append(candidates, buildCausationTreeTool(clients.SagaAdmin))
 	}
-	for _, t := range tools {
+	if clients.PositionKeeping != nil {
+		candidates = append(candidates, buildPositionsQueryTool(clients.PositionKeeping))
+	}
+	if clients.FinancialAccounting != nil {
+		candidates = append(candidates, buildPostingsQueryTool(clients.FinancialAccounting))
+	}
+	if clients.SagaRegistry != nil {
+		candidates = append(candidates, buildSagaExecutionsTool(clients.SagaRegistry))
+	}
+	if clients.Reconciliation != nil {
+		candidates = append(candidates, buildReconciliationStatusTool(clients.Reconciliation))
+	}
+	for _, t := range candidates {
 		if err := r.Register(t); err != nil {
 			panic(fmt.Sprintf("failed to register audit tool %q: %v", t.Name, err))
 		}
@@ -196,57 +207,65 @@ func buildPositionsQueryTool(client PositionQuerier) Tool {
 			},
 		},
 		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
-			var p struct {
-				AccountID string `json:"account_id"`
-				PageSize  int32  `json:"page_size"`
-			}
-			if err := json.Unmarshal(params, &p); err != nil {
-				return mcperrors.FormatGRPCError(err), nil
-			}
-
-			req := &positionkeepingv1.ListFinancialPositionLogsRequest{}
-			if p.AccountID != "" {
-				req.AccountId = p.AccountID
-			}
-
-			resp, err := client.ListFinancialPositionLogs(ctx, req)
-			if err != nil {
-				return mcperrors.FormatGRPCError(err), nil
-			}
-
-			if len(resp.Logs) == 0 {
-				return map[string]interface{}{
-					"message": "no position logs found matching the query",
-					"logs":    []interface{}{},
-				}, nil
-			}
-
-			logs := make([]map[string]interface{}, 0, len(resp.Logs))
-			for _, log := range resp.Logs {
-				entry := map[string]interface{}{
-					"log_id":     log.LogId,
-					"account_id": log.AccountId,
-					"version":    log.Version,
-				}
-				if log.StatusTracking != nil {
-					entry["status"] = log.StatusTracking.CurrentStatus.String()
-				}
-				if log.CreatedAt != nil {
-					entry["created_at"] = log.CreatedAt.AsTime().Format(time.RFC3339)
-				}
-				if log.UpdatedAt != nil {
-					entry["updated_at"] = log.UpdatedAt.AsTime().Format(time.RFC3339)
-				}
-				entry["transaction_count"] = len(log.TransactionLogEntries)
-				logs = append(logs, entry)
-			}
-
-			return map[string]interface{}{
-				"count": len(logs),
-				"logs":  logs,
-			}, nil
+			return handlePositionsQuery(ctx, client, params)
 		},
 	}
+}
+
+// handlePositionsQuery implements the meridian_positions_query handler logic.
+func handlePositionsQuery(ctx context.Context, client PositionQuerier, params json.RawMessage) (interface{}, error) {
+	var p struct {
+		AccountID string `json:"account_id"`
+		PageSize  int32  `json:"page_size"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	req := &positionkeepingv1.ListFinancialPositionLogsRequest{}
+	if p.AccountID != "" {
+		req.AccountId = p.AccountID
+	}
+	if p.PageSize > 0 {
+		req.Pagination = &commonv1.Pagination{PageSize: p.PageSize}
+	}
+
+	resp, err := client.ListFinancialPositionLogs(ctx, req)
+	if err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	if len(resp.Logs) == 0 {
+		return map[string]interface{}{
+			"message": "no position logs found matching the query",
+			"logs":    []interface{}{},
+		}, nil
+	}
+
+	logs := make([]map[string]interface{}, 0, len(resp.Logs))
+	for _, log := range resp.Logs {
+		entry := map[string]interface{}{
+			"log_id":     log.LogId,
+			"account_id": log.AccountId,
+			"version":    log.Version,
+		}
+		if log.StatusTracking != nil {
+			entry["status"] = log.StatusTracking.CurrentStatus.String()
+		}
+		if log.CreatedAt != nil {
+			entry["created_at"] = log.CreatedAt.AsTime().Format(time.RFC3339)
+		}
+		if log.UpdatedAt != nil {
+			entry["updated_at"] = log.UpdatedAt.AsTime().Format(time.RFC3339)
+		}
+		entry["transaction_count"] = len(log.TransactionLogEntries)
+		logs = append(logs, entry)
+	}
+
+	return map[string]interface{}{
+		"count": len(logs),
+		"logs":  logs,
+	}, nil
 }
 
 // buildPostingsQueryTool returns the meridian_postings_query tool.
@@ -345,11 +364,16 @@ func buildPostingsRequest(p postingsQueryParams) (*financialaccountingv1.ListLed
 	if p.BookingLogID != "" {
 		req.FinancialBookingLogId = p.BookingLogID
 	}
+	if p.PageSize > 0 {
+		req.Pagination = &commonv1.Pagination{PageSize: p.PageSize}
+	}
+	var dateFrom, dateTo time.Time
 	if p.DateFrom != "" {
 		t, err := time.Parse(time.RFC3339, p.DateFrom)
 		if err != nil {
 			return nil, fmt.Sprintf("invalid date_from format (expected RFC3339): %v", err)
 		}
+		dateFrom = t
 		req.ValueDateFrom = timestamppb.New(t)
 	}
 	if p.DateTo != "" {
@@ -357,7 +381,11 @@ func buildPostingsRequest(p postingsQueryParams) (*financialaccountingv1.ListLed
 		if err != nil {
 			return nil, fmt.Sprintf("invalid date_to format (expected RFC3339): %v", err)
 		}
+		dateTo = t
 		req.ValueDateTo = timestamppb.New(t)
+	}
+	if !dateFrom.IsZero() && !dateTo.IsZero() && dateFrom.After(dateTo) {
+		return nil, "date_from must be before or equal to date_to"
 	}
 	return req, ""
 }
@@ -444,6 +472,9 @@ func handleSagaExecutions(ctx context.Context, client SagaExecutionQuerier, para
 			}, nil
 		}
 		req.StatusFilter = statusVal
+	}
+	if p.PageSize > 0 {
+		req.PageSize = p.PageSize
 	}
 
 	resp, err := client.ListSagas(ctx, req)

--- a/services/mcp-server/internal/tools/audit.go
+++ b/services/mcp-server/internal/tools/audit.go
@@ -188,7 +188,7 @@ func buildPositionsQueryTool(client PositionQuerier) Tool {
 	return Tool{
 		Name:     "meridian_positions_query",
 		Category: CategoryRead,
-		Description: "Query financial position logs with optional bi-temporal filtering. " +
+		Description: "Query financial position logs with optional account filtering. " +
 			"Returns position log summaries for one or all accounts. " +
 			"Use this to inspect account positions, transaction histories, and status tracking.",
 		InputSchema: map[string]interface{}{

--- a/services/mcp-server/internal/tools/audit_test.go
+++ b/services/mcp-server/internal/tools/audit_test.go
@@ -44,11 +44,11 @@ func (m *mockFinancialAccountingClient) ListLedgerPostings(ctx context.Context, 
 	return m.listPostingsFn(ctx, req)
 }
 
-type mockSagaRegistryClient struct {
+type mockAuditSagaRegistryClient struct {
 	listSagasFn func(ctx context.Context, req *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error)
 }
 
-func (m *mockSagaRegistryClient) ListSagas(ctx context.Context, req *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error) {
+func (m *mockAuditSagaRegistryClient) ListSagas(ctx context.Context, req *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error) {
 	return m.listSagasFn(ctx, req)
 }
 
@@ -421,7 +421,7 @@ func TestPostingsQuery_EmptyResults_MeaningfulResponse(t *testing.T) {
 // --- meridian_saga_executions tests ---
 
 func TestSagaExecutions_ValidParams_ReturnSagas(t *testing.T) {
-	mock := &mockSagaRegistryClient{
+	mock := &mockAuditSagaRegistryClient{
 		listSagasFn: func(_ context.Context, _ *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error) {
 			return &sagav1.ListSagasResponse{
 				Sagas: []*sagav1.SagaDefinition{
@@ -451,7 +451,7 @@ func TestSagaExecutions_ValidParams_ReturnSagas(t *testing.T) {
 func TestSagaExecutions_StatusFilter_PassedToClient(t *testing.T) {
 	var capturedReq *sagav1.ListSagasRequest
 
-	mock := &mockSagaRegistryClient{
+	mock := &mockAuditSagaRegistryClient{
 		listSagasFn: func(_ context.Context, req *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error) {
 			capturedReq = req
 			return &sagav1.ListSagasResponse{}, nil
@@ -488,7 +488,7 @@ func TestSagaExecutions_InvalidStatus_ValidationError(t *testing.T) {
 }
 
 func TestSagaExecutions_GRPCError_FormattedResponse(t *testing.T) {
-	mock := &mockSagaRegistryClient{
+	mock := &mockAuditSagaRegistryClient{
 		listSagasFn: func(_ context.Context, _ *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error) {
 			return nil, errors.New("saga registry unavailable")
 		},
@@ -671,7 +671,7 @@ func noopMocks() (tools.SagaAdminQuerier, tools.PositionQuerier, tools.PostingQu
 			return &financialaccountingv1.ListLedgerPostingsResponse{}, nil
 		},
 	}
-	sagaRegistry := &mockSagaRegistryClient{
+	sagaRegistry := &mockAuditSagaRegistryClient{
 		listSagasFn: func(_ context.Context, _ *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error) {
 			return &sagav1.ListSagasResponse{}, nil
 		},

--- a/services/mcp-server/internal/tools/audit_test.go
+++ b/services/mcp-server/internal/tools/audit_test.go
@@ -1,0 +1,664 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+)
+
+// --- Mock implementations ---
+
+type mockSagaAdminClient struct {
+	getCausationTreeFn func(ctx context.Context, req *sagav1.GetCausationTreeRequest) (*sagav1.GetCausationTreeResponse, error)
+}
+
+func (m *mockSagaAdminClient) GetCausationTree(ctx context.Context, req *sagav1.GetCausationTreeRequest) (*sagav1.GetCausationTreeResponse, error) {
+	return m.getCausationTreeFn(ctx, req)
+}
+
+type mockPositionKeepingClient struct {
+	listLogsFn func(ctx context.Context, req *positionkeepingv1.ListFinancialPositionLogsRequest) (*positionkeepingv1.ListFinancialPositionLogsResponse, error)
+}
+
+func (m *mockPositionKeepingClient) ListFinancialPositionLogs(ctx context.Context, req *positionkeepingv1.ListFinancialPositionLogsRequest) (*positionkeepingv1.ListFinancialPositionLogsResponse, error) {
+	return m.listLogsFn(ctx, req)
+}
+
+type mockFinancialAccountingClient struct {
+	listPostingsFn func(ctx context.Context, req *financialaccountingv1.ListLedgerPostingsRequest) (*financialaccountingv1.ListLedgerPostingsResponse, error)
+}
+
+func (m *mockFinancialAccountingClient) ListLedgerPostings(ctx context.Context, req *financialaccountingv1.ListLedgerPostingsRequest) (*financialaccountingv1.ListLedgerPostingsResponse, error) {
+	return m.listPostingsFn(ctx, req)
+}
+
+type mockSagaRegistryClient struct {
+	listSagasFn func(ctx context.Context, req *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error)
+}
+
+func (m *mockSagaRegistryClient) ListSagas(ctx context.Context, req *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error) {
+	return m.listSagasFn(ctx, req)
+}
+
+type mockReconciliationClient struct {
+	listRunsFn    func(ctx context.Context, req *reconciliationv1.ListAccountReconciliationsRequest) (*reconciliationv1.ListAccountReconciliationsResponse, error)
+	listResultsFn func(ctx context.Context, req *reconciliationv1.ListReconciliationResultsRequest) (*reconciliationv1.ListReconciliationResultsResponse, error)
+}
+
+func (m *mockReconciliationClient) ListAccountReconciliations(ctx context.Context, req *reconciliationv1.ListAccountReconciliationsRequest) (*reconciliationv1.ListAccountReconciliationsResponse, error) {
+	return m.listRunsFn(ctx, req)
+}
+
+func (m *mockReconciliationClient) ListReconciliationResults(ctx context.Context, req *reconciliationv1.ListReconciliationResultsRequest) (*reconciliationv1.ListReconciliationResultsResponse, error) {
+	return m.listResultsFn(ctx, req)
+}
+
+// --- AuditClients helper ---
+
+func newAuditClients(
+	sagaAdmin tools.SagaAdminQuerier,
+	positionKeeping tools.PositionQuerier,
+	financialAccounting tools.PostingQuerier,
+	sagaRegistry tools.SagaExecutionQuerier,
+	reconciliation tools.ReconciliationQuerier,
+) tools.AuditClients {
+	return tools.AuditClients{
+		SagaAdmin:           sagaAdmin,
+		PositionKeeping:     positionKeeping,
+		FinancialAccounting: financialAccounting,
+		SagaRegistry:        sagaRegistry,
+		Reconciliation:      reconciliation,
+	}
+}
+
+// --- meridian_causation_tree tests ---
+
+func TestCausationTree_ValidParams_ReturnTree(t *testing.T) {
+	sagaID := "550e8400-e29b-41d4-a716-446655440000"
+
+	mock := &mockSagaAdminClient{
+		getCausationTreeFn: func(_ context.Context, req *sagav1.GetCausationTreeRequest) (*sagav1.GetCausationTreeResponse, error) {
+			if req.SagaId != sagaID {
+				return nil, fmt.Errorf("unexpected saga_id: %s", req.SagaId)
+			}
+			return &sagav1.GetCausationTreeResponse{
+				Tree: &sagav1.CausationTreeNode{
+					SagaId:   sagaID,
+					SagaName: "current_account_withdrawal",
+					Status:   "COMPLETED",
+					Steps: []*sagav1.StepNode{
+						{Index: 0, Name: "debit_account", Status: "COMPLETED"},
+					},
+				},
+				Depth: 1,
+			}, nil
+		},
+	}
+
+	clients := newAuditClients(mock, nil, nil, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	params := json.RawMessage(fmt.Sprintf(`{"saga_id": %q}`, sagaID))
+	result, err := r.Call(context.Background(), "meridian_causation_tree", params)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestCausationTree_MissingSagaID_ValidationError(t *testing.T) {
+	clients := newAuditClients(nil, nil, nil, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	_, err := r.Call(context.Background(), "meridian_causation_tree", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected validation error for missing saga_id")
+	}
+}
+
+func TestCausationTree_GRPCError_FormattedResponse(t *testing.T) {
+	sagaID := "550e8400-e29b-41d4-a716-446655440000"
+
+	mock := &mockSagaAdminClient{
+		getCausationTreeFn: func(_ context.Context, _ *sagav1.GetCausationTreeRequest) (*sagav1.GetCausationTreeResponse, error) {
+			return nil, status.Errorf(codes.NotFound, "saga not found: %s", sagaID)
+		},
+	}
+
+	clients := newAuditClients(mock, nil, nil, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	params := json.RawMessage(fmt.Sprintf(`{"saga_id": %q}`, sagaID))
+	result, err := r.Call(context.Background(), "meridian_causation_tree", params)
+	if err != nil {
+		t.Fatalf("expected handler to return formatted error as result, not error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result for gRPC error")
+	}
+}
+
+func TestCausationTree_EmptyTree_MeaningfulResponse(t *testing.T) {
+	sagaID := "550e8400-e29b-41d4-a716-446655440000"
+
+	mock := &mockSagaAdminClient{
+		getCausationTreeFn: func(_ context.Context, _ *sagav1.GetCausationTreeRequest) (*sagav1.GetCausationTreeResponse, error) {
+			return &sagav1.GetCausationTreeResponse{
+				Tree:  nil,
+				Depth: 0,
+			}, nil
+		},
+	}
+
+	clients := newAuditClients(mock, nil, nil, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	params := json.RawMessage(fmt.Sprintf(`{"saga_id": %q}`, sagaID))
+	result, err := r.Call(context.Background(), "meridian_causation_tree", params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- meridian_positions_query tests ---
+
+func TestPositionsQuery_ValidParams_ReturnLogs(t *testing.T) {
+	mock := &mockPositionKeepingClient{
+		listLogsFn: func(_ context.Context, _ *positionkeepingv1.ListFinancialPositionLogsRequest) (*positionkeepingv1.ListFinancialPositionLogsResponse, error) {
+			return &positionkeepingv1.ListFinancialPositionLogsResponse{
+				Logs: []*positionkeepingv1.FinancialPositionLog{
+					{
+						LogId:     "log-001",
+						AccountId: "acc-001",
+						StatusTracking: &positionkeepingv1.StatusTracking{
+							StatusUpdatedAt: timestamppb.Now(),
+						},
+						CreatedAt: timestamppb.Now(),
+						UpdatedAt: timestamppb.Now(),
+					},
+				},
+			}, nil
+		},
+	}
+
+	clients := newAuditClients(nil, mock, nil, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	params := json.RawMessage(`{"account_id": "acc-001"}`)
+	result, err := r.Call(context.Background(), "meridian_positions_query", params)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestPositionsQuery_NoParams_DefaultQuery(t *testing.T) {
+	called := false
+	mock := &mockPositionKeepingClient{
+		listLogsFn: func(_ context.Context, _ *positionkeepingv1.ListFinancialPositionLogsRequest) (*positionkeepingv1.ListFinancialPositionLogsResponse, error) {
+			called = true
+			return &positionkeepingv1.ListFinancialPositionLogsResponse{}, nil
+		},
+	}
+
+	clients := newAuditClients(nil, mock, nil, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	result, err := r.Call(context.Background(), "meridian_positions_query", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !called {
+		t.Fatal("expected handler to call gRPC client")
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestPositionsQuery_GRPCError_FormattedResponse(t *testing.T) {
+	mock := &mockPositionKeepingClient{
+		listLogsFn: func(_ context.Context, _ *positionkeepingv1.ListFinancialPositionLogsRequest) (*positionkeepingv1.ListFinancialPositionLogsResponse, error) {
+			return nil, status.Errorf(codes.Internal, "position service unavailable")
+		},
+	}
+
+	clients := newAuditClients(nil, mock, nil, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	result, err := r.Call(context.Background(), "meridian_positions_query", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("expected formatted error result, not returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestPositionsQuery_EmptyResults_MeaningfulResponse(t *testing.T) {
+	mock := &mockPositionKeepingClient{
+		listLogsFn: func(_ context.Context, _ *positionkeepingv1.ListFinancialPositionLogsRequest) (*positionkeepingv1.ListFinancialPositionLogsResponse, error) {
+			return &positionkeepingv1.ListFinancialPositionLogsResponse{
+				Logs: []*positionkeepingv1.FinancialPositionLog{},
+			}, nil
+		},
+	}
+
+	clients := newAuditClients(nil, mock, nil, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	result, err := r.Call(context.Background(), "meridian_positions_query", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- meridian_postings_query tests ---
+
+func TestPostingsQuery_ValidParams_ReturnPostings(t *testing.T) {
+	mock := &mockFinancialAccountingClient{
+		listPostingsFn: func(_ context.Context, _ *financialaccountingv1.ListLedgerPostingsRequest) (*financialaccountingv1.ListLedgerPostingsResponse, error) {
+			return &financialaccountingv1.ListLedgerPostingsResponse{
+				LedgerPostings: []*financialaccountingv1.LedgerPosting{
+					{
+						Id:                    "posting-001",
+						FinancialBookingLogId: "log-001",
+						AccountId:             "acc-001",
+						ValueDate:             timestamppb.Now(),
+						CreatedAt:             timestamppb.Now(),
+					},
+				},
+			}, nil
+		},
+	}
+
+	clients := newAuditClients(nil, nil, mock, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	params := json.RawMessage(`{"account_id": "acc-001"}`)
+	result, err := r.Call(context.Background(), "meridian_postings_query", params)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestPostingsQuery_DateRangeFilter_PassedToClient(t *testing.T) {
+	var capturedReq *financialaccountingv1.ListLedgerPostingsRequest
+
+	mock := &mockFinancialAccountingClient{
+		listPostingsFn: func(_ context.Context, req *financialaccountingv1.ListLedgerPostingsRequest) (*financialaccountingv1.ListLedgerPostingsResponse, error) {
+			capturedReq = req
+			return &financialaccountingv1.ListLedgerPostingsResponse{}, nil
+		},
+	}
+
+	clients := newAuditClients(nil, nil, mock, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	params := json.RawMessage(`{"date_from": "2024-01-01T00:00:00Z", "date_to": "2024-01-31T23:59:59Z"}`)
+	_, err := r.Call(context.Background(), "meridian_postings_query", params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedReq == nil {
+		t.Fatal("expected request to be captured")
+	}
+	if capturedReq.ValueDateFrom == nil {
+		t.Error("expected value_date_from to be set")
+	}
+	if capturedReq.ValueDateTo == nil {
+		t.Error("expected value_date_to to be set")
+	}
+}
+
+func TestPostingsQuery_GRPCError_FormattedResponse(t *testing.T) {
+	mock := &mockFinancialAccountingClient{
+		listPostingsFn: func(_ context.Context, _ *financialaccountingv1.ListLedgerPostingsRequest) (*financialaccountingv1.ListLedgerPostingsResponse, error) {
+			return nil, status.Errorf(codes.Unavailable, "financial accounting service unavailable")
+		},
+	}
+
+	clients := newAuditClients(nil, nil, mock, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	result, err := r.Call(context.Background(), "meridian_postings_query", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("expected formatted error result, not returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestPostingsQuery_EmptyResults_MeaningfulResponse(t *testing.T) {
+	mock := &mockFinancialAccountingClient{
+		listPostingsFn: func(_ context.Context, _ *financialaccountingv1.ListLedgerPostingsRequest) (*financialaccountingv1.ListLedgerPostingsResponse, error) {
+			return &financialaccountingv1.ListLedgerPostingsResponse{
+				LedgerPostings: []*financialaccountingv1.LedgerPosting{},
+			}, nil
+		},
+	}
+
+	clients := newAuditClients(nil, nil, mock, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	result, err := r.Call(context.Background(), "meridian_postings_query", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- meridian_saga_executions tests ---
+
+func TestSagaExecutions_ValidParams_ReturnSagas(t *testing.T) {
+	mock := &mockSagaRegistryClient{
+		listSagasFn: func(_ context.Context, _ *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error) {
+			return &sagav1.ListSagasResponse{
+				Sagas: []*sagav1.SagaDefinition{
+					{
+						Id:     "def-001",
+						Name:   "current_account_withdrawal",
+						Status: sagav1.SagaStatus_SAGA_STATUS_ACTIVE,
+					},
+				},
+			}, nil
+		},
+	}
+
+	clients := newAuditClients(nil, nil, nil, mock, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	result, err := r.Call(context.Background(), "meridian_saga_executions", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestSagaExecutions_StatusFilter_PassedToClient(t *testing.T) {
+	var capturedReq *sagav1.ListSagasRequest
+
+	mock := &mockSagaRegistryClient{
+		listSagasFn: func(_ context.Context, req *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error) {
+			capturedReq = req
+			return &sagav1.ListSagasResponse{}, nil
+		},
+	}
+
+	clients := newAuditClients(nil, nil, nil, mock, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	params := json.RawMessage(`{"status": "ACTIVE"}`)
+	_, err := r.Call(context.Background(), "meridian_saga_executions", params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedReq == nil {
+		t.Fatal("expected request to be captured")
+	}
+	if capturedReq.StatusFilter != sagav1.SagaStatus_SAGA_STATUS_ACTIVE {
+		t.Errorf("expected status ACTIVE, got %v", capturedReq.StatusFilter)
+	}
+}
+
+func TestSagaExecutions_InvalidStatus_ValidationError(t *testing.T) {
+	clients := newAuditClients(nil, nil, nil, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	params := json.RawMessage(`{"status": "INVALID_STATUS_VALUE"}`)
+	_, err := r.Call(context.Background(), "meridian_saga_executions", params)
+	if err == nil {
+		t.Fatal("expected validation error for invalid status")
+	}
+}
+
+func TestSagaExecutions_GRPCError_FormattedResponse(t *testing.T) {
+	mock := &mockSagaRegistryClient{
+		listSagasFn: func(_ context.Context, _ *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error) {
+			return nil, errors.New("saga registry unavailable")
+		},
+	}
+
+	clients := newAuditClients(nil, nil, nil, mock, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	result, err := r.Call(context.Background(), "meridian_saga_executions", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("expected formatted error result, not returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- meridian_reconciliation_status tests ---
+
+func TestReconciliationStatus_ValidParams_ReturnRuns(t *testing.T) {
+	mock := &mockReconciliationClient{
+		listRunsFn: func(_ context.Context, _ *reconciliationv1.ListAccountReconciliationsRequest) (*reconciliationv1.ListAccountReconciliationsResponse, error) {
+			return &reconciliationv1.ListAccountReconciliationsResponse{
+				Runs: []*reconciliationv1.SettlementRunSummary{
+					{
+						RunId:         "run-001",
+						AccountId:     "acc-001",
+						Status:        reconciliationv1.RunStatus_RUN_STATUS_COMPLETED,
+						VarianceCount: 0,
+						TotalVariance: "0.00",
+						PeriodStart:   timestamppb.Now(),
+						PeriodEnd:     timestamppb.Now(),
+						InitiatedBy:   "system",
+						CreatedAt:     timestamppb.Now(),
+						UpdatedAt:     timestamppb.Now(),
+					},
+				},
+			}, nil
+		},
+		listResultsFn: func(_ context.Context, _ *reconciliationv1.ListReconciliationResultsRequest) (*reconciliationv1.ListReconciliationResultsResponse, error) {
+			return &reconciliationv1.ListReconciliationResultsResponse{}, nil
+		},
+	}
+
+	clients := newAuditClients(nil, nil, nil, nil, mock)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	result, err := r.Call(context.Background(), "meridian_reconciliation_status", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestReconciliationStatus_WithRunID_FetchesVariances(t *testing.T) {
+	runID := "550e8400-e29b-41d4-a716-446655440001"
+	variancesFetched := false
+
+	mock := &mockReconciliationClient{
+		listRunsFn: func(_ context.Context, _ *reconciliationv1.ListAccountReconciliationsRequest) (*reconciliationv1.ListAccountReconciliationsResponse, error) {
+			return &reconciliationv1.ListAccountReconciliationsResponse{
+				Runs: []*reconciliationv1.SettlementRunSummary{
+					{
+						RunId:       runID,
+						AccountId:   "acc-001",
+						Status:      reconciliationv1.RunStatus_RUN_STATUS_FAILED,
+						PeriodStart: timestamppb.Now(),
+						PeriodEnd:   timestamppb.Now(),
+						InitiatedBy: "system",
+						CreatedAt:   timestamppb.Now(),
+						UpdatedAt:   timestamppb.Now(),
+					},
+				},
+			}, nil
+		},
+		listResultsFn: func(_ context.Context, req *reconciliationv1.ListReconciliationResultsRequest) (*reconciliationv1.ListReconciliationResultsResponse, error) {
+			variancesFetched = true
+			if req.RunId != runID {
+				return nil, fmt.Errorf("unexpected run_id: %s", req.RunId)
+			}
+			return &reconciliationv1.ListReconciliationResultsResponse{
+				Variances: []*reconciliationv1.VarianceDetail{
+					{
+						VarianceId:     "var-001",
+						RunId:          runID,
+						AccountId:      "acc-001",
+						InstrumentCode: "GBP",
+						ExpectedAmount: "100.00",
+						ActualAmount:   "99.50",
+						VarianceAmount: "-0.50",
+						CreatedAt:      timestamppb.Now(),
+						UpdatedAt:      timestamppb.Now(),
+					},
+				},
+			}, nil
+		},
+	}
+
+	clients := newAuditClients(nil, nil, nil, nil, mock)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	params := json.RawMessage(fmt.Sprintf(`{"run_id": %q}`, runID))
+	result, err := r.Call(context.Background(), "meridian_reconciliation_status", params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if !variancesFetched {
+		t.Error("expected variances to be fetched when run_id is provided")
+	}
+}
+
+func TestReconciliationStatus_GRPCError_FormattedResponse(t *testing.T) {
+	mock := &mockReconciliationClient{
+		listRunsFn: func(_ context.Context, _ *reconciliationv1.ListAccountReconciliationsRequest) (*reconciliationv1.ListAccountReconciliationsResponse, error) {
+			return nil, status.Errorf(codes.Unavailable, "reconciliation service unavailable")
+		},
+		listResultsFn: nil,
+	}
+
+	clients := newAuditClients(nil, nil, nil, nil, mock)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	result, err := r.Call(context.Background(), "meridian_reconciliation_status", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("expected formatted error result, not returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestReconciliationStatus_EmptyResults_MeaningfulResponse(t *testing.T) {
+	mock := &mockReconciliationClient{
+		listRunsFn: func(_ context.Context, _ *reconciliationv1.ListAccountReconciliationsRequest) (*reconciliationv1.ListAccountReconciliationsResponse, error) {
+			return &reconciliationv1.ListAccountReconciliationsResponse{
+				Runs: []*reconciliationv1.SettlementRunSummary{},
+			}, nil
+		},
+		listResultsFn: func(_ context.Context, _ *reconciliationv1.ListReconciliationResultsRequest) (*reconciliationv1.ListReconciliationResultsResponse, error) {
+			return &reconciliationv1.ListReconciliationResultsResponse{}, nil
+		},
+	}
+
+	clients := newAuditClients(nil, nil, nil, nil, mock)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	result, err := r.Call(context.Background(), "meridian_reconciliation_status", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- Audit log entries tests (via AuditService) ---
+
+func TestAuditLogEntries_ToolRegistered(t *testing.T) {
+	clients := newAuditClients(nil, nil, nil, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	listed := r.List()
+	names := make(map[string]bool)
+	for _, tool := range listed {
+		names[tool.Name] = true
+	}
+
+	required := []string{
+		"meridian_causation_tree",
+		"meridian_positions_query",
+		"meridian_postings_query",
+		"meridian_saga_executions",
+		"meridian_reconciliation_status",
+	}
+	for _, name := range required {
+		if !names[name] {
+			t.Errorf("expected tool %q to be registered", name)
+		}
+	}
+}
+
+func TestAuditTools_AllCategoryRead(t *testing.T) {
+	clients := newAuditClients(nil, nil, nil, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	for _, tool := range r.List() {
+		if tool.Category != tools.CategoryRead {
+			t.Errorf("expected tool %q to be CategoryRead, got %v", tool.Name, tool.Category)
+		}
+	}
+}

--- a/services/mcp-server/internal/tools/audit_test.go
+++ b/services/mcp-server/internal/tools/audit_test.go
@@ -62,6 +62,9 @@ func (m *mockReconciliationClient) ListAccountReconciliations(ctx context.Contex
 }
 
 func (m *mockReconciliationClient) ListReconciliationResults(ctx context.Context, req *reconciliationv1.ListReconciliationResultsRequest) (*reconciliationv1.ListReconciliationResultsResponse, error) {
+	if m.listResultsFn == nil {
+		return &reconciliationv1.ListReconciliationResultsResponse{}, nil
+	}
 	return m.listResultsFn(ctx, req)
 }
 

--- a/services/mcp-server/internal/tools/audit_test.go
+++ b/services/mcp-server/internal/tools/audit_test.go
@@ -330,7 +330,7 @@ func TestPostingsQuery_DateRangeFilter_PassedToClient(t *testing.T) {
 	r := tools.NewRegistry()
 	tools.RegisterAuditTools(r, clients)
 
-	params := json.RawMessage(`{"date_from": "2024-01-01T00:00:00Z", "date_to": "2024-01-31T23:59:59Z"}`)
+	params := json.RawMessage(`{"date_from": "2024-01-01T00:00:00Z", "date_to": "2024-01-31T23:59:59Z", "page_size": 50}`)
 	_, err := r.Call(context.Background(), "meridian_postings_query", params)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -343,6 +343,9 @@ func TestPostingsQuery_DateRangeFilter_PassedToClient(t *testing.T) {
 	}
 	if capturedReq.ValueDateTo == nil {
 		t.Error("expected value_date_to to be set")
+	}
+	if capturedReq.Pagination == nil || capturedReq.Pagination.PageSize != 50 {
+		t.Errorf("expected page_size=50 to be propagated, got pagination=%v", capturedReq.Pagination)
 	}
 }
 
@@ -363,6 +366,33 @@ func TestPostingsQuery_GRPCError_FormattedResponse(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestPostingsQuery_DateFromAfterDateTo_ReturnsError(t *testing.T) {
+	mock := &mockFinancialAccountingClient{
+		listPostingsFn: func(_ context.Context, _ *financialaccountingv1.ListLedgerPostingsRequest) (*financialaccountingv1.ListLedgerPostingsResponse, error) {
+			t.Fatal("handler should not be called for invalid date range")
+			return nil, nil
+		},
+	}
+
+	clients := newAuditClients(nil, nil, mock, nil, nil)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	// date_from is after date_to — should return an error map, not call the backend.
+	params := json.RawMessage(`{"date_from": "2024-02-01T00:00:00Z", "date_to": "2024-01-01T00:00:00Z"}`)
+	result, err := r.Call(context.Background(), "meridian_postings_query", params)
+	if err != nil {
+		t.Fatalf("unexpected error return: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if _, hasErr := m["error"]; !hasErr {
+		t.Errorf("expected 'error' key in result, got keys: %v", m)
 	}
 }
 
@@ -624,10 +654,43 @@ func TestReconciliationStatus_EmptyResults_MeaningfulResponse(t *testing.T) {
 	}
 }
 
+// noopMocks returns a full set of non-nil mock clients that return empty responses.
+func noopMocks() (tools.SagaAdminQuerier, tools.PositionQuerier, tools.PostingQuerier, tools.SagaExecutionQuerier, tools.ReconciliationQuerier) {
+	sagaAdmin := &mockSagaAdminClient{
+		getCausationTreeFn: func(_ context.Context, _ *sagav1.GetCausationTreeRequest) (*sagav1.GetCausationTreeResponse, error) {
+			return &sagav1.GetCausationTreeResponse{}, nil
+		},
+	}
+	positionKeeping := &mockPositionKeepingClient{
+		listLogsFn: func(_ context.Context, _ *positionkeepingv1.ListFinancialPositionLogsRequest) (*positionkeepingv1.ListFinancialPositionLogsResponse, error) {
+			return &positionkeepingv1.ListFinancialPositionLogsResponse{}, nil
+		},
+	}
+	financialAccounting := &mockFinancialAccountingClient{
+		listPostingsFn: func(_ context.Context, _ *financialaccountingv1.ListLedgerPostingsRequest) (*financialaccountingv1.ListLedgerPostingsResponse, error) {
+			return &financialaccountingv1.ListLedgerPostingsResponse{}, nil
+		},
+	}
+	sagaRegistry := &mockSagaRegistryClient{
+		listSagasFn: func(_ context.Context, _ *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error) {
+			return &sagav1.ListSagasResponse{}, nil
+		},
+	}
+	reconciliation := &mockReconciliationClient{
+		listRunsFn: func(_ context.Context, _ *reconciliationv1.ListAccountReconciliationsRequest) (*reconciliationv1.ListAccountReconciliationsResponse, error) {
+			return &reconciliationv1.ListAccountReconciliationsResponse{}, nil
+		},
+		listResultsFn: func(_ context.Context, _ *reconciliationv1.ListReconciliationResultsRequest) (*reconciliationv1.ListReconciliationResultsResponse, error) {
+			return &reconciliationv1.ListReconciliationResultsResponse{}, nil
+		},
+	}
+	return sagaAdmin, positionKeeping, financialAccounting, sagaRegistry, reconciliation
+}
+
 // --- Audit log entries tests (via AuditService) ---
 
 func TestAuditLogEntries_ToolRegistered(t *testing.T) {
-	clients := newAuditClients(nil, nil, nil, nil, nil)
+	clients := newAuditClients(noopMocks())
 	r := tools.NewRegistry()
 	tools.RegisterAuditTools(r, clients)
 
@@ -652,7 +715,7 @@ func TestAuditLogEntries_ToolRegistered(t *testing.T) {
 }
 
 func TestAuditTools_AllCategoryRead(t *testing.T) {
-	clients := newAuditClients(nil, nil, nil, nil, nil)
+	clients := newAuditClients(noopMocks())
 	r := tools.NewRegistry()
 	tools.RegisterAuditTools(r, clients)
 
@@ -660,5 +723,27 @@ func TestAuditTools_AllCategoryRead(t *testing.T) {
 		if tool.Category != tools.CategoryRead {
 			t.Errorf("expected tool %q to be CategoryRead, got %v", tool.Name, tool.Category)
 		}
+	}
+}
+
+func TestAuditTools_NilClient_SkipsRegistration(t *testing.T) {
+	// Only SagaAdmin is configured; the other 4 tools must not be registered.
+	clients := newAuditClients(
+		&mockSagaAdminClient{
+			getCausationTreeFn: func(_ context.Context, _ *sagav1.GetCausationTreeRequest) (*sagav1.GetCausationTreeResponse, error) {
+				return &sagav1.GetCausationTreeResponse{}, nil
+			},
+		},
+		nil, nil, nil, nil,
+	)
+	r := tools.NewRegistry()
+	tools.RegisterAuditTools(r, clients)
+
+	listed := r.List()
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 registered tool, got %d", len(listed))
+	}
+	if listed[0].Name != "meridian_causation_tree" {
+		t.Errorf("expected meridian_causation_tree, got %q", listed[0].Name)
 	}
 }

--- a/services/mcp-server/internal/tools/audit_test.go
+++ b/services/mcp-server/internal/tools/audit_test.go
@@ -122,7 +122,13 @@ func TestCausationTree_ValidParams_ReturnTree(t *testing.T) {
 }
 
 func TestCausationTree_MissingSagaID_ValidationError(t *testing.T) {
-	clients := newAuditClients(nil, nil, nil, nil, nil)
+	mock := &mockSagaAdminClient{
+		getCausationTreeFn: func(_ context.Context, _ *sagav1.GetCausationTreeRequest) (*sagav1.GetCausationTreeResponse, error) {
+			t.Fatal("handler should not be called for missing saga_id")
+			return nil, nil
+		},
+	}
+	clients := newAuditClients(mock, nil, nil, nil, nil)
 	r := tools.NewRegistry()
 	tools.RegisterAuditTools(r, clients)
 
@@ -476,10 +482,18 @@ func TestSagaExecutions_StatusFilter_PassedToClient(t *testing.T) {
 }
 
 func TestSagaExecutions_InvalidStatus_ValidationError(t *testing.T) {
-	clients := newAuditClients(nil, nil, nil, nil, nil)
+	mock := &mockAuditSagaRegistryClient{
+		listSagasFn: func(_ context.Context, _ *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error) {
+			t.Fatal("handler should not be called for invalid status")
+			return nil, nil
+		},
+	}
+	clients := newAuditClients(nil, nil, nil, mock, nil)
 	r := tools.NewRegistry()
 	tools.RegisterAuditTools(r, clients)
 
+	// "INVALID_STATUS_VALUE" is rejected by the JSON schema enum constraint,
+	// so r.Call returns a non-nil error (schema validation, not tool-not-found).
 	params := json.RawMessage(`{"status": "INVALID_STATUS_VALUE"}`)
 	_, err := r.Call(context.Background(), "meridian_saga_executions", params)
 	if err == nil {


### PR DESCRIPTION
## Summary

- Implements five read-only audit tools for the MCP server: `meridian_causation_tree`, `meridian_positions_query`, `meridian_postings_query`, `meridian_saga_executions`, and `meridian_reconciliation_status`
- Tools use minimal querier interfaces (interface injection) for testability without real gRPC connections
- All tools registered under `CategoryRead` - no state mutations

## Changes Made

**New file: `services/mcp-server/internal/tools/audit.go`**
- Defines 5 querier interfaces: `SagaAdminQuerier`, `PositionQuerier`, `PostingQuerier`, `SagaExecutionQuerier`, `ReconciliationQuerier`
- `AuditClients` struct aggregates all queriers
- `RegisterAuditTools(r *Registry, clients AuditClients)` registers all 5 tools
- Handler logic extracted into named functions to satisfy cognitive complexity limits

**New file: `services/mcp-server/internal/tools/audit_test.go`**
- Mock implementations for all 5 querier interfaces
- Tests cover: valid params, missing required params, gRPC error formatting, empty results
- `TestAuditLogEntries_ToolRegistered` verifies all 5 tools are registered
- `TestAuditTools_AllCategoryRead` verifies correct category

## Technical Details

- `meridian_causation_tree`: calls `SagaAdminService.GetCausationTree` - requires `saga_id`
- `meridian_positions_query`: calls `PositionKeepingService.ListFinancialPositionLogs` - optional account/instrument filters
- `meridian_postings_query`: calls `FinancialAccountingService.ListLedgerPostings` - optional account/date filters
- `meridian_saga_executions`: calls `SagaRegistryService.ListSagas` - optional status filter
- `meridian_reconciliation_status`: calls `AccountReconciliationService.ListAccountReconciliations` + optionally `ListReconciliationResults` when run_id provided

## Testing

All tests pass: `go test ./services/mcp-server/internal/tools/...`

All pre-commit checks pass (gitleaks, gofumpt, golangci-lint).

## Task Reference

Task Master: mcp-server.8