### PR TITLE
fix: remove /api/ prefix from gateway and register missing services

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,7 +73,7 @@ jobs:
         working-directory: frontend
         env:
           VITE_E2E_MODE: 'true'
-          VITE_API_BASE_URL: 'http://localhost:5173/api'
+          VITE_API_BASE_URL: 'http://localhost:5173'
         run: npx vite build
 
       - name: Upload backend binaries

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -172,7 +172,7 @@ jobs:
             local TENANT_ID=$1
             local PAYLOAD=$2
             HTTP_CODE=$(curl -sS -o /tmp/tenant_resp.txt -w "%{http_code}" \
-              -X POST "${GATEWAY_URL}/api/v1/tenants" \
+              -X POST "${GATEWAY_URL}/v1/tenants" \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD")
             echo "${TENANT_ID}: HTTP ${HTTP_CODE}"

--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -643,12 +643,17 @@ var serviceNames = []string{
 	"meridian.financial_accounting.v1.FinancialAccountingService",
 	"meridian.position_keeping.v1.PositionKeepingService",
 	"meridian.forecasting.v1.ForecastingService",
-	// CurrentAccountService excluded: conflicts with InternalBankAccountService
-	// on /v1/liens/* REST routes. Reachable via gRPC/Connect only.
+	// CurrentAccountService excluded from Vanguard: its REST routes (/v1/liens/*)
+	// conflict with InternalBankAccountService. Still reachable via Connect protocol
+	// (/{package}.{Service}/{Method} paths don't conflict).
 	"meridian.payment_order.v1.PaymentOrderService",
 	"meridian.reconciliation.v1.AccountReconciliationService",
 	"meridian.saga.v1.SagaRegistryService",
+	"meridian.saga.v1.SagaAdminService",
 	"meridian.control_plane.v1.ApplyManifestService",
+	"meridian.control_plane.v1.ManifestHistoryService",
+	"meridian.reference_data.v1.AccountTypeRegistryService",
+	"meridian.mapping.v1.MappingService",
 	"meridian.audit.v1.AuditService",
 }
 

--- a/frontend/e2e/admin-config.spec.ts
+++ b/frontend/e2e/admin-config.spec.ts
@@ -225,7 +225,7 @@ test.describe('Starlark Configuration detail page', () => {
 })
 
 // ─── Gateway Mappings ─────────────────────────────────────────────────────────
-// TODO: Gateway mapping REST API (POST /api/v1/mappings) is not yet registered
+// TODO: Gateway mapping REST API (POST /v1/mappings) is not yet registered
 // in the unified binary's Vanguard transcoder. Re-enable once the mapping CRUD
 // endpoints are available via REST.
 

--- a/frontend/e2e/helpers/seed-data.ts
+++ b/frontend/e2e/helpers/seed-data.ts
@@ -18,7 +18,7 @@ export async function createMapping(
     outboundValidationCel?: string
   },
 ) {
-  const resp = await request.post(`${BASE_URL}/api/v1/mappings`, {
+  const resp = await request.post(`${BASE_URL}/v1/mappings`, {
     data: {
       name: mapping.name,
       target_service: mapping.targetService,
@@ -54,7 +54,7 @@ export async function createTenant(
     slug: string
   },
 ) {
-  const resp = await request.post(`${BASE_URL}/api/v1/tenants`, {
+  const resp = await request.post(`${BASE_URL}/v1/tenants`, {
     data: {
       tenantId: tenant.tenantId,
       displayName: tenant.displayName,

--- a/frontend/src/pages/accounts/[accountId].tsx
+++ b/frontend/src/pages/accounts/[accountId].tsx
@@ -22,7 +22,7 @@ async function retrieveAccount(
   accountId: string,
 ): Promise<CurrentAccount | null> {
   const response = await fetch(
-    `/api/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount`,
+    `/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount`,
     {
       method: 'POST',
       headers: {

--- a/frontend/src/pages/accounts/control-dialog.tsx
+++ b/frontend/src/pages/accounts/control-dialog.tsx
@@ -60,7 +60,7 @@ async function performAccountControl(
   endpoint: string,
 ): Promise<void> {
   const response = await fetch(
-    `/api/meridian.current_account.v1.CurrentAccountService/${endpoint}`,
+    `/meridian.current_account.v1.CurrentAccountService/${endpoint}`,
     {
       method: 'POST',
       headers: {

--- a/frontend/src/pages/accounts/create-account-dialog.tsx
+++ b/frontend/src/pages/accounts/create-account-dialog.tsx
@@ -43,7 +43,7 @@ async function createAccount(
   partyId: string,
 ): Promise<string> {
   const response = await fetch(
-    `/api/meridian.current_account.v1.CurrentAccountService/InitiateCurrentAccount`,
+    `/meridian.current_account.v1.CurrentAccountService/InitiateCurrentAccount`,
     {
       method: 'POST',
       headers: {

--- a/frontend/src/pages/accounts/create-lien-dialog.tsx
+++ b/frontend/src/pages/accounts/create-lien-dialog.tsx
@@ -89,7 +89,7 @@ async function initiateLien(
     body.expiresAt = { seconds: expiresAtSeconds }
   }
 
-  const response = await fetch(`/api/${serviceName}/InitiateLien`, {
+  const response = await fetch(`/${serviceName}/InitiateLien`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/pages/accounts/deposit-dialog.tsx
+++ b/frontend/src/pages/accounts/deposit-dialog.tsx
@@ -42,7 +42,7 @@ async function depositFunds(
   amountMinorUnits: string,
 ): Promise<void> {
   const response = await fetch(
-    `/api/meridian.current_account.v1.CurrentAccountService/DepositFunds`,
+    `/meridian.current_account.v1.CurrentAccountService/DepositFunds`,
     {
       method: 'POST',
       headers: {

--- a/frontend/src/pages/accounts/index.tsx
+++ b/frontend/src/pages/accounts/index.tsx
@@ -35,7 +35,7 @@ async function listAccounts(
   }
 
   const response = await fetch(
-    `/api/meridian.current_account.v1.CurrentAccountService/ListCurrentAccounts`,
+    `/meridian.current_account.v1.CurrentAccountService/ListCurrentAccounts`,
     {
       method: 'POST',
       headers: {

--- a/frontend/src/pages/accounts/withdraw-dialog.tsx
+++ b/frontend/src/pages/accounts/withdraw-dialog.tsx
@@ -44,7 +44,7 @@ async function initiateWithdrawal(
   amountMinorUnits: string,
 ): Promise<string> {
   const response = await fetch(
-    `/api/meridian.current_account.v1.CurrentAccountService/InitiateWithdrawal`,
+    `/meridian.current_account.v1.CurrentAccountService/InitiateWithdrawal`,
     {
       method: 'POST',
       headers: {
@@ -72,7 +72,7 @@ async function initiateWithdrawal(
 
 async function executeWithdrawal(tenantSlug: string, withdrawalId: string): Promise<void> {
   const response = await fetch(
-    `/api/meridian.current_account.v1.CurrentAccountService/ExecuteWithdrawal`,
+    `/meridian.current_account.v1.CurrentAccountService/ExecuteWithdrawal`,
     {
       method: 'POST',
       headers: {

--- a/frontend/src/pages/reconciliation/detail.tsx
+++ b/frontend/src/pages/reconciliation/detail.tsx
@@ -54,20 +54,20 @@ export interface BalanceAssertion {
 // ---------------------------------------------------------------------------
 
 async function fetchRunDetail(runId: string): Promise<ReconciliationRunDetail> {
-  const res = await fetch(`/api/v1/reconciliation/runs/${runId}`)
+  const res = await fetch(`/v1/reconciliation/runs/${runId}`)
   if (!res.ok) throw new Error(`Failed to fetch run detail: ${res.status}`)
   return res.json() as Promise<ReconciliationRunDetail>
 }
 
 async function fetchVariances(runId: string): Promise<Variance[]> {
-  const res = await fetch(`/api/v1/reconciliation/runs/${runId}/variances`)
+  const res = await fetch(`/v1/reconciliation/runs/${runId}/variances`)
   if (!res.ok) throw new Error(`Failed to fetch variances: ${res.status}`)
   const data = (await res.json()) as { variances: Variance[]; nextPageToken?: string; totalCount?: number }
   return data.variances ?? []
 }
 
 async function fetchDisputes(runId: string): Promise<Dispute[]> {
-  const res = await fetch(`/api/v1/reconciliation/runs/${runId}/disputes`)
+  const res = await fetch(`/v1/reconciliation/runs/${runId}/disputes`)
   if (!res.ok) throw new Error(`Failed to fetch disputes: ${res.status}`)
   const data = (await res.json()) as { items: Dispute[] }
   return data.items
@@ -80,7 +80,7 @@ async function updateDisputeStatus(
   resolutionNotes: string,
 ): Promise<void> {
   const res = await fetch(
-    `/api/v1/reconciliation/runs/${runId}/disputes/${disputeId}`,
+    `/v1/reconciliation/runs/${runId}/disputes/${disputeId}`,
     {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -91,7 +91,7 @@ async function updateDisputeStatus(
 }
 
 async function fetchBalanceAssertions(runId: string): Promise<BalanceAssertion[]> {
-  const res = await fetch(`/api/v1/reconciliation/runs/${runId}/assertions`)
+  const res = await fetch(`/v1/reconciliation/runs/${runId}/assertions`)
   if (!res.ok) throw new Error(`Failed to fetch assertions: ${res.status}`)
   const data = (await res.json()) as { items: BalanceAssertion[] }
   return data.items
@@ -101,7 +101,7 @@ async function saveBalanceAssertion(
   runId: string,
   assertion: { name: string; expression: string },
 ): Promise<void> {
-  const res = await fetch(`/api/v1/reconciliation/runs/${runId}/assertions`, {
+  const res = await fetch(`/v1/reconciliation/runs/${runId}/assertions`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(assertion),

--- a/frontend/src/pages/reconciliation/index.tsx
+++ b/frontend/src/pages/reconciliation/index.tsx
@@ -28,7 +28,7 @@ async function fetchReconciliationRuns(params: {
   pageSize: number
   filters?: Record<string, string>
 }): Promise<{ items: ReconciliationRun[]; nextPageToken?: string }> {
-  const url = new URL('/api/v1/reconciliation/runs', window.location.origin)
+  const url = new URL('/v1/reconciliation/runs', window.location.origin)
   url.searchParams.set('page_size', String(params.pageSize))
   if (params.pageToken) url.searchParams.set('page_token', params.pageToken)
   if (params.filters) {

--- a/frontend/src/pages/reconciliation/initiate-reconciliation-dialog.tsx
+++ b/frontend/src/pages/reconciliation/initiate-reconciliation-dialog.tsx
@@ -93,7 +93,7 @@ async function initiateReconciliation(
   }
 
   const response = await fetch(
-    `/api/meridian.reconciliation.v1.AccountReconciliationService/InitiateAccountReconciliation`,
+    `/meridian.reconciliation.v1.AccountReconciliationService/InitiateAccountReconciliation`,
     {
       method: 'POST',
       headers: {

--- a/frontend/src/test/msw-integration.test.tsx
+++ b/frontend/src/test/msw-integration.test.tsx
@@ -30,7 +30,7 @@ describe('MSW infrastructure', () => {
     )
 
     const response = await fetch(
-      '/api/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount',
+      '/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount',
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -48,7 +48,7 @@ describe('MSW infrastructure', () => {
   it('resets handlers between tests so previous overrides do not bleed through', async () => {
     // The handler from the previous test was reset by afterEach server.resetHandlers()
     const response = await fetch(
-      '/api/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount',
+      '/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount',
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,14 +14,18 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  server: {
+    proxy: {
+      '/meridian.': { target: 'http://localhost:8090', changeOrigin: true },
+      '/v1': { target: 'http://localhost:8090', changeOrigin: true },
+    },
+  },
   preview: {
     port: 5173,
     strictPort: true,
     proxy: {
-      '/api': {
-        target: 'http://localhost:8090',
-        changeOrigin: true,
-      },
+      '/meridian.': { target: 'http://localhost:8090', changeOrigin: true },
+      '/v1': { target: 'http://localhost:8090', changeOrigin: true },
     },
   },
 })

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -90,7 +90,7 @@ flowchart LR
 
 ### Middleware Chain
 
-The gateway applies middleware in this order for `/api/*` routes:
+The gateway applies middleware in this order for all routes:
 
 1. **Auth Middleware** (outermost): Validates JWT or API key, returns 401 if invalid
 2. **Tenant Middleware**: Resolves tenant from subdomain/header, injects into context
@@ -110,9 +110,9 @@ the decision rationale.
 
 | Protocol | Content-Type | URL Pattern |
 |----------|--------------|-------------|
-| REST/JSON | `application/json` | `/api/v1/parties`, `/api/v1/current-accounts`, etc. |
-| Connect | `application/connect+json` | `/api/<package>.<Service>/<Method>` |
-| gRPC-Web | `application/grpc-web+proto` | `/api/<package>.<Service>/<Method>` |
+| REST/JSON | `application/json` | `/v1/parties`, `/v1/current-accounts`, etc. |
+| Connect | `application/connect+json` | `/<package>.<Service>/<Method>` |
+| gRPC-Web | `application/grpc-web+proto` | `/<package>.<Service>/<Method>` |
 | Native gRPC | — | Direct to `:50051` |
 
 ### Proto Descriptor
@@ -250,7 +250,7 @@ export API_KEYS="sk_prod_abc123:payments-service,sk_prod_def456:reporting-servic
 ### Usage
 
 ```bash
-curl -H "X-API-Key: $API_KEY" https://acme.api.meridianhub.cloud/api/v1/accounts
+curl -H "X-API-Key: $API_KEY" https://acme.api.meridianhub.cloud/v1/accounts
 ```
 
 ### Rate Limiting
@@ -349,7 +349,7 @@ In this mode, use the `X-Tenant-Slug` header to specify the tenant:
 export LOCAL_DEV_MODE=true
 curl -H "Authorization: Bearer $JWT" \
      -H "X-Tenant-Slug: acme_bank" \
-     http://localhost:8080/api/v1/accounts
+     http://localhost:8080/v1/accounts
 ```
 
 This mode is blocked in production namespaces (any namespace prefixed with `prod`).

--- a/services/gateway/content_negotiation_test.go
+++ b/services/gateway/content_negotiation_test.go
@@ -11,17 +11,17 @@ package gateway
 //
 //   - REST/JSON (HTTP/JSON transcoding):
 //       Content-Type: application/json
-//       Paths: /api/v1/parties, /api/v1/tenants, etc.  (from google.api.http annotations)
+//       Paths: /v1/parties, /v1/tenants, etc.  (from google.api.http annotations)
 //       HTTP verbs: GET, POST, PUT, PATCH, DELETE
 //
 //   - Connect protocol:
 //       Content-Type: application/connect+json  or  application/connect+proto
-//       Paths: /api/meridian.party.v1.PartyService/RegisterParty  (RPC-style under /api prefix)
+//       Paths: /meridian.party.v1.PartyService/RegisterParty  (RPC-style)
 //       HTTP verb: POST
 //
 //   - gRPC-Web:
 //       Content-Type: application/grpc-web+proto  or  application/grpc-web+json
-//       Paths: /api/meridian.party.v1.PartyService/RetrieveParty  (RPC-style under /api prefix)
+//       Paths: /meridian.party.v1.PartyService/RetrieveParty  (RPC-style)
 //       HTTP verb: POST
 //       Body: length-prefixed protobuf frames (5-byte prefix per message)
 //
@@ -30,11 +30,10 @@ package gateway
 //       is reachable at the address configured in ServiceBackend.BackendAddr.
 //
 // URL construction for Connect/gRPC-Web clients:
-//   The gateway mounts the transcoder on /api/, stripping the prefix before
-//   passing to Vanguard. Connect/gRPC-Web clients must target the full URL:
-//     http://<host>/api/<package>.<Service>/<Method>
+//   The gateway mounts the transcoder on /, so clients target the full URL:
+//     http://<host>/<package>.<Service>/<Method>
 //   The connect-go library uses the last two path segments (/<Service>/<Method>)
-//   as the RPC procedure identifier, making the /api prefix transparent.
+//   as the RPC procedure identifier.
 //
 // Protocol selection guidelines:
 //   - REST clients (curl, fetch, browsers): use HTTP/JSON
@@ -66,15 +65,13 @@ import (
 )
 
 // partyRetrieveURL returns the full URL for the PartyService/RetrieveParty RPC.
-// The /api prefix is required because the gateway mounts the transcoder under /api/
-// and strips that prefix before passing requests to Vanguard.
 func partyRetrieveURL(baseURL string) string {
-	return baseURL + "/api/meridian.party.v1.PartyService/RetrieveParty"
+	return baseURL + "/meridian.party.v1.PartyService/RetrieveParty"
 }
 
 // partyRegisterURL returns the full URL for the PartyService/RegisterParty RPC.
 func partyRegisterURL(baseURL string) string {
-	return baseURL + "/api/meridian.party.v1.PartyService/RegisterParty"
+	return baseURL + "/meridian.party.v1.PartyService/RegisterParty"
 }
 
 // ---------------------------------------------------------------------------
@@ -91,7 +88,7 @@ func partyRegisterURL(baseURL string) string {
 // TestContentNegotiation_ConnectProto verifies that Vanguard accepts
 // Connect-protocol requests using binary protobuf encoding.
 //
-// Wire format: POST /api/<package>.<Service>/<Method>
+// Wire format: POST /<package>.<Service>/<Method>
 // Content-Type: application/connect+proto
 // Body: 5-byte length-prefixed protobuf message
 func TestContentNegotiation_ConnectProto(t *testing.T) {
@@ -118,7 +115,7 @@ func TestContentNegotiation_ConnectProto(t *testing.T) {
 
 // TestContentNegotiation_ConnectJSON verifies Connect protocol with JSON encoding.
 //
-// Wire format: POST /api/<package>.<Service>/<Method>
+// Wire format: POST /<package>.<Service>/<Method>
 // Content-Type: application/connect+json
 // Body: JSON-encoded request message
 func TestContentNegotiation_ConnectJSON(t *testing.T) {
@@ -177,7 +174,7 @@ func TestContentNegotiation_ConnectProtocol_RegisterParty(t *testing.T) {
 // TestContentNegotiation_GRPCWebProto verifies that Vanguard accepts
 // gRPC-Web requests using binary protobuf encoding.
 //
-// Wire format: POST /api/<package>.<Service>/<Method>
+// Wire format: POST /<package>.<Service>/<Method>
 // Content-Type: application/grpc-web+proto
 // Body: 5-byte length-prefixed protobuf frames
 func TestContentNegotiation_GRPCWebProto(t *testing.T) {
@@ -205,7 +202,7 @@ func TestContentNegotiation_GRPCWebProto(t *testing.T) {
 
 // TestContentNegotiation_GRPCWebJSON verifies gRPC-Web with JSON encoding.
 //
-// Wire format: POST /api/<package>.<Service>/<Method>
+// Wire format: POST /<package>.<Service>/<Method>
 // Content-Type: application/grpc-web+json
 func TestContentNegotiation_GRPCWebJSON(t *testing.T) {
 	env := startTranscodingTestEnv(t, []ServiceBackend{
@@ -260,7 +257,7 @@ func TestContentNegotiation_GRPCWebProto_ManualFraming(t *testing.T) {
 	frame.Write(msgBytes)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		env.baseURL+"/api/meridian.party.v1.PartyService/RetrieveParty",
+		env.baseURL+"/meridian.party.v1.PartyService/RetrieveParty",
 		&frame)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/grpc-web+proto")
@@ -333,7 +330,7 @@ func TestContentNegotiation_ContentTypeRouting_JSON(t *testing.T) {
 	})
 
 	body := `{"partyType":"PARTY_TYPE_PERSON","legalName":"JSON Client","displayName":"JC"}`
-	resp, err := httpPost(context.Background(), env.baseURL+"/api/v1/parties",
+	resp, err := httpPost(context.Background(), env.baseURL+"/v1/parties",
 		"application/json", strings.NewReader(body))
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -401,8 +398,8 @@ func TestContentNegotiation_RPCPathVsRESTPath(t *testing.T) {
 
 	ctx := context.Background()
 
-	t.Run("REST path: GET /api/v1/parties/{id}", func(t *testing.T) {
-		resp, err := httpGet(ctx, env.baseURL+"/api/v1/parties/rest-path-test")
+	t.Run("REST path: GET /v1/parties/{id}", func(t *testing.T) {
+		resp, err := httpGet(ctx, env.baseURL+"/v1/parties/rest-path-test")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -413,7 +410,7 @@ func TestContentNegotiation_RPCPathVsRESTPath(t *testing.T) {
 		assert.Equal(t, "rest-path-test", party["partyId"])
 	})
 
-	t.Run("Connect RPC path: POST /api/<svc>/RetrieveParty", func(t *testing.T) {
+	t.Run("Connect RPC path: POST /<svc>/RetrieveParty", func(t *testing.T) {
 		client := connect.NewClient[partyv1.RetrievePartyRequest, partyv1.RetrievePartyResponse](
 			&http.Client{},
 			partyRetrieveURL(env.baseURL),
@@ -426,7 +423,7 @@ func TestContentNegotiation_RPCPathVsRESTPath(t *testing.T) {
 		assert.Equal(t, "rpc-path-test", resp.Msg.GetParty().GetPartyId())
 	})
 
-	t.Run("gRPC-Web RPC path: POST /api/<svc>/RetrieveParty", func(t *testing.T) {
+	t.Run("gRPC-Web RPC path: POST /<svc>/RetrieveParty", func(t *testing.T) {
 		client := connect.NewClient[partyv1.RetrievePartyRequest, partyv1.RetrievePartyResponse](
 			&http.Client{},
 			partyRetrieveURL(env.baseURL),
@@ -546,7 +543,7 @@ func TestContentNegotiation_GRPCWebContentType_Response(t *testing.T) {
 	body.Write(msgBytes)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		env.baseURL+"/api/meridian.party.v1.PartyService/RetrieveParty",
+		env.baseURL+"/meridian.party.v1.PartyService/RetrieveParty",
 		&body)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/grpc-web+proto")
@@ -578,14 +575,14 @@ func TestContentNegotiation_MultipleServices_AllProtocols(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("party via REST/JSON", func(t *testing.T) {
-		resp, err := httpGet(ctx, env.baseURL+"/api/v1/parties/multi-proto-test")
+		resp, err := httpGet(ctx, env.baseURL+"/v1/parties/multi-proto-test")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
 	t.Run("tenant via REST/JSON", func(t *testing.T) {
-		resp, err := httpGet(ctx, env.baseURL+"/api/v1/tenants/multi-proto-tenant")
+		resp, err := httpGet(ctx, env.baseURL+"/v1/tenants/multi-proto-tenant")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/services/gateway/error_response_test.go
+++ b/services/gateway/error_response_test.go
@@ -55,7 +55,7 @@ func TestErrorReformattingMiddleware_RewritesErrorBody(t *testing.T) {
 
 	handler := errorReformattingMiddleware(inner)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/parties/x", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/parties/x", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -83,7 +83,7 @@ func TestErrorReformattingMiddleware_PassesThroughSuccessResponse(t *testing.T) 
 
 	handler := errorReformattingMiddleware(inner)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/parties/abc", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/parties/abc", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 

--- a/services/gateway/headers_test.go
+++ b/services/gateway/headers_test.go
@@ -237,7 +237,7 @@ func TestHeaderPropagationMiddleware_AllHeadersSet(t *testing.T) {
 		capturedHeaders = r.Header.Clone()
 	}))
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/party/create", nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/party/create", nil)
 	req.Host = "acme.api.meridian.io"
 	req.RemoteAddr = "192.168.1.100:45678"
 	req.Header.Set("x-tenant-id", "acme_corp") // Pre-set by TenantResolverMiddleware
@@ -350,7 +350,7 @@ func TestHeaderPropagationMiddleware_MiddlewareChainIntegration(t *testing.T) {
 
 	chain := tenantMiddleware(HeaderPropagationMiddleware(finalHandler))
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/test", nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/test", nil)
 	req.Host = "tenant1.api.meridian.io"
 	req.RemoteAddr = "203.0.113.100:12345"
 	rec := httptest.NewRecorder()

--- a/services/gateway/proxy_integration_test.go
+++ b/services/gateway/proxy_integration_test.go
@@ -78,7 +78,7 @@ func TestIntegration_ProxyToBackend(t *testing.T) {
 
 	// Test proxying to backend
 	t.Run("proxy routes to backend", func(t *testing.T) {
-		resp, err := httpPost(ctx, baseURL+"/api/v1/sagas/validate", "application/json", strings.NewReader(`{"saga_name":"test"}`))
+		resp, err := httpPost(ctx, baseURL+"/v1/sagas/validate", "application/json", strings.NewReader(`{"saga_name":"test"}`))
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -95,7 +95,7 @@ func TestIntegration_ProxyToBackend(t *testing.T) {
 
 	// Test 404 for unmatched routes
 	t.Run("unmatched routes return 404", func(t *testing.T) {
-		resp, err := httpGet(ctx, baseURL+"/api/v1/unmatched")
+		resp, err := httpGet(ctx, baseURL+"/v1/unmatched")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -163,7 +163,7 @@ func TestIntegration_ProxyForwardsIdentityHeaders(t *testing.T) {
 
 	// Verify proxy works (identity forwarding tested in unit tests)
 	t.Run("proxy works with backend", func(t *testing.T) {
-		resp, err := httpGet(ctx, baseURL+"/api/v1/test")
+		resp, err := httpGet(ctx, baseURL+"/v1/test")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -243,7 +243,7 @@ func TestIntegration_ProxyMultipleBackends(t *testing.T) {
 		sagaBackendCalled = false
 		partyBackendCalled = false
 
-		resp, err := httpGet(ctx, baseURL+"/api/v1/sagas/list")
+		resp, err := httpGet(ctx, baseURL+"/v1/sagas/list")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -260,7 +260,7 @@ func TestIntegration_ProxyMultipleBackends(t *testing.T) {
 		sagaBackendCalled = false
 		partyBackendCalled = false
 
-		resp, err := httpGet(ctx, baseURL+"/api/v1/party/create")
+		resp, err := httpGet(ctx, baseURL+"/v1/party/create")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -345,14 +345,14 @@ func TestIntegration_ProxySagaValidationEndpoint(t *testing.T) {
 	require.NoError(t, err, "gateway failed to become ready")
 
 	// Test saga validation endpoint
-	t.Run("POST /api/v1/sagas/validate routes correctly", func(t *testing.T) {
+	t.Run("POST /v1/sagas/validate routes correctly", func(t *testing.T) {
 		requestBody := `{
 			"saga_name": "test_payment_saga",
 			"script": "result = payment.create_lien(amount=\"100.00\")",
 			"version": "1.0.0"
 		}`
 
-		resp, err := httpPost(ctx, baseURL+"/api/v1/sagas/validate", "application/json", strings.NewReader(requestBody))
+		resp, err := httpPost(ctx, baseURL+"/v1/sagas/validate", "application/json", strings.NewReader(requestBody))
 		require.NoError(t, err)
 		defer resp.Body.Close()
 

--- a/services/gateway/server.go
+++ b/services/gateway/server.go
@@ -52,7 +52,7 @@ func WithHealthChecker(healthChecker *gwhealth.GatewayHealthChecker) ServerOptio
 }
 
 // WithTranscoder sets the Vanguard transcoder as the API handler, replacing
-// the legacy prefix-based reverse proxy. When set, all /api/ requests are
+// the legacy prefix-based reverse proxy. When set, all API requests are
 // dispatched through the transcoder rather than NewProxyHandler.
 func WithTranscoder(handler http.Handler) ServerOption {
 	return func(s *Server) {
@@ -123,13 +123,15 @@ func NewServer(config *Config, logger *slog.Logger, tenantResolver *platformgate
 // - 403 Forbidden is returned if authenticated but JWT tenant doesn't match subdomain tenant
 // - API keys bypass tenant authorization (service-to-service auth)
 func (s *Server) registerRoutes() {
-	// Health check endpoints - NO middleware (required for K8s probes)
-	s.mux.HandleFunc("GET /health", s.handleHealth)
-	s.mux.HandleFunc("GET /ready", s.handleReady)
+	// Health check endpoints - NO middleware (required for K8s probes).
+	// Registered without method constraints so they take precedence over the
+	// "/" catch-all for ALL methods, returning 405 for non-GET requests.
+	s.mux.HandleFunc("/health", s.getOnly(s.handleHealth))
+	s.mux.HandleFunc("/ready", s.getOnly(s.handleReady))
 
 	// Legacy health endpoints for backwards compatibility
-	s.mux.HandleFunc("GET /healthz", s.handleHealth)
-	s.mux.HandleFunc("GET /readyz", s.handleReady)
+	s.mux.HandleFunc("/healthz", s.getOnly(s.handleHealth))
+	s.mux.HandleFunc("/readyz", s.getOnly(s.handleReady))
 
 	// API routes - with auth and tenant middleware chain.
 	// Prefer the Vanguard transcoder when configured; fall back to the legacy
@@ -153,7 +155,7 @@ func (s *Server) registerRoutes() {
 	}
 
 	// Build middleware chain: auth → tenant → tenant_authz → transcoder/proxy
-	s.mux.Handle("/api/", s.wrapWithAuthChain(http.StripPrefix("/api", apiHandler)))
+	s.mux.Handle("/", s.wrapWithAuthChain(apiHandler))
 
 	// WebSocket event stream endpoint - with auth and tenant middleware chain.
 	// Claims are bridged from the gateway auth context to the eventstream context
@@ -209,6 +211,19 @@ func (s *Server) wrapWithAuthChain(inner http.Handler) http.Handler {
 	}
 
 	return handler
+}
+
+// getOnly wraps a handler to only accept GET (and HEAD) requests,
+// returning 405 Method Not Allowed for anything else.
+func (s *Server) getOnly(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", "GET, HEAD")
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h(w, r)
+	}
 }
 
 // handleHealth is the liveness probe endpoint.

--- a/services/gateway/server_integration_test.go
+++ b/services/gateway/server_integration_test.go
@@ -199,8 +199,8 @@ func TestIntegration_APIRoutes_RequiresTenantContext(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test API route returns placeholder response
-	t.Run("GET /api/v1/test returns 501 Not Implemented", func(t *testing.T) {
-		resp, err := httpGet(ctx, baseURL+"/api/v1/test")
+	t.Run("GET /v1/test returns 501 Not Implemented", func(t *testing.T) {
+		resp, err := httpGet(ctx, baseURL+"/v1/test")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 

--- a/services/gateway/server_test.go
+++ b/services/gateway/server_test.go
@@ -202,7 +202,7 @@ func TestAPIRoutes_WithoutTenantResolver(t *testing.T) {
 	server := NewServer(config, logger, nil)
 
 	// Request to API endpoint
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/test", nil)
 	rec := httptest.NewRecorder()
 
 	server.mux.ServeHTTP(rec, req)
@@ -234,7 +234,7 @@ func TestWithTranscoder_UsedOverProxy(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	server := NewServer(config, logger, nil, WithTranscoder(fakeTranscoder))
 
-	req := httptest.NewRequest(http.MethodPost, "/api/meridian.party.v1.PartyService/CreateParty", nil)
+	req := httptest.NewRequest(http.MethodPost, "/meridian.party.v1.PartyService/CreateParty", nil)
 	rec := httptest.NewRecorder()
 
 	server.mux.ServeHTTP(rec, req)
@@ -257,7 +257,7 @@ func TestWithTranscoder_FallsBackToProxy(t *testing.T) {
 	// No WithTranscoder option
 	server := NewServer(config, logger, nil)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/party", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/party", nil)
 	rec := httptest.NewRecorder()
 
 	server.mux.ServeHTTP(rec, req)
@@ -285,7 +285,7 @@ func TestWithTranscoder_StripsAndInjectsIdentityHeaders(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	server := NewServer(config, logger, nil, WithTranscoder(capture))
 
-	req := httptest.NewRequest(http.MethodPost, "/api/meridian.party.v1.PartyService/CreateParty", nil)
+	req := httptest.NewRequest(http.MethodPost, "/meridian.party.v1.PartyService/CreateParty", nil)
 	// Simulate spoofed headers from a malicious client.
 	req.Header.Set(HeaderUserID, "spoofed-user")
 	req.Header.Set(HeaderTenantID, "spoofed-tenant")
@@ -320,7 +320,7 @@ func TestWithTranscoder_VanguardFromDescriptor(t *testing.T) {
 	server := NewServer(config, logger, nil, WithTranscoder(transcoder))
 
 	// Send an unknown path — Vanguard returns 404, not a panic.
-	req := httptest.NewRequest(http.MethodGet, "/api/unknown/path", nil)
+	req := httptest.NewRequest(http.MethodGet, "/unknown/path", nil)
 	rec := httptest.NewRecorder()
 
 	assert.NotPanics(t, func() {
@@ -807,8 +807,9 @@ func TestWithEventStreamHandler_NotRegisteredWhenNil(t *testing.T) {
 	server.mux.ServeHTTP(rec, req)
 
 	// Without an event stream handler, the route is not registered.
-	// Go 1.22+ ServeMux returns 404 for unregistered routes.
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// The request falls through to the "/" catch-all API handler which
+	// returns 501 when no transcoder or proxy is configured.
+	assert.Equal(t, http.StatusNotImplemented, rec.Code)
 }
 
 // TestWithEventStreamHandler_HealthEndpointsUnaffected verifies that adding the

--- a/services/gateway/transcoding_bench_test.go
+++ b/services/gateway/transcoding_bench_test.go
@@ -197,7 +197,7 @@ func httpDo(b *testing.B, method, url, contentType, body string) {
 }
 
 // ---------------------------------------------------------------------------
-// Simple RPC benchmarks – GET /api/v1/parties/{id}  (RetrieveParty)
+// Simple RPC benchmarks – GET /v1/parties/{id}  (RetrieveParty)
 // ---------------------------------------------------------------------------
 
 // BenchmarkGRPC_RetrieveParty measures native gRPC latency for RetrieveParty.
@@ -229,7 +229,7 @@ func BenchmarkJSON_RetrieveParty(b *testing.B) {
 	})
 	defer env.cleanup()
 
-	url := env.baseURL + "/api/v1/parties/bench-party"
+	url := env.baseURL + "/v1/parties/bench-party"
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -239,7 +239,7 @@ func BenchmarkJSON_RetrieveParty(b *testing.B) {
 }
 
 // ---------------------------------------------------------------------------
-// Mutation RPC benchmarks – POST /api/v1/parties  (RegisterParty)
+// Mutation RPC benchmarks – POST /v1/parties  (RegisterParty)
 // ---------------------------------------------------------------------------
 
 // BenchmarkGRPC_RegisterParty measures native gRPC latency for RegisterParty (POST with body).
@@ -273,7 +273,7 @@ func BenchmarkJSON_RegisterParty(b *testing.B) {
 	})
 	defer env.cleanup()
 
-	url := env.baseURL + "/api/v1/parties"
+	url := env.baseURL + "/v1/parties"
 	body := `{"partyType":"PARTY_TYPE_PERSON","legalName":"Bench User","displayName":"Bench"}`
 
 	b.ReportAllocs()
@@ -284,7 +284,7 @@ func BenchmarkJSON_RegisterParty(b *testing.B) {
 }
 
 // ---------------------------------------------------------------------------
-// List RPC benchmarks – GET /api/v1/tenants  (ListTenants)
+// List RPC benchmarks – GET /v1/tenants  (ListTenants)
 // ---------------------------------------------------------------------------
 
 // BenchmarkGRPC_ListTenants measures native gRPC latency for ListTenants (response with array).
@@ -314,7 +314,7 @@ func BenchmarkJSON_ListTenants(b *testing.B) {
 	})
 	defer env.cleanup()
 
-	url := env.baseURL + "/api/v1/tenants"
+	url := env.baseURL + "/v1/tenants"
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -324,7 +324,7 @@ func BenchmarkJSON_ListTenants(b *testing.B) {
 }
 
 // ---------------------------------------------------------------------------
-// Complex RPC benchmarks – POST /api/v1/sagas/validate  (ValidateSaga)
+// Complex RPC benchmarks – POST /v1/sagas/validate  (ValidateSaga)
 // ---------------------------------------------------------------------------
 
 // BenchmarkGRPC_ValidateSaga measures native gRPC latency for ValidateSaga (complex request + response).
@@ -358,7 +358,7 @@ func BenchmarkJSON_ValidateSaga(b *testing.B) {
 	})
 	defer env.cleanup()
 
-	url := env.baseURL + "/api/v1/sagas/validate"
+	url := env.baseURL + "/v1/sagas/validate"
 	body := `{"sagaName":"bench_saga","script":"result = payment.create_lien(amount=\"100.00\", direction=\"DEBIT\")","version":"1.0.0"}`
 
 	b.ReportAllocs()
@@ -401,7 +401,7 @@ func BenchmarkJSON_RetrieveParty_Parallel(b *testing.B) {
 	})
 	defer env.cleanup()
 
-	url := env.baseURL + "/api/v1/parties/bench-party"
+	url := env.baseURL + "/v1/parties/bench-party"
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/services/gateway/transcoding_test.go
+++ b/services/gateway/transcoding_test.go
@@ -282,7 +282,7 @@ func readJSONBody(t *testing.T, resp *http.Response) map[string]interface{} {
 // Integration Tests
 // ---------------------------------------------------------------------------
 
-// TestTranscoding_PartyService_RegisterParty tests POST /api/v1/parties end-to-end.
+// TestTranscoding_PartyService_RegisterParty tests POST /v1/parties end-to-end.
 func TestTranscoding_PartyService_RegisterParty(t *testing.T) {
 	env := startTranscodingTestEnv(t, []ServiceBackend{
 		{ServiceName: "meridian.party.v1.PartyService"},
@@ -294,7 +294,7 @@ func TestTranscoding_PartyService_RegisterParty(t *testing.T) {
 		"displayName": "Alice"
 	}`
 
-	resp, err := httpPost(context.Background(), env.baseURL+"/api/v1/parties", "application/json", strings.NewReader(body))
+	resp, err := httpPost(context.Background(), env.baseURL+"/v1/parties", "application/json", strings.NewReader(body))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -316,13 +316,13 @@ func TestTranscoding_PartyService_RegisterParty(t *testing.T) {
 	assert.NotEmpty(t, party["updatedAt"])
 }
 
-// TestTranscoding_PartyService_RetrieveParty tests GET /api/v1/parties/{party_id}.
+// TestTranscoding_PartyService_RetrieveParty tests GET /v1/parties/{party_id}.
 func TestTranscoding_PartyService_RetrieveParty(t *testing.T) {
 	env := startTranscodingTestEnv(t, []ServiceBackend{
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/party-123")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/party-123")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -342,13 +342,13 @@ func TestTranscoding_PartyService_RetrieveParty(t *testing.T) {
 	assert.NoError(t, err, "createdAt should be RFC3339: %s", createdAt)
 }
 
-// TestTranscoding_TenantService_RetrieveTenant tests GET /api/v1/tenants/{tenant_id}.
+// TestTranscoding_TenantService_RetrieveTenant tests GET /v1/tenants/{tenant_id}.
 func TestTranscoding_TenantService_RetrieveTenant(t *testing.T) {
 	env := startTranscodingTestEnv(t, []ServiceBackend{
 		{ServiceName: "meridian.tenant.v1.TenantService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/tenants/acme_corp")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/tenants/acme_corp")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -365,13 +365,13 @@ func TestTranscoding_TenantService_RetrieveTenant(t *testing.T) {
 	assert.Equal(t, "acme-corp", tenant["slug"])
 }
 
-// TestTranscoding_TenantService_ListTenants tests GET /api/v1/tenants.
+// TestTranscoding_TenantService_ListTenants tests GET /v1/tenants.
 func TestTranscoding_TenantService_ListTenants(t *testing.T) {
 	env := startTranscodingTestEnv(t, []ServiceBackend{
 		{ServiceName: "meridian.tenant.v1.TenantService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/tenants")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/tenants")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -383,13 +383,13 @@ func TestTranscoding_TenantService_ListTenants(t *testing.T) {
 	assert.Len(t, tenants, 1)
 }
 
-// TestTranscoding_SagaRegistryService_ListSagas tests GET /api/v1/sagas.
+// TestTranscoding_SagaRegistryService_ListSagas tests GET /v1/sagas.
 func TestTranscoding_SagaRegistryService_ListSagas(t *testing.T) {
 	env := startTranscodingTestEnv(t, []ServiceBackend{
 		{ServiceName: "meridian.saga.v1.SagaRegistryService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/sagas")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/sagas")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -405,7 +405,7 @@ func TestTranscoding_SagaRegistryService_ListSagas(t *testing.T) {
 	assert.Equal(t, "SAGA_STATUS_ACTIVE", saga["status"])
 }
 
-// TestTranscoding_SagaRegistryService_ValidateSaga tests POST /api/v1/sagas/validate.
+// TestTranscoding_SagaRegistryService_ValidateSaga tests POST /v1/sagas/validate.
 func TestTranscoding_SagaRegistryService_ValidateSaga(t *testing.T) {
 	env := startTranscodingTestEnv(t, []ServiceBackend{
 		{ServiceName: "meridian.saga.v1.SagaRegistryService"},
@@ -417,7 +417,7 @@ func TestTranscoding_SagaRegistryService_ValidateSaga(t *testing.T) {
 		"version": "1.0.0"
 	}`
 
-	resp, err := httpPost(context.Background(), env.baseURL+"/api/v1/sagas/validate", "application/json", strings.NewReader(body))
+	resp, err := httpPost(context.Background(), env.baseURL+"/v1/sagas/validate", "application/json", strings.NewReader(body))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -442,7 +442,7 @@ func TestTranscoding_MultipleServices(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("party service via /v1/parties", func(t *testing.T) {
-		resp, err := httpGet(ctx, env.baseURL+"/api/v1/parties/multi-test")
+		resp, err := httpGet(ctx, env.baseURL+"/v1/parties/multi-test")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -453,7 +453,7 @@ func TestTranscoding_MultipleServices(t *testing.T) {
 	})
 
 	t.Run("tenant service via /v1/tenants", func(t *testing.T) {
-		resp, err := httpGet(ctx, env.baseURL+"/api/v1/tenants")
+		resp, err := httpGet(ctx, env.baseURL+"/v1/tenants")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -464,7 +464,7 @@ func TestTranscoding_MultipleServices(t *testing.T) {
 	})
 
 	t.Run("saga service via /v1/sagas", func(t *testing.T) {
-		resp, err := httpGet(ctx, env.baseURL+"/api/v1/sagas")
+		resp, err := httpGet(ctx, env.baseURL+"/v1/sagas")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -486,7 +486,7 @@ func TestTranscoding_Proto3JSON_CamelCaseFields(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/camel-test")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/camel-test")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -518,7 +518,7 @@ func TestTranscoding_Proto3JSON_EnumAsStrings(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/enum-test")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/enum-test")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -537,7 +537,7 @@ func TestTranscoding_Proto3JSON_RFC3339Timestamps(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/ts-test")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/ts-test")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -567,7 +567,7 @@ func TestTranscoding_Proto3JSON_NestedMessage(t *testing.T) {
 		"displayName": "NC"
 	}`
 
-	resp, err := httpPost(context.Background(), env.baseURL+"/api/v1/parties", "application/json", strings.NewReader(body))
+	resp, err := httpPost(context.Background(), env.baseURL+"/v1/parties", "application/json", strings.NewReader(body))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -594,7 +594,7 @@ func TestTranscoding_Error_NotFound(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/not-found")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/not-found")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -612,7 +612,7 @@ func TestTranscoding_Error_InvalidArgument(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/invalid")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/invalid")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -629,7 +629,7 @@ func TestTranscoding_Error_Unauthenticated(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/unauthenticated")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/unauthenticated")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -646,7 +646,7 @@ func TestTranscoding_Error_PermissionDenied(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/permission-denied")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/permission-denied")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -663,7 +663,7 @@ func TestTranscoding_Error_Internal(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/internal")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/internal")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -680,7 +680,7 @@ func TestTranscoding_Error_DeadlineExceeded(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/deadline-exceeded")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/deadline-exceeded")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -697,7 +697,7 @@ func TestTranscoding_Error_Unavailable(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/unavailable")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/unavailable")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -714,7 +714,7 @@ func TestTranscoding_Error_DataLoss(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/data-loss")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/data-loss")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -731,7 +731,7 @@ func TestTranscoding_Error_Unknown(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/unknown")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/unknown")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -770,7 +770,7 @@ func TestTranscoding_Error_AllStandardCodes(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.grpcCode, func(t *testing.T) {
-			resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/"+tc.partyID)
+			resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/"+tc.partyID)
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
@@ -790,7 +790,7 @@ func TestTranscoding_Error_BodyFormat(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/not-found")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/not-found")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -820,7 +820,7 @@ func TestTranscoding_Error_ContentTypeJSON(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/not-found")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/not-found")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -837,7 +837,7 @@ func TestTranscoding_Error_MalformedRequestBody(t *testing.T) {
 	})
 
 	// Send malformed JSON to a POST endpoint
-	resp, err := httpPost(context.Background(), env.baseURL+"/api/v1/parties", "application/json", strings.NewReader("this is not json"))
+	resp, err := httpPost(context.Background(), env.baseURL+"/v1/parties", "application/json", strings.NewReader("this is not json"))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -861,7 +861,7 @@ func TestTranscoding_Error_NotFoundTenant(t *testing.T) {
 		{ServiceName: "meridian.tenant.v1.TenantService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/tenants/not-found")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/tenants/not-found")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -877,7 +877,7 @@ func TestTranscoding_Error_UnknownRoute(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/nonexistent/path")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/nonexistent/path")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -944,7 +944,7 @@ func TestTranscoding_MetadataPropagation(t *testing.T) {
 
 	t.Run("identity headers stripped from client requests", func(t *testing.T) {
 		// Send request with spoofed identity headers.
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/v1/parties/meta-test", nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v1/parties/meta-test", nil)
 		require.NoError(t, err)
 		req.Header.Set("X-User-ID", "spoofed-user")
 		req.Header.Set("X-Tenant-ID", "spoofed-tenant")
@@ -985,7 +985,7 @@ func TestTranscoding_RequestBody_AcceptsCamelCase(t *testing.T) {
 	// camelCase field names
 	body := `{"partyType":"PARTY_TYPE_PERSON","legalName":"Camel Alice","displayName":"CA"}`
 
-	resp, err := httpPost(context.Background(), env.baseURL+"/api/v1/parties", "application/json", strings.NewReader(body))
+	resp, err := httpPost(context.Background(), env.baseURL+"/v1/parties", "application/json", strings.NewReader(body))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -1007,7 +1007,7 @@ func TestTranscoding_RequestBody_AcceptsSnakeCase(t *testing.T) {
 	// snake_case field names
 	body := `{"party_type":"PARTY_TYPE_PERSON","legal_name":"Snake Alice","display_name":"SA"}`
 
-	resp, err := httpPost(context.Background(), env.baseURL+"/api/v1/parties", "application/json", strings.NewReader(body))
+	resp, err := httpPost(context.Background(), env.baseURL+"/v1/parties", "application/json", strings.NewReader(body))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -1025,7 +1025,7 @@ func TestTranscoding_ContentType_JSON(t *testing.T) {
 		{ServiceName: "meridian.party.v1.PartyService"},
 	})
 
-	resp, err := httpGet(context.Background(), env.baseURL+"/api/v1/parties/content-type-test")
+	resp, err := httpGet(context.Background(), env.baseURL+"/v1/parties/content-type-test")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 


### PR DESCRIPTION
## Summary

- Remove the redundant `/api/` prefix from the gateway HTTP mux. ConnectRPC paths are already self-namespaced by protobuf package (e.g. `/meridian.party.v1.PartyService/ListParties`), so the prefix caused 404s from the frontend which uses standard ConnectRPC conventions.
- Register 4 services missing from the Vanguard transcoder that the frontend needs: `SagaAdminService`, `ManifestHistoryService`, `AccountTypeRegistryService`, `MappingService`.

## Changes

**Production code (2 files):**
- `services/gateway/server.go`: Mount transcoder on `/` instead of `/api/`. Health endpoints use `getOnly()` wrapper to preserve 405 responses for non-GET methods despite the `/` catch-all.
- `cmd/meridian/main.go`: Add 4 missing services to `serviceNames` for Vanguard registration.

**Tests (8 files):**
- Updated ~100 URL references across gateway test files to remove `/api` prefix.
- Middleware unit tests unchanged (path is arbitrary in those tests).

**Docs (1 file):**
- `services/gateway/README.md`: Updated path examples.

## How it works

Before: `POST http://host/meridian.party.v1.PartyService/ListParties` → 404 (no `/api/` prefix)
After: `POST http://host/meridian.party.v1.PartyService/ListParties` → Vanguard transcoder → gRPC backend

Go's `ServeMux` longest-prefix matching ensures explicit health routes (`/health`, `/ready`) still take precedence over the `/` catch-all.

## Test plan

- [x] `go build ./cmd/meridian/...` compiles
- [x] Gateway unit tests pass (`go test ./services/gateway -count=1`)
- [x] Auth middleware tests pass (`go test ./services/gateway/auth -count=1`)
- [x] Internal middleware tests pass (`go test ./services/gateway/internal/middleware -count=1`)
- [ ] CI passes