### PR TITLE
feat: add economy design tools for manifest lifecycle

### DIFF
--- a/services/mcp-server/internal/tools/economy.go
+++ b/services/mcp-server/internal/tools/economy.go
@@ -1,0 +1,465 @@
+// Package tools provides the tool registry for the MCP server.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	mcperrors "github.com/meridianhub/meridian/services/mcp-server/internal/errors"
+)
+
+// PlanStore abstracts the session plan cache to avoid an import cycle
+// between tools and session packages. The session.Session type satisfies
+// this interface.
+type PlanStore interface {
+	// StorePlan hashes the manifest bytes and stores the result. Returns the hash.
+	StorePlan(manifest []byte) string
+	// ValidatePlan returns true when a plan with the given hash exists and has not expired.
+	ValidatePlan(hash string) bool
+}
+
+// ManifestApplier is the minimal interface for validating, planning, and applying manifests.
+type ManifestApplier interface {
+	ApplyManifest(ctx context.Context, req *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error)
+}
+
+// ManifestHistorian is the minimal interface for querying manifest version history.
+type ManifestHistorian interface {
+	ListManifestVersions(ctx context.Context, req *controlplanev1.ListManifestVersionsRequest) (*controlplanev1.ListManifestVersionsResponse, error)
+}
+
+// EconomyDeps holds all service clients used by economy design tools.
+type EconomyDeps struct {
+	Applier   ManifestApplier
+	Historian ManifestHistorian
+}
+
+// RegisterEconomyTools registers the manifest lifecycle tools into the registry.
+// Tools whose required client is nil are silently skipped.
+func RegisterEconomyTools(registry *Registry, sess PlanStore, deps EconomyDeps) {
+	var candidates []Tool
+
+	if deps.Applier != nil {
+		candidates = append(candidates, buildManifestValidateTool(deps.Applier))
+		candidates = append(candidates, buildManifestPlanTool(deps.Applier, sess))
+		candidates = append(candidates, buildManifestApplyTool(deps.Applier, sess))
+	}
+	if deps.Historian != nil {
+		candidates = append(candidates, buildManifestHistoryTool(deps.Historian))
+	}
+
+	for _, t := range candidates {
+		if err := registry.Register(t); err != nil {
+			panic(fmt.Sprintf("failed to register economy tool %q: %v", t.Name, err))
+		}
+	}
+}
+
+// manifestJSONToProto converts a JSON manifest object into a controlplanev1.Manifest proto.
+func manifestJSONToProto(manifestJSON json.RawMessage) (*controlplanev1.Manifest, error) {
+	m := &controlplanev1.Manifest{}
+	opts := protojson.UnmarshalOptions{DiscardUnknown: true}
+	if err := opts.Unmarshal(manifestJSON, m); err != nil {
+		return nil, fmt.Errorf("invalid manifest JSON: %w", err)
+	}
+	return m, nil
+}
+
+// buildManifestValidateTool returns the meridian_manifest_validate tool.
+func buildManifestValidateTool(client ManifestApplier) Tool {
+	return Tool{
+		Name:     "meridian_manifest_validate",
+		Category: CategorySimulate,
+		Description: "Validate a manifest YAML/JSON without applying it. " +
+			"Runs structural validation and returns any errors with paths and suggestions. " +
+			"Use this to check a manifest before planning or applying.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"manifest": map[string]interface{}{
+					"type":        "object",
+					"description": "The manifest JSON object to validate.",
+				},
+			},
+			"required": []interface{}{"manifest"},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			return handleManifestValidate(ctx, client, params)
+		},
+	}
+}
+
+// manifestValidateParams holds parsed parameters for meridian_manifest_validate.
+type manifestValidateParams struct {
+	Manifest json.RawMessage `json:"manifest"`
+}
+
+// handleManifestValidate implements the meridian_manifest_validate handler logic.
+func handleManifestValidate(ctx context.Context, client ManifestApplier, params json.RawMessage) (interface{}, error) {
+	var p manifestValidateParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	manifest, err := manifestJSONToProto(p.Manifest)
+	if err != nil {
+		return map[string]interface{}{ //nolint:nilerr // err is surfaced in the tool response
+			"valid":  false,
+			"errors": []interface{}{map[string]interface{}{"type": mcperrors.TypeManifestValidation, "message": err.Error()}},
+		}, nil
+	}
+
+	resp, err := client.ApplyManifest(ctx, &controlplanev1.ApplyManifestRequest{
+		Manifest:  manifest,
+		DryRun:    true,
+		AppliedBy: "mcp-server-validate",
+	})
+	if err != nil {
+		formatted := mcperrors.FormatGRPCError(err)
+		return map[string]interface{}{
+			"valid":  false,
+			"errors": formatValidationErrors(formatted.Errors),
+		}, nil
+	}
+
+	if resp.Status == controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_VALIDATION_FAILED {
+		return map[string]interface{}{
+			"valid":  false,
+			"errors": formatProtoValidationErrors(resp.ValidationErrors),
+		}, nil
+	}
+
+	return map[string]interface{}{
+		"valid":   true,
+		"message": "Manifest is valid",
+	}, nil
+}
+
+// buildManifestPlanTool returns the meridian_manifest_plan tool.
+func buildManifestPlanTool(client ManifestApplier, sess PlanStore) Tool {
+	return Tool{
+		Name:     "meridian_manifest_plan",
+		Category: CategoryWrite,
+		Description: "Dry-run a manifest apply and store the result for later application. " +
+			"Returns a diff summary and a plan_hash that must be provided to meridian_manifest_apply. " +
+			"Use this to preview changes before committing them.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"manifest": map[string]interface{}{
+					"type":        "object",
+					"description": "The manifest JSON object to plan.",
+				},
+			},
+			"required": []interface{}{"manifest"},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			return handleManifestPlan(ctx, client, sess, params)
+		},
+	}
+}
+
+// manifestPlanParams holds parsed parameters for meridian_manifest_plan.
+type manifestPlanParams struct {
+	Manifest json.RawMessage `json:"manifest"`
+}
+
+// handleManifestPlan implements the meridian_manifest_plan handler logic.
+func handleManifestPlan(ctx context.Context, client ManifestApplier, sess PlanStore, params json.RawMessage) (interface{}, error) {
+	var p manifestPlanParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	manifest, err := manifestJSONToProto(p.Manifest)
+	if err != nil {
+		return map[string]interface{}{ //nolint:nilerr // err is surfaced in the tool response
+			"valid":  false,
+			"errors": []interface{}{map[string]interface{}{"type": mcperrors.TypeManifestValidation, "message": err.Error()}},
+		}, nil
+	}
+
+	resp, err := client.ApplyManifest(ctx, &controlplanev1.ApplyManifestRequest{
+		Manifest:  manifest,
+		DryRun:    true,
+		AppliedBy: "mcp-server-plan",
+	})
+	if err != nil {
+		formatted := mcperrors.FormatGRPCError(err)
+		return map[string]interface{}{
+			"valid":  false,
+			"errors": formatValidationErrors(formatted.Errors),
+		}, nil
+	}
+
+	if resp.Status == controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_VALIDATION_FAILED {
+		return map[string]interface{}{
+			"valid":  false,
+			"errors": formatProtoValidationErrors(resp.ValidationErrors),
+		}, nil
+	}
+
+	// Store the manifest in the plan cache so apply can verify it.
+	planHash := sess.StorePlan(p.Manifest)
+
+	result := map[string]interface{}{
+		"valid":     true,
+		"plan_hash": planHash,
+		"status":    resp.Status.String(),
+	}
+	if resp.DiffSummary != "" {
+		result["diff_summary"] = resp.DiffSummary
+	}
+	if len(resp.StepResults) > 0 {
+		result["steps"] = formatStepResults(resp.StepResults)
+	}
+	return result, nil
+}
+
+// buildManifestApplyTool returns the meridian_manifest_apply tool.
+func buildManifestApplyTool(client ManifestApplier, sess PlanStore) Tool {
+	return Tool{
+		Name:     "meridian_manifest_apply",
+		Category: CategoryWrite,
+		Description: "Apply a manifest that has been previously planned. " +
+			"Requires a valid plan_hash from meridian_manifest_plan. " +
+			"This enforces the plan-before-apply workflow for safety.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"manifest": map[string]interface{}{
+					"type":        "object",
+					"description": "The manifest JSON object to apply (must match the planned manifest).",
+				},
+				"plan_hash": map[string]interface{}{
+					"type":        "string",
+					"description": "The plan hash returned by meridian_manifest_plan.",
+				},
+				"applied_by": map[string]interface{}{
+					"type":        "string",
+					"description": "Identifier of who is applying this manifest (e.g., user email).",
+				},
+			},
+			"required": []interface{}{"manifest", "plan_hash", "applied_by"},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			return handleManifestApply(ctx, client, sess, params)
+		},
+	}
+}
+
+// manifestApplyParams holds parsed parameters for meridian_manifest_apply.
+type manifestApplyParams struct {
+	Manifest  json.RawMessage `json:"manifest"`
+	PlanHash  string          `json:"plan_hash"`
+	AppliedBy string          `json:"applied_by"`
+}
+
+// handleManifestApply implements the meridian_manifest_apply handler logic.
+func handleManifestApply(ctx context.Context, client ManifestApplier, sess PlanStore, params json.RawMessage) (interface{}, error) {
+	var p manifestApplyParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	// Enforce plan-before-apply: the plan hash must exist in the session cache.
+	if !sess.ValidatePlan(p.PlanHash) {
+		return map[string]interface{}{
+			"error":   "no valid plan found for this manifest",
+			"message": "You must run meridian_manifest_plan first and provide the returned plan_hash.",
+		}, nil
+	}
+
+	manifest, err := manifestJSONToProto(p.Manifest)
+	if err != nil {
+		return map[string]interface{}{ //nolint:nilerr // err is surfaced in the tool response
+			"valid":  false,
+			"errors": []interface{}{map[string]interface{}{"type": mcperrors.TypeManifestValidation, "message": err.Error()}},
+		}, nil
+	}
+
+	resp, err := client.ApplyManifest(ctx, &controlplanev1.ApplyManifestRequest{
+		Manifest:  manifest,
+		DryRun:    false,
+		AppliedBy: p.AppliedBy,
+	})
+	if err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	result := map[string]interface{}{
+		"status": resp.Status.String(),
+	}
+	if resp.JobId != "" {
+		result["job_id"] = resp.JobId
+	}
+	if resp.DiffSummary != "" {
+		result["diff_summary"] = resp.DiffSummary
+	}
+	if len(resp.StepResults) > 0 {
+		result["steps"] = formatStepResults(resp.StepResults)
+	}
+	if resp.Snapshot != nil {
+		result["snapshot"] = formatManifestVersion(resp.Snapshot)
+	}
+	if resp.Status == controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_VALIDATION_FAILED {
+		result["validation_errors"] = formatProtoValidationErrors(resp.ValidationErrors)
+	}
+	return result, nil
+}
+
+// buildManifestHistoryTool returns the meridian_manifest_history tool.
+func buildManifestHistoryTool(client ManifestHistorian) Tool {
+	return Tool{
+		Name:     "meridian_manifest_history",
+		Category: CategoryRead,
+		Description: "Query manifest version history for the current tenant. " +
+			"Returns a paginated list of manifest versions with apply status and timestamps. " +
+			"Use this to review the change history of a tenant's economy configuration.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"limit": map[string]interface{}{
+					"type":        "integer",
+					"description": "Maximum number of versions to return (default 20, max 100).",
+					"minimum":     1,
+					"maximum":     100,
+				},
+				"offset": map[string]interface{}{
+					"type":        "integer",
+					"description": "Number of versions to skip for pagination.",
+					"minimum":     0,
+				},
+			},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			return handleManifestHistory(ctx, client, params)
+		},
+	}
+}
+
+// manifestHistoryParams holds parsed parameters for meridian_manifest_history.
+type manifestHistoryParams struct {
+	Limit  int32 `json:"limit"`
+	Offset int32 `json:"offset"`
+}
+
+// handleManifestHistory implements the meridian_manifest_history handler logic.
+func handleManifestHistory(ctx context.Context, client ManifestHistorian, params json.RawMessage) (interface{}, error) {
+	var p manifestHistoryParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	req := &controlplanev1.ListManifestVersionsRequest{}
+	if p.Limit > 0 {
+		req.Limit = p.Limit
+	}
+	if p.Offset > 0 {
+		req.Offset = p.Offset
+	}
+
+	resp, err := client.ListManifestVersions(ctx, req)
+	if err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	if len(resp.Versions) == 0 {
+		return map[string]interface{}{
+			"message":     "no manifest versions found",
+			"versions":    []interface{}{},
+			"total_count": resp.TotalCount,
+		}, nil
+	}
+
+	versions := make([]map[string]interface{}, 0, len(resp.Versions))
+	for _, v := range resp.Versions {
+		versions = append(versions, formatManifestVersion(v))
+	}
+
+	return map[string]interface{}{
+		"count":       len(versions),
+		"total_count": resp.TotalCount,
+		"versions":    versions,
+	}, nil
+}
+
+// formatManifestVersion formats a ManifestVersion for LLM consumption.
+func formatManifestVersion(v *controlplanev1.ManifestVersion) map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	entry := map[string]interface{}{
+		"id":           v.Id,
+		"version":      v.Version,
+		"apply_status": v.ApplyStatus.String(),
+		"applied_by":   v.AppliedBy,
+	}
+	if v.AppliedAt != nil {
+		entry["applied_at"] = v.AppliedAt.AsTime().Format(time.RFC3339)
+	}
+	if v.CreatedAt != nil {
+		entry["created_at"] = v.CreatedAt.AsTime().Format(time.RFC3339)
+	}
+	if v.ApplyJobId != nil {
+		entry["apply_job_id"] = *v.ApplyJobId
+	}
+	if v.DiffSummary != nil {
+		entry["diff_summary"] = *v.DiffSummary
+	}
+	return entry
+}
+
+// formatStepResults formats a slice of StepResult for LLM consumption.
+func formatStepResults(steps []*controlplanev1.StepResult) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(steps))
+	for _, s := range steps {
+		entry := map[string]interface{}{
+			"step_name": s.StepName,
+			"status":    s.Status.String(),
+		}
+		if s.Message != "" {
+			entry["message"] = s.Message
+		}
+		if len(s.Details) > 0 {
+			entry["details"] = s.Details
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+// formatProtoValidationErrors formats proto ValidationError messages for tool responses.
+func formatProtoValidationErrors(errs []*controlplanev1.ValidationError) []interface{} {
+	result := make([]interface{}, 0, len(errs))
+	for _, e := range errs {
+		entry := map[string]interface{}{
+			"type":    mcperrors.TypeManifestValidation,
+			"message": e.Message,
+		}
+		if e.Path != "" {
+			entry["path"] = e.Path
+		}
+		if e.Code != "" {
+			entry["code"] = e.Code
+		}
+		if e.Severity != "" {
+			entry["severity"] = e.Severity
+		}
+		if e.Suggestion != "" {
+			entry["suggestion"] = e.Suggestion
+		}
+		result = append(result, entry)
+	}
+	return result
+}
+
+// formatValidationErrors converts mcperrors.ErrorDetail into tool-response-compatible format.
+func formatValidationErrors(details []mcperrors.ErrorDetail) []interface{} {
+	return formatErrorDetails(details)
+}

--- a/services/mcp-server/internal/tools/economy.go
+++ b/services/mcp-server/internal/tools/economy.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
 	mcperrors "github.com/meridianhub/meridian/services/mcp-server/internal/errors"
@@ -48,8 +49,10 @@ func RegisterEconomyTools(registry *Registry, sess PlanStore, deps EconomyDeps) 
 
 	if deps.Applier != nil {
 		candidates = append(candidates, buildManifestValidateTool(deps.Applier))
-		candidates = append(candidates, buildManifestPlanTool(deps.Applier, sess))
-		candidates = append(candidates, buildManifestApplyTool(deps.Applier, sess))
+		if sess != nil {
+			candidates = append(candidates, buildManifestPlanTool(deps.Applier, sess))
+			candidates = append(candidates, buildManifestApplyTool(deps.Applier, sess))
+		}
 	}
 	if deps.Historian != nil {
 		candidates = append(candidates, buildManifestHistoryTool(deps.Historian))
@@ -206,8 +209,12 @@ func handleManifestPlan(ctx context.Context, client ManifestApplier, sess PlanSt
 		}, nil
 	}
 
-	// Store the manifest in the plan cache so apply can verify it.
-	planHash := sess.StorePlan(p.Manifest)
+	// Store canonical manifest bytes so semantically equivalent JSON hashes identically.
+	canonicalBytes, err := canonicalManifestBytes(manifest)
+	if err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+	planHash := sess.StorePlan(canonicalBytes)
 
 	result := map[string]interface{}{
 		"valid":     true,
@@ -277,22 +284,26 @@ func handleManifestApply(ctx context.Context, client ManifestApplier, sess PlanS
 		}, nil
 	}
 
-	// Verify that the manifest content matches the planned manifest by comparing
-	// the SHA256 hash of the apply-time manifest against the provided plan_hash.
-	// This prevents applying a different manifest than what was planned.
-	contentHash := sha256Hex(p.Manifest)
-	if contentHash != p.PlanHash {
-		return map[string]interface{}{
-			"error":   "manifest content does not match the planned manifest",
-			"message": "The manifest provided to apply differs from the one used during plan. Re-run meridian_manifest_plan with the updated manifest.",
-		}, nil
-	}
-
 	manifest, err := manifestJSONToProto(p.Manifest)
 	if err != nil {
 		return map[string]interface{}{ //nolint:nilerr // err is surfaced in the tool response
 			"valid":  false,
 			"errors": []interface{}{map[string]interface{}{"type": mcperrors.TypeManifestValidation, "message": err.Error()}},
+		}, nil
+	}
+
+	// Verify manifest content matches the plan by comparing canonical proto bytes.
+	// This is whitespace/key-order agnostic since we canonicalize via deterministic
+	// proto marshaling before hashing.
+	canonicalBytes, err := canonicalManifestBytes(manifest)
+	if err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+	contentHash := sha256Hex(canonicalBytes)
+	if contentHash != p.PlanHash {
+		return map[string]interface{}{
+			"error":   "manifest content does not match the planned manifest",
+			"message": "The manifest provided to apply differs from the one used during plan. Re-run meridian_manifest_plan with the updated manifest.",
 		}, nil
 	}
 
@@ -475,6 +486,17 @@ func formatProtoValidationErrors(errs []*controlplanev1.ValidationError) []inter
 // formatValidationErrors converts mcperrors.ErrorDetail into tool-response-compatible format.
 func formatValidationErrors(details []mcperrors.ErrorDetail) []interface{} {
 	return formatErrorDetails(details)
+}
+
+// canonicalManifestBytes returns deterministic proto-encoded bytes for a manifest.
+// This ensures semantically equivalent manifests (differing only in JSON key
+// order or whitespace) produce identical hashes.
+func canonicalManifestBytes(m *controlplanev1.Manifest) ([]byte, error) {
+	b, err := proto.MarshalOptions{Deterministic: true}.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to canonicalize manifest: %w", err)
+	}
+	return b, nil
 }
 
 // sha256Hex returns the hex-encoded SHA256 digest of data.

--- a/services/mcp-server/internal/tools/economy.go
+++ b/services/mcp-server/internal/tools/economy.go
@@ -3,6 +3,8 @@ package tools
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -275,6 +277,17 @@ func handleManifestApply(ctx context.Context, client ManifestApplier, sess PlanS
 		}, nil
 	}
 
+	// Verify that the manifest content matches the planned manifest by comparing
+	// the SHA256 hash of the apply-time manifest against the provided plan_hash.
+	// This prevents applying a different manifest than what was planned.
+	contentHash := sha256Hex(p.Manifest)
+	if contentHash != p.PlanHash {
+		return map[string]interface{}{
+			"error":   "manifest content does not match the planned manifest",
+			"message": "The manifest provided to apply differs from the one used during plan. Re-run meridian_manifest_plan with the updated manifest.",
+		}, nil
+	}
+
 	manifest, err := manifestJSONToProto(p.Manifest)
 	if err != nil {
 		return map[string]interface{}{ //nolint:nilerr // err is surfaced in the tool response
@@ -462,4 +475,10 @@ func formatProtoValidationErrors(errs []*controlplanev1.ValidationError) []inter
 // formatValidationErrors converts mcperrors.ErrorDetail into tool-response-compatible format.
 func formatValidationErrors(details []mcperrors.ErrorDetail) []interface{} {
 	return formatErrorDetails(details)
+}
+
+// sha256Hex returns the hex-encoded SHA256 digest of data.
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }

--- a/services/mcp-server/internal/tools/economy_test.go
+++ b/services/mcp-server/internal/tools/economy_test.go
@@ -1,0 +1,676 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/session"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+)
+
+// --- Mock implementations ---
+
+type mockManifestApplier struct {
+	applyFn func(ctx context.Context, req *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error)
+}
+
+func (m *mockManifestApplier) ApplyManifest(ctx context.Context, req *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+	return m.applyFn(ctx, req)
+}
+
+type mockManifestHistorian struct {
+	listFn func(ctx context.Context, req *controlplanev1.ListManifestVersionsRequest) (*controlplanev1.ListManifestVersionsResponse, error)
+}
+
+func (m *mockManifestHistorian) ListManifestVersions(ctx context.Context, req *controlplanev1.ListManifestVersionsRequest) (*controlplanev1.ListManifestVersionsResponse, error) {
+	return m.listFn(ctx, req)
+}
+
+// validManifestJSON returns a minimal valid manifest JSON for testing.
+func validManifestJSON() json.RawMessage {
+	return json.RawMessage(`{
+		"version": "1.0",
+		"metadata": {"name": "Test Economy", "industry": "energy", "description": "Test"}
+	}`)
+}
+
+// newTestSession creates a session with a short TTL suitable for tests.
+func newTestSession() *session.Session {
+	return session.New(session.Config{
+		PlanTTL: 5 * time.Minute,
+		Limits:  session.DefaultLimits(),
+	})
+}
+
+// --- meridian_manifest_validate tests ---
+
+func TestManifestValidate_ValidManifest_ReturnsValid(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, req *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			if !req.DryRun {
+				t.Error("expected dry_run to be true for validate")
+			}
+			return &controlplanev1.ApplyManifestResponse{
+				Status: controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN,
+			}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	params := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, validManifestJSON()))
+	result, err := r.Call(context.Background(), "meridian_manifest_validate", params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if valid, _ := m["valid"].(bool); !valid {
+		t.Errorf("expected valid=true, got %v", m)
+	}
+}
+
+func TestManifestValidate_ValidationFailed_ReturnsErrors(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			return &controlplanev1.ApplyManifestResponse{
+				Status: controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_VALIDATION_FAILED,
+				ValidationErrors: []*controlplanev1.ValidationError{
+					{
+						Severity: "ERROR",
+						Path:     "instruments[0].code",
+						Code:     "INVALID_CODE",
+						Message:  "instrument code must be uppercase",
+					},
+				},
+			}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	params := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, validManifestJSON()))
+	result, err := r.Call(context.Background(), "meridian_manifest_validate", params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if valid, _ := m["valid"].(bool); valid {
+		t.Error("expected valid=false for validation failure")
+	}
+	errs, ok := m["errors"].([]interface{})
+	if !ok || len(errs) == 0 {
+		t.Error("expected non-empty errors slice")
+	}
+}
+
+func TestManifestValidate_GRPCError_FormattedResponse(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			return nil, status.Errorf(codes.Unavailable, "control plane unavailable")
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	params := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, validManifestJSON()))
+	result, err := r.Call(context.Background(), "meridian_manifest_validate", params)
+	if err != nil {
+		t.Fatalf("expected handler to return formatted error, not Go error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestManifestValidate_InvalidJSON_ReturnsError(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			t.Fatal("should not call backend with invalid JSON")
+			return nil, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	// manifest with invalid field type
+	params := json.RawMessage(`{"manifest": {"version": 123}}`)
+	result, err := r.Call(context.Background(), "meridian_manifest_validate", params)
+	if err != nil {
+		t.Fatalf("expected handler error in result, not Go error: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if valid, _ := m["valid"].(bool); valid {
+		t.Error("expected valid=false for invalid manifest JSON")
+	}
+}
+
+func TestManifestValidate_MissingManifest_SchemaError(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			t.Fatal("should not call backend with missing manifest")
+			return nil, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	_, err := r.Call(context.Background(), "meridian_manifest_validate", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected schema validation error for missing manifest")
+	}
+}
+
+// --- meridian_manifest_plan tests ---
+
+func TestManifestPlan_ValidManifest_StoresInCache(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, req *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			if !req.DryRun {
+				t.Error("expected dry_run to be true for plan")
+			}
+			return &controlplanev1.ApplyManifestResponse{
+				Status:      controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN,
+				DiffSummary: "Added 2 instruments, 1 account type",
+				StepResults: []*controlplanev1.StepResult{
+					{StepName: "validate", Status: controlplanev1.StepResultStatus_STEP_RESULT_STATUS_SUCCESS},
+					{StepName: "diff", Status: controlplanev1.StepResultStatus_STEP_RESULT_STATUS_SUCCESS, Message: "2 additions"},
+				},
+			}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	params := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, validManifestJSON()))
+	result, err := r.Call(context.Background(), "meridian_manifest_plan", params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if valid, _ := m["valid"].(bool); !valid {
+		t.Errorf("expected valid=true, got %v", m)
+	}
+	planHash, ok := m["plan_hash"].(string)
+	if !ok || planHash == "" {
+		t.Error("expected non-empty plan_hash")
+	}
+	if diff, _ := m["diff_summary"].(string); diff == "" {
+		t.Error("expected non-empty diff_summary")
+	}
+
+	// Verify the plan was stored in the session cache.
+	if !sess.ValidatePlan(planHash) {
+		t.Error("expected plan hash to be valid in session cache")
+	}
+}
+
+func TestManifestPlan_ValidationFailed_NoCache(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			return &controlplanev1.ApplyManifestResponse{
+				Status: controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_VALIDATION_FAILED,
+				ValidationErrors: []*controlplanev1.ValidationError{
+					{Message: "bad manifest", Path: "metadata.name"},
+				},
+			}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	params := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, validManifestJSON()))
+	result, err := r.Call(context.Background(), "meridian_manifest_plan", params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if valid, _ := m["valid"].(bool); valid {
+		t.Error("expected valid=false for validation failure")
+	}
+	if _, hasPlan := m["plan_hash"]; hasPlan {
+		t.Error("expected no plan_hash when validation fails")
+	}
+}
+
+func TestManifestPlan_GRPCError_FormattedResponse(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			return nil, status.Errorf(codes.Internal, "server error")
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	params := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, validManifestJSON()))
+	result, err := r.Call(context.Background(), "meridian_manifest_plan", params)
+	if err != nil {
+		t.Fatalf("expected formatted error result, not Go error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- meridian_manifest_apply tests ---
+
+func TestManifestApply_WithValidPlan_Succeeds(t *testing.T) {
+	applyCalled := false
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, req *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			if req.DryRun {
+				// Plan call (dry_run=true)
+				return &controlplanev1.ApplyManifestResponse{
+					Status:      controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN,
+					DiffSummary: "changes detected",
+				}, nil
+			}
+			// Apply call (dry_run=false)
+			applyCalled = true
+			if req.AppliedBy != "test@example.com" {
+				t.Errorf("expected applied_by=test@example.com, got %q", req.AppliedBy)
+			}
+			return &controlplanev1.ApplyManifestResponse{
+				Status:      controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_APPLIED,
+				JobId:       "job-001",
+				DiffSummary: "applied changes",
+				Snapshot: &controlplanev1.ManifestVersion{
+					Id:        "ver-001",
+					Version:   "1.0",
+					AppliedAt: timestamppb.Now(),
+					AppliedBy: "test@example.com",
+				},
+			}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	// Step 1: Plan
+	manifest := validManifestJSON()
+	planParams := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, manifest))
+	planResult, err := r.Call(context.Background(), "meridian_manifest_plan", planParams)
+	if err != nil {
+		t.Fatalf("plan failed: %v", err)
+	}
+	planMap := planResult.(map[string]interface{})
+	planHash := planMap["plan_hash"].(string)
+
+	// Step 2: Apply with the plan hash
+	applyParams := json.RawMessage(fmt.Sprintf(`{"manifest": %s, "plan_hash": %q, "applied_by": "test@example.com"}`, manifest, planHash))
+	applyResult, err := r.Call(context.Background(), "meridian_manifest_apply", applyParams)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if !applyCalled {
+		t.Fatal("expected apply to call the backend")
+	}
+	m, ok := applyResult.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", applyResult)
+	}
+	if s, _ := m["status"].(string); s != "APPLY_MANIFEST_STATUS_APPLIED" {
+		t.Errorf("expected APPLIED status, got %q", s)
+	}
+	if jobID, _ := m["job_id"].(string); jobID != "job-001" {
+		t.Errorf("expected job_id=job-001, got %q", jobID)
+	}
+	if snap, ok := m["snapshot"].(map[string]interface{}); !ok || snap["id"] != "ver-001" {
+		t.Errorf("expected snapshot with id=ver-001, got %v", m["snapshot"])
+	}
+}
+
+func TestManifestApply_WithoutPlan_Rejected(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			t.Fatal("should not call backend without valid plan")
+			return nil, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	params := json.RawMessage(fmt.Sprintf(`{"manifest": %s, "plan_hash": "invalid-hash", "applied_by": "test@example.com"}`, validManifestJSON()))
+	result, err := r.Call(context.Background(), "meridian_manifest_apply", params)
+	if err != nil {
+		t.Fatalf("expected error in result, not Go error: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if _, hasError := m["error"]; !hasError {
+		t.Error("expected 'error' key in result when no plan exists")
+	}
+}
+
+func TestManifestApply_MissingRequiredFields_SchemaError(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			t.Fatal("should not call backend")
+			return nil, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	// Missing plan_hash and applied_by
+	params := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, validManifestJSON()))
+	_, err := r.Call(context.Background(), "meridian_manifest_apply", params)
+	if err == nil {
+		t.Fatal("expected schema validation error for missing required fields")
+	}
+}
+
+func TestManifestApply_GRPCError_FormattedResponse(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, req *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			if req.DryRun {
+				// Plan step
+				return &controlplanev1.ApplyManifestResponse{
+					Status: controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN,
+				}, nil
+			}
+			// Apply step fails
+			return nil, status.Errorf(codes.FailedPrecondition, "manifest locked")
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	// Plan first
+	manifest := validManifestJSON()
+	planParams := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, manifest))
+	planResult, err := r.Call(context.Background(), "meridian_manifest_plan", planParams)
+	if err != nil {
+		t.Fatalf("plan failed: %v", err)
+	}
+	planHash := planResult.(map[string]interface{})["plan_hash"].(string)
+
+	// Apply with gRPC failure
+	applyParams := json.RawMessage(fmt.Sprintf(`{"manifest": %s, "plan_hash": %q, "applied_by": "test"}`, manifest, planHash))
+	result, err := r.Call(context.Background(), "meridian_manifest_apply", applyParams)
+	if err != nil {
+		t.Fatalf("expected formatted error result, not Go error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- meridian_manifest_history tests ---
+
+func TestManifestHistory_ReturnsVersions(t *testing.T) {
+	now := timestamppb.Now()
+	mock := &mockManifestHistorian{
+		listFn: func(_ context.Context, _ *controlplanev1.ListManifestVersionsRequest) (*controlplanev1.ListManifestVersionsResponse, error) {
+			diffSummary := "Initial manifest"
+			return &controlplanev1.ListManifestVersionsResponse{
+				Versions: []*controlplanev1.ManifestVersion{
+					{
+						Id:          "ver-001",
+						Version:     "1.0",
+						AppliedAt:   now,
+						AppliedBy:   "admin@example.com",
+						ApplyStatus: controlplanev1.ApplyStatus_APPLY_STATUS_APPLIED,
+						DiffSummary: &diffSummary,
+						CreatedAt:   now,
+					},
+				},
+				TotalCount: 1,
+			}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Historian: mock})
+
+	result, err := r.Call(context.Background(), "meridian_manifest_history", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if count, _ := m["count"].(int); count != 1 {
+		t.Errorf("expected count=1, got %v", m["count"])
+	}
+	versions, ok := m["versions"].([]map[string]interface{})
+	if !ok || len(versions) == 0 {
+		t.Fatalf("expected versions slice with entries, got %v", m["versions"])
+	}
+	if versions[0]["id"] != "ver-001" {
+		t.Errorf("expected version id=ver-001, got %v", versions[0]["id"])
+	}
+}
+
+func TestManifestHistory_Pagination_PassedToClient(t *testing.T) {
+	var capturedReq *controlplanev1.ListManifestVersionsRequest
+
+	mock := &mockManifestHistorian{
+		listFn: func(_ context.Context, req *controlplanev1.ListManifestVersionsRequest) (*controlplanev1.ListManifestVersionsResponse, error) {
+			capturedReq = req
+			return &controlplanev1.ListManifestVersionsResponse{}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Historian: mock})
+
+	params := json.RawMessage(`{"limit": 10, "offset": 5}`)
+	_, err := r.Call(context.Background(), "meridian_manifest_history", params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedReq == nil {
+		t.Fatal("expected request to be captured")
+	}
+	if capturedReq.Limit != 10 {
+		t.Errorf("expected limit=10, got %d", capturedReq.Limit)
+	}
+	if capturedReq.Offset != 5 {
+		t.Errorf("expected offset=5, got %d", capturedReq.Offset)
+	}
+}
+
+func TestManifestHistory_EmptyResults_MeaningfulResponse(t *testing.T) {
+	mock := &mockManifestHistorian{
+		listFn: func(_ context.Context, _ *controlplanev1.ListManifestVersionsRequest) (*controlplanev1.ListManifestVersionsResponse, error) {
+			return &controlplanev1.ListManifestVersionsResponse{
+				Versions:   []*controlplanev1.ManifestVersion{},
+				TotalCount: 0,
+			}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Historian: mock})
+
+	result, err := r.Call(context.Background(), "meridian_manifest_history", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if msg, _ := m["message"].(string); msg == "" {
+		t.Error("expected non-empty message for empty results")
+	}
+}
+
+func TestManifestHistory_GRPCError_FormattedResponse(t *testing.T) {
+	mock := &mockManifestHistorian{
+		listFn: func(_ context.Context, _ *controlplanev1.ListManifestVersionsRequest) (*controlplanev1.ListManifestVersionsResponse, error) {
+			return nil, status.Errorf(codes.Unavailable, "history service unavailable")
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Historian: mock})
+
+	result, err := r.Call(context.Background(), "meridian_manifest_history", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("expected formatted error result, not Go error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+// --- Registration tests ---
+
+func TestEconomyTools_AllRegistered(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			return &controlplanev1.ApplyManifestResponse{}, nil
+		},
+	}
+	historian := &mockManifestHistorian{
+		listFn: func(_ context.Context, _ *controlplanev1.ListManifestVersionsRequest) (*controlplanev1.ListManifestVersionsResponse, error) {
+			return &controlplanev1.ListManifestVersionsResponse{}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{
+		Applier:   mock,
+		Historian: historian,
+	})
+
+	listed := r.List()
+	names := make(map[string]bool)
+	for _, tool := range listed {
+		names[tool.Name] = true
+	}
+
+	required := []string{
+		"meridian_manifest_validate",
+		"meridian_manifest_plan",
+		"meridian_manifest_apply",
+		"meridian_manifest_history",
+	}
+	for _, name := range required {
+		if !names[name] {
+			t.Errorf("expected tool %q to be registered", name)
+		}
+	}
+}
+
+func TestEconomyTools_CorrectCategories(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			return &controlplanev1.ApplyManifestResponse{}, nil
+		},
+	}
+	historian := &mockManifestHistorian{
+		listFn: func(_ context.Context, _ *controlplanev1.ListManifestVersionsRequest) (*controlplanev1.ListManifestVersionsResponse, error) {
+			return &controlplanev1.ListManifestVersionsResponse{}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{
+		Applier:   mock,
+		Historian: historian,
+	})
+
+	expected := map[string]tools.ToolCategory{
+		"meridian_manifest_validate": tools.CategorySimulate,
+		"meridian_manifest_plan":     tools.CategoryWrite,
+		"meridian_manifest_apply":    tools.CategoryWrite,
+		"meridian_manifest_history":  tools.CategoryRead,
+	}
+
+	for _, tool := range r.List() {
+		if expectedCat, ok := expected[tool.Name]; ok {
+			if tool.Category != expectedCat {
+				t.Errorf("tool %q: expected category %v, got %v", tool.Name, expectedCat, tool.Category)
+			}
+		}
+	}
+}
+
+func TestEconomyTools_NilClients_SkipsRegistration(t *testing.T) {
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{})
+
+	listed := r.List()
+	if len(listed) != 0 {
+		t.Fatalf("expected 0 registered tools with nil clients, got %d", len(listed))
+	}
+}
+
+func TestEconomyTools_PartialClients_RegistersAvailable(t *testing.T) {
+	historian := &mockManifestHistorian{
+		listFn: func(_ context.Context, _ *controlplanev1.ListManifestVersionsRequest) (*controlplanev1.ListManifestVersionsResponse, error) {
+			return &controlplanev1.ListManifestVersionsResponse{}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Historian: historian})
+
+	listed := r.List()
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 registered tool, got %d", len(listed))
+	}
+	if listed[0].Name != "meridian_manifest_history" {
+		t.Errorf("expected meridian_manifest_history, got %q", listed[0].Name)
+	}
+}

--- a/services/mcp-server/internal/tools/economy_test.go
+++ b/services/mcp-server/internal/tools/economy_test.go
@@ -386,6 +386,48 @@ func TestManifestApply_WithoutPlan_Rejected(t *testing.T) {
 	}
 }
 
+func TestManifestApply_ContentMismatch_Rejected(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, req *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			if req.DryRun {
+				return &controlplanev1.ApplyManifestResponse{
+					Status: controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN,
+				}, nil
+			}
+			t.Fatal("should not call backend with mismatched manifest")
+			return nil, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	// Plan with manifest A
+	manifestA := validManifestJSON()
+	planParams := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, manifestA))
+	planResult, err := r.Call(context.Background(), "meridian_manifest_plan", planParams)
+	if err != nil {
+		t.Fatalf("plan failed: %v", err)
+	}
+	planHash := planResult.(map[string]interface{})["plan_hash"].(string)
+
+	// Apply with a different manifest B but the plan_hash from manifest A
+	manifestB := json.RawMessage(`{"version": "2.0", "metadata": {"name": "Different", "industry": "banking", "description": "Changed"}}`)
+	applyParams := json.RawMessage(fmt.Sprintf(`{"manifest": %s, "plan_hash": %q, "applied_by": "test@example.com"}`, manifestB, planHash))
+	result, err := r.Call(context.Background(), "meridian_manifest_apply", applyParams)
+	if err != nil {
+		t.Fatalf("expected error in result, not Go error: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if errMsg, _ := m["error"].(string); errMsg == "" {
+		t.Error("expected 'error' key in result for content mismatch")
+	}
+}
+
 func TestManifestApply_MissingRequiredFields_SchemaError(t *testing.T) {
 	mock := &mockManifestApplier{
 		applyFn: func(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {

--- a/services/mcp-server/internal/tools/economy_test.go
+++ b/services/mcp-server/internal/tools/economy_test.go
@@ -697,6 +697,84 @@ func TestEconomyTools_NilClients_SkipsRegistration(t *testing.T) {
 	}
 }
 
+func TestEconomyTools_NilSession_SkipsPlanApply(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			return &controlplanev1.ApplyManifestResponse{}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	// nil session: plan and apply should not be registered
+	tools.RegisterEconomyTools(r, nil, tools.EconomyDeps{Applier: mock})
+
+	listed := r.List()
+	names := make(map[string]bool)
+	for _, tool := range listed {
+		names[tool.Name] = true
+	}
+	if !names["meridian_manifest_validate"] {
+		t.Error("expected meridian_manifest_validate to be registered with nil session")
+	}
+	if names["meridian_manifest_plan"] {
+		t.Error("expected meridian_manifest_plan to NOT be registered with nil session")
+	}
+	if names["meridian_manifest_apply"] {
+		t.Error("expected meridian_manifest_apply to NOT be registered with nil session")
+	}
+}
+
+func TestManifestApply_DifferentJSONWhitespace_StillMatches(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, req *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			if req.DryRun {
+				return &controlplanev1.ApplyManifestResponse{
+					Status: controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN,
+				}, nil
+			}
+			return &controlplanev1.ApplyManifestResponse{
+				Status: controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_APPLIED,
+				JobId:  "job-whitespace",
+			}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	// Plan with compact JSON
+	compact := json.RawMessage(`{"version":"1.0","metadata":{"name":"Test","industry":"energy","description":"Test"}}`)
+	planParams := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, compact))
+	planResult, err := r.Call(context.Background(), "meridian_manifest_plan", planParams)
+	if err != nil {
+		t.Fatalf("plan failed: %v", err)
+	}
+	planHash := planResult.(map[string]interface{})["plan_hash"].(string)
+
+	// Apply with same data but different whitespace/key order
+	spaced := json.RawMessage(`{
+		"version": "1.0",
+		"metadata": {
+			"name": "Test",
+			"industry": "energy",
+			"description": "Test"
+		}
+	}`)
+	applyParams := json.RawMessage(fmt.Sprintf(`{"manifest": %s, "plan_hash": %q, "applied_by": "test"}`, spaced, planHash))
+	result, err := r.Call(context.Background(), "meridian_manifest_apply", applyParams)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if s, _ := m["status"].(string); s != "APPLY_MANIFEST_STATUS_APPLIED" {
+		t.Errorf("expected APPLIED status (whitespace should not matter), got %q; result=%v", s, m)
+	}
+}
+
 func TestEconomyTools_PartialClients_RegistersAvailable(t *testing.T) {
 	historian := &mockManifestHistorian{
 		listFn: func(_ context.Context, _ *controlplanev1.ListManifestVersionsRequest) (*controlplanev1.ListManifestVersionsResponse, error) {


### PR DESCRIPTION
## Summary

- Implements four manifest lifecycle MCP tools: `meridian_manifest_validate`, `meridian_manifest_plan`, `meridian_manifest_apply`, and `meridian_manifest_history`
- Introduces `PlanStore` interface to break the import cycle between `tools` and `session` packages while maintaining plan-before-apply enforcement
- All tools follow existing patterns: gRPC errors formatted via `mcperrors.FormatGRPCError`, nil clients silently skipped, correct `ToolCategory` assignments

## Changes Made

**New files:**
- `services/mcp-server/internal/tools/economy.go` — Tool registration, handlers, and proto conversion
- `services/mcp-server/internal/tools/economy_test.go` — 20 tests covering all tools

**Tools:**

| Tool | Category | Description |
|------|----------|-------------|
| `meridian_manifest_validate` | Simulate | Dry-run validation via `ApplyManifest(dry_run=true)` |
| `meridian_manifest_plan` | Write | Dry-run + stores plan hash in `PlanStore` for later apply |
| `meridian_manifest_apply` | Write | Applies manifest only if a valid plan hash exists |
| `meridian_manifest_history` | Read | Queries `ListManifestVersions` with pagination |

**Architecture:**
- `PlanStore` interface (`StorePlan`, `ValidatePlan`) decouples tools from session package
- `manifestJSONToProto` uses `protojson.Unmarshal` with `DiscardUnknown` for forward compatibility
- Proto `ValidationError` structured errors surfaced with path, code, severity, suggestion

## Test Plan

- [x] Validate: valid manifest passes, invalid returns structured errors, missing manifest triggers schema error
- [x] Plan: dry-run stores result in cache, returns diff summary; validation failure does not cache
- [x] Apply: rejects without prior plan, accepts with valid plan hash, handles gRPC errors
- [x] History: returns version list with timestamps, pagination passed to client, empty results handled
- [x] Registration: all 4 tools registered with correct categories, nil clients skip, partial clients register available
- [x] All existing mcp-server tests continue to pass

## Task Master

Task: mcp-server.6 — Economy Design Tools (Manifest Lifecycle)