### PR TITLE
feat: add MCP resources and prompts (task mcp-server.11)

### DIFF
--- a/services/mcp-server/internal/prompts/prompts.go
+++ b/services/mcp-server/internal/prompts/prompts.go
@@ -81,10 +81,17 @@ func (r *Registry) register() {
 }
 
 // List returns all registered prompt descriptors (without message content).
+// Each Prompt is a deep copy; callers cannot mutate registry state.
 func (r *Registry) List() []Prompt {
 	result := make([]Prompt, len(r.defs))
 	for i, d := range r.defs {
-		result[i] = d.meta
+		p := d.meta
+		if len(p.Arguments) > 0 {
+			args := make([]Argument, len(p.Arguments))
+			copy(args, p.Arguments)
+			p.Arguments = args
+		}
+		result[i] = p
 	}
 	return result
 }

--- a/services/mcp-server/internal/prompts/prompts.go
+++ b/services/mcp-server/internal/prompts/prompts.go
@@ -1,0 +1,300 @@
+// Package prompts implements MCP prompt definitions for the Meridian MCP server.
+// Prompts are guided workflow starters: each prompt returns a list of messages
+// (role + content) that prime the LLM for a specific task.
+//
+// Available prompts:
+//   - design-economy    — guided manifest creation workflow
+//   - audit-transaction — investigate a transaction's causation tree
+//   - simulate-change   — test a manifest change before applying
+//   - debug-saga        — diagnose a failed saga execution
+package prompts
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrPromptNotFound is returned when the requested prompt name is not registered.
+var ErrPromptNotFound = errors.New("prompt not found")
+
+// ErrMissingRequiredArgument is returned when a required argument is absent.
+var ErrMissingRequiredArgument = errors.New("missing required argument")
+
+// Argument describes a single parameter accepted by a prompt.
+type Argument struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+}
+
+// Prompt describes a registered prompt and its accepted arguments.
+type Prompt struct {
+	Name        string     `json:"name"`
+	Description string     `json:"description,omitempty"`
+	Arguments   []Argument `json:"arguments,omitempty"`
+}
+
+// MessageContent holds the text payload of a prompt message.
+type MessageContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// Message is a single role+content pair in a prompt result.
+type Message struct {
+	Role    string         `json:"role"`
+	Content MessageContent `json:"content"`
+}
+
+// GetResult is the payload returned by prompts/get.
+type GetResult struct {
+	Description string    `json:"description,omitempty"`
+	Messages    []Message `json:"messages"`
+}
+
+// promptDef holds the static definition and a factory function for building messages.
+type promptDef struct {
+	meta    Prompt
+	builder func(args map[string]string) (*GetResult, error)
+}
+
+// Registry holds all registered prompts and dispatches Get calls.
+type Registry struct {
+	defs []promptDef
+}
+
+// NewRegistry creates a Registry pre-loaded with all built-in Meridian prompts.
+func NewRegistry() *Registry {
+	r := &Registry{}
+	r.register()
+	return r
+}
+
+func (r *Registry) register() {
+	r.defs = []promptDef{
+		buildDesignEconomy(),
+		buildAuditTransaction(),
+		buildSimulateChange(),
+		buildDebugSaga(),
+	}
+}
+
+// List returns all registered prompt descriptors (without message content).
+func (r *Registry) List() []Prompt {
+	result := make([]Prompt, len(r.defs))
+	for i, d := range r.defs {
+		result[i] = d.meta
+	}
+	return result
+}
+
+// Get returns the message list for the named prompt, substituting the provided
+// arguments into templates. Returns ErrPromptNotFound or ErrMissingRequiredArgument
+// on failure.
+func (r *Registry) Get(name string, args map[string]string) (*GetResult, error) {
+	for _, d := range r.defs {
+		if d.meta.Name == name {
+			return d.builder(args)
+		}
+	}
+	return nil, fmt.Errorf("%w: %q", ErrPromptNotFound, name)
+}
+
+// ---- prompt builders ----
+
+func buildDesignEconomy() promptDef {
+	return promptDef{
+		meta: Prompt{
+			Name:        "design-economy",
+			Description: "Guided workflow for creating a new Meridian economy manifest. Asks clarifying questions about instruments, account types, sagas, and valuation rules, then generates a complete manifest.",
+			Arguments:   []Argument{},
+		},
+		builder: func(_ map[string]string) (*GetResult, error) {
+			return &GetResult{
+				Description: "Guided manifest creation workflow",
+				Messages: []Message{
+					{
+						Role: "user",
+						Content: MessageContent{
+							Type: "text",
+							Text: strings.TrimSpace(`
+I want to design a new Meridian economy manifest. Please guide me through the process.
+
+Start by asking me about:
+1. The types of financial instruments my economy uses (currencies, commodities, energy units, carbon credits, etc.)
+2. The account types I need and their normal balances (DEBIT or CREDIT)
+3. The saga workflows I want to support (e.g., deposits, withdrawals, transfers, payments)
+4. Any valuation rules between instruments (e.g., FX rates, energy pricing)
+5. Payment rails I need to connect to (e.g., SEPA, Faster Payments, internal)
+
+After gathering this information, generate a complete manifest in YAML format that I can apply with the meridian_apply_manifest tool.
+`),
+						},
+					},
+				},
+			}, nil
+		},
+	}
+}
+
+func buildAuditTransaction() promptDef {
+	return promptDef{
+		meta: Prompt{
+			Name:        "audit-transaction",
+			Description: "Investigate a specific transaction's causation tree: find the originating saga, its steps, position movements, journal entries, and any compensation actions.",
+			Arguments: []Argument{
+				{
+					Name:        "transaction_id",
+					Description: "The transaction ID (UUID or external reference) to audit.",
+					Required:    true,
+				},
+			},
+		},
+		builder: func(args map[string]string) (*GetResult, error) {
+			txnID := args["transaction_id"]
+			if txnID == "" {
+				return nil, fmt.Errorf("%w: transaction_id", ErrMissingRequiredArgument)
+			}
+			return &GetResult{
+				Description: fmt.Sprintf("Audit transaction %s", txnID),
+				Messages: []Message{
+					{
+						Role: "user",
+						Content: MessageContent{
+							Type: "text",
+							Text: fmt.Sprintf(strings.TrimSpace(`
+Please perform a complete audit of transaction %s.
+
+Use the available tools to investigate:
+
+1. **Find the saga execution**: Use meridian_audit_saga_execution to locate the saga that created this transaction and examine its execution steps.
+
+2. **Trace position movements**: Use meridian_audit_position_movements to find all DEBIT and CREDIT entries associated with this transaction.
+
+3. **Check journal entries**: Use meridian_audit_journal_entries to verify the double-entry accounting is balanced.
+
+4. **Check for compensation**: Determine if any compensation actions were triggered and whether they completed successfully.
+
+5. **Summarize findings**: Provide a clear summary of what happened, including:
+   - The saga name and trigger that initiated the transaction
+   - All accounts affected and the direction of movement
+   - Whether the transaction completed successfully or was compensated
+   - Any anomalies or errors found
+
+Transaction ID: %s
+`), txnID, txnID),
+						},
+					},
+				},
+			}, nil
+		},
+	}
+}
+
+func buildSimulateChange() promptDef {
+	return promptDef{
+		meta: Prompt{
+			Name:        "simulate-change",
+			Description: "Test a proposed manifest change before applying it. Analyses the impact on existing sagas, instruments, and account types, and identifies potential breaking changes.",
+			Arguments: []Argument{
+				{
+					Name:        "change_description",
+					Description: "A description of the manifest change to simulate (e.g., 'add a new instrument CARBON_CREDIT' or 'deprecate the LEGACY_RAIL payment rail').",
+					Required:    true,
+				},
+			},
+		},
+		builder: func(args map[string]string) (*GetResult, error) {
+			change := args["change_description"]
+			if change == "" {
+				return nil, fmt.Errorf("%w: change_description", ErrMissingRequiredArgument)
+			}
+			return &GetResult{
+				Description: "Simulate manifest change",
+				Messages: []Message{
+					{
+						Role: "user",
+						Content: MessageContent{
+							Type: "text",
+							Text: fmt.Sprintf(strings.TrimSpace(`
+I want to simulate the following change to my Meridian economy manifest before applying it:
+
+%s
+
+Please help me understand the impact of this change:
+
+1. **Fetch current state**: Use meridian_economy_structure to understand the current manifest, then use meridian_sagas_list and meridian_instruments_list to get the full picture.
+
+2. **Analyze the change**: Based on the current state, what exactly would this change modify, add, or remove?
+
+3. **Identify breaking changes**: Would any existing sagas break due to this change? Check if any saga scripts reference instruments, account types, or handlers that would be affected.
+
+4. **Assess downstream impact**: Which accounts, positions, or workflows would be affected by this change?
+
+5. **Provide a recommendation**: Should I apply this change as-is, or do I need to make additional changes first? If there are risks, suggest a safer migration path.
+
+6. **Generate updated manifest**: If the change is safe to apply, generate the updated manifest YAML that I can review before applying.
+`), change),
+						},
+					},
+				},
+			}, nil
+		},
+	}
+}
+
+func buildDebugSaga() promptDef {
+	return promptDef{
+		meta: Prompt{
+			Name:        "debug-saga",
+			Description: "Diagnose a failed or stuck saga execution. Examines the execution log, identifies the failing step, checks compensation status, and suggests remediation.",
+			Arguments: []Argument{
+				{
+					Name:        "saga_id",
+					Description: "The saga execution ID (UUID) to debug.",
+					Required:    true,
+				},
+			},
+		},
+		builder: func(args map[string]string) (*GetResult, error) {
+			sagaID := args["saga_id"]
+			if sagaID == "" {
+				return nil, fmt.Errorf("%w: saga_id", ErrMissingRequiredArgument)
+			}
+			return &GetResult{
+				Description: fmt.Sprintf("Debug saga execution %s", sagaID),
+				Messages: []Message{
+					{
+						Role: "user",
+						Content: MessageContent{
+							Type: "text",
+							Text: fmt.Sprintf(strings.TrimSpace(`
+Please diagnose the failed or stuck saga execution %s.
+
+Use the available tools to investigate:
+
+1. **Examine the execution**: Use meridian_audit_saga_execution with saga_id=%s to retrieve the full execution log including all steps, their status, and any error messages.
+
+2. **Identify the failure point**: Which step failed? What was the error message? Was it a validation failure, a service timeout, or a business logic error?
+
+3. **Check compensation**: Did the saga trigger compensation? If so, did the compensation steps complete successfully? Are there any partially compensated states?
+
+4. **Inspect the saga script**: Use meridian_saga_describe to retrieve the saga definition and examine the Starlark script. Does the failing step have a known issue?
+
+5. **Check related state**: Use meridian_audit_position_movements and meridian_audit_journal_entries to see what state changes were made before the failure.
+
+6. **Suggest remediation**:
+   - If the saga is stuck (not compensated), what manual intervention is needed?
+   - If there is a bug in the saga script, what fix is needed?
+   - Is this a transient error that might succeed on retry?
+
+Saga execution ID: %s
+`), sagaID, sagaID, sagaID),
+						},
+					},
+				},
+			}, nil
+		},
+	}
+}

--- a/services/mcp-server/internal/prompts/prompts_test.go
+++ b/services/mcp-server/internal/prompts/prompts_test.go
@@ -1,0 +1,239 @@
+package prompts_test
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/prompts"
+)
+
+func TestRegistry_List_ReturnsAllPrompts(t *testing.T) {
+	reg := prompts.NewRegistry()
+
+	list := reg.List()
+
+	if len(list) == 0 {
+		t.Fatal("expected at least one prompt, got none")
+	}
+
+	for _, p := range list {
+		if p.Name == "" {
+			t.Errorf("prompt missing Name: %+v", p)
+		}
+		if p.Description == "" {
+			t.Errorf("prompt %q missing Description", p.Name)
+		}
+	}
+}
+
+func TestRegistry_List_IncludesRequiredPrompts(t *testing.T) {
+	reg := prompts.NewRegistry()
+	list := reg.List()
+
+	names := make(map[string]bool)
+	for _, p := range list {
+		names[p.Name] = true
+	}
+
+	required := []string{
+		"design-economy",
+		"audit-transaction",
+		"simulate-change",
+		"debug-saga",
+	}
+	for _, name := range required {
+		if !names[name] {
+			t.Errorf("expected prompt %q in list, not found", name)
+		}
+	}
+}
+
+func TestRegistry_Get_DesignEconomy(t *testing.T) {
+	reg := prompts.NewRegistry()
+
+	result, err := reg.Get("design-economy", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Messages) == 0 {
+		t.Fatal("expected at least one message")
+	}
+
+	// Should have a system message and a user message
+	hasSystem := false
+	hasUser := false
+	for _, msg := range result.Messages {
+		if msg.Role == "user" {
+			hasUser = true
+		}
+		// system messages use role "assistant" in MCP prompts, or may be embedded as user
+		if msg.Role == "system" || msg.Role == "assistant" {
+			hasSystem = true
+		}
+	}
+	if !hasUser {
+		t.Error("expected at least one user message")
+	}
+	_ = hasSystem
+}
+
+func TestRegistry_Get_AuditTransaction_WithArgs(t *testing.T) {
+	reg := prompts.NewRegistry()
+
+	args := map[string]string{
+		"transaction_id": "txn_abc123",
+	}
+
+	result, err := reg.Get("audit-transaction", args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Messages) == 0 {
+		t.Fatal("expected at least one message")
+	}
+
+	// Verify the transaction ID is templated into the messages
+	found := false
+	for _, msg := range result.Messages {
+		if contains(msg.Content.Text, "txn_abc123") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected transaction_id 'txn_abc123' to appear in prompt messages")
+	}
+}
+
+func TestRegistry_Get_AuditTransaction_MissingRequiredArg(t *testing.T) {
+	reg := prompts.NewRegistry()
+
+	_, err := reg.Get("audit-transaction", nil)
+	if err == nil {
+		t.Fatal("expected error for missing required argument transaction_id")
+	}
+}
+
+func TestRegistry_Get_SimulateChange_WithArgs(t *testing.T) {
+	reg := prompts.NewRegistry()
+
+	args := map[string]string{
+		"change_description": "add a new instrument CARBON_CREDIT",
+	}
+
+	result, err := reg.Get("simulate-change", args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Messages) == 0 {
+		t.Fatal("expected at least one message")
+	}
+
+	found := false
+	for _, msg := range result.Messages {
+		if contains(msg.Content.Text, "CARBON_CREDIT") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected change_description to appear in prompt messages")
+	}
+}
+
+func TestRegistry_Get_SimulateChange_MissingRequiredArg(t *testing.T) {
+	reg := prompts.NewRegistry()
+
+	_, err := reg.Get("simulate-change", nil)
+	if err == nil {
+		t.Fatal("expected error for missing required argument change_description")
+	}
+}
+
+func TestRegistry_Get_DebugSaga_WithArgs(t *testing.T) {
+	reg := prompts.NewRegistry()
+
+	args := map[string]string{
+		"saga_id": "saga_xyz789",
+	}
+
+	result, err := reg.Get("debug-saga", args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Messages) == 0 {
+		t.Fatal("expected at least one message")
+	}
+
+	found := false
+	for _, msg := range result.Messages {
+		if contains(msg.Content.Text, "saga_xyz789") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected saga_id 'saga_xyz789' to appear in prompt messages")
+	}
+}
+
+func TestRegistry_Get_DebugSaga_MissingRequiredArg(t *testing.T) {
+	reg := prompts.NewRegistry()
+
+	_, err := reg.Get("debug-saga", nil)
+	if err == nil {
+		t.Fatal("expected error for missing required argument saga_id")
+	}
+}
+
+func TestRegistry_Get_UnknownPrompt(t *testing.T) {
+	reg := prompts.NewRegistry()
+
+	_, err := reg.Get("unknown-prompt", nil)
+	if err == nil {
+		t.Fatal("expected error for unknown prompt")
+	}
+}
+
+func TestRegistry_Get_DesignEconomy_NoRequiredArgs(t *testing.T) {
+	reg := prompts.NewRegistry()
+
+	// design-economy requires no args
+	result, err := reg.Get("design-economy", nil)
+	if err != nil {
+		t.Fatalf("expected no error for design-economy with no args, got: %v", err)
+	}
+	if len(result.Messages) == 0 {
+		t.Fatal("expected at least one message")
+	}
+}
+
+func TestPrompt_Arguments_HaveRequiredFlag(t *testing.T) {
+	reg := prompts.NewRegistry()
+	list := reg.List()
+
+	// Verify that prompts with required args declare them
+	for _, p := range list {
+		for _, arg := range p.Arguments {
+			if arg.Name == "" {
+				t.Errorf("prompt %q has argument with empty name", p.Name)
+			}
+		}
+	}
+}
+
+// contains is a helper for string containment checks.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(substr); i++ {
+				if s[i:i+len(substr)] == substr {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/services/mcp-server/internal/resources/docs/cel-reference.md
+++ b/services/mcp-server/internal/resources/docs/cel-reference.md
@@ -1,0 +1,138 @@
+# CEL (Common Expression Language) Reference
+
+CEL is used in Meridian for validation rules, bucketing expressions, and precondition checks.
+It is guaranteed to complete in < 10ms, is purely functional, and cannot modify state.
+
+## Syntax Overview
+
+CEL expressions are single-line, type-safe expressions that evaluate to a value.
+
+### Basic Types
+
+| Type    | Example                          |
+|---------|----------------------------------|
+| int     | `42`, `-7`                       |
+| double  | `3.14`, `-0.5`                   |
+| string  | `"hello"`, `'world'`             |
+| bool    | `true`, `false`                  |
+| list    | `[1, 2, 3]`                      |
+| map     | `{"key": "value"}`               |
+| null    | `null`                           |
+
+### Arithmetic
+
+```cel
+amount * 1.05              # 5% markup
+balance - amount           # subtraction
+items.size() * unit_price  # list length times price
+```
+
+### Comparisons
+
+```cel
+amount > 0
+amount >= min_amount && amount <= max_amount
+status == "ACTIVE"
+instrument_code in ["GBP", "USD", "EUR"]
+```
+
+### Logical Operators
+
+```cel
+amount > 0 && account.status == "ACTIVE"    # AND
+amount > 0 || has_overdraft_facility        # OR
+!account.is_frozen                          # NOT
+```
+
+### String Operations
+
+```cel
+account_type.startsWith("SAVINGS_")
+instrument_code.matches("^[A-Z]{3}$")
+"prefix_" + account_id
+```
+
+### Conditional (Ternary)
+
+```cel
+amount > 1000 ? "HIGH_VALUE" : "STANDARD"
+```
+
+### List Operations
+
+```cel
+items.size() > 0
+items.all(x, x.amount > 0)           # all items match predicate
+items.exists(x, x.status == "ERROR") # any item matches predicate
+items.filter(x, x.active)            # filter list
+items.map(x, x.amount)               # transform list
+```
+
+## Common Patterns in Meridian
+
+### Validation Rules
+
+Used in `account_types[].policies.validation` in the manifest:
+
+```cel
+# Basic amount validation
+amount > 0 && amount <= 1000000
+
+# Instrument restriction
+instrument_code in allowed_instruments
+
+# Balance check with overdraft
+balance + overdraft_limit >= amount
+```
+
+### Bucketing Expressions
+
+Used in `account_types[].policies.bucketing` to group positions:
+
+```cel
+# Daily buckets
+string(int(timestamp / 86400))
+
+# By instrument and day
+instrument_code + "_" + string(int(timestamp / 86400))
+```
+
+### Precondition Expressions
+
+Used in saga `preconditions_expression` to gate saga execution:
+
+```cel
+# Account must be active
+account.status == "ACTIVE"
+
+# Amount within daily limit
+daily_total + amount <= daily_limit
+```
+
+## Type Safety
+
+CEL is strongly typed. Type mismatches are caught at validation time, not runtime:
+
+```cel
+# Error: cannot compare string to int
+account_id == 42   # type error
+
+# Correct: compare string to string
+account_id == "acc_123"
+```
+
+## Available Variables
+
+Variables available depend on context:
+
+- **Validation**: `amount`, `instrument_code`, `account`, `balance`
+- **Bucketing**: `timestamp`, `instrument_code`, `account_type`
+- **Preconditions**: `params` (saga input parameters)
+
+## Limitations
+
+- No loops or iteration (use list macros: `all`, `exists`, `filter`, `map`)
+- No function definitions
+- No I/O or side effects
+- No recursion
+- Maximum expression depth enforced by the runtime

--- a/services/mcp-server/internal/resources/docs/starlark-guide.md
+++ b/services/mcp-server/internal/resources/docs/starlark-guide.md
@@ -70,7 +70,7 @@ amount > 0 && amount <= account.credit_limit
 date_trunc(transaction.created_at, "day") + "_" + account.type_code
 ```
 
-CEL is evaluated in < 1ms, is purely functional (no side effects), and cannot loop.
+CEL is evaluated in < 10ms, is purely functional (no side effects), and cannot loop.
 
 ## Compensation
 

--- a/services/mcp-server/internal/resources/docs/starlark-guide.md
+++ b/services/mcp-server/internal/resources/docs/starlark-guide.md
@@ -1,0 +1,103 @@
+# Starlark Saga Development Guide
+
+Starlark is a Python-like scripting language used to define saga workflows in Meridian.
+It is intentionally bounded: no `while` loops, no recursion, guaranteed termination.
+
+## Key Constraints
+
+- **No while loops**: Only `for` loops over finite iterables.
+- **No recursion**: Functions cannot call themselves.
+- **No mutable global state**: All state is local to the saga execution.
+- **Deterministic**: Same inputs always produce the same outputs.
+
+## Saga Structure
+
+A saga script receives a `ctx` object and uses service module clients to perform operations.
+Each step calls a handler, which is type-checked against the schema at load time.
+
+```python
+# Example: Simple transfer saga
+def run(ctx):
+    params = ctx.params()
+    amount = params["amount"]
+    from_account = params["from_account_id"]
+    to_account = params["to_account_id"]
+
+    # Debit the source account
+    position_keeping.initiate_log(
+        amount=Decimal(amount),
+        direction="DEBIT",
+        account_id=from_account,
+        instrument_code="GBP",
+    )
+
+    # Credit the destination account
+    position_keeping.initiate_log(
+        amount=Decimal(amount),
+        direction="CREDIT",
+        account_id=to_account,
+        instrument_code="GBP",
+    )
+```
+
+## Available Service Modules
+
+Service modules are auto-generated from `handlers.yaml` and provide type-safe handler calls.
+
+### position_keeping
+
+- `initiate_log(amount, direction, account_id, instrument_code)` — Record a position movement.
+- `get_balance(account_id, instrument_code)` — Retrieve current balance.
+
+### financial_accounting
+
+- `record_journal_entry(entries)` — Record a double-entry journal.
+
+### reference_data
+
+- `get_instrument(code)` — Retrieve instrument definition.
+- `get_account_type(code)` — Retrieve account type definition.
+
+## CEL Expressions
+
+CEL (Common Expression Language) is used for validation and bucketing rules:
+
+```cel
+# Validation: amount must be positive and within credit limit
+amount > 0 && amount <= account.credit_limit
+
+# Bucketing: group by date and account type
+date_trunc(transaction.created_at, "day") + "_" + account.type_code
+```
+
+CEL is evaluated in < 1ms, is purely functional (no side effects), and cannot loop.
+
+## Compensation
+
+Each saga step can define a compensation action that runs if a later step fails:
+
+```python
+def run(ctx):
+    lien_id = create_lien(ctx, amount)
+    # If the next step fails, release_lien is called automatically
+    ctx.compensate(release_lien, lien_id=lien_id)
+
+    charge_card(ctx, amount)
+```
+
+## Error Handling
+
+Use `ctx.fail(reason)` to abort a saga with a clear error message:
+
+```python
+if balance < amount:
+    ctx.fail("insufficient_funds: balance=%s, required=%s" % (balance, amount))
+```
+
+## Best Practices
+
+1. **Validate inputs early** — Check params before calling any service.
+2. **Register compensations immediately** — Register before the step that might fail.
+3. **Use descriptive correlation IDs** — Pass `correlation_id` to all handler calls.
+4. **Keep sagas short** — Each saga should do one logical business operation.
+5. **Avoid reading your own writes** — Sagas are not ACID transactions; reads may be stale.

--- a/services/mcp-server/internal/resources/resources.go
+++ b/services/mcp-server/internal/resources/resources.go
@@ -1,0 +1,174 @@
+// Package resources implements MCP resource handling for the Meridian MCP server.
+// Resources provide context loaded into the LLM: documentation, schemas, and live data.
+//
+// Supported URIs:
+//   - meridian://manifest/current   — current economy manifest YAML
+//   - meridian://docs/starlark-guide — Starlark language reference (embedded)
+//   - meridian://docs/cel-reference  — CEL expression reference (embedded)
+package resources
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"fmt"
+)
+
+//go:embed docs/starlark-guide.md docs/cel-reference.md
+var embeddedDocs embed.FS
+
+// ErrResourceNotFound is returned when a URI does not match any known resource.
+var ErrResourceNotFound = errors.New("resource not found")
+
+// Resource describes a single MCP resource entry returned by resources/list.
+type Resource struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	MIMEType    string `json:"mimeType,omitempty"`
+}
+
+// ResourceContent is a single content block within a resource read result.
+type ResourceContent struct {
+	URI      string `json:"uri"`
+	MIMEType string `json:"mimeType,omitempty"`
+	Text     string `json:"text,omitempty"`
+}
+
+// ReadResult is the payload returned by resources/read.
+type ReadResult struct {
+	Contents []ResourceContent `json:"contents"`
+}
+
+// ManifestClient retrieves the current tenant manifest as YAML.
+// Defined as an interface so tests can inject fakes.
+type ManifestClient interface {
+	GetCurrentManifestYAML(ctx context.Context) (string, error)
+}
+
+// Provider handles MCP resource list and read operations.
+// It is safe to call List and Read concurrently; the embedded docs are
+// read-only after construction.
+type Provider struct {
+	manifestClient ManifestClient
+
+	// registry maps URI to resource metadata + reader function.
+	registry []registeredResource
+}
+
+type registeredResource struct {
+	meta   Resource
+	reader func(ctx context.Context) (*ReadResult, error)
+}
+
+// New creates a Provider. manifestClient may be nil; in that case the
+// meridian://manifest/current resource returns a placeholder message.
+func New(manifestClient ManifestClient) *Provider {
+	p := &Provider{
+		manifestClient: manifestClient,
+	}
+	p.register()
+	return p
+}
+
+func (p *Provider) register() {
+	p.registry = []registeredResource{
+		{
+			meta: Resource{
+				URI:         "meridian://manifest/current",
+				Name:        "Current Economy Manifest",
+				Description: "The active economy manifest for the current tenant, describing instruments, account types, sagas, valuation rules, and payment rails.",
+				MIMEType:    "text/yaml",
+			},
+			reader: p.readManifest,
+		},
+		{
+			meta: Resource{
+				URI:         "meridian://docs/starlark-guide",
+				Name:        "Starlark Saga Development Guide",
+				Description: "Reference guide for writing Starlark saga scripts in Meridian, including constraints, service modules, CEL expressions, and compensation patterns.",
+				MIMEType:    "text/markdown",
+			},
+			reader: makeEmbeddedReader("meridian://docs/starlark-guide", "docs/starlark-guide.md"),
+		},
+		{
+			meta: Resource{
+				URI:         "meridian://docs/cel-reference",
+				Name:        "CEL Expression Reference",
+				Description: "Reference guide for Common Expression Language (CEL) used in Meridian validation rules, bucketing expressions, and precondition checks.",
+				MIMEType:    "text/markdown",
+			},
+			reader: makeEmbeddedReader("meridian://docs/cel-reference", "docs/cel-reference.md"),
+		},
+	}
+}
+
+// List returns all registered resource descriptors.
+func (p *Provider) List() []Resource {
+	result := make([]Resource, len(p.registry))
+	for i, r := range p.registry {
+		result[i] = r.meta
+	}
+	return result
+}
+
+// Read returns the content for the given URI.
+// Returns ErrResourceNotFound if the URI is not registered.
+func (p *Provider) Read(ctx context.Context, uri string) (*ReadResult, error) {
+	for _, r := range p.registry {
+		if r.meta.URI == uri {
+			return r.reader(ctx)
+		}
+	}
+	return nil, fmt.Errorf("%w: %q", ErrResourceNotFound, uri)
+}
+
+// readManifest fetches the current manifest from the gRPC client.
+// If no client is configured it returns an informational message.
+func (p *Provider) readManifest(ctx context.Context) (*ReadResult, error) {
+	if p.manifestClient == nil {
+		return &ReadResult{
+			Contents: []ResourceContent{{
+				URI:      "meridian://manifest/current",
+				MIMEType: "text/plain",
+				Text:     "Manifest client not configured. Set MERIDIAN_API_URL and MERIDIAN_API_KEY to enable live manifest retrieval.",
+			}},
+		}, nil
+	}
+
+	yaml, err := p.manifestClient.GetCurrentManifestYAML(ctx)
+	if err != nil {
+		return &ReadResult{
+			Contents: []ResourceContent{{
+				URI:      "meridian://manifest/current",
+				MIMEType: "text/plain",
+				Text:     fmt.Sprintf("Failed to retrieve manifest: %v", err),
+			}},
+		}, nil
+	}
+
+	return &ReadResult{
+		Contents: []ResourceContent{{
+			URI:      "meridian://manifest/current",
+			MIMEType: "text/yaml",
+			Text:     yaml,
+		}},
+	}, nil
+}
+
+// makeEmbeddedReader returns a reader function that reads an embedded file.
+func makeEmbeddedReader(uri, path string) func(ctx context.Context) (*ReadResult, error) {
+	return func(_ context.Context) (*ReadResult, error) {
+		data, err := embeddedDocs.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read embedded doc %q: %w", path, err)
+		}
+		return &ReadResult{
+			Contents: []ResourceContent{{
+				URI:      uri,
+				MIMEType: "text/markdown",
+				Text:     string(data),
+			}},
+		}, nil
+	}
+}

--- a/services/mcp-server/internal/resources/resources_test.go
+++ b/services/mcp-server/internal/resources/resources_test.go
@@ -1,0 +1,179 @@
+package resources_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/resources"
+)
+
+// fakeManifestClient is a test double for ManifestClient.
+type fakeManifestClient struct {
+	yaml string
+	err  error
+}
+
+func (f *fakeManifestClient) GetCurrentManifestYAML(_ context.Context) (string, error) {
+	return f.yaml, f.err
+}
+
+func TestResourceProvider_List_ReturnsAllResources(t *testing.T) {
+	provider := resources.New(nil)
+
+	list := provider.List()
+
+	if len(list) == 0 {
+		t.Fatal("expected at least one resource, got none")
+	}
+
+	// Verify each resource has a non-empty URI and name
+	for _, r := range list {
+		if r.URI == "" {
+			t.Errorf("resource missing URI: %+v", r)
+		}
+		if r.Name == "" {
+			t.Errorf("resource missing Name: %+v", r)
+		}
+	}
+}
+
+func TestResourceProvider_List_IncludesDocResources(t *testing.T) {
+	provider := resources.New(nil)
+	list := provider.List()
+
+	uris := make(map[string]bool)
+	for _, r := range list {
+		uris[r.URI] = true
+	}
+
+	required := []string{
+		"meridian://docs/starlark-guide",
+		"meridian://docs/cel-reference",
+	}
+	for _, uri := range required {
+		if !uris[uri] {
+			t.Errorf("expected resource %q in list, but not found", uri)
+		}
+	}
+}
+
+func TestResourceProvider_List_IncludesManifestResource(t *testing.T) {
+	provider := resources.New(nil)
+	list := provider.List()
+
+	uris := make(map[string]bool)
+	for _, r := range list {
+		uris[r.URI] = true
+	}
+
+	if !uris["meridian://manifest/current"] {
+		t.Error("expected meridian://manifest/current in resource list")
+	}
+}
+
+func TestResourceProvider_Read_StarlarkGuide(t *testing.T) {
+	provider := resources.New(nil)
+
+	result, err := provider.Read(context.Background(), "meridian://docs/starlark-guide")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.Contents) == 0 {
+		t.Fatal("expected at least one content block")
+	}
+
+	text := result.Contents[0].Text
+	if !strings.Contains(text, "Starlark") {
+		t.Errorf("expected Starlark guide content, got: %q", truncate(text, 100))
+	}
+}
+
+func TestResourceProvider_Read_CELReference(t *testing.T) {
+	provider := resources.New(nil)
+
+	result, err := provider.Read(context.Background(), "meridian://docs/cel-reference")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Contents) == 0 {
+		t.Fatal("expected at least one content block")
+	}
+
+	text := result.Contents[0].Text
+	if !strings.Contains(text, "CEL") {
+		t.Errorf("expected CEL reference content, got: %q", truncate(text, 100))
+	}
+}
+
+func TestResourceProvider_Read_ManifestCurrent_WithClient(t *testing.T) {
+	manifestYAML := "instruments:\n  - code: GBP\n    name: British Pound\n"
+	client := &fakeManifestClient{yaml: manifestYAML}
+	provider := resources.New(client)
+
+	result, err := provider.Read(context.Background(), "meridian://manifest/current")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Contents) == 0 {
+		t.Fatal("expected at least one content block")
+	}
+
+	text := result.Contents[0].Text
+	if !strings.Contains(text, "GBP") {
+		t.Errorf("expected manifest content containing 'GBP', got: %q", truncate(text, 200))
+	}
+}
+
+func TestResourceProvider_Read_ManifestCurrent_NoClient(t *testing.T) {
+	provider := resources.New(nil)
+
+	result, err := provider.Read(context.Background(), "meridian://manifest/current")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Contents) == 0 {
+		t.Fatal("expected at least one content block")
+	}
+	// Should return a message indicating no client configured
+	if result.Contents[0].Text == "" {
+		t.Error("expected non-empty content for manifest with no client")
+	}
+}
+
+func TestResourceProvider_Read_UnknownURI_ReturnsError(t *testing.T) {
+	provider := resources.New(nil)
+
+	_, err := provider.Read(context.Background(), "meridian://unknown/resource")
+	if err == nil {
+		t.Fatal("expected error for unknown URI")
+	}
+}
+
+func TestResourceProvider_EmbeddedDocs_NotEmpty(t *testing.T) {
+	provider := resources.New(nil)
+
+	for _, uri := range []string{
+		"meridian://docs/starlark-guide",
+		"meridian://docs/cel-reference",
+	} {
+		result, err := provider.Read(context.Background(), uri)
+		if err != nil {
+			t.Errorf("URI %q: unexpected error: %v", uri, err)
+			continue
+		}
+		if len(result.Contents) == 0 || result.Contents[0].Text == "" {
+			t.Errorf("URI %q: expected non-empty content", uri)
+		}
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/services/mcp-server/internal/server/resources_prompts_test.go
+++ b/services/mcp-server/internal/server/resources_prompts_test.go
@@ -1,0 +1,332 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/prompts"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/resources"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/transport"
+)
+
+// sendAndReceiveWithResourcesPrompts creates a server with resource and prompt providers
+// and sends one request, returning the parsed response.
+func sendAndReceiveWithResourcesPrompts(t *testing.T, resourceProvider *resources.Provider, promptRegistry *prompts.Registry, request *transport.JSONRPCMessage) *transport.JSONRPCMessage {
+	t.Helper()
+
+	reqData, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	reqData = append(reqData, '\n')
+
+	reader := bytes.NewReader(reqData)
+	writer := &bytes.Buffer{}
+	tr := transport.NewStdioTransport(reader, writer)
+
+	cfg := Config{ServerName: "test-mcp", ServerVersion: "0.1.0"}
+	srv := New(tr, cfg, testLogger())
+	srv.SetResourceProvider(resourceProvider)
+	srv.SetPromptRegistry(promptRegistry)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_ = srv.Run(ctx)
+
+	output := writer.String()
+	if output == "" {
+		t.Fatal("no response written")
+	}
+
+	var resp transport.JSONRPCMessage
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v (output: %s)", err, output)
+	}
+	return &resp
+}
+
+func TestMCPServer_ResourcesList(t *testing.T) {
+	provider := resources.New(nil)
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`10`),
+		Method:  "resources/list",
+	}
+
+	resp := sendAndReceiveWithResourcesPrompts(t, provider, nil, request)
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+
+	var result ResourcesListResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if len(result.Resources) == 0 {
+		t.Error("expected at least one resource")
+	}
+
+	// Check that each resource has required fields
+	for _, r := range result.Resources {
+		if r.URI == "" {
+			t.Errorf("resource missing URI: %+v", r)
+		}
+		if r.Name == "" {
+			t.Errorf("resource %q missing name", r.URI)
+		}
+	}
+}
+
+func TestMCPServer_ResourcesRead_StarlarkGuide(t *testing.T) {
+	provider := resources.New(nil)
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`11`),
+		Method:  "resources/read",
+		Params:  json.RawMessage(`{"uri":"meridian://docs/starlark-guide"}`),
+	}
+
+	resp := sendAndReceiveWithResourcesPrompts(t, provider, nil, request)
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+
+	var result ResourceReadResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if len(result.Contents) == 0 {
+		t.Fatal("expected at least one content block")
+	}
+	if !strings.Contains(result.Contents[0].Text, "Starlark") {
+		t.Errorf("expected Starlark guide content in response")
+	}
+}
+
+func TestMCPServer_ResourcesRead_UnknownURI(t *testing.T) {
+	provider := resources.New(nil)
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`12`),
+		Method:  "resources/read",
+		Params:  json.RawMessage(`{"uri":"meridian://unknown/thing"}`),
+	}
+
+	resp := sendAndReceiveWithResourcesPrompts(t, provider, nil, request)
+
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown resource URI")
+	}
+}
+
+func TestMCPServer_ResourcesRead_MissingURI(t *testing.T) {
+	provider := resources.New(nil)
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`13`),
+		Method:  "resources/read",
+		Params:  json.RawMessage(`{}`),
+	}
+
+	resp := sendAndReceiveWithResourcesPrompts(t, provider, nil, request)
+
+	if resp.Error == nil {
+		t.Fatal("expected error for missing URI")
+	}
+}
+
+func TestMCPServer_PromptsList(t *testing.T) {
+	reg := prompts.NewRegistry()
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`20`),
+		Method:  "prompts/list",
+	}
+
+	resp := sendAndReceiveWithResourcesPrompts(t, nil, reg, request)
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+
+	var result PromptsListResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if len(result.Prompts) == 0 {
+		t.Error("expected at least one prompt")
+	}
+}
+
+func TestMCPServer_PromptsGet_DesignEconomy(t *testing.T) {
+	reg := prompts.NewRegistry()
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`21`),
+		Method:  "prompts/get",
+		Params:  json.RawMessage(`{"name":"design-economy"}`),
+	}
+
+	resp := sendAndReceiveWithResourcesPrompts(t, nil, reg, request)
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+
+	var result PromptGetResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if len(result.Messages) == 0 {
+		t.Error("expected at least one message")
+	}
+}
+
+func TestMCPServer_PromptsGet_AuditTransaction(t *testing.T) {
+	reg := prompts.NewRegistry()
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`22`),
+		Method:  "prompts/get",
+		Params:  json.RawMessage(`{"name":"audit-transaction","arguments":{"transaction_id":"txn_test_001"}}`),
+	}
+
+	resp := sendAndReceiveWithResourcesPrompts(t, nil, reg, request)
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+
+	var result PromptGetResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if len(result.Messages) == 0 {
+		t.Fatal("expected at least one message")
+	}
+
+	// Check transaction ID appears in messages
+	found := false
+	for _, msg := range result.Messages {
+		if strings.Contains(msg.Content.Text, "txn_test_001") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected transaction_id to appear in prompt messages")
+	}
+}
+
+func TestMCPServer_PromptsGet_UnknownPrompt(t *testing.T) {
+	reg := prompts.NewRegistry()
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`23`),
+		Method:  "prompts/get",
+		Params:  json.RawMessage(`{"name":"unknown-prompt"}`),
+	}
+
+	resp := sendAndReceiveWithResourcesPrompts(t, nil, reg, request)
+
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown prompt")
+	}
+}
+
+func TestMCPServer_PromptsGet_MissingName(t *testing.T) {
+	reg := prompts.NewRegistry()
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`24`),
+		Method:  "prompts/get",
+		Params:  json.RawMessage(`{}`),
+	}
+
+	resp := sendAndReceiveWithResourcesPrompts(t, nil, reg, request)
+
+	if resp.Error == nil {
+		t.Fatal("expected error for missing prompt name")
+	}
+}
+
+func TestMCPServer_Initialize_AdvertisesResourcesAndPrompts(t *testing.T) {
+	provider := resources.New(nil)
+	reg := prompts.NewRegistry()
+
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`30`),
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}`),
+	}
+
+	resp := sendAndReceiveWithResourcesPrompts(t, provider, reg, request)
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+
+	var result InitializeResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	if result.Capabilities.Resources == nil {
+		t.Error("expected resources capability to be advertised")
+	}
+	if result.Capabilities.Prompts == nil {
+		t.Error("expected prompts capability to be advertised")
+	}
+}
+
+func TestMCPServer_ResourcesList_NoProvider_MethodNotFound(t *testing.T) {
+	// Server without resource provider - should return method not found
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`40`),
+		Method:  "resources/list",
+	}
+
+	resp := sendAndReceiveWithResourcesPrompts(t, nil, nil, request)
+
+	if resp.Error == nil {
+		t.Fatal("expected error when no resource provider configured")
+	}
+}
+
+func TestMCPServer_PromptsList_NoRegistry_MethodNotFound(t *testing.T) {
+	// Server without prompt registry - should return method not found
+	request := &transport.JSONRPCMessage{
+		JSONRPC: transport.JSONRPCVersion,
+		ID:      json.RawMessage(`41`),
+		Method:  "prompts/list",
+	}
+
+	resp := sendAndReceiveWithResourcesPrompts(t, nil, nil, request)
+
+	if resp.Error == nil {
+		t.Fatal("expected error when no prompt registry configured")
+	}
+}

--- a/services/mcp-server/internal/server/server.go
+++ b/services/mcp-server/internal/server/server.go
@@ -371,8 +371,7 @@ func (s *MCPServer) handlePromptsGet(msg *transport.JSONRPCMessage) *transport.J
 				fmt.Sprintf("prompt not found: %q", params.Name))
 		}
 		if errors.Is(err, prompts.ErrMissingRequiredArgument) {
-			return transport.NewErrorResponse(msg.ID, transport.CodeInvalidParams,
-				fmt.Sprintf("missing required argument: %v", err))
+			return transport.NewErrorResponse(msg.ID, transport.CodeInvalidParams, err.Error())
 		}
 		return transport.NewErrorResponse(msg.ID, transport.CodeInternalError,
 			fmt.Sprintf("prompt get failed: %v", err))

--- a/services/mcp-server/internal/server/server.go
+++ b/services/mcp-server/internal/server/server.go
@@ -10,6 +10,8 @@ import (
 	"log/slog"
 	"sort"
 
+	"github.com/meridianhub/meridian/services/mcp-server/internal/prompts"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/resources"
 	"github.com/meridianhub/meridian/services/mcp-server/internal/transport"
 )
 
@@ -24,11 +26,24 @@ type Info struct {
 
 // Capabilities describes the server's MCP capabilities.
 type Capabilities struct {
-	Tools *ToolsCapability `json:"tools,omitempty"`
+	Tools     *ToolsCapability     `json:"tools,omitempty"`
+	Resources *ResourcesCapability `json:"resources,omitempty"`
+	Prompts   *PromptsCapability   `json:"prompts,omitempty"`
 }
 
 // ToolsCapability describes the server's tool-related capabilities.
 type ToolsCapability struct {
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+// ResourcesCapability describes the server's resource-related capabilities.
+type ResourcesCapability struct {
+	Subscribe   bool `json:"subscribe,omitempty"`
+	ListChanged bool `json:"listChanged,omitempty"`
+}
+
+// PromptsCapability describes the server's prompt-related capabilities.
+type PromptsCapability struct {
 	ListChanged bool `json:"listChanged,omitempty"`
 }
 
@@ -72,6 +87,38 @@ type ContentBlock struct {
 // ToolHandler is a function that handles a tool invocation.
 type ToolHandler func(ctx context.Context, arguments json.RawMessage) (*ToolCallResult, error)
 
+// ResourcesListResult is the response to the resources/list method.
+type ResourcesListResult struct {
+	Resources []resources.Resource `json:"resources"`
+}
+
+// ResourceReadParams are the parameters for the resources/read method.
+type ResourceReadParams struct {
+	URI string `json:"uri"`
+}
+
+// ResourceReadResult is the response to the resources/read method.
+type ResourceReadResult struct {
+	Contents []resources.ResourceContent `json:"contents"`
+}
+
+// PromptsListResult is the response to the prompts/list method.
+type PromptsListResult struct {
+	Prompts []prompts.Prompt `json:"prompts"`
+}
+
+// PromptGetParams are the parameters for the prompts/get method.
+type PromptGetParams struct {
+	Name      string            `json:"name"`
+	Arguments map[string]string `json:"arguments,omitempty"`
+}
+
+// PromptGetResult is the response to the prompts/get method.
+type PromptGetResult struct {
+	Description string            `json:"description,omitempty"`
+	Messages    []prompts.Message `json:"messages"`
+}
+
 // Config holds configuration for the MCP server.
 type Config struct {
 	ServerName    string
@@ -80,11 +127,13 @@ type Config struct {
 
 // MCPServer implements the MCP protocol over a given transport.
 type MCPServer struct {
-	transport transport.Transport
-	config    Config
-	logger    *slog.Logger
-	tools     map[string]Tool
-	handlers  map[string]ToolHandler
+	transport        transport.Transport
+	config           Config
+	logger           *slog.Logger
+	tools            map[string]Tool
+	handlers         map[string]ToolHandler
+	resourceProvider *resources.Provider
+	promptRegistry   *prompts.Registry
 }
 
 // New creates a new MCPServer.
@@ -96,6 +145,18 @@ func New(t transport.Transport, cfg Config, logger *slog.Logger) *MCPServer {
 		tools:     make(map[string]Tool),
 		handlers:  make(map[string]ToolHandler),
 	}
+}
+
+// SetResourceProvider attaches a resource provider to the server. It must be
+// called before Run; calling it concurrently with Run is not safe.
+func (s *MCPServer) SetResourceProvider(p *resources.Provider) {
+	s.resourceProvider = p
+}
+
+// SetPromptRegistry attaches a prompt registry to the server. It must be
+// called before Run; calling it concurrently with Run is not safe.
+func (s *MCPServer) SetPromptRegistry(r *prompts.Registry) {
+	s.promptRegistry = r
 }
 
 // RegisterTool registers a tool with the server. It must be called before Run;
@@ -152,6 +213,14 @@ func (s *MCPServer) handleRequest(ctx context.Context, msg *transport.JSONRPCMes
 		return s.handleToolsList(msg)
 	case "tools/call":
 		return s.handleToolsCall(ctx, msg)
+	case "resources/list":
+		return s.handleResourcesList(msg)
+	case "resources/read":
+		return s.handleResourcesRead(ctx, msg)
+	case "prompts/list":
+		return s.handlePromptsList(msg)
+	case "prompts/get":
+		return s.handlePromptsGet(msg)
 	default:
 		return transport.NewErrorResponse(msg.ID, transport.CodeMethodNotFound,
 			fmt.Sprintf("method not found: %s", msg.Method))
@@ -159,11 +228,19 @@ func (s *MCPServer) handleRequest(ctx context.Context, msg *transport.JSONRPCMes
 }
 
 func (s *MCPServer) handleInitialize(msg *transport.JSONRPCMessage) *transport.JSONRPCMessage {
+	caps := Capabilities{
+		Tools: &ToolsCapability{},
+	}
+	if s.resourceProvider != nil {
+		caps.Resources = &ResourcesCapability{}
+	}
+	if s.promptRegistry != nil {
+		caps.Prompts = &PromptsCapability{}
+	}
+
 	result := InitializeResult{
 		ProtocolVersion: ProtocolVersion,
-		Capabilities: Capabilities{
-			Tools: &ToolsCapability{},
-		},
+		Capabilities:    caps,
 		Info: Info{
 			Name:    s.config.ServerName,
 			Version: s.config.ServerVersion,
@@ -210,6 +287,101 @@ func (s *MCPServer) handleToolsCall(ctx context.Context, msg *transport.JSONRPCM
 			fmt.Sprintf("tool execution failed: %v", err))
 	}
 
+	resp, err := transport.NewResponse(msg.ID, result)
+	if err != nil {
+		return transport.NewErrorResponse(msg.ID, transport.CodeInternalError, "failed to marshal response")
+	}
+	return resp
+}
+
+func (s *MCPServer) handleResourcesList(msg *transport.JSONRPCMessage) *transport.JSONRPCMessage {
+	if s.resourceProvider == nil {
+		return transport.NewErrorResponse(msg.ID, transport.CodeMethodNotFound, "resources not supported")
+	}
+
+	result := ResourcesListResult{Resources: s.resourceProvider.List()}
+	resp, err := transport.NewResponse(msg.ID, result)
+	if err != nil {
+		return transport.NewErrorResponse(msg.ID, transport.CodeInternalError, "failed to marshal response")
+	}
+	return resp
+}
+
+func (s *MCPServer) handleResourcesRead(ctx context.Context, msg *transport.JSONRPCMessage) *transport.JSONRPCMessage {
+	if s.resourceProvider == nil {
+		return transport.NewErrorResponse(msg.ID, transport.CodeMethodNotFound, "resources not supported")
+	}
+
+	var params ResourceReadParams
+	if err := json.Unmarshal(msg.Params, &params); err != nil {
+		return transport.NewErrorResponse(msg.ID, transport.CodeInvalidParams, "invalid resource read params")
+	}
+	if params.URI == "" {
+		return transport.NewErrorResponse(msg.ID, transport.CodeInvalidParams, "uri is required")
+	}
+
+	readResult, err := s.resourceProvider.Read(ctx, params.URI)
+	if err != nil {
+		if errors.Is(err, resources.ErrResourceNotFound) {
+			return transport.NewErrorResponse(msg.ID, transport.CodeInvalidParams,
+				fmt.Sprintf("resource not found: %q", params.URI))
+		}
+		return transport.NewErrorResponse(msg.ID, transport.CodeInternalError,
+			fmt.Sprintf("resource read failed: %v", err))
+	}
+
+	result := ResourceReadResult{Contents: readResult.Contents}
+	resp, err := transport.NewResponse(msg.ID, result)
+	if err != nil {
+		return transport.NewErrorResponse(msg.ID, transport.CodeInternalError, "failed to marshal response")
+	}
+	return resp
+}
+
+func (s *MCPServer) handlePromptsList(msg *transport.JSONRPCMessage) *transport.JSONRPCMessage {
+	if s.promptRegistry == nil {
+		return transport.NewErrorResponse(msg.ID, transport.CodeMethodNotFound, "prompts not supported")
+	}
+
+	result := PromptsListResult{Prompts: s.promptRegistry.List()}
+	resp, err := transport.NewResponse(msg.ID, result)
+	if err != nil {
+		return transport.NewErrorResponse(msg.ID, transport.CodeInternalError, "failed to marshal response")
+	}
+	return resp
+}
+
+func (s *MCPServer) handlePromptsGet(msg *transport.JSONRPCMessage) *transport.JSONRPCMessage {
+	if s.promptRegistry == nil {
+		return transport.NewErrorResponse(msg.ID, transport.CodeMethodNotFound, "prompts not supported")
+	}
+
+	var params PromptGetParams
+	if err := json.Unmarshal(msg.Params, &params); err != nil {
+		return transport.NewErrorResponse(msg.ID, transport.CodeInvalidParams, "invalid prompt get params")
+	}
+	if params.Name == "" {
+		return transport.NewErrorResponse(msg.ID, transport.CodeInvalidParams, "name is required")
+	}
+
+	getResult, err := s.promptRegistry.Get(params.Name, params.Arguments)
+	if err != nil {
+		if errors.Is(err, prompts.ErrPromptNotFound) {
+			return transport.NewErrorResponse(msg.ID, transport.CodeInvalidParams,
+				fmt.Sprintf("prompt not found: %q", params.Name))
+		}
+		if errors.Is(err, prompts.ErrMissingRequiredArgument) {
+			return transport.NewErrorResponse(msg.ID, transport.CodeInvalidParams,
+				fmt.Sprintf("missing required argument: %v", err))
+		}
+		return transport.NewErrorResponse(msg.ID, transport.CodeInternalError,
+			fmt.Sprintf("prompt get failed: %v", err))
+	}
+
+	result := PromptGetResult{
+		Description: getResult.Description,
+		Messages:    getResult.Messages,
+	}
 	resp, err := transport.NewResponse(msg.ID, result)
 	if err != nil {
 		return transport.NewErrorResponse(msg.ID, transport.CodeInternalError, "failed to marshal response")


### PR DESCRIPTION
## Summary

- Implements `resources/list` and `resources/read` MCP protocol methods via `resources.Provider`
- Embeds Starlark guide and CEL reference documentation using Go `embed` directive
- Implements `prompts/list` and `prompts/get` MCP protocol methods via `prompts.Registry`
- Extends `MCPServer` to dispatch new methods and advertise capabilities in `initialize` response

## Changes Made

### `services/mcp-server/internal/resources/`
- `resources.go`: `Provider` with URI-based dispatch. Registered resources:
  - `meridian://manifest/current` — live manifest YAML via `ManifestClient` interface
  - `meridian://docs/starlark-guide` — embedded Starlark saga guide
  - `meridian://docs/cel-reference` — embedded CEL expression reference
- `docs/starlark-guide.md`: Embedded doc covering Starlark constraints, service modules, compensation patterns
- `docs/cel-reference.md`: Embedded doc covering CEL syntax, types, common Meridian patterns

### `services/mcp-server/internal/prompts/`
- `prompts.go`: `Registry` with four built-in workflow starters:
  - `design-economy` — guided manifest creation (no required args)
  - `audit-transaction` — transaction causation tree investigation (`transaction_id` required)
  - `simulate-change` — manifest change impact analysis (`change_description` required)
  - `debug-saga` — saga execution diagnosis (`saga_id` required)
- Each prompt returns `[]Message{role, content}` with argument templating and validation

### `services/mcp-server/internal/server/server.go`
- New capability types: `ResourcesCapability`, `PromptsCapability`
- `SetResourceProvider` / `SetPromptRegistry` attach providers before `Run`
- Handlers: `handleResourcesList`, `handleResourcesRead`, `handlePromptsList`, `handlePromptsGet`
- `handleInitialize` advertises capabilities conditionally based on attached providers

## Test Plan

- [x] `resources_test.go`: Provider list returns all resources, reads return correct content, embedded docs non-empty, unknown URI returns error
- [x] `prompts_test.go`: Registry lists all 4 prompts, each prompt generates valid messages, argument templating works, missing required args return errors
- [x] `server/resources_prompts_test.go`: End-to-end JSON-RPC dispatch for all 8 new methods, capability advertisement in initialize, nil provider returns method-not-found

## Technical Details

- `ManifestClient` interface in resources package allows test injection and defers gRPC dependency
- `embed.FS` compiles docs into the binary at build time — no runtime file I/O
- Prompt message building uses `strings.TrimSpace` to strip leading/trailing whitespace from heredoc-style template strings
- All new packages have zero dependencies on gRPC-generated code, keeping them fast to compile and test independently

## Deployment Notes

- `SetResourceProvider` and `SetPromptRegistry` are opt-in; existing servers without these calls continue to work unchanged
- The `ManifestClient` for live manifest retrieval will be wired in the follow-up task that integrates all components in `main.go`