### PR TITLE
feat: add Create Account Type dialog

### DIFF
--- a/frontend/src/pages/reference-data/account-types/create-account-type-dialog.test.tsx
+++ b/frontend/src/pages/reference-data/account-types/create-account-type-dialog.test.tsx
@@ -1,0 +1,393 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BrowserRouter } from 'react-router-dom'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+const mockCreateDraft = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    definition: {
+      id: 'aaaaaaaa-0000-0000-0000-000000000001',
+      code: 'CUSTOMER_CURRENT',
+      version: 1,
+      status: 1, // DRAFT
+    },
+  }),
+)
+
+const mockListInstruments = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    instruments: [
+      { code: 'GBP', displayName: 'British Pound', status: 2 },
+      { code: 'USD', displayName: 'US Dollar', status: 2 },
+      { code: 'KWH', displayName: 'Kilowatt Hour', status: 2 },
+    ],
+    nextPageToken: '',
+  }),
+)
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(() => ({
+    accountTypeRegistry: {
+      createDraft: mockCreateDraft,
+    },
+    referenceData: {
+      listInstruments: mockListInstruments,
+    },
+  })),
+}))
+
+import { CreateAccountTypeDialog } from './create-account-type-dialog'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = makeQueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <BrowserRouter>{children}</BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+function renderDialog(props: { open?: boolean; onOpenChange?: (open: boolean) => void } = {}) {
+  const onOpenChange = props.onOpenChange ?? vi.fn()
+  render(
+    <Wrapper>
+      <CreateAccountTypeDialog open={props.open ?? true} onOpenChange={onOpenChange} />
+    </Wrapper>,
+  )
+  return { onOpenChange }
+}
+
+async function fillRequiredFields(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/code/i), 'CUSTOMER')
+  await user.type(screen.getByLabelText(/display name/i), 'Customer Account')
+  await user.selectOptions(screen.getByLabelText(/normal balance/i), '2') // Credit
+  await user.selectOptions(screen.getByLabelText(/behavior class/i), '1') // Customer
+  await waitFor(() => {
+    expect(screen.getByLabelText(/instrument/i)).not.toBeDisabled()
+  })
+  await user.selectOptions(screen.getByLabelText(/instrument/i), 'GBP')
+}
+
+describe('CreateAccountTypeDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListInstruments.mockResolvedValue({
+      instruments: [
+        { code: 'GBP', displayName: 'British Pound', status: 2 },
+        { code: 'USD', displayName: 'US Dollar', status: 2 },
+        { code: 'KWH', displayName: 'Kilowatt Hour', status: 2 },
+      ],
+      nextPageToken: '',
+    })
+  })
+
+  it('renders dialog title when open', () => {
+    renderDialog()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /create account type/i })).toBeInTheDocument()
+  })
+
+  it('does not render when closed', () => {
+    renderDialog({ open: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders all required form fields', () => {
+    renderDialog()
+    expect(screen.getByLabelText(/code/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/normal balance/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/behavior class/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/instrument/i)).toBeInTheDocument()
+  })
+
+  it('renders optional fields', () => {
+    renderDialog()
+    expect(screen.getByLabelText(/default saga prefix/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
+  })
+
+  it('renders Cancel and Create buttons', () => {
+    renderDialog()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /create account type/i })).toBeInTheDocument()
+  })
+
+  it('auto-uppercases code field input', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    const codeInput = screen.getByLabelText(/code/i)
+    await user.type(codeInput, 'customer')
+    expect(codeInput).toHaveValue('CUSTOMER')
+  })
+
+  it('validates code is required on submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.click(screen.getByRole('button', { name: /create account type/i }))
+    expect(await screen.findByText(/code is required/i)).toBeInTheDocument()
+  })
+
+  it('validates code pattern — must start with uppercase letter', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    const codeInput = screen.getByLabelText(/code/i)
+    await user.type(codeInput, '1INVALID')
+    await user.click(screen.getByRole('button', { name: /create account type/i }))
+    expect(await screen.findByText(/invalid code format/i)).toBeInTheDocument()
+  })
+
+  it('validates code length is between 2 and 50 characters', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    const codeInput = screen.getByLabelText(/code/i)
+    // Single char — too short after uppercase forced (A → A is 1 char)
+    await user.type(codeInput, 'A')
+    await user.click(screen.getByRole('button', { name: /create account type/i }))
+    expect(await screen.findByText(/code must be between 2 and 50 characters/i)).toBeInTheDocument()
+  })
+
+  it('validates display name is required on submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.type(screen.getByLabelText(/code/i), 'CUSTOMER')
+    await user.click(screen.getByRole('button', { name: /create account type/i }))
+    expect(await screen.findByText(/display name is required/i)).toBeInTheDocument()
+  })
+
+  it('validates normal balance is required on submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.type(screen.getByLabelText(/code/i), 'CUSTOMER')
+    await user.type(screen.getByLabelText(/display name/i), 'Customer Account')
+    await user.click(screen.getByRole('button', { name: /create account type/i }))
+    expect(await screen.findByText(/normal balance is required/i)).toBeInTheDocument()
+  })
+
+  it('validates behavior class is required on submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.type(screen.getByLabelText(/code/i), 'CUSTOMER')
+    await user.type(screen.getByLabelText(/display name/i), 'Customer Account')
+    await user.selectOptions(screen.getByLabelText(/normal balance/i), '2')
+    await user.click(screen.getByRole('button', { name: /create account type/i }))
+    expect(await screen.findByText(/behavior class is required/i)).toBeInTheDocument()
+  })
+
+  it('validates instrument is required on submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.type(screen.getByLabelText(/code/i), 'CUSTOMER')
+    await user.type(screen.getByLabelText(/display name/i), 'Customer Account')
+    await user.selectOptions(screen.getByLabelText(/normal balance/i), '2')
+    await user.selectOptions(screen.getByLabelText(/behavior class/i), '1')
+    await user.click(screen.getByRole('button', { name: /create account type/i }))
+    expect(await screen.findByText(/instrument is required/i)).toBeInTheDocument()
+  })
+
+  it('validates saga prefix pattern when provided', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await fillRequiredFields(user)
+    await user.type(screen.getByLabelText(/default saga prefix/i), 'InvalidPrefix')
+    await user.click(screen.getByRole('button', { name: /create account type/i }))
+    expect(await screen.findByText(/saga prefix must start with a lowercase letter/i)).toBeInTheDocument()
+  })
+
+  it('accepts valid lowercase saga prefix', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await fillRequiredFields(user)
+    await user.type(screen.getByLabelText(/default saga prefix/i), 'savings')
+    await user.click(screen.getByRole('button', { name: /create account type/i }))
+    expect(screen.queryByText(/saga prefix must start/i)).not.toBeInTheDocument()
+  })
+
+  it('renders DEBIT and CREDIT normal balance options', () => {
+    renderDialog()
+    const balanceSelect = screen.getByLabelText(/normal balance/i)
+    const options = Array.from(balanceSelect.querySelectorAll('option')).map((o) => o.textContent)
+    expect(options).toContain('Debit')
+    expect(options).toContain('Credit')
+  })
+
+  it('renders all behavior class options', () => {
+    renderDialog()
+    const behaviorSelect = screen.getByLabelText(/behavior class/i)
+    const options = Array.from(behaviorSelect.querySelectorAll('option')).map((o) => o.textContent)
+    expect(options).toContain('Customer')
+    expect(options).toContain('Clearing')
+    expect(options).toContain('Nostro')
+    expect(options).toContain('Vostro')
+    expect(options).toContain('Holding')
+    expect(options).toContain('Suspense')
+    expect(options).toContain('Revenue')
+    expect(options).toContain('Expense')
+    expect(options).toContain('Inventory')
+  })
+
+  it('loads and shows only ACTIVE instruments in dropdown', async () => {
+    renderDialog()
+    await waitFor(() => {
+      expect(mockListInstruments).toHaveBeenCalledWith(expect.objectContaining({ statusFilter: 2 }))
+    })
+    await waitFor(() => {
+      const instrumentSelect = screen.getByLabelText(/instrument/i)
+      expect(instrumentSelect).not.toBeDisabled()
+      const options = Array.from(instrumentSelect.querySelectorAll('option')).map((o) => o.textContent)
+      expect(options.some((o) => o?.includes('GBP'))).toBe(true)
+      expect(options.some((o) => o?.includes('USD'))).toBe(true)
+    })
+  })
+
+  it('shows loading state for instruments while fetching', () => {
+    mockListInstruments.mockImplementation(() => new Promise(() => {})) // never resolves
+    renderDialog()
+    const instrumentSelect = screen.getByLabelText(/instrument/i)
+    expect(instrumentSelect).toBeDisabled()
+    expect(screen.getByText(/loading instruments/i)).toBeInTheDocument()
+  })
+
+  it('renders CEL editor components', () => {
+    renderDialog()
+    expect(screen.getByText(/validation cel/i)).toBeInTheDocument()
+    expect(screen.getByText(/bucketing cel/i)).toBeInTheDocument()
+    expect(screen.getByText(/eligibility cel/i)).toBeInTheDocument()
+  })
+
+  it('calls createDraft with correct data on valid submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await fillRequiredFields(user)
+    await user.click(screen.getByRole('button', { name: /create account type/i }))
+
+    await waitFor(() => {
+      expect(mockCreateDraft).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'CUSTOMER',
+          displayName: 'Customer Account',
+          normalBalance: 2,
+          behaviorClass: 1,
+          instrumentCode: 'GBP',
+        }),
+      )
+    })
+  })
+
+  it('shows DRAFT status note after successful creation', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await fillRequiredFields(user)
+    await user.click(screen.getByRole('button', { name: /create account type/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument()
+      expect(screen.getByText(/activation required before it can be used/i)).toBeInTheDocument()
+    })
+  })
+
+  it('clears form fields after successful creation', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await fillRequiredFields(user)
+    await user.click(screen.getByRole('button', { name: /create account type/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument()
+    })
+
+    expect(screen.getByLabelText(/code/i)).toHaveValue('')
+    expect(screen.getByLabelText(/display name/i)).toHaveValue('')
+  })
+
+  it('invalidates account-types query after successful creation', async () => {
+    const user = userEvent.setup()
+    const qc = makeQueryClient()
+    vi.spyOn(qc, 'invalidateQueries')
+
+    render(
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <BrowserRouter>
+            <CreateAccountTypeDialog open={true} onOpenChange={vi.fn()} />
+          </BrowserRouter>
+        </TooltipProvider>
+      </QueryClientProvider>,
+    )
+
+    await fillRequiredFields(user)
+    await user.click(screen.getByRole('button', { name: /create account type/i }))
+
+    await waitFor(() => {
+      expect(qc.invalidateQueries).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: expect.arrayContaining(['reference', 'account-types']),
+        }),
+      )
+    })
+  })
+
+  it('closes dialog on Cancel button click', async () => {
+    const user = userEvent.setup()
+    const { onOpenChange } = renderDialog()
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('shows general error on API failure', async () => {
+    mockCreateDraft.mockRejectedValueOnce(new Error('Server error'))
+    const user = userEvent.setup()
+    renderDialog()
+    await fillRequiredFields(user)
+    await user.click(screen.getByRole('button', { name: /create account type/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+
+  it('resets form when dialog is closed and reopened', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    const { rerender } = render(
+      <Wrapper>
+        <CreateAccountTypeDialog open={true} onOpenChange={onOpenChange} />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/code/i), 'CUSTOMER')
+    expect(screen.getByLabelText(/code/i)).toHaveValue('CUSTOMER')
+
+    rerender(
+      <Wrapper>
+        <CreateAccountTypeDialog open={false} onOpenChange={onOpenChange} />
+      </Wrapper>,
+    )
+    rerender(
+      <Wrapper>
+        <CreateAccountTypeDialog open={true} onOpenChange={onOpenChange} />
+      </Wrapper>,
+    )
+
+    expect(screen.getByLabelText(/code/i)).toHaveValue('')
+  })
+
+  it('shows saga prefix helper text', () => {
+    renderDialog()
+    expect(screen.getByText(/sagas for this account type will be resolved as/i)).toBeInTheDocument()
+    expect(screen.getByText(/savings.withdraw/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/reference-data/account-types/create-account-type-dialog.test.tsx
+++ b/frontend/src/pages/reference-data/account-types/create-account-type-dialog.test.tsx
@@ -49,8 +49,8 @@ function makeQueryClient() {
   })
 }
 
-function Wrapper({ children }: { children: React.ReactNode }) {
-  const qc = makeQueryClient()
+function Wrapper({ children, queryClient }: { children: React.ReactNode; queryClient?: QueryClient }) {
+  const qc = queryClient ?? makeQueryClient()
   return (
     <QueryClientProvider client={qc}>
       <TooltipProvider>
@@ -150,14 +150,14 @@ describe('CreateAccountTypeDialog', () => {
     expect(await screen.findByText(/invalid code format/i)).toBeInTheDocument()
   })
 
-  it('validates code length is between 2 and 50 characters', async () => {
+  it('validates code with trailing underscore as invalid', async () => {
     const user = userEvent.setup()
     renderDialog()
     const codeInput = screen.getByLabelText(/code/i)
-    // Single char — too short after uppercase forced (A → A is 1 char)
-    await user.type(codeInput, 'A')
+    // Trailing underscore is rejected by proto pattern
+    await user.type(codeInput, 'CUSTOMER_')
     await user.click(screen.getByRole('button', { name: /create account type/i }))
-    expect(await screen.findByText(/code must be between 2 and 50 characters/i)).toBeInTheDocument()
+    expect(await screen.findByText(/invalid code format/i)).toBeInTheDocument()
   })
 
   it('validates display name is required on submit', async () => {
@@ -362,8 +362,9 @@ describe('CreateAccountTypeDialog', () => {
   it('resets form when dialog is closed and reopened', async () => {
     const user = userEvent.setup()
     const onOpenChange = vi.fn()
+    const qc = makeQueryClient()
     const { rerender } = render(
-      <Wrapper>
+      <Wrapper queryClient={qc}>
         <CreateAccountTypeDialog open={true} onOpenChange={onOpenChange} />
       </Wrapper>,
     )
@@ -372,12 +373,12 @@ describe('CreateAccountTypeDialog', () => {
     expect(screen.getByLabelText(/code/i)).toHaveValue('CUSTOMER')
 
     rerender(
-      <Wrapper>
+      <Wrapper queryClient={qc}>
         <CreateAccountTypeDialog open={false} onOpenChange={onOpenChange} />
       </Wrapper>,
     )
     rerender(
-      <Wrapper>
+      <Wrapper queryClient={qc}>
         <CreateAccountTypeDialog open={true} onOpenChange={onOpenChange} />
       </Wrapper>,
     )

--- a/frontend/src/pages/reference-data/account-types/create-account-type-dialog.tsx
+++ b/frontend/src/pages/reference-data/account-types/create-account-type-dialog.tsx
@@ -16,7 +16,8 @@ import { handleConnectError } from '@/lib/error-handling'
 import { referenceKeys } from '@/lib/query-keys'
 import { Code } from '@connectrpc/connect'
 
-const CODE_PATTERN = /^[A-Z][A-Z0-9_]*$/
+// Matches proto: ^[A-Z][A-Z0-9_]{0,48}[A-Z0-9]$ (2-50 chars, no trailing underscore)
+const CODE_PATTERN = /^[A-Z][A-Z0-9_]{0,48}[A-Z0-9]$/
 const SAGA_PREFIX_PATTERN = /^[a-z][a-z0-9_]*$/
 
 const NORMAL_BALANCE_OPTIONS = [
@@ -88,7 +89,7 @@ export function CreateAccountTypeDialog({ open, onOpenChange }: CreateAccountTyp
   const [errors, setErrors] = React.useState<FormErrors>({})
   const [successMessage, setSuccessMessage] = React.useState<string | null>(null)
 
-  const { data: instrumentsData, isLoading: instrumentsLoading } = useQuery({
+  const { data: instrumentsData, isLoading: instrumentsLoading, isError: instrumentsError } = useQuery({
     queryKey: [...referenceKeys.instruments(), 'active'],
     queryFn: async () => {
       const res = await clients.referenceData.listInstruments({ statusFilter: 2 })
@@ -161,9 +162,7 @@ export function CreateAccountTypeDialog({ open, onOpenChange }: CreateAccountTyp
     if (!code) {
       next.code = 'Code is required'
     } else if (!CODE_PATTERN.test(code)) {
-      next.code = 'Invalid code format — must start with an uppercase letter, uppercase letters, digits, and underscores only'
-    } else if (code.length < 2 || code.length > 50) {
-      next.code = 'Code must be between 2 and 50 characters'
+      next.code = 'Invalid code format — must start and end with an uppercase letter or digit, with uppercase letters, digits, and underscores only (2–50 characters)'
     }
 
     if (!formData.displayName.trim()) {
@@ -219,13 +218,19 @@ export function CreateAccountTypeDialog({ open, onOpenChange }: CreateAccountTyp
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
+    if (mutation.isPending) return
     if (!validate()) return
     setSuccessMessage(null)
     mutation.mutate()
   }
 
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && mutation.isPending) return
+    onOpenChange(nextOpen)
+  }
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Create Account Type</DialogTitle>
@@ -362,6 +367,15 @@ export function CreateAccountTypeDialog({ open, onOpenChange }: CreateAccountTyp
                   >
                     <option value="">Loading instruments…</option>
                   </select>
+                ) : instrumentsError ? (
+                  <select
+                    id="account-type-instrument"
+                    disabled
+                    className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+                    aria-describedby="account-type-instrument-load-error"
+                  >
+                    <option value="">Failed to load instruments</option>
+                  </select>
                 ) : (
                   <select
                     id="account-type-instrument"
@@ -378,6 +392,11 @@ export function CreateAccountTypeDialog({ open, onOpenChange }: CreateAccountTyp
                       </option>
                     ))}
                   </select>
+                )}
+                {instrumentsError && (
+                  <p id="account-type-instrument-load-error" className="text-sm text-destructive">
+                    Unable to load instruments. Please close and reopen the dialog to retry.
+                  </p>
                 )}
                 {errors.instrumentCode && (
                   <p id="account-type-instrument-error" className="text-sm text-destructive">

--- a/frontend/src/pages/reference-data/account-types/create-account-type-dialog.tsx
+++ b/frontend/src/pages/reference-data/account-types/create-account-type-dialog.tsx
@@ -1,0 +1,497 @@
+import * as React from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { CELEditor } from '@/components/shared/cel-editor'
+import { useApiClients } from '@/api/context'
+import { handleConnectError } from '@/lib/error-handling'
+import { referenceKeys } from '@/lib/query-keys'
+import { Code } from '@connectrpc/connect'
+
+const CODE_PATTERN = /^[A-Z][A-Z0-9_]*$/
+const SAGA_PREFIX_PATTERN = /^[a-z][a-z0-9_]*$/
+
+const NORMAL_BALANCE_OPTIONS = [
+  { label: 'Debit', value: 1 },
+  { label: 'Credit', value: 2 },
+]
+
+const BEHAVIOR_CLASS_OPTIONS = [
+  { label: 'Customer', value: 1 },
+  { label: 'Clearing', value: 2 },
+  { label: 'Nostro', value: 3 },
+  { label: 'Vostro', value: 4 },
+  { label: 'Holding', value: 5 },
+  { label: 'Suspense', value: 6 },
+  { label: 'Revenue', value: 7 },
+  { label: 'Expense', value: 8 },
+  { label: 'Inventory', value: 9 },
+]
+
+interface FormData {
+  code: string
+  displayName: string
+  normalBalance: string
+  behaviorClass: string
+  instrumentCode: string
+  defaultSagaPrefix: string
+  description: string
+  validationCel: string
+  bucketingCel: string
+  eligibilityCel: string
+}
+
+interface FormErrors {
+  code?: string
+  displayName?: string
+  normalBalance?: string
+  behaviorClass?: string
+  instrumentCode?: string
+  defaultSagaPrefix?: string
+  description?: string
+  validationCel?: string
+  bucketingCel?: string
+  eligibilityCel?: string
+  general?: string
+}
+
+export interface CreateAccountTypeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const INITIAL_FORM: FormData = {
+  code: '',
+  displayName: '',
+  normalBalance: '',
+  behaviorClass: '',
+  instrumentCode: '',
+  defaultSagaPrefix: '',
+  description: '',
+  validationCel: '',
+  bucketingCel: '',
+  eligibilityCel: '',
+}
+
+export function CreateAccountTypeDialog({ open, onOpenChange }: CreateAccountTypeDialogProps) {
+  const clients = useApiClients()
+  const queryClient = useQueryClient()
+  const [formData, setFormData] = React.useState<FormData>(INITIAL_FORM)
+  const [errors, setErrors] = React.useState<FormErrors>({})
+  const [successMessage, setSuccessMessage] = React.useState<string | null>(null)
+
+  const { data: instrumentsData, isLoading: instrumentsLoading } = useQuery({
+    queryKey: [...referenceKeys.instruments(), 'active'],
+    queryFn: async () => {
+      const res = await clients.referenceData.listInstruments({ statusFilter: 2 })
+      return res.instruments ?? []
+    },
+    enabled: open,
+  })
+
+  const instruments = instrumentsData ?? []
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      clients.accountTypeRegistry.createDraft({
+        code: formData.code.trim(),
+        displayName: formData.displayName.trim(),
+        normalBalance: Number(formData.normalBalance),
+        behaviorClass: Number(formData.behaviorClass),
+        instrumentCode: formData.instrumentCode,
+        defaultSagaPrefix: formData.defaultSagaPrefix.trim(),
+        description: formData.description.trim(),
+        validationCel: formData.validationCel,
+        bucketingCel: formData.bucketingCel,
+        eligibilityCel: formData.eligibilityCel,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: referenceKeys.accountTypes() })
+      setFormData(INITIAL_FORM)
+      setErrors({})
+      setSuccessMessage(
+        'Account type created in DRAFT status. Activation required before it can be used.',
+      )
+    },
+    onError: (err) => {
+      const result = handleConnectError(err)
+      if (result.code === Code.InvalidArgument && Object.keys(result.fieldErrors).length > 0) {
+        const fieldMap: FormErrors = {}
+        for (const [field, msg] of Object.entries(result.fieldErrors)) {
+          if (field === 'code') fieldMap.code = msg
+          else if (field === 'display_name') fieldMap.displayName = msg
+          else if (field === 'normal_balance') fieldMap.normalBalance = msg
+          else if (field === 'behavior_class') fieldMap.behaviorClass = msg
+          else if (field === 'instrument_code') fieldMap.instrumentCode = msg
+          else if (field === 'default_saga_prefix') fieldMap.defaultSagaPrefix = msg
+          else if (field === 'description') fieldMap.description = msg
+          else if (field === 'validation_cel') fieldMap.validationCel = msg
+          else if (field === 'bucketing_cel') fieldMap.bucketingCel = msg
+          else if (field === 'eligibility_cel') fieldMap.eligibilityCel = msg
+          else fieldMap.general = msg
+        }
+        setErrors(fieldMap)
+      } else {
+        setErrors({ general: result.message })
+      }
+    },
+  })
+
+  React.useEffect(() => {
+    if (!open) {
+      setFormData(INITIAL_FORM)
+      setErrors({})
+      setSuccessMessage(null)
+      mutation.reset()
+    }
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  function validate(): boolean {
+    const next: FormErrors = {}
+
+    const code = formData.code.trim()
+    if (!code) {
+      next.code = 'Code is required'
+    } else if (!CODE_PATTERN.test(code)) {
+      next.code = 'Invalid code format — must start with an uppercase letter, uppercase letters, digits, and underscores only'
+    } else if (code.length < 2 || code.length > 50) {
+      next.code = 'Code must be between 2 and 50 characters'
+    }
+
+    if (!formData.displayName.trim()) {
+      next.displayName = 'Display name is required'
+    } else if (formData.displayName.trim().length > 255) {
+      next.displayName = 'Display name must be 255 characters or fewer'
+    }
+
+    if (!formData.normalBalance) {
+      next.normalBalance = 'Normal balance is required'
+    }
+
+    if (!formData.behaviorClass) {
+      next.behaviorClass = 'Behavior class is required'
+    }
+
+    if (!formData.instrumentCode) {
+      next.instrumentCode = 'Instrument is required'
+    }
+
+    const sagaPrefix = formData.defaultSagaPrefix.trim()
+    if (sagaPrefix && !SAGA_PREFIX_PATTERN.test(sagaPrefix)) {
+      next.defaultSagaPrefix = 'Saga prefix must start with a lowercase letter, followed by lowercase letters, digits, and underscores only'
+    }
+
+    if (formData.description && formData.description.length > 1000) {
+      next.description = 'Description must be 1000 characters or fewer'
+    }
+
+    setErrors(next)
+    return Object.keys(next).length === 0
+  }
+
+  function handleCodeChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const upper = e.target.value.toUpperCase()
+    setFormData((prev) => ({ ...prev, code: upper }))
+    if (errors.code) setErrors((prev) => ({ ...prev, code: undefined }))
+  }
+
+  function handleChange(field: keyof FormData) {
+    return (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+      setFormData((prev) => ({ ...prev, [field]: e.target.value }))
+      if (errors[field]) setErrors((prev) => ({ ...prev, [field]: undefined }))
+    }
+  }
+
+  function handleCelChange(field: 'validationCel' | 'bucketingCel' | 'eligibilityCel') {
+    return (value: string) => {
+      setFormData((prev) => ({ ...prev, [field]: value }))
+      if (errors[field]) setErrors((prev) => ({ ...prev, [field]: undefined }))
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+    setSuccessMessage(null)
+    mutation.mutate()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Create Account Type</DialogTitle>
+          <DialogDescription>
+            Define a new account type. It will be created in DRAFT status and must be activated
+            before it can be used.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="create-account-type-form">
+          <div className="space-y-4 py-2">
+            {errors.general && (
+              <div
+                role="alert"
+                className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                {errors.general}
+              </div>
+            )}
+
+            {successMessage && (
+              <div
+                role="status"
+                className="rounded-md border border-green-500/50 bg-green-50 px-3 py-2 text-sm text-green-800 dark:bg-green-950/30 dark:text-green-300"
+              >
+                {successMessage}
+              </div>
+            )}
+
+            {/* Primary fields - two column layout */}
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <label htmlFor="account-type-code" className="text-sm font-medium">
+                  Code <span className="text-destructive">*</span>
+                </label>
+                <Input
+                  id="account-type-code"
+                  value={formData.code}
+                  onChange={handleCodeChange}
+                  placeholder="CUSTOMER_CURRENT"
+                  aria-label="Code"
+                  aria-describedby={errors.code ? 'account-type-code-error' : undefined}
+                  maxLength={50}
+                />
+                {errors.code && (
+                  <p id="account-type-code-error" className="text-sm text-destructive">
+                    {errors.code}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-1">
+                <label htmlFor="account-type-display-name" className="text-sm font-medium">
+                  Display Name <span className="text-destructive">*</span>
+                </label>
+                <Input
+                  id="account-type-display-name"
+                  value={formData.displayName}
+                  onChange={handleChange('displayName')}
+                  placeholder="Customer Current Account"
+                  aria-label="Display Name"
+                  aria-describedby={errors.displayName ? 'account-type-display-name-error' : undefined}
+                  maxLength={255}
+                />
+                {errors.displayName && (
+                  <p id="account-type-display-name-error" className="text-sm text-destructive">
+                    {errors.displayName}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-1">
+                <label htmlFor="account-type-normal-balance" className="text-sm font-medium">
+                  Normal Balance <span className="text-destructive">*</span>
+                </label>
+                <select
+                  id="account-type-normal-balance"
+                  value={formData.normalBalance}
+                  onChange={handleChange('normalBalance')}
+                  aria-label="Normal Balance"
+                  aria-describedby={errors.normalBalance ? 'account-type-normal-balance-error' : undefined}
+                  className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+                >
+                  <option value="">Select normal balance…</option>
+                  {NORMAL_BALANCE_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+                {errors.normalBalance && (
+                  <p id="account-type-normal-balance-error" className="text-sm text-destructive">
+                    {errors.normalBalance}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-1">
+                <label htmlFor="account-type-behavior-class" className="text-sm font-medium">
+                  Behavior Class <span className="text-destructive">*</span>
+                </label>
+                <select
+                  id="account-type-behavior-class"
+                  value={formData.behaviorClass}
+                  onChange={handleChange('behaviorClass')}
+                  aria-label="Behavior Class"
+                  aria-describedby={errors.behaviorClass ? 'account-type-behavior-class-error' : undefined}
+                  className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+                >
+                  <option value="">Select behavior class…</option>
+                  {BEHAVIOR_CLASS_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+                {errors.behaviorClass && (
+                  <p id="account-type-behavior-class-error" className="text-sm text-destructive">
+                    {errors.behaviorClass}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-1">
+                <label htmlFor="account-type-instrument" className="text-sm font-medium">
+                  Instrument <span className="text-destructive">*</span>
+                </label>
+                {instrumentsLoading ? (
+                  <select
+                    id="account-type-instrument"
+                    disabled
+                    className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+                    aria-busy="true"
+                  >
+                    <option value="">Loading instruments…</option>
+                  </select>
+                ) : (
+                  <select
+                    id="account-type-instrument"
+                    value={formData.instrumentCode}
+                    onChange={handleChange('instrumentCode')}
+                    aria-label="Instrument"
+                    aria-describedby={errors.instrumentCode ? 'account-type-instrument-error' : undefined}
+                    className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+                  >
+                    <option value="">Select an instrument…</option>
+                    {instruments.map((inst) => (
+                      <option key={inst.code} value={inst.code}>
+                        {inst.code}{inst.displayName ? ` — ${inst.displayName}` : ''}
+                      </option>
+                    ))}
+                  </select>
+                )}
+                {errors.instrumentCode && (
+                  <p id="account-type-instrument-error" className="text-sm text-destructive">
+                    {errors.instrumentCode}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-1">
+                <label htmlFor="account-type-saga-prefix" className="text-sm font-medium">
+                  Default Saga Prefix
+                </label>
+                <Input
+                  id="account-type-saga-prefix"
+                  value={formData.defaultSagaPrefix}
+                  onChange={handleChange('defaultSagaPrefix')}
+                  placeholder="savings"
+                  aria-label="Default Saga Prefix"
+                  aria-describedby={
+                    errors.defaultSagaPrefix
+                      ? 'account-type-saga-prefix-error'
+                      : 'account-type-saga-prefix-hint'
+                  }
+                />
+                <p id="account-type-saga-prefix-hint" className="text-xs text-muted-foreground">
+                  Sagas for this account type will be resolved as{' '}
+                  <code className="font-mono">{'{prefix}.{operation}'}</code> (e.g.,{' '}
+                  <code className="font-mono">savings.withdraw</code>). Leave empty to use generic saga names.
+                </p>
+                {errors.defaultSagaPrefix && (
+                  <p id="account-type-saga-prefix-error" className="text-sm text-destructive">
+                    {errors.defaultSagaPrefix}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="account-type-description" className="text-sm font-medium">
+                Description
+              </label>
+              <textarea
+                id="account-type-description"
+                value={formData.description}
+                onChange={handleChange('description')}
+                placeholder="Optional description of this account type"
+                aria-label="Description"
+                aria-describedby={errors.description ? 'account-type-description-error' : undefined}
+                maxLength={1000}
+                rows={3}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs resize-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+              {errors.description && (
+                <p id="account-type-description-error" className="text-sm text-destructive">
+                  {errors.description}
+                </p>
+              )}
+            </div>
+
+            {/* CEL editors - full width */}
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Validation CEL</label>
+              <p className="text-xs text-muted-foreground">
+                Validates account operations. Available: amount, attributes, valid_from, valid_to, source.
+              </p>
+              <CELEditor
+                value={formData.validationCel}
+                onChange={handleCelChange('validationCel')}
+                context="validation"
+                errors={errors.validationCel ? [{ message: errors.validationCel }] : []}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Bucketing CEL</label>
+              <p className="text-xs text-muted-foreground">
+                Determines fungibility buckets for amount pooling. Available: attributes.
+              </p>
+              <CELEditor
+                value={formData.bucketingCel}
+                onChange={handleCelChange('bucketingCel')}
+                context="bucketKey"
+                errors={errors.bucketingCel ? [{ message: errors.bucketingCel }] : []}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Eligibility CEL</label>
+              <p className="text-xs text-muted-foreground">
+                Determines account eligibility for operations. Available: party.type, party.status, party.external_reference_type, attributes.
+              </p>
+              <CELEditor
+                value={formData.eligibilityCel}
+                onChange={handleCelChange('eligibilityCel')}
+                context="eligibility"
+                errors={errors.eligibilityCel ? [{ message: errors.eligibilityCel }] : []}
+              />
+            </div>
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="create-account-type-form"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Creating…' : 'Create Account Type'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/reference-data/account-types/index.tsx
+++ b/frontend/src/pages/reference-data/account-types/index.tsx
@@ -5,10 +5,12 @@ import { StatusBadge } from '@/components/shared/status-badge'
 import { CELEditor } from '@/components/shared/cel-editor'
 import { useApiClients } from '@/api/context'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
 import {
   BehaviorClass,
   type AccountTypeDefinition,
 } from '@/api/gen/meridian/reference_data/v1/account_type_pb'
+import { CreateAccountTypeDialog } from './create-account-type-dialog'
 
 const BEHAVIOR_CLASS_LABELS: Record<number, string> = {
   0: 'Unspecified',
@@ -42,6 +44,7 @@ interface ListAccountTypesResult {
 export function AccountTypesPage() {
   const clients = useApiClients()
   const [selectedDefinition, setSelectedDefinition] = React.useState<AccountTypeDefinition | null>(null)
+  const [createDialogOpen, setCreateDialogOpen] = React.useState(false)
 
   const columns: ColumnDef<AccountTypeDefinition>[] = [
     {
@@ -99,12 +102,22 @@ export function AccountTypesPage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Account Types</h1>
-        <p className="mt-2 text-muted-foreground">
-          Account type registry with CEL policy configuration.
-        </p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Account Types</h1>
+          <p className="mt-2 text-muted-foreground">
+            Account type registry with CEL policy configuration.
+          </p>
+        </div>
+        <Button onClick={() => setCreateDialogOpen(true)}>
+          Create Account Type
+        </Button>
       </div>
+
+      <CreateAccountTypeDialog
+        open={createDialogOpen}
+        onOpenChange={setCreateDialogOpen}
+      />
 
       <Card className="p-6">
         <DataTable

--- a/frontend/src/pages/reference-data/account-types/index.tsx
+++ b/frontend/src/pages/reference-data/account-types/index.tsx
@@ -6,6 +6,7 @@ import { CELEditor } from '@/components/shared/cel-editor'
 import { useApiClients } from '@/api/context'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { referenceKeys } from '@/lib/query-keys'
 import {
   BehaviorClass,
   type AccountTypeDefinition,
@@ -121,7 +122,7 @@ export function AccountTypesPage() {
 
       <Card className="p-6">
         <DataTable
-          queryKey={['account-types']}
+          queryKey={referenceKeys.accountTypes()}
           queryFn={queryFn}
           columns={columns}
           pageSize={25}


### PR DESCRIPTION
## Summary

- Implements `CreateAccountTypeDialog` for the Account Types reference data page
- Adds a "Create Account Type" button to `AccountTypesPage` that opens the dialog

## Changes Made

**New files:**
- `frontend/src/pages/reference-data/account-types/create-account-type-dialog.tsx` — dialog component
- `frontend/src/pages/reference-data/account-types/create-account-type-dialog.test.tsx` — 28 tests

**Modified:**
- `frontend/src/pages/reference-data/account-types/index.tsx` — wires in the dialog with a Create button

## Technical Details

**Form fields:**
- `code` (required): auto-uppercased, pattern `^[A-Z][A-Z0-9_]*$`, 2–50 chars
- `displayName` (required): 1–255 chars
- `normalBalance` (required): DEBIT (1) / CREDIT (2) select
- `behaviorClass` (required): 9-option select (Customer, Clearing, Nostro, Vostro, Holding, Suspense, Revenue, Expense, Inventory)
- `instrumentCode` (required): select populated from `referenceData.listInstruments({ statusFilter: 2 })` (ACTIVE only)
- `defaultSagaPrefix` (optional): pattern `^[a-z][a-z0-9_]*$`, with helper text
- `description` (optional): textarea, max 1000 chars
- `validationCel`, `bucketingCel`, `eligibilityCel` (optional): CELEditor components, full-width

**Behaviour:**
- Calls `clients.accountTypeRegistry.createDraft()` on submit
- Shows DRAFT status note on success, invalidates `referenceKeys.accountTypes()` query
- Form resets on close via `useEffect([open])`
- Field-level error mapping from `google.rpc.BadRequest` details

## Testing

28 tests covering:
- Dialog render/close behaviour
- All required field validations (code pattern, length, required selects)
- Saga prefix pattern validation
- Normal balance and behavior class option rendering
- Instrument dropdown ACTIVE filter and loading state
- CEL editor rendering
- Successful submission (mutation call, DRAFT note, form reset, query invalidation)
- Error handling
- Form reset on dialog reopen

All 35 tests in the account-types directory pass.

## Deployment Notes

No migration or backend changes. Pure frontend addition.