### PR TITLE
feat(operations-console): add CreateValuationFeatureDialog component

### DIFF
--- a/frontend/src/components/shared/create-valuation-feature-dialog.test.tsx
+++ b/frontend/src/components/shared/create-valuation-feature-dialog.test.tsx
@@ -1,0 +1,402 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/msw-handlers'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { CreateValuationFeatureDialog } from './create-valuation-feature-dialog'
+
+const tenantToken = createTenantUserToken('tenant-test')
+
+const CURRENT_ACCOUNT_URL =
+  '*/meridian.current_account.v1.CurrentAccountService/CreateValuationFeature'
+const INTERNAL_ACCOUNT_URL =
+  '*/meridian.internal_bank_account.v1.InternalBankAccountService/CreateValuationFeature'
+
+function renderCurrentAccountDialog(
+  props: {
+    open?: boolean
+    onOpenChange?: (open: boolean) => void
+    accountId?: string
+    accountCurrency?: string
+  } = {},
+) {
+  const {
+    open = true,
+    onOpenChange = vi.fn(),
+    accountId = 'acct-001',
+    accountCurrency = 'GBP',
+  } = props
+  return renderWithProviders(
+    <MemoryRouter>
+      <CreateValuationFeatureDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        accountId={accountId}
+        accountType="current"
+        accountCurrency={accountCurrency}
+      />
+    </MemoryRouter>,
+    { initialToken: tenantToken },
+  )
+}
+
+function renderInternalAccountDialog(
+  props: {
+    open?: boolean
+    onOpenChange?: (open: boolean) => void
+    accountId?: string
+    accountCurrency?: string
+  } = {},
+) {
+  const {
+    open = true,
+    onOpenChange = vi.fn(),
+    accountId = 'internal-acct-001',
+    accountCurrency = 'GBP',
+  } = props
+  return renderWithProviders(
+    <MemoryRouter>
+      <CreateValuationFeatureDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        accountId={accountId}
+        accountType="internal"
+        accountCurrency={accountCurrency}
+      />
+    </MemoryRouter>,
+    { initialToken: tenantToken },
+  )
+}
+
+async function fillValidForm(accountCurrency = 'GBP') {
+  await userEvent.type(screen.getByLabelText(/input instrument code/i), 'USD')
+  await userEvent.type(screen.getByLabelText(/valuation method id/i), 'fx-rate-usd-gbp')
+  await userEvent.type(screen.getByLabelText(/method version/i), '1')
+  await userEvent.type(screen.getByLabelText(/output instrument/i), accountCurrency)
+}
+
+describe('CreateValuationFeatureDialog - rendering', () => {
+  it('renders dialog when open', () => {
+    renderCurrentAccountDialog()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getAllByText(/add valuation feature/i).length).toBeGreaterThan(0)
+  })
+
+  it('does not render when closed', () => {
+    renderCurrentAccountDialog({ open: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders all form fields', () => {
+    renderCurrentAccountDialog()
+    expect(screen.getByLabelText(/input instrument code/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/valuation method id/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/method version/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/output instrument/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/parameters/i)).toBeInTheDocument()
+  })
+
+  it('renders submit and cancel buttons', () => {
+    renderCurrentAccountDialog()
+    expect(screen.getByRole('button', { name: /add valuation feature/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('shows account currency in description', () => {
+    renderCurrentAccountDialog({ accountCurrency: 'GBP' })
+    expect(screen.getAllByText(/GBP/).length).toBeGreaterThan(0)
+  })
+
+  it('shows account currency hint for output instrument', () => {
+    renderCurrentAccountDialog({ accountCurrency: 'EUR' })
+    expect(screen.getByText(/Must match the account currency: EUR/i)).toBeInTheDocument()
+  })
+})
+
+describe('CreateValuationFeatureDialog - validation', () => {
+  it('shows error when instrumentCode is empty on submit', async () => {
+    renderCurrentAccountDialog()
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/instrument code is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when valuationMethodId is empty on submit', async () => {
+    renderCurrentAccountDialog()
+    await userEvent.type(screen.getByLabelText(/input instrument code/i), 'USD')
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/valuation method id is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when valuationMethodVersion is empty on submit', async () => {
+    renderCurrentAccountDialog()
+    await userEvent.type(screen.getByLabelText(/input instrument code/i), 'USD')
+    await userEvent.type(screen.getByLabelText(/valuation method id/i), 'method-1')
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/version is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when valuationMethodVersion is less than 1', async () => {
+    renderCurrentAccountDialog()
+    await userEvent.type(screen.getByLabelText(/input instrument code/i), 'USD')
+    await userEvent.type(screen.getByLabelText(/valuation method id/i), 'method-1')
+    await userEvent.type(screen.getByLabelText(/method version/i), '0')
+    await userEvent.type(screen.getByLabelText(/output instrument/i), 'GBP')
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/version must be a whole number of 1 or greater/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when outputInstrument is empty on submit', async () => {
+    renderCurrentAccountDialog()
+    await userEvent.type(screen.getByLabelText(/input instrument code/i), 'USD')
+    await userEvent.type(screen.getByLabelText(/valuation method id/i), 'method-1')
+    await userEvent.type(screen.getByLabelText(/method version/i), '1')
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/output instrument is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when outputInstrument does not match accountCurrency', async () => {
+    renderCurrentAccountDialog({ accountCurrency: 'GBP' })
+    await userEvent.type(screen.getByLabelText(/input instrument code/i), 'USD')
+    await userEvent.type(screen.getByLabelText(/valuation method id/i), 'method-1')
+    await userEvent.type(screen.getByLabelText(/method version/i), '1')
+    await userEvent.type(screen.getByLabelText(/output instrument/i), 'EUR')
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/output instrument must match the account currency \(GBP\)/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when parameters is invalid JSON', async () => {
+    renderCurrentAccountDialog()
+    await fillValidForm()
+    await userEvent.type(screen.getByLabelText(/parameters/i), 'not-json')
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/parameters must be valid json/i)).toBeInTheDocument()
+    })
+  })
+
+  it('accepts empty parameters', async () => {
+    server.use(
+      http.post(CURRENT_ACCOUNT_URL, () =>
+        HttpResponse.json({ feature: { id: 'feature-001' } }),
+      ),
+    )
+    renderCurrentAccountDialog()
+    await fillValidForm()
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('feature-id')).toBeInTheDocument()
+    })
+  })
+
+  it('accepts valid JSON parameters', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post(CURRENT_ACCOUNT_URL, async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({ feature: { id: 'feature-001' } })
+      }),
+    )
+    renderCurrentAccountDialog()
+    await fillValidForm()
+    // Use fireEvent to bypass userEvent special char handling for braces
+    const { fireEvent } = await import('@testing-library/react')
+    fireEvent.change(screen.getByLabelText(/parameters/i), {
+      target: { value: '{"source": "ecb"}' },
+    })
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({
+        parameters: '{"source": "ecb"}',
+      })
+    })
+  })
+})
+
+describe('CreateValuationFeatureDialog - current account API', () => {
+  beforeEach(() => {
+    server.use(
+      http.post(CURRENT_ACCOUNT_URL, () =>
+        HttpResponse.json({ feature: { id: 'feature-001' } }),
+      ),
+    )
+  })
+
+  it('calls CurrentAccountService with correct request body', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post(CURRENT_ACCOUNT_URL, async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({ feature: { id: 'feature-001' } })
+      }),
+    )
+    renderCurrentAccountDialog({ accountId: 'acct-001', accountCurrency: 'GBP' })
+    await fillValidForm('GBP')
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({
+        accountId: 'acct-001',
+        instrumentCode: 'USD',
+        valuationMethodId: 'fx-rate-usd-gbp',
+        valuationMethodVersion: 1,
+        outputInstrument: 'GBP',
+      })
+    })
+  })
+
+  it('shows feature ID on success', async () => {
+    renderCurrentAccountDialog()
+    await fillValidForm()
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('feature-id')).toHaveTextContent('feature-001')
+    })
+  })
+
+  it('shows success dialog with feature ID after creation', async () => {
+    renderCurrentAccountDialog()
+    await fillValidForm()
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/valuation feature created/i)).toBeInTheDocument()
+      expect(screen.getByTestId('feature-id')).toHaveTextContent('feature-001')
+    })
+  })
+
+  it('invalidates account query key on success', async () => {
+    renderCurrentAccountDialog({ accountId: 'acct-001' })
+    await fillValidForm()
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('feature-id')).toBeInTheDocument()
+    })
+  })
+
+  it('shows server error on API failure', async () => {
+    server.use(
+      http.post(CURRENT_ACCOUNT_URL, () =>
+        HttpResponse.json({ message: 'Method not found' }, { status: 400 }),
+      ),
+    )
+    renderCurrentAccountDialog()
+    await fillValidForm()
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+
+  it('disables submit button during submission', async () => {
+    server.use(
+      http.post(CURRENT_ACCOUNT_URL, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        return HttpResponse.json({ feature: { id: 'feature-001' } })
+      }),
+    )
+    renderCurrentAccountDialog()
+    await fillValidForm()
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    expect(screen.getByRole('button', { name: /creating|add valuation feature/i })).toBeDisabled()
+  })
+})
+
+describe('CreateValuationFeatureDialog - internal account API', () => {
+  it('calls InternalBankAccountService for internal account type', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.post(INTERNAL_ACCOUNT_URL, async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({ feature: { id: 'feature-internal-001' } })
+      }),
+    )
+    renderInternalAccountDialog({ accountId: 'internal-acct-001', accountCurrency: 'GBP' })
+    await userEvent.type(screen.getByLabelText(/input instrument code/i), 'USD')
+    await userEvent.type(screen.getByLabelText(/valuation method id/i), 'fx-rate-usd-gbp')
+    await userEvent.type(screen.getByLabelText(/method version/i), '2')
+    await userEvent.type(screen.getByLabelText(/output instrument/i), 'GBP')
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({
+        accountId: 'internal-acct-001',
+        instrumentCode: 'USD',
+        valuationMethodId: 'fx-rate-usd-gbp',
+        valuationMethodVersion: 2,
+        outputInstrument: 'GBP',
+      })
+    })
+  })
+
+  it('shows feature ID on success for internal accounts', async () => {
+    server.use(
+      http.post(INTERNAL_ACCOUNT_URL, () =>
+        HttpResponse.json({ feature: { id: 'feature-internal-001' } }),
+      ),
+    )
+    renderInternalAccountDialog()
+    await userEvent.type(screen.getByLabelText(/input instrument code/i), 'USD')
+    await userEvent.type(screen.getByLabelText(/valuation method id/i), 'method-1')
+    await userEvent.type(screen.getByLabelText(/method version/i), '1')
+    await userEvent.type(screen.getByLabelText(/output instrument/i), 'GBP')
+    await userEvent.click(screen.getByRole('button', { name: /add valuation feature/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('feature-id')).toHaveTextContent('feature-internal-001')
+    })
+  })
+})
+
+describe('CreateValuationFeatureDialog - cancel', () => {
+  it('calls onOpenChange(false) when cancel clicked', async () => {
+    const onOpenChange = vi.fn()
+    renderCurrentAccountDialog({ onOpenChange })
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})
+
+describe('CreateValuationFeatureDialog - reset on close', () => {
+  it('clears form when dialog closes and reopens', () => {
+    const { rerender } = renderCurrentAccountDialog({ open: true })
+
+    rerender(
+      <MemoryRouter>
+        <CreateValuationFeatureDialog
+          open={false}
+          onOpenChange={vi.fn()}
+          accountId="acct-001"
+          accountType="current"
+          accountCurrency="GBP"
+        />
+      </MemoryRouter>,
+    )
+
+    rerender(
+      <MemoryRouter>
+        <CreateValuationFeatureDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          accountId="acct-001"
+          accountType="current"
+          accountCurrency="GBP"
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByLabelText(/input instrument code/i)).toHaveValue('')
+    expect(screen.getByLabelText(/valuation method id/i)).toHaveValue('')
+    expect(screen.getByLabelText(/output instrument/i)).toHaveValue('')
+  })
+})

--- a/frontend/src/components/shared/create-valuation-feature-dialog.test.tsx
+++ b/frontend/src/components/shared/create-valuation-feature-dialog.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { http, HttpResponse } from 'msw'
 import { server } from '@/test/msw-handlers'
-import { renderWithProviders } from '@/test/test-utils'
+import { renderWithProviders, createTestQueryClient } from '@/test/test-utils'
 import { createTenantUserToken } from '@/test/jwt-helpers'
 import { CreateValuationFeatureDialog } from './create-valuation-feature-dialog'
 
@@ -369,31 +369,29 @@ describe('CreateValuationFeatureDialog - cancel', () => {
 
 describe('CreateValuationFeatureDialog - reset on close', () => {
   it('clears form when dialog closes and reopens', () => {
-    const { rerender } = renderCurrentAccountDialog({ open: true })
+    const queryClient = createTestQueryClient()
 
-    rerender(
-      <MemoryRouter>
-        <CreateValuationFeatureDialog
-          open={false}
-          onOpenChange={vi.fn()}
-          accountId="acct-001"
-          accountType="current"
-          accountCurrency="GBP"
-        />
-      </MemoryRouter>,
-    )
+    function makeDialog(open: boolean) {
+      return (
+        <MemoryRouter>
+          <CreateValuationFeatureDialog
+            open={open}
+            onOpenChange={vi.fn()}
+            accountId="acct-001"
+            accountType="current"
+            accountCurrency="GBP"
+          />
+        </MemoryRouter>
+      )
+    }
 
-    rerender(
-      <MemoryRouter>
-        <CreateValuationFeatureDialog
-          open={true}
-          onOpenChange={vi.fn()}
-          accountId="acct-001"
-          accountType="current"
-          accountCurrency="GBP"
-        />
-      </MemoryRouter>,
-    )
+    const { rerender } = renderWithProviders(makeDialog(true), {
+      initialToken: tenantToken,
+      queryClient,
+    })
+
+    rerender(makeDialog(false))
+    rerender(makeDialog(true))
 
     expect(screen.getByLabelText(/input instrument code/i)).toHaveValue('')
     expect(screen.getByLabelText(/valuation method id/i)).toHaveValue('')

--- a/frontend/src/components/shared/create-valuation-feature-dialog.tsx
+++ b/frontend/src/components/shared/create-valuation-feature-dialog.tsx
@@ -1,0 +1,398 @@
+import * as React from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useTenantContext } from '@/contexts/tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import { handleConnectError } from '@/lib/error-handling'
+import { Code, ConnectError } from '@connectrpc/connect'
+
+export type AccountType = 'current' | 'internal'
+
+export interface CreateValuationFeatureDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  accountId: string
+  accountType: AccountType
+  accountCurrency: string
+}
+
+interface FormData {
+  instrumentCode: string
+  valuationMethodId: string
+  valuationMethodVersion: string
+  outputInstrument: string
+  parameters: string
+}
+
+interface FormErrors {
+  instrumentCode?: string
+  valuationMethodId?: string
+  valuationMethodVersion?: string
+  outputInstrument?: string
+  parameters?: string
+  general?: string
+}
+
+const initialFormData: FormData = {
+  instrumentCode: '',
+  valuationMethodId: '',
+  valuationMethodVersion: '',
+  outputInstrument: '',
+  parameters: '',
+}
+
+async function createValuationFeature(
+  tenantSlug: string,
+  accountType: AccountType,
+  accountId: string,
+  instrumentCode: string,
+  valuationMethodId: string,
+  valuationMethodVersion: number,
+  outputInstrument: string,
+  parameters: string,
+): Promise<string> {
+  const serviceName =
+    accountType === 'current'
+      ? 'meridian.current_account.v1.CurrentAccountService'
+      : 'meridian.internal_bank_account.v1.InternalBankAccountService'
+
+  const body: Record<string, unknown> = {
+    accountId,
+    instrumentCode,
+    valuationMethodId,
+    valuationMethodVersion,
+    outputInstrument,
+  }
+
+  if (parameters.trim()) {
+    body.parameters = parameters.trim()
+  }
+
+  const response = await fetch(`/api/${serviceName}/CreateValuationFeature`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Tenant-Slug': tenantSlug,
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    const data = (await response.json().catch(() => ({}))) as {
+      message?: string
+      code?: number
+      details?: unknown[]
+    }
+    const err = new ConnectError(
+      data.message ?? `Failed to create valuation feature: ${response.status}`,
+      data.code ?? Code.Unknown,
+    )
+    throw err
+  }
+
+  const data = (await response.json()) as { feature?: { id?: string } }
+  return data.feature?.id ?? ''
+}
+
+function validateForm(formData: FormData, accountCurrency: string): FormErrors {
+  const errors: FormErrors = {}
+
+  if (!formData.instrumentCode.trim()) {
+    errors.instrumentCode = 'Instrument code is required'
+  }
+
+  if (!formData.valuationMethodId.trim()) {
+    errors.valuationMethodId = 'Valuation method ID is required'
+  }
+
+  const version = parseInt(formData.valuationMethodVersion, 10)
+  if (!formData.valuationMethodVersion.trim()) {
+    errors.valuationMethodVersion = 'Version is required'
+  } else if (isNaN(version) || version < 1) {
+    errors.valuationMethodVersion = 'Version must be a whole number of 1 or greater'
+  }
+
+  if (!formData.outputInstrument.trim()) {
+    errors.outputInstrument = 'Output instrument is required'
+  } else if (formData.outputInstrument.trim() !== accountCurrency) {
+    errors.outputInstrument = `Output instrument must match the account currency (${accountCurrency})`
+  }
+
+  if (formData.parameters.trim()) {
+    try {
+      JSON.parse(formData.parameters.trim())
+    } catch {
+      errors.parameters = 'Parameters must be valid JSON'
+    }
+  }
+
+  return errors
+}
+
+function hasErrors(errors: FormErrors): boolean {
+  return Object.keys(errors).length > 0
+}
+
+export function CreateValuationFeatureDialog({
+  open,
+  onOpenChange,
+  accountId,
+  accountType,
+  accountCurrency,
+}: CreateValuationFeatureDialogProps) {
+  const { tenantSlug } = useTenantContext()
+  const queryClient = useQueryClient()
+
+  const [formData, setFormData] = React.useState<FormData>(initialFormData)
+  const [errors, setErrors] = React.useState<FormErrors>({})
+  const [successFeatureId, setSuccessFeatureId] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    if (!open) {
+      setFormData(initialFormData)
+      setErrors({})
+      setSuccessFeatureId(null)
+    }
+  }, [open])
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      const version = parseInt(formData.valuationMethodVersion, 10)
+      return createValuationFeature(
+        tenantSlug ?? '',
+        accountType,
+        accountId,
+        formData.instrumentCode.trim(),
+        formData.valuationMethodId.trim(),
+        version,
+        formData.outputInstrument.trim(),
+        formData.parameters,
+      )
+    },
+    onSuccess: (featureId) => {
+      if (accountType === 'current') {
+        queryClient.invalidateQueries({
+          queryKey: tenantKeys.account(tenantSlug ?? '', accountId),
+        })
+      } else {
+        queryClient.invalidateQueries({
+          queryKey: tenantKeys.internalAccount(tenantSlug ?? '', accountId),
+        })
+      }
+      setSuccessFeatureId(featureId)
+    },
+    onError: (err) => {
+      const result = handleConnectError(err)
+      if (result.code === Code.InvalidArgument && Object.keys(result.fieldErrors).length > 0) {
+        const fieldMap: FormErrors = {}
+        for (const [field, msg] of Object.entries(result.fieldErrors)) {
+          if (field === 'instrument_code') fieldMap.instrumentCode = msg
+          else if (field === 'valuation_method_id') fieldMap.valuationMethodId = msg
+          else if (field === 'valuation_method_version') fieldMap.valuationMethodVersion = msg
+          else if (field === 'output_instrument') fieldMap.outputInstrument = msg
+          else if (field === 'parameters') fieldMap.parameters = msg
+          else fieldMap.general = msg
+        }
+        setErrors(fieldMap)
+      } else {
+        setErrors({ general: result.message })
+      }
+    },
+  })
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const validationErrors = validateForm(formData, accountCurrency)
+    if (hasErrors(validationErrors)) {
+      setErrors(validationErrors)
+      return
+    }
+    setErrors({})
+    mutation.mutate()
+  }
+
+  function handleChange(field: keyof FormData) {
+    return (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setFormData((prev) => ({ ...prev, [field]: e.target.value }))
+      if (errors[field]) {
+        setErrors((prev) => ({ ...prev, [field]: undefined }))
+      }
+    }
+  }
+
+  if (successFeatureId) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Valuation Feature Created</DialogTitle>
+            <DialogDescription>
+              The valuation feature has been successfully created for account {accountId}.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="py-2">
+            <p className="text-sm text-muted-foreground">Feature ID</p>
+            <p className="font-mono text-sm" data-testid="feature-id">
+              {successFeatureId}
+            </p>
+          </div>
+          <DialogFooter>
+            <Button onClick={() => onOpenChange(false)}>Close</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Valuation Feature</DialogTitle>
+          <DialogDescription>
+            Map an input instrument to the account&apos;s native instrument ({accountCurrency}) using
+            a valuation method.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="create-valuation-feature-form">
+          <div className="space-y-4 py-2">
+            {errors.general && (
+              <div
+                role="alert"
+                className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                {errors.general}
+              </div>
+            )}
+
+            <div className="space-y-1">
+              <label htmlFor="instrumentCode" className="text-sm font-medium">
+                Input Instrument Code <span aria-hidden="true">*</span>
+              </label>
+              <Input
+                id="instrumentCode"
+                value={formData.instrumentCode}
+                onChange={handleChange('instrumentCode')}
+                placeholder="e.g. USD, EUR, kWh"
+                aria-describedby={errors.instrumentCode ? 'instrumentCode-error' : undefined}
+                aria-required="true"
+              />
+              {errors.instrumentCode && (
+                <p id="instrumentCode-error" className="text-sm text-destructive">
+                  {errors.instrumentCode}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="valuationMethodId" className="text-sm font-medium">
+                Valuation Method ID <span aria-hidden="true">*</span>
+              </label>
+              <Input
+                id="valuationMethodId"
+                value={formData.valuationMethodId}
+                onChange={handleChange('valuationMethodId')}
+                placeholder="e.g. fx-rate-usd-gbp"
+                aria-describedby={errors.valuationMethodId ? 'valuationMethodId-error' : undefined}
+                aria-required="true"
+              />
+              {errors.valuationMethodId && (
+                <p id="valuationMethodId-error" className="text-sm text-destructive">
+                  {errors.valuationMethodId}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="valuationMethodVersion" className="text-sm font-medium">
+                Method Version <span aria-hidden="true">*</span>
+              </label>
+              <Input
+                id="valuationMethodVersion"
+                value={formData.valuationMethodVersion}
+                onChange={handleChange('valuationMethodVersion')}
+                placeholder="e.g. 1"
+                inputMode="numeric"
+                aria-describedby={
+                  errors.valuationMethodVersion ? 'valuationMethodVersion-error' : undefined
+                }
+                aria-required="true"
+              />
+              {errors.valuationMethodVersion && (
+                <p id="valuationMethodVersion-error" className="text-sm text-destructive">
+                  {errors.valuationMethodVersion}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="outputInstrument" className="text-sm font-medium">
+                Output Instrument <span aria-hidden="true">*</span>
+              </label>
+              <Input
+                id="outputInstrument"
+                value={formData.outputInstrument}
+                onChange={handleChange('outputInstrument')}
+                placeholder={accountCurrency}
+                aria-describedby={errors.outputInstrument ? 'outputInstrument-error' : undefined}
+                aria-required="true"
+              />
+              <p className="text-xs text-muted-foreground">
+                Must match the account currency: {accountCurrency}
+              </p>
+              {errors.outputInstrument && (
+                <p id="outputInstrument-error" className="text-sm text-destructive">
+                  {errors.outputInstrument}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="parameters" className="text-sm font-medium">
+                Parameters (optional)
+              </label>
+              <Input
+                id="parameters"
+                value={formData.parameters}
+                onChange={handleChange('parameters')}
+                placeholder='e.g. {"source": "ecb"}'
+                aria-describedby={errors.parameters ? 'parameters-error' : undefined}
+              />
+              <p className="text-xs text-muted-foreground">
+                Optional JSON configuration for the valuation method
+              </p>
+              {errors.parameters && (
+                <p id="parameters-error" className="text-sm text-destructive">
+                  {errors.parameters}
+                </p>
+              )}
+            </div>
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="create-valuation-feature-form"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Creating...' : 'Add Valuation Feature'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/shared/create-valuation-feature-dialog.tsx
+++ b/frontend/src/components/shared/create-valuation-feature-dialog.tsx
@@ -100,7 +100,11 @@ async function createValuationFeature(
   }
 
   const data = (await response.json()) as { feature?: { id?: string } }
-  return data.feature?.id ?? ''
+  const featureId = data.feature?.id
+  if (!featureId) {
+    throw new ConnectError('Feature ID missing from response', Code.Internal)
+  }
+  return featureId
 }
 
 function validateForm(formData: FormData, accountCurrency: string): FormErrors {

--- a/frontend/src/components/shared/index.ts
+++ b/frontend/src/components/shared/index.ts
@@ -11,3 +11,5 @@ export { SagaTimeline } from './saga-timeline';
 export type { SagaTimelineProps, SagaStep } from './saga-timeline';
 export { QualityLadderBadge } from './quality-ladder-badge';
 export { DirectionBadge } from './direction-badge';
+export { CreateValuationFeatureDialog } from './create-valuation-feature-dialog';
+export type { CreateValuationFeatureDialogProps, AccountType } from './create-valuation-feature-dialog';

--- a/frontend/src/pages/accounts/[accountId].tsx
+++ b/frontend/src/pages/accounts/[accountId].tsx
@@ -15,6 +15,7 @@ import { WithdrawDialog } from './withdraw-dialog'
 import { ControlDialog } from './control-dialog'
 import type { ControlAction } from './control-dialog'
 import { CreateLienDialog } from './create-lien-dialog'
+import { CreateValuationFeatureDialog } from '@/components/shared/create-valuation-feature-dialog'
 import type { AccountStatus, CurrentAccount, RetrieveCurrentAccountResponse } from './types'
 
 async function retrieveAccount(
@@ -107,6 +108,7 @@ function AccountActions({ status, accountId, currency }: AccountActionsProps) {
   const [lienOpen, setLienOpen] = React.useState(false)
   const [controlOpen, setControlOpen] = React.useState(false)
   const [controlAction, setControlAction] = React.useState<ControlAction>('freeze')
+  const [valuationFeatureOpen, setValuationFeatureOpen] = React.useState(false)
 
   if (status === 'CLOSED' || status === 'SUSPENDED') {
     return null
@@ -130,6 +132,9 @@ function AccountActions({ status, accountId, currency }: AccountActionsProps) {
             </Button>
             <Button variant="outline" size="sm" onClick={() => setLienOpen(true)}>
               Create Lien
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => setValuationFeatureOpen(true)}>
+              Add Valuation Feature
             </Button>
             <Button variant="outline" size="sm" onClick={() => openControl('freeze')}>
               Freeze
@@ -173,6 +178,14 @@ function AccountActions({ status, accountId, currency }: AccountActionsProps) {
         onOpenChange={setControlOpen}
         accountId={accountId}
         action={controlAction}
+      />
+
+      <CreateValuationFeatureDialog
+        open={valuationFeatureOpen}
+        onOpenChange={setValuationFeatureOpen}
+        accountId={accountId}
+        accountType="current"
+        accountCurrency={currency}
       />
     </>
   )


### PR DESCRIPTION
## Summary

- Adds reusable `CreateValuationFeatureDialog` component to `components/shared/` for creating valuation features on both current and internal bank accounts
- Integrates into `AccountDetailPage` with an "Add Valuation Feature" button visible on active accounts
- 25 unit tests covering all acceptance criteria

## Changes Made

### New: `frontend/src/components/shared/create-valuation-feature-dialog.tsx`

Reusable dialog component with:
- Form fields: input instrument code, valuation method ID, method version (>=1), output instrument, optional JSON parameters
- Client-side validation matching proto requirements (instrument required, method ID required, version >=1, output instrument must match `accountCurrency` prop)
- Conditional API dispatch: `CurrentAccountService/CreateValuationFeature` for `accountType="current"`, `InternalBankAccountService/CreateValuationFeature` for `accountType="internal"`
- Success state displaying the created feature ID
- Form reset on dialog close
- Error handling via `handleConnectError` with field-level error mapping

### New: `frontend/src/components/shared/create-valuation-feature-dialog.test.tsx`

25 tests covering:
- Rendering (fields, buttons, currency labels)
- Validation (all required fields, version >=1, output instrument matching account currency, valid JSON parameters)
- Current account API (correct request body, success state, server errors, loading state)
- Internal account API (correct service called, success state)
- Cancel behaviour and form reset

### Modified: `frontend/src/components/shared/index.ts`

Exports `CreateValuationFeatureDialog` and `AccountType`.

### Modified: `frontend/src/pages/accounts/[accountId].tsx`

Adds "Add Valuation Feature" button and dialog mount to `AccountActions` for active current accounts.

## Technical Details

- Uses direct JSON fetch (consistent with other account dialogs: deposit, withdraw, lien)
- Invalidates `tenantKeys.account()` or `tenantKeys.internalAccount()` query on success
- `output_instrument` must match `accountCurrency` prop — validated client-side before submission
- `parameters` field is optional; omitted from request body if empty

## Testing

```bash
cd frontend && node_modules/.bin/vitest run src/components/shared/create-valuation-feature-dialog.test.tsx
# 25 passed (25)

node_modules/.bin/vitest run
# 1402 passed (108 test files)
```

## Task Master

026-operations-console.77 - Implement CreateValuationFeatureDialog component