### PR TITLE
feat: add Register Party Associations dialog to Operations Console

### DIFF
--- a/frontend/src/pages/parties/dialogs/register-associations-dialog.test.tsx
+++ b/frontend/src/pages/parties/dialogs/register-associations-dialog.test.tsx
@@ -1,0 +1,472 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { RegisterAssociationsDialog } from './register-associations-dialog'
+
+const mockRegisterAssociations = vi.fn()
+const mockListParties = vi.fn()
+const mockInvalidateQueries = vi.fn()
+
+vi.mock('@/api/context', async () => {
+  const actual = await vi.importActual('@/api/context')
+  return {
+    ...actual,
+    useApiClients: vi.fn(() => ({
+      party: {
+        registerAssociations: mockRegisterAssociations,
+        listParties: mockListParties,
+      },
+    })),
+    useClients: vi.fn(() => ({
+      party: {
+        registerAssociations: mockRegisterAssociations,
+        listParties: mockListParties,
+      },
+    })),
+  }
+})
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query')
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: mockInvalidateQueries,
+    }),
+  }
+})
+
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: () => 'test-tenant',
+  useCurrentTenant: () => null,
+  useIsPlatformAdmin: () => false,
+  useSwitchTenant: () => vi.fn(),
+  useClearTenant: () => vi.fn(),
+}))
+
+const mockParties = [
+  { partyId: 'party-001', displayName: 'Acme Corp', legalName: 'Acme Corporation Ltd' },
+  { partyId: 'party-002', displayName: 'Beta Inc', legalName: 'Beta Incorporated' },
+]
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = makeQueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>{children}</TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+function renderDialog(
+  props: {
+    open?: boolean
+    onOpenChange?: (open: boolean) => void
+    partyId?: string
+  } = {},
+) {
+  const { open = true, onOpenChange = vi.fn(), partyId = 'current-party-001' } = props
+  return render(
+    <Wrapper>
+      <RegisterAssociationsDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        partyId={partyId}
+      />
+    </Wrapper>,
+  )
+}
+
+describe('RegisterAssociationsDialog - rendering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListParties.mockResolvedValue({ parties: [] })
+    mockRegisterAssociations.mockResolvedValue({ associationId: 'assoc-123' })
+  })
+
+  it('does not render dialog content when closed', () => {
+    renderDialog({ open: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders dialog content when open', () => {
+    renderDialog()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /add association/i })).toBeInTheDocument()
+  })
+
+  it('renders relationship type select', () => {
+    renderDialog()
+    expect(screen.getByLabelText(/relationship type/i)).toBeInTheDocument()
+  })
+
+  it('renders effective from and effective to date inputs', () => {
+    renderDialog()
+    expect(screen.getByLabelText(/effective from/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/effective to/i)).toBeInTheDocument()
+  })
+
+  it('renders submit and cancel buttons', () => {
+    renderDialog()
+    expect(screen.getByRole('button', { name: /add association/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('renders all relationship type options', () => {
+    renderDialog()
+    const select = screen.getByLabelText(/relationship type/i) as HTMLSelectElement
+    const optionValues = Array.from(select.options).map((o) => o.value)
+    expect(optionValues).toContain('RELATIONSHIP_TYPE_SPOUSE')
+    expect(optionValues).toContain('RELATIONSHIP_TYPE_DEPENDENT')
+    expect(optionValues).toContain('RELATIONSHIP_TYPE_BUSINESS_PARTNER')
+    expect(optionValues).toContain('RELATIONSHIP_TYPE_GUARANTOR')
+    expect(optionValues).toContain('RELATIONSHIP_TYPE_BENEFICIAL_OWNER')
+    expect(optionValues).toContain('RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT')
+    expect(optionValues).toContain('RELATIONSHIP_TYPE_SYNDICATE_HOST')
+  })
+})
+
+describe('RegisterAssociationsDialog - party search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListParties.mockResolvedValue({ parties: mockParties })
+    mockRegisterAssociations.mockResolvedValue({ associationId: 'assoc-123' })
+  })
+
+  it('renders the party search input', () => {
+    renderDialog()
+    expect(screen.getByLabelText(/related party/i)).toBeInTheDocument()
+  })
+
+  it('does not call listParties when search is less than 2 characters', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/related party/i), 'A')
+
+    await new Promise((r) => setTimeout(r, 400))
+    expect(mockListParties).not.toHaveBeenCalled()
+  })
+
+  it('calls listParties with searchQuery when input has 2+ characters', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/related party/i), 'Ac')
+
+    await waitFor(() => {
+      expect(mockListParties).toHaveBeenCalledWith(
+        expect.objectContaining({ searchQuery: 'Ac', pageSize: 20 }),
+      )
+    })
+  })
+
+  it('shows party search results in dropdown', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/related party/i), 'Ac')
+
+    await waitFor(() => {
+      expect(screen.getByText('Acme Corp')).toBeInTheDocument()
+    })
+  })
+
+  it('shows party ID alongside party name in results', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/related party/i), 'Ac')
+
+    await waitFor(() => {
+      expect(screen.getByText(/party-001/i)).toBeInTheDocument()
+    })
+  })
+
+  it('allows selecting a party from results', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/related party/i), 'Ac')
+
+    await waitFor(() => {
+      expect(screen.getByText('Acme Corp')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Acme Corp'))
+
+    // After selection, the input should show the selected party name
+    await waitFor(() => {
+      const input = screen.getByLabelText(/related party/i) as HTMLInputElement
+      expect(input.value).toBe('Acme Corp')
+    })
+  })
+
+  it('clears selected party ID when input is cleared after selection', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/related party/i), 'Ac')
+    await waitFor(() => {
+      expect(screen.getByText('Acme Corp')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Acme Corp'))
+
+    // Verify party was selected (input shows party name)
+    const input = screen.getByLabelText(/related party/i) as HTMLInputElement
+    expect(input.value).toBe('Acme Corp')
+
+    // Clear the input - submission should fail without a re-selection
+    await user.clear(input)
+
+    // After clearing and submitting, should show error (party was deselected)
+    await user.click(screen.getByRole('button', { name: /add association/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/related party is required/i)).toBeInTheDocument()
+    })
+  })
+})
+
+describe('RegisterAssociationsDialog - validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListParties.mockResolvedValue({ parties: mockParties })
+    mockRegisterAssociations.mockResolvedValue({ associationId: 'assoc-123' })
+  })
+
+  it('shows error when related party is not selected on submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /add association/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/related party is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when relationship type is not selected on submit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    // Select a party
+    await user.type(screen.getByLabelText(/related party/i), 'Ac')
+    await waitFor(() => expect(screen.getByText('Acme Corp')).toBeInTheDocument())
+    await user.click(screen.getByText('Acme Corp'))
+
+    await user.click(screen.getByRole('button', { name: /add association/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/relationship type is required/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when effectiveTo is before effectiveFrom', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/effective from/i), '2025-06-01')
+    await user.type(screen.getByLabelText(/effective to/i), '2025-01-01')
+    await user.click(screen.getByRole('button', { name: /add association/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/effective to must be after effective from/i)).toBeInTheDocument()
+    })
+  })
+
+  it('does not show date error when effectiveTo equals effectiveFrom', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    // Select a party and relationship type first
+    await user.type(screen.getByLabelText(/related party/i), 'Ac')
+    await waitFor(() => expect(screen.getByText('Acme Corp')).toBeInTheDocument())
+    await user.click(screen.getByText('Acme Corp'))
+    await user.selectOptions(screen.getByLabelText(/relationship type/i), 'RELATIONSHIP_TYPE_GUARANTOR')
+
+    await user.type(screen.getByLabelText(/effective from/i), '2025-06-01')
+    await user.type(screen.getByLabelText(/effective to/i), '2025-06-01')
+    await user.click(screen.getByRole('button', { name: /add association/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText(/effective to must be after/i)).not.toBeInTheDocument()
+    })
+  })
+})
+
+describe('RegisterAssociationsDialog - successful submission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListParties.mockResolvedValue({ parties: mockParties })
+    mockRegisterAssociations.mockResolvedValue({ associationId: 'assoc-new-123' })
+  })
+
+  it('submits form with partyId, relatedPartyId, and relationshipType', async () => {
+    const user = userEvent.setup()
+    renderDialog({ partyId: 'current-party-001' })
+
+    await user.type(screen.getByLabelText(/related party/i), 'Ac')
+    await waitFor(() => expect(screen.getByText('Acme Corp')).toBeInTheDocument())
+    await user.click(screen.getByText('Acme Corp'))
+
+    await user.selectOptions(screen.getByLabelText(/relationship type/i), 'RELATIONSHIP_TYPE_GUARANTOR')
+
+    await user.click(screen.getByRole('button', { name: /add association/i }))
+
+    await waitFor(() => {
+      expect(mockRegisterAssociations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          partyId: 'current-party-001',
+          relatedPartyId: 'party-001',
+          relationshipType: 4, // RELATIONSHIP_TYPE_GUARANTOR enum value
+        }),
+      )
+    })
+  })
+
+  it('invalidates party associations query on success', async () => {
+    const user = userEvent.setup()
+    renderDialog({ partyId: 'current-party-001' })
+
+    await user.type(screen.getByLabelText(/related party/i), 'Ac')
+    await waitFor(() => expect(screen.getByText('Acme Corp')).toBeInTheDocument())
+    await user.click(screen.getByText('Acme Corp'))
+    await user.selectOptions(screen.getByLabelText(/relationship type/i), 'RELATIONSHIP_TYPE_GUARANTOR')
+    await user.click(screen.getByRole('button', { name: /add association/i }))
+
+    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: expect.arrayContaining(['associations']),
+        }),
+      )
+    })
+  })
+
+  it('closes dialog on success', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    renderDialog({ onOpenChange, partyId: 'current-party-001' })
+
+    await user.type(screen.getByLabelText(/related party/i), 'Ac')
+    await waitFor(() => expect(screen.getByText('Acme Corp')).toBeInTheDocument())
+    await user.click(screen.getByText('Acme Corp'))
+    await user.selectOptions(screen.getByLabelText(/relationship type/i), 'RELATIONSHIP_TYPE_GUARANTOR')
+    await user.click(screen.getByRole('button', { name: /add association/i }))
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('includes effectiveFrom timestamp when provided', async () => {
+    const user = userEvent.setup()
+    renderDialog({ partyId: 'current-party-001' })
+
+    await user.type(screen.getByLabelText(/related party/i), 'Ac')
+    await waitFor(() => expect(screen.getByText('Acme Corp')).toBeInTheDocument())
+    await user.click(screen.getByText('Acme Corp'))
+    await user.selectOptions(screen.getByLabelText(/relationship type/i), 'RELATIONSHIP_TYPE_GUARANTOR')
+    await user.type(screen.getByLabelText(/effective from/i), '2025-01-15')
+
+    await user.click(screen.getByRole('button', { name: /add association/i }))
+
+    await waitFor(() => {
+      expect(mockRegisterAssociations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          effectiveFrom: expect.objectContaining({ seconds: expect.any(BigInt) }),
+        }),
+      )
+    })
+  })
+
+  it('disables submit button while mutation is pending', async () => {
+    mockRegisterAssociations.mockImplementation(() => new Promise(() => {}))
+    const user = userEvent.setup()
+    renderDialog({ partyId: 'current-party-001' })
+
+    await user.type(screen.getByLabelText(/related party/i), 'Ac')
+    await waitFor(() => expect(screen.getByText('Acme Corp')).toBeInTheDocument())
+    await user.click(screen.getByText('Acme Corp'))
+    await user.selectOptions(screen.getByLabelText(/relationship type/i), 'RELATIONSHIP_TYPE_GUARANTOR')
+    await user.click(screen.getByRole('button', { name: /add association/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /adding/i })).toBeDisabled()
+    })
+  })
+})
+
+describe('RegisterAssociationsDialog - error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListParties.mockResolvedValue({ parties: mockParties })
+  })
+
+  it('shows general error banner for server errors', async () => {
+    const user = userEvent.setup()
+    const { Code, ConnectError } = await import('@connectrpc/connect')
+    mockRegisterAssociations.mockRejectedValue(new ConnectError('server error', Code.Internal))
+
+    renderDialog({ partyId: 'current-party-001' })
+
+    await user.type(screen.getByLabelText(/related party/i), 'Ac')
+    await waitFor(() => expect(screen.getByText('Acme Corp')).toBeInTheDocument())
+    await user.click(screen.getByText('Acme Corp'))
+    await user.selectOptions(screen.getByLabelText(/relationship type/i), 'RELATIONSHIP_TYPE_GUARANTOR')
+    await user.click(screen.getByRole('button', { name: /add association/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('RegisterAssociationsDialog - reset on close', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListParties.mockResolvedValue({ parties: mockParties })
+    mockRegisterAssociations.mockResolvedValue({ associationId: 'assoc-123' })
+  })
+
+  it('clears form when dialog is closed and reopened', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    const { rerender } = renderDialog({ onOpenChange })
+
+    await user.selectOptions(screen.getByLabelText(/relationship type/i), 'RELATIONSHIP_TYPE_GUARANTOR')
+
+    rerender(
+      <Wrapper>
+        <RegisterAssociationsDialog open={false} onOpenChange={onOpenChange} partyId="current-party-001" />
+      </Wrapper>,
+    )
+
+    rerender(
+      <Wrapper>
+        <RegisterAssociationsDialog open={true} onOpenChange={onOpenChange} partyId="current-party-001" />
+      </Wrapper>,
+    )
+
+    const select = screen.getByLabelText(/relationship type/i) as HTMLSelectElement
+    expect(select.value).toBe('')
+  })
+
+  it('closes dialog when cancel is clicked', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    renderDialog({ onOpenChange })
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/frontend/src/pages/parties/dialogs/register-associations-dialog.test.tsx
+++ b/frontend/src/pages/parties/dialogs/register-associations-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor, act } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { TooltipProvider } from '@/components/ui/tooltip'

--- a/frontend/src/pages/parties/dialogs/register-associations-dialog.tsx
+++ b/frontend/src/pages/parties/dialogs/register-associations-dialog.tsx
@@ -115,7 +115,7 @@ export function RegisterAssociationsDialog({
     // Include tenantSlug in the key to prevent cross-tenant cache contamination.
     queryKey: ['party-search', tenantSlug ?? '', debouncedSearch],
     queryFn: () => clients.party.listParties({ searchQuery: debouncedSearch, pageSize: 20 }),
-    enabled: debouncedSearch.length >= 2,
+    enabled: !!tenantSlug && debouncedSearch.length >= 2,
   })
 
   const searchResults: Party[] = partySearchData?.parties ?? []
@@ -147,6 +147,7 @@ export function RegisterAssociationsDialog({
         for (const [field, msg] of Object.entries(result.fieldErrors)) {
           if (field === 'related_party_id') fieldMap.relatedPartyId = msg
           else if (field === 'relationship_type') fieldMap.relationshipType = msg
+          else if (field === 'effective_to') fieldMap.effectiveTo = msg
           else fieldMap.general = msg
         }
         setErrors(fieldMap)
@@ -244,6 +245,7 @@ export function RegisterAssociationsDialog({
               </label>
               <Input
                 id="relatedParty"
+                role="combobox"
                 value={searchInput}
                 onChange={handleSearchChange}
                 onFocus={() => setShowDropdown(true)}
@@ -251,8 +253,8 @@ export function RegisterAssociationsDialog({
                 autoComplete="off"
                 aria-describedby={errors.relatedPartyId ? 'relatedParty-error' : undefined}
                 aria-required="true"
-                aria-label="Related Party"
                 aria-autocomplete="list"
+                aria-haspopup="listbox"
                 aria-controls={showResults && searchResults.length > 0 ? 'party-search-listbox' : undefined}
                 aria-expanded={showResults && searchResults.length > 0}
               />

--- a/frontend/src/pages/parties/dialogs/register-associations-dialog.tsx
+++ b/frontend/src/pages/parties/dialogs/register-associations-dialog.tsx
@@ -1,0 +1,360 @@
+import * as React from 'react'
+import { Code } from '@connectrpc/connect'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useApiClients } from '@/api/context'
+import { handleConnectError } from '@/lib/error-handling'
+import { tenantKeys } from '@/lib/query-keys'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+
+// RelationshipType enum values (from proto meridian.party.v1)
+const RELATIONSHIP_TYPE_ENUM: Record<string, number> = {
+  RELATIONSHIP_TYPE_SPOUSE: 1,
+  RELATIONSHIP_TYPE_DEPENDENT: 2,
+  RELATIONSHIP_TYPE_BUSINESS_PARTNER: 3,
+  RELATIONSHIP_TYPE_GUARANTOR: 4,
+  RELATIONSHIP_TYPE_BENEFICIAL_OWNER: 5,
+  RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT: 6,
+  RELATIONSHIP_TYPE_SYNDICATE_HOST: 7,
+}
+
+const RELATIONSHIP_TYPE_LABELS: Record<string, string> = {
+  RELATIONSHIP_TYPE_SPOUSE: 'Spouse',
+  RELATIONSHIP_TYPE_DEPENDENT: 'Dependent',
+  RELATIONSHIP_TYPE_BUSINESS_PARTNER: 'Business Partner',
+  RELATIONSHIP_TYPE_GUARANTOR: 'Guarantor',
+  RELATIONSHIP_TYPE_BENEFICIAL_OWNER: 'Beneficial Owner',
+  RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT: 'Syndicate Participant',
+  RELATIONSHIP_TYPE_SYNDICATE_HOST: 'Syndicate Host',
+}
+
+interface Party {
+  partyId: string
+  displayName: string
+  legalName?: string
+}
+
+interface FormData {
+  relatedPartyId: string
+  relatedPartyName: string
+  relationshipType: string
+  effectiveFrom: string
+  effectiveTo: string
+}
+
+interface FormErrors {
+  relatedPartyId?: string
+  relationshipType?: string
+  effectiveTo?: string
+  general?: string
+}
+
+export interface RegisterAssociationsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  partyId: string
+}
+
+const initialFormData: FormData = {
+  relatedPartyId: '',
+  relatedPartyName: '',
+  relationshipType: '',
+  effectiveFrom: '',
+  effectiveTo: '',
+}
+
+function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = React.useState(value)
+  React.useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(timer)
+  }, [value, delay])
+  return debounced
+}
+
+function parseLocalDateToTimestamp(dateStr: string): { seconds: bigint; nanos: number } | undefined {
+  if (!dateStr) return undefined
+  const date = new Date(`${dateStr}T00:00:00Z`)
+  if (isNaN(date.getTime())) return undefined
+  return { seconds: BigInt(Math.floor(date.getTime() / 1000)), nanos: 0 }
+}
+
+export function RegisterAssociationsDialog({
+  open,
+  onOpenChange,
+  partyId,
+}: RegisterAssociationsDialogProps) {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+  const queryClient = useQueryClient()
+
+  const [formData, setFormData] = React.useState<FormData>(initialFormData)
+  const [errors, setErrors] = React.useState<FormErrors>({})
+  const [searchInput, setSearchInput] = React.useState('')
+  const [showDropdown, setShowDropdown] = React.useState(false)
+
+  const debouncedSearch = useDebounce(searchInput, 300)
+
+  React.useEffect(() => {
+    if (!open) {
+      setFormData(initialFormData)
+      setErrors({})
+      setSearchInput('')
+      setShowDropdown(false)
+    }
+  }, [open])
+
+  const { data: partySearchData } = useQuery({
+    queryKey: ['party-search', debouncedSearch],
+    queryFn: () => clients.party.listParties({ searchQuery: debouncedSearch, pageSize: 20 }),
+    enabled: debouncedSearch.length >= 2,
+  })
+
+  const searchResults: Party[] = partySearchData?.parties ?? []
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const relationshipTypeValue = RELATIONSHIP_TYPE_ENUM[formData.relationshipType] ?? 0
+      return clients.party.registerAssociations({
+        partyId,
+        relatedPartyId: formData.relatedPartyId,
+        relationshipType: relationshipTypeValue,
+        effectiveFrom: parseLocalDateToTimestamp(formData.effectiveFrom),
+        effectiveTo: parseLocalDateToTimestamp(formData.effectiveTo),
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: tenantKeys.partyAssociations(tenantSlug ?? '', partyId),
+      })
+      onOpenChange(false)
+    },
+    onError: (err) => {
+      const result = handleConnectError(err)
+      if (result.code === Code.InvalidArgument && Object.keys(result.fieldErrors).length > 0) {
+        const fieldMap: FormErrors = {}
+        for (const [field, msg] of Object.entries(result.fieldErrors)) {
+          if (field === 'related_party_id') fieldMap.relatedPartyId = msg
+          else if (field === 'relationship_type') fieldMap.relationshipType = msg
+          else fieldMap.general = msg
+        }
+        setErrors(fieldMap)
+      } else {
+        setErrors({ general: result.message })
+      }
+    },
+  })
+
+  function validate(): boolean {
+    const newErrors: FormErrors = {}
+
+    if (!formData.relatedPartyId) {
+      newErrors.relatedPartyId = 'Related party is required'
+    }
+
+    if (!formData.relationshipType) {
+      newErrors.relationshipType = 'Relationship type is required'
+    }
+
+    if (formData.effectiveFrom && formData.effectiveTo) {
+      if (formData.effectiveTo < formData.effectiveFrom) {
+        newErrors.effectiveTo = 'Effective to must be after effective from'
+      }
+    }
+
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+    mutation.mutate()
+  }
+
+  function handleSearchChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value
+    setSearchInput(value)
+    setShowDropdown(true)
+    // Clear selected party if user edits the input
+    if (formData.relatedPartyId) {
+      setFormData((prev) => ({ ...prev, relatedPartyId: '', relatedPartyName: '' }))
+    }
+    if (errors.relatedPartyId) {
+      setErrors((prev) => ({ ...prev, relatedPartyId: undefined }))
+    }
+  }
+
+  function handleSelectParty(party: Party) {
+    setFormData((prev) => ({
+      ...prev,
+      relatedPartyId: party.partyId,
+      relatedPartyName: party.displayName,
+    }))
+    setSearchInput(party.displayName)
+    setShowDropdown(false)
+  }
+
+  function handleFieldChange(field: keyof Pick<FormData, 'relationshipType' | 'effectiveFrom' | 'effectiveTo'>) {
+    return (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+      setFormData((prev) => ({ ...prev, [field]: e.target.value }))
+      if (errors[field as keyof FormErrors]) {
+        setErrors((prev) => ({ ...prev, [field]: undefined }))
+      }
+    }
+  }
+
+  const showResults = showDropdown && debouncedSearch.length >= 2 && !formData.relatedPartyId
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Association</DialogTitle>
+          <DialogDescription>
+            Create a new party association for this party.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="register-associations-form">
+          <div className="space-y-4 py-2">
+            {errors.general && (
+              <div
+                role="alert"
+                className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                {errors.general}
+              </div>
+            )}
+
+            <div className="relative space-y-1">
+              <label htmlFor="relatedParty" className="text-sm font-medium">
+                Related Party <span aria-hidden="true">*</span>
+              </label>
+              <Input
+                id="relatedParty"
+                value={searchInput}
+                onChange={handleSearchChange}
+                onFocus={() => setShowDropdown(true)}
+                placeholder="Search by name..."
+                autoComplete="off"
+                aria-describedby={errors.relatedPartyId ? 'relatedParty-error' : undefined}
+                aria-required="true"
+                aria-label="Related Party"
+              />
+              {errors.relatedPartyId && (
+                <p id="relatedParty-error" className="text-sm text-destructive">
+                  {errors.relatedPartyId}
+                </p>
+              )}
+              {showResults && searchResults.length > 0 && (
+                <ul
+                  role="listbox"
+                  aria-label="Party search results"
+                  className="absolute z-50 mt-1 max-h-48 w-full overflow-auto rounded-md border border-input bg-popover shadow-md"
+                >
+                  {searchResults.map((party) => (
+                    <li
+                      key={party.partyId}
+                      role="option"
+                      aria-selected={false}
+                      className="cursor-pointer px-3 py-2 text-sm hover:bg-accent hover:text-accent-foreground"
+                      onMouseDown={(e) => {
+                        e.preventDefault()
+                        handleSelectParty(party)
+                      }}
+                    >
+                      <span className="font-medium">{party.displayName}</span>
+                      <span className="ml-2 text-xs text-muted-foreground">{party.partyId}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="relationshipType" className="text-sm font-medium">
+                Relationship Type <span aria-hidden="true">*</span>
+              </label>
+              <select
+                id="relationshipType"
+                value={formData.relationshipType}
+                onChange={handleFieldChange('relationshipType')}
+                className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+                aria-describedby={errors.relationshipType ? 'relationshipType-error' : undefined}
+                aria-required="true"
+              >
+                <option value="">Select relationship type</option>
+                {Object.entries(RELATIONSHIP_TYPE_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+              {errors.relationshipType && (
+                <p id="relationshipType-error" className="text-sm text-destructive">
+                  {errors.relationshipType}
+                </p>
+              )}
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <label htmlFor="effectiveFrom" className="text-sm font-medium">
+                  Effective From
+                </label>
+                <Input
+                  id="effectiveFrom"
+                  type="date"
+                  value={formData.effectiveFrom}
+                  onChange={handleFieldChange('effectiveFrom')}
+                  aria-describedby={undefined}
+                />
+              </div>
+
+              <div className="space-y-1">
+                <label htmlFor="effectiveTo" className="text-sm font-medium">
+                  Effective To
+                </label>
+                <Input
+                  id="effectiveTo"
+                  type="date"
+                  value={formData.effectiveTo}
+                  onChange={handleFieldChange('effectiveTo')}
+                  aria-describedby={errors.effectiveTo ? 'effectiveTo-error' : undefined}
+                />
+                {errors.effectiveTo && (
+                  <p id="effectiveTo-error" className="text-sm text-destructive">
+                    {errors.effectiveTo}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="register-associations-form"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Adding...' : 'Add Association'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/parties/dialogs/register-associations-dialog.tsx
+++ b/frontend/src/pages/parties/dialogs/register-associations-dialog.tsx
@@ -16,26 +16,21 @@ import { handleConnectError } from '@/lib/error-handling'
 import { tenantKeys } from '@/lib/query-keys'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
 
-// RelationshipType enum values (from proto meridian.party.v1)
-const RELATIONSHIP_TYPE_ENUM: Record<string, number> = {
-  RELATIONSHIP_TYPE_SPOUSE: 1,
-  RELATIONSHIP_TYPE_DEPENDENT: 2,
-  RELATIONSHIP_TYPE_BUSINESS_PARTNER: 3,
-  RELATIONSHIP_TYPE_GUARANTOR: 4,
-  RELATIONSHIP_TYPE_BENEFICIAL_OWNER: 5,
-  RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT: 6,
-  RELATIONSHIP_TYPE_SYNDICATE_HOST: 7,
-}
+// RelationshipType enum values mirrored from proto meridian.party.v1.RelationshipType.
+// Keep in sync with the proto definition; order matches numeric values 1–7.
+const RELATIONSHIP_TYPES = [
+  { value: 'RELATIONSHIP_TYPE_SPOUSE', numericValue: 1, label: 'Spouse' },
+  { value: 'RELATIONSHIP_TYPE_DEPENDENT', numericValue: 2, label: 'Dependent' },
+  { value: 'RELATIONSHIP_TYPE_BUSINESS_PARTNER', numericValue: 3, label: 'Business Partner' },
+  { value: 'RELATIONSHIP_TYPE_GUARANTOR', numericValue: 4, label: 'Guarantor' },
+  { value: 'RELATIONSHIP_TYPE_BENEFICIAL_OWNER', numericValue: 5, label: 'Beneficial Owner' },
+  { value: 'RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT', numericValue: 6, label: 'Syndicate Participant' },
+  { value: 'RELATIONSHIP_TYPE_SYNDICATE_HOST', numericValue: 7, label: 'Syndicate Host' },
+] as const
 
-const RELATIONSHIP_TYPE_LABELS: Record<string, string> = {
-  RELATIONSHIP_TYPE_SPOUSE: 'Spouse',
-  RELATIONSHIP_TYPE_DEPENDENT: 'Dependent',
-  RELATIONSHIP_TYPE_BUSINESS_PARTNER: 'Business Partner',
-  RELATIONSHIP_TYPE_GUARANTOR: 'Guarantor',
-  RELATIONSHIP_TYPE_BENEFICIAL_OWNER: 'Beneficial Owner',
-  RELATIONSHIP_TYPE_SYNDICATE_PARTICIPANT: 'Syndicate Participant',
-  RELATIONSHIP_TYPE_SYNDICATE_HOST: 'Syndicate Host',
-}
+const RELATIONSHIP_TYPE_ENUM: Record<string, number> = Object.fromEntries(
+  RELATIONSHIP_TYPES.map(({ value, numericValue }) => [value, numericValue]),
+)
 
 interface Party {
   partyId: string
@@ -81,6 +76,9 @@ function useDebounce<T>(value: T, delay: number): T {
   return debounced
 }
 
+// Converts a YYYY-MM-DD string to a proto Timestamp.
+// The date is interpreted as UTC midnight so the stored timestamp is
+// timezone-neutral and consistent regardless of the browser's locale.
 function parseLocalDateToTimestamp(dateStr: string): { seconds: bigint; nanos: number } | undefined {
   if (!dateStr) return undefined
   const date = new Date(`${dateStr}T00:00:00Z`)
@@ -114,7 +112,8 @@ export function RegisterAssociationsDialog({
   }, [open])
 
   const { data: partySearchData } = useQuery({
-    queryKey: ['party-search', debouncedSearch],
+    // Include tenantSlug in the key to prevent cross-tenant cache contamination.
+    queryKey: ['party-search', tenantSlug ?? '', debouncedSearch],
     queryFn: () => clients.party.listParties({ searchQuery: debouncedSearch, pageSize: 20 }),
     enabled: debouncedSearch.length >= 2,
   })
@@ -133,9 +132,12 @@ export function RegisterAssociationsDialog({
       })
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: tenantKeys.partyAssociations(tenantSlug ?? '', partyId),
-      })
+      // Only invalidate if we have a valid tenant slug.
+      if (tenantSlug) {
+        queryClient.invalidateQueries({
+          queryKey: tenantKeys.partyAssociations(tenantSlug, partyId),
+        })
+      }
       onOpenChange(false)
     },
     onError: (err) => {
@@ -185,7 +187,7 @@ export function RegisterAssociationsDialog({
     const value = e.target.value
     setSearchInput(value)
     setShowDropdown(true)
-    // Clear selected party if user edits the input
+    // Clear selected party if user edits the input after making a selection.
     if (formData.relatedPartyId) {
       setFormData((prev) => ({ ...prev, relatedPartyId: '', relatedPartyName: '' }))
     }
@@ -250,6 +252,9 @@ export function RegisterAssociationsDialog({
                 aria-describedby={errors.relatedPartyId ? 'relatedParty-error' : undefined}
                 aria-required="true"
                 aria-label="Related Party"
+                aria-autocomplete="list"
+                aria-controls={showResults && searchResults.length > 0 ? 'party-search-listbox' : undefined}
+                aria-expanded={showResults && searchResults.length > 0}
               />
               {errors.relatedPartyId && (
                 <p id="relatedParty-error" className="text-sm text-destructive">
@@ -258,6 +263,7 @@ export function RegisterAssociationsDialog({
               )}
               {showResults && searchResults.length > 0 && (
                 <ul
+                  id="party-search-listbox"
                   role="listbox"
                   aria-label="Party search results"
                   className="absolute z-50 mt-1 max-h-48 w-full overflow-auto rounded-md border border-input bg-popover shadow-md"
@@ -266,7 +272,7 @@ export function RegisterAssociationsDialog({
                     <li
                       key={party.partyId}
                       role="option"
-                      aria-selected={false}
+                      aria-selected={party.partyId === formData.relatedPartyId}
                       className="cursor-pointer px-3 py-2 text-sm hover:bg-accent hover:text-accent-foreground"
                       onMouseDown={(e) => {
                         e.preventDefault()
@@ -294,7 +300,7 @@ export function RegisterAssociationsDialog({
                 aria-required="true"
               >
                 <option value="">Select relationship type</option>
-                {Object.entries(RELATIONSHIP_TYPE_LABELS).map(([value, label]) => (
+                {RELATIONSHIP_TYPES.map(({ value, label }) => (
                   <option key={value} value={value}>
                     {label}
                   </option>
@@ -317,7 +323,6 @@ export function RegisterAssociationsDialog({
                   type="date"
                   value={formData.effectiveFrom}
                   onChange={handleFieldChange('effectiveFrom')}
-                  aria-describedby={undefined}
                 />
               </div>
 

--- a/frontend/src/pages/parties/tabs/associations-tab.test.tsx
+++ b/frontend/src/pages/parties/tabs/associations-tab.test.tsx
@@ -1,12 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TooltipProvider } from '@/components/ui/tooltip'
 
 vi.mock('@/api/context', () => ({
   useClients: vi.fn(),
+  useApiClients: vi.fn(),
 }))
 
-import { useClients } from '@/api/context'
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: () => 'test-tenant',
+  useCurrentTenant: () => null,
+  useIsPlatformAdmin: () => false,
+  useSwitchTenant: () => vi.fn(),
+  useClearTenant: () => vi.fn(),
+}))
+
+import { useClients, useApiClients } from '@/api/context'
 import { AssociationsTab } from './associations-tab'
 
 function makeQueryClient() {
@@ -17,10 +27,18 @@ function makeQueryClient() {
   })
 }
 
+const mockPartyClient = {
+  getAssociations: vi.fn(),
+  listParties: vi.fn().mockResolvedValue({ parties: [] }),
+  registerAssociations: vi.fn(),
+}
+
 function renderTab(partyId = 'party-001') {
   return render(
     <QueryClientProvider client={makeQueryClient()}>
-      <AssociationsTab partyId={partyId} />
+      <TooltipProvider>
+        <AssociationsTab partyId={partyId} />
+      </TooltipProvider>
     </QueryClientProvider>,
   )
 }
@@ -28,6 +46,9 @@ function renderTab(partyId = 'party-001') {
 describe('AssociationsTab', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(useApiClients).mockReturnValue({
+      party: mockPartyClient,
+    } as ReturnType<typeof useApiClients>)
   })
 
   describe('loading state', () => {
@@ -83,6 +104,20 @@ describe('AssociationsTab', () => {
 
       await waitFor(() => {
         expect(screen.getByText(/no associations information available/i)).toBeInTheDocument()
+      })
+    })
+
+    it('renders add association button', async () => {
+      vi.mocked(useClients).mockReturnValue({
+        party: {
+          getAssociations: vi.fn().mockResolvedValue({}),
+        },
+      } as ReturnType<typeof useClients>)
+
+      renderTab()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /add association/i })).toBeInTheDocument()
       })
     })
   })

--- a/frontend/src/pages/parties/tabs/associations-tab.tsx
+++ b/frontend/src/pages/parties/tabs/associations-tab.tsx
@@ -4,6 +4,8 @@ import { useClients } from '@/api/context'
 import { Skeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Button } from '@/components/ui/button'
+import { tenantKeys } from '@/lib/query-keys'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { RegisterAssociationsDialog } from '../dialogs/register-associations-dialog'
 
 interface AssociationsTabProps {
@@ -12,10 +14,11 @@ interface AssociationsTabProps {
 
 export function AssociationsTab({ partyId }: AssociationsTabProps) {
   const clients = useClients()
+  const tenantSlug = useTenantSlug()
   const [dialogOpen, setDialogOpen] = React.useState(false)
 
   const { isLoading } = useQuery({
-    queryKey: ['party', partyId, 'associations'],
+    queryKey: tenantKeys.partyAssociations(tenantSlug ?? '', partyId),
     queryFn: async () => {
       return await clients.party.getAssociations({ partyId })
     },

--- a/frontend/src/pages/parties/tabs/associations-tab.tsx
+++ b/frontend/src/pages/parties/tabs/associations-tab.tsx
@@ -3,6 +3,8 @@ import { useQuery } from '@tanstack/react-query'
 import { useClients } from '@/api/context'
 import { Skeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
+import { Button } from '@/components/ui/button'
+import { RegisterAssociationsDialog } from '../dialogs/register-associations-dialog'
 
 interface AssociationsTabProps {
   partyId: string
@@ -10,6 +12,7 @@ interface AssociationsTabProps {
 
 export function AssociationsTab({ partyId }: AssociationsTabProps) {
   const clients = useClients()
+  const [dialogOpen, setDialogOpen] = React.useState(false)
 
   const { isLoading } = useQuery({
     queryKey: ['party', partyId, 'associations'],
@@ -27,5 +30,17 @@ export function AssociationsTab({ partyId }: AssociationsTabProps) {
     )
   }
 
-  return <EmptyState title="Associations" description="No associations information available." />
+  return (
+    <>
+      <div className="flex justify-end mb-4">
+        <Button onClick={() => setDialogOpen(true)}>Add Association</Button>
+      </div>
+      <EmptyState title="Associations" description="No associations information available." />
+      <RegisterAssociationsDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        partyId={partyId}
+      />
+    </>
+  )
 }


### PR DESCRIPTION
## Summary

- Adds `RegisterAssociationsDialog` component to the Party Detail Associations tab
- Implements inline party search with debounced input (300ms, min 2 chars) and dropdown results
- Relationship type select with all proto-defined `RelationshipType` values
- Optional `effectiveFrom` / `effectiveTo` date pickers with validation (effectiveTo must not precede effectiveFrom)
- On success: invalidates `partyAssociations` query key and closes dialog
- Adds "Add Association" button to `AssociationsTab` to open the dialog
- 25 unit tests covering search debounce, party selection, validation, submission, and error handling

## Test plan

- [x] All 1403 frontend unit tests pass
- [x] Party search debouncing: no API call under 2 chars, debounced 300ms
- [x] Party selection sets `relatedPartyId` in form state
- [x] Clearing input after selection deselects party (submit shows validation error)
- [x] Date validation: effectiveTo before effectiveFrom shows error
- [x] Successful submission calls `registerAssociations` with correct proto fields
- [x] `effectiveFrom` is sent as a protobuf Timestamp when provided
- [x] On success invalidates `partyAssociations` query and closes dialog
- [x] Error banner shown for server errors
- [x] Form resets on dialog close/reopen