### PR TITLE
feat: add dispute dialog for reconciliation variance items

### DIFF
--- a/frontend/src/pages/reconciliation/create-dispute-dialog.test.tsx
+++ b/frontend/src/pages/reconciliation/create-dispute-dialog.test.tsx
@@ -135,6 +135,19 @@ describe('CreateDisputeDialog', () => {
       await user.selectOptions(screen.getByRole('combobox', { name: /reason/i }), 'DISPUTE_REASON_OTHER')
       expect(screen.queryByLabelText('Expected Amount')).not.toBeInTheDocument()
     })
+
+    it('shows error when expected amount is empty for AMOUNT_MISMATCH reason', async () => {
+      const user = userEvent.setup()
+      renderDialog({ open: true })
+
+      await user.selectOptions(screen.getByRole('combobox', { name: /reason/i }), 'DISPUTE_REASON_AMOUNT_MISMATCH')
+      await user.type(screen.getByLabelText('Description'), 'Amount is wrong')
+      await user.click(screen.getByRole('button', { name: /raise dispute/i }))
+
+      expect(
+        await screen.findByText('Expected amount is required for amount mismatch disputes'),
+      ).toBeInTheDocument()
+    })
   })
 
   describe('description validation', () => {
@@ -212,7 +225,7 @@ describe('CreateDisputeDialog', () => {
       })
     })
 
-    it('invalidates reconciliation-disputes query on success', async () => {
+    it('completes dispute submission without error', async () => {
       const user = userEvent.setup()
 
       server.use(
@@ -221,21 +234,22 @@ describe('CreateDisputeDialog', () => {
         }),
       )
 
-      renderDialog({ open: true })
+      const onOpenChange = vi.fn()
+      renderDialog({ open: true, onOpenChange })
 
       await user.selectOptions(screen.getByRole('combobox', { name: /reason/i }), 'DISPUTE_REASON_OTHER')
       await user.type(screen.getByLabelText('Description'), 'Test')
       await user.click(screen.getByRole('button', { name: /raise dispute/i }))
 
-      // Just verify the mutation completes without error (query invalidation is a side effect)
       await waitFor(() => {
-        expect(screen.queryByText('Submitting...')).not.toBeInTheDocument()
+        expect(onOpenChange).toHaveBeenCalledWith(false)
       })
     })
   })
 
   describe('form reset on close', () => {
-    it('resets form fields when dialog is closed and reopened', () => {
+    it('resets form fields when dialog is closed and reopened', async () => {
+      const user = userEvent.setup()
       const { rerender } = renderWithProviders(
         <MemoryRouter>
           <Routes>
@@ -254,6 +268,14 @@ describe('CreateDisputeDialog', () => {
         </MemoryRouter>,
       )
 
+      // Populate fields before closing
+      await user.selectOptions(screen.getByRole('combobox', { name: /reason/i }), 'DISPUTE_REASON_OTHER')
+      await user.type(screen.getByLabelText('Description'), 'Some content')
+
+      expect((screen.getByRole('combobox', { name: /reason/i }) as HTMLSelectElement).value).toBe('DISPUTE_REASON_OTHER')
+      expect((screen.getByLabelText('Description') as HTMLTextAreaElement).value).toBe('Some content')
+
+      // Close dialog
       rerender(
         <MemoryRouter>
           <Routes>
@@ -272,6 +294,7 @@ describe('CreateDisputeDialog', () => {
         </MemoryRouter>,
       )
 
+      // Reopen dialog
       rerender(
         <MemoryRouter>
           <Routes>
@@ -290,6 +313,7 @@ describe('CreateDisputeDialog', () => {
         </MemoryRouter>,
       )
 
+      // Fields should be reset to empty
       expect((screen.getByRole('combobox', { name: /reason/i }) as HTMLSelectElement).value).toBe('')
       expect((screen.getByLabelText('Description') as HTMLTextAreaElement).value).toBe('')
     })

--- a/frontend/src/pages/reconciliation/create-dispute-dialog.test.tsx
+++ b/frontend/src/pages/reconciliation/create-dispute-dialog.test.tsx
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { server } from '@/test/msw-handlers'
+import { CreateDisputeDialog } from './create-dispute-dialog'
+
+const defaultLineItem = {
+  varianceId: 'var-001',
+  amount: '100.00',
+  expectedAmount: '150.00',
+  timestamp: '2026-01-01T00:00:00Z',
+}
+
+function renderDialog(props: {
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  runId?: string
+  lineItem?: typeof defaultLineItem
+}) {
+  const onOpenChange = props.onOpenChange ?? vi.fn()
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/reconciliation/run-123']}>
+      <Routes>
+        <Route
+          path="/reconciliation/:runId"
+          element={
+            <CreateDisputeDialog
+              open={props.open ?? true}
+              onOpenChange={onOpenChange}
+              runId={props.runId ?? 'run-123'}
+              lineItem={props.lineItem ?? defaultLineItem}
+            />
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('CreateDisputeDialog', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('rendering', () => {
+    it('renders dialog when open', () => {
+      renderDialog({ open: true })
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: 'Raise Dispute' })).toBeInTheDocument()
+    })
+
+    it('does not render dialog when closed', () => {
+      renderDialog({ open: false })
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    it('renders reason select with options', () => {
+      renderDialog({ open: true })
+      const select = screen.getByRole('combobox', { name: /reason/i })
+      expect(select).toBeInTheDocument()
+      expect(screen.getByText('Amount Mismatch')).toBeInTheDocument()
+      expect(screen.getByText('Missing Entry')).toBeInTheDocument()
+      expect(screen.getByText('Duplicate')).toBeInTheDocument()
+      expect(screen.getByText('Timing')).toBeInTheDocument()
+      expect(screen.getByText('Other')).toBeInTheDocument()
+    })
+
+    it('renders description textarea', () => {
+      renderDialog({ open: true })
+      expect(screen.getByLabelText('Description')).toBeInTheDocument()
+    })
+
+    it('renders Raise Dispute and Cancel buttons', () => {
+      renderDialog({ open: true })
+      expect(screen.getByRole('button', { name: /raise dispute/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+    })
+  })
+
+  describe('pre-filled line item context', () => {
+    it('displays varianceId in the disputed item section', () => {
+      renderDialog({ open: true })
+      expect(screen.getByText('var-001')).toBeInTheDocument()
+    })
+
+    it('displays amount in the disputed item section', () => {
+      renderDialog({ open: true })
+      expect(screen.getByText('100.00')).toBeInTheDocument()
+    })
+
+    it('displays expectedAmount when provided', () => {
+      renderDialog({ open: true })
+      expect(screen.getByText('150.00')).toBeInTheDocument()
+    })
+
+    it('displays timestamp when provided', () => {
+      renderDialog({ open: true })
+      expect(screen.getByText('2026-01-01T00:00:00Z')).toBeInTheDocument()
+    })
+
+    it('does not display expectedAmount section when not provided', () => {
+      renderDialog({
+        open: true,
+        lineItem: { varianceId: 'var-002', amount: '50.00' },
+      })
+      expect(screen.queryByText('Expected:')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('conditional expected amount field', () => {
+    it('does not show expected amount input by default', () => {
+      renderDialog({ open: true })
+      expect(screen.queryByLabelText('Expected Amount')).not.toBeInTheDocument()
+    })
+
+    it('shows expected amount input when reason is AMOUNT_MISMATCH', async () => {
+      const user = userEvent.setup()
+      renderDialog({ open: true })
+
+      await user.selectOptions(screen.getByRole('combobox', { name: /reason/i }), 'DISPUTE_REASON_AMOUNT_MISMATCH')
+
+      expect(screen.getByLabelText('Expected Amount')).toBeInTheDocument()
+    })
+
+    it('hides expected amount input when reason changes away from AMOUNT_MISMATCH', async () => {
+      const user = userEvent.setup()
+      renderDialog({ open: true })
+
+      await user.selectOptions(screen.getByRole('combobox', { name: /reason/i }), 'DISPUTE_REASON_AMOUNT_MISMATCH')
+      expect(screen.getByLabelText('Expected Amount')).toBeInTheDocument()
+
+      await user.selectOptions(screen.getByRole('combobox', { name: /reason/i }), 'DISPUTE_REASON_OTHER')
+      expect(screen.queryByLabelText('Expected Amount')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('description validation', () => {
+    it('shows error when description is empty', async () => {
+      const user = userEvent.setup()
+      renderDialog({ open: true })
+
+      await user.selectOptions(screen.getByRole('combobox', { name: /reason/i }), 'DISPUTE_REASON_OTHER')
+      await user.click(screen.getByRole('button', { name: /raise dispute/i }))
+
+      expect(await screen.findByText('Description is required')).toBeInTheDocument()
+    })
+
+    it('shows error when reason is not selected', async () => {
+      const user = userEvent.setup()
+      renderDialog({ open: true })
+
+      await user.type(screen.getByLabelText('Description'), 'Some description')
+      await user.click(screen.getByRole('button', { name: /raise dispute/i }))
+
+      expect(await screen.findByText('Reason is required')).toBeInTheDocument()
+    })
+  })
+
+  describe('successful submission', () => {
+    it('calls API and closes dialog on success', async () => {
+      const user = userEvent.setup()
+      const onOpenChange = vi.fn()
+
+      server.use(
+        http.post('*/reconciliation/runs/run-123/disputes', () => {
+          return HttpResponse.json({ disputeId: 'dispute-001' })
+        }),
+      )
+
+      renderDialog({ open: true, onOpenChange })
+
+      await user.selectOptions(screen.getByRole('combobox', { name: /reason/i }), 'DISPUTE_REASON_OTHER')
+      await user.type(screen.getByLabelText('Description'), 'Test dispute description')
+      await user.click(screen.getByRole('button', { name: /raise dispute/i }))
+
+      await waitFor(() => {
+        expect(onOpenChange).toHaveBeenCalledWith(false)
+      })
+    })
+
+    it('submits with expectedAmount when reason is AMOUNT_MISMATCH', async () => {
+      const user = userEvent.setup()
+      const onOpenChange = vi.fn()
+      let capturedBody: unknown
+
+      server.use(
+        http.post('*/reconciliation/runs/run-123/disputes', async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json({ disputeId: 'dispute-002' })
+        }),
+      )
+
+      renderDialog({ open: true, onOpenChange })
+
+      await user.selectOptions(screen.getByRole('combobox', { name: /reason/i }), 'DISPUTE_REASON_AMOUNT_MISMATCH')
+      await user.type(screen.getByLabelText('Expected Amount'), '200.00')
+      await user.type(screen.getByLabelText('Description'), 'Amount does not match')
+      await user.click(screen.getByRole('button', { name: /raise dispute/i }))
+
+      await waitFor(() => {
+        expect(onOpenChange).toHaveBeenCalledWith(false)
+      })
+
+      expect(capturedBody).toMatchObject({
+        reason: 'DISPUTE_REASON_AMOUNT_MISMATCH',
+        expectedAmount: '200',
+        description: 'Amount does not match',
+        varianceId: 'var-001',
+      })
+    })
+
+    it('invalidates reconciliation-disputes query on success', async () => {
+      const user = userEvent.setup()
+
+      server.use(
+        http.post('*/reconciliation/runs/run-123/disputes', () => {
+          return HttpResponse.json({ disputeId: 'dispute-003' })
+        }),
+      )
+
+      renderDialog({ open: true })
+
+      await user.selectOptions(screen.getByRole('combobox', { name: /reason/i }), 'DISPUTE_REASON_OTHER')
+      await user.type(screen.getByLabelText('Description'), 'Test')
+      await user.click(screen.getByRole('button', { name: /raise dispute/i }))
+
+      // Just verify the mutation completes without error (query invalidation is a side effect)
+      await waitFor(() => {
+        expect(screen.queryByText('Submitting...')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('form reset on close', () => {
+    it('resets form fields when dialog is closed and reopened', () => {
+      const { rerender } = renderWithProviders(
+        <MemoryRouter>
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <CreateDisputeDialog
+                  open={true}
+                  onOpenChange={vi.fn()}
+                  runId="run-123"
+                  lineItem={defaultLineItem}
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>,
+      )
+
+      rerender(
+        <MemoryRouter>
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <CreateDisputeDialog
+                  open={false}
+                  onOpenChange={vi.fn()}
+                  runId="run-123"
+                  lineItem={defaultLineItem}
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>,
+      )
+
+      rerender(
+        <MemoryRouter>
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <CreateDisputeDialog
+                  open={true}
+                  onOpenChange={vi.fn()}
+                  runId="run-123"
+                  lineItem={defaultLineItem}
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>,
+      )
+
+      expect((screen.getByRole('combobox', { name: /reason/i }) as HTMLSelectElement).value).toBe('')
+      expect((screen.getByLabelText('Description') as HTMLTextAreaElement).value).toBe('')
+    })
+  })
+
+  describe('API error handling', () => {
+    it('shows error alert when API returns an error', async () => {
+      const user = userEvent.setup()
+
+      server.use(
+        http.post('*/reconciliation/runs/run-123/disputes', () => {
+          return HttpResponse.json({ message: 'Internal server error' }, { status: 500 })
+        }),
+      )
+
+      renderDialog({ open: true })
+
+      await user.selectOptions(screen.getByRole('combobox', { name: /reason/i }), 'DISPUTE_REASON_OTHER')
+      await user.type(screen.getByLabelText('Description'), 'Test description')
+      await user.click(screen.getByRole('button', { name: /raise dispute/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument()
+      })
+
+      expect(screen.getByRole('alert')).toHaveTextContent('Internal server error')
+    })
+  })
+
+  describe('cancel button', () => {
+    it('calls onOpenChange(false) when cancel is clicked', async () => {
+      const user = userEvent.setup()
+      const onOpenChange = vi.fn()
+      renderDialog({ open: true, onOpenChange })
+
+      await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+})

--- a/frontend/src/pages/reconciliation/create-dispute-dialog.tsx
+++ b/frontend/src/pages/reconciliation/create-dispute-dialog.tsx
@@ -11,7 +11,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 
-export const DISPUTE_REASON_OPTIONS = [
+const DISPUTE_REASON_OPTIONS = [
   { label: 'Amount Mismatch', value: 'DISPUTE_REASON_AMOUNT_MISMATCH' },
   { label: 'Missing Entry', value: 'DISPUTE_REASON_MISSING_ENTRY' },
   { label: 'Duplicate', value: 'DISPUTE_REASON_DUPLICATE' },

--- a/frontend/src/pages/reconciliation/create-dispute-dialog.tsx
+++ b/frontend/src/pages/reconciliation/create-dispute-dialog.tsx
@@ -1,0 +1,293 @@
+import * as React from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+export const DISPUTE_REASON_OPTIONS = [
+  { label: 'Amount Mismatch', value: 'DISPUTE_REASON_AMOUNT_MISMATCH' },
+  { label: 'Missing Entry', value: 'DISPUTE_REASON_MISSING_ENTRY' },
+  { label: 'Duplicate', value: 'DISPUTE_REASON_DUPLICATE' },
+  { label: 'Timing', value: 'DISPUTE_REASON_TIMING' },
+  { label: 'Other', value: 'DISPUTE_REASON_OTHER' },
+]
+
+type DisputeReason = (typeof DISPUTE_REASON_OPTIONS)[number]['value']
+
+export interface CreateDisputeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  runId: string
+  lineItem: {
+    varianceId: string
+    amount: string
+    expectedAmount?: string
+    timestamp?: string
+  }
+}
+
+interface FormData {
+  reason: DisputeReason | ''
+  description: string
+  expectedAmount: string
+}
+
+interface FormErrors {
+  reason?: string
+  description?: string
+  expectedAmount?: string
+  general?: string
+}
+
+function validateForm(data: FormData): FormErrors {
+  const errors: FormErrors = {}
+
+  if (!data.reason) {
+    errors.reason = 'Reason is required'
+  }
+
+  if (!data.description.trim()) {
+    errors.description = 'Description is required'
+  } else if (data.description.length > 1000) {
+    errors.description = 'Description must be 1000 characters or fewer'
+  }
+
+  if (data.reason === 'DISPUTE_REASON_AMOUNT_MISMATCH' && !data.expectedAmount.trim()) {
+    errors.expectedAmount = 'Expected amount is required for amount mismatch disputes'
+  }
+
+  return errors
+}
+
+async function createDispute(
+  runId: string,
+  varianceId: string,
+  data: FormData,
+): Promise<{ disputeId: string }> {
+  const body: Record<string, unknown> = {
+    varianceId,
+    reason: data.reason,
+    description: data.description,
+  }
+
+  if (data.reason === 'DISPUTE_REASON_AMOUNT_MISMATCH' && data.expectedAmount) {
+    body.expectedAmount = data.expectedAmount
+  }
+
+  const response = await fetch(`/api/v1/reconciliation/runs/${runId}/disputes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    const err = (await response.json().catch(() => ({}))) as { message?: string }
+    throw new Error(err.message ?? `Failed to create dispute: ${response.status}`)
+  }
+
+  return response.json() as Promise<{ disputeId: string }>
+}
+
+export function CreateDisputeDialog({
+  open,
+  onOpenChange,
+  runId,
+  lineItem,
+}: CreateDisputeDialogProps) {
+  const queryClient = useQueryClient()
+
+  const [formData, setFormData] = React.useState<FormData>({
+    reason: '',
+    description: '',
+    expectedAmount: '',
+  })
+  const [errors, setErrors] = React.useState<FormErrors>({})
+
+  React.useEffect(() => {
+    if (!open) {
+      setFormData({ reason: '', description: '', expectedAmount: '' })
+      setErrors({})
+    }
+  }, [open])
+
+  const mutation = useMutation({
+    mutationFn: () => createDispute(runId, lineItem.varianceId, formData),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['reconciliation-disputes', runId] })
+      onOpenChange(false)
+    },
+    onError: (err: Error) => {
+      setErrors({ general: err.message })
+    },
+  })
+
+  function handleChange<K extends keyof FormData>(field: K, value: FormData[K]) {
+    setFormData((prev) => ({ ...prev, [field]: value }))
+    if (errors[field as keyof FormErrors]) {
+      setErrors((prev) => ({ ...prev, [field]: undefined }))
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const next = validateForm(formData)
+    if (Object.keys(next).length > 0) {
+      setErrors(next)
+      return
+    }
+    setErrors({})
+    mutation.mutate()
+  }
+
+  const showExpectedAmount = formData.reason === 'DISPUTE_REASON_AMOUNT_MISMATCH'
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Raise Dispute</DialogTitle>
+          <DialogDescription>
+            Raise a dispute on this variance item. Provide the reason and a description.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="create-dispute-form">
+          <div className="space-y-4 py-2">
+            {errors.general && (
+              <div
+                role="alert"
+                className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                {errors.general}
+              </div>
+            )}
+
+            {/* Read-only line item context */}
+            <div className="space-y-1">
+              <span className="text-sm font-medium">Disputed Item</span>
+              <div
+                aria-label="Disputed item details"
+                className="rounded-md border bg-muted/50 px-3 py-2 text-sm space-y-1"
+              >
+                <div>
+                  <span className="text-muted-foreground">Variance ID: </span>
+                  <span className="font-mono">{lineItem.varianceId}</span>
+                </div>
+                <div>
+                  <span className="text-muted-foreground">Amount: </span>
+                  <span>{lineItem.amount}</span>
+                </div>
+                {lineItem.expectedAmount && (
+                  <div>
+                    <span className="text-muted-foreground">Expected: </span>
+                    <span>{lineItem.expectedAmount}</span>
+                  </div>
+                )}
+                {lineItem.timestamp && (
+                  <div>
+                    <span className="text-muted-foreground">Timestamp: </span>
+                    <span>{lineItem.timestamp}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Reason */}
+            <div className="space-y-1">
+              <label htmlFor="dispute-reason" className="text-sm font-medium">
+                Reason
+              </label>
+              <select
+                id="dispute-reason"
+                value={formData.reason}
+                onChange={(e) => handleChange('reason', e.target.value as DisputeReason)}
+                className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+                aria-label="Reason"
+                aria-describedby={errors.reason ? 'dispute-reason-error' : undefined}
+              >
+                <option value="">Select a reason</option>
+                {DISPUTE_REASON_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+              {errors.reason && (
+                <p id="dispute-reason-error" className="text-sm text-destructive">
+                  {errors.reason}
+                </p>
+              )}
+            </div>
+
+            {/* Description */}
+            <div className="space-y-1">
+              <label htmlFor="dispute-description" className="text-sm font-medium">
+                Description
+              </label>
+              <textarea
+                id="dispute-description"
+                value={formData.description}
+                onChange={(e) => handleChange('description', e.target.value)}
+                placeholder="Describe the issue in detail..."
+                maxLength={1000}
+                rows={4}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs resize-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                aria-describedby={errors.description ? 'dispute-description-error' : undefined}
+              />
+              {errors.description && (
+                <p id="dispute-description-error" className="text-sm text-destructive">
+                  {errors.description}
+                </p>
+              )}
+            </div>
+
+            {/* Conditional expected amount */}
+            {showExpectedAmount && (
+              <div className="space-y-1">
+                <label htmlFor="dispute-expected-amount" className="text-sm font-medium">
+                  Expected Amount
+                </label>
+                <Input
+                  id="dispute-expected-amount"
+                  type="number"
+                  step="any"
+                  value={formData.expectedAmount}
+                  onChange={(e) => handleChange('expectedAmount', e.target.value)}
+                  placeholder="Enter expected amount"
+                  aria-describedby={
+                    errors.expectedAmount ? 'dispute-expected-amount-error' : undefined
+                  }
+                />
+                {errors.expectedAmount && (
+                  <p id="dispute-expected-amount-error" className="text-sm text-destructive">
+                    {errors.expectedAmount}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="create-dispute-form"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Submitting...' : 'Raise Dispute'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/reconciliation/create-dispute-dialog.tsx
+++ b/frontend/src/pages/reconciliation/create-dispute-dialog.tsx
@@ -118,10 +118,13 @@ export function CreateDisputeDialog({
   }, [open])
 
   const mutation = useMutation({
-    mutationFn: () => createDispute(runId, lineItem.varianceId, formData),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['reconciliation-disputes', runId] })
-      onOpenChange(false)
+    mutationFn: (vars: { runId: string; varianceId: string; data: FormData }) =>
+      createDispute(vars.runId, vars.varianceId, vars.data),
+    onSuccess: (_result, vars) => {
+      void queryClient.invalidateQueries({ queryKey: ['reconciliation-disputes', vars.runId] })
+      if (lineItem.varianceId === vars.varianceId) {
+        onOpenChange(false)
+      }
     },
     onError: (err: Error) => {
       setErrors({ general: err.message })
@@ -143,7 +146,7 @@ export function CreateDisputeDialog({
       return
     }
     setErrors({})
-    mutation.mutate()
+    mutation.mutate({ runId, varianceId: lineItem.varianceId, data: { ...formData } })
   }
 
   const showExpectedAmount = formData.reason === 'DISPUTE_REASON_AMOUNT_MISMATCH'

--- a/frontend/src/pages/reconciliation/create-dispute-dialog.tsx
+++ b/frontend/src/pages/reconciliation/create-dispute-dialog.tsx
@@ -133,9 +133,10 @@ export function CreateDisputeDialog({
 
   function handleChange<K extends keyof FormData>(field: K, value: FormData[K]) {
     setFormData((prev) => ({ ...prev, [field]: value }))
-    if (errors[field as keyof FormErrors]) {
-      setErrors((prev) => ({ ...prev, [field]: undefined }))
-    }
+    setErrors((prev) => {
+      if (!prev[field as keyof FormErrors] && !prev.general) return prev
+      return { ...prev, [field]: undefined, general: undefined }
+    })
   }
 
   function handleSubmit(e: React.FormEvent) {

--- a/frontend/src/pages/reconciliation/detail.tsx
+++ b/frontend/src/pages/reconciliation/detail.tsx
@@ -12,6 +12,7 @@ import {
   type Variance,
 } from '@/components/reconciliation/variance-detail'
 import { cn } from '@/lib/utils'
+import { CreateDisputeDialog } from './create-dispute-dialog'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -119,6 +120,9 @@ function VariancesTab({ runId }: { runId: string }) {
     queryFn: () => fetchVariances(runId),
   })
 
+  const [disputeDialogOpen, setDisputeDialogOpen] = React.useState(false)
+  const [selectedVariance, setSelectedVariance] = React.useState<Variance | null>(null)
+
   if (isLoading) {
     return (
       <div className="space-y-3">
@@ -153,11 +157,41 @@ function VariancesTab({ runId }: { runId: string }) {
   }
 
   return (
-    <div className="space-y-3">
-      {variances.map((v) => (
-        <VarianceDetail key={v.varianceId} variance={v} />
-      ))}
-    </div>
+    <>
+      <div className="space-y-3">
+        {variances.map((v) => (
+          <div key={v.varianceId}>
+            <VarianceDetail variance={v} />
+            <div className="mt-2 flex justify-end">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setSelectedVariance(v)
+                  setDisputeDialogOpen(true)
+                }}
+              >
+                Raise Dispute
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {selectedVariance && (
+        <CreateDisputeDialog
+          open={disputeDialogOpen}
+          onOpenChange={setDisputeDialogOpen}
+          runId={runId}
+          lineItem={{
+            varianceId: selectedVariance.varianceId,
+            amount: selectedVariance.varianceAmount,
+            expectedAmount: selectedVariance.expectedAmount,
+            timestamp: selectedVariance.createdAt,
+          }}
+        />
+      )}
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary

- Adds `CreateDisputeDialog` component for raising disputes on reconciliation variance line items
- Dialog pre-fills variance context (ID, amount, expected amount, timestamp) as read-only display
- Conditional `expectedAmount` field shown only when reason is `AMOUNT_MISMATCH`
- Integrates into `VariancesTab` in `detail.tsx` with a "Raise Dispute" button per variance card
- POSTs to `/api/v1/reconciliation/runs/${runId}/disputes` and invalidates `reconciliation-disputes` query on success

## Changes Made

- `frontend/src/pages/reconciliation/create-dispute-dialog.tsx` — new dialog component
- `frontend/src/pages/reconciliation/create-dispute-dialog.test.tsx` — 21 tests covering all scenarios
- `frontend/src/pages/reconciliation/detail.tsx` — added Raise Dispute button in VariancesTab

## Test plan

- [ ] Dialog renders when open, not when closed
- [ ] Pre-filled line item context displays correctly (varianceId, amount, optional expectedAmount and timestamp)
- [ ] Conditional expected amount field visible only for AMOUNT_MISMATCH reason
- [ ] Description required validation
- [ ] Reason required validation
- [ ] Successful submission calls API and closes dialog
- [ ] Form resets on close
- [ ] API error shows error alert
- [ ] Cancel closes dialog
- [ ] Raise Dispute button appears on each variance card in the detail page