### PR TITLE
ci: auto-tag develop branch on each merge

### DIFF
--- a/.github/workflows/tag-develop.yml
+++ b/.github/workflows/tag-develop.yml
@@ -1,0 +1,31 @@
+name: Tag Develop
+
+on:
+  push:
+    branches: [develop]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create development tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create lightweight tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.sha.substring(0, 7);
+            const now = new Date();
+            const date = now.toISOString().replace(/T/, '-').replace(/:/g, '').substring(0, 15);
+            const tag = `dev-${date}-${sha}`;
+
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${tag}`,
+              sha: context.sha,
+            });
+
+            core.info(`Created tag: ${tag}`);

--- a/.github/workflows/tag-develop.yml
+++ b/.github/workflows/tag-develop.yml
@@ -18,8 +18,8 @@ jobs:
           script: |
             const sha = context.sha.substring(0, 7);
             const now = new Date();
-            const date = now.toISOString().replace(/T/, '-').replace(/:/g, '').substring(0, 15);
-            const tag = `dev-${date}-${sha}`;
+            const d = now.toISOString().replace(/[-:T]/g, '').substring(0, 14);
+            const tag = `dev-${d.substring(0, 8)}-${d.substring(8)}-${sha}`;
 
             await github.rest.git.createRef({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

- Adds a lightweight GitHub Actions workflow that creates a tag on every push to `develop`
- Tag format: `dev-YYYYMMDD-HHMMSS-<short-sha>` (e.g. `dev-20260225-143200-abc1234`)

## Why

Makes it trivial to see exactly which commit is deployed to demo (or any environment). Run `git tag -l 'dev-*' --sort=-creatordate | head` to see recent deploys.

## Test plan

- [x] Workflow syntax valid
- [ ] Merge → verify tag appears on the repo's tags page