### PR TITLE
feat: add Create Saga Draft dialog

### DIFF
--- a/frontend/src/pages/starlark/create-saga-draft-dialog.test.tsx
+++ b/frontend/src/pages/starlark/create-saga-draft-dialog.test.tsx
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { BrowserRouter } from 'react-router-dom'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+const mockCreateSagaDraft = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    saga: {
+      id: 'aaaaaaaa-0000-0000-0000-000000000001',
+      name: 'savings.withdraw',
+      version: 1,
+      status: 1, // DRAFT
+    },
+  }),
+)
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(() => ({
+    sagaRegistry: {
+      createSagaDraft: mockCreateSagaDraft,
+    },
+  })),
+}))
+
+import { CreateSagaDraftDialog } from './create-saga-draft-dialog'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function Wrapper({ children, queryClient }: { children: React.ReactNode; queryClient?: QueryClient }) {
+  const qc = queryClient ?? makeQueryClient()
+  return (
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <BrowserRouter>{children}</BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+function renderDialog(props: { open?: boolean; onOpenChange?: (open: boolean) => void } = {}) {
+  const onOpenChange = props.onOpenChange ?? vi.fn()
+  render(
+    <Wrapper>
+      <CreateSagaDraftDialog open={props.open ?? true} onOpenChange={onOpenChange} />
+    </Wrapper>,
+  )
+  return { onOpenChange }
+}
+
+const STARTER_SCRIPT_FRAGMENT = 'def execute(ctx):'
+
+describe('CreateSagaDraftDialog - rendering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders dialog when open', () => {
+    renderDialog()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /create saga draft/i })).toBeInTheDocument()
+  })
+
+  it('does not render dialog content when closed', () => {
+    renderDialog({ open: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders all form fields', () => {
+    renderDialog()
+    expect(screen.getByLabelText(/^name$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^script$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/preconditions cel/i)).toBeInTheDocument()
+  })
+
+  it('renders Cancel and Create buttons', () => {
+    renderDialog()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /create saga draft/i })).toBeInTheDocument()
+  })
+
+  it('pre-fills script with starter template', () => {
+    renderDialog()
+    const scriptArea = screen.getByLabelText(/^script$/i) as HTMLTextAreaElement
+    expect(scriptArea.value).toContain(STARTER_SCRIPT_FRAGMENT)
+  })
+})
+
+describe('CreateSagaDraftDialog - name validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows error when name is empty', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.click(screen.getByRole('button', { name: /create saga draft/i }))
+    expect(await screen.findByText(/name is required/i)).toBeInTheDocument()
+  })
+
+  it('shows error for name starting with digit', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.type(screen.getByLabelText(/^name$/i), '1invalid')
+    await user.click(screen.getByRole('button', { name: /create saga draft/i }))
+    expect(await screen.findByText(/must start with a lowercase letter/i)).toBeInTheDocument()
+  })
+
+  it('shows error for name with uppercase letters', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.type(screen.getByLabelText(/^name$/i), 'InvalidName')
+    await user.click(screen.getByRole('button', { name: /create saga draft/i }))
+    expect(await screen.findByText(/must start with a lowercase letter/i)).toBeInTheDocument()
+  })
+
+  it('accepts valid name with dot separator', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.type(screen.getByLabelText(/^name$/i), 'savings.withdraw')
+    await user.click(screen.getByRole('button', { name: /create saga draft/i }))
+    await waitFor(() => {
+      expect(screen.queryByText(/must start with a lowercase letter/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/name is required/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('accepts valid name with underscores', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.type(screen.getByLabelText(/^name$/i), 'payment_order.create')
+    await user.click(screen.getByRole('button', { name: /create saga draft/i }))
+    await waitFor(() => {
+      expect(screen.queryByText(/must start with a lowercase letter/i)).not.toBeInTheDocument()
+    })
+  })
+})
+
+describe('CreateSagaDraftDialog - script validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows error when script is cleared', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    const scriptArea = screen.getByLabelText(/^script$/i)
+    await user.clear(scriptArea)
+    await user.type(screen.getByLabelText(/^name$/i), 'savings.withdraw')
+    await user.click(screen.getByRole('button', { name: /create saga draft/i }))
+    expect(await screen.findByText(/script is required/i)).toBeInTheDocument()
+  })
+})
+
+describe('CreateSagaDraftDialog - successful submission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls createSagaDraft with correct data', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/^name$/i), 'savings.withdraw')
+    await user.type(screen.getByLabelText(/display name/i), 'Savings Withdrawal')
+    await user.click(screen.getByRole('button', { name: /create saga draft/i }))
+
+    await waitFor(() => {
+      expect(mockCreateSagaDraft).toHaveBeenCalledOnce()
+      expect(mockCreateSagaDraft).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'savings.withdraw',
+          displayName: 'Savings Withdrawal',
+          version: 1,
+        }),
+      )
+    })
+  })
+
+  it('disables submit button while pending', async () => {
+    const user = userEvent.setup()
+    mockCreateSagaDraft.mockReturnValueOnce(new Promise(() => {}))
+    renderDialog()
+
+    await user.type(screen.getByLabelText(/^name$/i), 'savings.withdraw')
+    await user.click(screen.getByRole('button', { name: /create saga draft/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /creating/i })).toBeDisabled()
+    })
+  })
+
+  it('closes dialog on successful submission', async () => {
+    const user = userEvent.setup()
+    const { onOpenChange } = renderDialog()
+
+    await user.type(screen.getByLabelText(/^name$/i), 'savings.withdraw')
+    await user.click(screen.getByRole('button', { name: /create saga draft/i }))
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+})
+
+describe('CreateSagaDraftDialog - error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows general error banner on server error', async () => {
+    const user = userEvent.setup()
+    const { Code, ConnectError } = await import('@connectrpc/connect')
+    const err = new ConnectError('Service unavailable', Code.Unavailable)
+    mockCreateSagaDraft.mockRejectedValueOnce(err)
+
+    renderDialog()
+    await user.type(screen.getByLabelText(/^name$/i), 'savings.withdraw')
+    await user.click(screen.getByRole('button', { name: /create saga draft/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('CreateSagaDraftDialog - close and reset', () => {
+  it('closes dialog on Cancel button click', async () => {
+    const user = userEvent.setup()
+    const { onOpenChange } = renderDialog()
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('resets form when dialog is closed and reopened', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    const qc = makeQueryClient()
+    const { rerender } = render(
+      <Wrapper queryClient={qc}>
+        <CreateSagaDraftDialog open={true} onOpenChange={onOpenChange} />
+      </Wrapper>,
+    )
+
+    await user.type(screen.getByLabelText(/^name$/i), 'savings.withdraw')
+    expect(screen.getByLabelText(/^name$/i)).toHaveValue('savings.withdraw')
+
+    rerender(
+      <Wrapper queryClient={qc}>
+        <CreateSagaDraftDialog open={false} onOpenChange={onOpenChange} />
+      </Wrapper>,
+    )
+    rerender(
+      <Wrapper queryClient={qc}>
+        <CreateSagaDraftDialog open={true} onOpenChange={onOpenChange} />
+      </Wrapper>,
+    )
+
+    expect(screen.getByLabelText(/^name$/i)).toHaveValue('')
+    // Script should be reset to starter template
+    const scriptArea = screen.getByLabelText(/^script$/i) as HTMLTextAreaElement
+    expect(scriptArea.value).toContain(STARTER_SCRIPT_FRAGMENT)
+  })
+})

--- a/frontend/src/pages/starlark/create-saga-draft-dialog.tsx
+++ b/frontend/src/pages/starlark/create-saga-draft-dialog.tsx
@@ -60,14 +60,6 @@ export function CreateSagaDraftDialog({ open, onOpenChange }: CreateSagaDraftDia
   const [formData, setFormData] = React.useState<FormData>(INITIAL_FORM)
   const [errors, setErrors] = React.useState<FormErrors>({})
 
-  React.useEffect(() => {
-    if (!open) {
-      setFormData(INITIAL_FORM)
-      setErrors({})
-      mutation.reset()
-    }
-  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
-
   const mutation = useMutation({
     mutationFn: () =>
       clients.sagaRegistry.createSagaDraft({
@@ -101,6 +93,14 @@ export function CreateSagaDraftDialog({ open, onOpenChange }: CreateSagaDraftDia
       }
     },
   })
+
+  React.useEffect(() => {
+    if (!open) {
+      setFormData(INITIAL_FORM)
+      setErrors({})
+      mutation.reset()
+    }
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
 
   function validate(): boolean {
     const next: FormErrors = {}

--- a/frontend/src/pages/starlark/create-saga-draft-dialog.tsx
+++ b/frontend/src/pages/starlark/create-saga-draft-dialog.tsx
@@ -1,0 +1,306 @@
+import * as React from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useApiClients } from '@/api/context'
+import { handleConnectError } from '@/lib/error-handling'
+import { referenceKeys } from '@/lib/query-keys'
+
+const NAME_PATTERN = /^[a-z][a-z0-9_.]*$/
+
+const STARTER_SCRIPT = `def execute(ctx):
+    """Saga entry point."""
+    # ctx.input contains the trigger payload
+    # Use service module clients for type-safe operations
+    pass
+`
+
+interface FormData {
+  name: string
+  displayName: string
+  description: string
+  script: string
+  preconditionsCel: string
+}
+
+interface FormErrors {
+  name?: string
+  displayName?: string
+  description?: string
+  script?: string
+  general?: string
+}
+
+export interface CreateSagaDraftDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const INITIAL_FORM: FormData = {
+  name: '',
+  displayName: '',
+  description: '',
+  script: STARTER_SCRIPT,
+  preconditionsCel: '',
+}
+
+export function CreateSagaDraftDialog({ open, onOpenChange }: CreateSagaDraftDialogProps) {
+  const clients = useApiClients()
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const [formData, setFormData] = React.useState<FormData>(INITIAL_FORM)
+  const [errors, setErrors] = React.useState<FormErrors>({})
+
+  React.useEffect(() => {
+    if (!open) {
+      setFormData(INITIAL_FORM)
+      setErrors({})
+      mutation.reset()
+    }
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      clients.sagaRegistry.createSagaDraft({
+        name: formData.name.trim(),
+        displayName: formData.displayName.trim(),
+        description: formData.description.trim(),
+        script: formData.script,
+        preconditionsExpression: formData.preconditionsCel.trim(),
+        version: 1,
+      }),
+    onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: referenceKeys.sagas() })
+      onOpenChange(false)
+      const sagaId = res.saga?.id ?? ''
+      navigate(`/starlark-config/${sagaId}`)
+    },
+    onError: (err) => {
+      const result = handleConnectError(err)
+      if (Object.keys(result.fieldErrors).length > 0) {
+        const fieldMap: FormErrors = {}
+        for (const [field, msg] of Object.entries(result.fieldErrors)) {
+          if (field === 'name') fieldMap.name = msg
+          else if (field === 'display_name') fieldMap.displayName = msg
+          else if (field === 'description') fieldMap.description = msg
+          else if (field === 'script') fieldMap.script = msg
+          else fieldMap.general = msg
+        }
+        setErrors(fieldMap)
+      } else {
+        setErrors({ general: result.message })
+      }
+    },
+  })
+
+  function validate(): boolean {
+    const next: FormErrors = {}
+
+    const name = formData.name.trim()
+    if (!name) {
+      next.name = 'Name is required'
+    } else if (name.length < 1 || name.length > 100) {
+      next.name = 'Name must be 1–100 characters'
+    } else if (!NAME_PATTERN.test(name)) {
+      next.name = 'Name must start with a lowercase letter and contain only lowercase letters, digits, dots, or underscores'
+    }
+
+    if (formData.displayName.trim().length > 255) {
+      next.displayName = 'Display name must be 255 characters or fewer'
+    }
+
+    if (formData.description.length > 1000) {
+      next.description = 'Description must be 1000 characters or fewer'
+    }
+
+    const script = formData.script
+    if (!script || script.trim().length === 0) {
+      next.script = 'Script is required'
+    } else if (script.length > 65536) {
+      next.script = 'Script must be 65536 characters or fewer'
+    }
+
+    setErrors(next)
+    return Object.keys(next).length === 0
+  }
+
+  function handleChange(field: keyof FormData) {
+    return (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setFormData((prev) => ({ ...prev, [field]: e.target.value }))
+      if (errors[field as keyof FormErrors]) {
+        setErrors((prev) => ({ ...prev, [field]: undefined }))
+      }
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (mutation.isPending) return
+    if (!validate()) return
+    mutation.mutate()
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && mutation.isPending) return
+    onOpenChange(nextOpen)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Create Saga Draft</DialogTitle>
+          <DialogDescription>
+            Define a new Starlark saga workflow. It will be created in DRAFT status and must be
+            activated before it can be executed.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => void handleSubmit(e)} id="create-saga-draft-form">
+          <div className="space-y-4 py-2">
+            {errors.general && (
+              <div
+                role="alert"
+                className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                {errors.general}
+              </div>
+            )}
+
+            <div className="space-y-1">
+              <label htmlFor="saga-name" className="text-sm font-medium">
+                Name <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="saga-name"
+                value={formData.name}
+                onChange={handleChange('name')}
+                placeholder="savings.withdraw"
+                aria-label="Name"
+                aria-describedby={
+                  errors.name ? 'saga-name-error' : 'saga-name-hint'
+                }
+                maxLength={100}
+              />
+              <p id="saga-name-hint" className="text-xs text-muted-foreground">
+                Use <code className="font-mono">prefix.operation</code> format to link with an
+                account type (e.g., <code className="font-mono">savings.withdraw</code>).
+              </p>
+              {errors.name && (
+                <p id="saga-name-error" className="text-sm text-destructive">
+                  {errors.name}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="saga-display-name" className="text-sm font-medium">
+                Display Name{' '}
+                <span className="font-normal text-muted-foreground">(optional)</span>
+              </label>
+              <Input
+                id="saga-display-name"
+                value={formData.displayName}
+                onChange={handleChange('displayName')}
+                placeholder="Savings Withdrawal"
+                aria-label="Display Name"
+                aria-describedby={errors.displayName ? 'saga-display-name-error' : undefined}
+                maxLength={255}
+              />
+              {errors.displayName && (
+                <p id="saga-display-name-error" className="text-sm text-destructive">
+                  {errors.displayName}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="saga-description" className="text-sm font-medium">
+                Description{' '}
+                <span className="font-normal text-muted-foreground">(optional)</span>
+              </label>
+              <textarea
+                id="saga-description"
+                value={formData.description}
+                onChange={handleChange('description')}
+                placeholder="Describe what this saga does..."
+                aria-label="Description"
+                aria-describedby={errors.description ? 'saga-description-error' : undefined}
+                maxLength={1000}
+                rows={3}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs resize-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring placeholder:text-muted-foreground"
+              />
+              {errors.description && (
+                <p id="saga-description-error" className="text-sm text-destructive">
+                  {errors.description}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="saga-script" className="text-sm font-medium">
+                Script <span className="text-destructive">*</span>
+              </label>
+              <textarea
+                id="saga-script"
+                value={formData.script}
+                onChange={handleChange('script')}
+                placeholder="def execute(ctx):&#10;    pass"
+                aria-label="Script"
+                aria-describedby={errors.script ? 'saga-script-error' : undefined}
+                rows={12}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 font-mono text-sm shadow-xs resize-y focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring placeholder:text-muted-foreground"
+                spellCheck={false}
+              />
+              {errors.script && (
+                <p id="saga-script-error" className="text-sm text-destructive">
+                  {errors.script}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="saga-preconditions" className="text-sm font-medium">
+                Preconditions CEL{' '}
+                <span className="font-normal text-muted-foreground">(optional)</span>
+              </label>
+              <Input
+                id="saga-preconditions"
+                value={formData.preconditionsCel}
+                onChange={handleChange('preconditionsCel')}
+                placeholder="amount > 0"
+                aria-label="Preconditions CEL"
+                className="font-mono text-sm"
+              />
+              <p className="text-xs text-muted-foreground">
+                CEL expression evaluated before saga execution. Leave empty for no preconditions.
+              </p>
+            </div>
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="create-saga-draft-form"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Creating…' : 'Create Saga Draft'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/starlark/create-saga-draft-dialog.tsx
+++ b/frontend/src/pages/starlark/create-saga-draft-dialog.tsx
@@ -73,8 +73,10 @@ export function CreateSagaDraftDialog({ open, onOpenChange }: CreateSagaDraftDia
     onSuccess: (res) => {
       queryClient.invalidateQueries({ queryKey: referenceKeys.sagas() })
       onOpenChange(false)
-      const sagaId = res.saga?.id ?? ''
-      navigate(`/starlark-config/${sagaId}`)
+      const sagaId = res.saga?.id
+      if (sagaId) {
+        navigate(`/starlark-config/${sagaId}`)
+      }
     },
     onError: (err) => {
       const result = handleConnectError(err)

--- a/frontend/src/pages/starlark/index.tsx
+++ b/frontend/src/pages/starlark/index.tsx
@@ -1,13 +1,15 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import type { ColumnDef } from '@tanstack/react-table'
 import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
 import { DataTable, type DataTableQueryParams, type DataTableResult } from '@/components/shared/data-table'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { useApiClients } from '@/api/context'
 import type { SagaDefinition } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
 import { SagaStatus } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
+import { CreateSagaDraftDialog } from './create-saga-draft-dialog'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -52,6 +54,7 @@ export interface StarlarkConfigPageProps {
 
 export function StarlarkConfigPage({ isPlatformAdmin = false }: StarlarkConfigPageProps) {
   const { sagaRegistry } = useApiClients()
+  const [createDialogOpen, setCreateDialogOpen] = useState(false)
 
   const columns = useMemo((): ColumnDef<SagaDefinition>[] => {
     const base: ColumnDef<SagaDefinition>[] = [
@@ -128,12 +131,17 @@ export function StarlarkConfigPage({ isPlatformAdmin = false }: StarlarkConfigPa
 
   return (
     <div className="flex flex-col gap-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Starlark Configuration</h1>
-        <p className="mt-2 text-muted-foreground">
-          Manage saga workflow definitions and Starlark scripts
-        </p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Starlark Configuration</h1>
+          <p className="mt-2 text-muted-foreground">
+            Manage saga workflow definitions and Starlark scripts
+          </p>
+        </div>
+        <Button onClick={() => setCreateDialogOpen(true)}>Create Saga</Button>
       </div>
+
+      <CreateSagaDraftDialog open={createDialogOpen} onOpenChange={setCreateDialogOpen} />
 
       <Card className="p-6">
         <DataTable<SagaDefinition>


### PR DESCRIPTION
## Summary

- Adds `CreateSagaDraftDialog` component to the Starlark configuration page
- Provides a form for creating new saga drafts with Starlark script editor
- Integrates with `sagaRegistry.createSagaDraft()` via Connect-ES pattern

## Changes Made

**`frontend/src/pages/starlark/create-saga-draft-dialog.tsx`**
- Dialog with name (required, pattern `^[a-z][a-z0-9_.]*$`, 1–100 chars), display name (optional, 255 chars), description (optional, 1000 chars), script (required, monospace textarea, 65536 chars, pre-filled with starter template), and preconditions CEL (optional) fields
- Name helper text explains `prefix.operation` format convention
- On success: invalidates `referenceKeys.sagas()`, closes dialog, navigates to `/starlark-config/{saga.id}`
- Form resets on close via `useEffect`

**`frontend/src/pages/starlark/index.tsx`**
- Adds "Create Saga" button to page header
- Mounts `CreateSagaDraftDialog` controlled by local state

**`frontend/src/pages/starlark/create-saga-draft-dialog.test.tsx`**
- 17 tests covering: rendering, closed state, form fields present, starter template pre-fill, name pattern validation, script required validation, successful submission, pending state, dialog close, server error banner, cancel close, and form reset on reopen

## Test plan

- [x] All 17 unit tests pass (`npx vitest run src/pages/starlark/create-saga-draft-dialog.test.tsx`)
- [x] Name validation: rejects digits/uppercase at start, accepts `savings.withdraw`, `payment_order.create`
- [x] Script textarea pre-filled with `def execute(ctx):` starter template
- [x] Successful submission calls `createSagaDraft` with correct shape
- [x] Error banner shown on API failure
- [x] Form resets when dialog closes and reopens