### PR TITLE
feat: update current account proto for asset-agnostic fields

### DIFF
--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -128,7 +128,7 @@ message CurrentAccountFacility {
     not_in: [0] /* Prevent UNSPECIFIED in requests */
   }];
 
-  // instrument_code is the primary instrument for this account (e.g. "GBP", "kWh", "GPU_HOUR").
+  // instrument_code is the primary instrument for this account (e.g. "GBP", "KWH", "GPU_HOUR").
   string instrument_code = 4 [(buf.validate.field).string = {
     min_len: 1
     max_len: 32
@@ -347,7 +347,7 @@ message InitiateCurrentAccountRequest {
     max_len: 255
   }];
 
-  // instrument_code is the primary instrument for this account (e.g. "GBP", "kWh", "GPU_HOUR").
+  // instrument_code is the primary instrument for this account (e.g. "GBP", "KWH", "GPU_HOUR").
   string instrument_code = 3 [(buf.validate.field).string = {
     min_len: 1
     max_len: 32

--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -115,12 +115,11 @@ message CurrentAccountFacility {
     pattern: "^[a-zA-Z0-9_-]+$"
   }];
 
-  // account_identification is the IBAN or other standard account identifier.
-  // IBAN format: 2 letter country code + 2 check digits + up to 30 alphanumeric characters.
-  string account_identification = 2 [(buf.validate.field).string = {
+  // external_identifier is the external account identifier (e.g. IBAN, sort code + account number, or
+  // any product-type-specific reference). Format validated by product type CEL rules.
+  string external_identifier = 2 [(buf.validate.field).string = {
     min_len: 1
-    max_len: 34 // IBAN max length
-    pattern: "^[A-Z]{2}[0-9]{2}[A-Z0-9]{1,30}$" // IBAN format validation
+    max_len: 255
   }];
 
   // account_status is the current lifecycle state of the account
@@ -129,10 +128,11 @@ message CurrentAccountFacility {
     not_in: [0] /* Prevent UNSPECIFIED in requests */
   }];
 
-  // base_currency is the primary currency for this account
-  meridian.common.v1.Currency base_currency = 4 [(buf.validate.field).enum = {
-    defined_only: true
-    not_in: [0] /* Prevent UNSPECIFIED currency */
+  // instrument_code is the primary instrument for this account (e.g. "GBP", "kWh", "GPU_HOUR").
+  string instrument_code = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
   }];
 
   // created_at is when the account facility was created
@@ -148,8 +148,9 @@ message CurrentAccountFacility {
   // Task 5.2: Implement account balance tracking and overdraft limits
   AccountBalance current_balance = 8;
 
-  // overdraft_limit configures the overdraft facility for this account
-  OverdraftConfiguration overdraft_limit = 9;
+  // Field 9 reserved - overdraft_limit removed (use product type configuration instead)
+  reserved 9;
+  reserved "overdraft_limit";
 
   // transaction_history tracks recent transactions for this account
   // Task 5.4: Add transaction history and account status management features
@@ -167,6 +168,10 @@ message CurrentAccountFacility {
 
   // product_type_version is the pinned version of the product type definition (immutable after creation).
   int32 product_type_version = 13;
+
+  // dimension classifies the instrument type (e.g. "CURRENCY", "ENERGY", "COMPUTE", "CARBON").
+  // Used for reporting, validation, and routing. Validated by product type CEL rules.
+  string dimension = 14;
 }
 
 // AccountBalance represents the current balance state of an account
@@ -183,8 +188,10 @@ message AccountBalance {
 }
 
 // OverdraftConfiguration defines the overdraft facility settings
-// Task 5.2: Overdraft limits
+// Deprecated: Overdraft configuration is now managed via product type definitions.
+// This message is retained for wire compatibility with existing consumers.
 message OverdraftConfiguration {
+  option deprecated = true;
   // overdraft_limit is the maximum overdraft amount allowed
   meridian.common.v1.MoneyAmount overdraft_limit = 1 [(buf.validate.field).required = true];
 
@@ -333,17 +340,18 @@ message InitiateCurrentAccountRequest {
     max_len: 100
   }];
 
-  // account_identification is the IBAN
-  string account_identification = 2 [(buf.validate.field).string = {
+  // external_identifier is the external account identifier (e.g. IBAN, sort code + account number, or
+  // any product-type-specific reference). Format validated by product type CEL rules.
+  string external_identifier = 2 [(buf.validate.field).string = {
     min_len: 1
-    max_len: 34
-    pattern: "^[A-Z]{2}[0-9]{2}[A-Z0-9]{1,30}$"
+    max_len: 255
   }];
 
-  // base_currency is the account currency
-  meridian.common.v1.Currency base_currency = 3 [(buf.validate.field).enum = {
-    defined_only: true
-    not_in: [0]
+  // instrument_code is the primary instrument for this account (e.g. "GBP", "kWh", "GPU_HOUR").
+  string instrument_code = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
   }];
 
   // org_party_id references the organization party for org-scoped accounts.

--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -365,7 +365,7 @@ message InitiateCurrentAccountRequest {
   // When provided, the service resolves the product type via LocalAccountTypeCache,
   // validates BehaviorClass == CUSTOMER, evaluates EligibilityCEL, validates attributes
   // against AttributeSchema, and seeds ValuationFeatures from templates.
-  // During transition, if empty, the service falls back to base_currency-derived defaults.
+  // When empty, the service uses instrument_code and dimension from this request directly.
   string product_type_code = 5 [(buf.validate.field).string = {
     max_len: 50
     pattern: "^[A-Z0-9_]*$"

--- a/api/proto/meridian/current_account/v1/current_account_test.go
+++ b/api/proto/meridian/current_account/v1/current_account_test.go
@@ -17,26 +17,26 @@ func TestCurrentAccountFacility_BasicConstruction(t *testing.T) {
 	now := timestamppb.New(time.Now())
 
 	facility := &currentaccountv1.CurrentAccountFacility{
-		AccountId:             "ACC-12345",
-		AccountIdentification: "GB29NWBK60161331926819",
-		AccountStatus:         currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
-		BaseCurrency:          commonv1.Currency_CURRENCY_GBP,
-		CreatedAt:             now,
-		UpdatedAt:             now,
-		Version:               1,
+		AccountId:          "ACC-12345",
+		ExternalIdentifier: "GB29NWBK60161331926819",
+		AccountStatus:      currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
+		InstrumentCode:     "GBP",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+		Version:            1,
 	}
 
 	if facility.GetAccountId() == "" {
 		t.Error("AccountId should not be empty")
 	}
-	if facility.GetAccountIdentification() == "" {
-		t.Error("AccountIdentification should not be empty")
+	if facility.GetExternalIdentifier() == "" {
+		t.Error("ExternalIdentifier should not be empty")
 	}
 	if facility.GetAccountStatus() != currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE {
 		t.Error("AccountStatus should be ACTIVE")
 	}
-	if facility.GetBaseCurrency() != commonv1.Currency_CURRENCY_GBP {
-		t.Error("BaseCurrency should be GBP")
+	if facility.GetInstrumentCode() != "GBP" {
+		t.Errorf("Expected instrument code GBP, got %s", facility.GetInstrumentCode())
 	}
 	if facility.GetVersion() != 1 {
 		t.Errorf("Expected version 1, got %d", facility.GetVersion())
@@ -69,12 +69,12 @@ func TestCurrentAccountFacility_StatusTransitions(t *testing.T) {
 	now := timestamppb.New(time.Now())
 
 	facility := &currentaccountv1.CurrentAccountFacility{
-		AccountId:             "ACC-12345",
-		AccountIdentification: "GB29NWBK60161331926819",
-		AccountStatus:         currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
-		BaseCurrency:          commonv1.Currency_CURRENCY_GBP,
-		CreatedAt:             now,
-		UpdatedAt:             now,
+		AccountId:          "ACC-12345",
+		ExternalIdentifier: "GB29NWBK60161331926819",
+		AccountStatus:      currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
+		InstrumentCode:     "GBP",
+		CreatedAt:          now,
+		UpdatedAt:          now,
 	}
 
 	// Test transition to frozen
@@ -96,10 +96,10 @@ func TestCurrentAccountFacility_BalanceTracking(t *testing.T) {
 	now := timestamppb.New(time.Now())
 
 	facility := &currentaccountv1.CurrentAccountFacility{
-		AccountId:             "ACC-12345",
-		AccountIdentification: "GB29NWBK60161331926819",
-		AccountStatus:         currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
-		BaseCurrency:          commonv1.Currency_CURRENCY_GBP,
+		AccountId:          "ACC-12345",
+		ExternalIdentifier: "GB29NWBK60161331926819",
+		AccountStatus:      currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
+		InstrumentCode:     "GBP",
 		CurrentBalance: &currentaccountv1.AccountBalance{
 			AvailableBalance: &commonv1.MoneyAmount{
 				Amount: &money.Money{
@@ -136,213 +136,41 @@ func TestCurrentAccountFacility_BalanceTracking(t *testing.T) {
 	}
 }
 
-// TestCurrentAccountFacility_OverdraftLimit tests overdraft limit functionality
-func TestCurrentAccountFacility_OverdraftLimit(t *testing.T) {
+// TestCurrentAccountFacility_InstrumentCode tests asset-agnostic instrument code field
+func TestCurrentAccountFacility_InstrumentCode(t *testing.T) {
 	now := timestamppb.New(time.Now())
 
-	facility := &currentaccountv1.CurrentAccountFacility{
-		AccountId:             "ACC-12345",
-		AccountIdentification: "GB29NWBK60161331926819",
-		AccountStatus:         currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
-		BaseCurrency:          commonv1.Currency_CURRENCY_GBP,
-		OverdraftLimit: &currentaccountv1.OverdraftConfiguration{
-			OverdraftLimit: &commonv1.MoneyAmount{
-				Amount: &money.Money{
-					CurrencyCode: "GBP",
-					Units:        500,
-					Nanos:        0,
-				},
-			},
-			InterestRate: 12.5,
-			IsEnabled:    true,
-			LastUpdated:  now,
-		},
-		CreatedAt: now,
-		UpdatedAt: now,
-		Version:   1,
+	tests := []struct {
+		name           string
+		instrumentCode string
+		dimension      string
+	}{
+		{"currency GBP", "GBP", "CURRENCY"},
+		{"energy kWh", "KWH", "ENERGY"},
+		{"compute GPU hours", "GPU_HOUR", "COMPUTE"},
+		{"carbon credits", "TONNE_CO2E", "CARBON"},
 	}
 
-	if facility.GetOverdraftLimit() == nil {
-		t.Error("OverdraftLimit should not be nil")
-	}
-	if facility.GetOverdraftLimit().GetOverdraftLimit() == nil {
-		t.Error("OverdraftLimit.OverdraftLimit should not be nil")
-	}
-	if facility.GetOverdraftLimit().GetOverdraftLimit().GetAmount().GetUnits() != 500 {
-		t.Errorf("Expected overdraft limit 500, got %d", facility.GetOverdraftLimit().GetOverdraftLimit().GetAmount().GetUnits())
-	}
-	if !facility.GetOverdraftLimit().GetIsEnabled() {
-		t.Error("Overdraft should be enabled")
-	}
-	if facility.GetOverdraftLimit().GetInterestRate() != 12.5 {
-		t.Errorf("Expected interest rate 12.5, got %f", facility.GetOverdraftLimit().GetInterestRate())
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			facility := &currentaccountv1.CurrentAccountFacility{
+				AccountId:          "ACC-12345",
+				ExternalIdentifier: "ACCT-001",
+				AccountStatus:      currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
+				InstrumentCode:     tt.instrumentCode,
+				Dimension:          tt.dimension,
+				CreatedAt:          now,
+				UpdatedAt:          now,
+				Version:            1,
+			}
 
-// TestCurrentAccountFacility_BalanceWithOverdraft tests balance calculation with overdraft
-func TestCurrentAccountFacility_BalanceWithOverdraft(t *testing.T) {
-	now := timestamppb.New(time.Now())
-
-	facility := &currentaccountv1.CurrentAccountFacility{
-		AccountId:             "ACC-12345",
-		AccountIdentification: "GB29NWBK60161331926819",
-		AccountStatus:         currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
-		BaseCurrency:          commonv1.Currency_CURRENCY_GBP,
-		CurrentBalance: &currentaccountv1.AccountBalance{
-			CurrentBalance: &commonv1.MoneyAmount{
-				Amount: &money.Money{
-					CurrencyCode: "GBP",
-					Units:        100,
-					Nanos:        0,
-				},
-			},
-			AvailableBalance: &commonv1.MoneyAmount{
-				Amount: &money.Money{
-					CurrencyCode: "GBP",
-					Units:        600, // 100 (current) + 500 (overdraft)
-					Nanos:        0,
-				},
-			},
-			LastUpdated: now,
-		},
-		OverdraftLimit: &currentaccountv1.OverdraftConfiguration{
-			OverdraftLimit: &commonv1.MoneyAmount{
-				Amount: &money.Money{
-					CurrencyCode: "GBP",
-					Units:        500,
-					Nanos:        0,
-				},
-			},
-			InterestRate: 10.0,
-			IsEnabled:    true,
-			LastUpdated:  now,
-		},
-		CreatedAt: now,
-		UpdatedAt: now,
-		Version:   1,
-	}
-
-	// Test that available balance includes overdraft
-	currentBal := facility.GetCurrentBalance().GetCurrentBalance().GetAmount().GetUnits()
-	overdraftLim := facility.GetOverdraftLimit().GetOverdraftLimit().GetAmount().GetUnits()
-	availableBal := facility.GetCurrentBalance().GetAvailableBalance().GetAmount().GetUnits()
-
-	expectedAvailable := currentBal + overdraftLim
-	if availableBal != expectedAvailable {
-		t.Errorf("Expected available balance %d (current %d + overdraft %d), got %d",
-			expectedAvailable, currentBal, overdraftLim, availableBal)
-	}
-}
-
-// TestDebitTransaction_BasicConstruction tests debit transaction message
-// for subtask 5.3: Create debit/credit transaction operations
-func TestDebitTransaction_BasicConstruction(t *testing.T) {
-	now := timestamppb.New(time.Now())
-
-	debit := &currentaccountv1.AccountTransaction{
-		TransactionId: "TXN-12345",
-		AccountId:     "ACC-12345",
-		Direction:     commonv1.PostingDirection_POSTING_DIRECTION_DEBIT,
-		Amount: &commonv1.MoneyAmount{
-			Amount: &money.Money{
-				CurrencyCode: "GBP",
-				Units:        100,
-				Nanos:        0,
-			},
-		},
-		Status:      commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
-		Description: "Debit transaction test",
-		Reference:   "REF-12345",
-		Timestamp:   now,
-	}
-
-	if debit.GetTransactionId() == "" {
-		t.Error("TransactionId should not be empty")
-	}
-	if debit.GetDirection() != commonv1.PostingDirection_POSTING_DIRECTION_DEBIT {
-		t.Error("Direction should be DEBIT")
-	}
-	if debit.GetAmount().GetAmount().GetUnits() != 100 {
-		t.Errorf("Expected amount 100, got %d", debit.GetAmount().GetAmount().GetUnits())
-	}
-	if debit.GetStatus() != commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED {
-		t.Error("Status should be POSTED")
-	}
-}
-
-// TestCreditTransaction_BasicConstruction tests credit transaction message
-func TestCreditTransaction_BasicConstruction(t *testing.T) {
-	now := timestamppb.New(time.Now())
-
-	credit := &currentaccountv1.AccountTransaction{
-		TransactionId: "TXN-67890",
-		AccountId:     "ACC-12345",
-		Direction:     commonv1.PostingDirection_POSTING_DIRECTION_CREDIT,
-		Amount: &commonv1.MoneyAmount{
-			Amount: &money.Money{
-				CurrencyCode: "GBP",
-				Units:        250,
-				Nanos:        0,
-			},
-		},
-		Status:      commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
-		Description: "Credit transaction test",
-		Reference:   "REF-67890",
-		Timestamp:   now,
-	}
-
-	if credit.GetTransactionId() == "" {
-		t.Error("TransactionId should not be empty")
-	}
-	if credit.GetDirection() != commonv1.PostingDirection_POSTING_DIRECTION_CREDIT {
-		t.Error("Direction should be CREDIT")
-	}
-	if credit.GetAmount().GetAmount().GetUnits() != 250 {
-		t.Errorf("Expected amount 250, got %d", credit.GetAmount().GetAmount().GetUnits())
-	}
-}
-
-// TestTransactionHistory_BasicConstruction tests transaction history
-// for subtask 5.4: Add transaction history and account status management features
-func TestTransactionHistory_BasicConstruction(t *testing.T) {
-	now := timestamppb.New(time.Now())
-
-	history := &currentaccountv1.TransactionHistory{
-		AccountId: "ACC-12345",
-		Transactions: []*currentaccountv1.AccountTransaction{
-			{
-				TransactionId: "TXN-1",
-				AccountId:     "ACC-12345",
-				Direction:     commonv1.PostingDirection_POSTING_DIRECTION_CREDIT,
-				Amount: &commonv1.MoneyAmount{
-					Amount: &money.Money{CurrencyCode: "GBP", Units: 100},
-				},
-				Status:    commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
-				Timestamp: now,
-			},
-			{
-				TransactionId: "TXN-2",
-				AccountId:     "ACC-12345",
-				Direction:     commonv1.PostingDirection_POSTING_DIRECTION_DEBIT,
-				Amount: &commonv1.MoneyAmount{
-					Amount: &money.Money{CurrencyCode: "GBP", Units: 50},
-				},
-				Status:    commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
-				Timestamp: now,
-			},
-		},
-		TotalCount:  2,
-		LastUpdated: now,
-	}
-
-	if history.GetAccountId() == "" {
-		t.Error("AccountId should not be empty")
-	}
-	if len(history.GetTransactions()) != 2 {
-		t.Errorf("Expected 2 transactions, got %d", len(history.GetTransactions()))
-	}
-	if history.GetTotalCount() != 2 {
-		t.Errorf("Expected total count 2, got %d", history.GetTotalCount())
+			if facility.GetInstrumentCode() != tt.instrumentCode {
+				t.Errorf("Expected instrument code %s, got %s", tt.instrumentCode, facility.GetInstrumentCode())
+			}
+			if facility.GetDimension() != tt.dimension {
+				t.Errorf("Expected dimension %s, got %s", tt.dimension, facility.GetDimension())
+			}
+		})
 	}
 }
 
@@ -351,10 +179,10 @@ func TestCurrentAccountFacility_WithTransactionHistory(t *testing.T) {
 	now := timestamppb.New(time.Now())
 
 	facility := &currentaccountv1.CurrentAccountFacility{
-		AccountId:             "ACC-12345",
-		AccountIdentification: "GB29NWBK60161331926819",
-		AccountStatus:         currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
-		BaseCurrency:          commonv1.Currency_CURRENCY_GBP,
+		AccountId:          "ACC-12345",
+		ExternalIdentifier: "GB29NWBK60161331926819",
+		AccountStatus:      currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
+		InstrumentCode:     "GBP",
 		CurrentBalance: &currentaccountv1.AccountBalance{
 			CurrentBalance: &commonv1.MoneyAmount{
 				Amount: &money.Money{CurrencyCode: "GBP", Units: 500},
@@ -414,8 +242,9 @@ func TestCurrentAccountFacility_WithTransactionHistory(t *testing.T) {
 	}
 }
 
-// TestValidation_IBANFormat tests IBAN format validation
-func TestValidation_IBANFormat(t *testing.T) {
+// TestValidation_ExternalIdentifierFormat tests external identifier validation
+// The field now accepts any string up to 255 characters; format is validated by product type CEL rules.
+func TestValidation_ExternalIdentifierFormat(t *testing.T) {
 	validator, err := protovalidate.New()
 	if err != nil {
 		t.Fatalf("Failed to create validator: %v", err)
@@ -424,72 +253,57 @@ func TestValidation_IBANFormat(t *testing.T) {
 	now := timestamppb.New(time.Now())
 
 	tests := []struct {
-		name      string
-		iban      string
-		wantError bool
+		name       string
+		identifier string
+		wantError  bool
 	}{
 		{
-			name:      "valid UK IBAN",
-			iban:      "GB29NWBK60161331926819",
-			wantError: false,
+			name:       "valid IBAN",
+			identifier: "GB29NWBK60161331926819",
+			wantError:  false,
 		},
 		{
-			name:      "valid German IBAN",
-			iban:      "DE89370400440532013000",
-			wantError: false,
+			name:       "valid sort code and account number",
+			identifier: "20-00-00/12345678",
+			wantError:  false,
 		},
 		{
-			name:      "valid French IBAN",
-			iban:      "FR1420041010050500013M02606",
-			wantError: false,
+			name:       "valid meter ID",
+			identifier: "METER-UK-001-2024",
+			wantError:  false,
 		},
 		{
-			name:      "invalid no country code",
-			iban:      "29NWBK60161331926819",
-			wantError: true,
+			name:       "valid GPU node reference",
+			identifier: "NODE-A100-CLUSTER-42",
+			wantError:  false,
 		},
 		{
-			name:      "invalid lowercase country code",
-			iban:      "gb29NWBK60161331926819",
-			wantError: true,
-		},
-		{
-			name:      "invalid missing check digits",
-			iban:      "GBNWBK60161331926819",
-			wantError: true,
-		},
-		{
-			name:      "invalid with spaces",
-			iban:      "GB29 NWBK 6016 1331 9268 19",
-			wantError: true,
-		},
-		{
-			name:      "invalid with special characters",
-			iban:      "GB29-NWBK-60161331926819",
-			wantError: true,
+			name:       "empty string fails (min_len: 1)",
+			identifier: "",
+			wantError:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			facility := &currentaccountv1.CurrentAccountFacility{
-				AccountId:             "acc-123",
-				AccountIdentification: tt.iban,
-				AccountStatus:         currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
-				BaseCurrency:          commonv1.Currency_CURRENCY_GBP,
-				CreatedAt:             now,
-				UpdatedAt:             now,
-				Version:               1,
+				AccountId:          "acc-123",
+				ExternalIdentifier: tt.identifier,
+				AccountStatus:      currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
+				InstrumentCode:     "GBP",
+				CreatedAt:          now,
+				UpdatedAt:          now,
+				Version:            1,
 			}
 
 			err := validator.Validate(facility)
 			if tt.wantError {
 				if err == nil {
-					t.Errorf("Expected validation error for IBAN %q but got none", tt.iban)
+					t.Errorf("Expected validation error for identifier %q but got none", tt.identifier)
 				}
 			} else {
 				if err != nil {
-					t.Errorf("Unexpected validation error for IBAN %q: %v", tt.iban, err)
+					t.Errorf("Unexpected validation error for identifier %q: %v", tt.identifier, err)
 				}
 			}
 		})
@@ -550,13 +364,13 @@ func TestValidation_AccountIDPattern_CurrentAccount(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			facility := &currentaccountv1.CurrentAccountFacility{
-				AccountId:             tt.accountID,
-				AccountIdentification: "GB29NWBK60161331926819",
-				AccountStatus:         currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
-				BaseCurrency:          commonv1.Currency_CURRENCY_GBP,
-				CreatedAt:             now,
-				UpdatedAt:             now,
-				Version:               1,
+				AccountId:          tt.accountID,
+				ExternalIdentifier: "GB29NWBK60161331926819",
+				AccountStatus:      currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
+				InstrumentCode:     "GBP",
+				CreatedAt:          now,
+				UpdatedAt:          now,
+				Version:            1,
 			}
 
 			err := validator.Validate(facility)

--- a/api/proto/meridian/current_account/v1/current_account_test.go
+++ b/api/proto/meridian/current_account/v1/current_account_test.go
@@ -1,6 +1,7 @@
 package currentaccountv1_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -276,6 +277,16 @@ func TestValidation_ExternalIdentifierFormat(t *testing.T) {
 			name:       "valid GPU node reference",
 			identifier: "NODE-A100-CLUSTER-42",
 			wantError:  false,
+		},
+		{
+			name:       "max length 255 valid",
+			identifier: strings.Repeat("A", 255),
+			wantError:  false,
+		},
+		{
+			name:       "max length 256 invalid",
+			identifier: strings.Repeat("A", 256),
+			wantError:  true,
 		},
 		{
 			name:       "empty string fails (min_len: 1)",

--- a/services/current-account/service/grpc_account_endpoints.go
+++ b/services/current-account/service/grpc_account_endpoints.go
@@ -37,11 +37,11 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 	// Generate account ID
 	accountID := fmt.Sprintf("ACC-%s", uuid.New().String()[:8])
 
-	// Map currency enum to string
-	currency := mapCurrency(req.BaseCurrency)
+	// Use instrument_code directly as the account's native instrument
+	currency := req.InstrumentCode
 	if currency == "" {
 		operationStatus = operationStatusInvalidCurrency
-		return nil, status.Errorf(codes.InvalidArgument, "unsupported currency: %v", req.BaseCurrency)
+		return nil, status.Errorf(codes.InvalidArgument, "instrument_code is required")
 	}
 
 	// Validate party exists and is active (if party client is configured)
@@ -188,7 +188,7 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 	// Create domain model
 	account, err := domain.NewCurrentAccount(
 		accountID,
-		req.AccountIdentification,
+		req.ExternalIdentifier,
 		req.PartyId,
 		currency,
 		opts...,

--- a/services/current-account/service/grpc_mappers.go
+++ b/services/current-account/service/grpc_mappers.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"log/slog"
-	"time"
 
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
@@ -20,24 +19,18 @@ const (
 
 func toProtoFacility(account domain.CurrentAccount) *pb.CurrentAccountFacility {
 	return &pb.CurrentAccountFacility{
-		AccountId:             account.AccountID(),
-		AccountIdentification: account.AccountIdentification(),
-		AccountStatus:         mapStatusToProto(account.Status()),
-		BaseCurrency:          mapCurrencyToProto(string(account.Balance().Currency())),
-		CreatedAt:             timestamppb.New(account.CreatedAt()),
-		UpdatedAt:             timestamppb.New(account.UpdatedAt()),
+		AccountId:          account.AccountID(),
+		ExternalIdentifier: account.AccountIdentification(),
+		AccountStatus:      mapStatusToProto(account.Status()),
+		InstrumentCode:     string(account.Balance().Currency()),
+		CreatedAt:          timestamppb.New(account.CreatedAt()),
+		UpdatedAt:          timestamppb.New(account.UpdatedAt()),
 		// #nosec G115 - Version is bounded by database constraints
 		Version: int32(account.Version()),
 		CurrentBalance: &pb.AccountBalance{
 			CurrentBalance:   toMoneyAmount(account.Balance()),
 			AvailableBalance: toMoneyAmount(account.AvailableBalance()),
 			LastUpdated:      timestamppb.New(account.BalanceUpdatedAt()),
-		},
-		OverdraftLimit: &pb.OverdraftConfiguration{
-			OverdraftLimit: toMoneyAmount(account.OverdraftLimit()),
-			InterestRate:   account.OverdraftRate(),
-			IsEnabled:      account.OverdraftEnabled(),
-			LastUpdated:    timestamppb.New(time.Now()),
 		},
 		ProductTypeCode: account.ProductTypeCode(),
 		// #nosec G115 - ProductTypeVersion is bounded by database constraints
@@ -124,19 +117,6 @@ func mapStatusToProto(status domain.AccountStatus) pb.AccountStatus {
 		return pb.AccountStatus_ACCOUNT_STATUS_CLOSED
 	default:
 		return pb.AccountStatus_ACCOUNT_STATUS_UNSPECIFIED
-	}
-}
-
-func mapCurrencyToProto(currency string) commonpb.Currency {
-	switch currency {
-	case currencyGBP:
-		return commonpb.Currency_CURRENCY_GBP
-	case currencyUSD:
-		return commonpb.Currency_CURRENCY_USD
-	case currencyEUR:
-		return commonpb.Currency_CURRENCY_EUR
-	default:
-		return commonpb.Currency_CURRENCY_UNSPECIFIED
 	}
 }
 

--- a/services/current-account/service/grpc_service_party_integration_test.go
+++ b/services/current-account/service/grpc_service_party_integration_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/google/uuid"
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 
-	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
@@ -167,9 +166,9 @@ func setupPartyIntegrationTestDB(t *testing.T) (*gorm.DB, context.Context, func(
 
 func createInitiateAccountRequest(partyID, iban string) *pb.InitiateCurrentAccountRequest {
 	return &pb.InitiateCurrentAccountRequest{
-		AccountIdentification: iban,
-		PartyId:               partyID,
-		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+		ExternalIdentifier: iban,
+		PartyId:            partyID,
+		InstrumentCode:     "GBP",
 	}
 }
 
@@ -218,7 +217,7 @@ func TestInitiateCurrentAccount_WithPartyValidation_Success(t *testing.T) {
 	assert.NotNil(t, resp)
 	assert.NotEmpty(t, resp.AccountId)
 	assert.NotNil(t, resp.Facility)
-	assert.Equal(t, commonpb.Currency_CURRENCY_GBP, resp.Facility.BaseCurrency)
+	assert.Equal(t, "GBP", resp.Facility.InstrumentCode)
 
 	// Verify party validation was called
 	assert.Equal(t, 1, mockParty.validateCalls, "Party validation should be called once")
@@ -455,9 +454,9 @@ func TestInitiateCurrentAccount_ConcurrentCreationSameParty(t *testing.T) {
 	for i := 0; i < numAccounts; i++ {
 		go func(idx int) {
 			req := &pb.InitiateCurrentAccountRequest{
-				AccountIdentification: "GB82WEST1234569876543" + string(rune('0'+idx)),
-				PartyId:               partyID,
-				BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+				ExternalIdentifier: "GB82WEST1234569876543" + string(rune('0'+idx)),
+				PartyId:            partyID,
+				InstrumentCode:     "GBP",
 			}
 			_, err := svc.InitiateCurrentAccount(ctx, req)
 			results <- err

--- a/services/current-account/service/grpc_service_product_type_test.go
+++ b/services/current-account/service/grpc_service_product_type_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/lib/pq"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 
-	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
@@ -163,10 +162,10 @@ func TestInitiateCurrentAccount_WithProductType_Success(t *testing.T) {
 	}
 
 	req := &pb.InitiateCurrentAccountRequest{
-		AccountIdentification: "GB82WEST12345698765432",
-		PartyId:               newTestPartyID(),
-		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
-		ProductTypeCode:       "CURRENT_GBP",
+		ExternalIdentifier: "GB82WEST12345698765432",
+		PartyId:            newTestPartyID(),
+		InstrumentCode:     "GBP",
+		ProductTypeCode:    "CURRENT_GBP",
 	}
 	resp, err := svc.InitiateCurrentAccount(ctx, req)
 
@@ -207,11 +206,11 @@ func TestInitiateCurrentAccount_WithProductType_VersionOverride(t *testing.T) {
 
 	requestedVersion := int32(2)
 	req := &pb.InitiateCurrentAccountRequest{
-		AccountIdentification: "GB82WEST12345698765432",
-		PartyId:               newTestPartyID(),
-		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
-		ProductTypeCode:       "CURRENT_GBP",
-		ProductTypeVersion:    &requestedVersion,
+		ExternalIdentifier: "GB82WEST12345698765432",
+		PartyId:            newTestPartyID(),
+		InstrumentCode:     "GBP",
+		ProductTypeCode:    "CURRENT_GBP",
+		ProductTypeVersion: &requestedVersion,
 	}
 	resp, err := svc.InitiateCurrentAccount(ctx, req)
 
@@ -244,10 +243,10 @@ func TestInitiateCurrentAccount_WithProductType_NotFound(t *testing.T) {
 	}
 
 	req := &pb.InitiateCurrentAccountRequest{
-		AccountIdentification: "GB82WEST12345698765432",
-		PartyId:               newTestPartyID(),
-		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
-		ProductTypeCode:       "NONEXISTENT",
+		ExternalIdentifier: "GB82WEST12345698765432",
+		PartyId:            newTestPartyID(),
+		InstrumentCode:     "GBP",
+		ProductTypeCode:    "NONEXISTENT",
 	}
 	resp, err := svc.InitiateCurrentAccount(ctx, req)
 
@@ -299,10 +298,10 @@ func TestInitiateCurrentAccount_WithProductType_NonCustomerBehaviorClass(t *test
 			}
 
 			req := &pb.InitiateCurrentAccountRequest{
-				AccountIdentification: "GB82WEST12345698765432",
-				PartyId:               newTestPartyID(),
-				BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
-				ProductTypeCode:       "INTERNAL_" + tt.name,
+				ExternalIdentifier: "GB82WEST12345698765432",
+				PartyId:            newTestPartyID(),
+				InstrumentCode:     "GBP",
+				ProductTypeCode:    "INTERNAL_" + tt.name,
 			}
 			resp, err := svc.InitiateCurrentAccount(ctx, req)
 
@@ -355,10 +354,10 @@ func TestInitiateCurrentAccount_WithProductType_CELEligibility(t *testing.T) {
 		}
 
 		req := &pb.InitiateCurrentAccountRequest{
-			AccountIdentification: "GB82WEST12345698765432",
-			PartyId:               newTestPartyID(),
-			BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
-			ProductTypeCode:       "PERSONAL_CURRENT",
+			ExternalIdentifier: "GB82WEST12345698765432",
+			PartyId:            newTestPartyID(),
+			InstrumentCode:     "GBP",
+			ProductTypeCode:    "PERSONAL_CURRENT",
 		}
 		resp, err := svc.InitiateCurrentAccount(ctx, req)
 
@@ -402,10 +401,10 @@ func TestInitiateCurrentAccount_WithProductType_CELEligibility(t *testing.T) {
 		}
 
 		req := &pb.InitiateCurrentAccountRequest{
-			AccountIdentification: "GB82WEST12345698765432",
-			PartyId:               newTestPartyID(),
-			BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
-			ProductTypeCode:       "PERSONAL_CURRENT",
+			ExternalIdentifier: "GB82WEST12345698765432",
+			PartyId:            newTestPartyID(),
+			InstrumentCode:     "GBP",
+			ProductTypeCode:    "PERSONAL_CURRENT",
 		}
 		resp, err := svc.InitiateCurrentAccount(ctx, req)
 
@@ -448,10 +447,10 @@ func TestInitiateCurrentAccount_WithProductType_EligibilityRequiresPartyClient(t
 	}
 
 	req := &pb.InitiateCurrentAccountRequest{
-		AccountIdentification: "GB82WEST12345698765432",
-		PartyId:               newTestPartyID(),
-		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
-		ProductTypeCode:       "PERSONAL_CURRENT",
+		ExternalIdentifier: "GB82WEST12345698765432",
+		PartyId:            newTestPartyID(),
+		InstrumentCode:     "GBP",
+		ProductTypeCode:    "PERSONAL_CURRENT",
 	}
 	resp, err := svc.InitiateCurrentAccount(ctx, req)
 
@@ -493,11 +492,11 @@ func TestInitiateCurrentAccount_WithProductType_VersionExceedsLatest(t *testing.
 
 	requestedVersion := int32(5) // higher than latest version 3
 	req := &pb.InitiateCurrentAccountRequest{
-		AccountIdentification: "GB82WEST12345698765432",
-		PartyId:               newTestPartyID(),
-		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
-		ProductTypeCode:       "CURRENT_GBP",
-		ProductTypeVersion:    &requestedVersion,
+		ExternalIdentifier: "GB82WEST12345698765432",
+		PartyId:            newTestPartyID(),
+		InstrumentCode:     "GBP",
+		ProductTypeCode:    "CURRENT_GBP",
+		ProductTypeVersion: &requestedVersion,
 	}
 	resp, err := svc.InitiateCurrentAccount(ctx, req)
 
@@ -555,11 +554,11 @@ func TestInitiateCurrentAccount_WithProductType_AttributeValidation(t *testing.T
 		}
 
 		req := &pb.InitiateCurrentAccountRequest{
-			AccountIdentification: "GB82WEST12345698765432",
-			PartyId:               newTestPartyID(),
-			BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
-			ProductTypeCode:       "RISK_CURRENT",
-			Attributes:            map[string]string{"risk_level": "LOW"},
+			ExternalIdentifier: "GB82WEST12345698765432",
+			PartyId:            newTestPartyID(),
+			InstrumentCode:     "GBP",
+			ProductTypeCode:    "RISK_CURRENT",
+			Attributes:         map[string]string{"risk_level": "LOW"},
 		}
 		resp, err := svc.InitiateCurrentAccount(ctx, req)
 
@@ -599,11 +598,11 @@ func TestInitiateCurrentAccount_WithProductType_AttributeValidation(t *testing.T
 		}
 
 		req := &pb.InitiateCurrentAccountRequest{
-			AccountIdentification: "GB82WEST12345698765432",
-			PartyId:               newTestPartyID(),
-			BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
-			ProductTypeCode:       "RISK_CURRENT",
-			Attributes:            map[string]string{"risk_level": "EXTREME"}, // Invalid enum value
+			ExternalIdentifier: "GB82WEST12345698765432",
+			PartyId:            newTestPartyID(),
+			InstrumentCode:     "GBP",
+			ProductTypeCode:    "RISK_CURRENT",
+			Attributes:         map[string]string{"risk_level": "EXTREME"}, // Invalid enum value
 		}
 		resp, err := svc.InitiateCurrentAccount(ctx, req)
 
@@ -647,11 +646,11 @@ func TestInitiateCurrentAccount_WithProductType_AttributeValidation(t *testing.T
 		}
 
 		req := &pb.InitiateCurrentAccountRequest{
-			AccountIdentification: "GB82WEST12345698765432",
-			PartyId:               newTestPartyID(),
-			BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
-			ProductTypeCode:       "RISK_CURRENT",
-			Attributes:            map[string]string{}, // Missing required risk_level
+			ExternalIdentifier: "GB82WEST12345698765432",
+			PartyId:            newTestPartyID(),
+			InstrumentCode:     "GBP",
+			ProductTypeCode:    "RISK_CURRENT",
+			Attributes:         map[string]string{}, // Missing required risk_level
 		}
 		resp, err := svc.InitiateCurrentAccount(ctx, req)
 
@@ -715,10 +714,10 @@ func TestInitiateCurrentAccount_WithProductType_ValuationFeatureSeeding(t *testi
 	}
 
 	req := &pb.InitiateCurrentAccountRequest{
-		AccountIdentification: "GB82WEST12345698765432",
-		PartyId:               newTestPartyID(),
-		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
-		ProductTypeCode:       "MULTI_CCY_CURRENT",
+		ExternalIdentifier: "GB82WEST12345698765432",
+		PartyId:            newTestPartyID(),
+		InstrumentCode:     "GBP",
+		ProductTypeCode:    "MULTI_CCY_CURRENT",
 	}
 	resp, err := svc.InitiateCurrentAccount(ctx, req)
 
@@ -770,9 +769,9 @@ func TestInitiateCurrentAccount_BackwardsCompatibility(t *testing.T) {
 
 	// No product_type_code - legacy behavior
 	req := &pb.InitiateCurrentAccountRequest{
-		AccountIdentification: "GB82WEST12345698765432",
-		PartyId:               newTestPartyID(),
-		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+		ExternalIdentifier: "GB82WEST12345698765432",
+		PartyId:            newTestPartyID(),
+		InstrumentCode:     "GBP",
 	}
 	resp, err := svc.InitiateCurrentAccount(ctx, req)
 
@@ -805,10 +804,10 @@ func TestInitiateCurrentAccount_WithProductType_NoCacheConfigured(t *testing.T) 
 	}
 
 	req := &pb.InitiateCurrentAccountRequest{
-		AccountIdentification: "GB82WEST12345698765432",
-		PartyId:               newTestPartyID(),
-		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
-		ProductTypeCode:       "CURRENT_GBP", // Provided but will be ignored
+		ExternalIdentifier: "GB82WEST12345698765432",
+		PartyId:            newTestPartyID(),
+		InstrumentCode:     "GBP",
+		ProductTypeCode:    "CURRENT_GBP", // Provided but will be ignored
 	}
 	resp, err := svc.InitiateCurrentAccount(ctx, req)
 
@@ -840,10 +839,10 @@ func TestInitiateCurrentAccount_WithProductType_MissingTenantContext(t *testing.
 	}
 
 	req := &pb.InitiateCurrentAccountRequest{
-		AccountIdentification: "GB82WEST12345698765432",
-		PartyId:               newTestPartyID(),
-		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
-		ProductTypeCode:       "CURRENT_GBP",
+		ExternalIdentifier: "GB82WEST12345698765432",
+		PartyId:            newTestPartyID(),
+		InstrumentCode:     "GBP",
+		ProductTypeCode:    "CURRENT_GBP",
 	}
 	resp, err := svc.InitiateCurrentAccount(ctx, req)
 
@@ -880,10 +879,10 @@ func TestInitiateCurrentAccount_WithProductType_CacheError(t *testing.T) {
 	}
 
 	req := &pb.InitiateCurrentAccountRequest{
-		AccountIdentification: "GB82WEST12345698765432",
-		PartyId:               newTestPartyID(),
-		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
-		ProductTypeCode:       "CURRENT_GBP",
+		ExternalIdentifier: "GB82WEST12345698765432",
+		PartyId:            newTestPartyID(),
+		InstrumentCode:     "GBP",
+		ProductTypeCode:    "CURRENT_GBP",
 	}
 	resp, err := svc.InitiateCurrentAccount(ctx, req)
 

--- a/services/current-account/service/grpc_service_test.go
+++ b/services/current-account/service/grpc_service_test.go
@@ -348,9 +348,9 @@ func TestInitiateCurrentAccount(t *testing.T) {
 	svc := mustNewService(t, repo, nil)
 
 	req := &pb.InitiateCurrentAccountRequest{
-		AccountIdentification: "GB82WEST12345698765432",
-		PartyId:               uuid.New().String(),
-		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+		ExternalIdentifier: "GB82WEST12345698765432",
+		PartyId:            uuid.New().String(),
+		InstrumentCode:     "GBP",
 	}
 
 	resp, err := svc.InitiateCurrentAccount(ctx, req)
@@ -366,8 +366,8 @@ func TestInitiateCurrentAccount(t *testing.T) {
 		t.Fatal("Expected facility in response")
 	}
 
-	if resp.Facility.AccountIdentification != req.AccountIdentification {
-		t.Errorf("Expected IBAN %s, got %s", req.AccountIdentification, resp.Facility.AccountIdentification)
+	if resp.Facility.ExternalIdentifier != req.ExternalIdentifier {
+		t.Errorf("Expected external identifier %s, got %s", req.ExternalIdentifier, resp.Facility.ExternalIdentifier)
 	}
 
 	if resp.Facility.AccountStatus != pb.AccountStatus_ACCOUNT_STATUS_ACTIVE {
@@ -659,14 +659,14 @@ func TestInitiateCurrentAccountUnsupportedCurrency(t *testing.T) {
 	svc := mustNewService(t, repo, nil)
 
 	req := &pb.InitiateCurrentAccountRequest{
-		AccountIdentification: "GB82WEST12345698765432",
-		PartyId:               uuid.New().String(),
-		BaseCurrency:          commonpb.Currency_CURRENCY_JPY,
+		ExternalIdentifier: "GB82WEST12345698765432",
+		PartyId:            uuid.New().String(),
+		InstrumentCode:     "",
 	}
 
 	_, err := svc.InitiateCurrentAccount(ctx, req)
 	if err == nil {
-		t.Fatal("Expected error for unsupported currency")
+		t.Fatal("Expected error for missing instrument code")
 	}
 
 	st, ok := status.FromError(err)
@@ -1220,7 +1220,7 @@ func TestListCurrentAccounts(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Len(t, resp.Accounts, 1)
-		require.Equal(t, "GB82WEST12345698765432", resp.Accounts[0].AccountIdentification)
+		require.Equal(t, "GB82WEST12345698765432", resp.Accounts[0].ExternalIdentifier)
 	})
 
 	t.Run("paginates results", func(t *testing.T) {

--- a/utilities/horizon-demo/preflight.go
+++ b/utilities/horizon-demo/preflight.go
@@ -98,9 +98,9 @@ func RunPreFlight(ctx context.Context, clients *Clients, cfg *PreFlightConfig) (
 
 	// Step 2: Create the test account
 	createResp, err := clients.CurrentAccount.InitiateCurrentAccount(ctx, &currentaccountv1.InitiateCurrentAccountRequest{
-		PartyId:               accountID, // Use account ID as party ID for demo
-		AccountIdentification: iban,
-		BaseCurrency:          commonv1.Currency_CURRENCY_GBP,
+		PartyId:            accountID, // Use account ID as party ID for demo
+		ExternalIdentifier: iban,
+		InstrumentCode:     "GBP",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrAccountCreationFailed, err)

--- a/utilities/horizon-demo/preflight_test.go
+++ b/utilities/horizon-demo/preflight_test.go
@@ -500,8 +500,8 @@ func TestRunPreFlight_BalanceMismatch(t *testing.T) {
 func TestRunPreFlight_DefaultConfig(t *testing.T) {
 	mockClient := &mockCurrentAccountClient{
 		initiateFunc: func(_ context.Context, req *currentaccountv1.InitiateCurrentAccountRequest) (*currentaccountv1.InitiateCurrentAccountResponse, error) {
-			// Verify GBP currency is used
-			assert.Equal(t, commonv1.Currency_CURRENCY_GBP, req.GetBaseCurrency())
+			// Verify GBP instrument code is used
+			assert.Equal(t, "GBP", req.GetInstrumentCode())
 			return &currentaccountv1.InitiateCurrentAccountResponse{
 				AccountId: "test-account",
 				Facility:  &currentaccountv1.CurrentAccountFacility{},


### PR DESCRIPTION
## Summary

- Replace `base_currency` (Currency enum) with `instrument_code` (string) in `CurrentAccountFacility` and `InitiateCurrentAccountRequest` to support any instrument code (GBP, kWh, GPU_HOUR, etc.)
- Rename `account_identification` to `external_identifier` in both messages; remove IBAN-only pattern validation and widen `max_len` from 34 to 255 to support product-type-specific identifier formats with a comment noting format is validated by product type CEL rules
- Remove `overdraft_limit` field (field 9) from `CurrentAccountFacility` with a `reserved` declaration; mark `OverdraftConfiguration` message as `deprecated = true`
- Add `dimension` field (field 14) to `CurrentAccountFacility` for instrument classification (CURRENCY, ENERGY, COMPUTE, CARBON, etc.)

## Changes Made

### Proto (`api/proto/meridian/current_account/v1/current_account.proto`)
- `CurrentAccountFacility`: replaced `base_currency` (field 4, enum) with `instrument_code` (field 4, string, pattern `^[A-Z][A-Z0-9_]*$`); renamed `account_identification` (field 2) to `external_identifier` with widened validation; reserved field 9 (`overdraft_limit`); added `dimension` (field 14)
- `InitiateCurrentAccountRequest`: replaced `base_currency` (field 3) with `instrument_code`; renamed `account_identification` (field 2) to `external_identifier`
- `OverdraftConfiguration`: marked `option deprecated = true`

### Go Service Layer
- `grpc_mappers.go`: updated `toProtoFacility` to use `ExternalIdentifier` and `InstrumentCode`; removed `OverdraftLimit` struct from facility; removed unused `mapCurrencyToProto` function
- `grpc_account_endpoints.go`: replaced `mapCurrency(req.BaseCurrency)` with direct `req.InstrumentCode`; replaced `req.AccountIdentification` with `req.ExternalIdentifier`

### Test Files and Utilities
- Updated all compile errors in `grpc_service_test.go`, `grpc_service_party_integration_test.go`, `grpc_service_product_type_test.go`, `preflight.go`, and `preflight_test.go`

## Task Reference

asset-agnostic-accounts.3 — Update Current Account proto definitions for asset-agnostic fields

## Test Plan

- [ ] `buf lint` passes (verified in pre-commit hook)
- [ ] No breaking proto changes (verified in pre-commit hook)
- [ ] `go build ./...` passes across entire monorepo
- [ ] `golangci-lint` passes (verified in pre-commit hook)
- [ ] CI passes end-to-end