### PR TITLE
fix: use superuser DSN for applying migrations

### DIFF
--- a/internal/migrations/driver_test.go
+++ b/internal/migrations/driver_test.go
@@ -1,10 +1,13 @@
 package migrations_test
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/meridianhub/meridian/internal/migrations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDriverFromEnv(t *testing.T) {
@@ -117,4 +120,102 @@ func TestBuildServiceDSN_DatabaseAndUser(t *testing.T) {
 	if !strings.Contains(got, "simple_protocol") {
 		t.Errorf("expected simple_protocol query param in DSN, got %q", got)
 	}
+}
+
+func TestBuildSuperuserDSN_PreservesCredentials(t *testing.T) {
+	tests := []struct {
+		name     string
+		superDSN string
+		dbName   string
+		driver   migrations.Driver
+		wantUser string
+		wantPass string
+		wantDB   string
+		wantPort string
+	}{
+		{
+			name:     "CockroachDB preserves root credentials",
+			superDSN: "postgres://root:secretpass@localhost:26257/defaultdb?sslmode=disable",
+			dbName:   "meridian_tenant",
+			driver:   migrations.DriverCockroachDB,
+			wantUser: "root",
+			wantPass: "secretpass",
+			wantDB:   "meridian_tenant",
+			wantPort: "26257",
+		},
+		{
+			name:     "PostgreSQL preserves postgres credentials",
+			superDSN: "postgres://postgres:pgpass@db.example.com:5432/postgres",
+			dbName:   "meridian_party",
+			driver:   migrations.DriverPostgres,
+			wantUser: "postgres",
+			wantPass: "pgpass",
+			wantDB:   "meridian_party",
+			wantPort: "5432",
+		},
+		{
+			name:     "adds default CockroachDB port when missing",
+			superDSN: "postgres://root@localhost/defaultdb",
+			dbName:   "meridian_platform",
+			driver:   migrations.DriverCockroachDB,
+			wantUser: "root",
+			wantDB:   "meridian_platform",
+			wantPort: "26257",
+		},
+		{
+			name:     "adds default PostgreSQL port when missing",
+			superDSN: "postgres://postgres:pass@localhost/postgres",
+			dbName:   "meridian_current_account",
+			driver:   migrations.DriverPostgres,
+			wantUser: "postgres",
+			wantPass: "pass",
+			wantDB:   "meridian_current_account",
+			wantPort: "5432",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := migrations.BuildSuperuserDSN(tt.superDSN, tt.dbName, tt.driver)
+
+			parsed, err := url.Parse(result)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantUser, parsed.User.Username(), "user mismatch")
+			if tt.wantPass != "" {
+				pass, _ := parsed.User.Password()
+				assert.Equal(t, tt.wantPass, pass, "password mismatch")
+			}
+			assert.Equal(t, "/"+tt.wantDB, parsed.Path, "database mismatch")
+			assert.Equal(t, tt.wantPort, parsed.Port(), "port mismatch")
+			assert.Equal(t, "simple_protocol", parsed.Query().Get("default_query_exec_mode"))
+		})
+	}
+}
+
+func TestBuildSuperuserDSN_DiffersFromServiceDSN(t *testing.T) {
+	superDSN := "postgres://postgres:secretpass@localhost:5432/postgres"
+	sdb := migrations.ServiceDatabase{
+		Database: "meridian_party",
+		User:     "meridian_party_user",
+		Password: "",
+	}
+
+	serviceDSN := migrations.BuildServiceDSN(superDSN, sdb, migrations.DriverPostgres)
+	superuserTargetDSN := migrations.BuildSuperuserDSN(superDSN, "meridian_party", migrations.DriverPostgres)
+
+	// Service DSN uses service user (passwordless).
+	serviceParsed, err := url.Parse(serviceDSN)
+	require.NoError(t, err)
+	assert.Equal(t, "meridian_party_user", serviceParsed.User.Username())
+	_, hasPass := serviceParsed.User.Password()
+	assert.False(t, hasPass, "service DSN should not have password")
+
+	// Superuser DSN preserves superuser credentials.
+	superParsed, err := url.Parse(superuserTargetDSN)
+	require.NoError(t, err)
+	assert.Equal(t, "postgres", superParsed.User.Username())
+	pass, hasPass := superParsed.User.Password()
+	assert.True(t, hasPass, "superuser DSN should preserve password")
+	assert.Equal(t, "secretpass", pass)
 }

--- a/internal/migrations/export_test.go
+++ b/internal/migrations/export_test.go
@@ -5,3 +5,8 @@ package migrations
 func BuildServiceDSN(superuserDSN string, sdb ServiceDatabase, driver Driver) string {
 	return buildServiceDSN(superuserDSN, sdb, driver)
 }
+
+// BuildSuperuserDSN is the exported test alias for buildSuperuserDSN.
+func BuildSuperuserDSN(superuserDSN string, dbName string, driver Driver) string {
+	return buildSuperuserDSN(superuserDSN, dbName, driver)
+}

--- a/internal/migrations/runner.go
+++ b/internal/migrations/runner.go
@@ -135,10 +135,11 @@ func runMigrations(ctx context.Context, migrationFS fs.FS, superuserDSN string, 
 	// Group migrations by target database.
 	byDB := groupByDatabase(migrations)
 
-	// Apply migrations to each database.
+	// Apply migrations to each database using superuser credentials.
+	// Service users may not have password-based auth configured (scram-sha-256),
+	// so we preserve the superuser credentials and only change the database name.
 	for dbName, dbMigrations := range byDB {
-		sdb := dbMigrations[0].sdb
-		dsn := buildServiceDSN(superuserDSN, sdb, driver)
+		dsn := buildSuperuserDSN(superuserDSN, dbName, driver)
 
 		if err := applyDatabaseMigrations(ctx, dsn, dbName, dbMigrations, driver, logger); err != nil {
 			return fmt.Errorf("apply migrations to %s: %w", dbName, err)
@@ -482,6 +483,39 @@ func buildServiceDSN(superuserDSN string, sdb ServiceDatabase, driver Driver) st
 
 	// Replace database in path (postgres://user@host:port/database).
 	parsed.Path = "/" + sdb.Database
+
+	// Ensure default port if not specified.
+	if parsed.Port() == "" {
+		defaultPort := "26257"
+		if driver == DriverPostgres {
+			defaultPort = "5432"
+		}
+		parsed.Host = parsed.Hostname() + ":" + defaultPort
+	}
+
+	// Enable simple protocol so multi-statement migration SQL files work with pgx v5.
+	q := parsed.Query()
+	if q.Get("default_query_exec_mode") == "" {
+		q.Set("default_query_exec_mode", "simple_protocol")
+	}
+	parsed.RawQuery = q.Encode()
+
+	return parsed.String()
+}
+
+// buildSuperuserDSN modifies a superuser DSN to target a specific database while
+// preserving the superuser credentials. This is used for applying migrations where
+// the service user may not have password-based authentication configured.
+//
+// The default port is 26257 for CockroachDB and 5432 for PostgreSQL.
+func buildSuperuserDSN(superuserDSN string, dbName string, driver Driver) string {
+	parsed, err := url.Parse(superuserDSN)
+	if err != nil {
+		return superuserDSN
+	}
+
+	// Preserve superuser credentials, only replace database.
+	parsed.Path = "/" + dbName
 
 	// Ensure default port if not specified.
 	if parsed.Port() == "" {

--- a/internal/migrations/runner_postgres_test.go
+++ b/internal/migrations/runner_postgres_test.go
@@ -135,7 +135,7 @@ func TestRunMigrations_Postgres_ScramAuth(t *testing.T) {
 
 	t.Setenv("DB_DRIVER", "postgres")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 
 	// Start PostgreSQL WITHOUT trust auth (uses default scram-sha-256).

--- a/internal/migrations/runner_postgres_test.go
+++ b/internal/migrations/runner_postgres_test.go
@@ -128,6 +128,70 @@ func TestRunMigrations_Postgres(t *testing.T) {
 	}
 }
 
+func TestRunMigrations_Postgres_ScramAuth(t *testing.T) {
+	if os.Getenv("CI") == "" && testing.Short() {
+		t.Skip("skipping integration test; use -short=false or set CI=true")
+	}
+
+	t.Setenv("DB_DRIVER", "postgres")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	// Start PostgreSQL WITHOUT trust auth (uses default scram-sha-256).
+	// This simulates production where service users have no passwords.
+	container, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("defaultdb"),
+		tcpostgres.WithUsername("postgres"),
+		tcpostgres.WithPassword("secretpassword"),
+		// NO POSTGRES_HOST_AUTH_METHOD=trust - uses default scram-sha-256
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(90*time.Second)),
+	)
+	if err != nil {
+		t.Fatalf("start PostgreSQL container: %v", err)
+	}
+	defer func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		_ = container.Terminate(cleanupCtx)
+	}()
+
+	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("get PostgreSQL connection string: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	testFS := testMigrationFS()
+
+	// This should succeed using superuser credentials for migrations.
+	err = migrations.RunMigrations(ctx, testFS, connStr, logger)
+	if err != nil {
+		t.Fatalf("migrations should succeed with scram-sha-256 auth: %v", err)
+	}
+
+	// Verify migrations were applied.
+	caDSN := replaceDSNDatabasePG(t, connStr, "meridian_current_account")
+	caConn, err := pgx.Connect(ctx, caDSN+"&default_query_exec_mode=simple_protocol")
+	if err != nil {
+		t.Fatalf("connect to meridian_current_account: %v", err)
+	}
+	defer caConn.Close(ctx)
+
+	var count int
+	err = caConn.QueryRow(ctx, `SELECT count(*) FROM _meridian_migrations`).Scan(&count)
+	if err != nil {
+		t.Fatalf("count migrations: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 migrations recorded, got %d", count)
+	}
+}
+
 func TestRunMigrations_Postgres_Idempotent(t *testing.T) {
 	if os.Getenv("CI") == "" && testing.Short() {
 		t.Skip("skipping integration test; use -short=false or set CI=true")


### PR DESCRIPTION
## Summary

- Fix scram-sha-256 authentication failures in the migration runner by using superuser credentials instead of passwordless per-service users when applying migrations
- Add `buildSuperuserDSN` function that preserves superuser credentials while targeting specific databases
- Per-service users remain for future RBAC enforcement

## Technical Details

In `runMigrations`, the loop was calling `buildServiceDSN` which replaced superuser credentials with per-service user credentials (empty passwords). PostgreSQL with scram-sha-256 rejects passwordless remote connections.

The fix introduces `buildSuperuserDSN` that only changes the database name in the DSN while preserving the original superuser credentials. This mirrors the existing pattern in `grantPostgresSchemaPrivileges`.

## Test plan

- [x] Unit tests for `buildSuperuserDSN` credential preservation (CockroachDB + PostgreSQL)
- [x] Unit test contrasting `buildSuperuserDSN` vs `buildServiceDSN` behavior
- [x] Integration test: PostgreSQL with scram-sha-256 auth (no trust mode)
- [x] All existing CockroachDB integration tests pass (no regression)
- [x] All existing PostgreSQL integration tests pass (no regression)

Closes #1214