### PR TITLE
fix: align current account persistence layer with instrument_code/dimension schema

### DIFF
--- a/services/current-account/adapters/persistence/org_scoped_account_test.go
+++ b/services/current-account/adapters/persistence/org_scoped_account_test.go
@@ -26,8 +26,8 @@ func setupOrgScopedTestDB(t *testing.T) (*gorm.DB, *Repository, context.Context,
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	// Create the accounts table in tenant schema with org_party_id column
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.accounts (
+	// Create the account table in tenant schema (matches CurrentAccountEntity.TableName() = "account")
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.account (
 		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 		account_id VARCHAR(100) NOT NULL UNIQUE,
 		account_identification VARCHAR(34) NOT NULL UNIQUE,
@@ -37,11 +37,10 @@ func setupOrgScopedTestDB(t *testing.T) (*gorm.DB, *Repository, context.Context,
 		status VARCHAR(20) NOT NULL DEFAULT 'active',
 		party_id UUID NOT NULL,
 		org_party_id UUID NULL,
-		balance BIGINT NOT NULL DEFAULT 0,
-		available_balance BIGINT NOT NULL DEFAULT 0,
 		overdraft_limit BIGINT NOT NULL DEFAULT 0,
 		overdraft_rate NUMERIC(5,4) NOT NULL DEFAULT 0,
-		balance_updated_at TIMESTAMP WITH TIME ZONE,
+		product_type_code VARCHAR(50) NULL,
+		product_type_version INT NULL,
 		opened_at TIMESTAMP WITH TIME ZONE,
 		closed_at TIMESTAMP WITH TIME ZONE,
 		freeze_reason VARCHAR(1000),

--- a/services/current-account/adapters/persistence/repository.go
+++ b/services/current-account/adapters/persistence/repository.go
@@ -221,14 +221,12 @@ func (r *Repository) Save(ctx context.Context, account domain.CurrentAccount) er
 			updateResult := tx.Model(&CurrentAccountEntity{}).
 				Where("account_identification = ? AND version = ?", entity.AccountIdentification, originalVersion).
 				Updates(map[string]interface{}{
-					"status":          entity.Status,
-					"freeze_reason":   entity.FreezeReason,
-					"status_history":  entity.StatusHistory,
-					"overdraft_limit": entity.OverdraftLimit,
-					"overdraft_rate":  entity.OverdraftRate,
-					"version":         entity.Version,
-					"updated_at":      entity.UpdatedAt,
-					"updated_by":      entity.UpdatedBy,
+					"status":         entity.Status,
+					"freeze_reason":  entity.FreezeReason,
+					"status_history": entity.StatusHistory,
+					"version":        entity.Version,
+					"updated_at":     entity.UpdatedAt,
+					"updated_by":     entity.UpdatedBy,
 				})
 
 			if updateResult.Error != nil {

--- a/services/current-account/adapters/persistence/repository_test.go
+++ b/services/current-account/adapters/persistence/repository_test.go
@@ -32,8 +32,8 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	// Create the accounts table in the tenant schema (matching CurrentAccountEntity.TableName())
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.accounts (
+	// Create the account table in the tenant schema (matches CurrentAccountEntity.TableName() = "account")
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.account (
 		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 		account_id VARCHAR(100) NOT NULL UNIQUE,
 		account_identification VARCHAR(34) NOT NULL UNIQUE,
@@ -43,11 +43,10 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		status VARCHAR(20) NOT NULL DEFAULT 'active',
 		party_id UUID NOT NULL,
 		org_party_id UUID NULL,
-		balance BIGINT NOT NULL DEFAULT 0,
-		available_balance BIGINT NOT NULL DEFAULT 0,
 		overdraft_limit BIGINT NOT NULL DEFAULT 0,
 		overdraft_rate NUMERIC(5,4) NOT NULL DEFAULT 0,
-		balance_updated_at TIMESTAMP WITH TIME ZONE,
+		product_type_code VARCHAR(50) NULL,
+		product_type_version INT NULL,
 		opened_at TIMESTAMP WITH TIME ZONE,
 		closed_at TIMESTAMP WITH TIME ZONE,
 		freeze_reason VARCHAR(1000),
@@ -344,6 +343,52 @@ func TestOptimisticLocking(t *testing.T) {
 	}
 }
 
+func TestSave_InstrumentCodeAndDimensionRoundTrip(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	partyID := uuid.New().String()
+	accountID := "ACC-" + uuid.New().String()[:8]
+	iban := "GB82WEST12345698765432"
+
+	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "EUR")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	retrieved, err := repo.FindByID(ctx, accountID)
+	require.NoError(t, err)
+
+	assert.Equal(t, "EUR", retrieved.InstrumentCode(), "InstrumentCode should round-trip correctly")
+	assert.Equal(t, "CURRENCY", retrieved.Dimension(), "Dimension should round-trip correctly")
+}
+
+func TestSave_InstrumentCodePersistedOnEntity(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	partyID := uuid.New().String()
+	accountID := "ACC-" + uuid.New().String()[:8]
+	iban := "GB82WEST12345698765432"
+
+	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	// Read raw entity to verify column values in DB
+	var entity CurrentAccountEntity
+	err = db.Where("account_id = ?", accountID).First(&entity).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, "GBP", entity.InstrumentCode, "instrument_code column should be persisted")
+	assert.Equal(t, "CURRENCY", entity.Dimension, "dimension column should be persisted")
+}
+
 // Defensive tests for toDomain error handling per ADR-008
 
 func TestToDomain_InvalidCurrency_ReturnsError(t *testing.T) {
@@ -579,9 +624,9 @@ func TestSave_UpdatePreservesCreatedByButUpdatesUpdatedBy(t *testing.T) {
 // - Redis key prefixing per organization
 // - Kafka header propagation
 //
-// The entity now uses unqualified table name "accounts" which allows
+// The entity uses unqualified table name "account" which allows
 // PostgreSQL's search_path mechanism to route queries to organization-specific
-// schemas (e.g., org_acme_bank.accounts, org_motive_corp.accounts).
+// schemas (e.g., org_acme_bank.account, org_motive_corp.account).
 //
 // See: shared/platform/db/gorm_organization_scope.go for the implementation
 // See: shared/platform/db/gorm_organization_scope_test.go for unit tests


### PR DESCRIPTION
## Summary

Aligns the current account persistence layer with the schema changes introduced by task 1 (instrument_code/dimension columns) and task 2 (domain model refactoring).

## Changes Made

### `repository.go`
- Removed `overdraft_limit` and `overdraft_rate` from the `Save()` update map. Overdraft is now product-type behavior (not mutable domain state), so these fields should not be updated on account save. The entity struct retains these fields for schema compatibility, but the `toEntity()` mapper already sets them to zero.

### `repository_test.go`
- Fixed test DDL table name from `accounts` (plural) to `account` (singular) to match `CurrentAccountEntity.TableName()`. Tests were silently passing against the public schema's AutoMigrate-created table instead of the tenant schema table, masking isolation correctness.
- Added `product_type_code` and `product_type_version` columns to match the schema after migration `20260220000001`.
- Removed stale `balance`, `available_balance`, and `balance_updated_at` columns from test DDL to match the schema after migration `20260108000001_remove_balance_columns`.
- Added `TestSave_InstrumentCodeAndDimensionRoundTrip`: verifies `instrument_code` and `dimension` survive a save/retrieve cycle.
- Added `TestSave_InstrumentCodePersistedOnEntity`: verifies the raw DB entity has the correct column values.
- Fixed stale comment referencing `"accounts"` plural table name.

### `org_scoped_account_test.go`
- Same DDL fixes as `repository_test.go`: table name corrected to `account`, added product type columns, removed balance columns.

## Technical Details

The previous test DDLs created a table named `accounts` in the tenant schema, but GORM queries `account` (singular). When the search path resolved `<tenant>.accounts` (not found) → `public.account` (found via AutoMigrate), tests passed but were testing the wrong schema. This meant tenant isolation was not actually validated. The fix ensures queries hit the correctly named table in the tenant schema.

## Testing

All unit tests (`TestToDomain_*`, `TestToEntity_*`) pass immediately. Integration tests (testcontainer-based) validated individually:
- `TestSaveNewAccount` - PASS
- `TestSave_InstrumentCodeAndDimensionRoundTrip` - PASS  
- `TestSave_InstrumentCodePersistedOnEntity` - PASS
- `TestOrgScopedAccount_FindByScopedParty` - PASS

## Task Master Reference

asset-agnostic-accounts.5