### PR TITLE
test: remove stale current_accounts DDL from service test helpers

### DIFF
--- a/services/current-account/service/grpc_service_integration_test.go
+++ b/services/current-account/service/grpc_service_integration_test.go
@@ -438,22 +438,6 @@ func setupIntegrationTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	// Create the current_accounts table in the tenant schema
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.current_accounts (
-		id UUID PRIMARY KEY,
-		account_number VARCHAR(255) NOT NULL UNIQUE,
-		party_id UUID NOT NULL,
-		currency VARCHAR(3) NOT NULL,
-		balance_cents BIGINT NOT NULL DEFAULT 0,
-		status VARCHAR(20) NOT NULL,
-		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
-		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
-		version INT NOT NULL DEFAULT 1,
-		created_by VARCHAR(255),
-		updated_by VARCHAR(255)
-	)`, pq.QuoteIdentifier(schemaName))).Error
-	require.NoError(t, err)
-
 	// Set default search_path to include tenant schema
 	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)

--- a/services/current-account/service/grpc_service_party_integration_test.go
+++ b/services/current-account/service/grpc_service_party_integration_test.go
@@ -138,22 +138,6 @@ func setupPartyIntegrationTestDB(t *testing.T) (*gorm.DB, context.Context, func(
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	// Create the current_accounts table in the tenant schema
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.current_accounts (
-		id UUID PRIMARY KEY,
-		account_number VARCHAR(255) NOT NULL UNIQUE,
-		party_id UUID NOT NULL,
-		currency VARCHAR(3) NOT NULL,
-		balance_cents BIGINT NOT NULL DEFAULT 0,
-		status VARCHAR(20) NOT NULL,
-		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
-		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
-		version INT NOT NULL DEFAULT 1,
-		created_by VARCHAR(255),
-		updated_by VARCHAR(255)
-	)`, pq.QuoteIdentifier(schemaName))).Error
-	require.NoError(t, err)
-
 	// Set default search_path to include tenant schema
 	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)

--- a/services/current-account/service/grpc_service_test.go
+++ b/services/current-account/service/grpc_service_test.go
@@ -314,23 +314,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	// Create the current_accounts table in the tenant schema
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.current_accounts (
-		id UUID PRIMARY KEY,
-		account_number VARCHAR(255) NOT NULL UNIQUE,
-		party_id UUID NOT NULL,
-		currency VARCHAR(3) NOT NULL,
-		balance_cents BIGINT NOT NULL DEFAULT 0,
-		status VARCHAR(20) NOT NULL,
-		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
-		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
-		version INT NOT NULL DEFAULT 1,
-		created_by VARCHAR(255),
-		updated_by VARCHAR(255)
-	)`, pq.QuoteIdentifier(schemaName))).Error
-	require.NoError(t, err)
-
-	// Set default search_path to include tenant schema
+	// Set default search_path to include tenant schema so queries route to tenant-scoped tables
 	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 

--- a/services/current-account/service/lien_service_test.go
+++ b/services/current-account/service/lien_service_test.go
@@ -43,22 +43,6 @@ func setupLienTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	// Create the current_accounts table in the tenant schema
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.current_accounts (
-		id UUID PRIMARY KEY,
-		account_number VARCHAR(255) NOT NULL UNIQUE,
-		party_id UUID NOT NULL,
-		currency VARCHAR(3) NOT NULL,
-		balance_cents BIGINT NOT NULL DEFAULT 0,
-		status VARCHAR(20) NOT NULL,
-		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
-		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
-		version INT NOT NULL DEFAULT 1,
-		created_by VARCHAR(255),
-		updated_by VARCHAR(255)
-	)`, pq.QuoteIdentifier(schemaName))).Error
-	require.NoError(t, err)
-
 	// Create the lien table in the tenant schema
 	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.lien (
 		id UUID PRIMARY KEY,


### PR DESCRIPTION
## Summary

- Prior tasks (1, 2, 5, 6, 7) already updated all substantive test fixtures to use `instrument_code`/`dimension` instead of the old `currency` column
- This PR removes dead code: four service test setup functions contained a `CREATE TABLE current_accounts` DDL with the old `currency VARCHAR(3)` schema
- The `current_accounts` table was never used by these tests — the persistence layer uses the `account` table auto-migrated from `CurrentAccountEntity` (which already has `instrument_code`/`dimension`)

## Changes Made

- `services/current-account/service/grpc_service_test.go`: Remove stale `current_accounts` DDL from `setupTestDB`
- `services/current-account/service/grpc_service_integration_test.go`: Remove stale `current_accounts` DDL from integration test setup
- `services/current-account/service/grpc_service_party_integration_test.go`: Remove stale `current_accounts` DDL from party integration test setup
- `services/current-account/service/lien_service_test.go`: Remove stale `current_accounts` DDL from lien test setup

## Test plan

- [ ] All service package tests compile cleanly (`go vet` passes)
- [ ] Domain, config, observability, webhook tests pass without containers
- [ ] Internal account service tests pass
- [ ] Proto and integration test packages compile

## Technical Details

The test helpers called `testdb.SetupPostgres(t, []interface{}{&persistence.CurrentAccountEntity{}})` which already auto-migrates the correct `account` table schema (with `instrument_code`/`dimension`). The subsequent `CREATE TABLE current_accounts` with the old `currency` column was dead code that was never referenced by the actual test queries.

## Related

Part of asset-agnostic-accounts epic — task asset-agnostic-accounts.11.