### PR TITLE
feat: deprecate Currency enum and migrate to string instrument_code

### DIFF
--- a/api/proto/buf.yaml
+++ b/api/proto/buf.yaml
@@ -3,3 +3,47 @@ deps:
   - buf.build/bufbuild/protovalidate
   - buf.build/googleapis/googleapis
   - buf.build/grpc-ecosystem/grpc-gateway
+
+breaking:
+  # Intentional breaking changes for asset-agnostic-accounts epic:
+  # Replacing deprecated Currency enum fields with string instrument_code fields.
+  # These fields changed from enum to string type and were renamed to reflect
+  # the Universal Asset System (supporting currencies, energy, carbon credits, etc.).
+  # Ignoring specific rules to allow these deliberate proto evolution decisions.
+  ignore_only:
+    FIELD_SAME_JSON_NAME:
+      - meridian/events/v1/current_account_events.proto
+      - meridian/events/v1/deposit_event.proto
+      - meridian/events/v1/financial_accounting_events.proto
+      - meridian/events/v1/position_keeping_events.proto
+      - meridian/financial_accounting/v1/financial_accounting.proto
+    FIELD_SAME_TYPE:
+      - meridian/events/v1/current_account_events.proto
+      - meridian/events/v1/deposit_event.proto
+      - meridian/events/v1/financial_accounting_events.proto
+      - meridian/events/v1/position_keeping_events.proto
+      - meridian/financial_accounting/v1/financial_accounting.proto
+    FIELD_SAME_ONEOF:
+      - meridian/events/v1/current_account_events.proto
+      - meridian/events/v1/deposit_event.proto
+      - meridian/events/v1/financial_accounting_events.proto
+      - meridian/events/v1/position_keeping_events.proto
+      - meridian/financial_accounting/v1/financial_accounting.proto
+    FIELD_SAME_NAME:
+      - meridian/events/v1/current_account_events.proto
+      - meridian/events/v1/deposit_event.proto
+      - meridian/events/v1/financial_accounting_events.proto
+      - meridian/events/v1/position_keeping_events.proto
+      - meridian/financial_accounting/v1/financial_accounting.proto
+    FIELD_WIRE_COMPATIBLE_TYPE:
+      - meridian/events/v1/current_account_events.proto
+      - meridian/events/v1/deposit_event.proto
+      - meridian/events/v1/financial_accounting_events.proto
+      - meridian/events/v1/position_keeping_events.proto
+      - meridian/financial_accounting/v1/financial_accounting.proto
+    FIELD_WIRE_JSON_COMPATIBLE_TYPE:
+      - meridian/events/v1/current_account_events.proto
+      - meridian/events/v1/deposit_event.proto
+      - meridian/events/v1/financial_accounting_events.proto
+      - meridian/events/v1/position_keeping_events.proto
+      - meridian/financial_accounting/v1/financial_accounting.proto

--- a/api/proto/meridian/common/v1/types.proto
+++ b/api/proto/meridian/common/v1/types.proto
@@ -34,22 +34,37 @@ enum TransactionStatus {
 }
 
 // Currency defines ISO 4217 currency codes commonly used in banking.
+//
+// Deprecated: Use string instrument_code fields instead. This enum is retained
+// for backward compatibility with existing serialized messages and will be
+// removed in a future version. New fields should use string instrument_code
+// (e.g., "GBP", "USD", "EUR") which supports the Universal Asset System
+// for non-currency instruments such as energy (kWh) and carbon credits.
 enum Currency {
+  option deprecated = true;
+
   // CURRENCY_UNSPECIFIED means the currency is unknown.
   CURRENCY_UNSPECIFIED = 0;
   // CURRENCY_GBP is British Pound Sterling.
+  // Deprecated: Use instrument_code = "GBP" instead.
   CURRENCY_GBP = 1;
   // CURRENCY_USD is United States Dollar.
+  // Deprecated: Use instrument_code = "USD" instead.
   CURRENCY_USD = 2;
   // CURRENCY_EUR is Euro.
+  // Deprecated: Use instrument_code = "EUR" instead.
   CURRENCY_EUR = 3;
   // CURRENCY_JPY is Japanese Yen.
+  // Deprecated: Use instrument_code = "JPY" instead.
   CURRENCY_JPY = 4;
   // CURRENCY_CHF is Swiss Franc.
+  // Deprecated: Use instrument_code = "CHF" instead.
   CURRENCY_CHF = 5;
   // CURRENCY_CAD is Canadian Dollar.
+  // Deprecated: Use instrument_code = "CAD" instead.
   CURRENCY_CAD = 6;
   // CURRENCY_AUD is Australian Dollar.
+  // Deprecated: Use instrument_code = "AUD" instead.
   CURRENCY_AUD = 7;
 }
 

--- a/api/proto/meridian/events/v1/current_account_events.proto
+++ b/api/proto/meridian/events/v1/current_account_events.proto
@@ -31,10 +31,11 @@ message AccountCreatedEvent {
     max_len: 34  // IBAN max length
   }];
 
-  // base_currency is the account's base currency
-  meridian.common.v1.Currency base_currency = 4 [(buf.validate.field).enum = {
-    defined_only: true
-    not_in: [0]
+  // base_instrument_code is the account's base instrument code (e.g., "GBP", "USD").
+  // Replaces the deprecated base_currency enum field.
+  string base_instrument_code = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
   }];
 
   // account_status is the initial status (typically ACTIVE)

--- a/api/proto/meridian/events/v1/deposit_event.proto
+++ b/api/proto/meridian/events/v1/deposit_event.proto
@@ -4,7 +4,6 @@ package meridian.events.v1;
 
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
-import "meridian/common/v1/types.proto";
 
 option go_package = "github.com/meridianhub/meridian/api/proto/meridian/events/v1;eventsv1";
 
@@ -22,10 +21,11 @@ message DepositEvent {
   // amount_cents is the deposit amount in cents (or smallest currency unit)
   int64 amount_cents = 2 [(buf.validate.field).int64 = {gt: 0}];
 
-  // currency is the ISO 4217 currency code
-  meridian.common.v1.Currency currency = 3 [(buf.validate.field).enum = {
-    defined_only: true
-    not_in: [0]
+  // instrument_code is the ISO 4217 currency code or other instrument identifier (e.g., "GBP", "USD").
+  // Replaces the deprecated currency enum field.
+  string instrument_code = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
   }];
 
   // correlation_id links this event to the originating transaction

--- a/api/proto/meridian/events/v1/financial_accounting_events.proto
+++ b/api/proto/meridian/events/v1/financial_accounting_events.proto
@@ -34,10 +34,11 @@ message FinancialBookingLogInitiatedEvent {
     max_len: 255
   }];
 
-  // base_currency is the currency for this booking log
-  meridian.common.v1.Currency base_currency = 5 [(buf.validate.field).enum = {
-    defined_only: true
-    not_in: [0]
+  // base_instrument_code is the instrument code for this booking log (e.g., "GBP", "USD", "kWh").
+  // Replaces the deprecated base_currency enum field.
+  string base_instrument_code = 5 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
   }];
 
   // correlation_id links related events across services

--- a/api/proto/meridian/events/v1/financial_accounting_events_test.go
+++ b/api/proto/meridian/events/v1/financial_accounting_events_test.go
@@ -44,7 +44,7 @@ func TestFinancialBookingLogInitiatedEvent_Serialization(t *testing.T) {
 		t.Errorf("FinancialAccountType mismatch: got %v, want %v", decoded.FinancialAccountType, event.FinancialAccountType)
 	}
 	if decoded.BaseInstrumentCode != event.BaseInstrumentCode {
-		t.Errorf("BaseCurrency mismatch: got %v, want %v", decoded.BaseInstrumentCode, event.BaseInstrumentCode)
+		t.Errorf("BaseInstrumentCode mismatch: got %v, want %v", decoded.BaseInstrumentCode, event.BaseInstrumentCode)
 	}
 	if decoded.Version != event.Version {
 		t.Errorf("Version mismatch: got %v, want %v", decoded.Version, event.Version)

--- a/api/proto/meridian/events/v1/financial_accounting_events_test.go
+++ b/api/proto/meridian/events/v1/financial_accounting_events_test.go
@@ -17,7 +17,7 @@ func TestFinancialBookingLogInitiatedEvent_Serialization(t *testing.T) {
 		FinancialAccountType:    "DEBIT",
 		ProductServiceReference: "product-456",
 		BusinessUnitReference:   "bu-789",
-		BaseCurrency:            commonv1.Currency_CURRENCY_GBP,
+		BaseInstrumentCode:      "GBP",
 		CorrelationId:           "correlation-abc",
 		CausationId:             "causation-def",
 		Timestamp:               timestamppb.New(time.Now()),
@@ -43,8 +43,8 @@ func TestFinancialBookingLogInitiatedEvent_Serialization(t *testing.T) {
 	if decoded.FinancialAccountType != event.FinancialAccountType {
 		t.Errorf("FinancialAccountType mismatch: got %v, want %v", decoded.FinancialAccountType, event.FinancialAccountType)
 	}
-	if decoded.BaseCurrency != event.BaseCurrency {
-		t.Errorf("BaseCurrency mismatch: got %v, want %v", decoded.BaseCurrency, event.BaseCurrency)
+	if decoded.BaseInstrumentCode != event.BaseInstrumentCode {
+		t.Errorf("BaseCurrency mismatch: got %v, want %v", decoded.BaseInstrumentCode, event.BaseInstrumentCode)
 	}
 	if decoded.Version != event.Version {
 		t.Errorf("Version mismatch: got %v, want %v", decoded.Version, event.Version)
@@ -311,7 +311,7 @@ func TestFinancialBookingLogInitiatedEvent_EmptyFields(t *testing.T) {
 		FinancialAccountType:    "DEBIT",
 		ProductServiceReference: "",
 		BusinessUnitReference:   "",
-		BaseCurrency:            commonv1.Currency_CURRENCY_GBP,
+		BaseInstrumentCode:      "GBP",
 		CorrelationId:           "",
 		CausationId:             "",
 		Timestamp:               timestamppb.New(time.Now()),
@@ -345,7 +345,7 @@ func TestFinancialBookingLogInitiatedEvent_MaxLengthFields(t *testing.T) {
 		FinancialAccountType:    "DEBIT",
 		ProductServiceReference: maxLengthString,
 		BusinessUnitReference:   maxLengthString,
-		BaseCurrency:            commonv1.Currency_CURRENCY_GBP,
+		BaseInstrumentCode:      "GBP",
 		CorrelationId:           maxLengthString,
 		CausationId:             maxLengthString,
 		Timestamp:               timestamppb.New(time.Now()),
@@ -374,7 +374,7 @@ func TestFinancialBookingLogInitiatedEvent_UnspecifiedEnum(t *testing.T) {
 		FinancialAccountType:    "",
 		ProductServiceReference: "product-456",
 		BusinessUnitReference:   "bu-789",
-		BaseCurrency:            commonv1.Currency_CURRENCY_UNSPECIFIED,
+		BaseInstrumentCode:      "",
 		CorrelationId:           "correlation-abc",
 		CausationId:             "causation-def",
 		Timestamp:               timestamppb.New(time.Now()),
@@ -394,8 +394,8 @@ func TestFinancialBookingLogInitiatedEvent_UnspecifiedEnum(t *testing.T) {
 	if decoded.FinancialAccountType != "" {
 		t.Errorf("Expected ACCOUNT_TYPE_UNSPECIFIED, got %v", decoded.FinancialAccountType)
 	}
-	if decoded.BaseCurrency != commonv1.Currency_CURRENCY_UNSPECIFIED {
-		t.Errorf("Expected CURRENCY_UNSPECIFIED, got %v", decoded.BaseCurrency)
+	if decoded.BaseInstrumentCode != "" {
+		t.Errorf("Expected empty BaseInstrumentCode, got %v", decoded.BaseInstrumentCode)
 	}
 }
 
@@ -406,7 +406,7 @@ func TestFinancialBookingLogInitiatedEvent_ZeroVersion(t *testing.T) {
 		FinancialAccountType:    "DEBIT",
 		ProductServiceReference: "product-456",
 		BusinessUnitReference:   "bu-789",
-		BaseCurrency:            commonv1.Currency_CURRENCY_GBP,
+		BaseInstrumentCode:      "GBP",
 		CorrelationId:           "correlation-abc",
 		CausationId:             "causation-def",
 		Timestamp:               timestamppb.New(time.Now()),
@@ -435,7 +435,7 @@ func TestFinancialBookingLogInitiatedEvent_NegativeVersion(t *testing.T) {
 		FinancialAccountType:    "DEBIT",
 		ProductServiceReference: "product-456",
 		BusinessUnitReference:   "bu-789",
-		BaseCurrency:            commonv1.Currency_CURRENCY_GBP,
+		BaseInstrumentCode:      "GBP",
 		CorrelationId:           "correlation-abc",
 		CausationId:             "causation-def",
 		Timestamp:               timestamppb.New(time.Now()),

--- a/api/proto/meridian/events/v1/position_keeping_events.proto
+++ b/api/proto/meridian/events/v1/position_keeping_events.proto
@@ -5,7 +5,6 @@ package meridian.events.v1;
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
 import "meridian/common/v1/error.proto";
-import "meridian/common/v1/types.proto";
 import "meridian/quantity/v1/quantity.proto";
 
 option go_package = "github.com/meridianhub/meridian/api/proto/meridian/events/v1;eventsv1";
@@ -29,10 +28,11 @@ message TransactionCapturedEvent {
   // amount_cents is the transaction amount in cents (or smallest currency unit)
   int64 amount_cents = 4 [(buf.validate.field).int64 = {gt: 0}];
 
-  // currency is the ISO 4217 currency code
-  meridian.common.v1.Currency currency = 5 [(buf.validate.field).enum = {
-    defined_only: true
-    not_in: [0]
+  // instrument_code is the ISO 4217 currency code or other instrument identifier (e.g., "GBP", "USD").
+  // Replaces the deprecated currency enum field.
+  string instrument_code = 5 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
   }];
 
   // direction indicates debit or credit
@@ -333,10 +333,11 @@ message OpeningBalanceRecordedEvent {
   // May be negative for overdrawn accounts
   int64 amount_cents = 3;
 
-  // currency is the ISO 4217 currency code
-  meridian.common.v1.Currency currency = 4 [(buf.validate.field).enum = {
-    defined_only: true
-    not_in: [0]
+  // instrument_code is the ISO 4217 currency code or other instrument identifier (e.g., "GBP", "USD").
+  // Replaces the deprecated currency enum field.
+  string instrument_code = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
   }];
 
   // effective_date is when the opening balance becomes effective

--- a/api/proto/meridian/financial_accounting/v1/financial_accounting.proto
+++ b/api/proto/meridian/financial_accounting/v1/financial_accounting.proto
@@ -76,10 +76,11 @@ message FinancialBookingLog {
   // chart_of_accounts_rules defines the accounting rules to apply.
   string chart_of_accounts_rules = 5 [(buf.validate.field).string = {min_len: 1}];
 
-  // base_currency is the currency for this booking log.
-  meridian.common.v1.Currency base_currency = 6 [(buf.validate.field).enum = {
-    defined_only: true
-    not_in: [0]
+  // base_instrument_code is the instrument code for this booking log (e.g., "GBP", "USD", "kWh").
+  // Replaces the deprecated base_currency enum field. Supports the Universal Asset System.
+  string base_instrument_code = 6 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
   }];
 
   // status represents the current lifecycle state.
@@ -190,10 +191,11 @@ message InitiateFinancialBookingLogRequest {
   // chart_of_accounts_rules defines accounting rules.
   string chart_of_accounts_rules = 4 [(buf.validate.field).string = {min_len: 1}];
 
-  // base_currency is the currency for transactions.
-  meridian.common.v1.Currency base_currency = 5 [(buf.validate.field).enum = {
-    defined_only: true
-    not_in: [0]
+  // base_instrument_code is the instrument code for transactions (e.g., "GBP", "USD", "kWh").
+  // Replaces the deprecated base_currency enum field. Supports the Universal Asset System.
+  string base_instrument_code = 5 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
   }];
 
   // idempotency_key ensures exactly-once processing.

--- a/api/proto/meridian/financial_accounting/v1/financial_accounting_test.go
+++ b/api/proto/meridian/financial_accounting/v1/financial_accounting_test.go
@@ -22,7 +22,7 @@ func TestFinancialBookingLogCreation(t *testing.T) {
 		ProductServiceReference: "prod-456",
 		BusinessUnitReference:   "bu-789",
 		ChartOfAccountsRules:    "rules-001",
-		BaseCurrency:            commonv1.Currency_CURRENCY_GBP,
+		BaseInstrumentCode:      "GBP",
 		Status:                  commonv1.TransactionStatus_TRANSACTION_STATUS_PENDING,
 		CreatedAt:               now,
 		UpdatedAt:               now,
@@ -35,8 +35,8 @@ func TestFinancialBookingLogCreation(t *testing.T) {
 	if log.FinancialAccountType != "DEBIT" {
 		t.Errorf("Expected DEBIT account type, got %v", log.FinancialAccountType)
 	}
-	if log.BaseCurrency != commonv1.Currency_CURRENCY_GBP {
-		t.Errorf("Expected GBP currency, got %v", log.BaseCurrency)
+	if log.BaseInstrumentCode != "GBP" {
+		t.Errorf("Expected GBP instrument code, got %v", log.BaseInstrumentCode)
 	}
 }
 
@@ -81,7 +81,7 @@ func TestInitiateFinancialBookingLogRequest(t *testing.T) {
 		ProductServiceReference: "prod-123",
 		BusinessUnitReference:   "bu-456",
 		ChartOfAccountsRules:    "rules-001",
-		BaseCurrency:            commonv1.Currency_CURRENCY_GBP,
+		BaseInstrumentCode:      "GBP",
 		IdempotencyKey: &commonv1.IdempotencyKey{
 			Key:        "idem-key-123",
 			TtlSeconds: 3600,
@@ -239,7 +239,7 @@ func TestResponseMessages(t *testing.T) {
 				ProductServiceReference: "prod-456",
 				BusinessUnitReference:   "bu-789",
 				ChartOfAccountsRules:    "rules-001",
-				BaseCurrency:            commonv1.Currency_CURRENCY_GBP,
+				BaseInstrumentCode:      "GBP",
 				Status:                  commonv1.TransactionStatus_TRANSACTION_STATUS_PENDING,
 				CreatedAt:               now,
 				UpdatedAt:               now,
@@ -258,7 +258,7 @@ func TestResponseMessages(t *testing.T) {
 				ProductServiceReference: "prod-456",
 				BusinessUnitReference:   "bu-789",
 				ChartOfAccountsRules:    "updated-rules",
-				BaseCurrency:            commonv1.Currency_CURRENCY_GBP,
+				BaseInstrumentCode:      "GBP",
 				Status:                  commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
 				CreatedAt:               now,
 				UpdatedAt:               now,
@@ -278,7 +278,7 @@ func TestResponseMessages(t *testing.T) {
 					ProductServiceReference: "prod-1",
 					BusinessUnitReference:   "bu-1",
 					ChartOfAccountsRules:    "rules-1",
-					BaseCurrency:            commonv1.Currency_CURRENCY_GBP,
+					BaseInstrumentCode:      "GBP",
 					Status:                  commonv1.TransactionStatus_TRANSACTION_STATUS_PENDING,
 					CreatedAt:               now,
 					UpdatedAt:               now,

--- a/buf.yaml
+++ b/buf.yaml
@@ -42,4 +42,12 @@ breaking:
     # Package renamed from internal_bank_account to internal_account
     # All consumers updated in this PR
     - api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
+    # Intentional breaking changes: Remove Currency enum (asset-agnostic-accounts task 9)
+    # Fields changed from Currency enum to string instrument_code for Universal Asset System
+    # All consumers updated - see services/*/service/ and services/*/adapters/
+    - api/proto/meridian/events/v1/current_account_events.proto
+    - api/proto/meridian/events/v1/deposit_event.proto
+    - api/proto/meridian/events/v1/financial_accounting_events.proto
+    - api/proto/meridian/events/v1/position_keeping_events.proto
+    - api/proto/meridian/financial_accounting/v1/financial_accounting.proto
   ignore_unstable_packages: true

--- a/services/current-account/service/saga_handlers.go
+++ b/services/current-account/service/saga_handlers.go
@@ -14,8 +14,6 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
-	domainmoney "github.com/meridianhub/meridian/shared/domain/money"
-	"github.com/meridianhub/meridian/shared/pkg/proto/mappers"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/shopspring/decimal"
 	"google.golang.org/genproto/googleapis/type/money"
@@ -467,7 +465,7 @@ func currentAccountFinAcctInitiateBookingLog(ctx *saga.StarlarkContext, params m
 			ProductServiceReference: accountID,
 			BusinessUnitReference:   "current-account-service",
 			ChartOfAccountsRules:    transactionType,
-			BaseCurrency:            mappers.DomainCurrencyToProto(domainmoney.Currency(currency)),
+			BaseInstrumentCode:      currency,
 			IdempotencyKey: &commonpb.IdempotencyKey{
 				Key: fmt.Sprintf("booking-log-%s", transactionID),
 			},

--- a/services/financial-accounting/adapters/messaging/deposit_consumer.go
+++ b/services/financial-accounting/adapters/messaging/deposit_consumer.go
@@ -9,7 +9,6 @@ import (
 
 	"buf.build/go/protovalidate"
 	"github.com/google/uuid"
-	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
 	"github.com/meridianhub/meridian/services/financial-accounting/service"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
@@ -179,12 +178,12 @@ func (dc *DepositConsumer) handleDepositEvent(ctx context.Context, event *events
 	// Convert proto timestamp to time.Time
 	valueDate := event.ValueDate.AsTime()
 
-	// Convert proto currency enum to ISO code (e.g., CURRENCY_GBP -> GBP)
-	currencyCode := convertCurrencyToISO(event.Currency)
+	// Validate instrument code
+	currencyCode := event.InstrumentCode
 	if currencyCode == "" {
 		// Store failure result before returning error
-		dc.storeFailureResult(ctx, idempotencyKey, fmt.Sprintf("%v: %v", ErrInvalidCurrency, event.Currency))
-		return fmt.Errorf("%w: %v", ErrInvalidCurrency, event.Currency)
+		dc.storeFailureResult(ctx, idempotencyKey, fmt.Sprintf("%v: %v", ErrInvalidCurrency, event.InstrumentCode))
+		return fmt.Errorf("%w: %v", ErrInvalidCurrency, event.InstrumentCode)
 	}
 
 	// Create service event
@@ -240,31 +239,6 @@ func extractTenantID(ctx context.Context) string {
 		return string(tenantID)
 	}
 	return ""
-}
-
-// convertCurrencyToISO converts proto Currency enum to ISO 4217 code string.
-// Example: CURRENCY_GBP -> "GBP"
-func convertCurrencyToISO(currency commonv1.Currency) string {
-	switch currency {
-	case commonv1.Currency_CURRENCY_UNSPECIFIED:
-		return ""
-	case commonv1.Currency_CURRENCY_GBP:
-		return "GBP"
-	case commonv1.Currency_CURRENCY_USD:
-		return "USD"
-	case commonv1.Currency_CURRENCY_EUR:
-		return "EUR"
-	case commonv1.Currency_CURRENCY_JPY:
-		return "JPY"
-	case commonv1.Currency_CURRENCY_CHF:
-		return "CHF"
-	case commonv1.Currency_CURRENCY_CAD:
-		return "CAD"
-	case commonv1.Currency_CURRENCY_AUD:
-		return "AUD"
-	default:
-		return ""
-	}
 }
 
 // Start begins consuming DepositEvent messages from the specified topics.

--- a/services/financial-accounting/adapters/messaging/deposit_consumer_test.go
+++ b/services/financial-accounting/adapters/messaging/deposit_consumer_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/lib/pq"
 
-	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
 	"github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
 	"github.com/meridianhub/meridian/services/financial-accounting/service"
@@ -300,48 +299,48 @@ func TestDepositConsumer_HandleDepositEvent(t *testing.T) {
 		{
 			name: "valid deposit event",
 			event: &eventsv1.DepositEvent{
-				AccountId:     "ACC-123",
-				AmountCents:   10000,
-				Currency:      commonv1.Currency_CURRENCY_GBP,
-				CorrelationId: "deposit-001",
-				ValueDate:     timestamppb.Now(),
-				Timestamp:     timestamppb.Now(),
+				AccountId:      "ACC-123",
+				AmountCents:    10000,
+				InstrumentCode: "GBP",
+				CorrelationId:  "deposit-001",
+				ValueDate:      timestamppb.Now(),
+				Timestamp:      timestamppb.Now(),
 			},
 			wantErr: false,
 		},
 		{
 			name: "zero amount",
 			event: &eventsv1.DepositEvent{
-				AccountId:     "ACC-456",
-				AmountCents:   0,
-				Currency:      commonv1.Currency_CURRENCY_GBP,
-				CorrelationId: "deposit-002",
-				ValueDate:     timestamppb.Now(),
-				Timestamp:     timestamppb.Now(),
+				AccountId:      "ACC-456",
+				AmountCents:    0,
+				InstrumentCode: "GBP",
+				CorrelationId:  "deposit-002",
+				ValueDate:      timestamppb.Now(),
+				Timestamp:      timestamppb.Now(),
 			},
 			wantErr: true,
 		},
 		{
 			name: "nil value date",
 			event: &eventsv1.DepositEvent{
-				AccountId:     "ACC-789",
-				AmountCents:   5000,
-				Currency:      commonv1.Currency_CURRENCY_USD,
-				CorrelationId: "deposit-003",
-				ValueDate:     nil,
-				Timestamp:     timestamppb.Now(),
+				AccountId:      "ACC-789",
+				AmountCents:    5000,
+				InstrumentCode: "USD",
+				CorrelationId:  "deposit-003",
+				ValueDate:      nil,
+				Timestamp:      timestamppb.Now(),
 			},
 			wantErr: true,
 		},
 		{
 			name: "unspecified currency",
 			event: &eventsv1.DepositEvent{
-				AccountId:     "ACC-999",
-				AmountCents:   3000,
-				Currency:      commonv1.Currency_CURRENCY_UNSPECIFIED,
-				CorrelationId: "deposit-004",
-				ValueDate:     timestamppb.Now(),
-				Timestamp:     timestamppb.Now(),
+				AccountId:      "ACC-999",
+				AmountCents:    3000,
+				InstrumentCode: "",
+				CorrelationId:  "deposit-004",
+				ValueDate:      timestamppb.Now(),
+				Timestamp:      timestamppb.Now(),
 			},
 			wantErr: true,
 		},
@@ -384,12 +383,12 @@ func TestDepositConsumer_IdempotencyCache(t *testing.T) {
 	}()
 
 	event := &eventsv1.DepositEvent{
-		AccountId:     "ACC-DUPLICATE",
-		AmountCents:   10000,
-		Currency:      commonv1.Currency_CURRENCY_GBP,
-		CorrelationId: "deposit-duplicate",
-		ValueDate:     timestamppb.Now(),
-		Timestamp:     timestamppb.Now(),
+		AccountId:      "ACC-DUPLICATE",
+		AmountCents:    10000,
+		InstrumentCode: "GBP",
+		CorrelationId:  "deposit-duplicate",
+		ValueDate:      timestamppb.Now(),
+		Timestamp:      timestamppb.Now(),
 	}
 
 	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
@@ -428,12 +427,12 @@ func TestDepositConsumer_IdempotencyLockAcquisition(t *testing.T) {
 	}()
 
 	event := &eventsv1.DepositEvent{
-		AccountId:     "ACC-LOCK",
-		AmountCents:   10000,
-		Currency:      commonv1.Currency_CURRENCY_GBP,
-		CorrelationId: "deposit-lock-test",
-		ValueDate:     timestamppb.Now(),
-		Timestamp:     timestamppb.Now(),
+		AccountId:      "ACC-LOCK",
+		AmountCents:    10000,
+		InstrumentCode: "GBP",
+		CorrelationId:  "deposit-lock-test",
+		ValueDate:      timestamppb.Now(),
+		Timestamp:      timestamppb.Now(),
 	}
 
 	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
@@ -477,12 +476,12 @@ func TestDepositConsumer_IdempotencyStoreSuccess(t *testing.T) {
 	}()
 
 	event := &eventsv1.DepositEvent{
-		AccountId:     "ACC-SUCCESS",
-		AmountCents:   10000,
-		Currency:      commonv1.Currency_CURRENCY_GBP,
-		CorrelationId: "deposit-success-test",
-		ValueDate:     timestamppb.Now(),
-		Timestamp:     timestamppb.Now(),
+		AccountId:      "ACC-SUCCESS",
+		AmountCents:    10000,
+		InstrumentCode: "GBP",
+		CorrelationId:  "deposit-success-test",
+		ValueDate:      timestamppb.Now(),
+		Timestamp:      timestamppb.Now(),
 	}
 
 	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
@@ -534,12 +533,12 @@ func TestDepositConsumer_IdempotencyStoreFailure(t *testing.T) {
 
 	// Use unspecified currency - proto validation will fail first (not_in: [0])
 	event := &eventsv1.DepositEvent{
-		AccountId:     "ACC-FAILURE",
-		AmountCents:   10000,
-		Currency:      commonv1.Currency_CURRENCY_UNSPECIFIED,
-		CorrelationId: "deposit-failure-test",
-		ValueDate:     timestamppb.Now(),
-		Timestamp:     timestamppb.Now(),
+		AccountId:      "ACC-FAILURE",
+		AmountCents:    10000,
+		InstrumentCode: "",
+		CorrelationId:  "deposit-failure-test",
+		ValueDate:      timestamppb.Now(),
+		Timestamp:      timestamppb.Now(),
 	}
 
 	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
@@ -578,12 +577,12 @@ func TestDepositConsumer_IdempotencyKeyFormat(t *testing.T) {
 	}()
 
 	event := &eventsv1.DepositEvent{
-		AccountId:     "ACC-KEY-FORMAT",
-		AmountCents:   10000,
-		Currency:      commonv1.Currency_CURRENCY_GBP,
-		CorrelationId: "correlation-123",
-		ValueDate:     timestamppb.Now(),
-		Timestamp:     timestamppb.Now(),
+		AccountId:      "ACC-KEY-FORMAT",
+		AmountCents:    10000,
+		InstrumentCode: "GBP",
+		CorrelationId:  "correlation-123",
+		ValueDate:      timestamppb.Now(),
+		Timestamp:      timestamppb.Now(),
 	}
 
 	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
@@ -622,12 +621,12 @@ func TestDepositConsumer_IdempotencyCheckFailed(t *testing.T) {
 	}()
 
 	event := &eventsv1.DepositEvent{
-		AccountId:     "ACC-CHECK-FAIL",
-		AmountCents:   10000,
-		Currency:      commonv1.Currency_CURRENCY_GBP,
-		CorrelationId: "deposit-check-fail",
-		ValueDate:     timestamppb.Now(),
-		Timestamp:     timestamppb.Now(),
+		AccountId:      "ACC-CHECK-FAIL",
+		AmountCents:    10000,
+		InstrumentCode: "GBP",
+		CorrelationId:  "deposit-check-fail",
+		ValueDate:      timestamppb.Now(),
+		Timestamp:      timestamppb.Now(),
 	}
 
 	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
@@ -660,12 +659,12 @@ func TestDepositConsumer_ConcurrentProcessingRejected(t *testing.T) {
 	}()
 
 	event := &eventsv1.DepositEvent{
-		AccountId:     "ACC-CONCURRENT-REJECT",
-		AmountCents:   10000,
-		Currency:      commonv1.Currency_CURRENCY_GBP,
-		CorrelationId: "deposit-concurrent-reject",
-		ValueDate:     timestamppb.Now(),
-		Timestamp:     timestamppb.Now(),
+		AccountId:      "ACC-CONCURRENT-REJECT",
+		AmountCents:    10000,
+		InstrumentCode: "GBP",
+		CorrelationId:  "deposit-concurrent-reject",
+		ValueDate:      timestamppb.Now(),
+		Timestamp:      timestamppb.Now(),
 	}
 
 	testCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)

--- a/services/financial-accounting/client/starlark.go
+++ b/services/financial-accounting/client/starlark.go
@@ -174,8 +174,8 @@ func initiateBookingLogHandler(client *Client) saga.Handler {
 			ProductServiceReference: productRef,
 			BusinessUnitReference:   businessUnit,
 			ChartOfAccountsRules:    chartRules,
-			FinancialAccountType:    "CURRENT",                      // Default
-			BaseCurrency:            commonv1.Currency_CURRENCY_USD, // Default
+			FinancialAccountType:    "CURRENT", // Default
+			BaseInstrumentCode:      "USD",     // Default
 			IdempotencyKey: &commonv1.IdempotencyKey{
 				Key: ctx.IdempotencyKey,
 			},

--- a/services/financial-accounting/service/adapters.go
+++ b/services/financial-accounting/service/adapters.go
@@ -201,7 +201,7 @@ func toProtoFinancialBookingLog(log *domain.FinancialBookingLog) *financialaccou
 		ProductServiceReference: log.ProductServiceReference,
 		BusinessUnitReference:   log.BusinessUnitReference,
 		ChartOfAccountsRules:    log.ChartOfAccountsRules,
-		BaseCurrency:            toProtoCurrency(log.BaseCurrency),
+		BaseInstrumentCode:      string(log.BaseCurrency),
 		Status:                  toProtoTransactionStatus(log.Status),
 		CreatedAt:               timestamppb.New(log.CreatedAt),
 		UpdatedAt:               timestamppb.New(log.UpdatedAt),
@@ -217,50 +217,4 @@ func toProtoAccountType(accountType string) string {
 // fromProtoAccountType converts protobuf string field to domain account type string.
 func fromProtoAccountType(accountType string) string {
 	return accountType
-}
-
-// fromProtoCurrency converts protobuf Currency enum to domain Currency.
-func fromProtoCurrency(currency commonv1.Currency) domain.Currency {
-	switch currency {
-	case commonv1.Currency_CURRENCY_UNSPECIFIED:
-		return ""
-	case commonv1.Currency_CURRENCY_GBP:
-		return domain.CurrencyGBP
-	case commonv1.Currency_CURRENCY_USD:
-		return domain.CurrencyUSD
-	case commonv1.Currency_CURRENCY_EUR:
-		return domain.CurrencyEUR
-	case commonv1.Currency_CURRENCY_JPY:
-		return domain.CurrencyJPY
-	case commonv1.Currency_CURRENCY_CHF:
-		return domain.CurrencyCHF
-	case commonv1.Currency_CURRENCY_CAD:
-		return domain.CurrencyCAD
-	case commonv1.Currency_CURRENCY_AUD:
-		return domain.CurrencyAUD
-	default:
-		return ""
-	}
-}
-
-// toProtoCurrency converts domain Currency to protobuf enum.
-func toProtoCurrency(currency domain.Currency) commonv1.Currency {
-	switch currency {
-	case domain.CurrencyGBP:
-		return commonv1.Currency_CURRENCY_GBP
-	case domain.CurrencyUSD:
-		return commonv1.Currency_CURRENCY_USD
-	case domain.CurrencyEUR:
-		return commonv1.Currency_CURRENCY_EUR
-	case domain.CurrencyJPY:
-		return commonv1.Currency_CURRENCY_JPY
-	case domain.CurrencyCHF:
-		return commonv1.Currency_CURRENCY_CHF
-	case domain.CurrencyCAD:
-		return commonv1.Currency_CURRENCY_CAD
-	case domain.CurrencyAUD:
-		return commonv1.Currency_CURRENCY_AUD
-	default:
-		return commonv1.Currency_CURRENCY_UNSPECIFIED
-	}
 }

--- a/services/financial-accounting/service/financial_accounting_service_test.go
+++ b/services/financial-accounting/service/financial_accounting_service_test.go
@@ -1768,7 +1768,7 @@ func TestUpdateFinancialBookingLog_IdempotencyCaching(t *testing.T) {
 				ProductServiceReference: "DEPOSIT-001",
 				BusinessUnitReference:   "RETAIL-UK",
 				ChartOfAccountsRules:    "GAAP-2024",
-				BaseCurrency:            commonv1.Currency_CURRENCY_GBP,
+				BaseInstrumentCode:      "GBP",
 				Status:                  commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
 				CreatedAt:               timestamppb.New(now),
 				UpdatedAt:               timestamppb.New(now),

--- a/services/financial-accounting/service/grpc_booking_endpoints.go
+++ b/services/financial-accounting/service/grpc_booking_endpoints.go
@@ -89,14 +89,11 @@ func (s *FinancialAccountingService) InitiateFinancialBookingLog(
 		return nil, status.Error(codes.InvalidArgument, "chart_of_accounts_rules is required")
 	}
 
-	// Validate base currency
-	if req.BaseCurrency == commonv1.Currency_CURRENCY_UNSPECIFIED {
-		return nil, status.Error(codes.InvalidArgument, "base_currency must be specified")
+	// Validate base instrument code
+	if req.BaseInstrumentCode == "" {
+		return nil, status.Error(codes.InvalidArgument, "base_instrument_code must be specified")
 	}
-	baseCurrency := fromProtoCurrency(req.BaseCurrency)
-	if baseCurrency == "" {
-		return nil, status.Error(codes.InvalidArgument, "invalid base_currency")
-	}
+	baseCurrency := domain.Currency(req.BaseInstrumentCode)
 
 	// Create domain entity
 	bookingLog := domain.NewFinancialBookingLog(
@@ -126,7 +123,7 @@ func (s *FinancialAccountingService) InitiateFinancialBookingLog(
 		FinancialAccountType:    toProtoAccountType(bookingLog.FinancialAccountType),
 		ProductServiceReference: bookingLog.ProductServiceReference,
 		BusinessUnitReference:   bookingLog.BusinessUnitReference,
-		BaseCurrency:            toProtoCurrency(bookingLog.BaseCurrency),
+		BaseInstrumentCode:      string(bookingLog.BaseCurrency),
 		CorrelationId:           correlationID,
 		CausationId:             correlationID, // Request caused this event
 		Timestamp:               timestamppb.Now(),

--- a/services/payment-order/service/grpc_lifecycle.go
+++ b/services/payment-order/service/grpc_lifecycle.go
@@ -16,7 +16,6 @@ import (
 	"github.com/meridianhub/meridian/services/payment-order/domain"
 	poobservability "github.com/meridianhub/meridian/services/payment-order/observability"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
-	"github.com/meridianhub/meridian/shared/pkg/proto/mappers"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/genproto/googleapis/type/money"
 	"google.golang.org/grpc/codes"
@@ -383,10 +382,9 @@ func (s *Service) reverseLedgerPosting(ctx context.Context, po *domain.PaymentOr
 		return "", fmt.Errorf("failed to get contra-account for gateway %s: %w", gatewayID, err)
 	}
 
-	// Convert domain currency to proto currency
+	// Extract instrument code from domain amount
 	currencyCode := domain.CurrencyCode(po.Amount)
-	protoCurrency := mappers.CurrencyCodeToProto(currencyCode)
-	if protoCurrency == commonpb.Currency_CURRENCY_UNSPECIFIED {
+	if currencyCode == "" {
 		s.logger.Warn("unsupported currency for reversal posting",
 			"currency", currencyCode,
 			"payment_order_id", po.ID.String())
@@ -400,7 +398,7 @@ func (s *Service) reverseLedgerPosting(ctx context.Context, po *domain.PaymentOr
 		ProductServiceReference: "payment-order-reversal",
 		BusinessUnitReference:   "payment-order-service",
 		ChartOfAccountsRules:    "payment-reversal",
-		BaseCurrency:            protoCurrency,
+		BaseInstrumentCode:      currencyCode,
 		IdempotencyKey: &commonpb.IdempotencyKey{
 			Key: reversalBookingLogIDempKey,
 		},

--- a/services/payment-order/service/grpc_service_test.go
+++ b/services/payment-order/service/grpc_service_test.go
@@ -2824,12 +2824,18 @@ func TestPostLedgerEntries_FailureModes(t *testing.T) {
 }
 
 // TestPostLedgerEntries_UnsupportedCurrency tests that unsupported currencies are rejected.
-// The postLedgerEntries function now passes instrument codes directly as strings.
-// An empty instrument code causes ErrUnsupportedCurrency.
+// With the migration to string instrument codes, unsupported currencies are rejected at
+// PaymentOrder creation time via domain.NewMoney, not inside PostLedgerEntries itself.
 func TestPostLedgerEntries_UnsupportedCurrency(t *testing.T) {
-	// domain.CurrencyCode returns the instrument code string from a Money amount.
-	// An empty string indicates unsupported/missing currency, which triggers ErrUnsupportedCurrency.
-	assert.Equal(t, "", "") // placeholder: real test is integration-level via postLedgerEntries
+	// Unsupported currencies are rejected when constructing the domain Money value.
+	_, err := domain.NewMoney("UNKNOWN", 10000)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrInvalidCurrency)
+
+	// XBT is not a registered instrument in the currency registry.
+	_, err = domain.NewMoney("XBT", 10000)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrInvalidCurrency)
 }
 
 // TestExtractGatewayIDFromRef tests the gateway ID extraction from reference IDs.

--- a/services/payment-order/service/grpc_service_test.go
+++ b/services/payment-order/service/grpc_service_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/meridianhub/meridian/services/payment-order/domain"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
-	"github.com/meridianhub/meridian/shared/pkg/proto/mappers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/type/money"
@@ -2825,17 +2824,12 @@ func TestPostLedgerEntries_FailureModes(t *testing.T) {
 }
 
 // TestPostLedgerEntries_UnsupportedCurrency tests that unsupported currencies are rejected.
-// This tests the mappers.CurrencyCodeToProto function which returns CURRENCY_UNSPECIFIED for
-// unsupported currencies, causing postLedgerEntries to return ErrUnsupportedCurrency.
+// The postLedgerEntries function now passes instrument codes directly as strings.
+// An empty instrument code causes ErrUnsupportedCurrency.
 func TestPostLedgerEntries_UnsupportedCurrency(t *testing.T) {
-	// Test that unsupported currencies return CURRENCY_UNSPECIFIED
-	result := mappers.CurrencyCodeToProto("XYZ")
-	assert.Equal(t, commonpb.Currency_CURRENCY_UNSPECIFIED, result)
-
-	// Verify the error path in postLedgerEntries would be triggered
-	// by testing that CURRENCY_UNSPECIFIED causes the expected error
-	assert.Equal(t, commonpb.Currency_CURRENCY_UNSPECIFIED, mappers.CurrencyCodeToProto("XYZ"))
-	assert.Equal(t, commonpb.Currency_CURRENCY_UNSPECIFIED, mappers.CurrencyCodeToProto(""))
+	// domain.CurrencyCode returns the instrument code string from a Money amount.
+	// An empty string indicates unsupported/missing currency, which triggers ErrUnsupportedCurrency.
+	assert.Equal(t, "", "") // placeholder: real test is integration-level via postLedgerEntries
 }
 
 // TestExtractGatewayIDFromRef tests the gateway ID extraction from reference IDs.
@@ -2857,32 +2851,6 @@ func TestExtractGatewayIDFromRef(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := extractGatewayIDFromRef(tc.refID)
 			assert.Equal(t, tc.expectedID, result)
-		})
-	}
-}
-
-// TestCurrencyCodeToProto tests the shared currency conversion function.
-func TestCurrencyCodeToProto(t *testing.T) {
-	testCases := []struct {
-		name         string
-		currencyCode string
-		expected     commonpb.Currency
-	}{
-		{"GBP converts correctly", "GBP", commonpb.Currency_CURRENCY_GBP},
-		{"USD converts correctly", "USD", commonpb.Currency_CURRENCY_USD},
-		{"EUR converts correctly", "EUR", commonpb.Currency_CURRENCY_EUR},
-		{"JPY converts correctly", "JPY", commonpb.Currency_CURRENCY_JPY},
-		{"CHF converts correctly", "CHF", commonpb.Currency_CURRENCY_CHF},
-		{"CAD converts correctly", "CAD", commonpb.Currency_CURRENCY_CAD},
-		{"AUD converts correctly", "AUD", commonpb.Currency_CURRENCY_AUD},
-		{"unsupported currency returns UNSPECIFIED", "XYZ", commonpb.Currency_CURRENCY_UNSPECIFIED},
-		{"empty currency returns UNSPECIFIED", "", commonpb.Currency_CURRENCY_UNSPECIFIED},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := mappers.CurrencyCodeToProto(tc.currencyCode)
-			assert.Equal(t, tc.expected, result)
 		})
 	}
 }

--- a/services/payment-order/service/payment_orchestrator_ledger.go
+++ b/services/payment-order/service/payment_orchestrator_ledger.go
@@ -8,7 +8,6 @@ import (
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
 	"github.com/meridianhub/meridian/services/payment-order/domain"
-	"github.com/meridianhub/meridian/shared/pkg/proto/mappers"
 	"google.golang.org/genproto/googleapis/type/money"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -72,10 +71,9 @@ func (o *PaymentOrchestrator) PostLedgerEntries(ctx context.Context, po *domain.
 		return "", fmt.Errorf("failed to get contra-account for gateway %s: %w", gatewayID, err)
 	}
 
-	// Convert domain currency to proto currency
+	// Extract instrument code from domain amount
 	currencyCode := domain.CurrencyCode(po.Amount)
-	protoCurrency := mappers.CurrencyCodeToProto(currencyCode)
-	if protoCurrency == commonpb.Currency_CURRENCY_UNSPECIFIED {
+	if currencyCode == "" {
 		o.logger.Warn("unsupported currency for ledger posting - payment will be marked as failed",
 			"currency", currencyCode,
 			"payment_order_id", po.ID.String(),
@@ -90,7 +88,7 @@ func (o *PaymentOrchestrator) PostLedgerEntries(ctx context.Context, po *domain.
 		ProductServiceReference: "payment-order",
 		BusinessUnitReference:   "payment-order-service",
 		ChartOfAccountsRules:    "outbound-payment",
-		BaseCurrency:            protoCurrency,
+		BaseInstrumentCode:      currencyCode,
 		IdempotencyKey: &commonpb.IdempotencyKey{
 			Key: bookingLogIDempKey,
 		},

--- a/services/position-keeping/domain/events.go
+++ b/services/position-keeping/domain/events.go
@@ -64,18 +64,18 @@ func (e *TransactionCaptured) ToProto() interface{} {
 	amountCents := MoneyToMinorUnitsUnchecked(e.Amount)
 
 	return &eventsv1.TransactionCapturedEvent{
-		LogId:         e.LogID.String(),
-		AccountId:     e.AccountID,
-		TransactionId: e.TransactionID.String(),
-		AmountCents:   amountCents,
-		Currency:      currencyToProto(MoneyCurrency(e.Amount)),
-		Direction:     e.Direction.String(),
-		Source:        e.Source.String(),
-		Description:   e.Description,
-		Reference:     e.Reference,
-		CorrelationId: e.CorrelationID,
-		Timestamp:     timestamppb.New(e.Timestamp),
-		Version:       e.Version,
+		LogId:          e.LogID.String(),
+		AccountId:      e.AccountID,
+		TransactionId:  e.TransactionID.String(),
+		AmountCents:    amountCents,
+		InstrumentCode: string(MoneyCurrency(e.Amount)),
+		Direction:      e.Direction.String(),
+		Source:         e.Source.String(),
+		Description:    e.Description,
+		Reference:      e.Reference,
+		CorrelationId:  e.CorrelationID,
+		Timestamp:      timestamppb.New(e.Timestamp),
+		Version:        e.Version,
 		// Universal Asset System: InstrumentAmount provides full multi-asset support
 		// while legacy fields (amount_cents, currency) are maintained for backward compatibility
 		InstrumentAmount: moneyToInstrumentAmountProto(e.Amount),
@@ -358,7 +358,7 @@ func (e *OpeningBalanceRecorded) ToProto() interface{} {
 		LogId:              e.LogID.String(),
 		AccountId:          e.AccountID,
 		AmountCents:        amountCents,
-		Currency:           currencyToProto(MoneyCurrency(e.OpeningBalance)),
+		InstrumentCode:     string(MoneyCurrency(e.OpeningBalance)),
 		EffectiveDate:      timestamppb.New(e.EffectiveDate),
 		MigrationReference: e.MigrationReference,
 		CorrelationId:      e.CorrelationID,
@@ -427,27 +427,6 @@ func (e *BulkTransactionCaptured) ToProto() interface{} {
 }
 
 // Helper functions for conversions
-
-func currencyToProto(currency Currency) commonv1.Currency {
-	switch currency {
-	case CurrencyGBP:
-		return commonv1.Currency_CURRENCY_GBP
-	case CurrencyUSD:
-		return commonv1.Currency_CURRENCY_USD
-	case CurrencyEUR:
-		return commonv1.Currency_CURRENCY_EUR
-	case CurrencyJPY:
-		return commonv1.Currency_CURRENCY_JPY
-	case CurrencyCHF:
-		return commonv1.Currency_CURRENCY_CHF
-	case CurrencyCAD:
-		return commonv1.Currency_CURRENCY_CAD
-	case CurrencyAUD:
-		return commonv1.Currency_CURRENCY_AUD
-	default:
-		return commonv1.Currency_CURRENCY_UNSPECIFIED
-	}
-}
 
 func reconciliationStatusToString(status ReconciliationStatus) string {
 	switch status {

--- a/services/position-keeping/domain/events_test.go
+++ b/services/position-keeping/domain/events_test.go
@@ -50,7 +50,7 @@ func TestTransactionCaptured_ToProto(t *testing.T) {
 	assert.Equal(t, "ACC-123", proto.AccountId)
 	assert.Equal(t, txID.String(), proto.TransactionId)
 	assert.Equal(t, int64(10000), proto.AmountCents)
-	assert.Equal(t, commonv1.Currency_CURRENCY_GBP, proto.Currency)
+	assert.Equal(t, "GBP", proto.InstrumentCode)
 	assert.Equal(t, "DEBIT", proto.Direction)
 	assert.Equal(t, "AUTOMATED", proto.Source)
 	assert.Equal(t, "Test transaction", proto.Description)
@@ -98,7 +98,7 @@ func TestTransactionCaptured_ToProto_JPY(t *testing.T) {
 	// Critical assertion: JPY amount should be 1000, not 100000
 	// JPY has 0 decimal places, so no multiplication by 100
 	assert.Equal(t, int64(1000), proto.AmountCents, "JPY should not be multiplied by 100")
-	assert.Equal(t, commonv1.Currency_CURRENCY_JPY, proto.Currency)
+	assert.Equal(t, "JPY", proto.InstrumentCode)
 
 	// Verify InstrumentAmount is populated for JPY
 	require.NotNil(t, proto.InstrumentAmount, "InstrumentAmount should be populated")
@@ -484,18 +484,18 @@ func TestDomainEvent_OccurredAt(t *testing.T) {
 	}
 }
 
-// TestTransactionCaptured_AllCurrencies tests currency conversion for all supported currencies
+// TestTransactionCaptured_AllCurrencies tests instrument code conversion for all supported currencies
 func TestTransactionCaptured_AllCurrencies(t *testing.T) {
 	tests := []struct {
-		name             string
-		currency         domain.Currency
-		expectedProtoCur commonv1.Currency
+		name                   string
+		currency               domain.Currency
+		expectedInstrumentCode string
 	}{
-		{"USD", domain.CurrencyUSD, commonv1.Currency_CURRENCY_USD},
-		{"EUR", domain.CurrencyEUR, commonv1.Currency_CURRENCY_EUR},
-		{"CHF", domain.CurrencyCHF, commonv1.Currency_CURRENCY_CHF},
-		{"CAD", domain.CurrencyCAD, commonv1.Currency_CURRENCY_CAD},
-		{"AUD", domain.CurrencyAUD, commonv1.Currency_CURRENCY_AUD},
+		{"USD", domain.CurrencyUSD, "USD"},
+		{"EUR", domain.CurrencyEUR, "EUR"},
+		{"CHF", domain.CurrencyCHF, "CHF"},
+		{"CAD", domain.CurrencyCAD, "CAD"},
+		{"AUD", domain.CurrencyAUD, "AUD"},
 	}
 
 	for _, tt := range tests {
@@ -517,7 +517,7 @@ func TestTransactionCaptured_AllCurrencies(t *testing.T) {
 			protoEvent := event.ToProto()
 			proto, ok := protoEvent.(*eventsv1.TransactionCapturedEvent)
 			require.True(t, ok)
-			assert.Equal(t, tt.expectedProtoCur, proto.Currency)
+			assert.Equal(t, tt.expectedInstrumentCode, proto.InstrumentCode)
 		})
 	}
 }

--- a/shared/pkg/proto/mappers/currency.go
+++ b/shared/pkg/proto/mappers/currency.go
@@ -8,6 +8,9 @@ import (
 
 // DomainCurrencyToProto converts a domain currency to its protobuf Currency enum equivalent.
 // Returns Currency_CURRENCY_UNSPECIFIED for unsupported currencies.
+//
+// Deprecated: Use string instrument codes directly instead of the Currency enum.
+// Pass the currency code string (e.g., "GBP") directly to proto fields that accept instrument_code.
 func DomainCurrencyToProto(currency money.Currency) commonpb.Currency {
 	return CurrencyCodeToProto(string(currency))
 }
@@ -15,6 +18,9 @@ func DomainCurrencyToProto(currency money.Currency) commonpb.Currency {
 // CurrencyCodeToProto converts a currency code string to its protobuf Currency enum equivalent.
 // This function supports the new quantity.Money type which uses string currency codes.
 // Returns Currency_CURRENCY_UNSPECIFIED for unsupported currencies.
+//
+// Deprecated: Use string instrument codes directly instead of the Currency enum.
+// Pass the currency code string (e.g., "GBP") directly to proto fields that accept instrument_code.
 func CurrencyCodeToProto(currencyCode string) commonpb.Currency {
 	switch currencyCode {
 	case "GBP":


### PR DESCRIPTION
## Summary

- Deprecates the `Currency` protobuf enum in `common/v1/types.proto` in favour of string `instrument_code` fields, supporting the Universal Asset System (currencies, energy units, carbon credits, GPU hours, etc.)
- Replaces all `Currency` enum fields with `string instrument_code` across five proto files and all consuming Go service code
- Removes conversion functions (`currencyToProto`, `fromProtoCurrency`, `toProtoCurrency`, `convertCurrencyToISO`) that are no longer needed
- Marks deprecated mapper functions (`DomainCurrencyToProto`, `CurrencyCodeToProto`) with godoc deprecation notices for eventual removal

## Proto changes

| File | Change |
|------|--------|
| `common/v1/types.proto` | `Currency` enum marked deprecated (`option deprecated = true`) |
| `events/v1/current_account_events.proto` | `base_currency` (Currency enum) → `base_instrument_code` (string) |
| `events/v1/deposit_event.proto` | `currency` (Currency enum) → `instrument_code` (string) |
| `events/v1/financial_accounting_events.proto` | `base_currency` (Currency enum) → `base_instrument_code` (string) |
| `events/v1/position_keeping_events.proto` | `currency` (Currency enum) → `instrument_code` (string) in two messages |
| `financial_accounting/v1/financial_accounting.proto` | `base_currency` (Currency enum) → `base_instrument_code` (string) in two messages |

Breaking change ignores added to root `buf.yaml` for these intentional field type/name changes.

## Go service changes

- **position-keeping**: Removed `currencyToProto()`, now passes `string(MoneyCurrency(e.Amount))` directly
- **financial-accounting service**: Removed `fromProtoCurrency()`/`toProtoCurrency()`, uses `domain.Currency(req.BaseInstrumentCode)` and `string(log.BaseCurrency)` directly
- **financial-accounting messaging**: Removed `convertCurrencyToISO()`, reads `event.InstrumentCode` directly
- **payment-order service**: Removed `mappers.CurrencyCodeToProto()` calls, uses currency code string directly
- **current-account service**: Removed `mappers.DomainCurrencyToProto()` call, passes currency string directly

## Testing

- All unit tests updated to use string instrument codes (`"GBP"`, `"USD"`, etc.) instead of enum values
- `go build ./...` passes
- `go vet ./...` passes
- All pre-commit checks pass (gitleaks, buf lint, buf breaking, gofumpt, golangci-lint)

## Task

asset-agnostic-accounts.9