### PR TITLE
feat: add seed migration for master tenant

### DIFF
--- a/services/tenant/migrations/20260226000001_seed_master_tenant.sql
+++ b/services/tenant/migrations/20260226000001_seed_master_tenant.sql
@@ -1,0 +1,21 @@
+-- Seed master tenant for market-information service shared data access
+-- This tenant hosts canonical shared datasets accessible to all tenants
+-- Uses ON CONFLICT DO NOTHING for idempotent reruns
+
+INSERT INTO tenant (
+    id,
+    display_name,
+    settlement_asset,
+    status,
+    metadata,
+    version,
+    created_at
+) VALUES (
+    'meridian_master',
+    'Meridian Platform',
+    'USD',
+    'active',
+    '{"is_system_tenant": true, "description": "System tenant for shared platform data"}'::jsonb,
+    1,
+    NOW()
+) ON CONFLICT (id) DO NOTHING;

--- a/services/tenant/migrations/20260226000001_seed_master_tenant.sql
+++ b/services/tenant/migrations/20260226000001_seed_master_tenant.sql
@@ -13,7 +13,7 @@ INSERT INTO tenant (
 ) VALUES (
     'meridian_master',
     'Meridian Platform',
-    'USD',
+    'GBP',
     'active',
     '{"is_system_tenant": true, "description": "System tenant for shared platform data"}'::jsonb,
     1,

--- a/services/tenant/migrations/atlas.sum
+++ b/services/tenant/migrations/atlas.sum
@@ -1,5 +1,6 @@
-h1:syXyHwTGMMPwbjolpTbqR8Zm4axPvJ0AAkXITcVTu9M=
+h1:JIU4em/2gJmHrIZQO5elrRDKE8xmvjVbUsIkIUojCYc=
 20251216000001_initial.sql h1:fDcJR00ykXOFp9882/ieCQyoMbvkdJN3jF7y+fH+4DQ=
 20251223000001_add_status_updated_at_index.sql h1:+gm99ghOO5+QMv5uYxTbOIl52cCpzlu599SHFUzThIk=
 20260223000001_fix_audit_outbox_column_types.sql h1:3CSTxMS9bEv1S0rLhXYWPmFEFvV57CULZYRHp+p/WHE=
 20260223000002_fix_audit_outbox_column_types_data.sql h1:xSkSJVnbYPb0CXhJf4iqW0m/L7Vko0ssUec6nE04TK8=
+20260226000001_seed_master_tenant.sql h1:YKqaDEa9DrWJVRry6c/mS8hjAKDgTIu3ygtiglzcyQ0=

--- a/services/tenant/migrations/atlas.sum
+++ b/services/tenant/migrations/atlas.sum
@@ -1,6 +1,6 @@
-h1:JIU4em/2gJmHrIZQO5elrRDKE8xmvjVbUsIkIUojCYc=
+h1:u6ZwkR3/+Sqvc0w1D6l412Wr1dLxdTDhn7wYu1QI2ok=
 20251216000001_initial.sql h1:fDcJR00ykXOFp9882/ieCQyoMbvkdJN3jF7y+fH+4DQ=
 20251223000001_add_status_updated_at_index.sql h1:+gm99ghOO5+QMv5uYxTbOIl52cCpzlu599SHFUzThIk=
 20260223000001_fix_audit_outbox_column_types.sql h1:3CSTxMS9bEv1S0rLhXYWPmFEFvV57CULZYRHp+p/WHE=
 20260223000002_fix_audit_outbox_column_types_data.sql h1:xSkSJVnbYPb0CXhJf4iqW0m/L7Vko0ssUec6nE04TK8=
-20260226000001_seed_master_tenant.sql h1:YKqaDEa9DrWJVRry6c/mS8hjAKDgTIu3ygtiglzcyQ0=
+20260226000001_seed_master_tenant.sql h1:OEAOiO8E6Xu/3X6FXEewH3VoBvHby0YcNOsoZs5qDl4=


### PR DESCRIPTION
## Summary

- Adds idempotent seed migration (`20260226000001_seed_master_tenant.sql`) that inserts the `meridian_master` tenant row on first startup
- Ensures the frontend and market-information service can load data immediately after deployment without manual tenant creation
- Uses `ON CONFLICT (id) DO NOTHING` for safe reruns

## Task Master

Tag: `1214-demo-migration-fix`, Task: `1`

Closes #1214

## Test plan

- [ ] Atlas migration validates successfully
- [ ] Fresh database migration creates the master tenant row
- [ ] Re-running migration is idempotent (no duplicate rows)
- [ ] Service starts without errors after migration