### PR TITLE
feat: add build info footer, fix MCP URL derivation, and deploy config

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -113,6 +113,8 @@ jobs:
         env:
           VITE_API_BASE_URL: https://demo.meridianhub.cloud
           VITE_DEMO_MODE: "true"
+          VITE_BUILD_VERSION: ${{ github.ref_name }}
+          VITE_BUILD_COMMIT: ${{ github.sha }}
         run: npx vite build
 
       - name: Upload frontend artifact

--- a/cmd/meridian/Dockerfile
+++ b/cmd/meridian/Dockerfile
@@ -37,8 +37,13 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} go build \
     -o seed-dev \
     ./cmd/seed-dev/
 
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} go build \
+    -ldflags="-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildDate=${BUILD_DATE}" \
+    -o mcp-server \
+    ./services/mcp-server/cmd/
+
 # Verify the binaries exist and are executable
-RUN test -x meridian && test -x seed-dev && echo "Binaries built successfully"
+RUN test -x meridian && test -x seed-dev && test -x mcp-server && echo "Binaries built successfully"
 
 # Runtime stage - distroless for minimal attack surface (~2MB base)
 FROM gcr.io/distroless/static-debian12
@@ -49,6 +54,7 @@ COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 # Copy binaries from builder
 COPY --from=builder /build/meridian /meridian
 COPY --from=builder /build/seed-dev /seed-dev
+COPY --from=builder /build/mcp-server /mcp-server
 
 # Use non-root user (distroless provides nonroot user at uid 65532)
 USER nonroot:nonroot

--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -98,6 +98,14 @@ import (
 	"gorm.io/gorm"
 )
 
+// Version information injected at build time via ldflags.
+// See Dockerfile: -X main.Version=... -X main.Commit=... -X main.BuildDate=...
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)
+
 func main() {
 	migrate := flag.Bool("migrate", false, "Apply all embedded SQL migrations to CockroachDB and exit")
 	databaseURL := flag.String("database-url", "", "Superuser DSN for CockroachDB (e.g., postgres://root@localhost:26257/defaultdb?sslmode=disable)")
@@ -702,6 +710,12 @@ func wireGateway(grpcPort, httpPort int, databaseURL string, logger *slog.Logger
 		}
 		opts = append(opts, gateway.WithAuthMiddleware(authMiddleware))
 	}
+
+	opts = append(opts, gateway.WithVersionInfo(&gateway.VersionInfo{
+		Version:   Version,
+		Commit:    Commit,
+		BuildDate: BuildDate,
+	}))
 
 	return gateway.NewServer(config, logger, nil, opts...), nil
 }

--- a/deploy/demo/.env.demo.example
+++ b/deploy/demo/.env.demo.example
@@ -152,6 +152,17 @@ MASTER_TENANT_ID=meridian_master
 #OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
 
 # ---------------------------------------------------------------------------
+# MCP Server (AI Integration)
+# ---------------------------------------------------------------------------
+
+# [REQUIRED] Public base URL for MCP OAuth callbacks and SSE endpoint discovery.
+MCP_BASE_URL=https://demo.meridianhub.cloud
+
+# [REQUIRED] API key for MCP server to authenticate with Meridian gRPC API.
+# Must match an entry in API_KEYS above (format: "key:identity").
+MERIDIAN_API_KEY=changeme
+
+# ---------------------------------------------------------------------------
 # Frontend
 # ---------------------------------------------------------------------------
 

--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -1,3 +1,9 @@
+{
+	# Cloudflare origin certs are provided manually; disable ACME attempts
+	# (otherwise Caddy retries DNS-01 wildcard challenges every 6 hours).
+	auto_https disable_certs
+}
+
 demo.meridianhub.cloud, *.demo.meridianhub.cloud {
 	tls /etc/caddy/certs/origin-cert.pem /etc/caddy/certs/origin-key.pem
 
@@ -6,9 +12,18 @@ demo.meridianhub.cloud, *.demo.meridianhub.cloud {
 		reverse_proxy dex:5556
 	}
 
-	# API: ConnectRPC + health probes
+	# MCP Server: SSE transport + message endpoint
+	# NOTE: Requires mcp-server container to be running; routes will 502 until deployed.
+	handle /sse {
+		reverse_proxy mcp-server:8090
+	}
+	handle /message {
+		reverse_proxy mcp-server:8090
+	}
+
+	# API: ConnectRPC + health probes + version
 	@api {
-		path /meridian.* /grpc.* /healthz /readyz
+		path /meridian.* /grpc.* /healthz /readyz /version
 	}
 	handle @api {
 		reverse_proxy meridian:8090

--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -110,7 +110,8 @@ services:
     # Not exposed to host — accessed only by caddy on the internal network
 
   mcp-server:
-    image: ${MCP_SERVER_IMAGE:-ghcr.io/meridianhub/mcp-server:demo}
+    image: ${MERIDIAN_IMAGE:-ghcr.io/meridianhub/meridian:demo}
+    entrypoint: ["/mcp-server"]
     restart: unless-stopped
     depends_on:
       meridian:
@@ -134,8 +135,7 @@ services:
       MCP_OAUTH_CLIENT_ID: ${MCP_OAUTH_CLIENT_ID:-}      # required when MCP_OAUTH_ENABLED=true
       MCP_OAUTH_REDIRECT_URI: ${MCP_OAUTH_REDIRECT_URI:-} # required when MCP_OAUTH_ENABLED=true
     # Not exposed to host — accessed only by caddy on the internal network
-    # Add to Caddyfile: reverse_proxy /sse mcp-server:8090
-    #                   reverse_proxy /message mcp-server:8090
+    # Caddy proxies /sse and /message to this container
 
   caddy:
     image: caddy:2-alpine

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,10 @@
 # API base URL (set per environment)
 VITE_API_BASE_URL=http://localhost:8090
 
+# Build info (injected by CI, optional for local dev)
+# VITE_BUILD_VERSION=dev
+# VITE_BUILD_COMMIT=unknown
+
 # Auth settings
 VITE_AUTH_AUDIENCE=meridian-api
 VITE_AUTH_CLIENT_ID=your-client-id

--- a/frontend/src/components/layout/build-info.tsx
+++ b/frontend/src/components/layout/build-info.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+import { apiConfig } from '@/api/config'
+
+interface VersionInfo {
+  version: string
+  commit: string
+  build_date: string
+}
+
+export function BuildInfo() {
+  const [info, setInfo] = useState<VersionInfo | null>(null)
+
+  useEffect(() => {
+    fetch(`${apiConfig.baseUrl}/version`)
+      .then((res) => (res.ok ? res.json() : Promise.reject(res)))
+      .then((data: VersionInfo) => setInfo(data))
+      .catch(() => {
+        // Fall back to build-time env vars
+        const version = import.meta.env.VITE_BUILD_VERSION
+        const commit = import.meta.env.VITE_BUILD_COMMIT
+        if (version || commit) {
+          setInfo({
+            version: version ?? 'dev',
+            commit: commit ?? 'unknown',
+            build_date: 'unknown',
+          })
+        }
+      })
+  }, [])
+
+  if (!info) return null
+
+  const shortCommit =
+    info.commit && info.commit !== 'unknown' ? info.commit.slice(0, 7) : null
+  const label = shortCommit ? `${info.version} (${shortCommit})` : info.version
+
+  return (
+    <div className="px-3 py-2 text-xs text-gray-500">
+      <span title={info.commit}>{label}</span>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { BuildInfo } from './build-info'
 import {
   LayoutDashboard,
   Wallet,
@@ -80,7 +81,7 @@ export function Sidebar({ lens, currentPath = '/', isOpen = false, id, onClose }
         !isOpen && 'max-md:-translate-x-full',
       )}
     >
-      <nav aria-label="Main navigation" className="flex-1 overflow-y-auto py-4">
+      <nav aria-label="Main navigation" className="min-h-0 flex-1 overflow-y-auto py-4">
         <ul role="list" className="space-y-1 px-2">
           {TENANT_NAV_ITEMS.map((item) => {
             const Icon = item.icon
@@ -132,6 +133,7 @@ export function Sidebar({ lens, currentPath = '/', isOpen = false, id, onClose }
           )}
         </ul>
       </nav>
+      <BuildInfo />
     </aside>
     </>
   )

--- a/frontend/src/pages/mcp-config/index.tsx
+++ b/frontend/src/pages/mcp-config/index.tsx
@@ -6,7 +6,10 @@ import { Copy, Check, ExternalLink } from 'lucide-react'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { McpToolsSection } from './mcp-tools-section'
 
-const MCP_SERVER_URL = import.meta.env.VITE_MCP_SERVER_URL ?? 'http://localhost:8091'
+const MCP_SERVER_URL =
+  import.meta.env.VITE_MCP_SERVER_URL ??
+  import.meta.env.VITE_API_BASE_URL ??
+  'http://localhost:8091'
 
 function buildClaudeDesktopConfig(serverUrl: string): string {
   const config = {

--- a/services/gateway/config.go
+++ b/services/gateway/config.go
@@ -112,6 +112,13 @@ type AuthConfig struct {
 	RateLimitBurst int
 }
 
+// VersionInfo holds build metadata injected at compile time via ldflags.
+type VersionInfo struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	BuildDate string `json:"build_date"`
+}
+
 // BackendRoute defines a mapping from a URL prefix to a backend service.
 type BackendRoute struct {
 	// Prefix is the URL path prefix to match (e.g., "/v1/party").

--- a/services/gateway/server.go
+++ b/services/gateway/server.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -32,6 +33,7 @@ type Server struct {
 	transcoderHandler     http.Handler
 	eventStreamHandler    *eventstream.Handler
 	rawEventStreamHandler http.Handler // used by tests and WithEventStreamHandlerHTTP
+	versionInfo           *VersionInfo
 }
 
 // ServerOption is a functional option for configuring the server.
@@ -74,6 +76,13 @@ func WithEventStreamHandler(handler *eventstream.Handler) ServerOption {
 func WithEventStreamHandlerHTTP(handler http.Handler) ServerOption {
 	return func(s *Server) {
 		s.rawEventStreamHandler = handler
+	}
+}
+
+// WithVersionInfo sets the build version metadata returned by the /version endpoint.
+func WithVersionInfo(info *VersionInfo) ServerOption {
+	return func(s *Server) {
+		s.versionInfo = info
 	}
 }
 
@@ -132,6 +141,9 @@ func (s *Server) registerRoutes() {
 	// Legacy health endpoints for backwards compatibility
 	s.mux.HandleFunc("/healthz", s.getOnly(s.handleHealth))
 	s.mux.HandleFunc("/readyz", s.getOnly(s.handleReady))
+
+	// Build version endpoint - NO middleware (public, like health)
+	s.mux.HandleFunc("/version", s.getOnly(s.handleVersion))
 
 	// API routes - with auth and tenant middleware chain.
 	// Prefer the Vanguard transcoder when configured; fall back to the legacy
@@ -299,6 +311,17 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 
 		s.logHealthCheckResult(ctx, report, overallStatus, slog.LevelError)
 	}
+}
+
+// handleVersion returns build version information as JSON.
+// This endpoint does NOT require authentication or tenant context.
+func (s *Server) handleVersion(w http.ResponseWriter, _ *http.Request) {
+	info := s.versionInfo
+	if info == nil {
+		info = &VersionInfo{Version: "dev", Commit: "unknown", BuildDate: "unknown"}
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	_ = json.NewEncoder(w).Encode(info)
 }
 
 // logHealthCheckResult logs the health check result with structured details.


### PR DESCRIPTION
## Summary

- Add `/version` API endpoint (no auth) returning build metadata (version, commit, build date) injected via ldflags
- Add build info display in the frontend sidebar footer, fetched from `/version` with fallback to `VITE_BUILD_*` env vars
- Fix MCP config page URL resolution: `VITE_MCP_SERVER_URL` -> `VITE_API_BASE_URL` -> `localhost:8091`
- Bake `mcp-server` binary into the unified Dockerfile so the demo stack no longer needs a separate MCP image
- Update `docker-compose.yml` to use unified image with entrypoint override instead of `MCP_SERVER_IMAGE`
- Add `auto_https disable_certs` to Caddyfile to stop ACME wildcard cert retry spam
- Add `/sse`, `/message` proxy routes and `/version` to Caddyfile API matcher
- Inject `VITE_BUILD_VERSION`/`VITE_BUILD_COMMIT` in CI frontend build step
- Add `MCP_BASE_URL` and `MERIDIAN_API_KEY` to `.env.demo.example`

## Changes Made

| File | Change |
|------|--------|
| `cmd/meridian/main.go` | Declare `Version`, `Commit`, `BuildDate` vars; pass to gateway as `VersionInfo` |
| `services/gateway/config.go` | Add `VersionInfo` struct |
| `services/gateway/server.go` | Add `WithVersionInfo` option, register `GET /version` endpoint |
| `cmd/meridian/Dockerfile` | Build `mcp-server` binary, copy to runtime stage |
| `deploy/demo/Caddyfile` | Disable ACME, add MCP + version proxy routes |
| `deploy/demo/docker-compose.yml` | Use unified image + entrypoint for mcp-server |
| `deploy/demo/.env.demo.example` | Add MCP server env vars |
| `.github/workflows/deploy-demo.yml` | Add `VITE_BUILD_VERSION`/`COMMIT` to frontend build |
| `frontend/.env.example` | Document build info env vars |
| `frontend/src/components/layout/build-info.tsx` | New: fetches `/version`, displays in sidebar |
| `frontend/src/components/layout/sidebar.tsx` | Add `<BuildInfo />` at sidebar bottom |
| `frontend/src/pages/mcp-config/index.tsx` | Fix MCP URL fallback chain |

## Test plan

- [ ] `curl localhost:8090/version` returns `{"version":"dev","commit":"unknown","build_date":"unknown"}` locally
- [ ] Frontend sidebar shows "dev" when running locally (no env vars set)
- [ ] MCP config page shows `http://localhost:8091` locally (correct for dev)
- [ ] Docker build succeeds with all 3 binaries (meridian, seed-dev, mcp-server)
- [ ] After deploy to demo, sidebar shows branch name + commit SHA
- [ ] MCP config page on demo shows `https://demo.meridianhub.cloud`
- [ ] Caddy logs no longer show ACME retry errors