### PR TITLE
feat: rename IBAN to External Reference across frontend UI

### DIFF
--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -1153,7 +1153,7 @@ message ListCurrentAccountsRequest {
   // status filters results to accounts with a specific status (optional).
   AccountStatus status = 3 [(buf.validate.field).enum = {defined_only: true}];
 
-  // iban filters results by IBAN prefix match (optional).
+  // iban filters results by external reference prefix match (optional).
   string iban = 4 [(buf.validate.field).string = {max_len: 34}];
 }
 
@@ -1310,7 +1310,7 @@ service CurrentAccountService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "List current accounts"
-      description: "Returns a paginated list of current accounts with optional filtering by status and IBAN."
+      description: "Returns a paginated list of current accounts with optional filtering by status and external reference."
     };
   }
 

--- a/api/proto/meridian/payment_order/v1/payment_order.proto
+++ b/api/proto/meridian/payment_order/v1/payment_order.proto
@@ -155,8 +155,8 @@ message PaymentOrder {
     pattern: "^[a-zA-Z0-9_-]+$"
   }];
 
-  // creditor_reference is the external account identifier (IBAN or other standard).
-  // IBAN format: 2 letter country code + 2 check digits + up to 30 alphanumeric characters.
+  // creditor_reference is the external account identifier (e.g. IBAN, sort code + account number,
+  // or any product-type-specific reference).
   string creditor_reference = 3 [(buf.validate.field).string = {
     min_len: 1
     max_len: 34
@@ -271,7 +271,7 @@ message InitiatePaymentOrderRequest {
     pattern: "^[a-zA-Z0-9_-]+$"
   }];
 
-  // creditor_reference is the external account to credit (IBAN format).
+  // creditor_reference is the external account to credit (e.g. IBAN, sort code, or other reference).
   string creditor_reference = 2 [(buf.validate.field).string = {
     min_len: 1
     max_len: 34

--- a/frontend/e2e/accounts.spec.ts
+++ b/frontend/e2e/accounts.spec.ts
@@ -42,13 +42,13 @@ test.describe('Accounts page', () => {
     ).toBeVisible()
   })
 
-  test('Create Account dialog contains IBAN, Currency, and Party ID fields', async ({
+  test('Create Account dialog contains External Reference, Currency, and Party ID fields', async ({
     authenticatedPage,
   }) => {
     await navigateTo(authenticatedPage, '/accounts')
     await authenticatedPage.getByRole('button', { name: 'Create Account' }).click()
     const dialog = authenticatedPage.getByRole('dialog')
-    await expect(dialog.getByLabel('IBAN')).toBeVisible()
+    await expect(dialog.getByLabel('External Reference')).toBeVisible()
     await expect(dialog.getByLabel('Currency')).toBeVisible()
     await expect(dialog.getByLabel('Party ID')).toBeVisible()
   })
@@ -67,18 +67,8 @@ test.describe('Accounts page', () => {
     const dialog = authenticatedPage.getByRole('dialog')
     // Submit without filling any fields
     await dialog.getByRole('button', { name: 'Create Account', exact: true }).click()
-    await expect(dialog.getByText('IBAN is required')).toBeVisible()
+    await expect(dialog.getByText('External reference is required')).toBeVisible()
     await expect(dialog.getByText('Party ID is required')).toBeVisible()
-  })
-
-  test('Create Account dialog validates IBAN format', async ({ authenticatedPage }) => {
-    await navigateTo(authenticatedPage, '/accounts')
-    await authenticatedPage.getByRole('button', { name: 'Create Account' }).click()
-    const dialog = authenticatedPage.getByRole('dialog')
-    await dialog.getByLabel('IBAN').fill('not-a-valid-iban')
-    await dialog.getByLabel('Party ID').fill('party-001')
-    await dialog.getByRole('button', { name: 'Create Account', exact: true }).click()
-    await expect(dialog.getByText(/valid IBAN/i)).toBeVisible()
   })
 
   test('Create Account dialog resets fields after cancel and reopen', async ({
@@ -88,14 +78,14 @@ test.describe('Accounts page', () => {
     // Open and fill the dialog
     await authenticatedPage.getByRole('button', { name: 'Create Account' }).click()
     let dialog = authenticatedPage.getByRole('dialog')
-    await dialog.getByLabel('IBAN').fill('GB82WEST12345698765432')
+    await dialog.getByLabel('External Reference').fill('GB82WEST12345698765432')
     await dialog.getByLabel('Party ID').fill('party-001')
     // Cancel
     await authenticatedPage.getByRole('button', { name: 'Cancel' }).click()
     // Reopen - fields should be reset
     await authenticatedPage.getByRole('button', { name: 'Create Account' }).click()
     dialog = authenticatedPage.getByRole('dialog')
-    await expect(dialog.getByLabel('IBAN')).toHaveValue('')
+    await expect(dialog.getByLabel('External Reference')).toHaveValue('')
     await expect(dialog.getByLabel('Party ID')).toHaveValue('')
   })
 
@@ -157,7 +147,7 @@ test.describe('Account lifecycle (requires backend)', () => {
 
     // Step 3: Fill and submit form (scope to dialog to avoid collision with DataTable filter)
     const createDialog = authenticatedPage.getByRole('dialog')
-    await createDialog.getByLabel('IBAN').fill(testIban)
+    await createDialog.getByLabel('External Reference').fill(testIban)
     await createDialog.getByLabel('Currency').selectOption(currency)
     await createDialog.getByLabel('Party ID').fill('dev-party-001')
     await createDialog.getByRole('button', { name: 'Create Account', exact: true }).click()

--- a/frontend/e2e/payments.spec.ts
+++ b/frontend/e2e/payments.spec.ts
@@ -33,7 +33,7 @@ test.describe('Payments page', () => {
       authenticatedPage.getByRole('columnheader', { name: /debtor account/i }),
     ).toBeVisible()
     await expect(
-      authenticatedPage.getByRole('columnheader', { name: /creditor iban/i }),
+      authenticatedPage.getByRole('columnheader', { name: /creditor reference/i }),
     ).toBeVisible()
     await expect(authenticatedPage.getByRole('columnheader', { name: /amount/i })).toBeVisible()
     await expect(authenticatedPage.getByRole('columnheader', { name: /status/i })).toBeVisible()
@@ -194,7 +194,7 @@ test.describe.serial('Payment lifecycle (requires backend)', () => {
     await expect(dialog).toBeVisible()
 
     await expect(dialog.getByLabel('Debtor Account')).toBeVisible()
-    await expect(dialog.getByLabel('Creditor IBAN')).toBeVisible()
+    await expect(dialog.getByLabel('Creditor Reference')).toBeVisible()
     await expect(dialog.getByLabel('Amount')).toBeVisible()
     await expect(dialog.getByLabel('Currency')).toBeVisible()
   })
@@ -218,22 +218,8 @@ test.describe.serial('Payment lifecycle (requires backend)', () => {
     // Submit without filling any fields
     await dialog.getByRole('button', { name: 'Initiate Payment' }).click()
     await expect(dialog.getByText('Debtor account is required')).toBeVisible()
-    await expect(dialog.getByText('IBAN is required')).toBeVisible()
+    await expect(dialog.getByText('Creditor reference is required')).toBeVisible()
     await expect(dialog.getByText('Amount is required')).toBeVisible()
-  })
-
-  test('Initiate Payment dialog validates IBAN format', async ({ authenticatedPage }) => {
-    await navigateToFirstPayment(authenticatedPage)
-
-    await authenticatedPage.getByRole('button', { name: 'New Payment' }).click()
-    const dialog = authenticatedPage.getByRole('dialog')
-    await expect(dialog).toBeVisible()
-
-    await dialog.getByLabel('Debtor Account').fill('dev-account-001')
-    await dialog.getByLabel('Creditor IBAN').fill('not-a-valid-iban')
-    await dialog.getByLabel('Amount').fill('10.00')
-    await dialog.getByRole('button', { name: 'Initiate Payment' }).click()
-    await expect(dialog.getByText('Invalid IBAN format')).toBeVisible()
   })
 
   test('Initiate Payment dialog closes on Cancel', async ({ authenticatedPage }) => {
@@ -257,7 +243,7 @@ test.describe.serial('Payment lifecycle (requires backend)', () => {
     let dialog = authenticatedPage.getByRole('dialog')
     await expect(dialog).toBeVisible()
     await dialog.getByLabel('Debtor Account').fill('dev-account-001')
-    await dialog.getByLabel('Creditor IBAN').fill('GB29NWBK60161331926819')
+    await dialog.getByLabel('Creditor Reference').fill('GB29NWBK60161331926819')
     await dialog.getByLabel('Amount').fill('10.00')
 
     // Cancel and reopen
@@ -269,7 +255,7 @@ test.describe.serial('Payment lifecycle (requires backend)', () => {
 
     // Fields should be reset
     await expect(dialog.getByLabel('Debtor Account')).toHaveValue('')
-    await expect(dialog.getByLabel('Creditor IBAN')).toHaveValue('')
+    await expect(dialog.getByLabel('Creditor Reference')).toHaveValue('')
     await expect(dialog.getByLabel('Amount')).toHaveValue('')
   })
 
@@ -289,7 +275,7 @@ test.describe.serial('Payment lifecycle (requires backend)', () => {
     // Without string-based BigInt parsing: Math.round(0.29 * 100) = 28 → GBP 0.28 (wrong)
     // With amountToBigInt string parsing: "0.29" → 29n → GBP 0.29 (correct)
     await dialog.getByLabel('Debtor Account').fill('dev-account-001')
-    await dialog.getByLabel('Creditor IBAN').fill('GB29NWBK60161331926819')
+    await dialog.getByLabel('Creditor Reference').fill('GB29NWBK60161331926819')
     await dialog.getByLabel('Amount').fill('0.29')
     await dialog.getByRole('button', { name: 'Initiate Payment' }).click()
 
@@ -320,7 +306,7 @@ test.describe.serial('Payment lifecycle (requires backend)', () => {
       await expect(dialog).toBeVisible()
 
       await dialog.getByLabel('Debtor Account').fill('dev-account-001')
-      await dialog.getByLabel('Creditor IBAN').fill('GB29NWBK60161331926819')
+      await dialog.getByLabel('Creditor Reference').fill('GB29NWBK60161331926819')
       await dialog.getByLabel('Amount').fill(amount)
       await dialog.getByRole('button', { name: 'Initiate Payment' }).click()
 
@@ -336,7 +322,7 @@ test.describe.serial('Payment lifecycle (requires backend)', () => {
     const dialog = authenticatedPage.getByRole('dialog')
     await expect(dialog).toBeVisible()
     await dialog.getByLabel('Debtor Account').fill('dev-account-001')
-    await dialog.getByLabel('Creditor IBAN').fill('GB29NWBK60161331926819')
+    await dialog.getByLabel('Creditor Reference').fill('GB29NWBK60161331926819')
     await dialog.getByLabel('Amount').fill('10.00')
     await dialog.getByRole('button', { name: 'Initiate Payment' }).click()
     await expect(dialog).not.toBeVisible({ timeout: 10_000 })
@@ -361,7 +347,7 @@ test.describe.serial('Payment lifecycle (requires backend)', () => {
     const dialog = authenticatedPage.getByRole('dialog')
     await expect(dialog).toBeVisible()
     await dialog.getByLabel('Debtor Account').fill('dev-account-001')
-    await dialog.getByLabel('Creditor IBAN').fill('GB29NWBK60161331926819')
+    await dialog.getByLabel('Creditor Reference').fill('GB29NWBK60161331926819')
     await dialog.getByLabel('Amount').fill('5.00')
     await dialog.getByRole('button', { name: 'Initiate Payment' }).click()
     await expect(dialog).not.toBeVisible({ timeout: 10_000 })
@@ -386,7 +372,7 @@ test.describe.serial('Payment lifecycle (requires backend)', () => {
     const dialog = authenticatedPage.getByRole('dialog')
     await expect(dialog).toBeVisible()
     await dialog.getByLabel('Debtor Account').fill('dev-account-001')
-    await dialog.getByLabel('Creditor IBAN').fill('GB29NWBK60161331926819')
+    await dialog.getByLabel('Creditor Reference').fill('GB29NWBK60161331926819')
     await dialog.getByLabel('Amount').fill('15.00')
     await dialog.getByRole('button', { name: 'Initiate Payment' }).click()
     await expect(dialog).not.toBeVisible({ timeout: 10_000 })

--- a/frontend/src/pages/accounts/[accountId].tsx
+++ b/frontend/src/pages/accounts/[accountId].tsx
@@ -246,8 +246,8 @@ export function AccountDetailPage() {
             <h1 className="text-2xl font-semibold">{account.accountId}</h1>
             <StatusBadge status={account.status} />
           </div>
-          {account.iban && (
-            <p className="mt-1 font-mono text-sm text-muted-foreground">{account.iban}</p>
+          {account.externalReference && (
+            <p className="mt-1 font-mono text-sm text-muted-foreground">{account.externalReference}</p>
           )}
         </div>
         <AccountActions
@@ -293,7 +293,7 @@ export function AccountDetailPage() {
               <CardContent>
                 <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                   <DetailField label="Account ID">{account.accountId}</DetailField>
-                  <DetailField label="IBAN">{account.iban || '—'}</DetailField>
+                  <DetailField label="External Reference">{account.externalReference || '—'}</DetailField>
                   <DetailField label="Status">
                     <StatusBadge status={account.status} />
                   </DetailField>

--- a/frontend/src/pages/accounts/account-detail.test.tsx
+++ b/frontend/src/pages/accounts/account-detail.test.tsx
@@ -24,7 +24,7 @@ function renderDetailPage(accountId = 'acct-001') {
 
 const mockAccount = {
   accountId: 'acct-001',
-  iban: 'GB29NWBK60161331926819',
+  externalReference: 'GB29NWBK60161331926819',
   status: 'ACTIVE',
   baseCurrency: 'GBP',
   availableBalance: '100000',
@@ -90,7 +90,7 @@ describe('AccountDetailPage - account overview', () => {
     })
   })
 
-  it('renders IBAN', async () => {
+  it('renders external reference', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
         HttpResponse.json({ account: mockAccount }),

--- a/frontend/src/pages/accounts/accounts-list.test.tsx
+++ b/frontend/src/pages/accounts/accounts-list.test.tsx
@@ -100,7 +100,7 @@ describe('AccountsPage - list rendering', () => {
       expect(screen.getByRole('columnheader', { name: /account id/i })).toBeInTheDocument()
     })
 
-    expect(screen.getByRole('columnheader', { name: /iban/i })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /external ref/i })).toBeInTheDocument()
     expect(screen.getByRole('columnheader', { name: /status/i })).toBeInTheDocument()
     expect(screen.getByRole('columnheader', { name: /currency/i })).toBeInTheDocument()
   })
@@ -146,7 +146,7 @@ describe('AccountsPage - filtering', () => {
     expect(screen.getByRole('combobox', { name: /status/i })).toBeInTheDocument()
   })
 
-  it('renders IBAN text filter', async () => {
+  it('renders External Ref text filter', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/ListCurrentAccounts', () =>
         HttpResponse.json({ accounts: [], nextPageToken: '' }),
@@ -155,7 +155,7 @@ describe('AccountsPage - filtering', () => {
 
     renderAccountsPage()
 
-    expect(screen.getByPlaceholderText(/filter by iban/i)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/filter by external ref/i)).toBeInTheDocument()
   })
 
   it('passes status filter to query when selected', async () => {

--- a/frontend/src/pages/accounts/create-account-dialog.tsx
+++ b/frontend/src/pages/accounts/create-account-dialog.tsx
@@ -15,17 +15,14 @@ import { tenantKeys } from '@/lib/query-keys'
 
 const CURRENCIES = ['GBP', 'USD', 'EUR']
 
-// IBAN pattern: 2 letter country code + 2 digits + up to 30 alphanumeric chars
-const IBAN_PATTERN = /^[A-Z]{2}[0-9]{2}[A-Z0-9]{1,30}$/
-
 interface FormData {
-  iban: string
+  externalReference: string
   currency: string
   partyId: string
 }
 
 interface FormErrors {
-  iban?: string
+  externalReference?: string
   partyId?: string
   general?: string
 }
@@ -38,7 +35,7 @@ interface CreateAccountDialogProps {
 
 async function createAccount(
   tenantSlug: string,
-  iban: string,
+  externalReference: string,
   currency: string,
   partyId: string,
 ): Promise<string> {
@@ -51,7 +48,7 @@ async function createAccount(
         'X-Tenant-Slug': tenantSlug,
       },
       body: JSON.stringify({
-        accountIdentification: iban,
+        accountIdentification: externalReference,
         baseCurrency: currency,
         partyId,
       }),
@@ -74,7 +71,7 @@ export function CreateAccountDialog({ open, onOpenChange, onCreated }: CreateAcc
   const { tenantSlug } = useTenantContext()
   const queryClient = useQueryClient()
   const [formData, setFormData] = React.useState<FormData>({
-    iban: '',
+    externalReference: '',
     currency: 'GBP',
     partyId: '',
   })
@@ -82,7 +79,7 @@ export function CreateAccountDialog({ open, onOpenChange, onCreated }: CreateAcc
 
   React.useEffect(() => {
     if (!open) {
-      setFormData({ iban: '', currency: 'GBP', partyId: '' })
+      setFormData({ externalReference: '', currency: 'GBP', partyId: '' })
       setErrors({})
     }
   }, [open])
@@ -93,11 +90,9 @@ export function CreateAccountDialog({ open, onOpenChange, onCreated }: CreateAcc
       next.general = 'No tenant selected'
       return next
     }
-    const iban = formData.iban.trim().toUpperCase()
-    if (!iban) {
-      next.iban = 'IBAN is required'
-    } else if (!IBAN_PATTERN.test(iban)) {
-      next.iban = 'Enter a valid IBAN (e.g. GB82WEST12345698765432)'
+    const ref = formData.externalReference.trim()
+    if (!ref) {
+      next.externalReference = 'External reference is required'
     }
     if (!formData.partyId.trim()) {
       next.partyId = 'Party ID is required'
@@ -109,7 +104,7 @@ export function CreateAccountDialog({ open, onOpenChange, onCreated }: CreateAcc
     mutationFn: () =>
       createAccount(
         tenantSlug ?? '',
-        formData.iban.trim().toUpperCase(),
+        formData.externalReference.trim(),
         formData.currency,
         formData.partyId.trim(),
       ),
@@ -158,20 +153,20 @@ export function CreateAccountDialog({ open, onOpenChange, onCreated }: CreateAcc
         <form onSubmit={(e) => void handleSubmit(e)} id="create-account-form">
           <div className="space-y-4 py-2">
             <div className="space-y-1">
-              <label htmlFor="account-iban" className="text-sm font-medium">
-                IBAN
+              <label htmlFor="account-external-reference" className="text-sm font-medium">
+                External Reference
               </label>
               <Input
-                id="account-iban"
-                value={formData.iban}
-                onChange={handleChange('iban')}
-                placeholder="GB82WEST12345698765432"
-                aria-label="IBAN"
-                aria-describedby={errors.iban ? 'account-iban-error' : undefined}
+                id="account-external-reference"
+                value={formData.externalReference}
+                onChange={handleChange('externalReference')}
+                placeholder="e.g. GB82WEST12345698765432 or 12-34-56-78901234"
+                aria-label="External Reference"
+                aria-describedby={errors.externalReference ? 'account-external-reference-error' : undefined}
               />
-              {errors.iban && (
-                <p id="account-iban-error" className="text-sm text-destructive">
-                  {errors.iban}
+              {errors.externalReference && (
+                <p id="account-external-reference-error" className="text-sm text-destructive">
+                  {errors.externalReference}
                 </p>
               )}
             </div>

--- a/frontend/src/pages/accounts/index.tsx
+++ b/frontend/src/pages/accounts/index.tsx
@@ -30,8 +30,8 @@ async function listAccounts(
   if (params.filters?.status) {
     body.status = params.filters.status
   }
-  if (params.filters?.iban) {
-    body.iban = params.filters.iban
+  if (params.filters?.externalReference) {
+    body.iban = params.filters.externalReference
   }
 
   const response = await fetch(
@@ -55,7 +55,7 @@ async function listAccounts(
   // Map proto CurrentAccountFacility fields to frontend CurrentAccount shape
   const accounts: CurrentAccount[] = (data.accounts ?? []).map((a) => ({
     accountId: a.accountId ?? '',
-    iban: a.accountIdentification ?? '',
+    externalReference: a.accountIdentification ?? '',
     status: stripEnumPrefix(a.accountStatus ?? '', 'ACCOUNT_STATUS_') as CurrentAccount['status'],
     baseCurrency: stripEnumPrefix(a.baseCurrency ?? '', 'CURRENCY_'),
     availableBalance: '',
@@ -99,8 +99,8 @@ export function AccountsPage() {
       header: 'Account ID',
     },
     {
-      accessorKey: 'iban',
-      header: 'IBAN',
+      accessorKey: 'externalReference',
+      header: 'External Ref',
     },
     {
       accessorKey: 'status',
@@ -147,8 +147,8 @@ export function AccountsPage() {
             options: STATUS_OPTIONS,
           },
           {
-            field: 'iban',
-            label: 'IBAN',
+            field: 'externalReference',
+            label: 'External Ref',
             type: 'text',
           },
         ]}

--- a/frontend/src/pages/accounts/types.ts
+++ b/frontend/src/pages/accounts/types.ts
@@ -6,7 +6,7 @@
 
 export interface CurrentAccount {
   accountId: string
-  iban: string
+  externalReference: string
   status: AccountStatus
   baseCurrency: string
   availableBalance: string

--- a/frontend/src/pages/payments/dialogs/initiate-payment-dialog.test.tsx
+++ b/frontend/src/pages/payments/dialogs/initiate-payment-dialog.test.tsx
@@ -81,7 +81,7 @@ describe('InitiatePaymentDialog - rendering', () => {
     )
 
     expect(screen.getByLabelText(/debtor account/i)).toBeInTheDocument()
-    expect(screen.getByLabelText(/creditor iban/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/creditor reference/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/amount/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/currency/i)).toBeInTheDocument()
   })
@@ -98,12 +98,12 @@ describe('InitiatePaymentDialog - rendering', () => {
   })
 })
 
-describe('InitiatePaymentDialog - IBAN validation', () => {
+describe('InitiatePaymentDialog - creditor reference validation', () => {
   beforeEach(() => {
     mockUseInitiatePayment.mockReturnValue(makeMockMutation())
   })
 
-  it('shows validation error for empty IBAN on submit', async () => {
+  it('shows validation error for empty creditor reference on submit', async () => {
     const user = userEvent.setup()
 
     render(
@@ -115,28 +115,11 @@ describe('InitiatePaymentDialog - IBAN validation', () => {
     await user.click(screen.getByRole('button', { name: /initiate payment/i }))
 
     await waitFor(() => {
-      expect(screen.getByText(/iban is required/i)).toBeInTheDocument()
+      expect(screen.getByText(/creditor reference is required/i)).toBeInTheDocument()
     })
   })
 
-  it('shows validation error for invalid IBAN format', async () => {
-    const user = userEvent.setup()
-
-    render(
-      <Wrapper>
-        <InitiatePaymentDialog open={true} onOpenChange={vi.fn()} onSuccess={vi.fn()} />
-      </Wrapper>,
-    )
-
-    await user.type(screen.getByLabelText(/creditor iban/i), 'not-an-iban')
-    await user.click(screen.getByRole('button', { name: /initiate payment/i }))
-
-    await waitFor(() => {
-      expect(screen.getByText(/invalid iban format/i)).toBeInTheDocument()
-    })
-  })
-
-  it('accepts valid IBAN format', async () => {
+  it('accepts any non-empty creditor reference', async () => {
     const user = userEvent.setup()
     const mutateAsync = vi.fn().mockResolvedValue({ paymentOrderId: 'po-new' })
     mockUseInitiatePayment.mockReturnValue(makeMockMutation({ mutateAsync }))
@@ -148,12 +131,12 @@ describe('InitiatePaymentDialog - IBAN validation', () => {
     )
 
     await user.type(screen.getByLabelText(/debtor account/i), 'acct-001')
-    await user.type(screen.getByLabelText(/creditor iban/i), 'GB29NWBK60161331926819')
+    await user.type(screen.getByLabelText(/creditor reference/i), '12-34-56-78901234')
     await user.type(screen.getByLabelText(/amount/i), '100.00')
     await user.click(screen.getByRole('button', { name: /initiate payment/i }))
 
     await waitFor(() => {
-      expect(screen.queryByText(/invalid iban format/i)).not.toBeInTheDocument()
+      expect(mutateAsync).toHaveBeenCalledOnce()
     })
   })
 
@@ -167,7 +150,7 @@ describe('InitiatePaymentDialog - IBAN validation', () => {
     )
 
     await user.type(screen.getByLabelText(/debtor account/i), 'acct-001')
-    await user.type(screen.getByLabelText(/creditor iban/i), 'GB29NWBK60161331926819')
+    await user.type(screen.getByLabelText(/creditor reference/i), 'GB29NWBK60161331926819')
     await user.click(screen.getByRole('button', { name: /initiate payment/i }))
 
     await waitFor(() => {
@@ -185,7 +168,7 @@ describe('InitiatePaymentDialog - IBAN validation', () => {
     )
 
     await user.type(screen.getByLabelText(/debtor account/i), 'acct-001')
-    await user.type(screen.getByLabelText(/creditor iban/i), 'GB29NWBK60161331926819')
+    await user.type(screen.getByLabelText(/creditor reference/i), 'GB29NWBK60161331926819')
     await user.type(screen.getByLabelText(/amount/i), '0')
     await user.click(screen.getByRole('button', { name: /initiate payment/i }))
 
@@ -210,7 +193,7 @@ describe('InitiatePaymentDialog - successful submission', () => {
     )
 
     await user.type(screen.getByLabelText(/debtor account/i), 'acct-001')
-    await user.type(screen.getByLabelText(/creditor iban/i), 'GB29NWBK60161331926819')
+    await user.type(screen.getByLabelText(/creditor reference/i), 'GB29NWBK60161331926819')
     await user.type(screen.getByLabelText(/amount/i), '100.00')
     await user.click(screen.getByRole('button', { name: /initiate payment/i }))
 
@@ -244,7 +227,7 @@ describe('InitiatePaymentDialog - successful submission', () => {
 })
 
 describe('InitiatePaymentDialog - error handling', () => {
-  it('shows field-level error for INVALID_ARGUMENT with field violations', async () => {
+  it('shows field-level error for creditor reference validation failure', async () => {
     const user = userEvent.setup()
     const { Code, ConnectError } = await import('@connectrpc/connect')
     const err = new ConnectError('invalid', Code.InvalidArgument)
@@ -254,7 +237,7 @@ describe('InitiatePaymentDialog - error handling', () => {
         value: new Uint8Array(),
         debug: {
           fieldViolations: [
-            { field: 'creditor_reference', description: 'Invalid IBAN checksum' },
+            { field: 'creditor_reference', description: 'Invalid creditor reference' },
           ],
         },
       },
@@ -269,12 +252,12 @@ describe('InitiatePaymentDialog - error handling', () => {
     )
 
     await user.type(screen.getByLabelText(/debtor account/i), 'acct-001')
-    await user.type(screen.getByLabelText(/creditor iban/i), 'GB29NWBK60161331926819')
+    await user.type(screen.getByLabelText(/creditor reference/i), 'GB29NWBK60161331926819')
     await user.type(screen.getByLabelText(/amount/i), '100.00')
     await user.click(screen.getByRole('button', { name: /initiate payment/i }))
 
     await waitFor(() => {
-      expect(screen.getByText('Invalid IBAN checksum')).toBeInTheDocument()
+      expect(screen.getByText('Invalid creditor reference')).toBeInTheDocument()
     })
   })
 
@@ -292,7 +275,7 @@ describe('InitiatePaymentDialog - error handling', () => {
     )
 
     await user.type(screen.getByLabelText(/debtor account/i), 'acct-001')
-    await user.type(screen.getByLabelText(/creditor iban/i), 'GB29NWBK60161331926819')
+    await user.type(screen.getByLabelText(/creditor reference/i), 'GB29NWBK60161331926819')
     await user.type(screen.getByLabelText(/amount/i), '100.00')
     await user.click(screen.getByRole('button', { name: /initiate payment/i }))
 

--- a/frontend/src/pages/payments/dialogs/initiate-payment-dialog.tsx
+++ b/frontend/src/pages/payments/dialogs/initiate-payment-dialog.tsx
@@ -14,19 +14,16 @@ import { handleConnectError } from '@/lib/error-handling'
 import { useInitiatePayment } from './payment-mutations'
 import { amountToBigInt } from './payment-form-utils'
 
-// IBAN pattern: 2 letter country code + 2 digits + up to 30 alphanumeric chars (no spaces)
-const IBAN_PATTERN = /^[A-Z]{2}[0-9]{2}[A-Z0-9]{1,30}$/
-
 interface FormData {
   debtorAccountId: string
-  creditorIban: string
+  creditorReference: string
   amount: string
   currency: string
 }
 
 interface FormErrors {
   debtorAccountId?: string
-  creditorIban?: string
+  creditorReference?: string
   amount?: string
   currency?: string
   general?: string
@@ -46,7 +43,7 @@ export function InitiatePaymentDialog({
   const initiate = useInitiatePayment()
   const [formData, setFormData] = React.useState<FormData>({
     debtorAccountId: '',
-    creditorIban: '',
+    creditorReference: '',
     amount: '',
     currency: 'GBP',
   })
@@ -54,7 +51,7 @@ export function InitiatePaymentDialog({
 
   React.useEffect(() => {
     if (!open) {
-      setFormData({ debtorAccountId: '', creditorIban: '', amount: '', currency: 'GBP' })
+      setFormData({ debtorAccountId: '', creditorReference: '', amount: '', currency: 'GBP' })
       setErrors({})
       initiate.reset()
     }
@@ -67,10 +64,8 @@ export function InitiatePaymentDialog({
       newErrors.debtorAccountId = 'Debtor account is required'
     }
 
-    if (!formData.creditorIban.trim()) {
-      newErrors.creditorIban = 'IBAN is required'
-    } else if (!IBAN_PATTERN.test(formData.creditorIban.trim())) {
-      newErrors.creditorIban = 'Invalid IBAN format'
+    if (!formData.creditorReference.trim()) {
+      newErrors.creditorReference = 'Creditor reference is required'
     }
 
     if (!formData.amount.trim()) {
@@ -97,7 +92,7 @@ export function InitiatePaymentDialog({
     try {
       const result = await initiate.mutateAsync({
         debtorAccountId: formData.debtorAccountId.trim(),
-        creditorReference: formData.creditorIban.trim(),
+        creditorReference: formData.creditorReference.trim(),
         amount: formData.amount.trim(),
         currency: formData.currency,
       })
@@ -112,7 +107,7 @@ export function InitiatePaymentDialog({
       if (result.code === Code.InvalidArgument && Object.keys(result.fieldErrors).length > 0) {
         const fieldMap: FormErrors = {}
         for (const [field, msg] of Object.entries(result.fieldErrors)) {
-          if (field === 'creditor_reference') fieldMap.creditorIban = msg
+          if (field === 'creditor_reference') fieldMap.creditorReference = msg
           else if (field === 'debtor_account_id') fieldMap.debtorAccountId = msg
           else if (field === 'amount') fieldMap.amount = msg
           else fieldMap.general = msg
@@ -173,19 +168,19 @@ export function InitiatePaymentDialog({
             </div>
 
             <div className="space-y-1">
-              <label htmlFor="creditorIban" className="text-sm font-medium">
-                Creditor IBAN
+              <label htmlFor="creditorReference" className="text-sm font-medium">
+                Creditor Reference
               </label>
               <Input
-                id="creditorIban"
-                value={formData.creditorIban}
-                onChange={handleChange('creditorIban')}
-                placeholder="GB29NWBK60161331926819"
-                aria-describedby={errors.creditorIban ? 'creditorIban-error' : undefined}
+                id="creditorReference"
+                value={formData.creditorReference}
+                onChange={handleChange('creditorReference')}
+                placeholder="e.g. GB29NWBK60161331926819 or sort code"
+                aria-describedby={errors.creditorReference ? 'creditorReference-error' : undefined}
               />
-              {errors.creditorIban && (
-                <p id="creditorIban-error" className="text-sm text-destructive">
-                  {errors.creditorIban}
+              {errors.creditorReference && (
+                <p id="creditorReference-error" className="text-sm text-destructive">
+                  {errors.creditorReference}
                 </p>
               )}
             </div>

--- a/frontend/src/pages/payments/dialogs/payment-mutations.test.tsx
+++ b/frontend/src/pages/payments/dialogs/payment-mutations.test.tsx
@@ -30,7 +30,7 @@ function makeWrapper() {
 const mockPaymentOrder = {
   paymentOrderId: 'po-123',
   debtorAccountId: 'acc-456',
-  creditorIban: 'GB29NWBK60161331926819',
+  creditorReference: 'GB29NWBK60161331926819',
   amount: '10000',
   currency: 'GBP',
   status: 'COMPLETED',

--- a/frontend/src/pages/payments/index.tsx
+++ b/frontend/src/pages/payments/index.tsx
@@ -37,8 +37,8 @@ const columns: ColumnDef<PaymentOrder>[] = [
     header: 'Debtor Account',
   },
   {
-    accessorKey: 'creditorIban',
-    header: 'Creditor IBAN',
+    accessorKey: 'creditorReference',
+    header: 'Creditor Reference',
   },
   {
     accessorKey: 'amount',

--- a/frontend/src/pages/payments/payment-detail-query.test.ts
+++ b/frontend/src/pages/payments/payment-detail-query.test.ts
@@ -4,7 +4,7 @@ import { fetchPaymentDetail } from './payment-detail-query'
 const mockPaymentOrder = {
   paymentOrderId: 'po-123',
   debtorAccountId: 'acc-456',
-  creditorIban: 'GB29NWBK60161331926819',
+  creditorReference: 'GB29NWBK60161331926819',
   amount: '10000',
   currency: 'GBP',
   status: 'COMPLETED',

--- a/frontend/src/pages/payments/payment-detail-query.ts
+++ b/frontend/src/pages/payments/payment-detail-query.ts
@@ -3,7 +3,7 @@ import type { SagaStep } from '@/components/shared/saga-timeline'
 export interface PaymentOrderDetail {
   paymentOrderId: string
   debtorAccountId: string
-  creditorIban: string
+  creditorReference: string
   amount: string
   currency: string
   status: string

--- a/frontend/src/pages/payments/payment-detail.test.tsx
+++ b/frontend/src/pages/payments/payment-detail.test.tsx
@@ -56,7 +56,7 @@ function Wrapper({
 const sampleDetail = {
   paymentOrderId: 'po-001',
   debtorAccountId: 'acct-debtor-1',
-  creditorIban: 'GB29 NWBK 6016 1331 9268 19',
+  creditorReference: 'GB29 NWBK 6016 1331 9268 19',
   amount: '10050',
   currency: 'GBP',
   status: 'COMPLETED',
@@ -159,7 +159,7 @@ describe('PaymentDetailPage - Overview tab', () => {
     })
   })
 
-  it('shows creditor IBAN', async () => {
+  it('shows creditor reference', async () => {
     render(
       <Wrapper>
         <PaymentDetailPage />

--- a/frontend/src/pages/payments/payment-detail.tsx
+++ b/frontend/src/pages/payments/payment-detail.tsx
@@ -200,7 +200,7 @@ export function PaymentDetailPage() {
               <div className="divide-y">
                 <DetailRow label="Payment Order ID">{data.paymentOrderId}</DetailRow>
                 <DetailRow label="Debtor Account">{data.debtorAccountId}</DetailRow>
-                <DetailRow label="Creditor IBAN">{data.creditorIban}</DetailRow>
+                <DetailRow label="Creditor Reference">{data.creditorReference}</DetailRow>
                 <DetailRow label="Amount">
                   <MoneyDisplay amount={data.amount} currency={data.currency} />
                 </DetailRow>

--- a/frontend/src/pages/payments/payments-list.test.tsx
+++ b/frontend/src/pages/payments/payments-list.test.tsx
@@ -41,7 +41,7 @@ const samplePayments = [
   {
     paymentOrderId: 'po-001',
     debtorAccountId: 'acct-debtor-1',
-    creditorIban: 'GB29 NWBK 6016 1331 9268 19',
+    creditorReference: 'GB29 NWBK 6016 1331 9268 19',
     amount: '10050',
     currency: 'GBP',
     status: 'COMPLETED',
@@ -50,7 +50,7 @@ const samplePayments = [
   {
     paymentOrderId: 'po-002',
     debtorAccountId: 'acct-debtor-2',
-    creditorIban: 'DE89 3704 0044 0532 0130 00',
+    creditorReference: 'DE89 3704 0044 0532 0130 00',
     amount: '50000',
     currency: 'EUR',
     status: 'EXECUTING',
@@ -83,7 +83,7 @@ describe('PaymentsPage - list rendering', () => {
     await waitFor(() => {
       expect(screen.getByRole('columnheader', { name: /payment id/i })).toBeInTheDocument()
       expect(screen.getByRole('columnheader', { name: /debtor account/i })).toBeInTheDocument()
-      expect(screen.getByRole('columnheader', { name: /creditor iban/i })).toBeInTheDocument()
+      expect(screen.getByRole('columnheader', { name: /creditor reference/i })).toBeInTheDocument()
       expect(screen.getByRole('columnheader', { name: /amount/i })).toBeInTheDocument()
       expect(screen.getByRole('columnheader', { name: /status/i })).toBeInTheDocument()
       expect(screen.getByRole('columnheader', { name: /created/i })).toBeInTheDocument()

--- a/frontend/src/pages/payments/payments-query.test.ts
+++ b/frontend/src/pages/payments/payments-query.test.ts
@@ -6,7 +6,7 @@ const mockPaymentOrders = [
   {
     paymentOrderId: 'po-001',
     debtorAccountId: 'acc-100',
-    creditorIban: 'GB29NWBK60161331926819',
+    creditorReference: 'GB29NWBK60161331926819',
     amount: '5000',
     currency: 'GBP',
     status: 'COMPLETED',
@@ -15,7 +15,7 @@ const mockPaymentOrders = [
   {
     paymentOrderId: 'po-002',
     debtorAccountId: 'acc-200',
-    creditorIban: 'DE89370400440532013000',
+    creditorReference: 'DE89370400440532013000',
     amount: '15000',
     currency: 'EUR',
     status: 'PENDING',

--- a/frontend/src/pages/payments/payments-query.ts
+++ b/frontend/src/pages/payments/payments-query.ts
@@ -3,7 +3,7 @@ import type { DataTableQueryParams, DataTableResult } from '@/components/shared/
 export interface PaymentOrder {
   paymentOrderId: string
   debtorAccountId: string
-  creditorIban: string
+  creditorReference: string
   amount: string
   currency: string
   status: string


### PR DESCRIPTION
## Summary

- Rename all IBAN-specific labels, field names, and validation patterns to generic "External Reference" / "Creditor Reference" terminology across the frontend accounts and payments modules
- Remove IBAN_PATTERN regex validation (keep required-only validation) since the field now stores MPANs, sort codes, and other external identifiers beyond IBANs
- Update proto comments to reflect asset-agnostic terminology

## Changes Made

### Accounts Module (7 files)
- **types.ts**: `iban` -> `externalReference` on `CurrentAccount` interface
- **index.tsx**: Column header "IBAN" -> "External Ref", filter field/label updated, field mapping renamed
- **create-account-dialog.tsx**: Removed `IBAN_PATTERN` constant, renamed form fields, updated labels/placeholders/error messages, removed format validation (kept required check)
- **[accountId].tsx**: Header and overview tab label "IBAN" -> "External Reference"
- **account-detail.test.tsx**: Updated mock data field name and test description
- **accounts-list.test.tsx**: Updated column header assertion and filter placeholder

### Payments Module (12 files)
- **payments-query.ts**: `creditorIban` -> `creditorReference` on `PaymentOrder` interface
- **payment-detail-query.ts**: `creditorIban` -> `creditorReference` on `PaymentOrderDetail` interface
- **index.tsx**: Column header "Creditor IBAN" -> "Creditor Reference"
- **payment-detail.tsx**: Detail row label "Creditor IBAN" -> "Creditor Reference"
- **initiate-payment-dialog.tsx**: Removed `IBAN_PATTERN`, renamed form fields, updated labels/placeholders/error messages, removed format validation
- **initiate-payment-dialog.test.tsx**: Rewrote IBAN validation tests to creditor reference validation tests, removed format validation test
- **payment-mutations.test.tsx**: Updated mock data field name
- **payment-detail-query.test.ts**: Updated mock data field name
- **payment-detail.test.tsx**: Updated mock data field name and test description
- **payments-list.test.tsx**: Updated mock data and column header assertion
- **payments-query.test.ts**: Updated mock data field names

### Proto Comments (2 files)
- **current_account.proto**: Updated filter field comment and OpenAPI description
- **payment_order.proto**: Updated creditor_reference comments to reference generic external identifiers

## Testing

- All 1511 unit tests pass across 113 test files
- All pre-commit checks pass (gitleaks, buf lint, buf breaking)

## Task Master

Task: asset-agnostic-accounts.13 - Rename IBAN to External Reference across frontend UI