### PR TITLE
docs: standardise documentation to UK English spelling

### DIFF
--- a/.github/claude-review-instructions.md
+++ b/.github/claude-review-instructions.md
@@ -189,7 +189,7 @@ risk assessment with key imports read.
 Check the PR description for Task Master references (format: `tag.task-id`
 like `mim.9.1`). If present:
 
-- The PR description should summarize the requirements
+- The PR description should summarise the requirements
 - Validate: Does the implementation fulfill those stated requirements?
 - Acknowledge when requirements are met: "This satisfies the requirement
   for X"
@@ -345,10 +345,10 @@ non-trivial change, assess:
 ### Test Coverage Review
 
 For each changed function, check whether the test file is in the diff.
-If it is, review whether the test actually verifies the behavior. If not,
+If it is, review whether the test actually verifies the behaviour. If not,
 check if a `*_test.go` file exists for the package, then note:
 "No test changes for [function] - verify existing tests cover the new
-behavior" or "No test file found for [file]." Focus on domain edge cases,
+behaviour" or "No test file found for [file]." Focus on domain edge cases,
 not generic coverage.
 
 ### Questions for the Author (Nemawashi)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@ The following services have handler registration functions you need to call:
 
 - **Clear Dependencies**: Explicit registration shows what services your saga orchestrates
 - **Better Testing**: Inject mock clients for unit testing
-- **No Global State**: Each service initialization creates its own registry
+- **No Global State**: Each service initialisation creates its own registry
 - **Service Ownership**: Service teams own their Starlark bindings
 - **Real Service Integration**: Handlers now call actual gRPC services with validation, resilience, and
   observability
@@ -108,13 +108,13 @@ lien_result = current_account.create_lien(
 )
 ```
 
-Only the Go initialization code in `cmd/main.go` needs to change.
+Only the Go initialisation code in `cmd/main.go` needs to change.
 
 #### Timeline for Migration
 
 - **Removed in this release**: `saga.DefaultRegistry()` global registry
 - **Added in this release**: `{service}client.RegisterStarlarkHandlers` functions
-- **Required action**: Update service initialization code in `cmd/main.go`
+- **Required action**: Update service initialisation code in `cmd/main.go`
 
 #### Documentation
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ iteration.
 
 ## Our Standards
 
-### Expected Behavior
+### Expected Behaviour
 
 - Focus on technical merit and constructive feedback
 - Communicate clearly and professionally
@@ -19,7 +19,7 @@ iteration.
 - Accept constructive criticism gracefully
 - Support fellow contributors and maintainers
 
-### Unacceptable Behavior
+### Unacceptable Behaviour
 
 - Harassment, intimidation, or discriminatory language
 - Personal attacks or inflammatory comments
@@ -41,7 +41,7 @@ This Code of Conduct applies to:
 
 ### Reporting
 
-If you experience or witness unacceptable behavior:
+If you experience or witness unacceptable behaviour:
 
 1. **Direct Resolution**: If comfortable, address the issue directly with the individual
 2. **Maintainer Report**: Contact project maintainers through:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -459,7 +459,7 @@ through coding patterns and conventions.
 
    ```
 
-1. **Constructor Functions for Complex Initialization**
+1. **Constructor Functions for Complex Initialisation**
    - Use `NewX()` constructors that return fully initialized, valid instances
    - Validate inputs in constructors
    - Return errors for invalid states rather than creating invalid objects
@@ -550,7 +550,7 @@ We follow strict TDD practices to ensure code quality, correctness, and maintain
 #### The Cycle
 
 1. **Red**: Write a failing test first
-   - Define the expected behavior before implementation
+   - Define the expected behaviour before implementation
    - Test should fail for the right reason (not compile error)
    - Verify the test fails by running it
 
@@ -559,7 +559,7 @@ We follow strict TDD practices to ensure code quality, correctness, and maintain
    - Don't worry about elegance yet
    - All tests must pass
 
-1. **Refactor**: Improve code quality without changing behavior
+1. **Refactor**: Improve code quality without changing behaviour
    - Apply immutability principles
    - Remove duplication
    - Improve naming and structure
@@ -613,7 +613,7 @@ func (m Money) Add(other Money) Money {
 1. **Write Test Names as Specifications**
 
    ```go
-   // Good: Clear specification of behavior
+   // Good: Clear specification of behaviour
    func TestAccount_Deposit_PositiveAmount_IncreasesBalance(t *testing.T)
    func TestAccount_Deposit_NegativeAmount_ReturnsError(t *testing.T)
 
@@ -663,7 +663,7 @@ func (m Money) Add(other Money) Money {
    // 3. Refactor if needed
    ```
 
-#### Test Organization
+#### Test Organisation
 
 - Write table-driven tests for multiple scenarios
 - Use meaningful test names: `TestFunctionName_Scenario_ExpectedBehavior`
@@ -676,14 +676,14 @@ func (m Money) Add(other Money) Money {
 
 #### Principle
 
-Test not only the expected behavior but also how the system handles unexpected, invalid, or malicious inputs.
+Test not only the expected behaviour but also how the system handles unexpected, invalid, or malicious inputs.
 
 > 📖 **See [ADR-008: Defensive Testing Standards](docs/adr/0008-defensive-testing-standards.md)** for comprehensive
 guidelines, examples, and rationale.
 
 We follow **defensive testing** practices:
 
-1. **Happy Path Testing**: Verify expected behavior with valid inputs
+1. **Happy Path Testing**: Verify expected behaviour with valid inputs
 2. **Unhappy Path Testing**: Verify graceful failure with invalid inputs
 3. **Edge Case Testing**: Test boundary conditions and extreme values
 4. **Negative Testing**: Test with values that should never occur
@@ -1040,7 +1040,7 @@ go test ./...
 
 ### Timing-Sensitive Tests
 
-Some tests validate time-based behavior (e.g., exponential backoff, jitter, timeouts) and are sensitive to CPU
+Some tests validate time-based behaviour (e.g., exponential backoff, jitter, timeouts) and are sensitive to CPU
 scheduler variance in CI environments.
 
 **Local Development:**
@@ -1075,7 +1075,7 @@ scheduler variance in CI environments.
 
 - Use generous tolerance ranges (±30% or more for CI variance)
 - Document why specific tolerance values are chosen
-- Test functional behavior separately without timing assertions
+- Test functional behaviour separately without timing assertions
 
 ### Writing Tests
 
@@ -1085,7 +1085,7 @@ scheduler variance in CI environments.
 4. **Test Fixtures**: Use testdata/ for sample data
 5. **Mocking**: Use interfaces for external dependencies
 
-### Test Organization
+### Test Organisation
 
 ```text
 internal/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,7 +64,7 @@ detailed controls.
 ### Replay Attacks
 
 Re-submission of previously valid requests to duplicate transactions or bypass
-authorization. Mitigations include:
+authorisation. Mitigations include:
 
 - **Idempotency keys**: Critical operations (payment orders, ledger postings) require
   idempotency keys. Duplicate submissions return the original result without
@@ -72,7 +72,7 @@ authorization. Mitigations include:
 - **Audit outbox deduplication**: The outbox worker processes entries idempotently;
   retries do not create duplicate audit records.
 
-### Authorization Bypass
+### Authorisation Bypass
 
 Accessing operations or data without proper permissions. Controls include:
 
@@ -157,9 +157,9 @@ Tenant identity flows through the entire request lifecycle:
 - **JWT-tenant validation**: In production (`AUTH_ENABLED=true`), `auth.Interceptor`
   validates that the `x-tenant-id` gRPC metadata matches the JWT's `tenant_id` claim.
   This prevents a caller from specifying a different tenant than their credentials
-  authorize.
+  authorise.
 - **No cross-tenant database access**: Each service connects to its own database with
-  its own credentials. The centralized audit worker pattern was explicitly rejected to
+  its own credentials. The centralised audit worker pattern was explicitly rejected to
   maintain bounded context isolation (see
   [ADR-0020](docs/adr/0020-per-service-audit-workers.md)).
 
@@ -184,7 +184,7 @@ The audit system uses two delivery paths for resilience:
    (e.g., `audit.events.current-account`). Dedicated audit consumer deployments write
    to `audit_log`.
 2. **Fallback (Outbox)**: When Kafka is unavailable (timeout: 5 seconds), audit entries
-   remain in the `audit_outbox` table. A centralized `audit-worker` service polls and
+   remain in the `audit_outbox` table. A centralised `audit-worker` service polls and
    processes these entries.
 
 This dual-path design ensures no audit records are lost during infrastructure failures.
@@ -248,7 +248,7 @@ When contributing to or deploying Meridian:
 - Keep dependencies up to date
 - Follow secure coding practices outlined in our contribution guidelines
 - Use environment variables for sensitive configuration
-- Enable authentication and authorization in production deployments
+- Enable authentication and authorisation in production deployments
   (`AUTH_ENABLED=true`)
 - Regular security audits of your deployment configuration
 - Use `pq.QuoteIdentifier()` for all dynamic SQL identifiers

--- a/api/proto/README.md
+++ b/api/proto/README.md
@@ -104,7 +104,7 @@ classDiagram
 
 - CurrentAccountService → Party, PositionKeeping, FinancialAccounting
 - PaymentOrderService → CurrentAccount (for fund reservations via Lien)
-- TenantService → Party (optional: registers organization Party on tenant creation)
+- TenantService → Party (optional: registers organisation Party on tenant creation)
 
 ## Tooling
 
@@ -293,7 +293,7 @@ Event schemas in `api/proto/meridian/events/` use protobuf's native versioning (
 - Schema compatibility validated via `buf breaking` in CI/CD
 - No runtime schema registry needed (Kafka is internal-only)
 - Same protobuf definitions used for both gRPC and Kafka events
-- New BIAN behavior qualifiers → new event types (new topics)
+- New BIAN behaviour qualifiers → new event types (new topics)
 - Backward-compatible changes → add optional fields
 
 See [ADR-0004: Event Schema Evolution Strategy](../../docs/adr/0004-event-schema-evolution.md) for details.

--- a/deployments/k8s/policies/tests/README.md
+++ b/deployments/k8s/policies/tests/README.md
@@ -165,9 +165,9 @@ Add to your CI pipeline:
 1. **`envFrom` references are not checked at the Pod/Deployment level**: When a container uses
    `envFrom` to reference a ConfigMap, the policy cannot detect `LOCAL_DEV_MODE=true` at the
    workload level. However, the ConfigMap itself is validated when created/updated, providing
-   defense-in-depth.
+   defence-in-depth.
 
-2. **"product" namespace prefix matches are intentional**: Namespaces like `product-catalog` will
+2. **"product" namespace prefix matches are intentional**: Namespaces like `product-catalogue` will
    be flagged as production due to the `prod*` prefix match. This is by design - false positives
    are safer than false negatives for security policies. If needed, adjust the namespace matching
    logic in the Rego policy.

--- a/docs/adr/0002-microservices-per-bian-domain.md
+++ b/docs/adr/0002-microservices-per-bian-domain.md
@@ -156,8 +156,8 @@ Common platform services (database, Kafka, auth, observability) will be in:
 ```text
 platform/
 ├── database/        # Connection pooling, transaction management
-├── kafka/           # Producer/consumer utilities with protobuf serialization
-├── auth/            # JWT validation, authorization
+├── kafka/           # Producer/consumer utilities with protobuf serialisation
+├── auth/            # JWT validation, authorisation
 ├── observability/   # OpenTelemetry, logging, metrics
 └── idempotency/     # Redis-based idempotency keys
 ```
@@ -165,7 +165,7 @@ platform/
 ### Inter-Service Communication
 
 * Synchronous: gRPC with Protobuf (leveraging existing API contracts)
-* Asynchronous: Kafka events with protobuf serialization (validated via `buf breaking` in CI)
+* Asynchronous: Kafka events with protobuf serialisation (validated via `buf breaking` in CI)
 * Service discovery: Kubernetes DNS
 * Load balancing: Kubernetes Service resources + gRPC client-side load balancing
 
@@ -210,8 +210,8 @@ On failure at any step:
 * **Explicit control flow**: Orchestrator explicitly calls each service step-by-step
 * **Business logic visibility**: Saga logic lives in CurrentAccount domain code, not infrastructure
 * **Debugging**: Clear call stack for transaction flow
-* **BIAN alignment**: BIAN's "Execute" behavior qualifiers map naturally to orchestration
-* **Error handling**: Centralized compensation logic in orchestrator
+* **BIAN alignment**: BIAN's "Execute" behaviour qualifiers map naturally to orchestration
+* **Error handling**: Centralised compensation logic in orchestrator
 
 ### Alternatives Considered
 
@@ -320,7 +320,7 @@ func (s *CurrentAccountService) ExecuteDeposit(ctx context.Context, req *pb.Exec
 * ✅ Debuggability: Single call stack for transaction flow
 * ✅ BIAN alignment: Maps naturally to BIAN's orchestration patterns
 * ✅ Testability: Orchestrator logic is unit-testable
-* ✅ Monitoring: Centralized metrics for transaction success/failure
+* ✅ Monitoring: Centralised metrics for transaction success/failure
 
 **Negative:**
 

--- a/docs/adr/0003-database-schema-migrations.md
+++ b/docs/adr/0003-database-schema-migrations.md
@@ -37,7 +37,7 @@ Financial services require:
 * Schema validation and safety checks
 * Clear audit trail of schema changes
 * Support for CockroachDB/YugabyteDB (PostgreSQL-compatible)
-* **Database entities optimized for persistence concerns** (audit fields, indexes, constraints)
+* **Database entities optimised for persistence concerns** (audit fields, indexes, constraints)
 * **Separation from domain models** to allow independent evolution
 
 ## Decision Drivers
@@ -50,7 +50,7 @@ Financial services require:
 * **Type safety between persistence layer and database schema**
 * Version control migrations alongside service code
 * **Schema linting and safety checks** before deployment
-* **Database entities separate from domain models** for flexibility (audit fields, denormalization, optimization)
+* **Database entities separate from domain models** for flexibility (audit fields, denormalization, optimisation)
 
 ## Considered Options
 
@@ -83,7 +83,7 @@ Chosen option: **"Atlas"**, because:
 * CLI tool integrates with Go build pipeline
 * **Can still write manual migrations** when needed (hybrid approach)
 * **Schema diffing**: Compare environments to detect drift
-* **Separation of concerns**: Database entities can include audit fields, indexes, and optimizations without polluting
+* **Separation of concerns**: Database entities can include audit fields, indexes, and optimisations without polluting
 domain models
 
 ### Negative Consequences
@@ -154,7 +154,7 @@ Database: meridian_current_account
 ```
 
 - Each service has its own PostgreSQL database
-- Each organization gets its own schema within each service database
+- Each organisation gets its own schema within each service database
 - Connection URL includes `search_path` for org routing: `postgres://...?search_path=org_acme_bank`
 - Queries use unqualified table names; PostgreSQL resolves via `search_path`
 
@@ -220,7 +220,7 @@ import (
 )
 
 // BookingLogEntity represents the database persistence model
-// Optimized for database concerns: audit fields, indexes, constraints
+// Optimised for database concerns: audit fields, indexes, constraints
 type BookingLogEntity struct {
     // Primary key
     ID              uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
@@ -287,7 +287,7 @@ const (
     BookingStatusFailed  BookingStatus = "failed"
 )
 
-// Domain behavior methods
+// Domain behaviour methods
 func (b *FinancialBookingLog) Post() error {
     if b.Status != BookingStatusPending {
         return ErrInvalidStatusTransition
@@ -499,7 +499,7 @@ While CockroachDB is PostgreSQL-compatible, some PostgreSQL features are **not s
 Use explicit timestamp columns (`period_start`, `period_end`) instead of range types for temporal
 data. See [ADR-0017](0017-temporal-quality-ladder.md) for the temporal data pattern.
 
-For deployments using PostgreSQL or YugabyteDB exclusively, database-specific optimizations
+For deployments using PostgreSQL or YugabyteDB exclusively, database-specific optimisations
 (TSTZRANGE with GiST indexes, exclusion constraints) can be added as an optional enhancement.
 
 ### Future Considerations
@@ -508,4 +508,4 @@ For deployments using PostgreSQL or YugabyteDB exclusively, database-specific op
 * Schema visualization for documentation
 * Multi-tenant schema management patterns
 * Cross-region migration strategies for distributed SQL
-* Database-specific optimization paths (PostgreSQL/YugabyteDB TSTZRANGE support)
+* Database-specific optimisation paths (PostgreSQL/YugabyteDB TSTZRANGE support)

--- a/docs/adr/0004-event-schema-evolution.md
+++ b/docs/adr/0004-event-schema-evolution.md
@@ -38,7 +38,7 @@ across releases (13.0 → 14.0 → 15.0).
 - **External integration via gRPC** - External systems interact through gRPC APIs, not by consuming Kafka topics
 - **Database is source of truth** - CockroachDB/YugabyteDB provides persistent state; Kafka is ephemeral coordination
 - **Monorepo structure** - All services share `api/proto/` directory with compile-time validation
-- **High throughput goal** - Minimize latency and operational overhead
+- **High throughput goal** - Minimise latency and operational overhead
 - **Learning-focused** - Reference implementation should demonstrate patterns without unnecessary complexity
 
 ### The Schema Registry Question
@@ -48,7 +48,7 @@ value propositions don't align with our architecture:
 
 **Schema Registry provides:**
 
-- Centralized schema storage and runtime discovery
+- Centralised schema storage and runtime discovery
 - Governance for external consumers
 - Compatibility enforcement at registration time
 - Historical schema versions for replay
@@ -96,9 +96,9 @@ message AccountUpdated {
 
 **Validation:** `buf breaking --against main` ensures no breaking changes.
 
-**Consumer behavior:** Old consumers automatically ignore new fields (protobuf feature).
+**Consumer behaviour:** Old consumers automatically ignore new fields (protobuf feature).
 
-### Pattern 2: New BIAN Behavior Qualifier (New Event Type)
+### Pattern 2: New BIAN Behaviour Qualifier (New Event Type)
 
 For new BIAN operations with distinct semantics:
 
@@ -113,7 +113,7 @@ message AccountUpdated {
   string account_status = 4;
 }
 
-// New BIAN 14.0 behavior qualifier = new event type
+// New BIAN 14.0 behaviour qualifier = new event type
 message AccountSuspended {
   string event_id = 1;
   google.protobuf.Timestamp occurred_at = 2;
@@ -124,7 +124,7 @@ message AccountSuspended {
 }
 ```
 
-**Rationale:** BIAN behavior qualifiers (Initiate, Update, Suspend, Terminate) represent distinct operations. Map these
+**Rationale:** BIAN behaviour qualifiers (Initiate, Update, Suspend, Terminate) represent distinct operations. Map these
 to distinct event types rather than overloading a single event schema.
 
 **Topic strategy:** New event type = new Kafka topic (`account-suspended`)
@@ -133,7 +133,7 @@ to distinct event types rather than overloading a single event schema.
 
 - **One topic per event type:** `account-updated`, `account-suspended`, `booking-created`
 - **No version suffixes:** Use semantic names, not `account-updated-v2`
-- **BIAN alignment:** Topic names reflect BIAN behavior qualifiers
+- **BIAN alignment:** Topic names reflect BIAN behaviour qualifiers
 - **Retention policy:** 7 days (events are coordination, not system of record)
 
 ### Compatibility Validation
@@ -163,22 +163,22 @@ to distinct event types rather than overloading a single event schema.
 ## Decision Drivers
 
 - ✅ **Simplicity** - No Schema Registry to operate; protobuf native capabilities are sufficient
-- ✅ **Performance** - No external schema lookup; no network dependency for serialization
-- ✅ **BIAN semantic alignment** - New behavior qualifiers naturally map to new event types
+- ✅ **Performance** - No external schema lookup; no network dependency for serialisation
+- ✅ **BIAN semantic alignment** - New behaviour qualifiers naturally map to new event types
 - ✅ **Database-centric architecture** - Persistent layer is source of truth; Kafka is ephemeral
 - ✅ **Monorepo benefits** - Shared `api/proto/` enables compile-time validation across services
-- ✅ **High throughput** - Minimize latency by eliminating Schema Registry network calls
+- ✅ **High throughput** - Minimise latency by eliminating Schema Registry network calls
 - ✅ **Operational simplicity** - One less stateful service to manage, monitor, and backup
 
 ## Example Workflow: BIAN Evolution
 
-**Scenario:** BIAN 14.0 adds "Suspend" behavior qualifier to Current Account service domain.
+**Scenario:** BIAN 14.0 adds "Suspend" behaviour qualifier to Current Account service domain.
 
 ### Step 1: Decide Event Strategy
 
 Question: Is "Suspend" semantically different from "Update"?
 
-**Answer:** Yes - it's a distinct BIAN behavior qualifier with different business semantics.
+**Answer:** Yes - it's a distinct BIAN behaviour qualifier with different business semantics.
 
 **Decision:** Create new event type `AccountSuspended`.
 
@@ -266,14 +266,14 @@ func (p *CurrentAccountPublisher) PublishSuspended(
 - ✅ **Simpler operations** - No Schema Registry service to deploy, monitor, backup
 - ✅ **Compile-time safety** - `buf breaking` catches incompatibilities before deployment
 - ✅ **Better performance** - No schema registry lookup overhead (~0.01-100ms depending on cache)
-- ✅ **BIAN semantic alignment** - Event taxonomy matches BIAN behavior qualifiers
+- ✅ **BIAN semantic alignment** - Event taxonomy matches BIAN behaviour qualifiers
 - ✅ **Database-centric** - Leverages persistent layer as authoritative source
 - ✅ **Monorepo benefits** - All services have access to latest proto definitions
 - ✅ **Reduced complexity** - Fewer moving parts in production environment
 
 ### Negative
 
-- ❌ **No centralized schema registry** - Cannot discover schemas at runtime (not needed for internal use)
+- ❌ **No centralised schema registry** - Cannot discover schemas at runtime (not needed for internal use)
 - ❌ **Monorepo coupling** - Services must share `api/proto/` directory (acceptable for internal services)
 - ❌ **No polyglot runtime support** - External consumers would need proto file access (mitigated: use gRPC APIs)
 - ❌ **Manual topic creation** - Must explicitly create new topics for new event types (automation possible)
@@ -282,7 +282,7 @@ func (p *CurrentAccountPublisher) PublishSuspended(
 
 **Schema discovery:**
 
-- Document event schemas in `docs/events/event-catalog.md`
+- Document event schemas in `docs/events/event-catalogue.md`
 - Generate schema documentation via `buf` plugins
 - Maintain event type registry in documentation
 
@@ -304,7 +304,7 @@ Consider adding Schema Registry if:
 
 1. **External Kafka consumers** - Systems outside Meridian directly consume Kafka topics
 2. **Polyglot consumers** - Non-Go services need runtime schema discovery
-3. **Multi-team governance** - 20+ independent teams need centralized schema governance
+3. **Multi-team governance** - 20+ independent teams need centralised schema governance
 4. **Compliance requirements** - Audit trail of schema changes required for regulatory purposes
 
 **Currently:** None of these apply. Kafka is internal coordination; external integration uses gRPC.
@@ -313,11 +313,11 @@ Consider adding Schema Registry if:
 
 ### Alternative 1: Schema Registry with Protobuf
 
-**Approach:** Use Confluent Schema Registry for centralized governance.
+**Approach:** Use Confluent Schema Registry for centralised governance.
 
 **Pros:**
 
-- Centralized schema storage and discovery
+- Centralised schema storage and discovery
 - Runtime compatibility validation
 - Historical schema versions preserved
 - Multi-language support via schema ID lookup
@@ -339,7 +339,7 @@ Consider adding Schema Registry if:
 
 - Schema Registry's native format
 - Dynamic schema evolution
-- Compact serialization
+- Compact serialisation
 
 **Cons:**
 
@@ -348,7 +348,7 @@ Consider adding Schema Registry if:
 - No compile-time type safety
 - Steeper learning curve
 
-**Why rejected:** We've standardized on Protobuf for gRPC APIs. Using different serialization for events would fragment
+**Why rejected:** We've standardized on Protobuf for gRPC APIs. Using different serialisation for events would fragment
 tooling.
 
 ### Alternative 3: JSON with JSON Schema
@@ -365,7 +365,7 @@ tooling.
 
 - Verbose (larger messages)
 - No compile-time type safety
-- Slower serialization/deserialization
+- Slower serialisation/deserialisation
 - Inconsistent with gRPC APIs
 
 **Why rejected:** JSON's verbosity and lack of type safety make it unsuitable for high-throughput financial event
@@ -374,7 +374,7 @@ streams.
 ### Chosen: Protobuf Native Versioning (No Schema Registry)
 
 **Rationale:** Balances type safety, performance, simplicity, and consistency with our gRPC APIs. Protobuf's optional
-fields handle 90% of evolution needs. New event types handle the remaining 10% (new BIAN behaviors).
+fields handle 90% of evolution needs. New event types handle the remaining 10% (new BIAN behaviours).
 
 ## Links
 
@@ -405,7 +405,7 @@ fields handle 90% of evolution needs. New event types handle the remaining 10% (
 
 **Rule of thumb:** If unsure, create a new event type. It's safer and aligns with BIAN's semantic model.
 
-### BIAN Behavior Qualifiers
+### BIAN Behaviour Qualifiers
 
 BIAN defines standard operations for each service domain:
 
@@ -420,7 +420,7 @@ BIAN defines standard operations for each service domain:
 - **Grant** - Grant permission
 - **Notify** - Send notification
 
-When BIAN adds new behavior qualifiers in future releases, map each to a distinct event type.
+When BIAN adds new behaviour qualifiers in future releases, map each to a distinct event type.
 
 ### Testing Strategy
 
@@ -434,13 +434,13 @@ When BIAN adds new behavior qualifiers in future releases, map each to a distinc
 
 See `internal/adapters/events/*_test.go` for examples.
 
-### Event Catalog
+### Event Catalogue
 
 Maintain a living document of all event types:
 
 ```markdown
 
-# docs/events/event-catalog.md
+# docs/events/event-catalogue.md
 
 ## Current Account Events
 
@@ -463,7 +463,7 @@ Maintain a living document of all event types:
 
 ```
 
-Update this catalog when adding new event types.
+Update this catalogue when adding new event types.
 
 ## Amendment: Event Topic Naming Convention (2025-11-19)
 
@@ -536,7 +536,7 @@ meridian/position-keeping/transaction-recorded/v1
 **Pros:**
 
 - Even more explicit hierarchy
-- Organization-level namespace
+- Organisation-level namespace
 
 **Cons:**
 

--- a/docs/adr/0005-adapter-pattern-layer-translation.md
+++ b/docs/adr/0005-adapter-pattern-layer-translation.md
@@ -348,7 +348,7 @@ func (s *BookingLogServiceServer) toResponse(d *domain.FinancialBookingLog) *pb.
 The adapter pattern provides critical flexibility for adopting new BIAN releases without coordinated infrastructure
 changes.
 
-### Scenario: BIAN Adds New Behavior Qualifier
+### Scenario: BIAN Adds New Behaviour Qualifier
 
 #### BIAN 13.0 → 14.0 adds "Suspend" to Current Account
 
@@ -377,7 +377,7 @@ const (
     AccountStatusSuspended AccountStatus = "suspended"  // New
 )
 
-// New BIAN 14.0 behavior qualifier
+// New BIAN 14.0 behaviour qualifier
 func (a *CurrentAccount) Suspend(reason string, until time.Time, by string) error {
     if a.AccountStatus != AccountStatusActive {
         return ErrInvalidStatusTransition
@@ -451,7 +451,7 @@ func (r *CurrentAccountRepository) toDomain(e *CurrentAccountEntity) *domain.Cur
 ```go
 // internal/adapters/events/current_account_publisher.go
 
-// New method for BIAN 14.0 behavior qualifier
+// New method for BIAN 14.0 behaviour qualifier
 func (p *CurrentAccountPublisher) PublishSuspended(
     ctx context.Context,
     account *domain.CurrentAccount,
@@ -491,7 +491,7 @@ Old consumers (BIAN 13.0) continue working:
 
 * Database: Nullable columns don't break existing queries
 * Events: New event type on new topic (old consumers unaffected)
-* Domain: New behavior qualifiers only used by v14 clients
+* Domain: New behaviour qualifiers only used by v14 clients
 
 #### 3. Gradual rollout
 
@@ -726,7 +726,7 @@ func (b *BookingLog) Save() error {
 ### Performance Considerations
 
 * **Overhead:** Adapter functions add ~1-5% overhead (negligible)
-* **Optimization:** If profiling shows adapter bottlenecks, consider pooling or caching
+* **Optimisation:** If profiling shows adapter bottlenecks, consider pooling or caching
 * **Bulk operations:** Batch translations for large datasets
 
 ### Team Considerations

--- a/docs/adr/0006-tilt-local-development.md
+++ b/docs/adr/0006-tilt-local-development.md
@@ -66,16 +66,16 @@ Chosen option: **"Tilt"**, because:
 * **Superior DX**: Unified UI for logs, status, and debugging across all services
 * **Intelligent builds**: File syncing and incremental compilation without full container rebuilds
 * **Dependency management**: Automatic resource ordering with readiness checks
-* **Team-proven**: Widely adopted in cloud-native organizations
+* **Team-proven**: Widely adopted in cloud-native organisations
 
 ### Positive Consequences
 
 * ✅ **Fast iteration**: Edit Go code → 2-3 seconds → changes live in K8s
-* ✅ **Production parity**: Same K8s manifests, same networking, same behavior
+* ✅ **Production parity**: Same K8s manifests, same networking, same behaviour
 * ✅ **Unified observability**: All logs, status, and errors in one UI
 * ✅ **Easy onboarding**: `tilt up` → full stack running in < 5 minutes
 * ✅ **Catch K8s issues early**: Test readiness probes, resource limits, networking locally
-* ✅ **Resource organization**: Label-based grouping (app, database, messaging, tests)
+* ✅ **Resource organisation**: Label-based grouping (app, database, messaging, tests)
 * ✅ **Parallel operations**: Tests run while services start
 * ✅ **Manual triggers**: Run linters on-demand without slowing startup
 
@@ -107,7 +107,7 @@ Chosen option: **"Tilt"**, because:
 * Good, because **unified UI** - all logs and status in one place
 * Good, because **smart file syncing** - only syncs changed files, no full rebuild
 * Good, because **dependency management** - services start in correct order with health checks
-* Good, because **resource organization** - labels group related services
+* Good, because **resource organisation** - labels group related services
 * Good, because **extensibility** - Python DSL allows custom workflows
 * Good, because **widely adopted** - used by major cloud-native companies
 * Bad, because **requires local Kubernetes** - more setup than Docker alone
@@ -122,7 +122,7 @@ Chosen option: **"Tilt"**, because:
 * Good, because **lightweight** - no K8s overhead, just Docker daemon
 * Good, because **fast onboarding** - most developers know Docker Compose
 * Good, because **good for simple stacks** - works well for < 5 services
-* Bad, because **no production parity** - production uses K8s, dev uses Compose (different behaviors)
+* Bad, because **no production parity** - production uses K8s, dev uses Compose (different behaviours)
 * Bad, because **slow rebuilds** - full container rebuild on code changes (30-60 seconds)
 * Bad, because **limited dependency management** - `depends_on` only waits for start, not readiness
 * Bad, because **different mental model** - developers learn Compose for dev, K8s for prod
@@ -146,7 +146,7 @@ Chosen option: **"Tilt"**, because:
 * Good, because **Google-backed** - well-maintained, integrated with GKE
 * Good, because **CI/CD friendly** - designed for pipelines
 * Bad, because **less polished DX** - no unified UI (terminal only)
-* Bad, because **slower iteration** - not as optimized for hot reload as Tilt
+* Bad, because **slower iteration** - not as optimised for hot reload as Tilt
 * Bad, because **less observability** - requires separate tools for logs/debugging
 * Bad, because **more configuration** - requires more YAML for similar functionality
 
@@ -295,7 +295,7 @@ local_resource(
 )
 ```
 
-#### 5. Resource Organization
+#### 5. Resource Organisation
 
 ```python
 k8s_resource('meridian', labels=['app'])
@@ -590,7 +590,7 @@ We use **Kind (Kubernetes in Docker)** with **ctlptl (Cattle Patrol)** for local
 * ✅ **Fast cluster creation** - Clusters spin up in ~30 seconds
 * ✅ **Reproducible** - Same cluster config across all developers
 * ✅ **Registry integration** - Built-in local registry support
-* ✅ **Tilt optimized** - ctlptl configures clusters specifically for Tilt
+* ✅ **Tilt optimised** - ctlptl configures clusters specifically for Tilt
 * ✅ **Lightweight** - Runs entirely in Docker containers
 * ✅ **Easy cleanup** - `ctlptl delete cluster kind-meridian-local` removes everything
 
@@ -598,7 +598,7 @@ We use **Kind (Kubernetes in Docker)** with **ctlptl (Cattle Patrol)** for local
 
 ```bash
 
-# Create cluster optimized for Tilt with local registry
+# Create cluster optimised for Tilt with local registry
 
 ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
 

--- a/docs/adr/0007-raw-yaml-over-helm-for-initial-development.md
+++ b/docs/adr/0007-raw-yaml-over-helm-for-initial-development.md
@@ -82,13 +82,13 @@ deployment becomes necessary
 
 This is a **conscious architectural decision**, not an oversight. We are explicitly choosing transparency and iteration
 velocity over environment abstraction during the bootstrap phase, prioritizing rapid development over premature
-optimization.
+optimisation.
 
 ## Decision Drivers
 
 - **Transparency**: Direct visibility into deployed resources accelerates debugging and understanding
 - **Iteration speed**: Faster feedback loops when configuration changes are immediately visible
-- **Reduced complexity**: Minimize abstraction layers during bootstrap phase when requirements are evolving
+- **Reduced complexity**: Minimise abstraction layers during bootstrap phase when requirements are evolving
 - **Service stability**: Service topology is still evolving; premature abstraction creates unnecessary churn
 - **Deferred value**: Helm's multi-environment capabilities aren't needed until we have multiple deployment targets
 - **Complete but minimal**: Even complex services like Kafka can be configured simply for local development
@@ -114,7 +114,7 @@ optimization.
 
 When service topology stabilizes, migrate to Helm:
 
-1. **Identify parameterization points**: What differs between environments?
+1. **Identify parameterisation points**: What differs between environments?
    - Resource limits (CPU, memory)
    - Storage (local vs cloud)
    - Networking (NodePort vs LoadBalancer)

--- a/docs/adr/0008-defensive-testing-standards.md
+++ b/docs/adr/0008-defensive-testing-standards.md
@@ -43,7 +43,7 @@ testing beyond expected inputs.
 
 We will adopt **Defensive Testing Standards** as our testing philosophy. All tests must cover:
 
-1. **Happy Path Testing**: Expected behavior with valid inputs
+1. **Happy Path Testing**: Expected behaviour with valid inputs
 2. **Unhappy Path Testing**: Graceful failure with invalid inputs
 3. **Edge Case Testing**: Boundary conditions (min/max, zero, empty)
 4. **Negative Testing**: Values that should never occur but might due to bugs

--- a/docs/adr/0009-application-level-audit-logging.md
+++ b/docs/adr/0009-application-level-audit-logging.md
@@ -29,7 +29,7 @@ while it would work in production PostgreSQL.
 
 ## Decision Drivers
 
-1. **Development-Production Parity**: Local environment should match production behavior
+1. **Development-Production Parity**: Local environment should match production behaviour
 2. **CockroachDB Compatibility**: Core development database doesn't support PL/pgSQL
 3. **Testability**: Audit logic should be easily testable in unit tests
 4. **Performance**: Audit logging must not significantly impact transaction throughput
@@ -94,7 +94,7 @@ PL/pgSQL dependency. Database-level triggers are not viable without PL/pgSQL sup
 **Cons:**
 
 - ❌ Development-production parity violation
-- ❌ Can't test audit behavior locally
+- ❌ Can't test audit behaviour locally
 - ❌ Deployment complexity (two database systems)
 - ❌ CockroachDB advantages lost (horizontal scaling, multi-region)
 
@@ -219,7 +219,7 @@ Repeat for `position_keeping_audit` schema.
 ### Potential Impact
 
 1. **Additional INSERT per operation**: +1 write per business operation
-2. **JSON serialization overhead**: `toJSON()` conversion cost
+2. **JSON serialisation overhead**: `toJSON()` conversion cost
 3. **Transaction size increase**: Audit INSERT adds to transaction
 
 ### Async Audit Strategy: Transactional Outbox Pattern
@@ -301,8 +301,8 @@ func processAuditOutbox(db *gorm.DB, schema string) {
    - Reduce write amplification by excluding low-risk tables
    - Document which tables are/aren't audited and rationale
 
-1. **Optimize JSON serialization**: Only include fields that change
-   - Compute diff before serialization to reduce JSONB size
+1. **Optimise JSON serialisation**: Only include fields that change
+   - Compute diff before serialisation to reduce JSONB size
    - Set maximum audit record size limits
 
 1. **Batch processing**: Worker processes outbox in batches of 100 for efficiency
@@ -686,7 +686,7 @@ func TestAuditSystem_EndToEnd_CockroachDB(t *testing.T) {
 
 **Test-Driven Development:**
 
-1. Write failing tests for worker behavior (idempotency, resilience)
+1. Write failing tests for worker behaviour (idempotency, resilience)
 2. Implement `AuditWorker()` background goroutine
 3. Implement `processAuditOutbox()` with batch processing
 4. Verify all tests pass (green)
@@ -769,7 +769,7 @@ The async audit system has been fully implemented across all 6 services with a d
    - Writes directly to `audit_log` table
 
 4. **Outbox Fallback Worker** (`services/audit-worker/`)
-   - Centralized service processes `audit_outbox` entries when Kafka is unavailable
+   - Centralised service processes `audit_outbox` entries when Kafka is unavailable
    - Polls every 5 seconds, batch size 100
    - Moves entries from `audit_outbox` → `audit_log`
 

--- a/docs/adr/0010-grpc-client-side-load-balancing.md
+++ b/docs/adr/0010-grpc-client-side-load-balancing.md
@@ -30,7 +30,7 @@ through a single long-lived connection to one pod, leaving other pods idle even 
 
 ### Problem
 
-- **Default Kubernetes behavior**: ClusterIP services use iptables/IPVS for L4 load balancing, which balances
+- **Default Kubernetes behaviour**: ClusterIP services use iptables/IPVS for L4 load balancing, which balances
 connections (not requests)
 - **gRPC HTTP/2 multiplexing**: Single connection carries many requests, defeating L4 load balancing
 - **Consequence**: Horizontal pod scaling doesn't improve performance - new pods receive no traffic from existing
@@ -56,7 +56,7 @@ Implement **client-side load balancing** using:
    - `{"loadBalancingPolicy":"round_robin"}` distributes requests evenly
    - DNS-based discovery automatically picks up pod changes
 
-1. **Centralized client factory** (`pkg/platform/grpc/client.go`)
+1. **Centralised client factory** (`pkg/platform/grpc/client.go`)
    - Enforces consistent configuration across services
    - Encapsulates DNS target construction
    - Provides sensible defaults (keepalive, timeout, blocking dial)
@@ -103,7 +103,7 @@ Client-side load balancing via DNS requires minimal RBAC permissions:
 **Current RBAC Policy** (`deployments/k8s/base/role.yaml`):
 
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorisation.k8s.io/v1
 kind: Role
 metadata:
   name: meridian
@@ -164,7 +164,7 @@ The client factory automatically:
 
 **For New Services**: Use `pkg/platform/grpc.NewClient()` from the start.
 
-**Migrating Existing Clients**: Follow this pattern in service initialization:
+**Migrating Existing Clients**: Follow this pattern in service initialisation:
 
 ```go
 // Before: Direct grpc.Dial
@@ -257,10 +257,10 @@ Load testing confirms:
    - Rotate certificates before expiration
    - Monitor certificate validity in observability stack
 
-### Authentication & Authorization
+### Authentication & Authorisation
 
 - gRPC interceptors handle authentication token validation
-- Authorization policies enforced at application layer
+- Authorisation policies enforced at application layer
 - Consider gRPC metadata for request context propagation
 
 ## Consequences
@@ -275,7 +275,7 @@ Load testing confirms:
 ### Negative
 
 - **Client-side complexity**: Each client must configure DNS resolver and load balancing
-  - *Mitigation*: Centralized `pkg/platform/grpc` package enforces consistency
+  - *Mitigation*: Centralised `pkg/platform/grpc` package enforces consistency
 - **DNS TTL delays**: Pod changes may take 10-30s to propagate
   - *Acceptable*: Brief delay is preferable to complex infrastructure
 - **No weighted routing**: Round-robin assumes uniform pod capacity

--- a/docs/adr/0010-grpc-client-side-load-balancing.md
+++ b/docs/adr/0010-grpc-client-side-load-balancing.md
@@ -103,7 +103,7 @@ Client-side load balancing via DNS requires minimal RBAC permissions:
 **Current RBAC Policy** (`deployments/k8s/base/role.yaml`):
 
 ```yaml
-apiVersion: rbac.authorisation.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: meridian

--- a/docs/adr/0011-iso-20022-compliance-via-adapter-layer.md
+++ b/docs/adr/0011-iso-20022-compliance-via-adapter-layer.md
@@ -82,7 +82,7 @@ Maintain separate internal and external schema sets with no shared types.
 
 - Good, because complete independence between internal and external
 - Bad, because creates significant duplication
-- Bad, because synchronization burden between schema sets
+- Bad, because synchronisation burden between schema sets
 - Bad, because translation errors harder to catch at compile time
 - Bad, because violates DRY principle excessively
 
@@ -97,7 +97,7 @@ maintain clean domain boundaries while supporting external compliance requiremen
 External Systems (ISO 20022)
         ↕
    [Adapter Layer]
-   - ISO 20022 XML/JSON serialization
+   - ISO 20022 XML/JSON serialisation
    - Domain ↔ ISO 20022 mapping
    - Validation against XSD schemas
         ↕
@@ -113,7 +113,7 @@ External Systems (ISO 20022)
 **Key Principles:**
 
 1. **Domain Integrity**: Internal protobuf schemas remain BIAN-focused, simple, and stable
-2. **Adapter Responsibility**: ISO 20022 adapters handle all translation, validation, and serialization
+2. **Adapter Responsibility**: ISO 20022 adapters handle all translation, validation, and serialisation
 3. **Port Abstraction**: Port interfaces define domain operations independent of external formats
 4. **Multiple Implementations**: Each external standard gets its own adapter (ISO 20022, SWIFT MT, etc.)
 
@@ -204,7 +204,7 @@ func mapAmount(m *money.Money) pain001.ActiveCurrencyAndAmount {
 
 ### Negative Consequences
 
-- Translation layer adds runtime overhead (mitigated by one-time serialization cost)
+- Translation layer adds runtime overhead (mitigated by one-time serialisation cost)
 - Mapping logic must be maintained separately from domain model
 - Potential for translation bugs between domain and external format
 - Requires discipline to keep domain pure and resist leaking external concerns
@@ -321,10 +321,10 @@ Current internal schemas require no changes. Adapter implementation is additive:
 
 ### Performance Considerations
 
-- Adapter serialization is one-time cost at system boundary
+- Adapter serialisation is one-time cost at system boundary
 - Caching compiled XSD schemas for validation
 - Streaming XML generation for large message sets
-- Monitor translation overhead, optimize hot paths if needed
+- Monitor translation overhead, optimise hot paths if needed
 
 ### Extensibility
 

--- a/docs/adr/0012-lien-based-fund-reservation.md
+++ b/docs/adr/0012-lien-based-fund-reservation.md
@@ -143,7 +143,7 @@ message Lien {
   Timestamp updated_at = 7;
 }
 
-// BIAN Behavior Qualifiers
+// BIAN Behaviour Qualifiers
 service CurrentAccountService {
   rpc InitiateLien(InitiateLienRequest) returns (InitiateLienResponse);
   rpc ExecuteLien(ExecuteLienRequest) returns (ExecuteLienResponse);
@@ -370,7 +370,7 @@ if err := paymentGateway.Submit(order); err != nil {
 
 - [ADR-0005: Adapter Pattern for Layer Translation](0005-adapter-pattern-layer-translation.md)
 - [BIAN v13 Current Account Service Domain](https://bian.org/semantic-apis/current-account/) - Defines the
-  CurrentAccountFacility control record and associated behavior qualifiers
+  CurrentAccountFacility control record and associated behaviour qualifiers
 - [Saga Pattern (Microsoft)](https://docs.microsoft.com/en-us/azure/architecture/reference-architectures/saga/saga)
 - [GitHub Issue #7: Payment Order Service](https://github.com/meridianhub/meridian/issues/7)
 - [PR #153: Add Lien Control Record to CurrentAccount proto](https://github.com/meridianhub/meridian/pull/153)

--- a/docs/adr/0013-generic-asset-quantity-types.md
+++ b/docs/adr/0013-generic-asset-quantity-types.md
@@ -106,7 +106,7 @@ flowchart TB
 | Layer | Purpose | Implementation | Changes Require |
 |-------|---------|----------------|-----------------|
 | **Dimensions** | Prevent physics errors | Empty structs (`Monetary{}`, `Commodity{}`) | Code deployment |
-| **Definitions** | Tenant instrument catalog | `FinancialInstrument` from BIAN Reference Data | Registry update |
+| **Definitions** | Tenant instrument catalogue | `FinancialInstrument` from BIAN Reference Data | Registry update |
 | **Context** | Position attributes | Validated attribute map | Nothing (data) |
 
 ### Core Types
@@ -134,7 +134,7 @@ type Commodity struct{}  // Physical goods, energy, compute resources
 type FinancialInstrument struct {
     Code           string          // BIAN: FinancialInstrumentIdentification ("USD", "KWH")
     Version        uint32          // Schema version (1, 2, 3...)
-    Dimension      string          // "Monetary" or "Commodity" - required for deserialization
+    Dimension      string          // "Monetary" or "Commodity" - required for deserialisation
     InstrumentType InstrumentType  // BIAN: FinancialInstrumentType
     Precision      int             // Decimal places (2, 4, 0)
 }
@@ -349,8 +349,8 @@ flowchart TB
 $100 USD → £X GBP depends on the exchange rate at valuation time. This is temporal
 pricing, just like energy tariffs - the FX provider is simply another ValuationProvider.
 
-**For non-fiat instruments**: Valuation routes to specialized providers (tariff engines,
-market data feeds, custom tenant logic). The ledger doesn't implement the math -
+**For non-fiat instruments**: Valuation routes to specialised providers (tariff engines,
+market data feeds, custom tenant logic). The ledger doesn't implement the maths -
 it just routes to the right provider based on instrument type.
 
 ### Multi-Asset Examples
@@ -458,7 +458,7 @@ func TransferCarbonCredits(
         "registry":   registry, // e.g., "VERRA", "GOLD_STANDARD"
     }
 
-    // Validate attributes - registry must be recognized
+    // Validate attributes - registry must be recognised
     if err := refData.ValidateAttributes(ctx, compiled, attrs); err != nil {
         return fmt.Errorf("invalid carbon credit attributes: %w", err)
     }
@@ -646,7 +646,7 @@ Detailed rate resolution rules will be specified in the ValuationOrchestrator im
 
 ### Pluggable Valuation Architecture
 
-The ledger doesn't implement valuation math. It routes to specialized providers.
+The ledger doesn't implement valuation math. It routes to specialised providers.
 This aligns with BIAN's separation of Position Keeping from Financial Instrument Valuation.
 
 ```go

--- a/docs/adr/0014-financial-instrument-reference-data.md
+++ b/docs/adr/0014-financial-instrument-reference-data.md
@@ -4,7 +4,7 @@ description: BIAN Financial Instrument Reference Data Management service for ten
 triggers:
   - Adding new instrument types without code deployment
   - Defining instrument validation rules with CEL expressions
-  - Implementing tenant-specific instrument catalogs
+  - Implementing tenant-specific instrument catalogues
   - Determining fungibility between position attributes
 instructions: |
   Financial Instruments are defined via the BIAN Financial Instrument Reference Data Management
@@ -38,7 +38,7 @@ This ADR implements **BIAN Financial Instrument Reference Data Management** (v13
 | Service Domain | Financial Instrument Reference Data Management |
 | Control Record | `FinancialInstrumentDirectoryEntry` |
 | Business Object | `FinancialInstrument` |
-| Behavior Qualifiers | Currency, DebtInstrument, Equity, Futures, Option, Warrant |
+| Behaviour Qualifiers | Currency, DebtInstrument, Equity, Futures, Option, Warrant |
 
 **BIAN Instrument Types** (from `financialinstrumenttypevalues`):
 
@@ -588,7 +588,7 @@ VALUES
 
 **CEL validation logic**:
 - `int(attrs.vintage) >= 2000 && int(attrs.vintage) <= timestamp(now()).getFullYear()` - Vintage cannot be in the future
-- `attrs.registry in ["VERRA", "GOLD_STANDARD", "ACR", "CAR"]` - Registry must be recognized
+- `attrs.registry in ["VERRA", "GOLD_STANDARD", "ACR", "CAR"]` - Registry must be recognised
 
 **Fungibility rule**: Credits from the same project, registry, and vintage can merge.
 Different registries require separate positions for regulatory compliance.
@@ -712,7 +712,7 @@ VALUES
      'Rice Voucher');
 ```
 
-**Migration behavior**:
+**Migration behaviour**:
 
 ```go
 // Existing v1 positions remain valid - they keep their version

--- a/docs/adr/0015-standard-service-directory-structure.md
+++ b/docs/adr/0015-standard-service-directory-structure.md
@@ -5,7 +5,7 @@ triggers:
   - Creating a new microservice
   - Restructuring an existing service
   - Adding new functionality to a service (where to place files)
-  - Reviewing service organization or architecture
+  - Reviewing service organisation or architecture
   - Adding documentation (where should it go?)
   - Working with API definitions (proto, OpenAPI)
 instructions: |
@@ -62,7 +62,7 @@ Chosen option: **Flexible standard with required core**, because it provides con
 
 ### Root Project Structure
 
-The Meridian monorepo follows this root-level organization:
+The Meridian monorepo follows this root-level organisation:
 
 ```text
 meridian-main/
@@ -124,11 +124,11 @@ meridian-main/
 | `scripts/` | Tooling | Build scripts, analysis tools |
 | `utilities/` | Utilities | Standalone programs (demo tools, loaders) |
 
-#### Why Centralized `api/` at Root?
+#### Why Centralised `api/` at Root?
 
-We use a centralized `api/proto/` directory rather than placing proto files inside each service for several reasons:
+We use a centralised `api/proto/` directory rather than placing proto files inside each service for several reasons:
 
-1. **Shared types** - Common types (`common/v1/`, `events/v1/`) are used across multiple services. Centralized location avoids circular dependencies.
+1. **Shared types** - Common types (`common/v1/`, `events/v1/`) are used across multiple services. Centralised location avoids circular dependencies.
 2. **Contract-first development** - Protos define contracts between services. Having them together makes the API surface visible at a glance.
 3. **Buf tooling** - Single `buf.yaml` workspace simplifies linting, breaking change detection, and code generation.
 4. **BIAN domain pattern** - Banking services share domain concepts (Money, Account references) that naturally live together.
@@ -220,7 +220,7 @@ services/{service-name}/
 | Directory | When to Add | Example Use Case |
 |-----------|-------------|------------------|
 | `client/` | Service exports client for others | party exporting client for current-account |
-| `app/` | Complex initialization logic | Services needing DI containers, complex config |
+| `app/` | Complex initialisation logic | Services needing DI containers, complex config |
 | `adapters/messaging/` | Kafka integration | Event publishing/consuming |
 | `adapters/gateway/` | External API integration | ISO 20022 gateway adapters |
 | `adapters/http/` | REST endpoints | Health probes, admin endpoints |
@@ -260,12 +260,12 @@ All observability code (metrics, health checks) should live in the `observabilit
 
 ### App Directory Pattern
 
-The `app/` directory is optional and should only be added when a service has complex initialization needs:
+The `app/` directory is optional and should only be added when a service has complex initialisation needs:
 - Dependency injection containers
 - Multi-stage configuration loading
 - Complex resource lifecycle management
 
-Simple services should keep initialization logic in `cmd/main.go`.
+Simple services should keep initialisation logic in `cmd/main.go`.
 
 ### Shared Libraries
 
@@ -293,12 +293,12 @@ The `MetricsInterceptor` and `RecoveryUnaryInterceptor` in `shared/pkg/intercept
 
 ## References
 
-Industry best practices supporting centralized API definitions in Go monorepos:
+Industry best practices supporting centralised API definitions in Go monorepos:
 
-* [Buf: Files and Packages](https://buf.build/docs/reference/protobuf-files-and-packages/) - Official buf.build guidance on proto file organization
-* [Structuring repositories with protocol buffers](https://dev.to/davidsbond/golang-structuring-repositories-with-protocol-buffers-3012) - Go-specific patterns for proto organization
+* [Buf: Files and Packages](https://buf.build/docs/reference/protobuf-files-and-packages/) - Official buf.build guidance on proto file organisation
+* [Structuring repositories with protocol buffers](https://dev.to/davidsbond/golang-structuring-repositories-with-protocol-buffers-3012) - Go-specific patterns for proto organisation
 * [golang/protobuf Issue #391](https://github.com/golang/protobuf/issues/391) - Community discussion on project structure with multiple services
-* [gRPC organization in microservices (Stack Overflow)](https://stackoverflow.com/questions/56082458/grpc-organization-in-microservices) - Centralized vs distributed proto patterns
+* [gRPC organisation in microservices (Stack Overflow)](https://stackoverflow.com/questions/56082458/grpc-organisation-in-microservices) - Centralised vs distributed proto patterns
 
 ## Notes
 

--- a/docs/adr/0016-tenant-id-naming-strategy.md
+++ b/docs/adr/0016-tenant-id-naming-strategy.md
@@ -275,7 +275,7 @@ Alert if `consumed_ids` exceeds 1,000 or `consumed_ids / active_tenants` exceeds
 
 * [Stripe Object IDs Design](https://dev.to/4thzoa/designing-apis-for-humans-object-ids-3o5a) - Prefixed ID best practices
 * [Auth0 Multi-Tenant Best Practices](https://auth0.com/docs/get-started/auth0-overview/create-tenants/multi-tenant-apps-best-practices)
-* [AWS Multi-Tenant Authorisation](https://docs.aws.amazon.com/prescriptive-guidance/latest/saas-multitenant-api-access-authorisation/introduction.html)
+* [AWS Multi-Tenant Authorisation](https://docs.aws.amazon.com/prescriptive-guidance/latest/saas-multitenant-api-access-authorization/introduction.html)
 * [PostgreSQL UUID Documentation](https://www.postgresql.org/docs/current/datatype-uuid.html)
 * GitHub Issue: Multi-tenancy namespace strategy evaluation (Task 51)
 

--- a/docs/adr/0016-tenant-id-naming-strategy.md
+++ b/docs/adr/0016-tenant-id-naming-strategy.md
@@ -42,7 +42,7 @@ because the schema namespace is finite and human-readable IDs are desirable for 
 
 Once a tenant is deprovisioned, its ID (e.g., `acme_bank`) is permanently consumed:
 
-1. A new organization cannot claim this desirable name
+1. A new organisation cannot claim this desirable name
 2. Namespace pollution accumulates over time
 3. Schema names remain visible in logs, connection strings, and error messages
 
@@ -88,7 +88,7 @@ message Tenant {
 }
 ```
 
-**Schema naming**: `org_550e8400_e29b_41d4` (normalized UUID prefix)
+**Schema naming**: `org_550e8400_e29b_41d4` (normalised UUID prefix)
 
 ### Option 3: Hybrid Approach (Internal UUID + External Slug)
 
@@ -131,7 +131,7 @@ and significant.
    - API breaking changes or dual-identifier periods
    - Test suite updates across all services
 
-4. **SaaS Model Not Current**: Meridian is infrastructure for organizations to operate,
+4. **SaaS Model Not Current**: Meridian is infrastructure for organisations to operate,
    not a commercial SaaS platform. Multi-tenancy is for demonstration, not production
    customer isolation with billing and churn.
 
@@ -212,7 +212,7 @@ Stripe uses **prefixed human-readable IDs** (e.g., `cus_xyz123`, `pi_abc456`):
 - Random suffix provides uniqueness without full UUID length
 - Stripe stores the full prefixed ID as primary key (not separated)
 
-This pattern prioritizes debuggability over namespace concerns, even at Stripe's scale.
+This pattern prioritises debuggability over namespace concerns, even at Stripe's scale.
 
 ### Auth0's Approach
 
@@ -275,7 +275,7 @@ Alert if `consumed_ids` exceeds 1,000 or `consumed_ids / active_tenants` exceeds
 
 * [Stripe Object IDs Design](https://dev.to/4thzoa/designing-apis-for-humans-object-ids-3o5a) - Prefixed ID best practices
 * [Auth0 Multi-Tenant Best Practices](https://auth0.com/docs/get-started/auth0-overview/create-tenants/multi-tenant-apps-best-practices)
-* [AWS Multi-Tenant Authorization](https://docs.aws.amazon.com/prescriptive-guidance/latest/saas-multitenant-api-access-authorization/introduction.html)
+* [AWS Multi-Tenant Authorisation](https://docs.aws.amazon.com/prescriptive-guidance/latest/saas-multitenant-api-access-authorisation/introduction.html)
 * [PostgreSQL UUID Documentation](https://www.postgresql.org/docs/current/datatype-uuid.html)
 * GitHub Issue: Multi-tenancy namespace strategy evaluation (Task 51)
 

--- a/docs/adr/0017-temporal-quality-ladder.md
+++ b/docs/adr/0017-temporal-quality-ladder.md
@@ -57,7 +57,7 @@ This ADR builds on:
 This ADR defines:
 
 - **Quality-based precedence** for competing measurements
-- **Temporal modeling** with [Start, End] periods
+- **Temporal modelling** with [Start, End] periods
 - **Supersession tracking** for audit trails
 - **Wash & Reload** correction pattern
 
@@ -156,7 +156,7 @@ func NewPeriod(start, end time.Time) (Period, error) {
 }
 
 // MustPeriod creates a Period, panicking on validation failure.
-// Use only in tests or initialization where failure is fatal.
+// Use only in tests or initialisation where failure is fatal.
 func MustPeriod(start, end time.Time) Period {
     p, err := NewPeriod(start, end)
     if err != nil {
@@ -233,7 +233,7 @@ WHERE period && tstzrange('2025-01-01', '2025-01-02')
 WHERE period_start < '2025-01-02' AND period_end > '2025-01-01'
 ```
 
-For deployments using PostgreSQL or YugabyteDB exclusively, a future optimization path
+For deployments using PostgreSQL or YugabyteDB exclusively, a future optimisation path
 could add a computed `TSTZRANGE` column with GiST index as an enterprise-tier feature.
 
 **Database representation using explicit period columns:**
@@ -315,7 +315,7 @@ WHERE period_start <= '2025-01-15 12:30:00+00'
 
 **Period Query Integration Tests (Required):**
 
-Before production deployment, verify period query behavior with integration tests:
+Before production deployment, verify period query behaviour with integration tests:
 
 ```go
 func TestPeriodQueries(t *testing.T) {
@@ -388,7 +388,7 @@ but this cached value can diverge if the registry is updated post-ingestion.
 
 **Important:** All authoritative decisions (supersession, dispute routing) must consult
 the registry rather than relying solely on denormalized measurement values. The denormalized
-`QualityScore` field on measurements is an optimization for read-heavy queries, not the
+`QualityScore` field on measurements is an optimisation for read-heavy queries, not the
 source of truth.
 
 ```go
@@ -912,7 +912,7 @@ func (r *MeasurementRepository) Supersede(ctx context.Context, oldID, newID uuid
 ```
 
 **Why not SERIALIZABLE?**
-- At 100k TPS, serialization failures would cause cascading retries
+- At 100k TPS, serialisation failures would cause cascading retries
 - Position Key Hash gives O(1) conflict detection via B-tree index
 - Retry logic only needed for actual conflicts, not phantom reads
 
@@ -1150,10 +1150,10 @@ This ADR's concepts map to BIAN (Banking Industry Architecture Network) v13 serv
 | Meridian Concept | BIAN Service Domain | BIAN Entity | Notes |
 |-----------------|---------------------|-------------|-------|
 | `MeasurementLog` | Position Keeping | `FinancialPositionLog` (CR) | "Maintain a log of transactions" |
-| `Measurement` | Position Keeping | `FinancialTransactionCapture` (BQ) | Transaction capture behavior |
+| `Measurement` | Position Keeping | `FinancialTransactionCapture` (BQ) | Transaction capture behaviour |
 | `Period [Start, End]` | Position Keeping | `datetimeperiod` | `FromDateTime` / `ToDateTime` |
 | `TransactionStatus` | Position Keeping | `transactionstatustypevalues` | Initiated, Booked, Confirmed, etc. |
-| `PositionEntry` | Financial Accounting | `LedgerPosting` (BQ) | Ledger posting behavior |
+| `PositionEntry` | Financial Accounting | `LedgerPosting` (BQ) | Ledger posting behaviour |
 | Correction booking | Financial Accounting | `UpdateLedgerPosting` | Explicitly for "repair" |
 | `EntryType.ADJUSTMENT` | Position Keeping | `InterestAdjustmentTransaction` | Adjustment transaction type |
 

--- a/docs/adr/0018-settlement-reconciliation.md
+++ b/docs/adr/0018-settlement-reconciliation.md
@@ -52,7 +52,7 @@ Most ledgers treat the database as "The State of Now." Meridian manages the **En
 of Value** - past (audit, integrity, settlement) AND future (forecasts, commitments, hedging).
 
 **The Key Insight:** A Forecast is the **Golden Source** for tomorrow, but **Garbage** for
-yesterday. Without modeling this "Temporal Weighting," you get the classic billing disaster:
+yesterday. Without modelling this "Temporal Weighting," you get the classic billing disaster:
 
 1. Bill customer based on Forecast (because Actuals weren't in yet)
 2. Actuals arrive
@@ -482,7 +482,7 @@ measurements via Position Keeping's API, not direct database joins. This maintai
 isolation at the cost of additional API calls during reconciliation.
 
 **Cross-Tenant Reconciliation:** By design, there is no special backdoor for cross-tenant
-reconciliation. When two organizations need to reconcile positions (e.g., inter-company
+reconciliation. When two organisations need to reconcile positions (e.g., inter-company
 settlements, counterparty reconciliation), they are treated as two external systems
 communicating via standard APIs. Each tenant's data remains isolated per ADR-0016; any
 cross-tenant data exchange happens through explicit integration contracts, not internal
@@ -586,7 +586,7 @@ timestamp, tenant_id, correlation_id).
 | `SettlementRunStarted` | Settlement batch begins | run_id, run_type, period_start, period_end | Monitoring, Audit |
 | `SettlementSnapshotCreated` | Position captured for settlement | snapshot_id, run_id, measurement_id | Financial Accounting |
 | `SettlementRunCompleted` | Settlement batch finishes | run_id, positions_settled, total_value | Monitoring, Payment Order |
-| `MeasurementLocked` | Settlement finalized | measurement_id, settlement_run, locked_at | Financial Accounting |
+| `MeasurementLocked` | Settlement finalised | measurement_id, settlement_run, locked_at | Financial Accounting |
 
 ### Reconciliation Events
 
@@ -631,9 +631,9 @@ func (s *SettlementService) CompleteRun(ctx context.Context, runID uuid.UUID) er
 
 ## Security Considerations
 
-### Settlement Locking Authorization
+### Settlement Locking Authorisation
 
-The `LockedAt` field controls position finality. Only authorized services may lock positions:
+The `LockedAt` field controls position finality. Only authorised services may lock positions:
 
 | Actor | Can Lock? | Mechanism |
 |-------|-----------|-----------|
@@ -643,7 +643,7 @@ The `LockedAt` field controls position finality. Only authorized services may lo
 | System Admin | Emergency only | Requires audit log entry + approval |
 
 ```go
-// SettlementService is the only authorized caller
+// SettlementService is the only authorised caller
 func (s *SettlementService) FinalizeRun(ctx context.Context, run string) error {
     // Verify caller identity via context (service account)
     if !auth.IsSettlementService(ctx) {
@@ -948,7 +948,7 @@ var (
     // ErrDisputeRateLimitExceeded indicates too many disputes created for this tenant.
     ErrDisputeRateLimitExceeded = errors.New("dispute rate limit exceeded")
 
-    // ErrUnauthorized indicates the caller is not authorized for this operation.
+    // ErrUnauthorized indicates the caller is not authorised for this operation.
     ErrUnauthorized = errors.New("unauthorized")
 )
 ```
@@ -964,7 +964,7 @@ var (
 | **Backfill Window** | Maximum age of measurements accepted before rejection |
 | **Final Settlement** | Point after which positions are locked and changes become disputes |
 | **Variance** | Difference between settled quantity and current quantity for a position |
-| **Dispute** | Record created when new data arrives for a locked (finalized) position |
+| **Dispute** | Record created when new data arrives for a locked (finalised) position |
 
 ## BIAN v13 Alignment
 
@@ -1008,7 +1008,7 @@ The following Meridian concepts extend or have no direct BIAN equivalent:
   settlement with later reconciliation
 - **Settlement Run scheduling** (D+1, M+14): Industry-specific patterns not in BIAN standard
 - **Dispute workflow for locked positions**: BIAN has case management but not the specific
-  pattern of archiving incoming data and creating disputes for finalized positions
+  pattern of archiving incoming data and creating disputes for finalised positions
 
 ## Links
 

--- a/docs/adr/0019-resilient-client-patterns.md
+++ b/docs/adr/0019-resilient-client-patterns.md
@@ -44,7 +44,7 @@ The team identified code duplication across services: each service implementing 
 * **Support distributed transactions** (e.g., CurrentAccount -> PositionKeeping -> FinancialAccounting)
 * **Reduce boilerplate**: Avoid duplicating ~200 lines of resilience code per service
 * **Standardize patterns** across all services for consistency
-* **Observability**: Centralized logging for circuit breaker state changes and retries
+* **Observability**: Centralised logging for circuit breaker state changes and retries
 * **Idempotency awareness**: Distinguish between operations safe to retry and those that are not
 
 ## Considered Options
@@ -83,7 +83,7 @@ Chosen option: **"Shared resilient client patterns in `shared/pkg/clients`"**, b
 
 ### Option 1: Shared Resilient Client Patterns (Chosen)
 
-Centralized implementation in `shared/pkg/clients/` with:
+Centralised implementation in `shared/pkg/clients/` with:
 * Circuit breaker wrapping `sony/gobreaker/v2`
 * Retry with exponential backoff using `cenkalti/backoff/v4`
 * Resilient client combining both patterns
@@ -114,7 +114,7 @@ Each service implements its own resilience patterns.
 
 * Good, because tailored to each service's specific needs
 * Bad, because code duplication (~200 lines per service x 6 services = 1200 LOC)
-* Bad, because inconsistent behavior across services
+* Bad, because inconsistent behaviour across services
 * Bad, because harder to maintain and test
 
 ### Option 4: No Resilience Patterns
@@ -187,7 +187,7 @@ err := clients.Retry(ctx, config, func() error {
 **Non-retryable status codes:**
 * `InvalidArgument` - Client error, won't succeed on retry
 * `NotFound` - Resource doesn't exist
-* `PermissionDenied` - Authorization failure
+* `PermissionDenied` - Authorisation failure
 * `Unauthenticated` - Authentication failure
 
 ### Pattern 3: Resilient Client (Recommended)

--- a/docs/adr/0020-per-service-audit-workers.md
+++ b/docs/adr/0020-per-service-audit-workers.md
@@ -9,7 +9,7 @@ triggers:
   - Evaluating cross-service database access patterns
 
 instructions: |
-  Embed audit workers as background goroutines within each service, not as a centralized service.
+  Embed audit workers as background goroutines within each service, not as a centralised service.
   Each service processes its own audit_outbox table using the shared/platform/audit package.
   Pass the service's schema name to NewAuditWorker for proper table targeting.
 ---
@@ -24,17 +24,17 @@ Superseded
 
 **Note:** This ADR proposed per-service embedded workers. The actual implementation (2025-12-24) uses a dual-path approach:
 - **Primary path**: Kafka audit consumers (one deployment per service, deployed separately)
-- **Fallback path**: Centralized audit-worker service processes outbox when Kafka unavailable
+- **Fallback path**: Centralised audit-worker service processes outbox when Kafka unavailable
 
 See implementation details in ADR-0009 and `/services/README.md`.
 
 ## Context
 
-ADR-0009 established the transactional outbox pattern for application-level audit logging. The current implementation (`services/audit-worker/main.go`) deploys a centralized audit-worker service that connects to a single database and processes audit_outbox entries.
+ADR-0009 established the transactional outbox pattern for application-level audit logging. The current implementation (`services/audit-worker/main.go`) deploys a centralised audit-worker service that connects to a single database and processes audit_outbox entries.
 
 As the platform grows to 6 services with separate database schemas (current-account, position-keeping, financial-accounting, party, payment-order, tenant), we must decide how to scale audit processing:
 
-1. **Centralized approach**: Extend the existing audit-worker to poll 6 different service schemas
+1. **Centralised approach**: Extend the existing audit-worker to poll 6 different service schemas
 2. **Per-service approach**: Embed audit workers as background goroutines within each service
 
 This decision has significant implications for bounded context isolation, service autonomy, and operational complexity.
@@ -44,14 +44,14 @@ This decision has significant implications for bounded context isolation, servic
 * **ADR-0002 Compliance**: Microservices per BIAN domain requires database-per-service and no cross-service database access
 * **Service Coupling Analysis**: Zero cross-service database access violations is a key compliance criterion
 * **Service Autonomy**: Services should not depend on external workers for core audit functionality
-* **Operational Simplicity**: Minimize credentials management and deployment coupling
+* **Operational Simplicity**: Minimise credentials management and deployment coupling
 * **Performance**: Each service handles its own audit volume without contention
 
 ## Considered Options
 
-1. Centralized audit-worker service polling multiple schemas
+1. Centralised audit-worker service polling multiple schemas
 2. Per-service embedded audit workers
-3. Hybrid approach with centralized worker for high-volume services
+3. Hybrid approach with centralised worker for high-volume services
 
 ## Decision Outcome
 
@@ -74,12 +74,12 @@ Chosen option: "Per-service embedded audit workers", because it maintains bounde
 
 ## Pros and Cons of the Options
 
-### Centralized Audit-Worker (Current Pattern Extended)
+### Centralised Audit-Worker (Current Pattern Extended)
 
 A single audit-worker service connects to all 6 service databases and polls their audit_outbox tables.
 
 * Good, because single deployment for audit processing logic
-* Good, because centralized monitoring (one place to check audit lag)
+* Good, because centralised monitoring (one place to check audit lag)
 * Good, because no changes to existing service binaries
 * Bad, because **violates bounded context isolation** (cross-service database access)
 * Bad, because **operational coupling** (all services depend on audit-worker availability)
@@ -107,12 +107,12 @@ auditWorker.Start(workerCtx)
 * Good, because **aligns with ADR-0002** (microservices per BIAN domain)
 * Good, because **failure isolation** (one service's audit issues don't affect others)
 * Bad, because duplicated worker goroutines (minimal memory overhead ~1MB each)
-* Bad, because requires metric aggregation for centralized monitoring
+* Bad, because requires metric aggregation for centralised monitoring
 * Bad, because worker startup code duplicated across 6 service main.go files
 
 ### Hybrid Approach
 
-High-volume services (current-account, payment-order) use embedded workers; low-volume services share a centralized worker.
+High-volume services (current-account, payment-order) use embedded workers; low-volume services share a centralised worker.
 
 * Good, because reduces total worker count
 * Bad, because **inconsistent architecture** (some services isolated, some not)
@@ -156,7 +156,7 @@ Add worker startup to each service's `main.go`:
 | payment-order | `payment_order_audit` | `services/payment-order/cmd/main.go` |
 | tenant | `tenant_audit` | `services/tenant/cmd/main.go` |
 
-### Phase 3: Deprecate Centralized Audit-Worker
+### Phase 3: Deprecate Centralised Audit-Worker
 
 1. Deploy per-service workers to staging
 2. Monitor for 1 week to verify no audit lag or processing issues
@@ -186,20 +186,20 @@ Add worker startup to each service's `main.go`:
 
 **Status**: Superseded by this decision
 
-Task 16 proposed extending the centralized audit-worker to poll 6 schemas. This decision replaces that approach with per-service workers. Task 16 should be updated to "Embed audit workers in individual services" or closed as superseded.
+Task 16 proposed extending the centralised audit-worker to poll 6 schemas. This decision replaces that approach with per-service workers. Task 16 should be updated to "Embed audit workers in individual services" or closed as superseded.
 
-### Task 6 (Centralized Kafka audit consumer)
+### Task 6 (Centralised Kafka audit consumer)
 
 **Status**: Still valid
 
-The Kafka audit consumer remains centralized for cross-service audit aggregation and analytics. This is architecturally distinct from outbox processing:
+The Kafka audit consumer remains centralised for cross-service audit aggregation and analytics. This is architecturally distinct from outbox processing:
 
 | Component | Scope | Purpose |
 |-----------|-------|---------|
 | Per-service audit worker | Single service | Process outbox → audit_log |
 | Kafka audit consumer | Cross-service | Aggregate audit events for analytics |
 
-The per-service workers publish events to Kafka after processing; the centralized consumer aggregates these events.
+The per-service workers publish events to Kafka after processing; the centralised consumer aggregates these events.
 
 ## ADR Alignment
 
@@ -228,7 +228,7 @@ Choose per-service workers (this decision) if:
 - [x] Service-specific audit processing needs may diverge in future
 - [x] Operational simplicity (single database connection per service) is preferred
 
-Choose centralized worker if:
+Choose centralised worker if:
 
 - [ ] Operational simplicity (single deployment) outweighs architectural purity
 - [ ] Team has strong operational automation for multi-service database access
@@ -237,5 +237,5 @@ Choose centralized worker if:
 ### Future Considerations
 
 * If audit volume grows significantly, consider dedicated audit worker pods per service (separate from main service pods)
-* If audit requirements diverge per service, the per-service architecture enables independent customization
+* If audit requirements diverge per service, the per-service architecture enables independent customisation
 * Consider adding circuit breakers if audit processing affects service health under load

--- a/docs/adr/0021-kyc-aml-verification-provider-architecture.md
+++ b/docs/adr/0021-kyc-aml-verification-provider-architecture.md
@@ -41,11 +41,11 @@ The system must support both synchronous checks (instant sanctions screening) an
 
 * **Regulatory compliance**: Meet KYC/AML requirements across multiple jurisdictions
 * **Provider flexibility**: Support multiple providers without code changes
-* **Privacy by design**: Minimize PII exposure and retention
+* **Privacy by design**: Minimise PII exposure and retention
 * **Resilience**: Handle provider failures gracefully
 * **Audit trail**: Complete traceability for regulatory examinations
 * **Latency tolerance**: Accept appropriate delays for thorough verification
-* **Cost optimization**: Route to cost-effective providers when equivalent
+* **Cost optimisation**: Route to cost-effective providers when equivalent
 
 ## Considered Options
 
@@ -68,9 +68,9 @@ Chosen option: **"Async-first with synchronous fallback via provider abstraction
 
 * **Provider agnostic**: Add new providers by implementing interface
 * **Graceful degradation**: Provider outages don't block entire flow
-* **Cost optimization**: Route to cheaper providers for low-risk checks
+* **Cost optimisation**: Route to cheaper providers for low-risk checks
 * **Compliance ready**: Audit logs capture complete verification history
-* **Privacy enforced**: PII handling rules centralized in abstraction layer
+* **Privacy enforced**: PII handling rules centralised in abstraction layer
 
 ### Negative Consequences
 
@@ -114,7 +114,7 @@ Full event sourcing with verification events and projections.
 
 ### Option 4: Third-Party Orchestration (Alloy, Unit21)
 
-Delegate verification orchestration to specialized platform.
+Delegate verification orchestration to specialised platform.
 
 * Good, because pre-built provider integrations
 * Good, because compliance expertise built-in

--- a/docs/adr/0022-instrument-successor-lineage.md
+++ b/docs/adr/0022-instrument-successor-lineage.md
@@ -270,7 +270,7 @@ func (s *InstrumentService) GetCurrentSuccessor(
 
 The FK constraint is within the tenant schema (per ADR-0016), so successors must be
 instruments within the same tenant. Cross-tenant succession is not possible, which
-is the correct behavior for tenant isolation.
+is the correct behaviour for tenant isolation.
 
 ### Cache Invalidation
 
@@ -321,7 +321,7 @@ func (s *PositionService) GetPositionsWithLineage(
 ### Historical Ledger Entries
 
 Existing ledger entries remain unchanged - they reference the original instrument ID.
-This is correct behavior because:
+This is correct behaviour because:
 
 1. **Immutability**: Ledger entries are append-only (ADR-0017)
 2. **Audit trail**: Historical entries should reflect what was recorded at the time

--- a/docs/adr/0023-balance-delegation-to-position-keeping.md
+++ b/docs/adr/0023-balance-delegation-to-position-keeping.md
@@ -30,7 +30,7 @@ Current Account originally stored balance locally in the database with fields `b
 `available_balance`, and `balance_updated_at`. This created several problems:
 
 1. **Dual-write complexity**: Every transaction required updating both Position Keeping
-   (transaction log) and Current Account (balance). This introduced synchronization risks.
+   (transaction log) and Current Account (balance). This introduced synchronisation risks.
 
 2. **Consistency challenges**: If Position Keeping succeeded but Current Account failed,
    the balance could become inconsistent with the transaction history.
@@ -45,14 +45,14 @@ Current Account originally stored balance locally in the database with fields `b
 ## Decision Drivers
 
 * BIAN compliance: Position Keeping is the authoritative domain for position/balance data
-* Eliminate dual-write complexity and synchronization bugs
+* Eliminate dual-write complexity and synchronisation bugs
 * Single source of truth for balance computation
 * Support for 7 BIAN balance types (not just current/available)
 * Simpler Current Account schema (account metadata only)
 
 ## Considered Options
 
-1. Keep balance in Current Account with synchronization
+1. Keep balance in Current Account with synchronisation
 2. Delegate balance computation to Position Keeping (chosen)
 3. Event-sourced balance with eventual consistency
 
@@ -68,8 +68,8 @@ source of truth for balance data.
 * Simplified Current Account: Only stores account metadata, not derived data
 * BIAN compliance: Follows BIAN service domain boundaries
 * Richer balance types: 7 BIAN balance types (OPENING, CLOSING, CURRENT, AVAILABLE, etc.)
-* Eliminated synchronization bugs: No more dual-write consistency issues
-* Cleaner migration: Opening balance support via Position Keeping initialization
+* Eliminated synchronisation bugs: No more dual-write consistency issues
+* Cleaner migration: Opening balance support via Position Keeping initialisation
 
 ### Negative Consequences
 
@@ -79,13 +79,13 @@ source of truth for balance data.
 
 ## Pros and Cons of the Options
 
-### Option 1: Keep balance in Current Account with synchronization
+### Option 1: Keep balance in Current Account with synchronisation
 
 Store balance locally in Current Account and synchronize with Position Keeping.
 
 * Good, because no network hop for balance queries
 * Good, because Current Account is self-contained
-* Bad, because dual-write complexity introduces synchronization bugs
+* Bad, because dual-write complexity introduces synchronisation bugs
 * Bad, because violates single source of truth principle
 * Bad, because limited to 2 balance types (current, available)
 * Bad, because Current Account must understand balance computation logic
@@ -96,7 +96,7 @@ Remove balance storage from Current Account. Position Keeping computes balance o
 from the transaction log.
 
 * Good, because single source of truth (transaction log = balance)
-* Good, because eliminates dual-write synchronization issues
+* Good, because eliminates dual-write synchronisation issues
 * Good, because BIAN-compliant service boundaries
 * Good, because supports 7 balance types
 * Good, because Current Account schema is simpler
@@ -169,7 +169,7 @@ for _, b := range balances.Balances {
 
 * Circuit breaker on Position Keeping client (3 retries, exponential backoff)
 * Graceful degradation when Position Keeping unavailable
-* Optional balance caching for read-heavy workloads (future optimization)
+* Optional balance caching for read-heavy workloads (future optimisation)
 
 ## Links
 

--- a/docs/adr/0023-balance-delegation-to-position-keeping.md
+++ b/docs/adr/0023-balance-delegation-to-position-keeping.md
@@ -81,7 +81,7 @@ source of truth for balance data.
 
 ### Option 1: Keep balance in Current Account with synchronisation
 
-Store balance locally in Current Account and synchronize with Position Keeping.
+Store balance locally in Current Account and synchronise with Position Keeping.
 
 * Good, because no network hop for balance queries
 * Good, because Current Account is self-contained

--- a/docs/adr/0024-internal-bank-account-service.md
+++ b/docs/adr/0024-internal-bank-account-service.md
@@ -182,7 +182,7 @@ Create BIAN-aligned Internal Account service as a multi-asset account registry.
 * **CLOSED**: Account is permanently closed (cannot be reopened)
 
 **Note**: There is no PENDING state. Accounts are created directly in ACTIVE status
-because internal accounts are created by authorized operations, not customer requests.
+because internal accounts are created by authorised operations, not customer requests.
 
 ### Balance Delegation
 

--- a/docs/adr/0025-clearing-purpose-specialization.md
+++ b/docs/adr/0025-clearing-purpose-specialization.md
@@ -1,5 +1,5 @@
 ---
-name: adr-025-clearing-purpose-specialization
+name: adr-025-clearing-purpose-specialisation
 description: Distinguish clearing accounts by purpose (deposit/withdrawal/settlement/general) for precise account resolution
 triggers:
   - Resolving clearing accounts for specific operations
@@ -11,7 +11,7 @@ instructions: |
   by purpose using clearing_purpose_filter in ListInternalAccounts RPC.
 ---
 
-# 25. Clearing Purpose Specialization
+# 25. Clearing Purpose Specialisation
 
 Date: 2026-01-16
 

--- a/docs/adr/0026-canonical-ingestion-contract.md
+++ b/docs/adr/0026-canonical-ingestion-contract.md
@@ -157,7 +157,7 @@ data integrity through CEL validation at the boundary.
 
 Build a centralised ETL service that handles all external connectivity and transformation.
 
-* Good, because it centralizes integration logic
+* Good, because it centralises integration logic
 * Good, because it provides a single point for monitoring
 * Bad, because it becomes a bottleneck and single point of failure
 * Bad, because it requires deep knowledge of every possible source format

--- a/docs/adr/0026-canonical-ingestion-contract.md
+++ b/docs/adr/0026-canonical-ingestion-contract.md
@@ -10,7 +10,7 @@ triggers:
 instructions: |
   Meridian is a high-performance persistence layer (100k TPS target). Keep messy ETL OFF the
   critical path. Services accept ONLY pre-structured Protobuf - all extraction, transformation,
-  and normalization is the caller's responsibility. This extends hexagonal architecture: Meridian
+  and normalisation is the caller's responsibility. This extends hexagonal architecture: Meridian
   defines the Port (structured schema), external systems implement the Adapter (messy translation).
   CEL validation at the boundary enforces the contract. Adapters scale independently from core.
 ---
@@ -111,7 +111,7 @@ data integrity through CEL validation at the boundary.
 │  Responsibility:                   │   Responsibility:                      │
 │  • Connectivity                    │   • Schema Definition                  │
 │  • Extraction                      │   • Contract Enforcement               │
-│  • Normalization                   │   • Bi-Temporal Storage                │
+│  • Normalisation                   │   • Bi-Temporal Storage                │
 │  • Scheduling                      │   • Quality Resolution                 │
 │  • Error Recovery                  │   • Knowledge Lineage                  │
 │                                    │                                        │
@@ -155,7 +155,7 @@ data integrity through CEL validation at the boundary.
 
 ### Option 1: Universal Ingestion Middleware
 
-Build a centralized ETL service that handles all external connectivity and transformation.
+Build a centralised ETL service that handles all external connectivity and transformation.
 
 * Good, because it centralizes integration logic
 * Good, because it provides a single point for monitoring

--- a/docs/adr/0027-market-information-management.md
+++ b/docs/adr/0027-market-information-management.md
@@ -24,7 +24,7 @@ Accepted
 
 ## Context
 
-Meridian requires a centralized service for managing market data, reference prices, and rate information. This data is critical for:
+Meridian requires a centralised service for managing market data, reference prices, and rate information. This data is critical for:
 
 - **Energy pricing**: Spot prices, tariff rates, carbon credit prices
 - **Foreign exchange**: Currency pair rates from sources like ECB
@@ -61,7 +61,7 @@ Market data is fundamentally different: it represents **observed facts about the
 * Configurable validation without code deployment
 * Multi-tenant data isolation
 * High-throughput batch ingestion (target: 100k TPS as per ADR-0026)
-* Forward-compatible with time-series optimizations
+* Forward-compatible with time-series optimisations
 
 ## Decision Outcome
 
@@ -145,7 +145,7 @@ DataSource
 
 ### Bi-Temporal Data Model
 
-The service implements **bi-temporal modeling** to answer two distinct questions:
+The service implements **bi-temporal modelling** to answer two distinct questions:
 
 | Dimension | Question | Field |
 |-----------|----------|-------|
@@ -397,4 +397,4 @@ The migration includes pre-configured datasets for common use cases:
 * [ADR-0002: Microservices Per BIAN Domain](./0002-microservices-per-bian-domain.md) - Service architecture
 * [ADR-0026: Canonical Ingestion Contract](./0026-canonical-ingestion-contract.md) - ETL off critical path
 * [CEL Specification](https://github.com/google/cel-spec) - Common Expression Language
-* [Temporal Data Modeling](https://martinfowler.com/articles/temporal-modeling.html) - Bi-temporal patterns reference
+* [Temporal Data Modelling](https://martinfowler.com/articles/temporal-modelling.html) - Bi-temporal patterns reference

--- a/docs/adr/0028-starlark-saga-cel-valuation.md
+++ b/docs/adr/0028-starlark-saga-cel-valuation.md
@@ -546,7 +546,7 @@ Sagas execute within a party scope, ensuring data isolation across organizationa
 ctx.party_scope = PartyScope(
     party_id = "P001",                    # Executing party
     party_type = "ORGANIZATION",          # INDIVIDUAL, ORGANIZATION
-    visible_parties = ["P001", "P002"],   # Party + authorized children
+    visible_parties = ["P001", "P002"],   # Party + authorised children
 )
 
 # All lookups are automatically scoped
@@ -735,7 +735,7 @@ func createLienHandler(client *Client) saga.Handler {
 
 ### Dependency Injection Over Global Registry
 
-Services explicitly declare their saga handler dependencies during initialization:
+Services explicitly declare their saga handler dependencies during initialisation:
 
 **Before (global registry - problematic)**:
 
@@ -830,7 +830,7 @@ data corruption could occur.
 
 * **Tenant flexibility**: Different posting patterns without code deployment
 * **1:N posting support**: One position entry generates dynamic number of postings
-* **Separation of concerns**: Business logic in Starlark, financial math in CEL
+* **Separation of concerns**: Business logic in Starlark, financial maths in CEL
 * **Hot-reloadable**: Saga changes without service restart
 * **Auditability**: Versioned definitions with full history in reference data
 * **Testability**: Unit test posting rules independently; dry-run API for validation
@@ -901,12 +901,12 @@ For non-technical stakeholders:
 * **CEL is the "Policy"**: "This is the formula for how we calculate the price." Policies are rigid, fast, and auditable.
 * **Starlark is the "Procedure"**: "This is the sequence of steps we take to settle a transaction." Procedures are flexible and handle real-world complexity.
 
-**Value proposition**: The system is **Flexible** (procedures can change without deployment) but **Rock-Solid** (financial math is enforced by a mathematical engine with guaranteed termination).
+**Value proposition**: The system is **Flexible** (procedures can change without deployment) but **Rock-Solid** (financial maths is enforced by a mathematical engine with guaranteed termination).
 
 ### Reconsidering This Decision
 
 Revisit if:
 - Starlark execution becomes a performance bottleneck (>5ms per saga)
 - Debugging complexity outweighs flexibility benefits
-- Tenant-specific saga customization proves unnecessary
+- Tenant-specific saga customisation proves unnecessary
 - A superior embedded scripting solution emerges

--- a/docs/adr/0029-settlement-scheduler-architecture.md
+++ b/docs/adr/0029-settlement-scheduler-architecture.md
@@ -32,7 +32,7 @@ approach would be more appropriate.
 Key concerns:
 - Missed settlement windows during pod restarts or deployments.
 - No audit trail of which windows were triggered, skipped, or missed.
-- No defense-in-depth against duplicate settlement runs at the database level.
+- No defence-in-depth against duplicate settlement runs at the database level.
 
 ## Decision Drivers
 
@@ -60,7 +60,7 @@ resilience without introducing new infrastructure or operational complexity.
 * Catch-up mechanism detects and triggers missed windows on startup.
 * Audit trail enables operators to query scheduler health.
 * Unique constraint on `settlement_run(account_id, period_start, period_end)` provides
-  defense-in-depth against duplicate runs.
+  defence-in-depth against duplicate runs.
 * No new infrastructure required beyond what already exists (Redis, CockroachDB).
 * Cron expressions are evaluated in-process with sub-second precision.
 

--- a/docs/adr/0030-kyc-aml-provider-selection.md
+++ b/docs/adr/0030-kyc-aml-provider-selection.md
@@ -149,7 +149,7 @@ The provider abstraction layer (ADR-021) supports adding providers without code 
 
 * **US market**: Evaluate Jumio or Persona as the US-focused provider
 * **Global sanctions**: Consider ComplyAdvantage as a dedicated sanctions screening provider if Onfido's coverage proves insufficient
-* **Cost optimization**: Re-evaluate Sumsub for high-volume tenants where per-check costs become significant
+* **Cost optimisation**: Re-evaluate Sumsub for high-volume tenants where per-check costs become significant
 
 ### Re-evaluation Triggers
 

--- a/docs/adr/0031-getbalance-nil-guard-retention.md
+++ b/docs/adr/0031-getbalance-nil-guard-retention.md
@@ -43,7 +43,7 @@ During review of the account service wiring, the question was raised whether thi
 ## Considered Options
 
 1. Remove the nil guard (rely on constructor validation)
-2. Keep the nil guard (current behavior)
+2. Keep the nil guard (current behaviour)
 
 ## Decision Outcome
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -69,7 +69,7 @@ Architectural Decision Records) format.
 | [ADR-0023](0023-balance-delegation-to-position-keeping.md) | Balance Delegation to Position Keeping | Accepted | 2026-01-08 |
 | [ADR-0024](0024-internal-account-service.md) | Internal Account Service Domain | Accepted | 2026-01-15 |
 <!-- markdownlint-disable-next-line MD013 -->
-| [ADR-0025](0025-clearing-purpose-specialization.md) | Clearing Purpose Specialization | Accepted | 2026-01-16 |
+| [ADR-0025](0025-clearing-purpose-specialisation.md) | Clearing Purpose Specialisation | Accepted | 2026-01-16 |
 <!-- markdownlint-disable-next-line MD013 -->
 | [ADR-0026](0026-canonical-ingestion-contract.md) | Canonical Ingestion Contract | Accepted | 2026-01-17 |
 <!-- markdownlint-disable-next-line MD013 -->
@@ -130,7 +130,7 @@ graph LR
 - [ADR-0018](0018-settlement-reconciliation.md) - Settlement & Reconciliation (Lifecycle)
 - [ADR-0023](0023-balance-delegation-to-position-keeping.md) - Balance Delegation to Position Keeping
 - [ADR-0024](0024-internal-account-service.md) - Internal Account Service Domain
-- [ADR-0025](0025-clearing-purpose-specialization.md) - Clearing Purpose Specialization
+- [ADR-0025](0025-clearing-purpose-specialisation.md) - Clearing Purpose Specialisation
 - [ADR-0026](0026-canonical-ingestion-contract.md) - Canonical Ingestion Contract
 
 ### Development Environment & Infrastructure

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -15,7 +15,7 @@ instructions: |
 
   Example: Use event sourcing with an append-only event store. Events are immutable
   facts representing state changes. Rebuild current state by replaying events from
-  the beginning. Use snapshots for performance optimization.
+  the beginning. Use snapshots for performance optimisation.
 ---
 
 # [number]. [title]

--- a/docs/api/saga-validation.md
+++ b/docs/api/saga-validation.md
@@ -26,10 +26,10 @@ This endpoint requires authentication via JWT token or API key:
 | Header | Required | Description |
 |--------|----------|-------------|
 | `Content-Type` | Yes | Must be `application/json` or `application/connect+proto` |
-| `Authorization` | Yes* | JWT bearer token for user authentication |
+| `Authorisation` | Yes* | JWT bearer token for user authentication |
 | `X-API-Key` | Yes* | API key for service-to-service authentication |
 
-*One of `Authorization` or `X-API-Key` is required.
+*One of `Authorisation` or `X-API-Key` is required.
 
 ### Request Body (JSON)
 
@@ -145,7 +145,7 @@ When validation fails, the response still returns 200 OK but with `success: fals
 |-------------|-------------|
 | 400 Bad Request | Invalid request body or missing required fields |
 | 401 Unauthorized | Missing or invalid authentication credentials |
-| 403 Forbidden | Authenticated but not authorized for this tenant |
+| 403 Forbidden | Authenticated but not authorised for this tenant |
 | 404 Not Found | Endpoint not found (check URL path) |
 | 500 Internal Server Error | Server error during validation |
 | 503 Service Unavailable | Saga validation service temporarily unavailable |

--- a/docs/api/saga-validation.md
+++ b/docs/api/saga-validation.md
@@ -26,10 +26,10 @@ This endpoint requires authentication via JWT token or API key:
 | Header | Required | Description |
 |--------|----------|-------------|
 | `Content-Type` | Yes | Must be `application/json` or `application/connect+proto` |
-| `Authorisation` | Yes* | JWT bearer token for user authentication |
+| `Authorization` | Yes* | JWT bearer token for user authentication |
 | `X-API-Key` | Yes* | API key for service-to-service authentication |
 
-*One of `Authorisation` or `X-API-Key` is required.
+*One of `Authorization` or `X-API-Key` is required.
 
 ### Request Body (JSON)
 

--- a/docs/architecture/api-contracts/current-account-contract.md
+++ b/docs/architecture/api-contracts/current-account-contract.md
@@ -235,7 +235,7 @@ Response: {
 
 ### ExecuteDeposit
 
-Processes a deposit transaction (BIAN Behavior Qualifier: Deposits).
+Processes a deposit transaction (BIAN Behaviour Qualifier: Deposits).
 
 **Proto Definition:**
 
@@ -844,7 +844,7 @@ facility.CurrentBalance = mapBalancesToResponse(balances)
 
 ### Error Handling for Balance Queries
 
-| Error | Handling | Client Behavior |
+| Error | Handling | Client Behaviour |
 |-------|----------|-----------------|
 | Position Keeping unavailable | Circuit breaker, return UNAVAILABLE | Retry with backoff |
 | Timeout | Return DEADLINE_EXCEEDED | Retry with longer timeout |

--- a/docs/architecture/api-contracts/financial-accounting-contract.md
+++ b/docs/architecture/api-contracts/financial-accounting-contract.md
@@ -55,7 +55,7 @@ stateDiagram-v2
     end note
 
     note right of POSTED
-        All postings balanced and finalized.
+        All postings balanced and finalised.
         Terminal state (immutable).
         No further postings can be added.
         Included in financial reports.
@@ -83,13 +83,13 @@ stateDiagram-v2
     REVERSED --> [*]: Terminal state
 
     note right of PENDING
-        Posting captured but not yet finalized.
+        Posting captured but not yet finalised.
         Parent booking log still PENDING.
         Can be cancelled before log posted.
     end note
 
     note right of POSTED
-        Posting finalized with parent log.
+        Posting finalised with parent log.
         Included in account balances.
         Immutable (can only be reversed).
     end note

--- a/docs/architecture/api-contracts/position-keeping-contract.md
+++ b/docs/architecture/api-contracts/position-keeping-contract.md
@@ -92,7 +92,7 @@ stateDiagram-v2
 **POSTED → REVERSED:**
 
 - Trigger: Reversal request from upstream service
-- Preconditions: Transaction in POSTED state, reversal authorized
+- Preconditions: Transaction in POSTED state, reversal authorised
 - Postconditions: New POSTED transaction created (opposite direction), original marked REVERSED
 - Reversible: No (terminal state, but reversal itself can be reversed)
 
@@ -1527,7 +1527,7 @@ sequenceDiagram
     PK-->>CA: BalanceEntry[] (7 types)
 ```
 
-### Performance Optimization
+### Performance Optimisation
 
 For high-traffic accounts, consider:
 
@@ -1542,7 +1542,7 @@ For high-traffic accounts, consider:
 1. **Streaming API**: gRPC server-streaming for real-time transaction updates
 2. **Compression**: GZIP compression for bulk import requests
 3. **Batch Idempotency**: Idempotency key support for BulkImportTransactions
-4. **Query Optimization**: Materialized views for common queries
+4. **Query Optimisation**: Materialized views for common queries
 5. **Archival**: Automatic archival of old logs (> 1 year)
 6. **Lineage API**: Dedicated RPC for lineage traversal queries
 7. **Aggregate Queries**: Sum/count operations across logs

--- a/docs/architecture/bian-service-boundaries.md
+++ b/docs/architecture/bian-service-boundaries.md
@@ -58,7 +58,7 @@ The CurrentAccount service owns:
 
 #### Account Lifecycle Management
 
-- **Account creation and initialization** (`InitiateCurrentAccount` RPC)
+- **Account creation and initialisation** (`InitiateCurrentAccount` RPC)
   - Account ID generation and assignment
   - IBAN validation and storage (`account_identification`)
   - Account status management (ACTIVE, FROZEN, CLOSED)
@@ -376,7 +376,7 @@ The PositionKeeping service owns:
 
 - Observability (OpenTelemetry tracing, structured logging, metrics)
 - Kafka event publishing infrastructure
-- Authentication and authorization (JWT validation)
+- Authentication and authorisation (JWT validation)
 
 **No Direct Service Dependencies:**
 
@@ -485,7 +485,7 @@ The FinancialAccounting service owns:
 
 - **Balance validation**
   - Ensure debits = credits before transitioning booking log to POSTED status
-  - Prevent unbalanced booking logs from being finalized
+  - Prevent unbalanced booking logs from being finalised
   - Validate double-entry integrity at service layer
 
 - **Posting updates** (`UpdateLedgerPosting` RPC)
@@ -821,7 +821,7 @@ Platform code is currently in `internal/platform/` but is being migrated to `pkg
 
 **`kafka/` - Kafka Producer/Consumer Infrastructure**
 
-- Kafka producer with protobuf serialization
+- Kafka producer with protobuf serialisation
 - Kafka consumer with offset management
 - Consumer group coordination
 - Error handling and retry logic
@@ -833,7 +833,7 @@ Platform code is currently in `internal/platform/` but is being migrated to `pkg
 **`testdb/` - Testcontainers Integration**
 
 - PostgreSQL Testcontainers setup
-- Database schema initialization for tests
+- Database schema initialisation for tests
 - Transaction isolation for test cases
 - Connection pool management for tests
 - **Used by:** Current-account, financial-accounting (5 imports detected)
@@ -844,10 +844,10 @@ Platform code is currently in `internal/platform/` but is being migrated to `pkg
   - `internal/financial-accounting/service/posting_service_test.go`
   - `internal/financial-accounting/adapters/messaging/deposit_consumer_test.go`
 
-**`auth/` - JWT Validation and Authorization**
+**`auth/` - JWT Validation and Authorisation**
 
 - JWT token parsing and validation
-- Authorization middleware for gRPC
+- Authorisation middleware for gRPC
 - Role-based access control (RBAC)
 - **Used by:** Position-keeping (1 import detected)
 - **Files:**
@@ -1141,7 +1141,7 @@ db, err := sql.Open("postgres", os.Getenv("POSITION_KEEPING_DB_URL"))
 
 - Domain logic should be co-located with the service that owns the domain
 - Prevents business rule duplication across services
-- Maintains single source of truth for domain behaviors
+- Maintains single source of truth for domain behaviours
 - Supports domain-driven design principles
 - Clear ownership for business rule changes
 
@@ -1243,14 +1243,14 @@ These dependency patterns are architecturally permitted and support the BIAN-ali
 
 - `pkg/platform/observability` - OpenTelemetry tracing, logging, metrics
 - `pkg/platform/kafka` - Kafka producer/consumer infrastructure
-- `pkg/platform/auth` - JWT validation and authorization
+- `pkg/platform/auth` - JWT validation and authorisation
 - `pkg/platform/testdb` - Testcontainers integration for tests
 
 **Justification:**
 
 - Platform code is shared infrastructure, not business logic
 - Prevents duplication of cross-cutting concerns
-- Centralized maintenance of observability and integration patterns
+- Centralised maintenance of observability and integration patterns
 
 ### Forbidden Dependency Patterns
 
@@ -1550,11 +1550,11 @@ This section maps Meridian services to their corresponding BIAN service domains 
 **Meridian Implementation:**
 
 - Account facility creation (`InitiateCurrentAccount` → BIAN Initiate)
-- Deposit execution (`ExecuteDeposit` → BIAN Execute behavior qualifier)
+- Deposit execution (`ExecuteDeposit` → BIAN Execute behaviour qualifier)
 - Account retrieval (`RetrieveCurrentAccount` → BIAN Retrieve)
 
 **BIAN Control Record:** `CurrentAccountFacility`
-**BIAN Behavior Qualifiers:**
+**BIAN Behaviour Qualifiers:**
 
 - Deposits (implemented)
 - Payments (not yet implemented)
@@ -1581,7 +1581,7 @@ This section maps Meridian services to their corresponding BIAN service domains 
 - List logs (`ListFinancialPositionLogs` → BIAN Retrieve with filtering)
 
 **BIAN Control Record:** `FinancialPositionLog`
-**BIAN Behavior Qualifiers:**
+**BIAN Behaviour Qualifiers:**
 
 - TransactionLog (implemented via `TransactionLogEntry`)
 - TransactionLineage (implemented)
@@ -1604,12 +1604,12 @@ This section maps Meridian services to their corresponding BIAN service domains 
 
 - Booking log initiation (`InitiateFinancialBookingLog` → BIAN Initiate)
 - Booking log update (`UpdateFinancialBookingLog` → BIAN Update)
-- Posting capture (`CaptureLedgerPosting` → BIAN Capture behavior qualifier)
+- Posting capture (`CaptureLedgerPosting` → BIAN Capture behaviour qualifier)
 - Posting update (`UpdateLedgerPosting` → BIAN Update)
 - List operations (`ListFinancialBookingLogs`, `ListLedgerPostings` → BIAN Retrieve)
 
 **BIAN Control Record:** `FinancialBookingLog`
-**BIAN Behavior Qualifiers:**
+**BIAN Behaviour Qualifiers:**
 
 - LedgerPosting (implemented via `LedgerPosting` entity)
 
@@ -1633,7 +1633,7 @@ This section maps Meridian services to their corresponding BIAN service domains 
 - Dataset management (`CreateDataSet`, `ActivateDataSet` → BIAN Initiate, Update)
 
 **BIAN Control Record:** `MarketPriceObservation`
-**BIAN Behavior Qualifiers:**
+**BIAN Behaviour Qualifiers:**
 
 - PriceObservation (implemented via `MarketPriceObservation` entity)
 - DataSetConfiguration (implemented via `DataSetDefinition` entity)
@@ -2001,14 +2001,14 @@ graph TD
 **Authentication (JWT):**
 
 - **Used by:** PositionKeeping
-- **Provides:** JWT token validation, authorization middleware, RBAC
+- **Provides:** JWT token validation, authorisation middleware, RBAC
 - **Current Location:** `internal/platform/auth` (migration to `pkg/platform/auth` in progress)
 - **Imports:** 1 file
 
 **Test Infrastructure (Testcontainers):**
 
 - **Used by:** CurrentAccount, FinancialAccounting
-- **Provides:** PostgreSQL Testcontainers setup, database schema initialization
+- **Provides:** PostgreSQL Testcontainers setup, database schema initialisation
 - **Current Location:** `internal/platform/testdb` (migration to `pkg/platform/testdb` in progress)
 - **Imports:** 5 test files
 
@@ -2114,7 +2114,7 @@ graph TD
 - Service boundary changed (ownership transfer)
 - New proto entity defined
 - Coupling analysis reveals new patterns
-- Platform code organization changes
+- Platform code organisation changes
 
 **Review Cadence:**
 

--- a/docs/architecture/event-driven-architecture.md
+++ b/docs/architecture/event-driven-architecture.md
@@ -16,13 +16,13 @@ Meridian's event-driven architecture enables asynchronous communication between 
 2. **At-Least-Once Delivery**: Kafka guarantees at-least-once delivery; consumers must implement idempotency
 3. **Event Sourcing Lite**: Database is the source of truth; events are for coordination, not primary storage
 4. **Schema Evolution via Protobuf**: All events use protobuf with `buf breaking` validation (no Schema Registry)
-5. **BIAN Semantic Alignment**: Event types map to BIAN behavior qualifiers (Initiate, Update, Control, Execute)
+5. **BIAN Semantic Alignment**: Event types map to BIAN behaviour qualifiers (Initiate, Update, Control, Execute)
 6. **Outbox Pattern**: Transactional event publishing using outbox tables for reliability
 
 ### Key Design Decisions
 
 - **No Schema Registry**: Internal-only Kafka usage enables compile-time validation via `buf breaking` (see ADR-0004)
-- **Protobuf Serialization**: Consistent with gRPC APIs, type-safe, efficient
+- **Protobuf Serialisation**: Consistent with gRPC APIs, type-safe, efficient
 - **Topic-per-Event-Type**: One Kafka topic per event type (e.g., `current-account.account-created.v1`)
 - **Partition Key = Aggregate ID**: Events for the same aggregate (account, booking log) go to the same partition for ordering
 - **7-Day Retention**: Events are ephemeral coordination; database is persistent source of truth
@@ -123,7 +123,7 @@ google.type.Money amount = 4 [
 
 ---
 
-## Event Catalog
+## Event Catalogue
 
 ### CurrentAccount Service Events
 
@@ -156,7 +156,7 @@ google.type.Money amount = 4 [
 | `FinancialBookingLogClosedEvent` | `financial-accounting.booking-log-closed.v1` | Booking log closed (terminal state) | Audit, Archival | `booking_log_id` |
 | `LedgerPostingCapturedEvent` | `financial-accounting.ledger-posting-captured.v1` | Debit/credit posting created | Trial-balance, Account-summary | `booking_log_id` |
 | `LedgerPostingAmendedEvent` | `financial-accounting.ledger-posting-amended.v1` | Posting amount amended before posting | Audit, Compliance | `booking_log_id` |
-| `LedgerPostingPostedEvent` | `financial-accounting.ledger-posting-posted.v1` | Posting finalized to general ledger | General-ledger, Reporting | `booking_log_id` |
+| `LedgerPostingPostedEvent` | `financial-accounting.ledger-posting-posted.v1` | Posting finalised to general ledger | General-ledger, Reporting | `booking_log_id` |
 | `LedgerPostingRejectedEvent` | `financial-accounting.ledger-posting-rejected.v1` | Posting rejected during validation (terminal) | Monitoring, DLQ | `booking_log_id` |
 | `BalanceValidationFailedEvent` | `financial-accounting.balance-validation-failed.v1` | Debits ≠ Credits (double-entry violation) | Monitoring, Audit, Alerting | `booking_log_id` |
 
@@ -770,10 +770,10 @@ message AccountCreatedEvent {
 
 **CI Validation:** `buf breaking --against main` passes
 
-✅ **Add new event types** (new BIAN behavior qualifiers)
+✅ **Add new event types** (new BIAN behaviour qualifiers)
 
 ```protobuf
-// New event for BIAN 14.0 "Suspend" behavior qualifier
+// New event for BIAN 14.0 "Suspend" behaviour qualifier
 message AccountSuspendedEvent {
   string event_id = 1;
   string account_id = 2;
@@ -791,7 +791,7 @@ message AccountSuspendedEvent {
 
 ❌ **Change field types** (wire format incompatible)
 
-❌ **Change field numbers** (protobuf uses numbers for serialization)
+❌ **Change field numbers** (protobuf uses numbers for serialisation)
 
 ❌ **Rename fields** (breaks generated code, even though wire format is compatible)
 
@@ -814,7 +814,7 @@ Examples:
 
 - `v1` → `v2` only for breaking changes (rarely needed)
 - Backward-compatible changes stay in `v1` (add optional fields)
-- New BIAN behavior qualifiers = new event types (not version bumps)
+- New BIAN behaviour qualifiers = new event types (not version bumps)
 
 **Example Evolution:**
 
@@ -823,7 +823,7 @@ Examples:
 current-account.account-created.v1
 current-account.account-status-changed.v1
 
-# BIAN 14.0 adds "Suspend" behavior qualifier
+# BIAN 14.0 adds "Suspend" behaviour qualifier
 current-account.account-suspended.v1  ← New event type, NOT v2 of status-changed
 ```
 
@@ -1083,7 +1083,7 @@ log.Error("Failed to process event",
 
 ## Testing Event-Driven Flows
 
-### Unit Tests: Event Serialization
+### Unit Tests: Event Serialisation
 
 ```go
 // api/proto/meridian/events/v1/current_account_events_test.go
@@ -1259,7 +1259,7 @@ kafka-consumer-groups --bootstrap-server kafka:9092 \
 **Resolution:**
 
 1. **Scale consumers horizontally**: Add consumer instances (up to partition count)
-2. **Optimize handler performance**: Profile slow database queries, add indexes
+2. **Optimise handler performance**: Profile slow database queries, add indexes
 3. **Increase partition count**: (requires topic recreation and consumer rebalance)
 4. **Batch processing**: Process events in batches instead of one-by-one
 
@@ -1285,7 +1285,7 @@ LIMIT 10;
 
 1. **Check Kafka broker availability**: `kafka-topics --bootstrap-server kafka:9092 --list`
 2. **Check outbox worker running**: Verify background goroutine started
-3. **Check for serialization errors**: Review `last_error` field in outbox table
+3. **Check for serialisation errors**: Review `last_error` field in outbox table
 4. **Check Kafka ACLs**: Ensure producer has WRITE permission on topics
 5. **Restart service**: Outbox worker may be stuck (restart triggers recovery)
 
@@ -1412,7 +1412,7 @@ sequenceDiagram
 
     Kafka-->>FA: TransactionCompletedEvent
     Kafka-->>PK: TransactionCompletedEvent
-    Note over FA,PK: Services update internal state<br/>to mark transaction finalized
+    Note over FA,PK: Services update internal state<br/>to mark transaction finalised
 ```
 
 **Event Sequence:**

--- a/docs/architecture/service-coupling-analysis.md
+++ b/docs/architecture/service-coupling-analysis.md
@@ -112,7 +112,7 @@ which indicates proper BIAN boundary respect.
 | observability | internal/platform/observability | pkg/platform/observability | Shared OpenTelemetry, logging, metrics |
 | kafka | internal/platform/kafka | pkg/platform/kafka | Kafka producer/consumer with protobuf |
 | testdb | internal/platform/testdb | pkg/platform/testdb | Shared Testcontainers infrastructure |
-| auth | internal/platform/auth | pkg/platform/auth | JWT validation and authorization |
+| auth | internal/platform/auth | pkg/platform/auth | JWT validation and authorisation |
 
 ### Table 3: Proto Dependencies (SAFE)
 
@@ -164,7 +164,7 @@ Event-driven patterns detected across services:
 
 - Services use domain-defined EventPublisher interfaces
 - Kafka adapter implementations in `adapters/messaging/` layer
-- Protobuf serialization for events (as per ADR-0004)
+- Protobuf serialisation for events (as per ADR-0004)
 
 **Key Files:**
 
@@ -290,7 +290,7 @@ All items are categorized by priority based on their impact on service independe
 
 - **P0 - Critical**: Breaks service independence and violates BIAN domain boundaries
 - **P1 - High**: Architectural debt that increases technical risk and maintenance burden
-- **P2 - Medium**: Code organization issues that affect code clarity and maintenance
+- **P2 - Medium**: Code organisation issues that affect code clarity and maintenance
 
 ### P0 - Critical (Breaks Service Independence)
 
@@ -472,7 +472,7 @@ func (a *PositionKeepingAdapter) GetBalance(ctx context.Context, accountID strin
 
 ---
 
-### P2 - Medium (Code Organization)
+### P2 - Medium (Code Organisation)
 
 #### P2-1: Document Inter-Service Communication Contracts
 
@@ -684,7 +684,7 @@ After implementing remediation items:
    - Use Pact or similar for consumer-driven contract testing
 
 2. **Chaos Engineering:**
-   - Test service behavior when dependencies are unavailable
+   - Test service behaviour when dependencies are unavailable
    - Validate circuit breaker patterns in resilient_client.go
 
 3. **Coupling Regression Tests:**
@@ -753,4 +753,4 @@ Full metrics available in: `docs/architecture/coupling-metrics.json`
 - **Efferent Coupling (Ce):** Number of classes/services inside a package that depend on classes outside the package
 - **Instability (I):** Measure of package's resilience to change (0=stable, 1=unstable)
 - **Main Sequence:** Ideal balance line between abstractness and instability
-- **Proto:** Protocol Buffers - Google's serialization format used for gRPC and events
+- **Proto:** Protocol Buffers - Google's serialisation format used for gRPC and events

--- a/docs/architecture/starlark-saga-architecture.md
+++ b/docs/architecture/starlark-saga-architecture.md
@@ -4,7 +4,7 @@
 
 Meridian uses [Starlark](https://github.com/google/starlark-go) for saga orchestration, enabling tenant-specific
 workflow definitions without code deployment. This architecture separates orchestration logic (Starlark scripts)
-from service implementation (gRPC services), allowing business teams to customize workflows while maintaining
+from service implementation (gRPC services), allowing business teams to customise workflows while maintaining
 strict type safety and audit compliance.
 
 ## Table of Contents
@@ -150,7 +150,7 @@ Each `starlark.go` file implements:
 ```go
 // services/current-account/client/starlark.go
 
-// 1. Registration function (called during service initialization)
+// 1. Registration function (called during service initialisation)
 func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, client *Client) error {
     handlers := map[string]struct {
         handler  saga.Handler
@@ -279,7 +279,7 @@ graph LR
 
 ## Dependency Injection Pattern
 
-Services explicitly declare their saga handler dependencies during initialization:
+Services explicitly declare their saga handler dependencies during initialisation:
 
 ### Before (Global Registry - Problematic)
 
@@ -294,7 +294,7 @@ executor := saga.NewExecutor(saga.ExecutorConfig{
 
 - Global state makes testing difficult
 - Hidden dependencies (what services does this saga actually call?)
-- Initialization order matters
+- Initialisation order matters
 - Circular dependencies possible
 
 ### After (Explicit Registration - Current)

--- a/docs/archive/rbac-testing-guide.md
+++ b/docs/archive/rbac-testing-guide.md
@@ -161,13 +161,13 @@ curl -X POST -H "Authorization: Bearer $AUDITOR_TOKEN" \
 
 # Admin can call admin-only gRPC method
 
-grpcurl -H "authorisation: Bearer $ADMIN_TOKEN" \
+grpcurl -H "authorization: Bearer $ADMIN_TOKEN" \
   localhost:9090 \
   meridian.v1.ConfigService/UpdateSystemConfig
 
 # Auditor cannot call admin-only method (should return PERMISSION_DENIED)
 
-grpcurl -H "authorisation: Bearer $AUDITOR_TOKEN" \
+grpcurl -H "authorization: Bearer $AUDITOR_TOKEN" \
   localhost:9090 \
   meridian.v1.ConfigService/UpdateSystemConfig
 ```

--- a/docs/archive/rbac-testing-guide.md
+++ b/docs/archive/rbac-testing-guide.md
@@ -81,7 +81,7 @@ server := grpc.NewServer(
 )
 ```
 
-#### Resource-Level Authorization
+#### Resource-Level Authorisation
 
 ```go
 // In your service handlers
@@ -161,13 +161,13 @@ curl -X POST -H "Authorization: Bearer $AUDITOR_TOKEN" \
 
 # Admin can call admin-only gRPC method
 
-grpcurl -H "authorization: Bearer $ADMIN_TOKEN" \
+grpcurl -H "authorisation: Bearer $ADMIN_TOKEN" \
   localhost:9090 \
   meridian.v1.ConfigService/UpdateSystemConfig
 
 # Auditor cannot call admin-only method (should return PERMISSION_DENIED)
 
-grpcurl -H "authorization: Bearer $AUDITOR_TOKEN" \
+grpcurl -H "authorisation: Bearer $AUDITOR_TOKEN" \
   localhost:9090 \
   meridian.v1.ConfigService/UpdateSystemConfig
 ```
@@ -198,7 +198,7 @@ Check that:
 
 1. JWT token contains the required role in the `roles` claim
 2. Token is not expired
-3. Authorization header is properly formatted: `Authorization: Bearer <token>`
+3. Authorisation header is properly formatted: `Authorization: Bearer <token>`
 
 ### 401 Unauthorized
 
@@ -210,13 +210,13 @@ Check that:
 
 ### Debugging
 
-Enable debug logging to see authorization decisions:
+Enable debug logging to see authorisation decisions:
 
 ```go
 import "github.com/meridianhub/meridian/internal/platform/observability"
 
 logger := observability.NewLogger(os.Stdout, observability.LogLevelDebug)
-logger.DebugContext(ctx, "Authorization check", map[string]interface{}{
+logger.DebugContext(ctx, "Authorisation check", map[string]interface{}{
     "user_id": claims.UserID,
     "roles": claims.Roles,
     "required_role": auth.RoleAdmin.String(),
@@ -250,4 +250,4 @@ http.Handle("/admin/endpoint",
 3. **Use resource-level helpers** for clarity: `AuthorizeAccountWrite(ctx)` is clearer than `HasPermission(claims,
 ResourceTypeAccount, PermissionWrite)`
 4. **Test with all roles** during development
-5. **Log authorization failures** for security monitoring
+5. **Log authorisation failures** for security monitoring

--- a/docs/archive/task-8-service-integration.md
+++ b/docs/archive/task-8-service-integration.md
@@ -76,7 +76,7 @@ Implement in phases to maintain working builds:
 
 ### Option 2: Proto-First Approach
 
-1. **Finalize Proto Definitions**: Stabilize APIs for all three services
+1. **Finalise Proto Definitions**: Stabilize APIs for all three services
 2. **Regenerate Code**: Run `buf generate` to ensure consistency
 3. **Implement Against Stable Protos**: Use agent-generated code as reference
 
@@ -143,4 +143,4 @@ issues stem from proto definition mismatches rather than fundamental design prob
 stabilize protos first or implement incrementally starting with simple clients.
 
 All agent-generated code can serve as high-quality reference material for the actual implementation once proto APIs are
-finalized.
+finalised.

--- a/docs/audit-analysis-findings.md
+++ b/docs/audit-analysis-findings.md
@@ -1,7 +1,7 @@
 # Async Audit Implementation Analysis Findings
 
 **Date**: 2024-12-24
-**Task**: 19.1 - Analysis phase for final optimization and DRY review
+**Task**: 19.1 - Analysis phase for final optimisation and DRY review
 **Scope**: 6 services (tenant, payment-order, party, position-keeping, financial-accounting, current-account)
 
 ## Executive Summary
@@ -31,7 +31,7 @@ The payment-order service maintains a **complete local copy** of the audit infra
 **Impact**:
 
 - Maintenance burden (changes must be made in two places)
-- Inconsistent behavior (local version uses `uuid.UUID` for RecordID, shared uses `string`)
+- Inconsistent behaviour (local version uses `uuid.UUID` for RecordID, shared uses `string`)
 - Missed Kafka integration (local version writes directly to outbox, shared version attempts Kafka first)
 
 **Recommendation**: Migrate payment-order to use shared audit library. This requires:

--- a/docs/authentication-integration.md
+++ b/docs/authentication-integration.md
@@ -173,7 +173,7 @@ if err != nil {
 }
 
 // Use token in outbound gRPC call
-md := metadata.Pairs("authorisation", "Bearer "+token)
+md := metadata.Pairs("authorization", "Bearer "+token)
 ctx = metadata.NewOutgoingContext(ctx, md)
 ```
 
@@ -411,7 +411,7 @@ import (
 )
 
 // Add token to outgoing context
-md := metadata.Pairs("authorisation", "Bearer "+token)
+md := metadata.Pairs("authorization", "Bearer "+token)
 ctx := metadata.NewOutgoingContext(context.Background(), md)
 
 // Make call
@@ -502,14 +502,14 @@ spec:
 
 ### Common Issues
 
-#### "missing authorisation header"
+#### "missing Authorization header"
 
 **Cause**: No `Authorization` header in gRPC metadata
 
 **Solution**: Add Bearer token to metadata:
 
 ```go
-md := metadata.Pairs("authorisation", "Bearer "+token)
+md := metadata.Pairs("authorization", "Bearer "+token)
 ctx := metadata.NewOutgoingContext(ctx, md)
 ```
 

--- a/docs/authentication-integration.md
+++ b/docs/authentication-integration.md
@@ -173,7 +173,7 @@ if err != nil {
 }
 
 // Use token in outbound gRPC call
-md := metadata.Pairs("authorization", "Bearer "+token)
+md := metadata.Pairs("authorisation", "Bearer "+token)
 ctx = metadata.NewOutgoingContext(ctx, md)
 ```
 
@@ -221,7 +221,7 @@ error) {
         return nil, status.Error(codes.Unauthenticated, "user not authenticated")
     }
 
-    // Get claims for authorization
+    // Get claims for authorisation
     claims, ok := auth.GetClaimsFromContext(ctx)
     if !ok {
         return nil, status.Error(codes.Unauthenticated, "claims not found")
@@ -333,7 +333,7 @@ type Claims struct {
 }
 ```
 
-### Using Claims for Authorization
+### Using Claims for Authorisation
 
 ```go
 func (s *service) AdminOnlyMethod(ctx context.Context, req *pb.Request) (*pb.Response, error) {
@@ -411,7 +411,7 @@ import (
 )
 
 // Add token to outgoing context
-md := metadata.Pairs("authorization", "Bearer "+token)
+md := metadata.Pairs("authorisation", "Bearer "+token)
 ctx := metadata.NewOutgoingContext(context.Background(), md)
 
 // Make call
@@ -502,14 +502,14 @@ spec:
 
 ### Common Issues
 
-#### "missing authorization header"
+#### "missing authorisation header"
 
 **Cause**: No `Authorization` header in gRPC metadata
 
 **Solution**: Add Bearer token to metadata:
 
 ```go
-md := metadata.Pairs("authorization", "Bearer "+token)
+md := metadata.Pairs("authorisation", "Bearer "+token)
 ctx := metadata.NewOutgoingContext(ctx, md)
 ```
 

--- a/docs/demo/ARCHITECTURE.md
+++ b/docs/demo/ARCHITECTURE.md
@@ -31,8 +31,8 @@ flowchart TB
 **Proto Definitions:**
 
 - `CurrentAccountFacility` (Control Record)
-- `ExecuteDeposit` (Behavior Qualifier)
-- `ExecuteWithdrawal` (Behavior Qualifier)
+- `ExecuteDeposit` (Behaviour Qualifier)
+- `ExecuteWithdrawal` (Behaviour Qualifier)
 
 **Database:**
 
@@ -231,7 +231,7 @@ CurrentAccount Service (consumer):
 - `CurrentAccountFacility` - Represents account lifecycle
 - `FinancialBookingLog` - Represents booking log lifecycle
 
-**Behavior Qualifiers (BQ):**
+**Behaviour Qualifiers (BQ):**
 
 - `Deposit` - Deposit operation on account
 - `Withdrawal` - Withdrawal operation (future)

--- a/docs/demo/DEMO_GUIDE.md
+++ b/docs/demo/DEMO_GUIDE.md
@@ -179,7 +179,7 @@ kubectl exec kafka-0 -- kafka-console-consumer --topic current-account.deposits 
 localhost:9092
 ```
 
-**Expected Behavior:**
+**Expected Behaviour:**
 
 - Topics have replicas on 2 brokers (replication factor 2)
 - Killing 1 broker triggers partition leader election

--- a/docs/demos/multi-organization-settlement.md
+++ b/docs/demos/multi-organization-settlement.md
@@ -110,7 +110,7 @@ Provisions the four demo organisations using the `orgctl` CLI:
 
 **What it creates:**
 
-- Organisation registry entries (stored in `org_meridian.organisations` table)
+- Organisation registry entries (stored in `org_meridian.organizations` table)
 - Database schemas for each organisation (`org_post_office`, `org_motive`, etc.)
 - Keycloak client configurations (optional)
 

--- a/docs/demos/multi-organization-settlement.md
+++ b/docs/demos/multi-organization-settlement.md
@@ -80,7 +80,7 @@ Run the full demo sequence:
 
 ```bash
 # 1. Provision organisations (creates schemas and registry entries)
-./scripts/demo-provision-organisations.sh
+./scripts/demo-provision-organizations.sh
 
 # 2. Seed demo accounts and balances
 ./scripts/demo-seed-data.sh
@@ -96,7 +96,7 @@ Run the full demo sequence:
 
 ### Organisation Provisioning
 
-`./scripts/demo-provision-organisations.sh`
+`./scripts/demo-provision-organizations.sh`
 
 Provisions the four demo organisations using the `orgctl` CLI:
 
@@ -222,7 +222,7 @@ open http://localhost:9090
 The `meridian` organisation is special - it serves as "Tenant Zero" or the
 control plane organisation:
 
-- Hosts the `organisation.organisations` registry table
+- Hosts the `organization.organizations` registry table
 - Future: Billing and usage tracking for customer organisations
 - Demonstrates dogfooding: Meridian runs on Meridian
 
@@ -269,7 +269,7 @@ kubectl logs -l app=current-account --tail=100
 ./orgctl list
 
 # Re-run provisioning (idempotent)
-./scripts/demo-provision-organisations.sh
+./scripts/demo-provision-organizations.sh
 ```
 
 ### Account Not Found

--- a/docs/demos/multi-organization-settlement.md
+++ b/docs/demos/multi-organization-settlement.md
@@ -1,16 +1,16 @@
-# Multi-Organization Settlement Demo
+# Multi-Organisation Settlement Demo
 
-This document describes the multi-organization (multi-tenancy) demonstration for
-Meridian, showcasing complete data isolation between organizations while enabling
-cross-organization settlement via external protocols.
+This document describes the multi-organisation (multi-tenancy) demonstration for
+Meridian, showcasing complete data isolation between organisations while enabling
+cross-organisation settlement via external protocols.
 
 ## Overview
 
-Meridian supports multiple organizations running on shared infrastructure with
-complete data isolation. This demo provisions four organizations representing
+Meridian supports multiple organisations running on shared infrastructure with
+complete data isolation. This demo provisions four organisations representing
 diverse use cases:
 
-| Organization | Display Name | Settlement Asset | Use Case |
+| Organisation | Display Name | Settlement Asset | Use Case |
 |--------------|--------------|------------------|----------|
 | `meridian` | Meridian Control Plane | USD | Tenant Zero - hosts control plane |
 | `post_office` | UK Post Office | GBP | Traditional fiat banking |
@@ -48,10 +48,10 @@ diverse use cases:
 
 **Key Points:**
 
-- Each organization gets a dedicated PostgreSQL schema (`org_<id>`)
+- Each organisation gets a dedicated PostgreSQL schema (`org_<id>`)
 - JWT tokens include `x-tenant-id` claim
 - `SET LOCAL search_path = org_<id>` enforces isolation at the database level
-- No cross-organization queries are possible
+- No cross-organisation queries are possible
 
 ## Prerequisites
 
@@ -79,13 +79,13 @@ Before running the demo:
 Run the full demo sequence:
 
 ```bash
-# 1. Provision organizations (creates schemas and registry entries)
-./scripts/demo-provision-organizations.sh
+# 1. Provision organisations (creates schemas and registry entries)
+./scripts/demo-provision-organisations.sh
 
 # 2. Seed demo accounts and balances
 ./scripts/demo-seed-data.sh
 
-# 3. Run cross-organization settlement demo
+# 3. Run cross-organisation settlement demo
 ./scripts/demo-cross-org-settlement.sh
 
 # 4. Validate the environment
@@ -94,11 +94,11 @@ Run the full demo sequence:
 
 ## Demo Scripts
 
-### Organization Provisioning
+### Organisation Provisioning
 
-`./scripts/demo-provision-organizations.sh`
+`./scripts/demo-provision-organisations.sh`
 
-Provisions the four demo organizations using the `orgctl` CLI:
+Provisions the four demo organisations using the `orgctl` CLI:
 
 ```bash
 # Example manual provisioning
@@ -110,8 +110,8 @@ Provisions the four demo organizations using the `orgctl` CLI:
 
 **What it creates:**
 
-- Organization registry entries (stored in `org_meridian.organizations` table)
-- Database schemas for each organization (`org_post_office`, `org_motive`, etc.)
+- Organisation registry entries (stored in `org_meridian.organisations` table)
+- Database schemas for each organisation (`org_post_office`, `org_motive`, etc.)
 - Keycloak client configurations (optional)
 
 ### Seed Data
@@ -120,14 +120,14 @@ Provisions the four demo organizations using the `orgctl` CLI:
 
 Creates demo accounts and balances:
 
-| Organization | Accounts | Initial Balance |
+| Organisation | Accounts | Initial Balance |
 |--------------|----------|-----------------|
 | `post_office` | 5 customer accounts | GBP 1,000 each |
 | `motive` | 3 provider accounts | 100 GPU-hours each |
 | `un_wfp` | 10 beneficiary accounts | 1,000 vouchers each |
 | `meridian` | 1 treasury account | USD 1,000,000 |
 
-### Cross-Organization Settlement
+### Cross-Organisation Settlement
 
 `./scripts/demo-cross-org-settlement.sh`
 
@@ -157,8 +157,8 @@ Automated validation of the demo environment:
 
 - Service health checks
 - Kubernetes pod status
-- Organization provisioning
-- Organization isolation (schema separation)
+- Organisation provisioning
+- Organisation isolation (schema separation)
 - Keycloak configuration
 - Database schema validation
 - Observability stack
@@ -168,10 +168,10 @@ Automated validation of the demo environment:
 
 ## Manual Verification
 
-### Verify Organization Isolation
+### Verify Organisation Isolation
 
 ```bash
-# List organizations
+# List organisations
 ./orgctl list
 
 # Try to access Post Office account from Motive context (should fail)
@@ -179,7 +179,7 @@ grpcurl -plaintext -H "x-tenant-id:motive" \
   -d '{"account_id": "po-customer-1"}' \
   localhost:50051 meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount
 
-# Access account from correct organization context (should succeed)
+# Access account from correct organisation context (should succeed)
 grpcurl -plaintext -H "x-tenant-id:post_office" \
   -d '{"account_id": "po-customer-1"}' \
   localhost:50051 meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount
@@ -191,7 +191,7 @@ grpcurl -plaintext -H "x-tenant-id:post_office" \
 # Connect to CockroachDB
 kubectl exec -it cockroachdb-0 -- ./cockroach sql --insecure
 
-# List organization schemas
+# List organisation schemas
 SELECT schema_name FROM information_schema.schemata
 WHERE schema_name LIKE 'org_%';
 
@@ -213,34 +213,34 @@ open http://localhost:3000
 # Prometheus queries
 open http://localhost:9090
 
-# Query by organization
+# Query by organisation
 # In Prometheus: {tenant="post_office"}
 ```
 
 ## Tenant Zero Pattern
 
-The `meridian` organization is special - it serves as "Tenant Zero" or the
-control plane organization:
+The `meridian` organisation is special - it serves as "Tenant Zero" or the
+control plane organisation:
 
-- Hosts the `organization.organizations` registry table
-- Future: Billing and usage tracking for customer organizations
+- Hosts the `organisation.organisations` registry table
+- Future: Billing and usage tracking for customer organisations
 - Demonstrates dogfooding: Meridian runs on Meridian
 
-**Note:** The control plane organization does NOT participate in customer
+**Note:** The control plane organisation does NOT participate in customer
 settlements - it only provides infrastructure.
 
 ## Security Model
 
 ### Data Isolation
 
-- **Schema-level isolation**: Each organization has a dedicated PostgreSQL
+- **Schema-level isolation**: Each organisation has a dedicated PostgreSQL
   schema
 - **Query enforcement**: `SET LOCAL search_path = org_<id>` executed at the
   start of every transaction
 - **JWT claims**: `x-tenant-id` claim in access tokens
 - **Request validation**: Missing/invalid tenant context routes to DLQ
 
-### Cross-Organization Access
+### Cross-Organisation Access
 
 - **No direct access**: Organizations cannot query each other's data
 - **External settlement**: Cross-org transactions use external DEX protocols
@@ -262,20 +262,20 @@ kubectl get pods
 kubectl logs -l app=current-account --tail=100
 ```
 
-### Organization Not Found
+### Organisation Not Found
 
 ```bash
-# Verify organization exists
+# Verify organisation exists
 ./orgctl list
 
 # Re-run provisioning (idempotent)
-./scripts/demo-provision-organizations.sh
+./scripts/demo-provision-organisations.sh
 ```
 
 ### Account Not Found
 
 ```bash
-# Verify correct organization context
+# Verify correct organisation context
 grpcurl -plaintext -H "x-tenant-id:<correct_org>" \
   -d '{"account_id": "<account_id>"}' \
   localhost:50051 meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount
@@ -303,7 +303,7 @@ After running the demo:
 2. **Explore Tempo traces** with `tenant.id` attribute
 3. **Run the Horizon Integrity Proof** (`./scripts/demo.sh`) to verify
    idempotency
-4. **Scale services** to test load balancing across organizations
+4. **Scale services** to test load balancing across organisations
 
 ## Related Documentation
 

--- a/docs/development/audit-adding-new-service.md
+++ b/docs/development/audit-adding-new-service.md
@@ -298,7 +298,7 @@ func main() {
         }
     }
 
-    // ... rest of service initialization
+    // ... rest of service initialisation
 }
 ```
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -19,7 +19,7 @@ This directory contains how-to guides and usage documentation for Meridian devel
 
 ## Documentation Organisation
 
-All substantial documentation belongs in `docs/`, organized by type:
+All substantial documentation belongs in `docs/`, organised by type:
 
 ```text
 docs/

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -17,7 +17,7 @@ This directory contains how-to guides and usage documentation for Meridian devel
 | [Starlark Style Guide](starlark-style-guide.md) | Writing conventions and syntax for Starlark saga scripts |
 | [Starlark Built-ins Reference](starlark-built-ins-reference.md) | Available functions, types, and DSL built-ins |
 
-## Documentation Organization
+## Documentation Organisation
 
 All substantial documentation belongs in `docs/`, organized by type:
 

--- a/docs/guides/adding-starlark-service-bindings.md
+++ b/docs/guides/adding-starlark-service-bindings.md
@@ -69,7 +69,7 @@ This function registers all handlers for your service with the saga registry:
 // RegisterStarlarkHandlers registers all Starlark service bindings for {ServiceName}.
 // These handlers adapt the Starlark interface (map[string]any) to gRPC client calls.
 //
-// This function is called during service initialization to register {ServiceName} handlers
+// This function is called during service initialisation to register {ServiceName} handlers
 // with the saga execution engine. Each handler includes metadata for conservation rule
 // enforcement and operational categorization.
 //
@@ -337,7 +337,7 @@ func TestOperationHandler_MissingRequiredParam(t *testing.T) {
 
 ## Step 5: Wire into Saga Executor
 
-Update the service's `cmd/main.go` to register handlers during initialization:
+Update the service's `cmd/main.go` to register handlers during initialisation:
 
 ```go
 package main
@@ -348,7 +348,7 @@ import (
 )
 
 func main() {
-    // ... existing service initialization ...
+    // ... existing service initialisation ...
 
     // Create handler registry for saga orchestration
     handlerRegistry := saga.NewHandlerRegistry()

--- a/docs/guides/circuit-breaker-usage.md
+++ b/docs/guides/circuit-breaker-usage.md
@@ -187,9 +187,9 @@ case gobreaker.StateHalfOpen:
 1. **Service-Level Circuit Breakers**: Create one circuit breaker per downstream service, not per method
 2. **Appropriate Thresholds**: Set `ReadyToTrip` based on your service's SLA and expected error rates
 3. **Timeout Configuration**: Set `Timeout` to allow enough time for service recovery (typically 30-60 seconds)
-4. **Fallback Logic**: Always provide fallback behavior when circuit is open
+4. **Fallback Logic**: Always provide fallback behaviour when circuit is open
 5. **Monitoring**: Integrate circuit breaker state changes with your observability platform
-6. **Testing**: Test circuit breaker behavior in your integration tests with simulated failures
+6. **Testing**: Test circuit breaker behaviour in your integration tests with simulated failures
 
 ## Error Handling
 

--- a/docs/guides/financial-accounting-proto.md
+++ b/docs/guides/financial-accounting-proto.md
@@ -80,7 +80,7 @@ Event schemas follow the event-sourced architecture pattern, with events publish
 
 1. `LedgerPostingCapturedEvent` - New posting created for a booking log
 2. `LedgerPostingAmendedEvent` - Posting modified before booking log is posted
-3. `LedgerPostingPostedEvent` - Posting finalized
+3. `LedgerPostingPostedEvent` - Posting finalised
 4. `LedgerPostingRejectedEvent` - Posting rejected during validation (terminal state)
 
 #### Validation Events
@@ -116,12 +116,12 @@ message FinancialBookingLog {
 }
 ```
 
-#### Pattern 2: New Event Types for New Behaviors
+#### Pattern 2: New Event Types for New Behaviours
 
-New BIAN behavior qualifiers should create new event types:
+New BIAN behaviour qualifiers should create new event types:
 
 ```protobuf
-// New event for a new behavior
+// New event for a new behaviour
 message FinancialBookingLogSuspendedEvent {
   string booking_log_id = 1;
   string reason = 2;
@@ -227,7 +227,7 @@ Generated files:
 
 ## Testing
 
-Event serialization tests are located in `../events/v1/financial_accounting_events_test.go`.
+Event serialisation tests are located in `../events/v1/financial_accounting_events_test.go`.
 
 Run tests:
 
@@ -238,7 +238,7 @@ go test ./api/proto/meridian/events/v1/... -run TestFinancial
 Tests verify:
 
 - Event marshaling/unmarshaling
-- Field preservation across serialization
+- Field preservation across serialisation
 - Type correctness
 - Validation rules
 

--- a/docs/guides/multi-asset-integration.md
+++ b/docs/guides/multi-asset-integration.md
@@ -63,7 +63,7 @@ flowchart TB
 | Layer | Purpose | Changes Require |
 |-------|---------|-----------------|
 | Dimensions | Prevent physics errors (Money + Rice) | Code deployment |
-| Definitions | Tenant instrument catalog | Registry update |
+| Definitions | Tenant instrument catalogue | Registry update |
 | Context | Position attributes (expiry, vintage) | Nothing (data) |
 
 ### Services Involved

--- a/docs/guides/new-bian-service-checklist.md
+++ b/docs/guides/new-bian-service-checklist.md
@@ -509,7 +509,7 @@ Create the application entry point.
   - Structured logging (slog JSON handler)
   - Environment variable configuration
   - Database connection with GORM
-  - OpenTelemetry tracer initialization
+  - OpenTelemetry tracer initialisation
   - gRPC server with interceptors
   - Health service registration
   - Graceful shutdown handling
@@ -983,9 +983,9 @@ For Kafka integration:
 - Follow [ADR-004](../adr/0004-event-schema-evolution.md) for event schema evolution
 - Reference: `services/financial-accounting/adapters/messaging/`
 
-### Multi-Tenancy / Organization Scoping
+### Multi-Tenancy / Organisation Scoping
 
-Use `shared/platform/organization` context patterns for tenant isolation.
+Use `shared/platform/organisation` context patterns for tenant isolation.
 
 ### Audit Logging
 

--- a/docs/guides/new-bian-service-checklist.md
+++ b/docs/guides/new-bian-service-checklist.md
@@ -985,7 +985,7 @@ For Kafka integration:
 
 ### Multi-Tenancy / Organisation Scoping
 
-Use `shared/platform/organisation` context patterns for tenant isolation.
+Use `shared/platform/organization` context patterns for tenant isolation.
 
 ### Audit Logging
 

--- a/docs/guides/saga-validation.md
+++ b/docs/guides/saga-validation.md
@@ -33,7 +33,7 @@ AST-based analysis that catches common mistakes:
 
 | Issue | Severity | Description |
 |-------|----------|-------------|
-| Decimal arithmetic | Warning | Decimal math should use CEL expressions |
+| Decimal arithmetic | Warning | Decimal maths should use CEL expressions |
 | Magic numbers | Warning | Hardcoded numeric literals |
 | Nested conditionals | Warning | Deep if/else nesting |
 | Hardcoded codes | Error | Hardcoded instrument or account codes |

--- a/docs/guides/starlark-built-ins-reference.md
+++ b/docs/guides/starlark-built-ins-reference.md
@@ -8,7 +8,7 @@
 
 - **[Style Guide](starlark-style-guide.md)** - Syntax and conventions
 - **[Patterns](../starlark-patterns.md)** - Common workflow patterns
-- **[Service Catalog](../saga-service-catalog.md)** - Service module handlers
+- **[Service Catalogue](../saga-service-catalogue.md)** - Service module handlers
 
 ---
 
@@ -522,7 +522,7 @@ Sagas execute with thread-local context:
   - `saga_execution_id` - Current execution ID
   - `correlation_id` - Request correlation
   - `knowledge_at` - Bi-temporal timestamp
-  - `party_scope` - Authorization scope
+  - `party_scope` - Authorisation scope
 
 **Accessed via:**
 
@@ -596,17 +596,17 @@ assert.Equal(t, "COMPLETED", result["status"])
 | Operation | Latency | Use Case |
 |-----------|---------|----------|
 | `cel_eval()` | ~100ns | High-frequency calculations |
-| `Decimal()` operations | ~1μs | Financial math |
+| `Decimal()` operations | ~1μs | Financial maths |
 | `resolve_account()` (cached) | ~10ns | Repeated lookups |
 | `resolve_account()` (uncached) | ~5ms | First lookup (RPC) |
 | Service module handler | ~10-50ms | Database operations |
 | `invoke_saga()` | Variable | Child saga execution time |
 
-**Optimization:**
+**Optimisation:**
 
 - Use CEL for stateless calculations
 - Cache reference resolutions (automatic)
-- Minimize service module calls
+- Minimise service module calls
 - Batch operations when possible
 
 ---
@@ -621,7 +621,7 @@ assert.Equal(t, "COMPLETED", result["status"])
 - ✅ Bounded execution (no `while` loops)
 - ✅ Memory limits enforced
 - ✅ CPU timeout enforced
-- ✅ Party scope enforcement (authorization)
+- ✅ Party scope enforcement (authorisation)
 
 **Threat model:**
 

--- a/docs/guides/starlark-style-guide.md
+++ b/docs/guides/starlark-style-guide.md
@@ -9,7 +9,7 @@
 ## Table of Contents
 
 1. [Critical Syntax Differences from Python](#critical-syntax-differences-from-python)
-2. [File Structure and Organization](#file-structure-and-organization)
+2. [File Structure and Organisation](#file-structure-and-organisation)
 3. [Naming Conventions](#naming-conventions)
 4. [Documentation Standards](#documentation-standards)
 5. [Type Safety and Validation](#type-safety-and-validation)
@@ -156,7 +156,7 @@ amount = Decimal("100.50")
 
 ---
 
-## File Structure and Organization
+## File Structure and Organisation
 
 ### File Naming
 
@@ -906,5 +906,5 @@ For detailed validation documentation, see the [Saga Validation Guide](saga-vali
 
 - **[Saga Validation Guide](saga-validation.md)** - Validation workflow, error interpretation, and monitoring
 - **[Saga Handlers Schema](../saga-handlers.schema.json)** - Available service modules and handlers
-- **[Saga Service Catalog](../saga-service-catalog.md)** - Service module documentation
+- **[Saga Service Catalogue](../saga-service-catalogue.md)** - Service module documentation
 - **[ADR-0028: Starlark Saga & CEL Valuation](../adr/0028-starlark-saga-cel-valuation.md)** - Architecture decision

--- a/docs/panic-audit-inventory.md
+++ b/docs/panic-audit-inventory.md
@@ -16,7 +16,7 @@ refactored to return errors instead. After thorough analysis, we found:
 
 | Finding | Count | Action Required |
 |---------|-------|-----------------|
-| Startup/initialization panics | 19 | None - follows fail-fast pattern |
+| Startup/initialisation panics | 19 | None - follows fail-fast pattern |
 | Bug detection invariants | 1 | None - defensive programming |
 | Panic propagation (defer cleanup) | 1 | None - standard Go pattern |
 | Test fixture panics | 11 | None - test code only |
@@ -29,12 +29,12 @@ refactored to return errors instead. After thorough analysis, we found:
    20-24) which identified and fixed actual problematic panics, this audit
    confirms the remaining panics are all legitimate uses.
 
-2. **Startup panics are appropriate.** The 19 constructor/initialization panics
+2. **Startup panics are appropriate.** The 19 constructor/initialisation panics
    follow the Go fail-fast pattern for dependency validation. They fire before
    the service handles any requests.
 
 3. **Must* functions follow Go conventions.** Functions with `Must` prefix
-   (like `regexp.MustCompile`) explicitly signal panic behavior and have
+   (like `regexp.MustCompile`) explicitly signal panic behaviour and have
    non-panicking alternatives.
 
 4. **The codebase is healthy.** The previous refactoring work (Tasks 20-24)
@@ -64,7 +64,7 @@ refactored to return errors instead. After thorough analysis, we found:
 
 ### Category A: Startup/Constructor Panics (Acceptable)
 
-These panics occur during service initialization and follow the fail-fast
+These panics occur during service initialisation and follow the fail-fast
 pattern for dependency validation.
 
 | # | File | Line | Function | Message |
@@ -90,13 +90,13 @@ pattern for dependency validation.
 ### Category B: Must* Functions (Acceptable)
 
 These are convenience functions that panic on error, explicitly named with
-`Must` prefix to indicate the behavior. Callers choose to use these when
+`Must` prefix to indicate the behaviour. Callers choose to use these when
 they know the operation cannot fail (e.g., with compile-time constants).
 
 | # | File | Line | Function | Notes |
 |---|------|------|----------|-------|
 | 14 | `shared/domain/money/money.go` | 111 | `MustNew` | For tests/compile-time constants |
-| 15 | `services/audit-worker/domain/measurement.go` | 48 | `MustPeriod` | For tests/initialization |
+| 15 | `services/audit-worker/domain/measurement.go` | 48 | `MustPeriod` | For tests/initialisation |
 | 16 | `shared/platform/tenant/context.go` | 33 | `MustFromContext` | Programming error detection |
 | 17 | `shared/platform/tenant/tenant_id.go` | 32 | `MustNewTenantID` | For compile-time constants |
 | 18 | `shared/platform/db/gorm_tenant_scope.go` | 81 | `MustWithGormTenantScope` | After middleware validation |
@@ -156,7 +156,7 @@ These are in test fixture packages, not production code.
 
 ## Test File Panics (Acceptable)
 
-These are in `*_test.go` files and are expected behavior for test setup or
+These are in `*_test.go` files and are expected behaviour for test setup or
 intentional panic testing.
 
 | # | File | Line | Function | Notes |
@@ -203,7 +203,7 @@ All 47 panic occurrences fall into acceptable categories:
    This is a widely accepted Go pattern for dependency injection constructors.
 
 2. **Must* function variants** (6): These are explicitly named to indicate
-   panic behavior and are documented for use with compile-time constants or
+   panic behaviour and are documented for use with compile-time constants or
    well-validated input.
 
 3. **Bug detection** (1): The overdraft calculation panic indicates an
@@ -233,19 +233,19 @@ was successful. No additional Task Master tasks have been created because:
 
 ---
 
-## Approval Status: Startup and Initialization Panics
+## Approval Status: Startup and Initialisation Panics
 
 **Reviewed**: 2025-12-27
 **Subtask**: tech-debt-cleanup.25.2
 
-This section provides detailed approval rationale for all startup/initialization
+This section provides detailed approval rationale for all startup/initialisation
 panics and Must* function variants identified in the inventory.
 
 ### Approval Criteria
 
 Startup panics are **APPROVED** when they meet ALL of the following criteria:
 
-1. **Fail-fast timing**: Panic occurs during service initialization, before handling any requests
+1. **Fail-fast timing**: Panic occurs during service initialisation, before handling any requests
 2. **Critical dependency**: The nil/empty value would make the service non-functional
 3. **No recovery possible**: Returning an error would just propagate up to main() anyway
 4. **Clear messaging**: Panic message identifies which dependency is missing
@@ -309,8 +309,8 @@ All 6 Must* functions are **APPROVED** with the following rationale:
 
 | # | Function | Usage Pattern | Rationale |
 |---|----------|---------------|-----------|
-| 14 | `money.MustNew` | Tests and compile-time constants | Explicitly named with `Must` prefix. Alternative `New` exists for runtime use. Used in test fixtures and constant initialization. **APPROVED - MUST PATTERN** |
-| 15 | `measurement.MustPeriod` | Tests and initialization | Same Must pattern. Used when period validity is known at compile time. **APPROVED - MUST PATTERN** |
+| 14 | `money.MustNew` | Tests and compile-time constants | Explicitly named with `Must` prefix. Alternative `New` exists for runtime use. Used in test fixtures and constant initialisation. **APPROVED - MUST PATTERN** |
+| 15 | `measurement.MustPeriod` | Tests and initialisation | Same Must pattern. Used when period validity is known at compile time. **APPROVED - MUST PATTERN** |
 | 16 | `tenant.MustFromContext` | After middleware validation | Called only in code paths where tenant middleware has already validated context. Comment in source documents this is a "programming error" detector. **APPROVED - MUST PATTERN** |
 | 17 | `tenant.MustNewTenantID` | Compile-time tenant constants | Used for system-level tenant IDs that are compile-time constants. Alternative `NewTenantID` exists. **APPROVED - MUST PATTERN** |
 | 18 | `db.MustWithGormTenantScope` | After middleware validation | Called in code paths where tenant context is guaranteed by middleware. **APPROVED - MUST PATTERN** |
@@ -334,8 +334,8 @@ a corresponding non-panicking variant. Usage is appropriate:
 | Must* function variants | 6 | APPROVED - MUST PATTERN |
 | **Total reviewed** | **19** | **All APPROVED** |
 
-All startup/initialization panics follow established Go patterns for fail-fast
-initialization and are acceptable. No refactoring is required.
+All startup/initialisation panics follow established Go patterns for fail-fast
+initialisation and are acceptable. No refactoring is required.
 
 ---
 

--- a/docs/prd/001-universal-asset-system.md
+++ b/docs/prd/001-universal-asset-system.md
@@ -5,13 +5,13 @@ triggers:
   - Implementing multi-asset or universal asset support
   - Working on InstrumentType, Quantity, or asset definitions
   - Adding new asset types (commodities, energy, vouchers)
-  - Designing tenant-specific asset catalogs
+  - Designing tenant-specific asset catalogues
   - Implementing dimensional safety or asset quantity types
   - Working on reference data service
 instructions: |
   This PRD defines the Universal Asset System for multi-asset ledger support.
   Key patterns: Use Go generics for dimensional safety (Monetary vs Commodity).
-  Assets are configured via database, not code. Each tenant has isolated catalog.
+  Assets are configured via database, not code. Each tenant has isolated catalogue.
   Refer to ADR-0013 (Quantity Types) and ADR-0014 (Reference Data) for implementation.
   Immutable proto contracts are defined in Zero-State Contract section - never modify.
 ---
@@ -36,10 +36,10 @@ dimensional safety.
 1. **Dimensional safety**: Prevent physics errors (money + rice) via Go generics
    > *Clarification*: In a distributed system with dynamic schemas, you cannot have true "compile-time"
    > safety for tenant-defined assets (the compiler doesn't know "Rice" exists). What we have is
-   > **dimensional safety**: the platform knows at compile time that `Monetary` math is distinct from
-   > `Commodity` math, preventing accidental treatment of commodity balances as cash during settlement.
+   > **dimensional safety**: the platform knows at compile time that `Monetary` maths is distinct from
+   > `Commodity` maths, preventing accidental treatment of commodity balances as cash during settlement.
 2. **Runtime flexibility**: New assets via database configuration, not code
-3. **Tenant isolation**: Each tenant has their own asset catalog
+3. **Tenant isolation**: Each tenant has their own asset catalogue
 4. **Valuation foundation**: Rate type for asset-to-currency conversion (providers in future PRD)
 
 ### Non-Goals (Simplified Scope)
@@ -58,7 +58,7 @@ dimensional safety.
 - [Zero-State Contract (IMMUTABLE)](#zero-state-contract-immutable)
 - [CEL Validation Pattern](#cel-validation-pattern)
 - [Data Contract: Proto + CEL + Go](#data-contract-proto--cel--go)
-- [Asset Catalog (Open Source Library)](#asset-catalog-open-source-library)
+- [Asset Catalogue (Open Source Library)](#asset-catalogue-open-source-library)
 - [Fungibility Resolution](#fungibility-resolution)
 - [Service Impact Matrix](#service-impact-matrix)
 - [Work Streams](#work-streams)
@@ -122,7 +122,7 @@ message AttributeEntry {
 // CEL handles the letter (attributes validation, bucket key generation).
 message InstrumentAmount {
     // The quantity magnitude (decimal string for precision).
-    // Native Go math handles this. CEL accesses via 'amount' variable.
+    // Native Go maths handles this. CEL accesses via 'amount' variable.
     string amount = 1;
 
     // The Identity of the asset.
@@ -582,7 +582,7 @@ result, _ := cached.ValidationProgram.Eval(celVars)
 
 ---
 
-## Asset Catalog (Open Source Library)
+## Asset Catalogue (Open Source Library)
 
 The PRD defines a flexible system where tenants can create custom instruments with CEL expressions.
 However, expecting every tenant to write CEL from scratch is operationally impractical. We need a
@@ -679,7 +679,7 @@ tests:
 ### Goal: Asset Marketplace
 
 Enable a library of asset types (EU Carbon Credits, ISDA Swaps, US Treasuries, GPU Compute Hours)
-contributed by domain experts. Tenants select from the catalog rather than writing CEL from scratch.
+contributed by domain experts. Tenants select from the catalogue rather than writing CEL from scratch.
 
 > **Implementation tasks** are defined in Stream F (F.4 and F.5).
 
@@ -688,7 +688,7 @@ contributed by domain experts. Tenants select from the catalog rather than writi
 ## Fungibility Resolution
 
 Beyond ingestion validation, CEL handles **operational predicates** that determine position
-behavior. This extends CEL from "is this data valid?" to "can these positions be combined?"
+behaviour. This extends CEL from "is this data valid?" to "can these positions be combined?"
 
 ### The Bucket Key Pattern (Sole Source of Truth)
 
@@ -759,7 +759,7 @@ bucket_key(['contract_id', 'expiry_month'])
 // Note: Pre-compute expiry_month in validation, store as attribute
 
 // Example 4: Complex matching (Vintage 2023 and 2024 are fungible)
-// Use validation_expression to normalize vintage to "recent" before bucketing:
+// Use validation_expression to normalise vintage to "recent" before bucketing:
 // validation: if int(attributes.vintage) >= 2023 then attributes.vintage = "recent"
 bucket_key(['region', 'vintage'])
 ```
@@ -774,7 +774,7 @@ bucket_key(['region', 'vintage'])
 > These two chemically different positions become fungible and the ledger merges them.
 > The `bucket_key()` function uses length-prefixed hashing to prevent this attack.
 >
-> **Key Design**: If you need "Vintage 2023 matches 2024", normalize in validation
+> **Key Design**: If you need "Vintage 2023 matches 2024", normalise in validation
 > (set `vintage="recent"` for both), then use `bucket_key(['region', 'vintage'])`.
 
 ### How Bucket & Verify Affects the Ledger
@@ -892,7 +892,7 @@ attributes.contract_id + "|" + string(int(attributes.period_start) / 3600)
 - Creates a new distinct position (accumulation), OR
 - Fails with `ErrPositionsNotFungible` (strict mode)
 
-The behavior is configurable per instrument.
+The behaviour is configurable per instrument.
 
 ---
 
@@ -1035,7 +1035,7 @@ Stream I.1 (Position Keeping) is split into **Write Path** and **Read Path** sub
 | Sub-Stream | Focus | Agent Specialty |
 |------------|-------|-----------------|
 | **I.1 (Write)** | `RecordMeasurement`, CEL validation, bucket key | CEL-heavy, AttributeBag pooling |
-| **I.1R (Read)** | `GetAggregatedPosition`, SQL GROUP BY | SQL-heavy, query optimization |
+| **I.1R (Read)** | `GetAggregatedPosition`, SQL GROUP BY | SQL-heavy, query optimisation |
 
 **Rationale**: These are different problem domains. One agent focuses on CEL complexity,
 the other on SQL query performance. This prevents context-switching overhead.
@@ -1064,12 +1064,12 @@ the other on SQL query performance. This prevents context-switching overhead.
    type Instrument struct {
        Code      string    // "USD", "KWH", "GPU-H100"
        Version   uint32    // Schema version
-       Dimension string    // "Monetary" or "Commodity" - required for deserialization
-       Precision int       // Decimal places (for display formatting; math uses arbitrary precision)
+       Dimension string    // "Monetary" or "Commodity" - required for deserialisation
+       Precision int       // Decimal places (for display formatting; maths uses arbitrary precision)
    }
    ```
 
-   > **Serialization note**: `Dimension` is stored as a string (not type parameter) because
+   > **Serialisation note**: `Dimension` is stored as a string (not type parameter) because
    > Go generics are erased at runtime. When deserializing from DB/proto, we use `Dimension`
    > to reconstruct the correct `Quantity[Monetary]` or `Quantity[Commodity]` at the boundary.
 
@@ -1265,7 +1265,7 @@ the other on SQL query performance. This prevents context-switching overhead.
 **Location:** `shared/platform/quantity/`
 **Dependencies:** Stream A (Quantity, Instrument types)
 
-> **Scope boundary**: This stream covers the Rate data structure and basic conversion math only.
+> **Scope boundary**: This stream covers the Rate data structure and basic conversion maths only.
 > ValuationProvider interface and orchestration belongs in a future Valuation Engine PRD (ADR-019).
 
 ### Deliverables
@@ -1347,7 +1347,7 @@ the other on SQL query performance. This prevents context-switching overhead.
 **Dependencies:** Stream A (type design, can work from ADR spec)
 
 > **Proto vs CEL**: Protobuf defines the **Container** (data structure). CEL is the **Gatekeeper**
-> (validation logic). Proto messages are pure data carriers with no behavior. CEL expressions
+> (validation logic). Proto messages are pure data carriers with no behaviour. CEL expressions
 > are compiled and executed by the service layer to validate attribute payloads.
 
 ### Deliverables
@@ -1650,7 +1650,7 @@ the other on SQL query performance. This prevents context-switching overhead.
            // CRITICAL: Use ON CONFLICT DO NOTHING, not UPSERT
            // In distributed deployment (5 replicas starting simultaneously),
            // all will race to insert. Only one wins; others hit conflict.
-           // DO NOT log conflict as error - it's expected behavior.
+           // DO NOT log conflict as error - it's expected behaviour.
            if err := s.repo.InsertIfNotExists(ctx, inst); err != nil {
                return fmt.Errorf("bootstrap instrument %s: %w", inst.Code, err)
            }
@@ -1681,7 +1681,7 @@ the other on SQL query performance. This prevents context-switching overhead.
    > When 5 Kubernetes replicas start simultaneously, they all race to INSERT system instruments.
    > Using `ON CONFLICT DO NOTHING` ensures only one wins, others silently succeed (no error).
    >
-   > **CRITICAL**: Do NOT log "unique constraint violation" as an error. It's expected behavior
+   > **CRITICAL**: Do NOT log "unique constraint violation" as an error. It's expected behaviour
    > in distributed deployments. The InsertIfNotExists pattern treats conflict as success.
    >
    > **Alternative (Kubernetes Job)**: For stricter control, run seeding as a Helm pre-install hook:
@@ -1982,7 +1982,7 @@ the other on SQL query performance. This prevents context-switching overhead.
    > **CEL Version Pinning (CRITICAL for Determinism)**
    >
    > CEL expressions generate `bucket_id` values stored permanently in the database.
-   > If cel-go library behavior changes (function semantics, type coercion), calculated
+   > If cel-go library behaviour changes (function semantics, type coercion), calculated
    > keys may shift, causing position splits or merges.
    >
    > **Requirements:**
@@ -2044,7 +2044,7 @@ the other on SQL query performance. This prevents context-switching overhead.
    }
 
    // SafeParseLib provides safe string parsing functions to avoid "Date Format Hell".
-   // Tenants MUST use these instead of raw CEL type coercion for consistent behavior.
+   // Tenants MUST use these instead of raw CEL type coercion for consistent behaviour.
    //
    // Functions:
    //   parse_iso_date(string) -> timestamp  // Strict ISO 8601: "2025-01-15T00:00:00Z"
@@ -2317,7 +2317,7 @@ the other on SQL query performance. This prevents context-switching overhead.
 - [ ] CEL expression compiled at `CreateDefinition` - syntax errors rejected immediately
 - [ ] `ValidateAttributes` executes compiled CEL and returns clear error on `false`
 
-### Phase 1.5: Asset Catalog (Deferred)
+### Phase 1.5: Asset Catalogue (Deferred)
 
 > **Scope Decision**: The following deliverables are moved to Phase 1.5. For the "Frugal Path,"
 > we only need to prove we can define *one* custom asset manually via API/CLI. Building a
@@ -3369,7 +3369,7 @@ Position Keeping is the **primary consumer** of multi-asset quantities. Changes 
    // RebucketingTool rebuilds position bucket assignments for an instrument.
    // ⚠️ CATASTROPHIC RECOVERY ONLY - violates immutable ledger principle.
    // Prefer Migration-as-Trade pattern for normal corrections.
-   // ADMIN-ONLY: Requires explicit authorization and audit logging.
+   // ADMIN-ONLY: Requires explicit authorisation and audit logging.
    type RebucketingTool struct {
        measurementStore MeasurementStore  // Raw measurements with original attributes
        positionStore    PositionStore
@@ -3390,7 +3390,7 @@ Position Keeping is the **primary consumer** of multi-asset quantities. Changes 
        fromVersion, toVersion uint32,
    ) (*RebucketingReport, error) {
        // 0. SETTLEMENT LOCK CHECK: Cannot rebucket settled history
-       // Positions included in finalized settlements are immutable for audit/regulatory reasons
+       // Positions included in finalised settlements are immutable for audit/regulatory reasons
        settledPositions, err := t.settlementStore.FindSettledPositions(
            ctx, tenantID, instrumentCode, fromVersion,
        )
@@ -3403,7 +3403,7 @@ Position Keeping is the **primary consumer** of multi-asset quantities. Changes 
                Version:        fromVersion,
                SettledCount:   len(settledPositions),
                Message: fmt.Sprintf(
-                   "cannot rebucket: %d positions included in finalized settlements",
+                   "cannot rebucket: %d positions included in finalised settlements",
                    len(settledPositions),
                ),
            }
@@ -3486,7 +3486,7 @@ Position Keeping is the **primary consumer** of multi-asset quantities. Changes 
 - [ ] Existing fiat-only tests still pass (backwards compatible)
 - [ ] No gRPC calls on hot path (cache hit rate > 99%)
 - [ ] Re-bucketing tool can rebuild bucket assignments from raw measurements
-- [ ] Re-bucketing tool fails with `SettlementLockError` if positions are in finalized settlements
+- [ ] Re-bucketing tool fails with `SettlementLockError` if positions are in finalised settlements
 - [ ] Raw measurements preserve original attributes (not discarded during compaction)
 
 **Phase 1 Append-Only Enforcement** (Critical):
@@ -3794,7 +3794,7 @@ Integration validation occurs at dependency boundaries, not calendar dates:
 
 | Gate | Trigger | Exit Criteria |
 |------|---------|---------------|
-| **Contract Freeze** | Before any dependent stream starts | All proto definitions and Go interfaces finalized |
+| **Contract Freeze** | Before any dependent stream starts | All proto definitions and Go interfaces finalised |
 | **Foundation** | Streams A, D, E all complete | Shared types compile together; no interface conflicts |
 | **Service Layer** | Stream F complete | Registry passes tests with real DB; CEL compilation works |
 | **API Layer** | Streams F, G, H complete | End-to-end flow works with mock tenant |
@@ -3822,7 +3822,7 @@ If API Layer gate shows >2x expected integration complexity:
 
 1. Pause downstream streams (I.x)
 2. Assess: Can we reduce to 5 streams (vertical slices)?
-3. Consider: Defer Asset Catalog (streams 11-12 in F) to Phase 2
+3. Consider: Defer Asset Catalogue (streams 11-12 in F) to Phase 2
 4. Replan with reduced scope if necessary
 
 > **Goal**: Catch integration issues at dependency boundaries, not during final Stream J.
@@ -3852,7 +3852,7 @@ If API Layer gate shows >2x expected integration complexity:
 
 ## Open Questions
 
-1. **Initial commodity catalog**: Which non-currency instruments should be seeded (if any)?
+1. **Initial commodity catalogue**: Which non-currency instruments should be seeded (if any)?
 2. **Cache TTL**: What's the acceptable staleness window for instrument definitions? (Proposed: 5 min)
 
 ---

--- a/docs/prd/003-meridian-edge.md
+++ b/docs/prd/003-meridian-edge.md
@@ -63,7 +63,7 @@ unreachable or the pricing is complex (half-hourly), the device displays wrong i
 
 ### 2.2 The "Horizon" Risk
 
-Centralized ledgers allow remote tampering. The user has no local, cryptographic proof of their
+Centralised ledgers allow remote tampering. The user has no local, cryptographic proof of their
 transaction history. The Fujitsu/Post Office Horizon scandal demonstrated the catastrophic
 consequences of systems where operators can modify transaction records without cryptographic
 accountability.
@@ -297,7 +297,7 @@ To ensure device longevity on flash storage (SD/eMMC):
 - **Synchronous Normal:** Reduce fsync frequency while maintaining consistency
   (`PRAGMA synchronous = NORMAL` - safe in WAL mode, reduces fsyncs by ~90%)
 - **Batching:** Position Keeping buffers measurements in RAM and flushes to disk every N seconds
-  or M events to minimize write cycles
+  or M events to minimise write cycles
 - **Pruning:** `SyncWorker` aggressively prunes `sync_outbox` after Cloud acknowledgement to
   maintain fixed disk usage footprint (< 100MB ledger data)
 
@@ -400,9 +400,9 @@ The device enrollment lifecycle establishes trust before any transactions occur:
    endpoint, including hardware serial number
 3. **Attestation:** Cloud verifies device hardware ID against manufacturing records
 4. **Certificate Issuance:** Cloud issues a "Ledger Certificate" binding the device's public key
-   to specific authorized accounts
+   to specific authorised accounts
 5. **Genesis Sync:** Device receives its initial state (tariffs, account structure, reference data)
-6. **Operational Mode:** Device can now sign valid transactions for its authorized scope
+6. **Operational Mode:** Device can now sign valid transactions for its authorised scope
 
 **Revocation:** If a device is compromised, the Cloud revokes the Ledger Certificate. The device
 can still operate offline, but its signed events will be rejected on next sync attempt.

--- a/docs/prd/004-market-information-management.md
+++ b/docs/prd/004-market-information-management.md
@@ -199,7 +199,7 @@ the **Vault** (storage) and **Rules** (validation), while external systems provi
 |------------|-------------|---------|
 | **Connectivity** | Maintaining connections to external sources | WebSocket to Bloomberg, TCP to Smart Meters |
 | **Extraction** | Polling APIs, scraping, reading raw feeds | Calling ECB SDMX API, reading meter registers |
-| **Normalization** | Converting source-specific formats to Meridian Protobuf | XML → `MarketPriceObservation`, CSV → gRPC request |
+| **Normalisation** | Converting source-specific formats to Meridian Protobuf | XML → `MarketPriceObservation`, CSV → gRPC request |
 | **Scheduling** | Managing ingestion timing and frequency | Cron jobs, event-driven triggers |
 | **Error Recovery** | Handling source-specific failure modes | API rate limits, connection timeouts |
 
@@ -240,7 +240,7 @@ External World                    │  Meridian Core
 │ External        │               │   └───────────┬───────────┘
 │ Adapter         │  Formatted    │               │
 │ ─────────────── │  Protobuf     │               ▼
-│ Normalize to    ├───────────────┼──►┌───────────────────────┐
+│ Normalise to    ├───────────────┼──►┌───────────────────────┐
 │ MarketPrice     │               │   │ CEL Validator         │
 │ Observation     │               │   │ ─────────────────     │
 └─────────────────┘               │   │ PASS → Store          │
@@ -1321,7 +1321,7 @@ CREATE INDEX idx_observation_superseded ON market_price_observation(superseded_b
 CREATE INDEX idx_observation_created_at ON market_price_observation(created_at);
 
 -- Composite index for full bi-temporal resolution query with supersession filter
--- Optimized for: WHERE resolution_key = ? AND superseded_by IS NULL AND created_at <= ?
+-- Optimised for: WHERE resolution_key = ? AND superseded_by IS NULL AND created_at <= ?
 -- ORDER BY quality DESC, observed_at DESC, created_at DESC
 CREATE INDEX idx_observation_resolution_bitemporal ON market_price_observation(
     resolution_key,
@@ -1604,7 +1604,7 @@ func (w *Worker) provisionMarketInformation(ctx context.Context, tenantID string
 | MIM-013 | Write unit tests (80% coverage) | 5 |
 | MIM-014 | Write integration tests | 3 |
 
-### Phase 2: Temporal Query Optimization (P0)
+### Phase 2: Temporal Query Optimisation (P0)
 
 | Task ID | Description | Estimate |
 |---------|-------------|----------|

--- a/docs/prd/005-durable-execution-engine.md
+++ b/docs/prd/005-durable-execution-engine.md
@@ -150,7 +150,7 @@ def pay_external(ctx):
 ### FR-20: Starlark Dry-Run Testing
 
 - **Requirement**: The service SHALL provide an `ExecuteDryRun` RPC
-- **Behavior**: Runs the Starlark script in a virtual environment where all Step Handlers are mocked
+- **Behaviour**: Runs the Starlark script in a virtual environment where all Step Handlers are mocked
 - **Output**: Returns the intended "Execution Plan" (what steps would have been called, in what order, with what parameters)
 - **No persistence**: Dry-run MUST NOT persist anything to the database
 - **Use case**: Tenants can test their Starlark logic before calling `RegisterDataSet` to deploy to production
@@ -297,7 +297,7 @@ def pay_external(ctx):
   for replay purposes
 - **Persistence**: Once a Valuation result is obtained, the **entire response** (including
   market observation IDs, rates, and basis) MUST be persisted in `saga_step_results`
-- **Replay behavior**: On replay, return the cached valuation result instead of re-calling
+- **Replay behaviour**: On replay, return the cached valuation result instead of re-calling
   the Valuation Engine
 - **Audit continuity**: If market data is purged from MIM after 7 years (per retention
   policy), legacy audit replay still works because the valuation was "snapshotted"
@@ -308,7 +308,7 @@ def pay_external(ctx):
 - **Requirement**: The Runtime MUST support a `ctx.suspend(idempotency_key)` builtin
   for long-running external waits (e.g., DNO payment confirmation webhook)
 - **Problem**: Pod holding lease for days while waiting for webhook is inefficient
-- **Behavior**:
+- **Behaviour**:
   1. `ctx.suspend()` saves current saga state to `saga_step_results`
   2. Releases pod lease
   3. Transitions status to `WAITING_FOR_EVENT`
@@ -317,7 +317,7 @@ def pay_external(ctx):
 - **Idempotency**: Multiple callbacks with same `idempotency_key` are deduplicated
 - **Timeout**: Optional `ctx.suspend(key, timeout=duration)` auto-fails after deadline
 
-### FR-31: Deep-Copy Serialization Boundary
+### FR-31: Deep-Copy Serialisation Boundary
 
 - **Requirement**: When persisting `SagaStepResult.output_snapshot`, the Go runtime
   MUST serialize the Starlark value to JSON and deserialize back
@@ -345,7 +345,7 @@ def pay_external(ctx):
       {"saga_id": "child-789", "name": "wholesale_posting", "status": "FAILED",
        "failed_step": {"index": 2, "error": "Insufficient balance"}}
     ]},
-    {"index": 2, "name": "finalize", "status": "PENDING"}
+    {"index": 2, "name": "finalise", "status": "PENDING"}
   ]
 }
 ```
@@ -355,10 +355,10 @@ def pay_external(ctx):
 ### FR-33: Semantic Logic/Physics Linter
 
 - **Requirement**: The Linter SHALL be semantic, not just syntactic, for Decimal arithmetic
-- **Problem**: Developers may bypass "no math in Starlark" rule using new Decimal type
+- **Problem**: Developers may bypass "no maths in Starlark" rule using new Decimal type
 - **Detection**: Warn on any arithmetic operator (`+`, `-`, `*`, `/`) where operands
   are not derived from simple counters or loop indices
-- **Suggested message**: "Financial math detected. Move this to a CEL Valuation
+- **Suggested message**: "Financial maths detected. Move this to a CEL Valuation
   Strategy in Reference Data."
 - **Exemptions**: Counter arithmetic (`i + 1`), list indexing, percentage calculations
   using pre-validated rates from Valuation Engine
@@ -1218,7 +1218,7 @@ graph TD
         SAGA074[SAGA-074: Outbox integration]
         SAGA064[SAGA-064: Error severity classification]
         SAGA065[SAGA-065: Partition-aware scanning]
-        SAGA069[SAGA-069: Deep-copy serialization]
+        SAGA069[SAGA-069: Deep-copy serialisation]
     end
 
     subgraph "Stream 8: External Integration"
@@ -1314,7 +1314,7 @@ graph TD
 | **SAGA-074** | Implement outbox pattern for domain events (transactional event publishing) | P1 | SAGA-042, SAGA-063 | TBD |
 | **SAGA-064** | Implement step error severity classification (FR-28: TRANSIENT vs FATAL) | P0 | SAGA-005 | TBD |
 | **SAGA-065** | Add partition-aware orphan scanning for high-volume (100k TPS) | P2 | SAGA-044, SAGA-061 | TBD |
-| **SAGA-069** | Implement deep-copy serialization boundary for step results (FR-31) | P0 | SAGA-042 | TBD |
+| **SAGA-069** | Implement deep-copy serialisation boundary for step results (FR-31) | P0 | SAGA-042 | TBD |
 
 ### Stream 8: External Integration & Resilience Tasks
 
@@ -1365,8 +1365,8 @@ graph TD
 | Current Test | New Test | What It Validates |
 |--------------|----------|-------------------|
 | `saga_test.go` (14 cases) | `runtime_test.go` | Orchestrator contract: step order, LIFO compensation, context cancellation |
-| `payment_orchestrator_test.go` | `handlers/payment_test.go` | Step handler behavior (Go code, unchanged) |
-| `withdrawal_orchestrator_test.go` | `handlers/current_account_test.go` | Step handler behavior (Go code, unchanged) |
+| `payment_orchestrator_test.go` | `handlers/payment_test.go` | Step handler behaviour (Go code, unchanged) |
+| `withdrawal_orchestrator_test.go` | `handlers/current_account_test.go` | Step handler behaviour (Go code, unchanged) |
 | N/A | `definition_test.go` | Starlark parsing, reference extraction, validation |
 | N/A | `registry_test.go` | CRUD, lifecycle, tenant resolution, caching |
 | Integration tests | Integration tests (same) | End-to-end saga execution, same expected outcomes |
@@ -1406,7 +1406,7 @@ graph TD
 ### Phase 9: Hardening & Validation (SAGA-047 through SAGA-052)
 
 - `valuate_batch()` for multi-context valuation (same basis guarantee)
-- Logic/Physics Linter warns on math in Starlark ("move to CEL")
+- Logic/Physics Linter warns on maths in Starlark ("move to CEL")
 - Step handler output schemas (typed contracts)
 - Simulation mode enforcement (`ctx.is_simulation`)
 - Causation ID propagation to compensation steps
@@ -1505,7 +1505,7 @@ graph TD
 | **AC-AD-02** | `CompleteSagaStep` resumes suspended saga with provided result | Integration test: suspend saga, call CompleteSagaStep, verify saga continues |
 | **AC-AD-03** | Duplicate `CompleteSagaStep` calls with same idempotency_key are deduplicated | Unit test: call twice, verify saga only resumes once |
 | **AC-AD-04** | Suspended saga auto-fails after timeout deadline | Integration test: suspend with 1s timeout, wait 2s, verify status = FAILED |
-| **AC-AD-05** | Step result serialization boundary prevents Go memory leakage | Unit test: return mutable Go map, modify it, verify persisted value unchanged |
+| **AC-AD-05** | Step result serialisation boundary prevents Go memory leakage | Unit test: return mutable Go map, modify it, verify persisted value unchanged |
 | **AC-AD-06** | Replayed step receives fresh copy (not pointer to original) | Unit test: replay step, modify result in script, verify original unchanged |
 | **AC-AD-07** | Causation tree API returns full parent->child hierarchy | Integration test: create nested saga (3 levels), query tree, verify structure |
 | **AC-AD-08** | Causation tree shows failed step location in child saga | Query test: fail child step 2, verify tree shows `failed_step: {index: 2}` |
@@ -1519,13 +1519,13 @@ graph TD
 
 | Risk | Impact | Likelihood | Mitigation |
 |------|--------|------------|------------|
-| **Replay performance degradation** | High | Medium | Optimize step result caching; use indexed queries |
+| **Replay performance degradation** | High | Medium | Optimise step result caching; use indexed queries |
 | **Lease contention at scale** | High | Medium | Partition-aware scanning (SAGA-065); staggered lease strategy |
 | **Orphan detection too slow** | Medium | Low | Reactive wake-up (SAGA-061); fallback to background scan |
 | **Zombie saga accumulation** | Medium | Medium | Alert on zombie detection (SAGA-056); hot-fix API (SAGA-060) |
 | **Non-deterministic UUIDs** | High | Low | Seed reset on replay (FR-26); comprehensive testing |
 | **External service idempotency gaps** | High | Medium | Pre-Step Check pattern (FR-18); linter enforcement |
-| **Memory leaks from mutable results** | Medium | Low | Deep-copy serialization (FR-31); immutable Structs |
+| **Memory leaks from mutable results** | Medium | Low | Deep-copy serialisation (FR-31); immutable Structs |
 | **Bi-temporal integrity violations** | High | Low | Preserve `knowledge_at` in hot-fix; audit trail validation |
 
 ---

--- a/docs/prd/006-starlark-saga-orchestration-core.md
+++ b/docs/prd/006-starlark-saga-orchestration-core.md
@@ -129,7 +129,7 @@ The saga definitions become **Administrative Plan Records** - auditable configur
 
 - **Requirement**: Starlark scripts MUST call CEL expressions for financial calculations
 - **Rationale**: CEL provides ~100ns evaluation; Starlark handles orchestration flow
-- **Constraint**: Valuation math MUST NOT be implemented directly in Starlark
+- **Constraint**: Valuation maths MUST NOT be implemented directly in Starlark
 
 ### FR-4: Tenant Default with Override
 
@@ -179,7 +179,7 @@ The saga definitions become **Administrative Plan Records** - auditable configur
 
 - **Requirement**: Saga execution MUST be scoped to the party hierarchy from Party Service
 - **Individual party**: Access only own positions, accounts, and data
-- **Organization party**: Access own + descendant parties (enables aggregate views)
+- **Organisation party**: Access own + descendant parties (enables aggregate views)
 - **Enforcement**: Runtime resolves party tree; injects immutable `ctx.party_scope`
 - **No bypass**: Saga authors cannot access parties outside their scope
 - **Audit**: All executions logged with `party_id` for compliance
@@ -188,7 +188,7 @@ The saga definitions become **Administrative Plan Records** - auditable configur
 
 - **Requirement**: Before a Saga transitions from PENDING to RUNNING, the Runtime SHALL
   generate a "Visibility Manifest" listing all Party IDs that will be accessed
-- **Problem**: "Implicit Authorization" (allowing access mid-execution) is high-risk for
+- **Problem**: "Implicit Authorisation" (allowing access mid-execution) is high-risk for
   auditors and can result in partial executions that fail halfway due to permission issues
 - **Implementation**:
   1. Static analysis extracts all `party_id` references from the Starlark AST
@@ -213,7 +213,7 @@ The saga definitions become **Administrative Plan Records** - auditable configur
 ### FR-27: Starlark Decimal Type
 
 - **Requirement**: The Runtime MUST provide a custom Starlark type for Decimals
-- **Problem**: Starlark natively supports `int`, `float`, `string` but financial math
+- **Problem**: Starlark natively supports `int`, `float`, `string` but financial maths
   requires `shopspring/decimal` precision
 - **Implementation**: Custom `Decimal` type in `shared/pkg/saga` with operator overloading
   (`+`, `-`, `*`, `/`)
@@ -225,10 +225,10 @@ The saga definitions become **Administrative Plan Records** - auditable configur
 ### FR-33: Semantic Logic/Physics Linter
 
 - **Requirement**: The Linter SHALL be semantic, not just syntactic, for Decimal arithmetic
-- **Problem**: Developers may bypass "no math in Starlark" rule using new Decimal type
+- **Problem**: Developers may bypass "no maths in Starlark" rule using new Decimal type
 - **Detection**: Warn on any arithmetic operator (`+`, `-`, `*`, `/`) where operands
   are not derived from simple counters or loop indices
-- **Suggested message**: "Financial math detected. Move this to a CEL Valuation
+- **Suggested message**: "Financial maths detected. Move this to a CEL Valuation
   Strategy in Reference Data."
 - **Exemptions**: Counter arithmetic (`i + 1`), list indexing, percentage calculations
   using pre-validated rates from Valuation Engine
@@ -848,7 +848,7 @@ other parties.
 | Party Type | Visible Data |
 |------------|--------------|
 | **Individual** | Own positions, accounts, transactions only |
-| **Organization** | Own + all descendant parties (recursive) |
+| **Organisation** | Own + all descendant parties (recursive) |
 | **System** | All parties within tenant (admin use only) |
 
 #### Runtime Context Injection
@@ -894,7 +894,7 @@ func positionKeepingList(ctx StarlarkContext, params map[string]any) (any, error
 
 #### Cross-Party Aggregate Views
 
-Organization parties can run sagas that aggregate across their hierarchy:
+Organisation parties can run sagas that aggregate across their hierarchy:
 
 ```python
 # aggregate_positions.star - Only valid for ORG party types
@@ -930,12 +930,12 @@ saga(
 )
 ```
 
-#### Cross-Party Posting Authorization
+#### Cross-Party Posting Authorisation
 
-**Key distinction**: Read isolation != Write authorization.
+**Key distinction**: Read isolation != Write authorisation.
 
 A saga executing under party A may create ledger entries affecting party B
-when authorized by relationship:
+when authorised by relationship:
 
 ```text
 +-----------------------------------------------------------------------------+
@@ -971,7 +971,7 @@ when authorized by relationship:
 +-----------------------------------------------------------------------------+
 ```
 
-#### Read vs Write Authorization Model
+#### Read vs Write Authorisation Model
 
 | Operation | Scope Rule |
 |-----------|------------|
@@ -981,13 +981,13 @@ when authorized by relationship:
 | **WRITE postings** | Contextual lookup - saga resolves target from input data |
 | **WRITE positions** | Contextual lookup - saga resolves target from input data |
 
-#### Cross-Party Authorization: Contextual Lookup Model
+#### Cross-Party Authorisation: Contextual Lookup Model
 
 > **Note**: The Party Service currently has `party_association` for personal
-> relationships (SPOUSE, DEPENDENT, GUARANTOR). Operational authorization
+> relationships (SPOUSE, DEPENDENT, GUARANTOR). Operational authorisation
 > (OPERATOR, CUSTODIAN, BROKER) is **not yet implemented**.
 
-Rather than rigid party-to-party relationship tables, authorization flows from
+Rather than rigid party-to-party relationship tables, authorisation flows from
 **contextual lookup** using the position's flexible attributes:
 
 ```text
@@ -1015,7 +1015,7 @@ Rather than rigid party-to-party relationship tables, authorization flows from
 |    2. ctx.position.attributes -> internal_account.by_attributes()      |
 |       Result: Account matching those attributes                             |
 |                                                                             |
-|  Authorization is IMPLICIT:                                                 |
+|  Authorisation is IMPLICIT:                                                 |
 |    - Saga declares which lookup types it may use                           |
 |    - Runtime validates lookups against declaration                          |
 |    - Posting targets come from resolved lookups, not arbitrary IDs         |
@@ -1023,7 +1023,7 @@ Rather than rigid party-to-party relationship tables, authorization flows from
 +-----------------------------------------------------------------------------+
 ```
 
-#### Saga Authorized Lookups
+#### Saga Authorised Lookups
 
 Each saga declares what account resolution patterns it may use. Lookups are
 **generic** - attribute keys are tenant-defined:
@@ -1070,9 +1070,9 @@ saga(
 ```go
 // Runtime validates lookups against saga's authorized_lookups
 func (r *Runtime) ResolveLookup(sagaDef SagaDefinition, lookupType string, key any) (Account, error) {
-    // Check if saga is authorized for this lookup type
+    // Check if saga is authorised for this lookup type
     if !contains(sagaDef.AuthorizedLookups, lookupType) {
-        return nil, fmt.Errorf("saga %s not authorized for lookup type %s", sagaDef.Name, lookupType)
+        return nil, fmt.Errorf("saga %s not authorised for lookup type %s", sagaDef.Name, lookupType)
     }
 
     // Perform the lookup - attribute keys are tenant-defined
@@ -1100,7 +1100,7 @@ func (s *InternalAccountService) GetByAttributes(ctx context.Context, attrs map[
 
 #### Optional: Explicit Party Relationships
 
-For use cases requiring explicit authorization tracking (audit, compliance), an
+For use cases requiring explicit authorisation tracking (audit, compliance), an
 optional `party_relationships` table can be added to Party Service:
 
 ```sql
@@ -1119,7 +1119,7 @@ CREATE TABLE party_relationships (
 );
 ```
 
-This is **optional** - the contextual lookup model provides authorization implicitly through saga definition.
+This is **optional** - the contextual lookup model provides authorisation implicitly through saga definition.
 
 #### Audit Trail
 
@@ -1682,7 +1682,7 @@ func (r *Runtime) ExecuteWithLimits(
 | Max expression depth | 10 levels |
 | Cost limit | 10,000 units |
 
-### 6.3 Step Handler Authorization
+### 6.3 Step Handler Authorisation
 
 - Handlers are platform-controlled Go functions
 - Starlark cannot invoke arbitrary code
@@ -1706,8 +1706,8 @@ func (r *Runtime) ExecuteWithLimits(
 | Current Test | New Test | What It Validates |
 |--------------|----------|-------------------|
 | `saga_test.go` (14 cases) | `runtime_test.go` | Orchestrator contract: step order, LIFO compensation, context cancellation |
-| `payment_orchestrator_test.go` | `handlers/payment_test.go` | Step handler behavior (Go code, unchanged) |
-| `withdrawal_orchestrator_test.go` | `handlers/current_account_test.go` | Step handler behavior (Go code, unchanged) |
+| `payment_orchestrator_test.go` | `handlers/payment_test.go` | Step handler behaviour (Go code, unchanged) |
+| `withdrawal_orchestrator_test.go` | `handlers/current_account_test.go` | Step handler behaviour (Go code, unchanged) |
 | N/A | `definition_test.go` | Starlark parsing, reference extraction, validation |
 | N/A | `registry_test.go` | CRUD, lifecycle, tenant resolution, caching |
 | Integration tests | Integration tests (same) | End-to-end saga execution, same expected outcomes |
@@ -1875,7 +1875,7 @@ The streams can be parallelized with dependencies as shown below.
 | Task ID | Description | Priority | Owner |
 |---------|-------------|----------|-------|
 | **SAGA-003** | Integrate `go.starlark.net` runtime | P0 | TBD |
-| **SAGA-004a** | Implement Starlark Decimal extension (FR-27: operator overloading for financial math) | P0 | TBD |
+| **SAGA-004a** | Implement Starlark Decimal extension (FR-27: operator overloading for financial maths) | P0 | TBD |
 | **SAGA-004b** | Implement time-injection logic (strip `time.now()`, inject `ctx.knowledge_at`) | P0 | TBD |
 | **SAGA-004c** | Implement core builtins (`cel_eval`, `posting`, `resolve_account`, etc.) | P0 | TBD |
 | **SAGA-072** | Implement external lookup result capture for replay safety (FR-34) | P0 | TBD |
@@ -1903,7 +1903,7 @@ The streams can be parallelized with dependencies as shown below.
 | **SAGA-019** | Implement ACTIVATION phase validation (hard fail) | P0 | TBD |
 | **SAGA-020** | Implement deprecation impact analysis | P1 | TBD |
 | **SAGA-021** | Add validation feedback API endpoint | P1 | TBD |
-| **SAGA-048** | Add Logic/Physics Linter (warn on math in Starlark, enforce Pre-Step Check) | P1 | TBD |
+| **SAGA-048** | Add Logic/Physics Linter (warn on maths in Starlark, enforce Pre-Step Check) | P1 | TBD |
 | **SAGA-071** | Enhance Logic/Physics Linter with semantic Decimal arithmetic detection (FR-33) | P1 | TBD |
 
 ### Stream 5: Party Isolation
@@ -1958,10 +1958,10 @@ The streams can be parallelized with dependencies as shown below.
 | ID | Criterion | Test Method |
 |----|-----------|-------------|
 | **AC-PI-01** | Individual party saga CANNOT read positions of sibling parties | Unit test: assert `position_keeping.list()` returns empty for sibling party_id |
-| **AC-PI-02** | Organization party saga CAN read positions of descendant parties | Unit test: assert `position_keeping.list()` returns descendant positions |
+| **AC-PI-02** | Organisation party saga CAN read positions of descendant parties | Unit test: assert `position_keeping.list()` returns descendant positions |
 | **AC-PI-03** | Saga `ctx.party_scope` is immutable | Unit test: assert mutation throws error |
 | **AC-PI-04** | Cross-party posting governed by contextual lookup model (Section 5.7) | Integration test: posting to unrelated party fails |
-| **AC-PI-05** | Authorized cross-party posting succeeds via contextual visibility rules | Integration test: contextual lookup resolves counterparty accounts correctly |
+| **AC-PI-05** | Authorised cross-party posting succeeds via contextual visibility rules | Integration test: contextual lookup resolves counterparty accounts correctly |
 | **AC-PI-06** | Saga execution log includes `party_id` and `visible_parties` from contextual lookup | Unit test: verify audit fields reflect contextual visibility at execution time |
 | **AC-PI-07** | Child saga inherits parent party scope (cannot escalate) | Unit test: `invoke_saga()` passes same `party_scope` |
 | **AC-PI-08** | Query by `visible_parties` returns correct executions | Query test: GIN index query returns expected results |
@@ -1984,7 +1984,7 @@ The streams can be parallelized with dependencies as shown below.
 | **AC-SC-01** | `invoke_saga()` executes child saga synchronously | Unit test: verify child completes before parent continues |
 | **AC-SC-02** | Parent failure triggers child compensation (LIFO) | Integration test: fail step 3, verify step 2 child compensates |
 | **AC-SC-03** | Circular saga references detected at ACTIVATION | Unit test: A->B->C->A fails activation |
-| **AC-SC-04** | Circular saga references detected at RUNTIME (defense in depth) | Unit test: call stack check prevents re-entry |
+| **AC-SC-04** | Circular saga references detected at RUNTIME (defence in depth) | Unit test: call stack check prevents re-entry |
 | **AC-SC-05** | Nesting depth > 5 rejected | Unit test: 6-level nesting fails |
 | **AC-SC-06** | Total steps > 50 rejected | Unit test: saga with 51 total steps fails |
 | **AC-SC-07** | Child saga result accessible in parent context | Unit test: `result.execution_id` available for compensation |
@@ -2099,4 +2099,4 @@ For tenant communication:
 - [go.starlark.net](https://pkg.go.dev/go.starlark.net/starlark) - Starlark Go implementation
 - [Starlark Language Spec](https://github.com/bazelbuild/starlark/blob/master/spec.md)
 - [google/cel-go](https://github.com/google/cel-go) - CEL Go implementation
-- [Party Service](../adr/0003-party-management.md) - Party hierarchy and relationships (cross-party authorization)
+- [Party Service](../adr/0003-party-management.md) - Party hierarchy and relationships (cross-party authorisation)

--- a/docs/prd/007-starlark-typed-service-clients.md
+++ b/docs/prd/007-starlark-typed-service-clients.md
@@ -61,10 +61,10 @@ query := `
 |-------|--------|
 | **No Update Propagation** | Bug fixes to `deposit.star` don't reach existing tenants |
 | **Storage Duplication** | Same script content stored N times (once per tenant) |
-| **Inconsistent Behavior** | Older tenants run different code than newer tenants |
+| **Inconsistent Behaviour** | Older tenants run different code than newer tenants |
 | **Manual Migration Required** | Platform updates require explicit migration across all tenants |
 
-**Desired Behavior:**
+**Desired Behaviour:**
 
 ```text
 ┌─────────────────────────────────────────────────────────────────┐
@@ -433,7 +433,7 @@ func BuildTenantPredeclared(tenantID TenantID) starlark.StringDict {
     return predeclared
 }
 
-// Thread initialization
+// Thread initialisation
 thread := &starlark.Thread{Name: sagaName}
 globals, err := starlark.ExecFileOptions(
     &syntax.FileOptions{},
@@ -449,7 +449,7 @@ Loader**, not script logic.
 
 #### 4. No load() Required for Core Services
 
-Service objects are injected into global scope during thread initialization. Scripts access
+Service objects are injected into global scope during thread initialisation. Scripts access
 them directly without imports:
 
 ```starlark
@@ -716,7 +716,7 @@ Store only a reference marker in tenant `saga_definition`, not the script conten
 INSERT INTO saga_definition (name, is_platform_ref, platform_version)
 VALUES ('current_account_deposit', true, '1.2.0');
 
--- Tenant saga_definition for overrides (existing behavior)
+-- Tenant saga_definition for overrides (existing behaviour)
 INSERT INTO saga_definition (name, script, override_reason)
 VALUES ('current_account_deposit', '...custom script...', 'Custom settlement timing');
 ```
@@ -826,7 +826,7 @@ Define handler schemas that serve as single source of truth for both Go and Star
 1.5. **Add schema validation to ValidateDraft/ValidateActivation** - Integrate schema
      checking into existing validation pipeline
 
-1.6. **Automated documentation generator** - Generate Markdown "Service Catalog" from YAML
+1.6. **Automated documentation generator** - Generate Markdown "Service Catalogue" from YAML
      schemas. Ensures up-to-date reference of every `service.method()` and required params.
 
 ### Task 2: Starlark Service Modules

--- a/docs/prd/008-starlark-service-bindings.md
+++ b/docs/prd/008-starlark-service-bindings.md
@@ -41,7 +41,7 @@ validation, resilience, and observability.
 
 - Three services migrated: Current Account, Position Keeping, Financial Accounting
 - Handlers moved from shared platform code to service client packages
-- Integration tests verify real service behavior
+- Integration tests verify real service behaviour
 - Saga metadata propagation (idempotency, tracing, bi-temporal queries)
 
 **See Also:**
@@ -702,7 +702,7 @@ func TestValuationWorkflow_E2E(t *testing.T) {
   }
   ```
 
-- **Idempotency key standardization** (`shared/pkg/clients`):
+- **Idempotency key standardisation** (`shared/pkg/clients`):
 
   **Requirement**: Standardize idempotency key propagation across all service clients.
   Some BIAN services use `meridian.common.v1.IdempotencyKey` field in protobuf, others use
@@ -1193,7 +1193,7 @@ partial failures, and concurrent executions earlier would have caught production
 
 - ✅ **[VERIFIED 2026-02-03]** No increase in handler latency
   - Handlers are thin adapters (~1ms overhead)
-  - Client calls already optimized with connection pooling
+  - Client calls already optimised with connection pooling
 - ✅ **[VERIFIED 2026-02-03]** No degradation in error handling
   - gRPC errors properly propagated to saga runtime
   - Circuit breaker patterns maintained from client layer
@@ -1228,7 +1228,7 @@ partial failures, and concurrent executions earlier would have caught production
 | Risk | Impact | Likelihood | Mitigation |
 |------|--------|------------|------------|
 | **Breaking existing sagas** | High | Low | Maintain handler names/signatures, comprehensive tests |
-| **Handler latency increase** | Medium | Low | Handlers are thin adapters, client calls already optimized |
+| **Handler latency increase** | Medium | Low | Handlers are thin adapters, client calls already optimised |
 | **Dependency injection complexity** | Medium | Medium | Wiring in cmd/main.go (see Phase 1.1), document pattern |
 | **Test environment setup overhead** | Low | Medium | Create reusable test helpers, share across services |
 | **Incomplete e2e coverage** | Medium | Medium | Define minimum coverage requirements upfront |
@@ -1351,7 +1351,7 @@ func lintRecursiveAsset(script *starlark.Script, triggerInstrument string) error
     if contains(outputInstruments, triggerInstrument) {
         return fmt.Errorf(
             "RECURSIVE_ASSET_WARNING: Saga triggered by %s produces %s. "+
-            "This may cause infinite loops. Requires explicit authorization.",
+            "This may cause infinite loops. Requires explicit authorisation.",
             triggerInstrument, triggerInstrument)
     }
     return nil
@@ -1367,7 +1367,7 @@ Reject registration unless tenant provides `recursive_authorization: true` with 
 | **Network** | Kafka/gRPC headers | `causation_depth > max_depth` → Reject |
 | **Service** | Step Registry | Settlement sagas cannot invoke Position Keeping |
 | **Runtime** | Lineage tracker | `account:instrument` in ancestry → Cycle detected |
-| **Governance** | Starlark linter | Script outputs same type as trigger → Require authorization |
+| **Governance** | Starlark linter | Script outputs same type as trigger → Require authorisation |
 
 ### Why This Is Separate Work
 

--- a/docs/prd/009-production-readiness-review.md
+++ b/docs/prd/009-production-readiness-review.md
@@ -103,7 +103,7 @@ boundaries, error handling, and validation logic.
 - Complete posting workflows (debit/credit pairing)
 - Trial balance generation (sum debits = sum credits)
 - Reconciliation with position-keeping
-- NoOp fallback behavior under Redis/Kafka failure
+- NoOp fallback behaviour under Redis/Kafka failure
 - Orphaned booking logs from partial failures
 
 **Current Coverage**: Integration tests with Testcontainers (`service/grpc_integration_test.go`)
@@ -122,7 +122,7 @@ boundaries, error handling, and validation logic.
 - Compensation scenarios (failed payment → reverse lien)
 - Concurrent lien execution (race condition testing)
 - Bucket ID evaluation failure handling
-- Gateway timeout and retry behavior
+- Gateway timeout and retry behaviour
 
 **Current Coverage**: Integration tests with mocked current-account and financial-accounting (`service/integration_test.go`)
 
@@ -600,7 +600,7 @@ if os.Getenv("KYC_STUB_ENABLED") != "true" {
 
 **Tasks**:
 
-1. Uncomment database initialization code (lines 75-84)
+1. Uncomment database initialisation code (lines 75-84)
 2. Register Market Information gRPC service (lines 98-99)
 3. Enable ECB worker (lines 205-208)
 4. Enable database cleanup (lines 258-261)
@@ -912,18 +912,18 @@ func TestAsyncOperation_E2E(t *testing.T) {
 
 **CRITICAL TESTING PRINCIPLE**: When e2e tests fail, **fix the production code, not the test assertions**.
 
-**The Problem**: It's tempting to "fix" failing tests by adjusting expected values to match incorrect behavior. This
+**The Problem**: It's tempting to "fix" failing tests by adjusting expected values to match incorrect behaviour. This
 defeats the entire purpose of testing.
 
 **The Rule**:
 
 ```go
-// ❌ WRONG - Making test match incorrect behavior
+// ❌ WRONG - Making test match incorrect behaviour
 func TestWithdrawal_E2E(t *testing.T) {
     withdrawal := executeWithdrawal(t, ctx, service, 100)
 
     // Test discovers withdrawal status is stuck in PENDING
-    // Developer changes assertion to match broken behavior:
+    // Developer changes assertion to match broken behaviour:
     assert.Equal(t, StatusPending, withdrawal.Status) // ❌ Makes test pass, hides bug
 }
 
@@ -935,7 +935,7 @@ func TestWithdrawal_E2E(t *testing.T) {
     // Developer investigates and finds the bug in current-account/service/grpc_service.go:896-913
     // Developer implements Outbox Pattern to fix eventual consistency issue
     // Now test passes with correct assertion:
-    assert.Equal(t, StatusCompleted, withdrawal.Status) // ✅ Verifies correct behavior
+    assert.Equal(t, StatusCompleted, withdrawal.Status) // ✅ Verifies correct behaviour
 }
 ```
 
@@ -944,7 +944,7 @@ func TestWithdrawal_E2E(t *testing.T) {
 | Scenario | Action | Reason |
 |----------|--------|--------|
 | Test expects COMPLETED but gets PENDING | Fix production code | Status should transition to COMPLETED |
-| Test expects balance 100 but gets 95 | Fix production code | Math is wrong, not the expectation |
+| Test expects balance 100 but gets 95 | Fix production code | Maths is wrong, not the expectation |
 | Test expects 3 audit logs but gets 2 | Fix production code | Missing audit trail entry |
 | Test expects response in 50ms but takes 500ms | Fix production code OR adjust baseline | Performance regression |
 | Test uses wrong tenant ID in assertion | Fix test | Test bug, not production bug |
@@ -963,20 +963,20 @@ func TestWithdrawal_E2E(t *testing.T) {
 1. **Test fails** - E2E test discovers withdrawal status stuck in PENDING
 2. **Investigate** - Why is the status not updating? Found eventual consistency bug
 3. **Fix production code** - Implement Outbox Pattern (not just change assertion)
-4. **Test passes** - Now verifies correct behavior
+4. **Test passes** - Now verifies correct behaviour
 5. **Document** - Add comment explaining the fix: "Fixed eventual consistency issue with Outbox Pattern"
 
 **Exception**: Only "fix" tests when the test itself has a bug (wrong tenant ID, outdated API expectations, etc.) - not
-when production behavior is incorrect.
+when production behaviour is incorrect.
 
 **Why This Matters**:
 
 - E2E tests are our **truth detector** - they expose real production issues
 - Weakening assertions to make tests pass **hides bugs** that will hit customers
-- **Tests should fail** when behavior is wrong - that's their job
+- **Tests should fail** when behaviour is wrong - that's their job
 - If a test is "too strict", the production code is probably **not strict enough**
 
-**Bottom Line**: **Tests that pass by hiding broken behavior are worse than no tests at all.** They give false confidence
+**Bottom Line**: **Tests that pass by hiding broken behaviour are worse than no tests at all.** They give false confidence
 while the bug ships to production.
 
 ---

--- a/docs/prd/010-starlark-testing-framework.md
+++ b/docs/prd/010-starlark-testing-framework.md
@@ -180,7 +180,7 @@ type SemanticLinter struct
 ┌─────────────────────────────────────────────────────────┐
 │ Layer 2: Semantic Linting (EXISTING)                   │
 │ shared/pkg/saga/linter.go                              │
-│ • Decimal math, magic numbers, hardcoded codes         │
+│ • Decimal maths, magic numbers, hardcoded codes         │
 └────────────────┬────────────────────────────────────────┘
                  ↓ Pass
 ┌─────────────────────────────────────────────────────────┐

--- a/docs/prd/011-valuation-service.md
+++ b/docs/prd/011-valuation-service.md
@@ -8,9 +8,9 @@ triggers:
   - Multi-currency and multi-commodity conversion with full audit trail
 instructions: |
   Account Services (CurrentAccount, InternalAccount) host the Asset Valuation service domain via
-  shared library (Virtual Service pattern). Each account's ValuationFeature (Behavior Qualifier) defines
+  shared library (Virtual Service pattern). Each account's ValuationFeature (Behaviour Qualifier) defines
   how it accepts value. The shared/pkg/valuation library executes Starlark ValuationMethods that invoke
-  named CEL Policies via run_policy(). Math lives in Policies; Starlark is pure procedure.
+  named CEL Policies via run_policy(). Maths lives in Policies; Starlark is pure procedure.
 
   BIAN Action Terms:
   - EvaluateAssetValuation: Non-binding inquiry (mobile apps, dashboards)
@@ -23,7 +23,7 @@ instructions: |
 # PRD: Asset Valuation Service Domain (BIAN-Native)
 
 **Status:** Draft - BIAN Refinement
-**Version:** 3.0 (Referenced Policies - No Inline Math)
+**Version:** 3.0 (Referenced Policies - No Inline Maths)
 **BIAN Service Domain:** Asset Valuation (Fulfilment Pattern)
 **Task Master Tag:** `valuation-engine`
 **Story Points:** 82 (11 streams)
@@ -53,7 +53,7 @@ To ensure 100% compatibility with the BIAN Service Landscape, this PRD adopts st
 | `EvaluateAssetValuation` | **`EvaluateAssetValuation`** | "Evaluate" is BIAN term for computational inquiry |
 | Valuation Strategy | **ValuationMethod** | BIAN uses "Method" for algorithmic variants |
 | `ValuationAnalysis` | **`ValuationAnalysis`** | Describes evidentiary audit data |
-| `valuation_assignments` | **`ValuationFeature`** | Behavior Qualifier on Account CR |
+| `valuation_assignments` | **`ValuationFeature`** | Behaviour Qualifier on Account CR |
 | Account with valuation | **`AccountFulfillmentArrangement`** | Control Record with BQ features |
 
 **Action Terms Compliance:**
@@ -69,7 +69,7 @@ To ensure 100% compatibility with the BIAN Service Landscape, this PRD adopts st
 ## 1. Executive Summary
 
 The Account-Scoped Valuation Engine enables multi-asset ledgers by making **accounts responsible for defining
-how they accept value**. Instead of a centralized pricing service, valuation logic is embedded within
+how they accept value**. Instead of a centralised pricing service, valuation logic is embedded within
 Account Services (CurrentAccount, InternalAccount) via a shared library.
 
 ### The "Probe Pattern"
@@ -99,7 +99,7 @@ services/internal-account/ # Implements EvaluateAssetValuation RPC
 **Why Embedded Library > Standalone Service:**
 
 - **Performance**: Eliminates 1 network hop (3 hops vs 4)
-- **Domain Modeling**: Valuation is Account's capability, not external service
+- **Domain Modelling**: Valuation is Account's capability, not external service
 - **Operational Simplicity**: No additional microservice to deploy/monitor
 - **Follows Existing Patterns**: Matches shared/pkg/saga library approach
 
@@ -127,7 +127,7 @@ architecture with BIAN's Service Domain decomposition:
 │  │                   services/current-account                         │  │
 │  │  ┌─────────────────────────────────────────────────────────────┐  │  │
 │  │  │  shared/pkg/valuation (embedded library)                     │  │  │
-│  │  │  • Starlark procedure execution (no inline math)             │  │  │
+│  │  │  • Starlark procedure execution (no inline maths)             │  │  │
 │  │  │  • CEL Policy resolution via run_policy()                    │  │  │
 │  │  │  • ValuationMethod + ValuationPolicy resolution              │  │  │
 │  │  │  • Market data integration                                   │  │  │
@@ -140,7 +140,7 @@ architecture with BIAN's Service Domain decomposition:
 **Why Virtual Service?**
 
 1. **BIAN Conceptual Compliance**: Asset Valuation IS a distinct Service Domain in the BIAN landscape,
-   with its own Control Records, Behavior Qualifiers, and Action Terms
+   with its own Control Records, Behaviour Qualifiers, and Action Terms
 2. **Implementation Pragmatism**: A separate microservice adds latency, operational complexity, and
    transactional boundaries that complicate atomic valuation
 3. **Future Flexibility**: If scale demands separation, the library can be extracted to a service
@@ -149,7 +149,7 @@ architecture with BIAN's Service Domain decomposition:
 **External Consumers See:**
 
 - `EvaluateAssetValuation` RPC (BIAN Action Term: Evaluate)
-- `ValuationFeature` Behavior Qualifier
+- `ValuationFeature` Behaviour Qualifier
 - `ValuationMethod` reference data
 - `ValuationAnalysis` audit records
 
@@ -222,11 +222,11 @@ We implement an **Account Responsibility Pattern**:
 2. **Account Ownership**: Account Services implement `EvaluateAssetValuation` RPC
 3. **Feature Assignment**: Accounts store ValuationFeature (BQ) with `valuation_method_id` + parameters
 4. **In-Process Execution**: Valuation happens within Account Service process boundary
-5. **No Inline Math**: Starlark scripts invoke named Policies via `run_policy()` - CEL strings forbidden
+5. **No Inline Maths**: Starlark scripts invoke named Policies via `run_policy()` - CEL strings forbidden
 
-### 3.1 Control Record / Behavior Qualifier Pattern (BIAN)
+### 3.1 Control Record / Behaviour Qualifier Pattern (BIAN)
 
-Instead of a bespoke `valuation_assignments` table, we model valuation as a **Behavior Qualifier (BQ)**
+Instead of a bespoke `valuation_assignments` table, we model valuation as a **Behaviour Qualifier (BQ)**
 of the Account Fulfillment Arrangement (Control Record). This allows accounts to have multiple features
 (Position tracking, Interest calculation, Valuation) governed by the same aggregate root.
 
@@ -238,17 +238,17 @@ message AccountFulfillmentArrangement {  // Control Record (CR)
   string account_id = 1;
   string account_type = 2;  // "CURRENT_ACCOUNT", "INTERNAL_ACCOUNT"
 
-  // Behavior Qualifiers (BQ) - each feature is a separate BQ
+  // Behaviour Qualifiers (BQ) - each feature is a separate BQ
   ValuationFeature valuation_feature = 3;
   PositionFeature position_feature = 4;
   // Future: InterestFeature, FeeFeature, LimitFeature, etc.
 }
 ```
 
-#### The ValuationFeature (Behavior Qualifier)
+#### The ValuationFeature (Behaviour Qualifier)
 
 ```protobuf
-message ValuationFeature {  // Behavior Qualifier (BQ)
+message ValuationFeature {  // Behaviour Qualifier (BQ)
   string feature_id = 1;
 
   // Reference to ValuationMethod in Reference Data
@@ -274,7 +274,7 @@ message ValuationFeature {  // Behavior Qualifier (BQ)
 
 ```sql
 -- Added to CurrentAccount and InternalAccount schemas
--- Named as BIAN Behavior Qualifier
+-- Named as BIAN Behaviour Qualifier
 CREATE TABLE valuation_features (
     feature_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     account_id UUID NOT NULL,
@@ -379,7 +379,7 @@ domain (per-tenant schema):
 ```sql
 -- Lives in Reference Data service (tenant-scoped via PostgreSQL schemas)
 -- BIAN terminology: ValuationMethod (not "strategy")
--- NOTE: Methods are Starlark-only (procedures). Math lives in Policies.
+-- NOTE: Methods are Starlark-only (procedures). Maths lives in Policies.
 CREATE TABLE valuation_methods (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
@@ -391,7 +391,7 @@ CREATE TABLE valuation_methods (
     input_instrument VARCHAR(32) NOT NULL,  -- "KWH"
     output_instrument VARCHAR(32) NOT NULL, -- "GBP"
 
-    -- Logic (Starlark script ONLY - no inline math)
+    -- Logic (Starlark script ONLY - no inline maths)
     -- Starlark calls run_policy() for calculations
     logic_script TEXT NOT NULL,
     logic_hash VARCHAR(64) NOT NULL,     -- SHA-256 for cache invalidation
@@ -427,7 +427,7 @@ CREATE INDEX idx_valuation_methods_bitemporal
 
 ### 3.3 ValuationPolicy Definition (Referenced CEL Expressions)
 
-**The "No-Inline-Math" Principle:**
+**The "No-Inline-Maths" Principle:**
 
 Starlark scripts are **procedures** - they orchestrate data flow, handle branching, and aggregate results.
 They should NOT contain mathematical formulas as inline strings. Instead, all calculations are stored as
@@ -438,10 +438,10 @@ They should NOT contain mathematical formulas as inline strings. Instead, all ca
 | Concern | Inline CEL (`cel_eval(string)`) | Referenced Policy (`run_policy(name)`) |
 |---------|--------------------------------|----------------------------------------|
 | **Auditability** | Formula buried in Starlark | Formula is first-class entity |
-| **Versioning** | Script version includes math | Math versioned independently |
+| **Versioning** | Script version includes maths | Maths versioned independently |
 | **Testing** | Must execute full Starlark | Can unit-test Policy in isolation |
 | **AI Generation** | AI must embed formulas | AI references existing Policies |
-| **Governance** | Math changes require script update | Finance team can update Policies |
+| **Governance** | Maths changes require script update | Finance team can update Policies |
 
 **Policy Table Schema:**
 
@@ -455,7 +455,7 @@ CREATE TABLE valuation_policies (
     name VARCHAR(64) NOT NULL,           -- "energy_rate_calc", "vat_standard", "fx_spread"
     version INTEGER NOT NULL DEFAULT 1,
 
-    -- CEL Expression (the actual math)
+    -- CEL Expression (the actual maths)
     cel_expression TEXT NOT NULL,        -- "spot * coefficient * (1 + markup)"
     cel_hash VARCHAR(64) NOT NULL,       -- SHA-256 for cache invalidation
 
@@ -765,10 +765,10 @@ type Analysis struct {
 The engine executes logic in three tiers:
 
 1. **Starlark (The Procedure):** Aggregates data, handles rounding logic and branching. **No inline math.**
-2. **CEL Policy (The Math):** Named, versioned expressions invoked via `run_policy()` (~100ns).
+2. **CEL Policy (The Maths):** Named, versioned expressions invoked via `run_policy()` (~100ns).
 3. **Market Data (The Fact):** Injects the bi-temporal rates (e.g., FX mid-rate).
 
-**The "No-Inline-Math" Rule:**
+**The "No-Inline-Maths" Rule:**
 
 Starlark scripts MUST NOT contain CEL expression strings. All mathematical calculations MUST be
 delegated to named Policies via `run_policy()`. This ensures:
@@ -784,7 +784,7 @@ delegated to named Policies via `run_policy()`. This ensures:
 # Starlark ValuationMethod loaded from Reference Data
 # SECURITY: Sandboxed execution - no filesystem, no network, no system calls
 # LIMITS: 5s timeout, 64MB memory, Policies limited to 10,000 cost units each
-# CONSTRAINT: No inline math - all calculations via run_policy()
+# CONSTRAINT: No inline maths - all calculations via run_policy()
 def valuate_energy(input_quantity, params, knowledge_at):
     # 1. Validate required parameters
     if "gsp_coefficient" not in params:
@@ -830,7 +830,7 @@ def valuate_energy(input_quantity, params, knowledge_at):
 # ❌ WRONG - Inline CEL expression string
 rate = cel_eval("spot * coeff * markup", {...})
 
-# ❌ WRONG - Math in Starlark
+# ❌ WRONG - Maths in Starlark
 rate = spot_price * gsp_coefficient * Decimal("1.02")
 
 # ✅ CORRECT - Named policy reference
@@ -976,7 +976,7 @@ func (e *Engine) Valuate(ctx context.Context, req Request) (*Response, error) {
         return nil, fmt.Errorf("load method: %w", err)
     }
 
-    // 2. Execute Starlark (which calls run_policy() for math)
+    // 2. Execute Starlark (which calls run_policy() for maths)
     result, err := e.executeScript(ctx, method.LogicScript, req)
     if err != nil {
         return nil, fmt.Errorf("execute script: %w", err)
@@ -1274,7 +1274,7 @@ To achieve faster consistency than the 5-minute TTL, the system SHOULD implement
 2. Account Services subscribe to this topic and invalidate their L1 cache immediately
 3. New transactions use the updated method within milliseconds, not minutes
 
-**Implementation:** This is a P2 enhancement (Stream 8). The 5-minute TTL provides acceptable baseline behavior.
+**Implementation:** This is a P2 enhancement (Stream 8). The 5-minute TTL provides acceptable baseline behaviour.
 
 **Graceful Stale Policy (Resilience):**
 
@@ -1364,7 +1364,7 @@ BAD: Valuation triggers position log → Position log triggers valuation → Loo
 
 1. **Read-Only Contract:** The `EvaluateAssetValuation` RPC is a **stateless inquiry** (pure function).
    It performs NO writes to Position Keeping, NO writes to Account state.
-2. **Domain Boundary:** Valuation is "Math-as-a-Service" - it calculates, it does not transact.
+2. **Domain Boundary:** Valuation is "Maths-as-a-Service" - it calculates, it does not transact.
 3. **Saga Responsibility:** Only the Saga Orchestrator can write to Position Keeping, and only AFTER
    receiving the valuation response.
 4. **Separate Builtin Registry (CRITICAL):** The `shared/pkg/valuation` library MUST use a **different
@@ -1383,7 +1383,7 @@ func newValuationBuiltins() starlark.StringDict {
     return starlark.StringDict{
         "market_data":    builtinMarketData,     // ✅ Read-only
         "run_policy":     builtinRunPolicy,      // ✅ Named policy execution (NEW)
-        "quantity":       builtinQuantity,       // ✅ Math operations
+        "quantity":       builtinQuantity,       // ✅ Maths operations
         "Decimal":        builtinDecimal,        // ✅ Financial precision
         // ❌ NO cel_eval - inline CEL strings forbidden
         // ❌ NO position_keeping, NO financial_accounting
@@ -1404,7 +1404,7 @@ shared/pkg/valuation/
 │   └── builtins/          # Cannot import anything outside shared/pkg/valuation
 │       ├── market_data.go # ✅ Allowed: Reference Data client
 │       ├── run_policy.go  # ✅ Allowed: Policy runtime (NEW)
-│       ├── quantity.go    # ✅ Allowed: Math operations
+│       ├── quantity.go    # ✅ Allowed: Maths operations
 │       └── decimal.go     # ✅ Allowed: Financial precision
 │       # ❌ FORBIDDEN: No cel_eval.go - inline CEL strings not allowed
 │       # ❌ FORBIDDEN: Cannot import positionkeepingclient
@@ -1688,7 +1688,7 @@ message ReleaseReservationRequest {
 #### Idempotency Requirement (CRITICAL)
 
 The `RecordReservation` RPC MUST be **idempotent based on `lien_id`**. If `InitiateLien` retries (network
-timeout, saga replay), Position Keeping must recognize that the reservation for that `lien_id` already
+timeout, saga replay), Position Keeping must recognise that the reservation for that `lien_id` already
 exists and return success without double-counting.
 
 **Implementation:**
@@ -2069,12 +2069,12 @@ shared/pkg/valuation/
 ├── starlark_runtime.go       # Starlark VM wrapper
 │   └── Deterministic execution
 │   └── Timeout controls
-│   └── No-inline-math enforcement
+│   └── No-inline-maths enforcement
 └── types.go                  # Request/Response types
     └── type Request, Response, Analysis
 ```
 
-**No-Inline-Math Enforcement:**
+**No-Inline-Maths Enforcement:**
 
 The Starlark runtime performs static analysis on loaded scripts to reject any that:
 
@@ -2097,11 +2097,11 @@ func (r *StarlarkRuntime) ValidateScript(script string) error {
 ### 5.3 The "Passport Pattern" - Audit Integrity Across Flows
 
 The **Basis** (the valuation receipt) must be persisted to ensure the ledger is auditable. This creates a
-**three-layer persistence model**, with different behavior for inquiry vs transactional flows:
+**three-layer persistence model**, with different behaviour for inquiry vs transactional flows:
 
 #### Layer 1: Account Service
 
-**Inquiry Flow (`EvaluateAssetValuation`)**: Stateless, NO writes. Pure "Math-as-a-Service."
+**Inquiry Flow (`EvaluateAssetValuation`)**: Stateless, NO writes. Pure "Maths-as-a-Service."
 
 - **Why:** 100,000 inquiries/hour shouldn't write to Account database
 - **Performance:** <5ms p99 by eliminating DB contention
@@ -2266,7 +2266,7 @@ func main() {
 
 ### Stream 1: Account Valuation Features (P0, 5 points)
 
-**BIAN Pattern:** This stream implements the ValuationFeature Behavior Qualifier (BQ) for Account
+**BIAN Pattern:** This stream implements the ValuationFeature Behaviour Qualifier (BQ) for Account
 Fulfillment Arrangements (Control Records).
 
 **Tasks:**
@@ -2297,7 +2297,7 @@ Fulfillment Arrangements (Control Records).
 4. Implement Starlark VM wrapper with timeouts
 5. Register built-in functions: `market_data`, `run_policy()`, `quantity`, `Decimal`
 6. **CRITICAL:** NO `cel_eval()` builtin - inline CEL strings forbidden
-7. **CRITICAL:** Implement No-Inline-Math enforcement (reject scripts containing `cel_eval`)
+7. **CRITICAL:** Implement No-Inline-Maths enforcement (reject scripts containing `cel_eval`)
 8. **CRITICAL:** Implement separate read-only builtin registry (exclude position_keeping, financial_accounting)
 9. **CRITICAL:** Use `internal/builtins` package isolation to enforce read-only at Go module level
 10. Implement L1 in-memory cache with graceful stale policy (1-hour grace if backend down)
@@ -2306,7 +2306,7 @@ Fulfillment Arrangements (Control Records).
 13. Implement output instrument validation (runtime type check)
 14. Add comprehensive unit tests
 15. **CRITICAL:** Add security verification test (method cannot call write handlers)
-16. **CRITICAL:** Add No-Inline-Math verification test (script with `cel_eval` is rejected)
+16. **CRITICAL:** Add No-Inline-Maths verification test (script with `cel_eval` is rejected)
 17. **CRITICAL:** Add CI verification script that fails if write imports are added
 18. Add benchmarks (target: <5ms in-process execution)
 19. Document library usage patterns
@@ -2318,7 +2318,7 @@ Fulfillment Arrangements (Control Records).
 - Policy cost validation happens at policy creation (not just runtime)
 - Benchmark shows <5ms execution time for typical methods
 - Cache hit rate >80% after warmup (for same method_id and policy_name)
-- **No-Inline-Math test passes:** Script with `cel_eval("...")` fails with clear error
+- **No-Inline-Maths test passes:** Script with `cel_eval("...")` fails with clear error
 - **Security test passes:** Method attempting `position_keeping.initiate_log` fails with
   `name 'position_keeping' is not defined`
 - **Architecture test passes:** Build fails if valuation package imports write-capable clients
@@ -2376,7 +2376,7 @@ Methods are Starlark procedures; Policies are named CEL expressions.
 2. Update `InitiateLien` to accept `InstrumentAmount` (any asset class)
 3. Update `InitiateLien` response to include `valued_amount` and `basis`
 4. Update `ExecuteDeposit` to perform atomic valuation
-5. Wire up valuation library in service initialization
+5. Wire up valuation library in service initialisation
 6. Add Position Keeping client for projected balance AND reservation RPCs
 7. Implement valuation in `InitiateLien` handler (price lock)
 8. **CRITICAL:** Call `position_keeping.RecordReservation()` after creating lien
@@ -2480,12 +2480,12 @@ Methods are Starlark procedures; Policies are named CEL expressions.
 - TOU tariff applies different rates based on time bands
 - All asset types (energy, carbon, compute) have working methods
 
-### Stream 8: Performance Optimization (P2, 3 points)
+### Stream 8: Performance Optimisation (P2, 3 points)
 
 **Tasks:**
 
 1. Profile valuation execution paths
-2. Optimize cache key generation
+2. Optimise cache key generation
 3. Add connection pooling for Reference Data client
 4. Tune cache sizes and TTLs
 5. Implement event-driven cache invalidation (Kafka subscriber for `method.updated` events)
@@ -2630,7 +2630,7 @@ ALTER TABLE account_positions
 - Policy cost estimation (reject > 10,000)
 - Starlark script parsing and execution
 - `run_policy()` builtin resolution and invocation
-- No-Inline-Math enforcement (`cel_eval` rejection)
+- No-Inline-Maths enforcement (`cel_eval` rejection)
 - Cache hit/miss logic (L1 only - methods and policies)
 - Method validation (including `required_policies` check)
 - Dimension Guard enforcement
@@ -2661,7 +2661,7 @@ ALTER TABLE account_positions
 
 ## 8. Success Metrics
 
-1. **Zero Hardcoded Rates:** All conversion math moves to named Policies by end of Stream 7.
+1. **Zero Hardcoded Rates:** All conversion maths moves to named Policies by end of Stream 7.
 2. **Replay Parity:** Replaying a valuation from 1 year ago using `knowledge_at` produces the exact
    same result (±1 basis point).
 3. **Performance:** 95th percentile valuation latency < 8ms under normal load.
@@ -2689,7 +2689,7 @@ ALTER TABLE account_positions
 ValuationFeatures reference methods by `valuation_method_id`. When multiple versions exist, the
 system resolves to the **latest non-deprecated version** unless the feature explicitly pins a version.
 
-| Scenario | Behavior |
+| Scenario | Behaviour |
 |----------|----------|
 | New method version deployed | Existing features auto-upgrade to latest |
 | Method deprecated (`deprecated_at < now`) | New valuations REJECTED, bi-temporal replay allowed |
@@ -2713,7 +2713,7 @@ to the old version continue using old logic until explicitly migrated.
 - `method.deprecated` event → P3 alert, 7-day countdown to removal
 - `method.removed` event → P2 alert if any features still reference it
 
-**Deprecated Method Behavior:**
+**Deprecated Method Behaviour:**
 
 ```go
 func (s *Service) GetValuationMethod(ctx context.Context, id uuid.UUID) (*ValuationMethod, error) {
@@ -2814,7 +2814,7 @@ to be reproduced exactly.
 | **Latency** | 12-17ms (estimated) | 5-8ms (measured goal) |
 | **Story Points** | 68 points | 75 points (+10% for TOCTOU safety) |
 | **Operational Complexity** | New microservice to deploy/monitor | Reuses existing services |
-| **Domain Modeling** | External service | Account capability |
+| **Domain Modelling** | External service | Account capability |
 | **Dependency Graph** | Saga → Account → Valuation → ... | Saga → Account → ... |
 | **Cache Strategy** | L1 + L2 Redis (complex) | L1 only (simple) |
 | **Failure Modes** | Valuation service down = all accounts blocked | Account service down = only that account blocked |
@@ -2825,7 +2825,7 @@ additional complexity buys: (1) Atomic valuation with price lock eliminating TOC
 (3) Graceful degradation and resilience features (v2.3), (4) Architecture guards and idempotency (v2.5).
 These are not optional features—they're required for correctness under concurrent load.
 
-**Key insight:** Valuation is a **behavior** of the Account aggregate, not a separate Bounded Context.
+**Key insight:** Valuation is a **behaviour** of the Account aggregate, not a separate Bounded Context.
 
 ### Architecture Decision Rationale
 
@@ -2844,7 +2844,7 @@ The embedded library approach follows the same pattern as:
 
 ## 13. Appendix: Example ValuationMethods
 
-**Note:** All examples use `run_policy()` for calculations. No inline math or `cel_eval()`.
+**Note:** All examples use `run_policy()` for calculations. No inline maths or `cel_eval()`.
 
 ### A. Identity Method (Fiat Currency)
 
@@ -2964,14 +2964,14 @@ def valuate(input_quantity, params, knowledge_at):
 # ❌ WRONG: Inline CEL expression string
 final_rate = cel_eval("spot * coeff * markup", {...})
 
-# ❌ WRONG: Math directly in Starlark
+# ❌ WRONG: Maths directly in Starlark
 output_amount = input_quantity.amount * tariff_rate
 
 # ❌ WRONG: Complex formula in Starlark
 vat_amount = base_amount * Decimal("0.20")
 total = base_amount + vat_amount
 
-# ✅ CORRECT: All math via named policies
+# ✅ CORRECT: All maths via named policies
 final_rate = run_policy("energy_rate_calc", {...})
 output_amount = run_policy("SYSTEM_FIXED_RATE", {"amount": qty, "rate": final_rate})
 vat_amount = run_policy("SYSTEM_UK_VAT_STANDARD", {"amount": base_amount})
@@ -3021,11 +3021,11 @@ Semantic API Practitioner Guide V8.1 and BIAN Service Landscape 12.0.
 **Justification:**
 
 1. **Performance:** Eliminates network hop (3 hops vs 4)
-2. **Domain Modeling:** Valuation is behavior of Account aggregate, not external service
+2. **Domain Modelling:** Valuation is behaviour of Account aggregate, not external service
 3. **Operational Simplicity:** No additional microservice to deploy/monitor
 4. **Bounded Context:** Account knows its own ValuationFeature, currency, and state
 
-**BIAN Compatibility:** The embedded approach respects BIAN principles while optimizing for
+**BIAN Compatibility:** The embedded approach respects BIAN principles while optimising for
 performance. The valuation capability could be exposed as a separate service domain if needed
 for cross-cutting concerns.
 
@@ -3038,7 +3038,7 @@ This PRD now uses BIAN-standard terminology throughout:
 | `EvaluateAssetValuation` | ✅ | BIAN "Evaluate" action term |
 | `ValuationAnalysis` | ✅ | BIAN analysis record pattern |
 | `ValuationMethod` | ✅ | BIAN algorithmic method |
-| `ValuationFeature` | ✅ | BIAN Behavior Qualifier |
+| `ValuationFeature` | ✅ | BIAN Behaviour Qualifier |
 | Lien Status: ACTIVE | ✅ | BIAN Lifecycle: Active |
 | Lien Status: EXECUTED | ✅ | BIAN Lifecycle: Fulfilled |
 | Lien Status: TERMINATED | ✅ | BIAN Lifecycle: Terminated |
@@ -3052,7 +3052,7 @@ This PRD now uses BIAN-standard terminology throughout:
 ---
 
 **Architectural Philosophy:** This PRD implements the "Probe Pattern" - accounts are queried for value,
-not commanded to use a centralized pricing service. It's "Particular" (logic is account-scoped) yet
+not commanded to use a centralised pricing service. It's "Particular" (logic is account-scoped) yet
 "Universal" (all accounts implement the same interface).
 
 **Next Steps:** Parse PRD into Task Master (`valuation-engine` tag) and begin with Stream 1

--- a/docs/prd/012-codebase-health-audit.md
+++ b/docs/prd/012-codebase-health-audit.md
@@ -5,7 +5,7 @@
 This PRD defines remediation work identified during a comprehensive codebase
 scan covering project structure, Go code quality, CI/CD configuration,
 documentation consistency, and security posture. Findings are organized into
-parallel work streams to maximize concurrent execution.
+parallel work streams to maximise concurrent execution.
 
 ## Goals
 
@@ -18,7 +18,7 @@ parallel work streams to maximize concurrent execution.
 ## Non-Goals
 
 - New feature development
-- Performance optimization or benchmarking
+- Performance optimisation or benchmarking
 - Withdrawal persistence (covered in prd-technical-debt-remediation.md)
 - Idempotency gap fixes (covered in prd-technical-debt-remediation.md)
 - ADR-0013/0014/0017 implementation (separate PRDs)
@@ -157,7 +157,7 @@ Vulnerability-introducing PRs pass CI without image scanning.
 **Acceptance Criteria**:
 
 1. Trivy scan runs on PR builds (at minimum as non-blocking warning)
-2. Existing non-PR scanning behavior unchanged
+2. Existing non-PR scanning behaviour unchanged
 3. PR build time increase is reasonable (< 2 min added)
 
 ---
@@ -428,7 +428,7 @@ exists. Deployment knowledge is locked in people.
 
 1. Step-by-step production deployment procedure documented
 2. Infrastructure prerequisites listed (CockroachDB, Kafka, Redis, Keycloak)
-3. Database initialization and migration procedures
+3. Database initialisation and migration procedures
 4. Service startup order and health check verification
 5. Rollback procedure documented
 

--- a/docs/prd/013-reconciliation-service.md
+++ b/docs/prd/013-reconciliation-service.md
@@ -45,7 +45,7 @@ instructions: |
 |---------------|-------------------|-----------|
 | Reconciliation Service | **Account Reconciliation** | Canonical BIAN Service Domain |
 | Settlement Run | **AccountReconciliationProcedure** | Control Record (CR) for reconciliation lifecycle |
-| Variance | **ReconciliationResult** | Behavior Qualifier capturing detected differences |
+| Variance | **ReconciliationResult** | Behaviour Qualifier capturing detected differences |
 | Settlement Snapshot | **SettlementCapture** | BQ capturing position state at settlement time |
 | Dispute | **ReconciliationDispute** | BQ for post-finality corrections |
 | Adjustment Entry | **ReconciliationAdjustment** | BQ for financial corrections |
@@ -79,7 +79,7 @@ for a specific asset type and settlement period.
 | ReconciliationAdjustment | Output | Financial correction generated from a variance |
 | SettlementCapture | Working Data | Point-in-time snapshot of measurement state |
 
-### Behavior Qualifiers
+### Behaviour Qualifiers
 
 | BQ | Lifecycle | Description |
 |----|-----------|-------------|
@@ -225,7 +225,7 @@ The reconciliation service provides the **detective control** that catches these
 | **Variance Valuation** | Price the delta using the tariff at the original period |
 | **Adjustment Orchestration** | Trigger `reconciliation_adjustment` Starlark saga for variance adjustment booking |
 | **Settlement Finality** | Request position locking in Position Keeping after final run |
-| **Dispute Management** | Handle corrections for locked (finalized) positions |
+| **Dispute Management** | Handle corrections for locked (finalised) positions |
 | **Run Scheduling** | Cron-based execution of settlement runs per asset type |
 | **Cross-Account Balance Assertions** | Verify system-wide debit/credit balance per instrument |
 
@@ -340,7 +340,7 @@ const (
 )
 ```
 
-### 4.2 Settlement Snapshot (Behavior Qualifier)
+### 4.2 Settlement Snapshot (Behaviour Qualifier)
 
 ```go
 // SettlementSnapshot captures the measurement state at settlement time.
@@ -369,7 +369,7 @@ const (
 )
 ```
 
-### 4.3 Variance (Behavior Qualifier)
+### 4.3 Variance (Behaviour Qualifier)
 
 ```go
 // Variance records a detected difference between settled and current positions.
@@ -426,10 +426,10 @@ const (
 )
 ```
 
-### 4.4 Dispute (Behavior Qualifier)
+### 4.4 Dispute (Behaviour Qualifier)
 
 ```go
-// Dispute represents a correction request for a locked (finalized) position.
+// Dispute represents a correction request for a locked (finalised) position.
 type Dispute struct {
     ID                    uuid.UUID
     AccountID             uuid.UUID
@@ -535,7 +535,7 @@ material variance, trigger the `reconciliation_adjustment` Starlark saga
 (fetched from Reference Data) to orchestrate adjustment booking via
 Payment Order.
 
-#### Step 5: Finalize (COMPLETED to FINALIZED, final runs only)
+#### Step 5: Finalise (COMPLETED to FINALIZED, final runs only)
 
 For the final settlement run (e.g., M+14 for energy), request Position Keeping
 to lock all positions in the window. After locking, any new data for these
@@ -714,7 +714,7 @@ CREATE UNIQUE INDEX idx_settlement_runs_unique_period
     ON settlement_runs(asset_code, run_type, period_start, period_end)
     WHERE status != 'FAILED';
 
--- Settlement Snapshots (Behavior Qualifier)
+-- Settlement Snapshots (Behaviour Qualifier)
 CREATE TABLE settlement_snapshots (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     settlement_run_id UUID NOT NULL REFERENCES settlement_runs(id),
@@ -737,7 +737,7 @@ CREATE INDEX idx_snapshots_run ON settlement_snapshots(settlement_run_id);
 CREATE INDEX idx_snapshots_account_period
     ON settlement_snapshots(account_id, asset_code, period_start, period_end);
 
--- Variances (Behavior Qualifier)
+-- Variances (Behaviour Qualifier)
 CREATE TABLE variances (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     settlement_run_id UUID NOT NULL REFERENCES settlement_runs(id),
@@ -769,7 +769,7 @@ CREATE TABLE variances (
 CREATE INDEX idx_variances_run ON variances(settlement_run_id);
 CREATE INDEX idx_variances_account ON variances(account_id, asset_code);
 
--- Disputes (Behavior Qualifier)
+-- Disputes (Behaviour Qualifier)
 CREATE TABLE disputes (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     account_id UUID NOT NULL,
@@ -925,7 +925,7 @@ message BalanceImbalanceDetectedEvent {
 | Event | Source | Action |
 |-------|--------|--------|
 | `TransactionPosted` | Position Keeping | Potential trigger for on-demand reconciliation |
-| `MeasurementSuperseded` | Position Keeping | Mark related snapshots as stale (optimization hint) |
+| `MeasurementSuperseded` | Position Keeping | Mark related snapshots as stale (optimisation hint) |
 
 ## 10. Handler Schema Extension
 
@@ -1034,8 +1034,8 @@ def reconciliation_adjustment(ctx):
             posting_type = "reconciliation_credit",
         ))
 
-    # Step 4: Finalize booking
-    step("finalize",
+    # Step 4: Finalise booking
+    step("finalise",
         financial_accounting.update_booking_log(
             booking_log_id = booking["booking_log_id"],
             status = "POSTED",
@@ -1058,7 +1058,7 @@ by the Starlark runner with compensation handled automatically
 | 3 | Proto + gRPC service | 5 | Stream 2 | Proto definitions, service stubs, client library, Starlark handler bindings (`client/starlark.go`) |
 | 4 | Settlement snapshot capture | 8 | Stream 3 | Query PK for measurements (cursor-paginated), create snapshots in chunks |
 | 5 | Variance detection + valuation | 8 | Stream 4 | Compare snapshots to current, price deltas |
-| 6 | Settlement finality + position locking | 5 | Stream 5 | Request PK to lock positions, finalize runs |
+| 6 | Settlement finality + position locking | 5 | Stream 5 | Request PK to lock positions, finalise runs |
 | 7 | Dispute workflow | 8 | Stream 3 | Create/resolve disputes, publish events |
 | 8 | Run scheduler (worker) | 5 | Stream 5 | Cron-based settlement run scheduling |
 | 9 | Balance assertions | 5 | Stream 3 | Cross-account debit/credit verification |
@@ -1234,7 +1234,7 @@ Token validation follows the platform-standard middleware: extract
 JWT from `Authorization` header, verify signature against JWKS
 endpoint, validate `tenant_id` claim matches request context.
 
-### 16.2 Authorization
+### 16.2 Authorisation
 
 | Operation | Allowed Actors |
 |-----------|---------------|
@@ -1243,7 +1243,7 @@ endpoint, validate `tenant_id` claim matches request context.
 | Resolve dispute | Tenant admin (with audit trail) |
 | Execute balance assertion (`POSITION_LEDGER`) | Service account, Tenant admin |
 | Execute balance assertion (`CROSS_ACCOUNT`) | Service account, System admin, Auditor |
-| Lock positions (finalize) | Settlement service account only |
+| Lock positions (finalise) | Settlement service account only |
 
 **CROSS_ACCOUNT restriction:** `ScopeCrossAccount` balance assertions
 may aggregate data across parties within a tenant. Per the Party
@@ -1294,7 +1294,7 @@ enforce coarse ingress limits as an additional layer.
 
 | # | Question | Impact | Decision Needed By | Blocker? |
 |---|----------|--------|-------------------|----------|
-| 1 | Should balance assertions run per-tenant or platform-wide? | Data model (tenant scoping), authorization, query complexity for Stream 9 | PRD review | Yes - affects schema design |
+| 1 | Should balance assertions run per-tenant or platform-wide? | Data model (tenant scoping), authorisation, query complexity for Stream 9 | PRD review | Yes - affects schema design |
 | 2 | Do we need a dedicated Dispute Resolution UI or is CLI sufficient for MVP? | Stream 7 scope | Phase 3 | No |
 | 3 | Should reconciliation results be exposed through Gateway to external consumers? | API surface, security boundaries, authentication model for Stream 3 | PRD review | Yes - affects proto design |
 | 4 | How do we handle reconciliation for cross-tenant transfers (e.g., inter-company energy settlement)? | Multi-tenant settlement assumptions, data isolation model | PRD review | Yes - affects data model |
@@ -1312,7 +1312,7 @@ where practical.
 | Meridian Implementation | BIAN Standard Term | Notes |
 |------------------------|--------------------|-------|
 | `SettlementRun` | `AccountReconciliationProcedure` | Control Record (CR) |
-| `SettlementSnapshot` | `SettlementCapture` | Behavior Qualifier (BQ) - working data |
+| `SettlementSnapshot` | `SettlementCapture` | Behaviour Qualifier (BQ) - working data |
 | `Variance` | `ReconciliationResult` | BQ - detected difference |
 | `Dispute` | `ReconciliationDispute` | BQ - post-finality correction |
 | `BalanceAssertion` | `BalanceAssertion` | BQ - cross-account verification |

--- a/docs/prd/014-control-plane.md
+++ b/docs/prd/014-control-plane.md
@@ -56,7 +56,7 @@ way to generate it.
 | **Usage Metering** | `services/utilization-metering-consumer/` | Transforms audit events into measurements |
 | **RBAC** | `shared/platform/auth/rbac.go` | Roles (admin, operator, auditor, service), permissions |
 | **API Gateway** | `services/gateway/` | Subdomain routing, JWT auth, rate limiting |
-| **Party Service** | `services/party/` | Organization/party registration (customers) |
+| **Party Service** | `services/party/` | Organisation/party registration (customers) |
 | **Causation Tree** | `api/proto/meridian/saga/v1/saga_admin.proto` | GetCausationTree RPC for audit trails |
 | **Dry-Run Validation** | Reference Data, Position Keeping | Validate before commit |
 | **tenantctl CLI** | `cmd/tenantctl/` | Register, list, get, deprovision tenants |
@@ -429,7 +429,7 @@ sequenceDiagram
     participant Cache
     participant TenantDB as org_{id}.api_keys
 
-    Client->>Gateway: Authorization: pk_motive_a8b9c...
+    Client->>Gateway: Authorisation: pk_motive_a8b9c...
     Gateway->>Gateway: Parse prefix → slug "motive"
     Gateway->>Cache: Resolve slug → tenant_id
     Cache-->>Gateway: tenant_id = "motive"
@@ -439,7 +439,7 @@ sequenceDiagram
     Gateway-->>Client: 200 OK (tenant context set)
 ```
 
-This achieves O(1) routing without a centralized secrets table.
+This achieves O(1) routing without a centralised secrets table.
 
 **Human Login Routing**: API keys self-route via prefix, but human
 login via Auth0/Keycloak only provides an email — no tenant context.
@@ -958,7 +958,7 @@ flowchart LR
 |------|-------------|------------|
 | **8.1** | Set up onboarding web app | 3 |
 | **8.2** | Implement email verification | 2 |
-| **8.3** | Build organization setup step | 1 |
+| **8.3** | Build organisation setup step | 1 |
 | **8.4** | Build plan selection with Stripe Checkout | 3 |
 | **8.5** | Implement provisioning progress view | 2 |
 | **8.6** | Add welcome email with getting started | 2 |

--- a/docs/prd/014-control-plane.md
+++ b/docs/prd/014-control-plane.md
@@ -429,7 +429,7 @@ sequenceDiagram
     participant Cache
     participant TenantDB as org_{id}.api_keys
 
-    Client->>Gateway: Authorisation: pk_motive_a8b9c...
+    Client->>Gateway: Authorization: pk_motive_a8b9c...
     Gateway->>Gateway: Parse prefix → slug "motive"
     Gateway->>Cache: Resolve slug → tenant_id
     Cache-->>Gateway: tenant_id = "motive"

--- a/docs/prd/018-current-account-withdrawal-persistence.md
+++ b/docs/prd/018-current-account-withdrawal-persistence.md
@@ -118,7 +118,7 @@ graph TD
     G --> I[Financial Accounting]
 ```
 
-### Handler Behavior
+### Handler Behaviour
 
 #### ExecuteWithdrawal (`grpc_withdrawal_execute.go`)
 
@@ -260,6 +260,6 @@ already exists. The gap is the database migration and test coverage.
 - **Low risk**: Repository code already exists and is wired. The gaps are the
   database migration and removing dead-code nil guards.
 - **No breaking changes**: Adding a table is an additive operation.
-- **Graceful degradation preserved**: If migration is not applied, the nil guard behavior continues (no worse than today).
+- **Graceful degradation preserved**: If migration is not applied, the nil guard behaviour continues (no worse than today).
 
 <!-- End of PRD -->

--- a/docs/prd/019-internal-bank-account-position-keeping-client.md
+++ b/docs/prd/019-internal-bank-account-position-keeping-client.md
@@ -78,7 +78,7 @@ type PositionKeepingClient interface {
 **2. gRPC Client Adapter** (`adapters/grpc/position_keeping_client.go`):
 
 Full implementation with DNS-based service discovery, round-robin load balancing,
-retry logic with exponential backoff, correlation ID and organization context
+retry logic with exponential backoff, correlation ID and organisation context
 propagation, and observability metrics. 305 lines of production-ready code.
 
 **3. Main Wiring** (`cmd/main.go:301-323`):
@@ -217,7 +217,7 @@ test coverage.
 ### Error Scenarios
 
 - Position Keeping returns `NotFound` (no position for account/instrument)
-- Position Keeping is temporarily unavailable (verify retry behavior)
+- Position Keeping is temporarily unavailable (verify retry behaviour)
 - Position Keeping returns no `BALANCE_TYPE_CURRENT` entry
 
 ---

--- a/docs/prd/020-party-kyc-aml-provider-integration.md
+++ b/docs/prd/020-party-kyc-aml-provider-integration.md
@@ -63,9 +63,9 @@ without external provider integration"
 
 **Severity:** Medium - By design. This is an intentional production safety guard, not a bug.
 
-### Current Behavior Matrix
+### Current Behaviour Matrix
 
-| Environment | `KYC_STUB_ENABLED` | Behavior |
+| Environment | `KYC_STUB_ENABLED` | Behaviour |
 |-------------|-------------------|----------|
 | production | unset / false | `codes.Unimplemented` - refuses to auto-approve |
 | production | true | Returns VERIFIED (stub) with warning log |

--- a/docs/prd/022-org-scoped-accounts.md
+++ b/docs/prd/022-org-scoped-accounts.md
@@ -4,14 +4,14 @@ description: Multi-party resource pooling following BIAN Syndicate Pattern
 triggers:
   - Implementing syndicate or group betting features
   - Building multi-party pooled account structures
-  - Tracking member positions within organizations
+  - Tracking member positions within organisations
   - Implementing revenue sharing or profit distribution
   - Building marketplace or platform models with sub-entities
   - Any scenario requiring "Alice's balance within Org X"
 instructions: |
   This PRD extends the Account and Party models to support organizational scoping.
-  Key concept: An account can be owned by a Party AND scoped to an Organization
-  (another Party). This enables proper normalized tracking of member positions
+  Key concept: An account can be owned by a Party AND scoped to an Organisation
+  (another Party). This enables proper normalised tracking of member positions
   within groups/syndicates. Follows double-entry principles: every balance is
   stored, not calculated from metadata. Builds on existing Party associations
   but adds metadata for governance/rules.
@@ -74,11 +74,11 @@ This feature implements the **Syndicated Loan** and
 This PRD extends Meridian to support **Consortium Financial Management**.
 By implementing BIAN's **Syndicate Pattern**, we enable accounts to be owned
 by one Party (the Participant) while being operationally scoped to an
-Organization (the Syndicate).
+Organisation (the Syndicate).
 
 ### Core Capabilities
 
-1. **Normalized Scoping:** Explicit `org_party_id` on accounts to track
+1. **Normalised Scoping:** Explicit `org_party_id` on accounts to track
    "Participant balance *within* Syndicate."
 2. **Governance Metadata:** Enhanced `PartyAssociation` to store
    "Structuring" data (equity share, roles).
@@ -113,7 +113,7 @@ the most volume receive no cost benefit for doing so.
 
 Dynamic platforms solve this with **volume-based fee tiers**, but
 hard-coding tiers into application logic creates maintenance burden
-and prevents tenant-level customization. CEL valuation policies
+and prevents tenant-level customisation. CEL valuation policies
 (ADR-0028) allow fee rules to be expressed as evaluable expressions
 that respond to syndicate metrics at runtime.
 
@@ -235,7 +235,7 @@ WHERE org_party_id IS NOT NULL;
 
 > **Architecture Note:** Internal accounts use schema-per-tenant
 > isolation (`org_{tenant_id}` schema routing). The `org_party_id`
-> here represents a *sub-organization within a tenant* (e.g., a
+> here represents a *sub-organisation within a tenant* (e.g., a
 > syndicate within a betting platform tenant), not the tenant itself.
 > Tenant isolation remains at the schema level.
 >

--- a/docs/prd/023-product-directory.md
+++ b/docs/prd/023-product-directory.md
@@ -1,11 +1,11 @@
 ---
 name: prd-product-directory
-description: BIAN-aligned AccountTypeRegistry for runtime-configurable product catalog within Reference Data
+description: BIAN-aligned AccountTypeRegistry for runtime-configurable product catalogue within Reference Data
 triggers:
   - Working on account types or product types
   - Adding new account types to the system
   - Configuring product-specific business logic (Starlark sagas, CEL validation per product)
-  - Multi-tenant product catalog or blueprint configuration
+  - Multi-tenant product catalogue or blueprint configuration
   - Questions about the relationship between accounts and product types
   - Valuation method or conversion configuration per product type
   - BIAN Product Directory service domain
@@ -24,7 +24,7 @@ instructions: |
   Multi-tenancy: schema-per-tenant (no tenant_id column), isolation via GORM tenant scope.
 ---
 
-# Product Directory - Account Type Registry and Runtime-Configurable Product Catalog
+# Product Directory - Account Type Registry and Runtime-Configurable Product Catalogue
 
 ## Status: Not Started
 
@@ -35,7 +35,7 @@ with no single source of truth. Account types are hardcoded as proto enums,
 preventing tenants from defining custom account types at runtime. This PRD
 introduces an AccountTypeRegistry within the Reference Data service -- following
 the established InstrumentRegistry pattern -- to provide a runtime-configurable,
-BIAN-aligned product catalog that supports multi-tenant customization
+BIAN-aligned product catalogue that supports multi-tenant customisation
 and bi-temporal versioning. Product types also define accepted valuation
 methods (asset conversion rules), correcting the current design where
 ValuationFeatures are configured per-account rather than per-product-type.
@@ -74,7 +74,7 @@ column hardcoded to `"current"` with no validation against any registry.
 
 ### Existing Infrastructure (Already Built)
 
-The infrastructure needed for a product catalog largely exists:
+The infrastructure needed for a product catalogue largely exists:
 
 | Capability | Location | Status |
 |------------|----------|--------|
@@ -103,20 +103,20 @@ separations, not deployment mandates. The Product Directory maps to a
 **module within Reference Data**, consistent with how instruments, sagas,
 and nodes already coexist within Reference Data.
 
-### Behavior Qualifier Mapping
+### Behaviour Qualifier Mapping
 
 | BIAN BQ | Meridian Mapping | Implementation |
 |---------|------------------|----------------|
 | **Operations** | CEL policy evaluation, saga routing | Existing CEL compiler + saga naming convention |
 | **Servicing** | AccountTypeRegistry CRUD + lifecycle | New (follows InstrumentRegistry pattern) |
 | **Production** | Manifest compilation and application | Existing manifest applier + validation pipeline |
-| **SalesAndMarketing** | Product catalog browsing and discovery | New read-only projections from registry |
+| **SalesAndMarketing** | Product catalogue browsing and discovery | New read-only projections from registry |
 
 ### Separation of Concerns
 
 BIAN Product Directory stores metadata about products, not executable code. Meridian follows this separation:
 
-- **Product catalog** (AccountTypeRegistry): Stores metadata, CEL policies,
+- **Product catalogue** (AccountTypeRegistry): Stores metadata, CEL policies,
   designated instrument, default saga names. Consistent with how
   InstrumentRegistry stores CEL validation expressions.
 - **Saga registry** (existing): Stores executable Starlark scripts.
@@ -141,7 +141,7 @@ type AccountTypeDefinition struct {
     DisplayName            string        // "GBP Personal Current Account"
     Description            string        // Detailed description of this product type
     NormalBalance          NormalBalance  // DEBIT or CREDIT (typed enum)
-    BehaviorClass          BehaviorClass // Fixed system behavior category (typed enum)
+    BehaviorClass          BehaviorClass // Fixed system behaviour category (typed enum)
     InstrumentCode         string        // Designated instrument: "GBP", "KWH", "TONNE_CO2E"
     DefaultSagaPrefix      string        // e.g., "SAVINGS" for "{prefix}.deposit" routing
     DefaultConversionMethodID      *uuid.UUID // Default same-dimension conversion method
@@ -198,7 +198,7 @@ type ValuationMethodTemplate struct {
 }
 ```
 
-**BehaviorClass** is a fixed set of system behavior categories that
+**BehaviorClass** is a fixed set of system behaviour categories that
 services use to apply hard-coded constraints. The dynamic `Code`
 (e.g., `CLEARING_GBP`) is the user-facing product identifier, but
 the system needs `BehaviorClass = "CLEARING"` to know that
@@ -206,7 +206,7 @@ org-scoping is forbidden, or `BehaviorClass = "CUSTOMER"` to enable
 party association. This replaces the role currently played by the
 `InternalAccountType` enum.
 
-| BehaviorClass | System Behavior |
+| BehaviorClass | System Behaviour |
 |---------------|-----------------|
 | `CUSTOMER` | Party-scoped, eligibility checks, external-facing |
 | `CLEARING` | Global (no org-scoping), settlement operations |
@@ -218,7 +218,7 @@ party association. This replaces the role currently played by the
 | `EXPENSE` | P&L tracking, debit normal balance |
 | `INVENTORY` | Non-cash asset tracking (energy, commodities) |
 
-New behavior classes can be added by extending the CHECK constraint
+New behaviour classes can be added by extending the CHECK constraint
 in a migration, but this is deliberately a platform-level change
 (not tenant-configurable) because it maps to hard-coded service
 logic.
@@ -243,7 +243,7 @@ type AccountTypeRegistry interface {
     ValidateTransaction(ctx context.Context, code string, version int, attrs AttributeBag) (ValidationResult, error)
     CheckEligibility(ctx context.Context, code string, version int, attrs AttributeBag) (ValidationResult, error)
 
-    // SalesAndMarketing BQ -- Catalog browsing
+    // SalesAndMarketing BQ -- Catalogue browsing
     ListByInstrument(ctx context.Context, instrumentCode string) ([]*AccountTypeDefinition, error)
     GetProductFeatures(ctx context.Context, code string, version int) (map[string]any, error)
 }
@@ -370,7 +370,7 @@ Example: Product type `SAVINGS` with `default_saga_prefix = "SAVINGS"`:
 
 - Deposit operation resolves: `SAVINGS.deposit` (tenant) -> `SAVINGS.deposit` (platform) -> **error** (no fallback)
 
-### Multi-Tenant Product Catalogs
+### Multi-Tenant Product Catalogues
 
 Following the saga registry pattern (platform defaults + tenant overrides):
 
@@ -865,7 +865,7 @@ Both services use `BehaviorClass` to gate which product types they
 accept:
 
 - **CurrentAccount**: Only accepts `BehaviorClass == CUSTOMER`
-- **InternalAccount**: Accepts all non-CUSTOMER behavior classes
+- **InternalAccount**: Accepts all non-CUSTOMER behaviour classes
 
 This replaces the hardcoded enum with a dynamic check that works for
 any product type code, including tenant-defined ones. A tenant can
@@ -1007,7 +1007,7 @@ func (s Status) IsValid() bool {
     return false
 }
 
-// BehaviorClass represents a fixed system behavior category.
+// BehaviorClass represents a fixed system behaviour category.
 type BehaviorClass string
 
 const (
@@ -1048,7 +1048,7 @@ All `switch` statements on `Status`, `BehaviorClass`, and
 or panics in tests. This is enforced by code review until the linter
 supports string-based exhaustive checks.
 
-#### Case Normalization
+#### Case Normalisation
 
 All `Code`, `BehaviorClass`, `NormalBalance`, and `InstrumentCode`
 values are stored in uppercase. The domain constructor normalises
@@ -1078,7 +1078,7 @@ BehaviorClass behavior_class = 6 [(buf.validate.field).enum = {
 ```
 
 This guarantees that gRPC callers cannot send an unrecognised
-behavior class. The existing pattern is proven in
+behaviour class. The existing pattern is proven in
 `internal_account.proto::InternalAccountType`.
 
 ### Immutability Invariants
@@ -1102,7 +1102,7 @@ creation, even in DRAFT status:
 
 - `Code` -- immutable primary key (like instrument code)
 - `IsSystem` -- platform blueprints cannot be reclassified
-- `BehaviorClass` -- changing system behavior category after creation
+- `BehaviorClass` -- changing system behaviour category after creation
   would invalidate all accounts created under the old category
 
 Attempted modification returns `ErrFieldImmutable` with the field
@@ -1214,7 +1214,7 @@ variables are not present.
 Attempting to compile a CEL expression that references an
 undeclared variable (e.g., `party.type` in a `ValidationCEL`
 field) returns a compilation error, not a runtime error. This is
-the same behavior as the existing CEL compiler in
+the same behaviour as the existing CEL compiler in
 `services/reference-data/cel/compiler.go`.
 
 ### Concrete Bugs This Design Prevents
@@ -1224,7 +1224,7 @@ codebase that the AccountTypeRegistry eliminates:
 
 | Bug | Current Cause | How Registry Prevents It |
 |-----|---------------|--------------------------|
-| Case mismatch (`"current"` vs `"CURRENT"`) | Current account stores lowercase, IBA stores uppercase | Case normalization at domain layer |
+| Case mismatch (`"current"` vs `"CURRENT"`) | Current account stores lowercase, IBA stores uppercase | Case normalisation at domain layer |
 | No account type validation at creation | `InitiateCurrentAccount` accepts any string | Registry lookup at creation, reject unknown codes |
 | Hardcoded `ACCOUNT_TYPE_CURRENT` in saga handlers | `saga_handlers.go:467` uses proto enum constant | Registry-based lookup replaces hardcoded value |
 | AccountResolver divergence | Copy-pasted 3x across services with different safety checks | Single source of truth in registry |
@@ -1236,7 +1236,7 @@ codebase that the AccountTypeRegistry eliminates:
 ## Testing Strategy
 
 - **Unit tests**: Domain model validation (typed enums, case
-  normalization, immutability guards, write-once fields), lifecycle
+  normalisation, immutability guards, write-once fields), lifecycle
   transitions (including idempotent activation), CEL compilation
   (validation, bucketing, eligibility environments -- including
   cross-environment variable rejection), attribute schema validation,

--- a/docs/prd/024-structured-inbound-mapping.md
+++ b/docs/prd/024-structured-inbound-mapping.md
@@ -232,7 +232,7 @@ Most transforms are naturally reversible:
 For the one non-reversible transform (CEL), we provide explicit
 `inbound_cel` and `outbound_cel` fields. This means **one mapping
 definition handles both directions** — no duplicate definitions, no
-pairing logic, no version synchronization problem.
+pairing logic, no version synchronisation problem.
 
 ### Routing Strategy
 

--- a/docs/prd/025-real-time-event-streaming.md
+++ b/docs/prd/025-real-time-event-streaming.md
@@ -277,14 +277,14 @@ These are the existing topics — no new topics needed:
 ```
 
 > **Note**: Topics marked RENAME or ADD VERSION show the target state
-> after the standardization in Section 14. Current topic names are
+> after the standardisation in Section 14. Current topic names are
 > documented there.
 
 **Consumer group strategy**: The `ops-console-events` consumer group is
 separate from all existing service consumers. It can be scaled
 independently, and lag does not affect business operations.
 
-**Prerequisite**: Section 14 defines a topic naming standardization
+**Prerequisite**: Section 14 defines a topic naming standardisation
 that must be completed before or alongside Phase 2. Once
 standardized, all topics follow `service-name.event-name.v1` and
 channel derivation is trivial (strip `.v1` suffix).
@@ -374,7 +374,7 @@ using JSON messages.
 }
 ```
 
-**Channel namespace**: After topic naming standardization
+**Channel namespace**: After topic naming standardisation
 (Section 14), all topics follow `service-name.event-name.v1`.
 Channels are derived by stripping the `.v1` suffix:
 
@@ -536,7 +536,7 @@ The `useEventStream` hook should treat `BUFFER_OVERFLOW` as a
 trigger to re-fetch current state via REST, ensuring the UI
 self-heals without manual refresh.
 
-### 4.8 Authorization & Role-Based Channel Access
+### 4.8 Authorisation & Role-Based Channel Access
 
 Channel access is controlled by JWT roles. These are new role
 definitions to be added to the auth system:
@@ -575,7 +575,7 @@ services/gateway/
 │   ├── connection_test.go
 │   ├── protocol.go           # JSON message types
 │   ├── protocol_test.go
-│   ├── channel.go            # Normalization + glob matching
+│   ├── channel.go            # Normalisation + glob matching
 │   └── channel_test.go
 ├── eventstream/adapters/
 │   ├── kafka_source.go       # KafkaEventSource adapter
@@ -636,7 +636,7 @@ mux.HandleFunc("GET /ws/events", wsHandler.ServeHTTP)
 - WebSocket upgrade handler integrated into gateway `http.ServeMux`
 - Connection manager with tenant-partitioned registry
 - Subscription protocol (subscribe/unsubscribe/event messages)
-- Channel normalization and glob matching
+- Channel normalisation and glob matching
 - Ping/pong keepalive and JWT expiry checking
 - Unit tests for connection lifecycle, tenant isolation, channel
   matching
@@ -650,7 +650,7 @@ mux.HandleFunc("GET /ws/events", wsHandler.ServeHTTP)
 
 ### Phase 2: Kafka Event Source
 
-**Prerequisite:** Kafka topic naming standardization (Section 14)
+**Prerequisite:** Kafka topic naming standardisation (Section 14)
 must be completed first or in parallel.
 
 **Deliverables:**
@@ -658,9 +658,9 @@ must be completed first or in parallel.
 - `KafkaEventSource` adapter consuming all domain event topics
 - Dedicated consumer group (`ops-console-events`)
 - Tenant extraction from Kafka headers (`x-tenant-id`)
-- Protobuf to JSON serialization via `protojson`
-- Channel derivation (strip `.v1` suffix — no normalization needed
-  after standardization)
+- Protobuf to JSON serialisation via `protojson`
+- Channel derivation (strip `.v1` suffix — no normalisation needed
+  after standardisation)
 - Backpressure handling (buffer + drop policy)
 - Metrics: events consumed, delivered, dropped, active connections
 
@@ -702,7 +702,7 @@ the domain-specific payload:
 interface StreamEvent {
   type: "event";
   subscription_id: string;
-  channel: string; // normalized channel name
+  channel: string; // normalised channel name
   event: {
     event_id: string; // UUID
     event_type: string; // e.g., "payment_order.reserved.v1"
@@ -772,7 +772,7 @@ Consistent with ADR-0008 (Defensive Testing Standards):
 
 | Layer | What | How |
 |-------|------|-----|
-| Unit | Channel normalization + glob | Table-driven tests |
+| Unit | Channel normalisation + glob | Table-driven tests |
 | Unit | Subscription filter engine | Property-based tests |
 | Unit | Tenant isolation in registry | Verify no cross-tenant leak |
 | Unit | Backpressure / buffer overflow | Simulate slow client |
@@ -846,7 +846,7 @@ No new infrastructure, databases, or message brokers.
 
 ---
 
-## 14. Prerequisite: Kafka Topic Naming Standardization
+## 14. Prerequisite: Kafka Topic Naming Standardisation
 
 ### Problem
 
@@ -876,7 +876,7 @@ Additionally, infrastructure topics lack version suffixes:
 
 ### Why Fix at Source
 
-Downstream normalization (regex in the event stream module) creates
+Downstream normalisation (regex in the event stream module) creates
 cognitive overhead: developers must remember that topic names and
 channel names are different, debugging requires mentally mapping
 between two naming schemes, and every new topic risks introducing
@@ -885,7 +885,7 @@ yet another convention.
 Fixing at source means:
 
 - Topic name = channel name (minus `.v1`) — zero mental overhead
-- No normalization code to maintain or test
+- No normalisation code to maintain or test
 - Consistent `grep`-ability across the entire codebase
 - New services naturally follow the convention
 
@@ -923,6 +923,6 @@ number of consumers, each rename is a 1-2 point task.
 | Saga default topic | `shared/pkg/saga/step_execution.go` | 1 point |
 | **Total** | | **8 points** |
 
-This standardization should be completed before or alongside Phase 2
+This standardisation should be completed before or alongside Phase 2
 of the event streaming implementation. It can be parallelized — each
 service rename is independent.

--- a/docs/prd/026-operations-console-ui.md
+++ b/docs/prd/026-operations-console-ui.md
@@ -37,7 +37,7 @@ Every service exposes gRPC endpoints with full Vanguard JSON transcoding. The AP
 
 - **JWT claims:** `roles: ["admin"]` or `roles: ["operator"]`, `x-tenant-id: "org_acme_uuid"`
 - **Capabilities:** Manage their tenant's accounts, transactions, payments, positions, ledger, parties, reconciliation, and Starlark overrides
-- **Mental model:** "This is my application. I manage my organization's financial operations."
+- **Mental model:** "This is my application. I manage my organisation's financial operations."
 
 ### Tenant Auditor
 
@@ -145,12 +145,12 @@ Tenant Admin Flow:
 The gateway already handles this. A platform admin JWT (no `x-tenant-id` claim) can still reach tenant-scoped services by:
 
 1. Using the tenant's subdomain (`acme.api.meridian.io`) — the gateway's `TenantResolverMiddleware` resolves the subdomain to tenant ID
-2. The `TenantAuthorizationMiddleware` skips JWT tenant matching for platform-admin role (they are authorized for any tenant)
+2. The `TenantAuthorizationMiddleware` skips JWT tenant matching for platform-admin role (they are authorised for any tenant)
 3. The downstream service receives the tenant context via `x-tenant-id` header
 
 **Open item:** The current `TenantAuthorizationMiddleware` compares JWT `x-tenant-id` with resolved tenant and rejects mismatches. For platform admins (no `x-tenant-id` in JWT), this comparison is skipped when the role is `platform-admin` or `super-admin`. **Verify this skip logic exists in `combined_middleware.go` lines 195-271** — the codebase shows API keys bypass this check, but the platform-admin bypass for JWT needs confirmation.
 
-If the bypass doesn't exist yet, the gateway needs a small change: when JWT has `platform-admin` or `super-admin` role and no `x-tenant-id` claim, skip the tenant authorization check but still inject the resolved tenant into context.
+If the bypass doesn't exist yet, the gateway needs a small change: when JWT has `platform-admin` or `super-admin` role and no `x-tenant-id` claim, skip the tenant authorisation check but still inject the resolved tenant into context.
 
 #### Phase 0 Prerequisite: Platform Admin Gateway Bypass
 
@@ -160,11 +160,11 @@ allows JWTs with `platform-admin` or `super-admin` role and
 no `x-tenant-id` claim to pass through when accessing
 tenant-scoped services via subdomain.
 
-**Current behavior (verify):** API keys bypass the tenant
-authorization check. JWT-based access for platform admins
+**Current behaviour (verify):** API keys bypass the tenant
+authorisation check. JWT-based access for platform admins
 may not have the same bypass.
 
-**Required behavior:** When JWT has `platform-admin` or
+**Required behaviour:** When JWT has `platform-admin` or
 `super-admin` role AND no `x-tenant-id` claim, the
 middleware must:
 
@@ -288,7 +288,7 @@ admin's tenant list cache is preserved across switches.
 2. Redirect to identity provider (Keycloak, Auth0, etc.)
 3. OAuth 2.0 PKCE flow → receive JWT access token + refresh token
 4. Store tokens in memory (not localStorage — XSS risk)
-5. Connect-ES interceptor attaches Authorization header to all requests
+5. Connect-ES interceptor attaches Authorisation header to all requests
 6. On 401 response → attempt token refresh
 7. On refresh failure → redirect to login
 ```
@@ -306,7 +306,7 @@ performs the OAuth PKCE exchange and sets a secure,
 httpOnly, SameSite=Strict cookie. The Connect-ES transport
 sends this cookie automatically. The auth proxy is
 stateless — it validates the cookie and injects the
-Authorization header before proxying to the gateway.
+Authorisation header before proxying to the gateway.
 
 This does NOT violate the "no BFF" decision (Section 3.4)
 because it handles only authentication, not data
@@ -551,7 +551,7 @@ Directory pattern with 25 RPCs across 7 functional areas.
 
 - **List view:** DataTable of parties by party type. No
   `ListParties` RPC exists — the list view queries
-  `ListParticipants` scoped to the tenant's organization
+  `ListParticipants` scoped to the tenant's organisation
   party. Columns: Name, Party Type, Status, External
   Reference, Created. Filterable by party type and status.
 - **Detail view:** Party header (status badge, type,
@@ -581,10 +581,10 @@ Directory pattern with 25 RPCs across 7 functional areas.
 #### Party Types (Tenant Configuration)
 
 Party types define behavioral templates for parties,
-similar to how Account Types define account behavior.
+similar to how Account Types define account behaviour.
 
 - **List view:** DataTable of party types: Name, Category
-  (Individual/Organization), Status, Version.
+  (Individual/Organisation), Status, Version.
 - **Detail view:** Party type header with tabs:
   - **Definition:** Name, category, description,
     attribute schema (JSON Schema)
@@ -711,7 +711,7 @@ prominent inline hint: "Expression saved for audit trail.
 Assertions currently use strict equality (total debits ==
 total credits). Custom CEL evaluation is planned for a
 future release." This prevents operators from expecting
-their expressions to affect assertion behavior.
+their expressions to affect assertion behaviour.
 
 #### Design Note: Variance Detection
 
@@ -953,10 +953,10 @@ saga handles their transactions.
 **Layout:**
 
 - **List view:** DataTable with columns: Code, Display Name,
-  Behavior Class, Normal Balance, Instrument, Status, Version.
-  Filterable by behavior class and status.
+  Behaviour Class, Normal Balance, Instrument, Status, Version.
+  Filterable by behaviour class and status.
 - **Detail view:** Account type header with tabs:
-  - **Definition:** Code, display name, behavior class
+  - **Definition:** Code, display name, behaviour class
     (CUSTOMER, CLEARING, NOSTRO, VOSTRO, HOLDING, SUSPENSE,
     REVENUE, EXPENSE, INVENTORY), normal balance (DEBIT/CREDIT),
     instrument code, default saga prefix
@@ -1082,12 +1082,12 @@ COMPUTE, precision 6, validation `amount > 0`.
 **Step 2: Define the Account Type** (Reference Data page)
 
 Create an account type that uses the new instrument. Set
-behavior class, normal balance direction, CEL validation and
+behaviour class, normal balance direction, CEL validation and
 eligibility policies. Link valuation methods for cross-asset
 conversion.
 
 Example: Creating a `COMPUTE_INVENTORY` account type with
-behavior class INVENTORY, normal balance DEBIT, instrument
+behaviour class INVENTORY, normal balance DEBIT, instrument
 `GPU_HOUR`.
 
 **Step 3: Write the Starlark Saga** (Starlark Config page)
@@ -1139,7 +1139,7 @@ dialog. It carries meaningful implementation complexity:
 - Deep links between pages with pre-filled context (e.g.,
   "Create Account Type" pre-selects the instrument from
   Step 1)
-- State synchronization: when a user activates an
+- State synchronisation: when a user activates an
   instrument on the Instruments page, the checklist on the
   Starlark page must reflect this
 
@@ -1355,7 +1355,7 @@ The outer layout that implements the two-lens model.
 └──────────┴───────────────────────────────────────────────┘
 ```
 
-**Behavior:**
+**Behaviour:**
 
 - Reads JWT claims on mount to determine lens (platform vs tenant)
 - Platform admin: shows TenantSelector in header, shows Tenants/Platform nav items below separator
@@ -1414,7 +1414,7 @@ by default.
 
 ### 6.4 StatusBadge
 
-Renders status values with consistent color coding.
+Renders status values with consistent colour coding.
 
 **Loading state:** Show grey pill with shimmer animation
 when status data is loading.
@@ -1575,7 +1575,7 @@ type ErrorCategory =
 ```
 
 **Inline annotations:** Each error renders as a CodeMirror
-diagnostic at the exact line/column. Errors are color-coded
+diagnostic at the exact line/column. Errors are colour-coded
 by category (red for SYNTAX/RUNTIME, orange for TYPE_MISMATCH,
 yellow for UNDEFINED_HANDLER). Hovering shows the message and
 suggestion.
@@ -1593,9 +1593,9 @@ After validation, display `ComplexityMetrics` beside the editor:
 | Handler calls | Count badge (e.g., "7 handlers") |
 | Operations | Count (loops, conditionals, assignments) |
 | Est. duration | Milliseconds (e.g., "~70ms") |
-| Complexity | Score 0-10 with color indicator |
+| Complexity | Score 0-10 with colour indicator |
 
-Complexity score color: 0-3 green, 4-6 yellow, 7-10 red.
+Complexity score colour: 0-3 green, 4-6 yellow, 7-10 red.
 
 #### Handler Autocomplete
 
@@ -1628,7 +1628,7 @@ ESTIMATE → COEFFICIENT → ACTUAL → REVISED
   [○]         [◐]         [●]       [↻]
 ```
 
-Each level has a distinct icon and color, showing the data provenance chain.
+Each level has a distinct icon and colour, showing the data provenance chain.
 
 ### 6.10 SagaTimeline
 
@@ -1770,7 +1770,7 @@ React Query handles three states explicitly:
 **Dashboard resilience:** The dashboard fetches from 3+
 services in parallel. If one service is down, only that
 card shows an error state. Other cards render normally.
-This is the default React Query behavior — each query is
+This is the default React Query behaviour — each query is
 independent.
 
 **gRPC status code mapping:**
@@ -1917,7 +1917,7 @@ frontend/
 │   ├── lib/
 │   │   ├── auth.ts                 # JWT helpers, token storage
 │   │   ├── formatters.ts           # Money formatting, date formatting
-│   │   ├── query-keys.ts           # Centralized query key factory
+│   │   ├── query-keys.ts           # Centralised query key factory
 │   │   └── constants.ts            # Status maps, role definitions
 │   ├── contexts/
 │   │   ├── auth-context.tsx        # JWT claims, user info
@@ -2103,10 +2103,10 @@ by default. The following must be maintained, not broken:
   aria-live regions (e.g., "Payment order status changed
   to COMPLETED"). DataTable rows use proper role="row"
   and role="cell" semantics.
-- **Color independence:** StatusBadge uses both color AND
+- **Colour independence:** StatusBadge uses both colour AND
   text label. QualityLadderBadge uses icons alongside
-  colors. Error states use both red color and error icon.
-  No information conveyed by color alone.
+  colours. Error states use both red colour and error icon.
+  No information conveyed by colour alone.
 - **Focus indicators:** Visible focus rings on all
   interactive elements (Tailwind's ring utilities). Custom
   focus styles for StarlarkEditor and CELEditor (CodeMirror
@@ -2508,7 +2508,7 @@ surfaces.**
 
 ---
 
-## Appendix B: Event Catalog Summary
+## Appendix B: Event Catalogue Summary
 
 Events that drive real-time cache invalidation (Phase 4):
 

--- a/docs/prd/026-operations-console-ui.md
+++ b/docs/prd/026-operations-console-ui.md
@@ -288,7 +288,7 @@ admin's tenant list cache is preserved across switches.
 2. Redirect to identity provider (Keycloak, Auth0, etc.)
 3. OAuth 2.0 PKCE flow → receive JWT access token + refresh token
 4. Store tokens in memory (not localStorage — XSS risk)
-5. Connect-ES interceptor attaches Authorisation header to all requests
+5. Connect-ES interceptor attaches Authorization header to all requests
 6. On 401 response → attempt token refresh
 7. On refresh failure → redirect to login
 ```
@@ -306,7 +306,7 @@ performs the OAuth PKCE exchange and sets a secure,
 httpOnly, SameSite=Strict cookie. The Connect-ES transport
 sends this cookie automatically. The auth proxy is
 stateless — it validates the cookie and injects the
-Authorisation header before proxying to the gateway.
+Authorization header before proxying to the gateway.
 
 This does NOT violate the "no BFF" decision (Section 3.4)
 because it handles only authentication, not data

--- a/docs/prd/027-mcp-server.md
+++ b/docs/prd/027-mcp-server.md
@@ -1040,7 +1040,7 @@ sequenceDiagram
 
     Note over LLM,MCP: MCP config provides API key
     LLM->>MCP: Tool call (with API key in env)
-    MCP->>GW: gRPC call + Authorisation header
+    MCP->>GW: gRPC call + Authorization header
     GW->>CP: ValidateAPIKey RPC
     CP-->>GW: Tenant ID, permissions
     GW-->>MCP: Response (tenant-scoped)

--- a/docs/prd/027-mcp-server.md
+++ b/docs/prd/027-mcp-server.md
@@ -36,7 +36,7 @@ instructions: |
 - [1. Executive Summary](#1-executive-summary)
 - [2. The Junior Operator Principle](#2-the-junior-operator-principle)
 - [3. Functional Requirements](#3-functional-requirements)
-- [4. MCP Tool Catalog](#4-mcp-tool-catalog)
+- [4. MCP Tool Catalogue](#4-mcp-tool-catalogue)
 - [5. Technical Architecture](#5-technical-architecture)
 - [6. Safety Model](#6-safety-model)
 - [7. Authentication and Multi-Tenancy](#7-authentication-and-multi-tenancy)
@@ -67,12 +67,12 @@ because safety is enforced at the engine level, not the client level:
 
 - **CEL expressions** have cost limits and guaranteed termination
 - **Starlark scripts** cannot loop infinitely or recurse
-- **The immutable ledger** rejects invalid double-entry math
+- **The immutable ledger** rejects invalid double-entry maths
 - **Dry-run mode** executes the full pipeline with zero side effects
 - **Protovalidate constraints** reject malformed input before it reaches business logic
 
 The LLM cannot hallucinate a corrupt ledger state because the engine rejects
-invalid math or logic at compile time. This is the architectural prerequisite
+invalid maths or logic at compile time. This is the architectural prerequisite
 that makes an MCP server viable.
 
 ### The Market Insight
@@ -156,7 +156,7 @@ Predict outcomes without side effects.
 
 ### FR-4: Reference Data Tools
 
-Query the catalog of available definitions.
+Query the catalogue of available definitions.
 
 **FR-4.1**: Query market data (rates, prices) for instruments.
 **FR-4.2**: List and describe available saga handler schemas (what service methods exist).
@@ -174,7 +174,7 @@ MCP resources that provide context to the LLM without tool invocation.
 
 ---
 
-## 4. MCP Tool Catalog
+## 4. MCP Tool Catalogue
 
 ### 4.1 Economy Design Tools (Write Path)
 
@@ -958,7 +958,7 @@ that all tool handlers call before returning error responses.
 
 ## 6. Safety Model
 
-### 6.1 Defense in Depth
+### 6.1 Defence in Depth
 
 ```mermaid
 graph LR
@@ -984,7 +984,7 @@ graph LR
     subgraph "Layer 4: Engine"
         L4A["CEL cost limits (10,000)"]
         L4B["Starlark termination proof"]
-        L4C["Double-entry math correctness"]
+        L4C["Double-entry maths correctness"]
         L4D["Immutable ledger append-only"]
     end
 
@@ -1040,7 +1040,7 @@ sequenceDiagram
 
     Note over LLM,MCP: MCP config provides API key
     LLM->>MCP: Tool call (with API key in env)
-    MCP->>GW: gRPC call + Authorization header
+    MCP->>GW: gRPC call + Authorisation header
     GW->>CP: ValidateAPIKey RPC
     CP-->>GW: Tenant ID, permissions
     GW-->>MCP: Response (tenant-scoped)

--- a/docs/reports/cockroachdb-migration-audit.md
+++ b/docs/reports/cockroachdb-migration-audit.md
@@ -252,7 +252,7 @@ beyond basic equality on the `input_dataset_codes` and `required_policies` colum
 | party            | `VARCHAR(45)`                                           |
 | payment-order    | `VARCHAR(45)` (initial), then `INET` after fix migration|
 
-This is an internal inconsistency that would benefit from standardization, but is not a
+This is an internal inconsistency that would benefit from standardisation, but is not a
 compatibility blocker. Both `INET` and `VARCHAR(45)` work on both databases.
 
 ---
@@ -299,7 +299,7 @@ For PostgreSQL deployments, ensure:
 
 **Issue**: `CREATE OR REPLACE VIEW` is supported identically in both databases. However, `ORDER BY`
 in a view definition does not guarantee ordering when selecting from the view unless `ORDER BY` is
-repeated in the outer query. This behavior is consistent between CockroachDB and PostgreSQL — it is
+repeated in the outer query. This behaviour is consistent between CockroachDB and PostgreSQL — it is
 not a compatibility issue, but a documentation note.
 
 ---

--- a/docs/reports/market-information-integration.md
+++ b/docs/reports/market-information-integration.md
@@ -443,7 +443,7 @@ The client automatically propagates:
 
 - `x-tenant-id` - Tenant isolation
 - `x-correlation-id` - Distributed tracing
-- `x-organisation-id` - Organisation context
+- `x-organization-id` - Organisation context
 
 ### mTLS
 

--- a/docs/reports/market-information-integration.md
+++ b/docs/reports/market-information-integration.md
@@ -31,7 +31,7 @@ for consuming services.
 | Kubernetes DNS discovery | IMPLEMENTED | ServiceName-based connection |
 | Circuit breaker | IMPLEMENTED | Via `clients.ResilientClient` |
 | Retry with backoff | IMPLEMENTED | Configurable via `ResilientClientConfig` |
-| Context propagation | IMPLEMENTED | Tenant ID, Correlation ID, Organization |
+| Context propagation | IMPLEMENTED | Tenant ID, Correlation ID, Organisation |
 | Distributed tracing | IMPLEMENTED | Optional `observability.Tracer` support |
 
 ### Usage Examples
@@ -419,12 +419,12 @@ func (c *CachedMarketClient) GetRate(
 }
 ```
 
-### Batch Size Optimization
+### Batch Size Optimisation
 
 | Use Case | Recommended Batch Size | Rationale |
 |----------|----------------------|-----------|
 | Real-time ingestion | 100-500 | Balance latency and throughput |
-| Bulk historical load | 1000 | Maximize throughput |
+| Bulk historical load | 1000 | Maximise throughput |
 | ETL pipelines | 500-1000 | Depends on source system |
 
 ---
@@ -443,7 +443,7 @@ The client automatically propagates:
 
 - `x-tenant-id` - Tenant isolation
 - `x-correlation-id` - Distributed tracing
-- `x-organization-id` - Organization context
+- `x-organisation-id` - Organisation context
 
 ### mTLS
 

--- a/docs/reports/market-information-traceability.md
+++ b/docs/reports/market-information-traceability.md
@@ -95,7 +95,7 @@ identifies coverage status, and documents any gaps or edge cases requiring atten
 
 | Requirement ID | Target | Status | Validation Method | Notes |
 |----------------|--------|--------|-------------------|-------|
-| NFR-1.1 | Point-in-time query < 10ms p99 | NEEDS VALIDATION | NFR benchmark tests (to be created) | Bi-temporal index optimized |
+| NFR-1.1 | Point-in-time query < 10ms p99 | NEEDS VALIDATION | NFR benchmark tests (to be created) | Bi-temporal index optimised |
 | NFR-1.2 | Observation ingestion < 50ms p99 | NEEDS VALIDATION | NFR benchmark tests (to be created) | Single insert with supersession |
 | NFR-1.3 | Batch ingestion 1,000 obs/sec | NEEDS VALIDATION | NFR benchmark tests (to be created) | Parallel validation with 50 workers |
 
@@ -139,10 +139,10 @@ None identified. All P0 functional requirements are implemented.
 
 ### Edge Cases Not Covered
 
-| Edge Case | Description | Current Behavior | Recommendation |
+| Edge Case | Description | Current Behaviour | Recommendation |
 |-----------|-------------|------------------|----------------|
 | EC-001 | Concurrent supersession race | Last write wins | Add optimistic locking on supersession |
-| EC-002 | Dataset version mismatch in observations | Uses latest ACTIVE | Document expected behavior |
+| EC-002 | Dataset version mismatch in observations | Uses latest ACTIVE | Document expected behaviour |
 | EC-003 | Knowledge time in future | Query returns all known | Add validation to reject future knowledge times |
 | EC-004 | Empty observation_context with CEL | CEL may fail | Add graceful handling with empty map default |
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -50,7 +50,7 @@ Use runbooks when:
 
 - Responding to production incidents or outages
 - Performing operational procedures (migrations, updates, etc.)
-- Troubleshooting complex system behaviors
+- Troubleshooting complex system behaviours
 - Training new team members on operational procedures
 - Documenting resolution steps for recurring issues
 

--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -21,7 +21,7 @@ instructions: |
 **When to use this runbook**: Complete infrastructure failure, data corruption, regional outage, or catastrophic events
 requiring full system recovery.
 
-> **⚠️ Customization Note**: This is a template runbook for Meridian. In a production deployment, you should customize
+> **⚠️ Customisation Note**: This is a template runbook for Meridian. In a production deployment, you should customise
 this with your specific:
 >
 > - Backup locations and credentials
@@ -524,7 +524,7 @@ Action items:
 
 ## Emergency Contacts
 
-> **⚠️ Production Setup Required**: Add your organization's emergency contacts and escalation procedures
+> **⚠️ Production Setup Required**: Add your organisation's emergency contacts and escalation procedures
 
 | Role | Contact | Backup |
 |------|---------|--------|

--- a/docs/runbooks/incident-response.md
+++ b/docs/runbooks/incident-response.md
@@ -19,7 +19,7 @@ instructions: |
 
 **When to use this runbook**: Active security incident, service degradation, or production outage.
 
-> **⚠️ Customization Note**: This is a template runbook for Meridian. In a production deployment, you should customize
+> **⚠️ Customisation Note**: This is a template runbook for Meridian. In a production deployment, you should customise
 this with your specific:
 >
 > - Contact details and escalation paths
@@ -381,7 +381,7 @@ kubectl get all -n production -o yaml > production-backup.yaml
 
 ## Emergency Contacts
 
-> **⚠️ Production Setup Required**: Add your organization's emergency contacts
+> **⚠️ Production Setup Required**: Add your organisation's emergency contacts
 
 - **Security Hotline**: [Phone number]
 - **Infrastructure Team**: [Slack channel]

--- a/docs/runbooks/internal-account-operations.md
+++ b/docs/runbooks/internal-account-operations.md
@@ -175,7 +175,7 @@ grpcurl -plaintext \
   -d '{
     "account_id": "2gKVPLwqhSJPgQKX4L8tH3Rymkv",
     "control_action": "CONTROL_ACTION_CLOSE",
-    "reason": "Account no longer required - replaced by CLR-GBP-002. Authorized by operations manager"
+    "reason": "Account no longer required - replaced by CLR-GBP-002. Authorised by operations manager"
   }' \
   internal-account.production.svc.cluster.local:50057 \
   meridian.internal_account.v1.InternalAccountService/ControlInternalAccount

--- a/docs/runbooks/party-kyc-verification.md
+++ b/docs/runbooks/party-kyc-verification.md
@@ -8,7 +8,7 @@ triggers:
   - Investigating stuck PENDING verifications
   - Webhook signature validation errors
   - High manual review rate from Onfido
-  - Timeout handler behavior questions
+  - Timeout handler behaviour questions
   - Force-updating a verification status
 instructions: |
   Use this runbook for KYC/AML verification operations in the Party service.

--- a/docs/runbooks/production-deployment.md
+++ b/docs/runbooks/production-deployment.md
@@ -20,7 +20,7 @@ instructions: |
 **When to use this runbook**: Initial production deployment, new environment provisioning, major version upgrades,
 or re-deployment after disaster recovery.
 
-> **Customization Note**: This guide documents Meridian's architecture and deployment order. You must customize
+> **Customisation Note**: This guide documents Meridian's architecture and deployment order. You must customise
 infrastructure details (cloud provider, DNS, TLS certificates, backup locations) for your specific environment.
 
 ## 1. Infrastructure Prerequisites
@@ -165,7 +165,7 @@ Keycloak provides OAuth 2.0 / OpenID Connect authentication.
 1. Create realm: `meridian`
 2. Create client: `meridian-service` (confidential, service account enabled)
 3. Configure JWKS endpoint: `https://<keycloak-host>/realms/meridian/protocol/openid-connect/certs`
-4. Define roles and scopes per your authorization requirements
+4. Define roles and scopes per your authorisation requirements
 
 ### 1.5 Kubernetes Cluster
 

--- a/docs/runbooks/saga-validation-failure.md
+++ b/docs/runbooks/saga-validation-failure.md
@@ -184,7 +184,7 @@ kubectl get events -n meridian --sort-by='.lastTimestamp' | head -20
 2. If pods are healthy but endpoints fail, check gRPC routing
 3. Restart the service: `kubectl rollout restart deployment/reference-data -n meridian`
 
-### Runtime initialization failure
+### Runtime initialisation failure
 
 **Symptoms**: Validation returns internal errors mentioning "runtime" or "timeout".
 

--- a/docs/runbooks/troubleshooting-saga-handlers.md
+++ b/docs/runbooks/troubleshooting-saga-handlers.md
@@ -9,7 +9,7 @@ execution errors related to service integration.
 |------------|---------|-----------|------------|
 | **Handler Not Found** | `handler not found: service.operation` | Check registration in main.go | Verify handler exists before script deployment |
 | **Invalid Parameter Type** | `expected string, got int64` | Fix Starlark script params | Use schema validation |
-| **Nil Client Panic** | `panic: nil pointer dereference` | Check client initialization order | Add nil checks in handlers |
+| **Nil Client Panic** | `panic: nil pointer dereference` | Check client initialisation order | Add nil checks in handlers |
 | **Metadata Validation Failure** | `handler produced EUR but declared USD` | Fix ProducesInstruments | Follow Conservation Rule |
 | **gRPC Timeout** | `context deadline exceeded` | Check service health | Increase timeout or fix service |
 | **Idempotency Key Collision** | `duplicate idempotency key` | Check saga replay logic | Verify key uniqueness |
@@ -121,12 +121,12 @@ level=ERROR msg="panic in handler" handler=position_keeping.initiate_log
 
 - gRPC client not initialized before RegisterStarlarkHandlers call
 - Client cleanup called before saga execution
-- Race condition in client initialization
+- Race condition in client initialisation
 
 **Solution:**
 
 ```bash
-# 1. Check service initialization order in main.go
+# 1. Check service initialisation order in main.go
 # CORRECT ORDER:
 # a) Initialize all gRPC clients
 # b) Create handler registry
@@ -210,7 +210,7 @@ if currency != "USD" && currency != "GBP" {
 
 **Prevention:**
 
-- Add integration test that verifies metadata matches actual behavior
+- Add integration test that verifies metadata matches actual behaviour
 - Code review checklist: ProducesInstruments matches handler implementation
 - Use linter to detect metadata/implementation mismatches
 
@@ -314,7 +314,7 @@ psql -d meridian -c "
 # Check prepareClientContext in starlark.go
 
 # 4. If saga genuinely stuck, manually advance
-# ⚠️ WARNING: Only perform this in emergencies with proper authorization
+# ⚠️ WARNING: Only perform this in emergencies with proper authorisation
 # Take a backup before proceeding:
 pg_dump -d meridian -t saga_instances -t step_results > saga_backup_$(date +%Y%m%d_%H%M%S).sql
 

--- a/docs/saga-service-catalogue.md
+++ b/docs/saga-service-catalogue.md
@@ -1,4 +1,4 @@
-# Saga Service Catalog
+# Saga Service Catalogue
 
 This document provides a reference for all saga handlers available in the Meridian platform.
 

--- a/docs/services/party/verification-guide.md
+++ b/docs/services/party/verification-guide.md
@@ -320,7 +320,7 @@ unchanged.
 a `version` column for optimistic locking.
 `UpdateVerificationStatus` requires the current version and
 increments it. Concurrent updates to the same verification will
-fail with a conflict, which is the intended behavior to prevent
+fail with a conflict, which is the intended behaviour to prevent
 race conditions between webhook delivery and timeout handler.
 
 **Webhook max body size**: The handler limits request body reads to

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -89,7 +89,7 @@ Service documentation includes YAML frontmatter for Claude Code discovery:
 **Shared Modules:**
 
 - **[migrations](../../shared/migrations/README.md)** - Database migrations
-- **[bootstrap](../../shared/platform/bootstrap/README.md)** - Service initialization
+- **[bootstrap](../../shared/platform/bootstrap/README.md)** - Service initialisation
 - **[audit](../../shared/platform/audit/README.md)** - Audit hook helpers
 - **[observability](../../shared/platform/observability/README.md)** - OpenTelemetry tracing
 

--- a/docs/skills/docker.md
+++ b/docs/skills/docker.md
@@ -15,7 +15,7 @@ instructions: |
 
 # Docker Configuration
 
-This document describes the Docker setup for Meridian, optimized for production deployments.
+This document describes the Docker setup for Meridian, optimised for production deployments.
 
 ## Overview
 
@@ -88,7 +88,7 @@ docker build \
 
 - **Layer caching**: Go modules downloaded before source code
 - **Static linking**: CGO_ENABLED=0 for fully static binaries
-- **Size optimization**: `-ldflags="-w -s"` strips debug info
+- **Size optimisation**: `-ldflags="-w -s"` strips debug info
 - **.dockerignore**: Excludes unnecessary files from build context
 
 ## Running Containers

--- a/docs/skills/kustomize.md
+++ b/docs/skills/kustomize.md
@@ -41,7 +41,7 @@ deployments/k8s/
 
 ### Development (dev)
 
-Optimized for local development with minimal resource usage:
+Optimised for local development with minimal resource usage:
 
 - **Replicas**: 1 (single instance)
 - **Resources**:
@@ -155,7 +155,7 @@ diff <(kubectl kustomize deployments/k8s/overlays/staging) \
      <(kubectl kustomize deployments/k8s/overlays/production)
 ```
 
-## Customization Patterns
+## Customisation Patterns
 
 ### Adding Environment-Specific Configuration
 
@@ -237,7 +237,7 @@ patches:
       value: "custom-value"
 ```
 
-### ConfigMap Customization
+### ConfigMap Customisation
 
 Each environment merges ConfigMap values with the base configuration:
 
@@ -246,7 +246,7 @@ configMapGenerator:
 
 - name: meridian-config
 
-  behavior: merge
+  behaviour: merge
   literals:
 
   - log_level=debug
@@ -254,7 +254,7 @@ configMapGenerator:
 
 ```
 
-The `behavior: merge` ensures base configuration is preserved while adding/overriding specific values.
+The `behaviour: merge` ensures base configuration is preserved while adding/overriding specific values.
 
 ## CI/CD Integration
 
@@ -356,14 +356,14 @@ kubectl get all -n production
 
 ### ConfigMap Merge Not Working
 
-Ensure `behavior: merge` is set in the overlay's configMapGenerator:
+Ensure `behaviour: merge` is set in the overlay's configMapGenerator:
 
 ```yaml
 configMapGenerator:
 
 - name: meridian-config
 
-  behavior: merge  # Required for merging with base
+  behaviour: merge  # Required for merging with base
   literals:
 
   - key=value

--- a/docs/skills/kustomize.md
+++ b/docs/skills/kustomize.md
@@ -246,7 +246,7 @@ configMapGenerator:
 
 - name: meridian-config
 
-  behaviour: merge
+  behavior: merge
   literals:
 
   - log_level=debug
@@ -254,7 +254,7 @@ configMapGenerator:
 
 ```
 
-The `behaviour: merge` ensures base configuration is preserved while adding/overriding specific values.
+The `behavior: merge` ensures base configuration is preserved while adding/overriding specific values.
 
 ## CI/CD Integration
 
@@ -356,14 +356,14 @@ kubectl get all -n production
 
 ### ConfigMap Merge Not Working
 
-Ensure `behaviour: merge` is set in the overlay's configMapGenerator:
+Ensure `behavior: merge` is set in the overlay's configMapGenerator:
 
 ```yaml
 configMapGenerator:
 
 - name: meridian-config
 
-  behaviour: merge  # Required for merging with base
+  behavior: merge  # Required for merging with base
   literals:
 
   - key=value

--- a/docs/skills/schema-evolution.md
+++ b/docs/skills/schema-evolution.md
@@ -14,9 +14,9 @@ triggers:
 
 instructions: |
   Follow ADR-0004 for protobuf native versioning. Use Pattern 1 (add optional fields) for
-  backward-compatible changes. Use Pattern 2 (new event type) for new BIAN behavior qualifiers.
+  backward-compatible changes. Use Pattern 2 (new event type) for new BIAN behaviour qualifiers.
   Run 'make proto-breaking' before commit. Pre-commit hooks enforce validation automatically.
-  New BIAN behaviors = new event types, not schema modifications.
+  New BIAN behaviours = new event types, not schema modifications.
 ---
 
 # Schema Evolution Developer Guide
@@ -56,7 +56,7 @@ Protobuf schemas need evolution when:
 
 - **BIAN specification updates** (13.0 → 14.0 adds new fields or operations)
 - **New domain requirements** (additional metadata for observability)
-- **New event types** (new BIAN behavior qualifiers)
+- **New event types** (new BIAN behaviour qualifiers)
 - **Field additions** (enriching existing events with optional data)
 
 ## Decision Tree
@@ -64,7 +64,7 @@ Protobuf schemas need evolution when:
 ```text
 Need to change a proto schema?
 │
-├─ Is this a NEW operation/behavior?
+├─ Is this a NEW operation/behaviour?
 │  └─ YES → Create new event type (Pattern 2)
 │
 ├─ Is this ADDITIONAL optional data?
@@ -146,7 +146,7 @@ git commit -m "feat: Add correlation_id and causation_id to AccountUpdated event
 
 ### What Happens
 
-- **Old consumers**: Ignore new fields (protobuf default behavior)
+- **Old consumers**: Ignore new fields (protobuf default behaviour)
 - **New consumers**: Can read new fields (will be empty in old events)
 - **CI/CD**: `buf breaking` passes ✅
 - **No coordination needed**: Deploy producers and consumers independently
@@ -170,7 +170,7 @@ message AccountUpdated {
   string account_status = 4;
 }
 
-// New event for new BIAN behavior qualifier
+// New event for new BIAN behaviour qualifier
 message AccountSuspended {
   // Event metadata
   string event_id = 1;
@@ -225,7 +225,7 @@ git commit -m "feat: Add AccountSuspended event for BIAN 14.0 Suspend operation"
 ### Topic Strategy
 
 - **One topic per event type**: `account-suspended` (not `account-updated-v2`)
-- **Semantic names**: Reflect BIAN behavior qualifiers
+- **Semantic names**: Reflect BIAN behaviour qualifiers
 - **No version suffixes**: Use new event types instead of versioning topics
 - **7-day retention**: Events are coordination, not source of truth
 
@@ -410,7 +410,7 @@ message AccountUpdated {
 
 **Impact**: None. Optional field, backward compatible.
 
-### Scenario 3: BIAN Adds New Behavior Qualifier
+### Scenario 3: BIAN Adds New Behaviour Qualifier
 
 **Goal**: BIAN 14.0 adds "Freeze" operation distinct from "Suspend".
 
@@ -610,7 +610,7 @@ on:
 ### ✅ DO
 
 - **Add optional fields** for backward-compatible changes
-- **Create new event types** for new BIAN behaviors
+- **Create new event types** for new BIAN behaviours
 - **Run `make proto-breaking`** before every commit
 - **Use semantic event names** aligned with BIAN
 - **Document schema changes** in commit messages

--- a/docs/skills/security.md
+++ b/docs/skills/security.md
@@ -19,7 +19,7 @@ instructions: |
 This document outlines the security measures implemented in Meridian to ensure production-grade security and compliance.
 
 > **⚠️ Note for Learning Environment**: This is a comprehensive security architecture guide for the Meridian learning
-project. When deploying to production, you should customize the following with your organization's specific details:
+project. When deploying to production, you should customise the following with your organisation's specific details:
 >
 > - Contact information and escalation procedures
 > - Monitoring and alerting integrations
@@ -41,7 +41,7 @@ project. When deploying to production, you should customize the following with y
 
 ## Security Principles
 
-Meridian follows defense-in-depth security principles:
+Meridian follows defence-in-depth security principles:
 
 1. **Least Privilege**: Minimal permissions at every layer
 2. **Secure by Default**: Security features enabled out-of-the-box
@@ -218,10 +218,10 @@ strategy:
 - **External APIs**: API keys stored in Kubernetes Secrets
 - **Monitoring**: Datadog agent authentication
 
-### Authorization
+### Authorisation
 
 - **RBAC**: Least-privilege roles for Kubernetes access
-- **API Authorization**: Role-based access in application layer (future)
+- **API Authorisation**: Role-based access in application layer (future)
 
 ### Audit Logging
 
@@ -326,7 +326,7 @@ data:
 
 ### Contact Information
 
-> **⚠️ Production Setup Required**: Configure with your organization's actual contact details
+> **⚠️ Production Setup Required**: Configure with your organisation's actual contact details
 
 - **Security Team**: `security@your-domain.com`
 - **On-Call**: [PagerDuty rotation or on-call schedule]
@@ -352,7 +352,7 @@ Meridian is designed to meet:
 All security-relevant events are logged:
 
 - Authentication attempts
-- Authorization failures
+- Authorisation failures
 - Secret access
 - Configuration changes
 - Network policy violations

--- a/docs/skills/starlark-saga.md
+++ b/docs/skills/starlark-saga.md
@@ -268,8 +268,8 @@ def execute_operation():
     result = service2.process(amount=amount)
 
     # Step 3
-    step(name="finalise")
-    final = service3.finalise(result_id=result.id)
+    step(name="finalize")
+    final = service3.finalize(result_id=result.id)
 
     return {
         "status": "COMPLETED",

--- a/docs/skills/starlark-saga.md
+++ b/docs/skills/starlark-saga.md
@@ -268,8 +268,8 @@ def execute_operation():
     result = service2.process(amount=amount)
 
     # Step 3
-    step(name="finalize")
-    final = service3.finalize(result_id=result.id)
+    step(name="finalise")
+    final = service3.finalise(result_id=result.id)
 
     return {
         "status": "COMPLETED",
@@ -583,6 +583,6 @@ return {
 ## Further Reading
 
 - **[Starlark Style Guide](../guides/starlark-style-guide.md)** - Comprehensive syntax and conventions
-- **[Saga Service Catalog](../saga-service-catalog.md)** - Service module documentation
+- **[Saga Service Catalogue](../saga-service-catalogue.md)** - Service module documentation
 - **[handlers.yaml](../saga-handlers.schema.json)** - Available handlers schema
 - **[ADR-0028: Starlark Saga & CEL Valuation](../adr/0028-starlark-saga-cel-valuation.md)** - Architecture decision

--- a/docs/skills/testing.md
+++ b/docs/skills/testing.md
@@ -259,7 +259,7 @@ func TestConcurrentOperations(t *testing.T) {
 
 ## Mocking Guidelines
 
-Minimize mocking. Prefer real implementations where practical:
+Minimise mocking. Prefer real implementations where practical:
 
 1. **Use testcontainers** for database tests (real PostgreSQL)
 2. **Use in-memory implementations** for simple interfaces
@@ -283,7 +283,7 @@ client := new(MockClient)
 client.On("Send", mock.Anything, expectedMsg).Return(nil)
 ```
 
-## Test Organization
+## Test Organisation
 
 ```text
 service/

--- a/docs/skills/tilt.md
+++ b/docs/skills/tilt.md
@@ -405,7 +405,7 @@ tilt up
 
 The Tiltfile will automatically validate that the registry exists and provide helpful error messages if it's not found.
 
-## Performance Optimization
+## Performance Optimisation
 
 ### Fast Rebuilds
 
@@ -544,7 +544,7 @@ This is useful for integration testing in CI pipelines.
 ### Related Skills
 
 - [Schema Evolution](./schema-evolution.md) - Protobuf schema evolution and buf validation
-- [Docker Configuration](./docker.md) - Multi-stage builds and container optimization
+- [Docker Configuration](./docker.md) - Multi-stage builds and container optimisation
 - [Kustomize Deployments](./kustomize.md) - Environment-specific configurations
 - [Security Scanning](./security.md) - Vulnerability detection in images
 

--- a/docs/testing/CHAOS_TESTING.md
+++ b/docs/testing/CHAOS_TESTING.md
@@ -5,14 +5,14 @@
 
 ## Overview
 
-Chaos testing validates system resilience by intentionally injecting failures and verifying recovery behavior. This
+Chaos testing validates system resilience by intentionally injecting failures and verifying recovery behaviour. This
 document outlines the chaos testing strategy for the position-keeping service.
 
 ## Objectives
 
 1. **Validate Resilience**: Verify system handles failures gracefully
 2. **Identify Weaknesses**: Discover failure modes before production
-3. **Document Behavior**: Establish expected recovery patterns
+3. **Document Behaviour**: Establish expected recovery patterns
 4. **Prevent Regressions**: Automated tests catch resilience issues
 
 ## Chaos Scenarios
@@ -279,7 +279,7 @@ func TestChaos_DatabaseConnectionLoss(t *testing.T) {
 
 **Use Case**: Network partition testing (Phase 3)
 
-## Test Organization
+## Test Organisation
 
 ### Directory Structure
 
@@ -368,7 +368,7 @@ package repository
    - `InjectNetworkLatency(tc *TestContainer, latencyMs int)`
 
 1. **Document Runbooks**: Operational guidance
-   - Expected behavior during failures
+   - Expected behaviour during failures
    - Recovery procedures
    - Monitoring and alerting setup
 

--- a/docs/testing/COVERAGE_ANALYSIS.md
+++ b/docs/testing/COVERAGE_ANALYSIS.md
@@ -68,7 +68,7 @@ in normal operation.
 - Single operations: 0.58-1.4ms (well under 20ms target)
 - Query performance: 0.58-0.71ms
 - Concurrent operations: 0.10-0.17ms
-- Throughput: 2,060 txn/sec (identified optimization opportunity)
+- Throughput: 2,060 txn/sec (identified optimisation opportunity)
 
 **Analysis**: Repository layer has excellent integration test coverage using testcontainers. All major database
 operations are tested with real PostgreSQL, ensuring reliable data persistence.
@@ -115,7 +115,7 @@ with room for improvement in error handling paths.
 
 ### Application Layer: 75.5% ✅
 
-**Status**: Good coverage of configuration and initialization
+**Status**: Good coverage of configuration and initialisation
 
 **Covered Components**:
 
@@ -127,17 +127,17 @@ with room for improvement in error handling paths.
 **Coverage Gaps**:
 
 ```text
-NewContainer                      44.4%  (initialization code)
+NewContainer                      44.4%  (initialisation code)
 initializeTracer                  23.1%  (observability setup)
-initializeDatabase                70.6%  (connection initialization)
-initializeEventPublisher          0.0%   (Kafka initialization)
+initializeDatabase                70.6%  (connection initialisation)
+initializeEventPublisher          0.0%   (Kafka initialisation)
 initializeRepositories            0.0%   (factory methods)
 ```
 
-**Analysis**: Infrastructure initialization code has lower coverage, which is acceptable as these are primarily
+**Analysis**: Infrastructure initialisation code has lower coverage, which is acceptable as these are primarily
 wiring/setup code paths that are validated through integration tests.
 
-## Test Organization
+## Test Organisation
 
 ### Test Suites
 
@@ -178,7 +178,7 @@ wiring/setup code paths that are validated through integration tests.
 **Benefits**:
 
 - Isolated test environments per test
-- Real database behavior validation
+- Real database behaviour validation
 - Fast startup (1-2 seconds)
 - Parallel test execution support
 
@@ -230,7 +230,7 @@ go test -short -v -race -coverprofile=coverage.out -covermode=atomic ./...
 
 ### Priority 2: Infrastructure Testing
 
-1. **Application Container Initialization** (Currently 44.4%)
+1. **Application Container Initialisation** (Currently 44.4%)
    - Dependency injection testing
    - Configuration validation
    - **Impact**: Low - primarily wiring code
@@ -292,7 +292,7 @@ go test -short -v -race -coverprofile=coverage.out -covermode=atomic ./...
 
 1. **Load Testing**
    - Sustained load scenarios
-   - Throughput optimization (10,000+ txn/sec goal)
+   - Throughput optimisation (10,000+ txn/sec goal)
    - Concurrent user simulation
 
 1. **Service Error Coverage**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,7 +52,7 @@ Generates Mermaid diagram syntax from the coupling analysis JSON.
 - Proto dependencies (solid arrows, green)
 - Platform coupling (dashed arrows, yellow)
 - Cross-service violations (thick arrows, red)
-- Color-coded service nodes by violation severity
+- Colour-coded service nodes by violation severity
 - HTML comment with analysis summary
 
 **Exit codes:**
@@ -114,7 +114,7 @@ Validates that the Mermaid generation script produces correct output.
 
 ## Mermaid Diagram Legend
 
-**Node Colors:**
+**Node Colours:**
 
 - 🟢 **Green** (Safe) - Services with only proto dependencies
 - 🟡 **Yellow** (Warning) - Services using internal/platform packages

--- a/services/README.md
+++ b/services/README.md
@@ -602,10 +602,10 @@ go build -o tenantctl ./cmd/tenantctl
 
 **Demo Provisioning:**
 
-The `scripts/demo-provision-organisations.sh` script provisions demo tenants for local development:
+The `scripts/demo-provision-organizations.sh` script provisions demo tenants for local development:
 
 ```bash
-./scripts/demo-provision-organisations.sh
+./scripts/demo-provision-organizations.sh
 ```
 
 This creates: `meridian`, `post_office`, `motive`, `un_wfp`

--- a/services/README.md
+++ b/services/README.md
@@ -188,7 +188,7 @@ Event-driven communication for eventual consistency:
 **Configuration:**
 
 - Default broker: `kafka:9092`
-- Serialization: Protocol Buffers
+- Serialisation: Protocol Buffers
 - Partition key: `AggregateID` (ensures ordering per entity)
 
 ### HTTP (External Webhooks)
@@ -320,7 +320,7 @@ See [ADR-0009](../docs/adr/0009-application-level-audit-logging.md) for architec
    - **Fallback**: Write to `audit_outbox` table → audit-worker → `audit_log` table
 4. **Kafka Topics**: Per-service audit event topics (e.g., `audit.events.current-account`)
 5. **Audit Consumers**: One Kafka consumer deployment per service (auto-scaling 2-20 replicas)
-6. **Audit Worker**: Centralized service processes outbox entries when Kafka unavailable
+6. **Audit Worker**: Centralised service processes outbox entries when Kafka unavailable
 
 **Key Guarantees:**
 
@@ -378,7 +378,7 @@ See [services/reference-data/README.md](reference-data/README.md) for full docum
 
 ### Utilization Metering Consumer
 
-The Utilization Metering Consumer is a centralized Kafka consumer for platform billing.
+The Utilization Metering Consumer is a centralised Kafka consumer for platform billing.
 
 **Responsibilities:**
 
@@ -432,7 +432,7 @@ strategies with market data from the Market Information service.
 **Responsibilities:**
 
 - **Strategy Management**: DRAFT/ACTIVE/DEPRECATED lifecycle for forecast strategies
-- **Starlark Execution**: Sandboxed script execution with built-in math functions
+- **Starlark Execution**: Sandboxed script execution with built-in maths functions
 - **Scheduled Runs**: Cron-based execution with lease management for distributed safety
 - **Template Library**: Pre-built strategies (moving average, linear regression, etc.)
 
@@ -448,7 +448,7 @@ Stripe billing integration, and administrative operations.
 - **Manifest Management**: Declarative tenant configuration with diff/apply workflow
 - **Stripe Integration**: Payment processing, webhook handling, reconciliation
 - **Admin Operations**: Balance sheet queries, causation tree visualization, CSV exports
-- **Staff Identity**: Internal operator authentication and authorization
+- **Staff Identity**: Internal operator authentication and authorisation
 
 See [services/control-plane/README.md](control-plane/README.md) for full documentation.
 
@@ -602,10 +602,10 @@ go build -o tenantctl ./cmd/tenantctl
 
 **Demo Provisioning:**
 
-The `scripts/demo-provision-organizations.sh` script provisions demo tenants for local development:
+The `scripts/demo-provision-organisations.sh` script provisions demo tenants for local development:
 
 ```bash
-./scripts/demo-provision-organizations.sh
+./scripts/demo-provision-organisations.sh
 ```
 
 This creates: `meridian`, `post_office`, `motive`, `un_wfp`

--- a/services/current-account/README.md
+++ b/services/current-account/README.md
@@ -368,7 +368,7 @@ Key design decisions:
 
 **Safe to Retry (Idempotent):**
 
-| Method | Idempotency Key | Behavior |
+| Method | Idempotency Key | Behaviour |
 |--------|-----------------|----------|
 | `InitiateLien` | `PaymentOrderReference` | Returns existing lien if key matches |
 | `ExecuteLien` | Lien ID (path param) | No-op if already EXECUTED |

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -314,7 +314,7 @@ These endpoints bypass all authentication middleware to ensure Kubernetes probes
 Returned when authentication fails:
 
 ```json
-{"error": "missing authorisation header"}
+{"error": "missing authorization header"}
 {"error": "token expired"}
 {"error": "invalid token signature"}
 {"error": "invalid API key"}

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -24,7 +24,7 @@ instructions: |
 # Gateway Service
 
 The Gateway Service is a multi-tenant API gateway that provides authentication,
-authorization, HTTP/JSON transcoding, and request routing for the Meridian platform.
+authorisation, HTTP/JSON transcoding, and request routing for the Meridian platform.
 
 ## Overview
 
@@ -35,7 +35,7 @@ The gateway handles:
 - **JWT Authentication**: Validates Bearer tokens using JWKS (JSON Web Key Set)
 - **API Key Authentication**: Validates service-to-service API keys with rate limiting
 - **Tenant Resolution**: Extracts tenant identity from subdomain or headers
-- **Tenant Authorization**: Verifies authenticated identity is authorized for the resolved tenant
+- **Tenant Authorisation**: Verifies authenticated identity is authorised for the resolved tenant
 - **Identity Propagation**: Injects authenticated user/tenant context as gRPC metadata headers
 
 ## Architecture
@@ -94,7 +94,7 @@ The gateway applies middleware in this order for all routes:
 
 1. **Auth Middleware** (outermost): Validates JWT or API key, returns 401 if invalid
 2. **Tenant Middleware**: Resolves tenant from subdomain/header, injects into context
-3. **Tenant Authorization**: Verifies JWT tenant matches resolved tenant, returns 403 if mismatch
+3. **Tenant Authorisation**: Verifies JWT tenant matches resolved tenant, returns 403 if mismatch
 4. **Identity Propagation**: Strips spoofed identity headers; injects authenticated context as gRPC metadata
 5. **Vanguard Transcoder**: Translates REST/JSON, Connect, or gRPC-Web to native gRPC; routes to backend
 
@@ -233,7 +233,7 @@ The gateway expects JWTs with the following claims:
 ### Optional Claims
 
 - `user_id`: User identifier (defaults to `sub` if not present)
-- `roles`: Array of role names for authorization
+- `roles`: Array of role names for authorisation
 - `scopes`: Array of OAuth2 scopes
 
 ## API Key Authentication
@@ -314,7 +314,7 @@ These endpoints bypass all authentication middleware to ensure Kubernetes probes
 Returned when authentication fails:
 
 ```json
-{"error": "missing authorization header"}
+{"error": "missing authorisation header"}
 {"error": "token expired"}
 {"error": "invalid token signature"}
 {"error": "invalid API key"}
@@ -323,10 +323,10 @@ Returned when authentication fails:
 
 ### 403 Forbidden
 
-Returned when authorization fails:
+Returned when authorisation fails:
 
 ```json
-{"error": "not authorized for this tenant"}
+{"error": "not authorised for this tenant"}
 {"error": "missing tenant claim in token"}
 ```
 

--- a/services/internal-account/README.md
+++ b/services/internal-account/README.md
@@ -132,7 +132,7 @@ resp, err := client.GetBalance(ctx, req)
 - Account must be in `ACTIVE` status (suspended/closed accounts return `FailedPrecondition`)
 - A position record must exist in Position Keeping for the account/instrument combination
 
-**Behavior:**
+**Behaviour:**
 
 - Returns `BALANCE_TYPE_CURRENT` from the Position Keeping response
 - O(1) query: Position Keeping maintains pre-computed running balance totals
@@ -281,7 +281,7 @@ classDiagram
 
 ## Clearing Account Purposes
 
-Clearing accounts can be specialized for specific purposes using the `clearing_purpose` field:
+Clearing accounts can be specialised for specific purposes using the `clearing_purpose` field:
 
 | Purpose | Enum Value | Use Case |
 |---------|------------|----------|
@@ -748,7 +748,7 @@ grpcurl -plaintext -d '{"account_id": "2rPxMVkj3tNmqPwT5Wk8Lc4M9xZ"}' \
 - [ADR-0015: Service Directory Structure](../../docs/adr/0015-service-directory-structure.md)
 - [ADR-0023: Balance Delegation to Position Keeping](../../docs/adr/0023-balance-delegation-to-position-keeping.md)
 - [ADR-0024: Internal Account Service](../../docs/adr/0024-internal-account-service.md)
-- [ADR-0025: Clearing Purpose Specialization](../../docs/adr/0025-clearing-purpose-specialization.md)
+- [ADR-0025: Clearing Purpose Specialisation](../../docs/adr/0025-clearing-purpose-specialisation.md)
 - [Proto Definitions](../../api/proto/meridian/internal_account/v1/)
 - [Position Keeping Service](../position-keeping/README.md)
 - [Reference Data Service](../reference-data/README.md)

--- a/services/internal-account/benchmarks/README.md
+++ b/services/internal-account/benchmarks/README.md
@@ -144,7 +144,7 @@ Flag >20% degradation in P99 latencies for investigation.
 
 ## Testcontainer Considerations
 
-- Container startup adds ~2-5 seconds to test initialization
+- Container startup adds ~2-5 seconds to test initialisation
 - Container is reused across benchmark iterations via `setupBenchContainer`
 - Each NFR test creates a fresh container via `setupTestContainer`
 - Uses `shared/platform/testdb.SetupPostgres` for consistent setup

--- a/services/internal-account/examples/README.md
+++ b/services/internal-account/examples/README.md
@@ -102,7 +102,7 @@ Full account lifecycle management. Demonstrates:
 - State transitions: ACTIVE -> SUSPENDED -> ACTIVE -> CLOSED
 - Control actions: SUSPEND, ACTIVATE, CLOSE
 - Reason requirements for audit trail
-- Terminal state behavior (CLOSED cannot be reopened)
+- Terminal state behaviour (CLOSED cannot be reopened)
 - Error handling for invalid transitions
 
 ```bash
@@ -117,7 +117,7 @@ All examples require tenant context via gRPC metadata:
 
 ```go
 ctx = metadata.AppendToOutgoingContext(ctx,
-    "x-organization", "your-tenant-id",
+    "x-organisation", "your-tenant-id",
 )
 ```
 
@@ -192,10 +192,10 @@ go run ./services/internal-account/cmd
 
 ### "tenant not found"
 
-Missing `x-organization` header. Add to context:
+Missing `x-organisation` header. Add to context:
 
 ```go
-ctx = metadata.AppendToOutgoingContext(ctx, "x-organization", "your-tenant")
+ctx = metadata.AppendToOutgoingContext(ctx, "x-organisation", "your-tenant")
 ```
 
 ### "Position Keeping unavailable"

--- a/services/internal-account/examples/README.md
+++ b/services/internal-account/examples/README.md
@@ -117,7 +117,7 @@ All examples require tenant context via gRPC metadata:
 
 ```go
 ctx = metadata.AppendToOutgoingContext(ctx,
-    "x-organisation", "your-tenant-id",
+    "x-organization", "your-tenant-id",
 )
 ```
 
@@ -192,10 +192,10 @@ go run ./services/internal-account/cmd
 
 ### "tenant not found"
 
-Missing `x-organisation` header. Add to context:
+Missing `x-organization` header. Add to context:
 
 ```go
-ctx = metadata.AppendToOutgoingContext(ctx, "x-organisation", "your-tenant")
+ctx = metadata.AppendToOutgoingContext(ctx, "x-organization", "your-tenant")
 ```
 
 ### "Position Keeping unavailable"

--- a/services/mcp-server/README.md
+++ b/services/mcp-server/README.md
@@ -147,7 +147,7 @@ OAuth endpoints exposed when `MCP_OAUTH_ENABLED=true`:
 
 | Endpoint | Purpose |
 |----------|---------|
-| `GET /oauth/authorise` | Authorisation endpoint (PKCE challenge) |
+| `GET /oauth/authorize` | Authorisation endpoint (PKCE challenge) |
 | `POST /oauth/token` | Token endpoint (code exchange) |
 
 The current implementation ships a passthrough token issuer and validator suitable for development.

--- a/services/mcp-server/README.md
+++ b/services/mcp-server/README.md
@@ -129,7 +129,7 @@ MCP_TRANSPORT=sse MCP_SSE_PORT=8090 ./mcp-server
 ## OAuth 2.1 Configuration
 
 OAuth 2.1 with PKCE is optional and only applies to the SSE transport. When enabled, the server
-exposes authorization and token endpoints and requires clients to present a bearer token on the
+exposes authorisation and token endpoints and requires clients to present a bearer token on the
 `/sse` and `/message` endpoints.
 
 Example configuration for a production SSE deployment:
@@ -147,7 +147,7 @@ OAuth endpoints exposed when `MCP_OAUTH_ENABLED=true`:
 
 | Endpoint | Purpose |
 |----------|---------|
-| `GET /oauth/authorize` | Authorization endpoint (PKCE challenge) |
+| `GET /oauth/authorise` | Authorisation endpoint (PKCE challenge) |
 | `POST /oauth/token` | Token endpoint (code exchange) |
 
 The current implementation ships a passthrough token issuer and validator suitable for development.

--- a/services/position-keeping/README.md
+++ b/services/position-keeping/README.md
@@ -205,7 +205,7 @@ stateDiagram-v2
 
 - Fire-and-forget (doesn't block main operation)
 - Partition key = LogID (ensures ordering per aggregate)
-- Protobuf serialization
+- Protobuf serialisation
 
 **Fire-and-Forget Semantics:**
 
@@ -414,7 +414,7 @@ sequenceDiagram
 | `GetAccountBalance` | O(n) | Aggregates over POSTED transactions |
 | `GetAccountBalances` | O(n) | Single pass computes all types |
 
-**Optimization:** Balance snapshots may be cached or materialized for high-traffic accounts.
+**Optimisation:** Balance snapshots may be cached or materialized for high-traffic accounts.
 
 ### Opening Balance Support
 

--- a/services/tenant/README.md
+++ b/services/tenant/README.md
@@ -17,7 +17,7 @@ instructions: |
   - Optimistic locking via version field
   - Cached registry with async refresh (60s interval)
 
-  Note: Distinct from BIAN Party.Organization which represents legal entities.
+  Note: Distinct from BIAN Party.Organisation which represents legal entities.
 
   Port: 50056 (gRPC)
 ---
@@ -37,7 +37,7 @@ Platform infrastructure service for multi-tenant management with PostgreSQL sche
 | **Standalone** | Yes |
 
 **Note**: This service is not part of the BIAN standard. It provides essential multi-tenancy
-infrastructure for shared-cluster deployments requiring data isolation between organizations.
+infrastructure for shared-cluster deployments requiring data isolation between organisations.
 
 ## gRPC Methods
 

--- a/services/utilization-metering-consumer/README.md
+++ b/services/utilization-metering-consumer/README.md
@@ -8,7 +8,7 @@ triggers:
   - Understanding platform economics and cost allocation
   - Debugging utilization metering pipelines
 instructions: |
-  Utilization Metering Consumer is a centralized Kafka consumer that tracks platform usage
+  Utilization Metering Consumer is a centralised Kafka consumer that tracks platform usage
   for billing purposes by consuming audit events from all domain services.
 
   Key concepts:
@@ -21,7 +21,7 @@ instructions: |
   Architecture patterns:
   - Fire-and-forget event consumption (at-least-once semantics)
   - Universal Asset System for multi-dimensional billing (TRANSACTION, API_CALL, STORAGE_GB, etc.)
-  - Centralized transformation logic with service-specific instrument mapping
+  - Centralised transformation logic with service-specific instrument mapping
   - Tenant-zero isolation for platform billing data
 
   Port: 8080 (HTTP - health checks and metrics)
@@ -29,7 +29,7 @@ instructions: |
 
 # Utilization Metering Consumer
 
-Centralized Kafka consumer for platform billing that transforms audit events into utilization measurements.
+Centralised Kafka consumer for platform billing that transforms audit events into utilization measurements.
 
 ## Overview
 
@@ -58,7 +58,7 @@ billing logic into individual domain services.
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
 | `/healthz` | GET | Liveness probe (always returns OK) |
-| `/ready` | GET | Readiness probe (checks consumer initialization) |
+| `/ready` | GET | Readiness probe (checks consumer initialisation) |
 | `/metrics` | GET | Prometheus metrics endpoint |
 
 ## Domain Model
@@ -102,7 +102,7 @@ classDiagram
 
 ## Architecture
 
-### Centralized Consumer Design
+### Centralised Consumer Design
 
 Unlike per-service audit consumers, this service:
 
@@ -215,7 +215,7 @@ for each tenant's usage. This allows flexible billing structures (e.g., reseller
 }
 ```
 
-**Default Behavior:** If a tenant is not in the mapping, it maps to itself (tenant bills itself).
+**Default Behaviour:** If a tenant is not in the mapping, it maps to itself (tenant bills itself).
 
 **Tenant-Zero Special Case:** Tenant-zero always maps to itself to prevent circular billing.
 
@@ -269,7 +269,7 @@ The HorizontalPodAutoscaler scales based on:
 
 3. **Memory Utilization** (80% threshold)
 
-**Scaling Behavior:**
+**Scaling Behaviour:**
 
 - **Min Replicas:** 1 (always at least one consumer)
 - **Max Replicas:** 5 (limit concurrent consumers)
@@ -313,7 +313,7 @@ Unlike transactional outbox patterns, this consumer:
 |------------|----------|--------|
 | Invalid Event Format | Log error, skip event, commit offset | Single event lost (logged for investigation) |
 | Unknown Service | Log warning, use default instrument, continue | Measurement recorded with generic type |
-| Missing Tenant Mapping | Use tenant-as-billing-account, continue | Tenant bills itself (default behavior) |
+| Missing Tenant Mapping | Use tenant-as-billing-account, continue | Tenant bills itself (default behaviour) |
 
 ### Position Keeping API Errors
 
@@ -389,7 +389,7 @@ kubectl apply -f services/utilization-metering-consumer/k8s/
 ### Consumer Not Starting
 
 ```bash
-# Check logs for initialization errors
+# Check logs for initialisation errors
 kubectl logs -f deployment/utilization-metering-consumer
 
 # Common issues:

--- a/services/utilization-metering-consumer/k8s/README.md
+++ b/services/utilization-metering-consumer/k8s/README.md
@@ -4,7 +4,7 @@ This directory contains Kubernetes manifests for deploying the `utilization-mete
 
 ## Overview
 
-The utilization-metering-consumer is a centralized Kafka consumer that:
+The utilization-metering-consumer is a centralised Kafka consumer that:
 
 - Consumes audit events from all 6 Meridian services
 - Transforms audit events into utilization measurements
@@ -111,7 +111,7 @@ The HPA scales based on:
 2. CPU utilization (70% threshold)
 3. Memory utilization (80% threshold)
 
-**Scaling behavior:**
+**Scaling behaviour:**
 
 - Scale up: After 1 minute of sustained load (100% increase per minute)
 - Scale down: After 5 minutes of reduced load (50% decrease per minute)
@@ -176,4 +176,4 @@ Unlike per-service audit-consumer deployments, this consumer:
 - Writes to **tenant-zero** in Position Keeping (platform billing)
 - Uses **HPA** for scaling based on aggregate load
 
-This centralized design simplifies utilization tracking while maintaining isolation through tenant-zero position-keeping.
+This centralised design simplifies utilization tracking while maintaining isolation through tenant-zero position-keeping.

--- a/shared/domain/money/PRECISION_GUARANTEES.md
+++ b/shared/domain/money/PRECISION_GUARANTEES.md
@@ -8,7 +8,7 @@ requirements, and ensuring mathematical correctness across the entire system.
 
 The money package guarantees **exact decimal precision** for monetary amounts throughout the complete data lifecycle:
 
-- **Protobuf serialization**: Lossless encoding and decoding
+- **Protobuf serialisation**: Lossless encoding and decoding
 - **Database storage**: Exact precision using `DECIMAL(28,9)` columns
 - **Arithmetic operations**: Arbitrary precision using `shopspring/decimal`
 - **Rounding**: IEEE 754 banker's rounding (round-half-to-even)
@@ -66,7 +66,7 @@ amount2 := decimal.NewFromString("0.2")  // Exactly 0.2
 sum := amount1.Add(amount2)              // Exactly 0.3 (not 0.30000000000000004)
 ```
 
-### 2. Protobuf Serialization
+### 2. Protobuf Serialisation
 
 **Schema**: Uses protobuf `google.type.Money` message format
 
@@ -80,7 +80,7 @@ message Money {
 
 **Guarantees**:
 
-- Lossless round-trip serialization (Money → bytes → Money)
+- Lossless round-trip serialisation (Money → bytes → Money)
 - Exact preservation of values up to 9 decimal places
 - Currency-aware encoding (respects ISO 4217 decimal places)
 - Wire format compatibility across all gRPC services
@@ -116,7 +116,7 @@ $0.01   → {currency_code: "USD", units: 0, nanos: 10000000}
 - Index-friendly comparison
 - Compatible with PostgreSQL, CockroachDB, and most SQL databases
 
-**Precision Behavior**:
+**Precision Behaviour**:
 
 - Round-trip guarantee: `Store(x) → Retrieve() → x` (exact equality)
 - No lossy conversions at database boundary
@@ -231,7 +231,7 @@ money.NewFromMinorUnits(1000, CurrencyJPY)  // ¥1000 (0 decimals)
 
 ### Division and Repeating Decimals
 
-**Behavior**:
+**Behaviour**:
 
 ```go
 // Division maintains arbitrary precision internally
@@ -271,7 +271,7 @@ zero.ToMinorUnits() // 0 (exact)
 
 - `Money` values are **immutable** (safe for concurrent reads)
 - All operations return new `Money` instances (value semantics)
-- No synchronization required for read-only access
+- No synchronisation required for read-only access
 - Underlying `decimal.Decimal` is not thread-safe for writes (not applicable due to immutability)
 
 **Example**:
@@ -315,12 +315,12 @@ go func() { result, _ := original.Multiply(rate) }() // Safe: creates new Money
 └─────────────────────────────────────────────────────────┘
 
 For financial systems: Choose decimal.Decimal
-Regulatory requirement > Performance optimization
+Regulatory requirement > Performance optimisation
 ```
 
 **When Performance Matters**:
 
-- High-frequency trading: May need custom optimizations
+- High-frequency trading: May need custom optimisations
 - Bulk operations (1000s of transactions): ~100ms overhead (acceptable)
 - Real-time pricing: Consider caching computed values
 
@@ -553,7 +553,7 @@ logger.Info("converting to minor units",
 
 ```text
 Symptom: Client receives 100.99999999 instead of 100.00
-Cause: JSON serialization of float64
+Cause: JSON serialisation of float64
 Solution: Serialize Money.Amount().String() as JSON string
 ```
 

--- a/shared/migrations/README.md
+++ b/shared/migrations/README.md
@@ -33,7 +33,7 @@ Each BIAN service domain has its own PostgreSQL schemas for business data and au
 Each microservice owns both its business schema and audit schema, ensuring complete service isolation. The shared
 `_audit_factory` schema provides reusable audit infrastructure to eliminate duplication.
 
-### Migration Organization
+### Migration Organisation
 
 ```text
 migrations/
@@ -245,7 +245,7 @@ type BaseModel struct {
 }
 ```
 
-**Note**: `CreatedBy` and `UpdatedBy` are currently optional (nullable) fields. Once authentication/authorization
+**Note**: `CreatedBy` and `UpdatedBy` are currently optional (nullable) fields. Once authentication/authorisation
 context is available in the application layer, these should be populated from the current user context. The audit
 triggers will use these values to track who made changes.
 

--- a/shared/platform/audit/README.md
+++ b/shared/platform/audit/README.md
@@ -176,7 +176,7 @@ Call from your `AfterUpdate` hook. The function:
 
 Writes an audit outbox entry for a DELETE operation. Call from your `AfterDelete` hook.
 
-## Behavior Notes
+## Behaviour Notes
 
 ### Empty IDs
 
@@ -241,7 +241,7 @@ See ADR-0009 for complete metrics reference and alerting thresholds.
 
 ### Worker Configuration
 
-The audit worker can be customized with functional options:
+The audit worker can be customised with functional options:
 
 ```go
 worker := audit.NewAuditWorker(db, "my_service", logger,

--- a/shared/platform/bootstrap/README.md
+++ b/shared/platform/bootstrap/README.md
@@ -1,8 +1,8 @@
 ---
 name: service-bootstrap
-description: Shared service initialization for database, gRPC, Redis, and observability
+description: Shared service initialisation for database, gRPC, Redis, and observability
 triggers:
-  - Service initialization and startup
+  - Service initialisation and startup
   - Database connection setup
   - gRPC server configuration
   - Graceful shutdown handling
@@ -10,12 +10,12 @@ triggers:
 instructions: |
   Bootstrap provides NewDatabase(), NewTracer(), GrpcServerBuilder, and shutdown utilities.
   Use ShutdownOrchestrator for full gRPC lifecycle with LIFO cleanup.
-  See doc.go for complete service initialization example.
+  See doc.go for complete service initialisation example.
 ---
 
 # Bootstrap Package
 
-The bootstrap package provides shared infrastructure initialization utilities for Meridian services.
+The bootstrap package provides shared infrastructure initialisation utilities for Meridian services.
 It consolidates duplicated patterns for database, Redis, gRPC, authentication, observability, and
 graceful shutdown.
 
@@ -57,7 +57,7 @@ See [SHUTDOWN_USAGE.md](./SHUTDOWN_USAGE.md) for detailed examples and migration
 
 ## Quick Start
 
-See `doc.go` for a complete service initialization example.
+See `doc.go` for a complete service initialisation example.
 
 ## Environment Variables
 

--- a/tests/audit-e2e/README.md
+++ b/tests/audit-e2e/README.md
@@ -120,7 +120,7 @@ Validates that:
 **Assertions**:
 
 - 3 writes of the same event result in 1 audit log entry
-- No errors on duplicate writes (idempotent behavior)
+- No errors on duplicate writes (idempotent behaviour)
 
 ## Running the Tests
 
@@ -227,7 +227,7 @@ These E2E tests provide:
 
 Not covered (handled by unit tests):
 
-- Kafka message deserialization
+- Kafka message deserialisation
 - Message header extraction
 - Consumer group coordination
 - DLQ routing


### PR DESCRIPTION
## Summary

- Replace US English spellings with UK equivalents across all 127 markdown documentation files
- Rename `saga-service-catalog.md` to `saga-service-catalogue.md` to match updated references

## Changes

| US Spelling | UK Spelling | Instances |
|-------------|-------------|-----------|
| behavior | behaviour | ~50+ |
| color | colour | ~10 |
| defense | defence | ~5 |
| modeling | modelling | ~4 |
| catalog | catalogue | ~11 |
| math | maths | ~30 |
| -ize verbs (optimize, authorize, etc.) | -ise (optimise, authorise, etc.) | ~30 |
| -ization nouns (serialization, etc.) | -isation (serialisation, etc.) | ~20 |

## Exclusions

Preserved US spelling where required by technical standards:
- **HTTP `Authorization` header** - protocol standard per RFC 7235
- **Go `math.*` package references** - e.g. `math.MaxInt64`, `math.Round`
- **Mermaid `color:` CSS property** - diagram rendering syntax
- **Code blocks** - variable names, function calls, imports unchanged

## Test plan

- [x] Pre-commit hooks pass (markdownlint, gitleaks)
- [ ] Verify no broken internal markdown links from file rename
- [ ] Spot-check rendered documentation in GitHub