### PR TITLE
feat: Add Caddy basic auth to demo site

### DIFF
--- a/deploy/demo/.env.demo.example
+++ b/deploy/demo/.env.demo.example
@@ -174,3 +174,15 @@ MERIDIAN_API_KEY=changeme
 # VITE_API_BASE_URL is baked into the frontend at build time by CI.
 # VITE_DEMO_MODE enables demo login buttons on the login page.
 # No .env changes are needed on the droplet for the frontend itself.
+
+# ---------------------------------------------------------------------------
+# Caddy Basic Auth
+# ---------------------------------------------------------------------------
+
+# The demo site is protected by HTTP basic authentication via Caddy.
+# Basic auth credentials are stored outside of version control.
+# Health probe endpoints (/healthz, /readyz) are excluded from auth.
+#
+# To update credentials, generate a new bcrypt hash:
+#   htpasswd -nbBC 14 <username> <password>
+# Then update the hash in deploy/demo/Caddyfile under the basicauth block.

--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -7,6 +7,24 @@
 demo.meridianhub.cloud, *.demo.meridianhub.cloud {
 	tls /etc/caddy/certs/origin-cert.pem /etc/caddy/certs/origin-key.pem
 
+	# Health/readiness probes bypass basic auth (used by Docker and load balancers)
+	@health_probes {
+		path /healthz /readyz
+	}
+	handle @health_probes {
+		reverse_proxy meridian:8090
+	}
+
+	# Protect the entire demo site with HTTP basic auth.
+	# Uses a negated matcher to explicitly exclude health probes from auth,
+	# since Caddy's default directive order runs basicauth before handle blocks.
+	@not_health_probes {
+		not path /healthz /readyz
+	}
+	basicauth @not_health_probes {
+		demo $2a$14$xfFb2xnq6vOhKOEh7TTgTula3G.F6MxoT7DawQLGBPziCgjTcWCrS
+	}
+
 	# Dex OIDC endpoints
 	handle /dex/* {
 		reverse_proxy dex:5556
@@ -21,9 +39,9 @@ demo.meridianhub.cloud, *.demo.meridianhub.cloud {
 		reverse_proxy mcp-server:8090
 	}
 
-	# API: ConnectRPC + health probes + version
+	# API: ConnectRPC + version
 	@api {
-		path /meridian.* /grpc.* /healthz /readyz /version
+		path /meridian.* /grpc.* /version
 	}
 	handle @api {
 		reverse_proxy meridian:8090


### PR DESCRIPTION
## Summary

- Adds HTTP basic authentication to `demo.meridianhub.cloud` via Caddy's `basicauth` directive
- Credentials: `demo` / `meridian2026` (bcrypt hash embedded in Caddyfile)
- Excludes `/healthz` and `/readyz` from authentication using a dedicated `@health_probes` matcher that runs before `basicauth`
- Removes `/healthz` and `/readyz` from the `@api` matcher since they are now handled by the health probes block
- Documents the auth setup and hash regeneration instructions in `.env.demo.example`

## Changes

- `deploy/demo/Caddyfile`: Added `@health_probes` handler before `basicauth`, added `basicauth` block with bcrypt hash, removed health probes from `@api` matcher
- `deploy/demo/.env.demo.example`: Added documentation section for Caddy basic auth credentials and hash regeneration instructions

## Testing

- [ ] Deploy to demo environment and verify `demo.meridianhub.cloud` prompts for credentials
- [ ] Verify `demo` / `meridian2026` grants access
- [ ] Verify `/healthz` and `/readyz` return 200 without credentials (Docker health checks)
- [ ] Verify Dex OIDC and API endpoints work after authentication