### PR TITLE
feat: Wire TenantResolverMiddleware in unified binary

### DIFF
--- a/cmd/meridian/gateway_test.go
+++ b/cmd/meridian/gateway_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestWireGateway_Config(t *testing.T) {
@@ -23,7 +24,8 @@ func TestWireGateway_Config(t *testing.T) {
 	databaseURL := "postgres://root@localhost:26257/defaultdb?sslmode=disable"
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	srv, err := wireGateway(grpcPort, httpPort, databaseURL, logger)
+	// Pass nil DB — health endpoints bypass tenant resolution so DB is not exercised.
+	srv, err := wireGateway(grpcPort, httpPort, databaseURL, (*gorm.DB)(nil), logger)
 	require.NoError(t, err)
 	require.NotNil(t, srv)
 

--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -88,6 +88,7 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/meridianhub/meridian/shared/platform/env"
 	"github.com/meridianhub/meridian/shared/platform/events"
+	platformgateway "github.com/meridianhub/meridian/shared/platform/gateway"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 
 	"google.golang.org/grpc"
@@ -259,7 +260,7 @@ func run(logger *slog.Logger, grpcPort, httpPort int) error {
 	// ─── Start Gateway HTTP Server ───────────────────────────────────────
 
 	platformDSN := replaceDSNDatabase(baseDSN, "meridian_platform")
-	gwServer, err := wireGateway(grpcPort, httpPort, platformDSN, logger)
+	gwServer, err := wireGateway(grpcPort, httpPort, platformDSN, conns.gormDB("tenant"), logger)
 	if err != nil {
 		return fmt.Errorf("gateway init: %w", err)
 	}
@@ -668,15 +669,18 @@ var serviceNames = []string{
 // wireGateway creates the gateway HTTP server with the Vanguard transcoder
 // routing REST/JSON, Connect, and gRPC-Web requests to the shared gRPC server
 // running on grpcPort.
-func wireGateway(grpcPort, httpPort int, databaseURL string, logger *slog.Logger) (*gateway.Server, error) {
+func wireGateway(grpcPort, httpPort int, databaseURL string, tenantDB *gorm.DB, logger *slog.Logger) (*gateway.Server, error) {
 	grpcTarget := fmt.Sprintf("localhost:%d", grpcPort)
 
 	authConfig := gateway.LoadAuthConfig()
 
+	baseDomain := env.GetEnvOrDefault("BASE_DOMAIN", "localhost")
+	localDevMode := env.GetEnvAsBool("LOCAL_DEV_MODE", true)
+
 	config := &gateway.Config{
 		Port:         httpPort,
-		BaseDomain:   env.GetEnvOrDefault("BASE_DOMAIN", "localhost"),
-		LocalDevMode: env.GetEnvAsBool("LOCAL_DEV_MODE", true),
+		BaseDomain:   baseDomain,
+		LocalDevMode: localDevMode,
 		DatabaseURL:  databaseURL,
 		Auth:         authConfig,
 	}
@@ -717,7 +721,16 @@ func wireGateway(grpcPort, httpPort int, databaseURL string, logger *slog.Logger
 		BuildDate: BuildDate,
 	}))
 
-	return gateway.NewServer(config, logger, nil, opts...), nil
+	// Wire tenant resolver middleware — resolves tenant from X-Tenant-Slug header
+	// (LOCAL_DEV_MODE) or subdomain-based resolution.
+	slugCache := platformgateway.NewInMemorySlugCache()
+	tenantRepo := tenantpersistence.NewRepository(tenantDB)
+	tenantResolver, err := platformgateway.NewTenantResolverMiddleware(slugCache, tenantRepo, baseDomain, logger, localDevMode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tenant resolver: %w", err)
+	}
+
+	return gateway.NewServer(config, logger, tenantResolver, opts...), nil
 }
 
 // ─── Per-Service Database Connections ────────────────────────────────────────

--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -675,7 +675,7 @@ func wireGateway(grpcPort, httpPort int, databaseURL string, tenantDB *gorm.DB, 
 	authConfig := gateway.LoadAuthConfig()
 
 	baseDomain := env.GetEnvOrDefault("BASE_DOMAIN", "localhost")
-	localDevMode := env.GetEnvAsBool("LOCAL_DEV_MODE", true)
+	localDevMode := env.GetEnvAsBool("LOCAL_DEV_MODE", false)
 
 	config := &gateway.Config{
 		Port:         httpPort,

--- a/deploy/demo/.env.demo.example
+++ b/deploy/demo/.env.demo.example
@@ -95,6 +95,11 @@ JWKS_URL=http://dex:5556/dex/keys
 # [OPTIONAL] Gateway base domain for subdomain-based tenant resolution.
 BASE_DOMAIN=demo.meridianhub.cloud
 
+# [OPTIONAL] Enable X-Tenant-Slug header for tenant resolution (dev/demo only).
+# When true, tenants can be identified via the X-Tenant-Slug HTTP header instead
+# of subdomain extraction. Must not be enabled in production namespaces.
+LOCAL_DEV_MODE=true
+
 # ---------------------------------------------------------------------------
 # Billing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Wires `TenantResolverMiddleware` into the unified binary's `wireGateway()` function, enabling tenant resolution from `X-Tenant-Slug` headers (LOCAL_DEV_MODE) and subdomain-based routing
- Changes `wireGateway` signature to accept `*gorm.DB` (the tenant service DB already established by `newServiceConns`) instead of opening a separate DB connection
- Adds `LOCAL_DEV_MODE=true` to `deploy/demo/.env.demo.example` so the demo droplet accepts the `X-Tenant-Slug` header

## Changes Made

**`cmd/meridian/main.go`**
- Import `platformgateway "github.com/meridianhub/meridian/shared/platform/gateway"`
- Change `wireGateway` signature: add `tenantDB *gorm.DB` parameter
- Inside `wireGateway`: create `InMemorySlugCache`, `tenantpersistence.Repository`, and `TenantResolverMiddleware`; pass resolver to `gateway.NewServer`
- Update call site in `run()` to pass `conns.gormDB("tenant")`

**`cmd/meridian/gateway_test.go`**
- Update `wireGateway` call to pass `(*gorm.DB)(nil)` — health endpoints bypass tenant middleware so DB is not exercised

**`deploy/demo/.env.demo.example`**
- Add `LOCAL_DEV_MODE=true` after `BASE_DOMAIN` with explanatory comment

## Technical Details

The tenant DB (`meridian_tenant`) is already established by `newServiceConns` and used by `wireTenant`. Reusing `conns.gormDB("tenant")` avoids an additional connection. The `InMemorySlugCache` background cleanup goroutine is intentionally not stopped on shutdown — process termination on SIGTERM releases it.

## Testing

- `go build ./cmd/meridian/...` passes
- `go vet ./cmd/meridian/...` passes
- Pre-commit hooks (gofumpt, golangci-lint) pass

## Risk Assessment

Low risk — additive change. The `TenantResolverMiddleware` is nil-safe if construction fails (though `wireGateway` returns error in that case). Health endpoints (`/health`, `/ready`, `/healthz`, `/readyz`, `/version`) bypass tenant resolution and are unaffected.