### PR TITLE
fix: Share single testcontainer across current-account service tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -175,6 +175,7 @@ jobs:
             HTTP_CODE=$(curl -sS -o /tmp/tenant_resp.txt -w "%{http_code}" \
               -X POST "${GATEWAY_URL}/v1/tenants" \
               -H "Content-Type: application/json" \
+              -H "X-Tenant-Slug: dev-tenant" \
               -d "$PAYLOAD")
             echo "${TENANT_ID}: HTTP ${HTTP_CODE}"
             if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ] && [ "$HTTP_CODE" != "409" ]; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -153,6 +153,7 @@ jobs:
       - name: Start meridian backend
         run: |
           DATABASE_URL="postgres://root@localhost:26257/defaultdb?sslmode=disable" \
+          LOCAL_DEV_MODE=true \
             ./dist/meridian >/tmp/meridian.log 2>&1 &
 
       - name: Seed dev tenant and apply manifest

--- a/services/current-account/service/account_control_integration_test.go
+++ b/services/current-account/service/account_control_integration_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
-	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,21 +21,26 @@ import (
 // Integration tests for Account Control Operations (BIAN CoCR)
 // These tests verify the status_history audit trail and concurrent control operations.
 
-const integrationTestTenant = "control_test_tenant"
-
-// setupControlTestDB creates a PostgreSQL testcontainer with the account table schema.
+// setupControlTestDB creates a test database using the shared PostgreSQL container.
 func setupControlTestDB(t *testing.T) (*persistence.Repository, *persistence.LienRepository, context.Context, func()) {
 	t.Helper()
 
-	// Create PostgreSQL testcontainer
-	db, cleanup := testdb.SetupPostgres(t, nil) // nil models - we'll use DDL
+	db := openSharedDB(t)
 
-	// Setup tenant schema
-	tc := testdb.SetupTenantSchema(t, db, integrationTestTenant)
+	tid := uniqueTenantID()
+	schemaName := tid.SchemaName()
+	quotedSchema := pq.QuoteIdentifier(schemaName)
+
+	// Create tenant schema
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quotedSchema)).Error
+	require.NoError(t, err)
+
+	// Set search_path
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", quotedSchema)).Error
+	require.NoError(t, err)
 
 	// Create account table with status_history support using raw DDL
-	// We use the entity's TableName() which is "account" (singular, unqualified)
-	accountDDL := `CREATE TABLE IF NOT EXISTS %s.account (
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.account (
 		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 		account_id VARCHAR(100) NOT NULL UNIQUE,
 		account_identification VARCHAR(34) NOT NULL UNIQUE,
@@ -64,11 +68,11 @@ func setupControlTestDB(t *testing.T) (*persistence.Repository, *persistence.Lie
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
 		updated_by VARCHAR(100) NOT NULL DEFAULT 'test',
 		deleted_at TIMESTAMP WITH TIME ZONE
-	)`
-	testdb.CreateTable(t, tc.DB, tc.Tenant, accountDDL)
+	)`, quotedSchema)).Error
+	require.NoError(t, err)
 
 	// Create lien table for close validation tests
-	lienDDL := `CREATE TABLE IF NOT EXISTS %s.lien (
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.lien (
 		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 		account_id UUID NOT NULL,
 		amount_cents BIGINT NOT NULL,
@@ -84,25 +88,31 @@ func setupControlTestDB(t *testing.T) (*persistence.Repository, *persistence.Lie
 		reserved_quantity JSONB,
 		valued_amount JSONB,
 		valuation_analysis JSONB
-	)`
-	testdb.CreateTable(t, tc.DB, tc.Tenant, lienDDL)
+	)`, quotedSchema)).Error
+	require.NoError(t, err)
 
 	// Create index on status for operational queries
-	quotedSchema := pq.QuoteIdentifier(tc.Tenant.SchemaName())
-	err := tc.DB.Exec(fmt.Sprintf("CREATE INDEX IF NOT EXISTS idx_account_status ON %s.account(status)", quotedSchema)).Error
+	err = db.Exec(fmt.Sprintf("CREATE INDEX IF NOT EXISTS idx_account_status ON %s.account(status)", quotedSchema)).Error
 	require.NoError(t, err)
 
 	// Create GIN index on status_history for audit queries
-	err = tc.DB.Exec(fmt.Sprintf("CREATE INDEX IF NOT EXISTS idx_account_status_history ON %s.account USING GIN(status_history)", quotedSchema)).Error
+	err = db.Exec(fmt.Sprintf("CREATE INDEX IF NOT EXISTS idx_account_status_history ON %s.account USING GIN(status_history)", quotedSchema)).Error
 	require.NoError(t, err)
 
-	repo := persistence.NewRepository(tc.DB)
-	lienRepo := persistence.NewLienRepository(tc.DB)
+	ctx := tenant.WithTenant(context.Background(), tid)
 
-	return repo, lienRepo, tc.Ctx, func() {
-		tc.Cleanup()
-		cleanup()
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+
+	cleanup := func() {
+		db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", quotedSchema))
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			sqlDB.Close()
+		}
 	}
+
+	return repo, lienRepo, ctx, cleanup
 }
 
 // createTestAccountForControl creates a test account with a unique ID for control tests.
@@ -217,10 +227,8 @@ func TestAccountControlConcurrent_FreezeRace(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 
-			// Create a new context with tenant for each goroutine
-			goroutineCtx := tenant.WithTenant(context.Background(), tenant.TenantID(integrationTestTenant))
-
-			_, err := svc.ControlCurrentAccount(goroutineCtx, &pb.ControlCurrentAccountRequest{
+			// Reuse test context — tenant context is read-only and safe for concurrent use
+			_, err := svc.ControlCurrentAccount(ctx, &pb.ControlCurrentAccountRequest{
 				AccountId:     accountID,
 				ControlAction: pb.ControlAction_CONTROL_ACTION_FREEZE,
 				Reason:        fmt.Sprintf("Concurrent freeze attempt %d for testing purposes", idx),

--- a/services/current-account/service/grpc_service_integration_test.go
+++ b/services/current-account/service/grpc_service_integration_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
-	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -424,26 +423,33 @@ func (m *mockFinancialAccountingClient) Close() error {
 
 // Helper functions for integration tests
 
-const integrationTestTenantID = "test_tenant"
-
 func setupIntegrationTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	t.Helper()
-	db, cleanup := testdb.SetupPostgres(t, []interface{}{
-		&persistence.CurrentAccountEntity{},
-	})
+	db := openSharedDB(t)
 
-	// Create the tenant schema for tests
-	tid := tenant.TenantID(integrationTestTenantID)
+	// Each test gets a unique tenant → unique schema for isolation
+	tid := uniqueTenantID()
 	schemaName := tid.SchemaName()
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	// Set default search_path to include tenant schema
+	// Set search_path so AutoMigrate creates tables in the tenant schema
 	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	// Create context with tenant
+	// AutoMigrate in the tenant schema
+	err = db.AutoMigrate(&persistence.CurrentAccountEntity{})
+	require.NoError(t, err)
+
 	ctx := tenant.WithTenant(context.Background(), tid)
+
+	cleanup := func() {
+		_ = db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", pq.QuoteIdentifier(schemaName)))
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+	}
 
 	return db, ctx, cleanup
 }

--- a/services/current-account/service/grpc_service_party_integration_test.go
+++ b/services/current-account/service/grpc_service_party_integration_test.go
@@ -20,7 +20,6 @@ import (
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
-	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -123,27 +122,36 @@ func (m *mockPartyClient) Close() error {
 	return nil
 }
 
-// Helper function for party integration tests
-const partyIntegrationTestTenantID = "test_tenant"
-
 func setupPartyIntegrationTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	t.Helper()
-	db, cleanup := testdb.SetupPostgres(t, []interface{}{
-		&persistence.CurrentAccountEntity{},
-	})
+	db := openSharedDB(t)
 
-	// Create the tenant schema for tests
-	tid := tenant.TenantID(partyIntegrationTestTenantID)
+	tid := uniqueTenantID()
 	schemaName := tid.SchemaName()
-	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
+	quotedSchema := pq.QuoteIdentifier(schemaName)
+
+	// Create the tenant schema
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quotedSchema)).Error
 	require.NoError(t, err)
 
 	// Set default search_path to include tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", quotedSchema)).Error
+	require.NoError(t, err)
+
+	// AutoMigrate the account entity in the tenant schema
+	err = db.AutoMigrate(&persistence.CurrentAccountEntity{})
 	require.NoError(t, err)
 
 	// Create context with tenant
 	ctx := tenant.WithTenant(context.Background(), tid)
+
+	cleanup := func() {
+		db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", quotedSchema))
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			sqlDB.Close()
+		}
+	}
 
 	return db, ctx, cleanup
 }

--- a/services/current-account/service/grpc_service_product_type_test.go
+++ b/services/current-account/service/grpc_service_product_type_test.go
@@ -24,7 +24,6 @@ import (
 	celutil "github.com/meridianhub/meridian/services/reference-data/cel"
 	vf "github.com/meridianhub/meridian/shared/pkg/valuationfeature"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
-	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -88,22 +87,19 @@ func (r *jsonStringReader) Read(p []byte) (n int, err error) {
 	return n, nil
 }
 
-const productTypeTestTenantID = "test_product_type_tenant"
-
 func setupProductTypeTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	t.Helper()
-	db, cleanup := testdb.SetupPostgres(t, []interface{}{
-		&persistence.CurrentAccountEntity{},
-		&vf.Entity{},
-	})
+	db := openSharedDB(t)
 
-	tid := tenant.TenantID(productTypeTestTenantID)
+	tid := uniqueTenantID()
 	schemaName := tid.SchemaName()
-	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
+	quotedSchema := pq.QuoteIdentifier(schemaName)
+
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quotedSchema)).Error
 	require.NoError(t, err)
 
 	// AutoMigrate tables in tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", quotedSchema)).Error
 	require.NoError(t, err)
 
 	err = db.AutoMigrate(&persistence.CurrentAccountEntity{}, &vf.Entity{})
@@ -113,10 +109,19 @@ func setupProductTypeTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	// AutoMigrate only creates the table structure; partial indexes must be created manually.
 	err = db.Exec(fmt.Sprintf(`CREATE UNIQUE INDEX IF NOT EXISTS idx_valuation_feature_account_instrument_active
 		ON %s.valuation_features (account_id, instrument_code)
-		WHERE lifecycle_status = 'ACTIVE' AND valid_to = '9999-12-31 23:59:59+00'`, pq.QuoteIdentifier(schemaName))).Error
+		WHERE lifecycle_status = 'ACTIVE' AND valid_to = '9999-12-31 23:59:59+00'`, quotedSchema)).Error
 	require.NoError(t, err)
 
 	ctx := tenant.WithTenant(context.Background(), tid)
+
+	cleanup := func() {
+		db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", quotedSchema))
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			sqlDB.Close()
+		}
+	}
+
 	return db, ctx, cleanup
 }
 

--- a/services/current-account/service/grpc_service_test.go
+++ b/services/current-account/service/grpc_service_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
-	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/type/money"
 	"google.golang.org/grpc/codes"
@@ -302,24 +301,33 @@ func mustNewMoney(currency string, amountCents int64) domain.Money {
 	return m
 }
 
-const svcTestTenantID = "test_tenant"
-
 func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	t.Helper()
-	db, cleanup := testdb.SetupPostgres(t, []interface{}{&persistence.CurrentAccountEntity{}})
+	db := openSharedDB(t)
 
-	// Create the tenant schema for tests
-	tid := tenant.TenantID(svcTestTenantID)
+	// Each test gets a unique tenant → unique schema for isolation
+	tid := uniqueTenantID()
 	schemaName := tid.SchemaName()
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	// Set default search_path to include tenant schema so queries route to tenant-scoped tables
+	// Set search_path so AutoMigrate creates tables in the tenant schema
 	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	// Create context with tenant
+	// AutoMigrate in the tenant schema
+	err = db.AutoMigrate(&persistence.CurrentAccountEntity{})
+	require.NoError(t, err)
+
 	ctx := tenant.WithTenant(context.Background(), tid)
+
+	cleanup := func() {
+		_ = db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", pq.QuoteIdentifier(schemaName)))
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+	}
 
 	return db, ctx, cleanup
 }
@@ -966,9 +974,10 @@ func TestExecuteDeposit_IdempotencyReturnsCachedResponse(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, repo.Save(ctx, account))
 
-	// Pre-populate cached response
+	// Pre-populate cached response — use tenant from context (dynamic per test)
+	tid, _ := tenant.FromContext(ctx)
 	idempKey := idempotency.Key{
-		TenantID:  svcTestTenantID,
+		TenantID:  string(tid),
 		Namespace: "current-account",
 		Operation: "deposit",
 		EntityID:  "ACC-IDEMP-001",
@@ -1017,8 +1026,9 @@ func TestExecuteDeposit_IdempotencyReturnsAbortedWhenInProgress(t *testing.T) {
 	require.NoError(t, repo.Save(ctx, account))
 
 	// Mark operation as pending (simulating concurrent request)
+	tid, _ := tenant.FromContext(ctx)
 	idempKey := idempotency.Key{
-		TenantID:  svcTestTenantID,
+		TenantID:  string(tid),
 		Namespace: "current-account",
 		Operation: "deposit",
 		EntityID:  "ACC-IDEMP-002",
@@ -1089,8 +1099,9 @@ func TestExecuteDeposit_IdempotencyCleanupOnFailure(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, repo.Save(ctx, account))
 
+	tid, _ := tenant.FromContext(ctx)
 	idempKey := idempotency.Key{
-		TenantID:  svcTestTenantID,
+		TenantID:  string(tid),
 		Namespace: "current-account",
 		Operation: "deposit",
 		EntityID:  "ACC-IDEMP-004",

--- a/services/current-account/service/grpc_withdrawal_tenant_isolation_test.go
+++ b/services/current-account/service/grpc_withdrawal_tenant_isolation_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	"github.com/meridianhub/meridian/shared/platform/events"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
-	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/type/money"
@@ -30,21 +29,17 @@ import (
 // tenant A must not be visible or executable from tenant B's context.
 // =============================================================================
 
-const (
-	tenantIsolationTenantA = "tenant_iso_a"
-	tenantIsolationTenantB = "tenant_iso_b"
-)
-
-// setupMultiTenantTestDB creates a testcontainer with two tenant schemas, each
-// containing the account, withdrawal, and event_outbox tables.
+// setupMultiTenantTestDB creates two tenant schemas in the shared container,
+// each containing the account, withdrawal, and event_outbox tables.
 // Returns the shared gorm.DB, per-tenant contexts, and a cleanup function.
 func setupMultiTenantTestDB(t *testing.T) (db *gorm.DB, ctxA context.Context, ctxB context.Context, cleanup func()) {
 	t.Helper()
 
-	db, dbCleanup := testdb.SetupPostgres(t, nil)
+	db = openSharedDB(t)
 
-	tenantA := tenant.TenantID(tenantIsolationTenantA)
-	tenantB := tenant.TenantID(tenantIsolationTenantB)
+	// Use unique tenant IDs so parallel tests don't collide
+	tenantA := uniqueTenantID()
+	tenantB := uniqueTenantID()
 
 	for _, tid := range []tenant.TenantID{tenantA, tenantB} {
 		schema := tid.SchemaName()
@@ -73,7 +68,18 @@ func setupMultiTenantTestDB(t *testing.T) (db *gorm.DB, ctxA context.Context, ct
 	ctxA = tenant.WithTenant(context.Background(), tenantA)
 	ctxB = tenant.WithTenant(context.Background(), tenantB)
 
-	return db, ctxA, ctxB, dbCleanup
+	schemaA := tenantA.SchemaName()
+	schemaB := tenantB.SchemaName()
+	cleanup = func() {
+		_ = db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", pq.QuoteIdentifier(schemaA)))
+		_ = db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", pq.QuoteIdentifier(schemaB)))
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+	}
+
+	return db, ctxA, ctxB, cleanup
 }
 
 // TestTenantIsolation_RetrieveWithdrawal_NotVisibleAcrossTenants verifies that

--- a/services/current-account/service/health_test.go
+++ b/services/current-account/service/health_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lib/pq"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/shared/pkg/health"
 	"github.com/meridianhub/meridian/shared/platform/await"
-	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -24,12 +24,30 @@ import (
 func setupTestRepository(t *testing.T) *persistence.Repository {
 	t.Helper()
 
-	db, cleanup := testdb.SetupPostgres(t, []interface{}{
-		&persistence.CurrentAccountEntity{},
-	})
+	db := openSharedDB(t)
 
-	// Register cleanup to run when test completes
-	t.Cleanup(cleanup)
+	// Each test gets a unique tenant → unique schema for isolation
+	tid := uniqueTenantID()
+	schemaName := tid.SchemaName()
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// Set search_path so AutoMigrate creates tables in the tenant schema
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// AutoMigrate in the tenant schema
+	err = db.AutoMigrate(&persistence.CurrentAccountEntity{})
+	require.NoError(t, err)
+
+	// Clean up schema and close connection when test completes
+	t.Cleanup(func() {
+		_ = db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", pq.QuoteIdentifier(schemaName)))
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+	})
 
 	return persistence.NewRepository(db)
 }

--- a/services/current-account/service/lien_service_test.go
+++ b/services/current-account/service/lien_service_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
-	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/type/money"
@@ -28,22 +27,25 @@ import (
 	"gorm.io/gorm"
 )
 
-const lienSvcTestTenantID = "test_tenant"
-
 func setupLienTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	t.Helper()
-	db, cleanup := testdb.SetupPostgres(t, []interface{}{
-		&persistence.CurrentAccountEntity{},
-		&persistence.LienEntity{},
-	})
+	db := openSharedDB(t)
 
-	// Create the tenant schema for tests
-	tid := tenant.TenantID(lienSvcTestTenantID)
+	// Each test gets a unique tenant → unique schema for isolation
+	tid := uniqueTenantID()
 	schemaName := tid.SchemaName()
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	// Create the lien table in the tenant schema
+	// Set search_path so tables are created in the tenant schema
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// AutoMigrate account and lien entities
+	err = db.AutoMigrate(&persistence.CurrentAccountEntity{}, &persistence.LienEntity{})
+	require.NoError(t, err)
+
+	// Ensure lien table has all required columns (AutoMigrate may not include all)
 	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.lien (
 		id UUID PRIMARY KEY,
 		account_id UUID NOT NULL,
@@ -63,12 +65,15 @@ func setupLienTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	)`, pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	// Set default search_path to include tenant schema
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
-	require.NoError(t, err)
-
-	// Create context with tenant
 	ctx := tenant.WithTenant(context.Background(), tid)
+
+	cleanup := func() {
+		_ = db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", pq.QuoteIdentifier(schemaName)))
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+	}
 
 	return db, ctx, cleanup
 }
@@ -722,8 +727,9 @@ func TestExecuteLien_IdempotencyReturnsCachedResponse(t *testing.T) {
 	require.NoError(t, lienRepo.Create(ctx, lien))
 
 	// Pre-populate cached response
+	tid, _ := tenant.FromContext(ctx)
 	idempKey := idempotency.Key{
-		TenantID:  lienSvcTestTenantID,
+		TenantID:  string(tid),
 		Namespace: "current-account",
 		Operation: "execute_lien",
 		EntityID:  lien.ID.String(),
@@ -776,8 +782,9 @@ func TestExecuteLien_IdempotencyReturnsAbortedWhenInProgress(t *testing.T) {
 	require.NoError(t, lienRepo.Create(ctx, lien))
 
 	// Mark operation as pending
+	tid, _ := tenant.FromContext(ctx)
 	idempKey := idempotency.Key{
-		TenantID:  lienSvcTestTenantID,
+		TenantID:  string(tid),
 		Namespace: "current-account",
 		Operation: "execute_lien",
 		EntityID:  lien.ID.String(),
@@ -841,8 +848,9 @@ func TestExecuteLien_IdempotencyCleanupOnFailure(t *testing.T) {
 	mockIdemp := newLienMockIdempotencyService()
 	svc := mustNewServiceWithIdempotency(t, repo, lienRepo, mockIdemp)
 
+	tid, _ := tenant.FromContext(ctx)
 	idempKey := idempotency.Key{
-		TenantID:  lienSvcTestTenantID,
+		TenantID:  string(tid),
 		Namespace: "current-account",
 		Operation: "execute_lien",
 		EntityID:  uuid.New().String(), // Non-existent lien ID
@@ -1393,11 +1401,15 @@ func TestGetActiveAmountBlocks_MapsAmountCorrectly(t *testing.T) {
 // mock valuation engine, and mock position keeping client for testing atomic valuation in InitiateLien.
 func setupAtomicValuationLienTest(t *testing.T, engine ValuationEngine, accountBalances map[string]int64) (*Service, context.Context, func()) {
 	t.Helper()
-	db, cleanup := testdb.SetupPostgres(t, nil)
+	db := openSharedDB(t)
 
-	tid := tenant.TenantID(lienSvcTestTenantID)
+	tid := uniqueTenantID()
 	schemaName := tid.SchemaName()
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// Set search_path so tables are created in the tenant schema
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
 	// Create account table (uses "account" table name like valuation engine tests)
@@ -1477,9 +1489,6 @@ func setupAtomicValuationLienTest(t *testing.T, engine ValuationEngine, accountB
 		WHERE lifecycle_status = 'ACTIVE' AND valid_to = '9999-12-31 23:59:59+00'`, pq.QuoteIdentifier(schemaName))).Error
 	require.NoError(t, err)
 
-	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
-	require.NoError(t, err)
-
 	ctx := tenant.WithTenant(context.Background(), tid)
 
 	repo := persistence.NewRepository(db)
@@ -1501,6 +1510,14 @@ func setupAtomicValuationLienTest(t *testing.T, engine ValuationEngine, accountB
 	}
 	mockPosKeeping := &mockPositionKeepingClient{accountBalances: accountBalances}
 	svc.posKeepingClient = mockPosKeeping
+
+	cleanup := func() {
+		_ = db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", pq.QuoteIdentifier(schemaName)))
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+	}
 
 	return svc, ctx, cleanup
 }
@@ -1529,7 +1546,7 @@ func TestInitiateLien_AtomicValuation_Success(t *testing.T) {
 	})
 	defer cleanup()
 
-	tid := tenant.TenantID(lienSvcTestTenantID)
+	tid, _ := tenant.FromContext(ctx)
 	schemaName := tid.SchemaName()
 
 	// Create account and valuation feature
@@ -1586,7 +1603,7 @@ func TestInitiateLien_AtomicValuation_NoValuationFeature(t *testing.T) {
 	})
 	defer cleanup()
 
-	tid := tenant.TenantID(lienSvcTestTenantID)
+	tid, _ := tenant.FromContext(ctx)
 	schemaName := tid.SchemaName()
 
 	// Create account WITHOUT valuation feature
@@ -1633,7 +1650,7 @@ func TestInitiateLien_AtomicValuation_IdempotencyReturnsPriceLock(t *testing.T) 
 	})
 	defer cleanup()
 
-	tid := tenant.TenantID(lienSvcTestTenantID)
+	tid, _ := tenant.FromContext(ctx)
 	schemaName := tid.SchemaName()
 
 	// Create account and valuation feature
@@ -1703,7 +1720,7 @@ func TestInitiateLien_AtomicValuation_InsufficientFunds(t *testing.T) {
 	})
 	defer cleanup()
 
-	tid := tenant.TenantID(lienSvcTestTenantID)
+	tid, _ := tenant.FromContext(ctx)
 	schemaName := tid.SchemaName()
 
 	accountUUID := createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-INSUF-001", "GBP")
@@ -1738,7 +1755,7 @@ func TestInitiateLien_AtomicValuation_LegacyModeStillWorks(t *testing.T) {
 	})
 	defer cleanup()
 
-	tid := tenant.TenantID(lienSvcTestTenantID)
+	tid, _ := tenant.FromContext(ctx)
 	schemaName := tid.SchemaName()
 	createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-LEGACY-001", "GBP")
 
@@ -2009,7 +2026,7 @@ func TestInitiateLien_AtomicValuation_ValuationImmutable(t *testing.T) {
 	})
 	defer cleanup()
 
-	tid := tenant.TenantID(lienSvcTestTenantID)
+	tid, _ := tenant.FromContext(ctx)
 	schemaName := tid.SchemaName()
 	accountUUID := createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-IMMUT-001", "GBP")
 	createTestValuationFeature(t, ctx, svc.repo.DB(), schemaName, accountUUID, "UNIT")

--- a/services/current-account/service/testmain_test.go
+++ b/services/current-account/service/testmain_test.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	gormpg "gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// sharedPGConnStr holds the connection string for the shared PostgreSQL
+// testcontainer started in TestMain. All tests in this package reuse this
+// single container instead of starting ~140 individual ones.
+var sharedPGConnStr string
+
+func TestMain(m *testing.M) {
+	connStr, cleanup := testdb.StartSharedPostgres()
+	sharedPGConnStr = connStr
+
+	code := m.Run()
+
+	cleanup()
+	os.Exit(code)
+}
+
+// tenantSeq is an atomic counter for generating unique tenant IDs per test.
+var tenantSeq uint64
+
+// uniqueTenantID returns a unique tenant.TenantID for test isolation.
+// Each call returns a different ID (t1, t2, …) so tests using the shared
+// container get non-overlapping schemas via tenant.TenantID.SchemaName().
+func uniqueTenantID() tenant.TenantID {
+	n := atomic.AddUint64(&tenantSeq, 1)
+	return tenant.TenantID(fmt.Sprintf("t%d", n))
+}
+
+// openSharedDB opens a new GORM connection to the shared testcontainer.
+// Each call returns an independent database session.
+func openSharedDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(gormpg.Open(sharedPGConnStr), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("Failed to connect to shared database: %v", err)
+	}
+	return db
+}

--- a/services/current-account/service/valuation_engine_test.go
+++ b/services/current-account/service/valuation_engine_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
-	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,8 +21,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gorm.io/gorm"
 )
-
-const testTenantIDForValuation = "test_valuation_tenant"
 
 // mockValuationEngine implements ValuationEngine for testing.
 type mockValuationEngine struct {
@@ -56,15 +53,15 @@ func (m *mockValuationEngine) Evaluate(ctx context.Context, params ValuationPara
 	}, nil
 }
 
-func setupValuationEngineTest(t *testing.T) (*Service, context.Context, func()) {
+func setupValuationEngineTest(t *testing.T) (*Service, context.Context, tenant.TenantID, func()) {
 	return setupValuationEngineTestWithEngine(t, nil)
 }
 
-func setupValuationEngineTestWithEngine(t *testing.T, engine ValuationEngine) (*Service, context.Context, func()) {
+func setupValuationEngineTestWithEngine(t *testing.T, engine ValuationEngine) (*Service, context.Context, tenant.TenantID, func()) {
 	t.Helper()
-	db, cleanup := testdb.SetupPostgres(t, nil)
+	db := openSharedDB(t)
 
-	tid := tenant.TenantID(testTenantIDForValuation)
+	tid := uniqueTenantID()
 	schemaName := tid.SchemaName()
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
 	require.NoError(t, err)
@@ -142,7 +139,15 @@ func setupValuationEngineTestWithEngine(t *testing.T, engine ValuationEngine) (*
 		svc.valuationEngine = engine
 	}
 
-	return svc, ctx, cleanup
+	cleanup := func() {
+		db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %q CASCADE", schemaName))
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			sqlDB.Close()
+		}
+	}
+
+	return svc, ctx, tid, cleanup
 }
 
 // createTestAccountForValuation creates a test account and returns its string account_id.
@@ -188,10 +193,9 @@ func createTestValuationFeature(t *testing.T, _ context.Context, db *gorm.DB, sc
 // --- Tests for EvaluateAssetValuation RPC ---
 
 func TestEvaluateAssetValuation_IdentityConversion(t *testing.T) {
-	svc, ctx, cleanup := setupValuationEngineTest(t)
+	svc, ctx, tid, cleanup := setupValuationEngineTest(t)
 	defer cleanup()
 
-	tid := tenant.TenantID(testTenantIDForValuation)
 	schemaName := tid.SchemaName()
 	createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-EVAL-001", "GBP")
 
@@ -217,10 +221,9 @@ func TestEvaluateAssetValuation_IdentityConversion(t *testing.T) {
 
 func TestEvaluateAssetValuation_WithEngine(t *testing.T) {
 	engine := &mockValuationEngine{}
-	svc, ctx, cleanup := setupValuationEngineTestWithEngine(t, engine)
+	svc, ctx, tid, cleanup := setupValuationEngineTestWithEngine(t, engine)
 	defer cleanup()
 
-	tid := tenant.TenantID(testTenantIDForValuation)
 	schemaName := tid.SchemaName()
 	accountUUID := createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-EVAL-002", "GBP")
 	createTestValuationFeature(t, ctx, svc.repo.DB(), schemaName, accountUUID, "USD")
@@ -249,10 +252,9 @@ func TestEvaluateAssetValuation_WithEngine(t *testing.T) {
 
 func TestEvaluateAssetValuation_DegradedMode_NoEngine(t *testing.T) {
 	// No engine configured - should return degraded mode passthrough
-	svc, ctx, cleanup := setupValuationEngineTest(t)
+	svc, ctx, tid, cleanup := setupValuationEngineTest(t)
 	defer cleanup()
 
-	tid := tenant.TenantID(testTenantIDForValuation)
 	schemaName := tid.SchemaName()
 	accountUUID := createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-EVAL-003", "GBP")
 	createTestValuationFeature(t, ctx, svc.repo.DB(), schemaName, accountUUID, "USD")
@@ -278,7 +280,7 @@ func TestEvaluateAssetValuation_DegradedMode_NoEngine(t *testing.T) {
 }
 
 func TestEvaluateAssetValuation_AccountNotFound(t *testing.T) {
-	svc, ctx, cleanup := setupValuationEngineTest(t)
+	svc, ctx, _, cleanup := setupValuationEngineTest(t)
 	defer cleanup()
 
 	_, err := svc.EvaluateAssetValuation(ctx, &pb.EvaluateAssetValuationRequest{
@@ -297,10 +299,9 @@ func TestEvaluateAssetValuation_AccountNotFound(t *testing.T) {
 }
 
 func TestEvaluateAssetValuation_NoValuationFeature(t *testing.T) {
-	svc, ctx, cleanup := setupValuationEngineTest(t)
+	svc, ctx, tid, cleanup := setupValuationEngineTest(t)
 	defer cleanup()
 
-	tid := tenant.TenantID(testTenantIDForValuation)
 	schemaName := tid.SchemaName()
 	createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-EVAL-004", "GBP")
 
@@ -321,7 +322,7 @@ func TestEvaluateAssetValuation_NoValuationFeature(t *testing.T) {
 }
 
 func TestEvaluateAssetValuation_InvalidInput_MissingAccountID(t *testing.T) {
-	svc, ctx, cleanup := setupValuationEngineTest(t)
+	svc, ctx, _, cleanup := setupValuationEngineTest(t)
 	defer cleanup()
 
 	_, err := svc.EvaluateAssetValuation(ctx, &pb.EvaluateAssetValuationRequest{
@@ -341,7 +342,7 @@ func TestEvaluateAssetValuation_InvalidInput_MissingAccountID(t *testing.T) {
 }
 
 func TestEvaluateAssetValuation_InvalidInput_MissingInput(t *testing.T) {
-	svc, ctx, cleanup := setupValuationEngineTest(t)
+	svc, ctx, _, cleanup := setupValuationEngineTest(t)
 	defer cleanup()
 
 	_, err := svc.EvaluateAssetValuation(ctx, &pb.EvaluateAssetValuationRequest{
@@ -356,7 +357,7 @@ func TestEvaluateAssetValuation_InvalidInput_MissingInput(t *testing.T) {
 }
 
 func TestEvaluateAssetValuation_InvalidInput_EmptyInstrument(t *testing.T) {
-	svc, ctx, cleanup := setupValuationEngineTest(t)
+	svc, ctx, _, cleanup := setupValuationEngineTest(t)
 	defer cleanup()
 
 	_, err := svc.EvaluateAssetValuation(ctx, &pb.EvaluateAssetValuationRequest{
@@ -375,7 +376,7 @@ func TestEvaluateAssetValuation_InvalidInput_EmptyInstrument(t *testing.T) {
 }
 
 func TestEvaluateAssetValuation_InvalidInput_BadAmount(t *testing.T) {
-	svc, ctx, cleanup := setupValuationEngineTest(t)
+	svc, ctx, _, cleanup := setupValuationEngineTest(t)
 	defer cleanup()
 
 	_, err := svc.EvaluateAssetValuation(ctx, &pb.EvaluateAssetValuationRequest{
@@ -394,7 +395,7 @@ func TestEvaluateAssetValuation_InvalidInput_BadAmount(t *testing.T) {
 }
 
 func TestEvaluateAssetValuation_InvalidInput_NegativeAmount(t *testing.T) {
-	svc, ctx, cleanup := setupValuationEngineTest(t)
+	svc, ctx, _, cleanup := setupValuationEngineTest(t)
 	defer cleanup()
 
 	_, err := svc.EvaluateAssetValuation(ctx, &pb.EvaluateAssetValuationRequest{
@@ -413,7 +414,7 @@ func TestEvaluateAssetValuation_InvalidInput_NegativeAmount(t *testing.T) {
 }
 
 func TestEvaluateAssetValuation_InvalidInput_ZeroAmount(t *testing.T) {
-	svc, ctx, cleanup := setupValuationEngineTest(t)
+	svc, ctx, _, cleanup := setupValuationEngineTest(t)
 	defer cleanup()
 
 	_, err := svc.EvaluateAssetValuation(ctx, &pb.EvaluateAssetValuationRequest{
@@ -452,10 +453,9 @@ func TestEvaluateAssetValuation_RepoNotConfigured(t *testing.T) {
 
 func TestEvaluateAssetValuation_WithKnowledgeAt(t *testing.T) {
 	engine := &mockValuationEngine{}
-	svc, ctx, cleanup := setupValuationEngineTestWithEngine(t, engine)
+	svc, ctx, tid, cleanup := setupValuationEngineTestWithEngine(t, engine)
 	defer cleanup()
 
-	tid := tenant.TenantID(testTenantIDForValuation)
 	schemaName := tid.SchemaName()
 	accountUUID := createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-EVAL-005", "GBP")
 	createTestValuationFeature(t, ctx, svc.repo.DB(), schemaName, accountUUID, "EUR")
@@ -486,10 +486,9 @@ func TestEvaluateAssetValuation_EngineError(t *testing.T) {
 			return nil, fmt.Errorf("market data unavailable")
 		},
 	}
-	svc, ctx, cleanup := setupValuationEngineTestWithEngine(t, engine)
+	svc, ctx, tid, cleanup := setupValuationEngineTestWithEngine(t, engine)
 	defer cleanup()
 
-	tid := tenant.TenantID(testTenantIDForValuation)
 	schemaName := tid.SchemaName()
 	accountUUID := createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-EVAL-006", "GBP")
 	createTestValuationFeature(t, ctx, svc.repo.DB(), schemaName, accountUUID, "USD")
@@ -535,10 +534,9 @@ func TestGhostPricingPrevention_IdenticalResults(t *testing.T) {
 		},
 	}
 
-	svc, ctx, cleanup := setupValuationEngineTestWithEngine(t, engine)
+	svc, ctx, tid, cleanup := setupValuationEngineTestWithEngine(t, engine)
 	defer cleanup()
 
-	tid := tenant.TenantID(testTenantIDForValuation)
 	schemaName := tid.SchemaName()
 	accountUUID := createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-GHOST-001", "GBP")
 	createTestValuationFeature(t, ctx, svc.repo.DB(), schemaName, accountUUID, "USD")
@@ -587,10 +585,9 @@ func TestGhostPricingPrevention_IdenticalResults(t *testing.T) {
 // --- valuateInternal unit tests ---
 
 func TestValuateInternal_IdentityConversion(t *testing.T) {
-	svc, ctx, cleanup := setupValuationEngineTest(t)
+	svc, ctx, tid, cleanup := setupValuationEngineTest(t)
 	defer cleanup()
 
-	tid := tenant.TenantID(testTenantIDForValuation)
 	schemaName := tid.SchemaName()
 	createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-INT-001", "GBP")
 
@@ -602,7 +599,7 @@ func TestValuateInternal_IdentityConversion(t *testing.T) {
 }
 
 func TestValuateInternal_AccountNotFound(t *testing.T) {
-	svc, ctx, cleanup := setupValuationEngineTest(t)
+	svc, ctx, _, cleanup := setupValuationEngineTest(t)
 	defer cleanup()
 
 	_, err := svc.valuateInternal(ctx, "ACC-NONEXISTENT", decimal.NewFromFloat(100), "USD", time.Now())
@@ -611,10 +608,9 @@ func TestValuateInternal_AccountNotFound(t *testing.T) {
 }
 
 func TestValuateInternal_NoFeature(t *testing.T) {
-	svc, ctx, cleanup := setupValuationEngineTest(t)
+	svc, ctx, tid, cleanup := setupValuationEngineTest(t)
 	defer cleanup()
 
-	tid := tenant.TenantID(testTenantIDForValuation)
 	schemaName := tid.SchemaName()
 	createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-INT-002", "GBP")
 
@@ -625,10 +621,9 @@ func TestValuateInternal_NoFeature(t *testing.T) {
 
 func TestValuateInternal_WithEngine(t *testing.T) {
 	engine := &mockValuationEngine{}
-	svc, ctx, cleanup := setupValuationEngineTestWithEngine(t, engine)
+	svc, ctx, tid, cleanup := setupValuationEngineTestWithEngine(t, engine)
 	defer cleanup()
 
-	tid := tenant.TenantID(testTenantIDForValuation)
 	schemaName := tid.SchemaName()
 	accountUUID := createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-INT-003", "GBP")
 	createTestValuationFeature(t, ctx, svc.repo.DB(), schemaName, accountUUID, "USD")
@@ -641,10 +636,9 @@ func TestValuateInternal_WithEngine(t *testing.T) {
 }
 
 func TestValuateInternal_FallbackWithoutEngine(t *testing.T) {
-	svc, ctx, cleanup := setupValuationEngineTest(t)
+	svc, ctx, tid, cleanup := setupValuationEngineTest(t)
 	defer cleanup()
 
-	tid := tenant.TenantID(testTenantIDForValuation)
 	schemaName := tid.SchemaName()
 	accountUUID := createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-INT-004", "GBP")
 	createTestValuationFeature(t, ctx, svc.repo.DB(), schemaName, accountUUID, "USD")

--- a/services/current-account/service/valuation_feature_service_test.go
+++ b/services/current-account/service/valuation_feature_service_test.go
@@ -9,7 +9,6 @@ import (
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
-	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -17,14 +16,12 @@ import (
 	"gorm.io/gorm"
 )
 
-const testTenantIDForVF = "test_tenant"
-
 func setupValuationFeatureServiceTest(t *testing.T) (*Service, context.Context, func()) {
 	t.Helper()
-	db, cleanup := testdb.SetupPostgres(t, nil)
+	db := openSharedDB(t)
 
 	// Create the tenant schema for tests
-	tid := tenant.TenantID(testTenantIDForVF)
+	tid := uniqueTenantID()
 	schemaName := tid.SchemaName()
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
 	require.NoError(t, err)
@@ -100,6 +97,14 @@ func setupValuationFeatureServiceTest(t *testing.T) (*Service, context.Context, 
 	// Create service
 	svc, err := NewServiceWithValuationFeatures(repo, valuationFeatureRepo)
 	require.NoError(t, err)
+
+	cleanup := func() {
+		db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %q CASCADE", schemaName))
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			sqlDB.Close()
+		}
+	}
 
 	return svc, ctx, cleanup
 }
@@ -502,7 +507,7 @@ func TestValuationFeatureRepoNil(t *testing.T) {
 	svc, err := NewService(repo, nil)
 	require.NoError(t, err)
 
-	ctx := tenant.WithTenant(context.Background(), tenant.TenantID(testTenantIDForVF))
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID("test_tenant"))
 
 	// All valuation feature operations should fail
 	_, err = svc.CreateValuationFeature(ctx, &pb.CreateValuationFeatureRequest{})

--- a/services/current-account/service/withdrawal_test.go
+++ b/services/current-account/service/withdrawal_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
 	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/type/money"
@@ -833,9 +834,10 @@ func TestExecuteWithdrawal_IdempotencyReturnsCachedResponse(t *testing.T) {
 	// Create account with balance
 	_ = createTestAccountWithBalance(t, ctx, repo, "ACC-WTH-IDEMP-001", 100000)
 
-	// Pre-populate cached response
+	// Pre-populate cached response — use tenant from context (dynamic per test)
+	tid, _ := tenant.FromContext(ctx)
 	idempKey := idempotency.Key{
-		TenantID:  svcTestTenantID,
+		TenantID:  string(tid),
 		Namespace: "current-account",
 		Operation: "withdrawal",
 		EntityID:  "ACC-WTH-IDEMP-001",
@@ -883,8 +885,9 @@ func TestExecuteWithdrawal_IdempotencyReturnsAbortedWhenInProgress(t *testing.T)
 	_ = createTestAccountWithBalance(t, ctx, repo, "ACC-WTH-IDEMP-002", 100000)
 
 	// Mark operation as pending
+	tid, _ := tenant.FromContext(ctx)
 	idempKey := idempotency.Key{
-		TenantID:  svcTestTenantID,
+		TenantID:  string(tid),
 		Namespace: "current-account",
 		Operation: "withdrawal",
 		EntityID:  "ACC-WTH-IDEMP-002",
@@ -953,8 +956,9 @@ func TestExecuteWithdrawal_IdempotencyCleanupOnFailure(t *testing.T) {
 	// Create account with insufficient balance
 	_ = createTestAccountWithBalance(t, ctx, repo, "ACC-WTH-IDEMP-004", 5000) // Only $50
 
+	tid, _ := tenant.FromContext(ctx)
 	idempKey := idempotency.Key{
-		TenantID:  svcTestTenantID,
+		TenantID:  string(tid),
 		Namespace: "current-account",
 		Operation: "withdrawal",
 		EntityID:  "ACC-WTH-IDEMP-004",

--- a/shared/platform/testdb/shared.go
+++ b/shared/platform/testdb/shared.go
@@ -1,0 +1,62 @@
+// Package testdb provides utilities for setting up test databases.
+package testdb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// StartSharedPostgres starts a single PostgreSQL testcontainer for sharing
+// across all tests in a package via TestMain. Returns the connection string
+// and a cleanup function that terminates the container.
+//
+// Usage in TestMain:
+//
+//	var sharedConnStr string
+//
+//	func TestMain(m *testing.M) {
+//	    connStr, cleanup := testdb.StartSharedPostgres()
+//	    sharedConnStr = connStr
+//	    code := m.Run()
+//	    cleanup()
+//	    os.Exit(code)
+//	}
+//
+// Then in each test setup, open a new GORM connection to sharedConnStr
+// and create a unique schema for test isolation.
+func StartSharedPostgres() (string, func()) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:15-alpine",
+		postgres.WithDatabase("test_db"),
+		postgres.WithUsername("test_user"),
+		postgres.WithPassword("test_password"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		panic(fmt.Sprintf("testdb: failed to start shared PostgreSQL container: %v", err))
+	}
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		panic(fmt.Sprintf("testdb: failed to get connection string: %v", err))
+	}
+
+	cleanup := func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		_ = pgContainer.Terminate(cleanupCtx)
+	}
+
+	return connStr, cleanup
+}


### PR DESCRIPTION
## Summary

- The `current-account/service` test package was creating **~140 individual PostgreSQL testcontainers** (one per test/subtest), causing 600s timeouts in CI
- Introduces `TestMain` to start a **single shared container**, with per-test isolation via unique tenant schemas (`org_t1`, `org_t2`, ...)
- Adds `testdb.StartSharedPostgres()` utility for reuse by other packages

## Changes

- **`shared/platform/testdb/shared.go`** — New `StartSharedPostgres()` function for TestMain usage
- **`testmain_test.go`** — Package-level TestMain + `openSharedDB()` / `uniqueTenantID()` helpers
- **11 test files** — Converted all `testdb.SetupPostgres()` calls to use the shared container with per-test schema isolation

## Performance

| Metric | Before | After |
|--------|--------|-------|
| Container starts | ~140 | 1 |
| Package test time | 600s+ (timeout) | ~10s |

## Test plan

- [x] Both originally flaky tests pass: `TestListCurrentAccounts`, `TestDirectWithdrawal_InvalidAmount_NilAmountReturnsError`
- [x] Full `current-account/service` package: all tests pass in ~10s
- [x] `go vet ./...` clean
- [x] golangci-lint clean
- [ ] CI pipeline passes