### PR TITLE
fix: resolve GitHub security alerts (XSS and hono vulnerability)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7648,9 +7648,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.1.tgz",
-      "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
+      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/services/gateway/internal/middleware/mapping_middleware.go
+++ b/services/gateway/internal/middleware/mapping_middleware.go
@@ -155,6 +155,7 @@ func (m *MappingMiddleware) handleMappingRequest(w http.ResponseWriter, r *http.
 	// Pass non-2xx responses through untransformed.
 	if rec.code < 200 || rec.code >= 300 {
 		copyHeaders(w.Header(), rec.headers)
+		setSafeResponseHeaders(w)
 		w.WriteHeader(rec.code)
 		_, _ = w.Write(rec.buf.Bytes())
 		return nil
@@ -193,6 +194,7 @@ func (m *MappingMiddleware) handleMappingRequest(w http.ResponseWriter, r *http.
 		"output_bytes", len(transformed))
 
 	copyHeaders(w.Header(), rec.headers)
+	setSafeResponseHeaders(w)
 	// Remove Transfer-Encoding before setting Content-Length to avoid conflicting
 	// HTTP headers (Transfer-Encoding: chunked + Content-Length violates semantics).
 	w.Header().Del("Transfer-Encoding")
@@ -201,6 +203,13 @@ func (m *MappingMiddleware) handleMappingRequest(w http.ResponseWriter, r *http.
 	w.WriteHeader(rec.code)
 	_, _ = w.Write(transformed)
 	return nil
+}
+
+// setSafeResponseHeaders sets Content-Type and X-Content-Type-Options to prevent
+// browsers from interpreting JSON API responses as HTML (reflected XSS mitigation).
+func setSafeResponseHeaders(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 }
 
 // copyHeaders copies all headers from src into dst.


### PR DESCRIPTION
## Summary

- **Reflected XSS (CodeQL #240, #241):** Add `Content-Type: application/json` and `X-Content-Type-Options: nosniff` headers to both response paths in `MappingMiddleware` — prevents browsers from interpreting JSON API responses as HTML
- **Hono IP Spoofing (Dependabot #4):** Update `hono` transitive dependency from 4.12.1 to 4.12.3, fixing authentication bypass via IP spoofing in AWS Lambda ALB conninfo

## Changes

| File | Change |
|------|--------|
| `services/gateway/internal/middleware/mapping_middleware.go` | Add `setSafeResponseHeaders()` to non-2xx and transformed response paths |
| `frontend/package-lock.json` | Bump `hono` 4.12.1 → 4.12.3 |

## Test plan

- [x] All 34 existing middleware tests pass
- [x] Go compiles cleanly
- [x] Pre-commit hooks (gofumpt, golangci-lint, gitleaks) pass
- [ ] CI passes