### PR TITLE
feat: Add Amount type compatibility to position-keeping and payment-order

### DIFF
--- a/services/payment-order/domain/quantity.go
+++ b/services/payment-order/domain/quantity.go
@@ -2,6 +2,16 @@
 //
 // This replaces the previous money.go which used shared/domain/money,
 // migrating to the new Universal Asset System quantity package.
+//
+// # Design Constraint: Currency-Only
+//
+// Payment Order is intentionally restricted to CURRENCY dimension instruments.
+// This is by design: payment orders represent fiat money movements (bank transfers,
+// direct debits, credit card charges) which are always denominated in a currency.
+//
+// Non-currency assets (energy kWh, compute GPU_HOUR, carbon credits) are NOT
+// supported here. For multi-asset position tracking, see the position-keeping service
+// which uses the dimension-agnostic Amount type from shared/pkg/amount.
 package domain
 
 import (

--- a/services/position-keeping/domain/amount_integration_test.go
+++ b/services/position-keeping/domain/amount_integration_test.go
@@ -1,0 +1,160 @@
+package domain_test
+
+// Amount type integration tests for position-keeping.
+//
+// These tests verify that the Amount type re-exported from shared/pkg/amount can be used
+// to represent multi-dimension positions (KWH, CARBON_CREDIT, GPU_HOUR) alongside the
+// existing Money type (currency-only) within the position-keeping domain.
+//
+// The Position domain already supports multi-dimension tracking via string InstrumentCode
+// and Dimension fields. The Amount type provides a strongly-typed, dimension-aware value
+// object for use when crossing service boundaries or computing aggregated position values.
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAmountType_KWHPosition(t *testing.T) {
+	// Create an energy instrument (KWH) using NewInstrument
+	inst, err := domain.NewInstrument("KWH", 0, "ENERGY", 3)
+	require.NoError(t, err)
+
+	// Create an Amount representing 1.500 KWH (1500 milli-KWH minor units)
+	amt := domain.NewAmount(inst, 1500)
+
+	assert.Equal(t, "KWH", amt.InstrumentCode())
+	assert.Equal(t, "ENERGY", amt.Dimension())
+	assert.Equal(t, 3, amt.Precision())
+	assert.True(t, decimal.NewFromFloat(1.5).Equal(amt.Amount()))
+
+	// Minor units round-trip
+	minor, err := amt.ToMinorUnits()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1500), minor)
+}
+
+func TestAmountType_CarbonCreditPosition(t *testing.T) {
+	// Create a carbon instrument (CARBON_CREDIT) using NewInstrument
+	inst, err := domain.NewInstrument("CARBON_CREDIT", 0, "CARBON", 2)
+	require.NoError(t, err)
+
+	// Create an Amount representing 10.50 carbon credits (1050 minor units)
+	amt := domain.NewAmount(inst, 1050)
+
+	assert.Equal(t, "CARBON_CREDIT", amt.InstrumentCode())
+	assert.Equal(t, "CARBON", amt.Dimension())
+	assert.Equal(t, 2, amt.Precision())
+	assert.True(t, decimal.NewFromFloat(10.5).Equal(amt.Amount()))
+}
+
+func TestAmountType_FromDecimal_KWH(t *testing.T) {
+	inst, err := domain.NewInstrument("KWH", 0, "ENERGY", 3)
+	require.NoError(t, err)
+
+	// Create from a major-unit decimal (e.g., computed result)
+	amt := domain.NewAmountFromDecimal(inst, decimal.NewFromFloat(2.750))
+
+	assert.True(t, decimal.NewFromFloat(2.750).Equal(amt.Amount()))
+	assert.Equal(t, "KWH", amt.InstrumentCode())
+}
+
+func TestAmountType_FromInstrument_CurrencyDelegates(t *testing.T) {
+	// For CURRENCY dimension, precision should be resolved from currency registry
+	amt, err := domain.NewAmountFromInstrument("GBP", "CURRENCY", 99 /* ignored */, 10000)
+	require.NoError(t, err)
+
+	// GBP has canonical precision 2, so 10000 minor units = 100.00
+	assert.Equal(t, "GBP", amt.InstrumentCode())
+	assert.Equal(t, "CURRENCY", amt.Dimension())
+	assert.Equal(t, 2, amt.Precision())
+	assert.True(t, decimal.NewFromFloat(100.0).Equal(amt.Amount()))
+}
+
+func TestAmountType_FromInstrument_EnergyPrecision(t *testing.T) {
+	// For non-currency dimensions, caller-supplied precision is used
+	amt, err := domain.NewAmountFromInstrument("KWH", "ENERGY", 3, 1500)
+	require.NoError(t, err)
+
+	assert.Equal(t, "KWH", amt.InstrumentCode())
+	assert.Equal(t, "ENERGY", amt.Dimension())
+	assert.Equal(t, 3, amt.Precision())
+	assert.True(t, decimal.NewFromFloat(1.5).Equal(amt.Amount()))
+}
+
+func TestAmountType_FromInstrument_InvalidDimension(t *testing.T) {
+	// Unknown dimension should return ErrInvalidDimension
+	_, err := domain.NewAmountFromInstrument("XYZ", "UNKNOWN_DIM", 2, 100)
+	require.Error(t, err)
+}
+
+func TestAmountType_Add_KWH(t *testing.T) {
+	inst, err := domain.NewInstrument("KWH", 0, "ENERGY", 3)
+	require.NoError(t, err)
+
+	a := domain.NewAmount(inst, 1000) // 1.000 KWH
+	b := domain.NewAmount(inst, 500)  // 0.500 KWH
+
+	sum, err := a.Add(b)
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromFloat(1.5).Equal(sum.Amount()))
+	assert.Equal(t, "KWH", sum.InstrumentCode())
+}
+
+func TestAmountType_Add_MismatchedInstruments(t *testing.T) {
+	instKWH, err := domain.NewInstrument("KWH", 0, "ENERGY", 3)
+	require.NoError(t, err)
+
+	instCarbon, err := domain.NewInstrument("CARBON_CREDIT", 0, "CARBON", 2)
+	require.NoError(t, err)
+
+	kwh := domain.NewAmount(instKWH, 1000)
+	carbon := domain.NewAmount(instCarbon, 100)
+
+	_, err = kwh.Add(carbon)
+	require.Error(t, err, "expected error when adding KWH and CARBON_CREDIT amounts")
+}
+
+func TestAmountType_ZeroAmount(t *testing.T) {
+	inst, err := domain.NewInstrument("KWH", 0, "ENERGY", 3)
+	require.NoError(t, err)
+
+	zero := domain.ZeroAmount(inst)
+	assert.True(t, zero.IsZero())
+	assert.Equal(t, "KWH", zero.InstrumentCode())
+}
+
+func TestAmountType_GPUHourCompute(t *testing.T) {
+	// Verify GPU_HOUR compute positions can be tracked
+	inst, err := domain.NewInstrument("GPU_HOUR", 0, "COMPUTE", 4)
+	require.NoError(t, err)
+
+	// 2.5000 GPU hours = 25000 minor units
+	amt := domain.NewAmount(inst, 25000)
+
+	assert.Equal(t, "GPU_HOUR", amt.InstrumentCode())
+	assert.Equal(t, "COMPUTE", amt.Dimension())
+	assert.True(t, decimal.NewFromFloat(2.5).Equal(amt.Amount()))
+	assert.False(t, amt.IsZero())
+	assert.True(t, amt.IsPositive())
+}
+
+func TestAmountType_PositionCompatibility(t *testing.T) {
+	// Verify that Amount values can be used alongside Position records
+	// by deriving Position fields from Amount metadata
+	inst, err := domain.NewInstrument("KWH", 0, "ENERGY", 3)
+	require.NoError(t, err)
+
+	amt := domain.NewAmountFromDecimal(inst, decimal.NewFromFloat(1500.750))
+
+	// Derive Position fields from Amount (typical cross-service pattern)
+	assert.Equal(t, "KWH", amt.InstrumentCode())
+	assert.Equal(t, "ENERGY", amt.Dimension())
+
+	// Verify the amount value maps to what a Position would store
+	assert.True(t, decimal.NewFromFloat(1500.750).Equal(amt.Amount()))
+}

--- a/services/position-keeping/domain/quantity.go
+++ b/services/position-keeping/domain/quantity.go
@@ -5,10 +5,15 @@
 //
 // The Money type (Qty[Monetary]) replaces the previous money.Money type while maintaining
 // backward compatibility for existing fiat currency use cases.
+//
+// The Amount type from shared/pkg/amount provides a dimension-agnostic value type that
+// accepts any valid dimension (CURRENCY, ENERGY, CARBON, COMPUTE, etc.) and is the
+// recommended type for cross-service communication involving non-currency instruments.
 package domain
 
 import (
 	"github.com/meridianhub/meridian/shared/domain/money"
+	sharedamount "github.com/meridianhub/meridian/shared/pkg/amount"
 	"github.com/meridianhub/meridian/shared/platform/quantity"
 	"github.com/shopspring/decimal"
 )
@@ -28,6 +33,12 @@ type Money = quantity.Money
 // Asset is a commodity quantity (Qty[Commodity]).
 // Use this for non-monetary assets like energy (KWH), compute (GPU_HOUR), carbon credits, etc.
 type Asset = quantity.Asset
+
+// Amount is a dimension-agnostic value type from shared/pkg/amount.
+// Unlike Money (currency-only) and Asset (commodity-only), Amount accepts any valid dimension
+// (CURRENCY, ENERGY, CARBON, COMPUTE, etc.) and is the recommended type for cross-service
+// communication and persistence when the instrument dimension is not known at compile time.
+type Amount = sharedamount.Amount
 
 // Dimension types for compile-time safety.
 type (
@@ -105,6 +116,9 @@ var (
 
 	// ErrInvalidCurrency is returned when a currency code is not valid.
 	ErrInvalidCurrency = money.ErrInvalidCurrency
+
+	// ErrAmountOverflow is returned when converting an Amount to minor units would overflow int64.
+	ErrAmountOverflow = sharedamount.ErrAmountOverflow
 )
 
 // DimensionCurrency is the canonical dimension name for currencies.
@@ -213,6 +227,32 @@ func NewAssetFromInt(amount int64, instrument Instrument) Asset {
 // ZeroAsset creates a zero-valued Asset for the given instrument.
 func ZeroAsset(instrument Instrument) Asset {
 	return quantity.ZeroAsset(instrument)
+}
+
+// =============================================================================
+// Amount Factory Functions (dimension-agnostic cross-service type)
+// =============================================================================
+
+// NewAmount creates an Amount from an existing instrument and a minor-unit amount.
+// Amount supports any dimension (CURRENCY, ENERGY, CARBON, COMPUTE, etc.).
+func NewAmount(inst Instrument, amountMinorUnits int64) Amount {
+	return sharedamount.New(inst, amountMinorUnits)
+}
+
+// NewAmountFromDecimal creates an Amount from an existing instrument and a decimal major-unit amount.
+func NewAmountFromDecimal(inst Instrument, majorUnits decimal.Decimal) Amount {
+	return sharedamount.NewFromDecimal(inst, majorUnits)
+}
+
+// NewAmountFromInstrument creates an Amount from persisted instrument_code, dimension, precision,
+// and a minor-unit amount. For CURRENCY dimension, precision is resolved from the currency registry.
+func NewAmountFromInstrument(code, dimension string, precision int, amountMinorUnits int64) (Amount, error) {
+	return sharedamount.NewFromInstrument(code, dimension, precision, amountMinorUnits)
+}
+
+// ZeroAmount creates a zero Amount for the given instrument.
+func ZeroAmount(inst Instrument) Amount {
+	return sharedamount.Zero(inst)
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Re-exports `shared/pkg/amount.Amount` as `domain.Amount` in position-keeping, providing a dimension-agnostic type for multi-asset cross-service communication (CURRENCY, ENERGY, CARBON, COMPUTE, etc.)
- Documents payment-order as intentionally currency-only by design
- Adds integration tests for multi-dimension position tracking (KWH, CARBON_CREDIT, GPU_HOUR)

## Changes Made

### `services/position-keeping/domain/quantity.go`
- Added `Amount = sharedamount.Amount` type alias alongside existing `Money` and `Asset`
- Added factory functions: `NewAmount`, `NewAmountFromDecimal`, `NewAmountFromInstrument`, `ZeroAmount`
- Re-exported `ErrAmountOverflow` sentinel from `shared/pkg/amount`
- Updated package doc to describe when to use each type

### `services/payment-order/domain/quantity.go`
- Added "Design Constraint: Currency-Only" section to package doc comment explaining why payment-order is intentionally restricted to CURRENCY dimension

### `services/position-keeping/domain/amount_integration_test.go` (new)
- Integration tests for KWH energy positions
- Integration tests for CARBON_CREDIT positions
- Integration tests for GPU_HOUR compute positions
- Tests for instrument mismatch errors
- Tests for CURRENCY precision delegation to currency registry

## Technical Details

The `Amount` type differs from `Money` and `Asset`:
- `Money` = `Qty[Monetary]` — compile-time enforced CURRENCY only
- `Asset` = `Qty[Commodity]` — compile-time enforced non-CURRENCY only
- `Amount` = `sharedamount.Amount` — dimension-agnostic, accepts any valid dimension at runtime

This is the recommended type for cross-service communication when the instrument dimension is not known at compile time (e.g., persistence layer, service boundaries).

## Testing

All existing tests pass unchanged. New integration tests added:

```
ok  github.com/meridianhub/meridian/services/position-keeping/domain
ok  github.com/meridianhub/meridian/services/payment-order/domain
```

## Risk Assessment

Low. Changes are additive only:
- New type alias and factory functions in position-keeping (no existing code modified)
- Documentation-only change in payment-order
- No schema or persistence changes

## Part of

Task Master: asset-agnostic-accounts.19