### PR TITLE
fix: resolve demo frontend to real tenant instead of hardcoded dev-tenant

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { queryClient } from '@/lib/query-client'
 import { PageErrorBoundary } from '@/components/error-boundary'
 import { AuthProvider, useAuth } from '@/contexts/auth-context'
 import { TenantProvider, useTenantContext } from '@/contexts/tenant-context'
+import { useTenants } from '@/hooks/use-tenants'
 import { ApiClientProvider } from '@/api/context'
 import { ProtectedRoute, PlatformOnlyRoute } from '@/components/routing'
 import { AppShell } from '@/components/layout/app-shell'
@@ -228,17 +229,22 @@ function ApiClientBridge({ children }: { children: ReactNode }) {
 }
 
 /**
- * In dev mode, auto-select the seeded dev tenant for platform admins
+ * In dev/demo mode, auto-select the first real tenant for platform admins
  * so pages show data immediately after login.
  */
 function DevTenantAutoSelector() {
   const { isPlatformAdmin, currentTenant, switchTenant } = useTenantContext()
+  const { data: tenants } = useTenants()
 
   useEffect(() => {
-    if (isPlatformAdmin && !currentTenant) {
-      switchTenant({ id: 'dev_tenant', slug: 'dev-tenant', name: 'Dev Tenant' })
+    if (isPlatformAdmin && !currentTenant && tenants?.length) {
+      // Pick the first tenant that has a slug (skip system tenants without one)
+      const tenant = tenants.find((t) => t.slug) ?? tenants[0]
+      if (tenant) {
+        switchTenant({ id: tenant.tenantId, slug: tenant.slug, name: tenant.displayName })
+      }
     }
-  }, [isPlatformAdmin, currentTenant, switchTenant])
+  }, [isPlatformAdmin, currentTenant, tenants, switchTenant])
 
   return null
 }

--- a/frontend/src/api/transport.ts
+++ b/frontend/src/api/transport.ts
@@ -12,11 +12,13 @@ export function createTenantTransport(
   getToken: TokenGetter,
   getTenantSlug: TenantSlugGetter,
 ): Transport {
-  // In development, keep the base URL and route via X-Tenant-Slug header
-  // (the gateway's LOCAL_DEV_MODE resolves tenants from the header).
+  // In development or demo mode, keep the base URL and route via X-Tenant-Slug header
+  // (the gateway resolves tenants from the header when not using subdomain routing).
   // In production, use subdomain-based URL for tenant routing.
+  const useHeaderRouting =
+    import.meta.env.DEV || import.meta.env.VITE_DEMO_MODE === 'true'
   const baseUrl =
-    tenantSlug && !import.meta.env.DEV ? buildTenantBaseUrl(tenantSlug) : apiConfig.baseUrl
+    tenantSlug && !useHeaderRouting ? buildTenantBaseUrl(tenantSlug) : apiConfig.baseUrl
 
   return createConnectTransport({
     baseUrl,

--- a/frontend/src/api/transport.ts
+++ b/frontend/src/api/transport.ts
@@ -12,13 +12,11 @@ export function createTenantTransport(
   getToken: TokenGetter,
   getTenantSlug: TenantSlugGetter,
 ): Transport {
-  // In development or demo mode, keep the base URL and route via X-Tenant-Slug header
-  // (the gateway resolves tenants from the header when not using subdomain routing).
+  // In development, keep the base URL and route via X-Tenant-Slug header
+  // (the gateway's LOCAL_DEV_MODE resolves tenants from the header).
   // In production, use subdomain-based URL for tenant routing.
-  const useHeaderRouting =
-    import.meta.env.DEV || import.meta.env.VITE_DEMO_MODE === 'true'
   const baseUrl =
-    tenantSlug && !useHeaderRouting ? buildTenantBaseUrl(tenantSlug) : apiConfig.baseUrl
+    tenantSlug && !import.meta.env.DEV ? buildTenantBaseUrl(tenantSlug) : apiConfig.baseUrl
 
   return createConnectTransport({
     baseUrl,


### PR DESCRIPTION
## Summary

- Demo frontend `DevTenantAutoSelector` hardcoded a non-existent `dev-tenant` slug
- All API calls routed to `dev-tenant.demo.meridianhub.cloud` which returned 503 (tenant not found in DB)
- Real tenant is `volterra-energy`

## Changes Made

**`frontend/src/App.tsx`**: `DevTenantAutoSelector` now queries real tenants from the `ListTenants` API and auto-selects the first tenant with a slug, instead of hardcoding a non-existent `dev-tenant`.

## Test plan

- [x] Type-check passes (`tsc --noEmit`)
- [x] Existing `use-tenants` hook tests pass
- [ ] After deploying to demo: login as Platform Admin, verify dashboard shows real tenant data
- [ ] Verify tenant selector populates with real tenants