### PR TITLE
fix: enable header-based tenant routing for demo and register CurrentAccountService

### DIFF
--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -745,9 +745,11 @@ var serviceNames = []string{
 	"meridian.financial_accounting.v1.FinancialAccountingService",
 	"meridian.position_keeping.v1.PositionKeepingService",
 	"meridian.forecasting.v1.ForecastingService",
-	// CurrentAccountService excluded from Vanguard: its REST routes (/v1/liens/*)
-	// conflict with InternalAccountService. Still reachable via Connect protocol
-	// (/{package}.{Service}/{Method} paths don't conflict).
+	// CurrentAccountService shares REST routes (/v1/liens/*) with InternalAccountService.
+	// Vanguard resolves the conflict by routing REST lien requests to whichever service
+	// was registered first (InternalAccountService above). Connect protocol paths
+	// (/{package}.{Service}/{Method}) are unique per service and never conflict.
+	"meridian.current_account.v1.CurrentAccountService",
 	"meridian.payment_order.v1.PaymentOrderService",
 	"meridian.reconciliation.v1.AccountReconciliationService",
 	"meridian.saga.v1.SagaRegistryService",

--- a/frontend/src/api/transport.ts
+++ b/frontend/src/api/transport.ts
@@ -12,11 +12,13 @@ export function createTenantTransport(
   getToken: TokenGetter,
   getTenantSlug: TenantSlugGetter,
 ): Transport {
-  // In development, keep the base URL and route via X-Tenant-Slug header
+  // In development or demo mode, keep the base URL and route via X-Tenant-Slug header
   // (the gateway's LOCAL_DEV_MODE resolves tenants from the header).
   // In production, use subdomain-based URL for tenant routing.
+  const useHeaderRouting =
+    import.meta.env.DEV || import.meta.env.VITE_DEMO_MODE === 'true'
   const baseUrl =
-    tenantSlug && !import.meta.env.DEV ? buildTenantBaseUrl(tenantSlug) : apiConfig.baseUrl
+    tenantSlug && !useHeaderRouting ? buildTenantBaseUrl(tenantSlug) : apiConfig.baseUrl
 
   return createConnectTransport({
     baseUrl,


### PR DESCRIPTION
## Summary

Two fixes for demo environment data loading:

- **Issue A**: Cloudflare does not proxy `*.demo.meridianhub.cloud` subdomains, causing 503 for all tenant-scoped API calls using subdomain routing
- **Issue B**: `CurrentAccountService` was excluded from the Vanguard HTTP transcoder, returning 404 for all Connect-protocol requests (e.g. `ListCurrentAccounts`)

## Changes Made

**`frontend/src/api/transport.ts`**: In demo mode (`VITE_DEMO_MODE=true`), use header-based routing (`X-Tenant-Slug` header on the base domain) instead of subdomain routing. Requires `LOCAL_DEV_MODE=true` on the demo server (already applied to `/opt/meridian/.env`).

**`cmd/meridian/main.go`**: Add `CurrentAccountService` to the Vanguard transcoder's `serviceNames` list. The previous comment claimed it was "still reachable via Connect protocol" after exclusion — this was incorrect. Connect-protocol paths (`/{package}.{Service}/{Method}`) are unique per service and do not conflict; only REST routes (`/v1/liens/*`) overlap with `InternalAccountService`, which continues to win as the first-registered handler.

## Test plan

- [x] Go build passes (no Vanguard route conflicts at compile time)
- [x] Frontend type-check passes
- [x] Pre-commit hooks pass (gofumpt, golangci-lint, gitleaks)
- [ ] After deploy: verify dashboard loads data via `demo.meridianhub.cloud` (not subdomain)
- [ ] After deploy: verify Accounts page loads via `CurrentAccountService`