### PR TITLE
fix: Propagate tenant context when auth is disabled

### DIFF
--- a/frontend/src/pages/positions/detail.tsx
+++ b/frontend/src/pages/positions/detail.tsx
@@ -208,7 +208,7 @@ export function PositionDetailPage() {
                 <SkeletonField />
               ) : (
                 <span>
-                  {log?.statusTracking?.currentStatus?.replace(/_/g, ' ') ?? '—'}
+                  {typeof log?.statusTracking?.currentStatus === 'string' ? log.statusTracking.currentStatus.replace(/_/g, ' ') : '—'}
                 </span>
               )}
             </LabeledField>

--- a/frontend/src/pages/positions/index.tsx
+++ b/frontend/src/pages/positions/index.tsx
@@ -84,8 +84,8 @@ export function PositionsPage() {
       accessorKey: 'statusTracking',
       header: 'Status',
       cell: ({ row }) => {
-        const status = row.original.statusTracking?.currentStatus ?? '—'
-        return <span className="text-sm">{status.replace(/_/g, ' ')}</span>
+        const status = row.original.statusTracking?.currentStatus
+        return <span className="text-sm">{typeof status === 'string' ? status.replace(/_/g, ' ') : '—'}</span>
       },
     },
     {

--- a/services/gateway/metadata.go
+++ b/services/gateway/metadata.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/meridianhub/meridian/services/gateway/auth"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
 // metadataPropagationMiddleware is an HTTP middleware for the Vanguard transcoder
@@ -88,5 +89,14 @@ func writeIdentityMetadata(req *http.Request) {
 		if tenantID, ok := auth.GetTenantIDFromContext(ctx); ok && tenantID != "" {
 			req.Header.Set("x-tenant-id", tenantID)
 		}
+		return
+	}
+
+	// Fall back to tenant resolver context. When auth is disabled
+	// (AUTH_ENABLED=false), the tenant resolver middleware still injects the
+	// tenant ID into the request context via tenant.WithTenant(). Propagate
+	// it as a header so Vanguard forwards it as gRPC metadata.
+	if tenantID, ok := tenant.FromContext(ctx); ok && !tenantID.IsEmpty() {
+		req.Header.Set("x-tenant-id", string(tenantID))
 	}
 }

--- a/services/gateway/metadata_test.go
+++ b/services/gateway/metadata_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/meridianhub/meridian/services/gateway/auth"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -232,4 +233,50 @@ func TestMetadataPropagationMiddleware_JWTPrioritizedOverAPIKey(t *testing.T) {
 	assert.Equal(t, "jwt-user", capturedHeaders.Get("x-user-id"))
 	assert.Equal(t, AuthMethodJWT, capturedHeaders.Get("x-auth-method"))
 	assert.Equal(t, "jwt-tenant", capturedHeaders.Get("x-tenant-id"))
+}
+
+// TestMetadataPropagationMiddleware_TenantResolverFallback verifies that when
+// auth is disabled (no JWT or API key identity), the middleware falls back to
+// tenant context set by the tenant resolver middleware.
+func TestMetadataPropagationMiddleware_TenantResolverFallback(t *testing.T) {
+	var capturedHeaders http.Header
+
+	handler := metadataPropagationMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/meridian.party.v1.PartyService/ListParties", nil)
+	// No auth context (AUTH_ENABLED=false), but tenant resolver injected tenant
+	ctx := tenant.WithTenant(req.Context(), tenant.TenantID("volterra_energy"))
+	req = req.WithContext(ctx)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	// Tenant ID propagated from resolver context
+	assert.Equal(t, "volterra_energy", capturedHeaders.Get("x-tenant-id"))
+	// No auth identity headers
+	assert.Empty(t, capturedHeaders.Get("x-user-id"))
+	assert.Empty(t, capturedHeaders.Get("x-auth-method"))
+}
+
+// TestMetadataPropagationMiddleware_TenantResolverSpoofedHeaderStripped verifies
+// that spoofed x-tenant-id headers are stripped even when tenant resolver context
+// is used as fallback.
+func TestMetadataPropagationMiddleware_TenantResolverSpoofedHeaderStripped(t *testing.T) {
+	var capturedHeaders http.Header
+
+	handler := metadataPropagationMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.Header.Set("x-tenant-id", "spoofed-tenant")
+	// Tenant resolver set the real tenant
+	ctx := tenant.WithTenant(req.Context(), tenant.TenantID("real_tenant"))
+	req = req.WithContext(ctx)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	// Spoofed header replaced by resolver tenant
+	assert.Equal(t, "real_tenant", capturedHeaders.Get("x-tenant-id"))
 }


### PR DESCRIPTION
## Summary

- Fix tenant context propagation in the gateway's metadata middleware when `AUTH_ENABLED=false`
- Fix frontend crash on Positions page when `statusTracking.currentStatus` is not a string

## Problem

On the demo environment (`AUTH_ENABLED=false`), all tenant-scoped API calls (Parties, Accounts, Ledger, etc.) returned 500 "tenant context missing". The Positions page crashed with `TypeError: o.replace is not a function`.

**Root cause**: The `metadataPropagationMiddleware` strips incoming `x-tenant-id` headers (security measure to prevent spoofing), then re-sets them from the auth context (JWT or API key). When auth is disabled, the auth context is empty, so the header set by the tenant resolver was stripped and never restored. Vanguard forwarded the request without `x-tenant-id`, and the gRPC `TenantExtractionInterceptor` found no tenant in the metadata.

## Changes

**Backend** (`services/gateway/metadata.go`):
- Add fallback in `writeIdentityMetadata()` that reads tenant from `tenant.FromContext(ctx)` when neither JWT nor API key identity is present
- The tenant resolver middleware sets this context value regardless of auth state

**Backend tests** (`services/gateway/metadata_test.go`):
- `TenantResolverFallback`: verifies tenant propagation when auth is disabled but tenant resolver is active
- `TenantResolverSpoofedHeaderStripped`: verifies spoofed headers are still stripped with fallback active

**Frontend** (`frontend/src/pages/positions/index.tsx`, `detail.tsx`):
- Guard `.replace()` calls with `typeof === 'string'` check to handle non-string `currentStatus` values from the API

## Testing

- All 12 metadata propagation tests pass (10 existing + 2 new)
- TypeScript compiles clean
- Pre-commit hooks pass (gofumpt, golangci-lint, gitleaks)