### PR TITLE
feat: enable Dex OIDC authentication for demo environment

### DIFF
--- a/deploy/demo/dex.yaml
+++ b/deploy/demo/dex.yaml
@@ -8,8 +8,8 @@
 #     -d "grant_type=password" \
 #     -d "client_id=meridian-service" \
 #     -d "scope=openid email profile" \
-#     -d "username=developer@meridian.local" \
-#     -d "password=<your-password>"
+#     -d "username=admin@volterra.energy" \
+#     -d "password=demo2026"
 
 issuer: https://demo.meridianhub.cloud/dex
 
@@ -36,8 +36,14 @@ staticClients:
 enablePasswordDB: true
 
 staticPasswords:
-  - email: "developer@meridian.local"
-    # Generate with: htpasswd -nbBC 10 "" 'your-password' | tr -d ':\n' | sed 's/$2y/$2a/'
-    hash: "REPLACE_WITH_BCRYPT_HASH"
-    username: "developer"
-    userID: "00000000-0000-0000-0000-000000000001"
+  - email: "admin@volterra.energy"
+    # Password: demo2026
+    # Generate with: htpasswd -nbBC 10 "" 'demo2026' | tr -d ':\n' | sed 's/$2y/$2a/'
+    hash: "$2a$10$lIDConGp2.xX/KXg31kHoezV2HN/hDeF/aVLlAZh4LDX9q9uaj5y."
+    username: "Admin"
+    userID: "admin-volterra-001"
+  - email: "operator@volterra.energy"
+    # Password: demo2026
+    hash: "$2a$10$lIDConGp2.xX/KXg31kHoezV2HN/hDeF/aVLlAZh4LDX9q9uaj5y."
+    username: "Operator"
+    userID: "operator-volterra-001"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useEffect, useRef } from 'react'
+import { type ReactNode, useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
 import { BrowserRouter, Routes, Route, useLocation, useNavigate } from 'react-router-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
@@ -54,6 +54,55 @@ function PlaceholderPage({ title }: { title: string }) {
 function LoginPage() {
   const { login } = useAuth()
   const navigate = useNavigate()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleDexLogin = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault()
+      setError('')
+      setLoading(true)
+
+      try {
+        const body = new URLSearchParams({
+          grant_type: 'password',
+          client_id: 'meridian-service',
+          scope: 'openid email profile',
+          username: email,
+          password,
+        })
+
+        const response = await fetch('/dex/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: body.toString(),
+        })
+
+        if (!response.ok) {
+          const text = await response.text()
+          setError(text.includes('invalid_grant') ? 'Invalid email or password' : 'Authentication failed')
+          return
+        }
+
+        const data = (await response.json()) as { id_token?: string; access_token?: string }
+        const token = data.id_token ?? data.access_token
+        if (!token) {
+          setError('No token received from identity provider')
+          return
+        }
+
+        login(token)
+        navigate('/')
+      } catch {
+        setError('Unable to reach identity provider')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [email, password, login, navigate],
+  )
 
   const devLogin = useCallback(
     (role: 'platform-admin' | 'tenant-user') => {
@@ -78,15 +127,60 @@ function LoginPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <div className="text-center space-y-6">
-        <div>
+      <div className="w-full max-w-sm space-y-6 px-4">
+        <div className="text-center">
           <h1 className="text-2xl font-semibold">Meridian Operations Console</h1>
           <p className="mt-2 text-muted-foreground">Please sign in to continue.</p>
         </div>
-        {(import.meta.env.DEV || import.meta.env.VITE_DEMO_MODE === 'true') && (
+
+        {/* Dex login form - shown in demo mode and production */}
+        {(import.meta.env.VITE_DEMO_MODE === 'true' || !import.meta.env.DEV) && (
+          <form onSubmit={(e) => void handleDexLogin(e)} className="space-y-4">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium mb-1">
+                Email
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoComplete="email"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                placeholder="admin@volterra.energy"
+              />
+            </div>
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium mb-1">
+                Password
+              </label>
+              <input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                autoComplete="current-password"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </div>
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              {loading ? 'Signing in...' : 'Sign in'}
+            </button>
+          </form>
+        )}
+
+        {/* Dev-only fake JWT buttons */}
+        {import.meta.env.DEV && (
           <div className="space-y-2">
-            <p className="text-xs text-muted-foreground uppercase tracking-wider">
-              {import.meta.env.DEV ? 'Development Login' : 'Demo Login'}
+            <p className="text-xs text-muted-foreground uppercase tracking-wider text-center">
+              Development Login
             </p>
             <div className="flex gap-2 justify-center">
               <button

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -40,19 +40,32 @@ export function parseJWT(token: unknown): JWTClaims | null {
       .padEnd(payload.length + ((4 - (payload.length % 4)) % 4), '=')
     const decoded = JSON.parse(atob(padded)) as Record<string, unknown>
 
+    // Determine user ID: prefer custom userId claim, fall back to standard OIDC sub claim
+    const userId =
+      typeof decoded.userId === 'string' && decoded.userId
+        ? decoded.userId
+        : typeof decoded.sub === 'string' && decoded.sub
+          ? decoded.sub
+          : null
+
     // Strict type validation to prevent expiry bypass and type confusion
     if (
-      typeof decoded.userId !== 'string' ||
+      !userId ||
       typeof decoded.exp !== 'number' ||
       !isFinite(decoded.exp) ||
       typeof decoded.iss !== 'string' ||
-      typeof decoded.aud !== 'string' ||
-      !decoded.userId ||
-      !decoded.iss ||
-      !decoded.aud
+      !decoded.iss
     ) {
       return null
     }
+
+    // Standard OIDC tokens may use aud as string or array
+    const aud =
+      typeof decoded.aud === 'string'
+        ? decoded.aud
+        : Array.isArray(decoded.aud) && decoded.aud.length > 0 && typeof decoded.aud[0] === 'string'
+          ? (decoded.aud[0] as string)
+          : ''
 
     const roles = Array.isArray(decoded.roles)
       ? (decoded.roles as unknown[]).filter((r): r is string => typeof r === 'string')
@@ -62,13 +75,13 @@ export function parseJWT(token: unknown): JWTClaims | null {
       : []
 
     return {
-      userId: decoded.userId,
+      userId,
       tenantId: typeof decoded.tenantId === 'string' ? decoded.tenantId : undefined,
       roles,
       scopes,
       exp: decoded.exp,
       iss: decoded.iss,
-      aud: decoded.aud,
+      aud,
       sub: typeof decoded.sub === 'string' ? decoded.sub : undefined,
     }
   } catch {
@@ -86,7 +99,11 @@ function getUserLens(claims: JWTClaims | null): 'platform' | 'tenant' {
   if (claims.tenantId) return 'tenant'
   const isPlatformLevel =
     claims.roles.includes('platform-admin') || claims.roles.includes('super-admin')
-  return isPlatformLevel ? 'platform' : 'tenant'
+  if (isPlatformLevel) return 'platform'
+  // In demo mode, standard OIDC tokens lack tenant and role claims.
+  // Default to 'platform' lens so DevTenantAutoSelector picks a tenant automatically.
+  if (import.meta.env.VITE_DEMO_MODE === 'true') return 'platform'
+  return 'tenant'
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)

--- a/services/gateway/auth/combined_middleware.go
+++ b/services/gateway/auth/combined_middleware.go
@@ -39,6 +39,9 @@ type CombinedAuthConfig struct {
 	// JWTValidator is the JWT token validator. Required for JWT authentication.
 	JWTValidator JWTValidator
 
+	// JWTConfig holds optional JWT middleware configuration (OIDC defaults).
+	JWTConfig JWTMiddlewareConfig
+
 	// APIKeyConfig is the configuration for API key authentication.
 	// If APIKeys is nil or empty, legacy API key authentication is disabled.
 	APIKeyConfig APIKeyConfig
@@ -64,7 +67,7 @@ func NewCombinedAuthMiddleware(config CombinedAuthConfig) (*CombinedAuthMiddlewa
 	// Set up JWT middleware if validator is provided
 	if config.JWTValidator != nil {
 		var err error
-		jwtMiddleware, err = NewJWTMiddleware(config.JWTValidator, config.Logger)
+		jwtMiddleware, err = NewJWTMiddleware(config.JWTValidator, config.Logger, config.JWTConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/services/gateway/auth/jwt_middleware.go
+++ b/services/gateway/auth/jwt_middleware.go
@@ -135,26 +135,28 @@ func (m *JWTMiddleware) Handler(next http.Handler) http.Handler {
 			return
 		}
 
-		// Step 3: Apply OIDC defaults for standard tokens missing custom claims
-		effectiveUserID := claims.EffectiveUserID()
-		effectiveTenantID := claims.TenantID
-		effectiveRoles := claims.GetRoles()
+		// Step 3: Apply OIDC defaults for standard tokens missing custom claims.
+		// Create a shallow copy so the original token claims are not mutated,
+		// but downstream middleware (e.g., TenantAuthorizationMiddleware) sees
+		// the effective values when reading claims from context.
+		effectiveClaims := *claims
+		effectiveClaims.UserID = claims.EffectiveUserID()
 
-		if effectiveTenantID == "" && m.defaultTenantID != "" {
-			effectiveTenantID = m.defaultTenantID
+		if effectiveClaims.TenantID == "" && m.defaultTenantID != "" {
+			effectiveClaims.TenantID = m.defaultTenantID
 		}
-		if len(claims.Roles) == 0 && len(m.defaultRoles) > 0 {
-			effectiveRoles = make([]string, len(m.defaultRoles))
-			copy(effectiveRoles, m.defaultRoles)
+		if len(effectiveClaims.Roles) == 0 && len(m.defaultRoles) > 0 {
+			effectiveClaims.Roles = make([]string, len(m.defaultRoles))
+			copy(effectiveClaims.Roles, m.defaultRoles)
 		}
 
-		// Step 4: Inject claims into context (using effective values)
-		ctx := injectClaimsToContextWithDefaults(r.Context(), claims, effectiveUserID, effectiveTenantID, effectiveRoles)
+		// Step 4: Inject effective claims into context
+		ctx := injectClaimsToContext(r.Context(), &effectiveClaims)
 
 		// Step 5: Log successful authentication
 		m.logger.Debug("JWT authentication successful",
-			slog.String("user_id", effectiveUserID),
-			slog.String("tenant_id", effectiveTenantID),
+			slog.String("user_id", effectiveClaims.UserID),
+			slog.String("tenant_id", effectiveClaims.TenantID),
 			slog.String("path", r.URL.Path),
 		)
 
@@ -248,22 +250,16 @@ func (m *JWTMiddleware) handleValidationError(w http.ResponseWriter, r *http.Req
 // It stores individual claim values for easy access and the full claims object
 // for cases where all claims are needed.
 func injectClaimsToContext(ctx context.Context, claims *platformauth.Claims) context.Context {
-	return injectClaimsToContextWithDefaults(ctx, claims, claims.UserID, claims.TenantID, claims.GetRoles())
-}
-
-// injectClaimsToContextWithDefaults adds JWT claims to context using effective values
-// that may differ from the raw token claims (e.g., when OIDC defaults are applied).
-func injectClaimsToContextWithDefaults(ctx context.Context, claims *platformauth.Claims, effectiveUserID, effectiveTenantID string, effectiveRoles []string) context.Context {
-	ctx = context.WithValue(ctx, UserIDContextKey, effectiveUserID)
-	ctx = context.WithValue(ctx, TenantIDContextKey, effectiveTenantID)
-	ctx = context.WithValue(ctx, RolesContextKey, effectiveRoles)
+	ctx = context.WithValue(ctx, UserIDContextKey, claims.UserID)
+	ctx = context.WithValue(ctx, TenantIDContextKey, claims.TenantID)
+	ctx = context.WithValue(ctx, RolesContextKey, claims.GetRoles())
 	ctx = context.WithValue(ctx, ScopesContextKey, claims.GetScopes())
 	ctx = context.WithValue(ctx, ClaimsContextKey, claims)
 
 	// Also inject tenant into context using the shared tenant package
 	// This allows downstream handlers to use tenant.FromContext()
-	if effectiveTenantID != "" {
-		if tenantID, err := tenant.NewTenantID(effectiveTenantID); err == nil {
+	if claims.TenantID != "" {
+		if tenantID, err := tenant.NewTenantID(claims.TenantID); err == nil {
 			ctx = tenant.WithTenant(ctx, tenantID)
 		}
 	}

--- a/services/gateway/auth/jwt_middleware.go
+++ b/services/gateway/auth/jwt_middleware.go
@@ -62,17 +62,28 @@ type JWTValidator interface {
 	ValidateToken(tokenString string) (*platformauth.Claims, error)
 }
 
+// JWTMiddlewareConfig holds optional configuration for the JWT middleware.
+type JWTMiddlewareConfig struct {
+	// DefaultTenantID is injected into context when the token lacks an x-tenant-id claim.
+	DefaultTenantID string
+	// DefaultRoles are injected into context when the token lacks a roles claim.
+	DefaultRoles []string
+}
+
 // JWTMiddleware provides HTTP middleware for JWT authentication.
 // It extracts the Authorization header, validates the Bearer token,
 // and injects verified claims into the request context.
 type JWTMiddleware struct {
-	validator JWTValidator
-	logger    *slog.Logger
+	validator       JWTValidator
+	logger          *slog.Logger
+	defaultTenantID string
+	defaultRoles    []string
 }
 
 // NewJWTMiddleware creates a new JWT authentication middleware.
 // Both validator and logger are required parameters.
-func NewJWTMiddleware(validator JWTValidator, logger *slog.Logger) (*JWTMiddleware, error) {
+// An optional config can be provided for OIDC claim defaults.
+func NewJWTMiddleware(validator JWTValidator, logger *slog.Logger, configs ...JWTMiddlewareConfig) (*JWTMiddleware, error) {
 	if validator == nil {
 		return nil, ErrNilValidator
 	}
@@ -80,10 +91,17 @@ func NewJWTMiddleware(validator JWTValidator, logger *slog.Logger) (*JWTMiddlewa
 		return nil, ErrNilLogger
 	}
 
-	return &JWTMiddleware{
+	m := &JWTMiddleware{
 		validator: validator,
 		logger:    logger,
-	}, nil
+	}
+
+	if len(configs) > 0 {
+		m.defaultTenantID = configs[0].DefaultTenantID
+		m.defaultRoles = configs[0].DefaultRoles
+	}
+
+	return m, nil
 }
 
 // Handler returns an http.Handler that performs JWT authentication.
@@ -117,13 +135,26 @@ func (m *JWTMiddleware) Handler(next http.Handler) http.Handler {
 			return
 		}
 
-		// Step 3: Inject claims into context
-		ctx := injectClaimsToContext(r.Context(), claims)
+		// Step 3: Apply OIDC defaults for standard tokens missing custom claims
+		effectiveUserID := claims.EffectiveUserID()
+		effectiveTenantID := claims.TenantID
+		effectiveRoles := claims.GetRoles()
 
-		// Step 4: Log successful authentication
+		if effectiveTenantID == "" && m.defaultTenantID != "" {
+			effectiveTenantID = m.defaultTenantID
+		}
+		if len(claims.Roles) == 0 && len(m.defaultRoles) > 0 {
+			effectiveRoles = make([]string, len(m.defaultRoles))
+			copy(effectiveRoles, m.defaultRoles)
+		}
+
+		// Step 4: Inject claims into context (using effective values)
+		ctx := injectClaimsToContextWithDefaults(r.Context(), claims, effectiveUserID, effectiveTenantID, effectiveRoles)
+
+		// Step 5: Log successful authentication
 		m.logger.Debug("JWT authentication successful",
-			slog.String("user_id", claims.UserID),
-			slog.String("tenant_id", claims.TenantID),
+			slog.String("user_id", effectiveUserID),
+			slog.String("tenant_id", effectiveTenantID),
 			slog.String("path", r.URL.Path),
 		)
 
@@ -217,16 +248,22 @@ func (m *JWTMiddleware) handleValidationError(w http.ResponseWriter, r *http.Req
 // It stores individual claim values for easy access and the full claims object
 // for cases where all claims are needed.
 func injectClaimsToContext(ctx context.Context, claims *platformauth.Claims) context.Context {
-	ctx = context.WithValue(ctx, UserIDContextKey, claims.UserID)
-	ctx = context.WithValue(ctx, TenantIDContextKey, claims.TenantID)
-	ctx = context.WithValue(ctx, RolesContextKey, claims.GetRoles())
+	return injectClaimsToContextWithDefaults(ctx, claims, claims.UserID, claims.TenantID, claims.GetRoles())
+}
+
+// injectClaimsToContextWithDefaults adds JWT claims to context using effective values
+// that may differ from the raw token claims (e.g., when OIDC defaults are applied).
+func injectClaimsToContextWithDefaults(ctx context.Context, claims *platformauth.Claims, effectiveUserID, effectiveTenantID string, effectiveRoles []string) context.Context {
+	ctx = context.WithValue(ctx, UserIDContextKey, effectiveUserID)
+	ctx = context.WithValue(ctx, TenantIDContextKey, effectiveTenantID)
+	ctx = context.WithValue(ctx, RolesContextKey, effectiveRoles)
 	ctx = context.WithValue(ctx, ScopesContextKey, claims.GetScopes())
 	ctx = context.WithValue(ctx, ClaimsContextKey, claims)
 
 	// Also inject tenant into context using the shared tenant package
 	// This allows downstream handlers to use tenant.FromContext()
-	if claims.TenantID != "" {
-		if tenantID, err := tenant.NewTenantID(claims.TenantID); err == nil {
+	if effectiveTenantID != "" {
+		if tenantID, err := tenant.NewTenantID(effectiveTenantID); err == nil {
 			ctx = tenant.WithTenant(ctx, tenantID)
 		}
 	}

--- a/services/gateway/auth_builder.go
+++ b/services/gateway/auth_builder.go
@@ -47,6 +47,10 @@ func BuildAuthMiddleware(config AuthConfig, logger *slog.Logger) (*auth.Combined
 	// Create combined middleware
 	middleware, err := auth.NewCombinedAuthMiddleware(auth.CombinedAuthConfig{
 		JWTValidator: validatorAdapter,
+		JWTConfig: auth.JWTMiddlewareConfig{
+			DefaultTenantID: config.DefaultTenantID,
+			DefaultRoles:    config.DefaultRoles,
+		},
 		APIKeyConfig: apiKeyConfig,
 		Logger:       logger,
 	})
@@ -56,7 +60,9 @@ func BuildAuthMiddleware(config AuthConfig, logger *slog.Logger) (*auth.Combined
 
 	logger.Info("auth middleware initialized",
 		"jwks_url", config.JWKSURL,
-		"api_keys_configured", len(config.APIKeys) > 0)
+		"api_keys_configured", len(config.APIKeys) > 0,
+		"default_tenant_id", config.DefaultTenantID,
+		"default_roles_configured", len(config.DefaultRoles) > 0)
 
 	return middleware, nil
 }

--- a/services/gateway/config.go
+++ b/services/gateway/config.go
@@ -110,6 +110,15 @@ type AuthConfig struct {
 	// RateLimitBurst is the maximum burst size for rate limiting.
 	// Defaults to 200 if not set.
 	RateLimitBurst int
+
+	// DefaultTenantID is injected into JWT context when the token lacks an x-tenant-id claim.
+	// This enables standard OIDC providers (like Dex) that don't issue custom tenant claims
+	// to work with Meridian's tenant authorization middleware.
+	DefaultTenantID string
+
+	// DefaultRoles are injected into JWT context when the token lacks a roles claim.
+	// This enables standard OIDC providers to work with Meridian's role-based access control.
+	DefaultRoles []string
 }
 
 // VersionInfo holds build metadata injected at compile time via ldflags.
@@ -205,6 +214,8 @@ func LoadConfig() (*Config, error) {
 //   - API_KEYS: Comma-separated list of "key:identity" pairs
 //   - API_KEY_RATE_LIMIT_PER_SECOND: Requests per second per key (default: 100)
 //   - API_KEY_RATE_LIMIT_BURST: Burst size for rate limiting (default: 200)
+//   - DEFAULT_TENANT_ID: Fallback tenant ID for standard OIDC tokens (optional)
+//   - DEFAULT_ROLES: Comma-separated fallback roles for standard OIDC tokens (optional)
 func LoadAuthConfig() AuthConfig {
 	config := AuthConfig{
 		Enabled:            env.GetEnvAsBool("AUTH_ENABLED", false),
@@ -253,6 +264,10 @@ func LoadAuthConfig() AuthConfig {
 			config.RateLimitBurst = v
 		}
 	}
+
+	// Parse OIDC fallback defaults
+	config.DefaultTenantID = os.Getenv("DEFAULT_TENANT_ID")
+	config.DefaultRoles = env.GetEnvAsSlice("DEFAULT_ROLES", nil)
 
 	return config
 }

--- a/shared/platform/auth/jwt.go
+++ b/shared/platform/auth/jwt.go
@@ -27,12 +27,18 @@ var (
 
 // Claims represents the JWT claims extracted from a validated token.
 // It contains standard JWT claims plus custom claims for user identification and authorization.
+// It also supports standard OIDC claims (email, name) for compatibility with external
+// identity providers like Dex that issue standard tokens without custom Meridian claims.
 type Claims struct {
 	UserID string `json:"user_id"`
 	// TenantID is the tenant identifier extracted from the x-tenant-id JWT claim.
 	TenantID string   `json:"x-tenant-id"`
 	Roles    []string `json:"roles"`
 	Scopes   []string `json:"scopes"`
+	// Email is the standard OIDC email claim, present in tokens from providers like Dex.
+	Email string `json:"email"`
+	// Name is the standard OIDC name claim.
+	Name string `json:"name"`
 	jwt.RegisteredClaims
 }
 
@@ -93,6 +99,16 @@ func (v *JWTValidator) ValidateToken(tokenString string) (*Claims, error) {
 // Returns an empty string if the user ID claim is not present.
 func (c *Claims) GetUserID() string {
 	return c.UserID
+}
+
+// EffectiveUserID returns the best available user identifier.
+// It prefers the custom UserID claim, falling back to the standard OIDC Subject claim.
+// This enables compatibility with identity providers like Dex that use "sub" instead of "user_id".
+func (c *Claims) EffectiveUserID() string {
+	if c.UserID != "" {
+		return c.UserID
+	}
+	return c.Subject
 }
 
 // GetTenantID extracts and validates the tenant ID from the claims.


### PR DESCRIPTION
## Summary

- Replace fake JWT workarounds (LOCAL_DEV_MODE, AUTH_ENABLED=false) with real Dex OIDC authentication on demo
- Backend gracefully handles standard OIDC tokens by falling back to `sub` for user ID and applying configurable defaults for tenant/roles
- Frontend login page with email/password form using Dex password grant flow
- Dex configured with demo users (admin@volterra.energy, operator@volterra.energy)

## Changes

### Backend
- **`shared/platform/auth/jwt.go`**: Add `Email`, `Name` OIDC fields and `EffectiveUserID()` method (prefers `user_id`, falls back to `sub`)
- **`services/gateway/config.go`**: New `DEFAULT_TENANT_ID` and `DEFAULT_ROLES` env vars
- **`services/gateway/auth/jwt_middleware.go`**: Apply configured defaults when token lacks custom Meridian claims; create shallow copy of claims with effective values so `TenantAuthorizationMiddleware` sees default roles via `claims.HasRole()`
- **`services/gateway/auth/combined_middleware.go`**: Wire `JWTConfig` through to JWT middleware
- **`services/gateway/auth_builder.go`**: Pass defaults from gateway config

### Frontend
- **`auth-context.tsx`**: `parseJWT()` accepts standard OIDC tokens (`sub` fallback, array `aud`); demo mode defaults to platform lens
- **`App.tsx`**: Login form POSTs to `/dex/token` (password grant); dev-only fake JWT buttons preserved for local development

### Dex
- **`deploy/demo/dex.yaml`**: Real bcrypt hashes, two demo users (password: `demo2026`)

## Deployment notes

After merge, on the demo server update `/opt/meridian/.env`:
```
AUTH_ENABLED=true
JWKS_URL=http://dex:5556/dex/keys
DEFAULT_ROLES=platform-admin
# DEFAULT_TENANT_ID intentionally empty — enables platform-admin cross-tenant bypass
# so demo users can access all tenants (post_office, motive, un_wfp)
```
Remove `LOCAL_DEV_MODE=true`. Copy updated `dex.yaml` to `/opt/meridian/`, pull new image, restart.

## Test plan

- [x] `go test ./shared/platform/auth/...` - all pass
- [x] `go test ./services/gateway/auth/...` - all pass
- [x] `go test ./services/gateway/ -run TestConfig` - all pass
- [x] `vitest run src/contexts/auth-context.test.tsx` - 21/21 pass
- [x] Gitleaks, gofumpt, golangci-lint pre-commit hooks pass
- [ ] CI green
- [ ] Deploy to demo and verify login flow end-to-end