### PR TITLE
feat: Update current-account service layer for dimension-agnostic Amount

### DIFF
--- a/services/current-account/service/grpc_deposit_endpoints.go
+++ b/services/current-account/service/grpc_deposit_endpoints.go
@@ -130,7 +130,7 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 	// validated against account.Balance().InstrumentCode() above.
 	amount, err := protoMoneyToAmount(req.Amount, account)
 	if err != nil {
-		operationStatus = operationStatusInvalidCurrency
+		operationStatus = opStatusInvalidAmount
 		return nil, status.Errorf(codes.InvalidArgument, "invalid amount: %v", err)
 	}
 

--- a/services/current-account/service/grpc_deposit_endpoints.go
+++ b/services/current-account/service/grpc_deposit_endpoints.go
@@ -100,6 +100,12 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 		}()
 	}
 
+	// Validate amount is present before account fetch to fail fast on malformed requests.
+	if req.Amount == nil || req.Amount.Amount == nil {
+		operationStatus = opStatusMissingAmount
+		return nil, status.Error(codes.InvalidArgument, "amount is required")
+	}
+
 	// Retrieve account (context carries organization for multi-tenant routing)
 	account, err := s.repo.FindByID(ctx, req.AccountId)
 	if err != nil {

--- a/services/current-account/service/grpc_deposit_endpoints.go
+++ b/services/current-account/service/grpc_deposit_endpoints.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"errors"
-	"math"
 	"time"
 
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
@@ -120,36 +119,13 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 			account.Balance().InstrumentCode(), req.Amount.Amount.CurrencyCode)
 	}
 
-	// Convert amount from proto (MoneyAmount wraps google.type.Money)
-	// Validate overflow: Units*100 must not overflow int64
-	if req.Amount.Amount.Units > math.MaxInt64/100 || req.Amount.Amount.Units < math.MinInt64/100 {
-		operationStatus = opStatusAmountOverflow
-		return nil, status.Errorf(codes.InvalidArgument,
-			"amount too large: units %d would overflow", req.Amount.Amount.Units)
-	}
-
-	// Convert to cents preserving precision
-	unitsCents := req.Amount.Amount.Units * 100
-	// Round nanos to nearest cent (0.5 rounds up)
-	nanosCents := (req.Amount.Amount.Nanos + 5000000) / 10000000
-
-	// Use Money.Add to safely handle potential overflow from adding nanosCents
-	centsMoney, err := domain.NewMoney(req.Amount.Amount.CurrencyCode, unitsCents)
+	// Convert amount from proto (MoneyAmount wraps google.type.Money) using the account's instrument.
+	// The account's instrument determines dimension and precision; the proto CurrencyCode is already
+	// validated against account.Balance().InstrumentCode() above.
+	amount, err := protoMoneyToAmount(req.Amount, account)
 	if err != nil {
 		operationStatus = operationStatusInvalidCurrency
-		return nil, status.Errorf(codes.InvalidArgument, "invalid currency: %v", err)
-	}
-
-	nanosMoney, err := domain.NewMoney(req.Amount.Amount.CurrencyCode, int64(nanosCents))
-	if err != nil {
-		operationStatus = operationStatusInvalidCurrency
-		return nil, status.Errorf(codes.InvalidArgument, "invalid currency: %v", err)
-	}
-
-	amount, err := centsMoney.Add(nanosMoney)
-	if err != nil {
-		operationStatus = operationStatusInvalidCurrency
-		return nil, status.Errorf(codes.InvalidArgument, "invalid currency: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid amount: %v", err)
 	}
 
 	// Validate amount is positive
@@ -162,7 +138,7 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 	if amountCents <= 0 {
 		operationStatus = opStatusInvalidAmount
 		return nil, status.Errorf(codes.InvalidArgument,
-			"deposit amount must be positive, got %d cents", amountCents)
+			"deposit amount must be positive, got %d minor units", amountCents)
 	}
 
 	// Generate transaction ID (full UUID required by position-keeping service)

--- a/services/current-account/service/grpc_mappers.go
+++ b/services/current-account/service/grpc_mappers.go
@@ -139,6 +139,11 @@ func protoMoneyToAmount(amount *commonpb.MoneyAmount, account domain.CurrentAcco
 	}
 
 	precision := account.Balance().Instrument().Precision
+	// google.type.Money uses nanos (10^9), so precision must be in [0..9].
+	// Values outside this range cannot be represented in nanos without losing precision.
+	if precision < 0 || precision > 9 {
+		return domain.Amount{}, fmt.Errorf("%w: got %d", ErrInvalidPrecision, precision)
+	}
 	// #nosec G115 - precision is bounded by instrument definition (0-9 in practice)
 	scale := int64(math.Pow10(precision))
 	nanosPerUnit := int64(math.Pow10(9 - precision))

--- a/services/current-account/service/grpc_mappers.go
+++ b/services/current-account/service/grpc_mappers.go
@@ -52,17 +52,21 @@ func safeMinorUnits(m domain.Amount) int64 {
 }
 
 func toMoneyAmount(m domain.Amount) *commonpb.MoneyAmount {
-	amountCents := safeMinorUnits(m)
-	units := amountCents / 100
-	remainder := amountCents % 100
+	amountMinor := safeMinorUnits(m)
+	precision := m.Instrument().Precision
+	// #nosec G115 - precision is bounded by instrument definition (0-9 in practice)
+	scale := int64(math.Pow10(precision))
+	nanosPerMinor := int64(math.Pow10(9 - precision))
 
-	// Convert remainder to nanos (9 digits, but we only use 8 for cents precision)
-	// Per google.type.Money spec: nanos MUST share the sign of units
+	units := amountMinor / scale
+	remainder := amountMinor % scale
+
+	// Per google.type.Money spec: nanos MUST share the sign of units.
 	// - Positive amounts: both units and nanos are positive or zero
 	// - Negative amounts: both units and nanos are negative or zero
-	// Example: -£1.23 = Units=-1, Nanos=-230000000
-	// #nosec G115 - remainder is always -99 to 99, multiplication result fits in int32
-	nanos := int32(remainder * 10000000)
+	// remainder already shares the sign of amountMinor due to Go's truncating division.
+	// #nosec G115 - remainder is always -(scale-1) to (scale-1); product fits in int32
+	nanos := int32(remainder * nanosPerMinor)
 
 	return &commonpb.MoneyAmount{
 		Amount: &money.Money{
@@ -148,9 +152,26 @@ func protoMoneyToAmount(amount *commonpb.MoneyAmount, account domain.CurrentAcco
 	}
 
 	unitsMinor := amount.Amount.Units * scale
-	// Round nanos to nearest minor unit (half-up rounding)
-	nanosMinor := (amount.Amount.Nanos + int32(nanosPerUnit/2)) / int32(nanosPerUnit)
-	totalMinor := unitsMinor + int64(nanosMinor)
+
+	// Round nanos to nearest minor unit using half-away-from-zero (banker's-round alternative).
+	// Simple half-up (+ half) rounds negative nanos toward zero, which is incorrect.
+	// We must branch on sign so that -5_000_001 rounds to -1, not 0.
+	nanos := int64(amount.Amount.Nanos)
+	half := nanosPerUnit / 2
+	var nanosMinor int64
+	if nanos >= 0 {
+		nanosMinor = (nanos + half) / nanosPerUnit
+	} else {
+		nanosMinor = (nanos - half) / nanosPerUnit
+	}
+
+	// Post-rounding overflow guard: unitsMinor + nanosMinor must not overflow int64.
+	if (nanosMinor > 0 && unitsMinor > math.MaxInt64-nanosMinor) ||
+		(nanosMinor < 0 && unitsMinor < math.MinInt64-nanosMinor) {
+		return domain.Amount{}, fmt.Errorf("%w: total minor units would overflow after nanos rounding",
+			ErrAmountOverflow)
+	}
+	totalMinor := unitsMinor + nanosMinor
 
 	return domain.NewAmountFromInstrument(
 		account.Balance().InstrumentCode(),

--- a/services/current-account/service/grpc_mappers.go
+++ b/services/current-account/service/grpc_mappers.go
@@ -1,7 +1,9 @@
 package service
 
 import (
+	"fmt"
 	"log/slog"
+	"math"
 
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
@@ -112,6 +114,50 @@ func mapRegistryDimension(registryDimension string) string {
 		return "CURRENCY"
 	}
 	return registryDimension
+}
+
+// protoMoneyToAmount converts a proto MoneyAmount to a domain Amount using the account's
+// instrument for dimension-agnostic precision support. The proto CurrencyCode field carries
+// the instrument code (e.g. "GBP" or "KWH"); the account's dimension and precision are used
+// to construct the correct minor-unit Amount regardless of instrument type.
+//
+// The conversion formula is precision-aware:
+//
+//	scale        = 10^precision
+//	nanosPerUnit = 10^(9-precision)
+//	totalMinor   = Units * scale + round(Nanos / nanosPerUnit)
+//
+// For 2-decimal CURRENCY (e.g. GBP): scale=100, nanosPerUnit=10_000_000
+// For 3-decimal ENERGY (e.g. KWH):   scale=1000, nanosPerUnit=1_000_000
+func protoMoneyToAmount(amount *commonpb.MoneyAmount, account domain.CurrentAccount) (domain.Amount, error) {
+	if amount == nil || amount.Amount == nil {
+		return domain.Amount{}, ErrAmountRequired
+	}
+
+	precision := account.Balance().Instrument().Precision
+	// #nosec G115 - precision is bounded by instrument definition (0-9 in practice)
+	scale := int64(math.Pow10(precision))
+	nanosPerUnit := int64(math.Pow10(9 - precision))
+
+	// Overflow guard: reject units that would cause Units*scale to overflow int64.
+	// Using the same boundary as math.MaxInt64/scale (integer division) which equals
+	// the largest units value where units*scale does not overflow.
+	if amount.Amount.Units > math.MaxInt64/scale || amount.Amount.Units < math.MinInt64/scale {
+		return domain.Amount{}, fmt.Errorf("%w: units %d would overflow for precision %d",
+			ErrAmountOverflow, amount.Amount.Units, precision)
+	}
+
+	unitsMinor := amount.Amount.Units * scale
+	// Round nanos to nearest minor unit (half-up rounding)
+	nanosMinor := (amount.Amount.Nanos + int32(nanosPerUnit/2)) / int32(nanosPerUnit)
+	totalMinor := unitsMinor + int64(nanosMinor)
+
+	return domain.NewAmountFromInstrument(
+		account.Balance().InstrumentCode(),
+		account.Balance().Dimension(),
+		precision,
+		totalMinor,
+	)
 }
 
 func mapStatusToProto(status domain.AccountStatus) pb.AccountStatus {

--- a/services/current-account/service/grpc_withdrawal_execute.go
+++ b/services/current-account/service/grpc_withdrawal_execute.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/google/uuid"
@@ -208,36 +207,13 @@ func (s *Service) ExecuteWithdrawal(ctx context.Context, req *pb.ExecuteWithdraw
 			account.Balance().InstrumentCode(), reqAmount.Amount.CurrencyCode)
 	}
 
-	// Convert amount from proto (MoneyAmount wraps google.type.Money)
-	// Validate overflow: Units*100 must not overflow int64
-	if reqAmount.Amount.Units > math.MaxInt64/100 || reqAmount.Amount.Units < math.MinInt64/100 {
-		operationStatus = opStatusAmountOverflow
-		return nil, status.Errorf(codes.InvalidArgument,
-			"amount too large: units %d would overflow", reqAmount.Amount.Units)
-	}
-
-	// Convert to cents preserving precision
-	unitsCents := reqAmount.Amount.Units * 100
-	// Round nanos to nearest cent (0.5 rounds up)
-	nanosCents := (reqAmount.Amount.Nanos + 5000000) / 10000000
-
-	// Use Money.Add to safely handle potential overflow from adding nanosCents
-	centsMoney, err := domain.NewMoney(reqAmount.Amount.CurrencyCode, unitsCents)
+	// Convert amount from proto (MoneyAmount wraps google.type.Money) using the account's instrument.
+	// The account's instrument determines dimension and precision; the proto CurrencyCode is already
+	// validated against account.Balance().InstrumentCode() above.
+	amount, err := protoMoneyToAmount(reqAmount, account)
 	if err != nil {
 		operationStatus = operationStatusInvalidCurrency
-		return nil, status.Errorf(codes.InvalidArgument, "invalid currency: %v", err)
-	}
-
-	nanosMoney, err := domain.NewMoney(reqAmount.Amount.CurrencyCode, int64(nanosCents))
-	if err != nil {
-		operationStatus = operationStatusInvalidCurrency
-		return nil, status.Errorf(codes.InvalidArgument, "invalid currency: %v", err)
-	}
-
-	amount, err := centsMoney.Add(nanosMoney)
-	if err != nil {
-		operationStatus = operationStatusInvalidCurrency
-		return nil, status.Errorf(codes.InvalidArgument, "invalid currency: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid amount: %v", err)
 	}
 
 	// Validate amount is positive
@@ -250,7 +226,7 @@ func (s *Service) ExecuteWithdrawal(ctx context.Context, req *pb.ExecuteWithdraw
 	if amountCents <= 0 {
 		operationStatus = opStatusInvalidAmount
 		return nil, status.Errorf(codes.InvalidArgument,
-			"withdrawal amount must be positive, got %d cents", amountCents)
+			"withdrawal amount must be positive, got %d minor units", amountCents)
 	}
 
 	// Generate transaction ID (full UUID required by position-keeping service)

--- a/services/current-account/service/grpc_withdrawal_manage.go
+++ b/services/current-account/service/grpc_withdrawal_manage.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/google/uuid"
@@ -78,41 +77,35 @@ func (s *Service) InitiateWithdrawal(ctx context.Context, req *pb.InitiateWithdr
 			account.Balance().InstrumentCode(), req.Amount.Amount.CurrencyCode)
 	}
 
-	// Validate overflow: Units*100 must not overflow int64
-	if req.Amount.Amount.Units > math.MaxInt64/100 || req.Amount.Amount.Units < math.MinInt64/100 {
-		operationStatus = opStatusAmountOverflow
-		return nil, status.Errorf(codes.InvalidArgument,
-			"amount too large: units %d would overflow", req.Amount.Amount.Units)
+	// Convert amount from proto using the account's instrument (supports any dimension/precision).
+	// The proto CurrencyCode is already validated against the account's instrument code above.
+	amount, err := protoMoneyToAmount(req.Amount, account)
+	if err != nil {
+		operationStatus = operationStatusInvalidCurrency
+		return nil, status.Errorf(codes.InvalidArgument, "invalid amount: %v", err)
 	}
 
-	// Convert and validate amount
-	unitsCents := req.Amount.Amount.Units * 100
-	nanosCents := (req.Amount.Amount.Nanos + 5000000) / 10000000
-	amountCents := unitsCents + int64(nanosCents)
-
-	if amountCents <= 0 {
+	amountMinor, err := amount.ToMinorUnits()
+	if err != nil {
+		operationStatus = opStatusAmountOverflow
+		return nil, status.Errorf(codes.InvalidArgument, "amount too large: %v", err)
+	}
+	if amountMinor <= 0 {
 		operationStatus = opStatusInvalidAmount
 		return nil, status.Errorf(codes.InvalidArgument, "withdrawal amount must be positive")
 	}
 
 	// Check available balance (warning only - balance could change before execution)
-	availCents, _ := account.AvailableBalance().ToMinorUnits()
-	if amountCents > availCents {
+	availMinor, _ := account.AvailableBalance().ToMinorUnits()
+	if amountMinor > availMinor {
 		validationMessages = append(validationMessages,
-			fmt.Sprintf("Warning: requested amount (%d cents) exceeds current available balance (%d cents)", amountCents, availCents))
+			fmt.Sprintf("Warning: requested amount (%d minor units) exceeds current available balance (%d minor units)", amountMinor, availMinor))
 	}
 
 	// Use provided reference if available, otherwise generate one
 	reference := req.Reference
 	if reference == "" {
 		reference = fmt.Sprintf("WTH-%s", uuid.New().String()[:8])
-	}
-
-	// Create domain Money from amount cents
-	amount, err := domain.NewMoney(req.Amount.Amount.CurrencyCode, amountCents)
-	if err != nil {
-		operationStatus = operationStatusInvalidCurrency
-		return nil, status.Errorf(codes.InvalidArgument, "invalid currency: %v", err)
 	}
 
 	// Create domain withdrawal
@@ -138,7 +131,7 @@ func (s *Service) InitiateWithdrawal(ctx context.Context, req *pb.InitiateWithdr
 		"withdrawal_id", domainWithdrawal.ID,
 		"withdrawal_reference", reference,
 		"account_id", req.AccountId,
-		"amount_cents", amountCents)
+		"amount_minor_units", amountMinor)
 
 	// Convert domain withdrawal to proto
 	withdrawal := toProtoWithdrawal(domainWithdrawal, req.AccountId)

--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -36,6 +36,7 @@ var (
 	ErrLienAmountNotPositive  = errors.New("lien amount must be positive")
 	ErrAmountRequired         = errors.New("amount is required")
 	ErrAmountOverflow         = errors.New("amount too large: would overflow")
+	ErrInvalidPrecision       = errors.New("invalid instrument precision: must be between 0 and 9")
 	ErrInstrumentCodeMismatch = errors.New("instrument code mismatch in balance response")
 	// Transaction operation errors for error detection
 	errTxSaveAccount       = errors.New("save_account")

--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -171,15 +171,23 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 		}
 
 		// Convert valued output to domain Amount for lien amount (the actual reservation).
-		// The valued amount is in the account's native currency; NewMoney handles CURRENCY dimension.
-		valuedCents := valuationResult.OutputAmount.Mul(decimal.NewFromInt(100)).RoundBank(0)
+		// Use the account's instrument precision so non-2-decimal instruments work correctly.
+		precision := prefetchedAccount.Balance().Instrument().Precision
+		// #nosec G115 - precision is bounded by instrument definition (0-9 in practice)
+		scale := decimal.NewFromInt(1).Shift(int32(precision))
+		valuedMinor := valuationResult.OutputAmount.Mul(scale).RoundBank(0)
 		maxInt64 := decimal.NewFromInt(math.MaxInt64)
 		minInt64 := decimal.NewFromInt(math.MinInt64)
-		if valuedCents.GreaterThan(maxInt64) || valuedCents.LessThan(minInt64) {
+		if valuedMinor.GreaterThan(maxInt64) || valuedMinor.LessThan(minInt64) {
 			operationStatus = opStatusInvalidAmount
 			return nil, status.Error(codes.InvalidArgument, ErrAmountOverflow.Error())
 		}
-		lienAmount, err = domain.NewMoney(valuationResult.OutputCode, valuedCents.IntPart())
+		lienAmount, err = domain.NewAmountFromInstrument(
+			valuationResult.OutputCode,
+			prefetchedAccount.Dimension(),
+			precision,
+			valuedMinor.IntPart(),
+		)
 		if err != nil {
 			operationStatus = opStatusInvalidAmount
 			return nil, status.Errorf(codes.Internal, "failed to create valued amount: %v", err)

--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
@@ -114,6 +113,18 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 	// Determine mode: multi-asset (input) or legacy (amount)
 	useValuation := req.Input != nil && req.Input.Amount != "" && req.Input.InstrumentCode != ""
 
+	// Prefetch account BEFORE amount parsing so we can use its instrument for dimension-agnostic
+	// amount construction. This also validates account existence early.
+	prefetchedAccount, err := s.repo.FindByID(ctx, req.AccountId)
+	if err != nil {
+		if errors.Is(err, persistence.ErrAccountNotFound) {
+			operationStatus = opStatusAccountNotFound
+			return nil, status.Errorf(codes.NotFound, "account not found: %s", req.AccountId)
+		}
+		operationStatus = opStatusRetrieveFailed
+		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+	}
+
 	var lienAmount domain.Amount
 	var valuationResult *valuateInternalResult
 
@@ -159,8 +170,8 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 			}
 		}
 
-		// Convert valued output to domain Money for lien amount (the actual reservation)
-		// The valued amount is in the account's native instrument (currency)
+		// Convert valued output to domain Amount for lien amount (the actual reservation).
+		// The valued amount is in the account's native currency; NewMoney handles CURRENCY dimension.
 		valuedCents := valuationResult.OutputAmount.Mul(decimal.NewFromInt(100)).RoundBank(0)
 		maxInt64 := decimal.NewFromInt(math.MaxInt64)
 		minInt64 := decimal.NewFromInt(math.MinInt64)
@@ -174,9 +185,20 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 			return nil, status.Errorf(codes.Internal, "failed to create valued amount: %v", err)
 		}
 	} else {
-		// Legacy mode: convert and validate MoneyAmount
+		// Legacy mode: validate instrument match and convert MoneyAmount using the account's
+		// instrument for dimension-agnostic support.
+		if req.Amount == nil || req.Amount.Amount == nil {
+			operationStatus = opStatusInvalidAmount
+			return nil, status.Error(codes.InvalidArgument, "amount is required")
+		}
+		if req.Amount.Amount.CurrencyCode != prefetchedAccount.InstrumentCode() {
+			operationStatus = opStatusCurrencyMismatch
+			return nil, status.Errorf(codes.InvalidArgument,
+				"currency mismatch: lien currency %s does not match account currency %s",
+				req.Amount.Amount.CurrencyCode, prefetchedAccount.InstrumentCode())
+		}
 		var err error
-		lienAmount, err = s.protoToMoney(req.Amount)
+		lienAmount, err = protoMoneyToAmount(req.Amount, prefetchedAccount)
 		if err != nil {
 			operationStatus = opStatusInvalidAmount
 			return nil, status.Errorf(codes.InvalidArgument, "invalid amount: %v", err)
@@ -186,17 +208,6 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 	if !lienAmount.IsPositive() {
 		operationStatus = opStatusInvalidAmount
 		return nil, status.Error(codes.InvalidArgument, "lien amount must be positive")
-	}
-
-	// Prefetch account and balance from Position Keeping BEFORE entering transaction
-	// to avoid holding database locks during external service calls (deadlock prevention).
-	if _, err := s.repo.FindByID(ctx, req.AccountId); err != nil {
-		if errors.Is(err, persistence.ErrAccountNotFound) {
-			operationStatus = opStatusAccountNotFound
-			return nil, status.Errorf(codes.NotFound, "account not found: %s", req.AccountId)
-		}
-		operationStatus = opStatusRetrieveFailed
-		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
 	}
 
 	bucketID := req.BucketId
@@ -319,9 +330,14 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 
 	// Calculate new available balance after this lien
 	newAvailableBalance := availableBalance - lienAmount.ToMinorUnitsUnchecked()
-	availableMoney, err := domain.NewMoney(account.Balance().InstrumentCode(), newAvailableBalance)
+	availableMoney, err := domain.NewAmountFromInstrument(
+		account.Balance().InstrumentCode(),
+		account.Balance().Dimension(),
+		account.Balance().Instrument().Precision,
+		newAvailableBalance,
+	)
 	if err != nil {
-		s.logger.Error("failed to create available balance money", "error", err)
+		s.logger.Error("failed to create available balance amount", "error", err)
 	}
 
 	resp := &pb.InitiateLienResponse{
@@ -833,30 +849,6 @@ func (s *Service) RetrieveLien(ctx context.Context, req *pb.RetrieveLienRequest)
 
 // Helper functions for lien service
 
-// protoToMoney converts a proto MoneyAmount to domain Amount
-func (s *Service) protoToMoney(amount *commonpb.MoneyAmount) (domain.Amount, error) {
-	if amount == nil || amount.Amount == nil {
-		return domain.Amount{}, ErrAmountRequired
-	}
-
-	// Calculate nanosCents first to include in overflow check
-	// nanosCents is at most 100 (nanos range 0-999999999, (999999999+5000000)/10000000 = 100)
-	nanosCents := (amount.Amount.Nanos + 5000000) / 10000000
-
-	// Validate units won't overflow when multiplied by 100 and added to nanosCents
-	// Reserve space for nanosCents (max 100) to prevent overflow in final addition
-	if amount.Amount.Units > (math.MaxInt64-100)/100 || amount.Amount.Units < (math.MinInt64+100)/100 {
-		return domain.Amount{}, ErrAmountOverflow
-	}
-
-	// Convert to cents
-	// unitsCents is safe due to overflow check above
-	unitsCents := amount.Amount.Units * 100
-	totalCents := unitsCents + int64(nanosCents)
-
-	return domain.NewMoney(amount.Amount.CurrencyCode, totalCents)
-}
-
 // toLienProto converts a domain Lien to proto Lien
 func toLienProto(lien *domain.Lien) *pb.Lien {
 	pbLien := &pb.Lien{
@@ -1167,7 +1159,12 @@ func (s *Service) calculateAvailableBalanceByBucket(ctx context.Context, account
 	}
 
 	availableBalance := currentBalanceCents - activeLiensTotal
-	availableMoney, err := domain.NewMoney(currentBalance.InstrumentCode(), availableBalance)
+	availableMoney, err := domain.NewAmountFromInstrument(
+		currentBalance.InstrumentCode(),
+		currentBalance.Dimension(),
+		currentBalance.Instrument().Precision,
+		availableBalance,
+	)
 	if err != nil {
 		s.logger.Error("failed to create available balance for response", "error", err)
 		return currentBalance // Best effort

--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -338,6 +338,8 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 	)
 	if err != nil {
 		s.logger.Error("failed to create available balance amount", "error", err)
+		// Fall back to the pre-lien available balance so the response is not zero.
+		availableMoney = account.AvailableBalance()
 	}
 
 	resp := &pb.InitiateLienResponse{


### PR DESCRIPTION
## Summary

- Adds `protoMoneyToAmount()` helper in `grpc_mappers.go` for precision-aware, dimension-agnostic conversion from `google.type.Money` proto to `domain.Amount` using the account's instrument
- Replaces `domain.NewMoney()` calls in deposit/withdrawal endpoints and lien service with `protoMoneyToAmount()` and `domain.NewAmountFromInstrument()` 
- Restructures `InitiateLien` to prefetch account before amount parsing, enabling instrument-aware amount construction and early instrument code validation

## Changes Made

**`services/current-account/service/grpc_mappers.go`**
- Add `protoMoneyToAmount(amount, account)` — converts proto `MoneyAmount` to `domain.Amount` using account's `Instrument()` for dimension and precision. Supports any instrument (CURRENCY, ENERGY, COMPUTE, CARBON). Overflow guard matches original semantics (`units > MaxInt64/scale`).

**`services/current-account/service/grpc_deposit_endpoints.go`**
- Replace `domain.NewMoney(req.Amount.Amount.CurrencyCode, ...)` two-step construction with single `protoMoneyToAmount(req.Amount, account)` call
- Remove now-unused `math` import
- Update error message: "cents" → "minor units"

**`services/current-account/service/grpc_withdrawal_execute.go`**
- Same replacement as deposit endpoints
- Remove now-unused `math` import

**`services/current-account/service/grpc_withdrawal_manage.go`**
- Same replacement; rename `amountCents` to `amountMinor` for dimension-agnostic naming
- Remove now-unused `math` import

**`services/current-account/service/lien_service.go`**
- Move `s.repo.FindByID()` call to before amount parsing so account instrument is available for `protoMoneyToAmount`
- Add explicit instrument code validation (`req.Amount.Amount.CurrencyCode != prefetchedAccount.InstrumentCode()`) in legacy lien path before calling `protoMoneyToAmount` — preserves existing currency mismatch error behaviour
- Replace `domain.NewMoney(account.Balance().InstrumentCode(), ...)` with `domain.NewAmountFromInstrument(..., account.Balance().Dimension(), account.Balance().Instrument().Precision, ...)` at available-balance calculation sites (two locations)
- Remove unused `protoToMoney()` method and `commonpb` import

## Technical Details

`protoMoneyToAmount` uses a precision-aware formula:

```
scale        = 10^precision
nanosPerUnit = 10^(9 - precision)
totalMinor   = Units * scale + round(Nanos / nanosPerUnit)
```

For 2-decimal CURRENCY (GBP): `scale=100, nanosPerUnit=10_000_000`
For 3-decimal ENERGY (KWH): `scale=1000, nanosPerUnit=1_000_000`

## Testing

- All existing `services/current-account/service/...` tests pass
- `TestExecuteDeposit_OverflowPrevention_UnitsTooCents` — overflow boundary maintained
- `TestInitiateLien_CurrencyMismatch` — instrument code validation preserved
- No regression in deposit, withdrawal, or lien integration tests

## Risk Assessment

Low. The changes preserve existing behaviour for CURRENCY instruments (GBP, USD, EUR) — all test assertions remain intact. The primary change is that `NewMoney()` calls (which fail for non-CURRENCY codes) are replaced with dimension-agnostic `protoMoneyToAmount()` and `NewAmountFromInstrument()`.

## Task Master

asset-agnostic-accounts.18