### PR TITLE
test: add multi-asset test fixtures and demo seed for energy accounts

### DIFF
--- a/cmd/seed-demo/main.go
+++ b/cmd/seed-demo/main.go
@@ -4,8 +4,10 @@
 //   - An energy company tenant ("volterra-energy")
 //   - The energy manifest (instruments: GBP, KWH, CARBON_CREDIT)
 //   - A DNO organization (UK Power Networks) with 4 Grid Supply Points
-//   - 10 residential customers with GBP + KWH current accounts
-//   - Initial deposits: GBP balances and KWH consumption credits
+//   - 10 residential customers each with:
+//   - A GBP billing account (charges in pounds sterling)
+//   - A KWH consumption tracking account (meter reading credits)
+//   - Initial deposits: GBP billing charges and KWH consumption credits (30 days simulated)
 //   - A wholesale energy price dataset with 30 days of historical prices
 //
 // All operations are idempotent — safe to run multiple times.
@@ -148,7 +150,7 @@ func run() error {
 	fmt.Printf("Tenant:     %s (slug: %s)\n", tenantID, tenantSlug)
 	fmt.Printf("DNO:        %s\n", dnoPartyID)
 	fmt.Printf("GSPs:       %d grid supply points\n", len(gspPartyIDs))
-	fmt.Printf("Customers:  %d customers with GBP billing accounts\n", len(customerPartyIDs))
+	fmt.Printf("Customers:  %d customers with GBP billing + KWH consumption accounts\n", len(customerPartyIDs))
 	fmt.Printf("Market:     30 days of wholesale energy prices\n")
 	return nil
 }
@@ -328,6 +330,7 @@ type customerAccountPair struct {
 	customerName string
 	partyID      string
 	gbpAccountID string
+	kwhAccountID string
 }
 
 func createAccounts(ctx context.Context, conn *grpc.ClientConn, dnoPartyID string, customerPartyIDs []string) ([]customerAccountPair, error) {
@@ -339,13 +342,21 @@ func createAccounts(ctx context.Context, conn *grpc.ClientConn, dnoPartyID strin
 		accounts[i].customerName = cust.legalName
 		accounts[i].partyID = partyID
 
-		// GBP billing account (energy consumption tracked via market data + position-keeping)
+		// GBP billing account — charges in pounds sterling
 		gbpID, err := createAccountIdempotent(ctx, client, partyID, fmt.Sprintf("VE-GBP-%03d", i+1), "GBP", dnoPartyID)
 		if err != nil {
 			return nil, fmt.Errorf("create GBP account for %s: %w", cust.legalName, err)
 		}
 		accounts[i].gbpAccountID = gbpID
 		fmt.Printf("  GBP: %s (%s)\n", gbpID, cust.legalName)
+
+		// KWH consumption tracking account — meter reading credits (ENERGY dimension)
+		kwhID, err := createAccountIdempotent(ctx, client, partyID, fmt.Sprintf("VE-KWH-%03d", i+1), "KWH", dnoPartyID)
+		if err != nil {
+			return nil, fmt.Errorf("create KWH account for %s: %w", cust.legalName, err)
+		}
+		accounts[i].kwhAccountID = kwhID
+		fmt.Printf("  KWH: %s (%s)\n", kwhID, cust.legalName)
 	}
 
 	return accounts, nil
@@ -418,11 +429,22 @@ func seedCustomerBalances(ctx context.Context, client currentaccountv1.CurrentAc
 		totalKWH += dailyKWH
 		totalGBP += dailyGBP
 
+		// GBP billing deposit — charge for energy consumed at fixed retail tariff
 		if err := depositIdempotent(ctx, client, acct.gbpAccountID, dailyGBP, "GBP",
 			fmt.Sprintf("Energy billing %s: %.2f kWh @ %.1fp/kWh", date.Format("2006-01-02"), dailyKWH, fixedRate*100),
 			fmt.Sprintf("BILL-%s-%s", acct.partyID, date.Format("20060102")),
 		); err != nil {
 			return fmt.Errorf("deposit GBP for %s day %d: %w", acct.customerName, day, err)
+		}
+
+		// KWH consumption deposit — meter reading credit for energy consumed
+		if acct.kwhAccountID != "" {
+			if err := depositIdempotent(ctx, client, acct.kwhAccountID, dailyKWH, "KWH",
+				fmt.Sprintf("Meter reading %s: %.3f kWh consumed", date.Format("2006-01-02"), dailyKWH),
+				fmt.Sprintf("METER-%s-%s", acct.partyID, date.Format("20060102")),
+			); err != nil {
+				return fmt.Errorf("deposit KWH for %s day %d: %w", acct.customerName, day, err)
+			}
 		}
 	}
 

--- a/services/current-account/domain/lien_test.go
+++ b/services/current-account/domain/lien_test.go
@@ -245,6 +245,24 @@ func TestLien_CanTerminate(t *testing.T) {
 	}
 }
 
+func TestNewLien_EnergyAccount(t *testing.T) {
+	accountID := uuid.New()
+	amount, err := NewAmountFromInstrument("KWH", "ENERGY", 0, 5000) // 5000 KWH
+	require.NoError(t, err)
+
+	lien, err := NewLien(accountID, amount, "bucket-energy", "PO-ENERGY-001", nil)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, lien.ID)
+	assert.Equal(t, accountID, lien.AccountID)
+	assert.Equal(t, int64(5000), toMinorUnits(lien.Amount))
+	assert.Equal(t, "KWH", lien.Amount.InstrumentCode())
+	assert.Equal(t, "ENERGY", lien.Amount.Dimension())
+	assert.Equal(t, "bucket-energy", lien.BucketID)
+	assert.Equal(t, LienStatusActive, lien.Status)
+	assert.Equal(t, "PO-ENERGY-001", lien.PaymentOrderReference)
+}
+
 // createTestLien is a helper to create a lien with a specific status for testing
 func createTestLien(t *testing.T, status LienStatus) *Lien {
 	t.Helper()
@@ -262,4 +280,60 @@ func createTestLien(t *testing.T, status LienStatus) *Lien {
 		CreatedAt:             now,
 		UpdatedAt:             now,
 	}
+}
+
+func TestNewLien_KWHAmountHelper(t *testing.T) {
+	account := createKWHTestAccount(t, "ACC-KWH-LIEN-001", 10000)
+	lienAmount := createKWHAmount(t, 3000)
+
+	lien, err := NewLien(account.ID(), lienAmount, "bucket-kwh", "PO-KWH-001", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(3000), toMinorUnits(lien.Amount))
+	assert.Equal(t, "KWH", lien.Amount.InstrumentCode())
+	assert.Equal(t, "ENERGY", lien.Amount.Dimension())
+	assert.Equal(t, account.ID(), lien.AccountID)
+}
+
+func TestNewLien_CarbonCreditAmountHelper(t *testing.T) {
+	creditAmount := createCarbonCreditAmount(t, 50)
+
+	lien, err := NewLien(uuid.New(), creditAmount, "bucket-carbon", "PO-CC-001", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(50), toMinorUnits(lien.Amount))
+	assert.Equal(t, "CARBON_CREDIT", lien.Amount.InstrumentCode())
+	assert.Equal(t, "CARBON", lien.Amount.Dimension())
+}
+
+// createKWHTestAccount creates a KWH energy account with an optional initial balance for testing.
+func createKWHTestAccount(t *testing.T, accountID string, initialKWH int64) CurrentAccount {
+	t.Helper()
+	account, err := NewCurrentAccountWithDimension(accountID, "KWH-"+accountID, "PARTY-TEST", "KWH", "ENERGY", 0)
+	require.NoError(t, err)
+
+	if initialKWH > 0 {
+		deposit, err := NewAmountFromInstrument("KWH", "ENERGY", 0, initialKWH)
+		require.NoError(t, err)
+		account, err = account.Deposit(deposit)
+		require.NoError(t, err)
+	}
+
+	return account
+}
+
+// createKWHAmount creates a KWH energy Amount for test assertions.
+func createKWHAmount(t *testing.T, minorUnits int64) Amount {
+	t.Helper()
+	a, err := NewAmountFromInstrument("KWH", "ENERGY", 0, minorUnits)
+	require.NoError(t, err)
+	return a
+}
+
+// createCarbonCreditAmount creates a CARBON_CREDIT Amount for test assertions.
+func createCarbonCreditAmount(t *testing.T, minorUnits int64) Amount {
+	t.Helper()
+	a, err := NewAmountFromInstrument("CARBON_CREDIT", "CARBON", 0, minorUnits)
+	require.NoError(t, err)
+	return a
 }

--- a/services/current-account/domain/quantity_test.go
+++ b/services/current-account/domain/quantity_test.go
@@ -254,6 +254,39 @@ func TestNewAmountFromInstrument_CARBON(t *testing.T) {
 	assert.Equal(t, int64(100), toMinorUnits(a))
 }
 
+func TestNewAmountFromInstrument_COMPUTE(t *testing.T) {
+	a, err := NewAmountFromInstrument("GPU_HOUR", "COMPUTE", 6, 2000000)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "GPU_HOUR", a.InstrumentCode())
+	assert.Equal(t, "COMPUTE", a.Dimension())
+	assert.Equal(t, int64(2000000), toMinorUnits(a))
+}
+
+func TestNewAmountFromInstrument_AllDimensions(t *testing.T) {
+	tests := []struct {
+		instrument string
+		dimension  string
+		precision  int
+		minorUnits int64
+	}{
+		{"GBP", "CURRENCY", 2, 10000},
+		{"KWH", "ENERGY", 3, 1500},
+		{"CARBON_CREDIT", "CARBON", 0, 100},
+		{"GPU_HOUR", "COMPUTE", 6, 2000000},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.instrument, func(t *testing.T) {
+			a, err := NewAmountFromInstrument(tc.instrument, tc.dimension, tc.precision, tc.minorUnits)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.instrument, a.InstrumentCode())
+			assert.Equal(t, tc.dimension, a.Dimension())
+			assert.Equal(t, tc.minorUnits, toMinorUnits(a))
+		})
+	}
+}
+
 func TestNewAmountFromInstrument_InvalidDimension_ReturnsError(t *testing.T) {
 	_, err := NewAmountFromInstrument("XYZ", "INVALID_DIM", 0, 100)
 


### PR DESCRIPTION
## Summary

- Adds `TestNewAmountFromInstrument_COMPUTE` (GPU_HOUR/COMPUTE dimension) and `TestNewAmountFromInstrument_AllDimensions` table test covering all four supported dimensions (CURRENCY, ENERGY, CARBON, COMPUTE) in `quantity_test.go`
- Adds `TestNewLien_EnergyAccount` verifying `NewLien` works with KWH amounts and ENERGY dimension, plus helper-driven tests in `lien_test.go`
- Adds reusable test helpers `createKWHTestAccount`, `createKWHAmount`, `createCarbonCreditAmount` in `lien_test.go`
- Updates `cmd/seed-demo` to create a KWH consumption tracking account per customer alongside the existing GBP billing account, and seeds 30 days of simulated meter reading credits

## Task Master

asset-agnostic-accounts.22 — Update test fixtures for multi-asset scenarios
asset-agnostic-accounts.23 — Update demo seed script for multi-asset accounts

## Test plan

- [x] All existing domain tests pass (`go test ./services/current-account/domain/...`)
- [x] All new tests pass: `TestNewLien_EnergyAccount`, `TestNewLien_KWHAmountHelper`, `TestNewLien_CarbonCreditAmountHelper`, `TestNewAmountFromInstrument_COMPUTE`, `TestNewAmountFromInstrument_AllDimensions`
- [x] Full current-account test suite passes (`go test ./services/current-account/...`)
- [x] `cmd/seed-demo` builds without errors
- [x] golangci-lint passes (no unused functions)