### PR TITLE
fix: resolve E2E test failures for tenant display names and dashboard subtitle

### DIFF
--- a/frontend/e2e/admin-config.spec.ts
+++ b/frontend/e2e/admin-config.spec.ts
@@ -277,8 +277,10 @@ test.describe('Tenant Management page', () => {
   test('shows tenant display names', async ({ platformAdminPage: page }) => {
     await navigateTo(page, '/tenants')
 
-    await expect(page.getByText('ACME Corporation')).toBeVisible({ timeout: 15_000 })
-    await expect(page.getByText('Energy Co Ltd')).toBeVisible()
+    // Scope to the table to avoid matching the TenantSelector dropdown in the header
+    const table = page.locator('table')
+    await expect(table.getByText('ACME Corporation')).toBeVisible({ timeout: 15_000 })
+    await expect(table.getByText('Energy Co Ltd')).toBeVisible()
   })
 
   test('shows status badges for tenants', async ({ platformAdminPage: page }) => {

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -48,8 +48,9 @@ test.describe('Dashboard', () => {
     })
 
     test('shows tenant context subtitle', async ({ platformAdminPage: page }) => {
-      // Platform admin auto-selects dev-tenant via DevTenantAutoSelector (DEV + E2E mode)
-      await expect(page.getByText(/Overview for dev-tenant/)).toBeVisible({ timeout: 15_000 })
+      // Platform admin auto-selects a tenant via DevTenantAutoSelector (DEV + E2E mode).
+      // The selected tenant depends on API response order, so match any valid slug.
+      await expect(page.getByText(/Overview for \S+/)).toBeVisible({ timeout: 15_000 })
     })
 
     test('stat cards resolve from loading state', async ({ platformAdminPage: page }) => {


### PR DESCRIPTION
## Summary

- **admin-config.spec.ts**: Scope `getByText('Energy Co Ltd')` to `page.locator('table')` to avoid Playwright strict mode violation caused by duplicate matches in the TenantSelector popover dropdown
- **dashboard.spec.ts**: Relax tenant slug regex from `/Overview for dev-tenant/` to `/Overview for \S+/` since `DevTenantAutoSelector` picks the first tenant from the API response (non-deterministic order)

## Test plan

- [ ] E2E shard 2/4 (`admin-config.spec.ts`) passes — no strict mode violation
- [ ] E2E shard 1/4 (`dashboard.spec.ts`) passes — subtitle matches any tenant slug
- [ ] All other E2E shards unaffected