### PR TITLE
fix: harden GitHub Actions workflows (supply chain, timeouts, concurrency)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ permissions:
   packages: write
   security-events: write  # Required for SARIF upload to Security tab
 
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -21,6 +25,7 @@ jobs:
   build:
     name: Build Docker Image
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ permissions:
   security-events: write  # Required for SARIF upload to Security tab
 
 concurrency:
-  group: build-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,6 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository

--- a/.github/workflows/control-plane-ci.yml
+++ b/.github/workflows/control-plane-ci.yml
@@ -25,6 +25,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: control-plane-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   proto-compile:
     name: Proto Compilation

--- a/.github/workflows/control-plane-ci.yml
+++ b/.github/workflows/control-plane-ci.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: control-plane-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -118,7 +118,7 @@ jobs:
         run: npx vite build
 
       - name: Upload frontend artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: frontend-dist
           path: frontend/dist/
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download frontend artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: frontend-dist
           path: frontend-dist/

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: frontend-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: frontend-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Frontend Tests & Coverage

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -27,6 +27,7 @@ jobs:
   verify-migrations:
     name: Verify Migration Checksums
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -58,6 +59,7 @@ jobs:
   test-multi-org-migrations:
     name: Test Multi-Organization Migrations
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     services:
       postgres:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,7 @@ jobs:
   benchmark-comparison:
     name: Benchmark Comparison
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -88,6 +89,7 @@ jobs:
   slow-integration-tests:
     name: Slow Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Note: No postgres service container needed - tests use testcontainers
     # which manage their own ephemeral containers with proper isolation.
 

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -14,6 +14,7 @@ jobs:
   proto-lint:
     name: Proto Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -30,6 +31,7 @@ jobs:
   proto-breaking:
     name: Proto Breaking Change Detection
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'pull_request'
 
     steps:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,17 +11,22 @@ permissions:
   pull-requests: read
   checks: write
 
+concurrency:
+  group: quality-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   shellcheck:
     name: Shell Script Linting
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@2.0.0
         with:
           scandir: '.'
           ignore_paths: 'node_modules .git'
@@ -30,6 +35,7 @@ jobs:
   golangci-lint:
     name: golangci-lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -58,6 +64,7 @@ jobs:
   tiltfile-syntax:
     name: Tiltfile Syntax
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,7 +12,7 @@ permissions:
   checks: write
 
 concurrency:
-  group: quality-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,6 +18,7 @@ jobs:
   govulncheck:
     name: Go Vulnerability Check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -44,6 +45,7 @@ jobs:
   gosec:
     name: Security Scanner (Gosec)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -92,6 +94,7 @@ jobs:
   trivy-repo:
     name: Trivy Repository Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -116,6 +119,7 @@ jobs:
   trivy-image:
     name: Trivy Container Image Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [govulncheck, gosec]  # Only scan image if code passes security checks
     steps:
     - name: Checkout code
@@ -157,6 +161,7 @@ jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'pull_request'
     steps:
     - name: Checkout code
@@ -170,6 +175,7 @@ jobs:
   sbom:
     name: Generate SBOM
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -216,6 +222,7 @@ jobs:
   secrets-scan:
     name: Secret Scanning with Gitleaks
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - name: Checkout code
       uses: actions/checkout@v6

--- a/.github/workflows/tag-develop.yml
+++ b/.github/workflows/tag-develop.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create lightweight tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const sha = context.sha.substring(0, 7);

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: test-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,15 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: "Tests (shard ${{ matrix.shard_index }})"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -95,6 +100,7 @@ jobs:
     name: Coverage Report
     needs: test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: always() && !cancelled()
 
     steps:


### PR DESCRIPTION
## Summary

Audit and hardening of all 22 GitHub Actions workflows. Addresses supply chain risks, missing timeouts, and redundant CI runs.

- **Pin shellcheck action**: `ludeeus/action-shellcheck@master` to `@2.0.0` -- `@master` is a supply chain attack vector
- **Add concurrency groups**: `test.yml`, `frontend.yml`, `quality.yml`, `build.yml`, `control-plane-ci.yml` -- prevents duplicate runs on the same PR, saving CI minutes
- **Add timeout-minutes**: All jobs across `test`, `build`, `security`, `quality`, `nightly`, `migrations`, `proto` workflows -- prevents runaway jobs from blocking CI queues indefinitely
- **Upgrade action versions**: `deploy-demo.yml` had `@v4` actions while rest of repo uses `@v6`; `tag-develop.yml` used `@v7` while rest uses `@v8`
- **Remove excess permissions**: `claude.yml` had `id-token: write` with no OIDC federation

## Test plan

- [ ] All existing CI checks pass (no functional changes, only workflow config)
- [ ] Concurrency groups cancel in-progress runs on same PR (verify by pushing twice quickly)
- [ ] ShellCheck job still runs correctly with pinned `@2.0.0` action
- [ ] Deploy-demo workflow still works with upgraded artifact actions