### PR TITLE
fix: add auth headers to all frontend API calls and fix proto field mappings

### DIFF
--- a/frontend/e2e/ledger.spec.ts
+++ b/frontend/e2e/ledger.spec.ts
@@ -41,7 +41,7 @@ test.describe('Ledger page', () => {
     await expect(
       authenticatedPage.getByRole('columnheader', { name: 'Business Unit' }),
     ).toBeVisible()
-    await expect(authenticatedPage.getByRole('columnheader', { name: 'Currency' })).toBeVisible()
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Instrument' })).toBeVisible()
     await expect(authenticatedPage.getByRole('columnheader', { name: 'Status' })).toBeVisible()
     await expect(authenticatedPage.getByRole('columnheader', { name: 'Postings' })).toBeVisible()
   })

--- a/frontend/src/components/shared/audit-trail.test.tsx
+++ b/frontend/src/components/shared/audit-trail.test.tsx
@@ -6,6 +6,10 @@ import { server } from '@/test/msw-handlers';
 import { AuditTrail } from './audit-trail';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
+vi.mock('@/hooks/use-authenticated-fetch', () => ({
+  useAuthenticatedFetch: () => fetch,
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/shared/audit-trail.tsx
+++ b/frontend/src/components/shared/audit-trail.tsx
@@ -3,6 +3,7 @@ import { ClockIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { TimeDisplay } from './time-display';
 import { EmptyState } from '@/components/ui/empty-state';
+import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -39,8 +40,9 @@ export interface AuditTrailProps {
 async function fetchAuditEntries(
   entityType: string,
   entityId: string,
+  fetchFn: typeof fetch = fetch,
 ): Promise<AuditEntriesResponse> {
-  const response = await fetch(
+  const response = await fetchFn(
     '/meridian.audit.v1.AuditService/ListAuditEntries',
     {
       method: 'POST',
@@ -232,9 +234,10 @@ function AuditEntryItem({ entry }: { entry: AuditEntry }) {
 // ---------------------------------------------------------------------------
 
 export function AuditTrail({ entityType, entityId }: AuditTrailProps) {
+  const authFetch = useAuthenticatedFetch();
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ['audit', entityType, entityId],
-    queryFn: () => fetchAuditEntries(entityType, entityId),
+    queryFn: () => fetchAuditEntries(entityType, entityId, authFetch),
     staleTime: 0, // Always refetch audit logs
   });
 

--- a/frontend/src/components/shared/create-valuation-feature-dialog.tsx
+++ b/frontend/src/components/shared/create-valuation-feature-dialog.tsx
@@ -10,7 +10,8 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { useTenantContext } from '@/contexts/tenant-context'
+import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
 import { handleConnectError } from '@/lib/error-handling'
 import { Code, ConnectError } from '@connectrpc/connect'
@@ -51,7 +52,6 @@ const initialFormData: FormData = {
 }
 
 async function createValuationFeature(
-  tenantSlug: string,
   accountType: AccountType,
   accountId: string,
   instrumentCode: string,
@@ -59,6 +59,7 @@ async function createValuationFeature(
   valuationMethodVersion: number,
   outputInstrument: string,
   parameters: string,
+  fetchFn: typeof fetch = fetch,
 ): Promise<string> {
   const serviceName =
     accountType === 'current'
@@ -77,12 +78,9 @@ async function createValuationFeature(
     body.parameters = parameters.trim()
   }
 
-  const response = await fetch(`/api/${serviceName}/CreateValuationFeature`, {
+  const response = await fetchFn(`/api/${serviceName}/CreateValuationFeature`, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Tenant-Slug': tenantSlug,
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
 
@@ -153,7 +151,8 @@ export function CreateValuationFeatureDialog({
   accountType,
   accountCurrency,
 }: CreateValuationFeatureDialogProps) {
-  const { tenantSlug } = useTenantContext()
+  const authFetch = useAuthenticatedFetch()
+  const tenantSlug = useTenantSlug()
   const queryClient = useQueryClient()
 
   const [formData, setFormData] = React.useState<FormData>(initialFormData)
@@ -172,7 +171,6 @@ export function CreateValuationFeatureDialog({
     mutationFn: () => {
       const version = parseInt(formData.valuationMethodVersion, 10)
       return createValuationFeature(
-        tenantSlug ?? '',
         accountType,
         accountId,
         formData.instrumentCode.trim(),
@@ -180,6 +178,7 @@ export function CreateValuationFeatureDialog({
         version,
         formData.outputInstrument.trim(),
         formData.parameters,
+        authFetch,
       )
     },
     onSuccess: (featureId) => {

--- a/frontend/src/hooks/use-authenticated-fetch.ts
+++ b/frontend/src/hooks/use-authenticated-fetch.ts
@@ -1,0 +1,30 @@
+import { useCallback } from 'react'
+import { useAuth } from '@/contexts/auth-context'
+import { useTenantContext } from '@/contexts/tenant-context'
+
+/**
+ * Returns a fetch wrapper that automatically includes Authorization and
+ * X-Tenant-Slug headers. Use this for pages that call REST/gRPC-web
+ * endpoints via raw fetch() instead of typed Connect-RPC clients.
+ */
+export function useAuthenticatedFetch() {
+  const { accessToken } = useAuth()
+  const { tenantSlug } = useTenantContext()
+
+  return useCallback(
+    (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const headers = new Headers(init?.headers)
+      if (accessToken) {
+        headers.set('Authorization', `Bearer ${accessToken}`)
+      }
+      if (tenantSlug) {
+        headers.set('X-Tenant-Slug', tenantSlug)
+      }
+      if (!headers.has('Content-Type')) {
+        headers.set('Content-Type', 'application/json')
+      }
+      return fetch(input, { ...init, headers })
+    },
+    [accessToken, tenantSlug],
+  )
+}

--- a/frontend/src/pages/accounts/[accountId].tsx
+++ b/frontend/src/pages/accounts/[accountId].tsx
@@ -8,42 +8,22 @@ import { Button } from '@/components/ui/button'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { AuditTrail } from '@/components/shared'
+import { useApiClients } from '@/api/context'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
+import { AccountStatus } from '@/api/gen/meridian/current_account/v1/current_account_pb'
 import { DepositDialog } from './deposit-dialog'
 import { WithdrawDialog } from './withdraw-dialog'
 import { ControlDialog } from './control-dialog'
 import type { ControlAction } from './control-dialog'
 import { CreateLienDialog } from './create-lien-dialog'
 import { CreateValuationFeatureDialog } from '@/components/shared/create-valuation-feature-dialog'
-import type { AccountStatus, CurrentAccount, RetrieveCurrentAccountResponse } from './types'
+import type { AccountStatus as AccountStatusType, CurrentAccount } from './types'
 
-async function retrieveAccount(
-  tenantSlug: string,
-  accountId: string,
-): Promise<CurrentAccount | null> {
-  const response = await fetch(
-    `/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Tenant-Slug': tenantSlug,
-      },
-      body: JSON.stringify({ accountId }),
-    },
-  )
-
-  if (response.status === 404) {
-    return null
-  }
-
-  if (!response.ok) {
-    throw new Error(`Failed to retrieve account: ${response.status}`)
-  }
-
-  const data = (await response.json()) as RetrieveCurrentAccountResponse
-  return data.account
+const ACCOUNT_STATUS_NAMES: Record<number, string> = {
+  [AccountStatus.ACTIVE]: 'ACTIVE',
+  [AccountStatus.FROZEN]: 'FROZEN',
+  [AccountStatus.CLOSED]: 'CLOSED',
 }
 
 // ---------------------------------------------------------------------------
@@ -211,10 +191,31 @@ function DetailField({ label, children }: { label: string; children: React.React
 export function AccountDetailPage() {
   const { accountId } = useParams<{ accountId: string }>()
   const { tenantSlug } = useTenantContext()
+  const clients = useApiClients()
 
   const { data: account, isLoading, isError } = useQuery({
     queryKey: tenantKeys.account(tenantSlug ?? '', accountId ?? ''),
-    queryFn: () => retrieveAccount(tenantSlug ?? '', accountId ?? ''),
+    queryFn: async (): Promise<CurrentAccount | null> => {
+      try {
+        const response = await clients.currentAccount.retrieveCurrentAccount({ accountId: accountId ?? '' })
+        const f = response.facility
+        if (!f) return null
+        return {
+          accountId: f.accountId,
+          externalReference: f.externalIdentifier ?? '',
+          status: (ACCOUNT_STATUS_NAMES[f.accountStatus] ?? String(f.accountStatus)) as AccountStatusType,
+          instrumentCode: f.instrumentCode || '',
+          availableBalance: '',
+          createdAt: f.createdAt ?? undefined,
+          updatedAt: f.updatedAt ?? undefined,
+          partyId: f.orgPartyId || undefined,
+        }
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err)
+        if (msg.includes('not_found') || msg.includes('NOT_FOUND')) return null
+        throw err
+      }
+    },
     enabled: !!accountId,
   })
 
@@ -253,7 +254,7 @@ export function AccountDetailPage() {
         <AccountActions
           status={account.status}
           accountId={account.accountId}
-          currency={account.baseCurrency}
+          currency={account.instrumentCode}
         />
       </div>
 
@@ -261,7 +262,7 @@ export function AccountDetailPage() {
       <Card className="mt-6">
         <CardContent>
           <dl className="grid grid-cols-2 gap-4 pt-2 md:grid-cols-4">
-            <DetailField label="Currency">{account.baseCurrency}</DetailField>
+            <DetailField label="Instrument">{account.instrumentCode}</DetailField>
             <DetailField label="Available Balance">
               {account.availableBalance ?? '—'}
             </DetailField>
@@ -297,7 +298,7 @@ export function AccountDetailPage() {
                   <DetailField label="Status">
                     <StatusBadge status={account.status} />
                   </DetailField>
-                  <DetailField label="Base Currency">{account.baseCurrency}</DetailField>
+                  <DetailField label="Instrument">{account.instrumentCode}</DetailField>
                   <DetailField label="Available Balance">
                     {account.availableBalance ?? '—'}
                   </DetailField>

--- a/frontend/src/pages/accounts/[accountId].tsx
+++ b/frontend/src/pages/accounts/[accountId].tsx
@@ -78,7 +78,7 @@ function AccountNotFound() {
 // ---------------------------------------------------------------------------
 
 interface AccountActionsProps {
-  status: AccountStatus
+  status: AccountStatusType
   accountId: string
   currency: string
 }

--- a/frontend/src/pages/accounts/[accountId].tsx
+++ b/frontend/src/pages/accounts/[accountId].tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { AuditTrail } from '@/components/shared'
+import { ConnectError, Code } from '@connectrpc/connect'
 import { useApiClients } from '@/api/context'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
@@ -211,8 +212,7 @@ export function AccountDetailPage() {
           partyId: f.orgPartyId || undefined,
         }
       } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err)
-        if (msg.includes('not_found') || msg.includes('NOT_FOUND')) return null
+        if (ConnectError.from(err).code === Code.NotFound) return null
         throw err
       }
     },

--- a/frontend/src/pages/accounts/account-detail.test.tsx
+++ b/frontend/src/pages/accounts/account-detail.test.tsx
@@ -22,29 +22,27 @@ function renderDetailPage(accountId = 'acct-001') {
   )
 }
 
-const mockAccount = {
+// Proto shape: RetrieveCurrentAccountResponse.facility (CurrentAccountFacility)
+const mockFacility = {
   accountId: 'acct-001',
-  externalReference: 'GB29NWBK60161331926819',
-  status: 'ACTIVE',
-  baseCurrency: 'GBP',
-  availableBalance: '100000',
-  reservedBalance: '0',
-  name: 'Main Account',
-  partyId: 'party-123',
-  createdAt: { seconds: 1700000000, nanos: 0 },
-  updatedAt: { seconds: 1700000001, nanos: 0 },
+  externalIdentifier: 'GB29NWBK60161331926819',
+  accountStatus: 1, // ACCOUNT_STATUS_ACTIVE
+  instrumentCode: 'GBP',
+  orgPartyId: 'party-123',
+  createdAt: '2023-11-14T22:13:20Z',
+  updatedAt: '2023-11-14T22:13:21Z',
 }
 
-const mockFrozenAccount = {
-  ...mockAccount,
+const mockFrozenFacility = {
+  ...mockFacility,
   accountId: 'acct-frozen',
-  status: 'FROZEN',
+  accountStatus: 2, // ACCOUNT_STATUS_FROZEN
 }
 
-const mockClosedAccount = {
-  ...mockAccount,
+const mockClosedFacility = {
+  ...mockFacility,
   accountId: 'acct-closed',
-  status: 'CLOSED',
+  accountStatus: 3, // ACCOUNT_STATUS_CLOSED
 }
 
 describe('AccountDetailPage - loading and error states', () => {
@@ -79,7 +77,7 @@ describe('AccountDetailPage - account overview', () => {
   it('renders account ID in header', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockAccount }),
+        HttpResponse.json({ facility: mockFacility }),
       ),
     )
 
@@ -93,7 +91,7 @@ describe('AccountDetailPage - account overview', () => {
   it('renders external reference', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockAccount }),
+        HttpResponse.json({ facility: mockFacility }),
       ),
     )
 
@@ -107,7 +105,7 @@ describe('AccountDetailPage - account overview', () => {
   it('renders status badge', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockAccount }),
+        HttpResponse.json({ facility: mockFacility }),
       ),
     )
 
@@ -121,7 +119,7 @@ describe('AccountDetailPage - account overview', () => {
   it('renders currency', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockAccount }),
+        HttpResponse.json({ facility: mockFacility }),
       ),
     )
 
@@ -137,7 +135,7 @@ describe('AccountDetailPage - tabs', () => {
   it('renders Overview tab by default', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockAccount }),
+        HttpResponse.json({ facility: mockFacility }),
       ),
     )
 
@@ -151,7 +149,7 @@ describe('AccountDetailPage - tabs', () => {
   it('renders all required tabs', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockAccount }),
+        HttpResponse.json({ facility: mockFacility }),
       ),
     )
 
@@ -169,7 +167,7 @@ describe('AccountDetailPage - tabs', () => {
   it('switches to Transactions tab when clicked', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockAccount }),
+        HttpResponse.json({ facility: mockFacility }),
       ),
     )
 
@@ -190,7 +188,7 @@ describe('AccountDetailPage - tabs', () => {
   it('switches to Audit Trail tab when clicked', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockAccount }),
+        HttpResponse.json({ facility: mockFacility }),
       ),
     )
 
@@ -210,7 +208,7 @@ describe('AccountDetailPage - action buttons', () => {
   it('renders Freeze button for ACTIVE account', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockAccount }),
+        HttpResponse.json({ facility: mockFacility }),
       ),
     )
 
@@ -224,7 +222,7 @@ describe('AccountDetailPage - action buttons', () => {
   it('renders Unfreeze button for FROZEN account', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockFrozenAccount }),
+        HttpResponse.json({ facility: mockFrozenFacility }),
       ),
     )
 
@@ -238,7 +236,7 @@ describe('AccountDetailPage - action buttons', () => {
   it('does not render action buttons for CLOSED account', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockClosedAccount }),
+        HttpResponse.json({ facility: mockClosedFacility }),
       ),
     )
 
@@ -255,7 +253,7 @@ describe('AccountDetailPage - action buttons', () => {
   it('renders Close button for ACTIVE account', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockAccount }),
+        HttpResponse.json({ facility: mockFacility }),
       ),
     )
 
@@ -269,7 +267,7 @@ describe('AccountDetailPage - action buttons', () => {
   it('hides Close button for FROZEN account (must unfreeze first)', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockFrozenAccount }),
+        HttpResponse.json({ facility: mockFrozenFacility }),
       ),
     )
 
@@ -287,7 +285,7 @@ describe('AccountDetailPage - dialog integration', () => {
   it('opens DepositDialog when Deposit button is clicked', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockAccount }),
+        HttpResponse.json({ facility: mockFacility }),
       ),
     )
 
@@ -307,7 +305,7 @@ describe('AccountDetailPage - dialog integration', () => {
   it('opens WithdrawDialog when Withdraw button is clicked', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockAccount }),
+        HttpResponse.json({ facility: mockFacility }),
       ),
     )
 
@@ -327,7 +325,7 @@ describe('AccountDetailPage - dialog integration', () => {
   it('opens ControlDialog when Freeze button is clicked', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockAccount }),
+        HttpResponse.json({ facility: mockFacility }),
       ),
     )
 
@@ -347,7 +345,7 @@ describe('AccountDetailPage - dialog integration', () => {
   it('opens ControlDialog when Unfreeze button is clicked', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockFrozenAccount }),
+        HttpResponse.json({ facility: mockFrozenFacility }),
       ),
     )
 
@@ -367,7 +365,7 @@ describe('AccountDetailPage - dialog integration', () => {
   it('opens ControlDialog when Close Account button is clicked', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockAccount }),
+        HttpResponse.json({ facility: mockFacility }),
       ),
     )
 
@@ -389,7 +387,7 @@ describe('AccountDetailPage - back navigation', () => {
   it('renders a back link to accounts list', async () => {
     server.use(
       http.post('*/meridian.current_account.v1.CurrentAccountService/RetrieveCurrentAccount', () =>
-        HttpResponse.json({ account: mockAccount }),
+        HttpResponse.json({ facility: mockFacility }),
       ),
     )
 

--- a/frontend/src/pages/accounts/accounts-list.test.tsx
+++ b/frontend/src/pages/accounts/accounts-list.test.tsx
@@ -22,21 +22,22 @@ function renderAccountsPage(initialPath = '/accounts') {
   )
 }
 
-// Mock proto response shape (CurrentAccountFacility fields)
+// Mock proto response shape (CurrentAccountFacility fields — Connect-RPC JSON format)
+// Timestamps use RFC 3339 strings per proto3 JSON mapping.
 const mockAccounts = [
   {
     accountId: 'acct-001',
-    accountIdentification: 'GB29NWBK60161331926819',
-    accountStatus: 'ACCOUNT_STATUS_ACTIVE',
-    baseCurrency: 'CURRENCY_GBP',
-    createdAt: { seconds: 1700000000, nanos: 0 },
+    externalIdentifier: 'GB29NWBK60161331926819',
+    accountStatus: 1, // ACCOUNT_STATUS_ACTIVE
+    instrumentCode: 'GBP',
+    createdAt: '2023-11-14T22:13:20Z',
   },
   {
     accountId: 'acct-002',
-    accountIdentification: 'DE89370400440532013000',
-    accountStatus: 'ACCOUNT_STATUS_FROZEN',
-    baseCurrency: 'CURRENCY_EUR',
-    createdAt: { seconds: 1700100000, nanos: 0 },
+    externalIdentifier: 'DE89370400440532013000',
+    accountStatus: 2, // ACCOUNT_STATUS_FROZEN
+    instrumentCode: 'EUR',
+    createdAt: '2023-11-15T01:46:40Z',
   },
 ]
 
@@ -102,7 +103,7 @@ describe('AccountsPage - list rendering', () => {
 
     expect(screen.getByRole('columnheader', { name: /external ref/i })).toBeInTheDocument()
     expect(screen.getByRole('columnheader', { name: /status/i })).toBeInTheDocument()
-    expect(screen.getByRole('columnheader', { name: /currency/i })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /instrument/i })).toBeInTheDocument()
   })
 
   it('shows skeleton rows while loading', () => {
@@ -174,7 +175,7 @@ describe('AccountsPage - filtering', () => {
     await waitFor(() => expect(capturedRequests.length).toBeGreaterThan(0))
 
     const statusSelect = screen.getByRole('combobox', { name: /status/i })
-    await userEvent.selectOptions(statusSelect, 'ACCOUNT_STATUS_ACTIVE')
+    await userEvent.selectOptions(statusSelect, '1')
 
     await waitFor(() => {
       // DataTable passes filters as a record - the page should call the API with the filter

--- a/frontend/src/pages/accounts/control-dialog.tsx
+++ b/frontend/src/pages/accounts/control-dialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
+import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
 
 export type ControlAction = 'freeze' | 'unfreeze' | 'close'
 
@@ -54,31 +55,9 @@ const ACTION_CONFIG: Record<
   },
 }
 
-async function performAccountControl(
-  tenantSlug: string,
-  accountId: string,
-  endpoint: string,
-): Promise<void> {
-  const response = await fetch(
-    `/meridian.current_account.v1.CurrentAccountService/${endpoint}`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Tenant-Slug': tenantSlug,
-      },
-      body: JSON.stringify({ accountId }),
-    },
-  )
-
-  if (!response.ok) {
-    const data = (await response.json().catch(() => ({}))) as { message?: string }
-    throw new Error(data.message ?? `Failed to ${endpoint}: ${response.status}`)
-  }
-}
-
 export function ControlDialog({ open, onOpenChange, accountId, action }: ControlDialogProps) {
   const { tenantSlug } = useTenantContext()
+  const authFetch = useAuthenticatedFetch()
   const queryClient = useQueryClient()
   const [serverError, setServerError] = React.useState<string | null>(null)
 
@@ -91,8 +70,16 @@ export function ControlDialog({ open, onOpenChange, accountId, action }: Control
   }, [open])
 
   const mutation = useMutation({
-    mutationFn: () =>
-      performAccountControl(tenantSlug ?? '', accountId, config.endpoint),
+    mutationFn: async () => {
+      const response = await authFetch(
+        `/meridian.current_account.v1.CurrentAccountService/${config.endpoint}`,
+        { method: 'POST', body: JSON.stringify({ accountId }) },
+      )
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as { message?: string }
+        throw new Error(data.message ?? `Failed to ${config.endpoint}: ${response.status}`)
+      }
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: tenantKeys.account(tenantSlug ?? '', accountId),

--- a/frontend/src/pages/accounts/create-account-dialog.tsx
+++ b/frontend/src/pages/accounts/create-account-dialog.tsx
@@ -12,8 +12,9 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
+import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
 
-const CURRENCIES = ['GBP', 'USD', 'EUR']
+const INSTRUMENTS = ['GBP', 'USD', 'EUR', 'KWH']
 
 interface FormData {
   externalReference: string
@@ -33,42 +34,9 @@ interface CreateAccountDialogProps {
   onCreated?: (accountId: string) => void
 }
 
-async function createAccount(
-  tenantSlug: string,
-  externalReference: string,
-  currency: string,
-  partyId: string,
-): Promise<string> {
-  const response = await fetch(
-    `/meridian.current_account.v1.CurrentAccountService/InitiateCurrentAccount`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Tenant-Slug': tenantSlug,
-      },
-      body: JSON.stringify({
-        accountIdentification: externalReference,
-        baseCurrency: currency,
-        partyId,
-      }),
-    },
-  )
-
-  if (!response.ok) {
-    const data = (await response.json().catch(() => ({}))) as { message?: string }
-    throw new Error(data.message ?? `Failed to create account: ${response.status}`)
-  }
-
-  const data = (await response.json()) as { accountId?: string }
-  if (!data.accountId) {
-    throw new Error('Account ID missing from response')
-  }
-  return data.accountId
-}
-
 export function CreateAccountDialog({ open, onOpenChange, onCreated }: CreateAccountDialogProps) {
   const { tenantSlug } = useTenantContext()
+  const authFetch = useAuthenticatedFetch()
   const queryClient = useQueryClient()
   const [formData, setFormData] = React.useState<FormData>({
     externalReference: '',
@@ -101,13 +69,26 @@ export function CreateAccountDialog({ open, onOpenChange, onCreated }: CreateAcc
   }
 
   const mutation = useMutation({
-    mutationFn: () =>
-      createAccount(
-        tenantSlug ?? '',
-        formData.externalReference.trim(),
-        formData.currency,
-        formData.partyId.trim(),
-      ),
+    mutationFn: async () => {
+      const response = await authFetch(
+        `/meridian.current_account.v1.CurrentAccountService/InitiateCurrentAccount`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            externalIdentifier: formData.externalReference.trim(),
+            instrumentCode: formData.currency,
+            partyId: formData.partyId.trim(),
+          }),
+        },
+      )
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as { message?: string }
+        throw new Error(data.message ?? `Failed to create account: ${response.status}`)
+      }
+      const data = (await response.json()) as { accountId?: string }
+      if (!data.accountId) throw new Error('Account ID missing from response')
+      return data.accountId
+    },
     onSuccess: (accountId) => {
       queryClient.invalidateQueries({
         queryKey: tenantKeys.accounts(tenantSlug ?? ''),
@@ -182,7 +163,7 @@ export function CreateAccountDialog({ open, onOpenChange, onCreated }: CreateAcc
                 aria-label="Currency"
                 className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
               >
-                {CURRENCIES.map((c) => (
+                {INSTRUMENTS.map((c) => (
                   <option key={c} value={c}>
                     {c}
                   </option>

--- a/frontend/src/pages/accounts/create-lien-dialog.tsx
+++ b/frontend/src/pages/accounts/create-lien-dialog.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
+import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
 import { amountToBigInt } from './account-form-utils'
 
 export interface CreateLienDialogProps {
@@ -61,56 +62,6 @@ function validateExpiry(value: string): string | null {
   return null
 }
 
-async function initiateLien(
-  tenantSlug: string,
-  accountId: string,
-  accountType: 'current' | 'internal',
-  amountMinorUnits: string,
-  reason: string,
-  expiresAtSeconds?: string,
-): Promise<string> {
-  const serviceName =
-    accountType === 'current'
-      ? 'meridian.current_account.v1.CurrentAccountService'
-      : 'meridian.internal_account.v1.InternalAccountService'
-
-  const body: Record<string, unknown> = {
-    accountId,
-    paymentOrderReference: reason,
-  }
-
-  if (accountType === 'current') {
-    body.amount = { amount: amountMinorUnits }
-  } else {
-    body.input = { amount: amountMinorUnits }
-  }
-
-  if (expiresAtSeconds) {
-    body.expiresAt = { seconds: expiresAtSeconds }
-  }
-
-  const response = await fetch(`/${serviceName}/InitiateLien`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Tenant-Slug': tenantSlug,
-    },
-    body: JSON.stringify(body),
-  })
-
-  if (!response.ok) {
-    const data = (await response.json().catch(() => ({}))) as { message?: string }
-    throw new Error(data.message ?? `Failed to create lien: ${response.status}`)
-  }
-
-  const data = (await response.json()) as { lien?: { lienId?: string } }
-  const lienId = data.lien?.lienId ?? ''
-  if (!lienId) {
-    throw new Error('Lien ID missing from response')
-  }
-  return lienId
-}
-
 export function CreateLienDialog({
   open,
   onOpenChange,
@@ -120,6 +71,7 @@ export function CreateLienDialog({
   decimalPlaces = 2,
 }: CreateLienDialogProps) {
   const { tenantSlug } = useTenantContext()
+  const authFetch = useAuthenticatedFetch()
   const queryClient = useQueryClient()
 
   const [amount, setAmount] = React.useState('')
@@ -145,19 +97,39 @@ export function CreateLienDialog({
   }, [open])
 
   const mutation = useMutation({
-    mutationFn: () => {
+    mutationFn: async () => {
       const minorUnits = amountToBigInt(amount, decimalPlaces).toString()
       const expiresAtSeconds = expiry
         ? Math.floor(parseDatetimeLocalAsUtc(expiry).getTime() / 1000).toString()
         : undefined
-      return initiateLien(
-        tenantSlug ?? '',
+      const serviceName =
+        accountType === 'current'
+          ? 'meridian.current_account.v1.CurrentAccountService'
+          : 'meridian.internal_account.v1.InternalAccountService'
+      const body: Record<string, unknown> = {
         accountId,
-        accountType,
-        minorUnits,
-        reason.trim(),
-        expiresAtSeconds,
-      )
+        paymentOrderReference: reason.trim(),
+      }
+      if (accountType === 'current') {
+        body.amount = { amount: minorUnits }
+      } else {
+        body.input = { amount: minorUnits }
+      }
+      if (expiresAtSeconds) {
+        body.expiresAt = { seconds: expiresAtSeconds }
+      }
+      const response = await authFetch(`/${serviceName}/InitiateLien`, {
+        method: 'POST',
+        body: JSON.stringify(body),
+      })
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as { message?: string }
+        throw new Error(data.message ?? `Failed to create lien: ${response.status}`)
+      }
+      const data = (await response.json()) as { lien?: { lienId?: string } }
+      const lienId = data.lien?.lienId ?? ''
+      if (!lienId) throw new Error('Lien ID missing from response')
+      return lienId
     },
     onSuccess: (lienId) => {
       queryClient.invalidateQueries({

--- a/frontend/src/pages/accounts/deposit-dialog.tsx
+++ b/frontend/src/pages/accounts/deposit-dialog.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
+import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
 import { amountToBigInt } from './account-form-utils'
 
 interface DepositDialogProps {
@@ -36,34 +37,9 @@ function validateAmount(value: string): string | null {
   return null
 }
 
-async function depositFunds(
-  tenantSlug: string,
-  accountId: string,
-  amountMinorUnits: string,
-): Promise<void> {
-  const response = await fetch(
-    `/meridian.current_account.v1.CurrentAccountService/DepositFunds`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Tenant-Slug': tenantSlug,
-      },
-      body: JSON.stringify({
-        accountId,
-        amount: { amount: amountMinorUnits },
-      }),
-    },
-  )
-
-  if (!response.ok) {
-    const data = (await response.json().catch(() => ({}))) as { message?: string }
-    throw new Error(data.message ?? `Failed to deposit: ${response.status}`)
-  }
-}
-
 export function DepositDialog({ open, onOpenChange, accountId, currency }: DepositDialogProps) {
   const { tenantSlug } = useTenantContext()
+  const authFetch = useAuthenticatedFetch()
   const queryClient = useQueryClient()
   const [amount, setAmount] = React.useState('')
   const [amountError, setAmountError] = React.useState<string | null>(null)
@@ -78,9 +54,19 @@ export function DepositDialog({ open, onOpenChange, accountId, currency }: Depos
   }, [open])
 
   const mutation = useMutation({
-    mutationFn: () => {
+    mutationFn: async () => {
       const minorUnits = amountToBigInt(amount).toString()
-      return depositFunds(tenantSlug ?? '', accountId, minorUnits)
+      const response = await authFetch(
+        `/meridian.current_account.v1.CurrentAccountService/DepositFunds`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ accountId, amount: { amount: minorUnits } }),
+        },
+      )
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as { message?: string }
+        throw new Error(data.message ?? `Failed to deposit: ${response.status}`)
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/frontend/src/pages/accounts/index.tsx
+++ b/frontend/src/pages/accounts/index.tsx
@@ -77,7 +77,7 @@ export function AccountsPage() {
         externalReference: a.externalIdentifier ?? '',
         status: (ACCOUNT_STATUS_NAMES[a.accountStatus] ?? String(a.accountStatus)) as CurrentAccount['status'],
         instrumentCode: a.instrumentCode || '',
-        availableBalance: '',
+        availableBalance: '', // fetched separately via PositionKeeping; not in ListCurrentAccounts response
         createdAt: a.createdAt ?? undefined,
         updatedAt: a.updatedAt ?? undefined,
       }))

--- a/frontend/src/pages/accounts/index.tsx
+++ b/frontend/src/pages/accounts/index.tsx
@@ -6,91 +6,29 @@ import type { DataTableQueryParams, DataTableResult } from '@/components/shared/
 import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { Button } from '@/components/ui/button'
+import { useApiClients } from '@/api/context'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
+import { AccountStatus } from '@/api/gen/meridian/current_account/v1/current_account_pb'
 import { CreateAccountDialog } from './create-account-dialog'
 import type { CurrentAccount } from './types'
 
 const STATUS_OPTIONS = [
-  { label: 'Active', value: 'ACCOUNT_STATUS_ACTIVE' },
-  { label: 'Frozen', value: 'ACCOUNT_STATUS_FROZEN' },
-  { label: 'Closed', value: 'ACCOUNT_STATUS_CLOSED' },
+  { label: 'Active', value: String(AccountStatus.ACTIVE) },
+  { label: 'Frozen', value: String(AccountStatus.FROZEN) },
+  { label: 'Closed', value: String(AccountStatus.CLOSED) },
 ]
 
-async function listAccounts(
-  tenantSlug: string,
-  params: DataTableQueryParams,
-): Promise<DataTableResult<CurrentAccount>> {
-  const body: Record<string, unknown> = {
-    pageSize: params.pageSize,
-  }
-  if (params.pageToken) {
-    body.pageToken = params.pageToken
-  }
-  if (params.filters?.status) {
-    body.status = params.filters.status
-  }
-  if (params.filters?.externalReference) {
-    body.iban = params.filters.externalReference
-  }
-
-  const response = await fetch(
-    `/meridian.current_account.v1.CurrentAccountService/ListCurrentAccounts`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Tenant-Slug': tenantSlug,
-      },
-      body: JSON.stringify(body),
-    },
-  )
-
-  if (!response.ok) {
-    throw new Error(`Failed to list accounts: ${response.status}`)
-  }
-
-  const data = (await response.json()) as RawListCurrentAccountsResponse
-
-  // Map proto CurrentAccountFacility fields to frontend CurrentAccount shape
-  const accounts: CurrentAccount[] = (data.accounts ?? []).map((a) => ({
-    accountId: a.accountId ?? '',
-    externalReference: a.accountIdentification ?? '',
-    status: stripEnumPrefix(a.accountStatus ?? '', 'ACCOUNT_STATUS_') as CurrentAccount['status'],
-    baseCurrency: stripEnumPrefix(a.baseCurrency ?? '', 'CURRENCY_'),
-    availableBalance: '',
-    createdAt: a.createdAt,
-    updatedAt: a.updatedAt,
-  }))
-
-  return {
-    items: accounts,
-    nextPageToken: data.nextPageToken || undefined,
-  }
-}
-
-// Strip proto enum prefix (e.g., "ACCOUNT_STATUS_ACTIVE" -> "ACTIVE")
-function stripEnumPrefix(value: string, prefix: string): string {
-  return value.startsWith(prefix) ? value.slice(prefix.length) : value
-}
-
-// Raw proto response shape before mapping
-interface RawListCurrentAccountsResponse {
-  accounts?: Array<{
-    accountId?: string
-    accountIdentification?: string
-    accountStatus?: string
-    baseCurrency?: string
-    createdAt?: { seconds: number | bigint; nanos?: number }
-    updatedAt?: { seconds: number | bigint; nanos?: number }
-  }>
-  nextPageToken?: string
-  totalCount?: string
+const ACCOUNT_STATUS_NAMES: Record<number, string> = {
+  [AccountStatus.ACTIVE]: 'ACTIVE',
+  [AccountStatus.FROZEN]: 'FROZEN',
+  [AccountStatus.CLOSED]: 'CLOSED',
 }
 
 export function AccountsPage() {
   const navigate = useNavigate()
   const { tenantSlug } = useTenantContext()
+  const clients = useApiClients()
   const [createOpen, setCreateOpen] = React.useState(false)
 
   const columns: ColumnDef<CurrentAccount>[] = [
@@ -108,8 +46,8 @@ export function AccountsPage() {
       cell: ({ row }) => <StatusBadge status={row.original.status} />,
     },
     {
-      accessorKey: 'baseCurrency',
-      header: 'Currency',
+      accessorKey: 'instrumentCode',
+      header: 'Instrument',
     },
     {
       accessorKey: 'createdAt',
@@ -124,8 +62,32 @@ export function AccountsPage() {
   )
 
   const queryFn = React.useCallback(
-    (params: DataTableQueryParams) => listAccounts(tenantSlug ?? '', params),
-    [tenantSlug],
+    async (params: DataTableQueryParams): Promise<DataTableResult<CurrentAccount>> => {
+      if (!tenantSlug) return { items: [] }
+
+      const statusFilter = params.filters?.status
+      const response = await clients.currentAccount.listCurrentAccounts({
+        pageSize: params.pageSize,
+        pageToken: params.pageToken ?? '',
+        ...(statusFilter !== undefined && { status: Number(statusFilter) as AccountStatus }),
+      })
+
+      const accounts: CurrentAccount[] = (response.accounts ?? []).map((a) => ({
+        accountId: a.accountId ?? '',
+        externalReference: a.externalIdentifier ?? '',
+        status: (ACCOUNT_STATUS_NAMES[a.accountStatus] ?? String(a.accountStatus)) as CurrentAccount['status'],
+        instrumentCode: a.instrumentCode || '',
+        availableBalance: '',
+        createdAt: a.createdAt ?? undefined,
+        updatedAt: a.updatedAt ?? undefined,
+      }))
+
+      return {
+        items: accounts,
+        nextPageToken: response.nextPageToken || undefined,
+      }
+    },
+    [tenantSlug, clients],
   )
 
   return (

--- a/frontend/src/pages/accounts/index.tsx
+++ b/frontend/src/pages/accounts/index.tsx
@@ -66,10 +66,14 @@ export function AccountsPage() {
       if (!tenantSlug) return { items: [] }
 
       const statusFilter = params.filters?.status
+      const parsedStatus =
+        statusFilter !== undefined && statusFilter !== '' ? Number(statusFilter) : undefined
       const response = await clients.currentAccount.listCurrentAccounts({
         pageSize: params.pageSize,
         pageToken: params.pageToken ?? '',
-        ...(statusFilter !== undefined && { status: Number(statusFilter) as AccountStatus }),
+        ...(parsedStatus !== undefined && Number.isFinite(parsedStatus)
+          ? { status: parsedStatus as AccountStatus }
+          : {}),
       })
 
       const accounts: CurrentAccount[] = (response.accounts ?? []).map((a) => ({

--- a/frontend/src/pages/accounts/types.ts
+++ b/frontend/src/pages/accounts/types.ts
@@ -8,7 +8,7 @@ export interface CurrentAccount {
   accountId: string
   externalReference: string
   status: AccountStatus
-  baseCurrency: string
+  instrumentCode: string
   availableBalance: string
   reservedBalance?: string
   name?: string

--- a/frontend/src/pages/accounts/withdraw-dialog.tsx
+++ b/frontend/src/pages/accounts/withdraw-dialog.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
+import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
 import { amountToBigInt } from './account-form-utils'
 
 interface WithdrawDialogProps {
@@ -38,59 +39,9 @@ function validateAmount(value: string): string | null {
   return null
 }
 
-async function initiateWithdrawal(
-  tenantSlug: string,
-  accountId: string,
-  amountMinorUnits: string,
-): Promise<string> {
-  const response = await fetch(
-    `/meridian.current_account.v1.CurrentAccountService/InitiateWithdrawal`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Tenant-Slug': tenantSlug,
-      },
-      body: JSON.stringify({
-        accountId,
-        amount: { amount: amountMinorUnits },
-      }),
-    },
-  )
-
-  if (!response.ok) {
-    const data = (await response.json().catch(() => ({}))) as { message?: string }
-    throw new Error(data.message ?? `Failed to initiate withdrawal: ${response.status}`)
-  }
-
-  const data = (await response.json()) as { withdrawalId?: string }
-  if (!data.withdrawalId) {
-    throw new Error('Withdrawal ID missing from response')
-  }
-  return data.withdrawalId
-}
-
-async function executeWithdrawal(tenantSlug: string, withdrawalId: string): Promise<void> {
-  const response = await fetch(
-    `/meridian.current_account.v1.CurrentAccountService/ExecuteWithdrawal`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Tenant-Slug': tenantSlug,
-      },
-      body: JSON.stringify({ withdrawalId }),
-    },
-  )
-
-  if (!response.ok) {
-    const data = (await response.json().catch(() => ({}))) as { message?: string }
-    throw new Error(data.message ?? `Failed to execute withdrawal: ${response.status}`)
-  }
-}
-
 export function WithdrawDialog({ open, onOpenChange, accountId, currency }: WithdrawDialogProps) {
   const { tenantSlug } = useTenantContext()
+  const authFetch = useAuthenticatedFetch()
   const queryClient = useQueryClient()
   const isOpenRef = React.useRef(open)
   const [step, setStep] = React.useState<Step>('initiate')
@@ -111,9 +62,19 @@ export function WithdrawDialog({ open, onOpenChange, accountId, currency }: With
   }, [open])
 
   const initiateMutation = useMutation({
-    mutationFn: () => {
+    mutationFn: async () => {
       const minorUnits = amountToBigInt(amount).toString()
-      return initiateWithdrawal(tenantSlug ?? '', accountId, minorUnits)
+      const response = await authFetch(
+        `/meridian.current_account.v1.CurrentAccountService/InitiateWithdrawal`,
+        { method: 'POST', body: JSON.stringify({ accountId, amount: { amount: minorUnits } }) },
+      )
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as { message?: string }
+        throw new Error(data.message ?? `Failed to initiate withdrawal: ${response.status}`)
+      }
+      const data = (await response.json()) as { withdrawalId?: string }
+      if (!data.withdrawalId) throw new Error('Withdrawal ID missing from response')
+      return data.withdrawalId
     },
     onSuccess: (id) => {
       if (!isOpenRef.current) return
@@ -127,8 +88,15 @@ export function WithdrawDialog({ open, onOpenChange, accountId, currency }: With
   })
 
   const executeMutation = useMutation({
-    mutationFn: () => {
-      return executeWithdrawal(tenantSlug ?? '', withdrawalId ?? '')
+    mutationFn: async () => {
+      const response = await authFetch(
+        `/meridian.current_account.v1.CurrentAccountService/ExecuteWithdrawal`,
+        { method: 'POST', body: JSON.stringify({ withdrawalId }) },
+      )
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as { message?: string }
+        throw new Error(data.message ?? `Failed to execute withdrawal: ${response.status}`)
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/frontend/src/pages/audit/index.test.tsx
+++ b/frontend/src/pages/audit/index.test.tsx
@@ -215,7 +215,8 @@ describe('AuditLogPage', () => {
       await waitFor(() => {
         const calls = (global.fetch as vi.MockedFunction<typeof fetch>).mock.calls
         const lastCall = calls[calls.length - 1]
-        expect(lastCall[0]).toContain('tableName=current_account')
+        const body = JSON.parse(lastCall[1]?.body as string)
+        expect(body.tableName).toBe('current_account')
       })
     })
 
@@ -240,7 +241,8 @@ describe('AuditLogPage', () => {
       await waitFor(() => {
         const calls = (global.fetch as vi.MockedFunction<typeof fetch>).mock.calls
         const lastCall = calls[calls.length - 1]
-        expect(lastCall[0]).toContain('operation=UPDATE')
+        const body = JSON.parse(lastCall[1]?.body as string)
+        expect(body.operation).toBe('UPDATE')
       })
     })
 
@@ -265,7 +267,8 @@ describe('AuditLogPage', () => {
       await waitFor(() => {
         const calls = (global.fetch as vi.MockedFunction<typeof fetch>).mock.calls
         const lastCall = calls[calls.length - 1]
-        expect(lastCall[0]).toContain('changedBy=user%40example.com')
+        const body = JSON.parse(lastCall[1]?.body as string)
+        expect(body.changedBy).toBe('user@example.com')
       })
     })
 
@@ -295,7 +298,8 @@ describe('AuditLogPage', () => {
       await waitFor(() => {
         const calls = (global.fetch as vi.MockedFunction<typeof fetch>).mock.calls
         const lastCall = calls[calls.length - 1]
-        expect(lastCall[0]).not.toContain('pageToken=token-1')
+        const body = JSON.parse(lastCall[1]?.body as string)
+        expect(body.pageToken).toBeUndefined()
       })
     })
   })

--- a/frontend/src/pages/audit/index.test.tsx
+++ b/frontend/src/pages/audit/index.test.tsx
@@ -4,6 +4,10 @@ import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuditLogPage, type AuditLogEntry } from './index'
 
+vi.mock('@/hooks/use-authenticated-fetch', () => ({
+  useAuthenticatedFetch: () => fetch,
+}))
+
 function makeQueryClient() {
   return new QueryClient({
     defaultOptions: {

--- a/frontend/src/pages/audit/index.tsx
+++ b/frontend/src/pages/audit/index.tsx
@@ -214,16 +214,19 @@ export function AuditLogPage() {
   const authFetch = useAuthenticatedFetch()
 
   const fetchAuditEntries = useCallback(async (params: DataTableQueryParams): Promise<DataTableResult<AuditLogEntry>> => {
-    const searchParams = new URLSearchParams()
-    if (params.pageToken) searchParams.set('pageToken', params.pageToken)
-    searchParams.set('pageSize', String(params.pageSize))
+    const body: Record<string, unknown> = {
+      pageSize: params.pageSize,
+    }
+    if (params.pageToken) body.pageToken = params.pageToken
     if (params.filters) {
       Object.entries(params.filters).forEach(([key, value]) => {
-        if (value) searchParams.set(key, value)
+        if (value) body[key] = value
       })
     }
-    const response = await authFetch(`/meridian.audit.v1.AuditService/ListAuditEntries?${searchParams}`, {
+    const response = await authFetch('/meridian.audit.v1.AuditService/ListAuditEntries', {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
     })
     if (!response.ok) {
       if (response.status === 501 || response.status === 503) {

--- a/frontend/src/pages/audit/index.tsx
+++ b/frontend/src/pages/audit/index.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import type { ColumnDef } from '@tanstack/react-table'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { DataTable, type DataTableQueryParams, type DataTableResult, type FilterConfig } from '@/components/shared/data-table'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { JsonDiffViewer } from '@/components/shared/audit-trail'
+import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
 import { cn } from '@/lib/utils'
 
 // ---------------------------------------------------------------------------
@@ -208,44 +209,31 @@ const columns: ColumnDef<AuditLogEntry>[] = [
   },
 ]
 
-async function fetchAuditEntries(params: DataTableQueryParams): Promise<DataTableResult<AuditLogEntry>> {
-  const searchParams = new URLSearchParams()
-
-  if (params.pageToken) {
-    searchParams.set('pageToken', params.pageToken)
-  }
-
-  searchParams.set('pageSize', String(params.pageSize))
-
-  if (params.filters) {
-    Object.entries(params.filters).forEach(([key, value]) => {
-      if (value) {
-        searchParams.set(key, value)
-      }
-    })
-  }
-
-  const response = await fetch(`/meridian.audit.v1.AuditService/ListAuditEntries?${searchParams}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-  })
-
-  if (!response.ok) {
-    if (response.status === 501 || response.status === 503) {
-      return { items: [], nextPageToken: undefined }
-    }
-    throw new Error(`Failed to fetch audit entries: ${response.status}`)
-  }
-
-  const data = (await response.json()) as AuditLogResponse
-  return {
-    items: data.entries ?? [],
-    nextPageToken: data.nextPageToken,
-  }
-}
-
 export function AuditLogPage() {
   const [selectedEntry, setSelectedEntry] = useState<AuditLogEntry | null>(null)
+  const authFetch = useAuthenticatedFetch()
+
+  const fetchAuditEntries = useCallback(async (params: DataTableQueryParams): Promise<DataTableResult<AuditLogEntry>> => {
+    const searchParams = new URLSearchParams()
+    if (params.pageToken) searchParams.set('pageToken', params.pageToken)
+    searchParams.set('pageSize', String(params.pageSize))
+    if (params.filters) {
+      Object.entries(params.filters).forEach(([key, value]) => {
+        if (value) searchParams.set(key, value)
+      })
+    }
+    const response = await authFetch(`/meridian.audit.v1.AuditService/ListAuditEntries?${searchParams}`, {
+      method: 'POST',
+    })
+    if (!response.ok) {
+      if (response.status === 501 || response.status === 503) {
+        return { items: [], nextPageToken: undefined }
+      }
+      throw new Error(`Failed to fetch audit entries: ${response.status}`)
+    }
+    const data = (await response.json()) as AuditLogResponse
+    return { items: data.entries ?? [], nextPageToken: data.nextPageToken }
+  }, [authFetch])
 
   return (
     <div className="flex flex-col gap-6">

--- a/frontend/src/pages/ledger/index.tsx
+++ b/frontend/src/pages/ledger/index.tsx
@@ -24,26 +24,9 @@ function getStatusName(status: unknown): string {
   return String(status ?? '')
 }
 
-function getCurrencyName(currency: unknown): string {
-  if (typeof currency === 'string') return currency
-  if (typeof currency === 'number') {
-    const currencyMap: Record<number, string> = {
-      0: 'UNSPECIFIED',
-      1: 'GBP',
-      2: 'USD',
-      3: 'EUR',
-      4: 'JPY',
-      5: 'AUD',
-      6: 'CAD',
-      7: 'CHF',
-      8: 'CNY',
-      9: 'INR',
-      10: 'SGD',
-      11: 'HKD',
-    }
-    return currencyMap[currency] ?? String(currency)
-  }
-  return String(currency ?? '')
+function getInstrumentCode(value: unknown): string {
+  if (typeof value === 'string' && value) return value
+  return ''
 }
 
 const columns: ColumnDef<FinancialBookingLog>[] = [
@@ -63,8 +46,8 @@ const columns: ColumnDef<FinancialBookingLog>[] = [
     header: 'Business Unit',
   },
   {
-    accessorKey: 'baseCurrency',
-    header: 'Currency',
+    accessorKey: 'instrumentCode',
+    header: 'Instrument',
   },
   {
     accessorKey: 'status',
@@ -108,7 +91,7 @@ export function LedgerPage() {
       productServiceReference: String(log.productServiceReference ?? ''),
       businessUnitReference: String(log.businessUnitReference ?? ''),
       chartOfAccountsRules: String(log.chartOfAccountsRules ?? ''),
-      baseCurrency: getCurrencyName(log.baseCurrency),
+      instrumentCode: getInstrumentCode(log.baseInstrumentCode),
       status: getStatusName(log.status),
       createdAt: log.createdAt ?? null,
       updatedAt: log.updatedAt ?? null,

--- a/frontend/src/pages/ledger/types.ts
+++ b/frontend/src/pages/ledger/types.ts
@@ -34,7 +34,7 @@ export interface FinancialBookingLog {
   productServiceReference: string
   businessUnitReference: string
   chartOfAccountsRules: string
-  baseCurrency: string
+  instrumentCode: string
   status: string
   createdAt: Timestamp | null | undefined
   updatedAt: Timestamp | null | undefined

--- a/frontend/src/pages/payments/index.tsx
+++ b/frontend/src/pages/payments/index.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { ColumnDef } from '@tanstack/react-table'
 import { DataTable } from '@/components/shared/data-table'
@@ -5,6 +6,7 @@ import { MoneyDisplay } from '@/components/shared/money-display'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
 import { tenantKeys } from '@/lib/query-keys'
 import { fetchPayments, type PaymentOrder } from './payments-query'
 
@@ -66,7 +68,12 @@ interface PaymentsPageProps {
 export function PaymentsPage({ onRowNavigate }: PaymentsPageProps = {}) {
   const navigate = useNavigate()
   const tenantSlug = useTenantSlug()
+  const authFetch = useAuthenticatedFetch()
   const queryKey = tenantSlug ? tenantKeys.payments(tenantSlug) : ['payments']
+  const queryFn = useCallback(
+    (params: Parameters<typeof fetchPayments>[0]) => fetchPayments(params, authFetch),
+    [authFetch],
+  )
 
   function handleRowClick(row: PaymentOrder) {
     if (onRowNavigate) {
@@ -81,7 +88,7 @@ export function PaymentsPage({ onRowNavigate }: PaymentsPageProps = {}) {
       <h1 className="mb-6 text-2xl font-semibold">Payments</h1>
       <DataTable
         queryKey={queryKey}
-        queryFn={fetchPayments}
+        queryFn={queryFn}
         columns={columns}
         filters={FILTER_CONFIGS}
         onRowClick={handleRowClick}

--- a/frontend/src/pages/payments/payment-detail-query.ts
+++ b/frontend/src/pages/payments/payment-detail-query.ts
@@ -15,8 +15,9 @@ export interface PaymentOrderDetail {
 
 export async function fetchPaymentDetail(
   paymentOrderId: string,
+  fetchFn: typeof fetch = fetch,
 ): Promise<PaymentOrderDetail> {
-  const response = await fetch(
+  const response = await fetchFn(
     '/meridian.payment_order.v1.PaymentOrderService/RetrievePaymentOrder',
     {
       method: 'POST',

--- a/frontend/src/pages/payments/payment-detail.tsx
+++ b/frontend/src/pages/payments/payment-detail.tsx
@@ -11,6 +11,7 @@ import { TimeDisplay } from '@/components/shared/time-display'
 import { SagaTimeline } from '@/components/shared/saga-timeline'
 import { AuditTrail } from '@/components/shared/audit-trail'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
 import { tenantKeys } from '@/lib/query-keys'
 import { fetchPaymentDetail } from './payment-detail-query'
 import {
@@ -103,6 +104,7 @@ function PaymentActions({
 export function PaymentDetailPage() {
   const { paymentOrderId } = useParams<{ paymentOrderId: string }>()
   const tenantSlug = useTenantSlug()
+  const authFetch = useAuthenticatedFetch()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [initiateOpen, setInitiateOpen] = React.useState(false)
@@ -113,7 +115,7 @@ export function PaymentDetailPage() {
 
   const { data, isLoading, isError } = useQuery({
     queryKey,
-    queryFn: () => fetchPaymentDetail(paymentOrderId!),
+    queryFn: () => fetchPaymentDetail(paymentOrderId!, authFetch),
     enabled: !!paymentOrderId,
   })
 

--- a/frontend/src/pages/payments/payments-query.ts
+++ b/frontend/src/pages/payments/payments-query.ts
@@ -12,6 +12,7 @@ export interface PaymentOrder {
 
 export async function fetchPayments(
   params: DataTableQueryParams,
+  fetchFn: typeof fetch = fetch,
 ): Promise<DataTableResult<PaymentOrder>> {
   const body: Record<string, unknown> = {
     pageSize: params.pageSize,
@@ -25,7 +26,7 @@ export async function fetchPayments(
     body.status = params.filters.status
   }
 
-  const response = await fetch(
+  const response = await fetchFn(
     '/meridian.payment_order.v1.PaymentOrderService/ListPaymentOrders',
     {
       method: 'POST',

--- a/frontend/src/pages/positions/index.tsx
+++ b/frontend/src/pages/positions/index.tsx
@@ -7,6 +7,14 @@ import { useApiClients } from '@/api/context'
 import { Card } from '@/components/ui/card'
 import { TransactionStatus } from '@/api/gen/meridian/common/v1/types_pb'
 
+const TRANSACTION_STATUS_NAMES: Record<number, string> = {
+  [TransactionStatus.PENDING]: 'PENDING',
+  [TransactionStatus.POSTED]: 'POSTED',
+  [TransactionStatus.FAILED]: 'FAILED',
+  [TransactionStatus.CANCELLED]: 'CANCELLED',
+  [TransactionStatus.REVERSED]: 'REVERSED',
+}
+
 export interface PositionEntry {
   entryId: string
   transactionId: string
@@ -85,7 +93,8 @@ export function PositionsPage() {
       header: 'Status',
       cell: ({ row }) => {
         const status = row.original.statusTracking?.currentStatus
-        return <span className="text-sm">{typeof status === 'string' ? status.replace(/_/g, ' ') : '—'}</span>
+        const label = typeof status === 'number' ? TRANSACTION_STATUS_NAMES[status] : (typeof status === 'string' ? status.replace(/_/g, ' ') : null)
+        return <span className="text-sm">{label ?? '—'}</span>
       },
     },
     {

--- a/frontend/src/pages/reconciliation/create-dispute-dialog.tsx
+++ b/frontend/src/pages/reconciliation/create-dispute-dialog.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
 
 const DISPUTE_REASON_OPTIONS = [
   { label: 'Amount Mismatch', value: 'DISPUTE_REASON_AMOUNT_MISMATCH' },
@@ -70,6 +71,7 @@ async function createDispute(
   runId: string,
   varianceId: string,
   data: FormData,
+  fetchFn: typeof fetch = fetch,
 ): Promise<{ disputeId: string }> {
   const body: Record<string, unknown> = {
     varianceId,
@@ -81,7 +83,7 @@ async function createDispute(
     body.expectedAmount = data.expectedAmount
   }
 
-  const response = await fetch(`/api/v1/reconciliation/runs/${runId}/disputes`, {
+  const response = await fetchFn(`/api/v1/reconciliation/runs/${runId}/disputes`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
@@ -101,6 +103,7 @@ export function CreateDisputeDialog({
   runId,
   lineItem,
 }: CreateDisputeDialogProps) {
+  const authFetch = useAuthenticatedFetch()
   const queryClient = useQueryClient()
 
   const [formData, setFormData] = React.useState<FormData>({
@@ -119,7 +122,7 @@ export function CreateDisputeDialog({
 
   const mutation = useMutation({
     mutationFn: (vars: { runId: string; varianceId: string; data: FormData }) =>
-      createDispute(vars.runId, vars.varianceId, vars.data),
+      createDispute(vars.runId, vars.varianceId, vars.data, authFetch),
     onSuccess: (_result, vars) => {
       void queryClient.invalidateQueries({ queryKey: ['reconciliation-disputes', vars.runId] })
       if (lineItem.varianceId === vars.varianceId) {

--- a/frontend/src/pages/reconciliation/detail.test.tsx
+++ b/frontend/src/pages/reconciliation/detail.test.tsx
@@ -5,6 +5,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { ReconciliationDetailPage } from './detail'
 
+vi.mock('@/hooks/use-authenticated-fetch', () => ({
+  useAuthenticatedFetch: () => fetch,
+}))
+
 // CodeMirror uses DOM APIs not available in jsdom. Mock at module level.
 vi.mock('codemirror', () => ({
   basicSetup: [],

--- a/frontend/src/pages/reconciliation/detail.tsx
+++ b/frontend/src/pages/reconciliation/detail.tsx
@@ -11,6 +11,7 @@ import {
   VarianceDetail,
   type Variance,
 } from '@/components/reconciliation/variance-detail'
+import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
 import { cn } from '@/lib/utils'
 import { CreateDisputeDialog } from './create-dispute-dialog'
 
@@ -54,21 +55,23 @@ export interface BalanceAssertion {
 // API helpers
 // ---------------------------------------------------------------------------
 
-async function fetchRunDetail(runId: string): Promise<ReconciliationRunDetail> {
-  const res = await fetch(`/v1/reconciliation/runs/${runId}`)
+type FetchFn = typeof fetch
+
+async function fetchRunDetail(runId: string, f: FetchFn = fetch): Promise<ReconciliationRunDetail> {
+  const res = await f(`/v1/reconciliation/runs/${runId}`)
   if (!res.ok) throw new Error(`Failed to fetch run detail: ${res.status}`)
   return res.json() as Promise<ReconciliationRunDetail>
 }
 
-async function fetchVariances(runId: string): Promise<Variance[]> {
-  const res = await fetch(`/v1/reconciliation/runs/${runId}/variances`)
+async function fetchVariances(runId: string, f: FetchFn = fetch): Promise<Variance[]> {
+  const res = await f(`/v1/reconciliation/runs/${runId}/variances`)
   if (!res.ok) throw new Error(`Failed to fetch variances: ${res.status}`)
   const data = (await res.json()) as { variances: Variance[]; nextPageToken?: string; totalCount?: number }
   return data.variances ?? []
 }
 
-async function fetchDisputes(runId: string): Promise<Dispute[]> {
-  const res = await fetch(`/v1/reconciliation/runs/${runId}/disputes`)
+async function fetchDisputes(runId: string, f: FetchFn = fetch): Promise<Dispute[]> {
+  const res = await f(`/v1/reconciliation/runs/${runId}/disputes`)
   if (!res.ok) throw new Error(`Failed to fetch disputes: ${res.status}`)
   const data = (await res.json()) as { items: Dispute[] }
   return data.items
@@ -79,8 +82,9 @@ async function updateDisputeStatus(
   disputeId: string,
   status: DisputeStatus,
   resolutionNotes: string,
+  f: FetchFn = fetch,
 ): Promise<void> {
-  const res = await fetch(
+  const res = await f(
     `/v1/reconciliation/runs/${runId}/disputes/${disputeId}`,
     {
       method: 'PATCH',
@@ -91,8 +95,8 @@ async function updateDisputeStatus(
   if (!res.ok) throw new Error(`Failed to update dispute: ${res.status}`)
 }
 
-async function fetchBalanceAssertions(runId: string): Promise<BalanceAssertion[]> {
-  const res = await fetch(`/v1/reconciliation/runs/${runId}/assertions`)
+async function fetchBalanceAssertions(runId: string, f: FetchFn = fetch): Promise<BalanceAssertion[]> {
+  const res = await f(`/v1/reconciliation/runs/${runId}/assertions`)
   if (!res.ok) throw new Error(`Failed to fetch assertions: ${res.status}`)
   const data = (await res.json()) as { items: BalanceAssertion[] }
   return data.items
@@ -101,8 +105,9 @@ async function fetchBalanceAssertions(runId: string): Promise<BalanceAssertion[]
 async function saveBalanceAssertion(
   runId: string,
   assertion: { name: string; expression: string },
+  f: FetchFn = fetch,
 ): Promise<void> {
-  const res = await fetch(`/v1/reconciliation/runs/${runId}/assertions`, {
+  const res = await f(`/v1/reconciliation/runs/${runId}/assertions`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(assertion),
@@ -115,9 +120,10 @@ async function saveBalanceAssertion(
 // ---------------------------------------------------------------------------
 
 function VariancesTab({ runId }: { runId: string }) {
+  const authFetch = useAuthenticatedFetch()
   const { data: variances, isLoading, isError } = useQuery({
     queryKey: ['reconciliation-variances', runId],
-    queryFn: () => fetchVariances(runId),
+    queryFn: () => fetchVariances(runId, authFetch),
   })
 
   const [disputeDialogOpen, setDisputeDialogOpen] = React.useState(false)
@@ -212,6 +218,7 @@ function DisputeCard({
   dispute: Dispute
   runId: string
 }) {
+  const authFetch = useAuthenticatedFetch()
   const qc = useQueryClient()
   const [notes, setNotes] = React.useState('')
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -219,7 +226,7 @@ function DisputeCard({
 
   const mutation = useMutation({
     mutationFn: (status: DisputeStatus) =>
-      updateDisputeStatus(runId, dispute.disputeId, status, notes),
+      updateDisputeStatus(runId, dispute.disputeId, status, notes, authFetch),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['reconciliation-disputes', runId] })
       setPendingStatus(null)
@@ -303,11 +310,12 @@ function DisputeCard({
 type DisputeFilter = 'ALL' | DisputeStatus
 
 function DisputesTab({ runId }: { runId: string }) {
+  const authFetch = useAuthenticatedFetch()
   const [filter, setFilter] = React.useState<DisputeFilter>('ALL')
 
   const { data: disputes, isLoading, isError } = useQuery({
     queryKey: ['reconciliation-disputes', runId],
-    queryFn: () => fetchDisputes(runId),
+    queryFn: () => fetchDisputes(runId, authFetch),
   })
 
   const filtered = React.useMemo(() => {
@@ -407,6 +415,7 @@ function AssertionCard({ assertion }: { assertion: BalanceAssertion }) {
 }
 
 function BalanceAssertionsTab({ runId }: { runId: string }) {
+  const authFetch = useAuthenticatedFetch()
   const qc = useQueryClient()
   const [name, setName] = React.useState('')
   const [expression, setExpression] = React.useState('')
@@ -414,11 +423,11 @@ function BalanceAssertionsTab({ runId }: { runId: string }) {
 
   const { data: assertions, isLoading, isError } = useQuery({
     queryKey: ['reconciliation-assertions', runId],
-    queryFn: () => fetchBalanceAssertions(runId),
+    queryFn: () => fetchBalanceAssertions(runId, authFetch),
   })
 
   const saveMutation = useMutation({
-    mutationFn: () => saveBalanceAssertion(runId, { name, expression }),
+    mutationFn: () => saveBalanceAssertion(runId, { name, expression }, authFetch),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['reconciliation-assertions', runId] })
       setName('')
@@ -539,10 +548,11 @@ function formatDate(iso: string): string {
 export function ReconciliationDetailPage() {
   const { runId } = useParams<{ runId: string }>()
   const navigate = useNavigate()
+  const authFetch = useAuthenticatedFetch()
 
   const { data: run, isLoading, isError } = useQuery({
     queryKey: ['reconciliation-run', runId],
-    queryFn: () => fetchRunDetail(runId!),
+    queryFn: () => fetchRunDetail(runId!, authFetch),
     enabled: !!runId,
   })
 

--- a/frontend/src/pages/reconciliation/index.tsx
+++ b/frontend/src/pages/reconciliation/index.tsx
@@ -5,6 +5,7 @@ import { DataTable } from '@/components/shared/data-table'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
 import { InitiateReconciliationDialog } from './initiate-reconciliation-dialog'
 
 export interface ReconciliationRun {
@@ -27,7 +28,7 @@ async function fetchReconciliationRuns(params: {
   pageToken?: string
   pageSize: number
   filters?: Record<string, string>
-}): Promise<{ items: ReconciliationRun[]; nextPageToken?: string }> {
+}, fetchFn: typeof fetch = fetch): Promise<{ items: ReconciliationRun[]; nextPageToken?: string }> {
   const url = new URL('/v1/reconciliation/runs', window.location.origin)
   url.searchParams.set('page_size', String(params.pageSize))
   if (params.pageToken) url.searchParams.set('page_token', params.pageToken)
@@ -36,7 +37,7 @@ async function fetchReconciliationRuns(params: {
       if (v) url.searchParams.set(k, v)
     }
   }
-  const res = await fetch(url.toString())
+  const res = await fetchFn(url.toString())
   if (!res.ok) throw new Error(`Failed to fetch reconciliation runs: ${res.status}`)
   const data = await res.json() as {
     runs?: Array<{
@@ -122,6 +123,7 @@ const columns: ColumnDef<ReconciliationRun>[] = [
 
 export function ReconciliationPage() {
   const navigate = useNavigate()
+  const authFetch = useAuthenticatedFetch()
   const [dialogOpen, setDialogOpen] = React.useState(false)
 
   function handleRowClick(run: ReconciliationRun) {
@@ -150,7 +152,7 @@ export function ReconciliationPage() {
       />
       <DataTable
         queryKey={['reconciliation-runs']}
-        queryFn={fetchReconciliationRuns}
+        queryFn={(params) => fetchReconciliationRuns(params, authFetch)}
         columns={columns}
         pageSize={25}
         filters={[

--- a/frontend/src/pages/reconciliation/initiate-reconciliation-dialog.tsx
+++ b/frontend/src/pages/reconciliation/initiate-reconciliation-dialog.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { useTenantContext } from '@/contexts/tenant-context'
+import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
 
 type Scope = 'ALL_ACCOUNTS' | 'SELECTED_ACCOUNTS'
 
@@ -63,9 +63,9 @@ function validateForm(data: FormData): FormErrors {
 }
 
 async function initiateReconciliation(
-  tenantSlug: string,
   data: FormData,
   idempotencyKey: string,
+  fetchFn: typeof fetch = fetch,
 ): Promise<string> {
   const date = new Date(data.settlementDate)
   const periodStart = new Date(date)
@@ -92,14 +92,11 @@ async function initiateReconciliation(
     body.attributes = { description: data.description }
   }
 
-  const response = await fetch(
+  const response = await fetchFn(
     `/meridian.reconciliation.v1.AccountReconciliationService/InitiateAccountReconciliation`,
     {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Tenant-Slug': tenantSlug,
-      },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     },
   )
@@ -118,7 +115,7 @@ export function InitiateReconciliationDialog({
   onOpenChange,
   onSuccess,
 }: InitiateReconciliationDialogProps) {
-  const { tenantSlug } = useTenantContext()
+  const authFetch = useAuthenticatedFetch()
   const queryClient = useQueryClient()
 
   const [formData, setFormData] = React.useState<FormData>({
@@ -141,7 +138,7 @@ export function InitiateReconciliationDialog({
 
   const mutation = useMutation({
     mutationFn: () =>
-      initiateReconciliation(tenantSlug ?? '', formData, idempotencyKey),
+      initiateReconciliation(formData, idempotencyKey, authFetch),
     onSuccess: (runId) => {
       void queryClient.invalidateQueries({ queryKey: ['reconciliation-runs'] })
       onSuccess(runId)


### PR DESCRIPTION
## Summary

- Create `useAuthenticatedFetch` hook that wraps `fetch()` with `Authorization: Bearer` and `X-Tenant-Slug` headers
- Convert accounts pages (list + detail) from raw `fetch()` to Connect-RPC clients with auth interceptor
- Add `fetchFn` parameter to all raw-fetch API helpers (payments, reconciliation, audit) and wire `authFetch` at call sites
- Fix proto field mismatches: `baseCurrency` to `instrumentCode`/`baseInstrumentCode` (string fields replacing numeric Currency enum)
- Map numeric `TransactionStatus` enums to display strings on positions page
- Update "Currency" column headers to "Instrument" across accounts and ledger pages
- Add `KWH` to the create-account instrument selector

## Root Cause

Two incompatible API patterns existed in the frontend:
1. **Connect-RPC client pages** (Positions, Ledger, Parties, Dashboard) used the auth interceptor — worked correctly
2. **Raw `fetch()` pages** (Accounts, Audit, Reconciliation, Payments) had no auth header — returned 401

The proto field renames (`baseCurrency` to `instrumentCode`) were from the multi-asset instrument migration but the frontend wasn't updated.

## Files Changed (23 files)

| Area | Files | Change |
|------|-------|--------|
| New hook | `hooks/use-authenticated-fetch.ts` | Bearer + tenant headers wrapper |
| Accounts | `index.tsx`, `[accountId].tsx`, 5 dialogs, `types.ts` | Convert to RPC + field fixes |
| Ledger | `index.tsx`, `types.ts` | `baseCurrency` to `baseInstrumentCode` |
| Positions | `index.tsx` | Numeric enum to string mapping |
| Payments | `payments-query.ts`, `payment-detail-query.ts`, `index.tsx`, `payment-detail.tsx` | Add `fetchFn` param |
| Audit | `pages/audit/index.tsx`, `shared/audit-trail.tsx` | Wire `authFetch` |
| Reconciliation | `index.tsx`, `detail.tsx`, 2 dialogs | Wire `authFetch` |
| Shared | `create-valuation-feature-dialog.tsx` | Wire `authFetch` |

## Test plan

- [ ] TypeScript compiles clean (verified locally)
- [ ] CI passes
- [ ] Deploy to demo, verify accounts/payments/reconciliation pages load with data
- [ ] Verify ledger shows instrument codes (GBP, KWH) instead of blank
- [ ] Verify positions show status strings instead of "—"