### PR TITLE
feat: add streamable HTTP transport to MCP server

### DIFF
--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -30,8 +30,11 @@ demo.meridianhub.cloud, *.demo.meridianhub.cloud {
 		reverse_proxy dex:5556
 	}
 
-	# MCP Server: SSE transport + message endpoint
+	# MCP Server: streamable HTTP + legacy SSE transport
 	# NOTE: Requires mcp-server container to be running; routes will 502 until deployed.
+	handle /mcp {
+		reverse_proxy mcp-server:8090
+	}
 	handle /sse {
 		reverse_proxy mcp-server:8090
 	}

--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -157,6 +157,7 @@ func runSSE(logger *slog.Logger, cfg server.Config) error {
 	// Streamable HTTP transport (MCP spec 2025-03-26).
 	// Shares the same MCPServer instance so tools/resources/prompts are identical.
 	streamableHandler := transport.NewStreamableHTTPHandler(srv, logger)
+	defer streamableHandler.Close()
 
 	mux := http.NewServeMux()
 

--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -154,6 +154,10 @@ func runSSE(logger *slog.Logger, cfg server.Config) error {
 
 	srv := server.New(sseTr, cfg, logger)
 
+	// Streamable HTTP transport (MCP spec 2025-03-26).
+	// Shares the same MCPServer instance so tools/resources/prompts are identical.
+	streamableHandler := transport.NewStreamableHTTPHandler(srv, logger)
+
 	mux := http.NewServeMux()
 
 	// OAuth 2.1 endpoints (optional — enabled via MCP_OAUTH_ENABLED=true).
@@ -180,9 +184,11 @@ func runSSE(logger *slog.Logger, cfg server.Config) error {
 		validator := &passthroughValidator{logger: logger}
 		bearerMW := mcpauth.NewBearerMiddleware(validator, meta)
 
+		mux.Handle("/mcp", bearerMW.Handler(streamableHandler))
 		mux.Handle("/sse", bearerMW.Handler(http.HandlerFunc(sseTr.HandleSSE)))
 		mux.Handle("/message", bearerMW.Handler(http.HandlerFunc(sseTr.HandleMessage)))
 	} else {
+		mux.Handle("/mcp", streamableHandler)
 		mux.HandleFunc("/sse", sseTr.HandleSSE)
 		mux.HandleFunc("/message", sseTr.HandleMessage)
 	}

--- a/services/mcp-server/internal/server/server.go
+++ b/services/mcp-server/internal/server/server.go
@@ -166,6 +166,21 @@ func (s *MCPServer) RegisterTool(tool Tool, handler ToolHandler) {
 	s.handlers[tool.Name] = handler
 }
 
+// Dispatch handles a single JSON-RPC message and returns the response.
+// For notifications it returns nil (no response required by JSON-RPC spec).
+// For non-request/non-notification messages it returns an invalid-request error.
+// This method is safe to call from multiple goroutines concurrently.
+func (s *MCPServer) Dispatch(ctx context.Context, msg *transport.JSONRPCMessage) *transport.JSONRPCMessage {
+	if msg.IsNotification() {
+		s.handleNotification(msg)
+		return nil
+	}
+	if !msg.IsRequest() {
+		return transport.NewErrorResponse(msg.ID, transport.CodeInvalidRequest, "invalid message")
+	}
+	return s.handleRequest(ctx, msg)
+}
+
 // Run starts the server's message processing loop. It blocks until the context
 // is cancelled or an unrecoverable error occurs.
 func (s *MCPServer) Run(ctx context.Context) error {
@@ -182,18 +197,11 @@ func (s *MCPServer) Run(ctx context.Context) error {
 			return fmt.Errorf("read message: %w", err)
 		}
 
-		if msg.IsNotification() {
-			s.handleNotification(msg)
+		resp := s.Dispatch(ctx, msg)
+		if resp == nil {
 			continue
 		}
-
-		if !msg.IsRequest() {
-			s.logger.Warn("ignoring non-request message")
-			continue
-		}
-
-		response := s.handleRequest(ctx, msg)
-		if err := s.transport.WriteMessage(ctx, response); err != nil {
+		if err := s.transport.WriteMessage(ctx, resp); err != nil {
 			s.logger.Error("failed to write response", "error", err)
 		}
 	}

--- a/services/mcp-server/internal/transport/streamable.go
+++ b/services/mcp-server/internal/transport/streamable.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"mime"
 	"net/http"
@@ -18,6 +19,8 @@ const (
 	sessionIdleTimeout = 1 * time.Hour
 	// sessionEvictInterval is how often the background goroutine sweeps idle sessions.
 	sessionEvictInterval = 5 * time.Minute
+	// maxRequestBodySize is the maximum size of a JSON-RPC request body (1 MB).
+	maxRequestBodySize = 1 << 20
 )
 
 // Dispatcher handles a single JSON-RPC message and returns the response.
@@ -84,7 +87,7 @@ func (h *StreamableHTTPHandler) evictIdleSessions() {
 	for id, sess := range h.sessions {
 		if time.Since(sess.lastUsed) > sessionIdleTimeout {
 			delete(h.sessions, id)
-			h.logger.Info("evicted idle streamable HTTP session", "session_id", id)
+			h.logger.Info("evicted idle streamable HTTP session", "session_id", redactSessionID(id))
 		}
 	}
 }
@@ -109,7 +112,7 @@ func (h *StreamableHTTPHandler) handlePost(w http.ResponseWriter, r *http.Reques
 	}
 
 	var msg JSONRPCMessage
-	if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxRequestBodySize)).Decode(&msg); err != nil {
 		writeJSONError(w, nil, CodeParseError, "invalid JSON")
 		return
 	}
@@ -153,8 +156,12 @@ func (h *StreamableHTTPHandler) handlePost(w http.ResponseWriter, r *http.Reques
 func (h *StreamableHTTPHandler) handleInitialize(w http.ResponseWriter, r *http.Request, msg *JSONRPCMessage) {
 	// Dispatch first — only create the session if initialize succeeds.
 	resp := h.dispatcher.Dispatch(r.Context(), msg)
-	if resp.Error != nil {
-		writeJSON(w, resp)
+	if resp == nil || resp.Error != nil {
+		if resp != nil {
+			writeJSON(w, resp)
+		} else {
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		}
 		return
 	}
 
@@ -169,7 +176,7 @@ func (h *StreamableHTTPHandler) handleInitialize(w http.ResponseWriter, r *http.
 	}
 	h.mu.Unlock()
 
-	h.logger.Info("streamable HTTP session created", "session_id", sessionID)
+	h.logger.Info("streamable HTTP session created", "session_id", redactSessionID(sessionID))
 
 	w.Header().Set("Mcp-Session-Id", sessionID)
 	writeJSON(w, resp)
@@ -194,7 +201,7 @@ func (h *StreamableHTTPHandler) handleDelete(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	h.logger.Info("streamable HTTP session terminated", "session_id", sessionID)
+	h.logger.Info("streamable HTTP session terminated", "session_id", redactSessionID(sessionID))
 	w.WriteHeader(http.StatusAccepted)
 }
 
@@ -237,4 +244,14 @@ func generateSessionID() string {
 		panic("crypto/rand failed: " + err.Error())
 	}
 	return hex.EncodeToString(b)
+}
+
+// redactSessionID returns a truncated session ID safe for logging.
+// Shows only the last 8 characters to aid debugging without exposing
+// the full value (which acts as authorization material).
+func redactSessionID(id string) string {
+	if len(id) <= 8 {
+		return "***"
+	}
+	return "..." + id[len(id)-8:]
 }

--- a/services/mcp-server/internal/transport/streamable.go
+++ b/services/mcp-server/internal/transport/streamable.go
@@ -1,0 +1,178 @@
+package transport
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Dispatcher handles a single JSON-RPC message and returns the response.
+// Notifications return nil (no response required).
+type Dispatcher interface {
+	Dispatch(ctx context.Context, msg *JSONRPCMessage) *JSONRPCMessage
+}
+
+// StreamableHTTPHandler implements the MCP streamable HTTP transport
+// (spec 2025-03-26). Clients POST JSON-RPC messages to a single endpoint
+// and receive synchronous JSON responses.
+type StreamableHTTPHandler struct {
+	dispatcher Dispatcher
+	sessions   map[string]*streamSession
+	mu         sync.RWMutex
+	logger     *slog.Logger
+}
+
+type streamSession struct {
+	id       string
+	created  time.Time
+	lastUsed time.Time
+}
+
+// NewStreamableHTTPHandler creates a handler for the MCP streamable HTTP transport.
+func NewStreamableHTTPHandler(dispatcher Dispatcher, logger *slog.Logger) *StreamableHTTPHandler {
+	return &StreamableHTTPHandler{
+		dispatcher: dispatcher,
+		sessions:   make(map[string]*streamSession),
+		logger:     logger,
+	}
+}
+
+// ServeHTTP routes requests by HTTP method.
+func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.handlePost(w, r)
+	case http.MethodDelete:
+		h.handleDelete(w, r)
+	default:
+		w.Header().Set("Allow", "POST, DELETE")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (h *StreamableHTTPHandler) handlePost(w http.ResponseWriter, r *http.Request) {
+	ct := r.Header.Get("Content-Type")
+	if ct != "application/json" {
+		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	var msg JSONRPCMessage
+	if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+		writeJSONError(w, nil, CodeParseError, "invalid JSON")
+		return
+	}
+
+	// For initialize requests, create a new session.
+	if msg.Method == "initialize" {
+		h.handleInitialize(w, r, &msg)
+		return
+	}
+
+	// All other messages require a valid session.
+	sessionID := r.Header.Get("Mcp-Session-Id")
+	if sessionID == "" {
+		http.Error(w, "Mcp-Session-Id header required", http.StatusBadRequest)
+		return
+	}
+
+	h.mu.RLock()
+	sess, exists := h.sessions[sessionID]
+	h.mu.RUnlock()
+
+	if !exists {
+		http.Error(w, "unknown session", http.StatusNotFound)
+		return
+	}
+
+	h.mu.Lock()
+	sess.lastUsed = time.Now()
+	h.mu.Unlock()
+
+	resp := h.dispatcher.Dispatch(r.Context(), &msg)
+	if resp == nil {
+		// Notification — no response body.
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	writeJSON(w, resp)
+}
+
+func (h *StreamableHTTPHandler) handleInitialize(w http.ResponseWriter, r *http.Request, msg *JSONRPCMessage) {
+	sessionID := generateSessionID()
+
+	h.mu.Lock()
+	now := time.Now()
+	h.sessions[sessionID] = &streamSession{
+		id:       sessionID,
+		created:  now,
+		lastUsed: now,
+	}
+	h.mu.Unlock()
+
+	h.logger.Info("streamable HTTP session created", "session_id", sessionID)
+
+	resp := h.dispatcher.Dispatch(r.Context(), msg)
+
+	w.Header().Set("Mcp-Session-Id", sessionID)
+	writeJSON(w, resp)
+}
+
+func (h *StreamableHTTPHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.Header.Get("Mcp-Session-Id")
+	if sessionID == "" {
+		http.Error(w, "Mcp-Session-Id header required", http.StatusBadRequest)
+		return
+	}
+
+	h.mu.Lock()
+	_, exists := h.sessions[sessionID]
+	if exists {
+		delete(h.sessions, sessionID)
+	}
+	h.mu.Unlock()
+
+	if !exists {
+		http.Error(w, "unknown session", http.StatusNotFound)
+		return
+	}
+
+	h.logger.Info("streamable HTTP session terminated", "session_id", sessionID)
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// SessionCount returns the number of active sessions.
+func (h *StreamableHTTPHandler) SessionCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.sessions)
+}
+
+func writeJSON(w http.ResponseWriter, msg *JSONRPCMessage) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(msg); err != nil {
+		// Headers already sent; log but can't send error response.
+		_ = err
+	}
+}
+
+func writeJSONError(w http.ResponseWriter, id json.RawMessage, code int, message string) {
+	resp := NewErrorResponse(id, code, message)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func generateSessionID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic("crypto/rand failed: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}

--- a/services/mcp-server/internal/transport/streamable.go
+++ b/services/mcp-server/internal/transport/streamable.go
@@ -6,9 +6,18 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"log/slog"
+	"mime"
 	"net/http"
 	"sync"
 	"time"
+)
+
+const (
+	methodInitialize = "initialize"
+	// sessionIdleTimeout is how long a session can be idle before eviction.
+	sessionIdleTimeout = 1 * time.Hour
+	// sessionEvictInterval is how often the background goroutine sweeps idle sessions.
+	sessionEvictInterval = 5 * time.Minute
 )
 
 // Dispatcher handles a single JSON-RPC message and returns the response.
@@ -25,6 +34,7 @@ type StreamableHTTPHandler struct {
 	sessions   map[string]*streamSession
 	mu         sync.RWMutex
 	logger     *slog.Logger
+	stop       chan struct{}
 }
 
 type streamSession struct {
@@ -34,11 +44,48 @@ type streamSession struct {
 }
 
 // NewStreamableHTTPHandler creates a handler for the MCP streamable HTTP transport.
+// Call Close to stop the background session eviction goroutine.
 func NewStreamableHTTPHandler(dispatcher Dispatcher, logger *slog.Logger) *StreamableHTTPHandler {
-	return &StreamableHTTPHandler{
+	h := &StreamableHTTPHandler{
 		dispatcher: dispatcher,
 		sessions:   make(map[string]*streamSession),
 		logger:     logger,
+		stop:       make(chan struct{}),
+	}
+	go h.evictLoop()
+	return h
+}
+
+// Close stops the background session eviction goroutine.
+func (h *StreamableHTTPHandler) Close() {
+	select {
+	case <-h.stop:
+	default:
+		close(h.stop)
+	}
+}
+
+func (h *StreamableHTTPHandler) evictLoop() {
+	ticker := time.NewTicker(sessionEvictInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			h.evictIdleSessions()
+		case <-h.stop:
+			return
+		}
+	}
+}
+
+func (h *StreamableHTTPHandler) evictIdleSessions() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for id, sess := range h.sessions {
+		if time.Since(sess.lastUsed) > sessionIdleTimeout {
+			delete(h.sessions, id)
+			h.logger.Info("evicted idle streamable HTTP session", "session_id", id)
+		}
 	}
 }
 
@@ -56,8 +103,7 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 }
 
 func (h *StreamableHTTPHandler) handlePost(w http.ResponseWriter, r *http.Request) {
-	ct := r.Header.Get("Content-Type")
-	if ct != "application/json" {
+	if !isJSONContentType(r) {
 		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
 		return
 	}
@@ -69,7 +115,7 @@ func (h *StreamableHTTPHandler) handlePost(w http.ResponseWriter, r *http.Reques
 	}
 
 	// For initialize requests, create a new session.
-	if msg.Method == "initialize" {
+	if msg.Method == methodInitialize {
 		h.handleInitialize(w, r, &msg)
 		return
 	}
@@ -105,6 +151,13 @@ func (h *StreamableHTTPHandler) handlePost(w http.ResponseWriter, r *http.Reques
 }
 
 func (h *StreamableHTTPHandler) handleInitialize(w http.ResponseWriter, r *http.Request, msg *JSONRPCMessage) {
+	// Dispatch first — only create the session if initialize succeeds.
+	resp := h.dispatcher.Dispatch(r.Context(), msg)
+	if resp.Error != nil {
+		writeJSON(w, resp)
+		return
+	}
+
 	sessionID := generateSessionID()
 
 	h.mu.Lock()
@@ -117,8 +170,6 @@ func (h *StreamableHTTPHandler) handleInitialize(w http.ResponseWriter, r *http.
 	h.mu.Unlock()
 
 	h.logger.Info("streamable HTTP session created", "session_id", sessionID)
-
-	resp := h.dispatcher.Dispatch(r.Context(), msg)
 
 	w.Header().Set("Mcp-Session-Id", sessionID)
 	writeJSON(w, resp)
@@ -167,6 +218,17 @@ func writeJSONError(w http.ResponseWriter, id json.RawMessage, code int, message
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusBadRequest)
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// isJSONContentType checks whether the request Content-Type is application/json,
+// tolerating optional parameters like charset (e.g. "application/json; charset=utf-8").
+func isJSONContentType(r *http.Request) bool {
+	ct := r.Header.Get("Content-Type")
+	mediaType, _, err := mime.ParseMediaType(ct)
+	if err != nil {
+		return false
+	}
+	return mediaType == "application/json"
 }
 
 func generateSessionID() string {

--- a/services/mcp-server/internal/transport/streamable_test.go
+++ b/services/mcp-server/internal/transport/streamable_test.go
@@ -1,0 +1,248 @@
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// mockDispatcher records calls and returns a canned response.
+type mockDispatcher struct {
+	lastMsg  *JSONRPCMessage
+	response *JSONRPCMessage
+}
+
+func (d *mockDispatcher) Dispatch(_ context.Context, msg *JSONRPCMessage) *JSONRPCMessage {
+	d.lastMsg = msg
+	return d.response
+}
+
+func newInitializeResponse() *JSONRPCMessage {
+	resp, _ := NewResponse(json.RawMessage(`1`), map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities":    map[string]any{},
+		"serverInfo":      map[string]any{"name": "test", "version": "1.0"},
+	})
+	return resp
+}
+
+func TestStreamableHTTP_Initialize(t *testing.T) {
+	d := &mockDispatcher{response: newInitializeResponse()}
+	h := NewStreamableHTTPHandler(d, testLogger())
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	sessionID := rec.Header().Get("Mcp-Session-Id")
+	if sessionID == "" {
+		t.Fatal("expected Mcp-Session-Id header in response")
+	}
+
+	if rec.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("expected Content-Type=application/json, got %s", rec.Header().Get("Content-Type"))
+	}
+
+	var resp JSONRPCMessage
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Result == nil {
+		t.Error("expected result in response")
+	}
+	if h.SessionCount() != 1 {
+		t.Errorf("expected 1 session, got %d", h.SessionCount())
+	}
+}
+
+func TestStreamableHTTP_ToolsList_WithSession(t *testing.T) {
+	toolsResp, _ := NewResponse(json.RawMessage(`2`), map[string]any{"tools": []any{}})
+	d := &mockDispatcher{response: toolsResp}
+	h := NewStreamableHTTPHandler(d, testLogger())
+
+	// First initialize to get a session.
+	d.response = newInitializeResponse()
+	initBody := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+	initReq := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(initBody))
+	initReq.Header.Set("Content-Type", "application/json")
+	initRec := httptest.NewRecorder()
+	h.ServeHTTP(initRec, initReq)
+
+	sessionID := initRec.Header().Get("Mcp-Session-Id")
+
+	// Now send tools/list with the session.
+	d.response = toolsResp
+	listBody := `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`
+	listReq := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(listBody))
+	listReq.Header.Set("Content-Type", "application/json")
+	listReq.Header.Set("Mcp-Session-Id", sessionID)
+	listRec := httptest.NewRecorder()
+	h.ServeHTTP(listRec, listReq)
+
+	if listRec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, listRec.Code)
+	}
+	if d.lastMsg.Method != "tools/list" {
+		t.Errorf("expected dispatched method=tools/list, got %s", d.lastMsg.Method)
+	}
+}
+
+func TestStreamableHTTP_MissingSessionHeader(t *testing.T) {
+	d := &mockDispatcher{}
+	h := NewStreamableHTTPHandler(d, testLogger())
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+	}
+}
+
+func TestStreamableHTTP_UnknownSession(t *testing.T) {
+	d := &mockDispatcher{}
+	h := NewStreamableHTTPHandler(d, testLogger())
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Mcp-Session-Id", "nonexistent-session")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status %d, got %d", http.StatusNotFound, rec.Code)
+	}
+}
+
+func TestStreamableHTTP_Notification(t *testing.T) {
+	d := &mockDispatcher{response: nil} // Notifications return nil.
+	h := NewStreamableHTTPHandler(d, testLogger())
+
+	// Create a session first.
+	d.response = newInitializeResponse()
+	initBody := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+	initReq := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(initBody))
+	initReq.Header.Set("Content-Type", "application/json")
+	initRec := httptest.NewRecorder()
+	h.ServeHTTP(initRec, initReq)
+	sessionID := initRec.Header().Get("Mcp-Session-Id")
+
+	// Send a notification (no id field).
+	d.response = nil
+	notifBody := `{"jsonrpc":"2.0","method":"notifications/initialized"}`
+	notifReq := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(notifBody))
+	notifReq.Header.Set("Content-Type", "application/json")
+	notifReq.Header.Set("Mcp-Session-Id", sessionID)
+	notifRec := httptest.NewRecorder()
+	h.ServeHTTP(notifRec, notifReq)
+
+	if notifRec.Code != http.StatusAccepted {
+		t.Errorf("expected status %d, got %d", http.StatusAccepted, notifRec.Code)
+	}
+	if notifRec.Body.Len() != 0 {
+		t.Errorf("expected empty body for notification, got %q", notifRec.Body.String())
+	}
+}
+
+func TestStreamableHTTP_InvalidJSON(t *testing.T) {
+	d := &mockDispatcher{}
+	h := NewStreamableHTTPHandler(d, testLogger())
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+	}
+}
+
+func TestStreamableHTTP_WrongContentType(t *testing.T) {
+	d := &mockDispatcher{}
+	h := NewStreamableHTTPHandler(d, testLogger())
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Errorf("expected status %d, got %d", http.StatusUnsupportedMediaType, rec.Code)
+	}
+}
+
+func TestStreamableHTTP_DeleteSession(t *testing.T) {
+	d := &mockDispatcher{response: newInitializeResponse()}
+	h := NewStreamableHTTPHandler(d, testLogger())
+
+	// Create a session.
+	initBody := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+	initReq := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(initBody))
+	initReq.Header.Set("Content-Type", "application/json")
+	initRec := httptest.NewRecorder()
+	h.ServeHTTP(initRec, initReq)
+	sessionID := initRec.Header().Get("Mcp-Session-Id")
+
+	if h.SessionCount() != 1 {
+		t.Fatalf("expected 1 session, got %d", h.SessionCount())
+	}
+
+	// Delete the session.
+	delReq := httptest.NewRequest(http.MethodDelete, "/mcp", nil)
+	delReq.Header.Set("Mcp-Session-Id", sessionID)
+	delRec := httptest.NewRecorder()
+	h.ServeHTTP(delRec, delReq)
+
+	if delRec.Code != http.StatusAccepted {
+		t.Errorf("expected status %d, got %d", http.StatusAccepted, delRec.Code)
+	}
+	if h.SessionCount() != 0 {
+		t.Errorf("expected 0 sessions after delete, got %d", h.SessionCount())
+	}
+}
+
+func TestStreamableHTTP_DeleteUnknownSession(t *testing.T) {
+	d := &mockDispatcher{}
+	h := NewStreamableHTTPHandler(d, testLogger())
+
+	req := httptest.NewRequest(http.MethodDelete, "/mcp", nil)
+	req.Header.Set("Mcp-Session-Id", "nonexistent")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status %d, got %d", http.StatusNotFound, rec.Code)
+	}
+}
+
+func TestStreamableHTTP_GetMethodNotAllowed(t *testing.T) {
+	d := &mockDispatcher{}
+	h := NewStreamableHTTPHandler(d, testLogger())
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, rec.Code)
+	}
+}

--- a/services/mcp-server/internal/transport/streamable_test.go
+++ b/services/mcp-server/internal/transport/streamable_test.go
@@ -32,6 +32,7 @@ func newInitializeResponse() *JSONRPCMessage {
 func TestStreamableHTTP_Initialize(t *testing.T) {
 	d := &mockDispatcher{response: newInitializeResponse()}
 	h := NewStreamableHTTPHandler(d, testLogger())
+	defer h.Close()
 
 	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
 	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
@@ -65,10 +66,32 @@ func TestStreamableHTTP_Initialize(t *testing.T) {
 	}
 }
 
+func TestStreamableHTTP_Initialize_FailedDispatch_NoSession(t *testing.T) {
+	errResp := NewErrorResponse(json.RawMessage(`1`), CodeInternalError, "something broke")
+	d := &mockDispatcher{response: errResp}
+	h := NewStreamableHTTPHandler(d, testLogger())
+	defer h.Close()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Header().Get("Mcp-Session-Id") != "" {
+		t.Error("expected no Mcp-Session-Id header when initialize fails")
+	}
+	if h.SessionCount() != 0 {
+		t.Errorf("expected 0 sessions after failed initialize, got %d", h.SessionCount())
+	}
+}
+
 func TestStreamableHTTP_ToolsList_WithSession(t *testing.T) {
 	toolsResp, _ := NewResponse(json.RawMessage(`2`), map[string]any{"tools": []any{}})
 	d := &mockDispatcher{response: toolsResp}
 	h := NewStreamableHTTPHandler(d, testLogger())
+	defer h.Close()
 
 	// First initialize to get a session.
 	d.response = newInitializeResponse()
@@ -100,6 +123,7 @@ func TestStreamableHTTP_ToolsList_WithSession(t *testing.T) {
 func TestStreamableHTTP_MissingSessionHeader(t *testing.T) {
 	d := &mockDispatcher{}
 	h := NewStreamableHTTPHandler(d, testLogger())
+	defer h.Close()
 
 	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
 	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
@@ -116,6 +140,7 @@ func TestStreamableHTTP_MissingSessionHeader(t *testing.T) {
 func TestStreamableHTTP_UnknownSession(t *testing.T) {
 	d := &mockDispatcher{}
 	h := NewStreamableHTTPHandler(d, testLogger())
+	defer h.Close()
 
 	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
 	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
@@ -133,6 +158,7 @@ func TestStreamableHTTP_UnknownSession(t *testing.T) {
 func TestStreamableHTTP_Notification(t *testing.T) {
 	d := &mockDispatcher{response: nil} // Notifications return nil.
 	h := NewStreamableHTTPHandler(d, testLogger())
+	defer h.Close()
 
 	// Create a session first.
 	d.response = newInitializeResponse()
@@ -163,6 +189,7 @@ func TestStreamableHTTP_Notification(t *testing.T) {
 func TestStreamableHTTP_InvalidJSON(t *testing.T) {
 	d := &mockDispatcher{}
 	h := NewStreamableHTTPHandler(d, testLogger())
+	defer h.Close()
 
 	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
@@ -178,6 +205,7 @@ func TestStreamableHTTP_InvalidJSON(t *testing.T) {
 func TestStreamableHTTP_WrongContentType(t *testing.T) {
 	d := &mockDispatcher{}
 	h := NewStreamableHTTPHandler(d, testLogger())
+	defer h.Close()
 
 	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "text/plain")
@@ -190,9 +218,27 @@ func TestStreamableHTTP_WrongContentType(t *testing.T) {
 	}
 }
 
+func TestStreamableHTTP_ContentTypeWithCharset(t *testing.T) {
+	d := &mockDispatcher{response: newInitializeResponse()}
+	h := NewStreamableHTTPHandler(d, testLogger())
+	defer h.Close()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d for Content-Type with charset, got %d", http.StatusOK, rec.Code)
+	}
+}
+
 func TestStreamableHTTP_DeleteSession(t *testing.T) {
 	d := &mockDispatcher{response: newInitializeResponse()}
 	h := NewStreamableHTTPHandler(d, testLogger())
+	defer h.Close()
 
 	// Create a session.
 	initBody := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
@@ -223,6 +269,7 @@ func TestStreamableHTTP_DeleteSession(t *testing.T) {
 func TestStreamableHTTP_DeleteUnknownSession(t *testing.T) {
 	d := &mockDispatcher{}
 	h := NewStreamableHTTPHandler(d, testLogger())
+	defer h.Close()
 
 	req := httptest.NewRequest(http.MethodDelete, "/mcp", nil)
 	req.Header.Set("Mcp-Session-Id", "nonexistent")
@@ -237,6 +284,7 @@ func TestStreamableHTTP_DeleteUnknownSession(t *testing.T) {
 func TestStreamableHTTP_GetMethodNotAllowed(t *testing.T) {
 	d := &mockDispatcher{}
 	h := NewStreamableHTTPHandler(d, testLogger())
+	defer h.Close()
 
 	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

- Add `/mcp` endpoint implementing the MCP streamable HTTP transport (spec 2025-03-26), enabling Claude Code to connect natively
- Expose `Dispatch()` on `MCPServer` for synchronous request handling without the channel-based Run() loop
- Keep legacy SSE endpoints (`/sse`, `/message`) for backwards compatibility
- Add Caddy proxy route for `/mcp` on demo environment

## Details

The MCP server only supported the legacy SSE transport (`GET /sse` + `POST /message`), deprecated in MCP spec 2025-03-26. Claude Code uses the newer streamable HTTP transport — it POSTs JSON-RPC to the endpoint with `Content-Type: application/json`, but the SSE handler expected a GET and tried to set up an event stream, causing connection failures.

**Streamable HTTP handler (`/mcp`):**
- `POST initialize` creates a session, returns `Mcp-Session-Id` header
- `POST` with valid session dispatches JSON-RPC and returns synchronous JSON
- `POST` notification returns `202 Accepted` (no body)
- `DELETE` with session terminates it
- `GET` returns `405 Method Not Allowed`

Both transports share one `MCPServer` instance. The new public `Dispatch()` method wraps the existing `handleRequest`/`handleNotification` and is also used internally by `Run()` to avoid duplication.

## Test plan

- [x] 10 new tests for StreamableHTTPHandler covering all HTTP methods and edge cases
- [x] All 32 existing tests pass (server + transport packages)
- [x] `go vet` and `golangci-lint` clean
- [ ] Deploy to demo, verify with curl:
  ```bash
  curl -X POST https://demo.meridianhub.cloud/mcp \
    -u "demo:meridian2026" \
    -H "Content-Type: application/json" \
    -H "Accept: application/json, text/event-stream" \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
  ```
- [ ] Verify Claude Code connects via `.mcp.json` URL config