### PR TITLE
fix: increase Build & Test timeout from 20 to 35 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     name: Build Docker Image
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- The hardening PR (#1262) added `timeout-minutes: 20` to the Build & Test workflow
- The un-sharded `make test` step on develop pushes takes ~25 minutes
- Every develop push since Feb 27 has been cancelled by the timeout
- Increases timeout to 35 minutes (sufficient headroom over observed ~25 min runtime)

## Test plan

- [ ] Verify this PR's own Build & Test check passes (it only runs `go build ./...` on PRs, not `make test`)
- [ ] After merge to develop, confirm the Build & Test workflow completes successfully