### PR TITLE
fix: global 401 handler, dashboard/payments field mappings, account transactions tab

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -298,7 +298,7 @@ function AppShellLayout() {
  * Must be rendered inside both AuthProvider and TenantProvider.
  */
 function ApiClientBridge({ children }: { children: ReactNode }) {
-  const { accessToken } = useAuth()
+  const { accessToken, logout } = useAuth()
   const { tenantSlug } = useTenantContext()
 
   const tokenRef = useRef(accessToken)
@@ -316,7 +316,7 @@ function ApiClientBridge({ children }: { children: ReactNode }) {
   const getTenantSlug = useCallback(() => slugRef.current, [])
 
   return (
-    <ApiClientProvider tenantSlug={tenantSlug} getToken={getToken} getTenantSlug={getTenantSlug}>
+    <ApiClientProvider tenantSlug={tenantSlug} getToken={getToken} getTenantSlug={getTenantSlug} onUnauthenticated={logout}>
       {children}
     </ApiClientProvider>
   )

--- a/frontend/src/api/context.tsx
+++ b/frontend/src/api/context.tsx
@@ -14,6 +14,7 @@ interface ApiClientProviderProps {
   tenantSlug: string | null
   getToken: TokenGetter
   getTenantSlug: TenantSlugGetter
+  onUnauthenticated?: () => void
   children: ReactNode
 }
 
@@ -21,12 +22,13 @@ export function ApiClientProvider({
   tenantSlug,
   getToken,
   getTenantSlug,
+  onUnauthenticated,
   children,
 }: ApiClientProviderProps) {
   const clients = useMemo(() => {
-    const transport = createTenantTransport(tenantSlug, getToken, getTenantSlug)
+    const transport = createTenantTransport(tenantSlug, getToken, getTenantSlug, onUnauthenticated)
     return createServiceClients(transport)
-  }, [tenantSlug, getToken, getTenantSlug])
+  }, [tenantSlug, getToken, getTenantSlug, onUnauthenticated])
 
   return (
     <ApiClientContext.Provider value={{ clients }}>

--- a/frontend/src/api/interceptors/auth-interceptor.ts
+++ b/frontend/src/api/interceptors/auth-interceptor.ts
@@ -1,13 +1,23 @@
-import type { Interceptor } from '@connectrpc/connect'
+import { ConnectError, Code, type Interceptor } from '@connectrpc/connect'
 
 export type TokenGetter = () => string | null | undefined
 
-export function createAuthInterceptor(getToken: TokenGetter): Interceptor {
+export function createAuthInterceptor(
+  getToken: TokenGetter,
+  onUnauthenticated?: () => void,
+): Interceptor {
   return (next) => async (req) => {
     const token = getToken()
     if (token) {
       req.header.set('Authorization', `Bearer ${token}`)
     }
-    return next(req)
+    try {
+      return await next(req)
+    } catch (err) {
+      if (err instanceof ConnectError && err.code === Code.Unauthenticated) {
+        onUnauthenticated?.()
+      }
+      throw err
+    }
   }
 }

--- a/frontend/src/api/interceptors/auth-interceptor.ts
+++ b/frontend/src/api/interceptors/auth-interceptor.ts
@@ -15,7 +15,11 @@ export function createAuthInterceptor(
       return await next(req)
     } catch (err) {
       if (err instanceof ConnectError && err.code === Code.Unauthenticated) {
-        onUnauthenticated?.()
+        try {
+          onUnauthenticated?.()
+        } catch {
+          // Preserve original auth error for downstream handling
+        }
       }
       throw err
     }

--- a/frontend/src/api/transport.ts
+++ b/frontend/src/api/transport.ts
@@ -11,6 +11,7 @@ export function createTenantTransport(
   tenantSlug: string | null,
   getToken: TokenGetter,
   getTenantSlug: TenantSlugGetter,
+  onUnauthenticated?: () => void,
 ): Transport {
   // In development or demo mode, keep the base URL and route via X-Tenant-Slug header
   // (the gateway's LOCAL_DEV_MODE resolves tenants from the header).
@@ -22,7 +23,7 @@ export function createTenantTransport(
 
   return createConnectTransport({
     baseUrl,
-    interceptors: [createAuthInterceptor(getToken), createTenantInterceptor(getTenantSlug)],
+    interceptors: [createAuthInterceptor(getToken, onUnauthenticated), createTenantInterceptor(getTenantSlug)],
     useBinaryFormat: apiConfig.useBinaryFormat,
   })
 }

--- a/frontend/src/hooks/use-authenticated-fetch.ts
+++ b/frontend/src/hooks/use-authenticated-fetch.ts
@@ -6,13 +6,15 @@ import { useTenantContext } from '@/contexts/tenant-context'
  * Returns a fetch wrapper that automatically includes Authorization and
  * X-Tenant-Slug headers. Use this for pages that call REST/gRPC-web
  * endpoints via raw fetch() instead of typed Connect-RPC clients.
+ *
+ * On 401 responses, automatically logs out (ProtectedRoute handles redirect).
  */
 export function useAuthenticatedFetch() {
-  const { accessToken } = useAuth()
+  const { accessToken, logout } = useAuth()
   const { tenantSlug } = useTenantContext()
 
   return useCallback(
-    (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
       const headers = new Headers(init?.headers)
       if (accessToken) {
         headers.set('Authorization', `Bearer ${accessToken}`)
@@ -23,8 +25,12 @@ export function useAuthenticatedFetch() {
       if (!headers.has('Content-Type')) {
         headers.set('Content-Type', 'application/json')
       }
-      return fetch(input, { ...init, headers })
+      const response = await fetch(input, { ...init, headers })
+      if (response.status === 401) {
+        logout()
+      }
+      return response
     },
-    [accessToken, tenantSlug],
+    [accessToken, tenantSlug, logout],
   )
 }

--- a/frontend/src/lib/query-client.ts
+++ b/frontend/src/lib/query-client.ts
@@ -1,11 +1,17 @@
 import { QueryClient } from '@tanstack/react-query'
+import { ConnectError, Code } from '@connectrpc/connect'
 
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 30_000,
       gcTime: 5 * 60 * 1000,
-      retry: 2,
+      retry: (failureCount, error) => {
+        if (error instanceof ConnectError && error.code === Code.Unauthenticated) {
+          return false
+        }
+        return failureCount < 2
+      },
       retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 10_000),
       refetchOnWindowFocus: true,
       refetchOnReconnect: true,

--- a/frontend/src/pages/accounts/[accountId].tsx
+++ b/frontend/src/pages/accounts/[accountId].tsx
@@ -7,6 +7,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
+import { MoneyDisplay } from '@/components/shared/money-display'
 import { AuditTrail } from '@/components/shared'
 import { ConnectError, Code } from '@connectrpc/connect'
 import { useApiClients } from '@/api/context'
@@ -25,6 +26,20 @@ const ACCOUNT_STATUS_NAMES: Record<number, string> = {
   [AccountStatus.ACTIVE]: 'ACTIVE',
   [AccountStatus.FROZEN]: 'FROZEN',
   [AccountStatus.CLOSED]: 'CLOSED',
+}
+
+/** Extract a display string from google.type.Money (units + nanos/1e9). */
+function formatBalance(money: { units?: bigint | number; nanos?: number; currencyCode?: string } | undefined | null): string {
+  if (!money) return ''
+  const units = typeof money.units === 'bigint' ? Number(money.units) : (money.units ?? 0)
+  const nanos = money.nanos ?? 0
+  const value = units + nanos / 1e9
+  if (money.currencyCode) {
+    try {
+      return new Intl.NumberFormat(undefined, { style: 'currency', currency: money.currencyCode }).format(value)
+    } catch { /* fall through for non-ISO codes */ }
+  }
+  return value.toFixed(2)
 }
 
 // ---------------------------------------------------------------------------
@@ -186,6 +201,85 @@ function DetailField({ label, children }: { label: string; children: React.React
 }
 
 // ---------------------------------------------------------------------------
+// Transactions (ledger postings for this account)
+// ---------------------------------------------------------------------------
+
+function AccountTransactions({ accountId, instrumentCode }: { accountId: string; instrumentCode: string }) {
+  const { tenantSlug } = useTenantContext()
+  const clients = useApiClients()
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: [...tenantKeys.account(tenantSlug ?? '', accountId), 'postings'],
+    queryFn: () =>
+      clients.financialAccounting.listLedgerPostings({
+        pagination: { pageSize: 50, pageToken: '' },
+        accountId,
+      }),
+    enabled: !!accountId,
+  })
+
+  const postings = data?.ledgerPostings ?? []
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Transactions</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="animate-pulse space-y-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="h-8 rounded bg-muted" />
+            ))}
+          </div>
+        )}
+        {isError && (
+          <p className="text-sm text-muted-foreground">Failed to load transactions.</p>
+        )}
+        {!isLoading && !isError && postings.length === 0 && (
+          <p className="text-sm text-muted-foreground">No transactions found for this account.</p>
+        )}
+        {!isLoading && postings.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left text-xs font-medium text-muted-foreground">
+                  <th className="pb-2 pr-4">Direction</th>
+                  <th className="pb-2 pr-4">Amount</th>
+                  <th className="pb-2 pr-4">Status</th>
+                  <th className="pb-2">Created</th>
+                </tr>
+              </thead>
+              <tbody>
+                {postings.map((p) => (
+                  <tr key={p.id} className="border-b last:border-0">
+                    <td className="py-2 pr-4">
+                      <StatusBadge status={String(p.postingDirection ?? '')} />
+                    </td>
+                    <td className="py-2 pr-4 tabular-nums">
+                      <MoneyDisplay
+                        amount={p.postingAmount?.amount?.units}
+                        currency={p.postingAmount?.amount?.currencyCode ?? instrumentCode}
+                      />
+                    </td>
+                    <td className="py-2 pr-4">
+                      <StatusBadge status={String(p.status ?? '')} />
+                    </td>
+                    <td className="py-2">
+                      <TimeDisplay timestamp={p.createdAt} format="relative" />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Main page
 // ---------------------------------------------------------------------------
 
@@ -206,7 +300,7 @@ export function AccountDetailPage() {
           externalReference: f.externalIdentifier ?? '',
           status: (ACCOUNT_STATUS_NAMES[f.accountStatus] ?? String(f.accountStatus)) as AccountStatusType,
           instrumentCode: f.instrumentCode || '',
-          availableBalance: '',
+          availableBalance: formatBalance(f.currentBalance?.availableBalance?.amount),
           createdAt: f.createdAt ?? undefined,
           updatedAt: f.updatedAt ?? undefined,
           partyId: f.orgPartyId || undefined,
@@ -323,16 +417,7 @@ export function AccountDetailPage() {
           </TabsContent>
 
           <TabsContent value="transactions" className="mt-4">
-            <Card>
-              <CardHeader>
-                <CardTitle>Transactions</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">
-                  Transaction history for this account will appear here.
-                </p>
-              </CardContent>
-            </Card>
+            <AccountTransactions accountId={account.accountId} instrumentCode={account.instrumentCode} />
           </TabsContent>
 
           <TabsContent value="liens" className="mt-4">

--- a/frontend/src/pages/accounts/[accountId].tsx
+++ b/frontend/src/pages/accounts/[accountId].tsx
@@ -243,7 +243,7 @@ function AccountTransactions({ accountId, instrumentCode }: { accountId: string;
         {!isLoading && !isError && postings.length === 0 && (
           <p className="text-sm text-muted-foreground">No transactions found for this account.</p>
         )}
-        {!isLoading && postings.length > 0 && (
+        {!isLoading && !isError && postings.length > 0 && (
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>

--- a/frontend/src/pages/accounts/[accountId].tsx
+++ b/frontend/src/pages/accounts/[accountId].tsx
@@ -29,9 +29,13 @@ const ACCOUNT_STATUS_NAMES: Record<number, string> = {
 }
 
 /** Extract a display string from google.type.Money (units + nanos/1e9). */
-function formatBalance(money: { units?: bigint | number; nanos?: number; currencyCode?: string } | undefined | null): string {
-  if (!money) return ''
-  const units = typeof money.units === 'bigint' ? Number(money.units) : (money.units ?? 0)
+function formatBalance(money: { units?: bigint | number; nanos?: number; currencyCode?: string } | undefined | null): string | undefined {
+  if (!money) return undefined
+  const rawUnits = typeof money.units === 'bigint' ? money.units : BigInt(Math.trunc(money.units ?? 0))
+  if (rawUnits > BigInt(Number.MAX_SAFE_INTEGER) || rawUnits < BigInt(Number.MIN_SAFE_INTEGER)) {
+    return money.currencyCode ? `${money.currencyCode} ${rawUnits.toString()}` : rawUnits.toString()
+  }
+  const units = Number(rawUnits)
   const nanos = money.nanos ?? 0
   const value = units + nanos / 1e9
   if (money.currencyCode) {

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -108,10 +108,10 @@ export function DashboardPage() {
 
   // Build recent activity feed from dedicated activity query (pageSize: 10)
   const activityItems: ActivityItem[] = (activityQuery.data?.paymentOrders ?? []).map((po, idx) => ({
-    id: po.id ?? `activity-${idx}`,
+    id: po.paymentOrderId || `activity-${idx}`,
     type: 'payment' as const,
-    title: `Payment order ${po.id ?? ''}`,
-    description: po.id ? `ID: ${po.id}` : undefined,
+    title: `Payment order ${po.paymentOrderId || ''}`,
+    description: po.paymentOrderId ? `ID: ${po.paymentOrderId}` : undefined,
     timestamp: po.createdAt ?? null,
     status: po.status?.toString(),
   }))

--- a/frontend/src/pages/ledger/index.tsx
+++ b/frontend/src/pages/ledger/index.tsx
@@ -55,11 +55,6 @@ const columns: ColumnDef<FinancialBookingLog>[] = [
     cell: ({ row }) => <StatusBadge status={row.original.status} />,
   },
   {
-    id: 'postingCount',
-    header: 'Postings',
-    cell: ({ row }) => row.original.postings?.length ?? 0,
-  },
-  {
     accessorKey: 'createdAt',
     header: 'Created',
     cell: ({ row }) => (

--- a/frontend/src/pages/payments/payments-query.test.ts
+++ b/frontend/src/pages/payments/payments-query.test.ts
@@ -10,7 +10,7 @@ const mockPaymentOrders = [
     amount: '5000',
     currency: 'GBP',
     status: 'COMPLETED',
-    createdAt: { seconds: 1700000000, nanos: 0 },
+    createdAt: '2023-11-14T22:13:20Z',
   },
   {
     paymentOrderId: 'po-002',
@@ -19,7 +19,7 @@ const mockPaymentOrders = [
     amount: '15000',
     currency: 'EUR',
     status: 'PENDING',
-    createdAt: { seconds: 1700001000, nanos: 0 },
+    createdAt: '2023-11-14T22:30:00Z',
   },
 ]
 
@@ -35,7 +35,10 @@ describe('fetchPayments', () => {
   it('fetches payments and returns items with nextPageToken', async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ paymentOrders: mockPaymentOrders, nextPageToken: 'token-2' }),
+      json: () => Promise.resolve({
+        paymentOrders: mockPaymentOrders,
+        pagination: { nextPageToken: 'token-2' },
+      }),
     } as Response)
 
     const params: DataTableQueryParams = { pageSize: 20 }
@@ -46,17 +49,17 @@ describe('fetchPayments', () => {
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ pageSize: 20 }),
+        body: JSON.stringify({ pagination: { pageSize: 20, pageToken: '' } }),
       },
     )
     expect(result.items).toEqual(mockPaymentOrders)
     expect(result.nextPageToken).toBe('token-2')
   })
 
-  it('includes pageToken in request body when provided', async () => {
+  it('includes pageToken in pagination when provided', async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ paymentOrders: [], nextPageToken: undefined }),
+      json: () => Promise.resolve({ paymentOrders: [] }),
     } as Response)
 
     const params: DataTableQueryParams = { pageSize: 10, pageToken: 'cursor-abc' }
@@ -64,10 +67,10 @@ describe('fetchPayments', () => {
 
     const callArgs = vi.mocked(fetch).mock.calls[0]
     const body = JSON.parse(callArgs[1]?.body as string)
-    expect(body.pageToken).toBe('cursor-abc')
+    expect(body.pagination.pageToken).toBe('cursor-abc')
   })
 
-  it('does not include pageToken when not provided', async () => {
+  it('sends empty pageToken when not provided', async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ paymentOrders: [] }),
@@ -78,7 +81,7 @@ describe('fetchPayments', () => {
 
     const callArgs = vi.mocked(fetch).mock.calls[0]
     const body = JSON.parse(callArgs[1]?.body as string)
-    expect(body).not.toHaveProperty('pageToken')
+    expect(body.pagination.pageToken).toBe('')
   })
 
   it('includes status filter in request body when provided', async () => {
@@ -123,6 +126,18 @@ describe('fetchPayments', () => {
     expect(body).not.toHaveProperty('status')
   })
 
+  it('reads nextPageToken from pagination in response', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ paymentOrders: mockPaymentOrders, pagination: { nextPageToken: 'page-2' } }),
+    } as Response)
+
+    const params: DataTableQueryParams = { pageSize: 20 }
+    const result = await fetchPayments(params)
+
+    expect(result.nextPageToken).toBe('page-2')
+  })
+
   it('returns empty items array when paymentOrders is absent', async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
@@ -165,7 +180,7 @@ describe('fetchPayments', () => {
     await expect(fetchPayments(params)).rejects.toThrow('Network failure')
   })
 
-  it('returns undefined nextPageToken when not in response', async () => {
+  it('returns undefined nextPageToken when pagination is absent', async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ paymentOrders: mockPaymentOrders }),
@@ -177,7 +192,7 @@ describe('fetchPayments', () => {
     expect(result.nextPageToken).toBeUndefined()
   })
 
-  it('passes pageSize correctly in request body', async () => {
+  it('passes pageSize correctly in pagination object', async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ paymentOrders: [] }),
@@ -188,6 +203,6 @@ describe('fetchPayments', () => {
 
     const callArgs = vi.mocked(fetch).mock.calls[0]
     const body = JSON.parse(callArgs[1]?.body as string)
-    expect(body.pageSize).toBe(50)
+    expect(body.pagination.pageSize).toBe(50)
   })
 })

--- a/frontend/src/pages/payments/payments-query.ts
+++ b/frontend/src/pages/payments/payments-query.ts
@@ -7,7 +7,7 @@ export interface PaymentOrder {
   amount: string
   currency: string
   status: string
-  createdAt: { seconds: bigint | number; nanos?: number } | null
+  createdAt: string | null
 }
 
 export async function fetchPayments(
@@ -15,11 +15,10 @@ export async function fetchPayments(
   fetchFn: typeof fetch = fetch,
 ): Promise<DataTableResult<PaymentOrder>> {
   const body: Record<string, unknown> = {
-    pageSize: params.pageSize,
-  }
-
-  if (params.pageToken) {
-    body.pageToken = params.pageToken
+    pagination: {
+      pageSize: params.pageSize,
+      pageToken: params.pageToken ?? '',
+    },
   }
 
   if (params.filters?.status) {
@@ -41,11 +40,11 @@ export async function fetchPayments(
 
   const data = (await response.json()) as {
     paymentOrders?: PaymentOrder[]
-    nextPageToken?: string
+    pagination?: { nextPageToken?: string }
   }
 
   return {
     items: data.paymentOrders ?? [],
-    nextPageToken: data.nextPageToken,
+    nextPageToken: data.pagination?.nextPageToken,
   }
 }

--- a/frontend/src/test/api/context.test.tsx
+++ b/frontend/src/test/api/context.test.tsx
@@ -65,7 +65,7 @@ describe('ApiClientProvider and useApiClients', () => {
 
     renderHook(() => useApiClients(), { wrapper })
 
-    expect(createTenantTransport).toHaveBeenCalledWith('acme', getToken, getTenantSlug)
+    expect(createTenantTransport).toHaveBeenCalledWith('acme', getToken, getTenantSlug, undefined)
   })
 
   it('creates transport with null when no tenant slug', () => {
@@ -78,7 +78,7 @@ describe('ApiClientProvider and useApiClients', () => {
 
     renderHook(() => useApiClients(), { wrapper })
 
-    expect(createTenantTransport).toHaveBeenCalledWith(null, getToken, nullSlugGetter)
+    expect(createTenantTransport).toHaveBeenCalledWith(null, getToken, nullSlugGetter, undefined)
   })
 
   it('recreates clients when tenant slug changes', () => {

--- a/frontend/src/test/query-client.test.ts
+++ b/frontend/src/test/query-client.test.ts
@@ -17,9 +17,14 @@ describe('queryClient', () => {
     expect(options.queries?.gcTime).toBe(5 * 60 * 1000)
   })
 
-  it('has correct retry count for queries', () => {
+  it('has correct retry behavior for queries', () => {
     const options = queryClient.getDefaultOptions()
-    expect(options.queries?.retry).toBe(2)
+    const retry = options.queries?.retry as (failureCount: number, error: Error) => boolean
+    expect(typeof retry).toBe('function')
+    // Regular errors retry up to 2 times
+    expect(retry(0, new Error('network'))).toBe(true)
+    expect(retry(1, new Error('network'))).toBe(true)
+    expect(retry(2, new Error('network'))).toBe(false)
   })
 
   it('has no retry for mutations', () => {

--- a/frontend/src/test/query-client.test.ts
+++ b/frontend/src/test/query-client.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { ConnectError, Code } from '@connectrpc/connect'
 import { queryClient } from '@/lib/query-client'
 import { QueryClient } from '@tanstack/react-query'
 
@@ -25,6 +26,8 @@ describe('queryClient', () => {
     expect(retry(0, new Error('network'))).toBe(true)
     expect(retry(1, new Error('network'))).toBe(true)
     expect(retry(2, new Error('network'))).toBe(false)
+    // Unauthenticated errors should never retry
+    expect(retry(0, new ConnectError('unauth', Code.Unauthenticated))).toBe(false)
   })
 
   it('has no retry for mutations', () => {


### PR DESCRIPTION
## Summary

Fixes 6 UI bugs discovered during demo testing after PR #1265 deployed:

- **Global 401 handler**: Connect-RPC interceptor catches `Unauthenticated` errors and triggers logout (ProtectedRoute redirects to /login). React Query skips retries for 401s. `useAuthenticatedFetch` also handles 401 for raw-fetch pages.
- **Dashboard activity feed**: Fixed `po.id` (undefined) to `po.paymentOrderId`
- **Payments page**: Restructured request body to nest `pageSize`/`pageToken` under `pagination` object; read `nextPageToken` from `pagination` in response
- **Account detail - available balance**: Map from `currentBalance.availableBalance.amount` (google.type.Money) instead of hardcoded empty string
- **Account detail - transactions tab**: Replace placeholder with `ListLedgerPostings` query filtered by accountId, rendering direction, amount, status, timestamp
- **Ledger list**: Remove misleading "Postings" column that always showed 0 (postings only populated on detail fetch)

Internal accounts (Issue 6) requires re-running `seed-demo` on the demo server after deployment — no code change needed.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] `npx vitest run` — 1479 tests pass, 3 pre-existing failures unchanged
- [ ] Deploy to demo, re-run `seed-demo`, verify:
  - Parties page loads without crash on expired token
  - 401 redirects to login (not error boundary)
  - Payments shows data (not skeleton)
  - Dashboard stat cards show numbers
  - Dashboard activity feed shows payment orders
  - Account detail shows available balance
  - Account detail transactions tab shows postings
  - Ledger list no longer shows "0" postings column
  - Internal accounts show seeded data