### PR TITLE
docs: update MCP config to recommend streamable HTTP transport

### DIFF
--- a/frontend/src/pages/mcp-config/index.test.tsx
+++ b/frontend/src/pages/mcp-config/index.test.tsx
@@ -47,21 +47,35 @@ describe('McpConfigPage', () => {
       expect(screen.getByText(/Model Context Protocol/i)).toBeInTheDocument()
     })
 
-    it('renders server connection section with SSE URL', () => {
+    it('renders server connection section with streamable HTTP URL', () => {
       render(<McpConfigPage />, { wrapper: Wrapper })
 
       expect(screen.getByText('Server Connection')).toBeInTheDocument()
-      expect(screen.getByTestId('sse-url')).toHaveTextContent('/sse')
+      expect(screen.getByTestId('mcp-url')).toHaveTextContent('/mcp')
     })
 
-    it('renders Claude Desktop config section with JSON', () => {
+    it('shows legacy SSE endpoint reference', () => {
       render(<McpConfigPage />, { wrapper: Wrapper })
 
-      expect(screen.getByText('Claude Desktop Configuration')).toBeInTheDocument()
-      const configEl = screen.getByTestId('claude-desktop-config')
+      expect(screen.getByText(/Legacy SSE endpoint/i)).toBeInTheDocument()
+    })
+
+    it('renders client configuration section with streamable HTTP config', () => {
+      render(<McpConfigPage />, { wrapper: Wrapper })
+
+      expect(screen.getByText('Client Configuration')).toBeInTheDocument()
+      const configEl = screen.getByTestId('streamable-http-config')
       expect(configEl).toHaveTextContent('mcpServers')
-      expect(configEl).toHaveTextContent('meridian')
+      expect(configEl).toHaveTextContent('streamable-http')
+      expect(configEl).toHaveTextContent('/mcp')
+    })
+
+    it('renders legacy SSE config section', () => {
+      render(<McpConfigPage />, { wrapper: Wrapper })
+
+      const configEl = screen.getByTestId('legacy-sse-config')
       expect(configEl).toHaveTextContent('mcp-remote')
+      expect(configEl).toHaveTextContent('/sse')
     })
 
     it('renders OAuth authorization section', () => {
@@ -120,18 +134,18 @@ describe('McpConfigPage', () => {
   })
 
   describe('copy to clipboard', () => {
-    it('copies SSE URL on button click', async () => {
+    it('copies MCP URL on button click', async () => {
       const writeText = vi.fn().mockResolvedValue(undefined)
       vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
 
       render(<McpConfigPage />, { wrapper: Wrapper })
 
-      const copyButton = screen.getByRole('button', { name: /Copy SSE URL/i })
+      const copyButton = screen.getByRole('button', { name: /Copy MCP URL/i })
       await act(async () => {
         copyButton.click()
       })
 
-      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('/sse'))
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('/mcp'))
     })
 
     it('shows Copied! feedback after clicking copy', async () => {
@@ -140,7 +154,7 @@ describe('McpConfigPage', () => {
 
       render(<McpConfigPage />, { wrapper: Wrapper })
 
-      const copyButton = screen.getByRole('button', { name: /Copy SSE URL/i })
+      const copyButton = screen.getByRole('button', { name: /Copy MCP URL/i })
       await act(async () => {
         copyButton.click()
       })
@@ -150,13 +164,13 @@ describe('McpConfigPage', () => {
       })
     })
 
-    it('copies Claude Desktop config on button click', async () => {
+    it('copies streamable HTTP config on button click', async () => {
       const writeText = vi.fn().mockResolvedValue(undefined)
       vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
 
       render(<McpConfigPage />, { wrapper: Wrapper })
 
-      const copyButton = screen.getByRole('button', { name: /Copy Claude Desktop config/i })
+      const copyButton = screen.getByRole('button', { name: /Copy streamable HTTP config/i })
       await act(async () => {
         copyButton.click()
       })

--- a/frontend/src/pages/mcp-config/index.tsx
+++ b/frontend/src/pages/mcp-config/index.tsx
@@ -11,7 +11,19 @@ const MCP_SERVER_URL =
   import.meta.env.VITE_API_BASE_URL ??
   'http://localhost:8091'
 
-function buildClaudeDesktopConfig(serverUrl: string): string {
+function buildStreamableHttpConfig(serverUrl: string): string {
+  const config = {
+    mcpServers: {
+      meridian: {
+        type: 'streamable-http',
+        url: `${serverUrl}/mcp`,
+      },
+    },
+  }
+  return JSON.stringify(config, null, 2)
+}
+
+function buildLegacySseConfig(serverUrl: string): string {
   const config = {
     mcpServers: {
       meridian: {
@@ -73,9 +85,11 @@ function CopyButton({ text, label }: { text: string; label?: string }) {
 export function McpConfigPage() {
   const { tenantSlug } = useTenantContext()
 
+  const mcpUrl = `${MCP_SERVER_URL}/mcp`
   const sseUrl = `${MCP_SERVER_URL}/sse`
   const oauthUrl = `${MCP_SERVER_URL}/oauth/authorize`
-  const claudeDesktopConfig = buildClaudeDesktopConfig(MCP_SERVER_URL)
+  const streamableHttpConfig = buildStreamableHttpConfig(MCP_SERVER_URL)
+  const legacySseConfig = buildLegacySseConfig(MCP_SERVER_URL)
 
   return (
     <div className="flex flex-col gap-6">
@@ -98,38 +112,57 @@ export function McpConfigPage() {
         <div>
           <h2 className="text-lg font-semibold">Server Connection</h2>
           <p className="mt-1 text-sm text-muted-foreground">
-            SSE endpoint for connecting MCP clients to Meridian
+            Streamable HTTP endpoint for connecting MCP clients to Meridian (recommended)
           </p>
         </div>
         <div className="flex items-center gap-3">
           <code
-            data-testid="sse-url"
+            data-testid="mcp-url"
             className="flex-1 rounded-md bg-muted px-3 py-2 font-mono text-sm"
           >
-            {sseUrl}
+            {mcpUrl}
           </code>
-          <CopyButton text={sseUrl} label="Copy SSE URL" />
+          <CopyButton text={mcpUrl} label="Copy MCP URL" />
+        </div>
+        <div>
+          <p className="text-xs text-muted-foreground">
+            Legacy SSE endpoint also available at{' '}
+            <code className="text-xs">{sseUrl}</code>
+          </p>
         </div>
       </Card>
 
-      {/* Claude Desktop Configuration */}
-      <Card className="p-6 space-y-4">
+      {/* Client Configuration */}
+      <Card className="p-6 space-y-6">
         <div className="flex items-start justify-between">
           <div>
-            <h2 className="text-lg font-semibold">Claude Desktop Configuration</h2>
+            <h2 className="text-lg font-semibold">Client Configuration</h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              Add this configuration to your Claude Desktop{' '}
-              <code className="text-xs">claude_desktop_config.json</code>
+              Add to your Claude Desktop{' '}
+              <code className="text-xs">claude_desktop_config.json</code>{' '}
+              or Claude Code <code className="text-xs">.mcp.json</code>
             </p>
           </div>
-          <CopyButton text={claudeDesktopConfig} label="Copy Claude Desktop config" />
+          <CopyButton text={streamableHttpConfig} label="Copy streamable HTTP config" />
         </div>
-        <pre
-          data-testid="claude-desktop-config"
-          className="overflow-x-auto rounded-md bg-muted p-4 font-mono text-sm"
-        >
-          {claudeDesktopConfig}
-        </pre>
+        <div>
+          <h3 className="mb-2 text-sm font-medium">Streamable HTTP (recommended)</h3>
+          <pre
+            data-testid="streamable-http-config"
+            className="overflow-x-auto rounded-md bg-muted p-4 font-mono text-sm"
+          >
+            {streamableHttpConfig}
+          </pre>
+        </div>
+        <div>
+          <h3 className="mb-2 text-sm font-medium text-muted-foreground">Legacy SSE</h3>
+          <pre
+            data-testid="legacy-sse-config"
+            className="overflow-x-auto rounded-md bg-muted/60 p-4 font-mono text-sm text-muted-foreground"
+          >
+            {legacySseConfig}
+          </pre>
+        </div>
       </Card>
 
       {/* OAuth Authorization */}

--- a/services/mcp-server/README.md
+++ b/services/mcp-server/README.md
@@ -9,20 +9,20 @@ triggers:
   - Configuring Claude Desktop for local Meridian development
 instructions: |
   MCP Server is a thin JSON-RPC adapter that exposes Meridian's gRPC services to LLM clients
-  using the Model Context Protocol (MCP 2024-11-05).
+  using the Model Context Protocol (MCP 2025-03-26).
 
   Key patterns:
-  - Transport agnostic: stdio for CLI tools (Claude Desktop), SSE for browser-based clients
+  - Transport agnostic: stdio for CLI tools, streamable HTTP for network clients (recommended), SSE for legacy clients
   - Tool categories: Read (no side effects), Simulate (dry-run), Write (state mutation)
   - Plan-before-apply safety: meridian_manifest_plan must precede meridian_manifest_apply
-  - OAuth 2.1 with PKCE: optional, enabled via MCP_OAUTH_ENABLED=true for SSE mode
+  - OAuth 2.1 with PKCE: optional, enabled via MCP_OAUTH_ENABLED=true for network transports
   - All logs go to stderr; stdout is reserved for the JSON-RPC protocol (stdio mode)
 ---
 
 # MCP Server
 
 Thin JSON-RPC adapter that exposes Meridian's backend services to LLM clients via the
-[Model Context Protocol](https://spec.modelcontextprotocol.io/) (MCP 2024-11-05).
+[Model Context Protocol](https://spec.modelcontextprotocol.io/) (MCP 2025-03-26).
 
 ## Overview
 
@@ -30,9 +30,9 @@ Thin JSON-RPC adapter that exposes Meridian's backend services to LLM clients vi
 |-----------|-------|
 | **Type** | Infrastructure (API Gateway) |
 | **Language** | Go |
-| **Protocol** | MCP 2024-11-05 |
-| **Transports** | stdio, SSE |
-| **Auth** | OAuth 2.1 with PKCE (optional, SSE only) |
+| **Protocol** | MCP 2025-03-26 |
+| **Transports** | stdio, streamable HTTP, SSE (legacy) |
+| **Auth** | OAuth 2.1 with PKCE (optional, network transports) |
 | **Standalone** | No (requires Meridian backend services via `MERIDIAN_API_URL`) |
 
 ## Architecture
@@ -50,7 +50,8 @@ flowchart TB
 
     subgraph "MCP Server"
         ST[stdio Transport]
-        SE[SSE Transport]
+        SH[Streamable HTTP Transport]
+        SE[SSE Transport - Legacy]
         TH[Tool Handlers]
         RH[Resource Handlers]
         PH[Prompt Handlers]
@@ -69,10 +70,12 @@ flowchart TB
 
     CD -->|JSON-RPC| ST
     CLI -->|JSON-RPC| ST
-    CB -->|JSON-RPC + Bearer| SE
+    CB -->|JSON-RPC + Bearer| SH
+    SH <--> OA
     SE <--> OA
 
     ST --> TH
+    SH --> TH
     SE --> TH
     TH --> RH
     TH --> PH
@@ -97,10 +100,28 @@ responses to stdout. Logs are written to stderr to avoid corrupting the protocol
 MCP_TRANSPORT=stdio ./mcp-server
 ```
 
-### SSE
+### Streamable HTTP (recommended for network deployments)
 
-Used by browser-based clients and network-accessible deployments. The server exposes two HTTP
-endpoints:
+The streamable HTTP transport (MCP spec 2025-03-26) uses a single `/mcp` endpoint for all
+communication. Clients POST JSON-RPC requests and receive synchronous JSON responses. Session
+management is handled via the `Mcp-Session-Id` header.
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/mcp` | `POST` | Send JSON-RPC requests (initialize, tools/list, tools/call, etc.) |
+| `/mcp` | `DELETE` | Terminate a session |
+
+The streamable HTTP transport is automatically available alongside SSE when running in `sse`
+mode -- no separate transport flag is needed.
+
+```bash
+MCP_TRANSPORT=sse MCP_SSE_PORT=8090 ./mcp-server
+# Both /mcp (streamable HTTP) and /sse + /message (legacy) are served
+```
+
+### SSE (legacy)
+
+The original SSE transport is still available for clients that do not yet support streamable HTTP.
 
 | Endpoint | Purpose |
 |----------|---------|
@@ -128,9 +149,9 @@ MCP_TRANSPORT=sse MCP_SSE_PORT=8090 ./mcp-server
 
 ## OAuth 2.1 Configuration
 
-OAuth 2.1 with PKCE is optional and only applies to the SSE transport. When enabled, the server
-exposes authorization and token endpoints and requires clients to present a bearer token on the
-`/sse` and `/message` endpoints.
+OAuth 2.1 with PKCE is optional and applies to both the streamable HTTP and SSE transports. When
+enabled, the server exposes authorization and token endpoints and requires clients to present a
+bearer token on the `/mcp`, `/sse`, and `/message` endpoints.
 
 Example configuration for a production SSE deployment:
 
@@ -153,7 +174,22 @@ OAuth endpoints exposed when `MCP_OAUTH_ENABLED=true`:
 The current implementation ships a passthrough token issuer and validator suitable for development.
 For production, configure a real JWT signer and validator.
 
-## Claude Desktop Configuration
+## Client Configuration
+
+### Streamable HTTP (recommended for network deployments)
+
+For Claude Desktop, Claude Code, or any MCP client connecting to a remote Meridian instance:
+
+```json
+{
+  "mcpServers": {
+    "meridian": {
+      "type": "streamable-http",
+      "url": "https://your-domain/mcp"
+    }
+  }
+}
+```
 
 ### stdio mode (recommended for local development)
 
@@ -176,7 +212,7 @@ Add the following to your Claude Desktop configuration file
 }
 ```
 
-### SSE mode (for network-accessible deployments)
+### Legacy SSE (for clients without streamable HTTP support)
 
 ```json
 {
@@ -298,7 +334,7 @@ MERIDIAN_API_URL=localhost:9090 \
   /tmp/meridian-mcp
 ```
 
-### Running standalone (SSE mode)
+### Running standalone (network mode)
 
 ```bash
 MCP_TRANSPORT=sse \
@@ -309,7 +345,24 @@ MCP_TRANSPORT=sse \
   /tmp/meridian-mcp
 ```
 
-Then connect Claude Desktop using the SSE configuration above, or test with curl:
+This starts both the streamable HTTP (`/mcp`) and legacy SSE (`/sse`, `/message`) endpoints.
+
+Test with curl using the streamable HTTP transport:
+
+```bash
+# Initialize a session
+curl -X POST http://localhost:8090/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
+
+# Use the Mcp-Session-Id from the response header for subsequent requests
+curl -X POST http://localhost:8090/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Mcp-Session-Id: <session-id-from-above>' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+```
+
+Or test with the legacy SSE transport:
 
 ```bash
 # Open SSE stream


### PR DESCRIPTION
## Summary

- Update frontend MCP config page to show streamable HTTP (`/mcp`) as the primary connection method
- Demote legacy SSE (`/sse`) to secondary option with muted styling
- Update MCP server README with streamable HTTP transport documentation, updated architecture diagram, and curl examples
- Update tests to match new UI structure

## Changes

**Frontend (`frontend/src/pages/mcp-config/index.tsx`)**
- Primary endpoint now shows `/mcp` (streamable HTTP) instead of `/sse`
- Client config section shows both streamable HTTP (recommended) and legacy SSE configs
- Copy button defaults to streamable HTTP config
- Legacy SSE shown with muted styling

**Tests (`frontend/src/pages/mcp-config/index.test.tsx`)**
- Updated assertions for new test IDs (`mcp-url`, `streamable-http-config`, `legacy-sse-config`)
- All 19 tests passing

**README (`services/mcp-server/README.md`)**
- Protocol version updated from MCP 2024-11-05 to MCP 2025-03-26
- Added streamable HTTP transport section with endpoint table
- Updated architecture diagram to include streamable HTTP transport
- Added curl examples for streamable HTTP session flow
- Updated OAuth docs to cover both transports
- SSE sections marked as legacy

## Test plan

- [x] Frontend tests pass (`vitest run src/pages/mcp-config/`)
- [ ] CI passes