### PR TITLE
feat: wire MCP server tools, resources, and prompts to gRPC backend

### DIFF
--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -77,6 +77,15 @@ func runStdio(logger *slog.Logger, cfg server.Config) error {
 
 	srv := server.New(tr, cfg, logger)
 
+	// Wire tools, resources, and prompts onto the server.
+	cleanup, err := wireServer(srv, logger)
+	if err != nil {
+		logger.Warn("tool wiring incomplete", "error", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
 	// For stdio, we run until stdin closes or we receive a signal.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -153,6 +162,15 @@ func runSSE(logger *slog.Logger, cfg server.Config) error {
 	defer sseTr.Close()
 
 	srv := server.New(sseTr, cfg, logger)
+
+	// Wire tools, resources, and prompts onto the server.
+	cleanup, wireErr := wireServer(srv, logger)
+	if wireErr != nil {
+		logger.Warn("tool wiring incomplete", "error", wireErr)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
 
 	// Streamable HTTP transport (MCP spec 2025-03-26).
 	// Shares the same MCPServer instance so tools/resources/prompts are identical.

--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -80,7 +80,7 @@ func runStdio(logger *slog.Logger, cfg server.Config) error {
 	// Wire tools, resources, and prompts onto the server.
 	cleanup, err := wireServer(srv, logger)
 	if err != nil {
-		logger.Warn("tool wiring incomplete", "error", err)
+		return fmt.Errorf("wire server: %w", err)
 	}
 	if cleanup != nil {
 		defer cleanup()
@@ -166,7 +166,7 @@ func runSSE(logger *slog.Logger, cfg server.Config) error {
 	// Wire tools, resources, and prompts onto the server.
 	cleanup, wireErr := wireServer(srv, logger)
 	if wireErr != nil {
-		logger.Warn("tool wiring incomplete", "error", wireErr)
+		return fmt.Errorf("wire server: %w", wireErr)
 	}
 	if cleanup != nil {
 		defer cleanup()

--- a/services/mcp-server/cmd/wire.go
+++ b/services/mcp-server/cmd/wire.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
@@ -52,7 +53,7 @@ func wireServer(srv *server.MCPServer, logger *slog.Logger) (func(), error) {
 	authCfg, err := mcpauth.LoadFromEnv()
 	if err != nil {
 		logger.Warn("Meridian backend not configured — only local tools available", "error", err)
-		bridgeToolsToServer(srv, toolReg)
+		bridgeToolsToServer(srv, toolReg, logger)
 		// Resource provider with nil manifest client returns a placeholder.
 		srv.SetResourceProvider(resources.New(nil))
 		return nil, nil //nolint:nilnil // partial availability is intentional
@@ -61,7 +62,7 @@ func wireServer(srv *server.MCPServer, logger *slog.Logger) (func(), error) {
 	mc, err := clients.New(authCfg)
 	if err != nil {
 		logger.Warn("failed to create gRPC clients — only local tools available", "error", err)
-		bridgeToolsToServer(srv, toolReg)
+		bridgeToolsToServer(srv, toolReg, logger)
 		srv.SetResourceProvider(resources.New(nil))
 		return nil, nil //nolint:nilnil // partial availability is intentional
 	}
@@ -110,14 +111,14 @@ func wireServer(srv *server.MCPServer, logger *slog.Logger) (func(), error) {
 	tools.RegisterSimulationTools(toolReg, tools.SimulationDeps{})
 
 	// Bridge all registered tools to the server.
-	bridgeToolsToServer(srv, toolReg)
+	bridgeToolsToServer(srv, toolReg, logger)
 
 	return cleanup, nil
 }
 
 // bridgeToolsToServer iterates tools from the registry and registers each
 // with the server, adapting the tools.ToolHandler signature to server.ToolHandler.
-func bridgeToolsToServer(srv *server.MCPServer, reg *tools.Registry) {
+func bridgeToolsToServer(srv *server.MCPServer, reg *tools.Registry, logger *slog.Logger) {
 	for _, t := range reg.List() {
 		name := t.Name // capture for closure
 		srv.RegisterTool(
@@ -126,7 +127,7 @@ func bridgeToolsToServer(srv *server.MCPServer, reg *tools.Registry) {
 				Description: t.Description,
 				InputSchema: t.InputSchema,
 			},
-			toolHandlerFor(reg, name),
+			toolHandlerFor(reg, name, logger),
 		)
 	}
 }
@@ -134,13 +135,17 @@ func bridgeToolsToServer(srv *server.MCPServer, reg *tools.Registry) {
 // toolHandlerFor returns a server.ToolHandler that delegates to the registry.
 // Tool-level errors (validation failures, gRPC errors) are returned as MCP
 // error content blocks rather than Go errors, following MCP convention.
-func toolHandlerFor(reg *tools.Registry, name string) server.ToolHandler {
+// Detailed error information is logged server-side; the client receives a
+// sanitized message to avoid leaking internal details.
+func toolHandlerFor(reg *tools.Registry, name string, logger *slog.Logger) server.ToolHandler {
 	return func(ctx context.Context, args json.RawMessage) (*server.ToolCallResult, error) {
 		result, callErr := reg.Call(ctx, name, args)
 		if callErr != nil {
-			// MCP convention: tool errors are returned as content blocks, not Go errors.
-			// The MCP client displays the error text to the user/LLM.
-			return toolErrorResult(callErr.Error()), nil
+			// Log the full error server-side for debugging.
+			logger.Warn("tool call failed", "tool", name, "error", callErr)
+			// Return a sanitized message to the MCP client.
+			sanitized := fmt.Sprintf("tool %q failed: %s", name, sanitizeError(callErr))
+			return toolErrorResult(sanitized), nil //nolint:nilerr // callErr is logged and returned as MCP content
 		}
 		data, err := json.Marshal(result)
 		if err != nil {
@@ -158,6 +163,16 @@ func toolErrorResult(msg string) *server.ToolCallResult {
 		Content: []server.ContentBlock{{Type: "text", Text: msg}},
 		IsError: true,
 	}
+}
+
+// sanitizeError extracts a user-safe message from the error.
+// gRPC status errors are reduced to their message; other errors pass through
+// as-is since they originate from local validation (CEL, Starlark, etc.).
+func sanitizeError(err error) string {
+	if s, ok := status.FromError(err); ok {
+		return s.Message()
+	}
+	return err.Error()
 }
 
 // ---------------------------------------------------------------------------

--- a/services/mcp-server/cmd/wire.go
+++ b/services/mcp-server/cmd/wire.go
@@ -1,0 +1,294 @@
+// Package main provides the wiring layer that connects gRPC clients to the
+// MCP server's tool registry, resource provider, and prompt registry.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
+	mcpauth "github.com/meridianhub/meridian/services/mcp-server/internal/auth"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/clients"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/prompts"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/resources"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/server"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/session"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+)
+
+// wireServer registers all MCP tools, resources, and prompts onto srv.
+// If the Meridian backend (MERIDIAN_API_URL / MERIDIAN_API_KEY) is configured,
+// it creates gRPC clients and wires all remote tools. If not, only local tools
+// (validation, prompts, embedded docs) are registered.
+//
+// Returns a cleanup function to close the gRPC connection (nil when no
+// connection was established).
+func wireServer(srv *server.MCPServer, logger *slog.Logger) (func(), error) {
+	// Prompts are always available (no external deps).
+	srv.SetPromptRegistry(prompts.NewRegistry())
+
+	// Tool registry collects all tools, then bridges them to the server.
+	toolReg := tools.NewRegistry()
+
+	// Validation tools use local CEL/Starlark libraries — no gRPC needed.
+	if err := tools.RegisterValidationTools(toolReg); err != nil {
+		return nil, fmt.Errorf("register validation tools: %w", err)
+	}
+
+	// Try to connect to the Meridian backend for remote tools.
+	var cleanup func()
+
+	authCfg, err := mcpauth.LoadFromEnv()
+	if err != nil {
+		logger.Warn("Meridian backend not configured — only local tools available", "error", err)
+		bridgeToolsToServer(srv, toolReg)
+		// Resource provider with nil manifest client returns a placeholder.
+		srv.SetResourceProvider(resources.New(nil))
+		return nil, nil //nolint:nilnil // partial availability is intentional
+	}
+
+	mc, err := clients.New(authCfg)
+	if err != nil {
+		logger.Warn("failed to create gRPC clients — only local tools available", "error", err)
+		bridgeToolsToServer(srv, toolReg)
+		srv.SetResourceProvider(resources.New(nil))
+		return nil, nil //nolint:nilnil // partial availability is intentional
+	}
+	cleanup = func() { _ = mc.Close() }
+
+	logger.Info("gRPC clients connected", "target", authCfg.APIUrl)
+
+	// -- Resource provider (live manifest) --
+	srv.SetResourceProvider(resources.New(&manifestResourceAdapter{c: mc.ManifestHistory}))
+
+	// -- Reference data tools --
+	mhAdapter := manifestHistoryAdapter{c: mc.ManifestHistory}
+	rdAdapter := referenceDataAdapter{c: mc.ReferenceData}
+	srAdapter := sagaRegistryAdapter{c: mc.SagaRegistry}
+	miAdapter := marketInfoAdapter{c: mc.MarketInfo}
+
+	if err := tools.RegisterReferenceDataTools(toolReg, tools.ReferenceDataDeps{
+		ManifestHistory:   mhAdapter,
+		ReferenceData:     rdAdapter,
+		SagaRegistry:      srAdapter,
+		MarketInformation: miAdapter,
+	}); err != nil {
+		logger.Warn("failed to register reference data tools", "error", err)
+	}
+
+	// -- Audit tools --
+	tools.RegisterAuditTools(toolReg, tools.AuditClients{
+		SagaAdmin:           sagaAdminAdapter{c: mc.SagaAdmin},
+		PositionKeeping:     positionKeepingAdapter{c: mc.PositionKeeping},
+		FinancialAccounting: postingAdapter{c: mc.Accounting},
+		SagaRegistry:        srAdapter,
+		Reconciliation:      reconciliationAdapter{c: mc.Reconciliation},
+	})
+
+	// -- Economy tools (manifest plan/apply/history) --
+	sess := session.NewDefault()
+	tools.RegisterEconomyTools(toolReg, sess, tools.EconomyDeps{
+		Applier:   applyManifestAdapter{c: mc.ApplyManifest},
+		Historian: mhAdapter,
+	})
+
+	// -- Simulation tools --
+	// CELEvaluator, ManifestDiffer, ValuationSimulator, and SagaSimulator
+	// require dedicated implementations that don't exist yet. Tools with
+	// nil deps are silently skipped — they'll light up once implemented.
+	tools.RegisterSimulationTools(toolReg, tools.SimulationDeps{})
+
+	// Bridge all registered tools to the server.
+	bridgeToolsToServer(srv, toolReg)
+
+	return cleanup, nil
+}
+
+// bridgeToolsToServer iterates tools from the registry and registers each
+// with the server, adapting the tools.ToolHandler signature to server.ToolHandler.
+func bridgeToolsToServer(srv *server.MCPServer, reg *tools.Registry) {
+	for _, t := range reg.List() {
+		name := t.Name // capture for closure
+		srv.RegisterTool(
+			server.Tool{
+				Name:        t.Name,
+				Description: t.Description,
+				InputSchema: t.InputSchema,
+			},
+			toolHandlerFor(reg, name),
+		)
+	}
+}
+
+// toolHandlerFor returns a server.ToolHandler that delegates to the registry.
+// Tool-level errors (validation failures, gRPC errors) are returned as MCP
+// error content blocks rather than Go errors, following MCP convention.
+func toolHandlerFor(reg *tools.Registry, name string) server.ToolHandler {
+	return func(ctx context.Context, args json.RawMessage) (*server.ToolCallResult, error) {
+		result, callErr := reg.Call(ctx, name, args)
+		if callErr != nil {
+			// MCP convention: tool errors are returned as content blocks, not Go errors.
+			// The MCP client displays the error text to the user/LLM.
+			return toolErrorResult(callErr.Error()), nil
+		}
+		data, err := json.Marshal(result)
+		if err != nil {
+			return nil, fmt.Errorf("marshal tool result: %w", err)
+		}
+		return &server.ToolCallResult{
+			Content: []server.ContentBlock{{Type: "text", Text: string(data)}},
+		}, nil
+	}
+}
+
+// toolErrorResult builds an MCP error content block from a message string.
+func toolErrorResult(msg string) *server.ToolCallResult {
+	return &server.ToolCallResult{
+		Content: []server.ContentBlock{{Type: "text", Text: msg}},
+		IsError: true,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// gRPC → tool interface adapters
+//
+// The generated gRPC clients accept ...grpc.CallOption as the last parameter,
+// but tool interfaces use a simpler (ctx, req) → (resp, error) signature.
+// These thin adapters bridge the gap.
+// ---------------------------------------------------------------------------
+
+// manifestHistoryAdapter satisfies tools.ManifestHistoryClient and tools.ManifestHistorian.
+type manifestHistoryAdapter struct {
+	c controlplanev1.ManifestHistoryServiceClient
+}
+
+func (a manifestHistoryAdapter) GetCurrentManifest(ctx context.Context, req *controlplanev1.GetCurrentManifestRequest) (*controlplanev1.GetCurrentManifestResponse, error) {
+	return a.c.GetCurrentManifest(ctx, req)
+}
+
+func (a manifestHistoryAdapter) ListManifestVersions(ctx context.Context, req *controlplanev1.ListManifestVersionsRequest) (*controlplanev1.ListManifestVersionsResponse, error) {
+	return a.c.ListManifestVersions(ctx, req)
+}
+
+// referenceDataAdapter satisfies tools.ReferenceDataClient.
+type referenceDataAdapter struct {
+	c referencedatav1.ReferenceDataServiceClient
+}
+
+func (a referenceDataAdapter) ListInstruments(ctx context.Context, req *referencedatav1.ListInstrumentsRequest) (*referencedatav1.ListInstrumentsResponse, error) {
+	return a.c.ListInstruments(ctx, req)
+}
+
+func (a referenceDataAdapter) RetrieveInstrument(ctx context.Context, req *referencedatav1.RetrieveInstrumentRequest) (*referencedatav1.RetrieveInstrumentResponse, error) {
+	return a.c.RetrieveInstrument(ctx, req)
+}
+
+// sagaRegistryAdapter satisfies tools.SagaRegistryClient and tools.SagaExecutionQuerier.
+type sagaRegistryAdapter struct {
+	c sagav1.SagaRegistryServiceClient
+}
+
+func (a sagaRegistryAdapter) ListSagas(ctx context.Context, req *sagav1.ListSagasRequest) (*sagav1.ListSagasResponse, error) {
+	return a.c.ListSagas(ctx, req)
+}
+
+func (a sagaRegistryAdapter) GetSaga(ctx context.Context, req *sagav1.GetSagaRequest) (*sagav1.GetSagaResponse, error) {
+	return a.c.GetSaga(ctx, req)
+}
+
+// marketInfoAdapter satisfies tools.MarketInformationClient.
+type marketInfoAdapter struct {
+	c marketinformationv1.MarketInformationServiceClient
+}
+
+func (a marketInfoAdapter) ListDataSets(ctx context.Context, req *marketinformationv1.ListDataSetsRequest) (*marketinformationv1.ListDataSetsResponse, error) {
+	return a.c.ListDataSets(ctx, req)
+}
+
+func (a marketInfoAdapter) ListObservations(ctx context.Context, req *marketinformationv1.ListObservationsRequest) (*marketinformationv1.ListObservationsResponse, error) {
+	return a.c.ListObservations(ctx, req)
+}
+
+// sagaAdminAdapter satisfies tools.SagaAdminQuerier.
+type sagaAdminAdapter struct {
+	c sagav1.SagaAdminServiceClient
+}
+
+func (a sagaAdminAdapter) GetCausationTree(ctx context.Context, req *sagav1.GetCausationTreeRequest) (*sagav1.GetCausationTreeResponse, error) {
+	return a.c.GetCausationTree(ctx, req)
+}
+
+// positionKeepingAdapter satisfies tools.PositionQuerier.
+type positionKeepingAdapter struct {
+	c positionkeepingv1.PositionKeepingServiceClient
+}
+
+func (a positionKeepingAdapter) ListFinancialPositionLogs(ctx context.Context, req *positionkeepingv1.ListFinancialPositionLogsRequest) (*positionkeepingv1.ListFinancialPositionLogsResponse, error) {
+	return a.c.ListFinancialPositionLogs(ctx, req)
+}
+
+// postingAdapter satisfies tools.PostingQuerier.
+type postingAdapter struct {
+	c financialaccountingv1.FinancialAccountingServiceClient
+}
+
+func (a postingAdapter) ListLedgerPostings(ctx context.Context, req *financialaccountingv1.ListLedgerPostingsRequest) (*financialaccountingv1.ListLedgerPostingsResponse, error) {
+	return a.c.ListLedgerPostings(ctx, req)
+}
+
+// reconciliationAdapter satisfies tools.ReconciliationQuerier.
+type reconciliationAdapter struct {
+	c reconciliationv1.AccountReconciliationServiceClient
+}
+
+func (a reconciliationAdapter) ListAccountReconciliations(ctx context.Context, req *reconciliationv1.ListAccountReconciliationsRequest) (*reconciliationv1.ListAccountReconciliationsResponse, error) {
+	return a.c.ListAccountReconciliations(ctx, req)
+}
+
+func (a reconciliationAdapter) ListReconciliationResults(ctx context.Context, req *reconciliationv1.ListReconciliationResultsRequest) (*reconciliationv1.ListReconciliationResultsResponse, error) {
+	return a.c.ListReconciliationResults(ctx, req)
+}
+
+// applyManifestAdapter satisfies tools.ManifestApplier.
+type applyManifestAdapter struct {
+	c controlplanev1.ApplyManifestServiceClient
+}
+
+func (a applyManifestAdapter) ApplyManifest(ctx context.Context, req *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+	return a.c.ApplyManifest(ctx, req)
+}
+
+// manifestResourceAdapter satisfies resources.ManifestClient.
+// It wraps the gRPC ManifestHistoryServiceClient to produce a JSON representation
+// of the current manifest (the resource MIME type is text/yaml but the content is
+// JSON — LLM clients handle both formats equally well).
+type manifestResourceAdapter struct {
+	c controlplanev1.ManifestHistoryServiceClient
+}
+
+func (a *manifestResourceAdapter) GetCurrentManifestYAML(ctx context.Context) (string, error) {
+	resp, err := a.c.GetCurrentManifest(ctx, &controlplanev1.GetCurrentManifestRequest{})
+	if err != nil {
+		return "", err
+	}
+	if resp.GetVersion() == nil || resp.GetVersion().GetManifest() == nil {
+		return "# No manifest applied\n", nil
+	}
+	opts := protojson.MarshalOptions{Multiline: true, Indent: "  "}
+	data, err := opts.Marshal(resp.GetVersion().GetManifest())
+	if err != nil {
+		return "", fmt.Errorf("marshal manifest: %w", err)
+	}
+	return string(data), nil
+}

--- a/services/mcp-server/internal/clients/clients.go
+++ b/services/mcp-server/internal/clients/clients.go
@@ -12,6 +12,7 @@ import (
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
 	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
 	"github.com/meridianhub/meridian/services/mcp-server/internal/auth"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -38,6 +39,10 @@ type MeridianClients struct {
 	Reconciliation reconciliationv1.AccountReconciliationServiceClient
 	// MarketInfo retrieves market price and rate data.
 	MarketInfo marketinformationv1.MarketInformationServiceClient
+	// SagaAdmin queries saga causation trees and execution state.
+	SagaAdmin sagav1.SagaAdminServiceClient
+	// SagaRegistry queries saga definitions and lifecycle.
+	SagaRegistry sagav1.SagaRegistryServiceClient
 	// Health allows the MCP server to check gateway liveness.
 	Health grpc_health_v1.HealthClient
 
@@ -80,6 +85,8 @@ func New(cfg *auth.Config) (*MeridianClients, error) {
 		Accounting:      financialaccountingv1.NewFinancialAccountingServiceClient(conn),
 		Reconciliation:  reconciliationv1.NewAccountReconciliationServiceClient(conn),
 		MarketInfo:      marketinformationv1.NewMarketInformationServiceClient(conn),
+		SagaAdmin:       sagav1.NewSagaAdminServiceClient(conn),
+		SagaRegistry:    sagav1.NewSagaRegistryServiceClient(conn),
 		Health:          grpc_health_v1.NewHealthClient(conn),
 		conn:            conn,
 	}, nil


### PR DESCRIPTION
## Summary

- Adds `SagaAdmin` and `SagaRegistry` gRPC clients to `MeridianClients`
- Creates thin adapter types in `wire.go` that bridge generated gRPC clients (`...grpc.CallOption` signatures) to the simpler tool interfaces
- Wires all tool groups (reference data, audit, economy, validation, simulation), the resource provider (live manifest), and the prompt registry onto the MCP server at startup
- Supports graceful degradation: when `MERIDIAN_API_URL` is not configured, only local tools (CEL/Starlark validation) and embedded documentation resources are available

## Test plan

- [x] All existing MCP server tests pass (`go test ./services/mcp-server/...`)
- [x] Binary builds successfully (`go build ./services/mcp-server/cmd/`)
- [x] Pre-commit hooks pass (gitleaks, gofumpt, golangci-lint)
- [ ] Deploy to demo and verify `tools/list` returns registered tools
- [ ] Verify tool invocation works end-to-end via Claude MCP client