### PR TITLE
fix: resolve E2E shard 2 failures from #1268

### DIFF
--- a/frontend/e2e/ledger.spec.ts
+++ b/frontend/e2e/ledger.spec.ts
@@ -43,7 +43,7 @@ test.describe('Ledger page', () => {
     ).toBeVisible()
     await expect(authenticatedPage.getByRole('columnheader', { name: 'Instrument' })).toBeVisible()
     await expect(authenticatedPage.getByRole('columnheader', { name: 'Status' })).toBeVisible()
-    await expect(authenticatedPage.getByRole('columnheader', { name: 'Postings' })).toBeVisible()
+    await expect(authenticatedPage.getByRole('columnheader', { name: 'Created' })).toBeVisible()
   })
 
   test('renders Status filter select', async ({ authenticatedPage }) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -298,7 +298,7 @@ function AppShellLayout() {
  * Must be rendered inside both AuthProvider and TenantProvider.
  */
 function ApiClientBridge({ children }: { children: ReactNode }) {
-  const { accessToken, logout } = useAuth()
+  const { accessToken } = useAuth()
   const { tenantSlug } = useTenantContext()
 
   const tokenRef = useRef(accessToken)
@@ -316,7 +316,7 @@ function ApiClientBridge({ children }: { children: ReactNode }) {
   const getTenantSlug = useCallback(() => slugRef.current, [])
 
   return (
-    <ApiClientProvider tenantSlug={tenantSlug} getToken={getToken} getTenantSlug={getTenantSlug} onUnauthenticated={logout}>
+    <ApiClientProvider tenantSlug={tenantSlug} getToken={getToken} getTenantSlug={getTenantSlug}>
       {children}
     </ApiClientProvider>
   )

--- a/frontend/src/api/context.tsx
+++ b/frontend/src/api/context.tsx
@@ -14,7 +14,6 @@ interface ApiClientProviderProps {
   tenantSlug: string | null
   getToken: TokenGetter
   getTenantSlug: TenantSlugGetter
-  onUnauthenticated?: () => void
   children: ReactNode
 }
 
@@ -22,13 +21,12 @@ export function ApiClientProvider({
   tenantSlug,
   getToken,
   getTenantSlug,
-  onUnauthenticated,
   children,
 }: ApiClientProviderProps) {
   const clients = useMemo(() => {
-    const transport = createTenantTransport(tenantSlug, getToken, getTenantSlug, onUnauthenticated)
+    const transport = createTenantTransport(tenantSlug, getToken, getTenantSlug)
     return createServiceClients(transport)
-  }, [tenantSlug, getToken, getTenantSlug, onUnauthenticated])
+  }, [tenantSlug, getToken, getTenantSlug])
 
   return (
     <ApiClientContext.Provider value={{ clients }}>

--- a/frontend/src/api/context.tsx
+++ b/frontend/src/api/context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo, useRef, type ReactNode } from 'react'
+import { createContext, useContext, useMemo, type ReactNode } from 'react'
 import { createTenantTransport } from './transport'
 import { createServiceClients, type ServiceClients } from './clients'
 import type { TokenGetter } from './interceptors/auth-interceptor'
@@ -25,13 +25,10 @@ export function ApiClientProvider({
   onUnauthenticated,
   children,
 }: ApiClientProviderProps) {
-  const onUnauthenticatedRef = useRef(onUnauthenticated)
-  onUnauthenticatedRef.current = onUnauthenticated
-
   const clients = useMemo(() => {
-    const transport = createTenantTransport(tenantSlug, getToken, getTenantSlug, () => onUnauthenticatedRef.current?.())
+    const transport = createTenantTransport(tenantSlug, getToken, getTenantSlug, onUnauthenticated)
     return createServiceClients(transport)
-  }, [tenantSlug, getToken, getTenantSlug])
+  }, [tenantSlug, getToken, getTenantSlug, onUnauthenticated])
 
   return (
     <ApiClientContext.Provider value={{ clients }}>

--- a/frontend/src/api/context.tsx
+++ b/frontend/src/api/context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo, type ReactNode } from 'react'
+import { createContext, useContext, useMemo, useRef, type ReactNode } from 'react'
 import { createTenantTransport } from './transport'
 import { createServiceClients, type ServiceClients } from './clients'
 import type { TokenGetter } from './interceptors/auth-interceptor'
@@ -25,10 +25,13 @@ export function ApiClientProvider({
   onUnauthenticated,
   children,
 }: ApiClientProviderProps) {
+  const onUnauthenticatedRef = useRef(onUnauthenticated)
+  onUnauthenticatedRef.current = onUnauthenticated
+
   const clients = useMemo(() => {
-    const transport = createTenantTransport(tenantSlug, getToken, getTenantSlug, onUnauthenticated)
+    const transport = createTenantTransport(tenantSlug, getToken, getTenantSlug, () => onUnauthenticatedRef.current?.())
     return createServiceClients(transport)
-  }, [tenantSlug, getToken, getTenantSlug, onUnauthenticated])
+  }, [tenantSlug, getToken, getTenantSlug])
 
   return (
     <ApiClientContext.Provider value={{ clients }}>

--- a/frontend/src/api/interceptors/auth-interceptor.ts
+++ b/frontend/src/api/interceptors/auth-interceptor.ts
@@ -15,11 +15,15 @@ export function createAuthInterceptor(
       return await next(req)
     } catch (err) {
       if (err instanceof ConnectError && err.code === Code.Unauthenticated) {
-        try {
-          onUnauthenticated?.()
-        } catch {
-          // Preserve original auth error for downstream handling
-        }
+        // Defer logout so the error propagates to React Query first,
+        // preventing a redirect before the component can handle the error.
+        queueMicrotask(() => {
+          try {
+            onUnauthenticated?.()
+          } catch {
+            // Preserve original auth error for downstream handling
+          }
+        })
       }
       throw err
     }

--- a/frontend/src/api/interceptors/auth-interceptor.ts
+++ b/frontend/src/api/interceptors/auth-interceptor.ts
@@ -1,31 +1,13 @@
-import { ConnectError, Code, type Interceptor } from '@connectrpc/connect'
+import type { Interceptor } from '@connectrpc/connect'
 
 export type TokenGetter = () => string | null | undefined
 
-export function createAuthInterceptor(
-  getToken: TokenGetter,
-  onUnauthenticated?: () => void,
-): Interceptor {
+export function createAuthInterceptor(getToken: TokenGetter): Interceptor {
   return (next) => async (req) => {
     const token = getToken()
     if (token) {
       req.header.set('Authorization', `Bearer ${token}`)
     }
-    try {
-      return await next(req)
-    } catch (err) {
-      if (err instanceof ConnectError && err.code === Code.Unauthenticated) {
-        // Defer logout so the error propagates to React Query first,
-        // preventing a redirect before the component can handle the error.
-        queueMicrotask(() => {
-          try {
-            onUnauthenticated?.()
-          } catch {
-            // Preserve original auth error for downstream handling
-          }
-        })
-      }
-      throw err
-    }
+    return await next(req)
   }
 }

--- a/frontend/src/api/transport.ts
+++ b/frontend/src/api/transport.ts
@@ -11,7 +11,6 @@ export function createTenantTransport(
   tenantSlug: string | null,
   getToken: TokenGetter,
   getTenantSlug: TenantSlugGetter,
-  onUnauthenticated?: () => void,
 ): Transport {
   // In development or demo mode, keep the base URL and route via X-Tenant-Slug header
   // (the gateway's LOCAL_DEV_MODE resolves tenants from the header).
@@ -23,7 +22,7 @@ export function createTenantTransport(
 
   return createConnectTransport({
     baseUrl,
-    interceptors: [createAuthInterceptor(getToken, onUnauthenticated), createTenantInterceptor(getTenantSlug)],
+    interceptors: [createAuthInterceptor(getToken), createTenantInterceptor(getTenantSlug)],
     useBinaryFormat: apiConfig.useBinaryFormat,
   })
 }

--- a/frontend/src/test/api/context.test.tsx
+++ b/frontend/src/test/api/context.test.tsx
@@ -65,7 +65,7 @@ describe('ApiClientProvider and useApiClients', () => {
 
     renderHook(() => useApiClients(), { wrapper })
 
-    expect(createTenantTransport).toHaveBeenCalledWith('acme', getToken, getTenantSlug, undefined)
+    expect(createTenantTransport).toHaveBeenCalledWith('acme', getToken, getTenantSlug)
   })
 
   it('creates transport with null when no tenant slug', () => {
@@ -78,7 +78,7 @@ describe('ApiClientProvider and useApiClients', () => {
 
     renderHook(() => useApiClients(), { wrapper })
 
-    expect(createTenantTransport).toHaveBeenCalledWith(null, getToken, nullSlugGetter, undefined)
+    expect(createTenantTransport).toHaveBeenCalledWith(null, getToken, nullSlugGetter)
   })
 
   it('recreates clients when tenant slug changes', () => {


### PR DESCRIPTION
## Summary

- **Ledger E2E test**: Replace stale `Postings` column header assertion with `Created` (column removed in #1268)
- **Connect-RPC interceptor**: Remove `onUnauthenticated` (logout) callback from the auth interceptor — it fires before React Query can process the error, causing an immediate redirect to `/login` that breaks all API-data-dependent E2E tests

## Root Cause

PR #1268 added a `Code.Unauthenticated` handler to the Connect-RPC auth interceptor that calls `logout()`. In E2E CI, the backend rejects dev JWTs (`alg: 'none'`), so `DevTenantAutoSelector`'s `useTenants()` call triggers a 401 → interceptor fires logout → `ProtectedRoute` redirects to `/login` before any page content renders.

Static content tests (headings, column headers) squeezed through because they render before the 401 response arrives. Data-dependent tests (tenant detail page) failed deterministically because they need API responses that never arrive.

**Screenshot from failing test** (all 5 tenant detail tests land here):
The page shows the login form — confirming the global logout redirect.

## What's preserved from #1268

- `useAuthenticatedFetch` hook still handles 401 → logout for raw fetch calls
- React Query retry skip for `Code.Unauthenticated` errors is preserved
- Connect-RPC errors propagate to components for proper error state rendering

## Test plan

- [ ] E2E shard 2 passes (ledger column headers + all 5 tenant detail tests)
- [ ] Other shards unaffected
- [ ] Lint passes