### PR TITLE
fix: use parse_decimal for CEL validation in seed-demo product types

### DIFF
--- a/cmd/seed-demo/main.go
+++ b/cmd/seed-demo/main.go
@@ -256,7 +256,7 @@ var productTypes = []productTypeDef{
 		normalBalance:  referencedatav1.NormalBalance_NORMAL_BALANCE_DEBIT,
 		behaviorClass:  referencedatav1.BehaviorClass_BEHAVIOR_CLASS_INVENTORY,
 		instrumentCode: "KWH",
-		validationCEL:  "amount > 0",
+		validationCEL:  "parse_decimal(amount) > 0.0",
 	},
 	{
 		code:           "ENERGY_TRADING",
@@ -265,7 +265,7 @@ var productTypes = []productTypeDef{
 		normalBalance:  referencedatav1.NormalBalance_NORMAL_BALANCE_DEBIT,
 		behaviorClass:  referencedatav1.BehaviorClass_BEHAVIOR_CLASS_CUSTOMER,
 		instrumentCode: "GBP",
-		validationCEL:  "amount > 0",
+		validationCEL:  "parse_decimal(amount) > 0.0",
 	},
 }
 


### PR DESCRIPTION
## Summary

- Fix CEL validation expressions in seed-demo product types: `amount > 0` fails because `amount` is declared as `StringType` in the CEL environment (for arbitrary precision decimal support)
- Use `parse_decimal(amount) > 0.0` which correctly converts the string to double before comparison

## Context

PR #1272 added product type registration to seed-demo but used `amount > 0` as the validation CEL expression. On demo deployment, this fails with:

```
CEL compilation failed: no matching overload for '_>_' applied to '(string, int)'
```

## Test plan

- [x] `go build ./cmd/seed-demo/` passes
- [ ] CI passes
- [ ] Deploy to demo and verify seed-demo completes