### PR TITLE
fix: handle empty attribute_schema in account type handler

### DIFF
--- a/services/reference-data/handler/account_type_handler.go
+++ b/services/reference-data/handler/account_type_handler.go
@@ -195,7 +195,7 @@ func (s *AccountTypeService) CreateDraft(ctx context.Context, req *pb.CreateDraf
 		ValidationCEL:                  req.GetValidationCel(),
 		BucketingCEL:                   req.GetBucketingCel(),
 		EligibilityCEL:                 req.GetEligibilityCel(),
-		AttributeSchema:                json.RawMessage(req.GetAttributeSchema()),
+		AttributeSchema:                toRawJSON(req.GetAttributeSchema()),
 		Attributes:                     stringMapToAnyMap(req.GetAttributes()),
 		Compiler:                       s.compiler,
 	})
@@ -244,7 +244,7 @@ func (s *AccountTypeService) UpdateDefinition(ctx context.Context, req *pb.Updat
 		ValidationCEL:                  req.GetValidationCel(),
 		BucketingCEL:                   req.GetBucketingCel(),
 		EligibilityCEL:                 req.GetEligibilityCel(),
-		AttributeSchema:                json.RawMessage(req.GetAttributeSchema()),
+		AttributeSchema:                toRawJSON(req.GetAttributeSchema()),
 		Attributes:                     stringMapToAnyMap(req.GetAttributes()),
 	}
 
@@ -707,6 +707,16 @@ func parseConversionMethodPair(idStr string, version int32) (*uuid.UUID, *int, e
 	}
 	v := int(version)
 	return &id, &v, nil
+}
+
+// toRawJSON converts a proto string field to json.RawMessage, returning nil for
+// empty strings so that PostgreSQL jsonb columns receive NULL rather than
+// invalid empty-string JSON.
+func toRawJSON(s string) json.RawMessage {
+	if s == "" {
+		return nil
+	}
+	return json.RawMessage(s)
 }
 
 func stringMapToAnyMap(m map[string]string) map[string]any {


### PR DESCRIPTION
## Summary

- Fix `CreateDraft` and `UpdateDefinition` handlers converting empty proto string to `json.RawMessage("")` which PostgreSQL rejects as invalid JSON syntax for jsonb columns
- Add `toRawJSON` helper that returns nil for empty strings, allowing the DB column to receive NULL

## Context

After PR #1273 fixed the CEL validation expressions, seed-demo still failed with:

```
invalid input syntax for type json (SQLSTATE 22P02)
```

Root cause: `req.GetAttributeSchema()` returns `""` when not set, and `json.RawMessage("")` is not valid JSON for PostgreSQL's jsonb type.

## Test plan

- [x] `go test ./services/reference-data/handler/...` passes
- [ ] CI passes
- [ ] Deploy to demo and verify seed-demo completes