### PR TITLE
fix: handle nil attributes and empty schema in account type handler

### DIFF
--- a/services/reference-data/accounttype/postgres_registry.go
+++ b/services/reference-data/accounttype/postgres_registry.go
@@ -1063,7 +1063,7 @@ func validateSchemaIfPresent(schema json.RawMessage) error {
 // marshalAttributes marshals a map to JSON bytes. Returns nil for nil maps.
 func marshalAttributes(attrs map[string]any) ([]byte, error) {
 	if attrs == nil {
-		return nil, nil
+		return []byte("{}"), nil
 	}
 	b, err := json.Marshal(attrs)
 	if err != nil {

--- a/services/reference-data/handler/account_type_handler.go
+++ b/services/reference-data/handler/account_type_handler.go
@@ -195,7 +195,7 @@ func (s *AccountTypeService) CreateDraft(ctx context.Context, req *pb.CreateDraf
 		ValidationCEL:                  req.GetValidationCel(),
 		BucketingCEL:                   req.GetBucketingCel(),
 		EligibilityCEL:                 req.GetEligibilityCel(),
-		AttributeSchema:                json.RawMessage(req.GetAttributeSchema()),
+		AttributeSchema:                toRawJSON(req.GetAttributeSchema()),
 		Attributes:                     stringMapToAnyMap(req.GetAttributes()),
 		Compiler:                       s.compiler,
 	})
@@ -244,7 +244,7 @@ func (s *AccountTypeService) UpdateDefinition(ctx context.Context, req *pb.Updat
 		ValidationCEL:                  req.GetValidationCel(),
 		BucketingCEL:                   req.GetBucketingCel(),
 		EligibilityCEL:                 req.GetEligibilityCel(),
-		AttributeSchema:                json.RawMessage(req.GetAttributeSchema()),
+		AttributeSchema:                toRawJSON(req.GetAttributeSchema()),
 		Attributes:                     stringMapToAnyMap(req.GetAttributes()),
 	}
 
@@ -707,6 +707,16 @@ func parseConversionMethodPair(idStr string, version int32) (*uuid.UUID, *int, e
 	}
 	v := int(version)
 	return &id, &v, nil
+}
+
+// toRawJSON converts a proto string field to json.RawMessage, returning nil for
+// empty strings so that PostgreSQL jsonb columns receive NULL rather than
+// invalid empty-string JSON.
+func toRawJSON(s string) json.RawMessage {
+	if s == "" {
+		return nil
+	}
+	return json.RawMessage(s)
 }
 
 func stringMapToAnyMap(m map[string]string) map[string]any {


### PR DESCRIPTION
## Summary

- Fix `CreateDraft` and `UpdateDefinition` converting empty proto string to `json.RawMessage("")` (invalid JSON) for `attribute_schema` column — use `toRawJSON()` helper that returns nil for empty strings
- Fix `marshalAttributes` returning nil for nil map, causing NOT NULL violation on `attributes` column — return `[]byte("{}")` instead

## Context

seed-demo product type registration fails with two sequential DB errors:
1. `invalid input syntax for type json` — empty string is not valid jsonb
2. `null value in column "attributes" violates not-null constraint` — nil `[]byte` inserted as NULL

## Test plan

- [x] `go test ./services/reference-data/...` all pass
- [x] `go build ./cmd/meridian/ ./cmd/seed-demo/` succeeds
- [ ] CI passes
- [ ] Deploy to demo, seed-demo completes all steps