### PR TITLE
fix: align party detail and account transaction UI with proto definitions

### DIFF
--- a/frontend/e2e/specs/parties.spec.ts
+++ b/frontend/e2e/specs/parties.spec.ts
@@ -195,8 +195,10 @@ test.describe('Tab switching', () => {
     await switchToTab(page, 'References')
     await expect(page.getByRole('tab', { name: 'References', selected: true })).toBeVisible()
     // ReferencesTab always renders EmptyState when not loading (references-tab.tsx:30)
+    // Scope to tabpanel to avoid matching the tab label itself
     await expect(
-      page.getByText('References').or(page.getByText('No references information available'))
+      page.getByRole('tabpanel').getByRole('heading', { name: 'References' })
+        .or(page.getByRole('tabpanel').getByText('No references information available'))
     ).toBeVisible()
   })
 

--- a/frontend/e2e/specs/parties.spec.ts
+++ b/frontend/e2e/specs/parties.spec.ts
@@ -199,6 +199,7 @@ test.describe('Tab switching', () => {
     await expect(
       page.getByRole('tabpanel').getByRole('heading', { name: 'References' })
         .or(page.getByRole('tabpanel').getByText('No references information available'))
+        .first()
     ).toBeVisible()
   })
 

--- a/frontend/src/pages/accounts/[accountId].tsx
+++ b/frontend/src/pages/accounts/[accountId].tsx
@@ -205,6 +205,28 @@ function DetailField({ label, children }: { label: string; children: React.React
 }
 
 // ---------------------------------------------------------------------------
+// Enum helpers
+// ---------------------------------------------------------------------------
+
+function getDirectionName(direction: unknown): string {
+  if (typeof direction === 'string') return direction
+  if (typeof direction === 'number') {
+    const dirMap: Record<number, string> = { 0: 'UNSPECIFIED', 1: 'DEBIT', 2: 'CREDIT' }
+    return dirMap[direction] ?? String(direction)
+  }
+  return String(direction ?? '')
+}
+
+function getPostingStatusName(status: unknown): string {
+  if (typeof status === 'string') return status
+  if (typeof status === 'number') {
+    const statusMap: Record<number, string> = { 0: 'UNSPECIFIED', 1: 'PENDING', 2: 'POSTED', 3: 'FAILED', 4: 'CANCELLED', 5: 'REVERSED' }
+    return statusMap[status] ?? String(status)
+  }
+  return String(status ?? '')
+}
+
+// ---------------------------------------------------------------------------
 // Transactions (ledger postings for this account)
 // ---------------------------------------------------------------------------
 
@@ -258,16 +280,16 @@ function AccountTransactions({ accountId, instrumentCode }: { accountId: string;
                 {postings.map((p) => (
                   <tr key={p.id} className="border-b last:border-0">
                     <td className="py-2 pr-4">
-                      <StatusBadge status={String(p.postingDirection ?? '')} />
+                      <StatusBadge status={getDirectionName(p.postingDirection)} />
                     </td>
                     <td className="py-2 pr-4 tabular-nums">
                       <MoneyDisplay
-                        amount={p.postingAmount?.amount?.units}
-                        currency={p.postingAmount?.amount?.currencyCode ?? instrumentCode}
+                        amount={p.postingAmount?.units}
+                        currency={p.postingAmount?.currencyCode ?? instrumentCode}
                       />
                     </td>
                     <td className="py-2 pr-4">
-                      <StatusBadge status={String(p.status ?? '')} />
+                      <StatusBadge status={getPostingStatusName(p.status)} />
                     </td>
                     <td className="py-2">
                       <TimeDisplay timestamp={p.createdAt} format="relative" />

--- a/frontend/src/pages/accounts/[accountId].tsx
+++ b/frontend/src/pages/accounts/[accountId].tsx
@@ -217,7 +217,7 @@ function getDirectionName(direction: unknown): string {
   return String(direction ?? '')
 }
 
-function getPostingStatusName(status: unknown): string {
+function getTransactionStatusName(status: unknown): string {
   if (typeof status === 'string') return status
   if (typeof status === 'number') {
     const statusMap: Record<number, string> = { 0: 'UNSPECIFIED', 1: 'PENDING', 2: 'POSTED', 3: 'FAILED', 4: 'CANCELLED', 5: 'REVERSED' }
@@ -289,7 +289,7 @@ function AccountTransactions({ accountId, instrumentCode }: { accountId: string;
                       />
                     </td>
                     <td className="py-2 pr-4">
-                      <StatusBadge status={getPostingStatusName(p.status)} />
+                      <StatusBadge status={getTransactionStatusName(p.status)} />
                     </td>
                     <td className="py-2">
                       <TimeDisplay timestamp={p.createdAt} format="relative" />

--- a/frontend/src/pages/parties/[partyId].test.tsx
+++ b/frontend/src/pages/parties/[partyId].test.tsx
@@ -7,16 +7,19 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 vi.mock('@/api/context', () => ({
   useClients: vi.fn(() => ({
     party: {
-      getParticipant: vi.fn().mockResolvedValue({
-        partyId: 'test-party-1',
-        name: 'Test Party',
-        partyType: 'ORGANIZATION',
-        status: 'ACTIVE',
+      retrieveParty: vi.fn().mockResolvedValue({
+        party: {
+          partyId: 'test-party-1',
+          legalName: 'Test Party',
+          partyType: 'PARTY_TYPE_ORGANIZATION',
+          status: 'PARTY_STATUS_ACTIVE',
+        },
       }),
-      getPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: [] }),
-      getReferences: vi.fn().mockResolvedValue({}),
-      getAssociations: vi.fn().mockResolvedValue({}),
-      getBankRelations: vi.fn().mockResolvedValue({}),
+      listPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: [] }),
+      retrieveReference: vi.fn().mockResolvedValue({}),
+      retrieveAssociations: vi.fn().mockResolvedValue({}),
+      retrieveBankRelations: vi.fn().mockResolvedValue({}),
+      retrieveDemographics: vi.fn().mockResolvedValue(null),
     },
   })),
 }))

--- a/frontend/src/pages/parties/components/party-header.test.tsx
+++ b/frontend/src/pages/parties/components/party-header.test.tsx
@@ -3,12 +3,12 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { PartyHeader } from './party-header'
 
-const mockGetParticipant = vi.fn()
+const mockRetrieveParty = vi.fn()
 
 vi.mock('@/api/context', () => ({
   useClients: vi.fn(() => ({
     party: {
-      getParticipant: mockGetParticipant,
+      retrieveParty: mockRetrieveParty,
     },
   })),
 }))
@@ -33,12 +33,11 @@ function renderPartyHeader(partyId = 'test-party-1') {
 describe('PartyHeader - loading state', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetParticipant.mockReturnValue(new Promise(() => {})) // never resolves
+    mockRetrieveParty.mockReturnValue(new Promise(() => {})) // never resolves
   })
 
   it('renders skeleton placeholders while loading', () => {
     renderPartyHeader()
-    // Skeletons are rendered during loading - check for loading container
     const container = document.querySelector('.space-y-4')
     expect(container).toBeInTheDocument()
   })
@@ -52,183 +51,77 @@ describe('PartyHeader - loading state', () => {
 describe('PartyHeader - error/not found state', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetParticipant.mockResolvedValue(undefined)
+    mockRetrieveParty.mockResolvedValue({ party: undefined })
   })
 
   it('shows "Party not found" when party data is undefined', async () => {
     renderPartyHeader()
-
     await waitFor(() => {
       expect(screen.getByText('Party not found')).toBeInTheDocument()
     })
   })
 })
 
-describe('PartyHeader - INDIVIDUAL party type', () => {
+describe('PartyHeader - PARTY_TYPE_PERSON', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetParticipant.mockResolvedValue({
-      partyId: 'indv-001',
-      name: 'Jane Smith',
-      partyType: 'INDIVIDUAL',
-      status: 'ACTIVE',
+    mockRetrieveParty.mockResolvedValue({
+      party: {
+        partyId: 'indv-001',
+        legalName: 'Jane Smith',
+        partyType: 'PARTY_TYPE_PERSON',
+        status: 'PARTY_STATUS_ACTIVE',
+      },
     })
   })
 
-  it('renders party name', async () => {
+  it('renders party legal name', async () => {
     renderPartyHeader('indv-001')
     await waitFor(() => {
       expect(screen.getByText('Jane Smith')).toBeInTheDocument()
     })
   })
 
-  it('renders INDIVIDUAL party type label', async () => {
+  it('renders party type label', async () => {
     renderPartyHeader('indv-001')
     await waitFor(() => {
-      expect(screen.getByText('INDIVIDUAL')).toBeInTheDocument()
+      expect(screen.getByText('PARTY_TYPE_PERSON')).toBeInTheDocument()
     })
   })
 
-  it('renders ACTIVE status badge', async () => {
+  it('renders status badge', async () => {
     renderPartyHeader('indv-001')
     await waitFor(() => {
-      expect(screen.getByText('ACTIVE')).toBeInTheDocument()
+      expect(screen.getByText(/ACTIVE/)).toBeInTheDocument()
     })
   })
 })
 
-describe('PartyHeader - ORGANIZATION party type', () => {
+describe('PartyHeader - PARTY_TYPE_ORGANIZATION', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetParticipant.mockResolvedValue({
-      partyId: 'org-001',
-      name: 'Acme Corp',
-      partyType: 'ORGANIZATION',
-      status: 'INACTIVE',
+    mockRetrieveParty.mockResolvedValue({
+      party: {
+        partyId: 'org-001',
+        legalName: 'Acme Corp',
+        partyType: 'PARTY_TYPE_ORGANIZATION',
+        status: 'PARTY_STATUS_RESTRICTED',
+      },
     })
   })
 
-  it('renders party name', async () => {
+  it('renders party legal name', async () => {
     renderPartyHeader('org-001')
     await waitFor(() => {
       expect(screen.getByText('Acme Corp')).toBeInTheDocument()
     })
   })
 
-  it('renders ORGANIZATION party type label', async () => {
+  it('renders party type label', async () => {
     renderPartyHeader('org-001')
     await waitFor(() => {
-      expect(screen.getByText('ORGANIZATION')).toBeInTheDocument()
+      expect(screen.getByText('PARTY_TYPE_ORGANIZATION')).toBeInTheDocument()
     })
-  })
-
-  it('renders INACTIVE status badge', async () => {
-    renderPartyHeader('org-001')
-    await waitFor(() => {
-      expect(screen.getByText('INACTIVE')).toBeInTheDocument()
-    })
-  })
-})
-
-describe('PartyHeader - GOVERNMENT party type', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    mockGetParticipant.mockResolvedValue({
-      partyId: 'gov-001',
-      name: 'HM Treasury',
-      partyType: 'GOVERNMENT',
-      status: 'SUSPENDED',
-    })
-  })
-
-  it('renders party name', async () => {
-    renderPartyHeader('gov-001')
-    await waitFor(() => {
-      expect(screen.getByText('HM Treasury')).toBeInTheDocument()
-    })
-  })
-
-  it('renders GOVERNMENT party type label', async () => {
-    renderPartyHeader('gov-001')
-    await waitFor(() => {
-      expect(screen.getByText('GOVERNMENT')).toBeInTheDocument()
-    })
-  })
-
-  it('renders SUSPENDED status badge', async () => {
-    renderPartyHeader('gov-001')
-    await waitFor(() => {
-      expect(screen.getByText('SUSPENDED')).toBeInTheDocument()
-    })
-  })
-})
-
-describe('PartyHeader - status badge variants', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  it('renders PENDING_VERIFICATION status', async () => {
-    mockGetParticipant.mockResolvedValue({
-      partyId: 'party-pv',
-      name: 'Pending Party',
-      partyType: 'INDIVIDUAL',
-      status: 'PENDING_VERIFICATION',
-    })
-    renderPartyHeader('party-pv')
-    await waitFor(() => {
-      // StatusBadge renders the status, which may format underscores as spaces
-      expect(screen.getByText(/pending.?verification/i)).toBeInTheDocument()
-    })
-  })
-})
-
-describe('PartyHeader - verification status', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  it('shows verification status when provided', async () => {
-    mockGetParticipant.mockResolvedValue({
-      partyId: 'party-v',
-      name: 'Verified Party',
-      partyType: 'ORGANIZATION',
-      status: 'ACTIVE',
-      verificationStatus: 'KYC_COMPLETE',
-    })
-    renderPartyHeader('party-v')
-    await waitFor(() => {
-      expect(screen.getByText('Verification: KYC_COMPLETE')).toBeInTheDocument()
-    })
-  })
-
-  it('does not show verification section when verificationStatus is absent', async () => {
-    mockGetParticipant.mockResolvedValue({
-      partyId: 'party-nv',
-      name: 'Unverified Party',
-      partyType: 'INDIVIDUAL',
-      status: 'ACTIVE',
-    })
-    renderPartyHeader('party-nv')
-    await waitFor(() => {
-      expect(screen.getByText('Unverified Party')).toBeInTheDocument()
-    })
-    expect(screen.queryByText(/verification:/i)).not.toBeInTheDocument()
-  })
-
-  it('does not show verification section when verificationStatus is empty string', async () => {
-    mockGetParticipant.mockResolvedValue({
-      partyId: 'party-ev',
-      name: 'Empty Verification',
-      partyType: 'INDIVIDUAL',
-      status: 'ACTIVE',
-      verificationStatus: '',
-    })
-    renderPartyHeader('party-ev')
-    await waitFor(() => {
-      expect(screen.getByText('Empty Verification')).toBeInTheDocument()
-    })
-    expect(screen.queryByText(/verification:/i)).not.toBeInTheDocument()
   })
 })
 
@@ -238,11 +131,13 @@ describe('PartyHeader - party name display', () => {
   })
 
   it('renders party name as heading level 2', async () => {
-    mockGetParticipant.mockResolvedValue({
-      partyId: 'party-h2',
-      name: 'Test Corporation',
-      partyType: 'ORGANIZATION',
-      status: 'ACTIVE',
+    mockRetrieveParty.mockResolvedValue({
+      party: {
+        partyId: 'party-h2',
+        legalName: 'Test Corporation',
+        partyType: 'PARTY_TYPE_ORGANIZATION',
+        status: 'PARTY_STATUS_ACTIVE',
+      },
     })
     renderPartyHeader('party-h2')
     await waitFor(() => {
@@ -251,16 +146,18 @@ describe('PartyHeader - party name display', () => {
     })
   })
 
-  it('calls getParticipant with the correct partyId', async () => {
-    mockGetParticipant.mockResolvedValue({
-      partyId: 'specific-id',
-      name: 'Specific Party',
-      partyType: 'INDIVIDUAL',
-      status: 'ACTIVE',
+  it('calls retrieveParty with the correct partyId', async () => {
+    mockRetrieveParty.mockResolvedValue({
+      party: {
+        partyId: 'specific-id',
+        legalName: 'Specific Party',
+        partyType: 'PARTY_TYPE_PERSON',
+        status: 'PARTY_STATUS_ACTIVE',
+      },
     })
     renderPartyHeader('specific-id')
     await waitFor(() => {
-      expect(mockGetParticipant).toHaveBeenCalledWith({ partyId: 'specific-id' })
+      expect(mockRetrieveParty).toHaveBeenCalledWith({ partyId: 'specific-id' })
     })
   })
 })

--- a/frontend/src/pages/parties/components/party-header.tsx
+++ b/frontend/src/pages/parties/components/party-header.tsx
@@ -8,22 +8,14 @@ interface PartyHeaderProps {
   partyId: string
 }
 
-interface PartyData {
-  partyId: string
-  name: string
-  partyType: 'INDIVIDUAL' | 'ORGANIZATION' | 'GOVERNMENT'
-  status: 'ACTIVE' | 'INACTIVE' | 'SUSPENDED' | 'PENDING_VERIFICATION'
-  verificationStatus?: string
-}
-
 export function PartyHeader({ partyId }: PartyHeaderProps) {
   const clients = useClients()
 
   const { data: party, isLoading } = useQuery({
     queryKey: ['party', partyId],
     queryFn: async () => {
-      const response = await clients.party.getParticipant({ partyId })
-      return response as PartyData
+      const response = await clients.party.retrieveParty({ partyId })
+      return response.party
     },
   })
 
@@ -44,17 +36,12 @@ export function PartyHeader({ partyId }: PartyHeaderProps) {
     <div className="p-6 border-b">
       <div className="flex items-start justify-between">
         <div className="space-y-2">
-          <h2 className="text-2xl font-bold">{party.name}</h2>
+          <h2 className="text-2xl font-bold">{party.legalName}</h2>
           <div className="flex items-center gap-3">
             <span className="text-sm text-muted-foreground">
               {party.partyType}
             </span>
             <StatusBadge status={party.status} />
-            {party.verificationStatus && (
-              <span className="text-sm font-medium">
-                Verification: {party.verificationStatus}
-              </span>
-            )}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/parties/tabs/associations-tab.test.tsx
+++ b/frontend/src/pages/parties/tabs/associations-tab.test.tsx
@@ -28,7 +28,7 @@ function makeQueryClient() {
 }
 
 const mockPartyClient = {
-  getAssociations: vi.fn(),
+  retrieveAssociations: vi.fn(),
   listParties: vi.fn().mockResolvedValue({ parties: [] }),
   registerAssociations: vi.fn(),
 }
@@ -55,7 +55,7 @@ describe('AssociationsTab', () => {
     it('renders skeletons while loading', () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getAssociations: vi.fn(() => new Promise(() => {})),
+          retrieveAssociations: vi.fn(() => new Promise(() => {})),
         },
       } as ReturnType<typeof useClients>)
 
@@ -68,7 +68,7 @@ describe('AssociationsTab', () => {
     it('does not render empty state while loading', () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getAssociations: vi.fn(() => new Promise(() => {})),
+          retrieveAssociations: vi.fn(() => new Promise(() => {})),
         },
       } as ReturnType<typeof useClients>)
 
@@ -82,7 +82,7 @@ describe('AssociationsTab', () => {
     it('renders empty state heading after data loads', async () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getAssociations: vi.fn().mockResolvedValue({}),
+          retrieveAssociations: vi.fn().mockResolvedValue({}),
         },
       } as ReturnType<typeof useClients>)
 
@@ -96,7 +96,7 @@ describe('AssociationsTab', () => {
     it('renders descriptive message', async () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getAssociations: vi.fn().mockResolvedValue({}),
+          retrieveAssociations: vi.fn().mockResolvedValue({}),
         },
       } as ReturnType<typeof useClients>)
 
@@ -110,7 +110,7 @@ describe('AssociationsTab', () => {
     it('renders add association button', async () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getAssociations: vi.fn().mockResolvedValue({}),
+          retrieveAssociations: vi.fn().mockResolvedValue({}),
         },
       } as ReturnType<typeof useClients>)
 
@@ -123,16 +123,16 @@ describe('AssociationsTab', () => {
   })
 
   describe('query key', () => {
-    it('calls getAssociations with the provided partyId', async () => {
-      const getAssociations = vi.fn().mockResolvedValue({})
+    it('calls retrieveAssociations with the provided partyId', async () => {
+      const retrieveAssociations = vi.fn().mockResolvedValue({})
       vi.mocked(useClients).mockReturnValue({
-        party: { getAssociations },
+        party: { retrieveAssociations },
       } as ReturnType<typeof useClients>)
 
       renderTab('party-abc')
 
       await waitFor(() => {
-        expect(getAssociations).toHaveBeenCalledWith({ partyId: 'party-abc' })
+        expect(retrieveAssociations).toHaveBeenCalledWith({ partyId: 'party-abc' })
       })
     })
   })

--- a/frontend/src/pages/parties/tabs/associations-tab.tsx
+++ b/frontend/src/pages/parties/tabs/associations-tab.tsx
@@ -20,7 +20,7 @@ export function AssociationsTab({ partyId }: AssociationsTabProps) {
   const { isLoading } = useQuery({
     queryKey: tenantKeys.partyAssociations(tenantSlug ?? '', partyId),
     queryFn: async () => {
-      return await clients.party.getAssociations({ partyId })
+      return await clients.party.retrieveAssociations({ partyId })
     },
   })
 

--- a/frontend/src/pages/parties/tabs/bank-relations-tab.test.tsx
+++ b/frontend/src/pages/parties/tabs/bank-relations-tab.test.tsx
@@ -34,7 +34,7 @@ describe('BankRelationsTab', () => {
     it('renders skeletons while loading', () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getBankRelations: vi.fn(() => new Promise(() => {})),
+          retrieveBankRelations: vi.fn(() => new Promise(() => {})),
         },
       } as ReturnType<typeof useClients>)
 
@@ -47,7 +47,7 @@ describe('BankRelationsTab', () => {
     it('does not render empty state while loading', () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getBankRelations: vi.fn(() => new Promise(() => {})),
+          retrieveBankRelations: vi.fn(() => new Promise(() => {})),
         },
       } as ReturnType<typeof useClients>)
 
@@ -61,7 +61,7 @@ describe('BankRelationsTab', () => {
     it('renders empty state heading after data loads', async () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getBankRelations: vi.fn().mockResolvedValue({}),
+          retrieveBankRelations: vi.fn().mockResolvedValue({}),
         },
       } as ReturnType<typeof useClients>)
 
@@ -75,7 +75,7 @@ describe('BankRelationsTab', () => {
     it('renders descriptive message', async () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getBankRelations: vi.fn().mockResolvedValue({}),
+          retrieveBankRelations: vi.fn().mockResolvedValue({}),
         },
       } as ReturnType<typeof useClients>)
 
@@ -88,16 +88,16 @@ describe('BankRelationsTab', () => {
   })
 
   describe('query key', () => {
-    it('calls getBankRelations with the provided partyId', async () => {
-      const getBankRelations = vi.fn().mockResolvedValue({})
+    it('calls retrieveBankRelations with the provided partyId', async () => {
+      const retrieveBankRelations = vi.fn().mockResolvedValue({})
       vi.mocked(useClients).mockReturnValue({
-        party: { getBankRelations },
+        party: { retrieveBankRelations },
       } as ReturnType<typeof useClients>)
 
       renderTab('party-xyz')
 
       await waitFor(() => {
-        expect(getBankRelations).toHaveBeenCalledWith({ partyId: 'party-xyz' })
+        expect(retrieveBankRelations).toHaveBeenCalledWith({ partyId: 'party-xyz' })
       })
     })
   })

--- a/frontend/src/pages/parties/tabs/bank-relations-tab.tsx
+++ b/frontend/src/pages/parties/tabs/bank-relations-tab.tsx
@@ -14,7 +14,7 @@ export function BankRelationsTab({ partyId }: BankRelationsTabProps) {
   const { isLoading } = useQuery({
     queryKey: ['party', partyId, 'bank-relations'],
     queryFn: async () => {
-      return await clients.party.getBankRelations({ partyId })
+      return await clients.party.retrieveBankRelations({ partyId })
     },
   })
 

--- a/frontend/src/pages/parties/tabs/demographics-tab.test.tsx
+++ b/frontend/src/pages/parties/tabs/demographics-tab.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TooltipProvider } from '@/components/ui/tooltip'
 
 vi.mock('@/api/context', () => ({
   useClients: vi.fn(),
@@ -22,26 +23,18 @@ function makeQueryClient() {
 function renderTab(partyId = 'party-001') {
   return render(
     <QueryClientProvider client={makeQueryClient()}>
-      <DemographicsTab partyId={partyId} />
+      <TooltipProvider>
+        <DemographicsTab partyId={partyId} />
+      </TooltipProvider>
     </QueryClientProvider>,
   )
 }
 
 const mockDemographics = {
   partyId: 'party-001',
-  email: 'contact@acme.com',
-  phoneNumber: '+44 20 1234 5678',
-  businessName: 'Acme Corp',
-  businessRegistration: 'BRN-12345',
-  legalName: 'Acme Corporation Ltd',
-  nationality: 'GB',
-  taxId: 'TAX-9876',
-  website: 'https://acme.com',
-  streetAddress: '123 Main Street',
-  city: 'London',
-  state: 'England',
-  postalCode: 'SW1A 1AA',
-  country: 'GB',
+  socioEconomicData: 'Middle income bracket',
+  employmentHistory: 'Software Engineer at Acme Corp',
+  updatedAt: { seconds: 1700001000, nanos: 0 },
 }
 
 describe('DemographicsTab', () => {
@@ -53,8 +46,8 @@ describe('DemographicsTab', () => {
     it('renders skeletons while loading', () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getParticipant: vi.fn(() => new Promise(() => {})),
-          updateParticipant: vi.fn(),
+          retrieveDemographics: vi.fn(() => new Promise(() => {})),
+          updateDemographics: vi.fn(),
         },
       } as ReturnType<typeof useClients>)
 
@@ -69,8 +62,8 @@ describe('DemographicsTab', () => {
     it('renders empty state when no demographics data is returned', async () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getParticipant: vi.fn().mockResolvedValue(null),
-          updateParticipant: vi.fn(),
+          retrieveDemographics: vi.fn().mockResolvedValue(null),
+          updateDemographics: vi.fn(),
         },
       } as ReturnType<typeof useClients>)
 
@@ -84,8 +77,8 @@ describe('DemographicsTab', () => {
     it('shows descriptive message in empty state', async () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getParticipant: vi.fn().mockResolvedValue(null),
-          updateParticipant: vi.fn(),
+          retrieveDemographics: vi.fn().mockResolvedValue(null),
+          updateDemographics: vi.fn(),
         },
       } as ReturnType<typeof useClients>)
 
@@ -101,44 +94,23 @@ describe('DemographicsTab', () => {
     beforeEach(() => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getParticipant: vi.fn().mockResolvedValue(mockDemographics),
-          updateParticipant: vi.fn(),
+          retrieveDemographics: vi.fn().mockResolvedValue(mockDemographics),
+          updateDemographics: vi.fn(),
         },
       } as ReturnType<typeof useClients>)
     })
 
-    it('renders email', async () => {
+    it('renders socio-economic data', async () => {
       renderTab()
       await waitFor(() => {
-        expect(screen.getByText('contact@acme.com')).toBeInTheDocument()
+        expect(screen.getByText('Middle income bracket')).toBeInTheDocument()
       })
     })
 
-    it('renders phone number', async () => {
+    it('renders employment history', async () => {
       renderTab()
       await waitFor(() => {
-        expect(screen.getByText('+44 20 1234 5678')).toBeInTheDocument()
-      })
-    })
-
-    it('renders business name', async () => {
-      renderTab()
-      await waitFor(() => {
-        expect(screen.getByText('Acme Corp')).toBeInTheDocument()
-      })
-    })
-
-    it('renders city', async () => {
-      renderTab()
-      await waitFor(() => {
-        expect(screen.getByText('London')).toBeInTheDocument()
-      })
-    })
-
-    it('renders country', async () => {
-      renderTab()
-      await waitFor(() => {
-        expect(screen.getAllByText('GB').length).toBeGreaterThan(0)
+        expect(screen.getByText('Software Engineer at Acme Corp')).toBeInTheDocument()
       })
     })
 
@@ -154,8 +126,8 @@ describe('DemographicsTab', () => {
     beforeEach(() => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getParticipant: vi.fn().mockResolvedValue(mockDemographics),
-          updateParticipant: vi.fn().mockResolvedValue({}),
+          retrieveDemographics: vi.fn().mockResolvedValue(mockDemographics),
+          updateDemographics: vi.fn().mockResolvedValue({}),
         },
       } as ReturnType<typeof useClients>)
     })
@@ -182,8 +154,8 @@ describe('DemographicsTab', () => {
 
       await userEvent.click(screen.getByRole('button', { name: /edit demographics/i }))
 
-      expect(screen.getByPlaceholderText(/email/i)).toBeInTheDocument()
-      expect(screen.getByPlaceholderText(/phone number/i)).toBeInTheDocument()
+      expect(screen.getByPlaceholderText(/socio-economic/i)).toBeInTheDocument()
+      expect(screen.getByPlaceholderText(/employment/i)).toBeInTheDocument()
     })
 
     it('returns to view mode when Cancel is clicked', async () => {
@@ -205,12 +177,12 @@ describe('DemographicsTab', () => {
   })
 
   describe('form submission', () => {
-    it('calls updateParticipant on save', async () => {
-      const updateParticipant = vi.fn().mockResolvedValue({})
+    it('calls updateDemographics on save', async () => {
+      const updateDemographics = vi.fn().mockResolvedValue({})
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getParticipant: vi.fn().mockResolvedValue(mockDemographics),
-          updateParticipant,
+          retrieveDemographics: vi.fn().mockResolvedValue(mockDemographics),
+          updateDemographics,
         },
       } as ReturnType<typeof useClients>)
 
@@ -224,7 +196,7 @@ describe('DemographicsTab', () => {
       await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
 
       await waitFor(() => {
-        expect(updateParticipant).toHaveBeenCalledWith(
+        expect(updateDemographics).toHaveBeenCalledWith(
           expect.objectContaining({ partyId: 'party-001' }),
         )
       })
@@ -233,8 +205,8 @@ describe('DemographicsTab', () => {
     it('returns to view mode on successful save', async () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getParticipant: vi.fn().mockResolvedValue(mockDemographics),
-          updateParticipant: vi.fn().mockResolvedValue({}),
+          retrieveDemographics: vi.fn().mockResolvedValue(mockDemographics),
+          updateDemographics: vi.fn().mockResolvedValue({}),
         },
       } as ReturnType<typeof useClients>)
 
@@ -255,8 +227,8 @@ describe('DemographicsTab', () => {
     it('disables Save button while mutation is pending', async () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getParticipant: vi.fn().mockResolvedValue(mockDemographics),
-          updateParticipant: vi.fn(
+          retrieveDemographics: vi.fn().mockResolvedValue(mockDemographics),
+          updateDemographics: vi.fn(
             () => new Promise((resolve) => setTimeout(resolve, 200)),
           ),
         },

--- a/frontend/src/pages/parties/tabs/demographics-tab.tsx
+++ b/frontend/src/pages/parties/tabs/demographics-tab.tsx
@@ -99,7 +99,10 @@ export function DemographicsTab({ partyId }: DemographicsTabProps) {
             variant="outline"
             onClick={() => {
               setIsEditing(false)
-              reset()
+              reset({
+                socioEconomicData: demographics?.socioEconomicData ?? '',
+                employmentHistory: demographics?.employmentHistory ?? '',
+              })
             }}
           >
             Cancel

--- a/frontend/src/pages/parties/tabs/demographics-tab.tsx
+++ b/frontend/src/pages/parties/tabs/demographics-tab.tsx
@@ -72,8 +72,9 @@ export function DemographicsTab({ partyId }: DemographicsTabProps) {
       <form onSubmit={handleSubmit((data) => void updateMutation.mutateAsync(data))} className="space-y-6">
         <div className="grid gap-6">
           <div>
-            <label className="text-sm font-medium">Socio-Economic Data</label>
+            <label htmlFor="socioEconomicData" className="text-sm font-medium">Socio-Economic Data</label>
             <Input
+              id="socioEconomicData"
               {...register('socioEconomicData')}
               placeholder="Socio-economic classification"
               className="mt-1"
@@ -81,8 +82,9 @@ export function DemographicsTab({ partyId }: DemographicsTabProps) {
           </div>
 
           <div>
-            <label className="text-sm font-medium">Employment History</label>
+            <label htmlFor="employmentHistory" className="text-sm font-medium">Employment History</label>
             <Input
+              id="employmentHistory"
               {...register('employmentHistory')}
               placeholder="Employment information"
               className="mt-1"

--- a/frontend/src/pages/parties/tabs/demographics-tab.tsx
+++ b/frontend/src/pages/parties/tabs/demographics-tab.tsx
@@ -5,44 +5,16 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { TimeDisplay } from '@/components/shared/time-display'
 import { useForm } from 'react-hook-form'
 
 interface DemographicsTabProps {
   partyId: string
 }
 
-interface Demographics {
-  partyId: string
-  email?: string
-  phoneNumber?: string
-  businessName?: string
-  businessRegistration?: string
-  legalName?: string
-  dateOfBirth?: { seconds: bigint | number; nanos?: number }
-  nationality?: string
-  taxId?: string
-  website?: string
-  streetAddress?: string
-  city?: string
-  state?: string
-  postalCode?: string
-  country?: string
-}
-
 interface DemographicsFormData {
-  email?: string
-  phoneNumber?: string
-  businessName?: string
-  businessRegistration?: string
-  legalName?: string
-  nationality?: string
-  taxId?: string
-  website?: string
-  streetAddress?: string
-  city?: string
-  state?: string
-  postalCode?: string
-  country?: string
+  socioEconomicData: string
+  employmentHistory: string
 }
 
 export function DemographicsTab({ partyId }: DemographicsTabProps) {
@@ -54,16 +26,16 @@ export function DemographicsTab({ partyId }: DemographicsTabProps) {
   const { data: demographics, isLoading } = useQuery({
     queryKey: ['party', partyId, 'demographics'],
     queryFn: async () => {
-      const response = await clients.party.getParticipant({ partyId })
-      return response as Demographics
+      return await clients.party.retrieveDemographics({ partyId })
     },
   })
 
   const updateMutation = useMutation({
     mutationFn: async (data: DemographicsFormData) => {
-      return await clients.party.updateParticipant({
+      return await clients.party.updateDemographics({
         partyId,
-        ...data,
+        socioEconomicData: data.socioEconomicData,
+        employmentHistory: data.employmentHistory,
       })
     },
     onSuccess: () => {
@@ -74,7 +46,10 @@ export function DemographicsTab({ partyId }: DemographicsTabProps) {
 
   React.useEffect(() => {
     if (demographics) {
-      reset(demographics)
+      reset({
+        socioEconomicData: demographics.socioEconomicData ?? '',
+        employmentHistory: demographics.employmentHistory ?? '',
+      })
     }
   }, [demographics, reset])
 
@@ -95,120 +70,21 @@ export function DemographicsTab({ partyId }: DemographicsTabProps) {
   if (isEditing) {
     return (
       <form onSubmit={handleSubmit((data) => void updateMutation.mutateAsync(data))} className="space-y-6">
-        <div className="grid gap-6 md:grid-cols-2">
+        <div className="grid gap-6">
           <div>
-            <label className="text-sm font-medium">Email</label>
+            <label className="text-sm font-medium">Socio-Economic Data</label>
             <Input
-              {...register('email')}
-              placeholder="Email"
+              {...register('socioEconomicData')}
+              placeholder="Socio-economic classification"
               className="mt-1"
             />
           </div>
 
           <div>
-            <label className="text-sm font-medium">Phone Number</label>
+            <label className="text-sm font-medium">Employment History</label>
             <Input
-              {...register('phoneNumber')}
-              placeholder="Phone Number"
-              className="mt-1"
-            />
-          </div>
-
-          <div>
-            <label className="text-sm font-medium">Business Name</label>
-            <Input
-              {...register('businessName')}
-              placeholder="Business Name"
-              className="mt-1"
-            />
-          </div>
-
-          <div>
-            <label className="text-sm font-medium">Business Registration</label>
-            <Input
-              {...register('businessRegistration')}
-              placeholder="Business Registration"
-              className="mt-1"
-            />
-          </div>
-
-          <div>
-            <label className="text-sm font-medium">Legal Name</label>
-            <Input
-              {...register('legalName')}
-              placeholder="Legal Name"
-              className="mt-1"
-            />
-          </div>
-
-          <div>
-            <label className="text-sm font-medium">Nationality</label>
-            <Input
-              {...register('nationality')}
-              placeholder="Nationality"
-              className="mt-1"
-            />
-          </div>
-
-          <div>
-            <label className="text-sm font-medium">Tax ID</label>
-            <Input
-              {...register('taxId')}
-              placeholder="Tax ID"
-              className="mt-1"
-            />
-          </div>
-
-          <div>
-            <label className="text-sm font-medium">Website</label>
-            <Input
-              {...register('website')}
-              placeholder="Website"
-              className="mt-1"
-            />
-          </div>
-
-          <div className="md:col-span-2">
-            <label className="text-sm font-medium">Street Address</label>
-            <Input
-              {...register('streetAddress')}
-              placeholder="Street Address"
-              className="mt-1"
-            />
-          </div>
-
-          <div>
-            <label className="text-sm font-medium">City</label>
-            <Input
-              {...register('city')}
-              placeholder="City"
-              className="mt-1"
-            />
-          </div>
-
-          <div>
-            <label className="text-sm font-medium">State/Province</label>
-            <Input
-              {...register('state')}
-              placeholder="State/Province"
-              className="mt-1"
-            />
-          </div>
-
-          <div>
-            <label className="text-sm font-medium">Postal Code</label>
-            <Input
-              {...register('postalCode')}
-              placeholder="Postal Code"
-              className="mt-1"
-            />
-          </div>
-
-          <div>
-            <label className="text-sm font-medium">Country</label>
-            <Input
-              {...register('country')}
-              placeholder="Country"
+              {...register('employmentHistory')}
+              placeholder="Employment information"
               className="mt-1"
             />
           </div>
@@ -235,23 +111,13 @@ export function DemographicsTab({ partyId }: DemographicsTabProps) {
 
   return (
     <div className="space-y-6">
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className="grid gap-4">
         {[
-          { label: 'Email', value: demographics.email },
-          { label: 'Phone Number', value: demographics.phoneNumber },
-          { label: 'Business Name', value: demographics.businessName },
-          { label: 'Business Registration', value: demographics.businessRegistration },
-          { label: 'Legal Name', value: demographics.legalName },
-          { label: 'Nationality', value: demographics.nationality },
-          { label: 'Tax ID', value: demographics.taxId },
-          { label: 'Website', value: demographics.website },
-          { label: 'Street Address', value: demographics.streetAddress, fullWidth: true },
-          { label: 'City', value: demographics.city },
-          { label: 'State/Province', value: demographics.state },
-          { label: 'Postal Code', value: demographics.postalCode },
-          { label: 'Country', value: demographics.country },
-        ].map(({ label, value, fullWidth }) => (
-          <div key={label} className={fullWidth ? 'md:col-span-2' : ''}>
+          { label: 'Socio-Economic Data', value: demographics.socioEconomicData },
+          { label: 'Employment History', value: demographics.employmentHistory },
+          { label: 'Last Updated', value: demographics.updatedAt ? <TimeDisplay timestamp={demographics.updatedAt} /> : undefined },
+        ].map(({ label, value }) => (
+          <div key={label}>
             <span className="text-sm font-medium text-muted-foreground">{label}</span>
             <p className="mt-1 text-sm">{value || '—'}</p>
           </div>

--- a/frontend/src/pages/parties/tabs/overview-tab.test.tsx
+++ b/frontend/src/pages/parties/tabs/overview-tab.test.tsx
@@ -30,11 +30,11 @@ function renderTab(partyId = 'party-001') {
 
 const mockParty = {
   partyId: 'party-001',
-  name: 'Acme Corp',
-  partyType: 'ORGANIZATION',
-  status: 'ACTIVE',
+  legalName: 'Acme Corp',
+  displayName: 'Acme',
+  partyType: 'PARTY_TYPE_ORGANIZATION',
+  status: 'PARTY_STATUS_ACTIVE',
   externalReference: 'EXT-123',
-  verificationStatus: 'VERIFIED',
   createdAt: { seconds: 1700000000, nanos: 0 },
   updatedAt: { seconds: 1700001000, nanos: 0 },
 }
@@ -48,7 +48,7 @@ describe('OverviewTab', () => {
     it('renders skeletons while loading', () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getParticipant: vi.fn(() => new Promise(() => {})),
+          retrieveParty: vi.fn(() => new Promise(() => {})),
         },
       } as ReturnType<typeof useClients>)
 
@@ -63,7 +63,7 @@ describe('OverviewTab', () => {
     it('renders empty state when no party data is returned', async () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getParticipant: vi.fn().mockResolvedValue(null),
+          retrieveParty: vi.fn().mockResolvedValue({ party: undefined }),
         },
       } as ReturnType<typeof useClients>)
 
@@ -77,7 +77,7 @@ describe('OverviewTab', () => {
     it('shows descriptive message in empty state', async () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getParticipant: vi.fn().mockResolvedValue(null),
+          retrieveParty: vi.fn().mockResolvedValue({ party: undefined }),
         },
       } as ReturnType<typeof useClients>)
 
@@ -93,7 +93,7 @@ describe('OverviewTab', () => {
     beforeEach(() => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getParticipant: vi.fn().mockResolvedValue(mockParty),
+          retrieveParty: vi.fn().mockResolvedValue({ party: mockParty }),
         },
       } as ReturnType<typeof useClients>)
     })
@@ -105,7 +105,7 @@ describe('OverviewTab', () => {
       })
     })
 
-    it('renders party name', async () => {
+    it('renders party legal name', async () => {
       renderTab()
       await waitFor(() => {
         expect(screen.getByText('Acme Corp')).toBeInTheDocument()
@@ -115,14 +115,14 @@ describe('OverviewTab', () => {
     it('renders party type', async () => {
       renderTab()
       await waitFor(() => {
-        expect(screen.getByText('ORGANIZATION')).toBeInTheDocument()
+        expect(screen.getByText('PARTY_TYPE_ORGANIZATION')).toBeInTheDocument()
       })
     })
 
     it('renders party status', async () => {
       renderTab()
       await waitFor(() => {
-        expect(screen.getByText('ACTIVE')).toBeInTheDocument()
+        expect(screen.getByText('PARTY_STATUS_ACTIVE')).toBeInTheDocument()
       })
     })
 
@@ -133,17 +133,16 @@ describe('OverviewTab', () => {
       })
     })
 
-    it('renders verification status', async () => {
+    it('renders display name', async () => {
       renderTab()
       await waitFor(() => {
-        expect(screen.getByText('VERIFIED')).toBeInTheDocument()
+        expect(screen.getByText('Acme')).toBeInTheDocument()
       })
     })
 
     it('renders TimeDisplay for createdAt timestamp', async () => {
       renderTab()
       await waitFor(() => {
-        // TimeDisplay renders a time representation; just verify the Created label is present
         expect(screen.getByText('Created')).toBeInTheDocument()
       })
     })
@@ -160,11 +159,13 @@ describe('OverviewTab', () => {
     it('renders em dash for missing externalReference', async () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getParticipant: vi.fn().mockResolvedValue({
-            partyId: 'party-001',
-            name: 'Acme Corp',
-            partyType: 'ORGANIZATION',
-            status: 'ACTIVE',
+          retrieveParty: vi.fn().mockResolvedValue({
+            party: {
+              partyId: 'party-001',
+              legalName: 'Acme Corp',
+              partyType: 'PARTY_TYPE_ORGANIZATION',
+              status: 'PARTY_STATUS_ACTIVE',
+            },
           }),
         },
       } as ReturnType<typeof useClients>)
@@ -178,18 +179,20 @@ describe('OverviewTab', () => {
     it('renders em dash for missing timestamps', async () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getParticipant: vi.fn().mockResolvedValue({
-            partyId: 'party-001',
-            name: 'Acme Corp',
-            partyType: 'ORGANIZATION',
-            status: 'ACTIVE',
+          retrieveParty: vi.fn().mockResolvedValue({
+            party: {
+              partyId: 'party-001',
+              legalName: 'Acme Corp',
+              partyType: 'PARTY_TYPE_ORGANIZATION',
+              status: 'PARTY_STATUS_ACTIVE',
+            },
           }),
         },
       } as ReturnType<typeof useClients>)
 
       const { getAllByText } = renderTab()
       await waitFor(() => {
-        // 4 dashes: externalReference, verificationStatus, createdAt, updatedAt
+        // 4 dashes: displayName, externalReference, createdAt, updatedAt
         expect(getAllByText('—').length).toBeGreaterThanOrEqual(4)
       })
     })

--- a/frontend/src/pages/parties/tabs/overview-tab.tsx
+++ b/frontend/src/pages/parties/tabs/overview-tab.tsx
@@ -9,25 +9,14 @@ interface OverviewTabProps {
   partyId: string
 }
 
-interface PartyOverview {
-  partyId: string
-  name: string
-  partyType: string
-  status: string
-  externalReference?: string
-  createdAt?: { seconds: bigint | number; nanos?: number }
-  updatedAt?: { seconds: bigint | number; nanos?: number }
-  verificationStatus?: string
-}
-
 export function OverviewTab({ partyId }: OverviewTabProps) {
   const clients = useClients()
 
   const { data: party, isLoading } = useQuery({
     queryKey: ['party', partyId, 'overview'],
     queryFn: async () => {
-      const response = await clients.party.getParticipant({ partyId })
-      return response as PartyOverview
+      const response = await clients.party.retrieveParty({ partyId })
+      return response.party
     },
   })
 
@@ -47,11 +36,11 @@ export function OverviewTab({ partyId }: OverviewTabProps) {
 
   const infoRows = [
     { label: 'Party ID', value: party.partyId },
-    { label: 'Name', value: party.name },
+    { label: 'Legal Name', value: party.legalName },
+    { label: 'Display Name', value: party.displayName || '—' },
     { label: 'Type', value: party.partyType },
     { label: 'Status', value: party.status },
     { label: 'External Reference', value: party.externalReference || '—' },
-    { label: 'Verification Status', value: party.verificationStatus || '—' },
     { label: 'Created', value: party.createdAt ? <TimeDisplay timestamp={party.createdAt} /> : '—' },
     { label: 'Updated', value: party.updatedAt ? <TimeDisplay timestamp={party.updatedAt} /> : '—' },
   ]

--- a/frontend/src/pages/parties/tabs/payment-methods-tab.test.tsx
+++ b/frontend/src/pages/parties/tabs/payment-methods-tab.test.tsx
@@ -29,18 +29,19 @@ function renderTab(partyId = 'party-001') {
 
 const mockPaymentMethods = [
   {
-    paymentMethodId: 'pm-001',
-    type: 'BANK_ACCOUNT',
-    accountNumber: '12345678',
-    routingNumber: '021000021',
-    accountHolderName: 'Acme Corp',
+    id: 'pm-001',
+    provider: 1,
+    providerCustomerId: 'cus_acme',
+    providerMethodId: 'pm_visa_1234',
+    methodType: 1,
     isDefault: true,
   },
   {
-    paymentMethodId: 'pm-002',
-    type: 'CARD',
-    accountNumber: '4111111111111234',
-    accountHolderName: 'John Doe',
+    id: 'pm-002',
+    provider: 1,
+    providerCustomerId: 'cus_doe',
+    providerMethodId: 'pm_mc_5678',
+    methodType: 2,
     isDefault: false,
   },
 ]
@@ -54,7 +55,7 @@ describe('PaymentMethodsTab', () => {
     it('renders skeletons while loading', () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getPaymentMethods: vi.fn(() => new Promise(() => {})),
+          listPaymentMethods: vi.fn(() => new Promise(() => {})),
           addPaymentMethod: vi.fn(),
           removePaymentMethod: vi.fn(),
           setDefaultPaymentMethod: vi.fn(),
@@ -72,7 +73,7 @@ describe('PaymentMethodsTab', () => {
     beforeEach(() => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: [] }),
+          listPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: [] }),
           addPaymentMethod: vi.fn(),
           removePaymentMethod: vi.fn(),
           setDefaultPaymentMethod: vi.fn(),
@@ -99,7 +100,7 @@ describe('PaymentMethodsTab', () => {
     beforeEach(() => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: mockPaymentMethods }),
+          listPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: mockPaymentMethods }),
           addPaymentMethod: vi.fn(),
           removePaymentMethod: vi.fn(),
           setDefaultPaymentMethod: vi.fn(),
@@ -110,8 +111,8 @@ describe('PaymentMethodsTab', () => {
     it('renders all payment methods', async () => {
       renderTab()
       await waitFor(() => {
-        expect(screen.getByText('Acme Corp')).toBeInTheDocument()
-        expect(screen.getByText('John Doe')).toBeInTheDocument()
+        expect(screen.getByText('pm_visa_1234')).toBeInTheDocument()
+        expect(screen.getByText('pm_mc_5678')).toBeInTheDocument()
       })
     })
 
@@ -122,24 +123,10 @@ describe('PaymentMethodsTab', () => {
       })
     })
 
-    it('shows masked account number', async () => {
+    it('shows provider customer ID', async () => {
       renderTab()
       await waitFor(() => {
-        expect(screen.getByText(/••••5678/)).toBeInTheDocument()
-      })
-    })
-
-    it('shows payment method type', async () => {
-      renderTab()
-      await waitFor(() => {
-        expect(screen.getByText(/BANK_ACCOUNT/)).toBeInTheDocument()
-      })
-    })
-
-    it('shows routing number when present', async () => {
-      renderTab()
-      await waitFor(() => {
-        expect(screen.getByText(/021000021/)).toBeInTheDocument()
+        expect(screen.getByText(/cus_acme/)).toBeInTheDocument()
       })
     })
 
@@ -155,7 +142,6 @@ describe('PaymentMethodsTab', () => {
       renderTab()
       await waitFor(() => {
         const setDefaultButtons = screen.getAllByRole('button', { name: /set default/i })
-        // Only the non-default method gets "Set Default"
         expect(setDefaultButtons).toHaveLength(1)
       })
     })
@@ -163,9 +149,8 @@ describe('PaymentMethodsTab', () => {
     it('does not render Set Default for already-default method', async () => {
       renderTab()
       await waitFor(() => {
-        expect(screen.getByText('Acme Corp')).toBeInTheDocument()
+        expect(screen.getByText('pm_visa_1234')).toBeInTheDocument()
       })
-      // The default method (Acme Corp, pm-001) should NOT have Set Default
       const setDefaultButtons = screen.getAllByRole('button', { name: /set default/i })
       expect(setDefaultButtons).toHaveLength(1)
     })
@@ -175,7 +160,7 @@ describe('PaymentMethodsTab', () => {
     beforeEach(() => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: [] }),
+          listPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: [] }),
           addPaymentMethod: vi.fn().mockResolvedValue({}),
           removePaymentMethod: vi.fn(),
           setDefaultPaymentMethod: vi.fn(),
@@ -210,8 +195,8 @@ describe('PaymentMethodsTab', () => {
         expect(screen.getByRole('dialog')).toBeInTheDocument()
       })
 
-      expect(screen.getByPlaceholderText(/account number/i)).toBeInTheDocument()
-      expect(screen.getByPlaceholderText(/routing number/i)).toBeInTheDocument()
+      expect(screen.getByPlaceholderText(/cus_/i)).toBeInTheDocument()
+      expect(screen.getByPlaceholderText(/pm_/i)).toBeInTheDocument()
     })
 
     it('closes dialog when Cancel is clicked in dialog', async () => {
@@ -238,7 +223,7 @@ describe('PaymentMethodsTab', () => {
       const addPaymentMethod = vi.fn().mockResolvedValue({})
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: [] }),
+          listPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: [] }),
           addPaymentMethod,
           removePaymentMethod: vi.fn(),
           setDefaultPaymentMethod: vi.fn(),
@@ -257,9 +242,8 @@ describe('PaymentMethodsTab', () => {
         expect(screen.getByRole('dialog')).toBeInTheDocument()
       })
 
-      // Select a type (required field)
-      await userEvent.selectOptions(screen.getByRole('combobox'), 'BANK_ACCOUNT')
-      await userEvent.type(screen.getByPlaceholderText(/account number/i), '987654321')
+      await userEvent.type(screen.getByPlaceholderText(/cus_/i), 'cus_new')
+      await userEvent.type(screen.getByPlaceholderText(/pm_/i), 'pm_new')
       await userEvent.click(screen.getByRole('button', { name: /^add$/i }))
 
       await waitFor(() => {
@@ -273,7 +257,7 @@ describe('PaymentMethodsTab', () => {
       const removePaymentMethod = vi.fn().mockResolvedValue({})
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: mockPaymentMethods }),
+          listPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: mockPaymentMethods }),
           addPaymentMethod: vi.fn(),
           removePaymentMethod,
           setDefaultPaymentMethod: vi.fn(),
@@ -301,7 +285,7 @@ describe('PaymentMethodsTab', () => {
       const setDefaultPaymentMethod = vi.fn().mockResolvedValue({})
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: mockPaymentMethods }),
+          listPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: mockPaymentMethods }),
           addPaymentMethod: vi.fn(),
           removePaymentMethod: vi.fn(),
           setDefaultPaymentMethod,

--- a/frontend/src/pages/parties/tabs/payment-methods-tab.tsx
+++ b/frontend/src/pages/parties/tabs/payment-methods-tab.tsx
@@ -14,23 +14,17 @@ interface PaymentMethodsTabProps {
 }
 
 interface PaymentMethod {
-  paymentMethodId: string
-  type: string
-  accountNumber: string
-  routingNumber?: string
-  accountHolderName?: string
+  id: string
+  provider: number
+  providerCustomerId: string
+  providerMethodId: string
+  methodType: number
   isDefault: boolean
 }
 
-interface PaymentMethodsResponse {
-  paymentMethods: PaymentMethod[]
-}
-
 interface AddPaymentMethodFormData {
-  type: string
-  accountNumber: string
-  routingNumber?: string
-  accountHolderName?: string
+  providerCustomerId: string
+  providerMethodId: string
 }
 
 export function PaymentMethodsTab({ partyId }: PaymentMethodsTabProps) {
@@ -42,16 +36,17 @@ export function PaymentMethodsTab({ partyId }: PaymentMethodsTabProps) {
   const { data, isLoading } = useQuery({
     queryKey: ['party', partyId, 'payment-methods'],
     queryFn: async () => {
-      const response = await clients.party.getPaymentMethods({ partyId })
-      return response as PaymentMethodsResponse
+      return await clients.party.listPaymentMethods({ partyId })
     },
   })
 
   const addMutation = useMutation({
-    mutationFn: async (paymentMethod: AddPaymentMethodFormData) => {
+    mutationFn: async (data: AddPaymentMethodFormData) => {
       return await clients.party.addPaymentMethod({
         partyId,
-        ...paymentMethod,
+        provider: 1,
+        providerCustomerId: data.providerCustomerId,
+        providerMethodId: data.providerMethodId,
       })
     },
     onSuccess: () => {
@@ -62,10 +57,10 @@ export function PaymentMethodsTab({ partyId }: PaymentMethodsTabProps) {
   })
 
   const removeMutation = useMutation({
-    mutationFn: async (paymentMethodId: string) => {
+    mutationFn: async (id: string) => {
       return await clients.party.removePaymentMethod({
         partyId,
-        paymentMethodId,
+        paymentMethodId: id,
       })
     },
     onSuccess: () => {
@@ -74,10 +69,10 @@ export function PaymentMethodsTab({ partyId }: PaymentMethodsTabProps) {
   })
 
   const setDefaultMutation = useMutation({
-    mutationFn: async (paymentMethodId: string) => {
+    mutationFn: async (id: string) => {
       return await clients.party.setDefaultPaymentMethod({
         partyId,
-        paymentMethodId,
+        paymentMethodId: id,
       })
     },
     onSuccess: () => {
@@ -110,41 +105,19 @@ export function PaymentMethodsTab({ partyId }: PaymentMethodsTabProps) {
             </DialogHeader>
             <form onSubmit={handleSubmit((data) => void addMutation.mutateAsync(data))} className="space-y-4">
               <div>
-                <label className="text-sm font-medium">Type</label>
-                <select
-                  {...register('type', { required: true })}
-                  className="mt-1 h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
-                >
-                  <option value="">Select Type</option>
-                  <option value="BANK_ACCOUNT">Bank Account</option>
-                  <option value="CARD">Card</option>
-                  <option value="WALLET">Wallet</option>
-                </select>
-              </div>
-
-              <div>
-                <label className="text-sm font-medium">Account Number</label>
+                <label className="text-sm font-medium">Provider Customer ID</label>
                 <Input
-                  {...register('accountNumber', { required: true })}
-                  placeholder="Account Number"
+                  {...register('providerCustomerId', { required: true })}
+                  placeholder="e.g. cus_xxx"
                   className="mt-1"
                 />
               </div>
 
               <div>
-                <label className="text-sm font-medium">Routing Number (optional)</label>
+                <label className="text-sm font-medium">Provider Method ID</label>
                 <Input
-                  {...register('routingNumber')}
-                  placeholder="Routing Number"
-                  className="mt-1"
-                />
-              </div>
-
-              <div>
-                <label className="text-sm font-medium">Account Holder Name</label>
-                <Input
-                  {...register('accountHolderName')}
-                  placeholder="Account Holder Name"
+                  {...register('providerMethodId', { required: true })}
+                  placeholder="e.g. pm_xxx"
                   className="mt-1"
                 />
               </div>
@@ -174,11 +147,11 @@ export function PaymentMethodsTab({ partyId }: PaymentMethodsTabProps) {
       ) : (
         <div className="space-y-4">
           {paymentMethods.map((method) => (
-            <Card key={method.paymentMethodId} className="p-4">
+            <Card key={method.id} className="p-4">
               <div className="flex items-start justify-between">
                 <div className="space-y-2">
                   <div className="flex items-center gap-2">
-                    <span className="font-medium">{method.accountHolderName || 'Unnamed'}</span>
+                    <span className="font-medium font-mono text-sm">{method.providerMethodId}</span>
                     {method.isDefault && (
                       <span className="inline-block rounded bg-blue-100 px-2 py-1 text-xs font-medium text-blue-700">
                         Default
@@ -186,13 +159,8 @@ export function PaymentMethodsTab({ partyId }: PaymentMethodsTabProps) {
                     )}
                   </div>
                   <p className="text-sm text-muted-foreground">
-                    {method.type}: ••••{method.accountNumber.slice(-4)}
+                    Customer: {method.providerCustomerId}
                   </p>
-                  {method.routingNumber && (
-                    <p className="text-xs text-muted-foreground">
-                      Routing: {method.routingNumber}
-                    </p>
-                  )}
                 </div>
 
                 <div className="flex gap-2">
@@ -200,7 +168,7 @@ export function PaymentMethodsTab({ partyId }: PaymentMethodsTabProps) {
                     <Button
                       size="sm"
                       variant="outline"
-                      onClick={() => void setDefaultMutation.mutateAsync(method.paymentMethodId)}
+                      onClick={() => void setDefaultMutation.mutateAsync(method.id)}
                       disabled={setDefaultMutation.isPending}
                     >
                       Set Default
@@ -209,7 +177,7 @@ export function PaymentMethodsTab({ partyId }: PaymentMethodsTabProps) {
                   <Button
                     size="sm"
                     variant="destructive"
-                    onClick={() => void removeMutation.mutateAsync(method.paymentMethodId)}
+                    onClick={() => void removeMutation.mutateAsync(method.id)}
                     disabled={removeMutation.isPending}
                   >
                     Remove

--- a/frontend/src/pages/parties/tabs/payment-methods-tab.tsx
+++ b/frontend/src/pages/parties/tabs/payment-methods-tab.tsx
@@ -13,15 +13,6 @@ interface PaymentMethodsTabProps {
   partyId: string
 }
 
-interface PaymentMethod {
-  id: string
-  provider: number
-  providerCustomerId: string
-  providerMethodId: string
-  methodType: number
-  isDefault: boolean
-}
-
 interface AddPaymentMethodFormData {
   providerCustomerId: string
   providerMethodId: string

--- a/frontend/src/pages/parties/tabs/references-tab.test.tsx
+++ b/frontend/src/pages/parties/tabs/references-tab.test.tsx
@@ -34,7 +34,7 @@ describe('ReferencesTab', () => {
     it('renders skeletons while loading', () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getReferences: vi.fn(() => new Promise(() => {})),
+          retrieveReference: vi.fn(() => new Promise(() => {})),
         },
       } as ReturnType<typeof useClients>)
 
@@ -47,7 +47,7 @@ describe('ReferencesTab', () => {
     it('does not render empty state while loading', () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getReferences: vi.fn(() => new Promise(() => {})),
+          retrieveReference: vi.fn(() => new Promise(() => {})),
         },
       } as ReturnType<typeof useClients>)
 
@@ -61,7 +61,7 @@ describe('ReferencesTab', () => {
     it('renders empty state heading after data loads', async () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getReferences: vi.fn().mockResolvedValue({}),
+          retrieveReference: vi.fn().mockResolvedValue({}),
         },
       } as ReturnType<typeof useClients>)
 
@@ -75,7 +75,7 @@ describe('ReferencesTab', () => {
     it('renders descriptive message', async () => {
       vi.mocked(useClients).mockReturnValue({
         party: {
-          getReferences: vi.fn().mockResolvedValue({}),
+          retrieveReference: vi.fn().mockResolvedValue({}),
         },
       } as ReturnType<typeof useClients>)
 
@@ -88,16 +88,16 @@ describe('ReferencesTab', () => {
   })
 
   describe('query key', () => {
-    it('calls getReferences with the provided partyId', async () => {
-      const getReferences = vi.fn().mockResolvedValue({})
+    it('calls retrieveReference with the provided partyId', async () => {
+      const retrieveReference = vi.fn().mockResolvedValue({})
       vi.mocked(useClients).mockReturnValue({
-        party: { getReferences },
+        party: { retrieveReference },
       } as ReturnType<typeof useClients>)
 
       renderTab('party-xyz')
 
       await waitFor(() => {
-        expect(getReferences).toHaveBeenCalledWith({ partyId: 'party-xyz' })
+        expect(retrieveReference).toHaveBeenCalledWith({ partyId: 'party-xyz' })
       })
     })
   })

--- a/frontend/src/pages/parties/tabs/references-tab.tsx
+++ b/frontend/src/pages/parties/tabs/references-tab.tsx
@@ -14,7 +14,7 @@ export function ReferencesTab({ partyId }: ReferencesTabProps) {
   const { isLoading } = useQuery({
     queryKey: ['party', partyId, 'references'],
     queryFn: async () => {
-      return await clients.party.getReferences({ partyId })
+      return await clients.party.retrieveReference({ partyId })
     },
   })
 


### PR DESCRIPTION
## Summary

- Fixed all 7 party detail tab components calling non-existent RPC methods (`getParticipant`, `updateParticipant`, `getReferences`, `getAssociations`, `getBankRelations`, `getPaymentMethods`) — replaced with correct proto-generated methods (`retrieveParty`, `retrieveDemographics`, `retrieveReference`, `retrieveAssociations`, `retrieveBankRelations`, `listPaymentMethods`)
- Fixed party field mappings: `name` → `legalName`, flat response → `response.party` wrapper, removed non-existent `verificationStatus`, added `displayName`
- Fixed account transactions rendering raw enum integers (e.g. `2` instead of `CREDIT`) by adding enum-to-label helpers
- Fixed account transaction amount field access: `postingAmount?.amount?.units` → `postingAmount?.units`

## Test plan

- [x] All 148 party-related tests pass (13 test files)
- [ ] Verify party detail page loads without crash on demo
- [ ] Verify account transaction enums display as labels
- [ ] Verify demographics edit/save workflow functions correctly