### PR TITLE
Remove basic auth from demo Caddyfile

### DIFF
--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -7,16 +7,6 @@
 demo.meridianhub.cloud, *.demo.meridianhub.cloud {
 	tls /etc/caddy/certs/origin-cert.pem /etc/caddy/certs/origin-key.pem
 
-	# Protect the demo site with HTTP basic auth, excluding specific paths.
-	# MCP clients authenticate via Bearer tokens (when OAuth is enabled),
-	# not HTTP basic auth.
-	@protected {
-		not path /healthz /readyz /mcp /mcp/* /sse /sse/* /message /message/* /.well-known/*
-	}
-	basicauth @protected {
-		demo $2a$14$xfFb2xnq6vOhKOEh7TTgTula3G.F6MxoT7DawQLGBPziCgjTcWCrS
-	}
-
 	# Health/readiness probes (used by Docker and load balancers)
 	handle /healthz {
 		reverse_proxy meridian:8090


### PR DESCRIPTION
## Summary
- Removes HTTP basic auth from the demo Caddyfile that was blocking MCP clients from connecting
- Every deploy re-copies `deploy/demo/Caddyfile` to the droplet (line 156-165 in deploy workflow), which re-enables basic auth even after manual removal

## Context
- Demo is behind Cloudflare (IP not publicly exposed)
- Dex OIDC handles real authentication
- Basic auth interferes with MCP client connections (Claude Desktop, Claude Code) which don't send basic auth credentials

## Test plan
- [ ] Verify `https://demo.meridianhub.cloud/` loads without auth prompt
- [ ] Verify `curl -X POST https://demo.meridianhub.cloud/mcp` returns JSON-RPC response
- [ ] Verify MCP tools work from Claude Code