### PR TITLE
fix: add REST transcoding paths to Caddy API route matcher

### DIFF
--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -35,9 +35,9 @@ demo.meridianhub.cloud, *.demo.meridianhub.cloud {
 		reverse_proxy dex:5556
 	}
 
-	# API: ConnectRPC + version
+	# API: REST transcoding + ConnectRPC + version
 	@api {
-		path /meridian.* /grpc.* /version
+		path /v1/* /meridian.* /grpc.* /version
 	}
 	handle @api {
 		reverse_proxy meridian:8090


### PR DESCRIPTION
## Summary

- Adds `/v1/*` to the Caddy `@api` path matcher so REST API requests are proxied to the Meridian service
- Without this, REST requests fall through to the SPA catch-all and return HTML instead of JSON

## Test plan

- [x] Verified on demo server: `curl https://demo.meridianhub.cloud/v1/current-accounts/ACC-b73423ff` returns JSON