### PR TITLE
fix: add per-route error boundaries to prevent full-page crashes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter, Routes, Route, useLocation, useNavigate } from 'react-ro
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { queryClient } from '@/lib/query-client'
-import { PageErrorBoundary } from '@/components/error-boundary'
+import { PageErrorBoundary, RouteErrorBoundary } from '@/components/error-boundary'
 import { AuthProvider, useAuth } from '@/contexts/auth-context'
 import { TenantProvider, useTenantContext } from '@/contexts/tenant-context'
 import { useTenants } from '@/hooks/use-tenants'
@@ -212,9 +212,17 @@ function NotFoundPage() {
   )
 }
 
+/** Wraps a page element with a route-level error boundary. */
+function guarded(element: ReactNode) {
+  return <RouteErrorBoundary>{element}</RouteErrorBoundary>
+}
+
 /**
  * Layout wrapper that reads the current path from React Router
  * and passes it to AppShell for active nav highlighting.
+ *
+ * Each route is wrapped with RouteErrorBoundary so that a crash in one page
+ * shows an inline error message instead of taking down the entire app.
  */
 function AppShellLayout() {
   const { pathname } = useLocation()
@@ -225,46 +233,46 @@ function AppShellLayout() {
     <AppShell currentPath={pathname}>
       <Routes>
         {/* Tenant-scoped routes */}
-        <Route path="/" element={<DashboardPage />} />
-        <Route path="/accounts" element={<AccountsPage />} />
-        <Route path="/accounts/:accountId" element={<AccountDetailPage />} />
-        <Route path="/internal-accounts" element={<InternalAccountsPage />} />
-        <Route path="/internal-accounts/:accountId" element={<PlaceholderPage title="Internal Account Detail" />} />
-        <Route path="/payments" element={<PaymentsPage />} />
-        <Route path="/payments/:paymentOrderId" element={<PaymentDetailPage />} />
-        <Route path="/transactions" element={<PlaceholderPage title="Transactions" />} />
-        <Route path="/positions" element={<PositionsPage />} />
-        <Route path="/positions/:logId" element={<PositionDetailPage />} />
-        <Route path="/ledger" element={<LedgerPage />} />
-        <Route path="/ledger/:bookingLogId" element={<BookingLogDetailPage />} />
-        <Route path="/parties" element={<PartiesPage />} />
-        <Route path="/parties/:partyId" element={<PartyDetailPage />} />
-        <Route path="/reconciliation" element={<ReconciliationPage />} />
-        <Route path="/reconciliation/:runId" element={<ReconciliationDetailPage />} />
+        <Route path="/" element={guarded(<DashboardPage />)} />
+        <Route path="/accounts" element={guarded(<AccountsPage />)} />
+        <Route path="/accounts/:accountId" element={guarded(<AccountDetailPage />)} />
+        <Route path="/internal-accounts" element={guarded(<InternalAccountsPage />)} />
+        <Route path="/internal-accounts/:accountId" element={guarded(<PlaceholderPage title="Internal Account Detail" />)} />
+        <Route path="/payments" element={guarded(<PaymentsPage />)} />
+        <Route path="/payments/:paymentOrderId" element={guarded(<PaymentDetailPage />)} />
+        <Route path="/transactions" element={guarded(<PlaceholderPage title="Transactions" />)} />
+        <Route path="/positions" element={guarded(<PositionsPage />)} />
+        <Route path="/positions/:logId" element={guarded(<PositionDetailPage />)} />
+        <Route path="/ledger" element={guarded(<LedgerPage />)} />
+        <Route path="/ledger/:bookingLogId" element={guarded(<BookingLogDetailPage />)} />
+        <Route path="/parties" element={guarded(<PartiesPage />)} />
+        <Route path="/parties/:partyId" element={guarded(<PartyDetailPage />)} />
+        <Route path="/reconciliation" element={guarded(<ReconciliationPage />)} />
+        <Route path="/reconciliation/:runId" element={guarded(<ReconciliationDetailPage />)} />
         <Route
           path="/starlark-config"
-          element={<StarlarkConfigPage isPlatformAdmin={isPlatformAdmin} />}
+          element={guarded(<StarlarkConfigPage isPlatformAdmin={isPlatformAdmin} />)}
         />
-        <Route path="/starlark-config/:definitionId" element={<StarlarkDetailPage />} />
-        <Route path="/market-data" element={<MarketDataPage />} />
-        <Route path="/market-data/:datasetCode" element={<DatasetDetailPage />} />
-        <Route path="/forecasting" element={<ForecastingPage />} />
-        <Route path="/reference-data" element={<PlaceholderPage title="Reference Data" />} />
-        <Route path="/reference-data/instruments" element={<InstrumentsPage />} />
-        <Route path="/reference-data/account-types" element={<AccountTypesPage />} />
-        <Route path="/reference-data/nodes" element={<NodesPage />} />
-        <Route path="/gateway-mappings" element={<MappingsPage />} />
-        <Route path="/gateway-mappings/:mappingId" element={<MappingDetailPage />} />
-        <Route path="/manifests" element={<ManifestsPage />} />
-        <Route path="/mcp-config" element={<McpConfigPage />} />
-        <Route path="/audit-log" element={<AuditLogPage />} />
+        <Route path="/starlark-config/:definitionId" element={guarded(<StarlarkDetailPage />)} />
+        <Route path="/market-data" element={guarded(<MarketDataPage />)} />
+        <Route path="/market-data/:datasetCode" element={guarded(<DatasetDetailPage />)} />
+        <Route path="/forecasting" element={guarded(<ForecastingPage />)} />
+        <Route path="/reference-data" element={guarded(<PlaceholderPage title="Reference Data" />)} />
+        <Route path="/reference-data/instruments" element={guarded(<InstrumentsPage />)} />
+        <Route path="/reference-data/account-types" element={guarded(<AccountTypesPage />)} />
+        <Route path="/reference-data/nodes" element={guarded(<NodesPage />)} />
+        <Route path="/gateway-mappings" element={guarded(<MappingsPage />)} />
+        <Route path="/gateway-mappings/:mappingId" element={guarded(<MappingDetailPage />)} />
+        <Route path="/manifests" element={guarded(<ManifestsPage />)} />
+        <Route path="/mcp-config" element={guarded(<McpConfigPage />)} />
+        <Route path="/audit-log" element={guarded(<AuditLogPage />)} />
 
         {/* Platform-only routes */}
         <Route
           path="/tenants"
           element={
             <PlatformOnlyRoute>
-              <TenantsPage />
+              {guarded(<TenantsPage />)}
             </PlatformOnlyRoute>
           }
         />
@@ -272,7 +280,7 @@ function AppShellLayout() {
           path="/tenants/:tenantId"
           element={
             <PlatformOnlyRoute>
-              <TenantDetailPage />
+              {guarded(<TenantDetailPage />)}
             </PlatformOnlyRoute>
           }
         />
@@ -280,7 +288,7 @@ function AppShellLayout() {
           path="/platform"
           element={
             <PlatformOnlyRoute>
-              <PlaceholderPage title="Platform Monitoring" />
+              {guarded(<PlaceholderPage title="Platform Monitoring" />)}
             </PlatformOnlyRoute>
           }
         />

--- a/frontend/src/components/error-boundary.tsx
+++ b/frontend/src/components/error-boundary.tsx
@@ -63,7 +63,7 @@ export class ErrorBoundary extends Component<Props, State> {
               An unexpected error occurred.
             </p>
 
-            {this.state.error && import.meta.env.DEV && (
+            {this.state.error && (
               <div className="rounded-lg bg-muted p-3 text-sm font-mono text-muted-foreground break-words">
                 {this.state.error.message}
               </div>
@@ -100,4 +100,64 @@ export function PageErrorBoundary({
       {children}
     </ErrorBoundary>
   )
+}
+
+/**
+ * Route-level error boundary that renders inline within the page layout
+ * instead of replacing the entire screen. This keeps the sidebar and header
+ * visible so the user can navigate to a different page.
+ */
+interface RouteErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+
+export class RouteErrorBoundary extends Component<{ children: ReactNode }, RouteErrorBoundaryState> {
+  constructor(props: { children: ReactNode }) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): RouteErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('Route error boundary caught:', error, errorInfo)
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center py-16 px-4">
+          <div className="max-w-md w-full space-y-4">
+            <div className="flex items-center gap-3">
+              <AlertTriangle className="size-6 text-destructive" />
+              <h2 className="text-xl font-semibold">Failed to load page</h2>
+            </div>
+
+            <p className="text-sm text-muted-foreground">
+              This page encountered an error. Other pages should still work normally.
+            </p>
+
+            {this.state.error && (
+              <div className="rounded-lg bg-muted p-3 text-sm font-mono text-muted-foreground break-words">
+                {this.state.error.message}
+              </div>
+            )}
+
+            <Button onClick={this.handleRetry} variant="default" size="sm">
+              Retry
+            </Button>
+          </div>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
 }

--- a/frontend/src/test/error-boundary.test.tsx
+++ b/frontend/src/test/error-boundary.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { ErrorBoundary, PageErrorBoundary } from '@/components/error-boundary'
+import { ErrorBoundary, PageErrorBoundary, RouteErrorBoundary } from '@/components/error-boundary'
 
 // Component that throws an error
 function ThrowError() {
@@ -150,5 +150,76 @@ describe('PageErrorBoundary', () => {
     )
 
     expect(screen.getByText('Safe content')).toBeInTheDocument()
+  })
+})
+
+describe('RouteErrorBoundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('renders inline error instead of full-page crash', () => {
+    render(
+      <RouteErrorBoundary>
+        <ThrowError />
+      </RouteErrorBoundary>
+    )
+
+    expect(screen.getByText('Failed to load page')).toBeInTheDocument()
+    expect(
+      screen.getByText('This page encountered an error. Other pages should still work normally.')
+    ).toBeInTheDocument()
+  })
+
+  it('shows error message', () => {
+    render(
+      <RouteErrorBoundary>
+        <ThrowError />
+      </RouteErrorBoundary>
+    )
+
+    expect(screen.getByText('Test error')).toBeInTheDocument()
+  })
+
+  it('renders children when no error', () => {
+    render(
+      <RouteErrorBoundary>
+        <SafeComponent />
+      </RouteErrorBoundary>
+    )
+
+    expect(screen.getByText('Safe content')).toBeInTheDocument()
+  })
+
+  it('retry button resets error state', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <RouteErrorBoundary>
+        <ThrowError />
+      </RouteErrorBoundary>
+    )
+
+    expect(screen.getByText('Failed to load page')).toBeInTheDocument()
+
+    rerender(
+      <RouteErrorBoundary>
+        <SafeComponent />
+      </RouteErrorBoundary>
+    )
+
+    const retryButton = screen.getByRole('button', { name: /retry/i })
+    await user.click(retryButton)
+
+    expect(screen.getByText('Safe content')).toBeInTheDocument()
+  })
+
+  it('does not show Go to Dashboard button (stays in layout)', () => {
+    render(
+      <RouteErrorBoundary>
+        <ThrowError />
+      </RouteErrorBoundary>
+    )
+
+    expect(screen.queryByRole('button', { name: /go to dashboard/i })).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

- Add `RouteErrorBoundary` component that renders inline error messages within the page layout, keeping the sidebar and header visible so users can navigate to other pages
- Wrap all routes in `AppShellLayout` with per-route error boundaries via a `guarded()` helper
- Show error messages in all environments (previously hidden in production behind `import.meta.env.DEV`)

## Problem

When any page component threw during render, the top-level `ErrorBoundary` replaced the entire screen with "Something went wrong", hiding all navigation. The user had no way to recover except clicking "Go to Dashboard" or refreshing. This was reported on the Parties page at `demo.meridianhub.cloud/parties`.

## Root Cause Analysis

The full-page crash was caused by the absence of per-route error boundaries. A single `PageErrorBoundary` at the app root caught all errors, and its full-screen fallback UI replaced the entire layout including the sidebar and header.

Additionally, error messages were hidden in production (`import.meta.env.DEV` guard), making it impossible to diagnose the actual error from the demo environment.

## Test plan

- [x] All 14 error boundary tests pass (including 5 new `RouteErrorBoundary` tests)
- [x] All 1470 frontend tests pass (3 pre-existing account test failures unrelated to this change)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Verify on demo that a failing page shows inline error with sidebar still visible
- [ ] Verify other pages remain functional when one page errors