### PR TITLE
feat: add cross-entity navigation links

### DIFF
--- a/frontend/src/components/shared/entity-link.tsx
+++ b/frontend/src/components/shared/entity-link.tsx
@@ -1,0 +1,46 @@
+import { Link } from 'react-router-dom'
+
+export type EntityType =
+  | 'account'
+  | 'party'
+  | 'internal-account'
+  | 'payment'
+  | 'booking-log'
+  | 'position'
+
+function entityPath(type: EntityType, id: string): string {
+  switch (type) {
+    case 'account':
+      return `/accounts/${id}`
+    case 'party':
+      return `/parties/${id}`
+    case 'internal-account':
+      return `/internal-accounts/${id}`
+    case 'payment':
+      return `/payments/${id}`
+    case 'booking-log':
+      return `/ledger/${id}`
+    case 'position':
+      return `/positions/${id}`
+  }
+}
+
+export interface EntityLinkProps {
+  type: EntityType
+  id: string
+  /** Display text; defaults to the id */
+  label?: string
+  className?: string
+}
+
+export function EntityLink({ type, id, label, className }: EntityLinkProps) {
+  if (!id) return null
+  return (
+    <Link
+      to={entityPath(type, id)}
+      className={className ?? 'text-blue-600 hover:underline dark:text-blue-400'}
+    >
+      {label ?? id}
+    </Link>
+  )
+}

--- a/frontend/src/components/shared/entity-link.tsx
+++ b/frontend/src/components/shared/entity-link.tsx
@@ -9,19 +9,20 @@ export type EntityType =
   | 'position'
 
 function entityPath(type: EntityType, id: string): string {
+  const encodedId = encodeURIComponent(id)
   switch (type) {
     case 'account':
-      return `/accounts/${id}`
+      return `/accounts/${encodedId}`
     case 'party':
-      return `/parties/${id}`
+      return `/parties/${encodedId}`
     case 'internal-account':
-      return `/internal-accounts/${id}`
+      return `/internal-accounts/${encodedId}`
     case 'payment':
-      return `/payments/${id}`
+      return `/payments/${encodedId}`
     case 'booking-log':
-      return `/ledger/${id}`
+      return `/ledger/${encodedId}`
     case 'position':
-      return `/positions/${id}`
+      return `/positions/${encodedId}`
   }
 }
 

--- a/frontend/src/components/shared/index.ts
+++ b/frontend/src/components/shared/index.ts
@@ -13,3 +13,6 @@ export { QualityLadderBadge } from './quality-ladder-badge';
 export { DirectionBadge } from './direction-badge';
 export { CreateValuationFeatureDialog } from './create-valuation-feature-dialog';
 export type { CreateValuationFeatureDialogProps, AccountType } from './create-valuation-feature-dialog';
+
+export { EntityLink } from './entity-link';
+export type { EntityLinkProps, EntityType } from './entity-link';

--- a/frontend/src/pages/accounts/[accountId].tsx
+++ b/frontend/src/pages/accounts/[accountId].tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { MoneyDisplay } from '@/components/shared/money-display'
-import { AuditTrail } from '@/components/shared'
+import { AuditTrail, EntityLink } from '@/components/shared'
 import { ConnectError, Code } from '@connectrpc/connect'
 import { useApiClients } from '@/api/context'
 import { useTenantContext } from '@/contexts/tenant-context'
@@ -387,7 +387,9 @@ export function AccountDetailPage() {
               {account.availableBalance ?? '—'}
             </DetailField>
             {account.partyId && (
-              <DetailField label="Party ID">{account.partyId}</DetailField>
+              <DetailField label="Party ID">
+                <EntityLink type="party" id={account.partyId} />
+              </DetailField>
             )}
             <DetailField label="Created">
               <TimeDisplay timestamp={account.createdAt} format="absolute" />
@@ -429,7 +431,9 @@ export function AccountDetailPage() {
                     <DetailField label="Name">{account.name}</DetailField>
                   )}
                   {account.partyId && (
-                    <DetailField label="Party ID">{account.partyId}</DetailField>
+                    <DetailField label="Party ID">
+                      <EntityLink type="party" id={account.partyId} />
+                    </DetailField>
                   )}
                   <DetailField label="Created">
                     <TimeDisplay timestamp={account.createdAt} format="both" />

--- a/frontend/src/pages/ledger/booking-log-detail.tsx
+++ b/frontend/src/pages/ledger/booking-log-detail.tsx
@@ -10,7 +10,7 @@ import { useApiClients } from '@/api/context'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
 import { StatusBadge } from '@/components/shared/status-badge'
-import { TimeDisplay } from '@/components/shared'
+import { TimeDisplay, EntityLink } from '@/components/shared'
 import { MoneyDisplay } from '@/components/shared/money-display'
 import {
   Table,
@@ -126,7 +126,7 @@ const postingColumns: ColumnDef<LedgerPosting>[] = [
     accessorKey: 'accountId',
     header: 'Account',
     cell: ({ row }) => (
-      <span className="font-mono text-sm">{row.original.accountId}</span>
+      <EntityLink type="account" id={row.original.accountId} />
     ),
   },
   {

--- a/frontend/src/pages/payments/payment-detail.tsx
+++ b/frontend/src/pages/payments/payment-detail.tsx
@@ -10,6 +10,7 @@ import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { SagaTimeline } from '@/components/shared/saga-timeline'
 import { AuditTrail } from '@/components/shared/audit-trail'
+import { EntityLink } from '@/components/shared'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
 import { tenantKeys } from '@/lib/query-keys'
@@ -201,7 +202,9 @@ export function PaymentDetailPage() {
             <CardContent>
               <div className="divide-y">
                 <DetailRow label="Payment Order ID">{data.paymentOrderId}</DetailRow>
-                <DetailRow label="Debtor Account">{data.debtorAccountId}</DetailRow>
+                <DetailRow label="Debtor Account">
+                  <EntityLink type="account" id={data.debtorAccountId} />
+                </DetailRow>
                 <DetailRow label="Creditor Reference">{data.creditorReference}</DetailRow>
                 <DetailRow label="Amount">
                   <MoneyDisplay amount={data.amount} currency={data.currency} />

--- a/frontend/src/pages/positions/detail.tsx
+++ b/frontend/src/pages/positions/detail.tsx
@@ -9,6 +9,7 @@ import { MoneyDisplay } from '@/components/shared/money-display'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { QualityLadderBadge } from '@/components/shared/quality-ladder-badge'
 import { DirectionBadge } from '@/components/shared/direction-badge'
+import { EntityLink } from '@/components/shared'
 import { useApiClients } from '@/api/context'
 import type { FinancialPositionLog, TransactionLogEntry } from './index'
 
@@ -198,8 +199,10 @@ export function PositionDetailPage() {
             <LabeledField label="Account ID">
               {isLoading ? (
                 <SkeletonField />
+              ) : log?.accountId ? (
+                <EntityLink type="account" id={log.accountId} className="font-mono text-xs text-blue-600 hover:underline dark:text-blue-400" />
               ) : (
-                <span className="font-mono text-xs">{log?.accountId ?? '—'}</span>
+                <span>—</span>
               )}
             </LabeledField>
 


### PR DESCRIPTION
## Summary

- Introduces a reusable `EntityLink` component (`frontend/src/components/shared/entity-link.tsx`) that maps entity types to their detail page routes
- Exports `EntityLink`, `EntityLinkProps`, and `EntityType` from the shared components barrel
- Applies `EntityLink` across four pages to make entity IDs clickable

## Changes Made

| File | Change |
|------|--------|
| `components/shared/entity-link.tsx` | New component: maps `account`, `party`, `internal-account`, `payment`, `booking-log`, `position` types to routes |
| `components/shared/index.ts` | Exports `EntityLink`, `EntityLinkProps`, `EntityType` |
| `accounts/[accountId].tsx` | Party ID fields (summary card + overview tab) link to `/parties/:id` |
| `payments/payment-detail.tsx` | Debtor Account ID links to `/accounts/:id` |
| `ledger/booking-log-detail.tsx` | Account column in postings table links to `/accounts/:id` |
| `positions/detail.tsx` | Account ID field links to `/accounts/:id` |

## Technical Details

`EntityLink` accepts `type`, `id`, an optional `label` (defaults to `id`), and an optional `className` (defaults to blue text + hover underline via Tailwind). When `id` is empty/falsy the component renders nothing, making it safe to apply to optional fields.

## Testing

- TypeScript typecheck: passes with no errors
- ESLint: 0 errors, 2 pre-existing warnings (unrelated `useReactTable` React Compiler compatibility notices)