### PR TITLE
feat: add clickable stat cards and activity feed links to dashboard

### DIFF
--- a/frontend/src/pages/dashboard/activity-feed.tsx
+++ b/frontend/src/pages/dashboard/activity-feed.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { cn } from '@/lib/utils'
@@ -9,6 +10,7 @@ export interface ActivityItem {
   description?: string
   timestamp: { seconds: bigint | number; nanos?: number } | null | undefined
   status?: string
+  href?: string
 }
 
 interface ActivityFeedProps {
@@ -59,28 +61,48 @@ export function ActivityFeed({ items, isLoading, className }: ActivityFeedProps)
 
   return (
     <div className={cn('divide-y', className)}>
-      {items.map((item) => (
-        <div key={item.id} className="flex items-start gap-3 py-3">
-          <div
-            className={cn(
-              'mt-2 h-2 w-2 flex-shrink-0 rounded-full',
-              TYPE_COLORS[item.type] ?? 'bg-gray-400',
-            )}
-          />
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <span className="truncate text-sm font-medium">{item.title}</span>
-              {item.status && <StatusBadge status={item.status} />}
+      {items.map((item) => {
+        const itemContent = (
+          <>
+            <div
+              className={cn(
+                'mt-2 h-2 w-2 flex-shrink-0 rounded-full',
+                TYPE_COLORS[item.type] ?? 'bg-gray-400',
+              )}
+            />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="truncate text-sm font-medium">{item.title}</span>
+                {item.status && <StatusBadge status={item.status} />}
+              </div>
+              {item.description && (
+                <p className="mt-0.5 truncate text-xs text-muted-foreground">{item.description}</p>
+              )}
             </div>
-            {item.description && (
-              <p className="mt-0.5 truncate text-xs text-muted-foreground">{item.description}</p>
-            )}
+            <div className="flex-shrink-0 text-xs text-muted-foreground">
+              <TimeDisplay timestamp={item.timestamp} format="relative" />
+            </div>
+          </>
+        )
+
+        if (item.href) {
+          return (
+            <Link
+              key={item.id}
+              to={item.href}
+              className="flex items-start gap-3 py-3 transition-colors hover:bg-accent/50 rounded-sm"
+            >
+              {itemContent}
+            </Link>
+          )
+        }
+
+        return (
+          <div key={item.id} className="flex items-start gap-3 py-3">
+            {itemContent}
           </div>
-          <div className="flex-shrink-0 text-xs text-muted-foreground">
-            <TimeDisplay timestamp={item.timestamp} format="relative" />
-          </div>
-        </div>
-      ))}
+        )
+      })}
     </div>
   )
 }

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -114,6 +114,7 @@ export function DashboardPage() {
     description: po.paymentOrderId ? `ID: ${po.paymentOrderId}` : undefined,
     timestamp: po.createdAt ?? null,
     status: po.status?.toString(),
+    href: po.paymentOrderId ? `/payments/${po.paymentOrderId}` : undefined,
   }))
 
   const quickActions: QuickAction[] = [
@@ -166,6 +167,7 @@ export function DashboardPage() {
           showRecentQualifier={!!(paymentsCount?.isEstimate && !paymentsQuery.isLoading && !paymentsQuery.isError)}
           description="Active payment orders"
           icon={<CreditCard className="h-4 w-4" />}
+          href="/payments"
         />
         <StatCard
           title="Booking Logs"
@@ -175,6 +177,7 @@ export function DashboardPage() {
           showRecentQualifier={!!(bookingLogsCount?.isEstimate && !bookingLogsQuery.isLoading && !bookingLogsQuery.isError)}
           description="Financial booking logs"
           icon={<FileText className="h-4 w-4" />}
+          href="/ledger"
         />
         <StatCard
           title="Ledger Postings"
@@ -184,6 +187,7 @@ export function DashboardPage() {
           showRecentQualifier={!!(ledgerPostingsCount?.isEstimate && !ledgerPostingsQuery.isLoading && !ledgerPostingsQuery.isError)}
           description="Double-entry postings"
           icon={<BarChart3 className="h-4 w-4" />}
+          href="/ledger"
         />
       </div>
 

--- a/frontend/src/pages/dashboard/stat-card.tsx
+++ b/frontend/src/pages/dashboard/stat-card.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 
@@ -11,6 +12,7 @@ interface StatCardProps {
   error?: boolean
   showRecentQualifier?: boolean
   className?: string
+  href?: string
 }
 
 export function StatCard({
@@ -22,9 +24,10 @@ export function StatCard({
   error,
   showRecentQualifier,
   className,
+  href,
 }: StatCardProps) {
-  return (
-    <Card className={cn('', className)}>
+  const cardContent = (
+    <>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-sm font-medium">{title}</CardTitle>
         {icon && <div className="text-muted-foreground">{icon}</div>}
@@ -53,6 +56,23 @@ export function StatCard({
           <p className="mt-1 text-xs text-muted-foreground">{description}</p>
         )}
       </CardContent>
-    </Card>
+    </>
   )
+
+  if (href) {
+    return (
+      <Link to={href} className="block">
+        <Card
+          className={cn(
+            'transition-colors hover:bg-accent/50 cursor-pointer',
+            className,
+          )}
+        >
+          {cardContent}
+        </Card>
+      </Link>
+    )
+  }
+
+  return <Card className={cn('', className)}>{cardContent}</Card>
 }


### PR DESCRIPTION
## Summary

- `StatCard` accepts an optional `href` prop; when provided, the card is wrapped in a `react-router-dom` `Link` with a subtle hover background highlight (`hover:bg-accent/50`) to communicate interactivity
- Dashboard stat cards now link to their respective pages: Payment Orders → `/payments`, Booking Logs → `/ledger`, Ledger Postings → `/ledger`
- `ActivityItem` gains an optional `href` prop; activity feed items render as `Link` elements when `href` is set, otherwise render as plain `div` (backwards-compatible)
- Payment order activity items link to `/payments/:paymentOrderId`

## Changes

- `frontend/src/pages/dashboard/stat-card.tsx` — add `href` prop, conditional `Link` wrapper
- `frontend/src/pages/dashboard/index.tsx` — pass `href` to stat cards, add `href` to activity items
- `frontend/src/pages/dashboard/activity-feed.tsx` — add `href` to `ActivityItem` interface, conditional `Link` rendering

## Testing

- All 27 existing dashboard tests pass (`vitest run src/pages/dashboard/`)
- TypeScript typecheck passes with no errors
- ESLint: 0 errors (2 pre-existing warnings in unrelated files)