### PR TITLE
fix: resolve parties page crash and reset error boundary on navigation

### DIFF
--- a/frontend/src/components/error-boundary.tsx
+++ b/frontend/src/components/error-boundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { useLocation } from 'react-router-dom'
 import { AlertTriangle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
@@ -106,20 +107,33 @@ export function PageErrorBoundary({
  * Route-level error boundary that renders inline within the page layout
  * instead of replacing the entire screen. This keeps the sidebar and header
  * visible so the user can navigate to a different page.
+ *
+ * Automatically resets when the user navigates to a different route.
  */
 interface RouteErrorBoundaryState {
   hasError: boolean
   error: Error | null
 }
 
-export class RouteErrorBoundary extends Component<{ children: ReactNode }, RouteErrorBoundaryState> {
-  constructor(props: { children: ReactNode }) {
+interface RouteErrorBoundaryInnerProps {
+  children: ReactNode
+  resetKey?: string
+}
+
+export class RouteErrorBoundaryInner extends Component<RouteErrorBoundaryInnerProps, RouteErrorBoundaryState> {
+  constructor(props: RouteErrorBoundaryInnerProps) {
     super(props)
     this.state = { hasError: false, error: null }
   }
 
   static getDerivedStateFromError(error: Error): RouteErrorBoundaryState {
     return { hasError: true, error }
+  }
+
+  componentDidUpdate(prevProps: RouteErrorBoundaryInnerProps) {
+    if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false, error: null })
+    }
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
@@ -160,4 +174,16 @@ export class RouteErrorBoundary extends Component<{ children: ReactNode }, Route
 
     return this.props.children
   }
+}
+
+/**
+ * Location-aware wrapper that resets the error boundary when the route changes.
+ */
+export function RouteErrorBoundary({ children }: { children: ReactNode }) {
+  const { pathname } = useLocation()
+  return (
+    <RouteErrorBoundaryInner resetKey={pathname}>
+      {children}
+    </RouteErrorBoundaryInner>
+  )
 }

--- a/frontend/src/components/shared/status-badge.tsx
+++ b/frontend/src/components/shared/status-badge.tsx
@@ -59,8 +59,9 @@ export function StatusBadge({ status, loading }: StatusBadgeProps) {
     )
   }
 
-  const variant = STATUS_MAP[status] ?? 'neutral'
-  const displayText = status.replace(/_/g, ' ')
+  const statusStr = typeof status === 'string' ? status : String(status)
+  const variant = STATUS_MAP[statusStr] ?? 'neutral'
+  const displayText = statusStr.replace(/_/g, ' ')
 
   return (
     <span

--- a/frontend/src/pages/parties/components/party-header.tsx
+++ b/frontend/src/pages/parties/components/party-header.tsx
@@ -4,6 +4,28 @@ import { useClients } from '@/api/context'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { Skeleton } from '@/components/ui/skeleton'
 
+function partyStatusLabel(status: unknown): string {
+  if (typeof status === 'string') return status
+  const map: Record<number, string> = {
+    0: 'UNSPECIFIED',
+    1: 'PARTY_STATUS_ACTIVE',
+    2: 'PARTY_STATUS_RESTRICTED',
+    3: 'PARTY_STATUS_SUSPENDED',
+    4: 'PARTY_STATUS_TERMINATED',
+  }
+  return map[status as number] ?? 'UNKNOWN'
+}
+
+function partyTypeLabel(partyType: unknown): string {
+  if (typeof partyType === 'string') return partyType
+  const map: Record<number, string> = {
+    0: 'UNSPECIFIED',
+    1: 'Person',
+    2: 'Organization',
+  }
+  return map[partyType as number] ?? 'Unknown'
+}
+
 interface PartyHeaderProps {
   partyId: string
 }
@@ -39,9 +61,9 @@ export function PartyHeader({ partyId }: PartyHeaderProps) {
           <h2 className="text-2xl font-bold">{party.legalName}</h2>
           <div className="flex items-center gap-3">
             <span className="text-sm text-muted-foreground">
-              {party.partyType}
+              {partyTypeLabel(party.partyType)}
             </span>
-            <StatusBadge status={party.status} />
+            <StatusBadge status={partyStatusLabel(party.status)} />
           </div>
         </div>
       </div>

--- a/frontend/src/pages/parties/index.tsx
+++ b/frontend/src/pages/parties/index.tsx
@@ -12,6 +12,28 @@ import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { RegisterPartyDialog } from './dialogs/register-party-dialog'
 import { RegisterPartyTypeDialog } from './dialogs/register-party-type-dialog'
 
+function partyStatusLabel(status: unknown): string {
+  if (typeof status === 'string') return status
+  const map: Record<number, string> = {
+    0: 'UNSPECIFIED',
+    1: 'PARTY_STATUS_ACTIVE',
+    2: 'PARTY_STATUS_RESTRICTED',
+    3: 'PARTY_STATUS_SUSPENDED',
+    4: 'PARTY_STATUS_TERMINATED',
+  }
+  return map[status as number] ?? 'UNKNOWN'
+}
+
+function partyTypeLabel(partyType: unknown): string {
+  if (typeof partyType === 'string') return partyType
+  const map: Record<number, string> = {
+    0: 'UNSPECIFIED',
+    1: 'PARTY_TYPE_PERSON',
+    2: 'PARTY_TYPE_ORGANIZATION',
+  }
+  return map[partyType as number] ?? 'UNKNOWN'
+}
+
 export interface Party {
   partyId: string
   legalName: string
@@ -110,8 +132,8 @@ export function PartiesPage() {
     const parties: Party[] = response.parties.map((p: Party) => ({
       partyId: p.partyId,
       legalName: p.legalName,
-      partyType: p.partyType,
-      status: p.status,
+      partyType: partyTypeLabel(p.partyType),
+      status: partyStatusLabel(p.status),
       externalReference: p.externalReference,
       createdAt: p.createdAt,
     }))

--- a/frontend/src/test/error-boundary.test.tsx
+++ b/frontend/src/test/error-boundary.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { ErrorBoundary, PageErrorBoundary, RouteErrorBoundary } from '@/components/error-boundary'
+import { MemoryRouter } from 'react-router-dom'
+import { ErrorBoundary, PageErrorBoundary, RouteErrorBoundary, RouteErrorBoundaryInner } from '@/components/error-boundary'
 
 // Component that throws an error
 function ThrowError() {
@@ -160,9 +161,11 @@ describe('RouteErrorBoundary', () => {
 
   it('renders inline error instead of full-page crash', () => {
     render(
-      <RouteErrorBoundary>
-        <ThrowError />
-      </RouteErrorBoundary>
+      <MemoryRouter>
+        <RouteErrorBoundary>
+          <ThrowError />
+        </RouteErrorBoundary>
+      </MemoryRouter>
     )
 
     expect(screen.getByText('Failed to load page')).toBeInTheDocument()
@@ -173,9 +176,11 @@ describe('RouteErrorBoundary', () => {
 
   it('shows error message', () => {
     render(
-      <RouteErrorBoundary>
-        <ThrowError />
-      </RouteErrorBoundary>
+      <MemoryRouter>
+        <RouteErrorBoundary>
+          <ThrowError />
+        </RouteErrorBoundary>
+      </MemoryRouter>
     )
 
     expect(screen.getByText('Test error')).toBeInTheDocument()
@@ -183,9 +188,11 @@ describe('RouteErrorBoundary', () => {
 
   it('renders children when no error', () => {
     render(
-      <RouteErrorBoundary>
-        <SafeComponent />
-      </RouteErrorBoundary>
+      <MemoryRouter>
+        <RouteErrorBoundary>
+          <SafeComponent />
+        </RouteErrorBoundary>
+      </MemoryRouter>
     )
 
     expect(screen.getByText('Safe content')).toBeInTheDocument()
@@ -194,17 +201,21 @@ describe('RouteErrorBoundary', () => {
   it('retry button resets error state', async () => {
     const user = userEvent.setup()
     const { rerender } = render(
-      <RouteErrorBoundary>
-        <ThrowError />
-      </RouteErrorBoundary>
+      <MemoryRouter>
+        <RouteErrorBoundaryInner>
+          <ThrowError />
+        </RouteErrorBoundaryInner>
+      </MemoryRouter>
     )
 
     expect(screen.getByText('Failed to load page')).toBeInTheDocument()
 
     rerender(
-      <RouteErrorBoundary>
-        <SafeComponent />
-      </RouteErrorBoundary>
+      <MemoryRouter>
+        <RouteErrorBoundaryInner>
+          <SafeComponent />
+        </RouteErrorBoundaryInner>
+      </MemoryRouter>
     )
 
     const retryButton = screen.getByRole('button', { name: /retry/i })
@@ -215,11 +226,32 @@ describe('RouteErrorBoundary', () => {
 
   it('does not show Go to Dashboard button (stays in layout)', () => {
     render(
-      <RouteErrorBoundary>
-        <ThrowError />
-      </RouteErrorBoundary>
+      <MemoryRouter>
+        <RouteErrorBoundary>
+          <ThrowError />
+        </RouteErrorBoundary>
+      </MemoryRouter>
     )
 
     expect(screen.queryByRole('button', { name: /go to dashboard/i })).not.toBeInTheDocument()
+  })
+
+  it('resets error state when route changes', () => {
+    const { rerender } = render(
+      <RouteErrorBoundaryInner resetKey="/parties">
+        <ThrowError />
+      </RouteErrorBoundaryInner>
+    )
+
+    expect(screen.getByText('Failed to load page')).toBeInTheDocument()
+
+    // Simulate navigation by changing resetKey and providing safe children
+    rerender(
+      <RouteErrorBoundaryInner resetKey="/accounts">
+        <SafeComponent />
+      </RouteErrorBoundaryInner>
+    )
+
+    expect(screen.getByText('Safe content')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- Fix `t.replace is not a function` crash on the Parties page caused by proto enum values arriving as numbers instead of strings
- Make `RouteErrorBoundary` automatically reset when the user navigates to a different page (no manual retry click needed)
- Make `StatusBadge` defensive against non-string status values

## Changes
- **`pages/parties/index.tsx`** and **`pages/parties/components/party-header.tsx`**: Add `partyStatusLabel()` and `partyTypeLabel()` to convert numeric proto enums (`PartyStatus`, `PartyType`) to their string representations
- **`components/shared/status-badge.tsx`**: Coerce status to string before calling `.replace()` to prevent crashes from non-string values
- **`components/error-boundary.tsx`**: Add `resetKey` prop to `RouteErrorBoundaryInner` and wrap it with a location-aware `RouteErrorBoundary` that passes `pathname` — error state clears automatically on navigation
- **`test/error-boundary.test.tsx`**: Wrap `RouteErrorBoundary` tests in `MemoryRouter`, add test for route-change reset behavior

## Test plan
- [x] All 1476 tests pass (3 pre-existing test file failures from missing generated proto files, unrelated)
- [x] TypeScript compiles cleanly
- [ ] Verify Parties page loads without crash on demo
- [ ] Verify navigating away from an errored page clears the error