### PR TITLE
feat: wire handler reference component to DescribeHandlers API

### DIFF
--- a/api/proto/meridian/saga/v1/saga_registry.proto
+++ b/api/proto/meridian/saga/v1/saga_registry.proto
@@ -204,6 +204,14 @@ service SagaRegistryService {
       get: "/v1/sagas/deprecation-impact"
     };
   }
+
+  // DescribeHandlers returns the platform handler schema registry.
+  // Used by the Starlark editor to display available handlers and their parameter types.
+  rpc DescribeHandlers(DescribeHandlersRequest) returns (DescribeHandlersResponse) {
+    option (google.api.http) = {
+      get: "/v1/sagas/handlers"
+    };
+  }
 }
 
 // CreateSagaDraftRequest contains the data for creating a new saga draft.
@@ -481,4 +489,59 @@ message ComplexityMetrics {
 
   // complexity_score is a 0-10 scale complexity rating.
   int32 complexity_score = 4;
+}
+
+// DescribeHandlersRequest is the request for the DescribeHandlers RPC.
+// No parameters required - returns the full platform handler schema.
+message DescribeHandlersRequest {}
+
+// DescribeHandlersResponse contains the handler schema grouped by service.
+message DescribeHandlersResponse {
+  // services lists all available services with their handlers.
+  repeated HandlerServiceSchema services = 1;
+}
+
+// HandlerServiceSchema describes a single service and its handlers.
+message HandlerServiceSchema {
+  // name is the service name (e.g., "position_keeping").
+  string name = 1;
+
+  // handlers lists the handlers provided by this service.
+  repeated HandlerSchema handlers = 2;
+}
+
+// HandlerSchema describes a single handler with its parameters.
+message HandlerSchema {
+  // name is the handler name (e.g., "initiate_log").
+  string name = 1;
+
+  // description provides human-readable documentation.
+  string description = 2;
+
+  // parameters lists the parameters accepted by this handler.
+  repeated HandlerParameter parameters = 3;
+
+  // is_external indicates this handler calls external systems (non-idempotent).
+  bool is_external = 4;
+
+  // compensate_handler is the handler used for compensation/rollback (if any).
+  string compensate_handler = 5;
+}
+
+// HandlerParameter describes a single parameter for a handler.
+message HandlerParameter {
+  // name is the parameter name.
+  string name = 1;
+
+  // type is the parameter type (e.g., "string", "Decimal", "enum", "bool").
+  string type = 2;
+
+  // required indicates whether the parameter must be provided.
+  bool required = 3;
+
+  // enum_values lists allowed values for enum type parameters.
+  repeated string enum_values = 4;
+
+  // description provides human-readable documentation.
+  string description = 5;
 }

--- a/frontend/src/components/shared/handler-reference.test.tsx
+++ b/frontend/src/components/shared/handler-reference.test.tsx
@@ -1,6 +1,87 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { HandlerReference } from './handler-reference'
+import type { ServiceClients } from '@/api/clients'
+
+// Mock the API context
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+}))
+
+import { useApiClients } from '@/api/context'
+
+// Mock handler schema matching the real handlers.yaml structure
+const mockDescribeHandlersResponse = {
+  services: [
+    {
+      name: 'position_keeping',
+      handlers: [
+        {
+          name: 'initiate_log',
+          description: 'Initiates a position log entry',
+          parameters: [
+            { name: 'amount', type: 'Decimal', required: true, enumValues: [], description: '' },
+            { name: 'direction', type: 'enum', required: true, enumValues: ['DEBIT', 'CREDIT'], description: '' },
+          ],
+          isExternal: false,
+          compensateHandler: '',
+        },
+        {
+          name: 'finalize_log',
+          description: 'Finalizes a position log entry',
+          parameters: [
+            { name: 'log_id', type: 'string', required: true, enumValues: [], description: '' },
+          ],
+          isExternal: false,
+          compensateHandler: '',
+        },
+      ],
+    },
+    {
+      name: 'current_account',
+      handlers: [
+        {
+          name: 'debit',
+          description: 'Debits an account',
+          parameters: [
+            { name: 'account_id', type: 'string', required: true, enumValues: [], description: '' },
+            { name: 'amount', type: 'Decimal', required: true, enumValues: [], description: '' },
+          ],
+          isExternal: false,
+          compensateHandler: '',
+        },
+      ],
+    },
+  ],
+}
+
+function createMockClients() {
+  return {
+    sagaRegistry: {
+      describeHandlers: vi.fn().mockResolvedValue(mockDescribeHandlersResponse),
+    },
+  } as unknown as ServiceClients
+}
+
+function renderWithProviders(ui: React.ReactElement, clients?: ServiceClients) {
+  const mockClients = clients ?? createMockClients()
+  vi.mocked(useApiClients).mockReturnValue(mockClients)
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      {ui}
+    </QueryClientProvider>
+  )
+}
 
 describe('HandlerReference', () => {
   const defaultProps = {
@@ -13,12 +94,12 @@ describe('HandlerReference', () => {
   })
 
   it('renders handler reference container', () => {
-    const { container } = render(<HandlerReference {...defaultProps} />)
+    const { container } = renderWithProviders(<HandlerReference {...defaultProps} />)
     expect(container.querySelector('[data-testid="handler-reference"]')).toBeTruthy()
   })
 
   it('loads and displays schema services', async () => {
-    render(<HandlerReference {...defaultProps} />)
+    renderWithProviders(<HandlerReference {...defaultProps} />)
     // Wait for schema to load
     expect(
       await screen.findByText('position_keeping')
@@ -26,7 +107,7 @@ describe('HandlerReference', () => {
   })
 
   it('displays all services from schema', async () => {
-    render(<HandlerReference {...defaultProps} />)
+    renderWithProviders(<HandlerReference {...defaultProps} />)
     expect(
       await screen.findByText('position_keeping')
     ).toBeTruthy()
@@ -34,7 +115,7 @@ describe('HandlerReference', () => {
   })
 
   it('displays handler names within services', async () => {
-    render(<HandlerReference {...defaultProps} />)
+    renderWithProviders(<HandlerReference {...defaultProps} />)
     expect(
       await screen.findByText('initiate_log')
     ).toBeTruthy()
@@ -43,33 +124,57 @@ describe('HandlerReference', () => {
   })
 
   it('filters handlers by service name', async () => {
-    const { rerender } = render(<HandlerReference {...defaultProps} filter="" />)
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.mocked(useApiClients).mockReturnValue(createMockClients())
+
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <HandlerReference {...defaultProps} filter="" />
+      </QueryClientProvider>
+    )
     expect(
       await screen.findByText('position_keeping')
     ).toBeTruthy()
 
     // Filter by service
-    rerender(<HandlerReference {...defaultProps} filter="current_account" />)
-    expect(screen.getByText('current_account')).toBeTruthy()
-    // position_keeping should still exist but handlers should be hidden
-    expect(screen.queryByText('initiate_log')).toBeNull()
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <HandlerReference {...defaultProps} filter="current_account" />
+      </QueryClientProvider>
+    )
+    await waitFor(() => {
+      expect(screen.queryByText('initiate_log')).toBeNull()
+    })
     expect(screen.getByText('debit')).toBeTruthy()
   })
 
   it('filters handlers by handler name', async () => {
-    const { rerender } = render(<HandlerReference {...defaultProps} filter="" />)
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.mocked(useApiClients).mockReturnValue(createMockClients())
+
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <HandlerReference {...defaultProps} filter="" />
+      </QueryClientProvider>
+    )
     expect(
       await screen.findByText('initiate_log')
     ).toBeTruthy()
 
-    rerender(<HandlerReference {...defaultProps} filter="debit" />)
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <HandlerReference {...defaultProps} filter="debit" />
+      </QueryClientProvider>
+    )
+    await waitFor(() => {
+      expect(screen.queryByText('initiate_log')).toBeNull()
+    })
     expect(screen.getByText('debit')).toBeTruthy()
-    expect(screen.queryByText('initiate_log')).toBeNull()
     expect(screen.queryByText('finalize_log')).toBeNull()
   })
 
   it('expands and collapses service accordion', async () => {
-    render(<HandlerReference {...defaultProps} />)
+    renderWithProviders(<HandlerReference {...defaultProps} />)
     const accordionTrigger = await screen.findByRole('button', {
       name: /position_keeping/i,
     })
@@ -87,7 +192,7 @@ describe('HandlerReference', () => {
   })
 
   it('displays handler description', async () => {
-    render(<HandlerReference {...defaultProps} />)
+    renderWithProviders(<HandlerReference {...defaultProps} />)
     expect(
       await screen.findByText('Initiates a position log entry')
     ).toBeTruthy()
@@ -95,7 +200,7 @@ describe('HandlerReference', () => {
   })
 
   it('displays handler parameters with types', async () => {
-    render(<HandlerReference {...defaultProps} />)
+    renderWithProviders(<HandlerReference {...defaultProps} />)
     const direction = await screen.findByText('direction')
     expect(direction).toBeTruthy()
     // Check that parameters are displayed within a handler
@@ -103,14 +208,14 @@ describe('HandlerReference', () => {
   })
 
   it('marks required parameters with asterisk', async () => {
-    render(<HandlerReference {...defaultProps} />)
+    renderWithProviders(<HandlerReference {...defaultProps} />)
     const direction = await screen.findByText('direction')
     const paramContainer = direction.closest('li')
     expect(paramContainer?.textContent).toContain('*')
   })
 
   it('displays enum values for enum parameters', async () => {
-    render(<HandlerReference {...defaultProps} />)
+    renderWithProviders(<HandlerReference {...defaultProps} />)
     const directionText = await screen.findByText('direction')
     const paramContainer = directionText.closest('li')
     expect(paramContainer?.textContent).toContain('DEBIT')
@@ -119,7 +224,7 @@ describe('HandlerReference', () => {
 
   it('calls onInsert with correct Starlark call template', async () => {
     const onInsert = vi.fn()
-    render(<HandlerReference {...defaultProps} onInsert={onInsert} />)
+    renderWithProviders(<HandlerReference {...defaultProps} onInsert={onInsert} />)
 
     const insertButton = await screen.findByRole('button', {
       name: /insert.*initiate_log/i,
@@ -139,7 +244,7 @@ describe('HandlerReference', () => {
 
   it('generates correct template with multiple parameters', async () => {
     const onInsert = vi.fn()
-    render(<HandlerReference {...defaultProps} onInsert={onInsert} />)
+    renderWithProviders(<HandlerReference {...defaultProps} onInsert={onInsert} />)
 
     const insertButton = await screen.findByRole('button', {
       name: /insert.*debit/i,
@@ -153,38 +258,58 @@ describe('HandlerReference', () => {
   })
 
   it('generates template without parameters for handlers without params', async () => {
-    const onInsert = vi.fn()
-    render(<HandlerReference {...defaultProps} onInsert={onInsert} />)
+    renderWithProviders(<HandlerReference {...defaultProps} />)
 
-    // Filter to show only handlers we care about - in this test we just verify
-    // that the component can handle handlers with no params
-    // Since our mock data has params, we test the template generation logic directly
-    // by checking one of the generated templates
-    const insertButtons = await screen.findAllByRole('button')
     // Just verify that buttons were generated
+    const insertButtons = await screen.findAllByRole('button')
     expect(insertButtons.length).toBeGreaterThan(0)
   })
 
   it('case-insensitive filter search', async () => {
-    const { rerender } = render(<HandlerReference {...defaultProps} filter="" />)
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.mocked(useApiClients).mockReturnValue(createMockClients())
+
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <HandlerReference {...defaultProps} filter="" />
+      </QueryClientProvider>
+    )
     expect(
       await screen.findByText('initiate_log')
     ).toBeTruthy()
 
-    rerender(<HandlerReference {...defaultProps} filter="POSITION" />)
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <HandlerReference {...defaultProps} filter="POSITION" />
+      </QueryClientProvider>
+    )
     expect(screen.getByText('initiate_log')).toBeTruthy()
 
-    rerender(<HandlerReference {...defaultProps} filter="DeBiT" />)
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <HandlerReference {...defaultProps} filter="DeBiT" />
+      </QueryClientProvider>
+    )
+    await waitFor(() => {
+      expect(screen.queryByText('initiate_log')).toBeNull()
+    })
     expect(screen.getByText('debit')).toBeTruthy()
   })
 
   it('no results message when filter matches nothing', async () => {
-    render(<HandlerReference {...defaultProps} filter="nonexistent" />)
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.mocked(useApiClients).mockReturnValue(createMockClients())
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HandlerReference {...defaultProps} filter="nonexistent" />
+      </QueryClientProvider>
+    )
     expect(await screen.findByText(/no handlers found/i)).toBeTruthy()
   })
 
   it('accepts optional className prop', async () => {
-    const { container } = render(
+    const { container } = renderWithProviders(
       <HandlerReference {...defaultProps} className="custom-class" />,
     )
     expect(
@@ -193,14 +318,14 @@ describe('HandlerReference', () => {
   })
 
   it('displays type information in parameter list', async () => {
-    render(<HandlerReference {...defaultProps} />)
+    renderWithProviders(<HandlerReference {...defaultProps} />)
     const direction = await screen.findByText('direction')
     const paramContainer = direction.closest('li')
     expect(paramContainer?.textContent).toContain('enum')
   })
 
   it('disables insert button when service is collapsed', async () => {
-    render(<HandlerReference {...defaultProps} />)
+    renderWithProviders(<HandlerReference {...defaultProps} />)
     const accordionTrigger = await screen.findByRole('button', {
       name: /position_keeping/i,
     })
@@ -214,5 +339,31 @@ describe('HandlerReference', () => {
         name: /insert.*initiate_log/i,
       }),
     ).toBeNull()
+  })
+
+  it('shows loading state while fetching', () => {
+    // Create a mock that never resolves (simulates loading)
+    const mockClients = {
+      sagaRegistry: {
+        describeHandlers: vi.fn().mockReturnValue(new Promise(() => {})),
+      },
+    } as unknown as ServiceClients
+
+    renderWithProviders(<HandlerReference {...defaultProps} />, mockClients)
+
+    expect(screen.getByText(/loading handlers/i)).toBeTruthy()
+  })
+
+  it('shows error state with retry button when API fails', async () => {
+    const mockClients = {
+      sagaRegistry: {
+        describeHandlers: vi.fn().mockRejectedValue(new Error('Network error')),
+      },
+    } as unknown as ServiceClients
+
+    renderWithProviders(<HandlerReference {...defaultProps} />, mockClients)
+
+    expect(await screen.findByText(/network error/i)).toBeTruthy()
+    expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy()
   })
 })

--- a/frontend/src/components/shared/handler-reference.tsx
+++ b/frontend/src/components/shared/handler-reference.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { ChevronRight } from 'lucide-react'
+import { useApiClients } from '@/api/context'
 
 /**
  * Represents a parameter for a Starlark handler.
@@ -64,7 +65,7 @@ export interface HandlerReferenceProps {
  * HandlerReference component displays available Starlark handlers organized by service.
  *
  * Features:
- * - Loads handler schema from API (currently mock data)
+ * - Loads handler schema from the DescribeHandlers API
  * - Displays handlers grouped by service using accordion
  * - Filters handlers by service name or handler name (case-insensitive)
  * - Shows parameter types, required status, and enum values
@@ -74,90 +75,30 @@ export interface HandlerReferenceProps {
  * @returns React component displaying handler reference
  */
 export function HandlerReference({ filter = '', onInsert, className }: HandlerReferenceProps) {
-  const [schema, setSchema] = useState<HandlerSchemaResponse | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const clients = useApiClients()
 
-  // Fetch handler schema on mount
-  useEffect(() => {
-    const fetchSchema = async () => {
-      try {
-        setLoading(true)
-        // TODO: Replace with actual API call via Connect-ES
-        // For now, use mock data for testing
-        const mockResponse: HandlerSchemaResponse = {
-          services: [
-            {
-              serviceName: 'position_keeping',
-              handlers: [
-                {
-                  name: 'initiate_log',
-                  description: 'Initiates a position log entry',
-                  params: [
-                    {
-                      name: 'amount',
-                      type: 'Decimal',
-                      required: true,
-                      enumValues: [],
-                    },
-                    {
-                      name: 'direction',
-                      type: 'enum',
-                      required: true,
-                      enumValues: ['DEBIT', 'CREDIT'],
-                    },
-                  ],
-                },
-                {
-                  name: 'finalize_log',
-                  description: 'Finalizes a position log entry',
-                  params: [
-                    {
-                      name: 'log_id',
-                      type: 'string',
-                      required: true,
-                      enumValues: [],
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              serviceName: 'current_account',
-              handlers: [
-                {
-                  name: 'debit',
-                  description: 'Debits an account',
-                  params: [
-                    {
-                      name: 'account_id',
-                      type: 'string',
-                      required: true,
-                      enumValues: [],
-                    },
-                    {
-                      name: 'amount',
-                      type: 'Decimal',
-                      required: true,
-                      enumValues: [],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        }
-        setSchema(mockResponse)
-        setError(null)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load handler schema')
-      } finally {
-        setLoading(false)
+  const { data: schema, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ['handlers', 'schema'],
+    queryFn: async (): Promise<HandlerSchemaResponse> => {
+      const response = await clients.sagaRegistry.describeHandlers({})
+      return {
+        services: response.services.map((s) => ({
+          serviceName: s.name,
+          handlers: s.handlers.map((h) => ({
+            name: h.name,
+            description: h.description,
+            params: h.parameters.map((p) => ({
+              name: p.name,
+              type: p.type,
+              required: p.required,
+              enumValues: p.enumValues ?? [],
+            })),
+          })),
+        })),
       }
-    }
-
-    fetchSchema()
-  }, [])
+    },
+    staleTime: 5 * 60 * 1000, // Cache for 5 minutes
+  })
 
   /**
    * Generates a Starlark call template for a handler with its parameters.
@@ -202,7 +143,7 @@ export function HandlerReference({ filter = '', onInsert, className }: HandlerRe
     }))
     .filter((service) => service.handlers.length > 0)
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div
         data-testid="handler-reference"
@@ -213,13 +154,22 @@ export function HandlerReference({ filter = '', onInsert, className }: HandlerRe
     )
   }
 
-  if (error) {
+  if (isError) {
     return (
       <div
         data-testid="handler-reference"
         className={cn('rounded border border-destructive/30 bg-destructive/5 p-4 text-destructive', className)}
       >
-        Error: {error}
+        <p>Error: {error instanceof Error ? error.message : 'Failed to load handler schema'}</p>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={() => void refetch()}
+          className="mt-2"
+        >
+          Retry
+        </Button>
       </div>
     )
   }

--- a/services/reference-data/saga/grpc_handler.go
+++ b/services/reference-data/saga/grpc_handler.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -16,6 +17,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
 	"github.com/meridianhub/meridian/shared/pkg/saga/validation"
 )
 
@@ -27,12 +29,14 @@ type RegistryHandler struct {
 	registry        Registry
 	validator       *ReferenceValidator
 	dryRunValidator *validation.DryRunValidator
+	schemaRegistry  *schema.Registry
 	logger          *slog.Logger
 }
 
 // NewRegistryHandler creates a new saga registry gRPC handler.
 // The validator is optional - if nil, ValidateSagaDraft will return empty results.
 // The dryRunValidator is optional - if nil, ValidateSaga will return an error.
+// The schemaRegistry is optional - if nil, DescribeHandlers will load the platform default registry.
 func NewRegistryHandler(registry Registry, validator *ReferenceValidator, dryRunValidator *validation.DryRunValidator, logger *slog.Logger) *RegistryHandler {
 	if logger == nil {
 		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
@@ -43,6 +47,13 @@ func NewRegistryHandler(registry Registry, validator *ReferenceValidator, dryRun
 		dryRunValidator: dryRunValidator,
 		logger:          logger,
 	}
+}
+
+// WithSchemaRegistry sets the schema registry on the handler.
+// Used to inject a pre-loaded registry instead of loading the default.
+func (h *RegistryHandler) WithSchemaRegistry(reg *schema.Registry) *RegistryHandler {
+	h.schemaRegistry = reg
+	return h
 }
 
 // CreateSagaDraft creates a new saga definition in DRAFT status.
@@ -794,4 +805,84 @@ func calculateComplexityScore(handlerCallCount int) int {
 		return 10
 	}
 	return score
+}
+
+// DescribeHandlers returns the platform handler schema registry grouped by service.
+// Used by the Starlark editor to display available handlers and their parameter types.
+func (h *RegistryHandler) DescribeHandlers(
+	_ context.Context,
+	_ *sagav1.DescribeHandlersRequest,
+) (*sagav1.DescribeHandlersResponse, error) {
+	reg := h.schemaRegistry
+	if reg == nil {
+		var err error
+		reg, err = schema.DefaultRegistry()
+		if err != nil {
+			h.logger.Error("failed to load default handler schema registry", "error", err)
+			return nil, status.Errorf(codes.Internal, "failed to load handler schema: %v", err)
+		}
+	}
+
+	// Group handlers by service name (first component of "service.handler" name)
+	handlerNames := reg.ListHandlers()
+	serviceMap := make(map[string][]*sagav1.HandlerSchema)
+	serviceOrder := make([]string, 0)
+
+	for _, fullName := range handlerNames {
+		parts := strings.SplitN(fullName, ".", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		serviceName := parts[0]
+		handlerName := parts[1]
+
+		def, err := reg.GetHandler(fullName)
+		if err != nil {
+			continue
+		}
+
+		params := make([]*sagav1.HandlerParameter, 0, len(def.Params))
+		// Sort parameter names for deterministic output
+		paramNames := make([]string, 0, len(def.Params))
+		for paramName := range def.Params {
+			paramNames = append(paramNames, paramName)
+		}
+		sort.Strings(paramNames)
+
+		for _, paramName := range paramNames {
+			paramDef := def.Params[paramName]
+			params = append(params, &sagav1.HandlerParameter{
+				Name:        paramName,
+				Type:        string(paramDef.Type),
+				Required:    paramDef.Required,
+				EnumValues:  paramDef.Values,
+				Description: paramDef.Description,
+			})
+		}
+
+		if _, exists := serviceMap[serviceName]; !exists {
+			serviceOrder = append(serviceOrder, serviceName)
+		}
+		serviceMap[serviceName] = append(serviceMap[serviceName], &sagav1.HandlerSchema{
+			Name:              handlerName,
+			Description:       def.Description,
+			Parameters:        params,
+			IsExternal:        def.External,
+			CompensateHandler: def.Compensate,
+		})
+	}
+
+	sort.Strings(serviceOrder)
+
+	services := make([]*sagav1.HandlerServiceSchema, 0, len(serviceOrder))
+	for _, serviceName := range serviceOrder {
+		services = append(services, &sagav1.HandlerServiceSchema{
+			Name:     serviceName,
+			Handlers: serviceMap[serviceName],
+		})
+	}
+
+	return &sagav1.DescribeHandlersResponse{
+		Services: services,
+	}, nil
 }

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -3,6 +3,7 @@
 package schema
 
 import (
+	_ "embed"
 	"errors"
 	"fmt"
 	"os"
@@ -12,6 +13,9 @@ import (
 
 	"gopkg.in/yaml.v3"
 )
+
+//go:embed handlers.yaml
+var embeddedPlatformHandlers []byte
 
 // FieldType represents the type of a handler parameter or return value.
 type FieldType string
@@ -305,6 +309,26 @@ func (r *Registry) LoadFromFile(path string) error {
 		return fmt.Errorf("failed to read schema file %s: %w", path, err)
 	}
 	return r.LoadFromYAML(data)
+}
+
+// ListSchemas returns all loaded schemas in the registry.
+func (r *Registry) ListSchemas() []*Schema {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]*Schema, len(r.schemas))
+	copy(result, r.schemas)
+	return result
+}
+
+// DefaultRegistry creates a schema registry pre-loaded with the embedded platform handlers.yaml.
+// This provides the standard handler schema for Starlark saga validation and tooling.
+func DefaultRegistry() (*Registry, error) {
+	reg := NewRegistry()
+	if err := reg.LoadFromYAML(embeddedPlatformHandlers); err != nil {
+		return nil, fmt.Errorf("failed to load platform handlers: %w", err)
+	}
+	return reg, nil
 }
 
 // LoadFromDirectory loads all YAML schema files from a directory.


### PR DESCRIPTION
## Summary

- Adds `DescribeHandlers` RPC to `SagaRegistryService` proto, exposing the platform handler schema (from `handlers.yaml`) as a gRPC endpoint
- Implements the backend handler in `services/reference-data/saga` using an embedded default schema registry
- Replaces hardcoded mock data in `HandlerReference` component with `useQuery` calling `sagaRegistry.describeHandlers({})`
- Updates tests to mock `useApiClients` and wrap components in `QueryClientProvider`; adds loading and error state coverage

## Changes Made

### Proto (`api/proto/meridian/saga/v1/saga_registry.proto`)
- Added `DescribeHandlers` RPC with HTTP GET `/v1/sagas/handlers`
- Added message types: `DescribeHandlersRequest`, `DescribeHandlersResponse`, `HandlerServiceSchema`, `HandlerSchema`, `HandlerParameter`

### Backend (`shared/pkg/saga/schema/schema.go`)
- Added `DefaultRegistry()` function that loads the embedded `handlers.yaml`
- Added `ListSchemas()` method to `Registry`

### Backend (`services/reference-data/saga/grpc_handler.go`)
- Added `schemaRegistry` field to `RegistryHandler`
- Added `WithSchemaRegistry()` builder method
- Implemented `DescribeHandlers()` which groups handlers by service name, sorts for deterministic output

### Frontend (`frontend/src/components/shared/handler-reference.tsx`)
- Replaced `useState`/`useEffect` mock fetch with `useQuery` calling `clients.sagaRegistry.describeHandlers({})`
- Added retry button in error state
- 5-minute stale time for caching

### Frontend Tests (`frontend/src/components/shared/handler-reference.test.tsx`)
- Added `QueryClientProvider` wrapper and `useApiClients` mock
- Added loading state test and error state with retry button test
- Maintained all existing functional tests

## Test Plan

- [x] All 21 frontend tests pass (`vitest run`)
- [x] Go build passes (`go build ./...`)
- [x] Go schema tests pass (`go test ./shared/pkg/saga/schema/...`)
- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [x] ESLint passes
- [x] Pre-commit hooks pass (gitleaks, buf lint, gofumpt, golangci-lint)