### PR TITLE
feat: add accounts tab to party detail page

### DIFF
--- a/frontend/e2e/specs/parties.spec.ts
+++ b/frontend/e2e/specs/parties.spec.ts
@@ -90,7 +90,7 @@ test.describe('Party detail navigation', () => {
   })
 })
 
-test.describe('Party detail — 7-tab layout', () => {
+test.describe('Party detail — 8-tab layout', () => {
   test.beforeEach(async ({ authenticatedPage: page }) => {
     await navigateTo(page, '/parties')
     const rowCount = await page.locator('table tbody tr').count()
@@ -103,7 +103,7 @@ test.describe('Party detail — 7-tab layout', () => {
     await expect(page.getByRole('heading', { name: 'Party Details' })).toBeVisible()
   })
 
-  test('renders all 7 tab triggers', async ({ authenticatedPage: page }) => {
+  test('renders all 8 tab triggers', async ({ authenticatedPage: page }) => {
     const expectedTabs = [
       'Overview',
       'Demographics',
@@ -111,6 +111,7 @@ test.describe('Party detail — 7-tab layout', () => {
       'Associations',
       'Bank Relations',
       'Payment Methods',
+      'Accounts',
       'Audit Trail',
     ] as const
 
@@ -119,11 +120,11 @@ test.describe('Party detail — 7-tab layout', () => {
     }
   })
 
-  test('tab list has 7-column grid layout', async ({ authenticatedPage: page }) => {
+  test('tab list has 8-column grid layout', async ({ authenticatedPage: page }) => {
     const tabList = page.getByRole('tablist')
     await expect(tabList).toBeVisible()
-    // Verify the CSS grid class from [partyId].tsx:33
-    await expect(tabList).toHaveClass(/grid-cols-7/)
+    // Verify the CSS grid class from [partyId].tsx:34
+    await expect(tabList).toHaveClass(/grid-cols-8/)
   })
 
   test('Overview tab is selected by default', async ({ authenticatedPage: page }) => {

--- a/frontend/src/pages/parties/[partyId].tsx
+++ b/frontend/src/pages/parties/[partyId].tsx
@@ -10,6 +10,7 @@ import { AssociationsTab } from './tabs/associations-tab'
 import { BankRelationsTab } from './tabs/bank-relations-tab'
 import { PaymentMethodsTab } from './tabs/payment-methods-tab'
 import { AuditTrailTab } from './tabs/audit-trail-tab'
+import { AccountsTab } from './tabs/accounts-tab'
 
 export function PartyDetailPage() {
   const { partyId } = useParams<{ partyId: string }>()
@@ -30,13 +31,14 @@ export function PartyDetailPage() {
 
       <Card>
         <Tabs defaultValue="overview" className="w-full">
-          <TabsList className="grid w-full grid-cols-7 border-b rounded-none">
+          <TabsList className="grid w-full grid-cols-8 border-b rounded-none">
             <TabsTrigger value="overview">Overview</TabsTrigger>
             <TabsTrigger value="demographics">Demographics</TabsTrigger>
             <TabsTrigger value="references">References</TabsTrigger>
             <TabsTrigger value="associations">Associations</TabsTrigger>
             <TabsTrigger value="bank-relations">Bank Relations</TabsTrigger>
             <TabsTrigger value="payment-methods">Payment Methods</TabsTrigger>
+            <TabsTrigger value="accounts">Accounts</TabsTrigger>
             <TabsTrigger value="audit-trail">Audit Trail</TabsTrigger>
           </TabsList>
 
@@ -63,6 +65,10 @@ export function PartyDetailPage() {
 
             <TabsContent value="payment-methods" className="mt-0">
               <PaymentMethodsTab partyId={partyId} />
+            </TabsContent>
+
+            <TabsContent value="accounts" className="mt-0">
+              <AccountsTab partyId={partyId} />
             </TabsContent>
 
             <TabsContent value="audit-trail" className="mt-0">

--- a/frontend/src/pages/parties/tabs/accounts-tab.tsx
+++ b/frontend/src/pages/parties/tabs/accounts-tab.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { ColumnDef } from '@tanstack/react-table'
+import { DataTable } from '@/components/shared/data-table'
+import type { DataTableQueryParams, DataTableResult } from '@/components/shared/data-table'
+import { EntityLink } from '@/components/shared/entity-link'
+import { StatusBadge } from '@/components/shared/status-badge'
+import { TimeDisplay } from '@/components/shared/time-display'
+import { useClients } from '@/api/context'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import { AccountStatus } from '@/api/gen/meridian/current_account/v1/current_account_pb'
+
+interface AccountsTabProps {
+  partyId: string
+}
+
+interface AccountRow {
+  accountId: string
+  externalReference: string
+  status: string
+  instrumentCode: string
+  createdAt?: { seconds: number | bigint; nanos?: number }
+}
+
+const ACCOUNT_STATUS_NAMES: Record<number, string> = {
+  [AccountStatus.ACTIVE]: 'ACTIVE',
+  [AccountStatus.FROZEN]: 'FROZEN',
+  [AccountStatus.CLOSED]: 'CLOSED',
+}
+
+const columns: ColumnDef<AccountRow>[] = [
+  {
+    accessorKey: 'accountId',
+    header: 'Account ID',
+    cell: ({ row }) => (
+      <EntityLink type="account" id={row.original.accountId} />
+    ),
+  },
+  {
+    accessorKey: 'externalReference',
+    header: 'External Ref',
+  },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    cell: ({ row }) => <StatusBadge status={row.original.status} />,
+  },
+  {
+    accessorKey: 'instrumentCode',
+    header: 'Instrument',
+  },
+  {
+    accessorKey: 'createdAt',
+    header: 'Created',
+    cell: ({ row }) => <TimeDisplay timestamp={row.original.createdAt} format="relative" />,
+  },
+]
+
+export function AccountsTab({ partyId }: AccountsTabProps) {
+  const clients = useClients()
+  const tenantSlug = useTenantSlug()
+  const navigate = useNavigate()
+
+  const queryKey = React.useMemo(
+    () => [...tenantKeys.party(tenantSlug ?? '', partyId), 'accounts'],
+    [tenantSlug, partyId],
+  )
+
+  const queryFn = React.useCallback(
+    async (params: DataTableQueryParams): Promise<DataTableResult<AccountRow>> => {
+      if (!tenantSlug) return { items: [] }
+
+      const response = await clients.currentAccount.listCurrentAccounts({
+        pageSize: params.pageSize,
+        pageToken: params.pageToken ?? '',
+      })
+
+      const accounts: AccountRow[] = (response.accounts ?? [])
+        .filter((a) => a.orgPartyId === partyId)
+        .map((a) => ({
+          accountId: a.accountId,
+          externalReference: a.externalIdentifier ?? '',
+          status: ACCOUNT_STATUS_NAMES[a.accountStatus] ?? String(a.accountStatus),
+          instrumentCode: a.instrumentCode || '',
+          createdAt: a.createdAt ?? undefined,
+        }))
+
+      return {
+        items: accounts,
+        nextPageToken: response.nextPageToken || undefined,
+      }
+    },
+    [tenantSlug, partyId, clients],
+  )
+
+  return (
+    <DataTable
+      queryKey={queryKey}
+      queryFn={queryFn}
+      columns={columns}
+      onRowClick={(row) => navigate(`/accounts/${row.accountId}`)}
+    />
+  )
+}

--- a/frontend/src/pages/parties/tabs/accounts-tab.tsx
+++ b/frontend/src/pages/parties/tabs/accounts-tab.tsx
@@ -73,12 +73,16 @@ export function AccountsTab({ partyId }: AccountsTabProps) {
 
       // The API does not support filtering by partyId, so we fetch pages and filter
       // client-side. We continue fetching until we have enough matching rows to fill
-      // pageSize, or the API is exhausted.
+      // pageSize, or the API is exhausted. MAX_PAGES caps sequential API calls to
+      // prevent unbounded fetching when the party owns few accounts in a large dataset.
+      const MAX_PAGES = 10
       const collected: AccountRow[] = []
       let cursor = params.pageToken ?? ''
       let nextPageToken: string | undefined
+      let pagesScanned = 0
 
-      while (collected.length < params.pageSize) {
+      while (collected.length < params.pageSize && pagesScanned < MAX_PAGES) {
+        pagesScanned++
         const response = await clients.currentAccount.listCurrentAccounts({
           pageSize: 100,
           pageToken: cursor,

--- a/frontend/src/pages/parties/tabs/accounts-tab.tsx
+++ b/frontend/src/pages/parties/tabs/accounts-tab.tsx
@@ -71,24 +71,43 @@ export function AccountsTab({ partyId }: AccountsTabProps) {
     async (params: DataTableQueryParams): Promise<DataTableResult<AccountRow>> => {
       if (!tenantSlug) return { items: [] }
 
-      const response = await clients.currentAccount.listCurrentAccounts({
-        pageSize: params.pageSize,
-        pageToken: params.pageToken ?? '',
-      })
+      // The API does not support filtering by partyId, so we fetch pages and filter
+      // client-side. We continue fetching until we have enough matching rows to fill
+      // pageSize, or the API is exhausted.
+      const collected: AccountRow[] = []
+      let cursor = params.pageToken ?? ''
+      let nextPageToken: string | undefined
 
-      const accounts: AccountRow[] = (response.accounts ?? [])
-        .filter((a) => a.orgPartyId === partyId)
-        .map((a) => ({
-          accountId: a.accountId,
-          externalReference: a.externalIdentifier ?? '',
-          status: ACCOUNT_STATUS_NAMES[a.accountStatus] ?? String(a.accountStatus),
-          instrumentCode: a.instrumentCode || '',
-          createdAt: a.createdAt ?? undefined,
-        }))
+      while (collected.length < params.pageSize) {
+        const response = await clients.currentAccount.listCurrentAccounts({
+          pageSize: 100,
+          pageToken: cursor,
+        })
+
+        for (const a of response.accounts ?? []) {
+          if (a.orgPartyId === partyId) {
+            collected.push({
+              accountId: a.accountId,
+              externalReference: a.externalIdentifier ?? '',
+              status: ACCOUNT_STATUS_NAMES[a.accountStatus] ?? String(a.accountStatus),
+              instrumentCode: a.instrumentCode || '',
+              createdAt: a.createdAt ?? undefined,
+            })
+          }
+        }
+
+        if (!response.nextPageToken) {
+          nextPageToken = undefined
+          break
+        }
+
+        cursor = response.nextPageToken
+        nextPageToken = response.nextPageToken
+      }
 
       return {
-        items: accounts,
-        nextPageToken: response.nextPageToken || undefined,
+        items: collected.slice(0, params.pageSize),
+        nextPageToken,
       }
     },
     [tenantSlug, partyId, clients],

--- a/frontend/src/pages/parties/tabs/accounts-tab.tsx
+++ b/frontend/src/pages/parties/tabs/accounts-tab.tsx
@@ -83,8 +83,12 @@ export function AccountsTab({ partyId }: AccountsTabProps) {
 
       while (collected.length < params.pageSize && pagesScanned < MAX_PAGES) {
         pagesScanned++
+        // Use remaining slots as batch size to avoid dropping same-page overflow:
+        // if the batch were larger than remaining slots, we might get more matches
+        // than pageSize in one batch but nextPageToken would advance past them.
+        const remaining = Math.max(params.pageSize - collected.length, 1)
         const response = await clients.currentAccount.listCurrentAccounts({
-          pageSize: 100,
+          pageSize: remaining,
           pageToken: cursor,
         })
 


### PR DESCRIPTION
## Summary

- Adds a new **Accounts** tab to the party detail page
- Displays all accounts associated with the party (filtered by `orgPartyId`) in a `DataTable`
- Account IDs are rendered as `EntityLink` components linking to `/accounts/:id`
- Columns: Account ID (linked), External Ref, Status (badge), Instrument, Created (relative)
- Clicking a row navigates to the account detail page

## Changes Made

- `frontend/src/pages/parties/tabs/accounts-tab.tsx` — new tab component using `DataTable` + `EntityLink`
- `frontend/src/pages/parties/[partyId].tsx` — integrates `AccountsTab` as the 7th tab (before Audit Trail), updates grid from `grid-cols-7` to `grid-cols-8`

## Technical Details

The `ListCurrentAccounts` API does not support filtering by `partyId` directly. Accounts are associated with a party via the `orgPartyId` field on `CurrentAccountFacility`, so results are filtered client-side by `orgPartyId === partyId`.

## Testing

- TypeScript typecheck: passes
- ESLint: no new errors (2 pre-existing warnings in unrelated files)