### PR TITLE
feat: implement transactions page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,6 +42,7 @@ import { ReconciliationDetailPage } from '@/pages/reconciliation/detail'
 import { DashboardPage } from '@/pages/dashboard'
 import { ManifestsPage } from '@/pages/manifests'
 import { McpConfigPage } from '@/pages/mcp-config'
+import { TransactionsPage } from '@/pages/transactions'
 
 // Placeholder page components - replaced as each page task is implemented
 function PlaceholderPage({ title }: { title: string }) {
@@ -242,7 +243,7 @@ function AppShellLayout() {
         <Route path="/internal-accounts/:accountId" element={guarded(<InternalAccountDetailPage />)} />
         <Route path="/payments" element={guarded(<PaymentsPage />)} />
         <Route path="/payments/:paymentOrderId" element={guarded(<PaymentDetailPage />)} />
-        <Route path="/transactions" element={guarded(<PlaceholderPage title="Transactions" />)} />
+        <Route path="/transactions" element={guarded(<TransactionsPage />)} />
         <Route path="/positions" element={guarded(<PositionsPage />)} />
         <Route path="/positions/:logId" element={guarded(<PositionDetailPage />)} />
         <Route path="/ledger" element={guarded(<LedgerPage />)} />

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -33,6 +33,7 @@ const TENANT_NAV_ITEMS: NavItem[] = [
   { label: 'Accounts', href: '/accounts', icon: Wallet },
   { label: 'Internal Accounts', href: '/internal-accounts', icon: Building },
   { label: 'Payments', href: '/payments', icon: ArrowLeftRight },
+  { label: 'Transactions', href: '/transactions', icon: Activity },
   { label: 'Positions', href: '/positions', icon: TrendingUp },
   { label: 'Ledger', href: '/ledger', icon: BookOpen },
   { label: 'Parties', href: '/parties', icon: Users },

--- a/frontend/src/pages/transactions/index.tsx
+++ b/frontend/src/pages/transactions/index.tsx
@@ -1,0 +1,181 @@
+import type { ColumnDef } from '@tanstack/react-table'
+import { useApiClients } from '@/api/context'
+import { useTenantContext } from '@/contexts/tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import { DataTable, type DataTableQueryParams, type DataTableResult } from '@/components/shared/data-table'
+import { TimeDisplay } from '@/components/shared/time-display'
+import { DirectionBadge } from '@/components/shared/direction-badge'
+import { EntityLink } from '@/components/shared/entity-link'
+import { MoneyDisplay } from '@/components/shared/money-display'
+
+interface LedgerPosting {
+  id: string
+  financialBookingLogId: string
+  postingDirection: string
+  amount: bigint | string
+  currency: string
+  accountId: string
+  valueDate: { seconds: bigint | number; nanos?: number } | null | undefined
+  createdAt: { seconds: bigint | number; nanos?: number } | null | undefined
+  status: string
+}
+
+function getDirectionName(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number') {
+    const directionMap: Record<number, string> = {
+      0: 'UNSPECIFIED',
+      1: 'DEBIT',
+      2: 'CREDIT',
+    }
+    return directionMap[value] ?? String(value)
+  }
+  return String(value ?? '')
+}
+
+const columns: ColumnDef<LedgerPosting>[] = [
+  {
+    accessorKey: 'valueDate',
+    header: 'Timestamp',
+    enableSorting: true,
+    cell: ({ row }) => (
+      <TimeDisplay timestamp={row.original.valueDate} format="relative" />
+    ),
+  },
+  {
+    accessorKey: 'accountId',
+    header: 'Account',
+    cell: ({ row }) => (
+      <EntityLink type="account" id={row.original.accountId} />
+    ),
+  },
+  {
+    accessorKey: 'postingDirection',
+    header: 'Direction',
+    cell: ({ row }) => <DirectionBadge direction={row.original.postingDirection} />,
+  },
+  {
+    accessorKey: 'amount',
+    header: 'Amount',
+    enableSorting: true,
+    cell: ({ row }) => (
+      <MoneyDisplay amount={row.original.amount} currency={row.original.currency} />
+    ),
+  },
+  {
+    accessorKey: 'currency',
+    header: 'Instrument',
+  },
+  {
+    accessorKey: 'financialBookingLogId',
+    header: 'Booking Log',
+    cell: ({ row }) => (
+      <EntityLink
+        type="booking-log"
+        id={row.original.financialBookingLogId}
+        label={row.original.financialBookingLogId.slice(0, 8) + '…'}
+      />
+    ),
+  },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    cell: ({ row }) => (
+      <span className="text-sm text-muted-foreground">{row.original.status}</span>
+    ),
+  },
+]
+
+export function TransactionsPage() {
+  const { tenantSlug } = useTenantContext()
+  const clients = useApiClients()
+
+  async function fetchPostings(
+    params: DataTableQueryParams,
+  ): Promise<DataTableResult<LedgerPosting>> {
+    if (!tenantSlug) return { items: [] }
+
+    const directionFilter = params.filters?.postingDirection
+    const accountFilter = params.filters?.accountId ?? ''
+
+    const directionEnumMap: Record<string, number> = {
+      DEBIT: 1,
+      CREDIT: 2,
+    }
+    const postingDirection = directionFilter
+      ? (directionEnumMap[directionFilter] as never)
+      : (0 as never)
+
+    const response = await clients.financialAccounting.listLedgerPostings({
+      pagination: { pageSize: params.pageSize, pageToken: params.pageToken ?? '' },
+      accountId: accountFilter,
+      postingDirection,
+    })
+
+    const items = (response.ledgerPostings ?? []).map((p) => {
+      const money = p.postingAmount as { currencyCode?: string; units?: bigint | string | number; nanos?: number } | null | undefined
+      const currency = money?.currencyCode ?? ''
+      const rawUnits = money?.units
+      let amount: bigint | string = 0n
+      if (rawUnits !== null && rawUnits !== undefined) {
+        amount = typeof rawUnits === 'bigint' ? rawUnits : BigInt(String(rawUnits))
+      }
+
+      return {
+        id: p.id ?? '',
+        financialBookingLogId: p.financialBookingLogId ?? '',
+        postingDirection: getDirectionName(p.postingDirection),
+        amount,
+        currency,
+        accountId: p.accountId ?? '',
+        valueDate: p.valueDate ?? null,
+        createdAt: p.createdAt ?? null,
+        status: getDirectionName(p.status),
+      }
+    }) as LedgerPosting[]
+
+    const nextPageToken =
+      typeof response.pagination?.nextPageToken === 'string'
+        ? response.pagination.nextPageToken
+        : undefined
+
+    return {
+      items,
+      nextPageToken: nextPageToken || undefined,
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Transactions</h1>
+        <p className="text-muted-foreground">
+          Ledger postings across all accounts
+        </p>
+      </div>
+
+      <DataTable<LedgerPosting>
+        queryKey={[...(tenantSlug ? tenantKeys.transactions(tenantSlug) : ['no-tenant']), 'postings']}
+        queryFn={fetchPostings}
+        columns={columns}
+        pageSize={25}
+        filters={[
+          {
+            field: 'accountId',
+            label: 'Account ID',
+            type: 'text',
+          },
+          {
+            field: 'postingDirection',
+            label: 'Direction',
+            type: 'select',
+            options: [
+              { label: 'Debit', value: 'DEBIT' },
+              { label: 'Credit', value: 'CREDIT' },
+            ],
+          },
+        ]}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/transactions/index.tsx
+++ b/frontend/src/pages/transactions/index.tsx
@@ -12,7 +12,7 @@ interface LedgerPosting {
   id: string
   financialBookingLogId: string
   postingDirection: string
-  amount: bigint | string
+  amount: bigint
   currency: string
   accountId: string
   valueDate: { seconds: bigint | number; nanos?: number } | null | undefined
@@ -31,6 +31,35 @@ function getDirectionName(value: unknown): string {
     return directionMap[value] ?? String(value)
   }
   return String(value ?? '')
+}
+
+function getStatusName(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number') {
+    const statusMap: Record<number, string> = {
+      0: 'UNSPECIFIED',
+      1: 'PENDING',
+      2: 'POSTED',
+      3: 'FAILED',
+      4: 'CANCELLED',
+      5: 'REVERSED',
+    }
+    return statusMap[value] ?? String(value)
+  }
+  return String(value ?? '')
+}
+
+function parseUnitsAsBigInt(rawUnits: bigint | string | number | null | undefined): bigint {
+  if (rawUnits === null || rawUnits === undefined) return 0n
+  if (typeof rawUnits === 'bigint') return rawUnits
+  try {
+    const str = String(rawUnits)
+    // Truncate decimal portion if present (e.g. float "1234.56" -> "1234")
+    const intStr = str.includes('.') ? str.split('.')[0] : str
+    return BigInt(intStr)
+  } catch {
+    return 0n
+  }
 }
 
 const columns: ColumnDef<LedgerPosting>[] = [
@@ -116,10 +145,7 @@ export function TransactionsPage() {
       const money = p.postingAmount as { currencyCode?: string; units?: bigint | string | number; nanos?: number } | null | undefined
       const currency = money?.currencyCode ?? ''
       const rawUnits = money?.units
-      let amount: bigint | string = 0n
-      if (rawUnits !== null && rawUnits !== undefined) {
-        amount = typeof rawUnits === 'bigint' ? rawUnits : BigInt(String(rawUnits))
-      }
+      const amount: bigint = parseUnitsAsBigInt(rawUnits)
 
       return {
         id: p.id ?? '',
@@ -130,7 +156,7 @@ export function TransactionsPage() {
         accountId: p.accountId ?? '',
         valueDate: p.valueDate ?? null,
         createdAt: p.createdAt ?? null,
-        status: getDirectionName(p.status),
+        status: getStatusName(p.status),
       }
     }) as LedgerPosting[]
 


### PR DESCRIPTION
## Summary

- Replaces `PlaceholderPage` on `/transactions` route with a full `TransactionsPage` component
- Displays ledger postings from the `financialAccounting.listLedgerPostings` API in a DataTable
- Adds account ID text filter and direction (debit/credit) dropdown filter
- Uses `EntityLink` for account and booking log navigation, `DirectionBadge` for direction display, `MoneyDisplay` for amount formatting
- Adds "Transactions" nav item to the sidebar between Payments and Positions

## Changes Made

- `frontend/src/pages/transactions/index.tsx` — new page component
- `frontend/src/App.tsx` — import and wire `TransactionsPage` to `/transactions` route
- `frontend/src/components/layout/sidebar.tsx` — add Transactions nav item

## Test plan

- [ ] `/transactions` route renders the DataTable (no longer shows "Coming soon")
- [ ] Account ID filter restricts rows to the given account
- [ ] Direction filter shows only DEBIT or CREDIT rows
- [ ] Account ID column links to `/accounts/<id>`
- [ ] Booking Log column links to `/ledger/<id>`
- [ ] Amount column displays formatted currency
- [ ] Direction column shows DirectionBadge (colour-coded DEBIT/CREDIT)
- [ ] Sidebar "Transactions" nav item is active when on `/transactions`
- [ ] Typecheck: `npm run typecheck` passes
- [ ] Lint: `npm run lint` shows no errors (pre-existing warnings only)