### PR TITLE
feat: add breadcrumb navigation to all detail pages

### DIFF
--- a/frontend/e2e/positions.spec.ts
+++ b/frontend/e2e/positions.spec.ts
@@ -60,19 +60,19 @@ test.describe('Position detail page', () => {
     ).toBeVisible({ timeout: 10_000 })
   })
 
-  test('renders back button on position detail page', async ({ authenticatedPage }) => {
+  test('renders breadcrumb back link on position detail page', async ({ authenticatedPage }) => {
     await navigateTo(authenticatedPage, '/positions/non-existent-log-id')
     await expect(
-      authenticatedPage.getByTestId('back-button'),
+      authenticatedPage.getByRole('link', { name: 'Positions' }),
     ).toBeVisible({ timeout: 10_000 })
   })
 
-  test('back button navigates to positions list', async ({ authenticatedPage }) => {
+  test('breadcrumb back link navigates to positions list', async ({ authenticatedPage }) => {
     await navigateTo(authenticatedPage, '/positions/non-existent-log-id')
     await expect(
-      authenticatedPage.getByTestId('back-button'),
+      authenticatedPage.getByRole('link', { name: 'Positions' }),
     ).toBeVisible({ timeout: 10_000 })
-    await authenticatedPage.getByTestId('back-button').click()
+    await authenticatedPage.getByRole('link', { name: 'Positions' }).click()
     await expect(authenticatedPage.getByRole('heading', { name: 'Positions' })).toBeVisible()
   })
 })

--- a/frontend/e2e/specs/parties.spec.ts
+++ b/frontend/e2e/specs/parties.spec.ts
@@ -74,16 +74,16 @@ test.describe('Party detail navigation', () => {
     await expect(firstRow).toBeVisible()
     await firstRow.click()
     await expect(page).toHaveURL(/\/parties\/[a-zA-Z0-9-]+/)
-    await expect(page.getByRole('heading', { name: 'Party Details' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Parties' })).toBeVisible()
   })
 
   test('shows Party ID not found for missing partyId param', async ({ authenticatedPage: page }) => {
     // Directly verify that the error message renders for an invalid ID
     await navigateTo(page, '/parties/00000000-0000-0000-0000-000000000000')
-    // Page should render — it will show either the header or an error state
+    // Page should render — it will show either the party data or an error state
     // (the component renders even without backend data)
     await expect(
-      page.getByRole('heading', { name: 'Party Details' }).or(
+      page.getByRole('link', { name: 'Parties' }).or(
         page.getByText('Party not found')
       )
     ).toBeVisible()
@@ -100,7 +100,7 @@ test.describe('Party detail — 7-tab layout', () => {
     } else {
       await page.locator('table tbody tr').first().click()
     }
-    await expect(page.getByRole('heading', { name: 'Party Details' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Parties' })).toBeVisible()
   })
 
   test('renders all 7 tab triggers', async ({ authenticatedPage: page }) => {
@@ -140,7 +140,7 @@ test.describe('Party header component', () => {
       return
     }
     await page.locator('table tbody tr').first().click()
-    await expect(page.getByRole('heading', { name: 'Party Details' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Parties' })).toBeVisible()
   })
 
   test('renders party header section', async ({ authenticatedPage: page }) => {
@@ -168,7 +168,7 @@ test.describe('Tab switching', () => {
     } else {
       await page.locator('table tbody tr').first().click()
     }
-    await expect(page.getByRole('heading', { name: 'Party Details' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Parties' })).toBeVisible()
   })
 
   test('Overview tab renders without error', async ({ authenticatedPage: page }) => {
@@ -243,7 +243,7 @@ test.describe('Tab keyboard navigation', () => {
     } else {
       await page.locator('table tbody tr').first().click()
     }
-    await expect(page.getByRole('heading', { name: 'Party Details' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Parties' })).toBeVisible()
   })
 
   test('ArrowRight moves focus to next tab', async ({ authenticatedPage: page }) => {

--- a/frontend/src/components/shared/breadcrumbs.tsx
+++ b/frontend/src/components/shared/breadcrumbs.tsx
@@ -1,0 +1,42 @@
+import { Link } from 'react-router-dom'
+import { ChevronRight, HomeIcon } from 'lucide-react'
+
+export interface BreadcrumbItem {
+  label: string
+  href?: string
+}
+
+export interface BreadcrumbsProps {
+  items: BreadcrumbItem[]
+}
+
+export function Breadcrumbs({ items }: BreadcrumbsProps) {
+  return (
+    <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-sm text-muted-foreground">
+      <Link
+        to="/"
+        className="flex items-center hover:text-foreground transition-colors"
+        aria-label="Dashboard"
+      >
+        <HomeIcon className="h-4 w-4" />
+      </Link>
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1
+        return (
+          <span key={index} className="flex items-center gap-1">
+            <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+            {isLast || !item.href ? (
+              <span className={isLast ? 'text-foreground font-medium' : undefined}>
+                {item.label}
+              </span>
+            ) : (
+              <Link to={item.href} className="hover:text-foreground transition-colors">
+                {item.label}
+              </Link>
+            )}
+          </span>
+        )
+      })}
+    </nav>
+  )
+}

--- a/frontend/src/components/shared/index.ts
+++ b/frontend/src/components/shared/index.ts
@@ -16,3 +16,6 @@ export type { CreateValuationFeatureDialogProps, AccountType } from './create-va
 
 export { EntityLink } from './entity-link';
 export type { EntityLinkProps, EntityType } from './entity-link';
+
+export { Breadcrumbs } from './breadcrumbs';
+export type { BreadcrumbsProps, BreadcrumbItem } from './breadcrumbs';

--- a/frontend/src/pages/accounts/[accountId].tsx
+++ b/frontend/src/pages/accounts/[accountId].tsx
@@ -1,14 +1,13 @@
 import * as React from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { ChevronLeftIcon } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { MoneyDisplay } from '@/components/shared/money-display'
-import { AuditTrail, EntityLink } from '@/components/shared'
+import { AuditTrail, EntityLink, Breadcrumbs } from '@/components/shared'
 import { ConnectError, Code } from '@connectrpc/connect'
 import { useApiClients } from '@/api/context'
 import { useTenantContext } from '@/contexts/tenant-context'
@@ -74,14 +73,7 @@ function AccountDetailSkeleton() {
 function AccountNotFound() {
   return (
     <div data-testid="account-not-found" className="p-6">
-      <Link
-        to="/accounts"
-        className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-        aria-label="Back to Accounts"
-      >
-        <ChevronLeftIcon className="h-4 w-4" />
-        Accounts
-      </Link>
+      <Breadcrumbs items={[{ label: 'Accounts', href: '/accounts' }, { label: 'Not found' }]} />
       <div className="mt-8 text-center">
         <h2 className="text-xl font-semibold">Account not found</h2>
         <p className="mt-2 text-sm text-muted-foreground">
@@ -350,15 +342,13 @@ export function AccountDetailPage() {
 
   return (
     <div className="p-6">
-      {/* Back navigation */}
-      <Link
-        to="/accounts"
-        className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-        aria-label="Back to Accounts"
-      >
-        <ChevronLeftIcon className="h-4 w-4" />
-        Accounts
-      </Link>
+      {/* Breadcrumb navigation */}
+      <Breadcrumbs
+        items={[
+          { label: 'Accounts', href: '/accounts' },
+          { label: account.accountId },
+        ]}
+      />
 
       {/* Page header */}
       <div className="mt-4 flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/internal-accounts/[accountId].tsx
+++ b/frontend/src/pages/internal-accounts/[accountId].tsx
@@ -1,14 +1,13 @@
 import * as React from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { ChevronLeftIcon } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { MoneyDisplay } from '@/components/shared/money-display'
-import { AuditTrail } from '@/components/shared'
+import { AuditTrail, Breadcrumbs } from '@/components/shared'
 import { ConnectError, Code } from '@connectrpc/connect'
 import { useApiClients } from '@/api/context'
 import { useTenantContext } from '@/contexts/tenant-context'
@@ -92,14 +91,7 @@ function InternalAccountDetailSkeleton() {
 function InternalAccountNotFound() {
   return (
     <div data-testid="internal-account-not-found" className="p-6">
-      <Link
-        to="/internal-accounts"
-        className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-        aria-label="Back to Internal Accounts"
-      >
-        <ChevronLeftIcon className="h-4 w-4" />
-        Internal Accounts
-      </Link>
+      <Breadcrumbs items={[{ label: 'Internal Accounts', href: '/internal-accounts' }, { label: 'Not found' }]} />
       <div className="mt-8 text-center">
         <h2 className="text-xl font-semibold">Account not found</h2>
         <p className="mt-2 text-sm text-muted-foreground">
@@ -321,14 +313,7 @@ export function InternalAccountDetailPage() {
   if (isError) {
     return (
       <div className="p-6">
-        <Link
-          to="/internal-accounts"
-          className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-          aria-label="Back to Internal Accounts"
-        >
-          <ChevronLeftIcon className="h-4 w-4" />
-          Internal Accounts
-        </Link>
+        <Breadcrumbs items={[{ label: 'Internal Accounts', href: '/internal-accounts' }, { label: 'Error' }]} />
         <p className="mt-4 text-sm text-destructive">Failed to load account details. Please try again.</p>
       </div>
     )
@@ -342,15 +327,13 @@ export function InternalAccountDetailPage() {
 
   return (
     <div className="p-6">
-      {/* Back navigation */}
-      <Link
-        to="/internal-accounts"
-        className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-        aria-label="Back to Internal Accounts"
-      >
-        <ChevronLeftIcon className="h-4 w-4" />
-        Internal Accounts
-      </Link>
+      {/* Breadcrumb navigation */}
+      <Breadcrumbs
+        items={[
+          { label: 'Internal Accounts', href: '/internal-accounts' },
+          { label: account.accountCode },
+        ]}
+      />
 
       {/* Page header */}
       <div className="mt-4 flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/ledger/booking-log-detail.tsx
+++ b/frontend/src/pages/ledger/booking-log-detail.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import type { ColumnDef } from '@tanstack/react-table'
 import {
@@ -10,7 +10,7 @@ import { useApiClients } from '@/api/context'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
 import { StatusBadge } from '@/components/shared/status-badge'
-import { TimeDisplay, EntityLink } from '@/components/shared'
+import { TimeDisplay, EntityLink, Breadcrumbs } from '@/components/shared'
 import { MoneyDisplay } from '@/components/shared/money-display'
 import {
   Table,
@@ -251,13 +251,7 @@ export function BookingLogDetailPage() {
   if (isLoading) {
     return (
       <div className="space-y-6">
-        <div className="flex items-center gap-2">
-          <Link to="/ledger" className="text-sm text-muted-foreground hover:underline">
-            Ledger
-          </Link>
-          <span className="text-muted-foreground">/</span>
-          <span className="text-sm">Loading...</span>
-        </div>
+        <Breadcrumbs items={[{ label: 'Ledger', href: '/ledger' }, { label: 'Loading...' }]} />
         <div className="h-32 animate-pulse rounded-lg bg-muted" />
       </div>
     )
@@ -266,13 +260,7 @@ export function BookingLogDetailPage() {
   if (isError || !data) {
     return (
       <div className="space-y-6">
-        <div className="flex items-center gap-2">
-          <Link to="/ledger" className="text-sm text-muted-foreground hover:underline">
-            Ledger
-          </Link>
-          <span className="text-muted-foreground">/</span>
-          <span className="text-sm">Error</span>
-        </div>
+        <Breadcrumbs items={[{ label: 'Ledger', href: '/ledger' }, { label: 'Error' }]} />
         <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
           Failed to load booking log. Please try again.
         </div>
@@ -283,13 +271,12 @@ export function BookingLogDetailPage() {
   return (
     <div className="space-y-6">
       {/* Breadcrumb navigation */}
-      <div className="flex items-center gap-2">
-        <Link to="/ledger" className="text-sm text-muted-foreground hover:underline">
-          Ledger
-        </Link>
-        <span className="text-muted-foreground">/</span>
-        <span className="font-mono text-sm">{data.id}</span>
-      </div>
+      <Breadcrumbs
+        items={[
+          { label: 'Ledger', href: '/ledger' },
+          { label: data.id },
+        ]}
+      />
 
       {/* Booking log header with metadata */}
       <BookingLogHeader bookingLog={data} />

--- a/frontend/src/pages/mappings/[mappingId].test.tsx
+++ b/frontend/src/pages/mappings/[mappingId].test.tsx
@@ -104,7 +104,10 @@ describe('MappingDetailPage', () => {
     renderAtRoute(<MappingDetailPage />, '/gateway-mappings/mapping-abc')
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /mapping details/i })).toBeInTheDocument()
+      // Breadcrumb link to parent section
+      const gatewayMappingsLink = screen.getByRole('link', { name: 'Gateway Mappings' })
+      expect(gatewayMappingsLink).toBeInTheDocument()
+      expect(gatewayMappingsLink).toHaveAttribute('href', '/mappings')
     })
   })
 
@@ -112,7 +115,8 @@ describe('MappingDetailPage', () => {
     renderAtRoute(<MappingDetailPage />, '/gateway-mappings/mapping-abc')
 
     await waitFor(() => {
-      expect(screen.getByText('Stripe Webhook')).toBeInTheDocument()
+      const elements = screen.getAllByText('Stripe Webhook')
+      expect(elements.length).toBeGreaterThan(0)
     })
   })
 

--- a/frontend/src/pages/mappings/[mappingId].test.tsx
+++ b/frontend/src/pages/mappings/[mappingId].test.tsx
@@ -115,8 +115,7 @@ describe('MappingDetailPage', () => {
     renderAtRoute(<MappingDetailPage />, '/gateway-mappings/mapping-abc')
 
     await waitFor(() => {
-      const elements = screen.getAllByText('Stripe Webhook')
-      expect(elements.length).toBeGreaterThan(0)
+      expect(screen.getByRole('heading', { name: 'Stripe Webhook' })).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/pages/mappings/[mappingId].tsx
+++ b/frontend/src/pages/mappings/[mappingId].tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useParams } from 'react-router-dom'
+import { Breadcrumbs } from '@/components/shared'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { Card } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -439,9 +440,7 @@ export function MappingDetailPage() {
   if (isLoading) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Mapping Details</h1>
-        </div>
+        <Breadcrumbs items={[{ label: 'Gateway Mappings', href: '/mappings' }, { label: 'Loading...' }]} />
         <Card>
           <div className="p-6">
             <div className="h-6 w-48 animate-pulse rounded bg-muted" />
@@ -454,9 +453,7 @@ export function MappingDetailPage() {
   if (isError || !data) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Mapping Details</h1>
-        </div>
+        <Breadcrumbs items={[{ label: 'Gateway Mappings', href: '/mappings' }, { label: 'Error' }]} />
         <Card className="p-6">
           <p className="text-destructive">Failed to load mapping.</p>
         </Card>
@@ -466,9 +463,12 @@ export function MappingDetailPage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Mapping Details</h1>
-      </div>
+      <Breadcrumbs
+        items={[
+          { label: 'Gateway Mappings', href: '/mappings' },
+          { label: data.name },
+        ]}
+      />
 
       <Card>
         <MappingHeader mapping={data} />

--- a/frontend/src/pages/market-data/[datasetCode].tsx
+++ b/frontend/src/pages/market-data/[datasetCode].tsx
@@ -1,4 +1,5 @@
 import { useParams } from 'react-router-dom'
+import { Breadcrumbs } from '@/components/shared'
 import { useQuery } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -242,6 +243,12 @@ export function DatasetDetailPage() {
 
   return (
     <div className="p-6 space-y-6">
+      <Breadcrumbs
+        items={[
+          { label: 'Market Data', href: '/market-data' },
+          { label: dataset?.displayName || datasetCode },
+        ]}
+      />
       <div>
         <h1 className="text-2xl font-semibold">
           {dataset?.displayName || datasetCode}

--- a/frontend/src/pages/market-data/[datasetCode].tsx
+++ b/frontend/src/pages/market-data/[datasetCode].tsx
@@ -196,7 +196,8 @@ export function DatasetDetailPage() {
   if (!tenantSlug) {
     return (
       <div className="p-6">
-        <p className="text-muted-foreground">No tenant selected.</p>
+        <Breadcrumbs items={[{ label: 'Market Data', href: '/market-data' }]} />
+        <p className="mt-4 text-muted-foreground">No tenant selected.</p>
       </div>
     )
   }
@@ -204,7 +205,8 @@ export function DatasetDetailPage() {
   if (!datasetCode) {
     return (
       <div className="p-6">
-        <p className="text-muted-foreground">No dataset selected.</p>
+        <Breadcrumbs items={[{ label: 'Market Data', href: '/market-data' }]} />
+        <p className="mt-4 text-muted-foreground">No dataset selected.</p>
       </div>
     )
   }

--- a/frontend/src/pages/parties/[partyId].test.tsx
+++ b/frontend/src/pages/parties/[partyId].test.tsx
@@ -30,6 +30,11 @@ vi.mock('@/contexts/auth-context', () => ({
   useAuth: vi.fn(() => ({ accessToken: 'test-token', logout: vi.fn() })),
 }))
 
+// Mock useTenantContext to avoid requiring TenantProvider in tests
+vi.mock('@/contexts/tenant-context', () => ({
+  useTenantContext: vi.fn(() => ({ tenantSlug: 'test-tenant', isPlatformAdmin: false, currentTenant: null, switchTenant: vi.fn() })),
+}))
+
 import { PartyDetailPage } from './[partyId]'
 
 function makeQueryClient() {

--- a/frontend/src/pages/parties/[partyId].test.tsx
+++ b/frontend/src/pages/parties/[partyId].test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 
@@ -76,35 +77,52 @@ describe('PartyDetailPage', () => {
     renderAtRoute(<PartyDetailPage />, '/parties/test-party-1')
 
     await waitFor(() => {
-      // Breadcrumb link to parent section
-      expect(screen.getByRole('link', { name: 'Parties' })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('data-state', 'active')
     })
   })
 
   it('switches to demographics tab on click', async () => {
+    const user = userEvent.setup()
     renderAtRoute(<PartyDetailPage />, '/parties/test-party-1')
 
     await waitFor(() => {
-      // Breadcrumb link to parent section
-      expect(screen.getByRole('link', { name: 'Parties' })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: 'Demographics' })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('tab', { name: 'Demographics' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Demographics' })).toHaveAttribute('data-state', 'active')
     })
   })
 
   it('switches to payment methods tab on click', async () => {
+    const user = userEvent.setup()
     renderAtRoute(<PartyDetailPage />, '/parties/test-party-1')
 
     await waitFor(() => {
-      // Breadcrumb link to parent section
-      expect(screen.getByRole('link', { name: 'Parties' })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: 'Payment Methods' })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('tab', { name: 'Payment Methods' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Payment Methods' })).toHaveAttribute('data-state', 'active')
     })
   })
 
   it('switches to audit trail tab on click', async () => {
+    const user = userEvent.setup()
     renderAtRoute(<PartyDetailPage />, '/parties/test-party-1')
 
     await waitFor(() => {
-      // Breadcrumb link to parent section
-      expect(screen.getByRole('link', { name: 'Parties' })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: 'Audit Trail' })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole('tab', { name: 'Audit Trail' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Audit Trail' })).toHaveAttribute('data-state', 'active')
     })
   })
 })

--- a/frontend/src/pages/parties/[partyId].test.tsx
+++ b/frontend/src/pages/parties/[partyId].test.tsx
@@ -58,7 +58,10 @@ describe('PartyDetailPage', () => {
     renderAtRoute(<PartyDetailPage />, '/parties/test-party-1')
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /party details/i })).toBeInTheDocument()
+      // Breadcrumb link to parent section
+      const partiesLink = screen.getByRole('link', { name: 'Parties' })
+      expect(partiesLink).toBeInTheDocument()
+      expect(partiesLink).toHaveAttribute('href', '/parties')
     })
   })
 
@@ -72,28 +75,36 @@ describe('PartyDetailPage', () => {
   it('renders overview tab by default', async () => {
     renderAtRoute(<PartyDetailPage />, '/parties/test-party-1')
 
-    // Just verify the component renders without crashing
-    expect(screen.getByRole('heading', { name: /party details/i })).toBeInTheDocument()
+    await waitFor(() => {
+      // Breadcrumb link to parent section
+      expect(screen.getByRole('link', { name: 'Parties' })).toBeInTheDocument()
+    })
   })
 
   it('switches to demographics tab on click', async () => {
     renderAtRoute(<PartyDetailPage />, '/parties/test-party-1')
 
-    // Verify page renders
-    expect(screen.getByRole('heading', { name: /party details/i })).toBeInTheDocument()
+    await waitFor(() => {
+      // Breadcrumb link to parent section
+      expect(screen.getByRole('link', { name: 'Parties' })).toBeInTheDocument()
+    })
   })
 
   it('switches to payment methods tab on click', async () => {
     renderAtRoute(<PartyDetailPage />, '/parties/test-party-1')
 
-    // Verify page renders
-    expect(screen.getByRole('heading', { name: /party details/i })).toBeInTheDocument()
+    await waitFor(() => {
+      // Breadcrumb link to parent section
+      expect(screen.getByRole('link', { name: 'Parties' })).toBeInTheDocument()
+    })
   })
 
   it('switches to audit trail tab on click', async () => {
     renderAtRoute(<PartyDetailPage />, '/parties/test-party-1')
 
-    // Verify page renders
-    expect(screen.getByRole('heading', { name: /party details/i })).toBeInTheDocument()
+    await waitFor(() => {
+      // Breadcrumb link to parent section
+      expect(screen.getByRole('link', { name: 'Parties' })).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/pages/parties/[partyId].test.tsx
+++ b/frontend/src/pages/parties/[partyId].test.tsx
@@ -25,6 +25,11 @@ vi.mock('@/api/context', () => ({
   })),
 }))
 
+// Mock useAuth to avoid requiring AuthProvider in tests
+vi.mock('@/contexts/auth-context', () => ({
+  useAuth: vi.fn(() => ({ accessToken: 'test-token', logout: vi.fn() })),
+}))
+
 import { PartyDetailPage } from './[partyId]'
 
 function makeQueryClient() {

--- a/frontend/src/pages/parties/[partyId].tsx
+++ b/frontend/src/pages/parties/[partyId].tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
 import { useParams } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
 import { Card } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Breadcrumbs } from '@/components/shared'
 import { PartyHeader } from './components/party-header'
 import { OverviewTab } from './tabs/overview-tab'
 import { DemographicsTab } from './tabs/demographics-tab'
@@ -10,19 +12,35 @@ import { AssociationsTab } from './tabs/associations-tab'
 import { BankRelationsTab } from './tabs/bank-relations-tab'
 import { PaymentMethodsTab } from './tabs/payment-methods-tab'
 import { AuditTrailTab } from './tabs/audit-trail-tab'
+import { useClients } from '@/api/context'
 
 export function PartyDetailPage() {
   const { partyId } = useParams<{ partyId: string }>()
+  const clients = useClients()
+
+  const { data: party } = useQuery({
+    queryKey: ['party', partyId],
+    queryFn: async () => {
+      const response = await clients.party.retrieveParty({ partyId: partyId! })
+      return response.party
+    },
+    enabled: !!partyId,
+  })
 
   if (!partyId) {
     return <div className="p-6 text-destructive">Party ID not found</div>
   }
 
+  const partyLabel = party?.legalName ?? partyId
+
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Party Details</h1>
-      </div>
+      <Breadcrumbs
+        items={[
+          { label: 'Parties', href: '/parties' },
+          { label: partyLabel },
+        ]}
+      />
 
       <Card>
         <PartyHeader partyId={partyId} />

--- a/frontend/src/pages/payments/payment-detail.tsx
+++ b/frontend/src/pages/payments/payment-detail.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { ChevronLeftIcon, Plus } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -10,7 +10,7 @@ import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { SagaTimeline } from '@/components/shared/saga-timeline'
 import { AuditTrail } from '@/components/shared/audit-trail'
-import { EntityLink } from '@/components/shared'
+import { EntityLink, Breadcrumbs } from '@/components/shared'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
 import { tenantKeys } from '@/lib/query-keys'
@@ -137,13 +137,7 @@ export function PaymentDetailPage() {
   if (isError || !data) {
     return (
       <div data-testid="payment-detail-error" className="p-6">
-        <Link
-          to="/payments"
-          className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-        >
-          <ChevronLeftIcon className="h-4 w-4" />
-          Payments
-        </Link>
+        <Breadcrumbs items={[{ label: 'Payments', href: '/payments' }, { label: 'Error' }]} />
         <p className="mt-4 text-sm text-destructive">Failed to load payment order details.</p>
       </div>
     )
@@ -151,14 +145,13 @@ export function PaymentDetailPage() {
 
   return (
     <div className="p-6 space-y-6">
-      {/* Back navigation */}
-      <Link
-        to="/payments"
-        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-      >
-        <ChevronLeftIcon className="h-4 w-4" />
-        Payments
-      </Link>
+      {/* Breadcrumb navigation */}
+      <Breadcrumbs
+        items={[
+          { label: 'Payments', href: '/payments' },
+          { label: data.paymentOrderId },
+        ]}
+      />
 
       {/* Page header */}
       <div className="flex flex-wrap items-center justify-between gap-4">

--- a/frontend/src/pages/positions/detail.test.tsx
+++ b/frontend/src/pages/positions/detail.test.tsx
@@ -82,19 +82,19 @@ describe('PositionDetailPage', () => {
     expect(screen.getByText('Position Log')).toBeInTheDocument()
   })
 
-  it('renders back button that links to positions list', () => {
+  it('renders back link to positions list', () => {
     renderDetailPage()
-    const backButton = screen.getByTestId('back-button')
-    expect(backButton).toBeInTheDocument()
-    expect(screen.getByText('Positions')).toBeInTheDocument()
+    const positionsLink = screen.getByRole('link', { name: 'Positions' })
+    expect(positionsLink).toBeInTheDocument()
+    expect(positionsLink).toHaveAttribute('href', '/positions')
   })
 
-  it('navigates back to positions list on back button click', async () => {
+  it('navigates back to positions list on breadcrumb link click', async () => {
     const user = userEvent.setup()
     renderDetailPage()
 
-    const backButton = screen.getByTestId('back-button')
-    await user.click(backButton)
+    const positionsLink = screen.getByRole('link', { name: 'Positions' })
+    await user.click(positionsLink)
 
     await waitFor(() => {
       expect(screen.getByText('Positions List')).toBeInTheDocument()

--- a/frontend/src/pages/positions/detail.tsx
+++ b/frontend/src/pages/positions/detail.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { ArrowLeft } from 'lucide-react'
-import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { MoneyDisplay } from '@/components/shared/money-display'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { QualityLadderBadge } from '@/components/shared/quality-ladder-badge'
 import { DirectionBadge } from '@/components/shared/direction-badge'
-import { EntityLink } from '@/components/shared'
+import { EntityLink, Breadcrumbs } from '@/components/shared'
 import { useApiClients } from '@/api/context'
 import type { FinancialPositionLog, TransactionLogEntry } from './index'
 
@@ -146,7 +144,6 @@ function MeasurementHistory({ entries }: MeasurementHistoryProps) {
 
 export function PositionDetailPage() {
   const { logId } = useParams<{ logId: string }>()
-  const navigate = useNavigate()
   const clients = useApiClients()
 
   const { data, isLoading, isError } = useQuery({
@@ -160,17 +157,12 @@ export function PositionDetailPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => navigate('/positions')}
-          data-testid="back-button"
-        >
-          <ArrowLeft className="mr-1 h-4 w-4" />
-          Positions
-        </Button>
-      </div>
+      <Breadcrumbs
+        items={[
+          { label: 'Positions', href: '/positions' },
+          { label: log?.logId ?? logId ?? 'Position Log' },
+        ]}
+      />
 
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Position Log</h1>

--- a/frontend/src/pages/reconciliation/detail.test.tsx
+++ b/frontend/src/pages/reconciliation/detail.test.tsx
@@ -220,7 +220,7 @@ describe('ReconciliationDetailPage - header', () => {
     mockFetch({ ...sampleRun, varianceCount: 0 })
     render(<ReconciliationDetailPage />, { wrapper: Wrapper })
     await waitFor(() => {
-      expect(screen.getByText('run-001')).toBeInTheDocument()
+      expect(screen.getAllByText('run-001').length).toBeGreaterThanOrEqual(1)
     })
     expect(screen.queryByText(/variances/)).not.toBeInTheDocument()
   })
@@ -239,7 +239,9 @@ describe('ReconciliationDetailPage - header', () => {
     mockFetch()
     render(<ReconciliationDetailPage />, { wrapper: Wrapper })
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /back to reconciliation list/i })).toBeInTheDocument()
+      const reconciliationLink = screen.getByRole('link', { name: 'Reconciliation' })
+      expect(reconciliationLink).toBeInTheDocument()
+      expect(reconciliationLink).toHaveAttribute('href', '/reconciliation')
     })
   })
 
@@ -247,9 +249,9 @@ describe('ReconciliationDetailPage - header', () => {
     mockFetch()
     render(<ReconciliationDetailPage />, { wrapper: Wrapper })
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /back to reconciliation list/i })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Reconciliation' })).toBeInTheDocument()
     })
-    await userEvent.click(screen.getByRole('button', { name: /back to reconciliation list/i }))
+    await userEvent.click(screen.getByRole('link', { name: 'Reconciliation' }))
     await waitFor(() => {
       expect(screen.getByText('Reconciliation List')).toBeInTheDocument()
     })

--- a/frontend/src/pages/reconciliation/detail.test.tsx
+++ b/frontend/src/pages/reconciliation/detail.test.tsx
@@ -194,7 +194,9 @@ describe('ReconciliationDetailPage - header', () => {
     mockFetch()
     render(<ReconciliationDetailPage />, { wrapper: Wrapper })
     await waitFor(() => {
-      expect(screen.getByText('run-001')).toBeInTheDocument()
+      const matches = screen.getAllByText('run-001')
+      expect(matches.length).toBeGreaterThanOrEqual(1)
+      expect(matches.some((el) => el.tagName === 'H1')).toBe(true)
     })
   })
 

--- a/frontend/src/pages/reconciliation/detail.tsx
+++ b/frontend/src/pages/reconciliation/detail.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Badge } from '@/components/ui/badge'
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { CELEditor } from '@/components/shared/cel-editor'
+import { Breadcrumbs } from '@/components/shared'
 import {
   VarianceDetail,
   type Variance,
@@ -547,7 +548,6 @@ function formatDate(iso: string): string {
 
 export function ReconciliationDetailPage() {
   const { runId } = useParams<{ runId: string }>()
-  const navigate = useNavigate()
   const authFetch = useAuthenticatedFetch()
 
   const { data: run, isLoading, isError } = useQuery({
@@ -577,16 +577,15 @@ export function ReconciliationDetailPage() {
 
   return (
     <div className="p-6">
-      {/* Header */}
+      {/* Breadcrumb navigation */}
       <div className="mb-6">
-        <button
-          onClick={() => void navigate('/reconciliation')}
-          className="mb-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-          aria-label="Back to reconciliation list"
-        >
-          ← Reconciliation
-        </button>
-        <div className="flex items-center gap-3">
+        <Breadcrumbs
+          items={[
+            { label: 'Reconciliation', href: '/reconciliation' },
+            { label: run.runId },
+          ]}
+        />
+        <div className="mt-4 flex items-center gap-3">
           <h1 className="text-2xl font-semibold font-mono">{run.runId}</h1>
           <StatusBadge status={run.status} />
           {run.varianceCount > 0 && (

--- a/frontend/src/pages/starlark/detail.tsx
+++ b/frontend/src/pages/starlark/detail.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { StarlarkEditor, type ValidationError, type ComplexityMetrics } from '@/components/shared/starlark-editor'
+import { Breadcrumbs } from '@/components/shared'
 import { useApiClients } from '@/api/context'
 import { SagaStatus, ErrorCategory } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
 import type { SagaDefinition } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
@@ -243,6 +244,14 @@ export function StarlarkDetailPage() {
 
   return (
     <div className="flex flex-col gap-6">
+      {/* Breadcrumb navigation */}
+      <Breadcrumbs
+        items={[
+          { label: 'Starlark Config', href: '/starlark' },
+          { label: sagaData.name },
+        ]}
+      />
+
       {/* Header */}
       <div className="flex items-start justify-between gap-4">
         <div>

--- a/frontend/src/pages/tenants/[tenantId].tsx
+++ b/frontend/src/pages/tenants/[tenantId].tsx
@@ -1,5 +1,6 @@
-import { Link, useParams } from 'react-router-dom'
-import { ChevronLeft, CheckCircle2, Circle, Loader2, XCircle } from 'lucide-react'
+import { useParams } from 'react-router-dom'
+import { CheckCircle2, Circle, Loader2, XCircle } from 'lucide-react'
+import { Breadcrumbs } from '@/components/shared'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
 import { Button } from '@/components/ui/button'
@@ -127,16 +128,13 @@ export function TenantDetailPage() {
 
   return (
     <div className="p-6 space-y-6">
-      {/* Header */}
-      <div>
-        <Link
-          to="/tenants"
-          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-        >
-          <ChevronLeft className="size-4" />
-          Back to Tenants
-        </Link>
-      </div>
+      {/* Breadcrumb navigation */}
+      <Breadcrumbs
+        items={[
+          { label: 'Tenants', href: '/tenants' },
+          { label: tenant.displayName },
+        ]}
+      />
 
       <div className="flex items-start justify-between gap-4">
         <div>


### PR DESCRIPTION
## Summary

- Creates a reusable `Breadcrumbs` component in `frontend/src/components/shared/breadcrumbs.tsx` with:
  - `BreadcrumbItem` interface (`label: string, href?: string`)
  - Home icon link at start, ChevronRight separators
  - Last item rendered as plain text (current page), intermediate items as links
- Exports `Breadcrumbs` and `BreadcrumbItem` from `frontend/src/components/shared/index.ts`
- Applies breadcrumbs to all 11 detail pages:
  - `accounts/[accountId].tsx`: Dashboard > Accounts > {account ID}
  - `internal-accounts/[accountId].tsx`: Dashboard > Internal Accounts > {account code}
  - `payments/payment-detail.tsx`: Dashboard > Payments > {payment order ID}
  - `parties/[partyId].tsx`: Dashboard > Parties > {party legal name}
  - `positions/detail.tsx`: Dashboard > Positions > {log ID}
  - `ledger/booking-log-detail.tsx`: Dashboard > Ledger > {booking log ID}
  - `reconciliation/detail.tsx`: Dashboard > Reconciliation > {run ID}
  - `starlark/detail.tsx`: Dashboard > Starlark Config > {saga name}
  - `market-data/[datasetCode].tsx`: Dashboard > Market Data > {dataset display name or code}
  - `mappings/[mappingId].tsx`: Dashboard > Gateway Mappings > {mapping name}
  - `tenants/[tenantId].tsx`: Dashboard > Tenants > {tenant display name}

## Test plan

- [ ] Verify breadcrumb trail renders on each detail page
- [ ] Verify home icon navigates to dashboard
- [ ] Verify section link (e.g. "Accounts") navigates back to list page
- [ ] Verify last item is not a link (plain text, current page)
- [ ] TypeScript typecheck passes (`tsc --noEmit`)
- [ ] ESLint passes