### PR TITLE
feat: standardize empty states and loading skeletons

### DIFF
--- a/frontend/src/components/shared/data-table.tsx
+++ b/frontend/src/components/shared/data-table.tsx
@@ -54,6 +54,8 @@ export interface DataTableProps<T> {
   onRowClick?: (row: T) => void
   className?: string
   defaultSort?: SortingState
+  /** Custom empty state rendered inside the table when there are no results */
+  emptyState?: React.ReactNode
 }
 
 interface SortableHeaderProps {
@@ -223,6 +225,7 @@ export function DataTable<T>({
   onRowClick,
   className,
   defaultSort = [],
+  emptyState,
 }: DataTableProps<T>) {
   const [activeFilters, setActiveFilters] = React.useState<Record<string, string>>({})
   const [pageToken, setPageToken] = React.useState<string | undefined>(undefined)
@@ -302,7 +305,15 @@ export function DataTable<T>({
           ) : isError ? (
             <ErrorState onRetry={() => void refetch()} />
           ) : rows.length === 0 ? (
-            <EmptyState />
+            emptyState ? (
+              <TableRow>
+                <TableCell colSpan={99} className="p-0">
+                  {emptyState}
+                </TableCell>
+              </TableRow>
+            ) : (
+              <EmptyState />
+            )
           ) : (
             rows.map((row) => (
               <TableRow

--- a/frontend/src/components/shared/detail-skeleton.tsx
+++ b/frontend/src/components/shared/detail-skeleton.tsx
@@ -22,6 +22,9 @@ export function DetailSkeleton({
   showBackNav = true,
   className,
 }: DetailSkeletonProps) {
+  const safeFieldCount = Math.max(0, Math.floor(fieldCount))
+  const safeTabCount = Math.max(0, Math.floor(tabCount))
+
   return (
     <div
       data-testid="detail-skeleton"
@@ -40,17 +43,17 @@ export function DetailSkeleton({
       {/* Summary stats grid */}
       <div className={cn(
         'grid gap-4',
-        fieldCount <= 2 ? 'grid-cols-2' : 'grid-cols-2 md:grid-cols-4'
+        safeFieldCount <= 2 ? 'grid-cols-2' : 'grid-cols-2 md:grid-cols-4'
       )}>
-        {Array.from({ length: fieldCount }).map((_, i) => (
+        {Array.from({ length: safeFieldCount }).map((_, i) => (
           <Skeleton key={i} className="h-20 rounded-lg" />
         ))}
       </div>
 
       {/* Tabs bar */}
-      {tabCount > 0 && (
+      {safeTabCount > 0 && (
         <div className="flex gap-2">
-          {Array.from({ length: tabCount }).map((_, i) => (
+          {Array.from({ length: safeTabCount }).map((_, i) => (
             <Skeleton key={i} className="h-9 w-24 rounded-md" />
           ))}
         </div>

--- a/frontend/src/components/shared/detail-skeleton.tsx
+++ b/frontend/src/components/shared/detail-skeleton.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react'
+import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/lib/utils'
+
+export interface DetailSkeletonProps {
+  /** Number of stat/summary fields to show in the top grid */
+  fieldCount?: number
+  /** Number of tabs to show */
+  tabCount?: number
+  /** Whether to show a back-nav skeleton */
+  showBackNav?: boolean
+  className?: string
+}
+
+/**
+ * Reusable full-page loading skeleton for detail pages.
+ * Renders a back-nav placeholder, title, stats grid, and optional tabs.
+ */
+export function DetailSkeleton({
+  fieldCount = 4,
+  tabCount = 3,
+  showBackNav = true,
+  className,
+}: DetailSkeletonProps) {
+  return (
+    <div
+      data-testid="detail-skeleton"
+      className={cn('animate-pulse space-y-6 p-6', className)}
+    >
+      {showBackNav && (
+        <Skeleton className="h-4 w-24" />
+      )}
+
+      {/* Title + badge */}
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-6 w-20 rounded-full" />
+      </div>
+
+      {/* Summary stats grid */}
+      <div className={cn(
+        'grid gap-4',
+        fieldCount <= 2 ? 'grid-cols-2' : 'grid-cols-2 md:grid-cols-4'
+      )}>
+        {Array.from({ length: fieldCount }).map((_, i) => (
+          <Skeleton key={i} className="h-20 rounded-lg" />
+        ))}
+      </div>
+
+      {/* Tabs bar */}
+      {tabCount > 0 && (
+        <div className="flex gap-2">
+          {Array.from({ length: tabCount }).map((_, i) => (
+            <Skeleton key={i} className="h-9 w-24 rounded-md" />
+          ))}
+        </div>
+      )}
+
+      {/* Tab content area */}
+      <Skeleton className="h-64 rounded-lg" />
+    </div>
+  )
+}

--- a/frontend/src/components/shared/index.ts
+++ b/frontend/src/components/shared/index.ts
@@ -16,3 +16,6 @@ export type { CreateValuationFeatureDialogProps, AccountType } from './create-va
 
 export { EntityLink } from './entity-link';
 export type { EntityLinkProps, EntityType } from './entity-link';
+
+export { DetailSkeleton } from './detail-skeleton';
+export type { DetailSkeletonProps } from './detail-skeleton';

--- a/frontend/src/components/ui/empty-state.tsx
+++ b/frontend/src/components/ui/empty-state.tsx
@@ -12,6 +12,8 @@ interface EmptyStateProps {
     label: string
     onClick: () => void
   }
+  /** Compact mode for use inside tables or small containers */
+  compact?: boolean
 }
 
 export function EmptyState({
@@ -19,19 +21,21 @@ export function EmptyState({
   title,
   description,
   action,
+  compact = false,
 }: EmptyStateProps) {
   return (
     <div
       data-slot="empty-state"
       className={cn(
-        "flex min-h-[400px] flex-col items-center justify-center gap-4 px-4 py-8"
+        "flex flex-col items-center justify-center gap-4 px-4",
+        compact ? "min-h-[120px] py-4" : "min-h-[400px] py-8"
       )}
     >
       <div
         data-slot="empty-state-icon"
         className="text-muted-foreground"
       >
-        <Icon className="size-12" />
+        <Icon className={compact ? "size-6" : "size-12"} />
       </div>
 
       <div

--- a/frontend/src/pages/mappings/[mappingId].tsx
+++ b/frontend/src/pages/mappings/[mappingId].tsx
@@ -6,6 +6,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { StatusBadge } from '@/components/shared/status-badge'
+import { DetailSkeleton } from '@/components/shared/detail-skeleton'
 import { useApiClients } from '@/api/context'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -437,18 +438,7 @@ export function MappingDetailPage() {
   }
 
   if (isLoading) {
-    return (
-      <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Mapping Details</h1>
-        </div>
-        <Card>
-          <div className="p-6">
-            <div className="h-6 w-48 animate-pulse rounded bg-muted" />
-          </div>
-        </Card>
-      </div>
-    )
+    return <DetailSkeleton fieldCount={4} tabCount={3} showBackNav={false} />
   }
 
   if (isError || !data) {

--- a/frontend/src/pages/market-data/[datasetCode].tsx
+++ b/frontend/src/pages/market-data/[datasetCode].tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { StatusBadge } from '@/components/shared/status-badge'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useApiClients } from '@/api/context'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
@@ -243,20 +244,29 @@ export function DatasetDetailPage() {
   return (
     <div className="p-6 space-y-6">
       <div>
-        <h1 className="text-2xl font-semibold">
-          {dataset?.displayName || datasetCode}
-        </h1>
-        {dataset && (
-          <div className="mt-2 flex items-center gap-3">
-            <span className="font-mono text-sm text-muted-foreground">{dataset.code}</span>
-            <StatusBadge status={statusLabel(dataset.status)} />
-            <span className="text-sm text-muted-foreground">
-              Unit: <span className="font-mono">{dataset.unit}</span>
-            </span>
+        {datasetQuery.isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-64" />
+            <Skeleton className="h-5 w-48" />
           </div>
-        )}
-        {dataset?.description && (
-          <p className="mt-2 text-sm text-muted-foreground">{dataset.description}</p>
+        ) : (
+          <>
+            <h1 className="text-2xl font-semibold">
+              {dataset?.displayName || datasetCode}
+            </h1>
+            {dataset && (
+              <div className="mt-2 flex items-center gap-3">
+                <span className="font-mono text-sm text-muted-foreground">{dataset.code}</span>
+                <StatusBadge status={statusLabel(dataset.status)} />
+                <span className="text-sm text-muted-foreground">
+                  Unit: <span className="font-mono">{dataset.unit}</span>
+                </span>
+              </div>
+            )}
+            {dataset?.description && (
+              <p className="mt-2 text-sm text-muted-foreground">{dataset.description}</p>
+            )}
+          </>
         )}
       </div>
 

--- a/frontend/src/pages/positions/detail.tsx
+++ b/frontend/src/pages/positions/detail.tsx
@@ -10,12 +10,9 @@ import { TimeDisplay } from '@/components/shared/time-display'
 import { QualityLadderBadge } from '@/components/shared/quality-ladder-badge'
 import { DirectionBadge } from '@/components/shared/direction-badge'
 import { EntityLink } from '@/components/shared'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useApiClients } from '@/api/context'
 import type { FinancialPositionLog, TransactionLogEntry } from './index'
-
-function SkeletonField() {
-  return <div className="h-5 w-40 animate-pulse rounded bg-muted" />
-}
 
 function LabeledField({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -187,51 +184,44 @@ export function PositionDetailPage() {
 
       {(isLoading || log) && (
         <Card className="p-6">
-          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <LabeledField label="Log ID">
-              {isLoading ? (
-                <SkeletonField />
-              ) : (
+          {isLoading ? (
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i}>
+                  <Skeleton className="h-4 w-24 mb-2" />
+                  <Skeleton className="h-5 w-40" />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              <LabeledField label="Log ID">
                 <span className="font-mono text-xs">{log?.logId ?? '—'}</span>
-              )}
-            </LabeledField>
+              </LabeledField>
 
-            <LabeledField label="Account ID">
-              {isLoading ? (
-                <SkeletonField />
-              ) : log?.accountId ? (
-                <EntityLink type="account" id={log.accountId} className="font-mono text-xs text-blue-600 hover:underline dark:text-blue-400" />
-              ) : (
-                <span>—</span>
-              )}
-            </LabeledField>
+              <LabeledField label="Account ID">
+                {log?.accountId ? (
+                  <EntityLink type="account" id={log.accountId} className="font-mono text-xs text-blue-600 hover:underline dark:text-blue-400" />
+                ) : (
+                  <span>—</span>
+                )}
+              </LabeledField>
 
-            <LabeledField label="Status">
-              {isLoading ? (
-                <SkeletonField />
-              ) : (
+              <LabeledField label="Status">
                 <span>
                   {typeof log?.statusTracking?.currentStatus === 'string' ? log.statusTracking.currentStatus.replace(/_/g, ' ') : '—'}
                 </span>
-              )}
-            </LabeledField>
+              </LabeledField>
 
-            <LabeledField label="Created">
-              {isLoading ? (
-                <SkeletonField />
-              ) : (
+              <LabeledField label="Created">
                 <TimeDisplay timestamp={log?.createdAt} />
-              )}
-            </LabeledField>
+              </LabeledField>
 
-            <LabeledField label="Last Updated">
-              {isLoading ? (
-                <SkeletonField />
-              ) : (
+              <LabeledField label="Last Updated">
                 <TimeDisplay timestamp={log?.updatedAt} />
-              )}
-            </LabeledField>
-          </dl>
+              </LabeledField>
+            </dl>
+          )}
         </Card>
       )}
 

--- a/frontend/src/pages/reconciliation/detail.tsx
+++ b/frontend/src/pages/reconciliation/detail.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { CELEditor } from '@/components/shared/cel-editor'
+import { DetailSkeleton } from '@/components/shared/detail-skeleton'
 import {
   VarianceDetail,
   type Variance,
@@ -559,12 +560,7 @@ export function ReconciliationDetailPage() {
   if (!runId) return null
 
   if (isLoading) {
-    return (
-      <div className="p-6 space-y-4">
-        <div className="h-8 w-64 animate-pulse rounded bg-muted" />
-        <div className="h-4 w-96 animate-pulse rounded bg-muted" />
-      </div>
-    )
+    return <DetailSkeleton fieldCount={4} tabCount={3} showBackNav={true} />
   }
 
   if (isError || !run) {

--- a/frontend/src/pages/tenants/[tenantId].tsx
+++ b/frontend/src/pages/tenants/[tenantId].tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from 'react-router-dom'
 import { ChevronLeft, CheckCircle2, Circle, Loader2, XCircle } from 'lucide-react'
 import { StatusBadge } from '@/components/shared/status-badge'
 import { TimeDisplay } from '@/components/shared/time-display'
+import { DetailSkeleton } from '@/components/shared/detail-skeleton'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useTenant, useTenantProvisioningStatus, useUpdateTenantStatus } from '@/hooks/use-tenant'
@@ -94,11 +95,7 @@ export function TenantDetailPage() {
   const updateStatus = useUpdateTenantStatus(tenantId ?? '')
 
   if (tenantLoading) {
-    return (
-      <div className="p-6">
-        <div className="h-8 w-48 animate-pulse rounded bg-muted" />
-      </div>
-    )
+    return <DetailSkeleton fieldCount={4} tabCount={0} showBackNav={true} />
   }
 
   if (!tenant) {


### PR DESCRIPTION
## Summary

- Enhance `EmptyState` component with `compact` prop for inline/table usage (smaller icon, reduced minimum height)
- Add `emptyState` prop to `DataTable` for per-table custom empty state content
- Create shared `DetailSkeleton` component to standardize full-page loading states across detail pages
- Apply `DetailSkeleton` to `TenantDetailPage`, `ReconciliationDetailPage`, and `MappingDetailPage`
- Improve loading skeletons in `DatasetDetailPage` (header area) and `PositionDetailPage` (card fields)

## Changes Made

**New component**: `frontend/src/components/shared/detail-skeleton.tsx`
- Renders back-nav placeholder, title+badge, stats grid, tabs bar, and content area
- Configurable via `fieldCount`, `tabCount`, and `showBackNav` props
- Exported from `components/shared/index.ts`

**Enhanced components**:
- `EmptyState`: added `compact` prop — reduces `min-h` from 400px to 120px and icon from 12→6 in compact mode
- `DataTable`: added `emptyState?: React.ReactNode` prop — when provided, wraps it in a full-width `TableCell` instead of rendering the default inline empty state

**Pages updated**:
- `tenants/[tenantId].tsx` — replaced single skeleton div with `DetailSkeleton`
- `reconciliation/detail.tsx` — replaced minimal pair of skeleton divs with `DetailSkeleton`
- `mappings/[mappingId].tsx` — replaced thin card skeleton with `DetailSkeleton`
- `market-data/[datasetCode].tsx` — added header skeleton while dataset query loads
- `positions/detail.tsx` — replaced per-field `SkeletonField` components with `Skeleton` from shadcn/ui

## Test plan

- [ ] TypeScript passes: `./node_modules/.bin/tsc --noEmit`
- [ ] ESLint passes: no new errors
- [ ] Existing tests continue to pass (no skeleton/loading assertions broken)
- [ ] Visually verify: detail pages show consistent skeleton on initial load
- [ ] DataTable: verify custom emptyState prop renders when rows are empty
- [ ] EmptyState: verify compact mode reduces height in table contexts