### PR TITLE
fix(e2e): update breadcrumb navigation assertions in E2E tests

### DIFF
--- a/frontend/e2e/accounts.spec.ts
+++ b/frontend/e2e/accounts.spec.ts
@@ -110,10 +110,10 @@ test.describe('Account detail page', () => {
     authenticatedPage,
   }) => {
     await navigateTo(authenticatedPage, '/accounts/non-existent-account-id')
-    await expect(authenticatedPage.getByRole('link', { name: 'Back to Accounts' })).toBeVisible({
+    await expect(authenticatedPage.getByRole('link', { name: 'Accounts' })).toBeVisible({
       timeout: 10_000,
     })
-    await authenticatedPage.getByRole('link', { name: 'Back to Accounts' }).click()
+    await authenticatedPage.getByRole('link', { name: 'Accounts' }).click()
     await expect(authenticatedPage.getByRole('heading', { name: 'Accounts' })).toBeVisible()
   })
 })

--- a/frontend/e2e/accounts.spec.ts
+++ b/frontend/e2e/accounts.spec.ts
@@ -110,10 +110,9 @@ test.describe('Account detail page', () => {
     authenticatedPage,
   }) => {
     await navigateTo(authenticatedPage, '/accounts/non-existent-account-id')
-    await expect(authenticatedPage.getByRole('link', { name: 'Accounts' })).toBeVisible({
-      timeout: 10_000,
-    })
-    await authenticatedPage.getByRole('link', { name: 'Accounts' }).click()
+    const breadcrumbLink = authenticatedPage.getByLabel('Breadcrumb').getByRole('link', { name: 'Accounts' })
+    await expect(breadcrumbLink).toBeVisible({ timeout: 10_000 })
+    await breadcrumbLink.click()
     await expect(authenticatedPage.getByRole('heading', { name: 'Accounts' })).toBeVisible()
   })
 })

--- a/frontend/e2e/admin-config.spec.ts
+++ b/frontend/e2e/admin-config.spec.ts
@@ -370,7 +370,7 @@ test.describe('Tenant detail page', () => {
   test('shows Back to Tenants link', async ({ platformAdminPage: page }) => {
     await navigateTo(page, '/tenants/acme_corp')
 
-    await expect(page.getByRole('link', { name: 'Back to Tenants' })).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByRole('link', { name: 'Tenants' })).toBeVisible({ timeout: 15_000 })
   })
 
   test('shows Provisioning Status card', async ({ platformAdminPage: page }) => {

--- a/frontend/e2e/payments.spec.ts
+++ b/frontend/e2e/payments.spec.ts
@@ -80,10 +80,9 @@ test.describe('Payment detail page', () => {
 
   test('back link on error page navigates to Payments list', async ({ authenticatedPage }) => {
     await navigateTo(authenticatedPage, '/payments/non-existent-payment-id')
-    await expect(
-      authenticatedPage.getByRole('link', { name: 'Payments' }),
-    ).toBeVisible({ timeout: 10_000 })
-    await authenticatedPage.getByRole('link', { name: 'Payments' }).click()
+    const breadcrumbLink = authenticatedPage.getByLabel('Breadcrumb').getByRole('link', { name: 'Payments' })
+    await expect(breadcrumbLink).toBeVisible({ timeout: 10_000 })
+    await breadcrumbLink.click()
     await expect(authenticatedPage.getByRole('heading', { name: 'Payments' })).toBeVisible()
   })
 })

--- a/frontend/e2e/positions.spec.ts
+++ b/frontend/e2e/positions.spec.ts
@@ -63,16 +63,15 @@ test.describe('Position detail page', () => {
   test('renders breadcrumb back link on position detail page', async ({ authenticatedPage }) => {
     await navigateTo(authenticatedPage, '/positions/non-existent-log-id')
     await expect(
-      authenticatedPage.getByRole('link', { name: 'Positions' }),
+      authenticatedPage.getByLabel('Breadcrumb').getByRole('link', { name: 'Positions' }),
     ).toBeVisible({ timeout: 10_000 })
   })
 
   test('breadcrumb back link navigates to positions list', async ({ authenticatedPage }) => {
     await navigateTo(authenticatedPage, '/positions/non-existent-log-id')
-    await expect(
-      authenticatedPage.getByRole('link', { name: 'Positions' }),
-    ).toBeVisible({ timeout: 10_000 })
-    await authenticatedPage.getByRole('link', { name: 'Positions' }).click()
+    const breadcrumbLink = authenticatedPage.getByLabel('Breadcrumb').getByRole('link', { name: 'Positions' })
+    await expect(breadcrumbLink).toBeVisible({ timeout: 10_000 })
+    await breadcrumbLink.click()
     await expect(authenticatedPage.getByRole('heading', { name: 'Positions' })).toBeVisible()
   })
 })

--- a/frontend/e2e/specs/parties.spec.ts
+++ b/frontend/e2e/specs/parties.spec.ts
@@ -74,7 +74,7 @@ test.describe('Party detail navigation', () => {
     await expect(firstRow).toBeVisible()
     await firstRow.click()
     await expect(page).toHaveURL(/\/parties\/[a-zA-Z0-9-]+/)
-    await expect(page.getByRole('link', { name: 'Parties' })).toBeVisible()
+    await expect(page.getByLabel('Breadcrumb').getByRole('link', { name: 'Parties' })).toBeVisible()
   })
 
   test('shows Party ID not found for missing partyId param', async ({ authenticatedPage: page }) => {
@@ -83,7 +83,7 @@ test.describe('Party detail navigation', () => {
     // Page should render — it will show either the party data or an error state
     // (the component renders even without backend data)
     await expect(
-      page.getByRole('link', { name: 'Parties' }).or(
+      page.getByLabel('Breadcrumb').getByRole('link', { name: 'Parties' }).or(
         page.getByText('Party not found')
       )
     ).toBeVisible()
@@ -100,7 +100,7 @@ test.describe('Party detail — 8-tab layout', () => {
     } else {
       await page.locator('table tbody tr').first().click()
     }
-    await expect(page.getByRole('link', { name: 'Parties' })).toBeVisible()
+    await expect(page.getByLabel('Breadcrumb').getByRole('link', { name: 'Parties' })).toBeVisible()
   })
 
   test('renders all 8 tab triggers', async ({ authenticatedPage: page }) => {
@@ -141,7 +141,7 @@ test.describe('Party header component', () => {
       return
     }
     await page.locator('table tbody tr').first().click()
-    await expect(page.getByRole('link', { name: 'Parties' })).toBeVisible()
+    await expect(page.getByLabel('Breadcrumb').getByRole('link', { name: 'Parties' })).toBeVisible()
   })
 
   test('renders party header section', async ({ authenticatedPage: page }) => {
@@ -169,7 +169,7 @@ test.describe('Tab switching', () => {
     } else {
       await page.locator('table tbody tr').first().click()
     }
-    await expect(page.getByRole('link', { name: 'Parties' })).toBeVisible()
+    await expect(page.getByLabel('Breadcrumb').getByRole('link', { name: 'Parties' })).toBeVisible()
   })
 
   test('Overview tab renders without error', async ({ authenticatedPage: page }) => {
@@ -244,7 +244,7 @@ test.describe('Tab keyboard navigation', () => {
     } else {
       await page.locator('table tbody tr').first().click()
     }
-    await expect(page.getByRole('link', { name: 'Parties' })).toBeVisible()
+    await expect(page.getByLabel('Breadcrumb').getByRole('link', { name: 'Parties' })).toBeVisible()
   })
 
   test('ArrowRight moves focus to next tab', async ({ authenticatedPage: page }) => {


### PR DESCRIPTION
## Summary

- Updates E2E test assertions broken by the breadcrumb navigation PR (#1293)
- `accounts.spec.ts`: 'Back to Accounts' link text → 'Accounts' (breadcrumb link)
- `admin-config.spec.ts`: 'Back to Tenants' link text → 'Tenants' (breadcrumb link)
- `positions.spec.ts`: scope 'Positions' link lookup to `getByLabel('Breadcrumb')` to avoid strict mode violation with sidebar navigation

## Test plan

- [ ] E2E Tests workflow passes (specifically accounts, admin-config, positions spec files)