### PR TITLE
Mark PRD-024 Structured Mapping Layer as implemented

### DIFF
--- a/docs/prd/024-structured-inbound-mapping.md
+++ b/docs/prd/024-structured-inbound-mapping.md
@@ -28,7 +28,7 @@ instructions: |
 
 # PRD: Structured Mapping Layer
 
-**Status:** Not Started
+**Status:** Implemented
 **Version:** 1.0
 **Date:** 2026-02-21
 **Author:** Architecture Team

--- a/docs/prd/029-operational-gateway.md
+++ b/docs/prd/029-operational-gateway.md
@@ -1689,7 +1689,7 @@ All tests use `testdb.SetupCockroachDB` and `shared/platform/await`
 | Starlark Service Clients (PRD-007) | Gateway exposes typed Starlark client | Implemented |
 | Control Plane / Manifest (PRD-014) | Connections declared in manifest | Implemented |
 | Platform Scheduler (PRD-021) | Health check and expiry workers use shared scheduler | In Progress |
-| **Structured Mapping (PRD-024)** | **Payload transformation engine (outbound + inbound)** | **Not Started** |
+| Structured Mapping (PRD-024) | Payload transformation engine (outbound + inbound) | Implemented |
 | Event Streaming (PRD-025) | Gateway events visible in ops console | Not Started |
 | Stripe Connect (PRD-015) | Payment collection is a gateway instruction type | Implemented |
 | Outbox Pattern | At-least-once dispatch uses outbox | Implemented |

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -44,6 +44,7 @@ stateDiagram-v2
 | [Universal Asset System](001-universal-asset-system.md) | `universal-asset-system` | 36/36 done |
 | [Starlark Service Bindings](008-starlark-service-bindings.md) | N/A (tracked across other tags) | Implemented 2026-02-04 |
 | [Starlark Testing Framework](010-starlark-testing-framework.md) | N/A (tracked across other tags) | Implemented 2026-02-06 |
+| [Structured Mapping Layer](024-structured-inbound-mapping.md) | `structured-mapping-layer` | 16/16 done |
 | [Valuation Service](011-valuation-service.md) | `valuation-engine` | 14/14 done |
 
 #### Paused (Deferred Items Remain)


### PR DESCRIPTION
## Summary

- Updates PRD-024 status from "Not Started" to "Implemented" — all 16 tasks complete
- Adds PRD-024 to the Implemented table in the PRD README (16/16 done)
- Updates PRD-029 dependency table: Structured Mapping no longer a blocker

## Evidence

- `shared/pkg/cel/` — CEL compiler extraction (compiler, benchmarks, security tests)
- `shared/pkg/mapping/` — bidirectional mapping engine (TransformInbound/Outbound, batch, dryrun)
- `api/proto/meridian/mapping/v1/mapping.proto` — MappingDefinition proto with full CRUD
- `services/reference-data/mapping/` — repository, domain, validator, handler
- `services/gateway/internal/mapping/` — gateway integration at `/mapping/{name}`
- Manifest integration (`mappings` field on Manifest proto)

## Test plan

- [ ] Verify markdown lint passes
- [ ] Confirm no code changes, docs only