### PR TITLE
feat: Add operational_gateway config to Manifest proto

### DIFF
--- a/api/jsonschema/manifest.v1.schema.json
+++ b/api/jsonschema/manifest.v1.schema.json
@@ -185,7 +185,7 @@
                 },
                 "apiKeySecretRef": {
                     "type": "string",
-                    "description": "api_key_secret_ref is a reference to the secret store key that holds the API key value. Example: \"sm://stripe/api_key\" or \"env://STRIPE_API_KEY\""
+                    "description": "api_key_secret_ref is a reference to the secret store key that holds the API key value. Must use a supported secret URI scheme: \"sm://\u003cstore\u003e/\u003ckey\u003e\" or \"env://\u003cVAR_NAME\u003e\". Example: \"sm://stripe/api_key\" or \"env://STRIPE_API_KEY\""
                 }
             },
             "additionalProperties": false,
@@ -300,7 +300,7 @@
                 },
                 "passwordSecretRef": {
                     "type": "string",
-                    "description": "password_secret_ref is a reference to the secret store key that holds the password."
+                    "description": "password_secret_ref is a reference to the secret store key that holds the password. Must use a supported secret URI scheme: \"sm://\u003cstore\u003e/\u003ckey\u003e\" or \"env://\u003cVAR_NAME\u003e\"."
                 }
             },
             "additionalProperties": false,
@@ -321,7 +321,7 @@
                 },
                 "secretRef": {
                     "type": "string",
-                    "description": "secret_ref is a reference to the secret store key that holds the HMAC signing secret."
+                    "description": "secret_ref is a reference to the secret store key that holds the HMAC signing secret. Must use a supported secret URI scheme: \"sm://\u003cstore\u003e/\u003ckey\u003e\" or \"env://\u003cVAR_NAME\u003e\"."
                 },
                 "signatureHeader": {
                     "type": "string",
@@ -481,15 +481,15 @@
             "properties": {
                 "clientCertSecretRef": {
                     "type": "string",
-                    "description": "client_cert_secret_ref is a reference to the secret store key holding the PEM-encoded client certificate."
+                    "description": "client_cert_secret_ref is a reference to the secret store key holding the PEM-encoded client certificate. Must use a supported secret URI scheme: \"sm://\u003cstore\u003e/\u003ckey\u003e\" or \"env://\u003cVAR_NAME\u003e\"."
                 },
                 "clientKeySecretRef": {
                     "type": "string",
-                    "description": "client_key_secret_ref is a reference to the secret store key holding the PEM-encoded private key."
+                    "description": "client_key_secret_ref is a reference to the secret store key holding the PEM-encoded private key. Must use a supported secret URI scheme: \"sm://\u003cstore\u003e/\u003ckey\u003e\" or \"env://\u003cVAR_NAME\u003e\"."
                 },
                 "caCertSecretRef": {
                     "type": "string",
-                    "description": "ca_cert_secret_ref is an optional reference to the secret store key holding the CA certificate for verifying the provider's server certificate."
+                    "description": "ca_cert_secret_ref is an optional reference to the secret store key holding the CA certificate for verifying the provider's server certificate. If set, must use a supported secret URI scheme: \"sm://\u003cstore\u003e/\u003ckey\u003e\" or \"env://\u003cVAR_NAME\u003e\"."
                 }
             },
             "additionalProperties": false,
@@ -540,7 +540,7 @@
                 },
                 "clientSecretRef": {
                     "type": "string",
-                    "description": "client_secret_ref is a reference to the secret store key that holds the client secret."
+                    "description": "client_secret_ref is a reference to the secret store key that holds the client secret. Must use a supported secret URI scheme: \"sm://\u003cstore\u003e/\u003ckey\u003e\" or \"env://\u003cVAR_NAME\u003e\"."
                 },
                 "scopes": {
                     "items": {

--- a/api/jsonschema/manifest.v1.schema.json
+++ b/api/jsonschema/manifest.v1.schema.json
@@ -13,7 +13,8 @@
                 "seedData",
                 "paymentRails",
                 "partyTypes",
-                "mappings"
+                "mappings",
+                "operationalGateway"
             ],
             "properties": {
                 "version": {
@@ -85,6 +86,11 @@
                     "additionalProperties": false,
                     "type": "array",
                     "description": "mappings defines the bidirectional field mapping definitions available to this tenant. Each mapping describes how an external JSON payload is transformed into an internal Meridian gRPC service call."
+                },
+                "operationalGateway": {
+                    "$ref": "#/definitions/meridian.control_plane.v1.OperationalGatewayConfig",
+                    "additionalProperties": false,
+                    "description": "operational_gateway defines external system integrations for this tenant."
                 }
             },
             "additionalProperties": false,
@@ -167,6 +173,236 @@
             "title": "Account Type Policies",
             "description": "AccountTypePolicies contains CEL expressions that govern account behavior. CEL syntax validation is deferred to the runtime validator - the manifest only stores the expression strings."
         },
+        "meridian.control_plane.v1.ApiKeyAuthConfig": {
+            "required": [
+                "headerName",
+                "apiKeySecretRef"
+            ],
+            "properties": {
+                "headerName": {
+                    "type": "string",
+                    "description": "header_name is the HTTP header used to transmit the API key. Example: \"X-API-Key\", \"Authorization\""
+                },
+                "apiKeySecretRef": {
+                    "type": "string",
+                    "description": "api_key_secret_ref is a reference to the secret store key that holds the API key value. Example: \"sm://stripe/api_key\" or \"env://STRIPE_API_KEY\""
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Api Key Auth Config",
+            "description": "ApiKeyAuthConfig configures authentication via a static API key header. All sensitive values are expressed as secret references, never raw values."
+        },
+        "meridian.control_plane.v1.AuthConfigManifest": {
+            "properties": {
+                "apiKey": {
+                    "$ref": "#/definitions/meridian.control_plane.v1.ApiKeyAuthConfig",
+                    "additionalProperties": false,
+                    "description": "api_key authenticates using a static API key in a header."
+                },
+                "basic": {
+                    "$ref": "#/definitions/meridian.control_plane.v1.BasicAuthConfig",
+                    "additionalProperties": false,
+                    "description": "basic authenticates using HTTP Basic authentication."
+                },
+                "oauth2": {
+                    "$ref": "#/definitions/meridian.control_plane.v1.OAuth2AuthConfig",
+                    "additionalProperties": false,
+                    "description": "oauth2 authenticates using OAuth 2.0 client credentials flow."
+                },
+                "hmac": {
+                    "$ref": "#/definitions/meridian.control_plane.v1.HMACAuthConfig",
+                    "additionalProperties": false,
+                    "description": "hmac authenticates by signing requests with HMAC."
+                },
+                "mtls": {
+                    "$ref": "#/definitions/meridian.control_plane.v1.MTLSAuthConfig",
+                    "additionalProperties": false,
+                    "description": "mtls authenticates using mutual TLS client certificates."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "allOf": [
+                {
+                    "oneOf": [
+                        {
+                            "not": {
+                                "anyOf": [
+                                    {
+                                        "required": [
+                                            "apiKey"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "basic"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "oauth2"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "hmac"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "mtls"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "required": [
+                                "apiKey"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "basic"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "oauth2"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "hmac"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "mtls"
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "title": "Auth Config Manifest",
+            "description": "AuthConfigManifest defines the authentication configuration for a provider connection. Exactly one variant must be set. All sensitive values use secret references."
+        },
+        "meridian.control_plane.v1.BasicAuthConfig": {
+            "required": [
+                "username",
+                "passwordSecretRef"
+            ],
+            "properties": {
+                "username": {
+                    "type": "string",
+                    "description": "username is the Basic auth username (not sensitive - stored directly)."
+                },
+                "passwordSecretRef": {
+                    "type": "string",
+                    "description": "password_secret_ref is a reference to the secret store key that holds the password."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Basic Auth Config",
+            "description": "BasicAuthConfig configures HTTP Basic authentication. All sensitive values are expressed as secret references, never raw values."
+        },
+        "meridian.control_plane.v1.HMACAuthConfig": {
+            "required": [
+                "algorithm",
+                "secretRef",
+                "signatureHeader"
+            ],
+            "properties": {
+                "algorithm": {
+                    "type": "string",
+                    "description": "algorithm is the HMAC signing algorithm. Supported values: \"sha256\", \"sha512\""
+                },
+                "secretRef": {
+                    "type": "string",
+                    "description": "secret_ref is a reference to the secret store key that holds the HMAC signing secret."
+                },
+                "signatureHeader": {
+                    "type": "string",
+                    "description": "signature_header is the HTTP header where the computed signature is placed. Example: \"X-Signature\", \"X-Hub-Signature-256\""
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "HMAC Auth Config",
+            "description": "HMACAuthConfig configures HMAC-based request signing. All sensitive values are expressed as secret references, never raw values."
+        },
+        "meridian.control_plane.v1.InboundRouteConfig": {
+            "required": [
+                "externalType",
+                "handlerSaga",
+                "mappingId"
+            ],
+            "properties": {
+                "externalType": {
+                    "type": "string",
+                    "description": "external_type identifies the category of inbound event from the provider. Example: \"stripe.payment_intent.succeeded\", \"modulr.account.credited\""
+                },
+                "handlerSaga": {
+                    "type": "string",
+                    "description": "handler_saga is the name of the SagaDefinition to invoke when this event is received. Must match a name in the manifest's sagas list."
+                },
+                "mappingId": {
+                    "type": "string",
+                    "description": "mapping_id is the name of the MappingDefinition applied to transform the inbound event payload before passing it to the handler saga. Must match a name in the manifest's mappings list. If empty, the payload is passed as-is."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Inbound Route Config",
+            "description": "InboundRouteConfig declares how inbound events from external providers are handled. This is a Phase 5 placeholder — configuration is captured in the manifest but runtime support is not yet implemented."
+        },
+        "meridian.control_plane.v1.InstructionRouteConfig": {
+            "required": [
+                "instructionType",
+                "connectionId",
+                "fallbackConnectionId",
+                "outboundMappingId",
+                "inboundMappingId",
+                "httpMethod",
+                "pathTemplate"
+            ],
+            "properties": {
+                "instructionType": {
+                    "type": "string",
+                    "description": "instruction_type is the instruction category this route handles. Must be unique within the manifest's instruction_routes list. Example: \"payment.initiate\", \"account.freeze\", \"kyc.verify\""
+                },
+                "connectionId": {
+                    "type": "string",
+                    "description": "connection_id references the primary ProviderConnectionConfig used to dispatch matching instructions. Must match a connection_id defined in operational_gateway.provider_connections."
+                },
+                "fallbackConnectionId": {
+                    "type": "string",
+                    "description": "fallback_connection_id references an optional secondary connection used when the primary is unhealthy. Must match a connection_id defined in operational_gateway.provider_connections, if set. If not set, instructions fail without fallback when the primary connection is unhealthy."
+                },
+                "outboundMappingId": {
+                    "type": "string",
+                    "description": "outbound_mapping_id is the name of the MappingDefinition applied to transform the instruction payload from the internal Meridian format to the provider's expected format before dispatch. Must match a name in the manifest's mappings list. If empty, the payload is sent as-is."
+                },
+                "inboundMappingId": {
+                    "type": "string",
+                    "description": "inbound_mapping_id is the name of the MappingDefinition applied to transform provider callback payloads from the provider's format to the internal Meridian format. Must match a name in the manifest's mappings list. If empty, callback payloads are processed as-is."
+                },
+                "httpMethod": {
+                    "type": "string",
+                    "description": "http_method is the HTTP method used when dispatching via HTTPS or WEBHOOK protocol. Example: \"POST\", \"PUT\", \"PATCH\" Required for HTTPS and WEBHOOK protocols; ignored for GRPC, MQTT, AMQP."
+                },
+                "pathTemplate": {
+                    "type": "string",
+                    "description": "path_template is the URL path template appended to the connection base_url. Supports simple variable substitution using {field_name} placeholders resolved from the payload. Example: \"/v1/payments/{payment_id}/execute\", \"/accounts/{account_id}/freeze\""
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Instruction Route Config",
+            "description": "InstructionRouteConfig maps an instruction_type to a provider connection for outbound dispatch. Routes determine which connection handles a given type of instruction and how the payload is transformed before dispatch."
+        },
         "meridian.control_plane.v1.InstrumentDefinition": {
             "required": [
                 "code",
@@ -236,6 +472,31 @@
             "title": "Instrument Dimensions",
             "description": "InstrumentDimensions describes the unit and precision of an instrument's quantities."
         },
+        "meridian.control_plane.v1.MTLSAuthConfig": {
+            "required": [
+                "clientCertSecretRef",
+                "clientKeySecretRef",
+                "caCertSecretRef"
+            ],
+            "properties": {
+                "clientCertSecretRef": {
+                    "type": "string",
+                    "description": "client_cert_secret_ref is a reference to the secret store key holding the PEM-encoded client certificate."
+                },
+                "clientKeySecretRef": {
+                    "type": "string",
+                    "description": "client_key_secret_ref is a reference to the secret store key holding the PEM-encoded private key."
+                },
+                "caCertSecretRef": {
+                    "type": "string",
+                    "description": "ca_cert_secret_ref is an optional reference to the secret store key holding the CA certificate for verifying the provider's server certificate."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "MTLS Auth Config",
+            "description": "MTLSAuthConfig configures mutual TLS (mTLS) authentication. All sensitive values are expressed as secret references, never raw values."
+        },
         "meridian.control_plane.v1.ManifestMetadata": {
             "required": [
                 "name",
@@ -260,6 +521,76 @@
             "type": "object",
             "title": "========================================\n Manifest Metadata\n ========================================",
             "description": "======================================== Manifest Metadata ========================================  ManifestMetadata contains identifying information about a manifest."
+        },
+        "meridian.control_plane.v1.OAuth2AuthConfig": {
+            "required": [
+                "tokenUrl",
+                "clientId",
+                "clientSecretRef",
+                "scopes"
+            ],
+            "properties": {
+                "tokenUrl": {
+                    "type": "string",
+                    "description": "token_url is the OAuth 2.0 token endpoint."
+                },
+                "clientId": {
+                    "type": "string",
+                    "description": "client_id is the OAuth 2.0 client identifier (not sensitive - stored directly)."
+                },
+                "clientSecretRef": {
+                    "type": "string",
+                    "description": "client_secret_ref is a reference to the secret store key that holds the client secret."
+                },
+                "scopes": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array",
+                    "description": "scopes lists the OAuth 2.0 scopes to request."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "O Auth 2 Auth Config",
+            "description": "OAuth2AuthConfig configures OAuth 2.0 client credentials flow authentication. All sensitive values are expressed as secret references, never raw values."
+        },
+        "meridian.control_plane.v1.OperationalGatewayConfig": {
+            "required": [
+                "providerConnections",
+                "instructionRoutes",
+                "inboundRoutes"
+            ],
+            "properties": {
+                "providerConnections": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.control_plane.v1.ProviderConnectionConfig"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "provider_connections defines the external provider endpoints this tenant connects to."
+                },
+                "instructionRoutes": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.control_plane.v1.InstructionRouteConfig"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "instruction_routes maps instruction types to provider connections for outbound dispatch."
+                },
+                "inboundRoutes": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.control_plane.v1.InboundRouteConfig"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "inbound_routes defines how inbound events from external providers are handled (Phase 5 placeholder)."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "========================================\n Operational Gateway Config\n ========================================",
+            "description": "======================================== Operational Gateway Config ========================================  OperationalGatewayConfig declares the external system integrations for a tenant. It configures provider connections, outbound instruction routing, and inbound event handling."
         },
         "meridian.control_plane.v1.PaymentRails": {
             "required": [
@@ -379,6 +710,131 @@
             "type": "object",
             "title": "Platform Fee",
             "description": "PlatformFee defines the fee structure for payment rail transactions."
+        },
+        "meridian.control_plane.v1.ProviderConnectionConfig": {
+            "required": [
+                "connectionId",
+                "providerName",
+                "providerType",
+                "protocol",
+                "baseUrl",
+                "auth",
+                "retryPolicy",
+                "rateLimit"
+            ],
+            "properties": {
+                "connectionId": {
+                    "type": "string",
+                    "description": "connection_id is the stable, unique identifier for this connection within the manifest. Used by InstructionRouteConfig to reference this connection. Must be unique within the manifest. Example: \"stripe-payments\", \"modulr-uk\", \"kraken-energy-grid\""
+                },
+                "providerName": {
+                    "type": "string",
+                    "description": "provider_name is the human-readable name for the external provider. Example: \"Stripe\", \"Modulr\", \"Kraken Energy Grid\""
+                },
+                "providerType": {
+                    "type": "string",
+                    "description": "provider_type is a machine-readable classifier for the provider category. Example: \"payment_gateway\", \"kyc_provider\", \"energy_scheduler\""
+                },
+                "protocol": {
+                    "enum": [
+                        "PROVIDER_PROTOCOL_UNSPECIFIED",
+                        0,
+                        "PROVIDER_PROTOCOL_HTTPS",
+                        1,
+                        "PROVIDER_PROTOCOL_GRPC",
+                        2,
+                        "PROVIDER_PROTOCOL_WEBHOOK",
+                        3,
+                        "PROVIDER_PROTOCOL_MQTT",
+                        4,
+                        "PROVIDER_PROTOCOL_AMQP",
+                        5
+                    ],
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "title": "Provider Protocol",
+                    "description": "ProviderProtocol defines the transport protocol used for a provider connection. Mirrors the runtime Protocol enum but is self-contained in the manifest config."
+                },
+                "baseUrl": {
+                    "type": "string",
+                    "description": "base_url is the root URL of the provider's API endpoint. Must be a valid URI. Example: \"https://api.stripe.com\""
+                },
+                "auth": {
+                    "$ref": "#/definitions/meridian.control_plane.v1.AuthConfigManifest",
+                    "additionalProperties": false,
+                    "description": "auth is the authentication configuration for this connection."
+                },
+                "retryPolicy": {
+                    "$ref": "#/definitions/meridian.control_plane.v1.RetryPolicyConfig",
+                    "additionalProperties": false,
+                    "description": "retry_policy defines how failed dispatch attempts are retried. If not set, a default policy is used by the runtime."
+                },
+                "rateLimit": {
+                    "$ref": "#/definitions/meridian.control_plane.v1.RateLimitConfig",
+                    "additionalProperties": false,
+                    "description": "rate_limit controls the outbound dispatch rate for this connection. If not set, no rate limiting is applied."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Provider Connection Config",
+            "description": "ProviderConnectionConfig declares a single external provider connection within the manifest. Each connection is identified by a stable connection_id used in InstructionRouteConfig."
+        },
+        "meridian.control_plane.v1.RateLimitConfig": {
+            "required": [
+                "requestsPerSecond",
+                "burstSize"
+            ],
+            "properties": {
+                "requestsPerSecond": {
+                    "type": "number",
+                    "description": "requests_per_second is the maximum sustained dispatch rate."
+                },
+                "burstSize": {
+                    "type": "integer",
+                    "description": "burst_size is the maximum number of requests allowed to exceed the rate limit momentarily."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Rate Limit Config",
+            "description": "RateLimitConfig controls the outbound dispatch rate for a connection."
+        },
+        "meridian.control_plane.v1.RetryPolicyConfig": {
+            "required": [
+                "maxAttempts",
+                "initialBackoffSeconds",
+                "maxBackoffSeconds",
+                "backoffMultiplier"
+            ],
+            "properties": {
+                "maxAttempts": {
+                    "type": "integer",
+                    "description": "max_attempts is the total number of dispatch attempts (including the first). A value of 1 means no retries (one attempt only)."
+                },
+                "initialBackoffSeconds": {
+                    "type": "integer",
+                    "description": "initial_backoff_seconds is the delay before the first retry in seconds."
+                },
+                "maxBackoffSeconds": {
+                    "type": "integer",
+                    "description": "max_backoff_seconds caps the computed backoff to prevent unbounded delays."
+                },
+                "backoffMultiplier": {
+                    "type": "number",
+                    "description": "backoff_multiplier is the factor by which the backoff duration grows after each attempt. Example: initial=1s, multiplier=2.0 → 1s, 2s, 4s, 8s..."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Retry Policy Config",
+            "description": "RetryPolicyConfig defines the backoff strategy for failed dispatch attempts."
         },
         "meridian.control_plane.v1.SagaDefinition": {
             "required": [

--- a/api/proto/meridian/control_plane/v1/manifest.proto
+++ b/api/proto/meridian/control_plane/v1/manifest.proto
@@ -490,10 +490,12 @@ message ApiKeyAuthConfig {
   }];
 
   // api_key_secret_ref is a reference to the secret store key that holds the API key value.
+  // Must use a supported secret URI scheme: "sm://<store>/<key>" or "env://<VAR_NAME>".
   // Example: "sm://stripe/api_key" or "env://STRIPE_API_KEY"
   string api_key_secret_ref = 2 [(buf.validate.field).string = {
     min_len: 1
     max_len: 512
+    pattern: "^(sm|env)://.+$"
   }];
 }
 
@@ -507,9 +509,11 @@ message BasicAuthConfig {
   }];
 
   // password_secret_ref is a reference to the secret store key that holds the password.
+  // Must use a supported secret URI scheme: "sm://<store>/<key>" or "env://<VAR_NAME>".
   string password_secret_ref = 2 [(buf.validate.field).string = {
     min_len: 1
     max_len: 512
+    pattern: "^(sm|env)://.+$"
   }];
 }
 
@@ -530,9 +534,11 @@ message OAuth2AuthConfig {
   }];
 
   // client_secret_ref is a reference to the secret store key that holds the client secret.
+  // Must use a supported secret URI scheme: "sm://<store>/<key>" or "env://<VAR_NAME>".
   string client_secret_ref = 3 [(buf.validate.field).string = {
     min_len: 1
     max_len: 512
+    pattern: "^(sm|env)://.+$"
   }];
 
   // scopes lists the OAuth 2.0 scopes to request.
@@ -555,9 +561,11 @@ message HMACAuthConfig {
   }];
 
   // secret_ref is a reference to the secret store key that holds the HMAC signing secret.
+  // Must use a supported secret URI scheme: "sm://<store>/<key>" or "env://<VAR_NAME>".
   string secret_ref = 2 [(buf.validate.field).string = {
     min_len: 1
     max_len: 512
+    pattern: "^(sm|env)://.+$"
   }];
 
   // signature_header is the HTTP header where the computed signature is placed.
@@ -572,20 +580,28 @@ message HMACAuthConfig {
 // All sensitive values are expressed as secret references, never raw values.
 message MTLSAuthConfig {
   // client_cert_secret_ref is a reference to the secret store key holding the PEM-encoded client certificate.
+  // Must use a supported secret URI scheme: "sm://<store>/<key>" or "env://<VAR_NAME>".
   string client_cert_secret_ref = 1 [(buf.validate.field).string = {
     min_len: 1
     max_len: 512
+    pattern: "^(sm|env)://.+$"
   }];
 
   // client_key_secret_ref is a reference to the secret store key holding the PEM-encoded private key.
+  // Must use a supported secret URI scheme: "sm://<store>/<key>" or "env://<VAR_NAME>".
   string client_key_secret_ref = 2 [(buf.validate.field).string = {
     min_len: 1
     max_len: 512
+    pattern: "^(sm|env)://.+$"
   }];
 
   // ca_cert_secret_ref is an optional reference to the secret store key holding the CA certificate
   // for verifying the provider's server certificate.
-  string ca_cert_secret_ref = 3 [(buf.validate.field).string.max_len = 512];
+  // If set, must use a supported secret URI scheme: "sm://<store>/<key>" or "env://<VAR_NAME>".
+  string ca_cert_secret_ref = 3 [(buf.validate.field).string = {
+    max_len: 512
+    pattern: "^$|^(sm|env)://.+$"
+  }];
 }
 
 // AuthConfigManifest defines the authentication configuration for a provider connection.

--- a/api/proto/meridian/control_plane/v1/manifest.proto
+++ b/api/proto/meridian/control_plane/v1/manifest.proto
@@ -60,6 +60,9 @@ message Manifest {
   // Each mapping describes how an external JSON payload is transformed into an internal
   // Meridian gRPC service call.
   repeated meridian.mapping.v1.MappingDefinition mappings = 10;
+
+  // operational_gateway defines external system integrations for this tenant.
+  OperationalGatewayConfig operational_gateway = 11;
 }
 
 // ========================================
@@ -396,4 +399,338 @@ message PaymentRails {
       }
     }
   }];
+}
+
+// ========================================
+// Operational Gateway Config
+// ========================================
+
+// OperationalGatewayConfig declares the external system integrations for a tenant.
+// It configures provider connections, outbound instruction routing, and inbound event handling.
+message OperationalGatewayConfig {
+  // provider_connections defines the external provider endpoints this tenant connects to.
+  repeated ProviderConnectionConfig provider_connections = 1;
+
+  // instruction_routes maps instruction types to provider connections for outbound dispatch.
+  repeated InstructionRouteConfig instruction_routes = 2;
+
+  // inbound_routes defines how inbound events from external providers are handled (Phase 5 placeholder).
+  repeated InboundRouteConfig inbound_routes = 3;
+}
+
+// ProviderProtocol defines the transport protocol used for a provider connection.
+// Mirrors the runtime Protocol enum but is self-contained in the manifest config.
+enum ProviderProtocol {
+  // PROVIDER_PROTOCOL_UNSPECIFIED means the protocol is unknown.
+  PROVIDER_PROTOCOL_UNSPECIFIED = 0;
+  // PROVIDER_PROTOCOL_HTTPS dispatches instructions via HTTPS REST calls.
+  PROVIDER_PROTOCOL_HTTPS = 1;
+  // PROVIDER_PROTOCOL_GRPC dispatches instructions via gRPC.
+  PROVIDER_PROTOCOL_GRPC = 2;
+  // PROVIDER_PROTOCOL_WEBHOOK sends instructions to a webhook endpoint (HTTPS with specific retry semantics).
+  PROVIDER_PROTOCOL_WEBHOOK = 3;
+  // PROVIDER_PROTOCOL_MQTT publishes instructions to an MQTT topic.
+  PROVIDER_PROTOCOL_MQTT = 4;
+  // PROVIDER_PROTOCOL_AMQP publishes instructions to an AMQP queue or exchange.
+  PROVIDER_PROTOCOL_AMQP = 5;
+}
+
+// RetryPolicyConfig defines the backoff strategy for failed dispatch attempts.
+message RetryPolicyConfig {
+  // max_attempts is the total number of dispatch attempts (including the first).
+  // A value of 1 means no retries (one attempt only).
+  int32 max_attempts = 1 [(buf.validate.field).int32 = {
+    gte: 1
+    lte: 20
+  }];
+
+  // initial_backoff_seconds is the delay before the first retry in seconds.
+  int32 initial_backoff_seconds = 2 [(buf.validate.field).int32 = {
+    gte: 1
+    lte: 3600
+  }];
+
+  // max_backoff_seconds caps the computed backoff to prevent unbounded delays.
+  int32 max_backoff_seconds = 3 [(buf.validate.field).int32 = {
+    gte: 1
+    lte: 86400
+  }];
+
+  // backoff_multiplier is the factor by which the backoff duration grows after each attempt.
+  // Example: initial=1s, multiplier=2.0 → 1s, 2s, 4s, 8s...
+  double backoff_multiplier = 4 [(buf.validate.field).double = {
+    gte: 1.0
+    lte: 10.0
+  }];
+}
+
+// RateLimitConfig controls the outbound dispatch rate for a connection.
+message RateLimitConfig {
+  // requests_per_second is the maximum sustained dispatch rate.
+  double requests_per_second = 1 [(buf.validate.field).double = {
+    gt: 0.0
+    lte: 10000.0
+  }];
+
+  // burst_size is the maximum number of requests allowed to exceed the rate limit momentarily.
+  int32 burst_size = 2 [(buf.validate.field).int32 = {
+    gte: 1
+    lte: 10000
+  }];
+}
+
+// ApiKeyAuthConfig configures authentication via a static API key header.
+// All sensitive values are expressed as secret references, never raw values.
+message ApiKeyAuthConfig {
+  // header_name is the HTTP header used to transmit the API key.
+  // Example: "X-API-Key", "Authorization"
+  string header_name = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 128
+  }];
+
+  // api_key_secret_ref is a reference to the secret store key that holds the API key value.
+  // Example: "sm://stripe/api_key" or "env://STRIPE_API_KEY"
+  string api_key_secret_ref = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 512
+  }];
+}
+
+// BasicAuthConfig configures HTTP Basic authentication.
+// All sensitive values are expressed as secret references, never raw values.
+message BasicAuthConfig {
+  // username is the Basic auth username (not sensitive - stored directly).
+  string username = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // password_secret_ref is a reference to the secret store key that holds the password.
+  string password_secret_ref = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 512
+  }];
+}
+
+// OAuth2AuthConfig configures OAuth 2.0 client credentials flow authentication.
+// All sensitive values are expressed as secret references, never raw values.
+message OAuth2AuthConfig {
+  // token_url is the OAuth 2.0 token endpoint.
+  string token_url = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 2048
+    uri: true
+  }];
+
+  // client_id is the OAuth 2.0 client identifier (not sensitive - stored directly).
+  string client_id = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 512
+  }];
+
+  // client_secret_ref is a reference to the secret store key that holds the client secret.
+  string client_secret_ref = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 512
+  }];
+
+  // scopes lists the OAuth 2.0 scopes to request.
+  repeated string scopes = 4 [(buf.validate.field).repeated = {
+    max_items: 32
+    items: {string: {max_len: 256}}
+  }];
+}
+
+// HMACAuthConfig configures HMAC-based request signing.
+// All sensitive values are expressed as secret references, never raw values.
+message HMACAuthConfig {
+  // algorithm is the HMAC signing algorithm.
+  // Supported values: "sha256", "sha512"
+  string algorithm = 1 [(buf.validate.field).string = {
+    in: [
+      "sha256",
+      "sha512"
+    ]
+  }];
+
+  // secret_ref is a reference to the secret store key that holds the HMAC signing secret.
+  string secret_ref = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 512
+  }];
+
+  // signature_header is the HTTP header where the computed signature is placed.
+  // Example: "X-Signature", "X-Hub-Signature-256"
+  string signature_header = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 128
+  }];
+}
+
+// MTLSAuthConfig configures mutual TLS (mTLS) authentication.
+// All sensitive values are expressed as secret references, never raw values.
+message MTLSAuthConfig {
+  // client_cert_secret_ref is a reference to the secret store key holding the PEM-encoded client certificate.
+  string client_cert_secret_ref = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 512
+  }];
+
+  // client_key_secret_ref is a reference to the secret store key holding the PEM-encoded private key.
+  string client_key_secret_ref = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 512
+  }];
+
+  // ca_cert_secret_ref is an optional reference to the secret store key holding the CA certificate
+  // for verifying the provider's server certificate.
+  string ca_cert_secret_ref = 3 [(buf.validate.field).string.max_len = 512];
+}
+
+// AuthConfigManifest defines the authentication configuration for a provider connection.
+// Exactly one variant must be set. All sensitive values use secret references.
+message AuthConfigManifest {
+  // auth_config is the authentication variant for this connection.
+  // Exactly one must be set.
+  oneof auth_config {
+    option (buf.validate.oneof).required = true;
+
+    // api_key authenticates using a static API key in a header.
+    ApiKeyAuthConfig api_key = 1;
+    // basic authenticates using HTTP Basic authentication.
+    BasicAuthConfig basic = 2;
+    // oauth2 authenticates using OAuth 2.0 client credentials flow.
+    OAuth2AuthConfig oauth2 = 3;
+    // hmac authenticates by signing requests with HMAC.
+    HMACAuthConfig hmac = 4;
+    // mtls authenticates using mutual TLS client certificates.
+    MTLSAuthConfig mtls = 5;
+  }
+}
+
+// ProviderConnectionConfig declares a single external provider connection within the manifest.
+// Each connection is identified by a stable connection_id used in InstructionRouteConfig.
+message ProviderConnectionConfig {
+  // connection_id is the stable, unique identifier for this connection within the manifest.
+  // Used by InstructionRouteConfig to reference this connection. Must be unique within the manifest.
+  // Example: "stripe-payments", "modulr-uk", "kraken-energy-grid"
+  string connection_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 128
+    pattern: "^[a-z][a-z0-9_-]*$"
+  }];
+
+  // provider_name is the human-readable name for the external provider.
+  // Example: "Stripe", "Modulr", "Kraken Energy Grid"
+  string provider_name = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // provider_type is a machine-readable classifier for the provider category.
+  // Example: "payment_gateway", "kyc_provider", "energy_scheduler"
+  string provider_type = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 128
+    pattern: "^[a-z][a-z0-9_]*$"
+  }];
+
+  // protocol is the transport protocol for dispatching instructions to this provider.
+  ProviderProtocol protocol = 4 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // base_url is the root URL of the provider's API endpoint.
+  // Must be a valid URI. Example: "https://api.stripe.com"
+  string base_url = 5 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 2048
+    uri: true
+  }];
+
+  // auth is the authentication configuration for this connection.
+  AuthConfigManifest auth = 6 [(buf.validate.field).required = true];
+
+  // retry_policy defines how failed dispatch attempts are retried.
+  // If not set, a default policy is used by the runtime.
+  RetryPolicyConfig retry_policy = 7;
+
+  // rate_limit controls the outbound dispatch rate for this connection.
+  // If not set, no rate limiting is applied.
+  RateLimitConfig rate_limit = 8;
+}
+
+// InstructionRouteConfig maps an instruction_type to a provider connection for outbound dispatch.
+// Routes determine which connection handles a given type of instruction and how the
+// payload is transformed before dispatch.
+message InstructionRouteConfig {
+  // instruction_type is the instruction category this route handles.
+  // Must be unique within the manifest's instruction_routes list.
+  // Example: "payment.initiate", "account.freeze", "kyc.verify"
+  string instruction_type = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // connection_id references the primary ProviderConnectionConfig used to dispatch matching instructions.
+  // Must match a connection_id defined in operational_gateway.provider_connections.
+  string connection_id = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 128
+  }];
+
+  // fallback_connection_id references an optional secondary connection used when the primary is unhealthy.
+  // Must match a connection_id defined in operational_gateway.provider_connections, if set.
+  // If not set, instructions fail without fallback when the primary connection is unhealthy.
+  string fallback_connection_id = 3 [(buf.validate.field).string.max_len = 128];
+
+  // outbound_mapping_id is the name of the MappingDefinition applied to transform the instruction
+  // payload from the internal Meridian format to the provider's expected format before dispatch.
+  // Must match a name in the manifest's mappings list. If empty, the payload is sent as-is.
+  string outbound_mapping_id = 4 [(buf.validate.field).string.max_len = 255];
+
+  // inbound_mapping_id is the name of the MappingDefinition applied to transform provider callback
+  // payloads from the provider's format to the internal Meridian format.
+  // Must match a name in the manifest's mappings list. If empty, callback payloads are processed as-is.
+  string inbound_mapping_id = 5 [(buf.validate.field).string.max_len = 255];
+
+  // http_method is the HTTP method used when dispatching via HTTPS or WEBHOOK protocol.
+  // Example: "POST", "PUT", "PATCH"
+  // Required for HTTPS and WEBHOOK protocols; ignored for GRPC, MQTT, AMQP.
+  string http_method = 6 [(buf.validate.field).string = {
+    max_len: 10
+    pattern: "^(GET|POST|PUT|PATCH|DELETE)?$"
+  }];
+
+  // path_template is the URL path template appended to the connection base_url.
+  // Supports simple variable substitution using {field_name} placeholders resolved from the payload.
+  // Example: "/v1/payments/{payment_id}/execute", "/accounts/{account_id}/freeze"
+  string path_template = 7 [(buf.validate.field).string.max_len = 1024];
+}
+
+// InboundRouteConfig declares how inbound events from external providers are handled.
+// This is a Phase 5 placeholder — configuration is captured in the manifest but runtime
+// support is not yet implemented.
+message InboundRouteConfig {
+  // external_type identifies the category of inbound event from the provider.
+  // Example: "stripe.payment_intent.succeeded", "modulr.account.credited"
+  string external_type = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // handler_saga is the name of the SagaDefinition to invoke when this event is received.
+  // Must match a name in the manifest's sagas list.
+  string handler_saga = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[a-z][a-z0-9_]*$"
+  }];
+
+  // mapping_id is the name of the MappingDefinition applied to transform the inbound event
+  // payload before passing it to the handler saga.
+  // Must match a name in the manifest's mappings list. If empty, the payload is passed as-is.
+  string mapping_id = 3 [(buf.validate.field).string.max_len = 255];
 }

--- a/api/proto/meridian/control_plane/v1/manifest.proto
+++ b/api/proto/meridian/control_plane/v1/manifest.proto
@@ -679,12 +679,16 @@ message InstructionRouteConfig {
   string connection_id = 2 [(buf.validate.field).string = {
     min_len: 1
     max_len: 128
+    pattern: "^[a-z][a-z0-9_-]*$"
   }];
 
   // fallback_connection_id references an optional secondary connection used when the primary is unhealthy.
   // Must match a connection_id defined in operational_gateway.provider_connections, if set.
   // If not set, instructions fail without fallback when the primary connection is unhealthy.
-  string fallback_connection_id = 3 [(buf.validate.field).string.max_len = 128];
+  string fallback_connection_id = 3 [(buf.validate.field).string = {
+    max_len: 128
+    pattern: "^$|^[a-z][a-z0-9_-]*$"
+  }];
 
   // outbound_mapping_id is the name of the MappingDefinition applied to transform the instruction
   // payload from the internal Meridian format to the provider's expected format before dispatch.

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -361,6 +361,48 @@ func (v *ManifestValidator) validateDuplicates(
 			mappingKeys[key] = i
 		}
 	}
+
+	// Check duplicate operational_gateway connection_ids and instruction_types
+	v.validateOperationalGatewayDuplicates(manifest, result)
+}
+
+// validateOperationalGatewayDuplicates checks for duplicate connection_ids and instruction_types.
+func (v *ManifestValidator) validateOperationalGatewayDuplicates(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	gw := manifest.GetOperationalGateway()
+	if gw == nil {
+		return
+	}
+
+	connectionIDs := make(map[string]int)
+	for i, conn := range gw.GetProviderConnections() {
+		if prev, exists := connectionIDs[conn.GetConnectionId()]; exists {
+			addError(result, ValidationError{
+				Severity: SeverityError,
+				Path:     fmt.Sprintf("operational_gateway.provider_connections[%d].connection_id", i),
+				Code:     "DUPLICATE_CONNECTION_ID",
+				Message:  fmt.Sprintf("duplicate connection_id %q (first defined at provider_connections[%d])", conn.GetConnectionId(), prev),
+			})
+		} else {
+			connectionIDs[conn.GetConnectionId()] = i
+		}
+	}
+
+	instructionTypes := make(map[string]int)
+	for i, route := range gw.GetInstructionRoutes() {
+		if prev, exists := instructionTypes[route.GetInstructionType()]; exists {
+			addError(result, ValidationError{
+				Severity: SeverityError,
+				Path:     fmt.Sprintf("operational_gateway.instruction_routes[%d].instruction_type", i),
+				Code:     "DUPLICATE_INSTRUCTION_TYPE",
+				Message:  fmt.Sprintf("duplicate instruction_type %q (first defined at instruction_routes[%d])", route.GetInstructionType(), prev),
+			})
+		} else {
+			instructionTypes[route.GetInstructionType()] = i
+		}
+	}
 }
 
 // validateCELExpressions type-checks CEL expressions in account type policies.
@@ -558,6 +600,159 @@ func (v *ManifestValidator) validateCrossReferences(
 			result,
 		)
 	}
+
+	// Validate operational_gateway cross-references
+	v.validateOperationalGatewayCrossRefs(manifest, result)
+}
+
+// validateOperationalGatewayCrossRefs validates referential integrity for the operational_gateway section.
+// It checks that:
+// - instruction_route.connection_id references an existing provider_connection
+// - instruction_route.fallback_connection_id (if set) references an existing provider_connection
+// - instruction_route.outbound_mapping_id (if set) references an existing mapping
+// - instruction_route.inbound_mapping_id (if set) references an existing mapping
+// - inbound_route.handler_saga references an existing saga
+// - inbound_route.mapping_id (if set) references an existing mapping
+func (v *ManifestValidator) validateOperationalGatewayCrossRefs(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	gw := manifest.GetOperationalGateway()
+	if gw == nil {
+		return
+	}
+
+	// Build lookup sets for valid connection_ids, mapping names, and saga names
+	connectionIDs := make(map[string]bool)
+	for _, conn := range gw.GetProviderConnections() {
+		if id := conn.GetConnectionId(); id != "" {
+			connectionIDs[id] = true
+		}
+	}
+
+	mappingNames := make(map[string]bool)
+	for _, mp := range manifest.GetMappings() {
+		if name := mp.GetName(); name != "" {
+			mappingNames[name] = true
+		}
+	}
+
+	sagaNames := make(map[string]bool)
+	for _, saga := range manifest.GetSagas() {
+		if name := saga.GetName(); name != "" {
+			sagaNames[name] = true
+		}
+	}
+
+	for i, route := range gw.GetInstructionRoutes() {
+		v.validateInstructionRouteRefs(route, i, connectionIDs, mappingNames, result)
+	}
+
+	for i, route := range gw.GetInboundRoutes() {
+		v.validateInboundRouteRefs(route, i, sagaNames, mappingNames, result)
+	}
+}
+
+// validateInstructionRouteRefs checks connection and mapping references for a single InstructionRouteConfig.
+func (v *ManifestValidator) validateInstructionRouteRefs(
+	route *controlplanev1.InstructionRouteConfig,
+	idx int,
+	connectionIDs map[string]bool,
+	mappingNames map[string]bool,
+	result *ValidationResult,
+) {
+	basePath := fmt.Sprintf("operational_gateway.instruction_routes[%d]", idx)
+	connectionIDList := mapKeys(connectionIDs)
+	mappingNameList := mapKeys(mappingNames)
+
+	checkConnectionRef(route.GetConnectionId(), basePath+".connection_id", connectionIDs, connectionIDList, result)
+	if fallbackID := route.GetFallbackConnectionId(); fallbackID != "" {
+		checkConnectionRef(fallbackID, basePath+".fallback_connection_id", connectionIDs, connectionIDList, result)
+	}
+	if id := route.GetOutboundMappingId(); id != "" {
+		checkMappingRef(id, basePath+".outbound_mapping_id", mappingNames, mappingNameList, result)
+	}
+	if id := route.GetInboundMappingId(); id != "" {
+		checkMappingRef(id, basePath+".inbound_mapping_id", mappingNames, mappingNameList, result)
+	}
+}
+
+// validateInboundRouteRefs checks saga and mapping references for a single InboundRouteConfig.
+func (v *ManifestValidator) validateInboundRouteRefs(
+	route *controlplanev1.InboundRouteConfig,
+	idx int,
+	sagaNames map[string]bool,
+	mappingNames map[string]bool,
+	result *ValidationResult,
+) {
+	basePath := fmt.Sprintf("operational_gateway.inbound_routes[%d]", idx)
+	sagaNameList := mapKeys(sagaNames)
+	mappingNameList := mapKeys(mappingNames)
+
+	if sagaName := route.GetHandlerSaga(); sagaName != "" && !sagaNames[sagaName] {
+		ve := ValidationError{
+			Severity:        SeverityError,
+			Path:            basePath + ".handler_saga",
+			Code:            "UNDEFINED_SAGA_REFERENCE",
+			Message:         fmt.Sprintf("handler_saga %q is not defined in sagas[]", sagaName),
+			AvailableFields: sagaNameList,
+		}
+		if suggestion := findClosestMatch(sagaName, sagaNameList); suggestion != "" {
+			ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+		}
+		addError(result, ve)
+	}
+	if id := route.GetMappingId(); id != "" {
+		checkMappingRef(id, basePath+".mapping_id", mappingNames, mappingNameList, result)
+	}
+}
+
+// checkConnectionRef validates that a connection ID string references an existing provider connection.
+func checkConnectionRef(
+	connID string,
+	path string,
+	validIDs map[string]bool,
+	idList []string,
+	result *ValidationResult,
+) {
+	if connID == "" || validIDs[connID] {
+		return
+	}
+	ve := ValidationError{
+		Severity:        SeverityError,
+		Path:            path,
+		Code:            "UNDEFINED_CONNECTION_REFERENCE",
+		Message:         fmt.Sprintf("connection_id %q is not defined in operational_gateway.provider_connections", connID),
+		AvailableFields: idList,
+	}
+	if suggestion := findClosestMatch(connID, idList); suggestion != "" {
+		ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+	}
+	addError(result, ve)
+}
+
+// checkMappingRef validates that a mapping name string references an existing mapping.
+func checkMappingRef(
+	mappingID string,
+	path string,
+	validNames map[string]bool,
+	nameList []string,
+	result *ValidationResult,
+) {
+	if mappingID == "" || validNames[mappingID] {
+		return
+	}
+	ve := ValidationError{
+		Severity:        SeverityError,
+		Path:            path,
+		Code:            "UNDEFINED_MAPPING_REFERENCE",
+		Message:         fmt.Sprintf("mapping %q is not defined in mappings[]", mappingID),
+		AvailableFields: nameList,
+	}
+	if suggestion := findClosestMatch(mappingID, nameList); suggestion != "" {
+		ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+	}
+	addError(result, ve)
 }
 
 // validateMappings validates all MappingDefinition entries in the manifest.


### PR DESCRIPTION
## Summary

Adds the `operational_gateway` field (field 11) to the `Manifest` proto, enabling tenants to declare external system integrations as part of their manifest configuration.

## Changes Made

**`api/proto/meridian/control_plane/v1/manifest.proto`**

- Added `operational_gateway = 11` field to `Manifest` message
- Added `OperationalGatewayConfig` message — top-level container with:
  - `provider_connections` — repeated `ProviderConnectionConfig`
  - `instruction_routes` — repeated `InstructionRouteConfig`
  - `inbound_routes` — repeated `InboundRouteConfig` (Phase 5 placeholder)
- Added `ProviderConnectionConfig` — connection_id, provider_name, provider_type, protocol, base_url, auth, retry_policy, rate_limit
- Added `AuthConfigManifest` — oneof wrapping `ApiKeyAuthConfig`, `BasicAuthConfig`, `OAuth2AuthConfig`, `HMACAuthConfig`, `MTLSAuthConfig` (all use secret references, never raw values)
- Added `InstructionRouteConfig` — instruction_type, connection_id, fallback_connection_id, outbound_mapping_id, inbound_mapping_id, http_method, path_template
- Added `InboundRouteConfig` — Phase 5 placeholder (external_type, handler_saga, mapping_id)
- Added `ProviderProtocol` enum, `RetryPolicyConfig`, `RateLimitConfig`

## Technical Details

- All manifest config messages are **self-contained** in `manifest.proto` — no import of `operational_gateway/v1/operational_gateway.proto`. The manifest describes the configuration structure, not the runtime domain.
- Auth config messages use **secret references** (e.g. `"sm://stripe/api_key"`) rather than raw values — manifests can be stored and version-controlled safely.
- `connection_id` in `ProviderConnectionConfig` uses a stable slug pattern (`^[a-z][a-z0-9_-]*$`) for human-readable references in `InstructionRouteConfig`, rather than UUIDs generated at runtime.
- All fields follow existing manifest.proto conventions: `buf.validate.field` annotations with min_len/max_len/pattern for IDs, enum validation with `defined_only` and `not_in: [0]`.

## Testing

- `buf lint` passes cleanly
- `buf generate api/proto` completes without errors
- Pre-commit hooks pass (Gitleaks, buf lint, buf breaking change check)
- JSON Schema auto-regenerated by pre-commit hook

## Risk Assessment

- **Non-breaking**: Adding field 11 to `Manifest` is a backwards-compatible proto change.
- **No runtime impact**: Proto definitions only — no service implementation in this PR.