### PR TITLE
docs: add PRD 031 - Identity and Access Management

### DIFF
--- a/docs/prd/030-identity-access-management.md
+++ b/docs/prd/030-identity-access-management.md
@@ -267,7 +267,7 @@ identity documents.
 ```go
 type Identity struct {
     ID             uuid.UUID
-    PartyID        uuid.UUID       // FK to Party.Individual
+    PartyID        *uuid.UUID      // FK to Party.Individual (nil during invite)
     TenantID       tenant.TenantID // nullable for platform admins
     Email          string          // Login identifier (unique per tenant)
     PasswordHash   string          // bcrypt (Meridian-managed auth)
@@ -404,6 +404,7 @@ CREATE TABLE identity (
     version         INT NOT NULL DEFAULT 1,
 
     UNIQUE (tenant_id, email),
+    UNIQUE (email) WHERE tenant_id IS NULL,
     UNIQUE (external_idp, external_idp_sub)
       WHERE external_idp IS NOT NULL
 );

--- a/docs/prd/030-identity-access-management.md
+++ b/docs/prd/030-identity-access-management.md
@@ -369,8 +369,13 @@ without re-authentication.
 ### 6. Platform Admin Bootstrap
 
 On first boot, Meridian creates a platform admin identity from
-`PLATFORM_ADMIN_EMAIL` and `PLATFORM_ADMIN_PASSWORD` env vars with forced
-password change. Subsequent admins are created via invitation.
+`PLATFORM_ADMIN_EMAIL` and `PLATFORM_ADMIN_PASSWORD` env vars.
+Bootstrap credentials are one-time use: the first login forces an
+immediate password reset, after which the env var value is no longer
+valid. In production, inject these via a secret manager (e.g.,
+Kubernetes Secrets, Vault) — never store plaintext passwords in
+environment files or container images. Subsequent admins are created
+via the invitation flow.
 
 ## Database Schema
 

--- a/docs/prd/030-identity-access-management.md
+++ b/docs/prd/030-identity-access-management.md
@@ -1,6 +1,9 @@
 ---
 name: prd-identity-access-management
-description: Bridge Party service identity (KYC) to authentication and authorization with dynamic user management, role assignment, and multi-level access control
+description: >-
+  Extend Party service with Identity and RoleAssignment business qualifiers
+  for dynamic user management, role assignment, and multi-level access control.
+  Dex as sole OIDC provider across all environments.
 triggers:
   - Working on authentication, authorization, or access control
   - Implementing user management, invitation flows, or role assignment
@@ -11,34 +14,37 @@ triggers:
 instructions: |
   The Party service handles two distinct access control concerns:
 
-  1. Customer Access Control (KYC path) — Party.Individual + verification providers
+  1. Customer Access Control (KYC path) — Party.Individual + verification
      - Handled by: Party service (ExchangeDemographics RPC, verification adapters)
      - PRD: 020-party-kyc-aml-provider-integration
      - Purpose: Verify customer identity for regulatory compliance
 
-  2. Staff/Operator Access Control (IAM path) — Identity + RoleAssignment + JWT claims
-     - Handled by: Identity service (this PRD, 030)
+  2. Staff/Operator Access Control (IAM path) — Identity + RoleAssignment
+     - Handled by: Party service (new business qualifiers, this PRD 030)
      - Purpose: Authenticate staff, assign roles, populate JWT claims
+     - Dex issues JWTs; Party service owns user CRUD and credentials
 
   Both paths create Party.Individual records, but serve different purposes:
   - KYC path: "Is this person who they claim to be?" (regulatory)
   - IAM path: "Can this person log in, and what can they do?" (operational)
 
   Key files:
+  - services/party/ (Identity + RoleAssignment added here)
   - shared/platform/auth/rbac.go (existing RBAC framework)
   - shared/platform/auth/grpc_interceptor.go (JWT validation + tenant context)
   - shared/platform/auth/jwt.go (Claims structure)
   - services/gateway/auth/ (HTTP auth middleware)
   - deploy/demo/dex.yaml (static users to be replaced)
 
-  The Identity service lives in the public schema (cross-tenant) because
-  users may have roles in multiple tenants. Party data remains tenant-scoped.
+  Identity and RoleAssignment tables live in the public schema (cross-tenant)
+  because users may have roles in multiple tenants. Party data remains
+  tenant-scoped. Dex is the sole OIDC provider (no Keycloak).
 ---
 
 # PRD 030: Identity and Access Management
 
 **Status:** Not Started
-**Version:** 1.0
+**Version:** 2.0
 **Date:** 2026-03-01
 **Author:** Architecture Team
 **Task Master Tag:** TBD
@@ -50,15 +56,19 @@ instructions: |
 
 **Related PRDs:**
 
-- [020 - Party KYC/AML Provider Integration](020-party-kyc-aml-provider-integration.md) — Customer-facing identity verification
-- [Multi-Tenancy](.taskmaster/docs/prd-multi-tenancy.md) — Tenant provisioning and isolation
+<!-- markdownlint-disable MD013 -->
+
+- [020 - Party KYC/AML Provider Integration](020-party-kyc-aml-provider-integration.md) —
+  Customer-facing identity verification
+
+<!-- markdownlint-enable MD013 -->
 
 ---
 
 ## The Two Access Control Concerns
 
-The Party service sits at the intersection of two distinct access control problems.
-Understanding this separation is essential to this PRD.
+The Party service handles two distinct access control problems. Both live
+within the Party domain but serve different purposes.
 
 ### Concern 1: Customer Access Control (KYC Path)
 
@@ -85,47 +95,48 @@ Customer → Party.Individual → KYC Provider (Onfido/Stripe Identity)
 This is the gap that this PRD addresses:
 
 ```text
-Staff member → Identity (email + credentials) → JWT (tenant + roles)
+Staff member → Party.Identity (email + credentials)
+  → Dex validates via gRPC connector → JWT (tenant + roles)
   → RBAC enforcement → Access granted/denied
 ```
 
 - **Operational requirement** — control who can operate the system
 - **Cross-tenant** — a user may have roles in multiple tenants
-- **Handled by:** New Identity service (this PRD)
+- **Handled by:** Party service (new Identity + RoleAssignment qualifiers)
 - **Data lives in:** public schema (cross-tenant)
 
 ### How They Connect
 
-Both concerns create `Party.Individual` records, but for different reasons:
+Both concerns anchor to `Party.Individual`, but as different business
+qualifiers — just like Demographics, References, and BankRelation:
 
 ```text
-                    Party.Individual
-                   /                \
-    KYC Path (PRD 020)        IAM Path (PRD 030)
-    "Verify identity"         "Grant system access"
-    Tenant-scoped             Cross-tenant
-    Regulatory                Operational
-    Async (days)              Sync (seconds)
-    External providers        Internal credentials
+Party.Individual
+  ├── Demographics    (employment, income, education)
+  ├── Reference       (passport, driver's license)
+  ├── BankRelation    (account officer, branch)
+  ├── Verification    (KYC result — PRD 020)
+  ├── Identity        (login credentials — PRD 030)   ← NEW
+  └── RoleAssignment  (tenant + role grants — PRD 030) ← NEW
 ```
 
 A staff member who is also a customer of the same tenant has:
 
 - One Party.Individual (their identity)
-- One KYC verification record (customer compliance)
-- One Identity record (login credentials)
-- One or more RoleAssignments (what they can do)
+- One Verification record (KYC compliance — PRD 020)
+- One Identity record (login credentials — PRD 030)
+- One or more RoleAssignments (what they can do — PRD 030)
 
 ---
 
 ## Problem Statement
 
-Meridian has two halves of an access control system that don't talk to each other:
+Meridian has two halves of an access control system that don't connect:
 
 **What exists and works well:**
 
 - JWT validation, JWKS key rotation, gRPC/HTTP interceptors
-- RBAC framework (admin, operator, auditor, service roles with permission matrix)
+- RBAC framework (admin, operator, auditor, service roles + permission matrix)
 - Schema-based multi-tenant isolation with subdomain-hopping prevention
 - Party service with Organization, Individual, KYC verification, references
 - Tenant service with provisioning, lifecycle, Party.Organization linkage
@@ -140,11 +151,14 @@ Meridian has two halves of an access control system that don't talk to each othe
 - No self-service: tenants can't manage their own users
 - Roles come from JWT claims, but nothing populates those claims dynamically
 
-**The result:** A fully-featured authorization enforcement layer with no way to actually manage who is authorized.
+**The result:** A fully-featured authorization enforcement layer with no way
+to actually manage who is authorized.
 
 ## Access Control Levels
 
 Meridian requires four distinct access tiers:
+
+<!-- markdownlint-disable MD013 -->
 
 | Level | Name | Scope | Who | Role |
 |-------|------|-------|-----|------|
@@ -153,12 +167,43 @@ Meridian requires four distinct access tiers:
 | 2 | Tenant Administrator | Single tenant | Staff appointed by tenant owner | `admin` |
 | 3 | Tenant User | Single tenant, restricted | Customers onboarded by tenant | `operator`, `auditor`, custom |
 
-**Level 0** can create/suspend tenants, apply platform manifests, view cross-tenant metrics.
-**Level 1** can manage tenant admins, view billing, apply tenant manifests, access all tenant data.
-**Level 2** can manage users, configure account types, run operations, view audit trails.
-**Level 3** can view own accounts, initiate transactions, complete KYC.
+<!-- markdownlint-enable MD013 -->
 
-## Architecture Context
+**Level 0** creates/suspends tenants, applies platform manifests,
+views cross-tenant metrics.
+**Level 1** manages tenant admins, views billing, applies tenant manifests.
+**Level 2** manages users, configures account types, runs operations.
+**Level 3** views own accounts, initiates transactions, completes KYC.
+
+## Architecture
+
+### OIDC Provider: Dex Everywhere
+
+**Decision:** Dex is the sole OIDC provider across all environments.
+Keycloak is removed entirely.
+
+| Responsibility | Owner |
+|---------------|-------|
+| User CRUD (create, invite, suspend) | Party service |
+| Password storage + validation | Party service |
+| Role assignment | Party service (RoleAssignment table) |
+| JWT issuance + signing | Dex |
+| JWKS endpoint + key rotation | Dex |
+| Federation (upstream IdPs) | Dex connectors |
+| Admin UI for user management | Meridian frontend (future) |
+
+**Why not Keycloak?** Once Identity management lives in the Party service,
+Keycloak becomes a ~500MB middleman duplicating what Meridian already owns.
+Dex does the one thing needed externally — issue and sign JWTs — at ~20MB.
+Dex is also what Kubernetes itself uses for OIDC.
+
+**Environment parity:**
+
+| Environment | OIDC Provider | Auth Enabled | Users |
+|-------------|--------------|:---:|-------|
+| Local (Tilt) | Dex | Yes | Dev users from dex.yaml |
+| Demo | Dex | Yes | Bootstrap from env vars |
+| Production | Dex | Yes | Dynamic via Party service |
 
 ### Current Authentication Flow (Demo)
 
@@ -170,84 +215,63 @@ User → Dex (static password check) → JWT (sub, email, name)
 ```
 
 **Problem:** `DEFAULT_TENANT_ID` and `DEFAULT_ROLES` are env vars.
-Every user gets the same tenant and same roles. No per-user differentiation.
+Every user gets the same tenant and same roles.
 
 ### Target Authentication Flow
 
 ```text
-User → Dex (connector → Meridian Identity Service)
-  → JWT (sub, email, x-tenant-id, roles)
+User → Dex (gRPC connector → Party service)
+  → Party validates credentials, looks up RoleAssignments
+  → Dex issues JWT (sub, email, x-tenant-id, roles)
   → Gateway validates JWT (no defaults needed)
   → Interceptor injects claims into context
   → RBAC enforcement (unchanged)
 ```
 
-Or, for production deployments with external IdPs:
+For production with external IdPs:
 
 ```text
-User → External IdP (Auth0, Okta, Google Workspace)
-  → Meridian Token Exchange enriches token with tenant + roles
+User → Dex (upstream connector → Auth0/Okta/Google)
+  → Dex calls Party service to enrich claims
   → JWT (sub, email, x-tenant-id, roles)
   → Gateway validates JWT
   → RBAC enforcement (unchanged)
 ```
 
+No separate Token Exchange service needed — Dex's connector model
+handles federation natively.
+
 ### BIAN Alignment
 
-BIAN defines a **Party Authentication** service domain for verifying party
-identity for access control:
+BIAN defines a **Party Authentication** service domain. Identity and
+RoleAssignment fit naturally as Party business qualifiers, consistent
+with how Demographics, References, and Verification already work:
 
 | Meridian Concept | BIAN Mapping |
 |-----------------|--------------|
 | Identity (login credentials) | Party Authentication Assessment |
-| Role Assignment | Party Role / Access Right |
+| RoleAssignment | Party Role / Access Right |
 | Session/Token | Authentication Token |
 | Password reset | Authentication Maintenance |
 
-### Local Development: Keycloak vs Dex Mismatch
-
-The local Tilt environment deploys **Keycloak** (v26.0, ~500MB RAM) as its OIDC
-provider, but keeps `AUTH_ENABLED=false` by default — meaning it's running but
-never exercised. The demo environment uses **Dex** (~20MB RAM) with static users
-and `AUTH_ENABLED=true`.
-
-This creates two problems:
-
-1. **Environment divergence**: Different OIDC providers means JWT claim formats,
-   token endpoints, and JWKS paths differ between local and demo
-2. **Auth is never tested locally**: Developers only discover auth issues when
-   deploying to demo
-
-**Recommendation:** Replace Keycloak with Dex in Tilt to match the demo stack.
-Dex is 25x lighter and aligns environments. Enable `AUTH_ENABLED=true` by
-default so auth code is always exercised locally.
-
-```yaml
-# Replace Keycloak deployment with Dex
-# Tilt: deploy/local/dex.yaml (~20MB vs ~500MB for Keycloak)
-# Reuse deploy/demo/dex.yaml as base, add local dev users
-```
-
-This is a prerequisite for Phase 1 — the Dex gRPC connector must be testable locally.
-
 ## Core Features
 
-### 1. Identity Entity — The Party-to-Login Bridge
+### 1. Identity — Party Business Qualifier
 
-Links a Party.Individual to authentication credentials. A Party represents a
-business entity (KYC, demographics, references). An Identity represents
-"this party can authenticate."
+Links a Party.Individual to authentication credentials, just as
+Demographics links to employment history or Reference links to
+identity documents.
 
 ```go
 type Identity struct {
     ID             uuid.UUID
-    PartyID        uuid.UUID       // FK to Party.Individual (nullable until KYC)
-    TenantID       tenant.TenantID
+    PartyID        uuid.UUID       // FK to Party.Individual
+    TenantID       tenant.TenantID // nullable for platform admins
     Email          string          // Login identifier (unique per tenant)
     PasswordHash   string          // bcrypt (Meridian-managed auth)
-    ExternalIDPSub string          // Subject from external IdP (federated auth)
-    ExternalIDP    string          // IdP name ("google", "auth0", "okta")
-    Status         IdentityStatus  // ACTIVE, PENDING_INVITE, SUSPENDED, LOCKED, DEPROVISIONED
+    ExternalIDPSub string          // Subject from external IdP
+    ExternalIDP    string          // "google", "auth0", "okta"
+    Status         IdentityStatus  // ACTIVE, PENDING_INVITE, etc.
     LastLoginAt    *time.Time
     FailedAttempts int
     LockedUntil    *time.Time
@@ -262,12 +286,22 @@ type Identity struct {
 
 - One Party.Individual can have at most one Identity per tenant
 - Email unique within a tenant (can exist across tenants)
-- Password-based and federated auth are mutually exclusive per identity
-- Identity can exist without a Party (invite flow — Party created during KYC)
+- Password-based and federated auth are mutually exclusive
+- Identity can exist without a Party (invite flow — Party created on accept)
 
-### 2. Role Assignment — Dynamic Authorization
+**Why in Party service, not a separate service:**
 
-Stores which roles a user has within which tenant. Replaces the static `DEFAULT_ROLES` mechanism.
+- **Same domain**: Identity is a Party business qualifier, like Demographics
+- **Simpler deployment**: No additional service to operate
+- **Shared context**: Party already has the Individual, Verification, and
+  Reference entities that Identity relates to
+- **Cross-tenant data**: The `identity` table lives in the public schema
+  (same pattern as the `tenant` table in the Tenant service)
+
+### 2. RoleAssignment — Dynamic Authorization
+
+Stores which roles a user has within which tenant. Replaces the static
+`DEFAULT_ROLES` mechanism.
 
 ```go
 type RoleAssignment struct {
@@ -296,29 +330,32 @@ auditor        → can grant: (nothing)
 
 Role changes take effect at next token refresh (not mid-session).
 
-### 3. Token Issuance — Claims Population
+### 3. Dex gRPC Connector — Claims Population
 
-When a user authenticates, their JWT is populated with the correct
-`x-tenant-id` and `roles` claims from RoleAssignment records.
+When a user authenticates, Dex calls the Party service's gRPC connector
+to validate credentials and populate JWT claims:
 
-**3a. Meridian-Managed Auth (Dex + Custom Connector):**
+```text
+Dex receives login request (email + password)
+  → Calls Party service Authenticate RPC
+  → Party validates password hash
+  → Party looks up RoleAssignments for this identity
+  → Returns: sub, email, name, x-tenant-id, roles[]
+  → Dex signs JWT with these claims
+```
 
-Write a Dex gRPC connector that calls the Identity service to validate
-credentials and return claims.
-
-**3b. Federated Auth (External IdP + Token Exchange):**
-
-Implement OAuth 2.0 Token Exchange (RFC 8693) to enrich external IdP tokens
-with Meridian tenant and role claims.
+For federated auth (Phase 3), Dex's upstream connectors handle the
+external IdP interaction, then call Party service to enrich claims
+with tenant and role information.
 
 ### 4. User Lifecycle Operations
 
-**Invitation:** `InviteUser(email, role)` creates a PENDING_INVITE identity with
-a time-limited token. User sets password or links IdP, then Party.Individual is
-created and KYC initiated if required.
+**Invitation:** `InviteUser(email, role)` creates a PENDING_INVITE identity
+with a time-limited token. User sets password or links IdP, then
+Party.Individual is created and KYC initiated if required.
 
-**Password management:** Self-service change, admin reset, forgot-password flow
-with time-limited reset tokens delivered via webhook.
+**Password management:** Self-service change, admin reset, forgot-password
+flow with time-limited reset tokens delivered via webhook.
 
 **Lifecycle:** Suspend (disable login), reactivate, deprovision (soft-delete
 with PII anonymization after retention).
@@ -335,26 +372,17 @@ On first boot, Meridian creates a platform admin identity from
 `PLATFORM_ADMIN_EMAIL` and `PLATFORM_ADMIN_PASSWORD` env vars with forced
 password change. Subsequent admins are created via invitation.
 
-## Service Design
+## Database Schema
 
-**Recommendation: New Identity Service** (separate from Party)
-
-Rationale:
-
-- **Security boundary**: Credentials isolated from business data
-- **BIAN alignment**: Party Authentication is distinct from Party Directory
-- **Scaling**: Auth endpoints have different performance characteristics
-- **Schema**: Identity data is cross-tenant; Party data is tenant-scoped
-
-### Database Schema
-
-Identity data lives in the **public schema** (cross-tenant):
+Identity and RoleAssignment tables live in the **public schema** because
+they span tenants. This is the same pattern used by the `tenant` table
+in the Tenant service.
 
 ```sql
 CREATE TABLE identity (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    tenant_id       VARCHAR(50) NOT NULL,
     party_id        UUID,
+    tenant_id       VARCHAR(50),
     email           VARCHAR(255) NOT NULL,
     password_hash   VARCHAR(255),
     external_idp    VARCHAR(50),
@@ -369,7 +397,8 @@ CREATE TABLE identity (
     version         INT NOT NULL DEFAULT 1,
 
     UNIQUE (tenant_id, email),
-    UNIQUE (external_idp, external_idp_sub) WHERE external_idp IS NOT NULL
+    UNIQUE (external_idp, external_idp_sub)
+      WHERE external_idp IS NOT NULL
 );
 
 CREATE TABLE role_assignment (
@@ -384,7 +413,8 @@ CREATE TABLE role_assignment (
     revoked_at   TIMESTAMPTZ,
     revoked_by   UUID REFERENCES identity(id),
 
-    UNIQUE (identity_id, tenant_id, role) WHERE revoked = false
+    UNIQUE (identity_id, tenant_id, role)
+      WHERE revoked = false
 );
 
 CREATE TABLE invitation (
@@ -398,59 +428,81 @@ CREATE TABLE invitation (
 );
 ```
 
-### Proto Definition
+## Proto Definition
+
+New RPCs added to the existing Party service proto, grouped as a
+business qualifier (same pattern as RetrieveDemographics,
+RetrieveReference, etc.):
 
 ```protobuf
-service IdentityService {
-  // Identity CRUD
-  rpc CreateIdentity(CreateIdentityRequest) returns (CreateIdentityResponse);
-  rpc RetrieveIdentity(RetrieveIdentityRequest) returns (RetrieveIdentityResponse);
-  rpc UpdateIdentity(UpdateIdentityRequest) returns (UpdateIdentityResponse);
-  rpc ListIdentities(ListIdentitiesRequest) returns (ListIdentitiesResponse);
+// Identity business qualifier RPCs (added to PartyService)
+rpc CreateIdentity(CreateIdentityRequest)
+    returns (CreateIdentityResponse);
+rpc RetrieveIdentity(RetrieveIdentityRequest)
+    returns (RetrieveIdentityResponse);
+rpc UpdateIdentity(UpdateIdentityRequest)
+    returns (UpdateIdentityResponse);
+rpc ListIdentities(ListIdentitiesRequest)
+    returns (ListIdentitiesResponse);
 
-  // Authentication
-  rpc Authenticate(AuthenticateRequest) returns (AuthenticateResponse);
-  rpc RefreshToken(RefreshTokenRequest) returns (RefreshTokenResponse);
-  rpc ExchangeToken(ExchangeTokenRequest) returns (ExchangeTokenResponse);
+// Authentication (called by Dex gRPC connector)
+rpc Authenticate(AuthenticateRequest)
+    returns (AuthenticateResponse);
+rpc RefreshToken(RefreshTokenRequest)
+    returns (RefreshTokenResponse);
 
-  // Password management
-  rpc SetPassword(SetPasswordRequest) returns (SetPasswordResponse);
-  rpc ChangePassword(ChangePasswordRequest) returns (ChangePasswordResponse);
-  rpc RequestPasswordReset(RequestPasswordResetRequest) returns (RequestPasswordResetResponse);
-  rpc CompletePasswordReset(CompletePasswordResetRequest) returns (CompletePasswordResetResponse);
+// Password management
+rpc SetPassword(SetPasswordRequest)
+    returns (SetPasswordResponse);
+rpc ChangePassword(ChangePasswordRequest)
+    returns (ChangePasswordResponse);
+rpc RequestPasswordReset(RequestPasswordResetRequest)
+    returns (RequestPasswordResetResponse);
+rpc CompletePasswordReset(CompletePasswordResetRequest)
+    returns (CompletePasswordResetResponse);
 
-  // Role management
-  rpc GrantRole(GrantRoleRequest) returns (GrantRoleResponse);
-  rpc RevokeRole(RevokeRoleRequest) returns (RevokeRoleResponse);
-  rpc ListRoleAssignments(ListRoleAssignmentsRequest) returns (ListRoleAssignmentsResponse);
+// Role management
+rpc GrantRole(GrantRoleRequest)
+    returns (GrantRoleResponse);
+rpc RevokeRole(RevokeRoleRequest)
+    returns (RevokeRoleResponse);
+rpc ListRoleAssignments(ListRoleAssignmentsRequest)
+    returns (ListRoleAssignmentsResponse);
 
-  // Invitation
-  rpc InviteUser(InviteUserRequest) returns (InviteUserResponse);
-  rpc AcceptInvitation(AcceptInvitationRequest) returns (AcceptInvitationResponse);
+// Invitation
+rpc InviteUser(InviteUserRequest)
+    returns (InviteUserResponse);
+rpc AcceptInvitation(AcceptInvitationRequest)
+    returns (AcceptInvitationResponse);
 
-  // Tenant resolution
-  rpc ListUserTenants(ListUserTenantsRequest) returns (ListUserTenantsResponse);
-  rpc SwitchTenant(SwitchTenantRequest) returns (SwitchTenantResponse);
+// Tenant resolution
+rpc ListUserTenants(ListUserTenantsRequest)
+    returns (ListUserTenantsResponse);
+rpc SwitchTenant(SwitchTenantRequest)
+    returns (SwitchTenantResponse);
 
-  // Lifecycle
-  rpc SuspendIdentity(SuspendIdentityRequest) returns (SuspendIdentityResponse);
-  rpc ReactivateIdentity(ReactivateIdentityRequest) returns (ReactivateIdentityResponse);
-}
+// Lifecycle
+rpc SuspendIdentity(SuspendIdentityRequest)
+    returns (SuspendIdentityResponse);
+rpc ReactivateIdentity(ReactivateIdentityRequest)
+    returns (ReactivateIdentityResponse);
 ```
 
 ## Implementation Phases
 
-### Phase 1: Replace Static Dex Users (Critical Path)
+### Phase 1: Dex Everywhere + Replace Static Users (Critical Path)
 
-1. Replace Keycloak with Dex in local Tilt stack (environment parity)
-2. Enable `AUTH_ENABLED=true` by default in local dev
-3. Add Identity + RoleAssignment tables to migrations
-4. Bootstrap creates identities for existing demo users
-5. Write Dex gRPC connector to validate against Identity service
-6. Remove `DEFAULT_TENANT_ID` and `DEFAULT_ROLES` env vars
-7. JWT claims populated from RoleAssignment table
+1. Remove Keycloak from Tilt; add Dex to local dev stack
+2. Enable `AUTH_ENABLED=true` by default in all environments
+3. Add Identity + RoleAssignment tables to Party service migrations
+4. Implement Authenticate RPC in Party service
+5. Write Dex gRPC connector that calls Party service
+6. Bootstrap creates platform admin identity from env vars
+7. Remove `DEFAULT_TENANT_ID` and `DEFAULT_ROLES` env vars
+8. JWT claims populated from RoleAssignment table
 
-**Demo works identically**, but credentials are now in the database, not in dex.yaml.
+**Demo and local dev work identically**, but credentials are in the
+database, not in dex.yaml static passwords.
 
 **Estimate:** 13 story points
 
@@ -465,8 +517,8 @@ service IdentityService {
 
 ### Phase 3: Federated Authentication
 
-1. Token Exchange endpoint (RFC 8693)
-2. External IdP support (Auth0, Okta, Google Workspace)
+1. Configure Dex upstream connectors (Auth0, Okta, Google Workspace)
+2. Party service claim enrichment for federated users
 3. SCIM provisioning for enterprise directory sync
 4. MFA support
 
@@ -506,26 +558,26 @@ service IdentityService {
 
 ## Success Criteria
 
-1. Demo environment works with dynamic users (no hard-coded Dex passwords)
-2. First platform admin created from env var, subsequent admins via invitation
-3. Tenant owner can invite admins, admins can invite users
-4. JWT claims reflect actual role assignments, not env var defaults
-5. Identity.party_id links to Party.Individual for KYC-verified users
-6. User with roles in multiple tenants can switch between them
-7. All auth events appear in audit trail
+1. Dex is sole OIDC provider (local, demo, production) — no Keycloak
+2. Demo works with dynamic users (no hard-coded Dex passwords)
+3. Platform admin bootstrapped from env var, subsequent admins invited
+4. Tenant owner can invite admins, admins can invite users
+5. JWT claims reflect actual RoleAssignments, not env var defaults
+6. Identity.party_id links to Party.Individual for KYC-verified users
+7. User with roles in multiple tenants can switch between them
+8. All auth events appear in audit trail
 
 ## Non-Goals
 
 - Frontend UI for user management (API-first; UI is separate)
-- SSO/SAML support (OIDC only)
+- SSO/SAML support (OIDC via Dex connectors only)
 - Custom permission definitions (Phase 4)
 - Biometric authentication (KYC provider concern)
 - Session management (stateless JWT)
 
 ## Dependencies
 
-- Party service (Party.Individual creation during invitation)
+- Dex (gRPC connector for Phase 1)
 - Tenant service (tenant validation, Party.Organization mapping)
 - Audit service (auth event logging)
-- Dex (gRPC connector for Phase 1)
 - Gateway (remove DEFAULT_TENANT_ID / DEFAULT_ROLES fallback)

--- a/docs/prd/030-identity-access-management.md
+++ b/docs/prd/030-identity-access-management.md
@@ -165,7 +165,7 @@ Meridian requires four distinct access tiers:
 | 0 | Platform Administrator | `meridian_master` | Meridian operators | `platform-admin`, `super-admin` |
 | 1 | Tenant Owner | Single tenant | Organization that contracted Meridian | `tenant-owner` (new) |
 | 2 | Tenant Administrator | Single tenant | Staff appointed by tenant owner | `admin` |
-| 3 | Tenant User | Single tenant, restricted | Customers onboarded by tenant | `operator`, `auditor`, custom |
+| 3 | Tenant User | Single tenant, restricted | End users (staff or customers) | `operator`, `auditor`, custom |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -173,7 +173,9 @@ Meridian requires four distinct access tiers:
 views cross-tenant metrics.
 **Level 1** manages tenant admins, views billing, applies tenant manifests.
 **Level 2** manages users, configures account types, runs operations.
-**Level 3** views own accounts, initiates transactions, completes KYC.
+**Level 3** accesses scoped resources per assigned role (e.g., view
+accounts, initiate transactions). Customer KYC verification is
+handled separately by PRD 020.
 
 ## Architecture
 

--- a/docs/prd/030-identity-access-management.md
+++ b/docs/prd/030-identity-access-management.md
@@ -1,0 +1,531 @@
+---
+name: prd-identity-access-management
+description: Bridge Party service identity (KYC) to authentication and authorization with dynamic user management, role assignment, and multi-level access control
+triggers:
+  - Working on authentication, authorization, or access control
+  - Implementing user management, invitation flows, or role assignment
+  - Connecting Party service to login credentials
+  - Configuring Dex OIDC, JWT claims, or token issuance
+  - Working on platform admin bootstrap or tenant owner onboarding
+  - Modifying DEFAULT_ROLES, DEFAULT_TENANT_ID, or auth interceptors
+instructions: |
+  The Party service handles two distinct access control concerns:
+
+  1. Customer Access Control (KYC path) — Party.Individual + verification providers
+     - Handled by: Party service (ExchangeDemographics RPC, verification adapters)
+     - PRD: 020-party-kyc-aml-provider-integration
+     - Purpose: Verify customer identity for regulatory compliance
+
+  2. Staff/Operator Access Control (IAM path) — Identity + RoleAssignment + JWT claims
+     - Handled by: Identity service (this PRD, 030)
+     - Purpose: Authenticate staff, assign roles, populate JWT claims
+
+  Both paths create Party.Individual records, but serve different purposes:
+  - KYC path: "Is this person who they claim to be?" (regulatory)
+  - IAM path: "Can this person log in, and what can they do?" (operational)
+
+  Key files:
+  - shared/platform/auth/rbac.go (existing RBAC framework)
+  - shared/platform/auth/grpc_interceptor.go (JWT validation + tenant context)
+  - shared/platform/auth/jwt.go (Claims structure)
+  - services/gateway/auth/ (HTTP auth middleware)
+  - deploy/demo/dex.yaml (static users to be replaced)
+
+  The Identity service lives in the public schema (cross-tenant) because
+  users may have roles in multiple tenants. Party data remains tenant-scoped.
+---
+
+# PRD 030: Identity and Access Management
+
+**Status:** Not Started
+**Version:** 1.0
+**Date:** 2026-03-01
+**Author:** Architecture Team
+**Task Master Tag:** TBD
+
+**ADRs:**
+
+- [0002 - Microservices Per BIAN Domain](../adr/0002-microservices-per-bian-domain.md)
+- [0021 - KYC/AML Verification Provider Architecture](../adr/0021-kyc-aml-verification-provider-architecture.md)
+
+**Related PRDs:**
+
+- [020 - Party KYC/AML Provider Integration](020-party-kyc-aml-provider-integration.md) — Customer-facing identity verification
+- [Multi-Tenancy](.taskmaster/docs/prd-multi-tenancy.md) — Tenant provisioning and isolation
+
+---
+
+## The Two Access Control Concerns
+
+The Party service sits at the intersection of two distinct access control problems.
+Understanding this separation is essential to this PRD.
+
+### Concern 1: Customer Access Control (KYC Path)
+
+**Question answered:** "Is this person who they claim to be?"
+
+This is the existing Party service capability, covered by PRD 020:
+
+```text
+Customer → Party.Individual → KYC Provider (Onfido/Stripe Identity)
+  → Verification result (APPROVED/REJECTED)
+  → Party status updated
+  → Customer can open accounts, transact
+```
+
+- **Regulatory requirement** — financial services must verify customer identity
+- **Tenant-scoped** — each tenant onboards their own customers
+- **Handled by:** Party service `ExchangeDemographics` RPC + verification adapters
+- **Data lives in:** tenant schema (`org_{tenant_id}`)
+
+### Concern 2: Staff/Operator Access Control (IAM Path)
+
+**Question answered:** "Can this person log in, and what can they do?"
+
+This is the gap that this PRD addresses:
+
+```text
+Staff member → Identity (email + credentials) → JWT (tenant + roles)
+  → RBAC enforcement → Access granted/denied
+```
+
+- **Operational requirement** — control who can operate the system
+- **Cross-tenant** — a user may have roles in multiple tenants
+- **Handled by:** New Identity service (this PRD)
+- **Data lives in:** public schema (cross-tenant)
+
+### How They Connect
+
+Both concerns create `Party.Individual` records, but for different reasons:
+
+```text
+                    Party.Individual
+                   /                \
+    KYC Path (PRD 020)        IAM Path (PRD 030)
+    "Verify identity"         "Grant system access"
+    Tenant-scoped             Cross-tenant
+    Regulatory                Operational
+    Async (days)              Sync (seconds)
+    External providers        Internal credentials
+```
+
+A staff member who is also a customer of the same tenant has:
+
+- One Party.Individual (their identity)
+- One KYC verification record (customer compliance)
+- One Identity record (login credentials)
+- One or more RoleAssignments (what they can do)
+
+---
+
+## Problem Statement
+
+Meridian has two halves of an access control system that don't talk to each other:
+
+**What exists and works well:**
+
+- JWT validation, JWKS key rotation, gRPC/HTTP interceptors
+- RBAC framework (admin, operator, auditor, service roles with permission matrix)
+- Schema-based multi-tenant isolation with subdomain-hopping prevention
+- Party service with Organization, Individual, KYC verification, references
+- Tenant service with provisioning, lifecycle, Party.Organization linkage
+- Platform admin vs tenant admin interceptor separation
+
+**What's missing:**
+
+- No dynamic user management (Dex has 2 hard-coded users)
+- No way to create, invite, or onboard users
+- No storage for "which user has which roles in which tenant"
+- No link from Party.Individual to "this person can log in"
+- No self-service: tenants can't manage their own users
+- Roles come from JWT claims, but nothing populates those claims dynamically
+
+**The result:** A fully-featured authorization enforcement layer with no way to actually manage who is authorized.
+
+## Access Control Levels
+
+Meridian requires four distinct access tiers:
+
+| Level | Name | Scope | Who | Role |
+|-------|------|-------|-----|------|
+| 0 | Platform Administrator | `meridian_master` | Meridian operators | `platform-admin`, `super-admin` |
+| 1 | Tenant Owner | Single tenant | Organization that contracted Meridian | `tenant-owner` (new) |
+| 2 | Tenant Administrator | Single tenant | Staff appointed by tenant owner | `admin` |
+| 3 | Tenant User | Single tenant, restricted | Customers onboarded by tenant | `operator`, `auditor`, custom |
+
+**Level 0** can create/suspend tenants, apply platform manifests, view cross-tenant metrics.
+**Level 1** can manage tenant admins, view billing, apply tenant manifests, access all tenant data.
+**Level 2** can manage users, configure account types, run operations, view audit trails.
+**Level 3** can view own accounts, initiate transactions, complete KYC.
+
+## Architecture Context
+
+### Current Authentication Flow (Demo)
+
+```text
+User → Dex (static password check) → JWT (sub, email, name)
+  → Gateway adds DEFAULT_TENANT_ID + DEFAULT_ROLES
+  → Interceptor injects claims into context
+  → RBAC enforcement checks role+resource+permission
+```
+
+**Problem:** `DEFAULT_TENANT_ID` and `DEFAULT_ROLES` are env vars.
+Every user gets the same tenant and same roles. No per-user differentiation.
+
+### Target Authentication Flow
+
+```text
+User → Dex (connector → Meridian Identity Service)
+  → JWT (sub, email, x-tenant-id, roles)
+  → Gateway validates JWT (no defaults needed)
+  → Interceptor injects claims into context
+  → RBAC enforcement (unchanged)
+```
+
+Or, for production deployments with external IdPs:
+
+```text
+User → External IdP (Auth0, Okta, Google Workspace)
+  → Meridian Token Exchange enriches token with tenant + roles
+  → JWT (sub, email, x-tenant-id, roles)
+  → Gateway validates JWT
+  → RBAC enforcement (unchanged)
+```
+
+### BIAN Alignment
+
+BIAN defines a **Party Authentication** service domain for verifying party
+identity for access control:
+
+| Meridian Concept | BIAN Mapping |
+|-----------------|--------------|
+| Identity (login credentials) | Party Authentication Assessment |
+| Role Assignment | Party Role / Access Right |
+| Session/Token | Authentication Token |
+| Password reset | Authentication Maintenance |
+
+### Local Development: Keycloak vs Dex Mismatch
+
+The local Tilt environment deploys **Keycloak** (v26.0, ~500MB RAM) as its OIDC
+provider, but keeps `AUTH_ENABLED=false` by default — meaning it's running but
+never exercised. The demo environment uses **Dex** (~20MB RAM) with static users
+and `AUTH_ENABLED=true`.
+
+This creates two problems:
+
+1. **Environment divergence**: Different OIDC providers means JWT claim formats,
+   token endpoints, and JWKS paths differ between local and demo
+2. **Auth is never tested locally**: Developers only discover auth issues when
+   deploying to demo
+
+**Recommendation:** Replace Keycloak with Dex in Tilt to match the demo stack.
+Dex is 25x lighter and aligns environments. Enable `AUTH_ENABLED=true` by
+default so auth code is always exercised locally.
+
+```yaml
+# Replace Keycloak deployment with Dex
+# Tilt: deploy/local/dex.yaml (~20MB vs ~500MB for Keycloak)
+# Reuse deploy/demo/dex.yaml as base, add local dev users
+```
+
+This is a prerequisite for Phase 1 — the Dex gRPC connector must be testable locally.
+
+## Core Features
+
+### 1. Identity Entity — The Party-to-Login Bridge
+
+Links a Party.Individual to authentication credentials. A Party represents a
+business entity (KYC, demographics, references). An Identity represents
+"this party can authenticate."
+
+```go
+type Identity struct {
+    ID             uuid.UUID
+    PartyID        uuid.UUID       // FK to Party.Individual (nullable until KYC)
+    TenantID       tenant.TenantID
+    Email          string          // Login identifier (unique per tenant)
+    PasswordHash   string          // bcrypt (Meridian-managed auth)
+    ExternalIDPSub string          // Subject from external IdP (federated auth)
+    ExternalIDP    string          // IdP name ("google", "auth0", "okta")
+    Status         IdentityStatus  // ACTIVE, PENDING_INVITE, SUSPENDED, LOCKED, DEPROVISIONED
+    LastLoginAt    *time.Time
+    FailedAttempts int
+    LockedUntil    *time.Time
+    MFAEnabled     bool
+    CreatedAt      time.Time
+    UpdatedAt      time.Time
+    Version        int
+}
+```
+
+**Constraints:**
+
+- One Party.Individual can have at most one Identity per tenant
+- Email unique within a tenant (can exist across tenants)
+- Password-based and federated auth are mutually exclusive per identity
+- Identity can exist without a Party (invite flow — Party created during KYC)
+
+### 2. Role Assignment — Dynamic Authorization
+
+Stores which roles a user has within which tenant. Replaces the static `DEFAULT_ROLES` mechanism.
+
+```go
+type RoleAssignment struct {
+    ID         uuid.UUID
+    IdentityID uuid.UUID
+    TenantID   tenant.TenantID
+    Role       auth.Role       // admin, operator, auditor, tenant-owner
+    GrantedBy  uuid.UUID
+    GrantedAt  time.Time
+    ExpiresAt  *time.Time      // Optional time-bound roles
+    Revoked    bool
+    RevokedAt  *time.Time
+    RevokedBy  *uuid.UUID
+}
+```
+
+**Role hierarchy (who can grant what):**
+
+```text
+platform-admin → can grant: tenant-owner, admin, operator, auditor
+tenant-owner   → can grant: admin, operator, auditor
+admin          → can grant: operator, auditor
+operator       → can grant: (nothing)
+auditor        → can grant: (nothing)
+```
+
+Role changes take effect at next token refresh (not mid-session).
+
+### 3. Token Issuance — Claims Population
+
+When a user authenticates, their JWT is populated with the correct
+`x-tenant-id` and `roles` claims from RoleAssignment records.
+
+**3a. Meridian-Managed Auth (Dex + Custom Connector):**
+
+Write a Dex gRPC connector that calls the Identity service to validate
+credentials and return claims.
+
+**3b. Federated Auth (External IdP + Token Exchange):**
+
+Implement OAuth 2.0 Token Exchange (RFC 8693) to enrich external IdP tokens
+with Meridian tenant and role claims.
+
+### 4. User Lifecycle Operations
+
+**Invitation:** `InviteUser(email, role)` creates a PENDING_INVITE identity with
+a time-limited token. User sets password or links IdP, then Party.Individual is
+created and KYC initiated if required.
+
+**Password management:** Self-service change, admin reset, forgot-password flow
+with time-limited reset tokens delivered via webhook.
+
+**Lifecycle:** Suspend (disable login), reactivate, deprovision (soft-delete
+with PII anonymization after retention).
+
+### 5. Multi-Tenant User Resolution
+
+A user with roles in multiple tenants selects their tenant at login time.
+Single-tenant users are auto-selected. Tenant switching issues a new JWT
+without re-authentication.
+
+### 6. Platform Admin Bootstrap
+
+On first boot, Meridian creates a platform admin identity from
+`PLATFORM_ADMIN_EMAIL` and `PLATFORM_ADMIN_PASSWORD` env vars with forced
+password change. Subsequent admins are created via invitation.
+
+## Service Design
+
+**Recommendation: New Identity Service** (separate from Party)
+
+Rationale:
+
+- **Security boundary**: Credentials isolated from business data
+- **BIAN alignment**: Party Authentication is distinct from Party Directory
+- **Scaling**: Auth endpoints have different performance characteristics
+- **Schema**: Identity data is cross-tenant; Party data is tenant-scoped
+
+### Database Schema
+
+Identity data lives in the **public schema** (cross-tenant):
+
+```sql
+CREATE TABLE identity (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id       VARCHAR(50) NOT NULL,
+    party_id        UUID,
+    email           VARCHAR(255) NOT NULL,
+    password_hash   VARCHAR(255),
+    external_idp    VARCHAR(50),
+    external_idp_sub VARCHAR(255),
+    status          VARCHAR(20) NOT NULL DEFAULT 'PENDING_INVITE',
+    last_login_at   TIMESTAMPTZ,
+    failed_attempts INT NOT NULL DEFAULT 0,
+    locked_until    TIMESTAMPTZ,
+    mfa_enabled     BOOLEAN NOT NULL DEFAULT false,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    version         INT NOT NULL DEFAULT 1,
+
+    UNIQUE (tenant_id, email),
+    UNIQUE (external_idp, external_idp_sub) WHERE external_idp IS NOT NULL
+);
+
+CREATE TABLE role_assignment (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    identity_id  UUID NOT NULL REFERENCES identity(id),
+    tenant_id    VARCHAR(50) NOT NULL,
+    role         VARCHAR(30) NOT NULL,
+    granted_by   UUID NOT NULL REFERENCES identity(id),
+    granted_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at   TIMESTAMPTZ,
+    revoked      BOOLEAN NOT NULL DEFAULT false,
+    revoked_at   TIMESTAMPTZ,
+    revoked_by   UUID REFERENCES identity(id),
+
+    UNIQUE (identity_id, tenant_id, role) WHERE revoked = false
+);
+
+CREATE TABLE invitation (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    identity_id  UUID NOT NULL REFERENCES identity(id),
+    token_hash   VARCHAR(255) NOT NULL UNIQUE,
+    invited_by   UUID NOT NULL REFERENCES identity(id),
+    expires_at   TIMESTAMPTZ NOT NULL,
+    accepted_at  TIMESTAMPTZ,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+### Proto Definition
+
+```protobuf
+service IdentityService {
+  // Identity CRUD
+  rpc CreateIdentity(CreateIdentityRequest) returns (CreateIdentityResponse);
+  rpc RetrieveIdentity(RetrieveIdentityRequest) returns (RetrieveIdentityResponse);
+  rpc UpdateIdentity(UpdateIdentityRequest) returns (UpdateIdentityResponse);
+  rpc ListIdentities(ListIdentitiesRequest) returns (ListIdentitiesResponse);
+
+  // Authentication
+  rpc Authenticate(AuthenticateRequest) returns (AuthenticateResponse);
+  rpc RefreshToken(RefreshTokenRequest) returns (RefreshTokenResponse);
+  rpc ExchangeToken(ExchangeTokenRequest) returns (ExchangeTokenResponse);
+
+  // Password management
+  rpc SetPassword(SetPasswordRequest) returns (SetPasswordResponse);
+  rpc ChangePassword(ChangePasswordRequest) returns (ChangePasswordResponse);
+  rpc RequestPasswordReset(RequestPasswordResetRequest) returns (RequestPasswordResetResponse);
+  rpc CompletePasswordReset(CompletePasswordResetRequest) returns (CompletePasswordResetResponse);
+
+  // Role management
+  rpc GrantRole(GrantRoleRequest) returns (GrantRoleResponse);
+  rpc RevokeRole(RevokeRoleRequest) returns (RevokeRoleResponse);
+  rpc ListRoleAssignments(ListRoleAssignmentsRequest) returns (ListRoleAssignmentsResponse);
+
+  // Invitation
+  rpc InviteUser(InviteUserRequest) returns (InviteUserResponse);
+  rpc AcceptInvitation(AcceptInvitationRequest) returns (AcceptInvitationResponse);
+
+  // Tenant resolution
+  rpc ListUserTenants(ListUserTenantsRequest) returns (ListUserTenantsResponse);
+  rpc SwitchTenant(SwitchTenantRequest) returns (SwitchTenantResponse);
+
+  // Lifecycle
+  rpc SuspendIdentity(SuspendIdentityRequest) returns (SuspendIdentityResponse);
+  rpc ReactivateIdentity(ReactivateIdentityRequest) returns (ReactivateIdentityResponse);
+}
+```
+
+## Implementation Phases
+
+### Phase 1: Replace Static Dex Users (Critical Path)
+
+1. Replace Keycloak with Dex in local Tilt stack (environment parity)
+2. Enable `AUTH_ENABLED=true` by default in local dev
+3. Add Identity + RoleAssignment tables to migrations
+4. Bootstrap creates identities for existing demo users
+5. Write Dex gRPC connector to validate against Identity service
+6. Remove `DEFAULT_TENANT_ID` and `DEFAULT_ROLES` env vars
+7. JWT claims populated from RoleAssignment table
+
+**Demo works identically**, but credentials are now in the database, not in dex.yaml.
+
+**Estimate:** 13 story points
+
+### Phase 2: Dynamic User Management
+
+1. InviteUser, AcceptInvitation flows
+2. GrantRole, RevokeRole APIs
+3. Password management (self-service change, admin reset, forgot-password)
+4. Tenant admins can invite operators and auditors
+
+**Estimate:** 8 story points
+
+### Phase 3: Federated Authentication
+
+1. Token Exchange endpoint (RFC 8693)
+2. External IdP support (Auth0, Okta, Google Workspace)
+3. SCIM provisioning for enterprise directory sync
+4. MFA support
+
+**Estimate:** 8 story points
+
+### Phase 4: Advanced Access Control
+
+1. Custom roles (tenant-defined, beyond built-in roles)
+2. Resource-scoped permissions
+3. Attribute-based access control (ABAC) via CEL expressions
+4. API key management tied to identities
+
+**Estimate:** 13 story points
+
+## Security Requirements
+
+### Password Policy
+
+- Minimum 12 characters, bcrypt cost factor 12
+- Account lockout after 5 failed attempts (30-minute lock)
+- Password history (prevent reuse of last 5)
+
+### Token Security
+
+- Access tokens: 15-minute expiry
+- Refresh tokens: 7-day expiry, single-use rotation
+- Invitation tokens: 72-hour expiry, single-use
+- Password reset tokens: 1-hour expiry, single-use
+- All tokens stored as bcrypt hashes
+
+### Audit Trail
+
+- All identity operations logged to audit service
+- Login attempts (success/failure) with IP and user agent
+- Role changes with who, what, when
+- SOC2 Type II compliant
+
+## Success Criteria
+
+1. Demo environment works with dynamic users (no hard-coded Dex passwords)
+2. First platform admin created from env var, subsequent admins via invitation
+3. Tenant owner can invite admins, admins can invite users
+4. JWT claims reflect actual role assignments, not env var defaults
+5. Identity.party_id links to Party.Individual for KYC-verified users
+6. User with roles in multiple tenants can switch between them
+7. All auth events appear in audit trail
+
+## Non-Goals
+
+- Frontend UI for user management (API-first; UI is separate)
+- SSO/SAML support (OIDC only)
+- Custom permission definitions (Phase 4)
+- Biometric authentication (KYC provider concern)
+- Session management (stateless JWT)
+
+## Dependencies
+
+- Party service (Party.Individual creation during invitation)
+- Tenant service (tenant validation, Party.Organization mapping)
+- Audit service (auth event logging)
+- Dex (gRPC connector for Phase 1)
+- Gateway (remove DEFAULT_TENANT_ID / DEFAULT_ROLES fallback)

--- a/docs/prd/030-identity-access-management.md
+++ b/docs/prd/030-identity-access-management.md
@@ -543,11 +543,10 @@ database, not in dex.yaml static passwords.
 
 ### Token Security
 
-- Access tokens: 15-minute expiry
-- Refresh tokens: 7-day expiry, single-use rotation
-- Invitation tokens: 72-hour expiry, single-use
-- Password reset tokens: 1-hour expiry, single-use
-- All tokens stored as bcrypt hashes
+- Access tokens: stateless JWTs, 15-minute expiry, validated via JWKS
+- Refresh tokens: 7-day expiry, single-use rotation, stored as bcrypt hash
+- Invitation tokens: 72-hour expiry, single-use, stored as bcrypt hash
+- Password reset tokens: 1-hour expiry, single-use, stored as bcrypt hash
 
 ### Audit Trail
 

--- a/docs/prd/031-identity-access-management.md
+++ b/docs/prd/031-identity-access-management.md
@@ -3,6 +3,7 @@ name: prd-identity-access-management
 description: >-
   Standalone Identity service (BIAN Employee Access) for staff/operator
   authentication, role assignment, and multi-level access control.
+  Tenant-scoped — each tenant manages its own staff.
   Dex as sole OIDC provider across all environments.
 triggers:
   - Working on authentication, authorization, or access control
@@ -28,6 +29,10 @@ instructions: |
      - Dex issues JWTs; Identity service owns user CRUD and credentials
      - BIAN: Employee Access service domain
 
+  Both services are tenant-scoped. Each tenant has its own subdomain
+  and manages its own staff and customers independently. Platform admins
+  are staff of the meridian_master tenant.
+
   Key files:
   - services/identity/ (NEW — Identity + RoleAssignment)
   - shared/pkg/credentials/ (NEW — shared password hashing, validation)
@@ -37,15 +42,14 @@ instructions: |
   - services/gateway/auth/ (HTTP auth middleware)
   - deploy/demo/dex.yaml (static users to be replaced)
 
-  Identity and RoleAssignment tables live in the Identity service's own
-  database (cross-tenant, like the Tenant service). Dex is the sole
-  OIDC provider (no Keycloak).
+  Identity data lives in per-tenant schemas (org_{tenant_id}), same
+  pattern as Party. Dex is the sole OIDC provider (no Keycloak).
 ---
 
 # PRD 031: Identity and Access Management
 
 **Status:** Not Started
-**Version:** 3.0
+**Version:** 4.0
 **Date:** 2026-03-02
 **Author:** Architecture Team
 **Task Master Tag:** TBD
@@ -106,26 +110,39 @@ different service domains. Meridian follows this guidance.
 | **BIAN domain** | Employee Access |
 | **PRD** | 031 — Identity and Access Management |
 | **Purpose** | Authenticate staff/operators, assign roles, populate JWT claims |
-| **Scope** | Cross-tenant — a user may have roles in multiple tenants |
-| **Data location** | Identity service database (cross-tenant) |
+| **Scope** | Tenant-scoped — each tenant manages their own staff |
+| **Data location** | Tenant schema (`org_{tenant_id}`) |
 
 <!-- markdownlint-enable MD013 -->
 
 ### Why Two Services
 
-A customer logging in to view their account balance and a platform admin
+A customer logging in to view their account balance and a tenant admin
 applying a manifest are categorically different operations:
 
 - **Different security profiles** — customer auth is regulatory
   (KYC/AML), staff auth is operational (RBAC)
-- **Different lifecycle** — customers are onboarded per-tenant, staff
-  may span tenants
+- **Different lifecycle** — customers go through KYC verification,
+  staff are invited by admins and assigned roles
 - **Different audit requirements** — customer identity is PII under
   GDPR, staff access is SOC2/operational audit
-- **Different schemas** — customer data is tenant-isolated, staff
-  identity is cross-tenant
+- **Different BIAN domains** — Party Authentication vs Employee Access
 
 The fact that both need "a login" doesn't make them the same domain.
+
+### Tenant Isolation
+
+Each tenant has its own subdomain (`acme.meridianhub.cloud`) and
+manages its own staff independently. There is no cross-tenant identity:
+
+- Tenant A's staff cannot see Tenant B's staff
+- If a person works for two tenants, they have two separate identities
+  (one per tenant, one per subdomain)
+- Platform administrators are staff of the `meridian_master` tenant
+- The subdomain determines which tenant's Identity service authenticates
+  the user — no "tenant selection" step at login
+
+This follows the same isolation model as every other Meridian service.
 
 ### Shared Libraries
 
@@ -138,8 +155,8 @@ shared/platform/auth/      — RBAC, JWT claims, interceptors (existing)
 ```
 
 This avoids duplication while preserving domain separation. If the
-Party service later needs customer login credentials (Phase 4+), it
-imports the same shared packages.
+Party service later needs customer login credentials, it imports the
+same shared packages.
 
 ---
 
@@ -155,14 +172,15 @@ Meridian has two halves of an access control system that don't connect:
 - Schema-based multi-tenant isolation with subdomain-hopping prevention
 - Party service with Organization, Individual, KYC verification,
   references
-- Tenant service with provisioning, lifecycle, Party.Organization linkage
+- Tenant service with provisioning, lifecycle, Party.Organization
+  linkage
 - Platform admin vs tenant admin interceptor separation
 
 **What's missing:**
 
 - No dynamic user management (Dex has 2 hard-coded users)
 - No way to create, invite, or onboard staff/operators
-- No storage for "which user has which roles in which tenant"
+- No storage for "which user has which roles"
 - No self-service: tenants can't manage their own staff
 - Roles come from JWT claims, but nothing populates those claims
   dynamically
@@ -178,7 +196,7 @@ Meridian requires four distinct access tiers:
 
 | Level | Name | Scope | Who | Role |
 |-------|------|-------|-----|------|
-| 0 | Platform Administrator | `meridian_master` | Meridian operators | `platform-admin`, `super-admin` |
+| 0 | Platform Administrator | `meridian_master` tenant | Meridian operators (staff of master tenant) | `platform-admin`, `super-admin` |
 | 1 | Tenant Owner | Single tenant | Organization that contracted Meridian | `tenant-owner` (new) |
 | 2 | Tenant Administrator | Single tenant | Staff appointed by tenant owner | `admin` |
 | 3 | Tenant Operator | Single tenant, restricted | Staff with scoped access | `operator`, `auditor`, custom |
@@ -186,7 +204,8 @@ Meridian requires four distinct access tiers:
 <!-- markdownlint-enable MD013 -->
 
 **Level 0** creates/suspends tenants, applies platform manifests,
-views cross-tenant metrics.
+views cross-tenant metrics. These are Identity records within the
+`meridian_master` tenant.
 **Level 1** manages tenant admins, views billing, applies tenant
 manifests.
 **Level 2** manages users, configures account types, runs operations.
@@ -205,7 +224,7 @@ Keycloak is removed entirely.
 
 | Responsibility | Owner |
 |---------------|-------|
-| User CRUD (create, invite, suspend) | Identity service |
+| User CRUD (create, invite, suspend) | Identity service (per tenant) |
 | Password storage + validation | Identity service (via `shared/pkg/credentials`) |
 | Role assignment | Identity service (RoleAssignment table) |
 | JWT issuance + signing | Dex |
@@ -244,18 +263,26 @@ Every user gets the same tenant and same roles.
 ### Target Authentication Flow
 
 ```text
-User → Dex (gRPC connector → Identity service)
-  → Identity validates credentials, looks up RoleAssignments
+User navigates to acme.meridianhub.cloud
+  → Gateway resolves subdomain → tenant_id
+  → Redirect to Dex with tenant context
+  → Dex (gRPC connector → Identity service, tenant-scoped)
+  → Identity validates credentials in org_acme schema
+  → Identity looks up RoleAssignments
+  → Returns: sub, email, roles[]
   → Dex issues JWT (sub, email, x-tenant-id, roles)
   → Gateway validates JWT (no defaults needed)
-  → Interceptor injects claims into context
   → RBAC enforcement (unchanged)
 ```
+
+The tenant is determined by the subdomain, not by user selection.
+No `DEFAULT_TENANT_ID` or `DEFAULT_ROLES` env vars needed.
 
 For production with external IdPs:
 
 ```text
-User → Dex (upstream connector → Auth0/Okta/Google)
+User navigates to acme.meridianhub.cloud
+  → Dex (upstream connector → Acme's Auth0/Okta/Google)
   → Dex calls Identity service to enrich claims
   → JWT (sub, email, x-tenant-id, roles)
   → Gateway validates JWT
@@ -296,26 +323,26 @@ services/identity/
   ├── grpc/                 # gRPC handlers
   ├── connector/            # Dex gRPC connector implementation
   ├── observability/        # Metrics, health checks
-  ├── migrations/           # Atlas migrations (own database)
+  ├── migrations/           # Atlas migrations (per-tenant schema)
   ├── atlas/                # Atlas config
   └── k8s/                  # Kubernetes manifests
 ```
 
-The Identity service has its own database (same pattern as Tenant,
-Party, and other services). Identity data is inherently cross-tenant,
-so it does not use per-tenant schemas.
+The Identity service uses **per-tenant schemas** (`org_{tenant_id}`),
+the same pattern as Party and other tenant-scoped services. Migrations
+run per-tenant during tenant provisioning.
 
 ## Core Features
 
 ### 1. Identity — Staff Authentication Record
 
 An Identity represents a staff member or operator who can authenticate
-to Meridian.
+to a specific tenant's Meridian instance.
 
 ```go
 type Identity struct {
     ID             uuid.UUID
-    Email          string          // Global login identifier
+    Email          string          // Unique within tenant
     PasswordHash   string          // bcrypt (via shared/pkg/credentials)
     ExternalIDPSub string          // Subject from external IdP
     ExternalIDP    string          // "google", "auth0", "okta"
@@ -332,20 +359,22 @@ type Identity struct {
 
 **Constraints:**
 
-- Email is globally unique (one identity per person)
+- Email is unique within a tenant (same person can have separate
+  identities in different tenants)
 - Password-based and federated auth are mutually exclusive per identity
-- Identity exists independently of Party.Individual (different domain)
+- Identity exists independently of Party.Individual (different domain,
+  different service)
+- Tenant scoping is implicit (per-tenant schema, not a column)
 
 ### 2. RoleAssignment — Dynamic Authorization
 
-Stores which roles a user has within which tenant. Replaces the static
+Stores which roles a user has within their tenant. Replaces the static
 `DEFAULT_ROLES` mechanism.
 
 ```go
 type RoleAssignment struct {
     ID         uuid.UUID
     IdentityID uuid.UUID
-    TenantID   tenant.TenantID
     Role       auth.Role       // admin, operator, auditor, tenant-owner
     GrantedBy  uuid.UUID
     GrantedAt  time.Time
@@ -368,23 +397,28 @@ auditor        → can grant: (nothing)
 
 Role changes take effect at next token refresh (not mid-session).
 
+**Note:** `TenantID` is not a column — it's implicit from the
+per-tenant schema. RoleAssignment is always within a single tenant.
+
 ### 3. Dex gRPC Connector — Claims Population
 
 When a user authenticates, Dex calls the Identity service's gRPC
 connector to validate credentials and populate JWT claims:
 
 ```text
-Dex receives login request (email + password)
-  → Calls Identity service Authenticate RPC
-  → Identity validates password hash
-  → Identity looks up RoleAssignments for this identity
-  → Returns: sub, email, name, x-tenant-id, roles[]
-  → Dex signs JWT with these claims
+User navigates to acme.meridianhub.cloud
+  → Gateway resolves subdomain → tenant_id = "acme"
+  → Dex receives login request (email + password + tenant context)
+  → Calls Identity service Authenticate RPC (tenant-scoped)
+  → Identity validates password hash in org_acme schema
+  → Identity looks up RoleAssignments in org_acme schema
+  → Returns: sub, email, name, roles[]
+  → Dex signs JWT with claims + x-tenant-id from subdomain
 ```
 
 For federated auth (Phase 3), Dex's upstream connectors handle the
 external IdP interaction, then call the Identity service to enrich
-claims with tenant and role information.
+claims with role information for that tenant.
 
 ### 4. User Lifecycle Operations
 
@@ -399,30 +433,26 @@ webhook.
 **Lifecycle:** Suspend (disable login), reactivate, deprovision
 (soft-delete with PII anonymization after retention).
 
-### 5. Multi-Tenant User Resolution
+### 5. Platform Admin Bootstrap
 
-A user with roles in multiple tenants selects their tenant at login
-time. Single-tenant users are auto-selected. Tenant switching issues
-a new JWT without re-authentication.
-
-### 6. Platform Admin Bootstrap
-
-On first boot, Meridian creates a platform admin identity from
-`PLATFORM_ADMIN_EMAIL` and `PLATFORM_ADMIN_PASSWORD` env vars.
-Bootstrap credentials are one-time use: the first login forces an
-immediate password reset, after which the env var value is no longer
-valid. In production, inject these via a secret manager (e.g.,
-Kubernetes Secrets, Vault) — never store plaintext passwords in
-environment files or container images. Subsequent admins are created
-via the invitation flow.
+On first boot, Meridian creates a platform admin identity within the
+`meridian_master` tenant from `PLATFORM_ADMIN_EMAIL` and
+`PLATFORM_ADMIN_PASSWORD` env vars. Bootstrap credentials are one-time
+use: the first login forces an immediate password reset, after which
+the env var value is no longer valid. In production, inject these via
+a secret manager (e.g., Kubernetes Secrets, Vault) — never store
+plaintext passwords in environment files or container images.
+Subsequent admins are created via the invitation flow.
 
 ## Database Schema
 
-The Identity service owns its own database. Identity data is
-inherently cross-tenant (a user may have roles in multiple tenants),
-so tables do not use per-tenant schemas.
+The Identity service uses **per-tenant schemas** (`org_{tenant_id}`),
+the same isolation model as Party and other services. No `tenant_id`
+columns needed — the schema provides isolation.
 
 ```sql
+-- Runs in each tenant's schema (org_{tenant_id})
+
 CREATE TABLE identity (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     email           VARCHAR(255) NOT NULL UNIQUE,
@@ -445,7 +475,6 @@ CREATE TABLE identity (
 CREATE TABLE role_assignment (
     id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     identity_id  UUID NOT NULL REFERENCES identity(id),
-    tenant_id    VARCHAR(50) NOT NULL,
     role         VARCHAR(30) NOT NULL,
     granted_by   UUID NOT NULL REFERENCES identity(id),
     granted_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -454,7 +483,7 @@ CREATE TABLE role_assignment (
     revoked_at   TIMESTAMPTZ,
     revoked_by   UUID REFERENCES identity(id),
 
-    UNIQUE (identity_id, tenant_id, role)
+    UNIQUE (identity_id, role)
       WHERE revoked = false
 );
 
@@ -469,11 +498,13 @@ CREATE TABLE invitation (
 );
 ```
 
-**Key simplifications vs v2.0:**
+**Key simplifications vs v3.0:**
 
-- `email` is globally unique (not per-tenant) — one identity per person
-- No `tenant_id` on Identity — tenant scoping lives in RoleAssignment
-- No `party_id` — Identity and Party are separate domains
+- No `tenant_id` columns anywhere — schema provides tenant isolation
+- `email` unique within tenant (not globally)
+- No cross-tenant queries — each tenant is fully independent
+- RoleAssignment simplified (no `tenant_id` column)
+- Platform admins are records in the `meridian_master` tenant schema
 
 ## Proto Definition
 
@@ -494,8 +525,6 @@ service IdentityService {
   // Authentication (called by Dex gRPC connector)
   rpc Authenticate(AuthenticateRequest)
       returns (AuthenticateResponse);
-  rpc RefreshToken(RefreshTokenRequest)
-      returns (RefreshTokenResponse);
 
   // Password management
   rpc SetPassword(SetPasswordRequest)
@@ -521,12 +550,6 @@ service IdentityService {
   rpc AcceptInvitation(AcceptInvitationRequest)
       returns (AcceptInvitationResponse);
 
-  // Tenant resolution
-  rpc ListUserTenants(ListUserTenantsRequest)
-      returns (ListUserTenantsResponse);
-  rpc SwitchTenant(SwitchTenantRequest)
-      returns (SwitchTenantResponse);
-
   // Lifecycle
   rpc SuspendIdentity(SuspendIdentityRequest)
       returns (SuspendIdentityResponse);
@@ -534,6 +557,10 @@ service IdentityService {
       returns (ReactivateIdentityResponse);
 }
 ```
+
+**Removed vs v3.0:** `ListUserTenants`, `SwitchTenant`, `RefreshToken`
+— no cross-tenant identity means no tenant switching. Token refresh is
+handled by Dex directly.
 
 ## Shared Libraries
 
@@ -560,14 +587,16 @@ use them without coupling:
    (proto, domain, adapters, service, gRPC, atlas, k8s, Tilt)
 2. Extract `shared/pkg/credentials` and `shared/pkg/tokens`
 3. Create Identity + RoleAssignment + Invitation tables (Atlas
-   migrations)
-4. Implement Authenticate RPC
-5. Write Dex gRPC connector that calls Identity service
+   migrations, per-tenant schema)
+4. Implement Authenticate RPC (tenant-scoped)
+5. Write Dex gRPC connector that calls Identity service with tenant
+   context from subdomain
 6. Remove Keycloak from Tilt; add Dex to local dev stack
 7. Enable `AUTH_ENABLED=true` by default in all environments
-8. Bootstrap creates platform admin identity from env vars
+8. Bootstrap creates platform admin identity in `meridian_master`
+   tenant from env vars
 9. Remove `DEFAULT_TENANT_ID` and `DEFAULT_ROLES` env vars
-10. JWT claims populated from RoleAssignment table
+10. JWT claims populated from tenant-scoped RoleAssignment table
 
 **Demo and local dev work identically**, but credentials are in the
 database, not in dex.yaml static passwords.
@@ -629,13 +658,13 @@ database, not in dex.yaml static passwords.
 ## Success Criteria
 
 1. Identity service operational as a standalone BIAN Employee Access
-   service
+   service with per-tenant schema isolation
 2. Dex is sole OIDC provider (local, demo, production) — no Keycloak
 3. Demo works with dynamic users (no hard-coded Dex passwords)
-4. Platform admin bootstrapped from env var, subsequent admins invited
+4. Platform admin bootstrapped in `meridian_master` tenant from env var
 5. Tenant owner can invite admins, admins can invite operators
 6. JWT claims reflect actual RoleAssignments, not env var defaults
-7. User with roles in multiple tenants can switch between them
+7. Subdomain determines tenant — no tenant selection at login
 8. All auth events appear in audit trail
 9. Party service unchanged — remains customer-only (KYC/AML)
 
@@ -645,11 +674,12 @@ database, not in dex.yaml static passwords.
 - SSO/SAML support (OIDC via Dex connectors only)
 - Custom permission definitions (Phase 4)
 - Customer authentication (Party service concern, PRD 020)
+- Cross-tenant identity (one identity per tenant, by design)
 - Session management (stateless JWT)
 
 ## Dependencies
 
 - Dex (gRPC connector for Phase 1)
-- Tenant service (tenant validation)
+- Tenant service (tenant validation, subdomain resolution)
 - Audit service (auth event logging)
-- Gateway (remove DEFAULT_TENANT_ID / DEFAULT_ROLES fallback)
+- Gateway (subdomain → tenant resolution, remove DEFAULT_* fallback)

--- a/docs/prd/031-identity-access-management.md
+++ b/docs/prd/031-identity-access-management.md
@@ -20,7 +20,7 @@ instructions: |
      - Purpose: Verify customer identity for regulatory compliance
 
   2. Staff/Operator Access Control (IAM path) — Identity + RoleAssignment
-     - Handled by: Party service (new business qualifiers, this PRD 030)
+     - Handled by: Party service (new business qualifiers, this PRD 031)
      - Purpose: Authenticate staff, assign roles, populate JWT claims
      - Dex issues JWTs; Party service owns user CRUD and credentials
 
@@ -41,7 +41,7 @@ instructions: |
   tenant-scoped. Dex is the sole OIDC provider (no Keycloak).
 ---
 
-# PRD 030: Identity and Access Management
+# PRD 031: Identity and Access Management
 
 **Status:** Not Started
 **Version:** 2.0

--- a/docs/prd/031-identity-access-management.md
+++ b/docs/prd/031-identity-access-management.md
@@ -1,65 +1,65 @@
 ---
 name: prd-identity-access-management
 description: >-
-  Extend Party service with Identity and RoleAssignment business qualifiers
-  for dynamic user management, role assignment, and multi-level access control.
+  Standalone Identity service (BIAN Employee Access) for staff/operator
+  authentication, role assignment, and multi-level access control.
   Dex as sole OIDC provider across all environments.
 triggers:
   - Working on authentication, authorization, or access control
   - Implementing user management, invitation flows, or role assignment
-  - Connecting Party service to login credentials
+  - Creating or modifying the Identity service
   - Configuring Dex OIDC, JWT claims, or token issuance
   - Working on platform admin bootstrap or tenant owner onboarding
   - Modifying DEFAULT_ROLES, DEFAULT_TENANT_ID, or auth interceptors
 instructions: |
-  The Party service handles two distinct access control concerns:
+  Meridian separates access control into two distinct services, following
+  BIAN's explicit guidance that employee and customer access are different
+  service domains:
 
-  1. Customer Access Control (KYC path) — Party.Individual + verification
+  1. Customer Access Control (Party Authentication)
      - Handled by: Party service (ExchangeDemographics RPC, verification adapters)
      - PRD: 020-party-kyc-aml-provider-integration
      - Purpose: Verify customer identity for regulatory compliance
+     - BIAN: Party Authentication service domain
 
-  2. Staff/Operator Access Control (IAM path) — Identity + RoleAssignment
-     - Handled by: Party service (new business qualifiers, this PRD 031)
+  2. Staff/Operator Access Control (Employee Access)
+     - Handled by: Identity service (this PRD 031)
      - Purpose: Authenticate staff, assign roles, populate JWT claims
-     - Dex issues JWTs; Party service owns user CRUD and credentials
-
-  Both paths create Party.Individual records, but serve different purposes:
-  - KYC path: "Is this person who they claim to be?" (regulatory)
-  - IAM path: "Can this person log in, and what can they do?" (operational)
+     - Dex issues JWTs; Identity service owns user CRUD and credentials
+     - BIAN: Employee Access service domain
 
   Key files:
-  - services/party/ (Identity + RoleAssignment added here)
+  - services/identity/ (NEW — Identity + RoleAssignment)
+  - shared/pkg/credentials/ (NEW — shared password hashing, validation)
   - shared/platform/auth/rbac.go (existing RBAC framework)
   - shared/platform/auth/grpc_interceptor.go (JWT validation + tenant context)
   - shared/platform/auth/jwt.go (Claims structure)
   - services/gateway/auth/ (HTTP auth middleware)
   - deploy/demo/dex.yaml (static users to be replaced)
 
-  Identity and RoleAssignment tables live in the public schema (cross-tenant)
-  because users may have roles in multiple tenants. Party data remains
-  tenant-scoped. Dex is the sole OIDC provider (no Keycloak).
+  Identity and RoleAssignment tables live in the Identity service's own
+  database (cross-tenant, like the Tenant service). Dex is the sole
+  OIDC provider (no Keycloak).
 ---
 
 # PRD 031: Identity and Access Management
 
 **Status:** Not Started
-**Version:** 2.0
-**Date:** 2026-03-01
+**Version:** 3.0
+**Date:** 2026-03-02
 **Author:** Architecture Team
 **Task Master Tag:** TBD
 
 **ADRs:**
 
 - [0002 - Microservices Per BIAN Domain](../adr/0002-microservices-per-bian-domain.md)
-- [0021 - KYC/AML Verification Provider Architecture](../adr/0021-kyc-aml-verification-provider-architecture.md)
 
 **Related PRDs:**
 
 <!-- markdownlint-disable MD013 -->
 
 - [020 - Party KYC/AML Provider Integration](020-party-kyc-aml-provider-integration.md) —
-  Customer-facing identity verification
+  Customer-facing identity verification (BIAN: Party Authentication)
 
 <!-- markdownlint-enable MD013 -->
 
@@ -67,65 +67,78 @@ instructions: |
 
 ## The Two Access Control Concerns
 
-The Party service handles two distinct access control problems. Both live
-within the Party domain but serve different purposes.
+BIAN explicitly separates employee and customer access control into
+different service domains. Meridian follows this guidance.
 
-### Concern 1: Customer Access Control (KYC Path)
+> "A similar type of facility is used for customer access control but
+> as the profile differs, here being for internal applications as opposed
+> to externally visible bank products and services, **the two functions
+> are captured as different service domains**."
+> — BIAN Employee Access service domain definition
+
+### Concern 1: Customer Access Control (Party Authentication)
 
 **Question answered:** "Is this person who they claim to be?"
 
-This is the existing Party service capability, covered by PRD 020:
+<!-- markdownlint-disable MD013 -->
 
-```text
-Customer → Party.Individual → KYC Provider (Onfido/Stripe Identity)
-  → Verification result (APPROVED/REJECTED)
-  → Party status updated
-  → Customer can open accounts, transact
-```
+| Aspect | Detail |
+|--------|--------|
+| **Service** | Party service (existing) |
+| **BIAN domain** | Party Authentication |
+| **PRD** | 020 — Party KYC/AML Provider Integration |
+| **Purpose** | Regulatory identity verification for customers |
+| **Scope** | Tenant-scoped — each tenant onboards their own customers |
+| **Data location** | Tenant schema (`org_{tenant_id}`) |
 
-- **Regulatory requirement** — financial services must verify customer identity
-- **Tenant-scoped** — each tenant onboards their own customers
-- **Handled by:** Party service `ExchangeDemographics` RPC + verification adapters
-- **Data lives in:** tenant schema (`org_{tenant_id}`)
+<!-- markdownlint-enable MD013 -->
 
-### Concern 2: Staff/Operator Access Control (IAM Path)
+### Concern 2: Staff/Operator Access Control (Employee Access)
 
 **Question answered:** "Can this person log in, and what can they do?"
 
-This is the gap that this PRD addresses:
+<!-- markdownlint-disable MD013 -->
+
+| Aspect | Detail |
+|--------|--------|
+| **Service** | Identity service (NEW — this PRD) |
+| **BIAN domain** | Employee Access |
+| **PRD** | 031 — Identity and Access Management |
+| **Purpose** | Authenticate staff/operators, assign roles, populate JWT claims |
+| **Scope** | Cross-tenant — a user may have roles in multiple tenants |
+| **Data location** | Identity service database (cross-tenant) |
+
+<!-- markdownlint-enable MD013 -->
+
+### Why Two Services
+
+A customer logging in to view their account balance and a platform admin
+applying a manifest are categorically different operations:
+
+- **Different security profiles** — customer auth is regulatory
+  (KYC/AML), staff auth is operational (RBAC)
+- **Different lifecycle** — customers are onboarded per-tenant, staff
+  may span tenants
+- **Different audit requirements** — customer identity is PII under
+  GDPR, staff access is SOC2/operational audit
+- **Different schemas** — customer data is tenant-isolated, staff
+  identity is cross-tenant
+
+The fact that both need "a login" doesn't make them the same domain.
+
+### Shared Libraries
+
+Common primitives live in shared packages, used by both services:
 
 ```text
-Staff member → Party.Identity (email + credentials)
-  → Dex validates via gRPC connector → JWT (tenant + roles)
-  → RBAC enforcement → Access granted/denied
+shared/pkg/credentials/    — password hashing, validation, history
+shared/pkg/tokens/         — token generation, hashing, expiry
+shared/platform/auth/      — RBAC, JWT claims, interceptors (existing)
 ```
 
-- **Operational requirement** — control who can operate the system
-- **Cross-tenant** — a user may have roles in multiple tenants
-- **Handled by:** Party service (new Identity + RoleAssignment qualifiers)
-- **Data lives in:** public schema (cross-tenant)
-
-### How They Connect
-
-Both concerns anchor to `Party.Individual`, but as different business
-qualifiers — just like Demographics, References, and BankRelation:
-
-```text
-Party.Individual
-  ├── Demographics    (employment, income, education)
-  ├── Reference       (passport, driver's license)
-  ├── BankRelation    (account officer, branch)
-  ├── Verification    (KYC result — PRD 020)
-  ├── Identity        (login credentials — PRD 031)   ← NEW
-  └── RoleAssignment  (tenant + role grants — PRD 031) ← NEW
-```
-
-A staff member who is also a customer of the same tenant has:
-
-- One Party.Individual (their identity)
-- One Verification record (KYC compliance — PRD 020)
-- One Identity record (login credentials — PRD 031)
-- One or more RoleAssignments (what they can do — PRD 031)
+This avoids duplication while preserving domain separation. If the
+Party service later needs customer login credentials (Phase 4+), it
+imports the same shared packages.
 
 ---
 
@@ -136,23 +149,25 @@ Meridian has two halves of an access control system that don't connect:
 **What exists and works well:**
 
 - JWT validation, JWKS key rotation, gRPC/HTTP interceptors
-- RBAC framework (admin, operator, auditor, service roles + permission matrix)
+- RBAC framework (admin, operator, auditor, service roles + permission
+  matrix)
 - Schema-based multi-tenant isolation with subdomain-hopping prevention
-- Party service with Organization, Individual, KYC verification, references
+- Party service with Organization, Individual, KYC verification,
+  references
 - Tenant service with provisioning, lifecycle, Party.Organization linkage
 - Platform admin vs tenant admin interceptor separation
 
 **What's missing:**
 
 - No dynamic user management (Dex has 2 hard-coded users)
-- No way to create, invite, or onboard users
+- No way to create, invite, or onboard staff/operators
 - No storage for "which user has which roles in which tenant"
-- No link from Party.Individual to "this person can log in"
-- No self-service: tenants can't manage their own users
-- Roles come from JWT claims, but nothing populates those claims dynamically
+- No self-service: tenants can't manage their own staff
+- Roles come from JWT claims, but nothing populates those claims
+  dynamically
 
-**The result:** A fully-featured authorization enforcement layer with no way
-to actually manage who is authorized.
+**The result:** A fully-featured authorization enforcement layer with no
+way to actually manage who is authorized.
 
 ## Access Control Levels
 
@@ -165,17 +180,18 @@ Meridian requires four distinct access tiers:
 | 0 | Platform Administrator | `meridian_master` | Meridian operators | `platform-admin`, `super-admin` |
 | 1 | Tenant Owner | Single tenant | Organization that contracted Meridian | `tenant-owner` (new) |
 | 2 | Tenant Administrator | Single tenant | Staff appointed by tenant owner | `admin` |
-| 3 | Tenant User | Single tenant, restricted | End users (staff or customers) | `operator`, `auditor`, custom |
+| 3 | Tenant Operator | Single tenant, restricted | Staff with scoped access | `operator`, `auditor`, custom |
 
 <!-- markdownlint-enable MD013 -->
 
 **Level 0** creates/suspends tenants, applies platform manifests,
 views cross-tenant metrics.
-**Level 1** manages tenant admins, views billing, applies tenant manifests.
+**Level 1** manages tenant admins, views billing, applies tenant
+manifests.
 **Level 2** manages users, configures account types, runs operations.
 **Level 3** accesses scoped resources per assigned role (e.g., view
-accounts, initiate transactions). Customer KYC verification is
-handled separately by PRD 020.
+accounts, run reports). Customer access is handled separately by
+PRD 020.
 
 ## Architecture
 
@@ -184,20 +200,25 @@ handled separately by PRD 020.
 **Decision:** Dex is the sole OIDC provider across all environments.
 Keycloak is removed entirely.
 
+<!-- markdownlint-disable MD013 -->
+
 | Responsibility | Owner |
 |---------------|-------|
-| User CRUD (create, invite, suspend) | Party service |
-| Password storage + validation | Party service |
-| Role assignment | Party service (RoleAssignment table) |
+| User CRUD (create, invite, suspend) | Identity service |
+| Password storage + validation | Identity service (via `shared/pkg/credentials`) |
+| Role assignment | Identity service (RoleAssignment table) |
 | JWT issuance + signing | Dex |
 | JWKS endpoint + key rotation | Dex |
 | Federation (upstream IdPs) | Dex connectors |
-| Admin UI for user management | Meridian frontend (future) |
+| Customer identity verification | Party service (unchanged) |
 
-**Why not Keycloak?** Once Identity management lives in the Party service,
-Keycloak becomes a ~500MB middleman duplicating what Meridian already owns.
-Dex does the one thing needed externally — issue and sign JWTs — at ~20MB.
-Dex is also what Kubernetes itself uses for OIDC.
+<!-- markdownlint-enable MD013 -->
+
+**Why not Keycloak?** Once Identity management lives in a dedicated
+Meridian service, Keycloak becomes a ~500MB middleman duplicating what
+Meridian already owns. Dex does the one thing needed externally — issue
+and sign JWTs — at ~20MB. Dex is also what Kubernetes itself uses for
+OIDC.
 
 **Environment parity:**
 
@@ -205,7 +226,7 @@ Dex is also what Kubernetes itself uses for OIDC.
 |-------------|--------------|:---:|-------|
 | Local (Tilt) | Dex | Yes | Dev users from dex.yaml |
 | Demo | Dex | Yes | Bootstrap from env vars |
-| Production | Dex | Yes | Dynamic via Party service |
+| Production | Dex | Yes | Dynamic via Identity service |
 
 ### Current Authentication Flow (Demo)
 
@@ -222,8 +243,8 @@ Every user gets the same tenant and same roles.
 ### Target Authentication Flow
 
 ```text
-User → Dex (gRPC connector → Party service)
-  → Party validates credentials, looks up RoleAssignments
+User → Dex (gRPC connector → Identity service)
+  → Identity validates credentials, looks up RoleAssignments
   → Dex issues JWT (sub, email, x-tenant-id, roles)
   → Gateway validates JWT (no defaults needed)
   → Interceptor injects claims into context
@@ -234,7 +255,7 @@ For production with external IdPs:
 
 ```text
 User → Dex (upstream connector → Auth0/Okta/Google)
-  → Dex calls Party service to enrich claims
+  → Dex calls Identity service to enrich claims
   → JWT (sub, email, x-tenant-id, roles)
   → Gateway validates JWT
   → RBAC enforcement (unchanged)
@@ -245,32 +266,52 @@ handles federation natively.
 
 ### BIAN Alignment
 
-BIAN defines a **Party Authentication** service domain. Identity and
-RoleAssignment fit naturally as Party business qualifiers, consistent
-with how Demographics, References, and Verification already work:
+BIAN explicitly separates these into distinct service domains:
 
-| Meridian Concept | BIAN Mapping |
-|-----------------|--------------|
-| Identity (login credentials) | Party Authentication Assessment |
-| RoleAssignment | Party Role / Access Right |
-| Session/Token | Authentication Token |
-| Password reset | Authentication Maintenance |
+<!-- markdownlint-disable MD013 -->
+
+| Meridian Concept | BIAN Service Domain | BIAN Mapping |
+|-----------------|---------------------|--------------|
+| Identity service (this PRD) | Employee Access | Access Profile Management |
+| Identity (login credentials) | Employee Access | Employee Authentication |
+| RoleAssignment | Employee Access | Access Right / Entitlement |
+| Party service (PRD 020) | Party Authentication | Customer Identity Verification |
+
+<!-- markdownlint-enable MD013 -->
+
+## Service Structure
+
+The Identity service follows the same patterns as other Meridian
+services:
+
+```text
+services/identity/
+  ├── cmd/                  # Service entrypoint
+  ├── domain/               # Identity, RoleAssignment, Invitation entities
+  ├── repository/           # Database access
+  ├── service/              # Business logic
+  ├── grpc/                 # gRPC handlers
+  ├── connector/            # Dex gRPC connector implementation
+  ├── migrations/           # Atlas migrations (own database)
+  └── atlas/                # Atlas config
+```
+
+The Identity service has its own database (same pattern as Tenant,
+Party, and other services). Identity data is inherently cross-tenant,
+so it does not use per-tenant schemas.
 
 ## Core Features
 
-### 1. Identity — Party Business Qualifier
+### 1. Identity — Staff Authentication Record
 
-Links a Party.Individual to authentication credentials, just as
-Demographics links to employment history or Reference links to
-identity documents.
+An Identity represents a staff member or operator who can authenticate
+to Meridian.
 
 ```go
 type Identity struct {
     ID             uuid.UUID
-    PartyID        *uuid.UUID      // FK to Party.Individual (nil during invite)
-    TenantID       tenant.TenantID // nullable for platform admins
-    Email          string          // Login identifier (unique per tenant)
-    PasswordHash   string          // bcrypt (Meridian-managed auth)
+    Email          string          // Global login identifier
+    PasswordHash   string          // bcrypt (via shared/pkg/credentials)
     ExternalIDPSub string          // Subject from external IdP
     ExternalIDP    string          // "google", "auth0", "okta"
     Status         IdentityStatus  // ACTIVE, PENDING_INVITE, etc.
@@ -286,19 +327,9 @@ type Identity struct {
 
 **Constraints:**
 
-- One Party.Individual can have at most one Identity per tenant
-- Email unique within a tenant (can exist across tenants)
-- Password-based and federated auth are mutually exclusive
-- Identity can exist without a Party (invite flow — Party created on accept)
-
-**Why in Party service, not a separate service:**
-
-- **Same domain**: Identity is a Party business qualifier, like Demographics
-- **Simpler deployment**: No additional service to operate
-- **Shared context**: Party already has the Individual, Verification, and
-  Reference entities that Identity relates to
-- **Cross-tenant data**: The `identity` table lives in the public schema
-  (same pattern as the `tenant` table in the Tenant service)
+- Email is globally unique (one identity per person)
+- Password-based and federated auth are mutually exclusive per identity
+- Identity exists independently of Party.Individual (different domain)
 
 ### 2. RoleAssignment — Dynamic Authorization
 
@@ -334,39 +365,40 @@ Role changes take effect at next token refresh (not mid-session).
 
 ### 3. Dex gRPC Connector — Claims Population
 
-When a user authenticates, Dex calls the Party service's gRPC connector
-to validate credentials and populate JWT claims:
+When a user authenticates, Dex calls the Identity service's gRPC
+connector to validate credentials and populate JWT claims:
 
 ```text
 Dex receives login request (email + password)
-  → Calls Party service Authenticate RPC
-  → Party validates password hash
-  → Party looks up RoleAssignments for this identity
+  → Calls Identity service Authenticate RPC
+  → Identity validates password hash
+  → Identity looks up RoleAssignments for this identity
   → Returns: sub, email, name, x-tenant-id, roles[]
   → Dex signs JWT with these claims
 ```
 
 For federated auth (Phase 3), Dex's upstream connectors handle the
-external IdP interaction, then call Party service to enrich claims
-with tenant and role information.
+external IdP interaction, then call the Identity service to enrich
+claims with tenant and role information.
 
 ### 4. User Lifecycle Operations
 
-**Invitation:** `InviteUser(email, role)` creates a PENDING_INVITE identity
-with a time-limited token. User sets password or links IdP, then
-Party.Individual is created and KYC initiated if required.
+**Invitation:** `InviteUser(email, role)` creates a PENDING_INVITE
+identity with a time-limited token. User sets password or links IdP
+on accept.
 
-**Password management:** Self-service change, admin reset, forgot-password
-flow with time-limited reset tokens delivered via webhook.
+**Password management:** Self-service change, admin reset,
+forgot-password flow with time-limited reset tokens delivered via
+webhook.
 
-**Lifecycle:** Suspend (disable login), reactivate, deprovision (soft-delete
-with PII anonymization after retention).
+**Lifecycle:** Suspend (disable login), reactivate, deprovision
+(soft-delete with PII anonymization after retention).
 
 ### 5. Multi-Tenant User Resolution
 
-A user with roles in multiple tenants selects their tenant at login time.
-Single-tenant users are auto-selected. Tenant switching issues a new JWT
-without re-authentication.
+A user with roles in multiple tenants selects their tenant at login
+time. Single-tenant users are auto-selected. Tenant switching issues
+a new JWT without re-authentication.
 
 ### 6. Platform Admin Bootstrap
 
@@ -381,16 +413,14 @@ via the invitation flow.
 
 ## Database Schema
 
-Identity and RoleAssignment tables live in the **public schema** because
-they span tenants. This is the same pattern used by the `tenant` table
-in the Tenant service.
+The Identity service owns its own database. Identity data is
+inherently cross-tenant (a user may have roles in multiple tenants),
+so tables do not use per-tenant schemas.
 
 ```sql
 CREATE TABLE identity (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    party_id        UUID,
-    tenant_id       VARCHAR(50),
-    email           VARCHAR(255) NOT NULL,
+    email           VARCHAR(255) NOT NULL UNIQUE,
     password_hash   VARCHAR(255),
     external_idp    VARCHAR(50),
     external_idp_sub VARCHAR(255),
@@ -403,8 +433,6 @@ CREATE TABLE identity (
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     version         INT NOT NULL DEFAULT 1,
 
-    UNIQUE (tenant_id, email),
-    UNIQUE (email) WHERE tenant_id IS NULL,
     UNIQUE (external_idp, external_idp_sub)
       WHERE external_idp IS NOT NULL
 );
@@ -436,78 +464,104 @@ CREATE TABLE invitation (
 );
 ```
 
+**Key simplifications vs v2.0:**
+
+- `email` is globally unique (not per-tenant) — one identity per person
+- No `tenant_id` on Identity — tenant scoping lives in RoleAssignment
+- No `party_id` — Identity and Party are separate domains
+
 ## Proto Definition
 
-New RPCs added to the existing Party service proto, grouped as a
-business qualifier (same pattern as RetrieveDemographics,
-RetrieveReference, etc.):
+New `IdentityService` proto at `api/proto/meridian/identity/v1/`:
 
 ```protobuf
-// Identity business qualifier RPCs (added to PartyService)
-rpc CreateIdentity(CreateIdentityRequest)
-    returns (CreateIdentityResponse);
-rpc RetrieveIdentity(RetrieveIdentityRequest)
-    returns (RetrieveIdentityResponse);
-rpc UpdateIdentity(UpdateIdentityRequest)
-    returns (UpdateIdentityResponse);
-rpc ListIdentities(ListIdentitiesRequest)
-    returns (ListIdentitiesResponse);
+service IdentityService {
+  // Identity CRUD
+  rpc CreateIdentity(CreateIdentityRequest)
+      returns (CreateIdentityResponse);
+  rpc RetrieveIdentity(RetrieveIdentityRequest)
+      returns (RetrieveIdentityResponse);
+  rpc UpdateIdentity(UpdateIdentityRequest)
+      returns (UpdateIdentityResponse);
+  rpc ListIdentities(ListIdentitiesRequest)
+      returns (ListIdentitiesResponse);
 
-// Authentication (called by Dex gRPC connector)
-rpc Authenticate(AuthenticateRequest)
-    returns (AuthenticateResponse);
-rpc RefreshToken(RefreshTokenRequest)
-    returns (RefreshTokenResponse);
+  // Authentication (called by Dex gRPC connector)
+  rpc Authenticate(AuthenticateRequest)
+      returns (AuthenticateResponse);
+  rpc RefreshToken(RefreshTokenRequest)
+      returns (RefreshTokenResponse);
 
-// Password management
-rpc SetPassword(SetPasswordRequest)
-    returns (SetPasswordResponse);
-rpc ChangePassword(ChangePasswordRequest)
-    returns (ChangePasswordResponse);
-rpc RequestPasswordReset(RequestPasswordResetRequest)
-    returns (RequestPasswordResetResponse);
-rpc CompletePasswordReset(CompletePasswordResetRequest)
-    returns (CompletePasswordResetResponse);
+  // Password management
+  rpc SetPassword(SetPasswordRequest)
+      returns (SetPasswordResponse);
+  rpc ChangePassword(ChangePasswordRequest)
+      returns (ChangePasswordResponse);
+  rpc RequestPasswordReset(RequestPasswordResetRequest)
+      returns (RequestPasswordResetResponse);
+  rpc CompletePasswordReset(CompletePasswordResetRequest)
+      returns (CompletePasswordResetResponse);
 
-// Role management
-rpc GrantRole(GrantRoleRequest)
-    returns (GrantRoleResponse);
-rpc RevokeRole(RevokeRoleRequest)
-    returns (RevokeRoleResponse);
-rpc ListRoleAssignments(ListRoleAssignmentsRequest)
-    returns (ListRoleAssignmentsResponse);
+  // Role management
+  rpc GrantRole(GrantRoleRequest)
+      returns (GrantRoleResponse);
+  rpc RevokeRole(RevokeRoleRequest)
+      returns (RevokeRoleResponse);
+  rpc ListRoleAssignments(ListRoleAssignmentsRequest)
+      returns (ListRoleAssignmentsResponse);
 
-// Invitation
-rpc InviteUser(InviteUserRequest)
-    returns (InviteUserResponse);
-rpc AcceptInvitation(AcceptInvitationRequest)
-    returns (AcceptInvitationResponse);
+  // Invitation
+  rpc InviteUser(InviteUserRequest)
+      returns (InviteUserResponse);
+  rpc AcceptInvitation(AcceptInvitationRequest)
+      returns (AcceptInvitationResponse);
 
-// Tenant resolution
-rpc ListUserTenants(ListUserTenantsRequest)
-    returns (ListUserTenantsResponse);
-rpc SwitchTenant(SwitchTenantRequest)
-    returns (SwitchTenantResponse);
+  // Tenant resolution
+  rpc ListUserTenants(ListUserTenantsRequest)
+      returns (ListUserTenantsResponse);
+  rpc SwitchTenant(SwitchTenantRequest)
+      returns (SwitchTenantResponse);
 
-// Lifecycle
-rpc SuspendIdentity(SuspendIdentityRequest)
-    returns (SuspendIdentityResponse);
-rpc ReactivateIdentity(ReactivateIdentityRequest)
-    returns (ReactivateIdentityResponse);
+  // Lifecycle
+  rpc SuspendIdentity(SuspendIdentityRequest)
+      returns (SuspendIdentityResponse);
+  rpc ReactivateIdentity(ReactivateIdentityRequest)
+      returns (ReactivateIdentityResponse);
+}
 ```
+
+## Shared Libraries
+
+Common auth primitives extracted to shared packages so both the
+Identity service and Party service (for future customer auth) can
+use them without coupling:
+
+<!-- markdownlint-disable MD013 -->
+
+| Package | Purpose | Used by |
+|---------|---------|---------|
+| `shared/pkg/credentials` | Password hashing (bcrypt), validation, history checking | Identity service, future Party customer auth |
+| `shared/pkg/tokens` | Token generation, hashing, expiry validation | Identity service, future Party customer auth |
+| `shared/platform/auth` | RBAC, JWT claims, gRPC interceptors (existing) | Gateway, all services |
+
+<!-- markdownlint-enable MD013 -->
 
 ## Implementation Phases
 
-### Phase 1: Dex Everywhere + Replace Static Users (Critical Path)
+### Phase 1: Identity Service + Dex Everywhere (Critical Path)
 
-1. Remove Keycloak from Tilt; add Dex to local dev stack
-2. Enable `AUTH_ENABLED=true` by default in all environments
-3. Add Identity + RoleAssignment tables to Party service migrations
-4. Implement Authenticate RPC in Party service
-5. Write Dex gRPC connector that calls Party service
-6. Bootstrap creates platform admin identity from env vars
-7. Remove `DEFAULT_TENANT_ID` and `DEFAULT_ROLES` env vars
-8. JWT claims populated from RoleAssignment table
+1. Create `services/identity/` service scaffold (domain, repo, service,
+   gRPC layers)
+2. Extract `shared/pkg/credentials` and `shared/pkg/tokens`
+3. Create Identity + RoleAssignment + Invitation tables (Atlas
+   migrations)
+4. Implement Authenticate RPC
+5. Write Dex gRPC connector that calls Identity service
+6. Remove Keycloak from Tilt; add Dex to local dev stack
+7. Enable `AUTH_ENABLED=true` by default in all environments
+8. Bootstrap creates platform admin identity from env vars
+9. Remove `DEFAULT_TENANT_ID` and `DEFAULT_ROLES` env vars
+10. JWT claims populated from RoleAssignment table
 
 **Demo and local dev work identically**, but credentials are in the
 database, not in dex.yaml static passwords.
@@ -518,7 +572,8 @@ database, not in dex.yaml static passwords.
 
 1. InviteUser, AcceptInvitation flows
 2. GrantRole, RevokeRole APIs
-3. Password management (self-service change, admin reset, forgot-password)
+3. Password management (self-service change, admin reset,
+   forgot-password)
 4. Tenant admins can invite operators and auditors
 
 **Estimate:** 8 story points
@@ -526,7 +581,7 @@ database, not in dex.yaml static passwords.
 ### Phase 3: Federated Authentication
 
 1. Configure Dex upstream connectors (Auth0, Okta, Google Workspace)
-2. Party service claim enrichment for federated users
+2. Identity service claim enrichment for federated users
 3. SCIM provisioning for enterprise directory sync
 4. MFA support
 
@@ -552,9 +607,11 @@ database, not in dex.yaml static passwords.
 ### Token Security
 
 - Access tokens: stateless JWTs, 15-minute expiry, validated via JWKS
-- Refresh tokens: 7-day expiry, single-use rotation, stored as bcrypt hash
+- Refresh tokens: 7-day expiry, single-use rotation, stored as bcrypt
+  hash
 - Invitation tokens: 72-hour expiry, single-use, stored as bcrypt hash
-- Password reset tokens: 1-hour expiry, single-use, stored as bcrypt hash
+- Password reset tokens: 1-hour expiry, single-use, stored as bcrypt
+  hash
 
 ### Audit Trail
 
@@ -565,26 +622,28 @@ database, not in dex.yaml static passwords.
 
 ## Success Criteria
 
-1. Dex is sole OIDC provider (local, demo, production) — no Keycloak
-2. Demo works with dynamic users (no hard-coded Dex passwords)
-3. Platform admin bootstrapped from env var, subsequent admins invited
-4. Tenant owner can invite admins, admins can invite users
-5. JWT claims reflect actual RoleAssignments, not env var defaults
-6. Identity.party_id links to Party.Individual for KYC-verified users
+1. Identity service operational as a standalone BIAN Employee Access
+   service
+2. Dex is sole OIDC provider (local, demo, production) — no Keycloak
+3. Demo works with dynamic users (no hard-coded Dex passwords)
+4. Platform admin bootstrapped from env var, subsequent admins invited
+5. Tenant owner can invite admins, admins can invite operators
+6. JWT claims reflect actual RoleAssignments, not env var defaults
 7. User with roles in multiple tenants can switch between them
 8. All auth events appear in audit trail
+9. Party service unchanged — remains customer-only (KYC/AML)
 
 ## Non-Goals
 
 - Frontend UI for user management (API-first; UI is separate)
 - SSO/SAML support (OIDC via Dex connectors only)
 - Custom permission definitions (Phase 4)
-- Biometric authentication (KYC provider concern)
+- Customer authentication (Party service concern, PRD 020)
 - Session management (stateless JWT)
 
 ## Dependencies
 
 - Dex (gRPC connector for Phase 1)
-- Tenant service (tenant validation, Party.Organization mapping)
+- Tenant service (tenant validation)
 - Audit service (auth event logging)
 - Gateway (remove DEFAULT_TENANT_ID / DEFAULT_ROLES fallback)

--- a/docs/prd/031-identity-access-management.md
+++ b/docs/prd/031-identity-access-management.md
@@ -116,16 +116,16 @@ Party.Individual
   ├── Reference       (passport, driver's license)
   ├── BankRelation    (account officer, branch)
   ├── Verification    (KYC result — PRD 020)
-  ├── Identity        (login credentials — PRD 030)   ← NEW
-  └── RoleAssignment  (tenant + role grants — PRD 030) ← NEW
+  ├── Identity        (login credentials — PRD 031)   ← NEW
+  └── RoleAssignment  (tenant + role grants — PRD 031) ← NEW
 ```
 
 A staff member who is also a customer of the same tenant has:
 
 - One Party.Individual (their identity)
 - One Verification record (KYC compliance — PRD 020)
-- One Identity record (login credentials — PRD 030)
-- One or more RoleAssignments (what they can do — PRD 030)
+- One Identity record (login credentials — PRD 031)
+- One or more RoleAssignments (what they can do — PRD 031)
 
 ---
 

--- a/docs/prd/031-identity-access-management.md
+++ b/docs/prd/031-identity-access-management.md
@@ -597,6 +597,10 @@ use them without coupling:
    tenant from env vars
 9. Remove `DEFAULT_TENANT_ID` and `DEFAULT_ROLES` env vars
 10. JWT claims populated from tenant-scoped RoleAssignment table
+11. Verify demo environment supports per-tenant subdomains
+    (`*.demo.meridianhub.cloud`) — wildcard DNS and Caddy TLS are
+    already configured; validate end-to-end tenant resolution via
+    subdomain in the demo stack
 
 **Demo and local dev work identically**, but credentials are in the
 database, not in dex.yaml static passwords.
@@ -647,6 +651,35 @@ database, not in dex.yaml static passwords.
 - Invitation tokens: 72-hour expiry, single-use, stored as bcrypt hash
 - Password reset tokens: 1-hour expiry, single-use, stored as bcrypt
   hash
+
+### Subdomain Security
+
+Subdomain-based tenant isolation is the foundation of the auth flow.
+The gateway already enforces these controls
+(`shared/platform/gateway/tenant_resolver.go`):
+
+- **Host header validation** — `BASE_DOMAIN` suffix check rejects
+  requests where the Host header doesn't end with
+  `.<base_domain>` (e.g., `acme.meridianhub.cloud` is valid;
+  `evil.attacker.com` is rejected)
+- **Slug format validation** — regex `^[a-z0-9]+([-.][a-z0-9]+)*$`
+  rejects injection attempts in subdomain component
+- **JWT-subdomain mismatch** — tenant authorization middleware returns
+  403 if the JWT `tenant_id` claim doesn't match the
+  subdomain-resolved tenant
+- **Header stripping** — `metadataPropagationMiddleware` strips
+  incoming identity headers (x-tenant-id, x-user-id, x-roles) before
+  re-injecting from authenticated context. Clients cannot forge
+  tenant identity via headers
+- **IP/localhost bypass prevention** — direct IP addresses and
+  localhost without subdomain return empty tenant (rejected)
+- **LOCAL_DEV_MODE guarded** — `ValidateForNamespace()` blocks
+  `LOCAL_DEV_MODE=true` in production Kubernetes namespaces
+
+The Identity service must operate within this existing trust boundary.
+Dex receives tenant context from the gateway's subdomain resolution,
+not from user-supplied parameters. Phase 1 must include end-to-end
+verification that DNS spoofing cannot bypass tenant isolation.
 
 ### Audit Trail
 

--- a/docs/prd/031-identity-access-management.md
+++ b/docs/prd/031-identity-access-management.md
@@ -53,6 +53,7 @@ instructions: |
 **ADRs:**
 
 - [0002 - Microservices Per BIAN Domain](../adr/0002-microservices-per-bian-domain.md)
+- [0015 - Standard Service Directory Structure](../adr/0015-standard-service-directory-structure.md)
 
 **Related PRDs:**
 
@@ -281,19 +282,23 @@ BIAN explicitly separates these into distinct service domains:
 
 ## Service Structure
 
-The Identity service follows the same patterns as other Meridian
-services:
+The Identity service follows
+[ADR-015](../adr/0015-standard-service-directory-structure.md) and the
+[New BIAN Service Checklist](../guides/new-bian-service-checklist.md).
+Use `services/party/` as the primary reference implementation.
 
 ```text
 services/identity/
   ├── cmd/                  # Service entrypoint
   ├── domain/               # Identity, RoleAssignment, Invitation entities
-  ├── repository/           # Database access
+  ├── adapters/persistence/ # Repository implementations
   ├── service/              # Business logic
   ├── grpc/                 # gRPC handlers
   ├── connector/            # Dex gRPC connector implementation
+  ├── observability/        # Metrics, health checks
   ├── migrations/           # Atlas migrations (own database)
-  └── atlas/                # Atlas config
+  ├── atlas/                # Atlas config
+  └── k8s/                  # Kubernetes manifests
 ```
 
 The Identity service has its own database (same pattern as Tenant,
@@ -550,8 +555,9 @@ use them without coupling:
 
 ### Phase 1: Identity Service + Dex Everywhere (Critical Path)
 
-1. Create `services/identity/` service scaffold (domain, repo, service,
-   gRPC layers)
+1. Scaffold `services/identity/` per the
+   [New BIAN Service Checklist](../guides/new-bian-service-checklist.md)
+   (proto, domain, adapters, service, gRPC, atlas, k8s, Tilt)
 2. Extract `shared/pkg/credentials` and `shared/pkg/tokens`
 3. Create Identity + RoleAssignment + Invitation tables (Atlas
    migrations)

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -79,6 +79,7 @@ stateDiagram-v2
 | PRD | Description |
 |-----|-------------|
 | [Asset-Agnostic Accounts](028-asset-agnostic-accounts.md) | Generalize account fields for non-fiat asset classes |
+| [Identity and Access Management](030-identity-access-management.md) | Bridge Party service identity to authentication with dynamic user management and RBAC |
 | [Meridian Edge](003-meridian-edge.md) | Embedded modular monolith for IoT devices and browser (WASM) |
 | [MCP Server](027-mcp-server.md) | Model Context Protocol server bridging LLMs to Meridian Core |
 | [Operational Gateway](029-operational-gateway.md) | Bidirectional asset-agnostic gateway for outbound instructions and inbound messages |
@@ -235,12 +236,25 @@ material.
 - [Codebase Health Audit](012-codebase-health-audit.md) - Remediation for documentation, CI/CD, and code hygiene
 - [Production Readiness Review](009-production-readiness-review.md) - Audit and remediation for production gaps
 
+### Identity & Access Control
+
+The Party service handles two distinct access control concerns:
+
+<!-- markdownlint-disable MD013 -->
+
+- [Party KYC/AML Provider Integration](020-party-kyc-aml-provider-integration.md) -
+  **Customer access control**: External KYC/AML verification for customer onboarding (regulatory)
+- [Identity and Access Management](030-identity-access-management.md) -
+  **Staff/operator access control**: Dynamic user management, role assignment,
+  JWT claims population (operational)
+
+<!-- markdownlint-enable MD013 -->
+
 ### Service Wiring (Micro-PRDs)
 
 - [Current Account Withdrawal Persistence](018-current-account-withdrawal-persistence.md) - Wire withdrawal-by-ID gRPC handlers
 - [Internal Account - PK Client](019-internal-account-position-keeping-client.md) -
   Wire PK gRPC client in Internal Account service
-- [Party KYC/AML Provider Integration](020-party-kyc-aml-provider-integration.md) - External KYC/AML provider adapter
 
 ### Deployment Targets
 

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -79,7 +79,7 @@ stateDiagram-v2
 | PRD | Description |
 |-----|-------------|
 | [Asset-Agnostic Accounts](028-asset-agnostic-accounts.md) | Generalize account fields for non-fiat asset classes |
-| [Identity and Access Management](030-identity-access-management.md) | Bridge Party service identity to authentication with dynamic user management and RBAC |
+| [Identity and Access Management](031-identity-access-management.md) | Bridge Party service identity to authentication with dynamic user management and RBAC |
 | [Meridian Edge](003-meridian-edge.md) | Embedded modular monolith for IoT devices and browser (WASM) |
 | [MCP Server](027-mcp-server.md) | Model Context Protocol server bridging LLMs to Meridian Core |
 | [Operational Gateway](029-operational-gateway.md) | Bidirectional asset-agnostic gateway for outbound instructions and inbound messages |
@@ -246,7 +246,7 @@ The Party service handles two distinct access control concerns:
 
 - [Party KYC/AML Provider Integration](020-party-kyc-aml-provider-integration.md) -
   **Customer access control**: External KYC/AML verification for customer onboarding (regulatory)
-- [Identity and Access Management](030-identity-access-management.md) -
+- [Identity and Access Management](031-identity-access-management.md) -
   **Staff/operator access control**: Dynamic user management, role assignment,
   JWT claims population (operational)
 

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -240,7 +240,7 @@ material.
 
 ### Identity & Access Control
 
-The Party service handles two distinct access control concerns:
+Meridian separates access control into two service domains:
 
 <!-- markdownlint-disable MD013 -->
 


### PR DESCRIPTION
## Summary

- Add PRD 031: Identity and Access Management (renumbered from 030 after AsyncAPI Specification took that slot)
- Extends the Party service with Identity and RoleAssignment as business qualifiers (same pattern as Demographics, References, Verification)
- Defines Dex as the sole OIDC provider across all environments (local Tilt, demo, production) — removes Keycloak entirely
- Party service owns user CRUD and credentials; Dex issues JWTs via gRPC connector
- Four access tiers: Platform Admin → Tenant Owner → Admin → User
- Four-phase implementation: Dex Everywhere → Dynamic Users → Federation → Advanced Access Control
- Updates PRD README index with new "Identity & Access Control" category

## Test plan

- [ ] Verify all markdown links resolve correctly
- [ ] Confirm markdownlint passes (pre-commit hook)
- [ ] Review PRD content for architectural alignment with existing Party service patterns