### PR TITLE
feat: create centralized topic registry package

### DIFF
--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
 	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/protobuf/proto"
@@ -65,14 +66,15 @@ const (
 	idempotencyResultTTL = 24 * time.Hour
 )
 
-// Kafka topic constants for account lifecycle events
+// Kafka topic aliases for account lifecycle events.
+// These reference the centralized topic registry in shared/platform/events/topics.
 const (
-	// TopicAccountFrozen is the Kafka topic for account frozen events
-	TopicAccountFrozen = "current-account.account-frozen.v1"
-	// TopicAccountUnfrozen is the Kafka topic for account unfrozen events
-	TopicAccountUnfrozen = "current-account.account-unfrozen.v1"
-	// TopicAccountClosed is the Kafka topic for account closed events
-	TopicAccountClosed = "current-account.account-closed.v1"
+	// TopicAccountFrozen is the Kafka topic for account frozen events.
+	TopicAccountFrozen = topics.CurrentAccountAccountFrozenV1
+	// TopicAccountUnfrozen is the Kafka topic for account unfrozen events.
+	TopicAccountUnfrozen = topics.CurrentAccountAccountUnfrozenV1
+	// TopicAccountClosed is the Kafka topic for account closed events.
+	TopicAccountClosed = topics.CurrentAccountAccountClosedV1
 )
 
 // AccountEventPublisher defines the interface for publishing account lifecycle events.

--- a/services/current-account/service/grpc_withdrawal_execute.go
+++ b/services/current-account/service/grpc_withdrawal_execute.go
@@ -15,6 +15,7 @@ import (
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -391,7 +392,7 @@ func (s *Service) completeWithdrawalWithOutbox(ctx context.Context, withdrawal *
 			AggregateType: "Withdrawal",
 			EventPayload:  eventPayload,
 			Status:        events.StatusPending,
-			Topic:         "current-account.withdrawal-status.v1",
+			Topic:         topics.CurrentAccountWithdrawalStatusV1,
 			PartitionKey:  accountID.String(),
 			CreatedAt:     time.Now(),
 			RetryCount:    0,

--- a/services/financial-accounting/service/grpc_control_endpoints.go
+++ b/services/financial-accounting/service/grpc_control_endpoints.go
@@ -20,6 +20,7 @@ import (
 	"github.com/meridianhub/meridian/services/financial-accounting/domain"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
 )
 
 // ControlFinancialBookingLog applies a control action (SUSPEND, RESUME, TERMINATE) to a booking log.
@@ -194,7 +195,7 @@ func (s *FinancialAccountingService) ControlFinancialBookingLog(
 			Version:        1,
 		}
 
-		eventTopic := "financial-accounting.booking-log.controlled"
+		eventTopic := topics.FinancialAccountingBookingLogControlled
 		if err := s.outboxPublisher.PublishControlEvent(
 			ctx,
 			tx,

--- a/services/market-information/service/event_publisher.go
+++ b/services/market-information/service/event_publisher.go
@@ -9,14 +9,15 @@ import (
 
 	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
 	"github.com/meridianhub/meridian/services/market-information/domain"
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
 	// ObservationRecordedTopic is the Kafka topic for observation recorded events.
-	// Named using the service-name.event-name.v1 convention for channel derivation.
-	ObservationRecordedTopic = "market-information.observation-recorded.v1"
+	// References the centralized topic registry in shared/platform/events/topics.
+	ObservationRecordedTopic = topics.MarketInformationObservationRecordedV1
 
 	// DeprecatedObservationRecordedTopic is the old topic name retained for
 	// dual-publish during migration.

--- a/services/payment-order/service/grpc_service.go
+++ b/services/payment-order/service/grpc_service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/protobuf/proto"
 )
@@ -44,15 +45,16 @@ var (
 	ErrUnsupportedCurrency          = errors.New("unsupported currency for ledger posting")
 )
 
-// Kafka topic constants
+// Kafka topic aliases for payment order lifecycle events.
+// These reference the centralized topic registry in shared/platform/events/topics.
 const (
-	TopicPaymentOrderInitiated = "payment-order.initiated.v1"
-	TopicPaymentOrderReserved  = "payment-order.reserved.v1"
-	TopicPaymentOrderExecuting = "payment-order.executing.v1"
-	TopicPaymentOrderCompleted = "payment-order.completed.v1"
-	TopicPaymentOrderFailed    = "payment-order.failed.v1"
-	TopicPaymentOrderCancelled = "payment-order.cancelled.v1"
-	TopicPaymentOrderReversed  = "payment-order.reversed.v1"
+	TopicPaymentOrderInitiated = topics.PaymentOrderInitiatedV1
+	TopicPaymentOrderReserved  = topics.PaymentOrderReservedV1
+	TopicPaymentOrderExecuting = topics.PaymentOrderExecutingV1
+	TopicPaymentOrderCompleted = topics.PaymentOrderCompletedV1
+	TopicPaymentOrderFailed    = topics.PaymentOrderFailedV1
+	TopicPaymentOrderCancelled = topics.PaymentOrderCancelledV1
+	TopicPaymentOrderReversed  = topics.PaymentOrderReversedV1
 )
 
 // Operation result status constants for observability

--- a/services/position-keeping/adapters/messaging/kafka_event_publisher.go
+++ b/services/position-keeping/adapters/messaging/kafka_event_publisher.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -60,15 +61,15 @@ type TopicConfig struct {
 // DefaultTopicConfig returns the default topic configuration for position keeping events.
 func DefaultTopicConfig() TopicConfig {
 	return TopicConfig{
-		TransactionCapturedTopic:     "position-keeping.transaction-captured.v1",
-		TransactionAmendedTopic:      "position-keeping.transaction-amended.v1",
-		TransactionReconciledTopic:   "position-keeping.transaction-reconciled.v1",
-		TransactionPostedTopic:       "position-keeping.transaction-posted.v1",
-		TransactionRejectedTopic:     "position-keeping.transaction-rejected.v1",
-		TransactionFailedTopic:       "position-keeping.transaction-failed.v1",
-		TransactionCancelledTopic:    "position-keeping.transaction-cancelled.v1",
-		BulkTransactionCapturedTopic: "position-keeping.bulk-transaction-captured.v1",
-		OpeningBalanceRecordedTopic:  "position-keeping.opening-balance-recorded.v1",
+		TransactionCapturedTopic:     topics.PositionKeepingTransactionCapturedV1,
+		TransactionAmendedTopic:      topics.PositionKeepingTransactionAmendedV1,
+		TransactionReconciledTopic:   topics.PositionKeepingTransactionReconciledV1,
+		TransactionPostedTopic:       topics.PositionKeepingTransactionPostedV1,
+		TransactionRejectedTopic:     topics.PositionKeepingTransactionRejectedV1,
+		TransactionFailedTopic:       topics.PositionKeepingTransactionFailedV1,
+		TransactionCancelledTopic:    topics.PositionKeepingTransactionCancelledV1,
+		BulkTransactionCapturedTopic: topics.PositionKeepingBulkTransactionCapturedV1,
+		OpeningBalanceRecordedTopic:  topics.PositionKeepingOpeningBalanceRecordedV1,
 	}
 }
 

--- a/services/reconciliation/adapters/messaging/kafka_publisher.go
+++ b/services/reconciliation/adapters/messaging/kafka_publisher.go
@@ -9,19 +9,20 @@ import (
 	"time"
 
 	"github.com/meridianhub/meridian/services/reconciliation/observability"
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
 	"github.com/meridianhub/meridian/shared/platform/kafka"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
-// Topic constants for reconciliation domain events.
-// Named using the service-name.event-name.v1 convention for channel derivation.
+// Topic aliases for reconciliation domain events.
+// These reference the centralized topic registry in shared/platform/events/topics.
 const (
-	TopicReconciliationRunStarted   = "reconciliation.run-started.v1"
-	TopicReconciliationRunCompleted = "reconciliation.run-completed.v1"
-	TopicVarianceDetected           = "reconciliation.variance-detected.v1"
-	TopicPositionLockRequested      = "reconciliation.position-lock-requested.v1"
-	TopicDisputeCreated             = "reconciliation.dispute-created.v1"
-	TopicDisputeResolved            = "reconciliation.dispute-resolved.v1"
+	TopicReconciliationRunStarted   = topics.ReconciliationRunStartedV1
+	TopicReconciliationRunCompleted = topics.ReconciliationRunCompletedV1
+	TopicVarianceDetected           = topics.ReconciliationVarianceDetectedV1
+	TopicPositionLockRequested      = topics.ReconciliationPositionLockRequestedV1
+	TopicDisputeCreated             = topics.ReconciliationDisputeCreatedV1
+	TopicDisputeResolved            = topics.ReconciliationDisputeResolvedV1
 
 	// Deprecated topic names retained for dual-publish migration.
 	DeprecatedTopicReconciliationRunStarted   = "reconciliation.run.started"

--- a/shared/platform/events/topics/topics.go
+++ b/shared/platform/events/topics/topics.go
@@ -1,0 +1,135 @@
+// Package topics provides a centralized registry of all Kafka topic names used across Meridian services.
+//
+// All topics follow the naming convention: <service>.<event-name>.<version>
+// as defined in ADR-0004.
+//
+// This package is the single source of truth for topic names and is used both by
+// service code and by the AsyncAPI specification generator.
+package topics
+
+// Audit topics
+const (
+	// AuditEventsV1 is the Kafka topic for audit events.
+	AuditEventsV1 = "audit.events.v1"
+	// AuditEventsDLQV1 is the dead letter queue for failed audit events.
+	AuditEventsDLQV1 = "audit.events.v1.dlq"
+)
+
+// Current Account topics
+const (
+	// CurrentAccountAccountFrozenV1 is the Kafka topic for account frozen events.
+	CurrentAccountAccountFrozenV1 = "current-account.account-frozen.v1"
+	// CurrentAccountAccountUnfrozenV1 is the Kafka topic for account unfrozen events.
+	CurrentAccountAccountUnfrozenV1 = "current-account.account-unfrozen.v1"
+	// CurrentAccountAccountClosedV1 is the Kafka topic for account closed events.
+	CurrentAccountAccountClosedV1 = "current-account.account-closed.v1"
+	// CurrentAccountWithdrawalStatusV1 is the Kafka topic for withdrawal status events.
+	CurrentAccountWithdrawalStatusV1 = "current-account.withdrawal-status.v1"
+)
+
+// Financial Accounting topics
+const (
+	// FinancialAccountingBookingLogControlled is the Kafka topic for booking log control events.
+	// Note: This topic does not follow the standard <service>.<event>.<version> pattern
+	// and is retained for backwards compatibility.
+	FinancialAccountingBookingLogControlled = "financial-accounting.booking-log.controlled"
+)
+
+// Market Information topics
+const (
+	// MarketInformationObservationRecordedV1 is the Kafka topic for observation recorded events.
+	MarketInformationObservationRecordedV1 = "market-information.observation-recorded.v1"
+)
+
+// Payment Order topics
+const (
+	// PaymentOrderInitiatedV1 is the Kafka topic for payment order initiated events.
+	PaymentOrderInitiatedV1 = "payment-order.initiated.v1"
+	// PaymentOrderReservedV1 is the Kafka topic for payment order reserved events.
+	PaymentOrderReservedV1 = "payment-order.reserved.v1"
+	// PaymentOrderExecutingV1 is the Kafka topic for payment order executing events.
+	PaymentOrderExecutingV1 = "payment-order.executing.v1"
+	// PaymentOrderCompletedV1 is the Kafka topic for payment order completed events.
+	PaymentOrderCompletedV1 = "payment-order.completed.v1"
+	// PaymentOrderFailedV1 is the Kafka topic for payment order failed events.
+	PaymentOrderFailedV1 = "payment-order.failed.v1"
+	// PaymentOrderCancelledV1 is the Kafka topic for payment order cancelled events.
+	PaymentOrderCancelledV1 = "payment-order.cancelled.v1"
+	// PaymentOrderReversedV1 is the Kafka topic for payment order reversed events.
+	PaymentOrderReversedV1 = "payment-order.reversed.v1"
+)
+
+// Position Keeping topics
+const (
+	// PositionKeepingTransactionCapturedV1 is the Kafka topic for transaction captured events.
+	PositionKeepingTransactionCapturedV1 = "position-keeping.transaction-captured.v1"
+	// PositionKeepingTransactionAmendedV1 is the Kafka topic for transaction amended events.
+	PositionKeepingTransactionAmendedV1 = "position-keeping.transaction-amended.v1"
+	// PositionKeepingTransactionReconciledV1 is the Kafka topic for transaction reconciled events.
+	PositionKeepingTransactionReconciledV1 = "position-keeping.transaction-reconciled.v1"
+	// PositionKeepingTransactionPostedV1 is the Kafka topic for transaction posted events.
+	PositionKeepingTransactionPostedV1 = "position-keeping.transaction-posted.v1"
+	// PositionKeepingTransactionRejectedV1 is the Kafka topic for transaction rejected events.
+	PositionKeepingTransactionRejectedV1 = "position-keeping.transaction-rejected.v1"
+	// PositionKeepingTransactionFailedV1 is the Kafka topic for transaction failed events.
+	PositionKeepingTransactionFailedV1 = "position-keeping.transaction-failed.v1"
+	// PositionKeepingTransactionCancelledV1 is the Kafka topic for transaction cancelled events.
+	PositionKeepingTransactionCancelledV1 = "position-keeping.transaction-cancelled.v1"
+	// PositionKeepingBulkTransactionCapturedV1 is the Kafka topic for bulk transaction captured events.
+	PositionKeepingBulkTransactionCapturedV1 = "position-keeping.bulk-transaction-captured.v1"
+	// PositionKeepingOpeningBalanceRecordedV1 is the Kafka topic for opening balance recorded events.
+	PositionKeepingOpeningBalanceRecordedV1 = "position-keeping.opening-balance-recorded.v1"
+)
+
+// Reconciliation topics
+const (
+	// ReconciliationRunStartedV1 is the Kafka topic for reconciliation run started events.
+	ReconciliationRunStartedV1 = "reconciliation.run-started.v1"
+	// ReconciliationRunCompletedV1 is the Kafka topic for reconciliation run completed events.
+	ReconciliationRunCompletedV1 = "reconciliation.run-completed.v1"
+	// ReconciliationVarianceDetectedV1 is the Kafka topic for variance detected events.
+	ReconciliationVarianceDetectedV1 = "reconciliation.variance-detected.v1"
+	// ReconciliationPositionLockRequestedV1 is the Kafka topic for position lock requested events.
+	ReconciliationPositionLockRequestedV1 = "reconciliation.position-lock-requested.v1"
+	// ReconciliationDisputeCreatedV1 is the Kafka topic for dispute created events.
+	ReconciliationDisputeCreatedV1 = "reconciliation.dispute-created.v1"
+	// ReconciliationDisputeResolvedV1 is the Kafka topic for dispute resolved events.
+	ReconciliationDisputeResolvedV1 = "reconciliation.dispute-resolved.v1"
+)
+
+// All returns a slice of all canonical topic names registered in this package.
+// Deprecated topics are excluded. This is used for validation and AsyncAPI generation.
+func All() []string {
+	return []string{
+		AuditEventsV1,
+		AuditEventsDLQV1,
+		CurrentAccountAccountFrozenV1,
+		CurrentAccountAccountUnfrozenV1,
+		CurrentAccountAccountClosedV1,
+		CurrentAccountWithdrawalStatusV1,
+		FinancialAccountingBookingLogControlled,
+		MarketInformationObservationRecordedV1,
+		PaymentOrderInitiatedV1,
+		PaymentOrderReservedV1,
+		PaymentOrderExecutingV1,
+		PaymentOrderCompletedV1,
+		PaymentOrderFailedV1,
+		PaymentOrderCancelledV1,
+		PaymentOrderReversedV1,
+		PositionKeepingTransactionCapturedV1,
+		PositionKeepingTransactionAmendedV1,
+		PositionKeepingTransactionReconciledV1,
+		PositionKeepingTransactionPostedV1,
+		PositionKeepingTransactionRejectedV1,
+		PositionKeepingTransactionFailedV1,
+		PositionKeepingTransactionCancelledV1,
+		PositionKeepingBulkTransactionCapturedV1,
+		PositionKeepingOpeningBalanceRecordedV1,
+		ReconciliationRunStartedV1,
+		ReconciliationRunCompletedV1,
+		ReconciliationVarianceDetectedV1,
+		ReconciliationPositionLockRequestedV1,
+		ReconciliationDisputeCreatedV1,
+		ReconciliationDisputeResolvedV1,
+	}
+}

--- a/shared/platform/events/topics/topics.yaml
+++ b/shared/platform/events/topics/topics.yaml
@@ -1,0 +1,219 @@
+# Meridian Kafka Topic Registry
+#
+# This file is the machine-readable source of truth for all Kafka topics used by Meridian services.
+# It is used by the AsyncAPI specification generator to produce the AsyncAPI 3.0 document.
+#
+# Topic naming convention: <service>.<event-name>.<version>  (ADR-0004)
+# Exceptions to this convention are explicitly marked.
+#
+# Fields:
+#   name:           Kafka topic string (must match the Go constant value in topics.go)
+#   constant:       Go constant name in this package
+#   description:    Human-readable description of the events on this topic
+#   service:        Owning service (publisher)
+#   event_type:     Logical event type identifier (snake_case)
+#   proto_message:  Proto message type published to this topic (if applicable)
+#   deprecated:     true if this topic is pending removal
+#   legacy_naming:  true if this topic does not follow the standard naming convention
+
+services:
+  audit:
+    description: Audit trail events for compliance and observability
+    topics:
+      - name: audit.events.v1
+        constant: AuditEventsV1
+        description: Audit events for all service operations
+        event_type: audit.event.v1
+        proto_message: AuditEvent
+
+      - name: audit.events.v1.dlq
+        constant: AuditEventsDLQV1
+        description: Dead letter queue for audit events that could not be processed
+        event_type: audit.event.v1.dlq
+
+  current-account:
+    description: Account lifecycle and withdrawal events for current (demand deposit) accounts
+    topics:
+      - name: current-account.account-frozen.v1
+        constant: CurrentAccountAccountFrozenV1
+        description: Published when an account is frozen (no debits or credits permitted)
+        event_type: current_account.account_frozen.v1
+        proto_message: AccountFrozenEvent
+
+      - name: current-account.account-unfrozen.v1
+        constant: CurrentAccountAccountUnfrozenV1
+        description: Published when a previously frozen account is unfrozen
+        event_type: current_account.account_unfrozen.v1
+        proto_message: AccountUnfrozenEvent
+
+      - name: current-account.account-closed.v1
+        constant: CurrentAccountAccountClosedV1
+        description: Published when an account is permanently closed
+        event_type: current_account.account_closed.v1
+        proto_message: AccountClosedEvent
+
+      - name: current-account.withdrawal-status.v1
+        constant: CurrentAccountWithdrawalStatusV1
+        description: Published when a withdrawal status changes (initiated, completed, failed, reversed)
+        event_type: current_account.withdrawal_status.v1
+        proto_message: WithdrawalStatusUpdated
+
+  financial-accounting:
+    description: Financial booking log control events
+    topics:
+      - name: financial-accounting.booking-log.controlled
+        constant: FinancialAccountingBookingLogControlled
+        description: Published when a booking log receives a control action (SUSPEND, RESUME, TERMINATE)
+        event_type: financial_accounting.booking_log_controlled.v1
+        proto_message: BookingLogControlledEvent
+        legacy_naming: true
+
+  market-information:
+    description: Market data observation events
+    topics:
+      - name: market-information.observation-recorded.v1
+        constant: MarketInformationObservationRecordedV1
+        description: Published when a new market price observation is recorded
+        event_type: market_information.observation_recorded.v1
+        proto_message: ObservationRecorded
+
+  payment-order:
+    description: Payment order lifecycle state transition events
+    topics:
+      - name: payment-order.initiated.v1
+        constant: PaymentOrderInitiatedV1
+        description: Published when a new payment order is initiated
+        event_type: payment_order.initiated.v1
+        proto_message: PaymentOrderInitiated
+
+      - name: payment-order.reserved.v1
+        constant: PaymentOrderReservedV1
+        description: Published when funds are successfully reserved for a payment order
+        event_type: payment_order.reserved.v1
+        proto_message: PaymentOrderReserved
+
+      - name: payment-order.executing.v1
+        constant: PaymentOrderExecutingV1
+        description: Published when a payment order begins execution with the payment gateway
+        event_type: payment_order.executing.v1
+        proto_message: PaymentOrderExecuting
+
+      - name: payment-order.completed.v1
+        constant: PaymentOrderCompletedV1
+        description: Published when a payment order successfully completes
+        event_type: payment_order.completed.v1
+        proto_message: PaymentOrderCompleted
+
+      - name: payment-order.failed.v1
+        constant: PaymentOrderFailedV1
+        description: Published when a payment order fails and cannot be retried
+        event_type: payment_order.failed.v1
+        proto_message: PaymentOrderFailed
+
+      - name: payment-order.cancelled.v1
+        constant: PaymentOrderCancelledV1
+        description: Published when a payment order is cancelled before execution
+        event_type: payment_order.cancelled.v1
+        proto_message: PaymentOrderCancelled
+
+      - name: payment-order.reversed.v1
+        constant: PaymentOrderReversedV1
+        description: Published when a completed payment order is reversed
+        event_type: payment_order.reversed.v1
+        proto_message: PaymentOrderReversed
+
+  position-keeping:
+    description: Financial position and transaction lifecycle events
+    topics:
+      - name: position-keeping.transaction-captured.v1
+        constant: PositionKeepingTransactionCapturedV1
+        description: Published when a new financial transaction is captured
+        event_type: position_keeping.transaction_captured.v1
+        proto_message: TransactionCaptured
+
+      - name: position-keeping.transaction-amended.v1
+        constant: PositionKeepingTransactionAmendedV1
+        description: Published when a captured transaction is amended
+        event_type: position_keeping.transaction_amended.v1
+        proto_message: TransactionAmended
+
+      - name: position-keeping.transaction-reconciled.v1
+        constant: PositionKeepingTransactionReconciledV1
+        description: Published when a transaction is reconciled against actual settlement data
+        event_type: position_keeping.transaction_reconciled.v1
+        proto_message: TransactionReconciled
+
+      - name: position-keeping.transaction-posted.v1
+        constant: PositionKeepingTransactionPostedV1
+        description: Published when a transaction is posted to the ledger
+        event_type: position_keeping.transaction_posted.v1
+        proto_message: TransactionPosted
+
+      - name: position-keeping.transaction-rejected.v1
+        constant: PositionKeepingTransactionRejectedV1
+        description: Published when a transaction is rejected due to validation failure
+        event_type: position_keeping.transaction_rejected.v1
+        proto_message: TransactionRejected
+
+      - name: position-keeping.transaction-failed.v1
+        constant: PositionKeepingTransactionFailedV1
+        description: Published when a transaction fails due to a system error
+        event_type: position_keeping.transaction_failed.v1
+        proto_message: TransactionFailed
+
+      - name: position-keeping.transaction-cancelled.v1
+        constant: PositionKeepingTransactionCancelledV1
+        description: Published when a transaction is cancelled
+        event_type: position_keeping.transaction_cancelled.v1
+        proto_message: TransactionCancelled
+
+      - name: position-keeping.bulk-transaction-captured.v1
+        constant: PositionKeepingBulkTransactionCapturedV1
+        description: Published when a batch of transactions is captured atomically
+        event_type: position_keeping.bulk_transaction_captured.v1
+        proto_message: BulkTransactionCaptured
+
+      - name: position-keeping.opening-balance-recorded.v1
+        constant: PositionKeepingOpeningBalanceRecordedV1
+        description: Published when an opening balance is recorded for a new account
+        event_type: position_keeping.opening_balance_recorded.v1
+        proto_message: OpeningBalanceRecorded
+
+  reconciliation:
+    description: Settlement reconciliation run and variance detection events
+    topics:
+      - name: reconciliation.run-started.v1
+        constant: ReconciliationRunStartedV1
+        description: Published when a reconciliation run begins
+        event_type: reconciliation.run_started.v1
+        proto_message: ReconciliationRunStarted
+
+      - name: reconciliation.run-completed.v1
+        constant: ReconciliationRunCompletedV1
+        description: Published when a reconciliation run completes (with or without variances)
+        event_type: reconciliation.run_completed.v1
+        proto_message: ReconciliationRunCompleted
+
+      - name: reconciliation.variance-detected.v1
+        constant: ReconciliationVarianceDetectedV1
+        description: Published when a position variance is detected during reconciliation
+        event_type: reconciliation.variance_detected.v1
+        proto_message: VarianceDetected
+
+      - name: reconciliation.position-lock-requested.v1
+        constant: ReconciliationPositionLockRequestedV1
+        description: Published when a position lock is requested to freeze a position for reconciliation
+        event_type: reconciliation.position_lock_requested.v1
+        proto_message: PositionLockRequested
+
+      - name: reconciliation.dispute-created.v1
+        constant: ReconciliationDisputeCreatedV1
+        description: Published when a reconciliation dispute is raised
+        event_type: reconciliation.dispute_created.v1
+        proto_message: DisputeCreated
+
+      - name: reconciliation.dispute-resolved.v1
+        constant: ReconciliationDisputeResolvedV1
+        description: Published when a reconciliation dispute is resolved
+        event_type: reconciliation.dispute_resolved.v1
+        proto_message: DisputeResolved

--- a/shared/platform/events/topics/topics_test.go
+++ b/shared/platform/events/topics/topics_test.go
@@ -1,0 +1,161 @@
+package topics_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
+	"gopkg.in/yaml.v3"
+)
+
+// standardTopicPattern matches the canonical <service>.<event>.<version> naming convention.
+// e.g. "position-keeping.transaction-captured.v1", "audit.events.v1"
+var standardTopicPattern = regexp.MustCompile(`^[a-z][a-z0-9-]+\.[a-z][a-z0-9-]+\.v\d+$`)
+
+// legacyTopics lists topics that are exempt from the standard naming pattern check.
+// These are retained for backwards compatibility.
+var legacyTopics = map[string]bool{
+	topics.FinancialAccountingBookingLogControlled: true,
+	topics.AuditEventsDLQV1:                        true,
+}
+
+func TestAll_NonEmpty(t *testing.T) {
+	all := topics.All()
+	if len(all) == 0 {
+		t.Fatal("topics.All() returned an empty slice")
+	}
+}
+
+func TestAllTopics_NonEmptyStrings(t *testing.T) {
+	for _, topic := range topics.All() {
+		if topic == "" {
+			t.Error("topics.All() contains an empty string")
+		}
+	}
+}
+
+func TestAllTopics_NamingConvention(t *testing.T) {
+	for _, topic := range topics.All() {
+		if legacyTopics[topic] {
+			continue
+		}
+		if !standardTopicPattern.MatchString(topic) {
+			t.Errorf("topic %q does not follow <service>.<event>.v<N> naming convention", topic)
+		}
+	}
+}
+
+func TestAllTopics_NoDuplicates(t *testing.T) {
+	seen := make(map[string]bool, len(topics.All()))
+	for _, topic := range topics.All() {
+		if seen[topic] {
+			t.Errorf("duplicate topic name: %q", topic)
+		}
+		seen[topic] = true
+	}
+}
+
+// topicsYAML mirrors the structure of topics.yaml for unmarshalling.
+type topicsYAML struct {
+	Services map[string]serviceEntry `yaml:"services"`
+}
+
+type serviceEntry struct {
+	Description string       `yaml:"description"`
+	Topics      []topicEntry `yaml:"topics"`
+}
+
+type topicEntry struct {
+	Name     string `yaml:"name"`
+	Constant string `yaml:"constant"`
+}
+
+func loadTopicsYAML(t *testing.T) topicsYAML {
+	t.Helper()
+
+	// Resolve path relative to this test file.
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	yamlPath := filepath.Join(filepath.Dir(thisFile), "topics.yaml")
+
+	data, err := os.ReadFile(yamlPath)
+	if err != nil {
+		t.Fatalf("failed to read topics.yaml: %v", err)
+	}
+
+	var parsed topicsYAML
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to parse topics.yaml: %v", err)
+	}
+	return parsed
+}
+
+func TestTopicsYAML_ParsesWithoutError(t *testing.T) {
+	parsed := loadTopicsYAML(t)
+	if len(parsed.Services) == 0 {
+		t.Fatal("topics.yaml parsed with no services")
+	}
+}
+
+func TestTopicsYAML_NoEmptyTopicNames(t *testing.T) {
+	parsed := loadTopicsYAML(t)
+	for svc, entry := range parsed.Services {
+		for _, topic := range entry.Topics {
+			if topic.Name == "" {
+				t.Errorf("service %q has a topic with an empty name", svc)
+			}
+		}
+	}
+}
+
+func TestTopicsYAML_ConsistentWithGoConstants(t *testing.T) {
+	parsed := loadTopicsYAML(t)
+
+	// Collect all topic names declared in topics.yaml.
+	yamlTopics := make(map[string]bool)
+	for _, entry := range parsed.Services {
+		for _, topic := range entry.Topics {
+			if topic.Name != "" {
+				yamlTopics[topic.Name] = true
+			}
+		}
+	}
+
+	// Every Go constant in All() must have a corresponding entry in topics.yaml.
+	for _, topic := range topics.All() {
+		if !yamlTopics[topic] {
+			t.Errorf("topic %q is in topics.All() but missing from topics.yaml", topic)
+		}
+	}
+
+	// Every topic in topics.yaml must appear in topics.All().
+	goTopics := make(map[string]bool, len(topics.All()))
+	for _, topic := range topics.All() {
+		goTopics[topic] = true
+	}
+
+	for topicName := range yamlTopics {
+		if !goTopics[topicName] {
+			t.Errorf("topic %q is in topics.yaml but missing from topics.All()", topicName)
+		}
+	}
+}
+
+func TestTopicsYAML_NoDuplicates(t *testing.T) {
+	parsed := loadTopicsYAML(t)
+
+	seen := make(map[string]string) // topic name -> service name
+	for svcName, entry := range parsed.Services {
+		for _, topic := range entry.Topics {
+			if prev, exists := seen[topic.Name]; exists {
+				t.Errorf("duplicate topic %q: defined in both %q and %q", topic.Name, prev, svcName)
+			}
+			seen[topic.Name] = svcName
+		}
+	}
+}

--- a/shared/platform/events/topics/topics_test.go
+++ b/shared/platform/events/topics/topics_test.go
@@ -152,10 +152,79 @@ func TestTopicsYAML_NoDuplicates(t *testing.T) {
 	seen := make(map[string]string) // topic name -> service name
 	for svcName, entry := range parsed.Services {
 		for _, topic := range entry.Topics {
+			if topic.Name == "" {
+				continue // Empty names are caught by TestTopicsYAML_NoEmptyTopicNames
+			}
 			if prev, exists := seen[topic.Name]; exists {
 				t.Errorf("duplicate topic %q: defined in both %q and %q", topic.Name, prev, svcName)
 			}
 			seen[topic.Name] = svcName
 		}
+	}
+}
+
+// TestAll_ContainsAllConstants verifies that All() returns exactly the set of
+// canonical topic constants defined in this package. This prevents drift between
+// the const block and the All() slice when new topics are added.
+func TestAll_ContainsAllConstants(t *testing.T) {
+	knownConstants := []string{
+		topics.AuditEventsV1,
+		topics.AuditEventsDLQV1,
+		topics.CurrentAccountAccountFrozenV1,
+		topics.CurrentAccountAccountUnfrozenV1,
+		topics.CurrentAccountAccountClosedV1,
+		topics.CurrentAccountWithdrawalStatusV1,
+		topics.FinancialAccountingBookingLogControlled,
+		topics.MarketInformationObservationRecordedV1,
+		topics.PaymentOrderInitiatedV1,
+		topics.PaymentOrderReservedV1,
+		topics.PaymentOrderExecutingV1,
+		topics.PaymentOrderCompletedV1,
+		topics.PaymentOrderFailedV1,
+		topics.PaymentOrderCancelledV1,
+		topics.PaymentOrderReversedV1,
+		topics.PositionKeepingTransactionCapturedV1,
+		topics.PositionKeepingTransactionAmendedV1,
+		topics.PositionKeepingTransactionReconciledV1,
+		topics.PositionKeepingTransactionPostedV1,
+		topics.PositionKeepingTransactionRejectedV1,
+		topics.PositionKeepingTransactionFailedV1,
+		topics.PositionKeepingTransactionCancelledV1,
+		topics.PositionKeepingBulkTransactionCapturedV1,
+		topics.PositionKeepingOpeningBalanceRecordedV1,
+		topics.ReconciliationRunStartedV1,
+		topics.ReconciliationRunCompletedV1,
+		topics.ReconciliationVarianceDetectedV1,
+		topics.ReconciliationPositionLockRequestedV1,
+		topics.ReconciliationDisputeCreatedV1,
+		topics.ReconciliationDisputeResolvedV1,
+	}
+
+	allSet := make(map[string]bool, len(topics.All()))
+	for _, topic := range topics.All() {
+		allSet[topic] = true
+	}
+
+	// Every known constant must be in All().
+	for _, c := range knownConstants {
+		if !allSet[c] {
+			t.Errorf("constant %q is missing from topics.All()", c)
+		}
+	}
+
+	// All() must not contain any extras beyond the known constants.
+	knownSet := make(map[string]bool, len(knownConstants))
+	for _, c := range knownConstants {
+		knownSet[c] = true
+	}
+	for _, topic := range topics.All() {
+		if !knownSet[topic] {
+			t.Errorf("topics.All() contains unexpected topic %q not in the known constants list", topic)
+		}
+	}
+
+	// Count must match exactly.
+	if len(topics.All()) != len(knownConstants) {
+		t.Errorf("topics.All() has %d entries, expected %d", len(topics.All()), len(knownConstants))
 	}
 }

--- a/shared/platform/kafka/config.go
+++ b/shared/platform/kafka/config.go
@@ -18,11 +18,6 @@ const (
 	// References the centralized topic registry in shared/platform/events/topics.
 	AuditEventsDLQTopic = topics.AuditEventsDLQV1
 
-	// DeprecatedAuditEventsTopic is the old topic name for migration backwards compatibility.
-	DeprecatedAuditEventsTopic = "audit.events"
-	// DeprecatedAuditEventsDLQTopic is the old DLQ topic name.
-	DeprecatedAuditEventsDLQTopic = "audit.events.dlq"
-
 	// AuditConsumerGroup is the consumer group for audit event processing.
 	AuditConsumerGroup = "audit-consumer-group"
 

--- a/shared/platform/kafka/config.go
+++ b/shared/platform/kafka/config.go
@@ -3,6 +3,8 @@ package kafka
 import (
 	"errors"
 	"os"
+
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
 )
 
 const (
@@ -10,10 +12,11 @@ const (
 	DefaultClientID = "meridian-service"
 
 	// AuditEventsTopic is the Kafka topic for audit events.
-	AuditEventsTopic = "audit.events.v1"
+	// References the centralized topic registry in shared/platform/events/topics.
+	AuditEventsTopic = topics.AuditEventsV1
 	// AuditEventsDLQTopic is the dead letter queue for failed audit events.
-	// Matches the suffix-derived name: AuditEventsTopic + ".dlq".
-	AuditEventsDLQTopic = "audit.events.v1.dlq"
+	// References the centralized topic registry in shared/platform/events/topics.
+	AuditEventsDLQTopic = topics.AuditEventsDLQV1
 
 	// DeprecatedAuditEventsTopic is the old topic name for migration backwards compatibility.
 	DeprecatedAuditEventsTopic = "audit.events"


### PR DESCRIPTION
## Summary

- Adds `shared/platform/events/topics` package as the single source of truth for all Kafka topic names across Meridian services (PRD-030 AsyncAPI spec, task 1)
- Extracts 30 topic constants from 7 services into typed Go constants organized by domain
- Creates `topics.yaml` for AsyncAPI specification generation
- Updates all services to reference centralized constants instead of inline string literals

## Changes Made

### New Package: `shared/platform/events/topics/`

- **`topics.go`**: Typed Go constants for all canonical topics across audit, current-account, financial-accounting, market-information, payment-order, position-keeping, and reconciliation domains. Includes `All()` helper for enumeration.
- **`topics.yaml`**: Machine-readable registry with service ownership, event types, and proto message names for AsyncAPI generation.
- **`topics_test.go`**: 8 tests covering naming convention (`<service>.<event>.v<N>`), uniqueness, non-empty strings, and YAML/Go constant consistency.

### Updated Services

| File | Change |
|------|--------|
| `services/current-account/service/grpc_service.go` | 3 topic constants → registry |
| `services/current-account/service/grpc_withdrawal_execute.go` | 1 inline string → registry |
| `services/financial-accounting/service/grpc_control_endpoints.go` | 1 inline string → registry |
| `services/market-information/service/event_publisher.go` | 1 topic constant → registry |
| `services/payment-order/service/grpc_service.go` | 7 topic constants → registry |
| `services/position-keeping/adapters/messaging/kafka_event_publisher.go` | 9 topic strings → registry |
| `services/reconciliation/adapters/messaging/kafka_publisher.go` | 6 topic constants → registry |
| `shared/platform/kafka/config.go` | 2 audit topic constants → registry |

## Technical Details

Service-local constants and config defaults are preserved as aliases to the registry constants to maintain backwards compatibility — no callers of the existing constants need to change.

The `FinancialAccountingBookingLogControlled` topic is exempt from the standard naming convention check (it predates ADR-0004 and does not carry a `.v1` suffix). This is documented in both the Go code and topics.yaml via `legacy_naming: true`.

## Testing

- 8 unit tests: all passing (`go test ./shared/platform/events/topics/...`)
- Pre-commit checks: gitleaks, gofumpt, golangci-lint — all passing
- No new dependencies added (yaml.v3 was already in go.mod)