### PR TITLE
feat: migrate current-account to outbox publisher

### DIFF
--- a/services/current-account/service/control_outbox_integration_test.go
+++ b/services/current-account/service/control_outbox_integration_test.go
@@ -117,10 +117,14 @@ func TestControlCurrentAccount_OutboxEvents(t *testing.T) {
 
 	outboxRepo := events.NewPostgresOutboxRepository(db)
 
+	// Use a unique account ID per test run to avoid cross-test pollution on the shared
+	// public.event_outbox table (which is not scoped to the tenant schema).
+	accountID := fmt.Sprintf("ACC-OUTBOX-%s", tid)
+
 	// Mock position keeping returns zero balance (needed for CLOSE validation)
 	mockPosKeeping := &mockPositionKeepingClient{
 		accountBalances: map[string]int64{
-			"ACC-OUTBOX-001": 0,
+			accountID: 0,
 		},
 	}
 
@@ -135,7 +139,6 @@ func TestControlCurrentAccount_OutboxEvents(t *testing.T) {
 		logger:           testLogger(),
 	}
 
-	accountID := "ACC-OUTBOX-001"
 	_ = createTestAccountForControl(t, ctx, repo, accountID)
 
 	t.Run("FreezeWritesOutboxEntry", func(t *testing.T) {
@@ -146,9 +149,13 @@ func TestControlCurrentAccount_OutboxEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Verify exactly one outbox entry was created for the freeze event
+		// Verify exactly one outbox entry was created for the freeze event.
+		// Filter by topic + aggregate_id + service_name to avoid matching rows from other runs.
 		var entries []events.EventOutbox
-		err = db.Where("topic = ?", topics.CurrentAccountAccountFrozenV1).Find(&entries).Error
+		err = db.Where(
+			"topic = ? AND aggregate_id = ? AND service_name = ?",
+			topics.CurrentAccountAccountFrozenV1, accountID, "current-account",
+		).Find(&entries).Error
 		require.NoError(t, err)
 		require.Len(t, entries, 1, "exactly one frozen event should be in outbox")
 
@@ -170,7 +177,10 @@ func TestControlCurrentAccount_OutboxEvents(t *testing.T) {
 		require.NoError(t, err)
 
 		var entries []events.EventOutbox
-		err = db.Where("topic = ?", topics.CurrentAccountAccountUnfrozenV1).Find(&entries).Error
+		err = db.Where(
+			"topic = ? AND aggregate_id = ? AND service_name = ?",
+			topics.CurrentAccountAccountUnfrozenV1, accountID, "current-account",
+		).Find(&entries).Error
 		require.NoError(t, err)
 		require.Len(t, entries, 1, "exactly one unfrozen event should be in outbox")
 
@@ -191,7 +201,10 @@ func TestControlCurrentAccount_OutboxEvents(t *testing.T) {
 		require.NoError(t, err)
 
 		var entries []events.EventOutbox
-		err = db.Where("topic = ?", topics.CurrentAccountAccountClosedV1).Find(&entries).Error
+		err = db.Where(
+			"topic = ? AND aggregate_id = ? AND service_name = ?",
+			topics.CurrentAccountAccountClosedV1, accountID, "current-account",
+		).Find(&entries).Error
 		require.NoError(t, err)
 		require.Len(t, entries, 1, "exactly one closed event should be in outbox")
 

--- a/services/current-account/service/control_outbox_integration_test.go
+++ b/services/current-account/service/control_outbox_integration_test.go
@@ -1,0 +1,254 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lib/pq"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// setupControlOutboxDB creates a test database with both account and event_outbox tables.
+func setupControlOutboxDB(t *testing.T) (*gorm.DB, *persistence.Repository, *persistence.LienRepository, tenant.TenantID, func()) {
+	t.Helper()
+
+	db := openSharedDB(t)
+
+	tid := uniqueTenantID()
+	schemaName := tid.SchemaName()
+	quotedSchema := pq.QuoteIdentifier(schemaName)
+
+	// Create tenant schema
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quotedSchema)).Error
+	require.NoError(t, err)
+
+	// Set search_path
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", quotedSchema)).Error
+	require.NoError(t, err)
+
+	// Create account table (same DDL as setupControlTestDB)
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.account (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		account_id VARCHAR(100) NOT NULL UNIQUE,
+		account_identification VARCHAR(34) NOT NULL UNIQUE,
+		account_type VARCHAR(50) NOT NULL DEFAULT 'current',
+		instrument_code VARCHAR(32) NOT NULL DEFAULT 'GBP',
+		dimension VARCHAR(20) NOT NULL DEFAULT 'CURRENCY',
+		precision INT NOT NULL DEFAULT 2,
+		status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+		party_id UUID NOT NULL,
+		org_party_id UUID NULL,
+		balance BIGINT NOT NULL DEFAULT 0,
+		available_balance BIGINT NOT NULL DEFAULT 0,
+		overdraft_limit BIGINT NOT NULL DEFAULT 0,
+		overdraft_rate NUMERIC(5,4) NOT NULL DEFAULT 0,
+		balance_updated_at TIMESTAMP WITH TIME ZONE,
+		opened_at TIMESTAMP WITH TIME ZONE,
+		closed_at TIMESTAMP WITH TIME ZONE,
+		freeze_reason VARCHAR(1000),
+		status_history JSONB NOT NULL DEFAULT '[]'::jsonb,
+		product_type_code VARCHAR(50) NULL,
+		product_type_version INT NULL,
+		behavior_class VARCHAR(50) NULL,
+		version BIGINT NOT NULL DEFAULT 1,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		created_by VARCHAR(100) NOT NULL DEFAULT 'test',
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		updated_by VARCHAR(100) NOT NULL DEFAULT 'test',
+		deleted_at TIMESTAMP WITH TIME ZONE
+	)`, quotedSchema)).Error
+	require.NoError(t, err)
+
+	// Create lien table
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.lien (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		account_id UUID NOT NULL,
+		amount_cents BIGINT NOT NULL,
+		currency VARCHAR(3) NOT NULL,
+		instrument_code VARCHAR(32) NOT NULL DEFAULT '',
+		dimension VARCHAR(20) NOT NULL DEFAULT 'CURRENCY',
+		precision INT NOT NULL DEFAULT 2,
+		bucket_id VARCHAR(255) NOT NULL DEFAULT '',
+		status VARCHAR(20) NOT NULL,
+		payment_order_reference VARCHAR(255) NOT NULL UNIQUE,
+		termination_reason TEXT,
+		expires_at TIMESTAMP WITH TIME ZONE,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		version BIGINT NOT NULL DEFAULT 1,
+		reserved_quantity JSONB,
+		valued_amount JSONB,
+		valuation_analysis JSONB
+	)`, quotedSchema)).Error
+	require.NoError(t, err)
+
+	// Create event_outbox table in public schema (shared across tenants)
+	err = db.AutoMigrate(&events.EventOutbox{})
+	require.NoError(t, err, "failed to create event_outbox table")
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+
+	cleanup := func() {
+		_ = db.Exec(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", quotedSchema))
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+	}
+
+	return db, repo, lienRepo, tid, cleanup
+}
+
+// TestControlCurrentAccount_OutboxEvents verifies that control actions write events to the
+// event outbox table atomically with the account state change.
+func TestControlCurrentAccount_OutboxEvents(t *testing.T) {
+	db, repo, lienRepo, tid, cleanup := setupControlOutboxDB(t)
+	defer cleanup()
+
+	ctx := tenant.WithTenant(t.Context(), tid)
+
+	outboxRepo := events.NewPostgresOutboxRepository(db)
+
+	// Mock position keeping returns zero balance (needed for CLOSE validation)
+	mockPosKeeping := &mockPositionKeepingClient{
+		accountBalances: map[string]int64{
+			"ACC-OUTBOX-001": 0,
+		},
+	}
+
+	// Build a service wired with outboxPublisher and db
+	svc := &Service{
+		repo:             repo,
+		lienRepo:         lienRepo,
+		outboxRepo:       outboxRepo,
+		outboxPublisher:  events.NewOutboxPublisher("current-account"),
+		db:               db,
+		posKeepingClient: mockPosKeeping,
+		logger:           testLogger(),
+	}
+
+	accountID := "ACC-OUTBOX-001"
+	_ = createTestAccountForControl(t, ctx, repo, accountID)
+
+	t.Run("FreezeWritesOutboxEntry", func(t *testing.T) {
+		_, err := svc.ControlCurrentAccount(ctx, &pb.ControlCurrentAccountRequest{
+			AccountId:     accountID,
+			ControlAction: pb.ControlAction_CONTROL_ACTION_FREEZE,
+			Reason:        "Compliance hold for regulatory review",
+		})
+		require.NoError(t, err)
+
+		// Verify exactly one outbox entry was created for the freeze event
+		var entries []events.EventOutbox
+		err = db.Where("topic = ?", topics.CurrentAccountAccountFrozenV1).Find(&entries).Error
+		require.NoError(t, err)
+		require.Len(t, entries, 1, "exactly one frozen event should be in outbox")
+
+		e := entries[0]
+		assert.Equal(t, topics.CurrentAccountAccountFrozenV1, e.Topic)
+		assert.Equal(t, "current_account.account_frozen.v1", e.EventType)
+		assert.Equal(t, "CurrentAccount", e.AggregateType)
+		assert.Equal(t, accountID, e.AggregateID)
+		assert.Equal(t, "current-account", e.ServiceName)
+		assert.Equal(t, events.StatusPending, e.Status)
+		assert.NotEmpty(t, e.EventPayload)
+	})
+
+	t.Run("UnfreezeWritesOutboxEntry", func(t *testing.T) {
+		_, err := svc.ControlCurrentAccount(ctx, &pb.ControlCurrentAccountRequest{
+			AccountId:     accountID,
+			ControlAction: pb.ControlAction_CONTROL_ACTION_UNFREEZE,
+		})
+		require.NoError(t, err)
+
+		var entries []events.EventOutbox
+		err = db.Where("topic = ?", topics.CurrentAccountAccountUnfrozenV1).Find(&entries).Error
+		require.NoError(t, err)
+		require.Len(t, entries, 1, "exactly one unfrozen event should be in outbox")
+
+		e := entries[0]
+		assert.Equal(t, topics.CurrentAccountAccountUnfrozenV1, e.Topic)
+		assert.Equal(t, "current_account.account_unfrozen.v1", e.EventType)
+		assert.Equal(t, "CurrentAccount", e.AggregateType)
+		assert.Equal(t, accountID, e.AggregateID)
+		assert.Equal(t, events.StatusPending, e.Status)
+	})
+
+	t.Run("CloseWritesOutboxEntry", func(t *testing.T) {
+		_, err := svc.ControlCurrentAccount(ctx, &pb.ControlCurrentAccountRequest{
+			AccountId:     accountID,
+			ControlAction: pb.ControlAction_CONTROL_ACTION_CLOSE,
+			Reason:        "Customer requested account closure",
+		})
+		require.NoError(t, err)
+
+		var entries []events.EventOutbox
+		err = db.Where("topic = ?", topics.CurrentAccountAccountClosedV1).Find(&entries).Error
+		require.NoError(t, err)
+		require.Len(t, entries, 1, "exactly one closed event should be in outbox")
+
+		e := entries[0]
+		assert.Equal(t, topics.CurrentAccountAccountClosedV1, e.Topic)
+		assert.Equal(t, "current_account.account_closed.v1", e.EventType)
+		assert.Equal(t, "CurrentAccount", e.AggregateType)
+		assert.Equal(t, accountID, e.AggregateID)
+		assert.Equal(t, events.StatusPending, e.Status)
+	})
+}
+
+// TestControlCurrentAccount_OutboxAtomicity verifies that if the outbox write fails,
+// the account state change is also rolled back (transactional guarantee).
+// This test uses a service with a nil outbox publisher to exercise the fallback path
+// and confirm control actions still succeed without outbox.
+func TestControlCurrentAccount_FallbackWithoutOutbox(t *testing.T) {
+	_, repo, lienRepo, tid, cleanup := setupControlOutboxDB(t)
+	defer cleanup()
+
+	ctx := tenant.WithTenant(t.Context(), tid)
+
+	mockPosKeeping := &mockPositionKeepingClient{
+		accountBalances: map[string]int64{
+			"ACC-FALLBACK-001": 0, // zero balance required for CLOSE validation
+		},
+	}
+
+	// Service without outboxPublisher or db — exercises fallback path
+	svc := &Service{
+		repo:             repo,
+		lienRepo:         lienRepo,
+		posKeepingClient: mockPosKeeping,
+		logger:           testLogger(),
+	}
+
+	accountID := "ACC-FALLBACK-001"
+	_ = createTestAccountForControl(t, ctx, repo, accountID)
+
+	// All three control actions should succeed via fallback (repo.Save only)
+	_, err := svc.ControlCurrentAccount(ctx, &pb.ControlCurrentAccountRequest{
+		AccountId:     accountID,
+		ControlAction: pb.ControlAction_CONTROL_ACTION_FREEZE,
+		Reason:        "Testing fallback path without outbox",
+	})
+	require.NoError(t, err, "freeze should succeed without outbox publisher")
+
+	_, err = svc.ControlCurrentAccount(ctx, &pb.ControlCurrentAccountRequest{
+		AccountId:     accountID,
+		ControlAction: pb.ControlAction_CONTROL_ACTION_UNFREEZE,
+	})
+	require.NoError(t, err, "unfreeze should succeed without outbox publisher")
+
+	_, err = svc.ControlCurrentAccount(ctx, &pb.ControlCurrentAccountRequest{
+		AccountId:     accountID,
+		ControlAction: pb.ControlAction_CONTROL_ACTION_CLOSE,
+		Reason:        "Close via fallback path",
+	})
+	require.NoError(t, err, "close should succeed without outbox publisher")
+}

--- a/services/current-account/service/control_outbox_integration_test.go
+++ b/services/current-account/service/control_outbox_integration_test.go
@@ -21,15 +21,21 @@ func setupControlOutboxDB(t *testing.T) (*gorm.DB, *persistence.Repository, *per
 
 	db := openSharedDB(t)
 
+	// Pin to a single connection so that SET search_path (which is connection-scoped)
+	// is reliably applied to every subsequent query on this *gorm.DB instance.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
 	tid := uniqueTenantID()
 	schemaName := tid.SchemaName()
 	quotedSchema := pq.QuoteIdentifier(schemaName)
 
 	// Create tenant schema
-	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quotedSchema)).Error
+	err = db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quotedSchema)).Error
 	require.NoError(t, err)
 
-	// Set search_path
+	// Set search_path (applies to the pinned connection for all subsequent queries)
 	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", quotedSchema)).Error
 	require.NoError(t, err)
 
@@ -222,14 +228,16 @@ func TestControlCurrentAccount_OutboxEvents(t *testing.T) {
 // This ensures backward compatibility for test environments and services that start without
 // a database connection available at construction time.
 func TestControlCurrentAccount_FallbackWithoutOutbox(t *testing.T) {
-	_, repo, lienRepo, tid, cleanup := setupControlOutboxDB(t)
+	db, repo, lienRepo, tid, cleanup := setupControlOutboxDB(t)
 	defer cleanup()
 
 	ctx := tenant.WithTenant(t.Context(), tid)
 
+	accountID := fmt.Sprintf("ACC-FALLBACK-%s", tid)
+
 	mockPosKeeping := &mockPositionKeepingClient{
 		accountBalances: map[string]int64{
-			"ACC-FALLBACK-001": 0, // zero balance required for CLOSE validation
+			accountID: 0, // zero balance required for CLOSE validation
 		},
 	}
 
@@ -241,7 +249,6 @@ func TestControlCurrentAccount_FallbackWithoutOutbox(t *testing.T) {
 		logger:           testLogger(),
 	}
 
-	accountID := "ACC-FALLBACK-001"
 	_ = createTestAccountForControl(t, ctx, repo, accountID)
 
 	// All three control actions should succeed via fallback (repo.Save only)
@@ -264,4 +271,12 @@ func TestControlCurrentAccount_FallbackWithoutOutbox(t *testing.T) {
 		Reason:        "Close via fallback path",
 	})
 	require.NoError(t, err, "close should succeed without outbox publisher")
+
+	// Confirm no outbox rows were written — the fallback path must not silently emit events.
+	var outboxCount int64
+	err = db.Model(&events.EventOutbox{}).
+		Where("aggregate_id = ? AND service_name = ?", accountID, "current-account").
+		Count(&outboxCount).Error
+	require.NoError(t, err)
+	assert.Zero(t, outboxCount, "fallback path should not write to event_outbox")
 }

--- a/services/current-account/service/control_outbox_integration_test.go
+++ b/services/current-account/service/control_outbox_integration_test.go
@@ -204,10 +204,10 @@ func TestControlCurrentAccount_OutboxEvents(t *testing.T) {
 	})
 }
 
-// TestControlCurrentAccount_OutboxAtomicity verifies that if the outbox write fails,
-// the account state change is also rolled back (transactional guarantee).
-// This test uses a service with a nil outbox publisher to exercise the fallback path
-// and confirm control actions still succeed without outbox.
+// TestControlCurrentAccount_FallbackWithoutOutbox verifies that control actions succeed
+// via the fallback path (direct repo.Save) when the outbox publisher is not configured.
+// This ensures backward compatibility for test environments and services that start without
+// a database connection available at construction time.
 func TestControlCurrentAccount_FallbackWithoutOutbox(t *testing.T) {
 	_, repo, lienRepo, tid, cleanup := setupControlOutboxDB(t)
 	defer cleanup()

--- a/services/current-account/service/grpc_control_endpoints.go
+++ b/services/current-account/service/grpc_control_endpoints.go
@@ -275,10 +275,21 @@ func (s *Service) saveWithOutboxEvent(
 
 		case pb.ControlAction_CONTROL_ACTION_CLOSE:
 			balanceCents, _ := account.Balance().ToMinorUnits()
+			// Derive the divisor from the account's precision so the conversion is
+			// correct for any currency (e.g., JPY precision=0, GBP precision=2, KWH precision=3).
+			precision := account.Balance().Precision()
+			divisor := int64(1)
+			for i := 0; i < precision; i++ {
+				divisor *= 10
+			}
+			var nanosMultiplier int32
+			if divisor > 0 {
+				nanosMultiplier = int32(1_000_000_000 / divisor)
+			}
 			closingBalance := &money.Money{
 				CurrencyCode: account.Balance().InstrumentCode(),
-				Units:        balanceCents / 100,
-				Nanos:        int32((balanceCents % 100) * 10000000),
+				Units:        balanceCents / divisor,
+				Nanos:        int32(balanceCents%divisor) * nanosMultiplier,
 			}
 			event := &eventsv1.AccountClosedEvent{
 				EventId:        uuid.New().String(),

--- a/services/current-account/service/grpc_control_endpoints.go
+++ b/services/current-account/service/grpc_control_endpoints.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -12,11 +13,14 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
 	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/genproto/googleapis/type/money"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
 )
 
 // ControlCurrentAccount performs lifecycle state transitions on an account.
@@ -156,8 +160,10 @@ func (s *Service) ControlCurrentAccount(ctx context.Context, req *pb.ControlCurr
 		return nil, status.Errorf(codes.InvalidArgument, "unknown control action: %v", req.ControlAction)
 	}
 
-	// Persist with optimistic locking
-	if err := s.repo.Save(ctx, account); err != nil {
+	// Atomically persist account state change and write event to outbox.
+	// Using transactional outbox ensures guaranteed at-least-once event delivery
+	// without the fire-and-forget reliability issues of direct Kafka publishing.
+	if err := s.saveWithOutboxEvent(ctx, req, &account, actionTimestamp); err != nil {
 		if errors.Is(err, persistence.ErrVersionConflict) {
 			operationStatus = "version_conflict"
 			s.logger.Warn("version conflict during control action",
@@ -168,11 +174,6 @@ func (s *Service) ControlCurrentAccount(ctx context.Context, req *pb.ControlCurr
 		operationStatus = opStatusSaveFailed
 		return nil, status.Errorf(codes.Internal, "failed to save account: %v", err)
 	}
-
-	// Emit Kafka events for account lifecycle changes (fire-and-forget pattern)
-	// Event publishing errors are logged but don't fail the operation to ensure
-	// the business operation completes successfully regardless of messaging issues.
-	s.publishControlActionEvent(ctx, req, &account, actionTimestamp)
 
 	// Emit webhook notifications for FREEZE and CLOSE actions (regulatory compliance)
 	// Webhooks are sent asynchronously with retry logic - errors are logged but don't fail the operation.
@@ -191,18 +192,21 @@ func (s *Service) ControlCurrentAccount(ctx context.Context, req *pb.ControlCurr
 	}, nil
 }
 
-// publishControlActionEvent emits lifecycle events to Kafka based on the control action.
-// This method uses fire-and-forget semantics - errors are logged but don't fail the operation.
-// The account balance and reason information is captured from the domain object and request.
-func (s *Service) publishControlActionEvent(
+// saveWithOutboxEvent atomically persists the account state change and writes the
+// corresponding lifecycle event to the outbox within a single database transaction.
+// This replaces the previous fire-and-forget PublishWithTenant pattern, guaranteeing
+// at-least-once event delivery via the background outbox worker.
+//
+// If the outbox publisher is not configured (e.g., in tests), falls back to repo.Save only.
+func (s *Service) saveWithOutboxEvent(
 	ctx context.Context,
 	req *pb.ControlCurrentAccountRequest,
 	account *domain.CurrentAccount,
 	actionTimestamp time.Time,
-) {
-	// Skip if event publisher is not configured
-	if s.eventPublisher == nil {
-		return
+) error {
+	// Fall back to direct save if outbox is not available (e.g., unit tests)
+	if s.outboxPublisher == nil || s.db == nil {
+		return s.repo.Save(ctx, *account)
 	}
 
 	// Extract actor identity from auth context (falls back to "system" if not available)
@@ -211,96 +215,100 @@ func (s *Service) publishControlActionEvent(
 		actorID = userID
 	}
 
-	// Generate correlation ID for event tracing
 	correlationID := uuid.New().String()
-
-	// Generate event timestamp
 	now := time.Now().UTC()
-
-	// Use AccountID() which returns the business account ID as string
 	accountID := account.AccountID()
 
-	switch req.ControlAction {
-	case pb.ControlAction_CONTROL_ACTION_FREEZE:
-		event := &eventsv1.AccountFrozenEvent{
-			EventId:       uuid.New().String(),
-			AccountId:     accountID,
-			Reason:        req.Reason,
-			FrozenAt:      timestamppb.New(actionTimestamp),
-			FrozenBy:      actorID,
-			CorrelationId: correlationID,
-			CausationId:   correlationID,
-			Timestamp:     timestamppb.New(now),
-			Version:       account.Version(),
-		}
-		if err := s.eventPublisher.PublishWithTenant(ctx, TopicAccountFrozen, accountID, event); err != nil {
-			s.logger.Error("failed to publish account frozen event",
-				"account_id", accountID,
-				"error", err)
-		} else {
-			s.logger.Debug("published account frozen event",
-				"account_id", accountID,
-				"event_id", event.EventId,
-				"correlation_id", correlationID)
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		// Save the account state using a transaction-scoped repository
+		txRepo := s.repo.WithTx(tx)
+		if err := txRepo.Save(ctx, *account); err != nil { //nolint:govet // account is a pointer to domain value
+			return err
 		}
 
-	case pb.ControlAction_CONTROL_ACTION_UNFREEZE:
-		event := &eventsv1.AccountUnfrozenEvent{
-			EventId:       uuid.New().String(),
-			AccountId:     accountID,
-			UnfrozenAt:    timestamppb.New(actionTimestamp),
-			UnfrozenBy:    actorID,
-			CorrelationId: correlationID,
-			CausationId:   correlationID,
-			Timestamp:     timestamppb.New(now),
-			Version:       account.Version(),
-		}
-		if err := s.eventPublisher.PublishWithTenant(ctx, TopicAccountUnfrozen, accountID, event); err != nil {
-			s.logger.Error("failed to publish account unfrozen event",
-				"account_id", accountID,
-				"error", err)
-		} else {
-			s.logger.Debug("published account unfrozen event",
-				"account_id", accountID,
-				"event_id", event.EventId,
-				"correlation_id", correlationID)
+		// Build and publish the lifecycle event to the outbox based on the control action
+		switch req.ControlAction {
+		case pb.ControlAction_CONTROL_ACTION_FREEZE:
+			event := &eventsv1.AccountFrozenEvent{
+				EventId:       uuid.New().String(),
+				AccountId:     accountID,
+				Reason:        req.Reason,
+				FrozenAt:      timestamppb.New(actionTimestamp),
+				FrozenBy:      actorID,
+				CorrelationId: correlationID,
+				CausationId:   correlationID,
+				Timestamp:     timestamppb.New(now),
+				Version:       account.Version(),
+			}
+			if err := s.outboxPublisher.Publish(ctx, tx, event, events.PublishConfig{
+				EventType:     "current_account.account_frozen.v1",
+				Topic:         topics.CurrentAccountAccountFrozenV1,
+				AggregateType: "CurrentAccount",
+				AggregateID:   accountID,
+				CorrelationID: correlationID,
+				CausationID:   correlationID,
+			}); err != nil {
+				return fmt.Errorf("failed to write account frozen event to outbox: %w", err)
+			}
+
+		case pb.ControlAction_CONTROL_ACTION_UNFREEZE:
+			event := &eventsv1.AccountUnfrozenEvent{
+				EventId:       uuid.New().String(),
+				AccountId:     accountID,
+				UnfrozenAt:    timestamppb.New(actionTimestamp),
+				UnfrozenBy:    actorID,
+				CorrelationId: correlationID,
+				CausationId:   correlationID,
+				Timestamp:     timestamppb.New(now),
+				Version:       account.Version(),
+			}
+			if err := s.outboxPublisher.Publish(ctx, tx, event, events.PublishConfig{
+				EventType:     "current_account.account_unfrozen.v1",
+				Topic:         topics.CurrentAccountAccountUnfrozenV1,
+				AggregateType: "CurrentAccount",
+				AggregateID:   accountID,
+				CorrelationID: correlationID,
+				CausationID:   correlationID,
+			}); err != nil {
+				return fmt.Errorf("failed to write account unfrozen event to outbox: %w", err)
+			}
+
+		case pb.ControlAction_CONTROL_ACTION_CLOSE:
+			balanceCents, _ := account.Balance().ToMinorUnits()
+			closingBalance := &money.Money{
+				CurrencyCode: account.Balance().InstrumentCode(),
+				Units:        balanceCents / 100,
+				Nanos:        int32((balanceCents % 100) * 10000000),
+			}
+			event := &eventsv1.AccountClosedEvent{
+				EventId:        uuid.New().String(),
+				AccountId:      accountID,
+				ClosingBalance: closingBalance,
+				ClosureReason:  req.Reason,
+				ClosedBy:       actorID,
+				ClosureDate:    timestamppb.New(actionTimestamp),
+				CorrelationId:  correlationID,
+				CausationId:    correlationID,
+				Timestamp:      timestamppb.New(now),
+				Version:        account.Version(),
+			}
+			if err := s.outboxPublisher.Publish(ctx, tx, event, events.PublishConfig{
+				EventType:     "current_account.account_closed.v1",
+				Topic:         topics.CurrentAccountAccountClosedV1,
+				AggregateType: "CurrentAccount",
+				AggregateID:   accountID,
+				CorrelationID: correlationID,
+				CausationID:   correlationID,
+			}); err != nil {
+				return fmt.Errorf("failed to write account closed event to outbox: %w", err)
+			}
+
+		case pb.ControlAction_CONTROL_ACTION_UNSPECIFIED:
+			// No event for unspecified action
 		}
 
-	case pb.ControlAction_CONTROL_ACTION_CLOSE:
-		// Convert domain balance to google.type.Money
-		balanceCents, _ := account.Balance().ToMinorUnits()
-		closingBalance := &money.Money{
-			CurrencyCode: account.Balance().InstrumentCode(),
-			Units:        balanceCents / 100,
-			Nanos:        int32((balanceCents % 100) * 10000000),
-		}
-
-		event := &eventsv1.AccountClosedEvent{
-			EventId:        uuid.New().String(),
-			AccountId:      accountID,
-			ClosingBalance: closingBalance,
-			ClosureReason:  req.Reason,
-			ClosedBy:       actorID,
-			ClosureDate:    timestamppb.New(actionTimestamp),
-			CorrelationId:  correlationID,
-			CausationId:    correlationID,
-			Timestamp:      timestamppb.New(now),
-			Version:        account.Version(),
-		}
-		if err := s.eventPublisher.PublishWithTenant(ctx, TopicAccountClosed, accountID, event); err != nil {
-			s.logger.Error("failed to publish account closed event",
-				"account_id", accountID,
-				"error", err)
-		} else {
-			s.logger.Debug("published account closed event",
-				"account_id", accountID,
-				"event_id", event.EventId,
-				"correlation_id", correlationID)
-		}
-
-	case pb.ControlAction_CONTROL_ACTION_UNSPECIFIED:
-		// No event for unspecified action (validation catches this earlier)
-	}
+		return nil
+	})
 }
 
 // sendControlActionWebhook sends webhook notifications for regulatory compliance events.

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -205,6 +205,7 @@ type Service struct {
 	withdrawalRepo         *persistence.WithdrawalRepository
 	valuationFeatureRepo   *persistence.ValuationFeatureRepository // ValuationFeature repository for valuation method assignments
 	outboxRepo             events.OutboxRepository                 // Outbox repository for reliable event delivery
+	outboxPublisher        *events.OutboxPublisher                 // OutboxPublisher for transactional event writing
 	db                     *gorm.DB                                // Database connection for transaction management
 	posKeepingClient       PositionKeepingClient
 	finAcctClient          FinancialAccountingClient
@@ -214,7 +215,7 @@ type Service struct {
 	valuationEngine        ValuationEngine  // Optional: executes valuation method logic
 	accountConfig          *config.AccountConfig
 	idempotencyService     idempotency.Service
-	eventPublisher         AccountEventPublisher // Optional: publishes lifecycle events to Kafka
+	eventPublisher         AccountEventPublisher // Optional: publishes lifecycle events to Kafka (deprecated: use outboxPublisher)
 	webhookNotifier        WebhookNotifier       // Optional: sends webhook notifications for lifecycle events
 	logger                 *slog.Logger
 	tracer                 *observability.Tracer
@@ -413,6 +414,7 @@ func NewServiceWithExistingClients(
 		lienRepo:               lienRepo,
 		withdrawalRepo:         withdrawalRepo,
 		outboxRepo:             outboxRepo,
+		outboxPublisher:        events.NewOutboxPublisher("current-account"),
 		db:                     db,
 		posKeepingClient:       posKeepingClient,
 		finAcctClient:          finAcctClient,


### PR DESCRIPTION
## Summary

- Replaces fire-and-forget `PublishWithTenant()` for account lifecycle events with the transactional outbox pattern
- Account state changes (freeze, unfreeze, close) and their corresponding events are now written atomically in a single database transaction
- Wires `OutboxPublisher` into the service alongside the existing `outboxRepo` + `db` dependencies

## Changes Made

### `services/current-account/service/grpc_service.go`
- Added `outboxPublisher *events.OutboxPublisher` field to `Service` struct
- Instantiate `events.NewOutboxPublisher("current-account")` in `NewServiceWithExistingClients`

### `services/current-account/service/grpc_control_endpoints.go`
- Removed `publishControlActionEvent` (fire-and-forget, error-logging-only pattern)
- Added `saveWithOutboxEvent` which executes a single `db.Transaction` that:
  1. Saves the account state via `repo.WithTx(tx).Save()`
  2. Writes the lifecycle event to outbox via `outboxPublisher.Publish()`
- Uses topic constants from `shared/platform/events/topics` registry (`CurrentAccountAccountFrozenV1`, `CurrentAccountAccountUnfrozenV1`, `CurrentAccountAccountClosedV1`)
- Falls back to direct `repo.Save` when outbox publisher is not configured (test compatibility)

### `services/current-account/service/control_outbox_integration_test.go` (new)
- `TestControlCurrentAccount_OutboxEvents`: verifies each control action (freeze, unfreeze, close) writes an outbox entry with correct topic, event type, aggregate type/ID, and pending status
- `TestControlCurrentAccount_FallbackWithoutOutbox`: verifies fallback path works when outbox publisher is absent

## Technical Details

The withdrawal status events (`current-account.withdrawal-status.v1`) were already using the outbox pattern — this PR completes the migration for the remaining three control event types.

The `AccountEventPublisher` interface and `WithEventPublisher` option are retained for backward compatibility but are no longer used in the control flow.

## Testing

- All existing `TestAccountControl*` integration tests pass unchanged
- New outbox-specific tests added in `control_outbox_integration_test.go`
- Full `go test ./services/current-account/...` suite passes

## Related

Part of prd-030-asyncapi-spec task 2: Migrate Current Account to OutboxPublisher