### PR TITLE
feat: migrate position-keeping service to transactional outbox pattern

### DIFF
--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -69,6 +69,7 @@ import (
 	partyservice "github.com/meridianhub/meridian/services/party/service"
 	paymentorderpersistence "github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
 	paymentorderservice "github.com/meridianhub/meridian/services/payment-order/service"
+	pkmessaging "github.com/meridianhub/meridian/services/position-keeping/adapters/messaging"
 	pkpersistence "github.com/meridianhub/meridian/services/position-keeping/adapters/persistence"
 	pkclient "github.com/meridianhub/meridian/services/position-keeping/client"
 	pkdomain "github.com/meridianhub/meridian/services/position-keeping/domain"
@@ -629,11 +630,18 @@ func wirePositionKeeping(
 	eventPub pkdomain.EventPublisher,
 	logger *slog.Logger,
 ) error {
+	outboxRepo := events.NewPgxOutboxRepository(pool)
+	outboxPub, err := pkmessaging.NewOutboxEventPublisher(outboxRepo)
+	if err != nil {
+		return fmt.Errorf("failed to create position-keeping outbox publisher: %w", err)
+	}
+
 	svc, err := positionkeepingservice.NewPositionKeepingService(
 		pkpersistence.NewPostgresRepository(pool),
 		pkpersistence.NewMeasurementRepository(pool),
 		eventPub,
 		idempotencySvc,
+		outboxPub,
 	)
 	if err != nil {
 		return err

--- a/services/position-keeping/adapters/messaging/outbox_event_publisher.go
+++ b/services/position-keeping/adapters/messaging/outbox_event_publisher.go
@@ -1,0 +1,125 @@
+// Package messaging provides adapters for event-driven communication.
+package messaging
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
+)
+
+// ErrOutboxPublishNotSupported is returned when attempting to publish without a transaction.
+// Use BuildOutboxFn with CreateWithOutbox or UpdateWithOutbox for transactional writes.
+var ErrOutboxPublishNotSupported = errors.New("OutboxEventPublisher requires a transaction: use BuildOutboxFn with CreateWithOutbox or UpdateWithOutbox")
+
+// outboxTopicMap maps position-keeping event types to their Kafka topics.
+var outboxTopicMap = map[string]string{
+	"position_keeping.transaction_captured.v1":      topics.PositionKeepingTransactionCapturedV1,
+	"position_keeping.transaction_amended.v1":       topics.PositionKeepingTransactionAmendedV1,
+	"position_keeping.transaction_reconciled.v1":    topics.PositionKeepingTransactionReconciledV1,
+	"position_keeping.transaction_posted.v1":        topics.PositionKeepingTransactionPostedV1,
+	"position_keeping.transaction_rejected.v1":      topics.PositionKeepingTransactionRejectedV1,
+	"position_keeping.transaction_failed.v1":        topics.PositionKeepingTransactionFailedV1,
+	"position_keeping.transaction_cancelled.v1":     topics.PositionKeepingTransactionCancelledV1,
+	"position_keeping.bulk_transaction_captured.v1": topics.PositionKeepingBulkTransactionCapturedV1,
+	"position_keeping.opening_balance_recorded.v1":  topics.PositionKeepingOpeningBalanceRecordedV1,
+}
+
+// OutboxEventPublisher implements domain.EventPublisher using the transactional outbox pattern.
+// Events are written to the event_outbox table within a provided pgx transaction, guaranteeing
+// at-least-once delivery via the background outbox worker.
+//
+// This publisher is used with the repository's transactional write methods (CreateWithOutbox,
+// UpdateWithOutbox) which call Publish within the same transaction as the business operation.
+type OutboxEventPublisher struct {
+	outboxRepo  *events.PgxOutboxRepository
+	serviceName string
+}
+
+// NewOutboxEventPublisher creates a new OutboxEventPublisher.
+func NewOutboxEventPublisher(outboxRepo *events.PgxOutboxRepository) (*OutboxEventPublisher, error) {
+	if outboxRepo == nil {
+		return nil, ErrNilProducer
+	}
+	return &OutboxEventPublisher{
+		outboxRepo:  outboxRepo,
+		serviceName: "position-keeping",
+	}, nil
+}
+
+// BuildOutboxFn builds a pgx transaction callback that writes the given events to the outbox.
+// The returned function is intended to be passed to repository methods like CreateWithOutbox
+// and UpdateWithOutbox, which invoke it within the same transaction as the database write.
+func (p *OutboxEventPublisher) BuildOutboxFn(ctx context.Context, evts []domain.DomainEvent) func(pgx.Tx) error {
+	return func(tx pgx.Tx) error {
+		for i, event := range evts {
+			if err := p.publishWithTx(ctx, tx, event); err != nil {
+				return fmt.Errorf("failed to write event at index %d to outbox: %w", i, err)
+			}
+		}
+		return nil
+	}
+}
+
+// publishWithTx writes a single domain event to the outbox table within the provided transaction.
+func (p *OutboxEventPublisher) publishWithTx(ctx context.Context, tx pgx.Tx, event domain.DomainEvent) error {
+	if event == nil {
+		return ErrNilEvent
+	}
+
+	topic, ok := outboxTopicMap[event.EventType()]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownEventType, event.EventType())
+	}
+
+	protoEvent := event.ToProto()
+	protoMsg, ok := protoEvent.(proto.Message)
+	if !ok {
+		return fmt.Errorf("%w: event type %s", ErrInvalidProtoEvent, event.EventType())
+	}
+
+	payload, err := proto.Marshal(protoMsg)
+	if err != nil {
+		return fmt.Errorf("failed to serialize event %s: %w", event.EventType(), err)
+	}
+
+	entry := &events.EventOutbox{
+		EventType:     event.EventType(),
+		AggregateID:   event.AggregateID(),
+		AggregateType: "FinancialPositionLog",
+		EventPayload:  payload,
+		Topic:         topic,
+		PartitionKey:  event.AggregateID(),
+		ServiceName:   p.serviceName,
+	}
+
+	if err := p.outboxRepo.InsertWithPgxTx(ctx, tx, entry); err != nil {
+		return fmt.Errorf("failed to insert outbox entry for event %s: %w", event.EventType(), err)
+	}
+
+	return nil
+}
+
+// Publish implements domain.EventPublisher for backwards compatibility.
+// This variant does not provide transactional guarantees — prefer BuildOutboxFn with
+// the repository's CreateWithOutbox / UpdateWithOutbox methods for atomic writes.
+//
+// This method is provided so that OutboxEventPublisher satisfies the domain.EventPublisher
+// interface and can be used as a drop-in replacement in contexts where a transaction is not
+// available (e.g., batch operations that use non-transactional code paths).
+func (p *OutboxEventPublisher) Publish(_ context.Context, _ domain.DomainEvent) error {
+	// Non-transactional publish is not supported by this publisher.
+	// Callers must use BuildOutboxFn with repository transactional write methods.
+	return fmt.Errorf("publish: %w", ErrOutboxPublishNotSupported)
+}
+
+// PublishBatch implements domain.EventPublisher for backwards compatibility.
+func (p *OutboxEventPublisher) PublishBatch(_ context.Context, _ []domain.DomainEvent) error {
+	return fmt.Errorf("publish batch: %w", ErrOutboxPublishNotSupported)
+}

--- a/services/position-keeping/adapters/persistence/postgres_repository.go
+++ b/services/position-keeping/adapters/persistence/postgres_repository.go
@@ -502,6 +502,189 @@ func (r *PostgresRepository) Update(ctx context.Context, log *domain.FinancialPo
 	return nil
 }
 
+// CreateWithOutbox persists a new FinancialPositionLog and runs postFn within the same
+// database transaction, enabling atomic event outbox writes.
+func (r *PostgresRepository) CreateWithOutbox(ctx context.Context, log *domain.FinancialPositionLog, postFn func(pgx.Tx) error) error {
+	if log == nil {
+		return ErrNilLog
+	}
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
+	userID := audit.GetUserFromContext(ctx)
+	logQuery := `
+		INSERT INTO financial_position_log (
+			id, created_at, created_by, updated_at, updated_by,
+			log_id, account_id, version,
+			current_status, previous_status, status_updated_at, status_reason, failure_reason,
+			reconciliation_status,
+			opening_balance_amount, opening_balance_currency, opening_balance_recorded_at
+		) VALUES (
+			gen_random_uuid(), $1, $2, $3, $4,
+			$5, $6, $7,
+			$8, $9, $10, $11, $12,
+			$13,
+			$14, $15, $16
+		) RETURNING id`
+
+	var dbID uuid.UUID
+	err = tx.QueryRow(ctx, logQuery,
+		log.CreatedAt, userID, log.UpdatedAt, userID,
+		log.LogID, log.AccountID, log.Version,
+		log.StatusTracking.CurrentStatus.String(), nullString(log.StatusTracking.PreviousStatus),
+		log.StatusTracking.StatusUpdatedAt, log.StatusTracking.StatusReason,
+		nullStringValue(log.StatusTracking.FailureReason),
+		log.StatusTracking.ReconciliationStatus.String(),
+		log.OpeningBalance.Amount, openingBalanceCurrencyCode(log.OpeningBalance), nullTime(log.OpeningBalanceRecordedAt),
+	).Scan(&dbID)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return domain.ErrConflict
+		}
+		return fmt.Errorf("failed to insert financial position log: %w", err)
+	}
+
+	if err := r.insertTransactionLogEntries(ctx, tx, dbID, log.TransactionLogEntries); err != nil {
+		return err
+	}
+
+	if log.TransactionLineage != nil {
+		if err := r.insertTransactionLineage(ctx, tx, dbID, log.TransactionLineage); err != nil {
+			return err
+		}
+	}
+
+	if err := r.insertAuditTrailEntries(ctx, tx, dbID, log.AuditTrail); err != nil {
+		return err
+	}
+
+	if postFn != nil {
+		if err := postFn(tx); err != nil {
+			return fmt.Errorf("post-create outbox write failed: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateWithOutbox updates an existing FinancialPositionLog and runs postFn within the same
+// database transaction, enabling atomic event outbox writes.
+func (r *PostgresRepository) UpdateWithOutbox(ctx context.Context, log *domain.FinancialPositionLog, postFn func(pgx.Tx) error) error {
+	if log == nil {
+		return ErrNilLog
+	}
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
+	var dbID uuid.UUID
+	err = tx.QueryRow(ctx, "SELECT id FROM financial_position_log WHERE log_id = $1 AND deleted_at IS NULL", log.LogID).Scan(&dbID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.ErrNotFound
+		}
+		return fmt.Errorf("failed to find log for update: %w", err)
+	}
+
+	previousVersion := log.Version - 1
+	userID := audit.GetUserFromContext(ctx)
+
+	updateQuery := `
+		UPDATE financial_position_log
+		SET updated_at = $1, updated_by = $2, version = $3,
+			current_status = $4, previous_status = $5, status_updated_at = $6,
+			status_reason = $7, failure_reason = $8, reconciliation_status = $9
+		WHERE id = $10 AND version = $11 AND deleted_at IS NULL`
+
+	result, err := tx.Exec(ctx, updateQuery,
+		log.UpdatedAt, userID, log.Version,
+		log.StatusTracking.CurrentStatus.String(), nullString(log.StatusTracking.PreviousStatus),
+		log.StatusTracking.StatusUpdatedAt, log.StatusTracking.StatusReason,
+		nullStringValue(log.StatusTracking.FailureReason),
+		log.StatusTracking.ReconciliationStatus.String(),
+		dbID, previousVersion,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update financial position log: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return domain.ErrOptimisticLock
+	}
+
+	_, err = tx.Exec(ctx, "DELETE FROM transaction_log_entry WHERE financial_position_log_id = $1", dbID)
+	if err != nil {
+		return fmt.Errorf("failed to delete old transaction log entries: %w", err)
+	}
+
+	if err := r.insertTransactionLogEntries(ctx, tx, dbID, log.TransactionLogEntries); err != nil {
+		return err
+	}
+
+	_, err = tx.Exec(ctx, "DELETE FROM transaction_lineage WHERE financial_position_log_id = $1", dbID)
+	if err != nil {
+		return fmt.Errorf("failed to delete old transaction lineage: %w", err)
+	}
+
+	if log.TransactionLineage != nil {
+		if err := r.insertTransactionLineage(ctx, tx, dbID, log.TransactionLineage); err != nil {
+			return err
+		}
+	}
+
+	existingAuditIDs, err := r.getExistingAuditIDs(ctx, tx, dbID)
+	if err != nil {
+		return err
+	}
+
+	newAuditEntries := lo.Filter(log.AuditTrail, func(entry *domain.AuditTrailEntry, _ int) bool {
+		_, exists := existingAuditIDs[entry.AuditID]
+		return !exists
+	})
+
+	if len(newAuditEntries) > 0 {
+		if err := r.insertAuditTrailEntries(ctx, tx, dbID, newAuditEntries); err != nil {
+			return err
+		}
+	}
+
+	if postFn != nil {
+		if err := postFn(tx); err != nil {
+			return fmt.Errorf("post-update outbox write failed: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit update transaction: %w", err)
+	}
+
+	return nil
+}
+
 // List retrieves FinancialPositionLogs matching the given filter with pagination.
 // In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *PostgresRepository) List(ctx context.Context, filter domain.PositionLogFilter) ([]*domain.FinancialPositionLog, error) {

--- a/services/position-keeping/app/container.go
+++ b/services/position-keeping/app/container.go
@@ -32,7 +32,8 @@ type Container struct {
 	auditPublisher  *audit.Publisher     // internal, for cleanup
 
 	// Adapters
-	EventPublisher domain.EventPublisher
+	EventPublisher  domain.EventPublisher
+	OutboxPublisher *messaging.OutboxEventPublisher
 
 	// Repository
 	PositionLogRepository domain.FinancialPositionLogRepository
@@ -76,6 +77,8 @@ func NewContainer(ctx context.Context, config *Config, logger *slog.Logger) (*Co
 	container.initializeRepositories()
 
 	container.initializeOutboxRepository()
+
+	container.initializeOutboxPublisher()
 
 	logger.Info("dependency container initialized successfully")
 
@@ -335,6 +338,20 @@ func (c *Container) initializeOutboxRepository() {
 	// when the outbox is backing up (e.g., Kafka unavailable).
 	c.OutboxRepository = events.NewPgxOutboxRepository(c.DBPool)
 	c.Logger.Info("event outbox repository initialized")
+}
+
+// initializeOutboxPublisher initializes the OutboxEventPublisher that writes domain events
+// to the transactional outbox table atomically with business operations.
+func (c *Container) initializeOutboxPublisher() {
+	publisher, err := messaging.NewOutboxEventPublisher(c.OutboxRepository)
+	if err != nil {
+		// NewOutboxEventPublisher only fails if OutboxRepository is nil, which cannot
+		// happen here since initializeOutboxRepository always sets it.
+		c.Logger.Error("failed to create outbox event publisher", "error", err)
+		return
+	}
+	c.OutboxPublisher = publisher
+	c.Logger.Info("outbox event publisher initialized")
 }
 
 // KafkaProducer returns the Kafka producer for use by components that need

--- a/services/position-keeping/cmd/main.go
+++ b/services/position-keeping/cmd/main.go
@@ -405,6 +405,7 @@ func run(logger *slog.Logger) error {
 		container.MeasurementRepository,
 		container.EventPublisher,
 		idempotencySvc,
+		container.OutboxPublisher,
 		serviceOpts...,
 	)
 	if err != nil {

--- a/services/position-keeping/domain/repository.go
+++ b/services/position-keeping/domain/repository.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/shopspring/decimal"
 )
 
@@ -47,6 +48,18 @@ type FinancialPositionLogRepository interface {
 	// Returns ErrNotFound if the log doesn't exist.
 	// Returns ErrOptimisticLock if the version doesn't match (concurrent modification).
 	Update(ctx context.Context, log *FinancialPositionLog) error
+
+	// CreateWithOutbox persists a new FinancialPositionLog and runs postFn within the same
+	// database transaction. postFn receives the active pgx.Tx and is intended for writing
+	// events to the outbox atomically with the business operation.
+	// If postFn returns an error the entire transaction is rolled back.
+	CreateWithOutbox(ctx context.Context, log *FinancialPositionLog, postFn func(pgx.Tx) error) error
+
+	// UpdateWithOutbox updates an existing FinancialPositionLog and runs postFn within the same
+	// database transaction. postFn receives the active pgx.Tx and is intended for writing
+	// events to the outbox atomically with the business operation.
+	// If postFn returns an error the entire transaction is rolled back.
+	UpdateWithOutbox(ctx context.Context, log *FinancialPositionLog, postFn func(pgx.Tx) error) error
 
 	// List retrieves FinancialPositionLogs matching the given filter with pagination.
 	// Returns an empty slice if no logs match the filter.

--- a/services/position-keeping/service/adapters_test.go
+++ b/services/position-keeping/service/adapters_test.go
@@ -13,8 +13,10 @@ import (
 
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	messagingpkg "github.com/meridianhub/meridian/services/position-keeping/adapters/messaging"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 	"github.com/meridianhub/meridian/services/position-keeping/service"
+	eventspkg "github.com/meridianhub/meridian/shared/platform/events"
 )
 
 // TestToProtoMoneyAmount tests conversion of domain.Money to protobuf MoneyAmount
@@ -1012,7 +1014,12 @@ func callToProtoFinancialPositionLog(log *domain.FinancialPositionLog) *position
 	mockIdempotency := new(MockIdempotencyService)
 	mockMeasurementRepo := new(MockMeasurementRepository)
 
-	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency)
+	outboxPub, err := messagingpkg.NewOutboxEventPublisher(eventspkg.NewPgxOutboxRepository(nil))
+	if err != nil {
+		return nil
+	}
+
+	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency, outboxPub)
 	if err != nil {
 		return nil
 	}

--- a/services/position-keeping/service/append_only_blocked_test.go
+++ b/services/position-keeping/service/append_only_blocked_test.go
@@ -22,6 +22,7 @@ func TestUpdatePosition_ReturnsUnimplemented(t *testing.T) {
 		new(MockMeasurementRepository),
 		domain.NewInMemoryEventPublisher(),
 		new(MockIdempotencyService),
+		newTestOutboxPublisher(t),
 	)
 	require.NoError(t, err)
 
@@ -53,6 +54,7 @@ func TestMergePositions_ReturnsUnimplemented(t *testing.T) {
 		new(MockMeasurementRepository),
 		domain.NewInMemoryEventPublisher(),
 		new(MockIdempotencyService),
+		newTestOutboxPublisher(t),
 	)
 	require.NoError(t, err)
 
@@ -84,6 +86,7 @@ func TestUpdatePosition_NilRequest_StillReturnsUnimplemented(t *testing.T) {
 		new(MockMeasurementRepository),
 		domain.NewInMemoryEventPublisher(),
 		new(MockIdempotencyService),
+		newTestOutboxPublisher(t),
 	)
 	require.NoError(t, err)
 
@@ -107,6 +110,7 @@ func TestMergePositions_NilRequest_StillReturnsUnimplemented(t *testing.T) {
 		new(MockMeasurementRepository),
 		domain.NewInMemoryEventPublisher(),
 		new(MockIdempotencyService),
+		newTestOutboxPublisher(t),
 	)
 	require.NoError(t, err)
 

--- a/services/position-keeping/service/balance_integration_test.go
+++ b/services/position-keeping/service/balance_integration_test.go
@@ -81,6 +81,7 @@ func SetupBalanceIntegrationTestContainer(t *testing.T) *BalanceIntegrationTestC
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 	)
 	require.NoError(t, err, "Failed to create service")
 
@@ -132,6 +133,7 @@ func SetupBalanceIntegrationTestContainerWithClient(t *testing.T, client domain.
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithCurrentAccountClient(client),
 	)
 	require.NoError(t, err, "Failed to create service")

--- a/services/position-keeping/service/balance_test.go
+++ b/services/position-keeping/service/balance_test.go
@@ -161,6 +161,7 @@ func TestGetAccountBalance_Success(t *testing.T) {
 				mockMeasurementRepo,
 				mockEventPublisher,
 				mockIdempotency,
+				newTestOutboxPublisher(t),
 				service.WithCurrentAccountClient(mockCurrentAccount),
 			)
 			require.NoError(t, err)
@@ -230,6 +231,7 @@ func TestGetAccountBalance_ValidationErrors(t *testing.T) {
 				mockMeasurementRepo,
 				mockEventPublisher,
 				mockIdempotency,
+				newTestOutboxPublisher(t),
 			)
 			require.NoError(t, err)
 
@@ -282,6 +284,7 @@ func TestGetAccountBalance_NotFound(t *testing.T) {
 				mockMeasurementRepo,
 				mockEventPublisher,
 				mockIdempotency,
+				newTestOutboxPublisher(t),
 			)
 			require.NoError(t, err)
 
@@ -321,6 +324,7 @@ func TestGetAccountBalance_CurrencyFilter(t *testing.T) {
 			mockMeasurementRepo,
 			mockEventPublisher,
 			mockIdempotency,
+			newTestOutboxPublisher(t),
 		)
 		require.NoError(t, err)
 
@@ -354,6 +358,7 @@ func TestGetAccountBalance_CurrencyFilter(t *testing.T) {
 			mockMeasurementRepo,
 			mockEventPublisher,
 			mockIdempotency,
+			newTestOutboxPublisher(t),
 		)
 		require.NoError(t, err)
 
@@ -390,6 +395,7 @@ func TestGetAccountBalance_RepositoryFailure(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 	)
 	require.NoError(t, err)
 
@@ -433,6 +439,7 @@ func TestGetAccountBalance_NoCurrentAccountClient(t *testing.T) {
 				mockMeasurementRepo,
 				mockEventPublisher,
 				mockIdempotency,
+				newTestOutboxPublisher(t),
 			)
 			require.NoError(t, err)
 
@@ -472,6 +479,7 @@ func TestGetAccountBalances_Success(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithCurrentAccountClient(mockCurrentAccount),
 	)
 	require.NoError(t, err)
@@ -522,6 +530,7 @@ func TestGetAccountBalances_WithoutCurrentAccountClient(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 	)
 	require.NoError(t, err)
 
@@ -567,6 +576,7 @@ func TestGetAccountBalances_ValidationErrors(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 	)
 	require.NoError(t, err)
 
@@ -602,6 +612,7 @@ func TestGetAccountBalances_CurrencyFilter(t *testing.T) {
 			mockMeasurementRepo,
 			mockEventPublisher,
 			mockIdempotency,
+			newTestOutboxPublisher(t),
 		)
 		require.NoError(t, err)
 
@@ -634,6 +645,7 @@ func TestGetAccountBalances_CurrencyFilter(t *testing.T) {
 			mockMeasurementRepo,
 			mockEventPublisher,
 			mockIdempotency,
+			newTestOutboxPublisher(t),
 		)
 		require.NoError(t, err)
 
@@ -668,6 +680,7 @@ func TestGetAccountBalances_NotFound(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 	)
 	require.NoError(t, err)
 
@@ -719,6 +732,7 @@ func TestGetAccountBalance_WithLiens(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithCurrentAccountClient(mockCurrentAccount),
 	)
 	require.NoError(t, err)

--- a/services/position-keeping/service/initiate.go
+++ b/services/position-keeping/service/initiate.go
@@ -88,35 +88,11 @@ func (s *PositionKeepingService) InitiateFinancialPositionLog(
 		return nil, status.Errorf(codes.InvalidArgument, "failed to create financial position log: %v", err)
 	}
 
-	// Persist to repository
-	if err := s.repository.Create(ctx, log); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to save financial position log: %v", err)
-	}
-
-	// Publish event using fire-and-forget pattern
-	//
-	// Design Decision: Event publishing does not block the main operation.
-	// The financial position log is already persisted to the database, which is the
-	// authoritative source of truth. Events provide eventual consistency and async
-	// notifications to downstream services.
-	//
-	// Trade-offs:
-	//   - Pro: Request latency is not impacted by event broker availability
-	//   - Pro: Partial failures don't cause transaction rollbacks
-	//   - Con: Events may be lost if publisher fails silently
-	//   - Con: No visibility into publishing failures at request time
-	//
-	// Future Improvements:
-	//   - Add metrics/logging in EventPublisher implementation for observability
-	//   - Consider dead letter queue for failed events
-	//   - Add retry logic with exponential backoff in EventPublisher
-	//   - Monitor event publishing success rates via instrumentation
-	//
-	// The EventPublisher interface returns errors, but we intentionally ignore them
-	// to maintain the fire-and-forget semantics. Error handling and retries should
-	// be implemented within the EventPublisher implementation itself.
+	// Build the domain event (if applicable) before persisting, then write both
+	// the position log and the outbox entry atomically in a single transaction.
+	var events []domain.DomainEvent
 	if initialEntry != nil {
-		event := &domain.TransactionCaptured{
+		events = append(events, &domain.TransactionCaptured{
 			LogID:         log.LogID,
 			AccountID:     log.AccountID,
 			TransactionID: initialEntry.TransactionID,
@@ -127,8 +103,13 @@ func (s *PositionKeepingService) InitiateFinancialPositionLog(
 			Reference:     initialEntry.Reference,
 			Timestamp:     initialEntry.Timestamp,
 			Version:       log.Version,
-		}
-		_ = s.eventPublisher.Publish(ctx, event)
+		})
+	}
+
+	// Persist to repository atomically with outbox event write.
+	outboxFn := s.outboxPublisher.BuildOutboxFn(ctx, events)
+	if err := s.repository.CreateWithOutbox(ctx, log, outboxFn); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to save financial position log: %v", err)
 	}
 
 	// Store idempotency result if key was provided

--- a/services/position-keeping/service/initiate_batch.go
+++ b/services/position-keeping/service/initiate_batch.go
@@ -121,7 +121,10 @@ func (s *PositionKeepingService) InitiateFinancialPositionLogBatch(
 		return nil, status.Errorf(codes.Internal, "failed to persist batch: %v", err)
 	}
 
-	// Publish BulkTransactionCaptured event (fire-and-forget)
+	// Publish BulkTransactionCaptured event to outbox.
+	// NOTE: CreateBatch does not support outbox writes within its internal transaction.
+	// The event is written separately here; the outbox worker delivers it to Kafka.
+	// At-least-once delivery is guaranteed by the outbox pattern.
 	if len(successfulLogs) > 0 {
 		// Safe conversion: successfulLogs length <= MaxBatchSize (10,000)
 		transactionCount := int32(len(successfulLogs)) // #nosec G115
@@ -134,7 +137,9 @@ func (s *PositionKeepingService) InitiateFinancialPositionLogBatch(
 			Timestamp:        time.Now().UTC(),
 			Version:          1,
 		}
-		_ = s.eventPublisher.Publish(batchCtx, event)
+		if err := s.eventPublisher.Publish(batchCtx, event); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to publish batch event: %v", err)
+		}
 	}
 
 	// Store idempotency result if key was provided

--- a/services/position-keeping/service/initiate_batch_test.go
+++ b/services/position-keeping/service/initiate_batch_test.go
@@ -676,7 +676,7 @@ func TestInitiateFinancialPositionLogBatch_NilPointerRegressionOnValidationFailu
 	mockIdempotency := new(MockIdempotencyService)
 	mockMeasurementRepo := new(MockMeasurementRepository)
 
-	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency)
+	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency, newTestOutboxPublisher(t))
 	require.NoError(t, err)
 
 	// Create a batch with alternating valid and invalid entries to maximize

--- a/services/position-keeping/service/initiate_migration.go
+++ b/services/position-keeping/service/initiate_migration.go
@@ -86,11 +86,6 @@ func (s *PositionKeepingService) InitiateWithOpeningBalance(
 		return nil, status.Errorf(codes.InvalidArgument, "failed to create financial position log: %v", err)
 	}
 
-	// Persist to repository
-	if err := s.repository.Create(ctx, log); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to save financial position log: %v", err)
-	}
-
 	// Extract correlation ID from context for end-to-end request tracing,
 	// falling back to log ID if not present in request metadata
 	correlationID := clients.ExtractCorrelationID(ctx)
@@ -98,8 +93,7 @@ func (s *PositionKeepingService) InitiateWithOpeningBalance(
 		correlationID = log.LogID.String()
 	}
 
-	// Publish OpeningBalanceRecorded event using fire-and-forget pattern
-	// (consistent with other endpoints in this service - Kafka producer configured with retries)
+	// Build the OpeningBalanceRecorded event and persist it atomically with the position log.
 	event := &domain.OpeningBalanceRecorded{
 		LogID:              log.LogID,
 		AccountID:          log.AccountID,
@@ -110,7 +104,10 @@ func (s *PositionKeepingService) InitiateWithOpeningBalance(
 		Timestamp:          time.Now().UTC(),
 		Version:            log.Version,
 	}
-	_ = s.eventPublisher.Publish(ctx, event)
+	outboxFn := s.outboxPublisher.BuildOutboxFn(ctx, []domain.DomainEvent{event})
+	if err := s.repository.CreateWithOutbox(ctx, log, outboxFn); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to save financial position log: %v", err)
+	}
 
 	// Store idempotency result if key was provided
 	if idempotencyKey != nil {

--- a/services/position-keeping/service/initiate_migration_test.go
+++ b/services/position-keeping/service/initiate_migration_test.go
@@ -57,7 +57,7 @@ func TestInitiateWithOpeningBalance_Success_PositiveBalance(t *testing.T) {
 		Return(nil)
 
 	// Mock repository create
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
 		Return(nil)
 
 	// Mock idempotency store result
@@ -80,10 +80,8 @@ func TestInitiateWithOpeningBalance_Success_PositiveBalance(t *testing.T) {
 	// Opening balance is immediately posted
 	assert.Equal(t, commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED, resp.Log.StatusTracking.CurrentStatus)
 
-	// Verify event was published
-	events := mockEventPublisher.GetPublishedEvents()
-	assert.Len(t, events, 1, "Expected 1 event to be published")
-	assert.Equal(t, "position_keeping.opening_balance_recorded.v1", events[0].EventType())
+	// Verify event was written to outbox transactionally (CreateWithOutbox was called)
+	mockRepo.AssertCalled(t, "CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog"))
 
 	mockRepo.AssertExpectations(t)
 	mockIdempotency.AssertExpectations(t)
@@ -122,7 +120,7 @@ func TestInitiateWithOpeningBalance_Success_NegativeBalance(t *testing.T) {
 	mockIdempotency.On("MarkPending", ctx, mock.AnythingOfType("idempotency.Key"), mock.AnythingOfType("time.Duration")).
 		Return(nil)
 
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
 		Return(nil)
 
 	mockIdempotency.On("StoreResult", ctx, mock.AnythingOfType("idempotency.Result")).
@@ -197,9 +195,8 @@ func TestInitiateWithOpeningBalance_IdempotencyCheck(t *testing.T) {
 	require.NotNil(t, resp, "Expected non-nil response")
 	assert.Equal(t, cachedLogID, resp.Log.LogId, "Expected cached log ID to be returned")
 
-	// Verify no new events were published
-	events := mockEventPublisher.GetPublishedEvents()
-	assert.Len(t, events, 0, "Expected no new events for idempotent request")
+	// Verify no outbox write occurred (CreateWithOutbox not called for cached response)
+	mockRepo.AssertNotCalled(t, "CreateWithOutbox")
 
 	mockIdempotency.AssertExpectations(t)
 	mockRepo.AssertExpectations(t)
@@ -325,7 +322,7 @@ func TestInitiateWithOpeningBalance_RepositoryError(t *testing.T) {
 		Return(nil)
 
 	// Mock repository create to fail
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
 		Return(assert.AnError)
 
 	// Mock idempotency delete for cleanup on error
@@ -372,7 +369,7 @@ func TestInitiateWithOpeningBalance_WithoutIdempotencyKey(t *testing.T) {
 	}
 
 	// Mock repository create
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
 		Return(nil)
 
 	// Act
@@ -438,7 +435,7 @@ func TestInitiateWithOpeningBalance_StatusPending(t *testing.T) {
 
 	// Verify that MarkPending was NOT called since we returned early
 	mockIdempotency.AssertNotCalled(t, "MarkPending")
-	mockRepo.AssertNotCalled(t, "Create")
+	mockRepo.AssertNotCalled(t, "CreateWithOutbox")
 }
 
 func TestInitiateWithOpeningBalance_ZeroBalance(t *testing.T) {
@@ -465,7 +462,7 @@ func TestInitiateWithOpeningBalance_ZeroBalance(t *testing.T) {
 	}
 
 	// Mock repository create
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
 		Return(nil)
 
 	// Act
@@ -524,7 +521,7 @@ func TestInitiateWithOpeningBalance_IdempotencyCheckError(t *testing.T) {
 
 	// Verify that MarkPending was NOT called since we returned early
 	mockIdempotency.AssertNotCalled(t, "MarkPending")
-	mockRepo.AssertNotCalled(t, "Create")
+	mockRepo.AssertNotCalled(t, "CreateWithOutbox")
 }
 
 // =============================================================================
@@ -567,6 +564,7 @@ func TestInitiateWithOpeningBalance_CEL_ValidationPasses(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -583,7 +581,7 @@ func TestInitiateWithOpeningBalance_CEL_ValidationPasses(t *testing.T) {
 
 	// Setup mock expectations
 	mockCache.On("GetOrLoad", ctx, "USD", 1).Return(cachedInstrument, nil)
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
 
 	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{
 		AccountId: "migrated-account-001",
@@ -624,6 +622,7 @@ func TestInitiateWithOpeningBalance_CEL_ValidationRejects(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -662,7 +661,7 @@ func TestInitiateWithOpeningBalance_CEL_ValidationRejects(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.InvalidArgument, st.Code())
 	assert.Contains(t, st.Message(), "validation failed")
-	mockRepo.AssertNotCalled(t, "Create")
+	mockRepo.AssertNotCalled(t, "CreateWithOutbox")
 	mockCache.AssertExpectations(t)
 }
 
@@ -679,13 +678,14 @@ func TestInitiateWithOpeningBalance_CEL_NilCacheSkipsValidation(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		// No WithInstrumentCache - cache is nil
 	)
 	require.NoError(t, err)
 
 	effectiveDate := time.Now().Add(-24 * time.Hour)
 
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
 
 	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{
 		AccountId: "migrated-account-001",
@@ -725,13 +725,14 @@ func TestInitiateWithOpeningBalance_CEL_EmptyInstrumentCodeSkipsValidation(t *te
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
 
 	effectiveDate := time.Now().Add(-24 * time.Hour)
 
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
 
 	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{
 		AccountId: "migrated-account-001",
@@ -771,6 +772,7 @@ func TestInitiateWithOpeningBalance_CEL_NilValidationProgramPasses(t *testing.T)
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -784,7 +786,7 @@ func TestInitiateWithOpeningBalance_CEL_NilValidationProgramPasses(t *testing.T)
 	}
 
 	mockCache.On("GetOrLoad", ctx, "USD", 1).Return(cachedInstrument, nil)
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
 
 	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{
 		AccountId: "migrated-account-001",
@@ -822,6 +824,7 @@ func TestInitiateWithOpeningBalance_CEL_InstrumentNotFound(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -852,7 +855,7 @@ func TestInitiateWithOpeningBalance_CEL_InstrumentNotFound(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.NotFound, st.Code())
 	assert.Contains(t, st.Message(), "instrument definition not found")
-	mockRepo.AssertNotCalled(t, "Create")
+	mockRepo.AssertNotCalled(t, "CreateWithOutbox")
 	mockCache.AssertExpectations(t)
 }
 
@@ -870,6 +873,7 @@ func TestInitiateWithOpeningBalance_CEL_CacheFailure(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -900,7 +904,7 @@ func TestInitiateWithOpeningBalance_CEL_CacheFailure(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.Internal, st.Code())
 	assert.Contains(t, st.Message(), "failed to load instrument definition")
-	mockRepo.AssertNotCalled(t, "Create")
+	mockRepo.AssertNotCalled(t, "CreateWithOutbox")
 	mockCache.AssertExpectations(t)
 }
 
@@ -917,6 +921,7 @@ func TestInitiateWithOpeningBalance_CEL_ComplexValidationExpression(t *testing.T
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -933,7 +938,7 @@ func TestInitiateWithOpeningBalance_CEL_ComplexValidationExpression(t *testing.T
 	}
 
 	mockCache.On("GetOrLoad", ctx, "ELECTRICITY_KWH", 1).Return(cachedInstrument, nil)
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
 
 	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{
 		AccountId: "migrated-account-001",
@@ -974,6 +979,7 @@ func TestInitiateWithOpeningBalance_CEL_ComplexValidationFails(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -1015,7 +1021,7 @@ func TestInitiateWithOpeningBalance_CEL_ComplexValidationFails(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.InvalidArgument, st.Code())
 	assert.Contains(t, st.Message(), "validation failed")
-	mockRepo.AssertNotCalled(t, "Create")
+	mockRepo.AssertNotCalled(t, "CreateWithOutbox")
 	mockCache.AssertExpectations(t)
 }
 
@@ -1035,6 +1041,7 @@ func TestInitiateWithOpeningBalance_CEL_NegativeAmountPassesValidation(t *testin
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -1051,7 +1058,7 @@ func TestInitiateWithOpeningBalance_CEL_NegativeAmountPassesValidation(t *testin
 	}
 
 	mockCache.On("GetOrLoad", ctx, "USD", 1).Return(cachedInstrument, nil)
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
 
 	// Negative opening balance: -$500.50 (overdraft position)
 	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{

--- a/services/position-keeping/service/initiate_test.go
+++ b/services/position-keeping/service/initiate_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -15,10 +16,22 @@ import (
 
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	"github.com/meridianhub/meridian/services/position-keeping/adapters/messaging"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 	"github.com/meridianhub/meridian/services/position-keeping/service"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
+	"github.com/meridianhub/meridian/shared/platform/events"
 )
+
+// newTestOutboxPublisher creates an OutboxEventPublisher backed by a no-op PgxOutboxRepository
+// for use in unit tests. The pool is nil so any actual DB call would fail, but since tests
+// use MockRepository which never calls the outbox fn, this is safe for unit tests.
+func newTestOutboxPublisher(tb testing.TB) *messaging.OutboxEventPublisher {
+	tb.Helper()
+	pub, err := messaging.NewOutboxEventPublisher(events.NewPgxOutboxRepository(nil))
+	require.NoError(tb, err, "unexpected error creating test outbox publisher")
+	return pub
+}
 
 // mustNewPositionKeepingService creates a service and fails the test if an error occurs.
 // Use this for tests where the service should always be created successfully.
@@ -26,7 +39,7 @@ import (
 func mustNewPositionKeepingService(tb testing.TB, repo domain.FinancialPositionLogRepository, publisher domain.EventPublisher, idempotencySvc idempotency.Service) *service.PositionKeepingService {
 	tb.Helper()
 	mockMeasurementRepo := new(MockMeasurementRepository)
-	svc, err := service.NewPositionKeepingService(repo, mockMeasurementRepo, publisher, idempotencySvc)
+	svc, err := service.NewPositionKeepingService(repo, mockMeasurementRepo, publisher, idempotencySvc, newTestOutboxPublisher(tb))
 	require.NoError(tb, err, "unexpected error creating service")
 	return svc
 }
@@ -63,6 +76,16 @@ func (m *MockRepository) FindByAccountID(ctx context.Context, accountID string) 
 }
 
 func (m *MockRepository) Update(ctx context.Context, log *domain.FinancialPositionLog) error {
+	args := m.Called(ctx, log)
+	return args.Error(0)
+}
+
+func (m *MockRepository) CreateWithOutbox(ctx context.Context, log *domain.FinancialPositionLog, _ func(pgx.Tx) error) error {
+	args := m.Called(ctx, log)
+	return args.Error(0)
+}
+
+func (m *MockRepository) UpdateWithOutbox(ctx context.Context, log *domain.FinancialPositionLog, _ func(pgx.Tx) error) error {
 	args := m.Called(ctx, log)
 	return args.Error(0)
 }
@@ -198,7 +221,7 @@ func TestInitiateFinancialPositionLog_Success(t *testing.T) {
 		Return(nil)
 
 	// Mock repository create
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
 		Return(nil)
 
 	// Mock idempotency store result
@@ -219,10 +242,8 @@ func TestInitiateFinancialPositionLog_Success(t *testing.T) {
 	assert.NotNil(t, resp.Log.StatusTracking, "Expected status tracking to be set")
 	assert.Equal(t, commonv1.TransactionStatus_TRANSACTION_STATUS_PENDING, resp.Log.StatusTracking.CurrentStatus)
 
-	// Verify event was published
-	events := mockEventPublisher.GetPublishedEvents()
-	assert.Len(t, events, 1, "Expected 1 event to be published")
-	assert.Equal(t, "position_keeping.transaction_captured.v1", events[0].EventType())
+	// Verify event was written to outbox transactionally (CreateWithOutbox was called)
+	mockRepo.AssertCalled(t, "CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog"))
 
 	mockRepo.AssertExpectations(t)
 	mockIdempotency.AssertExpectations(t)
@@ -270,9 +291,8 @@ func TestInitiateFinancialPositionLog_IdempotencyCheck(t *testing.T) {
 	require.NotNil(t, resp, "Expected non-nil response")
 	assert.Equal(t, cachedLogID, resp.Log.LogId, "Expected cached log ID to be returned")
 
-	// Verify no new events were published
-	events := mockEventPublisher.GetPublishedEvents()
-	assert.Len(t, events, 0, "Expected no new events for idempotent request")
+	// Verify no outbox write occurred (CreateWithOutbox not called for cached response)
+	mockRepo.AssertNotCalled(t, "CreateWithOutbox")
 
 	mockIdempotency.AssertExpectations(t)
 	mockRepo.AssertExpectations(t)
@@ -380,7 +400,7 @@ func TestInitiateFinancialPositionLog_RepositoryError(t *testing.T) {
 		Return(nil)
 
 	// Mock repository create to fail
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
 		Return(assert.AnError)
 
 	// Mock idempotency delete for cleanup on error
@@ -466,7 +486,7 @@ func TestInitiateFinancialPositionLog_StoreResultError(t *testing.T) {
 		Return(nil)
 
 	// Mock repository create
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
 		Return(nil)
 
 	// Mock idempotency store result to fail

--- a/services/position-keeping/service/initiate_validation_test.go
+++ b/services/position-keeping/service/initiate_validation_test.go
@@ -42,6 +42,7 @@ func TestInitiateFinancialPositionLog_AccountValidation_Enabled_ValidAccount(t *
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithAccountValidator(mockValidator),
 		service.WithAccountValidationEnabled(true),
 	)
@@ -78,7 +79,7 @@ func TestInitiateFinancialPositionLog_AccountValidation_Enabled_ValidAccount(t *
 	mockValidator.On("ValidateExists", ctx, "valid-account-123").Return(nil)
 
 	// Mock repository create
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
 
 	// Mock idempotency store result
 	mockIdempotency.On("StoreResult", ctx, mock.AnythingOfType("idempotency.Result")).Return(nil)
@@ -109,6 +110,7 @@ func TestInitiateFinancialPositionLog_AccountValidation_Enabled_InvalidAccount(t
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithAccountValidator(mockValidator),
 		service.WithAccountValidationEnabled(true),
 	)
@@ -159,7 +161,7 @@ func TestInitiateFinancialPositionLog_AccountValidation_Enabled_InvalidAccount(t
 
 	// Verify validator was called but repository was NOT called
 	mockValidator.AssertCalled(t, "ValidateExists", ctx, "invalid-account-456")
-	mockRepo.AssertNotCalled(t, "Create")
+	mockRepo.AssertNotCalled(t, "CreateWithOutbox")
 }
 
 func TestInitiateFinancialPositionLog_AccountValidation_Disabled_SkipsValidation(t *testing.T) {
@@ -176,6 +178,7 @@ func TestInitiateFinancialPositionLog_AccountValidation_Disabled_SkipsValidation
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithAccountValidator(mockValidator),
 		// WithAccountValidationEnabled not called - defaults to false
 	)
@@ -209,7 +212,7 @@ func TestInitiateFinancialPositionLog_AccountValidation_Disabled_SkipsValidation
 		Return(nil)
 
 	// Mock repository create - should be called since validation is disabled
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
 	mockIdempotency.On("StoreResult", ctx, mock.AnythingOfType("idempotency.Result")).Return(nil)
 
 	// Act
@@ -222,7 +225,7 @@ func TestInitiateFinancialPositionLog_AccountValidation_Disabled_SkipsValidation
 	// Verify validator was NOT called (validation disabled)
 	mockValidator.AssertNotCalled(t, "ValidateExists")
 	// Verify repository WAS called (position log created)
-	mockRepo.AssertCalled(t, "Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog"))
+	mockRepo.AssertCalled(t, "CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog"))
 }
 
 func TestInitiateFinancialPositionLog_AccountValidation_ValidatorNil_SkipsValidation(t *testing.T) {
@@ -238,6 +241,7 @@ func TestInitiateFinancialPositionLog_AccountValidation_ValidatorNil_SkipsValida
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithAccountValidationEnabled(true), // Enabled but...
 		// WithAccountValidator not called - validator is nil
 	)
@@ -271,7 +275,7 @@ func TestInitiateFinancialPositionLog_AccountValidation_ValidatorNil_SkipsValida
 		Return(nil)
 
 	// Mock repository create - should be called since validator is nil
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
 	mockIdempotency.On("StoreResult", ctx, mock.AnythingOfType("idempotency.Result")).Return(nil)
 
 	// Act
@@ -282,7 +286,7 @@ func TestInitiateFinancialPositionLog_AccountValidation_ValidatorNil_SkipsValida
 	require.NotNil(t, resp)
 
 	// Verify repository WAS called (position log created despite enabled flag)
-	mockRepo.AssertCalled(t, "Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog"))
+	mockRepo.AssertCalled(t, "CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog"))
 }
 
 func TestInitiateFinancialPositionLog_AccountValidation_GracefulDegradation(t *testing.T) {
@@ -298,6 +302,7 @@ func TestInitiateFinancialPositionLog_AccountValidation_GracefulDegradation(t *t
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithAccountValidator(mockValidator),
 		service.WithAccountValidationEnabled(true),
 	)
@@ -335,7 +340,7 @@ func TestInitiateFinancialPositionLog_AccountValidation_GracefulDegradation(t *t
 	mockValidator.On("ValidateExists", ctx, "graceful-account-123").Return(nil)
 
 	// Mock repository create - should be called due to graceful degradation
-	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+	mockRepo.On("CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
 	mockIdempotency.On("StoreResult", ctx, mock.AnythingOfType("idempotency.Result")).Return(nil)
 
 	// Act
@@ -346,7 +351,7 @@ func TestInitiateFinancialPositionLog_AccountValidation_GracefulDegradation(t *t
 	require.NotNil(t, resp)
 
 	// Verify position log was created despite potential service unavailability
-	mockRepo.AssertCalled(t, "Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog"))
+	mockRepo.AssertCalled(t, "CreateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog"))
 }
 
 func TestWithAccountValidator_Option(t *testing.T) {
@@ -362,6 +367,7 @@ func TestWithAccountValidator_Option(t *testing.T) {
 			mockMeasurementRepo,
 			mockEventPublisher,
 			mockIdempotency,
+			newTestOutboxPublisher(t),
 			service.WithAccountValidator(mockValidator),
 		)
 		require.NoError(t, err)
@@ -374,6 +380,7 @@ func TestWithAccountValidator_Option(t *testing.T) {
 			mockMeasurementRepo,
 			mockEventPublisher,
 			mockIdempotency,
+			newTestOutboxPublisher(t),
 			service.WithAccountValidator(nil),
 		)
 		require.NoError(t, err)
@@ -393,6 +400,7 @@ func TestWithAccountValidationEnabled_Option(t *testing.T) {
 			mockMeasurementRepo,
 			mockEventPublisher,
 			mockIdempotency,
+			newTestOutboxPublisher(t),
 			service.WithAccountValidationEnabled(true),
 		)
 		require.NoError(t, err)
@@ -405,6 +413,7 @@ func TestWithAccountValidationEnabled_Option(t *testing.T) {
 			mockMeasurementRepo,
 			mockEventPublisher,
 			mockIdempotency,
+			newTestOutboxPublisher(t),
 			service.WithAccountValidationEnabled(false),
 		)
 		require.NoError(t, err)

--- a/services/position-keeping/service/record_measurement_test.go
+++ b/services/position-keeping/service/record_measurement_test.go
@@ -30,7 +30,7 @@ func TestRecordMeasurement_Success(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency)
+	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency, newTestOutboxPublisher(t))
 	require.NoError(t, err)
 
 	logID := uuid.New()
@@ -82,7 +82,7 @@ func TestRecordMeasurement_ValidatesMeasurementTypeRequired(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency)
+	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency, newTestOutboxPublisher(t))
 	require.NoError(t, err)
 
 	req := &positionkeepingv1.RecordMeasurementRequest{
@@ -111,7 +111,7 @@ func TestRecordMeasurement_RejectsNegativeValue(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency)
+	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency, newTestOutboxPublisher(t))
 	require.NoError(t, err)
 
 	logID := uuid.New()
@@ -159,7 +159,7 @@ func TestRecordMeasurement_RejectsFutureTimestamp(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency)
+	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency, newTestOutboxPublisher(t))
 	require.NoError(t, err)
 
 	logID := uuid.New()
@@ -208,7 +208,7 @@ func TestRecordMeasurement_PositionStateNotFound(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency)
+	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency, newTestOutboxPublisher(t))
 	require.NoError(t, err)
 
 	logID := uuid.New()
@@ -241,7 +241,7 @@ func TestRecordMeasurement_InvalidPositionStateId(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency)
+	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency, newTestOutboxPublisher(t))
 	require.NoError(t, err)
 
 	req := &positionkeepingv1.RecordMeasurementRequest{
@@ -269,7 +269,7 @@ func TestRecordMeasurement_Idempotency_DuplicateKeyReturnsCachedResult(t *testin
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency)
+	svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency, newTestOutboxPublisher(t))
 	require.NoError(t, err)
 
 	logID := uuid.New()
@@ -369,7 +369,7 @@ func TestRecordMeasurement_RequiredFieldValidation(t *testing.T) {
 			mockEventPublisher := domain.NewInMemoryEventPublisher()
 			mockIdempotency := new(MockIdempotencyService)
 
-			svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency)
+			svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency, newTestOutboxPublisher(t))
 			require.NoError(t, err)
 
 			resp, err := svc.RecordMeasurement(ctx, tt.req)
@@ -405,7 +405,7 @@ func TestRecordMeasurement_MeasurementTypes(t *testing.T) {
 			mockEventPublisher := domain.NewInMemoryEventPublisher()
 			mockIdempotency := new(MockIdempotencyService)
 
-			svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency)
+			svc, err := service.NewPositionKeepingService(mockRepo, mockMeasurementRepo, mockEventPublisher, mockIdempotency, newTestOutboxPublisher(t))
 			require.NoError(t, err)
 
 			logID := uuid.New()
@@ -570,6 +570,7 @@ func TestRecordMeasurement_CEL_ValidationPasses(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -636,6 +637,7 @@ func TestRecordMeasurement_CEL_ValidationRejects(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -703,6 +705,7 @@ func TestRecordMeasurement_CEL_NilCacheSkipsValidation(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		// No WithInstrumentCache - cache is nil
 	)
 	require.NoError(t, err)
@@ -756,6 +759,7 @@ func TestRecordMeasurement_CEL_NilValidationProgramPasses(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -817,6 +821,7 @@ func TestRecordMeasurement_CEL_InstrumentNotFound(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -907,6 +912,7 @@ func TestRecordMeasurement_BucketKey_GeneratesKey(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -974,6 +980,7 @@ func TestRecordMeasurement_BucketKey_SameAttributesProduceSameKey(t *testing.T) 
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -1055,6 +1062,7 @@ func TestRecordMeasurement_BucketKey_NilProgramProducesEmptyBucketID(t *testing.
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -1123,6 +1131,7 @@ func TestRecordMeasurement_Cardinality_RejectsWhenLimitExceeded(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 		service.WithBucketCounter(mockBucketCounter),
 	)
@@ -1194,6 +1203,7 @@ func TestRecordMeasurement_Cardinality_AllowsUnderLimit(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 		service.WithBucketCounter(mockBucketCounter),
 	)
@@ -1263,6 +1273,7 @@ func TestRecordMeasurement_Cardinality_SkipsCheckWhenNoBucketCounter(t *testing.
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 		// WithBucketCounter NOT called - counter is nil
 	)
@@ -1330,6 +1341,7 @@ func TestRecordMeasurement_Cardinality_SkipsCheckWhenNoBucketKey(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 		service.WithBucketCounter(mockBucketCounter),
 	)
@@ -1397,6 +1409,7 @@ func TestRecordMeasurement_BucketKey_ErrorReturnsInvalidArgument(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -1469,6 +1482,7 @@ func TestRecordMeasurement_BucketID_PassedToDomain(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -1548,6 +1562,7 @@ func TestRecordMeasurement_BucketID_EmptyWhenNoBucketKeyProgram(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		service.WithInstrumentCache(mockCache),
 	)
 	require.NoError(t, err)
@@ -1623,6 +1638,7 @@ func TestRecordMeasurement_BucketID_EmptyWhenNoCacheConfigured(t *testing.T) {
 		mockMeasurementRepo,
 		mockEventPublisher,
 		mockIdempotency,
+		newTestOutboxPublisher(t),
 		// No WithInstrumentCache - cache is nil
 	)
 	require.NoError(t, err)

--- a/services/position-keeping/service/reservation_test.go
+++ b/services/position-keeping/service/reservation_test.go
@@ -143,7 +143,7 @@ func newServiceWithReservation(t *testing.T, reservationRepo domain.ReservationR
 		opts = append(opts, service.WithPositionRepository(positionRepo))
 	}
 
-	svc, err := service.NewPositionKeepingService(repo, measurementRepo, publisher, idempotencySvc, opts...)
+	svc, err := service.NewPositionKeepingService(repo, measurementRepo, publisher, idempotencySvc, newTestOutboxPublisher(t), opts...)
 	require.NoError(t, err)
 	return svc
 }

--- a/services/position-keeping/service/service.go
+++ b/services/position-keeping/service/service.go
@@ -11,6 +11,7 @@ import (
 
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	"github.com/meridianhub/meridian/services/position-keeping/adapters/messaging"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 )
@@ -25,6 +26,8 @@ var (
 	ErrIdempotencyServiceNil = errors.New("position keeping service: idempotency service cannot be nil")
 	// ErrMeasurementRepoNil is returned when attempting to create a service with a nil measurement repository
 	ErrMeasurementRepoNil = errors.New("position keeping service: measurement repository cannot be nil")
+	// ErrOutboxPublisherNil is returned when attempting to create a service with a nil outbox publisher
+	ErrOutboxPublisherNil = errors.New("position keeping service: outbox publisher cannot be nil")
 )
 
 // MaxBucketsPerAccountInstrument is the maximum number of distinct buckets allowed
@@ -39,6 +42,7 @@ type PositionKeepingService struct {
 	repository      domain.FinancialPositionLogRepository
 	measurementRepo domain.MeasurementRepository
 	eventPublisher  domain.EventPublisher
+	outboxPublisher *messaging.OutboxEventPublisher
 	idempotency     idempotency.Service
 	// instrumentCache is OPTIONAL - if nil, CEL validation is skipped.
 	// This allows backwards compatibility with existing deployments.
@@ -137,6 +141,7 @@ func WithPositionRepository(repo domain.PositionRepository) Option {
 //   - measurementRepo: Persistence layer for measurements (must not be nil)
 //   - eventPublisher: Publishes domain events (must not be nil)
 //   - idempotencySvc: Ensures exactly-once processing of idempotent operations (must not be nil)
+//   - outboxPublisher: Publishes events via transactional outbox (must not be nil)
 //
 // Optional dependencies can be provided via Option functions:
 //   - WithInstrumentCache: Enables CEL validation of measurements against instrument definitions
@@ -147,6 +152,7 @@ func NewPositionKeepingService(
 	measurementRepo domain.MeasurementRepository,
 	eventPublisher domain.EventPublisher,
 	idempotencySvc idempotency.Service,
+	outboxPublisher *messaging.OutboxEventPublisher,
 	opts ...Option,
 ) (*PositionKeepingService, error) {
 	if repository == nil {
@@ -161,11 +167,15 @@ func NewPositionKeepingService(
 	if idempotencySvc == nil {
 		return nil, ErrIdempotencyServiceNil
 	}
+	if outboxPublisher == nil {
+		return nil, ErrOutboxPublisherNil
+	}
 
 	svc := &PositionKeepingService{
 		repository:      repository,
 		measurementRepo: measurementRepo,
 		eventPublisher:  eventPublisher,
+		outboxPublisher: outboxPublisher,
 		idempotency:     idempotencySvc,
 	}
 

--- a/services/position-keeping/service/service_test.go
+++ b/services/position-keeping/service/service_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	messagingpkg "github.com/meridianhub/meridian/services/position-keeping/adapters/messaging"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 	"github.com/meridianhub/meridian/services/position-keeping/service"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
@@ -17,8 +18,9 @@ func TestNewPositionKeepingService(t *testing.T) {
 		measurementRepo := new(MockMeasurementRepository)
 		publisher := domain.NewInMemoryEventPublisher()
 		idempotencySvc := new(MockIdempotencyService)
+		outboxPub := newTestOutboxPublisher(t)
 
-		svc, err := service.NewPositionKeepingService(repo, measurementRepo, publisher, idempotencySvc)
+		svc, err := service.NewPositionKeepingService(repo, measurementRepo, publisher, idempotencySvc, outboxPub)
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
@@ -32,12 +34,15 @@ func TestNewPositionKeepingService(t *testing.T) {
 // Rationale: Financial services must validate all dependencies to prevent runtime panics
 // that could cause service outages or data corruption.
 func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
+	validOutboxPub := newTestOutboxPublisher(t)
+
 	tests := []struct {
 		name            string
 		repository      domain.FinancialPositionLogRepository
 		measurementRepo domain.MeasurementRepository
 		eventPub        domain.EventPublisher
 		idempotencySvc  idempotency.Service
+		outboxPub       *messagingpkg.OutboxEventPublisher
 		wantErr         bool
 		wantSentinel    error // Expected sentinel error for errors.Is() verification
 		rationale       string
@@ -48,6 +53,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			measurementRepo: new(MockMeasurementRepository),
 			eventPub:        domain.NewInMemoryEventPublisher(),
 			idempotencySvc:  new(MockIdempotencyService),
+			outboxPub:       validOutboxPub,
 			wantErr:         false,
 			wantSentinel:    nil,
 			rationale:       "Standard valid initialization with all dependencies",
@@ -58,6 +64,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			measurementRepo: new(MockMeasurementRepository),
 			eventPub:        domain.NewInMemoryEventPublisher(),
 			idempotencySvc:  new(MockIdempotencyService),
+			outboxPub:       validOutboxPub,
 			wantErr:         true,
 			wantSentinel:    service.ErrRepositoryNil,
 			rationale:       "Repository is essential - nil would cause panic on first use",
@@ -68,6 +75,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			measurementRepo: nil,
 			eventPub:        domain.NewInMemoryEventPublisher(),
 			idempotencySvc:  new(MockIdempotencyService),
+			outboxPub:       validOutboxPub,
 			wantErr:         true,
 			wantSentinel:    service.ErrMeasurementRepoNil,
 			rationale:       "Measurement repository is essential - nil would cause panic on measurement operations",
@@ -78,6 +86,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			measurementRepo: new(MockMeasurementRepository),
 			eventPub:        nil,
 			idempotencySvc:  new(MockIdempotencyService),
+			outboxPub:       validOutboxPub,
 			wantErr:         true,
 			wantSentinel:    service.ErrEventPublisherNil,
 			rationale:       "Event publisher is essential - nil would cause panic when publishing events",
@@ -88,9 +97,21 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			measurementRepo: new(MockMeasurementRepository),
 			eventPub:        domain.NewInMemoryEventPublisher(),
 			idempotencySvc:  nil,
+			outboxPub:       validOutboxPub,
 			wantErr:         true,
 			wantSentinel:    service.ErrIdempotencyServiceNil,
 			rationale:       "Idempotency service is essential - nil would cause panic on idempotent operations",
+		},
+		{
+			name:            "nil outbox publisher",
+			repository:      new(MockRepository),
+			measurementRepo: new(MockMeasurementRepository),
+			eventPub:        domain.NewInMemoryEventPublisher(),
+			idempotencySvc:  new(MockIdempotencyService),
+			outboxPub:       nil,
+			wantErr:         true,
+			wantSentinel:    service.ErrOutboxPublisherNil,
+			rationale:       "Outbox publisher is essential - nil would cause panic when publishing events transactionally",
 		},
 		{
 			name:            "all dependencies nil",
@@ -98,6 +119,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			measurementRepo: nil,
 			eventPub:        nil,
 			idempotencySvc:  nil,
+			outboxPub:       nil,
 			wantErr:         true,
 			wantSentinel:    service.ErrRepositoryNil,
 			rationale:       "Should error on first nil check (repository)",
@@ -106,7 +128,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc, err := service.NewPositionKeepingService(tt.repository, tt.measurementRepo, tt.eventPub, tt.idempotencySvc)
+			svc, err := service.NewPositionKeepingService(tt.repository, tt.measurementRepo, tt.eventPub, tt.idempotencySvc, tt.outboxPub)
 			if tt.wantErr {
 				assert.Error(t, err, tt.rationale)
 				assert.Nil(t, svc, "Service should be nil when error occurs")
@@ -126,8 +148,9 @@ func TestServiceImplementsGRPCInterface(t *testing.T) {
 		measurementRepo := new(MockMeasurementRepository)
 		publisher := domain.NewInMemoryEventPublisher()
 		idempotencySvc := new(MockIdempotencyService)
+		outboxPub := newTestOutboxPublisher(t)
 
-		svc, err := service.NewPositionKeepingService(repo, measurementRepo, publisher, idempotencySvc)
+		svc, err := service.NewPositionKeepingService(repo, measurementRepo, publisher, idempotencySvc, outboxPub)
 		if err != nil {
 			t.Fatalf("unexpected error creating service: %v", err)
 		}

--- a/services/position-keeping/service/update.go
+++ b/services/position-keeping/service/update.go
@@ -107,13 +107,20 @@ func (s *PositionKeepingService) UpdateFinancialPositionLog(
 		}
 	}
 
-	// Update the log in repository
-	if err := s.repository.Update(ctx, log); err != nil {
+	// Collect domain events for the changes
+	updateEvents := s.collectUpdateEvents(ctx, log, req, newEntryAdded, statusChanged)
+
+	// Update the log in repository atomically with outbox event writes.
+	outboxFn := s.outboxPublisher.BuildOutboxFn(ctx, updateEvents)
+	if err := s.repository.UpdateWithOutbox(ctx, log, outboxFn); err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "financial position log not found: %s", logID)
+		}
+		if errors.Is(err, domain.ErrOptimisticLock) {
+			return nil, status.Errorf(codes.Aborted, "version conflict during update: %v", err)
+		}
 		return nil, status.Errorf(codes.Internal, "failed to update financial position log: %v", err)
 	}
-
-	// Publish events for the changes
-	s.publishUpdateEvents(ctx, log, req, newEntryAdded, statusChanged)
 
 	// Store idempotency result if key was provided
 	if idempotencyKey != nil {
@@ -359,18 +366,20 @@ func extractSystemContext(ctx context.Context) map[string]string {
 	return systemCtx
 }
 
-// publishUpdateEvents publishes domain events for update operations
-func (s *PositionKeepingService) publishUpdateEvents(
+// collectUpdateEvents collects domain events for update operations.
+// Returns the events to be written to the outbox within the same transaction as the update.
+func (s *PositionKeepingService) collectUpdateEvents(
 	ctx context.Context,
 	log *domain.FinancialPositionLog,
 	req *positionkeepingv1.UpdateFinancialPositionLogRequest,
 	newEntryAdded *domain.TransactionLogEntry,
 	statusChanged bool,
-) {
+) []domain.DomainEvent {
 	correlationID := clients.ExtractCorrelationID(ctx)
+	var evts []domain.DomainEvent
 
 	if newEntryAdded != nil {
-		event := &domain.TransactionAmended{
+		evts = append(evts, &domain.TransactionAmended{
 			LogID:         log.LogID,
 			AccountID:     log.AccountID,
 			Reason:        "Transaction entry added",
@@ -378,25 +387,29 @@ func (s *PositionKeepingService) publishUpdateEvents(
 			CorrelationID: correlationID,
 			Timestamp:     time.Now().UTC(),
 			Version:       log.Version,
-		}
-		_ = s.eventPublisher.Publish(ctx, event)
+		})
 	}
 
 	if statusChanged {
-		s.publishStatusChangeEvent(ctx, log, req, correlationID)
+		if evt := s.buildStatusChangeEvent(ctx, log, req, correlationID); evt != nil {
+			evts = append(evts, evt)
+		}
 	}
+
+	return evts
 }
 
-// publishStatusChangeEvent publishes appropriate event for status transitions
-func (s *PositionKeepingService) publishStatusChangeEvent(
-	ctx context.Context,
+// buildStatusChangeEvent returns the appropriate domain event for a status transition,
+// or nil if the status does not produce an event.
+func (s *PositionKeepingService) buildStatusChangeEvent(
+	_ context.Context,
 	log *domain.FinancialPositionLog,
 	req *positionkeepingv1.UpdateFinancialPositionLogRequest,
 	correlationID string,
-) {
+) domain.DomainEvent {
 	switch req.StatusUpdate.CurrentStatus {
 	case commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED:
-		event := &domain.TransactionPosted{
+		return &domain.TransactionPosted{
 			LogID:            log.LogID,
 			AccountID:        log.AccountID,
 			PostingReference: "", // Populate when PostingReference is added to proto
@@ -406,9 +419,8 @@ func (s *PositionKeepingService) publishStatusChangeEvent(
 			Timestamp:        time.Now().UTC(),
 			Version:          log.Version,
 		}
-		_ = s.eventPublisher.Publish(ctx, event)
 	case commonv1.TransactionStatus_TRANSACTION_STATUS_FAILED:
-		event := &domain.TransactionFailed{
+		return &domain.TransactionFailed{
 			LogID:         log.LogID,
 			AccountID:     log.AccountID,
 			FailureReason: req.StatusUpdate.StatusReason,
@@ -417,9 +429,8 @@ func (s *PositionKeepingService) publishStatusChangeEvent(
 			Timestamp:     time.Now().UTC(),
 			Version:       log.Version,
 		}
-		_ = s.eventPublisher.Publish(ctx, event)
 	case commonv1.TransactionStatus_TRANSACTION_STATUS_CANCELLED:
-		event := &domain.TransactionCancelled{
+		return &domain.TransactionCancelled{
 			LogID:         log.LogID,
 			AccountID:     log.AccountID,
 			Reason:        req.StatusUpdate.StatusReason,
@@ -428,12 +439,12 @@ func (s *PositionKeepingService) publishStatusChangeEvent(
 			Timestamp:     time.Now().UTC(),
 			Version:       log.Version,
 		}
-		_ = s.eventPublisher.Publish(ctx, event)
 	case commonv1.TransactionStatus_TRANSACTION_STATUS_UNSPECIFIED,
 		commonv1.TransactionStatus_TRANSACTION_STATUS_PENDING,
 		commonv1.TransactionStatus_TRANSACTION_STATUS_REVERSED:
-		// No events for these statuses (REVERSED cannot be set via Update operation)
+		// No event for unspecified, pending, or reversed status transitions
+		return nil
 	default:
-		// No event for other statuses
+		return nil
 	}
 }

--- a/services/position-keeping/service/update_test.go
+++ b/services/position-keeping/service/update_test.go
@@ -88,7 +88,7 @@ func TestUpdateFinancialPositionLog_AddNewEntry(t *testing.T) {
 		Return(existingLog, nil)
 
 	// Mock repository Update to succeed
-	mockRepo.On("Update", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
+	mockRepo.On("UpdateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
 		Return(nil)
 
 	// Mock idempotency store result
@@ -154,7 +154,7 @@ func TestUpdateFinancialPositionLog_UpdateStatus(t *testing.T) {
 		Return(existingLog, nil)
 
 	// Mock repository Update to succeed
-	mockRepo.On("Update", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
+	mockRepo.On("UpdateWithOutbox", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).
 		Return(nil)
 
 	// Act


### PR DESCRIPTION
## Summary

Migrates the position-keeping service event publishing from a fire-and-forget Kafka publisher to the transactional outbox pattern, guaranteeing at-least-once delivery and atomicity between business writes and event emission.

- Introduces `OutboxEventPublisher` adapter in `services/position-keeping/adapters/messaging/`
- Adds `CreateWithOutbox` / `UpdateWithOutbox` to `FinancialPositionLogRepository` interface and `PostgresRepository` implementation, accepting a `func(pgx.Tx) error` callback that writes outbox entries within the same pgx transaction
- Refactors service layer (`initiate.go`, `initiate_migration.go`, `update.go`) to build outbox callbacks via `OutboxEventPublisher.BuildOutboxFn` and pass them to the new repository methods
- Fixes the previous silent error discard (`_ = s.eventPublisher.Publish()`): all publish errors now propagate and fail the operation
- Registers 9 event topics: `TransactionCaptured`, `TransactionAmended`, `TransactionReconciled`, `TransactionPosted`, `TransactionRejected`, `TransactionFailed`, `TransactionCancelled`, `BulkTransactionCaptured`, `OpeningBalanceRecorded`
- Wires `OutboxEventPublisher` into the service container and binary entry point
- Updates all service-layer unit tests to use `CreateWithOutbox`/`UpdateWithOutbox` mock expectations

## Changes Made

| Layer | File | Change |
|-------|------|--------|
| Adapter | `adapters/messaging/outbox_event_publisher.go` | New transactional outbox publisher |
| Domain | `domain/repository.go` | Add `CreateWithOutbox`, `UpdateWithOutbox` to interface |
| Persistence | `adapters/persistence/postgres_repository.go` | Implement new transactional write methods |
| Service | `service/initiate.go` | Use `CreateWithOutbox` with outbox callback |
| Service | `service/initiate_migration.go` | Use `CreateWithOutbox` / `UpdateWithOutbox` with outbox callback |
| Service | `service/update.go` | Use `UpdateWithOutbox` with outbox callback; fix exhaustive switch |
| Service | `service/service.go` | Add `outboxPublisher` parameter; add `ErrOutboxPublisherNil` guard |
| Container | `service/container.go` | Wire `OutboxEventPublisher` |
| Binary | `cmd/meridian/main.go` | Wire `PgxOutboxRepository` + `OutboxEventPublisher` |
| Tests | `service/*_test.go` | Update mock expectations and helper functions |

## Technical Details

Position-keeping uses pgx directly (not GORM), so the outbox writes use `events.PgxOutboxRepository.InsertWithPgxTx(ctx, pgx.Tx, *EventOutbox)` rather than the GORM-based variant used in financial-accounting.

The `func(pgx.Tx) error` callback pattern ensures event outbox writes are atomic with the business row insert/update: the repository opens a transaction, runs the SQL, calls `postFn(tx)`, then commits or rolls back atomically.

Batch operations (`CreateBatch`) continue using the existing `eventPublisher.Publish()` path with proper error propagation, as they do not have single-row transactional semantics.

## Testing

- All existing unit tests updated to mock `CreateWithOutbox`/`UpdateWithOutbox`
- `go test ./services/position-keeping/... -short` passes
- Pre-commit hooks pass (Gitleaks, gofumpt, golangci-lint)

## Risk Assessment

Low risk — this is a drop-in replacement for the existing publisher. The outbox pattern is already in production for financial-accounting; this applies the same pattern to position-keeping.