### PR TITLE
feat: add protovalidate enforcement at outbox publish boundary

### DIFF
--- a/shared/platform/events/publisher.go
+++ b/shared/platform/events/publisher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"buf.build/go/protovalidate"
 	"google.golang.org/protobuf/proto"
 	"gorm.io/gorm"
 )
@@ -15,16 +16,23 @@ import (
 // The background Worker then processes these events asynchronously and publishes them to Kafka.
 type OutboxPublisher struct {
 	serviceName string
+	validator   protovalidate.Validator
 }
 
 // NewOutboxPublisher creates a new OutboxPublisher for the given service.
 // Panics if serviceName is empty to fail fast during initialization.
+// Panics if the protovalidate validator cannot be created.
 func NewOutboxPublisher(serviceName string) *OutboxPublisher {
 	if serviceName == "" {
 		panic("events: " + ErrEmptyServiceName.Error())
 	}
+	validator, err := protovalidate.New()
+	if err != nil {
+		panic(fmt.Sprintf("events: failed to create protovalidate validator: %v", err))
+	}
 	return &OutboxPublisher{
 		serviceName: serviceName,
+		validator:   validator,
 	}
 }
 
@@ -98,6 +106,13 @@ func (p *OutboxPublisher) Publish(
 	}
 	if config.AggregateType == "" {
 		return ErrEmptyAggregateType
+	}
+
+	// Validate the protobuf event against its buf/validate constraints.
+	// This enforces schema correctness before the event enters the outbox.
+	// Once in the outbox, events are considered proven valid.
+	if err := p.validator.Validate(event); err != nil {
+		return fmt.Errorf("event payload validation failed: %w", err)
 	}
 
 	// Serialize the protobuf event

--- a/shared/platform/events/publisher_integration_test.go
+++ b/shared/platform/events/publisher_integration_test.go
@@ -1,0 +1,100 @@
+package events
+
+import (
+	"context"
+	"testing"
+
+	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
+)
+
+// TestOutboxPublisher_ProtovalidateIntegration verifies protovalidate enforcement at the
+// outbox boundary using a real CockroachDB instance (production parity).
+func TestOutboxPublisher_ProtovalidateIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db, cleanup := testdb.SetupCockroachDB(t, []interface{}{&EventOutbox{}})
+	defer cleanup()
+
+	publisher := NewOutboxPublisher("integration-test-service")
+	ctx := context.Background()
+
+	baseConfig := PublishConfig{
+		EventType:     "events.transaction_captured.v1",
+		AggregateID:   "550e8400-e29b-41d4-a716-446655440000",
+		AggregateType: "FinancialPositionLog",
+		Topic:         "position-keeping.events.v1",
+		CorrelationID: "integ-corr-123",
+	}
+
+	validEvent := func() *eventsv1.TransactionCapturedEvent {
+		return &eventsv1.TransactionCapturedEvent{
+			LogId:          "550e8400-e29b-41d4-a716-446655440000",
+			AccountId:      "account-123",
+			TransactionId:  "550e8400-e29b-41d4-a716-446655440001",
+			AmountCents:    100,
+			InstrumentCode: "GBP",
+			Direction:      "DEBIT",
+			Source:         "MANUAL",
+			CorrelationId:  "integ-corr-123",
+			Timestamp:      timestamppb.Now(),
+			Version:        1,
+		}
+	}
+
+	t.Run("valid TransactionCapturedEvent is written to CockroachDB outbox", func(t *testing.T) {
+		db.Where("1=1").Delete(&EventOutbox{})
+
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return publisher.Publish(ctx, tx, validEvent(), baseConfig)
+		})
+
+		require.NoError(t, err)
+
+		var count int64
+		db.Model(&EventOutbox{}).Count(&count)
+		assert.Equal(t, int64(1), count)
+	})
+
+	t.Run("invalid UUID rejected and no entry written to CockroachDB outbox", func(t *testing.T) {
+		db.Where("1=1").Delete(&EventOutbox{})
+
+		event := validEvent()
+		event.LogId = "not-a-valid-uuid"
+
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return publisher.Publish(ctx, tx, event, baseConfig)
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "event payload validation failed")
+
+		var count int64
+		db.Model(&EventOutbox{}).Count(&count)
+		assert.Equal(t, int64(0), count, "no outbox entry must exist after validation failure")
+	})
+
+	t.Run("missing required timestamp rejected and no entry written to CockroachDB outbox", func(t *testing.T) {
+		db.Where("1=1").Delete(&EventOutbox{})
+
+		event := validEvent()
+		event.Timestamp = nil
+
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return publisher.Publish(ctx, tx, event, baseConfig)
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "event payload validation failed")
+
+		var count int64
+		db.Model(&EventOutbox{}).Count(&count)
+		assert.Equal(t, int64(0), count, "no outbox entry must exist after validation failure")
+	})
+}

--- a/shared/platform/events/publisher_integration_test.go
+++ b/shared/platform/events/publisher_integration_test.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"testing"
 
-	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"gorm.io/gorm"
 )
 
@@ -33,20 +31,8 @@ func TestOutboxPublisher_ProtovalidateIntegration(t *testing.T) {
 		CorrelationID: "integ-corr-123",
 	}
 
-	validEvent := func() *eventsv1.TransactionCapturedEvent {
-		return &eventsv1.TransactionCapturedEvent{
-			LogId:          "550e8400-e29b-41d4-a716-446655440000",
-			AccountId:      "account-123",
-			TransactionId:  "550e8400-e29b-41d4-a716-446655440001",
-			AmountCents:    100,
-			InstrumentCode: "GBP",
-			Direction:      "DEBIT",
-			Source:         "MANUAL",
-			CorrelationId:  "integ-corr-123",
-			Timestamp:      timestamppb.Now(),
-			Version:        1,
-		}
-	}
+	// Reuse the shared helper from publisher_test.go (same package).
+	validEvent := validTransactionCapturedEvent
 
 	t.Run("valid TransactionCapturedEvent is written to CockroachDB outbox", func(t *testing.T) {
 		db.Where("1=1").Delete(&EventOutbox{})

--- a/shared/platform/events/publisher_test.go
+++ b/shared/platform/events/publisher_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -351,5 +352,139 @@ func TestOutboxPublisher_AtomicWithBusinessOperation(t *testing.T) {
 		var outboxCount int64
 		db.Model(&EventOutbox{}).Where("aggregate_id = ?", "entity-3").Count(&outboxCount)
 		assert.Equal(t, int64(0), outboxCount)
+	})
+}
+
+// validTransactionCapturedEvent returns a TransactionCapturedEvent that satisfies all
+// buf/validate constraints defined in position_keeping_events.proto.
+func validTransactionCapturedEvent() *eventsv1.TransactionCapturedEvent {
+	return &eventsv1.TransactionCapturedEvent{
+		LogId:          "550e8400-e29b-41d4-a716-446655440000",
+		AccountId:      "account-123",
+		TransactionId:  "550e8400-e29b-41d4-a716-446655440001",
+		AmountCents:    100,
+		InstrumentCode: "GBP",
+		Direction:      "DEBIT",
+		Source:         "MANUAL",
+		CorrelationId:  "corr-123",
+		Timestamp:      timestamppb.Now(),
+		Version:        1,
+	}
+}
+
+func TestOutboxPublisher_ProtovalidateEnforcement(t *testing.T) {
+	db := setupPublisherTestDB(t)
+	publisher := NewOutboxPublisher("test-service")
+	ctx := context.Background()
+
+	baseConfig := PublishConfig{
+		EventType:     "events.transaction_captured.v1",
+		AggregateID:   "550e8400-e29b-41d4-a716-446655440000",
+		AggregateType: "FinancialPositionLog",
+		Topic:         "position-keeping.events.v1",
+		CorrelationID: "corr-123",
+	}
+
+	t.Run("valid event passes validation and is written to outbox", func(t *testing.T) {
+		// Clear outbox before test
+		db.Where("1=1").Delete(&EventOutbox{})
+
+		event := validTransactionCapturedEvent()
+
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return publisher.Publish(ctx, tx, event, baseConfig)
+		})
+
+		require.NoError(t, err)
+
+		var count int64
+		db.Model(&EventOutbox{}).Count(&count)
+		assert.Equal(t, int64(1), count, "valid event should be written to outbox")
+	})
+
+	t.Run("invalid UUID field is rejected before outbox insert", func(t *testing.T) {
+		// Clear outbox before test
+		db.Where("1=1").Delete(&EventOutbox{})
+
+		event := validTransactionCapturedEvent()
+		event.LogId = "not-a-uuid" // violates (buf.validate.field).string.uuid = true
+
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return publisher.Publish(ctx, tx, event, baseConfig)
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "event payload validation failed")
+
+		// Verify nothing was written to outbox
+		var count int64
+		db.Model(&EventOutbox{}).Count(&count)
+		assert.Equal(t, int64(0), count, "invalid event must not enter the outbox")
+	})
+
+	t.Run("required field missing is rejected before outbox insert", func(t *testing.T) {
+		// Clear outbox before test
+		db.Where("1=1").Delete(&EventOutbox{})
+
+		event := validTransactionCapturedEvent()
+		event.Timestamp = nil // violates (buf.validate.field).required = true
+
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return publisher.Publish(ctx, tx, event, baseConfig)
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "event payload validation failed")
+
+		var count int64
+		db.Model(&EventOutbox{}).Count(&count)
+		assert.Equal(t, int64(0), count, "event with missing required field must not enter the outbox")
+	})
+
+	t.Run("invalid enum value is rejected before outbox insert", func(t *testing.T) {
+		// Clear outbox before test
+		db.Where("1=1").Delete(&EventOutbox{})
+
+		event := validTransactionCapturedEvent()
+		event.Direction = "SIDEWAYS" // violates (buf.validate.field).string.in constraint
+
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return publisher.Publish(ctx, tx, event, baseConfig)
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "event payload validation failed")
+
+		var count int64
+		db.Model(&EventOutbox{}).Count(&count)
+		assert.Equal(t, int64(0), count, "event with invalid enum value must not enter the outbox")
+	})
+
+	t.Run("validation error rolls back business operation atomically", func(t *testing.T) {
+		// Create a simple business entity table
+		type BizEntity struct {
+			ID string `gorm:"primaryKey"`
+		}
+		db.AutoMigrate(&BizEntity{})
+		db.Where("1=1").Delete(&BizEntity{})
+		db.Where("1=1").Delete(&EventOutbox{})
+
+		event := validTransactionCapturedEvent()
+		event.LogId = "bad-uuid" // will fail validation
+
+		err := db.Transaction(func(tx *gorm.DB) error {
+			// Business operation first
+			if err := tx.Create(&BizEntity{ID: "entity-val-test"}).Error; err != nil {
+				return err
+			}
+			return publisher.Publish(ctx, tx, event, baseConfig)
+		})
+
+		require.Error(t, err)
+
+		// Business entity must also be rolled back
+		var entityCount int64
+		db.Model(&BizEntity{}).Where("id = ?", "entity-val-test").Count(&entityCount)
+		assert.Equal(t, int64(0), entityCount, "business operation must be rolled back on validation failure")
 	})
 }


### PR DESCRIPTION
## Summary

- Adds `buf.build/go/protovalidate` validation to `OutboxPublisher.Publish()` before the event payload is marshalled and inserted into the outbox
- Invalid protobuf messages (bad UUIDs, missing required fields, enum constraint violations) are rejected at the publish boundary, preventing malformed events from entering the outbox
- Validation failure rolls back the enclosing database transaction atomically, so neither the business operation nor the outbox entry is persisted

## Changes Made

### `shared/platform/events/publisher.go`
- Added `protovalidate.Validator` field to `OutboxPublisher`
- `NewOutboxPublisher` initialises the validator via `protovalidate.New()` (panics on failure to catch misconfiguration at startup)
- `Publish()` calls `validator.Validate(event)` before `proto.Marshal()`, returning a wrapped error on constraint violations

## Technical Details

`protovalidate` reads `buf/validate` option annotations compiled into the `.pb.go` files. No runtime reflection or schema lookups are required — validation is driven entirely by the proto descriptors already on the message type. The validator is created once per publisher instance (not per call), so there is no per-publish allocation cost.

The validation gate sits before serialisation deliberately: once an event is marshalled and inserted into the outbox, the downstream worker treats it as proven-valid. Enforcing constraints here means the outbox is a clean boundary.

## Testing

- **Unit tests** (`publisher_test.go`): SQLite in-memory DB, covers UUID constraint, required field, enum constraint, and atomic rollback on validation failure
- **Integration tests** (`publisher_integration_test.go`): CockroachDB testcontainer via `testdb.SetupCockroachDB`, verifies the same constraints against the production database engine

## Risk Assessment

Low. The change is additive — existing callers that already produce valid events see no difference. Callers producing invalid events will now fail fast at publish time rather than silently inserting corrupt payloads. The validator is created at startup; any proto descriptor issues will surface during service initialisation rather than at runtime.

## Performance Considerations

`protovalidate.Validator` is created once and reused. Validation runs in-process against compiled proto descriptors with no I/O. The overhead per publish call is negligible relative to the database insert that follows.