### PR TITLE
feat: implement AsyncAPI generation script and specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ GOMOD=$(GOCMD) mod
 GOGET=$(GOCMD) get
 GOFMT=$(GOCMD) fmt
 
-.PHONY: all help build seed-dev seed-dev-build test lint clean proto proto-v1 proto-v2 proto-openapi proto-lint proto-breaking proto-descriptors docker deploy-local fmt tidy deps coverage install proto-validate proto-deps-update proto-deps-graph proto-plugins-info validate-tilt validate-semconv validate-sagas proto-jsonschema validate-manifest-jsonschema validate-manifests control-plane-ci test-control-plane migrate-diff-all migrate-diff-current migrate-diff-position migrate-apply-all migrate-status-all migrate-lint-all migrate-hash-all migrate-apply-orgs migrate-status-orgs docs generate-saga-docs swagger-split swagger-ui dev-up dev-down dev-clean
+.PHONY: all help build seed-dev seed-dev-build test lint clean proto proto-v1 proto-v2 proto-openapi proto-lint proto-breaking proto-descriptors docker deploy-local fmt tidy deps coverage install proto-validate proto-deps-update proto-deps-graph proto-plugins-info validate-tilt validate-semconv validate-sagas proto-jsonschema validate-manifest-jsonschema validate-manifests control-plane-ci test-control-plane migrate-diff-all migrate-diff-current migrate-diff-position migrate-apply-all migrate-status-all migrate-lint-all migrate-hash-all migrate-apply-orgs migrate-status-orgs docs generate-saga-docs swagger-split swagger-ui dev-up dev-down dev-clean asyncapi
 
 # Default target
 all: help
@@ -489,6 +489,12 @@ generate-saga-docs:
 	@echo "Generating saga handler documentation..."
 	@go run tools/saga-doc-gen/main.go tools/saga-doc-gen/generator.go -schema-dir=shared/pkg/saga/schema -output-dir=docs
 	@echo "Documentation generated successfully"
+
+## asyncapi: Generate AsyncAPI 3.0.0 specs from topic registry and proto definitions
+asyncapi:
+	@echo "Generating AsyncAPI specs..."
+	@./scripts/gen-asyncapi.sh
+	@echo "AsyncAPI specs generated in api/asyncapi/"
 
 ## validate-manifests: Validate example manifests against protobuf schema, CEL, and Starlark
 validate-manifests:

--- a/api/asyncapi/audit.yaml
+++ b/api/asyncapi/audit.yaml
@@ -1,0 +1,58 @@
+asyncapi: 3.0.0
+info:
+  title: "Audit Events"
+  version: 1.0.0
+  description: "Audit trail events for compliance and observability"
+servers:
+  kafka:
+    host: kafka:9092
+    protocol: kafka
+channels:
+  audit.events.v1:
+    address: "audit.events.v1"
+    description: "Audit events for all service operations"
+    messages:
+      AuditEvent:
+        $ref: '#/components/messages/AuditEvent'
+  audit.events.v1.dlq:
+    address: "audit.events.v1.dlq"
+    description: "Dead letter queue for audit events that could not be processed"
+operations:
+  publishEvents:
+    action: send
+    channel:
+      $ref: '#/channels/audit.events.v1'
+  publishEventsDlq:
+    action: send
+    channel:
+      $ref: '#/channels/audit.events.v1.dlq'
+components:
+  messages:
+    AuditEvent:
+      name: "AuditEvent"
+      title: "AuditEvent"
+      description: "Audit events for all service operations"
+      contentType: application/protobuf
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/AuditEvent'
+  schemas:
+    AuditEvent:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.AuditEvent"
+      properties:
+        event_type:
+          type: string
+          description: "Proto definition not yet available in api/proto/meridian/events/v1/"

--- a/api/asyncapi/current-account.yaml
+++ b/api/asyncapi/current-account.yaml
@@ -1,0 +1,248 @@
+asyncapi: 3.0.0
+info:
+  title: "Current Account Events"
+  version: 1.0.0
+  description: "Account lifecycle and withdrawal events for current (demand deposit) accounts"
+servers:
+  kafka:
+    host: kafka:9092
+    protocol: kafka
+channels:
+  current-account.account-frozen.v1:
+    address: "current-account.account-frozen.v1"
+    description: "Published when an account is frozen (no debits or credits permitted)"
+    messages:
+      AccountFrozenEvent:
+        $ref: '#/components/messages/AccountFrozenEvent'
+  current-account.account-unfrozen.v1:
+    address: "current-account.account-unfrozen.v1"
+    description: "Published when a previously frozen account is unfrozen"
+    messages:
+      AccountUnfrozenEvent:
+        $ref: '#/components/messages/AccountUnfrozenEvent'
+  current-account.account-closed.v1:
+    address: "current-account.account-closed.v1"
+    description: "Published when an account is permanently closed"
+    messages:
+      AccountClosedEvent:
+        $ref: '#/components/messages/AccountClosedEvent'
+  current-account.withdrawal-status.v1:
+    address: "current-account.withdrawal-status.v1"
+    description: "Published when a withdrawal status changes (initiated, completed, failed, reversed)"
+    messages:
+      WithdrawalStatusUpdated:
+        $ref: '#/components/messages/WithdrawalStatusUpdated'
+operations:
+  publishAccountFrozen:
+    action: send
+    channel:
+      $ref: '#/channels/current-account.account-frozen.v1'
+  publishAccountUnfrozen:
+    action: send
+    channel:
+      $ref: '#/channels/current-account.account-unfrozen.v1'
+  publishAccountClosed:
+    action: send
+    channel:
+      $ref: '#/channels/current-account.account-closed.v1'
+  publishWithdrawalStatus:
+    action: send
+    channel:
+      $ref: '#/channels/current-account.withdrawal-status.v1'
+components:
+  messages:
+    AccountFrozenEvent:
+      name: "AccountFrozenEvent"
+      title: "AccountFrozenEvent"
+      description: "Published when an account is frozen (no debits or credits permitted)"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Account ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/AccountFrozenEvent'
+    AccountUnfrozenEvent:
+      name: "AccountUnfrozenEvent"
+      title: "AccountUnfrozenEvent"
+      description: "Published when a previously frozen account is unfrozen"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Account ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/AccountUnfrozenEvent'
+    AccountClosedEvent:
+      name: "AccountClosedEvent"
+      title: "AccountClosedEvent"
+      description: "Published when an account is permanently closed"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Account ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/AccountClosedEvent'
+    WithdrawalStatusUpdated:
+      name: "WithdrawalStatusUpdated"
+      title: "WithdrawalStatusUpdated"
+      description: "Published when a withdrawal status changes (initiated, completed, failed, reversed)"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Withdrawal ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/WithdrawalStatusUpdated'
+  schemas:
+    AccountFrozenEvent:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.AccountFrozenEvent"
+      properties:
+        event_id:
+          type: string
+        account_id:
+          type: string
+        reason:
+          type: string
+        frozen_at:
+          type: string
+        frozen_by:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+        idempotency_key:
+          type: string
+    AccountUnfrozenEvent:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.AccountUnfrozenEvent"
+      properties:
+        event_id:
+          type: string
+        account_id:
+          type: string
+        unfrozen_at:
+          type: string
+        unfrozen_by:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+        idempotency_key:
+          type: string
+    AccountClosedEvent:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.AccountClosedEvent"
+      properties:
+        event_id:
+          type: string
+        account_id:
+          type: string
+        closing_balance:
+          type: string
+        closure_reason:
+          type: string
+        closed_by:
+          type: string
+        closure_date:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+        idempotency_key:
+          type: string
+    WithdrawalStatusUpdated:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.WithdrawalStatusUpdatedEvent"
+      properties:
+        event_id:
+          type: string
+        withdrawal_id:
+          type: string
+        account_id:
+          type: string
+        status:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+        idempotency_key:
+          type: string

--- a/api/asyncapi/financial-accounting.yaml
+++ b/api/asyncapi/financial-accounting.yaml
@@ -1,0 +1,51 @@
+asyncapi: 3.0.0
+info:
+  title: "Financial Accounting Events"
+  version: 1.0.0
+  description: "Financial booking log control events"
+servers:
+  kafka:
+    host: kafka:9092
+    protocol: kafka
+channels:
+  financial-accounting.booking-log-controlled.v1:
+    address: "financial-accounting.booking-log-controlled.v1"
+    description: "Published when a booking log receives a control action (SUSPEND, RESUME, TERMINATE)"
+    messages:
+      BookingLogControlledEvent:
+        $ref: '#/components/messages/BookingLogControlledEvent'
+operations:
+  publishBookingLogControlled:
+    action: send
+    channel:
+      $ref: '#/channels/financial-accounting.booking-log-controlled.v1'
+components:
+  messages:
+    BookingLogControlledEvent:
+      name: "BookingLogControlledEvent"
+      title: "BookingLogControlledEvent"
+      description: "Published when a booking log receives a control action (SUSPEND, RESUME, TERMINATE)"
+      contentType: application/protobuf
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/BookingLogControlledEvent'
+  schemas:
+    BookingLogControlledEvent:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.BookingLogControlledEvent"
+      properties:
+        event_type:
+          type: string
+          description: "Proto definition not yet available in api/proto/meridian/events/v1/"

--- a/api/asyncapi/internal-account.yaml
+++ b/api/asyncapi/internal-account.yaml
@@ -1,0 +1,122 @@
+asyncapi: 3.0.0
+info:
+  title: "Internal Account Events"
+  version: 1.0.0
+  description: "Internal account facility lifecycle and booking events"
+servers:
+  kafka:
+    host: kafka:9092
+    protocol: kafka
+channels:
+  internal-account.facility-created.v1:
+    address: "internal-account.facility-created.v1"
+    description: "Published when a new internal account facility is initiated"
+    messages:
+      FacilityCreatedEvent:
+        $ref: '#/components/messages/FacilityCreatedEvent'
+  internal-account.booking-created.v1:
+    address: "internal-account.booking-created.v1"
+    description: "Published when a new booking is posted to an internal account"
+    messages:
+      BookingCreatedEvent:
+        $ref: '#/components/messages/BookingCreatedEvent'
+operations:
+  publishFacilityCreated:
+    action: send
+    channel:
+      $ref: '#/channels/internal-account.facility-created.v1'
+  publishBookingCreated:
+    action: send
+    channel:
+      $ref: '#/channels/internal-account.booking-created.v1'
+components:
+  messages:
+    FacilityCreatedEvent:
+      name: "FacilityCreatedEvent"
+      title: "FacilityCreatedEvent"
+      description: "Published when a new internal account facility is initiated"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Account ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/FacilityCreatedEvent'
+    BookingCreatedEvent:
+      name: "BookingCreatedEvent"
+      title: "BookingCreatedEvent"
+      description: "Published when a new booking is posted to an internal account"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Account ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/BookingCreatedEvent'
+  schemas:
+    FacilityCreatedEvent:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.FacilityCreatedEvent"
+      properties:
+        event_id:
+          type: string
+        account_id:
+          type: string
+        account_code:
+          type: string
+        account_type:
+          type: string
+        instrument_code:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string
+    BookingCreatedEvent:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.BookingCreatedEvent"
+      properties:
+        event_id:
+          type: string
+        account_id:
+          type: string
+        transaction_id:
+          type: string
+        instrument_code:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string

--- a/api/asyncapi/market-information.yaml
+++ b/api/asyncapi/market-information.yaml
@@ -1,0 +1,51 @@
+asyncapi: 3.0.0
+info:
+  title: "Market Information Events"
+  version: 1.0.0
+  description: "Market data observation events"
+servers:
+  kafka:
+    host: kafka:9092
+    protocol: kafka
+channels:
+  market-information.observation-recorded.v1:
+    address: "market-information.observation-recorded.v1"
+    description: "Published when a new market price observation is recorded"
+    messages:
+      ObservationRecorded:
+        $ref: '#/components/messages/ObservationRecorded'
+operations:
+  publishObservationRecorded:
+    action: send
+    channel:
+      $ref: '#/channels/market-information.observation-recorded.v1'
+components:
+  messages:
+    ObservationRecorded:
+      name: "ObservationRecorded"
+      title: "ObservationRecorded"
+      description: "Published when a new market price observation is recorded"
+      contentType: application/protobuf
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/ObservationRecorded'
+  schemas:
+    ObservationRecorded:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.ObservationRecorded"
+      properties:
+        event_type:
+          type: string
+          description: "Proto definition not yet available in api/proto/meridian/events/v1/"

--- a/api/asyncapi/party.yaml
+++ b/api/asyncapi/party.yaml
@@ -1,0 +1,181 @@
+asyncapi: 3.0.0
+info:
+  title: "Party Events"
+  version: 1.0.0
+  description: "Party registration and lifecycle events"
+servers:
+  kafka:
+    host: kafka:9092
+    protocol: kafka
+channels:
+  party.created.v1:
+    address: "party.created.v1"
+    description: "Published when a new party is registered in the system"
+    messages:
+      PartyCreatedEvent:
+        $ref: '#/components/messages/PartyCreatedEvent'
+  party.updated.v1:
+    address: "party.updated.v1"
+    description: "Published when an existing party's details are updated"
+    messages:
+      PartyUpdatedEvent:
+        $ref: '#/components/messages/PartyUpdatedEvent'
+  party.verification-completed.v1:
+    address: "party.verification-completed.v1"
+    description: "Published when a KYC/AML verification reaches a terminal state (APPROVED, REJECTED, MANUAL_REVIEW)"
+    messages:
+      PartyVerificationCompletedEvent:
+        $ref: '#/components/messages/PartyVerificationCompletedEvent'
+operations:
+  publishCreated:
+    action: send
+    channel:
+      $ref: '#/channels/party.created.v1'
+  publishUpdated:
+    action: send
+    channel:
+      $ref: '#/channels/party.updated.v1'
+  publishVerificationCompleted:
+    action: send
+    channel:
+      $ref: '#/channels/party.verification-completed.v1'
+components:
+  messages:
+    PartyCreatedEvent:
+      name: "PartyCreatedEvent"
+      title: "PartyCreatedEvent"
+      description: "Published when a new party is registered in the system"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Party ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/PartyCreatedEvent'
+    PartyUpdatedEvent:
+      name: "PartyUpdatedEvent"
+      title: "PartyUpdatedEvent"
+      description: "Published when an existing party's details are updated"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Party ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/PartyUpdatedEvent'
+    PartyVerificationCompletedEvent:
+      name: "PartyVerificationCompletedEvent"
+      title: "PartyVerificationCompletedEvent"
+      description: "Published when a KYC/AML verification reaches a terminal state (APPROVED, REJECTED, MANUAL_REVIEW)"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Party ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/PartyVerificationCompletedEvent'
+  schemas:
+    PartyCreatedEvent:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.PartyCreatedEvent"
+      properties:
+        event_id:
+          type: string
+        party_id:
+          type: string
+        party_type:
+          type: string
+        legal_name:
+          type: string
+        status:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string
+    PartyUpdatedEvent:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.PartyUpdatedEvent"
+      properties:
+        event_id:
+          type: string
+        party_id:
+          type: string
+        party_type:
+          type: string
+        status:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string
+    PartyVerificationCompletedEvent:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.PartyVerificationCompletedEvent"
+      properties:
+        event_id:
+          type: string
+        party_id:
+          type: string
+        verification_id:
+          type: string
+        provider:
+          type: string
+        status:
+          type: string
+        completed_at:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string
+        idempotency_key:
+          type: string

--- a/api/asyncapi/payment-order.yaml
+++ b/api/asyncapi/payment-order.yaml
@@ -1,0 +1,443 @@
+asyncapi: 3.0.0
+info:
+  title: "Payment Order Events"
+  version: 1.0.0
+  description: "Payment order lifecycle state transition events"
+servers:
+  kafka:
+    host: kafka:9092
+    protocol: kafka
+channels:
+  payment-order.initiated.v1:
+    address: "payment-order.initiated.v1"
+    description: "Published when a new payment order is initiated"
+    messages:
+      PaymentOrderInitiated:
+        $ref: '#/components/messages/PaymentOrderInitiated'
+  payment-order.reserved.v1:
+    address: "payment-order.reserved.v1"
+    description: "Published when funds are successfully reserved for a payment order"
+    messages:
+      PaymentOrderReserved:
+        $ref: '#/components/messages/PaymentOrderReserved'
+  payment-order.executing.v1:
+    address: "payment-order.executing.v1"
+    description: "Published when a payment order begins execution with the payment gateway"
+    messages:
+      PaymentOrderExecuting:
+        $ref: '#/components/messages/PaymentOrderExecuting'
+  payment-order.completed.v1:
+    address: "payment-order.completed.v1"
+    description: "Published when a payment order successfully completes"
+    messages:
+      PaymentOrderCompleted:
+        $ref: '#/components/messages/PaymentOrderCompleted'
+  payment-order.failed.v1:
+    address: "payment-order.failed.v1"
+    description: "Published when a payment order fails and cannot be retried"
+    messages:
+      PaymentOrderFailed:
+        $ref: '#/components/messages/PaymentOrderFailed'
+  payment-order.cancelled.v1:
+    address: "payment-order.cancelled.v1"
+    description: "Published when a payment order is cancelled before execution"
+    messages:
+      PaymentOrderCancelled:
+        $ref: '#/components/messages/PaymentOrderCancelled'
+  payment-order.reversed.v1:
+    address: "payment-order.reversed.v1"
+    description: "Published when a completed payment order is reversed"
+    messages:
+      PaymentOrderReversed:
+        $ref: '#/components/messages/PaymentOrderReversed'
+operations:
+  publishInitiated:
+    action: send
+    channel:
+      $ref: '#/channels/payment-order.initiated.v1'
+  publishReserved:
+    action: send
+    channel:
+      $ref: '#/channels/payment-order.reserved.v1'
+  publishExecuting:
+    action: send
+    channel:
+      $ref: '#/channels/payment-order.executing.v1'
+  publishCompleted:
+    action: send
+    channel:
+      $ref: '#/channels/payment-order.completed.v1'
+  publishFailed:
+    action: send
+    channel:
+      $ref: '#/channels/payment-order.failed.v1'
+  publishCancelled:
+    action: send
+    channel:
+      $ref: '#/channels/payment-order.cancelled.v1'
+  publishReversed:
+    action: send
+    channel:
+      $ref: '#/channels/payment-order.reversed.v1'
+components:
+  messages:
+    PaymentOrderInitiated:
+      name: "PaymentOrderInitiated"
+      title: "PaymentOrderInitiated"
+      description: "Published when a new payment order is initiated"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "payment_order_id"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/PaymentOrderInitiated'
+    PaymentOrderReserved:
+      name: "PaymentOrderReserved"
+      title: "PaymentOrderReserved"
+      description: "Published when funds are successfully reserved for a payment order"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "payment_order_id"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/PaymentOrderReserved'
+    PaymentOrderExecuting:
+      name: "PaymentOrderExecuting"
+      title: "PaymentOrderExecuting"
+      description: "Published when a payment order begins execution with the payment gateway"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "payment_order_id"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/PaymentOrderExecuting'
+    PaymentOrderCompleted:
+      name: "PaymentOrderCompleted"
+      title: "PaymentOrderCompleted"
+      description: "Published when a payment order successfully completes"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "payment_order_id"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/PaymentOrderCompleted'
+    PaymentOrderFailed:
+      name: "PaymentOrderFailed"
+      title: "PaymentOrderFailed"
+      description: "Published when a payment order fails and cannot be retried"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "payment_order_id"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/PaymentOrderFailed'
+    PaymentOrderCancelled:
+      name: "PaymentOrderCancelled"
+      title: "PaymentOrderCancelled"
+      description: "Published when a payment order is cancelled before execution"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "payment_order_id"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/PaymentOrderCancelled'
+    PaymentOrderReversed:
+      name: "PaymentOrderReversed"
+      title: "PaymentOrderReversed"
+      description: "Published when a completed payment order is reversed"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "payment_order_id"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/PaymentOrderReversed'
+  schemas:
+    PaymentOrderInitiated:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.PaymentOrderInitiatedEvent"
+      properties:
+        event_id:
+          type: string
+        payment_order_id:
+          type: string
+        debtor_account_id:
+          type: string
+        creditor_reference:
+          type: string
+        amount:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+        idempotency_key:
+          type: string
+    PaymentOrderReserved:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.PaymentOrderReservedEvent"
+      properties:
+        event_id:
+          type: string
+        payment_order_id:
+          type: string
+        debtor_account_id:
+          type: string
+        lien_id:
+          type: string
+        amount:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+        idempotency_key:
+          type: string
+    PaymentOrderExecuting:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.PaymentOrderExecutingEvent"
+      properties:
+        event_id:
+          type: string
+        payment_order_id:
+          type: string
+        gateway_reference_id:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+        idempotency_key:
+          type: string
+    PaymentOrderCompleted:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.PaymentOrderCompletedEvent"
+      properties:
+        event_id:
+          type: string
+        payment_order_id:
+          type: string
+        debtor_account_id:
+          type: string
+        amount:
+          type: string
+        lien_id:
+          type: string
+        gateway_reference_id:
+          type: string
+        ledger_booking_id:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+        idempotency_key:
+          type: string
+    PaymentOrderFailed:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.PaymentOrderFailedEvent"
+      properties:
+        event_id:
+          type: string
+        payment_order_id:
+          type: string
+        debtor_account_id:
+          type: string
+        amount:
+          type: string
+        failure_reason:
+          type: string
+        error_code:
+          type: string
+        failed_at_status:
+          type: string
+        lien_id:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+        idempotency_key:
+          type: string
+    PaymentOrderCancelled:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.PaymentOrderCancelledEvent"
+      properties:
+        event_id:
+          type: string
+        payment_order_id:
+          type: string
+        debtor_account_id:
+          type: string
+        amount:
+          type: string
+        cancellation_reason:
+          type: string
+        cancelled_by:
+          type: string
+        lien_id:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+        idempotency_key:
+          type: string
+    PaymentOrderReversed:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.PaymentOrderReversedEvent"
+      properties:
+        event_id:
+          type: string
+        payment_order_id:
+          type: string
+        debtor_account_id:
+          type: string
+        amount:
+          type: string
+        reversal_reason:
+          type: string
+        reversed_by:
+          type: string
+        original_ledger_booking_id:
+          type: string
+        compensating_ledger_booking_id:
+          type: string
+        correlation_id:
+          type: string
+        causation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+        idempotency_key:
+          type: string

--- a/api/asyncapi/payment-order.yaml
+++ b/api/asyncapi/payment-order.yaml
@@ -90,7 +90,7 @@ components:
         kafka:
           key:
             type: string
-            description: "payment_order_id"
+            description: "Payment order ID"
       headers:
         type: object
         properties:
@@ -115,7 +115,7 @@ components:
         kafka:
           key:
             type: string
-            description: "payment_order_id"
+            description: "Payment order ID"
       headers:
         type: object
         properties:
@@ -140,7 +140,7 @@ components:
         kafka:
           key:
             type: string
-            description: "payment_order_id"
+            description: "Payment order ID"
       headers:
         type: object
         properties:
@@ -165,7 +165,7 @@ components:
         kafka:
           key:
             type: string
-            description: "payment_order_id"
+            description: "Payment order ID"
       headers:
         type: object
         properties:
@@ -190,7 +190,7 @@ components:
         kafka:
           key:
             type: string
-            description: "payment_order_id"
+            description: "Payment order ID"
       headers:
         type: object
         properties:
@@ -215,7 +215,7 @@ components:
         kafka:
           key:
             type: string
-            description: "payment_order_id"
+            description: "Payment order ID"
       headers:
         type: object
         properties:
@@ -240,7 +240,7 @@ components:
         kafka:
           key:
             type: string
-            description: "payment_order_id"
+            description: "Payment order ID"
       headers:
         type: object
         properties:

--- a/api/asyncapi/position-keeping.yaml
+++ b/api/asyncapi/position-keeping.yaml
@@ -1,0 +1,517 @@
+asyncapi: 3.0.0
+info:
+  title: "Position Keeping Events"
+  version: 1.0.0
+  description: "Financial position and transaction lifecycle events"
+servers:
+  kafka:
+    host: kafka:9092
+    protocol: kafka
+channels:
+  position-keeping.transaction-captured.v1:
+    address: "position-keeping.transaction-captured.v1"
+    description: "Published when a new financial transaction is captured"
+    messages:
+      TransactionCaptured:
+        $ref: '#/components/messages/TransactionCaptured'
+  position-keeping.transaction-amended.v1:
+    address: "position-keeping.transaction-amended.v1"
+    description: "Published when a captured transaction is amended"
+    messages:
+      TransactionAmended:
+        $ref: '#/components/messages/TransactionAmended'
+  position-keeping.transaction-reconciled.v1:
+    address: "position-keeping.transaction-reconciled.v1"
+    description: "Published when a transaction is reconciled against actual settlement data"
+    messages:
+      TransactionReconciled:
+        $ref: '#/components/messages/TransactionReconciled'
+  position-keeping.transaction-posted.v1:
+    address: "position-keeping.transaction-posted.v1"
+    description: "Published when a transaction is posted to the ledger"
+    messages:
+      TransactionPosted:
+        $ref: '#/components/messages/TransactionPosted'
+  position-keeping.transaction-rejected.v1:
+    address: "position-keeping.transaction-rejected.v1"
+    description: "Published when a transaction is rejected due to validation failure"
+    messages:
+      TransactionRejected:
+        $ref: '#/components/messages/TransactionRejected'
+  position-keeping.transaction-failed.v1:
+    address: "position-keeping.transaction-failed.v1"
+    description: "Published when a transaction fails due to a system error"
+    messages:
+      TransactionFailed:
+        $ref: '#/components/messages/TransactionFailed'
+  position-keeping.transaction-cancelled.v1:
+    address: "position-keeping.transaction-cancelled.v1"
+    description: "Published when a transaction is cancelled"
+    messages:
+      TransactionCancelled:
+        $ref: '#/components/messages/TransactionCancelled'
+  position-keeping.bulk-transaction-captured.v1:
+    address: "position-keeping.bulk-transaction-captured.v1"
+    description: "Published when a batch of transactions is captured atomically"
+    messages:
+      BulkTransactionCaptured:
+        $ref: '#/components/messages/BulkTransactionCaptured'
+  position-keeping.opening-balance-recorded.v1:
+    address: "position-keeping.opening-balance-recorded.v1"
+    description: "Published when an opening balance is recorded for a new account"
+    messages:
+      OpeningBalanceRecorded:
+        $ref: '#/components/messages/OpeningBalanceRecorded'
+operations:
+  publishTransactionCaptured:
+    action: send
+    channel:
+      $ref: '#/channels/position-keeping.transaction-captured.v1'
+  publishTransactionAmended:
+    action: send
+    channel:
+      $ref: '#/channels/position-keeping.transaction-amended.v1'
+  publishTransactionReconciled:
+    action: send
+    channel:
+      $ref: '#/channels/position-keeping.transaction-reconciled.v1'
+  publishTransactionPosted:
+    action: send
+    channel:
+      $ref: '#/channels/position-keeping.transaction-posted.v1'
+  publishTransactionRejected:
+    action: send
+    channel:
+      $ref: '#/channels/position-keeping.transaction-rejected.v1'
+  publishTransactionFailed:
+    action: send
+    channel:
+      $ref: '#/channels/position-keeping.transaction-failed.v1'
+  publishTransactionCancelled:
+    action: send
+    channel:
+      $ref: '#/channels/position-keeping.transaction-cancelled.v1'
+  publishBulkTransactionCaptured:
+    action: send
+    channel:
+      $ref: '#/channels/position-keeping.bulk-transaction-captured.v1'
+  publishOpeningBalanceRecorded:
+    action: send
+    channel:
+      $ref: '#/channels/position-keeping.opening-balance-recorded.v1'
+components:
+  messages:
+    TransactionCaptured:
+      name: "TransactionCaptured"
+      title: "TransactionCaptured"
+      description: "Published when a new financial transaction is captured"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Position log ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/TransactionCaptured'
+    TransactionAmended:
+      name: "TransactionAmended"
+      title: "TransactionAmended"
+      description: "Published when a captured transaction is amended"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Position log ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/TransactionAmended'
+    TransactionReconciled:
+      name: "TransactionReconciled"
+      title: "TransactionReconciled"
+      description: "Published when a transaction is reconciled against actual settlement data"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Position log ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/TransactionReconciled'
+    TransactionPosted:
+      name: "TransactionPosted"
+      title: "TransactionPosted"
+      description: "Published when a transaction is posted to the ledger"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Position log ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/TransactionPosted'
+    TransactionRejected:
+      name: "TransactionRejected"
+      title: "TransactionRejected"
+      description: "Published when a transaction is rejected due to validation failure"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Position log ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/TransactionRejected'
+    TransactionFailed:
+      name: "TransactionFailed"
+      title: "TransactionFailed"
+      description: "Published when a transaction fails due to a system error"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Position log ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/TransactionFailed'
+    TransactionCancelled:
+      name: "TransactionCancelled"
+      title: "TransactionCancelled"
+      description: "Published when a transaction is cancelled"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Position log ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/TransactionCancelled'
+    BulkTransactionCaptured:
+      name: "BulkTransactionCaptured"
+      title: "BulkTransactionCaptured"
+      description: "Published when a batch of transactions is captured atomically"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Batch operation ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/BulkTransactionCaptured'
+    OpeningBalanceRecorded:
+      name: "OpeningBalanceRecorded"
+      title: "OpeningBalanceRecorded"
+      description: "Published when an opening balance is recorded for a new account"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Position log ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/OpeningBalanceRecorded'
+  schemas:
+    TransactionCaptured:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.TransactionCapturedEvent"
+      properties:
+        log_id:
+          type: string
+        account_id:
+          type: string
+        transaction_id:
+          type: string
+        amount_cents:
+          type: integer
+        instrument_code:
+          type: string
+        direction:
+          type: string
+        source:
+          type: string
+        description:
+          type: string
+        reference:
+          type: string
+        correlation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+        instrument_amount:
+          type: string
+    TransactionAmended:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.TransactionAmendedEvent"
+      properties:
+        log_id:
+          type: string
+        account_id:
+          type: string
+        reason:
+          type: string
+        amended_by:
+          type: string
+        correlation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+    TransactionReconciled:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.TransactionReconciledEvent"
+      properties:
+        log_id:
+          type: string
+        account_id:
+          type: string
+        reconciliation_status:
+          type: string
+        reason:
+          type: string
+        reconciled_by:
+          type: string
+        correlation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+    TransactionPosted:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.TransactionPostedEvent"
+      properties:
+        log_id:
+          type: string
+        account_id:
+          type: string
+        posting_reference:
+          type: string
+        reason:
+          type: string
+        posted_by:
+          type: string
+        correlation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+    TransactionRejected:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.TransactionRejectedEvent"
+      properties:
+        log_id:
+          type: string
+        account_id:
+          type: string
+        reason:
+          type: string
+        rejected_by:
+          type: string
+        correlation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+    TransactionFailed:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.TransactionFailedEvent"
+      properties:
+        log_id:
+          type: string
+        account_id:
+          type: string
+        failure_reason:
+          type: string
+        error_code:
+          type: string
+        correlation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+        error_code_enum:
+          type: string
+    TransactionCancelled:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.TransactionCancelledEvent"
+      properties:
+        log_id:
+          type: string
+        account_id:
+          type: string
+        reason:
+          type: string
+        cancelled_by:
+          type: string
+        correlation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+    BulkTransactionCaptured:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.BulkTransactionCapturedEvent"
+      properties:
+        batch_id:
+          type: string
+        transaction_count:
+          type: integer
+        log_ids:
+          type: array
+          items:
+            type: string
+        source:
+          type: string
+        correlation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+    OpeningBalanceRecorded:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.OpeningBalanceRecordedEvent"
+      properties:
+        log_id:
+          type: string
+        account_id:
+          type: string
+        amount_cents:
+          type: integer
+        instrument_code:
+          type: string
+        effective_date:
+          type: string
+        migration_reference:
+          type: string
+        correlation_id:
+          type: string
+        timestamp:
+          type: string
+        version:
+          type: integer
+        instrument_amount:
+          type: string

--- a/api/asyncapi/reconciliation.yaml
+++ b/api/asyncapi/reconciliation.yaml
@@ -1,0 +1,348 @@
+asyncapi: 3.0.0
+info:
+  title: "Reconciliation Events"
+  version: 1.0.0
+  description: "Settlement reconciliation run and variance detection events"
+servers:
+  kafka:
+    host: kafka:9092
+    protocol: kafka
+channels:
+  reconciliation.run-started.v1:
+    address: "reconciliation.run-started.v1"
+    description: "Published when a reconciliation run begins"
+    messages:
+      ReconciliationRunStarted:
+        $ref: '#/components/messages/ReconciliationRunStarted'
+  reconciliation.run-completed.v1:
+    address: "reconciliation.run-completed.v1"
+    description: "Published when a reconciliation run completes (with or without variances)"
+    messages:
+      ReconciliationRunCompleted:
+        $ref: '#/components/messages/ReconciliationRunCompleted'
+  reconciliation.variance-detected.v1:
+    address: "reconciliation.variance-detected.v1"
+    description: "Published when a position variance is detected during reconciliation"
+    messages:
+      VarianceDetected:
+        $ref: '#/components/messages/VarianceDetected'
+  reconciliation.position-lock-requested.v1:
+    address: "reconciliation.position-lock-requested.v1"
+    description: "Published when a position lock is requested to freeze a position for reconciliation"
+    messages:
+      PositionLockRequested:
+        $ref: '#/components/messages/PositionLockRequested'
+  reconciliation.dispute-created.v1:
+    address: "reconciliation.dispute-created.v1"
+    description: "Published when a reconciliation dispute is raised"
+    messages:
+      DisputeCreated:
+        $ref: '#/components/messages/DisputeCreated'
+  reconciliation.dispute-resolved.v1:
+    address: "reconciliation.dispute-resolved.v1"
+    description: "Published when a reconciliation dispute is resolved"
+    messages:
+      DisputeResolved:
+        $ref: '#/components/messages/DisputeResolved'
+operations:
+  publishRunStarted:
+    action: send
+    channel:
+      $ref: '#/channels/reconciliation.run-started.v1'
+  publishRunCompleted:
+    action: send
+    channel:
+      $ref: '#/channels/reconciliation.run-completed.v1'
+  publishVarianceDetected:
+    action: send
+    channel:
+      $ref: '#/channels/reconciliation.variance-detected.v1'
+  publishPositionLockRequested:
+    action: send
+    channel:
+      $ref: '#/channels/reconciliation.position-lock-requested.v1'
+  publishDisputeCreated:
+    action: send
+    channel:
+      $ref: '#/channels/reconciliation.dispute-created.v1'
+  publishDisputeResolved:
+    action: send
+    channel:
+      $ref: '#/channels/reconciliation.dispute-resolved.v1'
+components:
+  messages:
+    ReconciliationRunStarted:
+      name: "ReconciliationRunStarted"
+      title: "ReconciliationRunStarted"
+      description: "Published when a reconciliation run begins"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Reconciliation run ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/ReconciliationRunStarted'
+    ReconciliationRunCompleted:
+      name: "ReconciliationRunCompleted"
+      title: "ReconciliationRunCompleted"
+      description: "Published when a reconciliation run completes (with or without variances)"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Reconciliation run ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/ReconciliationRunCompleted'
+    VarianceDetected:
+      name: "VarianceDetected"
+      title: "VarianceDetected"
+      description: "Published when a position variance is detected during reconciliation"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "variance_id"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/VarianceDetected'
+    PositionLockRequested:
+      name: "PositionLockRequested"
+      title: "PositionLockRequested"
+      description: "Published when a position lock is requested to freeze a position for reconciliation"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Reconciliation run ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/PositionLockRequested'
+    DisputeCreated:
+      name: "DisputeCreated"
+      title: "DisputeCreated"
+      description: "Published when a reconciliation dispute is raised"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Dispute ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/DisputeCreated'
+    DisputeResolved:
+      name: "DisputeResolved"
+      title: "DisputeResolved"
+      description: "Published when a reconciliation dispute is resolved"
+      contentType: application/protobuf
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "Dispute ID"
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        $ref: '#/components/schemas/DisputeResolved'
+  schemas:
+    ReconciliationRunStarted:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.ReconciliationRunStartedEvent"
+      properties:
+        run_id:
+          type: string
+        account_id:
+          type: string
+        scope:
+          type: string
+        settlement_type:
+          type: string
+        period_start:
+          type: string
+        period_end:
+          type: string
+        initiated_by:
+          type: string
+        correlation_id:
+          type: string
+        timestamp:
+          type: string
+    ReconciliationRunCompleted:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.ReconciliationRunCompletedEvent"
+      properties:
+        run_id:
+          type: string
+        account_id:
+          type: string
+        status:
+          type: string
+        variance_count:
+          type: integer
+        snapshot_count:
+          type: integer
+        total_variance:
+          type: string
+        failure_reason:
+          type: string
+        correlation_id:
+          type: string
+        timestamp:
+          type: string
+    VarianceDetected:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.VarianceDetectedEvent"
+      properties:
+        variance_id:
+          type: string
+        run_id:
+          type: string
+        account_id:
+          type: string
+        instrument_code:
+          type: string
+        expected_amount:
+          type: string
+        actual_amount:
+          type: string
+        variance_amount:
+          type: string
+        reason:
+          type: string
+        correlation_id:
+          type: string
+        timestamp:
+          type: string
+    PositionLockRequested:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.PositionLockRequestedEvent"
+      properties:
+        run_id:
+          type: string
+        account_id:
+          type: string
+        instrument_code:
+          type: string
+        lock_duration_seconds:
+          type: integer
+        correlation_id:
+          type: string
+        timestamp:
+          type: string
+    DisputeCreated:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.DisputeCreatedEvent"
+      properties:
+        dispute_id:
+          type: string
+        variance_id:
+          type: string
+        run_id:
+          type: string
+        account_id:
+          type: string
+        reason:
+          type: string
+        raised_by:
+          type: string
+        correlation_id:
+          type: string
+        timestamp:
+          type: string
+    DisputeResolved:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.DisputeResolvedEvent"
+      properties:
+        dispute_id:
+          type: string
+        variance_id:
+          type: string
+        account_id:
+          type: string
+        outcome:
+          type: string
+        resolution:
+          type: string
+        resolved_by:
+          type: string
+        correlation_id:
+          type: string
+        timestamp:
+          type: string

--- a/scripts/gen-asyncapi.sh
+++ b/scripts/gen-asyncapi.sh
@@ -139,9 +139,14 @@ extract_proto_fields() {
       }
       # Repeated field: repeated type name = N
       else if (n >= 5 && parts[1] == "repeated" && parts[4] == "=") {
+        elem = parts[2]
         name = parts[3]
+        item_type = "string"
+        if (elem ~ /^(int32|int64|uint32|uint64|sint32|sint64|fixed32|fixed64|sfixed32|sfixed64)$/) item_type = "integer"
+        else if (elem ~ /^(float|double)$/) item_type = "number"
+        else if (elem == "bool") item_type = "boolean"
         if (first) printf ","
-        printf "\n  {\"name\":\"%s\",\"type\":\"array\"}", name
+        printf "\n  {\"name\":\"%s\",\"type\":\"array\",\"items_type\":\"%s\"}", name, item_type
         first = 1
       }
     }
@@ -221,7 +226,10 @@ PROPEOF
   local fields_json
   fields_json=$(extract_proto_fields "$proto_file" "$proto_msg")
   local field_count
-  field_count=$(echo "$fields_json" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
+  if ! field_count=$(echo "$fields_json" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))" 2>/dev/null); then
+    echo "  WARNING: failed to parse extracted fields for '${proto_msg}' from '${proto_file}'; using placeholder schema" >&2
+    field_count=0
+  fi
 
   if [ "$field_count" -gt 0 ]; then
     echo "$fields_json" | python3 -c "
@@ -231,10 +239,11 @@ for f in fields:
     name = f['name']
     ftype = f['type']
     if ftype == 'array':
+        items_type = f.get('items_type', 'string')
         print(f'        {name}:')
         print(f'          type: array')
         print(f'          items:')
-        print(f'            type: string')
+        print(f'            type: {items_type}')
     elif ftype == 'object':
         print(f'        {name}:')
         print(f'          type: object')

--- a/scripts/gen-asyncapi.sh
+++ b/scripts/gen-asyncapi.sh
@@ -31,6 +31,11 @@ if ! command -v yq &>/dev/null; then
   exit 1
 fi
 
+if ! command -v python3 &>/dev/null; then
+  echo "Error: python3 is required for JSON processing." >&2
+  exit 1
+fi
+
 mkdir -p "$OUTPUT_DIR"
 
 # --- Helper: convert service key to title ---
@@ -182,17 +187,18 @@ infer_partition_key() {
 describe_partition_key() {
   local key="$1"
   case "$key" in
-    account_id)    echo "Account ID" ;;
-    log_id)        echo "Position log ID" ;;
-    batch_id)      echo "Batch operation ID" ;;
-    withdrawal_id) echo "Withdrawal ID" ;;
-    transaction_id) echo "Transaction ID" ;;
-    facility_id)   echo "Facility ID" ;;
-    party_id)      echo "Party ID" ;;
-    order_id)      echo "Payment order ID" ;;
-    run_id)        echo "Reconciliation run ID" ;;
-    dispute_id)    echo "Dispute ID" ;;
-    *)             echo "$key" ;;
+    account_id)        echo "Account ID" ;;
+    log_id)            echo "Position log ID" ;;
+    batch_id)          echo "Batch operation ID" ;;
+    withdrawal_id)     echo "Withdrawal ID" ;;
+    transaction_id)    echo "Transaction ID" ;;
+    facility_id)       echo "Facility ID" ;;
+    party_id)          echo "Party ID" ;;
+    order_id)          echo "Payment order ID" ;;
+    payment_order_id)  echo "Payment order ID" ;;
+    run_id)            echo "Reconciliation run ID" ;;
+    dispute_id)        echo "Dispute ID" ;;
+    *)                 echo "$key" ;;
   esac
 }
 

--- a/scripts/gen-asyncapi.sh
+++ b/scripts/gen-asyncapi.sh
@@ -1,0 +1,430 @@
+#!/usr/bin/env bash
+# gen-asyncapi.sh - Generate AsyncAPI 3.0.0 specs from proto events and topic registry
+#
+# Usage: ./scripts/gen-asyncapi.sh [topics-file] [output-dir]
+#
+# Reads the Kafka topic registry (topics.yaml) and proto event definitions to
+# produce one AsyncAPI 3.0.0 YAML file per BIAN service domain.
+#
+# Inputs:
+#   - shared/platform/events/topics/topics.yaml  (topic registry)
+#   - api/proto/meridian/events/v1/*.proto        (event message definitions)
+#
+# Output:
+#   - api/asyncapi/<service>.yaml  (one per BIAN service domain)
+
+set -euo pipefail
+
+TOPICS_FILE="${1:-shared/platform/events/topics/topics.yaml}"
+OUTPUT_DIR="${2:-api/asyncapi}"
+PROTO_DIR="api/proto/meridian/events/v1"
+
+# --- Dependency checks ---
+
+if [ ! -f "$TOPICS_FILE" ]; then
+  echo "Error: $TOPICS_FILE not found." >&2
+  exit 1
+fi
+
+if ! command -v yq &>/dev/null; then
+  echo "Error: yq is required. Install with: brew install yq" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+# --- Helper: convert service key to title ---
+# "position-keeping" -> "Position Keeping"
+to_title() {
+  echo "$1" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2))}1'
+}
+
+# --- Helper: convert kebab-case to CamelCase ---
+# "transaction-captured" -> "TransactionCaptured"
+kebab_to_camel() {
+  echo "$1" | awk -F'-' '{for(i=1;i<=NF;i++) printf "%s", toupper(substr($i,1,1)) substr($i,2)}'
+}
+
+# --- Helper: find proto file containing a message ---
+# Returns the file path, or empty string if not found.
+find_proto_file() {
+  local message_name="$1"
+  for f in "$PROTO_DIR"/*.proto; do
+    if [ -f "$f" ] && grep -q "^message ${message_name} " "$f" 2>/dev/null; then
+      echo "$f"
+      return
+    fi
+  done
+  echo ""
+}
+
+# --- Helper: resolve proto_message from topics.yaml to actual proto message name ---
+# topics.yaml may use "TransactionCaptured" while proto defines "TransactionCapturedEvent".
+# Returns: "proto_file|proto_msg_name" or "|" if not found.
+resolve_proto_message() {
+  local topic_msg="$1"
+  if [ -z "$topic_msg" ]; then
+    echo "|"
+    return
+  fi
+
+  # Try exact name first
+  local pf
+  pf=$(find_proto_file "$topic_msg")
+  if [ -n "$pf" ]; then
+    echo "${pf}|${topic_msg}"
+    return
+  fi
+
+  # Try with Event suffix
+  pf=$(find_proto_file "${topic_msg}Event")
+  if [ -n "$pf" ]; then
+    echo "${pf}|${topic_msg}Event"
+    return
+  fi
+
+  echo "|"
+}
+
+# --- Helper: extract proto fields as JSON array ---
+extract_proto_fields() {
+  local proto_file="$1"
+  local message_name="$2"
+
+  if [ ! -f "$proto_file" ]; then
+    echo "[]"
+    return
+  fi
+
+  awk -v msg="$message_name" '
+    BEGIN { in_msg=0; depth=0; first=0; print "[" }
+    /^message / {
+      split($0, parts, " ")
+      if (parts[2] == msg) {
+        in_msg=1; depth=1
+        next
+      }
+    }
+    !in_msg { next }
+    /{/ { depth++ }
+    /}/ {
+      depth--
+      if (depth <= 0) { in_msg=0; next }
+    }
+    /^[[:space:]]*(message|oneof|enum) / { next }
+    /^[[:space:]]+[a-zA-Z]/ {
+      line = $0
+      gsub(/^[[:space:]]+/, "", line)
+      if (line ~ /^\/\//) next
+
+      n = split(line, parts, " ")
+      # Standard field: type name = N
+      if (n >= 4 && parts[3] == "=") {
+        type = parts[1]
+        name = parts[2]
+        json_type = "string"
+        if (type ~ /^(int32|int64|uint32|uint64|sint32|sint64|fixed32|fixed64|sfixed32|sfixed64)$/) json_type = "integer"
+        else if (type ~ /^(float|double)$/) json_type = "number"
+        else if (type == "bool") json_type = "boolean"
+        else if (type == "google.protobuf.Timestamp") json_type = "string"
+        else if (type ~ /^map/) json_type = "object"
+        if (first) printf ","
+        printf "\n  {\"name\":\"%s\",\"type\":\"%s\"}", name, json_type
+        first = 1
+      }
+      # Repeated field: repeated type name = N
+      else if (n >= 5 && parts[1] == "repeated" && parts[4] == "=") {
+        name = parts[3]
+        if (first) printf ","
+        printf "\n  {\"name\":\"%s\",\"type\":\"array\"}", name
+        first = 1
+      }
+    }
+    END { print "\n]" }
+  ' "$proto_file"
+}
+
+# --- Helper: infer partition key from proto message ---
+# Convention: first string field ending in _id (excluding event_id, correlation_id, etc.)
+infer_partition_key() {
+  local proto_file="$1"
+  local message_name="$2"
+
+  if [ ! -f "$proto_file" ]; then
+    echo ""
+    return
+  fi
+
+  awk -v msg="$message_name" '
+    BEGIN { in_msg=0; depth=0; found="" }
+    /^message / {
+      split($0, parts, " ")
+      if (parts[2] == msg) { in_msg=1; depth=1; next }
+    }
+    !in_msg { next }
+    /{/ { depth++ }
+    /}/ { depth--; if (depth <= 0) { in_msg=0; next } }
+    /^[[:space:]]+string [a-z]/ {
+      line = $0
+      gsub(/^[[:space:]]+/, "", line)
+      n = split(line, parts, " ")
+      if (n >= 4 && parts[3] == "=") {
+        name = parts[2]
+        if (name == "event_id" || name == "correlation_id" || name == "causation_id" || name == "idempotency_key") next
+        if (name ~ /_id$/ && found == "") found = name
+      }
+    }
+    END { print found }
+  ' "$proto_file"
+}
+
+# --- Helper: describe a partition key field ---
+describe_partition_key() {
+  local key="$1"
+  case "$key" in
+    account_id)    echo "Account ID" ;;
+    log_id)        echo "Position log ID" ;;
+    batch_id)      echo "Batch operation ID" ;;
+    withdrawal_id) echo "Withdrawal ID" ;;
+    transaction_id) echo "Transaction ID" ;;
+    facility_id)   echo "Facility ID" ;;
+    party_id)      echo "Party ID" ;;
+    order_id)      echo "Payment order ID" ;;
+    run_id)        echo "Reconciliation run ID" ;;
+    dispute_id)    echo "Dispute ID" ;;
+    *)             echo "$key" ;;
+  esac
+}
+
+# --- Helper: write schema properties from proto fields ---
+write_schema_properties() {
+  local proto_file="$1"
+  local proto_msg="$2"
+  local output="$3"
+
+  if [ -z "$proto_file" ] || [ ! -f "$proto_file" ]; then
+    cat >> "$output" <<'PROPEOF'
+        event_type:
+          type: string
+          description: "Proto definition not yet available in api/proto/meridian/events/v1/"
+PROPEOF
+    return
+  fi
+
+  local fields_json
+  fields_json=$(extract_proto_fields "$proto_file" "$proto_msg")
+  local field_count
+  field_count=$(echo "$fields_json" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
+
+  if [ "$field_count" -gt 0 ]; then
+    echo "$fields_json" | python3 -c "
+import sys, json
+fields = json.load(sys.stdin)
+for f in fields:
+    name = f['name']
+    ftype = f['type']
+    if ftype == 'array':
+        print(f'        {name}:')
+        print(f'          type: array')
+        print(f'          items:')
+        print(f'            type: string')
+    elif ftype == 'object':
+        print(f'        {name}:')
+        print(f'          type: object')
+    else:
+        print(f'        {name}:')
+        print(f'          type: {ftype}')
+" >> "$output"
+  else
+    cat >> "$output" <<'PROPEOF'
+        event_type:
+          type: string
+PROPEOF
+  fi
+}
+
+# --- Main: iterate over services in topics.yaml ---
+
+SERVICES=$(yq -r '.services | keys | .[]' "$TOPICS_FILE")
+
+FILE_COUNT=0
+
+for SERVICE in $SERVICES; do
+  SERVICE_DESC=$(yq -r ".services.\"${SERVICE}\".description // \"\"" "$TOPICS_FILE")
+  SERVICE_TITLE="$(to_title "$SERVICE") Events"
+  OUTPUT_FILE="${OUTPUT_DIR}/${SERVICE}.yaml"
+
+  # Count non-deprecated topics
+  TOPIC_COUNT=$(yq -r ".services.\"${SERVICE}\".topics[] | select(.deprecated != true) | .name" "$TOPICS_FILE" | wc -l | tr -d ' ')
+  if [ "$TOPIC_COUNT" -eq 0 ]; then
+    echo "  Skipping $SERVICE (no active topics)"
+    continue
+  fi
+
+  # --- Header ---
+  cat > "$OUTPUT_FILE" <<EOF
+asyncapi: 3.0.0
+info:
+  title: "${SERVICE_TITLE}"
+  version: 1.0.0
+  description: "${SERVICE_DESC}"
+servers:
+  kafka:
+    host: kafka:9092
+    protocol: kafka
+channels:
+EOF
+
+  # --- Channels ---
+  TOPICS=$(yq -r ".services.\"${SERVICE}\".topics[] | select(.deprecated != true) | .name" "$TOPICS_FILE")
+
+  for TOPIC in $TOPICS; do
+    PROTO_MSG_RAW=$(yq -r ".services.\"${SERVICE}\".topics[] | select(.name == \"${TOPIC}\") | .proto_message // \"\"" "$TOPICS_FILE")
+    TOPIC_DESC=$(yq -r ".services.\"${SERVICE}\".topics[] | select(.name == \"${TOPIC}\") | .description // \"\"" "$TOPICS_FILE")
+
+    # Use the topics.yaml name as the AsyncAPI reference name
+    MSG_REF="$PROTO_MSG_RAW"
+
+    cat >> "$OUTPUT_FILE" <<EOF
+  ${TOPIC}:
+    address: "${TOPIC}"
+    description: "${TOPIC_DESC}"
+EOF
+
+    if [ -n "$MSG_REF" ]; then
+      cat >> "$OUTPUT_FILE" <<EOF
+    messages:
+      ${MSG_REF}:
+        \$ref: '#/components/messages/${MSG_REF}'
+EOF
+    fi
+  done
+
+  # --- Operations ---
+  cat >> "$OUTPUT_FILE" <<EOF
+operations:
+EOF
+
+  for TOPIC in $TOPICS; do
+    PROTO_MSG_RAW=$(yq -r ".services.\"${SERVICE}\".topics[] | select(.name == \"${TOPIC}\") | .proto_message // \"\"" "$TOPICS_FILE")
+
+    # Build operation ID from all segments except the service prefix and version suffix.
+    # position-keeping.transaction-captured.v1 -> publishTransactionCaptured
+    # audit.events.v1.dlq -> publishEventsDlq
+    # Strip service prefix (first segment) and join remaining segments.
+    EVENT_PARTS=$(echo "$TOPIC" | awk -F. '{for(i=2;i<=NF;i++){if($i ~ /^v[0-9]+$/) continue; printf "%s\n", $i}}')
+    CAMEL=""
+    for PART in $EVENT_PARTS; do
+      CAMEL="${CAMEL}$(kebab_to_camel "$PART")"
+    done
+    OP_ID="publish${CAMEL}"
+
+    cat >> "$OUTPUT_FILE" <<EOF
+  ${OP_ID}:
+    action: send
+    channel:
+      \$ref: '#/channels/${TOPIC}'
+EOF
+  done
+
+  # --- Components: messages ---
+  cat >> "$OUTPUT_FILE" <<EOF
+components:
+  messages:
+EOF
+
+  for TOPIC in $TOPICS; do
+    PROTO_MSG_RAW=$(yq -r ".services.\"${SERVICE}\".topics[] | select(.name == \"${TOPIC}\") | .proto_message // \"\"" "$TOPICS_FILE")
+    if [ -z "$PROTO_MSG_RAW" ]; then
+      continue
+    fi
+
+    MSG_REF="$PROTO_MSG_RAW"
+    TOPIC_DESC=$(yq -r ".services.\"${SERVICE}\".topics[] | select(.name == \"${TOPIC}\") | .description // \"\"" "$TOPICS_FILE")
+
+    # Resolve proto message for partition key inference
+    RESOLVED=$(resolve_proto_message "$PROTO_MSG_RAW")
+    PROTO_FILE="${RESOLVED%%|*}"
+    PROTO_MSG="${RESOLVED##*|}"
+
+    # Infer partition key
+    PARTITION_KEY=""
+    PARTITION_DESC=""
+    if [ -n "$PROTO_FILE" ] && [ -n "$PROTO_MSG" ]; then
+      PARTITION_KEY=$(infer_partition_key "$PROTO_FILE" "$PROTO_MSG")
+      if [ -n "$PARTITION_KEY" ]; then
+        PARTITION_DESC=$(describe_partition_key "$PARTITION_KEY")
+      fi
+    fi
+
+    cat >> "$OUTPUT_FILE" <<EOF
+    ${MSG_REF}:
+      name: "${MSG_REF}"
+      title: "${MSG_REF}"
+      description: "${TOPIC_DESC}"
+      contentType: application/protobuf
+EOF
+
+    if [ -n "$PARTITION_KEY" ]; then
+      cat >> "$OUTPUT_FILE" <<EOF
+      bindings:
+        kafka:
+          key:
+            type: string
+            description: "${PARTITION_DESC}"
+EOF
+    fi
+
+    cat >> "$OUTPUT_FILE" <<EOF
+      headers:
+        type: object
+        properties:
+          event_type:
+            type: string
+            description: Logical event type identifier
+          correlation_id:
+            type: string
+            format: uuid
+            description: Links related events across services
+          tenant_id:
+            type: string
+            description: Tenant identifier for multi-tenant isolation
+      payload:
+        \$ref: '#/components/schemas/${MSG_REF}'
+EOF
+  done
+
+  # --- Components: schemas ---
+  cat >> "$OUTPUT_FILE" <<EOF
+  schemas:
+EOF
+
+  for TOPIC in $TOPICS; do
+    PROTO_MSG_RAW=$(yq -r ".services.\"${SERVICE}\".topics[] | select(.name == \"${TOPIC}\") | .proto_message // \"\"" "$TOPICS_FILE")
+    if [ -z "$PROTO_MSG_RAW" ]; then
+      continue
+    fi
+
+    MSG_REF="$PROTO_MSG_RAW"
+
+    # Resolve to actual proto message name for field extraction
+    RESOLVED=$(resolve_proto_message "$PROTO_MSG_RAW")
+    PROTO_FILE="${RESOLVED%%|*}"
+    PROTO_MSG="${RESOLVED##*|}"
+
+    cat >> "$OUTPUT_FILE" <<EOF
+    ${MSG_REF}:
+      type: object
+      description: "Derived from protobuf message meridian.events.v1.${PROTO_MSG:-$MSG_REF}"
+      properties:
+EOF
+
+    write_schema_properties "$PROTO_FILE" "$PROTO_MSG" "$OUTPUT_FILE"
+  done
+
+  FILE_COUNT=$((FILE_COUNT + 1))
+  echo "  ${OUTPUT_FILE} (${TOPIC_COUNT} channels)"
+done
+
+echo ""
+echo "Generated ${FILE_COUNT} AsyncAPI spec files in ${OUTPUT_DIR}/"

--- a/scripts/gen-asyncapi.sh
+++ b/scripts/gen-asyncapi.sh
@@ -209,6 +209,7 @@ write_schema_properties() {
   local output="$3"
 
   if [ -z "$proto_file" ] || [ ! -f "$proto_file" ]; then
+    echo "  WARNING: unresolved proto message '${proto_msg}' — schema will use placeholder" >&2
     cat >> "$output" <<'PROPEOF'
         event_type:
           type: string


### PR DESCRIPTION
## Summary

- Add `scripts/gen-asyncapi.sh` that reads the Kafka topic registry (`shared/platform/events/topics/topics.yaml`) and proto event definitions to produce one AsyncAPI 3.0.0 YAML file per BIAN service domain
- Generate 9 AsyncAPI spec files covering all active service domains: audit, current-account, financial-accounting, internal-account, market-information, party, payment-order, position-keeping, and reconciliation
- Add `make asyncapi` Makefile target for easy regeneration

## Changes Made

**Generation script** (`scripts/gen-asyncapi.sh`):
- Reads topic registry YAML, iterates over services, generates AsyncAPI 3.0.0 compliant YAML
- Extracts schema properties from protobuf message definitions in `api/proto/meridian/events/v1/`
- Infers Kafka partition keys from proto fields (first `*_id` string field, excluding event/correlation/causation/idempotency IDs) and emits them as Kafka message binding `key`
- Correctly excludes deprecated topics (e.g., legacy `financial-accounting.booking-log.controlled`)
- Requires `yq` for YAML parsing, `python3` for JSON processing

**Generated specs** (`api/asyncapi/*.yaml`):
- AsyncAPI 3.0.0 format with channels, operations, messages, and schemas
- Standard Kafka headers (event_type, correlation_id, tenant_id) on all messages
- Schema properties derived from proto message fields with proper type mapping (proto types to JSON Schema types)
- Validated with `asyncapi validate` (zero errors)

## Task Master

prd-030-asyncapi-spec.6

## Test Plan

- [x] `make asyncapi` regenerates all 9 spec files
- [x] `asyncapi validate api/asyncapi/*.yaml` passes with zero errors on all files
- [x] All non-deprecated topics from topics.yaml have corresponding channels
- [x] Deprecated topics are excluded
- [ ] CI passes