### PR TITLE
feat: generate type-safe event publishers from AsyncAPI specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ GOMOD=$(GOCMD) mod
 GOGET=$(GOCMD) get
 GOFMT=$(GOCMD) fmt
 
-.PHONY: all help build seed-dev seed-dev-build test lint clean proto proto-v1 proto-v2 proto-openapi proto-lint proto-breaking proto-descriptors docker deploy-local fmt tidy deps coverage install proto-validate proto-deps-update proto-deps-graph proto-plugins-info validate-tilt validate-semconv validate-sagas proto-jsonschema validate-manifest-jsonschema validate-manifests control-plane-ci test-control-plane migrate-diff-all migrate-diff-current migrate-diff-position migrate-apply-all migrate-status-all migrate-lint-all migrate-hash-all migrate-apply-orgs migrate-status-orgs docs generate-saga-docs swagger-split swagger-ui dev-up dev-down dev-clean asyncapi
+.PHONY: all help build seed-dev seed-dev-build test lint clean proto proto-v1 proto-v2 proto-openapi proto-lint proto-breaking proto-descriptors docker deploy-local fmt tidy deps coverage install proto-validate proto-deps-update proto-deps-graph proto-plugins-info validate-tilt validate-semconv validate-sagas proto-jsonschema validate-manifest-jsonschema validate-manifests control-plane-ci test-control-plane migrate-diff-all migrate-diff-current migrate-diff-position migrate-apply-all migrate-status-all migrate-lint-all migrate-hash-all migrate-apply-orgs migrate-status-orgs docs generate-saga-docs swagger-split swagger-ui dev-up dev-down dev-clean asyncapi gen-event-publishers
 
 # Default target
 all: help
@@ -495,6 +495,10 @@ asyncapi:
 	@echo "Generating AsyncAPI specs..."
 	@./scripts/gen-asyncapi.sh
 	@echo "AsyncAPI specs generated in api/asyncapi/"
+
+## gen-event-publishers: Generate typed event publishers from AsyncAPI specs
+gen-event-publishers:
+	@$(GOCMD) run ./tools/gen-event-publishers
 
 ## validate-manifests: Validate example manifests against protobuf schema, CEL, and Starlark
 validate-manifests:

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ help:
 	@echo ""
 	@echo "Documentation targets:"
 	@echo "  make generate-saga-docs        - Generate Markdown and JSON Schema docs for saga handlers"
+	@echo "  make gen-event-publishers      - Generate typed event publishers from AsyncAPI specs"
 	@echo ""
 	@echo "API Explorer targets:"
 	@echo "  make swagger-split             - Split monolithic swagger into per-service files"

--- a/gen/events/current_account/publisher.go
+++ b/gen/events/current_account/publisher.go
@@ -1,0 +1,131 @@
+// Code generated from api/asyncapi/current-account.yaml. DO NOT EDIT.
+
+package current_account
+
+import (
+	"context"
+
+	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"gorm.io/gorm"
+)
+
+// Publisher provides type-safe event publishing for the Current Account Events domain.
+type Publisher struct {
+	outbox *events.OutboxPublisher
+}
+
+// NewPublisher creates a new Publisher wrapping the given OutboxPublisher.
+func NewPublisher(outbox *events.OutboxPublisher) *Publisher {
+	return &Publisher{outbox: outbox}
+}
+
+// PublishOption configures event publishing behavior.
+type PublishOption func(*events.PublishConfig)
+
+// WithCorrelationID returns a PublishOption that sets the correlation ID.
+func WithCorrelationID(id string) PublishOption {
+	return func(c *events.PublishConfig) { c.CorrelationID = id }
+}
+
+// WithCausationID returns a PublishOption that sets the causation ID.
+func WithCausationID(id string) PublishOption {
+	return func(c *events.PublishConfig) { c.CausationID = id }
+}
+
+// WithPartitionKey returns a PublishOption that overrides the default partition key.
+func WithPartitionKey(key string) PublishOption {
+	return func(c *events.PublishConfig) { c.PartitionKey = key }
+}
+
+// PublishAccountClosedEvent publishes a AccountClosedEvent to "current-account.account-closed.v1".
+//
+// Published when an account is permanently closed
+func (p *Publisher) PublishAccountClosedEvent(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.AccountClosedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "current_account.account_closed.v1",
+		Topic:         "current-account.account-closed.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishAccountFrozenEvent publishes a AccountFrozenEvent to "current-account.account-frozen.v1".
+//
+// Published when an account is frozen (no debits or credits permitted)
+func (p *Publisher) PublishAccountFrozenEvent(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.AccountFrozenEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "current_account.account_frozen.v1",
+		Topic:         "current-account.account-frozen.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishAccountUnfrozenEvent publishes a AccountUnfrozenEvent to "current-account.account-unfrozen.v1".
+//
+// Published when a previously frozen account is unfrozen
+func (p *Publisher) PublishAccountUnfrozenEvent(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.AccountUnfrozenEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "current_account.account_unfrozen.v1",
+		Topic:         "current-account.account-unfrozen.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishWithdrawalStatusUpdated publishes a WithdrawalStatusUpdatedEvent to "current-account.withdrawal-status.v1".
+//
+// Published when a withdrawal status changes (initiated, completed, failed, reversed)
+func (p *Publisher) PublishWithdrawalStatusUpdated(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.WithdrawalStatusUpdatedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "current_account.withdrawal_status.v1",
+		Topic:         "current-account.withdrawal-status.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}

--- a/gen/events/internal_account/publisher.go
+++ b/gen/events/internal_account/publisher.go
@@ -1,0 +1,85 @@
+// Code generated from api/asyncapi/internal-account.yaml. DO NOT EDIT.
+
+package internal_account
+
+import (
+	"context"
+
+	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"gorm.io/gorm"
+)
+
+// Publisher provides type-safe event publishing for the Internal Account Events domain.
+type Publisher struct {
+	outbox *events.OutboxPublisher
+}
+
+// NewPublisher creates a new Publisher wrapping the given OutboxPublisher.
+func NewPublisher(outbox *events.OutboxPublisher) *Publisher {
+	return &Publisher{outbox: outbox}
+}
+
+// PublishOption configures event publishing behavior.
+type PublishOption func(*events.PublishConfig)
+
+// WithCorrelationID returns a PublishOption that sets the correlation ID.
+func WithCorrelationID(id string) PublishOption {
+	return func(c *events.PublishConfig) { c.CorrelationID = id }
+}
+
+// WithCausationID returns a PublishOption that sets the causation ID.
+func WithCausationID(id string) PublishOption {
+	return func(c *events.PublishConfig) { c.CausationID = id }
+}
+
+// WithPartitionKey returns a PublishOption that overrides the default partition key.
+func WithPartitionKey(key string) PublishOption {
+	return func(c *events.PublishConfig) { c.PartitionKey = key }
+}
+
+// PublishBookingCreatedEvent publishes a BookingCreatedEvent to "internal-account.booking-created.v1".
+//
+// Published when a new booking is posted to an internal account
+func (p *Publisher) PublishBookingCreatedEvent(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.BookingCreatedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "internal_account.booking_created.v1",
+		Topic:         "internal-account.booking-created.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishFacilityCreatedEvent publishes a FacilityCreatedEvent to "internal-account.facility-created.v1".
+//
+// Published when a new internal account facility is initiated
+func (p *Publisher) PublishFacilityCreatedEvent(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.FacilityCreatedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "internal_account.facility_created.v1",
+		Topic:         "internal-account.facility-created.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}

--- a/gen/events/party/publisher.go
+++ b/gen/events/party/publisher.go
@@ -1,0 +1,108 @@
+// Code generated from api/asyncapi/party.yaml. DO NOT EDIT.
+
+package party
+
+import (
+	"context"
+
+	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"gorm.io/gorm"
+)
+
+// Publisher provides type-safe event publishing for the Party Events domain.
+type Publisher struct {
+	outbox *events.OutboxPublisher
+}
+
+// NewPublisher creates a new Publisher wrapping the given OutboxPublisher.
+func NewPublisher(outbox *events.OutboxPublisher) *Publisher {
+	return &Publisher{outbox: outbox}
+}
+
+// PublishOption configures event publishing behavior.
+type PublishOption func(*events.PublishConfig)
+
+// WithCorrelationID returns a PublishOption that sets the correlation ID.
+func WithCorrelationID(id string) PublishOption {
+	return func(c *events.PublishConfig) { c.CorrelationID = id }
+}
+
+// WithCausationID returns a PublishOption that sets the causation ID.
+func WithCausationID(id string) PublishOption {
+	return func(c *events.PublishConfig) { c.CausationID = id }
+}
+
+// WithPartitionKey returns a PublishOption that overrides the default partition key.
+func WithPartitionKey(key string) PublishOption {
+	return func(c *events.PublishConfig) { c.PartitionKey = key }
+}
+
+// PublishPartyCreatedEvent publishes a PartyCreatedEvent to "party.created.v1".
+//
+// Published when a new party is registered in the system
+func (p *Publisher) PublishPartyCreatedEvent(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.PartyCreatedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "party.created.v1",
+		Topic:         "party.created.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishPartyUpdatedEvent publishes a PartyUpdatedEvent to "party.updated.v1".
+//
+// Published when an existing party's details are updated
+func (p *Publisher) PublishPartyUpdatedEvent(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.PartyUpdatedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "party.updated.v1",
+		Topic:         "party.updated.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishPartyVerificationCompletedEvent publishes a PartyVerificationCompletedEvent to "party.verification-completed.v1".
+//
+// Published when a KYC/AML verification reaches a terminal state (APPROVED, REJECTED, MANUAL_REVIEW)
+func (p *Publisher) PublishPartyVerificationCompletedEvent(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.PartyVerificationCompletedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "party.verification_completed.v1",
+		Topic:         "party.verification-completed.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}

--- a/gen/events/payment_order/publisher.go
+++ b/gen/events/payment_order/publisher.go
@@ -1,0 +1,200 @@
+// Code generated from api/asyncapi/payment-order.yaml. DO NOT EDIT.
+
+package payment_order
+
+import (
+	"context"
+
+	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"gorm.io/gorm"
+)
+
+// Publisher provides type-safe event publishing for the Payment Order Events domain.
+type Publisher struct {
+	outbox *events.OutboxPublisher
+}
+
+// NewPublisher creates a new Publisher wrapping the given OutboxPublisher.
+func NewPublisher(outbox *events.OutboxPublisher) *Publisher {
+	return &Publisher{outbox: outbox}
+}
+
+// PublishOption configures event publishing behavior.
+type PublishOption func(*events.PublishConfig)
+
+// WithCorrelationID returns a PublishOption that sets the correlation ID.
+func WithCorrelationID(id string) PublishOption {
+	return func(c *events.PublishConfig) { c.CorrelationID = id }
+}
+
+// WithCausationID returns a PublishOption that sets the causation ID.
+func WithCausationID(id string) PublishOption {
+	return func(c *events.PublishConfig) { c.CausationID = id }
+}
+
+// WithPartitionKey returns a PublishOption that overrides the default partition key.
+func WithPartitionKey(key string) PublishOption {
+	return func(c *events.PublishConfig) { c.PartitionKey = key }
+}
+
+// PublishPaymentOrderCancelled publishes a PaymentOrderCancelledEvent to "payment-order.cancelled.v1".
+//
+// Published when a payment order is cancelled before execution
+func (p *Publisher) PublishPaymentOrderCancelled(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.PaymentOrderCancelledEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "payment_order.cancelled.v1",
+		Topic:         "payment-order.cancelled.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishPaymentOrderCompleted publishes a PaymentOrderCompletedEvent to "payment-order.completed.v1".
+//
+// Published when a payment order successfully completes
+func (p *Publisher) PublishPaymentOrderCompleted(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.PaymentOrderCompletedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "payment_order.completed.v1",
+		Topic:         "payment-order.completed.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishPaymentOrderExecuting publishes a PaymentOrderExecutingEvent to "payment-order.executing.v1".
+//
+// Published when a payment order begins execution with the payment gateway
+func (p *Publisher) PublishPaymentOrderExecuting(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.PaymentOrderExecutingEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "payment_order.executing.v1",
+		Topic:         "payment-order.executing.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishPaymentOrderFailed publishes a PaymentOrderFailedEvent to "payment-order.failed.v1".
+//
+// Published when a payment order fails and cannot be retried
+func (p *Publisher) PublishPaymentOrderFailed(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.PaymentOrderFailedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "payment_order.failed.v1",
+		Topic:         "payment-order.failed.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishPaymentOrderInitiated publishes a PaymentOrderInitiatedEvent to "payment-order.initiated.v1".
+//
+// Published when a new payment order is initiated
+func (p *Publisher) PublishPaymentOrderInitiated(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.PaymentOrderInitiatedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "payment_order.initiated.v1",
+		Topic:         "payment-order.initiated.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishPaymentOrderReserved publishes a PaymentOrderReservedEvent to "payment-order.reserved.v1".
+//
+// Published when funds are successfully reserved for a payment order
+func (p *Publisher) PublishPaymentOrderReserved(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.PaymentOrderReservedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "payment_order.reserved.v1",
+		Topic:         "payment-order.reserved.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishPaymentOrderReversed publishes a PaymentOrderReversedEvent to "payment-order.reversed.v1".
+//
+// Published when a completed payment order is reversed
+func (p *Publisher) PublishPaymentOrderReversed(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.PaymentOrderReversedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "payment_order.reversed.v1",
+		Topic:         "payment-order.reversed.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}

--- a/gen/events/position_keeping/publisher.go
+++ b/gen/events/position_keeping/publisher.go
@@ -1,0 +1,246 @@
+// Code generated from api/asyncapi/position-keeping.yaml. DO NOT EDIT.
+
+package position_keeping
+
+import (
+	"context"
+
+	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"gorm.io/gorm"
+)
+
+// Publisher provides type-safe event publishing for the Position Keeping Events domain.
+type Publisher struct {
+	outbox *events.OutboxPublisher
+}
+
+// NewPublisher creates a new Publisher wrapping the given OutboxPublisher.
+func NewPublisher(outbox *events.OutboxPublisher) *Publisher {
+	return &Publisher{outbox: outbox}
+}
+
+// PublishOption configures event publishing behavior.
+type PublishOption func(*events.PublishConfig)
+
+// WithCorrelationID returns a PublishOption that sets the correlation ID.
+func WithCorrelationID(id string) PublishOption {
+	return func(c *events.PublishConfig) { c.CorrelationID = id }
+}
+
+// WithCausationID returns a PublishOption that sets the causation ID.
+func WithCausationID(id string) PublishOption {
+	return func(c *events.PublishConfig) { c.CausationID = id }
+}
+
+// WithPartitionKey returns a PublishOption that overrides the default partition key.
+func WithPartitionKey(key string) PublishOption {
+	return func(c *events.PublishConfig) { c.PartitionKey = key }
+}
+
+// PublishBulkTransactionCaptured publishes a BulkTransactionCapturedEvent to "position-keeping.bulk-transaction-captured.v1".
+//
+// Published when a batch of transactions is captured atomically
+func (p *Publisher) PublishBulkTransactionCaptured(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.BulkTransactionCapturedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "position_keeping.bulk_transaction_captured.v1",
+		Topic:         "position-keeping.bulk-transaction-captured.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishOpeningBalanceRecorded publishes a OpeningBalanceRecordedEvent to "position-keeping.opening-balance-recorded.v1".
+//
+// Published when an opening balance is recorded for a new account
+func (p *Publisher) PublishOpeningBalanceRecorded(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.OpeningBalanceRecordedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "position_keeping.opening_balance_recorded.v1",
+		Topic:         "position-keeping.opening-balance-recorded.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishTransactionAmended publishes a TransactionAmendedEvent to "position-keeping.transaction-amended.v1".
+//
+// Published when a captured transaction is amended
+func (p *Publisher) PublishTransactionAmended(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.TransactionAmendedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "position_keeping.transaction_amended.v1",
+		Topic:         "position-keeping.transaction-amended.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishTransactionCancelled publishes a TransactionCancelledEvent to "position-keeping.transaction-cancelled.v1".
+//
+// Published when a transaction is cancelled
+func (p *Publisher) PublishTransactionCancelled(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.TransactionCancelledEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "position_keeping.transaction_cancelled.v1",
+		Topic:         "position-keeping.transaction-cancelled.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishTransactionCaptured publishes a TransactionCapturedEvent to "position-keeping.transaction-captured.v1".
+//
+// Published when a new financial transaction is captured
+func (p *Publisher) PublishTransactionCaptured(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.TransactionCapturedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "position_keeping.transaction_captured.v1",
+		Topic:         "position-keeping.transaction-captured.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishTransactionFailed publishes a TransactionFailedEvent to "position-keeping.transaction-failed.v1".
+//
+// Published when a transaction fails due to a system error
+func (p *Publisher) PublishTransactionFailed(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.TransactionFailedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "position_keeping.transaction_failed.v1",
+		Topic:         "position-keeping.transaction-failed.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishTransactionPosted publishes a TransactionPostedEvent to "position-keeping.transaction-posted.v1".
+//
+// Published when a transaction is posted to the ledger
+func (p *Publisher) PublishTransactionPosted(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.TransactionPostedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "position_keeping.transaction_posted.v1",
+		Topic:         "position-keeping.transaction-posted.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishTransactionReconciled publishes a TransactionReconciledEvent to "position-keeping.transaction-reconciled.v1".
+//
+// Published when a transaction is reconciled against actual settlement data
+func (p *Publisher) PublishTransactionReconciled(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.TransactionReconciledEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "position_keeping.transaction_reconciled.v1",
+		Topic:         "position-keeping.transaction-reconciled.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishTransactionRejected publishes a TransactionRejectedEvent to "position-keeping.transaction-rejected.v1".
+//
+// Published when a transaction is rejected due to validation failure
+func (p *Publisher) PublishTransactionRejected(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.TransactionRejectedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "position_keeping.transaction_rejected.v1",
+		Topic:         "position-keeping.transaction-rejected.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}

--- a/gen/events/reconciliation/publisher.go
+++ b/gen/events/reconciliation/publisher.go
@@ -1,0 +1,177 @@
+// Code generated from api/asyncapi/reconciliation.yaml. DO NOT EDIT.
+
+package reconciliation
+
+import (
+	"context"
+
+	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"gorm.io/gorm"
+)
+
+// Publisher provides type-safe event publishing for the Reconciliation Events domain.
+type Publisher struct {
+	outbox *events.OutboxPublisher
+}
+
+// NewPublisher creates a new Publisher wrapping the given OutboxPublisher.
+func NewPublisher(outbox *events.OutboxPublisher) *Publisher {
+	return &Publisher{outbox: outbox}
+}
+
+// PublishOption configures event publishing behavior.
+type PublishOption func(*events.PublishConfig)
+
+// WithCorrelationID returns a PublishOption that sets the correlation ID.
+func WithCorrelationID(id string) PublishOption {
+	return func(c *events.PublishConfig) { c.CorrelationID = id }
+}
+
+// WithCausationID returns a PublishOption that sets the causation ID.
+func WithCausationID(id string) PublishOption {
+	return func(c *events.PublishConfig) { c.CausationID = id }
+}
+
+// WithPartitionKey returns a PublishOption that overrides the default partition key.
+func WithPartitionKey(key string) PublishOption {
+	return func(c *events.PublishConfig) { c.PartitionKey = key }
+}
+
+// PublishDisputeCreated publishes a DisputeCreatedEvent to "reconciliation.dispute-created.v1".
+//
+// Published when a reconciliation dispute is raised
+func (p *Publisher) PublishDisputeCreated(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.DisputeCreatedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "reconciliation.dispute_created.v1",
+		Topic:         "reconciliation.dispute-created.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishDisputeResolved publishes a DisputeResolvedEvent to "reconciliation.dispute-resolved.v1".
+//
+// Published when a reconciliation dispute is resolved
+func (p *Publisher) PublishDisputeResolved(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.DisputeResolvedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "reconciliation.dispute_resolved.v1",
+		Topic:         "reconciliation.dispute-resolved.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishPositionLockRequested publishes a PositionLockRequestedEvent to "reconciliation.position-lock-requested.v1".
+//
+// Published when a position lock is requested to freeze a position for reconciliation
+func (p *Publisher) PublishPositionLockRequested(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.PositionLockRequestedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "reconciliation.position_lock_requested.v1",
+		Topic:         "reconciliation.position-lock-requested.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishReconciliationRunCompleted publishes a ReconciliationRunCompletedEvent to "reconciliation.run-completed.v1".
+//
+// Published when a reconciliation run completes (with or without variances)
+func (p *Publisher) PublishReconciliationRunCompleted(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.ReconciliationRunCompletedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "reconciliation.run_completed.v1",
+		Topic:         "reconciliation.run-completed.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishReconciliationRunStarted publishes a ReconciliationRunStartedEvent to "reconciliation.run-started.v1".
+//
+// Published when a reconciliation run begins
+func (p *Publisher) PublishReconciliationRunStarted(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.ReconciliationRunStartedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "reconciliation.run_started.v1",
+		Topic:         "reconciliation.run-started.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+
+// PublishVarianceDetected publishes a VarianceDetectedEvent to "reconciliation.variance-detected.v1".
+//
+// Published when a position variance is detected during reconciliation
+func (p *Publisher) PublishVarianceDetected(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.VarianceDetectedEvent,
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "reconciliation.variance_detected.v1",
+		Topic:         "reconciliation.variance-detected.v1",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}

--- a/tools/gen-event-publishers/main.go
+++ b/tools/gen-event-publishers/main.go
@@ -167,8 +167,7 @@ func main() {
 
 		svc, err := processAsyncAPIFile(filepath.Join(asyncAPIDir, entry.Name()), knownProtoTypes)
 		if err != nil {
-			log.Printf("WARN: skipping %s: %v", entry.Name(), err)
-			continue
+			log.Fatalf("Failed to process %s: %v", entry.Name(), err)
 		}
 		if svc == nil {
 			continue
@@ -243,6 +242,7 @@ func processAsyncAPIFile(path string, knownProtoTypes map[string]bool) (*Service
 		channelKey := strings.TrimPrefix(op.Channel.Ref, "#/channels/")
 		channel, ok := spec.Channels[channelKey]
 		if !ok {
+			log.Printf("WARN: %s: operation references unknown channel %q", filename, channelKey)
 			continue
 		}
 
@@ -285,12 +285,14 @@ func resolveChannelEvents(channel Channel, components Components, schemaToProto 
 		componentName := strings.TrimPrefix(msg.Ref, "#/components/messages/")
 		component, ok := components.Messages[componentName]
 		if !ok {
+			log.Printf("WARN: channel %q references unknown component message %q", channel.Address, componentName)
 			continue
 		}
 		schemaName := strings.TrimPrefix(component.Payload.Ref, "#/components/schemas/")
 
 		protoType, ok := schemaToProto[schemaName]
 		if !ok {
+			// Schema exists but has no valid proto type mapping (already logged during schema scan).
 			continue
 		}
 

--- a/tools/gen-event-publishers/main.go
+++ b/tools/gen-event-publishers/main.go
@@ -241,33 +241,7 @@ func processAsyncAPIFile(path string, knownProtoTypes map[string]bool) (*Service
 			continue
 		}
 
-		// Get the first (and typically only) message key from the channel.
-		var msgKey string
-		for k := range channel.Messages {
-			msgKey = k
-			break
-		}
-		if msgKey == "" {
-			continue
-		}
-
-		// Look up the proto type from the schema name.
-		protoType, ok := schemaToProto[msgKey]
-		if !ok {
-			continue
-		}
-
-		topic := channel.Address
-		eventType := topicToEventType(topic)
-		methodName := "Publish" + msgKey
-
-		events = append(events, EventDef{
-			MethodName:  methodName,
-			ProtoType:   protoType,
-			Topic:       topic,
-			EventType:   eventType,
-			Description: channel.Description,
-		})
+		events = append(events, resolveChannelEvents(channel, spec.Components, schemaToProto)...)
 	}
 
 	if len(events) == 0 {
@@ -286,6 +260,48 @@ func processAsyncAPIFile(path string, knownProtoTypes map[string]bool) (*Service
 		Events:       events,
 		ModulePath:   modulePath,
 	}, nil
+}
+
+// resolveChannelEvents follows the $ref chain for each message in a channel
+// and returns EventDefs for messages with known proto types.
+func resolveChannelEvents(channel Channel, components Components, schemaToProto map[string]string) []EventDef {
+	// Iterate messages deterministically by sorting keys.
+	msgKeys := make([]string, 0, len(channel.Messages))
+	for k := range channel.Messages {
+		msgKeys = append(msgKeys, k)
+	}
+	sort.Strings(msgKeys)
+
+	var out []EventDef
+	for _, msgKey := range msgKeys {
+		msg := channel.Messages[msgKey]
+
+		// Follow the explicit $ref chain: message -> component message -> payload schema.
+		componentName := strings.TrimPrefix(msg.Ref, "#/components/messages/")
+		component, ok := components.Messages[componentName]
+		if !ok {
+			continue
+		}
+		schemaName := strings.TrimPrefix(component.Payload.Ref, "#/components/schemas/")
+
+		protoType, ok := schemaToProto[schemaName]
+		if !ok {
+			continue
+		}
+
+		topic := channel.Address
+		eventType := topicToEventType(topic)
+		methodName := "Publish" + componentName
+
+		out = append(out, EventDef{
+			MethodName:  methodName,
+			ProtoType:   protoType,
+			Topic:       topic,
+			EventType:   eventType,
+			Description: channel.Description,
+		})
+	}
+	return out
 }
 
 // topicToEventType converts "position-keeping.transaction-captured.v1" to "position_keeping.transaction_captured.v1".

--- a/tools/gen-event-publishers/main.go
+++ b/tools/gen-event-publishers/main.go
@@ -1,0 +1,388 @@
+// gen-event-publishers generates type-safe event publisher packages from AsyncAPI specs.
+//
+// It reads AsyncAPI 3.0.0 YAML files from api/asyncapi/ and generates Go packages
+// in gen/events/ that provide typed wrappers around the OutboxPublisher.
+//
+// Usage:
+//
+//	go run ./tools/gen-event-publishers
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"go/format"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	asyncAPIDir = "api/asyncapi"
+	outputDir   = "gen/events"
+	modulePath  = "github.com/meridianhub/meridian"
+	protoDir    = "api/proto/meridian/events/v1"
+)
+
+// AsyncAPI represents the subset of AsyncAPI 3.0.0 we need.
+type AsyncAPI struct {
+	Info       Info                 `yaml:"info"`
+	Channels   map[string]Channel   `yaml:"channels"`
+	Operations map[string]Operation `yaml:"operations"`
+	Components Components           `yaml:"components"`
+}
+
+// Info holds AsyncAPI document info.
+type Info struct {
+	Title string `yaml:"title"`
+}
+
+// Channel represents an AsyncAPI channel.
+type Channel struct {
+	Address     string             `yaml:"address"`
+	Description string             `yaml:"description"`
+	Messages    map[string]Message `yaml:"messages"`
+}
+
+// Message is a $ref to a component message.
+type Message struct {
+	Ref string `yaml:"$ref"`
+}
+
+// Operation represents an AsyncAPI operation.
+type Operation struct {
+	Action  string       `yaml:"action"`
+	Channel OperationRef `yaml:"channel"`
+}
+
+// OperationRef is a $ref to a channel.
+type OperationRef struct {
+	Ref string `yaml:"$ref"`
+}
+
+// Components holds the reusable message and schema definitions.
+type Components struct {
+	Messages map[string]ComponentMessage `yaml:"messages"`
+	Schemas  map[string]Schema           `yaml:"schemas"`
+}
+
+// ComponentMessage is a named message definition.
+type ComponentMessage struct {
+	Name    string `yaml:"name"`
+	Payload Ref    `yaml:"payload"`
+}
+
+// Ref is a generic $ref.
+type Ref struct {
+	Ref string `yaml:"$ref"`
+}
+
+// Schema holds the JSON schema with a description containing the proto type.
+type Schema struct {
+	Description string `yaml:"description"`
+}
+
+// EventDef holds the data needed to generate a publisher method.
+type EventDef struct {
+	MethodName  string
+	ProtoType   string
+	Topic       string
+	EventType   string
+	Description string
+}
+
+// ServiceDef holds all events for a single service publisher package.
+type ServiceDef struct {
+	PackageName  string
+	ServiceTitle string
+	SourceFile   string
+	Events       []EventDef
+	ModulePath   string
+}
+
+// protoTypeRe extracts the proto message name from the schema description.
+// Example: "Derived from protobuf message meridian.events.v1.TransactionCapturedEvent"
+var protoTypeRe = regexp.MustCompile(`meridian\.events\.v1\.(\w+)`)
+
+// protoMessageRe matches "message FooEvent {" lines in .proto files.
+var protoMessageRe = regexp.MustCompile(`^message\s+(\w+)\s*\{`)
+
+// loadProtoTypes scans .proto files and returns a set of known message type names.
+func loadProtoTypes() (map[string]bool, error) {
+	entries, err := os.ReadDir(protoDir)
+	if err != nil {
+		return nil, fmt.Errorf("read proto dir: %w", err)
+	}
+
+	types := make(map[string]bool)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".proto") {
+			continue
+		}
+		f, err := os.Open(filepath.Join(protoDir, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			if m := protoMessageRe.FindStringSubmatch(scanner.Text()); len(m) == 2 {
+				types[m[1]] = true
+			}
+		}
+		if err := f.Close(); err != nil {
+			return nil, err
+		}
+		if err := scanner.Err(); err != nil {
+			return nil, err
+		}
+	}
+	return types, nil
+}
+
+func main() {
+	knownProtoTypes, err := loadProtoTypes()
+	if err != nil {
+		log.Fatalf("Failed to load proto types: %v", err)
+	}
+	fmt.Printf("Found %d proto message types in %s\n", len(knownProtoTypes), protoDir)
+
+	entries, err := os.ReadDir(asyncAPIDir)
+	if err != nil {
+		log.Fatalf("Failed to read %s: %v", asyncAPIDir, err)
+	}
+
+	var services []ServiceDef
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+
+		svc, err := processAsyncAPIFile(filepath.Join(asyncAPIDir, entry.Name()), knownProtoTypes)
+		if err != nil {
+			log.Printf("WARN: skipping %s: %v", entry.Name(), err)
+			continue
+		}
+		if svc == nil {
+			continue
+		}
+
+		services = append(services, *svc)
+	}
+
+	if len(services) == 0 {
+		log.Fatal("No services generated")
+	}
+
+	for _, svc := range services {
+		if err := generatePublisher(svc); err != nil {
+			log.Fatalf("Failed to generate %s: %v", svc.PackageName, err)
+		}
+		fmt.Printf("Generated gen/events/%s/publisher.go (%d events)\n", svc.PackageName, len(svc.Events))
+	}
+
+	fmt.Printf("\nGenerated %d publisher packages in %s/\n", len(services), outputDir)
+}
+
+func processAsyncAPIFile(path string, knownProtoTypes map[string]bool) (*ServiceDef, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+
+	var spec AsyncAPI
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("parse YAML: %w", err)
+	}
+
+	filename := filepath.Base(path)
+	serviceName := strings.TrimSuffix(filename, ".yaml")
+
+	// Build a map from schema name to proto type extracted from description.
+	// Only include types that exist in the actual .proto files.
+	schemaToProto := make(map[string]string)
+	for name, schema := range spec.Components.Schemas {
+		matches := protoTypeRe.FindStringSubmatch(schema.Description)
+		if len(matches) < 2 {
+			continue
+		}
+		protoType := matches[1]
+		if !knownProtoTypes[protoType] {
+			log.Printf("INFO: skipping %s/%s (proto type %s not found in .proto files)", filename, name, protoType)
+			continue
+		}
+		schemaToProto[name] = protoType
+	}
+
+	// If no schemas have valid proto types, skip this service.
+	if len(schemaToProto) == 0 {
+		log.Printf("INFO: skipping %s (no valid proto type references in schemas)", filename)
+		return nil, nil //nolint:nilnil // nil,nil signals "skip this file" to caller
+	}
+
+	// Build event definitions from operations that have action=send.
+	var events []EventDef
+	for _, op := range spec.Operations {
+		if op.Action != "send" {
+			continue
+		}
+
+		// Resolve the channel ref: "#/channels/position-keeping.transaction-captured.v1"
+		channelKey := strings.TrimPrefix(op.Channel.Ref, "#/channels/")
+		channel, ok := spec.Channels[channelKey]
+		if !ok {
+			continue
+		}
+
+		// Get the first (and typically only) message key from the channel.
+		var msgKey string
+		for k := range channel.Messages {
+			msgKey = k
+			break
+		}
+		if msgKey == "" {
+			continue
+		}
+
+		// Look up the proto type from the schema name.
+		protoType, ok := schemaToProto[msgKey]
+		if !ok {
+			continue
+		}
+
+		topic := channel.Address
+		eventType := topicToEventType(topic)
+		methodName := "Publish" + msgKey
+
+		events = append(events, EventDef{
+			MethodName:  methodName,
+			ProtoType:   protoType,
+			Topic:       topic,
+			EventType:   eventType,
+			Description: channel.Description,
+		})
+	}
+
+	if len(events) == 0 {
+		return nil, nil //nolint:nilnil // nil,nil signals "skip this file" to caller
+	}
+
+	// Sort events by method name for deterministic output.
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].MethodName < events[j].MethodName
+	})
+
+	return &ServiceDef{
+		PackageName:  serviceToPackage(serviceName),
+		ServiceTitle: spec.Info.Title,
+		SourceFile:   filename,
+		Events:       events,
+		ModulePath:   modulePath,
+	}, nil
+}
+
+// topicToEventType converts "position-keeping.transaction-captured.v1" to "position_keeping.transaction_captured.v1".
+func topicToEventType(topic string) string {
+	return strings.ReplaceAll(topic, "-", "_")
+}
+
+// serviceToPackage converts "position-keeping" to "position_keeping".
+func serviceToPackage(name string) string {
+	return strings.ReplaceAll(name, "-", "_")
+}
+
+func generatePublisher(svc ServiceDef) error {
+	dir := filepath.Join(outputDir, svc.PackageName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := publisherTmpl.Execute(&buf, svc); err != nil {
+		return fmt.Errorf("template: %w", err)
+	}
+
+	// Format the generated code.
+	formatted, err := format.Source(buf.Bytes())
+	if err != nil {
+		// Write unformatted for debugging.
+		debugPath := filepath.Join(dir, "publisher.go.unformatted")
+		_ = os.WriteFile(debugPath, buf.Bytes(), 0o644)
+		return fmt.Errorf("gofmt (see %s): %w", debugPath, err)
+	}
+
+	return os.WriteFile(filepath.Join(dir, "publisher.go"), formatted, 0o644)
+}
+
+var publisherTmpl = template.Must(template.New("publisher").Parse(
+	`// Code generated from api/asyncapi/{{ .SourceFile }}. DO NOT EDIT.
+
+package {{ .PackageName }}
+
+import (
+	"context"
+
+	eventsv1 "{{ .ModulePath }}/api/proto/meridian/events/v1"
+	"{{ .ModulePath }}/shared/platform/events"
+	"gorm.io/gorm"
+)
+
+// Publisher provides type-safe event publishing for the {{ .ServiceTitle }} domain.
+type Publisher struct {
+	outbox *events.OutboxPublisher
+}
+
+// NewPublisher creates a new Publisher wrapping the given OutboxPublisher.
+func NewPublisher(outbox *events.OutboxPublisher) *Publisher {
+	return &Publisher{outbox: outbox}
+}
+
+// PublishOption configures event publishing behavior.
+type PublishOption func(*events.PublishConfig)
+
+// WithCorrelationID returns a PublishOption that sets the correlation ID.
+func WithCorrelationID(id string) PublishOption {
+	return func(c *events.PublishConfig) { c.CorrelationID = id }
+}
+
+// WithCausationID returns a PublishOption that sets the causation ID.
+func WithCausationID(id string) PublishOption {
+	return func(c *events.PublishConfig) { c.CausationID = id }
+}
+
+// WithPartitionKey returns a PublishOption that overrides the default partition key.
+func WithPartitionKey(key string) PublishOption {
+	return func(c *events.PublishConfig) { c.PartitionKey = key }
+}
+{{ range .Events }}
+// {{ .MethodName }} publishes a {{ .ProtoType }} to "{{ .Topic }}".
+//
+// {{ .Description }}
+func (p *Publisher) {{ .MethodName }}(
+	ctx context.Context,
+	tx *gorm.DB,
+	event *eventsv1.{{ .ProtoType }},
+	aggregateID string,
+	aggregateType string,
+	opts ...PublishOption,
+) error {
+	config := events.PublishConfig{
+		EventType:     "{{ .EventType }}",
+		Topic:         "{{ .Topic }}",
+		AggregateType: aggregateType,
+		AggregateID:   aggregateID,
+	}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	return p.outbox.Publish(ctx, tx, event, config)
+}
+{{ end -}}
+`))

--- a/tools/gen-event-publishers/main.go
+++ b/tools/gen-event-publishers/main.go
@@ -181,6 +181,11 @@ func main() {
 		log.Fatal("No services generated")
 	}
 
+	// Clean stale packages from prior runs so removed/renamed specs don't linger.
+	if err := os.RemoveAll(outputDir); err != nil {
+		log.Fatalf("Failed to clean %s: %v", outputDir, err)
+	}
+
 	for _, svc := range services {
 		if err := generatePublisher(svc); err != nil {
 			log.Fatalf("Failed to generate %s: %v", svc.PackageName, err)


### PR DESCRIPTION
## Summary

- Add Go code generator (`tools/gen-event-publishers/`) that reads AsyncAPI 3.0.0 YAML specs from `api/asyncapi/` and produces typed event publisher packages in `gen/events/`
- Each generated `Publisher` wraps `OutboxPublisher` with methods that accept the correct proto event type, hardcoded topic, and event type string -- eliminating string-based configuration errors
- Generator validates proto types against actual `.proto` files, skipping services whose definitions are not yet available (audit, financial-accounting, market-information)

## Generated Packages

| Package | Events | Source |
|---------|--------|--------|
| `current_account` | 4 | `current-account.yaml` |
| `internal_account` | 2 | `internal-account.yaml` |
| `party` | 3 | `party.yaml` |
| `payment_order` | 7 | `payment-order.yaml` |
| `position_keeping` | 9 | `position-keeping.yaml` |
| `reconciliation` | 6 | `reconciliation.yaml` |

## Usage Example

```go
import (
    pkpub "github.com/meridianhub/meridian/gen/events/position_keeping"
    eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
)

publisher := pkpub.NewPublisher(outboxPublisher)

err := publisher.PublishTransactionCaptured(
    ctx, tx, event,
    logID,                // aggregateID
    "FinancialPositionLog", // aggregateType
    pkpub.WithCorrelationID(correlationID),
)
```

## Design Decisions

- **Proto type validation**: Generator scans `.proto` files for `message` declarations and skips AsyncAPI schemas that reference undefined types
- **No protovalidate in generated code**: `OutboxPublisher.Publish()` already validates via protovalidate (task 7)
- **aggregateType as parameter**: Varies per call site (not derivable from AsyncAPI), so callers pass it explicitly
- **Functional options**: `WithCorrelationID`, `WithCausationID`, `WithPartitionKey` for optional fields
- **Deterministic output**: Events sorted alphabetically by method name

## Test Plan

- [x] Generator runs successfully: `make gen-event-publishers`
- [x] All 6 generated packages compile: `go build ./gen/events/...`
- [x] All packages pass `go vet ./gen/events/...`
- [x] All packages pass `golangci-lint`
- [x] Pre-commit hooks pass (gitleaks, gofumpt, golangci-lint)
- [ ] CI passes