### PR TITLE
feat: Add gRPC service handlers for operational gateway

### DIFF
--- a/services/operational-gateway/adapters/persistence/instruction_repository.go
+++ b/services/operational-gateway/adapters/persistence/instruction_repository.go
@@ -198,6 +198,68 @@ func (r *InstructionRepository) FetchDispatchable(ctx context.Context, params po
 	return results, nil
 }
 
+// ListByTenant retrieves instructions for a tenant with optional filtering and pagination.
+// Returns the matching instructions and the total count matching the filter (before pagination).
+// Results are ordered by created_at DESC, id DESC for stable cursor-based pagination.
+func (r *InstructionRepository) ListByTenant(ctx context.Context, params ports.ListInstructionsParams) ([]*domain.Instruction, int64, error) {
+	limit := params.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+
+	query := r.db.WithContext(ctx).Model(&InstructionEntity{}).
+		Where("tenant_id = ?", params.TenantID)
+
+	if params.InstructionType != "" {
+		query = query.Where("instruction_type = ?", params.InstructionType)
+	}
+	if params.ProviderConnectionID != "" {
+		query = query.Where("provider_connection_id = ?", params.ProviderConnectionID)
+	}
+	if len(params.Statuses) > 0 {
+		statusStrs := make([]string, len(params.Statuses))
+		for i, s := range params.Statuses {
+			statusStrs[i] = string(s)
+		}
+		query = query.Where("status IN ?", statusStrs)
+	}
+	if !params.CreatedAfter.IsZero() {
+		query = query.Where("created_at >= ?", params.CreatedAfter)
+	}
+	if !params.CreatedBefore.IsZero() {
+		query = query.Where("created_at <= ?", params.CreatedBefore)
+	}
+
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var entities []InstructionEntity
+	if err := query.
+		Order("created_at DESC, id DESC").
+		Limit(limit).
+		Offset(params.Offset).
+		Find(&entities).Error; err != nil {
+		return nil, 0, err
+	}
+
+	results := make([]*domain.Instruction, 0, len(entities))
+	for i := range entities {
+		attempts, err := r.fetchAttempts(ctx, entities[i].ID)
+		if err != nil {
+			return nil, 0, err
+		}
+		inst, err := instructionFromEntity(&entities[i], attempts)
+		if err != nil {
+			return nil, 0, err
+		}
+		results = append(results, inst)
+	}
+
+	return results, total, nil
+}
+
 // fetchAttempts loads instruction_attempts for a given instruction ID.
 func (r *InstructionRepository) fetchAttempts(ctx context.Context, instructionID uuid.UUID) ([]InstructionAttemptEntity, error) {
 	var attempts []InstructionAttemptEntity

--- a/services/operational-gateway/ports/repositories.go
+++ b/services/operational-gateway/ports/repositories.go
@@ -32,6 +32,26 @@ type FetchDispatchableParams struct {
 	AsOf time.Time
 }
 
+// ListInstructionsParams holds the parameters for listing instructions.
+type ListInstructionsParams struct {
+	// TenantID scopes the query to a specific tenant.
+	TenantID string
+	// InstructionType filters by instruction type. Empty means all types.
+	InstructionType string
+	// Statuses filters by instruction status. Empty means all statuses.
+	Statuses []domain.InstructionStatus
+	// ProviderConnectionID filters by provider connection. Empty means all connections.
+	ProviderConnectionID string
+	// CreatedAfter filters instructions created at or after this time. Zero means no lower bound.
+	CreatedAfter time.Time
+	// CreatedBefore filters instructions created at or before this time. Zero means no upper bound.
+	CreatedBefore time.Time
+	// Limit is the maximum number of instructions to return.
+	Limit int
+	// Offset is the number of instructions to skip (for cursor-based pagination).
+	Offset int
+}
+
 // InstructionRepository defines persistence operations for instructions.
 type InstructionRepository interface {
 	// Save creates or updates an instruction with optimistic locking via the version field.
@@ -42,6 +62,10 @@ type InstructionRepository interface {
 	// FindByID retrieves an instruction by its UUID.
 	// Returns ErrInstructionNotFound if no matching instruction exists.
 	FindByID(ctx context.Context, id uuid.UUID) (*domain.Instruction, error)
+
+	// ListByTenant retrieves instructions for a tenant with optional filtering and pagination.
+	// Results are ordered by created_at DESC, id DESC for stable cursor-based pagination.
+	ListByTenant(ctx context.Context, params ListInstructionsParams) ([]*domain.Instruction, int64, error)
 
 	// FetchDispatchable atomically fetches a batch of PENDING or RETRYING instructions
 	// that are ready for dispatch and locks them using SELECT FOR UPDATE SKIP LOCKED.

--- a/services/operational-gateway/service/grpc_connection_service.go
+++ b/services/operational-gateway/service/grpc_connection_service.go
@@ -1,0 +1,190 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// UpsertConnection creates or updates a provider connection.
+func (s *ProviderConnectionService) UpsertConnection(
+	ctx context.Context,
+	req *opgatewayv1.UpsertConnectionRequest,
+) (*opgatewayv1.UpsertConnectionResponse, error) {
+	tid, err := requireTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	authConfig := protoToDomainAuthConfig(req)
+	if authConfig == nil {
+		return nil, status.Error(codes.InvalidArgument, "auth_config is required")
+	}
+
+	retryPolicy := protoToDomainRetryPolicy(req.RetryPolicy)
+	rateLimit := protoToDomainRateLimit(req.RateLimit)
+	protocol := protoToDomainProtocol(req.Protocol)
+
+	conn, err := domain.NewProviderConnection(
+		tenantIDToUUID(tid),
+		req.ProviderName,
+		req.ProviderType,
+		protocol,
+		req.BaseUrl,
+		authConfig,
+		retryPolicy,
+		rateLimit,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid connection: %v", err)
+	}
+
+	// Override the generated UUID if the caller specified one (upsert semantics).
+	if req.ConnectionId != "" {
+		if _, parseErr := uuid.Parse(req.ConnectionId); parseErr != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid connection_id: %v", parseErr)
+		}
+		conn.ConnectionID = req.ConnectionId
+	}
+
+	if err := s.connectionRepo.Upsert(ctx, conn); err != nil {
+		s.logger.Error("failed to upsert provider connection", "error", err)
+		return nil, status.Error(codes.Internal, "failed to upsert connection")
+	}
+
+	return &opgatewayv1.UpsertConnectionResponse{
+		Connection: connectionToProto(conn),
+	}, nil
+}
+
+// GetConnection retrieves a specific provider connection by ID.
+func (s *ProviderConnectionService) GetConnection(
+	ctx context.Context,
+	req *opgatewayv1.GetConnectionRequest,
+) (*opgatewayv1.GetConnectionResponse, error) {
+	tid, err := requireTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := s.connectionRepo.FindByID(ctx, tenantIDToUUID(tid), req.ConnectionId)
+	if err != nil {
+		if errors.Is(err, ports.ErrConnectionNotFound) {
+			return nil, status.Errorf(codes.NotFound, "connection not found: %s", req.ConnectionId)
+		}
+		s.logger.Error("failed to retrieve connection", "error", err)
+		return nil, status.Error(codes.Internal, "failed to retrieve connection")
+	}
+
+	return &opgatewayv1.GetConnectionResponse{
+		Connection: connectionToProto(conn),
+	}, nil
+}
+
+// ListConnections returns a paginated list of provider connections.
+func (s *ProviderConnectionService) ListConnections(
+	ctx context.Context,
+	req *opgatewayv1.ListConnectionsRequest,
+) (*opgatewayv1.ListConnectionsResponse, error) {
+	tid, err := requireTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse pagination.
+	pageSize := defaultPageSize
+	offset := 0
+	if req.Pagination != nil {
+		if req.Pagination.PageSize > 0 {
+			pageSize = int(req.Pagination.PageSize)
+			if pageSize > maxPageSize {
+				pageSize = maxPageSize
+			}
+		}
+		if req.Pagination.PageToken != "" {
+			offset, err = decodeOffsetToken(req.Pagination.PageToken)
+			if err != nil {
+				return nil, status.Error(codes.InvalidArgument, "invalid page_token")
+			}
+		}
+	}
+
+	all, err := s.connectionRepo.ListByTenant(ctx, tenantIDToUUID(tid))
+	if err != nil {
+		s.logger.Error("failed to list connections", "error", err)
+		return nil, status.Error(codes.Internal, "failed to list connections")
+	}
+
+	// Apply optional filters.
+	filtered := make([]*domain.ProviderConnection, 0, len(all))
+	for _, conn := range all {
+		if req.Protocol != opgatewayv1.Protocol_PROTOCOL_UNSPECIFIED &&
+			protoToDomainProtocol(req.Protocol) != conn.Protocol {
+			continue
+		}
+		if req.HealthStatus != opgatewayv1.HealthStatus_HEALTH_STATUS_UNSPECIFIED &&
+			domainToProtoHealthStatus(conn.HealthStatus) != req.HealthStatus {
+			continue
+		}
+		filtered = append(filtered, conn)
+	}
+
+	// Apply pagination.
+	total := int64(len(filtered))
+	if offset > len(filtered) {
+		offset = len(filtered)
+	}
+	page := filtered[offset:]
+	if len(page) > pageSize {
+		page = page[:pageSize]
+	}
+
+	protoConns := make([]*opgatewayv1.ProviderConnection, 0, len(page))
+	for _, conn := range page {
+		protoConns = append(protoConns, connectionToProto(conn))
+	}
+
+	nextOffset := offset + len(page)
+	var nextPageToken string
+	if int64(nextOffset) < total {
+		nextPageToken = encodeOffsetToken(nextOffset)
+	}
+
+	return &opgatewayv1.ListConnectionsResponse{
+		Connections: protoConns,
+		Pagination: &commonpb.PaginationResponse{
+			NextPageToken: nextPageToken,
+			TotalCount:    total,
+		},
+	}, nil
+}
+
+// TestConnection performs a health check on a provider connection (Phase 2 placeholder).
+func (s *ProviderConnectionService) TestConnection(
+	ctx context.Context,
+	req *opgatewayv1.TestConnectionRequest,
+) (*opgatewayv1.TestConnectionResponse, error) {
+	tid, err := requireTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify the connection exists and belongs to the tenant.
+	_, err = s.connectionRepo.FindByID(ctx, tenantIDToUUID(tid), req.ConnectionId)
+	if err != nil {
+		if errors.Is(err, ports.ErrConnectionNotFound) {
+			return nil, status.Errorf(codes.NotFound, "connection not found: %s", req.ConnectionId)
+		}
+		s.logger.Error("failed to retrieve connection for health check", "error", err)
+		return nil, status.Error(codes.Internal, "failed to retrieve connection")
+	}
+
+	return nil, status.Error(codes.Unimplemented, "TestConnection is reserved for Phase 2")
+}

--- a/services/operational-gateway/service/grpc_mappers.go
+++ b/services/operational-gateway/service/grpc_mappers.go
@@ -1,0 +1,390 @@
+package service
+
+import (
+	"time"
+
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// ========== Instruction mappers ==========
+
+// instructionToProto converts a domain Instruction to its proto representation.
+func instructionToProto(i *domain.Instruction) *opgatewayv1.Instruction {
+	p := &opgatewayv1.Instruction{
+		Id:                   i.ID.String(),
+		TenantId:             i.TenantID.String(),
+		InstructionType:      i.InstructionType,
+		ProviderConnectionId: i.ProviderConnectionID,
+		CorrelationId:        i.CorrelationID,
+		CausationId:          i.CausationID,
+		Metadata:             i.Metadata,
+		Priority:             domainToProtoPriority(i.Priority),
+		Status:               domainToProtoStatus(i.Status),
+		Payload:              mapToStruct(i.Payload),
+		CreatedAt:            timestamppb.New(i.CreatedAt),
+		UpdatedAt:            timestamppb.New(i.UpdatedAt),
+	}
+
+	if i.ScheduledAt != nil {
+		p.ScheduledAt = timestamppb.New(*i.ScheduledAt)
+	}
+	if i.ExpiresAt != nil {
+		p.ExpiresAt = timestamppb.New(*i.ExpiresAt)
+	}
+
+	for _, a := range i.Attempts {
+		p.Attempts = append(p.Attempts, attemptToProto(a))
+	}
+
+	return p
+}
+
+// attemptToProto converts a domain InstructionAttempt to proto.
+func attemptToProto(a domain.InstructionAttempt) *opgatewayv1.InstructionAttempt {
+	return &opgatewayv1.InstructionAttempt{
+		AttemptNumber:      int32(a.AttemptNumber), // #nosec G115 — attempt number is a small positive int
+		DispatchedAt:       timestamppb.New(a.AttemptedAt),
+		ErrorMessage:       a.FailureReason,
+		ResponseStatusCode: 0,
+		DurationMs:         0,
+	}
+}
+
+// mapToStruct converts a Go map[string]any to a protobuf Struct.
+func mapToStruct(m map[string]any) *structpb.Struct {
+	if m == nil {
+		return nil
+	}
+	fields := make(map[string]*structpb.Value, len(m))
+	for k, v := range m {
+		fields[k] = anyToProtoValue(v)
+	}
+	return &structpb.Struct{Fields: fields}
+}
+
+// anyToProtoValue converts a Go value to a structpb.Value.
+func anyToProtoValue(v any) *structpb.Value {
+	if v == nil {
+		return structpb.NewNullValue()
+	}
+	switch val := v.(type) {
+	case bool:
+		return structpb.NewBoolValue(val)
+	case float64:
+		return structpb.NewNumberValue(val)
+	case float32:
+		return structpb.NewNumberValue(float64(val))
+	case int:
+		return structpb.NewNumberValue(float64(val))
+	case int32:
+		return structpb.NewNumberValue(float64(val))
+	case int64:
+		return structpb.NewNumberValue(float64(val))
+	case uint:
+		return structpb.NewNumberValue(float64(val))
+	case uint32:
+		return structpb.NewNumberValue(float64(val))
+	case uint64:
+		return structpb.NewNumberValue(float64(val))
+	case string:
+		return structpb.NewStringValue(val)
+	case []any:
+		items := make([]*structpb.Value, len(val))
+		for i, item := range val {
+			items[i] = anyToProtoValue(item)
+		}
+		return structpb.NewListValue(&structpb.ListValue{Values: items})
+	case map[string]any:
+		return structpb.NewStructValue(mapToStruct(val))
+	default:
+		return structpb.NewNullValue()
+	}
+}
+
+// ========== Status mappers ==========
+
+// domainToProtoStatus converts a domain InstructionStatus to proto InstructionStatus.
+func domainToProtoStatus(s domain.InstructionStatus) opgatewayv1.InstructionStatus {
+	switch s {
+	case domain.InstructionStatusPending:
+		return opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING
+	case domain.InstructionStatusDispatching:
+		return opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DISPATCHING
+	case domain.InstructionStatusDelivered:
+		return opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DELIVERED
+	case domain.InstructionStatusAcknowledged:
+		return opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_ACKNOWLEDGED
+	case domain.InstructionStatusRetrying:
+		return opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_RETRYING
+	case domain.InstructionStatusFailed:
+		return opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_FAILED
+	case domain.InstructionStatusExpired:
+		return opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_EXPIRED
+	case domain.InstructionStatusCancelled:
+		return opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_CANCELLED
+	default:
+		return opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_UNSPECIFIED
+	}
+}
+
+// protoToDomainStatus converts a proto InstructionStatus to domain InstructionStatus.
+func protoToDomainStatus(s opgatewayv1.InstructionStatus) domain.InstructionStatus {
+	switch s {
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_UNSPECIFIED:
+		return ""
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING:
+		return domain.InstructionStatusPending
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DISPATCHING:
+		return domain.InstructionStatusDispatching
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DELIVERED:
+		return domain.InstructionStatusDelivered
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_ACKNOWLEDGED:
+		return domain.InstructionStatusAcknowledged
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_RETRYING:
+		return domain.InstructionStatusRetrying
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_FAILED:
+		return domain.InstructionStatusFailed
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_EXPIRED:
+		return domain.InstructionStatusExpired
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_CANCELLED:
+		return domain.InstructionStatusCancelled
+	}
+	return ""
+}
+
+// ========== Priority mappers ==========
+
+// domainToProtoPriority converts a domain Priority to proto Priority.
+func domainToProtoPriority(p domain.Priority) opgatewayv1.Priority {
+	switch p {
+	case domain.PriorityLow:
+		return opgatewayv1.Priority_PRIORITY_LOW
+	case domain.PriorityNormal:
+		return opgatewayv1.Priority_PRIORITY_NORMAL
+	case domain.PriorityHigh:
+		return opgatewayv1.Priority_PRIORITY_HIGH
+	case domain.PriorityCritical:
+		return opgatewayv1.Priority_PRIORITY_CRITICAL
+	default:
+		return opgatewayv1.Priority_PRIORITY_NORMAL
+	}
+}
+
+// protoToDomainPriority converts a proto Priority to a domain Priority.
+func protoToDomainPriority(p opgatewayv1.Priority) domain.Priority {
+	switch p {
+	case opgatewayv1.Priority_PRIORITY_UNSPECIFIED:
+		return domain.PriorityNormal
+	case opgatewayv1.Priority_PRIORITY_LOW:
+		return domain.PriorityLow
+	case opgatewayv1.Priority_PRIORITY_NORMAL:
+		return domain.PriorityNormal
+	case opgatewayv1.Priority_PRIORITY_HIGH:
+		return domain.PriorityHigh
+	case opgatewayv1.Priority_PRIORITY_CRITICAL:
+		return domain.PriorityCritical
+	}
+	return domain.PriorityNormal
+}
+
+// ========== ProviderConnection mappers ==========
+
+// connectionToProto converts a domain ProviderConnection to proto ProviderConnection.
+func connectionToProto(c *domain.ProviderConnection) *opgatewayv1.ProviderConnection {
+	p := &opgatewayv1.ProviderConnection{
+		ConnectionId: c.ConnectionID,
+		TenantId:     c.TenantID,
+		ProviderName: c.ProviderName,
+		ProviderType: c.ProviderType,
+		Protocol:     domainToProtoProtocol(c.Protocol),
+		BaseUrl:      c.BaseURL,
+		HealthStatus: domainToProtoHealthStatus(c.HealthStatus),
+		RetryPolicy: &opgatewayv1.RetryPolicy{
+			MaxAttempts:           int32(c.RetryPolicy.MaxAttempts),              // #nosec G115 — bounded domain value
+			InitialBackoffSeconds: int32(c.RetryPolicy.InitialBackoff.Seconds()), // #nosec G115
+			MaxBackoffSeconds:     int32(c.RetryPolicy.MaxBackoff.Seconds()),     // #nosec G115
+			BackoffMultiplier:     c.RetryPolicy.BackoffMultiplier,
+		},
+		CreatedAt: timestamppb.New(c.CreatedAt),
+		UpdatedAt: timestamppb.New(c.UpdatedAt),
+	}
+
+	if c.RateLimitConfig.RequestsPerSecond > 0 {
+		p.RateLimit = &opgatewayv1.RateLimit{
+			RequestsPerSecond: c.RateLimitConfig.RequestsPerSecond,
+			BurstSize:         int32(c.RateLimitConfig.BurstSize), // #nosec G115
+		}
+	}
+
+	if c.LastHealthCheckAt != nil {
+		p.LastHealthCheckAt = timestamppb.New(*c.LastHealthCheckAt)
+	}
+
+	// Map auth config.
+	switch auth := c.AuthConfig.(type) {
+	case *domain.APIKeyAuth:
+		p.AuthConfig = &opgatewayv1.ProviderConnection_ApiKey{
+			ApiKey: &opgatewayv1.ApiKeyAuth{
+				HeaderName: auth.HeaderName,
+				SecretRef:  auth.SecretRef,
+			},
+		}
+	case *domain.BasicAuth:
+		p.AuthConfig = &opgatewayv1.ProviderConnection_Basic{
+			Basic: &opgatewayv1.BasicAuth{
+				Username:          auth.Username,
+				PasswordSecretRef: auth.PasswordRef,
+			},
+		}
+	case *domain.OAuth2Auth:
+		p.AuthConfig = &opgatewayv1.ProviderConnection_Oauth2{
+			Oauth2: &opgatewayv1.OAuth2Auth{
+				TokenUrl:        auth.TokenURL,
+				ClientId:        auth.ClientID,
+				ClientSecretRef: auth.ClientSecretRef,
+				Scopes:          auth.Scopes,
+			},
+		}
+	case *domain.HMACAuth:
+		p.AuthConfig = &opgatewayv1.ProviderConnection_Hmac{
+			Hmac: &opgatewayv1.HMACAuth{
+				Algorithm:       auth.Algorithm,
+				SecretRef:       auth.SecretRef,
+				SignatureHeader: auth.SignatureHeader,
+			},
+		}
+	case *domain.MTLSAuth:
+		p.AuthConfig = &opgatewayv1.ProviderConnection_Mtls{
+			Mtls: &opgatewayv1.MTLSAuth{
+				ClientCertSecretRef: auth.ClientCertRef,
+				ClientKeySecretRef:  auth.ClientKeyRef,
+				CaCertSecretRef:     auth.CACertRef,
+			},
+		}
+	}
+
+	return p
+}
+
+// protoToDomainAuthConfig converts a proto auth config oneof to a domain AuthConfig.
+func protoToDomainAuthConfig(req *opgatewayv1.UpsertConnectionRequest) domain.AuthConfig {
+	switch auth := req.AuthConfig.(type) {
+	case *opgatewayv1.UpsertConnectionRequest_ApiKey:
+		return &domain.APIKeyAuth{
+			HeaderName: auth.ApiKey.HeaderName,
+			SecretRef:  auth.ApiKey.SecretRef,
+		}
+	case *opgatewayv1.UpsertConnectionRequest_Basic:
+		return &domain.BasicAuth{
+			Username:    auth.Basic.Username,
+			PasswordRef: auth.Basic.PasswordSecretRef,
+		}
+	case *opgatewayv1.UpsertConnectionRequest_Oauth2:
+		return &domain.OAuth2Auth{
+			TokenURL:        auth.Oauth2.TokenUrl,
+			ClientID:        auth.Oauth2.ClientId,
+			ClientSecretRef: auth.Oauth2.ClientSecretRef,
+			Scopes:          auth.Oauth2.Scopes,
+		}
+	case *opgatewayv1.UpsertConnectionRequest_Hmac:
+		return &domain.HMACAuth{
+			Algorithm:       auth.Hmac.Algorithm,
+			SecretRef:       auth.Hmac.SecretRef,
+			SignatureHeader: auth.Hmac.SignatureHeader,
+		}
+	case *opgatewayv1.UpsertConnectionRequest_Mtls:
+		return &domain.MTLSAuth{
+			ClientCertRef: auth.Mtls.ClientCertSecretRef,
+			ClientKeyRef:  auth.Mtls.ClientKeySecretRef,
+			CACertRef:     auth.Mtls.CaCertSecretRef,
+		}
+	default:
+		return nil
+	}
+}
+
+// protoToDomainRetryPolicy converts a proto RetryPolicy to domain RetryPolicy.
+func protoToDomainRetryPolicy(r *opgatewayv1.RetryPolicy) domain.RetryPolicy {
+	if r == nil {
+		return domain.RetryPolicy{
+			MaxAttempts:       3,
+			InitialBackoff:    1 * time.Second,
+			MaxBackoff:        60 * time.Second,
+			BackoffMultiplier: 2.0,
+		}
+	}
+	return domain.RetryPolicy{
+		MaxAttempts:       int(r.MaxAttempts),
+		InitialBackoff:    time.Duration(r.InitialBackoffSeconds) * time.Second,
+		MaxBackoff:        time.Duration(r.MaxBackoffSeconds) * time.Second,
+		BackoffMultiplier: r.BackoffMultiplier,
+	}
+}
+
+// protoToDomainRateLimit converts a proto RateLimit to domain RateLimitConfig.
+func protoToDomainRateLimit(r *opgatewayv1.RateLimit) domain.RateLimitConfig {
+	if r == nil {
+		return domain.RateLimitConfig{}
+	}
+	return domain.RateLimitConfig{
+		RequestsPerSecond: r.RequestsPerSecond,
+		BurstSize:         int(r.BurstSize),
+	}
+}
+
+// ========== Protocol / HealthStatus mappers ==========
+
+// domainToProtoProtocol converts a domain Protocol to proto Protocol.
+func domainToProtoProtocol(p domain.Protocol) opgatewayv1.Protocol {
+	switch p {
+	case domain.ProtocolHTTPS:
+		return opgatewayv1.Protocol_PROTOCOL_HTTPS
+	case domain.ProtocolGRPC:
+		return opgatewayv1.Protocol_PROTOCOL_GRPC
+	case domain.ProtocolWebhook:
+		return opgatewayv1.Protocol_PROTOCOL_WEBHOOK
+	case domain.ProtocolMQTT:
+		return opgatewayv1.Protocol_PROTOCOL_MQTT
+	case domain.ProtocolAMQP:
+		return opgatewayv1.Protocol_PROTOCOL_AMQP
+	default:
+		return opgatewayv1.Protocol_PROTOCOL_UNSPECIFIED
+	}
+}
+
+// protoToDomainProtocol converts a proto Protocol to domain Protocol.
+func protoToDomainProtocol(p opgatewayv1.Protocol) domain.Protocol {
+	switch p {
+	case opgatewayv1.Protocol_PROTOCOL_UNSPECIFIED:
+		return ""
+	case opgatewayv1.Protocol_PROTOCOL_HTTPS:
+		return domain.ProtocolHTTPS
+	case opgatewayv1.Protocol_PROTOCOL_GRPC:
+		return domain.ProtocolGRPC
+	case opgatewayv1.Protocol_PROTOCOL_WEBHOOK:
+		return domain.ProtocolWebhook
+	case opgatewayv1.Protocol_PROTOCOL_MQTT:
+		return domain.ProtocolMQTT
+	case opgatewayv1.Protocol_PROTOCOL_AMQP:
+		return domain.ProtocolAMQP
+	}
+	return ""
+}
+
+// domainToProtoHealthStatus converts a domain HealthStatus to proto HealthStatus.
+func domainToProtoHealthStatus(h domain.HealthStatus) opgatewayv1.HealthStatus {
+	switch h {
+	case domain.HealthStatusUnknown:
+		return opgatewayv1.HealthStatus_HEALTH_STATUS_UNSPECIFIED
+	case domain.HealthStatusHealthy:
+		return opgatewayv1.HealthStatus_HEALTH_STATUS_HEALTHY
+	case domain.HealthStatusDegraded:
+		return opgatewayv1.HealthStatus_HEALTH_STATUS_DEGRADED
+	case domain.HealthStatusUnhealthy:
+		return opgatewayv1.HealthStatus_HEALTH_STATUS_UNHEALTHY
+	}
+	return opgatewayv1.HealthStatus_HEALTH_STATUS_UNSPECIFIED
+}

--- a/services/operational-gateway/service/grpc_mappers.go
+++ b/services/operational-gateway/service/grpc_mappers.go
@@ -307,21 +307,31 @@ func protoToDomainAuthConfig(req *opgatewayv1.UpsertConnectionRequest) domain.Au
 }
 
 // protoToDomainRetryPolicy converts a proto RetryPolicy to domain RetryPolicy.
+// Zero-valued fields in the proto message fall back to safe defaults so that callers
+// do not need to fully populate the policy in order to get sensible behavior.
 func protoToDomainRetryPolicy(r *opgatewayv1.RetryPolicy) domain.RetryPolicy {
+	p := domain.RetryPolicy{
+		MaxAttempts:       3,
+		InitialBackoff:    1 * time.Second,
+		MaxBackoff:        60 * time.Second,
+		BackoffMultiplier: 2.0,
+	}
 	if r == nil {
-		return domain.RetryPolicy{
-			MaxAttempts:       3,
-			InitialBackoff:    1 * time.Second,
-			MaxBackoff:        60 * time.Second,
-			BackoffMultiplier: 2.0,
-		}
+		return p
 	}
-	return domain.RetryPolicy{
-		MaxAttempts:       int(r.MaxAttempts),
-		InitialBackoff:    time.Duration(r.InitialBackoffSeconds) * time.Second,
-		MaxBackoff:        time.Duration(r.MaxBackoffSeconds) * time.Second,
-		BackoffMultiplier: r.BackoffMultiplier,
+	if r.MaxAttempts > 0 {
+		p.MaxAttempts = int(r.MaxAttempts)
 	}
+	if r.InitialBackoffSeconds > 0 {
+		p.InitialBackoff = time.Duration(r.InitialBackoffSeconds) * time.Second
+	}
+	if r.MaxBackoffSeconds > 0 {
+		p.MaxBackoff = time.Duration(r.MaxBackoffSeconds) * time.Second
+	}
+	if r.BackoffMultiplier > 0 {
+		p.BackoffMultiplier = r.BackoffMultiplier
+	}
+	return p
 }
 
 // protoToDomainRateLimit converts a proto RateLimit to domain RateLimitConfig.

--- a/services/operational-gateway/service/grpc_query.go
+++ b/services/operational-gateway/service/grpc_query.go
@@ -1,0 +1,239 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Sentinel errors for page token parsing.
+var (
+	errInvalidPageTokenFormat = errors.New("invalid token format")
+	errNegativePageOffset     = errors.New("offset cannot be negative")
+)
+
+// GetInstruction retrieves a specific instruction by ID.
+func (s *OperationalGatewayService) GetInstruction(
+	ctx context.Context,
+	req *opgatewayv1.GetInstructionRequest,
+) (*opgatewayv1.GetInstructionResponse, error) {
+	tid, err := requireTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := uuid.Parse(req.InstructionId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid instruction_id: %v", err)
+	}
+
+	instruction, err := s.instructionRepo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, ports.ErrInstructionNotFound) {
+			return nil, status.Errorf(codes.NotFound, "instruction not found: %s", req.InstructionId)
+		}
+		s.logger.Error("failed to retrieve instruction", "error", err)
+		return nil, status.Error(codes.Internal, "failed to retrieve instruction")
+	}
+
+	// Verify tenant ownership.
+	if instruction.TenantID.String() != tenantIDToUUID(tid) {
+		return nil, status.Errorf(codes.NotFound, "instruction not found: %s", req.InstructionId)
+	}
+
+	return &opgatewayv1.GetInstructionResponse{
+		Instruction: instructionToProto(instruction),
+	}, nil
+}
+
+// ListInstructions returns a paginated list of instructions with optional filtering.
+func (s *OperationalGatewayService) ListInstructions(
+	ctx context.Context,
+	req *opgatewayv1.ListInstructionsRequest,
+) (*opgatewayv1.ListInstructionsResponse, error) {
+	tid, err := requireTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse pagination.
+	pageSize := defaultPageSize
+	offset := 0
+	if req.Pagination != nil {
+		if req.Pagination.PageSize > 0 {
+			pageSize = int(req.Pagination.PageSize)
+			if pageSize > maxPageSize {
+				pageSize = maxPageSize
+			}
+		}
+		if req.Pagination.PageToken != "" {
+			offset, err = decodeOffsetToken(req.Pagination.PageToken)
+			if err != nil {
+				return nil, status.Error(codes.InvalidArgument, "invalid page_token")
+			}
+		}
+	}
+
+	// Build list params.
+	params := ports.ListInstructionsParams{
+		TenantID:             tenantIDToUUID(tid),
+		InstructionType:      req.InstructionType,
+		ProviderConnectionID: req.ProviderConnectionId,
+		Limit:                pageSize,
+		Offset:               offset,
+	}
+
+	// Parse status filters.
+	for _, s := range req.Status {
+		domainStatus := protoToDomainStatus(s)
+		if domainStatus != "" {
+			params.Statuses = append(params.Statuses, domainStatus)
+		}
+	}
+
+	// Parse date range.
+	if req.DateRange != nil {
+		if req.DateRange.StartDate != "" {
+			t, parseErr := parseDate(req.DateRange.StartDate)
+			if parseErr != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid date_range.start_date: %v", parseErr)
+			}
+			params.CreatedAfter = t
+		}
+		if req.DateRange.EndDate != "" {
+			t, parseErr := parseDate(req.DateRange.EndDate)
+			if parseErr != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid date_range.end_date: %v", parseErr)
+			}
+			params.CreatedBefore = t
+		}
+	}
+
+	instructions, total, err := s.instructionRepo.ListByTenant(ctx, params)
+	if err != nil {
+		s.logger.Error("failed to list instructions", "error", err)
+		return nil, status.Error(codes.Internal, "failed to list instructions")
+	}
+
+	protoInstructions := make([]*opgatewayv1.Instruction, 0, len(instructions))
+	for _, inst := range instructions {
+		protoInstructions = append(protoInstructions, instructionToProto(inst))
+	}
+
+	// Build next page token if there are more results.
+	nextOffset := offset + len(instructions)
+	var nextPageToken string
+	if int64(nextOffset) < total {
+		nextPageToken = encodeOffsetToken(nextOffset)
+	}
+
+	return &opgatewayv1.ListInstructionsResponse{
+		Instructions: protoInstructions,
+		Pagination: &commonpb.PaginationResponse{
+			NextPageToken: nextPageToken,
+			TotalCount:    total,
+		},
+	}, nil
+}
+
+// ProcessCallback handles an inbound callback from a provider, acknowledging an instruction.
+func (s *OperationalGatewayService) ProcessCallback(
+	ctx context.Context,
+	req *opgatewayv1.ProcessCallbackRequest,
+) (*opgatewayv1.ProcessCallbackResponse, error) {
+	tid, err := requireTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.IdempotencyKey == nil || req.IdempotencyKey.Key == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+	if req.Callback == nil {
+		return nil, status.Error(codes.InvalidArgument, "callback is required")
+	}
+
+	// Resolve the instruction by ID or provider_reference.
+	var id uuid.UUID
+	if req.InstructionId != "" {
+		id, err = uuid.Parse(req.InstructionId)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid instruction_id: %v", err)
+		}
+	} else if req.ProviderReference == "" {
+		return nil, status.Error(codes.InvalidArgument, "at least one of instruction_id or provider_reference must be provided")
+	}
+
+	instruction, err := s.instructionRepo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, ports.ErrInstructionNotFound) {
+			return nil, status.Errorf(codes.NotFound, "instruction not found: %s", req.InstructionId)
+		}
+		s.logger.Error("failed to retrieve instruction for callback", "error", err)
+		return nil, status.Error(codes.Internal, "failed to retrieve instruction")
+	}
+
+	// Verify tenant ownership.
+	if instruction.TenantID.String() != tenantIDToUUID(tid) {
+		return nil, status.Errorf(codes.NotFound, "instruction not found: %s", req.InstructionId)
+	}
+
+	// Transition to ACKNOWLEDGED from DELIVERED.
+	if err := instruction.MarkAcknowledged(); err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "instruction cannot be acknowledged in status %s", instruction.Status)
+	}
+
+	if err := s.instructionRepo.Save(ctx, instruction, req.IdempotencyKey.Key); err != nil {
+		if errors.Is(err, ports.ErrInstructionConflict) {
+			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
+		}
+		if errors.Is(err, ports.ErrDuplicateIdempotency) {
+			// Idempotent: return the current state.
+			return &opgatewayv1.ProcessCallbackResponse{
+				Instruction: instructionToProto(instruction),
+			}, nil
+		}
+		s.logger.Error("failed to save acknowledged instruction", "error", err)
+		return nil, status.Error(codes.Internal, "failed to save instruction")
+	}
+
+	return &opgatewayv1.ProcessCallbackResponse{
+		Instruction: instructionToProto(instruction),
+	}, nil
+}
+
+// encodeOffsetToken encodes a numeric offset as an opaque page token.
+func encodeOffsetToken(offset int) string {
+	return fmt.Sprintf("offset:%d", offset)
+}
+
+// decodeOffsetToken decodes an opaque page token back to a numeric offset.
+func decodeOffsetToken(token string) (int, error) {
+	const prefix = "offset:"
+	if !strings.HasPrefix(token, prefix) {
+		return 0, errInvalidPageTokenFormat
+	}
+	n, err := strconv.Atoi(strings.TrimPrefix(token, prefix))
+	if err != nil {
+		return 0, fmt.Errorf("invalid token value: %w", err)
+	}
+	if n < 0 {
+		return 0, errNegativePageOffset
+	}
+	return n, nil
+}
+
+// parseDate parses a YYYY-MM-DD date string to a time.Time (UTC midnight).
+func parseDate(s string) (time.Time, error) {
+	return time.Parse("2006-01-02", s)
+}

--- a/services/operational-gateway/service/grpc_query.go
+++ b/services/operational-gateway/service/grpc_query.go
@@ -96,10 +96,14 @@ func (s *OperationalGatewayService) ListInstructions(
 
 	// Parse status filters.
 	for _, s := range req.Status {
-		domainStatus := protoToDomainStatus(s)
-		if domainStatus != "" {
-			params.Statuses = append(params.Statuses, domainStatus)
+		if s == opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_UNSPECIFIED {
+			continue
 		}
+		domainStatus := protoToDomainStatus(s)
+		if domainStatus == "" {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid status filter: %v", s)
+		}
+		params.Statuses = append(params.Statuses, domainStatus)
 	}
 
 	// Parse date range.

--- a/services/operational-gateway/service/grpc_query.go
+++ b/services/operational-gateway/service/grpc_query.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
 	"github.com/meridianhub/meridian/services/operational-gateway/ports"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -115,7 +116,8 @@ func (s *OperationalGatewayService) ListInstructions(
 			if parseErr != nil {
 				return nil, status.Errorf(codes.InvalidArgument, "invalid date_range.end_date: %v", parseErr)
 			}
-			params.CreatedBefore = t
+			// Include records created through the end of the specified day.
+			params.CreatedBefore = t.Add(24*time.Hour - time.Nanosecond)
 		}
 	}
 
@@ -164,13 +166,17 @@ func (s *OperationalGatewayService) ProcessCallback(
 	}
 
 	// Resolve the instruction by ID or provider_reference.
+	// provider_reference lookup requires a repository method not yet implemented; return
+	// Unimplemented until that capability is added in a future iteration.
 	var id uuid.UUID
 	if req.InstructionId != "" {
 		id, err = uuid.Parse(req.InstructionId)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid instruction_id: %v", err)
 		}
-	} else if req.ProviderReference == "" {
+	} else if req.ProviderReference != "" {
+		return nil, status.Error(codes.Unimplemented, "lookup by provider_reference is not yet supported; provide instruction_id instead")
+	} else {
 		return nil, status.Error(codes.InvalidArgument, "at least one of instruction_id or provider_reference must be provided")
 	}
 
@@ -186,6 +192,13 @@ func (s *OperationalGatewayService) ProcessCallback(
 	// Verify tenant ownership.
 	if instruction.TenantID.String() != tenantIDToUUID(tid) {
 		return nil, status.Errorf(codes.NotFound, "instruction not found: %s", req.InstructionId)
+	}
+
+	// Idempotency: if already acknowledged, return the current state without re-applying.
+	if instruction.Status == domain.InstructionStatusAcknowledged {
+		return &opgatewayv1.ProcessCallbackResponse{
+			Instruction: instructionToProto(instruction),
+		}, nil
 	}
 
 	// Transition to ACKNOWLEDGED from DELIVERED.

--- a/services/operational-gateway/service/grpc_query.go
+++ b/services/operational-gateway/service/grpc_query.go
@@ -33,7 +33,7 @@ func (s *OperationalGatewayService) GetInstruction(
 		return nil, err
 	}
 
-	id, err := uuid.Parse(req.InstructionId)
+	id, err := uuid.Parse(req.GetInstructionId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid instruction_id: %v", err)
 	}
@@ -41,7 +41,7 @@ func (s *OperationalGatewayService) GetInstruction(
 	instruction, err := s.instructionRepo.FindByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, ports.ErrInstructionNotFound) {
-			return nil, status.Errorf(codes.NotFound, "instruction not found: %s", req.InstructionId)
+			return nil, status.Errorf(codes.NotFound, "instruction not found: %s", req.GetInstructionId())
 		}
 		s.logger.Error("failed to retrieve instruction", "error", err)
 		return nil, status.Error(codes.Internal, "failed to retrieve instruction")
@@ -49,7 +49,7 @@ func (s *OperationalGatewayService) GetInstruction(
 
 	// Verify tenant ownership.
 	if instruction.TenantID.String() != tenantIDToUUID(tid) {
-		return nil, status.Errorf(codes.NotFound, "instruction not found: %s", req.InstructionId)
+		return nil, status.Errorf(codes.NotFound, "instruction not found: %s", req.GetInstructionId())
 	}
 
 	return &opgatewayv1.GetInstructionResponse{
@@ -70,15 +70,15 @@ func (s *OperationalGatewayService) ListInstructions(
 	// Parse pagination.
 	pageSize := defaultPageSize
 	offset := 0
-	if req.Pagination != nil {
-		if req.Pagination.PageSize > 0 {
-			pageSize = int(req.Pagination.PageSize)
+	if req.GetPagination() != nil {
+		if req.GetPagination().GetPageSize() > 0 {
+			pageSize = int(req.GetPagination().GetPageSize())
 			if pageSize > maxPageSize {
 				pageSize = maxPageSize
 			}
 		}
-		if req.Pagination.PageToken != "" {
-			offset, err = decodeOffsetToken(req.Pagination.PageToken)
+		if req.GetPagination().GetPageToken() != "" {
+			offset, err = decodeOffsetToken(req.GetPagination().GetPageToken())
 			if err != nil {
 				return nil, status.Error(codes.InvalidArgument, "invalid page_token")
 			}
@@ -88,14 +88,14 @@ func (s *OperationalGatewayService) ListInstructions(
 	// Build list params.
 	params := ports.ListInstructionsParams{
 		TenantID:             tenantIDToUUID(tid),
-		InstructionType:      req.InstructionType,
-		ProviderConnectionID: req.ProviderConnectionId,
+		InstructionType:      req.GetInstructionType(),
+		ProviderConnectionID: req.GetProviderConnectionId(),
 		Limit:                pageSize,
 		Offset:               offset,
 	}
 
 	// Parse status filters.
-	for _, s := range req.Status {
+	for _, s := range req.GetStatus() {
 		if s == opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_UNSPECIFIED {
 			continue
 		}
@@ -107,21 +107,28 @@ func (s *OperationalGatewayService) ListInstructions(
 	}
 
 	// Parse date range.
-	if req.DateRange != nil {
-		if req.DateRange.StartDate != "" {
-			t, parseErr := parseDate(req.DateRange.StartDate)
+	if req.GetDateRange() != nil {
+		var startDate, endDate time.Time
+		if req.GetDateRange().GetStartDate() != "" {
+			t, parseErr := parseDate(req.GetDateRange().GetStartDate())
 			if parseErr != nil {
 				return nil, status.Errorf(codes.InvalidArgument, "invalid date_range.start_date: %v", parseErr)
 			}
+			startDate = t
 			params.CreatedAfter = t
 		}
-		if req.DateRange.EndDate != "" {
-			t, parseErr := parseDate(req.DateRange.EndDate)
+		if req.GetDateRange().GetEndDate() != "" {
+			t, parseErr := parseDate(req.GetDateRange().GetEndDate())
 			if parseErr != nil {
 				return nil, status.Errorf(codes.InvalidArgument, "invalid date_range.end_date: %v", parseErr)
 			}
 			// Include records created through the end of the specified day.
-			params.CreatedBefore = t.Add(24*time.Hour - time.Nanosecond)
+			endDate = t.Add(24*time.Hour - time.Nanosecond)
+			params.CreatedBefore = endDate
+		}
+		// Reject inverted ranges eagerly to avoid contradictory queries.
+		if !startDate.IsZero() && !endDate.IsZero() && startDate.After(endDate) {
+			return nil, status.Error(codes.InvalidArgument, "date_range.start_date must not be after date_range.end_date")
 		}
 	}
 
@@ -162,10 +169,10 @@ func (s *OperationalGatewayService) ProcessCallback(
 		return nil, err
 	}
 
-	if req.IdempotencyKey == nil || req.IdempotencyKey.Key == "" {
+	if req.GetIdempotencyKey() == nil || req.GetIdempotencyKey().GetKey() == "" {
 		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
 	}
-	if req.Callback == nil {
+	if req.GetCallback() == nil {
 		return nil, status.Error(codes.InvalidArgument, "callback is required")
 	}
 
@@ -173,12 +180,12 @@ func (s *OperationalGatewayService) ProcessCallback(
 	// provider_reference lookup requires a repository method not yet implemented; return
 	// Unimplemented until that capability is added in a future iteration.
 	var id uuid.UUID
-	if req.InstructionId != "" {
-		id, err = uuid.Parse(req.InstructionId)
+	if req.GetInstructionId() != "" {
+		id, err = uuid.Parse(req.GetInstructionId())
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid instruction_id: %v", err)
 		}
-	} else if req.ProviderReference != "" {
+	} else if req.GetProviderReference() != "" {
 		return nil, status.Error(codes.Unimplemented, "lookup by provider_reference is not yet supported; provide instruction_id instead")
 	} else {
 		return nil, status.Error(codes.InvalidArgument, "at least one of instruction_id or provider_reference must be provided")
@@ -187,7 +194,7 @@ func (s *OperationalGatewayService) ProcessCallback(
 	instruction, err := s.instructionRepo.FindByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, ports.ErrInstructionNotFound) {
-			return nil, status.Errorf(codes.NotFound, "instruction not found: %s", req.InstructionId)
+			return nil, status.Errorf(codes.NotFound, "instruction not found: %s", req.GetInstructionId())
 		}
 		s.logger.Error("failed to retrieve instruction for callback", "error", err)
 		return nil, status.Error(codes.Internal, "failed to retrieve instruction")
@@ -195,7 +202,7 @@ func (s *OperationalGatewayService) ProcessCallback(
 
 	// Verify tenant ownership.
 	if instruction.TenantID.String() != tenantIDToUUID(tid) {
-		return nil, status.Errorf(codes.NotFound, "instruction not found: %s", req.InstructionId)
+		return nil, status.Errorf(codes.NotFound, "instruction not found: %s", req.GetInstructionId())
 	}
 
 	// Idempotency: if already acknowledged, return the current state without re-applying.
@@ -210,7 +217,7 @@ func (s *OperationalGatewayService) ProcessCallback(
 		return nil, status.Errorf(codes.FailedPrecondition, "instruction cannot be acknowledged in status %s", instruction.Status)
 	}
 
-	if err := s.instructionRepo.Save(ctx, instruction, req.IdempotencyKey.Key); err != nil {
+	if err := s.instructionRepo.Save(ctx, instruction, req.GetIdempotencyKey().GetKey()); err != nil {
 		if errors.Is(err, ports.ErrInstructionConflict) {
 			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
 		}

--- a/services/operational-gateway/service/grpc_service.go
+++ b/services/operational-gateway/service/grpc_service.go
@@ -154,13 +154,13 @@ func (s *OperationalGatewayService) DispatchInstruction(
 	}
 
 	// Resolve provider connection: for dispatch, we don't require a connection_id upfront —
-	// the worker resolves it via InstructionRoute. We use an empty string placeholder that
-	// the dispatcher will fill in. The domain constructor requires a non-empty value, so we
-	// use "pending" as the sentinel that the dispatcher replaces.
+	// the worker resolves it via InstructionRoute. We use uuid.Nil as the sentinel that
+	// the dispatcher replaces. uuid.Nil is a valid UUID string so it passes persistence
+	// layer parsing and is clearly distinguishable from a real connection ID.
 	instruction, err := domain.NewInstruction(
 		tenantUUID,
 		req.InstructionType,
-		"pending",
+		uuid.Nil.String(),
 		payload,
 		opts...,
 	)

--- a/services/operational-gateway/service/grpc_service.go
+++ b/services/operational-gateway/service/grpc_service.go
@@ -1,0 +1,290 @@
+// Package service implements gRPC services for the operational gateway domain.
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+
+	"github.com/google/uuid"
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// Pagination defaults.
+const (
+	defaultPageSize = 50
+	maxPageSize     = 1000
+)
+
+// Service errors.
+var (
+	ErrInstructionRepoNil = errors.New("instruction repository cannot be nil")
+	ErrConnectionRepoNil  = errors.New("connection repository cannot be nil")
+)
+
+// OperationalGatewayService implements OperationalGatewayServiceServer.
+type OperationalGatewayService struct {
+	opgatewayv1.UnimplementedOperationalGatewayServiceServer
+	instructionRepo ports.InstructionRepository
+	connectionRepo  ports.ConnectionRepository
+	logger          *slog.Logger
+}
+
+// ProviderConnectionService implements ProviderConnectionServiceServer.
+type ProviderConnectionService struct {
+	opgatewayv1.UnimplementedProviderConnectionServiceServer
+	connectionRepo  ports.ConnectionRepository
+	instructionRepo ports.InstructionRepository
+	logger          *slog.Logger
+}
+
+// NewOperationalGatewayService creates a new OperationalGatewayService.
+func NewOperationalGatewayService(
+	instructionRepo ports.InstructionRepository,
+	connectionRepo ports.ConnectionRepository,
+	logger *slog.Logger,
+) (*OperationalGatewayService, error) {
+	if instructionRepo == nil {
+		return nil, ErrInstructionRepoNil
+	}
+	if connectionRepo == nil {
+		return nil, ErrConnectionRepoNil
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	}
+	return &OperationalGatewayService{
+		instructionRepo: instructionRepo,
+		connectionRepo:  connectionRepo,
+		logger:          logger,
+	}, nil
+}
+
+// NewProviderConnectionService creates a new ProviderConnectionService.
+func NewProviderConnectionService(
+	connectionRepo ports.ConnectionRepository,
+	instructionRepo ports.InstructionRepository,
+	logger *slog.Logger,
+) (*ProviderConnectionService, error) {
+	if connectionRepo == nil {
+		return nil, ErrConnectionRepoNil
+	}
+	if instructionRepo == nil {
+		return nil, ErrInstructionRepoNil
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	}
+	return &ProviderConnectionService{
+		connectionRepo:  connectionRepo,
+		instructionRepo: instructionRepo,
+		logger:          logger,
+	}, nil
+}
+
+// requireTenant extracts the tenant ID from context, returning FailedPrecondition if missing.
+func requireTenant(ctx context.Context) (tenant.TenantID, error) {
+	tid, ok := tenant.FromContext(ctx)
+	if !ok {
+		return "", status.Error(codes.FailedPrecondition, "tenant context is required")
+	}
+	return tid, nil
+}
+
+// DispatchInstruction accepts a new instruction and queues it for dispatch.
+func (s *OperationalGatewayService) DispatchInstruction(
+	ctx context.Context,
+	req *opgatewayv1.DispatchInstructionRequest,
+) (*opgatewayv1.DispatchInstructionResponse, error) {
+	tid, err := requireTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate required fields.
+	if req.InstructionType == "" {
+		return nil, status.Error(codes.InvalidArgument, "instruction_type is required")
+	}
+	if req.Payload == nil {
+		return nil, status.Error(codes.InvalidArgument, "payload is required")
+	}
+	if req.IdempotencyKey == nil || req.IdempotencyKey.Key == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+
+	// Convert payload proto -> domain map.
+	payload := structToMap(req.Payload)
+
+	// Build functional options.
+	opts := []domain.InstructionOption{
+		domain.WithPriority(protoToDomainPriority(req.Priority)),
+	}
+	if req.CorrelationId != "" {
+		opts = append(opts, domain.WithCorrelationID(req.CorrelationId))
+	}
+	if req.CausationId != "" {
+		opts = append(opts, domain.WithCausationID(req.CausationId))
+	}
+	if len(req.Metadata) > 0 {
+		opts = append(opts, domain.WithMetadata(req.Metadata))
+	}
+	if req.ScheduledAt != nil {
+		t := req.ScheduledAt.AsTime()
+		opts = append(opts, domain.WithScheduledAt(t))
+	}
+	if req.ExpiresAt != nil {
+		t := req.ExpiresAt.AsTime()
+		opts = append(opts, domain.WithExpiresAt(t))
+	}
+
+	// Convert the tenant ID string to a UUID for the domain model.
+	// The tenant.TenantID may be a UUID string (from JWT claims) or an alphanumeric slug.
+	// tenantIDToUUID produces a stable UUID in either case.
+	tenantUUID, parseErr := uuid.Parse(tenantIDToUUID(tid))
+	if parseErr != nil {
+		s.logger.Error("failed to parse tenant ID as UUID", "tenant_id", tid, "error", parseErr)
+		return nil, status.Error(codes.Internal, "invalid tenant context")
+	}
+
+	// Resolve provider connection: for dispatch, we don't require a connection_id upfront —
+	// the worker resolves it via InstructionRoute. We use an empty string placeholder that
+	// the dispatcher will fill in. The domain constructor requires a non-empty value, so we
+	// use "pending" as the sentinel that the dispatcher replaces.
+	instruction, err := domain.NewInstruction(
+		tenantUUID,
+		req.InstructionType,
+		"pending",
+		payload,
+		opts...,
+	)
+	if err != nil {
+		s.logger.Error("failed to create instruction domain object", "error", err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid instruction: %v", err)
+	}
+
+	// Assign a fresh UUID for this instruction.
+	instruction.ID = uuid.New()
+
+	if err := s.instructionRepo.Save(ctx, instruction, req.IdempotencyKey.Key); err != nil {
+		if errors.Is(err, ports.ErrDuplicateIdempotency) {
+			return nil, status.Error(codes.AlreadyExists, "instruction with this idempotency key already exists")
+		}
+		s.logger.Error("failed to save instruction", "error", err)
+		return nil, status.Error(codes.Internal, "failed to save instruction")
+	}
+
+	return &opgatewayv1.DispatchInstructionResponse{
+		Instruction: instructionToProto(instruction),
+	}, nil
+}
+
+// CancelInstruction cancels a pending instruction.
+func (s *OperationalGatewayService) CancelInstruction(
+	ctx context.Context,
+	req *opgatewayv1.CancelInstructionRequest,
+) (*opgatewayv1.CancelInstructionResponse, error) {
+	tid, err := requireTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := uuid.Parse(req.InstructionId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid instruction_id: %v", err)
+	}
+
+	instruction, err := s.instructionRepo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, ports.ErrInstructionNotFound) {
+			return nil, status.Errorf(codes.NotFound, "instruction not found: %s", req.InstructionId)
+		}
+		s.logger.Error("failed to find instruction", "error", err)
+		return nil, status.Error(codes.Internal, "failed to retrieve instruction")
+	}
+
+	// Verify tenant ownership.
+	if instruction.TenantID.String() != tenantIDToUUID(tid) {
+		return nil, status.Errorf(codes.NotFound, "instruction not found: %s", req.InstructionId)
+	}
+
+	if err := instruction.Cancel(); err != nil {
+		if errors.Is(err, domain.ErrInstructionNotCancellable) {
+			return nil, status.Errorf(codes.FailedPrecondition, "instruction cannot be cancelled in status %s", instruction.Status)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to cancel instruction: %v", err)
+	}
+
+	if err := s.instructionRepo.Save(ctx, instruction, ""); err != nil {
+		if errors.Is(err, ports.ErrInstructionConflict) {
+			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
+		}
+		s.logger.Error("failed to save cancelled instruction", "error", err)
+		return nil, status.Error(codes.Internal, "failed to save instruction")
+	}
+
+	return &opgatewayv1.CancelInstructionResponse{
+		Instruction: instructionToProto(instruction),
+	}, nil
+}
+
+// tenantIDToUUID converts a tenant.TenantID string to a UUID string.
+// Tenant IDs are stored as UUID strings in the instruction domain.
+// If the tenant ID is already a valid UUID string, return it directly.
+// Otherwise, generate a deterministic UUID from the tenant ID.
+func tenantIDToUUID(tid tenant.TenantID) string {
+	_, err := uuid.Parse(tid.String())
+	if err == nil {
+		return tid.String()
+	}
+	// Derive a deterministic UUID v5 from the tenant ID string.
+	return uuid.NewSHA1(uuid.NameSpaceDNS, []byte(tid.String())).String()
+}
+
+// structToMap converts a protobuf Struct to a Go map[string]any.
+func structToMap(s *structpb.Struct) map[string]any {
+	if s == nil {
+		return map[string]any{}
+	}
+	result := make(map[string]any, len(s.Fields))
+	for k, v := range s.Fields {
+		result[k] = protoValueToAny(v)
+	}
+	return result
+}
+
+// protoValueToAny converts a structpb.Value to a native Go value.
+func protoValueToAny(v *structpb.Value) any {
+	if v == nil {
+		return nil
+	}
+	switch k := v.Kind.(type) {
+	case *structpb.Value_NullValue:
+		return nil
+	case *structpb.Value_BoolValue:
+		return k.BoolValue
+	case *structpb.Value_NumberValue:
+		return k.NumberValue
+	case *structpb.Value_StringValue:
+		return k.StringValue
+	case *structpb.Value_ListValue:
+		if k.ListValue == nil {
+			return []any{}
+		}
+		items := make([]any, len(k.ListValue.Values))
+		for i, item := range k.ListValue.Values {
+			items[i] = protoValueToAny(item)
+		}
+		return items
+	case *structpb.Value_StructValue:
+		return structToMap(k.StructValue)
+	default:
+		return nil
+	}
+}

--- a/services/operational-gateway/service/grpc_service_test.go
+++ b/services/operational-gateway/service/grpc_service_test.go
@@ -693,3 +693,92 @@ func TestNewProviderConnectionService_NilConnRepo(t *testing.T) {
 	_, err := NewProviderConnectionService(nil, newMockInstructionRepo(), nil)
 	assert.ErrorIs(t, err, ErrConnectionRepoNil)
 }
+
+// ========== ProcessCallback tests ==========
+
+// makeDeliveredInstruction creates an instruction in DELIVERED state and stores it in the repo.
+func makeDeliveredInstruction(t *testing.T, instRepo *mockInstructionRepo) *domain.Instruction {
+	t.Helper()
+	tid := testTenantID()
+	tenantUUID, err := uuid.Parse(tid)
+	require.NoError(t, err)
+
+	inst, err := domain.NewInstruction(tenantUUID, "payment.initiate", uuid.Nil.String(), map[string]any{"amount": 100.0})
+	require.NoError(t, err)
+	inst.ID = uuid.New()
+	require.NoError(t, inst.MarkDispatching())
+	require.NoError(t, inst.MarkDelivered())
+	stored := *inst
+	instRepo.instructions[inst.ID] = &stored
+	return inst
+}
+
+func TestProcessCallback_AlreadyAcked(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	inst := makeDeliveredInstruction(t, instRepo)
+	// Pre-transition to ACKNOWLEDGED.
+	require.NoError(t, inst.MarkAcknowledged())
+	instRepo.instructions[inst.ID] = inst
+
+	resp, err := svc.ProcessCallback(ctx, &opgatewayv1.ProcessCallbackRequest{
+		InstructionId:  inst.ID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "idem-ack"},
+		Callback:       &opgatewayv1.CallbackPayload{},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_ACKNOWLEDGED, resp.Instruction.Status)
+}
+
+func TestProcessCallback_Success(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	inst := makeDeliveredInstruction(t, instRepo)
+
+	resp, err := svc.ProcessCallback(ctx, &opgatewayv1.ProcessCallbackRequest{
+		InstructionId:  inst.ID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "idem-cb-1"},
+		Callback:       &opgatewayv1.CallbackPayload{},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_ACKNOWLEDGED, resp.Instruction.Status)
+}
+
+func TestProcessCallback_ProviderReferenceUnimplemented(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.ProcessCallback(ctx, &opgatewayv1.ProcessCallbackRequest{
+		ProviderReference: "ext-ref-123",
+		IdempotencyKey:    &commonpb.IdempotencyKey{Key: "idem-ref"},
+		Callback:          &opgatewayv1.CallbackPayload{},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unimplemented, st.Code())
+}
+
+func TestProcessCallback_DuplicateIdempotency(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	inst := makeDeliveredInstruction(t, instRepo)
+	instRepo.saveErr = ports.ErrDuplicateIdempotency
+
+	resp, err := svc.ProcessCallback(ctx, &opgatewayv1.ProcessCallbackRequest{
+		InstructionId:  inst.ID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "idem-dup"},
+		Callback:       &opgatewayv1.CallbackPayload{},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}

--- a/services/operational-gateway/service/grpc_service_test.go
+++ b/services/operational-gateway/service/grpc_service_test.go
@@ -94,8 +94,8 @@ func (m *mockInstructionRepo) ListByTenant(_ context.Context, params ports.ListI
 
 	total := int64(len(result))
 	// Apply offset and limit.
-	if params.Offset > len(result) {
-		return []*domain.Instruction{}, 0, nil
+	if params.Offset >= len(result) {
+		return []*domain.Instruction{}, total, nil
 	}
 	result = result[params.Offset:]
 	if params.Limit > 0 && len(result) > params.Limit {

--- a/services/operational-gateway/service/grpc_service_test.go
+++ b/services/operational-gateway/service/grpc_service_test.go
@@ -1,0 +1,695 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+)
+
+// ========== Mock repositories ==========
+
+// mockInstructionRepo is an in-memory implementation of ports.InstructionRepository for testing.
+type mockInstructionRepo struct {
+	mu           sync.RWMutex
+	instructions map[uuid.UUID]*domain.Instruction
+	saveErr      error
+	findErr      error
+}
+
+func newMockInstructionRepo() *mockInstructionRepo {
+	return &mockInstructionRepo{
+		instructions: make(map[uuid.UUID]*domain.Instruction),
+	}
+}
+
+func (m *mockInstructionRepo) Save(_ context.Context, inst *domain.Instruction, _ string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	stored := *inst
+	m.instructions[inst.ID] = &stored
+	inst.Version++
+	return nil
+}
+
+func (m *mockInstructionRepo) FindByID(_ context.Context, id uuid.UUID) (*domain.Instruction, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.findErr != nil {
+		return nil, m.findErr
+	}
+	inst, ok := m.instructions[id]
+	if !ok {
+		return nil, ports.ErrInstructionNotFound
+	}
+	stored := *inst
+	return &stored, nil
+}
+
+func (m *mockInstructionRepo) ListByTenant(_ context.Context, params ports.ListInstructionsParams) ([]*domain.Instruction, int64, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var result []*domain.Instruction
+	for _, inst := range m.instructions {
+		if inst.TenantID.String() != params.TenantID {
+			continue
+		}
+		if params.InstructionType != "" && inst.InstructionType != params.InstructionType {
+			continue
+		}
+		if params.ProviderConnectionID != "" && inst.ProviderConnectionID != params.ProviderConnectionID {
+			continue
+		}
+		if len(params.Statuses) > 0 {
+			found := false
+			for _, s := range params.Statuses {
+				if inst.Status == s {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+		stored := *inst
+		result = append(result, &stored)
+	}
+
+	total := int64(len(result))
+	// Apply offset and limit.
+	if params.Offset > len(result) {
+		return []*domain.Instruction{}, 0, nil
+	}
+	result = result[params.Offset:]
+	if params.Limit > 0 && len(result) > params.Limit {
+		result = result[:params.Limit]
+	}
+	return result, total, nil
+}
+
+func (m *mockInstructionRepo) FetchDispatchable(_ context.Context, _ ports.FetchDispatchableParams) ([]*domain.Instruction, error) {
+	return nil, nil
+}
+
+// mockConnectionRepo is an in-memory implementation of ports.ConnectionRepository for testing.
+type mockConnectionRepo struct {
+	mu          sync.RWMutex
+	connections map[string]*domain.ProviderConnection
+	upsertErr   error
+	findErr     error
+}
+
+func newMockConnectionRepo() *mockConnectionRepo {
+	return &mockConnectionRepo{
+		connections: make(map[string]*domain.ProviderConnection),
+	}
+}
+
+func (m *mockConnectionRepo) Upsert(_ context.Context, conn *domain.ProviderConnection) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.upsertErr != nil {
+		return m.upsertErr
+	}
+	stored := *conn
+	m.connections[conn.TenantID+":"+conn.ConnectionID] = &stored
+	return nil
+}
+
+func (m *mockConnectionRepo) FindByID(_ context.Context, tenantID string, connectionID string) (*domain.ProviderConnection, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.findErr != nil {
+		return nil, m.findErr
+	}
+	conn, ok := m.connections[tenantID+":"+connectionID]
+	if !ok {
+		return nil, ports.ErrConnectionNotFound
+	}
+	stored := *conn
+	return &stored, nil
+}
+
+func (m *mockConnectionRepo) ListByTenant(_ context.Context, tenantID string) ([]*domain.ProviderConnection, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var result []*domain.ProviderConnection
+	for _, conn := range m.connections {
+		if conn.TenantID == tenantID {
+			stored := *conn
+			result = append(result, &stored)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockConnectionRepo) UpdateHealth(_ context.Context, conn *domain.ProviderConnection) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := conn.TenantID + ":" + conn.ConnectionID
+	existing, ok := m.connections[key]
+	if !ok {
+		return ports.ErrConnectionNotFound
+	}
+	existing.HealthStatus = conn.HealthStatus
+	existing.LastHealthCheckAt = conn.LastHealthCheckAt
+	existing.CircuitState = conn.CircuitState
+	return nil
+}
+
+// ========== Test helpers ==========
+
+// tenantContext returns a context with the given tenant ID attached.
+func tenantContext(tid string) context.Context {
+	return tenant.WithTenant(context.Background(), tenant.TenantID(tid))
+}
+
+// testTenantUUID is a fixed UUID for use in tests as both the tenant context value
+// and the UUID that tenantIDToUUID produces for "test-tenant".
+func testTenantID() string {
+	// tenantIDToUUID("test-tenant") → UUID v5 derived from "test-tenant"
+	return tenantIDToUUID(tenant.TenantID("test-tenant"))
+}
+
+func newTestOGService(t *testing.T) (*OperationalGatewayService, *mockInstructionRepo, *mockConnectionRepo) {
+	t.Helper()
+	instRepo := newMockInstructionRepo()
+	connRepo := newMockConnectionRepo()
+	svc, err := NewOperationalGatewayService(instRepo, connRepo, nil)
+	require.NoError(t, err)
+	return svc, instRepo, connRepo
+}
+
+func newTestConnService(t *testing.T) (*ProviderConnectionService, *mockConnectionRepo) {
+	t.Helper()
+	connRepo := newMockConnectionRepo()
+	instRepo := newMockInstructionRepo()
+	svc, err := NewProviderConnectionService(connRepo, instRepo, nil)
+	require.NoError(t, err)
+	return svc, connRepo
+}
+
+// ========== DispatchInstruction tests ==========
+
+func TestDispatchInstruction_Success(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	payload, err := structpb.NewStruct(map[string]any{"amount": 100.0})
+	require.NoError(t, err)
+
+	resp, err := svc.DispatchInstruction(ctx, &opgatewayv1.DispatchInstructionRequest{
+		InstructionType: "payment.initiate",
+		Payload:         payload,
+		IdempotencyKey:  &commonpb.IdempotencyKey{Key: "idem-1"},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.Instruction.Id)
+	assert.Equal(t, opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING, resp.Instruction.Status)
+	assert.Equal(t, "payment.initiate", resp.Instruction.InstructionType)
+}
+
+func TestDispatchInstruction_MissingTenant(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+
+	payload, err := structpb.NewStruct(map[string]any{"amount": 100.0})
+	require.NoError(t, err)
+
+	_, err = svc.DispatchInstruction(context.Background(), &opgatewayv1.DispatchInstructionRequest{
+		InstructionType: "payment.initiate",
+		Payload:         payload,
+		IdempotencyKey:  &commonpb.IdempotencyKey{Key: "idem-1"},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestDispatchInstruction_MissingInstructionType(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	payload, err := structpb.NewStruct(map[string]any{"amount": 100.0})
+	require.NoError(t, err)
+
+	_, err = svc.DispatchInstruction(ctx, &opgatewayv1.DispatchInstructionRequest{
+		InstructionType: "",
+		Payload:         payload,
+		IdempotencyKey:  &commonpb.IdempotencyKey{Key: "idem-1"},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestDispatchInstruction_MissingPayload(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.DispatchInstruction(ctx, &opgatewayv1.DispatchInstructionRequest{
+		InstructionType: "payment.initiate",
+		Payload:         nil,
+		IdempotencyKey:  &commonpb.IdempotencyKey{Key: "idem-1"},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestDispatchInstruction_MissingIdempotencyKey(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	payload, _ := structpb.NewStruct(map[string]any{"x": 1.0})
+	_, err := svc.DispatchInstruction(ctx, &opgatewayv1.DispatchInstructionRequest{
+		InstructionType: "payment.initiate",
+		Payload:         payload,
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestDispatchInstruction_RepoError(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	instRepo.saveErr = assert.AnError
+	ctx := tenantContext("test-tenant")
+
+	payload, _ := structpb.NewStruct(map[string]any{"x": 1.0})
+	_, err := svc.DispatchInstruction(ctx, &opgatewayv1.DispatchInstructionRequest{
+		InstructionType: "payment.initiate",
+		Payload:         payload,
+		IdempotencyKey:  &commonpb.IdempotencyKey{Key: "idem-2"},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+// ========== CancelInstruction tests ==========
+
+func TestCancelInstruction_Success(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	// Pre-populate a PENDING instruction.
+	tid := uuid.MustParse(testTenantID())
+	inst, err := domain.NewInstruction(tid, "payment.initiate", "pending", map[string]any{"x": 1})
+	require.NoError(t, err)
+	inst.ID = uuid.New()
+	instRepo.instructions[inst.ID] = inst
+
+	resp, err := svc.CancelInstruction(ctx, &opgatewayv1.CancelInstructionRequest{
+		InstructionId: inst.ID.String(),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_CANCELLED, resp.Instruction.Status)
+}
+
+func TestCancelInstruction_NotFound(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.CancelInstruction(ctx, &opgatewayv1.CancelInstructionRequest{
+		InstructionId: uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestCancelInstruction_WrongTenant(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+
+	// Store instruction under a different tenant.
+	otherTenantID := uuid.New()
+	inst, err := domain.NewInstruction(otherTenantID, "payment.initiate", "pending", map[string]any{"x": 1})
+	require.NoError(t, err)
+	inst.ID = uuid.New()
+	instRepo.instructions[inst.ID] = inst
+
+	// Request from a different tenant.
+	ctx := tenantContext("test-tenant")
+	_, err = svc.CancelInstruction(ctx, &opgatewayv1.CancelInstructionRequest{
+		InstructionId: inst.ID.String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestCancelInstruction_NotCancellable(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	tid := uuid.MustParse(testTenantID())
+	inst, err := domain.NewInstruction(tid, "payment.initiate", "pending", map[string]any{"x": 1})
+	require.NoError(t, err)
+	inst.ID = uuid.New()
+	// Transition to DISPATCHING.
+	require.NoError(t, inst.MarkDispatching())
+	instRepo.instructions[inst.ID] = inst
+
+	_, err = svc.CancelInstruction(ctx, &opgatewayv1.CancelInstructionRequest{
+		InstructionId: inst.ID.String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+// ========== GetInstruction tests ==========
+
+func TestGetInstruction_Success(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	tid := uuid.MustParse(testTenantID())
+	inst, err := domain.NewInstruction(tid, "payment.initiate", "pending", map[string]any{"x": 1})
+	require.NoError(t, err)
+	inst.ID = uuid.New()
+	instRepo.instructions[inst.ID] = inst
+
+	resp, err := svc.GetInstruction(ctx, &opgatewayv1.GetInstructionRequest{
+		InstructionId: inst.ID.String(),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, inst.ID.String(), resp.Instruction.Id)
+	assert.Equal(t, opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING, resp.Instruction.Status)
+}
+
+func TestGetInstruction_NotFound(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.GetInstruction(ctx, &opgatewayv1.GetInstructionRequest{
+		InstructionId: uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestGetInstruction_MissingTenant(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+
+	_, err := svc.GetInstruction(context.Background(), &opgatewayv1.GetInstructionRequest{
+		InstructionId: uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestGetInstruction_InvalidUUID(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.GetInstruction(ctx, &opgatewayv1.GetInstructionRequest{
+		InstructionId: "not-a-uuid",
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// ========== ListInstructions tests ==========
+
+func TestListInstructions_Success(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	tid := uuid.MustParse(testTenantID())
+	for i := 0; i < 3; i++ {
+		inst, err := domain.NewInstruction(tid, "payment.initiate", "pending", map[string]any{"i": float64(i)})
+		require.NoError(t, err)
+		inst.ID = uuid.New()
+		instRepo.instructions[inst.ID] = inst
+	}
+
+	resp, err := svc.ListInstructions(ctx, &opgatewayv1.ListInstructionsRequest{})
+	require.NoError(t, err)
+	assert.Len(t, resp.Instructions, 3)
+	assert.Equal(t, int64(3), resp.Pagination.TotalCount)
+}
+
+func TestListInstructions_Pagination(t *testing.T) {
+	svc, instRepo, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	tid := uuid.MustParse(testTenantID())
+	for i := 0; i < 5; i++ {
+		inst, err := domain.NewInstruction(tid, "payment.initiate", "pending", map[string]any{"i": float64(i)})
+		require.NoError(t, err)
+		inst.ID = uuid.New()
+		instRepo.instructions[inst.ID] = inst
+	}
+
+	// First page: 2 items.
+	resp1, err := svc.ListInstructions(ctx, &opgatewayv1.ListInstructionsRequest{
+		Pagination: &commonpb.Pagination{PageSize: 2},
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp1.Instructions, 2)
+	assert.NotEmpty(t, resp1.Pagination.NextPageToken)
+
+	// Second page using token.
+	resp2, err := svc.ListInstructions(ctx, &opgatewayv1.ListInstructionsRequest{
+		Pagination: &commonpb.Pagination{
+			PageSize:  2,
+			PageToken: resp1.Pagination.NextPageToken,
+		},
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp2.Instructions, 2)
+
+	// Third page.
+	resp3, err := svc.ListInstructions(ctx, &opgatewayv1.ListInstructionsRequest{
+		Pagination: &commonpb.Pagination{
+			PageSize:  2,
+			PageToken: resp2.Pagination.NextPageToken,
+		},
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp3.Instructions, 1)
+	assert.Empty(t, resp3.Pagination.NextPageToken)
+}
+
+func TestListInstructions_PageSizeBounds(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	// Page size > maxPageSize should be clamped (no error).
+	resp, err := svc.ListInstructions(ctx, &opgatewayv1.ListInstructionsRequest{
+		Pagination: &commonpb.Pagination{PageSize: 999999},
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestListInstructions_InvalidPageToken(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.ListInstructions(ctx, &opgatewayv1.ListInstructionsRequest{
+		Pagination: &commonpb.Pagination{PageToken: "garbage"},
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestListInstructions_MissingTenant(t *testing.T) {
+	svc, _, _ := newTestOGService(t)
+
+	_, err := svc.ListInstructions(context.Background(), &opgatewayv1.ListInstructionsRequest{})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+// ========== UpsertConnection tests ==========
+
+func TestUpsertConnection_Success(t *testing.T) {
+	svc, _ := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+
+	resp, err := svc.UpsertConnection(ctx, &opgatewayv1.UpsertConnectionRequest{
+		ProviderName: "Stripe",
+		ProviderType: "payment_gateway",
+		Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+		BaseUrl:      "https://api.stripe.com",
+		AuthConfig: &opgatewayv1.UpsertConnectionRequest_ApiKey{
+			ApiKey: &opgatewayv1.ApiKeyAuth{
+				HeaderName: "X-API-Key",
+				SecretRef:  "stripe-api-key",
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.Connection)
+	assert.Equal(t, "Stripe", resp.Connection.ProviderName)
+	assert.Equal(t, opgatewayv1.Protocol_PROTOCOL_HTTPS, resp.Connection.Protocol)
+}
+
+func TestUpsertConnection_MissingTenant(t *testing.T) {
+	svc, _ := newTestConnService(t)
+
+	_, err := svc.UpsertConnection(context.Background(), &opgatewayv1.UpsertConnectionRequest{
+		ProviderName: "Stripe",
+		ProviderType: "payment_gateway",
+		Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+		BaseUrl:      "https://api.stripe.com",
+		AuthConfig: &opgatewayv1.UpsertConnectionRequest_ApiKey{
+			ApiKey: &opgatewayv1.ApiKeyAuth{HeaderName: "X-API-Key", SecretRef: "key"},
+		},
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestUpsertConnection_WithExplicitConnectionID(t *testing.T) {
+	svc, _ := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+
+	connID := uuid.New().String()
+	resp, err := svc.UpsertConnection(ctx, &opgatewayv1.UpsertConnectionRequest{
+		ProviderName: "Modulr",
+		ProviderType: "payment_gateway",
+		Protocol:     opgatewayv1.Protocol_PROTOCOL_HTTPS,
+		BaseUrl:      "https://api.modulrfinance.com",
+		ConnectionId: connID,
+		AuthConfig: &opgatewayv1.UpsertConnectionRequest_Basic{
+			Basic: &opgatewayv1.BasicAuth{Username: "user", PasswordSecretRef: "pass-ref"},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, connID, resp.Connection.ConnectionId)
+}
+
+// ========== GetConnection tests ==========
+
+func TestGetConnection_Success(t *testing.T) {
+	svc, connRepo := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+	tid := tenantIDToUUID(tenant.TenantID("test-tenant"))
+
+	conn, err := domain.NewProviderConnection(tid, "Stripe", "payment_gateway", domain.ProtocolHTTPS, "https://api.stripe.com",
+		&domain.APIKeyAuth{HeaderName: "X-API-Key", SecretRef: "key"}, domain.RetryPolicy{MaxAttempts: 3}, domain.RateLimitConfig{})
+	require.NoError(t, err)
+	connRepo.connections[tid+":"+conn.ConnectionID] = conn
+
+	resp, err := svc.GetConnection(ctx, &opgatewayv1.GetConnectionRequest{ConnectionId: conn.ConnectionID})
+	require.NoError(t, err)
+	assert.Equal(t, conn.ConnectionID, resp.Connection.ConnectionId)
+}
+
+func TestGetConnection_NotFound(t *testing.T) {
+	svc, _ := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+
+	_, err := svc.GetConnection(ctx, &opgatewayv1.GetConnectionRequest{
+		ConnectionId: uuid.New().String(),
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+// ========== ListConnections tests ==========
+
+func TestListConnections_Success(t *testing.T) {
+	svc, connRepo := newTestConnService(t)
+	ctx := tenantContext("test-tenant")
+	tid := tenantIDToUUID(tenant.TenantID("test-tenant"))
+
+	for i := 0; i < 3; i++ {
+		conn, err := domain.NewProviderConnection(tid, "Provider", "type", domain.ProtocolHTTPS, "https://api.example.com",
+			&domain.APIKeyAuth{HeaderName: "X-Key", SecretRef: "ref"}, domain.RetryPolicy{MaxAttempts: 3}, domain.RateLimitConfig{})
+		require.NoError(t, err)
+		connRepo.connections[tid+":"+conn.ConnectionID] = conn
+	}
+
+	resp, err := svc.ListConnections(ctx, &opgatewayv1.ListConnectionsRequest{})
+	require.NoError(t, err)
+	assert.Len(t, resp.Connections, 3)
+}
+
+func TestListConnections_MissingTenant(t *testing.T) {
+	svc, _ := newTestConnService(t)
+
+	_, err := svc.ListConnections(context.Background(), &opgatewayv1.ListConnectionsRequest{})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+// ========== Constructor tests ==========
+
+func TestNewOperationalGatewayService_NilRepo(t *testing.T) {
+	_, err := NewOperationalGatewayService(nil, newMockConnectionRepo(), nil)
+	assert.ErrorIs(t, err, ErrInstructionRepoNil)
+}
+
+func TestNewOperationalGatewayService_NilConnRepo(t *testing.T) {
+	_, err := NewOperationalGatewayService(newMockInstructionRepo(), nil, nil)
+	assert.ErrorIs(t, err, ErrConnectionRepoNil)
+}
+
+func TestNewProviderConnectionService_NilConnRepo(t *testing.T) {
+	_, err := NewProviderConnectionService(nil, newMockInstructionRepo(), nil)
+	assert.ErrorIs(t, err, ErrConnectionRepoNil)
+}


### PR DESCRIPTION
## Summary

- Implements `OperationalGatewayService` and `ProviderConnectionService` gRPC handlers following existing Meridian patterns (payment-order service as reference)
- Extends `InstructionRepository` port with `ListByTenant` for paginated instruction queries with filtering
- Full proto <-> domain mapper layer for all message types

## Changes Made

### New Files
- `services/operational-gateway/service/grpc_service.go` — Service structs, constructors, `DispatchInstruction`, `CancelInstruction`, tenant helpers
- `services/operational-gateway/service/grpc_query.go` — `GetInstruction`, `ListInstructions`, `ProcessCallback` with offset-based pagination
- `services/operational-gateway/service/grpc_connection_service.go` — `UpsertConnection`, `GetConnection`, `ListConnections`, `TestConnection` (Phase 2 placeholder)
- `services/operational-gateway/service/grpc_mappers.go` — Proto <-> domain converters for all types
- `services/operational-gateway/service/grpc_service_test.go` — 28 unit tests with in-memory mock repositories

### Modified Files
- `services/operational-gateway/ports/repositories.go` — Adds `ListByTenant` method and `ListInstructionsParams` struct to `InstructionRepository`
- `services/operational-gateway/adapters/persistence/instruction_repository.go` — Implements `ListByTenant` with GORM filtering and pagination

## Testing

All 28 unit tests pass with in-memory mock repositories. Covers tenant isolation, validation, state machine enforcement, pagination bounds, and constructor guards.

```
ok  github.com/meridianhub/meridian/services/operational-gateway/service   0.6s
```

## Risk Assessment

Low. All changes are additive. Existing adapter/persistence tests continue to pass.