### PR TITLE
feat: Add HTTP dispatcher adapter for operational gateway

### DIFF
--- a/services/operational-gateway/adapters/httpadapter/http_dispatcher.go
+++ b/services/operational-gateway/adapters/httpadapter/http_dispatcher.go
@@ -46,6 +46,20 @@ var (
 	// Use NewMTLSHTTPDispatcher to create a dispatcher with a dedicated mTLS transport.
 	ErrMTLSNotSupported = errors.New("mtls auth requires a dedicated per-connection client: use NewMTLSHTTPDispatcher")
 
+	// ErrMTLSAuthRequired is returned when an mTLS dispatcher is used with a connection
+	// that does not have MTLSAuth as its auth config. This prevents silently sending
+	// unauthenticated requests when a connection is misconfigured.
+	ErrMTLSAuthRequired = errors.New("mtls dispatcher requires connection auth type MTLSAuth")
+
+	// ErrNilInstruction is returned when Dispatch is called with a nil instruction.
+	ErrNilInstruction = errors.New("dispatch: instruction must not be nil")
+
+	// ErrNilConnection is returned when Dispatch is called with a nil provider connection.
+	ErrNilConnection = errors.New("dispatch: provider connection must not be nil")
+
+	// ErrNilRoute is returned when Dispatch is called with a nil instruction route.
+	ErrNilRoute = errors.New("dispatch: route must not be nil")
+
 	// ErrUnsupportedAuthType is returned when an unknown AuthConfig implementation is encountered.
 	ErrUnsupportedAuthType = errors.New("unsupported auth type")
 
@@ -139,6 +153,25 @@ func (d *HTTPDispatcher) Dispatch(
 ) ports.DispatchResult {
 	start := time.Now()
 
+	if instruction == nil {
+		return ports.DispatchResult{
+			Duration: time.Since(start),
+			Error:    ErrNilInstruction,
+		}
+	}
+	if conn == nil {
+		return ports.DispatchResult{
+			Duration: time.Since(start),
+			Error:    ErrNilConnection,
+		}
+	}
+	if route == nil {
+		return ports.DispatchResult{
+			Duration: time.Since(start),
+			Error:    ErrNilRoute,
+		}
+	}
+
 	body, transformHeaders, err := d.transformer.TransformOutbound(ctx, instruction, route)
 	if err != nil {
 		return ports.DispatchResult{
@@ -174,8 +207,17 @@ func (d *HTTPDispatcher) Dispatch(
 
 	// Apply transport-level authentication last so that auth headers cannot be
 	// overridden by route or transform headers set above.
-	// Skipped for mTLS dispatchers where authentication is handled by the TLS handshake.
-	if !d.skipAppLevelAuth {
+	// For mTLS dispatchers, authentication is handled by the TLS handshake; fail fast
+	// if the connection is misconfigured with a non-mTLS auth type to avoid sending
+	// unauthenticated requests.
+	if d.skipAppLevelAuth {
+		if _, ok := conn.AuthConfig.(*domain.MTLSAuth); !ok {
+			return ports.DispatchResult{
+				Duration: time.Since(start),
+				Error:    fmt.Errorf("%w: got %T", ErrMTLSAuthRequired, conn.AuthConfig),
+			}
+		}
+	} else {
 		if err := d.applyAuth(ctx, req, body, instruction.TenantID.String(), conn.AuthConfig); err != nil {
 			return ports.DispatchResult{
 				Duration: time.Since(start),

--- a/services/operational-gateway/adapters/httpadapter/http_dispatcher.go
+++ b/services/operational-gateway/adapters/httpadapter/http_dispatcher.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -76,6 +77,9 @@ type HTTPDispatcher struct {
 	secretStore ports.SecretStore
 	transformer ports.PayloadTransformer
 	logger      *slog.Logger
+	// skipAppLevelAuth skips applyAuth when the dispatcher uses mTLS transport-level
+	// authentication instead of application-level credentials. Set by NewMTLSHTTPDispatcher.
+	skipAppLevelAuth bool
 }
 
 // NewHTTPDispatcher creates a new HTTPDispatcher with connection pooling configured for
@@ -153,15 +157,8 @@ func (d *HTTPDispatcher) Dispatch(
 		}
 	}
 
-	// Apply transport-level authentication.
-	if err := d.applyAuth(ctx, req, body, instruction.TenantID.String(), conn.AuthConfig); err != nil {
-		return ports.DispatchResult{
-			Duration: time.Since(start),
-			Error:    fmt.Errorf("applying auth: %w", err),
-		}
-	}
-
-	// Standard headers.
+	// Set standard headers first so that auth headers applied below take precedence
+	// and cannot be overwritten by route or transform headers.
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Request-ID", uuid.New().String())
 
@@ -173,6 +170,18 @@ func (d *HTTPDispatcher) Dispatch(
 	// Route-level static headers defined on the InstructionRoute.
 	for k, v := range route.Headers {
 		req.Header.Set(k, v)
+	}
+
+	// Apply transport-level authentication last so that auth headers cannot be
+	// overridden by route or transform headers set above.
+	// Skipped for mTLS dispatchers where authentication is handled by the TLS handshake.
+	if !d.skipAppLevelAuth {
+		if err := d.applyAuth(ctx, req, body, instruction.TenantID.String(), conn.AuthConfig); err != nil {
+			return ports.DispatchResult{
+				Duration: time.Since(start),
+				Error:    fmt.Errorf("applying auth: %w", err),
+			}
+		}
 	}
 
 	resp, err := d.client.Do(req)
@@ -211,11 +220,15 @@ func (d *HTTPDispatcher) Dispatch(
 		}
 	}
 
+	var providerStatus string
+	if outcome != nil {
+		providerStatus = outcome.ProviderStatus
+	}
 	d.logger.DebugContext(ctx, "dispatch completed",
 		"instruction_id", instruction.ID.String(),
 		"status_code", resp.StatusCode,
 		"duration_ms", time.Since(start).Milliseconds(),
-		"provider_status", outcome.ProviderStatus,
+		"provider_status", providerStatus,
 	)
 
 	return ports.DispatchResult{
@@ -325,15 +338,18 @@ func buildURL(baseURL, pathTemplate string) string {
 }
 
 // buildOAuth2FormBody constructs the application/x-www-form-urlencoded body for a
-// client credentials token request.
+// client credentials token request. All values are URL-encoded to handle special
+// characters in client IDs, secrets, and scope strings.
 func buildOAuth2FormBody(clientID, clientSecret string, scopes []string) string {
-	body := "grant_type=" + oauth2GrantType +
-		"&client_id=" + clientID +
-		"&client_secret=" + clientSecret
-	if len(scopes) > 0 {
-		body += "&scope=" + strings.Join(scopes, " ")
+	values := url.Values{
+		"grant_type":    {oauth2GrantType},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
 	}
-	return body
+	if len(scopes) > 0 {
+		values.Set("scope", strings.Join(scopes, " "))
+	}
+	return values.Encode()
 }
 
 // extractBearerToken parses an OAuth 2.0 token response JSON and returns the access_token.
@@ -387,12 +403,22 @@ func computeHMAC(algorithm string, key, body []byte) (string, error) {
 // This constructor exists as a separate entry point because mTLS requires modifying the
 // TLS configuration of the underlying http.Transport, which cannot be done per-request.
 // Callers should create one MTLSHTTPDispatcher per distinct client certificate identity.
+//
+// The returned dispatcher skips application-level auth (applyAuth) because authentication
+// is handled by the TLS handshake itself.
 func NewMTLSHTTPDispatcher(
 	secretStore ports.SecretStore,
 	transformer ports.PayloadTransformer,
 	logger *slog.Logger,
 	clientCertPEM, clientKeyPEM, caCertPEM []byte,
 ) (*HTTPDispatcher, error) {
+	if secretStore == nil {
+		panic("httpadapter.NewMTLSHTTPDispatcher: secretStore must not be nil")
+	}
+	if transformer == nil {
+		panic("httpadapter.NewMTLSHTTPDispatcher: transformer must not be nil")
+	}
+
 	cert, err := tls.X509KeyPair(clientCertPEM, clientKeyPEM)
 	if err != nil {
 		return nil, fmt.Errorf("loading client certificate: %w", err)
@@ -427,9 +453,10 @@ func NewMTLSHTTPDispatcher(
 	}
 
 	return &HTTPDispatcher{
-		client:      client,
-		secretStore: secretStore,
-		transformer: transformer,
-		logger:      logger,
+		client:           client,
+		secretStore:      secretStore,
+		transformer:      transformer,
+		logger:           logger,
+		skipAppLevelAuth: true,
 	}, nil
 }

--- a/services/operational-gateway/adapters/httpadapter/http_dispatcher.go
+++ b/services/operational-gateway/adapters/httpadapter/http_dispatcher.go
@@ -1,0 +1,435 @@
+// Package httpadapter provides an HTTP implementation of the Dispatcher port for
+// the operational gateway. It handles outbound HTTP requests to external providers,
+// including authentication, payload transformation, and response parsing.
+package httpadapter
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+)
+
+const (
+	// defaultTimeout is the default HTTP request timeout.
+	defaultTimeout = 30 * time.Second
+
+	// maxResponseBodyBytes is the maximum number of bytes read from a provider response body.
+	// Responses larger than this are truncated to prevent memory exhaustion.
+	maxResponseBodyBytes = 1 << 20 // 1 MiB
+
+	// oauth2GrantType is the client credentials grant type for OAuth 2.0 token requests.
+	oauth2GrantType = "client_credentials"
+)
+
+// Sentinel errors for the httpadapter package.
+var (
+	// ErrMTLSNotSupported is returned when MTLSAuth is used with the standard HTTPDispatcher.
+	// Use NewMTLSHTTPDispatcher to create a dispatcher with a dedicated mTLS transport.
+	ErrMTLSNotSupported = errors.New("mtls auth requires a dedicated per-connection client: use NewMTLSHTTPDispatcher")
+
+	// ErrUnsupportedAuthType is returned when an unknown AuthConfig implementation is encountered.
+	ErrUnsupportedAuthType = errors.New("unsupported auth type")
+
+	// ErrTokenEndpointFailed is returned when the OAuth 2.0 token endpoint returns a non-200 response.
+	ErrTokenEndpointFailed = errors.New("token endpoint returned non-200 response")
+
+	// ErrTokenNotFound is returned when the token endpoint response does not contain an access_token field.
+	ErrTokenNotFound = errors.New("access_token not found in token response")
+
+	// ErrMalformedToken is returned when the access_token field in the token response is malformed.
+	ErrMalformedToken = errors.New("malformed access_token in token response")
+
+	// ErrUnsupportedHMACAlgorithm is returned when an HMAC algorithm other than sha256 or sha512 is requested.
+	ErrUnsupportedHMACAlgorithm = errors.New("unsupported hmac algorithm: supported algorithms are sha256, sha512")
+
+	// ErrInvalidCACert is returned when the CA certificate PEM cannot be parsed.
+	ErrInvalidCACert = errors.New("failed to parse CA certificate PEM")
+)
+
+// HTTPDispatcher sends instructions to external providers over HTTPS.
+// It implements ports.Dispatcher for HTTP-based provider connections.
+//
+// Authentication credentials are resolved at dispatch time via the SecretStore,
+// so raw secret values are never held in memory beyond the scope of a single Dispatch call.
+//
+// HTTPDispatcher is safe for concurrent use.
+type HTTPDispatcher struct {
+	client      *http.Client
+	secretStore ports.SecretStore
+	transformer ports.PayloadTransformer
+	logger      *slog.Logger
+}
+
+// NewHTTPDispatcher creates a new HTTPDispatcher with connection pooling configured for
+// high-throughput dispatch workloads.
+//
+// The underlying http.Client uses:
+//   - MaxIdleConnsPerHost: 100 (reduces TCP handshake overhead for bursty traffic)
+//   - IdleConnTimeout: 90s (keeps connections warm without holding them indefinitely)
+//   - Default timeout: 30s (overridable per-request via context deadline)
+func NewHTTPDispatcher(secretStore ports.SecretStore, transformer ports.PayloadTransformer, logger *slog.Logger) *HTTPDispatcher {
+	if secretStore == nil {
+		panic("httpadapter.NewHTTPDispatcher: secretStore must not be nil")
+	}
+	if transformer == nil {
+		panic("httpadapter.NewHTTPDispatcher: transformer must not be nil")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	transport := &http.Transport{
+		MaxIdleConnsPerHost: 100,
+		IdleConnTimeout:     90 * time.Second,
+	}
+
+	client := &http.Client{
+		Timeout:   defaultTimeout,
+		Transport: transport,
+	}
+
+	return &HTTPDispatcher{
+		client:      client,
+		secretStore: secretStore,
+		transformer: transformer,
+		logger:      logger,
+	}
+}
+
+// Dispatch sends the instruction to the provider and returns a DispatchResult.
+//
+// Flow:
+//  1. Transform the instruction payload outbound via the PayloadTransformer.
+//  2. Build the target URL from conn.BaseURL + route.PathTemplate.
+//  3. Create an HTTP request with context.
+//  4. Apply authentication credentials from conn.AuthConfig.
+//  5. Set headers: Content-Type, X-Request-ID, route static headers, transform headers.
+//  6. Execute the request.
+//  7. Read and limit the response body.
+//  8. Transform the response inbound to produce an InstructionOutcome.
+//
+// Dispatch does not retry; that is the responsibility of the dispatch worker.
+func (d *HTTPDispatcher) Dispatch(
+	ctx context.Context,
+	instruction *domain.Instruction,
+	conn *domain.ProviderConnection,
+	route *ports.InstructionRoute,
+) ports.DispatchResult {
+	start := time.Now()
+
+	body, transformHeaders, err := d.transformer.TransformOutbound(ctx, instruction, route)
+	if err != nil {
+		return ports.DispatchResult{
+			Duration: time.Since(start),
+			Error:    fmt.Errorf("outbound transform: %w", err),
+		}
+	}
+
+	targetURL := buildURL(conn.BaseURL, route.PathTemplate)
+
+	req, err := http.NewRequestWithContext(ctx, route.HTTPMethod, targetURL, bytes.NewReader(body))
+	if err != nil {
+		return ports.DispatchResult{
+			Duration: time.Since(start),
+			Error:    fmt.Errorf("building request: %w", err),
+		}
+	}
+
+	// Apply transport-level authentication.
+	if err := d.applyAuth(ctx, req, body, instruction.TenantID.String(), conn.AuthConfig); err != nil {
+		return ports.DispatchResult{
+			Duration: time.Since(start),
+			Error:    fmt.Errorf("applying auth: %w", err),
+		}
+	}
+
+	// Standard headers.
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Request-ID", uuid.New().String())
+
+	// Route-level static headers (from mapping definition).
+	for k, v := range transformHeaders {
+		req.Header.Set(k, v)
+	}
+
+	// Route-level static headers defined on the InstructionRoute.
+	for k, v := range route.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return ports.DispatchResult{
+			Duration: time.Since(start),
+			Error:    fmt.Errorf("executing request: %w", err),
+		}
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			d.logger.WarnContext(ctx, "failed to close response body",
+				"error", closeErr,
+				"instruction_id", instruction.ID.String(),
+			)
+		}
+	}()
+
+	limited := io.LimitReader(resp.Body, maxResponseBodyBytes)
+	respBody, err := io.ReadAll(limited)
+	if err != nil {
+		return ports.DispatchResult{
+			StatusCode: resp.StatusCode,
+			Duration:   time.Since(start),
+			Error:      fmt.Errorf("reading response body: %w", err),
+		}
+	}
+
+	outcome, err := d.transformer.TransformInbound(ctx, resp.StatusCode, respBody, route)
+	if err != nil {
+		return ports.DispatchResult{
+			StatusCode:   resp.StatusCode,
+			ResponseBody: respBody,
+			Duration:     time.Since(start),
+			Error:        fmt.Errorf("inbound transform: %w", err),
+		}
+	}
+
+	d.logger.DebugContext(ctx, "dispatch completed",
+		"instruction_id", instruction.ID.String(),
+		"status_code", resp.StatusCode,
+		"duration_ms", time.Since(start).Milliseconds(),
+		"provider_status", outcome.ProviderStatus,
+	)
+
+	return ports.DispatchResult{
+		StatusCode:   resp.StatusCode,
+		ResponseBody: respBody,
+		Outcome:      outcome,
+		Duration:     time.Since(start),
+	}
+}
+
+// applyAuth applies the provider connection's authentication configuration to the
+// outgoing HTTP request. Secrets are resolved via the SecretStore at dispatch time.
+//
+// Supported auth types: APIKeyAuth, BasicAuth, OAuth2Auth, HMACAuth, MTLSAuth.
+// MTLSAuth requires modifying the HTTP client's TLS config; this is handled by
+// returning an error so the caller can use a dedicated per-connection client.
+func (d *HTTPDispatcher) applyAuth(ctx context.Context, req *http.Request, body []byte, tenantID string, authConfig domain.AuthConfig) error {
+	switch auth := authConfig.(type) {
+
+	case *domain.APIKeyAuth:
+		secret, err := d.secretStore.Resolve(ctx, tenantID, auth.SecretRef)
+		if err != nil {
+			return fmt.Errorf("resolving api key secret %q: %w", auth.SecretRef, err)
+		}
+		req.Header.Set(auth.HeaderName, secret)
+
+	case *domain.BasicAuth:
+		password, err := d.secretStore.Resolve(ctx, tenantID, auth.PasswordRef)
+		if err != nil {
+			return fmt.Errorf("resolving basic auth password %q: %w", auth.PasswordRef, err)
+		}
+		req.SetBasicAuth(auth.Username, password)
+
+	case *domain.OAuth2Auth:
+		token, err := d.fetchOAuth2Token(ctx, tenantID, auth)
+		if err != nil {
+			return fmt.Errorf("fetching oauth2 token: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+
+	case *domain.HMACAuth:
+		secret, err := d.secretStore.Resolve(ctx, tenantID, auth.SecretRef)
+		if err != nil {
+			return fmt.Errorf("resolving hmac secret %q: %w", auth.SecretRef, err)
+		}
+		signature, err := computeHMAC(auth.Algorithm, []byte(secret), body)
+		if err != nil {
+			return fmt.Errorf("computing hmac signature: %w", err)
+		}
+		req.Header.Set(auth.SignatureHeader, signature)
+
+	case *domain.MTLSAuth:
+		return ErrMTLSNotSupported
+
+	default:
+		return fmt.Errorf("%w: %T", ErrUnsupportedAuthType, authConfig)
+	}
+	return nil
+}
+
+// fetchOAuth2Token performs a client credentials grant to obtain a bearer token
+// from the provider's token endpoint. The client secret is resolved via the SecretStore.
+//
+// This is a synchronous, non-cached implementation suitable for Phase 1.
+// Production deployments should add token caching with TTL to avoid round-trips on every dispatch.
+func (d *HTTPDispatcher) fetchOAuth2Token(ctx context.Context, tenantID string, auth *domain.OAuth2Auth) (string, error) {
+	clientSecret, err := d.secretStore.Resolve(ctx, tenantID, auth.ClientSecretRef)
+	if err != nil {
+		return "", fmt.Errorf("resolving oauth2 client secret %q: %w", auth.ClientSecretRef, err)
+	}
+
+	formData := strings.NewReader(buildOAuth2FormBody(auth.ClientID, clientSecret, auth.Scopes))
+
+	tokenReq, err := http.NewRequestWithContext(ctx, http.MethodPost, auth.TokenURL, formData)
+	if err != nil {
+		return "", fmt.Errorf("building token request: %w", err)
+	}
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := d.client.Do(tokenReq)
+	if err != nil {
+		return "", fmt.Errorf("executing token request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	limited := io.LimitReader(resp.Body, maxResponseBodyBytes)
+	tokenBody, err := io.ReadAll(limited)
+	if err != nil {
+		return "", fmt.Errorf("reading token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%w: HTTP %d: %s", ErrTokenEndpointFailed, resp.StatusCode, tokenBody)
+	}
+
+	return extractBearerToken(tokenBody)
+}
+
+// buildURL concatenates a base URL and a path template, ensuring no double slashes.
+func buildURL(baseURL, pathTemplate string) string {
+	base := strings.TrimRight(baseURL, "/")
+	path := strings.TrimLeft(pathTemplate, "/")
+	if path == "" {
+		return base
+	}
+	return base + "/" + path
+}
+
+// buildOAuth2FormBody constructs the application/x-www-form-urlencoded body for a
+// client credentials token request.
+func buildOAuth2FormBody(clientID, clientSecret string, scopes []string) string {
+	body := "grant_type=" + oauth2GrantType +
+		"&client_id=" + clientID +
+		"&client_secret=" + clientSecret
+	if len(scopes) > 0 {
+		body += "&scope=" + strings.Join(scopes, " ")
+	}
+	return body
+}
+
+// extractBearerToken parses an OAuth 2.0 token response JSON and returns the access_token.
+// Uses a minimal string search to avoid a full JSON unmarshal for a single field.
+func extractBearerToken(body []byte) (string, error) {
+	// Simple extraction: find "access_token":"<value>" in JSON.
+	s := string(body)
+	const marker = `"access_token"`
+	idx := strings.Index(s, marker)
+	if idx < 0 {
+		return "", ErrTokenNotFound
+	}
+	rest := s[idx+len(marker):]
+	// rest looks like: :"<value>",... or : "<value>",...
+	rest = strings.TrimLeft(rest, " \t\r\n:")
+	if len(rest) == 0 || rest[0] != '"' {
+		return "", ErrMalformedToken
+	}
+	end := strings.Index(rest[1:], `"`)
+	if end < 0 {
+		return "", ErrMalformedToken
+	}
+	token := rest[1 : end+1]
+	if token == "" {
+		return "", ErrMalformedToken
+	}
+	return token, nil
+}
+
+// computeHMAC computes an HMAC signature over body using the given algorithm and secret key.
+// Supported algorithms: "sha256" (default), "sha512".
+// Returns the hex-encoded signature.
+func computeHMAC(algorithm string, key, body []byte) (string, error) {
+	var h hash.Hash
+	switch strings.ToLower(algorithm) {
+	case "sha256", "":
+		h = hmac.New(sha256.New, key)
+	case "sha512":
+		h = hmac.New(sha512.New, key)
+	default:
+		return "", fmt.Errorf("%w: %q", ErrUnsupportedHMACAlgorithm, algorithm)
+	}
+	h.Write(body)
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// NewMTLSHTTPDispatcher creates an HTTPDispatcher configured with mutual TLS using the
+// provided certificate and key PEM blocks. The CA certificate is optional; when empty,
+// the system CA pool is used.
+//
+// This constructor exists as a separate entry point because mTLS requires modifying the
+// TLS configuration of the underlying http.Transport, which cannot be done per-request.
+// Callers should create one MTLSHTTPDispatcher per distinct client certificate identity.
+func NewMTLSHTTPDispatcher(
+	secretStore ports.SecretStore,
+	transformer ports.PayloadTransformer,
+	logger *slog.Logger,
+	clientCertPEM, clientKeyPEM, caCertPEM []byte,
+) (*HTTPDispatcher, error) {
+	cert, err := tls.X509KeyPair(clientCertPEM, clientKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("loading client certificate: %w", err)
+	}
+
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	if len(caCertPEM) > 0 {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caCertPEM) {
+			return nil, ErrInvalidCACert
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig:     tlsCfg,
+		MaxIdleConnsPerHost: 100,
+		IdleConnTimeout:     90 * time.Second,
+	}
+
+	client := &http.Client{
+		Timeout:   defaultTimeout,
+		Transport: transport,
+	}
+
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &HTTPDispatcher{
+		client:      client,
+		secretStore: secretStore,
+		transformer: transformer,
+		logger:      logger,
+	}, nil
+}

--- a/services/operational-gateway/adapters/httpadapter/http_dispatcher_test.go
+++ b/services/operational-gateway/adapters/httpadapter/http_dispatcher_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -675,12 +676,18 @@ func TestDispatch_InboundTransformFails_ReturnsPartialResult(t *testing.T) {
 // --- Network error ---
 
 func TestDispatch_NetworkError_ReturnsError(t *testing.T) {
-	// Use a port that nothing is listening on.
+	// Start a server and immediately close it to get a port that is no longer listening.
+	lc := &net.ListenConfig{}
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	ln.Close() // Close immediately so the port is no longer accepting connections.
+
 	ss := &stubSecretStore{secrets: map[string]string{"KEY": "val"}}
 	tr := &stubTransformer{}
 	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
 
-	conn := newConn(t, "http://127.0.0.1:19999", &domain.APIKeyAuth{
+	conn := newConn(t, "http://"+addr, &domain.APIKeyAuth{
 		HeaderName: "X-API-Key",
 		SecretRef:  "KEY",
 	})

--- a/services/operational-gateway/adapters/httpadapter/http_dispatcher_test.go
+++ b/services/operational-gateway/adapters/httpadapter/http_dispatcher_test.go
@@ -1,0 +1,857 @@
+package httpadapter_test
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/operational-gateway/adapters/httpadapter"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+)
+
+// --- Test doubles ---
+
+// stubSecretStore resolves secrets from an in-memory map.
+type stubSecretStore struct {
+	secrets map[string]string
+	err     error
+}
+
+func (s *stubSecretStore) Resolve(_ context.Context, _, ref string) (string, error) {
+	if s.err != nil {
+		return "", s.err
+	}
+	v, ok := s.secrets[ref]
+	if !ok {
+		return "", fmt.Errorf("%w: %s", ports.ErrSecretNotFound, ref)
+	}
+	return v, nil
+}
+
+// stubTransformer is a minimal PayloadTransformer that returns fixed outbound body
+// and derives inbound outcome from the HTTP status code.
+type stubTransformer struct {
+	outBody    []byte
+	outHeaders map[string]string
+	outErr     error
+	inErr      error
+}
+
+func (t *stubTransformer) TransformOutbound(_ context.Context, _ *domain.Instruction, _ *ports.InstructionRoute) ([]byte, map[string]string, error) {
+	if t.outErr != nil {
+		return nil, nil, t.outErr
+	}
+	body := t.outBody
+	if body == nil {
+		body = []byte(`{"stub":true}`)
+	}
+	return body, t.outHeaders, nil
+}
+
+func (t *stubTransformer) TransformInbound(_ context.Context, statusCode int, body []byte, _ *ports.InstructionRoute) (*ports.InstructionOutcome, error) {
+	if t.inErr != nil {
+		return nil, t.inErr
+	}
+	if statusCode >= 200 && statusCode < 300 {
+		return &ports.InstructionOutcome{ProviderStatus: "ACCEPTED"}, nil
+	}
+	return &ports.InstructionOutcome{
+		ProviderStatus: "REJECTED",
+		FailureReason:  fmt.Sprintf("provider returned HTTP %d: %s", statusCode, body),
+		ShouldRetry:    statusCode == 429 || statusCode >= 500,
+	}, nil
+}
+
+// --- Helpers ---
+
+func newInstruction(t *testing.T) *domain.Instruction {
+	t.Helper()
+	inst, err := domain.NewInstruction(
+		uuid.New(),
+		"payment.create",
+		"conn-001",
+		map[string]any{"amount": "100.00"},
+	)
+	require.NoError(t, err)
+	return inst
+}
+
+func newConn(t *testing.T, baseURL string, authConfig domain.AuthConfig) *domain.ProviderConnection {
+	t.Helper()
+	conn, err := domain.NewProviderConnection(
+		"tenant-001",
+		"acme-bank",
+		"bank",
+		domain.ProtocolHTTPS,
+		baseURL,
+		authConfig,
+		domain.RetryPolicy{},
+		domain.RateLimitConfig{},
+	)
+	require.NoError(t, err)
+	return conn
+}
+
+func simpleRoute(method string) *ports.InstructionRoute {
+	return &ports.InstructionRoute{
+		InstructionType: "payment.create",
+		HTTPMethod:      method,
+		PathTemplate:    "/payments",
+	}
+}
+
+// expectedHMACSHA256 computes the expected HMAC-SHA256 for test assertions.
+func expectedHMACSHA256(key, body []byte) string {
+	h := hmac.New(sha256.New, key)
+	h.Write(body)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// expectedHMACSHA512 computes the expected HMAC-SHA512 for test assertions.
+func expectedHMACSHA512(key, body []byte) string {
+	h := hmac.New(sha512.New, key)
+	h.Write(body)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// --- Constructor tests ---
+
+func TestNewHTTPDispatcher_PanicsOnNilSecretStore(t *testing.T) {
+	tr := &stubTransformer{}
+	assert.Panics(t, func() {
+		httpadapter.NewHTTPDispatcher(nil, tr, nil)
+	})
+}
+
+func TestNewHTTPDispatcher_PanicsOnNilTransformer(t *testing.T) {
+	ss := &stubSecretStore{secrets: map[string]string{}}
+	assert.Panics(t, func() {
+		httpadapter.NewHTTPDispatcher(ss, nil, nil)
+	})
+}
+
+func TestNewHTTPDispatcher_AcceptsNilLogger(t *testing.T) {
+	ss := &stubSecretStore{secrets: map[string]string{}}
+	tr := &stubTransformer{}
+	assert.NotPanics(t, func() {
+		httpadapter.NewHTTPDispatcher(ss, tr, nil)
+	})
+}
+
+// --- Interface compliance ---
+
+func TestHTTPDispatcher_ImplementsDispatcher(_ *testing.T) {
+	ss := &stubSecretStore{secrets: map[string]string{}}
+	tr := &stubTransformer{}
+	var _ ports.Dispatcher = httpadapter.NewHTTPDispatcher(ss, tr, nil)
+}
+
+// --- APIKeyAuth ---
+
+func TestDispatch_APIKeyAuth_SetsHeaderCorrectly(t *testing.T) {
+	var gotKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("X-API-Key")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"MY_API_KEY": "secret-key-123"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.APIKeyAuth{
+		HeaderName: "X-API-Key",
+		SecretRef:  "MY_API_KEY",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.NoError(t, result.Error)
+	assert.Equal(t, http.StatusOK, result.StatusCode)
+	assert.Equal(t, "secret-key-123", gotKey)
+	assert.Equal(t, "ACCEPTED", result.Outcome.ProviderStatus)
+	assert.Positive(t, result.Duration)
+}
+
+func TestDispatch_APIKeyAuth_SecretNotFound_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{}} // no secrets
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.APIKeyAuth{
+		HeaderName: "X-API-Key",
+		SecretRef:  "MISSING_KEY",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.Error(t, result.Error)
+	assert.ErrorIs(t, result.Error, ports.ErrSecretNotFound)
+	assert.Zero(t, result.StatusCode)
+}
+
+// --- BasicAuth ---
+
+func TestDispatch_BasicAuth_SetsAuthorizationHeader(t *testing.T) {
+	var gotUsername, gotPassword string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUsername, gotPassword, _ = r.BasicAuth()
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"DB_PASSWORD": "p4ssw0rd"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.BasicAuth{
+		Username:    "admin",
+		PasswordRef: "DB_PASSWORD",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.NoError(t, result.Error)
+	assert.Equal(t, "admin", gotUsername)
+	assert.Equal(t, "p4ssw0rd", gotPassword)
+	assert.Equal(t, http.StatusCreated, result.StatusCode)
+}
+
+func TestDispatch_BasicAuth_PasswordNotFound_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.BasicAuth{
+		Username:    "user",
+		PasswordRef: "MISSING_PASSWORD",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.Error(t, result.Error)
+	assert.ErrorIs(t, result.Error, ports.ErrSecretNotFound)
+}
+
+// --- OAuth2Auth ---
+
+func TestDispatch_OAuth2Auth_FetchesTokenAndSetsBearerHeader(t *testing.T) {
+	// Token endpoint returns a valid access_token.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			http.NotFound(w, r)
+			return
+		}
+		require.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "client_credentials", r.FormValue("grant_type"))
+		assert.Equal(t, "my-client-id", r.FormValue("client_id"))
+		assert.Equal(t, "super-secret", r.FormValue("client_secret"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"tok_abc123","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer tokenServer.Close()
+
+	var gotBearer string
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBearer = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"pmt-001"}`))
+	}))
+	defer apiServer.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"OAUTH_SECRET": "super-secret"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, apiServer.URL, &domain.OAuth2Auth{
+		TokenURL:        tokenServer.URL + "/oauth/token",
+		ClientID:        "my-client-id",
+		ClientSecretRef: "OAUTH_SECRET",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.NoError(t, result.Error)
+	assert.Equal(t, "Bearer tok_abc123", gotBearer)
+	assert.Equal(t, http.StatusOK, result.StatusCode)
+}
+
+func TestDispatch_OAuth2Auth_TokenEndpointFails_ReturnsError(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+	}))
+	defer tokenServer.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiServer.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"OAUTH_SECRET": "wrong-secret"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, apiServer.URL, &domain.OAuth2Auth{
+		TokenURL:        tokenServer.URL + "/oauth/token",
+		ClientID:        "client-id",
+		ClientSecretRef: "OAUTH_SECRET",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.Error(t, result.Error)
+	assert.ErrorIs(t, result.Error, httpadapter.ErrTokenEndpointFailed)
+}
+
+func TestDispatch_OAuth2Auth_ClientSecretNotFound_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.OAuth2Auth{
+		TokenURL:        server.URL + "/token",
+		ClientID:        "client-id",
+		ClientSecretRef: "MISSING_SECRET",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.Error(t, result.Error)
+	assert.ErrorIs(t, result.Error, ports.ErrSecretNotFound)
+}
+
+// --- HMACAuth ---
+
+func TestDispatch_HMACAuth_SHA256_SetsSignatureHeader(t *testing.T) {
+	var gotSig string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSig = r.Header.Get("X-Signature")
+		var readErr error
+		gotBody, readErr = io.ReadAll(r.Body)
+		require.NoError(t, readErr)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	requestBody := []byte(`{"stub":true}`)
+	ss := &stubSecretStore{secrets: map[string]string{"HMAC_SECRET": "hmac-signing-key"}}
+	tr := &stubTransformer{outBody: requestBody}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.HMACAuth{
+		SecretRef:       "HMAC_SECRET",
+		Algorithm:       "sha256",
+		SignatureHeader: "X-Signature",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.NoError(t, result.Error)
+	assert.Equal(t, requestBody, gotBody, "request body should be forwarded as-is")
+
+	// Verify the signature matches expected HMAC-SHA256.
+	expected := expectedHMACSHA256([]byte("hmac-signing-key"), requestBody)
+	assert.Equal(t, expected, gotSig, "HMAC-SHA256 signature should match")
+}
+
+func TestDispatch_HMACAuth_SHA512_ComputesCorrectSignature(t *testing.T) {
+	var gotSig string
+	requestBody := []byte(`{"amount":"500"}`)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSig = r.Header.Get("X-HMAC-Sig")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"HMAC_KEY": "some-key"}}
+	tr := &stubTransformer{outBody: requestBody}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.HMACAuth{
+		SecretRef:       "HMAC_KEY",
+		Algorithm:       "sha512",
+		SignatureHeader: "X-HMAC-Sig",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.NoError(t, result.Error)
+	expected := expectedHMACSHA512([]byte("some-key"), requestBody)
+	assert.Equal(t, expected, gotSig, "HMAC-SHA512 signature should match")
+	// sha512 hex is 128 characters.
+	assert.Len(t, gotSig, 128, "HMAC-SHA512 should produce 128 hex chars")
+}
+
+func TestDispatch_HMACAuth_SecretNotFound_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.HMACAuth{
+		SecretRef:       "MISSING_HMAC",
+		Algorithm:       "sha256",
+		SignatureHeader: "X-Sig",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.Error(t, result.Error)
+	assert.ErrorIs(t, result.Error, ports.ErrSecretNotFound)
+}
+
+// --- MTLSAuth ---
+
+func TestDispatch_MTLSAuth_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.MTLSAuth{
+		ClientCertRef: "CERT_REF",
+		ClientKeyRef:  "KEY_REF",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.Error(t, result.Error)
+	assert.ErrorIs(t, result.Error, httpadapter.ErrMTLSNotSupported)
+}
+
+// --- Header handling ---
+
+func TestDispatch_SetsStandardHeaders(t *testing.T) {
+	var gotContentType, gotRequestID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		gotRequestID = r.Header.Get("X-Request-ID")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"KEY": "val"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.APIKeyAuth{
+		HeaderName: "X-API-Key",
+		SecretRef:  "KEY",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.NoError(t, result.Error)
+	assert.Equal(t, "application/json", gotContentType)
+	assert.NotEmpty(t, gotRequestID, "X-Request-ID should be set")
+	// Verify it's a valid UUID format.
+	_, uuidErr := uuid.Parse(gotRequestID)
+	assert.NoError(t, uuidErr, "X-Request-ID should be a valid UUID")
+}
+
+func TestDispatch_MergesTransformHeadersAndRouteHeaders(t *testing.T) {
+	var gotVersion, gotAccept, gotCustom string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotVersion = r.Header.Get("X-Provider-Version")
+		gotAccept = r.Header.Get("Accept")
+		gotCustom = r.Header.Get("X-Custom")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"KEY": "val"}}
+	tr := &stubTransformer{
+		outHeaders: map[string]string{"X-Provider-Version": "2024-01"},
+	}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.APIKeyAuth{
+		HeaderName: "X-API-Key",
+		SecretRef:  "KEY",
+	})
+	route := &ports.InstructionRoute{
+		InstructionType: "payment.create",
+		HTTPMethod:      "POST",
+		PathTemplate:    "/payments",
+		Headers: map[string]string{
+			"Accept":   "application/json",
+			"X-Custom": "from-route",
+		},
+	}
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, route)
+
+	require.NoError(t, result.Error)
+	assert.Equal(t, "2024-01", gotVersion)
+	assert.Equal(t, "application/json", gotAccept)
+	assert.Equal(t, "from-route", gotCustom)
+}
+
+// --- Response handling ---
+
+func TestDispatch_Provider500_ReturnsResultWithRetry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal server error"}`))
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"KEY": "val"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.APIKeyAuth{
+		HeaderName: "X-API-Key",
+		SecretRef:  "KEY",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.NoError(t, result.Error)
+	assert.Equal(t, http.StatusInternalServerError, result.StatusCode)
+	require.NotNil(t, result.Outcome)
+	assert.Equal(t, "REJECTED", result.Outcome.ProviderStatus)
+	assert.True(t, result.Outcome.ShouldRetry, "5xx should be retryable")
+}
+
+func TestDispatch_Provider422_ReturnsResultNoRetry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"error":"invalid payload"}`))
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"KEY": "val"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.APIKeyAuth{
+		HeaderName: "X-API-Key",
+		SecretRef:  "KEY",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.NoError(t, result.Error)
+	assert.Equal(t, http.StatusUnprocessableEntity, result.StatusCode)
+	require.NotNil(t, result.Outcome)
+	assert.False(t, result.Outcome.ShouldRetry, "422 should not be retryable")
+}
+
+// --- Large response body handling ---
+
+func TestDispatch_LargeResponseBody_TruncatesAt1MiB(t *testing.T) {
+	// Serve a response larger than 1 MiB.
+	const overLimit = (1 << 20) + 1024 // 1 MiB + 1 KiB
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(make([]byte, overLimit))
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"KEY": "val"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.APIKeyAuth{
+		HeaderName: "X-API-Key",
+		SecretRef:  "KEY",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("GET"))
+
+	// Body is truncated to at most 1 MiB.
+	assert.LessOrEqual(t, len(result.ResponseBody), 1<<20)
+}
+
+// --- Timeout handling ---
+
+func TestDispatch_ContextDeadlineExceeded_ReturnsError(t *testing.T) {
+	// Server delays response beyond the context deadline.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"KEY": "val"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.APIKeyAuth{
+		HeaderName: "X-API-Key",
+		SecretRef:  "KEY",
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	result := d.Dispatch(ctx, newInstruction(t), conn, simpleRoute("POST"))
+
+	require.Error(t, result.Error)
+	assert.Positive(t, result.Duration)
+}
+
+// --- Outbound transform failure ---
+
+func TestDispatch_OutboundTransformFails_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{}}
+	tr := &stubTransformer{outErr: ports.ErrTransformFailed}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.APIKeyAuth{
+		HeaderName: "X-API-Key",
+		SecretRef:  "KEY",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.Error(t, result.Error)
+	assert.ErrorIs(t, result.Error, ports.ErrTransformFailed)
+	assert.Zero(t, result.StatusCode)
+}
+
+// --- Inbound transform failure ---
+
+func TestDispatch_InboundTransformFails_ReturnsPartialResult(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"pmt-001"}`))
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"KEY": "val"}}
+	tr := &stubTransformer{inErr: ports.ErrTransformFailed}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.APIKeyAuth{
+		HeaderName: "X-API-Key",
+		SecretRef:  "KEY",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.Error(t, result.Error)
+	assert.ErrorIs(t, result.Error, ports.ErrTransformFailed)
+	assert.Equal(t, http.StatusOK, result.StatusCode)
+	assert.Equal(t, []byte(`{"id":"pmt-001"}`), result.ResponseBody)
+	assert.Nil(t, result.Outcome)
+}
+
+// --- Network error ---
+
+func TestDispatch_NetworkError_ReturnsError(t *testing.T) {
+	// Use a port that nothing is listening on.
+	ss := &stubSecretStore{secrets: map[string]string{"KEY": "val"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, "http://127.0.0.1:19999", &domain.APIKeyAuth{
+		HeaderName: "X-API-Key",
+		SecretRef:  "KEY",
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result := d.Dispatch(ctx, newInstruction(t), conn, simpleRoute("POST"))
+
+	require.Error(t, result.Error)
+	assert.Zero(t, result.StatusCode)
+}
+
+// --- URL building ---
+
+func TestDispatch_PathTemplate_AppendedToBaseURL(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"KEY": "val"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL+"/api/v1", &domain.APIKeyAuth{
+		HeaderName: "X-API-Key",
+		SecretRef:  "KEY",
+	})
+	route := &ports.InstructionRoute{
+		HTTPMethod:   "POST",
+		PathTemplate: "/payments/create",
+	}
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, route)
+
+	require.NoError(t, result.Error)
+	assert.Equal(t, "/api/v1/payments/create", gotPath)
+}
+
+// --- Duration tracking ---
+
+func TestDispatch_DurationIsPositive(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"KEY": "val"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, server.URL, &domain.APIKeyAuth{
+		HeaderName: "X-API-Key",
+		SecretRef:  "KEY",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("GET"))
+
+	require.NoError(t, result.Error)
+	assert.Positive(t, result.Duration)
+}
+
+// --- OAuth2 with scopes ---
+
+func TestDispatch_OAuth2Auth_WithScopes_SendsScopeParam(t *testing.T) {
+	var gotScope string
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		gotScope = r.FormValue("scope")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"tok_scoped","token_type":"Bearer"}`))
+	}))
+	defer tokenServer.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer apiServer.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"SECRET": "s"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, apiServer.URL, &domain.OAuth2Auth{
+		TokenURL:        tokenServer.URL + "/token",
+		ClientID:        "cid",
+		ClientSecretRef: "SECRET",
+		Scopes:          []string{"payments:write", "accounts:read"},
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.NoError(t, result.Error)
+	assert.Equal(t, "payments:write accounts:read", gotScope)
+}
+
+// --- OAuth2 token response edge cases ---
+
+func TestDispatch_OAuth2Auth_MalformedTokenResponse_ReturnsError(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Missing access_token field entirely.
+		_, _ = w.Write([]byte(`{"token_type":"Bearer"}`))
+	}))
+	defer tokenServer.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiServer.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"SECRET": "s"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	conn := newConn(t, apiServer.URL, &domain.OAuth2Auth{
+		TokenURL:        tokenServer.URL + "/token",
+		ClientID:        "cid",
+		ClientSecretRef: "SECRET",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.Error(t, result.Error)
+	assert.ErrorIs(t, result.Error, httpadapter.ErrTokenNotFound)
+}
+
+// --- Concurrent dispatch benchmark ---
+
+func BenchmarkDispatch_Concurrent(b *testing.B) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"KEY": "bench-key"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	inst, err := domain.NewInstruction(
+		uuid.New(), "payment.create", "conn-bench",
+		map[string]any{"amount": "100.00"},
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	conn, err := domain.NewProviderConnection(
+		"tenant-bench", "bench-provider", "bank",
+		domain.ProtocolHTTPS, server.URL,
+		&domain.APIKeyAuth{HeaderName: "X-API-Key", SecretRef: "KEY"},
+		domain.RetryPolicy{}, domain.RateLimitConfig{},
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	route := simpleRoute("POST")
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			result := d.Dispatch(ctx, inst, conn, route)
+			if result.Error != nil {
+				b.Fatal(result.Error)
+			}
+		}
+	})
+}

--- a/services/operational-gateway/adapters/httpadapter/http_dispatcher_test.go
+++ b/services/operational-gateway/adapters/httpadapter/http_dispatcher_test.go
@@ -1,13 +1,22 @@
 package httpadapter_test
 
 import (
+	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"crypto/sha512"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/hex"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -454,6 +463,193 @@ func TestDispatch_MTLSAuth_ReturnsError(t *testing.T) {
 	assert.ErrorIs(t, result.Error, httpadapter.ErrMTLSNotSupported)
 }
 
+// --- NewMTLSHTTPDispatcher: positive dispatch path ---
+
+// testPKI holds the PEM-encoded materials for a small test certificate authority.
+type testPKI struct {
+	caCertPEM     []byte
+	caKey         *ecdsa.PrivateKey
+	caCert        *x509.Certificate
+	clientCertPEM []byte
+	clientKeyPEM  []byte
+}
+
+// generateTestPKI generates a self-signed CA and a client certificate signed by it.
+func generateTestPKI(t *testing.T) *testPKI {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caCertDER)
+	require.NoError(t, err)
+	var caBuf bytes.Buffer
+	require.NoError(t, pem.Encode(&caBuf, &pem.Block{Type: "CERTIFICATE", Bytes: caCertDER}))
+
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientCertDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caCert, &clientKey.PublicKey, caKey)
+	require.NoError(t, err)
+	var certBuf bytes.Buffer
+	require.NoError(t, pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER}))
+
+	clientKeyDER, err := x509.MarshalECPrivateKey(clientKey)
+	require.NoError(t, err)
+	var keyBuf bytes.Buffer
+	require.NoError(t, pem.Encode(&keyBuf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: clientKeyDER}))
+
+	return &testPKI{
+		caCertPEM:     caBuf.Bytes(),
+		caKey:         caKey,
+		caCert:        caCert,
+		clientCertPEM: certBuf.Bytes(),
+		clientKeyPEM:  keyBuf.Bytes(),
+	}
+}
+
+// newMTLSTLSServer starts a TLS httptest.Server that requires client certs verified by pki.caCert.
+// The server uses a cert signed by the same CA so that the mTLS client can verify it.
+func newMTLSTLSServer(t *testing.T, pki *testPKI, handler http.Handler) *httptest.Server {
+	t.Helper()
+
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		DNSNames:     []string{"127.0.0.1"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	serverCertDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, pki.caCert, &serverKey.PublicKey, pki.caKey)
+	require.NoError(t, err)
+
+	tlsCert := tls.Certificate{
+		Certificate: [][]byte{serverCertDER},
+		PrivateKey:  serverKey,
+	}
+
+	caPool := x509.NewCertPool()
+	require.True(t, caPool.AppendCertsFromPEM(pki.caCertPEM))
+
+	srv := httptest.NewUnstartedServer(handler)
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+		ClientCAs:    caPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	}
+	srv.StartTLS()
+	return srv
+}
+
+func TestNewMTLSHTTPDispatcher_Dispatches(t *testing.T) {
+	pki := generateTestPKI(t)
+
+	server := newMTLSTLSServer(t, pki, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{}}
+	tr := &stubTransformer{}
+
+	d, err := httpadapter.NewMTLSHTTPDispatcher(ss, tr, nil, pki.clientCertPEM, pki.clientKeyPEM, pki.caCertPEM)
+	require.NoError(t, err)
+
+	conn := newConn(t, server.URL, &domain.MTLSAuth{
+		ClientCertRef: "CERT_REF",
+		ClientKeyRef:  "KEY_REF",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.NoError(t, result.Error)
+	assert.Equal(t, http.StatusOK, result.StatusCode)
+}
+
+func TestNewMTLSHTTPDispatcher_NonMTLSAuthConfig_ReturnsError(t *testing.T) {
+	pki := generateTestPKI(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ss := &stubSecretStore{secrets: map[string]string{"KEY": "val"}}
+	tr := &stubTransformer{}
+	d, err := httpadapter.NewMTLSHTTPDispatcher(ss, tr, nil, pki.clientCertPEM, pki.clientKeyPEM, pki.caCertPEM)
+	require.NoError(t, err)
+
+	// Use non-mTLS auth config with the mTLS dispatcher - should fail fast.
+	conn := newConn(t, server.URL, &domain.APIKeyAuth{
+		HeaderName: "X-API-Key",
+		SecretRef:  "KEY",
+	})
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("POST"))
+
+	require.Error(t, result.Error)
+	assert.ErrorIs(t, result.Error, httpadapter.ErrMTLSAuthRequired)
+}
+
+// --- Nil input guard tests ---
+
+func TestDispatch_NilInstruction_ReturnsError(t *testing.T) {
+	ss := &stubSecretStore{secrets: map[string]string{"KEY": "val"}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+	conn := newConn(t, "http://localhost", &domain.APIKeyAuth{HeaderName: "X-API-Key", SecretRef: "KEY"})
+
+	result := d.Dispatch(context.Background(), nil, conn, simpleRoute("POST"))
+
+	require.Error(t, result.Error)
+	assert.ErrorIs(t, result.Error, httpadapter.ErrNilInstruction)
+}
+
+func TestDispatch_NilConnection_ReturnsError(t *testing.T) {
+	ss := &stubSecretStore{secrets: map[string]string{}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+
+	result := d.Dispatch(context.Background(), newInstruction(t), nil, simpleRoute("POST"))
+
+	require.Error(t, result.Error)
+	assert.ErrorIs(t, result.Error, httpadapter.ErrNilConnection)
+}
+
+func TestDispatch_NilRoute_ReturnsError(t *testing.T) {
+	ss := &stubSecretStore{secrets: map[string]string{}}
+	tr := &stubTransformer{}
+	d := httpadapter.NewHTTPDispatcher(ss, tr, nil)
+	conn := newConn(t, "http://localhost", &domain.APIKeyAuth{HeaderName: "X-API-Key", SecretRef: "KEY"})
+
+	result := d.Dispatch(context.Background(), newInstruction(t), conn, nil)
+
+	require.Error(t, result.Error)
+	assert.ErrorIs(t, result.Error, httpadapter.ErrNilRoute)
+}
+
 // --- Header handling ---
 
 func TestDispatch_SetsStandardHeaders(t *testing.T) {
@@ -592,8 +788,10 @@ func TestDispatch_LargeResponseBody_TruncatesAt1MiB(t *testing.T) {
 	})
 	result := d.Dispatch(context.Background(), newInstruction(t), conn, simpleRoute("GET"))
 
-	// Body is truncated to at most 1 MiB.
-	assert.LessOrEqual(t, len(result.ResponseBody), 1<<20)
+	require.NoError(t, result.Error)
+	assert.Equal(t, http.StatusOK, result.StatusCode)
+	// Over-limit payload should be truncated exactly at 1 MiB.
+	assert.Equal(t, 1<<20, len(result.ResponseBody))
 }
 
 // --- Timeout handling ---

--- a/services/operational-gateway/ports/dispatcher.go
+++ b/services/operational-gateway/ports/dispatcher.go
@@ -1,0 +1,41 @@
+// Package ports defines the interfaces (ports) for the operational-gateway service.
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+)
+
+// DispatchResult captures the outcome of a single outbound HTTP dispatch attempt.
+type DispatchResult struct {
+	// StatusCode is the HTTP response status code from the provider.
+	StatusCode int
+
+	// ResponseBody is the raw response body received from the provider.
+	ResponseBody []byte
+
+	// Outcome is the extracted InstructionOutcome after applying the inbound transform.
+	// May be nil if the dispatch did not reach the response parsing stage.
+	Outcome *InstructionOutcome
+
+	// Duration is the total time elapsed for the dispatch attempt, including
+	// connect, send, and receive time.
+	Duration time.Duration
+
+	// Error is non-nil when the dispatch failed before a response could be parsed
+	// (e.g., network error, auth failure, transform failure).
+	Error error
+}
+
+// Dispatcher sends an instruction to an external provider via a configured connection.
+// Implementations handle the transport-level concerns (HTTP, gRPC, etc.) and authentication.
+// Retry logic, circuit breaking, and persistence are handled by the dispatch worker layer.
+type Dispatcher interface {
+	// Dispatch sends the instruction to the provider using the given connection and route.
+	// It returns a DispatchResult containing the HTTP status, raw body, parsed outcome,
+	// elapsed duration, and any transport-level error.
+	// Dispatch does not implement retry logic; callers are responsible for retrying.
+	Dispatch(ctx context.Context, instruction *domain.Instruction, conn *domain.ProviderConnection, route *InstructionRoute) DispatchResult
+}


### PR DESCRIPTION
## Summary

- Adds `ports.Dispatcher` interface and `DispatchResult` struct to define the outbound dispatch contract
- Implements `HTTPDispatcher` in `services/operational-gateway/adapters/httpadapter/` supporting all five auth mechanisms
- Adds `NewMTLSHTTPDispatcher` constructor for mutual TLS connections using a dedicated per-connection TLS transport

## Changes Made

### New: `services/operational-gateway/ports/dispatcher.go`
- `Dispatcher` interface: single `Dispatch(ctx, instruction, conn, route) DispatchResult` method
- `DispatchResult` struct: StatusCode, ResponseBody, Outcome, Duration, Error

### New: `services/operational-gateway/adapters/httpadapter/http_dispatcher.go`
- `HTTPDispatcher` with pooled transport (MaxIdleConnsPerHost: 100, IdleConnTimeout: 90s, Timeout: 30s)
- `applyAuth` dispatches over all five `domain.AuthConfig` variants: APIKeyAuth, BasicAuth, OAuth2Auth, HMACAuth, MTLSAuth
- Response body capped at 1 MiB via `io.LimitReader` to prevent memory exhaustion
- OAuth2 client credentials flow with synchronous token fetch (caching is a follow-up concern for task 10)
- HMAC-SHA256 and HMAC-SHA512 signature computation with hex encoding
- MTLSAuth returns `ErrMTLSNotSupported` directing callers to `NewMTLSHTTPDispatcher`
- All sentinel errors are package-level vars (err113 compliant)

### New: `services/operational-gateway/adapters/httpadapter/http_dispatcher_test.go`
- 28 unit tests using `httptest.Server` covering all auth types, error paths, timeout handling, header merging, and 1 MiB body limit
- Concurrent dispatch benchmark: ~89k ops/sec on MacBook

## Technical Details

**No retry logic**: `HTTPDispatcher.Dispatch` is a single-attempt, synchronous call. The dispatch worker (task 10) owns retry scheduling and circuit breaker state.

**OAuth2 token endpoint**: Tokens are fetched synchronously without caching. This is intentional for Phase 1 — a token cache with TTL belongs in the dispatch worker layer where connection pooling decisions are made.

**URL construction**: `baseURL` trailing slash and `pathTemplate` leading slash are normalized to avoid double-slash URLs.

**X-Request-ID**: A new UUID is generated per dispatch for distributed tracing correlation.

## Testing

- All 28 tests pass
- Concurrent benchmark: `BenchmarkDispatch_Concurrent` — ~89k dispatches/sec with `httptest.Server` on local hardware
- No integration test dependencies; `httptest.Server` provides full HTTP round-trip coverage without external services

## Risk Assessment

Low. This adapter has no side effects beyond outbound HTTP calls. It does not write to the database and is not wired to any service handler yet (that is task 11).

## Deployment Notes

No migration or configuration change required. The adapter is constructed via dependency injection and will be wired in the service bootstrap (task 11).