### PR TITLE
feat: Add dispatch worker for operational gateway

### DIFF
--- a/services/operational-gateway/ports/route_resolver.go
+++ b/services/operational-gateway/ports/route_resolver.go
@@ -1,0 +1,19 @@
+// Package ports defines the interfaces (ports) for the operational-gateway service.
+package ports
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrRouteNotFound is returned when no route is configured for the given instruction type.
+var ErrRouteNotFound = errors.New("no route configured for instruction type")
+
+// RouteResolver resolves the dispatch route for an instruction type within a tenant.
+// Implementations may look up routes from a configuration store, manifest registry,
+// or an in-memory cache seeded at startup.
+type RouteResolver interface {
+	// Resolve returns the InstructionRoute for the given tenant and instruction type.
+	// Returns ErrRouteNotFound if no route is configured.
+	Resolve(ctx context.Context, tenantID string, instructionType string) (*InstructionRoute, error)
+}

--- a/services/operational-gateway/worker/dispatch_worker.go
+++ b/services/operational-gateway/worker/dispatch_worker.go
@@ -172,13 +172,22 @@ func (w *DispatchWorker) processInstruction(ctx context.Context, instr *domain.I
 	// 1. Resolve route for this instruction type.
 	route, err := w.routeResolver.Resolve(ctx, instr.TenantID.String(), instr.InstructionType)
 	if err != nil {
-		return w.handleFailure(ctx, instr, fmt.Sprintf("route resolution failed: %v", err), "ROUTE_NOT_FOUND")
+		if errors.Is(err, ports.ErrRouteNotFound) {
+			return w.handleFailure(ctx, instr, fmt.Sprintf("route resolution failed: %v", err), "ROUTE_NOT_FOUND")
+		}
+		// Transient error (e.g., DB/network) — return error so the instruction stays
+		// DISPATCHING and will be picked up by the stuck-instruction reaper for retry.
+		return fmt.Errorf("route resolution transient error: %w", err)
 	}
 
 	// 2. Look up the provider connection.
 	conn, err := w.connectionRepo.FindByID(ctx, instr.TenantID.String(), instr.ProviderConnectionID)
 	if err != nil {
-		return w.handleFailure(ctx, instr, fmt.Sprintf("connection lookup failed: %v", err), "CONNECTION_NOT_FOUND")
+		if errors.Is(err, ports.ErrConnectionNotFound) {
+			return w.handleFailure(ctx, instr, fmt.Sprintf("connection lookup failed: %v", err), "CONNECTION_NOT_FOUND")
+		}
+		// Transient error — leave instruction in DISPATCHING for reaper.
+		return fmt.Errorf("connection lookup transient error: %w", err)
 	}
 
 	// 3. Check circuit breaker.

--- a/services/operational-gateway/worker/dispatch_worker.go
+++ b/services/operational-gateway/worker/dispatch_worker.go
@@ -1,0 +1,328 @@
+// Package worker contains background workers for the operational gateway service.
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+)
+
+// Default configuration values.
+const (
+	defaultBatchSize    = 50
+	defaultPollInterval = 1 * time.Second
+)
+
+// DispatchWorkerConfig configures the dispatch worker's polling and processing behavior.
+type DispatchWorkerConfig struct {
+	// BatchSize is the maximum number of instructions to claim per poll cycle.
+	BatchSize int
+	// PollInterval is the duration between successive poll cycles.
+	PollInterval time.Duration
+}
+
+// applyDefaults fills in zero-valued fields with sensible defaults.
+func (c *DispatchWorkerConfig) applyDefaults() {
+	if c.BatchSize <= 0 {
+		c.BatchSize = defaultBatchSize
+	}
+	if c.PollInterval <= 0 {
+		c.PollInterval = defaultPollInterval
+	}
+}
+
+// DispatchWorker polls for dispatchable instructions and sends them to external
+// providers via the Dispatcher port. It integrates with the circuit breaker on each
+// ProviderConnection and handles retry/failure transitions on the Instruction aggregate.
+//
+// FetchDispatchable (in the repository) already marks instructions as DISPATCHING
+// within its transaction, so the worker does not call MarkDispatching again.
+//
+// DispatchWorker is safe for concurrent use; multiple instances can run against the
+// same database because FetchDispatchable uses FOR UPDATE SKIP LOCKED.
+type DispatchWorker struct {
+	instructionRepo ports.InstructionRepository
+	connectionRepo  ports.ConnectionRepository
+	routeResolver   ports.RouteResolver
+	dispatcher      ports.Dispatcher
+	config          DispatchWorkerConfig
+	logger          *slog.Logger
+	shutdown        chan struct{}
+	shutdownOnce    sync.Once
+	wg              sync.WaitGroup
+}
+
+// NewDispatchWorker creates a new DispatchWorker with the given dependencies and config.
+func NewDispatchWorker(
+	instructionRepo ports.InstructionRepository,
+	connectionRepo ports.ConnectionRepository,
+	routeResolver ports.RouteResolver,
+	dispatcher ports.Dispatcher,
+	config DispatchWorkerConfig,
+	logger *slog.Logger,
+) *DispatchWorker {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	config.applyDefaults()
+
+	return &DispatchWorker{
+		instructionRepo: instructionRepo,
+		connectionRepo:  connectionRepo,
+		routeResolver:   routeResolver,
+		dispatcher:      dispatcher,
+		config:          config,
+		logger:          logger.With("component", "dispatch-worker"),
+		shutdown:        make(chan struct{}),
+	}
+}
+
+// Start begins the background polling loop. Returns immediately; the loop runs
+// in a separate goroutine until Stop is called or ctx is cancelled.
+func (w *DispatchWorker) Start(ctx context.Context) {
+	w.wg.Add(1)
+	go w.run(ctx)
+
+	w.logger.InfoContext(ctx, "dispatch worker started",
+		"batch_size", w.config.BatchSize,
+		"poll_interval", w.config.PollInterval,
+	)
+}
+
+// Stop signals the worker to shut down and blocks until the current batch completes.
+// Safe to call multiple times.
+func (w *DispatchWorker) Stop() {
+	w.shutdownOnce.Do(func() {
+		w.logger.Info("dispatch worker stopping")
+		close(w.shutdown)
+	})
+	w.wg.Wait()
+	w.logger.Info("dispatch worker stopped")
+}
+
+// run is the main polling loop.
+func (w *DispatchWorker) run(ctx context.Context) {
+	defer w.wg.Done()
+
+	ticker := time.NewTicker(w.config.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.InfoContext(ctx, "dispatch worker context cancelled")
+			return
+		case <-w.shutdown:
+			w.logger.Info("dispatch worker shutdown signal received")
+			return
+		case <-ticker.C:
+			w.processBatch(ctx)
+		}
+	}
+}
+
+// processBatch fetches a batch of dispatchable instructions and processes each one.
+func (w *DispatchWorker) processBatch(ctx context.Context) {
+	instructions, err := w.instructionRepo.FetchDispatchable(ctx, ports.FetchDispatchableParams{
+		Limit: w.config.BatchSize,
+	})
+	if err != nil {
+		w.logger.ErrorContext(ctx, "failed to fetch dispatchable instructions", "error", err)
+		return
+	}
+	if len(instructions) == 0 {
+		return
+	}
+
+	w.logger.InfoContext(ctx, "processing dispatch batch", "count", len(instructions))
+
+	var processed, failed int
+	for _, instr := range instructions {
+		if err := w.processInstruction(ctx, instr); err != nil {
+			w.logger.ErrorContext(ctx, "failed to process instruction",
+				"instruction_id", instr.ID,
+				"instruction_type", instr.InstructionType,
+				"error", err,
+			)
+			failed++
+		} else {
+			processed++
+		}
+	}
+
+	w.logger.InfoContext(ctx, "dispatch batch completed",
+		"processed", processed,
+		"failed", failed,
+		"total", len(instructions),
+	)
+}
+
+// processInstruction dispatches a single instruction through the full flow:
+// resolve route -> look up connection -> check circuit breaker -> dispatch -> handle outcome.
+//
+// The instruction arrives already in DISPATCHING state (set by FetchDispatchable).
+func (w *DispatchWorker) processInstruction(ctx context.Context, instr *domain.Instruction) error {
+	// 1. Resolve route for this instruction type.
+	route, err := w.routeResolver.Resolve(ctx, instr.TenantID.String(), instr.InstructionType)
+	if err != nil {
+		return w.handleFailure(ctx, instr, fmt.Sprintf("route resolution failed: %v", err), "ROUTE_NOT_FOUND")
+	}
+
+	// 2. Look up the provider connection.
+	conn, err := w.connectionRepo.FindByID(ctx, instr.TenantID.String(), instr.ProviderConnectionID)
+	if err != nil {
+		return w.handleFailure(ctx, instr, fmt.Sprintf("connection lookup failed: %v", err), "CONNECTION_NOT_FOUND")
+	}
+
+	// 3. Check circuit breaker.
+	if !conn.IsAvailable() {
+		return w.handleRetryOrFail(ctx, instr, conn, "circuit breaker open", "CIRCUIT_OPEN")
+	}
+
+	// 4. Dispatch to external provider.
+	result := w.dispatcher.Dispatch(ctx, instr, conn, route)
+
+	// 5. Handle transport-level error (no response received).
+	if result.Error != nil {
+		if err := conn.RecordFailure(conn.RetryPolicy.MaxAttempts); err != nil {
+			w.logger.ErrorContext(ctx, "failed to record connection failure",
+				"connection_id", conn.ConnectionID, "error", err,
+			)
+		}
+		if saveErr := w.connectionRepo.UpdateHealth(ctx, conn); saveErr != nil {
+			w.logger.ErrorContext(ctx, "failed to persist connection health",
+				"connection_id", conn.ConnectionID, "error", saveErr,
+			)
+		}
+		return w.handleRetryOrFail(ctx, instr, conn, fmt.Sprintf("dispatch error: %v", result.Error), "DISPATCH_ERROR")
+	}
+
+	// 6. Record success on the connection circuit breaker.
+	conn.RecordSuccess()
+	if saveErr := w.connectionRepo.UpdateHealth(ctx, conn); saveErr != nil {
+		w.logger.ErrorContext(ctx, "failed to persist connection health",
+			"connection_id", conn.ConnectionID, "error", saveErr,
+		)
+	}
+
+	// 7. Handle the parsed outcome.
+	if result.Outcome == nil {
+		return w.handleFailure(ctx, instr, "dispatch returned no outcome", "NO_OUTCOME")
+	}
+
+	outcome := result.Outcome
+	if outcome.ShouldRetry {
+		return w.handleRetryOrFail(ctx, instr, conn, outcome.FailureReason, "PROVIDER_RETRY")
+	}
+	if outcome.FailureReason != "" {
+		return w.handleFailure(ctx, instr, outcome.FailureReason, "PROVIDER_REJECTED")
+	}
+
+	// 8. Mark delivered.
+	if err := instr.MarkDelivered(); err != nil {
+		return fmt.Errorf("marking delivered: %w", err)
+	}
+	if err := w.instructionRepo.Save(ctx, instr, ""); err != nil {
+		return fmt.Errorf("saving delivered instruction: %w", err)
+	}
+
+	w.logger.InfoContext(ctx, "instruction delivered",
+		"instruction_id", instr.ID,
+		"external_id", outcome.ExternalID,
+		"duration_ms", result.Duration.Milliseconds(),
+	)
+	return nil
+}
+
+// handleRetryOrFail attempts to schedule a retry; if retries are exhausted it marks the
+// instruction as permanently failed.
+func (w *DispatchWorker) handleRetryOrFail(ctx context.Context, instr *domain.Instruction, conn *domain.ProviderConnection, reason string, errorCode string) error {
+	if instr.CanRetry() {
+		return w.handleRetry(ctx, instr, conn, reason, errorCode)
+	}
+	return w.handleFailure(ctx, instr, reason, errorCode)
+}
+
+// handleRetry transitions the instruction to RETRYING and schedules the next retry
+// using exponential backoff derived from the connection's RetryPolicy.
+func (w *DispatchWorker) handleRetry(ctx context.Context, instr *domain.Instruction, conn *domain.ProviderConnection, reason string, errorCode string) error {
+	if err := instr.MarkRetrying(reason, errorCode); err != nil {
+		// MarkRetrying can return ErrMaxAttemptsExhausted if the domain model
+		// detects exhaustion — fall through to failure.
+		if errors.Is(err, domain.ErrMaxAttemptsExhausted) {
+			return w.handleFailure(ctx, instr, reason, errorCode)
+		}
+		return fmt.Errorf("marking retrying: %w", err)
+	}
+
+	// Calculate next retry time using exponential backoff.
+	nextRetry := calculateNextRetry(instr.AttemptCount, conn.RetryPolicy)
+	instr.NextRetryAt = &nextRetry
+
+	if err := w.instructionRepo.Save(ctx, instr, ""); err != nil {
+		return fmt.Errorf("saving retrying instruction: %w", err)
+	}
+
+	w.logger.InfoContext(ctx, "instruction scheduled for retry",
+		"instruction_id", instr.ID,
+		"attempt", instr.AttemptCount,
+		"max_attempts", instr.MaxAttempts,
+		"next_retry_at", nextRetry,
+		"reason", reason,
+	)
+	return nil
+}
+
+// handleFailure transitions the instruction to FAILED and persists it.
+func (w *DispatchWorker) handleFailure(ctx context.Context, instr *domain.Instruction, reason string, errorCode string) error {
+	if err := instr.MarkFailed(reason, errorCode); err != nil {
+		return fmt.Errorf("marking failed: %w", err)
+	}
+	if err := w.instructionRepo.Save(ctx, instr, ""); err != nil {
+		return fmt.Errorf("saving failed instruction: %w", err)
+	}
+
+	w.logger.WarnContext(ctx, "instruction failed permanently",
+		"instruction_id", instr.ID,
+		"attempt", instr.AttemptCount,
+		"reason", reason,
+		"error_code", errorCode,
+	)
+	return nil
+}
+
+// calculateNextRetry computes the next retry time using exponential backoff with a cap.
+// attempt is the 1-based attempt number that just failed.
+func calculateNextRetry(attempt int, policy domain.RetryPolicy) time.Time {
+	backoff := policy.InitialBackoff
+	if backoff <= 0 {
+		backoff = 1 * time.Second
+	}
+
+	multiplier := policy.BackoffMultiplier
+	if multiplier < 1.0 {
+		multiplier = 2.0
+	}
+
+	maxBackoff := policy.MaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = 5 * time.Minute
+	}
+
+	// Exponential backoff: initialBackoff * multiplier^(attempt-1)
+	// attempt is 1-based; first retry (attempt=1) uses initialBackoff directly.
+	factor := math.Pow(multiplier, float64(attempt-1))
+	wait := time.Duration(float64(backoff) * factor)
+	if wait > maxBackoff {
+		wait = maxBackoff
+	}
+
+	return time.Now().Add(wait)
+}

--- a/services/operational-gateway/worker/dispatch_worker.go
+++ b/services/operational-gateway/worker/dispatch_worker.go
@@ -145,6 +145,15 @@ func (w *DispatchWorker) processBatch(ctx context.Context) {
 
 	var processed, failed int
 	for _, instr := range instructions {
+		if ctx.Err() != nil {
+			w.logger.InfoContext(ctx, "batch interrupted by context cancellation",
+				"processed", processed,
+				"failed", failed,
+				"remaining", len(instructions)-processed-failed,
+			)
+			return
+		}
+
 		if err := w.processInstruction(ctx, instr); err != nil {
 			w.logger.ErrorContext(ctx, "failed to process instruction",
 				"instruction_id", instr.ID,

--- a/services/operational-gateway/worker/dispatch_worker.go
+++ b/services/operational-gateway/worker/dispatch_worker.go
@@ -56,6 +56,7 @@ type DispatchWorker struct {
 	logger          *slog.Logger
 	shutdown        chan struct{}
 	shutdownOnce    sync.Once
+	startOnce       sync.Once
 	wg              sync.WaitGroup
 }
 
@@ -86,14 +87,17 @@ func NewDispatchWorker(
 
 // Start begins the background polling loop. Returns immediately; the loop runs
 // in a separate goroutine until Stop is called or ctx is cancelled.
+// Calling Start more than once is a no-op.
 func (w *DispatchWorker) Start(ctx context.Context) {
-	w.wg.Add(1)
-	go w.run(ctx)
+	w.startOnce.Do(func() {
+		w.wg.Add(1)
+		go w.run(ctx)
 
-	w.logger.InfoContext(ctx, "dispatch worker started",
-		"batch_size", w.config.BatchSize,
-		"poll_interval", w.config.PollInterval,
-	)
+		w.logger.InfoContext(ctx, "dispatch worker started",
+			"batch_size", w.config.BatchSize,
+			"poll_interval", w.config.PollInterval,
+		)
+	})
 }
 
 // Stop signals the worker to shut down and blocks until the current batch completes.

--- a/services/operational-gateway/worker/dispatch_worker_test.go
+++ b/services/operational-gateway/worker/dispatch_worker_test.go
@@ -1,0 +1,828 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mocks ---
+
+type mockInstructionRepo struct {
+	mu                sync.Mutex
+	fetchDispatchable func(ctx context.Context, params ports.FetchDispatchableParams) ([]*domain.Instruction, error)
+	save              func(ctx context.Context, instruction *domain.Instruction, idempotencyKey string) error
+	savedInstructions []*domain.Instruction
+	fetchCalls        int
+	saveCalls         int
+}
+
+func (m *mockInstructionRepo) FetchDispatchable(ctx context.Context, params ports.FetchDispatchableParams) ([]*domain.Instruction, error) {
+	m.mu.Lock()
+	m.fetchCalls++
+	m.mu.Unlock()
+	if m.fetchDispatchable != nil {
+		return m.fetchDispatchable(ctx, params)
+	}
+	return nil, nil
+}
+
+func (m *mockInstructionRepo) Save(ctx context.Context, instruction *domain.Instruction, idempotencyKey string) error {
+	m.mu.Lock()
+	m.saveCalls++
+	m.savedInstructions = append(m.savedInstructions, instruction)
+	m.mu.Unlock()
+	if m.save != nil {
+		return m.save(ctx, instruction, idempotencyKey)
+	}
+	return nil
+}
+
+func (m *mockInstructionRepo) FindByID(_ context.Context, _ uuid.UUID) (*domain.Instruction, error) {
+	return nil, ports.ErrInstructionNotFound
+}
+
+func (m *mockInstructionRepo) ListByTenant(_ context.Context, _ ports.ListInstructionsParams) ([]*domain.Instruction, int64, error) {
+	return nil, 0, nil
+}
+
+func (m *mockInstructionRepo) getSavedInstructions() []*domain.Instruction {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]*domain.Instruction, len(m.savedInstructions))
+	copy(cp, m.savedInstructions)
+	return cp
+}
+
+func (m *mockInstructionRepo) getSaveCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.saveCalls
+}
+
+func (m *mockInstructionRepo) getFetchCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.fetchCalls
+}
+
+type mockConnectionRepo struct {
+	findByID     func(ctx context.Context, tenantID string, connectionID string) (*domain.ProviderConnection, error)
+	updateHealth func(ctx context.Context, conn *domain.ProviderConnection) error
+}
+
+func (m *mockConnectionRepo) FindByID(ctx context.Context, tenantID string, connectionID string) (*domain.ProviderConnection, error) {
+	if m.findByID != nil {
+		return m.findByID(ctx, tenantID, connectionID)
+	}
+	return nil, ports.ErrConnectionNotFound
+}
+
+func (m *mockConnectionRepo) UpdateHealth(ctx context.Context, conn *domain.ProviderConnection) error {
+	if m.updateHealth != nil {
+		return m.updateHealth(ctx, conn)
+	}
+	return nil
+}
+
+func (m *mockConnectionRepo) Upsert(_ context.Context, _ *domain.ProviderConnection) error {
+	return nil
+}
+
+func (m *mockConnectionRepo) ListByTenant(_ context.Context, _ string) ([]*domain.ProviderConnection, error) {
+	return nil, nil
+}
+
+type mockRouteResolver struct {
+	resolve func(ctx context.Context, tenantID string, instructionType string) (*ports.InstructionRoute, error)
+}
+
+func (m *mockRouteResolver) Resolve(ctx context.Context, tenantID string, instructionType string) (*ports.InstructionRoute, error) {
+	if m.resolve != nil {
+		return m.resolve(ctx, tenantID, instructionType)
+	}
+	return nil, ports.ErrRouteNotFound
+}
+
+type mockDispatcher struct {
+	dispatch func(ctx context.Context, instruction *domain.Instruction, conn *domain.ProviderConnection, route *ports.InstructionRoute) ports.DispatchResult
+}
+
+func (m *mockDispatcher) Dispatch(ctx context.Context, instruction *domain.Instruction, conn *domain.ProviderConnection, route *ports.InstructionRoute) ports.DispatchResult {
+	if m.dispatch != nil {
+		return m.dispatch(ctx, instruction, conn, route)
+	}
+	return ports.DispatchResult{Error: errors.New("not implemented")}
+}
+
+// --- Test helpers ---
+
+func testTenantID() uuid.UUID {
+	return uuid.MustParse("11111111-1111-1111-1111-111111111111")
+}
+
+func testConnection() *domain.ProviderConnection {
+	return &domain.ProviderConnection{
+		TenantID:     testTenantID().String(),
+		ConnectionID: "conn-123",
+		ProviderName: "test-provider",
+		Protocol:     domain.ProtocolHTTPS,
+		BaseURL:      "https://provider.example.com",
+		AuthConfig:   &domain.APIKeyAuth{HeaderName: "X-API-Key", SecretRef: "test-key"},
+		RetryPolicy: domain.RetryPolicy{
+			MaxAttempts:       3,
+			InitialBackoff:    1 * time.Second,
+			MaxBackoff:        30 * time.Second,
+			BackoffMultiplier: 2.0,
+		},
+		CircuitState: domain.CircuitStateClosed,
+		HealthStatus: domain.HealthStatusHealthy,
+	}
+}
+
+func testRoute() *ports.InstructionRoute {
+	return &ports.InstructionRoute{
+		InstructionType: "payment_order.create",
+		HTTPMethod:      "POST",
+		PathTemplate:    "/v1/payments",
+	}
+}
+
+// dispatchingInstruction creates an instruction already in DISPATCHING state
+// (as returned by FetchDispatchable).
+func dispatchingInstruction() *domain.Instruction {
+	now := time.Now()
+	return &domain.Instruction{
+		ID:                   uuid.New(),
+		TenantID:             testTenantID(),
+		InstructionType:      "payment_order.create",
+		ProviderConnectionID: "conn-123",
+		Payload:              map[string]any{"amount": 100},
+		Priority:             domain.PriorityNormal,
+		Status:               domain.InstructionStatusDispatching,
+		MaxAttempts:          3,
+		AttemptCount:         1,
+		Attempts:             []domain.InstructionAttempt{},
+		DispatchedAt:         &now,
+		Version:              1,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+}
+
+// --- Tests ---
+
+func TestNewDispatchWorker_AppliesDefaults(t *testing.T) {
+	w := NewDispatchWorker(
+		&mockInstructionRepo{},
+		&mockConnectionRepo{},
+		&mockRouteResolver{},
+		&mockDispatcher{},
+		DispatchWorkerConfig{},
+		nil,
+	)
+
+	assert.Equal(t, defaultBatchSize, w.config.BatchSize)
+	assert.Equal(t, defaultPollInterval, w.config.PollInterval)
+	assert.NotNil(t, w.logger)
+}
+
+func TestNewDispatchWorker_RespectsCustomConfig(t *testing.T) {
+	w := NewDispatchWorker(
+		&mockInstructionRepo{},
+		&mockConnectionRepo{},
+		&mockRouteResolver{},
+		&mockDispatcher{},
+		DispatchWorkerConfig{BatchSize: 10, PollInterval: 500 * time.Millisecond},
+		nil,
+	)
+
+	assert.Equal(t, 10, w.config.BatchSize)
+	assert.Equal(t, 500*time.Millisecond, w.config.PollInterval)
+}
+
+func TestDispatchWorker_StartAndStop(t *testing.T) {
+	repo := &mockInstructionRepo{}
+	w := NewDispatchWorker(
+		repo,
+		&mockConnectionRepo{},
+		&mockRouteResolver{},
+		&mockDispatcher{},
+		DispatchWorkerConfig{PollInterval: 50 * time.Millisecond},
+		nil,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w.Start(ctx)
+
+	// Wait for at least one fetch cycle.
+	err := await.AtMost(2 * time.Second).PollInterval(20 * time.Millisecond).Until(func() bool {
+		return repo.getFetchCalls() >= 1
+	})
+	require.NoError(t, err)
+
+	w.Stop()
+
+	// Verify that Stop is idempotent.
+	w.Stop()
+}
+
+func TestDispatchWorker_StopsOnContextCancel(t *testing.T) {
+	repo := &mockInstructionRepo{}
+	w := NewDispatchWorker(
+		repo,
+		&mockConnectionRepo{},
+		&mockRouteResolver{},
+		&mockDispatcher{},
+		DispatchWorkerConfig{PollInterval: 50 * time.Millisecond},
+		nil,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w.Start(ctx)
+
+	// Wait for at least one fetch cycle.
+	err := await.AtMost(2 * time.Second).PollInterval(20 * time.Millisecond).Until(func() bool {
+		return repo.getFetchCalls() >= 1
+	})
+	require.NoError(t, err)
+
+	cancel()
+
+	// Worker should stop after context cancel. Wait via wg.
+	done := make(chan struct{})
+	go func() {
+		w.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not stop after context cancellation")
+	}
+}
+
+func TestProcessInstruction_HappyPath_Delivered(t *testing.T) {
+	instr := dispatchingInstruction()
+	conn := testConnection()
+	route := testRoute()
+
+	instrRepo := &mockInstructionRepo{}
+	connRepo := &mockConnectionRepo{
+		findByID: func(_ context.Context, _, _ string) (*domain.ProviderConnection, error) {
+			return conn, nil
+		},
+	}
+	resolver := &mockRouteResolver{
+		resolve: func(_ context.Context, _, _ string) (*ports.InstructionRoute, error) {
+			return route, nil
+		},
+	}
+	dispatcher := &mockDispatcher{
+		dispatch: func(_ context.Context, _ *domain.Instruction, _ *domain.ProviderConnection, _ *ports.InstructionRoute) ports.DispatchResult {
+			return ports.DispatchResult{
+				StatusCode: 200,
+				Outcome: &ports.InstructionOutcome{
+					ExternalID:     "ext-123",
+					ProviderStatus: "ACCEPTED",
+				},
+				Duration: 50 * time.Millisecond,
+			}
+		},
+	}
+
+	w := NewDispatchWorker(instrRepo, connRepo, resolver, dispatcher, DispatchWorkerConfig{}, nil)
+
+	err := w.processInstruction(context.Background(), instr)
+	require.NoError(t, err)
+
+	saved := instrRepo.getSavedInstructions()
+	require.Len(t, saved, 1)
+	assert.Equal(t, domain.InstructionStatusDelivered, saved[0].Status)
+}
+
+func TestProcessInstruction_RouteNotFound_MarksFailed(t *testing.T) {
+	instr := dispatchingInstruction()
+
+	instrRepo := &mockInstructionRepo{}
+	connRepo := &mockConnectionRepo{}
+	resolver := &mockRouteResolver{
+		resolve: func(_ context.Context, _, _ string) (*ports.InstructionRoute, error) {
+			return nil, ports.ErrRouteNotFound
+		},
+	}
+	dispatcher := &mockDispatcher{}
+
+	w := NewDispatchWorker(instrRepo, connRepo, resolver, dispatcher, DispatchWorkerConfig{}, nil)
+
+	err := w.processInstruction(context.Background(), instr)
+	require.NoError(t, err)
+
+	saved := instrRepo.getSavedInstructions()
+	require.Len(t, saved, 1)
+	assert.Equal(t, domain.InstructionStatusFailed, saved[0].Status)
+	assert.Contains(t, saved[0].FailureReason, "route resolution failed")
+	assert.Equal(t, "ROUTE_NOT_FOUND", saved[0].ErrorCode)
+}
+
+func TestProcessInstruction_ConnectionNotFound_MarksFailed(t *testing.T) {
+	instr := dispatchingInstruction()
+
+	instrRepo := &mockInstructionRepo{}
+	connRepo := &mockConnectionRepo{
+		findByID: func(_ context.Context, _, _ string) (*domain.ProviderConnection, error) {
+			return nil, ports.ErrConnectionNotFound
+		},
+	}
+	resolver := &mockRouteResolver{
+		resolve: func(_ context.Context, _, _ string) (*ports.InstructionRoute, error) {
+			return testRoute(), nil
+		},
+	}
+	dispatcher := &mockDispatcher{}
+
+	w := NewDispatchWorker(instrRepo, connRepo, resolver, dispatcher, DispatchWorkerConfig{}, nil)
+
+	err := w.processInstruction(context.Background(), instr)
+	require.NoError(t, err)
+
+	saved := instrRepo.getSavedInstructions()
+	require.Len(t, saved, 1)
+	assert.Equal(t, domain.InstructionStatusFailed, saved[0].Status)
+	assert.Equal(t, "CONNECTION_NOT_FOUND", saved[0].ErrorCode)
+}
+
+func TestProcessInstruction_CircuitOpen_RetriesWhenPossible(t *testing.T) {
+	instr := dispatchingInstruction()
+	conn := testConnection()
+	conn.CircuitState = domain.CircuitStateOpen
+
+	instrRepo := &mockInstructionRepo{}
+	connRepo := &mockConnectionRepo{
+		findByID: func(_ context.Context, _, _ string) (*domain.ProviderConnection, error) {
+			return conn, nil
+		},
+	}
+	resolver := &mockRouteResolver{
+		resolve: func(_ context.Context, _, _ string) (*ports.InstructionRoute, error) {
+			return testRoute(), nil
+		},
+	}
+	dispatcher := &mockDispatcher{}
+
+	w := NewDispatchWorker(instrRepo, connRepo, resolver, dispatcher, DispatchWorkerConfig{}, nil)
+
+	err := w.processInstruction(context.Background(), instr)
+	require.NoError(t, err)
+
+	saved := instrRepo.getSavedInstructions()
+	require.Len(t, saved, 1)
+	assert.Equal(t, domain.InstructionStatusRetrying, saved[0].Status)
+	require.Len(t, saved[0].Attempts, 1)
+	assert.Equal(t, "CIRCUIT_OPEN", saved[0].Attempts[0].ErrorCode)
+	assert.NotNil(t, saved[0].NextRetryAt)
+}
+
+func TestProcessInstruction_CircuitOpen_FailsWhenRetriesExhausted(t *testing.T) {
+	instr := dispatchingInstruction()
+	instr.AttemptCount = 3 // Matches MaxAttempts, so CanRetry() returns false
+	conn := testConnection()
+	conn.CircuitState = domain.CircuitStateOpen
+
+	instrRepo := &mockInstructionRepo{}
+	connRepo := &mockConnectionRepo{
+		findByID: func(_ context.Context, _, _ string) (*domain.ProviderConnection, error) {
+			return conn, nil
+		},
+	}
+	resolver := &mockRouteResolver{
+		resolve: func(_ context.Context, _, _ string) (*ports.InstructionRoute, error) {
+			return testRoute(), nil
+		},
+	}
+	dispatcher := &mockDispatcher{}
+
+	w := NewDispatchWorker(instrRepo, connRepo, resolver, dispatcher, DispatchWorkerConfig{}, nil)
+
+	err := w.processInstruction(context.Background(), instr)
+	require.NoError(t, err)
+
+	saved := instrRepo.getSavedInstructions()
+	require.Len(t, saved, 1)
+	assert.Equal(t, domain.InstructionStatusFailed, saved[0].Status)
+}
+
+func TestProcessInstruction_DispatchError_RetriesWithBackoff(t *testing.T) {
+	instr := dispatchingInstruction()
+	conn := testConnection()
+
+	instrRepo := &mockInstructionRepo{}
+	connRepo := &mockConnectionRepo{
+		findByID: func(_ context.Context, _, _ string) (*domain.ProviderConnection, error) {
+			return conn, nil
+		},
+	}
+	resolver := &mockRouteResolver{
+		resolve: func(_ context.Context, _, _ string) (*ports.InstructionRoute, error) {
+			return testRoute(), nil
+		},
+	}
+	dispatcher := &mockDispatcher{
+		dispatch: func(_ context.Context, _ *domain.Instruction, _ *domain.ProviderConnection, _ *ports.InstructionRoute) ports.DispatchResult {
+			return ports.DispatchResult{
+				Error:    errors.New("connection refused"),
+				Duration: 100 * time.Millisecond,
+			}
+		},
+	}
+
+	w := NewDispatchWorker(instrRepo, connRepo, resolver, dispatcher, DispatchWorkerConfig{}, nil)
+
+	err := w.processInstruction(context.Background(), instr)
+	require.NoError(t, err)
+
+	saved := instrRepo.getSavedInstructions()
+	require.Len(t, saved, 1)
+	assert.Equal(t, domain.InstructionStatusRetrying, saved[0].Status)
+	assert.NotNil(t, saved[0].NextRetryAt)
+	assert.Contains(t, saved[0].Attempts[0].FailureReason, "dispatch error")
+}
+
+func TestProcessInstruction_ProviderRetry_SchedulesRetry(t *testing.T) {
+	instr := dispatchingInstruction()
+	conn := testConnection()
+
+	instrRepo := &mockInstructionRepo{}
+	connRepo := &mockConnectionRepo{
+		findByID: func(_ context.Context, _, _ string) (*domain.ProviderConnection, error) {
+			return conn, nil
+		},
+	}
+	resolver := &mockRouteResolver{
+		resolve: func(_ context.Context, _, _ string) (*ports.InstructionRoute, error) {
+			return testRoute(), nil
+		},
+	}
+	dispatcher := &mockDispatcher{
+		dispatch: func(_ context.Context, _ *domain.Instruction, _ *domain.ProviderConnection, _ *ports.InstructionRoute) ports.DispatchResult {
+			return ports.DispatchResult{
+				StatusCode:   429,
+				ResponseBody: []byte(`{"error":"rate limited"}`),
+				Outcome: &ports.InstructionOutcome{
+					ShouldRetry:   true,
+					FailureReason: "rate limited",
+				},
+				Duration: 20 * time.Millisecond,
+			}
+		},
+	}
+
+	w := NewDispatchWorker(instrRepo, connRepo, resolver, dispatcher, DispatchWorkerConfig{}, nil)
+
+	err := w.processInstruction(context.Background(), instr)
+	require.NoError(t, err)
+
+	saved := instrRepo.getSavedInstructions()
+	require.Len(t, saved, 1)
+	assert.Equal(t, domain.InstructionStatusRetrying, saved[0].Status)
+	assert.NotNil(t, saved[0].NextRetryAt)
+}
+
+func TestProcessInstruction_ProviderReject_MarksFailed(t *testing.T) {
+	instr := dispatchingInstruction()
+	conn := testConnection()
+
+	instrRepo := &mockInstructionRepo{}
+	connRepo := &mockConnectionRepo{
+		findByID: func(_ context.Context, _, _ string) (*domain.ProviderConnection, error) {
+			return conn, nil
+		},
+	}
+	resolver := &mockRouteResolver{
+		resolve: func(_ context.Context, _, _ string) (*ports.InstructionRoute, error) {
+			return testRoute(), nil
+		},
+	}
+	dispatcher := &mockDispatcher{
+		dispatch: func(_ context.Context, _ *domain.Instruction, _ *domain.ProviderConnection, _ *ports.InstructionRoute) ports.DispatchResult {
+			return ports.DispatchResult{
+				StatusCode:   400,
+				ResponseBody: []byte(`{"error":"bad request"}`),
+				Outcome: &ports.InstructionOutcome{
+					FailureReason:  "invalid payload",
+					ProviderStatus: "REJECTED",
+				},
+				Duration: 20 * time.Millisecond,
+			}
+		},
+	}
+
+	w := NewDispatchWorker(instrRepo, connRepo, resolver, dispatcher, DispatchWorkerConfig{}, nil)
+
+	err := w.processInstruction(context.Background(), instr)
+	require.NoError(t, err)
+
+	saved := instrRepo.getSavedInstructions()
+	require.Len(t, saved, 1)
+	assert.Equal(t, domain.InstructionStatusFailed, saved[0].Status)
+	assert.Equal(t, "invalid payload", saved[0].FailureReason)
+	assert.Equal(t, "PROVIDER_REJECTED", saved[0].ErrorCode)
+}
+
+func TestProcessInstruction_NilOutcome_MarksFailed(t *testing.T) {
+	instr := dispatchingInstruction()
+	conn := testConnection()
+
+	instrRepo := &mockInstructionRepo{}
+	connRepo := &mockConnectionRepo{
+		findByID: func(_ context.Context, _, _ string) (*domain.ProviderConnection, error) {
+			return conn, nil
+		},
+	}
+	resolver := &mockRouteResolver{
+		resolve: func(_ context.Context, _, _ string) (*ports.InstructionRoute, error) {
+			return testRoute(), nil
+		},
+	}
+	dispatcher := &mockDispatcher{
+		dispatch: func(_ context.Context, _ *domain.Instruction, _ *domain.ProviderConnection, _ *ports.InstructionRoute) ports.DispatchResult {
+			return ports.DispatchResult{
+				StatusCode: 200,
+				Duration:   20 * time.Millisecond,
+				// Outcome is nil
+			}
+		},
+	}
+
+	w := NewDispatchWorker(instrRepo, connRepo, resolver, dispatcher, DispatchWorkerConfig{}, nil)
+
+	err := w.processInstruction(context.Background(), instr)
+	require.NoError(t, err)
+
+	saved := instrRepo.getSavedInstructions()
+	require.Len(t, saved, 1)
+	assert.Equal(t, domain.InstructionStatusFailed, saved[0].Status)
+	assert.Equal(t, "NO_OUTCOME", saved[0].ErrorCode)
+}
+
+func TestProcessInstruction_DispatchError_RecordsFailureOnConnection(t *testing.T) {
+	instr := dispatchingInstruction()
+	conn := testConnection()
+
+	var healthUpdated bool
+	instrRepo := &mockInstructionRepo{}
+	connRepo := &mockConnectionRepo{
+		findByID: func(_ context.Context, _, _ string) (*domain.ProviderConnection, error) {
+			return conn, nil
+		},
+		updateHealth: func(_ context.Context, c *domain.ProviderConnection) error {
+			healthUpdated = true
+			assert.Equal(t, 1, c.FailureCount)
+			return nil
+		},
+	}
+	resolver := &mockRouteResolver{
+		resolve: func(_ context.Context, _, _ string) (*ports.InstructionRoute, error) {
+			return testRoute(), nil
+		},
+	}
+	dispatcher := &mockDispatcher{
+		dispatch: func(_ context.Context, _ *domain.Instruction, _ *domain.ProviderConnection, _ *ports.InstructionRoute) ports.DispatchResult {
+			return ports.DispatchResult{Error: errors.New("timeout"), Duration: 30 * time.Second}
+		},
+	}
+
+	w := NewDispatchWorker(instrRepo, connRepo, resolver, dispatcher, DispatchWorkerConfig{}, nil)
+
+	err := w.processInstruction(context.Background(), instr)
+	require.NoError(t, err)
+	assert.True(t, healthUpdated, "connection health should have been updated")
+}
+
+func TestProcessInstruction_SuccessfulDispatch_RecordsSuccessOnConnection(t *testing.T) {
+	instr := dispatchingInstruction()
+	conn := testConnection()
+	conn.FailureCount = 2 // Existing failures should be reset on success
+
+	var healthUpdated bool
+	instrRepo := &mockInstructionRepo{}
+	connRepo := &mockConnectionRepo{
+		findByID: func(_ context.Context, _, _ string) (*domain.ProviderConnection, error) {
+			return conn, nil
+		},
+		updateHealth: func(_ context.Context, c *domain.ProviderConnection) error {
+			healthUpdated = true
+			assert.Equal(t, 0, c.FailureCount)
+			assert.Equal(t, 1, c.SuccessCount)
+			return nil
+		},
+	}
+	resolver := &mockRouteResolver{
+		resolve: func(_ context.Context, _, _ string) (*ports.InstructionRoute, error) {
+			return testRoute(), nil
+		},
+	}
+	dispatcher := &mockDispatcher{
+		dispatch: func(_ context.Context, _ *domain.Instruction, _ *domain.ProviderConnection, _ *ports.InstructionRoute) ports.DispatchResult {
+			return ports.DispatchResult{
+				StatusCode: 200,
+				Outcome:    &ports.InstructionOutcome{ExternalID: "ext-1", ProviderStatus: "ACCEPTED"},
+				Duration:   10 * time.Millisecond,
+			}
+		},
+	}
+
+	w := NewDispatchWorker(instrRepo, connRepo, resolver, dispatcher, DispatchWorkerConfig{}, nil)
+
+	err := w.processInstruction(context.Background(), instr)
+	require.NoError(t, err)
+	assert.True(t, healthUpdated)
+}
+
+func TestProcessBatch_ProcessesMultipleInstructions(t *testing.T) {
+	instr1 := dispatchingInstruction()
+	instr2 := dispatchingInstruction()
+	conn := testConnection()
+
+	instrRepo := &mockInstructionRepo{
+		fetchDispatchable: func(_ context.Context, _ ports.FetchDispatchableParams) ([]*domain.Instruction, error) {
+			return []*domain.Instruction{instr1, instr2}, nil
+		},
+	}
+	connRepo := &mockConnectionRepo{
+		findByID: func(_ context.Context, _, _ string) (*domain.ProviderConnection, error) {
+			return conn, nil
+		},
+	}
+	resolver := &mockRouteResolver{
+		resolve: func(_ context.Context, _, _ string) (*ports.InstructionRoute, error) {
+			return testRoute(), nil
+		},
+	}
+	dispatcher := &mockDispatcher{
+		dispatch: func(_ context.Context, _ *domain.Instruction, _ *domain.ProviderConnection, _ *ports.InstructionRoute) ports.DispatchResult {
+			return ports.DispatchResult{
+				StatusCode: 200,
+				Outcome:    &ports.InstructionOutcome{ExternalID: "ext-1", ProviderStatus: "ACCEPTED"},
+				Duration:   10 * time.Millisecond,
+			}
+		},
+	}
+
+	w := NewDispatchWorker(instrRepo, connRepo, resolver, dispatcher, DispatchWorkerConfig{}, nil)
+	w.processBatch(context.Background())
+
+	saved := instrRepo.getSavedInstructions()
+	assert.Len(t, saved, 2)
+	for _, s := range saved {
+		assert.Equal(t, domain.InstructionStatusDelivered, s.Status)
+	}
+}
+
+func TestProcessBatch_FetchError_DoesNotPanic(t *testing.T) {
+	instrRepo := &mockInstructionRepo{
+		fetchDispatchable: func(_ context.Context, _ ports.FetchDispatchableParams) ([]*domain.Instruction, error) {
+			return nil, errors.New("db connection lost")
+		},
+	}
+
+	w := NewDispatchWorker(instrRepo, &mockConnectionRepo{}, &mockRouteResolver{}, &mockDispatcher{}, DispatchWorkerConfig{}, nil)
+	// Should not panic.
+	w.processBatch(context.Background())
+	assert.Equal(t, 0, instrRepo.getSaveCalls())
+}
+
+func TestProcessBatch_EmptyBatch_NoOp(t *testing.T) {
+	instrRepo := &mockInstructionRepo{
+		fetchDispatchable: func(_ context.Context, _ ports.FetchDispatchableParams) ([]*domain.Instruction, error) {
+			return nil, nil
+		},
+	}
+
+	w := NewDispatchWorker(instrRepo, &mockConnectionRepo{}, &mockRouteResolver{}, &mockDispatcher{}, DispatchWorkerConfig{}, nil)
+	w.processBatch(context.Background())
+	assert.Equal(t, 0, instrRepo.getSaveCalls())
+}
+
+func TestCalculateNextRetry_ExponentialBackoff(t *testing.T) {
+	policy := domain.RetryPolicy{
+		InitialBackoff:    1 * time.Second,
+		MaxBackoff:        1 * time.Minute,
+		BackoffMultiplier: 2.0,
+	}
+
+	before := time.Now()
+
+	// First retry (attempt 1): 1s * 2^0 = 1s
+	retry1 := calculateNextRetry(1, policy)
+	assert.InDelta(t, 1*time.Second, retry1.Sub(before), float64(200*time.Millisecond))
+
+	// Second retry (attempt 2): 1s * 2^1 = 2s
+	retry2 := calculateNextRetry(2, policy)
+	assert.InDelta(t, 2*time.Second, retry2.Sub(before), float64(200*time.Millisecond))
+
+	// Third retry (attempt 3): 1s * 2^2 = 4s
+	retry3 := calculateNextRetry(3, policy)
+	assert.InDelta(t, 4*time.Second, retry3.Sub(before), float64(200*time.Millisecond))
+}
+
+func TestCalculateNextRetry_CapsAtMaxBackoff(t *testing.T) {
+	policy := domain.RetryPolicy{
+		InitialBackoff:    10 * time.Second,
+		MaxBackoff:        30 * time.Second,
+		BackoffMultiplier: 10.0,
+	}
+
+	before := time.Now()
+
+	// attempt 3: 10s * 10^2 = 1000s, but capped at 30s
+	retry := calculateNextRetry(3, policy)
+	assert.InDelta(t, 30*time.Second, retry.Sub(before), float64(200*time.Millisecond))
+}
+
+func TestCalculateNextRetry_FallbackDefaults(t *testing.T) {
+	policy := domain.RetryPolicy{} // All zero values
+
+	before := time.Now()
+
+	// Should use defaults: 1s initial, 2.0 multiplier, 5m max
+	retry := calculateNextRetry(1, policy)
+	assert.InDelta(t, 1*time.Second, retry.Sub(before), float64(200*time.Millisecond))
+}
+
+func TestDispatchWorker_PassesBatchSizeToFetch(t *testing.T) {
+	var capturedLimit int
+	instrRepo := &mockInstructionRepo{
+		fetchDispatchable: func(_ context.Context, params ports.FetchDispatchableParams) ([]*domain.Instruction, error) {
+			capturedLimit = params.Limit
+			return nil, nil
+		},
+	}
+
+	w := NewDispatchWorker(instrRepo, &mockConnectionRepo{}, &mockRouteResolver{}, &mockDispatcher{},
+		DispatchWorkerConfig{BatchSize: 25, PollInterval: 50 * time.Millisecond}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w.Start(ctx)
+
+	err := await.AtMost(2 * time.Second).PollInterval(20 * time.Millisecond).Until(func() bool {
+		return instrRepo.getFetchCalls() >= 1
+	})
+	require.NoError(t, err)
+
+	w.Stop()
+	assert.Equal(t, 25, capturedLimit)
+}
+
+func TestProcessInstruction_HalfOpenCircuit_AllowsDispatch(t *testing.T) {
+	instr := dispatchingInstruction()
+	conn := testConnection()
+	conn.CircuitState = domain.CircuitStateHalfOpen // IsAvailable() returns true
+
+	instrRepo := &mockInstructionRepo{}
+	connRepo := &mockConnectionRepo{
+		findByID: func(_ context.Context, _, _ string) (*domain.ProviderConnection, error) {
+			return conn, nil
+		},
+	}
+	resolver := &mockRouteResolver{
+		resolve: func(_ context.Context, _, _ string) (*ports.InstructionRoute, error) {
+			return testRoute(), nil
+		},
+	}
+	dispatcher := &mockDispatcher{
+		dispatch: func(_ context.Context, _ *domain.Instruction, _ *domain.ProviderConnection, _ *ports.InstructionRoute) ports.DispatchResult {
+			return ports.DispatchResult{
+				StatusCode: 200,
+				Outcome:    &ports.InstructionOutcome{ExternalID: "ext-1", ProviderStatus: "ACCEPTED"},
+				Duration:   10 * time.Millisecond,
+			}
+		},
+	}
+
+	w := NewDispatchWorker(instrRepo, connRepo, resolver, dispatcher, DispatchWorkerConfig{}, nil)
+
+	err := w.processInstruction(context.Background(), instr)
+	require.NoError(t, err)
+
+	saved := instrRepo.getSavedInstructions()
+	require.Len(t, saved, 1)
+	assert.Equal(t, domain.InstructionStatusDelivered, saved[0].Status)
+	// Half-open -> closed on success
+	assert.Equal(t, domain.CircuitStateClosed, conn.CircuitState)
+}

--- a/services/operational-gateway/worker/dispatch_worker_test.go
+++ b/services/operational-gateway/worker/dispatch_worker_test.go
@@ -365,6 +365,56 @@ func TestProcessInstruction_ConnectionNotFound_MarksFailed(t *testing.T) {
 	assert.Equal(t, "CONNECTION_NOT_FOUND", saved[0].ErrorCode)
 }
 
+func TestProcessInstruction_RouteTransientError_ReturnsError(t *testing.T) {
+	instr := dispatchingInstruction()
+
+	instrRepo := &mockInstructionRepo{}
+	connRepo := &mockConnectionRepo{}
+	resolver := &mockRouteResolver{
+		resolve: func(_ context.Context, _, _ string) (*ports.InstructionRoute, error) {
+			return nil, errors.New("database connection lost")
+		},
+	}
+	dispatcher := &mockDispatcher{}
+
+	w := NewDispatchWorker(instrRepo, connRepo, resolver, dispatcher, DispatchWorkerConfig{}, nil)
+
+	err := w.processInstruction(context.Background(), instr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "route resolution transient error")
+
+	// Instruction should NOT be marked failed — stays DISPATCHING for reaper.
+	saved := instrRepo.getSavedInstructions()
+	assert.Len(t, saved, 0)
+}
+
+func TestProcessInstruction_ConnectionTransientError_ReturnsError(t *testing.T) {
+	instr := dispatchingInstruction()
+
+	instrRepo := &mockInstructionRepo{}
+	connRepo := &mockConnectionRepo{
+		findByID: func(_ context.Context, _, _ string) (*domain.ProviderConnection, error) {
+			return nil, errors.New("network timeout")
+		},
+	}
+	resolver := &mockRouteResolver{
+		resolve: func(_ context.Context, _, _ string) (*ports.InstructionRoute, error) {
+			return testRoute(), nil
+		},
+	}
+	dispatcher := &mockDispatcher{}
+
+	w := NewDispatchWorker(instrRepo, connRepo, resolver, dispatcher, DispatchWorkerConfig{}, nil)
+
+	err := w.processInstruction(context.Background(), instr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection lookup transient error")
+
+	// Instruction should NOT be marked failed — stays DISPATCHING for reaper.
+	saved := instrRepo.getSavedInstructions()
+	assert.Len(t, saved, 0)
+}
+
 func TestProcessInstruction_CircuitOpen_RetriesWhenPossible(t *testing.T) {
 	instr := dispatchingInstruction()
 	conn := testConnection()


### PR DESCRIPTION
## Summary

Implements operational-gateway task 10: the dispatch worker that polls for dispatchable instructions and processes them through the full dispatch lifecycle.

- Adds `DispatchWorker` with ticker-based polling loop, graceful shutdown via context cancellation and shutdown channel, and configurable batch size and poll interval
- Adds `RouteResolver` port interface for resolving `InstructionRoute` by tenant and instruction type
- Integrates circuit breaker: checks `IsAvailable()` before dispatch, records `RecordSuccess()`/`RecordFailure()` after, persists health updates
- Handles retry with exponential backoff using the connection's `RetryPolicy` (initial backoff, multiplier, max backoff cap)
- Leverages `FetchDispatchable` which already marks instructions as DISPATCHING within its `FOR UPDATE SKIP LOCKED` transaction, enabling safe concurrent multi-worker operation

## Key Design Decisions

- **No duplicate state transition**: `FetchDispatchable` already transitions PENDING/RETRYING to DISPATCHING and increments `attempt_count`, so the worker does not call `MarkDispatching()` again
- **Route resolution as a port**: Introduced `RouteResolver` interface to decouple route lookup from the worker, allowing future implementations backed by manifest config or in-memory cache
- **Failure handling**: Route not found and connection not found are treated as permanent failures (not retryable), while dispatch errors and circuit breaker open are retryable

## Test Plan

- [x] 21 unit tests covering all dispatch paths
- [x] Happy path: instruction dispatched and marked DELIVERED
- [x] Route not found: instruction marked FAILED with ROUTE_NOT_FOUND error code
- [x] Connection not found: instruction marked FAILED with CONNECTION_NOT_FOUND error code
- [x] Circuit breaker open: retries when attempts remain, fails when exhausted
- [x] Half-open circuit: allows probe dispatch and closes circuit on success
- [x] Dispatch transport error: retries with backoff, records failure on connection
- [x] Provider retry response: schedules retry with exponential backoff
- [x] Provider reject response: marks FAILED with PROVIDER_REJECTED
- [x] Nil outcome: marks FAILED with NO_OUTCOME
- [x] Batch processing: processes multiple instructions per cycle
- [x] Worker lifecycle: start/stop, context cancellation, idempotent Stop()
- [x] Backoff calculation: exponential growth, max cap, fallback defaults