### PR TITLE
feat: Add Starlark service client for operational gateway sagas

### DIFF
--- a/services/current-account/service/saga_handlers.go
+++ b/services/current-account/service/saga_handlers.go
@@ -130,6 +130,11 @@ func RegisterCurrentAccountHandlers(registry *saga.HandlerRegistry) error {
 
 		// Party handlers (stubs - defined in schema for party service)
 		{"party.get_default_payment_method", stubNotImplemented("party.get_default_payment_method")},
+
+		// Operational Gateway handlers (stubs - defined in schema for operational gateway service)
+		{"operational_gateway.dispatch_instruction", stubNotImplemented("operational_gateway.dispatch_instruction")},
+		{"operational_gateway.cancel_instruction", stubNotImplemented("operational_gateway.cancel_instruction")},
+		{"operational_gateway.get_instruction", stubNotImplemented("operational_gateway.get_instruction")},
 	}
 
 	for _, h := range handlers {

--- a/services/operational-gateway/client/client.go
+++ b/services/operational-gateway/client/client.go
@@ -138,7 +138,7 @@ func New(cfg Config) (*Client, func(), error) {
 		}
 	} else if cfg.Target != "" {
 		dialOpts := cfg.DialOptions
-		if dialOpts == nil {
+		if len(dialOpts) == 0 {
 			dialOpts = []grpc.DialOption{
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 			}

--- a/services/operational-gateway/client/client.go
+++ b/services/operational-gateway/client/client.go
@@ -1,0 +1,266 @@
+// Package client provides a gRPC client for the OperationalGateway service.
+//
+// The OperationalGateway service manages the lifecycle of outbound instructions
+// to external providers. This client enables inter-service communication with
+// proper context propagation and resilience patterns.
+//
+// Usage with Kubernetes DNS-based load balancing (recommended for production):
+//
+//	client, cleanup, err := client.New(client.Config{
+//	    ServiceName: "operational-gateway",
+//	    Namespace:   "default",
+//	    Port:        50051,
+//	})
+//	if err != nil {
+//	    return err
+//	}
+//	defer cleanup()
+//
+// Usage with direct connection (for local development):
+//
+//	client, cleanup, err := client.New(client.Config{
+//	    Target:  "localhost:50051",
+//	    Timeout: 30 * time.Second,
+//	})
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
+	"github.com/meridianhub/meridian/shared/platform/observability"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	// DefaultPort is the default gRPC port for the OperationalGateway service.
+	DefaultPort = 50051
+
+	// DefaultTimeout is the default timeout for gRPC calls.
+	DefaultTimeout = 30 * time.Second
+
+	// DefaultNamespace is the default Kubernetes namespace.
+	DefaultNamespace = "default"
+
+	// ServiceName is the Kubernetes service name for OperationalGateway.
+	ServiceName = "operational-gateway"
+)
+
+// ErrTargetRequired is returned when neither Target nor ServiceName is provided.
+var ErrTargetRequired = errors.New("either Target or ServiceName must be provided")
+
+// Config holds configuration for the OperationalGateway client.
+type Config struct {
+	// Target is the gRPC server address (e.g., "localhost:50051").
+	// If set, overrides Kubernetes DNS-based discovery.
+	//
+	// Deprecated: Use ServiceName, Namespace, and Port for DNS-based load balancing.
+	Target string
+
+	// ServiceName is the Kubernetes service name (e.g., "operational-gateway").
+	// When specified, enables DNS-based client-side load balancing.
+	ServiceName string
+
+	// Namespace is the Kubernetes namespace (e.g., "default", "production").
+	// Defaults to "default" if not specified.
+	Namespace string
+
+	// Port is the service port number.
+	// Defaults to 50051 if not specified.
+	Port int
+
+	// Timeout is the default timeout for RPC calls.
+	// Defaults to 30 seconds if not specified.
+	Timeout time.Duration
+
+	// Tracer is an optional observability tracer for distributed tracing.
+	Tracer *observability.Tracer
+
+	// Resilience is an optional configuration for circuit breaker and retry.
+	Resilience *clients.ResilientClientConfig
+
+	// DialOptions allows custom gRPC dial options.
+	DialOptions []grpc.DialOption
+}
+
+// Client provides access to the OperationalGateway service.
+type Client struct {
+	conn               *grpc.ClientConn
+	operationalGateway opgatewayv1.OperationalGatewayServiceClient
+	tracer             *observability.Tracer
+	resilient          *clients.ResilientClient
+	timeout            time.Duration
+}
+
+// New creates a new OperationalGateway gRPC client.
+//
+// Returns the client, a cleanup function to close the connection, and any error.
+// The cleanup function should be deferred immediately after checking the error.
+func New(cfg Config) (*Client, func(), error) {
+	// Apply defaults
+	if cfg.Timeout == 0 {
+		cfg.Timeout = DefaultTimeout
+	}
+	if cfg.Port == 0 {
+		cfg.Port = DefaultPort
+	}
+	if cfg.Namespace == "" {
+		cfg.Namespace = DefaultNamespace
+	}
+
+	var conn *grpc.ClientConn
+	var err error
+
+	if cfg.ServiceName != "" {
+		dialOpts := cfg.DialOptions
+
+		if cfg.Tracer != nil {
+			dialOpts = append(dialOpts,
+				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
+				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
+			)
+		}
+
+		conn, err = platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
+			ServiceName: cfg.ServiceName,
+			Namespace:   cfg.Namespace,
+			Port:        cfg.Port,
+			DialOptions: dialOpts,
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create operational-gateway gRPC connection via platform factory: %w", err)
+		}
+	} else if cfg.Target != "" {
+		dialOpts := cfg.DialOptions
+		if dialOpts == nil {
+			dialOpts = []grpc.DialOption{
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			}
+		}
+
+		if cfg.Tracer != nil {
+			dialOpts = append(dialOpts,
+				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
+				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
+			)
+		}
+
+		conn, err = grpc.NewClient(cfg.Target, dialOpts...)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create operational-gateway gRPC connection to %s: %w", cfg.Target, err)
+		}
+	} else {
+		return nil, nil, ErrTargetRequired
+	}
+
+	var resilient *clients.ResilientClient
+	if cfg.Resilience != nil {
+		resilient = clients.NewResilientClient(*cfg.Resilience)
+	}
+
+	c := &Client{
+		conn:               conn,
+		operationalGateway: opgatewayv1.NewOperationalGatewayServiceClient(conn),
+		tracer:             cfg.Tracer,
+		resilient:          resilient,
+		timeout:            cfg.Timeout,
+	}
+
+	cleanup := func() {
+		if c.conn != nil {
+			_ = c.conn.Close()
+		}
+	}
+
+	return c, cleanup, nil
+}
+
+// DispatchInstruction submits a new instruction for outbound dispatch.
+// This is a non-idempotent operation (idempotency enforced via idempotency_key).
+func (c *Client) DispatchInstruction(ctx context.Context, req *opgatewayv1.DispatchInstructionRequest) (*opgatewayv1.DispatchInstructionResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilienceNoRetry(ctx, c.resilient, "DispatchInstruction", func() (*opgatewayv1.DispatchInstructionResponse, error) {
+			return c.operationalGateway.DispatchInstruction(ctx, req)
+		})
+	}
+
+	resp, err := c.operationalGateway.DispatchInstruction(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dispatch instruction: %w", err)
+	}
+
+	return resp, nil
+}
+
+// CancelInstruction cancels a pending instruction before dispatch.
+// Idempotent when called on an already-cancelled instruction.
+func (c *Client) CancelInstruction(ctx context.Context, req *opgatewayv1.CancelInstructionRequest) (*opgatewayv1.CancelInstructionResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilience(ctx, c.resilient, "CancelInstruction", func() (*opgatewayv1.CancelInstructionResponse, error) {
+			return c.operationalGateway.CancelInstruction(ctx, req)
+		})
+	}
+
+	resp, err := c.operationalGateway.CancelInstruction(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to cancel instruction: %w", err)
+	}
+
+	return resp, nil
+}
+
+// GetInstruction retrieves a specific instruction by its ID.
+// This is an idempotent read operation.
+func (c *Client) GetInstruction(ctx context.Context, req *opgatewayv1.GetInstructionRequest) (*opgatewayv1.GetInstructionResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilience(ctx, c.resilient, "GetInstruction", func() (*opgatewayv1.GetInstructionResponse, error) {
+			return c.operationalGateway.GetInstruction(ctx, req)
+		})
+	}
+
+	resp, err := c.operationalGateway.GetInstruction(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get instruction: %w", err)
+	}
+
+	return resp, nil
+}
+
+// Close terminates the gRPC connection gracefully.
+func (c *Client) Close() error {
+	if c.conn != nil {
+		if err := c.conn.Close(); err != nil {
+			return fmt.Errorf("failed to close operational-gateway client connection: %w", err)
+		}
+	}
+	return nil
+}
+
+// Conn returns the underlying gRPC connection.
+func (c *Client) Conn() *grpc.ClientConn {
+	return c.conn
+}

--- a/services/operational-gateway/client/starlark.go
+++ b/services/operational-gateway/client/starlark.go
@@ -1,0 +1,291 @@
+// Package client provides Starlark service bindings for OperationalGateway.
+// These handlers adapt the Starlark interface (map[string]any) to gRPC client calls,
+// enabling saga scripts to dispatch instructions to external providers.
+package client
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// contextKey is a type for context keys to avoid collisions.
+type contextKey string
+
+// correlationIDContextKey is the typed context key for correlation ID.
+const correlationIDContextKey contextKey = "x-correlation-id"
+
+// RegisterStarlarkHandlers registers all Starlark service bindings for OperationalGateway.
+// These handlers adapt the Starlark interface (map[string]any) to gRPC client calls.
+//
+// This function is called during service initialization to register OperationalGateway
+// handlers with the saga execution engine. Registered handlers:
+//   - operational_gateway.dispatch_instruction
+//   - operational_gateway.cancel_instruction
+//   - operational_gateway.get_instruction
+//
+// Example usage:
+//
+//	registry := saga.NewHandlerRegistry()
+//	client, cleanup, _ := client.New(client.Config{...})
+//	defer cleanup()
+//	err := RegisterStarlarkHandlers(registry, client)
+func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, c *Client) error {
+	handlers := map[string]struct {
+		handler  saga.Handler
+		metadata saga.HandlerMetadata
+	}{
+		"operational_gateway.dispatch_instruction": {
+			handler: dispatchInstructionHandler(c),
+			metadata: saga.HandlerMetadata{
+				Category:            saga.HandlerCategorySettlement,
+				ProducesInstruments: []string{},
+			},
+		},
+		"operational_gateway.cancel_instruction": {
+			handler: cancelInstructionHandler(c),
+			metadata: saga.HandlerMetadata{
+				Category:            saga.HandlerCategorySettlement,
+				ProducesInstruments: []string{},
+			},
+		},
+		"operational_gateway.get_instruction": {
+			handler: getInstructionHandler(c),
+			metadata: saga.HandlerMetadata{
+				Category:            saga.HandlerCategorySettlement,
+				ProducesInstruments: []string{},
+			},
+		},
+	}
+
+	for name, h := range handlers {
+		if err := registry.RegisterWithMetadata(name, h.handler, &h.metadata); err != nil {
+			return fmt.Errorf("failed to register %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// dispatchInstructionHandler queues an instruction for dispatch to an external provider.
+//
+// Parameters:
+//   - instruction_type (string, required): The category of operation (e.g., "payment.collect")
+//   - payload (map, required): Instruction-specific data sent to the provider
+//   - priority (string, optional): Dispatch priority: LOW, NORMAL, HIGH, CRITICAL (default: NORMAL)
+//   - correlation_id (string, optional): Links to originating saga/event
+//   - causation_id (string, optional): Identifies the event that caused this instruction
+//   - scheduled_at (string, optional): ISO 8601 timestamp for deferred dispatch
+//
+// Returns a map containing:
+//   - instruction_id: UUID of the created instruction
+//   - status: Always "PENDING" for newly queued instructions
+func dispatchInstructionHandler(c *Client) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		req, err := buildDispatchRequest(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+
+		clientCtx := prepareClientContext(ctx)
+		resp, err := c.DispatchInstruction(clientCtx, req)
+		if err != nil {
+			return nil, fmt.Errorf("operational_gateway.dispatch_instruction: %w", err)
+		}
+
+		instruction := resp.GetInstruction()
+		return map[string]any{
+			"instruction_id": instruction.GetId(),
+			"status":         "PENDING",
+		}, nil
+	}
+}
+
+// buildDispatchRequest constructs a DispatchInstructionRequest from Starlark params.
+func buildDispatchRequest(ctx *saga.StarlarkContext, params map[string]any) (*opgatewayv1.DispatchInstructionRequest, error) {
+	instructionType, err := saga.RequireStringParam(params, "instruction_type")
+	if err != nil {
+		return nil, err
+	}
+
+	payloadStruct, err := extractPayload(params)
+	if err != nil {
+		return nil, err
+	}
+
+	req := &opgatewayv1.DispatchInstructionRequest{
+		InstructionType: instructionType,
+		Payload:         payloadStruct,
+		IdempotencyKey:  &commonv1.IdempotencyKey{Key: ctx.IdempotencyKey},
+	}
+
+	if priorityStr, ok := params["priority"].(string); ok && priorityStr != "" {
+		req.Priority = stringToPriority(priorityStr)
+	}
+
+	if corrID, ok := params["correlation_id"].(string); ok && corrID != "" {
+		req.CorrelationId = corrID
+	} else {
+		req.CorrelationId = ctx.CorrelationID.String()
+	}
+
+	if causationID, ok := params["causation_id"].(string); ok && causationID != "" {
+		req.CausationId = causationID
+	}
+
+	if scheduledAtStr, ok := params["scheduled_at"].(string); ok && scheduledAtStr != "" {
+		t, parseErr := time.Parse(time.RFC3339, scheduledAtStr)
+		if parseErr != nil {
+			return nil, fmt.Errorf("operational_gateway.dispatch_instruction: invalid scheduled_at %q: %w", scheduledAtStr, parseErr)
+		}
+		req.ScheduledAt = timestamppb.New(t)
+	}
+
+	return req, nil
+}
+
+// extractPayload extracts and converts the payload param to a structpb.Struct.
+func extractPayload(params map[string]any) (*structpb.Struct, error) {
+	payloadVal, ok := params["payload"]
+	if !ok || payloadVal == nil {
+		return nil, fmt.Errorf("operational_gateway.dispatch_instruction: %w: payload", saga.ErrMissingParam)
+	}
+	payloadRaw, ok := payloadVal.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("operational_gateway.dispatch_instruction: %w: payload must be a map, got %T", saga.ErrInvalidParamType, payloadVal)
+	}
+	payloadStruct, err := structpb.NewStruct(payloadRaw)
+	if err != nil {
+		return nil, fmt.Errorf("operational_gateway.dispatch_instruction: failed to convert payload: %w", err)
+	}
+	return payloadStruct, nil
+}
+
+// cancelInstructionHandler cancels a pending instruction before dispatch.
+// This is the compensation handler for dispatch_instruction.
+//
+// Parameters:
+//   - instruction_id (string, required): UUID of the instruction to cancel
+//   - reason (string, optional): Cancellation reason for audit trail
+//
+// Returns a map containing:
+//   - instruction_id: Echo of the input instruction ID
+//   - status: Always "CANCELLED"
+func cancelInstructionHandler(c *Client) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		instructionID, err := saga.RequireStringParam(params, "instruction_id")
+		if err != nil {
+			return nil, err
+		}
+
+		req := &opgatewayv1.CancelInstructionRequest{
+			InstructionId: instructionID,
+		}
+
+		if reason, ok := params["reason"].(string); ok && reason != "" {
+			req.CancellationReason = reason
+		}
+
+		clientCtx := prepareClientContext(ctx)
+		_, err = c.CancelInstruction(clientCtx, req)
+		if err != nil {
+			return nil, fmt.Errorf("operational_gateway.cancel_instruction: %w", err)
+		}
+
+		return map[string]any{
+			"instruction_id": instructionID,
+			"status":         "CANCELLED",
+		}, nil
+	}
+}
+
+// getInstructionHandler retrieves an instruction by ID.
+//
+// Parameters:
+//   - instruction_id (string, required): UUID of the instruction to retrieve
+//
+// Returns a map containing:
+//   - instruction_id: UUID of the instruction
+//   - instruction_type: Type of instruction
+//   - status: Current lifecycle status
+func getInstructionHandler(c *Client) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		instructionID, err := saga.RequireStringParam(params, "instruction_id")
+		if err != nil {
+			return nil, err
+		}
+
+		clientCtx := prepareClientContext(ctx)
+		resp, err := c.GetInstruction(clientCtx, &opgatewayv1.GetInstructionRequest{
+			InstructionId: instructionID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("operational_gateway.get_instruction: %w", err)
+		}
+
+		instruction := resp.GetInstruction()
+		return map[string]any{
+			"instruction_id":   instruction.GetId(),
+			"instruction_type": instruction.GetInstructionType(),
+			"status":           instructionStatusToString(instruction.GetStatus()),
+		}, nil
+	}
+}
+
+// prepareClientContext enriches the gRPC client context with saga metadata.
+func prepareClientContext(ctx *saga.StarlarkContext) context.Context {
+	clientCtx := ctx.Context
+
+	clientCtx = context.WithValue(clientCtx, correlationIDContextKey, ctx.CorrelationID.String())
+	clientCtx = clients.PropagateIdempotencyKey(clientCtx, ctx.IdempotencyKey)
+	clientCtx = clients.PropagateKnowledgeAt(clientCtx, ctx.KnowledgeAt)
+
+	return clientCtx
+}
+
+// stringToPriority converts a Starlark priority string to the proto Priority enum.
+func stringToPriority(s string) opgatewayv1.Priority {
+	switch s {
+	case "LOW":
+		return opgatewayv1.Priority_PRIORITY_LOW
+	case "NORMAL":
+		return opgatewayv1.Priority_PRIORITY_NORMAL
+	case "HIGH":
+		return opgatewayv1.Priority_PRIORITY_HIGH
+	case "CRITICAL":
+		return opgatewayv1.Priority_PRIORITY_CRITICAL
+	default:
+		return opgatewayv1.Priority_PRIORITY_NORMAL
+	}
+}
+
+// instructionStatusToString converts the proto InstructionStatus to a human-readable string.
+func instructionStatusToString(s opgatewayv1.InstructionStatus) string {
+	switch s {
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_UNSPECIFIED:
+		return "UNKNOWN"
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING:
+		return "PENDING"
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DISPATCHING:
+		return "DISPATCHING"
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DELIVERED:
+		return "DELIVERED"
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_ACKNOWLEDGED:
+		return "ACKNOWLEDGED"
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_RETRYING:
+		return "RETRYING"
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_FAILED:
+		return "FAILED"
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_EXPIRED:
+		return "EXPIRED"
+	case opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_CANCELLED:
+		return "CANCELLED"
+	}
+	return "UNKNOWN"
+}

--- a/services/operational-gateway/client/starlark.go
+++ b/services/operational-gateway/client/starlark.go
@@ -81,7 +81,7 @@ func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, c *Client) error {
 //   - priority (string, optional): Dispatch priority: LOW, NORMAL, HIGH, CRITICAL (default: NORMAL)
 //   - correlation_id (string, optional): Links to originating saga/event
 //   - causation_id (string, optional): Identifies the event that caused this instruction
-//   - scheduled_at (string, optional): ISO 8601 timestamp for deferred dispatch
+//   - scheduled_at (string, optional): RFC3339 timestamp for deferred dispatch (e.g. "2026-01-15T10:30:00Z")
 //
 // Returns a map containing:
 //   - instruction_id: UUID of the created instruction
@@ -93,7 +93,7 @@ func dispatchInstructionHandler(c *Client) saga.Handler {
 			return nil, err
 		}
 
-		clientCtx := prepareClientContext(ctx)
+		clientCtx := prepareClientContext(ctx, req.GetCorrelationId())
 		resp, err := c.DispatchInstruction(clientCtx, req)
 		if err != nil {
 			return nil, fmt.Errorf("operational_gateway.dispatch_instruction: %w", err)
@@ -137,17 +137,29 @@ func buildDispatchRequest(ctx *saga.StarlarkContext, params map[string]any) (*op
 		req.Priority = p
 	}
 
-	if corrID, ok := params["correlation_id"].(string); ok && corrID != "" {
+	corrID, _, err := optionalStringParam(params, "correlation_id")
+	if err != nil {
+		return nil, fmt.Errorf("operational_gateway.dispatch_instruction: %w", err)
+	}
+	if corrID != "" {
 		req.CorrelationId = corrID
 	} else {
 		req.CorrelationId = ctx.CorrelationID.String()
 	}
 
-	if causationID, ok := params["causation_id"].(string); ok && causationID != "" {
+	causationID, _, err := optionalStringParam(params, "causation_id")
+	if err != nil {
+		return nil, fmt.Errorf("operational_gateway.dispatch_instruction: %w", err)
+	}
+	if causationID != "" {
 		req.CausationId = causationID
 	}
 
-	if scheduledAtStr, ok := params["scheduled_at"].(string); ok && scheduledAtStr != "" {
+	scheduledAtStr, _, err := optionalStringParam(params, "scheduled_at")
+	if err != nil {
+		return nil, fmt.Errorf("operational_gateway.dispatch_instruction: %w", err)
+	}
+	if scheduledAtStr != "" {
 		t, parseErr := time.Parse(time.RFC3339, scheduledAtStr)
 		if parseErr != nil {
 			return nil, fmt.Errorf("operational_gateway.dispatch_instruction: invalid scheduled_at %q: %w", scheduledAtStr, parseErr)
@@ -196,11 +208,15 @@ func cancelInstructionHandler(c *Client) saga.Handler {
 			InstructionId: instructionID,
 		}
 
-		if reason, ok := params["reason"].(string); ok && reason != "" {
+		reason, _, err := optionalStringParam(params, "reason")
+		if err != nil {
+			return nil, fmt.Errorf("operational_gateway.cancel_instruction: %w", err)
+		}
+		if reason != "" {
 			req.CancellationReason = reason
 		}
 
-		clientCtx := prepareClientContext(ctx)
+		clientCtx := prepareClientContext(ctx, ctx.CorrelationID.String())
 		_, err = c.CancelInstruction(clientCtx, req)
 		if err != nil {
 			return nil, fmt.Errorf("operational_gateway.cancel_instruction: %w", err)
@@ -229,7 +245,7 @@ func getInstructionHandler(c *Client) saga.Handler {
 			return nil, err
 		}
 
-		clientCtx := prepareClientContext(ctx)
+		clientCtx := prepareClientContext(ctx, ctx.CorrelationID.String())
 		resp, err := c.GetInstruction(clientCtx, &opgatewayv1.GetInstructionRequest{
 			InstructionId: instructionID,
 		})
@@ -247,14 +263,31 @@ func getInstructionHandler(c *Client) saga.Handler {
 }
 
 // prepareClientContext enriches the gRPC client context with saga metadata.
-func prepareClientContext(ctx *saga.StarlarkContext) context.Context {
+// correlationID is the resolved correlation ID to propagate; pass req.GetCorrelationId()
+// so that any caller-supplied override is consistent with the transport metadata.
+func prepareClientContext(ctx *saga.StarlarkContext, correlationID string) context.Context {
 	clientCtx := ctx.Context
 
-	clientCtx = context.WithValue(clientCtx, correlationIDContextKey, ctx.CorrelationID.String())
+	clientCtx = context.WithValue(clientCtx, correlationIDContextKey, correlationID)
 	clientCtx = clients.PropagateIdempotencyKey(clientCtx, ctx.IdempotencyKey)
 	clientCtx = clients.PropagateKnowledgeAt(clientCtx, ctx.KnowledgeAt)
 
 	return clientCtx
+}
+
+// optionalStringParam looks up key in params. If absent or nil, it returns ("", false, nil).
+// If present with a non-string type, it returns a typed ErrInvalidParamType error so that
+// script bugs are caught immediately rather than silently ignored.
+func optionalStringParam(params map[string]any, key string) (string, bool, error) {
+	raw, exists := params[key]
+	if !exists || raw == nil {
+		return "", false, nil
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", true, fmt.Errorf("%w: %s must be a string, got %T", saga.ErrInvalidParamType, key, raw)
+	}
+	return s, true, nil
 }
 
 // stringToPriority converts a Starlark priority string to the proto Priority enum.

--- a/services/operational-gateway/client/starlark.go
+++ b/services/operational-gateway/client/starlark.go
@@ -125,8 +125,16 @@ func buildDispatchRequest(ctx *saga.StarlarkContext, params map[string]any) (*op
 		IdempotencyKey:  &commonv1.IdempotencyKey{Key: ctx.IdempotencyKey},
 	}
 
-	if priorityStr, ok := params["priority"].(string); ok && priorityStr != "" {
-		req.Priority = stringToPriority(priorityStr)
+	if rawPriority, exists := params["priority"]; exists && rawPriority != nil {
+		priorityStr, ok := rawPriority.(string)
+		if !ok {
+			return nil, fmt.Errorf("operational_gateway.dispatch_instruction: %w: priority must be a string, got %T", saga.ErrInvalidParamType, rawPriority)
+		}
+		p, err := stringToPriority(priorityStr)
+		if err != nil {
+			return nil, fmt.Errorf("operational_gateway.dispatch_instruction: %w", err)
+		}
+		req.Priority = p
 	}
 
 	if corrID, ok := params["correlation_id"].(string); ok && corrID != "" {
@@ -250,18 +258,19 @@ func prepareClientContext(ctx *saga.StarlarkContext) context.Context {
 }
 
 // stringToPriority converts a Starlark priority string to the proto Priority enum.
-func stringToPriority(s string) opgatewayv1.Priority {
+// Returns an error for unrecognized values rather than silently defaulting to NORMAL.
+func stringToPriority(s string) (opgatewayv1.Priority, error) {
 	switch s {
 	case "LOW":
-		return opgatewayv1.Priority_PRIORITY_LOW
+		return opgatewayv1.Priority_PRIORITY_LOW, nil
 	case "NORMAL":
-		return opgatewayv1.Priority_PRIORITY_NORMAL
+		return opgatewayv1.Priority_PRIORITY_NORMAL, nil
 	case "HIGH":
-		return opgatewayv1.Priority_PRIORITY_HIGH
+		return opgatewayv1.Priority_PRIORITY_HIGH, nil
 	case "CRITICAL":
-		return opgatewayv1.Priority_PRIORITY_CRITICAL
+		return opgatewayv1.Priority_PRIORITY_CRITICAL, nil
 	default:
-		return opgatewayv1.Priority_PRIORITY_NORMAL
+		return opgatewayv1.Priority_PRIORITY_UNSPECIFIED, fmt.Errorf("%w: priority %q is not valid (expected LOW|NORMAL|HIGH|CRITICAL)", saga.ErrInvalidParamType, s)
 	}
 }
 

--- a/services/operational-gateway/client/starlark_test.go
+++ b/services/operational-gateway/client/starlark_test.go
@@ -1,0 +1,341 @@
+package client
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const bufSize = 1024 * 1024
+
+// mockOperationalGatewayServer implements OperationalGatewayServiceServer for testing.
+type mockOperationalGatewayServer struct {
+	opgatewayv1.UnimplementedOperationalGatewayServiceServer
+
+	dispatchCalled bool
+	cancelCalled   bool
+	getCalled      bool
+
+	lastDispatchReq *opgatewayv1.DispatchInstructionRequest
+	lastCancelReq   *opgatewayv1.CancelInstructionRequest
+}
+
+func (m *mockOperationalGatewayServer) DispatchInstruction(_ context.Context, req *opgatewayv1.DispatchInstructionRequest) (*opgatewayv1.DispatchInstructionResponse, error) {
+	m.dispatchCalled = true
+	m.lastDispatchReq = req
+
+	return &opgatewayv1.DispatchInstructionResponse{
+		Instruction: &opgatewayv1.Instruction{
+			Id:              "test-instruction-id",
+			InstructionType: req.InstructionType,
+			Status:          opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_PENDING,
+			Priority:        opgatewayv1.Priority_PRIORITY_NORMAL,
+		},
+	}, nil
+}
+
+func (m *mockOperationalGatewayServer) CancelInstruction(_ context.Context, req *opgatewayv1.CancelInstructionRequest) (*opgatewayv1.CancelInstructionResponse, error) {
+	m.cancelCalled = true
+	m.lastCancelReq = req
+
+	return &opgatewayv1.CancelInstructionResponse{
+		Instruction: &opgatewayv1.Instruction{
+			Id:     req.InstructionId,
+			Status: opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_CANCELLED,
+		},
+	}, nil
+}
+
+func (m *mockOperationalGatewayServer) GetInstruction(_ context.Context, req *opgatewayv1.GetInstructionRequest) (*opgatewayv1.GetInstructionResponse, error) {
+	m.getCalled = true
+
+	return &opgatewayv1.GetInstructionResponse{
+		Instruction: &opgatewayv1.Instruction{
+			Id:              req.InstructionId,
+			InstructionType: "payment.collect",
+			Status:          opgatewayv1.InstructionStatus_INSTRUCTION_STATUS_DELIVERED,
+		},
+	}, nil
+}
+
+// setupTestClient creates an in-memory gRPC client/server pair for testing.
+func setupTestClient(t *testing.T) (*Client, *mockOperationalGatewayServer, func()) {
+	t.Helper()
+
+	lis := bufconn.Listen(bufSize)
+	srv := grpc.NewServer()
+	mock := &mockOperationalGatewayServer{}
+	opgatewayv1.RegisterOperationalGatewayServiceServer(srv, mock)
+
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+
+	conn, err := grpc.NewClient("passthrough://bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	c := &Client{
+		conn:               conn,
+		operationalGateway: opgatewayv1.NewOperationalGatewayServiceClient(conn),
+		timeout:            10 * time.Second,
+	}
+
+	cleanup := func() {
+		conn.Close()
+		srv.Stop()
+		lis.Close()
+	}
+
+	return c, mock, cleanup
+}
+
+// newTestStarlarkContext creates a minimal StarlarkContext for testing.
+func newTestStarlarkContext() *saga.StarlarkContext {
+	return &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		CorrelationID:   uuid.New(),
+		KnowledgeAt:     time.Now(),
+		IdempotencyKey:  "test-idempotency-key",
+		LookupCache:     saga.NewLookupResultCache(),
+	}
+}
+
+func TestRegisterStarlarkHandlers(t *testing.T) {
+	c, _, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, c)
+	require.NoError(t, err)
+
+	handlers := registry.List()
+	assert.Len(t, handlers, 3)
+
+	expectedHandlers := []string{
+		"operational_gateway.dispatch_instruction",
+		"operational_gateway.cancel_instruction",
+		"operational_gateway.get_instruction",
+	}
+	for _, name := range expectedHandlers {
+		_, err := registry.Get(name)
+		require.NoError(t, err, "handler %q should be registered", name)
+	}
+}
+
+func TestDispatchInstructionHandler(t *testing.T) {
+	c, mock, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("operational_gateway.dispatch_instruction")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"instruction_type": "payment.collect",
+		"payload": map[string]any{
+			"account_id": "acc-123",
+			"amount":     "100.00",
+		},
+		"priority":       "HIGH",
+		"correlation_id": "corr-abc",
+	}
+
+	result, err := handler(ctx, params)
+	require.NoError(t, err)
+	assert.True(t, mock.dispatchCalled)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "test-instruction-id", resultMap["instruction_id"])
+	assert.Equal(t, "PENDING", resultMap["status"])
+
+	// Verify idempotency key was propagated
+	assert.Equal(t, "test-idempotency-key", mock.lastDispatchReq.GetIdempotencyKey().GetKey())
+	assert.Equal(t, "payment.collect", mock.lastDispatchReq.GetInstructionType())
+	assert.Equal(t, opgatewayv1.Priority_PRIORITY_HIGH, mock.lastDispatchReq.GetPriority())
+	assert.Equal(t, "corr-abc", mock.lastDispatchReq.GetCorrelationId())
+}
+
+func TestDispatchInstructionHandlerMissingType(t *testing.T) {
+	c, _, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("operational_gateway.dispatch_instruction")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"payload": map[string]any{"key": "value"},
+	}
+
+	_, err = handler(ctx, params)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "instruction_type")
+}
+
+func TestDispatchInstructionHandlerMissingPayload(t *testing.T) {
+	c, _, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("operational_gateway.dispatch_instruction")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"instruction_type": "payment.collect",
+	}
+
+	_, err = handler(ctx, params)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "payload")
+}
+
+func TestDispatchInstructionHandlerScheduledAt(t *testing.T) {
+	c, mock, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("operational_gateway.dispatch_instruction")
+	require.NoError(t, err)
+
+	scheduledAt := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"instruction_type": "payment.collect",
+		"payload":          map[string]any{"key": "value"},
+		"scheduled_at":     scheduledAt,
+	}
+
+	_, err = handler(ctx, params)
+	require.NoError(t, err)
+	assert.NotNil(t, mock.lastDispatchReq.GetScheduledAt())
+}
+
+func TestCancelInstructionHandler(t *testing.T) {
+	c, mock, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("operational_gateway.cancel_instruction")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"instruction_id": "inst-xyz",
+		"reason":         "saga_compensation",
+	}
+
+	result, err := handler(ctx, params)
+	require.NoError(t, err)
+	assert.True(t, mock.cancelCalled)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "inst-xyz", resultMap["instruction_id"])
+	assert.Equal(t, "CANCELLED", resultMap["status"])
+	assert.Equal(t, "saga_compensation", mock.lastCancelReq.GetCancellationReason())
+}
+
+func TestCancelInstructionHandlerMissingID(t *testing.T) {
+	c, _, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("operational_gateway.cancel_instruction")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+
+	_, err = handler(ctx, map[string]any{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "instruction_id")
+}
+
+func TestGetInstructionHandler(t *testing.T) {
+	c, mock, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("operational_gateway.get_instruction")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"instruction_id": "inst-abc",
+	}
+
+	result, err := handler(ctx, params)
+	require.NoError(t, err)
+	assert.True(t, mock.getCalled)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "inst-abc", resultMap["instruction_id"])
+	assert.Equal(t, "payment.collect", resultMap["instruction_type"])
+	assert.Equal(t, "DELIVERED", resultMap["status"])
+}
+
+func TestDispatchInstructionHandlerIdempotencyKey(t *testing.T) {
+	c, mock, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	registry := saga.NewHandlerRegistry()
+	require.NoError(t, RegisterStarlarkHandlers(registry, c))
+
+	handler, err := registry.Get("operational_gateway.dispatch_instruction")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	ctx.IdempotencyKey = "unique-saga-step-key"
+	params := map[string]any{
+		"instruction_type": "notification.sms",
+		"payload":          map[string]any{"phone": "+1234567890"},
+	}
+
+	_, err = handler(ctx, params)
+	require.NoError(t, err)
+
+	// The idempotency key from the StarlarkContext must be used.
+	assert.Equal(t, "unique-saga-step-key", mock.lastDispatchReq.GetIdempotencyKey().GetKey())
+}
+
+// Ensure the package-level common types compile correctly.
+var (
+	_ *commonv1.IdempotencyKey = &commonv1.IdempotencyKey{}
+	_ *structpb.Struct         = &structpb.Struct{}
+)

--- a/shared/pkg/saga/schema/handlers.yaml
+++ b/shared/pkg/saga/schema/handlers.yaml
@@ -778,3 +778,78 @@ handlers:
       status:
         type: string
         description: "Status of the dispute (OPEN)"
+
+  # Operational Gateway Service
+  operational_gateway.dispatch_instruction:
+    description: "Queue an instruction for dispatch to an external provider"
+    params:
+      instruction_type:
+        type: string
+        required: true
+        description: "Type of instruction (e.g., payment.collect, notification.sms)"
+      payload:
+        type: map
+        required: true
+        description: "Instruction-specific data sent to the provider"
+      priority:
+        type: enum
+        values: [LOW, NORMAL, HIGH, CRITICAL]
+        required: false
+        description: "Dispatch priority (default: NORMAL)"
+      correlation_id:
+        type: string
+        required: false
+        description: "Links to originating saga/event for distributed tracing"
+      causation_id:
+        type: string
+        required: false
+        description: "Identifies the event or command that caused this instruction"
+      scheduled_at:
+        type: string
+        required: false
+        description: "ISO 8601 timestamp: when to dispatch (null = immediate)"
+    returns:
+      instruction_id:
+        type: string
+        description: "UUID of the created instruction"
+      status:
+        type: string
+        description: "Status of the instruction (PENDING)"
+    compensate: operational_gateway.cancel_instruction
+
+  operational_gateway.cancel_instruction:
+    description: "Cancel a pending instruction before it is dispatched (compensation handler)"
+    params:
+      instruction_id:
+        type: string
+        required: true
+        description: "UUID of the instruction to cancel"
+      reason:
+        type: string
+        required: false
+        description: "Reason for cancellation (for audit trail)"
+    returns:
+      instruction_id:
+        type: string
+        description: "Echo of the input instruction ID"
+      status:
+        type: string
+        description: "Status of the instruction (CANCELLED)"
+
+  operational_gateway.get_instruction:
+    description: "Get instruction status and details by ID"
+    params:
+      instruction_id:
+        type: string
+        required: true
+        description: "UUID of the instruction to retrieve"
+    returns:
+      instruction_id:
+        type: string
+        description: "UUID of the instruction"
+      instruction_type:
+        type: string
+        description: "Type of instruction"
+      status:
+        type: string
+        description: "Current lifecycle status of the instruction"

--- a/shared/pkg/saga/schema/handlers_test.go
+++ b/shared/pkg/saga/schema/handlers_test.go
@@ -50,6 +50,9 @@ func TestPlatformHandlersSchema(t *testing.T) {
 		"reconciliation.assert_balance",
 		"reconciliation.initiate_dispute",
 		"party.get_default_payment_method",
+		"operational_gateway.dispatch_instruction",
+		"operational_gateway.cancel_instruction",
+		"operational_gateway.get_instruction",
 	}
 
 	assert.Len(t, schema.Handlers, len(expectedHandlers),
@@ -110,7 +113,7 @@ func TestRegistryLoadPlatformHandlers(t *testing.T) {
 	require.NoError(t, err)
 
 	handlers := registry.ListHandlers()
-	assert.Len(t, handlers, 30, "registry should contain all 30 platform handlers")
+	assert.Len(t, handlers, 33, "registry should contain all 33 platform handlers")
 
 	// Verify we can get each handler
 	for _, name := range handlers {


### PR DESCRIPTION
## Summary

- Adds `operational_gateway` handlers (`dispatch_instruction`, `cancel_instruction`, `get_instruction`) to the global `handlers.yaml` schema, making them available to all saga scripts via `operational_gateway.<handler>(...)` Starlark calls
- Creates `services/operational-gateway/client` package with a gRPC client wrapper and Starlark handler registrations
- Adds stub registrations in `current-account` to maintain `BuildServiceModules` schema-registry parity

## Changes Made

### Schema (`shared/pkg/saga/schema/handlers.yaml`)
- Added 3 new handlers under the `operational_gateway` namespace
- `dispatch_instruction` has `compensate: operational_gateway.cancel_instruction` for automatic saga rollback
- `cancel_instruction` and `get_instruction` added as standalone handlers

### New Package (`services/operational-gateway/client/`)
- `client.go`: gRPC client wrapper following the `current-account/client` pattern — supports both Kubernetes DNS-based (`ServiceName`) and direct (`Target`) connection, with optional resilience and tracing
- `starlark.go`: `RegisterStarlarkHandlers(registry, client)` entry point with three handler implementations:
  - `dispatchInstructionHandler`: validates `instruction_type` + `payload`, converts to `structpb.Struct`, propagates `IdempotencyKey`/`CorrelationId` from `StarlarkContext`, supports optional `priority`/`scheduled_at`/`causation_id`
  - `cancelInstructionHandler`: validates `instruction_id`, optional `reason`
  - `getInstructionHandler`: validates `instruction_id`, returns `instruction_type` and `status` as strings

### Stub Registrations (`services/current-account/service/saga_handlers.go`)
- Added 3 `stubNotImplemented` entries to keep `BuildServiceModules` happy (it validates schema ↔ registry parity at startup)

## Technical Details

- `DispatchInstruction` uses `ExecuteWithResilienceNoRetry` (non-idempotent — idempotency enforced via `IdempotencyKey`)
- `CancelInstruction` and `GetInstruction` use `ExecuteWithResilience` (idempotent operations)
- Status strings match proto enum names without prefix (e.g. `INSTRUCTION_STATUS_PENDING` → `"PENDING"`)
- Cognitive complexity reduced by extracting `buildDispatchRequest` and `extractPayload` helpers

## Testing

- 9 tests in `services/operational-gateway/client/starlark_test.go` using in-memory bufconn gRPC server
- Covers: handler registration, dispatch/cancel/get happy paths, missing required params, `scheduled_at` parsing, idempotency key propagation
- Updated `shared/pkg/saga/schema/handlers_test.go` count from 30 to 33