### PR TITLE
feat(operational-gateway): Add Kafka event publishing via transactional outbox

### DIFF
--- a/api/proto/meridian/events/v1/operational_gateway_events.proto
+++ b/api/proto/meridian/events/v1/operational_gateway_events.proto
@@ -1,0 +1,251 @@
+syntax = "proto3";
+
+package meridian.events.v1;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/meridianhub/meridian/api/proto/meridian/events/v1;eventsv1";
+
+// InstructionCreatedEvent is published when a new instruction is accepted and enters PENDING state.
+message InstructionCreatedEvent {
+  // event_id uniquely identifies this event instance.
+  string event_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // instruction_id is the unique identifier for the instruction.
+  string instruction_id = 2 [(buf.validate.field).string.uuid = true];
+
+  // tenant_id is the tenant that owns this instruction.
+  string tenant_id = 3 [(buf.validate.field).string.uuid = true];
+
+  // instruction_type identifies the category of operation being requested.
+  string instruction_type = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // provider_connection_id is the connection that will be used for dispatch.
+  string provider_connection_id = 5 [(buf.validate.field).string.max_len = 36];
+
+  // correlation_id links related events across services.
+  string correlation_id = 6 [(buf.validate.field).string.max_len = 255];
+
+  // causation_id identifies the event or command that caused this instruction.
+  string causation_id = 7 [(buf.validate.field).string.max_len = 255];
+
+  // occurred_at is when the instruction was created.
+  google.protobuf.Timestamp occurred_at = 8 [(buf.validate.field).required = true];
+
+  // version is the aggregate version at the time of this event.
+  int64 version = 9 [(buf.validate.field).int64.gte = 0];
+}
+
+// InstructionDispatchedEvent is published when an instruction transitions to DISPATCHING state.
+message InstructionDispatchedEvent {
+  // event_id uniquely identifies this event instance.
+  string event_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // instruction_id is the unique identifier for the instruction.
+  string instruction_id = 2 [(buf.validate.field).string.uuid = true];
+
+  // tenant_id is the tenant that owns this instruction.
+  string tenant_id = 3 [(buf.validate.field).string.uuid = true];
+
+  // instruction_type identifies the category of operation being requested.
+  string instruction_type = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // provider_connection_id is the connection being used for dispatch.
+  string provider_connection_id = 5 [(buf.validate.field).string.max_len = 36];
+
+  // attempt_number is the 1-based attempt ordinal for this dispatch.
+  int32 attempt_number = 6 [(buf.validate.field).int32.gte = 1];
+
+  // correlation_id links related events across services.
+  string correlation_id = 7 [(buf.validate.field).string.max_len = 255];
+
+  // causation_id identifies the event or command that caused this instruction.
+  string causation_id = 8 [(buf.validate.field).string.max_len = 255];
+
+  // occurred_at is when the dispatch was initiated.
+  google.protobuf.Timestamp occurred_at = 9 [(buf.validate.field).required = true];
+
+  // version is the aggregate version at the time of this event.
+  int64 version = 10 [(buf.validate.field).int64.gte = 0];
+}
+
+// InstructionDeliveredEvent is published when an instruction is successfully delivered to the provider.
+message InstructionDeliveredEvent {
+  // event_id uniquely identifies this event instance.
+  string event_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // instruction_id is the unique identifier for the instruction.
+  string instruction_id = 2 [(buf.validate.field).string.uuid = true];
+
+  // tenant_id is the tenant that owns this instruction.
+  string tenant_id = 3 [(buf.validate.field).string.uuid = true];
+
+  // instruction_type identifies the category of operation being requested.
+  string instruction_type = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // provider_connection_id is the connection that was used for dispatch.
+  string provider_connection_id = 5 [(buf.validate.field).string.max_len = 36];
+
+  // correlation_id links related events across services.
+  string correlation_id = 6 [(buf.validate.field).string.max_len = 255];
+
+  // causation_id identifies the event or command that caused this instruction.
+  string causation_id = 7 [(buf.validate.field).string.max_len = 255];
+
+  // occurred_at is when delivery was confirmed.
+  google.protobuf.Timestamp occurred_at = 8 [(buf.validate.field).required = true];
+
+  // version is the aggregate version at the time of this event.
+  int64 version = 9 [(buf.validate.field).int64.gte = 0];
+}
+
+// InstructionAcknowledgedEvent is published when a provider confirms it has processed the instruction.
+message InstructionAcknowledgedEvent {
+  // event_id uniquely identifies this event instance.
+  string event_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // instruction_id is the unique identifier for the instruction.
+  string instruction_id = 2 [(buf.validate.field).string.uuid = true];
+
+  // tenant_id is the tenant that owns this instruction.
+  string tenant_id = 3 [(buf.validate.field).string.uuid = true];
+
+  // instruction_type identifies the category of operation being requested.
+  string instruction_type = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // provider_connection_id is the connection that was used for dispatch.
+  string provider_connection_id = 5 [(buf.validate.field).string.max_len = 36];
+
+  // correlation_id links related events across services.
+  string correlation_id = 6 [(buf.validate.field).string.max_len = 255];
+
+  // causation_id identifies the event or command that caused this instruction.
+  string causation_id = 7 [(buf.validate.field).string.max_len = 255];
+
+  // occurred_at is when the acknowledgement was received.
+  google.protobuf.Timestamp occurred_at = 8 [(buf.validate.field).required = true];
+
+  // version is the aggregate version at the time of this event.
+  int64 version = 9 [(buf.validate.field).int64.gte = 0];
+}
+
+// InstructionFailedEvent is published when an instruction permanently fails after exhausting retries.
+message InstructionFailedEvent {
+  // event_id uniquely identifies this event instance.
+  string event_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // instruction_id is the unique identifier for the instruction.
+  string instruction_id = 2 [(buf.validate.field).string.uuid = true];
+
+  // tenant_id is the tenant that owns this instruction.
+  string tenant_id = 3 [(buf.validate.field).string.uuid = true];
+
+  // instruction_type identifies the category of operation being requested.
+  string instruction_type = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // provider_connection_id is the connection that was used for dispatch.
+  string provider_connection_id = 5 [(buf.validate.field).string.max_len = 36];
+
+  // failure_reason describes why the instruction failed.
+  string failure_reason = 6 [(buf.validate.field).string.max_len = 2048];
+
+  // error_code is the provider-specific or system error code.
+  string error_code = 7 [(buf.validate.field).string.max_len = 128];
+
+  // attempt_count is the total number of dispatch attempts made.
+  int32 attempt_count = 8 [(buf.validate.field).int32.gte = 0];
+
+  // correlation_id links related events across services.
+  string correlation_id = 9 [(buf.validate.field).string.max_len = 255];
+
+  // causation_id identifies the event or command that caused this instruction.
+  string causation_id = 10 [(buf.validate.field).string.max_len = 255];
+
+  // occurred_at is when the instruction entered FAILED state.
+  google.protobuf.Timestamp occurred_at = 11 [(buf.validate.field).required = true];
+
+  // version is the aggregate version at the time of this event.
+  int64 version = 12 [(buf.validate.field).int64.gte = 0];
+}
+
+// InstructionExpiredEvent is published when an instruction expires before being delivered.
+message InstructionExpiredEvent {
+  // event_id uniquely identifies this event instance.
+  string event_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // instruction_id is the unique identifier for the instruction.
+  string instruction_id = 2 [(buf.validate.field).string.uuid = true];
+
+  // tenant_id is the tenant that owns this instruction.
+  string tenant_id = 3 [(buf.validate.field).string.uuid = true];
+
+  // instruction_type identifies the category of operation being requested.
+  string instruction_type = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // provider_connection_id is the connection associated with this instruction.
+  string provider_connection_id = 5 [(buf.validate.field).string.max_len = 36];
+
+  // correlation_id links related events across services.
+  string correlation_id = 6 [(buf.validate.field).string.max_len = 255];
+
+  // causation_id identifies the event or command that caused this instruction.
+  string causation_id = 7 [(buf.validate.field).string.max_len = 255];
+
+  // occurred_at is when the instruction expired.
+  google.protobuf.Timestamp occurred_at = 8 [(buf.validate.field).required = true];
+
+  // version is the aggregate version at the time of this event.
+  int64 version = 9 [(buf.validate.field).int64.gte = 0];
+}
+
+// InstructionCancelledEvent is published when a pending instruction is explicitly cancelled.
+message InstructionCancelledEvent {
+  // event_id uniquely identifies this event instance.
+  string event_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // instruction_id is the unique identifier for the instruction.
+  string instruction_id = 2 [(buf.validate.field).string.uuid = true];
+
+  // tenant_id is the tenant that owns this instruction.
+  string tenant_id = 3 [(buf.validate.field).string.uuid = true];
+
+  // instruction_type identifies the category of operation being requested.
+  string instruction_type = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // provider_connection_id is the connection associated with this instruction.
+  string provider_connection_id = 5 [(buf.validate.field).string.max_len = 36];
+
+  // correlation_id links related events across services.
+  string correlation_id = 6 [(buf.validate.field).string.max_len = 255];
+
+  // causation_id identifies the event or command that caused this instruction.
+  string causation_id = 7 [(buf.validate.field).string.max_len = 255];
+
+  // occurred_at is when the instruction was cancelled.
+  google.protobuf.Timestamp occurred_at = 8 [(buf.validate.field).required = true];
+
+  // version is the aggregate version at the time of this event.
+  int64 version = 9 [(buf.validate.field).int64.gte = 0];
+}

--- a/services/operational-gateway/adapters/messaging/outbox_publisher.go
+++ b/services/operational-gateway/adapters/messaging/outbox_publisher.go
@@ -31,6 +31,12 @@ var topicToEventType = map[string]string{
 // ErrUnknownTopic is returned when a topic has no mapping in the outbox publisher.
 var ErrUnknownTopic = errors.New("unknown topic for outbox publishing")
 
+// ErrPublisherNil is returned when the outbox publisher is not configured.
+var ErrPublisherNil = errors.New("outbox publisher is not configured")
+
+// ErrInstructionNil is returned when a nil instruction is passed to a publish method.
+var ErrInstructionNil = errors.New("instruction must not be nil")
+
 // InstructionEventPublisher publishes instruction lifecycle events to the transactional outbox.
 // Events are written to the event_outbox table within the same database transaction as the
 // business operation, ensuring at-least-once delivery via the background outbox worker.
@@ -45,6 +51,9 @@ func NewInstructionEventPublisher(publisher *events.OutboxPublisher) *Instructio
 
 // PublishCreated writes an instruction-created event to the outbox within the provided transaction.
 func (p *InstructionEventPublisher) PublishCreated(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+	if instr == nil {
+		return ErrInstructionNil
+	}
 	event := &eventsv1.InstructionCreatedEvent{
 		EventId:              uuid.New().String(),
 		InstructionId:        instr.ID.String(),
@@ -61,6 +70,9 @@ func (p *InstructionEventPublisher) PublishCreated(ctx context.Context, tx *gorm
 
 // PublishDispatched writes an instruction-dispatched event to the outbox within the provided transaction.
 func (p *InstructionEventPublisher) PublishDispatched(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+	if instr == nil {
+		return ErrInstructionNil
+	}
 	event := &eventsv1.InstructionDispatchedEvent{
 		EventId:              uuid.New().String(),
 		InstructionId:        instr.ID.String(),
@@ -78,6 +90,9 @@ func (p *InstructionEventPublisher) PublishDispatched(ctx context.Context, tx *g
 
 // PublishDelivered writes an instruction-delivered event to the outbox within the provided transaction.
 func (p *InstructionEventPublisher) PublishDelivered(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+	if instr == nil {
+		return ErrInstructionNil
+	}
 	event := &eventsv1.InstructionDeliveredEvent{
 		EventId:              uuid.New().String(),
 		InstructionId:        instr.ID.String(),
@@ -94,6 +109,9 @@ func (p *InstructionEventPublisher) PublishDelivered(ctx context.Context, tx *go
 
 // PublishAcknowledged writes an instruction-acknowledged event to the outbox within the provided transaction.
 func (p *InstructionEventPublisher) PublishAcknowledged(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+	if instr == nil {
+		return ErrInstructionNil
+	}
 	event := &eventsv1.InstructionAcknowledgedEvent{
 		EventId:              uuid.New().String(),
 		InstructionId:        instr.ID.String(),
@@ -110,6 +128,9 @@ func (p *InstructionEventPublisher) PublishAcknowledged(ctx context.Context, tx 
 
 // PublishFailed writes an instruction-failed event to the outbox within the provided transaction.
 func (p *InstructionEventPublisher) PublishFailed(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+	if instr == nil {
+		return ErrInstructionNil
+	}
 	event := &eventsv1.InstructionFailedEvent{
 		EventId:              uuid.New().String(),
 		InstructionId:        instr.ID.String(),
@@ -129,6 +150,9 @@ func (p *InstructionEventPublisher) PublishFailed(ctx context.Context, tx *gorm.
 
 // PublishExpired writes an instruction-expired event to the outbox within the provided transaction.
 func (p *InstructionEventPublisher) PublishExpired(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+	if instr == nil {
+		return ErrInstructionNil
+	}
 	event := &eventsv1.InstructionExpiredEvent{
 		EventId:              uuid.New().String(),
 		InstructionId:        instr.ID.String(),
@@ -145,6 +169,9 @@ func (p *InstructionEventPublisher) PublishExpired(ctx context.Context, tx *gorm
 
 // PublishCancelled writes an instruction-cancelled event to the outbox within the provided transaction.
 func (p *InstructionEventPublisher) PublishCancelled(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+	if instr == nil {
+		return ErrInstructionNil
+	}
 	event := &eventsv1.InstructionCancelledEvent{
 		EventId:              uuid.New().String(),
 		InstructionId:        instr.ID.String(),
@@ -169,6 +196,10 @@ func (p *InstructionEventPublisher) publish(
 	correlationID string,
 	causationID string,
 ) error {
+	if p.publisher == nil {
+		return ErrPublisherNil
+	}
+
 	eventType, ok := topicToEventType[topic]
 	if !ok {
 		return fmt.Errorf("%w: %s", ErrUnknownTopic, topic)

--- a/services/operational-gateway/adapters/messaging/outbox_publisher.go
+++ b/services/operational-gateway/adapters/messaging/outbox_publisher.go
@@ -1,0 +1,186 @@
+// Package messaging provides event publishing adapters for the operational gateway service.
+package messaging
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
+)
+
+// topicToEventType maps Kafka topic constants to outbox event type strings.
+var topicToEventType = map[string]string{
+	topics.OperationalGatewayInstructionCreatedV1:      "operational_gateway.instruction_created.v1",
+	topics.OperationalGatewayInstructionDispatchedV1:   "operational_gateway.instruction_dispatched.v1",
+	topics.OperationalGatewayInstructionDeliveredV1:    "operational_gateway.instruction_delivered.v1",
+	topics.OperationalGatewayInstructionAcknowledgedV1: "operational_gateway.instruction_acknowledged.v1",
+	topics.OperationalGatewayInstructionFailedV1:       "operational_gateway.instruction_failed.v1",
+	topics.OperationalGatewayInstructionExpiredV1:      "operational_gateway.instruction_expired.v1",
+	topics.OperationalGatewayInstructionCancelledV1:    "operational_gateway.instruction_cancelled.v1",
+}
+
+// ErrUnknownTopic is returned when a topic has no mapping in the outbox publisher.
+var ErrUnknownTopic = errors.New("unknown topic for outbox publishing")
+
+// InstructionEventPublisher publishes instruction lifecycle events to the transactional outbox.
+// Events are written to the event_outbox table within the same database transaction as the
+// business operation, ensuring at-least-once delivery via the background outbox worker.
+type InstructionEventPublisher struct {
+	publisher *events.OutboxPublisher
+}
+
+// NewInstructionEventPublisher creates a new InstructionEventPublisher.
+func NewInstructionEventPublisher(publisher *events.OutboxPublisher) *InstructionEventPublisher {
+	return &InstructionEventPublisher{publisher: publisher}
+}
+
+// PublishCreated writes an instruction-created event to the outbox within the provided transaction.
+func (p *InstructionEventPublisher) PublishCreated(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+	event := &eventsv1.InstructionCreatedEvent{
+		EventId:              uuid.New().String(),
+		InstructionId:        instr.ID.String(),
+		TenantId:             instr.TenantID.String(),
+		InstructionType:      instr.InstructionType,
+		ProviderConnectionId: instr.ProviderConnectionID,
+		CorrelationId:        instr.CorrelationID,
+		CausationId:          instr.CausationID,
+		OccurredAt:           timestamppb.New(time.Now()),
+		Version:              instr.Version,
+	}
+	return p.publish(ctx, tx, event, topics.OperationalGatewayInstructionCreatedV1, instr.ID.String(), instr.CorrelationID, instr.CausationID)
+}
+
+// PublishDispatched writes an instruction-dispatched event to the outbox within the provided transaction.
+func (p *InstructionEventPublisher) PublishDispatched(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+	event := &eventsv1.InstructionDispatchedEvent{
+		EventId:              uuid.New().String(),
+		InstructionId:        instr.ID.String(),
+		TenantId:             instr.TenantID.String(),
+		InstructionType:      instr.InstructionType,
+		ProviderConnectionId: instr.ProviderConnectionID,
+		AttemptNumber:        int32(instr.AttemptCount),
+		CorrelationId:        instr.CorrelationID,
+		CausationId:          instr.CausationID,
+		OccurredAt:           timestamppb.New(time.Now()),
+		Version:              instr.Version,
+	}
+	return p.publish(ctx, tx, event, topics.OperationalGatewayInstructionDispatchedV1, instr.ID.String(), instr.CorrelationID, instr.CausationID)
+}
+
+// PublishDelivered writes an instruction-delivered event to the outbox within the provided transaction.
+func (p *InstructionEventPublisher) PublishDelivered(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+	event := &eventsv1.InstructionDeliveredEvent{
+		EventId:              uuid.New().String(),
+		InstructionId:        instr.ID.String(),
+		TenantId:             instr.TenantID.String(),
+		InstructionType:      instr.InstructionType,
+		ProviderConnectionId: instr.ProviderConnectionID,
+		CorrelationId:        instr.CorrelationID,
+		CausationId:          instr.CausationID,
+		OccurredAt:           timestamppb.New(time.Now()),
+		Version:              instr.Version,
+	}
+	return p.publish(ctx, tx, event, topics.OperationalGatewayInstructionDeliveredV1, instr.ID.String(), instr.CorrelationID, instr.CausationID)
+}
+
+// PublishAcknowledged writes an instruction-acknowledged event to the outbox within the provided transaction.
+func (p *InstructionEventPublisher) PublishAcknowledged(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+	event := &eventsv1.InstructionAcknowledgedEvent{
+		EventId:              uuid.New().String(),
+		InstructionId:        instr.ID.String(),
+		TenantId:             instr.TenantID.String(),
+		InstructionType:      instr.InstructionType,
+		ProviderConnectionId: instr.ProviderConnectionID,
+		CorrelationId:        instr.CorrelationID,
+		CausationId:          instr.CausationID,
+		OccurredAt:           timestamppb.New(time.Now()),
+		Version:              instr.Version,
+	}
+	return p.publish(ctx, tx, event, topics.OperationalGatewayInstructionAcknowledgedV1, instr.ID.String(), instr.CorrelationID, instr.CausationID)
+}
+
+// PublishFailed writes an instruction-failed event to the outbox within the provided transaction.
+func (p *InstructionEventPublisher) PublishFailed(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+	event := &eventsv1.InstructionFailedEvent{
+		EventId:              uuid.New().String(),
+		InstructionId:        instr.ID.String(),
+		TenantId:             instr.TenantID.String(),
+		InstructionType:      instr.InstructionType,
+		ProviderConnectionId: instr.ProviderConnectionID,
+		FailureReason:        instr.FailureReason,
+		ErrorCode:            instr.ErrorCode,
+		AttemptCount:         int32(instr.AttemptCount),
+		CorrelationId:        instr.CorrelationID,
+		CausationId:          instr.CausationID,
+		OccurredAt:           timestamppb.New(time.Now()),
+		Version:              instr.Version,
+	}
+	return p.publish(ctx, tx, event, topics.OperationalGatewayInstructionFailedV1, instr.ID.String(), instr.CorrelationID, instr.CausationID)
+}
+
+// PublishExpired writes an instruction-expired event to the outbox within the provided transaction.
+func (p *InstructionEventPublisher) PublishExpired(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+	event := &eventsv1.InstructionExpiredEvent{
+		EventId:              uuid.New().String(),
+		InstructionId:        instr.ID.String(),
+		TenantId:             instr.TenantID.String(),
+		InstructionType:      instr.InstructionType,
+		ProviderConnectionId: instr.ProviderConnectionID,
+		CorrelationId:        instr.CorrelationID,
+		CausationId:          instr.CausationID,
+		OccurredAt:           timestamppb.New(time.Now()),
+		Version:              instr.Version,
+	}
+	return p.publish(ctx, tx, event, topics.OperationalGatewayInstructionExpiredV1, instr.ID.String(), instr.CorrelationID, instr.CausationID)
+}
+
+// PublishCancelled writes an instruction-cancelled event to the outbox within the provided transaction.
+func (p *InstructionEventPublisher) PublishCancelled(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+	event := &eventsv1.InstructionCancelledEvent{
+		EventId:              uuid.New().String(),
+		InstructionId:        instr.ID.String(),
+		TenantId:             instr.TenantID.String(),
+		InstructionType:      instr.InstructionType,
+		ProviderConnectionId: instr.ProviderConnectionID,
+		CorrelationId:        instr.CorrelationID,
+		CausationId:          instr.CausationID,
+		OccurredAt:           timestamppb.New(time.Now()),
+		Version:              instr.Version,
+	}
+	return p.publish(ctx, tx, event, topics.OperationalGatewayInstructionCancelledV1, instr.ID.String(), instr.CorrelationID, instr.CausationID)
+}
+
+// publish is the internal helper that serializes and writes a proto event to the outbox.
+func (p *InstructionEventPublisher) publish(
+	ctx context.Context,
+	tx *gorm.DB,
+	event proto.Message,
+	topic string,
+	aggregateID string,
+	correlationID string,
+	causationID string,
+) error {
+	eventType, ok := topicToEventType[topic]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownTopic, topic)
+	}
+
+	return p.publisher.Publish(ctx, tx, event, events.PublishConfig{
+		EventType:     eventType,
+		Topic:         topic,
+		AggregateType: "Instruction",
+		AggregateID:   aggregateID,
+		PartitionKey:  aggregateID,
+		CorrelationID: correlationID,
+		CausationID:   causationID,
+	})
+}

--- a/services/operational-gateway/adapters/messaging/outbox_publisher_test.go
+++ b/services/operational-gateway/adapters/messaging/outbox_publisher_test.go
@@ -1,0 +1,217 @@
+package messaging_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/operational-gateway/adapters/messaging"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// setupTestDB creates an in-memory SQLite database with the event_outbox table.
+// Used for testing that outbox entries are written correctly.
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, db.AutoMigrate(&events.EventOutbox{}))
+	return db
+}
+
+func newTestInstruction(t *testing.T) *domain.Instruction {
+	t.Helper()
+	instr, err := domain.NewInstruction(
+		uuid.New(),
+		"payment.initiate",
+		uuid.New().String(),
+		map[string]any{"amount": 100.0},
+		domain.WithCorrelationID(uuid.New().String()),
+		domain.WithCausationID(uuid.New().String()),
+	)
+	require.NoError(t, err)
+	instr.ID = uuid.New()
+	instr.Version = 1
+	return instr
+}
+
+func TestInstructionEventPublisher_PublishCreated(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("operational-gateway")
+	ep := messaging.NewInstructionEventPublisher(publisher)
+	instr := newTestInstruction(t)
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return ep.PublishCreated(context.Background(), tx, instr)
+	})
+	require.NoError(t, err)
+
+	var entries []events.EventOutbox
+	require.NoError(t, db.Find(&entries).Error)
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	assert.Equal(t, "operational_gateway.instruction_created.v1", entry.EventType)
+	assert.Equal(t, "operational-gateway.instruction-created.v1", entry.Topic)
+	assert.Equal(t, "Instruction", entry.AggregateType)
+	assert.Equal(t, instr.ID.String(), entry.AggregateID)
+	assert.Equal(t, instr.CorrelationID, entry.CorrelationID)
+	assert.Equal(t, events.StatusPending, entry.Status)
+	assert.Equal(t, "operational-gateway", entry.ServiceName)
+	assert.NotEmpty(t, entry.EventPayload)
+}
+
+func TestInstructionEventPublisher_PublishDispatched(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("operational-gateway")
+	ep := messaging.NewInstructionEventPublisher(publisher)
+	instr := newTestInstruction(t)
+	instr.AttemptCount = 1
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return ep.PublishDispatched(context.Background(), tx, instr)
+	})
+	require.NoError(t, err)
+
+	var entries []events.EventOutbox
+	require.NoError(t, db.Find(&entries).Error)
+	require.Len(t, entries, 1)
+
+	assert.Equal(t, "operational_gateway.instruction_dispatched.v1", entries[0].EventType)
+	assert.Equal(t, "operational-gateway.instruction-dispatched.v1", entries[0].Topic)
+}
+
+func TestInstructionEventPublisher_PublishDelivered(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("operational-gateway")
+	ep := messaging.NewInstructionEventPublisher(publisher)
+	instr := newTestInstruction(t)
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return ep.PublishDelivered(context.Background(), tx, instr)
+	})
+	require.NoError(t, err)
+
+	var entries []events.EventOutbox
+	require.NoError(t, db.Find(&entries).Error)
+	assert.Equal(t, "operational_gateway.instruction_delivered.v1", entries[0].EventType)
+}
+
+func TestInstructionEventPublisher_PublishAcknowledged(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("operational-gateway")
+	ep := messaging.NewInstructionEventPublisher(publisher)
+	instr := newTestInstruction(t)
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return ep.PublishAcknowledged(context.Background(), tx, instr)
+	})
+	require.NoError(t, err)
+
+	var entries []events.EventOutbox
+	require.NoError(t, db.Find(&entries).Error)
+	assert.Equal(t, "operational_gateway.instruction_acknowledged.v1", entries[0].EventType)
+}
+
+func TestInstructionEventPublisher_PublishFailed(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("operational-gateway")
+	ep := messaging.NewInstructionEventPublisher(publisher)
+	instr := newTestInstruction(t)
+	instr.FailureReason = "connection timeout"
+	instr.ErrorCode = "TIMEOUT"
+	instr.AttemptCount = 3
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return ep.PublishFailed(context.Background(), tx, instr)
+	})
+	require.NoError(t, err)
+
+	var entries []events.EventOutbox
+	require.NoError(t, db.Find(&entries).Error)
+	assert.Equal(t, "operational_gateway.instruction_failed.v1", entries[0].EventType)
+}
+
+func TestInstructionEventPublisher_PublishExpired(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("operational-gateway")
+	ep := messaging.NewInstructionEventPublisher(publisher)
+	instr := newTestInstruction(t)
+	expiry := time.Now().Add(-time.Minute)
+	instr.ExpiresAt = &expiry
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return ep.PublishExpired(context.Background(), tx, instr)
+	})
+	require.NoError(t, err)
+
+	var entries []events.EventOutbox
+	require.NoError(t, db.Find(&entries).Error)
+	assert.Equal(t, "operational_gateway.instruction_expired.v1", entries[0].EventType)
+}
+
+func TestInstructionEventPublisher_PublishCancelled(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("operational-gateway")
+	ep := messaging.NewInstructionEventPublisher(publisher)
+	instr := newTestInstruction(t)
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return ep.PublishCancelled(context.Background(), tx, instr)
+	})
+	require.NoError(t, err)
+
+	var entries []events.EventOutbox
+	require.NoError(t, db.Find(&entries).Error)
+	assert.Equal(t, "operational_gateway.instruction_cancelled.v1", entries[0].EventType)
+}
+
+func TestInstructionEventPublisher_RollbackOnError(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("operational-gateway")
+	ep := messaging.NewInstructionEventPublisher(publisher)
+	instr := newTestInstruction(t)
+
+	// Simulate a transaction that writes the event but then fails (rollback)
+	_ = db.Transaction(func(tx *gorm.DB) error {
+		if err := ep.PublishCreated(context.Background(), tx, instr); err != nil {
+			return err
+		}
+		// Force rollback
+		return assert.AnError
+	})
+
+	// The event should NOT be in the outbox since the transaction was rolled back
+	var entries []events.EventOutbox
+	require.NoError(t, db.Find(&entries).Error)
+	assert.Empty(t, entries, "event outbox should be empty after rollback")
+}
+
+func TestInstructionEventPublisher_PartitionKeyIsInstructionID(t *testing.T) {
+	db := setupTestDB(t)
+	publisher := events.NewOutboxPublisher("operational-gateway")
+	ep := messaging.NewInstructionEventPublisher(publisher)
+	instr := newTestInstruction(t)
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		return ep.PublishCreated(context.Background(), tx, instr)
+	})
+	require.NoError(t, err)
+
+	var entries []events.EventOutbox
+	require.NoError(t, db.Find(&entries).Error)
+	require.Len(t, entries, 1)
+
+	// Partition key should be the instruction ID for ordered delivery per instruction
+	assert.Equal(t, instr.ID.String(), entries[0].PartitionKey)
+}

--- a/services/operational-gateway/adapters/persistence/instruction_repository.go
+++ b/services/operational-gateway/adapters/persistence/instruction_repository.go
@@ -22,6 +22,13 @@ func NewInstructionRepository(db *gorm.DB) *InstructionRepository {
 	return &InstructionRepository{db: db}
 }
 
+// WithTx returns a new InstructionRepository that operates within the provided transaction.
+// Use this to perform repository operations within a caller-managed transaction, enabling
+// atomic commits with other operations (e.g., outbox event writes).
+func (r *InstructionRepository) WithTx(tx *gorm.DB) *InstructionRepository {
+	return &InstructionRepository{db: tx}
+}
+
 // Save creates or updates an instruction with optimistic locking.
 //
 // For new instructions (Version == 0), performs an INSERT and sets inst.Version = 1.
@@ -36,61 +43,76 @@ func (r *InstructionRepository) Save(ctx context.Context, inst *domain.Instructi
 	}
 
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var existing InstructionEntity
-		result := tx.Where("id = ?", entity.ID).First(&existing)
-
-		if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return result.Error
-		}
-
-		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			// New instruction - INSERT
-			entity.Version = 1
-			if err := tx.Create(entity).Error; err != nil {
-				if isDuplicateKeyError(err) {
-					return ports.ErrDuplicateIdempotency
-				}
-				return err
-			}
-			// Propagate the assigned version back so the caller doesn't hold a stale 0.
-			inst.Version = entity.Version
-			return nil
-		}
-
-		// Existing instruction - UPDATE with optimistic locking.
-		// entity.Version carries the version the caller loaded from the DB (set by instructionFromEntity).
-		// We require the DB row still has that version; on match we increment to entity.Version+1.
-		expectedVersion := entity.Version
-		newVersion := expectedVersion + 1
-		entity.Version = newVersion
-		entity.CreatedAt = existing.CreatedAt
-
-		updateResult := tx.Model(&InstructionEntity{}).
-			Where("id = ? AND version = ?", entity.ID, expectedVersion).
-			Updates(map[string]interface{}{
-				"status":         entity.Status,
-				"attempt_count":  entity.AttemptCount,
-				"next_retry_at":  entity.NextRetryAt,
-				"dispatched_at":  entity.DispatchedAt,
-				"completed_at":   entity.CompletedAt,
-				"failure_reason": entity.FailureReason,
-				"error_code":     entity.ErrorCode,
-				"version":        newVersion,
-				"updated_at":     entity.UpdatedAt,
-			})
-
-		if updateResult.Error != nil {
-			return updateResult.Error
-		}
-
-		if updateResult.RowsAffected == 0 {
-			return ports.ErrInstructionConflict
-		}
-
-		// Propagate the new version back so the caller can make further Saves without reloading.
-		inst.Version = newVersion
-		return nil
+		return r.saveInTx(ctx, tx, inst, entity)
 	})
+}
+
+// SaveInTx performs the save operation within the provided transaction.
+// This is used when the caller manages the transaction (e.g., for atomic event publishing).
+func (r *InstructionRepository) SaveInTx(ctx context.Context, tx *gorm.DB, inst *domain.Instruction, idempotencyKey string) error {
+	entity, err := instructionToEntity(inst, idempotencyKey)
+	if err != nil {
+		return err
+	}
+	return r.saveInTx(ctx, tx, inst, entity)
+}
+
+// saveInTx contains the core save logic operating on a provided transaction handle.
+func (r *InstructionRepository) saveInTx(ctx context.Context, tx *gorm.DB, inst *domain.Instruction, entity *InstructionEntity) error {
+	var existing InstructionEntity
+	result := tx.WithContext(ctx).Where("id = ?", entity.ID).First(&existing)
+
+	if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return result.Error
+	}
+
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		// New instruction - INSERT
+		entity.Version = 1
+		if err := tx.WithContext(ctx).Create(entity).Error; err != nil {
+			if isDuplicateKeyError(err) {
+				return ports.ErrDuplicateIdempotency
+			}
+			return err
+		}
+		// Propagate the assigned version back so the caller doesn't hold a stale 0.
+		inst.Version = entity.Version
+		return nil
+	}
+
+	// Existing instruction - UPDATE with optimistic locking.
+	// entity.Version carries the version the caller loaded from the DB (set by instructionFromEntity).
+	// We require the DB row still has that version; on match we increment to entity.Version+1.
+	expectedVersion := entity.Version
+	newVersion := expectedVersion + 1
+	entity.Version = newVersion
+	entity.CreatedAt = existing.CreatedAt
+
+	updateResult := tx.WithContext(ctx).Model(&InstructionEntity{}).
+		Where("id = ? AND version = ?", entity.ID, expectedVersion).
+		Updates(map[string]interface{}{
+			"status":         entity.Status,
+			"attempt_count":  entity.AttemptCount,
+			"next_retry_at":  entity.NextRetryAt,
+			"dispatched_at":  entity.DispatchedAt,
+			"completed_at":   entity.CompletedAt,
+			"failure_reason": entity.FailureReason,
+			"error_code":     entity.ErrorCode,
+			"version":        newVersion,
+			"updated_at":     entity.UpdatedAt,
+		})
+
+	if updateResult.Error != nil {
+		return updateResult.Error
+	}
+
+	if updateResult.RowsAffected == 0 {
+		return ports.ErrInstructionConflict
+	}
+
+	// Propagate the new version back so the caller can make further Saves without reloading.
+	inst.Version = newVersion
+	return nil
 }
 
 // FindByID retrieves an instruction and its attempts by UUID.

--- a/services/operational-gateway/ports/repositories.go
+++ b/services/operational-gateway/ports/repositories.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"gorm.io/gorm"
 )
 
 // Instruction repository errors.
@@ -72,6 +73,32 @@ type InstructionRepository interface {
 	// Instructions are returned ordered by priority DESC (CRITICAL first), then scheduled_at ASC.
 	// The caller must call Save to update instruction state after dispatch.
 	FetchDispatchable(ctx context.Context, params FetchDispatchableParams) ([]*domain.Instruction, error)
+}
+
+// InstructionEventPublisher defines the interface for publishing instruction lifecycle events.
+// Implementations must write events to the transactional outbox within a provided transaction,
+// ensuring atomic consistency with the instruction state change.
+type InstructionEventPublisher interface {
+	// PublishCreated publishes an instruction-created event within the provided transaction.
+	PublishCreated(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error
+
+	// PublishDispatched publishes an instruction-dispatched event within the provided transaction.
+	PublishDispatched(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error
+
+	// PublishDelivered publishes an instruction-delivered event within the provided transaction.
+	PublishDelivered(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error
+
+	// PublishAcknowledged publishes an instruction-acknowledged event within the provided transaction.
+	PublishAcknowledged(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error
+
+	// PublishFailed publishes an instruction-failed event within the provided transaction.
+	PublishFailed(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error
+
+	// PublishExpired publishes an instruction-expired event within the provided transaction.
+	PublishExpired(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error
+
+	// PublishCancelled publishes an instruction-cancelled event within the provided transaction.
+	PublishCancelled(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error
 }
 
 // ConnectionRepository defines persistence operations for provider connections.

--- a/services/operational-gateway/service/grpc_service.go
+++ b/services/operational-gateway/service/grpc_service.go
@@ -28,8 +28,9 @@ const (
 
 // Service errors.
 var (
-	ErrInstructionRepoNil = errors.New("instruction repository cannot be nil")
-	ErrConnectionRepoNil  = errors.New("connection repository cannot be nil")
+	ErrInstructionRepoNil           = errors.New("instruction repository cannot be nil")
+	ErrConnectionRepoNil            = errors.New("connection repository cannot be nil")
+	ErrEventPublishingPartialConfig = errors.New("event publishing is partially configured")
 )
 
 // OperationalGatewayService implements OperationalGatewayServiceServer.
@@ -116,17 +117,41 @@ func requireTenant(ctx context.Context) (tenant.TenantID, error) {
 // saveInstructionWithEvent atomically saves the instruction and publishes a lifecycle event
 // to the transactional outbox within a single database transaction.
 //
-// If event publishing is not configured (db or eventPublisher is nil), falls back to
-// instructionRepo.Save without event publishing. This preserves backwards compatibility
-// for tests and deployments that do not require event publishing.
+// If event publishing is not configured at all (db, instructionRepoImpl, and eventPublisher
+// are all nil), falls back to instructionRepo.Save without event publishing. This preserves
+// backwards compatibility for tests and deployments that do not require event publishing.
+// Partial configuration (some but not all dependencies set) is treated as a misconfiguration
+// and returns an error to prevent silently dropping lifecycle events.
 func (s *OperationalGatewayService) saveInstructionWithEvent(
 	ctx context.Context,
 	instruction *domain.Instruction,
 	idempotencyKey string,
 	publishEvent func(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error,
 ) error {
-	// Fallback: no event publishing configured (e.g., unit tests)
-	if s.db == nil || s.instructionRepoImpl == nil || s.eventPublisher == nil || publishEvent == nil {
+	// Detect partial configuration: if any (but not all) event publishing dependencies
+	// are set, the wiring is incomplete and events would be silently dropped.
+	configuredCount := 0
+	if s.db != nil {
+		configuredCount++
+	}
+	if s.instructionRepoImpl != nil {
+		configuredCount++
+	}
+	if s.eventPublisher != nil {
+		configuredCount++
+	}
+	if configuredCount > 0 && configuredCount < 3 {
+		s.logger.Warn("event publishing is partially configured; lifecycle events will not be published",
+			"db_set", s.db != nil,
+			"impl_set", s.instructionRepoImpl != nil,
+			"publisher_set", s.eventPublisher != nil,
+		)
+		return fmt.Errorf("%w: db=%v, instructionRepoImpl=%v, eventPublisher=%v",
+			ErrEventPublishingPartialConfig, s.db != nil, s.instructionRepoImpl != nil, s.eventPublisher != nil)
+	}
+
+	// No event publishing configured (e.g., unit tests): fall back to plain save.
+	if configuredCount == 0 || publishEvent == nil {
 		return s.instructionRepo.Save(ctx, instruction, idempotencyKey)
 	}
 

--- a/services/operational-gateway/service/grpc_service.go
+++ b/services/operational-gateway/service/grpc_service.go
@@ -4,17 +4,20 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 
 	"github.com/google/uuid"
 	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/services/operational-gateway/adapters/persistence"
 	"github.com/meridianhub/meridian/services/operational-gateway/domain"
 	"github.com/meridianhub/meridian/services/operational-gateway/ports"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
+	"gorm.io/gorm"
 )
 
 // Pagination defaults.
@@ -32,9 +35,12 @@ var (
 // OperationalGatewayService implements OperationalGatewayServiceServer.
 type OperationalGatewayService struct {
 	opgatewayv1.UnimplementedOperationalGatewayServiceServer
-	instructionRepo ports.InstructionRepository
-	connectionRepo  ports.ConnectionRepository
-	logger          *slog.Logger
+	instructionRepo     ports.InstructionRepository
+	instructionRepoImpl *persistence.InstructionRepository
+	connectionRepo      ports.ConnectionRepository
+	db                  *gorm.DB
+	eventPublisher      ports.InstructionEventPublisher
+	logger              *slog.Logger
 }
 
 // ProviderConnectionService implements ProviderConnectionServiceServer.
@@ -67,6 +73,15 @@ func NewOperationalGatewayService(
 	}, nil
 }
 
+// WithEventPublishing configures transactional event publishing for the service.
+// When set, state-changing operations atomically write events to the outbox within the
+// same database transaction as the instruction save.
+func (s *OperationalGatewayService) WithEventPublishing(db *gorm.DB, impl *persistence.InstructionRepository, publisher ports.InstructionEventPublisher) {
+	s.db = db
+	s.instructionRepoImpl = impl
+	s.eventPublisher = publisher
+}
+
 // NewProviderConnectionService creates a new ProviderConnectionService.
 func NewProviderConnectionService(
 	connectionRepo ports.ConnectionRepository,
@@ -96,6 +111,34 @@ func requireTenant(ctx context.Context) (tenant.TenantID, error) {
 		return "", status.Error(codes.FailedPrecondition, "tenant context is required")
 	}
 	return tid, nil
+}
+
+// saveInstructionWithEvent atomically saves the instruction and publishes a lifecycle event
+// to the transactional outbox within a single database transaction.
+//
+// If event publishing is not configured (db or eventPublisher is nil), falls back to
+// instructionRepo.Save without event publishing. This preserves backwards compatibility
+// for tests and deployments that do not require event publishing.
+func (s *OperationalGatewayService) saveInstructionWithEvent(
+	ctx context.Context,
+	instruction *domain.Instruction,
+	idempotencyKey string,
+	publishEvent func(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error,
+) error {
+	// Fallback: no event publishing configured (e.g., unit tests)
+	if s.db == nil || s.instructionRepoImpl == nil || s.eventPublisher == nil || publishEvent == nil {
+		return s.instructionRepo.Save(ctx, instruction, idempotencyKey)
+	}
+
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := s.instructionRepoImpl.SaveInTx(ctx, tx, instruction, idempotencyKey); err != nil {
+			return err
+		}
+		if err := publishEvent(ctx, tx, instruction); err != nil {
+			return fmt.Errorf("failed to publish instruction event: %w", err)
+		}
+		return nil
+	})
 }
 
 // DispatchInstruction accepts a new instruction and queues it for dispatch.
@@ -172,7 +215,9 @@ func (s *OperationalGatewayService) DispatchInstruction(
 	// Assign a fresh UUID for this instruction.
 	instruction.ID = uuid.New()
 
-	if err := s.instructionRepo.Save(ctx, instruction, req.IdempotencyKey.Key); err != nil {
+	if err := s.saveInstructionWithEvent(ctx, instruction, req.IdempotencyKey.Key, func(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+		return s.eventPublisher.PublishCreated(ctx, tx, instr)
+	}); err != nil {
 		if errors.Is(err, ports.ErrDuplicateIdempotency) {
 			return nil, status.Error(codes.AlreadyExists, "instruction with this idempotency key already exists")
 		}
@@ -221,7 +266,9 @@ func (s *OperationalGatewayService) CancelInstruction(
 		return nil, status.Errorf(codes.Internal, "failed to cancel instruction: %v", err)
 	}
 
-	if err := s.instructionRepo.Save(ctx, instruction, ""); err != nil {
+	if err := s.saveInstructionWithEvent(ctx, instruction, "", func(ctx context.Context, tx *gorm.DB, instr *domain.Instruction) error {
+		return s.eventPublisher.PublishCancelled(ctx, tx, instr)
+	}); err != nil {
 		if errors.Is(err, ports.ErrInstructionConflict) {
 			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
 		}

--- a/shared/platform/events/topics/topics.go
+++ b/shared/platform/events/topics/topics.go
@@ -104,6 +104,24 @@ const (
 	InternalAccountBookingCreatedV1 = "internal-account.booking-created.v1"
 )
 
+// Operational Gateway topics
+const (
+	// OperationalGatewayInstructionCreatedV1 is the Kafka topic for instruction created events.
+	OperationalGatewayInstructionCreatedV1 = "operational-gateway.instruction-created.v1"
+	// OperationalGatewayInstructionDispatchedV1 is the Kafka topic for instruction dispatched events.
+	OperationalGatewayInstructionDispatchedV1 = "operational-gateway.instruction-dispatched.v1"
+	// OperationalGatewayInstructionDeliveredV1 is the Kafka topic for instruction delivered events.
+	OperationalGatewayInstructionDeliveredV1 = "operational-gateway.instruction-delivered.v1"
+	// OperationalGatewayInstructionAcknowledgedV1 is the Kafka topic for instruction acknowledged events.
+	OperationalGatewayInstructionAcknowledgedV1 = "operational-gateway.instruction-acknowledged.v1"
+	// OperationalGatewayInstructionFailedV1 is the Kafka topic for instruction failed events.
+	OperationalGatewayInstructionFailedV1 = "operational-gateway.instruction-failed.v1"
+	// OperationalGatewayInstructionExpiredV1 is the Kafka topic for instruction expired events.
+	OperationalGatewayInstructionExpiredV1 = "operational-gateway.instruction-expired.v1"
+	// OperationalGatewayInstructionCancelledV1 is the Kafka topic for instruction cancelled events.
+	OperationalGatewayInstructionCancelledV1 = "operational-gateway.instruction-cancelled.v1"
+)
+
 // Reconciliation topics
 const (
 	// ReconciliationRunStartedV1 is the Kafka topic for reconciliation run started events.
@@ -159,5 +177,12 @@ func All() []string {
 		ReconciliationPositionLockRequestedV1,
 		ReconciliationDisputeCreatedV1,
 		ReconciliationDisputeResolvedV1,
+		OperationalGatewayInstructionCreatedV1,
+		OperationalGatewayInstructionDispatchedV1,
+		OperationalGatewayInstructionDeliveredV1,
+		OperationalGatewayInstructionAcknowledgedV1,
+		OperationalGatewayInstructionFailedV1,
+		OperationalGatewayInstructionExpiredV1,
+		OperationalGatewayInstructionCancelledV1,
 	}
 }

--- a/shared/platform/events/topics/topics.yaml
+++ b/shared/platform/events/topics/topics.yaml
@@ -260,3 +260,48 @@ services:
         description: Published when a reconciliation dispute is resolved
         event_type: reconciliation.dispute_resolved.v1
         proto_message: DisputeResolved
+
+  operational-gateway:
+    description: Instruction lifecycle events for the operational gateway service
+    topics:
+      - name: operational-gateway.instruction-created.v1
+        constant: OperationalGatewayInstructionCreatedV1
+        description: Published when a new instruction is accepted and created in PENDING state
+        event_type: operational_gateway.instruction_created.v1
+        proto_message: InstructionCreatedEvent
+
+      - name: operational-gateway.instruction-dispatched.v1
+        constant: OperationalGatewayInstructionDispatchedV1
+        description: Published when an instruction transitions to DISPATCHING state
+        event_type: operational_gateway.instruction_dispatched.v1
+        proto_message: InstructionDispatchedEvent
+
+      - name: operational-gateway.instruction-delivered.v1
+        constant: OperationalGatewayInstructionDeliveredV1
+        description: Published when an instruction is successfully delivered to the provider
+        event_type: operational_gateway.instruction_delivered.v1
+        proto_message: InstructionDeliveredEvent
+
+      - name: operational-gateway.instruction-acknowledged.v1
+        constant: OperationalGatewayInstructionAcknowledgedV1
+        description: Published when a provider confirms it has processed the instruction
+        event_type: operational_gateway.instruction_acknowledged.v1
+        proto_message: InstructionAcknowledgedEvent
+
+      - name: operational-gateway.instruction-failed.v1
+        constant: OperationalGatewayInstructionFailedV1
+        description: Published when an instruction permanently fails after exhausting retries
+        event_type: operational_gateway.instruction_failed.v1
+        proto_message: InstructionFailedEvent
+
+      - name: operational-gateway.instruction-expired.v1
+        constant: OperationalGatewayInstructionExpiredV1
+        description: Published when an instruction expires before being delivered
+        event_type: operational_gateway.instruction_expired.v1
+        proto_message: InstructionExpiredEvent
+
+      - name: operational-gateway.instruction-cancelled.v1
+        constant: OperationalGatewayInstructionCancelledV1
+        description: Published when a pending instruction is explicitly cancelled
+        event_type: operational_gateway.instruction_cancelled.v1
+        proto_message: InstructionCancelledEvent

--- a/shared/platform/events/topics/topics_test.go
+++ b/shared/platform/events/topics/topics_test.go
@@ -204,6 +204,13 @@ func TestAll_ContainsAllConstants(t *testing.T) {
 		topics.ReconciliationPositionLockRequestedV1,
 		topics.ReconciliationDisputeCreatedV1,
 		topics.ReconciliationDisputeResolvedV1,
+		topics.OperationalGatewayInstructionCreatedV1,
+		topics.OperationalGatewayInstructionDispatchedV1,
+		topics.OperationalGatewayInstructionDeliveredV1,
+		topics.OperationalGatewayInstructionAcknowledgedV1,
+		topics.OperationalGatewayInstructionFailedV1,
+		topics.OperationalGatewayInstructionExpiredV1,
+		topics.OperationalGatewayInstructionCancelledV1,
 	}
 
 	allSet := make(map[string]bool, len(topics.All()))


### PR DESCRIPTION
## Summary

- Implements transactional outbox-based event publishing for instruction lifecycle events in the operational gateway service
- Adds 7 proto event messages and 7 Kafka topic constants for the full instruction lifecycle
- Wires atomic save+event publishing into `DispatchInstruction` and `CancelInstruction` gRPC handlers

## Changes Made

### Proto
- **`api/proto/meridian/events/v1/operational_gateway_events.proto`** (new): Defines `InstructionCreatedEvent`, `InstructionDispatchedEvent`, `InstructionDeliveredEvent`, `InstructionAcknowledgedEvent`, `InstructionFailedEvent`, `InstructionExpiredEvent`, `InstructionCancelledEvent`

### Shared Platform
- **`shared/platform/events/topics/topics.go`**: Added 7 `OperationalGateway*` topic constants and updated `All()`
- **`shared/platform/events/topics/topics.yaml`**: Registered operational-gateway topics in the canonical topic registry
- **`shared/platform/events/topics/topics_test.go`**: Added new constants to `TestAll_ContainsAllConstants`

### Operational Gateway Service
- **`adapters/messaging/outbox_publisher.go`** (new): `InstructionEventPublisher` adapter wrapping `*events.OutboxPublisher` with 7 lifecycle publish methods
- **`adapters/messaging/outbox_publisher_test.go`** (new): 9 unit tests covering all event types, rollback atomicity, and partition key correctness
- **`adapters/persistence/instruction_repository.go`**: Added `SaveInTx` for caller-managed transaction boundaries
- **`ports/repositories.go`**: Added `InstructionEventPublisher` port interface
- **`service/grpc_service.go`**: Added `WithEventPublishing` option, `saveInstructionWithEvent` helper, and wired publish callbacks into `DispatchInstruction` and `CancelInstruction`

## Technical Details

### Outbox Pattern (Atomic Consistency)
Events are written to the `event_outbox` table **within the same database transaction** as the instruction save. This guarantees that events are published if and only if the business operation commits — eliminating the dual-write problem. A background worker (existing outbox relay) publishes the events to Kafka asynchronously.

### Backwards Compatibility
The `WithEventPublishing` option method is called at wire-up time. When not configured (e.g., unit tests), `saveInstructionWithEvent` falls back to the standard `instructionRepo.Save`, so all existing tests pass without modification.

### Pattern Reference
Follows the current-account service pattern: `db.Transaction` wrapping both `SaveInTx` and `publishEvent` in a single atomic transaction.

## Test Plan

- [x] All 9 `TestInstructionEventPublisher_*` tests pass (SQLite in-memory, verifies outbox writes, rollback, partition key)
- [x] All existing operational-gateway tests pass
- [x] `TestAll_ContainsAllConstants` passes with new topic constants registered
- [x] Pre-commit hooks pass (buf lint, gofumpt, golangci-lint, gitleaks)