### PR TITLE
feat(operational-gateway): Add observability instrumentation

### DIFF
--- a/services/operational-gateway/observability/metrics.go
+++ b/services/operational-gateway/observability/metrics.go
@@ -1,0 +1,137 @@
+// Package observability provides Prometheus metrics and monitoring for the operational gateway service.
+package observability
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// instructionsTotal counts all instructions by tenant, type, and terminal status.
+	instructionsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "meridian_gateway_instructions_total",
+			Help: "Total number of instructions processed, labeled by tenant, instruction type, and terminal status.",
+		},
+		[]string{"tenant", "instruction_type", "status"},
+	)
+
+	// dispatchDuration records how long a single dispatch attempt takes.
+	dispatchDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "meridian_gateway_dispatch_duration_seconds",
+			Help:    "Duration of a dispatch attempt to an external provider in seconds.",
+			Buckets: []float64{.01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30},
+		},
+		[]string{"tenant", "provider"},
+	)
+
+	// dispatchAttemptsTotal counts all dispatch attempts by tenant, provider, and outcome.
+	dispatchAttemptsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "meridian_gateway_dispatch_attempts_total",
+			Help: "Total number of individual dispatch attempts to external providers.",
+		},
+		[]string{"tenant", "provider", "outcome"},
+	)
+
+	// circuitBreakerState tracks the circuit breaker state per connection.
+	// Values: 0 = CLOSED, 1 = HALF_OPEN, 2 = OPEN.
+	circuitBreakerState = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "meridian_gateway_circuit_breaker_state",
+			Help: "Current circuit breaker state per provider connection (0=closed, 1=half-open, 2=open).",
+		},
+		[]string{"tenant", "connection_id", "state"},
+	)
+
+	// activeInstructions tracks the number of instructions currently in a given non-terminal status.
+	activeInstructions = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "meridian_gateway_active_instructions",
+			Help: "Current number of instructions in non-terminal states, labeled by tenant and status.",
+		},
+		[]string{"tenant", "status"},
+	)
+)
+
+// DispatchOutcome represents the result of a single dispatch attempt.
+const (
+	// DispatchOutcomeSuccess means the provider accepted the instruction.
+	DispatchOutcomeSuccess = "success"
+	// DispatchOutcomeRetry means the attempt failed but will be retried.
+	DispatchOutcomeRetry = "retry"
+	// DispatchOutcomeFailure means the attempt failed permanently.
+	DispatchOutcomeFailure = "failure"
+	// DispatchOutcomeCircuitOpen means the circuit breaker blocked the attempt.
+	DispatchOutcomeCircuitOpen = "circuit_open"
+)
+
+// CircuitBreakerStateValue encodes the circuit breaker state as a Prometheus gauge value.
+type CircuitBreakerStateValue float64
+
+const (
+	// CircuitBreakerClosed represents a closed (healthy) circuit breaker.
+	CircuitBreakerClosed CircuitBreakerStateValue = 0
+	// CircuitBreakerHalfOpen represents a half-open (probing) circuit breaker.
+	CircuitBreakerHalfOpen CircuitBreakerStateValue = 1
+	// CircuitBreakerOpen represents an open (blocking) circuit breaker.
+	CircuitBreakerOpen CircuitBreakerStateValue = 2
+)
+
+// RecordInstruction increments the instructions counter for the given terminal status.
+// Call this when an instruction reaches a terminal state (DELIVERED, FAILED, EXPIRED, CANCELLED, ACKNOWLEDGED).
+func RecordInstruction(tenant, instructionType, status string) {
+	instructionsTotal.WithLabelValues(tenant, instructionType, status).Inc()
+}
+
+// RecordDispatchDuration records how long a dispatch attempt took.
+func RecordDispatchDuration(tenant, provider string, duration time.Duration) {
+	dispatchDuration.WithLabelValues(tenant, provider).Observe(duration.Seconds())
+}
+
+// RecordDispatchAttempt increments the dispatch attempts counter.
+// outcome should be one of the DispatchOutcome* constants.
+func RecordDispatchAttempt(tenant, provider, outcome string) {
+	dispatchAttemptsTotal.WithLabelValues(tenant, provider, outcome).Inc()
+}
+
+// RecordCircuitBreakerState updates the gauge for a specific connection's circuit breaker state.
+// state should be one of the CircuitBreaker* constants.
+func RecordCircuitBreakerState(tenant, connectionID string, state CircuitBreakerStateValue) {
+	// Reset all state label values for this connection before setting the current one
+	// to avoid stale multi-value time series. Using three separate gauge vectors would
+	// require separate Reset calls; instead we use a single gauge and set the value.
+	circuitBreakerState.WithLabelValues(tenant, connectionID, "closed").Set(0)
+	circuitBreakerState.WithLabelValues(tenant, connectionID, "half_open").Set(0)
+	circuitBreakerState.WithLabelValues(tenant, connectionID, "open").Set(0)
+
+	switch state {
+	case CircuitBreakerClosed:
+		circuitBreakerState.WithLabelValues(tenant, connectionID, "closed").Set(1)
+	case CircuitBreakerHalfOpen:
+		circuitBreakerState.WithLabelValues(tenant, connectionID, "half_open").Set(1)
+	case CircuitBreakerOpen:
+		circuitBreakerState.WithLabelValues(tenant, connectionID, "open").Set(1)
+	}
+}
+
+// SetActiveInstructions sets the gauge for instructions currently in a given status.
+// Call this after each polling cycle with the current count per status.
+func SetActiveInstructions(tenant, status string, count float64) {
+	activeInstructions.WithLabelValues(tenant, status).Set(count)
+}
+
+// IncrActiveInstructions increments the active instructions gauge.
+// Call this when a new instruction enters a non-terminal status.
+func IncrActiveInstructions(tenant, status string) {
+	activeInstructions.WithLabelValues(tenant, status).Inc()
+}
+
+// DecrActiveInstructions decrements the active instructions gauge.
+// Call this when an instruction leaves a status (transitions to another or reaches terminal).
+func DecrActiveInstructions(tenant, status string) {
+	activeInstructions.WithLabelValues(tenant, status).Dec()
+}

--- a/services/operational-gateway/observability/metrics.go
+++ b/services/operational-gateway/observability/metrics.go
@@ -38,11 +38,11 @@ var (
 	)
 
 	// circuitBreakerState tracks the circuit breaker state per connection.
-	// Values: 0 = CLOSED, 1 = HALF_OPEN, 2 = OPEN.
+	// One time series per state label: active state is 1, inactive states are 0.
 	circuitBreakerState = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "meridian_gateway_circuit_breaker_state",
-			Help: "Current circuit breaker state per provider connection (0=closed, 1=half-open, 2=open).",
+			Help: "One-hot circuit breaker state per provider connection and state label (1=active, 0=inactive).",
 		},
 		[]string{"tenant", "connection_id", "state"},
 	)

--- a/services/operational-gateway/observability/metrics_test.go
+++ b/services/operational-gateway/observability/metrics_test.go
@@ -1,0 +1,171 @@
+package observability
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRecordInstruction(t *testing.T) {
+	instructionsTotal.Reset()
+
+	RecordInstruction("tenant-a", "PAYMENT_INITIATION", "ACKNOWLEDGED")
+	RecordInstruction("tenant-a", "PAYMENT_INITIATION", "FAILED")
+	RecordInstruction("tenant-b", "REFUND", "ACKNOWLEDGED")
+
+	count := testutil.CollectAndCount(instructionsTotal)
+	if count != 3 {
+		t.Errorf("expected 3 series, got %d", count)
+	}
+}
+
+func TestRecordDispatchDuration(t *testing.T) {
+	dispatchDuration.Reset()
+
+	RecordDispatchDuration("tenant-a", "acme-bank", 150*time.Millisecond)
+	RecordDispatchDuration("tenant-a", "acme-bank", 300*time.Millisecond)
+	RecordDispatchDuration("tenant-b", "energy-co", 50*time.Millisecond)
+
+	count := testutil.CollectAndCount(dispatchDuration)
+	if count == 0 {
+		t.Error("expected dispatch duration metrics to be recorded")
+	}
+}
+
+func TestRecordDispatchAttempt(t *testing.T) {
+	dispatchAttemptsTotal.Reset()
+
+	RecordDispatchAttempt("tenant-a", "acme-bank", DispatchOutcomeSuccess)
+	RecordDispatchAttempt("tenant-a", "acme-bank", DispatchOutcomeRetry)
+	RecordDispatchAttempt("tenant-a", "acme-bank", DispatchOutcomeFailure)
+	RecordDispatchAttempt("tenant-b", "energy-co", DispatchOutcomeCircuitOpen)
+
+	count := testutil.CollectAndCount(dispatchAttemptsTotal)
+	if count != 4 {
+		t.Errorf("expected 4 series, got %d", count)
+	}
+}
+
+func TestRecordCircuitBreakerState(t *testing.T) {
+	circuitBreakerState.Reset()
+
+	tests := []struct {
+		name        string
+		state       CircuitBreakerStateValue
+		activeLabel string
+		inactiveA   string
+		inactiveB   string
+	}{
+		{
+			name:        "closed state",
+			state:       CircuitBreakerClosed,
+			activeLabel: "closed",
+			inactiveA:   "half_open",
+			inactiveB:   "open",
+		},
+		{
+			name:        "half-open state",
+			state:       CircuitBreakerHalfOpen,
+			activeLabel: "half_open",
+			inactiveA:   "closed",
+			inactiveB:   "open",
+		},
+		{
+			name:        "open state",
+			state:       CircuitBreakerOpen,
+			activeLabel: "open",
+			inactiveA:   "closed",
+			inactiveB:   "half_open",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			circuitBreakerState.Reset()
+			RecordCircuitBreakerState("tenant-a", "conn-1", tt.state)
+
+			// Verify the active label has value 1
+			active := testutil.ToFloat64(circuitBreakerState.WithLabelValues("tenant-a", "conn-1", tt.activeLabel))
+			if active != 1 {
+				t.Errorf("expected %s gauge to be 1, got %f", tt.activeLabel, active)
+			}
+
+			// Verify inactive labels are set to 0
+			inactiveAVal := testutil.ToFloat64(circuitBreakerState.WithLabelValues("tenant-a", "conn-1", tt.inactiveA))
+			if inactiveAVal != 0 {
+				t.Errorf("expected %s gauge to be 0, got %f", tt.inactiveA, inactiveAVal)
+			}
+
+			inactiveBVal := testutil.ToFloat64(circuitBreakerState.WithLabelValues("tenant-a", "conn-1", tt.inactiveB))
+			if inactiveBVal != 0 {
+				t.Errorf("expected %s gauge to be 0, got %f", tt.inactiveB, inactiveBVal)
+			}
+		})
+	}
+}
+
+func TestSetActiveInstructions(t *testing.T) {
+	activeInstructions.Reset()
+
+	SetActiveInstructions("tenant-a", "PENDING", 10)
+	SetActiveInstructions("tenant-a", "DISPATCHING", 5)
+	SetActiveInstructions("tenant-b", "RETRYING", 2)
+
+	pendingVal := testutil.ToFloat64(activeInstructions.WithLabelValues("tenant-a", "PENDING"))
+	if pendingVal != 10 {
+		t.Errorf("expected PENDING gauge to be 10, got %f", pendingVal)
+	}
+
+	dispatchingVal := testutil.ToFloat64(activeInstructions.WithLabelValues("tenant-a", "DISPATCHING"))
+	if dispatchingVal != 5 {
+		t.Errorf("expected DISPATCHING gauge to be 5, got %f", dispatchingVal)
+	}
+}
+
+func TestIncrDecrActiveInstructions(t *testing.T) {
+	activeInstructions.Reset()
+
+	IncrActiveInstructions("tenant-a", "PENDING")
+	IncrActiveInstructions("tenant-a", "PENDING")
+	IncrActiveInstructions("tenant-a", "PENDING")
+
+	val := testutil.ToFloat64(activeInstructions.WithLabelValues("tenant-a", "PENDING"))
+	if val != 3 {
+		t.Errorf("expected gauge to be 3 after 3 increments, got %f", val)
+	}
+
+	DecrActiveInstructions("tenant-a", "PENDING")
+
+	val = testutil.ToFloat64(activeInstructions.WithLabelValues("tenant-a", "PENDING"))
+	if val != 2 {
+		t.Errorf("expected gauge to be 2 after decrement, got %f", val)
+	}
+}
+
+func TestDispatchOutcomeConstants(t *testing.T) {
+	if DispatchOutcomeSuccess != "success" {
+		t.Errorf("DispatchOutcomeSuccess should be 'success', got %q", DispatchOutcomeSuccess)
+	}
+	if DispatchOutcomeRetry != "retry" {
+		t.Errorf("DispatchOutcomeRetry should be 'retry', got %q", DispatchOutcomeRetry)
+	}
+	if DispatchOutcomeFailure != "failure" {
+		t.Errorf("DispatchOutcomeFailure should be 'failure', got %q", DispatchOutcomeFailure)
+	}
+	if DispatchOutcomeCircuitOpen != "circuit_open" {
+		t.Errorf("DispatchOutcomeCircuitOpen should be 'circuit_open', got %q", DispatchOutcomeCircuitOpen)
+	}
+}
+
+func TestCircuitBreakerStateValueConstants(t *testing.T) {
+	if CircuitBreakerClosed != 0 {
+		t.Errorf("CircuitBreakerClosed should be 0, got %v", CircuitBreakerClosed)
+	}
+	if CircuitBreakerHalfOpen != 1 {
+		t.Errorf("CircuitBreakerHalfOpen should be 1, got %v", CircuitBreakerHalfOpen)
+	}
+	if CircuitBreakerOpen != 2 {
+		t.Errorf("CircuitBreakerOpen should be 2, got %v", CircuitBreakerOpen)
+	}
+}

--- a/services/operational-gateway/observability/tracing.go
+++ b/services/operational-gateway/observability/tracing.go
@@ -27,10 +27,11 @@ func StartSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (c
 
 // RecordError marks a span as having errored and records the error message.
 func RecordError(span trace.Span, err error) {
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
+	if err == nil || span == nil {
+		return
 	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, "error")
 }
 
 // Common attribute keys for operational gateway spans.

--- a/services/operational-gateway/observability/tracing.go
+++ b/services/operational-gateway/observability/tracing.go
@@ -1,0 +1,48 @@
+package observability
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const tracerName = "meridian/operational-gateway"
+
+// Tracer returns the OpenTelemetry tracer for the operational gateway service.
+func Tracer() trace.Tracer {
+	return otel.Tracer(tracerName)
+}
+
+// StartSpan creates a new internal span as a child of the span in the context.
+// The returned context contains the new span; callers must call span.End() when done.
+func StartSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	return Tracer().Start(ctx, name,
+		trace.WithAttributes(attrs...),
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+}
+
+// RecordError marks a span as having errored and records the error message.
+func RecordError(span trace.Span, err error) {
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+}
+
+// Common attribute keys for operational gateway spans.
+var (
+	AttrTenantID             = attribute.Key("gateway.tenant_id")
+	AttrInstructionID        = attribute.Key("gateway.instruction_id")
+	AttrInstructionType      = attribute.Key("gateway.instruction_type")
+	AttrInstructionStatus    = attribute.Key("gateway.instruction_status")
+	AttrProviderConnectionID = attribute.Key("gateway.provider_connection_id")
+	AttrProviderName         = attribute.Key("gateway.provider_name")
+	AttrAttemptCount         = attribute.Key("gateway.attempt_count")
+	AttrMaxAttempts          = attribute.Key("gateway.max_attempts")
+	AttrErrorCode            = attribute.Key("gateway.error_code")
+	AttrBatchSize            = attribute.Key("gateway.batch_size")
+)


### PR DESCRIPTION
## Summary

- Adds `services/operational-gateway/observability/metrics.go` with five Prometheus metrics covering instruction lifecycle, dispatch performance, circuit breaker state, and active instruction tracking
- Adds `services/operational-gateway/observability/tracing.go` with an OpenTelemetry tracer and span helpers following the pattern established in `services/reconciliation/observability/tracing.go`
- Adds `services/operational-gateway/observability/metrics_test.go` with full coverage of all metric recording functions

## Changes Made

### Prometheus Metrics (`metrics.go`)

| Metric | Type | Labels |
|--------|------|--------|
| `meridian_gateway_instructions_total` | Counter | `tenant`, `instruction_type`, `status` |
| `meridian_gateway_dispatch_duration_seconds` | Histogram | `tenant`, `provider` |
| `meridian_gateway_dispatch_attempts_total` | Counter | `tenant`, `provider`, `outcome` |
| `meridian_gateway_circuit_breaker_state` | Gauge | `tenant`, `connection_id`, `state` |
| `meridian_gateway_active_instructions` | Gauge | `tenant`, `status` |

Constants are provided for `DispatchOutcome*` and `CircuitBreaker*` values to enforce bounded label cardinality at the call site.

### OpenTelemetry Tracing (`tracing.go`)

- Tracer scoped to `meridian/operational-gateway`
- `StartSpan` helper creates internal child spans from context
- `RecordError` marks span as failed and sets error status
- Attribute keys for `tenant_id`, `instruction_id`, `instruction_type`, `instruction_status`, `provider_connection_id`, `provider_name`, `attempt_count`, `max_attempts`, `error_code`, `batch_size`

## Technical Details

The `circuitBreakerState` gauge uses a three-label pattern (`closed` / `half_open` / `open`) with mutual exclusion enforced by `RecordCircuitBreakerState`, which zeros the inactive labels before setting the active one. This avoids stale multi-state series in Prometheus while remaining queryable per state.

## Testing

- Unit tests verify counter increments, histogram recording, and gauge set/incr/decr
- `TestRecordCircuitBreakerState` asserts active label is 1 and both inactive labels are 0 after each state transition
- All tests use `prometheus/testutil` for metric introspection, matching the pattern in `services/current-account/observability/metrics_test.go`

## Risk Assessment

Low. New package with no changes to existing code. No integration with running components yet — call sites in the dispatch worker and service layer will be added separately.