### PR TITLE
feat(operational-gateway): Add instruction expiry worker

### DIFF
--- a/services/operational-gateway/adapters/persistence/instruction_repository.go
+++ b/services/operational-gateway/adapters/persistence/instruction_repository.go
@@ -292,7 +292,7 @@ func (r *InstructionRepository) FindExpired(ctx context.Context, batchSize int) 
 
 	var entities []InstructionEntity
 	err := r.db.WithContext(ctx).
-		Where("expires_at IS NOT NULL AND expires_at < ? AND status IN ?", time.Now(), []string{
+		Where("expires_at IS NOT NULL AND expires_at < ? AND status IN ?", gorm.Expr("NOW()"), []string{
 			string(domain.InstructionStatusPending),
 			string(domain.InstructionStatusRetrying),
 		}).

--- a/services/operational-gateway/adapters/persistence/instruction_repository.go
+++ b/services/operational-gateway/adapters/persistence/instruction_repository.go
@@ -260,6 +260,45 @@ func (r *InstructionRepository) ListByTenant(ctx context.Context, params ports.L
 	return results, total, nil
 }
 
+// FindExpired returns up to batchSize instructions whose expires_at has passed and whose
+// status is PENDING or RETRYING. Results are ordered by expires_at ASC so the oldest
+// expirations are processed first.
+func (r *InstructionRepository) FindExpired(ctx context.Context, batchSize int) ([]*domain.Instruction, error) {
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+
+	var entities []InstructionEntity
+	err := r.db.WithContext(ctx).
+		Where("expires_at IS NOT NULL AND expires_at < ? AND status IN ?", time.Now(), []string{
+			string(domain.InstructionStatusPending),
+			string(domain.InstructionStatusRetrying),
+		}).
+		Order("expires_at ASC").
+		Limit(batchSize).
+		Find(&entities).Error
+	if err != nil {
+		return nil, err
+	}
+	if len(entities) == 0 {
+		return nil, nil
+	}
+
+	results := make([]*domain.Instruction, 0, len(entities))
+	for i := range entities {
+		attempts, err := r.fetchAttempts(ctx, entities[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		inst, err := instructionFromEntity(&entities[i], attempts)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, inst)
+	}
+	return results, nil
+}
+
 // fetchAttempts loads instruction_attempts for a given instruction ID.
 func (r *InstructionRepository) fetchAttempts(ctx context.Context, instructionID uuid.UUID) ([]InstructionAttemptEntity, error) {
 	var attempts []InstructionAttemptEntity

--- a/services/operational-gateway/adapters/persistence/instruction_repository_test.go
+++ b/services/operational-gateway/adapters/persistence/instruction_repository_test.go
@@ -302,6 +302,121 @@ func TestInstructionRepository_RoundTrip_AllPriorities(t *testing.T) {
 	}
 }
 
+// TestInstructionRepository_FindExpired verifies that FindExpired returns only PENDING
+// and RETRYING instructions whose expires_at has passed, ordered by expires_at ASC.
+func TestInstructionRepository_FindExpired(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	tenantID := uuid.New()
+	connID := uuid.New()
+	insertTestConnection(t, db, tenantID, connID)
+
+	repo := NewInstructionRepository(db)
+
+	past1 := time.Now().Add(-2 * time.Minute)
+	past2 := time.Now().Add(-1 * time.Minute)
+	future := time.Now().Add(10 * time.Minute)
+
+	// expired PENDING - oldest (past1)
+	expiredPending1, err := domain.NewInstruction(
+		tenantID, "payment.initiate", connID.String(),
+		map[string]any{"amount": "10"},
+		domain.WithExpiresAt(past1),
+	)
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, expiredPending1, fmt.Sprintf("idem-%s", expiredPending1.ID)))
+
+	// expired PENDING - newer (past2)
+	expiredPending2, err := domain.NewInstruction(
+		tenantID, "payment.initiate", connID.String(),
+		map[string]any{"amount": "20"},
+		domain.WithExpiresAt(past2),
+	)
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, expiredPending2, fmt.Sprintf("idem-%s", expiredPending2.ID)))
+
+	// PENDING with future expiry - should NOT be returned
+	notYetExpired, err := domain.NewInstruction(
+		tenantID, "payment.initiate", connID.String(),
+		map[string]any{"amount": "30"},
+		domain.WithExpiresAt(future),
+	)
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, notYetExpired, fmt.Sprintf("idem-%s", notYetExpired.ID)))
+
+	// PENDING with no expiry - should NOT be returned
+	noExpiry := makeInstruction(t, tenantID, connID.String(), domain.PriorityNormal)
+	require.NoError(t, repo.Save(ctx, noExpiry, fmt.Sprintf("idem-%s", noExpiry.ID)))
+
+	// RETRYING with past expiry - should be returned
+	retryID := uuid.New()
+	require.NoError(t, db.Exec(`
+		INSERT INTO instructions
+			(id, tenant_id, instruction_type, provider_connection_id, payload, priority, status, expires_at, attempt_count, max_attempts, idempotency_key, version)
+		VALUES (?, ?, 'payment.initiate', ?, '{"amount":"40"}', 2, 'RETRYING', ?, 1, 3, ?, 1)
+	`, retryID, tenantID, connID, past2, fmt.Sprintf("idem-retry-%s", retryID)).Error)
+
+	// FAILED with past expiry - should NOT be returned (terminal)
+	failedID := uuid.New()
+	require.NoError(t, db.Exec(`
+		INSERT INTO instructions
+			(id, tenant_id, instruction_type, provider_connection_id, payload, priority, status, expires_at, attempt_count, max_attempts, idempotency_key, version, failure_reason, error_code)
+		VALUES (?, ?, 'payment.initiate', ?, '{"amount":"50"}', 2, 'FAILED', ?, 3, 3, ?, 1, 'some error', 'ERR')
+	`, failedID, tenantID, connID, past1, fmt.Sprintf("idem-failed-%s", failedID)).Error)
+
+	results, err := repo.FindExpired(ctx, 100)
+	require.NoError(t, err)
+	require.Len(t, results, 3) // expiredPending1, expiredPending2, retrying
+
+	// Results should be ordered by expires_at ASC.
+	assert.True(t, results[0].ExpiresAt.Before(*results[1].ExpiresAt) || results[0].ExpiresAt.Equal(*results[1].ExpiresAt))
+	assert.True(t, results[1].ExpiresAt.Before(*results[2].ExpiresAt) || results[1].ExpiresAt.Equal(*results[2].ExpiresAt))
+
+	// Verify all returned instructions are expirable.
+	for _, r := range results {
+		assert.Contains(t, []domain.InstructionStatus{
+			domain.InstructionStatusPending,
+			domain.InstructionStatusRetrying,
+		}, r.Status)
+	}
+}
+
+// TestInstructionRepository_FindExpired_LimitEnforced verifies the batchSize parameter.
+func TestInstructionRepository_FindExpired_LimitEnforced(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	tenantID := uuid.New()
+	connID := uuid.New()
+	insertTestConnection(t, db, tenantID, connID)
+
+	repo := NewInstructionRepository(db)
+
+	past := time.Now().Add(-1 * time.Minute)
+	for i := 0; i < 5; i++ {
+		inst, err := domain.NewInstruction(
+			tenantID, "payment.initiate", connID.String(),
+			map[string]any{"i": i},
+			domain.WithExpiresAt(past),
+		)
+		require.NoError(t, err)
+		require.NoError(t, repo.Save(ctx, inst, fmt.Sprintf("idem-%d-%s", i, inst.ID)))
+	}
+
+	results, err := repo.FindExpired(ctx, 3)
+	require.NoError(t, err)
+	assert.Len(t, results, 3)
+}
+
+// TestInstructionRepository_FindExpired_ReturnsNilWhenEmpty verifies empty result handling.
+func TestInstructionRepository_FindExpired_ReturnsNilWhenEmpty(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	repo := NewInstructionRepository(db)
+
+	results, err := repo.FindExpired(ctx, 100)
+	require.NoError(t, err)
+	assert.Nil(t, results)
+}
+
 // TestInstructionRepository_FetchDispatchable_RespectsNextRetryAt verifies that
 // RETRYING instructions with a future next_retry_at are not fetched until the backoff expires.
 func TestInstructionRepository_FetchDispatchable_RespectsNextRetryAt(t *testing.T) {

--- a/services/operational-gateway/ports/repositories.go
+++ b/services/operational-gateway/ports/repositories.go
@@ -72,6 +72,10 @@ type InstructionRepository interface {
 	// Instructions are returned ordered by priority DESC (CRITICAL first), then scheduled_at ASC.
 	// The caller must call Save to update instruction state after dispatch.
 	FetchDispatchable(ctx context.Context, params FetchDispatchableParams) ([]*domain.Instruction, error)
+
+	// FindExpired returns up to batchSize instructions whose expires_at has passed and
+	// whose status is PENDING or RETRYING (non-terminal, expirable states).
+	FindExpired(ctx context.Context, batchSize int) ([]*domain.Instruction, error)
 }
 
 // ConnectionRepository defines persistence operations for provider connections.

--- a/services/operational-gateway/service/grpc_service_test.go
+++ b/services/operational-gateway/service/grpc_service_test.go
@@ -108,6 +108,10 @@ func (m *mockInstructionRepo) FetchDispatchable(_ context.Context, _ ports.Fetch
 	return nil, nil
 }
 
+func (m *mockInstructionRepo) FindExpired(_ context.Context, _ int) ([]*domain.Instruction, error) {
+	return nil, nil
+}
+
 // mockConnectionRepo is an in-memory implementation of ports.ConnectionRepository for testing.
 type mockConnectionRepo struct {
 	mu          sync.RWMutex

--- a/services/operational-gateway/worker/dispatch_worker_test.go
+++ b/services/operational-gateway/worker/dispatch_worker_test.go
@@ -55,6 +55,10 @@ func (m *mockInstructionRepo) ListByTenant(_ context.Context, _ ports.ListInstru
 	return nil, 0, nil
 }
 
+func (m *mockInstructionRepo) FindExpired(_ context.Context, _ int) ([]*domain.Instruction, error) {
+	return nil, nil
+}
+
 func (m *mockInstructionRepo) getSavedInstructions() []*domain.Instruction {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/services/operational-gateway/worker/expiry_worker.go
+++ b/services/operational-gateway/worker/expiry_worker.go
@@ -1,0 +1,185 @@
+// Package worker contains background workers for the operational gateway service.
+package worker
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+)
+
+// Default configuration values for the expiry worker.
+const (
+	defaultExpiryScanInterval = 30 * time.Second
+	defaultExpiryBatchSize    = 100
+)
+
+// ExpiryWorkerConfig configures the expiry worker's scan behavior.
+type ExpiryWorkerConfig struct {
+	// ScanInterval is the duration between successive expiry scan cycles.
+	ScanInterval time.Duration
+	// BatchSize is the maximum number of expired instructions to process per scan cycle.
+	BatchSize int
+}
+
+// applyDefaults fills in zero-valued fields with sensible defaults.
+func (c *ExpiryWorkerConfig) applyDefaults() {
+	if c.ScanInterval <= 0 {
+		c.ScanInterval = defaultExpiryScanInterval
+	}
+	if c.BatchSize <= 0 {
+		c.BatchSize = defaultExpiryBatchSize
+	}
+}
+
+// ExpiryWorker periodically scans for instructions whose TTL has elapsed and transitions
+// them to EXPIRED status. It targets PENDING and RETRYING instructions with a non-null
+// expires_at in the past.
+//
+// ExpiryWorker is safe for concurrent use; multiple instances can run against the same
+// database because each instruction is updated with optimistic locking, so concurrent
+// workers will produce at most one EXPIRED transition per instruction.
+type ExpiryWorker struct {
+	instructionRepo ports.InstructionRepository
+	config          ExpiryWorkerConfig
+	logger          *slog.Logger
+	shutdown        chan struct{}
+	shutdownOnce    sync.Once
+	startOnce       sync.Once
+	wg              sync.WaitGroup
+}
+
+// NewExpiryWorker creates a new ExpiryWorker with the given dependencies and config.
+func NewExpiryWorker(
+	instructionRepo ports.InstructionRepository,
+	config ExpiryWorkerConfig,
+	logger *slog.Logger,
+) *ExpiryWorker {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	config.applyDefaults()
+
+	return &ExpiryWorker{
+		instructionRepo: instructionRepo,
+		config:          config,
+		logger:          logger.With("component", "expiry-worker"),
+		shutdown:        make(chan struct{}),
+	}
+}
+
+// Start begins the background scan loop. Returns immediately; the loop runs in a separate
+// goroutine until Stop is called or ctx is cancelled.
+// Calling Start more than once is a no-op.
+func (w *ExpiryWorker) Start(ctx context.Context) {
+	w.startOnce.Do(func() {
+		w.wg.Add(1)
+		go w.run(ctx)
+
+		w.logger.InfoContext(ctx, "expiry worker started",
+			"batch_size", w.config.BatchSize,
+			"scan_interval", w.config.ScanInterval,
+		)
+	})
+}
+
+// Stop signals the worker to shut down and blocks until the current scan completes.
+// Safe to call multiple times.
+func (w *ExpiryWorker) Stop() {
+	w.shutdownOnce.Do(func() {
+		w.logger.Info("expiry worker stopping")
+		close(w.shutdown)
+	})
+	w.wg.Wait()
+	w.logger.Info("expiry worker stopped")
+}
+
+// run is the main scan loop.
+func (w *ExpiryWorker) run(ctx context.Context) {
+	defer w.wg.Done()
+
+	ticker := time.NewTicker(w.config.ScanInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.InfoContext(ctx, "expiry worker context cancelled")
+			return
+		case <-w.shutdown:
+			w.logger.Info("expiry worker shutdown signal received")
+			return
+		case <-ticker.C:
+			w.scanAndExpire(ctx)
+		}
+	}
+}
+
+// scanAndExpire fetches a batch of expired instructions and transitions each to EXPIRED.
+func (w *ExpiryWorker) scanAndExpire(ctx context.Context) {
+	instructions, err := w.instructionRepo.FindExpired(ctx, w.config.BatchSize)
+	if err != nil {
+		w.logger.ErrorContext(ctx, "failed to find expired instructions", "error", err)
+		return
+	}
+	if len(instructions) == 0 {
+		return
+	}
+
+	w.logger.InfoContext(ctx, "processing expiry batch", "count", len(instructions))
+
+	var expired, skipped, failed int
+	for _, instr := range instructions {
+		if ctx.Err() != nil {
+			w.logger.InfoContext(ctx, "expiry batch interrupted by context cancellation",
+				"expired", expired,
+				"skipped", skipped,
+				"failed", failed,
+				"remaining", len(instructions)-expired-skipped-failed,
+			)
+			return
+		}
+
+		if instr.IsTerminal() {
+			// The instruction reached a terminal state between the query and now.
+			skipped++
+			continue
+		}
+
+		if err := instr.MarkExpired(); err != nil {
+			w.logger.ErrorContext(ctx, "failed to mark instruction expired",
+				"instruction_id", instr.ID,
+				"status", instr.Status,
+				"error", err,
+			)
+			failed++
+			continue
+		}
+
+		if err := w.instructionRepo.Save(ctx, instr, ""); err != nil {
+			w.logger.ErrorContext(ctx, "failed to save expired instruction",
+				"instruction_id", instr.ID,
+				"error", err,
+			)
+			failed++
+			continue
+		}
+
+		w.logger.InfoContext(ctx, "instruction expired",
+			"instruction_id", instr.ID,
+			"tenant_id", instr.TenantID,
+			"instruction_type", instr.InstructionType,
+			"expires_at", instr.ExpiresAt,
+		)
+		expired++
+	}
+
+	w.logger.InfoContext(ctx, "expiry batch completed",
+		"expired", expired,
+		"skipped", skipped,
+		"failed", failed,
+		"total", len(instructions),
+	)
+}

--- a/services/operational-gateway/worker/expiry_worker_test.go
+++ b/services/operational-gateway/worker/expiry_worker_test.go
@@ -1,0 +1,329 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Helpers ---
+
+// expiredInstruction creates a PENDING instruction with an expires_at in the past.
+func expiredInstruction() *domain.Instruction {
+	past := time.Now().Add(-1 * time.Minute)
+	return &domain.Instruction{
+		ID:                   uuid.New(),
+		TenantID:             testTenantID(),
+		InstructionType:      "payment.initiate",
+		ProviderConnectionID: "conn-123",
+		Payload:              map[string]any{"amount": "100.00"},
+		Priority:             domain.PriorityNormal,
+		Status:               domain.InstructionStatusPending,
+		ExpiresAt:            &past,
+		MaxAttempts:          3,
+		AttemptCount:         0,
+		Attempts:             []domain.InstructionAttempt{},
+		Version:              1,
+		CreatedAt:            time.Now().Add(-2 * time.Minute),
+		UpdatedAt:            time.Now().Add(-2 * time.Minute),
+	}
+}
+
+// retryingExpiredInstruction creates a RETRYING instruction with an expires_at in the past.
+func retryingExpiredInstruction() *domain.Instruction {
+	instr := expiredInstruction()
+	instr.Status = domain.InstructionStatusRetrying
+	instr.AttemptCount = 1
+	return instr
+}
+
+// mockExpiryRepo is a minimal mock satisfying ports.InstructionRepository for expiry worker tests.
+type mockExpiryRepo struct {
+	mockInstructionRepo
+	findExpired      func(ctx context.Context, batchSize int) ([]*domain.Instruction, error)
+	findExpiredCalls int
+}
+
+func (m *mockExpiryRepo) FindExpired(ctx context.Context, batchSize int) ([]*domain.Instruction, error) {
+	m.mu.Lock()
+	m.findExpiredCalls++
+	m.mu.Unlock()
+	if m.findExpired != nil {
+		return m.findExpired(ctx, batchSize)
+	}
+	return nil, nil
+}
+
+func (m *mockExpiryRepo) getFindExpiredCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.findExpiredCalls
+}
+
+// --- Tests ---
+
+func TestNewExpiryWorker_AppliesDefaults(t *testing.T) {
+	repo := &mockExpiryRepo{}
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{}, nil)
+
+	assert.Equal(t, defaultExpiryScanInterval, w.config.ScanInterval)
+	assert.Equal(t, defaultExpiryBatchSize, w.config.BatchSize)
+	assert.NotNil(t, w.logger)
+}
+
+func TestNewExpiryWorker_RespectsCustomConfig(t *testing.T) {
+	repo := &mockExpiryRepo{}
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{
+		ScanInterval: 10 * time.Second,
+		BatchSize:    50,
+	}, nil)
+
+	assert.Equal(t, 10*time.Second, w.config.ScanInterval)
+	assert.Equal(t, 50, w.config.BatchSize)
+}
+
+func TestExpiryWorker_StartAndStop(t *testing.T) {
+	repo := &mockExpiryRepo{}
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{ScanInterval: 50 * time.Millisecond}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w.Start(ctx)
+
+	// Wait for at least one scan cycle.
+	err := await.AtMost(2 * time.Second).PollInterval(20 * time.Millisecond).Until(func() bool {
+		return repo.getFindExpiredCalls() >= 1
+	})
+	require.NoError(t, err)
+
+	w.Stop()
+
+	// Idempotent Stop.
+	w.Stop()
+}
+
+func TestExpiryWorker_StartIdempotent(t *testing.T) {
+	repo := &mockExpiryRepo{}
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{ScanInterval: 50 * time.Millisecond}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w.Start(ctx)
+	w.Start(ctx) // second call is a no-op
+
+	err := await.AtMost(2 * time.Second).PollInterval(20 * time.Millisecond).Until(func() bool {
+		return repo.getFindExpiredCalls() >= 1
+	})
+	require.NoError(t, err)
+
+	w.Stop()
+}
+
+func TestExpiryWorker_StopsOnContextCancel(t *testing.T) {
+	repo := &mockExpiryRepo{}
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{ScanInterval: 50 * time.Millisecond}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w.Start(ctx)
+
+	err := await.AtMost(2 * time.Second).PollInterval(20 * time.Millisecond).Until(func() bool {
+		return repo.getFindExpiredCalls() >= 1
+	})
+	require.NoError(t, err)
+
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		w.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not stop after context cancellation")
+	}
+}
+
+func TestScanAndExpire_ExpiresInstructions(t *testing.T) {
+	instr := expiredInstruction()
+
+	repo := &mockExpiryRepo{
+		findExpired: func(_ context.Context, _ int) ([]*domain.Instruction, error) {
+			return []*domain.Instruction{instr}, nil
+		},
+	}
+
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{}, nil)
+	w.scanAndExpire(context.Background())
+
+	saved := repo.getSavedInstructions()
+	require.Len(t, saved, 1)
+	assert.Equal(t, domain.InstructionStatusExpired, saved[0].Status)
+	assert.NotNil(t, saved[0].CompletedAt)
+}
+
+func TestScanAndExpire_ExpiresRetryingInstructions(t *testing.T) {
+	instr := retryingExpiredInstruction()
+
+	repo := &mockExpiryRepo{
+		findExpired: func(_ context.Context, _ int) ([]*domain.Instruction, error) {
+			return []*domain.Instruction{instr}, nil
+		},
+	}
+
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{}, nil)
+	w.scanAndExpire(context.Background())
+
+	saved := repo.getSavedInstructions()
+	require.Len(t, saved, 1)
+	assert.Equal(t, domain.InstructionStatusExpired, saved[0].Status)
+}
+
+func TestScanAndExpire_SkipsTerminalInstructions(t *testing.T) {
+	// Simulate an instruction that reached FAILED between query and processing.
+	instr := expiredInstruction()
+	instr.Status = domain.InstructionStatusFailed
+	instr.FailureReason = "some error"
+	instr.ErrorCode = "SOME_ERROR"
+
+	repo := &mockExpiryRepo{
+		findExpired: func(_ context.Context, _ int) ([]*domain.Instruction, error) {
+			return []*domain.Instruction{instr}, nil
+		},
+	}
+
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{}, nil)
+	w.scanAndExpire(context.Background())
+
+	// Nothing saved — skipped because already terminal.
+	assert.Equal(t, 0, repo.getSaveCalls())
+}
+
+func TestScanAndExpire_SkipsAlreadyExpired(t *testing.T) {
+	instr := expiredInstruction()
+	instr.Status = domain.InstructionStatusExpired
+
+	repo := &mockExpiryRepo{
+		findExpired: func(_ context.Context, _ int) ([]*domain.Instruction, error) {
+			return []*domain.Instruction{instr}, nil
+		},
+	}
+
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{}, nil)
+	w.scanAndExpire(context.Background())
+
+	assert.Equal(t, 0, repo.getSaveCalls())
+}
+
+func TestScanAndExpire_EmptyBatch_NoOp(t *testing.T) {
+	repo := &mockExpiryRepo{
+		findExpired: func(_ context.Context, _ int) ([]*domain.Instruction, error) {
+			return nil, nil
+		},
+	}
+
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{}, nil)
+	w.scanAndExpire(context.Background())
+
+	assert.Equal(t, 0, repo.getSaveCalls())
+}
+
+func TestScanAndExpire_FindExpiredError_DoesNotPanic(t *testing.T) {
+	repo := &mockExpiryRepo{
+		findExpired: func(_ context.Context, _ int) ([]*domain.Instruction, error) {
+			return nil, errors.New("db connection lost")
+		},
+	}
+
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{}, nil)
+	// Should not panic.
+	w.scanAndExpire(context.Background())
+	assert.Equal(t, 0, repo.getSaveCalls())
+}
+
+func TestScanAndExpire_SaveError_ContinuesProcessingRemainder(t *testing.T) {
+	instr1 := expiredInstruction()
+	instr2 := expiredInstruction()
+
+	saveCount := 0
+	repo := &mockExpiryRepo{
+		findExpired: func(_ context.Context, _ int) ([]*domain.Instruction, error) {
+			return []*domain.Instruction{instr1, instr2}, nil
+		},
+	}
+	// Override save to fail on first call, succeed on second.
+	repo.save = func(_ context.Context, _ *domain.Instruction, _ string) error {
+		saveCount++
+		if saveCount == 1 {
+			return errors.New("transient write error")
+		}
+		return nil
+	}
+
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{}, nil)
+	w.scanAndExpire(context.Background())
+
+	// Both instructions attempted; first save failed but second succeeded.
+	assert.Equal(t, 2, saveCount)
+}
+
+func TestScanAndExpire_PassesBatchSizeToFindExpired(t *testing.T) {
+	var capturedBatchSize int
+	repo := &mockExpiryRepo{
+		findExpired: func(_ context.Context, batchSize int) ([]*domain.Instruction, error) {
+			capturedBatchSize = batchSize
+			return nil, nil
+		},
+	}
+
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{
+		BatchSize:    42,
+		ScanInterval: 50 * time.Millisecond,
+	}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w.Start(ctx)
+
+	err := await.AtMost(2 * time.Second).PollInterval(20 * time.Millisecond).Until(func() bool {
+		return repo.getFindExpiredCalls() >= 1
+	})
+	require.NoError(t, err)
+
+	w.Stop()
+	assert.Equal(t, 42, capturedBatchSize)
+}
+
+func TestScanAndExpire_ProcessesMultipleInstructions(t *testing.T) {
+	instr1 := expiredInstruction()
+	instr2 := retryingExpiredInstruction()
+	instr3 := expiredInstruction()
+
+	repo := &mockExpiryRepo{
+		findExpired: func(_ context.Context, _ int) ([]*domain.Instruction, error) {
+			return []*domain.Instruction{instr1, instr2, instr3}, nil
+		},
+	}
+
+	w := NewExpiryWorker(repo, ExpiryWorkerConfig{}, nil)
+	w.scanAndExpire(context.Background())
+
+	saved := repo.getSavedInstructions()
+	require.Len(t, saved, 3)
+	for _, s := range saved {
+		assert.Equal(t, domain.InstructionStatusExpired, s.Status)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `ExpiryWorker`, a background worker that periodically scans for instructions whose TTL has elapsed and transitions them to `EXPIRED` status
- Adds `FindExpired` to `InstructionRepository` port and its CockroachDB GORM implementation
- Follows the exact `DispatchWorker` pattern: `Start`/`Stop` lifecycle with `sync.Once` + `WaitGroup`, ticker loop, batch scanning

## Worker Behavior

`ExpiryWorker` runs on a configurable interval (default 30s) and:
1. Calls `FindExpired(ctx, batchSize)` to fetch PENDING/RETRYING instructions with `expires_at < NOW()`
2. For each instruction, calls `instr.MarkExpired()` (skips already-terminal instructions gracefully)
3. Persists via `Save` with optimistic locking — concurrent workers produce at most one EXPIRED transition per instruction
4. Logs each expiry with `instruction_id`, `tenant_id`, `instruction_type`, and `expires_at`

## Configuration

```go
ExpiryWorkerConfig{
    ScanInterval: 30 * time.Second, // default
    BatchSize:    100,               // default
}
```

## Changes Made

| File | Change |
|------|--------|
| `ports/repositories.go` | Added `FindExpired(ctx, batchSize) ([]*Instruction, error)` to `InstructionRepository` interface |
| `adapters/persistence/instruction_repository.go` | Implemented `FindExpired` using GORM query: `expires_at IS NOT NULL AND expires_at < NOW() AND status IN (PENDING, RETRYING)`, ordered by `expires_at ASC` |
| `adapters/persistence/instruction_repository_test.go` | 3 integration tests against CockroachDB testcontainer |
| `worker/expiry_worker.go` | `ExpiryWorker` implementation |
| `worker/expiry_worker_test.go` | 11 unit tests |
| `worker/dispatch_worker_test.go` | Added `FindExpired` stub to existing mock to satisfy updated interface |

## Testing

- **11 unit tests** covering: defaults/config, Start/Stop lifecycle, idempotent Start, context cancellation, batch expiry (PENDING + RETRYING), terminal-state skip, empty batch no-op, fetch error resilience, save error continues remainder, batch size propagation, multiple instructions
- **3 integration tests** against CockroachDB: ordering by expires_at ASC, limit enforcement, empty result handling