### PR TITLE
feat(operational-gateway): Add service entrypoint and dependency wiring

### DIFF
--- a/services/operational-gateway/adapters/persistence/route_resolver.go
+++ b/services/operational-gateway/adapters/persistence/route_resolver.go
@@ -1,0 +1,35 @@
+package persistence
+
+import (
+	"context"
+
+	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+)
+
+// DBRouteResolver implements ports.RouteResolver by looking up routes from the database
+// via RouteRepository.
+type DBRouteResolver struct {
+	routeRepo ports.RouteRepository
+}
+
+// NewDBRouteResolver creates a new DBRouteResolver backed by the given RouteRepository.
+func NewDBRouteResolver(routeRepo ports.RouteRepository) *DBRouteResolver {
+	return &DBRouteResolver{routeRepo: routeRepo}
+}
+
+// Resolve looks up the InstructionRoute for the given tenant and instruction type.
+// Returns ports.ErrRouteNotFound if no matching route is configured.
+func (r *DBRouteResolver) Resolve(ctx context.Context, tenantID string, instructionType string) (*ports.InstructionRoute, error) {
+	route, err := r.routeRepo.FindByInstructionType(ctx, tenantID, instructionType)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ports.InstructionRoute{
+		InstructionType: route.InstructionType,
+		HTTPMethod:      route.HTTPMethod,
+		PathTemplate:    route.PathTemplate,
+		OutboundMapping: route.OutboundMapping,
+		InboundMapping:  route.InboundMapping,
+	}, nil
+}

--- a/services/operational-gateway/cmd/main.go
+++ b/services/operational-gateway/cmd/main.go
@@ -64,7 +64,8 @@ func main() {
 }
 
 func run(logger *slog.Logger) error {
-	ctx := context.Background()
+	ctx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
 	cfg := config.LoadConfig()
 
 	// Initialize OpenTelemetry tracer.
@@ -176,16 +177,16 @@ func run(logger *slog.Logger) error {
 		logger,
 	)
 
-	// Start background workers.
-	dispatchWorker.Start(ctx)
-	expiryWorker.Start(ctx)
-
-	// Create listener.
+	// Create listener before starting workers to fail fast if the port is unavailable.
 	address := fmt.Sprintf(":%s", cfg.GRPCPort)
 	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", address)
 	if err != nil {
 		return fmt.Errorf("failed to listen on %s: %w", address, err)
 	}
+
+	// Start background workers after listener is ready.
+	dispatchWorker.Start(ctx)
+	expiryWorker.Start(ctx)
 
 	// Start gRPC server in background.
 	serverErrors := make(chan error, 1)
@@ -210,7 +211,7 @@ func run(logger *slog.Logger) error {
 	})
 
 	orchestrator.AddCleanup(func() error {
-		bootstrap.CloseDatabase(db, logger)
+		runCancel()
 		return nil
 	})
 

--- a/services/operational-gateway/cmd/main.go
+++ b/services/operational-gateway/cmd/main.go
@@ -1,0 +1,241 @@
+// Package main is the entry point for the operational-gateway standalone binary.
+//
+// It wires all operational-gateway components: gRPC services, background workers,
+// repositories, and event publishing. The binary can be run standalone or integrated
+// into the unified Meridian binary.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"strings"
+
+	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	"github.com/meridianhub/meridian/services/operational-gateway/adapters/httpadapter"
+	"github.com/meridianhub/meridian/services/operational-gateway/adapters/messaging"
+	"github.com/meridianhub/meridian/services/operational-gateway/adapters/passthrough"
+	"github.com/meridianhub/meridian/services/operational-gateway/adapters/persistence"
+	"github.com/meridianhub/meridian/services/operational-gateway/adapters/secrets"
+	"github.com/meridianhub/meridian/services/operational-gateway/config"
+	"github.com/meridianhub/meridian/services/operational-gateway/service"
+	"github.com/meridianhub/meridian/services/operational-gateway/worker"
+	"github.com/meridianhub/meridian/shared/platform/bootstrap"
+	"github.com/meridianhub/meridian/shared/platform/events"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+)
+
+// ErrMissingDatabaseURL is returned when the DATABASE_URL environment variable is not set.
+var ErrMissingDatabaseURL = errors.New("DATABASE_URL is required")
+
+// Build information set via ldflags during compilation.
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)
+
+func main() {
+	logLevel := parseLogLevel(os.Getenv("LOG_LEVEL"))
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevel,
+	}))
+	slog.SetDefault(logger)
+
+	logger.Info("starting operational-gateway service",
+		"version", Version,
+		"commit", Commit,
+		"build_date", BuildDate)
+
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("service stopped gracefully")
+}
+
+func run(logger *slog.Logger) error {
+	ctx := context.Background()
+	cfg := config.LoadConfig()
+
+	// Initialize OpenTelemetry tracer.
+	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
+		ServiceName:    "operational-gateway-service",
+		ServiceVersion: Version,
+		Logger:         logger,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize tracer: %w", err)
+	}
+	defer bootstrap.ShutdownTracer(tracer, logger)
+
+	// Initialize database connection.
+	if cfg.DatabaseURL == "" {
+		return bootstrap.Permanent(ErrMissingDatabaseURL)
+	}
+
+	dbCfg := bootstrap.DefaultDatabaseConfig()
+	dbCfg.DSN = cfg.DatabaseURL
+	dbCfg.Logger = logger
+
+	db, err := bootstrap.NewDatabase(ctx, dbCfg)
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+	defer bootstrap.CloseDatabase(db, logger)
+
+	logger.Info("database connection established")
+
+	// Initialize repositories.
+	instructionRepo := persistence.NewInstructionRepository(db)
+	connectionRepo := persistence.NewConnectionRepository(db)
+	routeRepo := persistence.NewRouteRepository(db)
+
+	// Initialize event publishing (outbox pattern).
+	outboxPublisher := events.NewOutboxPublisher("operational-gateway")
+	eventPublisher := messaging.NewInstructionEventPublisher(outboxPublisher)
+
+	// Initialize auth interceptor.
+	authConfig := bootstrap.DefaultAuthConfig(logger)
+	authInterceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth: %w", err)
+	}
+
+	// Create gRPC server.
+	grpcServer := bootstrap.NewGrpcServerBuilder(tracer, logger).
+		WithAuthInterceptor(authInterceptor).
+		Build()
+
+	// Initialize and register OperationalGatewayService.
+	gatewaySvc, err := service.NewOperationalGatewayService(instructionRepo, connectionRepo, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create gateway service: %w", err)
+	}
+	gatewaySvc.WithEventPublishing(db, instructionRepo, eventPublisher)
+	opgatewayv1.RegisterOperationalGatewayServiceServer(grpcServer, gatewaySvc)
+
+	// Initialize and register ProviderConnectionService.
+	connectionSvc, err := service.NewProviderConnectionService(connectionRepo, instructionRepo, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create connection service: %w", err)
+	}
+	opgatewayv1.RegisterProviderConnectionServiceServer(grpcServer, connectionSvc)
+
+	// Initialize and register InstructionRouteService.
+	routeSvc, err := service.NewInstructionRouteService(routeRepo, connectionRepo, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create route service: %w", err)
+	}
+	opgatewayv1.RegisterInstructionRouteServiceServer(grpcServer, routeSvc)
+
+	// Register health check.
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
+
+	// Register reflection for debugging.
+	reflection.Register(grpcServer)
+
+	logger.Info("gRPC services registered")
+
+	// Initialize dispatch worker dependencies.
+	routeResolver := persistence.NewDBRouteResolver(routeRepo)
+	secretStore := secrets.NewEnvSecretStore(&identitySlugResolver{})
+	transformer := passthrough.NewTransformer()
+	dispatcher := httpadapter.NewHTTPDispatcher(secretStore, transformer, logger)
+
+	dispatchWorker := worker.NewDispatchWorker(
+		instructionRepo,
+		connectionRepo,
+		routeResolver,
+		dispatcher,
+		worker.DispatchWorkerConfig{
+			BatchSize:    cfg.DispatchWorker.BatchSize,
+			PollInterval: cfg.DispatchWorker.PollInterval,
+		},
+		logger,
+	)
+
+	// Initialize expiry worker.
+	expiryWorker := worker.NewExpiryWorker(
+		instructionRepo,
+		worker.ExpiryWorkerConfig{
+			ScanInterval: cfg.ExpiryWorker.ScanInterval,
+			BatchSize:    cfg.ExpiryWorker.BatchSize,
+		},
+		logger,
+	)
+
+	// Start background workers.
+	dispatchWorker.Start(ctx)
+	expiryWorker.Start(ctx)
+
+	// Create listener.
+	address := fmt.Sprintf(":%s", cfg.GRPCPort)
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", address)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", address, err)
+	}
+
+	// Start gRPC server in background.
+	serverErrors := make(chan error, 1)
+	go func() {
+		logger.Info("starting gRPC server", "address", address)
+		if err := grpcServer.Serve(listener); err != nil {
+			serverErrors <- err
+		}
+	}()
+
+	// Wait for shutdown signal.
+	orchestrator := bootstrap.NewShutdownOrchestrator(grpcServer, logger)
+
+	orchestrator.AddCleanup(func() error {
+		dispatchWorker.Stop()
+		return nil
+	})
+
+	orchestrator.AddCleanup(func() error {
+		expiryWorker.Stop()
+		return nil
+	})
+
+	orchestrator.AddCleanup(func() error {
+		bootstrap.CloseDatabase(db, logger)
+		return nil
+	})
+
+	return orchestrator.Wait(serverErrors)
+}
+
+// identitySlugResolver is a TenantSlugResolver that returns the tenant ID as-is.
+// This is suitable for environments where tenant IDs are already usable as slugs
+// or where the env-based secret naming convention uses tenant IDs directly.
+type identitySlugResolver struct{}
+
+func (r *identitySlugResolver) GetSlug(_ context.Context, tenantID string) (string, error) {
+	return tenantID, nil
+}
+
+// parseLogLevel converts a string log level to slog.Level.
+func parseLogLevel(levelStr string) slog.Level {
+	switch strings.ToLower(levelStr) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/services/operational-gateway/config/config.go
+++ b/services/operational-gateway/config/config.go
@@ -1,0 +1,61 @@
+// Package config provides configuration loading for the operational-gateway service.
+package config
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/env"
+	"github.com/meridianhub/meridian/shared/platform/ports"
+)
+
+// Config holds the operational-gateway service configuration.
+type Config struct {
+	// GRPCPort is the gRPC listen port.
+	GRPCPort string
+
+	// DatabaseURL is the CockroachDB/PostgreSQL connection string.
+	DatabaseURL string
+
+	// LogLevel controls the log verbosity (debug, info, warn, error).
+	LogLevel string
+
+	// DispatchWorker configures the background dispatch worker.
+	DispatchWorker DispatchWorkerConfig
+
+	// ExpiryWorker configures the background expiry worker.
+	ExpiryWorker ExpiryWorkerConfig
+}
+
+// DispatchWorkerConfig configures the dispatch worker.
+type DispatchWorkerConfig struct {
+	// BatchSize is the maximum number of instructions to claim per poll cycle.
+	BatchSize int
+	// PollInterval is the duration between successive poll cycles.
+	PollInterval time.Duration
+}
+
+// ExpiryWorkerConfig configures the expiry worker.
+type ExpiryWorkerConfig struct {
+	// ScanInterval is the duration between successive expiry scan cycles.
+	ScanInterval time.Duration
+	// BatchSize is the maximum number of expired instructions to process per scan.
+	BatchSize int
+}
+
+// LoadConfig loads configuration from environment variables with sensible defaults.
+func LoadConfig() Config {
+	return Config{
+		GRPCPort:    env.GetEnvOrDefault("GRPC_PORT", strconv.Itoa(ports.OperationalGateway)),
+		DatabaseURL: env.GetEnvOrDefault("DATABASE_URL", ""),
+		LogLevel:    env.GetEnvOrDefault("LOG_LEVEL", "info"),
+		DispatchWorker: DispatchWorkerConfig{
+			BatchSize:    env.GetEnvAsInt("DISPATCH_WORKER_BATCH_SIZE", 50),
+			PollInterval: env.GetEnvAsDuration("DISPATCH_WORKER_POLL_INTERVAL", 1*time.Second),
+		},
+		ExpiryWorker: ExpiryWorkerConfig{
+			ScanInterval: env.GetEnvAsDuration("EXPIRY_WORKER_SCAN_INTERVAL", 30*time.Second),
+			BatchSize:    env.GetEnvAsInt("EXPIRY_WORKER_BATCH_SIZE", 100),
+		},
+	}
+}

--- a/shared/platform/ports/ports.go
+++ b/shared/platform/ports/ports.go
@@ -124,6 +124,12 @@ const (
 	// Protocol: gRPC (internal)
 	// Visibility: Cluster-internal only
 	ControlPlane = 50062
+
+	// OperationalGateway is the gRPC port for the Operational Gateway service.
+	// Manages outbound instruction dispatch, provider connections, and routing.
+	// Protocol: gRPC (internal)
+	// Visibility: Cluster-internal only
+	OperationalGateway = 50063
 )
 
 // HTTP service ports (various protocols).


### PR DESCRIPTION
## Summary

- Add standalone binary entrypoint (`services/operational-gateway/cmd/main.go`) with full dependency injection wiring for all operational-gateway components
- Create config package (`services/operational-gateway/config/config.go`) loading from environment variables with sensible defaults
- Add `DBRouteResolver` adapter (`services/operational-gateway/adapters/persistence/route_resolver.go`) bridging `RouteRepository` to the `RouteResolver` port interface
- Register `OperationalGateway` port constant (50063) in `shared/platform/ports`

### Components wired

| Component | Description |
|-----------|-------------|
| gRPC services | OperationalGatewayService, ProviderConnectionService, InstructionRouteService |
| Background workers | DispatchWorker (polls for dispatchable instructions), ExpiryWorker (expires TTL'd instructions) |
| Event publishing | Outbox-based InstructionEventPublisher for instruction lifecycle events |
| Auth | JWT auth via bootstrap interceptor chain (tracing, auth, recovery) |
| Observability | OpenTelemetry tracer, health check, gRPC reflection |
| Graceful shutdown | ShutdownOrchestrator with worker stop, database close in LIFO order |

### Configuration (env vars)

| Variable | Default | Description |
|----------|---------|-------------|
| `GRPC_PORT` | `50063` | gRPC listen port |
| `DATABASE_URL` | (required) | CockroachDB connection string |
| `LOG_LEVEL` | `info` | Log verbosity |
| `DISPATCH_WORKER_BATCH_SIZE` | `50` | Instructions per dispatch poll |
| `DISPATCH_WORKER_POLL_INTERVAL` | `1s` | Dispatch poll interval |
| `EXPIRY_WORKER_SCAN_INTERVAL` | `30s` | Expiry scan interval |
| `EXPIRY_WORKER_BATCH_SIZE` | `100` | Instructions per expiry scan |

## Test plan

- [x] `go build ./...` passes (full project)
- [x] `go vet ./services/operational-gateway/...` clean
- [x] All pre-commit checks pass (gitleaks, gofumpt, golangci-lint)
- [ ] CI passes