### PR TITLE
feat(identity): add identity domain model

### DIFF
--- a/services/identity/domain/errors.go
+++ b/services/identity/domain/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrInvitationExpired           = errors.New("invitation has expired")
 	ErrInvitationAlreadyAccepted   = errors.New("invitation has already been accepted")
 	ErrRoleAlreadyRevoked          = errors.New("role assignment has already been revoked")
+	ErrInvitationNotFound          = errors.New("invitation not found")
 	ErrInvalidEmail                = errors.New("invalid email address")
 	ErrPasswordHashEmpty           = errors.New("password hash must not be empty")
 	ErrExternalIDPEmpty            = errors.New("external IDP provider and subject must not be empty")

--- a/services/identity/domain/errors.go
+++ b/services/identity/domain/errors.go
@@ -1,0 +1,20 @@
+// Package domain contains the core business logic for identity and access management.
+package domain
+
+import "errors"
+
+// Domain errors
+var (
+	ErrIdentityNotFound            = errors.New("identity not found")
+	ErrEmailAlreadyExists          = errors.New("email already exists")
+	ErrInvalidStatusTransition     = errors.New("invalid status transition")
+	ErrAccountLocked               = errors.New("account is locked")
+	ErrInvitationExpired           = errors.New("invitation has expired")
+	ErrInvitationAlreadyAccepted   = errors.New("invitation has already been accepted")
+	ErrRoleAlreadyRevoked          = errors.New("role assignment has already been revoked")
+	ErrInvalidEmail                = errors.New("invalid email address")
+	ErrPasswordHashEmpty           = errors.New("password hash must not be empty")
+	ErrExternalIDPEmpty            = errors.New("external IDP provider and subject must not be empty")
+	ErrInvalidRole                 = errors.New("invalid role")
+	ErrInsufficientRolePermissions = errors.New("insufficient permissions to grant this role")
+)

--- a/services/identity/domain/identity.go
+++ b/services/identity/domain/identity.go
@@ -206,7 +206,20 @@ func (i *Identity) Unlock() error {
 // RecordLoginAttempt records a login attempt result. On success it resets the
 // failed attempts counter. On failure it increments the counter and locks the
 // account when the threshold is reached.
+// Returns ErrAccountLocked if the identity is already locked, and
+// ErrInvalidStatusTransition if the identity is not in ACTIVE status.
 func (i *Identity) RecordLoginAttempt(success bool) error {
+	switch i.status {
+	case IdentityStatusLocked:
+		return ErrAccountLocked
+	case IdentityStatusPendingInvite, IdentityStatusSuspended:
+		return ErrInvalidStatusTransition
+	case IdentityStatusActive:
+		// valid — proceed below
+	default:
+		return ErrInvalidStatusTransition
+	}
+
 	if success {
 		i.failedAttempts = 0
 		i.updatedAt = time.Now()

--- a/services/identity/domain/identity.go
+++ b/services/identity/domain/identity.go
@@ -1,0 +1,249 @@
+package domain
+
+import (
+	"regexp"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// IdentityStatus represents the lifecycle state of an identity
+type IdentityStatus string
+
+// Identity status constants
+const (
+	IdentityStatusPendingInvite IdentityStatus = "PENDING_INVITE"
+	IdentityStatusActive        IdentityStatus = "ACTIVE"
+	IdentityStatusSuspended     IdentityStatus = "SUSPENDED"
+	IdentityStatusLocked        IdentityStatus = "LOCKED"
+)
+
+// maxFailedAttempts is the number of consecutive failed login attempts before lockout.
+const maxFailedAttempts = 5
+
+// emailRegex is a basic email validation pattern.
+var emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
+
+// Identity represents a platform identity (user account) within a tenant.
+//
+// The Version field implements optimistic concurrency control to prevent lost updates.
+// The persistence layer should use this field in UPDATE statements to detect conflicts.
+type Identity struct {
+	id             uuid.UUID
+	email          string
+	status         IdentityStatus
+	passwordHash   string
+	externalIDP    string
+	externalSub    string
+	failedAttempts int
+	createdAt      time.Time
+	updatedAt      time.Time
+	version        int64
+}
+
+// NewIdentity creates a new identity in PENDING_INVITE status.
+func NewIdentity(email string) (*Identity, error) {
+	if !emailRegex.MatchString(email) {
+		return nil, ErrInvalidEmail
+	}
+
+	now := time.Now()
+	return &Identity{
+		id:        uuid.New(),
+		email:     email,
+		status:    IdentityStatusPendingInvite,
+		createdAt: now,
+		updatedAt: now,
+		version:   1,
+	}, nil
+}
+
+// ReconstructIdentity recreates an Identity from persistence layer data.
+// This should only be used by repositories when loading from the database.
+func ReconstructIdentity(
+	id uuid.UUID,
+	email string,
+	status IdentityStatus,
+	passwordHash string,
+	externalIDP string,
+	externalSub string,
+	failedAttempts int,
+	createdAt time.Time,
+	updatedAt time.Time,
+	version int64,
+) *Identity {
+	return &Identity{
+		id:             id,
+		email:          email,
+		status:         status,
+		passwordHash:   passwordHash,
+		externalIDP:    externalIDP,
+		externalSub:    externalSub,
+		failedAttempts: failedAttempts,
+		createdAt:      createdAt,
+		updatedAt:      updatedAt,
+		version:        version,
+	}
+}
+
+// ID returns the identity's unique identifier.
+func (i *Identity) ID() uuid.UUID {
+	return i.id
+}
+
+// Email returns the identity's email address.
+func (i *Identity) Email() string {
+	return i.email
+}
+
+// Status returns the identity's current lifecycle status.
+func (i *Identity) Status() IdentityStatus {
+	return i.status
+}
+
+// PasswordHash returns the stored bcrypt password hash.
+func (i *Identity) PasswordHash() string {
+	return i.passwordHash
+}
+
+// ExternalIDP returns the external identity provider name (e.g., "google").
+func (i *Identity) ExternalIDP() string {
+	return i.externalIDP
+}
+
+// ExternalSub returns the subject identifier from the external IDP.
+func (i *Identity) ExternalSub() string {
+	return i.externalSub
+}
+
+// FailedAttempts returns the count of consecutive failed login attempts.
+func (i *Identity) FailedAttempts() int {
+	return i.failedAttempts
+}
+
+// CreatedAt returns when the identity was created.
+func (i *Identity) CreatedAt() time.Time {
+	return i.createdAt
+}
+
+// UpdatedAt returns when the identity was last updated.
+func (i *Identity) UpdatedAt() time.Time {
+	return i.updatedAt
+}
+
+// Version returns the optimistic locking version.
+func (i *Identity) Version() int64 {
+	return i.version
+}
+
+// IsLocked returns true when the account is in LOCKED status.
+func (i *Identity) IsLocked() bool {
+	return i.status == IdentityStatusLocked
+}
+
+// Activate transitions the identity to ACTIVE status.
+// Valid from PENDING_INVITE or SUSPENDED; invalid from LOCKED.
+func (i *Identity) Activate() error {
+	switch i.status {
+	case IdentityStatusActive:
+		return nil
+	case IdentityStatusPendingInvite, IdentityStatusSuspended:
+		i.status = IdentityStatusActive
+		i.updatedAt = time.Now()
+		i.version++
+		return nil
+	case IdentityStatusLocked:
+		return ErrInvalidStatusTransition
+	default:
+		return ErrInvalidStatusTransition
+	}
+}
+
+// Suspend transitions the identity to SUSPENDED status.
+// Valid from ACTIVE; invalid from PENDING_INVITE or LOCKED.
+func (i *Identity) Suspend() error {
+	switch i.status {
+	case IdentityStatusActive:
+		i.status = IdentityStatusSuspended
+		i.updatedAt = time.Now()
+		i.version++
+		return nil
+	case IdentityStatusPendingInvite, IdentityStatusSuspended, IdentityStatusLocked:
+		return ErrInvalidStatusTransition
+	default:
+		return ErrInvalidStatusTransition
+	}
+}
+
+// Lock transitions the identity to LOCKED status.
+// Valid from ACTIVE or SUSPENDED.
+func (i *Identity) Lock() error {
+	switch i.status {
+	case IdentityStatusActive, IdentityStatusSuspended:
+		i.status = IdentityStatusLocked
+		i.updatedAt = time.Now()
+		i.version++
+		return nil
+	case IdentityStatusPendingInvite, IdentityStatusLocked:
+		return ErrInvalidStatusTransition
+	default:
+		return ErrInvalidStatusTransition
+	}
+}
+
+// Unlock transitions the identity from LOCKED back to ACTIVE.
+func (i *Identity) Unlock() error {
+	if i.status != IdentityStatusLocked {
+		return ErrInvalidStatusTransition
+	}
+	i.status = IdentityStatusActive
+	i.failedAttempts = 0
+	i.updatedAt = time.Now()
+	i.version++
+	return nil
+}
+
+// RecordLoginAttempt records a login attempt result. On success it resets the
+// failed attempts counter. On failure it increments the counter and locks the
+// account when the threshold is reached.
+func (i *Identity) RecordLoginAttempt(success bool) error {
+	if success {
+		i.failedAttempts = 0
+		i.updatedAt = time.Now()
+		i.version++
+		return nil
+	}
+
+	i.failedAttempts++
+	i.updatedAt = time.Now()
+	i.version++
+
+	if i.failedAttempts >= maxFailedAttempts {
+		i.status = IdentityStatusLocked
+	}
+	return nil
+}
+
+// SetPassword stores a pre-computed bcrypt hash on the identity.
+// The caller is responsible for hashing the plaintext before calling this method.
+func (i *Identity) SetPassword(hash string) error {
+	if hash == "" {
+		return ErrPasswordHashEmpty
+	}
+	i.passwordHash = hash
+	i.updatedAt = time.Now()
+	i.version++
+	return nil
+}
+
+// SetExternalIDP records the external identity provider and subject identifier.
+func (i *Identity) SetExternalIDP(idp, sub string) error {
+	if idp == "" || sub == "" {
+		return ErrExternalIDPEmpty
+	}
+	i.externalIDP = idp
+	i.externalSub = sub
+	i.updatedAt = time.Now()
+	i.version++
+	return nil
+}

--- a/services/identity/domain/identity_test.go
+++ b/services/identity/domain/identity_test.go
@@ -215,6 +215,44 @@ func TestIdentity_UnlockResetFailedAttempts(t *testing.T) {
 	assert.Equal(t, IdentityStatusActive, identity.Status())
 }
 
+func TestIdentity_RecordLoginAttempt_GuardsNonActiveStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(*Identity)
+		expectedErr error
+	}{
+		{
+			name:        "pending invite",
+			setup:       func(_ *Identity) {},
+			expectedErr: ErrInvalidStatusTransition,
+		},
+		{
+			name: "suspended",
+			setup: func(id *Identity) {
+				_ = id.Activate()
+				_ = id.Suspend()
+			},
+			expectedErr: ErrInvalidStatusTransition,
+		},
+		{
+			name: "locked",
+			setup: func(id *Identity) {
+				_ = id.Activate()
+				_ = id.Lock()
+			},
+			expectedErr: ErrAccountLocked,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			identity, _ := NewIdentity("user@example.com")
+			tt.setup(identity)
+			err := identity.RecordLoginAttempt(false)
+			assert.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}
+
 func TestIdentity_SetPassword(t *testing.T) {
 	identity, _ := NewIdentity("user@example.com")
 

--- a/services/identity/domain/identity_test.go
+++ b/services/identity/domain/identity_test.go
@@ -1,0 +1,263 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewIdentity_ValidEmail(t *testing.T) {
+	emails := []string{
+		"user@example.com",
+		"user+tag@example.co.uk",
+		"first.last@sub.domain.com",
+	}
+	for _, email := range emails {
+		t.Run(email, func(t *testing.T) {
+			id, err := NewIdentity(email)
+			require.NoError(t, err)
+			assert.NotEqual(t, uuid.Nil, id.ID())
+			assert.Equal(t, email, id.Email())
+			assert.Equal(t, IdentityStatusPendingInvite, id.Status())
+			assert.Equal(t, int64(1), id.Version())
+			assert.Equal(t, 0, id.FailedAttempts())
+			assert.Empty(t, id.PasswordHash())
+			assert.Empty(t, id.ExternalIDP())
+			assert.Empty(t, id.ExternalSub())
+			assert.NotZero(t, id.CreatedAt())
+			assert.NotZero(t, id.UpdatedAt())
+		})
+	}
+}
+
+func TestNewIdentity_InvalidEmail(t *testing.T) {
+	cases := []string{"", "not-an-email", "@nodomain", "no@", "spaces in@email.com"}
+	for _, email := range cases {
+		t.Run(email, func(t *testing.T) {
+			_, err := NewIdentity(email)
+			assert.ErrorIs(t, err, ErrInvalidEmail)
+		})
+	}
+}
+
+func TestIdentity_StatusTransitions(t *testing.T) {
+	tests := []struct {
+		name         string
+		setup        func(*Identity)
+		transition   func(*Identity) error
+		expectedErr  error
+		expectStatus IdentityStatus
+	}{
+		{
+			name:         "activate from pending invite",
+			setup:        func(_ *Identity) {},
+			transition:   (*Identity).Activate,
+			expectStatus: IdentityStatusActive,
+		},
+		{
+			name: "activate from suspended",
+			setup: func(id *Identity) {
+				_ = id.Activate()
+				_ = id.Suspend()
+			},
+			transition:   (*Identity).Activate,
+			expectStatus: IdentityStatusActive,
+		},
+		{
+			name: "activate from locked returns error",
+			setup: func(id *Identity) {
+				_ = id.Activate()
+				_ = id.Lock()
+			},
+			transition:   (*Identity).Activate,
+			expectedErr:  ErrInvalidStatusTransition,
+			expectStatus: IdentityStatusLocked,
+		},
+		{
+			name: "suspend from active",
+			setup: func(id *Identity) {
+				_ = id.Activate()
+			},
+			transition:   (*Identity).Suspend,
+			expectStatus: IdentityStatusSuspended,
+		},
+		{
+			name:         "suspend from pending invite returns error",
+			setup:        func(_ *Identity) {},
+			transition:   (*Identity).Suspend,
+			expectedErr:  ErrInvalidStatusTransition,
+			expectStatus: IdentityStatusPendingInvite,
+		},
+		{
+			name: "lock from active",
+			setup: func(id *Identity) {
+				_ = id.Activate()
+			},
+			transition:   (*Identity).Lock,
+			expectStatus: IdentityStatusLocked,
+		},
+		{
+			name: "lock from suspended",
+			setup: func(id *Identity) {
+				_ = id.Activate()
+				_ = id.Suspend()
+			},
+			transition:   (*Identity).Lock,
+			expectStatus: IdentityStatusLocked,
+		},
+		{
+			name:         "lock from pending invite returns error",
+			setup:        func(_ *Identity) {},
+			transition:   (*Identity).Lock,
+			expectedErr:  ErrInvalidStatusTransition,
+			expectStatus: IdentityStatusPendingInvite,
+		},
+		{
+			name: "unlock from locked",
+			setup: func(id *Identity) {
+				_ = id.Activate()
+				_ = id.Lock()
+			},
+			transition:   (*Identity).Unlock,
+			expectStatus: IdentityStatusActive,
+		},
+		{
+			name: "unlock from active returns error",
+			setup: func(id *Identity) {
+				_ = id.Activate()
+			},
+			transition:   (*Identity).Unlock,
+			expectedErr:  ErrInvalidStatusTransition,
+			expectStatus: IdentityStatusActive,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			identity, err := NewIdentity("test@example.com")
+			require.NoError(t, err)
+
+			tt.setup(identity)
+			versionBefore := identity.Version()
+			updatedBefore := identity.UpdatedAt()
+
+			err = tt.transition(identity)
+
+			if tt.expectedErr != nil {
+				assert.ErrorIs(t, err, tt.expectedErr)
+				assert.Equal(t, versionBefore, identity.Version(), "version should not change on error")
+			} else {
+				require.NoError(t, err)
+				assert.Greater(t, identity.Version(), versionBefore)
+				assert.True(t, identity.UpdatedAt().Equal(updatedBefore) || identity.UpdatedAt().After(updatedBefore))
+			}
+			assert.Equal(t, tt.expectStatus, identity.Status())
+		})
+	}
+}
+
+func TestIdentity_IsLocked(t *testing.T) {
+	identity, _ := NewIdentity("user@example.com")
+	assert.False(t, identity.IsLocked())
+
+	_ = identity.Activate()
+	_ = identity.Lock()
+	assert.True(t, identity.IsLocked())
+
+	_ = identity.Unlock()
+	assert.False(t, identity.IsLocked())
+}
+
+func TestIdentity_RecordLoginAttempt_SuccessResetsCounter(t *testing.T) {
+	identity, _ := NewIdentity("user@example.com")
+	_ = identity.Activate()
+
+	// Record some failures first
+	_ = identity.RecordLoginAttempt(false)
+	_ = identity.RecordLoginAttempt(false)
+	assert.Equal(t, 2, identity.FailedAttempts())
+
+	// Success resets the counter
+	_ = identity.RecordLoginAttempt(true)
+	assert.Equal(t, 0, identity.FailedAttempts())
+	assert.Equal(t, IdentityStatusActive, identity.Status())
+}
+
+func TestIdentity_RecordLoginAttempt_LockAfterFiveFailures(t *testing.T) {
+	identity, _ := NewIdentity("user@example.com")
+	_ = identity.Activate()
+
+	for i := 0; i < maxFailedAttempts-1; i++ {
+		_ = identity.RecordLoginAttempt(false)
+		assert.False(t, identity.IsLocked(), "should not be locked after %d failures", i+1)
+	}
+
+	// The 5th failure triggers lockout
+	_ = identity.RecordLoginAttempt(false)
+	assert.True(t, identity.IsLocked())
+	assert.Equal(t, maxFailedAttempts, identity.FailedAttempts())
+}
+
+func TestIdentity_UnlockResetFailedAttempts(t *testing.T) {
+	identity, _ := NewIdentity("user@example.com")
+	_ = identity.Activate()
+	for i := 0; i < maxFailedAttempts; i++ {
+		_ = identity.RecordLoginAttempt(false)
+	}
+	require.True(t, identity.IsLocked())
+
+	err := identity.Unlock()
+	require.NoError(t, err)
+	assert.Equal(t, 0, identity.FailedAttempts())
+	assert.Equal(t, IdentityStatusActive, identity.Status())
+}
+
+func TestIdentity_SetPassword(t *testing.T) {
+	identity, _ := NewIdentity("user@example.com")
+
+	err := identity.SetPassword("")
+	assert.ErrorIs(t, err, ErrPasswordHashEmpty)
+
+	err = identity.SetPassword("$2a$12$somevalidhash")
+	require.NoError(t, err)
+	assert.Equal(t, "$2a$12$somevalidhash", identity.PasswordHash())
+}
+
+func TestIdentity_SetExternalIDP(t *testing.T) {
+	identity, _ := NewIdentity("user@example.com")
+
+	err := identity.SetExternalIDP("", "some-sub")
+	assert.ErrorIs(t, err, ErrExternalIDPEmpty)
+
+	err = identity.SetExternalIDP("google", "")
+	assert.ErrorIs(t, err, ErrExternalIDPEmpty)
+
+	err = identity.SetExternalIDP("google", "12345")
+	require.NoError(t, err)
+	assert.Equal(t, "google", identity.ExternalIDP())
+	assert.Equal(t, "12345", identity.ExternalSub())
+}
+
+func TestReconstructIdentity(t *testing.T) {
+	id := uuid.New()
+	now := time.Now()
+	revokedAt := now.Add(time.Hour)
+
+	identity := ReconstructIdentity(
+		id, "user@example.com", IdentityStatusLocked,
+		"$2a$12$hash", "github", "gh-sub",
+		3, now, revokedAt, 5,
+	)
+
+	assert.Equal(t, id, identity.ID())
+	assert.Equal(t, "user@example.com", identity.Email())
+	assert.Equal(t, IdentityStatusLocked, identity.Status())
+	assert.Equal(t, "$2a$12$hash", identity.PasswordHash())
+	assert.Equal(t, "github", identity.ExternalIDP())
+	assert.Equal(t, "gh-sub", identity.ExternalSub())
+	assert.Equal(t, 3, identity.FailedAttempts())
+	assert.Equal(t, int64(5), identity.Version())
+}

--- a/services/identity/domain/invitation.go
+++ b/services/identity/domain/invitation.go
@@ -1,0 +1,130 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/pkg/tokens"
+)
+
+// InvitationStatus represents the lifecycle state of an invitation.
+type InvitationStatus string
+
+// Invitation status constants.
+const (
+	InvitationStatusPending  InvitationStatus = "PENDING"
+	InvitationStatusAccepted InvitationStatus = "ACCEPTED"
+)
+
+// Invitation represents a pending invite for an identity to join the platform.
+type Invitation struct {
+	id         uuid.UUID
+	identityID uuid.UUID
+	invitedBy  uuid.UUID
+	tokenHash  string
+	expiresAt  time.Time
+	status     InvitationStatus
+	createdAt  time.Time
+	updatedAt  time.Time
+}
+
+// NewInvitation creates a new invitation and returns both the domain object and
+// the plaintext token that must be delivered to the invitee. The plaintext token
+// is never stored; only its SHA256 hash is persisted.
+func NewInvitation(identityID, invitedBy uuid.UUID) (*Invitation, string, error) {
+	plaintext, hash, err := tokens.GenerateToken(tokens.InvitationTokenLength)
+	if err != nil {
+		return nil, "", err
+	}
+
+	now := time.Now()
+	inv := &Invitation{
+		id:         uuid.New(),
+		identityID: identityID,
+		invitedBy:  invitedBy,
+		tokenHash:  hash,
+		expiresAt:  now.Add(tokens.InvitationTokenTTL),
+		status:     InvitationStatusPending,
+		createdAt:  now,
+		updatedAt:  now,
+	}
+	return inv, plaintext, nil
+}
+
+// ReconstructInvitation recreates an Invitation from persistence layer data.
+func ReconstructInvitation(
+	id uuid.UUID,
+	identityID uuid.UUID,
+	invitedBy uuid.UUID,
+	tokenHash string,
+	expiresAt time.Time,
+	status InvitationStatus,
+	createdAt time.Time,
+	updatedAt time.Time,
+) *Invitation {
+	return &Invitation{
+		id:         id,
+		identityID: identityID,
+		invitedBy:  invitedBy,
+		tokenHash:  tokenHash,
+		expiresAt:  expiresAt,
+		status:     status,
+		createdAt:  createdAt,
+		updatedAt:  updatedAt,
+	}
+}
+
+// ID returns the invitation's unique identifier.
+func (inv *Invitation) ID() uuid.UUID {
+	return inv.id
+}
+
+// IdentityID returns the identity this invitation is for.
+func (inv *Invitation) IdentityID() uuid.UUID {
+	return inv.identityID
+}
+
+// InvitedBy returns the identity that created the invitation.
+func (inv *Invitation) InvitedBy() uuid.UUID {
+	return inv.invitedBy
+}
+
+// TokenHash returns the SHA256 hash of the invitation token.
+func (inv *Invitation) TokenHash() string {
+	return inv.tokenHash
+}
+
+// ExpiresAt returns when the invitation expires.
+func (inv *Invitation) ExpiresAt() time.Time {
+	return inv.expiresAt
+}
+
+// Status returns the invitation's current status.
+func (inv *Invitation) Status() InvitationStatus {
+	return inv.status
+}
+
+// CreatedAt returns when the invitation was created.
+func (inv *Invitation) CreatedAt() time.Time {
+	return inv.createdAt
+}
+
+// UpdatedAt returns when the invitation was last updated.
+func (inv *Invitation) UpdatedAt() time.Time {
+	return inv.updatedAt
+}
+
+// Accept marks the invitation as accepted.
+// Returns ErrInvitationExpired if the invitation has passed its expiry time.
+// Returns ErrInvitationAlreadyAccepted if it has already been accepted.
+func (inv *Invitation) Accept() error {
+	if inv.status == InvitationStatusAccepted {
+		return ErrInvitationAlreadyAccepted
+	}
+	if !time.Now().Before(inv.expiresAt) {
+		return ErrInvitationExpired
+	}
+	inv.status = InvitationStatusAccepted
+	inv.updatedAt = time.Now()
+	return nil
+}

--- a/services/identity/domain/invitation_test.go
+++ b/services/identity/domain/invitation_test.go
@@ -1,0 +1,84 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInvitation_CreatesValidInvitation(t *testing.T) {
+	identityID := uuid.New()
+	invitedBy := uuid.New()
+
+	inv, plaintext, err := NewInvitation(identityID, invitedBy)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, uuid.Nil, inv.ID())
+	assert.Equal(t, identityID, inv.IdentityID())
+	assert.Equal(t, invitedBy, inv.InvitedBy())
+	assert.Equal(t, InvitationStatusPending, inv.Status())
+	assert.NotEmpty(t, plaintext)
+	assert.NotEmpty(t, inv.TokenHash())
+	assert.NotEqual(t, plaintext, inv.TokenHash(), "plaintext should not equal stored hash")
+	assert.True(t, inv.ExpiresAt().After(time.Now()))
+	assert.NotZero(t, inv.CreatedAt())
+	assert.NotZero(t, inv.UpdatedAt())
+}
+
+func TestInvitation_Accept_Success(t *testing.T) {
+	identityID := uuid.New()
+	invitedBy := uuid.New()
+
+	inv, _, err := NewInvitation(identityID, invitedBy)
+	require.NoError(t, err)
+
+	err = inv.Accept()
+	require.NoError(t, err)
+	assert.Equal(t, InvitationStatusAccepted, inv.Status())
+}
+
+func TestInvitation_Accept_AlreadyAccepted(t *testing.T) {
+	inv, _, _ := NewInvitation(uuid.New(), uuid.New())
+	_ = inv.Accept()
+
+	err := inv.Accept()
+	assert.ErrorIs(t, err, ErrInvitationAlreadyAccepted)
+}
+
+func TestInvitation_Accept_Expired(t *testing.T) {
+	// Reconstruct an expired invitation
+	inv := ReconstructInvitation(
+		uuid.New(), uuid.New(), uuid.New(),
+		"somehash",
+		time.Now().Add(-time.Hour), // expired
+		InvitationStatusPending,
+		time.Now().Add(-2*time.Hour),
+		time.Now().Add(-2*time.Hour),
+	)
+
+	err := inv.Accept()
+	assert.ErrorIs(t, err, ErrInvitationExpired)
+}
+
+func TestReconstructInvitation(t *testing.T) {
+	id := uuid.New()
+	identityID := uuid.New()
+	invitedBy := uuid.New()
+	hash := "abc123hash"
+	expiry := time.Now().Add(24 * time.Hour)
+	now := time.Now()
+
+	inv := ReconstructInvitation(
+		id, identityID, invitedBy, hash, expiry,
+		InvitationStatusAccepted, now, now,
+	)
+
+	assert.Equal(t, id, inv.ID())
+	assert.Equal(t, identityID, inv.IdentityID())
+	assert.Equal(t, invitedBy, inv.InvitedBy())
+	assert.Equal(t, hash, inv.TokenHash())
+	assert.Equal(t, InvitationStatusAccepted, inv.Status())
+}

--- a/services/identity/domain/repository.go
+++ b/services/identity/domain/repository.go
@@ -1,0 +1,43 @@
+package domain
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// Repository defines persistence operations for identity domain objects.
+type Repository interface {
+	// Identity operations
+
+	// Save persists a new or updated identity.
+	Save(ctx context.Context, identity *Identity) error
+
+	// FindByID retrieves an identity by its unique identifier.
+	// Returns ErrIdentityNotFound if no matching record exists.
+	FindByID(ctx context.Context, id uuid.UUID) (*Identity, error)
+
+	// FindByEmail retrieves an identity by email address within the tenant scope.
+	// Returns ErrIdentityNotFound if no matching record exists.
+	FindByEmail(ctx context.Context, email string) (*Identity, error)
+
+	// ListByTenant returns all identities within the current tenant context.
+	ListByTenant(ctx context.Context) ([]*Identity, error)
+
+	// Role assignment operations
+
+	// SaveRoleAssignment persists a new or updated role assignment.
+	SaveRoleAssignment(ctx context.Context, assignment *RoleAssignment) error
+
+	// FindRoleAssignments returns all role assignments for the given identity.
+	FindRoleAssignments(ctx context.Context, identityID uuid.UUID) ([]*RoleAssignment, error)
+
+	// Invitation operations
+
+	// SaveInvitation persists a new or updated invitation.
+	SaveInvitation(ctx context.Context, invitation *Invitation) error
+
+	// FindInvitationByTokenHash retrieves an invitation by the SHA256 hash of its token.
+	// Returns ErrIdentityNotFound if no matching record exists.
+	FindInvitationByTokenHash(ctx context.Context, tokenHash string) (*Invitation, error)
+}

--- a/services/identity/domain/repository.go
+++ b/services/identity/domain/repository.go
@@ -38,6 +38,6 @@ type Repository interface {
 	SaveInvitation(ctx context.Context, invitation *Invitation) error
 
 	// FindInvitationByTokenHash retrieves an invitation by the SHA256 hash of its token.
-	// Returns ErrIdentityNotFound if no matching record exists.
+	// Returns ErrInvitationNotFound if no matching invitation exists.
 	FindInvitationByTokenHash(ctx context.Context, tokenHash string) (*Invitation, error)
 }

--- a/services/identity/domain/role_assignment.go
+++ b/services/identity/domain/role_assignment.go
@@ -1,0 +1,181 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Role represents a named permission level within the platform.
+type Role string
+
+// Defined role constants in ascending privilege order.
+const (
+	RoleViewer      Role = "VIEWER"
+	RoleOperator    Role = "OPERATOR"
+	RoleAdmin       Role = "ADMIN"
+	RoleTenantOwner Role = "TENANT_OWNER"
+	RolePlatform    Role = "PLATFORM"
+)
+
+// roleHierarchy maps each role to its numeric privilege level.
+// Higher values indicate greater privilege.
+var roleHierarchy = map[Role]int{
+	RoleViewer:      1,
+	RoleOperator:    2,
+	RoleAdmin:       3,
+	RoleTenantOwner: 4,
+	RolePlatform:    5,
+}
+
+// IsValidRole returns true if the role string is a recognized platform role.
+func IsValidRole(r string) bool {
+	_, ok := roleHierarchy[Role(r)]
+	return ok
+}
+
+// RoleAssignment represents a granted role for an identity.
+type RoleAssignment struct {
+	id         uuid.UUID
+	identityID uuid.UUID
+	grantedBy  uuid.UUID
+	role       Role
+	expiresAt  *time.Time
+	revokedAt  *time.Time
+	revokedBy  *uuid.UUID
+	createdAt  time.Time
+	updatedAt  time.Time
+}
+
+// NewRoleAssignment creates a new active role assignment.
+// Returns ErrInvalidRole if the role is not recognized.
+func NewRoleAssignment(identityID, grantedBy uuid.UUID, role string) (*RoleAssignment, error) {
+	if !IsValidRole(role) {
+		return nil, ErrInvalidRole
+	}
+	now := time.Now()
+	return &RoleAssignment{
+		id:         uuid.New(),
+		identityID: identityID,
+		grantedBy:  grantedBy,
+		role:       Role(role),
+		createdAt:  now,
+		updatedAt:  now,
+	}, nil
+}
+
+// ReconstructRoleAssignment recreates a RoleAssignment from persistence layer data.
+func ReconstructRoleAssignment(
+	id uuid.UUID,
+	identityID uuid.UUID,
+	grantedBy uuid.UUID,
+	role Role,
+	expiresAt *time.Time,
+	revokedAt *time.Time,
+	revokedBy *uuid.UUID,
+	createdAt time.Time,
+	updatedAt time.Time,
+) *RoleAssignment {
+	return &RoleAssignment{
+		id:         id,
+		identityID: identityID,
+		grantedBy:  grantedBy,
+		role:       role,
+		expiresAt:  expiresAt,
+		revokedAt:  revokedAt,
+		revokedBy:  revokedBy,
+		createdAt:  createdAt,
+		updatedAt:  updatedAt,
+	}
+}
+
+// ID returns the role assignment's unique identifier.
+func (r *RoleAssignment) ID() uuid.UUID {
+	return r.id
+}
+
+// IdentityID returns the identity this assignment belongs to.
+func (r *RoleAssignment) IdentityID() uuid.UUID {
+	return r.identityID
+}
+
+// GrantedBy returns the identity that granted this role.
+func (r *RoleAssignment) GrantedBy() uuid.UUID {
+	return r.grantedBy
+}
+
+// Role returns the granted role.
+func (r *RoleAssignment) Role() Role {
+	return r.role
+}
+
+// ExpiresAt returns the optional expiry time.
+func (r *RoleAssignment) ExpiresAt() *time.Time {
+	return r.expiresAt
+}
+
+// RevokedAt returns when the assignment was revoked, or nil if still active.
+func (r *RoleAssignment) RevokedAt() *time.Time {
+	return r.revokedAt
+}
+
+// RevokedBy returns who revoked the assignment, or nil if still active.
+func (r *RoleAssignment) RevokedBy() *uuid.UUID {
+	return r.revokedBy
+}
+
+// CreatedAt returns when the assignment was created.
+func (r *RoleAssignment) CreatedAt() time.Time {
+	return r.createdAt
+}
+
+// UpdatedAt returns when the assignment was last updated.
+func (r *RoleAssignment) UpdatedAt() time.Time {
+	return r.updatedAt
+}
+
+// IsActive returns true when the assignment has not been revoked and has not expired.
+func (r *RoleAssignment) IsActive() bool {
+	if r.revokedAt != nil {
+		return false
+	}
+	if r.expiresAt != nil && !time.Now().Before(*r.expiresAt) {
+		return false
+	}
+	return true
+}
+
+// Revoke marks this role assignment as revoked.
+// Returns ErrRoleAlreadyRevoked if it has already been revoked.
+func (r *RoleAssignment) Revoke(revokedBy uuid.UUID) error {
+	if r.revokedAt != nil {
+		return ErrRoleAlreadyRevoked
+	}
+	now := time.Now()
+	r.revokedAt = &now
+	r.revokedBy = &revokedBy
+	r.updatedAt = now
+	return nil
+}
+
+// minGranterLevel is the minimum privilege level required to grant any role.
+// Only Admin (level 3) and above may grant roles.
+const minGranterLevel = 3
+
+// CanGrant returns true if an identity holding granterRole is permitted to grant targetRole.
+// A granter must have at least Admin-level privilege and must hold a strictly higher privilege
+// level than the target role.
+func CanGrant(granterRole, targetRole string) bool {
+	granterLevel, ok := roleHierarchy[Role(granterRole)]
+	if !ok {
+		return false
+	}
+	if granterLevel < minGranterLevel {
+		return false
+	}
+	targetLevel, ok := roleHierarchy[Role(targetRole)]
+	if !ok {
+		return false
+	}
+	return granterLevel > targetLevel
+}

--- a/services/identity/domain/role_assignment.go
+++ b/services/identity/domain/role_assignment.go
@@ -48,17 +48,24 @@ type RoleAssignment struct {
 }
 
 // NewRoleAssignment creates a new active role assignment.
-// Returns ErrInvalidRole if the role is not recognized.
-func NewRoleAssignment(identityID, grantedBy uuid.UUID, role string) (*RoleAssignment, error) {
-	if !IsValidRole(role) {
+// granterRole is the role held by the identity performing the grant; it is used
+// to enforce the privilege hierarchy via CanGrant so that high-privilege roles
+// cannot be assigned without proper authorization.
+// Returns ErrInvalidRole if targetRole is not recognized, and
+// ErrInsufficientRolePermissions if the granter lacks authority to assign targetRole.
+func NewRoleAssignment(identityID, grantedBy uuid.UUID, granterRole, targetRole string) (*RoleAssignment, error) {
+	if !IsValidRole(targetRole) {
 		return nil, ErrInvalidRole
+	}
+	if !CanGrant(granterRole, targetRole) {
+		return nil, ErrInsufficientRolePermissions
 	}
 	now := time.Now()
 	return &RoleAssignment{
 		id:         uuid.New(),
 		identityID: identityID,
 		grantedBy:  grantedBy,
-		role:       Role(role),
+		role:       Role(targetRole),
 		createdAt:  now,
 		updatedAt:  now,
 	}, nil

--- a/services/identity/domain/role_assignment_test.go
+++ b/services/identity/domain/role_assignment_test.go
@@ -10,24 +10,28 @@ import (
 )
 
 func TestNewRoleAssignment_ValidRole(t *testing.T) {
-	roles := []string{
-		string(RoleViewer),
-		string(RoleOperator),
-		string(RoleAdmin),
-		string(RoleTenantOwner),
-		string(RolePlatform),
+	tests := []struct {
+		granter string
+		target  string
+	}{
+		{string(RolePlatform), string(RoleTenantOwner)},
+		{string(RolePlatform), string(RoleAdmin)},
+		{string(RolePlatform), string(RoleOperator)},
+		{string(RolePlatform), string(RoleViewer)},
+		{string(RoleTenantOwner), string(RoleAdmin)},
+		{string(RoleAdmin), string(RoleViewer)},
 	}
 	identityID := uuid.New()
 	grantedBy := uuid.New()
 
-	for _, role := range roles {
-		t.Run(role, func(t *testing.T) {
-			ra, err := NewRoleAssignment(identityID, grantedBy, role)
+	for _, tt := range tests {
+		t.Run(tt.granter+"->"+tt.target, func(t *testing.T) {
+			ra, err := NewRoleAssignment(identityID, grantedBy, tt.granter, tt.target)
 			require.NoError(t, err)
 			assert.NotEqual(t, uuid.Nil, ra.ID())
 			assert.Equal(t, identityID, ra.IdentityID())
 			assert.Equal(t, grantedBy, ra.GrantedBy())
-			assert.Equal(t, Role(role), ra.Role())
+			assert.Equal(t, Role(tt.target), ra.Role())
 			assert.True(t, ra.IsActive())
 			assert.Nil(t, ra.RevokedAt())
 			assert.Nil(t, ra.RevokedBy())
@@ -37,12 +41,35 @@ func TestNewRoleAssignment_ValidRole(t *testing.T) {
 }
 
 func TestNewRoleAssignment_InvalidRole(t *testing.T) {
-	_, err := NewRoleAssignment(uuid.New(), uuid.New(), "SUPERUSER")
+	_, err := NewRoleAssignment(uuid.New(), uuid.New(), string(RolePlatform), "SUPERUSER")
 	assert.ErrorIs(t, err, ErrInvalidRole)
 }
 
+func TestNewRoleAssignment_InsufficientPermissions(t *testing.T) {
+	tests := []struct {
+		granter string
+		target  string
+	}{
+		// Operator cannot grant anyone
+		{string(RoleOperator), string(RoleViewer)},
+		// Viewer cannot grant anyone
+		{string(RoleViewer), string(RoleViewer)},
+		// Admin cannot grant itself or above
+		{string(RoleAdmin), string(RoleAdmin)},
+		{string(RoleAdmin), string(RoleTenantOwner)},
+		// TenantOwner cannot grant Platform
+		{string(RoleTenantOwner), string(RolePlatform)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.granter+"->"+tt.target, func(t *testing.T) {
+			_, err := NewRoleAssignment(uuid.New(), uuid.New(), tt.granter, tt.target)
+			assert.ErrorIs(t, err, ErrInsufficientRolePermissions)
+		})
+	}
+}
+
 func TestRoleAssignment_Revoke(t *testing.T) {
-	ra, _ := NewRoleAssignment(uuid.New(), uuid.New(), string(RoleViewer))
+	ra, _ := NewRoleAssignment(uuid.New(), uuid.New(), string(RoleAdmin), string(RoleViewer))
 	assert.True(t, ra.IsActive())
 
 	revokedBy := uuid.New()
@@ -55,7 +82,7 @@ func TestRoleAssignment_Revoke(t *testing.T) {
 }
 
 func TestRoleAssignment_RevokeAlreadyRevoked(t *testing.T) {
-	ra, _ := NewRoleAssignment(uuid.New(), uuid.New(), string(RoleAdmin))
+	ra, _ := NewRoleAssignment(uuid.New(), uuid.New(), string(RolePlatform), string(RoleAdmin))
 	_ = ra.Revoke(uuid.New())
 
 	err := ra.Revoke(uuid.New())
@@ -63,7 +90,7 @@ func TestRoleAssignment_RevokeAlreadyRevoked(t *testing.T) {
 }
 
 func TestRoleAssignment_IsActive_Expired(t *testing.T) {
-	ra, _ := NewRoleAssignment(uuid.New(), uuid.New(), string(RoleOperator))
+	ra, _ := NewRoleAssignment(uuid.New(), uuid.New(), string(RolePlatform), string(RoleOperator))
 	// Set expiry in the past via reconstruction
 	past := time.Now().Add(-time.Hour)
 	ra2 := ReconstructRoleAssignment(
@@ -74,7 +101,7 @@ func TestRoleAssignment_IsActive_Expired(t *testing.T) {
 }
 
 func TestRoleAssignment_IsActive_NotExpired(t *testing.T) {
-	ra, _ := NewRoleAssignment(uuid.New(), uuid.New(), string(RoleOperator))
+	ra, _ := NewRoleAssignment(uuid.New(), uuid.New(), string(RolePlatform), string(RoleOperator))
 	future := time.Now().Add(time.Hour)
 	ra2 := ReconstructRoleAssignment(
 		ra.ID(), ra.IdentityID(), ra.GrantedBy(), ra.Role(),

--- a/services/identity/domain/role_assignment_test.go
+++ b/services/identity/domain/role_assignment_test.go
@@ -1,0 +1,134 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRoleAssignment_ValidRole(t *testing.T) {
+	roles := []string{
+		string(RoleViewer),
+		string(RoleOperator),
+		string(RoleAdmin),
+		string(RoleTenantOwner),
+		string(RolePlatform),
+	}
+	identityID := uuid.New()
+	grantedBy := uuid.New()
+
+	for _, role := range roles {
+		t.Run(role, func(t *testing.T) {
+			ra, err := NewRoleAssignment(identityID, grantedBy, role)
+			require.NoError(t, err)
+			assert.NotEqual(t, uuid.Nil, ra.ID())
+			assert.Equal(t, identityID, ra.IdentityID())
+			assert.Equal(t, grantedBy, ra.GrantedBy())
+			assert.Equal(t, Role(role), ra.Role())
+			assert.True(t, ra.IsActive())
+			assert.Nil(t, ra.RevokedAt())
+			assert.Nil(t, ra.RevokedBy())
+			assert.Nil(t, ra.ExpiresAt())
+		})
+	}
+}
+
+func TestNewRoleAssignment_InvalidRole(t *testing.T) {
+	_, err := NewRoleAssignment(uuid.New(), uuid.New(), "SUPERUSER")
+	assert.ErrorIs(t, err, ErrInvalidRole)
+}
+
+func TestRoleAssignment_Revoke(t *testing.T) {
+	ra, _ := NewRoleAssignment(uuid.New(), uuid.New(), string(RoleViewer))
+	assert.True(t, ra.IsActive())
+
+	revokedBy := uuid.New()
+	err := ra.Revoke(revokedBy)
+	require.NoError(t, err)
+
+	assert.False(t, ra.IsActive())
+	assert.NotNil(t, ra.RevokedAt())
+	assert.Equal(t, &revokedBy, ra.RevokedBy())
+}
+
+func TestRoleAssignment_RevokeAlreadyRevoked(t *testing.T) {
+	ra, _ := NewRoleAssignment(uuid.New(), uuid.New(), string(RoleAdmin))
+	_ = ra.Revoke(uuid.New())
+
+	err := ra.Revoke(uuid.New())
+	assert.ErrorIs(t, err, ErrRoleAlreadyRevoked)
+}
+
+func TestRoleAssignment_IsActive_Expired(t *testing.T) {
+	ra, _ := NewRoleAssignment(uuid.New(), uuid.New(), string(RoleOperator))
+	// Set expiry in the past via reconstruction
+	past := time.Now().Add(-time.Hour)
+	ra2 := ReconstructRoleAssignment(
+		ra.ID(), ra.IdentityID(), ra.GrantedBy(), ra.Role(),
+		&past, nil, nil, ra.CreatedAt(), ra.UpdatedAt(),
+	)
+	assert.False(t, ra2.IsActive())
+}
+
+func TestRoleAssignment_IsActive_NotExpired(t *testing.T) {
+	ra, _ := NewRoleAssignment(uuid.New(), uuid.New(), string(RoleOperator))
+	future := time.Now().Add(time.Hour)
+	ra2 := ReconstructRoleAssignment(
+		ra.ID(), ra.IdentityID(), ra.GrantedBy(), ra.Role(),
+		&future, nil, nil, ra.CreatedAt(), ra.UpdatedAt(),
+	)
+	assert.True(t, ra2.IsActive())
+}
+
+func TestCanGrant_HierarchyEnforcement(t *testing.T) {
+	tests := []struct {
+		granter  string
+		target   string
+		canGrant bool
+	}{
+		// Platform can grant all lower roles
+		{string(RolePlatform), string(RoleTenantOwner), true},
+		{string(RolePlatform), string(RoleAdmin), true},
+		{string(RolePlatform), string(RoleOperator), true},
+		{string(RolePlatform), string(RoleViewer), true},
+		// TenantOwner can grant admin and below
+		{string(RoleTenantOwner), string(RoleAdmin), true},
+		{string(RoleTenantOwner), string(RoleOperator), true},
+		{string(RoleTenantOwner), string(RoleViewer), true},
+		// TenantOwner cannot grant Platform
+		{string(RoleTenantOwner), string(RolePlatform), false},
+		// Admin can grant operator and below
+		{string(RoleAdmin), string(RoleOperator), true},
+		{string(RoleAdmin), string(RoleViewer), true},
+		// Admin cannot grant itself or above
+		{string(RoleAdmin), string(RoleAdmin), false},
+		{string(RoleAdmin), string(RoleTenantOwner), false},
+		// Operator cannot grant anyone
+		{string(RoleOperator), string(RoleViewer), false},
+		// Viewer cannot grant anyone
+		{string(RoleViewer), string(RoleViewer), false},
+		// Invalid roles
+		{"INVALID", string(RoleViewer), false},
+		{string(RoleAdmin), "INVALID", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.granter+"->"+tt.target, func(t *testing.T) {
+			result := CanGrant(tt.granter, tt.target)
+			assert.Equal(t, tt.canGrant, result)
+		})
+	}
+}
+
+func TestIsValidRole(t *testing.T) {
+	assert.True(t, IsValidRole(string(RoleViewer)))
+	assert.True(t, IsValidRole(string(RoleOperator)))
+	assert.True(t, IsValidRole(string(RoleAdmin)))
+	assert.True(t, IsValidRole(string(RoleTenantOwner)))
+	assert.True(t, IsValidRole(string(RolePlatform)))
+	assert.False(t, IsValidRole("SUPERUSER"))
+	assert.False(t, IsValidRole(""))
+}


### PR DESCRIPTION
## Summary

- Implements `services/identity/domain/` following party service patterns
- Identity aggregate with lifecycle state machine (PENDING_INVITE → ACTIVE → SUSPENDED/LOCKED), login attempt tracking with automatic lockout after 5 consecutive failures, password hash storage, and external IDP linkage
- RoleAssignment aggregate with role hierarchy enforcement (Admin-level minimum to grant; granter must hold strictly higher privilege than target role), time-bound assignments, and revocation
- Invitation aggregate using `shared/pkg/tokens` for secure token generation (SHA256 hash stored, plaintext delivered to invitee), 72-hour TTL, and single-use acceptance guards
- Repository interface defining the persistence contract for all three aggregates
- Sentinel domain errors for all failure conditions

## Design decisions

- Status transitions use exhaustive switch statements to satisfy the `exhaustive` linter and make unhandled transitions explicit
- `CanGrant` requires Admin (level 3) or above as minimum granter — Operator and Viewer cannot grant roles to anyone
- `RecordLoginAttempt` is a side-effect-only method (does not return `ErrAccountLocked`); callers should check `IsLocked()` after a failed attempt if they need to act on the lockout
- `SetPassword` accepts a pre-computed hash — the domain model does not perform hashing, consistent with separation of concerns

## Test plan

- [x] `go test ./services/identity/domain/...` — all tests passing
- [x] golangci-lint — 0 issues
- [x] gofumpt — formatted
- Table-driven tests cover all status transition paths (valid and invalid), lockout threshold, role hierarchy for all role pairs, invitation expiry and double-accept, and reconstruction constructors