### PR TITLE
feat(identity): add identity persistence layer

### DIFF
--- a/services/identity/adapters/persistence/identity_entity.go
+++ b/services/identity/adapters/persistence/identity_entity.go
@@ -1,0 +1,71 @@
+// Package persistence provides database persistence for the identity domain.
+package persistence
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/identity/domain"
+)
+
+// IdentityEntity represents the database persistence model for identities.
+// This entity must match the schema defined in migrations for the identity service.
+// The mapping between domain model and entity is handled by toEntity/toDomain functions.
+type IdentityEntity struct {
+	// Primary key
+	ID uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+
+	// Business fields
+	Email          string `gorm:"column:email;type:varchar(255);not null;uniqueIndex:idx_identity_email,where:deleted_at IS NULL"`
+	Status         string `gorm:"column:status;type:varchar(30);not null;default:'PENDING_INVITE'"`
+	PasswordHash   string `gorm:"column:password_hash;type:varchar(255);not null;default:''"`
+	ExternalIDP    string `gorm:"column:external_idp;type:varchar(100);not null;default:''"`
+	ExternalSub    string `gorm:"column:external_sub;type:varchar(255);not null;default:''"`
+	FailedAttempts int    `gorm:"column:failed_attempts;not null;default:0"`
+
+	// Optimistic locking
+	Version int64 `gorm:"column:version;not null;default:1"`
+
+	// Audit fields
+	CreatedAt time.Time  `gorm:"column:created_at;not null;default:now()"`
+	UpdatedAt time.Time  `gorm:"column:updated_at;not null;default:now()"`
+	DeletedAt *time.Time `gorm:"column:deleted_at;index"`
+}
+
+// TableName overrides the default table name.
+// Uses singular, unqualified name — search_path routing handles tenant schema.
+func (IdentityEntity) TableName() string {
+	return "identity"
+}
+
+// ToEntity converts a domain Identity to a persistence IdentityEntity.
+func ToEntity(identity *domain.Identity) *IdentityEntity {
+	return &IdentityEntity{
+		ID:             identity.ID(),
+		Email:          identity.Email(),
+		Status:         string(identity.Status()),
+		PasswordHash:   identity.PasswordHash(),
+		ExternalIDP:    identity.ExternalIDP(),
+		ExternalSub:    identity.ExternalSub(),
+		FailedAttempts: identity.FailedAttempts(),
+		Version:        identity.Version(),
+		CreatedAt:      identity.CreatedAt(),
+		UpdatedAt:      identity.UpdatedAt(),
+	}
+}
+
+// ToDomain converts a persistence IdentityEntity to a domain Identity.
+func ToDomain(entity *IdentityEntity) *domain.Identity {
+	return domain.ReconstructIdentity(
+		entity.ID,
+		entity.Email,
+		domain.IdentityStatus(entity.Status),
+		entity.PasswordHash,
+		entity.ExternalIDP,
+		entity.ExternalSub,
+		entity.FailedAttempts,
+		entity.CreatedAt,
+		entity.UpdatedAt,
+		entity.Version,
+	)
+}

--- a/services/identity/adapters/persistence/invitation_entity.go
+++ b/services/identity/adapters/persistence/invitation_entity.go
@@ -1,0 +1,55 @@
+package persistence
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/identity/domain"
+)
+
+// InvitationEntity represents the database persistence model for invitations.
+type InvitationEntity struct {
+	ID         uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+	IdentityID uuid.UUID `gorm:"column:identity_id;type:uuid;not null;index:idx_invitation_identity"`
+	InvitedBy  uuid.UUID `gorm:"column:invited_by;type:uuid;not null"`
+	// TokenHash stores the SHA256 hash of the invitation token.
+	// The unique index enforces one-lookup semantics per token.
+	TokenHash string    `gorm:"column:token_hash;type:varchar(64);not null;uniqueIndex:idx_invitation_token_hash"`
+	ExpiresAt time.Time `gorm:"column:expires_at;not null"`
+	Status    string    `gorm:"column:status;type:varchar(20);not null;default:'PENDING'"`
+	CreatedAt time.Time `gorm:"column:created_at;not null;default:now()"`
+	UpdatedAt time.Time `gorm:"column:updated_at;not null;default:now()"`
+}
+
+// TableName overrides the default table name.
+func (InvitationEntity) TableName() string {
+	return "invitation"
+}
+
+// toInvitationEntity converts a domain Invitation to a persistence entity.
+func toInvitationEntity(inv *domain.Invitation) *InvitationEntity {
+	return &InvitationEntity{
+		ID:         inv.ID(),
+		IdentityID: inv.IdentityID(),
+		InvitedBy:  inv.InvitedBy(),
+		TokenHash:  inv.TokenHash(),
+		ExpiresAt:  inv.ExpiresAt(),
+		Status:     string(inv.Status()),
+		CreatedAt:  inv.CreatedAt(),
+		UpdatedAt:  inv.UpdatedAt(),
+	}
+}
+
+// toInvitationDomain converts a persistence entity to a domain Invitation.
+func toInvitationDomain(entity *InvitationEntity) *domain.Invitation {
+	return domain.ReconstructInvitation(
+		entity.ID,
+		entity.IdentityID,
+		entity.InvitedBy,
+		entity.TokenHash,
+		entity.ExpiresAt,
+		domain.InvitationStatus(entity.Status),
+		entity.CreatedAt,
+		entity.UpdatedAt,
+	)
+}

--- a/services/identity/adapters/persistence/repository.go
+++ b/services/identity/adapters/persistence/repository.go
@@ -134,7 +134,7 @@ func (r *Repository) ListByTenant(ctx context.Context) ([]*domain.Identity, erro
 	var identities []*domain.Identity
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 		var entities []IdentityEntity
-		if err := tx.Where("deleted_at IS NULL").Find(&entities).Error; err != nil {
+		if err := tx.Where("deleted_at IS NULL").Order("created_at ASC").Find(&entities).Error; err != nil {
 			return err
 		}
 		identities = make([]*domain.Identity, len(entities))

--- a/services/identity/adapters/persistence/repository.go
+++ b/services/identity/adapters/persistence/repository.go
@@ -1,0 +1,261 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/identity/domain"
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"gorm.io/gorm"
+)
+
+// Repository provides persistence operations for the identity domain.
+// It implements domain.Repository.
+type Repository struct {
+	db *gorm.DB
+}
+
+// NewRepository creates a new identity Repository.
+func NewRepository(database *gorm.DB) *Repository {
+	return &Repository{db: database}
+}
+
+// withTenantTransaction executes fn inside a tenant-scoped transaction.
+func (r *Repository) withTenantTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	return db.WithGormTenantTransaction(ctx, r.db, fn)
+}
+
+// Save persists a new or updated identity using optimistic locking.
+// For creates: inserts with version=1.
+// For updates: applies WHERE id=? AND version=expectedVersion to detect conflicts.
+func (r *Repository) Save(ctx context.Context, identity *domain.Identity) error {
+	entity := ToEntity(identity)
+
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var existing IdentityEntity
+		result := tx.Where("id = ? AND deleted_at IS NULL", entity.ID).First(&existing)
+
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			// New identity — insert
+			if err := tx.Create(entity).Error; err != nil {
+				if isDuplicateKeyError(err) {
+					return domain.ErrEmailAlreadyExists
+				}
+				return err
+			}
+			return nil
+		}
+
+		if result.Error != nil {
+			return result.Error
+		}
+
+		// Existing identity — optimistic locking update.
+		// The domain increments Version on each mutation, so entity.Version is the
+		// target version and the expected DB version is entity.Version-1.
+		expectedDBVersion := entity.Version - 1
+
+		updateResult := tx.Model(&IdentityEntity{}).
+			Where("id = ? AND version = ? AND deleted_at IS NULL", entity.ID, expectedDBVersion).
+			Updates(map[string]interface{}{
+				"email":           entity.Email,
+				"status":          entity.Status,
+				"password_hash":   entity.PasswordHash,
+				"external_idp":    entity.ExternalIDP,
+				"external_sub":    entity.ExternalSub,
+				"failed_attempts": entity.FailedAttempts,
+				"version":         entity.Version,
+				"updated_at":      entity.UpdatedAt,
+			})
+
+		if updateResult.Error != nil {
+			if isDuplicateKeyError(updateResult.Error) {
+				return domain.ErrEmailAlreadyExists
+			}
+			return updateResult.Error
+		}
+
+		if updateResult.RowsAffected == 0 {
+			return ErrVersionConflict
+		}
+
+		return nil
+	})
+}
+
+// FindByID retrieves an identity by its unique identifier.
+// Returns domain.ErrIdentityNotFound if no matching record exists.
+func (r *Repository) FindByID(ctx context.Context, id uuid.UUID) (*domain.Identity, error) {
+	var identity *domain.Identity
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var entity IdentityEntity
+		result := tx.Where("id = ? AND deleted_at IS NULL", id).First(&entity)
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return domain.ErrIdentityNotFound
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+		identity = ToDomain(&entity)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return identity, nil
+}
+
+// FindByEmail retrieves an identity by email address within the tenant scope.
+// Returns domain.ErrIdentityNotFound if no matching record exists.
+func (r *Repository) FindByEmail(ctx context.Context, email string) (*domain.Identity, error) {
+	var identity *domain.Identity
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var entity IdentityEntity
+		result := tx.Where("email = ? AND deleted_at IS NULL", email).First(&entity)
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return domain.ErrIdentityNotFound
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+		identity = ToDomain(&entity)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return identity, nil
+}
+
+// ListByTenant returns all non-deleted identities within the current tenant context.
+func (r *Repository) ListByTenant(ctx context.Context) ([]*domain.Identity, error) {
+	var identities []*domain.Identity
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var entities []IdentityEntity
+		if err := tx.Where("deleted_at IS NULL").Find(&entities).Error; err != nil {
+			return err
+		}
+		identities = make([]*domain.Identity, len(entities))
+		for i := range entities {
+			identities[i] = ToDomain(&entities[i])
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return identities, nil
+}
+
+// SaveRoleAssignment persists a new or updated role assignment.
+func (r *Repository) SaveRoleAssignment(ctx context.Context, assignment *domain.RoleAssignment) error {
+	entity := toRoleAssignmentEntity(assignment)
+
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var existing RoleAssignmentEntity
+		result := tx.Where("id = ?", entity.ID).First(&existing)
+
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return tx.Create(entity).Error
+		}
+
+		if result.Error != nil {
+			return result.Error
+		}
+
+		// Update mutable fields (revocation, expiry, updated_at)
+		return tx.Model(&RoleAssignmentEntity{}).
+			Where("id = ?", entity.ID).
+			Updates(map[string]interface{}{
+				"revoked_at": entity.RevokedAt,
+				"revoked_by": entity.RevokedBy,
+				"expires_at": entity.ExpiresAt,
+				"updated_at": entity.UpdatedAt,
+			}).Error
+	})
+}
+
+// FindRoleAssignments returns all role assignments for the given identity.
+func (r *Repository) FindRoleAssignments(ctx context.Context, identityID uuid.UUID) ([]*domain.RoleAssignment, error) {
+	var assignments []*domain.RoleAssignment
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var entities []RoleAssignmentEntity
+		if err := tx.Where("identity_id = ?", identityID).Find(&entities).Error; err != nil {
+			return err
+		}
+		assignments = make([]*domain.RoleAssignment, len(entities))
+		for i := range entities {
+			assignments[i] = toRoleAssignmentDomain(&entities[i])
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return assignments, nil
+}
+
+// SaveInvitation persists a new or updated invitation.
+func (r *Repository) SaveInvitation(ctx context.Context, invitation *domain.Invitation) error {
+	entity := toInvitationEntity(invitation)
+
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var existing InvitationEntity
+		result := tx.Where("id = ?", entity.ID).First(&existing)
+
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return tx.Create(entity).Error
+		}
+
+		if result.Error != nil {
+			return result.Error
+		}
+
+		// Update mutable fields (status, updated_at)
+		return tx.Model(&InvitationEntity{}).
+			Where("id = ?", entity.ID).
+			Updates(map[string]interface{}{
+				"status":     entity.Status,
+				"updated_at": entity.UpdatedAt,
+			}).Error
+	})
+}
+
+// FindInvitationByTokenHash retrieves an invitation by the SHA256 hash of its token.
+// Returns domain.ErrInvitationNotFound if no matching invitation exists.
+func (r *Repository) FindInvitationByTokenHash(ctx context.Context, tokenHash string) (*domain.Invitation, error) {
+	var invitation *domain.Invitation
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var entity InvitationEntity
+		result := tx.Where("token_hash = ?", tokenHash).First(&entity)
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return domain.ErrInvitationNotFound
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+		invitation = toInvitationDomain(&entity)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return invitation, nil
+}
+
+// ErrVersionConflict is returned when an optimistic locking conflict is detected.
+var ErrVersionConflict = errors.New("version conflict: identity was modified by another transaction")
+
+// isDuplicateKeyError returns true when err represents a unique constraint violation.
+func isDuplicateKeyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return errors.Is(err, gorm.ErrDuplicatedKey) ||
+		strings.Contains(errStr, "23505") ||
+		strings.Contains(errStr, "duplicate key") ||
+		strings.Contains(errStr, "unique constraint")
+}

--- a/services/identity/adapters/persistence/repository_test.go
+++ b/services/identity/adapters/persistence/repository_test.go
@@ -1,0 +1,375 @@
+package persistence
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/identity/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+const (
+	testTenantID   = "test_tenant"
+	secondTenantID = "test_tenant_b"
+)
+
+func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
+	t.Helper()
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+
+	tid := tenant.TenantID(testTenantID)
+	ctx := setupTenantSchema(t, db, tid)
+
+	return db, ctx, cleanup
+}
+
+// setupTenantSchema creates the identity tables in a tenant schema and returns a context with tenant.
+func setupTenantSchema(t *testing.T, db *gorm.DB, tid tenant.TenantID) context.Context {
+	t.Helper()
+	schemaName := tid.SchemaName()
+
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
+	require.NoError(t, err)
+
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.identity (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		email VARCHAR(255) NOT NULL,
+		status VARCHAR(30) NOT NULL DEFAULT 'PENDING_INVITE',
+		password_hash VARCHAR(255) NOT NULL DEFAULT '',
+		external_idp VARCHAR(100) NOT NULL DEFAULT '',
+		external_sub VARCHAR(255) NOT NULL DEFAULT '',
+		failed_attempts INT NOT NULL DEFAULT 0,
+		version BIGINT NOT NULL DEFAULT 1,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		deleted_at TIMESTAMP WITH TIME ZONE,
+		UNIQUE (email) WHERE deleted_at IS NULL
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.role_assignment (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		identity_id UUID NOT NULL,
+		granted_by UUID NOT NULL,
+		role VARCHAR(50) NOT NULL,
+		expires_at TIMESTAMP WITH TIME ZONE,
+		revoked_at TIMESTAMP WITH TIME ZONE,
+		revoked_by UUID,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.invitation (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		identity_id UUID NOT NULL,
+		invited_by UUID NOT NULL,
+		token_hash VARCHAR(64) NOT NULL UNIQUE,
+		expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	return tenant.WithTenant(context.Background(), tid)
+}
+
+// TestSaveNewIdentity verifies basic create + retrieve round-trip.
+func TestSaveNewIdentity(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	identity, err := domain.NewIdentity("alice@example.com")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, identity)
+	require.NoError(t, err)
+
+	retrieved, err := repo.FindByID(ctx, identity.ID())
+	require.NoError(t, err)
+	assert.Equal(t, identity.ID(), retrieved.ID())
+	assert.Equal(t, "alice@example.com", retrieved.Email())
+	assert.Equal(t, domain.IdentityStatusPendingInvite, retrieved.Status())
+	assert.Equal(t, int64(1), retrieved.Version())
+}
+
+// TestSaveIdentity_UpdateWithOptimisticLocking verifies that an updated identity
+// increments the version and persists field changes.
+func TestSaveIdentity_UpdateWithOptimisticLocking(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	identity, err := domain.NewIdentity("bob@example.com")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, identity)
+	require.NoError(t, err)
+
+	// Mutate: activate transitions status and increments version
+	err = identity.Activate()
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, identity)
+	require.NoError(t, err)
+
+	retrieved, err := repo.FindByID(ctx, identity.ID())
+	require.NoError(t, err)
+	assert.Equal(t, domain.IdentityStatusActive, retrieved.Status())
+	assert.Equal(t, int64(2), retrieved.Version())
+}
+
+// TestSaveIdentity_VersionConflict verifies that concurrent saves on stale version return ErrVersionConflict.
+func TestSaveIdentity_VersionConflict(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	identity, err := domain.NewIdentity("carol@example.com")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, identity)
+	require.NoError(t, err)
+
+	// Load the same identity into two separate instances
+	v1, err := repo.FindByID(ctx, identity.ID())
+	require.NoError(t, err)
+	v2, err := repo.FindByID(ctx, identity.ID())
+	require.NoError(t, err)
+
+	// First save succeeds
+	require.NoError(t, v1.Activate())
+	err = repo.Save(ctx, v1)
+	require.NoError(t, err)
+
+	// Second save on stale version fails
+	require.NoError(t, v2.Activate())
+	err = repo.Save(ctx, v2)
+	assert.ErrorIs(t, err, ErrVersionConflict)
+}
+
+// TestSaveIdentity_DuplicateEmail verifies that inserting a duplicate email returns ErrEmailAlreadyExists.
+func TestSaveIdentity_DuplicateEmail(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	first, err := domain.NewIdentity("dave@example.com")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, first))
+
+	second, err := domain.NewIdentity("dave@example.com")
+	require.NoError(t, err)
+	err = repo.Save(ctx, second)
+	assert.ErrorIs(t, err, domain.ErrEmailAlreadyExists)
+}
+
+// TestFindByID_NotFound verifies that a missing identity returns ErrIdentityNotFound.
+func TestFindByID_NotFound(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	_, err := repo.FindByID(ctx, uuid.New())
+	assert.ErrorIs(t, err, domain.ErrIdentityNotFound)
+}
+
+// TestFindByEmail verifies lookup by email address.
+func TestFindByEmail(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	identity, err := domain.NewIdentity("eve@example.com")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, identity))
+
+	retrieved, err := repo.FindByEmail(ctx, "eve@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, identity.ID(), retrieved.ID())
+}
+
+// TestFindByEmail_NotFound verifies that a missing email returns ErrIdentityNotFound.
+func TestFindByEmail_NotFound(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	_, err := repo.FindByEmail(ctx, "nobody@example.com")
+	assert.ErrorIs(t, err, domain.ErrIdentityNotFound)
+}
+
+// TestListByTenant verifies that all tenant identities are returned.
+func TestListByTenant(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	for _, email := range []string{"a@example.com", "b@example.com", "c@example.com"} {
+		identity, err := domain.NewIdentity(email)
+		require.NoError(t, err)
+		require.NoError(t, repo.Save(ctx, identity))
+	}
+
+	all, err := repo.ListByTenant(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+}
+
+// TestCrossTenantIsolation verifies that identities in one tenant are not visible to another.
+func TestCrossTenantIsolation(t *testing.T) {
+	db, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	tidA := tenant.TenantID(testTenantID)
+	tidB := tenant.TenantID(secondTenantID)
+
+	ctxA := tenant.WithTenant(context.Background(), tidA)
+	ctxB := setupTenantSchema(t, db, tidB)
+
+	repoA := NewRepository(db)
+	repoB := NewRepository(db)
+
+	// Save identity in tenant A
+	identityA, err := domain.NewIdentity("tenant-a@example.com")
+	require.NoError(t, err)
+	require.NoError(t, repoA.Save(ctxA, identityA))
+
+	// Tenant B should not see tenant A's identity
+	_, err = repoB.FindByID(ctxB, identityA.ID())
+	assert.ErrorIs(t, err, domain.ErrIdentityNotFound)
+
+	listB, err := repoB.ListByTenant(ctxB)
+	require.NoError(t, err)
+	assert.Empty(t, listB)
+}
+
+// TestSaveRoleAssignment_CreateAndRetrieve verifies basic role assignment persistence.
+func TestSaveRoleAssignment_CreateAndRetrieve(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	// Create an identity first
+	identity, err := domain.NewIdentity("frank@example.com")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, identity))
+
+	granterID := uuid.New()
+	assignment, err := domain.NewRoleAssignment(identity.ID(), granterID, string(domain.RolePlatform), string(domain.RoleAdmin))
+	require.NoError(t, err)
+
+	err = repo.SaveRoleAssignment(ctx, assignment)
+	require.NoError(t, err)
+
+	assignments, err := repo.FindRoleAssignments(ctx, identity.ID())
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	assert.Equal(t, assignment.ID(), assignments[0].ID())
+	assert.Equal(t, domain.RoleAdmin, assignments[0].Role())
+	assert.Nil(t, assignments[0].RevokedAt())
+}
+
+// TestSaveRoleAssignment_Revoke verifies that revoking a role assignment is persisted.
+func TestSaveRoleAssignment_Revoke(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	identity, err := domain.NewIdentity("grace@example.com")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, identity))
+
+	granterID := uuid.New()
+	assignment, err := domain.NewRoleAssignment(identity.ID(), granterID, string(domain.RolePlatform), string(domain.RoleViewer))
+	require.NoError(t, err)
+	require.NoError(t, repo.SaveRoleAssignment(ctx, assignment))
+
+	// Revoke the assignment
+	revokerID := uuid.New()
+	require.NoError(t, assignment.Revoke(revokerID))
+	require.NoError(t, repo.SaveRoleAssignment(ctx, assignment))
+
+	assignments, err := repo.FindRoleAssignments(ctx, identity.ID())
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	assert.NotNil(t, assignments[0].RevokedAt())
+	assert.Equal(t, revokerID, *assignments[0].RevokedBy())
+}
+
+// TestSaveInvitation_CreateAndRetrieveByTokenHash verifies invitation persistence.
+func TestSaveInvitation_CreateAndRetrieveByTokenHash(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	identity, err := domain.NewIdentity("henry@example.com")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, identity))
+
+	inviterID := uuid.New()
+	invitation, _, err := domain.NewInvitation(identity.ID(), inviterID)
+	require.NoError(t, err)
+
+	err = repo.SaveInvitation(ctx, invitation)
+	require.NoError(t, err)
+
+	retrieved, err := repo.FindInvitationByTokenHash(ctx, invitation.TokenHash())
+	require.NoError(t, err)
+	assert.Equal(t, invitation.ID(), retrieved.ID())
+	assert.Equal(t, domain.InvitationStatusPending, retrieved.Status())
+}
+
+// TestFindInvitationByTokenHash_NotFound verifies that a missing token returns ErrInvitationNotFound.
+func TestFindInvitationByTokenHash_NotFound(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	_, err := repo.FindInvitationByTokenHash(ctx, "nonexistent-hash")
+	assert.ErrorIs(t, err, domain.ErrInvitationNotFound)
+}
+
+// TestSaveInvitation_Accept verifies that accepting an invitation persists the status change.
+func TestSaveInvitation_Accept(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	identity, err := domain.NewIdentity("iris@example.com")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, identity))
+
+	inviterID := uuid.New()
+	invitation, _, err := domain.NewInvitation(identity.ID(), inviterID)
+	require.NoError(t, err)
+	require.NoError(t, repo.SaveInvitation(ctx, invitation))
+
+	require.NoError(t, invitation.Accept())
+	require.NoError(t, repo.SaveInvitation(ctx, invitation))
+
+	retrieved, err := repo.FindInvitationByTokenHash(ctx, invitation.TokenHash())
+	require.NoError(t, err)
+	assert.Equal(t, domain.InvitationStatusAccepted, retrieved.Status())
+}

--- a/services/identity/adapters/persistence/role_assignment_entity.go
+++ b/services/identity/adapters/persistence/role_assignment_entity.go
@@ -1,0 +1,57 @@
+package persistence
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/identity/domain"
+)
+
+// RoleAssignmentEntity represents the database persistence model for role assignments.
+type RoleAssignmentEntity struct {
+	ID         uuid.UUID  `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+	IdentityID uuid.UUID  `gorm:"column:identity_id;type:uuid;not null;index:idx_role_assignment_identity"`
+	GrantedBy  uuid.UUID  `gorm:"column:granted_by;type:uuid;not null"`
+	Role       string     `gorm:"column:role;type:varchar(50);not null"`
+	ExpiresAt  *time.Time `gorm:"column:expires_at"`
+	RevokedAt  *time.Time `gorm:"column:revoked_at"`
+	RevokedBy  *uuid.UUID `gorm:"column:revoked_by;type:uuid"`
+	CreatedAt  time.Time  `gorm:"column:created_at;not null;default:now()"`
+	UpdatedAt  time.Time  `gorm:"column:updated_at;not null;default:now()"`
+}
+
+// TableName overrides the default table name.
+// Partial unique index on (identity_id, role) WHERE revoked_at IS NULL is enforced via SQL migration (task 6).
+func (RoleAssignmentEntity) TableName() string {
+	return "role_assignment"
+}
+
+// toRoleAssignmentEntity converts a domain RoleAssignment to a persistence entity.
+func toRoleAssignmentEntity(ra *domain.RoleAssignment) *RoleAssignmentEntity {
+	return &RoleAssignmentEntity{
+		ID:         ra.ID(),
+		IdentityID: ra.IdentityID(),
+		GrantedBy:  ra.GrantedBy(),
+		Role:       string(ra.Role()),
+		ExpiresAt:  ra.ExpiresAt(),
+		RevokedAt:  ra.RevokedAt(),
+		RevokedBy:  ra.RevokedBy(),
+		CreatedAt:  ra.CreatedAt(),
+		UpdatedAt:  ra.UpdatedAt(),
+	}
+}
+
+// toRoleAssignmentDomain converts a persistence entity to a domain RoleAssignment.
+func toRoleAssignmentDomain(entity *RoleAssignmentEntity) *domain.RoleAssignment {
+	return domain.ReconstructRoleAssignment(
+		entity.ID,
+		entity.IdentityID,
+		entity.GrantedBy,
+		domain.Role(entity.Role),
+		entity.ExpiresAt,
+		entity.RevokedAt,
+		entity.RevokedBy,
+		entity.CreatedAt,
+		entity.UpdatedAt,
+	)
+}


### PR DESCRIPTION
## Summary

- Implements `services/identity/adapters/persistence/` following the party service persistence pattern
- Adds GORM entities for `Identity`, `RoleAssignment`, and `Invitation` domain objects with table names routing via CockroachDB `search_path` (tenant schema isolation)
- Implements `domain.Repository` interface with optimistic locking on `Identity` saves, duplicate email detection, and per-tenant query scoping via `shared/platform/db.WithGormTenantTransaction`
- Integration tests with CockroachDB testcontainers verify: create/read round-trip, optimistic locking conflict, duplicate email rejection, cross-tenant isolation, role revocation persistence, and invitation acceptance

## Changes Made

- `identity_entity.go`: `IdentityEntity` with GORM tags; `ToEntity`/`ToDomain` mappers; `TableName()` returns `"identity"`
- `role_assignment_entity.go`: `RoleAssignmentEntity`; private `toRoleAssignmentEntity`/`toRoleAssignmentDomain` converters; `TableName()` returns `"role_assignment"`; partial unique index on `(identity_id, role) WHERE revoked_at IS NULL` annotated (enforced at migration layer in task 6)
- `invitation_entity.go`: `InvitationEntity` with `uniqueIndex` on `token_hash`; `TableName()` returns `"invitation"`
- `repository.go`: `Repository` struct implementing `domain.Repository`; optimistic locking via `WHERE id = ? AND version = ?`; maps `ErrRecordNotFound` → `domain.ErrIdentityNotFound`, unique violations → `domain.ErrEmailAlreadyExists`
- `repository_test.go`: 14 integration tests using `testdb.SetupCockroachDB`

## Technical Details

- Optimistic locking: domain `Version` is pre-incremented on mutation; repository checks `version = entity.Version - 1` in the UPDATE WHERE clause; zero `RowsAffected` → `ErrVersionConflict`
- Tenant isolation: all queries go through `db.WithGormTenantTransaction` which sets `SET LOCAL search_path TO <tenant_schema>, public` scoped to the transaction
- No Atlas migration files created — that is task 6. Test tables are created inline with raw DDL matching the entity schema

## Testing

- 14 integration tests, all passing against CockroachDB v24.3.0 testcontainer
- Covers: happy path CRUD, optimistic locking conflict, duplicate email, not-found errors, cross-tenant isolation, role revocation, invitation acceptance

## Risk Assessment

Low. This is a new package with no callers yet; no existing code is modified.