### PR TITLE
feat(identity): add Atlas migrations and schema loader

### DIFF
--- a/internal/migrations/runner.go
+++ b/internal/migrations/runner.go
@@ -69,6 +69,7 @@ var ServiceDatabases = map[string]ServiceDatabase{
 	"tenant":               {Database: "meridian_platform", User: "meridian_platform_user", Password: ""},
 	"current-account":      {Database: "meridian_current_account", User: "meridian_current_account_user", Password: ""},
 	"financial-accounting": {Database: "meridian_financial_accounting", User: "meridian_financial_accounting_user", Password: ""},
+	"identity":             {Database: "meridian_identity", User: "meridian_identity_user", Password: ""},
 	"position-keeping":     {Database: "meridian_position_keeping", User: "meridian_position_keeping_user", Password: ""},
 	"payment-order":        {Database: "meridian_payment_order", User: "meridian_payment_order_user", Password: ""},
 	"party":                {Database: "meridian_party", User: "meridian_party_user", Password: ""},

--- a/services/identity/atlas/atlas.hcl
+++ b/services/identity/atlas/atlas.hcl
@@ -1,0 +1,77 @@
+// Atlas configuration for Identity Service
+// Manages platform identities (user accounts), role assignments, and invitations
+// Uses database-per-service architecture with unqualified table names
+//
+// Multi-tenant support:
+// - Migrations use unqualified table names (no schema prefix)
+// - For multi-org mode: search_path routes to organization schemas (org_{tenant_id})
+// - For local development: uses default public schema in service-specific database
+
+data "external_schema" "gorm" {
+  program = [
+    "go",
+    "run",
+    "-mod=mod",
+    "./utilities/atlas-loader",
+    "--schema=identity"
+  ]
+}
+
+env "local" {
+  // Service-specific migration directory
+  migration {
+    dir = "file://services/identity/migrations"
+  }
+
+  // Dev database - uses default public schema
+  dev = "docker://postgres/16/dev"
+
+  // Source schema from GORM models via external loader
+  src = data.external_schema.gorm.url
+
+  // Lint configuration to catch dangerous changes
+  lint {
+    destructive {
+      error = true
+    }
+    data_depend {
+      error = true
+    }
+    incompatible {
+      error = true
+    }
+  }
+}
+
+env "ci" {
+  migration {
+    dir = "file://services/identity/migrations"
+  }
+
+  dev = "docker://postgres/16/dev"
+
+  src = data.external_schema.gorm.url
+
+  lint {
+    destructive {
+      error = true
+    }
+    data_depend {
+      error = true
+    }
+    incompatible {
+      error = true
+    }
+  }
+}
+
+env "production" {
+  // Production environment - apply only, never diff
+  // URL points to service-specific database (meridian_identity)
+  // For multi-org: URL includes search_path for org schema
+  url = getenv("DATABASE_URL")
+
+  migration {
+    dir = "file://services/identity/migrations"
+  }
+}

--- a/services/identity/migrations/20260302000001_initial.sql
+++ b/services/identity/migrations/20260302000001_initial.sql
@@ -35,7 +35,10 @@ CREATE TABLE "role_assignment" (
   "created_at" timestamptz NOT NULL DEFAULT now(),
   "updated_at" timestamptz NOT NULL DEFAULT now(),
   PRIMARY KEY ("id"),
-  CONSTRAINT "chk_role_assignment_role" CHECK (role IN ('VIEWER', 'OPERATOR', 'ADMIN', 'TENANT_OWNER', 'PLATFORM'))
+  CONSTRAINT "chk_role_assignment_role" CHECK (role IN ('VIEWER', 'OPERATOR', 'ADMIN', 'TENANT_OWNER', 'PLATFORM')),
+  CONSTRAINT "fk_role_assignment_identity" FOREIGN KEY ("identity_id") REFERENCES "identity" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT,
+  CONSTRAINT "fk_role_assignment_granted_by" FOREIGN KEY ("granted_by") REFERENCES "identity" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT,
+  CONSTRAINT "fk_role_assignment_revoked_by" FOREIGN KEY ("revoked_by") REFERENCES "identity" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT
 );
 -- Indexes for role_assignment
 CREATE INDEX "idx_role_assignment_identity" ON "role_assignment" ("identity_id");
@@ -54,7 +57,9 @@ CREATE TABLE "invitation" (
   "created_at" timestamptz NOT NULL DEFAULT now(),
   "updated_at" timestamptz NOT NULL DEFAULT now(),
   PRIMARY KEY ("id"),
-  CONSTRAINT "chk_invitation_status" CHECK (status IN ('PENDING', 'ACCEPTED'))
+  CONSTRAINT "chk_invitation_status" CHECK (status IN ('PENDING', 'ACCEPTED')),
+  CONSTRAINT "fk_invitation_identity" FOREIGN KEY ("identity_id") REFERENCES "identity" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT,
+  CONSTRAINT "fk_invitation_invited_by" FOREIGN KEY ("invited_by") REFERENCES "identity" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT
 );
 -- Indexes for invitation
 CREATE INDEX "idx_invitation_identity" ON "invitation" ("identity_id");

--- a/services/identity/migrations/20260302000001_initial.sql
+++ b/services/identity/migrations/20260302000001_initial.sql
@@ -1,0 +1,61 @@
+-- Identity Service Schema
+-- Uses UNQUALIFIED table names to support multi-organization routing via search_path.
+-- For local dev: search_path routes to default schema
+-- For multi-org: org schemas created by provisioning, search_path routes to org schema
+
+-- Create "identity" table (singular, unqualified - uses search_path for schema routing)
+CREATE TABLE "identity" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "email" character varying(255) NOT NULL,
+  "status" character varying(30) NOT NULL DEFAULT 'PENDING_INVITE',
+  "password_hash" character varying(255) NOT NULL DEFAULT '',
+  "external_idp" character varying(100) NOT NULL DEFAULT '',
+  "external_sub" character varying(255) NOT NULL DEFAULT '',
+  "failed_attempts" bigint NOT NULL DEFAULT 0,
+  "version" bigint NOT NULL DEFAULT 1,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  "deleted_at" timestamptz NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "chk_identity_status" CHECK (status IN ('PENDING_INVITE', 'ACTIVE', 'SUSPENDED', 'LOCKED'))
+);
+-- Indexes for identity
+CREATE UNIQUE INDEX "idx_identity_email" ON "identity" ("email") WHERE (deleted_at IS NULL);
+CREATE INDEX "idx_identity_deleted_at" ON "identity" ("deleted_at");
+
+-- Create "role_assignment" table
+CREATE TABLE "role_assignment" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "identity_id" uuid NOT NULL,
+  "granted_by" uuid NOT NULL,
+  "role" character varying(50) NOT NULL,
+  "expires_at" timestamptz NULL,
+  "revoked_at" timestamptz NULL,
+  "revoked_by" uuid NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "chk_role_assignment_role" CHECK (role IN ('VIEWER', 'OPERATOR', 'ADMIN', 'TENANT_OWNER', 'PLATFORM'))
+);
+-- Indexes for role_assignment
+CREATE INDEX "idx_role_assignment_identity" ON "role_assignment" ("identity_id");
+-- Partial unique index enforces one active role per (identity, role) pair.
+-- CockroachDB: partial index on existing columns in a separate statement is safe.
+CREATE UNIQUE INDEX "idx_role_assignment_active" ON "role_assignment" ("identity_id", "role") WHERE (revoked_at IS NULL);
+
+-- Create "invitation" table
+CREATE TABLE "invitation" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "identity_id" uuid NOT NULL,
+  "invited_by" uuid NOT NULL,
+  "token_hash" character varying(64) NOT NULL,
+  "expires_at" timestamptz NOT NULL,
+  "status" character varying(20) NOT NULL DEFAULT 'PENDING',
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "chk_invitation_status" CHECK (status IN ('PENDING', 'ACCEPTED'))
+);
+-- Indexes for invitation
+CREATE INDEX "idx_invitation_identity" ON "invitation" ("identity_id");
+CREATE UNIQUE INDEX "idx_invitation_token_hash" ON "invitation" ("token_hash");

--- a/services/identity/migrations/atlas.sum
+++ b/services/identity/migrations/atlas.sum
@@ -1,0 +1,2 @@
+h1:xB0UKdcoLffUu10i1CPJukha5b6vjGC4qhCr/sNOq5Y=
+20260302000001_initial.sql h1:kshvBLEa1ewgitM2ynKFpDnJkeU/I4NCXu1+cdEAbTg=

--- a/services/identity/migrations/atlas.sum
+++ b/services/identity/migrations/atlas.sum
@@ -1,2 +1,2 @@
-h1:xB0UKdcoLffUu10i1CPJukha5b6vjGC4qhCr/sNOq5Y=
-20260302000001_initial.sql h1:kshvBLEa1ewgitM2ynKFpDnJkeU/I4NCXu1+cdEAbTg=
+h1:Tn/5cytIH9dlz3yIx//SIVmDVeh83jHJ9Z5V1R7Jz+w=
+20260302000001_initial.sql h1:SsQN4cGTrm/6qs12GD9YXoSO6QyKTIpNZrM+4rRBWJA=

--- a/utilities/atlas-loader/main.go
+++ b/utilities/atlas-loader/main.go
@@ -10,6 +10,7 @@ import (
 	"ariga.io/atlas-provider-gorm/gormschema"
 	capersistence "github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	fapersistence "github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
+	identitypersistence "github.com/meridianhub/meridian/services/identity/adapters/persistence"
 	partypersistence "github.com/meridianhub/meridian/services/party/adapters/persistence"
 	popersistence "github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
 	tenantpersistence "github.com/meridianhub/meridian/services/tenant/adapters/persistence"
@@ -23,6 +24,7 @@ const (
 	schemaCurrentAccount      = "current_account"
 	schemaPositionKeeping     = "position_keeping"
 	schemaFinancialAccounting = "financial_accounting"
+	schemaIdentity            = "identity"
 	schemaParty               = "party"
 	schemaPaymentOrder        = "payment_order"
 	schemaPlatform            = "platform"
@@ -30,7 +32,7 @@ const (
 
 func main() {
 	// Parse schema filter flag
-	schemaFilter := flag.String("schema", "", "Filter models by schema (current_account, position_keeping, financial_accounting, party, payment_order, platform)")
+	schemaFilter := flag.String("schema", "", "Filter models by schema (current_account, position_keeping, financial_accounting, identity, party, payment_order, platform)")
 	flag.Parse()
 
 	// Determine which models to load based on schema filter
@@ -62,6 +64,13 @@ func main() {
 		modelList = []interface{}{
 			&fapersistence.FinancialBookingLogEntity{},
 			&fapersistence.LedgerPostingEntity{},
+		}
+	case schemaIdentity:
+		// Identity service for platform user accounts, roles, and invitations
+		modelList = []interface{}{
+			&identitypersistence.IdentityEntity{},
+			&identitypersistence.RoleAssignmentEntity{},
+			&identitypersistence.InvitationEntity{},
 		}
 	case schemaParty:
 		// Party service for customer/organization identity management


### PR DESCRIPTION
## Summary

- Creates `services/identity/atlas/atlas.hcl` with local, ci, and production environments following the same pattern as `services/party/atlas/atlas.hcl`
- Creates `services/identity/migrations/20260302000001_initial.sql` with the initial schema for `identity`, `role_assignment`, and `invitation` tables
- Updates `utilities/atlas-loader/main.go` to support `--schema=identity`, loading the three identity persistence entities

## Changes

### `services/identity/atlas/atlas.hcl`
Atlas configuration with `external_schema` loader pointing to `--schema=identity`. Three environments: `local` and `ci` (with destructive/data-depend/incompatible lint rules), and `production` (apply-only via `DATABASE_URL`).

### `services/identity/migrations/20260302000001_initial.sql`
Initial migration creating three tables:

**`identity`**: UUID primary key, email with partial unique index (where `deleted_at IS NULL`), status with CHECK constraint (`PENDING_INVITE`, `ACTIVE`, `SUSPENDED`, `LOCKED`), password hash, external IDP fields, failed login attempt counter, optimistic locking version, and soft-delete timestamp.

**`role_assignment`**: UUID primary key, FK to identity, role with CHECK constraint (`VIEWER`, `OPERATOR`, `ADMIN`, `TENANT_OWNER`, `PLATFORM`), optional expiry and revocation fields, and a partial unique index on `(identity_id, role) WHERE revoked_at IS NULL` enforcing one active assignment per identity per role.

**`invitation`**: UUID primary key, FK to identity, SHA256 token hash with unique index, expiry timestamp, and status with CHECK constraint (`PENDING`, `ACCEPTED`).

CockroachDB compliance: no triggers, no `CONCURRENTLY`, no expression indexes, partial index placed in same migration as CREATE TABLE (safe since column is committed in same DDL statement).

### `utilities/atlas-loader/main.go`
Added `schemaIdentity = "identity"` constant and corresponding case loading `IdentityEntity`, `RoleAssignmentEntity`, and `InvitationEntity`. Updated flag description to include `identity`.

## Testing

- `atlas migrate hash` run to generate `atlas.sum` integrity file
- `atlas migrate validate --dir file://services/identity/migrations --dev-url docker://postgres/16/dev` passes cleanly
- `go run ./utilities/atlas-loader --schema=identity` outputs correct DDL matching the GORM entity definitions
- `go build ./utilities/atlas-loader/` compiles without errors

## Task Master

identity-access-management.6