### PR TITLE
chore: add GitHub Action to mark CLA as passed for bot contributors

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,21 @@
+name: CLA Bot Bypass
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  cla-bot-bypass:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.user.login, '[bot]')
+    steps:
+      - name: Mark CLA passed for bot contributors
+        run: |
+          gh api "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            --method POST \
+            -f state=success \
+            -f description="CLA not required for bot contributors" \
+            -f context="license/cla" \
+            -f target_url="https://cla-assistant.io/meridianhub/meridian"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,8 +4,12 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   cla-bot-bypass:
+    permissions:
+      statuses: write
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.user.login, '[bot]')
     steps:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/cla.yml` — a workflow that marks `license/cla` as **success** for bot contributors (e.g. dependabot, renovate)
- Leaves the existing cla-assistant.io webhook untouched for human contributors

## Problem

The hosted cla-assistant.io webhook service does not honour the `.clabot` allowlist file. All dependabot PRs remain in `PENDING` state indefinitely, even after the allowlist was added in PR #516. This is visible on every open dependabot PR (#1344–#1349) and confirmed on merged PRs (e.g. #1152 was merged with `license/cla: pending`).

## Solution

A `pull_request_target` workflow triggers on bot PRs (detected via `[bot]` in the login) and calls the GitHub Statuses API to set `license/cla` to `success` with the same context string the cla-assistant service uses. No PAT or extra secrets required — `GITHUB_TOKEN` has sufficient permissions.

Human contributor PRs are unaffected: the existing cla-assistant.io webhook continues to handle them.

## Testing

After merge, open a new dependabot PR (or rebase an existing one) and confirm the `license/cla` check shows green rather than pending.