### PR TITLE
feat: implement Dex gRPC connector for identity service

### DIFF
--- a/services/identity/connector/claims.go
+++ b/services/identity/connector/claims.go
@@ -1,0 +1,35 @@
+package connector
+
+import "github.com/meridianhub/meridian/shared/platform/tenant"
+
+// BuildClaims constructs the JWT custom claims map for an authenticated identity.
+// The map is consumed by Dex's ID-token builder when enriching tokens with
+// connector-provided attributes.
+//
+// Claim keys follow the shared platform conventions:
+//   - "sub"        — stable user identifier (UUID)
+//   - "email"      — verified email address
+//   - "name"       — display name (falls back to email when not set)
+//   - "x-tenant-id" — tenant identifier injected into every token for downstream routing
+//   - "roles"      — active role names; downstream services use this for RBAC
+//   - "groups"     — mirrors roles; included for compatibility with Dex's group claim handling
+func BuildClaims(identity Identity, tenantID tenant.TenantID) map[string]interface{} {
+	name := identity.Username
+	if name == "" {
+		name = identity.Email
+	}
+
+	roles := identity.Groups
+	if roles == nil {
+		roles = []string{}
+	}
+
+	return map[string]interface{}{
+		"sub":              identity.UserID,
+		"email":            identity.Email,
+		"name":             name,
+		tenant.TenantIDKey: tenantID.String(),
+		"roles":            roles,
+		"groups":           roles,
+	}
+}

--- a/services/identity/connector/claims_test.go
+++ b/services/identity/connector/claims_test.go
@@ -1,0 +1,74 @@
+package connector_test
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/services/identity/connector"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildClaims_FullIdentity(t *testing.T) {
+	tid, err := tenant.NewTenantID("volterra")
+	require.NoError(t, err)
+
+	id := connector.Identity{
+		UserID:   "user-uuid-123",
+		Username: "Alice",
+		Email:    "alice@example.com",
+		Groups:   []string{"ADMIN", "OPERATOR"},
+	}
+
+	claims := connector.BuildClaims(id, tid)
+
+	assert.Equal(t, "user-uuid-123", claims["sub"])
+	assert.Equal(t, "alice@example.com", claims["email"])
+	assert.Equal(t, "Alice", claims["name"])
+	assert.Equal(t, "volterra", claims["x-tenant-id"])
+	assert.Equal(t, []string{"ADMIN", "OPERATOR"}, claims["roles"])
+	assert.Equal(t, []string{"ADMIN", "OPERATOR"}, claims["groups"])
+}
+
+func TestBuildClaims_EmptyUsernameDefaultsToEmail(t *testing.T) {
+	tid, err := tenant.NewTenantID("acme")
+	require.NoError(t, err)
+
+	id := connector.Identity{
+		UserID: "user-uuid-456",
+		Email:  "bob@example.com",
+		// Username intentionally empty
+	}
+
+	claims := connector.BuildClaims(id, tid)
+
+	assert.Equal(t, "bob@example.com", claims["name"])
+}
+
+func TestBuildClaims_NilGroupsProducesEmptySlice(t *testing.T) {
+	tid, err := tenant.NewTenantID("demo")
+	require.NoError(t, err)
+
+	id := connector.Identity{
+		UserID: "user-uuid-789",
+		Email:  "carol@example.com",
+		Groups: nil,
+	}
+
+	claims := connector.BuildClaims(id, tid)
+
+	roles, ok := claims["roles"].([]string)
+	require.True(t, ok)
+	assert.Empty(t, roles)
+}
+
+func TestBuildClaims_TenantIDPropagated(t *testing.T) {
+	tid, err := tenant.NewTenantID("tenant_xyz")
+	require.NoError(t, err)
+
+	id := connector.Identity{UserID: "u1", Email: "e@e.com"}
+
+	claims := connector.BuildClaims(id, tid)
+
+	assert.Equal(t, "tenant_xyz", claims["x-tenant-id"])
+}

--- a/services/identity/connector/connector.go
+++ b/services/identity/connector/connector.go
@@ -1,0 +1,207 @@
+// Package connector implements a local Dex password connector that validates
+// credentials directly against the identity domain layer without a network hop.
+//
+// Dex supports pluggable connectors via the connector.PasswordConnector interface.
+// Since Meridian runs Dex in the same process (or tightly coupled), this connector
+// bypasses HTTP/gRPC overhead by calling the domain repository directly.
+//
+// The connector:
+//   - Resolves the tenant from context metadata (set by the gateway from subdomain)
+//   - Looks up the identity by email within that tenant scope
+//   - Validates the password using bcrypt via the credentials package
+//   - Checks account status (locked, suspended, pending invite → reject)
+//   - Queries active role assignments and maps them to Dex groups
+//   - Returns a connector.Identity with groups populated for JWT claim injection
+package connector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/meridianhub/meridian/services/identity/domain"
+	"github.com/meridianhub/meridian/shared/pkg/credentials"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// Identity represents the result of a successful authentication, compatible with
+// Dex's connector.Identity shape. Groups are populated with the identity's active roles
+// and are injected into the JWT as the "groups" claim by Dex.
+type Identity struct {
+	// UserID is the stable identifier for the user (UUID string).
+	UserID string
+	// Username is the display name, defaulting to email if not set.
+	Username string
+	// Email is the verified email address.
+	Email string
+	// EmailVerified indicates whether the email has been verified.
+	EmailVerified bool
+	// Groups contains active role assignments, used to populate JWT group claims.
+	Groups []string
+	// ConnectorData is opaque bytes stored by Dex for refresh token support.
+	ConnectorData []byte
+}
+
+// LoginResult is returned by Login to convey both success state and the identity.
+type LoginResult struct {
+	Identity Identity
+	// Valid is true when authentication succeeded.
+	Valid bool
+}
+
+// PasswordConnector validates username/password credentials.
+// This interface mirrors Dex's connector.PasswordConnector to keep the implementation
+// decoupled from the Dex library (which is not a declared Go module dependency).
+type PasswordConnector interface {
+	// Login validates credentials and returns the identity on success.
+	// valid is false when credentials are incorrect without an underlying error.
+	Login(ctx context.Context, scopes []string, username, password string) (identity Identity, valid bool, err error)
+}
+
+// ErrRepositoryNil is returned by New when a nil repository is provided.
+var ErrRepositoryNil = errors.New("connector: repository must not be nil")
+
+// Connector is the local implementation of PasswordConnector.
+// It performs credential validation and role resolution directly against the
+// identity domain repository, avoiding any network hop.
+type Connector struct {
+	repo   domain.Repository
+	logger *slog.Logger
+}
+
+// New creates a Connector with the given repository. If logger is nil a default
+// JSON logger writing to stdout is used.
+func New(repo domain.Repository, logger *slog.Logger) (*Connector, error) {
+	if repo == nil {
+		return nil, ErrRepositoryNil
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	}
+	return &Connector{repo: repo, logger: logger}, nil
+}
+
+// Login validates the supplied username (email) and password against the identity
+// domain within the tenant derived from ctx.
+//
+// Returns:
+//   - (identity, true, nil) on success
+//   - (zero, false, nil) when credentials are simply wrong (no programming error)
+//   - (zero, false, err) only for unexpected infrastructure errors
+func (c *Connector) Login(ctx context.Context, _ []string, username, password string) (Identity, bool, error) {
+	tenantID, err := tenant.RequireFromContext(ctx)
+	if err != nil {
+		c.logger.ErrorContext(ctx, "connector: tenant context missing during login",
+			"username", username,
+			"error", err)
+		return Identity{}, false, fmt.Errorf("connector: %w", err)
+	}
+
+	identity, err := c.repo.FindByEmail(ctx, username)
+	if err != nil {
+		if errors.Is(err, domain.ErrIdentityNotFound) {
+			c.logger.InfoContext(ctx, "connector: identity not found",
+				"tenant_id", tenantID,
+				"username", username)
+			return Identity{}, false, nil
+		}
+		c.logger.ErrorContext(ctx, "connector: repository error looking up identity",
+			"tenant_id", tenantID,
+			"username", username,
+			"error", err)
+		return Identity{}, false, fmt.Errorf("connector: lookup identity: %w", err)
+	}
+
+	// Reject non-active accounts before any password check.
+	switch identity.Status() {
+	case domain.IdentityStatusLocked:
+		c.logger.InfoContext(ctx, "connector: login rejected — account locked",
+			"tenant_id", tenantID,
+			"identity_id", identity.ID())
+		return Identity{}, false, nil
+	case domain.IdentityStatusSuspended:
+		c.logger.InfoContext(ctx, "connector: login rejected — account suspended",
+			"tenant_id", tenantID,
+			"identity_id", identity.ID())
+		return Identity{}, false, nil
+	case domain.IdentityStatusPendingInvite:
+		c.logger.InfoContext(ctx, "connector: login rejected — account not yet activated",
+			"tenant_id", tenantID,
+			"identity_id", identity.ID())
+		return Identity{}, false, nil
+	case domain.IdentityStatusActive:
+		// valid — proceed to password verification
+	default:
+		c.logger.WarnContext(ctx, "connector: login rejected — unknown account status",
+			"tenant_id", tenantID,
+			"identity_id", identity.ID(),
+			"status", identity.Status())
+		return Identity{}, false, nil
+	}
+
+	if err := credentials.ValidatePassword(password, identity.PasswordHash()); err != nil {
+		// Record the failed attempt; best-effort — do not surface save errors to caller.
+		_ = identity.RecordLoginAttempt(false)
+		if saveErr := c.repo.Save(ctx, identity); saveErr != nil {
+			c.logger.ErrorContext(ctx, "connector: failed to persist failed login attempt",
+				"identity_id", identity.ID(),
+				"error", saveErr)
+		}
+		c.logger.InfoContext(ctx, "connector: invalid password",
+			"tenant_id", tenantID,
+			"identity_id", identity.ID())
+		return Identity{}, false, nil
+	}
+
+	// Record successful login; best-effort.
+	_ = identity.RecordLoginAttempt(true)
+	if saveErr := c.repo.Save(ctx, identity); saveErr != nil {
+		c.logger.ErrorContext(ctx, "connector: failed to persist successful login",
+			"identity_id", identity.ID(),
+			"error", saveErr)
+	}
+
+	// Resolve active role assignments → Dex groups.
+	groups, err := c.activeRoles(ctx, identity)
+	if err != nil {
+		// Non-fatal: log and proceed with empty groups rather than denying login.
+		c.logger.ErrorContext(ctx, "connector: failed to load role assignments",
+			"identity_id", identity.ID(),
+			"error", err)
+		groups = []string{}
+	}
+
+	connIdentity := Identity{
+		UserID:        identity.ID().String(),
+		Username:      identity.Email(),
+		Email:         identity.Email(),
+		EmailVerified: true,
+		Groups:        groups,
+	}
+
+	c.logger.InfoContext(ctx, "connector: login successful",
+		"tenant_id", tenantID,
+		"identity_id", identity.ID(),
+		"roles", groups)
+
+	return connIdentity, true, nil
+}
+
+// activeRoles returns the string role names for all non-revoked, non-expired
+// role assignments associated with the given identity.
+func (c *Connector) activeRoles(ctx context.Context, identity *domain.Identity) ([]string, error) {
+	assignments, err := c.repo.FindRoleAssignments(ctx, identity.ID())
+	if err != nil {
+		return nil, fmt.Errorf("find role assignments: %w", err)
+	}
+
+	roles := make([]string, 0, len(assignments))
+	for _, a := range assignments {
+		if a.IsActive() {
+			roles = append(roles, string(a.Role()))
+		}
+	}
+	return roles, nil
+}

--- a/services/identity/connector/connector.go
+++ b/services/identity/connector/connector.go
@@ -94,7 +94,6 @@ func (c *Connector) Login(ctx context.Context, _ []string, username, password st
 	tenantID, err := tenant.RequireFromContext(ctx)
 	if err != nil {
 		c.logger.ErrorContext(ctx, "connector: tenant context missing during login",
-			"username", username,
 			"error", err)
 		return Identity{}, false, fmt.Errorf("connector: %w", err)
 	}
@@ -103,8 +102,7 @@ func (c *Connector) Login(ctx context.Context, _ []string, username, password st
 	if err != nil {
 		if errors.Is(err, domain.ErrIdentityNotFound) {
 			c.logger.InfoContext(ctx, "connector: identity not found",
-				"tenant_id", tenantID,
-				"username", username)
+				"tenant_id", tenantID)
 			return Identity{}, false, nil
 		}
 		c.logger.ErrorContext(ctx, "connector: repository error looking up identity",

--- a/services/identity/connector/connector_test.go
+++ b/services/identity/connector/connector_test.go
@@ -1,0 +1,353 @@
+package connector_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/identity/connector"
+	"github.com/meridianhub/meridian/services/identity/domain"
+	"github.com/meridianhub/meridian/shared/pkg/credentials"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func now() time.Time { return time.Now() }
+
+// --- Mock repository ---
+
+type mockRepo struct {
+	identity    *domain.Identity
+	assignments []*domain.RoleAssignment
+
+	findByEmailErr error
+	findRoleErr    error
+	saveErr        error
+}
+
+func (m *mockRepo) Save(_ context.Context, id *domain.Identity) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.identity = id
+	return nil
+}
+
+func (m *mockRepo) FindByID(_ context.Context, _ uuid.UUID) (*domain.Identity, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockRepo) FindByEmail(_ context.Context, _ string) (*domain.Identity, error) {
+	if m.findByEmailErr != nil {
+		return nil, m.findByEmailErr
+	}
+	if m.identity == nil {
+		return nil, domain.ErrIdentityNotFound
+	}
+	return m.identity, nil
+}
+
+func (m *mockRepo) ListByTenant(_ context.Context) ([]*domain.Identity, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockRepo) SaveRoleAssignment(_ context.Context, _ *domain.RoleAssignment) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockRepo) FindRoleAssignments(_ context.Context, _ uuid.UUID) ([]*domain.RoleAssignment, error) {
+	if m.findRoleErr != nil {
+		return nil, m.findRoleErr
+	}
+	return m.assignments, nil
+}
+
+func (m *mockRepo) SaveIdentityWithInvitation(_ context.Context, _ *domain.Identity, _ *domain.Invitation) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockRepo) SaveInvitation(_ context.Context, _ *domain.Invitation) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockRepo) FindInvitationByTokenHash(_ context.Context, _ string) (*domain.Invitation, error) {
+	return nil, errors.New("not implemented")
+}
+
+// --- Helpers ---
+
+const testPassword = "ValidPassword1!"
+
+func makeActiveIdentity(t *testing.T, email string) *domain.Identity {
+	t.Helper()
+	id, err := domain.NewIdentity(email)
+	require.NoError(t, err)
+
+	hash, err := credentials.HashPassword(testPassword)
+	require.NoError(t, err)
+	require.NoError(t, id.SetPassword(hash))
+	require.NoError(t, id.Activate())
+	return id
+}
+
+func ctxWithTenant(t *testing.T, tid string) context.Context {
+	t.Helper()
+	tenantID, err := tenant.NewTenantID(tid)
+	require.NoError(t, err)
+	return tenant.WithTenant(context.Background(), tenantID)
+}
+
+func newConnector(t *testing.T, repo domain.Repository) *connector.Connector {
+	t.Helper()
+	c, err := connector.New(repo, slog.Default())
+	require.NoError(t, err)
+	return c
+}
+
+// --- New tests ---
+
+func TestNew_NilRepository(t *testing.T) {
+	_, err := connector.New(nil, nil)
+	require.Error(t, err)
+}
+
+func TestNew_NilLogger_UsesDefault(t *testing.T) {
+	repo := &mockRepo{identity: makeActiveIdentity(t, "a@example.com")}
+	c, err := connector.New(repo, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+}
+
+// --- Login: success ---
+
+func TestLogin_Success(t *testing.T) {
+	identity := makeActiveIdentity(t, "alice@example.com")
+	repo := &mockRepo{identity: identity}
+	c := newConnector(t, repo)
+	ctx := ctxWithTenant(t, "volterra")
+
+	got, valid, err := c.Login(ctx, nil, "alice@example.com", testPassword)
+
+	require.NoError(t, err)
+	assert.True(t, valid)
+	assert.Equal(t, identity.ID().String(), got.UserID)
+	assert.Equal(t, "alice@example.com", got.Email)
+	assert.True(t, got.EmailVerified)
+}
+
+func TestLogin_Success_PopulatesGroups(t *testing.T) {
+	identity := makeActiveIdentity(t, "bob@example.com")
+
+	// Build two active assignments.
+	adminAssign := domain.ReconstructRoleAssignment(
+		uuid.New(), identity.ID(), uuid.New(),
+		domain.RoleAdmin, nil, nil, nil,
+		now(), now(),
+	)
+	operatorAssign := domain.ReconstructRoleAssignment(
+		uuid.New(), identity.ID(), uuid.New(),
+		domain.RoleOperator, nil, nil, nil,
+		now(), now(),
+	)
+
+	repo := &mockRepo{
+		identity:    identity,
+		assignments: []*domain.RoleAssignment{adminAssign, operatorAssign},
+	}
+	c := newConnector(t, repo)
+	ctx := ctxWithTenant(t, "volterra")
+
+	got, valid, err := c.Login(ctx, nil, "bob@example.com", testPassword)
+
+	require.NoError(t, err)
+	require.True(t, valid)
+	assert.ElementsMatch(t, []string{"ADMIN", "OPERATOR"}, got.Groups)
+}
+
+func TestLogin_Success_SkipsRevokedAssignments(t *testing.T) {
+	identity := makeActiveIdentity(t, "carol@example.com")
+
+	active := domain.ReconstructRoleAssignment(
+		uuid.New(), identity.ID(), uuid.New(),
+		domain.RoleAdmin, nil, nil, nil,
+		now(), now(),
+	)
+	// Revoked assignment — should be excluded.
+	revokedBy := uuid.New()
+	revokedAt := now()
+	revoked := domain.ReconstructRoleAssignment(
+		uuid.New(), identity.ID(), uuid.New(),
+		domain.RoleOperator, nil, &revokedAt, &revokedBy,
+		now(), now(),
+	)
+
+	repo := &mockRepo{
+		identity:    identity,
+		assignments: []*domain.RoleAssignment{active, revoked},
+	}
+	c := newConnector(t, repo)
+	ctx := ctxWithTenant(t, "volterra")
+
+	got, valid, err := c.Login(ctx, nil, "carol@example.com", testPassword)
+
+	require.NoError(t, err)
+	require.True(t, valid)
+	assert.Equal(t, []string{"ADMIN"}, got.Groups)
+}
+
+// --- Login: wrong password ---
+
+func TestLogin_WrongPassword_ReturnsFalse(t *testing.T) {
+	identity := makeActiveIdentity(t, "dave@example.com")
+	repo := &mockRepo{identity: identity}
+	c := newConnector(t, repo)
+	ctx := ctxWithTenant(t, "volterra")
+
+	got, valid, err := c.Login(ctx, nil, "dave@example.com", "WrongPassword999!")
+
+	require.NoError(t, err)
+	assert.False(t, valid)
+	assert.Empty(t, got.UserID)
+}
+
+// --- Login: account states ---
+
+func TestLogin_LockedAccount_ReturnsFalse(t *testing.T) {
+	id, err := domain.NewIdentity("locked@example.com")
+	require.NoError(t, err)
+	hash, err := credentials.HashPassword(testPassword)
+	require.NoError(t, err)
+	require.NoError(t, id.SetPassword(hash))
+	require.NoError(t, id.Activate())
+	// Lock via RecordLoginAttempt failures (5 attempts).
+	for range 5 {
+		_ = id.RecordLoginAttempt(false)
+	}
+	require.True(t, id.IsLocked())
+
+	repo := &mockRepo{identity: id}
+	c := newConnector(t, repo)
+	ctx := ctxWithTenant(t, "volterra")
+
+	_, valid, err := c.Login(ctx, nil, "locked@example.com", testPassword)
+
+	require.NoError(t, err)
+	assert.False(t, valid)
+}
+
+func TestLogin_SuspendedAccount_ReturnsFalse(t *testing.T) {
+	id, err := domain.NewIdentity("suspended@example.com")
+	require.NoError(t, err)
+	hash, err := credentials.HashPassword(testPassword)
+	require.NoError(t, err)
+	require.NoError(t, id.SetPassword(hash))
+	require.NoError(t, id.Activate())
+	require.NoError(t, id.Suspend())
+
+	repo := &mockRepo{identity: id}
+	c := newConnector(t, repo)
+	ctx := ctxWithTenant(t, "volterra")
+
+	_, valid, err := c.Login(ctx, nil, "suspended@example.com", testPassword)
+
+	require.NoError(t, err)
+	assert.False(t, valid)
+}
+
+func TestLogin_PendingInviteAccount_ReturnsFalse(t *testing.T) {
+	// NewIdentity starts in PENDING_INVITE — no need to transition.
+	id, err := domain.NewIdentity("pending@example.com")
+	require.NoError(t, err)
+
+	repo := &mockRepo{identity: id}
+	c := newConnector(t, repo)
+	ctx := ctxWithTenant(t, "volterra")
+
+	_, valid, err := c.Login(ctx, nil, "pending@example.com", testPassword)
+
+	require.NoError(t, err)
+	assert.False(t, valid)
+}
+
+// --- Login: not found ---
+
+func TestLogin_IdentityNotFound_ReturnsFalse(t *testing.T) {
+	repo := &mockRepo{} // identity is nil → FindByEmail returns ErrIdentityNotFound
+	c := newConnector(t, repo)
+	ctx := ctxWithTenant(t, "volterra")
+
+	_, valid, err := c.Login(ctx, nil, "nobody@example.com", testPassword)
+
+	require.NoError(t, err)
+	assert.False(t, valid)
+}
+
+// --- Login: infrastructure errors ---
+
+func TestLogin_RepositoryError_ReturnsError(t *testing.T) {
+	repo := &mockRepo{findByEmailErr: errors.New("db connection lost")}
+	c := newConnector(t, repo)
+	ctx := ctxWithTenant(t, "volterra")
+
+	_, valid, err := c.Login(ctx, nil, "err@example.com", testPassword)
+
+	require.Error(t, err)
+	assert.False(t, valid)
+}
+
+func TestLogin_RoleQueryError_SucceedsWithEmptyGroups(t *testing.T) {
+	// Role resolution failure is non-fatal — login should still succeed.
+	identity := makeActiveIdentity(t, "grace@example.com")
+	repo := &mockRepo{
+		identity:    identity,
+		findRoleErr: errors.New("role service unavailable"),
+	}
+	c := newConnector(t, repo)
+	ctx := ctxWithTenant(t, "volterra")
+
+	got, valid, err := c.Login(ctx, nil, "grace@example.com", testPassword)
+
+	require.NoError(t, err)
+	assert.True(t, valid)
+	assert.Empty(t, got.Groups)
+}
+
+// --- Login: missing tenant context ---
+
+func TestLogin_MissingTenantContext_ReturnsError(t *testing.T) {
+	identity := makeActiveIdentity(t, "henry@example.com")
+	repo := &mockRepo{identity: identity}
+	c := newConnector(t, repo)
+	ctx := context.Background() // no tenant set
+
+	_, valid, err := c.Login(ctx, nil, "henry@example.com", testPassword)
+
+	require.Error(t, err)
+	assert.False(t, valid)
+}
+
+// --- Tenant propagation ---
+
+func TestLogin_TenantContextPropagation(t *testing.T) {
+	// Verifies the connector routes within tenant scope by checking it rejects
+	// calls with no tenant while accepting calls with a valid tenant.
+	identity := makeActiveIdentity(t, "iris@example.com")
+	repo := &mockRepo{identity: identity}
+	c := newConnector(t, repo)
+
+	t.Run("with tenant context succeeds", func(t *testing.T) {
+		ctx := ctxWithTenant(t, "acme_corp")
+		_, valid, err := c.Login(ctx, nil, "iris@example.com", testPassword)
+		require.NoError(t, err)
+		assert.True(t, valid)
+	})
+
+	t.Run("without tenant context returns error", func(t *testing.T) {
+		_, _, err := c.Login(context.Background(), nil, "iris@example.com", testPassword)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `services/identity/connector` package implementing a local `PasswordConnector` for Dex
- `connector.go`: validates credentials against the identity domain layer directly (no network hop), resolves tenant from context, rejects non-active accounts, maps active role assignments to Dex groups
- `claims.go`: `BuildClaims()` builds the JWT custom claims map (`sub`, `email`, `name`, `x-tenant-id`, `roles`, `groups`) consumed by Dex's token builder
- 18 unit tests covering all happy and unhappy paths

## Changes Made

**`services/identity/connector/connector.go`**
- `PasswordConnector` interface matching Dex's shape (decoupled — no `dexidp/dex` module dependency)
- `Connector.Login()`: tenant resolution from context → identity lookup by email → account status gate (locked/suspended/pending-invite → reject) → bcrypt password validation → active role resolution → structured log on each outcome
- Role resolution failure is non-fatal: login succeeds with empty groups rather than denying access due to a role service hiccup

**`services/identity/connector/claims.go`**
- `BuildClaims(identity, tenantID)` → `map[string]interface{}` with standard OIDC claims plus platform-specific `x-tenant-id` and `roles`/`groups` for downstream RBAC

## Technical Details

- No Dex library import — the connector defines its own `PasswordConnector` interface matching Dex's shape; this keeps the package lightweight and avoids a heavy transitive dependency
- Tenant is required in context; `Login` returns an error (not `valid=false`) when tenant context is absent, as this indicates a misconfigured request path rather than bad credentials
- Failed login attempts are persisted via `RecordLoginAttempt(false)` + `Save`; errors are logged but do not surface to the caller (best-effort audit trail)

## Testing

- `connector_test.go`: 14 tests — successful login, groups populated from role assignments, revoked assignments skipped, wrong password, locked/suspended/pending-invite account, identity not found, repository error, role query error (non-fatal), missing tenant context, tenant propagation
- `claims_test.go`: 4 tests — full identity, empty username defaults to email, nil groups produces empty slice, tenant ID propagation

## Risk Assessment

Low. New package with no modifications to existing code. The connector is not wired into any existing service wiring yet; integration point will be addressed separately.