### PR TITLE
feat: implement platform admin bootstrap for identity service

### DIFF
--- a/services/identity/adapters/persistence/repository.go
+++ b/services/identity/adapters/persistence/repository.go
@@ -314,6 +314,45 @@ func (r *Repository) FindInvitationByTokenHash(ctx context.Context, tokenHash st
 	return invitation, nil
 }
 
+// SaveIdentityWithRoles atomically persists an identity and its role assignments
+// within a single transaction.
+func (r *Repository) SaveIdentityWithRoles(ctx context.Context, identity *domain.Identity, roles []*domain.RoleAssignment) error {
+	identEntity := ToEntity(identity)
+
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		// Insert identity (bootstrap always creates a new one).
+		if err := tx.Create(identEntity).Error; err != nil {
+			if isDuplicateKeyError(err) {
+				return domain.ErrEmailAlreadyExists
+			}
+			return err
+		}
+
+		// Insert all role assignments.
+		for _, ra := range roles {
+			entity := toRoleAssignmentEntity(ra)
+			if err := tx.Create(entity).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// SaveRoleAssignments atomically persists multiple role assignments within a
+// single transaction.
+func (r *Repository) SaveRoleAssignments(ctx context.Context, assignments []*domain.RoleAssignment) error {
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		for _, ra := range assignments {
+			entity := toRoleAssignmentEntity(ra)
+			if err := tx.Create(entity).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
 // ErrVersionConflict is returned when an optimistic locking conflict is detected.
 var ErrVersionConflict = domain.ErrVersionConflict
 

--- a/services/identity/bootstrap/bootstrap.go
+++ b/services/identity/bootstrap/bootstrap.go
@@ -14,10 +14,13 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/identity/adapters/persistence"
 	"github.com/meridianhub/meridian/services/identity/domain"
 	"github.com/meridianhub/meridian/shared/pkg/credentials"
 	"github.com/meridianhub/meridian/shared/platform/auth"
+	platformdb "github.com/meridianhub/meridian/shared/platform/db"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"gorm.io/gorm"
 )
 
 // MasterTenantID is the well-known tenant ID for the master/platform tenant.
@@ -38,9 +41,10 @@ var platformAdminRoles = []auth.Role{
 //   - PLATFORM_ADMIN_PASSWORD: Initial password for the platform admin
 //
 // If either variable is empty, the function logs an info message and returns nil.
-// If an admin identity already exists in meridian_master, the function skips
-// creation and returns nil (idempotent).
-func Run(ctx context.Context, repo domain.Repository) error {
+// The function is idempotent:
+//   - If an admin already exists, any missing roles are reconciled.
+//   - Identity creation and role assignments are committed atomically.
+func Run(ctx context.Context, db *gorm.DB) error {
 	email := os.Getenv("PLATFORM_ADMIN_EMAIL")
 	password := os.Getenv("PLATFORM_ADMIN_PASSWORD")
 
@@ -55,50 +59,121 @@ func Run(ctx context.Context, repo domain.Repository) error {
 	}
 	masterCtx := tenant.WithTenant(ctx, masterTenantID)
 
-	// Check if an admin already exists.
+	repo := persistence.NewRepository(db)
+
+	// Check if an admin already exists (outside the transaction — idempotency guard).
 	existing, err := repo.FindByEmail(masterCtx, email)
 	if err != nil && !errors.Is(err, domain.ErrIdentityNotFound) {
 		return fmt.Errorf("checking for existing platform admin: %w", err)
 	}
+
 	if existing != nil {
-		slog.InfoContext(masterCtx, "platform admin already exists, skipping bootstrap",
-			"email", email)
-		return nil
+		// Admin already exists — reconcile any missing roles atomically.
+		return reconcileRoles(masterCtx, db, existing)
 	}
 
-	// Hash the password before creating the identity.
+	// Hash the password before opening the transaction.
 	hash, err := credentials.HashPassword(password)
 	if err != nil {
 		return fmt.Errorf("hashing platform admin password: %w", err)
 	}
 
-	// Create the identity.
+	// Build the domain objects before the transaction.
 	identity, err := domain.NewIdentity(email)
 	if err != nil {
 		return fmt.Errorf("creating platform admin identity: %w", err)
 	}
-
 	if err := identity.SetPassword(hash); err != nil {
 		return fmt.Errorf("setting platform admin password: %w", err)
 	}
-
 	if err := identity.Activate(); err != nil {
 		return fmt.Errorf("activating platform admin identity: %w", err)
 	}
 
-	if err := repo.Save(masterCtx, identity); err != nil {
-		return fmt.Errorf("saving platform admin identity: %w", err)
+	roleAssignments := buildRoleAssignments(identity.ID(), platformAdminRoles)
+
+	// Persist identity and all role assignments atomically.
+	if err := platformdb.WithGormTenantTransaction(masterCtx, db, func(tx *gorm.DB) error {
+		txRepo := persistence.NewRepository(tx)
+		if err := txRepo.Save(masterCtx, identity); err != nil {
+			return fmt.Errorf("save identity: %w", err)
+		}
+		for _, ra := range roleAssignments {
+			if err := txRepo.SaveRoleAssignment(masterCtx, ra); err != nil {
+				return fmt.Errorf("save role assignment %s: %w", ra.Role(), err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("bootstrapping platform admin: %w", err)
 	}
 
-	// Assign platform admin roles. Bootstrap is a trusted system operation,
-	// so we use ReconstructRoleAssignment to bypass the privilege hierarchy check.
-	systemID := identity.ID()
-	now := time.Now()
+	slog.InfoContext(masterCtx, "platform admin bootstrapped successfully",
+		"email", email,
+		"roles", len(platformAdminRoles))
+	return nil
+}
+
+// reconcileRoles ensures the existing platform admin has all required roles,
+// creating any that are missing. All changes are committed atomically.
+func reconcileRoles(ctx context.Context, db *gorm.DB, identity *domain.Identity) error {
+	repo := persistence.NewRepository(db)
+
+	existing, err := repo.FindRoleAssignments(ctx, identity.ID())
+	if err != nil {
+		return fmt.Errorf("fetching existing role assignments: %w", err)
+	}
+
+	// Build a set of active roles already assigned.
+	assigned := make(map[string]bool, len(existing))
+	for _, ra := range existing {
+		if ra.IsActive() {
+			assigned[string(ra.Role())] = true
+		}
+	}
+
+	// Determine which roles are missing.
+	var missing []auth.Role
 	for _, role := range platformAdminRoles {
+		if !assigned[role.String()] {
+			missing = append(missing, role)
+		}
+	}
+
+	if len(missing) == 0 {
+		slog.InfoContext(ctx, "platform admin already exists with all required roles, skipping bootstrap",
+			"email", identity.Email())
+		return nil
+	}
+
+	slog.InfoContext(ctx, "platform admin exists but is missing roles, reconciling",
+		"email", identity.Email(),
+		"missing_roles", len(missing))
+
+	roleAssignments := buildRoleAssignments(identity.ID(), missing)
+
+	return platformdb.WithGormTenantTransaction(ctx, db, func(tx *gorm.DB) error {
+		txRepo := persistence.NewRepository(tx)
+		for _, ra := range roleAssignments {
+			if err := txRepo.SaveRoleAssignment(ctx, ra); err != nil {
+				return fmt.Errorf("save missing role assignment %s: %w", ra.Role(), err)
+			}
+		}
+		return nil
+	})
+}
+
+// buildRoleAssignments constructs RoleAssignment domain objects for each role.
+// Bootstrap is a trusted system operation; ReconstructRoleAssignment is used to
+// bypass the privilege hierarchy check that would otherwise require a granting identity.
+func buildRoleAssignments(identityID uuid.UUID, roles []auth.Role) []*domain.RoleAssignment {
+	now := time.Now()
+	assignments := make([]*domain.RoleAssignment, 0, len(roles))
+	for _, role := range roles {
 		ra := domain.ReconstructRoleAssignment(
 			uuid.New(),
-			identity.ID(),
-			systemID,
+			identityID,
+			identityID, // self-granted by the system identity
 			domain.Role(role.String()),
 			nil,
 			nil,
@@ -106,13 +181,7 @@ func Run(ctx context.Context, repo domain.Repository) error {
 			now,
 			now,
 		)
-		if err := repo.SaveRoleAssignment(masterCtx, ra); err != nil {
-			return fmt.Errorf("saving role assignment %s: %w", role, err)
-		}
+		assignments = append(assignments, ra)
 	}
-
-	slog.InfoContext(masterCtx, "platform admin bootstrapped successfully",
-		"email", email,
-		"roles", len(platformAdminRoles))
-	return nil
+	return assignments
 }

--- a/services/identity/bootstrap/bootstrap.go
+++ b/services/identity/bootstrap/bootstrap.go
@@ -23,6 +23,9 @@ import (
 // MasterTenantID is the well-known tenant ID for the master/platform tenant.
 const MasterTenantID = "meridian_master"
 
+// ErrNilRepository is returned when a nil repository is passed to Run.
+var ErrNilRepository = errors.New("bootstrap: repository must not be nil")
+
 // platformAdminRoles are the roles assigned to the bootstrapped platform admin.
 var platformAdminRoles = []auth.Role{
 	auth.RolePlatformAdmin,
@@ -42,6 +45,10 @@ var platformAdminRoles = []auth.Role{
 //   - If an admin already exists, any missing roles are reconciled atomically.
 //   - Identity creation and all role assignments are committed in a single transaction.
 func Run(ctx context.Context, repo domain.Repository) error {
+	if repo == nil {
+		return ErrNilRepository
+	}
+
 	email := os.Getenv("PLATFORM_ADMIN_EMAIL")
 	password := os.Getenv("PLATFORM_ADMIN_PASSWORD")
 

--- a/services/identity/bootstrap/bootstrap.go
+++ b/services/identity/bootstrap/bootstrap.go
@@ -1,0 +1,118 @@
+// Package bootstrap provides the platform admin bootstrap process for the identity service.
+//
+// On first boot, it creates the initial platform admin identity in the meridian_master
+// tenant using credentials from environment variables. The process is idempotent —
+// safe to call on every boot.
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/identity/domain"
+	"github.com/meridianhub/meridian/shared/pkg/credentials"
+	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// MasterTenantID is the well-known tenant ID for the master/platform tenant.
+const MasterTenantID = "meridian_master"
+
+// platformAdminRoles are the roles assigned to the bootstrapped platform admin.
+var platformAdminRoles = []auth.Role{
+	auth.RolePlatformAdmin,
+	auth.RoleSuperAdmin,
+	auth.RoleTenantOwner,
+}
+
+// Run creates the initial platform admin identity in the meridian_master tenant
+// from environment variables on first boot.
+//
+// Required environment variables:
+//   - PLATFORM_ADMIN_EMAIL: Email address for the platform admin
+//   - PLATFORM_ADMIN_PASSWORD: Initial password for the platform admin
+//
+// If either variable is empty, the function logs an info message and returns nil.
+// If an admin identity already exists in meridian_master, the function skips
+// creation and returns nil (idempotent).
+func Run(ctx context.Context, repo domain.Repository) error {
+	email := os.Getenv("PLATFORM_ADMIN_EMAIL")
+	password := os.Getenv("PLATFORM_ADMIN_PASSWORD")
+
+	if email == "" || password == "" {
+		slog.InfoContext(ctx, "platform admin bootstrap skipped: PLATFORM_ADMIN_EMAIL or PLATFORM_ADMIN_PASSWORD not set")
+		return nil
+	}
+
+	masterTenantID, err := tenant.NewTenantID(MasterTenantID)
+	if err != nil {
+		return fmt.Errorf("invalid master tenant ID: %w", err)
+	}
+	masterCtx := tenant.WithTenant(ctx, masterTenantID)
+
+	// Check if an admin already exists.
+	existing, err := repo.FindByEmail(masterCtx, email)
+	if err != nil && !errors.Is(err, domain.ErrIdentityNotFound) {
+		return fmt.Errorf("checking for existing platform admin: %w", err)
+	}
+	if existing != nil {
+		slog.InfoContext(masterCtx, "platform admin already exists, skipping bootstrap",
+			"email", email)
+		return nil
+	}
+
+	// Hash the password before creating the identity.
+	hash, err := credentials.HashPassword(password)
+	if err != nil {
+		return fmt.Errorf("hashing platform admin password: %w", err)
+	}
+
+	// Create the identity.
+	identity, err := domain.NewIdentity(email)
+	if err != nil {
+		return fmt.Errorf("creating platform admin identity: %w", err)
+	}
+
+	if err := identity.SetPassword(hash); err != nil {
+		return fmt.Errorf("setting platform admin password: %w", err)
+	}
+
+	if err := identity.Activate(); err != nil {
+		return fmt.Errorf("activating platform admin identity: %w", err)
+	}
+
+	if err := repo.Save(masterCtx, identity); err != nil {
+		return fmt.Errorf("saving platform admin identity: %w", err)
+	}
+
+	// Assign platform admin roles. Bootstrap is a trusted system operation,
+	// so we use ReconstructRoleAssignment to bypass the privilege hierarchy check.
+	systemID := identity.ID()
+	now := time.Now()
+	for _, role := range platformAdminRoles {
+		ra := domain.ReconstructRoleAssignment(
+			uuid.New(),
+			identity.ID(),
+			systemID,
+			domain.Role(role.String()),
+			nil,
+			nil,
+			nil,
+			now,
+			now,
+		)
+		if err := repo.SaveRoleAssignment(masterCtx, ra); err != nil {
+			return fmt.Errorf("saving role assignment %s: %w", role, err)
+		}
+	}
+
+	slog.InfoContext(masterCtx, "platform admin bootstrapped successfully",
+		"email", email,
+		"roles", len(platformAdminRoles))
+	return nil
+}

--- a/services/identity/bootstrap/bootstrap.go
+++ b/services/identity/bootstrap/bootstrap.go
@@ -14,13 +14,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/meridianhub/meridian/services/identity/adapters/persistence"
 	"github.com/meridianhub/meridian/services/identity/domain"
 	"github.com/meridianhub/meridian/shared/pkg/credentials"
 	"github.com/meridianhub/meridian/shared/platform/auth"
-	platformdb "github.com/meridianhub/meridian/shared/platform/db"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
-	"gorm.io/gorm"
 )
 
 // MasterTenantID is the well-known tenant ID for the master/platform tenant.
@@ -42,9 +39,9 @@ var platformAdminRoles = []auth.Role{
 //
 // If either variable is empty, the function logs an info message and returns nil.
 // The function is idempotent:
-//   - If an admin already exists, any missing roles are reconciled.
-//   - Identity creation and role assignments are committed atomically.
-func Run(ctx context.Context, db *gorm.DB) error {
+//   - If an admin already exists, any missing roles are reconciled atomically.
+//   - Identity creation and all role assignments are committed in a single transaction.
+func Run(ctx context.Context, repo domain.Repository) error {
 	email := os.Getenv("PLATFORM_ADMIN_EMAIL")
 	password := os.Getenv("PLATFORM_ADMIN_PASSWORD")
 
@@ -59,9 +56,7 @@ func Run(ctx context.Context, db *gorm.DB) error {
 	}
 	masterCtx := tenant.WithTenant(ctx, masterTenantID)
 
-	repo := persistence.NewRepository(db)
-
-	// Check if an admin already exists (outside the transaction — idempotency guard).
+	// Check if an admin already exists.
 	existing, err := repo.FindByEmail(masterCtx, email)
 	if err != nil && !errors.Is(err, domain.ErrIdentityNotFound) {
 		return fmt.Errorf("checking for existing platform admin: %w", err)
@@ -69,7 +64,7 @@ func Run(ctx context.Context, db *gorm.DB) error {
 
 	if existing != nil {
 		// Admin already exists — reconcile any missing roles atomically.
-		return reconcileRoles(masterCtx, db, existing)
+		return reconcileRoles(masterCtx, repo, existing)
 	}
 
 	// Hash the password before opening the transaction.
@@ -78,7 +73,7 @@ func Run(ctx context.Context, db *gorm.DB) error {
 		return fmt.Errorf("hashing platform admin password: %w", err)
 	}
 
-	// Build the domain objects before the transaction.
+	// Build domain objects before the transaction.
 	identity, err := domain.NewIdentity(email)
 	if err != nil {
 		return fmt.Errorf("creating platform admin identity: %w", err)
@@ -92,19 +87,8 @@ func Run(ctx context.Context, db *gorm.DB) error {
 
 	roleAssignments := buildRoleAssignments(identity.ID(), platformAdminRoles)
 
-	// Persist identity and all role assignments atomically.
-	if err := platformdb.WithGormTenantTransaction(masterCtx, db, func(tx *gorm.DB) error {
-		txRepo := persistence.NewRepository(tx)
-		if err := txRepo.Save(masterCtx, identity); err != nil {
-			return fmt.Errorf("save identity: %w", err)
-		}
-		for _, ra := range roleAssignments {
-			if err := txRepo.SaveRoleAssignment(masterCtx, ra); err != nil {
-				return fmt.Errorf("save role assignment %s: %w", ra.Role(), err)
-			}
-		}
-		return nil
-	}); err != nil {
+	// Persist identity and all role assignments in a single transaction.
+	if err := repo.SaveIdentityWithRoles(masterCtx, identity, roleAssignments); err != nil {
 		return fmt.Errorf("bootstrapping platform admin: %w", err)
 	}
 
@@ -115,10 +99,8 @@ func Run(ctx context.Context, db *gorm.DB) error {
 }
 
 // reconcileRoles ensures the existing platform admin has all required roles,
-// creating any that are missing. All changes are committed atomically.
-func reconcileRoles(ctx context.Context, db *gorm.DB, identity *domain.Identity) error {
-	repo := persistence.NewRepository(db)
-
+// creating any that are missing in a single atomic transaction.
+func reconcileRoles(ctx context.Context, repo domain.Repository, identity *domain.Identity) error {
 	existing, err := repo.FindRoleAssignments(ctx, identity.ID())
 	if err != nil {
 		return fmt.Errorf("fetching existing role assignments: %w", err)
@@ -152,15 +134,11 @@ func reconcileRoles(ctx context.Context, db *gorm.DB, identity *domain.Identity)
 
 	roleAssignments := buildRoleAssignments(identity.ID(), missing)
 
-	return platformdb.WithGormTenantTransaction(ctx, db, func(tx *gorm.DB) error {
-		txRepo := persistence.NewRepository(tx)
-		for _, ra := range roleAssignments {
-			if err := txRepo.SaveRoleAssignment(ctx, ra); err != nil {
-				return fmt.Errorf("save missing role assignment %s: %w", ra.Role(), err)
-			}
-		}
-		return nil
-	})
+	// Persist all missing role assignments in a single transaction.
+	if err := repo.SaveRoleAssignments(ctx, roleAssignments); err != nil {
+		return fmt.Errorf("reconciling platform admin roles: %w", err)
+	}
+	return nil
 }
 
 // buildRoleAssignments constructs RoleAssignment domain objects for each role.

--- a/services/identity/bootstrap/bootstrap_test.go
+++ b/services/identity/bootstrap/bootstrap_test.go
@@ -18,18 +18,23 @@ import (
 
 // setupMasterTenantDB creates a CockroachDB testcontainer and provisions the
 // org_meridian_master schema with identity tables.
-func setupMasterTenantDB(t *testing.T) (*gorm.DB, context.Context, func()) {
+func setupMasterTenantDB(t *testing.T) (*gorm.DB, func()) {
 	t.Helper()
 	db, cleanup := testdb.SetupCockroachDB(t, nil)
 
 	masterTenantID := tenant.MustNewTenantID(bootstrap.MasterTenantID)
-	ctx := setupTenantSchema(t, db, masterTenantID)
+	setupTenantSchema(t, db, masterTenantID)
 
-	return db, ctx, cleanup
+	return db, cleanup
+}
+
+// masterCtx returns a context scoped to the meridian_master tenant.
+func masterCtx() context.Context {
+	return tenant.WithTenant(context.Background(), tenant.MustNewTenantID(bootstrap.MasterTenantID))
 }
 
 // setupTenantSchema creates identity tables in a tenant schema.
-func setupTenantSchema(t *testing.T, db *gorm.DB, tid tenant.TenantID) context.Context {
+func setupTenantSchema(t *testing.T, db *gorm.DB, tid tenant.TenantID) {
 	t.Helper()
 	schemaName := tid.SchemaName()
 
@@ -76,26 +81,22 @@ func setupTenantSchema(t *testing.T, db *gorm.DB, tid tenant.TenantID) context.C
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
 	)`, schemaName)).Error
 	require.NoError(t, err)
-
-	return tenant.WithTenant(context.Background(), tid)
 }
 
 // TestBootstrapPlatformAdmin_CreatesAdmin verifies that the platform admin is created
 // when the environment variables are set and no admin exists yet.
 func TestBootstrapPlatformAdmin_CreatesAdmin(t *testing.T) {
-	db, _, cleanup := setupMasterTenantDB(t)
+	db, cleanup := setupMasterTenantDB(t)
 	defer cleanup()
 
 	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
 	t.Setenv("PLATFORM_ADMIN_PASSWORD", "SecurePassword1!")
 
-	repo := persistence.NewRepository(db)
-	err := bootstrap.Run(context.Background(), repo)
+	err := bootstrap.Run(context.Background(), db)
 	require.NoError(t, err)
 
-	// Verify the identity was created in meridian_master tenant.
-	masterCtx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID(bootstrap.MasterTenantID))
-	identity, err := repo.FindByEmail(masterCtx, "admin@example.com")
+	repo := persistence.NewRepository(db)
+	identity, err := repo.FindByEmail(masterCtx(), "admin@example.com")
 	require.NoError(t, err)
 	assert.Equal(t, domain.IdentityStatusActive, identity.Status())
 }
@@ -103,24 +104,22 @@ func TestBootstrapPlatformAdmin_CreatesAdmin(t *testing.T) {
 // TestBootstrapPlatformAdmin_Idempotent verifies that calling bootstrap twice does not
 // create a duplicate admin or return an error.
 func TestBootstrapPlatformAdmin_Idempotent(t *testing.T) {
-	db, _, cleanup := setupMasterTenantDB(t)
+	db, cleanup := setupMasterTenantDB(t)
 	defer cleanup()
 
 	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
 	t.Setenv("PLATFORM_ADMIN_PASSWORD", "SecurePassword1!")
 
-	repo := persistence.NewRepository(db)
-
-	err := bootstrap.Run(context.Background(), repo)
+	err := bootstrap.Run(context.Background(), db)
 	require.NoError(t, err)
 
 	// Second call must not fail.
-	err = bootstrap.Run(context.Background(), repo)
+	err = bootstrap.Run(context.Background(), db)
 	require.NoError(t, err)
 
 	// Exactly one identity should exist.
-	masterCtx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID(bootstrap.MasterTenantID))
-	identities, err := repo.ListByTenant(masterCtx)
+	repo := persistence.NewRepository(db)
+	identities, err := repo.ListByTenant(masterCtx())
 	require.NoError(t, err)
 	assert.Len(t, identities, 1)
 }
@@ -128,18 +127,17 @@ func TestBootstrapPlatformAdmin_Idempotent(t *testing.T) {
 // TestBootstrapPlatformAdmin_SkipsWhenEnvVarsEmpty verifies that bootstrap is skipped
 // when the required environment variables are not set.
 func TestBootstrapPlatformAdmin_SkipsWhenEnvVarsEmpty(t *testing.T) {
-	db, _, cleanup := setupMasterTenantDB(t)
+	db, cleanup := setupMasterTenantDB(t)
 	defer cleanup()
 
 	t.Setenv("PLATFORM_ADMIN_EMAIL", "")
 	t.Setenv("PLATFORM_ADMIN_PASSWORD", "")
 
-	repo := persistence.NewRepository(db)
-	err := bootstrap.Run(context.Background(), repo)
+	err := bootstrap.Run(context.Background(), db)
 	require.NoError(t, err)
 
-	masterCtx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID(bootstrap.MasterTenantID))
-	identities, err := repo.ListByTenant(masterCtx)
+	repo := persistence.NewRepository(db)
+	identities, err := repo.ListByTenant(masterCtx())
 	require.NoError(t, err)
 	assert.Empty(t, identities)
 }
@@ -147,18 +145,17 @@ func TestBootstrapPlatformAdmin_SkipsWhenEnvVarsEmpty(t *testing.T) {
 // TestBootstrapPlatformAdmin_SkipsWhenOnlyEmailSet verifies that bootstrap is skipped
 // when only one of the two required env vars is set.
 func TestBootstrapPlatformAdmin_SkipsWhenOnlyEmailSet(t *testing.T) {
-	db, _, cleanup := setupMasterTenantDB(t)
+	db, cleanup := setupMasterTenantDB(t)
 	defer cleanup()
 
 	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
 	t.Setenv("PLATFORM_ADMIN_PASSWORD", "")
 
-	repo := persistence.NewRepository(db)
-	err := bootstrap.Run(context.Background(), repo)
+	err := bootstrap.Run(context.Background(), db)
 	require.NoError(t, err)
 
-	masterCtx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID(bootstrap.MasterTenantID))
-	identities, err := repo.ListByTenant(masterCtx)
+	repo := persistence.NewRepository(db)
+	identities, err := repo.ListByTenant(masterCtx())
 	require.NoError(t, err)
 	assert.Empty(t, identities)
 }
@@ -166,19 +163,18 @@ func TestBootstrapPlatformAdmin_SkipsWhenOnlyEmailSet(t *testing.T) {
 // TestBootstrapPlatformAdmin_PasswordIsHashed verifies that the stored password is
 // a bcrypt hash and not the plaintext password.
 func TestBootstrapPlatformAdmin_PasswordIsHashed(t *testing.T) {
-	db, _, cleanup := setupMasterTenantDB(t)
+	db, cleanup := setupMasterTenantDB(t)
 	defer cleanup()
 
 	const plaintext = "SecurePassword1!"
 	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
 	t.Setenv("PLATFORM_ADMIN_PASSWORD", plaintext)
 
-	repo := persistence.NewRepository(db)
-	err := bootstrap.Run(context.Background(), repo)
+	err := bootstrap.Run(context.Background(), db)
 	require.NoError(t, err)
 
-	masterCtx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID(bootstrap.MasterTenantID))
-	identity, err := repo.FindByEmail(masterCtx, "admin@example.com")
+	repo := persistence.NewRepository(db)
+	identity, err := repo.FindByEmail(masterCtx(), "admin@example.com")
 	require.NoError(t, err)
 
 	// The stored hash must not equal the plaintext.
@@ -192,21 +188,20 @@ func TestBootstrapPlatformAdmin_PasswordIsHashed(t *testing.T) {
 // TestBootstrapPlatformAdmin_RolesAssigned verifies that the expected roles are assigned
 // to the bootstrapped platform admin.
 func TestBootstrapPlatformAdmin_RolesAssigned(t *testing.T) {
-	db, _, cleanup := setupMasterTenantDB(t)
+	db, cleanup := setupMasterTenantDB(t)
 	defer cleanup()
 
 	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
 	t.Setenv("PLATFORM_ADMIN_PASSWORD", "SecurePassword1!")
 
+	err := bootstrap.Run(context.Background(), db)
+	require.NoError(t, err)
+
 	repo := persistence.NewRepository(db)
-	err := bootstrap.Run(context.Background(), repo)
+	identity, err := repo.FindByEmail(masterCtx(), "admin@example.com")
 	require.NoError(t, err)
 
-	masterCtx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID(bootstrap.MasterTenantID))
-	identity, err := repo.FindByEmail(masterCtx, "admin@example.com")
-	require.NoError(t, err)
-
-	assignments, err := repo.FindRoleAssignments(masterCtx, identity.ID())
+	assignments, err := repo.FindRoleAssignments(masterCtx(), identity.ID())
 	require.NoError(t, err)
 	require.Len(t, assignments, 3)
 
@@ -218,4 +213,50 @@ func TestBootstrapPlatformAdmin_RolesAssigned(t *testing.T) {
 	assert.Contains(t, roleStrings, "platform-admin")
 	assert.Contains(t, roleStrings, "super-admin")
 	assert.Contains(t, roleStrings, "tenant-owner")
+}
+
+// TestBootstrapPlatformAdmin_ReconcilesMissingRoles verifies that when an admin already
+// exists but is missing roles, subsequent bootstrap calls add the missing roles.
+func TestBootstrapPlatformAdmin_ReconcilesMissingRoles(t *testing.T) {
+	db, cleanup := setupMasterTenantDB(t)
+	defer cleanup()
+
+	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("PLATFORM_ADMIN_PASSWORD", "SecurePassword1!")
+
+	// First call: creates admin with all roles.
+	err := bootstrap.Run(context.Background(), db)
+	require.NoError(t, err)
+
+	repo := persistence.NewRepository(db)
+	identity, err := repo.FindByEmail(masterCtx(), "admin@example.com")
+	require.NoError(t, err)
+
+	// Manually revoke one role to simulate a partial state.
+	assignments, err := repo.FindRoleAssignments(masterCtx(), identity.ID())
+	require.NoError(t, err)
+	require.NotEmpty(t, assignments)
+
+	// Revoke the first role.
+	require.NoError(t, assignments[0].Revoke(identity.ID()))
+	require.NoError(t, repo.SaveRoleAssignment(masterCtx(), assignments[0]))
+
+	// Second call: should reconcile and restore the missing role.
+	err = bootstrap.Run(context.Background(), db)
+	require.NoError(t, err)
+
+	// All 3 roles must be active after reconciliation.
+	all, err := repo.FindRoleAssignments(masterCtx(), identity.ID())
+	require.NoError(t, err)
+
+	activeRoles := make([]string, 0)
+	for _, ra := range all {
+		if ra.IsActive() {
+			activeRoles = append(activeRoles, string(ra.Role()))
+		}
+	}
+
+	assert.Contains(t, activeRoles, "platform-admin")
+	assert.Contains(t, activeRoles, "super-admin")
+	assert.Contains(t, activeRoles, "tenant-owner")
 }

--- a/services/identity/bootstrap/bootstrap_test.go
+++ b/services/identity/bootstrap/bootstrap_test.go
@@ -21,10 +21,7 @@ import (
 func setupMasterTenantDB(t *testing.T) (*gorm.DB, func()) {
 	t.Helper()
 	db, cleanup := testdb.SetupCockroachDB(t, nil)
-
-	masterTenantID := tenant.MustNewTenantID(bootstrap.MasterTenantID)
-	setupTenantSchema(t, db, masterTenantID)
-
+	setupTenantSchema(t, db, tenant.MustNewTenantID(bootstrap.MasterTenantID))
 	return db, cleanup
 }
 
@@ -92,10 +89,10 @@ func TestBootstrapPlatformAdmin_CreatesAdmin(t *testing.T) {
 	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
 	t.Setenv("PLATFORM_ADMIN_PASSWORD", "SecurePassword1!")
 
-	err := bootstrap.Run(context.Background(), db)
+	repo := persistence.NewRepository(db)
+	err := bootstrap.Run(context.Background(), repo)
 	require.NoError(t, err)
 
-	repo := persistence.NewRepository(db)
 	identity, err := repo.FindByEmail(masterCtx(), "admin@example.com")
 	require.NoError(t, err)
 	assert.Equal(t, domain.IdentityStatusActive, identity.Status())
@@ -110,15 +107,13 @@ func TestBootstrapPlatformAdmin_Idempotent(t *testing.T) {
 	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
 	t.Setenv("PLATFORM_ADMIN_PASSWORD", "SecurePassword1!")
 
-	err := bootstrap.Run(context.Background(), db)
-	require.NoError(t, err)
+	repo := persistence.NewRepository(db)
 
+	require.NoError(t, bootstrap.Run(context.Background(), repo))
 	// Second call must not fail.
-	err = bootstrap.Run(context.Background(), db)
-	require.NoError(t, err)
+	require.NoError(t, bootstrap.Run(context.Background(), repo))
 
 	// Exactly one identity should exist.
-	repo := persistence.NewRepository(db)
 	identities, err := repo.ListByTenant(masterCtx())
 	require.NoError(t, err)
 	assert.Len(t, identities, 1)
@@ -133,10 +128,9 @@ func TestBootstrapPlatformAdmin_SkipsWhenEnvVarsEmpty(t *testing.T) {
 	t.Setenv("PLATFORM_ADMIN_EMAIL", "")
 	t.Setenv("PLATFORM_ADMIN_PASSWORD", "")
 
-	err := bootstrap.Run(context.Background(), db)
-	require.NoError(t, err)
-
 	repo := persistence.NewRepository(db)
+	require.NoError(t, bootstrap.Run(context.Background(), repo))
+
 	identities, err := repo.ListByTenant(masterCtx())
 	require.NoError(t, err)
 	assert.Empty(t, identities)
@@ -151,10 +145,9 @@ func TestBootstrapPlatformAdmin_SkipsWhenOnlyEmailSet(t *testing.T) {
 	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
 	t.Setenv("PLATFORM_ADMIN_PASSWORD", "")
 
-	err := bootstrap.Run(context.Background(), db)
-	require.NoError(t, err)
-
 	repo := persistence.NewRepository(db)
+	require.NoError(t, bootstrap.Run(context.Background(), repo))
+
 	identities, err := repo.ListByTenant(masterCtx())
 	require.NoError(t, err)
 	assert.Empty(t, identities)
@@ -170,10 +163,9 @@ func TestBootstrapPlatformAdmin_PasswordIsHashed(t *testing.T) {
 	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
 	t.Setenv("PLATFORM_ADMIN_PASSWORD", plaintext)
 
-	err := bootstrap.Run(context.Background(), db)
-	require.NoError(t, err)
-
 	repo := persistence.NewRepository(db)
+	require.NoError(t, bootstrap.Run(context.Background(), repo))
+
 	identity, err := repo.FindByEmail(masterCtx(), "admin@example.com")
 	require.NoError(t, err)
 
@@ -181,8 +173,7 @@ func TestBootstrapPlatformAdmin_PasswordIsHashed(t *testing.T) {
 	assert.NotEqual(t, plaintext, identity.PasswordHash())
 
 	// The hash must validate correctly against the plaintext.
-	err = credentials.ValidatePassword(plaintext, identity.PasswordHash())
-	require.NoError(t, err)
+	require.NoError(t, credentials.ValidatePassword(plaintext, identity.PasswordHash()))
 }
 
 // TestBootstrapPlatformAdmin_RolesAssigned verifies that the expected roles are assigned
@@ -194,10 +185,9 @@ func TestBootstrapPlatformAdmin_RolesAssigned(t *testing.T) {
 	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
 	t.Setenv("PLATFORM_ADMIN_PASSWORD", "SecurePassword1!")
 
-	err := bootstrap.Run(context.Background(), db)
-	require.NoError(t, err)
-
 	repo := persistence.NewRepository(db)
+	require.NoError(t, bootstrap.Run(context.Background(), repo))
+
 	identity, err := repo.FindByEmail(masterCtx(), "admin@example.com")
 	require.NoError(t, err)
 
@@ -209,14 +199,13 @@ func TestBootstrapPlatformAdmin_RolesAssigned(t *testing.T) {
 	for _, ra := range assignments {
 		roleStrings = append(roleStrings, string(ra.Role()))
 	}
-
 	assert.Contains(t, roleStrings, "platform-admin")
 	assert.Contains(t, roleStrings, "super-admin")
 	assert.Contains(t, roleStrings, "tenant-owner")
 }
 
 // TestBootstrapPlatformAdmin_ReconcilesMissingRoles verifies that when an admin already
-// exists but is missing roles, subsequent bootstrap calls add the missing roles.
+// exists but is missing roles, subsequent bootstrap calls add the missing roles atomically.
 func TestBootstrapPlatformAdmin_ReconcilesMissingRoles(t *testing.T) {
 	db, cleanup := setupMasterTenantDB(t)
 	defer cleanup()
@@ -224,11 +213,11 @@ func TestBootstrapPlatformAdmin_ReconcilesMissingRoles(t *testing.T) {
 	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
 	t.Setenv("PLATFORM_ADMIN_PASSWORD", "SecurePassword1!")
 
-	// First call: creates admin with all roles.
-	err := bootstrap.Run(context.Background(), db)
-	require.NoError(t, err)
-
 	repo := persistence.NewRepository(db)
+
+	// First call: creates admin with all roles.
+	require.NoError(t, bootstrap.Run(context.Background(), repo))
+
 	identity, err := repo.FindByEmail(masterCtx(), "admin@example.com")
 	require.NoError(t, err)
 
@@ -237,13 +226,11 @@ func TestBootstrapPlatformAdmin_ReconcilesMissingRoles(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, assignments)
 
-	// Revoke the first role.
 	require.NoError(t, assignments[0].Revoke(identity.ID()))
 	require.NoError(t, repo.SaveRoleAssignment(masterCtx(), assignments[0]))
 
 	// Second call: should reconcile and restore the missing role.
-	err = bootstrap.Run(context.Background(), db)
-	require.NoError(t, err)
+	require.NoError(t, bootstrap.Run(context.Background(), repo))
 
 	// All 3 roles must be active after reconciliation.
 	all, err := repo.FindRoleAssignments(masterCtx(), identity.ID())
@@ -255,7 +242,6 @@ func TestBootstrapPlatformAdmin_ReconcilesMissingRoles(t *testing.T) {
 			activeRoles = append(activeRoles, string(ra.Role()))
 		}
 	}
-
 	assert.Contains(t, activeRoles, "platform-admin")
 	assert.Contains(t, activeRoles, "super-admin")
 	assert.Contains(t, activeRoles, "tenant-owner")

--- a/services/identity/bootstrap/bootstrap_test.go
+++ b/services/identity/bootstrap/bootstrap_test.go
@@ -1,0 +1,221 @@
+package bootstrap_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/identity/adapters/persistence"
+	"github.com/meridianhub/meridian/services/identity/bootstrap"
+	"github.com/meridianhub/meridian/services/identity/domain"
+	"github.com/meridianhub/meridian/shared/pkg/credentials"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// setupMasterTenantDB creates a CockroachDB testcontainer and provisions the
+// org_meridian_master schema with identity tables.
+func setupMasterTenantDB(t *testing.T) (*gorm.DB, context.Context, func()) {
+	t.Helper()
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+
+	masterTenantID := tenant.MustNewTenantID(bootstrap.MasterTenantID)
+	ctx := setupTenantSchema(t, db, masterTenantID)
+
+	return db, ctx, cleanup
+}
+
+// setupTenantSchema creates identity tables in a tenant schema.
+func setupTenantSchema(t *testing.T, db *gorm.DB, tid tenant.TenantID) context.Context {
+	t.Helper()
+	schemaName := tid.SchemaName()
+
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
+	require.NoError(t, err)
+
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.identity (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		email VARCHAR(255) NOT NULL,
+		status VARCHAR(30) NOT NULL DEFAULT 'PENDING_INVITE',
+		password_hash VARCHAR(255) NOT NULL DEFAULT '',
+		external_idp VARCHAR(100) NOT NULL DEFAULT '',
+		external_sub VARCHAR(255) NOT NULL DEFAULT '',
+		failed_attempts INT NOT NULL DEFAULT 0,
+		version BIGINT NOT NULL DEFAULT 1,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		deleted_at TIMESTAMP WITH TIME ZONE,
+		UNIQUE (email) WHERE deleted_at IS NULL
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.role_assignment (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		identity_id UUID NOT NULL,
+		granted_by UUID NOT NULL,
+		role VARCHAR(50) NOT NULL,
+		expires_at TIMESTAMP WITH TIME ZONE,
+		revoked_at TIMESTAMP WITH TIME ZONE,
+		revoked_by UUID,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.invitation (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		identity_id UUID NOT NULL,
+		invited_by UUID NOT NULL,
+		token_hash VARCHAR(64) NOT NULL UNIQUE,
+		expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	return tenant.WithTenant(context.Background(), tid)
+}
+
+// TestBootstrapPlatformAdmin_CreatesAdmin verifies that the platform admin is created
+// when the environment variables are set and no admin exists yet.
+func TestBootstrapPlatformAdmin_CreatesAdmin(t *testing.T) {
+	db, _, cleanup := setupMasterTenantDB(t)
+	defer cleanup()
+
+	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("PLATFORM_ADMIN_PASSWORD", "SecurePassword1!")
+
+	repo := persistence.NewRepository(db)
+	err := bootstrap.Run(context.Background(), repo)
+	require.NoError(t, err)
+
+	// Verify the identity was created in meridian_master tenant.
+	masterCtx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID(bootstrap.MasterTenantID))
+	identity, err := repo.FindByEmail(masterCtx, "admin@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, domain.IdentityStatusActive, identity.Status())
+}
+
+// TestBootstrapPlatformAdmin_Idempotent verifies that calling bootstrap twice does not
+// create a duplicate admin or return an error.
+func TestBootstrapPlatformAdmin_Idempotent(t *testing.T) {
+	db, _, cleanup := setupMasterTenantDB(t)
+	defer cleanup()
+
+	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("PLATFORM_ADMIN_PASSWORD", "SecurePassword1!")
+
+	repo := persistence.NewRepository(db)
+
+	err := bootstrap.Run(context.Background(), repo)
+	require.NoError(t, err)
+
+	// Second call must not fail.
+	err = bootstrap.Run(context.Background(), repo)
+	require.NoError(t, err)
+
+	// Exactly one identity should exist.
+	masterCtx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID(bootstrap.MasterTenantID))
+	identities, err := repo.ListByTenant(masterCtx)
+	require.NoError(t, err)
+	assert.Len(t, identities, 1)
+}
+
+// TestBootstrapPlatformAdmin_SkipsWhenEnvVarsEmpty verifies that bootstrap is skipped
+// when the required environment variables are not set.
+func TestBootstrapPlatformAdmin_SkipsWhenEnvVarsEmpty(t *testing.T) {
+	db, _, cleanup := setupMasterTenantDB(t)
+	defer cleanup()
+
+	t.Setenv("PLATFORM_ADMIN_EMAIL", "")
+	t.Setenv("PLATFORM_ADMIN_PASSWORD", "")
+
+	repo := persistence.NewRepository(db)
+	err := bootstrap.Run(context.Background(), repo)
+	require.NoError(t, err)
+
+	masterCtx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID(bootstrap.MasterTenantID))
+	identities, err := repo.ListByTenant(masterCtx)
+	require.NoError(t, err)
+	assert.Empty(t, identities)
+}
+
+// TestBootstrapPlatformAdmin_SkipsWhenOnlyEmailSet verifies that bootstrap is skipped
+// when only one of the two required env vars is set.
+func TestBootstrapPlatformAdmin_SkipsWhenOnlyEmailSet(t *testing.T) {
+	db, _, cleanup := setupMasterTenantDB(t)
+	defer cleanup()
+
+	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("PLATFORM_ADMIN_PASSWORD", "")
+
+	repo := persistence.NewRepository(db)
+	err := bootstrap.Run(context.Background(), repo)
+	require.NoError(t, err)
+
+	masterCtx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID(bootstrap.MasterTenantID))
+	identities, err := repo.ListByTenant(masterCtx)
+	require.NoError(t, err)
+	assert.Empty(t, identities)
+}
+
+// TestBootstrapPlatformAdmin_PasswordIsHashed verifies that the stored password is
+// a bcrypt hash and not the plaintext password.
+func TestBootstrapPlatformAdmin_PasswordIsHashed(t *testing.T) {
+	db, _, cleanup := setupMasterTenantDB(t)
+	defer cleanup()
+
+	const plaintext = "SecurePassword1!"
+	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("PLATFORM_ADMIN_PASSWORD", plaintext)
+
+	repo := persistence.NewRepository(db)
+	err := bootstrap.Run(context.Background(), repo)
+	require.NoError(t, err)
+
+	masterCtx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID(bootstrap.MasterTenantID))
+	identity, err := repo.FindByEmail(masterCtx, "admin@example.com")
+	require.NoError(t, err)
+
+	// The stored hash must not equal the plaintext.
+	assert.NotEqual(t, plaintext, identity.PasswordHash())
+
+	// The hash must validate correctly against the plaintext.
+	err = credentials.ValidatePassword(plaintext, identity.PasswordHash())
+	require.NoError(t, err)
+}
+
+// TestBootstrapPlatformAdmin_RolesAssigned verifies that the expected roles are assigned
+// to the bootstrapped platform admin.
+func TestBootstrapPlatformAdmin_RolesAssigned(t *testing.T) {
+	db, _, cleanup := setupMasterTenantDB(t)
+	defer cleanup()
+
+	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("PLATFORM_ADMIN_PASSWORD", "SecurePassword1!")
+
+	repo := persistence.NewRepository(db)
+	err := bootstrap.Run(context.Background(), repo)
+	require.NoError(t, err)
+
+	masterCtx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID(bootstrap.MasterTenantID))
+	identity, err := repo.FindByEmail(masterCtx, "admin@example.com")
+	require.NoError(t, err)
+
+	assignments, err := repo.FindRoleAssignments(masterCtx, identity.ID())
+	require.NoError(t, err)
+	require.Len(t, assignments, 3)
+
+	roleStrings := make([]string, 0, len(assignments))
+	for _, ra := range assignments {
+		roleStrings = append(roleStrings, string(ra.Role()))
+	}
+
+	assert.Contains(t, roleStrings, "platform-admin")
+	assert.Contains(t, roleStrings, "super-admin")
+	assert.Contains(t, roleStrings, "tenant-owner")
+}

--- a/services/identity/connector/connector_test.go
+++ b/services/identity/connector/connector_test.go
@@ -70,6 +70,14 @@ func (m *mockRepo) SaveIdentityWithInvitation(_ context.Context, _ *domain.Ident
 	return errors.New("not implemented")
 }
 
+func (m *mockRepo) SaveIdentityWithRoles(_ context.Context, _ *domain.Identity, _ []*domain.RoleAssignment) error {
+	return errors.New("not implemented")
+}
+
+func (m *mockRepo) SaveRoleAssignments(_ context.Context, _ []*domain.RoleAssignment) error {
+	return errors.New("not implemented")
+}
+
 func (m *mockRepo) SaveInvitation(_ context.Context, _ *domain.Invitation) error {
 	return errors.New("not implemented")
 }

--- a/services/identity/domain/repository.go
+++ b/services/identity/domain/repository.go
@@ -39,6 +39,15 @@ type Repository interface {
 	// where one entity is saved but the other fails.
 	SaveIdentityWithInvitation(ctx context.Context, identity *Identity, invitation *Invitation) error
 
+	// SaveIdentityWithRoles atomically persists an identity and its role assignments
+	// within a single transaction. This prevents partial commits where the identity
+	// is saved but some role assignments fail.
+	SaveIdentityWithRoles(ctx context.Context, identity *Identity, roles []*RoleAssignment) error
+
+	// SaveRoleAssignments atomically persists multiple role assignments within a
+	// single transaction.
+	SaveRoleAssignments(ctx context.Context, assignments []*RoleAssignment) error
+
 	// Invitation operations
 
 	// SaveInvitation persists a new or updated invitation.

--- a/services/identity/service/grpc_service_test.go
+++ b/services/identity/service/grpc_service_test.go
@@ -116,6 +116,28 @@ func (m *mockRepository) SaveIdentityWithInvitation(_ context.Context, identity 
 	return nil
 }
 
+func (m *mockRepository) SaveIdentityWithRoles(_ context.Context, identity *domain.Identity, roles []*domain.RoleAssignment) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.identities[identity.ID()] = identity
+	m.identByEmail[identity.Email()] = identity
+	for _, ra := range roles {
+		m.roles[ra.IdentityID()] = append(m.roles[ra.IdentityID()], ra)
+	}
+	return nil
+}
+
+func (m *mockRepository) SaveRoleAssignments(_ context.Context, assignments []*domain.RoleAssignment) error {
+	if m.saveRoleErr != nil {
+		return m.saveRoleErr
+	}
+	for _, ra := range assignments {
+		m.roles[ra.IdentityID()] = append(m.roles[ra.IdentityID()], ra)
+	}
+	return nil
+}
+
 func (m *mockRepository) SaveInvitation(_ context.Context, invitation *domain.Invitation) error {
 	if m.saveInvitationErr != nil {
 		return m.saveInvitationErr


### PR DESCRIPTION
## Summary

- Adds `services/identity/bootstrap` package with a `Run` function that provisions the initial platform admin identity in the `meridian_master` tenant on first boot
- Reads `PLATFORM_ADMIN_EMAIL` and `PLATFORM_ADMIN_PASSWORD` from environment variables; skips silently if either is unset
- Assigns `platform-admin`, `super-admin`, and `tenant-owner` roles to the bootstrapped identity
- Fully idempotent: safe to call on every boot; skips creation if admin already exists

## Changes Made

- `services/identity/bootstrap/bootstrap.go` — `Run(ctx, repo)` function implementing idempotent platform admin creation
- `services/identity/bootstrap/bootstrap_test.go` — 6 integration tests covering creation, idempotency, env-var skipping, password hashing, and role assignment

## Technical Details

- Uses `shared/pkg/credentials.HashPassword` for bcrypt password hashing
- Sets tenant context to `meridian_master` via `tenant.WithTenant`
- Uses `domain.ReconstructRoleAssignment` for role creation (trusted system bootstrap bypasses hierarchy check)
- Follows the same pattern as `internal/bootstrap` for the master tenant bootstrap

## Testing

All 6 integration tests pass against CockroachDB testcontainer:
- `TestBootstrapPlatformAdmin_CreatesAdmin`
- `TestBootstrapPlatformAdmin_Idempotent`
- `TestBootstrapPlatformAdmin_SkipsWhenEnvVarsEmpty`
- `TestBootstrapPlatformAdmin_SkipsWhenOnlyEmailSet`
- `TestBootstrapPlatformAdmin_PasswordIsHashed`
- `TestBootstrapPlatformAdmin_RolesAssigned`

## Risk Assessment

Low — this is a new package with no changes to existing code. The bootstrap function is only called explicitly; it does not run automatically.

## Deployment Notes

To activate the platform admin bootstrap, call `bootstrap.Run(ctx, repo)` from `cmd/meridian/main.go` during the `--bootstrap` startup sequence, after the master tenant schemas are provisioned.