### PR TITLE
feat: update Dex configuration for identity service integration

### DIFF
--- a/deploy/demo/dex-identity-migration-plan.md
+++ b/deploy/demo/dex-identity-migration-plan.md
@@ -1,0 +1,104 @@
+# Dex → Meridian Identity Connector Migration Plan
+
+## Current State (Demo)
+
+The demo environment uses Dex's built-in password database (`enablePasswordDB: true`)
+with static credentials defined in `dex.yaml`. This is intentional for the demo:
+credentials are predictable, the environment is throwaway, and it requires zero
+runtime dependency on the identity service being fully bootstrapped.
+
+## Target State (Production)
+
+Dex authenticates users via the **Meridian identity connector** — a Go implementation
+of `dex/connector.PasswordConnector` that validates credentials directly against the
+identity domain repository (no network hop).
+
+### Architecture
+
+```text
+User → Dex (password grant)
+         │
+         └─ PasswordConnector.Login()
+                  │
+                  └─ services/identity/connector.Connector
+                           │
+                           ├─ tenant.RequireFromContext(ctx)   ← subdomain → tenant ID
+                           ├─ repo.FindByEmail(ctx, email)     ← identity lookup
+                           ├─ credentials.ValidatePassword()   ← bcrypt verify
+                           └─ repo.FindRoleAssignments()       ← groups → JWT claims
+```
+
+The connector is a **compile-time, in-process** integration. Dex is not a separate
+binary that calls Meridian over the network — it is embedded as a library or its
+server is initialised with a custom connector registered under the ID `"meridian"`.
+
+### Why Not a Network Connector
+
+Dex supports 16 connector types (LDAP, OIDC, GitHub, SAML, etc.). None is a generic
+gRPC or HTTP connector. A `type: grpc` does not exist in Dex v2.x. Implementing a
+custom connector as a separate Dex plugin would require forking Dex or using the
+(experimental) gRPC connector interface — neither is appropriate for the demo.
+
+The in-process approach is superior:
+
+- Zero network latency for authentication
+- No TLS configuration required
+- Single binary deployment preserved
+- Tenant context propagated via Go `context.Context`, not HTTP headers
+
+## Migration Steps
+
+### 1. Wire the Connector at Startup
+
+In `services/identity/bootstrap/` (or wherever the Dex server is initialised),
+register the Meridian connector:
+
+```go
+import (
+    dexserver "github.com/dexidp/dex/server"
+    "github.com/meridianhub/meridian/services/identity/connector"
+)
+
+meridianConn, err := connector.New(identityRepo, logger)
+// ...
+
+cfg := dexserver.Config{
+    PasswordConnector: meridianConn,  // replaces the built-in password DB
+    // ...
+}
+```
+
+### 2. Update dex.yaml
+
+Once the connector is wired:
+
+```yaml
+# Remove these lines:
+enablePasswordDB: true
+staticPasswords: [...]
+
+# Update oauth2 section:
+oauth2:
+  passwordConnector: meridian   # matches the ID registered at startup
+  skipApprovalScreen: true
+```
+
+### 3. Subdomain → Tenant Resolution
+
+The connector uses `tenant.RequireFromContext(ctx)` to scope identity lookups.
+Ensure the gateway populates the tenant in context before the Dex password flow
+reaches the connector — typically via subdomain extraction in the HTTP middleware.
+
+### 4. Seed Demo Users via Identity Service
+
+Replace `staticPasswords` with seeded identities created through the identity
+service bootstrap (see `services/identity/bootstrap/`). The `admin@volterra.energy`
+and `operator@volterra.energy` users should be created via the identity API with
+appropriate role assignments.
+
+## Reference
+
+- Connector implementation: `services/identity/connector/connector.go`
+- Claims mapping: `services/identity/connector/claims.go`
+- Bootstrap: `services/identity/bootstrap/`
+- Dex connector interface: `github.com/dexidp/dex/connector.PasswordConnector`

--- a/deploy/demo/dex.yaml
+++ b/deploy/demo/dex.yaml
@@ -10,6 +10,20 @@
 #     -d "scope=openid email profile" \
 #     -d "username=admin@volterra.energy" \
 #     -d "password=demo2026"
+#
+# Integration architecture note:
+#
+# Dex does not have a network "grpc" connector type. The Meridian identity
+# connector (services/identity/connector/) is a Go-level integration that is
+# wired directly into the Dex PasswordConnector interface at process startup
+# (services/identity/bootstrap/ or cmd/meridian/main.go). It validates
+# credentials by calling the identity domain repository in-process — no
+# network hop required.
+#
+# When the identity service is fully bootstrapped and the Dex server is
+# initialised with the MeridianConnector (replacing enablePasswordDB), the
+# staticPasswords block below can be removed. Until then, it serves as the
+# demo fallback and is kept here for reference.
 
 issuer: https://demo.meridianhub.cloud/dex
 
@@ -22,6 +36,9 @@ web:
   http: 0.0.0.0:5556
 
 oauth2:
+  # "local" routes password grants through the built-in password DB.
+  # Once the Meridian identity connector is wired into the Dex server binary,
+  # change this to the connector ID registered at startup (e.g. "meridian").
   passwordConnector: local
   skipApprovalScreen: true
 
@@ -30,15 +47,18 @@ staticClients:
     name: Meridian
     redirectURIs:
       - "https://demo.meridianhub.cloud/callback"
+      # Subdomain-based tenants — e.g. volterra.demo.meridianhub.cloud
+      - "https://volterra.demo.meridianhub.cloud/callback"
       - "http://localhost:8090/callback"
     public: true
 
 enablePasswordDB: true
 
+# Demo credentials. Managed by the Meridian identity service in production.
+# To generate a new hash: htpasswd -nbBC 10 "" '<password>' | tr -d ':\n' | sed 's/$2y/$2a/'
 staticPasswords:
   - email: "admin@volterra.energy"
     # Password: demo2026
-    # Generate with: htpasswd -nbBC 10 "" 'demo2026' | tr -d ':\n' | sed 's/$2y/$2a/'
     hash: "$2a$10$lIDConGp2.xX/KXg31kHoezV2HN/hDeF/aVLlAZh4LDX9q9uaj5y."
     username: "Admin"
     userID: "admin-volterra-001"


### PR DESCRIPTION
## Summary

- Clarifies the Dex/Meridian identity integration architecture in `dex.yaml` comments: Dex has no network gRPC connector type; the Meridian connector is wired in-process via `dex/connector.PasswordConnector`
- Adds subdomain redirect URI (`https://volterra.demo.meridianhub.cloud/callback`) to `staticClients` for subdomain-based tenant routing
- Creates `deploy/demo/dex-identity-migration-plan.md` documenting the full migration path from static passwords to the Meridian identity connector

## Changes Made

### `deploy/demo/dex.yaml`
- Added architecture comment block explaining that `services/identity/connector/` is a Go-level, in-process integration — not a network connector — and when `staticPasswords` can be removed
- Added inline comment on `passwordConnector: local` explaining the future migration to `passwordConnector: meridian`
- Added `https://volterra.demo.meridianhub.cloud/callback` redirect URI for subdomain-based tenant routing

### `deploy/demo/dex-identity-migration-plan.md` (new)
- Documents current state (static passwords) vs target state (Meridian connector in-process)
- Explains why a network gRPC connector is not the right approach (Dex does not support `type: grpc`)
- Step-by-step migration: wiring the connector at startup, updating `dex.yaml`, subdomain → tenant resolution, seeding demo users via the identity service

## Technical Details

Dex v2.x supports 16 connector types (LDAP, OIDC, GitHub, SAML, etc.). There is no `type: grpc` connector. The `services/identity/connector.Connector` struct implements `dex/connector.PasswordConnector` directly and is registered at Dex server initialisation — authentication calls traverse Go function calls, not the network. This preserves single-binary deployment and eliminates TLS configuration overhead.

## Risk Assessment

No runtime behaviour changes. `dex.yaml` changes are documentation/comment additions plus one new redirect URI. The migration plan document is reference material only.