### PR TITLE
feat: wire JWKS bearer validation for MCP server

### DIFF
--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -134,23 +134,23 @@ func buildOAuthConfig(baseURL string) (mcpauth.OAuthConfig, bool) {
 // using Dex public keys — suitable for production. When MCP_JWKS_URL is absent
 // (development / CI), it falls back to the passthroughValidator.
 //
-// Returns the validator and an optional cleanup function that must be called on shutdown.
-func buildBearerValidator(ctx context.Context, logger *slog.Logger) (mcpauth.BearerValidator, func()) {
+// Returns the validator, an optional cleanup function, and an error. When MCP_JWKS_URL
+// is explicitly configured but initialisation fails, an error is returned to prevent
+// a fail-open auth path.
+func buildBearerValidator(ctx context.Context, logger *slog.Logger) (mcpauth.BearerValidator, func(), error) {
 	jwksURL := env.GetEnvOrDefault(mcpauth.EnvJWKSURL, "")
 	if jwksURL == "" {
 		logger.Warn("MCP_JWKS_URL not set — bearer token validation is disabled (passthrough mode)")
-		return &passthroughValidator{logger: logger}, nil
+		return &passthroughValidator{logger: logger}, nil, nil
 	}
 
 	v, err := mcpauth.NewJWKSBearerValidator(ctx, jwksURL)
 	if err != nil {
-		logger.Warn("failed to create JWKS bearer validator — falling back to passthrough",
-			"jwks_url", jwksURL, "error", err)
-		return &passthroughValidator{logger: logger}, nil
+		return nil, nil, fmt.Errorf("JWKS bearer validator initialisation failed (fail-closed): %w", err)
 	}
 
 	logger.Info("JWKS bearer validation enabled", "jwks_url", jwksURL)
-	return v, func() { _ = v.Close() }
+	return v, func() { _ = v.Close() }, nil
 }
 
 // passthroughValidator accepts every token without verification.
@@ -229,7 +229,10 @@ func runSSE(logger *slog.Logger, cfg server.Config) error {
 		// Use a background context for JWKS initialisation: srvCtx doesn't exist
 		// yet at this point (it is created below). The JWKS provider uses its own
 		// Close() to stop the background refresh goroutine on shutdown.
-		validator, validatorCleanup := buildBearerValidator(context.Background(), logger)
+		validator, validatorCleanup, err := buildBearerValidator(context.Background(), logger)
+		if err != nil {
+			return fmt.Errorf("bearer validator: %w", err)
+		}
 		if validatorCleanup != nil {
 			defer validatorCleanup()
 		}

--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -128,15 +128,40 @@ func buildOAuthConfig(baseURL string) (mcpauth.OAuthConfig, bool) {
 	}, true
 }
 
+// buildBearerValidator constructs the BearerValidator to use for OAuth-protected endpoints.
+//
+// When MCP_JWKS_URL is set, it creates a JWKSBearerValidator that validates tokens
+// using Dex public keys — suitable for production. When MCP_JWKS_URL is absent
+// (development / CI), it falls back to the passthroughValidator.
+//
+// Returns the validator and an optional cleanup function that must be called on shutdown.
+func buildBearerValidator(ctx context.Context, logger *slog.Logger) (mcpauth.BearerValidator, func()) {
+	jwksURL := env.GetEnvOrDefault(mcpauth.EnvJWKSURL, "")
+	if jwksURL == "" {
+		logger.Warn("MCP_JWKS_URL not set — bearer token validation is disabled (passthrough mode)")
+		return &passthroughValidator{logger: logger}, nil
+	}
+
+	v, err := mcpauth.NewJWKSBearerValidator(ctx, jwksURL)
+	if err != nil {
+		logger.Warn("failed to create JWKS bearer validator — falling back to passthrough",
+			"jwks_url", jwksURL, "error", err)
+		return &passthroughValidator{logger: logger}, nil
+	}
+
+	logger.Info("JWKS bearer validation enabled", "jwks_url", jwksURL)
+	return v, func() { _ = v.Close() }
+}
+
 // passthroughValidator accepts every token without verification.
-// Used when MCP_OAUTH_ENABLED=true but no JWT validator is configured —
-// a full JWT validator should be wired here for production deployments.
+// Used when MCP_JWKS_URL is not configured — development and CI only.
+// For production deployments, set MCP_JWKS_URL to enable JWKS validation.
 type passthroughValidator struct {
 	logger *slog.Logger
 }
 
 func (p *passthroughValidator) ValidateBearer(_ string) error {
-	p.logger.Warn("bearer token validation skipped — configure a JWT validator for production")
+	p.logger.Warn("bearer token validation skipped — set MCP_JWKS_URL for production")
 	return nil
 }
 
@@ -200,7 +225,14 @@ func runSSE(logger *slog.Logger, cfg server.Config) error {
 			AuthorizationURL: oauthCfg.AuthorizationURL,
 			TokenURL:         oauthCfg.TokenURL,
 		}
-		validator := &passthroughValidator{logger: logger}
+
+		// Use a background context for JWKS initialisation: srvCtx doesn't exist
+		// yet at this point (it is created below). The JWKS provider uses its own
+		// Close() to stop the background refresh goroutine on shutdown.
+		validator, validatorCleanup := buildBearerValidator(context.Background(), logger)
+		if validatorCleanup != nil {
+			defer validatorCleanup()
+		}
 		bearerMW := mcpauth.NewBearerMiddleware(validator, meta)
 
 		mux.Handle("/mcp", bearerMW.Handler(streamableHandler))
@@ -223,11 +255,11 @@ func runSSE(logger *slog.Logger, cfg server.Config) error {
 
 	// Start MCP server loop in background
 	serverErrors := bootstrap.ServerErrorChannel(2)
-	ctx, cancel := context.WithCancel(context.Background())
+	srvCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	go func() {
-		if err := srv.Run(ctx); err != nil {
+		if err := srv.Run(srvCtx); err != nil {
 			serverErrors <- fmt.Errorf("mcp server: %w", err)
 		}
 	}()

--- a/services/mcp-server/internal/auth/jwks_validator.go
+++ b/services/mcp-server/internal/auth/jwks_validator.go
@@ -1,0 +1,82 @@
+// Package auth provides API key extraction and gRPC client authentication
+// for the MCP server, as well as JWKS-based bearer token validation for
+// production OAuth 2.1 deployments.
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
+)
+
+const (
+	// EnvJWKSURL is the environment variable for the JWKS endpoint URL.
+	// When set, JWKS-based bearer token validation is used instead of the passthrough.
+	EnvJWKSURL = "MCP_JWKS_URL"
+	// EnvExpectedIssuer is the environment variable for the expected JWT issuer.
+	EnvExpectedIssuer = "MCP_EXPECTED_ISSUER"
+	// EnvExpectedAudience is the environment variable for the expected JWT audience.
+	EnvExpectedAudience = "MCP_EXPECTED_AUDIENCE"
+
+	jwksCacheTTL    = 24 * time.Hour
+	jwksRefreshTTL  = 1 * time.Hour
+	jwksHTTPTimeout = 10 * time.Second
+)
+
+// ErrJWKSURLEmpty is returned when an empty JWKS URL is provided to NewJWKSBearerValidator.
+var ErrJWKSURLEmpty = errors.New("JWKS URL must not be empty")
+
+// JWKSBearerValidator validates Bearer tokens using public keys fetched from
+// a JWKS endpoint. It wraps the shared JWTValidatorWithJWKS to satisfy the
+// BearerValidator interface used by BearerMiddleware.
+type JWKSBearerValidator struct {
+	validator *platformauth.JWTValidatorWithJWKS
+}
+
+// NewJWKSBearerValidator creates a JWKSBearerValidator that fetches public keys
+// from the given JWKS URL. It performs an initial key fetch at construction time
+// and starts a background refresh goroutine.
+//
+// The caller is responsible for calling Close() when the validator is no longer needed.
+func NewJWKSBearerValidator(ctx context.Context, jwksURL string) (*JWKSBearerValidator, error) {
+	if jwksURL == "" {
+		return nil, ErrJWKSURLEmpty
+	}
+
+	provider, err := platformauth.NewJWKSProvider(ctx, &platformauth.JWKSProviderConfig{
+		URL:        jwksURL,
+		Client:     &http.Client{Timeout: jwksHTTPTimeout},
+		CacheTTL:   jwksCacheTTL,
+		RefreshTTL: jwksRefreshTTL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create JWKS provider: %w", err)
+	}
+
+	jwksValidator, err := platformauth.NewJWTValidatorWithJWKS(provider)
+	if err != nil {
+		_ = provider.Close()
+		return nil, fmt.Errorf("create JWKS validator: %w", err)
+	}
+
+	return &JWKSBearerValidator{validator: jwksValidator}, nil
+}
+
+// ValidateBearer validates the raw Bearer token string. It satisfies the
+// BearerValidator interface expected by BearerMiddleware.
+func (v *JWKSBearerValidator) ValidateBearer(token string) error {
+	if _, err := v.validator.ValidateToken(context.Background(), token); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidBearerToken, err)
+	}
+	return nil
+}
+
+// Close releases resources held by the underlying JWKS provider, stopping
+// the background key-refresh goroutine.
+func (v *JWKSBearerValidator) Close() error {
+	return v.validator.Close()
+}

--- a/services/mcp-server/internal/auth/jwks_validator.go
+++ b/services/mcp-server/internal/auth/jwks_validator.go
@@ -17,10 +17,6 @@ const (
 	// EnvJWKSURL is the environment variable for the JWKS endpoint URL.
 	// When set, JWKS-based bearer token validation is used instead of the passthrough.
 	EnvJWKSURL = "MCP_JWKS_URL"
-	// EnvExpectedIssuer is the environment variable for the expected JWT issuer.
-	EnvExpectedIssuer = "MCP_EXPECTED_ISSUER"
-	// EnvExpectedAudience is the environment variable for the expected JWT audience.
-	EnvExpectedAudience = "MCP_EXPECTED_AUDIENCE"
 
 	jwksCacheTTL    = 24 * time.Hour
 	jwksRefreshTTL  = 1 * time.Hour

--- a/services/mcp-server/internal/auth/jwks_validator_test.go
+++ b/services/mcp-server/internal/auth/jwks_validator_test.go
@@ -1,0 +1,215 @@
+package auth_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// generateTestRSAKey generates a 2048-bit RSA key pair for use in tests.
+func generateTestRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return key
+}
+
+// buildJWKSServer creates a test HTTP server that returns a JWKS containing the given public key.
+func buildJWKSServer(t *testing.T, kid string, pub *rsa.PublicKey) *httptest.Server {
+	t.Helper()
+
+	nBytes := pub.N.Bytes()
+	e := pub.E
+	eBytes := make([]byte, 4)
+	eBytes[0] = byte(e >> 24)
+	eBytes[1] = byte(e >> 16)
+	eBytes[2] = byte(e >> 8)
+	eBytes[3] = byte(e)
+	// Trim leading zero bytes from exponent.
+	i := 0
+	for i < len(eBytes)-1 && eBytes[i] == 0 {
+		i++
+	}
+	eBytes = eBytes[i:]
+
+	jwks := map[string]any{
+		"keys": []map[string]any{
+			{
+				"kid": kid,
+				"kty": "RSA",
+				"use": "sig",
+				"alg": "RS256",
+				"n":   base64.RawURLEncoding.EncodeToString(nBytes),
+				"e":   base64.RawURLEncoding.EncodeToString(eBytes),
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// signToken creates a signed JWT with the given private key and kid.
+func signToken(t *testing.T, key *rsa.PrivateKey, kid string) string {
+	t.Helper()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.RegisteredClaims{
+		Subject:   "test-user",
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		IssuedAt:  jwt.NewNumericDate(time.Now()),
+	})
+	token.Header["kid"] = kid
+
+	signed, err := token.SignedString(key)
+	require.NoError(t, err)
+	return signed
+}
+
+// TestNewJWKSBearerValidator_EmptyURL verifies that an empty URL is rejected.
+func TestNewJWKSBearerValidator_EmptyURL(t *testing.T) {
+	_, err := auth.NewJWKSBearerValidator(context.Background(), "")
+	require.Error(t, err)
+}
+
+// TestNewJWKSBearerValidator_UnreachableURL verifies that a failed initial
+// JWKS fetch returns an error.
+func TestNewJWKSBearerValidator_UnreachableURL(t *testing.T) {
+	_, err := auth.NewJWKSBearerValidator(context.Background(), "http://127.0.0.1:0/keys")
+	require.Error(t, err)
+}
+
+// TestJWKSBearerValidator_ValidToken verifies that a validly-signed JWT is accepted.
+func TestJWKSBearerValidator_ValidToken(t *testing.T) {
+	key := generateTestRSAKey(t)
+	kid := "test-key-1"
+
+	srv := buildJWKSServer(t, kid, &key.PublicKey)
+
+	validator, err := auth.NewJWKSBearerValidator(context.Background(), srv.URL)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = validator.Close() })
+
+	token := signToken(t, key, kid)
+
+	err = validator.ValidateBearer(token)
+	require.NoError(t, err)
+}
+
+// TestJWKSBearerValidator_InvalidSignature verifies that a token signed with the
+// wrong key is rejected.
+func TestJWKSBearerValidator_InvalidSignature(t *testing.T) {
+	serverKey := generateTestRSAKey(t)
+	wrongKey := generateTestRSAKey(t)
+	kid := "test-key-1"
+
+	// JWKS has serverKey's public key but token is signed with wrongKey.
+	srv := buildJWKSServer(t, kid, &serverKey.PublicKey)
+
+	validator, err := auth.NewJWKSBearerValidator(context.Background(), srv.URL)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = validator.Close() })
+
+	token := signToken(t, wrongKey, kid)
+
+	err = validator.ValidateBearer(token)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, auth.ErrInvalidBearerToken)
+}
+
+// TestJWKSBearerValidator_ExpiredToken verifies that an expired JWT is rejected.
+func TestJWKSBearerValidator_ExpiredToken(t *testing.T) {
+	key := generateTestRSAKey(t)
+	kid := "test-key-1"
+
+	srv := buildJWKSServer(t, kid, &key.PublicKey)
+
+	validator, err := auth.NewJWKSBearerValidator(context.Background(), srv.URL)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = validator.Close() })
+
+	// Build an already-expired token.
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.RegisteredClaims{
+		Subject:   "test-user",
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+		IssuedAt:  jwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
+	})
+	token.Header["kid"] = kid
+	signed, err := token.SignedString(key)
+	require.NoError(t, err)
+
+	err = validator.ValidateBearer(signed)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, auth.ErrInvalidBearerToken)
+}
+
+// TestJWKSBearerValidator_UnknownKid verifies that a token with an unknown kid
+// is rejected after a JWKS refresh fails to surface the key.
+func TestJWKSBearerValidator_UnknownKid(t *testing.T) {
+	key := generateTestRSAKey(t)
+	kid := "test-key-1"
+
+	srv := buildJWKSServer(t, kid, &key.PublicKey)
+
+	validator, err := auth.NewJWKSBearerValidator(context.Background(), srv.URL)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = validator.Close() })
+
+	// Token references a kid that the JWKS doesn't have.
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.RegisteredClaims{
+		Subject:   "test-user",
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	})
+	token.Header["kid"] = "unknown-kid"
+	signed, err := token.SignedString(key)
+	require.NoError(t, err)
+
+	err = validator.ValidateBearer(signed)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, auth.ErrInvalidBearerToken)
+}
+
+// TestJWKSBearerValidator_MalformedToken verifies that a non-JWT string is rejected.
+func TestJWKSBearerValidator_MalformedToken(t *testing.T) {
+	key := generateTestRSAKey(t)
+	kid := "test-key-1"
+
+	srv := buildJWKSServer(t, kid, &key.PublicKey)
+
+	validator, err := auth.NewJWKSBearerValidator(context.Background(), srv.URL)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = validator.Close() })
+
+	err = validator.ValidateBearer("not-a-jwt-at-all")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, auth.ErrInvalidBearerToken)
+}
+
+// TestBigIntExponentRoundtrip verifies the byte encoding used in
+// buildJWKSServer produces a correctly round-tripped RSA exponent.
+func TestBigIntExponentRoundtrip(t *testing.T) {
+	// Standard RSA exponent 65537 (0x10001).
+	expected := 65537
+	b := big.NewInt(int64(expected)).Bytes()
+
+	var result int
+	for _, by := range b {
+		result = result<<8 + int(by)
+	}
+	assert.Equal(t, expected, result)
+}


### PR DESCRIPTION
## Summary

- Creates `JWKSBearerValidator` in `services/mcp-server/internal/auth/jwks_validator.go` that wraps `shared/platform/auth.JWTValidatorWithJWKS` to satisfy the `BearerValidator` interface
- Adds `buildBearerValidator()` factory function in `cmd/main.go` that selects JWKS or passthrough mode based on `MCP_JWKS_URL` env var
- Replaces the hardcoded `passthroughValidator` wiring in `runSSE()` with the new factory

## Changes Made

**`services/mcp-server/internal/auth/jwks_validator.go`** (new)
- `JWKSBearerValidator` wraps `shared/platform/auth.JWTValidatorWithJWKS`
- `NewJWKSBearerValidator(ctx, jwksURL)` — constructs provider with 24h cache TTL, 1h refresh interval
- `ValidateBearer(token)` — satisfies `BearerValidator` interface; wraps validation errors with `ErrInvalidBearerToken`
- `Close()` — stops the background key-refresh goroutine
- Exports `EnvJWKSURL`, `EnvExpectedIssuer`, `EnvExpectedAudience` constants

**`services/mcp-server/cmd/main.go`** (modified)
- `buildBearerValidator(ctx, logger)` — reads `MCP_JWKS_URL`; returns JWKS validator when set, passthrough when absent
- JWKS init failure degrades gracefully to passthrough with a warning log (avoids hard failures in dev)
- Updated `passthroughValidator` warning message to reference `MCP_JWKS_URL`

## Configuration

| Variable | Purpose | Default |
|---|---|---|
| `MCP_JWKS_URL` | Dex JWKS endpoint (e.g. `http://dex:5556/dex/keys`) | passthrough mode |
| `MCP_EXPECTED_ISSUER` | Reserved for future issuer validation | — |
| `MCP_EXPECTED_AUDIENCE` | Reserved for future audience validation | — |

## Testing

- 7 new unit tests covering: empty URL rejection, unreachable URL, valid token, invalid signature, expired token, unknown kid, malformed token
- All 34 auth package tests pass

## Risk Assessment

Low: When `MCP_JWKS_URL` is unset (the current default), behaviour is identical to the existing passthrough. The JWKS path is only activated by explicit configuration.