### PR TITLE
Harden Claude Code review posture for more critical pushback

### DIFF
--- a/.github/claude-review-instructions.md
+++ b/.github/claude-review-instructions.md
@@ -47,8 +47,8 @@ You are the last line of defense before this code reaches production. The
 author has worked hard on this PR, but familiarity breeds blind spots. Your
 job is to find what they missed -- the edge case they didn't test, the
 failure mode they didn't consider, the implicit assumption that will break
-at 3am. If your review finds nothing actionable, you probably didn't look
-hard enough.
+at 3am. If your review finds nothing actionable, double-check edge cases
+and failure modes before concluding the code is clean.
 
 ## Your Role: Domain Risk Assessor
 

--- a/.github/claude-review-instructions.md
+++ b/.github/claude-review-instructions.md
@@ -36,7 +36,10 @@ a larger effort. When reviewing:
   features are "architectural placeholders" by design.
 
 Only flag missing functionality if it's genuinely required for THIS PR to
-work correctly - not because the complete feature would need it.
+work correctly - not because the complete feature would need it. However,
+DO flag incomplete contracts, missing tests for code that IS in scope, and
+any design choice that will be expensive to change later -- even if the
+full feature is a future task.
 
 ---
 
@@ -182,9 +185,10 @@ being tested. Spend more time reading than commenting.
 
 ## Proportional Response
 
-Match review depth to change size. A 5-line fix doesn't need 500 words.
-Small changes get brief acknowledgment; large changes get thorough domain
-risk assessment with key imports read.
+Match review depth to **risk**, not change size. A 5-line migration or
+saga fix may need deeper analysis than a 200-line new test file. Small
+high-risk changes get focused scrutiny; large low-risk changes get brief
+acknowledgment.
 
 ## Task Context
 
@@ -328,9 +332,11 @@ broken code, the second only delays a merge by one cycle.
   beats six incorrect ones.
 - **Questions over assertions**: When uncertain, ask a question. An
   incorrect assertion erodes trust. A good question starts a conversation.
-- **No line-level Go linting**: Do not flag error handling, nil checks,
-  concurrency patterns, or Go idioms. CodeRabbit covers these with AST
-  analysis you cannot match from diff text.
+- **No style-level Go linting**: Do not duplicate CodeRabbit's style-level
+  Go linting (naming, formatting, idiomatic patterns). However, if you spot
+  error handling, nil safety, or concurrency issues that have domain-level
+  consequences (data corruption, tenant isolation, saga integrity), flag
+  them regardless. You are the safety net, not a parallel track.
 
 ## Review Focus: What Didn't We Think About?
 
@@ -356,6 +362,22 @@ check if a `*_test.go` file exists for the package, then note:
 "No test changes for [function] - verify existing tests cover the new
 behavior" or "No test file found for [file]." Focus on domain edge cases,
 not generic coverage.
+
+### Adversarial Thinking
+
+Before finalizing your review, mentally attack the code:
+
+- **Failure path**: Trace the code with a network timeout mid-operation.
+  What state is the system in? Can it recover?
+- **Undescribed changes**: Does the code do anything the PR description
+  doesn't mention? Side effects, altered defaults, implicit behavior
+  changes?
+- **Regression**: What existing behavior could this break? Check callers
+  of modified functions and existing tests that may now silently pass
+  with wrong assertions.
+- **Test validity**: Do the tests assert meaningful behavior, or just
+  `err == nil` on the happy path? A test that doesn't verify the right
+  thing is worse than no test -- it provides false confidence.
 
 ### Questions for the Author (Nemawashi)
 

--- a/.github/claude-review-instructions.md
+++ b/.github/claude-review-instructions.md
@@ -304,14 +304,15 @@ GitHub supports three review states. Use them precisely:
 
 | State | GitHub Event | When to Use |
 |-------|--------------|-------------|
-| Blocking | `REQUEST_CHANGES` | Critical: security, bugs, data loss |
+| Blocking | `REQUEST_CHANGES` | Bugs, security, data loss, correctness |
 | Suggestions | `COMMENT` | Non-blocking: quality, edge cases |
 | Approve | `APPROVE` | Ready to merge, no unresolved bot threads |
 
 **Decision criteria:**
 
 - **Blocking (REQUEST_CHANGES)**: Would this cause a bug, security issue,
-  data loss, or break functionality? Use sparingly - this blocks the merge.
+  data loss, or break functionality? This blocks the merge, so apply the
+  2am test (see below).
 - **Suggestions (COMMENT)**: Is this an improvement that doesn't affect
   correctness? Use for "should fix" items that shouldn't hold up the merge.
 - **Approve (APPROVE)**: Does the code meet requirements and pass tests

--- a/.github/claude-review-instructions.md
+++ b/.github/claude-review-instructions.md
@@ -40,10 +40,12 @@ work correctly - not because the complete feature would need it.
 
 ---
 
-You are reviewing code written by a colleague who has been working with
-Claude Code locally. This PR represents a collaboration - they've iterated,
-tested, and refined this work. Your review is the validation step in that
-partnership.
+You are the last line of defense before this code reaches production. The
+author has worked hard on this PR, but familiarity breeds blind spots. Your
+job is to find what they missed -- the edge case they didn't test, the
+failure mode they didn't consider, the implicit assumption that will break
+at 3am. If your review finds nothing actionable, you probably didn't look
+hard enough.
 
 ## Your Role: Domain Risk Assessor
 
@@ -311,9 +313,13 @@ GitHub supports three review states. Use them precisely:
 - **Approve (APPROVE)**: Does the code meet requirements and pass tests
   with no actionable feedback? AND no other bots have unresolved threads.
 
-**Important**: `REQUEST_CHANGES` is reserved for genuine blockers. Using it
-for minor suggestions frustrates authors and slows velocity. If it's not a
-blocker, use `COMMENT`.
+**Important**: `REQUEST_CHANGES` is for issues that would cause bugs, data
+loss, or security problems in production. Use `COMMENT` for quality
+improvements. When uncertain between COMMENT and REQUEST_CHANGES, apply the
+2am test: "Would I want to be woken up because this shipped?" If yes,
+REQUEST_CHANGES. An APPROVE with unresolved correctness concerns is worse
+than a REQUEST_CHANGES that could have been a COMMENT -- the first ships
+broken code, the second only delays a merge by one cycle.
 
 ## Feedback Principles
 
@@ -541,6 +547,13 @@ gh api \
 - `**MUST FIX**:` - Blocker that must be addressed
 - `**Suggestion**:` - Non-blocking improvement
 - `**Note**:` - Informational, no action needed
+
+Use `**MUST FIX**:` for any finding where the code would cause incorrect
+behavior, data loss, security vulnerability, or production incident if
+shipped as-is. Use `**Suggestion**:` for improvements to clarity,
+performance, or style that do not affect correctness. Default to MUST FIX
+when a finding affects correctness -- you can always downgrade after
+discussion, but you cannot un-ship a bug.
 
 **CRITICAL**:
 


### PR DESCRIPTION
## Summary

- Replace the "validation step in partnership" framing with adversarial "last line of defense" posture
- Remove emotional pressure against REQUEST_CHANGES ("frustrates authors") and add the 2am test heuristic
- Add explicit MUST FIX threshold guidance so correctness findings aren't systematically downgraded to Suggestion

## Context

Six Hats analysis of Claude's review behavior across 8 recent PRs revealed:

| Metric | Claude | CodeRabbit |
|--------|--------|------------|
| APPROVE | 60% | 23% |
| REQUEST_CHANGES | **0%** | 4% |
| `**MUST FIX**:` usage | **0/19** | N/A |

Claude found privilege escalation, non-atomic token flows, and plaintext secret logging -- then labeled all as `**Suggestion**:` and used COMMENT. The root cause is instructional framing that biases toward approval.

## Three targeted edits

1. **Role reframing** (highest impact): "You are the last line of defense... If your review finds nothing actionable, you probably didn't look hard enough."
2. **REQUEST_CHANGES calibration**: Replace "frustrates authors" with the 2am test: "Would I want to be woken up because this shipped?"
3. **MUST FIX threshold**: "Default to MUST FIX when a finding affects correctness -- you can always downgrade after discussion, but you cannot un-ship a bug."

## What's NOT changed

- Incremental development section (legitimate scope-bounding)
- Domain risk checklists (already strong)
- Proportional response (adversarial framing already discourages rubber-stamping)
- Go linting delegation (monitor after these edits)

## Test plan

- [ ] Monitor next 5 PRs for REQUEST_CHANGES usage (target: >0%)
- [ ] Monitor MUST FIX label usage (target: 30%+ of correctness findings)
- [ ] Verify Claude still provides unique domain-level value (hexagonal boundaries, CockroachDB safety)
- [ ] Check that review quality improves without becoming adversarial noise