### PR TITLE
fix: allow OIDC tokens without tenant claim for subdomain-based tenancy

### DIFF
--- a/services/gateway/auth/combined_middleware.go
+++ b/services/gateway/auth/combined_middleware.go
@@ -245,10 +245,10 @@ func (m *TenantAuthorizationMiddleware) Handler(next http.Handler) http.Handler 
 			return
 		}
 
-		// Platform-admin/super-admin bypass: when JWT has no tenant claim but has
-		// elevated platform role, allow access without tenant context (platform-level
-		// endpoints like ListTenants) or cross-tenant access (tenant-scoped endpoints
-		// resolved via subdomain).
+		// When JWT has no tenant claim (e.g. standard OIDC tokens from Dex):
+		// 1. Platform-admin/super-admin: allow access to any tenant
+		// 2. Regular user with resolved tenant (subdomain/slug): scope to that tenant
+		// 3. Otherwise: deny
 		if jwtTenantID == "" {
 			claims, hasClaims := GetClaimsFromContext(ctx)
 			if hasClaims && hasPlatformAdminRole(claims) {
@@ -259,7 +259,20 @@ func (m *TenantAuthorizationMiddleware) Handler(next http.Handler) http.Handler 
 				next.ServeHTTP(w, r)
 				return
 			}
-			// No tenant claim and not a platform admin
+
+			// Allow if tenant was resolved from subdomain/slug — user inherits
+			// tenant scope from the request routing rather than from JWT claims.
+			// This supports OIDC providers (like Dex) that issue identity-only
+			// tokens without custom tenant claims.
+			if resolvedTenant, ok := tenant.FromContext(ctx); ok && !resolvedTenant.IsEmpty() {
+				m.logger.Debug("tenant resolved from request context (no JWT tenant claim)",
+					slog.String("tenant", resolvedTenant.String()),
+					slog.String("path", r.URL.Path),
+				)
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			writeForbidden(w, "missing tenant claim in token")
 			return
 		}

--- a/services/gateway/auth/combined_middleware_test.go
+++ b/services/gateway/auth/combined_middleware_test.go
@@ -353,7 +353,39 @@ func TestTenantAuthorizationMiddleware(t *testing.T) {
 		assert.Contains(t, rr.Body.String(), "not authorized for this tenant")
 	})
 
-	t.Run("403 when no JWT tenant claim", func(t *testing.T) {
+	t.Run("OIDC token without tenant claim uses resolved tenant from subdomain", func(t *testing.T) {
+		middleware := NewTenantAuthorizationMiddleware(logger)
+
+		var capturedCtx context.Context
+		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+		})
+
+		handler := middleware.Handler(nextHandler)
+
+		// Simulate OIDC token (e.g. Dex) with no tenant claim but resolved tenant from subdomain
+		claims := &platformauth.Claims{
+			UserID: "oidc-user",
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject: "dex-subject-id",
+			},
+		}
+		ctx := injectClaimsToContext(context.Background(), claims)
+		ctx = tenant.WithTenant(ctx, tenant.MustNewTenantID("volterra"))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req = req.WithContext(ctx)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		resolvedTenant, hasTenant := tenant.FromContext(capturedCtx)
+		assert.True(t, hasTenant)
+		assert.Equal(t, "volterra", resolvedTenant.String())
+	})
+
+	t.Run("403 when no JWT tenant claim and no resolved tenant", func(t *testing.T) {
 		middleware := NewTenantAuthorizationMiddleware(logger)
 
 		nextHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
@@ -362,8 +394,11 @@ func TestTenantAuthorizationMiddleware(t *testing.T) {
 
 		handler := middleware.Handler(nextHandler)
 
-		// Create context with resolved tenant but no JWT tenant
-		ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("some_corp"))
+		// JWT has no tenant claim and no tenant resolved from subdomain
+		claims := &platformauth.Claims{
+			UserID: "oidc-user",
+		}
+		ctx := injectClaimsToContext(context.Background(), claims)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
 		req = req.WithContext(ctx)


### PR DESCRIPTION
## Summary

- Fix `TenantAuthorizationMiddleware` to allow authenticated OIDC tokens (e.g. from Dex) that lack custom `x-tenant-id` claims when the tenant has been resolved from subdomain or `X-Tenant-Slug` header

## Context

Standard OIDC providers like Dex issue identity-only tokens with `sub`, `email`, `name` claims but no custom `x-tenant-id` or `roles` claims. When tenant routing is subdomain-based, `TenantResolverMiddleware` resolves the tenant from the hostname before `TenantAuthorizationMiddleware` runs.

Previously, `TenantAuthorizationMiddleware` required the tenant to come from the JWT — blocking all standard OIDC tokens regardless of whether the tenant was resolved from the request context. This was masked by `DEFAULT_TENANT_ID` (removed in #1355) which injected a fallback tenant into every token.

The fix adds a third path in the empty-JWT-tenant check: if the user is not a platform admin but a tenant was resolved from the request context (subdomain/slug), allow the request scoped to that tenant.

## Test plan

- [x] `TestTenantAuthorizationMiddleware` — 12 tests pass including new `OIDC_token_without_tenant_claim_uses_resolved_tenant_from_subdomain` test
- [x] Full `./services/gateway/...` test suite passes
- [ ] Deploy to demo and verify Dex tokens work with `X-Tenant-Slug` header