### PR TITLE
feat: extend proto schema for event trigger type with filter field

### DIFF
--- a/api/jsonschema/manifest.v1.schema.json
+++ b/api/jsonschema/manifest.v1.schema.json
@@ -849,17 +849,21 @@
                 },
                 "trigger": {
                     "type": "string",
-                    "description": "trigger defines what initiates this saga. Supported prefixes:   \"api:\" - triggered by an API call (e.g., \"api:/v1/settlements\")   \"webhook:\" - triggered by an external webhook (e.g., \"webhook:stripe_payment\")   \"scheduled:\" - triggered on a schedule (e.g., \"scheduled:daily_reconciliation\")"
+                    "description": "trigger defines what initiates this saga. Supported prefixes:   \"api:\" - triggered by an API call (e.g., \"api:/v1/settlements\")   \"webhook:\" - triggered by an external webhook (e.g., \"webhook:stripe_payment\")   \"scheduled:\" - triggered on a schedule (e.g., \"scheduled:daily_reconciliation\")   \"event:\" - triggered by an internal domain event (e.g., \"event:position-keeping.transaction-captured.v1\")"
                 },
                 "script": {
                     "type": "string",
                     "description": "script is the inline Starlark source code defining the saga workflow. Must not be empty - all saga logic is defined inline in the manifest. Starlark guarantees termination (no while loops, no recursion)."
+                },
+                "filter": {
+                    "type": "string",
+                    "description": "filter is a CEL expression evaluated against the event payload to determine whether this saga should execute. Required when trigger starts with \"event:\". The expression must return a boolean; the saga executes only when it returns true. Example: `event.amount \u003e 0 \u0026\u0026 event.currency == \"GBP\"`"
                 }
             },
             "additionalProperties": false,
             "type": "object",
             "title": "========================================\n Saga Definitions\n ========================================",
-            "description": "======================================== Saga Definitions ========================================  SagaDefinition declares a workflow within the manifest. Sagas are triggered by API calls, webhooks, or scheduled events, and contain inline Starlark scripts that orchestrate service interactions."
+            "description": "======================================== Saga Definitions ========================================  SagaDefinition declares a workflow within the manifest. Sagas are triggered by API calls, webhooks, scheduled events, or internal domain events, and contain inline Starlark scripts that orchestrate service interactions."
         },
         "meridian.control_plane.v1.ValuationRule": {
             "required": [

--- a/api/jsonschema/manifest.v1.schema.json
+++ b/api/jsonschema/manifest.v1.schema.json
@@ -857,7 +857,7 @@
                 },
                 "filter": {
                     "type": "string",
-                    "description": "filter is a CEL expression evaluated against the event payload to determine whether this saga should execute. Required when trigger starts with \"event:\". The expression must return a boolean; the saga executes only when it returns true. Example: `event.amount \u003e 0 \u0026\u0026 event.currency == \"GBP\"`"
+                    "description": "filter is a CEL expression evaluated against the event payload to determine whether this saga should execute. Recommended when trigger starts with \"event:\"; omitting it causes a validation warning because the saga will execute for every matching event. The expression must return a boolean; the saga executes only when it returns true. Must be non-empty when present. Example: `event.amount \u003e 0 \u0026\u0026 event.currency == \"GBP\"`"
                 }
             },
             "additionalProperties": false,

--- a/api/proto/meridian/control_plane/v1/manifest.proto
+++ b/api/proto/meridian/control_plane/v1/manifest.proto
@@ -295,10 +295,15 @@ message SagaDefinition {
   }];
 
   // filter is a CEL expression evaluated against the event payload to determine
-  // whether this saga should execute. Required when trigger starts with "event:".
-  // The expression must return a boolean; the saga executes only when it returns true.
+  // whether this saga should execute. Recommended when trigger starts with "event:";
+  // omitting it causes a validation warning because the saga will execute for every
+  // matching event. The expression must return a boolean; the saga executes only when
+  // it returns true. Must be non-empty when present.
   // Example: `event.amount > 0 && event.currency == "GBP"`
-  optional string filter = 4 [(buf.validate.field).string = {max_len: 4096}];
+  optional string filter = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 4096
+  }];
 }
 
 // ========================================

--- a/api/proto/meridian/control_plane/v1/manifest.proto
+++ b/api/proto/meridian/control_plane/v1/manifest.proto
@@ -263,7 +263,7 @@ message ValuationRule {
 // ========================================
 
 // SagaDefinition declares a workflow within the manifest.
-// Sagas are triggered by API calls, webhooks, or scheduled events,
+// Sagas are triggered by API calls, webhooks, scheduled events, or internal domain events,
 // and contain inline Starlark scripts that orchestrate service interactions.
 message SagaDefinition {
   // name is the unique identifier for this saga (e.g., "process_energy_settlement").
@@ -279,10 +279,11 @@ message SagaDefinition {
   //   "api:" - triggered by an API call (e.g., "api:/v1/settlements")
   //   "webhook:" - triggered by an external webhook (e.g., "webhook:stripe_payment")
   //   "scheduled:" - triggered on a schedule (e.g., "scheduled:daily_reconciliation")
+  //   "event:" - triggered by an internal domain event (e.g., "event:position-keeping.transaction-captured.v1")
   string trigger = 2 [(buf.validate.field).string = {
     min_len: 1
     max_len: 255
-    pattern: "^(api:|webhook:|scheduled:).+$"
+    pattern: "^(api:|webhook:|scheduled:|event:).+$"
   }];
 
   // script is the inline Starlark source code defining the saga workflow.
@@ -292,6 +293,12 @@ message SagaDefinition {
     min_len: 1
     max_len: 65536
   }];
+
+  // filter is a CEL expression evaluated against the event payload to determine
+  // whether this saga should execute. Required when trigger starts with "event:".
+  // The expression must return a boolean; the saga executes only when it returns true.
+  // Example: `event.amount > 0 && event.currency == "GBP"`
+  optional string filter = 4 [(buf.validate.field).string = {max_len: 4096}];
 }
 
 // ========================================

--- a/api/proto/meridian/control_plane/v1/manifest_test.go
+++ b/api/proto/meridian/control_plane/v1/manifest_test.go
@@ -672,6 +672,16 @@ func TestSagaDefinitionValidation(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "invalid: filter set to empty string",
+			saga: &controlplanev1.SagaDefinition{
+				Name:    "test_saga",
+				Trigger: "event:some.event.v1",
+				Script:  "def execute(ctx):\n    return {}\n",
+				Filter:  proto.String(""),
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/api/proto/meridian/control_plane/v1/manifest_test.go
+++ b/api/proto/meridian/control_plane/v1/manifest_test.go
@@ -643,6 +643,35 @@ func TestSagaDefinitionValidation(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "valid event trigger with filter",
+			saga: &controlplanev1.SagaDefinition{
+				Name:    "on_transaction_captured",
+				Trigger: "event:position-keeping.transaction-captured.v1",
+				Script:  "def execute(ctx):\n    return {}\n",
+				Filter:  proto.String(`event.amount > 0 && event.currency == "GBP"`),
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid event trigger without filter",
+			saga: &controlplanev1.SagaDefinition{
+				Name:    "on_transaction_captured",
+				Trigger: "event:position-keeping.transaction-captured.v1",
+				Script:  "def execute(ctx):\n    return {}\n",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid: filter exceeds max length",
+			saga: &controlplanev1.SagaDefinition{
+				Name:    "test_saga",
+				Trigger: "event:some.event.v1",
+				Script:  "def execute(ctx):\n    return {}\n",
+				Filter:  proto.String(strings.Repeat("x", 4097)),
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -652,6 +681,34 @@ func TestSagaDefinitionValidation(t *testing.T) {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestSagaDefinitionEventTrigger verifies event trigger round-trip serialization.
+func TestSagaDefinitionEventTrigger(t *testing.T) {
+	filter := `event.amount > 0 && event.currency == "GBP"`
+	original := &controlplanev1.SagaDefinition{
+		Name:    "on_transaction_captured",
+		Trigger: "event:position-keeping.transaction-captured.v1",
+		Script:  "def execute(ctx):\n    return {}\n",
+		Filter:  proto.String(filter),
+	}
+
+	data, err := proto.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	decoded := &controlplanev1.SagaDefinition{}
+	if err := proto.Unmarshal(data, decoded); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if !proto.Equal(original, decoded) {
+		t.Error("round-trip proto serialization produced different message")
+	}
+	if decoded.GetFilter() != filter {
+		t.Errorf("expected filter %q, got %q", filter, decoded.GetFilter())
 	}
 }
 

--- a/services/control-plane/internal/differ/manifest_differ.go
+++ b/services/control-plane/internal/differ/manifest_differ.go
@@ -664,6 +664,9 @@ func describeSagaChanges(name string, prev, updated *controlplanev1.SagaDefiniti
 	if prev.GetScript() != updated.GetScript() {
 		changes = append(changes, "script changed")
 	}
+	if prev.GetFilter() != updated.GetFilter() {
+		changes = append(changes, "filter changed")
+	}
 	if len(changes) == 0 {
 		return fmt.Sprintf("Update saga %s", name)
 	}

--- a/services/control-plane/internal/differ/manifest_differ_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_test.go
@@ -860,3 +860,46 @@ func TestDiff_NilLastApplied_WithPartyTypes_AllCreates(t *testing.T) {
 	assert.Len(t, creates, 1)
 	assert.Equal(t, "tenant-1:PERSON", creates[0].ResourceCode)
 }
+
+func TestDiff_AddedEventSaga_Create(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	filter := `event.amount > 0 && event.currency == "GBP"`
+	newManifest := testManifest()
+	newManifest.Sagas = append(newManifest.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_transaction_captured",
+		Trigger: "event:position-keeping.transaction-captured.v1",
+		Script:  "def execute(ctx):\n    return {}\n",
+		Filter:  &filter,
+	})
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceSaga)
+	assert.Len(t, creates, 1)
+	assert.Equal(t, "on_transaction_captured", creates[0].ResourceCode)
+	assert.Contains(t, creates[0].Description, "trigger: event:")
+}
+
+func TestDiff_ModifiedSagaFilter_DescribesChange(t *testing.T) {
+	d := New(nil, nil)
+
+	filter := `event.amount > 0`
+	oldManifest := testManifest()
+	oldManifest.Sagas[0].Trigger = "event:position-keeping.transaction-captured.v1"
+	oldManifest.Sagas[0].Filter = &filter
+
+	newFilter := `event.amount > 100`
+	newManifest := testManifest()
+	newManifest.Sagas[0].Trigger = "event:position-keeping.transaction-captured.v1"
+	newManifest.Sagas[0].Filter = &newFilter
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceSaga)
+	assert.Len(t, updates, 1)
+	assert.Contains(t, updates[0].Description, "filter changed")
+}

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -327,7 +327,7 @@ func (v *ManifestValidator) validateDuplicates(
 		}
 	}
 
-	// Check duplicate saga names
+	// Check duplicate saga names and event trigger filter requirements
 	sagaNames := make(map[string]int)
 	for i, saga := range manifest.GetSagas() {
 		if prev, exists := sagaNames[saga.GetName()]; exists {
@@ -339,6 +339,16 @@ func (v *ManifestValidator) validateDuplicates(
 			})
 		} else {
 			sagaNames[saga.GetName()] = i
+		}
+		// Warn when an event-triggered saga has no filter; all events will trigger the saga
+		if strings.HasPrefix(saga.GetTrigger(), "event:") && saga.Filter == nil {
+			addError(result, ValidationError{
+				Severity:   SeverityWarning,
+				Path:       fmt.Sprintf("sagas[%d].filter", i),
+				Code:       "MISSING_EVENT_FILTER",
+				Message:    fmt.Sprintf("saga %q subscribes to event trigger %q without a filter; the saga will execute for every matching event", saga.GetName(), saga.GetTrigger()),
+				Suggestion: `Add a CEL filter expression, e.g. filter: 'event.amount > 0'`,
+			})
 		}
 	}
 

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -249,6 +249,64 @@ func TestValidateDuplicate_SagaNames(t *testing.T) {
 	}
 }
 
+func TestValidate_EventTriggerWithoutFilter_Warning(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_transaction_captured",
+		Trigger: "event:position-keeping.transaction-captured.v1",
+		Script:  "def execute(ctx):\n    return {}\n",
+		// No Filter set - should produce a warning
+	})
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest (missing event filter is a warning), got errors: %v", result.Errors)
+	}
+
+	found := false
+	for _, w := range result.Warnings {
+		if w.Code == "MISSING_EVENT_FILTER" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected MISSING_EVENT_FILTER warning, got warnings: %v", result.Warnings)
+	}
+}
+
+func TestValidate_EventTriggerWithFilter_NoWarning(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	filter := `event.amount > 0 && event.currency == "GBP"`
+	m := validManifest()
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_transaction_captured",
+		Trigger: "event:position-keeping.transaction-captured.v1",
+		Script:  "def execute(ctx):\n    return {}\n",
+		Filter:  &filter,
+	})
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest, got errors: %v", result.Errors)
+	}
+
+	for _, w := range result.Warnings {
+		if w.Code == "MISSING_EVENT_FILTER" {
+			t.Errorf("unexpected MISSING_EVENT_FILTER warning when filter is set")
+		}
+	}
+}
+
 func TestValidateCEL_ValidExpression(t *testing.T) {
 	v, err := New()
 	if err != nil {

--- a/services/mcp-server/internal/tools/refdata.go
+++ b/services/mcp-server/internal/tools/refdata.go
@@ -365,7 +365,7 @@ func buildSagaDescribeTool(client SagaRegistryClient) Tool {
 func buildHandlersDescribeTool(client ManifestHistoryClient) Tool {
 	return Tool{
 		Name:        "meridian_handlers_describe",
-		Description: "Returns the tenant's available saga triggers and account type policies from the current manifest. Shows which handlers are wired to API endpoints, webhooks, and scheduled jobs.",
+		Description: "Returns the tenant's available saga triggers and account type policies from the current manifest. Shows which handlers are wired to API endpoints, webhooks, scheduled jobs, and domain events.",
 		Category:    CategoryRead,
 		InputSchema: map[string]interface{}{
 			"type":                 "object",
@@ -373,8 +373,8 @@ func buildHandlersDescribeTool(client ManifestHistoryClient) Tool {
 			"properties": map[string]interface{}{
 				"trigger_prefix": map[string]interface{}{
 					"type":        "string",
-					"description": "Filter saga triggers by prefix: api, webhook, or scheduled. Omit to return all.",
-					"enum":        []interface{}{"api", "webhook", "scheduled"},
+					"description": "Filter saga triggers by prefix: api, webhook, scheduled, or event. Omit to return all.",
+					"enum":        []interface{}{"api", "webhook", "scheduled", "event"},
 				},
 			},
 		},

--- a/services/mcp-server/internal/tools/refdata_test.go
+++ b/services/mcp-server/internal/tools/refdata_test.go
@@ -612,6 +612,43 @@ func TestHandlersDescribe_TriggerFilter(t *testing.T) {
 	}
 }
 
+func TestHandlersDescribe_EventTriggerFilter(t *testing.T) {
+	filter := `event.amount > 0 && event.currency == "GBP"`
+	manifest := buildTestManifest()
+	manifest.Sagas = append(manifest.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_transaction_captured",
+		Trigger: "event:position-keeping.transaction-captured.v1",
+		Script:  "# event saga script",
+		Filter:  &filter,
+	})
+	client := &mockManifestHistoryClient{
+		resp: &controlplanev1.GetCurrentManifestResponse{
+			Version: &controlplanev1.ManifestVersion{
+				Version:  "1.0",
+				Manifest: manifest,
+			},
+		},
+	}
+	r := mustRegisterRefdata(t, tools.ReferenceDataDeps{ManifestHistory: client})
+
+	// Filter by "event" trigger only - should return the event saga
+	result := callTool(t, r, "meridian_handlers_describe", `{"trigger_prefix":"event"}`)
+	m := resultMap(t, result)
+
+	triggerCount, _ := m["saga_trigger_count"].(int)
+	if triggerCount != 1 {
+		t.Errorf("expected 1 event saga trigger, got %v", m["saga_trigger_count"])
+	}
+
+	// Unfiltered result should include all 3 sagas now
+	result = callTool(t, r, "meridian_handlers_describe", `{}`)
+	m = resultMap(t, result)
+	triggerCount, _ = m["saga_trigger_count"].(int)
+	if triggerCount != 3 {
+		t.Errorf("expected 3 saga triggers (api + scheduled + event), got %v", m["saga_trigger_count"])
+	}
+}
+
 func TestHandlersDescribe_GRPCError(t *testing.T) {
 	client := &mockManifestHistoryClient{
 		err: errors.New("rpc error: unavailable"),


### PR DESCRIPTION
## Summary

- Adds `event:` as a valid saga trigger prefix (alongside `api:`, `webhook:`, `scheduled:`) to the `SagaDefinition` proto message
- Introduces an optional `filter` field (CEL expression, max 4096 chars) that controls which events execute the saga
- Adds a `MISSING_EVENT_FILTER` validation warning when an event-triggered saga has no filter, alerting authors that all matching events will trigger execution

## Changes Made

| File | Change |
|------|--------|
| `api/proto/meridian/control_plane/v1/manifest.proto` | Updated trigger pattern regex; added optional `filter` field (field 4) |
| `api/proto/meridian/control_plane/v1/manifest.pb.go` | Regenerated via `buf generate api/proto` |
| `services/control-plane/internal/differ/manifest_differ.go` | Include filter field in saga diff descriptions |
| `services/control-plane/internal/validator/manifest_validator.go` | Warn (`MISSING_EVENT_FILTER`) when event saga has no filter |
| `services/mcp-server/internal/tools/refdata.go` | Add `event` to `trigger_prefix` enum; update tool description |

## Technical Details

**Proto change** — `SagaDefinition` gains one new field:
```protobuf
// trigger pattern now accepts event: prefix
pattern: "^(api:|webhook:|scheduled:|event:).+$"

// New optional filter field
optional string filter = 4 [(buf.validate.field).string = {max_len: 4096}];
```

**Validation warning** — event triggers without a filter receive a `SeverityWarning` (`MISSING_EVENT_FILTER`). The manifest remains valid; this is advisory only.

**No breaking changes** — `filter` is `optional`; existing manifests without the field are unaffected.

## Testing

- Proto validation: `TestSagaDefinitionValidation` extended with event trigger cases (with/without filter, filter exceeding max length)
- Proto round-trip: `TestSagaDefinitionEventTrigger` verifies serialize/deserialize preserves filter
- Differ: `TestDiff_AddedEventSaga_Create`, `TestDiff_ModifiedSagaFilter_DescribesChange`
- Validator: `TestValidate_EventTriggerWithoutFilter_Warning`, `TestValidate_EventTriggerWithFilter_NoWarning`
- MCP server: `TestHandlersDescribe_EventTriggerFilter`

All tests pass locally.

## Related

Part of 032-event-driven-saga epic — task 032-event-driven-saga.1