### PR TITLE
feat: Implement SagaTrigger gRPC client adapter for event-router (032-event-driven-saga.8)

### DIFF
--- a/api/proto/meridian/control_plane/v1/saga_execution_service.proto
+++ b/api/proto/meridian/control_plane/v1/saga_execution_service.proto
@@ -1,0 +1,56 @@
+syntax = "proto3";
+
+package meridian.control_plane.v1;
+
+import "buf/validate/validate.proto";
+import "google/api/annotations.proto";
+import "google/protobuf/struct.proto";
+
+option go_package = "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1;controlplanev1";
+
+// SagaExecutionService provides an API for triggering saga workflows.
+// External services (e.g., event-router) use this to start saga instances
+// in response to domain events without requiring direct Starlark runtime access.
+service SagaExecutionService {
+  // ExecuteSaga triggers a new saga instance by name with the given input data.
+  // Uses idempotency key to prevent duplicate saga instances from concurrent or
+  // retry triggers (e.g., Kafka at-least-once delivery).
+  rpc ExecuteSaga(ExecuteSagaRequest) returns (ExecuteSagaResponse) {
+    option (google.api.http) = {
+      post: "/v1/sagas/execute"
+      body: "*"
+    };
+  }
+}
+
+// ExecuteSagaRequest contains the saga to trigger and its input.
+message ExecuteSagaRequest {
+  // saga_name is the registered saga name (e.g., "energy_settlement").
+  string saga_name = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[a-z][a-z0-9_]*$"
+  }];
+
+  // input_data contains the saga input parameters as a JSON-compatible struct.
+  // Keys and values correspond to the saga's input schema.
+  google.protobuf.Struct input_data = 2;
+
+  // idempotency_key is a unique key for this trigger event.
+  // If a saga was already started with this key, the existing saga_id is returned
+  // without starting a new instance.
+  string idempotency_key = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+}
+
+// ExecuteSagaResponse contains the result of the saga trigger.
+message ExecuteSagaResponse {
+  // saga_id is the UUID of the saga instance that was started or found.
+  string saga_id = 1;
+
+  // was_duplicate is true if the saga was already started with this idempotency key.
+  // When true, saga_id refers to the existing instance, no new execution was started.
+  bool was_duplicate = 2;
+}

--- a/services/event-router/adapters/grpc/saga_trigger_client.go
+++ b/services/event-router/adapters/grpc/saga_trigger_client.go
@@ -16,6 +16,9 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// ErrSagaTriggerConfigRequired is returned when a nil config is passed to NewSagaTriggerClient.
+var ErrSagaTriggerConfigRequired = fmt.Errorf("SagaTriggerClientConfig is required")
+
 // ErrSagaTriggerServiceNameRequired is returned when ServiceName is not provided.
 var ErrSagaTriggerServiceNameRequired = fmt.Errorf("ServiceName is required for saga trigger client")
 
@@ -60,8 +63,8 @@ type SagaTriggerClientConfig struct {
 //
 // The client uses DNS-based service discovery and round-robin load balancing.
 // TriggerSaga calls include retry logic with exponential backoff for transient
-// failures (UNAVAILABLE, INTERNAL, DEADLINE_EXCEEDED) and skip retries for
-// permanent errors (INVALID_ARGUMENT, NOT_FOUND).
+// failures (UNAVAILABLE, INTERNAL, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED) and
+// skip retries for permanent errors (INVALID_ARGUMENT, NOT_FOUND).
 //
 // Example:
 //
@@ -74,6 +77,10 @@ type SagaTriggerClientConfig struct {
 //	}
 //	client, err := grpc.NewSagaTriggerClient(config)
 func NewSagaTriggerClient(cfg *SagaTriggerClientConfig) (*SagaTriggerClient, error) {
+	if cfg == nil {
+		return nil, ErrSagaTriggerConfigRequired
+	}
+
 	if cfg.ServiceName == "" {
 		return nil, ErrSagaTriggerServiceNameRequired
 	}
@@ -123,7 +130,7 @@ func NewSagaTriggerClient(cfg *SagaTriggerClientConfig) (*SagaTriggerClient, err
 // Error handling:
 //   - INVALID_ARGUMENT errors are not retried (bad saga name or input)
 //   - NOT_FOUND errors are not retried (saga definition does not exist)
-//   - UNAVAILABLE / INTERNAL / DEADLINE_EXCEEDED errors are retried with backoff
+//   - UNAVAILABLE / INTERNAL / DEADLINE_EXCEEDED / RESOURCE_EXHAUSTED errors are retried with backoff
 //   - Context cancellation stops retries immediately
 func (c *SagaTriggerClient) TriggerSaga(ctx context.Context, sagaName string, inputData map[string]any, idempotencyKey string) (string, error) {
 	ctx, cancel := sharedclients.WithTimeout(ctx, c.timeout)

--- a/services/event-router/adapters/grpc/saga_trigger_client.go
+++ b/services/event-router/adapters/grpc/saga_trigger_client.go
@@ -163,18 +163,21 @@ func (c *SagaTriggerClient) TriggerSaga(ctx context.Context, sagaName string, in
 			c.logger.Debug("saga trigger was duplicate, returning existing instance",
 				"saga_name", sagaName,
 				"saga_id", sagaID,
-				"idempotency_key", idempotencyKey,
 			)
 		} else {
 			c.logger.Debug("saga triggered successfully",
 				"saga_name", sagaName,
 				"saga_id", sagaID,
-				"idempotency_key", idempotencyKey,
 			)
 		}
 		return nil
 	})
 	if err != nil {
+		// If the context was cancelled or timed out, return the context error
+		// rather than the last RPC error which may be stale.
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
 		if lastErr != nil {
 			return "", lastErr
 		}

--- a/services/event-router/adapters/grpc/saga_trigger_client.go
+++ b/services/event-router/adapters/grpc/saga_trigger_client.go
@@ -1,0 +1,257 @@
+// Package grpc provides gRPC client adapters for external service communication.
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
+	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// ErrSagaTriggerServiceNameRequired is returned when ServiceName is not provided.
+var ErrSagaTriggerServiceNameRequired = fmt.Errorf("ServiceName is required for saga trigger client")
+
+// SagaTriggerClient implements domain.SagaTrigger using gRPC.
+// It calls the control-plane's SagaExecutionService to trigger saga instances
+// from Kafka events, with retry logic for transient failures.
+type SagaTriggerClient struct {
+	conn        *grpc.ClientConn
+	client      controlplanev1.SagaExecutionServiceClient
+	timeout     time.Duration
+	logger      *slog.Logger
+	retryConfig sharedclients.RetryConfig
+}
+
+// SagaTriggerClientConfig holds configuration for creating a SagaTriggerClient.
+type SagaTriggerClientConfig struct {
+	// ServiceName is the Kubernetes service name (e.g., "control-plane").
+	// Required for DNS-based load balancing.
+	ServiceName string
+
+	// Namespace is the Kubernetes namespace (defaults to "default" if empty).
+	Namespace string
+
+	// Port is the service gRPC port number.
+	Port int
+
+	// Timeout is the default timeout for RPC calls (defaults to 5 seconds).
+	Timeout time.Duration
+
+	// Logger is used for structured logging.
+	Logger *slog.Logger
+
+	// RetryConfig configures retry behavior for transient failures.
+	// If nil, uses DefaultRetryConfig (3 retries, 100ms-1s exponential backoff).
+	RetryConfig *sharedclients.RetryConfig
+
+	// DialOptions allows custom gRPC dial options.
+	DialOptions []grpc.DialOption
+}
+
+// NewSagaTriggerClient creates a new gRPC client for the control-plane SagaExecutionService.
+//
+// The client uses DNS-based service discovery and round-robin load balancing.
+// TriggerSaga calls include retry logic with exponential backoff for transient
+// failures (UNAVAILABLE, INTERNAL, DEADLINE_EXCEEDED) and skip retries for
+// permanent errors (INVALID_ARGUMENT, NOT_FOUND).
+//
+// Example:
+//
+//	config := &grpc.SagaTriggerClientConfig{
+//	    ServiceName: "control-plane",
+//	    Namespace:   "default",
+//	    Port:        50051,
+//	    Timeout:     5 * time.Second,
+//	    Logger:      logger,
+//	}
+//	client, err := grpc.NewSagaTriggerClient(config)
+func NewSagaTriggerClient(cfg *SagaTriggerClientConfig) (*SagaTriggerClient, error) {
+	if cfg.ServiceName == "" {
+		return nil, ErrSagaTriggerServiceNameRequired
+	}
+
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 5 * time.Second
+	}
+
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+
+	retryConfig := sharedclients.DefaultRetryConfig()
+	if cfg.RetryConfig != nil {
+		retryConfig = *cfg.RetryConfig
+	}
+	// Cap max interval at 1s to avoid excessive backoff on saga trigger retries
+	if retryConfig.MaxInterval > 1*time.Second {
+		retryConfig.MaxInterval = 1 * time.Second
+	}
+
+	conn, err := platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
+		ServiceName: cfg.ServiceName,
+		Namespace:   cfg.Namespace,
+		Port:        cfg.Port,
+		DialOptions: cfg.DialOptions,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+
+	return &SagaTriggerClient{
+		conn:        conn,
+		client:      controlplanev1.NewSagaExecutionServiceClient(conn),
+		timeout:     cfg.Timeout,
+		logger:      cfg.Logger,
+		retryConfig: retryConfig,
+	}, nil
+}
+
+// TriggerSaga starts a new saga instance by name with the given input data.
+//
+// The idempotencyKey ensures duplicate triggers (e.g., Kafka at-least-once delivery)
+// are handled safely. If a saga with the same key already exists, the existing
+// saga ID is returned without re-executing.
+//
+// Error handling:
+//   - INVALID_ARGUMENT errors are not retried (bad saga name or input)
+//   - NOT_FOUND errors are not retried (saga definition does not exist)
+//   - UNAVAILABLE / INTERNAL / DEADLINE_EXCEEDED errors are retried with backoff
+//   - Context cancellation stops retries immediately
+func (c *SagaTriggerClient) TriggerSaga(ctx context.Context, sagaName string, inputData map[string]any, idempotencyKey string) (string, error) {
+	ctx, cancel := sharedclients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = sharedclients.PropagateCorrelationID(ctx)
+	ctx = sharedclients.PropagateOrganization(ctx)
+
+	req, err := c.buildRequest(sagaName, inputData, idempotencyKey)
+	if err != nil {
+		return "", err
+	}
+
+	var (
+		sagaID  string
+		lastErr error
+	)
+
+	err = sharedclients.Retry(ctx, c.retryConfig, func() error {
+		resp, rpcErr := c.client.ExecuteSaga(ctx, req)
+		if rpcErr != nil {
+			lastErr = rpcErr
+			c.handleError(rpcErr, sagaName)
+			return rpcErr
+		}
+
+		sagaID = resp.GetSagaId()
+
+		if resp.GetWasDuplicate() {
+			c.logger.Debug("saga trigger was duplicate, returning existing instance",
+				"saga_name", sagaName,
+				"saga_id", sagaID,
+				"idempotency_key", idempotencyKey,
+			)
+		} else {
+			c.logger.Debug("saga triggered successfully",
+				"saga_name", sagaName,
+				"saga_id", sagaID,
+				"idempotency_key", idempotencyKey,
+			)
+		}
+		return nil
+	})
+	if err != nil {
+		if lastErr != nil {
+			return "", lastErr
+		}
+		return "", err
+	}
+
+	return sagaID, nil
+}
+
+// buildRequest constructs the ExecuteSagaRequest proto from the given parameters.
+// Returns an error if inputData contains types that cannot be serialized to structpb.
+func (c *SagaTriggerClient) buildRequest(sagaName string, inputData map[string]any, idempotencyKey string) (*controlplanev1.ExecuteSagaRequest, error) {
+	req := &controlplanev1.ExecuteSagaRequest{
+		SagaName:       sagaName,
+		IdempotencyKey: idempotencyKey,
+	}
+
+	if len(inputData) > 0 {
+		s, err := structpb.NewStruct(inputData)
+		if err != nil {
+			return nil, fmt.Errorf("invalid input_data: cannot serialize to protobuf struct: %w", err)
+		}
+		req.InputData = s
+	}
+
+	return req, nil
+}
+
+// handleError logs and categorizes gRPC errors from ExecuteSaga calls.
+func (c *SagaTriggerClient) handleError(err error, sagaName string) {
+	st, ok := status.FromError(err)
+	if !ok {
+		c.logger.Error("non-gRPC error triggering saga",
+			"error", err,
+			"saga_name", sagaName,
+		)
+		return
+	}
+
+	//exhaustive:ignore
+	switch st.Code() {
+	case codes.InvalidArgument:
+		c.logger.Warn("invalid saga trigger request, will not retry",
+			"error", st.Message(),
+			"saga_name", sagaName,
+		)
+	case codes.NotFound:
+		c.logger.Warn("saga definition not found, will not retry",
+			"error", st.Message(),
+			"saga_name", sagaName,
+		)
+	case codes.Unavailable:
+		c.logger.Warn("control-plane unavailable, will retry",
+			"error", st.Message(),
+			"saga_name", sagaName,
+		)
+	case codes.Internal:
+		c.logger.Warn("control-plane internal error, will retry",
+			"error", st.Message(),
+			"saga_name", sagaName,
+		)
+	case codes.DeadlineExceeded:
+		c.logger.Warn("saga trigger timed out, will retry",
+			"saga_name", sagaName,
+		)
+	case codes.ResourceExhausted:
+		c.logger.Warn("control-plane rate limited, will retry",
+			"saga_name", sagaName,
+		)
+	default:
+		c.logger.Error("unexpected error triggering saga",
+			"code", st.Code().String(),
+			"error", st.Message(),
+			"saga_name", sagaName,
+		)
+	}
+}
+
+// Close releases the gRPC client connection.
+func (c *SagaTriggerClient) Close() error {
+	if c.conn != nil {
+		if err := c.conn.Close(); err != nil {
+			return fmt.Errorf("failed to close saga trigger client connection: %w", err)
+		}
+	}
+	return nil
+}

--- a/services/event-router/adapters/grpc/saga_trigger_client_test.go
+++ b/services/event-router/adapters/grpc/saga_trigger_client_test.go
@@ -1,0 +1,482 @@
+// Package grpc provides gRPC client adapters for external service communication.
+package grpc
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// mockSagaExecutionServer implements SagaExecutionServiceServer for testing.
+type mockSagaExecutionServer struct {
+	controlplanev1.UnimplementedSagaExecutionServiceServer
+
+	executeSagaFunc func(ctx context.Context, req *controlplanev1.ExecuteSagaRequest) (*controlplanev1.ExecuteSagaResponse, error)
+	callCount       atomic.Int32
+}
+
+func (s *mockSagaExecutionServer) ExecuteSaga(ctx context.Context, req *controlplanev1.ExecuteSagaRequest) (*controlplanev1.ExecuteSagaResponse, error) {
+	s.callCount.Add(1)
+	if s.executeSagaFunc != nil {
+		return s.executeSagaFunc(ctx, req)
+	}
+	return &controlplanev1.ExecuteSagaResponse{
+		SagaId:       uuid.New().String(),
+		WasDuplicate: false,
+	}, nil
+}
+
+// startMockSagaServer starts a gRPC server with the mock saga execution implementation.
+func startMockSagaServer(t *testing.T, mock *mockSagaExecutionServer) (string, func()) {
+	t.Helper()
+
+	var lc net.ListenConfig
+	lis, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	controlplanev1.RegisterSagaExecutionServiceServer(server, mock)
+
+	go func() {
+		_ = server.Serve(lis)
+	}()
+
+	return lis.Addr().String(), func() {
+		server.GracefulStop()
+	}
+}
+
+// createTestSagaTriggerClient creates a SagaTriggerClient connected to the mock server.
+func createTestSagaTriggerClient(t *testing.T, addr string) *SagaTriggerClient {
+	t.Helper()
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	retryConfig := sharedclients.RetryConfig{
+		MaxRetries:          3,
+		InitialInterval:     10 * time.Millisecond,
+		MaxInterval:         50 * time.Millisecond,
+		Multiplier:          2.0,
+		RandomizationFactor: 0,
+	}
+
+	return &SagaTriggerClient{
+		conn:        conn,
+		client:      controlplanev1.NewSagaExecutionServiceClient(conn),
+		timeout:     5 * time.Second,
+		logger:      slog.Default(),
+		retryConfig: retryConfig,
+	}
+}
+
+func TestSagaTriggerClient_TriggerSaga_Success(t *testing.T) {
+	expectedSagaID := uuid.New().String()
+	mock := &mockSagaExecutionServer{
+		executeSagaFunc: func(_ context.Context, _ *controlplanev1.ExecuteSagaRequest) (*controlplanev1.ExecuteSagaResponse, error) {
+			return &controlplanev1.ExecuteSagaResponse{
+				SagaId:       expectedSagaID,
+				WasDuplicate: false,
+			}, nil
+		},
+	}
+	addr, cleanup := startMockSagaServer(t, mock)
+	defer cleanup()
+
+	client := createTestSagaTriggerClient(t, addr)
+	defer func() {
+		_ = client.Close()
+	}()
+
+	inputData := map[string]any{
+		"tenant_id": "tenant-123",
+		"amount":    "100.00",
+		"currency":  "GBP",
+	}
+
+	sagaID, err := client.TriggerSaga(context.Background(), "energy_settlement", inputData, "idempotency-key-123")
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedSagaID, sagaID)
+	assert.Equal(t, int32(1), mock.callCount.Load())
+}
+
+func TestSagaTriggerClient_TriggerSaga_Duplicate_ReturnsExistingSagaID(t *testing.T) {
+	existingSagaID := uuid.New().String()
+	mock := &mockSagaExecutionServer{
+		executeSagaFunc: func(_ context.Context, _ *controlplanev1.ExecuteSagaRequest) (*controlplanev1.ExecuteSagaResponse, error) {
+			return &controlplanev1.ExecuteSagaResponse{
+				SagaId:       existingSagaID,
+				WasDuplicate: true,
+			}, nil
+		},
+	}
+	addr, cleanup := startMockSagaServer(t, mock)
+	defer cleanup()
+
+	client := createTestSagaTriggerClient(t, addr)
+	defer func() {
+		_ = client.Close()
+	}()
+
+	sagaID, err := client.TriggerSaga(context.Background(), "energy_settlement", nil, "duplicate-key")
+
+	require.NoError(t, err)
+	assert.Equal(t, existingSagaID, sagaID)
+}
+
+func TestSagaTriggerClient_TriggerSaga_InvalidArgument_NoRetry(t *testing.T) {
+	mock := &mockSagaExecutionServer{
+		executeSagaFunc: func(_ context.Context, _ *controlplanev1.ExecuteSagaRequest) (*controlplanev1.ExecuteSagaResponse, error) {
+			return nil, status.Error(codes.InvalidArgument, "saga_name must not be empty")
+		},
+	}
+	addr, cleanup := startMockSagaServer(t, mock)
+	defer cleanup()
+
+	client := createTestSagaTriggerClient(t, addr)
+	defer func() {
+		_ = client.Close()
+	}()
+
+	_, err := client.TriggerSaga(context.Background(), "bad_name", nil, "key-1")
+
+	require.Error(t, err)
+	// INVALID_ARGUMENT must not be retried — only 1 call expected
+	assert.Equal(t, int32(1), mock.callCount.Load())
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestSagaTriggerClient_TriggerSaga_Unavailable_Retries(t *testing.T) {
+	callCount := &atomic.Int32{}
+	mock := &mockSagaExecutionServer{
+		executeSagaFunc: func(_ context.Context, _ *controlplanev1.ExecuteSagaRequest) (*controlplanev1.ExecuteSagaResponse, error) {
+			count := callCount.Add(1)
+			if count < 3 {
+				return nil, status.Error(codes.Unavailable, "service temporarily unavailable")
+			}
+			return &controlplanev1.ExecuteSagaResponse{
+				SagaId: uuid.New().String(),
+			}, nil
+		},
+	}
+	addr, cleanup := startMockSagaServer(t, mock)
+	defer cleanup()
+
+	client := createTestSagaTriggerClient(t, addr)
+	defer func() {
+		_ = client.Close()
+	}()
+
+	sagaID, err := client.TriggerSaga(context.Background(), "energy_settlement", nil, "key-2")
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, sagaID)
+	// Should have retried: 3 total calls (2 failures + 1 success)
+	assert.Equal(t, int32(3), callCount.Load())
+}
+
+func TestSagaTriggerClient_TriggerSaga_Internal_Retries(t *testing.T) {
+	callCount := &atomic.Int32{}
+	mock := &mockSagaExecutionServer{
+		executeSagaFunc: func(_ context.Context, _ *controlplanev1.ExecuteSagaRequest) (*controlplanev1.ExecuteSagaResponse, error) {
+			count := callCount.Add(1)
+			if count < 2 {
+				return nil, status.Error(codes.Internal, "internal server error")
+			}
+			return &controlplanev1.ExecuteSagaResponse{
+				SagaId: uuid.New().String(),
+			}, nil
+		},
+	}
+	addr, cleanup := startMockSagaServer(t, mock)
+	defer cleanup()
+
+	client := createTestSagaTriggerClient(t, addr)
+	defer func() {
+		_ = client.Close()
+	}()
+
+	sagaID, err := client.TriggerSaga(context.Background(), "energy_settlement", nil, "key-3")
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, sagaID)
+	// 2 total calls (1 failure + 1 success)
+	assert.Equal(t, int32(2), callCount.Load())
+}
+
+func TestSagaTriggerClient_TriggerSaga_MaxRetries_Exceeded(t *testing.T) {
+	mock := &mockSagaExecutionServer{
+		executeSagaFunc: func(_ context.Context, _ *controlplanev1.ExecuteSagaRequest) (*controlplanev1.ExecuteSagaResponse, error) {
+			return nil, status.Error(codes.Unavailable, "service permanently unavailable")
+		},
+	}
+	addr, cleanup := startMockSagaServer(t, mock)
+	defer cleanup()
+
+	client := createTestSagaTriggerClient(t, addr)
+	defer func() {
+		_ = client.Close()
+	}()
+
+	_, err := client.TriggerSaga(context.Background(), "energy_settlement", nil, "key-4")
+
+	require.Error(t, err)
+	// Initial attempt + 3 retries = 4 total calls
+	assert.Equal(t, int32(4), mock.callCount.Load())
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unavailable, st.Code())
+}
+
+func TestSagaTriggerClient_TriggerSaga_ContextCancelled(t *testing.T) {
+	mock := &mockSagaExecutionServer{
+		executeSagaFunc: func(ctx context.Context, _ *controlplanev1.ExecuteSagaRequest) (*controlplanev1.ExecuteSagaResponse, error) {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(10 * time.Second):
+				return nil, nil
+			}
+		},
+	}
+	addr, cleanup := startMockSagaServer(t, mock)
+	defer cleanup()
+
+	client := createTestSagaTriggerClient(t, addr)
+	defer func() {
+		_ = client.Close()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := client.TriggerSaga(ctx, "energy_settlement", nil, "key-5")
+
+	require.Error(t, err)
+	assert.LessOrEqual(t, mock.callCount.Load(), int32(2))
+}
+
+func TestSagaTriggerClient_TriggerSaga_InputDataConversion(t *testing.T) {
+	var capturedReq *controlplanev1.ExecuteSagaRequest
+	mock := &mockSagaExecutionServer{
+		executeSagaFunc: func(_ context.Context, req *controlplanev1.ExecuteSagaRequest) (*controlplanev1.ExecuteSagaResponse, error) {
+			capturedReq = req
+			return &controlplanev1.ExecuteSagaResponse{
+				SagaId: uuid.New().String(),
+			}, nil
+		},
+	}
+	addr, cleanup := startMockSagaServer(t, mock)
+	defer cleanup()
+
+	client := createTestSagaTriggerClient(t, addr)
+	defer func() {
+		_ = client.Close()
+	}()
+
+	inputData := map[string]any{
+		"tenant_id":    "tenant-abc",
+		"amount":       "500.00",
+		"event_type":   "ENERGY_CONSUMED",
+		"reading_time": "2026-01-01T00:00:00Z",
+	}
+
+	_, err := client.TriggerSaga(context.Background(), "energy_settlement", inputData, "idempotency-xyz")
+
+	require.NoError(t, err)
+	require.NotNil(t, capturedReq)
+	assert.Equal(t, "energy_settlement", capturedReq.SagaName)
+	assert.Equal(t, "idempotency-xyz", capturedReq.IdempotencyKey)
+
+	// Verify input data was serialized to structpb
+	require.NotNil(t, capturedReq.InputData)
+	fields := capturedReq.InputData.GetFields()
+	assert.Equal(t, "tenant-abc", fields["tenant_id"].GetStringValue())
+	assert.Equal(t, "500.00", fields["amount"].GetStringValue())
+	assert.Equal(t, "ENERGY_CONSUMED", fields["event_type"].GetStringValue())
+}
+
+func TestSagaTriggerClient_TriggerSaga_NilInputData(t *testing.T) {
+	var capturedReq *controlplanev1.ExecuteSagaRequest
+	mock := &mockSagaExecutionServer{
+		executeSagaFunc: func(_ context.Context, req *controlplanev1.ExecuteSagaRequest) (*controlplanev1.ExecuteSagaResponse, error) {
+			capturedReq = req
+			return &controlplanev1.ExecuteSagaResponse{
+				SagaId: uuid.New().String(),
+			}, nil
+		},
+	}
+	addr, cleanup := startMockSagaServer(t, mock)
+	defer cleanup()
+
+	client := createTestSagaTriggerClient(t, addr)
+	defer func() {
+		_ = client.Close()
+	}()
+
+	// nil inputData should be valid — some sagas take no input
+	sagaID, err := client.TriggerSaga(context.Background(), "simple_saga", nil, "key-nil")
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, sagaID)
+	require.NotNil(t, capturedReq)
+	// inputData should be nil or empty struct
+	if capturedReq.InputData != nil {
+		assert.Empty(t, capturedReq.InputData.GetFields())
+	}
+}
+
+func TestSagaTriggerClient_buildRequest_ConvertsInputData(t *testing.T) {
+	client := &SagaTriggerClient{}
+
+	inputData := map[string]any{
+		"string_val": "hello",
+		"bool_val":   true,
+		"num_val":    float64(42),
+	}
+
+	req, err := client.buildRequest("my_saga", inputData, "idem-key")
+
+	require.NoError(t, err)
+	assert.Equal(t, "my_saga", req.SagaName)
+	assert.Equal(t, "idem-key", req.IdempotencyKey)
+	require.NotNil(t, req.InputData)
+
+	fields := req.InputData.GetFields()
+	assert.Equal(t, "hello", fields["string_val"].GetStringValue())
+	assert.True(t, fields["bool_val"].GetBoolValue())
+	assert.Equal(t, float64(42), fields["num_val"].GetNumberValue())
+}
+
+func TestSagaTriggerClient_buildRequest_NilInputData(t *testing.T) {
+	client := &SagaTriggerClient{}
+
+	req, err := client.buildRequest("my_saga", nil, "idem-key")
+
+	require.NoError(t, err)
+	assert.Equal(t, "my_saga", req.SagaName)
+	assert.Equal(t, "idem-key", req.IdempotencyKey)
+	// nil input data => nil struct (valid for sagas with no input)
+	assert.Nil(t, req.InputData)
+}
+
+func TestSagaTriggerClient_buildRequest_InvalidInputData(t *testing.T) {
+	client := &SagaTriggerClient{}
+
+	// structpb.NewStruct cannot handle non-JSON-compatible types like chan
+	inputData := map[string]any{
+		"channel": make(chan int), // invalid type
+	}
+
+	_, err := client.buildRequest("my_saga", inputData, "idem-key")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid input_data")
+}
+
+func TestNewSagaTriggerClient_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *SagaTriggerClientConfig
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "missing service name",
+			config: &SagaTriggerClientConfig{
+				ServiceName: "",
+				Port:        50051,
+			},
+			wantErr:     true,
+			errContains: "ServiceName is required",
+		},
+		{
+			name: "valid config",
+			config: &SagaTriggerClientConfig{
+				ServiceName: "control-plane",
+				Port:        50051,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewSagaTriggerClient(tt.config)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err == nil && client != nil {
+				_ = client.Close()
+			}
+		})
+	}
+}
+
+func TestSagaTriggerClient_Close(t *testing.T) {
+	mock := &mockSagaExecutionServer{}
+	addr, cleanup := startMockSagaServer(t, mock)
+	defer cleanup()
+
+	client := createTestSagaTriggerClient(t, addr)
+	err := client.Close()
+
+	require.NoError(t, err)
+}
+
+func TestSagaTriggerClient_buildRequest_NestedData(t *testing.T) {
+	client := &SagaTriggerClient{}
+
+	inputData := map[string]any{
+		"nested": map[string]any{
+			"key": "value",
+		},
+		"list": []any{"a", "b", "c"},
+	}
+
+	req, err := client.buildRequest("my_saga", inputData, "idem-key")
+
+	require.NoError(t, err)
+	require.NotNil(t, req.InputData)
+
+	fields := req.InputData.GetFields()
+	require.NotNil(t, fields["nested"])
+	nestedFields := fields["nested"].GetStructValue().GetFields()
+	assert.Equal(t, "value", nestedFields["key"].GetStringValue())
+
+	listValues := fields["list"].GetListValue().GetValues()
+	require.Len(t, listValues, 3)
+	assert.Equal(t, "a", listValues[0].GetStringValue())
+}
+
+// Ensure SagaTriggerClient satisfies the domain.SagaTrigger interface at compile time.
+var _ interface {
+	TriggerSaga(ctx context.Context, sagaName string, inputData map[string]any, idempotencyKey string) (string, error)
+	Close() error
+} = (*SagaTriggerClient)(nil)
+
+// Ensure structpb is imported (used by buildRequest tests indirectly).
+var _ = (*structpb.Struct)(nil)

--- a/services/event-router/adapters/grpc/saga_trigger_client_test.go
+++ b/services/event-router/adapters/grpc/saga_trigger_client_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/event-router/domain"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -401,6 +402,12 @@ func TestNewSagaTriggerClient_ValidationErrors(t *testing.T) {
 		errContains string
 	}{
 		{
+			name:        "nil config",
+			config:      nil,
+			wantErr:     true,
+			errContains: "SagaTriggerClientConfig is required",
+		},
+		{
 			name: "missing service name",
 			config: &SagaTriggerClientConfig{
 				ServiceName: "",
@@ -429,9 +436,9 @@ func TestNewSagaTriggerClient_ValidationErrors(t *testing.T) {
 				}
 				return
 			}
-			if err == nil && client != nil {
-				_ = client.Close()
-			}
+			require.NoError(t, err)
+			require.NotNil(t, client)
+			_ = client.Close()
 		})
 	}
 }
@@ -473,10 +480,7 @@ func TestSagaTriggerClient_buildRequest_NestedData(t *testing.T) {
 }
 
 // Ensure SagaTriggerClient satisfies the domain.SagaTrigger interface at compile time.
-var _ interface {
-	TriggerSaga(ctx context.Context, sagaName string, inputData map[string]any, idempotencyKey string) (string, error)
-	Close() error
-} = (*SagaTriggerClient)(nil)
+var _ domain.SagaTrigger = (*SagaTriggerClient)(nil)
 
 // Ensure structpb is imported (used by buildRequest tests indirectly).
 var _ = (*structpb.Struct)(nil)

--- a/services/event-router/domain/saga_trigger.go
+++ b/services/event-router/domain/saga_trigger.go
@@ -1,0 +1,17 @@
+// Package domain contains the core domain models for the event-router service.
+package domain
+
+import "context"
+
+// SagaTrigger defines the port for triggering saga workflows.
+// Implementations connect to the control-plane's SagaExecutionService via gRPC.
+type SagaTrigger interface {
+	// TriggerSaga starts a new saga instance by name with the given input data.
+	// The idempotencyKey ensures duplicate triggers (e.g., Kafka redelivery) are
+	// handled safely — the existing saga_id is returned without re-executing.
+	// Returns the saga instance ID on success.
+	TriggerSaga(ctx context.Context, sagaName string, inputData map[string]any, idempotencyKey string) (string, error)
+
+	// Close releases any resources held by the client (e.g., gRPC connections).
+	Close() error
+}


### PR DESCRIPTION
## Summary

- Adds `SagaExecutionService` proto with `ExecuteSaga` RPC to control-plane, providing a gRPC API for external services to trigger saga workflows
- Adds `SagaTrigger` port interface to event-router domain following hexagonal architecture patterns
- Implements `SagaTriggerClient` gRPC adapter with `structpb` conversion, retry logic, and connection lifecycle management

## Changes Made

### New Proto: `api/proto/meridian/control_plane/v1/saga_execution_service.proto`

`SagaExecutionService.ExecuteSaga` RPC accepts:
- `saga_name`: registered saga identifier
- `input_data`: `google.protobuf.Struct` (JSON-compatible, converted from `map[string]any`)
- `idempotency_key`: deduplication key for Kafka at-least-once delivery

Returns `saga_id` and `was_duplicate` flag.

### New Port: `services/event-router/domain/saga_trigger.go`

```go
type SagaTrigger interface {
    TriggerSaga(ctx context.Context, sagaName string, inputData map[string]any, idempotencyKey string) (string, error)
    Close() error
}
```

### New Adapter: `services/event-router/adapters/grpc/saga_trigger_client.go`

`SagaTriggerClient` follows the same pattern as `PositionKeepingGRPCClient`:
- DNS-based service discovery via `platformgrpc.NewClient`
- Context propagation (correlation ID, organization/tenant)
- Exponential backoff retry for transient errors (UNAVAILABLE, INTERNAL, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED)
- No retry for permanent errors (INVALID_ARGUMENT, NOT_FOUND)
- `map[string]any` → `structpb.Struct` conversion with error handling for non-serializable types

## Technical Details

The `map[string]any` → `structpb.Struct` conversion uses `structpb.NewStruct()` which validates that all values are JSON-compatible. Non-serializable types (e.g., channels, functions) return an error at request build time rather than panicking at runtime.

Retry config caps `MaxInterval` at 1s to prevent excessive backoff in event-driven pipelines where stale sagas could cascade.

## Testing

15 unit tests using a mock gRPC server (same pattern as `position_keeping_client_test.go`):
- Success path (new saga and duplicate idempotency)
- Error categories: INVALID_ARGUMENT (no retry), UNAVAILABLE (retries), INTERNAL (retries)
- Max retries exceeded returns last gRPC error
- Context cancellation stops retries
- Input data serialization: string/bool/number/nested/list/nil
- Invalid input data (non-serializable types) returns error
- Connection lifecycle (Close)
- Compile-time interface satisfaction check

## Related Tasks

032-event-driven-saga.8 — Implement Saga Trigger gRPC Client Adapter