### PR TITLE
feat: Manifest validator — event trigger channel validation

### DIFF
--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/cel-go/cel"
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
 	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
 	"github.com/shopspring/decimal"
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
@@ -149,6 +150,8 @@ type ManifestValidator struct {
 	bucketCelEnv    *cel.Env
 	partyTypeCelEnv *cel.Env
 	mappingCelEnv   *cel.Env
+	eventFilterEnv  *cel.Env
+	channelRegistry map[string]bool
 }
 
 // New creates a new ManifestValidator.
@@ -202,12 +205,30 @@ func New() (*ManifestValidator, error) {
 		return nil, fmt.Errorf("failed to create mapping CEL environment: %w", err)
 	}
 
+	// CEL environment for event trigger filter expressions.
+	// Filters operate on a dynamic event map representing the domain event payload.
+	eventFilterEnv, err := cel.NewEnv(
+		cel.Variable("event", cel.MapType(cel.StringType, cel.DynType)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create event filter CEL environment: %w", err)
+	}
+
+	// Build channel registry from the canonical topic list.
+	allTopics := topics.All()
+	channelRegistry := make(map[string]bool, len(allTopics))
+	for _, topic := range allTopics {
+		channelRegistry[topic] = true
+	}
+
 	return &ManifestValidator{
 		protoValidator:  pv,
 		celEnv:          celEnv,
 		bucketCelEnv:    bucketCelEnv,
 		partyTypeCelEnv: partyTypeCelEnv,
 		mappingCelEnv:   mappingCelEnv,
+		eventFilterEnv:  eventFilterEnv,
+		channelRegistry: channelRegistry,
 	}, nil
 }
 
@@ -243,7 +264,10 @@ func (v *ManifestValidator) Validate(
 	// 8. Mappings validation
 	v.validateMappings(manifest, result)
 
-	// 9. Immutability checks
+	// 9. Event trigger channel and filter validation
+	v.validateEventTriggers(manifest, result)
+
+	// 10. Immutability checks
 	if previousManifest != nil {
 		v.validateImmutability(manifest, previousManifest, result)
 	}
@@ -965,6 +989,111 @@ func (v *ManifestValidator) validateMappingIdempotency(
 			Message:  "content_hash_fields must have at least one entry when use_content_hash is true",
 		})
 	}
+}
+
+// eventFilterAvailableFields lists the variables available in event trigger filter CEL expressions.
+var eventFilterAvailableFields = []string{"event"}
+
+// validateEventTriggers validates all event-triggered sagas in the manifest.
+// It checks that the channel referenced after "event:" exists in the topic registry,
+// and that any filter expression is valid CEL.
+func (v *ManifestValidator) validateEventTriggers(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	for i, saga := range manifest.GetSagas() {
+		if !strings.HasPrefix(saga.GetTrigger(), "event:") {
+			continue
+		}
+		path := fmt.Sprintf("sagas[%d]", i)
+		v.validateEventTrigger(saga, path, result)
+	}
+}
+
+// validateEventTrigger validates a single event-triggered saga definition.
+// It checks channel existence and, if a filter is provided, validates it as CEL.
+func (v *ManifestValidator) validateEventTrigger(
+	saga *controlplanev1.SagaDefinition,
+	path string,
+	result *ValidationResult,
+) {
+	channel := strings.TrimPrefix(saga.GetTrigger(), "event:")
+
+	if !v.channelRegistry[channel] {
+		ve := ValidationError{
+			Severity:        SeverityError,
+			Path:            path + ".trigger",
+			Code:            "INVALID_EVENT_CHANNEL",
+			Message:         fmt.Sprintf("unknown event channel %q; must be a registered topic", channel),
+			AvailableFields: v.availableChannels(),
+		}
+		if suggestion := findClosestMatch(channel, v.availableChannels()); suggestion != "" {
+			ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+		}
+		addError(result, ve)
+	}
+
+	if saga.Filter == nil || saga.GetFilter() == "" {
+		// Missing filter warning is already emitted in validateDuplicates; skip here.
+		return
+	}
+
+	v.validateEventFilterCEL(saga.GetFilter(), path+".filter", result)
+}
+
+// validateEventFilterCEL compiles a CEL expression in the event filter environment.
+func (v *ManifestValidator) validateEventFilterCEL(
+	expression string,
+	path string,
+	result *ValidationResult,
+) {
+	if len(expression) > 4096 {
+		addError(result, ValidationError{
+			Severity: SeverityError,
+			Path:     path,
+			Code:     "CEL_EXPRESSION_TOO_LONG",
+			Message:  fmt.Sprintf("CEL expression exceeds maximum length of 4096 bytes (got %d)", len(expression)),
+		})
+		return
+	}
+
+	_, issues := v.eventFilterEnv.Compile(expression)
+	if issues == nil || issues.Err() == nil {
+		return
+	}
+
+	errMsg := issues.Err().Error()
+
+	if strings.Contains(errMsg, "undeclared reference") {
+		undeclaredField := extractUndeclaredReference(errMsg)
+		suggestion := ""
+		if undeclaredField != "" {
+			if match := findClosestMatch(undeclaredField, eventFilterAvailableFields); match != "" {
+				suggestion = fmt.Sprintf("Did you mean %q?", match)
+			}
+		}
+		addError(result, ValidationError{
+			Severity:        SeverityError,
+			Path:            path,
+			Code:            "CEL_UNDECLARED_REFERENCE",
+			Message:         errMsg,
+			Suggestion:      suggestion,
+			AvailableFields: eventFilterAvailableFields,
+		})
+		return
+	}
+
+	addError(result, ValidationError{
+		Severity: SeverityError,
+		Path:     path,
+		Code:     "CEL_COMPILATION_ERROR",
+		Message:  errMsg,
+	})
+}
+
+// availableChannels returns a sorted list of all registered event channel names.
+func (v *ManifestValidator) availableChannels() []string {
+	return mapKeys(v.channelRegistry)
 }
 
 // accountIDPattern matches valid Stripe Connect account IDs (acct_ followed by 16+ alphanumeric chars).

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -1020,14 +1020,15 @@ func (v *ManifestValidator) validateEventTrigger(
 	channel := strings.TrimPrefix(saga.GetTrigger(), "event:")
 
 	if !v.channelRegistry[channel] {
+		availableChans := v.availableChannels()
 		ve := ValidationError{
 			Severity:        SeverityError,
 			Path:            path + ".trigger",
 			Code:            "INVALID_EVENT_CHANNEL",
 			Message:         fmt.Sprintf("unknown event channel %q; must be a registered topic", channel),
-			AvailableFields: v.availableChannels(),
+			AvailableFields: availableChans,
 		}
-		if suggestion := findClosestMatch(channel, v.availableChannels()); suggestion != "" {
+		if suggestion := findClosestMatch(channel, availableChans); suggestion != "" {
 			ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
 		}
 		addError(result, ve)

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -307,6 +307,120 @@ func TestValidate_EventTriggerWithFilter_NoWarning(t *testing.T) {
 	}
 }
 
+func TestValidate_EventTrigger_InvalidChannel_Error(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_unknown_event",
+		Trigger: "event:nonexistent.topic.v1",
+		Script:  "def execute(ctx):\n    return {}\n",
+	})
+
+	result := v.Validate(m, nil)
+	assert.False(t, result.Valid, "expected invalid manifest for unknown event channel")
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_EVENT_CHANNEL" {
+			found = true
+			assert.Contains(t, e.Message, "nonexistent.topic.v1")
+			assert.NotEmpty(t, e.AvailableFields, "expected available channels listed")
+			break
+		}
+	}
+	assert.True(t, found, "expected INVALID_EVENT_CHANNEL error, got errors: %v", result.Errors)
+}
+
+func TestValidate_EventTrigger_ValidChannel_Passes(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	filter := "event.amount > 0"
+	m := validManifest()
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_transaction_posted",
+		Trigger: "event:position-keeping.transaction-posted.v1",
+		Script:  "def execute(ctx):\n    return {}\n",
+		Filter:  &filter,
+	})
+
+	result := v.Validate(m, nil)
+	assert.True(t, result.Valid, "expected valid manifest, got errors: %v", result.Errors)
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "INVALID_EVENT_CHANNEL", e.Code)
+	}
+}
+
+func TestValidate_NonEventTrigger_NoChannelCheck(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	m := validManifest()
+	// api: trigger should not trigger channel validation even with a weird path
+	m.Sagas[0].Trigger = "api:/v1/some-handler"
+
+	result := v.Validate(m, nil)
+	assert.True(t, result.Valid, "expected valid manifest, got errors: %v", result.Errors)
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "INVALID_EVENT_CHANNEL", e.Code)
+	}
+}
+
+func TestValidate_EventTrigger_InvalidCELFilter_Error(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	badFilter := "event.amount >>> 0"
+	m := validManifest()
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_transaction_captured_filtered",
+		Trigger: "event:position-keeping.transaction-captured.v1",
+		Script:  "def execute(ctx):\n    return {}\n",
+		Filter:  &badFilter,
+	})
+
+	result := v.Validate(m, nil)
+	assert.False(t, result.Valid, "expected invalid manifest for bad CEL filter")
+
+	found := false
+	for _, e := range result.Errors {
+		if strings.Contains(e.Code, "CEL") && strings.Contains(e.Path, "filter") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected CEL error on filter path, got errors: %v", result.Errors)
+}
+
+func TestValidate_EventTrigger_InvalidChannel_SuggestsClose(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	// Typo close to "position-keeping.transaction-captured.v1"
+	// Use a channel name with one character deleted to trigger the suggestion logic.
+	m := validManifest()
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_transaction_captured_typo",
+		Trigger: "event:position-keeping.transacton-captured.v1", //nolint:misspell
+		Script:  "def execute(ctx):\n    return {}\n",
+	})
+
+	result := v.Validate(m, nil)
+	assert.False(t, result.Valid, "expected invalid manifest for typo'd event channel")
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_EVENT_CHANNEL" {
+			found = true
+			assert.NotEmpty(t, e.Suggestion, "expected a suggestion for close typo")
+			break
+		}
+	}
+	assert.True(t, found, "expected INVALID_EVENT_CHANNEL error, got errors: %v", result.Errors)
+}
+
 func TestValidateCEL_ValidExpression(t *testing.T) {
 	v, err := New()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Extends `ManifestValidator` with a channel registry populated from `topics.All()`
- Validates that `event:` trigger channels reference a known Kafka topic, emitting `INVALID_EVENT_CHANNEL` with available channels and closest-match suggestions
- Validates any `filter` CEL expression using a dedicated `eventFilterEnv` with an `event` map variable
- Wires the new pass into the existing `Validate` pipeline as step 9

## Changes Made

- `manifest_validator.go`: added `channelRegistry`/`eventFilterEnv` fields, `validateEventTriggers`, `validateEventTrigger`, `validateEventFilterCEL`, and `availableChannels` helper; wired as validation step 9
- `manifest_validator_test.go`: 5 new tests covering invalid channel, valid channel, non-event trigger no-op, invalid CEL filter, and typo suggestion

## Test plan

- [ ] All existing validator tests pass
- [ ] `TestValidate_EventTrigger_InvalidChannel_Error` — unknown channel → `INVALID_EVENT_CHANNEL` error with available fields
- [ ] `TestValidate_EventTrigger_ValidChannel_Passes` — known channel passes without errors
- [ ] `TestValidate_NonEventTrigger_NoChannelCheck` — `api:` trigger skips channel check
- [ ] `TestValidate_EventTrigger_InvalidCELFilter_Error` — bad CEL filter expression → CEL compilation error on `.filter` path
- [ ] `TestValidate_EventTrigger_InvalidChannel_SuggestsClose` — near-miss channel name → suggestion populated