### PR TITLE
feat: Add event_filter CEL environment for event-triggered saga filtering

### DIFF
--- a/services/mcp-server/internal/tools/validation.go
+++ b/services/mcp-server/internal/tools/validation.go
@@ -44,7 +44,7 @@ func celValidateTool() Tool {
 				},
 				"environment": map[string]interface{}{
 					"type":        "string",
-					"enum":        []interface{}{"validation", "bucket_key", "eligibility"},
+					"enum":        []interface{}{"validation", "bucket_key", "eligibility", "event_filter"},
 					"description": "Which CEL environment to compile against (determines available variables)",
 				},
 			},
@@ -138,8 +138,13 @@ func createCELEnvironment(envName string) (*cel.Env, error) {
 			cel.Variable("party", cel.MapType(cel.StringType, cel.StringType)),
 			cel.Variable("attributes", cel.MapType(cel.StringType, cel.StringType)),
 		)
+	case "event_filter":
+		return cel.NewEnv(
+			cel.Variable("event", cel.DynType),
+			cel.Variable("metadata", cel.MapType(cel.StringType, cel.StringType)),
+		)
 	default:
-		return nil, fmt.Errorf("%w: %q (must be one of validation, bucket_key, eligibility)", ErrUnknownCELEnvironment, envName)
+		return nil, fmt.Errorf("%w: %q (must be one of validation, bucket_key, eligibility, event_filter)", ErrUnknownCELEnvironment, envName)
 	}
 }
 

--- a/services/mcp-server/internal/tools/validation_test.go
+++ b/services/mcp-server/internal/tools/validation_test.go
@@ -315,6 +315,118 @@ func TestStarlarkValidate_CommentedWhileLoopAllowed(t *testing.T) {
 	}
 }
 
+// TestCELValidate_EventFilterEnvironment verifies that the event_filter environment
+// compiles expressions using event and metadata variables.
+func TestCELValidate_EventFilterEnvironment(t *testing.T) {
+	r := newValidationRegistry(t)
+
+	tests := []struct {
+		name       string
+		expression string
+		wantValid  bool
+	}{
+		{
+			name:       "event field filter",
+			expression: `event.amount > 1000`,
+			wantValid:  true,
+		},
+		{
+			name:       "metadata field filter",
+			expression: `metadata["source"] == "bank"`,
+			wantValid:  true,
+		},
+		{
+			name:       "combined event and metadata",
+			expression: `event.type == "PAYMENT" && metadata["correlation_id"] != ""`,
+			wantValid:  true,
+		},
+		{
+			name:       "validation env variable not available",
+			expression: `amount > 0`,
+			wantValid:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params, _ := json.Marshal(map[string]string{
+				"expression":  tt.expression,
+				"environment": "event_filter",
+			})
+
+			result, err := r.Call(context.Background(), "meridian_cel_validate", json.RawMessage(params))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			m, ok := result.(map[string]interface{})
+			if !ok {
+				t.Fatalf("expected map result, got %T", result)
+			}
+
+			valid, _ := m["valid"].(bool)
+			if valid != tt.wantValid {
+				t.Errorf("expected valid=%v, got: %v", tt.wantValid, m)
+			}
+		})
+	}
+}
+
+// TestCELValidate_EventFilterNonBooleanRejected verifies that a non-boolean event filter
+// expression returns an error.
+func TestCELValidate_EventFilterNonBooleanRejected(t *testing.T) {
+	r := newValidationRegistry(t)
+
+	// event.amount returns a number, not a boolean — the MCP tool surfaces this via
+	// an invalid compilation result. Note: the event_filter env uses DynType for event,
+	// so field access on dyn compiles successfully but the return type is dyn, not bool.
+	// The tool reports valid=true with return_type="dyn" — which is the CEL compiler's
+	// behavior for dynamic field access. The boolean check happens in CompileEventFilter,
+	// not in createCELEnvironment used by the MCP tool.
+	// This test verifies the MCP tool correctly reports the return_type.
+	params := json.RawMessage(`{
+		"expression": "metadata",
+		"environment": "event_filter"
+	}`)
+
+	result, err := r.Call(context.Background(), "meridian_cel_validate", params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+
+	// metadata is map(string, string) — valid expression with non-bool return type
+	valid, _ := m["valid"].(bool)
+	if !valid {
+		t.Errorf("expected valid=true (tool reports compile success), got: %v", m)
+	}
+
+	returnType, _ := m["return_type"].(string)
+	if returnType == "bool" {
+		t.Errorf("expected non-bool return_type, got: %v", returnType)
+	}
+}
+
+// TestCELValidate_UnknownEnvironmentRejected verifies that an unknown environment name
+// is rejected by the JSON schema validator before reaching the handler.
+func TestCELValidate_UnknownEnvironmentRejected(t *testing.T) {
+	r := newValidationRegistry(t)
+
+	params := json.RawMessage(`{
+		"expression": "true",
+		"environment": "unknown_env"
+	}`)
+
+	_, err := r.Call(context.Background(), "meridian_cel_validate", params)
+	if err == nil {
+		t.Fatal("expected error for unknown environment, got nil")
+	}
+}
+
 // TestStarlarkValidate_ForbiddenWhileLoop verifies that a script containing an
 // actual while statement is rejected as a syntax error (Starlark does not
 // permit while loops at the language level).

--- a/shared/pkg/cel/compiler.go
+++ b/shared/pkg/cel/compiler.go
@@ -58,6 +58,9 @@ var (
 
 	// ErrValidationNotBool is returned when a validation expression does not return a boolean.
 	ErrValidationNotBool = errors.New("validation expression must return boolean")
+
+	// ErrEventFilterNotBool is returned when an event filter expression does not return a boolean.
+	ErrEventFilterNotBool = errors.New("event filter expression must return boolean")
 )
 
 // Compiler provides CEL expression compilation with security constraints.
@@ -65,6 +68,7 @@ type Compiler struct {
 	validationEnv  *cel.Env
 	bucketKeyEnv   *cel.Env
 	eligibilityEnv *cel.Env
+	eventFilterEnv *cel.Env
 }
 
 // NewCompiler creates a new CEL Compiler with configured environments.
@@ -84,10 +88,16 @@ func NewCompiler() (*Compiler, error) {
 		return nil, errors.Join(ErrEnvironmentCreation, fmt.Errorf("eligibility env: %w", err))
 	}
 
+	eventFilterEnv, err := createEventFilterEnv()
+	if err != nil {
+		return nil, errors.Join(ErrEnvironmentCreation, fmt.Errorf("event filter env: %w", err))
+	}
+
 	return &Compiler{
 		validationEnv:  validationEnv,
 		bucketKeyEnv:   bucketKeyEnv,
 		eligibilityEnv: eligibilityEnv,
+		eventFilterEnv: eventFilterEnv,
 	}, nil
 }
 
@@ -132,6 +142,19 @@ func createEligibilityEnv() (*cel.Env, error) {
 	return cel.NewEnv(
 		cel.Variable("party", cel.MapType(cel.StringType, cel.StringType)),
 		cel.Variable("attributes", cel.MapType(cel.StringType, cel.StringType)),
+	)
+}
+
+// createEventFilterEnv creates the CEL environment for event filter expressions.
+// Variables available:
+//   - event: dyn - the full event payload as a dynamic map (any event proto or JSON object)
+//   - metadata: map[string]string - Kafka message headers and other event metadata
+//
+// The expression must return a boolean indicating whether the saga should trigger.
+func createEventFilterEnv() (*cel.Env, error) {
+	return cel.NewEnv(
+		cel.Variable("event", cel.DynType),
+		cel.Variable("metadata", cel.MapType(cel.StringType, cel.StringType)),
 	)
 }
 
@@ -225,6 +248,31 @@ func (c *Compiler) CompileEligibility(expression string) (cel.Program, error) {
 	}
 
 	prg, err := c.eligibilityEnv.Program(ast, cel.CostLimit(CostLimit))
+	if err != nil {
+		return nil, errors.Join(ErrCompilation, err)
+	}
+
+	return prg, nil
+}
+
+// CompileEventFilter compiles a boolean event filter expression against the event filter environment.
+// Returns a cel.Program that can be evaluated with event and metadata input values.
+// The expression must return a boolean indicating whether the saga should be triggered.
+func (c *Compiler) CompileEventFilter(expression string) (cel.Program, error) {
+	if err := validateExpressionConstraints(expression); err != nil {
+		return nil, err
+	}
+
+	ast, issues := c.eventFilterEnv.Compile(expression)
+	if issues != nil && issues.Err() != nil {
+		return nil, errors.Join(ErrCompilation, issues.Err())
+	}
+
+	if ast.OutputType() != cel.BoolType {
+		return nil, errors.Join(ErrCompilation, ErrEventFilterNotBool)
+	}
+
+	prg, err := c.eventFilterEnv.Program(ast, cel.CostLimit(CostLimit))
 	if err != nil {
 		return nil, errors.Join(ErrCompilation, err)
 	}

--- a/shared/pkg/cel/compiler_test.go
+++ b/shared/pkg/cel/compiler_test.go
@@ -621,6 +621,131 @@ func TestCompileEligibility_TooLong(t *testing.T) {
 	assert.ErrorIs(t, err, ErrExpressionTooLong)
 }
 
+func TestCompileEventFilter(t *testing.T) {
+	c, err := NewCompiler()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		expression string
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name:       "simple boolean true",
+			expression: `true`,
+			wantErr:    false,
+		},
+		{
+			name:       "event field comparison",
+			expression: `event.amount > 1000`,
+			wantErr:    false,
+		},
+		{
+			name:       "metadata field check",
+			expression: `metadata["correlation_id"] != ""`,
+			wantErr:    false,
+		},
+		{
+			name:       "combined event and metadata",
+			expression: `event.type == "PAYMENT" && metadata["source"] == "bank"`,
+			wantErr:    false,
+		},
+		{
+			name:       "non-boolean return type rejected",
+			expression: `event.amount`,
+			wantErr:    true,
+			errContain: "event filter expression must return boolean",
+		},
+		{
+			name:       "unknown variable rejected",
+			expression: `payload.foo == "bar"`,
+			wantErr:    true,
+			errContain: "undeclared reference",
+		},
+		{
+			name:       "attributes variable not available",
+			expression: `attributes["key"] == "value"`,
+			wantErr:    true,
+			errContain: "undeclared reference",
+		},
+		{
+			name:       "syntax error",
+			expression: `event.type ==`,
+			wantErr:    true,
+			errContain: "CEL compilation failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prg, err := c.CompileEventFilter(tt.expression)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContain != "" {
+					assert.Contains(t, err.Error(), tt.errContain)
+				}
+				assert.Nil(t, prg)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, prg)
+			}
+		})
+	}
+}
+
+func TestCompileEventFilter_Evaluation(t *testing.T) {
+	c, err := NewCompiler()
+	require.NoError(t, err)
+
+	prg, err := c.CompileEventFilter(`event.type == "PAYMENT" && metadata["source"] == "bank"`)
+	require.NoError(t, err)
+
+	result, _, err := prg.Eval(map[string]any{
+		"event":    map[string]any{"type": "PAYMENT", "amount": 500},
+		"metadata": map[string]string{"source": "bank"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, true, result.Value())
+}
+
+func TestCompileEventFilter_CrossEnvRejection(t *testing.T) {
+	c, err := NewCompiler()
+	require.NoError(t, err)
+
+	// event_filter env should reject validation-env-only variables
+	_, err = c.CompileEventFilter(`amount > 0`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "undeclared reference")
+
+	// event_filter env should reject eligibility-env-only variables
+	_, err = c.CompileEventFilter(`party.type == "ORGANIZATION"`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "undeclared reference")
+
+	// validation env should reject event_filter-env-only variables
+	_, err = c.CompileValidation(`event.type == "PAYMENT"`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "undeclared reference")
+}
+
+func TestCompileEventFilter_SecurityLimits(t *testing.T) {
+	c, err := NewCompiler()
+	require.NoError(t, err)
+
+	longExpr := strings.Repeat("true || ", MaxExpressionLength/8+1) + "true"
+	require.Greater(t, len(longExpr), MaxExpressionLength)
+
+	_, err = c.CompileEventFilter(longExpr)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExpressionTooLong)
+
+	deepExpr := strings.Repeat("(", MaxExpressionDepth+2) + "true" + strings.Repeat(")", MaxExpressionDepth+2)
+	_, err = c.CompileEventFilter(deepExpr)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExpressionTooDeep)
+}
+
 func BenchmarkCompileValidation(b *testing.B) {
 	c, err := NewCompiler()
 	require.NoError(b, err)


### PR DESCRIPTION
## Summary

- Adds a fourth CEL environment (`event_filter`) to the `Compiler` struct in `shared/pkg/cel`, exposing `event` (dyn) and `metadata` (map<string,string>) variables for event-triggered saga filtering
- Adds `CompileEventFilter` method with boolean return type validation and `ErrEventFilterNotBool` sentinel error, enforcing the same security constraints (expression length, depth, cost limit) as existing compile methods
- Extends the `meridian_cel_validate` MCP tool to support `event_filter` as a fourth environment option

## Changes Made

**`shared/pkg/cel/compiler.go`**
- Added `eventFilterEnv *cel.Env` field to `Compiler`
- Added `createEventFilterEnv()` builder function
- Added `CompileEventFilter(expression string) (cel.Program, error)` method
- Added `ErrEventFilterNotBool` sentinel error

**`services/mcp-server/internal/tools/validation.go`**
- Added `"event_filter"` to the JSON schema enum for the `environment` parameter
- Added `"event_filter"` case to `createCELEnvironment()` switch

## Test Plan

- [x] `TestCompileEventFilter` — valid expressions compile, non-boolean return type rejected, unknown variables rejected
- [x] `TestCompileEventFilter_Evaluation` — compiled filter evaluates correctly with event/metadata inputs
- [x] `TestCompileEventFilter_CrossEnvRejection` — event_filter env rejects validation/eligibility variables; validation env rejects event_filter variables
- [x] `TestCompileEventFilter_SecurityLimits` — expression length and depth limits enforced
- [x] `TestCELValidate_EventFilterEnvironment` — MCP tool handles event_filter environment correctly
- [x] `TestCELValidate_EventFilterNonBooleanRejected` — MCP tool reports correct return_type for non-boolean expressions
- [x] `TestCELValidate_UnknownEnvironmentRejected` — JSON schema rejects unknown environment names