### PR TITLE
feat: Implement Saga Trigger Registry for event-driven sagas

### DIFF
--- a/services/event-router/adapters/grpc/manifest_client.go
+++ b/services/event-router/adapters/grpc/manifest_client.go
@@ -34,7 +34,8 @@ type ManifestClientConfig struct {
 	// ServiceName is the Kubernetes service name (e.g., "control-plane").
 	ServiceName string
 
-	// Namespace is the Kubernetes namespace (defaults to "default" if empty).
+	// Namespace is the Kubernetes namespace. Empty string defaults to "default"
+	// (handled by platformgrpc.NewClient).
 	Namespace string
 
 	// Port is the service gRPC port number.

--- a/services/event-router/adapters/grpc/manifest_client.go
+++ b/services/event-router/adapters/grpc/manifest_client.go
@@ -20,6 +20,9 @@ var ErrManifestClientConfigRequired = fmt.Errorf("ManifestClientConfig is requir
 // ErrManifestClientServiceNameRequired is returned when ServiceName is not provided.
 var ErrManifestClientServiceNameRequired = fmt.Errorf("ServiceName is required for manifest client")
 
+// ErrManifestClientNegativeTimeout is returned when a negative Timeout is provided.
+var ErrManifestClientNegativeTimeout = fmt.Errorf("timeout must be non-negative")
+
 // ManifestClient fetches the current manifest saga definitions from the control-plane.
 // Used by the event-router to initialize and reload the SagaRegistry on startup.
 type ManifestClient struct {
@@ -58,6 +61,9 @@ func NewManifestClient(cfg *ManifestClientConfig) (*ManifestClient, error) {
 	}
 	if cfg.ServiceName == "" {
 		return nil, ErrManifestClientServiceNameRequired
+	}
+	if cfg.Timeout < 0 {
+		return nil, ErrManifestClientNegativeTimeout
 	}
 	if cfg.Timeout == 0 {
 		cfg.Timeout = 10 * time.Second

--- a/services/event-router/adapters/grpc/manifest_client.go
+++ b/services/event-router/adapters/grpc/manifest_client.go
@@ -1,0 +1,124 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ErrManifestClientConfigRequired is returned when a nil config is passed to NewManifestClient.
+var ErrManifestClientConfigRequired = fmt.Errorf("ManifestClientConfig is required")
+
+// ErrManifestClientServiceNameRequired is returned when ServiceName is not provided.
+var ErrManifestClientServiceNameRequired = fmt.Errorf("ServiceName is required for manifest client")
+
+// ManifestClient fetches the current manifest saga definitions from the control-plane.
+// Used by the event-router to initialize and reload the SagaRegistry on startup.
+type ManifestClient struct {
+	conn    *grpc.ClientConn
+	client  controlplanev1.ManifestHistoryServiceClient
+	timeout time.Duration
+	logger  *slog.Logger
+}
+
+// ManifestClientConfig holds configuration for creating a ManifestClient.
+type ManifestClientConfig struct {
+	// ServiceName is the Kubernetes service name (e.g., "control-plane").
+	ServiceName string
+
+	// Namespace is the Kubernetes namespace (defaults to "default" if empty).
+	Namespace string
+
+	// Port is the service gRPC port number.
+	Port int
+
+	// Timeout is the default timeout for RPC calls (defaults to 10 seconds).
+	Timeout time.Duration
+
+	// Logger is used for structured logging.
+	Logger *slog.Logger
+
+	// DialOptions allows custom gRPC dial options (for testing).
+	DialOptions []grpc.DialOption
+}
+
+// NewManifestClient creates a new gRPC client for the control-plane ManifestHistoryService.
+func NewManifestClient(cfg *ManifestClientConfig) (*ManifestClient, error) {
+	if cfg == nil {
+		return nil, ErrManifestClientConfigRequired
+	}
+	if cfg.ServiceName == "" {
+		return nil, ErrManifestClientServiceNameRequired
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 10 * time.Second
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+
+	conn, err := platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
+		ServiceName: cfg.ServiceName,
+		Namespace:   cfg.Namespace,
+		Port:        cfg.Port,
+		DialOptions: cfg.DialOptions,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gRPC connection to control-plane: %w", err)
+	}
+
+	return &ManifestClient{
+		conn:    conn,
+		client:  controlplanev1.NewManifestHistoryServiceClient(conn),
+		timeout: cfg.Timeout,
+		logger:  cfg.Logger,
+	}, nil
+}
+
+// GetCurrentSagaDefinitions fetches the saga definitions from the most recently
+// applied manifest. Returns an empty slice when no manifest has been applied yet.
+func (c *ManifestClient) GetCurrentSagaDefinitions(ctx context.Context) ([]*controlplanev1.SagaDefinition, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	resp, err := c.client.GetCurrentManifest(ctx, &controlplanev1.GetCurrentManifestRequest{})
+	if err != nil {
+		st, ok := status.FromError(err)
+		if ok && st.Code() == codes.NotFound {
+			// No manifest applied yet — return empty slice, not an error.
+			c.logger.Info("no manifest found for tenant, saga registry will start empty")
+			return nil, nil
+		}
+		return nil, fmt.Errorf("fetch current manifest: %w", err)
+	}
+
+	mf := resp.GetVersion().GetManifest()
+	if mf == nil {
+		c.logger.Info("current manifest has no content, saga registry will start empty")
+		return nil, nil
+	}
+
+	c.logger.Info("loaded saga definitions from current manifest",
+		"count", len(mf.GetSagas()),
+		"manifest_version", mf.GetVersion(),
+	)
+
+	return mf.GetSagas(), nil
+}
+
+// Close releases the gRPC client connection.
+func (c *ManifestClient) Close() error {
+	if c.conn != nil {
+		if err := c.conn.Close(); err != nil {
+			return fmt.Errorf("failed to close manifest client connection: %w", err)
+		}
+	}
+	return nil
+}

--- a/services/event-router/adapters/grpc/manifest_client.go
+++ b/services/event-router/adapters/grpc/manifest_client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -88,13 +89,16 @@ func (c *ManifestClient) GetCurrentSagaDefinitions(ctx context.Context) ([]*cont
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
+	ctx = sharedclients.PropagateCorrelationID(ctx)
+	ctx = sharedclients.PropagateOrganization(ctx)
+
 	resp, err := c.client.GetCurrentManifest(ctx, &controlplanev1.GetCurrentManifestRequest{})
 	if err != nil {
 		st, ok := status.FromError(err)
 		if ok && st.Code() == codes.NotFound {
 			// No manifest applied yet — return empty slice, not an error.
 			c.logger.Info("no manifest found for tenant, saga registry will start empty")
-			return nil, nil
+			return []*controlplanev1.SagaDefinition{}, nil
 		}
 		return nil, fmt.Errorf("fetch current manifest: %w", err)
 	}
@@ -102,7 +106,7 @@ func (c *ManifestClient) GetCurrentSagaDefinitions(ctx context.Context) ([]*cont
 	mf := resp.GetVersion().GetManifest()
 	if mf == nil {
 		c.logger.Info("current manifest has no content, saga registry will start empty")
-		return nil, nil
+		return []*controlplanev1.SagaDefinition{}, nil
 	}
 
 	c.logger.Info("loaded saga definitions from current manifest",

--- a/services/event-router/internal/registry/saga_registry.go
+++ b/services/event-router/internal/registry/saga_registry.go
@@ -3,6 +3,7 @@
 package registry
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -13,6 +14,9 @@ import (
 )
 
 const eventTriggerPrefix = "event:"
+
+// ErrNilSagaDefinition is returned by Reload when a nil entry is found in the input slice.
+var ErrNilSagaDefinition = errors.New("nil saga definition")
 
 // CompiledSaga pairs a saga definition with its precompiled CEL filter program.
 // FilterProgram is nil when the saga definition carries no filter expression.
@@ -54,12 +58,16 @@ func NewSagaRegistry() (*SagaRegistry, error) {
 // Only definitions whose trigger begins with "event:" are registered; all others
 // are silently skipped.
 //
-// If any definition carries an invalid CEL filter expression, Reload returns an
-// error and leaves the registry unchanged (atomic replacement guarantee).
+// If any definition is nil or carries an invalid CEL filter expression, Reload
+// returns an error and leaves the registry unchanged (atomic replacement guarantee).
 func (r *SagaRegistry) Reload(sagas []*controlplanev1.SagaDefinition) error {
 	newByChannel := make(map[string][]*CompiledSaga)
 
-	for _, def := range sagas {
+	for i, def := range sagas {
+		if def == nil {
+			return fmt.Errorf("%w at index %d", ErrNilSagaDefinition, i)
+		}
+
 		if !strings.HasPrefix(def.GetTrigger(), eventTriggerPrefix) {
 			continue
 		}
@@ -86,9 +94,8 @@ func (r *SagaRegistry) Reload(sagas []*controlplanev1.SagaDefinition) error {
 	return nil
 }
 
-// GetApplicableSagas returns the compiled sagas registered for the given channel.
-// Returns nil if no sagas are registered for the channel.
-// The returned slice must not be modified by callers.
+// GetApplicableSagas returns a defensive copy of the compiled sagas registered
+// for the given channel. Returns nil if no sagas are registered for the channel.
 func (r *SagaRegistry) GetApplicableSagas(channel string) []*CompiledSaga {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -98,5 +105,7 @@ func (r *SagaRegistry) GetApplicableSagas(channel string) []*CompiledSaga {
 		return nil
 	}
 
-	return sagas
+	out := make([]*CompiledSaga, len(sagas))
+	copy(out, sagas)
+	return out
 }

--- a/services/event-router/internal/registry/saga_registry.go
+++ b/services/event-router/internal/registry/saga_registry.go
@@ -1,0 +1,102 @@
+// Package registry provides an in-memory registry mapping event channels to
+// applicable saga definitions with precompiled CEL filter programs.
+package registry
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/google/cel-go/cel"
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	sharedcel "github.com/meridianhub/meridian/shared/pkg/cel"
+)
+
+const eventTriggerPrefix = "event:"
+
+// CompiledSaga pairs a saga definition with its precompiled CEL filter program.
+// FilterProgram is nil when the saga definition carries no filter expression.
+type CompiledSaga struct {
+	// Definition is the original saga definition from the manifest.
+	Definition *controlplanev1.SagaDefinition
+
+	// FilterProgram is the precompiled CEL program for the filter expression.
+	// Nil when the definition has no filter — the saga matches all events on the channel.
+	FilterProgram cel.Program
+}
+
+// SagaRegistry is a thread-safe, in-memory index mapping event channel names to
+// the compiled sagas that should be triggered when an event on that channel arrives.
+//
+// The registry is populated by calling Reload, which atomically replaces all
+// registrations. Only sagas whose trigger starts with "event:" are indexed.
+type SagaRegistry struct {
+	mu        sync.RWMutex
+	byChannel map[string][]*CompiledSaga
+	compiler  *sharedcel.Compiler
+}
+
+// NewSagaRegistry creates an empty SagaRegistry with a CEL compiler ready to
+// compile event-filter expressions.
+func NewSagaRegistry() (*SagaRegistry, error) {
+	compiler, err := sharedcel.NewCompiler()
+	if err != nil {
+		return nil, fmt.Errorf("create CEL compiler: %w", err)
+	}
+
+	return &SagaRegistry{
+		byChannel: make(map[string][]*CompiledSaga),
+		compiler:  compiler,
+	}, nil
+}
+
+// Reload atomically replaces all registrations from the provided saga definitions.
+// Only definitions whose trigger begins with "event:" are registered; all others
+// are silently skipped.
+//
+// If any definition carries an invalid CEL filter expression, Reload returns an
+// error and leaves the registry unchanged (atomic replacement guarantee).
+func (r *SagaRegistry) Reload(sagas []*controlplanev1.SagaDefinition) error {
+	newByChannel := make(map[string][]*CompiledSaga)
+
+	for _, def := range sagas {
+		if !strings.HasPrefix(def.GetTrigger(), eventTriggerPrefix) {
+			continue
+		}
+
+		channel := strings.TrimPrefix(def.GetTrigger(), eventTriggerPrefix)
+
+		compiled := &CompiledSaga{Definition: def}
+
+		if def.Filter != nil {
+			prg, err := r.compiler.CompileEventFilter(def.GetFilter())
+			if err != nil {
+				return fmt.Errorf("compile CEL filter for saga %q: %w", def.GetName(), err)
+			}
+			compiled.FilterProgram = prg
+		}
+
+		newByChannel[channel] = append(newByChannel[channel], compiled)
+	}
+
+	r.mu.Lock()
+	r.byChannel = newByChannel
+	r.mu.Unlock()
+
+	return nil
+}
+
+// GetApplicableSagas returns the compiled sagas registered for the given channel.
+// Returns nil if no sagas are registered for the channel.
+// The returned slice must not be modified by callers.
+func (r *SagaRegistry) GetApplicableSagas(channel string) []*CompiledSaga {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	sagas, ok := r.byChannel[channel]
+	if !ok {
+		return nil
+	}
+
+	return sagas
+}

--- a/services/event-router/internal/registry/saga_registry_test.go
+++ b/services/event-router/internal/registry/saga_registry_test.go
@@ -1,0 +1,315 @@
+package registry_test
+
+import (
+	"sync"
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/event-router/internal/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSagaRegistry_Reload_RegistersEventTriggeredSagas(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	sagas := []*controlplanev1.SagaDefinition{
+		{
+			Name:    "process_settlement",
+			Trigger: "event:position-keeping.transaction-captured.v1",
+			Script:  "def run(ctx, input): pass",
+		},
+	}
+
+	err = reg.Reload(sagas)
+	require.NoError(t, err)
+
+	results := reg.GetApplicableSagas("position-keeping.transaction-captured.v1")
+	require.Len(t, results, 1)
+	assert.Equal(t, "process_settlement", results[0].Definition.GetName())
+}
+
+func TestSagaRegistry_Reload_IgnoresNonEventTriggers(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	sagas := []*controlplanev1.SagaDefinition{
+		{
+			Name:    "api_saga",
+			Trigger: "api:/v1/settlements",
+			Script:  "def run(ctx, input): pass",
+		},
+		{
+			Name:    "webhook_saga",
+			Trigger: "webhook:stripe_payment",
+			Script:  "def run(ctx, input): pass",
+		},
+		{
+			Name:    "scheduled_saga",
+			Trigger: "scheduled:daily_reconciliation",
+			Script:  "def run(ctx, input): pass",
+		},
+	}
+
+	err = reg.Reload(sagas)
+	require.NoError(t, err)
+
+	// All non-event triggers should be ignored
+	results := reg.GetApplicableSagas("position-keeping.transaction-captured.v1")
+	assert.Nil(t, results)
+}
+
+func TestSagaRegistry_GetApplicableSagas_MultipleSagasForSameChannel(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	channel := "position-keeping.transaction-captured.v1"
+	sagas := []*controlplanev1.SagaDefinition{
+		{
+			Name:    "settlement_a",
+			Trigger: "event:" + channel,
+			Script:  "def run(ctx, input): pass",
+		},
+		{
+			Name:    "settlement_b",
+			Trigger: "event:" + channel,
+			Script:  "def run(ctx, input): pass",
+		},
+	}
+
+	err = reg.Reload(sagas)
+	require.NoError(t, err)
+
+	results := reg.GetApplicableSagas(channel)
+	require.Len(t, results, 2)
+
+	names := []string{results[0].Definition.GetName(), results[1].Definition.GetName()}
+	assert.ElementsMatch(t, []string{"settlement_a", "settlement_b"}, names)
+}
+
+func TestSagaRegistry_GetApplicableSagas_UnknownChannelReturnsNil(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	err = reg.Reload([]*controlplanev1.SagaDefinition{
+		{
+			Name:    "process_settlement",
+			Trigger: "event:position-keeping.transaction-captured.v1",
+			Script:  "def run(ctx, input): pass",
+		},
+	})
+	require.NoError(t, err)
+
+	results := reg.GetApplicableSagas("unknown-channel")
+	assert.Nil(t, results)
+}
+
+func TestSagaRegistry_Reload_ClearsPreviousRegistrations(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	// First load with one saga
+	err = reg.Reload([]*controlplanev1.SagaDefinition{
+		{
+			Name:    "old_saga",
+			Trigger: "event:some-channel",
+			Script:  "def run(ctx, input): pass",
+		},
+	})
+	require.NoError(t, err)
+
+	results := reg.GetApplicableSagas("some-channel")
+	require.Len(t, results, 1)
+
+	// Reload with different saga
+	err = reg.Reload([]*controlplanev1.SagaDefinition{
+		{
+			Name:    "new_saga",
+			Trigger: "event:other-channel",
+			Script:  "def run(ctx, input): pass",
+		},
+	})
+	require.NoError(t, err)
+
+	// Old channel should no longer be registered
+	oldResults := reg.GetApplicableSagas("some-channel")
+	assert.Nil(t, oldResults)
+
+	// New channel should be registered
+	newResults := reg.GetApplicableSagas("other-channel")
+	require.Len(t, newResults, 1)
+	assert.Equal(t, "new_saga", newResults[0].Definition.GetName())
+}
+
+func TestSagaRegistry_Reload_WithValidCELFilter(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	filter := `event.amount > 0`
+	sagas := []*controlplanev1.SagaDefinition{
+		{
+			Name:    "filtered_saga",
+			Trigger: "event:position-keeping.transaction-captured.v1",
+			Script:  "def run(ctx, input): pass",
+			Filter:  &filter,
+		},
+	}
+
+	err = reg.Reload(sagas)
+	require.NoError(t, err)
+
+	results := reg.GetApplicableSagas("position-keeping.transaction-captured.v1")
+	require.Len(t, results, 1)
+	assert.Equal(t, "filtered_saga", results[0].Definition.GetName())
+	assert.NotNil(t, results[0].FilterProgram, "FilterProgram should be compiled and non-nil")
+}
+
+func TestSagaRegistry_Reload_WithInvalidCELFilter_ReturnsError(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	filter := `this is not valid CEL !!!`
+	sagas := []*controlplanev1.SagaDefinition{
+		{
+			Name:    "bad_filter_saga",
+			Trigger: "event:some-channel",
+			Script:  "def run(ctx, input): pass",
+			Filter:  &filter,
+		},
+	}
+
+	err = reg.Reload(sagas)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad_filter_saga")
+}
+
+func TestSagaRegistry_Reload_WithNoFilter_FilterProgramIsNil(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	sagas := []*controlplanev1.SagaDefinition{
+		{
+			Name:    "unfiltered_saga",
+			Trigger: "event:some-channel",
+			Script:  "def run(ctx, input): pass",
+			// No Filter field
+		},
+	}
+
+	err = reg.Reload(sagas)
+	require.NoError(t, err)
+
+	results := reg.GetApplicableSagas("some-channel")
+	require.Len(t, results, 1)
+	assert.Nil(t, results[0].FilterProgram, "FilterProgram should be nil when no filter is set")
+}
+
+func TestSagaRegistry_ThreadSafety_ConcurrentReadsAndReload(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	// Seed with initial data
+	err = reg.Reload([]*controlplanev1.SagaDefinition{
+		{
+			Name:    "initial_saga",
+			Trigger: "event:test-channel",
+			Script:  "def run(ctx, input): pass",
+		},
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 10)
+
+	// Concurrent readers
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				results := reg.GetApplicableSagas("test-channel")
+				_ = results // Just ensure no panic or race
+			}
+		}()
+	}
+
+	// Concurrent writer (Reload)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < 10; j++ {
+			if err := reg.Reload([]*controlplanev1.SagaDefinition{
+				{
+					Name:    "updated_saga",
+					Trigger: "event:test-channel",
+					Script:  "def run(ctx, input): pass",
+				},
+			}); err != nil {
+				errCh <- err
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Errorf("concurrent reload error: %v", err)
+	}
+}
+
+func TestSagaRegistry_Reload_EmptySlice_ClearsAll(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	err = reg.Reload([]*controlplanev1.SagaDefinition{
+		{
+			Name:    "some_saga",
+			Trigger: "event:some-channel",
+			Script:  "def run(ctx, input): pass",
+		},
+	})
+	require.NoError(t, err)
+
+	// Now reload with empty slice
+	err = reg.Reload([]*controlplanev1.SagaDefinition{})
+	require.NoError(t, err)
+
+	results := reg.GetApplicableSagas("some-channel")
+	assert.Nil(t, results)
+}
+
+func TestSagaRegistry_Reload_MultipleDifferentChannels(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	sagas := []*controlplanev1.SagaDefinition{
+		{
+			Name:    "saga_for_channel_a",
+			Trigger: "event:channel-a",
+			Script:  "def run(ctx, input): pass",
+		},
+		{
+			Name:    "saga_for_channel_b",
+			Trigger: "event:channel-b",
+			Script:  "def run(ctx, input): pass",
+		},
+		{
+			Name:    "another_saga_for_channel_a",
+			Trigger: "event:channel-a",
+			Script:  "def run(ctx, input): pass",
+		},
+	}
+
+	err = reg.Reload(sagas)
+	require.NoError(t, err)
+
+	channelA := reg.GetApplicableSagas("channel-a")
+	require.Len(t, channelA, 2)
+
+	channelB := reg.GetApplicableSagas("channel-b")
+	require.Len(t, channelB, 1)
+	assert.Equal(t, "saga_for_channel_b", channelB[0].Definition.GetName())
+}

--- a/services/event-router/internal/registry/saga_registry_test.go
+++ b/services/event-router/internal/registry/saga_registry_test.go
@@ -281,6 +281,51 @@ func TestSagaRegistry_Reload_EmptySlice_ClearsAll(t *testing.T) {
 	assert.Nil(t, results)
 }
 
+func TestSagaRegistry_Reload_FailedReload_LeavesRegistryUnchanged(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	// Step 1: Load valid sagas
+	err = reg.Reload([]*controlplanev1.SagaDefinition{
+		{
+			Name:    "valid_saga",
+			Trigger: "event:my-channel",
+			Script:  "def run(ctx, input): pass",
+		},
+	})
+	require.NoError(t, err)
+
+	// Verify step 1 loaded correctly
+	results := reg.GetApplicableSagas("my-channel")
+	require.Len(t, results, 1)
+
+	// Step 2: Reload with invalid CEL filter — expect error
+	badFilter := `not valid CEL !!!`
+	err = reg.Reload([]*controlplanev1.SagaDefinition{
+		{
+			Name:    "bad_saga",
+			Trigger: "event:my-channel",
+			Script:  "def run(ctx, input): pass",
+			Filter:  &badFilter,
+		},
+	})
+	require.Error(t, err)
+
+	// Step 3: Previous registrations must survive the failed reload
+	surviving := reg.GetApplicableSagas("my-channel")
+	require.Len(t, surviving, 1, "registry must be unchanged after failed reload")
+	assert.Equal(t, "valid_saga", surviving[0].Definition.GetName())
+}
+
+func TestSagaRegistry_Reload_NilEntryReturnsError(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	err = reg.Reload([]*controlplanev1.SagaDefinition{nil})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, registry.ErrNilSagaDefinition)
+}
+
 func TestSagaRegistry_Reload_MultipleDifferentChannels(t *testing.T) {
 	reg, err := registry.NewSagaRegistry()
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Implements `SagaRegistry` (`services/event-router/internal/registry/`) — a thread-safe, in-memory registry that maps event channel names to applicable saga definitions with precompiled CEL filter programs
- CEL filter expressions are compiled eagerly at `Reload` time (subtask 5.2), making hot-path event routing a simple map lookup with zero compilation cost
- Adds `ManifestClient` gRPC adapter (`services/event-router/adapters/grpc/manifest_client.go`) for fetching the current manifest's saga definitions from the control-plane at startup (subtask 5.3)

## Changes

**`services/event-router/internal/registry/saga_registry.go`**
- `SagaRegistry` with `Reload(sagas)` and `GetApplicableSagas(channel)` methods
- `Reload` atomically replaces all registrations; only `event:`-prefixed triggers are indexed
- Invalid CEL filters cause `Reload` to return an error before any state is mutated
- `RWMutex` — reads are concurrent, writes exclusive

**`services/event-router/adapters/grpc/manifest_client.go`**
- `ManifestClient` wrapping the control-plane `ManifestHistoryService`
- `GetCurrentSagaDefinitions(ctx)` returns `[]*SagaDefinition` or nil (no error) when no manifest exists yet

## Test plan

- [x] `Reload` registers sagas with `event:` trigger; non-event triggers are ignored
- [x] Multiple sagas on the same channel all returned by `GetApplicableSagas`
- [x] Reload atomically clears previous registrations
- [x] Valid CEL filter compiles to non-nil `FilterProgram`; no filter → nil `FilterProgram`
- [x] Invalid CEL filter causes `Reload` to return an error naming the failing saga
- [x] Thread safety: 8 concurrent readers + concurrent `Reload` writer under race detector
- [x] Empty `Reload` clears all registrations

## Part of

Issue #032 — Event-Driven Saga Orchestration  
Task: `032-event-driven-saga.5` — Implement Saga Trigger Registry