### PR TITLE
feat: Add SagaDispatchHandler with CEL filter evaluation

### DIFF
--- a/services/event-router/internal/handlers/saga_dispatch_handler.go
+++ b/services/event-router/internal/handlers/saga_dispatch_handler.go
@@ -38,17 +38,22 @@ type SagaDispatchHandler struct {
 type Option func(*SagaDispatchHandler)
 
 // WithMaxChainDepth sets the maximum allowed chain depth. Events with a chain
-// depth >= this value are dropped with a warning log.
+// depth >= this value are dropped with a warning log. Non-positive values are
+// ignored and the default is kept to prevent accidentally disabling dispatch.
 func WithMaxChainDepth(depth int) Option {
 	return func(h *SagaDispatchHandler) {
-		h.maxChainDepth = depth
+		if depth > 0 {
+			h.maxChainDepth = depth
+		}
 	}
 }
 
-// WithLogger sets the structured logger.
+// WithLogger sets the structured logger. A nil logger is ignored.
 func WithLogger(logger *slog.Logger) Option {
 	return func(h *SagaDispatchHandler) {
-		h.logger = logger
+		if logger != nil {
+			h.logger = logger
+		}
 	}
 }
 

--- a/services/event-router/internal/handlers/saga_dispatch_handler.go
+++ b/services/event-router/internal/handlers/saga_dispatch_handler.go
@@ -178,14 +178,15 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 	return nil
 }
 
-// extractChainDepth reads the chain depth from metadata, returning 0 if absent or unparseable.
+// extractChainDepth reads the chain depth from metadata, returning 0 if absent,
+// unparseable, or negative.
 func extractChainDepth(metadata map[string]string) int {
 	raw, ok := metadata[chainDepthHeader]
 	if !ok {
 		return 0
 	}
 	depth, err := strconv.Atoi(raw)
-	if err != nil {
+	if err != nil || depth < 0 {
 		return 0
 	}
 	return depth

--- a/services/event-router/internal/handlers/saga_dispatch_handler.go
+++ b/services/event-router/internal/handlers/saga_dispatch_handler.go
@@ -3,6 +3,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -13,6 +14,9 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"google.golang.org/protobuf/proto"
 )
+
+// ErrHandlerNotInitialized is returned when Handle is called on a handler with nil dependencies.
+var ErrHandlerNotInitialized = errors.New("saga dispatch handler is not properly initialized")
 
 const (
 	// defaultMaxChainDepth is the maximum saga chain depth before events are dropped.
@@ -83,6 +87,10 @@ func NewSagaDispatchHandler(reg *registry.SagaRegistry, trigger domain.SagaTrigg
 // warning log) while other sagas continue processing. Trigger errors are
 // returned immediately as they indicate infrastructure failures.
 func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event proto.Message, metadata map[string]string) error {
+	if h.registry == nil || h.sagaTrigger == nil {
+		return ErrHandlerNotInitialized
+	}
+
 	// Convert event to input_data (also validates event is non-nil).
 	inputData, err := saga.EventToInputData(event, metadata)
 	if err != nil {

--- a/services/event-router/internal/handlers/saga_dispatch_handler.go
+++ b/services/event-router/internal/handlers/saga_dispatch_handler.go
@@ -1,0 +1,188 @@
+// Package handlers provides event handler implementations for the event-router.
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/event-router/domain"
+	"github.com/meridianhub/meridian/services/event-router/internal/registry"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// defaultMaxChainDepth is the maximum saga chain depth before events are dropped.
+	defaultMaxChainDepth = 10
+
+	// chainDepthHeader is the metadata key carrying the current chain depth.
+	chainDepthHeader = "x-chain-depth"
+
+	// correlationIDHeader is the metadata key carrying the correlation ID.
+	correlationIDHeader = "x-correlation-id"
+)
+
+// SagaDispatchHandler evaluates CEL filters against incoming events and triggers
+// matching sagas via the SagaTrigger port. It implements domain.EventHandler.
+type SagaDispatchHandler struct {
+	registry      *registry.SagaRegistry
+	sagaTrigger   domain.SagaTrigger
+	maxChainDepth int
+	logger        *slog.Logger
+}
+
+// Option configures a SagaDispatchHandler.
+type Option func(*SagaDispatchHandler)
+
+// WithMaxChainDepth sets the maximum allowed chain depth. Events with a chain
+// depth >= this value are dropped with a warning log.
+func WithMaxChainDepth(depth int) Option {
+	return func(h *SagaDispatchHandler) {
+		h.maxChainDepth = depth
+	}
+}
+
+// WithLogger sets the structured logger.
+func WithLogger(logger *slog.Logger) Option {
+	return func(h *SagaDispatchHandler) {
+		h.logger = logger
+	}
+}
+
+// NewSagaDispatchHandler creates a handler that dispatches events to sagas
+// registered in the provided registry.
+func NewSagaDispatchHandler(reg *registry.SagaRegistry, trigger domain.SagaTrigger, opts ...Option) *SagaDispatchHandler {
+	h := &SagaDispatchHandler{
+		registry:      reg,
+		sagaTrigger:   trigger,
+		maxChainDepth: defaultMaxChainDepth,
+		logger:        slog.Default().With("component", "saga_dispatch_handler"),
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
+
+// Handle processes a single event by looking up applicable sagas for the channel,
+// evaluating each saga's CEL filter, and triggering matching sagas.
+//
+// Chain depth enforcement: if the metadata carries an x-chain-depth value >= the
+// configured maximum, the event is dropped silently (with a warning log) to
+// prevent infinite saga chains.
+//
+// Filter evaluation errors cause the individual saga to be skipped (with a
+// warning log) while other sagas continue processing. Trigger errors are
+// returned immediately as they indicate infrastructure failures.
+func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event proto.Message, metadata map[string]string) error {
+	// Convert event to input_data (also validates event is non-nil).
+	inputData, err := saga.EventToInputData(event, metadata)
+	if err != nil {
+		return fmt.Errorf("convert event to input_data: %w", err)
+	}
+
+	// Check chain depth.
+	depth := extractChainDepth(metadata)
+	if depth >= h.maxChainDepth {
+		h.logger.WarnContext(ctx, "chain depth exceeded, dropping event",
+			"channel", channel,
+			"chain_depth", depth,
+			"max_chain_depth", h.maxChainDepth,
+		)
+		return nil
+	}
+
+	// Look up applicable sagas for this channel.
+	sagas := h.registry.GetApplicableSagas(channel)
+	if len(sagas) == 0 {
+		return nil
+	}
+
+	// Build the CEL activation map for filter evaluation.
+	// CEL event filter environment expects "event" (dyn) and "metadata" (map[string]string).
+	activation := map[string]any{
+		"event":    inputData["event"],
+		"metadata": metadata,
+	}
+
+	idempotencyKey := extractCorrelationID(metadata)
+
+	for _, cs := range sagas {
+		sagaName := cs.Definition.GetName()
+
+		// If no filter, the saga always matches.
+		if cs.FilterProgram == nil {
+			if _, err := h.sagaTrigger.TriggerSaga(ctx, sagaName, inputData, idempotencyKey); err != nil {
+				return fmt.Errorf("trigger saga %q: %w", sagaName, err)
+			}
+			h.logger.DebugContext(ctx, "saga triggered (no filter)",
+				"saga_name", sagaName,
+				"channel", channel,
+			)
+			continue
+		}
+
+		// Evaluate CEL filter.
+		out, _, evalErr := cs.FilterProgram.Eval(activation)
+		if evalErr != nil {
+			h.logger.WarnContext(ctx, "CEL filter evaluation error, skipping saga",
+				"saga_name", sagaName,
+				"channel", channel,
+				"error", evalErr,
+			)
+			continue
+		}
+
+		matched, ok := out.Value().(bool)
+		if !ok {
+			h.logger.WarnContext(ctx, "CEL filter returned non-boolean, skipping saga",
+				"saga_name", sagaName,
+				"channel", channel,
+				"result_type", fmt.Sprintf("%T", out.Value()),
+			)
+			continue
+		}
+
+		if !matched {
+			h.logger.DebugContext(ctx, "CEL filter did not match, skipping saga",
+				"saga_name", sagaName,
+				"channel", channel,
+			)
+			continue
+		}
+
+		if _, err := h.sagaTrigger.TriggerSaga(ctx, sagaName, inputData, idempotencyKey); err != nil {
+			return fmt.Errorf("trigger saga %q: %w", sagaName, err)
+		}
+		h.logger.DebugContext(ctx, "saga triggered",
+			"saga_name", sagaName,
+			"channel", channel,
+		)
+	}
+
+	return nil
+}
+
+// extractChainDepth reads the chain depth from metadata, returning 0 if absent or unparseable.
+func extractChainDepth(metadata map[string]string) int {
+	raw, ok := metadata[chainDepthHeader]
+	if !ok {
+		return 0
+	}
+	depth, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0
+	}
+	return depth
+}
+
+// extractCorrelationID reads the correlation ID from metadata, generating a UUID if absent.
+func extractCorrelationID(metadata map[string]string) string {
+	if id, ok := metadata[correlationIDHeader]; ok && id != "" {
+		return id
+	}
+	return uuid.New().String()
+}

--- a/services/event-router/internal/handlers/saga_dispatch_handler.go
+++ b/services/event-router/internal/handlers/saga_dispatch_handler.go
@@ -109,6 +109,13 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 	}
 
 	idempotencyKey := extractCorrelationID(metadata)
+	if idempotencyKey == "" {
+		idempotencyKey = uuid.New().String()
+		h.logger.WarnContext(ctx, "no correlation ID in metadata, generated UUID as idempotency key — Kafka redelivery may cause duplicate saga executions",
+			"channel", channel,
+			"generated_key", idempotencyKey,
+		)
+	}
 
 	for _, cs := range sagas {
 		sagaName := cs.Definition.GetName()
@@ -179,10 +186,11 @@ func extractChainDepth(metadata map[string]string) int {
 	return depth
 }
 
-// extractCorrelationID reads the correlation ID from metadata, generating a UUID if absent.
+// extractCorrelationID reads the correlation ID from metadata.
+// Returns empty string if absent — caller is responsible for fallback and logging.
 func extractCorrelationID(metadata map[string]string) string {
 	if id, ok := metadata[correlationIDHeader]; ok && id != "" {
 		return id
 	}
-	return uuid.New().String()
+	return ""
 }

--- a/services/event-router/internal/handlers/saga_dispatch_handler_test.go
+++ b/services/event-router/internal/handlers/saga_dispatch_handler_test.go
@@ -1,0 +1,421 @@
+package handlers_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/event-router/internal/handlers"
+	"github.com/meridianhub/meridian/services/event-router/internal/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// fakeSagaTrigger is a test double for domain.SagaTrigger.
+type fakeSagaTrigger struct {
+	calls []triggerCall
+	err   error
+}
+
+type triggerCall struct {
+	SagaName       string
+	InputData      map[string]any
+	IdempotencyKey string
+}
+
+func (f *fakeSagaTrigger) TriggerSaga(_ context.Context, sagaName string, inputData map[string]any, idempotencyKey string) (string, error) {
+	f.calls = append(f.calls, triggerCall{
+		SagaName:       sagaName,
+		InputData:      inputData,
+		IdempotencyKey: idempotencyKey,
+	})
+	if f.err != nil {
+		return "", f.err
+	}
+	return "saga-instance-" + sagaName, nil
+}
+
+func (f *fakeSagaTrigger) Close() error { return nil }
+
+// newTestEvent creates a simple structpb.Struct as a proto.Message for testing.
+func newTestEvent(t *testing.T, fields map[string]any) proto.Message {
+	t.Helper()
+	s, err := structpb.NewStruct(fields)
+	require.NoError(t, err)
+	return s
+}
+
+func TestSagaDispatchHandler_MatchingFilter(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	filter := `event.account_id == "acct-123"`
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "test_saga", Trigger: "event:accounts", Filter: &filter, Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger, handlers.WithLogger(slog.Default()))
+
+	event := newTestEvent(t, map[string]any{"account_id": "acct-123"})
+	err = h.Handle(context.Background(), "accounts", event, map[string]string{"x-correlation-id": "corr-1"})
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 1)
+	assert.Equal(t, "test_saga", trigger.calls[0].SagaName)
+	assert.Equal(t, "corr-1", trigger.calls[0].IdempotencyKey)
+}
+
+func TestSagaDispatchHandler_NonMatchingFilter(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	filter := `event.account_id == "acct-999"`
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "test_saga", Trigger: "event:accounts", Filter: &filter, Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger)
+
+	event := newTestEvent(t, map[string]any{"account_id": "acct-123"})
+	err = h.Handle(context.Background(), "accounts", event, map[string]string{"x-correlation-id": "corr-1"})
+
+	require.NoError(t, err)
+	assert.Empty(t, trigger.calls)
+}
+
+func TestSagaDispatchHandler_NilFilter_AlwaysMatches(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "always_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger)
+
+	event := newTestEvent(t, map[string]any{"order_id": "ord-1"})
+	err = h.Handle(context.Background(), "orders", event, map[string]string{"x-correlation-id": "corr-2"})
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 1)
+	assert.Equal(t, "always_saga", trigger.calls[0].SagaName)
+}
+
+func TestSagaDispatchHandler_MultipleSagas_AllMatchingExecute(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	filter1 := `event.amount > 0`
+	filter2 := `event.amount > 100`
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "low_threshold", Trigger: "event:payments", Filter: &filter1, Script: "def run(ctx): pass"},
+		{Name: "high_threshold", Trigger: "event:payments", Filter: &filter2, Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger)
+
+	event := newTestEvent(t, map[string]any{"amount": 200.0})
+	err = h.Handle(context.Background(), "payments", event, map[string]string{"x-correlation-id": "corr-3"})
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 2)
+	assert.Equal(t, "low_threshold", trigger.calls[0].SagaName)
+	assert.Equal(t, "high_threshold", trigger.calls[1].SagaName)
+}
+
+func TestSagaDispatchHandler_MultipleSagas_PartialMatch(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	filter1 := `event.amount > 0`
+	filter2 := `event.amount > 500`
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "low_threshold", Trigger: "event:payments", Filter: &filter1, Script: "def run(ctx): pass"},
+		{Name: "high_threshold", Trigger: "event:payments", Filter: &filter2, Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger)
+
+	event := newTestEvent(t, map[string]any{"amount": 200.0})
+	err = h.Handle(context.Background(), "payments", event, map[string]string{"x-correlation-id": "corr-4"})
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 1)
+	assert.Equal(t, "low_threshold", trigger.calls[0].SagaName)
+}
+
+func TestSagaDispatchHandler_NoSagasForChannel(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	// Registry is empty — no sagas registered
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger)
+
+	event := newTestEvent(t, map[string]any{"id": "1"})
+	err = h.Handle(context.Background(), "unknown-channel", event, nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, trigger.calls)
+}
+
+func TestSagaDispatchHandler_ChainDepthExceeded(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "chain_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger, handlers.WithMaxChainDepth(3))
+
+	event := newTestEvent(t, map[string]any{"order_id": "ord-1"})
+	metadata := map[string]string{
+		"x-correlation-id": "corr-5",
+		"x-chain-depth":    "5",
+	}
+	err = h.Handle(context.Background(), "orders", event, metadata)
+
+	require.NoError(t, err)
+	assert.Empty(t, trigger.calls, "should not trigger saga when chain depth exceeded")
+}
+
+func TestSagaDispatchHandler_ChainDepthAtLimit(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "chain_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger, handlers.WithMaxChainDepth(3))
+
+	event := newTestEvent(t, map[string]any{"order_id": "ord-1"})
+	metadata := map[string]string{
+		"x-correlation-id": "corr-6",
+		"x-chain-depth":    "3",
+	}
+	err = h.Handle(context.Background(), "orders", event, metadata)
+
+	require.NoError(t, err)
+	assert.Empty(t, trigger.calls, "should not trigger saga when chain depth equals max")
+}
+
+func TestSagaDispatchHandler_ChainDepthBelowLimit(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "chain_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger, handlers.WithMaxChainDepth(3))
+
+	event := newTestEvent(t, map[string]any{"order_id": "ord-1"})
+	metadata := map[string]string{
+		"x-correlation-id": "corr-7",
+		"x-chain-depth":    "2",
+	}
+	err = h.Handle(context.Background(), "orders", event, metadata)
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 1)
+}
+
+func TestSagaDispatchHandler_ChainDepthMissing_DefaultsToZero(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "chain_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger, handlers.WithMaxChainDepth(3))
+
+	event := newTestEvent(t, map[string]any{"order_id": "ord-1"})
+	err = h.Handle(context.Background(), "orders", event, map[string]string{"x-correlation-id": "corr-8"})
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 1)
+}
+
+func TestSagaDispatchHandler_ChainDepthInvalid_DefaultsToZero(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "chain_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger, handlers.WithMaxChainDepth(3))
+
+	event := newTestEvent(t, map[string]any{"order_id": "ord-1"})
+	metadata := map[string]string{
+		"x-correlation-id": "corr-9",
+		"x-chain-depth":    "not-a-number",
+	}
+	err = h.Handle(context.Background(), "orders", event, metadata)
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 1)
+}
+
+func TestSagaDispatchHandler_CELFilterError_SkipsSaga_ContinuesOthers(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	// First saga has a filter that will error because event.missing_field doesn't exist
+	// on a dyn type this won't error at compile time but will at eval time
+	filter1 := `event.missing_field.nested == "x"`
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "error_saga", Trigger: "event:orders", Filter: &filter1, Script: "def run(ctx): pass"},
+		{Name: "good_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger)
+
+	event := newTestEvent(t, map[string]any{"order_id": "ord-1"})
+	err = h.Handle(context.Background(), "orders", event, map[string]string{"x-correlation-id": "corr-10"})
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 1)
+	assert.Equal(t, "good_saga", trigger.calls[0].SagaName)
+}
+
+func TestSagaDispatchHandler_TriggerError_ReturnsError(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "fail_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{err: errors.New("trigger failed")}
+	h := handlers.NewSagaDispatchHandler(reg, trigger)
+
+	event := newTestEvent(t, map[string]any{"order_id": "ord-1"})
+	err = h.Handle(context.Background(), "orders", event, map[string]string{"x-correlation-id": "corr-11"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trigger failed")
+}
+
+func TestSagaDispatchHandler_NilEvent_ReturnsError(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "test_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger)
+
+	err = h.Handle(context.Background(), "orders", nil, map[string]string{"x-correlation-id": "corr-12"})
+
+	require.Error(t, err)
+}
+
+func TestSagaDispatchHandler_MetadataFilter(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	filter := `metadata.source == "billing"`
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "billing_saga", Trigger: "event:payments", Filter: &filter, Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger)
+
+	event := newTestEvent(t, map[string]any{"amount": 100.0})
+	err = h.Handle(context.Background(), "payments", event, map[string]string{
+		"x-correlation-id": "corr-13",
+		"source":           "billing",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 1)
+	assert.Equal(t, "billing_saga", trigger.calls[0].SagaName)
+}
+
+func TestSagaDispatchHandler_CorrelationIDFromMetadata(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "test_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger)
+
+	event := newTestEvent(t, map[string]any{"id": "1"})
+	err = h.Handle(context.Background(), "orders", event, map[string]string{
+		"x-correlation-id": "my-unique-corr-id",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 1)
+	assert.Equal(t, "my-unique-corr-id", trigger.calls[0].IdempotencyKey)
+}
+
+func TestSagaDispatchHandler_NoCorrelationID_GeneratesKey(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "test_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger)
+
+	event := newTestEvent(t, map[string]any{"id": "1"})
+	err = h.Handle(context.Background(), "orders", event, map[string]string{})
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 1)
+	assert.NotEmpty(t, trigger.calls[0].IdempotencyKey, "should generate an idempotency key when correlation_id missing")
+}
+
+func TestSagaDispatchHandler_InputDataContainsEventAndMetadata(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "test_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger)
+
+	event := newTestEvent(t, map[string]any{"order_id": "ord-42"})
+	metadata := map[string]string{
+		"x-correlation-id": "corr-14",
+		"source":           "test",
+	}
+	err = h.Handle(context.Background(), "orders", event, metadata)
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 1)
+
+	inputData := trigger.calls[0].InputData
+	assert.Contains(t, inputData, "event")
+	assert.Contains(t, inputData, "metadata")
+}


### PR DESCRIPTION
## Summary

Implements the event-router saga dispatch handler (032-event-driven-saga task 7) that:

- Evaluates precompiled CEL filters against incoming events and triggers matching sagas via the SagaTrigger gRPC port
- Enforces chain depth limits to prevent infinite saga chains (configurable, default 10)
- Handles CEL filter evaluation errors gracefully — skips the failing saga, continues processing others
- Uses correlation ID from metadata as idempotency key (generates UUID if absent)
- Converts events to `input_data` maps using `saga.EventToInputData` for Starlark script consumption

## Changes Made

- **`services/event-router/internal/handlers/saga_dispatch_handler.go`** — `SagaDispatchHandler` struct implementing `domain.EventHandler` interface with `Handle` method that orchestrates registry lookup, CEL filter evaluation, chain depth enforcement, and saga triggering
- **`services/event-router/internal/handlers/saga_dispatch_handler_test.go`** — 18 unit tests covering: matching/non-matching filters, nil filters (always match), multiple sagas on same channel, chain depth enforcement (exceeded/at-limit/below/missing/invalid), CEL filter errors, trigger errors, nil events, metadata-based filters, correlation ID extraction, and input_data structure

## Test Plan

- [x] Event with matching CEL filter triggers saga execution
- [x] Event with non-matching filter skips saga
- [x] Multiple sagas on same channel: all matching ones execute
- [x] CEL filter error: saga skipped, others continue
- [x] Chain depth exceeded: event dropped with warning
- [x] Chain depth at limit: event dropped
- [x] Chain depth below limit: saga executes
- [x] Chain depth missing/invalid in metadata: defaults to 0
- [x] No sagas registered for channel: no-op
- [x] Nil filter program: saga always executes
- [x] Nil event: returns error
- [x] Trigger error: propagated to caller
- [x] Metadata-based CEL filter evaluation
- [x] Correlation ID used as idempotency key
- [x] Missing correlation ID generates UUID
- [x] Input data contains event and metadata keys