### PR TITLE
feat(event-router): Add observability and monitoring for saga dispatch

### DIFF
--- a/deployments/grafana/dashboards/event-router-saga-dispatch.json
+++ b/deployments/grafana/dashboards/event-router-saga-dispatch.json
@@ -1,0 +1,209 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Event Router Saga Dispatch - Event rates, CEL filter latency, chain depth violations, and duplicate detection.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "Event Throughput",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2 },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "sum by (channel) (rate(meridian_event_router_events_received_total[$__rate_interval]))",
+          "legendFormat": "channel={{channel}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Events Received Rate (by channel)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2 },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "sum by (saga_name, channel) (rate(meridian_event_router_sagas_triggered_total[$__rate_interval]))",
+          "legendFormat": "saga={{saga_name}} channel={{channel}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Sagas Triggered Rate (by saga and channel)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "id": 10,
+      "title": "CEL Filter Evaluation Latency",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2 },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 10 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, saga_name) (rate(meridian_event_router_filter_evaluation_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p50 {{saga_name}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, saga_name) (rate(meridian_event_router_filter_evaluation_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p95 {{saga_name}}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, saga_name) (rate(meridian_event_router_filter_evaluation_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p99 {{saga_name}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Filter Evaluation Latency p50/p95/p99 (per saga)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 },
+      "id": 20,
+      "title": "Safety and Reliability",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 19 },
+      "id": 21,
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "increase(meridian_event_router_chain_depth_exceeded_total[$__rate_interval])",
+          "legendFormat": "chain depth exceeded",
+          "refId": "A"
+        }
+      ],
+      "title": "Chain Depth Exceeded (events dropped)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 19 },
+      "id": 22,
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "sum by (saga_name) (increase(meridian_event_router_duplicate_events_total[$__rate_interval]))",
+          "legendFormat": "{{saga_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Duplicate Events Detected (by saga)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["event-router", "saga-dispatch", "meridian"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Event Router - Saga Dispatch",
+  "uid": "event-router-saga-dispatch",
+  "version": 1
+}

--- a/deployments/prometheus/alerts/event-router-saga-dispatch.yml
+++ b/deployments/prometheus/alerts/event-router-saga-dispatch.yml
@@ -53,7 +53,8 @@ groups:
           summary: "High CEL filter evaluation latency (p99 > 10ms) for saga {{ $labels.saga_name }}"
           description: |
             CEL filter evaluation p99 latency is {{ $value | humanizeDuration }} for saga {{ $labels.saga_name }}.
-            CEL filters should complete in < 1ms. Complex expressions may need simplification.
+            CEL filters should complete in < 10ms. Sustained p99 above this threshold may indicate overly complex expressions.
+            Consider simplifying the filter or pre-computing expensive lookups.
           runbook_url: "https://docs.meridian.io/runbooks/event-router-filter-latency"
 
       # =============================================================================

--- a/deployments/prometheus/alerts/event-router-saga-dispatch.yml
+++ b/deployments/prometheus/alerts/event-router-saga-dispatch.yml
@@ -1,0 +1,134 @@
+# Event Router Saga Dispatch Alert Rules
+#
+# These alerts monitor the event-router's saga dispatch pipeline:
+# - Filter evaluation latency
+# - Chain depth limit violations
+# - Saga execution failures
+#
+# Metrics namespace: meridian_event_router_*
+
+groups:
+  - name: event_router_saga_dispatch
+    interval: 30s
+    rules:
+      # =============================================================================
+      # FILTER EVALUATION ALERTS
+      # =============================================================================
+
+      # High CEL filter error rate — sagas are being skipped due to evaluation errors.
+      # Filter errors indicate invalid saga filter expressions in the manifest.
+      - alert: EventRouterFilterErrorRateHigh
+        expr: |
+          (
+            sum(rate(meridian_event_router_filter_evaluation_errors_total[5m]))
+            / clamp_min(sum(rate(meridian_event_router_events_received_total[5m])), 0.0001)
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+          service: event-router
+          category: saga_dispatch
+        annotations:
+          summary: "High CEL filter error rate in event-router"
+          description: |
+            CEL filter evaluation is failing at {{ $value | humanizePercentage }} of events.
+            Sagas with broken filters are being skipped silently.
+            Check saga definitions in the manifest for invalid CEL expressions.
+          runbook_url: "https://docs.meridian.io/runbooks/event-router-filter-errors"
+
+      # Elevated filter evaluation latency p99 — CEL expressions may be too complex.
+      - alert: EventRouterFilterLatencyHigh
+        expr: |
+          histogram_quantile(0.99,
+            sum by (le, saga_name) (
+              rate(meridian_event_router_filter_evaluation_duration_seconds_bucket[5m])
+            )
+          ) > 0.010
+        for: 5m
+        labels:
+          severity: warning
+          service: event-router
+          category: performance
+        annotations:
+          summary: "High CEL filter evaluation latency (p99 > 10ms) for saga {{ $labels.saga_name }}"
+          description: |
+            CEL filter evaluation p99 latency is {{ $value | humanizeDuration }} for saga {{ $labels.saga_name }}.
+            CEL filters should complete in < 1ms. Complex expressions may need simplification.
+          runbook_url: "https://docs.meridian.io/runbooks/event-router-filter-latency"
+
+      # =============================================================================
+      # CHAIN DEPTH ALERTS
+      # =============================================================================
+
+      # Sustained chain depth violations — potential infinite saga loop.
+      # A small number of chain depth exceeded events is expected in normal operation.
+      # A sustained spike indicates a saga is triggering itself or forming a cycle.
+      - alert: EventRouterChainDepthSpikeDetected
+        expr: |
+          rate(meridian_event_router_chain_depth_exceeded_total[5m]) > 0.1
+        for: 5m
+        labels:
+          severity: critical
+          service: event-router
+          category: saga_dispatch
+        annotations:
+          summary: "Sustained saga chain depth limit violations in event-router"
+          description: |
+            Events are being dropped at {{ $value }} chain-depth-exceeded/second.
+            This may indicate an infinite saga chain loop where a saga is triggering itself.
+            Immediate investigation required to identify the cyclic saga dependency.
+          runbook_url: "https://docs.meridian.io/runbooks/event-router-chain-depth"
+
+      # =============================================================================
+      # SAGA EXECUTION FAILURE ALERTS
+      # =============================================================================
+
+      # Saga trigger failures — infrastructure-level failures prevent saga execution.
+      - alert: EventRouterSagaTriggerFailureRateHigh
+        expr: |
+          (
+            sum(rate(meridian_event_router_saga_trigger_failures_total[5m]))
+            / clamp_min(sum(rate(meridian_event_router_sagas_triggered_total[5m])), 0.0001)
+          ) > 0.01
+        for: 5m
+        labels:
+          severity: critical
+          service: event-router
+          category: saga_dispatch
+        annotations:
+          summary: "High saga trigger failure rate in event-router"
+          description: |
+            Saga trigger failures are at {{ $value | humanizePercentage }} of trigger attempts.
+            Events matching saga filters are failing to start saga execution.
+            Check saga-runner connectivity and gRPC health.
+          runbook_url: "https://docs.meridian.io/runbooks/event-router-saga-failures"
+
+  - name: event_router_saga_dispatch_slo
+    interval: 60s
+    rules:
+      # Record event routing rate for SLO dashboards.
+      - record: event_router:events_received:rate5m
+        expr: sum(rate(meridian_event_router_events_received_total[5m]))
+
+      # Record saga trigger success rate.
+      - record: event_router:sagas_triggered:rate5m
+        expr: sum(rate(meridian_event_router_sagas_triggered_total[5m]))
+
+      # Record filter evaluation p50/p95/p99 latency.
+      - record: event_router:filter_latency_p50:5m
+        expr: |
+          histogram_quantile(0.50,
+            sum by (le) (rate(meridian_event_router_filter_evaluation_duration_seconds_bucket[5m]))
+          )
+
+      - record: event_router:filter_latency_p95:5m
+        expr: |
+          histogram_quantile(0.95,
+            sum by (le) (rate(meridian_event_router_filter_evaluation_duration_seconds_bucket[5m]))
+          )
+
+      - record: event_router:filter_latency_p99:5m
+        expr: |
+          histogram_quantile(0.99,
+            sum by (le) (rate(meridian_event_router_filter_evaluation_duration_seconds_bucket[5m]))
+          )

--- a/services/event-router/adapters/grpc/saga_trigger_client.go
+++ b/services/event-router/adapters/grpc/saga_trigger_client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/event-router/internal/observability"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
 	"google.golang.org/grpc"
@@ -160,6 +161,7 @@ func (c *SagaTriggerClient) TriggerSaga(ctx context.Context, sagaName string, in
 		sagaID = resp.GetSagaId()
 
 		if resp.GetWasDuplicate() {
+			observability.RecordDuplicateEvent(sagaName)
 			c.logger.Debug("saga trigger was duplicate, returning existing instance",
 				"saga_name", sagaName,
 				"saga_id", sagaID,

--- a/services/event-router/internal/handlers/saga_dispatch_handler.go
+++ b/services/event-router/internal/handlers/saga_dispatch_handler.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/event-router/domain"
+	"github.com/meridianhub/meridian/services/event-router/internal/observability"
 	"github.com/meridianhub/meridian/services/event-router/internal/registry"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"google.golang.org/protobuf/proto"
@@ -91,6 +93,9 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 		return ErrHandlerNotInitialized
 	}
 
+	// Record event received at handler entry.
+	observability.RecordEventReceived(channel)
+
 	// Convert event to input_data (also validates event is non-nil).
 	inputData, err := saga.EventToInputData(event, metadata)
 	if err != nil {
@@ -99,11 +104,15 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 
 	// Check chain depth.
 	depth := extractChainDepth(metadata)
+	correlationID := extractCorrelationID(metadata)
+
 	if depth >= h.maxChainDepth {
+		observability.RecordChainDepthExceeded()
 		h.logger.WarnContext(ctx, "chain depth exceeded, dropping event",
 			"channel", channel,
 			"chain_depth", depth,
 			"max_chain_depth", h.maxChainDepth,
+			"correlation_id", correlationID,
 		)
 		return nil
 	}
@@ -121,7 +130,7 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 		"metadata": metadata,
 	}
 
-	idempotencyKey := extractCorrelationID(metadata)
+	idempotencyKey := correlationID
 	if idempotencyKey == "" {
 		idempotencyKey = uuid.New().String()
 		h.logger.WarnContext(ctx, "no correlation ID in metadata, generated UUID as idempotency key — Kafka redelivery may cause duplicate saga executions",
@@ -138,19 +147,27 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 			if _, err := h.sagaTrigger.TriggerSaga(ctx, sagaName, inputData, idempotencyKey); err != nil {
 				return fmt.Errorf("trigger saga %q: %w", sagaName, err)
 			}
-			h.logger.DebugContext(ctx, "saga triggered (no filter)",
+			observability.RecordSagaTriggered(sagaName, channel)
+			h.logger.InfoContext(ctx, "saga triggered",
 				"saga_name", sagaName,
 				"channel", channel,
+				"correlation_id", idempotencyKey,
+				"chain_depth", depth,
+				"filter_matched", false,
 			)
 			continue
 		}
 
-		// Evaluate CEL filter.
+		// Evaluate CEL filter, recording duration.
+		filterStart := time.Now()
 		out, _, evalErr := cs.FilterProgram.Eval(activation)
+		observability.RecordFilterEvaluationDuration(sagaName, time.Since(filterStart).Seconds())
+
 		if evalErr != nil {
-			h.logger.WarnContext(ctx, "CEL filter evaluation error, skipping saga",
+			h.logger.ErrorContext(ctx, "CEL filter evaluation error, skipping saga",
 				"saga_name", sagaName,
 				"channel", channel,
+				"correlation_id", idempotencyKey,
 				"error", evalErr,
 			)
 			continue
@@ -161,6 +178,7 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 			h.logger.WarnContext(ctx, "CEL filter returned non-boolean, skipping saga",
 				"saga_name", sagaName,
 				"channel", channel,
+				"correlation_id", idempotencyKey,
 				"result_type", fmt.Sprintf("%T", out.Value()),
 			)
 			continue
@@ -170,6 +188,7 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 			h.logger.DebugContext(ctx, "CEL filter did not match, skipping saga",
 				"saga_name", sagaName,
 				"channel", channel,
+				"correlation_id", idempotencyKey,
 			)
 			continue
 		}
@@ -177,9 +196,13 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 		if _, err := h.sagaTrigger.TriggerSaga(ctx, sagaName, inputData, idempotencyKey); err != nil {
 			return fmt.Errorf("trigger saga %q: %w", sagaName, err)
 		}
-		h.logger.DebugContext(ctx, "saga triggered",
+		observability.RecordSagaTriggered(sagaName, channel)
+		h.logger.InfoContext(ctx, "saga triggered",
 			"saga_name", sagaName,
 			"channel", channel,
+			"correlation_id", idempotencyKey,
+			"chain_depth", depth,
+			"filter_matched", true,
 		)
 	}
 

--- a/services/event-router/internal/handlers/saga_dispatch_handler.go
+++ b/services/event-router/internal/handlers/saga_dispatch_handler.go
@@ -145,6 +145,7 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 		// If no filter, the saga always matches.
 		if cs.FilterProgram == nil {
 			if _, err := h.sagaTrigger.TriggerSaga(ctx, sagaName, inputData, idempotencyKey); err != nil {
+				observability.RecordSagaTriggerFailure(sagaName, channel)
 				return fmt.Errorf("trigger saga %q: %w", sagaName, err)
 			}
 			observability.RecordSagaTriggered(sagaName, channel)
@@ -164,6 +165,7 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 		observability.RecordFilterEvaluationDuration(sagaName, time.Since(filterStart).Seconds())
 
 		if evalErr != nil {
+			observability.RecordFilterEvaluationError(sagaName)
 			h.logger.ErrorContext(ctx, "CEL filter evaluation error, skipping saga",
 				"saga_name", sagaName,
 				"channel", channel,
@@ -194,6 +196,7 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 		}
 
 		if _, err := h.sagaTrigger.TriggerSaga(ctx, sagaName, inputData, idempotencyKey); err != nil {
+			observability.RecordSagaTriggerFailure(sagaName, channel)
 			return fmt.Errorf("trigger saga %q: %w", sagaName, err)
 		}
 		observability.RecordSagaTriggered(sagaName, channel)

--- a/services/event-router/internal/observability/metrics.go
+++ b/services/event-router/internal/observability/metrics.go
@@ -1,0 +1,105 @@
+// Package observability provides Prometheus metrics for the event-router saga dispatch pipeline.
+//
+// Namespace: "meridian", Subsystem: "event_router"
+//
+// Metrics:
+//   - events_received_total (counter, label: channel) — events entering the dispatch handler
+//   - sagas_triggered_total (counter, labels: saga_name, channel) — successful saga triggers
+//   - filter_evaluation_duration_seconds (histogram, label: saga_name) — CEL evaluation latency
+//   - chain_depth_exceeded_total (counter) — events dropped due to chain-depth limit
+//   - duplicate_events_total (counter, label: saga_name) — idempotency key collisions
+package observability
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// eventsReceivedTotal counts all events entering the saga dispatch handler.
+	// Label: channel — the event channel (e.g., "payments", "accounts").
+	eventsReceivedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "meridian",
+			Subsystem: "event_router",
+			Name:      "events_received_total",
+			Help:      "Total number of events received by the saga dispatch handler",
+		},
+		[]string{"channel"},
+	)
+
+	// sagasTriggeredTotal counts successful saga trigger calls.
+	// Labels: saga_name — the saga definition name; channel — the event channel.
+	sagasTriggeredTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "meridian",
+			Subsystem: "event_router",
+			Name:      "sagas_triggered_total",
+			Help:      "Total number of sagas successfully triggered by the dispatch handler",
+		},
+		[]string{"saga_name", "channel"},
+	)
+
+	// filterEvaluationDuration tracks per-saga CEL filter evaluation latency.
+	// Label: saga_name — the saga whose filter was evaluated.
+	// Buckets cover the expected sub-millisecond to low-millisecond range.
+	filterEvaluationDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "meridian",
+			Subsystem: "event_router",
+			Name:      "filter_evaluation_duration_seconds",
+			Help:      "Duration of CEL filter evaluation per saga in seconds",
+			Buckets:   []float64{.0001, .0005, .001, .005, .01, .025, .05, .1, .25},
+		},
+		[]string{"saga_name"},
+	)
+
+	// chainDepthExceededTotal counts events dropped because the saga chain depth
+	// reached or exceeded the configured maximum.
+	chainDepthExceededTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "meridian",
+			Subsystem: "event_router",
+			Name:      "chain_depth_exceeded_total",
+			Help:      "Total number of events dropped due to saga chain depth limit",
+		},
+	)
+
+	// duplicateEventsTotal counts saga trigger calls that were rejected as duplicates
+	// by the idempotency key check.
+	// Label: saga_name — the saga for which the duplicate was detected.
+	duplicateEventsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "meridian",
+			Subsystem: "event_router",
+			Name:      "duplicate_events_total",
+			Help:      "Total number of duplicate saga trigger attempts detected by idempotency key",
+		},
+		[]string{"saga_name"},
+	)
+)
+
+// RecordEventReceived increments the events received counter for the given channel.
+func RecordEventReceived(channel string) {
+	eventsReceivedTotal.WithLabelValues(channel).Inc()
+}
+
+// RecordSagaTriggered increments the sagas triggered counter.
+func RecordSagaTriggered(sagaName, channel string) {
+	sagasTriggeredTotal.WithLabelValues(sagaName, channel).Inc()
+}
+
+// RecordFilterEvaluationDuration observes the CEL filter evaluation duration for a saga.
+func RecordFilterEvaluationDuration(sagaName string, durationSeconds float64) {
+	filterEvaluationDuration.WithLabelValues(sagaName).Observe(durationSeconds)
+}
+
+// RecordChainDepthExceeded increments the chain depth exceeded counter.
+func RecordChainDepthExceeded() {
+	chainDepthExceededTotal.Inc()
+}
+
+// RecordDuplicateEvent increments the duplicate events counter for the given saga.
+func RecordDuplicateEvent(sagaName string) {
+	duplicateEventsTotal.WithLabelValues(sagaName).Inc()
+}

--- a/services/event-router/internal/observability/metrics.go
+++ b/services/event-router/internal/observability/metrics.go
@@ -6,8 +6,10 @@
 //   - events_received_total (counter, label: channel) — events entering the dispatch handler
 //   - sagas_triggered_total (counter, labels: saga_name, channel) — successful saga triggers
 //   - filter_evaluation_duration_seconds (histogram, label: saga_name) — CEL evaluation latency
+//   - filter_evaluation_errors_total (counter, label: saga_name) — CEL evaluation failures
 //   - chain_depth_exceeded_total (counter) — events dropped due to chain-depth limit
-//   - duplicate_events_total (counter, label: saga_name) — idempotency key collisions
+//   - saga_trigger_failures_total (counter, labels: saga_name, channel) — trigger infrastructure failures
+//   - duplicate_events_total (counter, label: saga_name) — idempotency key collisions (reported by gRPC client)
 package observability
 
 import (
@@ -54,6 +56,19 @@ var (
 		[]string{"saga_name"},
 	)
 
+	// filterEvaluationErrorsTotal counts CEL filter evaluation failures.
+	// A non-zero rate indicates saga definitions contain invalid filter expressions.
+	// Label: saga_name — the saga whose filter failed to evaluate.
+	filterEvaluationErrorsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "meridian",
+			Subsystem: "event_router",
+			Name:      "filter_evaluation_errors_total",
+			Help:      "Total number of CEL filter evaluation errors (saga skipped on error)",
+		},
+		[]string{"saga_name"},
+	)
+
 	// chainDepthExceededTotal counts events dropped because the saga chain depth
 	// reached or exceeded the configured maximum.
 	chainDepthExceededTotal = promauto.NewCounter(
@@ -65,15 +80,30 @@ var (
 		},
 	)
 
-	// duplicateEventsTotal counts saga trigger calls that were rejected as duplicates
-	// by the idempotency key check.
+	// sagaTriggerFailuresTotal counts saga trigger calls that returned an error
+	// after all retries. These are infrastructure-level failures (gRPC errors).
+	// Labels: saga_name — the saga that failed to trigger; channel — the event channel.
+	sagaTriggerFailuresTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "meridian",
+			Subsystem: "event_router",
+			Name:      "saga_trigger_failures_total",
+			Help:      "Total number of saga trigger failures after all retries exhausted",
+		},
+		[]string{"saga_name", "channel"},
+	)
+
+	// duplicateEventsTotal counts saga trigger calls where the control-plane
+	// responded with WasDuplicate=true (idempotency key already seen).
+	// This counter is incremented by the gRPC adapter, not the dispatch handler,
+	// because duplicate detection happens inside TriggerSaga after all retries.
 	// Label: saga_name — the saga for which the duplicate was detected.
 	duplicateEventsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "meridian",
 			Subsystem: "event_router",
 			Name:      "duplicate_events_total",
-			Help:      "Total number of duplicate saga trigger attempts detected by idempotency key",
+			Help:      "Total number of saga trigger attempts that were idempotency duplicates",
 		},
 		[]string{"saga_name"},
 	)
@@ -94,12 +124,26 @@ func RecordFilterEvaluationDuration(sagaName string, durationSeconds float64) {
 	filterEvaluationDuration.WithLabelValues(sagaName).Observe(durationSeconds)
 }
 
+// RecordFilterEvaluationError increments the filter evaluation error counter for a saga.
+// Called when CEL evaluation returns an error (saga is skipped, not retried).
+func RecordFilterEvaluationError(sagaName string) {
+	filterEvaluationErrorsTotal.WithLabelValues(sagaName).Inc()
+}
+
 // RecordChainDepthExceeded increments the chain depth exceeded counter.
 func RecordChainDepthExceeded() {
 	chainDepthExceededTotal.Inc()
 }
 
+// RecordSagaTriggerFailure increments the saga trigger failure counter.
+// Called when TriggerSaga returns a non-nil error after all retries are exhausted.
+func RecordSagaTriggerFailure(sagaName, channel string) {
+	sagaTriggerFailuresTotal.WithLabelValues(sagaName, channel).Inc()
+}
+
 // RecordDuplicateEvent increments the duplicate events counter for the given saga.
+// This should be called by the gRPC adapter when the control-plane responds with
+// WasDuplicate=true, not by the dispatch handler directly.
 func RecordDuplicateEvent(sagaName string) {
 	duplicateEventsTotal.WithLabelValues(sagaName).Inc()
 }

--- a/services/event-router/internal/observability/metrics_test.go
+++ b/services/event-router/internal/observability/metrics_test.go
@@ -1,0 +1,65 @@
+package observability
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRecordEventReceived(t *testing.T) {
+	eventsReceivedTotal.Reset()
+
+	RecordEventReceived("payments")
+	RecordEventReceived("payments")
+	RecordEventReceived("accounts")
+
+	if got := testutil.ToFloat64(eventsReceivedTotal.WithLabelValues("payments")); got != 2.0 {
+		t.Errorf("payments count = %v, want 2.0", got)
+	}
+	if got := testutil.ToFloat64(eventsReceivedTotal.WithLabelValues("accounts")); got != 1.0 {
+		t.Errorf("accounts count = %v, want 1.0", got)
+	}
+}
+
+func TestRecordSagaTriggered(t *testing.T) {
+	sagasTriggeredTotal.Reset()
+
+	RecordSagaTriggered("payment_saga", "payments")
+	RecordSagaTriggered("payment_saga", "payments")
+	RecordSagaTriggered("account_saga", "accounts")
+
+	if got := testutil.ToFloat64(sagasTriggeredTotal.WithLabelValues("payment_saga", "payments")); got != 2.0 {
+		t.Errorf("payment_saga/payments count = %v, want 2.0", got)
+	}
+	if got := testutil.ToFloat64(sagasTriggeredTotal.WithLabelValues("account_saga", "accounts")); got != 1.0 {
+		t.Errorf("account_saga/accounts count = %v, want 1.0", got)
+	}
+}
+
+func TestRecordFilterEvaluationDuration(_ *testing.T) {
+	// Smoke test: verify no panic on observation.
+	RecordFilterEvaluationDuration("payment_saga", 0.001)
+	RecordFilterEvaluationDuration("payment_saga", 0.005)
+}
+
+func TestRecordChainDepthExceeded(t *testing.T) {
+	// Reset via re-registration is not possible with promauto; use a fresh counter
+	// name to isolate. Instead we read the current value and verify increment.
+	before := testutil.ToFloat64(chainDepthExceededTotal)
+	RecordChainDepthExceeded()
+	after := testutil.ToFloat64(chainDepthExceededTotal)
+	if after-before != 1.0 {
+		t.Errorf("chainDepthExceededTotal delta = %v, want 1.0", after-before)
+	}
+}
+
+func TestRecordDuplicateEvent(t *testing.T) {
+	duplicateEventsTotal.Reset()
+
+	RecordDuplicateEvent("idempotent_saga")
+	RecordDuplicateEvent("idempotent_saga")
+
+	if got := testutil.ToFloat64(duplicateEventsTotal.WithLabelValues("idempotent_saga")); got != 2.0 {
+		t.Errorf("idempotent_saga duplicate count = %v, want 2.0", got)
+	}
+}

--- a/services/event-router/internal/observability/metrics_test.go
+++ b/services/event-router/internal/observability/metrics_test.go
@@ -42,14 +42,35 @@ func TestRecordFilterEvaluationDuration(_ *testing.T) {
 	RecordFilterEvaluationDuration("payment_saga", 0.005)
 }
 
+func TestRecordFilterEvaluationError(t *testing.T) {
+	filterEvaluationErrorsTotal.Reset()
+
+	RecordFilterEvaluationError("broken_saga")
+	RecordFilterEvaluationError("broken_saga")
+
+	if got := testutil.ToFloat64(filterEvaluationErrorsTotal.WithLabelValues("broken_saga")); got != 2.0 {
+		t.Errorf("broken_saga filter error count = %v, want 2.0", got)
+	}
+}
+
 func TestRecordChainDepthExceeded(t *testing.T) {
-	// Reset via re-registration is not possible with promauto; use a fresh counter
-	// name to isolate. Instead we read the current value and verify increment.
+	// Cannot reset a promauto.NewCounter — read delta instead.
 	before := testutil.ToFloat64(chainDepthExceededTotal)
 	RecordChainDepthExceeded()
 	after := testutil.ToFloat64(chainDepthExceededTotal)
 	if after-before != 1.0 {
 		t.Errorf("chainDepthExceededTotal delta = %v, want 1.0", after-before)
+	}
+}
+
+func TestRecordSagaTriggerFailure(t *testing.T) {
+	sagaTriggerFailuresTotal.Reset()
+
+	RecordSagaTriggerFailure("failing_saga", "payments")
+	RecordSagaTriggerFailure("failing_saga", "payments")
+
+	if got := testutil.ToFloat64(sagaTriggerFailuresTotal.WithLabelValues("failing_saga", "payments")); got != 2.0 {
+		t.Errorf("failing_saga trigger failure count = %v, want 2.0", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `services/event-router/internal/observability` package with Prometheus metrics for the saga dispatch pipeline (event receipt, saga triggers, CEL filter latency, chain depth exceeded, duplicate events)
- Instruments `SagaDispatchHandler` to record metrics at all key decision points
- Upgrades saga trigger log level from `Debug` to `Info` with structured fields (`correlation_id`, `chain_depth`, `filter_matched`)
- Upgrades CEL filter evaluation errors from `Warn` to `Error` level
- Adds Prometheus alert rules for filter error rate, filter p99 latency, chain depth spikes, and saga trigger failures
- Adds Grafana dashboard for event rates, filter latency p50/p95/p99, chain depth violations, and duplicate detection

## Changes Made

| File | Change |
|------|--------|
| `services/event-router/internal/observability/metrics.go` | New — Prometheus metrics (promauto, namespace: `meridian`, subsystem: `event_router`) |
| `services/event-router/internal/observability/metrics_test.go` | New — Unit tests for all Record* functions |
| `services/event-router/internal/handlers/saga_dispatch_handler.go` | Modified — metric recording and structured log enrichment |
| `deployments/prometheus/alerts/event-router-saga-dispatch.yml` | New — Alert rules for filter errors, latency, chain depth, trigger failures |
| `deployments/grafana/dashboards/event-router-saga-dispatch.json` | New — Dashboard with event rates, filter latency, chain depth, duplicates |

## Metrics Added

| Metric | Type | Labels |
|--------|------|--------|
| `meridian_event_router_events_received_total` | Counter | `channel` |
| `meridian_event_router_sagas_triggered_total` | Counter | `saga_name`, `channel` |
| `meridian_event_router_filter_evaluation_duration_seconds` | Histogram | `saga_name` |
| `meridian_event_router_chain_depth_exceeded_total` | Counter | — |
| `meridian_event_router_duplicate_events_total` | Counter | `saga_name` |

## Test Plan

- [x] `go test ./services/event-router/internal/...` — all packages pass
- [x] `golangci-lint` — 0 issues
- [x] `gofumpt` — no formatting changes needed
- [x] `/metrics` endpoint already registered in `cmd/main.go` — no wiring changes needed

## Deployment Notes

Alert rules reference metrics that are registered via `promauto` at startup — no additional Prometheus scrape configuration is required beyond the existing `/metrics` endpoint. Grafana dashboard uses the standard `prometheus` datasource template variable.