### PR TITLE
feat(event-router): implement idempotency store for event-triggered sagas

### DIFF
--- a/services/event-router/internal/correlation/extractor.go
+++ b/services/event-router/internal/correlation/extractor.go
@@ -1,0 +1,107 @@
+// Package correlation provides utilities for extracting and tracking correlation IDs
+// from Kafka message headers and domain events.
+package correlation
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/gateway/eventstream"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Source indicates how the correlation ID was obtained.
+type Source string
+
+const (
+	// SourceEvent means the correlation ID came from DomainEvent.CorrelationID.
+	SourceEvent Source = "event"
+
+	// SourceHeader means the correlation ID came from a Kafka message header.
+	SourceHeader Source = "header"
+
+	// SourceEventID means the correlation ID fell back to DomainEvent.EventID.
+	SourceEventID Source = "event_id"
+
+	// SourceGenerated means a UUID was generated as a last resort.
+	SourceGenerated Source = "generated"
+)
+
+// Known header keys for correlation ID, checked in priority order.
+var correlationIDHeaders = []string{
+	"correlation_id",
+	"x-correlation-id",
+	"X-Correlation-ID",
+	"correlationId",
+}
+
+// extractionCounter tracks how correlation IDs are being sourced.
+var extractionCounter = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "event_router",
+		Subsystem: "correlation",
+		Name:      "id_extraction_total",
+		Help:      "Total number of correlation ID extractions by source.",
+	},
+	[]string{"source"},
+)
+
+// Extractor extracts correlation IDs from domain events and Kafka headers.
+type Extractor struct{}
+
+// NewExtractor creates a new correlation ID extractor.
+func NewExtractor() *Extractor {
+	return &Extractor{}
+}
+
+// Extract returns the best correlation ID available, following the fallback chain:
+//  1. event.CorrelationID (primary)
+//  2. Kafka headers: correlation_id → x-correlation-id → X-Correlation-ID → correlationId
+//  3. event.EventID
+//  4. Generated UUID (last resort)
+//
+// The second return value indicates how the correlation ID was obtained.
+func (e *Extractor) Extract(_ context.Context, event *eventstream.DomainEvent, headers map[string]string) (string, Source) {
+	// Primary: DomainEvent.CorrelationID
+	if event != nil && event.CorrelationID != "" {
+		extractionCounter.WithLabelValues(string(SourceEvent)).Inc()
+		return event.CorrelationID, SourceEvent
+	}
+
+	// Fallback 1: Kafka message headers
+	for _, key := range correlationIDHeaders {
+		if val, ok := headers[key]; ok && val != "" {
+			extractionCounter.WithLabelValues(string(SourceHeader)).Inc()
+			return val, SourceHeader
+		}
+	}
+
+	// Fallback 2: DomainEvent.EventID
+	if event != nil && event.EventID != "" {
+		extractionCounter.WithLabelValues(string(SourceEventID)).Inc()
+		return event.EventID, SourceEventID
+	}
+
+	// Last resort: generate UUID
+	extractionCounter.WithLabelValues(string(SourceGenerated)).Inc()
+	return uuid.New().String(), SourceGenerated
+}
+
+// ExtractFromMetadata extracts a correlation ID from metadata headers only
+// (no DomainEvent). Used when only the metadata map is available (e.g., in proto-based handlers).
+//
+// Fallback chain:
+//  1. Kafka headers: correlation_id → x-correlation-id → X-Correlation-ID → correlationId
+//  2. Generated UUID
+func ExtractFromMetadata(headers map[string]string) (string, Source) {
+	for _, key := range correlationIDHeaders {
+		if val, ok := headers[key]; ok && val != "" {
+			extractionCounter.WithLabelValues(string(SourceHeader)).Inc()
+			return val, SourceHeader
+		}
+	}
+
+	extractionCounter.WithLabelValues(string(SourceGenerated)).Inc()
+	return uuid.New().String(), SourceGenerated
+}

--- a/services/event-router/internal/correlation/extractor_test.go
+++ b/services/event-router/internal/correlation/extractor_test.go
@@ -1,0 +1,143 @@
+package correlation_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/event-router/internal/correlation"
+	"github.com/meridianhub/meridian/services/gateway/eventstream"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractor_PrimarySource_DomainEventCorrelationID(t *testing.T) {
+	e := correlation.NewExtractor()
+	event := &eventstream.DomainEvent{
+		CorrelationID: "corr-from-event",
+		EventID:       "event-id-1",
+	}
+	headers := map[string]string{
+		"correlation_id": "corr-from-header",
+	}
+
+	id, src := e.Extract(context.Background(), event, headers)
+
+	assert.Equal(t, "corr-from-event", id)
+	assert.Equal(t, correlation.SourceEvent, src)
+}
+
+func TestExtractor_FallbackToHeader_WhenEventCorrelationIDEmpty(t *testing.T) {
+	e := correlation.NewExtractor()
+	event := &eventstream.DomainEvent{
+		CorrelationID: "",
+		EventID:       "event-id-2",
+	}
+
+	tests := []struct {
+		name       string
+		headerKey  string
+		headerVal  string
+		wantSource correlation.Source
+	}{
+		{"correlation_id header", "correlation_id", "corr-1", correlation.SourceHeader},
+		{"x-correlation-id header", "x-correlation-id", "corr-2", correlation.SourceHeader},
+		{"X-Correlation-ID header", "X-Correlation-ID", "corr-3", correlation.SourceHeader},
+		{"correlationId header", "correlationId", "corr-4", correlation.SourceHeader},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			headers := map[string]string{tc.headerKey: tc.headerVal}
+			id, src := e.Extract(context.Background(), event, headers)
+			assert.Equal(t, tc.headerVal, id)
+			assert.Equal(t, tc.wantSource, src)
+		})
+	}
+}
+
+func TestExtractor_HeaderPriority_FirstMatchWins(t *testing.T) {
+	e := correlation.NewExtractor()
+	event := &eventstream.DomainEvent{CorrelationID: ""}
+	// Both correlation_id and x-correlation-id present — correlation_id should win
+	headers := map[string]string{
+		"correlation_id":   "first-wins",
+		"x-correlation-id": "second",
+	}
+
+	id, src := e.Extract(context.Background(), event, headers)
+
+	assert.Equal(t, "first-wins", id)
+	assert.Equal(t, correlation.SourceHeader, src)
+}
+
+func TestExtractor_FallbackToEventID(t *testing.T) {
+	e := correlation.NewExtractor()
+	event := &eventstream.DomainEvent{
+		CorrelationID: "",
+		EventID:       "fallback-event-id",
+	}
+	headers := map[string]string{} // No correlation headers
+
+	id, src := e.Extract(context.Background(), event, headers)
+
+	assert.Equal(t, "fallback-event-id", id)
+	assert.Equal(t, correlation.SourceEventID, src)
+}
+
+func TestExtractor_FallbackToGenerated_WhenNoEventOrHeaders(t *testing.T) {
+	e := correlation.NewExtractor()
+
+	id, src := e.Extract(context.Background(), nil, nil)
+
+	assert.NotEmpty(t, id)
+	assert.Equal(t, correlation.SourceGenerated, src)
+}
+
+func TestExtractor_FallbackToGenerated_WhenEventEmpty(t *testing.T) {
+	e := correlation.NewExtractor()
+	event := &eventstream.DomainEvent{
+		CorrelationID: "",
+		EventID:       "",
+	}
+
+	id, src := e.Extract(context.Background(), event, nil)
+
+	assert.NotEmpty(t, id)
+	assert.Equal(t, correlation.SourceGenerated, src)
+}
+
+func TestExtractFromMetadata_HeaderFound(t *testing.T) {
+	headers := map[string]string{
+		"x-correlation-id": "meta-corr-id",
+	}
+
+	id, src := correlation.ExtractFromMetadata(headers)
+
+	assert.Equal(t, "meta-corr-id", id)
+	assert.Equal(t, correlation.SourceHeader, src)
+}
+
+func TestExtractFromMetadata_Generated_WhenNoHeaders(t *testing.T) {
+	id, src := correlation.ExtractFromMetadata(nil)
+
+	assert.NotEmpty(t, id)
+	assert.Equal(t, correlation.SourceGenerated, src)
+}
+
+func TestExtractFromMetadata_Generated_WhenHeadersEmpty(t *testing.T) {
+	id, src := correlation.ExtractFromMetadata(map[string]string{})
+
+	assert.NotEmpty(t, id)
+	assert.Equal(t, correlation.SourceGenerated, src)
+}
+
+func TestExtractFromMetadata_SkipsEmptyHeaderValues(t *testing.T) {
+	headers := map[string]string{
+		"correlation_id":   "",
+		"x-correlation-id": "actual-id",
+	}
+
+	id, src := correlation.ExtractFromMetadata(headers)
+
+	assert.Equal(t, "actual-id", id)
+	assert.Equal(t, correlation.SourceHeader, src)
+}

--- a/services/event-router/internal/handlers/saga_dispatch_handler.go
+++ b/services/event-router/internal/handlers/saga_dispatch_handler.go
@@ -8,13 +8,14 @@ import (
 	"log/slog"
 	"strconv"
 
-	"github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/meridianhub/meridian/services/event-router/domain"
+	"github.com/meridianhub/meridian/services/event-router/internal/correlation"
 	sagaidempotency "github.com/meridianhub/meridian/services/event-router/internal/idempotency"
 	"github.com/meridianhub/meridian/services/event-router/internal/registry"
 	sharedidempotency "github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
-	"google.golang.org/protobuf/proto"
 )
 
 // ErrHandlerNotInitialized is returned when Handle is called on a handler with nil dependencies.
@@ -26,9 +27,6 @@ const (
 
 	// chainDepthHeader is the metadata key carrying the current chain depth.
 	chainDepthHeader = "x-chain-depth"
-
-	// correlationIDHeader is the metadata key carrying the correlation ID.
-	correlationIDHeader = "x-correlation-id"
 )
 
 // idempotencyStore is the interface for idempotency-protected saga dispatch.
@@ -144,9 +142,8 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 		"metadata": metadata,
 	}
 
-	idempotencyKey := extractCorrelationID(metadata)
-	if idempotencyKey == "" {
-		idempotencyKey = uuid.New().String()
+	idempotencyKey, src := correlation.ExtractFromMetadata(metadata)
+	if src == correlation.SourceGenerated {
 		h.logger.WarnContext(ctx, "no correlation ID in metadata, generated UUID as idempotency key — Kafka redelivery may cause duplicate saga executions",
 			"channel", channel,
 			"generated_key", idempotencyKey,
@@ -240,7 +237,7 @@ func (h *SagaDispatchHandler) dispatchSaga(
 		return fmt.Errorf("idempotent dispatch of saga %q: %w", sagaName, err)
 	}
 
-	if result.FromCache {
+	if result != nil && result.FromCache {
 		h.logger.InfoContext(ctx, "saga already dispatched (idempotent skip)",
 			"saga_name", sagaName,
 			"channel", channel,
@@ -269,13 +266,4 @@ func extractChainDepth(metadata map[string]string) int {
 		return 0
 	}
 	return depth
-}
-
-// extractCorrelationID reads the correlation ID from metadata.
-// Returns empty string if absent — caller is responsible for fallback and logging.
-func extractCorrelationID(metadata map[string]string) string {
-	if id, ok := metadata[correlationIDHeader]; ok && id != "" {
-		return id
-	}
-	return ""
 }

--- a/services/event-router/internal/handlers/saga_dispatch_handler.go
+++ b/services/event-router/internal/handlers/saga_dispatch_handler.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/event-router/domain"
+	sagaidempotency "github.com/meridianhub/meridian/services/event-router/internal/idempotency"
 	"github.com/meridianhub/meridian/services/event-router/internal/registry"
+	sharedidempotency "github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"google.golang.org/protobuf/proto"
 )
@@ -29,13 +31,19 @@ const (
 	correlationIDHeader = "x-correlation-id"
 )
 
+// idempotencyStore is the interface for idempotency-protected saga dispatch.
+type idempotencyStore interface {
+	Execute(ctx context.Context, sagaName, correlationID string, fn sagaidempotency.DispatchFunc) (*sharedidempotency.ExecuteResult, error)
+}
+
 // SagaDispatchHandler evaluates CEL filters against incoming events and triggers
 // matching sagas via the SagaTrigger port. It implements domain.EventHandler.
 type SagaDispatchHandler struct {
-	registry      *registry.SagaRegistry
-	sagaTrigger   domain.SagaTrigger
-	maxChainDepth int
-	logger        *slog.Logger
+	registry         *registry.SagaRegistry
+	sagaTrigger      domain.SagaTrigger
+	maxChainDepth    int
+	logger           *slog.Logger
+	idempotencyStore idempotencyStore
 }
 
 // Option configures a SagaDispatchHandler.
@@ -57,6 +65,17 @@ func WithLogger(logger *slog.Logger) Option {
 	return func(h *SagaDispatchHandler) {
 		if logger != nil {
 			h.logger = logger
+		}
+	}
+}
+
+// WithIdempotencyStore sets the idempotency store used to deduplicate saga dispatches.
+// When set, each saga trigger is wrapped with idempotency protection keyed on
+// (sagaName, correlationID). A nil store is ignored.
+func WithIdempotencyStore(store idempotencyStore) Option {
+	return func(h *SagaDispatchHandler) {
+		if store != nil {
+			h.idempotencyStore = store
 		}
 	}
 }
@@ -86,6 +105,10 @@ func NewSagaDispatchHandler(reg *registry.SagaRegistry, trigger domain.SagaTrigg
 // Filter evaluation errors cause the individual saga to be skipped (with a
 // warning log) while other sagas continue processing. Trigger errors are
 // returned immediately as they indicate infrastructure failures.
+//
+// When an idempotency store is configured, each saga trigger is deduplicated
+// by (sagaName, correlationID). Duplicate dispatches are logged and skipped.
+// ErrOperationInProgress is logged and skipped (another worker is processing).
 func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event proto.Message, metadata map[string]string) error {
 	if h.registry == nil || h.sagaTrigger == nil {
 		return ErrHandlerNotInitialized
@@ -135,13 +158,9 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 
 		// If no filter, the saga always matches.
 		if cs.FilterProgram == nil {
-			if _, err := h.sagaTrigger.TriggerSaga(ctx, sagaName, inputData, idempotencyKey); err != nil {
-				return fmt.Errorf("trigger saga %q: %w", sagaName, err)
+			if err := h.dispatchSaga(ctx, sagaName, channel, inputData, idempotencyKey); err != nil {
+				return err
 			}
-			h.logger.DebugContext(ctx, "saga triggered (no filter)",
-				"saga_name", sagaName,
-				"channel", channel,
-			)
 			continue
 		}
 
@@ -174,15 +193,67 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 			continue
 		}
 
-		if _, err := h.sagaTrigger.TriggerSaga(ctx, sagaName, inputData, idempotencyKey); err != nil {
+		if err := h.dispatchSaga(ctx, sagaName, channel, inputData, idempotencyKey); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// dispatchSaga triggers a single saga, optionally wrapping with idempotency protection.
+func (h *SagaDispatchHandler) dispatchSaga(
+	ctx context.Context,
+	sagaName, channel string,
+	inputData map[string]any,
+	correlationID string,
+) error {
+	if h.idempotencyStore == nil {
+		// No idempotency store — trigger directly.
+		if _, err := h.sagaTrigger.TriggerSaga(ctx, sagaName, inputData, correlationID); err != nil {
 			return fmt.Errorf("trigger saga %q: %w", sagaName, err)
 		}
 		h.logger.DebugContext(ctx, "saga triggered",
 			"saga_name", sagaName,
 			"channel", channel,
+			"correlation_id", correlationID,
 		)
+		return nil
 	}
 
+	// Idempotency-protected dispatch.
+	result, err := h.idempotencyStore.Execute(ctx, sagaName, correlationID, func(ctx context.Context) error {
+		if _, triggerErr := h.sagaTrigger.TriggerSaga(ctx, sagaName, inputData, correlationID); triggerErr != nil {
+			return fmt.Errorf("trigger saga %q: %w", sagaName, triggerErr)
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, sharedidempotency.ErrOperationInProgress) {
+			h.logger.InfoContext(ctx, "saga dispatch in progress by another worker, skipping",
+				"saga_name", sagaName,
+				"channel", channel,
+				"correlation_id", correlationID,
+			)
+			return nil
+		}
+		return fmt.Errorf("idempotent dispatch of saga %q: %w", sagaName, err)
+	}
+
+	if result.FromCache {
+		h.logger.InfoContext(ctx, "saga already dispatched (idempotent skip)",
+			"saga_name", sagaName,
+			"channel", channel,
+			"correlation_id", correlationID,
+		)
+		return nil
+	}
+
+	h.logger.DebugContext(ctx, "saga triggered",
+		"saga_name", sagaName,
+		"channel", channel,
+		"correlation_id", correlationID,
+	)
 	return nil
 }
 

--- a/services/event-router/internal/handlers/saga_dispatch_handler_test.go
+++ b/services/event-router/internal/handlers/saga_dispatch_handler_test.go
@@ -8,7 +8,9 @@ import (
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
 	"github.com/meridianhub/meridian/services/event-router/internal/handlers"
+	sagaidempotency "github.com/meridianhub/meridian/services/event-router/internal/idempotency"
 	"github.com/meridianhub/meridian/services/event-router/internal/registry"
+	sharedidempotency "github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -418,4 +420,145 @@ func TestSagaDispatchHandler_InputDataContainsEventAndMetadata(t *testing.T) {
 	inputData := trigger.calls[0].InputData
 	assert.Contains(t, inputData, "event")
 	assert.Contains(t, inputData, "metadata")
+}
+
+// fakeIdempotencyStore is a test double for the idempotency store.
+type fakeIdempotencyStore struct {
+	// calls tracks (sagaName, correlationID) pairs
+	calls []idempotencyCall
+	// fromCache determines whether Execute returns FromCache=true
+	fromCache bool
+	// err is returned by Execute when non-nil
+	err error
+}
+
+type idempotencyCall struct {
+	SagaName      string
+	CorrelationID string
+}
+
+func (f *fakeIdempotencyStore) Execute(
+	ctx context.Context,
+	sagaName, correlationID string,
+	fn sagaidempotency.DispatchFunc,
+) (*sharedidempotency.ExecuteResult, error) {
+	f.calls = append(f.calls, idempotencyCall{
+		SagaName:      sagaName,
+		CorrelationID: correlationID,
+	})
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.fromCache {
+		return &sharedidempotency.ExecuteResult{FromCache: true}, nil
+	}
+	// Execute the function
+	if err := fn(ctx); err != nil {
+		return nil, err
+	}
+	return &sharedidempotency.ExecuteResult{FromCache: false}, nil
+}
+
+func TestSagaDispatchHandler_WithIdempotencyStore_FirstCall_Triggers(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "test_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	iStore := &fakeIdempotencyStore{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger,
+		handlers.WithIdempotencyStore(iStore),
+		handlers.WithLogger(slog.Default()),
+	)
+
+	event := newTestEvent(t, map[string]any{"id": "1"})
+	err = h.Handle(context.Background(), "orders", event, map[string]string{"x-correlation-id": "corr-idem-1"})
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 1, "saga should be triggered on first call")
+	require.Len(t, iStore.calls, 1)
+	assert.Equal(t, "test_saga", iStore.calls[0].SagaName)
+	assert.Equal(t, "corr-idem-1", iStore.calls[0].CorrelationID)
+}
+
+func TestSagaDispatchHandler_WithIdempotencyStore_CacheHit_SkipsTrigger(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "dup_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	iStore := &fakeIdempotencyStore{fromCache: true}
+	h := handlers.NewSagaDispatchHandler(reg, trigger, handlers.WithIdempotencyStore(iStore))
+
+	event := newTestEvent(t, map[string]any{"id": "2"})
+	err = h.Handle(context.Background(), "orders", event, map[string]string{"x-correlation-id": "corr-dup"})
+
+	require.NoError(t, err)
+	assert.Empty(t, trigger.calls, "saga should NOT be triggered when idempotency cache hits")
+	require.Len(t, iStore.calls, 1)
+}
+
+func TestSagaDispatchHandler_WithIdempotencyStore_InProgress_SkipsWithoutError(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "prog_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	iStore := &fakeIdempotencyStore{err: sharedidempotency.ErrOperationInProgress}
+	h := handlers.NewSagaDispatchHandler(reg, trigger, handlers.WithIdempotencyStore(iStore))
+
+	event := newTestEvent(t, map[string]any{"id": "3"})
+	err = h.Handle(context.Background(), "orders", event, map[string]string{"x-correlation-id": "corr-prog"})
+
+	require.NoError(t, err, "ErrOperationInProgress should be swallowed")
+	assert.Empty(t, trigger.calls)
+}
+
+func TestSagaDispatchHandler_WithIdempotencyStore_OtherError_ReturnsError(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "err_saga", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	iStore := &fakeIdempotencyStore{err: errors.New("db connection lost")}
+	h := handlers.NewSagaDispatchHandler(reg, trigger, handlers.WithIdempotencyStore(iStore))
+
+	event := newTestEvent(t, map[string]any{"id": "4"})
+	err = h.Handle(context.Background(), "orders", event, map[string]string{"x-correlation-id": "corr-err"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db connection lost")
+}
+
+func TestSagaDispatchHandler_WithIdempotencyStore_MultipleSagas_EachCheckedIndependently(t *testing.T) {
+	reg, err := registry.NewSagaRegistry()
+	require.NoError(t, err)
+	require.NoError(t, reg.Reload([]*controlplanev1.SagaDefinition{
+		{Name: "saga_a", Trigger: "event:orders", Script: "def run(ctx): pass"},
+		{Name: "saga_b", Trigger: "event:orders", Script: "def run(ctx): pass"},
+	}))
+
+	trigger := &fakeSagaTrigger{}
+	iStore := &fakeIdempotencyStore{}
+	h := handlers.NewSagaDispatchHandler(reg, trigger, handlers.WithIdempotencyStore(iStore))
+
+	event := newTestEvent(t, map[string]any{"id": "5"})
+	err = h.Handle(context.Background(), "orders", event, map[string]string{"x-correlation-id": "corr-multi"})
+
+	require.NoError(t, err)
+	require.Len(t, trigger.calls, 2)
+	require.Len(t, iStore.calls, 2)
+	assert.Equal(t, "saga_a", iStore.calls[0].SagaName)
+	assert.Equal(t, "saga_b", iStore.calls[1].SagaName)
+	// Both use the same correlation ID
+	assert.Equal(t, "corr-multi", iStore.calls[0].CorrelationID)
+	assert.Equal(t, "corr-multi", iStore.calls[1].CorrelationID)
 }

--- a/services/event-router/internal/idempotency/store.go
+++ b/services/event-router/internal/idempotency/store.go
@@ -11,8 +11,14 @@ import (
 	sharedidempotency "github.com/meridianhub/meridian/shared/pkg/idempotency"
 )
 
-// ErrNilPool is returned when a nil pool is provided.
-var ErrNilPool = errors.New("pool cannot be nil")
+// Sentinel errors returned by NewSagaIdempotencyStore.
+var (
+	// ErrNilPool is returned when a nil pool is provided.
+	ErrNilPool = errors.New("pool cannot be nil")
+
+	// ErrInvalidConfig is returned when the configuration is invalid.
+	ErrInvalidConfig = errors.New("invalid idempotency store config")
+)
 
 const (
 	// sagaNamespace is the idempotency namespace for saga dispatch operations.
@@ -20,27 +26,19 @@ const (
 
 	// DefaultTTL is how long idempotency records are retained.
 	DefaultTTL = 24 * time.Hour
-
-	// DefaultStaleThreshold is how long a PENDING record can exist before being considered stale.
-	DefaultStaleThreshold = 1 * time.Hour
 )
 
 // Config holds configuration for the SagaIdempotencyStore.
 type Config struct {
 	// DefaultTTL is how long idempotency records are retained.
-	// Default: 24h
+	// Default: 24h. Must be > 0.
 	DefaultTTL time.Duration
-
-	// StaleThreshold is how long a PENDING record can exist before being considered stale.
-	// Default: 1h
-	StaleThreshold time.Duration
 }
 
 // DefaultConfig returns the default store configuration.
 func DefaultConfig() Config {
 	return Config{
-		DefaultTTL:     DefaultTTL,
-		StaleThreshold: DefaultStaleThreshold,
+		DefaultTTL: DefaultTTL,
 	}
 }
 
@@ -56,14 +54,21 @@ type SagaIdempotencyStore struct {
 
 // NewSagaIdempotencyStore creates a new store backed by a PostgreSQL/CockroachDB connection pool.
 // It calls EnsureTable to create the _idempotency_keys table if it does not exist.
+//
+// When cfg is nil, DefaultConfig is used. When cfg is non-nil, its fields are merged
+// over the defaults so that zero values fall back to the defaults.
 func NewSagaIdempotencyStore(ctx context.Context, pool *pgxpool.Pool, cfg *Config) (*SagaIdempotencyStore, error) {
 	if pool == nil {
 		return nil, ErrNilPool
 	}
 
-	if cfg == nil {
-		defaultCfg := DefaultConfig()
-		cfg = &defaultCfg
+	// Merge caller-supplied config over defaults so zero-valued fields fall back.
+	effectiveCfg := DefaultConfig()
+	if cfg != nil && cfg.DefaultTTL > 0 {
+		effectiveCfg.DefaultTTL = cfg.DefaultTTL
+	}
+	if effectiveCfg.DefaultTTL <= 0 {
+		return nil, fmt.Errorf("%w: DefaultTTL must be > 0", ErrInvalidConfig)
 	}
 
 	svc := sharedidempotency.NewPostgresService(pool)
@@ -72,7 +77,7 @@ func NewSagaIdempotencyStore(ctx context.Context, pool *pgxpool.Pool, cfg *Confi
 	}
 
 	execCfg := sharedidempotency.ExecutorConfig{
-		DefaultTTL:         cfg.DefaultTTL,
+		DefaultTTL:         effectiveCfg.DefaultTTL,
 		MaxDeadlockRetries: 3,
 		DeadlockRetryDelay: 50 * time.Millisecond,
 	}
@@ -80,7 +85,7 @@ func NewSagaIdempotencyStore(ctx context.Context, pool *pgxpool.Pool, cfg *Confi
 
 	return &SagaIdempotencyStore{
 		executor: executor,
-		config:   *cfg,
+		config:   effectiveCfg,
 	}, nil
 }
 

--- a/services/event-router/internal/idempotency/store.go
+++ b/services/event-router/internal/idempotency/store.go
@@ -1,0 +1,118 @@
+// Package idempotency provides saga-specific idempotency checking for event-triggered sagas.
+package idempotency
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	sharedidempotency "github.com/meridianhub/meridian/shared/pkg/idempotency"
+)
+
+// ErrNilPool is returned when a nil pool is provided.
+var ErrNilPool = errors.New("pool cannot be nil")
+
+const (
+	// sagaNamespace is the idempotency namespace for saga dispatch operations.
+	sagaNamespace = "saga-dispatch"
+
+	// DefaultTTL is how long idempotency records are retained.
+	DefaultTTL = 24 * time.Hour
+
+	// DefaultStaleThreshold is how long a PENDING record can exist before being considered stale.
+	DefaultStaleThreshold = 1 * time.Hour
+)
+
+// Config holds configuration for the SagaIdempotencyStore.
+type Config struct {
+	// DefaultTTL is how long idempotency records are retained.
+	// Default: 24h
+	DefaultTTL time.Duration
+
+	// StaleThreshold is how long a PENDING record can exist before being considered stale.
+	// Default: 1h
+	StaleThreshold time.Duration
+}
+
+// DefaultConfig returns the default store configuration.
+func DefaultConfig() Config {
+	return Config{
+		DefaultTTL:     DefaultTTL,
+		StaleThreshold: DefaultStaleThreshold,
+	}
+}
+
+// DispatchFunc is the saga dispatch function protected by idempotency.
+type DispatchFunc func(ctx context.Context) error
+
+// SagaIdempotencyStore prevents duplicate saga executions by tracking processed correlation IDs
+// using the shared idempotency infrastructure.
+type SagaIdempotencyStore struct {
+	executor *sharedidempotency.Executor
+	config   Config
+}
+
+// NewSagaIdempotencyStore creates a new store backed by a PostgreSQL/CockroachDB connection pool.
+// It calls EnsureTable to create the _idempotency_keys table if it does not exist.
+func NewSagaIdempotencyStore(ctx context.Context, pool *pgxpool.Pool, cfg *Config) (*SagaIdempotencyStore, error) {
+	if pool == nil {
+		return nil, ErrNilPool
+	}
+
+	if cfg == nil {
+		defaultCfg := DefaultConfig()
+		cfg = &defaultCfg
+	}
+
+	svc := sharedidempotency.NewPostgresService(pool)
+	if err := svc.EnsureTable(ctx); err != nil {
+		return nil, fmt.Errorf("failed to ensure idempotency table: %w", err)
+	}
+
+	execCfg := sharedidempotency.ExecutorConfig{
+		DefaultTTL:         cfg.DefaultTTL,
+		MaxDeadlockRetries: 3,
+		DeadlockRetryDelay: 50 * time.Millisecond,
+	}
+	executor := sharedidempotency.NewExecutor(svc, &execCfg)
+
+	return &SagaIdempotencyStore{
+		executor: executor,
+		config:   *cfg,
+	}, nil
+}
+
+// buildKey constructs an idempotency key for a saga dispatch.
+// namespace=saga-dispatch, operation=sagaName, entityID=correlationID.
+func buildKey(sagaName, correlationID string) sharedidempotency.Key {
+	return sharedidempotency.Key{
+		Namespace: sagaNamespace,
+		Operation: sagaName,
+		EntityID:  correlationID,
+	}
+}
+
+// Execute runs fn with idempotency protection keyed on (sagaName, correlationID).
+//
+// Behavior:
+//   - If already completed: fn is not called, returns (result, nil) with FromCache=true.
+//   - If in progress: fn is not called, returns (nil, ErrOperationInProgress).
+//   - If new: marks PENDING, calls fn, records COMPLETED on success.
+//   - On fn error: cleans up PENDING state and returns the error.
+func (s *SagaIdempotencyStore) Execute(
+	ctx context.Context,
+	sagaName, correlationID string,
+	fn DispatchFunc,
+) (*sharedidempotency.ExecuteResult, error) {
+	key := buildKey(sagaName, correlationID)
+
+	return s.executor.Execute(ctx, key, s.config.DefaultTTL, func(ctx context.Context) ([]byte, error) {
+		if err := fn(ctx); err != nil {
+			return nil, err
+		}
+		// Store the saga name as the result data so it can be logged on cache hit.
+		return []byte(fmt.Sprintf("%q", sagaName)), nil
+	})
+}

--- a/services/event-router/internal/idempotency/store_test.go
+++ b/services/event-router/internal/idempotency/store_test.go
@@ -1,0 +1,219 @@
+package idempotency_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	sagaidempotency "github.com/meridianhub/meridian/services/event-router/internal/idempotency"
+	sharedidempotency "github.com/meridianhub/meridian/shared/pkg/idempotency"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
+)
+
+// Shared CockroachDB container for all tests in this package.
+var (
+	once       sync.Once
+	sharedPool *pgxpool.Pool
+	initErr    error
+)
+
+func getPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	once.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
+
+		container, err := cockroachdb.Run(ctx,
+			"cockroachdb/cockroach:v24.3.0",
+			cockroachdb.WithDatabase("test_db"),
+			cockroachdb.WithUser("root"),
+			cockroachdb.WithInsecure(),
+		)
+		if err != nil {
+			initErr = err
+			return
+		}
+
+		connConfig, err := container.ConnectionConfig(ctx)
+		if err != nil {
+			initErr = err
+			return
+		}
+
+		pool, err := pgxpool.New(ctx, connConfig.ConnString())
+		if err != nil {
+			initErr = err
+			return
+		}
+		sharedPool = pool
+	})
+
+	if initErr != nil {
+		t.Fatalf("failed to initialize CockroachDB: %v", initErr)
+	}
+	return sharedPool
+}
+
+func newStore(t *testing.T) *sagaidempotency.SagaIdempotencyStore {
+	t.Helper()
+	pool := getPool(t)
+	store, err := sagaidempotency.NewSagaIdempotencyStore(context.Background(), pool, nil)
+	require.NoError(t, err)
+	return store
+}
+
+func TestNewSagaIdempotencyStore_NilPool(t *testing.T) {
+	_, err := sagaidempotency.NewSagaIdempotencyStore(context.Background(), nil, nil)
+	require.ErrorIs(t, err, sagaidempotency.ErrNilPool)
+}
+
+func TestNewSagaIdempotencyStore_DefaultConfig(t *testing.T) {
+	store := newStore(t)
+	assert.NotNil(t, store)
+}
+
+func TestExecute_FirstCall_RunsFunction(t *testing.T) {
+	store := newStore(t)
+	sagaName := "test-saga"
+	correlationID := uuid.New().String()
+
+	called := false
+	result, err := store.Execute(context.Background(), sagaName, correlationID, func(_ context.Context) error {
+		called = true
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.False(t, result.FromCache)
+}
+
+func TestExecute_DuplicateCall_SkipsFunction(t *testing.T) {
+	store := newStore(t)
+	sagaName := "test-saga-dup"
+	correlationID := uuid.New().String()
+
+	// First call — executes
+	_, err := store.Execute(context.Background(), sagaName, correlationID, func(_ context.Context) error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Second call — should be from cache
+	var callCount int
+	result, err := store.Execute(context.Background(), sagaName, correlationID, func(_ context.Context) error {
+		callCount++
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, callCount, "fn should not be called on duplicate")
+	assert.True(t, result.FromCache, "result should be from cache")
+}
+
+func TestExecute_DifferentSagaName_SameCorrelationID_ExecutesBoth(t *testing.T) {
+	store := newStore(t)
+	correlationID := uuid.New().String()
+
+	var calls []string
+	_, err := store.Execute(context.Background(), "saga-a", correlationID, func(_ context.Context) error {
+		calls = append(calls, "saga-a")
+		return nil
+	})
+	require.NoError(t, err)
+
+	_, err = store.Execute(context.Background(), "saga-b", correlationID, func(_ context.Context) error {
+		calls = append(calls, "saga-b")
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"saga-a", "saga-b"}, calls, "different saga names should be independent")
+}
+
+func TestExecute_FunctionError_AllowsRetry(t *testing.T) {
+	store := newStore(t)
+	sagaName := "saga-retry"
+	correlationID := uuid.New().String()
+
+	// First call fails
+	dispatchErr := errors.New("dispatch failed")
+	_, err := store.Execute(context.Background(), sagaName, correlationID, func(_ context.Context) error {
+		return dispatchErr
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, dispatchErr))
+
+	// Second call should succeed (PENDING state was cleaned up)
+	var callCount int32
+	result, err := store.Execute(context.Background(), sagaName, correlationID, func(_ context.Context) error {
+		atomic.AddInt32(&callCount, 1)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), callCount, "fn should be called after failed attempt")
+	assert.False(t, result.FromCache)
+}
+
+func TestExecute_InProgress_ReturnsErrOperationInProgress(t *testing.T) {
+	store := newStore(t)
+	sagaName := "saga-in-progress"
+	correlationID := uuid.New().String()
+
+	// Block the first execution
+	blockCh := make(chan struct{})
+	doneCh := make(chan error, 1)
+
+	go func() {
+		_, err := store.Execute(context.Background(), sagaName, correlationID, func(_ context.Context) error {
+			<-blockCh // hold the PENDING state
+			return nil
+		})
+		doneCh <- err
+	}()
+
+	// Give the goroutine time to mark PENDING
+	time.Sleep(100 * time.Millisecond)
+
+	// Second call should see PENDING and return ErrOperationInProgress
+	_, err := store.Execute(context.Background(), sagaName, correlationID, func(_ context.Context) error {
+		return nil
+	})
+
+	// Unblock the first goroutine
+	close(blockCh)
+	firstErr := <-doneCh
+	require.NoError(t, firstErr)
+
+	// Check the second call got ErrOperationInProgress
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, sharedidempotency.ErrOperationInProgress),
+		"expected ErrOperationInProgress, got: %v", err)
+}
+
+func TestExecute_CustomConfig(t *testing.T) {
+	pool := getPool(t)
+	cfg := &sagaidempotency.Config{
+		DefaultTTL:     5 * time.Minute,
+		StaleThreshold: 30 * time.Second,
+	}
+	store, err := sagaidempotency.NewSagaIdempotencyStore(context.Background(), pool, cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, store)
+
+	// Verify it works
+	correlationID := uuid.New().String()
+	result, err := store.Execute(context.Background(), "custom-saga", correlationID, func(_ context.Context) error {
+		return nil
+	})
+	require.NoError(t, err)
+	assert.False(t, result.FromCache)
+}

--- a/services/event-router/internal/idempotency/store_test.go
+++ b/services/event-router/internal/idempotency/store_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	sagaidempotency "github.com/meridianhub/meridian/services/event-router/internal/idempotency"
 	sharedidempotency "github.com/meridianhub/meridian/shared/pkg/idempotency"
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
@@ -172,16 +173,27 @@ func TestExecute_InProgress_ReturnsErrOperationInProgress(t *testing.T) {
 	blockCh := make(chan struct{})
 	doneCh := make(chan error, 1)
 
+	// pendingCh is closed once the first execution has started (PENDING written to DB).
+	pendingCh := make(chan struct{})
+
 	go func() {
 		_, err := store.Execute(context.Background(), sagaName, correlationID, func(_ context.Context) error {
-			<-blockCh // hold the PENDING state
+			close(pendingCh) // signal that PENDING state is now in the DB
+			<-blockCh        // hold the PENDING state
 			return nil
 		})
 		doneCh <- err
 	}()
 
-	// Give the goroutine time to mark PENDING
-	time.Sleep(100 * time.Millisecond)
+	// Wait until the first goroutine has written PENDING to the DB.
+	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
+		select {
+		case <-pendingCh:
+			return true
+		default:
+			return false
+		}
+	}), "timed out waiting for PENDING state to be written")
 
 	// Second call should see PENDING and return ErrOperationInProgress
 	_, err := store.Execute(context.Background(), sagaName, correlationID, func(_ context.Context) error {
@@ -202,8 +214,7 @@ func TestExecute_InProgress_ReturnsErrOperationInProgress(t *testing.T) {
 func TestExecute_CustomConfig(t *testing.T) {
 	pool := getPool(t)
 	cfg := &sagaidempotency.Config{
-		DefaultTTL:     5 * time.Minute,
-		StaleThreshold: 30 * time.Second,
+		DefaultTTL: 5 * time.Minute,
 	}
 	store, err := sagaidempotency.NewSagaIdempotencyStore(context.Background(), pool, cfg)
 	require.NoError(t, err)

--- a/services/event-router/internal/worker/idempotency_cleanup_worker.go
+++ b/services/event-router/internal/worker/idempotency_cleanup_worker.go
@@ -1,0 +1,146 @@
+// Package worker provides background workers for the event-router service.
+package worker
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	sharedidempotency "github.com/meridianhub/meridian/shared/pkg/idempotency"
+)
+
+// IdempotencyCleanupConfig holds configuration for the idempotency cleanup worker.
+type IdempotencyCleanupConfig struct {
+	// CleanupInterval is how often expired idempotency keys are purged.
+	// Default: 60s
+	CleanupInterval time.Duration
+}
+
+// DefaultIdempotencyCleanupConfig returns the default cleanup configuration.
+func DefaultIdempotencyCleanupConfig() IdempotencyCleanupConfig {
+	return IdempotencyCleanupConfig{
+		CleanupInterval: 60 * time.Second,
+	}
+}
+
+// Errors returned by the cleanup worker.
+var (
+	ErrNilPool         = errors.New("pool cannot be nil")
+	ErrNilLogger       = errors.New("logger cannot be nil")
+	ErrInvalidInterval = errors.New("cleanup interval must be greater than zero")
+	ErrAlreadyRunning  = errors.New("worker is already running")
+)
+
+// IdempotencyCleanupWorker periodically purges expired idempotency keys from the
+// _idempotency_keys table. Keys are created with an expires_at TTL; this worker
+// ensures they are removed promptly rather than accumulating indefinitely.
+type IdempotencyCleanupWorker struct {
+	svc    *sharedidempotency.PostgresService
+	config IdempotencyCleanupConfig
+	logger *slog.Logger
+
+	mu      sync.Mutex
+	running bool
+	done    chan struct{}
+}
+
+// NewIdempotencyCleanupWorker creates a new cleanup worker.
+//
+// Parameters:
+//   - pool: pgxpool.Pool connected to the CockroachDB/PostgreSQL database.
+//   - cfg:  Worker configuration.
+//   - logger: Structured logger.
+func NewIdempotencyCleanupWorker(
+	pool *pgxpool.Pool,
+	cfg IdempotencyCleanupConfig,
+	logger *slog.Logger,
+) (*IdempotencyCleanupWorker, error) {
+	if pool == nil {
+		return nil, ErrNilPool
+	}
+	if logger == nil {
+		return nil, ErrNilLogger
+	}
+	if cfg.CleanupInterval <= 0 {
+		return nil, ErrInvalidInterval
+	}
+
+	svc := sharedidempotency.NewPostgresService(
+		pool,
+		sharedidempotency.WithCleanupInterval(cfg.CleanupInterval),
+	)
+
+	return &IdempotencyCleanupWorker{
+		svc:    svc,
+		config: cfg,
+		logger: logger.With("component", "idempotency_cleanup_worker"),
+		done:   make(chan struct{}),
+	}, nil
+}
+
+// Start begins the background cleanup loop.
+// It blocks until ctx is cancelled or Stop() is called.
+// The cleanup runs immediately on first tick and then at each CleanupInterval.
+//
+// Returns ErrAlreadyRunning if Start is called while already running.
+func (w *IdempotencyCleanupWorker) Start(ctx context.Context) error {
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return ErrAlreadyRunning
+	}
+	w.running = true
+	w.mu.Unlock()
+
+	w.logger.Info("idempotency cleanup worker started",
+		"cleanup_interval", w.config.CleanupInterval,
+	)
+
+	// Use a child context so that Stop() can cancel the cleanup goroutine
+	// independently of the parent context.
+	cleanupCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Wire the done channel to cancel the cleanup context.
+	go func() {
+		select {
+		case <-w.done:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	// StartCleanup runs the periodic deletion in its own goroutine and returns immediately.
+	// It stops when cleanupCtx is cancelled.
+	w.svc.StartCleanup(cleanupCtx)
+
+	// Block until shutdown signal.
+	select {
+	case <-cleanupCtx.Done():
+	case <-w.done:
+	}
+
+	w.mu.Lock()
+	w.running = false
+	w.mu.Unlock()
+
+	w.logger.Info("idempotency cleanup worker stopped")
+	return nil
+}
+
+// Stop signals the worker to shut down.
+// It is safe to call Stop multiple times.
+func (w *IdempotencyCleanupWorker) Stop() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	select {
+	case <-w.done:
+		// Already closed
+	default:
+		close(w.done)
+	}
+}

--- a/services/event-router/internal/worker/idempotency_cleanup_worker.go
+++ b/services/event-router/internal/worker/idempotency_cleanup_worker.go
@@ -135,6 +135,14 @@ func (w *IdempotencyCleanupWorker) Start(ctx context.Context) error {
 	return nil
 }
 
+// Running reports whether the worker is currently running.
+// Safe to call from any goroutine.
+func (w *IdempotencyCleanupWorker) Running() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.running
+}
+
 // Stop signals the worker to shut down.
 // It is safe to call Stop multiple times.
 func (w *IdempotencyCleanupWorker) Stop() {

--- a/services/event-router/internal/worker/idempotency_cleanup_worker.go
+++ b/services/event-router/internal/worker/idempotency_cleanup_worker.go
@@ -86,12 +86,16 @@ func NewIdempotencyCleanupWorker(
 // The cleanup runs immediately on first tick and then at each CleanupInterval.
 //
 // Returns ErrAlreadyRunning if Start is called while already running.
+// Start can be called again after Stop() returns; the done channel is
+// re-initialized so the worker is restartable.
 func (w *IdempotencyCleanupWorker) Start(ctx context.Context) error {
 	w.mu.Lock()
 	if w.running {
 		w.mu.Unlock()
 		return ErrAlreadyRunning
 	}
+	// Re-initialize the done channel so the worker is restartable after Stop().
+	w.done = make(chan struct{})
 	w.running = true
 	w.mu.Unlock()
 

--- a/services/event-router/internal/worker/idempotency_cleanup_worker_test.go
+++ b/services/event-router/internal/worker/idempotency_cleanup_worker_test.go
@@ -107,10 +107,8 @@ func TestIdempotencyCleanupWorker_StartsAndStops(t *testing.T) {
 		errCh <- w.Start(ctx)
 	}()
 
-	// Wait until the worker is running (evidenced by ErrAlreadyRunning on a second Start attempt).
-	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
-		return w.Start(ctx) != nil
-	}))
+	// Wait until the worker has set running=true before stopping.
+	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(w.Running))
 
 	w.Stop()
 
@@ -137,10 +135,8 @@ func TestIdempotencyCleanupWorker_ContextCancellation_Stops(t *testing.T) {
 		errCh <- w.Start(ctx)
 	}()
 
-	// Wait until the worker is running before cancelling.
-	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
-		return w.Start(ctx) != nil
-	}))
+	// Wait until the worker has set running=true before cancelling.
+	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(w.Running))
 	cancel()
 
 	select {
@@ -174,26 +170,13 @@ func TestIdempotencyCleanupWorker_AlreadyRunning_ReturnsError(t *testing.T) {
 	defer cancel()
 	defer w.Stop()
 
-	startedCh := make(chan struct{})
 	go func() {
-		close(startedCh)
 		_ = w.Start(ctx)
 	}()
 
-	// Wait until Start() is definitely running before attempting second start.
-	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
-		select {
-		case <-startedCh:
-			return true
-		default:
-			return false
-		}
-	}))
-	// Poll until ErrAlreadyRunning is returned to ensure Start goroutine has set running=true.
-	var secondErr error
-	_ = await.New().AtMost(5 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
-		secondErr = w.Start(ctx)
-		return secondErr != nil
-	})
-	require.ErrorIs(t, secondErr, worker.ErrAlreadyRunning)
+	// Wait until the worker has set running=true, then verify a second Start returns ErrAlreadyRunning.
+	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(w.Running))
+
+	err = w.Start(ctx)
+	require.ErrorIs(t, err, worker.ErrAlreadyRunning)
 }

--- a/services/event-router/internal/worker/idempotency_cleanup_worker_test.go
+++ b/services/event-router/internal/worker/idempotency_cleanup_worker_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/meridianhub/meridian/services/event-router/internal/worker"
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
@@ -106,8 +107,10 @@ func TestIdempotencyCleanupWorker_StartsAndStops(t *testing.T) {
 		errCh <- w.Start(ctx)
 	}()
 
-	// Let it run briefly
-	time.Sleep(200 * time.Millisecond)
+	// Wait until the worker is running (evidenced by ErrAlreadyRunning on a second Start attempt).
+	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
+		return w.Start(ctx) != nil
+	}))
 
 	w.Stop()
 
@@ -134,7 +137,10 @@ func TestIdempotencyCleanupWorker_ContextCancellation_Stops(t *testing.T) {
 		errCh <- w.Start(ctx)
 	}()
 
-	time.Sleep(150 * time.Millisecond)
+	// Wait until the worker is running before cancelling.
+	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
+		return w.Start(ctx) != nil
+	}))
 	cancel()
 
 	select {
@@ -174,9 +180,20 @@ func TestIdempotencyCleanupWorker_AlreadyRunning_ReturnsError(t *testing.T) {
 		_ = w.Start(ctx)
 	}()
 
-	<-startedCh
-	time.Sleep(50 * time.Millisecond) // ensure Start() is running
-
-	err = w.Start(ctx)
-	require.ErrorIs(t, err, worker.ErrAlreadyRunning)
+	// Wait until Start() is definitely running before attempting second start.
+	require.NoError(t, await.New().AtMost(5*time.Second).PollInterval(10*time.Millisecond).Until(func() bool {
+		select {
+		case <-startedCh:
+			return true
+		default:
+			return false
+		}
+	}))
+	// Poll until ErrAlreadyRunning is returned to ensure Start goroutine has set running=true.
+	var secondErr error
+	_ = await.New().AtMost(5 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		secondErr = w.Start(ctx)
+		return secondErr != nil
+	})
+	require.ErrorIs(t, secondErr, worker.ErrAlreadyRunning)
 }

--- a/services/event-router/internal/worker/idempotency_cleanup_worker_test.go
+++ b/services/event-router/internal/worker/idempotency_cleanup_worker_test.go
@@ -1,0 +1,182 @@
+package worker_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/services/event-router/internal/worker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
+)
+
+// Shared CockroachDB container for worker tests.
+var (
+	workerOnce sync.Once
+	workerPool *pgxpool.Pool
+	workerErr  error
+)
+
+func getWorkerPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	workerOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
+
+		container, err := cockroachdb.Run(ctx,
+			"cockroachdb/cockroach:v24.3.0",
+			cockroachdb.WithDatabase("worker_test_db"),
+			cockroachdb.WithUser("root"),
+			cockroachdb.WithInsecure(),
+		)
+		if err != nil {
+			workerErr = err
+			return
+		}
+
+		connConfig, err := container.ConnectionConfig(ctx)
+		if err != nil {
+			workerErr = err
+			return
+		}
+
+		pool, err := pgxpool.New(ctx, connConfig.ConnString())
+		if err != nil {
+			workerErr = err
+			return
+		}
+		workerPool = pool
+	})
+
+	if workerErr != nil {
+		t.Fatalf("failed to initialize CockroachDB for worker tests: %v", workerErr)
+	}
+	return workerPool
+}
+
+func TestNewIdempotencyCleanupWorker_NilPool(t *testing.T) {
+	cfg := worker.DefaultIdempotencyCleanupConfig()
+	_, err := worker.NewIdempotencyCleanupWorker(nil, cfg, slog.Default())
+	require.Error(t, err)
+	assert.Equal(t, worker.ErrNilPool, err)
+}
+
+func TestNewIdempotencyCleanupWorker_NilLogger(t *testing.T) {
+	pool := getWorkerPool(t)
+	cfg := worker.DefaultIdempotencyCleanupConfig()
+	_, err := worker.NewIdempotencyCleanupWorker(pool, cfg, nil)
+	require.Error(t, err)
+	assert.Equal(t, worker.ErrNilLogger, err)
+}
+
+func TestNewIdempotencyCleanupWorker_InvalidInterval(t *testing.T) {
+	pool := getWorkerPool(t)
+	cfg := worker.IdempotencyCleanupConfig{CleanupInterval: 0}
+	_, err := worker.NewIdempotencyCleanupWorker(pool, cfg, slog.Default())
+	require.Error(t, err)
+	assert.Equal(t, worker.ErrInvalidInterval, err)
+}
+
+func TestNewIdempotencyCleanupWorker_ValidConfig(t *testing.T) {
+	pool := getWorkerPool(t)
+	cfg := worker.DefaultIdempotencyCleanupConfig()
+	w, err := worker.NewIdempotencyCleanupWorker(pool, cfg, slog.Default())
+	require.NoError(t, err)
+	assert.NotNil(t, w)
+}
+
+func TestIdempotencyCleanupWorker_StartsAndStops(t *testing.T) {
+	pool := getWorkerPool(t)
+	cfg := worker.IdempotencyCleanupConfig{
+		CleanupInterval: 100 * time.Millisecond,
+	}
+	w, err := worker.NewIdempotencyCleanupWorker(pool, cfg, slog.Default())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- w.Start(ctx)
+	}()
+
+	// Let it run briefly
+	time.Sleep(200 * time.Millisecond)
+
+	w.Stop()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("worker did not stop within timeout")
+	}
+}
+
+func TestIdempotencyCleanupWorker_ContextCancellation_Stops(t *testing.T) {
+	pool := getWorkerPool(t)
+	cfg := worker.IdempotencyCleanupConfig{
+		CleanupInterval: 100 * time.Millisecond,
+	}
+	w, err := worker.NewIdempotencyCleanupWorker(pool, cfg, slog.Default())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- w.Start(ctx)
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("worker did not stop after context cancellation")
+	}
+}
+
+func TestIdempotencyCleanupWorker_StopIdempotent(t *testing.T) {
+	pool := getWorkerPool(t)
+	cfg := worker.DefaultIdempotencyCleanupConfig()
+	w, err := worker.NewIdempotencyCleanupWorker(pool, cfg, slog.Default())
+	require.NoError(t, err)
+
+	// Stop before starting should not panic
+	w.Stop()
+	w.Stop() // second call should not panic
+}
+
+func TestIdempotencyCleanupWorker_AlreadyRunning_ReturnsError(t *testing.T) {
+	pool := getWorkerPool(t)
+	cfg := worker.IdempotencyCleanupConfig{
+		CleanupInterval: 100 * time.Millisecond,
+	}
+	w, err := worker.NewIdempotencyCleanupWorker(pool, cfg, slog.Default())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	defer w.Stop()
+
+	startedCh := make(chan struct{})
+	go func() {
+		close(startedCh)
+		_ = w.Start(ctx)
+	}()
+
+	<-startedCh
+	time.Sleep(50 * time.Millisecond) // ensure Start() is running
+
+	err = w.Start(ctx)
+	require.ErrorIs(t, err, worker.ErrAlreadyRunning)
+}


### PR DESCRIPTION
## Summary

- Add `internal/idempotency.SagaIdempotencyStore` backed by the shared `PostgresService` executor to deduplicate saga dispatches keyed on `(saga-dispatch, sagaName, correlationID)` with a 24h TTL.
- Add `internal/correlation.Extractor` with a four-level fallback chain for correlation ID resolution: `DomainEvent.CorrelationID` → Kafka headers (`correlation_id`, `x-correlation-id`, `X-Correlation-ID`, `correlationId`) → `EventID` → generated UUID. Tracks source via a Prometheus counter.
- Add `internal/worker.IdempotencyCleanupWorker` that wraps `PostgresService.StartCleanup` to periodically purge expired idempotency records.
- Integrate the store into `SagaDispatchHandler` via an optional `WithIdempotencyStore` option. `ErrOperationInProgress` is logged and skipped; cache hits skip the trigger with an info log.

## Changes Made

- `services/event-router/internal/idempotency/store.go` — `SagaIdempotencyStore` + `Config` + `ErrNilPool`
- `services/event-router/internal/idempotency/store_test.go` — integration tests using CockroachDB testcontainer (duplicate skip, in-progress, retry after failure)
- `services/event-router/internal/correlation/extractor.go` — `Extractor` + `ExtractFromMetadata` with Prometheus metrics
- `services/event-router/internal/correlation/extractor_test.go` — unit tests for all fallback paths
- `services/event-router/internal/worker/idempotency_cleanup_worker.go` — cleanup worker
- `services/event-router/internal/worker/idempotency_cleanup_worker_test.go` — start/stop lifecycle tests
- `services/event-router/internal/handlers/saga_dispatch_handler.go` — `WithIdempotencyStore` option + `dispatchSaga` helper
- `services/event-router/internal/handlers/saga_dispatch_handler_test.go` — 5 new tests for idempotency integration

## Test Plan

- [ ] All existing handler tests still pass (17 tests)
- [ ] New correlation extractor tests pass (10 tests)
- [ ] New idempotency store integration tests pass against CockroachDB (7 tests)
- [ ] New cleanup worker tests pass (6 tests)
- [ ] CI green

## Technical Details

The idempotency store reuses `shared/pkg/idempotency.PostgresService` and `Executor`. Keys are structured as:
```
idempotency:saga-dispatch:<sagaName>:<correlationID>
```

The `SagaDispatchHandler` without an idempotency store behaves identically to before — the option is additive and backward-compatible. `ErrOperationInProgress` is treated as a non-fatal skip to avoid blocking the Kafka consumer when two workers race on the same event.