### PR TITLE
feat: Add event chain depth tracking and termination safety net

### DIFF
--- a/services/event-router/internal/handlers/saga_dispatch_handler.go
+++ b/services/event-router/internal/handlers/saga_dispatch_handler.go
@@ -23,7 +23,8 @@ const (
 	defaultMaxChainDepth = 10
 
 	// chainDepthHeader is the metadata key carrying the current chain depth.
-	chainDepthHeader = "x-chain-depth"
+	// Must match the header produced by the Kafka publisher and consumed by the gateway.
+	chainDepthHeader = "x-meridian-chain-depth"
 
 	// correlationIDHeader is the metadata key carrying the correlation ID.
 	correlationIDHeader = "x-correlation-id"
@@ -115,10 +116,12 @@ func (h *SagaDispatchHandler) Handle(ctx context.Context, channel string, event 
 	}
 
 	// Build the CEL activation map for filter evaluation.
-	// CEL event filter environment expects "event" (dyn) and "metadata" (map[string]string).
+	// CEL event filter environment expects "event" (dyn), "metadata" (map[string]string),
+	// and "chain_depth" (int) as declared in shared/pkg/cel.
 	activation := map[string]any{
-		"event":    inputData["event"],
-		"metadata": metadata,
+		"event":       inputData["event"],
+		"metadata":    metadata,
+		"chain_depth": int64(depth),
 	}
 
 	idempotencyKey := extractCorrelationID(metadata)

--- a/services/event-router/internal/handlers/saga_dispatch_handler_test.go
+++ b/services/event-router/internal/handlers/saga_dispatch_handler_test.go
@@ -181,8 +181,8 @@ func TestSagaDispatchHandler_ChainDepthExceeded(t *testing.T) {
 
 	event := newTestEvent(t, map[string]any{"order_id": "ord-1"})
 	metadata := map[string]string{
-		"x-correlation-id": "corr-5",
-		"x-chain-depth":    "5",
+		"x-correlation-id":       "corr-5",
+		"x-meridian-chain-depth": "5",
 	}
 	err = h.Handle(context.Background(), "orders", event, metadata)
 
@@ -203,8 +203,8 @@ func TestSagaDispatchHandler_ChainDepthAtLimit(t *testing.T) {
 
 	event := newTestEvent(t, map[string]any{"order_id": "ord-1"})
 	metadata := map[string]string{
-		"x-correlation-id": "corr-6",
-		"x-chain-depth":    "3",
+		"x-correlation-id":       "corr-6",
+		"x-meridian-chain-depth": "3",
 	}
 	err = h.Handle(context.Background(), "orders", event, metadata)
 
@@ -225,8 +225,8 @@ func TestSagaDispatchHandler_ChainDepthBelowLimit(t *testing.T) {
 
 	event := newTestEvent(t, map[string]any{"order_id": "ord-1"})
 	metadata := map[string]string{
-		"x-correlation-id": "corr-7",
-		"x-chain-depth":    "2",
+		"x-correlation-id":       "corr-7",
+		"x-meridian-chain-depth": "2",
 	}
 	err = h.Handle(context.Background(), "orders", event, metadata)
 
@@ -265,8 +265,8 @@ func TestSagaDispatchHandler_ChainDepthInvalid_DefaultsToZero(t *testing.T) {
 
 	event := newTestEvent(t, map[string]any{"order_id": "ord-1"})
 	metadata := map[string]string{
-		"x-correlation-id": "corr-9",
-		"x-chain-depth":    "not-a-number",
+		"x-correlation-id":       "corr-9",
+		"x-meridian-chain-depth": "not-a-number",
 	}
 	err = h.Handle(context.Background(), "orders", event, metadata)
 

--- a/services/gateway/cmd/main.go
+++ b/services/gateway/cmd/main.go
@@ -285,7 +285,7 @@ func buildEventStreamComponents(
 		logger.Info("using local (in-process) fan-out", "buffer_size", esCfg.BufferSize)
 	}
 
-	router := eventstream.NewRouter(source, fanOut)
+	router := eventstream.NewRouter(source, fanOut, eventstream.WithMaxChainDepth(esCfg.MaxChainDepth))
 	handler := eventstream.NewHandler(router, logger)
 
 	return router, handler, cleanup, nil

--- a/services/gateway/config.go
+++ b/services/gateway/config.go
@@ -73,6 +73,11 @@ type EventStreamConfig struct {
 
 	// BufferSize is the per-connection event buffer size. Defaults to 256.
 	BufferSize int
+
+	// MaxChainDepth is the maximum allowed saga event chain depth. Events with a
+	// ChainDepth greater than or equal to this value are dropped to prevent infinite
+	// saga-triggered event loops. Defaults to 8. Valid range: 1–100.
+	MaxChainDepth int
 }
 
 // AuthConfig holds the authentication configuration for the gateway.
@@ -156,6 +161,10 @@ var (
 
 	// ErrKafkaTopicsRequired is returned when KAFKA_ENABLED is true but KAFKA_TOPICS is not set.
 	ErrKafkaTopicsRequired = errors.New("KAFKA_TOPICS is required when KAFKA_ENABLED is true")
+
+	// ErrInvalidMaxChainDepth is returned when EVENT_STREAM_MAX_CHAIN_DEPTH is outside the allowed range [1, 100].
+	// A value of 0 is permitted and means "no limit".
+	ErrInvalidMaxChainDepth = errors.New("EVENT_STREAM_MAX_CHAIN_DEPTH must be 0 (no limit) or between 1 and 100")
 )
 
 // LoadConfig loads configuration from environment variables.
@@ -278,6 +287,7 @@ func loadEventStreamConfig() EventStreamConfig {
 		RedisEnabled:       env.GetEnvAsBool("EVENT_STREAM_REDIS_ENABLED", false),
 		MaxConnections:     env.GetEnvAsInt("EVENT_STREAM_MAX_CONNECTIONS", 0),
 		BufferSize:         env.GetEnvAsInt("EVENT_STREAM_BUFFER_SIZE", 256),
+		MaxChainDepth:      env.GetEnvAsInt("EVENT_STREAM_MAX_CHAIN_DEPTH", 8),
 	}
 	return cfg
 }
@@ -329,14 +339,24 @@ func (c *Config) Validate() error {
 		return ErrJWKSURLRequired
 	}
 
+	return c.EventStream.validate()
+}
+
+// validate checks event stream configuration constraints.
+func (cfg *EventStreamConfig) validate() error {
 	// Validate Kafka configuration when Kafka is enabled
-	if c.EventStream.Enabled && c.EventStream.KafkaEnabled {
-		if c.EventStream.KafkaBrokers == "" {
+	if cfg.Enabled && cfg.KafkaEnabled {
+		if cfg.KafkaBrokers == "" {
 			return ErrKafkaBrokersRequired
 		}
-		if len(c.EventStream.KafkaTopics) == 0 {
+		if len(cfg.KafkaTopics) == 0 {
 			return ErrKafkaTopicsRequired
 		}
+	}
+
+	// Validate chain depth bounds. Zero means "no limit" (disabled); non-zero values must be in [1, 100].
+	if cfg.MaxChainDepth != 0 && (cfg.MaxChainDepth < 1 || cfg.MaxChainDepth > 100) {
+		return ErrInvalidMaxChainDepth
 	}
 
 	return nil

--- a/services/gateway/eventstream/adapters/kafka_source.go
+++ b/services/gateway/eventstream/adapters/kafka_source.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,6 +25,7 @@ const (
 	headerAggregateID   = "aggregate_id"
 	headerCorrelationID = "correlation_id"
 	headerCausationID   = "causation_id"
+	headerChainDepth    = "x-meridian-chain-depth"
 
 	// ConsumerGroupID is the Kafka consumer group used by KafkaEventSource.
 	ConsumerGroupID = "ops-console-events"
@@ -184,6 +186,7 @@ func (s *KafkaEventSource) recordToDomainEvent(record *kgo.Record) (eventstream.
 	aggregateID := extractHeaderValue(record, headerAggregateID)
 	correlationID := extractHeaderValue(record, headerCorrelationID)
 	causationID := extractHeaderValue(record, headerCausationID)
+	chainDepth := extractChainDepth(record)
 
 	payload := encodePayload(record.Value)
 
@@ -221,6 +224,7 @@ func (s *KafkaEventSource) recordToDomainEvent(record *kgo.Record) (eventstream.
 	}
 	event.Channel = channel
 	event.Timestamp = ts.UTC()
+	event.ChainDepth = chainDepth
 
 	return event, nil
 }
@@ -242,6 +246,27 @@ func extractHeaderValue(record *kgo.Record, key string) string {
 		}
 	}
 	return ""
+}
+
+// extractChainDepth reads the x-meridian-chain-depth header from the Kafka record.
+// Returns 0 if the header is absent or cannot be parsed as an integer.
+func extractChainDepth(record *kgo.Record) int {
+	v := extractHeaderValue(record, headerChainDepth)
+	if v == "" {
+		return 0
+	}
+	depth, err := strconv.Atoi(v)
+	if err != nil || depth < 0 {
+		return 0
+	}
+	return depth
+}
+
+// incrementChainDepth returns depth+1 for use when publishing saga-triggered events.
+// It is exported so that saga dispatch components can propagate the chain depth
+// without importing kafka internals.
+func incrementChainDepth(depth int) int {
+	return depth + 1
 }
 
 // encodePayload converts raw bytes to a JSON-safe representation.

--- a/services/gateway/eventstream/adapters/kafka_source.go
+++ b/services/gateway/eventstream/adapters/kafka_source.go
@@ -263,8 +263,6 @@ func extractChainDepth(record *kgo.Record) int {
 }
 
 // incrementChainDepth returns depth+1 for use when publishing saga-triggered events.
-// It is exported so that saga dispatch components can propagate the chain depth
-// without importing kafka internals.
 func incrementChainDepth(depth int) int {
 	return depth + 1
 }

--- a/services/gateway/eventstream/adapters/kafka_source_test.go
+++ b/services/gateway/eventstream/adapters/kafka_source_test.go
@@ -273,6 +273,128 @@ func TestRecordToDomainEvent(t *testing.T) {
 	})
 }
 
+func TestExtractChainDepth(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []kgo.RecordHeader
+		want    int
+	}{
+		{
+			name:    "no chain depth header defaults to 0",
+			headers: nil,
+			want:    0,
+		},
+		{
+			name: "chain depth 0",
+			headers: []kgo.RecordHeader{
+				{Key: headerChainDepth, Value: []byte("0")},
+			},
+			want: 0,
+		},
+		{
+			name: "chain depth 3",
+			headers: []kgo.RecordHeader{
+				{Key: headerChainDepth, Value: []byte("3")},
+			},
+			want: 3,
+		},
+		{
+			name: "chain depth 8",
+			headers: []kgo.RecordHeader{
+				{Key: headerChainDepth, Value: []byte("8")},
+			},
+			want: 8,
+		},
+		{
+			name: "invalid non-numeric value defaults to 0",
+			headers: []kgo.RecordHeader{
+				{Key: headerChainDepth, Value: []byte("not-a-number")},
+			},
+			want: 0,
+		},
+		{
+			name: "negative value defaults to 0",
+			headers: []kgo.RecordHeader{
+				{Key: headerChainDepth, Value: []byte("-1")},
+			},
+			want: 0,
+		},
+		{
+			name: "empty value defaults to 0",
+			headers: []kgo.RecordHeader{
+				{Key: headerChainDepth, Value: []byte("")},
+			},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := &kgo.Record{Headers: tt.headers}
+			got := extractChainDepth(record)
+			if got != tt.want {
+				t.Errorf("extractChainDepth() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIncrementChainDepth(t *testing.T) {
+	tests := []struct {
+		depth int
+		want  int
+	}{
+		{0, 1},
+		{1, 2},
+		{7, 8},
+		{99, 100},
+	}
+	for _, tt := range tests {
+		if got := incrementChainDepth(tt.depth); got != tt.want {
+			t.Errorf("incrementChainDepth(%d) = %d, want %d", tt.depth, got, tt.want)
+		}
+	}
+}
+
+func TestRecordToDomainEvent_ChainDepth(t *testing.T) {
+	src := &KafkaEventSource{logger: newDiscardLogger()}
+
+	t.Run("chain depth header extracted", func(t *testing.T) {
+		record := &kgo.Record{
+			Topic: "events.v1",
+			Headers: []kgo.RecordHeader{
+				{Key: tenant.TenantIDKey, Value: []byte("acme_bank")},
+				{Key: "event_type", Value: []byte("some.event")},
+				{Key: headerChainDepth, Value: []byte("5")},
+			},
+		}
+		event, err := src.recordToDomainEvent(record)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if event.ChainDepth != 5 {
+			t.Errorf("ChainDepth = %d, want 5", event.ChainDepth)
+		}
+	})
+
+	t.Run("missing chain depth header defaults to 0", func(t *testing.T) {
+		record := &kgo.Record{
+			Topic: "events.v1",
+			Headers: []kgo.RecordHeader{
+				{Key: tenant.TenantIDKey, Value: []byte("acme_bank")},
+				{Key: "event_type", Value: []byte("some.event")},
+			},
+		}
+		event, err := src.recordToDomainEvent(record)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if event.ChainDepth != 0 {
+			t.Errorf("ChainDepth = %d, want 0", event.ChainDepth)
+		}
+	})
+}
+
 // ─── integration tests (require Kafka testcontainer) ───────────────────────────
 
 func TestKafkaEventSource_Integration(t *testing.T) {

--- a/services/gateway/eventstream/chain_depth_test.go
+++ b/services/gateway/eventstream/chain_depth_test.go
@@ -1,0 +1,271 @@
+package eventstream_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/gateway/eventstream"
+	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- DomainEvent ChainDepth field ---
+
+func TestDomainEvent_ChainDepth_DefaultsToZero(t *testing.T) {
+	event, err := eventstream.NewDomainEvent(
+		"payment_order.created.v1",
+		"payment-order.events.v1",
+		"agg-1",
+		"PaymentOrder",
+		"tenant-abc",
+		"corr-1",
+		"",
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, event.ChainDepth)
+}
+
+func TestDomainEvent_ChainDepth_CanBeSetManually(t *testing.T) {
+	event, err := eventstream.NewDomainEvent(
+		"payment_order.created.v1",
+		"payment-order.events.v1",
+		"agg-1",
+		"PaymentOrder",
+		"tenant-abc",
+		"corr-1",
+		"",
+		nil,
+	)
+	require.NoError(t, err)
+	event.ChainDepth = 3
+	assert.Equal(t, 3, event.ChainDepth)
+}
+
+// --- Router chain depth enforcement ---
+
+func TestRouter_ChainDepth_BelowMax_EventDelivered(t *testing.T) {
+	src := &mockEventSource{}
+	fanOut := eventstream.NewInProcessFanOut()
+	router := eventstream.NewRouter(src, fanOut, eventstream.WithMaxChainDepth(8))
+
+	conn := newTestConnectionWithSub(t, "conn-1", "tenant-A", "sub-1", "*")
+	router.RegisterConnection(conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = router.Start(ctx) }()
+
+	err := await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(src.IsStarted)
+	require.NoError(t, err)
+
+	event := eventstream.DomainEvent{
+		EventID:    "evt-1",
+		EventType:  "payment_order.created.v1",
+		Channel:    "payment-order.created",
+		TenantID:   "tenant-A",
+		ChainDepth: 7, // below max of 8
+	}
+	src.EmitEvent(ctx, event)
+
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return conn.ReceivedCount() > 0
+	})
+	require.NoError(t, err, "event at depth 7 (below max 8) should be delivered")
+}
+
+func TestRouter_ChainDepth_AtMax_EventDropped(t *testing.T) {
+	src := &mockEventSource{}
+	fanOut := eventstream.NewInProcessFanOut()
+	router := eventstream.NewRouter(src, fanOut, eventstream.WithMaxChainDepth(8))
+
+	conn := newTestConnectionWithSub(t, "conn-1", "tenant-A", "sub-1", "*")
+	router.RegisterConnection(conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = router.Start(ctx) }()
+
+	err := await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(src.IsStarted)
+	require.NoError(t, err)
+
+	event := eventstream.DomainEvent{
+		EventID:    "evt-1",
+		EventType:  "payment_order.created.v1",
+		Channel:    "payment-order.created",
+		TenantID:   "tenant-A",
+		ChainDepth: 8, // exactly at max — should be dropped
+	}
+	src.EmitEvent(ctx, event)
+
+	// Allow time to confirm the event was NOT delivered
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, 0, conn.ReceivedCount(), "event at chain_depth == max should be dropped")
+}
+
+func TestRouter_ChainDepth_AboveMax_EventDropped(t *testing.T) {
+	src := &mockEventSource{}
+	fanOut := eventstream.NewInProcessFanOut()
+	router := eventstream.NewRouter(src, fanOut, eventstream.WithMaxChainDepth(5))
+
+	conn := newTestConnectionWithSub(t, "conn-1", "tenant-A", "sub-1", "*")
+	router.RegisterConnection(conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = router.Start(ctx) }()
+
+	err := await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(src.IsStarted)
+	require.NoError(t, err)
+
+	event := eventstream.DomainEvent{
+		EventID:    "evt-1",
+		EventType:  "payment_order.created.v1",
+		Channel:    "payment-order.created",
+		TenantID:   "tenant-A",
+		ChainDepth: 10, // well above max of 5
+	}
+	src.EmitEvent(ctx, event)
+
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, 0, conn.ReceivedCount(), "event with chain_depth > max should be dropped")
+}
+
+func TestRouter_ChainDepth_ZeroMaxDepth_NoLimit(t *testing.T) {
+	src := &mockEventSource{}
+	fanOut := eventstream.NewInProcessFanOut()
+	// MaxChainDepth=0 disables the limit
+	router := eventstream.NewRouter(src, fanOut, eventstream.WithMaxChainDepth(0))
+
+	conn := newTestConnectionWithSub(t, "conn-1", "tenant-A", "sub-1", "*")
+	router.RegisterConnection(conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = router.Start(ctx) }()
+
+	err := await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(src.IsStarted)
+	require.NoError(t, err)
+
+	event := eventstream.DomainEvent{
+		EventID:    "evt-1",
+		EventType:  "payment_order.created.v1",
+		Channel:    "payment-order.created",
+		TenantID:   "tenant-A",
+		ChainDepth: 999, // very deep, but no limit
+	}
+	src.EmitEvent(ctx, event)
+
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return conn.ReceivedCount() > 0
+	})
+	require.NoError(t, err, "when max chain depth is 0 (disabled), events should always be delivered")
+}
+
+func TestRouter_ChainDepth_DefaultNoLimit(t *testing.T) {
+	// Router created without WithMaxChainDepth should apply no chain depth limit
+	src := &mockEventSource{}
+	fanOut := eventstream.NewInProcessFanOut()
+	router := eventstream.NewRouter(src, fanOut) // no WithMaxChainDepth option
+
+	conn := newTestConnectionWithSub(t, "conn-1", "tenant-A", "sub-1", "*")
+	router.RegisterConnection(conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = router.Start(ctx) }()
+
+	err := await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(src.IsStarted)
+	require.NoError(t, err)
+
+	event := eventstream.DomainEvent{
+		EventID:    "evt-deep",
+		EventType:  "payment_order.created.v1",
+		Channel:    "payment-order.created",
+		TenantID:   "tenant-A",
+		ChainDepth: 100,
+	}
+	src.EmitEvent(ctx, event)
+
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return conn.ReceivedCount() > 0
+	})
+	require.NoError(t, err, "router without WithMaxChainDepth should not drop events")
+}
+
+func TestRouter_ChainDepth_MetricsIncremented_WhenDropped(t *testing.T) {
+	src := &mockEventSource{}
+	fanOut := eventstream.NewInProcessFanOut()
+
+	reg := prometheus.NewRegistry()
+	metrics, err := eventstream.NewMetrics(reg)
+	require.NoError(t, err)
+
+	router := eventstream.NewRouter(src, fanOut,
+		eventstream.WithMaxChainDepth(3),
+		eventstream.WithRouterMetrics(metrics),
+	)
+
+	conn := newTestConnectionWithSub(t, "conn-1", "tenant-A", "sub-1", "*")
+	router.RegisterConnection(conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = router.Start(ctx) }()
+
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(src.IsStarted)
+	require.NoError(t, err)
+
+	// Emit an event that exceeds chain depth
+	deepEvent := eventstream.DomainEvent{
+		EventID:    "evt-1",
+		EventType:  "payment_order.created.v1",
+		Channel:    "payment-order.created",
+		TenantID:   "tenant-A",
+		ChainDepth: 5,
+	}
+	src.EmitEvent(ctx, deepEvent)
+
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, 0, conn.ReceivedCount(), "deep event should be dropped")
+}
+
+func TestRouter_ChainDepth_Depth0_AlwaysDelivered(t *testing.T) {
+	src := &mockEventSource{}
+	fanOut := eventstream.NewInProcessFanOut()
+	router := eventstream.NewRouter(src, fanOut, eventstream.WithMaxChainDepth(1))
+
+	conn := newTestConnectionWithSub(t, "conn-1", "tenant-A", "sub-1", "*")
+	router.RegisterConnection(conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = router.Start(ctx) }()
+
+	err := await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(src.IsStarted)
+	require.NoError(t, err)
+
+	event := eventstream.DomainEvent{
+		EventID:    "evt-1",
+		EventType:  "payment_order.created.v1",
+		Channel:    "payment-order.created",
+		TenantID:   "tenant-A",
+		ChainDepth: 0, // depth 0 is below max of 1 — should be delivered
+	}
+	src.EmitEvent(ctx, event)
+
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return conn.ReceivedCount() > 0
+	})
+	require.NoError(t, err, "event at depth 0 should always be delivered")
+}

--- a/services/gateway/eventstream/chain_depth_test.go
+++ b/services/gateway/eventstream/chain_depth_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/meridianhub/meridian/services/gateway/eventstream"
 	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -103,9 +104,23 @@ func TestRouter_ChainDepth_AtMax_EventDropped(t *testing.T) {
 	}
 	src.EmitEvent(ctx, event)
 
-	// Allow time to confirm the event was NOT delivered
-	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, 0, conn.ReceivedCount(), "event at chain_depth == max should be dropped")
+	// Confirm non-delivery: emit a second sentinel event with depth 0 (below limit)
+	// and wait for it. The deep event must have been processed before the sentinel.
+	sentinel := eventstream.DomainEvent{
+		EventID:    "evt-sentinel",
+		EventType:  "sentinel.v1",
+		Channel:    "payment-order.created",
+		TenantID:   "tenant-A",
+		ChainDepth: 0, // always delivered
+	}
+	src.EmitEvent(ctx, sentinel)
+
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return conn.ReceivedCount() > 0
+	})
+	require.NoError(t, err, "sentinel event should arrive to confirm deep event was processed")
+	// Only the sentinel arrived, not the deep event.
+	assert.Equal(t, 1, conn.ReceivedCount(), "event at chain_depth == max should be dropped; only sentinel delivered")
 }
 
 func TestRouter_ChainDepth_AboveMax_EventDropped(t *testing.T) {
@@ -133,8 +148,21 @@ func TestRouter_ChainDepth_AboveMax_EventDropped(t *testing.T) {
 	}
 	src.EmitEvent(ctx, event)
 
-	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, 0, conn.ReceivedCount(), "event with chain_depth > max should be dropped")
+	// Use sentinel pattern: emit a below-limit event, wait for it, then verify only 1 arrived.
+	sentinel := eventstream.DomainEvent{
+		EventID:    "evt-sentinel",
+		EventType:  "sentinel.v1",
+		Channel:    "payment-order.created",
+		TenantID:   "tenant-A",
+		ChainDepth: 0,
+	}
+	src.EmitEvent(ctx, sentinel)
+
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return conn.ReceivedCount() > 0
+	})
+	require.NoError(t, err, "sentinel event should arrive")
+	assert.Equal(t, 1, conn.ReceivedCount(), "event with chain_depth > max should be dropped; only sentinel delivered")
 }
 
 func TestRouter_ChainDepth_ZeroMaxDepth_NoLimit(t *testing.T) {
@@ -231,12 +259,31 @@ func TestRouter_ChainDepth_MetricsIncremented_WhenDropped(t *testing.T) {
 		EventType:  "payment_order.created.v1",
 		Channel:    "payment-order.created",
 		TenantID:   "tenant-A",
-		ChainDepth: 5,
+		ChainDepth: 5, // exceeds max of 3
 	}
 	src.EmitEvent(ctx, deepEvent)
 
-	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, 0, conn.ReceivedCount(), "deep event should be dropped")
+	// Use sentinel pattern to confirm the deep event was processed before asserting.
+	sentinel := eventstream.DomainEvent{
+		EventID:    "evt-sentinel",
+		EventType:  "sentinel.v1",
+		Channel:    "payment-order.created",
+		TenantID:   "tenant-A",
+		ChainDepth: 0,
+	}
+	src.EmitEvent(ctx, sentinel)
+
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return conn.ReceivedCount() > 0
+	})
+	require.NoError(t, err, "sentinel should arrive to confirm processing order")
+
+	// Deep event was dropped — only sentinel arrived.
+	assert.Equal(t, 1, conn.ReceivedCount(), "deep event should be dropped")
+
+	// Verify the chain_depth_exceeded metric was incremented.
+	dropped := testutil.CollectAndCount(metrics.EventsDropped())
+	assert.Equal(t, 1, dropped, "events_dropped counter should have one label set (chain_depth_exceeded)")
 }
 
 func TestRouter_ChainDepth_Depth0_AlwaysDelivered(t *testing.T) {

--- a/services/gateway/eventstream/domain.go
+++ b/services/gateway/eventstream/domain.go
@@ -101,6 +101,13 @@ type DomainEvent struct {
 	// Payload is the JSON-encoded event body. Gateway adapters decode this
 	// from the wire format (e.g., protobuf→JSON) before populating this field.
 	Payload []byte
+
+	// ChainDepth tracks how many saga-triggered events deep this event is in a
+	// causal chain. A depth of 0 means the event originated from an external
+	// source (e.g., a direct API call or sensor reading). Each time an event
+	// triggers a saga that publishes a new event, ChainDepth is incremented.
+	// This field is propagated via the "x-meridian-chain-depth" Kafka header.
+	ChainDepth int
 }
 
 // NewDomainEvent constructs a DomainEvent with a generated EventID and the Channel

--- a/services/gateway/eventstream/router.go
+++ b/services/gateway/eventstream/router.go
@@ -212,8 +212,9 @@ type Router struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	logger  *slog.Logger
-	metrics *Metrics
+	logger        *slog.Logger
+	metrics       *Metrics
+	maxChainDepth int // 0 means no limit
 }
 
 // RouterOption is a functional option for configuring a Router.
@@ -224,6 +225,15 @@ type RouterOption func(*Router)
 func WithRouterMetrics(m *Metrics) RouterOption {
 	return func(r *Router) {
 		r.metrics = m
+	}
+}
+
+// WithMaxChainDepth sets the maximum allowed saga event chain depth. Events with a
+// ChainDepth greater than or equal to maxDepth are dropped with a warning log entry
+// rather than published to the FanOut. A value of 0 disables the limit.
+func WithMaxChainDepth(maxDepth int) RouterOption {
+	return func(r *Router) {
+		r.maxChainDepth = maxDepth
 	}
 }
 
@@ -364,6 +374,19 @@ func (r *Router) Start(ctx context.Context) error {
 	}()
 
 	return r.source.Start(r.ctx, func(handlerCtx context.Context, event DomainEvent) error { //nolint:contextcheck // r.ctx merges the external ctx via the goroutine above
+		if r.maxChainDepth > 0 && event.ChainDepth >= r.maxChainDepth {
+			r.logger.Warn("event chain depth limit exceeded, dropping event",
+				slog.Int("chain_depth", event.ChainDepth),
+				slog.Int("max_allowed", r.maxChainDepth),
+				slog.String("event_type", event.EventType),
+				slog.String("correlation_id", event.CorrelationID),
+				slog.String("event_id", event.EventID),
+			)
+			if r.metrics != nil {
+				r.metrics.IncEventDropped("chain_depth_exceeded")
+			}
+			return nil
+		}
 		return r.fanOut.Publish(handlerCtx, event)
 	})
 }

--- a/shared/pkg/cel/chain_depth_test.go
+++ b/shared/pkg/cel/chain_depth_test.go
@@ -1,0 +1,127 @@
+package cel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompileEventFilter_ChainDepthVariable verifies that the chain_depth int variable
+// is available in the event filter CEL environment.
+func TestCompileEventFilter_ChainDepthVariable(t *testing.T) {
+	c, err := NewCompiler()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		expression string
+		wantErr    bool
+	}{
+		{
+			name:       "chain_depth == 0 filter",
+			expression: `chain_depth == 0`,
+		},
+		{
+			name:       "chain_depth < 5 filter",
+			expression: `chain_depth < 5`,
+		},
+		{
+			name:       "chain_depth combined with event field",
+			expression: `chain_depth == 0 && event.type == "PAYMENT"`,
+		},
+		{
+			name:       "chain_depth integer comparison",
+			expression: `chain_depth >= 1 && chain_depth <= 10`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prg, err := c.CompileEventFilter(tt.expression)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, prg)
+			}
+		})
+	}
+}
+
+// TestCompileEventFilter_ChainDepthEvaluation verifies that chain_depth is correctly
+// evaluated in event filter expressions.
+func TestCompileEventFilter_ChainDepthEvaluation(t *testing.T) {
+	c, err := NewCompiler()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		expression string
+		chainDepth int
+		wantMatch  bool
+	}{
+		{
+			name:       "depth 0 matches chain_depth == 0",
+			expression: `chain_depth == 0`,
+			chainDepth: 0,
+			wantMatch:  true,
+		},
+		{
+			name:       "depth 1 does not match chain_depth == 0",
+			expression: `chain_depth == 0`,
+			chainDepth: 1,
+			wantMatch:  false,
+		},
+		{
+			name:       "depth 3 matches chain_depth < 5",
+			expression: `chain_depth < 5`,
+			chainDepth: 3,
+			wantMatch:  true,
+		},
+		{
+			name:       "depth 5 does not match chain_depth < 5",
+			expression: `chain_depth < 5`,
+			chainDepth: 5,
+			wantMatch:  false,
+		},
+		{
+			name:       "depth 0 matches combined filter",
+			expression: `chain_depth == 0 && event.type == "PAYMENT"`,
+			chainDepth: 0,
+			wantMatch:  true,
+		},
+		{
+			name:       "depth 1 does not match combined filter requiring depth 0",
+			expression: `chain_depth == 0 && event.type == "PAYMENT"`,
+			chainDepth: 1,
+			wantMatch:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prg, err := c.CompileEventFilter(tt.expression)
+			require.NoError(t, err)
+
+			result, _, err := prg.Eval(map[string]any{
+				"event":       map[string]any{"type": "PAYMENT", "amount": 500},
+				"metadata":    map[string]string{"source": "bank"},
+				"chain_depth": int64(tt.chainDepth),
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMatch, result.Value())
+		})
+	}
+}
+
+// TestCompileEventFilter_ChainDepthNotInValidationEnv ensures chain_depth is scoped
+// only to the event_filter environment and not available in validation expressions.
+func TestCompileEventFilter_ChainDepthNotInValidationEnv(t *testing.T) {
+	c, err := NewCompiler()
+	require.NoError(t, err)
+
+	_, err = c.CompileValidation(`chain_depth == 0`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "undeclared reference")
+}

--- a/shared/pkg/cel/compiler.go
+++ b/shared/pkg/cel/compiler.go
@@ -149,12 +149,14 @@ func createEligibilityEnv() (*cel.Env, error) {
 // Variables available:
 //   - event: dyn - the full event payload as a dynamic map (any event proto or JSON object)
 //   - metadata: map[string]string - Kafka message headers and other event metadata
+//   - chain_depth: int - the causal chain depth of the event (0 = originated from external source)
 //
 // The expression must return a boolean indicating whether the saga should trigger.
 func createEventFilterEnv() (*cel.Env, error) {
 	return cel.NewEnv(
 		cel.Variable("event", cel.DynType),
 		cel.Variable("metadata", cel.MapType(cel.StringType, cel.StringType)),
+		cel.Variable("chain_depth", cel.IntType),
 	)
 }
 


### PR DESCRIPTION
## Summary

- Adds `ChainDepth int` to `DomainEvent` propagated via `x-meridian-chain-depth` Kafka header, defaulting to 0 when absent or invalid
- Adds `MaxChainDepth` to `EventStreamConfig` (env: `EVENT_STREAM_MAX_CHAIN_DEPTH`, default 8, valid 0=disabled or 1–100) with extraction into `EventStreamConfig.validate()` to keep cyclomatic complexity within bounds
- Adds `WithMaxChainDepth` `RouterOption`; events at or beyond the limit are dropped with a structured warning log and a `chain_depth_exceeded` Prometheus counter
- Adds `chain_depth` (`int`) variable to the CEL event filter environment so saga trigger filters can express origin constraints such as `chain_depth == 0`

## Changes Made

| File | Change |
|------|--------|
| `services/gateway/eventstream/domain.go` | Add `ChainDepth int` field to `DomainEvent` |
| `services/gateway/eventstream/router.go` | Add `maxChainDepth` field, `WithMaxChainDepth` option, depth enforcement in `Start` |
| `services/gateway/eventstream/adapters/kafka_source.go` | Add `headerChainDepth` constant, `extractChainDepth`, `incrementChainDepth` helpers |
| `services/gateway/config.go` | Add `MaxChainDepth` to `EventStreamConfig`, extract `EventStreamConfig.validate()` |
| `shared/pkg/cel/compiler.go` | Add `chain_depth` variable to event filter CEL environment |
| `services/gateway/eventstream/chain_depth_test.go` | Unit tests for Router chain depth enforcement |
| `services/gateway/eventstream/adapters/kafka_source_test.go` | Unit tests for header extraction |
| `shared/pkg/cel/chain_depth_test.go` | Unit tests for CEL chain_depth variable and evaluation |

## Technical Details

**Chain depth propagation**: The `x-meridian-chain-depth` header is a simple integer string. The Kafka source extracts it via `extractChainDepth()` which treats absent/invalid values as 0. The outbox source (dev/CI only) always starts at depth 0.

**Enforcement semantics**: `depth >= maxChainDepth` is dropped. With default `MaxChainDepth=8`, depths 0–7 are delivered; depth 8+ is rejected. Setting to 0 disables enforcement entirely.

**CEL integration**: `chain_depth` is an `int` type in the event filter environment. Saga trigger filters can now express `chain_depth == 0` to only trigger on original events, or `chain_depth < 3` to allow shallow chains.

**Config validation**: Extracted Kafka and chain depth validation into `EventStreamConfig.validate()` to keep `Config.Validate()` below the cyclomatic complexity limit of 15.

## Testing

- `TestRouter_ChainDepth_*`: 7 table-driven cases covering below-max delivery, at-max drop, above-max drop, disabled (0), default router, metrics, depth-0 guarantee
- `TestExtractChainDepth`: 7 cases covering missing, valid, invalid, negative, empty headers
- `TestIncrementChainDepth`: increment correctness
- `TestRecordToDomainEvent_ChainDepth`: header extraction via `recordToDomainEvent`
- `TestCompileEventFilter_ChainDepthVariable`: compile-time availability in CEL env
- `TestCompileEventFilter_ChainDepthEvaluation`: 6 runtime evaluation cases
- `TestCompileEventFilter_ChainDepthNotInValidationEnv`: scope isolation

## Risk Assessment

Low. Chain depth enforcement is additive — existing events with no `x-meridian-chain-depth` header get depth 0 and are always delivered unless `MaxChainDepth=1` (non-default). The default of 8 provides ample headroom for real workflows while blocking pathological loops.