### PR TITLE
docs(032): event-triggered saga documentation — ADR-0033, skill, runbook

### DIFF
--- a/docs/adr/0033-event-triggered-sagas.md
+++ b/docs/adr/0033-event-triggered-sagas.md
@@ -131,7 +131,7 @@ The `event_filter` CEL environment exposes three variables:
 | Variable | Type | Description |
 |----------|------|-------------|
 | `event` | `dyn` | Event payload fields (deserialized from proto via AsyncAPI mapping) |
-| `metadata` | `map(string, string)` | Kafka message headers (correlation-id, tenant-id, chain-depth, etc.) |
+| `metadata` | `map(string, string)` | Kafka message headers (`x-tenant-id`, `x-meridian-chain-depth`, etc.) |
 | `chain_depth` | `int` | Current saga chain depth (number of event-triggered hops in this chain) |
 
 ### Chain Depth Enforcement

--- a/docs/adr/0033-event-triggered-sagas.md
+++ b/docs/adr/0033-event-triggered-sagas.md
@@ -266,11 +266,14 @@ The manifest applier validates event-triggered sagas at apply time:
 
 ### Idempotency Key Derivation
 
-The correlation ID for idempotency is extracted from Kafka message headers in priority order:
+The correlation ID for idempotency is extracted in priority order:
 
-1. `x-meridian-correlation-id` header
-2. `correlation-id` header
-3. Generated UUID (with a warning log — Kafka redelivery may cause duplicate executions)
+1. Event proto `CorrelationID` field (populated during AsyncAPI deserialization)
+2. Kafka header `correlation_id`
+3. Kafka header `x-correlation-id`
+4. Kafka header `X-Correlation-ID`
+5. Kafka header `correlationId`
+6. Generated UUID (with a warning log — Kafka redelivery may cause duplicate executions)
 
 ### Prometheus Metrics
 

--- a/docs/adr/0033-event-triggered-sagas.md
+++ b/docs/adr/0033-event-triggered-sagas.md
@@ -1,0 +1,351 @@
+---
+name: adr-0033-event-triggered-sagas
+description: Reactive saga execution via Kafka event channels with CEL-filtered dispatch and chain-depth termination
+triggers:
+  - Adding event-triggered saga workflows to a tenant manifest
+  - Understanding the event:channel trigger syntax in saga definitions
+  - Debugging event-driven saga dispatch or CEL filter evaluation
+  - Configuring the event-router service for new Kafka channels
+  - Implementing chain termination in multi-step saga pipelines
+instructions: |
+  Use the event: trigger prefix in saga definitions to execute sagas reactively when Kafka events arrive.
+  CEL filters on the optional filter field scope which events fire the saga; omit the filter to match all events on the channel.
+  Prevent infinite loops by writing filters that exclude the saga's own output events (chain termination pattern).
+  The event-router service (formerly utilization-metering-consumer) consumes Kafka topics, evaluates filters, and calls control-plane ExecuteSaga.
+  Maximum chain depth defaults to 10; access current depth in CEL via chain_depth.
+---
+
+# 33. Event-Triggered Sagas
+
+Date: 2026-03-04
+
+## Status
+
+Accepted
+
+## Context
+
+[ADR-0028](0028-starlark-saga-cel-valuation.md) established Starlark sagas as the orchestration layer and
+identified three trigger types: API calls, webhooks, and scheduled jobs. This covered reactive triggers
+from external clients and time-based triggers, but left a gap for **platform-internal reactivity**: sagas
+that must fire when another service emits a Kafka event.
+
+### The Gap: No Reactive Pipeline Trigger
+
+Without a reactive trigger, tenant configurations must choose between:
+
+1. **Pull-based polling**: A scheduled saga queries for new events. Adds latency, wastes compute during
+   quiet periods, and strains upstream services during catch-up.
+
+2. **Hardcoded consumers**: Platform engineers write Go consumers per use case. Eliminates tenant
+   self-service and creates an N×M coupling problem (N services × M tenant use cases).
+
+3. **Webhook fan-out**: External systems push events back into the platform. Doubles network traffic and
+   requires tenants to operate infrastructure outside Meridian.
+
+### The Business Need
+
+The convergence of finance, energy, and real-world assets requires closed-loop workflows where a position
+capture automatically triggers valuation, where a party registration triggers compliance checks, and where
+a market data observation triggers a payout distribution. These workflows are tenant-specific business
+logic that cannot be hardcoded into platform services.
+
+| Use Case | Triggering Event | Downstream Action |
+|----------|-----------------|-------------------|
+| Energy billing | kWh position captured | Compute GBP settlement value |
+| Cloud billing | GPU_HOUR position captured | Calculate USD charge |
+| KYC initiation | Individual party created | Book compliance reserve |
+| Payout distribution | Race result becomes official | Distribute winnings to syndicate |
+| Cost basis adjustment | Corporate action recorded | Adjust cost basis accounts |
+
+### Why CEL for Filters
+
+Event channels carry heterogeneous events. A single position-keeping channel publishes transactions for
+all instruments (GBP, kWh, GPU_HOUR, GOLD, SILVER, PLATINUM, etc.). A saga that only handles kWh
+transactions must not fire on GBP transactions.
+
+CEL was already in use for validation expressions ([ADR-0014](0014-financial-instrument-reference-data.md))
+and saga preconditions ([ADR-0028](0028-starlark-saga-cel-valuation.md)). It provides:
+
+- Sub-millisecond evaluation (guaranteed bounded execution)
+- Compile-time validation at manifest apply (errors caught before production)
+- Access to event payload fields, metadata headers, and chain depth
+
+### The Chain Depth Problem
+
+Event-triggered sagas create new positions. New positions emit events. Those events trigger sagas. Without
+a termination mechanism, this loop runs indefinitely.
+
+Three approaches were evaluated:
+
+| Approach | Mechanism | Risk |
+|----------|-----------|------|
+| Filter-only | CEL filter excludes output events | Correct but easily misconfigured |
+| Time-to-live | Discard events older than N seconds | Breaks slow-path sagas legitimately |
+| Depth counter | Increment header on each hop; drop beyond limit | Bounded by construction; safe backstop |
+
+**Decision**: Use both CEL filters (the correct solution) and a depth counter (the safe backstop).
+Filters terminate loops by design; the counter terminates loops when filters are misconfigured.
+
+## Decision Drivers
+
+* **Tenant self-service**: Reactive workflows must be configurable from manifests without platform
+  engineering involvement.
+* **Zero latency**: React to events as they arrive; polling introduces unnecessary lag for financial data.
+* **Safety**: No infinite loops, no unbounded resource consumption, no cross-tenant data leakage.
+* **Idempotency**: At-least-once Kafka delivery requires exactly-once saga execution.
+* **Consistency**: Same Starlark + CEL toolchain already used for other trigger types.
+
+## Considered Options
+
+1. **Polling schedulers per tenant** — Periodic sagas query for unprocessed events
+2. **Per-use-case Go consumers** — Platform engineers write consumers for each reactive pattern
+3. **Webhook fan-out via external system** — Events routed through an external broker back to webhooks
+4. **Event-triggered sagas with CEL filters** (chosen) — `event:` trigger prefix with optional filter field
+
+## Decision Outcome
+
+Chosen option: **event-triggered sagas with CEL filters**, because it extends the existing Starlark
+manifest model to reactive pipelines without introducing new primitives or requiring platform code changes
+for each new tenant use case.
+
+### Trigger Format
+
+The `trigger` field in a saga definition accepts the `event:` prefix followed by the Kafka channel name:
+
+```yaml
+saga_definitions:
+  - name: kwh_valuation
+    trigger: "event:position-keeping.transaction-captured.v1"
+    filter: "event.instrument_code == 'KWH' && event.direction == 'DEBIT'"
+    script: |
+      # Starlark saga body...
+```
+
+The `filter` field is optional. When omitted, the saga fires on every event on the channel.
+
+### CEL Filter Environment
+
+The `event_filter` CEL environment exposes three variables:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `event` | `dyn` | Event payload fields (deserialized from proto via AsyncAPI mapping) |
+| `metadata` | `map(string, string)` | Kafka message headers (correlation-id, tenant-id, chain-depth, etc.) |
+| `chain_depth` | `int` | Current saga chain depth (number of event-triggered hops in this chain) |
+
+### Chain Depth Enforcement
+
+Each saga execution adds the `x-meridian-chain-depth` header to outbound Kafka messages. The event-router
+reads this header and increments it on each hop. Events arriving with `chain_depth >= max_chain_depth`
+(default: 10) are dropped with a warning log.
+
+```
+Event arrives (depth=0)
+    → Filter matches → Saga executes → New position created
+    → New event published (depth=1)
+    → Filter matches → Saga executes → ...
+    → Event arrives (depth=9)
+    → Filter excludes output instrument (chain terminated by design)
+    → OR depth >= 10 (chain terminated by safety limit)
+```
+
+### Event-Router Service
+
+The event-router service handles the Kafka → CEL → gRPC dispatch pipeline:
+
+1. **Kafka consumer**: Multi-channel consumer subscribing to all registered event channels
+2. **Saga registry**: Thread-safe in-memory index mapping channel names to compiled sagas with
+   precompiled CEL filter programs. Reloaded atomically when the manifest changes.
+3. **CEL evaluation**: For each incoming event, evaluates each registered filter. Non-matching sagas
+   are skipped; evaluation errors skip the saga with a warning log.
+4. **Idempotency store**: CockroachDB-backed store deduplicates saga dispatches by `(sagaName, correlationID)`.
+   At-least-once Kafka delivery cannot cause duplicate saga executions.
+5. **gRPC trigger**: Calls control-plane `ExecuteSaga` RPC with the event payload as `input_data`.
+
+### Input Data Structure
+
+The `input_data` dictionary available to the Starlark saga script contains the event proto fields
+mapped to Go types, plus standard headers:
+
+```python
+input_data = {
+    # Standard headers (always present)
+    "correlation_id": "uuid-from-message-headers",
+
+    # Event payload fields (from proto via AsyncAPI deserialization)
+    "event": {
+        "instrument_code": "KWH",
+        "direction": "DEBIT",
+        "amount_cents": 150000,
+        "account_id": "acc-uuid",
+        # ... other proto fields
+    },
+
+    # Raw metadata headers
+    "metadata": {
+        "x-meridian-chain-depth": "1",
+        "x-tenant-id": "tenant-uuid",
+        # ...
+    },
+}
+```
+
+The thin event pattern applies: the saga receives only the fields published by the event producer.
+Business data (account type, valuation method, billing account) is resolved by the saga via service
+module calls against the entity graph.
+
+### Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                          Tenant Manifest                              │
+│  saga_definitions:                                                   │
+│    - name: kwh_valuation                                             │
+│      trigger: "event:position-keeping.transaction-captured.v1"       │
+│      filter: "event.instrument_code == 'KWH'"                        │
+│      script: <starlark>                                              │
+└─────────────────────────────┬────────────────────────────────────────┘
+                              │ applied via control-plane
+                              ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                          Event Router                                 │
+│                                                                      │
+│  Kafka Consumer                                                      │
+│    ↓                                                                 │
+│  Saga Registry (channel → [CompiledSaga])                            │
+│    ↓                                                                 │
+│  CEL Filter Evaluation (< 1ms per saga)                              │
+│    ↓                                                                 │
+│  Idempotency Store (CockroachDB-backed dedup)                        │
+│    ↓                                                                 │
+│  gRPC → control-plane.ExecuteSaga                                    │
+└─────────────────────────────┬────────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                         Control Plane                                 │
+│  Executes Starlark saga with input_data from event                   │
+│  New positions emitted → new Kafka events → loop or terminate        │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Positive Consequences
+
+* **Tenant self-service**: New reactive workflows defined entirely in manifests; no platform code changes.
+* **Real-time**: Sub-second latency from event arrival to saga execution.
+* **Type-safe filters**: CEL filters validated at manifest apply; invalid expressions rejected before
+  they can silently fail in production.
+* **Bounded execution**: Chain depth counter provides a hard safety limit against runaway loops.
+* **Idempotency**: CockroachDB-backed deduplication protects against Kafka at-least-once redelivery.
+* **Observability**: Prometheus metrics for events received, sagas triggered, filter latency, chain depth
+  exceeded, and trigger failures.
+* **Consistent toolchain**: Same Starlark + CEL model as API and scheduled triggers; no new languages.
+
+### Negative Consequences
+
+* **Filter correctness is tenant responsibility**: Misconfigured filters that do not terminate loops rely
+  on the depth counter backstop, which drops events rather than surfacing a configuration error.
+* **Kafka ordering not guaranteed**: Multiple event-router replicas may process partitions independently;
+  sagas must not assume ordering of events within a channel.
+* **Registry staleness**: The saga registry is loaded on manifest apply. Sagas added between registry
+  reloads will not fire on events arriving during that window.
+* **Channel proliferation**: Each new reactive use case requires a Kafka channel; the event-router
+  subscribes to all registered channels, increasing broker connections.
+
+## Implementation Details
+
+### Manifest Validation
+
+The manifest applier validates event-triggered sagas at apply time:
+
+1. `trigger` channel must be registered in the AsyncAPI channel registry
+2. `filter` CEL expression must compile against the `event_filter` environment
+3. `filter` must return a boolean value (validated by type-checking the AST)
+4. Chain termination is not automatically verified — operators must ensure filters exclude output events
+
+### Idempotency Key Derivation
+
+The correlation ID for idempotency is extracted from Kafka message headers in priority order:
+
+1. `x-meridian-correlation-id` header
+2. `correlation-id` header
+3. Generated UUID (with a warning log — Kafka redelivery may cause duplicate executions)
+
+### Prometheus Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `meridian_event_router_events_received_total` | Counter | `channel` | Events entering the dispatch handler |
+| `meridian_event_router_sagas_triggered_total` | Counter | `saga_name`, `channel` | Successful saga triggers |
+| `meridian_event_router_filter_evaluation_duration_seconds` | Histogram | `saga_name` | CEL evaluation latency |
+| `meridian_event_router_filter_evaluation_errors_total` | Counter | `saga_name` | CEL evaluation failures |
+| `meridian_event_router_chain_depth_exceeded_total` | Counter | — | Events dropped at chain depth limit |
+| `meridian_event_router_saga_trigger_failures_total` | Counter | `saga_name`, `channel` | Trigger infrastructure failures |
+| `meridian_event_router_duplicate_events_total` | Counter | `saga_name` | Idempotency key collisions |
+
+## Chain Termination Patterns
+
+### Filter-Based Termination (Recommended)
+
+Exclude the saga's own output from re-triggering:
+
+```cel
+# Energy valuation: only fire on non-GBP debits (GBP output excluded by filter)
+event.instrument_code != 'GBP' && event.direction == 'DEBIT'
+
+# Precious metals: only fire on listed metals (GBP settlement output excluded)
+event.instrument_code in ['GOLD', 'SILVER', 'PLATINUM']
+
+# Party events: only fire on new individual parties (no downstream loop possible)
+event.party_type == 'INDIVIDUAL'
+```
+
+### Depth-Based Termination (Safety Backstop)
+
+Use `chain_depth` in CEL to hard-limit multi-hop chains:
+
+```cel
+# Allow up to 3 hops in a chain, then stop
+event.instrument_code != 'GBP' && chain_depth < 3
+```
+
+## Links
+
+### Reference Implementations
+
+* [`valuation_on_capture.star`](../../services/control-plane/internal/applier/testdata/tenant-saga-examples/valuation_on_capture.star) — Precious metals spot valuation
+* [`kyc_on_party.star`](../../services/control-plane/internal/applier/testdata/tenant-saga-examples/kyc_on_party.star) — KYC compliance marker
+* [`usage_to_value.star`](../../services/control-plane/internal/applier/testdata/tenant-saga-examples/usage_to_value.star) — Energy cross-instrument valuation
+* [`compute_billing.star`](../../services/control-plane/internal/applier/testdata/tenant-saga-examples/compute_billing.star) — Cloud usage billing
+* [`race_result_distribution.star`](../../services/control-plane/internal/applier/testdata/tenant-saga-examples/race_result_distribution.star) — Party hierarchy payout
+
+### Related Services
+
+* [Event Router Service](../../services/event-router/README.md) — Kafka consumer and dispatch service
+* Event Router Runbook — `docs/runbooks/event-router.md`
+* Event-Triggered Sagas Skill — `docs/skills/event-triggered-sagas.md`
+
+### Related ADRs
+
+* [ADR-0028: Starlark Saga Orchestration with CEL Valuation](0028-starlark-saga-cel-valuation.md) — Foundation
+* [ADR-0014: Financial Instrument Reference Data](0014-financial-instrument-reference-data.md) — CEL compiler
+* [ADR-0004: Event Schema Evolution](0004-event-schema-evolution.md) — Protobuf + Kafka conventions
+
+### Guides
+
+* [Manifest Design Patterns](../guides/manifest-design-patterns.md) — Trigger and filter design
+* [Starlark Style Guide](../guides/starlark-style-guide.md) — Starlark syntax conventions
+
+## Notes
+
+### Reconsidering This Decision
+
+Revisit if:
+
+- The saga registry reload window causes observable missed events in production (consider push-based
+  registry updates from the control plane)
+- Channel proliferation causes Kafka broker connection saturation (consider a multiplexed event bus
+  with topic-level routing)
+- CEL filter errors become a support burden (consider surfacing filter validation warnings as manifest
+  apply responses rather than silent skip-with-log)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -80,6 +80,8 @@ Architectural Decision Records) format.
 | [ADR-0031](0031-getbalance-nil-guard-retention.md) | Retain Nil Guard on PositionKeepingClient in GetBalance | Accepted | 2026-02-13 |
 <!-- markdownlint-disable-next-line MD013 -->
 | [ADR-0032](0032-vanguard-json-transcoding-gateway.md) | Vanguard HTTP/JSON Transcoding Gateway | Accepted | 2026-02-20 |
+<!-- markdownlint-disable-next-line MD013 -->
+| [ADR-0033](0033-event-triggered-sagas.md) | Event-Triggered Sagas | Accepted | 2026-03-04 |
 
 ## Architecture Decision Relationships
 
@@ -147,6 +149,10 @@ graph LR
 ### API Gateway & Protocols
 
 - [ADR-0032](0032-vanguard-json-transcoding-gateway.md) - Vanguard HTTP/JSON Transcoding Gateway
+
+### Event-Driven Architecture
+
+- [ADR-0033](0033-event-triggered-sagas.md) - Event-Triggered Sagas
 
 ### Multi-Tenancy
 

--- a/docs/guides/manifest-design-patterns.md
+++ b/docs/guides/manifest-design-patterns.md
@@ -557,3 +557,84 @@ When guiding a tenant through economy design, follow this sequence:
 
 This sequence maps directly to the manifest structure and can be driven by
 conversational AI that asks the right questions at each step.
+
+---
+
+## Event-Triggered Saga Pattern
+
+**When to use:** Any saga that should fire reactively when a Kafka event arrives, without requiring a
+user-initiated API call or a scheduled job.
+
+**Reference examples:**
+
+<!-- markdownlint-disable MD013 -->
+- [`valuation_on_capture.star`](../../services/control-plane/internal/applier/testdata/tenant-saga-examples/valuation_on_capture.star) — Spot rate valuation on precious metals
+- [`kyc_on_party.star`](../../services/control-plane/internal/applier/testdata/tenant-saga-examples/kyc_on_party.star) — Compliance marker on party creation
+<!-- markdownlint-enable MD013 -->
+
+**Manifest definition:**
+
+```yaml
+saga_definitions:
+  - name: kwh_valuation
+    trigger: "event:position-keeping.transaction-captured.v1"
+    filter: "event.instrument_code == 'KWH' && event.direction == 'DEBIT'"
+    script: |
+      kwh_valuation_saga = saga(name="kwh_valuation")
+
+      def execute():
+          ctx = input_data
+          correlation_id = ctx["correlation_id"]
+          account_id     = ctx["event"]["account_id"]
+          amount         = Decimal(ctx["event"]["instrument_amount"]["amount"])
+
+          # Resolve billing account from entity graph (thin event pattern)
+          step(name="lookup_account")
+          account = reference_data.get_account(id=account_id)
+          billing_account_id = account.metadata["billing_account_id"]
+
+          # Idempotency check
+          step(name="check_idempotency")
+          existing = position_keeping.query_logs(
+              correlation_id=correlation_id,
+              instrument_code="GBP",
+              account_id=billing_account_id,
+          )
+          if existing.count > 0:
+              return {"status": "ALREADY_VALUED"}
+
+          # Compute and book GBP charge
+          step(name="compute_valuation")
+          account_type = reference_data.get_account_type(code=account.account_type_code)
+          valuation = valuation_engine.compute(
+              method_id=account_type.default_conversion_method_id,
+              amount=amount,
+              from_instrument="KWH",
+              to_instrument="GBP",
+          )
+
+          step(name="book_charge")
+          position_keeping.initiate_log(
+              account_id=billing_account_id,
+              instrument_code="GBP",
+              direction="DEBIT",
+              amount=valuation.amount,
+              correlation_id=correlation_id,
+          )
+
+          return {"status": "VALUED", "gbp_amount": str(valuation.amount)}
+
+      output = execute()
+```
+
+**Key design decisions:**
+
+- **Chain termination:** The CEL filter `instrument_code == 'KWH'` excludes GBP positions created by
+  this saga from re-triggering it. The saga will never fire on its own output.
+- **Thin event:** Only `account_id` and `amount` are taken from the event. Billing account and
+  conversion method are resolved from the entity graph at runtime — not hardcoded in the manifest.
+- **Idempotency:** Checks for an existing GBP position before proceeding. Safe against Kafka
+  at-least-once redelivery.
+
+**See also:** [ADR-0033: Event-Triggered Sagas](../adr/0033-event-triggered-sagas.md) and
+[Event-Triggered Sagas Skill](../skills/event-triggered-sagas.md).

--- a/docs/guides/starlark-style-guide.md
+++ b/docs/guides/starlark-style-guide.md
@@ -907,4 +907,92 @@ For detailed validation documentation, see the [Saga Validation Guide](saga-vali
 - **[Saga Validation Guide](saga-validation.md)** - Validation workflow, error interpretation, and monitoring
 - **[Saga Handlers Schema](../saga-handlers.schema.json)** - Available service modules and handlers
 - **[Saga Service Catalog](../saga-service-catalog.md)** - Service module documentation
+
+---
+
+## Event-Triggered Saga Patterns
+
+Sagas triggered by the `event:` prefix receive their input from a Kafka event. The `input_data`
+dictionary has a nested structure compared to API-triggered sagas.
+
+### Input Data Access
+
+```python
+def execute():
+    ctx = input_data
+
+    # Standard headers (same as all trigger types)
+    correlation_id = ctx["correlation_id"]
+
+    # Event payload fields are nested under "event"
+    account_id       = ctx["event"]["account_id"]
+    instrument_code  = ctx["event"]["instrument_code"]
+    direction        = ctx["event"]["direction"]
+
+    # Multi-asset amount
+    amount = Decimal(ctx["event"]["instrument_amount"]["amount"])
+
+    # Kafka metadata headers (for advanced use)
+    chain_depth = int(ctx["metadata"].get("x-meridian-chain-depth", "0"))
+```
+
+### Chain Termination Pattern
+
+Event-triggered sagas create positions that emit new events. Prevent infinite loops by writing
+CEL filters that exclude the saga's own output:
+
+```python
+# If this saga creates GBP positions, the filter must exclude GBP events:
+# trigger: "event:position-keeping.transaction-captured.v1"
+# filter:  "event.instrument_code != 'GBP' && event.direction == 'DEBIT'"
+#
+# The saga then handles kWh/GPU_HOUR/GOLD events but NOT GBP events it creates.
+```
+
+### Idempotency Check Pattern
+
+Kafka guarantees at-least-once delivery. Event-triggered sagas must check whether work has
+already been done:
+
+```python
+def execute():
+    ctx = input_data
+    correlation_id = ctx["correlation_id"]
+
+    # Always check before doing work
+    step(name="check_idempotency")
+    existing = position_keeping.query_logs(
+        correlation_id=correlation_id,
+        instrument_code="GBP",
+        account_id=settlement_account_id,
+    )
+
+    if existing.count > 0:
+        return {"status": "ALREADY_PROCESSED", "correlation_id": correlation_id}
+
+    # Proceed with actual work only if not already done
+```
+
+### Entity Graph Resolution Pattern
+
+The event carries only the fields published by the producer. Resolve business data via service
+module calls — do not embed computed values in the event payload:
+
+```python
+def execute():
+    ctx = input_data
+    account_id = ctx["event"]["account_id"]  # From event
+
+    # Resolve business data from entity graph (not from event)
+    step(name="lookup_account")
+    account = reference_data.get_account(id=account_id)
+    billing_account_id = account.metadata["billing_account_id"]  # From entity graph
+
+    step(name="lookup_account_type")
+    account_type = reference_data.get_account_type(code=account.account_type_code)
+    conversion_method = account_type.default_conversion_method_id
+```
+
+For complete event-triggered saga documentation, see **[Event-Triggered Sagas](../skills/event-triggered-sagas.md)**.
+
 - **[ADR-0028: Starlark Saga & CEL Valuation](../adr/0028-starlark-saga-cel-valuation.md)** - Architecture decision

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -32,6 +32,8 @@ scenarios.
   pricing updates, and rate management
 - **[troubleshooting-saga-handlers.md](troubleshooting-saga-handlers.md)** - Debugging Starlark saga
   scripts, handler errors, and execution failures
+- **[event-router.md](event-router.md)** - Event-router service operations: dispatching Kafka events
+  to tenant sagas, CEL filter troubleshooting, chain depth incidents
 
 ## Runbook Structure
 

--- a/docs/runbooks/event-router.md
+++ b/docs/runbooks/event-router.md
@@ -56,7 +56,7 @@ evaluates registered CEL filters and triggers matching sagas.
 | `CONSUMER_GROUP_ID` | No | `event-router` | Consumer group ID for offset management |
 | `POSITION_KEEPING_ENDPOINT` | Yes | — | gRPC endpoint for Position Keeping (legacy, billing path) |
 | `TENANT_ZERO_ID` | Yes | — | UUID of the platform billing tenant |
-| `TENANT_ACCOUNT_MAPPING` | No | `{}` | JSON mapping of tenant UUIDs to billing account UUIDs |
+| `TENANT_ACCOUNT_MAPPING` | No | `""` | JSON mapping of tenant UUIDs to billing account UUIDs |
 | `HTTP_PORT` | No | `8080` | HTTP port for health checks and metrics |
 | `ENABLE_MDS_OUTPUT` | No | `true` | Feature flag for Market Data Service output |
 | `MDS_SERVICE_ADDR` | No | — | gRPC address for Market Data Service |
@@ -199,8 +199,10 @@ kubectl logs deployment/event-router | grep "trigger saga"
 
 ```bash
 # Via Meridian MCP: confirm saga exists and has event: trigger
-mcp__meridian__meridian_handlers_describe(trigger_prefix: "webhook")
-# Note: use the control-plane describe API to inspect active sagas
+mcp__meridian__meridian_handlers_describe(trigger_prefix: "api")
+# Review the output for sagas with trigger beginning "event:"
+# Note: the handlers_describe tool lists api/webhook/scheduled triggers;
+# use the control-plane describe API to inspect active saga definitions
 ```
 
 ---
@@ -245,12 +247,9 @@ mcp__meridian__meridian_manifest_plan(manifest: {...})
 mcp__meridian__meridian_manifest_apply(manifest: {...}, plan_hash: "...", applied_by: "operator@example.com")
 ```
 
-**Step 4:** If immediate relief is needed, temporarily increase `MAX_CHAIN_DEPTH` (not recommended for
-permanent use — fix the filter instead):
-
-```bash
-kubectl set env deployment/event-router MAX_CHAIN_DEPTH=20
-```
+**Step 4:** If immediate relief is needed, the maximum chain depth can be overridden via the
+`WithMaxChainDepth` option when constructing the `SagaDispatchHandler` (requires a code change and
+redeployment). This is not recommended as a permanent fix — correct the filter instead.
 
 ---
 

--- a/docs/runbooks/event-router.md
+++ b/docs/runbooks/event-router.md
@@ -1,0 +1,470 @@
+---
+name: event-router-runbook
+description: Operational runbook for the event-router service that dispatches Kafka events to tenant sagas
+triggers:
+  - Event-triggered sagas are not firing when expected
+  - Kafka consumer lag is growing on event-router topics
+  - Chain depth exceeded alerts are firing
+  - Saga trigger failures or CEL filter errors are reported
+  - Event-router service is failing health checks or not starting
+instructions: |
+  The event-router service consumes Kafka events and dispatches them to tenant sagas via control-plane ExecuteSaga gRPC.
+  Check Prometheus metrics (events_received, sagas_triggered, filter_evaluation_errors, chain_depth_exceeded) first.
+  Use kubectl logs deployment/event-router to inspect structured logs with channel, saga_name, and correlation_id fields.
+  The saga registry reloads on manifest apply; a missed event window is expected during reload.
+  CockroachDB-backed idempotency store deduplicates by (sagaName, correlationID); duplicate_events_total is expected to be non-zero.
+---
+
+# Event Router Runbook
+
+Operational procedures for the event-router service, which consumes Kafka events and dispatches them to
+tenant-configured sagas via the `event:` trigger.
+
+## Service Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **Service Name** | `event-router` |
+| **Port** | 8080 (HTTP — health checks and metrics) |
+| **Kubernetes Deployment** | `deployment/event-router` |
+| **Language** | Go |
+| **Dependency: Kafka** | Multi-channel consumer (all registered event channels) |
+| **Dependency: Control Plane** | gRPC `ExecuteSaga` RPC |
+| **Dependency: CockroachDB** | Idempotency store |
+
+## Architecture
+
+```text
+Kafka Topics
+    │
+    ▼
+Event Router
+    ├── Saga Registry (channel → [CompiledSaga with CEL filter])
+    ├── CEL Filter Evaluation (< 1ms per saga)
+    ├── Idempotency Store (CockroachDB-backed dedup)
+    └── gRPC → control-plane:ExecuteSaga
+```
+
+The event-router performs no business logic itself. It is a routing layer: for each Kafka event, it
+evaluates registered CEL filters and triggers matching sagas.
+
+## Configuration Reference
+
+| Environment Variable | Required | Default | Description |
+|---------------------|----------|---------|-------------|
+| `KAFKA_BOOTSTRAP_SERVERS` | Yes | — | Kafka broker addresses (e.g., `kafka:9092`) |
+| `CONSUMER_GROUP_ID` | No | `event-router` | Consumer group ID for offset management |
+| `POSITION_KEEPING_ENDPOINT` | Yes | — | gRPC endpoint for Position Keeping (legacy, billing path) |
+| `TENANT_ZERO_ID` | Yes | — | UUID of the platform billing tenant |
+| `TENANT_ACCOUNT_MAPPING` | No | `{}` | JSON mapping of tenant UUIDs to billing account UUIDs |
+| `HTTP_PORT` | No | `8080` | HTTP port for health checks and metrics |
+| `ENABLE_MDS_OUTPUT` | No | `true` | Feature flag for Market Data Service output |
+| `MDS_SERVICE_ADDR` | No | — | gRPC address for Market Data Service |
+| `MDS_AGGREGATION_WINDOW` | No | `1h` | Aggregation window for buffered observations |
+| `MDS_FLUSH_INTERVAL` | No | `5m` | Flush interval for buffered observations |
+
+## HTTP Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/healthz` | GET | Liveness probe (always returns 200 OK) |
+| `/ready` | GET | Readiness probe (checks Kafka consumer initialization) |
+| `/metrics` | GET | Prometheus metrics endpoint |
+
+## Prometheus Metrics
+
+### Dispatch Pipeline
+
+| Metric | Type | Labels | Alert Threshold |
+|--------|------|--------|-----------------|
+| `meridian_event_router_events_received_total` | Counter | `channel` | Monitor for sudden drops |
+| `meridian_event_router_sagas_triggered_total` | Counter | `saga_name`, `channel` | Monitor for unexpected drops |
+| `meridian_event_router_filter_evaluation_duration_seconds` | Histogram | `saga_name` | p99 > 10ms warrants investigation |
+| `meridian_event_router_filter_evaluation_errors_total` | Counter | `saga_name` | Any non-zero rate is an alert |
+| `meridian_event_router_chain_depth_exceeded_total` | Counter | — | Any non-zero rate warrants investigation |
+| `meridian_event_router_saga_trigger_failures_total` | Counter | `saga_name`, `channel` | Any non-zero rate is an alert |
+| `meridian_event_router_duplicate_events_total` | Counter | `saga_name` | Non-zero is expected; track trend |
+
+### Recommended Alert Rules
+
+```yaml
+# Critical: Saga trigger failures
+- alert: EventRouterSagaTriggerFailures
+  expr: rate(meridian_event_router_saga_trigger_failures_total[5m]) > 0
+  for: 2m
+  annotations:
+    summary: "Event-router saga trigger failures detected"
+    description: "Saga {{ $labels.saga_name }} is failing to trigger on channel {{ $labels.channel }}"
+
+# Warning: CEL filter evaluation errors
+- alert: EventRouterFilterEvaluationErrors
+  expr: rate(meridian_event_router_filter_evaluation_errors_total[5m]) > 0
+  for: 1m
+  annotations:
+    summary: "CEL filter evaluation errors in event-router"
+    description: "Saga {{ $labels.saga_name }} has a misconfigured CEL filter"
+
+# Warning: Chain depth exceeded
+- alert: EventRouterChainDepthExceeded
+  expr: rate(meridian_event_router_chain_depth_exceeded_total[5m]) > 0
+  for: 2m
+  annotations:
+    summary: "Event-router chain depth limit exceeded — events are being dropped"
+    description: "A saga pipeline has reached max chain depth. Check CEL filter chain termination."
+
+# Warning: No events received on channel (possible Kafka issue)
+- alert: EventRouterNoEventsOnChannel
+  expr: increase(meridian_event_router_events_received_total[10m]) == 0
+  for: 10m
+  annotations:
+    summary: "No events received on any channel for 10 minutes"
+    description: "Event-router may have lost Kafka connection or consumer group is stalled"
+```
+
+---
+
+## Procedures
+
+### Check Service Health
+
+```bash
+# Liveness
+kubectl exec -it deployment/event-router -- curl -s http://localhost:8080/healthz
+
+# Readiness (includes Kafka consumer initialization check)
+kubectl exec -it deployment/event-router -- curl -s http://localhost:8080/ready
+
+# Recent logs
+kubectl logs deployment/event-router --tail=50
+
+# Structured log fields to look for:
+# "component": "saga_dispatch_handler"
+# "channel": the Kafka channel
+# "saga_name": the saga that fired
+# "correlation_id": the idempotency key
+# "chain_depth": current chain hop count
+```
+
+### Investigate: Saga Not Firing
+
+**Step 1:** Confirm events are arriving on the channel.
+
+```bash
+# Check events received counter
+kubectl exec -it deployment/event-router -- \
+  curl -s http://localhost:8080/metrics | grep 'events_received_total'
+
+# Expected output:
+# meridian_event_router_events_received_total{channel="position-keeping.transaction-captured.v1"} 1234
+```
+
+**Step 2:** Confirm the saga is registered and filter is compiling.
+
+```bash
+# Check for filter evaluation errors at startup
+kubectl logs deployment/event-router | grep "compile CEL filter"
+
+# Expected output if OK: nothing
+# Expected output if error:
+# level=ERROR msg="compile CEL filter for saga" saga_name="my_saga" error="..."
+```
+
+**Step 3:** Check if events are matching the filter.
+
+```bash
+# Check sagas triggered counter
+kubectl exec -it deployment/event-router -- \
+  curl -s http://localhost:8080/metrics | grep 'sagas_triggered_total'
+
+# Check filter did not match logs
+kubectl logs deployment/event-router | grep "CEL filter did not match"
+# Log fields: saga_name, channel, correlation_id
+
+# Check filter evaluation errors
+kubectl logs deployment/event-router | grep "CEL filter evaluation error"
+```
+
+**Step 4:** Check control-plane is reachable.
+
+```bash
+# Check saga trigger failures
+kubectl exec -it deployment/event-router -- \
+  curl -s http://localhost:8080/metrics | grep 'saga_trigger_failures_total'
+
+# Check gRPC connectivity to control-plane
+kubectl logs deployment/event-router | grep "trigger saga"
+```
+
+**Step 5:** Check manifest is applied and saga is registered.
+
+```bash
+# Via Meridian MCP: confirm saga exists and has event: trigger
+mcp__meridian__meridian_handlers_describe(trigger_prefix: "webhook")
+# Note: use the control-plane describe API to inspect active sagas
+```
+
+---
+
+### Investigate: Chain Depth Exceeded
+
+**Symptom:** `meridian_event_router_chain_depth_exceeded_total` is non-zero. Events are being dropped.
+
+**Impact:** Sagas in the chain after the depth limit are not executing. Positions may be missing.
+
+**Step 1:** Identify which sagas are in the chain.
+
+```bash
+kubectl logs deployment/event-router | grep "chain depth exceeded"
+# Log fields: channel, chain_depth, max_chain_depth
+```
+
+**Step 2:** Review the saga's CEL filter for chain termination.
+
+The filter must exclude events produced by the saga itself. Common pattern: if the saga produces
+GBP positions, the filter must exclude `instrument_code == 'GBP'`:
+
+```cel
+# Correct: terminates at GBP
+event.instrument_code != 'GBP' && event.direction == 'DEBIT'
+
+# Wrong: does not terminate, loops on GBP output
+event.direction == 'DEBIT'
+```
+
+**Step 3:** Update the manifest with a corrected filter and re-apply.
+
+```bash
+# Via Meridian MCP: validate the updated filter
+mcp__meridian__meridian_cel_validate(
+  expression: "event.instrument_code != 'GBP' && event.direction == 'DEBIT'",
+  environment: "eligibility"
+)
+
+# Apply manifest with plan-then-apply workflow
+mcp__meridian__meridian_manifest_plan(manifest: {...})
+mcp__meridian__meridian_manifest_apply(manifest: {...}, plan_hash: "...", applied_by: "operator@example.com")
+```
+
+**Step 4:** If immediate relief is needed, temporarily increase `MAX_CHAIN_DEPTH` (not recommended for
+permanent use — fix the filter instead):
+
+```bash
+kubectl set env deployment/event-router MAX_CHAIN_DEPTH=20
+```
+
+---
+
+### Investigate: High Kafka Consumer Lag
+
+**Symptom:** Consumer group `event-router` is falling behind on one or more partitions.
+
+**Step 1:** Check lag per topic/partition.
+
+```bash
+# Kafka consumer lag via kubectl
+kubectl exec -it deployment/kafka -- \
+  kafka-consumer-groups.sh --bootstrap-server localhost:9092 \
+  --group event-router --describe
+
+# Or via metrics
+kubectl exec -it deployment/event-router -- \
+  curl -s http://localhost:8080/metrics | grep 'consumer_lag'
+```
+
+**Step 2:** Check if the service is healthy and processing.
+
+```bash
+kubectl get pods -l app=event-router
+kubectl logs deployment/event-router --tail=20
+```
+
+**Step 3:** Scale up if lag is due to high throughput.
+
+```bash
+kubectl scale deployment/event-router --replicas=3
+```
+
+Note: Kafka partitions cap the effective parallelism. Each partition is processed by at most one
+consumer in the group. If lag persists, check partition count vs. replica count.
+
+**Step 4:** Check for slow downstream (control-plane gRPC latency causing backpressure).
+
+```bash
+# Check saga trigger duration in logs
+kubectl logs deployment/event-router | grep "saga triggered"
+
+# Check control-plane health
+kubectl get pods -l app=control-plane
+```
+
+---
+
+### Investigate: Saga Trigger Failures
+
+**Symptom:** `meridian_event_router_saga_trigger_failures_total` is non-zero.
+
+These are infrastructure-level failures where the control-plane `ExecuteSaga` gRPC call returned an
+error after all retries were exhausted.
+
+**Step 1:** Identify which sagas and channels are failing.
+
+```bash
+kubectl exec -it deployment/event-router -- \
+  curl -s http://localhost:8080/metrics | grep 'saga_trigger_failures_total'
+
+kubectl logs deployment/event-router | grep "trigger saga"
+# Log fields: saga_name, channel, correlation_id, error
+```
+
+**Step 2:** Check control-plane health.
+
+```bash
+kubectl get pods -l app=control-plane
+kubectl logs deployment/control-plane --tail=50
+```
+
+**Step 3:** Check for saga definition errors in the control-plane.
+
+```bash
+kubectl logs deployment/control-plane | grep "ExecuteSaga"
+```
+
+**Note:** The event-router does not retry saga trigger failures after they return an error. If the
+control-plane was temporarily unavailable, affected events are not replayed. Events must be replayed
+from Kafka if recovery is needed.
+
+---
+
+### Investigate: CEL Filter Evaluation Errors
+
+**Symptom:** `meridian_event_router_filter_evaluation_errors_total` is non-zero.
+
+CEL filter evaluation errors indicate a filter expression that compiled successfully but fails at
+runtime (e.g., accessing a field that does not exist on the event proto).
+
+**Step 1:** Identify the failing saga.
+
+```bash
+kubectl exec -it deployment/event-router -- \
+  curl -s http://localhost:8080/metrics | grep 'filter_evaluation_errors_total'
+
+kubectl logs deployment/event-router | grep "CEL filter evaluation error"
+# Log fields: saga_name, channel, correlation_id, error
+```
+
+**Step 2:** Review the filter expression and event payload structure.
+
+The filter expression may be accessing a field that does not exist in the channel's event proto.
+Compare the filter against the AsyncAPI channel definition.
+
+**Step 3:** Fix the filter and re-apply the manifest.
+
+```bash
+# Validate the corrected expression
+mcp__meridian__meridian_cel_validate(
+  expression: "event.correct_field_name == 'VALUE'",
+  environment: "eligibility"
+)
+```
+
+The saga is skipped (not retried) when the filter evaluation fails. Events that arrived while the
+filter was broken are not replayed. If data consistency is critical, replay from Kafka.
+
+---
+
+### Restart the Service
+
+```bash
+# Rolling restart (preserves availability)
+kubectl rollout restart deployment/event-router
+
+# Verify rollout completed
+kubectl rollout status deployment/event-router
+
+# Check new pods are healthy
+kubectl get pods -l app=event-router
+```
+
+**Note:** During restart, the consumer group rebalances. There is a brief window where events are
+buffered in Kafka and not processed. This is normal and self-corrects after rebalance completes.
+
+---
+
+## Failure Mode Reference
+
+| Failure | Behaviour | Impact | Recovery |
+|---------|-----------|--------|----------|
+| CEL filter compile error at startup | Saga not registered (event-router logs error) | Saga never fires | Fix filter in manifest and re-apply |
+| CEL filter evaluation error at runtime | Saga skipped for this event (warning log) | Single event not processed | Fix filter; replay event if needed |
+| Chain depth exceeded | Event dropped (warning log) | Sagas beyond depth limit don't fire | Fix CEL filter chain termination |
+| Control-plane gRPC failure | Trigger fails; error logged | Saga not executed | Replay event from Kafka |
+| Kafka consumer lag | Events processed late | Saga execution latency increases | Scale deployment; check partition count |
+| Idempotency store unavailable | Dispatch attempted without deduplication | Risk of duplicate executions | Restore CockroachDB connectivity |
+| Event-router pod crash | Consumer group rebalances; events queue in Kafka | Temporary processing delay | Kubernetes restarts pod automatically |
+
+---
+
+## Escalation
+
+### When to Escalate
+
+Escalate to the on-call engineering team if:
+
+- Saga trigger failures persist for more than 5 minutes
+- Kafka consumer lag exceeds 5,000 messages and does not stabilize
+- Chain depth exceeded events are causing missing positions (data consistency concern)
+- CEL filter errors affect a high-value saga (billing, settlement, compliance)
+- Service fails to restart after rollout
+
+### Escalation Information
+
+```text
+Event Router Incident Report
+=============================
+
+Affected Sagas: [saga names]
+Affected Channels: [channel names]
+Duration: [start time to now]
+Event Count Affected: [from metrics]
+
+Symptoms:
+- [metric name and value]
+- [log excerpt]
+
+Investigation Steps Taken:
+- [step 1 and finding]
+- [step 2 and finding]
+
+Data Consistency Assessment:
+- Are positions missing? [yes/no/unknown]
+- Can missing events be replayed from Kafka? [yes/no - retention period?]
+```
+
+---
+
+## Post-Incident Actions
+
+After resolving an incident:
+
+1. **Document root cause** and timeline
+2. **Verify metrics** return to baseline
+3. **Check downstream data consistency**: query position logs for affected accounts/channels
+4. **Replay events if needed** (within Kafka retention window)
+5. **Update alert thresholds** if current thresholds were insufficient
+6. **Update this runbook** with any new troubleshooting steps discovered
+
+---
+
+## Related Documentation
+
+- [ADR-0033: Event-Triggered Sagas](../adr/0033-event-triggered-sagas.md) — Architecture decisions
+- [Event-Triggered Sagas Skill](../skills/event-triggered-sagas.md) — Configuration guide
+- [Saga Failure Recovery Runbook](saga-failure-recovery.md) — Recovering from saga execution failures
+- [Event Router Service README](../../services/event-router/README.md) — Service documentation
+- [Starlark Style Guide](../guides/starlark-style-guide.md) — Saga authoring conventions
+
+## Changelog
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-03-04 | Initial version — event-router operational runbook | Platform Team |

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -16,6 +16,8 @@ Each skill document includes:
 - **[docker.md](docker.md)** - Docker configuration and multi-stage builds
 - **[schema-evolution.md](schema-evolution.md)** - Protobuf schema evolution with buf breaking change detection
 - **[starlark-saga.md](starlark-saga.md)** - Generate Starlark saga scripts following Meridian conventions
+<!-- markdownlint-disable-next-line MD013 -->
+- **[event-triggered-sagas.md](event-triggered-sagas.md)** - Configure sagas that fire reactively on Kafka events with CEL filters
 
 ### Deployment
 

--- a/docs/skills/event-triggered-sagas.md
+++ b/docs/skills/event-triggered-sagas.md
@@ -323,7 +323,7 @@ keyed on `(sagaName, correlationID)`.
 
 ## Examples
 
-### Energy Billing: Single-Leg Valuation
+### Precious Metals: Spot Rate Settlement
 
 **File:** [`valuation_on_capture.star`](../../services/control-plane/internal/applier/testdata/tenant-saga-examples/valuation_on_capture.star)
 

--- a/docs/skills/event-triggered-sagas.md
+++ b/docs/skills/event-triggered-sagas.md
@@ -1,0 +1,464 @@
+---
+name: event-triggered-sagas
+description: Configure sagas that fire reactively when Kafka events arrive using event: trigger prefix and CEL filters
+triggers:
+  - Adding a saga that reacts to position captures, party events, or market data observations
+  - Writing CEL filters to scope which events trigger a saga
+  - Preventing infinite saga chains via chain termination filters
+  - Debugging why an event-triggered saga is not firing or firing too often
+  - Configuring the event-router service for a new Kafka channel
+instructions: |
+  Use the event: prefix in the trigger field of a saga definition to fire reactively on Kafka events.
+  The optional filter field accepts a CEL expression that must return bool; omit to match all events on the channel.
+  Prevent infinite loops by excluding the saga's own output events from the filter (e.g., instrument_code != 'GBP' when the saga creates GBP positions).
+  The CEL filter has access to event (dyn), metadata (map<string,string>), and chain_depth (int).
+  Reference ADR-0033 and the manifest-design-patterns guide for detailed patterns.
+---
+
+# Event-Triggered Sagas
+
+Configure sagas that execute reactively when Kafka events arrive on a channel.
+
+**Related:**
+
+- **[ADR-0033: Event-Triggered Sagas](../adr/0033-event-triggered-sagas.md)** - Architecture decision and design rationale
+- **[Manifest Design Patterns](../guides/manifest-design-patterns.md)** - Trigger and filter design
+- **[Starlark Style Guide](../guides/starlark-style-guide.md)** - Saga script conventions
+- **[Event Router Runbook](../runbooks/event-router.md)** - Operational procedures for the dispatch service
+
+---
+
+## Quick Start
+
+### Minimal Event-Triggered Saga
+
+```yaml
+saga_definitions:
+  - name: my_reactive_saga
+    trigger: "event:position-keeping.transaction-captured.v1"
+    filter: "event.instrument_code == 'KWH' && event.direction == 'DEBIT'"
+    script: |
+      my_saga = saga(name="my_reactive_saga")
+
+      def execute():
+          ctx = input_data
+          correlation_id = ctx["correlation_id"]
+          account_id = ctx["event"]["account_id"]
+          amount = Decimal(ctx["event"]["instrument_amount"]["amount"])
+
+          step(name="process")
+          position_keeping.initiate_log(
+              account_id=account_id,
+              instrument_code="GBP",
+              direction="DEBIT",
+              amount=amount,
+              correlation_id=correlation_id,
+          )
+
+          return {"status": "COMPLETED"}
+
+      output = execute()
+```
+
+### Trigger Format
+
+```text
+event:<channel-name>
+```
+
+| Part | Example | Description |
+|------|---------|-------------|
+| `event:` | `event:` | Fixed prefix for event-triggered sagas |
+| channel name | `position-keeping.transaction-captured.v1` | Kafka channel from the AsyncAPI registry |
+
+### Available Channels
+
+Common channels used in event-triggered sagas:
+
+| Channel | Events | Typical Use |
+|---------|--------|-------------|
+| `position-keeping.transaction-captured.v1` | Position captured | Valuation, billing, cost basis |
+| `market-information.observation-recorded.v1` | Market data | Payout distribution, price updates |
+| `party.created.v1` | Party registered | KYC initiation (aspirational) |
+
+---
+
+## CEL Filter Syntax
+
+The `filter` field is a CEL expression evaluated for each event arriving on the channel. Only events where
+the expression evaluates to `true` trigger the saga.
+
+### Available Variables
+
+| Variable | Type | Example Access |
+|----------|------|----------------|
+| `event` | `dyn` (dynamic map) | `event.instrument_code`, `event.direction` |
+| `metadata` | `map(string, string)` | `metadata["x-tenant-id"]` |
+| `chain_depth` | `int` | `chain_depth < 3` |
+
+### Common Filter Patterns
+
+**Single instrument:**
+
+```cel
+event.instrument_code == 'KWH' && event.direction == 'DEBIT'
+```
+
+**Multiple instruments (CEL `in` operator):**
+
+```cel
+event.instrument_code in ['GOLD', 'SILVER', 'PLATINUM']
+```
+
+**Exclude own output (chain termination):**
+
+```cel
+# Fires on any non-GBP debit; GBP positions created by this saga are excluded
+event.instrument_code != 'GBP' && event.direction == 'DEBIT'
+```
+
+**Market data events:**
+
+```cel
+event.dataset_code == 'HORSE_RACING' && event.quality == 'ACTUAL'
+```
+
+**Party events:**
+
+```cel
+event.party_type == 'INDIVIDUAL'
+```
+
+**Depth-limited chains:**
+
+```cel
+event.instrument_code != 'GBP' && chain_depth < 3
+```
+
+### Filter Omitted (Match All)
+
+When `filter` is absent, the saga fires on every event on the channel:
+
+```yaml
+saga_definitions:
+  - name: log_all_transactions
+    trigger: "event:position-keeping.transaction-captured.v1"
+    # No filter — matches every transaction
+    script: |
+      ...
+```
+
+---
+
+## Input Data Structure
+
+The Starlark `input_data` dictionary contains event payload fields plus standard headers:
+
+```python
+input_data = {
+    # Standard header (always present)
+    "correlation_id": "550e8400-e29b-41d4-a716-446655440000",
+
+    # Kafka metadata headers
+    "metadata": {
+        "x-meridian-chain-depth": "1",
+        "x-tenant-id": "tenant-uuid",
+        "x-meridian-correlation-id": "correlation-uuid",
+    },
+
+    # Event payload fields (from proto via AsyncAPI deserialization)
+    "event": {
+        "instrument_code": "KWH",
+        "direction": "DEBIT",
+        "amount_cents": 150000,
+        "account_id": "acc-uuid",
+        "log_id": "log-uuid",
+        "transaction_id": "txn-uuid",
+        "instrument_amount": {
+            "amount": "1500.00",
+            "instrument_code": "KWH",
+        },
+    },
+}
+```
+
+### Accessing Input Data
+
+```python
+def execute():
+    ctx = input_data
+
+    # Standard headers
+    correlation_id = ctx["correlation_id"]
+
+    # Event payload fields
+    account_id   = ctx["event"]["account_id"]
+    instrument   = ctx["event"]["instrument_code"]
+    direction    = ctx["event"]["direction"]
+    amount       = Decimal(ctx["event"]["instrument_amount"]["amount"])
+
+    # Chain depth (also available in CEL filter)
+    chain_depth  = int(ctx["metadata"].get("x-meridian-chain-depth", "0"))
+```
+
+### Thin Event Pattern
+
+The event carries only the fields published by the producer. Business data (account type, billing account,
+valuation method) is resolved by the saga via service module calls:
+
+```python
+def execute():
+    ctx = input_data
+    account_id = ctx["event"]["account_id"]
+
+    # Resolve business data from entity graph
+    step(name="lookup_account")
+    account = reference_data.get_account(id=account_id)
+    billing_account_id = account.metadata["billing_account_id"]
+    account_type = reference_data.get_account_type(code=account.account_type_code)
+```
+
+---
+
+## Chain Depth
+
+Event-triggered sagas create positions. New positions emit events. Those events can trigger more sagas.
+The chain depth counter prevents infinite loops.
+
+### How It Works
+
+1. Initial event arrives with no chain depth header (depth = 0)
+2. Saga executes and creates a new position
+3. New position event is published with `x-meridian-chain-depth: 1`
+4. Event arrives at event-router with depth = 1
+5. CEL filter evaluates `chain_depth` = 1
+6. If depth reaches `max_chain_depth` (default: 10), event is dropped with a warning log
+
+### Correct Termination: Filter-Based
+
+The preferred approach is to write CEL filters that exclude the saga's own output:
+
+```cel
+# Energy billing: fires on kWh debits, not on the GBP positions this saga creates
+event.instrument_code == 'KWH' && event.direction == 'DEBIT'
+```
+
+### Fallback Termination: Depth-Based
+
+Use `chain_depth` as a backstop when filter-based termination is insufficient:
+
+```cel
+event.instrument_code == 'KWH' && event.direction == 'DEBIT' && chain_depth < 5
+```
+
+### Checking Chain Depth in Starlark
+
+```python
+def execute():
+    ctx = input_data
+    depth = int(ctx["metadata"].get("x-meridian-chain-depth", "0"))
+
+    # Defensive check inside the saga (belt-and-suspenders)
+    if depth >= 5:
+        return {"status": "CHAIN_DEPTH_LIMIT_REACHED", "depth": depth}
+```
+
+---
+
+## Idempotency
+
+Kafka guarantees at-least-once delivery. The same event may arrive more than once. Write sagas to be
+idempotent by checking whether work has already been done before proceeding.
+
+### Standard Idempotency Check
+
+```python
+def execute():
+    ctx = input_data
+    correlation_id = ctx["correlation_id"]
+    settlement_account_id = "..."  # resolved from entity graph
+
+    # Check before doing work
+    step(name="check_idempotency")
+    existing = position_keeping.query_logs(
+        correlation_id=correlation_id,
+        instrument_code="GBP",
+        account_id=settlement_account_id,
+    )
+
+    if existing.count > 0:
+        return {"status": "ALREADY_PROCESSED", "correlation_id": correlation_id}
+
+    # Proceed with saga...
+```
+
+### Multi-Leg Idempotency
+
+When a saga creates multiple positions, check that ALL expected positions exist before skipping:
+
+```python
+step(name="check_retail")
+existing_retail = position_keeping.query_logs(
+    correlation_id=correlation_id,
+    instrument_code="GBP",
+    account_id=retail_account_id,
+)
+
+step(name="check_wholesale")
+existing_wholesale = position_keeping.query_logs(
+    correlation_id=correlation_id,
+    instrument_code="GBP",
+    account_id=wholesale_account_id,
+)
+
+# Both must exist — checking only one is insufficient
+if existing_retail.count > 0 and existing_wholesale.count > 0:
+    return {"status": "ALREADY_VALUED"}
+```
+
+The event-router also deduplicates at the dispatch level using a CockroachDB-backed idempotency store
+keyed on `(sagaName, correlationID)`.
+
+---
+
+## Examples
+
+### Energy Billing: Single-Leg Valuation
+
+**File:** [`valuation_on_capture.star`](../../services/control-plane/internal/applier/testdata/tenant-saga-examples/valuation_on_capture.star)
+
+```yaml
+trigger: "event:position-keeping.transaction-captured.v1"
+filter:  "event.instrument_code in ['GOLD', 'SILVER', 'PLATINUM']"
+```
+
+Pattern: Resolve account → check idempotency → look up account type → compute valuation → book GBP settlement.
+
+### Cloud Billing: Usage to Value
+
+**File:** [`compute_billing.star`](../../services/control-plane/internal/applier/testdata/tenant-saga-examples/compute_billing.star)
+
+```yaml
+trigger: "event:position-keeping.transaction-captured.v1"
+filter:  "event.instrument_code == 'GPU_HOUR' && event.direction == 'DEBIT'"
+```
+
+Pattern: Single-leg valuation — GPU_HOUR position → USD charge.
+
+### Compliance: KYC Initiation
+
+**File:** [`kyc_on_party.star`](../../services/control-plane/internal/applier/testdata/tenant-saga-examples/kyc_on_party.star)
+
+```yaml
+trigger: "event:party.created.v1"
+filter:  "event.party_type == 'INDIVIDUAL'"
+```
+
+Pattern: Resolve party → check idempotency → find compliance account by jurisdiction → book zero-amount marker position.
+
+---
+
+## Troubleshooting
+
+### Saga Not Firing
+
+**Check 1:** Is the channel name correct?
+
+```bash
+# Confirm the channel exists in the AsyncAPI registry
+# The trigger value must match exactly (case-sensitive)
+trigger: "event:position-keeping.transaction-captured.v1"
+```
+
+**Check 2:** Does the CEL filter match? Test with `meridian_cel_validate`:
+
+```bash
+# Validate CEL expression compiles
+mcp__meridian__meridian_cel_validate(
+  expression: "event.instrument_code == 'KWH' && event.direction == 'DEBIT'",
+  environment: "eligibility"
+)
+```
+
+**Check 3:** Check event-router logs for filter evaluation:
+
+```bash
+kubectl logs -n production deployment/event-router | grep "CEL filter did not match"
+kubectl logs -n production deployment/event-router | grep "CEL filter evaluation error"
+```
+
+**Check 4:** Check Prometheus metrics:
+
+```promql
+# Events received on the channel
+meridian_event_router_events_received_total{channel="position-keeping.transaction-captured.v1"}
+
+# Sagas triggered
+meridian_event_router_sagas_triggered_total{saga_name="my_saga"}
+
+# Filter evaluation errors
+meridian_event_router_filter_evaluation_errors_total{saga_name="my_saga"}
+```
+
+### Saga Firing Too Often (Loop)
+
+**Symptom:** `meridian_event_router_chain_depth_exceeded_total` is non-zero, or sagas run repeatedly.
+
+**Fix 1:** Add chain termination to the filter:
+
+```cel
+# Before (loops)
+event.direction == 'DEBIT'
+
+# After (terminates)
+event.instrument_code == 'KWH' && event.direction == 'DEBIT'
+#                               ^ saga creates GBP positions, not KWH
+```
+
+**Fix 2:** Add depth limit to the filter:
+
+```cel
+event.instrument_code == 'KWH' && event.direction == 'DEBIT' && chain_depth < 3
+```
+
+**Fix 3:** Add idempotency check inside the saga to prevent re-processing.
+
+### Duplicate Executions
+
+**Symptom:** `meridian_event_router_duplicate_events_total` is non-zero.
+
+This is expected behavior. The event-router's idempotency store deduplicates by `(sagaName, correlationID)`.
+Duplicates are silently skipped and recorded in the metric. Verify the saga also performs an internal
+idempotency check for defense-in-depth.
+
+### Chain Depth Exceeded
+
+**Symptom:** `meridian_event_router_chain_depth_exceeded_total` is incrementing.
+
+Events are being dropped because the chain depth reached the maximum (default: 10). The filter is not
+terminating the chain correctly. See **Saga Firing Too Often** above.
+
+---
+
+## Syntax Checklist
+
+Before applying a manifest with event-triggered sagas:
+
+- [ ] Trigger uses `event:` prefix followed by valid channel name
+- [ ] CEL filter compiles without errors (test with `meridian_cel_validate`)
+- [ ] CEL filter returns `bool` (not `int`, not `string`)
+- [ ] Filter excludes output events (chain termination is correct)
+- [ ] Saga has an idempotency check before creating positions
+- [ ] Multi-leg sagas check ALL legs, not just one
+- [ ] Input data fields accessed via `ctx["event"]["field"]` not `ctx["field"]`
+- [ ] Decimal amounts wrapped with `Decimal(...)` before arithmetic
+
+---
+
+## Further Reading
+
+- **[ADR-0033: Event-Triggered Sagas](../adr/0033-event-triggered-sagas.md)** - Design decisions and consequences
+- **[Manifest Design Patterns](../guides/manifest-design-patterns.md)** - Pattern catalog with examples
+- **[Starlark Style Guide](../guides/starlark-style-guide.md)** - Comprehensive syntax conventions
+- **[Event Router Runbook](../runbooks/event-router.md)** - Operational procedures
+- **[Example Scripts](../../services/control-plane/internal/applier/testdata/tenant-saga-examples/)** - Reference implementations


### PR DESCRIPTION
## Summary

- Adds **ADR-0033** documenting the architectural decision for reactive saga execution via the `event:` trigger prefix, CEL-filtered dispatch, chain-depth termination, and the event-router dispatch pipeline
- Adds **event-triggered-sagas skill** (`docs/skills/event-triggered-sagas.md`) with quick start, CEL filter syntax, input data structure, chain depth patterns, idempotency guidance, examples, and troubleshooting
- Adds **event-router operational runbook** (`docs/runbooks/event-router.md`) with service overview, config reference, Prometheus metrics, alert rules, investigation procedures for all failure modes, and escalation templates
- Updates **starlark style guide** with event-triggered input data access, chain termination, idempotency check, and entity graph resolution patterns
- Updates **manifest design patterns guide** with the event-triggered saga pattern showing a complete annotated manifest example

## Changes Made

| File | Change |
|------|--------|
| `docs/adr/0033-event-triggered-sagas.md` | New ADR — event: trigger, CEL filter environment, chain depth, architecture overview, Prometheus metrics table |
| `docs/adr/README.md` | Added ADR-0033 to index table and new Event-Driven Architecture category |
| `docs/skills/event-triggered-sagas.md` | New skill — quick start, filter syntax, input data, chain depth, idempotency, examples, troubleshooting checklist |
| `docs/skills/README.md` | Added event-triggered-sagas.md to Development Workflow section |
| `docs/runbooks/event-router.md` | New runbook — service overview, config table, metrics, alert rules, investigation procedures, failure mode reference |
| `docs/runbooks/README.md` | Added event-router.md to Operations & Troubleshooting section |
| `docs/guides/starlark-style-guide.md` | Added Event-Triggered Saga Patterns section at end |
| `docs/guides/manifest-design-patterns.md` | Added Event-Triggered Saga Pattern with annotated manifest and design decision callouts |

## Test plan

- [x] All markdownlint checks pass (verified via pre-commit hook)
- [x] All links reference real files that exist in the repository
- [x] Code blocks have language specifiers
- [x] YAML frontmatter is valid on all new skill/runbook/ADR files
- [x] ADR index table entry follows existing format (date, status, link)
- [x] Prometheus metric names match `services/event-router/internal/observability/metrics.go`
- [x] Configuration table matches `services/event-router/app/config.go`
- [x] CEL filter environment variables (`event`, `metadata`, `chain_depth`) match `services/event-router/internal/handlers/saga_dispatch_handler.go`
- [x] Default max chain depth (10) matches `defaultMaxChainDepth` constant in code