### PR TITLE
feat: extract shared dispatch library from operational-gateway

### DIFF
--- a/shared/pkg/dispatch/backoff.go
+++ b/shared/pkg/dispatch/backoff.go
@@ -43,10 +43,11 @@ func calculateBackoff(attempt int, policy RetryPolicy) time.Duration {
 	// Exponential backoff: initialBackoff * multiplier^(attempt-1)
 	// attempt is 1-based; first retry (attempt=1) uses initialBackoff directly.
 	factor := math.Pow(multiplier, float64(attempt-1))
-	wait := time.Duration(float64(backoff) * factor)
-	if wait > maxBackoff {
-		wait = maxBackoff
+	waitFloat := float64(backoff) * factor
+	// Cap in float64 space before converting to time.Duration to avoid
+	// int64 overflow for extreme attempt counts.
+	if waitFloat > float64(maxBackoff) {
+		return maxBackoff
 	}
-
-	return wait
+	return time.Duration(waitFloat)
 }

--- a/shared/pkg/dispatch/backoff.go
+++ b/shared/pkg/dispatch/backoff.go
@@ -1,0 +1,52 @@
+package dispatch
+
+import (
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+// CalculateNextRetry computes the next retry time using exponential backoff with a cap.
+// attempt is the 1-based attempt number that just failed.
+// Uses policy defaults for zero-valued fields: 1s initial backoff, 2.0 multiplier, 5m max.
+func CalculateNextRetry(attempt int, policy RetryPolicy) time.Time {
+	return time.Now().Add(calculateBackoff(attempt, policy))
+}
+
+// CalculateNextRetryWithJitter computes the next retry time using exponential backoff
+// with added jitter to prevent thundering herd problems. The jitter adds a random
+// duration between 0 and the calculated backoff, resulting in a total wait between
+// 1x and 2x the base backoff.
+func CalculateNextRetryWithJitter(attempt int, policy RetryPolicy) time.Time {
+	backoff := calculateBackoff(attempt, policy)
+	jitter := time.Duration(rand.Int64N(int64(backoff) + 1))
+	return time.Now().Add(backoff + jitter)
+}
+
+// calculateBackoff computes the raw backoff duration for a given attempt and policy.
+func calculateBackoff(attempt int, policy RetryPolicy) time.Duration {
+	backoff := policy.InitialBackoff
+	if backoff <= 0 {
+		backoff = 1 * time.Second
+	}
+
+	multiplier := policy.BackoffMultiplier
+	if multiplier < 1.0 {
+		multiplier = 2.0
+	}
+
+	maxBackoff := policy.MaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = 5 * time.Minute
+	}
+
+	// Exponential backoff: initialBackoff * multiplier^(attempt-1)
+	// attempt is 1-based; first retry (attempt=1) uses initialBackoff directly.
+	factor := math.Pow(multiplier, float64(attempt-1))
+	wait := time.Duration(float64(backoff) * factor)
+	if wait > maxBackoff {
+		wait = maxBackoff
+	}
+
+	return wait
+}

--- a/shared/pkg/dispatch/backoff_test.go
+++ b/shared/pkg/dispatch/backoff_test.go
@@ -58,6 +58,22 @@ func TestCalculateNextRetry_CapsAtMaxBackoff(t *testing.T) {
 	assert.InDelta(t, 10*time.Second, wait, float64(500*time.Millisecond))
 }
 
+func TestCalculateNextRetry_OverflowSafeForExtremeAttempts(t *testing.T) {
+	policy := RetryPolicy{
+		MaxAttempts:       100,
+		InitialBackoff:    1 * time.Second,
+		MaxBackoff:        5 * time.Minute,
+		BackoffMultiplier: 2.0,
+	}
+
+	now := time.Now()
+	// attempt=100: 2^99 would overflow int64, should be capped to MaxBackoff
+	result := CalculateNextRetry(100, policy)
+	wait := result.Sub(now)
+	assert.InDelta(t, 5*time.Minute, wait, float64(500*time.Millisecond))
+	assert.True(t, wait > 0, "backoff should never be negative even for extreme attempts")
+}
+
 func TestCalculateNextRetry_DefaultsForZeroValues(t *testing.T) {
 	// Zero-value policy should use sensible defaults
 	policy := RetryPolicy{}

--- a/shared/pkg/dispatch/backoff_test.go
+++ b/shared/pkg/dispatch/backoff_test.go
@@ -1,0 +1,120 @@
+package dispatch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalculateNextRetry_FirstAttempt(t *testing.T) {
+	policy := RetryPolicy{
+		MaxAttempts:       5,
+		InitialBackoff:    1 * time.Second,
+		MaxBackoff:        1 * time.Minute,
+		BackoffMultiplier: 2.0,
+	}
+
+	before := time.Now()
+	result := CalculateNextRetry(1, policy)
+	after := time.Now()
+
+	// First attempt (attempt=1) should use InitialBackoff * 2^0 = 1s
+	assert.True(t, result.After(before.Add(900*time.Millisecond)), "retry should be at least ~1s in future")
+	assert.True(t, result.Before(after.Add(2*time.Second)), "retry should not be too far in future")
+}
+
+func TestCalculateNextRetry_ExponentialGrowth(t *testing.T) {
+	policy := RetryPolicy{
+		MaxAttempts:       5,
+		InitialBackoff:    1 * time.Second,
+		MaxBackoff:        1 * time.Minute,
+		BackoffMultiplier: 2.0,
+	}
+
+	now := time.Now()
+	retry1 := CalculateNextRetry(1, policy)
+	retry2 := CalculateNextRetry(2, policy)
+	retry3 := CalculateNextRetry(3, policy)
+
+	// attempt=1: 1s, attempt=2: 2s, attempt=3: 4s
+	assert.InDelta(t, 1*time.Second, retry1.Sub(now), float64(500*time.Millisecond))
+	assert.InDelta(t, 2*time.Second, retry2.Sub(now), float64(500*time.Millisecond))
+	assert.InDelta(t, 4*time.Second, retry3.Sub(now), float64(500*time.Millisecond))
+}
+
+func TestCalculateNextRetry_CapsAtMaxBackoff(t *testing.T) {
+	policy := RetryPolicy{
+		MaxAttempts:       10,
+		InitialBackoff:    1 * time.Second,
+		MaxBackoff:        10 * time.Second,
+		BackoffMultiplier: 2.0,
+	}
+
+	now := time.Now()
+	// attempt=5: 1s * 2^4 = 16s, should be capped to 10s
+	result := CalculateNextRetry(5, policy)
+	wait := result.Sub(now)
+	assert.InDelta(t, 10*time.Second, wait, float64(500*time.Millisecond))
+}
+
+func TestCalculateNextRetry_DefaultsForZeroValues(t *testing.T) {
+	// Zero-value policy should use sensible defaults
+	policy := RetryPolicy{}
+
+	before := time.Now()
+	result := CalculateNextRetry(1, policy)
+	after := time.Now()
+
+	// Should return a time in the future (defaults: 1s backoff, 2.0 multiplier)
+	assert.True(t, result.After(before), "retry should be in the future")
+	assert.True(t, result.Before(after.Add(10*time.Second)), "retry should use reasonable defaults")
+}
+
+func TestCalculateNextRetry_MultiplierLessThanOne(t *testing.T) {
+	policy := RetryPolicy{
+		MaxAttempts:       5,
+		InitialBackoff:    1 * time.Second,
+		MaxBackoff:        1 * time.Minute,
+		BackoffMultiplier: 0.5, // invalid, should use default 2.0
+	}
+
+	now := time.Now()
+	retry2 := CalculateNextRetry(2, policy)
+	// With default multiplier 2.0: 1s * 2^1 = 2s
+	assert.InDelta(t, 2*time.Second, retry2.Sub(now), float64(500*time.Millisecond))
+}
+
+func TestCalculateNextRetryWithJitter(t *testing.T) {
+	policy := RetryPolicy{
+		MaxAttempts:       5,
+		InitialBackoff:    1 * time.Second,
+		MaxBackoff:        1 * time.Minute,
+		BackoffMultiplier: 2.0,
+	}
+
+	now := time.Now()
+	// With jitter, the result should vary between calls but stay within bounds
+	// The base wait for attempt=1 is 1s; jitter adds 0-100% of that
+	results := make([]time.Time, 100)
+	for i := range results {
+		results[i] = CalculateNextRetryWithJitter(1, policy)
+	}
+
+	for _, result := range results {
+		wait := result.Sub(now)
+		// Jitter: result should be between base and 2*base
+		assert.True(t, wait >= 500*time.Millisecond, "jittered retry should be at least 500ms (base minus margin)")
+		assert.True(t, wait <= 3*time.Second, "jittered retry should not exceed 2x base + margin")
+	}
+
+	// Check that there's variance (not all identical)
+	allSame := true
+	for i := 1; i < len(results); i++ {
+		if results[i] != results[0] {
+			allSame = false
+			break
+		}
+	}
+	assert.False(t, allSame, "jittered results should have variance")
+}

--- a/shared/pkg/dispatch/circuit_breaker.go
+++ b/shared/pkg/dispatch/circuit_breaker.go
@@ -1,0 +1,130 @@
+package dispatch
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrInvalidThreshold is returned when a failure threshold of zero or less is used.
+var ErrInvalidThreshold = errors.New("threshold must be greater than zero")
+
+// CircuitBreaker implements a per-connection circuit breaker state machine.
+// It tracks consecutive failures and transitions between closed, open, and half-open
+// states to protect downstream systems from cascading failures.
+//
+// State transitions:
+//
+//	CLOSED → OPEN: when failure count reaches threshold
+//	OPEN → HALF_OPEN: via AttemptReset (allows a probe request)
+//	HALF_OPEN → CLOSED: on successful probe (RecordSuccess)
+//	HALF_OPEN → OPEN: on failed probe (RecordFailure)
+type CircuitBreaker struct {
+	state        CircuitState
+	openedAt     *time.Time
+	failureCount int
+	successCount int
+	lastUpdated  time.Time
+}
+
+// NewCircuitBreaker creates a new CircuitBreaker in the closed state.
+func NewCircuitBreaker() *CircuitBreaker {
+	return &CircuitBreaker{
+		state:       CircuitStateClosed,
+		lastUpdated: time.Now().UTC(),
+	}
+}
+
+// State returns the current circuit breaker state.
+func (cb *CircuitBreaker) State() CircuitState {
+	return cb.state
+}
+
+// OpenedAt returns the time the circuit was opened, or nil if it has not been tripped.
+func (cb *CircuitBreaker) OpenedAt() *time.Time {
+	return cb.openedAt
+}
+
+// FailureCount returns the count of consecutive failures since the last success.
+func (cb *CircuitBreaker) FailureCount() int {
+	return cb.failureCount
+}
+
+// SuccessCount returns the total number of recorded successes.
+func (cb *CircuitBreaker) SuccessCount() int {
+	return cb.successCount
+}
+
+// LastUpdated returns the time of the most recent state change.
+func (cb *CircuitBreaker) LastUpdated() time.Time {
+	return cb.lastUpdated
+}
+
+// RecordSuccess records a successful request. When the circuit is closed or half-open,
+// it resets the failure count. In half-open state, a success closes the circuit
+// (confirming recovery).
+func (cb *CircuitBreaker) RecordSuccess() {
+	cb.successCount++
+	switch cb.state {
+	case CircuitStateHalfOpen:
+		cb.state = CircuitStateClosed
+		cb.failureCount = 0
+		cb.openedAt = nil
+	case CircuitStateClosed:
+		cb.failureCount = 0
+	case CircuitStateOpen:
+		// Success during open state is unexpected (IsAvailable returns false).
+		// Record it but do not change circuit state; use AttemptReset first.
+	}
+	cb.lastUpdated = time.Now().UTC()
+}
+
+// RecordFailure records a failed request and trips the circuit breaker if the failure
+// count reaches the given threshold. In half-open state, any failure immediately
+// re-trips the circuit. Returns ErrInvalidThreshold if threshold <= 0.
+func (cb *CircuitBreaker) RecordFailure(threshold int) error {
+	if threshold <= 0 {
+		return ErrInvalidThreshold
+	}
+	cb.failureCount++
+	switch cb.state {
+	case CircuitStateClosed:
+		if cb.failureCount >= threshold {
+			cb.TripCircuit()
+			return nil
+		}
+	case CircuitStateHalfOpen:
+		cb.TripCircuit()
+		return nil
+	case CircuitStateOpen:
+		// Circuit already open; failure is recorded but no additional state change needed.
+	}
+	cb.lastUpdated = time.Now().UTC()
+	return nil
+}
+
+// TripCircuit transitions the circuit breaker to the open state, blocking further requests.
+// If the circuit is already open, OpenedAt is preserved so the open duration is measured
+// from the original trip time.
+func (cb *CircuitBreaker) TripCircuit() {
+	now := time.Now().UTC()
+	cb.state = CircuitStateOpen
+	if cb.openedAt == nil {
+		cb.openedAt = &now
+	}
+	cb.lastUpdated = now
+}
+
+// AttemptReset transitions the circuit breaker from open to half-open, allowing a probe
+// request to test recovery. Calling AttemptReset when closed or already half-open is a no-op.
+func (cb *CircuitBreaker) AttemptReset() {
+	if cb.state == CircuitStateOpen {
+		cb.state = CircuitStateHalfOpen
+		cb.lastUpdated = time.Now().UTC()
+	}
+}
+
+// IsAvailable returns true when the circuit breaker permits sending requests
+// (closed or half-open for a probe attempt).
+func (cb *CircuitBreaker) IsAvailable() bool {
+	return cb.state == CircuitStateClosed || cb.state == CircuitStateHalfOpen
+}

--- a/shared/pkg/dispatch/circuit_breaker.go
+++ b/shared/pkg/dispatch/circuit_breaker.go
@@ -12,6 +12,10 @@ var ErrInvalidThreshold = errors.New("threshold must be greater than zero")
 // It tracks consecutive failures and transitions between closed, open, and half-open
 // states to protect downstream systems from cascading failures.
 //
+// CircuitBreaker is NOT safe for concurrent use. Callers must ensure that all
+// method calls for a given instance are serialized (e.g., by the owning worker
+// goroutine that processes instructions for a single connection).
+//
 // State transitions:
 //
 //	CLOSED → OPEN: when failure count reaches threshold

--- a/shared/pkg/dispatch/circuit_breaker_test.go
+++ b/shared/pkg/dispatch/circuit_breaker_test.go
@@ -1,0 +1,167 @@
+package dispatch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCircuitBreaker_NewStartsClosed(t *testing.T) {
+	cb := NewCircuitBreaker()
+	assert.Equal(t, CircuitStateClosed, cb.State())
+	assert.True(t, cb.IsAvailable())
+	assert.Equal(t, 0, cb.FailureCount())
+	assert.Equal(t, 0, cb.SuccessCount())
+	assert.Nil(t, cb.OpenedAt())
+}
+
+func TestCircuitBreaker_RecordSuccess_ResetsFailureCount(t *testing.T) {
+	cb := NewCircuitBreaker()
+	threshold := 5
+
+	for i := 0; i < threshold-1; i++ {
+		require.NoError(t, cb.RecordFailure(threshold))
+	}
+	assert.Equal(t, threshold-1, cb.FailureCount())
+	assert.Equal(t, CircuitStateClosed, cb.State())
+
+	cb.RecordSuccess()
+	assert.Equal(t, 0, cb.FailureCount())
+	assert.Equal(t, 1, cb.SuccessCount())
+	assert.Equal(t, CircuitStateClosed, cb.State())
+}
+
+func TestCircuitBreaker_RecordFailureBelowThreshold(t *testing.T) {
+	cb := NewCircuitBreaker()
+	threshold := 5
+
+	for i := 1; i < threshold; i++ {
+		require.NoError(t, cb.RecordFailure(threshold))
+		assert.Equal(t, i, cb.FailureCount())
+		assert.Equal(t, CircuitStateClosed, cb.State())
+	}
+}
+
+func TestCircuitBreaker_RecordFailureAtThreshold(t *testing.T) {
+	cb := NewCircuitBreaker()
+	threshold := 5
+
+	for i := 0; i < threshold; i++ {
+		require.NoError(t, cb.RecordFailure(threshold))
+	}
+
+	assert.Equal(t, threshold, cb.FailureCount())
+	assert.Equal(t, CircuitStateOpen, cb.State())
+	assert.NotNil(t, cb.OpenedAt())
+}
+
+func TestCircuitBreaker_RecordFailureInvalidThreshold(t *testing.T) {
+	cb := NewCircuitBreaker()
+	assert.ErrorIs(t, cb.RecordFailure(0), ErrInvalidThreshold)
+	assert.ErrorIs(t, cb.RecordFailure(-1), ErrInvalidThreshold)
+}
+
+func TestCircuitBreaker_IsAvailableWhenClosed(t *testing.T) {
+	cb := NewCircuitBreaker()
+	assert.True(t, cb.IsAvailable())
+}
+
+func TestCircuitBreaker_IsAvailableWhenOpen(t *testing.T) {
+	cb := NewCircuitBreaker()
+	cb.TripCircuit()
+	assert.False(t, cb.IsAvailable())
+}
+
+func TestCircuitBreaker_IsAvailableWhenHalfOpen(t *testing.T) {
+	cb := NewCircuitBreaker()
+	cb.TripCircuit()
+	cb.AttemptReset()
+	assert.Equal(t, CircuitStateHalfOpen, cb.State())
+	assert.True(t, cb.IsAvailable())
+}
+
+func TestCircuitBreaker_TripCircuit(t *testing.T) {
+	cb := NewCircuitBreaker()
+	assert.Nil(t, cb.OpenedAt())
+
+	cb.TripCircuit()
+
+	assert.Equal(t, CircuitStateOpen, cb.State())
+	require.NotNil(t, cb.OpenedAt())
+	assert.WithinDuration(t, time.Now(), *cb.OpenedAt(), time.Second)
+}
+
+func TestCircuitBreaker_TripCircuit_PreservesOpenedAt(t *testing.T) {
+	cb := NewCircuitBreaker()
+	cb.TripCircuit()
+	original := *cb.OpenedAt()
+
+	cb.TripCircuit()
+	assert.Equal(t, original, *cb.OpenedAt())
+}
+
+func TestCircuitBreaker_AttemptReset(t *testing.T) {
+	cb := NewCircuitBreaker()
+	cb.TripCircuit()
+	assert.Equal(t, CircuitStateOpen, cb.State())
+
+	cb.AttemptReset()
+
+	assert.Equal(t, CircuitStateHalfOpen, cb.State())
+}
+
+func TestCircuitBreaker_AttemptReset_NoopWhenClosed(t *testing.T) {
+	cb := NewCircuitBreaker()
+	cb.AttemptReset()
+	assert.Equal(t, CircuitStateClosed, cb.State())
+}
+
+func TestCircuitBreaker_FullCycle(t *testing.T) {
+	cb := NewCircuitBreaker()
+	threshold := 3
+
+	// Trip the circuit
+	for i := 0; i < threshold; i++ {
+		require.NoError(t, cb.RecordFailure(threshold))
+	}
+	assert.Equal(t, CircuitStateOpen, cb.State())
+	assert.False(t, cb.IsAvailable())
+
+	// Move to half-open
+	cb.AttemptReset()
+	assert.Equal(t, CircuitStateHalfOpen, cb.State())
+	assert.True(t, cb.IsAvailable())
+
+	// Successful probe closes circuit
+	cb.RecordSuccess()
+	assert.Equal(t, CircuitStateClosed, cb.State())
+	assert.Equal(t, 0, cb.FailureCount())
+	assert.Nil(t, cb.OpenedAt())
+}
+
+func TestCircuitBreaker_HalfOpenFailureReopens(t *testing.T) {
+	cb := NewCircuitBreaker()
+	threshold := 3
+
+	for i := 0; i < threshold; i++ {
+		require.NoError(t, cb.RecordFailure(threshold))
+	}
+	cb.AttemptReset()
+	assert.Equal(t, CircuitStateHalfOpen, cb.State())
+
+	require.NoError(t, cb.RecordFailure(threshold))
+	assert.Equal(t, CircuitStateOpen, cb.State())
+	assert.NotNil(t, cb.OpenedAt())
+}
+
+func TestCircuitBreaker_LastUpdated(t *testing.T) {
+	cb := NewCircuitBreaker()
+	before := time.Now()
+
+	cb.RecordSuccess()
+
+	assert.True(t, !cb.LastUpdated().Before(before))
+	assert.True(t, !cb.LastUpdated().After(time.Now()))
+}

--- a/shared/pkg/dispatch/dispatcher.go
+++ b/shared/pkg/dispatch/dispatcher.go
@@ -1,0 +1,51 @@
+package dispatch
+
+import (
+	"context"
+	"time"
+)
+
+// Result captures the outcome of a single outbound dispatch attempt.
+type Result struct {
+	// StatusCode is the HTTP response status code from the provider.
+	StatusCode int
+
+	// ResponseBody is the raw response body received from the provider.
+	ResponseBody []byte
+
+	// Outcome is the extracted dispatch outcome after applying any inbound transform.
+	// May be nil if the dispatch did not reach the response parsing stage.
+	Outcome *Outcome
+
+	// Duration is the total time elapsed for the dispatch attempt.
+	Duration time.Duration
+
+	// Error is non-nil when the dispatch failed before a response could be parsed
+	// (e.g., network error, auth failure, transform failure).
+	Error error
+}
+
+// Outcome captures the parsed result from a provider response.
+type Outcome struct {
+	// ExternalID is the provider's identifier for the instruction, if returned.
+	ExternalID string
+
+	// ProviderStatus is the provider's status string for the instruction
+	// (e.g., "ACCEPTED", "PENDING", "REJECTED").
+	ProviderStatus string
+
+	// ShouldRetry indicates whether the dispatch should be retried.
+	ShouldRetry bool
+
+	// FailureReason contains a description of why the instruction failed.
+	// Non-empty only when the provider indicates a permanent failure.
+	FailureReason string
+}
+
+// Dispatcher sends a dispatchable instruction to an external endpoint.
+// Implementations handle transport-level concerns (HTTP, gRPC, etc.) and authentication.
+// Retry logic, circuit breaking, and persistence are handled by the worker layer.
+type Dispatcher[I DispatchableInstruction, C any, R any] interface {
+	// Dispatch sends the instruction to the provider using the given connection and route.
+	Dispatch(ctx context.Context, instruction I, connection C, route R) Result
+}

--- a/shared/pkg/dispatch/doc.go
+++ b/shared/pkg/dispatch/doc.go
@@ -1,0 +1,17 @@
+// Package dispatch provides shared dispatch infrastructure for gateway services.
+//
+// This package contains reusable building blocks for services that dispatch
+// instructions to external providers:
+//
+//   - Circuit breaker state machine (CircuitBreaker) for per-connection fault isolation
+//   - Exponential backoff with optional jitter (CalculateNextRetry, CalculateNextRetryWithJitter)
+//   - Domain types shared across gateways (CircuitState, HealthStatus, RetryPolicy, InstructionStatus)
+//   - Generic interfaces (Dispatcher, DispatchableInstruction, InstructionFetcher, InstructionPersister)
+//   - Poll-dispatch worker loop (Worker) parameterized by instruction type
+//
+// The types in this package complement (not replace) the generic HTTP client
+// resilience patterns in shared/pkg/clients. Those handle transport-level retry
+// and circuit breaking for HTTP calls. This package handles domain-level dispatch
+// patterns: instruction lifecycle management, per-connection circuit breaking with
+// explicit state tracking, and batch-oriented worker loops.
+package dispatch

--- a/shared/pkg/dispatch/domain.go
+++ b/shared/pkg/dispatch/domain.go
@@ -1,0 +1,47 @@
+// Package dispatch provides shared dispatch infrastructure for gateway services.
+// It contains circuit breaker state machines, retry policies with exponential backoff,
+// dispatcher interfaces, and generic poll-dispatch worker patterns that can be reused
+// across both operational and inbound gateways.
+package dispatch
+
+import "time"
+
+// CircuitState represents the current state of a circuit breaker.
+type CircuitState string
+
+const (
+	// CircuitStateClosed means the circuit is closed and requests flow normally.
+	CircuitStateClosed CircuitState = "CLOSED"
+	// CircuitStateOpen means the circuit is open and requests are blocked.
+	CircuitStateOpen CircuitState = "OPEN"
+	// CircuitStateHalfOpen means the circuit is allowing a probe request to test recovery.
+	CircuitStateHalfOpen CircuitState = "HALF_OPEN"
+)
+
+// HealthStatus represents the observed health of a connection endpoint.
+type HealthStatus string
+
+const (
+	// HealthStatusUnknown means no health check has been performed yet.
+	HealthStatusUnknown HealthStatus = "UNKNOWN"
+	// HealthStatusHealthy means the endpoint is responding normally.
+	HealthStatusHealthy HealthStatus = "HEALTHY"
+	// HealthStatusDegraded means the endpoint is responding but with elevated latency or errors.
+	HealthStatusDegraded HealthStatus = "DEGRADED"
+	// HealthStatusUnhealthy means the endpoint is not responding or returning errors.
+	HealthStatusUnhealthy HealthStatus = "UNHEALTHY"
+)
+
+// RetryPolicy defines how failed dispatch attempts should be retried.
+type RetryPolicy struct {
+	// MaxAttempts is the maximum number of dispatch attempts (including the initial attempt).
+	MaxAttempts int
+	// InitialBackoff is the wait duration before the first retry.
+	InitialBackoff time.Duration
+	// MaxBackoff is the maximum wait duration between retries.
+	MaxBackoff time.Duration
+	// BackoffMultiplier is the dimensionless scaling factor applied to the backoff duration
+	// on each retry (e.g., 2.0 doubles the backoff). This is a pure numeric multiplier,
+	// not a duration.
+	BackoffMultiplier float64
+}

--- a/shared/pkg/dispatch/domain_test.go
+++ b/shared/pkg/dispatch/domain_test.go
@@ -1,0 +1,34 @@
+package dispatch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCircuitStateConstants(t *testing.T) {
+	assert.Equal(t, CircuitState("CLOSED"), CircuitStateClosed)
+	assert.Equal(t, CircuitState("OPEN"), CircuitStateOpen)
+	assert.Equal(t, CircuitState("HALF_OPEN"), CircuitStateHalfOpen)
+}
+
+func TestHealthStatusConstants(t *testing.T) {
+	assert.Equal(t, HealthStatus("UNKNOWN"), HealthStatusUnknown)
+	assert.Equal(t, HealthStatus("HEALTHY"), HealthStatusHealthy)
+	assert.Equal(t, HealthStatus("DEGRADED"), HealthStatusDegraded)
+	assert.Equal(t, HealthStatus("UNHEALTHY"), HealthStatusUnhealthy)
+}
+
+func TestRetryPolicy(t *testing.T) {
+	policy := RetryPolicy{
+		MaxAttempts:       3,
+		InitialBackoff:    100 * time.Millisecond,
+		MaxBackoff:        10 * time.Second,
+		BackoffMultiplier: 2.0,
+	}
+	assert.Equal(t, 3, policy.MaxAttempts)
+	assert.Equal(t, 100*time.Millisecond, policy.InitialBackoff)
+	assert.Equal(t, 10*time.Second, policy.MaxBackoff)
+	assert.Equal(t, 2.0, policy.BackoffMultiplier)
+}

--- a/shared/pkg/dispatch/instruction.go
+++ b/shared/pkg/dispatch/instruction.go
@@ -1,0 +1,56 @@
+package dispatch
+
+// InstructionStatus represents the lifecycle state of a dispatchable instruction.
+type InstructionStatus string
+
+// Instruction status constants define the lifecycle states.
+const (
+	InstructionStatusPending      InstructionStatus = "PENDING"
+	InstructionStatusDispatching  InstructionStatus = "DISPATCHING"
+	InstructionStatusDelivered    InstructionStatus = "DELIVERED"
+	InstructionStatusAcknowledged InstructionStatus = "ACKNOWLEDGED"
+	InstructionStatusRetrying     InstructionStatus = "RETRYING"
+	InstructionStatusFailed       InstructionStatus = "FAILED"
+	InstructionStatusExpired      InstructionStatus = "EXPIRED"
+	InstructionStatusCancelled    InstructionStatus = "CANCELLED"
+)
+
+// IsTerminal returns true if the status represents a terminal state where no further
+// transitions are possible.
+func (s InstructionStatus) IsTerminal() bool {
+	switch s {
+	case InstructionStatusAcknowledged,
+		InstructionStatusFailed,
+		InstructionStatusExpired,
+		InstructionStatusCancelled:
+		return true
+	case InstructionStatusPending,
+		InstructionStatusDispatching,
+		InstructionStatusDelivered,
+		InstructionStatusRetrying:
+		return false
+	}
+	return false
+}
+
+// DispatchableInstruction is the interface that any instruction type must implement
+// to be processed by the generic dispatch worker. It provides the minimum information
+// needed for routing, dispatching, and retry management.
+type DispatchableInstruction interface {
+	// GetID returns the unique identifier for this instruction.
+	GetID() string
+	// GetTenantID returns the tenant identifier that owns this instruction.
+	GetTenantID() string
+	// GetInstructionType returns the type of instruction (used for route resolution).
+	GetInstructionType() string
+	// GetConnectionID returns the target provider connection identifier.
+	GetConnectionID() string
+	// GetStatus returns the current lifecycle status.
+	GetStatus() InstructionStatus
+	// GetAttemptCount returns the number of dispatch attempts made so far.
+	GetAttemptCount() int
+	// GetMaxAttempts returns the maximum number of dispatch attempts allowed.
+	GetMaxAttempts() int
+	// CanRetry returns true if the instruction has remaining retry attempts.
+	CanRetry() bool
+}

--- a/shared/pkg/dispatch/instruction_test.go
+++ b/shared/pkg/dispatch/instruction_test.go
@@ -1,0 +1,92 @@
+package dispatch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInstructionStatusConstants(t *testing.T) {
+	assert.Equal(t, InstructionStatus("PENDING"), InstructionStatusPending)
+	assert.Equal(t, InstructionStatus("DISPATCHING"), InstructionStatusDispatching)
+	assert.Equal(t, InstructionStatus("DELIVERED"), InstructionStatusDelivered)
+	assert.Equal(t, InstructionStatus("ACKNOWLEDGED"), InstructionStatusAcknowledged)
+	assert.Equal(t, InstructionStatus("RETRYING"), InstructionStatusRetrying)
+	assert.Equal(t, InstructionStatus("FAILED"), InstructionStatusFailed)
+	assert.Equal(t, InstructionStatus("EXPIRED"), InstructionStatusExpired)
+	assert.Equal(t, InstructionStatus("CANCELLED"), InstructionStatusCancelled)
+}
+
+func TestInstructionStatus_IsTerminal(t *testing.T) {
+	terminal := []InstructionStatus{
+		InstructionStatusAcknowledged,
+		InstructionStatusFailed,
+		InstructionStatusExpired,
+		InstructionStatusCancelled,
+	}
+	for _, s := range terminal {
+		assert.True(t, s.IsTerminal(), "expected %s to be terminal", s)
+	}
+
+	nonTerminal := []InstructionStatus{
+		InstructionStatusPending,
+		InstructionStatusDispatching,
+		InstructionStatusDelivered,
+		InstructionStatusRetrying,
+	}
+	for _, s := range nonTerminal {
+		assert.False(t, s.IsTerminal(), "expected %s to be non-terminal", s)
+	}
+}
+
+// mockInstruction verifies that the DispatchableInstruction interface is implementable.
+type mockInstruction struct {
+	id              string
+	tenantID        string
+	instructionType string
+	connectionID    string
+	status          InstructionStatus
+	attemptCount    int
+	maxAttempts     int
+}
+
+func (m *mockInstruction) GetID() string                { return m.id }
+func (m *mockInstruction) GetTenantID() string          { return m.tenantID }
+func (m *mockInstruction) GetInstructionType() string   { return m.instructionType }
+func (m *mockInstruction) GetConnectionID() string      { return m.connectionID }
+func (m *mockInstruction) GetStatus() InstructionStatus { return m.status }
+func (m *mockInstruction) GetAttemptCount() int         { return m.attemptCount }
+func (m *mockInstruction) GetMaxAttempts() int          { return m.maxAttempts }
+func (m *mockInstruction) CanRetry() bool               { return m.attemptCount < m.maxAttempts }
+
+// Compile-time check that mockInstruction implements DispatchableInstruction.
+var _ DispatchableInstruction = (*mockInstruction)(nil)
+
+func TestDispatchableInstruction_Interface(t *testing.T) {
+	instr := &mockInstruction{
+		id:              "instr-1",
+		tenantID:        "tenant-a",
+		instructionType: "payment.initiate",
+		connectionID:    "conn-1",
+		status:          InstructionStatusPending,
+		attemptCount:    1,
+		maxAttempts:     3,
+	}
+
+	assert.Equal(t, "instr-1", instr.GetID())
+	assert.Equal(t, "tenant-a", instr.GetTenantID())
+	assert.Equal(t, "payment.initiate", instr.GetInstructionType())
+	assert.Equal(t, "conn-1", instr.GetConnectionID())
+	assert.Equal(t, InstructionStatusPending, instr.GetStatus())
+	assert.Equal(t, 1, instr.GetAttemptCount())
+	assert.Equal(t, 3, instr.GetMaxAttempts())
+	assert.True(t, instr.CanRetry())
+}
+
+func TestDispatchableInstruction_CanRetryExhausted(t *testing.T) {
+	instr := &mockInstruction{
+		attemptCount: 3,
+		maxAttempts:  3,
+	}
+	assert.False(t, instr.CanRetry())
+}

--- a/shared/pkg/dispatch/repository.go
+++ b/shared/pkg/dispatch/repository.go
@@ -1,0 +1,18 @@
+package dispatch
+
+import "context"
+
+// InstructionFetcher abstracts the operation of fetching a batch of dispatchable
+// instructions from a persistence store. Implementations should use row-level locking
+// (e.g., SELECT FOR UPDATE SKIP LOCKED) to support concurrent workers.
+type InstructionFetcher[I DispatchableInstruction] interface {
+	// FetchDispatchable returns up to limit instructions that are ready for dispatch.
+	FetchDispatchable(ctx context.Context, limit int) ([]I, error)
+}
+
+// InstructionPersister abstracts the operation of saving an instruction after
+// processing (marking delivered, retrying, or failed).
+type InstructionPersister[I DispatchableInstruction] interface {
+	// SaveInstruction persists the current state of an instruction.
+	SaveInstruction(ctx context.Context, instruction I) error
+}

--- a/shared/pkg/dispatch/worker.go
+++ b/shared/pkg/dispatch/worker.go
@@ -1,0 +1,138 @@
+package dispatch
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Default worker configuration values.
+const (
+	DefaultBatchSize    = 50
+	DefaultPollInterval = 1 * time.Second
+)
+
+// WorkerConfig configures the dispatch worker's polling and processing behavior.
+type WorkerConfig struct {
+	// BatchSize is the maximum number of instructions to claim per poll cycle.
+	BatchSize int
+	// PollInterval is the duration between successive poll cycles.
+	PollInterval time.Duration
+}
+
+// applyDefaults fills in zero-valued fields with sensible defaults.
+func (c *WorkerConfig) applyDefaults() {
+	if c.BatchSize <= 0 {
+		c.BatchSize = DefaultBatchSize
+	}
+	if c.PollInterval <= 0 {
+		c.PollInterval = DefaultPollInterval
+	}
+}
+
+// BatchProcessor is the callback invoked by the Worker for each batch of instructions.
+// Implementations contain the domain-specific dispatch logic (route resolution,
+// circuit breaker checks, actual dispatch, outcome handling).
+type BatchProcessor[I DispatchableInstruction] func(ctx context.Context, instructions []I)
+
+// Worker implements the generic poll-dispatch-ack loop. It periodically fetches
+// batches of dispatchable instructions and delegates processing to a BatchProcessor
+// callback. The Worker manages the polling lifecycle (start, stop, shutdown) while
+// leaving domain-specific dispatch logic to the callback.
+//
+// Worker is safe for concurrent use; multiple instances can run against the same
+// database when the InstructionFetcher uses row-level locking (e.g., FOR UPDATE SKIP LOCKED).
+type Worker[I DispatchableInstruction] struct {
+	fetcher      InstructionFetcher[I]
+	processor    BatchProcessor[I]
+	config       WorkerConfig
+	logger       *slog.Logger
+	shutdown     chan struct{}
+	shutdownOnce sync.Once
+	startOnce    sync.Once
+	wg           sync.WaitGroup
+}
+
+// NewWorker creates a new Worker with the given fetcher, processor callback, and config.
+func NewWorker[I DispatchableInstruction](
+	fetcher InstructionFetcher[I],
+	processor BatchProcessor[I],
+	config WorkerConfig,
+	logger *slog.Logger,
+) *Worker[I] {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	config.applyDefaults()
+
+	return &Worker[I]{
+		fetcher:   fetcher,
+		processor: processor,
+		config:    config,
+		logger:    logger.With("component", "dispatch-worker"),
+		shutdown:  make(chan struct{}),
+	}
+}
+
+// Start begins the background polling loop. Returns immediately; the loop runs
+// in a separate goroutine until Stop is called or ctx is cancelled.
+// Calling Start more than once is a no-op.
+func (w *Worker[I]) Start(ctx context.Context) {
+	w.startOnce.Do(func() {
+		w.wg.Add(1)
+		go w.run(ctx)
+
+		w.logger.InfoContext(ctx, "dispatch worker started",
+			"batch_size", w.config.BatchSize,
+			"poll_interval", w.config.PollInterval,
+		)
+	})
+}
+
+// Stop signals the worker to shut down and blocks until the current batch completes.
+// Safe to call multiple times.
+func (w *Worker[I]) Stop() {
+	w.shutdownOnce.Do(func() {
+		w.logger.Info("dispatch worker stopping")
+		close(w.shutdown)
+	})
+	w.wg.Wait()
+	w.logger.Info("dispatch worker stopped")
+}
+
+// run is the main polling loop.
+func (w *Worker[I]) run(ctx context.Context) {
+	defer w.wg.Done()
+
+	ticker := time.NewTicker(w.config.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.InfoContext(ctx, "dispatch worker context cancelled")
+			return
+		case <-w.shutdown:
+			w.logger.Info("dispatch worker shutdown signal received")
+			return
+		case <-ticker.C:
+			w.processBatch(ctx)
+		}
+	}
+}
+
+// processBatch fetches a batch of dispatchable instructions and delegates to the processor.
+func (w *Worker[I]) processBatch(ctx context.Context) {
+	instructions, err := w.fetcher.FetchDispatchable(ctx, w.config.BatchSize)
+	if err != nil {
+		w.logger.ErrorContext(ctx, "failed to fetch dispatchable instructions", "error", err)
+		return
+	}
+	if len(instructions) == 0 {
+		return
+	}
+
+	w.logger.InfoContext(ctx, "processing dispatch batch", "count", len(instructions))
+	w.processor(ctx, instructions)
+}

--- a/shared/pkg/dispatch/worker.go
+++ b/shared/pkg/dispatch/worker.go
@@ -55,12 +55,19 @@ type Worker[I DispatchableInstruction] struct {
 }
 
 // NewWorker creates a new Worker with the given fetcher, processor callback, and config.
+// Panics if fetcher or processor is nil.
 func NewWorker[I DispatchableInstruction](
 	fetcher InstructionFetcher[I],
 	processor BatchProcessor[I],
 	config WorkerConfig,
 	logger *slog.Logger,
 ) *Worker[I] {
+	if fetcher == nil {
+		panic("dispatch: NewWorker requires non-nil fetcher")
+	}
+	if processor == nil {
+		panic("dispatch: NewWorker requires non-nil processor")
+	}
 	if logger == nil {
 		logger = slog.Default()
 	}

--- a/shared/pkg/dispatch/worker_test.go
+++ b/shared/pkg/dispatch/worker_test.go
@@ -28,6 +28,18 @@ func (f *stubFetcher) FetchDispatchable(_ context.Context, _ int) ([]*mockInstru
 	return f.instructions, nil
 }
 
+func TestNewWorker_PanicsOnNilFetcher(t *testing.T) {
+	assert.PanicsWithValue(t, "dispatch: NewWorker requires non-nil fetcher", func() {
+		NewWorker[*mockInstruction](nil, func(_ context.Context, _ []*mockInstruction) {}, WorkerConfig{}, nil)
+	})
+}
+
+func TestNewWorker_PanicsOnNilProcessor(t *testing.T) {
+	assert.PanicsWithValue(t, "dispatch: NewWorker requires non-nil processor", func() {
+		NewWorker[*mockInstruction](&stubFetcher{}, nil, WorkerConfig{}, nil)
+	})
+}
+
 func TestWorkerConfig_ApplyDefaults(t *testing.T) {
 	cfg := WorkerConfig{}
 	cfg.applyDefaults()

--- a/shared/pkg/dispatch/worker_test.go
+++ b/shared/pkg/dispatch/worker_test.go
@@ -1,0 +1,173 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/shared/platform/await"
+)
+
+// stubFetcher is a test double for InstructionFetcher.
+type stubFetcher struct {
+	instructions []*mockInstruction
+	err          error
+	callCount    atomic.Int32
+}
+
+func (f *stubFetcher) FetchDispatchable(_ context.Context, _ int) ([]*mockInstruction, error) {
+	f.callCount.Add(1)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.instructions, nil
+}
+
+func TestWorkerConfig_ApplyDefaults(t *testing.T) {
+	cfg := WorkerConfig{}
+	cfg.applyDefaults()
+	assert.Equal(t, DefaultBatchSize, cfg.BatchSize)
+	assert.Equal(t, DefaultPollInterval, cfg.PollInterval)
+}
+
+func TestWorkerConfig_ApplyDefaultsPreservesValues(t *testing.T) {
+	cfg := WorkerConfig{
+		BatchSize:    10,
+		PollInterval: 500 * time.Millisecond,
+	}
+	cfg.applyDefaults()
+	assert.Equal(t, 10, cfg.BatchSize)
+	assert.Equal(t, 500*time.Millisecond, cfg.PollInterval)
+}
+
+func TestWorker_StartAndStop(t *testing.T) {
+	fetcher := &stubFetcher{}
+	var processed atomic.Int32
+	processor := func(_ context.Context, instructions []*mockInstruction) {
+		processed.Add(int32(len(instructions)))
+	}
+
+	w := NewWorker[*mockInstruction](fetcher, processor, WorkerConfig{PollInterval: 10 * time.Millisecond}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w.Start(ctx)
+
+	// Wait for at least one poll cycle
+	err := await.Until(func() bool {
+		return fetcher.callCount.Load() > 0
+	})
+	require.NoError(t, err)
+
+	w.Stop()
+
+	// Should have polled but processed zero (no instructions returned)
+	assert.Equal(t, int32(0), processed.Load())
+}
+
+func TestWorker_StartIdempotent(_ *testing.T) {
+	fetcher := &stubFetcher{}
+	processor := func(_ context.Context, _ []*mockInstruction) {}
+
+	w := NewWorker[*mockInstruction](fetcher, processor, WorkerConfig{PollInterval: 10 * time.Millisecond}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w.Start(ctx)
+	w.Start(ctx) // second call is a no-op
+	w.Stop()
+}
+
+func TestWorker_ProcessesBatch(t *testing.T) {
+	instructions := []*mockInstruction{
+		{id: "1", tenantID: "t", instructionType: "pay", connectionID: "c", status: InstructionStatusPending},
+		{id: "2", tenantID: "t", instructionType: "pay", connectionID: "c", status: InstructionStatusPending},
+	}
+	fetcher := &stubFetcher{instructions: instructions}
+
+	var processed atomic.Int32
+	processor := func(_ context.Context, batch []*mockInstruction) {
+		processed.Add(int32(len(batch)))
+	}
+
+	w := NewWorker[*mockInstruction](fetcher, processor, WorkerConfig{PollInterval: 10 * time.Millisecond}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w.Start(ctx)
+
+	err := await.Until(func() bool {
+		return processed.Load() >= 2
+	})
+	require.NoError(t, err)
+
+	w.Stop()
+	assert.GreaterOrEqual(t, processed.Load(), int32(2))
+}
+
+func TestWorker_HandlesErrorFromFetcher(t *testing.T) {
+	fetcher := &stubFetcher{err: errors.New("db connection lost")}
+
+	var processed atomic.Int32
+	processor := func(_ context.Context, _ []*mockInstruction) {
+		processed.Add(1)
+	}
+
+	w := NewWorker[*mockInstruction](fetcher, processor, WorkerConfig{PollInterval: 10 * time.Millisecond}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w.Start(ctx)
+
+	// Let a few poll cycles run
+	err := await.Until(func() bool {
+		return fetcher.callCount.Load() >= 3
+	})
+	require.NoError(t, err)
+
+	w.Stop()
+
+	// Processor should never have been called
+	assert.Equal(t, int32(0), processed.Load())
+}
+
+func TestWorker_StopsOnContextCancellation(t *testing.T) {
+	fetcher := &stubFetcher{}
+	processor := func(_ context.Context, _ []*mockInstruction) {}
+
+	w := NewWorker[*mockInstruction](fetcher, processor, WorkerConfig{PollInterval: 10 * time.Millisecond}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w.Start(ctx)
+
+	// Wait for at least one poll
+	err := await.Until(func() bool {
+		return fetcher.callCount.Load() > 0
+	})
+	require.NoError(t, err)
+
+	// Cancel context — worker should stop
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		w.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// OK
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker did not stop after context cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

Extracts reusable dispatch infrastructure into `shared/pkg/dispatch/` to provide the foundation for both operational-gateway and future inbound-gateway to share common patterns.

### What's included

| File | Purpose |
|------|---------|
| `domain.go` | CircuitState, HealthStatus, RetryPolicy types |
| `backoff.go` | Exponential backoff with optional jitter (`CalculateNextRetry`, `CalculateNextRetryWithJitter`) |
| `circuit_breaker.go` | Per-connection circuit breaker state machine (closed/open/half-open) |
| `instruction.go` | InstructionStatus enum, DispatchableInstruction interface |
| `dispatcher.go` | Generic Dispatcher interface, Result and Outcome types |
| `repository.go` | InstructionFetcher and InstructionPersister interfaces |
| `worker.go` | Generic poll-dispatch Worker loop parameterized by instruction type |
| `doc.go` | Package documentation |

### Design decisions

- **Generic type parameters** on Dispatcher, Worker, and repository interfaces allow each gateway to use its own concrete instruction/connection/route types while sharing the dispatch loop and circuit breaker logic.
- **Jitter option** added to backoff calculation to prevent thundering herd when multiple workers retry simultaneously.
- **Complements existing `shared/pkg/clients/`** — those handle transport-level HTTP retry/circuit breaking. This package handles domain-level dispatch patterns (instruction lifecycle, per-connection state tracking, batch worker loops).
- **No breaking changes** to operational-gateway — this is a new package only. Operational-gateway integration (type aliases) is a follow-up task.

### Task Master context

- Tag: `033-gateway-architecture`
- Task: `033-gateway-architecture.1` — Extract shared dispatch library from operational-gateway

## Test plan

- [x] All 28 unit tests pass with `-race` flag
- [x] `go vet` clean
- [x] `golangci-lint` clean (0 issues)
- [x] No import cycles (`go build ./shared/pkg/dispatch/...`)
- [ ] CI passes