### PR TITLE
fix: resolve develop CI failures and add status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Meridian
 
+[![Build & Test](https://github.com/meridianhub/meridian/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/meridianhub/meridian/actions/workflows/build.yml?query=branch%3Adevelop)
+[![Nightly](https://github.com/meridianhub/meridian/actions/workflows/nightly.yml/badge.svg)](https://github.com/meridianhub/meridian/actions/workflows/nightly.yml)
+[![Code Quality](https://github.com/meridianhub/meridian/actions/workflows/quality.yml/badge.svg?branch=develop)](https://github.com/meridianhub/meridian/actions/workflows/quality.yml?query=branch%3Adevelop)
+[![Security Scanning](https://github.com/meridianhub/meridian/actions/workflows/security.yml/badge.svg?branch=develop)](https://github.com/meridianhub/meridian/actions/workflows/security.yml?query=branch%3Adevelop)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/meridianhub/meridian)](https://go.dev/)
+[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
+
 Open-source billing engine with a double-entry ledger.
 Define your pricing and settlement logic in code —
 Meridian handles the bookkeeping, audit trails, and payment collection.

--- a/services/reference-data/saga/platform_sync_test.go
+++ b/services/reference-data/saga/platform_sync_test.go
@@ -278,27 +278,27 @@ func TestPlatformSync_SyncPlatformDefaults(t *testing.T) {
 		err := sync.SyncPlatformDefaults(ctx)
 		require.NoError(t, err)
 
-		// Verify sagas were inserted
+		// Verify all unique sagas were inserted (some may have multiple versions)
 		var count int
-		err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.platform_saga_definition`).Scan(&count)
+		err = pool.QueryRow(ctx, `SELECT COUNT(DISTINCT name) FROM public.platform_saga_definition`).Scan(&count)
 		require.NoError(t, err)
 		defaults, defaultsErr := PlatformDefaults()
 		require.NoError(t, defaultsErr)
 		assert.Equal(t, len(defaults), count, "expected all platform defaults to be inserted")
 
-		// Verify each saga has correct fields and ACTIVE status
+		// Verify each saga has an ACTIVE version with correct fields
 		for _, meta := range defaults {
 			var name, displayName, description, version, status string
 			err := pool.QueryRow(ctx, `
 				SELECT name, version, display_name, description, status
 				FROM public.platform_saga_definition
-				WHERE name = $1
+				WHERE name = $1 AND status = 'ACTIVE'
 			`, meta.Name).Scan(&name, &version, &displayName, &description, &status)
-			require.NoError(t, err, "saga %s should exist", meta.Name)
+			require.NoError(t, err, "saga %s should have an ACTIVE version", meta.Name)
 			assert.Equal(t, meta.Name, name)
 			assert.Equal(t, meta.DisplayName, displayName)
 			assert.Regexp(t, `^\d+\.\d+\.\d+$`, version)
-			assert.Equal(t, "ACTIVE", status, "saga %s should be ACTIVE after sync", meta.Name)
+			assert.Equal(t, "ACTIVE", status)
 		}
 	})
 

--- a/services/tenant/worker/provisioning_worker.go
+++ b/services/tenant/worker/provisioning_worker.go
@@ -46,6 +46,7 @@ type ProvisioningWorker struct {
 	done                  chan struct{}
 	wg                    sync.WaitGroup // Tracks in-flight provisioning goroutines
 	stopping              atomic.Bool    // Prevents new work during shutdown
+	stoppingMu            sync.Mutex     // Guards stopping check + wg.Add to prevent race with wg.Wait
 }
 
 // namedHook wraps a hook with its name for logging.
@@ -219,6 +220,13 @@ func (w *ProvisioningWorker) Stop() {
 		close(w.done)
 	}
 
+	// Barrier: acquire and release stoppingMu so that any in-flight
+	// processPendingTenants holding the lock for stopping check + wg.Add
+	// must complete before we proceed to wg.Wait.
+	w.stoppingMu.Lock()
+	//nolint:staticcheck,gocritic // SA2001: intentional empty critical section used as barrier
+	w.stoppingMu.Unlock()
+
 	// Wait for all in-flight provisioning goroutines to complete
 	w.logger.Info("waiting for in-flight provisioning to complete")
 	w.wg.Wait()
@@ -343,22 +351,22 @@ func (w *ProvisioningWorker) processPendingTenants(ctx context.Context) {
 			"tenant_id", tenant.ID,
 			"schema", tenant.SchemaName())
 
-		// Check if worker is stopping before adding new work.
-		// This prevents a race condition where wg.Add(1) is called
-		// after Stop() has already called wg.Wait().
+		// Atomically check stopping + wg.Add under stoppingMu to prevent
+		// a race where Stop() calls wg.Wait() between our check and Add.
 		//
-		// Note: When this branch is taken, the tenant remains in PROVISIONING status
-		// but won't be provisioned in this session. On restart, the RecoverStuckTenants
-		// method (called during Start()) will reset any stale PROVISIONING tenants back
-		// to PROVISIONING_PENDING so they can be picked up by the next polling cycle.
+		// Note: When the stopping branch is taken, the tenant remains in PROVISIONING
+		// status but won't be provisioned in this session. On restart, RecoverStuckTenants
+		// (called during Start()) resets stale PROVISIONING tenants back to
+		// PROVISIONING_PENDING so they can be picked up by the next polling cycle.
+		w.stoppingMu.Lock()
 		if w.stopping.Load() {
+			w.stoppingMu.Unlock()
 			w.logger.Warn("not spawning provisioning goroutine - worker is stopping",
 				"tenant_id", tenant.ID)
 			continue
 		}
-
-		// Track the goroutine in the WaitGroup
 		w.wg.Add(1)
+		w.stoppingMu.Unlock()
 
 		// Spawn provisioning in background with detached context
 		// We use context.WithoutCancel to prevent parent cancellation from stopping provisioning


### PR DESCRIPTION
## Summary

- Fix data race in `ProvisioningWorker.Stop()` vs `processPendingTenants()` — `wg.Wait()` could race with `wg.Add(1)` due to a TOCTOU gap between the `stopping` check and the Add call. Added a mutex barrier to make the check+Add atomic.
- Fix `TestPlatformSync_SyncPlatformDefaults` nightly failure — `stripe_payment` gained a v2.0.0 version file, so `COUNT(*)` returned 9 while `PlatformDefaults()` returns 8 unique saga names. Fixed to use `COUNT(DISTINCT name)` and query `WHERE status = 'ACTIVE'`.
- Add CI status badges to README (Build & Test, Nightly, Code Quality, Security, Go version, License).

## Test plan

- [x] `TestProvisioningWorker_NoGoroutineLeaks` passes with `-race -count=3` locally
- [ ] Build & Test CI passes on this PR
- [ ] Verify badges render correctly in README preview