### PR TITLE
refactor: consume shared dispatch types in operational-gateway

### DIFF
--- a/services/operational-gateway/domain/provider_connection.go
+++ b/services/operational-gateway/domain/provider_connection.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/pkg/dispatch"
 )
 
 // Protocol represents the communication protocol used to connect to a provider.
@@ -34,29 +35,31 @@ var validProtocols = map[Protocol]struct{}{
 }
 
 // CircuitState represents the current state of the circuit breaker.
-type CircuitState string
+// It is an alias for dispatch.CircuitState from the shared dispatch package.
+type CircuitState = dispatch.CircuitState
 
 const (
 	// CircuitStateClosed means the circuit is closed and requests flow normally.
-	CircuitStateClosed CircuitState = "CLOSED"
+	CircuitStateClosed = dispatch.CircuitStateClosed
 	// CircuitStateOpen means the circuit is open and requests are blocked.
-	CircuitStateOpen CircuitState = "OPEN"
+	CircuitStateOpen = dispatch.CircuitStateOpen
 	// CircuitStateHalfOpen means the circuit is allowing a probe request to test recovery.
-	CircuitStateHalfOpen CircuitState = "HALF_OPEN"
+	CircuitStateHalfOpen = dispatch.CircuitStateHalfOpen
 )
 
 // HealthStatus represents the observed health of a provider connection.
-type HealthStatus string
+// It is an alias for dispatch.HealthStatus from the shared dispatch package.
+type HealthStatus = dispatch.HealthStatus
 
 const (
 	// HealthStatusUnknown means no health check has been performed yet.
-	HealthStatusUnknown HealthStatus = "UNKNOWN"
+	HealthStatusUnknown = dispatch.HealthStatusUnknown
 	// HealthStatusHealthy means the provider is responding normally.
-	HealthStatusHealthy HealthStatus = "HEALTHY"
+	HealthStatusHealthy = dispatch.HealthStatusHealthy
 	// HealthStatusDegraded means the provider is responding but with elevated latency or errors.
-	HealthStatusDegraded HealthStatus = "DEGRADED"
+	HealthStatusDegraded = dispatch.HealthStatusDegraded
 	// HealthStatusUnhealthy means the provider is not responding or returning errors.
-	HealthStatusUnhealthy HealthStatus = "UNHEALTHY"
+	HealthStatusUnhealthy = dispatch.HealthStatusUnhealthy
 )
 
 // Sentinel errors for domain validation.
@@ -153,17 +156,8 @@ type MTLSAuth struct {
 func (a *MTLSAuth) AuthType() string { return "mtls" }
 
 // RetryPolicy defines how failed requests to a provider should be retried.
-type RetryPolicy struct {
-	// MaxAttempts is the maximum number of request attempts (including the initial attempt).
-	MaxAttempts int
-	// InitialBackoff is the wait duration before the first retry.
-	InitialBackoff time.Duration
-	// MaxBackoff is the maximum wait duration between retries.
-	MaxBackoff time.Duration
-	// BackoffMultiplier is the dimensionless scaling factor applied to the backoff duration on each retry
-	// (e.g., 2.0 doubles the backoff). This is a pure numeric multiplier, not a duration.
-	BackoffMultiplier float64
-}
+// It is an alias for dispatch.RetryPolicy from the shared dispatch package.
+type RetryPolicy = dispatch.RetryPolicy
 
 // RateLimitConfig defines the rate limiting policy for outbound requests to a provider.
 type RateLimitConfig struct {

--- a/services/operational-gateway/ports/dispatcher.go
+++ b/services/operational-gateway/ports/dispatcher.go
@@ -3,31 +3,18 @@ package ports
 
 import (
 	"context"
-	"time"
 
 	"github.com/meridianhub/meridian/services/operational-gateway/domain"
+	"github.com/meridianhub/meridian/shared/pkg/dispatch"
 )
 
 // DispatchResult captures the outcome of a single outbound HTTP dispatch attempt.
-type DispatchResult struct {
-	// StatusCode is the HTTP response status code from the provider.
-	StatusCode int
+// It is an alias for dispatch.Result from the shared dispatch package.
+type DispatchResult = dispatch.Result
 
-	// ResponseBody is the raw response body received from the provider.
-	ResponseBody []byte
-
-	// Outcome is the extracted InstructionOutcome after applying the inbound transform.
-	// May be nil if the dispatch did not reach the response parsing stage.
-	Outcome *InstructionOutcome
-
-	// Duration is the total time elapsed for the dispatch attempt, including
-	// connect, send, and receive time.
-	Duration time.Duration
-
-	// Error is non-nil when the dispatch failed before a response could be parsed
-	// (e.g., network error, auth failure, transform failure).
-	Error error
-}
+// InstructionOutcome captures the result of processing an inbound provider response.
+// It is an alias for dispatch.Outcome from the shared dispatch package.
+type InstructionOutcome = dispatch.Outcome
 
 // Dispatcher sends an instruction to an external provider via a configured connection.
 // Implementations handle the transport-level concerns (HTTP, gRPC, etc.) and authentication.

--- a/services/operational-gateway/ports/payload_transformer.go
+++ b/services/operational-gateway/ports/payload_transformer.go
@@ -42,26 +42,6 @@ type InstructionRoute struct {
 	Headers map[string]string
 }
 
-// InstructionOutcome captures the result of processing an inbound provider response.
-// It represents the extracted state from a provider acknowledgement or status callback.
-type InstructionOutcome struct {
-	// ExternalID is the provider's identifier for the instruction, if returned.
-	// May be empty if the provider does not return an external reference.
-	ExternalID string
-
-	// ProviderStatus is the provider's status string for the instruction
-	// (e.g., "ACCEPTED", "PENDING", "REJECTED").
-	ProviderStatus string
-
-	// ShouldRetry indicates whether the dispatch should be retried.
-	// Set to true when the provider returns a transient error (e.g., rate limit, timeout).
-	ShouldRetry bool
-
-	// FailureReason contains a human-readable description of why the instruction failed.
-	// Non-empty only when the provider indicates a permanent failure.
-	FailureReason string
-}
-
 // PayloadTransformer transforms instruction payloads between Meridian's internal format
 // and the format expected by external providers.
 //

--- a/services/operational-gateway/worker/dispatch_worker.go
+++ b/services/operational-gateway/worker/dispatch_worker.go
@@ -6,12 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math"
 	"sync"
 	"time"
 
 	"github.com/meridianhub/meridian/services/operational-gateway/domain"
 	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+	"github.com/meridianhub/meridian/shared/pkg/dispatch"
 )
 
 // Default configuration values.
@@ -284,8 +284,8 @@ func (w *DispatchWorker) handleRetry(ctx context.Context, instr *domain.Instruct
 		return fmt.Errorf("marking retrying: %w", err)
 	}
 
-	// Calculate next retry time using exponential backoff.
-	nextRetry := calculateNextRetry(instr.AttemptCount, conn.RetryPolicy)
+	// Calculate next retry time using exponential backoff from the shared dispatch package.
+	nextRetry := dispatch.CalculateNextRetry(instr.AttemptCount, conn.RetryPolicy)
 	instr.NextRetryAt = &nextRetry
 
 	if err := w.instructionRepo.Save(ctx, instr, ""); err != nil {
@@ -318,33 +318,4 @@ func (w *DispatchWorker) handleFailure(ctx context.Context, instr *domain.Instru
 		"error_code", errorCode,
 	)
 	return nil
-}
-
-// calculateNextRetry computes the next retry time using exponential backoff with a cap.
-// attempt is the 1-based attempt number that just failed.
-func calculateNextRetry(attempt int, policy domain.RetryPolicy) time.Time {
-	backoff := policy.InitialBackoff
-	if backoff <= 0 {
-		backoff = 1 * time.Second
-	}
-
-	multiplier := policy.BackoffMultiplier
-	if multiplier < 1.0 {
-		multiplier = 2.0
-	}
-
-	maxBackoff := policy.MaxBackoff
-	if maxBackoff <= 0 {
-		maxBackoff = 5 * time.Minute
-	}
-
-	// Exponential backoff: initialBackoff * multiplier^(attempt-1)
-	// attempt is 1-based; first retry (attempt=1) uses initialBackoff directly.
-	factor := math.Pow(multiplier, float64(attempt-1))
-	wait := time.Duration(float64(backoff) * factor)
-	if wait > maxBackoff {
-		wait = maxBackoff
-	}
-
-	return time.Now().Add(wait)
 }

--- a/services/operational-gateway/worker/dispatch_worker_test.go
+++ b/services/operational-gateway/worker/dispatch_worker_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/operational-gateway/domain"
 	"github.com/meridianhub/meridian/services/operational-gateway/ports"
+	"github.com/meridianhub/meridian/shared/pkg/dispatch"
 	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -781,15 +782,15 @@ func TestCalculateNextRetry_ExponentialBackoff(t *testing.T) {
 	before := time.Now()
 
 	// First retry (attempt 1): 1s * 2^0 = 1s
-	retry1 := calculateNextRetry(1, policy)
+	retry1 := dispatch.CalculateNextRetry(1, policy)
 	assert.InDelta(t, 1*time.Second, retry1.Sub(before), float64(200*time.Millisecond))
 
 	// Second retry (attempt 2): 1s * 2^1 = 2s
-	retry2 := calculateNextRetry(2, policy)
+	retry2 := dispatch.CalculateNextRetry(2, policy)
 	assert.InDelta(t, 2*time.Second, retry2.Sub(before), float64(200*time.Millisecond))
 
 	// Third retry (attempt 3): 1s * 2^2 = 4s
-	retry3 := calculateNextRetry(3, policy)
+	retry3 := dispatch.CalculateNextRetry(3, policy)
 	assert.InDelta(t, 4*time.Second, retry3.Sub(before), float64(200*time.Millisecond))
 }
 
@@ -803,7 +804,7 @@ func TestCalculateNextRetry_CapsAtMaxBackoff(t *testing.T) {
 	before := time.Now()
 
 	// attempt 3: 10s * 10^2 = 1000s, but capped at 30s
-	retry := calculateNextRetry(3, policy)
+	retry := dispatch.CalculateNextRetry(3, policy)
 	assert.InDelta(t, 30*time.Second, retry.Sub(before), float64(200*time.Millisecond))
 }
 
@@ -813,7 +814,7 @@ func TestCalculateNextRetry_FallbackDefaults(t *testing.T) {
 	before := time.Now()
 
 	// Should use defaults: 1s initial, 2.0 multiplier, 5m max
-	retry := calculateNextRetry(1, policy)
+	retry := dispatch.CalculateNextRetry(1, policy)
 	assert.InDelta(t, 1*time.Second, retry.Sub(before), float64(200*time.Millisecond))
 }
 


### PR DESCRIPTION
## Summary

- Replace locally-defined `CircuitState`, `HealthStatus`, `RetryPolicy` in `domain/provider_connection.go` with type aliases from `shared/pkg/dispatch`
- Replace locally-defined `DispatchResult` and `InstructionOutcome` in `ports/dispatcher.go` and `ports/payload_transformer.go` with type aliases from `shared/pkg/dispatch`
- Replace local `calculateNextRetry` function in `worker/dispatch_worker.go` with `dispatch.CalculateNextRetry` from the shared package

## Changes Made

| File | Change |
|------|--------|
| `services/operational-gateway/domain/provider_connection.go` | `CircuitState`, `HealthStatus`, `RetryPolicy` → type aliases from `shared/pkg/dispatch` |
| `services/operational-gateway/ports/dispatcher.go` | `DispatchResult`, `InstructionOutcome` → type aliases from `shared/pkg/dispatch` |
| `services/operational-gateway/ports/payload_transformer.go` | Removed `InstructionOutcome` struct (now aliased in `dispatcher.go`) |
| `services/operational-gateway/worker/dispatch_worker.go` | Removed local `calculateNextRetry`; uses `dispatch.CalculateNextRetry` |
| `services/operational-gateway/worker/dispatch_worker_test.go` | Updated tests to call `dispatch.CalculateNextRetry` directly |

## Technical Details

All replacements use Go type aliases (`type X = pkg.X`) which provide full backwards compatibility — no changes required in service layer, gRPC handlers, or existing tests. The type identity is preserved so all existing code compiles and behaves identically.

The `DispatchResult` alias points to `dispatch.Result` and `InstructionOutcome` aliases to `dispatch.Outcome` — both structs have identical fields.

## Testing

- All unit tests pass: `domain`, `worker`, `ports`, `httpadapter`, `passthrough`, `persistence`, `secrets`, `observability`
- E2E tests pass
- Pre-existing build failures in `cmd` and `service` packages are due to missing generated proto files (unrelated to this change)

## Risk Assessment

Low. All changes are type aliases with identical underlying types. No logic changes. No API surface changes. Tests unchanged except direct calls to the now-removed local function.