### PR TITLE
feat(financial-gateway): add service scaffold with stub gRPC implementation

### DIFF
--- a/services/financial-gateway/cmd/main.go
+++ b/services/financial-gateway/cmd/main.go
@@ -147,7 +147,7 @@ func run(logger *slog.Logger) error {
 
 // parseLogLevel converts a string log level to slog.Level.
 func parseLogLevel(levelStr string) slog.Level {
-	switch strings.ToLower(levelStr) {
+	switch strings.ToLower(strings.TrimSpace(levelStr)) {
 	case "debug":
 		return slog.LevelDebug
 	case "warn", "warning":

--- a/services/financial-gateway/cmd/main.go
+++ b/services/financial-gateway/cmd/main.go
@@ -1,0 +1,160 @@
+// Package main is the entry point for the financial-gateway standalone binary.
+//
+// It wires all financial-gateway components: gRPC service stub, platform bootstrap,
+// and health checks. The Stripe adapter is wired in task 5; this binary serves as
+// the structural scaffold for the service.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"strings"
+
+	financialgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway/v1"
+	"github.com/meridianhub/meridian/services/financial-gateway/config"
+	"github.com/meridianhub/meridian/services/financial-gateway/service"
+	"github.com/meridianhub/meridian/shared/platform/bootstrap"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+)
+
+// ErrMissingDatabaseURL is returned when the DATABASE_URL environment variable is not set.
+var ErrMissingDatabaseURL = errors.New("DATABASE_URL is required")
+
+// Build information set via ldflags during compilation.
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)
+
+func main() {
+	logLevel := parseLogLevel(os.Getenv("LOG_LEVEL"))
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevel,
+	}))
+	slog.SetDefault(logger)
+
+	logger.Info("starting financial-gateway service",
+		"version", Version,
+		"commit", Commit,
+		"build_date", BuildDate)
+
+	if err := bootstrap.RunWithRetry(
+		func() error { return run(logger) },
+		bootstrap.WithRetryLogger(logger),
+	); err != nil {
+		logger.Error("service failed to start", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("service stopped gracefully")
+}
+
+func run(logger *slog.Logger) error {
+	ctx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+
+	cfg := config.LoadConfig()
+
+	// Initialize OpenTelemetry tracer.
+	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
+		ServiceName:    "financial-gateway-service",
+		ServiceVersion: Version,
+		Logger:         logger,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize tracer: %w", err)
+	}
+	defer bootstrap.ShutdownTracer(tracer, logger)
+
+	// Initialize database connection.
+	if cfg.DatabaseURL == "" {
+		return bootstrap.Permanent(ErrMissingDatabaseURL)
+	}
+
+	dbCfg := bootstrap.DefaultDatabaseConfig()
+	dbCfg.DSN = cfg.DatabaseURL
+	dbCfg.Logger = logger
+
+	db, err := bootstrap.NewDatabase(ctx, dbCfg)
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+	defer bootstrap.CloseDatabase(db, logger)
+
+	logger.Info("database connection established")
+
+	// Initialize auth interceptor.
+	authConfig := bootstrap.DefaultAuthConfig(logger)
+	authInterceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth: %w", err)
+	}
+
+	// Create gRPC server.
+	grpcServer := bootstrap.NewGrpcServerBuilder(tracer, logger).
+		WithAuthInterceptor(authInterceptor).
+		Build()
+
+	// Initialize and register FinancialGatewayService stub.
+	gatewaySvc, err := service.NewFinancialGatewayService(logger)
+	if err != nil {
+		return fmt.Errorf("failed to create financial gateway service: %w", err)
+	}
+	financialgatewayv1.RegisterFinancialGatewayServiceServer(grpcServer, gatewaySvc)
+
+	// Register health check.
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
+
+	// Register reflection for debugging.
+	reflection.Register(grpcServer)
+
+	logger.Info("gRPC services registered")
+
+	// Create listener before serving to fail fast if the port is unavailable.
+	address := fmt.Sprintf(":%s", cfg.GRPCPort)
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", address)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", address, err)
+	}
+
+	// Start gRPC server in background.
+	serverErrors := make(chan error, 1)
+	go func() {
+		logger.Info("starting gRPC server", "address", address)
+		if err := grpcServer.Serve(listener); err != nil {
+			serverErrors <- err
+		}
+	}()
+
+	// Wait for shutdown signal.
+	orchestrator := bootstrap.NewShutdownOrchestrator(grpcServer, logger)
+	orchestrator.AddCleanup(func() error {
+		runCancel()
+		return nil
+	})
+
+	return orchestrator.Wait(serverErrors)
+}
+
+// parseLogLevel converts a string log level to slog.Level.
+func parseLogLevel(levelStr string) slog.Level {
+	switch strings.ToLower(levelStr) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/services/financial-gateway/config/config.go
+++ b/services/financial-gateway/config/config.go
@@ -1,0 +1,67 @@
+// Package config provides configuration loading for the financial-gateway service.
+package config
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/env"
+	"github.com/meridianhub/meridian/shared/platform/ports"
+)
+
+// Config holds the financial-gateway service configuration.
+type Config struct {
+	// GRPCPort is the gRPC listen port.
+	GRPCPort string
+
+	// DatabaseURL is the CockroachDB/PostgreSQL connection string.
+	DatabaseURL string
+
+	// LogLevel controls the log verbosity (debug, info, warn, error).
+	LogLevel string
+
+	// StripeSecretKey is the Stripe API secret key for payment dispatch.
+	StripeSecretKey string
+
+	// CircuitBreaker configures per-connection circuit breaker behavior.
+	CircuitBreaker CircuitBreakerConfig
+
+	// RateLimit configures the inbound request rate limiter.
+	RateLimit RateLimitConfig
+}
+
+// CircuitBreakerConfig configures the circuit breaker for external provider calls.
+type CircuitBreakerConfig struct {
+	// Timeout is the duration the circuit stays open before transitioning to half-open.
+	Timeout time.Duration
+
+	// FailureThreshold is the number of consecutive failures required to trip the circuit.
+	FailureThreshold int
+}
+
+// RateLimitConfig configures inbound request rate limiting.
+type RateLimitConfig struct {
+	// RPS is the maximum sustained request rate (requests per second).
+	RPS float64
+
+	// Burst is the maximum burst size above the sustained rate.
+	Burst int
+}
+
+// LoadConfig loads configuration from environment variables with sensible defaults.
+func LoadConfig() Config {
+	return Config{
+		GRPCPort:        env.GetEnvOrDefault("GRPC_PORT", strconv.Itoa(ports.FinancialGateway)),
+		DatabaseURL:     env.GetEnvOrDefault("DATABASE_URL", ""),
+		LogLevel:        env.GetEnvOrDefault("LOG_LEVEL", "info"),
+		StripeSecretKey: env.GetEnvOrDefault("STRIPE_SECRET_KEY", ""),
+		CircuitBreaker: CircuitBreakerConfig{
+			Timeout:          env.GetEnvAsDuration("CIRCUIT_BREAKER_TIMEOUT", 30*time.Second),
+			FailureThreshold: env.GetEnvAsInt("CIRCUIT_BREAKER_FAILURES", 5),
+		},
+		RateLimit: RateLimitConfig{
+			RPS:   env.GetEnvAsFloat("RATE_LIMIT_RPS", 100),
+			Burst: env.GetEnvAsInt("RATE_LIMIT_BURST", 10),
+		},
+	}
+}

--- a/services/financial-gateway/observability/metrics.go
+++ b/services/financial-gateway/observability/metrics.go
@@ -1,0 +1,102 @@
+// Package observability provides Prometheus metrics and monitoring for the financial gateway service.
+package observability
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// paymentsTotal counts all payment dispatches by tenant, rail, and terminal status.
+	paymentsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "meridian_financial_gateway_payments_total",
+			Help: "Total number of payment dispatches processed, labeled by tenant, payment rail, and terminal status.",
+		},
+		[]string{"tenant", "rail", "status"},
+	)
+
+	// dispatchDuration records how long a single dispatch attempt takes.
+	dispatchDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "meridian_financial_gateway_dispatch_duration_seconds",
+			Help:    "Duration of a dispatch attempt to an external payment rail in seconds.",
+			Buckets: []float64{.01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30},
+		},
+		[]string{"tenant", "rail"},
+	)
+
+	// dispatchAttemptsTotal counts all dispatch attempts by tenant, rail, and outcome.
+	dispatchAttemptsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "meridian_financial_gateway_dispatch_attempts_total",
+			Help: "Total number of individual dispatch attempts to external payment rails.",
+		},
+		[]string{"tenant", "rail", "outcome"},
+	)
+
+	// circuitBreakerState tracks the circuit breaker state per payment rail provider.
+	// One time series per state label: active state is 1, inactive states are 0.
+	circuitBreakerState = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "meridian_financial_gateway_circuit_breaker_state",
+			Help: "One-hot circuit breaker state per payment rail provider and state label (1=active, 0=inactive).",
+		},
+		[]string{"tenant", "rail", "state"},
+	)
+
+	// activeDispatches tracks the number of dispatches currently in a given non-terminal status.
+	activeDispatches = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "meridian_financial_gateway_active_dispatches",
+			Help: "Current number of payment dispatches in non-terminal states, labeled by tenant and status.",
+		},
+		[]string{"tenant", "status"},
+	)
+)
+
+// DispatchOutcome represents the result of a single dispatch attempt.
+const (
+	// DispatchOutcomeSuccess means the payment rail accepted the payment.
+	DispatchOutcomeSuccess = "success"
+	// DispatchOutcomeRetry means the attempt failed but will be retried.
+	DispatchOutcomeRetry = "retry"
+	// DispatchOutcomeFailure means the attempt failed permanently.
+	DispatchOutcomeFailure = "failure"
+	// DispatchOutcomeCircuitOpen means the circuit breaker blocked the attempt.
+	DispatchOutcomeCircuitOpen = "circuit_open"
+)
+
+// RecordPayment increments the payments counter for the given terminal status.
+// Call this when a payment reaches a terminal state (DELIVERED, ACKNOWLEDGED, FAILED).
+func RecordPayment(tenant, rail, status string) {
+	paymentsTotal.WithLabelValues(tenant, rail, status).Inc()
+}
+
+// RecordDispatchDuration records how long a dispatch attempt took.
+func RecordDispatchDuration(tenant, rail string, duration time.Duration) {
+	dispatchDuration.WithLabelValues(tenant, rail).Observe(duration.Seconds())
+}
+
+// RecordDispatchAttempt increments the dispatch attempts counter.
+// outcome should be one of the DispatchOutcome* constants.
+func RecordDispatchAttempt(tenant, rail, outcome string) {
+	dispatchAttemptsTotal.WithLabelValues(tenant, rail, outcome).Inc()
+}
+
+// RecordCircuitBreakerState updates the gauge for a specific provider's circuit breaker state.
+// Resets all states before setting the active one to avoid stale time series.
+func RecordCircuitBreakerState(tenant, rail, state string) {
+	circuitBreakerState.WithLabelValues(tenant, rail, "closed").Set(0)
+	circuitBreakerState.WithLabelValues(tenant, rail, "half_open").Set(0)
+	circuitBreakerState.WithLabelValues(tenant, rail, "open").Set(0)
+	circuitBreakerState.WithLabelValues(tenant, rail, state).Set(1)
+}
+
+// SetActiveDispatches sets the gauge for dispatches currently in a given status.
+// Call this after each polling cycle with the current count per status.
+func SetActiveDispatches(tenant, status string, count float64) {
+	activeDispatches.WithLabelValues(tenant, status).Set(count)
+}

--- a/services/financial-gateway/observability/metrics.go
+++ b/services/financial-gateway/observability/metrics.go
@@ -80,23 +80,53 @@ func RecordDispatchDuration(tenant, rail string, duration time.Duration) {
 	dispatchDuration.WithLabelValues(tenant, rail).Observe(duration.Seconds())
 }
 
+// knownDispatchOutcomes is the set of valid outcome label values.
+// Any value outside this set is mapped to "unknown" to prevent cardinality blowup.
+var knownDispatchOutcomes = map[string]struct{}{
+	DispatchOutcomeSuccess:     {},
+	DispatchOutcomeRetry:       {},
+	DispatchOutcomeFailure:     {},
+	DispatchOutcomeCircuitOpen: {},
+}
+
+// knownCircuitStates is the set of valid circuit breaker state label values.
+var knownCircuitStates = []string{"closed", "half_open", "open"}
+
 // RecordDispatchAttempt increments the dispatch attempts counter.
-// outcome should be one of the DispatchOutcome* constants.
+// outcome must be one of the DispatchOutcome* constants; unknown values are recorded as "unknown".
 func RecordDispatchAttempt(tenant, rail, outcome string) {
+	if _, ok := knownDispatchOutcomes[outcome]; !ok {
+		outcome = "unknown"
+	}
 	dispatchAttemptsTotal.WithLabelValues(tenant, rail, outcome).Inc()
 }
 
 // RecordCircuitBreakerState updates the gauge for a specific provider's circuit breaker state.
-// Resets all states before setting the active one to avoid stale time series.
+// Resets all known states before setting the active one to guarantee the one-hot invariant.
+// Unknown state values are silently ignored to prevent unbounded label cardinality.
 func RecordCircuitBreakerState(tenant, rail, state string) {
-	circuitBreakerState.WithLabelValues(tenant, rail, "closed").Set(0)
-	circuitBreakerState.WithLabelValues(tenant, rail, "half_open").Set(0)
-	circuitBreakerState.WithLabelValues(tenant, rail, "open").Set(0)
+	valid := false
+	for _, s := range knownCircuitStates {
+		if s == state {
+			valid = true
+			break
+		}
+	}
+	if !valid {
+		return
+	}
+	for _, s := range knownCircuitStates {
+		circuitBreakerState.WithLabelValues(tenant, rail, s).Set(0)
+	}
 	circuitBreakerState.WithLabelValues(tenant, rail, state).Set(1)
 }
 
 // SetActiveDispatches sets the gauge for dispatches currently in a given status.
+// count is clamped to 0 if negative to prevent invalid operational signals.
 // Call this after each polling cycle with the current count per status.
 func SetActiveDispatches(tenant, status string, count float64) {
+	if count < 0 {
+		count = 0
+	}
 	activeDispatches.WithLabelValues(tenant, status).Set(count)
 }

--- a/services/financial-gateway/observability/tracing.go
+++ b/services/financial-gateway/observability/tracing.go
@@ -1,0 +1,48 @@
+package observability
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const tracerName = "meridian/financial-gateway"
+
+// Tracer returns the OpenTelemetry tracer for the financial gateway service.
+func Tracer() trace.Tracer {
+	return otel.Tracer(tracerName)
+}
+
+// StartSpan creates a new internal span as a child of the span in the context.
+// The returned context contains the new span; callers must call span.End() when done.
+func StartSpan(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	return Tracer().Start(ctx, name,
+		trace.WithAttributes(attrs...),
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+}
+
+// RecordError marks a span as having errored and records the error message.
+func RecordError(span trace.Span, err error) {
+	if err == nil || span == nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, "error")
+}
+
+// Common attribute keys for financial gateway spans.
+var (
+	AttrTenantID       = attribute.Key("financial_gateway.tenant_id")
+	AttrDispatchID     = attribute.Key("financial_gateway.dispatch_id")
+	AttrPaymentOrderID = attribute.Key("financial_gateway.payment_order_id")
+	AttrPaymentRail    = attribute.Key("financial_gateway.payment_rail")
+	AttrDispatchStatus = attribute.Key("financial_gateway.dispatch_status")
+	AttrCorrelationID  = attribute.Key("financial_gateway.correlation_id")
+	AttrProviderRef    = attribute.Key("financial_gateway.provider_reference")
+	AttrAmountUnits    = attribute.Key("financial_gateway.amount_units")
+	AttrInstrumentCode = attribute.Key("financial_gateway.instrument_code")
+)

--- a/services/financial-gateway/service/grpc_service.go
+++ b/services/financial-gateway/service/grpc_service.go
@@ -3,7 +3,6 @@ package service
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"os"
 
@@ -11,9 +10,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
-
-// ErrLoggerNil is returned when a nil logger is provided to a constructor.
-var ErrLoggerNil = errors.New("logger cannot be nil")
 
 // FinancialGatewayService implements FinancialGatewayServiceServer.
 // All RPCs return codes.Unimplemented until the Stripe adapter is wired in task 5.

--- a/services/financial-gateway/service/grpc_service.go
+++ b/services/financial-gateway/service/grpc_service.go
@@ -1,0 +1,61 @@
+// Package service implements the gRPC service for the financial-gateway domain.
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+
+	financialgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ErrLoggerNil is returned when a nil logger is provided to a constructor.
+var ErrLoggerNil = errors.New("logger cannot be nil")
+
+// FinancialGatewayService implements FinancialGatewayServiceServer.
+// All RPCs return codes.Unimplemented until the Stripe adapter is wired in task 5.
+type FinancialGatewayService struct {
+	financialgatewayv1.UnimplementedFinancialGatewayServiceServer
+	logger *slog.Logger
+}
+
+// NewFinancialGatewayService creates a new FinancialGatewayService stub.
+// If logger is nil a default JSON logger writing to stdout is used.
+func NewFinancialGatewayService(logger *slog.Logger) (*FinancialGatewayService, error) {
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	}
+	return &FinancialGatewayService{
+		logger: logger,
+	}, nil
+}
+
+// DispatchPayment submits a financial payment for outbound dispatch via a payment rail.
+// Returns Unimplemented until the Stripe adapter is wired (task 5).
+func (s *FinancialGatewayService) DispatchPayment(
+	_ context.Context,
+	_ *financialgatewayv1.DispatchPaymentRequest,
+) (*financialgatewayv1.DispatchPaymentResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "DispatchPayment not yet implemented")
+}
+
+// DispatchRefund submits a financial refund for outbound dispatch via the original payment rail.
+// Returns Unimplemented until the Stripe adapter is wired (task 5).
+func (s *FinancialGatewayService) DispatchRefund(
+	_ context.Context,
+	_ *financialgatewayv1.DispatchRefundRequest,
+) (*financialgatewayv1.DispatchRefundResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "DispatchRefund not yet implemented")
+}
+
+// GetProviderHealth returns the current health status of a payment rail provider.
+// Returns Unimplemented until the Stripe adapter is wired (task 5).
+func (s *FinancialGatewayService) GetProviderHealth(
+	_ context.Context,
+	_ *financialgatewayv1.GetProviderHealthRequest,
+) (*financialgatewayv1.GetProviderHealthResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "GetProviderHealth not yet implemented")
+}

--- a/shared/platform/ports/ports.go
+++ b/shared/platform/ports/ports.go
@@ -130,6 +130,12 @@ const (
 	// Protocol: gRPC (internal)
 	// Visibility: Cluster-internal only
 	OperationalGateway = 50063
+
+	// FinancialGateway is the gRPC port for the Financial Gateway service.
+	// Manages outbound financial payment dispatch to external payment rails (Stripe, SWIFT, ACH, FedNow).
+	// Protocol: gRPC (internal)
+	// Visibility: Cluster-internal only
+	FinancialGateway = 50064
 )
 
 // HTTP service ports (various protocols).


### PR DESCRIPTION
## Summary

- Introduces `services/financial-gateway/` with the complete directory structure for the Financial Gateway service
- All three gRPC RPCs (`DispatchPayment`, `DispatchRefund`, `GetProviderHealth`) return `codes.Unimplemented` as stubs pending Stripe adapter wiring (task 5)
- Adds `FinancialGateway = 50064` port constant to `shared/platform/ports`

## Changes Made

### New service scaffold (`services/financial-gateway/`)
- **`cmd/main.go`**: Standalone service entry point; wires shared bootstrap (slog, OpenTelemetry tracer, auth interceptor, gRPC server, graceful shutdown via `ShutdownOrchestrator`)
- **`config/config.go`**: Environment-driven config using `shared/platform/env`; includes `CircuitBreakerConfig` and `RateLimitConfig` for task 5 Stripe adapter
- **`service/grpc_service.go`**: `FinancialGatewayService` implementing the proto interface; all RPCs return `codes.Unimplemented`
- **`observability/metrics.go`**: Prometheus counters, histograms, and gauges (payments total, dispatch duration, dispatch attempts, circuit breaker state, active dispatches)
- **`observability/tracing.go`**: OpenTelemetry tracer with common span attribute keys for the financial domain
- **`adapters/stripe/`**: Empty placeholder directory — Stripe adapter implementation moves here in task 5

### Port registration
- `shared/platform/ports/ports.go`: `FinancialGateway = 50064`

## Technical Details

- Follows the same structural pattern as `services/operational-gateway/`
- Service is NOT yet wired into the unified `cmd/meridian/main.go` binary (deferred to task 12)
- Config defaults to port 50064 using the new `ports.FinancialGateway` constant
- Proto stubs from `api/proto/meridian/financial_gateway/v1/` (merged in PR #1379)

## Testing

- `go build ./services/financial-gateway/...` passes cleanly
- `go build ./...` passes cleanly (no regressions)
- No unit tests at scaffold stage — service logic added in task 5

## Risk Assessment

Low risk. All RPCs return `Unimplemented`; no production paths altered. Port 50064 allocation is additive.

## Deployment Notes

Service is not yet deployed. The standalone binary is buildable but not registered in the unified binary or Kubernetes manifests.

## Task Master

Implements 033-gateway-architecture.4 — financial-gateway service scaffold.