### PR TITLE
fix: increase nightly test timeout to 45 minutes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -89,7 +89,7 @@ jobs:
   slow-integration-tests:
     name: Slow Integration Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     # Note: No postgres service container needed - tests use testcontainers
     # which manage their own ephemeral containers with proper isolation.
 


### PR DESCRIPTION
## Summary

- Increase the `slow-integration-tests` job timeout from 30 to 45 minutes in the nightly workflow

## Context

The full test suite with `-race` (no `-short` flag) now takes ~30 minutes on CI runners. Recent nightly runs have been cancelled by the 30-minute job timeout before completion:

| Run | Date | Conclusion | Duration |
|-----|------|------------|----------|
| 22661210461 | Mar 4 (manual) | cancelled | 30m23s |
| 22654699425 | Mar 4 (scheduled) | cancelled | 30m21s |

The test failure from #1382 (`TestPlatformSync_SyncPlatformDefaults`) was confirmed fixed in the Mar 4 manual run - the test passed, but the overall job was cancelled due to the timeout.

## Test plan

- [x] Verified the PlatformSync test passes with the #1382 fix
- [ ] Next nightly run completes within 45 minutes without cancellation