### PR TITLE
feat(payment-order): add gRPC client for financial-gateway payment dispatch

### DIFF
--- a/services/financial-gateway/client/client.go
+++ b/services/financial-gateway/client/client.go
@@ -1,0 +1,272 @@
+// Package client provides a gRPC client for the FinancialGateway service.
+//
+// The FinancialGateway service manages outbound payment dispatch to external payment rails
+// (e.g. Stripe). This client enables inter-service communication with proper context
+// propagation, tracing, and resilience patterns.
+//
+// Usage with Kubernetes DNS-based load balancing (recommended for production):
+//
+//	client, cleanup, err := client.New(client.Config{
+//	    ServiceName: "financial-gateway",
+//	    Namespace:   "default",
+//	    Port:        50064,
+//	    Tracer:      tracer,
+//	})
+//	if err != nil {
+//	    return err
+//	}
+//	defer cleanup()
+//
+// Usage with direct connection (for local development):
+//
+//	client, cleanup, err := client.New(client.Config{
+//	    Target:  "localhost:50064",
+//	    Timeout: 30 * time.Second,
+//	})
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	financialgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway/v1"
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
+	"github.com/meridianhub/meridian/shared/platform/observability"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	// DefaultPort is the default gRPC port for the FinancialGateway service.
+	DefaultPort = 50064
+
+	// DefaultTimeout is the default timeout for gRPC calls.
+	DefaultTimeout = 30 * time.Second
+
+	// DefaultNamespace is the default Kubernetes namespace.
+	DefaultNamespace = "default"
+
+	// ServiceName is the Kubernetes service name for FinancialGateway.
+	ServiceName = "financial-gateway"
+)
+
+// ErrTargetRequired is returned when neither Target nor ServiceName is provided.
+var ErrTargetRequired = errors.New("either Target or ServiceName must be provided")
+
+// Config holds configuration for the FinancialGateway client.
+type Config struct {
+	// Target is the gRPC server address (e.g., "localhost:50064" or "financial-gateway:50064").
+	// If set, overrides Kubernetes DNS-based discovery.
+	//
+	// Deprecated: Use ServiceName, Namespace, and Port for DNS-based load balancing.
+	Target string
+
+	// ServiceName is the Kubernetes service name (e.g., "financial-gateway").
+	// When specified, enables DNS-based client-side load balancing via pkg/platform/grpc.
+	ServiceName string
+
+	// Namespace is the Kubernetes namespace (e.g., "default", "production").
+	// Defaults to "default" if not specified.
+	Namespace string
+
+	// Port is the service port number.
+	// Defaults to 50064 if not specified.
+	Port int
+
+	// Timeout is the default timeout for RPC calls.
+	// Defaults to 30 seconds if not specified.
+	Timeout time.Duration
+
+	// Tracer is an optional observability tracer for distributed tracing.
+	// If provided, the client will automatically propagate trace context.
+	Tracer *observability.Tracer
+
+	// Resilience is an optional configuration for circuit breaker and retry.
+	// If provided, calls will be wrapped with resilience patterns.
+	Resilience *clients.ResilientClientConfig
+
+	// DialOptions allows custom gRPC dial options.
+	DialOptions []grpc.DialOption
+}
+
+// Client provides access to the FinancialGateway service.
+type Client struct {
+	conn             *grpc.ClientConn
+	financialGateway financialgatewayv1.FinancialGatewayServiceClient
+	tracer           *observability.Tracer
+	resilient        *clients.ResilientClient
+	timeout          time.Duration
+}
+
+// New creates a new FinancialGateway gRPC client.
+//
+// Returns the client, a cleanup function to close the connection, and any error.
+// The cleanup function should be deferred immediately after checking the error.
+func New(cfg Config) (*Client, func(), error) {
+	// Apply defaults
+	if cfg.Timeout == 0 {
+		cfg.Timeout = DefaultTimeout
+	}
+	if cfg.Port == 0 {
+		cfg.Port = DefaultPort
+	}
+	if cfg.Namespace == "" {
+		cfg.Namespace = DefaultNamespace
+	}
+
+	var conn *grpc.ClientConn
+	var err error
+
+	// Use platform gRPC factory when ServiceName is provided (preferred)
+	if cfg.ServiceName != "" {
+		dialOpts := cfg.DialOptions
+
+		if cfg.Tracer != nil {
+			dialOpts = append(dialOpts,
+				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
+				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
+			)
+		}
+
+		conn, err = platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
+			ServiceName: cfg.ServiceName,
+			Namespace:   cfg.Namespace,
+			Port:        cfg.Port,
+			DialOptions: dialOpts,
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create financial-gateway gRPC connection via platform factory: %w", err)
+		}
+	} else if cfg.Target != "" {
+		dialOpts := cfg.DialOptions
+		if dialOpts == nil {
+			dialOpts = []grpc.DialOption{
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			}
+		}
+
+		if cfg.Tracer != nil {
+			dialOpts = append(dialOpts,
+				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
+				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
+			)
+		}
+
+		conn, err = grpc.NewClient(cfg.Target, dialOpts...)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create financial-gateway gRPC connection to %s: %w", cfg.Target, err)
+		}
+	} else {
+		return nil, nil, ErrTargetRequired
+	}
+
+	// Create resilient client if configuration is provided
+	var resilient *clients.ResilientClient
+	if cfg.Resilience != nil {
+		resilient = clients.NewResilientClient(*cfg.Resilience)
+	}
+
+	c := &Client{
+		conn:             conn,
+		financialGateway: financialgatewayv1.NewFinancialGatewayServiceClient(conn),
+		tracer:           cfg.Tracer,
+		resilient:        resilient,
+		timeout:          cfg.Timeout,
+	}
+
+	cleanup := func() {
+		if c.conn != nil {
+			_ = c.conn.Close()
+		}
+	}
+
+	return c, cleanup, nil
+}
+
+// DispatchPayment submits a payment for outbound dispatch via a payment rail.
+// This is a non-idempotent operation guarded by idempotency_key, so retry is disabled.
+func (c *Client) DispatchPayment(ctx context.Context, req *financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilienceNoRetry(ctx, c.resilient, "DispatchPayment", func() (*financialgatewayv1.DispatchPaymentResponse, error) {
+			return c.financialGateway.DispatchPayment(ctx, req)
+		})
+	}
+
+	resp, err := c.financialGateway.DispatchPayment(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dispatch payment: %w", err)
+	}
+
+	return resp, nil
+}
+
+// DispatchRefund submits a refund for outbound dispatch via the original payment rail.
+// This is a non-idempotent operation guarded by idempotency_key, so retry is disabled.
+func (c *Client) DispatchRefund(ctx context.Context, req *financialgatewayv1.DispatchRefundRequest) (*financialgatewayv1.DispatchRefundResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilienceNoRetry(ctx, c.resilient, "DispatchRefund", func() (*financialgatewayv1.DispatchRefundResponse, error) {
+			return c.financialGateway.DispatchRefund(ctx, req)
+		})
+	}
+
+	resp, err := c.financialGateway.DispatchRefund(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dispatch refund: %w", err)
+	}
+
+	return resp, nil
+}
+
+// GetProviderHealth returns the current health status of a payment rail provider.
+// This is an idempotent read operation, so retry is enabled.
+func (c *Client) GetProviderHealth(ctx context.Context, req *financialgatewayv1.GetProviderHealthRequest) (*financialgatewayv1.GetProviderHealthResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilience(ctx, c.resilient, "GetProviderHealth", func() (*financialgatewayv1.GetProviderHealthResponse, error) {
+			return c.financialGateway.GetProviderHealth(ctx, req)
+		})
+	}
+
+	resp, err := c.financialGateway.GetProviderHealth(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get provider health: %w", err)
+	}
+
+	return resp, nil
+}
+
+// Close terminates the gRPC connection gracefully.
+func (c *Client) Close() error {
+	if c.conn != nil {
+		if err := c.conn.Close(); err != nil {
+			return fmt.Errorf("failed to close financial-gateway client connection: %w", err)
+		}
+	}
+	return nil
+}
+
+// Conn returns the underlying gRPC connection for creating additional clients
+// (e.g., health check clients that bypass the business client's circuit breaker).
+func (c *Client) Conn() *grpc.ClientConn {
+	return c.conn
+}

--- a/services/payment-order/adapters/gateway/config.go
+++ b/services/payment-order/adapters/gateway/config.go
@@ -8,8 +8,9 @@ import (
 
 // Provider constants for gateway selection.
 const (
-	ProviderStripe = "stripe"
-	ProviderMock   = "mock"
+	ProviderStripe           = "stripe"
+	ProviderMock             = "mock"
+	ProviderFinancialGateway = "financial-gateway"
 )
 
 // Config holds configuration for payment gateway connections.

--- a/services/payment-order/adapters/gateway/financial_gateway_client.go
+++ b/services/payment-order/adapters/gateway/financial_gateway_client.go
@@ -1,0 +1,156 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	financialgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway/v1"
+	fgclient "github.com/meridianhub/meridian/services/financial-gateway/client"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Sentinel errors for the FinancialGatewayClient.
+var (
+	// ErrFinancialGatewayInvalidArgument is returned when the gateway rejects the request as invalid.
+	ErrFinancialGatewayInvalidArgument = errors.New("financial-gateway rejected payment (invalid argument)")
+	// ErrFinancialGatewayPreconditionFailed is returned when tenant configuration is missing.
+	ErrFinancialGatewayPreconditionFailed = errors.New("financial-gateway precondition failed")
+	// ErrFinancialGatewayDuplicateDispatch is returned when the idempotency key already exists.
+	ErrFinancialGatewayDuplicateDispatch = errors.New("financial-gateway duplicate dispatch (already exists)")
+	// ErrFinancialGatewayUnavailable is returned on transient service failures.
+	ErrFinancialGatewayUnavailable = errors.New("financial-gateway temporarily unavailable")
+	// ErrFinancialGatewayTimeout is returned when the request times out or is canceled.
+	ErrFinancialGatewayTimeout = errors.New("financial-gateway request timed out or canceled")
+	// ErrFinancialGatewayRailUnsupported is returned when the payment rail is not supported.
+	ErrFinancialGatewayRailUnsupported = errors.New("financial-gateway payment rail not supported")
+	// ErrFinancialGatewayUnexpected is returned for unexpected gRPC error codes.
+	ErrFinancialGatewayUnexpected = errors.New("financial-gateway unexpected error")
+)
+
+// FinancialGatewayClient implements PaymentGateway by calling the financial-gateway service via gRPC.
+type FinancialGatewayClient struct {
+	client *fgclient.Client
+	logger *slog.Logger
+}
+
+// NewFinancialGatewayClient creates a FinancialGatewayClient wrapping the provided gRPC client.
+func NewFinancialGatewayClient(client *fgclient.Client, logger *slog.Logger) *FinancialGatewayClient {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &FinancialGatewayClient{
+		client: client,
+		logger: logger,
+	}
+}
+
+// SendPayment dispatches a payment via the financial-gateway service using the Stripe rail.
+func (c *FinancialGatewayClient) SendPayment(ctx context.Context, req PaymentRequest) (PaymentResponse, error) {
+	amountUnits := domain.ToMinorUnits(req.Amount)
+	instrumentCode := domain.CurrencyCode(req.Amount)
+
+	protoReq := &financialgatewayv1.DispatchPaymentRequest{
+		PaymentOrderId:    req.PaymentOrderID.String(),
+		Rail:              financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+		AmountUnits:       amountUnits,
+		InstrumentCode:    instrumentCode,
+		DebtorAccountId:   req.DebtorAccountID,
+		CreditorAccountId: req.PaymentOrderID.String(), // placeholder UUID; Stripe routing via Reference
+		Reference:         req.CreditorReference,
+		CorrelationId:     req.PaymentOrderID.String(),
+		CausationId:       req.PaymentOrderID.String(),
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: req.IdempotencyKey,
+		},
+	}
+
+	c.logger.Debug("dispatching payment via financial-gateway",
+		"payment_order_id", req.PaymentOrderID.String(),
+		"amount_units", amountUnits,
+		"instrument_code", instrumentCode,
+	)
+
+	resp, err := c.client.DispatchPayment(ctx, protoReq)
+	if err != nil {
+		return PaymentResponse{}, c.mapGRPCError(err)
+	}
+
+	gatewayStatus := mapDispatchStatus(resp.GetStatus())
+
+	c.logger.Info("financial-gateway dispatch response",
+		"payment_order_id", req.PaymentOrderID.String(),
+		"dispatch_id", resp.GetDispatchId(),
+		"provider_reference", resp.GetProviderReference(),
+		"status", resp.GetStatus(),
+	)
+
+	return PaymentResponse{
+		GatewayReferenceID: resp.GetProviderReference(),
+		Status:             gatewayStatus,
+		Message:            resp.GetStatus().String(),
+	}, nil
+}
+
+// mapDispatchStatus maps a financial-gateway DispatchStatus to a gateway.Status.
+func mapDispatchStatus(s financialgatewayv1.DispatchStatus) Status {
+	switch s {
+	case financialgatewayv1.DispatchStatus_DISPATCH_STATUS_DELIVERED,
+		financialgatewayv1.DispatchStatus_DISPATCH_STATUS_ACKNOWLEDGED:
+		return StatusAccepted
+	case financialgatewayv1.DispatchStatus_DISPATCH_STATUS_FAILED:
+		return StatusRejected
+	case financialgatewayv1.DispatchStatus_DISPATCH_STATUS_PENDING,
+		financialgatewayv1.DispatchStatus_DISPATCH_STATUS_DISPATCHING,
+		financialgatewayv1.DispatchStatus_DISPATCH_STATUS_RETRYING:
+		return StatusPending
+	case financialgatewayv1.DispatchStatus_DISPATCH_STATUS_UNSPECIFIED:
+		return StatusPending
+	}
+	// Unknown status — treat as pending
+	return StatusPending
+}
+
+// mapGRPCError translates gRPC status codes into payment-order gateway errors.
+func (c *FinancialGatewayClient) mapGRPCError(err error) error {
+	st, ok := status.FromError(err)
+	if !ok {
+		return fmt.Errorf("financial-gateway dispatch failed: %w", err)
+	}
+
+	switch st.Code() { //nolint:exhaustive // remaining codes treated as unexpected
+	case codes.InvalidArgument:
+		// Permanent rejection — caller should treat as terminal failure.
+		return fmt.Errorf("%w: %s", ErrFinancialGatewayInvalidArgument, st.Message())
+
+	case codes.FailedPrecondition:
+		// Configuration error (missing tenant config, Stripe not set up).
+		return fmt.Errorf("%w: %s", ErrFinancialGatewayPreconditionFailed, st.Message())
+
+	case codes.AlreadyExists:
+		// Idempotency collision — same key was already dispatched.
+		return fmt.Errorf("%w: %s", ErrFinancialGatewayDuplicateDispatch, st.Message())
+
+	case codes.Unavailable:
+		// Transient failure — safe to retry.
+		return fmt.Errorf("%w: %s", ErrFinancialGatewayUnavailable, st.Message())
+
+	case codes.DeadlineExceeded, codes.Canceled:
+		// Propagate context errors for retry by the resilience layer.
+		return fmt.Errorf("%w: %w", ErrFinancialGatewayTimeout, err)
+
+	case codes.Unimplemented:
+		// Payment rail not supported — permanent error.
+		return fmt.Errorf("%w: %s", ErrFinancialGatewayRailUnsupported, st.Message())
+
+	default:
+		return fmt.Errorf("%w: code=%s msg=%s", ErrFinancialGatewayUnexpected, st.Code(), st.Message())
+	}
+}
+
+// Compile-time interface check.
+var _ PaymentGateway = (*FinancialGatewayClient)(nil)

--- a/services/payment-order/adapters/gateway/financial_gateway_client_test.go
+++ b/services/payment-order/adapters/gateway/financial_gateway_client_test.go
@@ -1,0 +1,242 @@
+package gateway_test
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	financialgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway/v1"
+	"github.com/meridianhub/meridian/services/financial-gateway/client"
+	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+)
+
+// fakeFinancialGatewayServer implements FinancialGatewayServiceServer for testing.
+type fakeFinancialGatewayServer struct {
+	financialgatewayv1.UnimplementedFinancialGatewayServiceServer
+	dispatchPaymentFn func(*financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error)
+}
+
+func (f *fakeFinancialGatewayServer) DispatchPayment(_ context.Context, req *financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error) {
+	if f.dispatchPaymentFn != nil {
+		return f.dispatchPaymentFn(req)
+	}
+	return nil, status.Error(codes.Unimplemented, "not configured")
+}
+
+// setupTestGRPC starts an in-process gRPC server with the provided fake and returns a connected client.
+func setupTestGRPC(t *testing.T, fake *fakeFinancialGatewayServer) *client.Client {
+	t.Helper()
+
+	lis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer()
+	financialgatewayv1.RegisterFinancialGatewayServiceServer(srv, fake)
+
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(srv.GracefulStop)
+
+	fgClient, cleanup, err := client.New(client.Config{
+		Target: lis.Addr().String(),
+		DialOptions: []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	return fgClient
+}
+
+func makePaymentRequest(t *testing.T) gateway.PaymentRequest {
+	t.Helper()
+	amount := domain.MustNewMoney("GBP", 10000)
+	return gateway.PaymentRequest{
+		PaymentOrderID:    uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		DebtorAccountID:   "cus_test123",
+		CreditorReference: "pm_testABC",
+		Amount:            amount,
+		IdempotencyKey:    "idem-key-001",
+	}
+}
+
+func TestFinancialGatewayClient_SendPayment_Accepted(t *testing.T) {
+	fake := &fakeFinancialGatewayServer{
+		dispatchPaymentFn: func(req *financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error) {
+			assert.Equal(t, "11111111-1111-1111-1111-111111111111", req.GetPaymentOrderId())
+			assert.Equal(t, financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE, req.GetRail())
+			assert.Equal(t, int64(10000), req.GetAmountUnits())
+			assert.Equal(t, "GBP", req.GetInstrumentCode())
+			assert.Equal(t, "cus_test123", req.GetDebtorAccountId())
+			assert.Equal(t, "pm_testABC", req.GetReference())
+			assert.Equal(t, "idem-key-001", req.GetIdempotencyKey().GetKey())
+
+			return &financialgatewayv1.DispatchPaymentResponse{
+				DispatchId:        uuid.New().String(),
+				PaymentOrderId:    req.GetPaymentOrderId(),
+				Rail:              financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+				Status:            financialgatewayv1.DispatchStatus_DISPATCH_STATUS_DELIVERED,
+				ProviderReference: "pi_stripe_abc",
+				CreatedAt:         timestamppb.Now(),
+			}, nil
+		},
+	}
+
+	fgClient := setupTestGRPC(t, fake)
+	c := gateway.NewFinancialGatewayClient(fgClient, slog.Default())
+
+	resp, err := c.SendPayment(context.Background(), makePaymentRequest(t))
+	require.NoError(t, err)
+	assert.Equal(t, gateway.StatusAccepted, resp.Status)
+	assert.Equal(t, "pi_stripe_abc", resp.GatewayReferenceID)
+}
+
+func TestFinancialGatewayClient_SendPayment_Acknowledged(t *testing.T) {
+	fake := &fakeFinancialGatewayServer{
+		dispatchPaymentFn: func(req *financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error) {
+			return &financialgatewayv1.DispatchPaymentResponse{
+				DispatchId:        uuid.New().String(),
+				PaymentOrderId:    req.GetPaymentOrderId(),
+				Rail:              financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+				Status:            financialgatewayv1.DispatchStatus_DISPATCH_STATUS_ACKNOWLEDGED,
+				ProviderReference: "pi_stripe_xyz",
+				CreatedAt:         timestamppb.Now(),
+			}, nil
+		},
+	}
+
+	fgClient := setupTestGRPC(t, fake)
+	c := gateway.NewFinancialGatewayClient(fgClient, slog.Default())
+
+	resp, err := c.SendPayment(context.Background(), makePaymentRequest(t))
+	require.NoError(t, err)
+	assert.Equal(t, gateway.StatusAccepted, resp.Status)
+}
+
+func TestFinancialGatewayClient_SendPayment_Pending(t *testing.T) {
+	for _, dispatchStatus := range []financialgatewayv1.DispatchStatus{
+		financialgatewayv1.DispatchStatus_DISPATCH_STATUS_PENDING,
+		financialgatewayv1.DispatchStatus_DISPATCH_STATUS_DISPATCHING,
+		financialgatewayv1.DispatchStatus_DISPATCH_STATUS_RETRYING,
+	} {
+		t.Run(dispatchStatus.String(), func(t *testing.T) {
+			fake := &fakeFinancialGatewayServer{
+				dispatchPaymentFn: func(req *financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error) {
+					return &financialgatewayv1.DispatchPaymentResponse{
+						DispatchId:     uuid.New().String(),
+						PaymentOrderId: req.GetPaymentOrderId(),
+						Rail:           financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+						Status:         dispatchStatus,
+						CreatedAt:      timestamppb.Now(),
+					}, nil
+				},
+			}
+
+			fgClient := setupTestGRPC(t, fake)
+			c := gateway.NewFinancialGatewayClient(fgClient, slog.Default())
+
+			resp, err := c.SendPayment(context.Background(), makePaymentRequest(t))
+			require.NoError(t, err)
+			assert.Equal(t, gateway.StatusPending, resp.Status)
+		})
+	}
+}
+
+func TestFinancialGatewayClient_SendPayment_Failed(t *testing.T) {
+	fake := &fakeFinancialGatewayServer{
+		dispatchPaymentFn: func(req *financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error) {
+			return &financialgatewayv1.DispatchPaymentResponse{
+				DispatchId:     uuid.New().String(),
+				PaymentOrderId: req.GetPaymentOrderId(),
+				Rail:           financialgatewayv1.PaymentRail_PAYMENT_RAIL_STRIPE,
+				Status:         financialgatewayv1.DispatchStatus_DISPATCH_STATUS_FAILED,
+				CreatedAt:      timestamppb.Now(),
+			}, nil
+		},
+	}
+
+	fgClient := setupTestGRPC(t, fake)
+	c := gateway.NewFinancialGatewayClient(fgClient, slog.Default())
+
+	resp, err := c.SendPayment(context.Background(), makePaymentRequest(t))
+	require.NoError(t, err)
+	assert.Equal(t, gateway.StatusRejected, resp.Status)
+}
+
+func TestFinancialGatewayClient_SendPayment_GRPCUnavailable(t *testing.T) {
+	fake := &fakeFinancialGatewayServer{
+		dispatchPaymentFn: func(_ *financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error) {
+			return nil, status.Error(codes.Unavailable, "stripe temporarily unavailable")
+		},
+	}
+
+	fgClient := setupTestGRPC(t, fake)
+	c := gateway.NewFinancialGatewayClient(fgClient, slog.Default())
+
+	_, err := c.SendPayment(context.Background(), makePaymentRequest(t))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, gateway.ErrFinancialGatewayUnavailable)
+}
+
+func TestFinancialGatewayClient_SendPayment_GRPCInvalidArgument(t *testing.T) {
+	fake := &fakeFinancialGatewayServer{
+		dispatchPaymentFn: func(_ *financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error) {
+			return nil, status.Error(codes.InvalidArgument, "invalid currency code")
+		},
+	}
+
+	fgClient := setupTestGRPC(t, fake)
+	c := gateway.NewFinancialGatewayClient(fgClient, slog.Default())
+
+	_, err := c.SendPayment(context.Background(), makePaymentRequest(t))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, gateway.ErrFinancialGatewayInvalidArgument)
+}
+
+func TestFinancialGatewayClient_SendPayment_GRPCFailedPrecondition(t *testing.T) {
+	fake := &fakeFinancialGatewayServer{
+		dispatchPaymentFn: func(_ *financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error) {
+			return nil, status.Error(codes.FailedPrecondition, "stripe not configured for tenant")
+		},
+	}
+
+	fgClient := setupTestGRPC(t, fake)
+	c := gateway.NewFinancialGatewayClient(fgClient, slog.Default())
+
+	_, err := c.SendPayment(context.Background(), makePaymentRequest(t))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, gateway.ErrFinancialGatewayPreconditionFailed)
+}
+
+func TestFinancialGatewayClient_SendPayment_GRPCDeadlineExceeded(t *testing.T) {
+	fake := &fakeFinancialGatewayServer{
+		dispatchPaymentFn: func(_ *financialgatewayv1.DispatchPaymentRequest) (*financialgatewayv1.DispatchPaymentResponse, error) {
+			return nil, status.Error(codes.DeadlineExceeded, "deadline exceeded")
+		},
+	}
+
+	fgClient := setupTestGRPC(t, fake)
+	c := gateway.NewFinancialGatewayClient(fgClient, slog.Default())
+
+	_, err := c.SendPayment(context.Background(), makePaymentRequest(t))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, gateway.ErrFinancialGatewayTimeout)
+}
+
+func TestFinancialGatewayClient_ImplementsInterface(t *testing.T) {
+	fgClient := setupTestGRPC(t, &fakeFinancialGatewayServer{})
+	var _ gateway.PaymentGateway = gateway.NewFinancialGatewayClient(fgClient, nil)
+}

--- a/services/payment-order/cmd/gateway_factory_test.go
+++ b/services/payment-order/cmd/gateway_factory_test.go
@@ -17,7 +17,8 @@ func TestCreatePaymentGateway_DefaultMock(t *testing.T) {
 		PaymentGatewayProvider: gateway.ProviderMock,
 	}
 
-	gw, err := createPaymentGateway(cfg, logger)
+	gw, cleanup, err := createPaymentGateway(cfg, logger)
+	t.Cleanup(cleanup)
 
 	require.NoError(t, err)
 	assert.NotNil(t, gw)
@@ -29,7 +30,8 @@ func TestCreatePaymentGateway_ExplicitMock(t *testing.T) {
 		PaymentGatewayProvider: gateway.ProviderMock,
 	}
 
-	gw, err := createPaymentGateway(cfg, logger)
+	gw, cleanup, err := createPaymentGateway(cfg, logger)
+	t.Cleanup(cleanup)
 
 	require.NoError(t, err)
 	assert.NotNil(t, gw)
@@ -42,7 +44,22 @@ func TestCreatePaymentGateway_StripeProvider(t *testing.T) {
 		StripeAPIKey:           "sk_test_fake_key_for_unit_test",
 	}
 
-	gw, err := createPaymentGateway(cfg, logger)
+	gw, cleanup, err := createPaymentGateway(cfg, logger)
+	t.Cleanup(cleanup)
+
+	require.NoError(t, err)
+	assert.NotNil(t, gw)
+}
+
+func TestCreatePaymentGateway_FinancialGatewayProvider(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	cfg := config.ServiceConfig{
+		PaymentGatewayProvider: gateway.ProviderFinancialGateway,
+		FinancialGatewayAddr:   "localhost:50064",
+	}
+
+	gw, cleanup, err := createPaymentGateway(cfg, logger)
+	t.Cleanup(cleanup)
 
 	require.NoError(t, err)
 	assert.NotNil(t, gw)
@@ -54,7 +71,10 @@ func TestCreatePaymentGateway_UnsupportedProvider(t *testing.T) {
 		PaymentGatewayProvider: "paypal",
 	}
 
-	gw, err := createPaymentGateway(cfg, logger)
+	gw, cleanup, err := createPaymentGateway(cfg, logger)
+	if cleanup != nil {
+		t.Cleanup(cleanup)
+	}
 
 	assert.ErrorIs(t, err, config.ErrInvalidGatewayProvider)
 	assert.Nil(t, gw)

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -48,6 +48,7 @@ import (
 	// Service-owned clients (standardized client packages from each service)
 	currentaccountclient "github.com/meridianhub/meridian/services/current-account/client"
 	financialaccountingclient "github.com/meridianhub/meridian/services/financial-accounting/client"
+	financialgatewayclient "github.com/meridianhub/meridian/services/financial-gateway/client"
 	internalaccountclient "github.com/meridianhub/meridian/services/internal-account/client"
 	partyclient "github.com/meridianhub/meridian/services/party/client"
 	positionkeepingclient "github.com/meridianhub/meridian/services/position-keeping/client"
@@ -166,10 +167,11 @@ func run(logger *slog.Logger) error {
 	}
 
 	// Create payment gateway
-	paymentGateway, err := createPaymentGateway(svcConfig, logger)
+	paymentGateway, gatewayCleanup, err := createPaymentGateway(svcConfig, logger)
 	if err != nil {
 		return fmt.Errorf("failed to create payment gateway: %w", err)
 	}
+	defer gatewayCleanup()
 	logger.Info("payment gateway initialized")
 
 	// Load gateway account configuration
@@ -851,8 +853,9 @@ func createInternalAccountClient(namespace string, logger *slog.Logger, tracer *
 // The gateway is wrapped with circuit breaker, rate limiting, and retry logic.
 // Provider selection and API key validation are handled by ServiceConfig.Validate,
 // so this function assumes the config is already validated.
-func createPaymentGateway(svcConfig config.ServiceConfig, logger *slog.Logger) (gateway.PaymentGateway, error) {
+func createPaymentGateway(svcConfig config.ServiceConfig, logger *slog.Logger) (gateway.PaymentGateway, func(), error) {
 	var baseGateway gateway.PaymentGateway
+	cleanup := func() {}
 
 	switch svcConfig.PaymentGatewayProvider {
 	case gateway.ProviderStripe:
@@ -864,6 +867,17 @@ func createPaymentGateway(svcConfig config.ServiceConfig, logger *slog.Logger) (
 		)
 		logger.Info("using stripe payment gateway")
 
+	case gateway.ProviderFinancialGateway:
+		fgClient, fgCleanup, err := financialgatewayclient.New(financialgatewayclient.Config{
+			Target: svcConfig.FinancialGatewayAddr,
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create financial-gateway gRPC client: %w", err)
+		}
+		cleanup = fgCleanup
+		baseGateway = gateway.NewFinancialGatewayClient(fgClient, logger)
+		logger.Info("using financial-gateway payment gateway", "addr", svcConfig.FinancialGatewayAddr)
+
 	case gateway.ProviderMock:
 		logger.Warn("using mock payment gateway")
 		baseGateway = gateway.New(gateway.Config{
@@ -874,7 +888,7 @@ func createPaymentGateway(svcConfig config.ServiceConfig, logger *slog.Logger) (
 		})
 
 	default:
-		return nil, fmt.Errorf("%w: %q (valid: %q, %q)", config.ErrInvalidGatewayProvider, svcConfig.PaymentGatewayProvider, gateway.ProviderStripe, gateway.ProviderMock)
+		return nil, nil, fmt.Errorf("%w: %q (valid: %q, %q, %q)", config.ErrInvalidGatewayProvider, svcConfig.PaymentGatewayProvider, gateway.ProviderStripe, gateway.ProviderFinancialGateway, gateway.ProviderMock)
 	}
 
 	// Configure resilience settings from environment
@@ -908,7 +922,7 @@ func createPaymentGateway(svcConfig config.ServiceConfig, logger *slog.Logger) (
 		"max_retries", resilientConfig.MaxRetries,
 	)
 
-	return gateway.NewResilientPaymentGateway(baseGateway, resilientConfig), nil
+	return gateway.NewResilientPaymentGateway(baseGateway, resilientConfig), cleanup, nil
 }
 
 // createRedisClient creates and validates a Redis client connection.

--- a/services/payment-order/config/service_config.go
+++ b/services/payment-order/config/service_config.go
@@ -16,7 +16,7 @@ import (
 // verify constraints.
 type ServiceConfig struct {
 	// PaymentGatewayProvider selects the payment gateway implementation.
-	// Valid values: "stripe", "mock". Default: "mock".
+	// Valid values: "stripe", "mock", "financial-gateway". Default: "mock".
 	PaymentGatewayProvider string
 
 	// StripeAPIKey is the platform Stripe API key. Required when
@@ -26,6 +26,11 @@ type ServiceConfig struct {
 	// StripeWebhookSecret is the Stripe webhook endpoint secret. Required when
 	// PaymentGatewayProvider is "stripe".
 	StripeWebhookSecret string
+
+	// FinancialGatewayAddr is the gRPC address of the financial-gateway service.
+	// Required when PaymentGatewayProvider is "financial-gateway".
+	// Example: "financial-gateway:50064" or "localhost:50064".
+	FinancialGatewayAddr string
 
 	// BillingEnabled controls whether billing background workers are started.
 	// Default: false.
@@ -51,9 +56,10 @@ type ServiceConfig struct {
 
 // Configuration validation errors.
 var (
-	ErrMissingStripeAPIKey        = errors.New("STRIPE_API_KEY is required when PAYMENT_GATEWAY_PROVIDER is \"stripe\"")
-	ErrMissingStripeWebhookSecret = errors.New("STRIPE_WEBHOOK_SECRET is required when PAYMENT_GATEWAY_PROVIDER is \"stripe\"")
-	ErrInvalidGatewayProvider     = errors.New("unsupported PAYMENT_GATEWAY_PROVIDER value")
+	ErrMissingStripeAPIKey         = errors.New("STRIPE_API_KEY is required when PAYMENT_GATEWAY_PROVIDER is \"stripe\"")
+	ErrMissingStripeWebhookSecret  = errors.New("STRIPE_WEBHOOK_SECRET is required when PAYMENT_GATEWAY_PROVIDER is \"stripe\"")
+	ErrMissingFinancialGatewayAddr = errors.New("FINANCIAL_GATEWAY_ADDR is required when PAYMENT_GATEWAY_PROVIDER is \"financial-gateway\"")
+	ErrInvalidGatewayProvider      = errors.New("unsupported PAYMENT_GATEWAY_PROVIDER value")
 )
 
 // LoadServiceConfig reads all payment-order environment variables and returns
@@ -63,6 +69,7 @@ func LoadServiceConfig() ServiceConfig {
 		PaymentGatewayProvider:   env.GetEnvOrDefault("PAYMENT_GATEWAY_PROVIDER", gateway.ProviderMock),
 		StripeAPIKey:             env.GetEnvOrDefault("STRIPE_API_KEY", ""),
 		StripeWebhookSecret:      env.GetEnvOrDefault("STRIPE_WEBHOOK_SECRET", ""),
+		FinancialGatewayAddr:     env.GetEnvOrDefault("FINANCIAL_GATEWAY_ADDR", ""),
 		BillingEnabled:           env.GetEnvAsBool("BILLING_ENABLED", false),
 		BillingCronSchedule:      env.GetEnvOrDefault("BILLING_CRON_SCHEDULE", "0 0 * * *"),
 		BillingShadowMode:        env.GetEnvAsBool("BILLING_SHADOW_MODE", false),
@@ -82,10 +89,14 @@ func (c ServiceConfig) Validate() error {
 		if c.StripeWebhookSecret == "" {
 			return ErrMissingStripeWebhookSecret
 		}
+	case gateway.ProviderFinancialGateway:
+		if c.FinancialGatewayAddr == "" {
+			return ErrMissingFinancialGatewayAddr
+		}
 	case gateway.ProviderMock:
 		// No additional requirements.
 	default:
-		return fmt.Errorf("%w: %q (valid: %q, %q)", ErrInvalidGatewayProvider, c.PaymentGatewayProvider, gateway.ProviderStripe, gateway.ProviderMock)
+		return fmt.Errorf("%w: %q (valid: %q, %q, %q)", ErrInvalidGatewayProvider, c.PaymentGatewayProvider, gateway.ProviderStripe, gateway.ProviderFinancialGateway, gateway.ProviderMock)
 	}
 	return nil
 }
@@ -97,6 +108,7 @@ func (c ServiceConfig) LogValues(logger *slog.Logger) {
 		"payment_gateway_provider", c.PaymentGatewayProvider,
 		"stripe_api_key", redact(c.StripeAPIKey),
 		"stripe_webhook_secret", redact(c.StripeWebhookSecret),
+		"financial_gateway_addr", c.FinancialGatewayAddr,
 		"billing_enabled", c.BillingEnabled,
 		"billing_cron_schedule", c.BillingCronSchedule,
 		"billing_shadow_mode", c.BillingShadowMode,

--- a/services/payment-order/config/service_config_test.go
+++ b/services/payment-order/config/service_config_test.go
@@ -51,6 +51,24 @@ func TestValidate_StripeMissingWebhookSecret(t *testing.T) {
 	assert.ErrorIs(t, err, ErrMissingStripeWebhookSecret)
 }
 
+func TestValidate_FinancialGatewayProviderValid(t *testing.T) {
+	cfg := ServiceConfig{
+		PaymentGatewayProvider: gateway.ProviderFinancialGateway,
+		FinancialGatewayAddr:   "financial-gateway:50064",
+	}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestValidate_FinancialGatewayMissingAddr(t *testing.T) {
+	cfg := ServiceConfig{
+		PaymentGatewayProvider: gateway.ProviderFinancialGateway,
+		FinancialGatewayAddr:   "",
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingFinancialGatewayAddr)
+}
+
 func TestValidate_UnsupportedProvider(t *testing.T) {
 	cfg := ServiceConfig{
 		PaymentGatewayProvider: "paypal",


### PR DESCRIPTION
## Summary

- Adds `services/financial-gateway/client` package providing a typed gRPC client for the FinancialGatewayService, following the same pattern as `services/financial-accounting/client`
- Adds `FinancialGatewayClient` in `services/payment-order/adapters/gateway` that implements the `PaymentGateway` interface by calling `financial-gateway`'s `DispatchPayment` RPC
- Wires the new client into `payment-order`'s service initialization as a new `PAYMENT_GATEWAY_PROVIDER=financial-gateway` option (controlled by `FINANCIAL_GATEWAY_ADDR` env var)

## Changes

**New: `services/financial-gateway/client/client.go`**
- gRPC client wrapping `FinancialGatewayServiceClient` with `DispatchPayment`, `DispatchRefund`, `GetProviderHealth`
- Follows financial-accounting client pattern: DNS-based load balancing via `platformgrpc.NewClient` or direct Target connection, optional Tracer/Resilience config, cleanup func

**New: `services/payment-order/adapters/gateway/financial_gateway_client.go`**
- Implements `PaymentGateway` interface via gRPC to financial-gateway
- Maps `PaymentRequest` to `DispatchPaymentRequest` using `PAYMENT_RAIL_STRIPE`
- Maps `DispatchStatus` to `gateway.Status`: `DELIVERED/ACKNOWLEDGED→ACCEPTED`, `FAILED→REJECTED`, `PENDING/DISPATCHING/RETRYING→PENDING`
- Defines sentinel errors per gRPC code (err113 compliant): `ErrFinancialGatewayUnavailable`, `ErrFinancialGatewayInvalidArgument`, etc.

**Modified: `services/payment-order/adapters/gateway/config.go`**
- Adds `ProviderFinancialGateway = "financial-gateway"` constant

**Modified: `services/payment-order/config/service_config.go`**
- Adds `FinancialGatewayAddr` field (populated from `FINANCIAL_GATEWAY_ADDR`)
- Adds `ErrMissingFinancialGatewayAddr` validation error
- Updates `Validate()` to require `FINANCIAL_GATEWAY_ADDR` when provider is `financial-gateway`

**Modified: `services/payment-order/cmd/main.go`**
- Imports `financialgatewayclient` package
- Updates `createPaymentGateway` to return `(PaymentGateway, func(), error)` — third return is connection cleanup
- Adds `ProviderFinancialGateway` case: creates gRPC client, wraps with resilient gateway

## Test Plan

- [x] `go build ./services/payment-order/... ./services/financial-gateway/...` passes
- [x] `go test ./services/payment-order/adapters/gateway/...` passes (all 45 tests including 11 new `FinancialGatewayClient` tests)
- [x] `go test ./services/payment-order/config/...` passes (2 new validation tests for financial-gateway provider)
- [x] `go test ./services/payment-order/cmd/...` passes (1 new factory test for financial-gateway provider)
- [x] All pre-commit hooks pass (gitleaks, gofumpt, golangci-lint)
- [x] New tests use in-process fake gRPC server via `net.ListenConfig.Listen` + `grpc.NewServer`