### PR TITLE
docs: replace Storybook with component registry, add Economy Cookbook PRD

### DIFF
--- a/docs/prd/034-frontend-service-alignment.md
+++ b/docs/prd/034-frontend-service-alignment.md
@@ -516,10 +516,10 @@ ui:
     dashboard:
       widgets:
         - feature: accounts
-          component: AccountSummaryCard
+          component: account-summary-card
           position: 1
         - feature: payments
-          component: RecentPayments
+          component: recent-payments
           position: 2
     table_defaults:
       accounts:
@@ -532,23 +532,33 @@ Dashboard reads widget list, `DataTable` reads column/sort
 defaults. Tenants change layout, refresh, done.
 
 **Component validation**: Widget component names are
-validated against the component registry. The registry is
-the source of truth for valid component names:
+validated against the component registry. The registry
+`name` field (kebab-case) is the **canonical identifier**
+used across tenant config, write-time validation, and
+render-time lookup:
 
 ```typescript
 // Generated from registry.json at build time
+// Keys are registry `name` values (kebab-case)
 const STAFF_DASHBOARD_WIDGETS: Record<string, () => Promise<ComponentType>> = {
-  AccountSummaryCard: () => import('@/features/accounts/...'),
-  RecentPayments: () => import('@/features/payments/...'),
+  'account-summary-card': () => import('@/features/accounts/...'),
+  'recent-payments': () => import('@/features/payments/...'),
 }
 ```
+
+**Canonical ID rule**: tenant config, validation, and
+runtime lookup all use the registry `name` field
+(kebab-case) as the single stable identifier. Display
+labels use the `title` field (human-readable). No
+case-conversion mapping is needed because all layers
+use the same format.
 
 Validation occurs at two points:
 
 - **Config write time** (manifest apply or tenant entity
-  update): reject configurations referencing unknown
-  component names with a descriptive error. The component
-  registry is the source of truth for valid names.
+  update): reject configurations referencing component
+  names not present in registry `items[].name`. The
+  component registry is the single source of truth.
 - **Render time**: skip unresolvable components with a
   warning log, render remaining widgets normally
 
@@ -633,15 +643,15 @@ changes naturally prompt UI parity discussion.
 - Add entries for feature-specific components with metadata
 - Validate widget component names in tenant config against
   registry at config write time
-- Add a dev-mode theme preview panel: a collapsible sidebar
-  that lets developers switch CSS variable overrides
-  without restarting the app
 
 ### Phase 5: Tenant Theme Foundation
 
 - CSS variable override system from tenant config
 - Tenant logo/branding in AppShell
-- Dev-mode theme preview panel wired to tenant config
+- Dev-mode theme preview panel: a collapsible sidebar that
+  lets developers switch CSS variable overrides (primary
+  colour, background, font) without restarting the app,
+  wired to tenant config schema
 
 ### Phase 6: Feature Visibility
 
@@ -690,12 +700,13 @@ changes naturally prompt UI parity discussion.
    storage: local filesystem (dev/demo), object storage
    (S3/GCS) for production? Is a CDN layer needed?
 
-6. **Registry scope**: Should the component registry
-   describe only tenant-configurable components (dashboard
-   widgets, table columns), or all components including
-   internal-only ones? Broader scope is more useful for AI
-   development assistance; narrower scope is easier to
-   maintain.
+6. **Registry maintenance**: The registry covers all shared
+   and feature components (see Success Criterion 3). The
+   open question is maintenance strategy: manually curated
+   entries vs auto-generated from TypeScript source (e.g.,
+   a build step that scans exports and generates
+   `registry.json`). Auto-generation reduces drift but
+   requires tooling investment.
 
 ## Success Criteria
 

--- a/docs/prd/034-frontend-service-alignment.md
+++ b/docs/prd/034-frontend-service-alignment.md
@@ -167,10 +167,10 @@ rendered visual browser.
 - **Composability metadata**: Components declare their
   feature module, dependencies, and tenant-configurable
   props as structured data.
-- **Consistent with Meridian's philosophy**: The Economy
-  Cookbook (PRD-035) uses the same registry pattern for
-  manifest patterns. One discovery model for both UI
-  components and business configuration.
+- **Consistent with Meridian's philosophy**: The Meridian
+  Cookbook (PRD-035) uses the same registry format for
+  both UI components and economy patterns. One discovery
+  model across the entire platform.
 
 **What Storybook provides that the registry does not:**
 
@@ -422,10 +422,9 @@ pattern, adapted for Meridian's needs.
   RPC-to-UI coverage script.
 - **Component dependency tracking**: `registryDependencies`
   makes component relationships explicit.
-- **Consistent pattern**: The Economy Cookbook (PRD-035)
-  uses the same registry format for manifest patterns.
-  One discovery model across both UI and business
-  configuration.
+- **Consistent pattern**: The Meridian Cookbook (PRD-035)
+  uses the same registry format for both UI components
+  and economy patterns. One unified discovery model.
 
 ### Tenant UI Customisation Architecture
 

--- a/docs/prd/034-frontend-service-alignment.md
+++ b/docs/prd/034-frontend-service-alignment.md
@@ -16,7 +16,8 @@ This makes it difficult to:
 1. **Find what to update** when a service API changes
 2. **Reuse data-fetching logic** across pages calling the
    same service
-3. **Develop and test components in isolation**
+3. **Discover available components** programmatically
+   (for AI-assisted development or tenant configuration)
 4. **Offer tenant-specific UI experiences** (branding,
    feature visibility, layout)
 5. **Distinguish staff operations views from customer-facing
@@ -46,10 +47,14 @@ The frontend should:
   statements) using the same component library but with a
   different shell and reduced scope
 
-The component library (via Storybook) becomes the catalogue
-of building blocks. Storybook serves two audiences:
-developers building features, and tenant administrators
-previewing what's available to configure.
+Components are described by a **component registry** - a
+structured JSON index following the shadcn/ui registry
+pattern. Each component has machine-readable metadata
+(name, props, dependencies, feature module). This serves
+two purposes: developers discover what's available without
+running a separate tool, and AI assistants can query the
+registry to generate or modify UI configurations
+programmatically.
 
 ### Runtime, Not Deployable
 
@@ -84,8 +89,9 @@ feature visibility + layout preferences.
    backend services
 2. Extract **service-aligned data hooks** to replace inline
    query construction
-3. Set up **Storybook** as a component catalogue and
-   development environment
+3. Create a **component registry** (shadcn-style JSON index)
+   describing all shared and feature components with
+   machine-readable metadata
 4. Design the **tenant UI customisation** architecture
    (theme, feature toggles, layout)
 5. Establish a **service coverage map** linking RPCs to UI
@@ -101,6 +107,9 @@ feature visibility + layout preferences.
 - Adding new backend RPCs
 - Micro-frontend architecture (see Architectural Decision
   below)
+- Storybook or similar visual component browser (the
+  component registry replaces this need - see Architectural
+  Decision below)
 
 ## Architectural Decision: Centralised Frontend
 
@@ -126,6 +135,50 @@ If Meridian ever needs independent deployment of UI modules
 migration from feature modules to micro-frontends. The
 feature module structure makes that migration easier, not
 harder.
+
+## Architectural Decision: Component Registry Over Storybook
+
+**Decision**: Use a structured JSON component registry
+(shadcn/ui registry pattern) instead of Storybook for
+component cataloguing and discovery.
+
+**Context**: The original PRD proposed Storybook as a
+component catalogue serving developers and tenant
+administrators. On review, Meridian's primary component
+consumers are AI assistants configuring tenant economies
+and developers navigating feature modules - both better
+served by structured, queryable metadata than by a
+rendered visual browser.
+
+**Rationale**:
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| Storybook | Visual preview, theme testing, established ecosystem | Requires running dev server, JS runtime for introspection, not AI-navigable without experimental MCP plugins |
+| Component Registry (shadcn model) | Static JSON, trivially machine-readable, AI-native, no runtime, composable | No visual preview (mitigated by dev-mode theme panel + running the app) |
+
+**What the registry provides that Storybook does not:**
+
+- **Static indexing**: `jq`, `grep`, or any JSON parser can
+  query the registry. No Node.js runtime needed.
+- **AI-native**: LLMs consume JSON trivially. Storybook
+  requires AST parsing of executable JavaScript or
+  experimental MCP plugins that need a running dev server.
+- **Composability metadata**: Components declare their
+  feature module, dependencies, and tenant-configurable
+  props as structured data.
+- **Consistent with Meridian's philosophy**: The Economy
+  Cookbook (PRD-035) uses the same registry pattern for
+  manifest patterns. One discovery model for both UI
+  components and business configuration.
+
+**What Storybook provides that the registry does not:**
+
+- **Visual preview**: Mitigated by feature module structure
+  (easy to navigate to any component in the running app)
+  and a dev-mode theme preview panel.
+- **Interaction testing**: Mitigated by existing E2E tests
+  and unit tests per feature module.
 
 ## Current State
 
@@ -179,8 +232,9 @@ src/
    `CELEditor`, `SagaTimeline`, and
    `CreateValuationFeatureDialog` live together despite
    serving different services.
-4. **No visual testing**: Component changes require running
-   the full app.
+4. **No component metadata**: No structured way to discover
+   what components exist, what props they take, or which
+   feature module they belong to.
 5. **No tenant customisation**: Every tenant sees the same
    UI.
 
@@ -230,6 +284,9 @@ src/
 │   ├── breadcrumbs.tsx
 │   ├── time-display.tsx
 │   └── handler-reference.tsx
+│
+├── registry/                   # Component registry
+│   └── registry.json           # shadcn-style component index
 │
 └── App.tsx                     # Route definitions
 ```
@@ -304,35 +361,71 @@ it a cross-cutting concern. The `features/audit/` module owns
 the dedicated `/audit-log` page but the reusable component
 stays in shared.
 
-### Storybook
+### Component Registry
 
-**Why Storybook matters for this project specifically:**
+A structured JSON index describing every shared and feature
+component. Follows the shadcn/ui `registry-item.json` schema
+pattern, adapted for Meridian's needs.
 
-1. **Component catalogue**: When building tenant-customisable
-   UI, you need a visual inventory of what's available.
-   Storybook is that inventory.
-2. **Theme testing**: Storybook's theme decorator lets you
-   preview components under different tenant themes without
-   running the full app.
-3. **Feature flag testing**: Stories can render components
-   with different feature toggle states to verify
-   conditional rendering.
-4. **Staff vs customer views**: Stories can show the same
-   data component in "operations" vs "customer portal"
-   contexts.
-5. **Design review**: PRs that change components include
-   Storybook previews (Chromatic or similar), so reviewers
-   see visual impact without pulling the branch.
+**Registry entry format:**
 
-**Setup:**
+```json
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "data-table",
+  "type": "registry:ui",
+  "title": "Data Table",
+  "description": "Sortable, filterable table with pagination. Used across all list pages.",
+  "registryDependencies": ["status-badge", "entity-link"],
+  "categories": ["shared", "layout"],
+  "meta": {
+    "feature_module": "shared",
+    "tenant_configurable": true,
+    "configurable_props": ["visible_columns", "default_sort"],
+    "used_by": ["accounts", "payments", "ledger", "positions", "reconciliation"]
+  },
+  "files": [
+    {
+      "path": "shared/data-table.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}
+```
 
-- Storybook 8.x with `@storybook/react-vite` (matches
-  build tool)
-- MSW addon (already using MSW in tests) for realistic
-  API data
-- a11y addon for accessibility auditing
-- Stories colocated with components:
-  `data-table.stories.tsx` next to `data-table.tsx`
+**Registry index** (`src/registry/registry.json`):
+
+```json
+{
+  "$schema": "https://ui.shadcn.com/schema/registry.json",
+  "name": "meridian-console",
+  "homepage": "https://github.com/meridianhub/meridian",
+  "items": [
+    { "name": "data-table", "type": "registry:ui", "title": "Data Table" },
+    { "name": "money-display", "type": "registry:ui", "title": "Money Display" },
+    { "name": "account-summary-card", "type": "registry:component", "title": "Account Summary Card" }
+  ]
+}
+```
+
+**What this enables:**
+
+- **AI-assisted development**: An AI assistant can query the
+  registry to understand what components exist, what props
+  they accept, and which feature modules use them - without
+  parsing TypeScript source.
+- **Tenant layout validation**: When a tenant configures
+  dashboard widgets, the registry validates component names
+  at config write time.
+- **Service coverage**: The registry's `meta.used_by` field
+  maps components to feature modules, supplementing the
+  RPC-to-UI coverage script.
+- **Component dependency tracking**: `registryDependencies`
+  makes component relationships explicit.
+- **Consistent pattern**: The Economy Cookbook (PRD-035)
+  uses the same registry format for manifest patterns.
+  One discovery model across both UI and business
+  configuration.
 
 ### Tenant UI Customisation Architecture
 
@@ -439,11 +532,11 @@ Dashboard reads widget list, `DataTable` reads column/sort
 defaults. Tenants change layout, refresh, done.
 
 **Component validation**: Widget component names are
-validated against a registry of allowed components per
-context (staff/customer). The registry maps string names to
-lazy-loaded component imports:
+validated against the component registry. The registry is
+the source of truth for valid component names:
 
 ```typescript
+// Generated from registry.json at build time
 const STAFF_DASHBOARD_WIDGETS: Record<string, () => Promise<ComponentType>> = {
   AccountSummaryCard: () => import('@/features/accounts/...'),
   RecentPayments: () => import('@/features/payments/...'),
@@ -454,7 +547,8 @@ Validation occurs at two points:
 
 - **Config write time** (manifest apply or tenant entity
   update): reject configurations referencing unknown
-  component names with a descriptive error
+  component names with a descriptive error. The component
+  registry is the source of truth for valid names.
 - **Render time**: skip unresolvable components with a
   warning log, render remaining widgets normally
 
@@ -529,19 +623,25 @@ changes naturally prompt UI parity discussion.
 - Update all imports
 - Verify no broken references
 
-### Phase 4: Storybook
+### Phase 4: Component Registry
 
-- Install Storybook 8 with Vite builder
-- Write stories for shared components
-- Write stories for feature-specific components
-- Add MSW integration for page-level stories
-- CI job to build Storybook
+- Create `src/registry/registry.json` with shadcn-style
+  schema
+- Add entries for all shared components (DataTable,
+  MoneyDisplay, etc.) with metadata: feature module,
+  tenant-configurable props, dependencies
+- Add entries for feature-specific components with metadata
+- Validate widget component names in tenant config against
+  registry at config write time
+- Add a dev-mode theme preview panel: a collapsible sidebar
+  that lets developers switch CSS variable overrides
+  without restarting the app
 
 ### Phase 5: Tenant Theme Foundation
 
 - CSS variable override system from tenant config
 - Tenant logo/branding in AppShell
-- Theme preview in Storybook
+- Dev-mode theme preview panel wired to tenant config
 
 ### Phase 6: Feature Visibility
 
@@ -569,12 +669,7 @@ changes naturally prompt UI parity discussion.
    tree-shaking. Recommendation: barrels for page exports
    (needed by App.tsx), direct imports for everything else.
 
-3. **Storybook hosting**: Chromatic (paid, best
-   integration), GitHub Pages (free, manual), or dev-only
-   (`npm run storybook`)? Start with dev-only, evaluate
-   Chromatic when tenant admins need a preview.
-
-4. **Tenant UI config location**: The `ui:` block shown in
+3. **Tenant UI config location**: The `ui:` block shown in
    the customisation section needs a home. Options:
    - **Manifest YAML** (alongside instruments, sagas) -
      consistent with config-as-code, versioned, auditable
@@ -584,24 +679,33 @@ changes naturally prompt UI parity discussion.
      manifest, cosmetic config (theme, logo) on tenant
      entity
 
-5. **Customer portal timeline**: Is this near-term or
+4. **Customer portal timeline**: Is this near-term or
    future? The architecture supports it regardless (same
    SPA, different shell based on JWT lens), but it affects
    investment in Layer 4 now vs later.
 
-6. **Tenant asset backend storage**: The gateway serves
+5. **Tenant asset backend storage**: The gateway serves
    assets via `/tenant-assets/:slug/` (per security
    requirements above). The open question is backend
    storage: local filesystem (dev/demo), object storage
    (S3/GCS) for production? Is a CDN layer needed?
 
+6. **Registry scope**: Should the component registry
+   describe only tenant-configurable components (dashboard
+   widgets, table columns), or all components including
+   internal-only ones? Broader scope is more useful for AI
+   development assistance; narrower scope is easier to
+   maintain.
+
 ## Success Criteria
 
 1. Every page lives inside `features/<service>/pages/`
 2. Data fetching uses feature hooks, not inline `useQuery()`
-3. Storybook builds and renders all shared + feature
-   components
+3. Component registry describes all shared and feature
+   components with machine-readable metadata
 4. A tenant can apply custom branding (logo, primary colour)
    via configuration at runtime
-5. All existing E2E tests pass
-6. No visual regressions
+5. Widget component names in tenant config are validated
+   against the component registry
+6. All existing E2E tests pass
+7. No visual regressions

--- a/docs/prd/034-frontend-service-alignment.md
+++ b/docs/prd/034-frontend-service-alignment.md
@@ -285,9 +285,6 @@ src/
 │   ├── time-display.tsx
 │   └── handler-reference.tsx
 │
-├── registry/                   # Component registry
-│   └── registry.json           # shadcn-style component index
-│
 └── App.tsx                     # Route definitions
 ```
 
@@ -371,11 +368,11 @@ pattern, adapted for Meridian's needs.
 
 ```json
 {
-  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
   "name": "data-table",
   "type": "registry:ui",
   "title": "Data Table",
-  "description": "Sortable, filterable table with pagination. Used across all list pages.",
+  "description": "Sortable, filterable table with pagination.",
   "registryDependencies": ["status-badge", "entity-link"],
   "categories": ["shared", "layout"],
   "meta": {
@@ -393,17 +390,18 @@ pattern, adapted for Meridian's needs.
 }
 ```
 
-**Registry index** (`src/registry/registry.json`):
+**Registry index** (`cookbook/registry.json` - the unified
+Meridian Cookbook, see PRD-035):
 
 ```json
 {
-  "$schema": "https://ui.shadcn.com/schema/registry.json",
-  "name": "meridian-console",
+  "$schema": "https://cookbook.meridianhub.org/schema/registry.json",
+  "name": "meridian-cookbook",
   "homepage": "https://github.com/meridianhub/meridian",
   "items": [
     { "name": "data-table", "type": "registry:ui", "title": "Data Table" },
     { "name": "money-display", "type": "registry:ui", "title": "Money Display" },
-    { "name": "account-summary-card", "type": "registry:component", "title": "Account Summary Card" }
+    { "name": "account-summary-card", "type": "registry:ui", "title": "Account Summary Card" }
   ]
 }
 ```
@@ -634,14 +632,14 @@ changes naturally prompt UI parity discussion.
 
 ### Phase 4: Component Registry
 
-- Create `src/registry/registry.json` with shadcn-style
-  schema
+- Create UI component entries in `cookbook/ui/` using the
+  unified Meridian Cookbook schema (see PRD-035)
 - Add entries for all shared components (DataTable,
   MoneyDisplay, etc.) with metadata: feature module,
   tenant-configurable props, dependencies
 - Add entries for feature-specific components with metadata
 - Validate widget component names in tenant config against
-  registry at config write time
+  `cookbook/registry.json` at config write time
 
 ### Phase 5: Tenant Theme Foundation
 

--- a/docs/prd/035-economy-cookbook.md
+++ b/docs/prd/035-economy-cookbook.md
@@ -1,0 +1,476 @@
+# PRD: Economy Cookbook - AI-Navigable Business Pattern Registry
+
+## Problem Statement
+
+Meridian has accumulated a rich set of economy
+configuration patterns across multiple industries: energy
+settlement, SaaS billing, carbon credit tracking, precious
+metals, betting distribution. These patterns exist as
+example manifests, saga scripts, and a design patterns
+guide - but they are scattered across documentation,
+test fixtures, and proto example directories.
+
+This creates three problems:
+
+1. **Discovery**: An AI assistant configuring a new tenant
+   economy must search across multiple directories and file
+   formats to find relevant patterns. There is no single
+   index of what's available.
+2. **Composition**: Patterns that work well together (energy
+   settlement + carbon offset) have no formal declaration of
+   compatibility. An AI must infer composition rules from
+   reading documentation.
+3. **Navigation**: Given a tenant's current economy state,
+   there is no way to ask "what can I add next?" The AI must
+   reason about the full pattern space rather than following
+   available transitions.
+
+## Vision
+
+An **Economy Cookbook** - a structured, AI-navigable registry
+of composable business configuration patterns. Following the
+shadcn/ui registry model for static discoverability, and
+HATEOAS principles for state-aware navigation.
+
+The cookbook is to Meridian manifests what shadcn/ui is to
+React components: a catalogue of building blocks that AI
+assistants and developers can browse, compose, and apply -
+without needing a running server, without parsing
+unstructured documentation, and without guessing what works
+together.
+
+### Three Layers
+
+| Layer | Model | Purpose |
+|-------|-------|---------|
+| **Registry** | shadcn/ui | Static JSON patterns with metadata, deps, files |
+| **Discovery** | HATEOAS | Given current state, what patterns are compatible? |
+| **Execution** | Existing MCP | validate, plan, apply (already built) |
+
+## Goals
+
+1. Structure existing economy patterns (manifests, sagas,
+   design patterns) into a machine-readable registry format
+2. Declare composability between patterns (what works
+   together, what conflicts)
+3. Provide state-aware discovery: given a tenant's current
+   manifest, surface compatible patterns with reasons
+4. Expose the cookbook through MCP tools for AI-assisted
+   economy configuration
+5. Maintain the cookbook as living documentation that evolves
+   with the platform
+
+## Non-Goals
+
+- Replacing the manifest apply workflow (the cookbook
+  produces manifests that go through the existing
+  validate/plan/apply pipeline)
+- Building a visual economy designer UI (the cookbook serves
+  AI and CLI consumers; a UI could consume it later)
+- Auto-generating saga scripts from natural language (the
+  cookbook provides tested reference scripts, not generated
+  ones)
+- Tenant-specific pattern storage (the cookbook is platform
+  content, not per-tenant)
+
+## Architecture
+
+### Pattern Format
+
+Each pattern is a JSON file following the shadcn/ui
+`registry-item.json` schema, extended with economy-specific
+metadata. Patterns live in `cookbook/patterns/`.
+
+```json
+{
+  "$schema": "https://cookbook.meridian.dev/schema/pattern.json",
+  "name": "energy-settlement",
+  "type": "registry:pattern",
+  "title": "Energy Usage-to-Value Settlement",
+  "description": "Converts metered kWh consumption into monetary value using market rates.",
+  "categories": ["energy", "utilities", "cross-instrument"],
+  "meta": {
+    "complexity": 3,
+    "design_pattern": "cross-instrument-valuation",
+    "industries": ["energy", "utilities"],
+    "provides": {
+      "instruments": ["KWH"],
+      "account_types": ["energy_metered", "energy_revenue_retail", "energy_revenue_wholesale"],
+      "sagas": ["usage_to_value"],
+      "valuation_rules": ["kwh_to_gbp_retail", "kwh_to_gbp_wholesale"],
+      "triggers": ["event:position-keeping.transaction-captured.v1"]
+    },
+    "requires": {
+      "instruments": ["GBP"],
+      "market_data": ["KWH_GBP_RETAIL", "KWH_GBP_WHOLESALE"]
+    },
+    "composes_with": ["carbon-offset", "time-of-use-pricing", "payment-gateway-stripe"],
+    "conflicts_with": ["flat-rate-billing"],
+    "extends": []
+  },
+  "registryDependencies": ["base-fiat-gbp"],
+  "files": [
+    {
+      "path": "patterns/energy-settlement/manifest-fragment.yaml",
+      "type": "registry:file",
+      "target": "~/manifest-fragment.yaml"
+    },
+    {
+      "path": "patterns/energy-settlement/usage_to_value.star",
+      "type": "registry:file",
+      "target": "~/sagas/usage_to_value.star"
+    }
+  ]
+}
+```
+
+### Pattern Metadata Schema
+
+The `meta` object carries economy-specific semantics:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `complexity` | int (1-8) | Story points estimate for implementation |
+| `design_pattern` | string | Reference to design patterns guide |
+| `industries` | string[] | Industry tags for filtering |
+| `provides.instruments` | string[] | Instrument codes this pattern defines |
+| `provides.account_types` | string[] | Account type codes this pattern defines |
+| `provides.sagas` | string[] | Saga names this pattern includes |
+| `provides.valuation_rules` | string[] | Valuation rules this pattern defines |
+| `provides.triggers` | string[] | Event triggers wired |
+| `requires.instruments` | string[] | Instruments that must exist |
+| `requires.market_data` | string[] | Market data datasets required |
+| `composes_with` | string[] | Patterns known to work together |
+| `conflicts_with` | string[] | Patterns that are mutually exclusive |
+| `extends` | string[] | Patterns this one builds upon |
+
+### Registry Index
+
+`cookbook/registry.json` lists all patterns:
+
+```json
+{
+  "$schema": "https://cookbook.meridian.dev/schema/registry.json",
+  "name": "meridian-economy-cookbook",
+  "homepage": "https://github.com/meridianhub/meridian",
+  "items": [
+    {
+      "name": "base-fiat-gbp",
+      "type": "registry:pattern",
+      "title": "Base Fiat Currency (GBP)",
+      "categories": ["foundation", "fiat"]
+    },
+    {
+      "name": "energy-settlement",
+      "type": "registry:pattern",
+      "title": "Energy Usage-to-Value Settlement",
+      "categories": ["energy", "cross-instrument"]
+    },
+    {
+      "name": "saas-billing",
+      "type": "registry:pattern",
+      "title": "SaaS Usage Billing",
+      "categories": ["technology", "billing"]
+    },
+    {
+      "name": "carbon-offset",
+      "type": "registry:pattern",
+      "title": "Carbon Credit Tracking and Retirement",
+      "categories": ["carbon", "esg"]
+    }
+  ]
+}
+```
+
+### Directory Structure
+
+```text
+cookbook/
+├── registry.json                    # Pattern index
+├── schema/
+│   ├── pattern.json                 # JSON Schema for pattern entries
+│   └── registry.json                # JSON Schema for registry index
+├── patterns/
+│   ├── base-fiat-gbp/
+│   │   ├── pattern.json             # Pattern metadata
+│   │   └── manifest-fragment.yaml   # Manifest fragment
+│   ├── energy-settlement/
+│   │   ├── pattern.json
+│   │   ├── manifest-fragment.yaml
+│   │   └── usage_to_value.star
+│   ├── time-of-use-pricing/
+│   │   ├── pattern.json
+│   │   ├── manifest-fragment.yaml
+│   │   └── tou_energy_valuation.star
+│   ├── saas-billing/
+│   │   ├── pattern.json
+│   │   ├── manifest-fragment.yaml
+│   │   └── compute_billing.star
+│   ├── carbon-offset/
+│   │   ├── pattern.json
+│   │   ├── manifest-fragment.yaml
+│   │   └── carbon_retirement.star
+│   ├── precious-metals/
+│   │   ├── pattern.json
+│   │   ├── manifest-fragment.yaml
+│   │   └── valuation_on_capture.star
+│   ├── entity-distribution/
+│   │   ├── pattern.json
+│   │   ├── manifest-fragment.yaml
+│   │   └── race_result_distribution.star
+│   ├── dynamic-capacity-pricing/
+│   │   ├── pattern.json
+│   │   ├── manifest-fragment.yaml
+│   │   └── dynamic_capacity_billing.star
+│   ├── payment-gateway-stripe/
+│   │   ├── pattern.json
+│   │   └── manifest-fragment.yaml
+│   └── kyc-compliance/
+│       ├── pattern.json
+│       ├── manifest-fragment.yaml
+│       └── kyc_on_party.star
+└── docs/
+    └── authoring-patterns.md        # Guide for adding new patterns
+```
+
+### HATEOAS Discovery
+
+The discovery layer inspects a tenant's current manifest
+and returns compatible patterns with navigation links.
+This is the key difference from a static catalogue: the
+response is state-aware.
+
+**MCP tool: `meridian_cookbook_discover`**
+
+Input: current manifest (or tenant_id to fetch it)
+
+Output:
+
+```json
+{
+  "economy_state": {
+    "instruments": ["GBP", "KWH"],
+    "account_types": ["energy_metered", "energy_revenue_retail"],
+    "sagas": ["usage_to_value"],
+    "market_data": ["KWH_GBP_RETAIL"]
+  },
+  "compatible_patterns": [
+    {
+      "name": "carbon-offset",
+      "rel": "extend",
+      "title": "Add Carbon Credit Tracking",
+      "reason": "You have KWH instruments - most energy tenants pair this with carbon accounting for ESG compliance",
+      "complexity": 3,
+      "_links": {
+        "detail": "/cookbook/patterns/carbon-offset",
+        "compose": "/cookbook/compose?patterns=carbon-offset"
+      }
+    },
+    {
+      "name": "time-of-use-pricing",
+      "rel": "enhance",
+      "title": "Add Time-of-Use Rate Curves",
+      "reason": "Your usage_to_value saga uses flat rates - this adds temporal pricing from forecast curves",
+      "complexity": 2,
+      "_links": {
+        "detail": "/cookbook/patterns/time-of-use-pricing",
+        "compose": "/cookbook/compose?patterns=time-of-use-pricing"
+      }
+    },
+    {
+      "name": "payment-gateway-stripe",
+      "rel": "connect",
+      "title": "Connect Stripe for Collections",
+      "reason": "You have GBP revenue accounts but no payment rail configured",
+      "complexity": 5,
+      "_links": {
+        "detail": "/cookbook/patterns/payment-gateway-stripe",
+        "compose": "/cookbook/compose?patterns=payment-gateway-stripe"
+      }
+    }
+  ],
+  "conflicting_patterns": [
+    {
+      "name": "flat-rate-billing",
+      "reason": "Conflicts with existing usage_to_value saga which uses cross-instrument valuation"
+    }
+  ],
+  "_links": {
+    "self": "/cookbook/discover",
+    "validate": "/manifest/validate",
+    "plan": "/manifest/plan"
+  }
+}
+```
+
+**Why HATEOAS matters for AI agents:**
+
+Traditional pattern catalogue: AI must know all patterns,
+understand all composition rules, and reason about
+compatibility from metadata. Works, but the AI carries the
+cognitive load.
+
+HATEOAS discovery: AI asks "what's possible from here?" and
+the system tells it. The AI follows links, not logic.
+Composition rules are enforced by the server, not
+interpreted by the client. New patterns become available to
+AI the moment they're added to the registry, with zero
+prompt engineering.
+
+### MCP Tools
+
+The cookbook adds three MCP tools alongside the existing
+manifest tools:
+
+| Tool | Layer | Purpose |
+|------|-------|---------|
+| `meridian_cookbook_list` | Registry | Browse all patterns, filter by category/industry |
+| `meridian_cookbook_describe` | Registry | Get full pattern detail with manifest fragment and saga files |
+| `meridian_cookbook_discover` | Discovery | Given current manifest, return compatible patterns with reasons |
+
+**Composition is done client-side.** The AI reads pattern
+manifest fragments and merges them into a complete manifest.
+The existing `meridian_manifest_validate` tool catches any
+conflicts or missing dependencies. This keeps the cookbook
+stateless and the validation authoritative.
+
+**Full conversation flow:**
+
+```text
+User: "We're an energy retailer billing residential customers"
+
+AI: meridian_cookbook_list(category: "energy")
+    → energy-settlement, time-of-use-pricing, carbon-offset
+
+AI: meridian_cookbook_describe("energy-settlement")
+    → full pattern with manifest fragment + saga script
+
+AI: Merges energy-settlement fragment into manifest
+
+AI: meridian_cookbook_discover(current_manifest)
+    → compatible: time-of-use-pricing, carbon-offset, payment-gateway-stripe
+    → reason: "Your usage_to_value uses flat rates - TOU adds temporal pricing"
+
+User: "Add time-of-use pricing"
+
+AI: meridian_cookbook_describe("time-of-use-pricing")
+    → manifest fragment + tou_energy_valuation.star
+
+AI: Merges TOU fragment into manifest
+
+AI: meridian_manifest_validate(merged_manifest)
+    → valid
+
+AI: meridian_manifest_plan(merged_manifest)
+    → shows diff
+
+User: "Looks good"
+
+AI: meridian_manifest_apply(merged_manifest, plan_hash)
+```
+
+## Initial Pattern Inventory
+
+Migrated from existing content:
+
+| Pattern | Source | Industry |
+|---------|--------|----------|
+| `base-fiat-gbp` | New (foundation) | All |
+| `base-fiat-usd` | New (foundation) | All |
+| `energy-settlement` | `usage_to_value.star` + `energy_trading.manifest.json` | Energy |
+| `time-of-use-pricing` | `tou_energy_valuation.star` | Energy |
+| `saas-billing` | `compute_billing.star` + `saas_billing.manifest.json` | Technology |
+| `dynamic-capacity-pricing` | `dynamic_capacity_billing.star` | Technology |
+| `carbon-offset` | `carbon_credits.manifest.json` | Carbon/ESG |
+| `precious-metals` | `valuation_on_capture.star` + `precious_metals.manifest.json` | Wealth |
+| `entity-distribution` | `race_result_distribution.star` | Betting/Finance |
+| `phantom-cost-basis` | `corporate_action_cost_adjustment.star` | Wealth |
+| `payment-gateway-stripe` | `stripe_operational_gateway.manifest.json` | Payments |
+| `kyc-compliance` | `kyc_on_party.star` | Compliance |
+
+## Implementation Phases
+
+### Phase 1: Schema and Directory Structure
+
+- Define `pattern.json` and `registry.json` JSON Schemas
+- Create `cookbook/` directory structure
+- Create the registry index file
+
+### Phase 2: Migrate Existing Patterns
+
+- Extract manifest fragments from existing example
+  manifests in `api/proto/.../examples/`
+- Extract saga scripts from `tenant-saga-examples/`
+- Create pattern.json metadata for each, declaring
+  provides/requires/composes_with/conflicts_with
+- Validate all fragments with `meridian_manifest_validate`
+- Cross-reference with `docs/guides/manifest-design-patterns.md`
+  to ensure coverage
+
+### Phase 3: MCP Discovery Tools
+
+- Implement `meridian_cookbook_list` (reads registry.json,
+  supports category/industry filtering)
+- Implement `meridian_cookbook_describe` (reads individual
+  pattern.json, returns full detail with file contents)
+- Implement `meridian_cookbook_discover` (inspects current
+  manifest, matches against pattern provides/requires,
+  returns compatible patterns with HATEOAS links)
+
+### Phase 4: Authoring Guide and Validation
+
+- Write `cookbook/docs/authoring-patterns.md` guide for
+  adding new patterns
+- Add CI validation: all pattern.json files conform to
+  schema, all manifest fragments pass validation, all
+  saga scripts pass Starlark syntax validation
+- Add test: composition of all `composes_with` pairs
+  produces valid manifests
+
+## Open Questions
+
+1. **Pattern granularity**: Should `energy-settlement`
+   include GBP as a provided instrument, or should there
+   be a separate `base-fiat-gbp` pattern that energy
+   depends on? Finer granularity enables more composition
+   but increases the number of patterns.
+
+2. **Versioning**: Should patterns have versions? A pattern
+   may evolve as the platform adds capabilities. Options:
+   - Unversioned (patterns always reflect current platform)
+   - Semver (breaking changes get major version bumps)
+   - Platform version pinning (pattern declares minimum
+     platform version)
+
+3. **Manifest fragment format**: Should fragments be YAML
+   (human-readable, matches manifest files) or JSON
+   (consistent with registry format, easier to merge
+   programmatically)?
+
+4. **Discovery implementation**: Should `cookbook_discover`
+   live in the MCP server (Go, alongside existing manifest
+   tools) or as a separate lightweight service? The logic
+   is simple set intersection - probably belongs in the
+   existing MCP server.
+
+5. **Community patterns**: Should the registry support
+   third-party pattern sources (like shadcn's namespace
+   system)? This enables an ecosystem but adds trust and
+   validation complexity.
+
+## Success Criteria
+
+1. All existing example manifests and saga scripts are
+   represented as cookbook patterns
+2. Each pattern declares its provides/requires/composes_with
+   metadata
+3. `meridian_cookbook_list` returns all patterns with
+   category filtering
+4. `meridian_cookbook_describe` returns full pattern detail
+   including manifest fragment and saga files
+5. `meridian_cookbook_discover` returns compatible patterns
+   given a current manifest
+6. Composing any declared `composes_with` pair produces a
+   manifest that passes `meridian_manifest_validate`
+7. CI validates all pattern schemas, manifest fragments,
+   and saga syntax

--- a/docs/prd/035-economy-cookbook.md
+++ b/docs/prd/035-economy-cookbook.md
@@ -160,7 +160,7 @@ shadcn/ui registry schema:
   },
   "files": [
     {
-      "path": "shared/data-table.tsx",
+      "path": "ui/data-table/data-table.tsx",
       "type": "registry:ui"
     }
   ]
@@ -232,6 +232,14 @@ Both types use the same `$schema`, the same
 `registryDependencies` mechanism, and the same `meta`
 object (with type-specific fields). The `type` field
 determines which metadata fields are relevant.
+
+**File path resolution**: All `files[].path` values are
+relative to the cookbook root (`cookbook/`). For
+`registry:ui` entries, paths reference frontend source
+files (e.g., `ui/data-table/data-table.tsx`). For
+`registry:pattern` entries, paths reference pattern
+artefacts (e.g.,
+`patterns/energy-settlement/manifest-fragment.yaml`).
 
 ### Metadata Schema by Type
 
@@ -527,9 +535,11 @@ fragments are merged using these deterministic rules:
 The merge order is deterministic: resolve
 `registryDependencies` depth-first, then append the
 requested patterns in the order specified by the user.
-The resulting manifest is passed to
-`meridian_manifest_validate` which is the authoritative
-arbiter of correctness.
+Shared transitive dependencies are included once (first
+encounter wins). Dependency cycles are rejected with an
+error listing the cycle path. The resulting manifest is
+passed to `meridian_manifest_validate` which is the
+authoritative arbiter of correctness.
 
 **Full conversation flow:**
 

--- a/docs/prd/035-economy-cookbook.md
+++ b/docs/prd/035-economy-cookbook.md
@@ -1,59 +1,92 @@
-# PRD: Economy Cookbook - AI-Navigable Business Pattern Registry
+# PRD: Meridian Cookbook - Unified Pattern Registry
 
 ## Problem Statement
 
-Meridian has accumulated a rich set of economy
-configuration patterns across multiple industries: energy
-settlement, SaaS billing, carbon credit tracking, precious
-metals, betting distribution. These patterns exist as
-example manifests, saga scripts, and a design patterns
-guide - but they are scattered across documentation,
-test fixtures, and proto example directories.
+Meridian has two categories of reusable building blocks
+with no unified discovery mechanism:
 
-This creates three problems:
+**Economy patterns** - manifest configurations, saga
+scripts, and design patterns for business models (energy
+settlement, SaaS billing, carbon credits). These exist as
+example manifests, test fixtures, and a design patterns
+guide - scattered across multiple directories and formats.
 
-1. **Discovery**: An AI assistant configuring a new tenant
-   economy must search across multiple directories and file
-   formats to find relevant patterns. There is no single
-   index of what's available.
-2. **Composition**: Patterns that work well together (energy
-   settlement + carbon offset) have no formal declaration of
-   compatibility. An AI must infer composition rules from
-   reading documentation.
-3. **Navigation**: Given a tenant's current economy state,
-   there is no way to ask "what can I add next?" The AI must
-   reason about the full pattern space rather than following
-   available transitions.
+**UI components** - shared React components, feature
+module widgets, and tenant-configurable layout elements.
+These exist as TypeScript files with no structured
+metadata describing what's available, what props they
+accept, or which feature modules use them.
+
+Dropping Storybook (see PRD-034 architectural decision)
+leaves a gap: there is no single catalogue where
+developers and AI assistants can discover both the UI
+building blocks for the console and the economy building
+blocks for tenant configuration. These are two sides of
+the same coin - a tenant's economy manifest drives what
+the UI displays, and the UI components determine how that
+economy is presented.
+
+This creates four problems:
+
+1. **Discovery**: No single index of available building
+   blocks across UI and economy configuration. AI must
+   search multiple directories and file formats.
+2. **Composition**: Economy patterns that work well
+   together (energy settlement + carbon offset) have no
+   formal declaration of compatibility. UI components
+   have no structured metadata linking them to the
+   features they serve.
+3. **Navigation**: Given a tenant's current state, there
+   is no way to ask "what can I add next?" for either
+   economy extensions or UI customisations.
+4. **Consistency**: UI components and economy patterns
+   use different discovery mechanisms despite both being
+   consumable through the same shadcn registry model.
 
 ## Vision
 
-An **Economy Cookbook** - a structured, AI-navigable registry
-of composable business configuration patterns. Following the
-shadcn/ui registry model for static discoverability, and
-HATEOAS principles for state-aware navigation.
+A **Meridian Cookbook** - a unified, AI-navigable registry
+of composable patterns covering both UI components and
+economy configurations. Following the shadcn/ui registry
+model for static discoverability, and HATEOAS principles
+for state-aware navigation.
 
-The cookbook is to Meridian manifests what shadcn/ui is to
-React components: a catalogue of building blocks that AI
-assistants and developers can browse, compose, and apply -
-without parsing unstructured documentation and without
-guessing what works together.
+The cookbook is to Meridian what shadcn/ui is to React: a
+catalogue of building blocks that AI assistants and
+developers can browse, compose, and apply - without
+parsing unstructured documentation and without guessing
+what works together. The difference is scope: our
+cookbook covers both the visual layer (React components,
+dashboard widgets) and the business layer (instruments,
+account types, sagas, valuation rules).
+
+**One registry, two pattern types:**
+
+| Type | Examples | Consumer |
+|------|----------|----------|
+| `registry:ui` | DataTable, MoneyDisplay, StatusBadge | Frontend dev, tenant UI config |
+| `registry:pattern` | Energy Settlement, SaaS Billing | AI manifest config, MCP tools |
+
+Both types share the same registry format, discovery
+tools, and composition model. An AI configuring a new
+tenant can browse economy patterns to build the manifest
+AND browse UI components to understand how it renders.
 
 ### Two Modes of Operation
 
 **Offline (static registry browsing)**: The registry layer
 is static JSON files. AI assistants can read `registry.json`
-and individual `pattern.json` files directly from the
+and individual pattern/component files directly from the
 filesystem or a CDN. No running server needed. This covers
-browsing, reading pattern metadata, and manually composing
-manifest fragments.
+browsing, reading metadata, and manually composing
+configurations.
 
 **Online (state-aware HATEOAS discovery)**: The
 `meridian_cookbook_discover` MCP tool inspects a tenant's
-current manifest and returns compatible patterns with
-reasons. This requires the MCP server to be running (same
-as existing `meridian_manifest_validate`). Discovery adds
-intelligence on top of the static registry - it is not
-required for basic pattern browsing.
+current manifest and UI config, returning compatible
+patterns with reasons. This requires the MCP server to be
+running. Discovery adds intelligence on top of the static
+registry - it is not required for basic browsing.
 
 ### Three Layers
 
@@ -65,24 +98,30 @@ required for basic pattern browsing.
 
 ## Goals
 
-1. Structure existing economy patterns (manifests, sagas,
-   design patterns) into a machine-readable registry format
-2. Declare composability between patterns (what works
-   together, what conflicts)
-3. Provide state-aware discovery: given a tenant's current
-   manifest, surface compatible patterns with reasons
-4. Expose the cookbook through MCP tools for AI-assisted
-   economy configuration
-5. Maintain the cookbook as living documentation that evolves
-   with the platform
+1. Unify UI component metadata and economy configuration
+   patterns into a single machine-readable registry
+2. Structure existing economy patterns (manifests, sagas,
+   design patterns) into the registry format
+3. Describe all shared and feature UI components with
+   structured metadata (props, dependencies, feature
+   module, tenant-configurable properties)
+4. Declare composability between economy patterns (what
+   works together, what conflicts)
+5. Provide state-aware discovery: given a tenant's current
+   manifest and UI config, surface compatible patterns
+6. Expose the cookbook through MCP tools for AI-assisted
+   configuration of both economy and UI
+7. Maintain the cookbook as living documentation that
+   evolves with the platform
 
 ## Non-Goals
 
 - Replacing the manifest apply workflow (the cookbook
   produces manifests that go through the existing
   validate/plan/apply pipeline)
-- Building a visual economy designer UI (the cookbook serves
-  AI and CLI consumers; a UI could consume it later)
+- Building a visual component browser to replace
+  Storybook (the registry serves AI and CLI consumers;
+  visual preview comes from running the app itself)
 - Auto-generating saga scripts from natural language (the
   cookbook provides tested reference scripts, not generated
   ones)
@@ -91,19 +130,52 @@ required for basic pattern browsing.
 
 ## Architecture
 
-### Pattern Format
+### Registry Entry Types
 
-Each pattern is a JSON file following the shadcn/ui
-`registry-item.json` schema, extended with economy-specific
-metadata. Patterns live in `cookbook/patterns/`.
+The cookbook uses two `type` values within the same
+shadcn/ui registry schema:
+
+**`registry:ui`** - UI components (React)
 
 ```json
 {
-  "$schema": "https://cookbook.meridian.dev/schema/pattern.json",
+  "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+  "name": "data-table",
+  "type": "registry:ui",
+  "title": "Data Table",
+  "description": "Sortable, filterable table with pagination.",
+  "registryDependencies": ["status-badge", "entity-link"],
+  "categories": ["shared", "layout"],
+  "meta": {
+    "feature_module": "shared",
+    "tenant_configurable": true,
+    "configurable_props": [
+      "visible_columns",
+      "default_sort"
+    ],
+    "used_by": [
+      "accounts", "payments", "ledger",
+      "positions", "reconciliation"
+    ]
+  },
+  "files": [
+    {
+      "path": "shared/data-table.tsx",
+      "type": "registry:ui"
+    }
+  ]
+}
+```
+
+**`registry:pattern`** - Economy configuration patterns
+
+```json
+{
+  "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
   "name": "energy-settlement",
   "type": "registry:pattern",
   "title": "Energy Usage-to-Value Settlement",
-  "description": "Converts metered kWh consumption into monetary value using market rates.",
+  "description": "Converts metered kWh into monetary value using market rates.",
   "categories": ["energy", "utilities", "cross-instrument"],
   "meta": {
     "complexity": 3,
@@ -111,16 +183,32 @@ metadata. Patterns live in `cookbook/patterns/`.
     "industries": ["energy", "utilities"],
     "provides": {
       "instruments": ["KWH"],
-      "account_types": ["energy_metered", "energy_revenue_retail", "energy_revenue_wholesale"],
+      "account_types": [
+        "energy_metered",
+        "energy_revenue_retail",
+        "energy_revenue_wholesale"
+      ],
       "sagas": ["usage_to_value"],
-      "valuation_rules": ["kwh_to_gbp_retail", "kwh_to_gbp_wholesale"],
-      "triggers": ["event:position-keeping.transaction-captured.v1"]
+      "valuation_rules": [
+        "kwh_to_gbp_retail",
+        "kwh_to_gbp_wholesale"
+      ],
+      "triggers": [
+        "event:position-keeping.transaction-captured.v1"
+      ]
     },
     "requires": {
       "instruments": ["GBP"],
-      "market_data": ["KWH_GBP_RETAIL", "KWH_GBP_WHOLESALE"]
+      "market_data": [
+        "KWH_GBP_RETAIL",
+        "KWH_GBP_WHOLESALE"
+      ]
     },
-    "composes_with": ["carbon-offset", "time-of-use-pricing", "payment-gateway-stripe"],
+    "composes_with": [
+      "carbon-offset",
+      "time-of-use-pricing",
+      "payment-gateway-stripe"
+    ],
     "conflicts_with": ["flat-rate-billing"],
     "extends": []
   },
@@ -140,36 +228,81 @@ metadata. Patterns live in `cookbook/patterns/`.
 }
 ```
 
-### Pattern Metadata Schema
+Both types use the same `$schema`, the same
+`registryDependencies` mechanism, and the same `meta`
+object (with type-specific fields). The `type` field
+determines which metadata fields are relevant.
 
-The `meta` object carries economy-specific semantics:
+### Metadata Schema by Type
+
+**Common fields (all types):**
 
 | Field | Type | Purpose |
 |-------|------|---------|
-| `complexity` | int (1-8) | Story points estimate for implementation |
-| `design_pattern` | string | Reference to design patterns guide |
-| `industries` | string[] | Industry tags for filtering |
-| `provides.instruments` | string[] | Instrument codes this pattern defines |
-| `provides.account_types` | string[] | Account type codes this pattern defines |
-| `provides.sagas` | string[] | Saga names this pattern includes |
-| `provides.valuation_rules` | string[] | Valuation rules this pattern defines |
-| `provides.triggers` | string[] | Event triggers wired |
-| `requires.instruments` | string[] | Instruments that must exist |
-| `requires.market_data` | string[] | Market data datasets required |
-| `composes_with` | string[] | Patterns known to work together |
-| `conflicts_with` | string[] | Patterns that are mutually exclusive |
-| `extends` | string[] | Patterns this one builds upon |
+| `name` | string | Kebab-case canonical identifier |
+| `type` | string | `registry:ui` or `registry:pattern` |
+| `title` | string | Human-readable display name |
+| `description` | string | Brief summary |
+| `categories` | string[] | Tags for filtering |
+| `registryDependencies` | string[] | Other registry items this depends on |
+| `files` | object[] | Associated source files |
+
+**UI-specific metadata (`registry:ui`):**
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `meta.feature_module` | string | Which feature module owns this component |
+| `meta.tenant_configurable` | bool | Whether tenants can configure this component |
+| `meta.configurable_props` | string[] | Props exposed to tenant config |
+| `meta.used_by` | string[] | Feature modules that use this component |
+
+**Pattern-specific metadata (`registry:pattern`):**
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `meta.complexity` | int (1-8) | Story points estimate |
+| `meta.design_pattern` | string | Reference to design patterns guide |
+| `meta.industries` | string[] | Industry tags |
+| `meta.provides.instruments` | string[] | Instrument codes defined |
+| `meta.provides.account_types` | string[] | Account types defined |
+| `meta.provides.sagas` | string[] | Saga names included |
+| `meta.provides.valuation_rules` | string[] | Valuation rules defined |
+| `meta.provides.triggers` | string[] | Event triggers wired |
+| `meta.requires.instruments` | string[] | Instruments that must exist |
+| `meta.requires.market_data` | string[] | Market data datasets required |
+| `meta.composes_with` | string[] | Patterns known to work together |
+| `meta.conflicts_with` | string[] | Mutually exclusive patterns |
+| `meta.extends` | string[] | Patterns this builds upon |
 
 ### Registry Index
 
-`cookbook/registry.json` lists all patterns:
+`cookbook/registry.json` lists all entries across both
+types:
 
 ```json
 {
-  "$schema": "https://cookbook.meridian.dev/schema/registry.json",
-  "name": "meridian-economy-cookbook",
+  "$schema": "https://cookbook.meridianhub.org/schema/registry.json",
+  "name": "meridian-cookbook",
   "homepage": "https://github.com/meridianhub/meridian",
   "items": [
+    {
+      "name": "data-table",
+      "type": "registry:ui",
+      "title": "Data Table",
+      "categories": ["shared", "layout"]
+    },
+    {
+      "name": "money-display",
+      "type": "registry:ui",
+      "title": "Money Display",
+      "categories": ["shared", "formatting"]
+    },
+    {
+      "name": "account-summary-card",
+      "type": "registry:ui",
+      "title": "Account Summary Card",
+      "categories": ["accounts", "dashboard"]
+    },
     {
       "name": "base-fiat-gbp",
       "type": "registry:pattern",
@@ -187,37 +320,52 @@ The `meta` object carries economy-specific semantics:
       "type": "registry:pattern",
       "title": "SaaS Usage Billing",
       "categories": ["technology", "billing"]
-    },
-    {
-      "name": "carbon-offset",
-      "type": "registry:pattern",
-      "title": "Carbon Credit Tracking and Retirement",
-      "categories": ["carbon", "esg"]
     }
   ]
 }
 ```
 
+The `type` field enables filtering: `type:registry:ui`
+for UI components, `type:registry:pattern` for economy
+patterns, or unfiltered for the full catalogue.
+
 ### Directory Structure
 
 ```text
 cookbook/
-├── registry.json                    # Pattern index
+├── registry.json                    # Unified index (UI + economy)
 ├── schema/
-│   ├── pattern.json                 # JSON Schema for pattern entries
-│   └── registry.json                # JSON Schema for registry index
-├── patterns/
+│   ├── registry.json                # JSON Schema for registry index
+│   └── registry-item.json           # JSON Schema for all entry types
+├── ui/                              # UI component entries
+│   ├── data-table/
+│   │   └── component.json           # UI component metadata
+│   ├── money-display/
+│   │   └── component.json
+│   ├── status-badge/
+│   │   └── component.json
+│   ├── entity-link/
+│   │   └── component.json
+│   ├── direction-badge/
+│   │   └── component.json
+│   ├── detail-skeleton/
+│   │   └── component.json
+│   ├── breadcrumbs/
+│   │   └── component.json
+│   ├── time-display/
+│   │   └── component.json
+│   ├── account-summary-card/
+│   │   └── component.json
+│   └── recent-payments/
+│       └── component.json
+├── patterns/                        # Economy pattern entries
 │   ├── base-fiat-gbp/
-│   │   ├── pattern.json             # Pattern metadata
-│   │   └── manifest-fragment.yaml   # Manifest fragment
+│   │   ├── pattern.json
+│   │   └── manifest-fragment.yaml
 │   ├── energy-settlement/
 │   │   ├── pattern.json
 │   │   ├── manifest-fragment.yaml
 │   │   └── usage_to_value.star
-│   ├── time-of-use-pricing/
-│   │   ├── pattern.json
-│   │   ├── manifest-fragment.yaml
-│   │   └── tou_energy_valuation.star
 │   ├── saas-billing/
 │   │   ├── pattern.json
 │   │   ├── manifest-fragment.yaml
@@ -226,44 +374,27 @@ cookbook/
 │   │   ├── pattern.json
 │   │   ├── manifest-fragment.yaml
 │   │   └── carbon_retirement.star
-│   ├── precious-metals/
-│   │   ├── pattern.json
-│   │   ├── manifest-fragment.yaml
-│   │   └── valuation_on_capture.star
-│   ├── entity-distribution/
-│   │   ├── pattern.json
-│   │   ├── manifest-fragment.yaml
-│   │   └── race_result_distribution.star
-│   ├── dynamic-capacity-pricing/
-│   │   ├── pattern.json
-│   │   ├── manifest-fragment.yaml
-│   │   └── dynamic_capacity_billing.star
-│   ├── payment-gateway-stripe/
-│   │   ├── pattern.json
-│   │   └── manifest-fragment.yaml
-│   └── kyc-compliance/
-│       ├── pattern.json
-│       ├── manifest-fragment.yaml
-│       └── kyc_on_party.star
-├── ...                              # Additional patterns added over time
+│   └── ...                          # See inventory tables below
 └── docs/
-    └── authoring-patterns.md        # Guide for adding new patterns
+    ├── authoring-patterns.md        # Guide for economy patterns
+    └── authoring-components.md      # Guide for UI components
 ```
 
 Note: the directory listing above is illustrative, not
-exhaustive. See the Initial Pattern Inventory section for
-the full list of patterns to migrate.
+exhaustive. See the Initial Inventory sections for the
+full lists.
 
 ### HATEOAS Discovery
 
 The discovery layer inspects a tenant's current manifest
-and returns compatible patterns with navigation links.
-This is the key difference from a static catalogue: the
-response is state-aware.
+and UI config, returning compatible patterns with
+navigation links. This is the key difference from a
+static catalogue: the response is state-aware.
 
 **MCP tool: `meridian_cookbook_discover`**
 
-Input: current manifest (or tenant_id to fetch it)
+Input: current manifest (or tenant_id to fetch it),
+optional `type` filter (`ui`, `pattern`, or both)
 
 Output:
 
@@ -271,16 +402,26 @@ Output:
 {
   "economy_state": {
     "instruments": ["GBP", "KWH"],
-    "account_types": ["energy_metered", "energy_revenue_retail"],
+    "account_types": [
+      "energy_metered",
+      "energy_revenue_retail"
+    ],
     "sagas": ["usage_to_value"],
     "market_data": ["KWH_GBP_RETAIL"]
+  },
+  "ui_state": {
+    "enabled_features": [
+      "accounts", "positions", "ledger"
+    ],
+    "dashboard_widgets": ["account-summary-card"]
   },
   "compatible_patterns": [
     {
       "name": "carbon-offset",
+      "type": "registry:pattern",
       "rel": "extend",
       "title": "Add Carbon Credit Tracking",
-      "reason": "You have KWH instruments - most energy tenants pair this with carbon accounting for ESG compliance",
+      "reason": "You have KWH instruments - most energy tenants pair this with carbon accounting",
       "complexity": 3,
       "_links": {
         "detail": "/cookbook/patterns/carbon-offset",
@@ -289,31 +430,33 @@ Output:
     },
     {
       "name": "time-of-use-pricing",
+      "type": "registry:pattern",
       "rel": "enhance",
       "title": "Add Time-of-Use Rate Curves",
-      "reason": "Your usage_to_value saga uses flat rates - this adds temporal pricing from forecast curves",
+      "reason": "Your usage_to_value saga uses flat rates - this adds temporal pricing",
       "complexity": 2,
       "_links": {
         "detail": "/cookbook/patterns/time-of-use-pricing",
         "compose": "/cookbook/compose?patterns=time-of-use-pricing"
       }
-    },
+    }
+  ],
+  "compatible_components": [
     {
-      "name": "payment-gateway-stripe",
-      "rel": "connect",
-      "title": "Connect Stripe for Collections",
-      "reason": "You have GBP revenue accounts but no payment rail configured",
-      "complexity": 5,
+      "name": "quality-ladder-badge",
+      "type": "registry:ui",
+      "rel": "enhance",
+      "title": "Quality Ladder Badge",
+      "reason": "You have position-keeping enabled but no quality indicator in your dashboard",
       "_links": {
-        "detail": "/cookbook/patterns/payment-gateway-stripe",
-        "compose": "/cookbook/compose?patterns=payment-gateway-stripe"
+        "detail": "/cookbook/ui/quality-ladder-badge"
       }
     }
   ],
   "conflicting_patterns": [
     {
       "name": "flat-rate-billing",
-      "reason": "Conflicts with existing usage_to_value saga which uses cross-instrument valuation"
+      "reason": "Conflicts with existing usage_to_value saga"
     }
   ],
   "_links": {
@@ -347,9 +490,13 @@ manifest tools:
 
 | Tool | Layer | Purpose |
 |------|-------|---------|
-| `meridian_cookbook_list` | Registry | Browse all patterns, filter by category/industry |
-| `meridian_cookbook_describe` | Registry | Get full pattern detail with manifest fragment and saga files |
-| `meridian_cookbook_discover` | Discovery | Given current manifest, return compatible patterns with reasons |
+| `meridian_cookbook_list` | Registry | Browse all entries, filter by type/category/industry |
+| `meridian_cookbook_describe` | Registry | Get full entry detail with associated files |
+| `meridian_cookbook_discover` | Discovery | Given current tenant state, return compatible entries |
+
+All three tools support both `registry:ui` and
+`registry:pattern` types. The `type` parameter filters
+results when a consumer only wants one category.
 
 **Composition is done client-side.** The AI reads pattern
 manifest fragments and merges them into a complete manifest.
@@ -357,34 +504,36 @@ The existing `meridian_manifest_validate` tool catches any
 conflicts or missing dependencies. This keeps the cookbook
 stateless and the validation authoritative.
 
-**Merge semantics**: Manifest fragments are merged using
-these deterministic rules:
+**Merge semantics** (economy patterns only): Manifest
+fragments are merged using these deterministic rules:
 
-- **Lists** (instruments, account_types, sagas): append in
-  pattern dependency order, deduplicate by `code`/`name`
-  field (first occurrence wins)
-- **Scalars** (metadata.name, metadata.description): later
-  pattern overrides earlier
-- **Nested objects** (valuation_rules, seed_data): recursive
-  merge, with later pattern values overriding on key
-  collision
-- **Conflict detection**: if two fragments define the same
-  `code`/`name` with different content,
-  `meridian_manifest_validate` rejects with a descriptive
-  error listing both sources
+- **Lists of scalars** (e.g., `instruments`,
+  `account_types`, `sagas`, `requires.market_data`):
+  append in pattern dependency order, then deduplicate
+  by exact string value (first occurrence wins)
+- **Scalars** (metadata.name, metadata.description):
+  later pattern overrides earlier
+- **Nested objects** (valuation_rules, seed_data):
+  recursive merge, with later pattern values overriding
+  on key collision
+- **Conflict detection**: if two fragments define the
+  same key with different content,
+  `meridian_manifest_validate` rejects with a
+  descriptive error listing both sources
 
 The merge order is deterministic: resolve
 `registryDependencies` depth-first, then append the
-requested patterns in the order specified by the user. The
-resulting manifest is passed to `meridian_manifest_validate`
-which is the authoritative arbiter of correctness.
+requested patterns in the order specified by the user.
+The resulting manifest is passed to
+`meridian_manifest_validate` which is the authoritative
+arbiter of correctness.
 
 **Full conversation flow:**
 
 ```text
 User: "We're an energy retailer billing residential customers"
 
-AI: meridian_cookbook_list(category: "energy")
+AI: meridian_cookbook_list(type: "pattern", category: "energy")
     → energy-settlement, time-of-use-pricing, carbon-offset
 
 AI: meridian_cookbook_describe("energy-settlement")
@@ -393,7 +542,8 @@ AI: meridian_cookbook_describe("energy-settlement")
 AI: Merges energy-settlement fragment into manifest
 
 AI: meridian_cookbook_discover(current_manifest)
-    → compatible: time-of-use-pricing, carbon-offset, payment-gateway-stripe
+    → compatible patterns: time-of-use-pricing, carbon-offset
+    → compatible components: quality-ladder-badge
     → reason: "Your usage_to_value uses flat rates - TOU adds temporal pricing"
 
 User: "Add time-of-use pricing"
@@ -412,9 +562,16 @@ AI: meridian_manifest_plan(merged_manifest)
 User: "Looks good"
 
 AI: meridian_manifest_apply(merged_manifest, plan_hash)
+
+User: "What UI components are available for energy?"
+
+AI: meridian_cookbook_list(type: "ui", category: "positions")
+    → quality-ladder-badge, data-table, money-display
 ```
 
-## Initial Pattern Inventory
+## Initial Inventory
+
+### Economy Patterns
 
 Migrated from existing content:
 
@@ -433,42 +590,85 @@ Migrated from existing content:
 | `payment-gateway-stripe` | `stripe_operational_gateway.manifest.json` | Payments |
 | `kyc-compliance` | `kyc_on_party.star` | Compliance |
 
+### UI Components
+
+Extracted from existing `shared/` and `features/`
+components (see PRD-034 for component relocation plan):
+
+| Component | Feature Module | Tenant Configurable |
+|-----------|---------------|---------------------|
+| `data-table` | shared | Yes (columns, sort) |
+| `money-display` | shared | No |
+| `direction-badge` | shared | No |
+| `status-badge` | shared | No |
+| `entity-link` | shared | No |
+| `detail-skeleton` | shared | No |
+| `breadcrumbs` | shared | No |
+| `time-display` | shared | No |
+| `handler-reference` | shared | No |
+| `audit-trail` | shared | No |
+| `account-summary-card` | accounts | Yes (visible fields) |
+| `recent-payments` | payments | Yes (row count) |
+| `cel-editor` | sagas | No |
+| `starlark-editor` | sagas | No |
+| `saga-timeline` | sagas | No |
+| `quality-ladder-badge` | positions | No |
+
 ## Implementation Phases
 
 ### Phase 1: Schema and Directory Structure
 
-- Define `pattern.json` and `registry.json` JSON Schemas
-- Create `cookbook/` directory structure
-- Create the registry index file
+- Define `registry-item.json` JSON Schema supporting
+  both `registry:ui` and `registry:pattern` types
+- Define `registry.json` JSON Schema for the unified
+  index
+- Create `cookbook/` directory structure with `ui/`,
+  `patterns/`, `schema/`, and `docs/` subdirectories
+- Create the initial `registry.json` index file
 
-### Phase 2: Migrate Existing Patterns
+### Phase 2: Populate UI Component Entries
+
+- Create `component.json` metadata for each shared
+  component listed in the UI inventory
+- Declare `feature_module`, `tenant_configurable`,
+  `configurable_props`, and `used_by` for each
+- Validate that `registryDependencies` between
+  components are accurate
+- Cross-reference with PRD-034's component registry
+  section for consistency
+
+### Phase 3: Migrate Economy Patterns
 
 - Extract manifest fragments from existing example
   manifests in `api/proto/.../examples/`
 - Extract saga scripts from `tenant-saga-examples/`
-- Create pattern.json metadata for each, declaring
+- Create `pattern.json` metadata for each, declaring
   provides/requires/composes_with/conflicts_with
 - Validate all fragments with `meridian_manifest_validate`
-- Cross-reference with `docs/guides/manifest-design-patterns.md`
-  to ensure coverage
+- Cross-reference with
+  `docs/guides/manifest-design-patterns.md` to ensure
+  coverage
 
-### Phase 3: MCP Discovery Tools
+### Phase 4: MCP Discovery Tools
 
 - Implement `meridian_cookbook_list` (reads registry.json,
-  supports category/industry filtering)
+  supports type/category/industry filtering)
 - Implement `meridian_cookbook_describe` (reads individual
-  pattern.json, returns full detail with file contents)
+  entry files, returns full detail with associated files)
 - Implement `meridian_cookbook_discover` (inspects current
-  manifest, matches against pattern provides/requires,
-  returns compatible patterns with HATEOAS links)
+  manifest and UI config, matches against
+  provides/requires, returns compatible entries with
+  HATEOAS links)
 
-### Phase 4: Authoring Guide and Validation
+### Phase 5: Authoring Guides and CI Validation
 
 - Write `cookbook/docs/authoring-patterns.md` guide for
-  adding new patterns
-- Add CI validation: all pattern.json files conform to
-  schema, all manifest fragments pass validation, all
-  saga scripts pass Starlark syntax validation
+  economy patterns
+- Write `cookbook/docs/authoring-components.md` guide for
+  UI component entries
+- Add CI validation: all entry files conform to schema,
+  all manifest fragments pass validation, all saga
+  scripts pass Starlark syntax validation
 - Add test: composition of all `composes_with` pairs
   produces valid manifests
 
@@ -480,11 +680,11 @@ Migrated from existing content:
    depends on? Finer granularity enables more composition
    but increases the number of patterns.
 
-2. **Versioning**: Should patterns have versions? A pattern
+2. **Versioning**: Should entries have versions? A pattern
    may evolve as the platform adds capabilities. Options:
-   - Unversioned (patterns always reflect current platform)
+   - Unversioned (entries always reflect current platform)
    - Semver (breaking changes get major version bumps)
-   - Platform version pinning (pattern declares minimum
+   - Platform version pinning (entry declares minimum
      platform version)
 
 3. **Manifest fragment format**: Should fragments be YAML
@@ -493,9 +693,9 @@ Migrated from existing content:
    programmatically)?
 
 4. **Discovery implementation**: Should
-   `meridian_cookbook_discover` live in the MCP server (Go,
-   alongside existing manifest tools) or as a separate
-   lightweight service? The logic is simple set
+   `meridian_cookbook_discover` live in the MCP server
+   (Go, alongside existing manifest tools) or as a
+   separate lightweight service? The logic is simple set
    intersection - probably belongs in the existing MCP
    server.
 
@@ -504,19 +704,30 @@ Migrated from existing content:
    system)? This enables an ecosystem but adds trust and
    validation complexity.
 
+6. **UI component auto-generation**: Should
+   `component.json` files be generated from TypeScript
+   source (parsing exports and prop types) or maintained
+   manually? Auto-generation ensures accuracy but adds
+   build tooling. Manual authoring is simpler but risks
+   drift.
+
 ## Success Criteria
 
-1. All existing example manifests and saga scripts are
+1. A single `cookbook/registry.json` index contains both
+   UI components and economy patterns
+2. All existing example manifests and saga scripts are
    represented as cookbook patterns
-2. Each pattern declares its provides/requires/composes_with
-   metadata
-3. `meridian_cookbook_list` returns all patterns with
-   category filtering
-4. `meridian_cookbook_describe` returns full pattern detail
-   including manifest fragment and saga files
-5. `meridian_cookbook_discover` returns compatible patterns
-   given a current manifest
-6. Composing any declared `composes_with` pair produces a
+3. All shared and feature UI components have structured
+   `component.json` metadata
+4. Each economy pattern declares its
+   provides/requires/composes_with metadata
+5. `meridian_cookbook_list` returns entries filtered by
+   type, category, or industry
+6. `meridian_cookbook_describe` returns full entry detail
+   including associated files
+7. `meridian_cookbook_discover` returns compatible entries
+   given a current tenant state
+8. Composing any declared `composes_with` pair produces a
    manifest that passes `meridian_manifest_validate`
-7. CI validates all pattern schemas, manifest fragments,
+9. CI validates all entry schemas, manifest fragments,
    and saga syntax

--- a/docs/prd/035-economy-cookbook.md
+++ b/docs/prd/035-economy-cookbook.md
@@ -394,7 +394,8 @@ static catalogue: the response is state-aware.
 **MCP tool: `meridian_cookbook_discover`**
 
 Input: current manifest (or tenant_id to fetch it),
-optional `type` filter (`ui`, `pattern`, or both)
+optional `type` filter (`registry:ui`, `registry:pattern`,
+or omit for both)
 
 Output:
 
@@ -516,10 +517,12 @@ fragments are merged using these deterministic rules:
 - **Nested objects** (valuation_rules, seed_data):
   recursive merge, with later pattern values overriding
   on key collision
-- **Conflict detection**: if two fragments define the
-  same key with different content,
-  `meridian_manifest_validate` rejects with a
-  descriptive error listing both sources
+- **Post-merge validation**:
+  `meridian_manifest_validate` runs on the merged result
+  and rejects structurally invalid manifests (e.g.,
+  duplicate instrument codes with conflicting
+  definitions, missing required references). The merge
+  itself is permissive; validation is authoritative
 
 The merge order is deterministic: resolve
 `registryDependencies` depth-first, then append the
@@ -533,7 +536,7 @@ arbiter of correctness.
 ```text
 User: "We're an energy retailer billing residential customers"
 
-AI: meridian_cookbook_list(type: "pattern", category: "energy")
+AI: meridian_cookbook_list(type: "registry:pattern", category: "energy")
     → energy-settlement, time-of-use-pricing, carbon-offset
 
 AI: meridian_cookbook_describe("energy-settlement")
@@ -565,7 +568,7 @@ AI: meridian_manifest_apply(merged_manifest, plan_hash)
 
 User: "What UI components are available for energy?"
 
-AI: meridian_cookbook_list(type: "ui", category: "positions")
+AI: meridian_cookbook_list(type: "registry:ui", category: "positions")
     → quality-ladder-badge, data-table, money-display
 ```
 

--- a/docs/prd/035-economy-cookbook.md
+++ b/docs/prd/035-economy-cookbook.md
@@ -35,17 +35,33 @@ HATEOAS principles for state-aware navigation.
 The cookbook is to Meridian manifests what shadcn/ui is to
 React components: a catalogue of building blocks that AI
 assistants and developers can browse, compose, and apply -
-without needing a running server, without parsing
-unstructured documentation, and without guessing what works
-together.
+without parsing unstructured documentation and without
+guessing what works together.
+
+### Two Modes of Operation
+
+**Offline (static registry browsing)**: The registry layer
+is static JSON files. AI assistants can read `registry.json`
+and individual `pattern.json` files directly from the
+filesystem or a CDN. No running server needed. This covers
+browsing, reading pattern metadata, and manually composing
+manifest fragments.
+
+**Online (state-aware HATEOAS discovery)**: The
+`meridian_cookbook_discover` MCP tool inspects a tenant's
+current manifest and returns compatible patterns with
+reasons. This requires the MCP server to be running (same
+as existing `meridian_manifest_validate`). Discovery adds
+intelligence on top of the static registry - it is not
+required for basic pattern browsing.
 
 ### Three Layers
 
-| Layer | Model | Purpose |
-|-------|-------|---------|
-| **Registry** | shadcn/ui | Static JSON patterns with metadata, deps, files |
-| **Discovery** | HATEOAS | Given current state, what patterns are compatible? |
-| **Execution** | Existing MCP | validate, plan, apply (already built) |
+| Layer | Model | Requires server? |
+|-------|-------|------------------|
+| **Registry** | shadcn/ui | No - static JSON files |
+| **Discovery** | HATEOAS | Yes - MCP server computes compatibility |
+| **Execution** | Existing MCP | Yes - validate, plan, apply |
 
 ## Goals
 
@@ -333,6 +349,28 @@ manifest fragments and merges them into a complete manifest.
 The existing `meridian_manifest_validate` tool catches any
 conflicts or missing dependencies. This keeps the cookbook
 stateless and the validation authoritative.
+
+**Merge semantics**: Manifest fragments are merged using
+these deterministic rules:
+
+- **Lists** (instruments, account_types, sagas): append in
+  pattern dependency order, deduplicate by `code`/`name`
+  field (first occurrence wins)
+- **Scalars** (metadata.name, metadata.description): later
+  pattern overrides earlier
+- **Nested objects** (valuation_rules, seed_data): recursive
+  merge, with later pattern values overriding on key
+  collision
+- **Conflict detection**: if two fragments define the same
+  `code`/`name` with different content,
+  `meridian_manifest_validate` rejects with a descriptive
+  error listing both sources
+
+The merge order is deterministic: resolve
+`registryDependencies` depth-first, then append the
+requested patterns in the order specified by the user. The
+resulting manifest is passed to `meridian_manifest_validate`
+which is the authoritative arbiter of correctness.
 
 **Full conversation flow:**
 

--- a/docs/prd/035-economy-cookbook.md
+++ b/docs/prd/035-economy-cookbook.md
@@ -245,9 +245,14 @@ cookbook/
 │       ├── pattern.json
 │       ├── manifest-fragment.yaml
 │       └── kyc_on_party.star
+├── ...                              # Additional patterns added over time
 └── docs/
     └── authoring-patterns.md        # Guide for adding new patterns
 ```
+
+Note: the directory listing above is illustrative, not
+exhaustive. See the Initial Pattern Inventory section for
+the full list of patterns to migrate.
 
 ### HATEOAS Discovery
 
@@ -328,10 +333,12 @@ cognitive load.
 
 HATEOAS discovery: AI asks "what's possible from here?" and
 the system tells it. The AI follows links, not logic.
-Composition rules are enforced by the server, not
-interpreted by the client. New patterns become available to
-AI the moment they're added to the registry, with zero
-prompt engineering.
+Compatibility rules are computed by the server (via
+`meridian_cookbook_discover`), while the actual manifest
+merge is done client-side by the AI. Validation remains
+server-side (`meridian_manifest_validate`). New patterns
+become available to AI the moment they're added to the
+registry, with zero prompt engineering.
 
 ### MCP Tools
 
@@ -485,11 +492,12 @@ Migrated from existing content:
    (consistent with registry format, easier to merge
    programmatically)?
 
-4. **Discovery implementation**: Should `cookbook_discover`
-   live in the MCP server (Go, alongside existing manifest
-   tools) or as a separate lightweight service? The logic
-   is simple set intersection - probably belongs in the
-   existing MCP server.
+4. **Discovery implementation**: Should
+   `meridian_cookbook_discover` live in the MCP server (Go,
+   alongside existing manifest tools) or as a separate
+   lightweight service? The logic is simple set
+   intersection - probably belongs in the existing MCP
+   server.
 
 5. **Community patterns**: Should the registry support
    third-party pattern sources (like shadcn's namespace


### PR DESCRIPTION
## Summary

- **PRD-034 updated**: Drops Storybook entirely. Replaces with a shadcn/ui-style component registry (static JSON index) that is AI-navigable without a running dev server. Adds an ADR documenting the rationale for component registry over Storybook.
- **PRD-035 created**: New Economy Cookbook PRD defining a composable, AI-navigable business pattern registry for manifest configuration. Combines shadcn/ui registry model (static, declarative) with HATEOAS-style state-aware discovery.
- **Task Master updated**: Cancelled Storybook tasks (12-14, 21, 23). Added replacement tasks: 26 (component registry schema + registry.json) and 27 (dev-mode theme preview panel). Fixed task 25 dependency chain.

### Key architectural decisions

| Decision | Rationale |
|----------|-----------|
| Component registry over Storybook | Meridian's primary component consumers are AI assistants and developers, not designers browsing visual previews. Static JSON is trivially machine-readable; Storybook requires a running dev server and experimental MCP plugins for AI access. |
| shadcn/ui registry format | Proven at scale, powers component distribution and AI code generation (v0.dev). Same schema works for both UI components (PRD-034) and economy patterns (PRD-035). |
| HATEOAS discovery for Economy Cookbook | AI agents are ideal HATEOAS clients. State-aware pattern discovery reduces decision space: "given your current economy, here's what you can add next" vs browsing a flat catalogue. |

## Test plan

- [ ] Verify PRD-034 has no Storybook references remaining
- [ ] Verify PRD-035 is internally consistent (pattern schema matches examples)
- [ ] Verify Task Master tag `034-frontend-alignment` has clean dependency graph (no dangling refs to cancelled tasks)