### PR TITLE
feat: add tenant UI config type definitions and Zod validation schemas

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,8 @@
         "react-dom": "^19.2.0",
         "react-hook-form": "^7.71.2",
         "react-router-dom": "^7.13.0",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.65.0",
@@ -11946,7 +11947,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,8 @@
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.71.2",
     "react-router-dom": "^7.13.0",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",

--- a/frontend/src/lib/__tests__/tenant-ui-config.test.ts
+++ b/frontend/src/lib/__tests__/tenant-ui-config.test.ts
@@ -103,6 +103,25 @@ describe("tenant-ui-config", () => {
       expect(() => validateTenantUIConfig(null)).toThrow()
       expect(() => validateTenantUIConfig(42)).toThrow()
     })
+
+    it("rejects unknown feature identifiers in enabled list", () => {
+      const config = {
+        features: {
+          enabled: ["dashboard", "acount"],  // typo: 'acount'
+        },
+      }
+      expect(() => validateTenantUIConfig(config)).toThrow()
+    })
+
+    it("rejects unknown feature identifier as defaultFeature", () => {
+      const config = {
+        features: {
+          enabled: ["dashboard"],
+          defaultFeature: "not-a-feature",
+        },
+      }
+      expect(() => validateTenantUIConfig(config)).toThrow()
+    })
   })
 
   describe("DEFAULT_UI_CONFIG", () => {

--- a/frontend/src/lib/__tests__/tenant-ui-config.test.ts
+++ b/frontend/src/lib/__tests__/tenant-ui-config.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest"
+import {
+  validateTenantUIConfig,
+  DEFAULT_UI_CONFIG,
+  TenantUIConfigSchema,
+  ALL_FEATURES,
+} from "../tenant-ui-config"
+
+describe("tenant-ui-config", () => {
+  describe("validateTenantUIConfig", () => {
+    it("accepts a valid full config", () => {
+      const config = {
+        theme: {
+          primaryColor: "#007bff",
+          logoUrl: "https://example.com/logo.png",
+          faviconUrl: "https://example.com/favicon.ico",
+          fontFamily: "Inter",
+        },
+        features: {
+          enabled: ["dashboard", "accounts", "payments"],
+          defaultFeature: "dashboard",
+        },
+        layout: {
+          dashboard: {
+            widgets: [
+              { feature: "accounts", component: "AccountSummaryWidget", position: 0 },
+              { feature: "payments", component: "RecentPaymentsWidget", position: 1 },
+            ],
+          },
+          tableDefaults: {
+            accounts: {
+              visibleColumns: ["id", "name", "balance"],
+              defaultSort: "name",
+            },
+          },
+        },
+      }
+      const result = validateTenantUIConfig(config)
+      expect(result).toEqual(config)
+    })
+
+    it("accepts a partial config with only theme", () => {
+      const config = {
+        theme: { primaryColor: "#ff0000" },
+      }
+      const result = validateTenantUIConfig(config)
+      expect(result.theme?.primaryColor).toBe("#ff0000")
+      expect(result.features).toBeUndefined()
+      expect(result.layout).toBeUndefined()
+    })
+
+    it("accepts an empty config (all fields optional)", () => {
+      const result = validateTenantUIConfig({})
+      expect(result).toEqual({})
+    })
+
+    it("accepts features config without defaultFeature", () => {
+      const config = {
+        features: {
+          enabled: ["dashboard", "accounts"],
+        },
+      }
+      const result = validateTenantUIConfig(config)
+      expect(result.features?.enabled).toEqual(["dashboard", "accounts"])
+      expect(result.features?.defaultFeature).toBeUndefined()
+    })
+
+    it("rejects invalid theme logoUrl (not a URL)", () => {
+      const config = {
+        theme: {
+          primaryColor: "#007bff",
+          logoUrl: "not-a-url",
+        },
+      }
+      expect(() => validateTenantUIConfig(config)).toThrow()
+    })
+
+    it("rejects theme missing primaryColor", () => {
+      const config = {
+        theme: {
+          logoUrl: "https://example.com/logo.png",
+        },
+      }
+      expect(() => validateTenantUIConfig(config)).toThrow()
+    })
+
+    it("rejects non-integer widget position", () => {
+      const config = {
+        layout: {
+          dashboard: {
+            widgets: [
+              { feature: "accounts", component: "AccountWidget", position: 1.5 },
+            ],
+          },
+          tableDefaults: {},
+        },
+      }
+      expect(() => validateTenantUIConfig(config)).toThrow()
+    })
+
+    it("rejects non-object input", () => {
+      expect(() => validateTenantUIConfig("invalid")).toThrow()
+      expect(() => validateTenantUIConfig(null)).toThrow()
+      expect(() => validateTenantUIConfig(42)).toThrow()
+    })
+  })
+
+  describe("DEFAULT_UI_CONFIG", () => {
+    it("passes schema validation", () => {
+      const result = TenantUIConfigSchema.safeParse(DEFAULT_UI_CONFIG)
+      expect(result.success).toBe(true)
+    })
+
+    it("includes all expected features", () => {
+      expect(DEFAULT_UI_CONFIG.features?.enabled).toEqual(expect.arrayContaining([...ALL_FEATURES]))
+      expect(DEFAULT_UI_CONFIG.features?.enabled).toHaveLength(ALL_FEATURES.length)
+    })
+
+    it("has dashboard as default feature", () => {
+      expect(DEFAULT_UI_CONFIG.features?.defaultFeature).toBe("dashboard")
+    })
+
+    it("contains all 17 features", () => {
+      expect(DEFAULT_UI_CONFIG.features?.enabled).toHaveLength(17)
+    })
+  })
+
+  describe("ALL_FEATURES", () => {
+    it("contains expected feature identifiers", () => {
+      expect(ALL_FEATURES).toContain("dashboard")
+      expect(ALL_FEATURES).toContain("accounts")
+      expect(ALL_FEATURES).toContain("payments")
+      expect(ALL_FEATURES).toContain("ledger")
+      expect(ALL_FEATURES).toContain("positions")
+      expect(ALL_FEATURES).toContain("reconciliation")
+      expect(ALL_FEATURES).toContain("parties")
+      expect(ALL_FEATURES).toContain("tenants")
+      expect(ALL_FEATURES).toContain("reference-data")
+      expect(ALL_FEATURES).toContain("internal-accounts")
+      expect(ALL_FEATURES).toContain("market-data")
+      expect(ALL_FEATURES).toContain("forecasting")
+      expect(ALL_FEATURES).toContain("sagas")
+      expect(ALL_FEATURES).toContain("manifests")
+      expect(ALL_FEATURES).toContain("mappings")
+      expect(ALL_FEATURES).toContain("audit")
+      expect(ALL_FEATURES).toContain("mcp-config")
+    })
+  })
+
+  describe("TenantLayoutConfig", () => {
+    it("accepts layout with empty widgets and tableDefaults", () => {
+      const config = {
+        layout: {
+          dashboard: { widgets: [] },
+          tableDefaults: {},
+        },
+      }
+      const result = validateTenantUIConfig(config)
+      expect(result.layout?.dashboard.widgets).toEqual([])
+      expect(result.layout?.tableDefaults).toEqual({})
+    })
+
+    it("accepts tableDefaults without defaultSort", () => {
+      const config = {
+        layout: {
+          dashboard: { widgets: [] },
+          tableDefaults: {
+            accounts: {
+              visibleColumns: ["id", "name"],
+            },
+          },
+        },
+      }
+      const result = validateTenantUIConfig(config)
+      expect(result.layout?.tableDefaults["accounts"].visibleColumns).toEqual(["id", "name"])
+      expect(result.layout?.tableDefaults["accounts"].defaultSort).toBeUndefined()
+    })
+  })
+})

--- a/frontend/src/lib/tenant-ui-config.ts
+++ b/frontend/src/lib/tenant-ui-config.ts
@@ -1,0 +1,110 @@
+import { z } from "zod"
+
+// TypeScript interfaces
+
+export interface TenantThemeConfig {
+  primaryColor: string
+  logoUrl?: string
+  faviconUrl?: string
+  fontFamily?: string
+}
+
+export interface TenantFeaturesConfig {
+  enabled: string[]
+  defaultFeature?: string
+}
+
+export interface DashboardWidget {
+  feature: string
+  component: string
+  position: number
+}
+
+export interface TableDefaults {
+  visibleColumns: string[]
+  defaultSort?: string
+}
+
+export interface TenantLayoutConfig {
+  dashboard: {
+    widgets: DashboardWidget[]
+  }
+  tableDefaults: Record<string, TableDefaults>
+}
+
+export interface TenantUIConfig {
+  theme?: TenantThemeConfig
+  features?: TenantFeaturesConfig
+  layout?: TenantLayoutConfig
+}
+
+// Default configuration with all features enabled
+
+export const ALL_FEATURES = [
+  "dashboard",
+  "accounts",
+  "payments",
+  "ledger",
+  "positions",
+  "reconciliation",
+  "parties",
+  "tenants",
+  "reference-data",
+  "internal-accounts",
+  "market-data",
+  "forecasting",
+  "sagas",
+  "manifests",
+  "mappings",
+  "audit",
+  "mcp-config",
+] as const
+
+export const DEFAULT_UI_CONFIG: TenantUIConfig = {
+  features: {
+    enabled: [...ALL_FEATURES],
+    defaultFeature: "dashboard",
+  },
+}
+
+// Zod validation schemas
+
+export const TenantThemeConfigSchema = z.object({
+  primaryColor: z.string(),
+  logoUrl: z.string().url().optional(),
+  faviconUrl: z.string().url().optional(),
+  fontFamily: z.string().optional(),
+})
+
+export const TenantFeaturesConfigSchema = z.object({
+  enabled: z.array(z.string()),
+  defaultFeature: z.string().optional(),
+})
+
+export const DashboardWidgetSchema = z.object({
+  feature: z.string(),
+  component: z.string(),
+  position: z.number().int(),
+})
+
+export const TableDefaultsSchema = z.object({
+  visibleColumns: z.array(z.string()),
+  defaultSort: z.string().optional(),
+})
+
+export const TenantLayoutConfigSchema = z.object({
+  dashboard: z.object({
+    widgets: z.array(DashboardWidgetSchema),
+  }),
+  tableDefaults: z.record(z.string(), TableDefaultsSchema),
+})
+
+export const TenantUIConfigSchema = z.object({
+  theme: TenantThemeConfigSchema.optional(),
+  features: TenantFeaturesConfigSchema.optional(),
+  layout: TenantLayoutConfigSchema.optional(),
+})
+
+export function validateTenantUIConfig(data: unknown): TenantUIConfig {
+  return TenantUIConfigSchema.parse(data)
+}

--- a/frontend/src/lib/tenant-ui-config.ts
+++ b/frontend/src/lib/tenant-ui-config.ts
@@ -1,44 +1,6 @@
 import { z } from "zod"
 
-// TypeScript interfaces
-
-export interface TenantThemeConfig {
-  primaryColor: string
-  logoUrl?: string
-  faviconUrl?: string
-  fontFamily?: string
-}
-
-export interface TenantFeaturesConfig {
-  enabled: string[]
-  defaultFeature?: string
-}
-
-export interface DashboardWidget {
-  feature: string
-  component: string
-  position: number
-}
-
-export interface TableDefaults {
-  visibleColumns: string[]
-  defaultSort?: string
-}
-
-export interface TenantLayoutConfig {
-  dashboard: {
-    widgets: DashboardWidget[]
-  }
-  tableDefaults: Record<string, TableDefaults>
-}
-
-export interface TenantUIConfig {
-  theme?: TenantThemeConfig
-  features?: TenantFeaturesConfig
-  layout?: TenantLayoutConfig
-}
-
-// Default configuration with all features enabled
+// Feature list — single source of truth for valid feature identifiers
 
 export const ALL_FEATURES = [
   "dashboard",
@@ -60,12 +22,7 @@ export const ALL_FEATURES = [
   "mcp-config",
 ] as const
 
-export const DEFAULT_UI_CONFIG: TenantUIConfig = {
-  features: {
-    enabled: [...ALL_FEATURES],
-    defaultFeature: "dashboard",
-  },
-}
+export type FeatureId = (typeof ALL_FEATURES)[number]
 
 // Zod validation schemas
 
@@ -77,8 +34,8 @@ export const TenantThemeConfigSchema = z.object({
 })
 
 export const TenantFeaturesConfigSchema = z.object({
-  enabled: z.array(z.string()),
-  defaultFeature: z.string().optional(),
+  enabled: z.array(z.enum(ALL_FEATURES)),
+  defaultFeature: z.enum(ALL_FEATURES).optional(),
 })
 
 export const DashboardWidgetSchema = z.object({
@@ -104,6 +61,24 @@ export const TenantUIConfigSchema = z.object({
   features: TenantFeaturesConfigSchema.optional(),
   layout: TenantLayoutConfigSchema.optional(),
 })
+
+// TypeScript types derived from Zod schemas
+
+export type TenantThemeConfig = z.infer<typeof TenantThemeConfigSchema>
+export type TenantFeaturesConfig = z.infer<typeof TenantFeaturesConfigSchema>
+export type DashboardWidget = z.infer<typeof DashboardWidgetSchema>
+export type TableDefaults = z.infer<typeof TableDefaultsSchema>
+export type TenantLayoutConfig = z.infer<typeof TenantLayoutConfigSchema>
+export type TenantUIConfig = z.infer<typeof TenantUIConfigSchema>
+
+// Default configuration with all features enabled
+
+export const DEFAULT_UI_CONFIG: TenantUIConfig = {
+  features: {
+    enabled: [...ALL_FEATURES],
+    defaultFeature: "dashboard",
+  },
+}
 
 export function validateTenantUIConfig(data: unknown): TenantUIConfig {
   return TenantUIConfigSchema.parse(data)


### PR DESCRIPTION
## Summary

- Adds `frontend/src/lib/tenant-ui-config.ts` with TypeScript interfaces for `TenantUIConfig`, `TenantThemeConfig`, `TenantFeaturesConfig`, `TenantLayoutConfig`, `DashboardWidget`, and `TableDefaults`
- Implements Zod validation schemas for all config types with a `validateTenantUIConfig` helper
- Exports `DEFAULT_UI_CONFIG` constant with all 17 features enabled (dashboard, accounts, payments, ledger, positions, reconciliation, parties, tenants, reference-data, internal-accounts, market-data, forecasting, sagas, manifests, mappings, audit, mcp-config)
- Installs `zod` as a runtime dependency

## Changes Made

- `frontend/src/lib/tenant-ui-config.ts` — config interfaces, Zod schemas, default config, validation helper
- `frontend/src/lib/__tests__/tenant-ui-config.test.ts` — 15 unit tests covering valid configs, partial configs, invalid inputs, and DEFAULT_UI_CONFIG validation
- `frontend/package.json` + `frontend/package-lock.json` — adds `zod` dependency

## Test plan

- [x] All 15 unit tests pass (`npm test -- --run src/lib/__tests__/tenant-ui-config.test.ts`)
- [x] Valid full config parses correctly
- [x] Invalid configs (bad URL, missing required fields, non-integer position) are rejected
- [x] Partial configs with optional fields are accepted
- [x] DEFAULT_UI_CONFIG passes schema validation
- [x] No TypeScript errors introduced in new files

Task: 034-frontend-alignment.15