### PR TITLE
fix: add retry to SBOM generation for GitHub CDN flakiness

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -197,11 +197,14 @@ jobs:
           .
 
     - name: Generate SBOM with Syft
-      uses: anchore/sbom-action@v0.23.0
+      uses: nick-fields/retry@v3
       with:
-        image: meridian:sbom
-        format: spdx-json
-        output-file: sbom.spdx.json
+        timeout_minutes: 5
+        max_attempts: 3
+        retry_wait_seconds: 10
+        command: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+          syft meridian:sbom -o spdx-json=sbom.spdx.json
 
     - name: Verify SBOM was created
       run: |


### PR DESCRIPTION
## Summary

- Replace `anchore/sbom-action` with `nick-fields/retry` wrapping the `syft` CLI directly
- Retries up to 3 times with 10s backoff on failure

## Context

The SBOM generation step fails intermittently when GitHub's releases CDN returns HTTP 500 during Syft download (e.g., [run 22668433659](https://github.com/meridianhub/meridian/actions/runs/22668433659/job/65705972883)). The `anchore/sbom-action` has no built-in retry, so a transient CDN blip fails the entire security workflow.

## Test plan

- [ ] Security Scanning workflow passes on this PR
- [ ] SBOM artifact is still uploaded correctly