### PR TITLE
feat: implement feature-filtered sidebar navigation

### DIFF
--- a/frontend/src/components/layout/sidebar.test.tsx
+++ b/frontend/src/components/layout/sidebar.test.tsx
@@ -1,7 +1,41 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { Sidebar } from '@/components/layout/sidebar'
+import type { TenantContextValue } from '@/contexts/tenant-context'
+
+vi.mock('@/contexts/tenant-context', () => ({
+  useTenantContext: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-tenant-features', () => ({
+  useTenantFeatures: vi.fn(),
+}))
+
+import { useTenantContext } from '@/contexts/tenant-context'
+import { useTenantFeatures } from '@/hooks/use-tenant-features'
+import { ALL_FEATURES } from '@/lib/tenant-ui-config'
+
+function makeContext(overrides: Partial<TenantContextValue> = {}): TenantContextValue {
+  return {
+    currentTenant: null,
+    tenantSlug: null,
+    isPlatformAdmin: false,
+    switchTenant: vi.fn(),
+    clearTenant: vi.fn(),
+    applyTheme: vi.fn(),
+    ...overrides,
+  }
+}
+
+function makeFeatures(enabledFeatures: readonly string[] = ALL_FEATURES) {
+  const enabledSet = new Set(enabledFeatures)
+  return {
+    isFeatureEnabled: (f: string) => enabledSet.has(f),
+    enabledFeatures,
+    defaultFeature: enabledFeatures[0] ?? 'dashboard',
+  }
+}
 
 function renderSidebar(props: React.ComponentProps<typeof Sidebar>) {
   return render(
@@ -12,8 +46,13 @@ function renderSidebar(props: React.ComponentProps<typeof Sidebar>) {
 }
 
 describe('Sidebar', () => {
+  beforeEach(() => {
+    vi.mocked(useTenantContext).mockReturnValue(makeContext())
+    vi.mocked(useTenantFeatures).mockReturnValue(makeFeatures())
+  })
+
   describe('tenant lens', () => {
-    it('renders all tenant nav items', () => {
+    it('renders all tenant nav items when all features enabled', () => {
       renderSidebar({ lens: 'tenant' })
 
       expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument()
@@ -108,6 +147,63 @@ describe('Sidebar', () => {
     it('has an accessible nav landmark', () => {
       renderSidebar({ lens: 'tenant' })
       expect(screen.getByRole('navigation')).toBeInTheDocument()
+    })
+  })
+
+  describe('feature filtering', () => {
+    it('hides nav items whose feature is disabled', () => {
+      vi.mocked(useTenantFeatures).mockReturnValue(
+        makeFeatures(['dashboard', 'payments']),
+      )
+      vi.mocked(useTenantContext).mockReturnValue(makeContext({ isPlatformAdmin: false }))
+
+      renderSidebar({ lens: 'tenant' })
+
+      expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Payments' })).toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'Accounts' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'Ledger' })).not.toBeInTheDocument()
+    })
+
+    it('always shows items without a feature field regardless of enabled features', () => {
+      vi.mocked(useTenantFeatures).mockReturnValue(
+        makeFeatures(['dashboard']),
+      )
+      vi.mocked(useTenantContext).mockReturnValue(makeContext({ isPlatformAdmin: false }))
+
+      renderSidebar({ lens: 'tenant' })
+
+      // Transactions has no feature field — always visible
+      expect(screen.getByRole('link', { name: 'Transactions' })).toBeInTheDocument()
+    })
+
+    it('platform admin sees all nav items regardless of enabled features', () => {
+      vi.mocked(useTenantFeatures).mockReturnValue(
+        makeFeatures(['dashboard']),
+      )
+      vi.mocked(useTenantContext).mockReturnValue(makeContext({ isPlatformAdmin: true }))
+
+      renderSidebar({ lens: 'platform' })
+
+      expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Accounts' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Ledger' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Starlark Config' })).toBeInTheDocument()
+    })
+
+    it('tenant user only sees enabled feature nav items', () => {
+      vi.mocked(useTenantFeatures).mockReturnValue(
+        makeFeatures(['dashboard', 'accounts', 'ledger']),
+      )
+      vi.mocked(useTenantContext).mockReturnValue(makeContext({ isPlatformAdmin: false }))
+
+      renderSidebar({ lens: 'tenant' })
+
+      expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Accounts' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Ledger' })).toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'Payments' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'Reconciliation' })).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -21,31 +21,34 @@ import {
   Bot,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useTenantFeatures } from '@/hooks/use-tenant-features'
+import { useTenantContext } from '@/contexts/tenant-context'
 
 interface NavItem {
   label: string
   href: string
   icon: React.ComponentType<{ className?: string }>
+  feature?: string
 }
 
 const TENANT_NAV_ITEMS: NavItem[] = [
-  { label: 'Dashboard', href: '/', icon: LayoutDashboard },
-  { label: 'Accounts', href: '/accounts', icon: Wallet },
-  { label: 'Internal Accounts', href: '/internal-accounts', icon: Building },
-  { label: 'Payments', href: '/payments', icon: ArrowLeftRight },
+  { label: 'Dashboard', href: '/', icon: LayoutDashboard, feature: 'dashboard' },
+  { label: 'Accounts', href: '/accounts', icon: Wallet, feature: 'accounts' },
+  { label: 'Internal Accounts', href: '/internal-accounts', icon: Building, feature: 'internal-accounts' },
+  { label: 'Payments', href: '/payments', icon: ArrowLeftRight, feature: 'payments' },
   { label: 'Transactions', href: '/transactions', icon: Activity },
-  { label: 'Positions', href: '/positions', icon: TrendingUp },
-  { label: 'Ledger', href: '/ledger', icon: BookOpen },
-  { label: 'Parties', href: '/parties', icon: Users },
-  { label: 'Reconciliation', href: '/reconciliation', icon: CheckSquare },
-  { label: 'Starlark Config', href: '/starlark-config', icon: Code },
-  { label: 'Market Data', href: '/market-data', icon: LineChart },
-  { label: 'Forecasting', href: '/forecasting', icon: BarChart3 },
-  { label: 'Reference Data', href: '/reference-data', icon: Database },
-  { label: 'Gateway Mappings', href: '/gateway-mappings', icon: Map },
-  { label: 'Manifests', href: '/manifests', icon: FileJson },
-  { label: 'MCP Config', href: '/mcp-config', icon: Bot },
-  { label: 'Audit Log', href: '/audit-log', icon: ClipboardList },
+  { label: 'Positions', href: '/positions', icon: TrendingUp, feature: 'positions' },
+  { label: 'Ledger', href: '/ledger', icon: BookOpen, feature: 'ledger' },
+  { label: 'Parties', href: '/parties', icon: Users, feature: 'parties' },
+  { label: 'Reconciliation', href: '/reconciliation', icon: CheckSquare, feature: 'reconciliation' },
+  { label: 'Starlark Config', href: '/starlark-config', icon: Code, feature: 'sagas' },
+  { label: 'Market Data', href: '/market-data', icon: LineChart, feature: 'market-data' },
+  { label: 'Forecasting', href: '/forecasting', icon: BarChart3, feature: 'forecasting' },
+  { label: 'Reference Data', href: '/reference-data', icon: Database, feature: 'reference-data' },
+  { label: 'Gateway Mappings', href: '/gateway-mappings', icon: Map, feature: 'mappings' },
+  { label: 'Manifests', href: '/manifests', icon: FileJson, feature: 'manifests' },
+  { label: 'MCP Config', href: '/mcp-config', icon: Bot, feature: 'mcp-config' },
+  { label: 'Audit Log', href: '/audit-log', icon: ClipboardList, feature: 'audit' },
 ]
 
 const PLATFORM_NAV_ITEMS: NavItem[] = [
@@ -63,6 +66,14 @@ interface SidebarProps {
 
 export function Sidebar({ lens, currentPath = '/', isOpen = false, id, onClose }: SidebarProps) {
   const showPlatformItems = lens === 'platform'
+  const { isFeatureEnabled } = useTenantFeatures()
+  const { isPlatformAdmin } = useTenantContext()
+
+  const visibleTenantItems = TENANT_NAV_ITEMS.filter((item) => {
+    if (!item.feature) return true
+    if (isPlatformAdmin) return true
+    return isFeatureEnabled(item.feature)
+  })
 
   return (
     <>
@@ -84,7 +95,7 @@ export function Sidebar({ lens, currentPath = '/', isOpen = false, id, onClose }
     >
       <nav aria-label="Main navigation" className="min-h-0 flex-1 overflow-y-auto py-4">
         <ul role="list" className="space-y-1 px-2">
-          {TENANT_NAV_ITEMS.map((item) => {
+          {visibleTenantItems.map((item) => {
             const Icon = item.icon
             const isActive = currentPath === item.href
             return (

--- a/frontend/src/test/navigation.a11y.test.tsx
+++ b/frontend/src/test/navigation.a11y.test.tsx
@@ -1,13 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { axe } from '@/test/test-utils'
+import { axe, renderWithProviders } from '@/test/test-utils'
 import { Sidebar } from '@/components/layout/sidebar'
 
 function renderSidebar(props: React.ComponentProps<typeof Sidebar>) {
-  return render(
+  return renderWithProviders(
     <MemoryRouter>
       <Sidebar {...props} />
     </MemoryRouter>,


### PR DESCRIPTION
## Summary

- Adds `feature?: string` field to `NavItem` interface in sidebar component
- Imports `useTenantFeatures` hook and `useTenantContext` to filter navigation items
- Platform admins (isPlatformAdmin) bypass feature filtering and always see all items
- Items without a `feature` field (Transactions) are always visible
- Maps all TENANT_NAV_ITEMS to their corresponding feature IDs from ALL_FEATURES

## Changes Made

**`frontend/src/components/layout/sidebar.tsx`**
- Added `feature?: string` to `NavItem` interface
- Added feature annotations to all TENANT_NAV_ITEMS (Transactions has no feature — always shown)
- Imported `useTenantFeatures` and `useTenantContext`
- Added `visibleTenantItems` computed list that filters by enabled features with admin bypass

**`frontend/src/components/layout/sidebar.test.tsx`**
- Added vi.mock for `@/contexts/tenant-context` and `@/hooks/use-tenant-features`
- Added `makeContext` and `makeFeatures` test helpers
- Updated `beforeEach` to set up default mocks (all features enabled, non-admin)
- Added `feature filtering` describe block with 4 new test cases:
  - Hides items when feature is disabled
  - Always shows items without a feature field (Transactions)
  - Platform admin sees all items regardless of enabled features
  - Tenant user only sees enabled feature items

## Technical Details

Feature-to-nav-item mapping follows ALL_FEATURES from `tenant-ui-config.ts`:
- `sagas` → Starlark Config
- `mappings` → Gateway Mappings
- `audit` → Audit Log
- All others map directly by name

Feature visibility is UX-only; backend RBAC enforces authorization.

## Test plan

- [x] All 17 sidebar tests pass
- [x] TypeScript typecheck clean
- [x] Existing test cases preserved (no regressions)
- [x] New feature filtering tests cover: disable by feature, always-visible items, admin bypass, tenant filtering