### PR TITLE
feat: add base fiat currency foundation patterns

### DIFF
--- a/cookbook/patterns/base-fiat-gbp/manifest-fragment.yaml
+++ b/cookbook/patterns/base-fiat-gbp/manifest-fragment.yaml
@@ -1,0 +1,7 @@
+instruments:
+  - code: GBP
+    name: British Pound Sterling
+    type: INSTRUMENT_TYPE_FIAT
+    dimensions:
+      unit: GBP
+      precision: 2

--- a/cookbook/patterns/base-fiat-gbp/pattern.json
+++ b/cookbook/patterns/base-fiat-gbp/pattern.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+    "name": "base-fiat-gbp",
+    "type": "registry:pattern",
+    "title": "Base Fiat Currency (GBP)",
+    "description": "Foundation instrument for British Pound Sterling. Provides GBP instrument with standard 2-decimal precision.",
+    "registryDependencies": [],
+    "categories": ["foundation", "fiat", "currency"],
+    "meta": {
+        "complexity": 1,
+        "design_pattern": null,
+        "industries": ["all"],
+        "provides": {
+            "instruments": ["GBP"],
+            "account_types": [],
+            "sagas": [],
+            "valuation_rules": [],
+            "triggers": []
+        },
+        "requires": {
+            "instruments": [],
+            "market_data": []
+        },
+        "composes_with": ["energy-settlement", "saas-billing", "carbon-offset", "precious-metals"],
+        "conflicts_with": [],
+        "extends": []
+    },
+    "files": [
+        {
+            "path": "patterns/base-fiat-gbp/manifest-fragment.yaml",
+            "type": "registry:file",
+            "target": "~/manifest-fragment.yaml"
+        }
+    ]
+}

--- a/cookbook/patterns/base-fiat-usd/manifest-fragment.yaml
+++ b/cookbook/patterns/base-fiat-usd/manifest-fragment.yaml
@@ -1,0 +1,7 @@
+instruments:
+  - code: USD
+    name: United States Dollar
+    type: INSTRUMENT_TYPE_FIAT
+    dimensions:
+      unit: USD
+      precision: 2

--- a/cookbook/patterns/base-fiat-usd/pattern.json
+++ b/cookbook/patterns/base-fiat-usd/pattern.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+    "name": "base-fiat-usd",
+    "type": "registry:pattern",
+    "title": "Base Fiat Currency (USD)",
+    "description": "Foundation instrument for United States Dollar. Provides USD instrument with standard 2-decimal precision.",
+    "registryDependencies": [],
+    "categories": ["foundation", "fiat", "currency"],
+    "meta": {
+        "complexity": 1,
+        "design_pattern": null,
+        "industries": ["all"],
+        "provides": {
+            "instruments": ["USD"],
+            "account_types": [],
+            "sagas": [],
+            "valuation_rules": [],
+            "triggers": []
+        },
+        "requires": {
+            "instruments": [],
+            "market_data": []
+        },
+        "composes_with": ["energy-settlement", "saas-billing", "carbon-offset", "precious-metals"],
+        "conflicts_with": [],
+        "extends": []
+    },
+    "files": [
+        {
+            "path": "patterns/base-fiat-usd/manifest-fragment.yaml",
+            "type": "registry:file",
+            "target": "~/manifest-fragment.yaml"
+        }
+    ]
+}

--- a/cookbook/patterns/patterns_test.go
+++ b/cookbook/patterns/patterns_test.go
@@ -1,0 +1,284 @@
+package patterns_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// patternsDir returns the absolute path to the patterns directory.
+func patternsDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller failed")
+	return filepath.Dir(file)
+}
+
+// schemaDir returns the absolute path to the schema directory.
+func schemaDir(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(patternsDir(t), "..", "schema")
+}
+
+// compileSchema loads and compiles a JSON Schema file.
+func compileSchema(t *testing.T, filename string) *jsonschema.Schema {
+	t.Helper()
+	path := filepath.Join(schemaDir(t), filename)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "failed to read schema file %s", filename)
+
+	compiler := jsonschema.NewCompiler()
+	compiler.Draft = jsonschema.Draft7
+
+	uri := "file:///" + strings.TrimPrefix(filepath.ToSlash(path), "/")
+	err = compiler.AddResource(uri, strings.NewReader(string(data)))
+	require.NoError(t, err)
+
+	s, err := compiler.Compile(uri)
+	require.NoError(t, err)
+	return s
+}
+
+// loadPatternJSON reads and unmarshals a pattern.json file.
+func loadPatternJSON(t *testing.T, patternName string) map[string]any {
+	t.Helper()
+	path := filepath.Join(patternsDir(t), patternName, "pattern.json")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "failed to read pattern.json for %s", patternName)
+
+	var v map[string]any
+	require.NoError(t, json.Unmarshal(data, &v))
+	return v
+}
+
+// validatePatternJSON validates a pattern.json against the registry-item.json schema.
+func validatePatternJSON(t *testing.T, s *jsonschema.Schema, patternName string) {
+	t.Helper()
+	path := filepath.Join(patternsDir(t), patternName, "pattern.json")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var v any
+	require.NoError(t, json.Unmarshal(data, &v))
+	err = s.Validate(v)
+	assert.NoError(t, err, "pattern.json for %s should be valid against registry-item.json schema", patternName)
+}
+
+// loadManifestFragment reads and parses the manifest-fragment.yaml for a pattern.
+func loadManifestFragment(t *testing.T, patternName string) map[string]any {
+	t.Helper()
+	path := filepath.Join(patternsDir(t), patternName, "manifest-fragment.yaml")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "failed to read manifest-fragment.yaml for %s", patternName)
+
+	var v map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &v))
+	return v
+}
+
+// --- base-fiat-gbp tests ---
+
+func TestBaseFiatGBP_PatternJSONValidatesAgainstSchema(t *testing.T) {
+	s := compileSchema(t, "registry-item.json")
+	validatePatternJSON(t, s, "base-fiat-gbp")
+}
+
+func TestBaseFiatGBP_ManifestFragmentIsValidYAML(t *testing.T) {
+	fragment := loadManifestFragment(t, "base-fiat-gbp")
+	require.NotNil(t, fragment, "manifest-fragment.yaml should not be empty")
+}
+
+func TestBaseFiatGBP_ManifestFragmentContainsGBPInstrument(t *testing.T) {
+	fragment := loadManifestFragment(t, "base-fiat-gbp")
+
+	instruments, ok := fragment["instruments"].([]any)
+	require.True(t, ok, "manifest-fragment.yaml should have an instruments list")
+	require.Len(t, instruments, 1, "base-fiat-gbp should define exactly one instrument")
+
+	instrument, ok := instruments[0].(map[string]any)
+	require.True(t, ok, "instrument entry should be a map")
+	assert.Equal(t, "GBP", instrument["code"], "instrument code should be GBP")
+}
+
+func TestBaseFiatGBP_ProvidesMatchesManifestInstruments(t *testing.T) {
+	pattern := loadPatternJSON(t, "base-fiat-gbp")
+	fragment := loadManifestFragment(t, "base-fiat-gbp")
+
+	meta, ok := pattern["meta"].(map[string]any)
+	require.True(t, ok)
+	provides, ok := meta["provides"].(map[string]any)
+	require.True(t, ok)
+	providedInstruments, ok := provides["instruments"].([]any)
+	require.True(t, ok)
+
+	instruments, ok := fragment["instruments"].([]any)
+	require.True(t, ok)
+
+	require.Equal(t, len(instruments), len(providedInstruments),
+		"provides.instruments count should match instruments in manifest-fragment.yaml")
+
+	fragmentCodes := make(map[string]bool)
+	for _, inst := range instruments {
+		m := inst.(map[string]any)
+		fragmentCodes[m["code"].(string)] = true
+	}
+	for _, code := range providedInstruments {
+		assert.True(t, fragmentCodes[code.(string)],
+			"instrument %q in provides should be present in manifest-fragment.yaml", code)
+	}
+}
+
+func TestBaseFiatGBP_HasEmptyDependencies(t *testing.T) {
+	pattern := loadPatternJSON(t, "base-fiat-gbp")
+
+	deps, ok := pattern["registryDependencies"].([]any)
+	require.True(t, ok, "registryDependencies should be present and an array")
+	assert.Empty(t, deps, "foundation pattern should have no registry dependencies")
+
+	meta, ok := pattern["meta"].(map[string]any)
+	require.True(t, ok)
+	requires, ok := meta["requires"].(map[string]any)
+	require.True(t, ok, "meta.requires should be present")
+
+	instrRequires, ok := requires["instruments"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, instrRequires, "foundation pattern should require no instruments")
+
+	marketRequires, ok := requires["market_data"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, marketRequires, "foundation pattern should require no market_data")
+}
+
+// --- base-fiat-usd tests ---
+
+func TestBaseFiatUSD_PatternJSONValidatesAgainstSchema(t *testing.T) {
+	s := compileSchema(t, "registry-item.json")
+	validatePatternJSON(t, s, "base-fiat-usd")
+}
+
+func TestBaseFiatUSD_ManifestFragmentIsValidYAML(t *testing.T) {
+	fragment := loadManifestFragment(t, "base-fiat-usd")
+	require.NotNil(t, fragment, "manifest-fragment.yaml should not be empty")
+}
+
+func TestBaseFiatUSD_ManifestFragmentContainsUSDInstrument(t *testing.T) {
+	fragment := loadManifestFragment(t, "base-fiat-usd")
+
+	instruments, ok := fragment["instruments"].([]any)
+	require.True(t, ok, "manifest-fragment.yaml should have an instruments list")
+	require.Len(t, instruments, 1, "base-fiat-usd should define exactly one instrument")
+
+	instrument, ok := instruments[0].(map[string]any)
+	require.True(t, ok, "instrument entry should be a map")
+	assert.Equal(t, "USD", instrument["code"], "instrument code should be USD")
+}
+
+func TestBaseFiatUSD_ProvidesMatchesManifestInstruments(t *testing.T) {
+	pattern := loadPatternJSON(t, "base-fiat-usd")
+	fragment := loadManifestFragment(t, "base-fiat-usd")
+
+	meta, ok := pattern["meta"].(map[string]any)
+	require.True(t, ok)
+	provides, ok := meta["provides"].(map[string]any)
+	require.True(t, ok)
+	providedInstruments, ok := provides["instruments"].([]any)
+	require.True(t, ok)
+
+	instruments, ok := fragment["instruments"].([]any)
+	require.True(t, ok)
+
+	require.Equal(t, len(instruments), len(providedInstruments),
+		"provides.instruments count should match instruments in manifest-fragment.yaml")
+
+	fragmentCodes := make(map[string]bool)
+	for _, inst := range instruments {
+		m := inst.(map[string]any)
+		fragmentCodes[m["code"].(string)] = true
+	}
+	for _, code := range providedInstruments {
+		assert.True(t, fragmentCodes[code.(string)],
+			"instrument %q in provides should be present in manifest-fragment.yaml", code)
+	}
+}
+
+func TestBaseFiatUSD_HasEmptyDependencies(t *testing.T) {
+	pattern := loadPatternJSON(t, "base-fiat-usd")
+
+	deps, ok := pattern["registryDependencies"].([]any)
+	require.True(t, ok, "registryDependencies should be present and an array")
+	assert.Empty(t, deps, "foundation pattern should have no registry dependencies")
+
+	meta, ok := pattern["meta"].(map[string]any)
+	require.True(t, ok)
+	requires, ok := meta["requires"].(map[string]any)
+	require.True(t, ok, "meta.requires should be present")
+
+	instrRequires, ok := requires["instruments"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, instrRequires, "foundation pattern should require no instruments")
+
+	marketRequires, ok := requires["market_data"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, marketRequires, "foundation pattern should require no market_data")
+}
+
+// --- registry.json integration tests ---
+
+func TestRegistry_ContainsBaseFiatGBP(t *testing.T) {
+	registryPath := filepath.Join(patternsDir(t), "..", "registry.json")
+	data, err := os.ReadFile(registryPath)
+	require.NoError(t, err)
+
+	var registry map[string]any
+	require.NoError(t, json.Unmarshal(data, &registry))
+
+	items, ok := registry["items"].([]any)
+	require.True(t, ok)
+
+	found := false
+	for _, item := range items {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["name"] == "base-fiat-gbp" {
+			found = true
+			assert.Equal(t, "registry:pattern", m["type"])
+		}
+	}
+	assert.True(t, found, "registry.json should contain base-fiat-gbp entry")
+}
+
+func TestRegistry_ContainsBaseFiatUSD(t *testing.T) {
+	registryPath := filepath.Join(patternsDir(t), "..", "registry.json")
+	data, err := os.ReadFile(registryPath)
+	require.NoError(t, err)
+
+	var registry map[string]any
+	require.NoError(t, json.Unmarshal(data, &registry))
+
+	items, ok := registry["items"].([]any)
+	require.True(t, ok)
+
+	found := false
+	for _, item := range items {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["name"] == "base-fiat-usd" {
+			found = true
+			assert.Equal(t, "registry:pattern", m["type"])
+		}
+	}
+	assert.True(t, found, "registry.json should contain base-fiat-usd entry")
+}

--- a/cookbook/patterns/patterns_test.go
+++ b/cookbook/patterns/patterns_test.go
@@ -107,6 +107,9 @@ func TestBaseFiatGBP_ManifestFragmentContainsGBPInstrument(t *testing.T) {
 	instrument, ok := instruments[0].(map[string]any)
 	require.True(t, ok, "instrument entry should be a map")
 	assert.Equal(t, "GBP", instrument["code"], "instrument code should be GBP")
+	dimensions, ok := instrument["dimensions"].(map[string]any)
+	require.True(t, ok, "instrument should have a dimensions map")
+	assert.EqualValues(t, 2, dimensions["precision"], "instrument precision should be 2")
 }
 
 func TestBaseFiatGBP_ProvidesMatchesManifestInstruments(t *testing.T) {
@@ -185,6 +188,9 @@ func TestBaseFiatUSD_ManifestFragmentContainsUSDInstrument(t *testing.T) {
 	instrument, ok := instruments[0].(map[string]any)
 	require.True(t, ok, "instrument entry should be a map")
 	assert.Equal(t, "USD", instrument["code"], "instrument code should be USD")
+	dimensions, ok := instrument["dimensions"].(map[string]any)
+	require.True(t, ok, "instrument should have a dimensions map")
+	assert.EqualValues(t, 2, dimensions["precision"], "instrument precision should be 2")
 }
 
 func TestBaseFiatUSD_ProvidesMatchesManifestInstruments(t *testing.T) {

--- a/cookbook/patterns/patterns_test.go
+++ b/cookbook/patterns/patterns_test.go
@@ -127,13 +127,18 @@ func TestBaseFiatGBP_ProvidesMatchesManifestInstruments(t *testing.T) {
 		"provides.instruments count should match instruments in manifest-fragment.yaml")
 
 	fragmentCodes := make(map[string]bool)
-	for _, inst := range instruments {
-		m := inst.(map[string]any)
-		fragmentCodes[m["code"].(string)] = true
+	for i, inst := range instruments {
+		m, ok := inst.(map[string]any)
+		require.True(t, ok, "instrument[%d] should be an object", i)
+		c, ok := m["code"].(string)
+		require.True(t, ok, "instrument[%d].code should be a string", i)
+		fragmentCodes[c] = true
 	}
-	for _, code := range providedInstruments {
-		assert.True(t, fragmentCodes[code.(string)],
-			"instrument %q in provides should be present in manifest-fragment.yaml", code)
+	for i, code := range providedInstruments {
+		c, ok := code.(string)
+		require.True(t, ok, "provided instrument[%d] should be a string", i)
+		assert.True(t, fragmentCodes[c],
+			"instrument %q in provides should be present in manifest-fragment.yaml", c)
 	}
 }
 
@@ -200,13 +205,18 @@ func TestBaseFiatUSD_ProvidesMatchesManifestInstruments(t *testing.T) {
 		"provides.instruments count should match instruments in manifest-fragment.yaml")
 
 	fragmentCodes := make(map[string]bool)
-	for _, inst := range instruments {
-		m := inst.(map[string]any)
-		fragmentCodes[m["code"].(string)] = true
+	for i, inst := range instruments {
+		m, ok := inst.(map[string]any)
+		require.True(t, ok, "instrument[%d] should be an object", i)
+		c, ok := m["code"].(string)
+		require.True(t, ok, "instrument[%d].code should be a string", i)
+		fragmentCodes[c] = true
 	}
-	for _, code := range providedInstruments {
-		assert.True(t, fragmentCodes[code.(string)],
-			"instrument %q in provides should be present in manifest-fragment.yaml", code)
+	for i, code := range providedInstruments {
+		c, ok := code.(string)
+		require.True(t, ok, "provided instrument[%d] should be a string", i)
+		assert.True(t, fragmentCodes[c],
+			"instrument %q in provides should be present in manifest-fragment.yaml", c)
 	}
 }
 

--- a/cookbook/registry.json
+++ b/cookbook/registry.json
@@ -2,5 +2,8 @@
     "$schema": "https://cookbook.meridianhub.org/schema/registry.json",
     "name": "meridian-cookbook",
     "homepage": "https://github.com/meridianhub/meridian",
-    "items": []
+    "items": [
+        {"name": "base-fiat-gbp", "type": "registry:pattern", "title": "Base Fiat Currency (GBP)"},
+        {"name": "base-fiat-usd", "type": "registry:pattern", "title": "Base Fiat Currency (USD)"}
+    ]
 }


### PR DESCRIPTION
## Summary

- Adds `base-fiat-gbp` pattern: GBP instrument with 2-decimal precision
- Adds `base-fiat-usd` pattern: USD instrument with 2-decimal precision
- Updates `cookbook/registry.json` with both foundation pattern entries
- Adds `cookbook/patterns/patterns_test.go` with tests covering schema validation, YAML parsing, provides/fragment consistency, and empty dependencies

## Changes Made

- `cookbook/patterns/base-fiat-gbp/pattern.json` — registry item conforming to `registry-item.json` schema
- `cookbook/patterns/base-fiat-gbp/manifest-fragment.yaml` — GBP instrument definition
- `cookbook/patterns/base-fiat-usd/pattern.json` — registry item conforming to `registry-item.json` schema
- `cookbook/patterns/base-fiat-usd/manifest-fragment.yaml` — USD instrument definition
- `cookbook/registry.json` — adds base-fiat-gbp and base-fiat-usd entries
- `cookbook/patterns/patterns_test.go` — test suite for foundation patterns

## Test plan

- [ ] `go test ./cookbook/...` passes locally
- [ ] CI passes