### PR TITLE
feat: add MCP cookbook list and describe tools

### DIFF
--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -78,7 +78,8 @@ func runStdio(logger *slog.Logger, cfg server.Config) error {
 	srv := server.New(tr, cfg, logger)
 
 	// Wire tools, resources, and prompts onto the server.
-	cleanup, err := wireServer(srv, logger)
+	// cookbookFS is nil until the cookbook directory is embedded at build time.
+	cleanup, err := wireServer(srv, logger, nil)
 	if err != nil {
 		return fmt.Errorf("wire server: %w", err)
 	}
@@ -189,7 +190,8 @@ func runSSE(logger *slog.Logger, cfg server.Config) error {
 	srv := server.New(sseTr, cfg, logger)
 
 	// Wire tools, resources, and prompts onto the server.
-	cleanup, wireErr := wireServer(srv, logger)
+	// cookbookFS is nil until the cookbook directory is embedded at build time.
+	cleanup, wireErr := wireServer(srv, logger, nil)
 	if wireErr != nil {
 		return fmt.Errorf("wire server: %w", wireErr)
 	}

--- a/services/mcp-server/cmd/wire.go
+++ b/services/mcp-server/cmd/wire.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"log/slog"
 
 	"google.golang.org/grpc/status"
@@ -33,9 +34,11 @@ import (
 // it creates gRPC clients and wires all remote tools. If not, only local tools
 // (validation, prompts, embedded docs) are registered.
 //
+// cookbookFS provides the cookbook registry filesystem (may be nil to skip cookbook tools).
+//
 // Returns a cleanup function to close the gRPC connection (nil when no
 // connection was established).
-func wireServer(srv *server.MCPServer, logger *slog.Logger) (func(), error) {
+func wireServer(srv *server.MCPServer, logger *slog.Logger, cookbookFS fs.FS) (func(), error) {
 	// Prompts are always available (no external deps).
 	srv.SetPromptRegistry(prompts.NewRegistry())
 
@@ -46,6 +49,10 @@ func wireServer(srv *server.MCPServer, logger *slog.Logger) (func(), error) {
 	if err := tools.RegisterValidationTools(toolReg); err != nil {
 		return nil, fmt.Errorf("register validation tools: %w", err)
 	}
+
+	// Cookbook tools are local (filesystem-based). cookbookFS may be nil if the
+	// cookbook is not embedded in this build; in that case tools are silently skipped.
+	tools.RegisterCookbookTools(toolReg, cookbookFS)
 
 	// Try to connect to the Meridian backend for remote tools.
 	var cleanup func()

--- a/services/mcp-server/internal/tools/cookbook.go
+++ b/services/mcp-server/internal/tools/cookbook.go
@@ -1,0 +1,365 @@
+// Package tools provides the tool registry for the MCP server.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+)
+
+// itemTypePattern is the registry:pattern item type constant.
+const itemTypePattern = "registry:pattern"
+
+// cookbookRegistryItem is a summary entry from cookbook/registry.json.
+type cookbookRegistryItem struct {
+	Name       string   `json:"name"`
+	Type       string   `json:"type"`
+	Title      string   `json:"title"`
+	Categories []string `json:"categories,omitempty"`
+}
+
+// cookbookRegistry is the top-level structure of cookbook/registry.json.
+type cookbookRegistry struct {
+	Name  string                 `json:"name"`
+	Items []cookbookRegistryItem `json:"items"`
+}
+
+// RegisterCookbookTools registers the meridian_cookbook_list and meridian_cookbook_describe
+// tools into the registry. cookbookFS must expose the cookbook directory tree, rooted such that
+// "registry.json", "ui/<name>/component.json" and "patterns/<name>/pattern.json" are resolvable.
+//
+// If cookbookFS is nil the tools are silently skipped.
+func RegisterCookbookTools(registry *Registry, cookbookFS fs.FS) {
+	if cookbookFS == nil {
+		return
+	}
+
+	tools := []Tool{
+		buildCookbookListTool(cookbookFS),
+		buildCookbookDescribeTool(cookbookFS),
+	}
+	for _, t := range tools {
+		if err := registry.Register(t); err != nil {
+			panic(fmt.Sprintf("failed to register cookbook tool %q: %v", t.Name, err))
+		}
+	}
+}
+
+// buildCookbookListTool returns the meridian_cookbook_list tool.
+func buildCookbookListTool(cookbookFS fs.FS) Tool {
+	return Tool{
+		Name:     "meridian_cookbook_list",
+		Category: CategoryRead,
+		Description: "List available Meridian Cookbook entries. " +
+			"Returns registry summary items filtered by type, category, and industry. " +
+			"Use this to discover UI components (registry:ui) and business patterns (registry:pattern).",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"type": map[string]interface{}{
+					"type":        "string",
+					"enum":        []interface{}{"registry:ui", "registry:pattern"},
+					"description": "Filter by item type: UI component or business pattern.",
+				},
+				"category": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter by category tag (e.g. \"payments\", \"energy\"). Case-insensitive substring match.",
+				},
+				"industry": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter patterns by industry (meta.industries). Only applies to registry:pattern items.",
+				},
+			},
+		},
+		Handler: func(_ context.Context, params json.RawMessage) (interface{}, error) {
+			return handleCookbookList(cookbookFS, params)
+		},
+	}
+}
+
+// cookbookListParams holds parsed parameters for meridian_cookbook_list.
+type cookbookListParams struct {
+	Type     string `json:"type"`
+	Category string `json:"category"`
+	Industry string `json:"industry"`
+}
+
+// handleCookbookList implements the meridian_cookbook_list handler logic.
+func handleCookbookList(cookbookFS fs.FS, params json.RawMessage) (interface{}, error) {
+	var p cookbookListParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return map[string]interface{}{
+			"error": fmt.Sprintf("invalid parameters: %s", err.Error()),
+		}, nil
+	}
+
+	reg, err := loadCookbookRegistry(cookbookFS)
+	if err != nil {
+		return map[string]interface{}{
+			"error": fmt.Sprintf("failed to load cookbook registry: %s", err.Error()),
+		}, nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(reg.Items))
+	for _, item := range reg.Items {
+		if !itemPassesFilters(cookbookFS, item, p) {
+			continue
+		}
+		entry := map[string]interface{}{
+			"name":  item.Name,
+			"type":  item.Type,
+			"title": item.Title,
+		}
+		if len(item.Categories) > 0 {
+			entry["categories"] = item.Categories
+		}
+		result = append(result, entry)
+	}
+
+	return map[string]interface{}{
+		"count": len(result),
+		"items": result,
+	}, nil
+}
+
+// itemPassesFilters returns true when item satisfies all active filters in p.
+// All active filters must match (AND logic).
+func itemPassesFilters(cookbookFS fs.FS, item cookbookRegistryItem, p cookbookListParams) bool {
+	if p.Type != "" && item.Type != p.Type {
+		return false
+	}
+	if p.Category != "" && !containsCategory(item.Categories, p.Category) {
+		return false
+	}
+	if p.Industry != "" {
+		// Industry filter only applies to patterns; UI components have no industries.
+		if item.Type != itemTypePattern {
+			return false
+		}
+		match, err := itemMatchesIndustry(cookbookFS, item.Name, p.Industry)
+		if err != nil || !match {
+			return false
+		}
+	}
+	return true
+}
+
+// buildCookbookDescribeTool returns the meridian_cookbook_describe tool.
+func buildCookbookDescribeTool(cookbookFS fs.FS) Tool {
+	return Tool{
+		Name:     "meridian_cookbook_describe",
+		Category: CategoryRead,
+		Description: "Return full details for a specific Meridian Cookbook entry. " +
+			"Loads the complete item definition including metadata and optionally file contents. " +
+			"Use this to retrieve a pattern's manifest fragment or a UI component's configuration.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"name": map[string]interface{}{
+					"type":        "string",
+					"description": "The kebab-case name of the cookbook entry (e.g. \"current-account\").",
+				},
+				"include_files": map[string]interface{}{
+					"type":        "boolean",
+					"description": "Whether to include file contents in the response (default true).",
+				},
+			},
+			"required": []interface{}{"name"},
+		},
+		Handler: func(_ context.Context, params json.RawMessage) (interface{}, error) {
+			return handleCookbookDescribe(cookbookFS, params)
+		},
+	}
+}
+
+// cookbookDescribeParams holds parsed parameters for meridian_cookbook_describe.
+type cookbookDescribeParams struct {
+	Name         string `json:"name"`
+	IncludeFiles *bool  `json:"include_files"`
+}
+
+// handleCookbookDescribe implements the meridian_cookbook_describe handler logic.
+func handleCookbookDescribe(cookbookFS fs.FS, params json.RawMessage) (interface{}, error) {
+	var p cookbookDescribeParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return map[string]interface{}{
+			"error": fmt.Sprintf("invalid parameters: %s", err.Error()),
+		}, nil
+	}
+
+	// Resolve the item entry from the registry to determine its type.
+	reg, err := loadCookbookRegistry(cookbookFS)
+	if err != nil {
+		return map[string]interface{}{
+			"error": fmt.Sprintf("failed to load cookbook registry: %s", err.Error()),
+		}, nil
+	}
+
+	var registryEntry *cookbookRegistryItem
+	for i := range reg.Items {
+		if reg.Items[i].Name == p.Name {
+			registryEntry = &reg.Items[i]
+			break
+		}
+	}
+	if registryEntry == nil {
+		return map[string]interface{}{
+			"error": fmt.Sprintf("cookbook entry %q not found", p.Name),
+		}, nil
+	}
+
+	// Determine detail file path based on type.
+	detailPath := cookbookDetailPath(registryEntry.Type, p.Name)
+	data, err := fs.ReadFile(cookbookFS, detailPath)
+	if err != nil {
+		return map[string]interface{}{
+			"error": fmt.Sprintf("failed to read cookbook entry %q: %s", p.Name, err.Error()),
+		}, nil
+	}
+
+	var detail map[string]interface{}
+	if err := json.Unmarshal(data, &detail); err != nil {
+		return map[string]interface{}{
+			"error": fmt.Sprintf("failed to parse cookbook entry %q: %s", p.Name, err.Error()),
+		}, nil
+	}
+
+	// Include file contents by default.
+	includeFiles := true
+	if p.IncludeFiles != nil {
+		includeFiles = *p.IncludeFiles
+	}
+
+	if !includeFiles {
+		// Strip file content fields but keep file metadata.
+		stripFileContents(detail)
+	} else {
+		// Embed actual file contents into the "files" array.
+		if err := embedFileContents(cookbookFS, registryEntry.Type, p.Name, detail); err != nil {
+			// Non-fatal: return metadata without contents and note the error.
+			detail["files_error"] = err.Error()
+		}
+	}
+
+	return detail, nil
+}
+
+// loadCookbookRegistry reads and parses the cookbook registry.json from the given fs.
+func loadCookbookRegistry(cookbookFS fs.FS) (*cookbookRegistry, error) {
+	data, err := fs.ReadFile(cookbookFS, "registry.json")
+	if err != nil {
+		return nil, fmt.Errorf("read registry.json: %w", err)
+	}
+	var reg cookbookRegistry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		return nil, fmt.Errorf("parse registry.json: %w", err)
+	}
+	return &reg, nil
+}
+
+// cookbookDetailPath returns the path to the full detail file for a named item.
+func cookbookDetailPath(itemType, name string) string {
+	if itemType == itemTypePattern {
+		return fmt.Sprintf("patterns/%s/pattern.json", name)
+	}
+	return fmt.Sprintf("ui/%s/component.json", name)
+}
+
+// containsCategory reports whether categories contains a case-insensitive match for target.
+func containsCategory(categories []string, target string) bool {
+	targetLower := toLower(target)
+	for _, c := range categories {
+		if toLower(c) == targetLower {
+			return true
+		}
+	}
+	return false
+}
+
+// itemMatchesIndustry loads the full pattern detail and checks meta.industries.
+func itemMatchesIndustry(cookbookFS fs.FS, name, industry string) (bool, error) {
+	data, err := fs.ReadFile(cookbookFS, fmt.Sprintf("patterns/%s/pattern.json", name))
+	if err != nil {
+		return false, err
+	}
+	var detail struct {
+		Meta struct {
+			Industries []string `json:"industries"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal(data, &detail); err != nil {
+		return false, err
+	}
+	industryLower := toLower(industry)
+	for _, ind := range detail.Meta.Industries {
+		if toLower(ind) == industryLower {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// stripFileContents removes the "content" field from each entry in the "files" array,
+// preserving path, type, and target metadata.
+func stripFileContents(detail map[string]interface{}) {
+	files, ok := detail["files"].([]interface{})
+	if !ok {
+		return
+	}
+	for _, f := range files {
+		if fm, ok := f.(map[string]interface{}); ok {
+			delete(fm, "content")
+		}
+	}
+}
+
+// embedFileContents reads the content of each file listed in detail["files"] from the filesystem
+// and injects it as a "content" string field.
+func embedFileContents(cookbookFS fs.FS, itemType, name string, detail map[string]interface{}) error {
+	files, ok := detail["files"].([]interface{})
+	if !ok {
+		return nil
+	}
+
+	// Determine the base directory for relative file paths.
+	var baseDir string
+	if itemType == itemTypePattern {
+		baseDir = fmt.Sprintf("patterns/%s", name)
+	} else {
+		baseDir = fmt.Sprintf("ui/%s", name)
+	}
+
+	for _, f := range files {
+		fm, ok := f.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		pathVal, ok := fm["path"].(string)
+		if !ok || pathVal == "" {
+			continue
+		}
+		filePath := fmt.Sprintf("%s/%s", baseDir, pathVal)
+		data, err := fs.ReadFile(cookbookFS, filePath)
+		if err != nil {
+			// Best effort: note missing files but continue.
+			fm["content_error"] = fmt.Sprintf("could not read %q: %s", filePath, err.Error())
+			continue
+		}
+		fm["content"] = string(data)
+	}
+	return nil
+}
+
+// toLower returns a lowercase copy of s without importing strings in the function body.
+func toLower(s string) string {
+	result := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		result[i] = c
+	}
+	return string(result)
+}

--- a/services/mcp-server/internal/tools/cookbook.go
+++ b/services/mcp-server/internal/tools/cookbook.go
@@ -64,7 +64,7 @@ func buildCookbookListTool(cookbookFS fs.FS) Tool {
 				},
 				"category": map[string]interface{}{
 					"type":        "string",
-					"description": "Filter by category tag (e.g. \"payments\", \"energy\"). Case-insensitive substring match.",
+					"description": "Filter by category tag (e.g. \"payments\", \"energy\"). Case-insensitive exact match.",
 				},
 				"industry": map[string]interface{}{
 					"type":        "string",

--- a/services/mcp-server/internal/tools/cookbook_test.go
+++ b/services/mcp-server/internal/tools/cookbook_test.go
@@ -1,0 +1,282 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+)
+
+// newCookbookRegistry creates a test Registry with cookbook tools registered.
+func newCookbookRegistry(t *testing.T) *tools.Registry {
+	t.Helper()
+	r := tools.NewRegistry()
+	fsys := os.DirFS("testdata/cookbook")
+	tools.RegisterCookbookTools(r, fsys)
+	return r
+}
+
+// callCookbookTool calls the given tool with JSON params and returns the result.
+// The result is round-tripped through JSON to normalise types (e.g. int → float64,
+// []map[...]... → []interface{}) matching what an MCP client would see.
+func callCookbookTool(t *testing.T, r *tools.Registry, name string, params string) map[string]interface{} {
+	t.Helper()
+	raw, err := r.Call(context.Background(), name, json.RawMessage(params))
+	if err != nil {
+		t.Fatalf("tool %q call failed: %v", name, err)
+	}
+	// Round-trip through JSON to normalise types.
+	b, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	return m
+}
+
+// --- meridian_cookbook_list tests ---
+
+func TestCookbookList_NoFilter_ReturnsAllEntries(t *testing.T) {
+	r := newCookbookRegistry(t)
+	m := callCookbookTool(t, r, "meridian_cookbook_list", `{}`)
+
+	count, ok := m["count"].(float64)
+	if !ok {
+		t.Fatalf("expected count field, got %v", m)
+	}
+	if count != 3 {
+		t.Errorf("expected count=3, got %v", count)
+	}
+	items, ok := m["items"].([]interface{})
+	if !ok || len(items) == 0 {
+		t.Fatalf("expected non-empty items slice, got %T: %v", m["items"], m["items"])
+	}
+}
+
+func TestCookbookList_TypeFilterUI_ReturnsOnlyUI(t *testing.T) {
+	r := newCookbookRegistry(t)
+	m := callCookbookTool(t, r, "meridian_cookbook_list", `{"type": "registry:ui"}`)
+
+	items := m["items"].([]interface{})
+	if len(items) != 1 {
+		t.Fatalf("expected 1 UI item, got %d: %v", len(items), items)
+	}
+	item := items[0].(map[string]interface{})
+	if item["type"] != "registry:ui" {
+		t.Errorf("expected type=registry:ui, got %v", item["type"])
+	}
+	if item["name"] != "account-balance" {
+		t.Errorf("expected name=account-balance, got %v", item["name"])
+	}
+}
+
+func TestCookbookList_TypeFilterPattern_ReturnsOnlyPatterns(t *testing.T) {
+	r := newCookbookRegistry(t)
+	m := callCookbookTool(t, r, "meridian_cookbook_list", `{"type": "registry:pattern"}`)
+
+	items := m["items"].([]interface{})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 pattern items, got %d", len(items))
+	}
+	for _, v := range items {
+		item := v.(map[string]interface{})
+		if item["type"] != "registry:pattern" {
+			t.Errorf("expected type=registry:pattern, got %v", item["type"])
+		}
+	}
+}
+
+func TestCookbookList_CategoryFilter_ReturnsMatchingItems(t *testing.T) {
+	r := newCookbookRegistry(t)
+	m := callCookbookTool(t, r, "meridian_cookbook_list", `{"category": "banking"}`)
+
+	items := m["items"].([]interface{})
+	if len(items) != 1 {
+		t.Fatalf("expected 1 banking item, got %d", len(items))
+	}
+	item := items[0].(map[string]interface{})
+	if item["name"] != "current-account" {
+		t.Errorf("expected name=current-account, got %v", item["name"])
+	}
+}
+
+func TestCookbookList_IndustryFilter_ReturnsMatchingPatterns(t *testing.T) {
+	r := newCookbookRegistry(t)
+	m := callCookbookTool(t, r, "meridian_cookbook_list", `{"industry": "energy"}`)
+
+	items := m["items"].([]interface{})
+	if len(items) != 1 {
+		t.Fatalf("expected 1 energy pattern, got %d", len(items))
+	}
+	item := items[0].(map[string]interface{})
+	if item["name"] != "energy-settlement" {
+		t.Errorf("expected name=energy-settlement, got %v", item["name"])
+	}
+}
+
+func TestCookbookList_IndustryFilter_ExcludesUIItems(t *testing.T) {
+	r := newCookbookRegistry(t)
+	// UI items don't have industries — even without type filter, they should be excluded.
+	m := callCookbookTool(t, r, "meridian_cookbook_list", `{"industry": "banking"}`)
+
+	items := m["items"].([]interface{})
+	for _, v := range items {
+		item := v.(map[string]interface{})
+		if item["type"] == "registry:ui" {
+			t.Errorf("unexpected UI item %v when filtering by industry", item["name"])
+		}
+	}
+}
+
+func TestCookbookList_TypeAndCategoryFilter_ANDLogic(t *testing.T) {
+	r := newCookbookRegistry(t)
+	// registry:pattern AND category=banking → only current-account
+	m := callCookbookTool(t, r, "meridian_cookbook_list", `{"type": "registry:pattern", "category": "banking"}`)
+
+	items := m["items"].([]interface{})
+	if len(items) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(items))
+	}
+	item := items[0].(map[string]interface{})
+	if item["name"] != "current-account" {
+		t.Errorf("expected current-account, got %v", item["name"])
+	}
+}
+
+func TestCookbookList_NonexistentCategory_ReturnsEmpty(t *testing.T) {
+	r := newCookbookRegistry(t)
+	m := callCookbookTool(t, r, "meridian_cookbook_list", `{"category": "nonexistent-xyz"}`)
+
+	items, ok := m["items"].([]interface{})
+	if !ok {
+		t.Fatalf("expected items field")
+	}
+	if len(items) != 0 {
+		t.Errorf("expected 0 items for nonexistent category, got %d", len(items))
+	}
+	if count := m["count"].(float64); count != 0 {
+		t.Errorf("expected count=0, got %v", count)
+	}
+}
+
+// --- meridian_cookbook_describe tests ---
+
+func TestCookbookDescribe_UIComponent_ReturnsFullMetadata(t *testing.T) {
+	r := newCookbookRegistry(t)
+	m := callCookbookTool(t, r, "meridian_cookbook_describe", `{"name": "account-balance"}`)
+
+	if m["name"] != "account-balance" {
+		t.Errorf("expected name=account-balance, got %v", m["name"])
+	}
+	if m["type"] != "registry:ui" {
+		t.Errorf("expected type=registry:ui, got %v", m["type"])
+	}
+	if m["description"] == nil || m["description"] == "" {
+		t.Error("expected non-empty description")
+	}
+	meta, ok := m["meta"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected meta field, got %T", m["meta"])
+	}
+	if meta["feature_module"] == nil {
+		t.Error("expected feature_module in meta")
+	}
+}
+
+func TestCookbookDescribe_Pattern_ReturnsMetadataWithFiles(t *testing.T) {
+	r := newCookbookRegistry(t)
+	m := callCookbookTool(t, r, "meridian_cookbook_describe", `{"name": "current-account"}`)
+
+	if m["name"] != "current-account" {
+		t.Errorf("expected name=current-account, got %v", m["name"])
+	}
+
+	files, ok := m["files"].([]interface{})
+	if !ok || len(files) == 0 {
+		t.Fatalf("expected files slice, got %T: %v", m["files"], m["files"])
+	}
+
+	// With include_files default (true), file content should be embedded.
+	file := files[0].(map[string]interface{})
+	if file["content"] == nil {
+		t.Error("expected file content to be embedded by default")
+	}
+	content, ok := file["content"].(string)
+	if !ok || content == "" {
+		t.Error("expected non-empty file content string")
+	}
+}
+
+func TestCookbookDescribe_IncludeFilesFalse_OmitsContent(t *testing.T) {
+	r := newCookbookRegistry(t)
+	m := callCookbookTool(t, r, "meridian_cookbook_describe", `{"name": "current-account", "include_files": false}`)
+
+	files, ok := m["files"].([]interface{})
+	if !ok || len(files) == 0 {
+		t.Fatalf("expected files slice")
+	}
+
+	file := files[0].(map[string]interface{})
+	if _, hasContent := file["content"]; hasContent {
+		t.Error("expected file content to be absent when include_files=false")
+	}
+	// Path metadata should still be present.
+	if file["path"] == nil {
+		t.Error("expected path field even when content is omitted")
+	}
+}
+
+func TestCookbookDescribe_NonexistentEntry_ReturnsError(t *testing.T) {
+	r := newCookbookRegistry(t)
+	m := callCookbookTool(t, r, "meridian_cookbook_describe", `{"name": "does-not-exist"}`)
+
+	if m["error"] == nil {
+		t.Error("expected error field for nonexistent entry")
+	}
+}
+
+// --- Registration tests ---
+
+func TestCookbookTools_Registered(t *testing.T) {
+	r := newCookbookRegistry(t)
+
+	listed := r.List()
+	names := make(map[string]bool)
+	for _, tool := range listed {
+		names[tool.Name] = true
+	}
+
+	required := []string{
+		"meridian_cookbook_list",
+		"meridian_cookbook_describe",
+	}
+	for _, name := range required {
+		if !names[name] {
+			t.Errorf("expected tool %q to be registered", name)
+		}
+	}
+}
+
+func TestCookbookTools_NilFS_SkipsRegistration(t *testing.T) {
+	r := tools.NewRegistry()
+	tools.RegisterCookbookTools(r, nil)
+
+	if len(r.List()) != 0 {
+		t.Error("expected no tools registered when cookbookFS is nil")
+	}
+}
+
+func TestCookbookTools_CorrectCategory(t *testing.T) {
+	r := newCookbookRegistry(t)
+
+	for _, tool := range r.List() {
+		if tool.Category != tools.CategoryRead {
+			t.Errorf("tool %q: expected CategoryRead, got %v", tool.Name, tool.Category)
+		}
+	}
+}

--- a/services/mcp-server/internal/tools/testdata/cookbook/patterns/current-account/manifest.yaml
+++ b/services/mcp-server/internal/tools/testdata/cookbook/patterns/current-account/manifest.yaml
@@ -1,0 +1,6 @@
+instruments:
+  - code: GBP
+    type: currency
+account_types:
+  - code: CURRENT_ACCOUNT
+    label: Current Account

--- a/services/mcp-server/internal/tools/testdata/cookbook/patterns/current-account/pattern.json
+++ b/services/mcp-server/internal/tools/testdata/cookbook/patterns/current-account/pattern.json
@@ -1,0 +1,23 @@
+{
+    "name": "current-account",
+    "type": "registry:pattern",
+    "title": "Current Account",
+    "description": "Standard current account with debit/credit posting and overdraft.",
+    "categories": ["accounts", "banking"],
+    "meta": {
+        "complexity": 3,
+        "industries": ["banking", "fintech"],
+        "design_pattern": "double-entry",
+        "provides": {
+            "instruments": ["GBP"],
+            "account_types": ["CURRENT_ACCOUNT"],
+            "sagas": ["current_account_deposit", "current_account_withdrawal"]
+        }
+    },
+    "files": [
+        {
+            "path": "manifest.yaml",
+            "type": "registry:file"
+        }
+    ]
+}

--- a/services/mcp-server/internal/tools/testdata/cookbook/patterns/energy-settlement/manifest.yaml
+++ b/services/mcp-server/internal/tools/testdata/cookbook/patterns/energy-settlement/manifest.yaml
@@ -1,0 +1,6 @@
+instruments:
+  - code: KWH
+    type: energy
+account_types:
+  - code: ENERGY_ACCOUNT
+    label: Energy Account

--- a/services/mcp-server/internal/tools/testdata/cookbook/patterns/energy-settlement/pattern.json
+++ b/services/mcp-server/internal/tools/testdata/cookbook/patterns/energy-settlement/pattern.json
@@ -1,0 +1,23 @@
+{
+    "name": "energy-settlement",
+    "type": "registry:pattern",
+    "title": "Energy Settlement",
+    "description": "Bilateral energy settlement with estimate-to-actual reconciliation.",
+    "categories": ["energy", "settlement"],
+    "meta": {
+        "complexity": 5,
+        "industries": ["energy", "utilities"],
+        "design_pattern": "temporal-quality-ladder",
+        "provides": {
+            "instruments": ["KWH"],
+            "account_types": ["ENERGY_ACCOUNT"],
+            "sagas": ["energy_settlement"]
+        }
+    },
+    "files": [
+        {
+            "path": "manifest.yaml",
+            "type": "registry:file"
+        }
+    ]
+}

--- a/services/mcp-server/internal/tools/testdata/cookbook/registry.json
+++ b/services/mcp-server/internal/tools/testdata/cookbook/registry.json
@@ -1,0 +1,23 @@
+{
+    "name": "meridian-cookbook-test",
+    "items": [
+        {
+            "name": "account-balance",
+            "type": "registry:ui",
+            "title": "Account Balance Widget",
+            "categories": ["accounts", "dashboard"]
+        },
+        {
+            "name": "current-account",
+            "type": "registry:pattern",
+            "title": "Current Account",
+            "categories": ["accounts", "banking"]
+        },
+        {
+            "name": "energy-settlement",
+            "type": "registry:pattern",
+            "title": "Energy Settlement",
+            "categories": ["energy", "settlement"]
+        }
+    ]
+}

--- a/services/mcp-server/internal/tools/testdata/cookbook/ui/account-balance/balance.tsx
+++ b/services/mcp-server/internal/tools/testdata/cookbook/ui/account-balance/balance.tsx
@@ -1,0 +1,4 @@
+// AccountBalance component stub
+export function AccountBalance({ accountId }: { accountId: string }) {
+    return <div>{accountId}</div>;
+}

--- a/services/mcp-server/internal/tools/testdata/cookbook/ui/account-balance/component.json
+++ b/services/mcp-server/internal/tools/testdata/cookbook/ui/account-balance/component.json
@@ -1,0 +1,18 @@
+{
+    "name": "account-balance",
+    "type": "registry:ui",
+    "title": "Account Balance Widget",
+    "description": "Displays the current balance of an account with currency formatting.",
+    "categories": ["accounts", "dashboard"],
+    "meta": {
+        "feature_module": "position-keeping",
+        "tenant_configurable": true,
+        "configurable_props": ["currency", "show_available"]
+    },
+    "files": [
+        {
+            "path": "balance.tsx",
+            "type": "registry:file"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

- Adds `meridian_cookbook_list` tool: reads `cookbook/registry.json` and returns filtered entries supporting type (`registry:ui` or `registry:pattern`), category (case-insensitive), and industry (patterns only) filters with AND logic
- Adds `meridian_cookbook_describe` tool: loads full entry from `ui/<name>/component.json` or `patterns/<name>/pattern.json`, with optional file content embedding (default true)
- Both tools use an injected `fs.FS` for testability; `nil` gracefully skips registration
- Wires `RegisterCookbookTools` into `wireServer()` via a new `cookbookFS fs.FS` parameter (passed as `nil` until the cookbook directory is ready for embedding)

## Changes Made

- `services/mcp-server/internal/tools/cookbook.go` — new file with `RegisterCookbookTools`, list and describe handlers
- `services/mcp-server/internal/tools/cookbook_test.go` — 14 tests covering all filter combinations, describe with/without files, error cases, and registration
- `services/mcp-server/internal/tools/testdata/cookbook/` — self-contained test fixtures (2 patterns, 1 UI component)
- `services/mcp-server/cmd/wire.go` — accepts `cookbookFS fs.FS` parameter, registers cookbook tools
- `services/mcp-server/cmd/main.go` — passes `nil` cookbookFS to `wireServer`

## Test Plan

- [x] `go test ./services/mcp-server/...` — all tests pass
- [x] `golangci-lint` — zero issues
- [x] No filter returns all 3 test entries
- [x] Type filter returns only matching type
- [x] Category filter returns case-insensitive match
- [x] Industry filter excludes UI items, matches pattern meta.industries
- [x] Combined filters use AND logic
- [x] Nonexistent category returns empty result
- [x] Describe returns full metadata with embedded file contents by default
- [x] `include_files=false` omits content but preserves path metadata
- [x] Nonexistent entry returns structured error field
- [x] Nil FS skips registration silently

## Known Conflict Patterns

The `cookbook.go` file is additive — task-11 adds a `meridian_cookbook_discover` tool. Accept both sides on merge conflicts. The tool registration in `wire.go` similarly accepts both registration calls.