### PR TITLE
feat: add 9 economy pattern cookbook entries

### DIFF
--- a/cookbook/patterns/carbon-offset/manifest-fragment.yaml
+++ b/cookbook/patterns/carbon-offset/manifest-fragment.yaml
@@ -1,0 +1,55 @@
+instruments:
+  - code: TONNE_CO2E
+    name: Tonne of CO2 Equivalent
+    type: INSTRUMENT_TYPE_COMMODITY
+    dimensions:
+      unit: tCO2e
+      precision: 3
+  - code: VER
+    name: Verified Emission Reduction
+    type: INSTRUMENT_TYPE_VOUCHER
+    dimensions:
+      unit: VER
+      precision: 0
+  - code: CER
+    name: Certified Emission Reduction
+    type: INSTRUMENT_TYPE_VOUCHER
+    dimensions:
+      unit: CER
+      precision: 0
+
+accountTypes:
+  - code: CARBON_INVENTORY
+    name: Carbon Credit Inventory
+    normalBalance: NORMAL_BALANCE_DEBIT
+    allowedInstruments: [TONNE_CO2E, VER, CER]
+    policies:
+      validation: "amount > 0"
+      bucketing: "instrument_code + ':' + attributes.vintage_year + ':' + attributes.project_id"
+  - code: RETIREMENT
+    name: Retirement Account
+    normalBalance: NORMAL_BALANCE_DEBIT
+    allowedInstruments: [TONNE_CO2E, VER, CER]
+    policies:
+      validation: "amount > 0"
+      bucketing: "instrument_code + ':' + attributes.vintage_year + ':' + attributes.retirement_reason"
+
+valuationRules:
+  - fromInstrument: VER
+    toInstrument: USD
+    method: VALUATION_METHOD_SPOT_RATE
+    source: verra_registry
+  - fromInstrument: CER
+    toInstrument: USD
+    method: VALUATION_METHOD_SPOT_RATE
+    source: gold_standard_registry
+  - fromInstrument: TONNE_CO2E
+    toInstrument: USD
+    method: VALUATION_METHOD_SPOT_RATE
+    source: eu_ets_spot
+
+sagas:
+  - name: purchase_carbon_credits
+    trigger: "api:/v1/carbon/purchases"
+  - name: retire_carbon_credits
+    trigger: "api:/v1/carbon/retirements"

--- a/cookbook/patterns/carbon-offset/pattern.json
+++ b/cookbook/patterns/carbon-offset/pattern.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+    "name": "carbon-offset",
+    "type": "registry:pattern",
+    "title": "Carbon Credit Registry",
+    "description": "Carbon credit trading and retirement with verified emission reductions (VERs) and certified emission reductions (CERs). Tracks credit provenance by vintage year and project, with a permanent retirement account for irrevocable credit retirement.",
+    "registryDependencies": ["base-fiat-usd"],
+    "categories": ["economy", "carbon", "sustainability", "trading"],
+    "meta": {
+        "complexity": 5,
+        "design_pattern": "credit-retirement-lifecycle",
+        "industries": ["energy", "sustainability"],
+        "provides": {
+            "instruments": ["TONNE_CO2E", "VER", "CER"],
+            "account_types": ["CARBON_INVENTORY", "RETIREMENT"],
+            "sagas": ["purchase_carbon_credits", "retire_carbon_credits"],
+            "valuation_rules": ["VER->USD", "CER->USD", "TONNE_CO2E->USD"],
+            "triggers": ["api:/v1/carbon/purchases", "api:/v1/carbon/retirements"]
+        },
+        "requires": {
+            "instruments": ["USD"],
+            "market_data": ["verra_registry", "gold_standard_registry", "eu_ets_spot"]
+        },
+        "composes_with": ["saas-billing", "precious-metals"],
+        "conflicts_with": [],
+        "extends": ["base-fiat-usd"]
+    },
+    "files": [
+        {
+            "path": "patterns/carbon-offset/manifest-fragment.yaml",
+            "type": "registry:file",
+            "target": "~/manifest-fragment.yaml"
+        }
+    ]
+}

--- a/cookbook/patterns/dynamic-capacity-pricing/dynamic_capacity_billing.star
+++ b/cookbook/patterns/dynamic-capacity-pricing/dynamic_capacity_billing.star
@@ -1,0 +1,109 @@
+# Saga: dynamic_capacity_billing
+# Version: 2.0.0
+# Previous: 1.0.0
+# Changed: Thin event pattern — resolve billing account and region from entity graph
+# Author: Tenant Configuration (Cloud Compute)
+# Date: 2026-03-03
+#
+# Dynamic regional pricing for compute tokens. Bills token consumption at
+# rates derived from the platform's own utilisation forecasts per data centre
+# region — creating a feedback loop where usage patterns drive pricing, and
+# pricing shapes usage patterns.
+#
+# The feedback loop:
+#   1. TOKEN positions accumulate per region (position-keeping)
+#   2. Forecasting Service analyses historical utilisation to generate
+#      demand curves per region (forecasting -> market-data)
+#   3. This saga reads the regional dynamic price at the consumption timestamp
+#      and bills accordingly (market-data -> position-keeping)
+#   4. The resulting charges are also positions, closing the loop
+#
+# Trigger: event:position-keeping.transaction-captured.v1
+# Filter:  event.instrument_code == 'TOKEN' && event.direction == 'DEBIT'
+#
+# Account model:
+#   - Usage Account (TOKEN): source transaction (token consumption)
+#   - Billing Account (USD): dynamic charge at regional rate
+#
+# The saga queries Market Data directly for the regional price observation
+# at the consumption timestamp, rather than delegating to the valuation engine.
+# This demonstrates the market data query pattern for time-and-region-specific
+# dynamic pricing.
+#
+# Input data (from TransactionCapturedEvent via AsyncAPI-driven deserialization):
+#   - correlation_id: string - Idempotency key from standard headers
+#   - account_id: string - The usage account that triggered the event
+#   - instrument_amount: dict - Multi-asset amount {amount, instrument_code}
+#   - timestamp: string - ISO 8601 timestamp of consumption
+#
+# Entity graph resolution (via service module calls):
+#   - billing_account_id: from account.metadata
+#   - region_code: from account.metadata (each usage account is per-region)
+
+# Define the saga
+dynamic_billing_saga = saga(name="dynamic_capacity_billing")
+
+def execute_dynamic_billing():
+    ctx = input_data
+
+    correlation_id = ctx["correlation_id"]
+    source_account_id = ctx["account_id"]
+    tokens = Decimal(ctx["instrument_amount"]["amount"])
+    consumption_time = ctx["timestamp"]
+
+    # Resolve account details from entity graph.
+    # Each usage account is scoped to a specific data centre region.
+    # The region_code in account metadata determines which price curve to query.
+    step(name="lookup_account")
+    account = reference_data.get_account(id=source_account_id)
+
+    billing_account_id = account.metadata["billing_account_id"]
+    region_code = account.metadata["region_code"]
+
+    # Idempotency check
+    step(name="check_idempotency")
+    existing = position_keeping.query_logs(
+        correlation_id=correlation_id,
+        instrument_code="USD",
+        account_id=billing_account_id,
+    )
+
+    if existing.count > 0:
+        return {"status": "ALREADY_BILLED", "correlation_id": correlation_id}
+
+    # Query the regional dynamic price from Market Data.
+    # The dataset code encodes the region: TOKEN_PRICE_{REGION}.
+    # The Forecasting Service publishes these as ESTIMATE quality observations
+    # derived from the platform's own utilisation data.
+    dataset_code = "TOKEN_PRICE_" + region_code
+    step(name="lookup_regional_price")
+    price_observation = market_data.get_observation(
+        dataset_code=dataset_code,
+        effective_at=consumption_time,
+    )
+
+    # Compute charge: tokens x dynamic regional rate
+    rate = Decimal(price_observation.value)
+    charge_amount = tokens * rate
+
+    # Book USD charge on customer billing account
+    step(name="book_charge")
+    position_keeping.initiate_log(
+        account_id=billing_account_id,
+        instrument_code="USD",
+        direction="DEBIT",
+        amount=charge_amount,
+        correlation_id=correlation_id,
+        description="Dynamic rate: " + region_code + " @ " + str(rate),
+    )
+
+    return {
+        "status": "BILLED",
+        "amount": str(charge_amount),
+        "rate": str(rate),
+        "region": region_code,
+        "correlation_id": correlation_id,
+    }
+
+# Execute the saga
+output = execute_dynamic_billing()

--- a/cookbook/patterns/dynamic-capacity-pricing/manifest-fragment.yaml
+++ b/cookbook/patterns/dynamic-capacity-pricing/manifest-fragment.yaml
@@ -1,0 +1,12 @@
+instruments:
+  - code: TOKEN
+    name: Compute Token
+    type: INSTRUMENT_TYPE_COMMODITY
+    dimensions:
+      unit: tokens
+      precision: 0
+
+sagas:
+  - name: dynamic_capacity_billing
+    trigger: "event:position-keeping.transaction-captured.v1"
+    filter: "event.instrument_code == 'TOKEN' && event.direction == 'DEBIT'"

--- a/cookbook/patterns/dynamic-capacity-pricing/pattern.json
+++ b/cookbook/patterns/dynamic-capacity-pricing/pattern.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+    "name": "dynamic-capacity-pricing",
+    "type": "registry:pattern",
+    "title": "Dynamic Capacity Pricing",
+    "description": "Self-referential feedback loop pricing for compute tokens. Bills token consumption at rates derived from the platform's own utilisation forecasts per data centre region. Usage patterns drive pricing, and pricing shapes usage patterns.",
+    "registryDependencies": ["base-fiat-usd"],
+    "categories": ["economy", "compute", "pricing", "dynamic"],
+    "meta": {
+        "complexity": 5,
+        "design_pattern": "feedback-loop-pricing",
+        "industries": ["cloud", "infrastructure"],
+        "provides": {
+            "instruments": ["TOKEN"],
+            "account_types": [],
+            "sagas": ["dynamic_capacity_billing"],
+            "valuation_rules": [],
+            "triggers": ["event:position-keeping.transaction-captured.v1"]
+        },
+        "requires": {
+            "instruments": ["USD"],
+            "market_data": ["TOKEN_PRICE_{REGION}"]
+        },
+        "composes_with": ["saas-billing"],
+        "conflicts_with": [],
+        "extends": ["base-fiat-usd"]
+    },
+    "files": [
+        {
+            "path": "patterns/dynamic-capacity-pricing/manifest-fragment.yaml",
+            "type": "registry:file",
+            "target": "~/manifest-fragment.yaml"
+        },
+        {
+            "path": "patterns/dynamic-capacity-pricing/dynamic_capacity_billing.star",
+            "type": "registry:file",
+            "target": "~/sagas/dynamic_capacity_billing.star"
+        }
+    ]
+}

--- a/cookbook/patterns/entity-distribution/manifest-fragment.yaml
+++ b/cookbook/patterns/entity-distribution/manifest-fragment.yaml
@@ -1,0 +1,4 @@
+sagas:
+  - name: race_result_distribution
+    trigger: "event:market-information.observation-recorded.v1"
+    filter: "event.dataset_code == 'HORSE_RACING' && event.quality == 'ACTUAL'"

--- a/cookbook/patterns/entity-distribution/pattern.json
+++ b/cookbook/patterns/entity-distribution/pattern.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+    "name": "entity-distribution",
+    "type": "registry:pattern",
+    "title": "Entity Hierarchy Distribution",
+    "description": "Distributes value across a party hierarchy based on structuring data (allocation shares). Triggered by market data events, traverses the party organization graph to find participants and their payout ratios, then books proportional position logs for each participant.",
+    "registryDependencies": ["base-fiat-gbp"],
+    "categories": ["economy", "distribution", "party-hierarchy", "event-driven"],
+    "meta": {
+        "complexity": 5,
+        "design_pattern": "party-hierarchy-distribution",
+        "industries": ["gaming", "syndication"],
+        "provides": {
+            "instruments": [],
+            "account_types": [],
+            "sagas": ["race_result_distribution"],
+            "valuation_rules": [],
+            "triggers": ["event:market-information.observation-recorded.v1"]
+        },
+        "requires": {
+            "instruments": ["GBP"],
+            "market_data": ["HORSE_RACING"]
+        },
+        "composes_with": ["kyc-compliance"],
+        "conflicts_with": [],
+        "extends": ["base-fiat-gbp"]
+    },
+    "files": [
+        {
+            "path": "patterns/entity-distribution/manifest-fragment.yaml",
+            "type": "registry:file",
+            "target": "~/manifest-fragment.yaml"
+        },
+        {
+            "path": "patterns/entity-distribution/race_result_distribution.star",
+            "type": "registry:file",
+            "target": "~/sagas/race_result_distribution.star"
+        }
+    ]
+}

--- a/cookbook/patterns/entity-distribution/race_result_distribution.star
+++ b/cookbook/patterns/entity-distribution/race_result_distribution.star
@@ -1,0 +1,110 @@
+# Saga: race_result_distribution
+# Version: 2.0.0
+# Previous: 1.0.0
+# Changed: Thin event pattern — use actual ObservationRecorded proto fields
+# Author: Tenant Configuration (Betting/Syndicate)
+# Date: 2026-03-03
+#
+# Distributes pot winnings across a syndicate's participants when a horse race
+# completes. Demonstrates event-triggered saga with full entity graph traversal:
+# market data event -> party organization lookup -> hierarchy traversal ->
+# structuring data (allocation shares) -> position booking per participant.
+#
+# Trigger: event:market-information.observation-recorded.v1
+# Filter:  event.dataset_code == 'HORSE_RACING' && event.quality == 'ACTUAL'
+#
+# The event originates from market data, not position-keeping. The saga navigates
+# the party hierarchy to determine who gets paid and how much.
+#
+# Input data (from ObservationRecorded via AsyncAPI-driven deserialization):
+#   - correlation_id: string - Idempotency key from standard headers
+#   - observation_id: string (UUID) - Observation identifier
+#   - dataset_code: string - "HORSE_RACING"
+#   - resolution_key_value: string - Race identifier (e.g., "CHELTENHAM-GOLD-CUP-2026")
+#   - observed_at: string - ISO 8601 timestamp of race completion
+#   - quality: string - Quality level ("ACTUAL" for official results)
+#   - value: string - Observation value (total pot amount as decimal string)
+#   - source_id: string (UUID) - Data source identifier
+#   - recorded_at: string - ISO 8601 timestamp of recording
+#
+# Entity graph resolution (via service module calls):
+#   - syndicate party: from reference_data.query(entity_type="party", ...)
+#   - participants: from party.list_participants(org_id, relationship_type)
+#   - allocation shares: from party.get_structuring_data(...)
+#   - payout accounts: from participant metadata
+
+# Define the saga
+race_distribution_saga = saga(name="race_result_distribution")
+
+def execute_race_distribution():
+    ctx = input_data
+
+    correlation_id = ctx["correlation_id"]
+    race_id = ctx["resolution_key_value"]
+    pot = Decimal(ctx["value"])
+
+    # Idempotency check: has this race already been distributed?
+    step(name="check_idempotency")
+    existing = position_keeping.query_logs(
+        correlation_id=correlation_id,
+        instrument_code="GBP",
+    )
+
+    if existing.count > 0:
+        return {"status": "ALREADY_DISTRIBUTED", "correlation_id": correlation_id}
+
+    # Find the syndicate organization that placed bets on this race.
+    # The race identifier from the observation's resolution_key_value
+    # is used to locate the syndicate via reference data query.
+    step(name="find_syndicate")
+    syndicate = reference_data.query(
+        entity_type="party",
+        filter="attributes.active_race_id == '" + race_id + "'",
+    )
+
+    if syndicate.count == 0:
+        return {"status": "NO_SYNDICATE", "race_id": race_id}
+
+    syndicate_party_id = syndicate.items[0].party_id
+
+    # Traverse party hierarchy to get all syndicate participants
+    step(name="list_participants")
+    participants = party.list_participants(
+        org_id=syndicate_party_id,
+        relationship_type="SYNDICATE_PARTICIPANT",
+    )
+
+    # Distribute pot by allocation share
+    distributed_count = 0
+
+    for p in participants:
+        step(name="get_structuring_" + str(distributed_count))
+        structuring = party.get_structuring_data(
+            party_id=p.party_id,
+            org_id=syndicate_party_id,
+            relationship_type="SYNDICATE_PARTICIPANT",
+        )
+
+        payout = pot * Decimal(structuring.allocation_share)
+
+        step(name="book_payout_" + str(distributed_count))
+        position_keeping.initiate_log(
+            account_id=p.metadata.payout_account_id,
+            instrument_code="GBP",
+            direction="CREDIT",
+            amount=payout,
+            correlation_id=correlation_id,
+            description="Race " + race_id + " payout: " + str(structuring.allocation_share),
+        )
+
+        distributed_count = distributed_count + 1
+
+    return {
+        "status": "DISTRIBUTED",
+        "race_id": race_id,
+        "participants": distributed_count,
+        "total_pot": str(pot),
+    }
+
+# Execute the saga
+output = execute_race_distribution()

--- a/cookbook/patterns/kyc-compliance/kyc_on_party.star
+++ b/cookbook/patterns/kyc-compliance/kyc_on_party.star
@@ -1,0 +1,134 @@
+# Saga: kyc_on_party
+# Version: 1.1.0
+# Previous: 1.0.0
+# Changed: Use party entity graph as source of truth for jurisdiction_code
+# Author: Tenant Configuration (Financial Services)
+# Date: 2026-03-04
+#
+# Initiates KYC verification workflow when an individual party is created.
+# Demonstrates the entity graph resolution pattern for party-triggered events:
+# resolve party details, check existing KYC state, and book a compliance
+# reserve position to track the outstanding verification obligation.
+#
+# Trigger: event:party.created.v1
+# Filter:  event.party_type == 'INDIVIDUAL'
+#
+# NOTE: The party.created.v1 channel is aspirational — it does not exist in
+# the current event inventory. When implemented, the proto would define fields
+# such as party_id, party_type, and created_at. This example validates the
+# platform's ability to support compliance use cases once the event is defined.
+#
+# Pattern:
+#   1. Resolve party details from entity graph (source of truth for jurisdiction)
+#   2. Idempotency check via position log correlation_id
+#   3. Look up the compliance account for this jurisdiction
+#   4. Book a nominal compliance reserve position (tracks outstanding KYC)
+#
+# The compliance reserve is a GBP position at zero amount used as a durable
+# record that KYC has been triggered for this party. Downstream reconciliation
+# processes query for these positions to drive the KYC workflow.
+#
+# Input data (from hypothetical PartyCreatedEvent):
+#   - correlation_id: string - Idempotency key from standard headers
+#   - party_id: string (UUID) - The newly created party identifier
+#   - party_type: string - Party classification (filtered by CEL to 'INDIVIDUAL')
+#   - created_at: string - ISO 8601 timestamp of party creation
+#
+# Entity graph resolution (via service module calls):
+#   - party details: from party.get(party_id=...)  <-- jurisdiction source of truth
+#   - compliance account: from reference_data.query(entity_type="account", ...)
+
+# Define the saga
+kyc_on_party_saga = saga(name="kyc_on_party")
+
+def execute_kyc_on_party():
+    ctx = input_data
+
+    correlation_id = ctx["correlation_id"]
+    party_id = ctx["party_id"]
+
+    # Resolve the newly created party from the entity graph.
+    # party_details.jurisdiction_code is the source of truth — the event payload
+    # is not trusted for routing decisions because it could diverge from the
+    # party record if the event was replayed or the party was updated.
+    step(name="lookup_party")
+    party_details = party.get(party_id=party_id)
+    jurisdiction_code = party_details.jurisdiction_code
+
+    # Idempotency check: has KYC already been triggered for this party?
+    step(name="check_idempotency")
+    existing = position_keeping.query_logs(
+        correlation_id=correlation_id,
+    )
+
+    if existing.count > 0:
+        return {"status": "ALREADY_INITIATED", "party_id": party_id}
+
+    # Find the compliance account for this jurisdiction.
+    # Each jurisdiction has a dedicated compliance account used to track
+    # outstanding KYC obligations as position logs.
+    #
+    # jurisdiction_code is validated to strictly 2 uppercase ASCII letters (ISO 3166-1
+    # alpha-2, e.g. 'GB', 'US') before embedding in the filter string to prevent
+    # predicate injection. The None/type guard runs first so the length/range checks
+    # only execute on a valid string.
+    step(name="find_compliance_account")
+    valid_jc = (
+        jurisdiction_code != None
+        and type(jurisdiction_code) == type("")
+        and len(jurisdiction_code) == 2
+        and "A" <= jurisdiction_code[0] and jurisdiction_code[0] <= "Z"
+        and "A" <= jurisdiction_code[1] and jurisdiction_code[1] <= "Z"
+    )
+    if not valid_jc:
+        return {
+            "status": "INVALID_JURISDICTION_CODE",
+            "jurisdiction_code": jurisdiction_code,
+            "party_id": party_id,
+        }
+
+    compliance_accounts = reference_data.query(
+        entity_type="account",
+        filter="metadata.jurisdiction_code == '" + jurisdiction_code + "' && metadata.account_purpose == 'KYC_COMPLIANCE'",
+    )
+
+    if compliance_accounts.count == 0:
+        return {
+            "status": "NO_COMPLIANCE_ACCOUNT",
+            "jurisdiction_code": jurisdiction_code,
+            "party_id": party_id,
+        }
+
+    if compliance_accounts.count > 1:
+        return {
+            "status": "AMBIGUOUS_COMPLIANCE_ACCOUNT",
+            "jurisdiction_code": jurisdiction_code,
+            "party_id": party_id,
+        }
+
+    compliance_account_id = compliance_accounts.items[0].account_id
+
+    # Book a compliance reserve position to record the outstanding KYC obligation.
+    # Amount is zero — this is a marker position, not a financial movement.
+    # The position log reference field carries the party_id for downstream lookup.
+    # Description is PII-free; reference=party_id is the linkage for downstream queries.
+    step(name="book_kyc_marker")
+    position_keeping.initiate_log(
+        account_id=compliance_account_id,
+        instrument_code="GBP",
+        direction="DEBIT",
+        amount=Decimal("0"),
+        correlation_id=correlation_id,
+        description="KYC initiated",
+        reference=party_id,
+    )
+
+    return {
+        "status": "KYC_INITIATED",
+        "party_id": party_id,
+        "jurisdiction_code": jurisdiction_code,
+        "compliance_account_id": compliance_account_id,
+    }
+
+# Execute the saga
+output = execute_kyc_on_party()

--- a/cookbook/patterns/kyc-compliance/manifest-fragment.yaml
+++ b/cookbook/patterns/kyc-compliance/manifest-fragment.yaml
@@ -1,0 +1,13 @@
+accountTypes:
+  - code: KYC_COMPLIANCE
+    name: KYC Compliance Obligation Account
+    normalBalance: NORMAL_BALANCE_DEBIT
+    allowedInstruments: [GBP]
+    policies:
+      validation: "amount >= 0"
+      bucketing: ""
+
+sagas:
+  - name: kyc_on_party
+    trigger: "event:party.created.v1"
+    filter: "event.party_type == 'INDIVIDUAL'"

--- a/cookbook/patterns/kyc-compliance/pattern.json
+++ b/cookbook/patterns/kyc-compliance/pattern.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+    "name": "kyc-compliance",
+    "type": "registry:pattern",
+    "title": "KYC Compliance Workflow",
+    "description": "Initiates KYC verification when an individual party is created. Uses the compliance marker pattern: books a zero-amount position log to track outstanding KYC obligations per jurisdiction. Compliance accounts are resolved via entity graph traversal.",
+    "registryDependencies": ["base-fiat-gbp"],
+    "categories": ["economy", "compliance", "kyc", "event-driven"],
+    "meta": {
+        "complexity": 3,
+        "design_pattern": "compliance-marker",
+        "industries": ["banking", "compliance"],
+        "provides": {
+            "instruments": [],
+            "account_types": ["KYC_COMPLIANCE"],
+            "sagas": ["kyc_on_party"],
+            "valuation_rules": [],
+            "triggers": ["event:party.created.v1"]
+        },
+        "requires": {
+            "instruments": ["GBP"],
+            "market_data": []
+        },
+        "composes_with": ["precious-metals", "payment-gateway-stripe"],
+        "conflicts_with": [],
+        "extends": ["base-fiat-gbp"]
+    },
+    "files": [
+        {
+            "path": "patterns/kyc-compliance/manifest-fragment.yaml",
+            "type": "registry:file",
+            "target": "~/manifest-fragment.yaml"
+        },
+        {
+            "path": "patterns/kyc-compliance/kyc_on_party.star",
+            "type": "registry:file",
+            "target": "~/sagas/kyc_on_party.star"
+        }
+    ]
+}

--- a/cookbook/patterns/patterns_test.go
+++ b/cookbook/patterns/patterns_test.go
@@ -247,34 +247,165 @@ func TestBaseFiatUSD_HasEmptyDependencies(t *testing.T) {
 	assert.Empty(t, marketRequires, "foundation pattern should require no market_data")
 }
 
-// --- registry.json integration tests ---
+// --- economy pattern tests (all 9 patterns) ---
 
-func TestRegistry_ContainsBaseFiatGBP(t *testing.T) {
-	registryPath := filepath.Join(patternsDir(t), "..", "registry.json")
-	data, err := os.ReadFile(registryPath)
-	require.NoError(t, err)
-
-	var registry map[string]any
-	require.NoError(t, json.Unmarshal(data, &registry))
-
-	items, ok := registry["items"].([]any)
-	require.True(t, ok)
-
-	found := false
-	for _, item := range items {
-		m, ok := item.(map[string]any)
-		if !ok {
-			continue
-		}
-		if m["name"] == "base-fiat-gbp" {
-			found = true
-			assert.Equal(t, "registry:pattern", m["type"])
-		}
-	}
-	assert.True(t, found, "registry.json should contain base-fiat-gbp entry")
+// allEconomyPatterns lists all economy pattern names that should exist.
+var allEconomyPatterns = []string{
+	"saas-billing",
+	"carbon-offset",
+	"precious-metals",
+	"time-of-use-pricing",
+	"dynamic-capacity-pricing",
+	"kyc-compliance",
+	"payment-gateway-stripe",
+	"entity-distribution",
+	"phantom-cost-basis",
 }
 
-func TestRegistry_ContainsBaseFiatUSD(t *testing.T) {
+func TestEconomyPatterns_PatternJSONValidatesAgainstSchema(t *testing.T) {
+	s := compileSchema(t, "registry-item.json")
+	for _, name := range allEconomyPatterns {
+		t.Run(name, func(t *testing.T) {
+			validatePatternJSON(t, s, name)
+		})
+	}
+}
+
+func TestEconomyPatterns_ManifestFragmentIsValidYAML(t *testing.T) {
+	for _, name := range allEconomyPatterns {
+		t.Run(name, func(t *testing.T) {
+			fragment := loadManifestFragment(t, name)
+			require.NotNil(t, fragment, "manifest-fragment.yaml should not be empty")
+		})
+	}
+}
+
+func TestEconomyPatterns_TypeIsRegistryPattern(t *testing.T) {
+	for _, name := range allEconomyPatterns {
+		t.Run(name, func(t *testing.T) {
+			pattern := loadPatternJSON(t, name)
+			assert.Equal(t, "registry:pattern", pattern["type"])
+		})
+	}
+}
+
+func TestEconomyPatterns_HasRequiredMetaFields(t *testing.T) {
+	for _, name := range allEconomyPatterns {
+		t.Run(name, func(t *testing.T) {
+			pattern := loadPatternJSON(t, name)
+			meta, ok := pattern["meta"].(map[string]any)
+			require.True(t, ok, "meta should be present")
+
+			_, ok = meta["complexity"]
+			assert.True(t, ok, "meta.complexity should be present")
+
+			_, ok = meta["industries"]
+			assert.True(t, ok, "meta.industries should be present")
+
+			provides, ok := meta["provides"].(map[string]any)
+			require.True(t, ok, "meta.provides should be present")
+			_, ok = provides["instruments"]
+			assert.True(t, ok, "meta.provides.instruments should be present")
+			_, ok = provides["sagas"]
+			assert.True(t, ok, "meta.provides.sagas should be present")
+		})
+	}
+}
+
+func TestEconomyPatterns_ProvidesInstrumentsMatchManifest(t *testing.T) {
+	for _, name := range allEconomyPatterns {
+		t.Run(name, func(t *testing.T) {
+			pattern := loadPatternJSON(t, name)
+			fragment := loadManifestFragment(t, name)
+
+			meta := pattern["meta"].(map[string]any)
+			provides := meta["provides"].(map[string]any)
+			providedInstruments, ok := provides["instruments"].([]any)
+			require.True(t, ok)
+
+			// Collect instrument codes from manifest fragment
+			fragmentCodes := make(map[string]bool)
+			if instruments, ok := fragment["instruments"].([]any); ok {
+				for _, inst := range instruments {
+					m, ok := inst.(map[string]any)
+					if !ok {
+						continue
+					}
+					if c, ok := m["code"].(string); ok {
+						fragmentCodes[c] = true
+					}
+				}
+			}
+
+			// All provided instruments should be in the manifest fragment
+			for _, code := range providedInstruments {
+				c, ok := code.(string)
+				require.True(t, ok)
+				assert.True(t, fragmentCodes[c],
+					"instrument %q listed in provides should be in manifest-fragment.yaml", c)
+			}
+		})
+	}
+}
+
+func TestEconomyPatterns_StarFilesExistForSagaPatterns(t *testing.T) {
+	patternsWithStarFiles := map[string][]string{
+		"saas-billing":             {"compute_billing.star"},
+		"precious-metals":          {"valuation_on_capture.star"},
+		"time-of-use-pricing":      {"tou_energy_valuation.star"},
+		"dynamic-capacity-pricing": {"dynamic_capacity_billing.star"},
+		"kyc-compliance":           {"kyc_on_party.star"},
+		"payment-gateway-stripe":   {"stripe_payment_received.star"},
+		"entity-distribution":      {"race_result_distribution.star"},
+		"phantom-cost-basis":       {"corporate_action_cost_adjustment.star"},
+	}
+
+	for name, starFiles := range patternsWithStarFiles {
+		t.Run(name, func(t *testing.T) {
+			for _, starFile := range starFiles {
+				path := filepath.Join(patternsDir(t), name, starFile)
+				_, err := os.ReadFile(path)
+				assert.NoError(t, err, "star file %s should exist for pattern %s", starFile, name)
+			}
+		})
+	}
+}
+
+func TestEconomyPatterns_FilesListedInPatternJSONExist(t *testing.T) {
+	for _, name := range allEconomyPatterns {
+		t.Run(name, func(t *testing.T) {
+			pattern := loadPatternJSON(t, name)
+			files, ok := pattern["files"].([]any)
+			require.True(t, ok, "pattern should have files array")
+
+			for i, f := range files {
+				fileEntry, ok := f.(map[string]any)
+				require.True(t, ok, "file entry %d should be an object", i)
+				relPath, ok := fileEntry["path"].(string)
+				require.True(t, ok, "file entry %d should have a path", i)
+
+				absPath := filepath.Join(patternsDir(t), "..", relPath)
+				_, err := os.Stat(absPath)
+				assert.NoError(t, err, "file %s listed in pattern.json should exist", relPath)
+			}
+		})
+	}
+}
+
+func TestEconomyPatterns_HasRegistryDependencies(t *testing.T) {
+	for _, name := range allEconomyPatterns {
+		t.Run(name, func(t *testing.T) {
+			pattern := loadPatternJSON(t, name)
+			deps, ok := pattern["registryDependencies"].([]any)
+			require.True(t, ok, "registryDependencies should be present")
+			assert.NotEmpty(t, deps, "economy pattern should have at least one registry dependency")
+		})
+	}
+}
+
+// --- registry.json integration tests ---
+
+func TestRegistry_ContainsAllPatterns(t *testing.T) {
 	registryPath := filepath.Join(patternsDir(t), "..", "registry.json")
 	data, err := os.ReadFile(registryPath)
 	require.NoError(t, err)
@@ -285,16 +416,46 @@ func TestRegistry_ContainsBaseFiatUSD(t *testing.T) {
 	items, ok := registry["items"].([]any)
 	require.True(t, ok)
 
-	found := false
+	registryNames := make(map[string]bool)
 	for _, item := range items {
 		m, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
-		if m["name"] == "base-fiat-usd" {
-			found = true
-			assert.Equal(t, "registry:pattern", m["type"])
+		if name, ok := m["name"].(string); ok {
+			registryNames[name] = true
+			assert.Equal(t, "registry:pattern", m["type"], "registry item %s should have type registry:pattern", name)
 		}
 	}
-	assert.True(t, found, "registry.json should contain base-fiat-usd entry")
+
+	allPatterns := append([]string{"base-fiat-gbp", "base-fiat-usd"}, allEconomyPatterns...)
+	for _, name := range allPatterns {
+		assert.True(t, registryNames[name], "registry.json should contain %s entry", name)
+	}
+}
+
+func TestRegistry_NoDuplicateNames(t *testing.T) {
+	registryPath := filepath.Join(patternsDir(t), "..", "registry.json")
+	data, err := os.ReadFile(registryPath)
+	require.NoError(t, err)
+
+	var registry map[string]any
+	require.NoError(t, json.Unmarshal(data, &registry))
+
+	items, ok := registry["items"].([]any)
+	require.True(t, ok)
+
+	seen := make(map[string]bool)
+	for _, item := range items {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, ok := m["name"].(string)
+		if !ok {
+			continue
+		}
+		assert.False(t, seen[name], "registry.json should not have duplicate entry for %s", name)
+		seen[name] = true
+	}
 }

--- a/cookbook/patterns/patterns_test.go
+++ b/cookbook/patterns/patterns_test.go
@@ -350,7 +350,7 @@ func TestEconomyPatterns_ProvidesInstrumentsMatchManifest(t *testing.T) {
 
 func TestEconomyPatterns_StarFilesExistForSagaPatterns(t *testing.T) {
 	patternsWithStarFiles := map[string][]string{
-		"saas-billing":             {"compute_billing.star"},
+		"saas-billing":             {"record_gpu_usage.star", "compute_billing.star", "generate_monthly_invoice.star"},
 		"precious-metals":          {"valuation_on_capture.star"},
 		"time-of-use-pricing":      {"tou_energy_valuation.star"},
 		"dynamic-capacity-pricing": {"dynamic_capacity_billing.star"},

--- a/cookbook/patterns/payment-gateway-stripe/manifest-fragment.yaml
+++ b/cookbook/patterns/payment-gateway-stripe/manifest-fragment.yaml
@@ -30,6 +30,8 @@ operationalGateway:
       auth:
         apiKey:
           headerName: Authorization
+          # Secret must include 'Bearer ' prefix, e.g. 'Bearer sk_live_xxx'.
+          # APIKeyAuth sets the header value verbatim.
           apiKeySecretRef: "sm://stripe/api_key"
       retryPolicy:
         maxAttempts: 3

--- a/cookbook/patterns/payment-gateway-stripe/manifest-fragment.yaml
+++ b/cookbook/patterns/payment-gateway-stripe/manifest-fragment.yaml
@@ -1,0 +1,104 @@
+accountTypes:
+  - code: CUSTOMER_CURRENT
+    name: Customer Current Account
+    normalBalance: NORMAL_BALANCE_DEBIT
+    allowedInstruments: [GBP, USD, EUR]
+    policies:
+      validation: "amount > 0"
+      bucketing: ""
+  - code: PAYMENT_CLEARING
+    name: Payment Clearing Account
+    normalBalance: NORMAL_BALANCE_CREDIT
+    allowedInstruments: [GBP, USD, EUR]
+    policies:
+      validation: ""
+      bucketing: ""
+
+sagas:
+  - name: stripe_payment_via_gateway
+    trigger: "api:/v1/payments/stripe"
+  - name: stripe_payment_received
+    trigger: "webhook:stripe.payment_intent.succeeded"
+
+operationalGateway:
+  providerConnections:
+    - connectionId: stripe-payments
+      providerName: Stripe
+      providerType: payment_gateway
+      protocol: PROVIDER_PROTOCOL_HTTPS
+      baseUrl: https://api.stripe.com/v1
+      auth:
+        apiKey:
+          headerName: Authorization
+          apiKeySecretRef: "sm://stripe/api_key"
+      retryPolicy:
+        maxAttempts: 3
+        initialBackoffSeconds: 1
+        maxBackoffSeconds: 30
+        backoffMultiplier: 2.0
+      rateLimit:
+        requestsPerSecond: 25.0
+        burstSize: 50
+  instructionRoutes:
+    - instructionType: payment.collect
+      connectionId: stripe-payments
+      outboundMappingId: payment-collect-to-stripe
+      inboundMappingId: stripe-response-to-ack
+      httpMethod: POST
+      pathTemplate: /payment_intents
+
+mappings:
+  - name: payment-collect-to-stripe
+    targetService: external.stripe
+    targetRpc: CreatePaymentIntent
+    fields:
+      - externalPath: amount
+        internalPath: amount_cents
+        transform:
+          cel:
+            inboundCel: "int(value)"
+            outboundCel: "int(value)"
+      - externalPath: currency
+        internalPath: currency
+        transform:
+          cel:
+            inboundCel: "value.upperAscii()"
+            outboundCel: "value.lowerAscii()"
+      - externalPath: customer
+        internalPath: customer_id
+      - externalPath: payment_method
+        internalPath: payment_method_id
+    outboundComputedFields:
+      - targetPath: confirm
+        celExpression: "true"
+  - name: stripe-response-to-ack
+    targetService: internal.operational_gateway
+    targetRpc: AcknowledgeInstruction
+    fields:
+      - externalPath: id
+        internalPath: provider_reference_id
+      - externalPath: status
+        internalPath: provider_status
+        transform:
+          enumMapping:
+            values:
+              requires_payment_method: PENDING
+              requires_confirmation: PENDING
+              requires_action: PENDING
+              processing: PROCESSING
+              requires_capture: DELIVERED
+              succeeded: ACKNOWLEDGED
+              canceled: FAILED
+            fallback: UNKNOWN
+      - externalPath: amount
+        internalPath: amount_cents
+        transform:
+          cel:
+            inboundCel: "int(value)"
+            outboundCel: "int(value)"
+      - externalPath: currency
+        internalPath: currency
+        transform:
+          cel:
+            inboundCel: "value.upperAscii()"
+            outboundCel: "value.lowerAscii()"

--- a/cookbook/patterns/payment-gateway-stripe/pattern.json
+++ b/cookbook/patterns/payment-gateway-stripe/pattern.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+    "name": "payment-gateway-stripe",
+    "type": "registry:pattern",
+    "title": "Stripe Payment Gateway",
+    "description": "Stripe payment integration via the Operational Gateway abstraction layer. Includes provider connection configuration, outbound/inbound mapping definitions for payload transformation, instruction routing, and a multi-step saga with lien reservation, gateway dispatch, and conditional ledger posting.",
+    "registryDependencies": ["base-fiat-gbp"],
+    "categories": ["economy", "payments", "gateway", "integration"],
+    "meta": {
+        "complexity": 8,
+        "design_pattern": "operational-gateway",
+        "industries": ["payments", "fintech"],
+        "provides": {
+            "instruments": [],
+            "account_types": ["CUSTOMER_CURRENT", "PAYMENT_CLEARING"],
+            "sagas": ["stripe_payment_via_gateway", "stripe_payment_received"],
+            "valuation_rules": [],
+            "triggers": ["api:/v1/payments/stripe", "webhook:stripe.payment_intent.succeeded"]
+        },
+        "requires": {
+            "instruments": ["GBP"],
+            "market_data": []
+        },
+        "composes_with": ["kyc-compliance", "saas-billing"],
+        "conflicts_with": [],
+        "extends": ["base-fiat-gbp"]
+    },
+    "files": [
+        {
+            "path": "patterns/payment-gateway-stripe/manifest-fragment.yaml",
+            "type": "registry:file",
+            "target": "~/manifest-fragment.yaml"
+        },
+        {
+            "path": "patterns/payment-gateway-stripe/stripe_payment_received.star",
+            "type": "registry:file",
+            "target": "~/sagas/stripe_payment_received.star"
+        }
+    ]
+}

--- a/cookbook/patterns/payment-gateway-stripe/stripe_payment_received.star
+++ b/cookbook/patterns/payment-gateway-stripe/stripe_payment_received.star
@@ -1,0 +1,95 @@
+# Saga: stripe_payment_received
+# Version: 1.0.0
+# Previous: none
+# Changed: Initial implementation of Stripe cash-in double-entry posting
+# Author: Platform Team
+# Date: 2026-02-10
+#
+# This Starlark script defines the stripe_payment_received saga workflow.
+# When Stripe reports a successful payment (payment_intent.succeeded), this saga
+# records the cash-in as a double-entry ledger posting in the meridian-ops tenant.
+#
+# Double-Entry Accounting:
+#   DEBIT  stripe_nostro          (cash received from Stripe)
+#   CREDIT {party_id}_prepaid     (customer prepaid balance increases)
+#
+# The Stripe charge ID is stored as external_reference_id for O(1) reconciliation
+# against Stripe's settlement reports.
+#
+# Input data (provided via input_data dictionary):
+#   - tenant_id: string        - The tenant receiving the payment (e.g., "meridian-ops")
+#   - party_id: string         - The customer party identifier
+#   - amount_cents: int        - Payment amount in smallest currency unit (e.g., pence)
+#   - instrument_code: string  - Instrument code (e.g., "GBP"). Replaces currency field.
+#   - currency: string         - Deprecated: use instrument_code instead. ISO 4217 currency code (e.g., "gbp")
+#   - charge_id: string        - Stripe Charge ID for reconciliation
+#   - payment_intent_id: string - Stripe PaymentIntent ID
+#   - stripe_event_id: string  - Original Stripe event ID for audit trail
+#
+# Compensation Order (LIFO):
+#   If the credit step fails, the debit to stripe_nostro is reversed.
+
+stripe_payment_received_saga = saga(name="stripe_payment_received")
+
+def execute_stripe_payment_received():
+    # Extract input parameters
+    tenant_id = input_data["tenant_id"]
+    party_id = input_data["party_id"]
+    amount_cents = input_data["amount_cents"]
+    # Accept instrument_code (preferred) or currency (deprecated alias).
+    # Normalize once: strip whitespace, uppercase, default to "GBP".
+    instrument_code = input_data.get("instrument_code", "") or input_data.get("currency", "")
+    instrument_code = instrument_code.strip().upper()
+    if instrument_code == "":
+        instrument_code = "GBP"
+    charge_id = input_data["charge_id"]
+    payment_intent_id = input_data.get("payment_intent_id", "")
+    stripe_event_id = input_data.get("stripe_event_id", "")
+
+    # Convert from cents to major currency unit (e.g., pence to pounds)
+    # Stripe amounts are in the smallest currency unit
+    amount = Decimal(str(amount_cents)) / Decimal("100")
+
+    # Derive account identifiers
+    nostro_account = "stripe_nostro"
+    prepaid_account = party_id + "_prepaid"
+
+    # Step 1: Debit the stripe nostro account (cash received from Stripe)
+    # This represents Stripe holding funds on our behalf
+    step(name="debit_stripe_nostro")
+    debit_result = position_keeping.initiate_log(
+        account_id=nostro_account,
+        amount=amount,
+        instrument_code=instrument_code,
+        direction="DEBIT",
+        description="Stripe payment received: " + charge_id,
+        external_reference_id=charge_id,
+    )
+
+    # Step 2: Credit the customer prepaid balance
+    # This increases the customer's available balance
+    step(name="credit_customer_prepaid")
+    credit_result = position_keeping.initiate_log(
+        account_id=prepaid_account,
+        amount=amount,
+        instrument_code=instrument_code,
+        direction="CREDIT",
+        description="Payment from Stripe: " + charge_id,
+        external_reference_id=charge_id,
+    )
+
+    result = {
+        "status": "completed",
+        "tenant_id": tenant_id,
+        "party_id": party_id,
+        "prepaid_log_id": credit_result["log_id"],
+        "amount_cents": amount_cents,
+        "instrument_code": instrument_code,
+        "charge_id": charge_id,
+        "payment_intent_id": payment_intent_id,
+        "stripe_event_id": stripe_event_id,
+    }
+    return result
+
+# Execute the saga
+execute_stripe_payment_received()

--- a/cookbook/patterns/payment-gateway-stripe/stripe_payment_received.star
+++ b/cookbook/patterns/payment-gateway-stripe/stripe_payment_received.star
@@ -92,4 +92,4 @@ def execute_stripe_payment_received():
     return result
 
 # Execute the saga
-execute_stripe_payment_received()
+output = execute_stripe_payment_received()

--- a/cookbook/patterns/phantom-cost-basis/corporate_action_cost_adjustment.star
+++ b/cookbook/patterns/phantom-cost-basis/corporate_action_cost_adjustment.star
@@ -1,0 +1,107 @@
+# Saga: corporate_action_cost_adjustment
+# Version: 2.0.0
+# Previous: 1.0.0
+# Changed: Clarify this consumes a hypothetical corporate-action event type
+# Author: Tenant Configuration (Wealth Management)
+# Date: 2026-03-03
+#
+# Adjusts cost basis for all holdings of an instrument when a corporate action
+# occurs. Handles "phantom events" where no cash or units move but the tax
+# position changes (e.g., accumulating ETF dividends).
+#
+# Trigger: event:market-information.corporate-action.v1
+# Filter:  event.action_type == 'ACCUMULATING_DIVIDEND'
+#
+# NOTE: The corporate-action.v1 channel is aspirational — it does not exist in
+# the current event inventory. When implemented, the proto would define fields
+# such as instrument_code, action_type, amount_per_unit, and ex_date. This
+# example validates the platform's ability to support wealth management use cases
+# once the event is defined.
+#
+# Account model:
+#   - Custody Account (instrument units): what you own (unchanged by this saga)
+#   - Cost Basis Account (GBP): what it cost (adjusted by this saga)
+#   - Market Value: not an account, computed by valuation engine at query time
+#
+# The cost basis account is the key design choice: it's a GBP position that
+# changes when economic reality changes, even when no cash or units move.
+# The position log on this account IS the audit trail for HMRC.
+#
+# Input data (from hypothetical CorporateActionEvent):
+#   - correlation_id: string - Idempotency key from standard headers
+#   - instrument_code: string - Instrument affected by the corporate action
+#   - action_type: string - Type of corporate action (filtered by CEL)
+#   - amount_per_unit: string - Dividend amount per unit as decimal string
+#   - ex_date: string - Ex-dividend date (ISO 8601)
+#
+# Entity graph resolution (via service module calls):
+#   - holdings: from position_keeping.query_accounts(instrument_code=...)
+#   - balances: from position_keeping.get_balance(account_id=...)
+#   - cost_basis_account_id: from holding metadata
+
+# Define the saga
+cost_adjustment_saga = saga(name="corporate_action_cost_adjustment")
+
+def execute_cost_adjustment():
+    ctx = input_data
+
+    correlation_id = ctx["correlation_id"]
+    instrument_code = ctx["instrument_code"]
+    amount_per_unit = Decimal(ctx["amount_per_unit"])
+    ex_date = ctx["ex_date"]
+
+    # Idempotency check: has this corporate action already been processed?
+    step(name="check_idempotency")
+    existing = position_keeping.query_logs(
+        correlation_id=correlation_id,
+        instrument_code="GBP",
+    )
+
+    if existing.count > 0:
+        return {"status": "ALREADY_ADJUSTED", "correlation_id": correlation_id}
+
+    # Find all custody accounts holding this instrument
+    step(name="find_holdings")
+    holdings = position_keeping.query_accounts(
+        instrument_code=instrument_code,
+    )
+
+    adjustment_count = 0
+
+    for holding in holdings:
+        # Get current units on this account
+        step(name="get_balance_" + str(adjustment_count))
+        position = position_keeping.get_balance(
+            account_id=holding.account_id,
+        )
+
+        if position.amount == 0:
+            continue
+
+        # Cost basis adjustment: units x dividend per unit
+        # No cash moves. No units change. But the tax position changed.
+        adjustment = position.amount * amount_per_unit
+
+        step(name="book_adjustment_" + str(adjustment_count))
+        position_keeping.initiate_log(
+            account_id=holding.metadata.cost_basis_account_id,
+            instrument_code="GBP",
+            direction="CREDIT",
+            amount=adjustment,
+            correlation_id=correlation_id,
+            description="Accumulating dividend: " + instrument_code,
+            reference=ex_date,
+        )
+
+        adjustment_count = adjustment_count + 1
+
+    return {
+        "status": "ADJUSTED",
+        "instrument_code": instrument_code,
+        "holdings_adjusted": adjustment_count,
+        "amount_per_unit": str(amount_per_unit),
+        "ex_date": ex_date,
+    }
+
+# Execute the saga
+output = execute_cost_adjustment()

--- a/cookbook/patterns/phantom-cost-basis/manifest-fragment.yaml
+++ b/cookbook/patterns/phantom-cost-basis/manifest-fragment.yaml
@@ -1,0 +1,4 @@
+sagas:
+  - name: corporate_action_cost_adjustment
+    trigger: "event:market-information.corporate-action.v1"
+    filter: "event.action_type == 'ACCUMULATING_DIVIDEND'"

--- a/cookbook/patterns/phantom-cost-basis/pattern.json
+++ b/cookbook/patterns/phantom-cost-basis/pattern.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+    "name": "phantom-cost-basis",
+    "type": "registry:pattern",
+    "title": "Phantom Cost Basis Adjustment",
+    "description": "Adjusts cost basis for all holdings of an instrument when a corporate action occurs. Handles phantom events where no cash or units move but the tax position changes, such as accumulating ETF dividends. The cost basis account position log serves as the HMRC audit trail.",
+    "registryDependencies": ["base-fiat-gbp"],
+    "categories": ["economy", "corporate-actions", "cost-basis", "event-driven"],
+    "meta": {
+        "complexity": 5,
+        "design_pattern": "phantom-transaction-event",
+        "industries": ["trading", "corporate-actions"],
+        "provides": {
+            "instruments": [],
+            "account_types": [],
+            "sagas": ["corporate_action_cost_adjustment"],
+            "valuation_rules": [],
+            "triggers": ["event:market-information.corporate-action.v1"]
+        },
+        "requires": {
+            "instruments": ["GBP"],
+            "market_data": []
+        },
+        "composes_with": ["precious-metals"],
+        "conflicts_with": [],
+        "extends": ["base-fiat-gbp"]
+    },
+    "files": [
+        {
+            "path": "patterns/phantom-cost-basis/manifest-fragment.yaml",
+            "type": "registry:file",
+            "target": "~/manifest-fragment.yaml"
+        },
+        {
+            "path": "patterns/phantom-cost-basis/corporate_action_cost_adjustment.star",
+            "type": "registry:file",
+            "target": "~/sagas/corporate_action_cost_adjustment.star"
+        }
+    ]
+}

--- a/cookbook/patterns/precious-metals/manifest-fragment.yaml
+++ b/cookbook/patterns/precious-metals/manifest-fragment.yaml
@@ -1,0 +1,54 @@
+instruments:
+  - code: GOLD
+    name: Gold (troy ounce)
+    type: INSTRUMENT_TYPE_COMMODITY
+    dimensions:
+      unit: troy_oz
+      precision: 4
+  - code: SILVER
+    name: Silver (troy ounce)
+    type: INSTRUMENT_TYPE_COMMODITY
+    dimensions:
+      unit: troy_oz
+      precision: 4
+  - code: PLATINUM
+    name: Platinum (troy ounce)
+    type: INSTRUMENT_TYPE_COMMODITY
+    dimensions:
+      unit: troy_oz
+      precision: 4
+
+accountTypes:
+  - code: TRADING
+    name: Precious Metals Trading Account
+    normalBalance: NORMAL_BALANCE_DEBIT
+    allowedInstruments: [GOLD, SILVER, PLATINUM]
+    policies:
+      validation: "amount > 0"
+      bucketing: ""
+  - code: SETTLEMENT
+    name: GBP Settlement Account
+    normalBalance: NORMAL_BALANCE_DEBIT
+    allowedInstruments: [GBP]
+    policies:
+      validation: "amount >= 0"
+      bucketing: ""
+
+valuationRules:
+  - fromInstrument: GOLD
+    toInstrument: GBP
+    method: VALUATION_METHOD_SPOT_RATE
+    source: lbma_gold_fix
+  - fromInstrument: SILVER
+    toInstrument: GBP
+    method: VALUATION_METHOD_SPOT_RATE
+    source: lbma_silver_fix
+  - fromInstrument: PLATINUM
+    toInstrument: GBP
+    method: VALUATION_METHOD_SPOT_RATE
+    source: lppm_platinum_fix
+
+sagas:
+  - name: valuation_on_capture
+    trigger: "event:position-keeping.transaction-captured.v1"
+    filter: "event.instrument_code in ['GOLD', 'SILVER', 'PLATINUM']"

--- a/cookbook/patterns/precious-metals/pattern.json
+++ b/cookbook/patterns/precious-metals/pattern.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+    "name": "precious-metals",
+    "type": "registry:pattern",
+    "title": "Precious Metals Trading",
+    "description": "Precious metals trading platform with event-triggered valuation. When gold, silver, or platinum positions are captured, an event-driven saga automatically books the GBP settlement value at the current spot rate from LBMA/LPPM price fixes.",
+    "registryDependencies": ["base-fiat-gbp"],
+    "categories": ["economy", "commodities", "trading", "event-driven"],
+    "meta": {
+        "complexity": 5,
+        "design_pattern": "valuation-on-capture",
+        "industries": ["commodities", "trading"],
+        "provides": {
+            "instruments": ["GOLD", "SILVER", "PLATINUM"],
+            "account_types": ["TRADING", "SETTLEMENT"],
+            "sagas": ["valuation_on_capture"],
+            "valuation_rules": ["GOLD->GBP", "SILVER->GBP", "PLATINUM->GBP"],
+            "triggers": ["event:position-keeping.transaction-captured.v1"]
+        },
+        "requires": {
+            "instruments": ["GBP"],
+            "market_data": ["lbma_gold_fix", "lbma_silver_fix", "lppm_platinum_fix"]
+        },
+        "composes_with": ["kyc-compliance", "carbon-offset"],
+        "conflicts_with": [],
+        "extends": ["base-fiat-gbp"]
+    },
+    "files": [
+        {
+            "path": "patterns/precious-metals/manifest-fragment.yaml",
+            "type": "registry:file",
+            "target": "~/manifest-fragment.yaml"
+        },
+        {
+            "path": "patterns/precious-metals/valuation_on_capture.star",
+            "type": "registry:file",
+            "target": "~/sagas/valuation_on_capture.star"
+        }
+    ]
+}

--- a/cookbook/patterns/precious-metals/valuation_on_capture.star
+++ b/cookbook/patterns/precious-metals/valuation_on_capture.star
@@ -1,0 +1,99 @@
+# Saga: valuation_on_capture
+# Version: 1.0.0
+# Author: Tenant Configuration (Precious Metals Trading)
+# Date: 2026-03-04
+#
+# Books GBP settlement value when a precious metals position is captured.
+# When a GOLD, SILVER, or PLATINUM position is captured, this saga looks up
+# the current spot price via market data and creates a GBP settlement posting.
+#
+# Trigger: event:position-keeping.transaction-captured.v1
+# Filter:  event.instrument_code in ['GOLD', 'SILVER', 'PLATINUM']
+#
+# Single-leg valuation: precious metal quantity -> GBP at spot rate.
+#
+# Idempotency: checks a GBP posting exists for this correlation_id before
+# proceeding.
+# Chain termination: GBP positions emitted downstream are rejected by the
+# CEL filter (instrument_code in [...] does not include 'GBP').
+#
+# Input data (from TransactionCapturedEvent via AsyncAPI-driven deserialization):
+#   - correlation_id: string - Idempotency key from standard headers
+#   - log_id: string (UUID) - Position log identifier
+#   - account_id: string - The trading account that triggered the event
+#   - transaction_id: string (UUID) - Transaction identifier
+#   - amount_cents: int - Amount in smallest unit
+#   - instrument_code: string - Source instrument ('GOLD', 'SILVER', 'PLATINUM')
+#   - direction: string - 'DEBIT' or 'CREDIT'
+#   - instrument_amount: dict - Multi-asset amount {amount, instrument_code}
+#
+# Entity graph resolution (via service module calls):
+#   - settlement_account_id: from reference_data.get_account(id=account_id)
+#   - valuation method: from reference_data.get_account_type(code=...)
+
+# Define the saga
+valuation_on_capture_saga = saga(name="valuation_on_capture")
+
+def execute_valuation_on_capture():
+    ctx = input_data
+
+    correlation_id = ctx["correlation_id"]
+    source_account_id = ctx["account_id"]
+    amount = Decimal(ctx["instrument_amount"]["amount"])
+    instrument_code = ctx["instrument_code"]
+    direction = ctx["direction"]
+
+    # Resolve account details from the entity graph.
+    # The event carries only the account_id — the saga looks up the account
+    # type and settlement account via reference data service modules.
+    step(name="lookup_account")
+    account = reference_data.get_account(id=source_account_id)
+
+    settlement_account_id = account.metadata["settlement_account_id"]
+
+    # Idempotency check: has the GBP settlement already been booked?
+    step(name="check_idempotency")
+    existing = position_keeping.query_logs(
+        correlation_id=correlation_id,
+        instrument_code="GBP",
+        account_id=settlement_account_id,
+    )
+
+    if existing.count > 0:
+        return {"status": "ALREADY_VALUED", "correlation_id": correlation_id}
+
+    # Look up account type for the spot rate valuation method.
+    step(name="lookup_account_type")
+    account_type = reference_data.get_account_type(
+        code=account.account_type_code,
+    )
+
+    # Compute GBP settlement value at current spot rate.
+    step(name="compute_valuation")
+    valuation = valuation_engine.compute(
+        method_id=account_type.default_conversion_method_id,
+        amount=amount,
+        from_instrument=instrument_code,
+        to_instrument="GBP",
+    )
+
+    # Book GBP settlement posting — direction mirrors the source position.
+    step(name="book_settlement")
+    position_keeping.initiate_log(
+        account_id=settlement_account_id,
+        instrument_code="GBP",
+        direction=direction,
+        amount=valuation.amount,
+        correlation_id=correlation_id,
+        description="Spot valuation: " + instrument_code + " -> GBP",
+    )
+
+    return {
+        "status": "VALUED",
+        "instrument_code": instrument_code,
+        "gbp_amount": str(valuation.amount),
+        "correlation_id": correlation_id,
+    }
+
+# Execute the saga
+output = execute_valuation_on_capture()

--- a/cookbook/patterns/saas-billing/compute_billing.star
+++ b/cookbook/patterns/saas-billing/compute_billing.star
@@ -1,0 +1,87 @@
+# Saga: compute_billing
+# Version: 2.0.0
+# Previous: 1.0.0
+# Changed: Thin event pattern — resolve billing account from entity graph
+# Author: Tenant Configuration (Cloud Compute)
+# Date: 2026-03-03
+#
+# Usage billing saga for compute resources.
+# When GPU_HOUR positions are captured, this saga converts them to USD charges
+# using the account type's default conversion method.
+#
+# Trigger: event:position-keeping.transaction-captured.v1
+# Filter:  event.instrument_code == 'GPU_HOUR' && event.direction == 'DEBIT'
+#
+# Single-leg valuation (simpler than energy which has retail + wholesale).
+#
+# Input data (from TransactionCapturedEvent via AsyncAPI-driven deserialization):
+#   - correlation_id: string - Idempotency key from standard headers
+#   - account_id: string - The usage account that triggered the event
+#   - instrument_code: string - "GPU_HOUR"
+#   - instrument_amount: dict - Multi-asset amount {amount, instrument_code}
+#
+# Entity graph resolution (via service module calls):
+#   - account_type_code: from reference_data.get_account(id=account_id)
+#   - billing_account_id: from account.metadata
+#   - conversion method: from reference_data.get_account_type(code=...)
+
+# Define the saga
+compute_billing_saga = saga(name="compute_billing")
+
+def execute_compute_billing():
+    ctx = input_data
+
+    correlation_id = ctx["correlation_id"]
+    source_account_id = ctx["account_id"]
+    amount = Decimal(ctx["instrument_amount"]["amount"])
+
+    # Resolve account details from entity graph
+    step(name="lookup_account")
+    account = reference_data.get_account(id=source_account_id)
+
+    billing_account_id = account.metadata["billing_account_id"]
+
+    # Idempotency check
+    step(name="check_idempotency")
+    existing = position_keeping.query_logs(
+        correlation_id=correlation_id,
+        instrument_code="USD",
+        account_id=billing_account_id,
+    )
+
+    if existing.count > 0:
+        return {"status": "ALREADY_BILLED", "correlation_id": correlation_id}
+
+    # Look up account type for its default conversion method
+    step(name="lookup_account_type")
+    account_type = reference_data.get_account_type(
+        code=account.account_type_code,
+    )
+
+    # Convert GPU hours to USD
+    step(name="compute_charge")
+    charge = valuation_engine.compute(
+        method_id=account_type.default_conversion_method_id,
+        amount=amount,
+        from_instrument="GPU_HOUR",
+        to_instrument="USD",
+    )
+
+    # Book USD charge on customer billing account
+    step(name="book_charge")
+    position_keeping.initiate_log(
+        account_id=billing_account_id,
+        instrument_code="USD",
+        direction="DEBIT",
+        amount=charge.amount,
+        correlation_id=correlation_id,
+    )
+
+    return {
+        "status": "BILLED",
+        "amount": str(charge.amount),
+        "correlation_id": correlation_id,
+    }
+
+# Execute the saga
+output = execute_compute_billing()

--- a/cookbook/patterns/saas-billing/generate_monthly_invoice.star
+++ b/cookbook/patterns/saas-billing/generate_monthly_invoice.star
@@ -1,0 +1,58 @@
+# Saga: generate_monthly_invoice
+# Version: 1.0.0
+# Author: Tenant Configuration (Cloud Compute)
+# Date: 2026-03-04
+#
+# Generates monthly invoices by iterating all usage accounts, valuing
+# accumulated consumption (GPU hours, API calls, storage) in USD, and
+# charging the associated billing account.
+#
+# Trigger: scheduled:monthly_billing
+#
+# Input data (from scheduled trigger):
+#   - billing_period: string - The billing period to invoice (e.g., "2026-03")
+
+# Define the saga
+generate_monthly_invoice_saga = saga(name="generate_monthly_invoice")
+
+def execute_generate_monthly_invoice():
+    ctx = input_data
+    billing_period = ctx["billing_period"]
+
+    # Get all usage accounts for this period
+    step(name="list_usage_accounts")
+    accounts = position_keeping.list_accounts(
+        account_type="USAGE",
+    )
+
+    for account in accounts:
+        # Calculate total usage cost per instrument
+        for instrument in ["GPU_HOUR", "API_CALL", "STORAGE_GB"]:
+            step(name="retrieve_balance_" + instrument)
+            balance = position_keeping.retrieve_balance(
+                account_id=account.account_id,
+                instrument_code=instrument,
+            )
+
+            if balance.amount > 0:
+                # Value usage in USD
+                step(name="valuate_" + instrument)
+                valuation = current_account.evaluate_asset_valuation(
+                    account_id=account.billing_account_id,
+                    instrument_code=instrument,
+                    amount=balance.amount,
+                )
+
+                # Charge billing account
+                step(name="charge_" + instrument)
+                current_account.execute_withdrawal(
+                    account_id=account.billing_account_id,
+                    amount=valuation.output.amount,
+                    instrument_code="USD",
+                    reference="invoice:" + billing_period + ":" + instrument,
+                )
+
+    return {"status": "invoiced", "billing_period": billing_period}
+
+# Execute the saga
+output = execute_generate_monthly_invoice()

--- a/cookbook/patterns/saas-billing/manifest-fragment.yaml
+++ b/cookbook/patterns/saas-billing/manifest-fragment.yaml
@@ -1,0 +1,82 @@
+instruments:
+  - code: GPU_HOUR
+    name: GPU Compute Hour
+    type: INSTRUMENT_TYPE_COMMODITY
+    dimensions:
+      unit: GPU-hr
+      precision: 6
+  - code: API_CALL
+    name: API Call Unit
+    type: INSTRUMENT_TYPE_COMMODITY
+    dimensions:
+      unit: calls
+      precision: 0
+  - code: STORAGE_GB
+    name: Storage Gigabyte-Month
+    type: INSTRUMENT_TYPE_COMMODITY
+    dimensions:
+      unit: GB-mo
+      precision: 3
+  - code: CREDIT
+    name: Platform Credit
+    type: INSTRUMENT_TYPE_VOUCHER
+    dimensions:
+      unit: credits
+      precision: 2
+
+accountTypes:
+  - code: BILLING
+    name: Billing Account
+    normalBalance: NORMAL_BALANCE_DEBIT
+    allowedInstruments: [USD]
+    policies:
+      validation: ""
+      bucketing: ""
+  - code: USAGE
+    name: Usage Metering Account
+    normalBalance: NORMAL_BALANCE_DEBIT
+    allowedInstruments: [GPU_HOUR, API_CALL, STORAGE_GB]
+    policies:
+      validation: "amount > 0"
+      bucketing: "instrument_code + ':' + attributes.billing_period"
+  - code: CREDIT_BALANCE
+    name: Credit Balance Account
+    normalBalance: NORMAL_BALANCE_CREDIT
+    allowedInstruments: [CREDIT]
+    policies:
+      validation: "amount > 0"
+      bucketing: ""
+  - code: REVENUE
+    name: Revenue Account
+    normalBalance: NORMAL_BALANCE_CREDIT
+    allowedInstruments: [USD]
+    policies:
+      validation: ""
+      bucketing: ""
+
+valuationRules:
+  - fromInstrument: GPU_HOUR
+    toInstrument: USD
+    method: VALUATION_METHOD_FIXED
+    source: pricing_table_v2
+  - fromInstrument: API_CALL
+    toInstrument: USD
+    method: VALUATION_METHOD_FIXED
+    source: pricing_table_v2
+  - fromInstrument: STORAGE_GB
+    toInstrument: USD
+    method: VALUATION_METHOD_FIXED
+    source: pricing_table_v2
+  - fromInstrument: CREDIT
+    toInstrument: USD
+    method: VALUATION_METHOD_FIXED
+    source: credit_exchange_rate
+
+sagas:
+  - name: record_gpu_usage
+    trigger: "webhook:gpu_meter_event"
+  - name: compute_billing
+    trigger: "event:position-keeping.transaction-captured.v1"
+    filter: "event.instrument_code == 'GPU_HOUR' && event.direction == 'DEBIT'"
+  - name: generate_monthly_invoice
+    trigger: "scheduled:monthly_billing"

--- a/cookbook/patterns/saas-billing/pattern.json
+++ b/cookbook/patterns/saas-billing/pattern.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+    "name": "saas-billing",
+    "type": "registry:pattern",
+    "title": "SaaS Compute Billing",
+    "description": "Usage-based billing for cloud compute resources. Meters GPU hours, API calls, and storage consumption, then converts to USD charges via valuation rules. Includes platform credits as a voucher instrument.",
+    "registryDependencies": ["base-fiat-usd"],
+    "categories": ["economy", "billing", "compute", "usage-metering"],
+    "meta": {
+        "complexity": 5,
+        "design_pattern": "compute-metering",
+        "industries": ["saas", "cloud", "ai"],
+        "provides": {
+            "instruments": ["GPU_HOUR", "API_CALL", "STORAGE_GB", "CREDIT"],
+            "account_types": ["BILLING", "USAGE", "CREDIT_BALANCE", "REVENUE"],
+            "sagas": ["record_gpu_usage", "compute_billing", "generate_monthly_invoice"],
+            "valuation_rules": ["GPU_HOUR->USD", "API_CALL->USD", "STORAGE_GB->USD", "CREDIT->USD"],
+            "triggers": ["webhook:gpu_meter_event", "event:position-keeping.transaction-captured.v1", "scheduled:monthly_billing"]
+        },
+        "requires": {
+            "instruments": ["USD"],
+            "market_data": []
+        },
+        "composes_with": ["dynamic-capacity-pricing", "payment-gateway-stripe"],
+        "conflicts_with": [],
+        "extends": ["base-fiat-usd"]
+    },
+    "files": [
+        {
+            "path": "patterns/saas-billing/manifest-fragment.yaml",
+            "type": "registry:file",
+            "target": "~/manifest-fragment.yaml"
+        },
+        {
+            "path": "patterns/saas-billing/compute_billing.star",
+            "type": "registry:file",
+            "target": "~/sagas/compute_billing.star"
+        }
+    ]
+}

--- a/cookbook/patterns/saas-billing/pattern.json
+++ b/cookbook/patterns/saas-billing/pattern.json
@@ -32,9 +32,19 @@
             "target": "~/manifest-fragment.yaml"
         },
         {
+            "path": "patterns/saas-billing/record_gpu_usage.star",
+            "type": "registry:file",
+            "target": "~/sagas/record_gpu_usage.star"
+        },
+        {
             "path": "patterns/saas-billing/compute_billing.star",
             "type": "registry:file",
             "target": "~/sagas/compute_billing.star"
+        },
+        {
+            "path": "patterns/saas-billing/generate_monthly_invoice.star",
+            "type": "registry:file",
+            "target": "~/sagas/generate_monthly_invoice.star"
         }
     ]
 }

--- a/cookbook/patterns/saas-billing/record_gpu_usage.star
+++ b/cookbook/patterns/saas-billing/record_gpu_usage.star
@@ -1,0 +1,42 @@
+# Saga: record_gpu_usage
+# Version: 1.0.0
+# Author: Tenant Configuration (Cloud Compute)
+# Date: 2026-03-04
+#
+# Records GPU compute usage from webhook meter events into the usage
+# metering account. Each GPU job emits a webhook event with hours consumed,
+# GPU type, and billing period. This saga captures the raw usage position.
+#
+# Trigger: webhook:gpu_meter_event
+#
+# Input data (from webhook payload):
+#   - usage_account: string - The usage metering account ID
+#   - gpu_hours: decimal - Number of GPU hours consumed
+#   - billing_period: string - Billing period identifier (e.g., "2026-03")
+#   - gpu_type: string - GPU model (e.g., "A100", "H100")
+#   - job_id: string - Compute job identifier
+
+# Define the saga
+record_gpu_usage_saga = saga(name="record_gpu_usage")
+
+def execute_record_gpu_usage():
+    ctx = input_data
+
+    # Record usage in metering account
+    step(name="record_usage")
+    position_keeping.initiate_log(
+        account_id=ctx["usage_account"],
+        amount=Decimal(str(ctx["gpu_hours"])),
+        instrument_code="GPU_HOUR",
+        direction="DEBIT",
+        attributes={
+            "billing_period": ctx["billing_period"],
+            "gpu_type": ctx["gpu_type"],
+            "job_id": ctx["job_id"],
+        },
+    )
+
+    return {"status": "recorded", "job_id": ctx["job_id"]}
+
+# Execute the saga
+output = execute_record_gpu_usage()

--- a/cookbook/patterns/time-of-use-pricing/manifest-fragment.yaml
+++ b/cookbook/patterns/time-of-use-pricing/manifest-fragment.yaml
@@ -1,0 +1,18 @@
+instruments:
+  - code: KWH
+    name: Kilowatt Hour
+    type: INSTRUMENT_TYPE_COMMODITY
+    dimensions:
+      unit: kWh
+      precision: 3
+
+valuationRules:
+  - fromInstrument: KWH
+    toInstrument: GBP
+    method: VALUATION_METHOD_SPOT_RATE
+    source: nordpool_spot
+
+sagas:
+  - name: tou_energy_valuation
+    trigger: "event:position-keeping.transaction-captured.v1"
+    filter: "event.instrument_code == 'KWH' && event.direction == 'DEBIT'"

--- a/cookbook/patterns/time-of-use-pricing/pattern.json
+++ b/cookbook/patterns/time-of-use-pricing/pattern.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+    "name": "time-of-use-pricing",
+    "type": "registry:pattern",
+    "title": "Time-of-Use Energy Pricing",
+    "description": "Extends energy settlement with temporal pricing awareness. Values kWh consumption at dynamic rates that vary by settlement period (half-hour), using forecast-derived price curves from Market Data. Peak, off-peak, and overnight rates are resolved from the event timestamp.",
+    "registryDependencies": ["base-fiat-gbp"],
+    "categories": ["economy", "energy", "pricing", "temporal"],
+    "meta": {
+        "complexity": 5,
+        "design_pattern": "time-based-pricing",
+        "industries": ["energy", "utilities"],
+        "provides": {
+            "instruments": ["KWH"],
+            "account_types": [],
+            "sagas": ["tou_energy_valuation"],
+            "valuation_rules": ["KWH->GBP"],
+            "triggers": ["event:position-keeping.transaction-captured.v1"]
+        },
+        "requires": {
+            "instruments": ["GBP"],
+            "market_data": ["nordpool_spot"]
+        },
+        "composes_with": ["carbon-offset", "saas-billing"],
+        "conflicts_with": [],
+        "extends": ["base-fiat-gbp"]
+    },
+    "files": [
+        {
+            "path": "patterns/time-of-use-pricing/manifest-fragment.yaml",
+            "type": "registry:file",
+            "target": "~/manifest-fragment.yaml"
+        },
+        {
+            "path": "patterns/time-of-use-pricing/tou_energy_valuation.star",
+            "type": "registry:file",
+            "target": "~/sagas/tou_energy_valuation.star"
+        }
+    ]
+}

--- a/cookbook/patterns/time-of-use-pricing/tou_energy_valuation.star
+++ b/cookbook/patterns/time-of-use-pricing/tou_energy_valuation.star
@@ -1,0 +1,109 @@
+# Saga: tou_energy_valuation
+# Version: 2.0.0
+# Previous: 1.0.0
+# Changed: Thin event pattern — resolve billing account from entity graph,
+#          use event timestamp as settlement period for temporal rate lookup
+# Author: Tenant Configuration (Energy)
+# Date: 2026-03-03
+#
+# Time-of-use energy valuation saga. Values kWh meter reads at the dynamic
+# rate for the settlement period when consumption occurred, rather than a
+# flat rate. The rate comes from a forecast-derived price curve published to
+# Market Data by the Forecasting Service.
+#
+# This extends the cross-instrument valuation pattern (usage_to_value.star)
+# with temporal awareness: different half-hours have different prices.
+#
+# Trigger: event:position-keeping.transaction-captured.v1
+# Filter:  event.instrument_code == 'KWH' && event.direction == 'DEBIT'
+#
+# Account model:
+#   - Metered Account (kWh): source transaction (consumption)
+#   - Billing Account (GBP): time-of-use charge at dynamic rate
+#
+# The valuation engine resolves the rate by looking up the market data
+# observation for the given value_date in the configured price curve dataset.
+# Different settlement periods map to different rates (peak, off-peak,
+# overnight) based on the forecast curve published by the Forecasting Service.
+#
+# Input data (from TransactionCapturedEvent via AsyncAPI-driven deserialization):
+#   - correlation_id: string - Idempotency key from standard headers
+#   - account_id: string - The metered account that triggered the event
+#   - instrument_amount: dict - Multi-asset amount {amount, instrument_code}
+#   - timestamp: string - ISO 8601 event timestamp (used as settlement period)
+#   - reference: string - External reference (e.g., MPAN identifier)
+#
+# Entity graph resolution (via service module calls):
+#   - billing_account_id: from account.metadata
+#   - account_type_code: from reference_data.get_account(id=account_id)
+#   - conversion method: from reference_data.get_account_type(code=...)
+
+# Define the saga
+tou_valuation_saga = saga(name="tou_energy_valuation")
+
+def execute_tou_valuation():
+    ctx = input_data
+
+    correlation_id = ctx["correlation_id"]
+    source_account_id = ctx["account_id"]
+    amount = Decimal(ctx["instrument_amount"]["amount"])
+    # The event timestamp represents the settlement period start.
+    # For half-hourly reads, this is the start of the 30-minute window.
+    settlement_period = ctx["timestamp"]
+
+    # Resolve account details from entity graph
+    step(name="lookup_account")
+    account = reference_data.get_account(id=source_account_id)
+
+    billing_account_id = account.metadata["billing_account_id"]
+
+    # Idempotency check
+    step(name="check_idempotency")
+    existing = position_keeping.query_logs(
+        correlation_id=correlation_id,
+        instrument_code="GBP",
+        account_id=billing_account_id,
+    )
+
+    if existing.count > 0:
+        return {"status": "ALREADY_VALUED", "correlation_id": correlation_id}
+
+    # Look up account type for its time-of-use valuation method
+    step(name="lookup_account_type")
+    account_type = reference_data.get_account_type(
+        code=account.account_type_code,
+    )
+
+    # Compute value at the time-of-use rate for this settlement period.
+    # The valuation engine uses value_date to look up the correct rate from
+    # the forecast-derived price curve in Market Data. Different half-hours
+    # have different rates (peak, off-peak, overnight).
+    step(name="compute_tou_valuation")
+    charge = valuation_engine.compute(
+        method_id=account_type.default_conversion_method_id,
+        amount=amount,
+        from_instrument="KWH",
+        to_instrument="GBP",
+        value_date=settlement_period,
+    )
+
+    # Book GBP charge on customer billing account
+    step(name="book_charge")
+    position_keeping.initiate_log(
+        account_id=billing_account_id,
+        instrument_code="GBP",
+        direction="DEBIT",
+        amount=charge.amount,
+        correlation_id=correlation_id,
+        description="ToU charge: " + settlement_period,
+    )
+
+    return {
+        "status": "VALUED",
+        "amount": str(charge.amount),
+        "settlement_period": settlement_period,
+        "correlation_id": correlation_id,
+    }
+
+# Execute the saga
+output = execute_tou_valuation()

--- a/cookbook/registry.json
+++ b/cookbook/registry.json
@@ -4,6 +4,15 @@
     "homepage": "https://github.com/meridianhub/meridian",
     "items": [
         {"name": "base-fiat-gbp", "type": "registry:pattern", "title": "Base Fiat Currency (GBP)"},
-        {"name": "base-fiat-usd", "type": "registry:pattern", "title": "Base Fiat Currency (USD)"}
+        {"name": "base-fiat-usd", "type": "registry:pattern", "title": "Base Fiat Currency (USD)"},
+        {"name": "saas-billing", "type": "registry:pattern", "title": "SaaS Compute Billing"},
+        {"name": "carbon-offset", "type": "registry:pattern", "title": "Carbon Credit Registry"},
+        {"name": "precious-metals", "type": "registry:pattern", "title": "Precious Metals Trading"},
+        {"name": "time-of-use-pricing", "type": "registry:pattern", "title": "Time-of-Use Energy Pricing"},
+        {"name": "dynamic-capacity-pricing", "type": "registry:pattern", "title": "Dynamic Capacity Pricing"},
+        {"name": "kyc-compliance", "type": "registry:pattern", "title": "KYC Compliance Workflow"},
+        {"name": "payment-gateway-stripe", "type": "registry:pattern", "title": "Stripe Payment Gateway"},
+        {"name": "entity-distribution", "type": "registry:pattern", "title": "Entity Hierarchy Distribution"},
+        {"name": "phantom-cost-basis", "type": "registry:pattern", "title": "Phantom Cost Basis Adjustment"}
     ]
 }


### PR DESCRIPTION
## Summary

- Add 9 economy pattern cookbook entries: saas-billing, carbon-offset, precious-metals, time-of-use-pricing, dynamic-capacity-pricing, kyc-compliance, payment-gateway-stripe, entity-distribution, and phantom-cost-basis
- Each pattern includes pattern.json (metadata, dependencies, composition rules), manifest-fragment.yaml (instruments, account types, valuation rules, sagas), and Starlark saga scripts where applicable
- Update registry.json with all 11 pattern entries (2 existing base-fiat + 9 new economy patterns)
- Add table-driven tests validating schema conformance, file existence, provides/manifest consistency, and registry integrity across all patterns

## Patterns

| Pattern | Design Pattern | Industries | Complexity |
|---------|---------------|-----------|------------|
| saas-billing | compute-metering | saas, cloud, ai | 5 |
| carbon-offset | credit-retirement-lifecycle | energy, sustainability | 5 |
| precious-metals | valuation-on-capture | commodities, trading | 5 |
| time-of-use-pricing | time-based-pricing | energy, utilities | 5 |
| dynamic-capacity-pricing | feedback-loop-pricing | cloud, infrastructure | 5 |
| kyc-compliance | compliance-marker | banking, compliance | 3 |
| payment-gateway-stripe | operational-gateway | payments, fintech | 8 |
| entity-distribution | party-hierarchy-distribution | gaming, syndication | 5 |
| phantom-cost-basis | phantom-transaction-event | trading, corporate-actions | 5 |

## Test plan

- [x] All pattern.json files validate against registry-item.json schema
- [x] All manifest-fragment.yaml files parse as valid YAML
- [x] Provided instruments match manifest fragment instrument codes
- [x] All Starlark files exist for saga-providing patterns
- [x] All files listed in pattern.json files array exist on disk
- [x] Registry contains all 11 patterns with no duplicates
- [x] `go test ./cookbook/...` passes (28 files, all green)