### PR TITLE
docs: expand cookbook authoring guides for patterns and components

### DIFF
--- a/cookbook/docs/authoring-components.md
+++ b/cookbook/docs/authoring-components.md
@@ -4,3 +4,284 @@ This guide describes how to create and publish Meridian Cookbook UI components.
 
 A component is a reusable frontend building block tied to a Meridian feature module.
 Components are described by `registry:ui` entries conforming to the `registry-item.json` schema.
+
+---
+
+## Component Structure
+
+Every component lives in its own directory under `cookbook/ui/<component-name>/` and contains:
+
+```text
+cookbook/ui/<component-name>/
+└── component.json    # Registry metadata (required)
+```
+
+Unlike patterns, component entries do not bundle source files within the cookbook. The `files[]`
+array in `component.json` lists paths relative to the repository root where the component's
+source file(s) live.
+
+---
+
+## The `component.json` Schema
+
+All fields come from `cookbook/schema/registry-item.json`. For `registry:ui` entries:
+
+```json
+{
+    "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+    "name": "my-component",
+    "type": "registry:ui",
+    "title": "My Component",
+    "description": "One sentence: what this component renders and when you'd use it.",
+    "categories": ["display", "ledger"],
+    "files": [
+        {
+            "path": "frontend/src/features/my-feature/components/my-component.tsx",
+            "type": "registry:ui"
+        }
+    ],
+    "meta": {
+        "feature_module": "my-feature",
+        "tenant_configurable": false,
+        "used_by": ["ledger", "reconciliation"]
+    }
+}
+```
+
+### Field Reference
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | yes | Kebab-case, matches directory name. Pattern: `^[a-z][a-z0-9-]*$` |
+| `type` | string | yes | Always `"registry:ui"` |
+| `title` | string | yes | Human-readable display name |
+| `description` | string | yes | One or two sentences describing what it renders |
+| `categories` | array | no | Taxonomy tags: `"display"`, `"editor"`, `"form"`, `"timeline"`, etc. |
+| `files` | array | yes | Source file paths relative to the repository root |
+| `meta.feature_module` | string | yes | The Meridian feature module this component belongs to |
+| `meta.tenant_configurable` | boolean | no | Whether tenants can configure props. Defaults to false |
+| `meta.configurable_props` | array | no | List of prop names tenants can configure (if `tenant_configurable: true`) |
+| `meta.used_by` | array | no | Feature modules that consume this component |
+
+**`registryDependencies`** is optional for UI entries. Use it when the component depends on another
+registered component (e.g., a form dialog that embeds a `cel-editor`).
+
+---
+
+## Identifying Tenant-Configurable Props
+
+A component is `tenant_configurable: true` when operators or administrators can meaningfully
+change its appearance or behaviour from the Meridian control plane — without modifying source code.
+
+Use `tenant_configurable: false` (the default) for components that:
+
+- Display read-only data from a fixed data model (e.g., `balance-indicator`, `direction-badge`)
+- Visualise saga or ledger state without presentational options (e.g., `saga-timeline`)
+- Are developer tools embedded in the manifest editor (e.g., `starlark-editor`, `cel-editor`)
+
+Set `tenant_configurable: true` when the component accepts configuration that varies by tenant,
+such as column visibility toggles, labelling, or feature-flag-driven behaviour. List the
+configurable prop names in `meta.configurable_props`.
+
+---
+
+## Mapping Components to Feature Modules
+
+The `meta.feature_module` field ties a component to the Meridian service domain it belongs to.
+Use the same module names that appear in the frontend's `src/features/` directory structure.
+
+| Feature module | Domain |
+|---------------|--------|
+| `ledger` | Ledger postings, double-entry accounting display |
+| `reconciliation` | Reconciliation cycles, variance reports |
+| `sagas` | Saga execution, step timelines, script editors |
+| `reference-data` | Account types, instruments, valuation features |
+| `payments` | Payment flows, gateway instructions |
+| `transactions` | Transaction history, position logs |
+| `manifests` | Manifest authoring, YAML/CEL editors |
+| `market-data` | Market observations, price curves |
+| `internal-accounts` | Internal bank accounts, ledger structure |
+
+A component belongs to the module where its primary data source lives, not necessarily where it
+is rendered. `balance-indicator` belongs to `ledger` because it reads ledger postings, even though
+it might appear on a reconciliation page.
+
+The `meta.used_by` array lists all modules that import the component. A shared display primitive
+like `direction-badge` may be `used_by: ["ledger", "transactions", "payments"]` while its
+`feature_module` is `ledger` (where its data model originates).
+
+---
+
+## Declaring `registryDependencies` Between Components
+
+Use `registryDependencies` when a component embeds another registered component as a composable
+building block, and consumers installing this component should also install the dependency.
+
+**When to declare a dependency:**
+
+- The component renders another registered component inside it (composition)
+- The dependency is a shared primitive that must be co-installed for the component to work
+
+**When not to declare a dependency:**
+
+- The relationship is import-level only and managed by the build system
+- The dependency is a design system primitive not tracked in the cookbook
+
+Example: a form dialog that embeds `cel-editor` could declare `"registryDependencies": ["cel-editor"]`
+to signal that the cel-editor component must also be present.
+
+All names in `registryDependencies` must exist in `registry.json`. Tests enforce this.
+
+---
+
+## Step-by-Step: Documenting a New Component
+
+### 1. Create the directory
+
+```bash
+mkdir -p cookbook/ui/my-component
+```
+
+### 2. Write `component.json`
+
+```json
+{
+    "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+    "name": "my-component",
+    "type": "registry:ui",
+    "title": "My Component",
+    "description": "Renders X for Y use case. Shows Z when the condition is met.",
+    "categories": ["display"],
+    "files": [
+        {
+            "path": "frontend/src/features/my-feature/components/my-component.tsx",
+            "type": "registry:ui"
+        }
+    ],
+    "meta": {
+        "feature_module": "my-feature",
+        "tenant_configurable": false,
+        "used_by": ["my-feature"]
+    }
+}
+```
+
+### 3. Register in `registry.json`
+
+Add an entry to `cookbook/registry.json`:
+
+```json
+{
+    "name": "my-component",
+    "type": "registry:ui"
+}
+```
+
+### 4. Run the tests
+
+```bash
+cd cookbook && go test ./schema/...
+```
+
+Tests enforce: schema validation, `name` field matches directory name, `type` is `registry:ui`,
+all `files[]` paths exist on disk relative to the repository root, and the component appears in
+`registry.json`.
+
+---
+
+## Example: Shared Component (`saga-timeline`)
+
+`saga-timeline` visualises saga execution state as a horizontal step timeline. It is used by
+multiple feature modules — any page that shows transaction or payment status embeds it.
+
+**Key decisions in `component.json`:**
+
+```json
+{
+    "name": "saga-timeline",
+    "type": "registry:ui",
+    "title": "Saga Timeline",
+    "description": "Visualises the lifecycle of a Meridian saga as a horizontal step timeline...",
+    "categories": ["saga", "timeline", "display", "status"],
+    "files": [
+        {
+            "path": "frontend/src/features/sagas/components/saga-timeline.tsx",
+            "type": "registry:ui"
+        }
+    ],
+    "meta": {
+        "feature_module": "sagas",
+        "tenant_configurable": false,
+        "used_by": ["payments", "transactions", "reconciliation"]
+    }
+}
+```
+
+- `feature_module: "sagas"` — the component lives in the sagas feature domain even though it
+  appears in payments and transactions pages
+- `tenant_configurable: false` — saga state is a platform truth, not something operators configure
+- `used_by` lists three consuming modules, reflecting the component's shared nature
+- No `registryDependencies` — `saga-timeline` is a standalone display primitive
+
+---
+
+## Example: Feature-Specific Widget (`create-valuation-feature-dialog`)
+
+`create-valuation-feature-dialog` is a modal dialog for attaching a valuation feature to an
+account. It belongs to `reference-data` because that is where valuation feature management lives,
+and it is used by `ledger` and `internal-accounts` pages that expose account configuration.
+
+**Key decisions in `component.json`:**
+
+```json
+{
+    "name": "create-valuation-feature-dialog",
+    "type": "registry:ui",
+    "title": "Create Valuation Feature Dialog",
+    "description": "A modal dialog for attaching a valuation feature to a current or internal bank account...",
+    "categories": ["valuation", "account", "dialog", "form"],
+    "files": [
+        {
+            "path": "frontend/src/features/reference-data/components/create-valuation-feature-dialog.tsx",
+            "type": "registry:ui"
+        }
+    ],
+    "meta": {
+        "feature_module": "reference-data",
+        "tenant_configurable": false,
+        "used_by": ["ledger", "internal-accounts"]
+    }
+}
+```
+
+- `categories` uses both the domain tag (`"valuation"`, `"account"`) and the component type
+  (`"dialog"`, `"form"`) to aid discovery
+- `feature_module: "reference-data"` reflects the RPC it calls (`CreateValuationFeature`)
+- `tenant_configurable: false` — the dialog calls a fixed RPC, there is nothing for a tenant to configure
+
+---
+
+## Testing Requirements
+
+Every component must pass the suite in `cookbook/schema/ui_components_test.go`.
+
+**What the tests check:**
+
+1. **Schema validation** — `component.json` conforms to `registry-item.json`. The `meta.feature_module`
+   field is required for `registry:ui` entries.
+
+2. **Name matches directory** — the `name` field must equal the directory name under `cookbook/ui/`.
+
+3. **Type is `registry:ui`** — the `type` field must be exactly `"registry:ui"`.
+
+4. **Files exist on disk** — every path in `files[]` must exist relative to the repository root.
+   Paths must be relative (not absolute) and must not escape the repository root with `..` traversal.
+
+5. **Present in `registry.json`** — `registry.json` must contain an entry with a matching `name`.
+
+6. **`registryDependencies` are valid** — all names in `registryDependencies` must exist in `registry.json`.
+
+Run with: `cd cookbook && go test ./schema/...`
+
+To add a new component to the test suite, append its name to `uiComponentNames` in
+`cookbook/schema/ui_components_test.go`.

--- a/cookbook/docs/authoring-patterns.md
+++ b/cookbook/docs/authoring-patterns.md
@@ -33,7 +33,8 @@ in `pattern.json`'s `files[]` array.
 
 ## The `pattern.json` Schema
 
-All fields come from `cookbook/schema/registry-item.json`. For `registry:pattern` entries:
+All fields come from `cookbook/schema/registry-item.json`. For `registry:pattern` entries,
+`files[].path` values are relative to the **cookbook root** (`cookbook/`), for example `patterns/my-pattern/...`.
 
 ```json
 {
@@ -336,6 +337,7 @@ because its account types hold GBP, which must already exist.
 - `registryDependencies: ["base-fiat-gbp"]` — uses GBP instrument from that pattern
 - `requires.market_data: ["KWH_GBP_RETAIL", "KWH_GBP_WHOLESALE"]` — SPOT_RATE valuation needs live rates
 - `composes_with: ["carbon-offset", "time-of-use-pricing"]` — these patterns add value alongside this one
+- `conflicts_with: ["flat-rate-billing"]` — flat-rate billing contradicts usage-based settlement
 
 **`manifest-fragment.yaml` structure:** Declares KWH instrument, three account types (ENERGY_INVENTORY,
 SETTLEMENT, REVENUE), and two valuation rules for retail and wholesale conversion.
@@ -388,7 +390,7 @@ Every pattern needs to pass the suite in `cookbook/validation_test.go` and `cook
 3. **Dependency existence** — every name in `registryDependencies` and `meta.composes_with` must exist
    in `registry.json`. Add your pattern to the registry before adding cross-references to it.
 
-4. **File existence** — every path in `files[]` must exist on disk relative to the cookbook root.
+4. **File existence** — every path in `files[]` must exist on disk relative to the cookbook root (`cookbook/`).
 
 5. **Starlark syntax** — all `.star` files parse without errors using the saga runtime's file options
    (no `while` loops, no recursion).

--- a/cookbook/docs/authoring-patterns.md
+++ b/cookbook/docs/authoring-patterns.md
@@ -5,3 +5,395 @@ This guide describes how to create and publish Meridian Cookbook business patter
 A pattern is a reusable bundle of Meridian manifest fragments (instruments, account types, sagas, valuation rules)
 that solves a common business problem. Patterns are described by `registry:pattern` entries conforming to the
 `registry-item.json` schema.
+
+---
+
+## Pattern Structure
+
+Every pattern lives in its own directory under `cookbook/patterns/<pattern-name>/` and contains:
+
+```text
+cookbook/patterns/<pattern-name>/
+├── pattern.json              # Registry metadata (required)
+├── manifest-fragment.yaml    # Manifest primitives: instruments, account types, etc. (required)
+└── <saga-name>.star          # Starlark saga scripts (one per saga declared in manifest)
+```
+
+**`pattern.json`** — the registry entry. Describes what the pattern provides, requires, and composes with.
+Must conform to `cookbook/schema/registry-item.json`.
+
+**`manifest-fragment.yaml`** — the deployable configuration. Contains the Meridian manifest primitives
+(instruments, accountTypes, valuationRules, sagas) that a tenant applies when adopting this pattern.
+
+**`.star` files** — Starlark saga scripts. Required when the pattern declares sagas. Each saga in
+`manifest-fragment.yaml` needs a corresponding `.star` file, and all `.star` files must be referenced
+in `pattern.json`'s `files[]` array.
+
+---
+
+## The `pattern.json` Schema
+
+All fields come from `cookbook/schema/registry-item.json`. For `registry:pattern` entries:
+
+```json
+{
+    "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+    "name": "my-pattern",
+    "type": "registry:pattern",
+    "title": "Human-Readable Title",
+    "description": "One sentence: what this pattern does and why you'd use it.",
+    "registryDependencies": ["base-fiat-gbp"],
+    "categories": ["economy", "billing"],
+    "meta": {
+        "complexity": 3,
+        "design_pattern": "cross-instrument-valuation",
+        "industries": ["energy", "utilities"],
+        "provides": {
+            "instruments": ["KWH"],
+            "account_types": ["ENERGY_INVENTORY", "SETTLEMENT"],
+            "sagas": ["usage_to_value"],
+            "valuation_rules": ["kwh_to_gbp_retail"],
+            "triggers": ["event:position-keeping.transaction-captured.v1"]
+        },
+        "requires": {
+            "instruments": ["GBP"],
+            "market_data": ["KWH_GBP_RETAIL"]
+        },
+        "composes_with": ["carbon-offset"],
+        "conflicts_with": [],
+        "extends": []
+    },
+    "files": [
+        {
+            "path": "patterns/my-pattern/manifest-fragment.yaml",
+            "type": "registry:file",
+            "target": "~/manifest-fragment.yaml"
+        },
+        {
+            "path": "patterns/my-pattern/my_saga.star",
+            "type": "registry:file",
+            "target": "~/sagas/my_saga.star"
+        }
+    ]
+}
+```
+
+### Field Reference
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | yes | Kebab-case, matches directory name. Pattern: `^[a-z][a-z0-9-]*$` |
+| `type` | string | yes | Always `"registry:pattern"` |
+| `title` | string | yes | Human-readable display name |
+| `description` | string | yes | One or two sentences, not a bullet list |
+| `registryDependencies` | array | yes | Names of patterns this one depends on. Use `[]` for foundation patterns |
+| `categories` | array | no | Taxonomy tags for discovery (e.g., `"economy"`, `"billing"`, `"compliance"`) |
+| `meta.complexity` | integer | yes | Fibonacci: 1, 2, 3, 5, or 8 |
+| `meta.design_pattern` | string\|null | yes | Design pattern name, or `null` for foundation patterns |
+| `meta.industries` | array | yes | Industry sectors: `"all"` for universal, or specific sectors |
+| `meta.provides` | object | yes | What this pattern contributes to the manifest |
+| `meta.requires` | object | yes | External dependencies needed before this pattern works |
+| `meta.composes_with` | array | yes | Patterns that pair well with this one |
+| `meta.conflicts_with` | array | yes | Patterns that cannot be combined with this one |
+| `meta.extends` | array | yes | Patterns this one builds on top of |
+| `files` | array | yes | All files this pattern installs |
+
+### Provides vs Requires vs RegistryDependencies
+
+These three fields express different kinds of dependency:
+
+- **`registryDependencies`**: Other registry patterns that must be installed first. The current pattern's
+  manifest fragment may reference instruments or account types from these patterns.
+  Example: `energy-settlement` depends on `base-fiat-gbp` because its account types allow GBP.
+
+- **`meta.requires.instruments`**: Instruments that must already exist in the tenant's manifest but are
+  not provided by a listed registry dependency. Use this when the instrument comes from a pattern
+  outside the registry (e.g., a tenant-specific currency).
+
+- **`meta.requires.market_data`**: Market data dataset codes that the pattern's valuation rules reference.
+  Example: `energy-settlement` requires `KWH_GBP_RETAIL` because its SPOT_RATE valuation rule reads it.
+
+- **`meta.provides`**: What this pattern contributes. The contents of `provides` should match exactly
+  what is in `manifest-fragment.yaml`. Tests enforce this: `provides.instruments` must match the
+  `instruments` list in the manifest fragment.
+
+---
+
+## Complexity Scoring
+
+The `meta.complexity` field uses the Fibonacci scale (1, 2, 3, 5, 8):
+
+| Score | What it means | Example |
+|-------|--------------|---------|
+| 1 | Single instrument definition, no sagas, no account types | `base-fiat-gbp`, `base-fiat-usd` |
+| 2 | One account type and/or one simple saga with a single step | A simple webhook receiver |
+| 3 | Multiple account types, one or two sagas, standard trigger pattern | `energy-settlement`, `kyc-compliance` |
+| 5 | Multiple sagas, cross-instrument valuation, multiple triggers | `saas-billing`, `carbon-offset` |
+| 8 | Gateway integration, multi-step saga with compensation, external provider | `payment-gateway-stripe` |
+
+Score based on uncertainty and scope, not line count. A 50-line saga with a well-understood pattern
+is complexity 3. An 8-line saga that integrates with an external provider is complexity 5.
+
+---
+
+## Design Pattern References
+
+The `meta.design_pattern` field names the design pattern this entry exemplifies. Valid names come from
+[`docs/guides/manifest-design-patterns.md`](../../docs/guides/manifest-design-patterns.md):
+
+| Value | Pattern | When to use |
+|-------|---------|-------------|
+| `null` | No pattern (foundation) | Base currency instruments |
+| `cross-instrument-valuation` | Pattern 1 | kWh → GBP, GPU_HOUR → USD (multi-leg) |
+| `compute-metering` | Pattern 2 | Usage billing with single target instrument |
+| `credit-retirement-lifecycle` | Pattern 3 | Carbon credits, irreversible retirement |
+| `operational-gateway` | Pattern 5/6 | External payment provider integration |
+| `compliance-marker` | Custom | Zero-amount positions as compliance audit trail |
+
+Set to `null` for foundation patterns (`base-fiat-*`). Set to the closest named pattern otherwise.
+If your pattern doesn't fit an existing name, use a descriptive kebab-case string.
+
+---
+
+## CEL Filter Chain Termination
+
+When a saga uses the `event:` trigger type, it reacts to platform events. If the saga produces new
+positions (e.g., booking a GBP charge after metering kWh), those positions also emit events. Without
+a termination condition, the saga re-triggers on its own output.
+
+**Rule:** Every `event:`-triggered saga that creates positions must have a CEL filter that excludes
+the instruments it writes.
+
+**Example from `energy-settlement`:**
+
+The `usage_to_value` saga triggers on `event:position-keeping.transaction-captured.v1` and books GBP
+positions. Its filter is:
+
+```cel
+event.instrument_code != 'GBP' && event.direction == 'DEBIT'
+```
+
+The `!= 'GBP'` clause ensures the saga ignores the GBP positions it creates. Without this, every
+GBP booking would re-trigger the saga.
+
+**Example from `saas-billing`:**
+
+The `compute_billing` saga triggers on GPU_HOUR DEBITs and creates USD charges:
+
+```cel
+event.instrument_code == 'GPU_HOUR' && event.direction == 'DEBIT'
+```
+
+An `==` filter on the source instrument implicitly terminates the chain: the saga only fires on
+GPU_HOUR, and it creates USD — so its output never matches the filter.
+
+Both approaches are valid. Use `==` (allowlist) when your pattern handles exactly one source instrument.
+Use `!=` (denylist) when the pattern should handle any non-settlement instrument.
+
+---
+
+## Step-by-Step: Creating a New Pattern
+
+### 1. Create the directory
+
+```bash
+mkdir -p cookbook/patterns/my-pattern
+```
+
+### 2. Write `manifest-fragment.yaml`
+
+Declare the manifest primitives this pattern adds to a tenant economy:
+
+```yaml
+instruments:
+  - code: MY_ASSET
+    name: My Asset
+    type: INSTRUMENT_TYPE_COMMODITY
+    dimensions:
+      unit: units
+      precision: 3
+
+accountTypes:
+  - code: MY_ACCOUNT
+    name: My Account
+    normalBalance: NORMAL_BALANCE_DEBIT
+    allowedInstruments: [MY_ASSET]
+    policies:
+      validation: "amount > 0"
+      bucketing: ""
+```
+
+Refer to existing fragments for valid `type` values (`INSTRUMENT_TYPE_FIAT`, `INSTRUMENT_TYPE_COMMODITY`,
+`INSTRUMENT_TYPE_VOUCHER`) and `normalBalance` values (`NORMAL_BALANCE_DEBIT`, `NORMAL_BALANCE_CREDIT`).
+
+### 3. Write any `.star` saga files
+
+If the pattern declares sagas, write a `.star` file for each. See the
+[Starlark Style Guide](../../docs/guides/starlark-style-guide.md) for syntax conventions.
+
+Minimum structure:
+
+```python
+# Saga: my_saga
+# Trigger: event:position-keeping.transaction-captured.v1
+# Filter:  event.instrument_code == 'MY_ASSET' && event.direction == 'DEBIT'
+
+my_saga_saga = saga(name="my_saga")
+
+def execute_my_saga():
+    ctx = input_data
+    correlation_id = ctx["correlation_id"]
+
+    # Idempotency check first
+    step(name="check_idempotency")
+    existing = position_keeping.query_logs(correlation_id=correlation_id)
+    if existing.count > 0:
+        return {"status": "ALREADY_PROCESSED", "correlation_id": correlation_id}
+
+    # ... saga logic
+
+    return {"status": "PROCESSED", "correlation_id": correlation_id}
+
+output = execute_my_saga()
+```
+
+### 4. Write `pattern.json`
+
+```json
+{
+    "$schema": "https://cookbook.meridianhub.org/schema/registry-item.json",
+    "name": "my-pattern",
+    "type": "registry:pattern",
+    "title": "My Pattern",
+    "description": "One sentence description.",
+    "registryDependencies": ["base-fiat-gbp"],
+    "categories": ["economy"],
+    "meta": {
+        "complexity": 3,
+        "design_pattern": "cross-instrument-valuation",
+        "industries": ["your-sector"],
+        "provides": {
+            "instruments": ["MY_ASSET"],
+            "account_types": ["MY_ACCOUNT"],
+            "sagas": ["my_saga"],
+            "valuation_rules": [],
+            "triggers": ["event:position-keeping.transaction-captured.v1"]
+        },
+        "requires": {
+            "instruments": ["GBP"],
+            "market_data": []
+        },
+        "composes_with": [],
+        "conflicts_with": [],
+        "extends": []
+    },
+    "files": [
+        {
+            "path": "patterns/my-pattern/manifest-fragment.yaml",
+            "type": "registry:file",
+            "target": "~/manifest-fragment.yaml"
+        },
+        {
+            "path": "patterns/my-pattern/my_saga.star",
+            "type": "registry:file",
+            "target": "~/sagas/my_saga.star"
+        }
+    ]
+}
+```
+
+### 5. Register in `registry.json`
+
+Add an entry to `cookbook/registry.json`:
+
+```json
+{
+    "name": "my-pattern",
+    "type": "registry:pattern"
+}
+```
+
+### 6. Run the tests
+
+```bash
+cd cookbook && go test ./...
+```
+
+Tests enforce: schema validation, `provides.instruments` matches manifest, `registryDependencies` exist
+in registry, all `files[]` paths exist on disk, no `.star` syntax errors, and no orphan files.
+
+---
+
+## Example: Simple Pattern (Energy Settlement)
+
+`energy-settlement` converts metered kWh into GBP using market rates. It requires `base-fiat-gbp`
+because its account types hold GBP, which must already exist.
+
+**`pattern.json` key decisions:**
+
+- `complexity: 3` — two account types, one saga, one valuation rule pair, standard trigger
+- `design_pattern: "cross-instrument-valuation"` — two settlement legs (retail + wholesale)
+- `registryDependencies: ["base-fiat-gbp"]` — uses GBP instrument from that pattern
+- `requires.market_data: ["KWH_GBP_RETAIL", "KWH_GBP_WHOLESALE"]` — SPOT_RATE valuation needs live rates
+- `composes_with: ["carbon-offset", "time-of-use-pricing"]` — these patterns add value alongside this one
+
+**`manifest-fragment.yaml` structure:** Declares KWH instrument, three account types (ENERGY_INVENTORY,
+SETTLEMENT, REVENUE), and two valuation rules for retail and wholesale conversion.
+
+**`usage_to_value.star`:** Triggered by `event:position-keeping.transaction-captured.v1`. The CEL
+filter `event.instrument_code != 'GBP' && event.direction == 'DEBIT'` prevents the GBP positions
+the saga creates from re-triggering it. The saga performs dual idempotency checks (one per leg)
+before calling `valuation_engine.compute()` for each rate, then books both GBP positions.
+
+---
+
+## Example: Complex Pattern (SaaS Billing)
+
+`saas-billing` meters GPU hours, API calls, and storage, then converts each to USD charges. It has
+three sagas for different trigger points (webhook, event, scheduled).
+
+**`pattern.json` key decisions:**
+
+- `complexity: 5` — four instruments, four account types, three sagas, four valuation rules, three triggers
+- `registryDependencies: ["base-fiat-usd"]` — all billing targets USD
+- `extends: ["base-fiat-usd"]` — declares it builds on the USD foundation pattern
+- `provides.triggers` lists all three trigger types: `webhook:`, `event:`, and `scheduled:`
+
+**Three sagas, three trigger types:**
+
+| Saga | Trigger | What it does |
+|------|---------|-------------|
+| `record_gpu_usage` | `webhook:gpu_meter_event` | Captures raw GPU_HOUR usage from meter events |
+| `compute_billing` | `event:position-keeping.transaction-captured.v1` with GPU_HOUR filter | Converts GPU_HOUR to USD charge |
+| `generate_monthly_invoice` | `scheduled:monthly_billing` | Aggregates month's usage into invoice |
+
+The `compute_billing` saga's filter `event.instrument_code == 'GPU_HOUR' && event.direction == 'DEBIT'`
+is specific to one instrument — it implicitly terminates any chain because the USD positions it creates
+do not match the GPU_HOUR filter.
+
+---
+
+## Testing Requirements
+
+Every pattern needs to pass the suite in `cookbook/validation_test.go` and `cookbook/patterns/patterns_test.go`.
+
+**What the tests check:**
+
+1. **Schema validation** — `pattern.json` conforms to `registry-item.json` (all required fields,
+   `complexity` is a valid Fibonacci value, `name` matches the kebab-case pattern).
+
+2. **Manifest consistency** — `meta.provides.instruments` lists exactly the instruments defined in
+   `manifest-fragment.yaml`. If the manifest declares KWH, `provides.instruments` must include `"KWH"`.
+
+3. **Dependency existence** — every name in `registryDependencies` and `meta.composes_with` must exist
+   in `registry.json`. Add your pattern to the registry before adding cross-references to it.
+
+4. **File existence** — every path in `files[]` must exist on disk relative to the cookbook root.
+
+5. **Starlark syntax** — all `.star` files parse without errors using the saga runtime's file options
+   (no `while` loops, no recursion).
+
+6. **No orphan files** — every `.json`, `.yaml`, and `.star` file in `cookbook/patterns/` (except
+   `pattern.json` and `manifest-fragment.yaml`) must be listed in a `files[]` array.
+
+Run with: `cd cookbook && go test ./...`


### PR DESCRIPTION
## Summary

- Expands `cookbook/docs/authoring-patterns.md` from a 7-line stub into a complete guide covering pattern structure, the `pattern.json` schema field reference, complexity scoring, design pattern references, CEL filter chain termination rules, a step-by-step creation walkthrough, and two worked examples (`energy-settlement` and `saas-billing`)
- Expands `cookbook/docs/authoring-components.md` from a 7-line stub into a complete guide covering component structure, the `component.json` schema field reference, tenant-configurable props guidance, feature module mapping, `registryDependencies` between components, a step-by-step creation walkthrough, and two worked examples (`saga-timeline` and `create-valuation-feature-dialog`)

Both guides use real examples drawn from existing cookbook entries rather than hypothetical ones.

## Test plan

- [ ] Pre-commit markdownlint passes (verified locally)
- [ ] No new files added — existing stub files expanded in place
- [ ] All examples reference real pattern/component names that exist in the registry