### PR TITLE
feat(frontend): create data hooks for all feature modules

### DIFF
--- a/frontend/src/features/internal-accounts/hooks/index.ts
+++ b/frontend/src/features/internal-accounts/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useInternalAccountsTable, useInternalAccountDetail } from './use-internal-accounts'

--- a/frontend/src/features/internal-accounts/hooks/use-internal-accounts.ts
+++ b/frontend/src/features/internal-accounts/hooks/use-internal-accounts.ts
@@ -1,0 +1,105 @@
+import { useQuery } from '@tanstack/react-query'
+import { ConnectError, Code } from '@connectrpc/connect'
+import { useApiClients } from '@/api/context'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import type { DataTableQueryParams, DataTableResult } from '@/shared/data-table'
+
+interface InternalAccountRow {
+  accountId: string
+  accountCode: string
+  name: string
+  behaviorClass: string
+  accountStatus: number
+  instrumentCode: string
+  createdAt?: { seconds: bigint | number; nanos?: number } | null
+}
+
+interface InternalAccount {
+  accountId: string
+  accountCode: string
+  name: string
+  behaviorClass: string
+  instrumentCode: string
+  accountStatus: number
+  description: string
+  createdAt?: { seconds: bigint | number; nanos?: number } | null
+  updatedAt?: { seconds: bigint | number; nanos?: number } | null
+}
+
+/**
+ * Fetches a paginated list of internal accounts for use with DataTable.
+ */
+export function useInternalAccountsTable() {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  const queryKey = tenantKeys.internalAccounts(tenantSlug ?? '')
+
+  async function queryFn(
+    params: DataTableQueryParams,
+  ): Promise<DataTableResult<InternalAccountRow>> {
+    if (!tenantSlug) return { items: [] }
+
+    const statusFilter = params.filters?.status ? parseInt(params.filters.status, 10) : 0
+
+    const res = await clients.internalAccount.listInternalAccounts({
+      behaviorClassFilter: params.filters?.behaviorClass ?? '',
+      statusFilter,
+      pagination: { pageToken: params.pageToken ?? '', pageSize: params.pageSize },
+    })
+
+    return {
+      items: res.facilities.map((f) => ({
+        accountId: f.accountId,
+        accountCode: f.accountCode,
+        name: f.name,
+        behaviorClass: f.behaviorClass,
+        accountStatus: f.accountStatus,
+        instrumentCode: f.instrumentCode,
+        createdAt: f.createdAt ?? null,
+      })),
+      nextPageToken: res.pagination?.nextPageToken || undefined,
+    }
+  }
+
+  return { queryKey, queryFn, tenantSlug }
+}
+
+/**
+ * Fetches a single internal account by ID.
+ */
+export function useInternalAccountDetail(accountId: string | undefined) {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  const queryKey = tenantKeys.internalAccount(tenantSlug ?? '', accountId ?? '')
+
+  return useQuery({
+    queryKey,
+    queryFn: async (): Promise<InternalAccount | null> => {
+      try {
+        const response = await clients.internalAccount.retrieveInternalAccount({
+          accountId: accountId ?? '',
+        })
+        const f = response.facility
+        if (!f) return null
+        return {
+          accountId: f.accountId,
+          accountCode: f.accountCode,
+          name: f.name,
+          behaviorClass: f.behaviorClass,
+          instrumentCode: f.instrumentCode,
+          accountStatus: f.accountStatus,
+          description: f.description,
+          createdAt: f.createdAt ?? null,
+          updatedAt: f.updatedAt ?? null,
+        }
+      } catch (err: unknown) {
+        if (ConnectError.from(err).code === Code.NotFound) return null
+        throw err
+      }
+    },
+    enabled: Boolean(tenantSlug && accountId),
+  })
+}

--- a/frontend/src/features/internal-accounts/pages/[accountId].tsx
+++ b/frontend/src/features/internal-accounts/pages/[accountId].tsx
@@ -8,29 +8,17 @@ import { StatusBadge } from '@/shared/status-badge'
 import { TimeDisplay } from '@/shared/time-display'
 import { MoneyDisplay } from '@/shared/money-display'
 import { AuditTrail, Breadcrumbs } from '@/shared'
-import { ConnectError, Code } from '@connectrpc/connect'
 import { useApiClients } from '@/api/context'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
 import { ControlAction } from '@/api/gen/meridian/internal_account/v1/internal_account_pb'
+import { useInternalAccountDetail } from '../hooks'
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 type InternalAccountStatusLabel = 'ACTIVE' | 'SUSPENDED' | 'CLOSED' | 'UNKNOWN'
-
-interface InternalAccount {
-  accountId: string
-  accountCode: string
-  name: string
-  behaviorClass: string
-  instrumentCode: string
-  accountStatus: number
-  description: string
-  createdAt?: { seconds: bigint | number; nanos?: number } | null
-  updatedAt?: { seconds: bigint | number; nanos?: number } | null
-}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -276,35 +264,10 @@ function InternalAccountTransactions({ accountId, instrumentCode }: { accountId:
 export function InternalAccountDetailPage() {
   const { accountId } = useParams<{ accountId: string }>()
   const { tenantSlug } = useTenantContext()
-  const clients = useApiClients()
 
   const queryKey = tenantKeys.internalAccount(tenantSlug ?? '', accountId ?? '')
 
-  const { data: account, isLoading, isError } = useQuery({
-    queryKey,
-    queryFn: async (): Promise<InternalAccount | null> => {
-      try {
-        const response = await clients.internalAccount.retrieveInternalAccount({ accountId: accountId ?? '' })
-        const f = response.facility
-        if (!f) return null
-        return {
-          accountId: f.accountId,
-          accountCode: f.accountCode,
-          name: f.name,
-          behaviorClass: f.behaviorClass,
-          instrumentCode: f.instrumentCode,
-          accountStatus: f.accountStatus,
-          description: f.description,
-          createdAt: f.createdAt ?? null,
-          updatedAt: f.updatedAt ?? null,
-        }
-      } catch (err: unknown) {
-        if (ConnectError.from(err).code === Code.NotFound) return null
-        throw err
-      }
-    },
-    enabled: !!accountId,
-  })
+  const { data: account, isLoading, isError } = useInternalAccountDetail(accountId)
 
   if (isLoading) {
     return <InternalAccountDetailSkeleton />

--- a/frontend/src/features/internal-accounts/pages/index.tsx
+++ b/frontend/src/features/internal-accounts/pages/index.tsx
@@ -4,10 +4,8 @@ import { useNavigate } from 'react-router-dom'
 import { DataTable } from '@/shared/data-table'
 import { StatusBadge } from '@/shared/status-badge'
 import { TimeDisplay } from '@/shared'
-import { useApiClients } from '@/api/context'
-import { useTenantContext } from '@/contexts/tenant-context'
-import { tenantKeys } from '@/lib/query-keys'
 import { Button } from '@/components/ui/button'
+import { useInternalAccountsTable } from '../hooks'
 import { CreateInternalAccountDialog } from './create-internal-account-dialog'
 
 interface InternalAccountRow {
@@ -90,8 +88,7 @@ const columns: ColumnDef<InternalAccountRow>[] = [
 ]
 
 export function InternalAccountsPage() {
-  const { tenantSlug } = useTenantContext()
-  const clients = useApiClients()
+  const { queryKey, queryFn, tenantSlug } = useInternalAccountsTable()
   const navigate = useNavigate()
   const [createDialogOpen, setCreateDialogOpen] = React.useState(false)
 
@@ -121,27 +118,8 @@ export function InternalAccountsPage() {
       />
 
       <DataTable<InternalAccountRow>
-        queryKey={tenantKeys.internalAccounts(tenantSlug)}
-        queryFn={async ({ pageToken, pageSize, filters }) => {
-          const statusFilter = filters?.status ? parseInt(filters.status, 10) : 0
-          const res = await clients.internalAccount.listInternalAccounts({
-            behaviorClassFilter: filters?.behaviorClass ?? '',
-            statusFilter,
-            pagination: { pageToken: pageToken ?? '', pageSize },
-          })
-          return {
-            items: res.facilities.map((f) => ({
-              accountId: f.accountId,
-              accountCode: f.accountCode,
-              name: f.name,
-              behaviorClass: f.behaviorClass,
-              accountStatus: f.accountStatus,
-              instrumentCode: f.instrumentCode,
-              createdAt: f.createdAt ?? null,
-            })),
-            nextPageToken: res.pagination?.nextPageToken || undefined,
-          }
-        }}
+        queryKey={queryKey}
+        queryFn={queryFn}
         columns={columns}
         pageSize={25}
         filters={[

--- a/frontend/src/features/ledger/hooks/index.ts
+++ b/frontend/src/features/ledger/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useBookingLogsTable, useBookingLogDetail, useLedgerPostings } from './use-ledger'

--- a/frontend/src/features/ledger/hooks/use-ledger.ts
+++ b/frontend/src/features/ledger/hooks/use-ledger.ts
@@ -125,25 +125,13 @@ export function useBookingLogDetail(bookingLogId: string | undefined) {
         status: getStatusName(p.status),
       }))
 
-      function getCurrencyName(currency: unknown): string {
-        if (typeof currency === 'string') return currency
-        if (typeof currency === 'number') {
-          const currencyMap: Record<number, string> = {
-            0: 'UNSPECIFIED', 1: 'GBP', 2: 'USD', 3: 'EUR', 4: 'JPY',
-            5: 'AUD', 6: 'CAD', 7: 'CHF', 8: 'CNY', 9: 'INR', 10: 'SGD', 11: 'HKD',
-          }
-          return currencyMap[currency] ?? String(currency)
-        }
-        return String(currency ?? '')
-      }
-
       return {
         id: log.id,
         financialAccountType: String(log.financialAccountType ?? ''),
         productServiceReference: String(log.productServiceReference ?? ''),
         businessUnitReference: String(log.businessUnitReference ?? ''),
         chartOfAccountsRules: String(log.chartOfAccountsRules ?? ''),
-        instrumentCode: getCurrencyName(log.baseCurrency),
+        instrumentCode: getInstrumentCode(log.baseInstrumentCode),
         status: getStatusName(log.status),
         createdAt: log.createdAt ?? null,
         updatedAt: log.updatedAt ?? null,

--- a/frontend/src/features/ledger/hooks/use-ledger.ts
+++ b/frontend/src/features/ledger/hooks/use-ledger.ts
@@ -1,0 +1,173 @@
+import { useQuery } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import type { DataTableQueryParams, DataTableResult } from '@/shared/data-table'
+import type { FinancialBookingLog, LedgerPosting } from '../pages/types'
+
+function getStatusName(status: unknown): string {
+  if (typeof status === 'string') return status
+  if (typeof status === 'number') {
+    const statusMap: Record<number, string> = {
+      0: 'UNSPECIFIED',
+      1: 'PENDING',
+      2: 'POSTED',
+      3: 'FAILED',
+      4: 'CANCELLED',
+      5: 'REVERSED',
+    }
+    return statusMap[status] ?? String(status)
+  }
+  return String(status ?? '')
+}
+
+function getDirectionName(direction: unknown): string {
+  if (typeof direction === 'string') return direction
+  if (typeof direction === 'number') {
+    const dirMap: Record<number, string> = {
+      0: 'UNSPECIFIED',
+      1: 'DEBIT',
+      2: 'CREDIT',
+    }
+    return dirMap[direction] ?? String(direction)
+  }
+  return String(direction ?? '')
+}
+
+function getInstrumentCode(value: unknown): string {
+  if (typeof value === 'string' && value) return value
+  return ''
+}
+
+/**
+ * Fetches a paginated list of booking logs for use with DataTable.
+ */
+export function useBookingLogsTable() {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  const queryKey = [...(tenantSlug ? tenantKeys.all(tenantSlug) : ['no-tenant']), 'ledger', 'bookingLogs'] as const
+
+  async function queryFn(
+    params: DataTableQueryParams,
+  ): Promise<DataTableResult<FinancialBookingLog>> {
+    if (!tenantSlug) return { items: [] }
+
+    const statusFilter = params.filters?.status
+
+    const response = await clients.financialAccounting.listFinancialBookingLogs({
+      pagination: { pageSize: params.pageSize, pageToken: params.pageToken ?? '' },
+      ...(statusFilter !== undefined && { status: statusFilter as never }),
+    })
+
+    const items = (response.financialBookingLogs ?? []).map((log) => ({
+      id: log.id,
+      financialAccountType: String(log.financialAccountType ?? ''),
+      productServiceReference: String(log.productServiceReference ?? ''),
+      businessUnitReference: String(log.businessUnitReference ?? ''),
+      chartOfAccountsRules: String(log.chartOfAccountsRules ?? ''),
+      instrumentCode: getInstrumentCode(log.baseInstrumentCode),
+      status: getStatusName(log.status),
+      createdAt: log.createdAt ?? null,
+      updatedAt: log.updatedAt ?? null,
+      postings: (log.postings ?? []) as FinancialBookingLog['postings'],
+    })) as FinancialBookingLog[]
+
+    const nextPageToken =
+      typeof response.pagination?.nextPageToken === 'string'
+        ? response.pagination.nextPageToken
+        : undefined
+
+    return {
+      items,
+      nextPageToken: nextPageToken || undefined,
+    }
+  }
+
+  return { queryKey, queryFn, tenantSlug }
+}
+
+/**
+ * Fetches a single booking log by ID with its postings.
+ */
+export function useBookingLogDetail(bookingLogId: string | undefined) {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  return useQuery({
+    queryKey: [...tenantKeys.all(tenantSlug ?? ''), 'ledger', 'bookingLog', bookingLogId],
+    queryFn: async (): Promise<FinancialBookingLog | null> => {
+      const response = await clients.financialAccounting.retrieveFinancialBookingLog({
+        id: bookingLogId ?? '',
+      })
+
+      const log = response.financialBookingLog
+      if (!log) return null
+
+      const postings: LedgerPosting[] = (log.postings ?? []).map((p) => ({
+        id: p.id,
+        financialBookingLogId: p.financialBookingLogId,
+        postingDirection: getDirectionName(p.postingDirection),
+        postingAmount: {
+          currencyCode: typeof p.postingAmount?.currencyCode === 'string'
+            ? p.postingAmount.currencyCode
+            : '',
+          units: (() => {
+            const u = p.postingAmount?.units
+            return typeof u === 'bigint' ? u : typeof u === 'number' && Number.isSafeInteger(u) ? BigInt(u) : 0n
+          })(),
+          nanos: p.postingAmount?.nanos ?? 0,
+        },
+        accountId: p.accountId,
+        valueDate: p.valueDate ?? null,
+        postingResult: p.postingResult ?? '',
+        createdAt: p.createdAt ?? null,
+        status: getStatusName(p.status),
+      }))
+
+      function getCurrencyName(currency: unknown): string {
+        if (typeof currency === 'string') return currency
+        if (typeof currency === 'number') {
+          const currencyMap: Record<number, string> = {
+            0: 'UNSPECIFIED', 1: 'GBP', 2: 'USD', 3: 'EUR', 4: 'JPY',
+            5: 'AUD', 6: 'CAD', 7: 'CHF', 8: 'CNY', 9: 'INR', 10: 'SGD', 11: 'HKD',
+          }
+          return currencyMap[currency] ?? String(currency)
+        }
+        return String(currency ?? '')
+      }
+
+      return {
+        id: log.id,
+        financialAccountType: String(log.financialAccountType ?? ''),
+        productServiceReference: String(log.productServiceReference ?? ''),
+        businessUnitReference: String(log.businessUnitReference ?? ''),
+        chartOfAccountsRules: String(log.chartOfAccountsRules ?? ''),
+        instrumentCode: getCurrencyName(log.baseCurrency),
+        status: getStatusName(log.status),
+        createdAt: log.createdAt ?? null,
+        updatedAt: log.updatedAt ?? null,
+        postings,
+      }
+    },
+    enabled: Boolean(tenantSlug && bookingLogId),
+  })
+}
+
+/**
+ * Fetches ledger postings for a specific account.
+ */
+export function useLedgerPostings(accountId: string | undefined) {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  return useQuery({
+    queryKey: [...tenantKeys.all(tenantSlug ?? ''), 'ledger', 'postings', accountId],
+    queryFn: () =>
+      clients.financialAccounting.listLedgerPostings({
+        pagination: { pageSize: 50, pageToken: '' },
+        accountId: accountId ?? '',
+      }),
+    enabled: Boolean(tenantSlug && accountId),
+  })
+}

--- a/frontend/src/features/ledger/pages/booking-log-detail.test.tsx
+++ b/frontend/src/features/ledger/pages/booking-log-detail.test.tsx
@@ -86,7 +86,7 @@ const mockBookingLog = {
   productServiceReference: 'PROD-A',
   businessUnitReference: 'BU-TRADE',
   chartOfAccountsRules: 'STANDARD',
-  baseCurrency: 'GBP',
+  baseInstrumentCode: 'GBP',
   status: 'PENDING',
   createdAt: { seconds: 1700000000n, nanos: 0 },
   updatedAt: { seconds: 1700001000n, nanos: 0 },
@@ -369,7 +369,7 @@ describe('BookingLogDetailPage', () => {
   })
 
   it('handles numeric currency code (GBP=1)', async () => {
-    const logWithNumericCurrency = { ...mockBookingLog, baseCurrency: 1 }
+    const logWithNumericCurrency = { ...mockBookingLog, baseInstrumentCode: 1 }
     setupMockClients({ result: { financialBookingLog: logWithNumericCurrency } })
     renderWithApiClients(<BookingLogDetailPage />, {
       initialToken: createTenantUserToken('tenant-001'),

--- a/frontend/src/features/ledger/pages/booking-log-detail.tsx
+++ b/frontend/src/features/ledger/pages/booking-log-detail.tsx
@@ -1,14 +1,10 @@
 import { useParams } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
 import type { ColumnDef } from '@tanstack/react-table'
 import {
   flexRender,
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import { useApiClients } from '@/api/context'
-import { useTenantContext } from '@/contexts/tenant-context'
-import { tenantKeys } from '@/lib/query-keys'
 import { StatusBadge } from '@/shared/status-badge'
 import { TimeDisplay, EntityLink, Breadcrumbs } from '@/shared'
 import { MoneyDisplay } from '@/shared/money-display'
@@ -21,26 +17,11 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useBookingLogDetail } from '../hooks'
 import { BalanceIndicator } from './balance-indicator'
 import { DirectionBadge } from './direction-badge'
 import { BookingLogHeader } from './booking-log-header'
-import type { LedgerPosting, FinancialBookingLog } from './types'
-
-function getStatusName(status: unknown): string {
-  if (typeof status === 'string') return status
-  if (typeof status === 'number') {
-    const statusMap: Record<number, string> = {
-      0: 'UNSPECIFIED',
-      1: 'PENDING',
-      2: 'POSTED',
-      3: 'FAILED',
-      4: 'CANCELLED',
-      5: 'REVERSED',
-    }
-    return statusMap[status] ?? String(status)
-  }
-  return String(status ?? '')
-}
+import type { LedgerPosting } from './types'
 
 function getDirectionName(direction: unknown): string {
   if (typeof direction === 'string') return direction
@@ -53,28 +34,6 @@ function getDirectionName(direction: unknown): string {
     return dirMap[direction] ?? String(direction)
   }
   return String(direction ?? '')
-}
-
-function getCurrencyName(currency: unknown): string {
-  if (typeof currency === 'string') return currency
-  if (typeof currency === 'number') {
-    const currencyMap: Record<number, string> = {
-      0: 'UNSPECIFIED',
-      1: 'GBP',
-      2: 'USD',
-      3: 'EUR',
-      4: 'JPY',
-      5: 'AUD',
-      6: 'CAD',
-      7: 'CHF',
-      8: 'CNY',
-      9: 'INR',
-      10: 'SGD',
-      11: 'HKD',
-    }
-    return currencyMap[currency] ?? String(currency)
-  }
-  return String(currency ?? '')
 }
 
 function computeTotals(postings: LedgerPosting[], _currency: string): { debitTotal: bigint; creditTotal: bigint } {
@@ -140,7 +99,7 @@ const postingColumns: ColumnDef<LedgerPosting>[] = [
     accessorKey: 'status',
     header: 'Status',
     cell: ({ row }) => (
-      <StatusBadge status={getStatusName(row.original.status)} />
+      <StatusBadge status={row.original.status} />
     ),
   },
 ]
@@ -192,60 +151,11 @@ function PostingsTable({ postings }: { postings: LedgerPosting[] }) {
 
 export function BookingLogDetailPage() {
   const { bookingLogId } = useParams<{ bookingLogId: string }>()
-  const { tenantSlug } = useTenantContext()
-  const clients = useApiClients()
 
-  const { data, isLoading, isError } = useQuery({
-    queryKey: [...tenantKeys.all(tenantSlug ?? ''), 'ledger', 'bookingLog', bookingLogId],
-    queryFn: async () => {
-      const response = await clients.financialAccounting.retrieveFinancialBookingLog({
-        id: bookingLogId ?? '',
-      })
-
-      const log = response.financialBookingLog
-      if (!log) return null
-
-      const postings: LedgerPosting[] = (log.postings ?? []).map((p) => ({
-        id: p.id,
-        financialBookingLogId: p.financialBookingLogId,
-        postingDirection: getDirectionName(p.postingDirection),
-        postingAmount: {
-          currencyCode: typeof p.postingAmount?.currencyCode === 'string'
-            ? p.postingAmount.currencyCode
-            : '',
-          units: (() => {
-            const u = p.postingAmount?.units
-            return typeof u === 'bigint' ? u : typeof u === 'number' && Number.isSafeInteger(u) ? BigInt(u) : 0n
-          })(),
-          nanos: p.postingAmount?.nanos ?? 0,
-        },
-        accountId: p.accountId,
-        valueDate: p.valueDate ?? null,
-        postingResult: p.postingResult ?? '',
-        createdAt: p.createdAt ?? null,
-        status: getStatusName(p.status),
-      }))
-
-      const bookingLog: FinancialBookingLog = {
-        id: log.id,
-        financialAccountType: String(log.financialAccountType ?? ''),
-        productServiceReference: String(log.productServiceReference ?? ''),
-        businessUnitReference: String(log.businessUnitReference ?? ''),
-        chartOfAccountsRules: String(log.chartOfAccountsRules ?? ''),
-        baseCurrency: getCurrencyName(log.baseCurrency),
-        status: getStatusName(log.status),
-        createdAt: log.createdAt ?? null,
-        updatedAt: log.updatedAt ?? null,
-        postings,
-      }
-
-      return bookingLog
-    },
-    enabled: !!tenantSlug && !!bookingLogId,
-  })
+  const { data, isLoading, isError } = useBookingLogDetail(bookingLogId)
 
   const postings = data?.postings ?? []
-  const currency = data?.baseCurrency ?? 'GBP'
+  const currency = data?.instrumentCode ?? 'GBP'
   const { debitTotal, creditTotal } = computeTotals(postings, currency)
 
   if (isLoading) {

--- a/frontend/src/features/ledger/pages/booking-log-detail.tsx
+++ b/frontend/src/features/ledger/pages/booking-log-detail.tsx
@@ -155,7 +155,8 @@ export function BookingLogDetailPage() {
   const { data, isLoading, isError } = useBookingLogDetail(bookingLogId)
 
   const postings = data?.postings ?? []
-  const currency = data?.instrumentCode ?? 'GBP'
+  const postingCurrency = postings.find((p) => p.postingAmount?.currencyCode)?.postingAmount?.currencyCode
+  const currency = data?.instrumentCode || postingCurrency || ''
   const { debitTotal, creditTotal } = computeTotals(postings, currency)
 
   if (isLoading) {

--- a/frontend/src/features/ledger/pages/booking-log-header.test.tsx
+++ b/frontend/src/features/ledger/pages/booking-log-header.test.tsx
@@ -9,7 +9,7 @@ const mockBookingLog: FinancialBookingLog = {
   productServiceReference: 'PRODUCT-A',
   businessUnitReference: 'BU-TRADING',
   chartOfAccountsRules: 'STANDARD',
-  baseCurrency: 'GBP',
+  instrumentCode: 'GBP',
   status: 'PENDING',
   createdAt: { seconds: 1700000000n, nanos: 0 },
   updatedAt: { seconds: 1700001000n, nanos: 0 },

--- a/frontend/src/features/ledger/pages/booking-log-header.tsx
+++ b/frontend/src/features/ledger/pages/booking-log-header.tsx
@@ -36,7 +36,7 @@ export function BookingLogHeader({ bookingLog }: BookingLogHeaderProps) {
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
         <MetaField label="Account Type" value={bookingLog.financialAccountType} />
         <MetaField label="Business Unit" value={bookingLog.businessUnitReference} />
-        <MetaField label="Currency" value={bookingLog.baseCurrency} />
+        <MetaField label="Currency" value={bookingLog.instrumentCode} />
         <MetaField
           label="Postings"
           value={

--- a/frontend/src/features/ledger/pages/index.tsx
+++ b/frontend/src/features/ledger/pages/index.tsx
@@ -1,33 +1,10 @@
 import { useNavigate } from 'react-router-dom'
 import type { ColumnDef } from '@tanstack/react-table'
-import { useApiClients } from '@/api/context'
-import { useTenantContext } from '@/contexts/tenant-context'
-import { tenantKeys } from '@/lib/query-keys'
-import { DataTable, type DataTableQueryParams, type DataTableResult } from '@/shared/data-table'
+import { DataTable } from '@/shared/data-table'
 import { StatusBadge } from '@/shared/status-badge'
 import { TimeDisplay } from '@/shared'
+import { useBookingLogsTable } from '../hooks'
 import type { FinancialBookingLog } from './types'
-
-function getStatusName(status: unknown): string {
-  if (typeof status === 'string') return status
-  if (typeof status === 'number') {
-    const statusMap: Record<number, string> = {
-      0: 'UNSPECIFIED',
-      1: 'PENDING',
-      2: 'POSTED',
-      3: 'FAILED',
-      4: 'CANCELLED',
-      5: 'REVERSED',
-    }
-    return statusMap[status] ?? String(status)
-  }
-  return String(status ?? '')
-}
-
-function getInstrumentCode(value: unknown): string {
-  if (typeof value === 'string' && value) return value
-  return ''
-}
 
 const columns: ColumnDef<FinancialBookingLog>[] = [
   {
@@ -64,45 +41,8 @@ const columns: ColumnDef<FinancialBookingLog>[] = [
 ]
 
 export function LedgerPage() {
-  const { tenantSlug } = useTenantContext()
-  const clients = useApiClients()
+  const { queryKey, queryFn } = useBookingLogsTable()
   const navigate = useNavigate()
-
-  async function fetchBookingLogs(
-    params: DataTableQueryParams,
-  ): Promise<DataTableResult<FinancialBookingLog>> {
-    if (!tenantSlug) return { items: [] }
-
-    const statusFilter = params.filters?.status
-
-    const response = await clients.financialAccounting.listFinancialBookingLogs({
-      pagination: { pageSize: params.pageSize, pageToken: params.pageToken ?? '' },
-      ...(statusFilter !== undefined && { status: statusFilter as never }),
-    })
-
-    const items = (response.financialBookingLogs ?? []).map((log) => ({
-      id: log.id,
-      financialAccountType: String(log.financialAccountType ?? ''),
-      productServiceReference: String(log.productServiceReference ?? ''),
-      businessUnitReference: String(log.businessUnitReference ?? ''),
-      chartOfAccountsRules: String(log.chartOfAccountsRules ?? ''),
-      instrumentCode: getInstrumentCode(log.baseInstrumentCode),
-      status: getStatusName(log.status),
-      createdAt: log.createdAt ?? null,
-      updatedAt: log.updatedAt ?? null,
-      postings: (log.postings ?? []) as FinancialBookingLog['postings'],
-    })) as FinancialBookingLog[]
-
-    const nextPageToken =
-      typeof response.pagination?.nextPageToken === 'string'
-        ? response.pagination.nextPageToken
-        : undefined
-
-    return {
-      items,
-      nextPageToken: nextPageToken || undefined,
-    }
-  }
 
   function handleRowClick(row: FinancialBookingLog) {
     void navigate(`/ledger/${row.id}`)
@@ -118,8 +58,8 @@ export function LedgerPage() {
       </div>
 
       <DataTable<FinancialBookingLog>
-        queryKey={[...(tenantSlug ? tenantKeys.all(tenantSlug) : ['no-tenant']), 'ledger', 'bookingLogs']}
-        queryFn={fetchBookingLogs}
+        queryKey={queryKey}
+        queryFn={queryFn}
         columns={columns}
         pageSize={25}
         filters={[

--- a/frontend/src/features/market-data/hooks/index.ts
+++ b/frontend/src/features/market-data/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useDatasetsTable, useDatasetDetail, useDatasetObservations } from './use-market-data'

--- a/frontend/src/features/market-data/hooks/use-market-data.ts
+++ b/frontend/src/features/market-data/hooks/use-market-data.ts
@@ -1,0 +1,93 @@
+import { useQuery } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import type { DataTableQueryParams, DataTableResult } from '@/shared/data-table'
+
+interface DataSetRow {
+  id: string
+  code: string
+  displayName: string
+  category: number
+  unit: string
+  status: number
+  createdAt?: { seconds: bigint | number; nanos?: number } | null
+}
+
+/**
+ * Fetches a paginated list of market data sets for use with DataTable.
+ */
+export function useDatasetsTable() {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  const queryKey = tenantKeys.marketDataSets(tenantSlug ?? '')
+
+  async function queryFn(
+    params: DataTableQueryParams,
+  ): Promise<DataTableResult<DataSetRow>> {
+    if (!tenantSlug) return { items: [] }
+
+    const statusFilter = params.filters?.status ? parseInt(params.filters.status, 10) : 0
+    const categoryFilter = params.filters?.category ? parseInt(params.filters.category, 10) : 0
+
+    const res = await clients.marketInformation.listDataSets({
+      statusFilter,
+      categoryFilter,
+      pageSize: params.pageSize,
+      pageToken: params.pageToken ?? '',
+    })
+
+    return {
+      items: res.datasets.map((d) => ({
+        id: d.id,
+        code: d.code,
+        displayName: d.displayName,
+        category: d.category,
+        unit: d.unit,
+        status: d.status,
+        createdAt: d.createdAt ?? null,
+      })),
+      nextPageToken: res.nextPageToken || undefined,
+    }
+  }
+
+  return { queryKey, queryFn, tenantSlug }
+}
+
+/**
+ * Fetches a single market data set by code.
+ */
+export function useDatasetDetail(datasetCode: string | undefined) {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  return useQuery({
+    queryKey: tenantKeys.marketDataSet(tenantSlug ?? '', datasetCode ?? ''),
+    queryFn: () =>
+      clients.marketInformation.retrieveDataSet({
+        code: datasetCode!,
+        version: 0,
+      }),
+    enabled: Boolean(tenantSlug && datasetCode),
+  })
+}
+
+/**
+ * Fetches observations for a dataset.
+ */
+export function useDatasetObservations(datasetCode: string | undefined) {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  return useQuery({
+    queryKey: [...tenantKeys.marketDataSet(tenantSlug ?? '', datasetCode ?? ''), 'observations'],
+    queryFn: () =>
+      clients.marketInformation.listObservations({
+        datasetCode: datasetCode!,
+        pageSize: 100,
+        pageToken: '',
+      }),
+    enabled: Boolean(tenantSlug && datasetCode),
+  })
+}

--- a/frontend/src/features/market-data/hooks/use-market-data.ts
+++ b/frontend/src/features/market-data/hooks/use-market-data.ts
@@ -28,8 +28,8 @@ export function useDatasetsTable() {
   ): Promise<DataTableResult<DataSetRow>> {
     if (!tenantSlug) return { items: [] }
 
-    const statusFilter = params.filters?.status ? parseInt(params.filters.status, 10) : 0
-    const categoryFilter = params.filters?.category ? parseInt(params.filters.category, 10) : 0
+    const statusFilter = params.filters?.status ? (parseInt(params.filters.status, 10) || 0) : 0
+    const categoryFilter = params.filters?.category ? (parseInt(params.filters.category, 10) || 0) : 0
 
     const res = await clients.marketInformation.listDataSets({
       statusFilter,

--- a/frontend/src/features/market-data/pages/[datasetCode].tsx
+++ b/frontend/src/features/market-data/pages/[datasetCode].tsx
@@ -1,13 +1,11 @@
 import { useParams } from 'react-router-dom'
 import { Breadcrumbs } from '@/shared'
-import { useQuery } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { StatusBadge } from '@/shared/status-badge'
 import { Skeleton } from '@/components/ui/skeleton'
-import { useApiClients } from '@/api/context'
-import { useTenantContext } from '@/contexts/tenant-context'
-import { tenantKeys } from '@/lib/query-keys'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { useDatasetDetail, useDatasetObservations } from '../hooks'
 
 interface ObservationPoint {
   x: number // unix seconds
@@ -159,40 +157,10 @@ function ObservationChart({ points, unit }: { points: ObservationPoint[]; unit: 
 
 export function DatasetDetailPage() {
   const { datasetCode } = useParams<{ datasetCode: string }>()
-  const { tenantSlug } = useTenantContext()
-  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
 
-  const datasetQuery = useQuery({
-    queryKey: [
-      ...tenantKeys.all(tenantSlug ?? ''),
-      'market-data',
-      'datasets',
-      datasetCode,
-    ],
-    queryFn: () =>
-      clients.marketInformation.retrieveDataSet({
-        code: datasetCode!,
-        version: 0,
-      }),
-    enabled: !!tenantSlug && !!datasetCode,
-  })
-
-  const observationsQuery = useQuery({
-    queryKey: [
-      ...tenantKeys.all(tenantSlug ?? ''),
-      'market-data',
-      'datasets',
-      datasetCode,
-      'observations',
-    ],
-    queryFn: () =>
-      clients.marketInformation.listObservations({
-        datasetCode: datasetCode!,
-        pageSize: 100,
-        pageToken: '',
-      }),
-    enabled: !!tenantSlug && !!datasetCode,
-  })
+  const datasetQuery = useDatasetDetail(datasetCode)
+  const observationsQuery = useDatasetObservations(datasetCode)
 
   if (!tenantSlug) {
     return (

--- a/frontend/src/features/market-data/pages/index.tsx
+++ b/frontend/src/features/market-data/pages/index.tsx
@@ -4,10 +4,8 @@ import { useNavigate } from 'react-router-dom'
 import { DataTable } from '@/shared/data-table'
 import { StatusBadge } from '@/shared/status-badge'
 import { TimeDisplay } from '@/shared'
-import { useApiClients } from '@/api/context'
-import { useTenantContext } from '@/contexts/tenant-context'
-import { tenantKeys } from '@/lib/query-keys'
 import { Button } from '@/components/ui/button'
+import { useDatasetsTable } from '../hooks'
 import { CATEGORY_OPTIONS, STATUS_OPTIONS } from './constants'
 import { RegisterDataSetDialog } from './register-dataset-dialog'
 
@@ -107,8 +105,7 @@ const columns: ColumnDef<DataSetRow>[] = [
 ]
 
 export function MarketDataPage() {
-  const { tenantSlug } = useTenantContext()
-  const clients = useApiClients()
+  const { queryKey, queryFn, tenantSlug } = useDatasetsTable()
   const navigate = useNavigate()
   const [registerOpen, setRegisterOpen] = React.useState(false)
 
@@ -133,29 +130,8 @@ export function MarketDataPage() {
       </div>
 
       <DataTable<DataSetRow>
-        queryKey={[...tenantKeys.all(tenantSlug), 'market-data', 'datasets']}
-        queryFn={async ({ pageToken, pageSize, filters }) => {
-          const statusFilter = filters?.status ? parseInt(filters.status, 10) : 0
-          const categoryFilter = filters?.category ? parseInt(filters.category, 10) : 0
-          const res = await clients.marketInformation.listDataSets({
-            statusFilter,
-            categoryFilter,
-            pageSize,
-            pageToken: pageToken ?? '',
-          })
-          return {
-            items: res.datasets.map((d) => ({
-              id: d.id,
-              code: d.code,
-              displayName: d.displayName,
-              category: d.category,
-              unit: d.unit,
-              status: d.status,
-              createdAt: d.createdAt ?? null,
-            })),
-            nextPageToken: res.nextPageToken || undefined,
-          }
-        }}
+        queryKey={queryKey}
+        queryFn={queryFn}
         columns={columns}
         pageSize={25}
         filters={[

--- a/frontend/src/features/parties/hooks/index.ts
+++ b/frontend/src/features/parties/hooks/index.ts
@@ -1,0 +1,1 @@
+export { usePartiesTable, usePartyDetail, usePartyAssociations } from './use-parties'

--- a/frontend/src/features/parties/hooks/use-parties.ts
+++ b/frontend/src/features/parties/hooks/use-parties.ts
@@ -1,0 +1,96 @@
+import { useCallback } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import type { DataTableQueryParams, DataTableResult } from '@/shared/data-table'
+import type { Party } from '../pages/index'
+
+function partyStatusLabel(status: unknown): string {
+  if (typeof status === 'string') return status
+  const map: Record<number, string> = {
+    0: 'UNSPECIFIED',
+    1: 'PARTY_STATUS_ACTIVE',
+    2: 'PARTY_STATUS_RESTRICTED',
+    3: 'PARTY_STATUS_SUSPENDED',
+    4: 'PARTY_STATUS_TERMINATED',
+  }
+  return map[status as number] ?? 'UNKNOWN'
+}
+
+function partyTypeLabel(partyType: unknown): string {
+  if (typeof partyType === 'string') return partyType
+  const map: Record<number, string> = {
+    0: 'UNSPECIFIED',
+    1: 'PARTY_TYPE_PERSON',
+    2: 'PARTY_TYPE_ORGANIZATION',
+  }
+  return map[partyType as number] ?? 'UNKNOWN'
+}
+
+/**
+ * Fetches a paginated list of parties for use with DataTable.
+ */
+export function usePartiesTable() {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  const queryKey = tenantKeys.parties(tenantSlug ?? '')
+
+  const queryFn = useCallback(async (params: DataTableQueryParams): Promise<DataTableResult<Party>> => {
+    const response = await clients.party.listParties({
+      pageToken: params.pageToken,
+      pageSize: params.pageSize,
+      searchQuery: params.filters?.searchQuery,
+      partyType: params.filters?.partyType,
+      status: params.filters?.status,
+    })
+
+    const parties: Party[] = response.parties.map((p: Party) => ({
+      partyId: p.partyId,
+      legalName: p.legalName,
+      partyType: partyTypeLabel(p.partyType),
+      status: partyStatusLabel(p.status),
+      externalReference: p.externalReference,
+      createdAt: p.createdAt,
+    }))
+
+    return {
+      items: parties,
+      nextPageToken: response.nextPageToken,
+    }
+  }, [clients.party])
+
+  return { queryKey, queryFn, tenantSlug }
+}
+
+/**
+ * Fetches a single party by ID.
+ */
+export function usePartyDetail(partyId: string | undefined) {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  return useQuery({
+    queryKey: tenantKeys.party(tenantSlug ?? '', partyId ?? ''),
+    queryFn: async () => {
+      const response = await clients.party.retrieveParty({ partyId: partyId! })
+      return response.party
+    },
+    enabled: Boolean(tenantSlug && partyId),
+  })
+}
+
+/**
+ * Fetches associations for a party.
+ */
+export function usePartyAssociations(partyId: string | undefined) {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  return useQuery({
+    queryKey: tenantKeys.partyAssociations(tenantSlug ?? '', partyId ?? ''),
+    queryFn: () => clients.party.retrieveAssociations({ partyId: partyId! }),
+    enabled: Boolean(tenantSlug && partyId),
+  })
+}

--- a/frontend/src/features/parties/hooks/use-parties.ts
+++ b/frontend/src/features/parties/hooks/use-parties.ts
@@ -1,4 +1,3 @@
-import { useCallback } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useApiClients } from '@/api/context'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
@@ -37,7 +36,7 @@ export function usePartiesTable() {
 
   const queryKey = tenantKeys.parties(tenantSlug ?? '')
 
-  const queryFn = useCallback(async (params: DataTableQueryParams): Promise<DataTableResult<Party>> => {
+  async function queryFn(params: DataTableQueryParams): Promise<DataTableResult<Party>> {
     const response = await clients.party.listParties({
       pageToken: params.pageToken,
       pageSize: params.pageSize,
@@ -59,7 +58,7 @@ export function usePartiesTable() {
       items: parties,
       nextPageToken: response.nextPageToken,
     }
-  }, [clients.party])
+  }
 
   return { queryKey, queryFn, tenantSlug }
 }

--- a/frontend/src/features/parties/hooks/use-parties.ts
+++ b/frontend/src/features/parties/hooks/use-parties.ts
@@ -73,7 +73,7 @@ export function usePartyDetail(partyId: string | undefined) {
   return useQuery({
     queryKey: tenantKeys.party(tenantSlug ?? '', partyId ?? ''),
     queryFn: async () => {
-      const response = await clients.party.retrieveParty({ partyId: partyId! })
+      const response = await clients.party.retrieveParty({ partyId: partyId ?? '' })
       return response.party
     },
     enabled: Boolean(tenantSlug && partyId),
@@ -89,7 +89,7 @@ export function usePartyAssociations(partyId: string | undefined) {
 
   return useQuery({
     queryKey: tenantKeys.partyAssociations(tenantSlug ?? '', partyId ?? ''),
-    queryFn: () => clients.party.retrieveAssociations({ partyId: partyId! }),
+    queryFn: () => clients.party.retrieveAssociations({ partyId: partyId ?? '' }),
     enabled: Boolean(tenantSlug && partyId),
   })
 }

--- a/frontend/src/features/parties/pages/[partyId].test.tsx
+++ b/frontend/src/features/parties/pages/[partyId].test.tsx
@@ -23,6 +23,23 @@ vi.mock('@/api/context', () => ({
       retrieveDemographics: vi.fn().mockResolvedValue(null),
     },
   })),
+  useApiClients: vi.fn(() => ({
+    party: {
+      retrieveParty: vi.fn().mockResolvedValue({
+        party: {
+          partyId: 'test-party-1',
+          legalName: 'Test Party',
+          partyType: 'PARTY_TYPE_ORGANIZATION',
+          status: 'PARTY_STATUS_ACTIVE',
+        },
+      }),
+      listPaymentMethods: vi.fn().mockResolvedValue({ paymentMethods: [] }),
+      retrieveReference: vi.fn().mockResolvedValue({}),
+      retrieveAssociations: vi.fn().mockResolvedValue({}),
+      retrieveBankRelations: vi.fn().mockResolvedValue({}),
+      retrieveDemographics: vi.fn().mockResolvedValue(null),
+    },
+  })),
 }))
 
 // Mock useAuth to avoid requiring AuthProvider in tests
@@ -33,6 +50,14 @@ vi.mock('@/contexts/auth-context', () => ({
 // Mock useTenantContext to avoid requiring TenantProvider in tests
 vi.mock('@/contexts/tenant-context', () => ({
   useTenantContext: vi.fn(() => ({ tenantSlug: 'test-tenant', isPlatformAdmin: false, currentTenant: null, switchTenant: vi.fn() })),
+}))
+
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: () => 'test-tenant',
+  useCurrentTenant: () => null,
+  useIsPlatformAdmin: () => false,
+  useSwitchTenant: () => vi.fn(),
+  useClearTenant: () => vi.fn(),
 }))
 
 import { PartyDetailPage } from './[partyId]'

--- a/frontend/src/features/parties/pages/[partyId].tsx
+++ b/frontend/src/features/parties/pages/[partyId].tsx
@@ -1,9 +1,8 @@
-import * as React from 'react'
 import { useParams } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
 import { Card } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Breadcrumbs } from '@/shared'
+import { usePartyDetail } from '../hooks'
 import { PartyHeader } from './components/party-header'
 import { OverviewTab } from './tabs/overview-tab'
 import { DemographicsTab } from './tabs/demographics-tab'
@@ -13,20 +12,11 @@ import { BankRelationsTab } from './tabs/bank-relations-tab'
 import { PaymentMethodsTab } from './tabs/payment-methods-tab'
 import { AuditTrailTab } from './tabs/audit-trail-tab'
 import { AccountsTab } from './tabs/accounts-tab'
-import { useClients } from '@/api/context'
 
 export function PartyDetailPage() {
   const { partyId } = useParams<{ partyId: string }>()
-  const clients = useClients()
 
-  const { data: party } = useQuery({
-    queryKey: ['party', partyId],
-    queryFn: async () => {
-      const response = await clients.party.retrieveParty({ partyId: partyId! })
-      return response.party
-    },
-    enabled: !!partyId,
-  })
+  const { data: party } = usePartyDetail(partyId)
 
   if (!partyId) {
     return <div className="p-6 text-destructive">Party ID not found</div>

--- a/frontend/src/features/parties/pages/index.tsx
+++ b/frontend/src/features/parties/pages/index.tsx
@@ -4,35 +4,11 @@ import type { ColumnDef } from '@tanstack/react-table'
 import { DataTable } from '@/shared/data-table'
 import { TimeDisplay } from '@/shared/time-display'
 import { StatusBadge } from '@/shared/status-badge'
-import { useClients } from '@/api/context'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { tenantKeys } from '@/lib/query-keys'
-import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { usePartiesTable } from '../hooks'
 import { RegisterPartyDialog } from './dialogs/register-party-dialog'
 import { RegisterPartyTypeDialog } from './dialogs/register-party-type-dialog'
-
-function partyStatusLabel(status: unknown): string {
-  if (typeof status === 'string') return status
-  const map: Record<number, string> = {
-    0: 'UNSPECIFIED',
-    1: 'PARTY_STATUS_ACTIVE',
-    2: 'PARTY_STATUS_RESTRICTED',
-    3: 'PARTY_STATUS_SUSPENDED',
-    4: 'PARTY_STATUS_TERMINATED',
-  }
-  return map[status as number] ?? 'UNKNOWN'
-}
-
-function partyTypeLabel(partyType: unknown): string {
-  if (typeof partyType === 'string') return partyType
-  const map: Record<number, string> = {
-    0: 'UNSPECIFIED',
-    1: 'PARTY_TYPE_PERSON',
-    2: 'PARTY_TYPE_ORGANIZATION',
-  }
-  return map[partyType as number] ?? 'UNKNOWN'
-}
 
 export interface Party {
   partyId: string
@@ -43,21 +19,9 @@ export interface Party {
   createdAt?: { seconds: bigint | number; nanos?: number }
 }
 
-interface ListPartiesParams {
-  pageToken?: string
-  pageSize: number
-  filters?: Record<string, string>
-}
-
-interface ListPartiesResult {
-  items: Party[]
-  nextPageToken?: string
-}
-
 export function PartiesPage() {
   const navigate = useNavigate()
-  const clients = useClients()
-  const tenantSlug = useTenantSlug()
+  const { queryKey, queryFn, tenantSlug } = usePartiesTable()
   const [registerOpen, setRegisterOpen] = React.useState(false)
   const [addPartyTypeOpen, setAddPartyTypeOpen] = React.useState(false)
 
@@ -120,30 +84,6 @@ export function PartiesPage() {
     },
   ]
 
-  const queryFn = React.useCallback(async (params: ListPartiesParams): Promise<ListPartiesResult> => {
-    const response = await clients.party.listParties({
-      pageToken: params.pageToken,
-      pageSize: params.pageSize,
-      searchQuery: params.filters?.searchQuery,
-      partyType: params.filters?.partyType,
-      status: params.filters?.status,
-    })
-
-    const parties: Party[] = response.parties.map((p: Party) => ({
-      partyId: p.partyId,
-      legalName: p.legalName,
-      partyType: partyTypeLabel(p.partyType),
-      status: partyStatusLabel(p.status),
-      externalReference: p.externalReference,
-      createdAt: p.createdAt,
-    }))
-
-    return {
-      items: parties,
-      nextPageToken: response.nextPageToken,
-    }
-  }, [clients.party])
-
   const handleRowClick = (party: Party) => {
     navigate(`/parties/${party.partyId}`)
   }
@@ -175,7 +115,7 @@ export function PartiesPage() {
 
       <Card className="p-6">
         <DataTable
-          queryKey={tenantKeys.parties(tenantSlug)}
+          queryKey={queryKey}
           queryFn={queryFn}
           columns={columns}
           pageSize={25}

--- a/frontend/src/features/parties/pages/tabs/associations-tab.test.tsx
+++ b/frontend/src/features/parties/pages/tabs/associations-tab.test.tsx
@@ -28,7 +28,7 @@ vi.mock('@/hooks/use-tenant-context', () => ({
   useClearTenant: () => vi.fn(),
 }))
 
-import { useClients, useApiClients } from '@/api/context'
+import { useApiClients } from '@/api/context'
 import { AssociationsTab } from './associations-tab'
 
 function makeQueryClient() {

--- a/frontend/src/features/parties/pages/tabs/associations-tab.test.tsx
+++ b/frontend/src/features/parties/pages/tabs/associations-tab.test.tsx
@@ -3,9 +3,21 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { TooltipProvider } from '@/components/ui/tooltip'
 
+const mockRetrieveAssociations = vi.fn().mockResolvedValue({})
+
 vi.mock('@/api/context', () => ({
-  useClients: vi.fn(),
-  useApiClients: vi.fn(),
+  useClients: vi.fn(() => ({
+    party: {
+      retrieveAssociations: mockRetrieveAssociations,
+    },
+  })),
+  useApiClients: vi.fn(() => ({
+    party: {
+      retrieveAssociations: mockRetrieveAssociations,
+      listParties: vi.fn().mockResolvedValue({ parties: [] }),
+      registerAssociations: vi.fn(),
+    },
+  })),
 }))
 
 vi.mock('@/hooks/use-tenant-context', () => ({
@@ -53,11 +65,11 @@ describe('AssociationsTab', () => {
 
   describe('loading state', () => {
     it('renders skeletons while loading', () => {
-      vi.mocked(useClients).mockReturnValue({
+      vi.mocked(useApiClients).mockReturnValue({
         party: {
           retrieveAssociations: vi.fn(() => new Promise(() => {})),
         },
-      } as ReturnType<typeof useClients>)
+      } as ReturnType<typeof useApiClients>)
 
       const { container } = renderTab()
 
@@ -66,11 +78,11 @@ describe('AssociationsTab', () => {
     })
 
     it('does not render empty state while loading', () => {
-      vi.mocked(useClients).mockReturnValue({
+      vi.mocked(useApiClients).mockReturnValue({
         party: {
           retrieveAssociations: vi.fn(() => new Promise(() => {})),
         },
-      } as ReturnType<typeof useClients>)
+      } as ReturnType<typeof useApiClients>)
 
       renderTab()
 
@@ -80,11 +92,11 @@ describe('AssociationsTab', () => {
 
   describe('empty state', () => {
     it('renders empty state heading after data loads', async () => {
-      vi.mocked(useClients).mockReturnValue({
+      vi.mocked(useApiClients).mockReturnValue({
         party: {
           retrieveAssociations: vi.fn().mockResolvedValue({}),
         },
-      } as ReturnType<typeof useClients>)
+      } as ReturnType<typeof useApiClients>)
 
       renderTab()
 
@@ -94,11 +106,11 @@ describe('AssociationsTab', () => {
     })
 
     it('renders descriptive message', async () => {
-      vi.mocked(useClients).mockReturnValue({
+      vi.mocked(useApiClients).mockReturnValue({
         party: {
           retrieveAssociations: vi.fn().mockResolvedValue({}),
         },
-      } as ReturnType<typeof useClients>)
+      } as ReturnType<typeof useApiClients>)
 
       renderTab()
 
@@ -108,11 +120,11 @@ describe('AssociationsTab', () => {
     })
 
     it('renders add association button', async () => {
-      vi.mocked(useClients).mockReturnValue({
+      vi.mocked(useApiClients).mockReturnValue({
         party: {
           retrieveAssociations: vi.fn().mockResolvedValue({}),
         },
-      } as ReturnType<typeof useClients>)
+      } as ReturnType<typeof useApiClients>)
 
       renderTab()
 
@@ -125,9 +137,9 @@ describe('AssociationsTab', () => {
   describe('query key', () => {
     it('calls retrieveAssociations with the provided partyId', async () => {
       const retrieveAssociations = vi.fn().mockResolvedValue({})
-      vi.mocked(useClients).mockReturnValue({
+      vi.mocked(useApiClients).mockReturnValue({
         party: { retrieveAssociations },
-      } as ReturnType<typeof useClients>)
+      } as ReturnType<typeof useApiClients>)
 
       renderTab('party-abc')
 

--- a/frontend/src/features/parties/pages/tabs/associations-tab.tsx
+++ b/frontend/src/features/parties/pages/tabs/associations-tab.tsx
@@ -12,6 +12,7 @@ interface AssociationsTabProps {
 export function AssociationsTab({ partyId }: AssociationsTabProps) {
   const [dialogOpen, setDialogOpen] = React.useState(false)
 
+  // TODO: Use fetched association data to populate the table once the UI is built
   const { isLoading } = usePartyAssociations(partyId)
 
   if (isLoading) {

--- a/frontend/src/features/parties/pages/tabs/associations-tab.tsx
+++ b/frontend/src/features/parties/pages/tabs/associations-tab.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { useClients } from '@/api/context'
 import { Skeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Button } from '@/components/ui/button'
-import { tenantKeys } from '@/lib/query-keys'
-import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { usePartyAssociations } from '../../hooks'
 import { RegisterAssociationsDialog } from '../dialogs/register-associations-dialog'
 
 interface AssociationsTabProps {
@@ -13,16 +10,9 @@ interface AssociationsTabProps {
 }
 
 export function AssociationsTab({ partyId }: AssociationsTabProps) {
-  const clients = useClients()
-  const tenantSlug = useTenantSlug()
   const [dialogOpen, setDialogOpen] = React.useState(false)
 
-  const { isLoading } = useQuery({
-    queryKey: tenantKeys.partyAssociations(tenantSlug ?? '', partyId),
-    queryFn: async () => {
-      return await clients.party.retrieveAssociations({ partyId })
-    },
-  })
+  const { isLoading } = usePartyAssociations(partyId)
 
   if (isLoading) {
     return (

--- a/frontend/src/features/payments/hooks/index.ts
+++ b/frontend/src/features/payments/hooks/index.ts
@@ -1,0 +1,1 @@
+export { usePaymentsTable, usePaymentDetail } from './use-payments'

--- a/frontend/src/features/payments/hooks/use-payments.ts
+++ b/frontend/src/features/payments/hooks/use-payments.ts
@@ -1,0 +1,70 @@
+import { useQuery } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import type { DataTableQueryParams, DataTableResult } from '@/shared/data-table'
+import type { PaymentOrder } from '../pages/payments-query'
+import type { PaymentOrderDetail } from '../pages/payment-detail-query'
+
+/**
+ * Fetches a paginated list of payment orders for use with DataTable.
+ * Returns the queryKey and queryFn ready to pass to DataTable.
+ */
+export function usePaymentsTable() {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  const queryKey = tenantKeys.payments(tenantSlug ?? '')
+
+  async function queryFn(
+    params: DataTableQueryParams,
+  ): Promise<DataTableResult<PaymentOrder>> {
+    if (!tenantSlug) return { items: [] }
+
+    const response = await clients.paymentOrder.listPaymentOrders({
+      pagination: {
+        pageSize: params.pageSize,
+        pageToken: params.pageToken ?? '',
+      },
+      ...(params.filters?.status ? { status: params.filters.status } : {}),
+    })
+
+    const items: PaymentOrder[] = (response.paymentOrders ?? []).map((p) => ({
+      paymentOrderId: p.paymentOrderId ?? '',
+      debtorAccountId: p.debtorAccountId ?? '',
+      creditorReference: p.creditorReference ?? '',
+      amount: p.amount ?? '',
+      currency: p.currency ?? '',
+      status: p.status ?? '',
+      createdAt: p.createdAt ?? null,
+    }))
+
+    return {
+      items,
+      nextPageToken: response.pagination?.nextPageToken || undefined,
+    }
+  }
+
+  return { queryKey, queryFn, tenantSlug }
+}
+
+/**
+ * Fetches a single payment order by ID.
+ */
+export function usePaymentDetail(paymentOrderId: string | undefined) {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  return useQuery({
+    queryKey: tenantKeys.payment(tenantSlug ?? '', paymentOrderId ?? ''),
+    queryFn: async (): Promise<PaymentOrderDetail | null> => {
+      const response = await clients.paymentOrder.retrievePaymentOrder({
+        paymentOrderId: paymentOrderId ?? '',
+      })
+      const p = response.paymentOrder
+      if (!p) return null
+      return p as unknown as PaymentOrderDetail
+    },
+    enabled: Boolean(tenantSlug && paymentOrderId),
+  })
+}

--- a/frontend/src/features/payments/hooks/use-payments.ts
+++ b/frontend/src/features/payments/hooks/use-payments.ts
@@ -63,7 +63,18 @@ export function usePaymentDetail(paymentOrderId: string | undefined) {
       })
       const p = response.paymentOrder
       if (!p) return null
-      return p as unknown as PaymentOrderDetail
+      return {
+        paymentOrderId: p.paymentOrderId ?? '',
+        debtorAccountId: p.debtorAccountId ?? '',
+        creditorReference: p.creditorReference ?? '',
+        amount: p.amount ?? '',
+        currency: p.currency ?? '',
+        status: p.status ?? '',
+        reference: p.reference ?? undefined,
+        createdAt: p.createdAt ?? null,
+        sagaSteps: (p.sagaSteps ?? []) as PaymentOrderDetail['sagaSteps'],
+        compensationSteps: (p.compensationSteps ?? []) as PaymentOrderDetail['compensationSteps'],
+      }
     },
     enabled: Boolean(tenantSlug && paymentOrderId),
   })

--- a/frontend/src/features/payments/pages/index.tsx
+++ b/frontend/src/features/payments/pages/index.tsx
@@ -1,14 +1,11 @@
-import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { ColumnDef } from '@tanstack/react-table'
 import { DataTable } from '@/shared/data-table'
 import { MoneyDisplay } from '@/shared/money-display'
 import { StatusBadge } from '@/shared/status-badge'
 import { TimeDisplay } from '@/shared/time-display'
-import { useTenantSlug } from '@/hooks/use-tenant-context'
-import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
-import { tenantKeys } from '@/lib/query-keys'
-import { fetchPayments, type PaymentOrder } from './payments-query'
+import { usePaymentsTable } from '../hooks'
+import type { PaymentOrder } from './payments-query'
 
 const STATUS_OPTIONS = [
   { label: 'Initiated', value: 'INITIATED' },
@@ -67,13 +64,7 @@ interface PaymentsPageProps {
 
 export function PaymentsPage({ onRowNavigate }: PaymentsPageProps = {}) {
   const navigate = useNavigate()
-  const tenantSlug = useTenantSlug()
-  const authFetch = useAuthenticatedFetch()
-  const queryKey = tenantSlug ? tenantKeys.payments(tenantSlug) : ['payments']
-  const queryFn = useCallback(
-    (params: Parameters<typeof fetchPayments>[0]) => fetchPayments(params, authFetch),
-    [authFetch],
-  )
+  const { queryKey, queryFn } = usePaymentsTable()
 
   function handleRowClick(row: PaymentOrder) {
     if (onRowNavigate) {

--- a/frontend/src/features/payments/pages/payment-detail.test.tsx
+++ b/frontend/src/features/payments/pages/payment-detail.test.tsx
@@ -7,8 +7,6 @@ import { TooltipProvider } from '@/components/ui/tooltip'
 import { AuthProvider } from '@/contexts/auth-context'
 import { TenantProvider } from '@/contexts/tenant-context'
 // Mock the payment detail hook
-const mockPaymentDetailQuery = vi.fn()
-
 vi.mock('../hooks', () => ({
   usePaymentDetail: vi.fn(() => ({
     data: null,

--- a/frontend/src/features/payments/pages/payment-detail.test.tsx
+++ b/frontend/src/features/payments/pages/payment-detail.test.tsx
@@ -6,10 +6,15 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { AuthProvider } from '@/contexts/auth-context'
 import { TenantProvider } from '@/contexts/tenant-context'
-import { PaymentDetailPage } from './payment-detail'
+// Mock the payment detail hook
+const mockPaymentDetailQuery = vi.fn()
 
-vi.mock('./payment-detail-query', () => ({
-  fetchPaymentDetail: vi.fn(),
+vi.mock('../hooks', () => ({
+  usePaymentDetail: vi.fn(() => ({
+    data: null,
+    isLoading: false,
+    isError: false,
+  })),
 }))
 
 // Mock dialog mutations to avoid requiring a live API transport
@@ -19,8 +24,17 @@ vi.mock('./dialogs/payment-mutations', () => ({
   useReversePayment: () => ({ mutateAsync: vi.fn(), isPending: false, reset: vi.fn() }),
 }))
 
-import { fetchPaymentDetail } from './payment-detail-query'
-const mockFetch = vi.mocked(fetchPaymentDetail)
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: () => 'test-tenant',
+  useCurrentTenant: () => null,
+  useIsPlatformAdmin: () => false,
+  useSwitchTenant: () => vi.fn(),
+  useClearTenant: () => vi.fn(),
+}))
+
+import { usePaymentDetail } from '../hooks'
+import { PaymentDetailPage } from './payment-detail'
+const mockUsePaymentDetail = vi.mocked(usePaymentDetail)
 
 function makeQueryClient() {
   return new QueryClient({
@@ -73,7 +87,7 @@ const sampleDetail = {
 
 describe('PaymentDetailPage - structure', () => {
   beforeEach(() => {
-    mockFetch.mockResolvedValue(sampleDetail)
+    mockUsePaymentDetail.mockReturnValue({ data: sampleDetail, isLoading: false, isError: false } as ReturnType<typeof usePaymentDetail>)
   })
 
   it('renders payment order ID as heading', async () => {
@@ -117,7 +131,7 @@ describe('PaymentDetailPage - structure', () => {
 
 describe('PaymentDetailPage - Overview tab', () => {
   beforeEach(() => {
-    mockFetch.mockResolvedValue(sampleDetail)
+    mockUsePaymentDetail.mockReturnValue({ data: sampleDetail, isLoading: false, isError: false } as ReturnType<typeof usePaymentDetail>)
   })
 
   it('shows payment details in Overview tab', async () => {
@@ -174,7 +188,7 @@ describe('PaymentDetailPage - Overview tab', () => {
 
 describe('PaymentDetailPage - Saga Steps tab', () => {
   beforeEach(() => {
-    mockFetch.mockResolvedValue(sampleDetail)
+    mockUsePaymentDetail.mockReturnValue({ data: sampleDetail, isLoading: false, isError: false } as ReturnType<typeof usePaymentDetail>)
   })
 
   it('shows SagaTimeline when Saga Steps tab is clicked', async () => {
@@ -221,8 +235,7 @@ describe('PaymentDetailPage - Saga Steps tab', () => {
 
 describe('PaymentDetailPage - loading state', () => {
   it('shows skeleton while loading', () => {
-    // Never resolves
-    mockFetch.mockReturnValue(new Promise(() => {}))
+    mockUsePaymentDetail.mockReturnValue({ data: undefined, isLoading: true, isError: false } as ReturnType<typeof usePaymentDetail>)
 
     render(
       <Wrapper>
@@ -236,7 +249,7 @@ describe('PaymentDetailPage - loading state', () => {
 
 describe('PaymentDetailPage - error state', () => {
   it('shows error message on fetch failure', async () => {
-    mockFetch.mockRejectedValue(new Error('Not found'))
+    mockUsePaymentDetail.mockReturnValue({ data: undefined, isLoading: false, isError: true } as ReturnType<typeof usePaymentDetail>)
 
     render(
       <Wrapper>

--- a/frontend/src/features/payments/pages/payment-detail.tsx
+++ b/frontend/src/features/payments/pages/payment-detail.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQueryClient } from '@tanstack/react-query'
 import { Plus } from 'lucide-react'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -11,10 +11,9 @@ import { TimeDisplay } from '@/shared/time-display'
 import { SagaTimeline } from '@/features/sagas/components/saga-timeline'
 import { AuditTrail } from '@/shared/audit-trail'
 import { EntityLink, Breadcrumbs } from '@/shared'
-import { useTenantSlug } from '@/hooks/use-tenant-context'
-import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
 import { tenantKeys } from '@/lib/query-keys'
-import { fetchPaymentDetail } from './payment-detail-query'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { usePaymentDetail } from '../hooks'
 import {
   InitiatePaymentDialog,
   CancelPaymentDialog,
@@ -105,7 +104,6 @@ function PaymentActions({
 export function PaymentDetailPage() {
   const { paymentOrderId } = useParams<{ paymentOrderId: string }>()
   const tenantSlug = useTenantSlug()
-  const authFetch = useAuthenticatedFetch()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [initiateOpen, setInitiateOpen] = React.useState(false)
@@ -114,11 +112,7 @@ export function PaymentDetailPage() {
     ? tenantKeys.payment(tenantSlug, paymentOrderId)
     : ['payments', paymentOrderId]
 
-  const { data, isLoading, isError } = useQuery({
-    queryKey,
-    queryFn: () => fetchPaymentDetail(paymentOrderId!, authFetch),
-    enabled: !!paymentOrderId,
-  })
+  const { data, isLoading, isError } = usePaymentDetail(paymentOrderId)
 
   function handleActionSuccess() {
     void queryClient.invalidateQueries({ queryKey })

--- a/frontend/src/features/payments/pages/payments-list.test.tsx
+++ b/frontend/src/features/payments/pages/payments-list.test.tsx
@@ -6,15 +6,18 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { AuthProvider } from '@/contexts/auth-context'
 import { TenantProvider } from '@/contexts/tenant-context'
-import { PaymentsPage } from './index'
+// Mock the payments hook
+const mockQueryFn = vi.fn()
 
-// Mock the payments query function
-vi.mock('./payments-query', () => ({
-  fetchPayments: vi.fn(),
+vi.mock('../hooks', () => ({
+  usePaymentsTable: vi.fn(() => ({
+    queryKey: ['test-tenant', 'payments'],
+    queryFn: mockQueryFn,
+    tenantSlug: 'test-tenant',
+  })),
 }))
 
-import { fetchPayments } from './payments-query'
-const mockFetchPayments = vi.mocked(fetchPayments)
+import { PaymentsPage } from './index'
 
 function makeQueryClient() {
   return new QueryClient({
@@ -60,7 +63,7 @@ const samplePayments = [
 
 describe('PaymentsPage - list rendering', () => {
   it('renders page heading', async () => {
-    mockFetchPayments.mockResolvedValue({ items: [] })
+    mockQueryFn.mockResolvedValue({ items: [] })
 
     render(
       <Wrapper>
@@ -72,7 +75,7 @@ describe('PaymentsPage - list rendering', () => {
   })
 
   it('renders column headers', async () => {
-    mockFetchPayments.mockResolvedValue({ items: [] })
+    mockQueryFn.mockResolvedValue({ items: [] })
 
     render(
       <Wrapper>
@@ -91,7 +94,7 @@ describe('PaymentsPage - list rendering', () => {
   })
 
   it('renders payment rows with data', async () => {
-    mockFetchPayments.mockResolvedValue({ items: samplePayments })
+    mockQueryFn.mockResolvedValue({ items: samplePayments })
 
     render(
       <Wrapper>
@@ -106,7 +109,7 @@ describe('PaymentsPage - list rendering', () => {
   })
 
   it('renders amount using MoneyDisplay', async () => {
-    mockFetchPayments.mockResolvedValue({ items: samplePayments })
+    mockQueryFn.mockResolvedValue({ items: samplePayments })
 
     render(
       <Wrapper>
@@ -121,7 +124,7 @@ describe('PaymentsPage - list rendering', () => {
   })
 
   it('renders status using StatusBadge', async () => {
-    mockFetchPayments.mockResolvedValue({ items: samplePayments })
+    mockQueryFn.mockResolvedValue({ items: samplePayments })
 
     render(
       <Wrapper>
@@ -138,7 +141,7 @@ describe('PaymentsPage - list rendering', () => {
 
 describe('PaymentsPage - navigation', () => {
   it('navigates to detail page on row click', async () => {
-    mockFetchPayments.mockResolvedValue({ items: samplePayments })
+    mockQueryFn.mockResolvedValue({ items: samplePayments })
 
     const onNavigate = vi.fn()
 
@@ -166,7 +169,7 @@ describe('PaymentsPage - navigation', () => {
 
 describe('PaymentsPage - filters', () => {
   it('renders status filter select', async () => {
-    mockFetchPayments.mockResolvedValue({ items: [] })
+    mockQueryFn.mockResolvedValue({ items: [] })
 
     render(
       <Wrapper>

--- a/frontend/src/features/positions/hooks/index.ts
+++ b/frontend/src/features/positions/hooks/index.ts
@@ -1,0 +1,1 @@
+export { usePositionLogsTable, usePositionLogDetail } from './use-positions'

--- a/frontend/src/features/positions/hooks/use-positions.ts
+++ b/frontend/src/features/positions/hooks/use-positions.ts
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import { TransactionStatus } from '@/api/gen/meridian/common/v1/types_pb'
+import type { DataTableQueryParams, DataTableResult } from '@/shared/data-table'
+import type { FinancialPositionLog } from '../pages/index'
+
+/**
+ * Fetches a paginated list of position logs for use with DataTable.
+ */
+export function usePositionLogsTable() {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  const queryKey = tenantSlug
+    ? [...tenantKeys.all(tenantSlug), 'positions']
+    : ['positions']
+
+  async function queryFn(
+    params: DataTableQueryParams,
+  ): Promise<DataTableResult<FinancialPositionLog>> {
+    const statusValue = params.filters?.status
+    const response = await clients.positionKeeping.listFinancialPositionLogs({
+      pageToken: params.pageToken ?? '',
+      accountId: params.filters?.accountId ?? '',
+      status: statusValue ? (Number(statusValue) as TransactionStatus) : TransactionStatus.UNSPECIFIED,
+      pagination: {
+        pageSize: params.pageSize,
+        pageToken: params.pageToken ?? '',
+      },
+    })
+
+    return {
+      items: (response.logs ?? []) as FinancialPositionLog[],
+      nextPageToken: response.pagination?.nextPageToken,
+    }
+  }
+
+  return { queryKey, queryFn, tenantSlug }
+}
+
+/**
+ * Fetches a single position log by ID.
+ */
+export function usePositionLogDetail(logId: string | undefined) {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  return useQuery({
+    queryKey: tenantSlug
+      ? [...tenantKeys.all(tenantSlug), 'positions', logId]
+      : ['positions', logId],
+    queryFn: () =>
+      clients.positionKeeping.retrieveFinancialPositionLog({ logId: logId! }),
+    enabled: !!logId,
+  })
+}

--- a/frontend/src/features/positions/hooks/use-positions.ts
+++ b/frontend/src/features/positions/hooks/use-positions.ts
@@ -24,7 +24,7 @@ export function usePositionLogsTable() {
     const response = await clients.positionKeeping.listFinancialPositionLogs({
       pageToken: params.pageToken ?? '',
       accountId: params.filters?.accountId ?? '',
-      status: statusValue ? (Number(statusValue) as TransactionStatus) : TransactionStatus.UNSPECIFIED,
+      status: statusValue && !Number.isNaN(Number(statusValue)) ? (Number(statusValue) as TransactionStatus) : TransactionStatus.UNSPECIFIED,
       pagination: {
         pageSize: params.pageSize,
         pageToken: params.pageToken ?? '',
@@ -53,6 +53,6 @@ export function usePositionLogDetail(logId: string | undefined) {
       : ['positions', logId],
     queryFn: () =>
       clients.positionKeeping.retrieveFinancialPositionLog({ logId: logId! }),
-    enabled: !!logId,
+    enabled: Boolean(tenantSlug && logId),
   })
 }

--- a/frontend/src/features/positions/pages/detail.test.tsx
+++ b/frontend/src/features/positions/pages/detail.test.tsx
@@ -15,6 +15,14 @@ vi.mock('@/api/context', () => ({
   })),
 }))
 
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: () => 'test-tenant',
+  useCurrentTenant: () => null,
+  useIsPlatformAdmin: () => false,
+  useSwitchTenant: () => vi.fn(),
+  useClearTenant: () => vi.fn(),
+}))
+
 import { PositionDetailPage } from './detail'
 
 function makeQueryClient() {

--- a/frontend/src/features/positions/pages/detail.tsx
+++ b/frontend/src/features/positions/pages/detail.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { useParams } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
 import { Card } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { MoneyDisplay } from '@/shared/money-display'
@@ -9,7 +8,7 @@ import { QualityLadderBadge } from '@/features/positions/components/quality-ladd
 import { DirectionBadge } from '@/shared/direction-badge'
 import { EntityLink, Breadcrumbs } from '@/shared'
 import { Skeleton } from '@/components/ui/skeleton'
-import { useApiClients } from '@/api/context'
+import { usePositionLogDetail } from '../hooks'
 import type { FinancialPositionLog, TransactionLogEntry } from './index'
 
 function LabeledField({ label, children }: { label: string; children: React.ReactNode }) {
@@ -141,14 +140,8 @@ function MeasurementHistory({ entries }: MeasurementHistoryProps) {
 
 export function PositionDetailPage() {
   const { logId } = useParams<{ logId: string }>()
-  const clients = useApiClients()
 
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ['positions', logId],
-    queryFn: () =>
-      clients.positionKeeping.retrieveFinancialPositionLog({ logId: logId! }),
-    enabled: !!logId,
-  })
+  const { data, isLoading, isError } = usePositionLogDetail(logId)
 
   const log = data?.log as FinancialPositionLog | undefined
 

--- a/frontend/src/features/positions/pages/index.test.tsx
+++ b/frontend/src/features/positions/pages/index.test.tsx
@@ -20,6 +20,14 @@ vi.mock('@/api/context', () => ({
   })),
 }))
 
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: () => 'test-tenant',
+  useCurrentTenant: () => null,
+  useIsPlatformAdmin: () => false,
+  useSwitchTenant: () => vi.fn(),
+  useClearTenant: () => vi.fn(),
+}))
+
 import { PositionsPage } from './index'
 
 function makeQueryClient() {

--- a/frontend/src/features/positions/pages/index.tsx
+++ b/frontend/src/features/positions/pages/index.tsx
@@ -1,11 +1,10 @@
-import * as React from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { ColumnDef } from '@tanstack/react-table'
 import { DataTable } from '@/shared/data-table'
 import { TimeDisplay } from '@/shared/time-display'
-import { useApiClients } from '@/api/context'
 import { Card } from '@/components/ui/card'
 import { TransactionStatus } from '@/api/gen/meridian/common/v1/types_pb'
+import { usePositionLogsTable } from '../hooks'
 
 const TRANSACTION_STATUS_NAMES: Record<number, string> = {
   [TransactionStatus.PENDING]: 'PENDING',
@@ -56,20 +55,9 @@ export interface TransactionLogEntry {
   reference?: string
 }
 
-interface ListPositionLogsParams {
-  pageToken?: string
-  pageSize: number
-  filters?: Record<string, string>
-}
-
-interface ListPositionLogsResult {
-  items: FinancialPositionLog[]
-  nextPageToken?: string
-}
-
 export function PositionsPage() {
   const navigate = useNavigate()
-  const clients = useApiClients()
+  const { queryKey, queryFn } = usePositionLogsTable()
 
   const columns: ColumnDef<FinancialPositionLog>[] = [
     {
@@ -129,24 +117,6 @@ export function PositionsPage() {
     },
   ]
 
-  const queryFn = async (params: ListPositionLogsParams): Promise<ListPositionLogsResult> => {
-    const statusValue = params.filters?.status
-    const response = await clients.positionKeeping.listFinancialPositionLogs({
-      pageToken: params.pageToken ?? '',
-      accountId: params.filters?.accountId ?? '',
-      status: statusValue ? (Number(statusValue) as TransactionStatus) : TransactionStatus.UNSPECIFIED,
-      pagination: {
-        pageSize: params.pageSize,
-        pageToken: params.pageToken ?? '',
-      },
-    })
-
-    return {
-      items: (response.logs ?? []) as FinancialPositionLog[],
-      nextPageToken: response.pagination?.nextPageToken,
-    }
-  }
-
   const handleRowClick = (log: FinancialPositionLog) => {
     navigate(`/positions/${log.logId}`)
   }
@@ -162,7 +132,7 @@ export function PositionsPage() {
 
       <Card className="p-6">
         <DataTable
-          queryKey={['positions']}
+          queryKey={queryKey}
           queryFn={queryFn}
           columns={columns}
           pageSize={25}

--- a/frontend/src/features/reconciliation/hooks/index.ts
+++ b/frontend/src/features/reconciliation/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useReconciliationRunsTable, useReconciliationRunDetail } from './use-reconciliation'

--- a/frontend/src/features/reconciliation/hooks/use-reconciliation.ts
+++ b/frontend/src/features/reconciliation/hooks/use-reconciliation.ts
@@ -61,7 +61,16 @@ export function useReconciliationRunDetail(runId: string | undefined) {
         runId: runId ?? '',
       })
       if (!response) return null
-      return response as unknown as ReconciliationRunDetail
+      return {
+        runId: response.runId ?? '',
+        accountId: response.accountId ?? '',
+        scope: (response.scope ?? '').replace('RECONCILIATION_SCOPE_', ''),
+        settlementType: (response.settlementType ?? '').replace('SETTLEMENT_TYPE_', ''),
+        status: (response.status ?? '').replace('RUN_STATUS_', ''),
+        varianceCount: response.varianceCount ?? 0,
+        periodStart: response.periodStart ?? '',
+        periodEnd: response.periodEnd ?? '',
+      }
     },
     enabled: Boolean(tenantSlug && runId),
   })

--- a/frontend/src/features/reconciliation/hooks/use-reconciliation.ts
+++ b/frontend/src/features/reconciliation/hooks/use-reconciliation.ts
@@ -1,0 +1,68 @@
+import { useQuery } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import type { DataTableQueryParams, DataTableResult } from '@/shared/data-table'
+import type { ReconciliationRun } from '../pages/index'
+import type { ReconciliationRunDetail } from '../pages/detail'
+
+/**
+ * Fetches a paginated list of reconciliation runs for use with DataTable.
+ */
+export function useReconciliationRunsTable() {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  const queryKey = tenantKeys.reconciliationRuns(tenantSlug ?? '')
+
+  async function queryFn(
+    params: DataTableQueryParams,
+  ): Promise<DataTableResult<ReconciliationRun>> {
+    if (!tenantSlug) return { items: [] }
+
+    const response = await clients.accountReconciliation.listReconciliationRuns({
+      pageSize: params.pageSize,
+      pageToken: params.pageToken ?? '',
+      ...(params.filters?.status ? { status: params.filters.status } : {}),
+      ...(params.filters?.account_id ? { accountId: params.filters.account_id } : {}),
+    })
+
+    const items: ReconciliationRun[] = (response.runs ?? []).map((run) => ({
+      runId: run.runId ?? '',
+      accountId: run.accountId ?? '',
+      scope: (run.scope ?? '').replace('RECONCILIATION_SCOPE_', ''),
+      settlementType: (run.settlementType ?? '').replace('SETTLEMENT_TYPE_', ''),
+      status: (run.status ?? '').replace('RUN_STATUS_', ''),
+      varianceCount: run.varianceCount ?? 0,
+      periodStart: run.periodStart ?? '',
+      periodEnd: run.periodEnd ?? '',
+    }))
+
+    return {
+      items,
+      nextPageToken: response.nextPageToken || undefined,
+    }
+  }
+
+  return { queryKey, queryFn, tenantSlug }
+}
+
+/**
+ * Fetches a single reconciliation run by ID.
+ */
+export function useReconciliationRunDetail(runId: string | undefined) {
+  const clients = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  return useQuery({
+    queryKey: tenantKeys.reconciliationRun(tenantSlug ?? '', runId ?? ''),
+    queryFn: async (): Promise<ReconciliationRunDetail | null> => {
+      const response = await clients.accountReconciliation.getReconciliationRun({
+        runId: runId ?? '',
+      })
+      if (!response) return null
+      return response as unknown as ReconciliationRunDetail
+    },
+    enabled: Boolean(tenantSlug && runId),
+  })
+}

--- a/frontend/src/features/reconciliation/pages/index.test.tsx
+++ b/frontend/src/features/reconciliation/pages/index.test.tsx
@@ -5,7 +5,9 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { renderWithProviders } from '@/test/test-utils'
 
 // Mock the reconciliation hook
-const mockQueryFn = vi.fn()
+const { mockQueryFn } = vi.hoisted(() => ({
+  mockQueryFn: vi.fn(),
+}))
 
 vi.mock('../hooks', () => ({
   useReconciliationRunsTable: vi.fn(() => ({

--- a/frontend/src/features/reconciliation/pages/index.test.tsx
+++ b/frontend/src/features/reconciliation/pages/index.test.tsx
@@ -3,6 +3,18 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { renderWithProviders } from '@/test/test-utils'
+
+// Mock the reconciliation hook
+const mockQueryFn = vi.fn()
+
+vi.mock('../hooks', () => ({
+  useReconciliationRunsTable: vi.fn(() => ({
+    queryKey: ['test-tenant', 'reconciliation-runs'],
+    queryFn: mockQueryFn,
+    tenantSlug: 'test-tenant',
+  })),
+}))
+
 import { ReconciliationPage } from './index'
 
 function renderPage() {
@@ -16,14 +28,14 @@ function renderPage() {
   )
 }
 
-// sampleRuns uses the proto/gateway response format (runs array with full enum names).
+// sampleRuns uses the hook output format (prefixes already stripped by the hook).
 const sampleRuns = [
   {
     runId: 'run-001',
     accountId: 'acc-123',
-    scope: 'RECONCILIATION_SCOPE_FULL',
-    settlementType: 'SETTLEMENT_TYPE_ON_DEMAND',
-    status: 'RUN_STATUS_COMPLETED',
+    scope: 'FULL',
+    settlementType: 'ON_DEMAND',
+    status: 'COMPLETED',
     varianceCount: 2,
     periodStart: '2026-01-01T00:00:00Z',
     periodEnd: '2026-01-31T23:59:59Z',
@@ -31,9 +43,9 @@ const sampleRuns = [
   {
     runId: 'run-002',
     accountId: 'acc-456',
-    scope: 'RECONCILIATION_SCOPE_ACCOUNT',
-    settlementType: 'SETTLEMENT_TYPE_DAILY',
-    status: 'RUN_STATUS_RUNNING',
+    scope: 'ACCOUNT',
+    settlementType: 'DAILY',
+    status: 'RUNNING',
     varianceCount: 0,
     periodStart: '2026-02-01T00:00:00Z',
     periodEnd: '2026-02-28T23:59:59Z',
@@ -43,20 +55,16 @@ const sampleRuns = [
 describe('ReconciliationPage - list view', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    mockQueryFn.mockResolvedValue({ items: [] })
   })
 
   it('renders page heading', () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ runs: [] }), { status: 200 }),
-    )
     renderPage()
     expect(screen.getByText('Reconciliation')).toBeInTheDocument()
   })
 
   it('renders settlement runs in the table', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ runs: sampleRuns }), { status: 200 }),
-    )
+    mockQueryFn.mockResolvedValue({ items: sampleRuns })
     renderPage()
 
     await waitFor(() => {
@@ -66,9 +74,7 @@ describe('ReconciliationPage - list view', () => {
   })
 
   it('shows variance count with destructive badge when count > 0', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ runs: sampleRuns }), { status: 200 }),
-    )
+    mockQueryFn.mockResolvedValue({ items: sampleRuns })
     renderPage()
 
     await waitFor(() => {
@@ -82,21 +88,17 @@ describe('ReconciliationPage - list view', () => {
   })
 
   it('renders status badges for each run', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ runs: sampleRuns }), { status: 200 }),
-    )
+    mockQueryFn.mockResolvedValue({ items: sampleRuns })
     renderPage()
 
     await waitFor(() => {
-      expect(screen.getByText('COMPLETED')).toBeInTheDocument()  // RUN_STATUS_ prefix stripped
-      expect(screen.getByText('RUNNING')).toBeInTheDocument()    // RUN_STATUS_ prefix stripped
+      expect(screen.getByText('COMPLETED')).toBeInTheDocument()
+      expect(screen.getByText('RUNNING')).toBeInTheDocument()
     })
   })
 
   it('renders period column with formatted dates', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ runs: sampleRuns }), { status: 200 }),
-    )
+    mockQueryFn.mockResolvedValue({ items: sampleRuns })
     renderPage()
 
     await waitFor(() => {
@@ -105,9 +107,6 @@ describe('ReconciliationPage - list view', () => {
   })
 
   it('renders column headers', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ runs: [] }), { status: 200 }),
-    )
     renderPage()
 
     await waitFor(() => {
@@ -119,9 +118,6 @@ describe('ReconciliationPage - list view', () => {
   })
 
   it('shows filters for status and account ID', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ runs: [] }), { status: 200 }),
-    )
     renderPage()
 
     await waitFor(() => {
@@ -131,10 +127,7 @@ describe('ReconciliationPage - list view', () => {
   })
 
   it('navigates to detail page on row click', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ runs: sampleRuns }), { status: 200 }),
-    )
-
+    mockQueryFn.mockResolvedValue({ items: sampleRuns })
     renderPage()
 
     await waitFor(() => {
@@ -155,7 +148,7 @@ describe('ReconciliationPage - list view', () => {
   })
 
   it('shows error state when fetch fails', async () => {
-    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'))
+    mockQueryFn.mockRejectedValue(new Error('Network error'))
     renderPage()
 
     await waitFor(() => {
@@ -164,9 +157,6 @@ describe('ReconciliationPage - list view', () => {
   })
 
   it('shows empty state when no runs returned', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ runs: [] }), { status: 200 }),
-    )
     renderPage()
 
     await waitFor(() => {
@@ -175,9 +165,6 @@ describe('ReconciliationPage - list view', () => {
   })
 
   it('renders Start Reconciliation button in header', () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ runs: [] }), { status: 200 }),
-    )
     renderPage()
     expect(screen.getByRole('button', { name: /start reconciliation/i })).toBeInTheDocument()
   })

--- a/frontend/src/features/reconciliation/pages/index.tsx
+++ b/frontend/src/features/reconciliation/pages/index.tsx
@@ -5,7 +5,7 @@ import { DataTable } from '@/shared/data-table'
 import { StatusBadge } from '@/shared/status-badge'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { useAuthenticatedFetch } from '@/hooks/use-authenticated-fetch'
+import { useReconciliationRunsTable } from '../hooks'
 import { InitiateReconciliationDialog } from './initiate-reconciliation-dialog'
 
 export interface ReconciliationRun {
@@ -22,49 +22,6 @@ export interface ReconciliationRun {
 function formatDate(iso: string): string {
   if (!iso) return '—'
   return iso.slice(0, 10)
-}
-
-async function fetchReconciliationRuns(params: {
-  pageToken?: string
-  pageSize: number
-  filters?: Record<string, string>
-}, fetchFn: typeof fetch = fetch): Promise<{ items: ReconciliationRun[]; nextPageToken?: string }> {
-  const url = new URL('/v1/reconciliation/runs', window.location.origin)
-  url.searchParams.set('page_size', String(params.pageSize))
-  if (params.pageToken) url.searchParams.set('page_token', params.pageToken)
-  if (params.filters) {
-    for (const [k, v] of Object.entries(params.filters)) {
-      if (v) url.searchParams.set(k, v)
-    }
-  }
-  const res = await fetchFn(url.toString())
-  if (!res.ok) throw new Error(`Failed to fetch reconciliation runs: ${res.status}`)
-  const data = await res.json() as {
-    runs?: Array<{
-      runId?: string
-      accountId?: string
-      scope?: string
-      settlementType?: string
-      status?: string
-      varianceCount?: number
-      periodStart?: string
-      periodEnd?: string
-    }>
-    nextPageToken?: string
-  }
-  return {
-    items: (data.runs ?? []).map((run) => ({
-      runId: run.runId ?? '',
-      accountId: run.accountId ?? '',
-      scope: run.scope?.replace('RECONCILIATION_SCOPE_', '') ?? '',
-      settlementType: run.settlementType?.replace('SETTLEMENT_TYPE_', '') ?? '',
-      status: run.status?.replace('RUN_STATUS_', '') ?? '',
-      varianceCount: run.varianceCount ?? 0,
-      periodStart: run.periodStart ?? '',
-      periodEnd: run.periodEnd ?? '',
-    })),
-    nextPageToken: data.nextPageToken,
-  }
 }
 
 const columns: ColumnDef<ReconciliationRun>[] = [
@@ -123,7 +80,7 @@ const columns: ColumnDef<ReconciliationRun>[] = [
 
 export function ReconciliationPage() {
   const navigate = useNavigate()
-  const authFetch = useAuthenticatedFetch()
+  const { queryKey, queryFn } = useReconciliationRunsTable()
   const [dialogOpen, setDialogOpen] = React.useState(false)
 
   function handleRowClick(run: ReconciliationRun) {
@@ -151,8 +108,8 @@ export function ReconciliationPage() {
         onSuccess={handleReconciliationSuccess}
       />
       <DataTable
-        queryKey={['reconciliation-runs']}
-        queryFn={(params) => fetchReconciliationRuns(params, authFetch)}
+        queryKey={queryKey}
+        queryFn={queryFn}
         columns={columns}
         pageSize={25}
         filters={[

--- a/frontend/src/features/sagas/hooks/index.ts
+++ b/frontend/src/features/sagas/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useSagasTable, useSagaDetail, useActiveSaga } from './use-sagas'

--- a/frontend/src/features/sagas/hooks/use-sagas.ts
+++ b/frontend/src/features/sagas/hooks/use-sagas.ts
@@ -1,0 +1,71 @@
+import { useQuery } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+import type { DataTableQueryParams, DataTableResult } from '@/shared/data-table'
+import type { SagaDefinition } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
+
+/**
+ * Fetches a paginated list of saga definitions for use with DataTable.
+ */
+export function useSagasTable() {
+  const { sagaRegistry } = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  const queryKey = tenantKeys.sagas(tenantSlug ?? '')
+
+  async function queryFn(
+    params: DataTableQueryParams,
+  ): Promise<DataTableResult<SagaDefinition>> {
+    const response = await sagaRegistry.listSagas({
+      pageSize: params.pageSize,
+      pageToken: params.pageToken,
+    })
+    return {
+      items: response.sagas ?? [],
+      nextPageToken: response.nextPageToken || undefined,
+    }
+  }
+
+  return { queryKey, queryFn, tenantSlug }
+}
+
+/**
+ * Fetches a single saga definition by ID.
+ */
+export function useSagaDetail(definitionId: string | undefined) {
+  const { sagaRegistry } = useApiClients()
+  const tenantSlug = useTenantSlug()
+
+  return useQuery({
+    queryKey: tenantSlug
+      ? [...tenantKeys.sagas(tenantSlug), definitionId]
+      : ['starlark-config', definitionId],
+    queryFn: async () => {
+      const response = await sagaRegistry.getSaga({ id: definitionId ?? '' })
+      return response.saga
+    },
+    enabled: !!definitionId,
+  })
+}
+
+/**
+ * Fetches the active saga for a given name (platform default).
+ */
+export function useActiveSaga(sagaName: string | undefined, enabled: boolean = true) {
+  const { sagaRegistry } = useApiClients()
+
+  return useQuery({
+    queryKey: ['starlark-config', 'active', sagaName],
+    queryFn: async () => {
+      if (!sagaName) return null
+      try {
+        const response = await sagaRegistry.getActiveSaga({ name: sagaName })
+        return response
+      } catch {
+        return null
+      }
+    },
+    enabled: !!sagaName && enabled,
+  })
+}

--- a/frontend/src/features/sagas/hooks/use-sagas.ts
+++ b/frontend/src/features/sagas/hooks/use-sagas.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import { ConnectError, Code } from '@connectrpc/connect'
 import { useApiClients } from '@/api/context'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
@@ -59,8 +60,15 @@ export function useActiveSaga(sagaName: string | undefined, enabled: boolean = t
     queryKey: ['starlark-config', 'active', sagaName],
     queryFn: async () => {
       if (!sagaName) return null
-      const response = await sagaRegistry.getActiveSaga({ name: sagaName })
-      return response
+      try {
+        const response = await sagaRegistry.getActiveSaga({ name: sagaName })
+        return response
+      } catch (error) {
+        if (error instanceof ConnectError && error.code === Code.NotFound) {
+          return null
+        }
+        throw error
+      }
     },
     enabled: !!sagaName && enabled,
   })

--- a/frontend/src/features/sagas/hooks/use-sagas.ts
+++ b/frontend/src/features/sagas/hooks/use-sagas.ts
@@ -45,7 +45,7 @@ export function useSagaDetail(definitionId: string | undefined) {
       const response = await sagaRegistry.getSaga({ id: definitionId ?? '' })
       return response.saga
     },
-    enabled: !!definitionId,
+    enabled: Boolean(tenantSlug && definitionId),
   })
 }
 
@@ -59,12 +59,8 @@ export function useActiveSaga(sagaName: string | undefined, enabled: boolean = t
     queryKey: ['starlark-config', 'active', sagaName],
     queryFn: async () => {
       if (!sagaName) return null
-      try {
-        const response = await sagaRegistry.getActiveSaga({ name: sagaName })
-        return response
-      } catch {
-        return null
-      }
+      const response = await sagaRegistry.getActiveSaga({ name: sagaName })
+      return response
     },
     enabled: !!sagaName && enabled,
   })

--- a/frontend/src/features/sagas/hooks/use-sagas.ts
+++ b/frontend/src/features/sagas/hooks/use-sagas.ts
@@ -46,7 +46,7 @@ export function useSagaDetail(definitionId: string | undefined) {
       const response = await sagaRegistry.getSaga({ id: definitionId ?? '' })
       return response.saga
     },
-    enabled: Boolean(tenantSlug && definitionId),
+    enabled: Boolean(definitionId),
   })
 }
 

--- a/frontend/src/features/sagas/pages/detail.test.tsx
+++ b/frontend/src/features/sagas/pages/detail.test.tsx
@@ -11,6 +11,14 @@ vi.mock('@/api/context', () => ({
   useApiClients: vi.fn(),
 }))
 
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: () => 'test-tenant',
+  useCurrentTenant: () => null,
+  useIsPlatformAdmin: () => false,
+  useSwitchTenant: () => vi.fn(),
+  useClearTenant: () => vi.fn(),
+}))
+
 // Mock CodeMirror (same as starlark-editor tests)
 vi.mock('codemirror', () => ({
   basicSetup: [],

--- a/frontend/src/features/sagas/pages/detail.tsx
+++ b/frontend/src/features/sagas/pages/detail.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
 import { useParams } from 'react-router-dom'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { StatusBadge } from '@/shared/status-badge'
@@ -10,6 +10,7 @@ import { Breadcrumbs } from '@/shared'
 import { useApiClients } from '@/api/context'
 import { SagaStatus, ErrorCategory } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
 import type { SagaDefinition } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
+import { useSagaDetail, useActiveSaga } from '../hooks'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -130,31 +131,12 @@ export function StarlarkDetailPage() {
   const [validationErrors, setValidationErrors] = useState<ValidationError[]>([])
   const [complexityMetrics, setComplexityMetrics] = useState<ComplexityMetrics | undefined>(undefined)
 
-  // Fetch the specific saga definition
-  const { data: sagaData, isLoading } = useQuery({
-    queryKey: ['starlark-config', definitionId],
-    queryFn: async () => {
-      const response = await sagaRegistry.getSaga({ id: definitionId ?? '' })
-      return response.saga
-    },
-    enabled: !!definitionId,
-  })
+  const { data: sagaData, isLoading } = useSagaDetail(definitionId)
 
-  // For non-system sagas: also fetch the platform default (system saga with same name)
-  // to show the split pane comparison
-  const { data: activeSagaData } = useQuery({
-    queryKey: ['starlark-config', 'active', sagaData?.name],
-    queryFn: async () => {
-      if (!sagaData?.name) return null
-      try {
-        const response = await sagaRegistry.getActiveSaga({ name: sagaData.name })
-        return response
-      } catch {
-        return null
-      }
-    },
-    enabled: !!sagaData?.name && !sagaData.isSystem,
-  })
+  const { data: activeSagaData } = useActiveSaga(
+    sagaData?.name,
+    !!sagaData?.name && !sagaData.isSystem,
+  )
 
   const effectiveScript = script ?? sagaData?.script ?? ''
 

--- a/frontend/src/features/sagas/pages/detail.tsx
+++ b/frontend/src/features/sagas/pages/detail.tsx
@@ -8,6 +8,8 @@ import { TimeDisplay } from '@/shared/time-display'
 import { StarlarkEditor, type ValidationError, type ComplexityMetrics } from '@/features/sagas/components/starlark-editor'
 import { Breadcrumbs } from '@/shared'
 import { useApiClients } from '@/api/context'
+import { useTenantSlug } from '@/hooks/use-tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
 import { SagaStatus, ErrorCategory } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
 import type { SagaDefinition } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
 import { useSagaDetail, useActiveSaga } from '../hooks'
@@ -125,7 +127,11 @@ function SplitPane({
 export function StarlarkDetailPage() {
   const { definitionId } = useParams<{ definitionId: string }>()
   const { sagaRegistry } = useApiClients()
+  const tenantSlug = useTenantSlug()
   const qc = useQueryClient()
+  const sagaQueryRoot = tenantSlug
+    ? [...tenantKeys.sagas(tenantSlug), definitionId]
+    : ['starlark-config', definitionId]
 
   const [script, setScript] = useState<string | null>(null)
   const [validationErrors, setValidationErrors] = useState<ValidationError[]>([])
@@ -179,7 +185,7 @@ export function StarlarkDetailPage() {
       return sagaRegistry.activateSaga({ id: sagaData.id })
     },
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ['starlark-config', definitionId] })
+      void qc.invalidateQueries({ queryKey: sagaQueryRoot })
     },
   })
 
@@ -190,7 +196,7 @@ export function StarlarkDetailPage() {
       return sagaRegistry.deprecateSaga({ id: sagaData.id, successorId: '' })
     },
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ['starlark-config', definitionId] })
+      void qc.invalidateQueries({ queryKey: sagaQueryRoot })
     },
   })
 

--- a/frontend/src/features/sagas/pages/index.test.tsx
+++ b/frontend/src/features/sagas/pages/index.test.tsx
@@ -9,6 +9,14 @@ vi.mock('@/api/context', () => ({
   useApiClients: vi.fn(),
 }))
 
+vi.mock('@/hooks/use-tenant-context', () => ({
+  useTenantSlug: () => 'test-tenant',
+  useCurrentTenant: () => null,
+  useIsPlatformAdmin: () => false,
+  useSwitchTenant: () => vi.fn(),
+  useClearTenant: () => vi.fn(),
+}))
+
 import { useApiClients } from '@/api/context'
 
 function makeQueryClient() {

--- a/frontend/src/features/sagas/pages/index.tsx
+++ b/frontend/src/features/sagas/pages/index.tsx
@@ -3,12 +3,12 @@ import { Link } from 'react-router-dom'
 import type { ColumnDef } from '@tanstack/react-table'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { DataTable, type DataTableQueryParams, type DataTableResult } from '@/shared/data-table'
+import { DataTable } from '@/shared/data-table'
 import { TimeDisplay } from '@/shared/time-display'
 import { StatusBadge } from '@/shared/status-badge'
-import { useApiClients } from '@/api/context'
 import type { SagaDefinition } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
 import { SagaStatus } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
+import { useSagasTable } from '../hooks'
 import { CreateSagaDraftDialog } from './create-saga-draft-dialog'
 
 // ---------------------------------------------------------------------------
@@ -53,7 +53,7 @@ export interface StarlarkConfigPageProps {
 // ---------------------------------------------------------------------------
 
 export function StarlarkConfigPage({ isPlatformAdmin = false }: StarlarkConfigPageProps) {
-  const { sagaRegistry } = useApiClients()
+  const { queryKey, queryFn } = useSagasTable()
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
 
   const columns = useMemo((): ColumnDef<SagaDefinition>[] => {
@@ -118,17 +118,6 @@ export function StarlarkConfigPage({ isPlatformAdmin = false }: StarlarkConfigPa
     return base
   }, [isPlatformAdmin])
 
-  async function fetchSagas(params: DataTableQueryParams): Promise<DataTableResult<SagaDefinition>> {
-    const response = await sagaRegistry.listSagas({
-      pageSize: params.pageSize,
-      pageToken: params.pageToken,
-    })
-    return {
-      items: response.sagas ?? [],
-      nextPageToken: response.nextPageToken || undefined,
-    }
-  }
-
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-start justify-between">
@@ -145,8 +134,8 @@ export function StarlarkConfigPage({ isPlatformAdmin = false }: StarlarkConfigPa
 
       <Card className="p-6">
         <DataTable<SagaDefinition>
-          queryKey={['starlark-config']}
-          queryFn={fetchSagas}
+          queryKey={queryKey}
+          queryFn={queryFn}
           columns={columns}
           pageSize={25}
           className="w-full"


### PR DESCRIPTION
## Summary

Extracts inline `useQuery` calls from all feature module page components into reusable data hooks, following the pattern established in `features/accounts/hooks/use-accounts.ts` (PR #1413).

- Creates data hooks for 8 feature modules: payments, ledger, positions, parties, reconciliation, sagas, market-data, and internal-accounts
- Updates all page components to consume the new hooks instead of inline query logic
- Converts legacy `useAuthenticatedFetch` patterns (payments, reconciliation) to Connect-RPC clients

## Changes

### New hook files (16 files)
Each module gets a `hooks/` directory with a hook file and barrel export:
- `payments/hooks/use-payments.ts` — `usePaymentsTable()`, `usePaymentDetail()`
- `ledger/hooks/use-ledger.ts` — `useBookingLogsTable()`, `useBookingLogDetail()`, `useLedgerPostings()`
- `positions/hooks/use-positions.ts` — `usePositionLogsTable()`, `usePositionLogDetail()`
- `parties/hooks/use-parties.ts` — `usePartiesTable()`, `usePartyDetail()`, `usePartyAssociations()`
- `reconciliation/hooks/use-reconciliation.ts` — `useReconciliationRunsTable()`, `useReconciliationRunDetail()`
- `sagas/hooks/use-sagas.ts` — `useSagasTable()`, `useSagaDetail()`, `useActiveSaga()`
- `market-data/hooks/use-market-data.ts` — `useDatasetsTable()`, `useDatasetDetail()`, `useDatasetObservations()`
- `internal-accounts/hooks/use-internal-accounts.ts` — `useInternalAccountsTable()`, `useInternalAccountDetail()`

### Modified page files (17 files)
All page components updated to import and use the new hooks, removing inline query logic, helper functions, and unused imports.

## Patterns

All hooks follow the established accounts pattern:
- **Table hooks**: Return `{ queryKey, queryFn, tenantSlug }` for `DataTable` component
- **Detail hooks**: Return `useQuery()` result directly
- Tenant-scoped query keys from `@/lib/query-keys.ts`
- Connect-RPC clients from `@/api/context`
- `useTenantSlug()` for tenant scoping

## Task Master

034-frontend-alignment.10 — Create data hooks for all feature modules

## Test plan

- [ ] Verify each list page renders data via DataTable (payments, ledger, positions, parties, reconciliation, sagas, market-data, internal-accounts)
- [ ] Verify each detail page loads and displays entity data
- [ ] Verify TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Verify no regressions in existing page functionality