### PR TITLE
feat(frontend): centralize tenant-scoped query keys

### DIFF
--- a/frontend/src/features/accounts/hooks/use-accounts.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.ts
@@ -141,7 +141,7 @@ export function useAccountPostings(accountId: string | undefined) {
   const tenantSlug = useTenantSlug()
 
   return useQuery({
-    queryKey: [...tenantKeys.account(tenantSlug ?? '', accountId ?? ''), 'postings'],
+    queryKey: tenantKeys.accountPostings(tenantSlug ?? '', accountId ?? ''),
     queryFn: () =>
       clients.financialAccounting.listLedgerPostings({
         pagination: { pageSize: 50, pageToken: '' },

--- a/frontend/src/features/ledger/hooks/use-ledger.ts
+++ b/frontend/src/features/ledger/hooks/use-ledger.ts
@@ -46,7 +46,7 @@ export function useBookingLogsTable() {
   const clients = useApiClients()
   const tenantSlug = useTenantSlug()
 
-  const queryKey = [...(tenantSlug ? tenantKeys.all(tenantSlug) : ['no-tenant']), 'ledger', 'bookingLogs'] as const
+  const queryKey = tenantKeys.bookingLogs(tenantSlug ?? '')
 
   async function queryFn(
     params: DataTableQueryParams,
@@ -95,7 +95,7 @@ export function useBookingLogDetail(bookingLogId: string | undefined) {
   const tenantSlug = useTenantSlug()
 
   return useQuery({
-    queryKey: [...tenantKeys.all(tenantSlug ?? ''), 'ledger', 'bookingLog', bookingLogId],
+    queryKey: tenantKeys.bookingLog(tenantSlug ?? '', bookingLogId ?? ''),
     queryFn: async (): Promise<FinancialBookingLog | null> => {
       const response = await clients.financialAccounting.retrieveFinancialBookingLog({
         id: bookingLogId ?? '',
@@ -150,7 +150,7 @@ export function useLedgerPostings(accountId: string | undefined) {
   const tenantSlug = useTenantSlug()
 
   return useQuery({
-    queryKey: [...tenantKeys.all(tenantSlug ?? ''), 'ledger', 'postings', accountId],
+    queryKey: tenantKeys.ledgerPostings(tenantSlug ?? '', accountId ?? ''),
     queryFn: () =>
       clients.financialAccounting.listLedgerPostings({
         pagination: { pageSize: 50, pageToken: '' },

--- a/frontend/src/features/mappings/pages/dialogs/mapping-mutations.ts
+++ b/frontend/src/features/mappings/pages/dialogs/mapping-mutations.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useApiClients } from '@/api/context'
+import { referenceKeys } from '@/lib/query-keys'
 
 export interface CreateMappingRequest {
   name: string
@@ -25,7 +26,7 @@ export function useCreateMapping() {
       return response.mapping
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['mappings'] })
+      void queryClient.invalidateQueries({ queryKey: referenceKeys.mappings() })
     },
   })
 }

--- a/frontend/src/features/market-data/hooks/use-market-data.ts
+++ b/frontend/src/features/market-data/hooks/use-market-data.ts
@@ -81,7 +81,7 @@ export function useDatasetObservations(datasetCode: string | undefined) {
   const tenantSlug = useTenantSlug()
 
   return useQuery({
-    queryKey: [...tenantKeys.marketDataSet(tenantSlug ?? '', datasetCode ?? ''), 'observations'],
+    queryKey: tenantKeys.marketDataObservations(tenantSlug ?? '', datasetCode ?? ''),
     queryFn: () =>
       clients.marketInformation.listObservations({
         datasetCode: datasetCode!,

--- a/frontend/src/features/positions/hooks/use-positions.ts
+++ b/frontend/src/features/positions/hooks/use-positions.ts
@@ -13,9 +13,7 @@ export function usePositionLogsTable() {
   const clients = useApiClients()
   const tenantSlug = useTenantSlug()
 
-  const queryKey = tenantSlug
-    ? [...tenantKeys.all(tenantSlug), 'positions']
-    : ['positions']
+  const queryKey = tenantKeys.positions(tenantSlug ?? '')
 
   async function queryFn(
     params: DataTableQueryParams,
@@ -48,9 +46,7 @@ export function usePositionLogDetail(logId: string | undefined) {
   const tenantSlug = useTenantSlug()
 
   return useQuery({
-    queryKey: tenantSlug
-      ? [...tenantKeys.all(tenantSlug), 'positions', logId]
-      : ['positions', logId],
+    queryKey: tenantKeys.position(tenantSlug ?? '', logId ?? ''),
     queryFn: () =>
       clients.positionKeeping.retrieveFinancialPositionLog({ logId: logId! }),
     enabled: Boolean(tenantSlug && logId),

--- a/frontend/src/features/sagas/hooks/use-sagas.ts
+++ b/frontend/src/features/sagas/hooks/use-sagas.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { ConnectError, Code } from '@connectrpc/connect'
 import { useApiClients } from '@/api/context'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
-import { tenantKeys } from '@/lib/query-keys'
+import { tenantKeys, referenceKeys } from '@/lib/query-keys'
 import type { DataTableQueryParams, DataTableResult } from '@/shared/data-table'
 import type { SagaDefinition } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
 
@@ -39,9 +39,7 @@ export function useSagaDetail(definitionId: string | undefined) {
   const tenantSlug = useTenantSlug()
 
   return useQuery({
-    queryKey: tenantSlug
-      ? [...tenantKeys.sagas(tenantSlug), definitionId]
-      : ['starlark-config', definitionId],
+    queryKey: tenantKeys.saga(tenantSlug ?? '', definitionId ?? ''),
     queryFn: async () => {
       const response = await sagaRegistry.getSaga({ id: definitionId ?? '' })
       return response.saga
@@ -57,7 +55,7 @@ export function useActiveSaga(sagaName: string | undefined, enabled: boolean = t
   const { sagaRegistry } = useApiClients()
 
   return useQuery({
-    queryKey: ['starlark-config', 'active', sagaName],
+    queryKey: referenceKeys.activeSaga(sagaName ?? ''),
     queryFn: async () => {
       if (!sagaName) return null
       try {

--- a/frontend/src/hooks/use-tenant.ts
+++ b/frontend/src/hooks/use-tenant.ts
@@ -26,7 +26,7 @@ export function useTenantProvisioningStatus(tenantId: string, tenantStatus?: Ten
   const isProvisioning = tenantStatus !== undefined && PROVISIONING_STATUSES.has(tenantStatus)
 
   return useQuery({
-    queryKey: [...platformKeys.tenant(tenantId), 'provisioning-status'],
+    queryKey: platformKeys.tenantProvisioningStatus(tenantId),
     queryFn: async () => {
       const response = await tenant.getTenantProvisioningStatus({ tenantId })
       return response
@@ -48,7 +48,7 @@ export function useUpdateTenantStatus(tenantId: string) {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: platformKeys.tenant(tenantId) })
       void queryClient.invalidateQueries({
-        queryKey: [...platformKeys.tenant(tenantId), 'provisioning-status'],
+        queryKey: platformKeys.tenantProvisioningStatus(tenantId),
       })
       void queryClient.invalidateQueries({ queryKey: platformKeys.tenants() })
     },

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -68,7 +68,7 @@ export const tenantKeys = {
   bookingLogs: (tenantId: string) =>
     [...tenantKeys.ledger(tenantId), 'bookingLogs'] as const,
   bookingLog: (tenantId: string, bookingLogId: string) =>
-    [...tenantKeys.ledger(tenantId), 'bookingLog', bookingLogId] as const,
+    [...tenantKeys.bookingLogs(tenantId), bookingLogId] as const,
   ledgerPostings: (tenantId: string, accountId: string) =>
     [...tenantKeys.ledger(tenantId), 'postings', accountId] as const,
 

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -4,34 +4,45 @@
  * Tenant-scoped keys include the tenantId to ensure cache isolation between tenants.
  * Platform-scoped keys are for platform-level data not tied to a specific tenant.
  * Reference keys are for non-tenant-scoped reference/configuration data.
+ *
+ * Key hierarchy follows the pattern: [scope, tenantId?, domain, entity?, id?]
+ * so that invalidating a parent key cascades to all children.
  */
 
 export const tenantKeys = {
   all: (tenantId: string) => ['tenants', tenantId] as const,
 
+  // Accounts
   accounts: (tenantId: string) =>
     [...tenantKeys.all(tenantId), 'accounts'] as const,
   account: (tenantId: string, accountId: string) =>
     [...tenantKeys.accounts(tenantId), accountId] as const,
+  accountPostings: (tenantId: string, accountId: string) =>
+    [...tenantKeys.account(tenantId, accountId), 'postings'] as const,
 
+  // Liens
   liens: (tenantId: string, accountId: string) =>
     [...tenantKeys.account(tenantId, accountId), 'liens'] as const,
 
+  // Transactions
   transactions: (tenantId: string) =>
     [...tenantKeys.all(tenantId), 'transactions'] as const,
   transaction: (tenantId: string, transactionId: string) =>
     [...tenantKeys.transactions(tenantId), transactionId] as const,
 
+  // Sagas
   sagas: (tenantId: string) =>
     [...tenantKeys.all(tenantId), 'sagas'] as const,
   saga: (tenantId: string, sagaId: string) =>
     [...tenantKeys.sagas(tenantId), sagaId] as const,
 
+  // Payments
   payments: (tenantId: string) =>
     [...tenantKeys.all(tenantId), 'payments'] as const,
   payment: (tenantId: string, paymentOrderId: string) =>
     [...tenantKeys.payments(tenantId), paymentOrderId] as const,
 
+  // Parties
   parties: (tenantId: string) =>
     [...tenantKeys.all(tenantId), 'parties'] as const,
   party: (tenantId: string, partyId: string) =>
@@ -42,6 +53,7 @@ export const tenantKeys = {
   partyTypes: (tenantId: string) =>
     [...tenantKeys.all(tenantId), 'party-types'] as const,
 
+  // Internal accounts
   internalAccounts: (tenantId: string) =>
     [...tenantKeys.all(tenantId), 'internal-accounts'] as const,
   internalAccount: (tenantId: string, accountId: string) =>
@@ -50,11 +62,31 @@ export const tenantKeys = {
   accountLiens: (tenantId: string, accountId: string) =>
     [...tenantKeys.all(tenantId), 'liens', accountId] as const,
 
+  // Ledger
+  ledger: (tenantId: string) =>
+    [...tenantKeys.all(tenantId), 'ledger'] as const,
+  bookingLogs: (tenantId: string) =>
+    [...tenantKeys.ledger(tenantId), 'bookingLogs'] as const,
+  bookingLog: (tenantId: string, bookingLogId: string) =>
+    [...tenantKeys.ledger(tenantId), 'bookingLog', bookingLogId] as const,
+  ledgerPostings: (tenantId: string, accountId: string) =>
+    [...tenantKeys.ledger(tenantId), 'postings', accountId] as const,
+
+  // Positions
+  positions: (tenantId: string) =>
+    [...tenantKeys.all(tenantId), 'positions'] as const,
+  position: (tenantId: string, logId: string) =>
+    [...tenantKeys.positions(tenantId), logId] as const,
+
+  // Market data
   marketDataSets: (tenantId: string) =>
     [...tenantKeys.all(tenantId), 'market-data', 'datasets'] as const,
   marketDataSet: (tenantId: string, datasetCode: string) =>
     [...tenantKeys.marketDataSets(tenantId), datasetCode] as const,
+  marketDataObservations: (tenantId: string, datasetCode: string) =>
+    [...tenantKeys.marketDataSet(tenantId, datasetCode), 'observations'] as const,
 
+  // Reconciliation
   reconciliationRuns: (tenantId: string) =>
     [...tenantKeys.all(tenantId), 'reconciliation-runs'] as const,
   reconciliationRun: (tenantId: string, runId: string) =>
@@ -66,6 +98,8 @@ export const platformKeys = {
 
   tenants: () => [...platformKeys.all, 'tenants'] as const,
   tenant: (tenantId: string) => [...platformKeys.tenants(), tenantId] as const,
+  tenantProvisioningStatus: (tenantId: string) =>
+    [...platformKeys.tenant(tenantId), 'provisioning-status'] as const,
 
   health: () => [...platformKeys.all, 'health'] as const,
 
@@ -94,6 +128,8 @@ export const referenceKeys = {
 
   sagas: () => [...referenceKeys.all, 'sagas'] as const,
   saga: (sagaId: string) => [...referenceKeys.sagas(), sagaId] as const,
+  activeSaga: (sagaName: string) =>
+    [...referenceKeys.sagas(), 'active', sagaName] as const,
 
   mappings: () => [...referenceKeys.all, 'mappings'] as const,
   mapping: (mappingId: string) => [...referenceKeys.mappings(), mappingId] as const,


### PR DESCRIPTION
## Summary

- Add missing query key factories to `query-keys.ts`: ledger (bookingLogs, bookingLog, ledgerPostings), positions, account postings, market data observations, starlark-config active saga, and platform provisioning status
- Update all feature hooks to use centralized keys instead of inline array construction
- Group keys by domain with section comments for readability

## Changes

| File | Change |
|------|--------|
| `src/lib/query-keys.ts` | Add `ledger`, `bookingLogs`, `bookingLog`, `ledgerPostings`, `positions`, `position`, `accountPostings`, `marketDataObservations`, `tenantProvisioningStatus`, `activeSaga` keys |
| `src/features/ledger/hooks/use-ledger.ts` | Replace 3 inline key constructions with `tenantKeys.bookingLogs()`, `.bookingLog()`, `.ledgerPostings()` |
| `src/features/positions/hooks/use-positions.ts` | Replace 2 inline key constructions with `tenantKeys.positions()`, `.position()` |
| `src/features/sagas/hooks/use-sagas.ts` | Replace inline `['starlark-config', ...]` with `tenantKeys.saga()` and `referenceKeys.activeSaga()` |
| `src/features/accounts/hooks/use-accounts.ts` | Replace inline `[...account, 'postings']` with `tenantKeys.accountPostings()` |
| `src/features/market-data/hooks/use-market-data.ts` | Replace inline `[...marketDataSet, 'observations']` with `tenantKeys.marketDataObservations()` |
| `src/features/mappings/pages/dialogs/mapping-mutations.ts` | Replace inline `['mappings']` with `referenceKeys.mappings()` |
| `src/hooks/use-tenant.ts` | Replace inline `[...tenant, 'provisioning-status']` with `platformKeys.tenantProvisioningStatus()` |

## Test plan

- [ ] TypeScript compilation passes (verified locally, no new errors)
- [ ] ESLint passes on all modified files
- [ ] Query key hierarchy preserved: invalidating parent keys still cascades to children