### PR TITLE
fix: Register MappingService in unified binary

### DIFF
--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -38,6 +38,7 @@ import (
 	forecastingv1 "github.com/meridianhub/meridian/api/proto/meridian/forecasting/v1"
 	identityv1 "github.com/meridianhub/meridian/api/proto/meridian/identity/v1"
 	internalaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
+	mappingv1 "github.com/meridianhub/meridian/api/proto/meridian/mapping/v1"
 	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	paymentorderv1 "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
@@ -84,6 +85,7 @@ import (
 	refcache "github.com/meridianhub/meridian/services/reference-data/cache"
 	refcel "github.com/meridianhub/meridian/services/reference-data/cel"
 	refhandler "github.com/meridianhub/meridian/services/reference-data/handler"
+	refmapping "github.com/meridianhub/meridian/services/reference-data/mapping"
 	refnode "github.com/meridianhub/meridian/services/reference-data/node"
 	refregistry "github.com/meridianhub/meridian/services/reference-data/registry"
 	refsaga "github.com/meridianhub/meridian/services/reference-data/saga"
@@ -497,10 +499,21 @@ func wireReferenceData(server *grpc.Server, pool *pgxpool.Pool, logger *slog.Log
 		return nil, fmt.Errorf("account type service: %w", err)
 	}
 
+	mappingRepo := refmapping.NewPostgresRepository(pool)
+	mappingValidator, err := refmapping.NewValidator(compiler)
+	if err != nil {
+		return nil, fmt.Errorf("mapping validator: %w", err)
+	}
+	mappingSvc, err := refhandler.NewMappingService(mappingRepo, mappingValidator, logger)
+	if err != nil {
+		return nil, fmt.Errorf("mapping service: %w", err)
+	}
+
 	referencedatav1.RegisterReferenceDataServiceServer(server, refDataSvc)
 	referencedatav1.RegisterNodeServiceServer(server, nodeSvc)
 	referencedatav1.RegisterAccountTypeRegistryServiceServer(server, acctTypeSvc)
 	sagav1.RegisterSagaRegistryServiceServer(server, sagaSvc)
+	mappingv1.RegisterMappingServiceServer(server, mappingSvc)
 	logger.Info("registered reference-data service")
 	return &refDataComponents{
 		accountTypeRegistry: acctTypeReg,


### PR DESCRIPTION
## Summary

- Register `MappingServiceServer` in the unified binary's `wireReferenceData()` function
- The mappings page showed "fail to load data" because MappingService was not registered with the gRPC server, even though the standalone reference-data service registered it correctly

## Changes Made

In `cmd/meridian/main.go` `wireReferenceData()`:
1. Added `mappingv1` proto import and `refmapping` package import
2. Instantiated mapping repository (`refmapping.NewPostgresRepository`), validator (`refmapping.NewValidator`), and service (`refhandler.NewMappingService`)
3. Registered `mappingv1.RegisterMappingServiceServer` on the gRPC server

## Test plan

- [x] `go build ./cmd/meridian/` compiles successfully
- [x] Pre-commit checks pass (gofumpt, golangci-lint, gitleaks)
- [ ] CI pipeline passes
- [ ] Gateway mappings page loads data in demo environment