### PR TITLE
fix: Persist auth token in sessionStorage to survive page refresh

### DIFF
--- a/frontend/src/contexts/auth-context.test.tsx
+++ b/frontend/src/contexts/auth-context.test.tsx
@@ -265,7 +265,7 @@ describe('AuthProvider', () => {
     expect(screen.getByTestId('userId').textContent).toBe('user-123')
   })
 
-  it('does NOT persist tokens to localStorage', async () => {
+  it('persists token to sessionStorage but NOT localStorage', async () => {
     const token = createTestToken({ userId: 'user-123' })
 
     const TestComponent = () => {
@@ -283,19 +283,114 @@ describe('AuthProvider', () => {
 
     expect(screen.getByTestId('auth').textContent).toBe('true')
 
-    // Verify nothing in localStorage or sessionStorage
-    const localStorageKeys = Object.keys(localStorage)
-    const sessionStorageKeys = Object.keys(sessionStorage)
+    // Token should be in sessionStorage
+    expect(sessionStorage.getItem('meridian_access_token')).toBe(token)
 
+    // Token must NOT be in localStorage
+    const localStorageKeys = Object.keys(localStorage)
     const tokenInLocalStorage = localStorageKeys.some(
       (key) => localStorage.getItem(key)?.includes(token),
     )
-    const tokenInSessionStorage = sessionStorageKeys.some(
-      (key) => sessionStorage.getItem(key)?.includes(token),
-    )
-
     expect(tokenInLocalStorage).toBe(false)
-    expect(tokenInSessionStorage).toBe(false)
+  })
+
+  it('restores auth state from sessionStorage on mount', async () => {
+    const token = createTestToken({ userId: 'user-restored' })
+    sessionStorage.setItem('meridian_access_token', token)
+
+    const TestComponent = () => {
+      const { isAuthenticated, claims } = useAuth()
+      return (
+        <div>
+          <span data-testid="auth">{String(isAuthenticated)}</span>
+          <span data-testid="userId">{claims?.userId ?? 'none'}</span>
+        </div>
+      )
+    }
+
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>,
+      )
+    })
+
+    expect(screen.getByTestId('auth').textContent).toBe('true')
+    expect(screen.getByTestId('userId').textContent).toBe('user-restored')
+  })
+
+  it('clears expired token from sessionStorage on mount', async () => {
+    const expiredToken = createExpiredToken()
+    sessionStorage.setItem('meridian_access_token', expiredToken)
+
+    const TestComponent = () => {
+      const { isAuthenticated } = useAuth()
+      return <span data-testid="auth">{String(isAuthenticated)}</span>
+    }
+
+    // Mock refresh to fail so we stay unauthenticated
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 })
+
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>,
+      )
+    })
+
+    expect(screen.getByTestId('auth').textContent).toBe('false')
+    expect(sessionStorage.getItem('meridian_access_token')).toBeNull()
+  })
+
+  it('clears sessionStorage on logout', async () => {
+    const token = createTestToken({ userId: 'user-123' })
+
+    let logoutFn: (() => void) | null = null
+
+    const TestComponent = () => {
+      const { isAuthenticated, logout } = useAuth()
+      logoutFn = logout
+      return <span data-testid="auth">{String(isAuthenticated)}</span>
+    }
+
+    await act(async () => {
+      render(
+        <AuthProvider initialToken={token}>
+          <TestComponent />
+        </AuthProvider>,
+      )
+    })
+
+    expect(sessionStorage.getItem('meridian_access_token')).toBe(token)
+
+    await act(async () => {
+      logoutFn!()
+    })
+
+    expect(screen.getByTestId('auth').textContent).toBe('false')
+    expect(sessionStorage.getItem('meridian_access_token')).toBeNull()
+  })
+
+  it('clears malformed token from sessionStorage on mount', async () => {
+    sessionStorage.setItem('meridian_access_token', 'not-a-valid-jwt')
+
+    const TestComponent = () => {
+      const { isAuthenticated } = useAuth()
+      return <span data-testid="auth">{String(isAuthenticated)}</span>
+    }
+
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>,
+      )
+    })
+
+    expect(screen.getByTestId('auth').textContent).toBe('false')
+    expect(sessionStorage.getItem('meridian_access_token')).toBeNull()
   })
 
   it('calls refresh endpoint and updates token on refresh', async () => {

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -113,22 +113,33 @@ interface AuthProviderProps {
   initialToken?: string
 }
 
+const SESSION_STORAGE_KEY = 'meridian_access_token'
+
+function restoreToken(initialToken?: string): { token: string | null; claims: JWTClaims | null } {
+  // Prefer explicit initialToken over stored token
+  const candidate = initialToken ?? sessionStorage.getItem(SESSION_STORAGE_KEY)
+  if (!candidate) return { token: null, claims: null }
+
+  const parsed = parseJWT(candidate)
+  if (!parsed || isTokenExpired(parsed)) {
+    sessionStorage.removeItem(SESSION_STORAGE_KEY)
+    return { token: null, claims: null }
+  }
+
+  sessionStorage.setItem(SESSION_STORAGE_KEY, candidate)
+  return { token: candidate, claims: parsed }
+}
+
 export function AuthProvider({ children, initialToken }: AuthProviderProps) {
-  // Tokens are stored in memory only - never persisted to localStorage/sessionStorage
-  const [accessToken, setAccessToken] = useState<string | null>(() => {
-    if (!initialToken) return null
-    // Only store token if it parses successfully
-    return parseJWT(initialToken) ? initialToken : null
-  })
-  const [claims, setClaims] = useState<JWTClaims | null>(() => {
-    if (!initialToken) return null
-    return parseJWT(initialToken)
-  })
+  const [restored] = useState(() => restoreToken(initialToken))
+  const [accessToken, setAccessToken] = useState<string | null>(restored.token)
+  const [claims, setClaims] = useState<JWTClaims | null>(restored.claims)
 
   const updateToken = useCallback((token: string | null) => {
     if (!token) {
       setAccessToken(null)
       setClaims(null)
+      sessionStorage.removeItem(SESSION_STORAGE_KEY)
       return
     }
     const parsed = parseJWT(token)
@@ -136,10 +147,12 @@ export function AuthProvider({ children, initialToken }: AuthProviderProps) {
       // Malformed token - clear both token and claims
       setAccessToken(null)
       setClaims(null)
+      sessionStorage.removeItem(SESSION_STORAGE_KEY)
       return
     }
     setAccessToken(token)
     setClaims(parsed)
+    sessionStorage.setItem(SESSION_STORAGE_KEY, token)
   }, [])
 
   const login = useCallback(

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -20,5 +20,6 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 afterEach(() => {
   cleanup()
   server.resetHandlers()
+  sessionStorage.clear()
 })
 afterAll(() => server.close())


### PR DESCRIPTION
## Summary

- Store access token in `sessionStorage` so browser refresh no longer forces re-login
- On mount, restore and validate token from `sessionStorage` (check parse + expiry)
- Clear stored token on logout, malformed input, or expiry
- Uses `sessionStorage` (not `localStorage`) so tokens are scoped to the tab and cleared on tab close

## Changes

- **`frontend/src/contexts/auth-context.tsx`**: Add `restoreToken()` helper that checks `sessionStorage` on mount; update `updateToken` callback to sync `sessionStorage` on every token change
- **`frontend/src/contexts/auth-context.test.tsx`**: Replace "does NOT persist" test with persistence verification; add tests for restore-on-mount, expired token cleanup, malformed token cleanup, and logout clearing

## Task Master

Task: `demo-polish-defects.5` - Fix Session Persistence on Browser Refresh

## Test plan

- [x] Existing 20 tests continue to pass
- [x] New test: token persisted to sessionStorage on login
- [x] New test: auth state restored from sessionStorage on mount
- [x] New test: expired token cleared from sessionStorage on mount
- [x] New test: malformed token cleared from sessionStorage on mount
- [x] New test: sessionStorage cleared on logout
- [x] Token NOT written to localStorage (verified in test)