### PR TITLE
feat: EntityLink auto-detect account type and reverse not-found links

### DIFF
--- a/frontend/src/features/accounts/pages/[accountId].tsx
+++ b/frontend/src/features/accounts/pages/[accountId].tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, Link } from 'react-router-dom'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
@@ -42,6 +42,7 @@ function AccountDetailSkeleton() {
 // ---------------------------------------------------------------------------
 
 function AccountNotFound() {
+  const { accountId } = useParams<{ accountId: string }>()
   return (
     <div data-testid="account-not-found" className="p-6">
       <Breadcrumbs items={[{ label: 'Accounts', href: '/accounts' }, { label: 'Not found' }]} />
@@ -50,6 +51,14 @@ function AccountNotFound() {
         <p className="mt-2 text-sm text-muted-foreground">
           The account you are looking for does not exist or has been removed.
         </p>
+        {accountId && (
+          <p className="mt-3 text-sm">
+            Did you mean?{' '}
+            <Link to={`/internal-accounts/${encodeURIComponent(accountId)}`} className="text-blue-600 hover:underline dark:text-blue-400">
+              View as internal account
+            </Link>
+          </p>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/features/internal-accounts/pages/[accountId].tsx
+++ b/frontend/src/features/internal-accounts/pages/[accountId].tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, Link } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -77,6 +77,7 @@ function InternalAccountDetailSkeleton() {
 // ---------------------------------------------------------------------------
 
 function InternalAccountNotFound() {
+  const { accountId } = useParams<{ accountId: string }>()
   return (
     <div data-testid="internal-account-not-found" className="p-6">
       <Breadcrumbs items={[{ label: 'Internal Accounts', href: '/internal-accounts' }, { label: 'Not found' }]} />
@@ -85,6 +86,14 @@ function InternalAccountNotFound() {
         <p className="mt-2 text-sm text-muted-foreground">
           The internal account you are looking for does not exist or has been removed.
         </p>
+        {accountId && (
+          <p className="mt-3 text-sm">
+            Did you mean?{' '}
+            <Link to={`/accounts/${encodeURIComponent(accountId)}`} className="text-blue-600 hover:underline dark:text-blue-400">
+              View as current account
+            </Link>
+          </p>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,9 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function isUuid(value: string): boolean {
+  return UUID_REGEX.test(value)
+}

--- a/frontend/src/shared/entity-link.tsx
+++ b/frontend/src/shared/entity-link.tsx
@@ -1,7 +1,9 @@
 import { Link } from 'react-router-dom'
+import { isUuid } from '@/lib/utils'
 
 export type EntityType =
   | 'account'
+  | 'current-account'
   | 'party'
   | 'internal-account'
   | 'payment'
@@ -12,6 +14,11 @@ function entityPath(type: EntityType, id: string): string {
   const encodedId = encodeURIComponent(id)
   switch (type) {
     case 'account':
+      // UUID → current account, human-readable code → internal account
+      return isUuid(id)
+        ? `/accounts/${encodedId}`
+        : `/internal-accounts/${encodedId}`
+    case 'current-account':
       return `/accounts/${encodedId}`
     case 'party':
       return `/parties/${encodedId}`


### PR DESCRIPTION
## Summary

- EntityLink with type `account` now auto-detects based on ID format: UUIDs route to `/accounts/` (current accounts), non-UUID codes route to `/internal-accounts/` (internal accounts)
- Added `current-account` explicit type for cases where the caller knows it is a current account regardless of ID format
- Both account detail not-found pages now show a "Did you mean?" link suggesting the alternative account type

## Changes

- `frontend/src/lib/utils.ts` - Added `isUuid()` utility function
- `frontend/src/shared/entity-link.tsx` - Added UUID-based auto-routing for `account` type, added `current-account` type
- `frontend/src/features/accounts/pages/[accountId].tsx` - Added reverse link to internal accounts on not-found
- `frontend/src/features/internal-accounts/pages/[accountId].tsx` - Added reverse link to current accounts on not-found

## Test plan

- [ ] Verify EntityLink with UUID ID routes to `/accounts/<id>`
- [ ] Verify EntityLink with human-readable code routes to `/internal-accounts/<id>`
- [ ] Verify explicit `current-account` and `internal-account` types still work as overrides
- [ ] Verify not-found page on `/accounts/<id>` shows "Did you mean? View as internal account" link
- [ ] Verify not-found page on `/internal-accounts/<id>` shows "Did you mean? View as current account" link