### PR TITLE
fix: party association search display name fallback

### DIFF
--- a/frontend/src/features/parties/pages/dialogs/register-associations-dialog.tsx
+++ b/frontend/src/features/parties/pages/dialogs/register-associations-dialog.tsx
@@ -198,12 +198,13 @@ export function RegisterAssociationsDialog({
   }
 
   function handleSelectParty(party: Party) {
+    const name = party.displayName || party.legalName || party.partyId
     setFormData((prev) => ({
       ...prev,
       relatedPartyId: party.partyId,
-      relatedPartyName: party.displayName,
+      relatedPartyName: name,
     }))
-    setSearchInput(party.displayName)
+    setSearchInput(name)
     setShowDropdown(false)
   }
 
@@ -281,7 +282,7 @@ export function RegisterAssociationsDialog({
                         handleSelectParty(party)
                       }}
                     >
-                      <span className="font-medium">{party.displayName}</span>
+                      <span className="font-medium">{party.displayName || party.legalName}</span>
                       <span className="ml-2 text-xs text-muted-foreground">{party.partyId}</span>
                     </li>
                   ))}


### PR DESCRIPTION
## Summary

- Fix party association search dropdown showing blank names when `displayName` is empty
- Use `legalName` (required proto field) as fallback when `displayName` (optional) is not set

## Changes

- `register-associations-dialog.tsx`: Display `displayName || legalName` in dropdown items
- `handleSelectParty`: Store `displayName || legalName || partyId` as selected party name

## Auth Investigation (Issue 2)

Investigated the POST `RegisterAssociations` returning 401 and triggering logout. Findings:

- The gateway auth chain (auth -> tenant resolver -> tenant authz -> transcoder) handles all HTTP methods identically
- The `metadataPropagationMiddleware` correctly propagates `x-tenant-id` for POST requests
- The `TenantAuthorizationMiddleware` allows requests when JWT has no tenant claim but tenant is resolved from subdomain (line 312 of `combined_middleware.go`)
- The `auth-interceptor.ts` correctly catches `Code.Unauthenticated` and triggers logout

**Root cause**: Most likely token expiration during form fill-out. The user opens the association dialog, spends time filling fields, and by submission the JWT has expired. The auth interceptor sees `Unauthenticated`, calls `onUnauthenticated()` which triggers `logout()`. This is the same root cause addressed by demo-polish-defects.5 (session persistence on refresh).

## Test Plan

- [ ] Search for a party that has no `displayName` set -- verify `legalName` appears in dropdown
- [ ] Select such a party -- verify the input field shows `legalName` not blank
- [ ] Submit the association form -- verify it works when token is fresh