### PR TITLE
feat: implement ManifestHistoryService gRPC handler

### DIFF
--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -371,7 +371,9 @@ func registerServices(
 		{"internal-account", func() error {
 			return wireInternalAccount(grpcServer, conns.gormDB("internal-account"), refDataComps, logger)
 		}},
-		{"control-plane", func() error { return wireControlPlane(grpcServer, conns.pgxPool("control-plane"), logger) }},
+		{"control-plane", func() error {
+			return wireControlPlane(grpcServer, conns.pgxPool("control-plane"), conns.gormDB("tenant"), logger)
+		}},
 		{"audit", func() error { return wireAudit(grpcServer, conns.gormDB("tenant"), logger) }}, // audit uses platform DB
 		{"identity", func() error { return wireIdentity(grpcServer, conns.gormDB("identity"), logger) }},
 	} {
@@ -823,7 +825,7 @@ func wireIdentity(server *grpc.Server, db *gorm.DB, logger *slog.Logger) error {
 
 // ─── Control Plane Wiring ────────────────────────────────────────────────────
 
-func wireControlPlane(server *grpc.Server, pool *pgxpool.Pool, logger *slog.Logger) error {
+func wireControlPlane(server *grpc.Server, pool *pgxpool.Pool, db *gorm.DB, logger *slog.Logger) error {
 	// Register ApplyManifestService without executor for now.
 	// HandlerDeps (reference-data, internal-account, operational-gateway gRPC clients)
 	// will be wired in a follow-up once cross-service connections are established here.
@@ -835,6 +837,16 @@ func wireControlPlane(server *grpc.Server, pool *pgxpool.Pool, logger *slog.Logg
 		return err
 	}
 	logger.Info("registered control-plane service (ApplyManifestService)")
+
+	// Register ManifestHistoryService for manifest version history queries.
+	if err := controlplaneservice.RegisterManifestHistoryService(server, controlplaneservice.ManifestHistoryServiceConfig{
+		DB:     db,
+		Logger: logger,
+	}); err != nil {
+		return err
+	}
+	logger.Info("registered control-plane service (ManifestHistoryService)")
+
 	return nil
 }
 

--- a/services/control-plane/internal/manifest/grpc_handler.go
+++ b/services/control-plane/internal/manifest/grpc_handler.go
@@ -1,0 +1,116 @@
+package manifest
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ErrHistoryServiceRequired is returned when history service is nil.
+var ErrHistoryServiceRequired = errors.New("history service is required")
+
+// HistoryHandler implements the ManifestHistoryService gRPC interface.
+type HistoryHandler struct {
+	controlplanev1.UnimplementedManifestHistoryServiceServer
+
+	history *HistoryService
+	logger  *slog.Logger
+}
+
+// NewHistoryHandler creates a new HistoryHandler.
+func NewHistoryHandler(history *HistoryService, logger *slog.Logger) (*HistoryHandler, error) {
+	if history == nil {
+		return nil, ErrHistoryServiceRequired
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &HistoryHandler{
+		history: history,
+		logger:  logger.With("component", "manifest_history_handler"),
+	}, nil
+}
+
+// GetCurrentManifest retrieves the most recently applied manifest for the tenant.
+func (h *HistoryHandler) GetCurrentManifest(
+	ctx context.Context,
+	_ *controlplanev1.GetCurrentManifestRequest,
+) (*controlplanev1.GetCurrentManifestResponse, error) {
+	entity, err := h.history.GetCurrentManifest(ctx)
+	if err != nil {
+		if errors.Is(err, ErrVersionNotFound) {
+			return nil, status.Error(codes.NotFound, "no applied manifest found")
+		}
+		h.logger.Error("failed to get current manifest", "error", err)
+		return nil, status.Error(codes.Internal, "failed to get current manifest")
+	}
+
+	version, err := EntityToProto(entity)
+	if err != nil {
+		h.logger.Error("failed to convert entity to proto", "error", err)
+		return nil, status.Error(codes.Internal, "failed to convert manifest version")
+	}
+
+	return &controlplanev1.GetCurrentManifestResponse{Version: version}, nil
+}
+
+// GetManifestVersion retrieves a specific manifest version by its version string.
+func (h *HistoryHandler) GetManifestVersion(
+	ctx context.Context,
+	req *controlplanev1.GetManifestVersionRequest,
+) (*controlplanev1.GetManifestVersionResponse, error) {
+	if req.GetVersion() == "" {
+		return nil, status.Error(codes.InvalidArgument, "version is required")
+	}
+
+	entity, err := h.history.GetManifestVersion(ctx, req.GetVersion())
+	if err != nil {
+		if errors.Is(err, ErrVersionNotFound) {
+			return nil, status.Errorf(codes.NotFound, "manifest version %q not found", req.GetVersion())
+		}
+		h.logger.Error("failed to get manifest version", "version", req.GetVersion(), "error", err)
+		return nil, status.Error(codes.Internal, "failed to get manifest version")
+	}
+
+	version, err := EntityToProto(entity)
+	if err != nil {
+		h.logger.Error("failed to convert entity to proto", "error", err)
+		return nil, status.Error(codes.Internal, "failed to convert manifest version")
+	}
+
+	return &controlplanev1.GetManifestVersionResponse{Version: version}, nil
+}
+
+// ListManifestVersions returns a paginated list of manifest versions.
+func (h *HistoryHandler) ListManifestVersions(
+	ctx context.Context,
+	req *controlplanev1.ListManifestVersionsRequest,
+) (*controlplanev1.ListManifestVersionsResponse, error) {
+	limit := int(req.GetLimit())
+	offset := int(req.GetOffset())
+
+	entities, totalCount, err := h.history.ListManifestVersions(ctx, limit, offset)
+	if err != nil {
+		h.logger.Error("failed to list manifest versions", "error", err)
+		return nil, status.Error(codes.Internal, "failed to list manifest versions")
+	}
+
+	versions := make([]*controlplanev1.ManifestVersion, 0, len(entities))
+	for i := range entities {
+		v, err := EntityToProto(&entities[i])
+		if err != nil {
+			h.logger.Error("failed to convert entity to proto", "entity_id", entities[i].ID, "error", err)
+			return nil, status.Error(codes.Internal, "failed to convert manifest version")
+		}
+		versions = append(versions, v)
+	}
+
+	return &controlplanev1.ListManifestVersionsResponse{
+		Versions:   versions,
+		TotalCount: int32(totalCount),
+	}, nil
+}

--- a/services/control-plane/internal/manifest/grpc_handler_test.go
+++ b/services/control-plane/internal/manifest/grpc_handler_test.go
@@ -1,0 +1,92 @@
+package manifest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func TestNewHistoryHandler_NilHistory(t *testing.T) {
+	_, err := NewHistoryHandler(nil, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "history service is required")
+}
+
+func TestNewHistoryHandler_NilLogger(t *testing.T) {
+	repo := &Repository{}
+	svc, _ := NewHistoryService(repo)
+
+	handler, err := NewHistoryHandler(svc, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, handler)
+}
+
+// stubRepo implements the repository methods needed for handler tests
+// by embedding Repository and overriding methods via the HistoryService.
+// Since HistoryService delegates to Repository, we use a test approach
+// that provides pre-populated data through a mock-like pattern.
+
+func newTestEntity(version string) *VersionEntity {
+	m := testManifest(version)
+	marshaler := protojson.MarshalOptions{UseProtoNames: true}
+	jsonBytes, _ := marshaler.Marshal(m)
+
+	return &VersionEntity{
+		ID:           uuid.New(),
+		Version:      version,
+		ManifestJSON: string(jsonBytes),
+		AppliedAt:    time.Now().UTC(),
+		AppliedBy:    "admin@meridian.io",
+		ApplyStatus:  ApplyStatusApplied,
+		CreatedAt:    time.Now().UTC(),
+	}
+}
+
+func TestGetCurrentManifest_EntityToProtoConversion(t *testing.T) {
+	entity := newTestEntity("1.0")
+	proto, err := EntityToProto(entity)
+	require.NoError(t, err)
+
+	assert.Equal(t, entity.ID.String(), proto.Id)
+	assert.Equal(t, "1.0", proto.Version)
+	assert.Equal(t, "admin@meridian.io", proto.AppliedBy)
+	assert.Equal(t, controlplanev1.ApplyStatus_APPLY_STATUS_APPLIED, proto.ApplyStatus)
+	assert.NotNil(t, proto.Manifest)
+}
+
+func TestGetManifestVersion_EmptyVersionReturnsInvalidArgument(t *testing.T) {
+	repo := &Repository{}
+	svc, _ := NewHistoryService(repo)
+	handler, err := NewHistoryHandler(svc, nil)
+	require.NoError(t, err)
+
+	_, err = handler.GetManifestVersion(context.Background(), &controlplanev1.GetManifestVersionRequest{
+		Version: "",
+	})
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "version is required")
+}
+
+func TestListManifestVersions_EmptyListReturnsOK(t *testing.T) {
+	// EntityToProto on empty slice should produce empty response
+	versions := make([]*controlplanev1.ManifestVersion, 0)
+	assert.Empty(t, versions)
+
+	resp := &controlplanev1.ListManifestVersionsResponse{
+		Versions:   versions,
+		TotalCount: 0,
+	}
+	assert.Equal(t, int32(0), resp.TotalCount)
+	assert.Empty(t, resp.Versions)
+}

--- a/services/control-plane/internal/manifest/grpc_handler_test.go
+++ b/services/control-plane/internal/manifest/grpc_handler_test.go
@@ -78,15 +78,7 @@ func TestGetManifestVersion_EmptyVersionReturnsInvalidArgument(t *testing.T) {
 	assert.Contains(t, st.Message(), "version is required")
 }
 
-func TestListManifestVersions_EmptyListReturnsOK(t *testing.T) {
-	// EntityToProto on empty slice should produce empty response
-	versions := make([]*controlplanev1.ManifestVersion, 0)
-	assert.Empty(t, versions)
-
-	resp := &controlplanev1.ListManifestVersionsResponse{
-		Versions:   versions,
-		TotalCount: 0,
-	}
-	assert.Equal(t, int32(0), resp.TotalCount)
-	assert.Empty(t, resp.Versions)
+func TestNewHistoryHandler_ErrorSentinel(t *testing.T) {
+	_, err := NewHistoryHandler(nil, nil)
+	assert.ErrorIs(t, err, ErrHistoryServiceRequired)
 }

--- a/services/control-plane/internal/manifest/grpc_handler_test.go
+++ b/services/control-plane/internal/manifest/grpc_handler_test.go
@@ -22,22 +22,20 @@ func TestNewHistoryHandler_NilHistory(t *testing.T) {
 
 func TestNewHistoryHandler_NilLogger(t *testing.T) {
 	repo := &Repository{}
-	svc, _ := NewHistoryService(repo)
+	svc, err := NewHistoryService(repo)
+	require.NoError(t, err)
 
 	handler, err := NewHistoryHandler(svc, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, handler)
 }
 
-// stubRepo implements the repository methods needed for handler tests
-// by embedding Repository and overriding methods via the HistoryService.
-// Since HistoryService delegates to Repository, we use a test approach
-// that provides pre-populated data through a mock-like pattern.
-
-func newTestEntity(version string) *VersionEntity {
+func newTestEntity(t *testing.T, version string) *VersionEntity {
+	t.Helper()
 	m := testManifest(version)
 	marshaler := protojson.MarshalOptions{UseProtoNames: true}
-	jsonBytes, _ := marshaler.Marshal(m)
+	jsonBytes, err := marshaler.Marshal(m)
+	require.NoError(t, err)
 
 	return &VersionEntity{
 		ID:           uuid.New(),
@@ -51,7 +49,7 @@ func newTestEntity(version string) *VersionEntity {
 }
 
 func TestGetCurrentManifest_EntityToProtoConversion(t *testing.T) {
-	entity := newTestEntity("1.0")
+	entity := newTestEntity(t, "1.0")
 	proto, err := EntityToProto(entity)
 	require.NoError(t, err)
 
@@ -64,7 +62,8 @@ func TestGetCurrentManifest_EntityToProtoConversion(t *testing.T) {
 
 func TestGetManifestVersion_EmptyVersionReturnsInvalidArgument(t *testing.T) {
 	repo := &Repository{}
-	svc, _ := NewHistoryService(repo)
+	svc, err := NewHistoryService(repo)
+	require.NoError(t, err)
 	handler, err := NewHistoryHandler(svc, nil)
 	require.NoError(t, err)
 

--- a/services/control-plane/service/manifest_history.go
+++ b/services/control-plane/service/manifest_history.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/control-plane/internal/manifest"
+	"google.golang.org/grpc"
+	"gorm.io/gorm"
+)
+
+// ManifestHistoryServiceConfig holds the configuration for RegisterManifestHistoryService.
+type ManifestHistoryServiceConfig struct {
+	// DB is the GORM database connection (required).
+	DB *gorm.DB
+
+	// Logger is the structured logger. Defaults to slog.Default() if nil.
+	Logger *slog.Logger
+}
+
+// ErrDBRequired is returned when DB is nil during service registration.
+var ErrDBRequired = errors.New("manifest history service: database connection is required")
+
+// RegisterManifestHistoryService creates and registers the ManifestHistoryService
+// on the given gRPC server.
+func RegisterManifestHistoryService(server *grpc.Server, cfg ManifestHistoryServiceConfig) error {
+	if cfg.DB == nil {
+		return ErrDBRequired
+	}
+
+	repo, err := manifest.NewRepository(cfg.DB)
+	if err != nil {
+		return fmt.Errorf("manifest repository: %w", err)
+	}
+
+	historySvc, err := manifest.NewHistoryService(repo)
+	if err != nil {
+		return fmt.Errorf("manifest history service: %w", err)
+	}
+
+	handler, err := manifest.NewHistoryHandler(historySvc, cfg.Logger)
+	if err != nil {
+		return fmt.Errorf("manifest history handler: %w", err)
+	}
+
+	controlplanev1.RegisterManifestHistoryServiceServer(server, handler)
+	return nil
+}


### PR DESCRIPTION
## Summary

- Implement `ManifestHistoryService` gRPC handler with `GetCurrentManifest`, `GetManifestVersion`, and `ListManifestVersions` RPCs
- Create `RegisterManifestHistoryService` in the control-plane service package for clean wiring
- Register the service in the unified binary `wireControlPlane` function

## Changes

- **`services/control-plane/internal/manifest/grpc_handler.go`**: `HistoryHandler` struct implementing `ManifestHistoryServiceServer`, delegating to the existing `HistoryService` domain layer
- **`services/control-plane/service/manifest_history.go`**: `RegisterManifestHistoryService` function that wires Repository -> HistoryService -> HistoryHandler -> gRPC registration
- **`cmd/meridian/main.go`**: Updated `wireControlPlane` to accept a `*gorm.DB` (shared `meridian_platform` database via tenant connection) and register the ManifestHistoryService
- **`services/control-plane/internal/manifest/grpc_handler_test.go`**: Unit tests for handler construction and input validation

## Technical Details

The ManifestHistoryService needs a GORM `*gorm.DB` for the manifest `Repository`, while the existing `wireControlPlane` only had a `*pgxpool.Pool`. Since control-plane and tenant share the `meridian_platform` database, the GORM connection from tenant is reused (`conns.gormDB("tenant")`).

## Test Plan

- [x] Unit tests for handler construction (nil history, nil logger)
- [x] Unit test for `GetManifestVersion` with empty version returns `InvalidArgument`
- [x] Entity-to-proto conversion verification
- [x] Full build (`go build ./...`) passes
- [x] All existing manifest package tests pass
- [x] Lint checks pass (golangci-lint)