### PR TITLE
fix: patch hono transitive security vulnerabilities

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1874,9 +1874,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7623,9 +7623,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
-      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,10 @@
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },
+  "overrides": {
+    "hono": "^4.12.4",
+    "@hono/node-server": "^1.19.10"
+  },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",
     "@bufbuild/protoc-gen-es": "^2.11.0",


### PR DESCRIPTION
## Summary

- Add npm `overrides` in `frontend/package.json` to force patched versions of transitive dependencies `hono` (>=4.12.4) and `@hono/node-server` (>=1.19.10)
- Resolves all 4 open Dependabot alerts (cookie attribute injection, auth bypass via encoded slashes, arbitrary file access, SSE control field injection)
- Root cause: `shadcn` (dev dep) pulls in `@modelcontextprotocol/sdk` which depends on vulnerable `hono` versions

## Changes Made

- `frontend/package.json`: Added `overrides` block for `hono` and `@hono/node-server`
- `frontend/package-lock.json`: Regenerated with patched versions (`hono@4.12.5`, `@hono/node-server@1.19.11`)

## Risk Assessment

Low risk. These are transitive dev dependencies (used by `shadcn` CLI tooling, not shipped to production). The overrides only bump patch versions within compatible ranges.