### PR TITLE
feat: catalogue grid component for cookbook browser

### DIFF
--- a/frontend/src/features/cookbook/components/catalogue-grid.test.tsx
+++ b/frontend/src/features/cookbook/components/catalogue-grid.test.tsx
@@ -35,7 +35,7 @@ const mockItems: CookbookItem[] = [
 
 const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  const actual = await vi.importActual('react-router-dom')
   return { ...actual, useNavigate: () => mockNavigate }
 })
 

--- a/frontend/src/features/cookbook/components/catalogue-grid.test.tsx
+++ b/frontend/src/features/cookbook/components/catalogue-grid.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { CatalogueGrid } from './catalogue-grid'
+import type { CookbookItem } from '../hooks/use-cookbook'
+
+vi.mock('@/api/transport', () => ({
+  createTenantTransport: vi.fn(() => ({ __type: 'mock-transport' })),
+}))
+
+vi.mock('@/api/clients', () => ({
+  createServiceClients: vi.fn(() => ({})),
+}))
+
+const mockItems: CookbookItem[] = [
+  {
+    name: 'energy-trading',
+    type: 'registry:pattern',
+    title: 'Energy Trading',
+    description: 'Buy and sell electricity',
+    categories: ['energy', 'trading'],
+    meta: { complexity: 7, design_pattern: 'saga', industries: ['energy'] },
+  },
+  {
+    name: 'balance-card',
+    type: 'registry:ui',
+    title: 'Balance Card',
+    description: 'Displays account balance',
+    categories: ['accounts'],
+    meta: { feature_module: 'accounts', configurable: true },
+  },
+]
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+function renderGrid(items: CookbookItem[], hasActiveFilters = false) {
+  return renderWithProviders(
+    <MemoryRouter>
+      <CatalogueGrid items={items} hasActiveFilters={hasActiveFilters} />
+    </MemoryRouter>,
+  )
+}
+
+describe('CatalogueGrid', () => {
+  it('renders cards for each item', () => {
+    renderGrid(mockItems)
+    expect(screen.getByText('Energy Trading')).toBeInTheDocument()
+    expect(screen.getByText('Balance Card')).toBeInTheDocument()
+  })
+
+  it('shows type badges', () => {
+    renderGrid(mockItems)
+    expect(screen.getByText('Pattern')).toBeInTheDocument()
+    expect(screen.getByText('UI')).toBeInTheDocument()
+  })
+
+  it('shows category badges', () => {
+    renderGrid(mockItems)
+    expect(screen.getByText('energy')).toBeInTheDocument()
+    expect(screen.getByText('trading')).toBeInTheDocument()
+    expect(screen.getByText('accounts')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no items', () => {
+    renderGrid([])
+    expect(screen.getByText('No cookbook entries yet')).toBeInTheDocument()
+  })
+
+  it('shows filter-specific empty state', () => {
+    renderGrid([], true)
+    expect(screen.getByText('No matching items')).toBeInTheDocument()
+  })
+
+  it('navigates on card click', async () => {
+    const user = userEvent.setup()
+    renderGrid(mockItems)
+    await user.click(screen.getByText('Energy Trading'))
+    expect(mockNavigate).toHaveBeenCalledWith('/cookbook/energy-trading')
+  })
+
+  it('shows complexity indicator for patterns', () => {
+    renderGrid(mockItems)
+    const complexityDots = document.querySelectorAll('[title="Complexity: 7/10"]')
+    expect(complexityDots.length).toBe(1)
+  })
+
+  it('shows design pattern label', () => {
+    renderGrid(mockItems)
+    expect(screen.getByText('saga')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/cookbook/components/catalogue-grid.tsx
+++ b/frontend/src/features/cookbook/components/catalogue-grid.tsx
@@ -69,10 +69,10 @@ function CookbookCard({ item }: { item: CookbookItem }) {
         )}
       </CardHeader>
 
-      {(item.categories?.length || patternMeta?.complexity) && (
+      {item.categories && item.categories.length > 0 && (
         <CardContent>
           <div className="flex flex-wrap gap-1">
-            {item.categories?.map((cat) => (
+            {item.categories.map((cat) => (
               <Badge key={cat} variant="outline" className="text-[10px]">
                 {cat}
               </Badge>

--- a/frontend/src/features/cookbook/components/catalogue-grid.tsx
+++ b/frontend/src/features/cookbook/components/catalogue-grid.tsx
@@ -37,8 +37,16 @@ function CookbookCard({ item }: { item: CookbookItem }) {
 
   return (
     <Card
-      className="cursor-pointer transition-colors hover:border-primary/50"
+      role="link"
+      tabIndex={0}
+      className="cursor-pointer transition-colors hover:border-primary/50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none"
       onClick={() => navigate(`/cookbook/${item.name}`)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          navigate(`/cookbook/${item.name}`)
+        }
+      }}
     >
       <CardHeader>
         <div className="flex items-start justify-between gap-2">

--- a/frontend/src/features/cookbook/components/catalogue-grid.tsx
+++ b/frontend/src/features/cookbook/components/catalogue-grid.tsx
@@ -1,0 +1,110 @@
+import { useNavigate } from 'react-router-dom'
+import { Blocks, BookOpen, SearchX } from 'lucide-react'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { EmptyState } from '@/components/ui/empty-state'
+import type { CookbookItem, PatternMeta, ComponentMeta } from '../hooks/use-cookbook'
+
+interface CatalogueGridProps {
+  items: CookbookItem[]
+  hasActiveFilters?: boolean
+}
+
+function isPatternMeta(meta: PatternMeta | ComponentMeta | undefined): meta is PatternMeta {
+  return meta !== undefined && 'complexity' in meta
+}
+
+function ComplexityIndicator({ score }: { score: number }) {
+  return (
+    <div className="flex items-center gap-1" title={`Complexity: ${score}/10`}>
+      {Array.from({ length: 5 }, (_, i) => (
+        <div
+          key={i}
+          className={`size-1.5 rounded-full ${
+            i < Math.ceil(score / 2) ? 'bg-primary' : 'bg-muted'
+          }`}
+        />
+      ))}
+    </div>
+  )
+}
+
+function CookbookCard({ item }: { item: CookbookItem }) {
+  const navigate = useNavigate()
+  const isPattern = item.type === 'registry:pattern'
+  const meta = item.meta
+  const patternMeta = isPatternMeta(meta) ? meta : undefined
+
+  return (
+    <Card
+      className="cursor-pointer transition-colors hover:border-primary/50"
+      onClick={() => navigate(`/cookbook/${item.name}`)}
+    >
+      <CardHeader>
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-center gap-2">
+            {isPattern ? (
+              <BookOpen className="size-4 text-primary shrink-0" />
+            ) : (
+              <Blocks className="size-4 text-muted-foreground shrink-0" />
+            )}
+            <CardTitle className="text-sm">{item.title}</CardTitle>
+          </div>
+          <Badge variant={isPattern ? 'default' : 'secondary'} className="text-[10px] shrink-0">
+            {isPattern ? 'Pattern' : 'UI'}
+          </Badge>
+        </div>
+        {item.description && (
+          <CardDescription className="line-clamp-2 text-xs">
+            {item.description}
+          </CardDescription>
+        )}
+      </CardHeader>
+
+      {(item.categories?.length || patternMeta?.complexity) && (
+        <CardContent>
+          <div className="flex flex-wrap gap-1">
+            {item.categories?.map((cat) => (
+              <Badge key={cat} variant="outline" className="text-[10px]">
+                {cat}
+              </Badge>
+            ))}
+          </div>
+        </CardContent>
+      )}
+
+      {patternMeta?.complexity !== undefined && (
+        <CardFooter className="justify-between">
+          <ComplexityIndicator score={patternMeta.complexity} />
+          {patternMeta.design_pattern && (
+            <span className="text-[10px] text-muted-foreground">{patternMeta.design_pattern}</span>
+          )}
+        </CardFooter>
+      )}
+    </Card>
+  )
+}
+
+export function CatalogueGrid({ items, hasActiveFilters }: CatalogueGridProps) {
+  if (items.length === 0) {
+    return (
+      <EmptyState
+        icon={hasActiveFilters ? SearchX : BookOpen}
+        title={hasActiveFilters ? 'No matching items' : 'No cookbook entries yet'}
+        description={
+          hasActiveFilters
+            ? 'Try adjusting your filters or search terms.'
+            : 'Cookbook entries will appear here once patterns and components are registered.'
+        }
+      />
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {items.map((item) => (
+        <CookbookCard key={item.name} item={item} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/features/cookbook/components/filter-bar.test.ts
+++ b/frontend/src/features/cookbook/components/filter-bar.test.ts
@@ -117,4 +117,9 @@ describe('applyFilters', () => {
     expect(result).toHaveLength(1)
     expect(result[0].name).toBe('energy-trading')
   })
+
+  it('filters out all items for unknown type value', () => {
+    const result = applyFilters(mockItems, { ...emptyFilters, type: 'invalid' })
+    expect(result).toHaveLength(0)
+  })
 })

--- a/frontend/src/features/cookbook/components/filter-bar.test.ts
+++ b/frontend/src/features/cookbook/components/filter-bar.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { applyFilters, type FilterState } from './filter-bar'
+import { applyFilters, type FilterState } from '../hooks/use-filter-state'
 import type { CookbookItem } from '../hooks/use-cookbook'
 
 const mockItems: CookbookItem[] = [

--- a/frontend/src/features/cookbook/components/filter-bar.test.ts
+++ b/frontend/src/features/cookbook/components/filter-bar.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import { applyFilters, type FilterState } from './filter-bar'
+import type { CookbookItem } from '../hooks/use-cookbook'
+
+const mockItems: CookbookItem[] = [
+  {
+    name: 'energy-trading',
+    type: 'registry:pattern',
+    title: 'Energy Trading',
+    description: 'Buy and sell electricity on wholesale markets',
+    categories: ['energy', 'trading'],
+    meta: {
+      complexity: 7,
+      design_pattern: 'saga',
+      industries: ['energy', 'utilities'],
+    },
+  },
+  {
+    name: 'carbon-offset',
+    type: 'registry:pattern',
+    title: 'Carbon Offset',
+    description: 'Track carbon credits and offsets',
+    categories: ['carbon', 'compliance'],
+    meta: {
+      complexity: 5,
+      industries: ['energy', 'finance'],
+    },
+  },
+  {
+    name: 'balance-card',
+    type: 'registry:ui',
+    title: 'Balance Card',
+    description: 'Displays account balance with currency formatting',
+    categories: ['accounts'],
+    meta: {
+      feature_module: 'accounts',
+      configurable: true,
+    },
+  },
+]
+
+const emptyFilters: FilterState = { search: '', type: '', category: '', industry: '' }
+
+describe('applyFilters', () => {
+  it('returns all items when no filters active', () => {
+    const result = applyFilters(mockItems, emptyFilters)
+    expect(result).toHaveLength(3)
+  })
+
+  it('filters by type pattern', () => {
+    const result = applyFilters(mockItems, { ...emptyFilters, type: 'pattern' })
+    expect(result).toHaveLength(2)
+    expect(result.every((i) => i.type === 'registry:pattern')).toBe(true)
+  })
+
+  it('filters by type ui', () => {
+    const result = applyFilters(mockItems, { ...emptyFilters, type: 'ui' })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('balance-card')
+  })
+
+  it('filters by category', () => {
+    const result = applyFilters(mockItems, { ...emptyFilters, category: 'energy' })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('energy-trading')
+  })
+
+  it('filters by industry', () => {
+    const result = applyFilters(mockItems, { ...emptyFilters, industry: 'finance' })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('carbon-offset')
+  })
+
+  it('filters by search term in title', () => {
+    const result = applyFilters(mockItems, { ...emptyFilters, search: 'balance' })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('balance-card')
+  })
+
+  it('filters by search term in description', () => {
+    const result = applyFilters(mockItems, { ...emptyFilters, search: 'electricity' })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('energy-trading')
+  })
+
+  it('search is case-insensitive', () => {
+    const result = applyFilters(mockItems, { ...emptyFilters, search: 'CARBON' })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('carbon-offset')
+  })
+
+  it('combines multiple filters with AND logic', () => {
+    const result = applyFilters(mockItems, {
+      type: 'pattern',
+      industry: 'energy',
+      category: '',
+      search: '',
+    })
+    expect(result).toHaveLength(2)
+  })
+
+  it('returns empty when no items match', () => {
+    const result = applyFilters(mockItems, { ...emptyFilters, search: 'nonexistent' })
+    expect(result).toHaveLength(0)
+  })
+
+  it('handles items without categories or meta gracefully', () => {
+    const sparse: CookbookItem[] = [
+      { name: 'bare', type: 'registry:pattern', title: 'Bare Item' },
+    ]
+    const result = applyFilters(sparse, { ...emptyFilters, category: 'anything' })
+    expect(result).toHaveLength(0)
+  })
+
+  it('handles items without meta.industries for industry filter', () => {
+    const result = applyFilters(mockItems, { ...emptyFilters, industry: 'utilities' })
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('energy-trading')
+  })
+})

--- a/frontend/src/features/cookbook/components/filter-bar.tsx
+++ b/frontend/src/features/cookbook/components/filter-bar.tsx
@@ -63,8 +63,9 @@ export function useFilterState(): [FilterState, (patch: Partial<FilterState>) =>
 export function applyFilters(items: CookbookItem[], filters: FilterState): CookbookItem[] {
   return items.filter((item) => {
     if (filters.type) {
-      const typeLabel = filters.type === 'pattern' ? 'registry:pattern' : 'registry:ui'
-      if (item.type !== typeLabel) return false
+      const typeMap: Record<string, string> = { pattern: 'registry:pattern', ui: 'registry:ui' }
+      const typeLabel = typeMap[filters.type]
+      if (!typeLabel || item.type !== typeLabel) return false
     }
 
     if (filters.category) {
@@ -163,17 +164,22 @@ interface FilterChipGroupProps {
 
 function FilterChipGroup({ label, options, value, onChange }: FilterChipGroupProps) {
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-1" role="group" aria-label={`${label} filter`}>
       <span className="text-xs text-muted-foreground mr-1">{label}:</span>
       {options.map((opt) => (
-        <Badge
+        <button
           key={opt.value}
-          variant={value === opt.value ? 'default' : 'outline'}
-          className="cursor-pointer text-xs"
+          type="button"
+          aria-pressed={value === opt.value}
           onClick={() => onChange(value === opt.value ? '' : opt.value)}
         >
-          {opt.label}
-        </Badge>
+          <Badge
+            variant={value === opt.value ? 'default' : 'outline'}
+            className="cursor-pointer text-xs"
+          >
+            {opt.label}
+          </Badge>
+        </button>
       ))}
     </div>
   )

--- a/frontend/src/features/cookbook/components/filter-bar.tsx
+++ b/frontend/src/features/cookbook/components/filter-bar.tsx
@@ -1,16 +1,9 @@
-import { useSearchParams } from 'react-router-dom'
 import { Search, X } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import type { CookbookItem, PatternMeta } from '../hooks/use-cookbook'
-
-export interface FilterState {
-  search: string
-  type: string
-  category: string
-  industry: string
-}
+import type { FilterState } from '../hooks/use-filter-state'
 
 function getUniqueCategories(items: CookbookItem[]): string[] {
   const set = new Set<string>()
@@ -31,60 +24,6 @@ function getUniqueIndustries(items: CookbookItem[]): string[] {
     }
   }
   return Array.from(set).sort()
-}
-
-export function useFilterState(): [FilterState, (patch: Partial<FilterState>) => void] {
-  const [searchParams, setSearchParams] = useSearchParams()
-
-  const state: FilterState = {
-    search: searchParams.get('search') ?? '',
-    type: searchParams.get('type') ?? '',
-    category: searchParams.get('category') ?? '',
-    industry: searchParams.get('industry') ?? '',
-  }
-
-  function update(patch: Partial<FilterState>) {
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev)
-      for (const [key, value] of Object.entries(patch)) {
-        if (value) {
-          next.set(key, value)
-        } else {
-          next.delete(key)
-        }
-      }
-      return next
-    })
-  }
-
-  return [state, update]
-}
-
-export function applyFilters(items: CookbookItem[], filters: FilterState): CookbookItem[] {
-  return items.filter((item) => {
-    if (filters.type) {
-      const typeMap: Record<string, string> = { pattern: 'registry:pattern', ui: 'registry:ui' }
-      const typeLabel = typeMap[filters.type]
-      if (!typeLabel || item.type !== typeLabel) return false
-    }
-
-    if (filters.category) {
-      if (!item.categories?.includes(filters.category)) return false
-    }
-
-    if (filters.industry) {
-      const meta = item.meta as PatternMeta | undefined
-      if (!meta?.industries?.includes(filters.industry)) return false
-    }
-
-    if (filters.search) {
-      const q = filters.search.toLowerCase()
-      const haystack = [item.name, item.title, item.description ?? ''].join(' ').toLowerCase()
-      if (!haystack.includes(q)) return false
-    }
-
-    return true
-  })
 }
 
 interface FilterBarProps {

--- a/frontend/src/features/cookbook/components/filter-bar.tsx
+++ b/frontend/src/features/cookbook/components/filter-bar.tsx
@@ -1,0 +1,180 @@
+import { useSearchParams } from 'react-router-dom'
+import { Search, X } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import type { CookbookItem, PatternMeta } from '../hooks/use-cookbook'
+
+export interface FilterState {
+  search: string
+  type: string
+  category: string
+  industry: string
+}
+
+function getUniqueCategories(items: CookbookItem[]): string[] {
+  const set = new Set<string>()
+  for (const item of items) {
+    for (const cat of item.categories ?? []) {
+      set.add(cat)
+    }
+  }
+  return Array.from(set).sort()
+}
+
+function getUniqueIndustries(items: CookbookItem[]): string[] {
+  const set = new Set<string>()
+  for (const item of items) {
+    const meta = item.meta as PatternMeta | undefined
+    for (const ind of meta?.industries ?? []) {
+      set.add(ind)
+    }
+  }
+  return Array.from(set).sort()
+}
+
+export function useFilterState(): [FilterState, (patch: Partial<FilterState>) => void] {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const state: FilterState = {
+    search: searchParams.get('search') ?? '',
+    type: searchParams.get('type') ?? '',
+    category: searchParams.get('category') ?? '',
+    industry: searchParams.get('industry') ?? '',
+  }
+
+  function update(patch: Partial<FilterState>) {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev)
+      for (const [key, value] of Object.entries(patch)) {
+        if (value) {
+          next.set(key, value)
+        } else {
+          next.delete(key)
+        }
+      }
+      return next
+    })
+  }
+
+  return [state, update]
+}
+
+export function applyFilters(items: CookbookItem[], filters: FilterState): CookbookItem[] {
+  return items.filter((item) => {
+    if (filters.type) {
+      const typeLabel = filters.type === 'pattern' ? 'registry:pattern' : 'registry:ui'
+      if (item.type !== typeLabel) return false
+    }
+
+    if (filters.category) {
+      if (!item.categories?.includes(filters.category)) return false
+    }
+
+    if (filters.industry) {
+      const meta = item.meta as PatternMeta | undefined
+      if (!meta?.industries?.includes(filters.industry)) return false
+    }
+
+    if (filters.search) {
+      const q = filters.search.toLowerCase()
+      const haystack = [item.name, item.title, item.description ?? ''].join(' ').toLowerCase()
+      if (!haystack.includes(q)) return false
+    }
+
+    return true
+  })
+}
+
+interface FilterBarProps {
+  items: CookbookItem[]
+  filters: FilterState
+  onFilterChange: (patch: Partial<FilterState>) => void
+}
+
+export function FilterBar({ items, filters, onFilterChange }: FilterBarProps) {
+  const categories = getUniqueCategories(items)
+  const industries = getUniqueIndustries(items)
+  const hasActiveFilters = filters.search || filters.type || filters.category || filters.industry
+
+  return (
+    <div className="space-y-3">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+        <Input
+          placeholder="Search patterns and components..."
+          value={filters.search}
+          onChange={(e) => onFilterChange({ search: e.target.value })}
+          className="pl-9"
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <FilterChipGroup
+          label="Type"
+          options={[
+            { value: 'pattern', label: 'Patterns' },
+            { value: 'ui', label: 'UI Components' },
+          ]}
+          value={filters.type}
+          onChange={(value) => onFilterChange({ type: value })}
+        />
+
+        {categories.length > 0 && (
+          <FilterChipGroup
+            label="Category"
+            options={categories.map((c) => ({ value: c, label: c }))}
+            value={filters.category}
+            onChange={(value) => onFilterChange({ category: value })}
+          />
+        )}
+
+        {industries.length > 0 && (
+          <FilterChipGroup
+            label="Industry"
+            options={industries.map((i) => ({ value: i, label: i }))}
+            value={filters.industry}
+            onChange={(value) => onFilterChange({ industry: value })}
+          />
+        )}
+
+        {hasActiveFilters && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onFilterChange({ search: '', type: '', category: '', industry: '' })}
+            className="h-7 text-xs"
+          >
+            <X className="size-3 mr-1" />
+            Clear
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface FilterChipGroupProps {
+  label: string
+  options: { value: string; label: string }[]
+  value: string
+  onChange: (value: string) => void
+}
+
+function FilterChipGroup({ label, options, value, onChange }: FilterChipGroupProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <span className="text-xs text-muted-foreground mr-1">{label}:</span>
+      {options.map((opt) => (
+        <Badge
+          key={opt.value}
+          variant={value === opt.value ? 'default' : 'outline'}
+          className="cursor-pointer text-xs"
+          onClick={() => onChange(value === opt.value ? '' : opt.value)}
+        >
+          {opt.label}
+        </Badge>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/features/cookbook/hooks/use-filter-state.ts
+++ b/frontend/src/features/cookbook/hooks/use-filter-state.ts
@@ -1,0 +1,63 @@
+import { useSearchParams } from 'react-router-dom'
+import type { CookbookItem, PatternMeta } from './use-cookbook'
+
+export interface FilterState {
+  search: string
+  type: string
+  category: string
+  industry: string
+}
+
+export function useFilterState(): [FilterState, (patch: Partial<FilterState>) => void] {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const state: FilterState = {
+    search: searchParams.get('search') ?? '',
+    type: searchParams.get('type') ?? '',
+    category: searchParams.get('category') ?? '',
+    industry: searchParams.get('industry') ?? '',
+  }
+
+  function update(patch: Partial<FilterState>) {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev)
+      for (const [key, value] of Object.entries(patch)) {
+        if (value) {
+          next.set(key, value)
+        } else {
+          next.delete(key)
+        }
+      }
+      return next
+    })
+  }
+
+  return [state, update]
+}
+
+export function applyFilters(items: CookbookItem[], filters: FilterState): CookbookItem[] {
+  return items.filter((item) => {
+    if (filters.type) {
+      const typeMap: Record<string, string> = { pattern: 'registry:pattern', ui: 'registry:ui' }
+      const typeLabel = typeMap[filters.type]
+      if (!typeLabel || item.type !== typeLabel) return false
+    }
+
+    if (filters.category) {
+      if (!item.categories?.includes(filters.category)) return false
+    }
+
+    if (filters.industry) {
+      const meta = item.meta as PatternMeta | undefined
+      if (!meta?.industries?.includes(filters.industry)) return false
+    }
+
+    if (filters.search) {
+      const q = filters.search.toLowerCase()
+      const haystack = [item.name, item.title, item.description ?? ''].join(' ').toLowerCase()
+      if (!haystack.includes(q)) return false
+    }
+
+    return true
+  })
+}

--- a/frontend/src/features/cookbook/pages/index.tsx
+++ b/frontend/src/features/cookbook/pages/index.tsx
@@ -1,11 +1,21 @@
+import { useCookbook } from '../hooks/use-cookbook'
+import { CatalogueGrid } from '../components/catalogue-grid'
+import { FilterBar, useFilterState, applyFilters } from '../components/filter-bar'
+
 export function CookbookPage() {
+  const { items } = useCookbook()
+  const [filters, setFilters] = useFilterState()
+  const filtered = applyFilters(items, filters)
+  const hasActiveFilters = !!(filters.search || filters.type || filters.category || filters.industry)
+
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-semibold">Cookbook</h1>
         <p className="text-muted-foreground">Browse economy patterns and UI components</p>
       </div>
-      {/* Catalogue grid placeholder - Task 3 */}
+      <FilterBar items={items} filters={filters} onFilterChange={setFilters} />
+      <CatalogueGrid items={filtered} hasActiveFilters={hasActiveFilters} />
     </div>
   )
 }

--- a/frontend/src/features/cookbook/pages/index.tsx
+++ b/frontend/src/features/cookbook/pages/index.tsx
@@ -1,6 +1,7 @@
 import { useCookbook } from '../hooks/use-cookbook'
+import { useFilterState, applyFilters } from '../hooks/use-filter-state'
 import { CatalogueGrid } from '../components/catalogue-grid'
-import { FilterBar, useFilterState, applyFilters } from '../components/filter-bar'
+import { FilterBar } from '../components/filter-bar'
 
 export function CookbookPage() {
   const { items } = useCookbook()


### PR DESCRIPTION
## Summary

- Adds `CatalogueGrid` component: responsive card grid (1/2/3/4 cols) displaying cookbook items with type badges, category badges, complexity dots, and design pattern labels
- Adds `FilterBar` component: search input + chip-style type/category/industry filters synced to URL query params via `useSearchParams`
- Exports pure `applyFilters` function with AND-logic across search, type, category, and industry dimensions
- Integrates both into `CookbookPage`, replacing the task-3 placeholder
- Empty states for zero items vs zero filter matches

## Task Master

Tag: `036-cookbook-browser`, Task: 3

## Test plan

- [x] 12 unit tests for `applyFilters` covering each filter dimension, combinations, case-insensitivity, sparse data
- [x] 8 component tests for `CatalogueGrid` covering rendering, type/category badges, empty states, card click navigation, complexity indicator
- [x] All 20 tests passing locally
- [ ] CI build passes