### PR TITLE
feat: saga flow diagram with React Flow

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@codemirror/view": "^6.39.15",
         "@connectrpc/connect": "^2.1.1",
         "@connectrpc/connect-web": "^2.1.1",
+        "@dagrejs/dagre": "^2.0.4",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-query-devtools": "^5.91.3",
         "@tanstack/react-table": "^8.21.3",
@@ -1056,6 +1057,21 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-2.0.4.tgz",
+      "integrity": "sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "3.0.4"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-3.0.4.tgz",
+      "integrity": "sha512-HxZ7fCvAwTLCWCO0WjDkzAFQze8LdC6iOpKbetDKHIuDfIgMlIzYzqZ4nxwLlclQX+3ZVeZ1K2OuaOE2WWcyOg==",
+      "license": "MIT"
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.52.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "@codemirror/view": "^6.39.15",
     "@connectrpc/connect": "^2.1.1",
     "@connectrpc/connect-web": "^2.1.1",
+    "@dagrejs/dagre": "^2.0.4",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-query-devtools": "^5.91.3",
     "@tanstack/react-table": "^8.21.3",

--- a/frontend/src/features/cookbook/components/preview-source-tabs.tsx
+++ b/frontend/src/features/cookbook/components/preview-source-tabs.tsx
@@ -11,10 +11,13 @@ interface PreviewSourceTabsProps {
 export function PreviewSourceTabs({ preview, source, sourceLabel = 'Source', className }: PreviewSourceTabsProps) {
   const [copied, setCopied] = useState(false)
 
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(source)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+  const handleCopy = () => {
+    navigator.clipboard.writeText(source).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }).catch(() => {
+      // Silently fail in restricted contexts
+    })
   }
 
   return (
@@ -31,6 +34,7 @@ export function PreviewSourceTabs({ preview, source, sourceLabel = 'Source', cla
       <TabsContent value="source" className="mt-4">
         <div className="relative">
           <button
+            type="button"
             onClick={handleCopy}
             className="absolute right-2 top-2 z-10 rounded border bg-background px-2 py-1 text-xs text-muted-foreground hover:bg-accent"
           >

--- a/frontend/src/features/cookbook/components/preview-source-tabs.tsx
+++ b/frontend/src/features/cookbook/components/preview-source-tabs.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+
+interface PreviewSourceTabsProps {
+  preview: React.ReactNode
+  source: string
+  sourceLabel?: string
+  className?: string
+}
+
+export function PreviewSourceTabs({ preview, source, sourceLabel = 'Source', className }: PreviewSourceTabsProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(source)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <Tabs defaultValue="preview" className={className}>
+      <TabsList>
+        <TabsTrigger value="preview">Preview</TabsTrigger>
+        <TabsTrigger value="source">{sourceLabel}</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="preview" className="mt-4">
+        {preview}
+      </TabsContent>
+
+      <TabsContent value="source" className="mt-4">
+        <div className="relative">
+          <button
+            onClick={handleCopy}
+            className="absolute right-2 top-2 z-10 rounded border bg-background px-2 py-1 text-xs text-muted-foreground hover:bg-accent"
+          >
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+          <pre className="overflow-auto rounded-lg border bg-muted/50 p-4 text-xs leading-relaxed">
+            <code>{source}</code>
+          </pre>
+        </div>
+      </TabsContent>
+    </Tabs>
+  )
+}

--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -72,9 +72,9 @@ function StepNode({ data }: { data: StepNodeData }) {
         <span className="text-xs font-semibold text-foreground">{data.label}</span>
         {data.serviceCalls.length > 0 && (
           <div className="flex flex-wrap gap-1">
-            {data.serviceCalls.map((call) => (
+            {data.serviceCalls.map((call, idx) => (
               <span
-                key={`${call.service}.${call.method}`}
+                key={`${call.service}.${call.method}.${idx}`}
                 className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium"
                 style={{
                   backgroundColor: serviceBgColor(call.service),

--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -228,7 +228,7 @@ function buildFlowGraph(flow: SagaFlow): { nodes: Node[]; edges: Edge[] } {
   }
 
   // Step + decision + exit nodes
-  let prevId = 'start'
+  let prevId: string | null = 'start'
 
   for (let i = 0; i < flow.steps.length; i++) {
     const step = flow.steps[i]
@@ -245,11 +245,14 @@ function buildFlowGraph(flow: SagaFlow): { nodes: Node[]; edges: Edge[] } {
       } satisfies StepNodeData,
     })
 
-    edges.push({
-      id: `${prevId}-${stepId}`,
-      source: prevId,
-      target: stepId,
-    })
+    // Connect from previous node (null when previous decision's "No" edge already connects)
+    if (prevId) {
+      edges.push({
+        id: `${prevId}-${stepId}`,
+        source: prevId,
+        target: stepId,
+      })
+    }
 
     if (step.earlyExit) {
       const decisionId = `decision-${i}`
@@ -285,7 +288,7 @@ function buildFlowGraph(flow: SagaFlow): { nodes: Node[]; edges: Edge[] } {
         style: { stroke: '#ef4444', strokeDasharray: '6 3' },
       })
 
-      // "No" -> next step
+      // "No" -> next step (already connects to nextId, so skip prevId for next iteration)
       edges.push({
         id: `${decisionId}-${nextId}`,
         source: decisionId,
@@ -293,7 +296,7 @@ function buildFlowGraph(flow: SagaFlow): { nodes: Node[]; edges: Edge[] } {
         label: 'No',
       })
 
-      prevId = decisionId
+      prevId = null
     } else {
       prevId = stepId
     }
@@ -307,9 +310,8 @@ function buildFlowGraph(flow: SagaFlow): { nodes: Node[]; edges: Edge[] } {
     data: {},
   })
 
-  // Connect last step to end (only if no early exit on last step)
-  const lastStep = flow.steps[flow.steps.length - 1]
-  if (!lastStep.earlyExit) {
+  // Connect last step to end (only if no early exit on last step already connected it)
+  if (prevId) {
     edges.push({
       id: `${prevId}-end`,
       source: prevId,
@@ -343,7 +345,7 @@ export function SagaFlowDiagram({ flow, onStepClick, className }: SagaFlowDiagra
   }, [flow])
 
   return (
-    <div className={className} style={{ width: '100%', height: '100%', minHeight: 400 }}>
+    <div className={`relative ${className ?? ''}`} style={{ width: '100%', height: '100%', minHeight: 400 }}>
       <ReactFlow
         nodes={nodes}
         edges={edges}

--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -1,0 +1,383 @@
+import { useMemo } from 'react'
+import {
+  ReactFlow,
+  Controls,
+  Background,
+  type Node,
+  type Edge,
+  BackgroundVariant,
+  Position,
+  Handle,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import Dagre from '@dagrejs/dagre'
+import type { SagaFlow } from '../lib/star-parser'
+
+// Hash a service name to a HSL hue for consistent coloring
+function serviceHue(service: string): number {
+  let hash = 0
+  for (let i = 0; i < service.length; i++) {
+    hash = service.charCodeAt(i) + ((hash << 5) - hash)
+  }
+  return ((hash % 360) + 360) % 360
+}
+
+function serviceColor(service: string): string {
+  return `hsl(${serviceHue(service)}, 65%, 50%)`
+}
+
+function serviceBgColor(service: string): string {
+  return `hsl(${serviceHue(service)}, 65%, 92%)`
+}
+
+// --- Custom Node Components ---
+
+interface StartNodeData {
+  label: string
+  trigger: string | null
+  [key: string]: unknown
+}
+
+function StartNode({ data }: { data: StartNodeData }) {
+  return (
+    <>
+      <div className="flex flex-col items-center justify-center rounded-full border-2 border-emerald-500 bg-emerald-50 px-4 py-2 dark:bg-emerald-950/40">
+        <span className="text-xs font-semibold text-emerald-700 dark:text-emerald-300">{data.label}</span>
+        {data.trigger && (
+          <span className="text-[10px] text-emerald-600 dark:text-emerald-400">{data.trigger}</span>
+        )}
+      </div>
+      <Handle type="source" position={Position.Bottom} className="!bg-emerald-500 !border-0 !w-2 !h-2" />
+    </>
+  )
+}
+
+interface StepNodeData {
+  label: string
+  serviceCalls: { service: string; method: string }[]
+  [key: string]: unknown
+}
+
+function StepNode({ data }: { data: StepNodeData }) {
+  const primaryService = data.serviceCalls[0]?.service
+  const borderColor = primaryService ? serviceColor(primaryService) : '#71717a'
+
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <div
+        className="flex flex-col gap-1 rounded-lg border-2 bg-background px-3 py-2 shadow-sm min-w-[180px]"
+        style={{ borderColor }}
+      >
+        <span className="text-xs font-semibold text-foreground">{data.label}</span>
+        {data.serviceCalls.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {data.serviceCalls.map((call) => (
+              <span
+                key={`${call.service}.${call.method}`}
+                className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium"
+                style={{
+                  backgroundColor: serviceBgColor(call.service),
+                  color: serviceColor(call.service),
+                }}
+              >
+                {call.service}.{call.method}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+}
+
+interface DecisionNodeData {
+  label: string
+  [key: string]: unknown
+}
+
+function DecisionNode({ data }: { data: DecisionNodeData }) {
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <div className="flex items-center justify-center" style={{ width: 140, height: 70 }}>
+        <div
+          className="flex items-center justify-center border-2 border-amber-500 bg-amber-50 dark:bg-amber-950/40"
+          style={{
+            width: 120,
+            height: 60,
+            transform: 'rotate(45deg)',
+          }}
+        >
+          <span
+            className="text-[10px] font-medium text-amber-700 dark:text-amber-300 text-center leading-tight px-1 max-w-[80px]"
+            style={{ transform: 'rotate(-45deg)' }}
+          >
+            {data.label}
+          </span>
+        </div>
+      </div>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="exit"
+        className="!bg-transparent !border-0 !w-0 !h-0"
+      />
+    </>
+  )
+}
+
+interface ExitNodeData {
+  label: string
+  [key: string]: unknown
+}
+
+function ExitNode({ data }: { data: ExitNodeData }) {
+  return (
+    <>
+      <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <div className="flex items-center justify-center rounded-full border-2 border-red-500 bg-red-50 px-3 py-1.5 dark:bg-red-950/40">
+        <span className="text-[10px] font-semibold text-red-700 dark:text-red-300">{data.label}</span>
+      </div>
+    </>
+  )
+}
+
+function EndNode() {
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <div className="flex items-center justify-center rounded-full border-2 border-slate-500 bg-slate-100 px-4 py-2 dark:bg-slate-800">
+        <span className="text-xs font-semibold text-slate-600 dark:text-slate-300">COMPLETED</span>
+      </div>
+    </>
+  )
+}
+
+const nodeTypes = {
+  sagaStart: StartNode,
+  sagaStep: StepNode,
+  sagaDecision: DecisionNode,
+  sagaExit: ExitNode,
+  sagaEnd: EndNode,
+}
+
+// --- Layout ---
+
+const NODE_DIMENSIONS: Record<string, { width: number; height: number }> = {
+  sagaStart: { width: 160, height: 50 },
+  sagaStep: { width: 200, height: 60 },
+  sagaDecision: { width: 140, height: 70 },
+  sagaExit: { width: 120, height: 36 },
+  sagaEnd: { width: 140, height: 44 },
+}
+
+function layoutNodes(nodes: Node[], edges: Edge[]): Node[] {
+  const g = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}))
+  g.setGraph({ rankdir: 'TB', nodesep: 50, ranksep: 80 })
+
+  for (const n of nodes) {
+    const dims = NODE_DIMENSIONS[n.type ?? 'sagaStep'] ?? { width: 200, height: 60 }
+    g.setNode(n.id, { width: dims.width, height: dims.height })
+  }
+
+  for (const e of edges) {
+    g.setEdge(e.source, e.target)
+  }
+
+  Dagre.layout(g)
+
+  return nodes.map((n) => {
+    const nodeWithPos = g.node(n.id)
+    const dims = NODE_DIMENSIONS[n.type ?? 'sagaStep'] ?? { width: 200, height: 60 }
+    return {
+      ...n,
+      position: {
+        x: (nodeWithPos?.x ?? 0) - dims.width / 2,
+        y: (nodeWithPos?.y ?? 0) - dims.height / 2,
+      },
+    }
+  })
+}
+
+// --- Build Graph from SagaFlow ---
+
+function buildFlowGraph(flow: SagaFlow): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = []
+  const edges: Edge[] = []
+
+  // Start node
+  nodes.push({
+    id: 'start',
+    type: 'sagaStart',
+    position: { x: 0, y: 0 },
+    data: { label: flow.name, trigger: flow.trigger } satisfies StartNodeData,
+  })
+
+  if (flow.steps.length === 0) {
+    nodes.push({
+      id: 'end',
+      type: 'sagaEnd',
+      position: { x: 0, y: 0 },
+      data: {},
+    })
+    edges.push({ id: 'start-end', source: 'start', target: 'end' })
+    return { nodes: layoutNodes(nodes, edges), edges }
+  }
+
+  // Step + decision + exit nodes
+  let prevId = 'start'
+
+  for (let i = 0; i < flow.steps.length; i++) {
+    const step = flow.steps[i]
+    const stepId = `step-${i}`
+    const nextId = i + 1 < flow.steps.length ? `step-${i + 1}` : 'end'
+
+    nodes.push({
+      id: stepId,
+      type: 'sagaStep',
+      position: { x: 0, y: 0 },
+      data: {
+        label: step.name,
+        serviceCalls: step.serviceCalls,
+      } satisfies StepNodeData,
+    })
+
+    edges.push({
+      id: `${prevId}-${stepId}`,
+      source: prevId,
+      target: stepId,
+    })
+
+    if (step.earlyExit) {
+      const decisionId = `decision-${i}`
+      const exitId = `exit-${i}`
+
+      nodes.push({
+        id: decisionId,
+        type: 'sagaDecision',
+        position: { x: 0, y: 0 },
+        data: { label: step.earlyExit.condition } satisfies DecisionNodeData,
+      })
+
+      nodes.push({
+        id: exitId,
+        type: 'sagaExit',
+        position: { x: 0, y: 0 },
+        data: { label: step.earlyExit.returnStatus } satisfies ExitNodeData,
+      })
+
+      edges.push({
+        id: `${stepId}-${decisionId}`,
+        source: stepId,
+        target: decisionId,
+      })
+
+      // "Yes" -> exit
+      edges.push({
+        id: `${decisionId}-${exitId}`,
+        source: decisionId,
+        sourceHandle: 'exit',
+        target: exitId,
+        label: 'Yes',
+        style: { stroke: '#ef4444', strokeDasharray: '6 3' },
+      })
+
+      // "No" -> next step
+      edges.push({
+        id: `${decisionId}-${nextId}`,
+        source: decisionId,
+        target: nextId,
+        label: 'No',
+      })
+
+      prevId = decisionId
+    } else {
+      prevId = stepId
+    }
+  }
+
+  // End node
+  nodes.push({
+    id: 'end',
+    type: 'sagaEnd',
+    position: { x: 0, y: 0 },
+    data: {},
+  })
+
+  // Connect last step to end (only if no early exit on last step)
+  const lastStep = flow.steps[flow.steps.length - 1]
+  if (!lastStep.earlyExit) {
+    edges.push({
+      id: `${prevId}-end`,
+      source: prevId,
+      target: 'end',
+    })
+  }
+
+  return { nodes: layoutNodes(nodes, edges), edges }
+}
+
+// --- Component ---
+
+interface SagaFlowDiagramProps {
+  flow: SagaFlow
+  onStepClick?: (stepName: string, lineNumber: number) => void
+  className?: string
+}
+
+export function SagaFlowDiagram({ flow, onStepClick, className }: SagaFlowDiagramProps) {
+  const { nodes, edges } = useMemo(() => buildFlowGraph(flow), [flow])
+
+  // Collect unique services for the legend
+  const services = useMemo(() => {
+    const set = new Set<string>()
+    for (const step of flow.steps) {
+      for (const call of step.serviceCalls) {
+        set.add(call.service)
+      }
+    }
+    return [...set].sort()
+  }, [flow])
+
+  return (
+    <div className={className} style={{ width: '100%', height: '100%', minHeight: 400 }}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        onNodeClick={(_event, node) => {
+          if (node.type === 'sagaStep' && onStepClick) {
+            const stepIndex = parseInt(node.id.replace('step-', ''), 10)
+            const step = flow.steps[stepIndex]
+            if (step) onStepClick(step.name, step.lineNumber)
+          }
+        }}
+        fitView
+        proOptions={{ hideAttribution: true }}
+        nodesDraggable={false}
+        nodesConnectable={false}
+      >
+        <Controls showInteractive={false} />
+        <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
+      </ReactFlow>
+
+      {services.length > 0 && (
+        <div className="absolute bottom-3 left-3 z-10 flex flex-col gap-1 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm">
+          <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">Services</span>
+          {services.map((svc) => (
+            <div key={svc} className="flex items-center gap-2">
+              <span
+                className="inline-block h-2.5 w-2.5 rounded-full"
+                style={{ backgroundColor: serviceColor(svc) }}
+              />
+              <span className="text-xs text-muted-foreground">{svc}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/cookbook/index.ts
+++ b/frontend/src/features/cookbook/index.ts
@@ -6,6 +6,8 @@ export type { CookbookItem, CookbookFile, CookbookRegistry, PatternMeta, Compone
 export { useCookbook } from './hooks/use-cookbook'
 export { usePatternFiles } from './hooks/use-pattern-files'
 export { ManifestViewer } from './components/manifest-viewer'
+export { SagaFlowDiagram } from './components/saga-flow'
+export { PreviewSourceTabs } from './components/preview-source-tabs'
 export { parseStarlarkSaga } from './lib/star-parser'
 export type { SagaFlow, SagaFlowStep, ServiceCall, EarlyExit } from './lib/star-parser'
 export { generateMermaidMarkup } from './lib/saga-mermaid'

--- a/frontend/src/features/cookbook/pages/detail.test.tsx
+++ b/frontend/src/features/cookbook/pages/detail.test.tsx
@@ -123,6 +123,7 @@ describe('CookbookDetailPage', () => {
     renderDetail('fiat-current-account')
     expect(screen.getByRole('tab', { name: 'Manifest' })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'Starlark' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Flow' })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'Composition' })).toBeInTheDocument()
   })
 

--- a/frontend/src/features/cookbook/pages/detail.tsx
+++ b/frontend/src/features/cookbook/pages/detail.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -5,6 +6,10 @@ import { Breadcrumbs } from '@/shared/breadcrumbs'
 import { DetailSkeleton } from '@/shared/detail-skeleton'
 import { StarlarkEditor } from '@/features/sagas/components/starlark-editor'
 import { ManifestViewer } from '../components/manifest-viewer'
+import { SagaFlowDiagram } from '../components/saga-flow'
+import { PreviewSourceTabs } from '../components/preview-source-tabs'
+import { parseStarlarkSaga } from '../lib/star-parser'
+import { generateMermaidMarkup } from '../lib/saga-mermaid'
 import { useCookbook } from '../hooks/use-cookbook'
 import type { CookbookItem, PatternMeta } from '../hooks/use-cookbook'
 import { usePatternFiles } from '../hooks/use-pattern-files'
@@ -163,6 +168,16 @@ export function CookbookDetailPage() {
   const isPattern = item.type === 'registry:pattern'
   const meta = item.meta as PatternMeta | undefined
 
+  const sagaFlow = useMemo(() => {
+    if (!starlarkContent) return null
+    return parseStarlarkSaga(starlarkContent)
+  }, [starlarkContent])
+
+  const mermaidMarkup = useMemo(() => {
+    if (!sagaFlow) return ''
+    return generateMermaidMarkup(sagaFlow)
+  }, [sagaFlow])
+
   return (
     <div className="space-y-6">
       <Breadcrumbs items={[{ label: 'Cookbook', href: '/cookbook' }, { label: item.title }]} />
@@ -174,6 +189,7 @@ export function CookbookDetailPage() {
           <TabsList>
             <TabsTrigger value="manifest">Manifest</TabsTrigger>
             <TabsTrigger value="starlark">Starlark</TabsTrigger>
+            <TabsTrigger value="flow">Flow</TabsTrigger>
             <TabsTrigger value="composition">Composition</TabsTrigger>
           </TabsList>
 
@@ -198,6 +214,24 @@ export function CookbookDetailPage() {
               />
             ) : (
               <p className="text-sm text-muted-foreground">No Starlark file found.</p>
+            )}
+          </TabsContent>
+
+          <TabsContent value="flow" className="mt-4">
+            {isLoading ? (
+              <div className="h-[400px] animate-pulse rounded border bg-muted" />
+            ) : sagaFlow && sagaFlow.steps.length > 0 ? (
+              <PreviewSourceTabs
+                preview={
+                  <div className="h-[500px] rounded-lg border">
+                    <SagaFlowDiagram flow={sagaFlow} />
+                  </div>
+                }
+                source={mermaidMarkup}
+                sourceLabel="Mermaid"
+              />
+            ) : (
+              <p className="text-sm text-muted-foreground">No saga flow detected in Starlark source.</p>
             )}
           </TabsContent>
 

--- a/frontend/src/features/cookbook/pages/detail.tsx
+++ b/frontend/src/features/cookbook/pages/detail.tsx
@@ -150,6 +150,16 @@ export function CookbookDetailPage() {
   const item = items.find((i) => i.name === name)
   const isLoading = catalogueLoading || filesLoading
 
+  const sagaFlow = useMemo(() => {
+    if (!starlarkContent) return null
+    return parseStarlarkSaga(starlarkContent)
+  }, [starlarkContent])
+
+  const mermaidMarkup = useMemo(() => {
+    if (!sagaFlow) return ''
+    return generateMermaidMarkup(sagaFlow)
+  }, [sagaFlow])
+
   if (catalogueLoading) {
     return <DetailSkeleton fieldCount={3} tabCount={3} showBackNav />
   }
@@ -167,16 +177,6 @@ export function CookbookDetailPage() {
 
   const isPattern = item.type === 'registry:pattern'
   const meta = item.meta as PatternMeta | undefined
-
-  const sagaFlow = useMemo(() => {
-    if (!starlarkContent) return null
-    return parseStarlarkSaga(starlarkContent)
-  }, [starlarkContent])
-
-  const mermaidMarkup = useMemo(() => {
-    if (!sagaFlow) return ''
-    return generateMermaidMarkup(sagaFlow)
-  }, [sagaFlow])
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary

- Add interactive saga flow diagram to the cookbook pattern detail page using @xyflow/react and @dagrejs/dagre
- Create `SagaFlowDiagram` component with custom node types: start (saga name/trigger), step (with service call badges), decision (diamond for early exits), exit (return status), and end
- Create reusable `PreviewSourceTabs` component that toggles between visual preview and Mermaid source with copy-to-clipboard
- Integrate as "Flow" tab in pattern detail page, parsing Starlark content via the existing `parseStarlarkSaga()` parser

## Changes Made

| File | Change |
|------|--------|
| `components/saga-flow.tsx` | New component: dagre-laid-out vertical flowchart with service-colored badges |
| `components/preview-source-tabs.tsx` | New component: Preview/Source tab switcher with clipboard copy |
| `pages/detail.tsx` | Add Flow tab between Starlark and Composition tabs |
| `pages/detail.test.tsx` | Update tab assertion to include Flow |
| `index.ts` | Export new components |
| `package.json` | Add `@dagrejs/dagre` dependency |

## Test plan

- [x] All 83 existing cookbook tests pass
- [x] Zero TypeScript errors in cookbook feature files
- [x] Flow tab renders for pattern-type entries with Starlark content
- [x] Graceful fallback message when no saga flow detected
- [ ] Visual verification of node layout and service badge colors