### PR TITLE
feat: cookbook performance optimization and comprehensive tests

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
+import { type ReactNode, lazy, Suspense, useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
 import { BrowserRouter, Routes, Route, useLocation, useNavigate } from 'react-router-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
@@ -30,7 +30,14 @@ import { DashboardPage } from '@/features/dashboard'
 import { ManifestsPage } from '@/features/manifests'
 import { McpConfigPage } from '@/features/mcp-config'
 import { TransactionsPage } from '@/features/transactions'
-import { CookbookPage, CookbookDetailPage, CookbookGraphPage } from '@/features/cookbook'
+import { CookbookPage } from '@/features/cookbook'
+
+const CookbookDetailPage = lazy(() =>
+  import('@/features/cookbook/pages/detail').then((m) => ({ default: m.CookbookDetailPage })),
+)
+const CookbookGraphPage = lazy(() =>
+  import('@/features/cookbook/pages/graph').then((m) => ({ default: m.CookbookGraphPage })),
+)
 import { ThemePreviewPanel } from '@/components/dev/theme-preview-panel'
 
 // Placeholder page components - replaced as each page task is implemented
@@ -258,8 +265,8 @@ function AppShellLayout() {
         <Route path="/manifests" element={<FeatureGuard feature="manifests">{guarded(<ManifestsPage />)}</FeatureGuard>} />
         <Route path="/mcp-config" element={<FeatureGuard feature="mcp-config">{guarded(<McpConfigPage />)}</FeatureGuard>} />
         <Route path="/cookbook" element={guarded(<CookbookPage />)} />
-        <Route path="/cookbook/graph" element={guarded(<CookbookGraphPage />)} />
-        <Route path="/cookbook/:name" element={guarded(<CookbookDetailPage />)} />
+        <Route path="/cookbook/graph" element={guarded(<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}><CookbookGraphPage /></Suspense>)} />
+        <Route path="/cookbook/:name" element={guarded(<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}><CookbookDetailPage /></Suspense>)} />
         <Route path="/audit-log" element={<FeatureGuard feature="audit">{guarded(<AuditLogPage />)}</FeatureGuard>} />
 
         {/* Platform-only routes */}

--- a/frontend/src/features/cookbook/components/component-detail.test.tsx
+++ b/frontend/src/features/cookbook/components/component-detail.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ComponentDetail } from './component-detail'
+import type { CookbookItem, ComponentMeta } from '../hooks/use-cookbook'
+
+vi.mock('@/api/transport', () => ({
+  createTenantTransport: vi.fn(() => ({ __type: 'mock-transport' })),
+}))
+
+vi.mock('@/api/clients', () => ({
+  createServiceClients: vi.fn(() => ({})),
+}))
+
+function renderDetail(item: CookbookItem) {
+  return render(
+    <MemoryRouter>
+      <ComponentDetail item={item} />
+    </MemoryRouter>,
+  )
+}
+
+const fullItem: CookbookItem = {
+  name: 'balance-card',
+  type: 'registry:ui',
+  title: 'Balance Card',
+  description: 'Displays account balance',
+  registryDependencies: ['currency-formatter', 'icon-set'],
+  categories: ['accounts'],
+  files: [
+    { path: 'components/balance-card.tsx', type: 'registry:ui' },
+    { path: 'components/balance-card.css' },
+  ],
+  meta: {
+    feature_module: 'accounts',
+    tenant_configurable: true,
+    configurable_props: ['showCurrency', 'decimals'],
+    used_by: ['dashboard', 'account-detail'],
+  } satisfies ComponentMeta,
+}
+
+const bareItem: CookbookItem = {
+  name: 'simple-widget',
+  type: 'registry:ui',
+  title: 'Simple Widget',
+}
+
+describe('ComponentDetail', () => {
+  it('renders configurable props table', () => {
+    renderDetail(fullItem)
+    expect(screen.getByText('Configurable Props')).toBeInTheDocument()
+    expect(screen.getByText('showCurrency')).toBeInTheDocument()
+    expect(screen.getByText('decimals')).toBeInTheDocument()
+  })
+
+  it('renders usage context with feature module', () => {
+    renderDetail(fullItem)
+    expect(screen.getByText('Usage Context')).toBeInTheDocument()
+    expect(screen.getByText('accounts')).toBeInTheDocument()
+  })
+
+  it('renders tenant configurable badge', () => {
+    renderDetail(fullItem)
+    expect(screen.getByText('Yes')).toBeInTheDocument()
+  })
+
+  it('renders used_by badges', () => {
+    renderDetail(fullItem)
+    expect(screen.getByText('dashboard')).toBeInTheDocument()
+    expect(screen.getByText('account-detail')).toBeInTheDocument()
+  })
+
+  it('renders registry dependencies as links', () => {
+    renderDetail(fullItem)
+    expect(screen.getByText('Registry Dependencies')).toBeInTheDocument()
+    expect(screen.getByText('currency-formatter')).toBeInTheDocument()
+    expect(screen.getByText('icon-set')).toBeInTheDocument()
+
+    const link = screen.getByText('currency-formatter').closest('a')
+    expect(link).toHaveAttribute('href', '/cookbook/currency-formatter')
+  })
+
+  it('shows no dependencies message when none exist', () => {
+    renderDetail(bareItem)
+    expect(screen.getByText('No registry dependencies.')).toBeInTheDocument()
+  })
+
+  it('renders source files list', () => {
+    renderDetail(fullItem)
+    expect(screen.getByText('Source Files')).toBeInTheDocument()
+    expect(screen.getByText('components/balance-card.tsx')).toBeInTheDocument()
+    expect(screen.getByText('components/balance-card.css')).toBeInTheDocument()
+  })
+
+  it('renders live preview placeholder', () => {
+    renderDetail(fullItem)
+    expect(screen.getByText('Preview not available')).toBeInTheDocument()
+  })
+
+  it('hides props table when no configurable_props', () => {
+    renderDetail(bareItem)
+    expect(screen.queryByText('Configurable Props')).not.toBeInTheDocument()
+  })
+
+  it('hides usage context when no meta', () => {
+    renderDetail(bareItem)
+    expect(screen.queryByText('Usage Context')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/cookbook/components/composition-graph.test.tsx
+++ b/frontend/src/features/cookbook/components/composition-graph.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useState } from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { CompositionGraph } from './composition-graph'
+import type { CookbookItem, PatternMeta } from '../hooks/use-cookbook'
+
+vi.mock('@/api/transport', () => ({
+  createTenantTransport: vi.fn(() => ({ __type: 'mock-transport' })),
+}))
+
+vi.mock('@/api/clients', () => ({
+  createServiceClients: vi.fn(() => ({})),
+}))
+
+// Mock @xyflow/react
+vi.mock('@xyflow/react', () => {
+  const Position = { Top: 'top', Bottom: 'bottom', Left: 'left', Right: 'right' }
+  const BackgroundVariant = { Dots: 'dots' }
+
+  function Handle() { return null }
+
+  function ReactFlow({ nodes, edges, children }: { nodes: unknown[]; edges: unknown[]; children?: React.ReactNode }) {
+    return (
+      <div data-testid="react-flow" data-node-count={nodes.length} data-edge-count={edges.length}>
+        {(nodes as { id: string; data: { label?: string } }[]).map((n) => (
+          <div key={n.id} data-testid={`node-${n.id}`}>
+            {n.data?.label ?? n.id}
+          </div>
+        ))}
+        {children}
+      </div>
+    )
+  }
+
+  function Controls() { return <div data-testid="controls" /> }
+  function Background() { return null }
+  function MiniMap() { return <div data-testid="minimap" /> }
+
+  return {
+    ReactFlow,
+    Controls,
+    Background,
+    MiniMap,
+    Handle,
+    Position,
+    BackgroundVariant,
+    useNodesState: (init: unknown[]) => {
+      const [s, setS] = useState(init)
+      return [s, setS, vi.fn()]
+    },
+    useEdgesState: (init: unknown[]) => {
+      const [s, setS] = useState(init)
+      return [s, setS, vi.fn()]
+    },
+  }
+})
+
+// Mock ELK for layout
+vi.mock('elkjs/lib/elk.bundled.js', () => ({
+  default: class MockELK {
+    async layout(graph: { children: { id: string }[] }) {
+      return {
+        children: graph.children.map((child, i) => ({
+          id: child.id,
+          x: i * 100,
+          y: i * 100,
+        })),
+      }
+    }
+  },
+}))
+
+const patterns: CookbookItem[] = [
+  {
+    name: 'energy-trading',
+    type: 'registry:pattern',
+    title: 'Energy Trading',
+    categories: ['energy'],
+    registryDependencies: ['fiat-settlement'],
+    meta: {
+      complexity: 7,
+      composes_with: ['carbon-offset'],
+      extends: [],
+      conflicts_with: [],
+    } satisfies PatternMeta,
+  },
+  {
+    name: 'fiat-settlement',
+    type: 'registry:pattern',
+    title: 'Fiat Settlement',
+    categories: ['foundation'],
+    meta: {
+      complexity: 3,
+    } satisfies PatternMeta,
+  },
+  {
+    name: 'carbon-offset',
+    type: 'registry:pattern',
+    title: 'Carbon Offset',
+    categories: ['carbon'],
+    meta: {
+      complexity: 5,
+      composes_with: ['energy-trading'],
+    } satisfies PatternMeta,
+  },
+]
+
+const mixedItems: CookbookItem[] = [
+  ...patterns,
+  {
+    name: 'balance-card',
+    type: 'registry:ui',
+    title: 'Balance Card',
+  },
+]
+
+function renderGraph(items: CookbookItem[]) {
+  return render(
+    <MemoryRouter>
+      <CompositionGraph patterns={items} className="h-96" />
+    </MemoryRouter>,
+  )
+}
+
+describe('CompositionGraph', () => {
+  it('renders ReactFlow container', () => {
+    renderGraph(patterns)
+    expect(screen.getByTestId('react-flow')).toBeInTheDocument()
+  })
+
+  it('renders controls and minimap', () => {
+    renderGraph(patterns)
+    expect(screen.getByTestId('controls')).toBeInTheDocument()
+    expect(screen.getByTestId('minimap')).toBeInTheDocument()
+  })
+
+  it('renders filter sidebar', () => {
+    renderGraph(patterns)
+    expect(screen.getByLabelText('Filter by category')).toBeInTheDocument()
+    expect(screen.getByLabelText('Filter by industry')).toBeInTheDocument()
+  })
+
+  it('renders edge legend', () => {
+    renderGraph(patterns)
+    expect(screen.getByText('Dependency')).toBeInTheDocument()
+    expect(screen.getByText('Composes with')).toBeInTheDocument()
+    expect(screen.getByText('Extends')).toBeInTheDocument()
+    expect(screen.getByText('Conflicts')).toBeInTheDocument()
+  })
+
+  it('filters out UI components (only patterns)', () => {
+    renderGraph(mixedItems)
+    expect(screen.getByText('3 patterns')).toBeInTheDocument()
+  })
+
+  it('shows category filter options', () => {
+    renderGraph(patterns)
+    const select = screen.getByLabelText('Filter by category')
+    expect(select).toBeInTheDocument()
+    const options = select.querySelectorAll('option')
+    expect(options.length).toBe(4) // All + 3 categories
+  })
+
+  it('renders with empty patterns', () => {
+    renderGraph([])
+    expect(screen.getByTestId('react-flow')).toBeInTheDocument()
+    expect(screen.getByText('0 patterns')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/cookbook/components/preview-source-tabs.test.tsx
+++ b/frontend/src/features/cookbook/components/preview-source-tabs.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PreviewSourceTabs } from './preview-source-tabs'
+
+describe('PreviewSourceTabs', () => {
+  it('renders preview tab by default', () => {
+    render(
+      <PreviewSourceTabs
+        preview={<div data-testid="preview-content">Hello</div>}
+        source="const x = 1"
+      />,
+    )
+    expect(screen.getByTestId('preview-content')).toBeInTheDocument()
+  })
+
+  it('renders both tab triggers', () => {
+    render(
+      <PreviewSourceTabs
+        preview={<div>Preview</div>}
+        source="code"
+      />,
+    )
+    expect(screen.getByRole('tab', { name: 'Preview' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Source' })).toBeInTheDocument()
+  })
+
+  it('uses custom sourceLabel', () => {
+    render(
+      <PreviewSourceTabs
+        preview={<div>Preview</div>}
+        source="code"
+        sourceLabel="Mermaid"
+      />,
+    )
+    expect(screen.getByRole('tab', { name: 'Mermaid' })).toBeInTheDocument()
+  })
+
+  it('switches to source tab and shows code', async () => {
+    const user = userEvent.setup()
+    render(
+      <PreviewSourceTabs
+        preview={<div>Preview Content</div>}
+        source="const hello = 'world'"
+      />,
+    )
+
+    await user.click(screen.getByRole('tab', { name: 'Source' }))
+    expect(screen.getByText("const hello = 'world'")).toBeInTheDocument()
+  })
+
+  it('shows copy button on source tab', async () => {
+    const user = userEvent.setup()
+    render(
+      <PreviewSourceTabs
+        preview={<div>Preview</div>}
+        source="copy me"
+      />,
+    )
+
+    await user.click(screen.getByRole('tab', { name: 'Source' }))
+    expect(screen.getByText('Copy')).toBeInTheDocument()
+  })
+
+  it('shows Copied state after clicking copy button', async () => {
+    // Set up clipboard mock before render
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true,
+    })
+
+    const user = userEvent.setup()
+    render(
+      <PreviewSourceTabs
+        preview={<div>Preview</div>}
+        source="data"
+      />,
+    )
+
+    await user.click(screen.getByRole('tab', { name: 'Source' }))
+    expect(await screen.findByText('data')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Copy'))
+
+    expect(await screen.findByText('Copied')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/cookbook/components/saga-flow.test.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.test.tsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SagaFlowDiagram } from './saga-flow'
+import type { SagaFlow } from '../lib/star-parser'
+
+// Mock @xyflow/react to avoid canvas rendering issues in jsdom
+vi.mock('@xyflow/react', () => {
+  const Position = { Top: 'top', Bottom: 'bottom', Left: 'left', Right: 'right' }
+  const BackgroundVariant = { Dots: 'dots' }
+
+  function Handle() { return null }
+
+  function ReactFlow({ nodes, edges, children }: { nodes: unknown[]; edges: unknown[]; children?: React.ReactNode }) {
+    return (
+      <div data-testid="react-flow" data-node-count={nodes.length} data-edge-count={edges.length}>
+        {(nodes as { id: string; data: { label?: string } }[]).map((n) => (
+          <div key={n.id} data-testid={`node-${n.id}`}>
+            {n.data?.label ?? n.id}
+          </div>
+        ))}
+        {children}
+      </div>
+    )
+  }
+
+  function Controls() { return <div data-testid="controls" /> }
+  function Background() { return null }
+
+  return { ReactFlow, Controls, Background, Handle, Position, BackgroundVariant }
+})
+
+// Mock dagre for layout
+vi.mock('@dagrejs/dagre', () => {
+  const graphlib = {
+    Graph: class {
+      nodes: Record<string, { x: number; y: number; width: number; height: number }> = {}
+      setDefaultEdgeLabel() { return this }
+      setGraph() {}
+      setNode(id: string, data: { width: number; height: number }) {
+        this.nodes[id] = { x: 0, y: 0, ...data }
+      }
+      setEdge() {}
+      node(id: string) { return this.nodes[id] ?? { x: 0, y: 0 } }
+    },
+  }
+
+  return {
+    default: {
+      graphlib,
+      layout(g: InstanceType<typeof graphlib.Graph>) {
+        // Assign sequential y positions
+        let y = 0
+        for (const [, data] of Object.entries(g.nodes)) {
+          data.x = 100
+          data.y = y
+          y += 100
+        }
+      },
+    },
+  }
+})
+
+const emptyFlow: SagaFlow = {
+  name: 'empty_saga',
+  trigger: null,
+  filter: null,
+  steps: [],
+}
+
+const simpleFlow: SagaFlow = {
+  name: 'deposit',
+  trigger: 'event:payments.received.v1',
+  filter: null,
+  steps: [
+    {
+      name: 'lookup_account',
+      lineNumber: 5,
+      serviceCalls: [{ service: 'reference_data', method: 'get_account', params: ['id'] }],
+      earlyExit: null,
+    },
+    {
+      name: 'book_position',
+      lineNumber: 10,
+      serviceCalls: [{ service: 'position_keeping', method: 'initiate_log', params: ['account_id', 'amount'] }],
+      earlyExit: null,
+    },
+  ],
+}
+
+const flowWithEarlyExit: SagaFlow = {
+  name: 'idempotent_saga',
+  trigger: null,
+  filter: null,
+  steps: [
+    {
+      name: 'check_duplicate',
+      lineNumber: 3,
+      serviceCalls: [{ service: 'pk', method: 'query_logs', params: ['cid'] }],
+      earlyExit: { condition: 'existing.count > 0', returnStatus: 'ALREADY_PROCESSED' },
+    },
+    {
+      name: 'book',
+      lineNumber: 8,
+      serviceCalls: [{ service: 'pk', method: 'initiate_log', params: ['aid'] }],
+      earlyExit: null,
+    },
+  ],
+}
+
+describe('SagaFlowDiagram', () => {
+  it('renders ReactFlow container', () => {
+    render(<SagaFlowDiagram flow={emptyFlow} />)
+    expect(screen.getByTestId('react-flow')).toBeInTheDocument()
+  })
+
+  it('renders start and end nodes for empty flow', () => {
+    render(<SagaFlowDiagram flow={emptyFlow} />)
+    expect(screen.getByTestId('node-start')).toBeInTheDocument()
+    expect(screen.getByTestId('node-end')).toBeInTheDocument()
+  })
+
+  it('renders step nodes for each step', () => {
+    render(<SagaFlowDiagram flow={simpleFlow} />)
+    expect(screen.getByTestId('node-step-0')).toBeInTheDocument()
+    expect(screen.getByTestId('node-step-1')).toBeInTheDocument()
+  })
+
+  it('displays step names', () => {
+    render(<SagaFlowDiagram flow={simpleFlow} />)
+    expect(screen.getByText('lookup_account')).toBeInTheDocument()
+    expect(screen.getByText('book_position')).toBeInTheDocument()
+  })
+
+  it('displays saga name in start node', () => {
+    render(<SagaFlowDiagram flow={simpleFlow} />)
+    expect(screen.getByText('deposit')).toBeInTheDocument()
+  })
+
+  it('renders decision and exit nodes for early exit', () => {
+    render(<SagaFlowDiagram flow={flowWithEarlyExit} />)
+    expect(screen.getByTestId('node-decision-0')).toBeInTheDocument()
+    expect(screen.getByTestId('node-exit-0')).toBeInTheDocument()
+  })
+
+  it('renders controls', () => {
+    render(<SagaFlowDiagram flow={simpleFlow} />)
+    expect(screen.getByTestId('controls')).toBeInTheDocument()
+  })
+
+  it('renders services legend', () => {
+    render(<SagaFlowDiagram flow={simpleFlow} />)
+    expect(screen.getByText('reference_data')).toBeInTheDocument()
+    expect(screen.getByText('position_keeping')).toBeInTheDocument()
+  })
+
+  it('shows correct node count', () => {
+    render(<SagaFlowDiagram flow={simpleFlow} />)
+    // start + 2 steps + end = 4 nodes
+    expect(screen.getByTestId('react-flow')).toHaveAttribute('data-node-count', '4')
+  })
+
+  it('shows correct edge count for simple flow', () => {
+    render(<SagaFlowDiagram flow={simpleFlow} />)
+    // start->step0, step0->step1, step1->end = 3 edges
+    expect(screen.getByTestId('react-flow')).toHaveAttribute('data-edge-count', '3')
+  })
+})

--- a/frontend/src/features/cookbook/hooks/use-cookbook.test.ts
+++ b/frontend/src/features/cookbook/hooks/use-cookbook.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useCookbook } from './use-cookbook'
+
+vi.mock('virtual:cookbook-data', () => ({
+  default: {
+    name: 'meridian-cookbook',
+    items: [
+      {
+        name: 'energy-trading',
+        type: 'registry:pattern',
+        title: 'Energy Trading',
+        description: 'Buy and sell electricity',
+        categories: ['energy'],
+        meta: { complexity: 7 },
+      },
+      {
+        name: 'balance-card',
+        type: 'registry:ui',
+        title: 'Balance Card',
+      },
+    ],
+  },
+}))
+
+describe('useCookbook', () => {
+  it('returns items from virtual cookbook data', () => {
+    const { result } = renderHook(() => useCookbook())
+    expect(result.current.items).toHaveLength(2)
+    expect(result.current.items[0].name).toBe('energy-trading')
+    expect(result.current.items[1].name).toBe('balance-card')
+  })
+
+  it('returns isLoading as false (static data)', () => {
+    const { result } = renderHook(() => useCookbook())
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('includes correct types for items', () => {
+    const { result } = renderHook(() => useCookbook())
+    expect(result.current.items[0].type).toBe('registry:pattern')
+    expect(result.current.items[1].type).toBe('registry:ui')
+  })
+})

--- a/frontend/src/features/cookbook/hooks/use-filter-state.test.tsx
+++ b/frontend/src/features/cookbook/hooks/use-filter-state.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { useFilterState } from './use-filter-state'
+
+vi.mock('@/api/transport', () => ({
+  createTenantTransport: vi.fn(() => ({ __type: 'mock-transport' })),
+}))
+
+vi.mock('@/api/clients', () => ({
+  createServiceClients: vi.fn(() => ({})),
+}))
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>
+}
+
+function wrapperWithParams(search: string) {
+  return ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[`/?${search}`]}>{children}</MemoryRouter>
+  )
+}
+
+describe('useFilterState', () => {
+  it('returns empty filters by default', () => {
+    const { result } = renderHook(() => useFilterState(), { wrapper })
+    const [state] = result.current
+    expect(state.search).toBe('')
+    expect(state.type).toBe('')
+    expect(state.category).toBe('')
+    expect(state.industry).toBe('')
+  })
+
+  it('reads initial state from URL search params', () => {
+    const { result } = renderHook(() => useFilterState(), {
+      wrapper: wrapperWithParams('search=energy&type=pattern'),
+    })
+    const [state] = result.current
+    expect(state.search).toBe('energy')
+    expect(state.type).toBe('pattern')
+    expect(state.category).toBe('')
+    expect(state.industry).toBe('')
+  })
+
+  it('updates filters via the setter function', () => {
+    const { result } = renderHook(() => useFilterState(), { wrapper })
+
+    act(() => {
+      const [, update] = result.current
+      update({ search: 'test', type: 'ui' })
+    })
+
+    const [state] = result.current
+    expect(state.search).toBe('test')
+    expect(state.type).toBe('ui')
+  })
+
+  it('removes empty values from URL params', () => {
+    const { result } = renderHook(() => useFilterState(), {
+      wrapper: wrapperWithParams('search=hello&type=pattern'),
+    })
+
+    act(() => {
+      const [, update] = result.current
+      update({ search: '' })
+    })
+
+    const [state] = result.current
+    expect(state.search).toBe('')
+    expect(state.type).toBe('pattern')
+  })
+
+  it('supports partial updates', () => {
+    const { result } = renderHook(() => useFilterState(), { wrapper })
+
+    act(() => {
+      result.current[1]({ category: 'energy' })
+    })
+
+    act(() => {
+      result.current[1]({ industry: 'utilities' })
+    })
+
+    const [state] = result.current
+    expect(state.category).toBe('energy')
+    expect(state.industry).toBe('utilities')
+  })
+
+  it('clears all filters at once', () => {
+    const { result } = renderHook(() => useFilterState(), {
+      wrapper: wrapperWithParams('search=x&type=pattern&category=energy&industry=fin'),
+    })
+
+    act(() => {
+      result.current[1]({ search: '', type: '', category: '', industry: '' })
+    })
+
+    const [state] = result.current
+    expect(state.search).toBe('')
+    expect(state.type).toBe('')
+    expect(state.category).toBe('')
+    expect(state.industry).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

- Lazy load `CookbookDetailPage` and `CookbookGraphPage` via `React.lazy()` with Suspense fallbacks to reduce initial bundle size. These pages pull in heavy dependencies (@xyflow/react, elkjs, dagre, CodeMirror) that are now loaded on demand.
- Add 42 new tests covering previously untested cookbook components and hooks, bringing total cookbook test count from 83 to 125.

## Changes Made

**Performance:**
- `App.tsx`: Convert `CookbookDetailPage` and `CookbookGraphPage` from static imports to `React.lazy()` dynamic imports with Suspense boundaries

**Tests added:**
- `ComponentDetail`: configurable props, usage context, dependencies, source files, empty states (10 tests)
- `CompositionGraph`: ReactFlow rendering, filter sidebar, legend, category options, UI component filtering (7 tests)
- `SagaFlowDiagram`: node rendering, step names, early exits, decision nodes, services legend, edge/node counts (10 tests)
- `PreviewSourceTabs`: tab switching, custom labels, copy button, clipboard state (6 tests)
- `useCookbook`: virtual data loading, isLoading state, type correctness (3 tests)
- `useFilterState`: URL sync, partial updates, param removal, clear all (6 tests)

## Testing

```bash
cd frontend && npx vitest run src/features/cookbook/
# 13 test files, 125 tests passing
# 0 lint errors
```

## Task Master

Task: 036-cookbook-browser.12 - Performance Optimization and Tests