### PR TITLE
fix: order platform saga query by version for deterministic migration

### DIFF
--- a/services/reference-data/saga/override_api.go
+++ b/services/reference-data/saga/override_api.go
@@ -412,7 +412,7 @@ func (s *OverrideService) loadPlatformSagas(ctx context.Context) (map[string]Pla
 	rows, err := s.pool.Query(ctx, `
 		SELECT id, name, version, script, display_name, description
 		FROM public.platform_saga_definition
-		ORDER BY name`)
+		ORDER BY name, version`)
 	if err != nil {
 		return nil, fmt.Errorf("query platform sagas: %w", err)
 	}

--- a/services/reference-data/saga/override_api.go
+++ b/services/reference-data/saga/override_api.go
@@ -412,7 +412,10 @@ func (s *OverrideService) loadPlatformSagas(ctx context.Context) (map[string]Pla
 	rows, err := s.pool.Query(ctx, `
 		SELECT id, name, version, script, display_name, description
 		FROM public.platform_saga_definition
-		ORDER BY name, version`)
+		ORDER BY name,
+			(string_to_array(version, '.'))[1]::INT,
+			(string_to_array(version, '.'))[2]::INT,
+			(string_to_array(version, '.'))[3]::INT`)
 	if err != nil {
 		return nil, fmt.Errorf("query platform sagas: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Fixes nightly CI failures in `TestOverrideService_MigrateToPlatformRef` and `TestE2E_ProvisioningOverrideMigration` (failing since 2026-03-05)

## Root Cause

`loadPlatformSagas` in `override_api.go` queries `platform_saga_definition` with `ORDER BY name` only. When multiple versions of the same saga exist (e.g., `stripe_payment` has v1.0.0, v2.0.0, v3.0.0), the results are stored in a map keyed by name — the last row scanned wins. Without deterministic version ordering, CockroachDB could return v1 as the last row instead of v3, causing the similarity check against the tenant's v3 script to fail (69% similar vs 95% threshold).

## Fix

Add `version` to the ORDER BY clause so the highest version always overwrites earlier ones in the map, ensuring the migration comparison uses the latest platform script.

## Test Plan

- [x] `TestOverrideService_MigrateToPlatformRef` (3 subtests) — all passing
- [x] `TestE2E_ProvisioningOverrideMigration` — passing
- [x] All stripe_payment sagas now show `similarity=1` (100% match)