### PR TITLE
fix: Replace 501 fallback with 503 in API gateway handleAPI

### DIFF
--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -975,7 +975,7 @@ func wireGateway(grpcPort, httpPort int, databaseURL string, tenantDB *gorm.DB, 
 	var opts []gateway.ServerOption
 	transcoder, err := gateway.NewTranscoder(GetProtoDescriptors(), backends)
 	if err != nil {
-		logger.Warn("failed to build Vanguard transcoder; API routes will return 501",
+		logger.Warn("failed to build Vanguard transcoder; API routes will return 503",
 			"error", err)
 	} else {
 		opts = append(opts, gateway.WithTranscoder(transcoder))

--- a/services/api-gateway/server.go
+++ b/services/api-gateway/server.go
@@ -148,7 +148,7 @@ func (s *Server) registerRoutes() {
 	// API routes - with auth and tenant middleware chain.
 	// Prefer the Vanguard transcoder when configured; fall back to the legacy
 	// prefix-based reverse proxy when Backends are provided; otherwise use a
-	// placeholder that returns 501 Not Implemented.
+	// fallback that returns 503 Service Unavailable (misconfiguration/degraded).
 	//
 	// For the transcoder path, metadataPropagationMiddleware wraps the handler to
 	// strip spoofed incoming identity headers and inject authenticated identity
@@ -352,18 +352,18 @@ func (s *Server) logHealthCheckResult(ctx context.Context, report *health.Report
 	}
 }
 
-// handleAPI is a placeholder handler for API routes.
-// This will be replaced with actual routing logic in future tasks.
+// handleAPI is the fallback handler for API routes when neither the Vanguard
+// transcoder nor a legacy proxy backend is configured. This indicates a
+// misconfiguration or degraded state (e.g. transcoder build failure).
 func (s *Server) handleAPI(w http.ResponseWriter, r *http.Request) {
-	s.logger.Debug("received API request",
+	s.logger.Warn("API request reached fallback handler: no transcoder or proxy backend configured",
 		"method", r.Method,
 		"path", r.URL.Path,
 		"host", r.Host)
 
-	// Placeholder response - actual routing will be implemented in future tasks
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(http.StatusNotImplemented)
-	if _, err := w.Write([]byte(`{"error":"gateway routing not yet implemented"}`)); err != nil {
+	w.WriteHeader(http.StatusServiceUnavailable)
+	if _, err := w.Write([]byte(`{"error":"no API backend configured","detail":"neither Vanguard transcoder nor proxy backends are available; check gateway startup logs"}`)); err != nil {
 		s.logger.Warn("failed to write API response",
 			"error", err,
 			"endpoint", r.URL.Path,

--- a/services/api-gateway/server_integration_test.go
+++ b/services/api-gateway/server_integration_test.go
@@ -198,17 +198,17 @@ func TestIntegration_APIRoutes_RequiresTenantContext(t *testing.T) {
 		})
 	require.NoError(t, err)
 
-	// Test API route returns placeholder response
-	t.Run("GET /v1/test returns 501 Not Implemented", func(t *testing.T) {
+	// Test API route returns 503 when no backend is configured
+	t.Run("GET /v1/test returns 503 Service Unavailable", func(t *testing.T) {
 		resp, err := httpGet(ctx, baseURL+"/v1/test")
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
-		assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 
 		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
-		assert.Contains(t, string(body), "gateway routing not yet implemented")
+		assert.Contains(t, string(body), "no API backend configured")
 	})
 
 	// Cleanup

--- a/services/api-gateway/server_test.go
+++ b/services/api-gateway/server_test.go
@@ -207,9 +207,9 @@ func TestAPIRoutes_WithoutTenantResolver(t *testing.T) {
 
 	server.mux.ServeHTTP(rec, req)
 
-	// Should return 501 Not Implemented (placeholder response)
-	assert.Equal(t, http.StatusNotImplemented, rec.Code)
-	assert.Contains(t, rec.Body.String(), "gateway routing not yet implemented")
+	// Should return 503 Service Unavailable (no backend configured)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Contains(t, rec.Body.String(), "no API backend configured")
 }
 
 // TestWithTranscoder_UsedOverProxy verifies that when WithTranscoder is set,
@@ -262,8 +262,8 @@ func TestWithTranscoder_FallsBackToProxy(t *testing.T) {
 
 	server.mux.ServeHTTP(rec, req)
 
-	// Should return 501 Not Implemented from the placeholder handler
-	assert.Equal(t, http.StatusNotImplemented, rec.Code)
+	// Should return 503 Service Unavailable from the fallback handler
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }
 
 // TestWithTranscoder_StripsAndInjectsIdentityHeaders verifies that the
@@ -808,8 +808,8 @@ func TestWithEventStreamHandler_NotRegisteredWhenNil(t *testing.T) {
 
 	// Without an event stream handler, the route is not registered.
 	// The request falls through to the "/" catch-all API handler which
-	// returns 501 when no transcoder or proxy is configured.
-	assert.Equal(t, http.StatusNotImplemented, rec.Code)
+	// returns 503 when no transcoder or proxy is configured.
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }
 
 // TestWithEventStreamHandler_HealthEndpointsUnaffected verifies that adding the


### PR DESCRIPTION
## Summary

- Replace 501 Not Implemented with 503 Service Unavailable in the API gateway fallback handler (`handleAPI`)
- The fallback is reachable when neither the Vanguard transcoder nor legacy proxy backends are configured, indicating a misconfiguration or degraded state rather than an unimplemented feature
- Add actionable error detail in the JSON response pointing operators to gateway startup logs
- Upgrade log level from Debug to Warn so fallback hits are visible in production monitoring

## Changes Made

| File | Change |
|------|--------|
| `services/api-gateway/server.go` | `handleAPI`: 501 to 503, Debug to Warn log, actionable error message, updated comments |
| `cmd/meridian/main.go` | Updated warning message from "501" to "503" when transcoder build fails |
| `services/api-gateway/server_test.go` | Updated 3 test assertions for new status code and error message |
| `services/api-gateway/server_integration_test.go` | Updated integration test for new status code and error message |

## Reachability Analysis

The fallback handler is reached via the `switch` in `registerRoutes` (server.go:160-167):
1. `transcoderHandler != nil` — uses Vanguard transcoder (normal production path)
2. `len(config.Backends) > 0` — uses legacy proxy (backwards compat)
3. **default** — fallback handler (this PR)

In the unified binary (`cmd/meridian/main.go:976-982`), the transcoder is always attempted. The fallback is only reachable if `NewTranscoder` fails (descriptor mismatch, proto staleness). In the standalone gateway binary, it's reachable when no backends are configured.

Both cases represent degraded/misconfigured state, making 503 semantically correct over 501.

## Test Plan

- [x] `TestAPIRoutes_WithoutTenantResolver` — verifies 503 + error message
- [x] `TestWithTranscoder_FallsBackToProxy` — verifies 503 when no transcoder or backends
- [x] `TestWithEventStreamHandler_NotRegisteredWhenNil` — verifies catch-all returns 503
- [x] Full gateway test suite passes (46+ tests)

## Task Master

codebase-debt-audit.10