### PR TITLE
fix: Remove dead Jumio verification provider stub

### DIFF
--- a/services/party/adapters/http/verification_webhook_test.go
+++ b/services/party/adapters/http/verification_webhook_test.go
@@ -50,7 +50,7 @@ func TestNewVerificationWebhookHandler(t *testing.T) {
 				VerificationService: &mockVerificationService{},
 				HMACSecrets: map[string][]byte{
 					"onfido": []byte("onfido-secret"),
-					"jumio":  []byte("jumio-secret"),
+					"stripe": []byte("stripe-secret"),
 				},
 			},
 			wantErr: false,
@@ -397,14 +397,14 @@ func TestVerificationWebhookHandler_HandleWebhook_MethodNotAllowed(t *testing.T)
 
 func TestVerificationWebhookHandler_HandleWebhook_MultipleProviders(t *testing.T) {
 	onfidoSecret := []byte("onfido-secret")
-	jumioSecret := []byte("jumio-secret")
+	stripeSecret := []byte("stripe-secret")
 
 	mockService := &mockVerificationService{}
 	handler, err := NewVerificationWebhookHandler(VerificationWebhookHandlerConfig{
 		VerificationService: mockService,
 		HMACSecrets: map[string][]byte{
 			"onfido": onfidoSecret,
-			"jumio":  jumioSecret,
+			"stripe": stripeSecret,
 		},
 	})
 	require.NoError(t, err)
@@ -429,11 +429,11 @@ func TestVerificationWebhookHandler_HandleWebhook_MultipleProviders(t *testing.T
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 
-	// Test with jumio provider - should fail with onfido signature
+	// Test with stripe provider - should fail with onfido signature
 	body2, _ := json.Marshal(webhookReq)
 	wrongSig := GenerateWebhookSignature(body2, onfidoSecret) // Using wrong secret
 
-	req2 := httptest.NewRequest(http.MethodPost, "/webhooks/verification/jumio", bytes.NewReader(body2))
+	req2 := httptest.NewRequest(http.MethodPost, "/webhooks/verification/stripe", bytes.NewReader(body2))
 	req2.Header.Set("Content-Type", "application/json")
 	req2.Header.Set(WebhookSignatureHeader, wrongSig)
 
@@ -620,7 +620,7 @@ func TestExtractProvider(t *testing.T) {
 		expected string
 	}{
 		{"/webhooks/verification/onfido", "onfido"},
-		{"/webhooks/verification/jumio", "jumio"},
+		{"/webhooks/verification/stripe", "stripe"},
 		{"/webhooks/verification/onfido/", "onfido"},
 		{"/api/v1/webhooks/verification/provider", "provider"},
 		{"/webhooks/verification", ""},

--- a/services/party/adapters/persistence/verification_entity.go
+++ b/services/party/adapters/persistence/verification_entity.go
@@ -20,7 +20,7 @@ type PartyVerificationEntity struct {
 	// Provider's verification ID (external reference)
 	VerificationID string `gorm:"column:verification_id;type:varchar(255);not null;uniqueIndex:idx_party_verification_verification_id"`
 
-	// Provider name (e.g., "onfido", "jumio")
+	// Provider name (e.g., "onfido", "stripe")
 	Provider string `gorm:"column:provider;type:varchar(100);not null"`
 
 	// Verification status (PENDING, APPROVED, REJECTED, MANUAL_REVIEW)

--- a/services/party/adapters/persistence/verification_repository_test.go
+++ b/services/party/adapters/persistence/verification_repository_test.go
@@ -151,7 +151,7 @@ func TestCreateVerification_GeneratesID(t *testing.T) {
 	verification := &PartyVerificationEntity{
 		PartyID:        partyID,
 		VerificationID: "prov-67890",
-		Provider:       "jumio",
+		Provider:       "onfido",
 		Status:         "PENDING",
 	}
 

--- a/services/party/config/verification.go
+++ b/services/party/config/verification.go
@@ -11,7 +11,6 @@ import (
 //
 // Provider identifies which verification provider to use. Supported values:
 //   - "mock": Mock provider for testing (always available)
-//   - "jumio": Jumio identity verification
 //   - "onfido": Onfido identity verification
 //   - "stripe": Stripe Identity verification
 //
@@ -29,11 +28,11 @@ import (
 // WebhookURL is the publicly accessible URL where providers send verification
 // callbacks. Required for production deployments.
 type VerificationConfig struct {
-	// Provider is the verification provider to use ("mock", "jumio", "onfido", "stripe").
+	// Provider is the verification provider to use ("mock", "onfido", "stripe").
 	Provider string
 
 	// ProviderConfig contains provider-specific configuration.
-	// For jumio/onfido: "api_key", "api_secret", "base_url" (optional).
+	// For onfido: "api_key", "api_secret", "base_url" (optional).
 	// For stripe: "api_key", "base_url" (optional), "stripe_account" (optional).
 	ProviderConfig map[string]string
 
@@ -65,7 +64,7 @@ var (
 )
 
 // SupportedProviders lists all supported verification provider names.
-var SupportedProviders = []string{"mock", "jumio", "onfido", "stripe"}
+var SupportedProviders = []string{"mock", "onfido", "stripe"}
 
 // LoadVerificationConfig loads verification configuration from environment variables.
 //

--- a/services/party/config/verification_test.go
+++ b/services/party/config/verification_test.go
@@ -52,7 +52,7 @@ func TestLoadVerificationConfig_MockProvider_WithOptionalFields(t *testing.T) {
 
 func TestLoadVerificationConfig_NonMockProvider_RequiresWebhookSecret(t *testing.T) {
 	clearVerificationEnv(t)
-	t.Setenv("VERIFICATION_PROVIDER", "jumio")
+	t.Setenv("VERIFICATION_PROVIDER", "onfido")
 	t.Setenv("VERIFICATION_WEBHOOK_URL", "https://example.com/webhook")
 	t.Setenv("VERIFICATION_API_KEY", "api-key")
 	t.Setenv("VERIFICATION_API_SECRET", "api-secret")
@@ -66,7 +66,7 @@ func TestLoadVerificationConfig_NonMockProvider_RequiresWebhookSecret(t *testing
 
 func TestLoadVerificationConfig_NonMockProvider_RequiresWebhookURL(t *testing.T) {
 	clearVerificationEnv(t)
-	t.Setenv("VERIFICATION_PROVIDER", "jumio")
+	t.Setenv("VERIFICATION_PROVIDER", "onfido")
 	t.Setenv("VERIFICATION_WEBHOOK_SECRET", "secret")
 	// Missing VERIFICATION_WEBHOOK_URL
 	t.Setenv("VERIFICATION_API_KEY", "api-key")
@@ -108,22 +108,22 @@ func TestLoadVerificationConfig_NonMockProvider_RequiresAPISecret(t *testing.T) 
 
 func TestLoadVerificationConfig_NonMockProvider_ValidFullConfig(t *testing.T) {
 	clearVerificationEnv(t)
-	t.Setenv("VERIFICATION_PROVIDER", "jumio")
+	t.Setenv("VERIFICATION_PROVIDER", "onfido")
 	t.Setenv("VERIFICATION_WEBHOOK_SECRET", "webhook-secret")
 	t.Setenv("VERIFICATION_WEBHOOK_URL", "https://api.example.com/webhooks/verification")
 	t.Setenv("VERIFICATION_API_KEY", "my-api-key")
 	t.Setenv("VERIFICATION_API_SECRET", "my-api-secret")
-	t.Setenv("VERIFICATION_BASE_URL", "https://custom.jumio.com/api")
+	t.Setenv("VERIFICATION_BASE_URL", "https://custom.onfido.com/api")
 
 	cfg, err := LoadVerificationConfig()
 
 	require.NoError(t, err)
-	assert.Equal(t, "jumio", cfg.Provider)
+	assert.Equal(t, "onfido", cfg.Provider)
 	assert.Equal(t, "webhook-secret", cfg.WebhookSecret)
 	assert.Equal(t, "https://api.example.com/webhooks/verification", cfg.WebhookURL)
 	assert.Equal(t, "my-api-key", cfg.ProviderConfig["api_key"])
 	assert.Equal(t, "my-api-secret", cfg.ProviderConfig["api_secret"])
-	assert.Equal(t, "https://custom.jumio.com/api", cfg.ProviderConfig["base_url"])
+	assert.Equal(t, "https://custom.onfido.com/api", cfg.ProviderConfig["base_url"])
 }
 
 func TestLoadVerificationConfig_MissingProvider(t *testing.T) {
@@ -206,9 +206,6 @@ func TestVerificationConfig_Validate_ProviderCaseInsensitive(t *testing.T) {
 		{"mock"},
 		{"MOCK"},
 		{"Mock"},
-		{"jumio"},
-		{"JUMIO"},
-		{"Jumio"},
 		{"onfido"},
 		{"ONFIDO"},
 		{"Onfido"},
@@ -244,8 +241,8 @@ func TestVerificationConfig_IsMock(t *testing.T) {
 		{"mock", true},
 		{"MOCK", true},
 		{"Mock", true},
-		{"jumio", false},
 		{"onfido", false},
+		{"stripe", false},
 		{"", false},
 	}
 
@@ -260,10 +257,9 @@ func TestVerificationConfig_IsMock(t *testing.T) {
 func TestVerificationConfig_SupportedProviders(t *testing.T) {
 	// Verify the SupportedProviders list contains expected values
 	assert.Contains(t, SupportedProviders, "mock")
-	assert.Contains(t, SupportedProviders, "jumio")
 	assert.Contains(t, SupportedProviders, "onfido")
 	assert.Contains(t, SupportedProviders, "stripe")
-	assert.Len(t, SupportedProviders, 4)
+	assert.Len(t, SupportedProviders, 3)
 }
 
 func TestLoadVerificationConfig_StripeProvider_OnlyNeedsAPIKey(t *testing.T) {
@@ -353,7 +349,7 @@ func TestVerificationConfig_ValidateForEnvironment_ProductionRejectsMock(t *test
 
 func TestVerificationConfig_ValidateForEnvironment_ProductionRejectsHTTPWebhook(t *testing.T) {
 	cfg := &VerificationConfig{
-		Provider:       "jumio",
+		Provider:       "onfido",
 		WebhookSecret:  "a]strongsecretthatis32charslong!!", // 32+ chars
 		WebhookURL:     "http://api.example.com/webhooks",   // HTTP, not HTTPS
 		ProviderConfig: map[string]string{"api_key": "key", "api_secret": "secret"},
@@ -367,7 +363,7 @@ func TestVerificationConfig_ValidateForEnvironment_ProductionRejectsHTTPWebhook(
 
 func TestVerificationConfig_ValidateForEnvironment_ProductionRejectsWeakSecret(t *testing.T) {
 	cfg := &VerificationConfig{
-		Provider:       "jumio",
+		Provider:       "onfido",
 		WebhookSecret:  "short-secret", // < 32 chars
 		WebhookURL:     "https://api.example.com/webhooks",
 		ProviderConfig: map[string]string{"api_key": "key", "api_secret": "secret"},
@@ -391,7 +387,7 @@ func TestVerificationConfig_ValidateForEnvironment_DevelopmentAllowsMock(t *test
 
 func TestVerificationConfig_ValidateForEnvironment_ProductionAcceptsValidConfig(t *testing.T) {
 	cfg := &VerificationConfig{
-		Provider:       "jumio",
+		Provider:       "onfido",
 		WebhookSecret:  "a-very-strong-secret-that-is-at-least-32-characters-long",
 		WebhookURL:     "https://api.example.com/webhooks/verification",
 		ProviderConfig: map[string]string{"api_key": "key", "api_secret": "secret"},

--- a/services/party/verification/factory.go
+++ b/services/party/verification/factory.go
@@ -22,9 +22,6 @@ var (
 //   - "onfido": Onfido identity verification
 //   - "stripe": Stripe Identity verification
 //
-// Future providers (stubs, not yet implemented):
-//   - "jumio": Jumio identity verification
-//
 // Returns ErrUnsupportedProvider for any unrecognized provider name.
 // The MockProvider is configured with AlwaysApprove=true by default.
 func NewProvider(cfg *config.VerificationConfig) (Provider, error) {
@@ -36,9 +33,6 @@ func NewProvider(cfg *config.VerificationConfig) (Provider, error) {
 	switch provider {
 	case "mock":
 		return NewMockProvider().WithAlwaysApprove(true), nil
-	case "jumio":
-		// Jumio provider not yet implemented
-		return nil, ErrUnsupportedProvider
 	case "onfido":
 		return NewOnfidoProvider(cfg, slog.Default())
 	case "stripe":
@@ -77,8 +71,6 @@ func NewProviderWithOptions(cfg *config.VerificationConfig, opts ProviderOptions
 		return NewMockProvider().
 			WithAlwaysApprove(opts.MockAlwaysApprove).
 			WithAsyncMode(opts.MockAsyncMode), nil
-	case "jumio":
-		return nil, ErrUnsupportedProvider
 	case "onfido":
 		return NewOnfidoProvider(cfg, slog.Default())
 	case "stripe":

--- a/services/party/verification/factory_test.go
+++ b/services/party/verification/factory_test.go
@@ -49,20 +49,6 @@ func TestNewProvider_MockProviderCaseInsensitive(t *testing.T) {
 	}
 }
 
-func TestNewProvider_JumioProvider_NotImplemented(t *testing.T) {
-	cfg := &config.VerificationConfig{
-		Provider:       "jumio",
-		WebhookSecret:  "secret",
-		WebhookURL:     "https://example.com/webhook",
-		ProviderConfig: map[string]string{"api_key": "key", "api_secret": "secret"},
-	}
-
-	provider, err := NewProvider(cfg)
-
-	assert.Nil(t, provider)
-	assert.ErrorIs(t, err, ErrUnsupportedProvider)
-}
-
 func TestNewProvider_OnfidoProvider(t *testing.T) {
 	cfg := &config.VerificationConfig{
 		Provider:       "onfido",
@@ -174,7 +160,7 @@ func TestNewProviderWithOptions_RespectsAsyncMode(t *testing.T) {
 }
 
 func TestNewProviderWithOptions_NonMockProvider_ReturnsError(t *testing.T) {
-	testCases := []string{"jumio", "unknown"}
+	testCases := []string{"unknown", "nonexistent"}
 
 	for _, providerName := range testCases {
 		t.Run(providerName, func(t *testing.T) {

--- a/services/party/verification/integration_test.go
+++ b/services/party/verification/integration_test.go
@@ -38,16 +38,16 @@ func TestProviderFactory_SwitchProviderViaConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, verification.StatusApproved, result.Status)
 
-	// Attempt to switch to jumio (should return error since not implemented)
-	jumioCfg := &config.VerificationConfig{
-		Provider:       "jumio",
+	// Attempt unsupported provider (should return error)
+	unsupportedCfg := &config.VerificationConfig{
+		Provider:       "unsupported",
 		WebhookSecret:  "secret",
 		WebhookURL:     "https://example.com/webhook",
 		ProviderConfig: map[string]string{"api_key": "key", "api_secret": "secret"},
 	}
 
-	jumioProvider, err := verification.NewProvider(jumioCfg)
-	assert.Nil(t, jumioProvider)
+	unsupportedProvider, err := verification.NewProvider(unsupportedCfg)
+	assert.Nil(t, unsupportedProvider)
 	assert.ErrorIs(t, err, verification.ErrUnsupportedProvider)
 
 	// Can switch back to mock with different options
@@ -286,14 +286,14 @@ func TestWebhookSecurity_TamperedBodyRejected(t *testing.T) {
 // TestMultiProviderWebhooks tests that different providers use different secrets
 func TestMultiProviderWebhooks(t *testing.T) {
 	onfidoSecret := []byte("onfido-secret-key")
-	jumioSecret := []byte("jumio-secret-key")
+	stripeSecret := []byte("stripe-secret-key")
 
 	mockService := &mockWebhookService{}
 	handler, err := partyhttp.NewVerificationWebhookHandler(partyhttp.VerificationWebhookHandlerConfig{
 		VerificationService: mockService,
 		HMACSecrets: map[string][]byte{
 			"onfido": onfidoSecret,
-			"jumio":  jumioSecret,
+			"stripe": stripeSecret,
 		},
 	})
 	require.NoError(t, err)
@@ -319,18 +319,18 @@ func TestMultiProviderWebhooks(t *testing.T) {
 		assert.Equal(t, 200, rr.Code)
 	})
 
-	t.Run("jumio webhook with correct secret succeeds", func(t *testing.T) {
+	t.Run("stripe webhook with correct secret succeeds", func(t *testing.T) {
 		mockService.calls = nil // Reset
 
 		webhookReq := partyhttp.VerificationWebhookRequest{
-			VerificationID: "jumio-verify-456",
+			VerificationID: "stripe-verify-456",
 			Status:         "REJECTED",
 			Timestamp:      time.Now(),
 		}
 		body, _ := json.Marshal(webhookReq)
-		signature := partyhttp.GenerateWebhookSignature(body, jumioSecret)
+		signature := partyhttp.GenerateWebhookSignature(body, stripeSecret)
 
-		req := httptest.NewRequest("POST", "/webhooks/verification/jumio", bytes.NewReader(body))
+		req := httptest.NewRequest("POST", "/webhooks/verification/stripe", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set(partyhttp.WebhookSignatureHeader, signature)
 
@@ -340,7 +340,7 @@ func TestMultiProviderWebhooks(t *testing.T) {
 		assert.Equal(t, 200, rr.Code)
 	})
 
-	t.Run("onfido webhook with jumio secret fails", func(t *testing.T) {
+	t.Run("onfido webhook with stripe secret fails", func(t *testing.T) {
 		mockService.calls = nil // Reset
 
 		webhookReq := partyhttp.VerificationWebhookRequest{
@@ -350,7 +350,7 @@ func TestMultiProviderWebhooks(t *testing.T) {
 		}
 		body, _ := json.Marshal(webhookReq)
 		// Sign with wrong provider's secret
-		wrongSignature := partyhttp.GenerateWebhookSignature(body, jumioSecret)
+		wrongSignature := partyhttp.GenerateWebhookSignature(body, stripeSecret)
 
 		req := httptest.NewRequest("POST", "/webhooks/verification/onfido", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")

--- a/services/party/verification/provider.go
+++ b/services/party/verification/provider.go
@@ -108,7 +108,7 @@ func (sr SanctionsResult) Validate() error {
 }
 
 // Provider defines the interface for KYC/AML verification services.
-// Implementations may integrate with external providers like Onfido, Jumio, etc.
+// Implementations may integrate with external providers like Onfido, Stripe Identity, etc.
 type Provider interface {
 	// VerifyIdentity initiates an identity verification check for the given party.
 	// Returns a Result with a unique VerificationID that can be used


### PR DESCRIPTION
## Summary

- Remove the unimplemented Jumio case from the verification factory and all associated references
- Jumio was a dead code path: the factory case returned `ErrUnsupportedProvider` unconditionally
- Onfido and Stripe Identity remain as the implemented external providers

## Changes Made

- **`factory.go`**: Remove Jumio case from `NewProvider` and `NewProviderWithOptions`; remove "Future providers" doc section
- **`verification.go` (config)**: Remove `"jumio"` from `SupportedProviders` slice; update doc comments
- **`provider.go`**: Update interface doc comment
- **`verification_entity.go`**: Update field comment
- **Tests**: Remove Jumio-specific test (`TestNewProvider_JumioProvider_NotImplemented`), replace Jumio references in config tests, webhook tests, integration tests, and persistence tests with implemented providers (onfido, stripe)

## Test Plan

- [x] All party config tests pass
- [x] All verification factory tests pass
- [x] All webhook handler tests pass
- [x] All integration tests pass
- [x] Pre-commit checks pass (gitleaks, gofumpt, golangci-lint)
- [x] `"jumio"` now correctly rejected as unsupported (falls through to default case)