### PR TITLE
feat: implement ObservationContext for market data observations

### DIFF
--- a/services/market-information/adapters/persistence/mappers.go
+++ b/services/market-information/adapters/persistence/mappers.go
@@ -3,6 +3,7 @@ package persistence
 
 import (
 	"database/sql"
+	"encoding/json"
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/market-information/domain"
@@ -157,7 +158,7 @@ func ObservationToEntity(o domain.MarketPriceObservation, dataSetDefinitionID uu
 		ObservedAt:          o.ObservedAt(),
 		CreatedAt:           o.CreatedAt(),
 		Quality:             o.QualityLevel().Int(),
-		ObservationContext:  []byte("{}"), // Placeholder - actual context handling TBD
+		ObservationContext:  marshalObservationContext(o.ObservationContext()),
 	}
 
 	// Set numeric value from decimal
@@ -224,5 +225,35 @@ func EntityToObservation(e MarketPriceObservationEntity, dataSetCode string, tru
 		builder.WithCausationID(e.CausationID.UUID)
 	}
 
+	// Set observation context (backward-compatible with empty/null JSONB)
+	builder.WithObservationContext(unmarshalObservationContext(e.ObservationContext))
+
 	return builder.Build()
+}
+
+// marshalObservationContext serializes an ObservationContext to JSON bytes for JSONB storage.
+// Returns "{}" for empty contexts to maintain a valid JSONB value.
+func marshalObservationContext(ctx domain.ObservationContext) []byte {
+	if ctx.IsEmpty() {
+		return []byte("{}")
+	}
+	data, err := json.Marshal(ctx)
+	if err != nil {
+		return []byte("{}")
+	}
+	return data
+}
+
+// unmarshalObservationContext deserializes JSON bytes from JSONB into an ObservationContext.
+// Returns an empty ObservationContext for nil, empty, or invalid JSON (backward compatibility
+// with existing records that store "{}").
+func unmarshalObservationContext(data []byte) domain.ObservationContext {
+	if len(data) == 0 {
+		return domain.ObservationContext{}
+	}
+	var ctx domain.ObservationContext
+	if err := json.Unmarshal(data, &ctx); err != nil {
+		return domain.ObservationContext{}
+	}
+	return ctx
 }

--- a/services/market-information/adapters/persistence/mappers_test.go
+++ b/services/market-information/adapters/persistence/mappers_test.go
@@ -1,0 +1,88 @@
+package persistence
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/services/market-information/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshalObservationContext_Empty(t *testing.T) {
+	ctx := domain.ObservationContext{}
+	data := marshalObservationContext(ctx)
+	assert.Equal(t, []byte("{}"), data)
+}
+
+func TestMarshalObservationContext_WithAttributes(t *testing.T) {
+	ctx := domain.NewObservationContext(map[string]string{
+		"base_code":  "USD",
+		"quote_code": "EUR",
+	})
+	data := marshalObservationContext(ctx)
+
+	// Unmarshal back and verify round-trip
+	result := unmarshalObservationContext(data)
+	assert.Equal(t, "USD", result.Attributes["base_code"])
+	assert.Equal(t, "EUR", result.Attributes["quote_code"])
+}
+
+func TestMarshalObservationContext_WithAllFields(t *testing.T) {
+	ctx := domain.ObservationContext{
+		Attributes:       map[string]string{"tenor": "1M"},
+		SourceSystem:     "bloomberg",
+		CollectionMethod: "api-poll",
+		Unit:             "USD/oz",
+		Notes:            "manual correction",
+	}
+	data := marshalObservationContext(ctx)
+
+	result := unmarshalObservationContext(data)
+	assert.Equal(t, "1M", result.Attributes["tenor"])
+	assert.Equal(t, "bloomberg", result.SourceSystem)
+	assert.Equal(t, "api-poll", result.CollectionMethod)
+	assert.Equal(t, "USD/oz", result.Unit)
+	assert.Equal(t, "manual correction", result.Notes)
+}
+
+func TestUnmarshalObservationContext_Nil(t *testing.T) {
+	result := unmarshalObservationContext(nil)
+	assert.True(t, result.IsEmpty())
+}
+
+func TestUnmarshalObservationContext_EmptyBytes(t *testing.T) {
+	result := unmarshalObservationContext([]byte{})
+	assert.True(t, result.IsEmpty())
+}
+
+func TestUnmarshalObservationContext_EmptyJSON(t *testing.T) {
+	result := unmarshalObservationContext([]byte("{}"))
+	assert.True(t, result.IsEmpty())
+}
+
+func TestUnmarshalObservationContext_InvalidJSON(t *testing.T) {
+	result := unmarshalObservationContext([]byte("not json"))
+	assert.True(t, result.IsEmpty())
+}
+
+func TestUnmarshalObservationContext_LegacyEmptyObject(t *testing.T) {
+	// Existing records store "{}" - must deserialize gracefully
+	result := unmarshalObservationContext([]byte("{}"))
+	assert.True(t, result.IsEmpty())
+	assert.Nil(t, result.Attributes) // omitempty means no "attributes" key in "{}"
+}
+
+func TestObservationContextRoundTrip_ViaMapper(t *testing.T) {
+	ctx := domain.ObservationContext{
+		Attributes:       map[string]string{"base_code": "GBP", "quote_code": "USD"},
+		SourceSystem:     "internal-engine",
+		CollectionMethod: "streaming-feed",
+	}
+
+	// Build a domain observation with context
+	obs := domain.NewMarketPriceObservationBuilder().
+		WithObservationContext(ctx).
+		Build()
+
+	// Assert the getter returns what we set
+	assert.Equal(t, ctx, obs.ObservationContext())
+}

--- a/services/market-information/adapters/persistence/observation_repository_test.go
+++ b/services/market-information/adapters/persistence/observation_repository_test.go
@@ -83,6 +83,7 @@ func TestObservationRepository_Record_NewObservation(t *testing.T) {
 		uuid.New(),
 		domain.QualityLevelActual,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 
@@ -122,6 +123,7 @@ func TestObservationRepository_Record_SupersessionByQuality(t *testing.T) {
 		uuid.New(),
 		domain.QualityLevelEstimate,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(ctx, estimate)
@@ -145,6 +147,7 @@ func TestObservationRepository_Record_SupersessionByQuality(t *testing.T) {
 		uuid.New(),
 		domain.QualityLevelActual,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(ctx, actual)
@@ -196,6 +199,7 @@ func TestObservationRepository_Query_ByDataSetCode(t *testing.T) {
 			uuid.New(),
 			domain.QualityLevelActual,
 			source.TrustLevel(),
+			domain.ObservationContext{},
 		)
 		require.NoError(t, err)
 		err = tc.Repos.Observation.Record(ctx, obs)
@@ -237,6 +241,7 @@ func TestObservationRepository_Query_ByResolutionKey(t *testing.T) {
 			uuid.New(),
 			domain.QualityLevelActual,
 			source.TrustLevel(),
+			domain.ObservationContext{},
 		)
 		require.NoError(t, err)
 		err = tc.Repos.Observation.Record(ctx, obs)
@@ -286,6 +291,7 @@ func TestObservationRepository_Query_ByQualityLevel(t *testing.T) {
 			uuid.New(),
 			q,
 			source.TrustLevel(),
+			domain.ObservationContext{},
 		)
 		require.NoError(t, err)
 		err = tc.Repos.Observation.Record(ctx, obs)
@@ -325,6 +331,7 @@ func TestObservationRepository_Query_IncludeSuperseded(t *testing.T) {
 		uuid.New(),
 		domain.QualityLevelEstimate,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(ctx, estimate)
@@ -343,6 +350,7 @@ func TestObservationRepository_Query_IncludeSuperseded(t *testing.T) {
 		uuid.New(),
 		domain.QualityLevelActual,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(ctx, actual)
@@ -391,6 +399,7 @@ func TestObservationRepository_GetLatest_QualityLadder(t *testing.T) {
 		uuid.New(),
 		domain.QualityLevelVerified,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(ctx, verified)
@@ -409,6 +418,7 @@ func TestObservationRepository_GetLatest_QualityLadder(t *testing.T) {
 		uuid.New(),
 		domain.QualityLevelActual,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(ctx, actual)
@@ -427,6 +437,7 @@ func TestObservationRepository_GetLatest_QualityLadder(t *testing.T) {
 		uuid.New(),
 		domain.QualityLevelEstimate,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(ctx, estimate)
@@ -464,6 +475,7 @@ func TestObservationRepository_RetrieveObservation_KnowledgeBaseTime(t *testing.
 		uuid.New(),
 		domain.QualityLevelActual,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(ctx, obs)
@@ -514,6 +526,7 @@ func TestObservationRepository_Record_InvalidDataSetCode(t *testing.T) {
 		uuid.New(),
 		domain.QualityLevelActual,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 
@@ -610,6 +623,7 @@ func TestObservationRepository_HierarchicalLookup_TenantOverride(t *testing.T) {
 		uuid.New(),
 		domain.QualityLevelActual,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(ctx, masterObs)
@@ -633,6 +647,7 @@ func TestObservationRepository_HierarchicalLookup_TenantOverride(t *testing.T) {
 		uuid.New(),
 		domain.QualityLevelActual,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(tenantCtx, tenantObs)
@@ -669,6 +684,7 @@ func TestObservationRepository_HierarchicalLookup_MasterFallback(t *testing.T) {
 		uuid.New(),
 		domain.QualityLevelActual,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(ctx, masterObs)
@@ -763,6 +779,7 @@ func TestObservationRepository_HierarchicalLookup_PrivateDatasetNoFallback(t *te
 		uuid.New(),
 		domain.QualityLevelActual,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(ctx, masterObs)
@@ -802,6 +819,7 @@ func TestObservationRepository_HierarchicalLookup_RestrictedAccessDenied(t *test
 		uuid.New(),
 		domain.QualityLevelActual,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(ctx, masterObs)
@@ -840,6 +858,7 @@ func TestObservationRepository_HierarchicalLookup_RestrictedAccessGranted(t *tes
 		uuid.New(),
 		domain.QualityLevelActual,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(ctx, masterObs)
@@ -884,6 +903,7 @@ func TestObservationRepository_HierarchicalLookup_RestrictedAccessExpired(t *tes
 		uuid.New(),
 		domain.QualityLevelActual,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(ctx, masterObs)
@@ -927,6 +947,7 @@ func TestObservationRepository_HierarchicalLookup_RestrictedAccessInactive(t *te
 		uuid.New(),
 		domain.QualityLevelActual,
 		source.TrustLevel(),
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err)
 	err = tc.Repos.Observation.Record(ctx, masterObs)
@@ -974,6 +995,7 @@ func TestObservationRepository_CountByDataset_Basic(t *testing.T) {
 			uuid.New(),
 			domain.QualityLevelActual,
 			source.TrustLevel(),
+			domain.ObservationContext{},
 		)
 		require.NoError(t, err)
 		err = tc.Repos.Observation.Record(ctx, obs)
@@ -1017,6 +1039,7 @@ func TestObservationRepository_CountByDataset_ExcludesSuperseded(t *testing.T) {
 			uuid.New(),
 			quality,
 			source.TrustLevel(),
+			domain.ObservationContext{},
 		)
 		require.NoError(t, err)
 		err = tc.Repos.Observation.Record(ctx, obs)

--- a/services/market-information/domain/observation.go
+++ b/services/market-information/domain/observation.go
@@ -227,8 +227,18 @@ func (o MarketPriceObservation) TrustLevel() int {
 }
 
 // ObservationContext returns the typed metadata about collection and processing.
+// Returns a defensive copy to preserve the immutability contract (the Attributes
+// map is a reference type).
 func (o MarketPriceObservation) ObservationContext() ObservationContext {
-	return o.observationContext
+	ctx := o.observationContext
+	if ctx.Attributes != nil {
+		cp := make(map[string]string, len(ctx.Attributes))
+		for k, v := range ctx.Attributes {
+			cp[k] = v
+		}
+		ctx.Attributes = cp
+	}
+	return ctx
 }
 
 // MarketPriceObservationBuilder provides a builder pattern for reconstructing

--- a/services/market-information/domain/observation.go
+++ b/services/market-information/domain/observation.go
@@ -25,21 +25,22 @@ import (
 //   - SupersededBy forms a chain linking to the observation that replaced this one
 //   - CausationID enables event sourcing correlation
 type MarketPriceObservation struct {
-	id            uuid.UUID
-	dataSetCode   string          // References DataSetDefinition.Code
-	sourceID      uuid.UUID       // References DataSource.ID
-	resolutionKey string          // Unique key from CEL expression evaluation
-	value         decimal.Decimal // High-precision market value
-	unit          string          // Unit of measurement (e.g., "USD", "kWh")
-	observedAt    time.Time       // When the measurement was taken
-	validFrom     time.Time       // Start of effective time range
-	validTo       time.Time       // End of effective time range
-	createdAt     time.Time       // Knowledge time: when we learned about this
-	supersededAt  *time.Time      // When this observation was replaced
-	supersededBy  *uuid.UUID      // ID of the observation that replaced this one
-	causationID   uuid.UUID       // For event sourcing correlation
-	qualityLevel  QualityLevel    // ESTIMATE, ACTUAL, or VERIFIED
-	trustLevel    int             // 0-100, derived from DataSource
+	id                 uuid.UUID
+	dataSetCode        string             // References DataSetDefinition.Code
+	sourceID           uuid.UUID          // References DataSource.ID
+	resolutionKey      string             // Unique key from CEL expression evaluation
+	value              decimal.Decimal    // High-precision market value
+	unit               string             // Unit of measurement (e.g., "USD", "kWh")
+	observedAt         time.Time          // When the measurement was taken
+	validFrom          time.Time          // Start of effective time range
+	validTo            time.Time          // End of effective time range
+	createdAt          time.Time          // Knowledge time: when we learned about this
+	supersededAt       *time.Time         // When this observation was replaced
+	supersededBy       *uuid.UUID         // ID of the observation that replaced this one
+	causationID        uuid.UUID          // For event sourcing correlation
+	qualityLevel       QualityLevel       // ESTIMATE, ACTUAL, or VERIFIED
+	trustLevel         int                // 0-100, derived from DataSource
+	observationContext ObservationContext // Typed metadata about collection and processing
 }
 
 // NewMarketPriceObservation creates a new MarketPriceObservation with validated fields.
@@ -70,6 +71,7 @@ func NewMarketPriceObservation(
 	causationID uuid.UUID,
 	qualityLevel QualityLevel,
 	trustLevel int,
+	observationContext ObservationContext,
 ) (MarketPriceObservation, error) {
 	if dataSetCode == "" {
 		return MarketPriceObservation{}, ErrDataSetCodeRequired
@@ -97,21 +99,22 @@ func NewMarketPriceObservation(
 	}
 
 	return MarketPriceObservation{
-		id:            uuid.New(),
-		dataSetCode:   dataSetCode,
-		sourceID:      sourceID,
-		resolutionKey: resolutionKey,
-		value:         value,
-		unit:          unit,
-		observedAt:    observedAt,
-		validFrom:     validFrom,
-		validTo:       validTo,
-		createdAt:     time.Now(),
-		supersededAt:  nil,
-		supersededBy:  nil,
-		causationID:   causationID,
-		qualityLevel:  qualityLevel,
-		trustLevel:    trustLevel,
+		id:                 uuid.New(),
+		dataSetCode:        dataSetCode,
+		sourceID:           sourceID,
+		resolutionKey:      resolutionKey,
+		value:              value,
+		unit:               unit,
+		observedAt:         observedAt,
+		validFrom:          validFrom,
+		validTo:            validTo,
+		createdAt:          time.Now(),
+		supersededAt:       nil,
+		supersededBy:       nil,
+		causationID:        causationID,
+		qualityLevel:       qualityLevel,
+		trustLevel:         trustLevel,
+		observationContext: observationContext,
 	}, nil
 }
 
@@ -223,6 +226,11 @@ func (o MarketPriceObservation) TrustLevel() int {
 	return o.trustLevel
 }
 
+// ObservationContext returns the typed metadata about collection and processing.
+func (o MarketPriceObservation) ObservationContext() ObservationContext {
+	return o.observationContext
+}
+
 // MarketPriceObservationBuilder provides a builder pattern for reconstructing
 // MarketPriceObservation from the persistence layer. This bypasses normal validation
 // since we assume persisted data was already validated.
@@ -324,6 +332,12 @@ func (b *MarketPriceObservationBuilder) WithQualityLevel(level QualityLevel) *Ma
 // WithTrustLevel sets the trust score.
 func (b *MarketPriceObservationBuilder) WithTrustLevel(level int) *MarketPriceObservationBuilder {
 	b.observation.trustLevel = level
+	return b
+}
+
+// WithObservationContext sets the observation context metadata.
+func (b *MarketPriceObservationBuilder) WithObservationContext(ctx ObservationContext) *MarketPriceObservationBuilder {
+	b.observation.observationContext = ctx
 	return b
 }
 

--- a/services/market-information/domain/observation_context.go
+++ b/services/market-information/domain/observation_context.go
@@ -35,11 +35,12 @@ type ObservationContext struct {
 // This is the primary constructor used during observation ingestion where
 // attributes come from the proto AttributeEntry list.
 func NewObservationContext(attributes map[string]string) ObservationContext {
-	if attributes == nil {
-		attributes = make(map[string]string)
+	cp := make(map[string]string, len(attributes))
+	for k, v := range attributes {
+		cp[k] = v
 	}
 	return ObservationContext{
-		Attributes: attributes,
+		Attributes: cp,
 	}
 }
 

--- a/services/market-information/domain/observation_context.go
+++ b/services/market-information/domain/observation_context.go
@@ -1,0 +1,53 @@
+// Package domain contains the domain models for the Market Information service.
+package domain
+
+// ObservationContext carries typed metadata about how a market data observation
+// was collected, processed, and qualified. It is stored as JSONB alongside each
+// observation record.
+//
+// The Attributes map holds the key-value pairs that drive CEL resolution-key
+// computation and validation (e.g. "base_code"="USD", "quote_code"="EUR").
+// Additional fields capture source metadata, collection parameters, and
+// processing metadata that are useful for audit and reconciliation.
+type ObservationContext struct {
+	// Attributes are the user-supplied key-value pairs from the proto
+	// AttributeEntry list. They are used by CEL expressions for resolution
+	// key computation, validation, and error message generation.
+	Attributes map[string]string `json:"attributes,omitempty"`
+
+	// SourceSystem identifies the upstream system that produced the observation
+	// (e.g. "bloomberg", "internal-forecast-engine").
+	SourceSystem string `json:"source_system,omitempty"`
+
+	// CollectionMethod describes how the data was obtained
+	// (e.g. "api-poll", "manual-entry", "streaming-feed").
+	CollectionMethod string `json:"collection_method,omitempty"`
+
+	// Unit is the unit of measurement for the observed value
+	// (e.g. "USD/oz", "p/kWh", "EUR/MWh").
+	Unit string `json:"unit,omitempty"`
+
+	// Notes is free-text annotation attached at ingestion time.
+	Notes string `json:"notes,omitempty"`
+}
+
+// NewObservationContext creates an ObservationContext from a map of attributes.
+// This is the primary constructor used during observation ingestion where
+// attributes come from the proto AttributeEntry list.
+func NewObservationContext(attributes map[string]string) ObservationContext {
+	if attributes == nil {
+		attributes = make(map[string]string)
+	}
+	return ObservationContext{
+		Attributes: attributes,
+	}
+}
+
+// IsEmpty returns true when the context carries no meaningful data.
+func (c ObservationContext) IsEmpty() bool {
+	return len(c.Attributes) == 0 &&
+		c.SourceSystem == "" &&
+		c.CollectionMethod == "" &&
+		c.Unit == "" &&
+		c.Notes == ""
+}

--- a/services/market-information/domain/observation_context_test.go
+++ b/services/market-information/domain/observation_context_test.go
@@ -1,0 +1,95 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewObservationContext_WithAttributes(t *testing.T) {
+	attrs := map[string]string{"base_code": "USD", "quote_code": "EUR"}
+	ctx := NewObservationContext(attrs)
+
+	assert.Equal(t, attrs, ctx.Attributes)
+	assert.False(t, ctx.IsEmpty())
+}
+
+func TestNewObservationContext_NilAttributes(t *testing.T) {
+	ctx := NewObservationContext(nil)
+
+	assert.NotNil(t, ctx.Attributes)
+	assert.Empty(t, ctx.Attributes)
+	assert.True(t, ctx.IsEmpty())
+}
+
+func TestNewObservationContext_EmptyAttributes(t *testing.T) {
+	ctx := NewObservationContext(map[string]string{})
+
+	assert.NotNil(t, ctx.Attributes)
+	assert.Empty(t, ctx.Attributes)
+	assert.True(t, ctx.IsEmpty())
+}
+
+func TestObservationContext_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name    string
+		ctx     ObservationContext
+		isEmpty bool
+	}{
+		{
+			name:    "zero value is empty",
+			ctx:     ObservationContext{},
+			isEmpty: true,
+		},
+		{
+			name:    "only empty attributes is empty",
+			ctx:     ObservationContext{Attributes: map[string]string{}},
+			isEmpty: true,
+		},
+		{
+			name:    "with attributes is not empty",
+			ctx:     ObservationContext{Attributes: map[string]string{"k": "v"}},
+			isEmpty: false,
+		},
+		{
+			name:    "with source system is not empty",
+			ctx:     ObservationContext{SourceSystem: "bloomberg"},
+			isEmpty: false,
+		},
+		{
+			name:    "with collection method is not empty",
+			ctx:     ObservationContext{CollectionMethod: "api-poll"},
+			isEmpty: false,
+		},
+		{
+			name:    "with unit is not empty",
+			ctx:     ObservationContext{Unit: "USD/oz"},
+			isEmpty: false,
+		},
+		{
+			name:    "with notes is not empty",
+			ctx:     ObservationContext{Notes: "manual correction"},
+			isEmpty: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.isEmpty, tt.ctx.IsEmpty())
+		})
+	}
+}
+
+func TestObservationContext_OnObservation(t *testing.T) {
+	attrs := map[string]string{"base_code": "USD", "quote_code": "EUR"}
+	ctx := NewObservationContext(attrs)
+	ctx.SourceSystem = "bloomberg"
+
+	obs := NewMarketPriceObservationBuilder().
+		WithObservationContext(ctx).
+		Build()
+
+	result := obs.ObservationContext()
+	assert.Equal(t, attrs, result.Attributes)
+	assert.Equal(t, "bloomberg", result.SourceSystem)
+}

--- a/services/market-information/domain/observation_test.go
+++ b/services/market-information/domain/observation_test.go
@@ -28,6 +28,7 @@ func createValidObservation(t *testing.T) MarketPriceObservation {
 		causationID,
 		QualityLevelActual,
 		85,
+		ObservationContext{},
 	)
 	require.NoError(t, err)
 	return obs
@@ -55,6 +56,7 @@ func TestNewMarketPriceObservation_Success(t *testing.T) {
 		causationID,
 		QualityLevelActual,
 		85,
+		ObservationContext{},
 	)
 
 	require.NoError(t, err)
@@ -102,6 +104,7 @@ func TestNewMarketPriceObservation_AllQualityLevels(t *testing.T) {
 				uuid.New(),
 				level,
 				50,
+				ObservationContext{},
 			)
 
 			require.NoError(t, err)
@@ -138,6 +141,7 @@ func TestNewMarketPriceObservation_TrustLevelBoundaries(t *testing.T) {
 				uuid.New(),
 				QualityLevelActual,
 				tt.trustLevel,
+				ObservationContext{},
 			)
 
 			if tt.expectErr {
@@ -309,6 +313,7 @@ func TestNewMarketPriceObservation_ValidationErrors(t *testing.T) {
 				tt.causationID,
 				tt.qualityLevel,
 				tt.trustLevel,
+				ObservationContext{},
 			)
 			assert.ErrorIs(t, err, tt.expectedErr)
 		})
@@ -370,6 +375,7 @@ func TestNewMarketPriceObservation_TemporalBoundsValidation(t *testing.T) {
 				uuid.New(),
 				QualityLevelActual,
 				50,
+				ObservationContext{},
 			)
 
 			if tt.expectErr {
@@ -558,6 +564,7 @@ func TestMarketPriceObservation_DecimalPrecision(t *testing.T) {
 				uuid.New(),
 				QualityLevelActual,
 				50,
+				ObservationContext{},
 			)
 
 			require.NoError(t, err)
@@ -610,6 +617,7 @@ func TestMarketPriceObservation_UniqueIDs(t *testing.T) {
 			uuid.New(),
 			QualityLevelActual,
 			50,
+			ObservationContext{},
 		)
 		require.NoError(t, err)
 		assert.False(t, ids[obs.ID()], "Duplicate ID generated")
@@ -697,6 +705,7 @@ func TestMarketPriceObservation_BiTemporalFields(t *testing.T) {
 		uuid.New(),
 		QualityLevelActual,
 		85,
+		ObservationContext{},
 	)
 
 	require.NoError(t, err)
@@ -730,6 +739,7 @@ func TestMarketPriceObservation_LineageTracking(t *testing.T) {
 		uuid.New(),
 		QualityLevelEstimate,
 		50,
+		ObservationContext{},
 	)
 	require.NoError(t, err)
 
@@ -746,6 +756,7 @@ func TestMarketPriceObservation_LineageTracking(t *testing.T) {
 		uuid.New(),
 		QualityLevelActual, // Higher quality
 		75,
+		ObservationContext{},
 	)
 	require.NoError(t, err)
 
@@ -778,6 +789,7 @@ func TestMarketPriceObservation_ZeroValue(t *testing.T) {
 			uuid.New(),
 			QualityLevelActual,
 			50,
+			ObservationContext{},
 		)
 		require.NoError(t, err)
 		assert.True(t, zeroValue.Equal(obs.Value()))
@@ -796,6 +808,7 @@ func TestMarketPriceObservation_ZeroValue(t *testing.T) {
 			uuid.New(),
 			QualityLevelActual,
 			50,
+			ObservationContext{},
 		)
 		require.NoError(t, err)
 		assert.True(t, negValue.Equal(obs.Value()))

--- a/services/market-information/domain/repository_test.go
+++ b/services/market-information/domain/repository_test.go
@@ -193,6 +193,7 @@ func TestObservationRepository_Record(t *testing.T) {
 		uuid.New(),
 		QualityLevelActual,
 		85,
+		ObservationContext{},
 	)
 	require.NoError(t, err)
 

--- a/services/market-information/e2e/e2e_test.go
+++ b/services/market-information/e2e/e2e_test.go
@@ -340,6 +340,7 @@ func createTestObservation(
 		uuid.New(),
 		quality,
 		trustLevel,
+		domain.ObservationContext{},
 	)
 	require.NoError(t, err, "Failed to create observation")
 
@@ -970,6 +971,7 @@ func TestE2E_ConcurrentIngestion(t *testing.T) {
 						uuid.New(),
 						domain.QualityLevelActual,
 						source.TrustLevel(),
+						domain.ObservationContext{},
 					)
 					if err != nil {
 						errChan <- err
@@ -1063,6 +1065,7 @@ func TestE2E_AsyncOperationsWithAwait(t *testing.T) {
 				uuid.New(),
 				domain.QualityLevelActual,
 				source.TrustLevel(),
+				domain.ObservationContext{},
 			)
 			_ = tc.repos.Observation.Record(ctx, obs)
 		}()

--- a/services/market-information/service/observation_service.go
+++ b/services/market-information/service/observation_service.go
@@ -120,6 +120,7 @@ func (s *Server) RecordObservation(ctx context.Context, req *pb.RecordObservatio
 		uuid.New(), // CausationID - generate new for this request
 		qualityLevel,
 		source.TrustLevel(),
+		domain.NewObservationContext(observationContext),
 	)
 	if err != nil {
 		s.logger.Warn("failed to create observation",
@@ -393,6 +394,7 @@ func (s *Server) RecordObservationBatch(ctx context.Context, req *pb.RecordObser
 			uuid.New(),
 			qualityLevel,
 			source.TrustLevel(),
+			domain.NewObservationContext(observationContext),
 		)
 		if err != nil {
 			results[i] = &pb.BatchObservationResult{


### PR DESCRIPTION
## Summary

- Define typed `ObservationContext` domain struct with `Attributes`, `SourceSystem`, `CollectionMethod`, `Unit`, and `Notes` fields
- Add `observationContext` field to `MarketPriceObservation` domain model with getter and builder support
- Wire JSON serialization in mappers with backward-compatible deserialization (handles null, empty, and legacy `{}` records)
- Replace hardcoded `[]byte("{}")` placeholder in `ObservationToEntity`

**Task Master**: codebase-debt-audit.7

## Changes Made

| File | Change |
|------|--------|
| `domain/observation_context.go` | New `ObservationContext` struct and `NewObservationContext` constructor |
| `domain/observation.go` | Add `observationContext` field, getter, constructor param, builder method |
| `adapters/persistence/mappers.go` | `marshalObservationContext` / `unmarshalObservationContext` with backward compat |
| `service/observation_service.go` | Pass `domain.NewObservationContext(observationContext)` at both call sites |

## Test Plan

- [x] `ObservationContext` domain tests: construction, emptiness, builder integration
- [x] Mapper serialization tests: round-trip, nil/empty/invalid JSON, legacy `{}` backward compat
- [x] All existing domain and persistence unit tests pass with new parameter
- [x] Pre-commit hooks pass (gofumpt, golangci-lint, gitleaks)