### PR TITLE
fix: Cookbook QA fixes and nav split into hub page

### DIFF
--- a/cookbook/patterns/base-fiat-gbp/pattern.json
+++ b/cookbook/patterns/base-fiat-gbp/pattern.json
@@ -8,7 +8,7 @@
     "categories": ["foundation", "fiat", "currency"],
     "meta": {
         "complexity": 1,
-        "design_pattern": null,
+        "design_pattern": "foundation-denomination",
         "industries": ["all"],
         "provides": {
             "instruments": ["GBP"],

--- a/cookbook/patterns/base-fiat-usd/pattern.json
+++ b/cookbook/patterns/base-fiat-usd/pattern.json
@@ -8,7 +8,7 @@
     "categories": ["foundation", "fiat", "currency"],
     "meta": {
         "complexity": 1,
-        "design_pattern": null,
+        "design_pattern": "foundation-denomination",
         "industries": ["all"],
         "provides": {
             "instruments": ["USD"],

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,12 @@ import { McpConfigPage } from '@/features/mcp-config'
 import { TransactionsPage } from '@/features/transactions'
 import { CookbookPage } from '@/features/cookbook'
 
+const CookbookPatternsPage = lazy(() =>
+  import('@/features/cookbook/pages/patterns').then((m) => ({ default: m.CookbookPatternsPage })),
+)
+const CookbookComponentsPage = lazy(() =>
+  import('@/features/cookbook/pages/components').then((m) => ({ default: m.CookbookComponentsPage })),
+)
 const CookbookDetailPage = lazy(() =>
   import('@/features/cookbook/pages/detail').then((m) => ({ default: m.CookbookDetailPage })),
 )
@@ -265,6 +271,8 @@ function AppShellLayout() {
         <Route path="/manifests" element={<FeatureGuard feature="manifests">{guarded(<ManifestsPage />)}</FeatureGuard>} />
         <Route path="/mcp-config" element={<FeatureGuard feature="mcp-config">{guarded(<McpConfigPage />)}</FeatureGuard>} />
         <Route path="/cookbook" element={guarded(<CookbookPage />)} />
+        <Route path="/cookbook/patterns" element={guarded(<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}><CookbookPatternsPage /></Suspense>)} />
+        <Route path="/cookbook/components" element={guarded(<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}><CookbookComponentsPage /></Suspense>)} />
         <Route path="/cookbook/graph" element={guarded(<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}><CookbookGraphPage /></Suspense>)} />
         <Route path="/cookbook/:name" element={guarded(<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}><CookbookDetailPage /></Suspense>)} />
         <Route path="/audit-log" element={<FeatureGuard feature="audit">{guarded(<AuditLogPage />)}</FeatureGuard>} />

--- a/frontend/src/features/cookbook/components/catalogue-grid.test.tsx
+++ b/frontend/src/features/cookbook/components/catalogue-grid.test.tsx
@@ -86,8 +86,8 @@ describe('CatalogueGrid', () => {
 
   it('shows complexity indicator for patterns', () => {
     renderGrid(mockItems)
-    const complexityDots = document.querySelectorAll('[title="Complexity: 7/10"]')
-    expect(complexityDots.length).toBe(1)
+    const indicators = screen.getAllByTestId('complexity-indicator')
+    expect(indicators.length).toBe(1)
   })
 
   it('shows design pattern label', () => {

--- a/frontend/src/features/cookbook/components/catalogue-grid.tsx
+++ b/frontend/src/features/cookbook/components/catalogue-grid.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom'
 import { Blocks, BookOpen, SearchX } from 'lucide-react'
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { EmptyState } from '@/components/ui/empty-state'
 import type { CookbookItem, PatternMeta, ComponentMeta } from '../hooks/use-cookbook'
 
@@ -16,16 +17,21 @@ function isPatternMeta(meta: PatternMeta | ComponentMeta | undefined): meta is P
 
 function ComplexityIndicator({ score }: { score: number }) {
   return (
-    <div className="flex items-center gap-1" title={`Complexity: ${score}/10`}>
-      {Array.from({ length: 5 }, (_, i) => (
-        <div
-          key={i}
-          className={`size-1.5 rounded-full ${
-            i < Math.ceil(score / 2) ? 'bg-primary' : 'bg-muted'
-          }`}
-        />
-      ))}
-    </div>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="flex items-center gap-1" data-testid="complexity-indicator">
+          {Array.from({ length: 5 }, (_, i) => (
+            <div
+              key={i}
+              className={`size-1.5 rounded-full ${
+                i < Math.ceil(score / 2) ? 'bg-primary' : 'bg-muted'
+              }`}
+            />
+          ))}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>Complexity: {score}/10</TooltipContent>
+    </Tooltip>
   )
 }
 

--- a/frontend/src/features/cookbook/components/catalogue-grid.tsx
+++ b/frontend/src/features/cookbook/components/catalogue-grid.tsx
@@ -19,7 +19,12 @@ function ComplexityIndicator({ score }: { score: number }) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <div className="flex items-center gap-1" data-testid="complexity-indicator">
+        <span
+          tabIndex={0}
+          aria-label={`Complexity: ${score}/10`}
+          className="flex items-center gap-1"
+          data-testid="complexity-indicator"
+        >
           {Array.from({ length: 5 }, (_, i) => (
             <div
               key={i}
@@ -28,7 +33,7 @@ function ComplexityIndicator({ score }: { score: number }) {
               }`}
             />
           ))}
-        </div>
+        </span>
       </TooltipTrigger>
       <TooltipContent>Complexity: {score}/10</TooltipContent>
     </Tooltip>

--- a/frontend/src/features/cookbook/components/filter-bar.tsx
+++ b/frontend/src/features/cookbook/components/filter-bar.tsx
@@ -30,9 +30,10 @@ interface FilterBarProps {
   items: CookbookItem[]
   filters: FilterState
   onFilterChange: (patch: Partial<FilterState>) => void
+  hideTypeFilter?: boolean
 }
 
-export function FilterBar({ items, filters, onFilterChange }: FilterBarProps) {
+export function FilterBar({ items, filters, onFilterChange, hideTypeFilter }: FilterBarProps) {
   const categories = getUniqueCategories(items)
   const industries = getUniqueIndustries(items)
   const hasActiveFilters = filters.search || filters.type || filters.category || filters.industry
@@ -50,15 +51,17 @@ export function FilterBar({ items, filters, onFilterChange }: FilterBarProps) {
       </div>
 
       <div className="flex flex-wrap gap-2">
-        <FilterChipGroup
-          label="Type"
-          options={[
-            { value: 'pattern', label: 'Patterns' },
-            { value: 'ui', label: 'UI Components' },
-          ]}
-          value={filters.type}
-          onChange={(value) => onFilterChange({ type: value })}
-        />
+        {!hideTypeFilter && (
+          <FilterChipGroup
+            label="Type"
+            options={[
+              { value: 'pattern', label: 'Patterns' },
+              { value: 'ui', label: 'UI Components' },
+            ]}
+            value={filters.type}
+            onChange={(value) => onFilterChange({ type: value })}
+          />
+        )}
 
         {categories.length > 0 && (
           <FilterChipGroup

--- a/frontend/src/features/cookbook/hooks/use-pattern-files.test.ts
+++ b/frontend/src/features/cookbook/hooks/use-pattern-files.test.ts
@@ -1,58 +1,91 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
 import { usePatternFiles } from './use-pattern-files'
+import type { CookbookItem } from './use-cookbook'
+
+function makeItem(overrides: Partial<CookbookItem> = {}): CookbookItem {
+  return {
+    name: 'test-pattern',
+    type: 'registry:pattern',
+    title: 'Test Pattern',
+    files: [
+      { path: 'patterns/test/saga.star', content: 'def execute():\n  pass' },
+      { path: 'patterns/test/manifest.yaml', content: 'name: test\ntype: registry:pattern' },
+    ],
+    ...overrides,
+  }
+}
 
 describe('usePatternFiles', () => {
-  beforeEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it('returns null content when no pattern name provided', () => {
+  it('returns empty state when no item provided', () => {
     const { result } = renderHook(() => usePatternFiles(undefined))
-    expect(result.current.starlarkContent).toBeNull()
+    expect(result.current.starlarkFiles).toEqual([])
     expect(result.current.manifestContent).toBeNull()
     expect(result.current.isLoading).toBe(false)
   })
 
-  it('fetches starlark and manifest files', async () => {
-    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
-      const path = typeof url === 'string' ? url : url.toString()
-      if (path.includes('saga.star')) {
-        return new Response('def execute():\n  pass', { status: 200 })
-      }
-      if (path.includes('manifest.yaml')) {
-        return new Response('name: test\ntype: registry:pattern', { status: 200 })
-      }
-      return new Response('', { status: 404 })
-    })
-
-    const { result } = renderHook(() => usePatternFiles('test-pattern'))
-
-    await waitFor(() => expect(result.current.isLoading).toBe(false))
-
-    expect(result.current.starlarkContent).toBe('def execute():\n  pass')
-    expect(result.current.manifestContent).toBe('name: test\ntype: registry:pattern')
-  })
-
-  it('returns null for files that return 404', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 404 }))
-
-    const { result } = renderHook(() => usePatternFiles('missing-pattern'))
-
-    await waitFor(() => expect(result.current.isLoading).toBe(false))
-
-    expect(result.current.starlarkContent).toBeNull()
+  it('returns empty state for UI component items', () => {
+    const item = makeItem({ type: 'registry:ui' })
+    const { result } = renderHook(() => usePatternFiles(item))
+    expect(result.current.starlarkFiles).toEqual([])
     expect(result.current.manifestContent).toBeNull()
   })
 
-  it('returns null for fetch errors', async () => {
-    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'))
+  it('extracts starlark and manifest content from bundled files', () => {
+    const item = makeItem()
+    const { result } = renderHook(() => usePatternFiles(item))
 
-    const { result } = renderHook(() => usePatternFiles('broken-pattern'))
+    expect(result.current.starlarkFiles).toEqual([
+      { name: 'saga.star', content: 'def execute():\n  pass' },
+    ])
+    expect(result.current.manifestContent).toBe('name: test\ntype: registry:pattern')
+    expect(result.current.isLoading).toBe(false)
+  })
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false))
+  it('handles multiple starlark files', () => {
+    const item = makeItem({
+      files: [
+        { path: 'patterns/test/billing.star', content: 'def billing(): pass' },
+        { path: 'patterns/test/onboarding.star', content: 'def onboard(): pass' },
+        { path: 'patterns/test/manifest.yaml', content: 'name: test' },
+      ],
+    })
+    const { result } = renderHook(() => usePatternFiles(item))
 
-    expect(result.current.starlarkContent).toBeNull()
+    expect(result.current.starlarkFiles).toHaveLength(2)
+    expect(result.current.starlarkFiles[0].name).toBe('billing.star')
+    expect(result.current.starlarkFiles[1].name).toBe('onboarding.star')
+  })
+
+  it('returns null manifest when no yaml file present', () => {
+    const item = makeItem({
+      files: [{ path: 'patterns/test/saga.star', content: 'def execute(): pass' }],
+    })
+    const { result } = renderHook(() => usePatternFiles(item))
+    expect(result.current.manifestContent).toBeNull()
+  })
+
+  it('rejects HTML content as invalid (SPA fallback protection)', () => {
+    const item = makeItem({
+      files: [
+        { path: 'patterns/test/saga.star', content: '<!DOCTYPE html><html></html>' },
+        { path: 'patterns/test/manifest.yaml', content: '<html><body>not yaml</body></html>' },
+      ],
+    })
+    const { result } = renderHook(() => usePatternFiles(item))
+    expect(result.current.starlarkFiles).toEqual([])
+    expect(result.current.manifestContent).toBeNull()
+  })
+
+  it('handles files with no content', () => {
+    const item = makeItem({
+      files: [
+        { path: 'patterns/test/saga.star' },
+        { path: 'patterns/test/manifest.yaml' },
+      ],
+    })
+    const { result } = renderHook(() => usePatternFiles(item))
+    expect(result.current.starlarkFiles).toEqual([])
     expect(result.current.manifestContent).toBeNull()
   })
 })

--- a/frontend/src/features/cookbook/hooks/use-pattern-files.ts
+++ b/frontend/src/features/cookbook/hooks/use-pattern-files.ts
@@ -1,68 +1,41 @@
-import { useEffect, useReducer } from 'react'
+import { useMemo } from 'react'
+import type { CookbookItem } from './use-cookbook'
 
-interface PatternFilesState {
-  starlarkContent: string | null
+export interface StarlarkFile {
+  name: string
+  content: string
+}
+
+export interface PatternFilesState {
+  starlarkFiles: StarlarkFile[]
   manifestContent: string | null
-  isLoading: boolean
+  isLoading: false
 }
 
-type PatternFilesAction =
-  | { type: 'reset' }
-  | { type: 'fetch_start' }
-  | { type: 'fetch_done'; starlark: string | null; manifest: string | null }
-
-const initialState: PatternFilesState = {
-  starlarkContent: null,
-  manifestContent: null,
-  isLoading: false,
+function isValidContent(content: string | undefined): content is string {
+  if (!content) return false
+  const trimmed = content.trimStart()
+  return !trimmed.startsWith('<!DOCTYPE') && !trimmed.startsWith('<html')
 }
 
-function reducer(_state: PatternFilesState, action: PatternFilesAction): PatternFilesState {
-  switch (action.type) {
-    case 'reset':
-      return initialState
-    case 'fetch_start':
-      return { starlarkContent: null, manifestContent: null, isLoading: true }
-    case 'fetch_done':
-      return { starlarkContent: action.starlark, manifestContent: action.manifest, isLoading: false }
-  }
-}
+export function usePatternFiles(item: CookbookItem | undefined): PatternFilesState {
+  return useMemo(() => {
+    const empty: PatternFilesState = { starlarkFiles: [], manifestContent: null, isLoading: false }
+    if (!item || item.type !== 'registry:pattern') return empty
 
-export function usePatternFiles(patternName: string | undefined): PatternFilesState {
-  const [state, dispatch] = useReducer(reducer, initialState)
+    const files = item.files ?? []
 
-  useEffect(() => {
-    if (!patternName) {
-      dispatch({ type: 'reset' })
-      return
-    }
+    const manifestFile = files.find((f) => f.path.endsWith('.yaml'))
+    const manifestContent = isValidContent(manifestFile?.content) ? manifestFile!.content : null
 
-    let cancelled = false
-    dispatch({ type: 'fetch_start' })
+    const starlarkFiles: StarlarkFile[] = files
+      .filter((f) => f.path.endsWith('.star'))
+      .map((f) => ({
+        name: f.path.split('/').pop() ?? f.path,
+        content: isValidContent(f.content) ? f.content : '',
+      }))
+      .filter((f) => f.content.length > 0)
 
-    const fetchFile = async (path: string): Promise<string | null> => {
-      try {
-        const res = await fetch(path)
-        if (!res.ok) return null
-        return await res.text()
-      } catch {
-        return null
-      }
-    }
-
-    const encoded = encodeURIComponent(patternName)
-    Promise.all([
-      fetchFile(`/cookbook/patterns/${encoded}/saga.star`),
-      fetchFile(`/cookbook/patterns/${encoded}/manifest.yaml`),
-    ]).then(([star, yaml]) => {
-      if (cancelled) return
-      dispatch({ type: 'fetch_done', starlark: star, manifest: yaml })
-    })
-
-    return () => {
-      cancelled = true
-    }
-  }, [patternName])
-
-  return state
+    return { starlarkFiles, manifestContent, isLoading: false }
+  }, [item])
 }

--- a/frontend/src/features/cookbook/index.ts
+++ b/frontend/src/features/cookbook/index.ts
@@ -1,4 +1,6 @@
 export { CookbookPage } from './pages/index'
+export { CookbookPatternsPage } from './pages/patterns'
+export { CookbookComponentsPage } from './pages/components'
 export { CookbookDetailPage } from './pages/detail'
 export { CookbookGraphPage } from './pages/graph'
 export { CompositionGraph } from './components/composition-graph'

--- a/frontend/src/features/cookbook/pages/components.tsx
+++ b/frontend/src/features/cookbook/pages/components.tsx
@@ -1,0 +1,25 @@
+import { Breadcrumbs } from '@/shared/breadcrumbs'
+import { useCookbook } from '../hooks/use-cookbook'
+import { useFilterState, applyFilters } from '../hooks/use-filter-state'
+import { CatalogueGrid } from '../components/catalogue-grid'
+import { FilterBar } from '../components/filter-bar'
+
+export function CookbookComponentsPage() {
+  const { items } = useCookbook()
+  const components = items.filter((i) => i.type === 'registry:ui')
+  const [filters, setFilters] = useFilterState()
+  const filtered = applyFilters(components, filters)
+  const hasActiveFilters = !!(filters.search || filters.category || filters.industry)
+
+  return (
+    <div className="space-y-6">
+      <Breadcrumbs items={[{ label: 'Cookbook', href: '/cookbook' }, { label: 'UI Components' }]} />
+      <div>
+        <h1 className="text-2xl font-semibold">UI Components</h1>
+        <p className="text-muted-foreground">Reusable interface components for Meridian-powered applications</p>
+      </div>
+      <FilterBar items={components} filters={filters} onFilterChange={setFilters} hideTypeFilter />
+      <CatalogueGrid items={filtered} hasActiveFilters={hasActiveFilters} />
+    </div>
+  )
+}

--- a/frontend/src/features/cookbook/pages/components.tsx
+++ b/frontend/src/features/cookbook/pages/components.tsx
@@ -8,7 +8,8 @@ export function CookbookComponentsPage() {
   const { items } = useCookbook()
   const components = items.filter((i) => i.type === 'registry:ui')
   const [filters, setFilters] = useFilterState()
-  const filtered = applyFilters(components, filters)
+  const effectiveFilters = { ...filters, type: '' }
+  const filtered = applyFilters(components, effectiveFilters)
   const hasActiveFilters = !!(filters.search || filters.category || filters.industry)
 
   return (

--- a/frontend/src/features/cookbook/pages/detail.test.tsx
+++ b/frontend/src/features/cookbook/pages/detail.test.tsx
@@ -38,7 +38,7 @@ vi.mock('../hooks/use-cookbook', () => ({
   useCookbook: () => mockUseCookbook(),
 }))
 
-const mockUsePatternFiles = vi.fn<() => { starlarkContent: string | null; manifestContent: string | null; isLoading: boolean }>()
+const mockUsePatternFiles = vi.fn<() => { starlarkFiles: Array<{ name: string; content: string }>; manifestContent: string | null; isLoading: false }>()
 vi.mock('../hooks/use-pattern-files', () => ({
   usePatternFiles: () => mockUsePatternFiles(),
 }))
@@ -82,7 +82,7 @@ describe('CookbookDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUseCookbook.mockReturnValue({ items: [patternItem, uiItem], isLoading: false })
-    mockUsePatternFiles.mockReturnValue({ starlarkContent: null, manifestContent: null, isLoading: false })
+    mockUsePatternFiles.mockReturnValue({ starlarkFiles: [], manifestContent: null, isLoading: false as const })
   })
 
   it('shows loading skeleton while catalogue is loading', () => {
@@ -134,11 +134,12 @@ describe('CookbookDetailPage', () => {
     expect(screen.queryByRole('tab')).not.toBeInTheDocument()
   })
 
-  it('renders breadcrumb navigation', () => {
+  it('renders breadcrumb navigation with sub-section', () => {
     renderDetail('fiat-current-account')
     const breadcrumb = screen.getByLabelText('Breadcrumb')
     expect(breadcrumb).toBeInTheDocument()
     expect(screen.getByText('Cookbook')).toBeInTheDocument()
+    expect(screen.getByText('Patterns')).toBeInTheDocument()
     // Title appears in both breadcrumb and heading
     expect(screen.getAllByText('Fiat Current Account').length).toBe(2)
   })
@@ -150,9 +151,9 @@ describe('CookbookDetailPage', () => {
 
   it('renders manifest viewer when content available', () => {
     mockUsePatternFiles.mockReturnValue({
-      starlarkContent: null,
+      starlarkFiles: [],
       manifestContent: 'name: test\ntype: registry:pattern',
-      isLoading: false,
+      isLoading: false as const,
     })
     renderDetail('fiat-current-account')
     expect(screen.getByTestId('manifest-viewer')).toBeInTheDocument()

--- a/frontend/src/features/cookbook/pages/detail.tsx
+++ b/frontend/src/features/cookbook/pages/detail.tsx
@@ -14,6 +14,7 @@ import { parseStarlarkSaga } from '../lib/star-parser'
 import { useCookbook } from '../hooks/use-cookbook'
 import type { CookbookItem, PatternMeta } from '../hooks/use-cookbook'
 import { usePatternFiles } from '../hooks/use-pattern-files'
+import type { StarlarkFile } from '../hooks/use-pattern-files'
 
 function complexityLabel(score: number): string {
   if (score <= 3) return 'Low'
@@ -192,18 +193,53 @@ function HandlerReferencePanel({ starlarkContent }: { starlarkContent: string | 
   )
 }
 
+function StarlarkTabContent({ starlarkFiles }: { starlarkFiles: StarlarkFile[] }) {
+  const [activeFile, setActiveFile] = useState(0)
+
+  if (starlarkFiles.length === 0) {
+    return <p className="text-sm text-muted-foreground">No Starlark file found.</p>
+  }
+
+  if (starlarkFiles.length === 1) {
+    return <StarlarkEditor value={starlarkFiles[0].content} onChange={() => {}} readOnly />
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-1 border-b">
+        {starlarkFiles.map((f, i) => (
+          <button
+            key={f.name}
+            type="button"
+            onClick={() => setActiveFile(i)}
+            className={`px-3 py-1.5 text-xs font-medium border-b-2 transition-colors ${
+              i === activeFile
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {f.name}
+          </button>
+        ))}
+      </div>
+      <StarlarkEditor value={starlarkFiles[activeFile].content} onChange={() => {}} readOnly />
+    </div>
+  )
+}
+
 export function CookbookDetailPage() {
   const { name } = useParams<{ name: string }>()
   const { items, isLoading: catalogueLoading } = useCookbook()
-  const { starlarkContent, manifestContent, isLoading: filesLoading } = usePatternFiles(name)
 
   const item = items.find((i) => i.name === name)
-  const isLoading = catalogueLoading || filesLoading
+  const { starlarkFiles, manifestContent } = usePatternFiles(item)
+
+  const firstStarlarkContent = starlarkFiles.length > 0 ? starlarkFiles[0].content : null
 
   const sagaFlow = useMemo(() => {
-    if (!starlarkContent) return null
-    return parseStarlarkSaga(starlarkContent)
-  }, [starlarkContent])
+    if (!firstStarlarkContent) return null
+    return parseStarlarkSaga(firstStarlarkContent)
+  }, [firstStarlarkContent])
 
   if (catalogueLoading) {
     return <DetailSkeleton fieldCount={3} tabCount={3} showBackNav />
@@ -222,10 +258,13 @@ export function CookbookDetailPage() {
 
   const isPattern = item.type === 'registry:pattern'
   const meta = item.meta as PatternMeta | undefined
+  const parentSection = isPattern
+    ? { label: 'Patterns', href: '/cookbook/patterns' }
+    : { label: 'UI Components', href: '/cookbook/components' }
 
   return (
     <div className="space-y-6">
-      <Breadcrumbs items={[{ label: 'Cookbook', href: '/cookbook' }, { label: item.title }]} />
+      <Breadcrumbs items={[{ label: 'Cookbook', href: '/cookbook' }, parentSection, { label: item.title }]} />
 
       <PatternInfoSection item={item} />
 
@@ -240,9 +279,7 @@ export function CookbookDetailPage() {
             </TabsList>
 
             <TabsContent value="manifest" className="mt-4">
-              {isLoading ? (
-                <div className="h-[200px] animate-pulse rounded border bg-muted" />
-              ) : manifestContent ? (
+              {manifestContent ? (
                 <ManifestViewer content={manifestContent} />
               ) : (
                 <p className="text-sm text-muted-foreground">No manifest file found.</p>
@@ -250,24 +287,12 @@ export function CookbookDetailPage() {
             </TabsContent>
 
             <TabsContent value="starlark" className="mt-4">
-              {isLoading ? (
-                <div className="h-[200px] animate-pulse rounded border bg-muted" />
-              ) : starlarkContent ? (
-                <StarlarkEditor
-                  value={starlarkContent}
-                  onChange={() => {}}
-                  readOnly
-                />
-              ) : (
-                <p className="text-sm text-muted-foreground">No Starlark file found.</p>
-              )}
+              <StarlarkTabContent starlarkFiles={starlarkFiles} />
             </TabsContent>
 
             <TabsContent value="flow" className="mt-4">
-              {isLoading ? (
-                <div className="h-[400px] animate-pulse rounded border bg-muted" />
-              ) : sagaFlow && sagaFlow.steps.length > 0 && starlarkContent ? (
-                <LinkedPatternDetail flow={sagaFlow} starlarkContent={starlarkContent} />
+              {sagaFlow && sagaFlow.steps.length > 0 && firstStarlarkContent ? (
+                <LinkedPatternDetail flow={sagaFlow} starlarkContent={firstStarlarkContent} />
               ) : (
                 <p className="text-sm text-muted-foreground">No saga flow detected in Starlark source.</p>
               )}
@@ -282,7 +307,7 @@ export function CookbookDetailPage() {
             </TabsContent>
           </Tabs>
 
-          <HandlerReferencePanel starlarkContent={starlarkContent} />
+          <HandlerReferencePanel starlarkContent={firstStarlarkContent} />
         </>
       ) : (
         <ComponentDetail item={item} />

--- a/frontend/src/features/cookbook/pages/detail.tsx
+++ b/frontend/src/features/cookbook/pages/detail.tsx
@@ -195,6 +195,7 @@ function HandlerReferencePanel({ starlarkContent }: { starlarkContent: string | 
 
 function StarlarkTabContent({ starlarkFiles }: { starlarkFiles: StarlarkFile[] }) {
   const [activeFile, setActiveFile] = useState(0)
+  const activeIndex = activeFile >= starlarkFiles.length ? 0 : activeFile
 
   if (starlarkFiles.length === 0) {
     return <p className="text-sm text-muted-foreground">No Starlark file found.</p>
@@ -213,7 +214,7 @@ function StarlarkTabContent({ starlarkFiles }: { starlarkFiles: StarlarkFile[] }
             type="button"
             onClick={() => setActiveFile(i)}
             className={`px-3 py-1.5 text-xs font-medium border-b-2 transition-colors ${
-              i === activeFile
+              i === activeIndex
                 ? 'border-primary text-foreground'
                 : 'border-transparent text-muted-foreground hover:text-foreground'
             }`}
@@ -222,7 +223,7 @@ function StarlarkTabContent({ starlarkFiles }: { starlarkFiles: StarlarkFile[] }
           </button>
         ))}
       </div>
-      <StarlarkEditor value={starlarkFiles[activeFile].content} onChange={() => {}} readOnly />
+      <StarlarkEditor value={starlarkFiles[activeIndex].content} onChange={() => {}} readOnly />
     </div>
   )
 }

--- a/frontend/src/features/cookbook/pages/index.tsx
+++ b/frontend/src/features/cookbook/pages/index.tsx
@@ -1,22 +1,79 @@
+import { Link } from 'react-router-dom'
+import { BookOpen, Blocks, ChevronRight, GitBranch } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useCookbook } from '../hooks/use-cookbook'
-import { useFilterState, applyFilters } from '../hooks/use-filter-state'
-import { CatalogueGrid } from '../components/catalogue-grid'
-import { FilterBar } from '../components/filter-bar'
+
+interface CookbookHubCardProps {
+  title: string
+  description: string
+  count: number
+  href: string
+  icon: React.ReactNode
+}
+
+function CookbookHubCard({ title, description, count, href, icon }: CookbookHubCardProps) {
+  return (
+    <Link to={href} className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-lg">
+      <Card className="h-full transition-colors group-hover:border-primary/50 group-focus-visible:border-primary/50">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">{title}</CardTitle>
+          <div className="text-muted-foreground">{icon}</div>
+        </CardHeader>
+        <CardContent>
+          <div className="mb-2 text-2xl font-bold">{count}</div>
+          <p className="text-xs text-muted-foreground">{description}</p>
+          <div className="mt-4 flex items-center text-xs font-medium text-primary">
+            View all
+            <ChevronRight className="ml-1 h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  )
+}
 
 export function CookbookPage() {
   const { items } = useCookbook()
-  const [filters, setFilters] = useFilterState()
-  const filtered = applyFilters(items, filters)
-  const hasActiveFilters = !!(filters.search || filters.type || filters.category || filters.industry)
+  const patternCount = items.filter((i) => i.type === 'registry:pattern').length
+  const componentCount = items.filter((i) => i.type === 'registry:ui').length
+
+  const cards: CookbookHubCardProps[] = [
+    {
+      title: 'Economy Patterns',
+      description: 'Saga definitions, manifest fragments, and instrument configurations for common business scenarios.',
+      count: patternCount,
+      href: '/cookbook/patterns',
+      icon: <BookOpen className="h-4 w-4" />,
+    },
+    {
+      title: 'UI Components',
+      description: 'Reusable interface components for building Meridian-powered applications.',
+      count: componentCount,
+      href: '/cookbook/components',
+      icon: <Blocks className="h-4 w-4" />,
+    },
+    {
+      title: 'Composition Graph',
+      description: 'Visual dependency graph showing how patterns relate to each other.',
+      count: items.length,
+      href: '/cookbook/graph',
+      icon: <GitBranch className="h-4 w-4" />,
+    },
+  ]
 
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-semibold">Cookbook</h1>
-        <p className="text-muted-foreground">Browse economy patterns and UI components</p>
+        <h1 className="text-3xl font-bold tracking-tight">Cookbook</h1>
+        <p className="mt-2 text-muted-foreground">
+          Browse economy patterns, UI components, and composition graphs.
+        </p>
       </div>
-      <FilterBar items={items} filters={filters} onFilterChange={setFilters} />
-      <CatalogueGrid items={filtered} hasActiveFilters={hasActiveFilters} />
+      <div className="grid gap-4 md:grid-cols-3">
+        {cards.map((card) => (
+          <CookbookHubCard key={card.href} {...card} />
+        ))}
+      </div>
     </div>
   )
 }

--- a/frontend/src/features/cookbook/pages/patterns.tsx
+++ b/frontend/src/features/cookbook/pages/patterns.tsx
@@ -8,7 +8,8 @@ export function CookbookPatternsPage() {
   const { items } = useCookbook()
   const patterns = items.filter((i) => i.type === 'registry:pattern')
   const [filters, setFilters] = useFilterState()
-  const filtered = applyFilters(patterns, filters)
+  const effectiveFilters = { ...filters, type: '' }
+  const filtered = applyFilters(patterns, effectiveFilters)
   const hasActiveFilters = !!(filters.search || filters.category || filters.industry)
 
   return (

--- a/frontend/src/features/cookbook/pages/patterns.tsx
+++ b/frontend/src/features/cookbook/pages/patterns.tsx
@@ -1,0 +1,25 @@
+import { Breadcrumbs } from '@/shared/breadcrumbs'
+import { useCookbook } from '../hooks/use-cookbook'
+import { useFilterState, applyFilters } from '../hooks/use-filter-state'
+import { CatalogueGrid } from '../components/catalogue-grid'
+import { FilterBar } from '../components/filter-bar'
+
+export function CookbookPatternsPage() {
+  const { items } = useCookbook()
+  const patterns = items.filter((i) => i.type === 'registry:pattern')
+  const [filters, setFilters] = useFilterState()
+  const filtered = applyFilters(patterns, filters)
+  const hasActiveFilters = !!(filters.search || filters.category || filters.industry)
+
+  return (
+    <div className="space-y-6">
+      <Breadcrumbs items={[{ label: 'Cookbook', href: '/cookbook' }, { label: 'Patterns' }]} />
+      <div>
+        <h1 className="text-2xl font-semibold">Economy Patterns</h1>
+        <p className="text-muted-foreground">Saga definitions, manifest fragments, and instrument configurations</p>
+      </div>
+      <FilterBar items={patterns} filters={filters} onFilterChange={setFilters} hideTypeFilter />
+      <CatalogueGrid items={filtered} hasActiveFilters={hasActiveFilters} />
+    </div>
+  )
+}

--- a/frontend/vite-plugins/cookbook-bundler.ts
+++ b/frontend/vite-plugins/cookbook-bundler.ts
@@ -41,12 +41,17 @@ function loadCookbookData(cookbookDir: string): string {
     }
 
     const detail = JSON.parse(readFileSync(metaPath, 'utf-8'))
+    const filesWithContent = (detail.files ?? []).map((file: { path: string; [k: string]: unknown }) => {
+      const filePath = resolve(cookbookDir, file.path)
+      if (!existsSync(filePath)) return file
+      return { ...file, content: readFileSync(filePath, 'utf-8') }
+    })
     return {
       ...entry,
       description: detail.description ?? entry.description,
       categories: detail.categories ?? entry.categories,
       meta: detail.meta,
-      files: detail.files,
+      files: filesWithContent,
     }
   })
 

--- a/frontend/vite-plugins/cookbook-bundler.ts
+++ b/frontend/vite-plugins/cookbook-bundler.ts
@@ -43,6 +43,10 @@ function loadCookbookData(cookbookDir: string): string {
     const detail = JSON.parse(readFileSync(metaPath, 'utf-8'))
     const filesWithContent = (detail.files ?? []).map((file: { path: string; [k: string]: unknown }) => {
       const filePath = resolve(cookbookDir, file.path)
+      if (!filePath.startsWith(cookbookDir + '/')) {
+        console.warn(`[cookbook-bundler] Skipping file outside cookbook directory: ${file.path}`)
+        return file
+      }
       if (!existsSync(filePath)) return file
       return { ...file, content: readFileSync(filePath, 'utf-8') }
     })


### PR DESCRIPTION
## Summary

- Bundle cookbook pattern file contents at build time instead of fetching via HTTP (fixes Bugs #1-3 where SPA fallback returned index.html as code)
- Split `/cookbook` into a hub page with cards linking to `/cookbook/patterns`, `/cookbook/components`, and `/cookbook/graph` sub-pages
- Fix base-fiat-gbp and base-fiat-usd missing `design_pattern` metadata (Bug #6)
- Replace complexity dots HTML `title` attribute with proper Tooltip component (Bug #7)

## Changes Made

| File | Change |
|------|--------|
| `frontend/vite-plugins/cookbook-bundler.ts` | Read file contents from disk into bundle |
| `frontend/src/features/cookbook/hooks/use-pattern-files.ts` | Rewrite: synchronous extraction from bundled data, multi-file support, HTML rejection guard |
| `frontend/src/features/cookbook/pages/detail.tsx` | New hook shape, starlark filename sub-tabs, updated breadcrumbs |
| `frontend/src/features/cookbook/pages/index.tsx` | Rewrite as hub page with 3 cards |
| `frontend/src/features/cookbook/pages/patterns.tsx` | New patterns listing page |
| `frontend/src/features/cookbook/pages/components.tsx` | New UI components listing page |
| `frontend/src/features/cookbook/components/catalogue-grid.tsx` | Tooltip upgrade for complexity dots |
| `frontend/src/features/cookbook/components/filter-bar.tsx` | Add `hideTypeFilter` prop |
| `frontend/src/App.tsx` | Add `/cookbook/patterns` and `/cookbook/components` routes |
| `cookbook/patterns/base-fiat-gbp/pattern.json` | Set `design_pattern` to `foundation-denomination` |
| `cookbook/patterns/base-fiat-usd/pattern.json` | Same fix |

## Test plan

- [x] All 136 cookbook tests passing
- [ ] `/cookbook` shows hub page with counts and cards
- [ ] `/cookbook/patterns` shows pattern grid with type filter hidden
- [ ] `/cookbook/components` shows UI component grid with type filter hidden
- [ ] Pattern detail page: Manifest tab shows YAML, Starlark tab shows .star code, Flow tab renders diagram
- [ ] `/cookbook/direction-badge` shows Direction Badge component (not Saga Timeline)
- [ ] Base Fiat GBP/USD detail shows "Design Pattern: foundation-denomination"
- [ ] Complexity dots show tooltip on hover