### PR TITLE
refactor: remove Starlark panel from Flow tab

### DIFF
--- a/frontend/src/features/cookbook/components/linked-detail.test.tsx
+++ b/frontend/src/features/cookbook/components/linked-detail.test.tsx
@@ -3,70 +3,6 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { LinkedPatternDetail } from './linked-detail'
 import type { SagaFlow } from '../lib/star-parser'
 
-// Mock CodeMirror (jsdom doesn't support it)
-vi.mock('codemirror', () => ({ basicSetup: [] }))
-
-const mockDispatch = vi.fn()
-let lastEditorDoc = ''
-
-vi.mock('@codemirror/view', () => ({
-  EditorView: class MockEditorView {
-    static editable = { of: vi.fn(() => ({})) }
-    static updateListener = { of: vi.fn(() => ({})) }
-    static lineWrapping = {}
-    dom: HTMLElement
-    state: { doc: { toString: () => string; line: (n: number) => { from: number; to: number } } }
-    dispatch = mockDispatch
-
-    constructor(config: { doc?: string; extensions?: unknown[]; parent?: HTMLElement }) {
-      this.dom = document.createElement('div')
-      this.dom.className = 'cm-editor'
-      lastEditorDoc = config.doc ?? ''
-      this.state = {
-        doc: {
-          toString: () => lastEditorDoc,
-          line: (n: number) => ({ from: (n - 1) * 20, to: n * 20 }),
-        },
-      }
-      if (config.parent) config.parent.appendChild(this.dom)
-    }
-
-    destroy() {
-      this.dom.remove()
-    }
-  },
-  Decoration: {
-    mark: vi.fn(() => ({
-      range: vi.fn((_from: number, _to: number) => ({})),
-    })),
-    set: vi.fn(() => ({})),
-  },
-  ViewPlugin: {
-    fromClass: vi.fn(() => ({})),
-  },
-}))
-
-vi.mock('@codemirror/state', () => ({
-  Compartment: class {
-    of = vi.fn(() => ({}))
-    reconfigure = vi.fn(() => ({}))
-  },
-  EditorState: { create: vi.fn(() => ({})), readOnly: { of: vi.fn(() => ({})) } },
-  Transaction: { userEvent: 'user-event' },
-  RangeSetBuilder: class {
-    add = vi.fn()
-    finish = vi.fn(() => ({}))
-  },
-  StateField: { define: vi.fn(() => ({})) },
-  StateEffect: { define: vi.fn(() => ({ of: vi.fn(() => ({})) })) },
-}))
-
-vi.mock('@codemirror/lang-python', () => ({ python: vi.fn(() => ({})) }))
-vi.mock('@codemirror/lint', () => ({
-  linter: vi.fn(() => ({})),
-  lintGutter: vi.fn(() => ({})),
-}))
-
 // Mock @xyflow/react
 vi.mock('@xyflow/react', () => ({
   ReactFlow: ({ onNodeClick, nodes }: { onNodeClick?: (e: unknown, node: unknown) => void; nodes: unknown[] }) => (
@@ -154,51 +90,27 @@ const sampleFlow: SagaFlow = {
   ],
 }
 
-const sampleStarlark = `# Saga: deposit-saga
-# Trigger: payment.inbound
-def execute(input_data):
-    step(name="validate_payment")
-    position_keeping.initiate_log(amount=input_data.amount)
-
-    step(name="apply_credit")
-    position_keeping.apply_credit(amount=input_data.amount, direction="CREDIT")
-    fees.calculate(amount=input_data.amount)
-`
-
 describe('LinkedPatternDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('renders editor, diagram, and handler reference panels', () => {
-    render(
-      <LinkedPatternDetail
-        flow={sampleFlow}
-        starlarkContent={sampleStarlark}
-      />,
-    )
-    expect(screen.getByTestId('starlark-editor')).toBeInTheDocument()
+  it('renders diagram and handler reference panels', () => {
+    render(<LinkedPatternDetail flow={sampleFlow} />)
     expect(screen.getByTestId('react-flow')).toBeInTheDocument()
     expect(screen.getByTestId('handler-reference')).toBeInTheDocument()
   })
 
-  it('renders three-panel layout with resizable areas', () => {
-    const { container } = render(
-      <LinkedPatternDetail
-        flow={sampleFlow}
-        starlarkContent={sampleStarlark}
-      />,
-    )
-    expect(container.querySelector('[data-testid="linked-detail"]')).toBeInTheDocument()
+  it('renders full-width layout without editor panel', () => {
+    const { container } = render(<LinkedPatternDetail flow={sampleFlow} />)
+    const detail = container.querySelector('[data-testid="linked-detail"]')
+    expect(detail).toBeInTheDocument()
+    // Should not contain starlark editor
+    expect(screen.queryByTestId('starlark-editor')).not.toBeInTheDocument()
   })
 
   it('highlights handler reference when step is clicked in diagram', () => {
-    render(
-      <LinkedPatternDetail
-        flow={sampleFlow}
-        starlarkContent={sampleStarlark}
-      />,
-    )
+    render(<LinkedPatternDetail flow={sampleFlow} />)
 
     const stepNode = screen.getByTestId('flow-node-step-0')
     fireEvent.click(stepNode)
@@ -208,48 +120,22 @@ describe('LinkedPatternDetail', () => {
   })
 
   it('updates selected step state when diagram step is clicked', () => {
-    render(
-      <LinkedPatternDetail
-        flow={sampleFlow}
-        starlarkContent={sampleStarlark}
-      />,
-    )
+    render(<LinkedPatternDetail flow={sampleFlow} />)
 
     const step1 = screen.getByTestId('flow-node-step-1')
     fireEvent.click(step1)
 
     const handlerRef = screen.getByTestId('handler-reference')
-    // The second step has position_keeping.apply_credit as first service call
     expect(handlerRef.dataset.highlighted).toBe('position_keeping.apply_credit')
   })
 
   it('passes service names to handler reference from flow', () => {
-    render(
-      <LinkedPatternDetail
-        flow={sampleFlow}
-        starlarkContent={sampleStarlark}
-      />,
-    )
+    render(<LinkedPatternDetail flow={sampleFlow} />)
 
     const handlerRef = screen.getByTestId('handler-reference')
     const services = handlerRef.dataset.services?.split(',') ?? []
     expect(services).toContain('position_keeping')
     expect(services).toContain('fees')
-  })
-
-  it('dispatches to editor when step is clicked to scroll to line', () => {
-    render(
-      <LinkedPatternDetail
-        flow={sampleFlow}
-        starlarkContent={sampleStarlark}
-      />,
-    )
-
-    const stepNode = screen.getByTestId('flow-node-step-0')
-    fireEvent.click(stepNode)
-
-    // Editor dispatch should be called to scroll/highlight
-    expect(mockDispatch).toHaveBeenCalled()
   })
 
   it('clears highlighted handler when clicked step has no service calls', () => {
@@ -261,7 +147,7 @@ describe('LinkedPatternDetail', () => {
       ],
     }
 
-    render(<LinkedPatternDetail flow={flowWithNoop} starlarkContent={sampleStarlark} />)
+    render(<LinkedPatternDetail flow={flowWithNoop} />)
 
     fireEvent.click(screen.getByTestId('flow-node-step-0'))
     expect(screen.getByTestId('handler-reference').dataset.highlighted).toBe('position_keeping.initiate_log')
@@ -278,12 +164,7 @@ describe('LinkedPatternDetail', () => {
       steps: [],
     }
 
-    render(
-      <LinkedPatternDetail
-        flow={emptyFlow}
-        starlarkContent=""
-      />,
-    )
+    render(<LinkedPatternDetail flow={emptyFlow} />)
 
     expect(screen.getByTestId('linked-detail')).toBeInTheDocument()
   })

--- a/frontend/src/features/cookbook/components/linked-detail.tsx
+++ b/frontend/src/features/cookbook/components/linked-detail.tsx
@@ -1,18 +1,14 @@
-import { useState, useMemo, useCallback, useRef } from 'react'
-import { type EditorView } from '@codemirror/view'
-import { StarlarkEditor } from '@/features/sagas/components/starlark-editor'
+import { useState, useMemo, useCallback } from 'react'
 import { HandlerReference } from '@/shared/handler-reference'
 import { SagaFlowDiagram } from './saga-flow'
 import type { SagaFlow } from '../lib/star-parser'
 
 interface LinkedPatternDetailProps {
   flow: SagaFlow
-  starlarkContent: string
 }
 
-export function LinkedPatternDetail({ flow, starlarkContent }: LinkedPatternDetailProps) {
+export function LinkedPatternDetail({ flow }: LinkedPatternDetailProps) {
   const [highlightedHandler, setHighlightedHandler] = useState<string | null>(null)
-  const editorViewRef = useRef<EditorView | null>(null)
 
   const serviceNames = useMemo(() => {
     const names = new Set<string>()
@@ -24,17 +20,8 @@ export function LinkedPatternDetail({ flow, starlarkContent }: LinkedPatternDeta
     return Array.from(names)
   }, [flow])
 
-  const handleStepClick = useCallback((stepName: string, lineNumber: number) => {
-    const view = editorViewRef.current
-    if (view && lineNumber >= 1 && lineNumber <= view.state.doc.lines) {
-      const line = view.state.doc.line(lineNumber)
-      view.dispatch({
-        selection: { anchor: line.from },
-        scrollIntoView: true,
-      })
-    }
-
-    const step = flow.steps.find((s) => s.name === stepName)
+  const handleStepClick = useCallback((_stepName: string, _lineNumber: number) => {
+    const step = flow.steps.find((s) => s.name === _stepName)
     if (step && step.serviceCalls.length > 0) {
       const firstCall = step.serviceCalls[0]
       setHighlightedHandler(`${firstCall.service}.${firstCall.method}`)
@@ -44,33 +31,20 @@ export function LinkedPatternDetail({ flow, starlarkContent }: LinkedPatternDeta
   }, [flow])
 
   return (
-    <div data-testid="linked-detail" className="flex flex-col gap-4 lg:flex-row lg:gap-6">
-      {/* Left panel: Starlark editor */}
-      <div className="flex-1 min-w-0">
-        <StarlarkEditor
-          value={starlarkContent}
-          onChange={() => {}}
-          readOnly
-          editorViewRef={editorViewRef}
+    <div data-testid="linked-detail" className="flex flex-col gap-4">
+      <div className="h-[400px] rounded-lg border">
+        <SagaFlowDiagram
+          flow={flow}
+          onStepClick={handleStepClick}
         />
       </div>
 
-      {/* Right panel: Diagram + Handler reference */}
-      <div className="flex flex-col gap-4 lg:w-[480px] lg:shrink-0">
-        <div className="h-[400px] rounded-lg border">
-          <SagaFlowDiagram
-            flow={flow}
-            onStepClick={handleStepClick}
-          />
-        </div>
-
-        <div className="rounded-lg border p-3">
-          <h3 className="mb-2 text-sm font-medium text-muted-foreground">Handler Reference</h3>
-          <HandlerReference
-            serviceNames={serviceNames.length > 0 ? serviceNames : undefined}
-            highlightedHandler={highlightedHandler ?? undefined}
-          />
-        </div>
+      <div className="rounded-lg border p-3">
+        <h3 className="mb-2 text-sm font-medium text-muted-foreground">Handler Reference</h3>
+        <HandlerReference
+          serviceNames={serviceNames.length > 0 ? serviceNames : undefined}
+          highlightedHandler={highlightedHandler ?? undefined}
+        />
       </div>
     </div>
   )

--- a/frontend/src/features/cookbook/pages/detail.tsx
+++ b/frontend/src/features/cookbook/pages/detail.tsx
@@ -293,7 +293,7 @@ export function CookbookDetailPage() {
 
             <TabsContent value="flow" className="mt-4">
               {sagaFlow && sagaFlow.steps.length > 0 && firstStarlarkContent ? (
-                <LinkedPatternDetail flow={sagaFlow} starlarkContent={firstStarlarkContent} />
+                <LinkedPatternDetail flow={sagaFlow} />
               ) : (
                 <p className="text-sm text-muted-foreground">No saga flow detected in Starlark source.</p>
               )}


### PR DESCRIPTION
## Summary

- Remove the redundant StarlarkEditor panel from the Flow tab's `LinkedPatternDetail` component
- The Starlark source is already available on the adjacent Starlark tab; the 45/55 split was causing the diagram to clip on complex patterns
- The `SagaFlowDiagram` now renders at full width with the Handler Reference below it

## Changes Made

- **`linked-detail.tsx`**: Removed `StarlarkEditor` import, `editorViewRef` state, editor dispatch in `handleStepClick`, split layout, and `starlarkContent` prop
- **`detail.tsx`**: Removed `starlarkContent` prop from `LinkedPatternDetail` call site
- **`linked-detail.test.tsx`**: Removed CodeMirror mocks and editor-related assertions; added test verifying editor panel is absent

## Test Plan

- [x] All 7 existing tests updated and passing
- [x] New test confirms StarlarkEditor is not rendered
- [x] Handler reference highlighting still works on step click
- [x] Flow diagram renders without width constraints

035-meridian-cookbook.14