### PR TITLE
fix: widen composition graph nodes and add hover tooltips

### DIFF
--- a/frontend/src/features/cookbook/components/composition-graph.test.tsx
+++ b/frontend/src/features/cookbook/components/composition-graph.test.tsx
@@ -13,6 +13,15 @@ vi.mock('@/api/clients', () => ({
   createServiceClients: vi.fn(() => ({})),
 }))
 
+vi.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="tooltip-content">{children}</div>
+  ),
+}))
+
 // Mock @xyflow/react
 vi.mock('@xyflow/react', () => {
   const Position = { Top: 'top', Bottom: 'bottom', Left: 'left', Right: 'right' }
@@ -23,8 +32,8 @@ vi.mock('@xyflow/react', () => {
   function ReactFlow({ nodes, edges, children }: { nodes: unknown[]; edges: unknown[]; children?: React.ReactNode }) {
     return (
       <div data-testid="react-flow" data-node-count={nodes.length} data-edge-count={edges.length}>
-        {(nodes as { id: string; data: { label?: string } }[]).map((n) => (
-          <div key={n.id} data-testid={`node-${n.id}`}>
+        {(nodes as { id: string; data: { label?: string; fullTitle?: string; designPattern?: string } }[]).map((n) => (
+          <div key={n.id} data-testid={`node-${n.id}`} data-full-title={n.data?.fullTitle} data-design-pattern={n.data?.designPattern}>
             {n.data?.label ?? n.id}
           </div>
         ))}
@@ -166,5 +175,30 @@ describe('CompositionGraph', () => {
     renderGraph([])
     expect(screen.getByTestId('react-flow')).toBeInTheDocument()
     expect(screen.getByText('0 patterns')).toBeInTheDocument()
+  })
+
+  it('passes fullTitle and designPattern to node data', async () => {
+    const patternsWithDesign: CookbookItem[] = [
+      {
+        name: 'energy-trading',
+        type: 'registry:pattern',
+        title: 'Energy Trading',
+        categories: ['energy'],
+        meta: {
+          complexity: 7,
+          design_pattern: 'Saga',
+        } satisfies PatternMeta,
+      },
+    ]
+    renderGraph(patternsWithDesign)
+    const node = await screen.findByTestId('node-energy-trading')
+    expect(node).toHaveAttribute('data-full-title', 'Energy Trading')
+    expect(node).toHaveAttribute('data-design-pattern', 'Saga')
+  })
+
+  it('renders full title text in node', async () => {
+    renderGraph(patterns)
+    const node = await screen.findByText('Energy Trading')
+    expect(node).toBeInTheDocument()
   })
 })

--- a/frontend/src/features/cookbook/components/composition-graph.tsx
+++ b/frontend/src/features/cookbook/components/composition-graph.tsx
@@ -16,6 +16,12 @@ import {
 import '@xyflow/react/dist/style.css'
 import ELK from 'elkjs/lib/elk.bundled.js'
 import { useNavigate } from 'react-router-dom'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import type { CookbookItem, PatternMeta } from '../hooks/use-cookbook'
 
 const elk = new ELK()
@@ -55,6 +61,8 @@ type RelationshipType = keyof typeof EDGE_STYLES
 // Custom node component
 interface PatternNodeData {
   label: string
+  fullTitle: string
+  designPattern?: string
   complexity: number
   categories: string[]
   color: string
@@ -64,33 +72,43 @@ interface PatternNodeData {
 }
 
 function PatternNode({ data }: { data: PatternNodeData }) {
-  const size = 40 + (data.complexity ?? 1) * 12
+  const height = 40 + (data.complexity ?? 1) * 12
+  const tooltipText = data.designPattern
+    ? `${data.fullTitle} (${data.designPattern})`
+    : data.fullTitle
   return (
     <>
       <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
-      <div
-        className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150"
-        style={{
-          width: size,
-          height: size,
-          borderColor: data.color,
-          backgroundColor: `${data.color}18`,
-          opacity: data.dimmed ? 0.25 : 1,
-          boxShadow: data.highlighted ? `0 0 12px ${data.color}88` : undefined,
-        }}
-      >
-        <span className="text-[10px] font-semibold leading-tight text-foreground truncate w-full">
-          {data.label}
-        </span>
-        {data.complexity > 0 && (
-          <span
-            className="mt-0.5 inline-flex items-center justify-center rounded-full text-[8px] font-bold text-white"
-            style={{ backgroundColor: data.color, width: 16, height: 16 }}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150"
+            style={{
+              width: 180,
+              height,
+              borderColor: data.color,
+              backgroundColor: `${data.color}18`,
+              opacity: data.dimmed ? 0.25 : 1,
+              boxShadow: data.highlighted ? `0 0 12px ${data.color}88` : undefined,
+            }}
           >
-            {data.complexity}
-          </span>
-        )}
-      </div>
+            <span className="text-[10px] font-semibold leading-tight text-foreground truncate w-full">
+              {data.label}
+            </span>
+            {data.complexity > 0 && (
+              <span
+                className="mt-0.5 inline-flex items-center justify-center rounded-full text-[8px] font-bold text-white"
+                style={{ backgroundColor: data.color, width: 16, height: 16 }}
+              >
+                {data.complexity}
+              </span>
+            )}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          {tooltipText}
+        </TooltipContent>
+      </Tooltip>
       <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
     </>
   )
@@ -189,8 +207,8 @@ async function layoutGraph(
 ): Promise<Node[]> {
   const elkNodes = patterns.map((p) => {
     const complexity = (p.meta as PatternMeta | undefined)?.complexity ?? 1
-    const size = 40 + complexity * 12
-    return { id: p.name, width: size + 20, height: size + 20 }
+    const height = 40 + complexity * 12
+    return { id: p.name, width: 200, height: height + 20 }
   })
 
   const elkEdges = edges.map((e) => ({
@@ -204,7 +222,7 @@ async function layoutGraph(
     layoutOptions: {
       'elk.algorithm': 'layered',
       'elk.direction': 'DOWN',
-      'elk.spacing.nodeNode': '80',
+      'elk.spacing.nodeNode': '60',
       'elk.layered.spacing.nodeNodeBetweenLayers': '100',
     },
     children: elkNodes,
@@ -221,6 +239,8 @@ async function layoutGraph(
       position: { x: elkNode?.x ?? 0, y: elkNode?.y ?? 0 },
       data: {
         label: p.title,
+        fullTitle: p.title,
+        designPattern: meta?.design_pattern,
         complexity: meta?.complexity ?? 1,
         categories: p.categories ?? [],
         color,
@@ -376,6 +396,7 @@ export function CompositionGraph({ patterns, className }: CompositionGraphProps)
 
   return (
     <div className={className} style={{ width: '100%', height: '100%' }}>
+      <TooltipProvider>
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -395,6 +416,7 @@ export function CompositionGraph({ patterns, className }: CompositionGraphProps)
           maskColor="rgba(0, 0, 0, 0.15)"
         />
       </ReactFlow>
+      </TooltipProvider>
 
       {/* Filter sidebar */}
       <div className="absolute top-3 left-3 z-10 flex flex-col gap-2 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm">


### PR DESCRIPTION
## Summary

- Increase PatternNode base width from ~40px to 180px so pattern labels are fully readable instead of truncated to 3-5 characters
- Add hover tooltips showing full pattern title and design pattern type (e.g., "Energy Trading (Saga)")
- Pass `fullTitle` and `designPattern` fields through node data for tooltip display
- Adjust ELK layout spacing for wider nodes

## Task Reference

035-meridian-cookbook.15 - Bug #9: Fix Composition Graph node label truncation

## Test plan

- [x] All 9 composition-graph tests pass (7 existing + 2 new)
- [x] New test verifies `fullTitle` and `designPattern` data attributes are passed to nodes
- [x] New test verifies full title text renders in nodes