### PR TITLE
fix: fix complexity tooltip and remove design-pattern slug from cards

### DIFF
--- a/frontend/src/features/cookbook/components/catalogue-grid.test.tsx
+++ b/frontend/src/features/cookbook/components/catalogue-grid.test.tsx
@@ -90,8 +90,14 @@ describe('CatalogueGrid', () => {
     expect(indicators.length).toBe(1)
   })
 
-  it('shows design pattern label', () => {
+  it('has accessible complexity label', () => {
     renderGrid(mockItems)
-    expect(screen.getByText('saga')).toBeInTheDocument()
+    const indicator = screen.getByTestId('complexity-indicator')
+    expect(indicator).toHaveAttribute('aria-label', 'Complexity: 7 — High')
+  })
+
+  it('does not show design pattern slug on card', () => {
+    renderGrid(mockItems)
+    expect(screen.queryByText('saga')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/features/cookbook/components/catalogue-grid.tsx
+++ b/frontend/src/features/cookbook/components/catalogue-grid.tsx
@@ -15,13 +15,22 @@ function isPatternMeta(meta: PatternMeta | ComponentMeta | undefined): meta is P
   return meta !== undefined && 'complexity' in meta
 }
 
+function complexityLabel(score: number): string {
+  if (score <= 2) return 'Simple'
+  if (score <= 4) return 'Low'
+  if (score <= 6) return 'Moderate'
+  if (score <= 8) return 'High'
+  return 'Very High'
+}
+
 function ComplexityIndicator({ score }: { score: number }) {
+  const label = complexityLabel(score)
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <span
           tabIndex={0}
-          aria-label={`Complexity: ${score}/10`}
+          aria-label={`Complexity: ${score} — ${label}`}
           className="flex items-center gap-1"
           data-testid="complexity-indicator"
         >
@@ -35,7 +44,7 @@ function ComplexityIndicator({ score }: { score: number }) {
           ))}
         </span>
       </TooltipTrigger>
-      <TooltipContent>Complexity: {score}/10</TooltipContent>
+      <TooltipContent side="top" sideOffset={4}>Complexity: {score} — {label}</TooltipContent>
     </Tooltip>
   )
 }
@@ -93,11 +102,8 @@ function CookbookCard({ item }: { item: CookbookItem }) {
       )}
 
       {patternMeta?.complexity !== undefined && (
-        <CardFooter className="justify-between">
+        <CardFooter>
           <ComplexityIndicator score={patternMeta.complexity} />
-          {patternMeta.design_pattern && (
-            <span className="text-[10px] text-muted-foreground">{patternMeta.design_pattern}</span>
-          )}
         </CardFooter>
       )}
     </Card>


### PR DESCRIPTION
## Summary

- Fix Bug #10: Complexity dot indicators on pattern cards now show a human-readable tooltip (e.g., "Complexity: 7 — High") with proper positioning (`side="top"`, `sideOffset=4`)
- Task 19: Remove design-pattern slug from card footers — the slug occupied visual space without being interactive. It remains on the detail page.

## Task Master

- 035-meridian-cookbook.16 — Bug #10: Fix complexity tooltip on pattern cards
- 035-meridian-cookbook.19 — T3: Remove design-pattern slug from pattern card footers

## Changes Made

**`frontend/src/features/cookbook/components/catalogue-grid.tsx`**
- Add `complexityLabel()` helper that maps score ranges to descriptive labels (Simple, Low, Moderate, High, Very High)
- Update `ComplexityIndicator` tooltip content from `Complexity: N/10` to `Complexity: N — Label`
- Add `side="top"` and `sideOffset={4}` to `TooltipContent` for visible positioning
- Remove `design_pattern` display from `CardFooter`
- Remove `justify-between` class from `CardFooter` (single child element now)

**`frontend/src/features/cookbook/components/catalogue-grid.test.tsx`**
- Add test: complexity indicator has accessible aria-label with descriptive level
- Replace design-pattern assertion with negative test confirming slug is not shown on card

## Test Plan

- [x] All 9 catalogue-grid tests pass
- [ ] Visual verification: hover over complexity dots shows tooltip
- [ ] Visual verification: design-pattern slug no longer appears on cards