### PR TITLE
fix: taxonomy and metadata cleanup for cookbook patterns

### DIFF
--- a/cookbook/patterns/base-fiat-gbp/pattern.json
+++ b/cookbook/patterns/base-fiat-gbp/pattern.json
@@ -9,7 +9,7 @@
     "meta": {
         "complexity": 1,
         "design_pattern": "foundation-denomination",
-        "industries": ["all"],
+        "industries": [],
         "provides": {
             "instruments": ["GBP"],
             "account_types": [],

--- a/cookbook/patterns/base-fiat-usd/pattern.json
+++ b/cookbook/patterns/base-fiat-usd/pattern.json
@@ -9,7 +9,7 @@
     "meta": {
         "complexity": 1,
         "design_pattern": "foundation-denomination",
-        "industries": ["all"],
+        "industries": [],
         "provides": {
             "instruments": ["USD"],
             "account_types": [],

--- a/cookbook/patterns/carbon-offset/pattern.json
+++ b/cookbook/patterns/carbon-offset/pattern.json
@@ -5,7 +5,7 @@
     "title": "Carbon Credit Registry",
     "description": "Carbon credit trading and retirement with verified emission reductions (VERs) and certified emission reductions (CERs). Tracks credit provenance by vintage year and project, with a permanent retirement account for irrevocable credit retirement.",
     "registryDependencies": ["base-fiat-usd"],
-    "categories": ["economy", "carbon", "sustainability", "trading"],
+    "categories": ["carbon", "sustainability", "trading"],
     "meta": {
         "complexity": 5,
         "design_pattern": "credit-retirement-lifecycle",

--- a/cookbook/patterns/dynamic-capacity-pricing/pattern.json
+++ b/cookbook/patterns/dynamic-capacity-pricing/pattern.json
@@ -5,7 +5,7 @@
     "title": "Dynamic Capacity Pricing",
     "description": "Self-referential feedback loop pricing for compute tokens. Bills token consumption at rates derived from the platform's own utilisation forecasts per data centre region. Usage patterns drive pricing, and pricing shapes usage patterns.",
     "registryDependencies": ["base-fiat-usd"],
-    "categories": ["economy", "compute", "pricing", "dynamic"],
+    "categories": ["compute", "pricing", "dynamic"],
     "meta": {
         "complexity": 5,
         "design_pattern": "feedback-loop-pricing",

--- a/cookbook/patterns/energy-settlement/pattern.json
+++ b/cookbook/patterns/energy-settlement/pattern.json
@@ -8,6 +8,7 @@
     "categories": ["energy", "utilities", "cross-instrument"],
     "meta": {
         "complexity": 3,
+        "trigger": "event-driven",
         "design_pattern": "cross-instrument-valuation",
         "industries": ["energy", "utilities"],
         "provides": {

--- a/cookbook/patterns/entity-distribution/pattern.json
+++ b/cookbook/patterns/entity-distribution/pattern.json
@@ -5,9 +5,10 @@
     "title": "Entity Hierarchy Distribution",
     "description": "Distributes value across a party hierarchy based on structuring data (allocation shares). Triggered by market data events, traverses the party organization graph to find participants and their payout ratios, then books proportional position logs for each participant.",
     "registryDependencies": ["base-fiat-gbp"],
-    "categories": ["distribution", "party-hierarchy", "event-driven"],
+    "categories": ["distribution", "party-hierarchy"],
     "meta": {
         "complexity": 5,
+        "trigger": "event-driven",
         "design_pattern": "party-hierarchy-distribution",
         "industries": ["gaming", "syndication"],
         "provides": {

--- a/cookbook/patterns/entity-distribution/pattern.json
+++ b/cookbook/patterns/entity-distribution/pattern.json
@@ -5,7 +5,7 @@
     "title": "Entity Hierarchy Distribution",
     "description": "Distributes value across a party hierarchy based on structuring data (allocation shares). Triggered by market data events, traverses the party organization graph to find participants and their payout ratios, then books proportional position logs for each participant.",
     "registryDependencies": ["base-fiat-gbp"],
-    "categories": ["economy", "distribution", "party-hierarchy", "event-driven"],
+    "categories": ["distribution", "party-hierarchy", "event-driven"],
     "meta": {
         "complexity": 5,
         "design_pattern": "party-hierarchy-distribution",

--- a/cookbook/patterns/kyc-compliance/pattern.json
+++ b/cookbook/patterns/kyc-compliance/pattern.json
@@ -10,7 +10,7 @@
         "complexity": 3,
         "trigger": "event-driven",
         "design_pattern": "compliance-marker",
-        "industries": ["banking", "compliance"],
+        "industries": ["banking"],
         "provides": {
             "instruments": [],
             "account_types": ["KYC_COMPLIANCE"],

--- a/cookbook/patterns/kyc-compliance/pattern.json
+++ b/cookbook/patterns/kyc-compliance/pattern.json
@@ -5,9 +5,10 @@
     "title": "KYC Compliance Workflow",
     "description": "Initiates KYC verification when an individual party is created. Uses the compliance marker pattern: books a zero-amount position log to track outstanding KYC obligations per jurisdiction. Compliance accounts are resolved via entity graph traversal.",
     "registryDependencies": ["base-fiat-gbp"],
-    "categories": ["compliance", "kyc", "event-driven"],
+    "categories": ["compliance", "kyc"],
     "meta": {
         "complexity": 3,
+        "trigger": "event-driven",
         "design_pattern": "compliance-marker",
         "industries": ["banking", "compliance"],
         "provides": {

--- a/cookbook/patterns/kyc-compliance/pattern.json
+++ b/cookbook/patterns/kyc-compliance/pattern.json
@@ -5,7 +5,7 @@
     "title": "KYC Compliance Workflow",
     "description": "Initiates KYC verification when an individual party is created. Uses the compliance marker pattern: books a zero-amount position log to track outstanding KYC obligations per jurisdiction. Compliance accounts are resolved via entity graph traversal.",
     "registryDependencies": ["base-fiat-gbp"],
-    "categories": ["economy", "compliance", "kyc", "event-driven"],
+    "categories": ["compliance", "kyc", "event-driven"],
     "meta": {
         "complexity": 3,
         "design_pattern": "compliance-marker",

--- a/cookbook/patterns/payment-gateway-stripe/pattern.json
+++ b/cookbook/patterns/payment-gateway-stripe/pattern.json
@@ -5,7 +5,7 @@
     "title": "Stripe Payment Gateway",
     "description": "Stripe payment integration via the Operational Gateway abstraction layer. Includes provider connection configuration, outbound/inbound mapping definitions for payload transformation, instruction routing, and a multi-step saga with lien reservation, gateway dispatch, and conditional ledger posting.",
     "registryDependencies": ["base-fiat-gbp"],
-    "categories": ["economy", "payments", "gateway", "integration"],
+    "categories": ["payments", "gateway", "integration"],
     "meta": {
         "complexity": 8,
         "design_pattern": "operational-gateway",

--- a/cookbook/patterns/phantom-cost-basis/pattern.json
+++ b/cookbook/patterns/phantom-cost-basis/pattern.json
@@ -10,7 +10,7 @@
         "complexity": 5,
         "trigger": "event-driven",
         "design_pattern": "phantom-transaction-event",
-        "industries": ["trading", "corporate-actions"],
+        "industries": ["trading"],
         "provides": {
             "instruments": [],
             "account_types": [],

--- a/cookbook/patterns/phantom-cost-basis/pattern.json
+++ b/cookbook/patterns/phantom-cost-basis/pattern.json
@@ -5,9 +5,10 @@
     "title": "Phantom Cost Basis Adjustment",
     "description": "Adjusts cost basis for all holdings of an instrument when a corporate action occurs. Handles phantom events where no cash or units move but the tax position changes, such as accumulating ETF dividends. The cost basis account position log serves as the HMRC audit trail.",
     "registryDependencies": ["base-fiat-gbp"],
-    "categories": ["corporate-actions", "cost-basis", "event-driven"],
+    "categories": ["corporate-actions", "cost-basis"],
     "meta": {
         "complexity": 5,
+        "trigger": "event-driven",
         "design_pattern": "phantom-transaction-event",
         "industries": ["trading", "corporate-actions"],
         "provides": {

--- a/cookbook/patterns/phantom-cost-basis/pattern.json
+++ b/cookbook/patterns/phantom-cost-basis/pattern.json
@@ -5,7 +5,7 @@
     "title": "Phantom Cost Basis Adjustment",
     "description": "Adjusts cost basis for all holdings of an instrument when a corporate action occurs. Handles phantom events where no cash or units move but the tax position changes, such as accumulating ETF dividends. The cost basis account position log serves as the HMRC audit trail.",
     "registryDependencies": ["base-fiat-gbp"],
-    "categories": ["economy", "corporate-actions", "cost-basis", "event-driven"],
+    "categories": ["corporate-actions", "cost-basis", "event-driven"],
     "meta": {
         "complexity": 5,
         "design_pattern": "phantom-transaction-event",

--- a/cookbook/patterns/precious-metals/pattern.json
+++ b/cookbook/patterns/precious-metals/pattern.json
@@ -5,7 +5,7 @@
     "title": "Precious Metals Trading",
     "description": "Precious metals trading platform with event-triggered valuation. When gold, silver, or platinum positions are captured, an event-driven saga automatically books the GBP settlement value at the current spot rate from LBMA/LPPM price fixes.",
     "registryDependencies": ["base-fiat-gbp"],
-    "categories": ["economy", "commodities", "trading", "event-driven"],
+    "categories": ["commodities", "trading", "event-driven"],
     "meta": {
         "complexity": 5,
         "design_pattern": "valuation-on-capture",

--- a/cookbook/patterns/precious-metals/pattern.json
+++ b/cookbook/patterns/precious-metals/pattern.json
@@ -5,9 +5,10 @@
     "title": "Precious Metals Trading",
     "description": "Precious metals trading platform with event-triggered valuation. When gold, silver, or platinum positions are captured, an event-driven saga automatically books the GBP settlement value at the current spot rate from LBMA/LPPM price fixes.",
     "registryDependencies": ["base-fiat-gbp"],
-    "categories": ["commodities", "trading", "event-driven"],
+    "categories": ["commodities", "trading"],
     "meta": {
         "complexity": 5,
+        "trigger": "event-driven",
         "design_pattern": "valuation-on-capture",
         "industries": ["commodities", "trading"],
         "provides": {

--- a/cookbook/patterns/precious-metals/pattern.json
+++ b/cookbook/patterns/precious-metals/pattern.json
@@ -5,7 +5,7 @@
     "title": "Precious Metals Trading",
     "description": "Precious metals trading platform with event-triggered valuation. When gold, silver, or platinum positions are captured, an event-driven saga automatically books the GBP settlement value at the current spot rate from LBMA/LPPM price fixes.",
     "registryDependencies": ["base-fiat-gbp"],
-    "categories": ["commodities", "trading"],
+    "categories": ["trading"],
     "meta": {
         "complexity": 5,
         "trigger": "event-driven",

--- a/cookbook/patterns/saas-billing/pattern.json
+++ b/cookbook/patterns/saas-billing/pattern.json
@@ -5,7 +5,7 @@
     "title": "SaaS Compute Billing",
     "description": "Usage-based billing for cloud compute resources. Meters GPU hours, API calls, and storage consumption, then converts to USD charges via valuation rules. Includes platform credits as a voucher instrument.",
     "registryDependencies": ["base-fiat-usd"],
-    "categories": ["economy", "billing", "compute", "usage-metering"],
+    "categories": ["billing", "compute", "usage-metering"],
     "meta": {
         "complexity": 5,
         "design_pattern": "compute-metering",

--- a/cookbook/patterns/time-of-use-pricing/pattern.json
+++ b/cookbook/patterns/time-of-use-pricing/pattern.json
@@ -5,7 +5,7 @@
     "title": "Time-of-Use Energy Pricing",
     "description": "Extends energy settlement with temporal pricing awareness. Values kWh consumption at dynamic rates that vary by settlement period (half-hour), using forecast-derived price curves from Market Data. Peak, off-peak, and overnight rates are resolved from the event timestamp.",
     "registryDependencies": ["base-fiat-gbp"],
-    "categories": ["economy", "energy", "pricing", "temporal"],
+    "categories": ["energy", "pricing", "temporal"],
     "meta": {
         "complexity": 5,
         "design_pattern": "time-based-pricing",

--- a/cookbook/schema/registry-item.json
+++ b/cookbook/schema/registry-item.json
@@ -119,6 +119,10 @@
                         "enum": [1, 2, 3, 5, 8],
                         "description": "Story point complexity estimate (Fibonacci: 1, 2, 3, 5, 8)."
                     },
+                    "trigger": {
+                        "type": "string",
+                        "description": "How the pattern is activated (e.g. event-driven, api, scheduled)."
+                    },
                     "design_pattern": {
                         "type": ["string", "null"],
                         "description": "Reference to a Meridian design patterns guide entry."

--- a/cookbook/ui/handler-reference/component.json
+++ b/cookbook/ui/handler-reference/component.json
@@ -4,7 +4,7 @@
     "type": "registry:ui",
     "title": "Handler Reference",
     "description": "Interactive accordion reference panel listing all Starlark handler services and their parameters. Fetches schemas from the DescribeHandlers API, supports text filtering, and provides an insert-template button that emits a Starlark call stub for each handler.",
-    "categories": ["editor", "reference", "starlark", "sagas"],
+    "categories": ["editor", "reference", "starlark", "saga"],
     "registryDependencies": [],
     "files": [
         {

--- a/frontend/src/features/cookbook/hooks/use-cookbook.ts
+++ b/frontend/src/features/cookbook/hooks/use-cookbook.ts
@@ -11,6 +11,7 @@ export interface CookbookItem {
 
 export interface PatternMeta {
   complexity?: number
+  trigger?: string
   design_pattern?: string
   industries?: string[]
   provides?: {

--- a/frontend/src/features/cookbook/pages/detail.tsx
+++ b/frontend/src/features/cookbook/pages/detail.tsx
@@ -54,6 +54,12 @@ function PatternInfoSection({ item }: { item: CookbookItem }) {
             <span className="font-medium">{meta.design_pattern}</span>
           </div>
         )}
+        {meta?.trigger && (
+          <div className="flex items-center gap-1.5">
+            <span className="text-muted-foreground">Trigger:</span>
+            <Badge variant="secondary" className="text-xs">{meta.trigger}</Badge>
+          </div>
+        )}
         {item.categories && item.categories.length > 0 && (
           <div className="flex items-center gap-1.5">
             <span className="text-muted-foreground">Categories:</span>

--- a/frontend/src/features/cookbook/pages/detail.tsx
+++ b/frontend/src/features/cookbook/pages/detail.tsx
@@ -70,14 +70,18 @@ function PatternInfoSection({ item }: { item: CookbookItem }) {
             ))}
           </div>
         )}
-        {meta?.industries && meta.industries.length > 0 && (
+        {meta?.industries != null && (
           <div className="flex items-center gap-1.5">
             <span className="text-muted-foreground">Industries:</span>
-            {meta.industries.map((ind) => (
-              <Badge key={ind} variant="secondary" className="text-xs">
-                {ind}
-              </Badge>
-            ))}
+            {meta.industries.length > 0 ? (
+              meta.industries.map((ind) => (
+                <Badge key={ind} variant="secondary" className="text-xs">
+                  {ind}
+                </Badge>
+              ))
+            ) : (
+              <span className="text-xs text-muted-foreground italic">Industry-agnostic</span>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Cleans up taxonomy inconsistencies across cookbook pattern and UI component metadata:

- Remove redundant `economy` category tag from all 9 patterns (035-meridian-cookbook.17)
- Extract `event-driven` from categories into a dedicated `meta.trigger` field with JSON schema and UI support (035-meridian-cookbook.18)
- Replace literal `"all"` industry value with empty array, display "Industry-agnostic" in UI (035-meridian-cookbook.20)
- Resolve category/industry tag overlaps in kyc-compliance, precious-metals, phantom-cost-basis (035-meridian-cookbook.21)
- Standardize singular form for UI component category tags (035-meridian-cookbook.22)

## Changes Made

**Pattern metadata** (cookbook/patterns/*/pattern.json):
- Removed `economy` from categories in all patterns
- Removed `event-driven` from categories where present; added `meta.trigger: "event-driven"` to kyc-compliance, precious-metals, phantom-cost-basis, entity-distribution, energy-settlement
- Changed `industries: ["all"]` to `industries: []` in base-fiat-gbp and base-fiat-usd
- Removed `compliance` from kyc-compliance industries (keep in categories)
- Removed `commodities` from precious-metals categories (keep in industries)
- Removed `corporate-actions` from phantom-cost-basis industries (keep in categories)

**JSON schema** (cookbook/schema/registry-item.json):
- Added `trigger` string property to pattern meta schema

**Frontend** (frontend/src/features/cookbook/):
- Added `trigger?: string` to `PatternMeta` interface
- Display trigger badge in PatternInfoSection
- Show "Industry-agnostic" when industries array is empty

**UI components** (cookbook/ui/handler-reference/component.json):
- Changed `sagas` to `saga` in categories for consistency with other components

## Test plan

- [x] `go test ./cookbook/...` -- all pattern validation, schema, and composition tests pass
- [ ] CI passes