### PR TITLE
fix: Resolve PartyID from account ownership in variance valuator

### DIFF
--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -177,6 +177,13 @@ message CurrentAccountFacility {
   // Derived from product_type_code at creation time and stored for query efficiency.
   // Examples: "CUSTOMER", "CLEARING", "NOSTRO". Empty for legacy accounts.
   string behavior_class = 15;
+
+  // party_id references the owning party from the Party Service.
+  // Set at account creation and immutable thereafter.
+  string party_id = 16 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+  }];
 }
 
 // AccountBalance represents the current balance state of an account

--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -181,7 +181,6 @@ message CurrentAccountFacility {
   // party_id references the owning party from the Party Service.
   // Set at account creation and immutable thereafter.
   string party_id = 16 [(buf.validate.field).string = {
-    min_len: 1
     max_len: 100
   }];
 }

--- a/services/current-account/service/grpc_mappers.go
+++ b/services/current-account/service/grpc_mappers.go
@@ -32,6 +32,7 @@ func toProtoFacility(account domain.CurrentAccount) *pb.CurrentAccountFacility {
 		// #nosec G115 - ProductTypeVersion is bounded by database constraints
 		ProductTypeVersion: int32(account.ProductTypeVersion()),
 		BehaviorClass:      account.BehaviorClass(),
+		PartyId:            account.PartyID(),
 	}
 }
 

--- a/services/reconciliation/cmd/main.go
+++ b/services/reconciliation/cmd/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
 	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
@@ -227,7 +228,30 @@ func run(logger *slog.Logger) error {
 			}
 		}
 	}()
-	valuator := service.NewVarianceValuator(valuationEngine, refDataProvider, varianceRepo, runRepo)
+	// Wire AccountPartyResolver if Current Account URL is configured
+	var partyResolver service.AccountPartyResolver
+	if cfg.Services.CurrentAccountURL != "" {
+		caConn, caErr := grpc.NewClient(
+			cfg.Services.CurrentAccountURL,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if caErr != nil {
+			logger.Warn("failed to create current account gRPC client, party resolution will fall back to account ID",
+				"error", caErr)
+		} else {
+			defer func() {
+				if err := caConn.Close(); err != nil {
+					logger.Error("failed to close current account connection", "error", err)
+				}
+			}()
+			caClient := currentaccountv1.NewCurrentAccountServiceClient(caConn)
+			partyResolver = service.NewGRPCAccountPartyResolver(caClient)
+			logger.Info("current account party resolver configured",
+				"current_account_url", cfg.Services.CurrentAccountURL)
+		}
+	}
+
+	valuator := service.NewVarianceValuator(valuationEngine, refDataProvider, partyResolver, varianceRepo, runRepo)
 	serviceOpts = append(serviceOpts,
 		service.WithVarianceValuator(valuator.ValueVariances),
 	)

--- a/services/reconciliation/service/account_party_resolver.go
+++ b/services/reconciliation/service/account_party_resolver.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+)
+
+var (
+	// ErrNoFacilityReturned is returned when the Current Account service returns no facility.
+	ErrNoFacilityReturned = errors.New("no facility returned for account")
+
+	// ErrNoPartyID is returned when the account has no party_id set.
+	ErrNoPartyID = errors.New("account has no party_id")
+)
+
+// AccountPartyResolver resolves the owning party ID for a given account.
+type AccountPartyResolver interface {
+	// ResolvePartyID returns the party UUID that owns the given account.
+	ResolvePartyID(ctx context.Context, accountID string) (uuid.UUID, error)
+}
+
+// GRPCAccountPartyResolver resolves party IDs by calling the Current Account gRPC service.
+type GRPCAccountPartyResolver struct {
+	client currentaccountv1.CurrentAccountServiceClient
+}
+
+// NewGRPCAccountPartyResolver creates a resolver backed by the Current Account gRPC service.
+func NewGRPCAccountPartyResolver(client currentaccountv1.CurrentAccountServiceClient) *GRPCAccountPartyResolver {
+	return &GRPCAccountPartyResolver{client: client}
+}
+
+// ResolvePartyID calls RetrieveCurrentAccount and extracts the party_id.
+func (r *GRPCAccountPartyResolver) ResolvePartyID(ctx context.Context, accountID string) (uuid.UUID, error) {
+	resp, err := r.client.RetrieveCurrentAccount(ctx, &currentaccountv1.RetrieveCurrentAccountRequest{
+		AccountId: accountID,
+	})
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("failed to retrieve account %s: %w", accountID, err)
+	}
+
+	facility := resp.GetFacility()
+	if facility == nil {
+		return uuid.Nil, fmt.Errorf("%w: %s", ErrNoFacilityReturned, accountID)
+	}
+
+	partyIDStr := facility.GetPartyId()
+	if partyIDStr == "" {
+		return uuid.Nil, fmt.Errorf("%w: %s", ErrNoPartyID, accountID)
+	}
+
+	partyID, err := uuid.Parse(partyIDStr)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("invalid party_id %q for account %s: %w", partyIDStr, accountID, err)
+	}
+
+	return partyID, nil
+}

--- a/services/reconciliation/service/account_party_resolver_test.go
+++ b/services/reconciliation/service/account_party_resolver_test.go
@@ -1,0 +1,110 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// mockCurrentAccountClient is a test double for the CurrentAccountServiceClient.
+type mockCurrentAccountClient struct {
+	currentaccountv1.CurrentAccountServiceClient
+	resp *currentaccountv1.RetrieveCurrentAccountResponse
+	err  error
+}
+
+func (m *mockCurrentAccountClient) RetrieveCurrentAccount(
+	_ context.Context,
+	_ *currentaccountv1.RetrieveCurrentAccountRequest,
+	_ ...grpc.CallOption,
+) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+	return m.resp, m.err
+}
+
+func TestGRPCAccountPartyResolver_ResolvePartyID_Success(t *testing.T) {
+	partyID := uuid.New()
+	client := &mockCurrentAccountClient{
+		resp: &currentaccountv1.RetrieveCurrentAccountResponse{
+			Facility: &currentaccountv1.CurrentAccountFacility{
+				AccountId: "ACC-001",
+				PartyId:   partyID.String(),
+			},
+		},
+	}
+
+	resolver := NewGRPCAccountPartyResolver(client)
+	result, err := resolver.ResolvePartyID(context.Background(), "ACC-001")
+
+	require.NoError(t, err)
+	assert.Equal(t, partyID, result)
+}
+
+func TestGRPCAccountPartyResolver_ResolvePartyID_GRPCError(t *testing.T) {
+	client := &mockCurrentAccountClient{
+		err: errors.New("connection refused"),
+	}
+
+	resolver := NewGRPCAccountPartyResolver(client)
+	result, err := resolver.ResolvePartyID(context.Background(), "ACC-001")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to retrieve account ACC-001")
+	assert.Equal(t, uuid.Nil, result)
+}
+
+func TestGRPCAccountPartyResolver_ResolvePartyID_NilFacility(t *testing.T) {
+	client := &mockCurrentAccountClient{
+		resp: &currentaccountv1.RetrieveCurrentAccountResponse{
+			Facility: nil,
+		},
+	}
+
+	resolver := NewGRPCAccountPartyResolver(client)
+	result, err := resolver.ResolvePartyID(context.Background(), "ACC-001")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoFacilityReturned)
+	assert.Equal(t, uuid.Nil, result)
+}
+
+func TestGRPCAccountPartyResolver_ResolvePartyID_EmptyPartyID(t *testing.T) {
+	client := &mockCurrentAccountClient{
+		resp: &currentaccountv1.RetrieveCurrentAccountResponse{
+			Facility: &currentaccountv1.CurrentAccountFacility{
+				AccountId: "ACC-001",
+				PartyId:   "",
+			},
+		},
+	}
+
+	resolver := NewGRPCAccountPartyResolver(client)
+	result, err := resolver.ResolvePartyID(context.Background(), "ACC-001")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoPartyID)
+	assert.Equal(t, uuid.Nil, result)
+}
+
+func TestGRPCAccountPartyResolver_ResolvePartyID_InvalidPartyID(t *testing.T) {
+	client := &mockCurrentAccountClient{
+		resp: &currentaccountv1.RetrieveCurrentAccountResponse{
+			Facility: &currentaccountv1.CurrentAccountFacility{
+				AccountId: "ACC-001",
+				PartyId:   "not-a-uuid",
+			},
+		},
+	}
+
+	resolver := NewGRPCAccountPartyResolver(client)
+	result, err := resolver.ResolvePartyID(context.Background(), "ACC-001")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid party_id")
+	assert.Equal(t, uuid.Nil, result)
+}

--- a/services/reconciliation/service/variance_valuator.go
+++ b/services/reconciliation/service/variance_valuator.go
@@ -40,26 +40,29 @@ type ReferenceDataProvider interface {
 // It calls the valuation engine in-process (not via gRPC) to convert quantity deltas
 // into monetary value deltas in settlement currency.
 type VarianceValuator struct {
-	engine       valuation.Engine
-	refData      ReferenceDataProvider
-	varianceRepo domain.VarianceRepository
-	runRepo      domain.SettlementRunRepository
-	concurrency  int
+	engine        valuation.Engine
+	refData       ReferenceDataProvider
+	partyResolver AccountPartyResolver
+	varianceRepo  domain.VarianceRepository
+	runRepo       domain.SettlementRunRepository
+	concurrency   int
 }
 
 // NewVarianceValuator creates a new VarianceValuator.
 func NewVarianceValuator(
 	engine valuation.Engine,
 	refData ReferenceDataProvider,
+	partyResolver AccountPartyResolver,
 	varianceRepo domain.VarianceRepository,
 	runRepo domain.SettlementRunRepository,
 ) *VarianceValuator {
 	return &VarianceValuator{
-		engine:       engine,
-		refData:      refData,
-		varianceRepo: varianceRepo,
-		runRepo:      runRepo,
-		concurrency:  defaultValuationConcurrency,
+		engine:        engine,
+		refData:       refData,
+		partyResolver: partyResolver,
+		varianceRepo:  varianceRepo,
+		runRepo:       runRepo,
+		concurrency:   defaultValuationConcurrency,
 	}
 }
 
@@ -174,6 +177,16 @@ func (vv *VarianceValuator) valueVariance(ctx context.Context, v *domain.Varianc
 		return nil, decimal.Zero, fmt.Errorf("failed to get valuation method for %s: %w", v.InstrumentCode, err)
 	}
 
+	// Resolve the owning party for this account
+	partyID, err := vv.resolvePartyID(ctx, v.AccountID)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to resolve party for account, falling back to account ID",
+			"account_id", v.AccountID,
+			"error", err,
+		)
+		partyID = uuidFromString(v.AccountID)
+	}
+
 	// Build valuation request
 	req := &valuation.Request{
 		RequestID: uuid.New(),
@@ -184,7 +197,7 @@ func (vv *VarianceValuator) valueVariance(ctx context.Context, v *domain.Varianc
 			Attributes:     v.Attributes,
 		},
 		AccountID:   uuidFromString(v.AccountID),
-		PartyID:     uuidFromString(v.AccountID), // TODO: resolve from tenant/party context when available
+		PartyID:     partyID,
 		KnowledgeAt: v.CreatedAt,
 	}
 
@@ -221,6 +234,15 @@ func (vv *VarianceValuator) valueVariance(ctx context.Context, v *domain.Varianc
 	}
 
 	return v, valueDelta, nil
+}
+
+// resolvePartyID resolves the owning party ID for an account.
+// If no resolver is configured, it falls back to parsing the account ID as a UUID.
+func (vv *VarianceValuator) resolvePartyID(ctx context.Context, accountID string) (uuid.UUID, error) {
+	if vv.partyResolver == nil {
+		return uuidFromString(accountID), nil
+	}
+	return vv.partyResolver.ResolvePartyID(ctx, accountID)
 }
 
 // uuidFromString tries to parse a string as UUID, returns uuid.Nil on failure.

--- a/services/reconciliation/service/variance_valuator.go
+++ b/services/reconciliation/service/variance_valuator.go
@@ -104,6 +104,23 @@ func (vv *VarianceValuator) ValueVariances(ctx context.Context, runID uuid.UUID)
 		"variance_count", len(detected),
 	)
 
+	// Pre-resolve party IDs to avoid N+1 gRPC calls per variance.
+	// Multiple variances may share the same account, so we deduplicate lookups.
+	partyIDs := make(map[string]uuid.UUID)
+	for _, v := range detected {
+		if _, ok := partyIDs[v.AccountID]; !ok {
+			pid, pidErr := vv.resolvePartyID(ctx, v.AccountID)
+			if pidErr != nil {
+				slog.WarnContext(ctx, "failed to resolve party for account, falling back to account ID",
+					"account_id", v.AccountID,
+					"error", pidErr,
+				)
+				pid = uuidFromString(v.AccountID)
+			}
+			partyIDs[v.AccountID] = pid
+		}
+	}
+
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(vv.concurrency)
 
@@ -116,8 +133,9 @@ func (vv *VarianceValuator) ValueVariances(ctx context.Context, runID uuid.UUID)
 
 	for _, v := range detected {
 		v := v // capture for closure
+		partyID := partyIDs[v.AccountID]
 		g.Go(func() error {
-			valued, valueDelta, err := vv.valueVariance(gCtx, v)
+			valued, valueDelta, err := vv.valueVariance(gCtx, v, partyID)
 			if err != nil {
 				slog.WarnContext(gCtx, "failed to value variance",
 					"variance_id", v.VarianceID,
@@ -170,21 +188,12 @@ func (vv *VarianceValuator) ValueVariances(ctx context.Context, runID uuid.UUID)
 }
 
 // valueVariance values a single variance using the in-process valuation engine.
-func (vv *VarianceValuator) valueVariance(ctx context.Context, v *domain.Variance) (*domain.Variance, decimal.Decimal, error) {
+// partyID is pre-resolved by the caller to avoid N+1 gRPC lookups.
+func (vv *VarianceValuator) valueVariance(ctx context.Context, v *domain.Variance, partyID uuid.UUID) (*domain.Variance, decimal.Decimal, error) {
 	// Look up the valuation method for this instrument
 	methodID, err := vv.refData.GetValuationMethodID(ctx, v.InstrumentCode)
 	if err != nil {
 		return nil, decimal.Zero, fmt.Errorf("failed to get valuation method for %s: %w", v.InstrumentCode, err)
-	}
-
-	// Resolve the owning party for this account
-	partyID, err := vv.resolvePartyID(ctx, v.AccountID)
-	if err != nil {
-		slog.WarnContext(ctx, "failed to resolve party for account, falling back to account ID",
-			"account_id", v.AccountID,
-			"error", err,
-		)
-		partyID = uuidFromString(v.AccountID)
 	}
 
 	// Build valuation request

--- a/services/reconciliation/service/variance_valuator_test.go
+++ b/services/reconciliation/service/variance_valuator_test.go
@@ -107,7 +107,7 @@ func TestValueVariances_SuccessfulValuation(t *testing.T) {
 		},
 	}
 
-	valuator := NewVarianceValuator(engine, refData, varianceRepo, runRepo)
+	valuator := NewVarianceValuator(engine, refData, nil, varianceRepo, runRepo)
 	err := valuator.ValueVariances(context.Background(), run.RunID)
 	require.NoError(t, err)
 
@@ -142,7 +142,7 @@ func TestValueVariances_MaterialityFiltering(t *testing.T) {
 		},
 	}
 
-	valuator := NewVarianceValuator(engine, refData, varianceRepo, runRepo)
+	valuator := NewVarianceValuator(engine, refData, nil, varianceRepo, runRepo)
 	err := valuator.ValueVariances(context.Background(), run.RunID)
 	require.NoError(t, err)
 
@@ -167,7 +167,7 @@ func TestValueVariances_NoDetectedVariances(t *testing.T) {
 	engine := &mockValuationEngine{}
 	refData := &mockRefData{}
 
-	valuator := NewVarianceValuator(engine, refData, varianceRepo, runRepo)
+	valuator := NewVarianceValuator(engine, refData, nil, varianceRepo, runRepo)
 	err := valuator.ValueVariances(context.Background(), run.RunID)
 	require.NoError(t, err)
 
@@ -188,7 +188,7 @@ func TestValueVariances_ValuationEngineError(t *testing.T) {
 	engine := &mockValuationEngine{err: errors.New("starlark timeout")}
 	refData := &mockRefData{}
 
-	valuator := NewVarianceValuator(engine, refData, varianceRepo, runRepo)
+	valuator := NewVarianceValuator(engine, refData, nil, varianceRepo, runRepo)
 	err := valuator.ValueVariances(context.Background(), run.RunID)
 	// When all variances fail valuation, the method returns an error
 	require.Error(t, err)
@@ -211,7 +211,7 @@ func TestValueVariances_ReferenceDataError(t *testing.T) {
 	engine := &mockValuationEngine{}
 	refData := &mockRefData{methodErr: errors.New("reference data unavailable")}
 
-	valuator := NewVarianceValuator(engine, refData, varianceRepo, runRepo)
+	valuator := NewVarianceValuator(engine, refData, nil, varianceRepo, runRepo)
 	err := valuator.ValueVariances(context.Background(), run.RunID)
 	// When all variances fail valuation, the method returns an error
 	require.Error(t, err)
@@ -231,7 +231,7 @@ func TestValueVariances_ThresholdError_StillValues(t *testing.T) {
 	engine := &mockValuationEngine{}
 	refData := &mockRefData{threshErr: errors.New("threshold lookup failed")}
 
-	valuator := NewVarianceValuator(engine, refData, varianceRepo, runRepo)
+	valuator := NewVarianceValuator(engine, refData, nil, varianceRepo, runRepo)
 	err := valuator.ValueVariances(context.Background(), run.RunID)
 	require.NoError(t, err)
 
@@ -257,7 +257,7 @@ func TestValueVariances_UpdatesRunSummary(t *testing.T) {
 		},
 	}
 
-	valuator := NewVarianceValuator(engine, refData, varianceRepo, runRepo)
+	valuator := NewVarianceValuator(engine, refData, nil, varianceRepo, runRepo)
 	err := valuator.ValueVariances(context.Background(), run.RunID)
 	require.NoError(t, err)
 
@@ -287,7 +287,7 @@ func TestValueVariances_ConcurrentValuation(t *testing.T) {
 		},
 	}
 
-	valuator := NewVarianceValuator(engine, refData, varianceRepo, runRepo)
+	valuator := NewVarianceValuator(engine, refData, nil, varianceRepo, runRepo)
 	err := valuator.ValueVariances(context.Background(), run.RunID)
 	require.NoError(t, err)
 
@@ -297,4 +297,125 @@ func TestValueVariances_ConcurrentValuation(t *testing.T) {
 	for _, v := range varianceRepo.variances {
 		assert.Equal(t, domain.VarianceStatusValued, v.Status)
 	}
+}
+
+// --- Mock AccountPartyResolver ---
+
+type mockPartyResolver struct {
+	partyIDs map[string]uuid.UUID
+	err      error
+}
+
+func (m *mockPartyResolver) ResolvePartyID(_ context.Context, accountID string) (uuid.UUID, error) {
+	if m.err != nil {
+		return uuid.Nil, m.err
+	}
+	if id, ok := m.partyIDs[accountID]; ok {
+		return id, nil
+	}
+	return uuid.Nil, errors.New("account not found")
+}
+
+func TestValueVariances_UsesPartyResolver(t *testing.T) {
+	runRepo := newMockRunRepo()
+	varianceRepo := &mockVarianceRepoFull{}
+
+	run := newRunningTestRun(t)
+	_ = runRepo.Create(context.Background(), run)
+
+	partyID := uuid.New()
+	v := createDetectedVariance(t, run.RunID, "ACC-001", "GBP", decimal.NewFromFloat(50.00))
+	varianceRepo.variances = []*domain.Variance{v}
+
+	var capturedPartyID uuid.UUID
+	engine := &mockValuationEngine{
+		responses: map[uuid.UUID]*valuation.Response{},
+	}
+	// Override to capture the request
+	capturingEngine := &partyCapturingEngine{delegate: engine, captured: &capturedPartyID}
+
+	resolver := &mockPartyResolver{
+		partyIDs: map[string]uuid.UUID{
+			"ACC-001": partyID,
+		},
+	}
+	refData := &mockRefData{
+		thresholds: map[string]decimal.Decimal{
+			"GBP": decimal.NewFromFloat(0.01),
+		},
+	}
+
+	valuator := NewVarianceValuator(capturingEngine, refData, resolver, varianceRepo, runRepo)
+	err := valuator.ValueVariances(context.Background(), run.RunID)
+	require.NoError(t, err)
+
+	assert.Equal(t, partyID, capturedPartyID, "valuator should use resolved party ID")
+}
+
+func TestValueVariances_PartyResolverError_FallsBackToAccountID(t *testing.T) {
+	runRepo := newMockRunRepo()
+	varianceRepo := &mockVarianceRepoFull{}
+
+	run := newRunningTestRun(t)
+	_ = runRepo.Create(context.Background(), run)
+
+	v := createDetectedVariance(t, run.RunID, "ACC-001", "GBP", decimal.NewFromFloat(50.00))
+	varianceRepo.variances = []*domain.Variance{v}
+
+	var capturedPartyID uuid.UUID
+	engine := &mockValuationEngine{}
+	capturingEngine := &partyCapturingEngine{delegate: engine, captured: &capturedPartyID}
+
+	resolver := &mockPartyResolver{err: errors.New("service unavailable")}
+	refData := &mockRefData{
+		thresholds: map[string]decimal.Decimal{
+			"GBP": decimal.NewFromFloat(0.01),
+		},
+	}
+
+	valuator := NewVarianceValuator(capturingEngine, refData, resolver, varianceRepo, runRepo)
+	err := valuator.ValueVariances(context.Background(), run.RunID)
+	require.NoError(t, err)
+
+	// Should fall back to uuidFromString("ACC-001") which is uuid.Nil
+	assert.Equal(t, uuid.Nil, capturedPartyID, "should fall back to account ID parse on resolver error")
+}
+
+func TestValueVariances_NilPartyResolver_FallsBackToAccountID(t *testing.T) {
+	runRepo := newMockRunRepo()
+	varianceRepo := &mockVarianceRepoFull{}
+
+	run := newRunningTestRun(t)
+	_ = runRepo.Create(context.Background(), run)
+
+	v := createDetectedVariance(t, run.RunID, "ACC-001", "GBP", decimal.NewFromFloat(50.00))
+	varianceRepo.variances = []*domain.Variance{v}
+
+	var capturedPartyID uuid.UUID
+	engine := &mockValuationEngine{}
+	capturingEngine := &partyCapturingEngine{delegate: engine, captured: &capturedPartyID}
+
+	refData := &mockRefData{
+		thresholds: map[string]decimal.Decimal{
+			"GBP": decimal.NewFromFloat(0.01),
+		},
+	}
+
+	valuator := NewVarianceValuator(capturingEngine, refData, nil, varianceRepo, runRepo)
+	err := valuator.ValueVariances(context.Background(), run.RunID)
+	require.NoError(t, err)
+
+	// nil resolver falls back to uuidFromString("ACC-001") = uuid.Nil
+	assert.Equal(t, uuid.Nil, capturedPartyID, "nil resolver should fall back to account ID parse")
+}
+
+// partyCapturingEngine wraps a valuation engine and captures the PartyID from requests.
+type partyCapturingEngine struct {
+	delegate valuation.Engine
+	captured *uuid.UUID
+}
+
+func (e *partyCapturingEngine) Valuate(ctx context.Context, req *valuation.Request) (*valuation.Response, error) {
+	*e.captured = req.PartyID
+	return e.delegate.Valuate(ctx, req)
 }

--- a/tests/reconciliation-e2e/infra_test.go
+++ b/tests/reconciliation-e2e/infra_test.go
@@ -139,6 +139,7 @@ func setupE2EInfra(t *testing.T) *e2eTestInfra {
 	infra.valuator = service.NewVarianceValuator(
 		infra.mockValEngine,
 		infra.mockRefData,
+		nil, // party resolver not needed in e2e tests (falls back to account ID)
 		infra.varianceRepo,
 		infra.runRepo,
 	)


### PR DESCRIPTION
## Summary

- Fixes PartyID being hardcoded to AccountID in the variance valuator's valuation request builder
- The valuation engine requires a party UUID, but AccountID is a business string identifier (e.g. "ACC-001"), not a UUID
- Adds `party_id` field to `CurrentAccountFacility` proto so the account-to-party mapping is available via gRPC

## Changes Made

**Proto (`current_account.proto`)**
- Add `party_id` string field (16) to `CurrentAccountFacility` message

**Current Account Service**
- Update `toProtoFacility` mapper to include `PartyId` from domain model

**Reconciliation Service**
- Add `AccountPartyResolver` interface with `ResolvePartyID(ctx, accountID) (uuid.UUID, error)`
- Add `GRPCAccountPartyResolver` adapter that calls `RetrieveCurrentAccount` RPC to resolve account -> party
- Add `partyResolver` dependency to `VarianceValuator` with graceful fallback:
  - If resolver is nil (not configured): falls back to `uuidFromString(accountID)` (existing behavior)
  - If resolver returns error: logs warning and falls back to `uuidFromString(accountID)`
  - If resolver succeeds: uses the resolved party UUID
- Wire Current Account gRPC client in `main.go` when `CURRENT_ACCOUNT_URL` is configured

## Testing

- Unit tests for `GRPCAccountPartyResolver`: success, gRPC error, nil facility, empty party_id, invalid UUID
- Unit tests for `VarianceValuator` party resolution: resolver success, resolver error fallback, nil resolver fallback
- All existing reconciliation service tests pass (backward compatible via nil resolver)

## Risk Assessment

Low risk. Backward compatible - nil resolver preserves existing behavior. The party resolver is only active when `CURRENT_ACCOUNT_URL` is configured.

## Task Master

Task: codebase-debt-audit.2 - Fix PartyID Hardcoded to AccountID in Variance Valuator