### PR TITLE
fix: remove live preview placeholder and make used-by pills clickable

### DIFF
--- a/frontend/src/features/cookbook/components/component-detail.test.tsx
+++ b/frontend/src/features/cookbook/components/component-detail.test.tsx
@@ -92,9 +92,20 @@ describe('ComponentDetail', () => {
     expect(screen.getByText('components/balance-card.css')).toBeInTheDocument()
   })
 
-  it('renders live preview placeholder', () => {
-    renderDetail(fullItem)
-    expect(screen.getByText('Preview not available')).toBeInTheDocument()
+  it('renders used_by badges as links when route exists', () => {
+    const item: CookbookItem = {
+      name: 'test-comp',
+      type: 'registry:ui',
+      title: 'Test',
+      meta: {
+        used_by: ['accounts', 'unknown-module'],
+      } satisfies ComponentMeta,
+    }
+    renderDetail(item)
+    const accountsLink = screen.getByText('accounts').closest('a')
+    expect(accountsLink).toHaveAttribute('href', '/accounts')
+    const unknownBadge = screen.getByText('unknown-module')
+    expect(unknownBadge.closest('a')).toBeNull()
   })
 
   it('hides props table when no configurable_props', () => {

--- a/frontend/src/features/cookbook/components/component-detail.tsx
+++ b/frontend/src/features/cookbook/components/component-detail.tsx
@@ -3,6 +3,20 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import type { CookbookItem, ComponentMeta } from '../hooks/use-cookbook'
 
+const featureModuleRoutes: Record<string, string> = {
+  'accounts': '/accounts',
+  'internal-accounts': '/internal-accounts',
+  'payments': '/payments',
+  'positions': '/positions',
+  'ledger': '/ledger',
+  'parties': '/parties',
+  'reconciliation': '/reconciliation',
+  'sagas': '/starlark-config',
+  'reference-data': '/reference-data',
+  'market-data': '/market-data',
+  'manifests': '/manifests',
+}
+
 interface ComponentDetailProps {
   item: CookbookItem
 }
@@ -66,11 +80,20 @@ export function ComponentDetail({ item }: ComponentDetailProps) {
               <div className="flex items-center gap-2 text-sm">
                 <span className="text-muted-foreground">Used by:</span>
                 <div className="flex flex-wrap gap-1.5">
-                  {meta.used_by.map((name) => (
-                    <Badge key={name} variant="secondary" className="text-xs">
-                      {name}
-                    </Badge>
-                  ))}
+                  {meta.used_by.map((name) => {
+                    const route = featureModuleRoutes[name]
+                    return route ? (
+                      <Link key={name} to={route}>
+                        <Badge variant="secondary" className="cursor-pointer text-xs hover:bg-accent hover:text-accent-foreground">
+                          {name}
+                        </Badge>
+                      </Link>
+                    ) : (
+                      <Badge key={name} variant="secondary" className="text-xs">
+                        {name}
+                      </Badge>
+                    )
+                  })}
                 </div>
               </div>
             )}
@@ -123,20 +146,6 @@ export function ComponentDetail({ item }: ComponentDetailProps) {
         </Card>
       )}
 
-      {/* Preview Placeholder */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base">Live Preview</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-12 text-center">
-            <p className="text-sm font-medium text-muted-foreground">Preview not available</p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Live component rendering requires a sandboxed runtime environment.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
     </div>
   )
 }

--- a/frontend/src/features/cookbook/pages/detail.test.tsx
+++ b/frontend/src/features/cookbook/pages/detail.test.tsx
@@ -129,7 +129,6 @@ describe('CookbookDetailPage', () => {
 
   it('shows component detail for UI component type', () => {
     renderDetail('transaction-table')
-    expect(screen.getByText('Preview not available')).toBeInTheDocument()
     expect(screen.getByText('Registry Dependencies')).toBeInTheDocument()
     expect(screen.queryByRole('tab')).not.toBeInTheDocument()
   })


### PR DESCRIPTION
## Summary

- Remove the dead-end Live Preview card from `ComponentDetail` that showed only a static "Preview not available" message
- Make 'Used by' badges in the Usage Context section clickable links that navigate to their corresponding feature module routes
- Badges without a known route remain as plain, non-clickable badges

## Task Master

| Task | Description |
|------|-------------|
| 036-cookbook-browser.16 | Remove Live Preview Section |
| 036-cookbook-browser.19 | Fix 'Used by' Pills |

## Changes

- `frontend/src/features/cookbook/components/component-detail.tsx`: Removed Live Preview card block, added `featureModuleRoutes` mapping, conditionally wrapped used_by badges in `Link` with hover styles
- `frontend/src/features/cookbook/components/component-detail.test.tsx`: Replaced live preview test with test verifying linked vs plain used_by badges
- `frontend/src/features/cookbook/pages/detail.test.tsx`: Updated UI component type assertion to check for Registry Dependencies instead of Preview not available

## Test plan

- [x] All 21 tests pass across both test files
- [x] TypeScript typecheck passes with no errors
- [ ] CI passes