### PR TITLE
feat: switch saga flow diagrams to left-to-right orientation

### DIFF
--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -47,7 +47,7 @@ function StartNode({ data }: { data: StartNodeData }) {
           <span className="text-[10px] text-emerald-600 dark:text-emerald-400">{data.trigger}</span>
         )}
       </div>
-      <Handle type="source" position={Position.Bottom} className="!bg-emerald-500 !border-0 !w-2 !h-2" />
+      <Handle type="source" position={Position.Right} className="!bg-emerald-500 !border-0 !w-2 !h-2" />
     </>
   )
 }
@@ -64,7 +64,7 @@ function StepNode({ data }: { data: StepNodeData }) {
 
   return (
     <>
-      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
       <div
         className="flex flex-col gap-1 rounded-lg border-2 bg-background px-3 py-2 shadow-sm min-w-[180px]"
         style={{ borderColor }}
@@ -87,7 +87,7 @@ function StepNode({ data }: { data: StepNodeData }) {
           </div>
         )}
       </div>
-      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="source" position={Position.Right} className="!bg-transparent !border-0 !w-0 !h-0" />
     </>
   )
 }
@@ -100,7 +100,7 @@ interface DecisionNodeData {
 function DecisionNode({ data }: { data: DecisionNodeData }) {
   return (
     <>
-      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
       <div className="flex items-center justify-center" style={{ width: 140, height: 70 }}>
         <div
           className="flex items-center justify-center border-2 border-amber-500 bg-amber-50 dark:bg-amber-950/40"
@@ -118,11 +118,16 @@ function DecisionNode({ data }: { data: DecisionNodeData }) {
           </span>
         </div>
       </div>
-      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="exit"
+        className="!bg-transparent !border-0 !w-0 !h-0"
+      />
       <Handle
         type="source"
         position={Position.Right}
-        id="exit"
+        id="no"
         className="!bg-transparent !border-0 !w-0 !h-0"
       />
     </>
@@ -148,7 +153,7 @@ function ExitNode({ data }: { data: ExitNodeData }) {
 function EndNode() {
   return (
     <>
-      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
       <div className="flex items-center justify-center rounded-full border-2 border-slate-500 bg-slate-100 px-4 py-2 dark:bg-slate-800">
         <span className="text-xs font-semibold text-slate-600 dark:text-slate-300">COMPLETED</span>
       </div>
@@ -176,7 +181,7 @@ const NODE_DIMENSIONS: Record<string, { width: number; height: number }> = {
 
 function layoutNodes(nodes: Node[], edges: Edge[]): Node[] {
   const g = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}))
-  g.setGraph({ rankdir: 'TB', nodesep: 50, ranksep: 80 })
+  g.setGraph({ rankdir: 'LR', nodesep: 60, ranksep: 100 })
 
   for (const n of nodes) {
     const dims = NODE_DIMENSIONS[n.type ?? 'sagaStep'] ?? { width: 200, height: 60 }
@@ -292,6 +297,7 @@ function buildFlowGraph(flow: SagaFlow): { nodes: Node[]; edges: Edge[] } {
       edges.push({
         id: `${decisionId}-${nextId}`,
         source: decisionId,
+        sourceHandle: 'no',
         target: nextId,
         label: 'No',
       })
@@ -345,7 +351,7 @@ export function SagaFlowDiagram({ flow, onStepClick, className }: SagaFlowDiagra
   }, [flow])
 
   return (
-    <div className={`relative ${className ?? ''}`} style={{ width: '100%', height: '100%', minHeight: 400 }}>
+    <div className={`relative ${className ?? ''}`} style={{ width: '100%', height: '100%', minHeight: 300 }}>
       <ReactFlow
         nodes={nodes}
         edges={edges}

--- a/frontend/src/features/cookbook/lib/saga-mermaid.test.ts
+++ b/frontend/src/features/cookbook/lib/saga-mermaid.test.ts
@@ -19,7 +19,7 @@ describe('generateMermaidMarkup', () => {
       steps: [],
     }
     const markup = generateMermaidMarkup(flow)
-    expect(markup).toMatch(/^flowchart TD/)
+    expect(markup).toMatch(/^flowchart LR/)
   })
 
   it('renders empty saga with start and end', () => {
@@ -149,7 +149,7 @@ describe('generateMermaidMarkup', () => {
         const markup = generateMermaidMarkup(flow)
 
         // Basic structural validation
-        expect(markup).toMatch(/^flowchart TD/)
+        expect(markup).toMatch(/^flowchart LR/)
         expect(markup).toContain('START')
         expect(markup).toContain('END')
 

--- a/frontend/src/features/cookbook/lib/saga-mermaid.ts
+++ b/frontend/src/features/cookbook/lib/saga-mermaid.ts
@@ -1,10 +1,10 @@
 import type { SagaFlow } from './star-parser'
 
 /**
- * Generate a Mermaid flowchart TD markup from a parsed SagaFlow.
+ * Generate a Mermaid flowchart LR markup from a parsed SagaFlow.
  */
 export function generateMermaidMarkup(flow: SagaFlow): string {
-  const lines: string[] = ['flowchart TD']
+  const lines: string[] = ['flowchart LR']
 
   const startLabel = flow.trigger
     ? `${escapeMermaid(flow.name)}\\n${escapeMermaid(flow.trigger)}`


### PR DESCRIPTION
## Summary

- Switch saga flow diagram layout from top-to-bottom (TB) to left-to-right (LR) for both the ReactFlow component and Mermaid export
- Update all node handle positions for horizontal flow direction
- Add dedicated `no` handle on DecisionNode for continue-flow edges, keep `exit` handle at bottom for early-exit edges

## Changes

**saga-flow.tsx:**
- Dagre layout: `rankdir: 'TB'` to `'LR'`, spacing adjusted to `nodesep: 60, ranksep: 100`
- StartNode: source handle Bottom to Right
- StepNode: target Top to Left, source Bottom to Right
- DecisionNode: target Top to Left, exit handle moved to Bottom, new `no` handle at Right
- EndNode: target Top to Left
- "No" edge updated with `sourceHandle: 'no'`
- Container minHeight reduced from 400 to 300

**saga-mermaid.ts:**
- `flowchart TD` to `flowchart LR`

**saga-mermaid.test.ts:**
- Updated assertions from `TD` to `LR`

## Test plan

- [x] All 138 cookbook tests pass
- [x] TypeScript type check passes
- [x] Mermaid markup assertions updated for LR