### PR TITLE
feat: improve saga flow diagram visuals

### DIFF
--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import {
   ReactFlow,
   Controls,
@@ -56,6 +56,7 @@ interface StepNodeData {
   label: string
   serviceCalls: { service: string; method: string }[]
   serviceIndex: Map<string, number>
+  highlightedService: string | null
   [key: string]: unknown
 }
 
@@ -63,12 +64,22 @@ function StepNode({ data }: { data: StepNodeData }) {
   const primaryService = data.serviceCalls[0]?.service
   const borderColor = primaryService ? getServiceColors(primaryService, data.serviceIndex).fg : '#71717a'
 
+  const isHighlightActive = data.highlightedService !== null
+  const isHighlighted = isHighlightActive && data.serviceCalls.some((c) => c.service === data.highlightedService)
+  const isDimmed = isHighlightActive && !isHighlighted
+
   return (
     <>
       <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
       <div
-        className="flex flex-col gap-1 rounded-lg border-2 bg-background px-3 py-2 shadow-sm min-w-[180px]"
-        style={{ borderColor }}
+        className="flex flex-col gap-1 rounded-lg border-2 bg-background px-3 py-2 shadow-sm min-w-[180px] transition-opacity duration-200"
+        style={{
+          borderColor,
+          opacity: isDimmed ? 0.3 : 1,
+          ...(isHighlighted
+            ? { boxShadow: `0 0 0 2px white, 0 0 0 4px ${borderColor}` }
+            : {}),
+        }}
       >
         <span className="text-xs font-semibold text-foreground">{data.label}</span>
         {data.serviceCalls.length > 0 && (
@@ -220,7 +231,11 @@ function buildServiceIndex(flow: SagaFlow): Map<string, number> {
   return seen
 }
 
-function buildFlowGraph(flow: SagaFlow, serviceIndex: Map<string, number>): { nodes: Node[]; edges: Edge[] } {
+function buildFlowGraph(
+  flow: SagaFlow,
+  serviceIndex: Map<string, number>,
+  highlightedService: string | null,
+): { nodes: Node[]; edges: Edge[] } {
   const nodes: Node[] = []
   const edges: Edge[] = []
 
@@ -259,6 +274,7 @@ function buildFlowGraph(flow: SagaFlow, serviceIndex: Map<string, number>): { no
         label: step.name,
         serviceCalls: step.serviceCalls,
         serviceIndex,
+        highlightedService,
       } satisfies StepNodeData,
     })
 
@@ -349,8 +365,12 @@ interface SagaFlowDiagramProps {
 }
 
 export function SagaFlowDiagram({ flow, onStepClick, className }: SagaFlowDiagramProps) {
+  const [highlightedService, setHighlightedService] = useState<string | null>(null)
   const serviceIndex = useMemo(() => buildServiceIndex(flow), [flow])
-  const { nodes, edges } = useMemo(() => buildFlowGraph(flow, serviceIndex), [flow, serviceIndex])
+  const { nodes, edges } = useMemo(
+    () => buildFlowGraph(flow, serviceIndex, highlightedService),
+    [flow, serviceIndex, highlightedService],
+  )
 
   // Collect unique services for the legend (sorted alphabetically)
   const services = useMemo(() => [...serviceIndex.keys()].sort(), [serviceIndex])
@@ -382,14 +402,21 @@ export function SagaFlowDiagram({ flow, onStepClick, className }: SagaFlowDiagra
           <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">Services</span>
           {services.map((svc) => {
             const colors = getServiceColors(svc, serviceIndex)
+            const isActive = highlightedService === svc
             return (
-              <div key={svc} className="flex items-center gap-2">
+              <button
+                key={svc}
+                type="button"
+                className="flex items-center gap-2 rounded px-1 -mx-1 transition-colors hover:bg-muted/50"
+                style={isActive ? { backgroundColor: colors.bg } : undefined}
+                onClick={() => setHighlightedService(isActive ? null : svc)}
+              >
                 <span
                   className="inline-block h-2.5 w-2.5 rounded-full"
                   style={{ backgroundColor: colors.fg }}
                 />
                 <span className="text-xs text-muted-foreground">{svc}</span>
-              </div>
+              </button>
             )
           })}
         </div>

--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -101,22 +101,17 @@ function DecisionNode({ data }: { data: DecisionNodeData }) {
   return (
     <>
       <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
-      <div className="flex items-center justify-center" style={{ width: 140, height: 70 }}>
-        <div
-          className="flex items-center justify-center border-2 border-amber-500 bg-amber-50 dark:bg-amber-950/40"
-          style={{
-            width: 120,
-            height: 60,
-            transform: 'rotate(45deg)',
-          }}
-        >
-          <span
-            className="text-[10px] font-medium text-amber-700 dark:text-amber-300 text-center leading-tight px-1 max-w-[80px]"
-            style={{ transform: 'rotate(-45deg)' }}
-          >
-            {data.label}
-          </span>
-        </div>
+      <div
+        className="flex items-center justify-center border-2 border-amber-500 bg-amber-50 dark:bg-amber-950/40"
+        style={{
+          width: 140,
+          height: 70,
+          clipPath: 'polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%)',
+        }}
+      >
+        <span className="text-[10px] font-medium text-amber-700 dark:text-amber-300 text-center leading-tight px-1 max-w-[80px]">
+          {data.label}
+        </span>
       </div>
       <Handle
         type="source"

--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -47,7 +47,7 @@ function StartNode({ data }: { data: StartNodeData }) {
           <span className="text-[10px] text-emerald-600 dark:text-emerald-400">{data.trigger}</span>
         )}
       </div>
-      <Handle type="source" position={Position.Bottom} className="!bg-emerald-500 !border-0 !w-2 !h-2" />
+      <Handle type="source" position={Position.Right} className="!bg-emerald-500 !border-0 !w-2 !h-2" />
     </>
   )
 }
@@ -64,7 +64,7 @@ function StepNode({ data }: { data: StepNodeData }) {
 
   return (
     <>
-      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
       <div
         className="flex flex-col gap-1 rounded-lg border-2 bg-background px-3 py-2 shadow-sm min-w-[180px]"
         style={{ borderColor }}
@@ -87,7 +87,7 @@ function StepNode({ data }: { data: StepNodeData }) {
           </div>
         )}
       </div>
-      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="source" position={Position.Right} className="!bg-transparent !border-0 !w-0 !h-0" />
     </>
   )
 }
@@ -100,7 +100,7 @@ interface DecisionNodeData {
 function DecisionNode({ data }: { data: DecisionNodeData }) {
   return (
     <>
-      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
       <div className="flex items-center justify-center" style={{ width: 140, height: 70 }}>
         <div
           className="flex items-center justify-center border-2 border-amber-500 bg-amber-50 dark:bg-amber-950/40"
@@ -118,11 +118,16 @@ function DecisionNode({ data }: { data: DecisionNodeData }) {
           </span>
         </div>
       </div>
-      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="exit"
+        className="!bg-transparent !border-0 !w-0 !h-0"
+      />
       <Handle
         type="source"
         position={Position.Right}
-        id="exit"
+        id="no"
         className="!bg-transparent !border-0 !w-0 !h-0"
       />
     </>
@@ -148,7 +153,7 @@ function ExitNode({ data }: { data: ExitNodeData }) {
 function EndNode() {
   return (
     <>
-      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
       <div className="flex items-center justify-center rounded-full border-2 border-slate-500 bg-slate-100 px-4 py-2 dark:bg-slate-800">
         <span className="text-xs font-semibold text-slate-600 dark:text-slate-300">COMPLETED</span>
       </div>
@@ -176,7 +181,7 @@ const NODE_DIMENSIONS: Record<string, { width: number; height: number }> = {
 
 function layoutNodes(nodes: Node[], edges: Edge[]): Node[] {
   const g = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}))
-  g.setGraph({ rankdir: 'TB', nodesep: 50, ranksep: 80 })
+  g.setGraph({ rankdir: 'LR', nodesep: 60, ranksep: 100 })
 
   for (const n of nodes) {
     const dims = NODE_DIMENSIONS[n.type ?? 'sagaStep'] ?? { width: 200, height: 60 }
@@ -292,6 +297,7 @@ function buildFlowGraph(flow: SagaFlow): { nodes: Node[]; edges: Edge[] } {
       edges.push({
         id: `${decisionId}-${nextId}`,
         source: decisionId,
+        sourceHandle: 'no',
         target: nextId,
         label: 'No',
       })
@@ -345,7 +351,7 @@ export function SagaFlowDiagram({ flow, onStepClick, className }: SagaFlowDiagra
   }, [flow])
 
   return (
-    <div className={`relative ${className ?? ''}`} style={{ width: '100%', height: '100%', minHeight: 400 }}>
+    <div className={`relative ${className ?? ''}`} style={{ width: '100%', height: '100%', minHeight: 300 }}>
       <ReactFlow
         nodes={nodes}
         edges={edges}

--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -13,21 +13,21 @@ import '@xyflow/react/dist/style.css'
 import Dagre from '@dagrejs/dagre'
 import type { SagaFlow } from '../lib/star-parser'
 
-// Hash a service name to a HSL hue for consistent coloring
-function serviceHue(service: string): number {
-  let hash = 0
-  for (let i = 0; i < service.length; i++) {
-    hash = service.charCodeAt(i) + ((hash << 5) - hash)
-  }
-  return ((hash % 360) + 360) % 360
-}
+// Curated palette of visually distinct service colors
+const SERVICE_PALETTE = [
+  { bg: 'hsl(220, 70%, 92%)', fg: 'hsl(220, 70%, 45%)' },  // Blue
+  { bg: 'hsl(150, 60%, 90%)', fg: 'hsl(150, 60%, 35%)' },  // Green
+  { bg: 'hsl(30, 80%, 92%)', fg: 'hsl(30, 80%, 45%)' },    // Orange
+  { bg: 'hsl(280, 60%, 92%)', fg: 'hsl(280, 60%, 45%)' },  // Purple
+  { bg: 'hsl(0, 70%, 92%)', fg: 'hsl(0, 70%, 45%)' },      // Red
+  { bg: 'hsl(180, 60%, 90%)', fg: 'hsl(180, 60%, 35%)' },  // Teal
+  { bg: 'hsl(50, 80%, 90%)', fg: 'hsl(50, 80%, 35%)' },    // Yellow
+  { bg: 'hsl(330, 60%, 92%)', fg: 'hsl(330, 60%, 45%)' },  // Pink
+]
 
-function serviceColor(service: string): string {
-  return `hsl(${serviceHue(service)}, 65%, 50%)`
-}
-
-function serviceBgColor(service: string): string {
-  return `hsl(${serviceHue(service)}, 65%, 92%)`
+function getServiceColors(service: string, serviceIndex: Map<string, number>): { fg: string; bg: string } {
+  const idx = serviceIndex.get(service) ?? 0
+  return SERVICE_PALETTE[idx % SERVICE_PALETTE.length]
 }
 
 // --- Custom Node Components ---
@@ -55,12 +55,13 @@ function StartNode({ data }: { data: StartNodeData }) {
 interface StepNodeData {
   label: string
   serviceCalls: { service: string; method: string }[]
+  serviceIndex: Map<string, number>
   [key: string]: unknown
 }
 
 function StepNode({ data }: { data: StepNodeData }) {
   const primaryService = data.serviceCalls[0]?.service
-  const borderColor = primaryService ? serviceColor(primaryService) : '#71717a'
+  const borderColor = primaryService ? getServiceColors(primaryService, data.serviceIndex).fg : '#71717a'
 
   return (
     <>
@@ -72,18 +73,21 @@ function StepNode({ data }: { data: StepNodeData }) {
         <span className="text-xs font-semibold text-foreground">{data.label}</span>
         {data.serviceCalls.length > 0 && (
           <div className="flex flex-wrap gap-1">
-            {data.serviceCalls.map((call, idx) => (
-              <span
-                key={`${call.service}.${call.method}.${idx}`}
-                className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium"
-                style={{
-                  backgroundColor: serviceBgColor(call.service),
-                  color: serviceColor(call.service),
-                }}
-              >
-                {call.service}.{call.method}
-              </span>
-            ))}
+            {data.serviceCalls.map((call, idx) => {
+              const colors = getServiceColors(call.service, data.serviceIndex)
+              return (
+                <span
+                  key={`${call.service}.${call.method}.${idx}`}
+                  className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium"
+                  style={{
+                    backgroundColor: colors.bg,
+                    color: colors.fg,
+                  }}
+                >
+                  {call.service}.{call.method}
+                </span>
+              )
+            })}
           </div>
         )}
       </div>
@@ -204,7 +208,19 @@ function layoutNodes(nodes: Node[], edges: Edge[]): Node[] {
 
 // --- Build Graph from SagaFlow ---
 
-function buildFlowGraph(flow: SagaFlow): { nodes: Node[]; edges: Edge[] } {
+function buildServiceIndex(flow: SagaFlow): Map<string, number> {
+  const seen = new Map<string, number>()
+  for (const step of flow.steps) {
+    for (const call of step.serviceCalls) {
+      if (!seen.has(call.service)) {
+        seen.set(call.service, seen.size)
+      }
+    }
+  }
+  return seen
+}
+
+function buildFlowGraph(flow: SagaFlow, serviceIndex: Map<string, number>): { nodes: Node[]; edges: Edge[] } {
   const nodes: Node[] = []
   const edges: Edge[] = []
 
@@ -242,6 +258,7 @@ function buildFlowGraph(flow: SagaFlow): { nodes: Node[]; edges: Edge[] } {
       data: {
         label: step.name,
         serviceCalls: step.serviceCalls,
+        serviceIndex,
       } satisfies StepNodeData,
     })
 
@@ -332,18 +349,11 @@ interface SagaFlowDiagramProps {
 }
 
 export function SagaFlowDiagram({ flow, onStepClick, className }: SagaFlowDiagramProps) {
-  const { nodes, edges } = useMemo(() => buildFlowGraph(flow), [flow])
+  const serviceIndex = useMemo(() => buildServiceIndex(flow), [flow])
+  const { nodes, edges } = useMemo(() => buildFlowGraph(flow, serviceIndex), [flow, serviceIndex])
 
-  // Collect unique services for the legend
-  const services = useMemo(() => {
-    const set = new Set<string>()
-    for (const step of flow.steps) {
-      for (const call of step.serviceCalls) {
-        set.add(call.service)
-      }
-    }
-    return [...set].sort()
-  }, [flow])
+  // Collect unique services for the legend (sorted alphabetically)
+  const services = useMemo(() => [...serviceIndex.keys()].sort(), [serviceIndex])
 
   return (
     <div className={`relative ${className ?? ''}`} style={{ width: '100%', height: '100%', minHeight: 300 }}>
@@ -370,15 +380,18 @@ export function SagaFlowDiagram({ flow, onStepClick, className }: SagaFlowDiagra
       {services.length > 0 && (
         <div className="absolute bottom-3 left-3 z-10 flex flex-col gap-1 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm">
           <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">Services</span>
-          {services.map((svc) => (
-            <div key={svc} className="flex items-center gap-2">
-              <span
-                className="inline-block h-2.5 w-2.5 rounded-full"
-                style={{ backgroundColor: serviceColor(svc) }}
-              />
-              <span className="text-xs text-muted-foreground">{svc}</span>
-            </div>
-          ))}
+          {services.map((svc) => {
+            const colors = getServiceColors(svc, serviceIndex)
+            return (
+              <div key={svc} className="flex items-center gap-2">
+                <span
+                  className="inline-block h-2.5 w-2.5 rounded-full"
+                  style={{ backgroundColor: colors.fg }}
+                />
+                <span className="text-xs text-muted-foreground">{svc}</span>
+              </div>
+            )
+          })}
         </div>
       )}
     </div>

--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -407,6 +407,8 @@ export function SagaFlowDiagram({ flow, onStepClick, className }: SagaFlowDiagra
               <button
                 key={svc}
                 type="button"
+                aria-pressed={isActive}
+                aria-label={`Highlight service ${svc}`}
                 className="flex items-center gap-2 rounded px-1 -mx-1 transition-colors hover:bg-muted/50"
                 style={isActive ? { backgroundColor: colors.bg } : undefined}
                 onClick={() => setHighlightedService(isActive ? null : svc)}

--- a/frontend/src/features/cookbook/lib/saga-mermaid.test.ts
+++ b/frontend/src/features/cookbook/lib/saga-mermaid.test.ts
@@ -19,7 +19,7 @@ describe('generateMermaidMarkup', () => {
       steps: [],
     }
     const markup = generateMermaidMarkup(flow)
-    expect(markup).toMatch(/^flowchart TD/)
+    expect(markup).toMatch(/^flowchart LR/)
   })
 
   it('renders empty saga with start and end', () => {
@@ -149,7 +149,7 @@ describe('generateMermaidMarkup', () => {
         const markup = generateMermaidMarkup(flow)
 
         // Basic structural validation
-        expect(markup).toMatch(/^flowchart TD/)
+        expect(markup).toMatch(/^flowchart LR/)
         expect(markup).toContain('START')
         expect(markup).toContain('END')
 

--- a/frontend/src/features/cookbook/lib/saga-mermaid.ts
+++ b/frontend/src/features/cookbook/lib/saga-mermaid.ts
@@ -1,10 +1,10 @@
 import type { SagaFlow } from './star-parser'
 
 /**
- * Generate a Mermaid flowchart TD markup from a parsed SagaFlow.
+ * Generate a Mermaid flowchart LR markup from a parsed SagaFlow.
  */
 export function generateMermaidMarkup(flow: SagaFlow): string {
-  const lines: string[] = ['flowchart TD']
+  const lines: string[] = ['flowchart LR']
 
   const startLabel = flow.trigger
     ? `${escapeMermaid(flow.name)}\\n${escapeMermaid(flow.trigger)}`


### PR DESCRIPTION
## Summary

Follow-up to #1473 (LR layout switch). Adds three visual improvements to the saga flow diagram:

- Fix diamond decision node shape using CSS `clip-path` instead of `rotate(45deg)` hack
- Replace hash-based service color palette with curated visually distinct colors (fixes collisions between similar service names)
- Add click-to-highlight filtering in the SERVICES legend (click a service to highlight its nodes, dim others)

## Changes

**saga-flow.tsx:**
- DecisionNode: Replace `rotate(45deg)` + counter-rotation with `clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%)`
- Replace `serviceHue/serviceColor/serviceBgColor` hash functions with `SERVICE_PALETTE` array of 8 distinct colors
- Add `buildServiceIndex()` for stable index-based color assignment
- Add `highlightedService` state with ring/dim visual effects on StepNodes
- Legend items are now clickable buttons that toggle service highlighting

## Test plan

- [x] All 138 cookbook tests pass
- [x] TypeScript type check passes
- [x] Clean commit history (1 commit per change)