### PR TITLE
feat: source saga trigger from manifest and color trigger service in flow diagram

### DIFF
--- a/frontend/src/features/cookbook/components/saga-flow.test.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { SagaFlowDiagram, parseTriggerService } from './saga-flow'
+import { SagaFlowDiagram } from './saga-flow'
+import { parseTriggerService } from '../lib/star-parser'
 import type { SagaFlow } from '../lib/star-parser'
 
 // Mock @xyflow/react to avoid canvas rendering issues in jsdom

--- a/frontend/src/features/cookbook/components/saga-flow.test.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { SagaFlowDiagram } from './saga-flow'
+import { SagaFlowDiagram, parseTriggerService } from './saga-flow'
 import type { SagaFlow } from '../lib/star-parser'
 
 // Mock @xyflow/react to avoid canvas rendering issues in jsdom
@@ -193,5 +193,38 @@ describe('SagaFlowDiagram', () => {
     const refDot = refDataBtn.querySelector('span[class*="rounded-full"]')
     const posDot = posKeepBtn.querySelector('span[class*="rounded-full"]')
     expect(refDot?.getAttribute('style')).not.toEqual(posDot?.getAttribute('style'))
+  })
+
+  it('includes trigger service in legend', () => {
+    render(<SagaFlowDiagram flow={simpleFlow} />)
+    // simpleFlow has trigger "event:payments.received.v1" → service "payments"
+    expect(screen.getByRole('button', { name: /payments/ })).toBeInTheDocument()
+  })
+
+  it('shows trigger label next to trigger service in legend', () => {
+    render(<SagaFlowDiagram flow={simpleFlow} />)
+    expect(screen.getByText('trigger')).toBeInTheDocument()
+  })
+})
+
+describe('parseTriggerService', () => {
+  it('extracts service from event trigger', () => {
+    expect(parseTriggerService('event:position-keeping.transaction-captured.v1')).toBe('position-keeping')
+  })
+
+  it('extracts service from webhook trigger', () => {
+    expect(parseTriggerService('webhook:stripe.payment_intent.succeeded')).toBe('stripe')
+  })
+
+  it('returns null for api trigger', () => {
+    expect(parseTriggerService('api:/v1/payments/stripe')).toBeNull()
+  })
+
+  it('returns null for null trigger', () => {
+    expect(parseTriggerService(null)).toBeNull()
+  })
+
+  it('handles event with no dot separator', () => {
+    expect(parseTriggerService('event:simple')).toBe('simple')
   })
 })

--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -12,6 +12,7 @@ import {
 import '@xyflow/react/dist/style.css'
 import Dagre from '@dagrejs/dagre'
 import type { SagaFlow } from '../lib/star-parser'
+import { parseTriggerService } from '../lib/star-parser'
 
 // Curated palette of visually distinct service colors
 const SERVICE_PALETTE = [
@@ -24,22 +25,6 @@ const SERVICE_PALETTE = [
   { bg: 'hsl(50, 80%, 90%)', fg: 'hsl(50, 80%, 35%)' },    // Yellow
   { bg: 'hsl(330, 60%, 92%)', fg: 'hsl(330, 60%, 45%)' },  // Pink
 ]
-
-/**
- * Extract the producing service name from a trigger string.
- * - "event:position-keeping.transaction-captured.v1" → "position-keeping"
- * - "webhook:stripe.payment_intent.succeeded" → "stripe"
- * - "api:/v1/payments/stripe" → null (no service)
- */
-export function parseTriggerService(trigger: string | null): string | null {
-  if (!trigger) return null
-  if (trigger.startsWith('event:') || trigger.startsWith('webhook:')) {
-    const rest = trigger.slice(trigger.indexOf(':') + 1)
-    const dotIdx = rest.indexOf('.')
-    return dotIdx > 0 ? rest.slice(0, dotIdx) : rest
-  }
-  return null
-}
 
 function buildServiceColorMap(flow: SagaFlow): Map<string, { bg: string; fg: string }> {
   const services = new Set<string>()

--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -25,8 +25,28 @@ const SERVICE_PALETTE = [
   { bg: 'hsl(330, 60%, 92%)', fg: 'hsl(330, 60%, 45%)' },  // Pink
 ]
 
+/**
+ * Extract the producing service name from a trigger string.
+ * - "event:position-keeping.transaction-captured.v1" → "position-keeping"
+ * - "webhook:stripe.payment_intent.succeeded" → "stripe"
+ * - "api:/v1/payments/stripe" → null (no service)
+ */
+export function parseTriggerService(trigger: string | null): string | null {
+  if (!trigger) return null
+  if (trigger.startsWith('event:') || trigger.startsWith('webhook:')) {
+    const rest = trigger.slice(trigger.indexOf(':') + 1)
+    const dotIdx = rest.indexOf('.')
+    return dotIdx > 0 ? rest.slice(0, dotIdx) : rest
+  }
+  return null
+}
+
 function buildServiceColorMap(flow: SagaFlow): Map<string, { bg: string; fg: string }> {
   const services = new Set<string>()
+  // Include trigger producing service
+  const triggerSvc = parseTriggerService(flow.trigger)
+  if (triggerSvc) services.add(triggerSvc)
+  // Include called services
   for (const step of flow.steps) {
     for (const call of step.serviceCalls) {
       services.add(call.service)
@@ -45,16 +65,35 @@ function buildServiceColorMap(flow: SagaFlow): Map<string, { bg: string; fg: str
 interface StartNodeData {
   label: string
   trigger: string | null
+  triggerService: string | null
+  serviceColors: Map<string, { bg: string; fg: string }>
+  highlightedService: string | null
   [key: string]: unknown
 }
 
 function StartNode({ data }: { data: StartNodeData }) {
+  const triggerColors = data.triggerService ? data.serviceColors.get(data.triggerService) : undefined
+  const isTriggerHighlighted = data.highlightedService === data.triggerService && data.triggerService != null
+  const dimmed = data.highlightedService && !isTriggerHighlighted
+
   return (
     <>
-      <div className="flex flex-col items-center justify-center rounded-full border-2 border-emerald-500 bg-emerald-50 px-4 py-2 dark:bg-emerald-950/40">
+      <div
+        className={`flex flex-col items-center justify-center rounded-full border-2 border-emerald-500 bg-emerald-50 px-4 py-2 dark:bg-emerald-950/40 transition-opacity ${dimmed ? 'opacity-30' : 'opacity-100'}`}
+        style={isTriggerHighlighted && triggerColors
+          ? { borderColor: triggerColors.fg, boxShadow: `0 0 0 2px ${triggerColors.fg}`, outline: `2px solid ${triggerColors.fg}`, outlineOffset: '2px' }
+          : {}}
+      >
         <span className="text-xs font-semibold text-emerald-700 dark:text-emerald-300">{data.label}</span>
         {data.trigger && (
-          <span className="text-[10px] text-emerald-600 dark:text-emerald-400">{data.trigger}</span>
+          <span
+            className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium mt-0.5"
+            style={triggerColors
+              ? { backgroundColor: triggerColors.bg, color: triggerColors.fg }
+              : {}}
+          >
+            {data.trigger}
+          </span>
         )}
       </div>
       <Handle type="source" position={Position.Right} className="!bg-emerald-500 !border-0 !w-2 !h-2" />
@@ -228,12 +267,20 @@ function buildFlowGraph(
   const nodes: Node[] = []
   const edges: Edge[] = []
 
+  const triggerService = parseTriggerService(flow.trigger)
+
   // Start node
   nodes.push({
     id: 'start',
     type: 'sagaStart',
     position: { x: 0, y: 0 },
-    data: { label: flow.name, trigger: flow.trigger } satisfies StartNodeData,
+    data: {
+      label: flow.name,
+      trigger: flow.trigger,
+      triggerService,
+      serviceColors,
+      highlightedService,
+    } satisfies StartNodeData,
   })
 
   if (flow.steps.length === 0) {
@@ -412,6 +459,9 @@ export function SagaFlowDiagram({ flow, onStepClick, className }: SagaFlowDiagra
                   style={{ backgroundColor: colors?.fg }}
                 />
                 <span className="text-xs text-muted-foreground">{svc}</span>
+                {svc === parseTriggerService(flow.trigger) && (
+                  <span className="text-[9px] text-muted-foreground/60 italic">trigger</span>
+                )}
               </button>
             )
           })}

--- a/frontend/src/features/cookbook/hooks/use-pattern-files.test.ts
+++ b/frontend/src/features/cookbook/hooks/use-pattern-files.test.ts
@@ -129,4 +129,29 @@ describe('usePatternFiles', () => {
     const { result } = renderHook(() => usePatternFiles(undefined))
     expect(result.current.hasSagas).toBe(false)
   })
+
+  it('extracts sagaTrigger from manifest YAML', () => {
+    const item = makeItem({
+      files: [
+        { path: 'patterns/test/manifest.yaml', content: 'name: test\nsagas:\n  - name: deposit\n    trigger: "event:position-keeping.transaction-captured.v1"' },
+      ],
+    })
+    const { result } = renderHook(() => usePatternFiles(item))
+    expect(result.current.sagaTrigger).toBe('event:position-keeping.transaction-captured.v1')
+  })
+
+  it('returns null sagaTrigger when no sagas in manifest', () => {
+    const item = makeItem({
+      files: [
+        { path: 'patterns/test/manifest.yaml', content: 'name: test\ntype: registry:pattern' },
+      ],
+    })
+    const { result } = renderHook(() => usePatternFiles(item))
+    expect(result.current.sagaTrigger).toBeNull()
+  })
+
+  it('returns null sagaTrigger for undefined item', () => {
+    const { result } = renderHook(() => usePatternFiles(undefined))
+    expect(result.current.sagaTrigger).toBeNull()
+  })
 })

--- a/frontend/src/features/cookbook/hooks/use-pattern-files.ts
+++ b/frontend/src/features/cookbook/hooks/use-pattern-files.ts
@@ -11,6 +11,7 @@ export interface PatternFilesState {
   starlarkFiles: StarlarkFile[]
   manifestContent: string | null
   hasSagas: boolean
+  sagaTrigger: string | null
   isLoading: false
 }
 
@@ -20,22 +21,32 @@ function isValidContent(content: string | undefined): content is string {
   return !trimmed.startsWith('<!DOCTYPE') && !trimmed.startsWith('<html')
 }
 
-function detectSagas(manifestContent: string | null, starlarkFiles: StarlarkFile[]): boolean {
-  if (starlarkFiles.length > 0) return true
-  if (!manifestContent) return false
+interface ManifestSaga {
+  name?: string
+  trigger?: string
+  filter?: string
+}
+
+function parseManifestSagas(manifestContent: string | null): ManifestSaga[] {
+  if (!manifestContent) return []
   try {
     const doc = yaml.load(manifestContent) as Record<string, unknown> | null
-    if (!doc || typeof doc !== 'object') return false
+    if (!doc || typeof doc !== 'object') return []
     const sagas = doc.sagas
-    return Array.isArray(sagas) && sagas.length > 0
+    return Array.isArray(sagas) ? sagas : []
   } catch {
-    return false
+    return []
   }
+}
+
+function detectSagas(manifestContent: string | null, starlarkFiles: StarlarkFile[]): boolean {
+  if (starlarkFiles.length > 0) return true
+  return parseManifestSagas(manifestContent).length > 0
 }
 
 export function usePatternFiles(item: CookbookItem | undefined): PatternFilesState {
   return useMemo(() => {
-    const empty: PatternFilesState = { starlarkFiles: [], manifestContent: null, hasSagas: false, isLoading: false }
+    const empty: PatternFilesState = { starlarkFiles: [], manifestContent: null, hasSagas: false, sagaTrigger: null, isLoading: false }
     if (!item || item.type !== 'registry:pattern') return empty
 
     const files = item.files ?? []
@@ -51,8 +62,10 @@ export function usePatternFiles(item: CookbookItem | undefined): PatternFilesSta
       }))
       .filter((f) => f.content.length > 0)
 
-    const hasSagas = detectSagas(manifestContent, starlarkFiles)
+    const manifestSagas = parseManifestSagas(manifestContent)
+    const hasSagas = starlarkFiles.length > 0 || manifestSagas.length > 0
+    const sagaTrigger = manifestSagas[0]?.trigger ?? null
 
-    return { starlarkFiles, manifestContent, hasSagas, isLoading: false }
+    return { starlarkFiles, manifestContent, hasSagas, sagaTrigger, isLoading: false }
   }, [item])
 }

--- a/frontend/src/features/cookbook/hooks/use-pattern-files.ts
+++ b/frontend/src/features/cookbook/hooks/use-pattern-files.ts
@@ -39,10 +39,6 @@ function parseManifestSagas(manifestContent: string | null): ManifestSaga[] {
   }
 }
 
-function detectSagas(manifestContent: string | null, starlarkFiles: StarlarkFile[]): boolean {
-  if (starlarkFiles.length > 0) return true
-  return parseManifestSagas(manifestContent).length > 0
-}
 
 export function usePatternFiles(item: CookbookItem | undefined): PatternFilesState {
   return useMemo(() => {

--- a/frontend/src/features/cookbook/lib/star-parser.ts
+++ b/frontend/src/features/cookbook/lib/star-parser.ts
@@ -24,6 +24,22 @@ export interface EarlyExit {
 }
 
 /**
+ * Extract the producing service name from a trigger string.
+ * - "event:position-keeping.transaction-captured.v1" → "position-keeping"
+ * - "webhook:stripe.payment_intent.succeeded" → "stripe"
+ * - "api:/v1/payments/stripe" → null (no service)
+ */
+export function parseTriggerService(trigger: string | null): string | null {
+  if (!trigger) return null
+  if (trigger.startsWith('event:') || trigger.startsWith('webhook:')) {
+    const rest = trigger.slice(trigger.indexOf(':') + 1)
+    const dotIdx = rest.indexOf('.')
+    return dotIdx > 0 ? rest.slice(0, dotIdx) : rest
+  }
+  return null
+}
+
+/**
  * Parse a Starlark saga source file into a structured SagaFlow.
  * Uses regex-based static analysis (not execution).
  */

--- a/frontend/src/features/cookbook/pages/detail.tsx
+++ b/frontend/src/features/cookbook/pages/detail.tsx
@@ -225,7 +225,7 @@ export function CookbookDetailPage() {
     if (!firstStarlarkContent) return null
     const flow = parseStarlarkSaga(firstStarlarkContent)
     // Manifest YAML is source of truth for trigger
-    if (sagaTrigger) flow.trigger = sagaTrigger
+    flow.trigger = sagaTrigger
     return flow
   }, [firstStarlarkContent, sagaTrigger])
 

--- a/frontend/src/features/cookbook/pages/detail.tsx
+++ b/frontend/src/features/cookbook/pages/detail.tsx
@@ -217,14 +217,17 @@ export function CookbookDetailPage() {
   const { items, isLoading: catalogueLoading } = useCookbook()
 
   const item = items.find((i) => i.name === name)
-  const { starlarkFiles, manifestContent, hasSagas } = usePatternFiles(item)
+  const { starlarkFiles, manifestContent, hasSagas, sagaTrigger } = usePatternFiles(item)
 
   const firstStarlarkContent = starlarkFiles.length > 0 ? starlarkFiles[0].content : null
 
   const sagaFlow = useMemo(() => {
     if (!firstStarlarkContent) return null
-    return parseStarlarkSaga(firstStarlarkContent)
-  }, [firstStarlarkContent])
+    const flow = parseStarlarkSaga(firstStarlarkContent)
+    // Manifest YAML is source of truth for trigger
+    if (sagaTrigger) flow.trigger = sagaTrigger
+    return flow
+  }, [firstStarlarkContent, sagaTrigger])
 
   if (catalogueLoading) {
     return <DetailSkeleton fieldCount={3} tabCount={3} showBackNav />


### PR DESCRIPTION
## Summary

- Manifest YAML is now the source of truth for saga triggers (not Starlark header comments)
- Trigger's producing service (parsed from `event:` / `webhook:` prefix) is included in the service color palette and legend
- Start node shows the trigger as a colored badge matching its producing service
- Clicking a trigger service in the legend highlights the start node and dims unrelated steps

## Changes Made

- **use-pattern-files.ts**: Parse manifest YAML `sagas[0].trigger` and expose as `sagaTrigger`
- **detail.tsx**: Override Starlark-parsed trigger with manifest trigger
- **saga-flow.tsx**: New `parseTriggerService()` extracts service from trigger string; trigger service included in color map; StartNode renders colored trigger badge with highlight/dim support; legend shows "trigger" label

## Testing

- 10 new tests (3 for sagaTrigger extraction, 5 for parseTriggerService, 2 for trigger in diagram)
- All 158 cookbook tests pass
- Typecheck clean

## Trigger Format Examples

| Trigger | Parsed Service |
|---------|---------------|
| `event:position-keeping.transaction-captured.v1` | `position-keeping` |
| `webhook:stripe.payment_intent.succeeded` | `stripe` |
| `api:/v1/payments/stripe` | _(none — no producing service)_ |