### PR TITLE
feat: Add CEL filter static analyzer

### DIFF
--- a/frontend/src/features/manifests/lib/cel-filter-analyzer.test.ts
+++ b/frontend/src/features/manifests/lib/cel-filter-analyzer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { analyzeFilter, EventContext } from './cel-filter-analyzer';
+import { analyzeFilter, type EventContext } from './cel-filter-analyzer';
 
 describe('analyzeFilter', () => {
   it('returns pass for empty filter', () => {

--- a/frontend/src/features/manifests/lib/cel-filter-analyzer.test.ts
+++ b/frontend/src/features/manifests/lib/cel-filter-analyzer.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+
+import { analyzeFilter, EventContext } from './cel-filter-analyzer';
+
+describe('analyzeFilter', () => {
+  it('returns pass for empty filter', () => {
+    const result = analyzeFilter('', { instrumentCode: 'GBP' });
+    expect(result.result).toBe('pass');
+    expect(result.reason).toBe('No filter applied');
+  });
+
+  it('returns pass for whitespace-only filter', () => {
+    const result = analyzeFilter('   ', { instrumentCode: 'GBP' });
+    expect(result.result).toBe('pass');
+  });
+
+  describe('simple equality', () => {
+    it('returns pass when field matches context', () => {
+      const context: EventContext = { instrumentCode: 'GBP' };
+      const result = analyzeFilter(
+        "event.instrument_code == 'GBP'",
+        context,
+      );
+      expect(result.result).toBe('pass');
+    });
+
+    it('returns fail when field does not match context', () => {
+      const context: EventContext = { instrumentCode: 'USD' };
+      const result = analyzeFilter(
+        "event.instrument_code == 'GBP'",
+        context,
+      );
+      expect(result.result).toBe('fail');
+      expect(result.reason).toContain('USD');
+    });
+
+    it('handles direction field', () => {
+      const context: EventContext = { direction: 'DEBIT' };
+      const result = analyzeFilter("event.direction == 'DEBIT'", context);
+      expect(result.result).toBe('pass');
+    });
+
+    it('handles account_type field', () => {
+      const context: EventContext = { accountType: 'SETTLEMENT' };
+      const result = analyzeFilter(
+        "event.account_type == 'SETTLEMENT'",
+        context,
+      );
+      expect(result.result).toBe('pass');
+    });
+  });
+
+  describe('simple inequality', () => {
+    it('returns pass when field does not equal value', () => {
+      const context: EventContext = { instrumentCode: 'USD' };
+      const result = analyzeFilter(
+        "event.instrument_code != 'GBP'",
+        context,
+      );
+      expect(result.result).toBe('pass');
+    });
+
+    it('returns fail when field equals value', () => {
+      const context: EventContext = { instrumentCode: 'GBP' };
+      const result = analyzeFilter(
+        "event.instrument_code != 'GBP'",
+        context,
+      );
+      expect(result.result).toBe('fail');
+    });
+  });
+
+  describe('has() checks', () => {
+    it('returns indeterminate for has() expressions', () => {
+      const result = analyzeFilter('has(event.metadata)', {});
+      expect(result.result).toBe('indeterminate');
+      expect(result.reason).toContain('has()');
+    });
+  });
+
+  describe('chain_depth references', () => {
+    it('returns indeterminate for chain_depth expressions', () => {
+      const result = analyzeFilter('chain_depth > 0', {});
+      expect(result.result).toBe('indeterminate');
+      expect(result.reason).toContain('chain_depth');
+    });
+  });
+
+  describe('unknown fields', () => {
+    it('returns indeterminate for unknown event fields', () => {
+      const result = analyzeFilter(
+        "event.unknown_field == 'value'",
+        {},
+      );
+      expect(result.result).toBe('indeterminate');
+      expect(result.reason).toContain('Unknown field');
+    });
+
+    it('returns indeterminate when context value is missing', () => {
+      const result = analyzeFilter(
+        "event.instrument_code == 'GBP'",
+        {},
+      );
+      expect(result.result).toBe('indeterminate');
+      expect(result.reason).toContain('missing');
+    });
+  });
+
+  describe('compound && expressions', () => {
+    it('returns pass when all parts pass', () => {
+      const context: EventContext = {
+        instrumentCode: 'GBP',
+        direction: 'CREDIT',
+      };
+      const result = analyzeFilter(
+        "event.instrument_code == 'GBP' && event.direction == 'CREDIT'",
+        context,
+      );
+      expect(result.result).toBe('pass');
+    });
+
+    it('returns fail when any part fails', () => {
+      const context: EventContext = {
+        instrumentCode: 'GBP',
+        direction: 'DEBIT',
+      };
+      const result = analyzeFilter(
+        "event.instrument_code == 'GBP' && event.direction == 'CREDIT'",
+        context,
+      );
+      expect(result.result).toBe('fail');
+    });
+
+    it('returns indeterminate when some parts are indeterminate and none fail', () => {
+      const context: EventContext = { instrumentCode: 'GBP' };
+      const result = analyzeFilter(
+        "event.instrument_code == 'GBP' && has(event.metadata)",
+        context,
+      );
+      expect(result.result).toBe('indeterminate');
+    });
+  });
+
+  describe('compound || expressions', () => {
+    it('returns pass when any part passes', () => {
+      const context: EventContext = {
+        instrumentCode: 'USD',
+        direction: 'CREDIT',
+      };
+      const result = analyzeFilter(
+        "event.instrument_code == 'GBP' || event.direction == 'CREDIT'",
+        context,
+      );
+      expect(result.result).toBe('pass');
+    });
+
+    it('returns fail when all parts fail', () => {
+      const context: EventContext = {
+        instrumentCode: 'USD',
+        direction: 'DEBIT',
+      };
+      const result = analyzeFilter(
+        "event.instrument_code == 'GBP' || event.direction == 'CREDIT'",
+        context,
+      );
+      expect(result.result).toBe('fail');
+    });
+
+    it('returns indeterminate when some parts are indeterminate and none pass', () => {
+      const context: EventContext = { instrumentCode: 'USD' };
+      const result = analyzeFilter(
+        "event.instrument_code == 'GBP' || has(event.metadata)",
+        context,
+      );
+      expect(result.result).toBe('indeterminate');
+    });
+  });
+
+  describe('complex expressions', () => {
+    it('returns indeterminate for unrecognized expressions', () => {
+      const result = analyzeFilter(
+        'event.amount > 100',
+        {},
+      );
+      expect(result.result).toBe('indeterminate');
+      expect(result.reason).toContain('Complex expression');
+    });
+  });
+});

--- a/frontend/src/features/manifests/lib/cel-filter-analyzer.ts
+++ b/frontend/src/features/manifests/lib/cel-filter-analyzer.ts
@@ -1,0 +1,196 @@
+export type FilterResult = 'pass' | 'fail' | 'indeterminate';
+
+export interface FilterAnalysis {
+  result: FilterResult;
+  reason: string;
+}
+
+export interface EventContext {
+  instrumentCode?: string;
+  direction?: 'DEBIT' | 'CREDIT';
+  accountType?: string;
+  [key: string]: string | undefined;
+}
+
+const FIELD_MAP: Record<string, keyof EventContext> = {
+  'event.instrument_code': 'instrumentCode',
+  'event.direction': 'direction',
+  'event.account_type': 'accountType',
+};
+
+function parseSimpleComparison(
+  expr: string,
+  context: EventContext,
+): FilterAnalysis | null {
+  // Match: event.field == 'value' or event.field == "value"
+  const eqMatch = expr.match(
+    /^(event\.\w+)\s*==\s*['"]([^'"]*)['"]\s*$/,
+  );
+  if (eqMatch) {
+    const [, field, value] = eqMatch;
+    const contextKey = FIELD_MAP[field];
+    if (!contextKey) {
+      return {
+        result: 'indeterminate',
+        reason: `Unknown field: ${field}`,
+      };
+    }
+    const contextValue = context[contextKey];
+    if (contextValue === undefined) {
+      return {
+        result: 'indeterminate',
+        reason: `Context missing value for ${field}`,
+      };
+    }
+    return contextValue === value
+      ? { result: 'pass', reason: `${field} equals '${value}'` }
+      : {
+          result: 'fail',
+          reason: `${field} is '${contextValue}', expected '${value}'`,
+        };
+  }
+
+  // Match: event.field != 'value' or event.field != "value"
+  const neqMatch = expr.match(
+    /^(event\.\w+)\s*!=\s*['"]([^'"]*)['"]\s*$/,
+  );
+  if (neqMatch) {
+    const [, field, value] = neqMatch;
+    const contextKey = FIELD_MAP[field];
+    if (!contextKey) {
+      return {
+        result: 'indeterminate',
+        reason: `Unknown field: ${field}`,
+      };
+    }
+    const contextValue = context[contextKey];
+    if (contextValue === undefined) {
+      return {
+        result: 'indeterminate',
+        reason: `Context missing value for ${field}`,
+      };
+    }
+    return contextValue !== value
+      ? { result: 'pass', reason: `${field} is not '${value}'` }
+      : {
+          result: 'fail',
+          reason: `${field} is '${contextValue}', which equals '${value}'`,
+        };
+  }
+
+  return null;
+}
+
+function splitCompoundParts(
+  expr: string,
+  operator: '&&' | '||',
+): string[] | null {
+  // Split on the operator, respecting parentheses depth
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+  const op = operator;
+
+  for (let i = 0; i < expr.length; i++) {
+    const char = expr[i];
+    if (char === '(') {
+      depth++;
+      current += char;
+    } else if (char === ')') {
+      depth--;
+      current += char;
+    } else if (
+      depth === 0 &&
+      expr.substring(i, i + op.length) === op
+    ) {
+      parts.push(current.trim());
+      current = '';
+      i += op.length - 1;
+    } else {
+      current += char;
+    }
+  }
+  if (current.trim()) {
+    parts.push(current.trim());
+  }
+
+  return parts.length > 1 ? parts : null;
+}
+
+function analyzeExpression(
+  expr: string,
+  context: EventContext,
+): FilterAnalysis {
+  const trimmed = expr.trim();
+
+  // has() checks
+  if (/\bhas\s*\(/.test(trimmed)) {
+    return {
+      result: 'indeterminate',
+      reason: 'has() checks require runtime evaluation',
+    };
+  }
+
+  // chain_depth references
+  if (/\bchain_depth\b/.test(trimmed)) {
+    return {
+      result: 'indeterminate',
+      reason: 'chain_depth requires runtime evaluation',
+    };
+  }
+
+  // Simple comparison
+  const simple = parseSimpleComparison(trimmed, context);
+  if (simple) {
+    return simple;
+  }
+
+  // Compound && expression
+  const andParts = splitCompoundParts(trimmed, '&&');
+  if (andParts) {
+    const results = andParts.map((part) => analyzeExpression(part, context));
+    if (results.every((r) => r.result === 'pass')) {
+      return { result: 'pass', reason: 'All conditions pass' };
+    }
+    if (results.some((r) => r.result === 'fail')) {
+      const failing = results.find((r) => r.result === 'fail')!;
+      return { result: 'fail', reason: failing.reason };
+    }
+    return {
+      result: 'indeterminate',
+      reason: 'Some conditions require runtime evaluation',
+    };
+  }
+
+  // Compound || expression
+  const orParts = splitCompoundParts(trimmed, '||');
+  if (orParts) {
+    const results = orParts.map((part) => analyzeExpression(part, context));
+    if (results.some((r) => r.result === 'pass')) {
+      return { result: 'pass', reason: 'At least one condition passes' };
+    }
+    if (results.every((r) => r.result === 'fail')) {
+      return { result: 'fail', reason: 'All conditions fail' };
+    }
+    return {
+      result: 'indeterminate',
+      reason: 'Some conditions require runtime evaluation',
+    };
+  }
+
+  return {
+    result: 'indeterminate',
+    reason: 'Complex expression requires runtime evaluation',
+  };
+}
+
+export function analyzeFilter(
+  filterExpression: string,
+  context: EventContext,
+): FilterAnalysis {
+  if (!filterExpression || filterExpression.trim() === '') {
+    return { result: 'pass', reason: 'No filter applied' };
+  }
+
+  return analyzeExpression(filterExpression, context);
+}

--- a/frontend/src/features/manifests/lib/cel-filter-analyzer.ts
+++ b/frontend/src/features/manifests/lib/cel-filter-analyzer.ts
@@ -145,7 +145,23 @@ function analyzeExpression(
     return simple;
   }
 
-  // Compound && expression
+  // Compound || expression (lower precedence, split first)
+  const orParts = splitCompoundParts(trimmed, '||');
+  if (orParts) {
+    const results = orParts.map((part) => analyzeExpression(part, context));
+    if (results.some((r) => r.result === 'pass')) {
+      return { result: 'pass', reason: 'At least one condition passes' };
+    }
+    if (results.every((r) => r.result === 'fail')) {
+      return { result: 'fail', reason: 'All conditions fail' };
+    }
+    return {
+      result: 'indeterminate',
+      reason: 'Some conditions require runtime evaluation',
+    };
+  }
+
+  // Compound && expression (higher precedence, split second)
   const andParts = splitCompoundParts(trimmed, '&&');
   if (andParts) {
     const results = andParts.map((part) => analyzeExpression(part, context));
@@ -155,22 +171,6 @@ function analyzeExpression(
     if (results.some((r) => r.result === 'fail')) {
       const failing = results.find((r) => r.result === 'fail')!;
       return { result: 'fail', reason: failing.reason };
-    }
-    return {
-      result: 'indeterminate',
-      reason: 'Some conditions require runtime evaluation',
-    };
-  }
-
-  // Compound || expression
-  const orParts = splitCompoundParts(trimmed, '||');
-  if (orParts) {
-    const results = orParts.map((part) => analyzeExpression(part, context));
-    if (results.some((r) => r.result === 'pass')) {
-      return { result: 'pass', reason: 'At least one condition passes' };
-    }
-    if (results.every((r) => r.result === 'fail')) {
-      return { result: 'fail', reason: 'All conditions fail' };
     }
     return {
       result: 'indeterminate',


### PR DESCRIPTION
## Summary

- Implement `cel-filter-analyzer.ts` for static analysis of CEL filter expressions used in manifest visualization
- Support simple equality/inequality checks (`event.field == 'value'`, `event.field != 'value'`) with field mapping to typed `EventContext`
- Handle compound `&&` / `||` expressions with correct short-circuit semantics (all pass/any fail for AND, any pass/all fail for OR)
- Gracefully return `indeterminate` for runtime-only constructs (`has()`, `chain_depth`) and unrecognized expressions

Task: 038-manifest-business-model-visualization.6

## Test plan

- [x] Empty filter returns pass (19 tests, all passing)
- [x] Simple equality with matching/non-matching context
- [x] Simple inequality with matching/non-matching context
- [x] `has()` returns indeterminate
- [x] `chain_depth` reference returns indeterminate
- [x] Unknown field returns indeterminate
- [x] Missing context value returns indeterminate
- [x] Compound `&&` with all pass, any fail, and mixed indeterminate
- [x] Compound `||` with any pass, all fail, and mixed indeterminate
- [x] Complex unrecognized expressions return indeterminate