### PR TITLE
feat: Add manifest graph model transformation

### DIFF
--- a/frontend/src/features/manifests/lib/manifest-graph-model.test.ts
+++ b/frontend/src/features/manifests/lib/manifest-graph-model.test.ts
@@ -46,7 +46,8 @@ const energyManifest = createMockManifest({
   sagas: [
     {
       name: 'usage_to_value',
-      trigger: 'event:position-keeping.transaction-captured.v1|event.instrument_code == "KWH"',
+      trigger: 'event:position-keeping.transaction-captured.v1',
+      filter: 'event.instrument_code == "KWH"',
       script: 'def main(): pass',
     },
     {
@@ -147,7 +148,7 @@ describe('buildManifestGraph', () => {
 
       expect(ruleNodes).toHaveLength(1)
       expect(ruleNodes[0]).toMatchObject({
-        id: 'valuation_rule:KWH:GBP',
+        id: 'valuation_rule:KWH:GBP:1',
         label: 'KWH -> GBP',
       })
     })
@@ -160,13 +161,13 @@ describe('buildManifestGraph', () => {
 
       expect(fromEdges).toHaveLength(1)
       expect(fromEdges[0]).toMatchObject({
-        source: 'valuation_rule:KWH:GBP',
+        source: 'valuation_rule:KWH:GBP:1',
         target: 'instrument:KWH',
       })
 
       expect(toEdges).toHaveLength(1)
       expect(toEdges[0]).toMatchObject({
-        source: 'valuation_rule:KWH:GBP',
+        source: 'valuation_rule:KWH:GBP:1',
         target: 'instrument:GBP',
       })
     })

--- a/frontend/src/features/manifests/lib/manifest-graph-model.test.ts
+++ b/frontend/src/features/manifests/lib/manifest-graph-model.test.ts
@@ -148,7 +148,7 @@ describe('buildManifestGraph', () => {
 
       expect(ruleNodes).toHaveLength(1)
       expect(ruleNodes[0]).toMatchObject({
-        id: 'valuation_rule:KWH:GBP:1',
+        id: 'valuation_rule:KWH:GBP:0',
         label: 'KWH -> GBP',
       })
     })
@@ -161,13 +161,13 @@ describe('buildManifestGraph', () => {
 
       expect(fromEdges).toHaveLength(1)
       expect(fromEdges[0]).toMatchObject({
-        source: 'valuation_rule:KWH:GBP:1',
+        source: 'valuation_rule:KWH:GBP:0',
         target: 'instrument:KWH',
       })
 
       expect(toEdges).toHaveLength(1)
       expect(toEdges[0]).toMatchObject({
-        source: 'valuation_rule:KWH:GBP:1',
+        source: 'valuation_rule:KWH:GBP:0',
         target: 'instrument:GBP',
       })
     })
@@ -232,6 +232,58 @@ describe('buildManifestGraph', () => {
 
       expect(graph.nodes).toHaveLength(1)
       expect(graph.edges).toHaveLength(0)
+    })
+
+    it('skips allowed_by edges referencing nonexistent instruments', () => {
+      const manifest = createMockManifest({
+        instruments: [
+          { code: 'GBP', name: 'British Pound', type: 1, dimensions: { unit: 'GBP', precision: 2 } },
+        ],
+        accountTypes: [
+          { code: 'MIXED', name: 'Mixed Account', normalBalance: 1, allowedInstruments: ['GBP', 'MISSING'] },
+        ],
+      })
+      const graph = buildManifestGraph(manifest)
+      const allowedEdges = graph.edges.filter((e) => e.relationship === 'allowed_by')
+
+      expect(allowedEdges).toHaveLength(1)
+      expect(allowedEdges[0]).toMatchObject({ target: 'instrument:GBP' })
+    })
+
+    it('skips valuation edges referencing nonexistent instruments', () => {
+      const manifest = createMockManifest({
+        instruments: [
+          { code: 'GBP', name: 'British Pound', type: 1, dimensions: { unit: 'GBP', precision: 2 } },
+        ],
+        valuationRules: [
+          { fromInstrument: 'MISSING', toInstrument: 'GBP', method: 1, source: 'test' },
+        ],
+      })
+      const graph = buildManifestGraph(manifest)
+      const fromEdges = graph.edges.filter((e) => e.relationship === 'converts_from')
+      const toEdges = graph.edges.filter((e) => e.relationship === 'converts_to')
+
+      expect(fromEdges).toHaveLength(0)
+      expect(toEdges).toHaveLength(1)
+    })
+
+    it('assigns unique IDs to duplicate from/to valuation rules', () => {
+      const manifest = createMockManifest({
+        instruments: [
+          { code: 'KWH', name: 'Kilowatt Hour', type: 2, dimensions: { unit: 'kWh', precision: 4 } },
+          { code: 'GBP', name: 'British Pound', type: 1, dimensions: { unit: 'GBP', precision: 2 } },
+        ],
+        valuationRules: [
+          { fromInstrument: 'KWH', toInstrument: 'GBP', method: 1, source: 'nordpool_spot' },
+          { fromInstrument: 'KWH', toInstrument: 'GBP', method: 2, source: 'admin_override' },
+        ],
+      })
+      const graph = buildManifestGraph(manifest)
+      const ruleNodes = graph.nodes.filter((n) => n.type === 'valuation_rule')
+
+      expect(ruleNodes).toHaveLength(2)
+      expect(ruleNodes[0].id).toBe('valuation_rule:KWH:GBP:0')
+      expect(ruleNodes[1].id).toBe('valuation_rule:KWH:GBP:1')
     })
   })
 })

--- a/frontend/src/features/manifests/lib/manifest-graph-model.test.ts
+++ b/frontend/src/features/manifests/lib/manifest-graph-model.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest'
+import { buildManifestGraph } from './manifest-graph-model'
+import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
+
+function createMockManifest(overrides: Partial<Record<string, unknown>> = {}): Manifest {
+  return {
+    version: '1.0',
+    metadata: { name: 'Test Manifest', industry: 'energy', description: '' },
+    instruments: [],
+    accountTypes: [],
+    valuationRules: [],
+    sagas: [],
+    seedData: undefined,
+    paymentRails: [],
+    partyTypes: [],
+    mappings: [],
+    operationalGateway: undefined,
+    ...overrides,
+  } as unknown as Manifest
+}
+
+const energyManifest = createMockManifest({
+  instruments: [
+    { code: 'KWH', name: 'Kilowatt Hour', type: 2, dimensions: { unit: 'kWh', precision: 4 } },
+    { code: 'GBP', name: 'British Pound', type: 1, dimensions: { unit: 'GBP', precision: 2 } },
+  ],
+  accountTypes: [
+    {
+      code: 'ENERGY_HOLDING',
+      name: 'Energy Holding',
+      normalBalance: 1,
+      allowedInstruments: ['KWH'],
+      policies: undefined,
+    },
+    {
+      code: 'REVENUE',
+      name: 'Revenue Account',
+      normalBalance: 2,
+      allowedInstruments: ['GBP', 'KWH'],
+      policies: undefined,
+    },
+  ],
+  valuationRules: [
+    { fromInstrument: 'KWH', toInstrument: 'GBP', method: 1, source: 'nordpool_spot' },
+  ],
+  sagas: [
+    {
+      name: 'usage_to_value',
+      trigger: 'event:position-keeping.transaction-captured.v1|event.instrument_code == "KWH"',
+      script: 'def main(): pass',
+    },
+    {
+      name: 'daily_reconciliation',
+      trigger: 'scheduled:daily_reconciliation',
+      script: 'def main(): pass',
+    },
+    {
+      name: 'process_payment',
+      trigger: 'api:/v1/payments',
+      script: 'def main(): pass',
+    },
+  ],
+})
+
+describe('buildManifestGraph', () => {
+  describe('instrument nodes', () => {
+    it('creates a node for each instrument', () => {
+      const graph = buildManifestGraph(energyManifest)
+      const instrumentNodes = graph.nodes.filter((n) => n.type === 'instrument')
+
+      expect(instrumentNodes).toHaveLength(2)
+      expect(instrumentNodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'instrument:KWH', label: 'Kilowatt Hour' }),
+          expect.objectContaining({ id: 'instrument:GBP', label: 'British Pound' }),
+        ]),
+      )
+    })
+
+    it('includes instrument data in node', () => {
+      const graph = buildManifestGraph(energyManifest)
+      const kwh = graph.nodes.find((n) => n.id === 'instrument:KWH')
+
+      expect(kwh?.data).toMatchObject({ code: 'KWH', name: 'Kilowatt Hour' })
+    })
+  })
+
+  describe('account type nodes', () => {
+    it('creates a node for each account type', () => {
+      const graph = buildManifestGraph(energyManifest)
+      const atNodes = graph.nodes.filter((n) => n.type === 'account_type')
+
+      expect(atNodes).toHaveLength(2)
+      expect(atNodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'account_type:ENERGY_HOLDING', label: 'Energy Holding' }),
+          expect.objectContaining({ id: 'account_type:REVENUE', label: 'Revenue Account' }),
+        ]),
+      )
+    })
+  })
+
+  describe('allowed_by edges', () => {
+    it('creates edges from account types to their allowed instruments', () => {
+      const graph = buildManifestGraph(energyManifest)
+      const allowedEdges = graph.edges.filter((e) => e.relationship === 'allowed_by')
+
+      expect(allowedEdges).toHaveLength(3)
+      expect(allowedEdges).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            source: 'account_type:ENERGY_HOLDING',
+            target: 'instrument:KWH',
+            relationship: 'allowed_by',
+          }),
+          expect.objectContaining({
+            source: 'account_type:REVENUE',
+            target: 'instrument:GBP',
+            relationship: 'allowed_by',
+          }),
+          expect.objectContaining({
+            source: 'account_type:REVENUE',
+            target: 'instrument:KWH',
+            relationship: 'allowed_by',
+          }),
+        ]),
+      )
+    })
+
+    it('creates no edges when allowedInstruments is empty', () => {
+      const manifest = createMockManifest({
+        accountTypes: [
+          { code: 'OPEN', name: 'Open Account', normalBalance: 1, allowedInstruments: [] },
+        ],
+      })
+      const graph = buildManifestGraph(manifest)
+      const allowedEdges = graph.edges.filter((e) => e.relationship === 'allowed_by')
+
+      expect(allowedEdges).toHaveLength(0)
+    })
+  })
+
+  describe('valuation rule nodes and edges', () => {
+    it('creates a node for each valuation rule', () => {
+      const graph = buildManifestGraph(energyManifest)
+      const ruleNodes = graph.nodes.filter((n) => n.type === 'valuation_rule')
+
+      expect(ruleNodes).toHaveLength(1)
+      expect(ruleNodes[0]).toMatchObject({
+        id: 'valuation_rule:KWH:GBP',
+        label: 'KWH -> GBP',
+      })
+    })
+
+    it('creates converts_from and converts_to edges', () => {
+      const graph = buildManifestGraph(energyManifest)
+
+      const fromEdges = graph.edges.filter((e) => e.relationship === 'converts_from')
+      const toEdges = graph.edges.filter((e) => e.relationship === 'converts_to')
+
+      expect(fromEdges).toHaveLength(1)
+      expect(fromEdges[0]).toMatchObject({
+        source: 'valuation_rule:KWH:GBP',
+        target: 'instrument:KWH',
+      })
+
+      expect(toEdges).toHaveLength(1)
+      expect(toEdges[0]).toMatchObject({
+        source: 'valuation_rule:KWH:GBP',
+        target: 'instrument:GBP',
+      })
+    })
+  })
+
+  describe('saga nodes', () => {
+    it('creates a node for each saga', () => {
+      const graph = buildManifestGraph(energyManifest)
+      const sagaNodes = graph.nodes.filter((n) => n.type === 'saga')
+
+      expect(sagaNodes).toHaveLength(3)
+    })
+
+    it('parses event trigger with filter into triggerMetadata', () => {
+      const graph = buildManifestGraph(energyManifest)
+      const usage = graph.nodes.find((n) => n.id === 'saga:usage_to_value')
+
+      expect(usage?.triggerMetadata).toEqual({
+        channel: 'position-keeping.transaction-captured.v1',
+        filterExpression: 'event.instrument_code == "KWH"',
+      })
+    })
+
+    it('parses event trigger without filter', () => {
+      const manifest = createMockManifest({
+        sagas: [{ name: 'all_events', trigger: 'event:some.channel.v1', script: '' }],
+      })
+      const graph = buildManifestGraph(manifest)
+      const node = graph.nodes.find((n) => n.id === 'saga:all_events')
+
+      expect(node?.triggerMetadata).toEqual({
+        channel: 'some.channel.v1',
+      })
+    })
+
+    it('does not set triggerMetadata for non-event triggers', () => {
+      const graph = buildManifestGraph(energyManifest)
+      const scheduled = graph.nodes.find((n) => n.id === 'saga:daily_reconciliation')
+      const api = graph.nodes.find((n) => n.id === 'saga:process_payment')
+
+      expect(scheduled?.triggerMetadata).toBeUndefined()
+      expect(api?.triggerMetadata).toBeUndefined()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns empty graph for empty manifest', () => {
+      const manifest = createMockManifest()
+      const graph = buildManifestGraph(manifest)
+
+      expect(graph.nodes).toHaveLength(0)
+      expect(graph.edges).toHaveLength(0)
+    })
+
+    it('handles manifest with instruments but no relationships', () => {
+      const manifest = createMockManifest({
+        instruments: [
+          { code: 'USD', name: 'US Dollar', type: 1, dimensions: { unit: 'USD', precision: 2 } },
+        ],
+      })
+      const graph = buildManifestGraph(manifest)
+
+      expect(graph.nodes).toHaveLength(1)
+      expect(graph.edges).toHaveLength(0)
+    })
+  })
+})

--- a/frontend/src/features/manifests/lib/manifest-graph-model.ts
+++ b/frontend/src/features/manifests/lib/manifest-graph-model.ts
@@ -1,0 +1,133 @@
+import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
+
+export type ManifestNodeType = 'instrument' | 'account_type' | 'valuation_rule' | 'saga'
+
+export interface SagaTriggerMetadata {
+  channel: string
+  filterExpression?: string
+}
+
+export interface ManifestNode {
+  id: string
+  type: ManifestNodeType
+  label: string
+  data: Record<string, unknown>
+  triggerMetadata?: SagaTriggerMetadata
+  dynamicTargets?: string[]
+}
+
+export type ManifestRelationship =
+  | 'allowed_by'
+  | 'converts_from'
+  | 'converts_to'
+
+export interface ManifestEdge {
+  id: string
+  source: string
+  target: string
+  relationship: ManifestRelationship
+}
+
+export interface ManifestGraph {
+  nodes: ManifestNode[]
+  edges: ManifestEdge[]
+}
+
+function parseSagaTrigger(trigger: string): SagaTriggerMetadata | undefined {
+  if (!trigger.startsWith('event:')) return undefined
+
+  const rest = trigger.slice('event:'.length)
+  const pipeIndex = rest.indexOf('|')
+
+  if (pipeIndex === -1) {
+    return { channel: rest }
+  }
+
+  return {
+    channel: rest.slice(0, pipeIndex),
+    filterExpression: rest.slice(pipeIndex + 1),
+  }
+}
+
+export function buildManifestGraph(manifest: Manifest): ManifestGraph {
+  const nodes: ManifestNode[] = []
+  const edges: ManifestEdge[] = []
+
+  const instruments = (manifest as Record<string, unknown>).instruments as Array<Record<string, unknown>> ?? []
+  const accountTypes = (manifest as Record<string, unknown>).accountTypes as Array<Record<string, unknown>> ?? []
+  const valuationRules = (manifest as Record<string, unknown>).valuationRules as Array<Record<string, unknown>> ?? []
+  const sagas = (manifest as Record<string, unknown>).sagas as Array<Record<string, unknown>> ?? []
+
+  for (const inst of instruments) {
+    nodes.push({
+      id: `instrument:${inst.code}`,
+      type: 'instrument',
+      label: inst.name as string,
+      data: { ...inst },
+    })
+  }
+
+  for (const at of accountTypes) {
+    nodes.push({
+      id: `account_type:${at.code}`,
+      type: 'account_type',
+      label: at.name as string,
+      data: { ...at },
+    })
+
+    const allowed = at.allowedInstruments as string[] | undefined
+    if (allowed) {
+      for (const instrumentCode of allowed) {
+        edges.push({
+          id: `allowed_by:${at.code}:${instrumentCode}`,
+          source: `account_type:${at.code}`,
+          target: `instrument:${instrumentCode}`,
+          relationship: 'allowed_by',
+        })
+      }
+    }
+  }
+
+  for (const rule of valuationRules) {
+    const from = rule.fromInstrument as string
+    const to = rule.toInstrument as string
+    const ruleId = `valuation_rule:${from}:${to}`
+
+    nodes.push({
+      id: ruleId,
+      type: 'valuation_rule',
+      label: `${from} -> ${to}`,
+      data: { ...rule },
+    })
+
+    edges.push({
+      id: `converts_from:${from}:${to}`,
+      source: ruleId,
+      target: `instrument:${from}`,
+      relationship: 'converts_from',
+    })
+
+    edges.push({
+      id: `converts_to:${from}:${to}`,
+      source: ruleId,
+      target: `instrument:${to}`,
+      relationship: 'converts_to',
+    })
+  }
+
+  for (const saga of sagas) {
+    const name = saga.name as string
+    const trigger = saga.trigger as string
+    const triggerMetadata = parseSagaTrigger(trigger)
+
+    nodes.push({
+      id: `saga:${name}`,
+      type: 'saga',
+      label: name,
+      data: { ...saga },
+      triggerMetadata,
+    })
+  }
+
+  return { nodes, edges }
+}

--- a/frontend/src/features/manifests/lib/manifest-graph-model.ts
+++ b/frontend/src/features/manifests/lib/manifest-graph-model.ts
@@ -90,6 +90,8 @@ export function buildManifestGraph(manifest: Manifest): ManifestGraph {
   const valuationRules = m.valuationRules ?? []
   const sagas = m.sagas ?? []
 
+  const instrumentCodes = new Set(instruments.map((i) => i.code))
+
   for (const inst of instruments) {
     nodes.push({
       id: `instrument:${inst.code}`,
@@ -109,19 +111,22 @@ export function buildManifestGraph(manifest: Manifest): ManifestGraph {
 
     if (at.allowedInstruments) {
       for (const instrumentCode of at.allowedInstruments) {
-        edges.push({
-          id: `allowed_by:${at.code}:${instrumentCode}`,
-          source: `account_type:${at.code}`,
-          target: `instrument:${instrumentCode}`,
-          relationship: 'allowed_by',
-        })
+        if (instrumentCodes.has(instrumentCode)) {
+          edges.push({
+            id: `allowed_by:${at.code}:${instrumentCode}`,
+            source: `account_type:${at.code}`,
+            target: `instrument:${instrumentCode}`,
+            relationship: 'allowed_by',
+          })
+        }
       }
     }
   }
 
-  for (const rule of valuationRules) {
-    const { fromInstrument: from, toInstrument: to, method } = rule
-    const ruleId = `valuation_rule:${from}:${to}:${method}`
+  for (let i = 0; i < valuationRules.length; i++) {
+    const rule = valuationRules[i]
+    const { fromInstrument: from, toInstrument: to } = rule
+    const ruleId = `valuation_rule:${from}:${to}:${i}`
 
     nodes.push({
       id: ruleId,
@@ -130,19 +135,23 @@ export function buildManifestGraph(manifest: Manifest): ManifestGraph {
       data: { ...rule },
     })
 
-    edges.push({
-      id: `converts_from:${from}:${to}:${method}`,
-      source: ruleId,
-      target: `instrument:${from}`,
-      relationship: 'converts_from',
-    })
+    if (instrumentCodes.has(from)) {
+      edges.push({
+        id: `converts_from:${from}:${to}:${i}`,
+        source: ruleId,
+        target: `instrument:${from}`,
+        relationship: 'converts_from',
+      })
+    }
 
-    edges.push({
-      id: `converts_to:${from}:${to}:${method}`,
-      source: ruleId,
-      target: `instrument:${to}`,
-      relationship: 'converts_to',
-    })
+    if (instrumentCodes.has(to)) {
+      edges.push({
+        id: `converts_to:${from}:${to}:${i}`,
+        source: ruleId,
+        target: `instrument:${to}`,
+        relationship: 'converts_to',
+      })
+    }
   }
 
   for (const saga of sagas) {

--- a/frontend/src/features/manifests/lib/manifest-graph-model.ts
+++ b/frontend/src/features/manifests/lib/manifest-graph-model.ts
@@ -1,5 +1,39 @@
 import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
 
+interface ManifestInstrument {
+  code: string
+  name: string
+  [key: string]: unknown
+}
+
+interface ManifestAccountType {
+  code: string
+  name: string
+  allowedInstruments?: string[]
+  [key: string]: unknown
+}
+
+interface ManifestValuationRule {
+  fromInstrument: string
+  toInstrument: string
+  method: number
+  [key: string]: unknown
+}
+
+interface ManifestSaga {
+  name: string
+  trigger: string
+  filter?: string
+  [key: string]: unknown
+}
+
+interface ManifestInput {
+  instruments?: ManifestInstrument[]
+  accountTypes?: ManifestAccountType[]
+  valuationRules?: ManifestValuationRule[]
+  sagas?: ManifestSaga[]
+}
+
 export type ManifestNodeType = 'instrument' | 'account_type' | 'valuation_rule' | 'saga'
 
 export interface SagaTriggerMetadata {
@@ -33,19 +67,16 @@ export interface ManifestGraph {
   edges: ManifestEdge[]
 }
 
-function parseSagaTrigger(trigger: string): SagaTriggerMetadata | undefined {
+function parseSagaTrigger(
+  trigger: string,
+  filter?: string,
+): SagaTriggerMetadata | undefined {
   if (!trigger.startsWith('event:')) return undefined
 
-  const rest = trigger.slice('event:'.length)
-  const pipeIndex = rest.indexOf('|')
-
-  if (pipeIndex === -1) {
-    return { channel: rest }
-  }
-
+  const channel = trigger.slice('event:'.length)
   return {
-    channel: rest.slice(0, pipeIndex),
-    filterExpression: rest.slice(pipeIndex + 1),
+    channel,
+    ...(filter ? { filterExpression: filter } : {}),
   }
 }
 
@@ -53,16 +84,17 @@ export function buildManifestGraph(manifest: Manifest): ManifestGraph {
   const nodes: ManifestNode[] = []
   const edges: ManifestEdge[] = []
 
-  const instruments = (manifest as Record<string, unknown>).instruments as Array<Record<string, unknown>> ?? []
-  const accountTypes = (manifest as Record<string, unknown>).accountTypes as Array<Record<string, unknown>> ?? []
-  const valuationRules = (manifest as Record<string, unknown>).valuationRules as Array<Record<string, unknown>> ?? []
-  const sagas = (manifest as Record<string, unknown>).sagas as Array<Record<string, unknown>> ?? []
+  const m = manifest as unknown as ManifestInput
+  const instruments = m.instruments ?? []
+  const accountTypes = m.accountTypes ?? []
+  const valuationRules = m.valuationRules ?? []
+  const sagas = m.sagas ?? []
 
   for (const inst of instruments) {
     nodes.push({
       id: `instrument:${inst.code}`,
       type: 'instrument',
-      label: inst.name as string,
+      label: inst.name,
       data: { ...inst },
     })
   }
@@ -71,13 +103,12 @@ export function buildManifestGraph(manifest: Manifest): ManifestGraph {
     nodes.push({
       id: `account_type:${at.code}`,
       type: 'account_type',
-      label: at.name as string,
+      label: at.name,
       data: { ...at },
     })
 
-    const allowed = at.allowedInstruments as string[] | undefined
-    if (allowed) {
-      for (const instrumentCode of allowed) {
+    if (at.allowedInstruments) {
+      for (const instrumentCode of at.allowedInstruments) {
         edges.push({
           id: `allowed_by:${at.code}:${instrumentCode}`,
           source: `account_type:${at.code}`,
@@ -89,9 +120,8 @@ export function buildManifestGraph(manifest: Manifest): ManifestGraph {
   }
 
   for (const rule of valuationRules) {
-    const from = rule.fromInstrument as string
-    const to = rule.toInstrument as string
-    const ruleId = `valuation_rule:${from}:${to}`
+    const { fromInstrument: from, toInstrument: to, method } = rule
+    const ruleId = `valuation_rule:${from}:${to}:${method}`
 
     nodes.push({
       id: ruleId,
@@ -101,14 +131,14 @@ export function buildManifestGraph(manifest: Manifest): ManifestGraph {
     })
 
     edges.push({
-      id: `converts_from:${from}:${to}`,
+      id: `converts_from:${from}:${to}:${method}`,
       source: ruleId,
       target: `instrument:${from}`,
       relationship: 'converts_from',
     })
 
     edges.push({
-      id: `converts_to:${from}:${to}`,
+      id: `converts_to:${from}:${to}:${method}`,
       source: ruleId,
       target: `instrument:${to}`,
       relationship: 'converts_to',
@@ -116,9 +146,8 @@ export function buildManifestGraph(manifest: Manifest): ManifestGraph {
   }
 
   for (const saga of sagas) {
-    const name = saga.name as string
-    const trigger = saga.trigger as string
-    const triggerMetadata = parseSagaTrigger(trigger)
+    const { name, trigger, filter } = saga
+    const triggerMetadata = parseSagaTrigger(trigger, filter)
 
     nodes.push({
       id: `saga:${name}`,


### PR DESCRIPTION
## Summary

- Implement `buildManifestGraph()` function that transforms a Manifest proto response into a typed graph structure (`ManifestGraph`) with nodes and edges
- Create typed node types (`instrument`, `account_type`, `valuation_rule`, `saga`) and relationship types (`allowed_by`, `converts_from`, `converts_to`)
- Parse saga `event:channel|filter` triggers into structured `SagaTriggerMetadata`

**Task Master**: 038-manifest-business-model-visualization.2

## Changes

| File | Description |
|------|-------------|
| `frontend/src/features/manifests/lib/manifest-graph-model.ts` | Graph model types and `buildManifestGraph` transformation |
| `frontend/src/features/manifests/lib/manifest-graph-model.test.ts` | 13 unit tests covering node generation, edge creation, trigger parsing, and edge cases |

## Test plan

- [x] Unit tests for instrument node generation
- [x] Unit tests for account type node generation
- [x] Unit tests for `allowed_by` edge creation from account type allowed instruments
- [x] Unit tests for valuation rule nodes with `converts_from`/`converts_to` edges
- [x] Unit tests for saga trigger metadata extraction (event with filter, event without filter, non-event triggers)
- [x] Edge case: empty manifest returns empty graph
- [x] Edge case: manifest with instruments but no relationships