### PR TITLE
feat: extend star-parser with saga output analysis

### DIFF
--- a/frontend/src/lib/visualization/star-parser.test.ts
+++ b/frontend/src/lib/visualization/star-parser.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
 import { join } from 'path'
-import { parseStarlarkSaga } from './star-parser'
+import { parseStarlarkSaga, analyzeSagaOutputs } from './star-parser'
 
 const PATTERNS_DIR = join(__dirname, '..', '..', '..', '..', 'cookbook', 'patterns')
 
@@ -339,6 +339,167 @@ position_keeping.initiate_log(account_id=aid)
       const lookupStep = result.steps.find((s) => s.name === 'lookup_account')!
       expect(lookupStep.earlyExit).not.toBeNull()
       expect(lookupStep.earlyExit!.returnStatus).toBe('CONFIG_ERROR')
+    })
+  })
+})
+
+describe('analyzeSagaOutputs', () => {
+  describe('literal value extraction', () => {
+    it('extracts literal instrument_code, account_id, and direction', () => {
+      const source = `
+saga(name="test")
+step(name="book")
+position_keeping.initiate_log(
+    account_id="ACC-001",
+    instrument_code="GBP",
+    direction="DEBIT",
+    amount=amt,
+)
+`
+      const result = analyzeSagaOutputs(source)
+      expect(result.producedEvents).toHaveLength(1)
+      expect(result.producedEvents[0]).toEqual({
+        stepName: 'book',
+        lineNumber: expect.any(Number),
+        instrumentCode: 'GBP',
+        accountId: 'ACC-001',
+        direction: 'DEBIT',
+      })
+      expect(result.dynamicTargets).toHaveLength(0)
+    })
+  })
+
+  describe('dynamic variable detection', () => {
+    it('detects dynamic instrument_code and account_id', () => {
+      const source = `
+saga(name="test")
+step(name="book")
+position_keeping.initiate_log(account_id=billing_account_id, instrument_code=inst_code, direction="CREDIT", amount=amt)
+`
+      const result = analyzeSagaOutputs(source)
+      expect(result.producedEvents).toHaveLength(1)
+      expect(result.producedEvents[0].instrumentCode).toBeNull()
+      expect(result.producedEvents[0].accountId).toBeNull()
+      expect(result.producedEvents[0].direction).toBe('CREDIT')
+      expect(result.dynamicTargets).toHaveLength(2)
+      expect(result.dynamicTargets[0].variableName).toBe('inst_code')
+      expect(result.dynamicTargets[1].variableName).toBe('billing_account_id')
+    })
+  })
+
+  describe('valuation_engine.compute extraction', () => {
+    it('extracts valuation call parameters', () => {
+      const source = `
+saga(name="test")
+step(name="compute")
+retail = valuation_engine.compute(
+    method_id="SPOT_RATE",
+    amount=amount,
+    from_instrument="KWH",
+    to_instrument="GBP",
+)
+`
+      const result = analyzeSagaOutputs(source)
+      expect(result.valuationCalls).toHaveLength(1)
+      expect(result.valuationCalls[0]).toEqual({
+        stepName: 'compute',
+        lineNumber: expect.any(Number),
+        fromInstrument: 'KWH',
+        toInstrument: 'GBP',
+        methodId: 'SPOT_RATE',
+      })
+    })
+
+    it('detects dynamic method_id and from_instrument', () => {
+      const source = `
+saga(name="test")
+step(name="compute")
+result = valuation_engine.compute(method_id=method, amount=amt, from_instrument=src_instr, to_instrument="GBP")
+`
+      const result = analyzeSagaOutputs(source)
+      expect(result.valuationCalls).toHaveLength(1)
+      expect(result.valuationCalls[0].methodId).toBeNull()
+      expect(result.valuationCalls[0].fromInstrument).toBeNull()
+      expect(result.valuationCalls[0].toInstrument).toBe('GBP')
+      expect(result.dynamicTargets).toHaveLength(2)
+      const varNames = result.dynamicTargets.map((d) => d.variableName)
+      expect(varNames).toContain('src_instr')
+      expect(varNames).toContain('method')
+    })
+  })
+
+  describe('multi-step saga', () => {
+    it('extracts multiple initiate_log calls across steps', () => {
+      const source = `
+saga(name="test")
+step(name="book_retail")
+position_keeping.initiate_log(account_id=billing_id, instrument_code="GBP", direction="DEBIT", amount=retail_amt)
+step(name="book_wholesale")
+position_keeping.initiate_log(account_id=counterparty_id, instrument_code="GBP", direction="CREDIT", amount=wholesale_amt)
+`
+      const result = analyzeSagaOutputs(source)
+      expect(result.producedEvents).toHaveLength(2)
+      expect(result.producedEvents[0].stepName).toBe('book_retail')
+      expect(result.producedEvents[0].instrumentCode).toBe('GBP')
+      expect(result.producedEvents[0].direction).toBe('DEBIT')
+      expect(result.producedEvents[1].stepName).toBe('book_wholesale')
+      expect(result.producedEvents[1].instrumentCode).toBe('GBP')
+      expect(result.producedEvents[1].direction).toBe('CREDIT')
+    })
+  })
+
+  describe('empty saga', () => {
+    it('returns empty arrays for saga with no position_keeping calls', () => {
+      const source = `
+saga(name="empty")
+step(name="lookup")
+account = reference_data.get_account(id=aid)
+`
+      const result = analyzeSagaOutputs(source)
+      expect(result.producedEvents).toHaveLength(0)
+      expect(result.valuationCalls).toHaveLength(0)
+      expect(result.dynamicTargets).toHaveLength(0)
+    })
+  })
+
+  describe('real patterns', () => {
+    it('analyzes usage_to_value.star outputs', () => {
+      const source = readPattern('energy-settlement', 'usage_to_value.star')
+      const result = analyzeSagaOutputs(source)
+
+      // Two position_keeping.initiate_log calls (retail + wholesale)
+      expect(result.producedEvents).toHaveLength(2)
+      expect(result.producedEvents[0].stepName).toBe('book_retail_position')
+      expect(result.producedEvents[0].instrumentCode).toBe('GBP')
+      expect(result.producedEvents[0].direction).toBe('DEBIT')
+      expect(result.producedEvents[1].stepName).toBe('book_wholesale_position')
+      expect(result.producedEvents[1].instrumentCode).toBe('GBP')
+      expect(result.producedEvents[1].direction).toBe('CREDIT')
+
+      // Two valuation_engine.compute calls
+      expect(result.valuationCalls).toHaveLength(2)
+      expect(result.valuationCalls[0].stepName).toBe('compute_retail_valuation')
+      expect(result.valuationCalls[0].toInstrument).toBe('GBP')
+      expect(result.valuationCalls[0].fromInstrument).toBeNull() // dynamic: instrument_code variable
+      expect(result.valuationCalls[1].stepName).toBe('compute_wholesale_valuation')
+
+      // Dynamic targets for from_instrument (variable references)
+      expect(result.dynamicTargets.length).toBeGreaterThan(0)
+      const dynamicVars = result.dynamicTargets.map((d) => d.variableName)
+      expect(dynamicVars).toContain('instrument_code')
+    })
+
+    it('analyzes stripe_payment_received.star outputs', () => {
+      const source = readPattern('payment-gateway-stripe', 'stripe_payment_received.star')
+      const result = analyzeSagaOutputs(source)
+
+      // Two position_keeping.initiate_log calls
+      expect(result.producedEvents).toHaveLength(2)
+      expect(result.producedEvents[0].stepName).toBe('debit_stripe_nostro')
+      expect(result.producedEvents[1].stepName).toBe('credit_customer_prepaid')
+
+      // No valuation calls
+      expect(result.valuationCalls).toHaveLength(0)
     })
   })
 })

--- a/frontend/src/lib/visualization/star-parser.ts
+++ b/frontend/src/lib/visualization/star-parser.ts
@@ -325,9 +325,11 @@ function extractReturnStatus(lines: string[], returnLineIdx: number): string | n
  * Returns the literal string value if quoted, or marks as dynamic if a variable reference.
  */
 function extractParamValue(callText: string, paramName: string): { value: string | null; isDynamic: boolean } {
-  const literalMatch = callText.match(new RegExp(`${paramName}\\s*=\\s*"([^"]+)"`))
-  if (literalMatch) return { value: literalMatch[1], isDynamic: false }
-  const varMatch = callText.match(new RegExp(`${paramName}\\s*=\\s*(\\w+)`))
+  const escapedParam = paramName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const prefix = `(?:^|[\\s,(])${escapedParam}\\s*=\\s*`
+  const literalMatch = callText.match(new RegExp(`${prefix}(['"])(.*?)\\1`))
+  if (literalMatch) return { value: literalMatch[2], isDynamic: false }
+  const varMatch = callText.match(new RegExp(`${prefix}(\\w+)`))
   if (varMatch) return { value: null, isDynamic: true }
   return { value: null, isDynamic: false }
 }
@@ -356,8 +358,10 @@ function collectCallText(lines: string[], startIdx: number): string {
  */
 function findEnclosingStep(lines: string[], targetIdx: number): string {
   for (let i = targetIdx; i >= 0; i--) {
-    const match = lines[i].match(/step\(\s*name\s*=\s*"([^"]+)"/)
-    if (match) return match[1]
+    const dynamicMatch = lines[i].match(/step\(\s*name\s*=\s*"([^"]+)"\s*\+/)
+    if (dynamicMatch) return `${dynamicMatch[1]}*`
+    const staticMatch = lines[i].match(/step\(\s*name\s*=\s*"([^"]+)"/)
+    if (staticMatch) return staticMatch[1]
   }
   return 'unknown'
 }
@@ -400,7 +404,7 @@ export function analyzeSagaOutputs(source: string): SagaOutputAnalysis {
         if (varMatch) {
           dynamicTargets.push({
             variableName: varMatch[1],
-            codeSnippet: trimmed,
+            codeSnippet: callText.trim(),
             lineNumber,
           })
         }
@@ -410,7 +414,7 @@ export function analyzeSagaOutputs(source: string): SagaOutputAnalysis {
         if (varMatch) {
           dynamicTargets.push({
             variableName: varMatch[1],
-            codeSnippet: trimmed,
+            codeSnippet: callText.trim(),
             lineNumber,
           })
         }
@@ -439,7 +443,7 @@ export function analyzeSagaOutputs(source: string): SagaOutputAnalysis {
         if (varMatch) {
           dynamicTargets.push({
             variableName: varMatch[1],
-            codeSnippet: trimmed,
+            codeSnippet: callText.trim(),
             lineNumber,
           })
         }
@@ -449,7 +453,7 @@ export function analyzeSagaOutputs(source: string): SagaOutputAnalysis {
         if (varMatch) {
           dynamicTargets.push({
             variableName: varMatch[1],
-            codeSnippet: trimmed,
+            codeSnippet: callText.trim(),
             lineNumber,
           })
         }
@@ -459,7 +463,7 @@ export function analyzeSagaOutputs(source: string): SagaOutputAnalysis {
         if (varMatch) {
           dynamicTargets.push({
             variableName: varMatch[1],
-            codeSnippet: trimmed,
+            codeSnippet: callText.trim(),
             lineNumber,
           })
         }

--- a/frontend/src/lib/visualization/star-parser.ts
+++ b/frontend/src/lib/visualization/star-parser.ts
@@ -1,3 +1,31 @@
+export interface SagaOutputAnalysis {
+  producedEvents: ProducedEvent[]
+  valuationCalls: ValuationCall[]
+  dynamicTargets: DynamicTarget[]
+}
+
+export interface ProducedEvent {
+  stepName: string
+  lineNumber: number
+  instrumentCode: string | null
+  accountId: string | null
+  direction: 'DEBIT' | 'CREDIT' | null
+}
+
+export interface ValuationCall {
+  stepName: string
+  lineNumber: number
+  fromInstrument: string | null
+  toInstrument: string | null
+  methodId: string | null
+}
+
+export interface DynamicTarget {
+  variableName: string
+  codeSnippet: string
+  lineNumber: number
+}
+
 export interface SagaFlow {
   name: string
   trigger: string | null
@@ -290,4 +318,154 @@ function extractReturnStatus(lines: string[], returnLineIdx: number): string | n
     if (combined.includes('}')) break
   }
   return null
+}
+
+/**
+ * Extract parameter value from a function call text.
+ * Returns the literal string value if quoted, or marks as dynamic if a variable reference.
+ */
+function extractParamValue(callText: string, paramName: string): { value: string | null; isDynamic: boolean } {
+  const literalMatch = callText.match(new RegExp(`${paramName}\\s*=\\s*"([^"]+)"`))
+  if (literalMatch) return { value: literalMatch[1], isDynamic: false }
+  const varMatch = callText.match(new RegExp(`${paramName}\\s*=\\s*(\\w+)`))
+  if (varMatch) return { value: null, isDynamic: true }
+  return { value: null, isDynamic: false }
+}
+
+/**
+ * Collect a potentially multi-line function call starting from a given line index.
+ * Joins lines until parentheses are balanced.
+ */
+function collectCallText(lines: string[], startIdx: number): string {
+  let depth = 0
+  let result = ''
+  for (let i = startIdx; i < lines.length; i++) {
+    const line = lines[i]
+    result += ' ' + line
+    for (const ch of line) {
+      if (ch === '(') depth++
+      if (ch === ')') depth--
+    }
+    if (depth <= 0) break
+  }
+  return result
+}
+
+/**
+ * Find the step name that contains a given line index.
+ */
+function findEnclosingStep(lines: string[], targetIdx: number): string {
+  for (let i = targetIdx; i >= 0; i--) {
+    const match = lines[i].match(/step\(\s*name\s*=\s*"([^"]+)"/)
+    if (match) return match[1]
+  }
+  return 'unknown'
+}
+
+/**
+ * Analyze saga source for output-producing calls: position_keeping.initiate_log
+ * and valuation_engine.compute.
+ */
+export function analyzeSagaOutputs(source: string): SagaOutputAnalysis {
+  const lines = source.split('\n')
+  const producedEvents: ProducedEvent[] = []
+  const valuationCalls: ValuationCall[] = []
+  const dynamicTargets: DynamicTarget[] = []
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim()
+    if (trimmed.startsWith('#')) continue
+
+    if (trimmed.includes('position_keeping.initiate_log(')) {
+      const callText = collectCallText(lines, i)
+      const stepName = findEnclosingStep(lines, i)
+      const lineNumber = i + 1
+
+      const instrParam = extractParamValue(callText, 'instrument_code')
+      const accountParam = extractParamValue(callText, 'account_id')
+      const dirParam = extractParamValue(callText, 'direction')
+
+      const direction = dirParam.value === 'DEBIT' || dirParam.value === 'CREDIT' ? dirParam.value : null
+
+      producedEvents.push({
+        stepName,
+        lineNumber,
+        instrumentCode: instrParam.value,
+        accountId: accountParam.value,
+        direction,
+      })
+
+      if (instrParam.isDynamic) {
+        const varMatch = callText.match(/instrument_code\s*=\s*(\w+)/)
+        if (varMatch) {
+          dynamicTargets.push({
+            variableName: varMatch[1],
+            codeSnippet: trimmed,
+            lineNumber,
+          })
+        }
+      }
+      if (accountParam.isDynamic) {
+        const varMatch = callText.match(/account_id\s*=\s*(\w+)/)
+        if (varMatch) {
+          dynamicTargets.push({
+            variableName: varMatch[1],
+            codeSnippet: trimmed,
+            lineNumber,
+          })
+        }
+      }
+    }
+
+    if (trimmed.includes('valuation_engine.compute(')) {
+      const callText = collectCallText(lines, i)
+      const stepName = findEnclosingStep(lines, i)
+      const lineNumber = i + 1
+
+      const fromParam = extractParamValue(callText, 'from_instrument')
+      const toParam = extractParamValue(callText, 'to_instrument')
+      const methodParam = extractParamValue(callText, 'method_id')
+
+      valuationCalls.push({
+        stepName,
+        lineNumber,
+        fromInstrument: fromParam.value,
+        toInstrument: toParam.value,
+        methodId: methodParam.value,
+      })
+
+      if (fromParam.isDynamic) {
+        const varMatch = callText.match(/from_instrument\s*=\s*(\w+)/)
+        if (varMatch) {
+          dynamicTargets.push({
+            variableName: varMatch[1],
+            codeSnippet: trimmed,
+            lineNumber,
+          })
+        }
+      }
+      if (toParam.isDynamic) {
+        const varMatch = callText.match(/to_instrument\s*=\s*(\w+)/)
+        if (varMatch) {
+          dynamicTargets.push({
+            variableName: varMatch[1],
+            codeSnippet: trimmed,
+            lineNumber,
+          })
+        }
+      }
+      if (methodParam.isDynamic) {
+        const varMatch = callText.match(/method_id\s*=\s*(\w+)/)
+        if (varMatch) {
+          dynamicTargets.push({
+            variableName: varMatch[1],
+            codeSnippet: trimmed,
+            lineNumber,
+          })
+        }
+      }
+    }
+  }
+
+  return { producedEvents, valuationCalls, dynamicTargets }
 }


### PR DESCRIPTION
## Summary

- Add `analyzeSagaOutputs()` function to `star-parser.ts` that extracts produced events from `position_keeping.initiate_log()` calls and valuation calls from `valuation_engine.compute()`
- New types: `SagaOutputAnalysis`, `ProducedEvent`, `ValuationCall`, `DynamicTarget`
- Detects literal string values vs dynamic variable references, recording dynamic targets for downstream visualization
- Handles multi-line function calls via parenthesis-balanced collection

## Task Master

Tag: `038-manifest-business-model-visualization`, Task: 5 - Extend Star-Parser for Saga Output Analysis

## Test plan

- [x] All 28 existing `parseStarlarkSaga` tests still pass
- [x] 7 new `analyzeSagaOutputs` tests covering:
  - Literal value extraction (`instrument_code="GBP"`)
  - Dynamic variable detection (`instrument_code=inst_code`)
  - `valuation_engine.compute()` parameter extraction
  - Multi-step saga with multiple `initiate_log` calls
  - Empty saga returns empty arrays
  - Real pattern: `usage_to_value.star` (2 events, 2 valuations, dynamic targets)
  - Real pattern: `stripe_payment_received.star` (2 events, 0 valuations)