### PR TITLE
feat: ManifestGraph ReactFlow component with custom nodes and filtering

### DIFF
--- a/frontend/src/features/manifests/components/manifest-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.test.tsx
@@ -22,31 +22,19 @@ vi.mock('@/components/ui/tooltip', () => ({
   ),
 }))
 
-// Track click/hover handlers for assertions
-const mockHandlers: {
-  onNodeClick?: (event: unknown, node: unknown) => void
-  onNodeMouseEnter?: (event: unknown, node: unknown) => void
-  onNodeMouseLeave?: () => void
-} = {}
-
 vi.mock('@xyflow/react', () => {
   const Position = { Top: 'top', Bottom: 'bottom', Left: 'left', Right: 'right' }
   const BackgroundVariant = { Dots: 'dots' }
 
   function Handle() { return null }
 
-  function ReactFlow({ nodes, edges, onNodeClick, onNodeMouseEnter, onNodeMouseLeave, children }: {
+  function ReactFlow({ nodes, edges, onNodeClick, children }: {
     nodes: { id: string; type?: string; data: Record<string, unknown> }[]
     edges: { id: string; source: string; target: string; data?: Record<string, unknown> }[]
     onNodeClick?: (event: unknown, node: unknown) => void
-    onNodeMouseEnter?: (event: unknown, node: unknown) => void
-    onNodeMouseLeave?: () => void
     children?: React.ReactNode
     [key: string]: unknown
   }) {
-    mockHandlers.onNodeClick = onNodeClick
-    mockHandlers.onNodeMouseEnter = onNodeMouseEnter
-    mockHandlers.onNodeMouseLeave = onNodeMouseLeave
     return (
       <div data-testid="react-flow" data-node-count={nodes.length} data-edge-count={edges.length}>
         {nodes.map((n) => {
@@ -113,7 +101,7 @@ vi.mock('elkjs/lib/elk.bundled.js', () => ({
 
 const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  const actual = await vi.importActual('react-router-dom')
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/src/features/manifests/components/manifest-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.test.tsx
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ManifestGraph } from './manifest-graph'
+import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
+
+vi.mock('@/api/transport', () => ({
+  createTenantTransport: vi.fn(() => ({ __type: 'mock-transport' })),
+}))
+
+vi.mock('@/api/clients', () => ({
+  createServiceClients: vi.fn(() => ({})),
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="tooltip-content">{children}</div>
+  ),
+}))
+
+// Track click/hover handlers for assertions
+const mockHandlers: {
+  onNodeClick?: (event: unknown, node: unknown) => void
+  onNodeMouseEnter?: (event: unknown, node: unknown) => void
+  onNodeMouseLeave?: () => void
+} = {}
+
+vi.mock('@xyflow/react', () => {
+  const Position = { Top: 'top', Bottom: 'bottom', Left: 'left', Right: 'right' }
+  const BackgroundVariant = { Dots: 'dots' }
+
+  function Handle() { return null }
+
+  function ReactFlow({ nodes, edges, onNodeClick, onNodeMouseEnter, onNodeMouseLeave, children }: {
+    nodes: { id: string; type?: string; data: Record<string, unknown> }[]
+    edges: { id: string; source: string; target: string; data?: Record<string, unknown> }[]
+    onNodeClick?: (event: unknown, node: unknown) => void
+    onNodeMouseEnter?: (event: unknown, node: unknown) => void
+    onNodeMouseLeave?: () => void
+    children?: React.ReactNode
+    [key: string]: unknown
+  }) {
+    mockHandlers.onNodeClick = onNodeClick
+    mockHandlers.onNodeMouseEnter = onNodeMouseEnter
+    mockHandlers.onNodeMouseLeave = onNodeMouseLeave
+    return (
+      <div data-testid="react-flow" data-node-count={nodes.length} data-edge-count={edges.length}>
+        {nodes.map((n) => {
+          const mn = (n.data as { manifestNode?: { type: string; label: string; data: Record<string, unknown> } }).manifestNode
+          return (
+            <div
+              key={n.id}
+              data-testid={`node-${n.id}`}
+              data-node-type={n.type}
+              data-dimmed={String((n.data as { dimmed?: boolean }).dimmed ?? false)}
+              data-highlighted={String((n.data as { highlighted?: boolean }).highlighted ?? false)}
+              onClick={() => onNodeClick?.({}, n)}
+            >
+              {mn?.label ?? n.id}
+            </div>
+          )
+        })}
+        {edges.map((e) => (
+          <div key={e.id} data-testid={`edge-${e.id}`} data-relationship={e.data?.relationship}>
+            {e.source} -&gt; {e.target}
+          </div>
+        ))}
+        {children}
+      </div>
+    )
+  }
+
+  function Controls() { return <div data-testid="controls" /> }
+  function Background() { return null }
+  function MiniMap() { return <div data-testid="minimap" /> }
+
+  return {
+    ReactFlow,
+    Controls,
+    Background,
+    MiniMap,
+    Handle,
+    Position,
+    BackgroundVariant,
+    useNodesState: (init: unknown[]) => {
+      const [s, setS] = useState(init)
+      return [s, setS, vi.fn()]
+    },
+    useEdgesState: (init: unknown[]) => {
+      const [s, setS] = useState(init)
+      return [s, setS, vi.fn()]
+    },
+  }
+})
+
+vi.mock('elkjs/lib/elk.bundled.js', () => ({
+  default: class MockELK {
+    async layout(graph: { children: { id: string }[] }) {
+      return {
+        children: graph.children.map((child, i) => ({
+          id: child.id,
+          x: i * 100,
+          y: i * 100,
+        })),
+      }
+    }
+  },
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+function createMockManifest(overrides: Partial<Record<string, unknown>> = {}): Manifest {
+  return {
+    version: '1.0',
+    metadata: { name: 'Test Manifest', industry: 'energy', description: '' },
+    instruments: [],
+    accountTypes: [],
+    valuationRules: [],
+    sagas: [],
+    seedData: undefined,
+    paymentRails: [],
+    partyTypes: [],
+    mappings: [],
+    operationalGateway: undefined,
+    ...overrides,
+  } as unknown as Manifest
+}
+
+const energyManifest = createMockManifest({
+  instruments: [
+    { code: 'KWH', name: 'Kilowatt Hour', type: 2, dimensions: { unit: 'kWh', precision: 4 } },
+    { code: 'GBP', name: 'British Pound', type: 1, dimensions: { unit: 'GBP', precision: 2 } },
+  ],
+  accountTypes: [
+    {
+      code: 'ENERGY_HOLDING',
+      name: 'Energy Holding',
+      normalBalance: 1,
+      allowedInstruments: ['KWH'],
+    },
+  ],
+  valuationRules: [
+    { fromInstrument: 'KWH', toInstrument: 'GBP', method: 1, source: 'nordpool_spot' },
+  ],
+  sagas: [
+    {
+      name: 'usage_to_value',
+      trigger: 'event:position-keeping.transaction-captured.v1',
+      filter: 'event.instrument_code == "KWH"',
+      script: 'def main(): pass',
+    },
+    {
+      name: 'daily_reconciliation',
+      trigger: 'scheduled:daily_reconciliation',
+      script: 'def main(): pass',
+    },
+  ],
+})
+
+function renderGraph(manifest: Manifest) {
+  return render(
+    <MemoryRouter>
+      <ManifestGraph manifest={manifest} className="h-96" />
+    </MemoryRouter>,
+  )
+}
+
+describe('ManifestGraph', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear()
+  })
+
+  describe('rendering', () => {
+    it('renders ReactFlow container with nodes', async () => {
+      renderGraph(energyManifest)
+      const flow = await screen.findByTestId('react-flow')
+      expect(flow).toBeInTheDocument()
+      expect(flow).toHaveAttribute('data-node-count', '6')
+    })
+
+    it('renders controls and minimap', async () => {
+      renderGraph(energyManifest)
+      expect(await screen.findByTestId('controls')).toBeInTheDocument()
+      expect(await screen.findByTestId('minimap')).toBeInTheDocument()
+    })
+
+    it('renders instrument nodes with code and name', async () => {
+      renderGraph(energyManifest)
+      expect(await screen.findByText('Kilowatt Hour')).toBeInTheDocument()
+      expect(screen.getByText('British Pound')).toBeInTheDocument()
+    })
+
+    it('renders saga nodes', async () => {
+      renderGraph(energyManifest)
+      expect(await screen.findByText('usage_to_value')).toBeInTheDocument()
+      expect(screen.getByText('daily_reconciliation')).toBeInTheDocument()
+    })
+
+    it('renders correct node types', async () => {
+      renderGraph(energyManifest)
+      const instrumentNode = await screen.findByTestId('node-instrument:KWH')
+      expect(instrumentNode).toHaveAttribute('data-node-type', 'instrument')
+
+      const sagaNode = screen.getByTestId('node-saga:usage_to_value')
+      expect(sagaNode).toHaveAttribute('data-node-type', 'saga')
+    })
+  })
+
+  describe('empty state', () => {
+    it('shows empty state for empty manifest', () => {
+      const emptyManifest = createMockManifest()
+      renderGraph(emptyManifest)
+      expect(screen.getByTestId('manifest-graph-empty')).toBeInTheDocument()
+      expect(screen.getByText('No elements in manifest to visualize.')).toBeInTheDocument()
+    })
+  })
+
+  describe('filter sidebar', () => {
+    it('renders type filter checkboxes', async () => {
+      renderGraph(energyManifest)
+      expect(await screen.findByLabelText('Show Instruments')).toBeInTheDocument()
+      expect(screen.getByLabelText('Show Account Types')).toBeInTheDocument()
+      expect(screen.getByLabelText('Show Valuation Rules')).toBeInTheDocument()
+      expect(screen.getByLabelText('Show Sagas')).toBeInTheDocument()
+    })
+
+    it('shows node counts per type', async () => {
+      renderGraph(energyManifest)
+      // 2 instruments, 1 account type, 1 valuation rule, 2 sagas
+      const counts = await screen.findAllByText('(2)')
+      expect(counts).toHaveLength(2) // instruments and sagas both have 2
+      const ones = screen.getAllByText('(1)')
+      expect(ones).toHaveLength(2) // account type and valuation rule both have 1
+    })
+
+    it('shows total visible count', async () => {
+      renderGraph(energyManifest)
+      expect(await screen.findByText('6 nodes visible')).toBeInTheDocument()
+    })
+
+    it('unchecking a type filters nodes', async () => {
+      renderGraph(energyManifest)
+      const sagaCheckbox = await screen.findByLabelText('Show Sagas')
+      fireEvent.click(sagaCheckbox)
+      // After unchecking sagas, saga nodes should be removed from the flow
+      const flow = await screen.findByTestId('react-flow')
+      // The node count should decrease (6 - 2 sagas = 4)
+      expect(flow).toHaveAttribute('data-node-count', '4')
+    })
+  })
+
+  describe('legend', () => {
+    it('renders edge type legend', async () => {
+      renderGraph(energyManifest)
+      expect(await screen.findByText('Allowed by')).toBeInTheDocument()
+      expect(screen.getByText('Converts from')).toBeInTheDocument()
+      expect(screen.getByText('Converts to')).toBeInTheDocument()
+    })
+  })
+
+  describe('click navigation', () => {
+    it('navigates to instruments page on instrument click', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-instrument:KWH')
+      fireEvent.click(node)
+      expect(mockNavigate).toHaveBeenCalledWith('/reference-data/instruments')
+    })
+
+    it('navigates to account types page on account type click', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-account_type:ENERGY_HOLDING')
+      fireEvent.click(node)
+      expect(mockNavigate).toHaveBeenCalledWith('/reference-data/account-types')
+    })
+
+    it('navigates to saga detail page on saga click', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-saga:usage_to_value')
+      fireEvent.click(node)
+      expect(mockNavigate).toHaveBeenCalledWith('/sagas/usage_to_value')
+    })
+  })
+})

--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -57,12 +57,12 @@ const EDGE_LEGEND: { label: string; color: string; dashed?: boolean }[] = [
   { label: 'Converts to', color: '#f59e0b' },
 ]
 
-// ELK layer ordering: instruments at top, account types below, valuation rules middle, sagas bottom
-const LAYER_ORDER: Record<ManifestNodeType, number> = {
-  instrument: 0,
-  account_type: 1,
-  valuation_rule: 2,
-  saga: 3,
+// ELK layer priority: higher values are placed earlier (top in DOWN direction)
+const LAYER_PRIORITY: Record<ManifestNodeType, string> = {
+  instrument: '40',
+  account_type: '30',
+  valuation_rule: '20',
+  saga: '10',
 }
 
 // Trigger type display
@@ -79,6 +79,7 @@ interface ManifestNodeData {
   color: string
   highlighted: boolean
   dimmed: boolean
+  connectedInstrumentCount?: number
   [key: string]: unknown
 }
 
@@ -116,7 +117,7 @@ function InstrumentNode({ data }: { data: ManifestNodeData }) {
 function AccountTypeNode({ data }: { data: ManifestNodeData }) {
   const node = data.manifestNode
   const code = node.data.code as string
-  const allowedCount = (node.data.allowedInstruments as string[] | undefined)?.length ?? 0
+  const allowedCount = data.connectedInstrumentCount ?? 0
   return (
     <>
       <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
@@ -241,10 +242,21 @@ async function layoutManifestGraph(
 
   const nodeMap = new Map(filteredNodes.map((n) => [n.id, n]))
 
+  // Compute connected instrument count per account_type node from actual edges
+  const connectedInstruments = new Map<string, number>()
+  for (const e of filteredEdges) {
+    if (e.relationship === 'allowed_by') {
+      connectedInstruments.set(e.source, (connectedInstruments.get(e.source) ?? 0) + 1)
+    }
+  }
+
   const layoutNodes = filteredNodes.map((n) => ({
     id: n.id,
     width: NODE_WIDTH,
     height: NODE_BASE_HEIGHT + NODE_PADDING,
+    layoutOptions: {
+      'elk.layered.layering.layerChoiceConstraint': LAYER_PRIORITY[n.type],
+    },
   }))
 
   const rfEdges = buildReactFlowEdges(filteredEdges)
@@ -264,6 +276,7 @@ async function layoutManifestGraph(
           color,
           highlighted: false,
           dimmed: false,
+          connectedInstrumentCount: connectedInstruments.get(id),
         } satisfies ManifestNodeData,
       }
     },
@@ -273,13 +286,6 @@ async function layoutManifestGraph(
       layerSpacing: '80',
     },
   )
-
-  // Sort by layer order for ELK placement hint
-  rfNodes.sort((a, b) => {
-    const aType = nodeMap.get(a.id)!.type
-    const bType = nodeMap.get(b.id)!.type
-    return LAYER_ORDER[aType] - LAYER_ORDER[bType]
-  })
 
   return { nodes: rfNodes, edges: rfEdges }
 }

--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -1,0 +1,509 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  ReactFlow,
+  Controls,
+  Background,
+  MiniMap,
+  useNodesState,
+  useEdgesState,
+  type Node,
+  type Edge,
+  type NodeMouseHandler,
+  BackgroundVariant,
+  Position,
+  Handle,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import { useNavigate } from 'react-router-dom'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import {
+  layoutWithELK,
+  NODE_WIDTH,
+  NODE_BASE_HEIGHT,
+  NODE_PADDING,
+} from '@/lib/visualization/graph-layout'
+import {
+  buildManifestGraph,
+  type ManifestNode,
+  type ManifestEdge,
+  type ManifestNodeType,
+  type ManifestGraph as ManifestGraphModel,
+} from '../lib/manifest-graph-model'
+import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
+
+// Theme colors per node type
+const NODE_THEMES: Record<ManifestNodeType, { color: string; label: string }> = {
+  instrument: { color: '#3b82f6', label: 'Instruments' },
+  account_type: { color: '#22c55e', label: 'Account Types' },
+  valuation_rule: { color: '#f59e0b', label: 'Valuation Rules' },
+  saga: { color: '#8b5cf6', label: 'Sagas' },
+}
+
+// Edge styles per relationship type
+const MANIFEST_EDGE_STYLES: Record<string, React.CSSProperties> = {
+  allowed_by: { stroke: '#3b82f6', strokeWidth: 2 },
+  converts_from: { stroke: '#f59e0b', strokeWidth: 1.5, strokeDasharray: '6 3' },
+  converts_to: { stroke: '#f59e0b', strokeWidth: 1.5 },
+}
+
+const EDGE_LEGEND: { label: string; color: string; dashed?: boolean }[] = [
+  { label: 'Allowed by', color: '#3b82f6' },
+  { label: 'Converts from', color: '#f59e0b', dashed: true },
+  { label: 'Converts to', color: '#f59e0b' },
+]
+
+// ELK layer ordering: instruments at top, account types below, valuation rules middle, sagas bottom
+const LAYER_ORDER: Record<ManifestNodeType, number> = {
+  instrument: 0,
+  account_type: 1,
+  valuation_rule: 2,
+  saga: 3,
+}
+
+// Trigger type display
+function getTriggerBadge(trigger: string): { label: string; variant: string } {
+  if (trigger.startsWith('event:')) return { label: 'event', variant: 'bg-purple-100 text-purple-800' }
+  if (trigger.startsWith('scheduled:')) return { label: 'scheduled', variant: 'bg-blue-100 text-blue-800' }
+  if (trigger.startsWith('api:')) return { label: 'api', variant: 'bg-green-100 text-green-800' }
+  return { label: 'unknown', variant: 'bg-gray-100 text-gray-800' }
+}
+
+// Custom node data interface
+interface ManifestNodeData {
+  manifestNode: ManifestNode
+  color: string
+  highlighted: boolean
+  dimmed: boolean
+  [key: string]: unknown
+}
+
+function InstrumentNode({ data }: { data: ManifestNodeData }) {
+  const node = data.manifestNode
+  const code = node.data.code as string
+  const unit = (node.data.dimensions as Record<string, unknown> | undefined)?.unit as string | undefined
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
+            style={{
+              width: 180,
+              borderColor: data.color,
+              backgroundColor: `${data.color}18`,
+              opacity: data.dimmed ? 0.25 : 1,
+              boxShadow: data.highlighted ? `0 0 12px ${data.color}88` : undefined,
+            }}
+          >
+            <span className="text-[11px] font-bold font-mono text-foreground">{code}</span>
+            <span className="text-[10px] text-muted-foreground truncate w-full">{node.label}</span>
+            {unit && <span className="text-[9px] text-muted-foreground">({unit})</span>}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">{node.label} ({code})</TooltipContent>
+      </Tooltip>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+}
+
+function AccountTypeNode({ data }: { data: ManifestNodeData }) {
+  const node = data.manifestNode
+  const code = node.data.code as string
+  const allowedCount = (node.data.allowedInstruments as string[] | undefined)?.length ?? 0
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
+            style={{
+              width: 180,
+              borderColor: data.color,
+              backgroundColor: `${data.color}18`,
+              opacity: data.dimmed ? 0.25 : 1,
+              boxShadow: data.highlighted ? `0 0 12px ${data.color}88` : undefined,
+            }}
+          >
+            <span className="text-[11px] font-bold font-mono text-foreground">{code}</span>
+            <span className="text-[10px] text-muted-foreground truncate w-full">{node.label}</span>
+            <span className="text-[9px] text-muted-foreground">{allowedCount} instrument{allowedCount !== 1 ? 's' : ''}</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">{node.label} ({code})</TooltipContent>
+      </Tooltip>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+}
+
+function ValuationRuleNode({ data }: { data: ManifestNodeData }) {
+  const node = data.manifestNode
+  const from = node.data.fromInstrument as string
+  const to = node.data.toInstrument as string
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150"
+            style={{
+              width: 180,
+              borderColor: data.color,
+              backgroundColor: `${data.color}18`,
+              opacity: data.dimmed ? 0.25 : 1,
+              boxShadow: data.highlighted ? `0 0 12px ${data.color}88` : undefined,
+            }}
+          >
+            <span className="text-[10px] font-semibold text-foreground">{from} &rarr; {to}</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">Valuation: {from} to {to}</TooltipContent>
+      </Tooltip>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+}
+
+function SagaNode({ data }: { data: ManifestNodeData }) {
+  const node = data.manifestNode
+  const trigger = node.data.trigger as string
+  const badge = getTriggerBadge(trigger)
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
+            style={{
+              width: 180,
+              borderColor: data.color,
+              backgroundColor: `${data.color}18`,
+              opacity: data.dimmed ? 0.25 : 1,
+              boxShadow: data.highlighted ? `0 0 12px ${data.color}88` : undefined,
+            }}
+          >
+            <span className="text-[11px] font-bold text-foreground truncate w-full">{node.label}</span>
+            <span className={`mt-0.5 text-[9px] font-medium px-1.5 py-0.5 rounded-full ${badge.variant}`}>
+              {badge.label}
+            </span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">{node.label} ({trigger})</TooltipContent>
+      </Tooltip>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+}
+
+const nodeTypes = {
+  instrument: InstrumentNode,
+  account_type: AccountTypeNode,
+  valuation_rule: ValuationRuleNode,
+  saga: SagaNode,
+}
+
+function buildReactFlowEdges(manifestEdges: ManifestEdge[]): Edge[] {
+  return manifestEdges.map((e) => ({
+    id: e.id,
+    source: e.source,
+    target: e.target,
+    style: MANIFEST_EDGE_STYLES[e.relationship] ?? {},
+    markerEnd: e.relationship === 'converts_to' || e.relationship === 'allowed_by'
+      ? { type: 'arrowclosed' as const, color: (MANIFEST_EDGE_STYLES[e.relationship]?.stroke as string) ?? '#999' }
+      : undefined,
+    data: { relationship: e.relationship },
+  }))
+}
+
+async function layoutManifestGraph(
+  graph: ManifestGraphModel,
+  visibleTypes: Set<ManifestNodeType>,
+): Promise<{ nodes: Node[]; edges: Edge[] }> {
+  const filteredNodes = graph.nodes.filter((n) => visibleTypes.has(n.type))
+  const filteredNodeIds = new Set(filteredNodes.map((n) => n.id))
+  const filteredEdges = graph.edges.filter(
+    (e) => filteredNodeIds.has(e.source) && filteredNodeIds.has(e.target),
+  )
+
+  if (filteredNodes.length === 0) {
+    return { nodes: [], edges: [] }
+  }
+
+  const nodeMap = new Map(filteredNodes.map((n) => [n.id, n]))
+
+  const layoutNodes = filteredNodes.map((n) => ({
+    id: n.id,
+    width: NODE_WIDTH,
+    height: NODE_BASE_HEIGHT + NODE_PADDING,
+  }))
+
+  const rfEdges = buildReactFlowEdges(filteredEdges)
+
+  const rfNodes = await layoutWithELK<ManifestNodeData>(
+    layoutNodes,
+    rfEdges,
+    (id, position) => {
+      const mn = nodeMap.get(id)!
+      const color = NODE_THEMES[mn.type].color
+      return {
+        id,
+        type: mn.type,
+        position,
+        data: {
+          manifestNode: mn,
+          color,
+          highlighted: false,
+          dimmed: false,
+        } satisfies ManifestNodeData,
+      }
+    },
+    {
+      direction: 'DOWN',
+      nodeNodeSpacing: '50',
+      layerSpacing: '80',
+    },
+  )
+
+  // Sort by layer order for ELK placement hint
+  rfNodes.sort((a, b) => {
+    const aType = nodeMap.get(a.id)!.type
+    const bType = nodeMap.get(b.id)!.type
+    return LAYER_ORDER[aType] - LAYER_ORDER[bType]
+  })
+
+  return { nodes: rfNodes, edges: rfEdges }
+}
+
+function LegendItem({ label, color, dashed }: { label: string; color: string; dashed?: boolean }) {
+  return (
+    <div className="flex items-center gap-2">
+      <svg width="32" height="12">
+        <line
+          x1="0" y1="6" x2="32" y2="6"
+          stroke={color}
+          strokeWidth={2}
+          strokeDasharray={dashed ? '6 3' : undefined}
+        />
+      </svg>
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  )
+}
+
+interface ManifestGraphProps {
+  manifest: Manifest
+  className?: string
+}
+
+export function ManifestGraph({ manifest, className }: ManifestGraphProps) {
+  const navigate = useNavigate()
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([])
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
+  const [hoveredNode, setHoveredNode] = useState<string | null>(null)
+  const [visibleTypes, setVisibleTypes] = useState<Set<ManifestNodeType>>(
+    () => new Set<ManifestNodeType>(['instrument', 'account_type', 'valuation_rule', 'saga']),
+  )
+
+  const graph = useMemo(() => buildManifestGraph(manifest), [manifest])
+
+  const nodeCountByType = useMemo(() => {
+    const counts: Record<ManifestNodeType, number> = {
+      instrument: 0,
+      account_type: 0,
+      valuation_rule: 0,
+      saga: 0,
+    }
+    for (const n of graph.nodes) {
+      counts[n.type]++
+    }
+    return counts
+  }, [graph])
+
+  // Memoize filtered edges for hover highlighting
+  const currentEdges = useMemo(() => {
+    const filteredNodeIds = new Set(
+      graph.nodes.filter((n) => visibleTypes.has(n.type)).map((n) => n.id),
+    )
+    return graph.edges.filter(
+      (e) => filteredNodeIds.has(e.source) && filteredNodeIds.has(e.target),
+    )
+  }, [graph, visibleTypes])
+
+  // Layout
+  useEffect(() => {
+    let cancelled = false
+    void layoutManifestGraph(graph, visibleTypes)
+      .then((result) => {
+        if (!cancelled) {
+          setNodes(result.nodes)
+          setEdges(result.edges)
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error('[ManifestGraph] layout failed:', err)
+        }
+      })
+    return () => { cancelled = true }
+  }, [graph, visibleTypes, setNodes, setEdges])
+
+  // Hover highlighting
+  useEffect(() => {
+    const connectedNodes = new Set<string>()
+    if (hoveredNode) {
+      connectedNodes.add(hoveredNode)
+      for (const e of currentEdges) {
+        if (e.source === hoveredNode || e.target === hoveredNode) {
+          connectedNodes.add(e.source)
+          connectedNodes.add(e.target)
+        }
+      }
+    }
+
+    setNodes((nds) => {
+      let changed = false
+      const next = nds.map((n) => {
+        const highlighted = hoveredNode ? n.id === hoveredNode : false
+        const dimmed = hoveredNode ? !connectedNodes.has(n.id) : false
+        const current = n.data as ManifestNodeData
+        if (current.highlighted === highlighted && current.dimmed === dimmed) return n
+        changed = true
+        return { ...n, data: { ...n.data, highlighted, dimmed } }
+      })
+      return changed ? next : nds
+    })
+
+    setEdges((eds) => {
+      let changed = false
+      const next = eds.map((e) => {
+        const animated = hoveredNode ? e.source === hoveredNode || e.target === hoveredNode : false
+        if (e.animated === animated) return e
+        changed = true
+        return { ...e, animated }
+      })
+      return changed ? next : eds
+    })
+  }, [hoveredNode, currentEdges, setNodes, setEdges])
+
+  const onNodeClick: NodeMouseHandler = useCallback(
+    (_event, node) => {
+      const data = node.data as ManifestNodeData
+      const mn = data.manifestNode
+      switch (mn.type) {
+        case 'instrument':
+          navigate('/reference-data/instruments')
+          break
+        case 'account_type':
+          navigate('/reference-data/account-types')
+          break
+        case 'saga':
+          navigate(`/sagas/${mn.label}`)
+          break
+      }
+    },
+    [navigate],
+  )
+
+  const onNodeMouseEnter: NodeMouseHandler = useCallback((_event, node) => {
+    setHoveredNode(node.id)
+  }, [])
+
+  const onNodeMouseLeave: NodeMouseHandler = useCallback(() => {
+    setHoveredNode(null)
+  }, [])
+
+  const toggleType = useCallback((type: ManifestNodeType) => {
+    setVisibleTypes((prev) => {
+      const next = new Set(prev)
+      if (next.has(type)) {
+        next.delete(type)
+      } else {
+        next.add(type)
+      }
+      return next
+    })
+  }, [])
+
+  const totalVisible = nodes.length
+
+  if (graph.nodes.length === 0) {
+    return (
+      <div className={className} data-testid="manifest-graph-empty" style={{ width: '100%', height: '100%' }}>
+        <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+          No elements in manifest to visualize.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={className} style={{ width: '100%', height: '100%', position: 'relative' }}>
+      <TooltipProvider>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onNodeClick={onNodeClick}
+          onNodeMouseEnter={onNodeMouseEnter}
+          onNodeMouseLeave={onNodeMouseLeave}
+          nodeTypes={nodeTypes}
+          fitView
+          proOptions={{ hideAttribution: true }}
+        >
+          <Controls />
+          <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
+          <MiniMap
+            nodeColor={(n) => (n.data as ManifestNodeData).color}
+            maskColor="rgba(0, 0, 0, 0.15)"
+          />
+        </ReactFlow>
+      </TooltipProvider>
+
+      {/* Filter sidebar */}
+      <div className="absolute top-3 left-3 z-10 flex flex-col gap-2 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm">
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Element Types</span>
+        {(Object.keys(NODE_THEMES) as ManifestNodeType[]).map((type) => {
+          const theme = NODE_THEMES[type]
+          const count = nodeCountByType[type]
+          return (
+            <label key={type} className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={visibleTypes.has(type)}
+                onChange={() => toggleType(type)}
+                className="rounded"
+                aria-label={`Show ${theme.label}`}
+              />
+              <span
+                className="w-2.5 h-2.5 rounded-full"
+                style={{ backgroundColor: theme.color }}
+              />
+              <span className="text-xs text-foreground">{theme.label}</span>
+              <span className="text-[10px] text-muted-foreground">({count})</span>
+            </label>
+          )
+        })}
+        <span className="text-[10px] text-muted-foreground mt-1">{totalVisible} nodes visible</span>
+      </div>
+
+      {/* Legend */}
+      <div className="absolute bottom-3 left-3 z-10 flex flex-col gap-1 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm">
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">Edges</span>
+        {EDGE_LEGEND.map((item) => (
+          <LegendItem key={item.label} {...item} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/visualization/graph-layout.ts
+++ b/frontend/src/lib/visualization/graph-layout.ts
@@ -27,6 +27,7 @@ export interface LayoutNode {
   id: string
   width: number
   height: number
+  layoutOptions?: Record<string, string>
 }
 
 /**
@@ -43,6 +44,7 @@ export async function layoutWithELK<T extends Record<string, unknown>>(
     id: n.id,
     width: n.width,
     height: n.height,
+    ...(n.layoutOptions ? { layoutOptions: n.layoutOptions } : {}),
   }))
 
   const elkEdges = edges.map((e) => ({


### PR DESCRIPTION
## Summary

- Adds `ManifestGraph` ReactFlow component (`frontend/src/features/manifests/components/manifest-graph.tsx`) that visualizes manifest business models as an interactive node graph
- Custom node components for each element type: `InstrumentNode` (blue), `AccountTypeNode` (green), `ValuationRuleNode` (amber), `SagaNode` (purple)
- ELK layered layout via shared `layoutWithELK` utility, following the same pattern as `CompositionGraph`
- Hover highlighting dims unrelated nodes and animates connected edges
- Click-to-navigate: instruments -> `/reference-data/instruments`, account types -> `/reference-data/account-types`, sagas -> `/sagas/{name}`
- Filter sidebar with checkboxes to toggle element type visibility, showing per-type node counts
- Edge type legend for allowed_by, converts_from, converts_to relationships
- Empty state when manifest has no elements

## Dependencies

- Task 1: Shared graph layout utilities (`@/lib/visualization/graph-layout`)
- Task 2: Manifest graph model (`@/features/manifests/lib/manifest-graph-model`)

## Test plan

- [x] 14 tests covering rendering, empty state, filtering, legend, and click navigation
- [x] All 83 manifest feature tests pass
- [x] Tests verify node type rendering, filter checkbox behavior, navigation on click