### PR TITLE
Deprecate legacy currency packages and document payment-order constraint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -169,17 +169,6 @@ linters:
         linters:
           - gocritic
 
-      # Suppress SA1019 (deprecated usage) for shared/domain/money and
-      # shared/platform/quantity/currency during the migration to
-      # shared/pkg/refdata.InstrumentResolver. Consumers will be migrated
-      # incrementally; these exclusions prevent lint failures in the interim.
-      - text: "SA1019:.*deprecated.*(InstrumentResolver|InstrumentProperties|quantity package|quantity error)"
-        linters:
-          - staticcheck
-      - text: "SA1019:.*shared/(domain/money|platform/quantity/currency)"
-        linters:
-          - staticcheck
-
       # Exclude misspell for protobuf enum references (CANCELLED is the official enum name)
       - text: "CANCELLED.*is a misspelling of.*CANCELED"
         linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -169,19 +169,6 @@ linters:
         linters:
           - gocritic
 
-      # Suppress SA1019 (deprecated usage) for shared/domain/money and
-      # shared/platform/quantity/currency during the migration to
-      # shared/pkg/refdata.InstrumentResolver. These packages are deprecated
-      # but consumers will be migrated incrementally across multiple PRs.
-      # The patterns match import-level warnings (package path in quotes) and
-      # usage-level warnings (migration targets in the deprecation message).
-      - text: "SA1019:.*shared/(domain/money|platform/quantity/currency)"
-        linters:
-          - staticcheck
-      - text: "SA1019:.*deprecated.*(InstrumentResolver|InstrumentProperties|quantity package|quantity error|quantity\\.|dynamic instrument)"
-        linters:
-          - staticcheck
-
       # Exclude misspell for protobuf enum references (CANCELLED is the official enum name)
       - text: "CANCELLED.*is a misspelling of.*CANCELED"
         linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -169,6 +169,17 @@ linters:
         linters:
           - gocritic
 
+      # Suppress SA1019 (deprecated usage) for shared/domain/money and
+      # shared/platform/quantity/currency during the migration to
+      # shared/pkg/refdata.InstrumentResolver. Consumers will be migrated
+      # incrementally; these exclusions prevent lint failures in the interim.
+      - text: "SA1019:.*money"
+        linters:
+          - staticcheck
+      - text: "SA1019:.*currency"
+        linters:
+          - staticcheck
+
       # Exclude misspell for protobuf enum references (CANCELLED is the official enum name)
       - text: "CANCELLED.*is a misspelling of.*CANCELED"
         linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -186,6 +186,16 @@ linters:
         linters:
           - misspell
 
+      # Suppress SA1019 for deprecated shared/domain/money and shared/platform/quantity/currency
+      # These packages are deprecated in favour of shared/pkg/refdata.InstrumentResolver but
+      # are still imported across the codebase during the migration period.
+      - text: "SA1019:.*shared/(domain/money|platform/quantity/currency)"
+        linters:
+          - staticcheck
+      - text: "SA1019:.*deprecated.*(InstrumentResolver|InstrumentProperties|quantity package|quantity error|quantity\\.|dynamic instrument)"
+        linters:
+          - staticcheck
+
   settings:
     govet:
       enable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -169,6 +169,17 @@ linters:
         linters:
           - gocritic
 
+      # Suppress SA1019 (deprecated usage) for shared/domain/money and
+      # shared/platform/quantity/currency during the migration to
+      # shared/pkg/refdata.InstrumentResolver. Consumers will be migrated
+      # incrementally; these exclusions prevent lint failures in the interim.
+      - text: "SA1019:.*deprecated.*(InstrumentResolver|InstrumentProperties|quantity package|quantity error)"
+        linters:
+          - staticcheck
+      - text: "SA1019:.*shared/(domain/money|platform/quantity/currency)"
+        linters:
+          - staticcheck
+
       # Exclude misspell for protobuf enum references (CANCELLED is the official enum name)
       - text: "CANCELLED.*is a misspelling of.*CANCELED"
         linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -169,17 +169,6 @@ linters:
         linters:
           - gocritic
 
-      # Suppress SA1019 (deprecated usage) for shared/domain/money and
-      # shared/platform/quantity/currency during the migration to
-      # shared/pkg/refdata.InstrumentResolver. Consumers will be migrated
-      # incrementally; these exclusions prevent lint failures in the interim.
-      - text: "SA1019:.*money"
-        linters:
-          - staticcheck
-      - text: "SA1019:.*currency"
-        linters:
-          - staticcheck
-
       # Exclude misspell for protobuf enum references (CANCELLED is the official enum name)
       - text: "CANCELLED.*is a misspelling of.*CANCELED"
         linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -169,6 +169,19 @@ linters:
         linters:
           - gocritic
 
+      # Suppress SA1019 (deprecated usage) for shared/domain/money and
+      # shared/platform/quantity/currency during the migration to
+      # shared/pkg/refdata.InstrumentResolver. These packages are deprecated
+      # but consumers will be migrated incrementally across multiple PRs.
+      # The patterns match import-level warnings (package path in quotes) and
+      # usage-level warnings (migration targets in the deprecation message).
+      - text: "SA1019:.*shared/(domain/money|platform/quantity/currency)"
+        linters:
+          - staticcheck
+      - text: "SA1019:.*deprecated.*(InstrumentResolver|InstrumentProperties|quantity package|quantity error|quantity\\.|dynamic instrument)"
+        linters:
+          - staticcheck
+
       # Exclude misspell for protobuf enum references (CANCELLED is the official enum name)
       - text: "CANCELLED.*is a misspelling of.*CANCELED"
         linters:

--- a/services/current-account/domain/account.go
+++ b/services/current-account/domain/account.go
@@ -116,7 +116,7 @@ func WithBehaviorClass(behaviorClass string) AccountOption {
 // Precision is derived automatically from the currency registry.
 // Dimension defaults to "CURRENCY". Use NewCurrentAccountWithDimension for explicit dimensions.
 func NewCurrentAccount(accountID, externalIdentifier, partyID, instrumentCode string, opts ...AccountOption) (CurrentAccount, error) {
-	inst, ok := currency.ByCode(strings.ToUpper(instrumentCode))
+	inst, ok := currency.ByCode(strings.ToUpper(instrumentCode)) //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 	if !ok {
 		return CurrentAccount{}, fmt.Errorf("%w: %s", ErrInvalidCurrency, instrumentCode)
 	}
@@ -141,7 +141,7 @@ func NewCurrentAccountWithDimension(accountID, externalIdentifier, partyID, inst
 	// the Reference Data service), precision validation is deferred: NewAmountFromInstrument
 	// will return ErrInvalidCurrency if the code is genuinely unknown.
 	if normalizedDimension == quantity.DimensionCurrency {
-		if inst, ok := currency.ByCode(strings.ToUpper(instrumentCode)); ok {
+		if inst, ok := currency.ByCode(strings.ToUpper(instrumentCode)); ok { //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 			if inst.Precision != precision {
 				return CurrentAccount{}, fmt.Errorf("%w: currency %s requires precision %d, got %d",
 					ErrPrecisionMismatch, strings.ToUpper(instrumentCode), inst.Precision, precision)

--- a/services/current-account/service/grpc_account_endpoints.go
+++ b/services/current-account/service/grpc_account_endpoints.go
@@ -80,7 +80,7 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 	} else {
 		// Fallback path: no Reference Data service configured.
 		// Derive precision from the currency registry for correctness (e.g. JPY needs 0, not 2).
-		if inst, ok := currency.ByCode(strings.ToUpper(instrumentCode)); ok {
+		if inst, ok := currency.ByCode(strings.ToUpper(instrumentCode)); ok { //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 			precision = inst.Precision
 		} else {
 			s.logger.Warn("currency not found in local registry, using default precision",

--- a/services/financial-accounting/domain/currency.go
+++ b/services/financial-accounting/domain/currency.go
@@ -5,15 +5,17 @@
 package domain
 
 import (
-	"github.com/meridianhub/meridian/shared/domain/money"
+	"github.com/meridianhub/meridian/shared/domain/money" //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 	"github.com/meridianhub/meridian/shared/platform/quantity"
 )
 
 // Currency is an alias for the shared money.Currency type.
 // This is maintained for backward compatibility with FinancialBookingLog.BaseCurrency.
-type Currency = money.Currency
+type Currency = money.Currency //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 
 // Supported currency codes following ISO 4217 standard.
+//
+//nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 const (
 	CurrencyGBP = money.CurrencyGBP
 	CurrencyUSD = money.CurrencyUSD
@@ -26,7 +28,7 @@ const (
 
 // ParseCurrency converts a string to a Currency type with validation.
 func ParseCurrency(s string) (Currency, error) {
-	return money.ParseCurrency(s)
+	return money.ParseCurrency(s) //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 }
 
 // CurrencyToInstrument converts a Currency to an Instrument for use with Qty[Monetary].
@@ -40,14 +42,14 @@ func ParseCurrency(s string) (Currency, error) {
 //
 // Returns an error if the currency is invalid.
 func CurrencyToInstrument(c Currency) (Instrument, error) {
-	if !c.IsValid() {
+	if !c.IsValid() { //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 		return Instrument{}, ErrInvalidDimension
 	}
 	return quantity.NewInstrument(
 		string(c),
 		1,
 		DimensionCurrency,
-		int(c.DecimalPlaces()),
+		int(c.DecimalPlaces()), //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 	)
 }
 

--- a/services/financial-accounting/domain/currency_test.go
+++ b/services/financial-accounting/domain/currency_test.go
@@ -17,7 +17,7 @@ func TestCurrency_IsValid(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.currency.IsValid(); got != tt.expected {
+			if got := tt.currency.IsValid(); got != tt.expected { //nolint:staticcheck // Tests deprecated type
 				t.Errorf("IsValid() = %v, want %v", got, tt.expected)
 			}
 		})

--- a/services/payment-order/README.md
+++ b/services/payment-order/README.md
@@ -220,7 +220,7 @@ erDiagram
         varchar(255) debtor_account_id
         varchar(255) creditor_reference "IBAN"
         bigint amount_cents
-        char(3) currency "ISO 4217"
+        varchar(3) currency "ISO 4217"
         varchar(20) status "saga state"
         varchar(255) lien_id "CurrentAccount reservation"
         varchar(255) gateway_reference_id "external txn ID"

--- a/services/payment-order/README.md
+++ b/services/payment-order/README.md
@@ -78,7 +78,7 @@ Payment Order is **intentionally restricted to CURRENCY dimension instruments**.
 
 - Payment orders model fiat money movements (bank transfers, direct debits, SEPA/SWIFT settlements)
 - These real-world payment rails only carry ISO 4217 currencies
-- The database stores currency as `VARCHAR(3)` for ISO 4217 codes
+- The database stores currency as `CHAR(3)` for ISO 4217 codes
 - Non-currency assets (energy kWh, compute GPU_HOUR, carbon credits) belong in
   the **position-keeping** service
 

--- a/services/payment-order/README.md
+++ b/services/payment-order/README.md
@@ -72,6 +72,19 @@ reference-data service via `GetSaga()` RPC.
 To modify this saga, update the file in reference-data service and run
 `PlatformSync.SyncPlatformDefaults()`.
 
+## Currency-Only Constraint
+
+Payment Order is **intentionally restricted to CURRENCY dimension instruments**. This is a permanent business rule:
+
+- Payment orders model fiat money movements (bank transfers, direct debits, SEPA/SWIFT settlements)
+- These real-world payment rails only carry ISO 4217 currencies
+- The database stores currency as `VARCHAR(3)` for ISO 4217 codes
+- Non-currency assets (energy kWh, compute GPU_HOUR, carbon credits) belong in
+  the **position-keeping** service
+
+The `ValidateCurrencyDimension()` helper in `domain/quantity.go` enforces this
+at the service boundary by rejecting instruments outside the CURRENCY dimension.
+
 ## Domain Model
 
 ```mermaid

--- a/services/payment-order/README.md
+++ b/services/payment-order/README.md
@@ -220,7 +220,7 @@ erDiagram
         varchar(255) debtor_account_id
         varchar(255) creditor_reference "IBAN"
         bigint amount_cents
-        varchar(3) currency "ISO 4217"
+        char(3) currency "ISO 4217"
         varchar(20) status "saga state"
         varchar(255) lien_id "CurrentAccount reservation"
         varchar(255) gateway_reference_id "external txn ID"

--- a/services/payment-order/domain/quantity.go
+++ b/services/payment-order/domain/quantity.go
@@ -3,22 +3,28 @@
 // This replaces the previous money.go which used shared/domain/money,
 // migrating to the new Universal Asset System quantity package.
 //
-// # Design Constraint: Currency-Only
+// # Design Constraint: Currency-Only (Intentional)
 //
-// Payment Order is intentionally restricted to CURRENCY dimension instruments.
-// This is by design: payment orders represent fiat money movements (bank transfers,
-// direct debits, credit card charges) which are always denominated in a currency.
+// Payment Order is permanently restricted to CURRENCY dimension instruments.
+// This is a deliberate business rule, not a migration gap:
 //
-// Non-currency assets (energy kWh, compute GPU_HOUR, carbon credits) are NOT
-// supported here. For multi-asset position tracking, see the position-keeping service
-// which uses the dimension-agnostic Amount type from shared/pkg/amount.
+//   - Payment orders model fiat money movements: bank transfers, direct debits,
+//     credit card charges, and SEPA/SWIFT settlements.
+//   - These real-world payment rails only carry ISO 4217 currencies.
+//   - The database stores currency as VARCHAR(3) for ISO 4217 codes.
+//   - Non-currency assets (energy kWh, compute GPU_HOUR, carbon credits) belong
+//     in the position-keeping service, which uses the dimension-agnostic Amount
+//     type from shared/pkg/amount.
+//
+// ValidateCurrencyDimension enforces this constraint at the domain boundary.
 package domain
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/meridianhub/meridian/shared/platform/quantity"
-	"github.com/meridianhub/meridian/shared/platform/quantity/currency"
+	"github.com/meridianhub/meridian/shared/platform/quantity/currency" //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 	"github.com/shopspring/decimal"
 )
 
@@ -33,6 +39,10 @@ var (
 	// ErrOverflow is kept for API compatibility but the new quantity package
 	// uses arbitrary precision decimals so overflow is not a practical concern.
 	ErrOverflow = errors.New("overflow")
+
+	// ErrNonCurrencyInstrument is returned when a non-CURRENCY dimension instrument
+	// is used in a payment order. Payment orders only support fiat currencies.
+	ErrNonCurrencyInstrument = errors.New("payment orders only support CURRENCY dimension instruments")
 )
 
 // Money is an alias for the quantity.Money type (Qty[Monetary]).
@@ -41,7 +51,9 @@ type Money = quantity.Money
 // Instrument is an alias for the quantity.Instrument type.
 type Instrument = quantity.Instrument
 
-// Re-export currency instruments for convenient access
+// Re-export currency instruments for convenient access.
+//
+//nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 var (
 	InstrumentGBP = currency.InstrumentGBP
 	InstrumentUSD = currency.InstrumentUSD
@@ -59,7 +71,7 @@ var (
 //
 //	money, err := NewMoney("GBP", 10000) // Creates £100.00
 func NewMoney(currencyCode string, amountCents int64) (Money, error) {
-	inst, ok := currency.ByCode(currencyCode)
+	inst, ok := currency.ByCode(currencyCode) //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 	if !ok {
 		return Money{}, ErrInvalidCurrency
 	}
@@ -115,4 +127,18 @@ func CurrencyCode(m Money) string {
 		panic("CurrencyCode: called on zero-value Money with no instrument")
 	}
 	return m.Instrument.Code
+}
+
+// ValidateCurrencyDimension checks that an instrument has the CURRENCY dimension.
+// Returns ErrNonCurrencyInstrument if the instrument represents a non-monetary
+// asset (energy, compute, carbon, etc.).
+//
+// Call this at the service boundary when accepting instrument codes from external
+// input to enforce the payment-order currency-only constraint.
+func ValidateCurrencyDimension(inst Instrument) error {
+	if inst.Dimension != quantity.DimensionCurrency {
+		return fmt.Errorf("%w: got dimension %q for instrument %q",
+			ErrNonCurrencyInstrument, inst.Dimension, inst.Code)
+	}
+	return nil
 }

--- a/services/payment-order/domain/quantity.go
+++ b/services/payment-order/domain/quantity.go
@@ -11,7 +11,7 @@
 //   - Payment orders model fiat money movements: bank transfers, direct debits,
 //     credit card charges, and SEPA/SWIFT settlements.
 //   - These real-world payment rails only carry ISO 4217 currencies.
-//   - The database stores currency as VARCHAR(3) for ISO 4217 codes.
+//   - The database stores currency as CHAR(3) for ISO 4217 codes.
 //   - Non-currency assets (energy kWh, compute GPU_HOUR, carbon credits) belong
 //     in the position-keeping service, which uses the dimension-agnostic Amount
 //     type from shared/pkg/amount.

--- a/services/payment-order/domain/quantity_test.go
+++ b/services/payment-order/domain/quantity_test.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"testing"
 
+	"github.com/meridianhub/meridian/shared/platform/quantity"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -103,6 +104,52 @@ func TestNewMoneyDecimal(t *testing.T) {
 		assert.Equal(t, "JPY", CurrencyCode(m))
 		assert.Equal(t, int64(1000), ToMinorUnits(m))
 	})
+}
+
+func TestValidateCurrencyDimension(t *testing.T) {
+	tests := []struct {
+		name      string
+		inst      Instrument
+		wantErr   bool
+		errTarget error
+	}{
+		{
+			name:    "CURRENCY dimension accepted",
+			inst:    quantity.Instrument{Code: "GBP", Dimension: quantity.DimensionCurrency, Precision: 2},
+			wantErr: false,
+		},
+		{
+			name:      "ENERGY dimension rejected",
+			inst:      quantity.Instrument{Code: "KWH", Dimension: "ENERGY", Precision: 3},
+			wantErr:   true,
+			errTarget: ErrNonCurrencyInstrument,
+		},
+		{
+			name:      "COMPUTE dimension rejected",
+			inst:      quantity.Instrument{Code: "GPU_HOUR", Dimension: "COMPUTE", Precision: 6},
+			wantErr:   true,
+			errTarget: ErrNonCurrencyInstrument,
+		},
+		{
+			name:      "empty dimension rejected",
+			inst:      quantity.Instrument{Code: "XXX", Dimension: "", Precision: 2},
+			wantErr:   true,
+			errTarget: ErrNonCurrencyInstrument,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCurrencyDimension(tt.inst)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.errTarget)
+				assert.Contains(t, err.Error(), tt.inst.Code)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestMoneyIsPositive(t *testing.T) {

--- a/services/position-keeping/domain/quantity.go
+++ b/services/position-keeping/domain/quantity.go
@@ -200,7 +200,7 @@ func NewMoneyFromMinorUnits(currencyCode string, minorUnits int64) (Money, error
 		return Money{}, err
 	}
 
-	decimalPlaces := cur.DecimalPlaces()
+	decimalPlaces := cur.DecimalPlaces() //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 	amount := decimal.NewFromInt(minorUnits).Shift(-decimalPlaces)
 	inst := currencyToInstrument(cur)
 
@@ -287,7 +287,7 @@ func ZeroQty[D quantity.Dimension](instrument Instrument) Qty[D] {
 
 // ParseCurrency converts a string to a Currency type with validation.
 func ParseCurrency(s string) (Currency, error) {
-	return money.ParseCurrency(s)
+	return money.ParseCurrency(s) //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 }
 
 // NewMoneyFromInstrumentCode creates a Money value from any instrument code (currency or non-currency).
@@ -305,7 +305,7 @@ func NewMoneyFromInstrumentCode(amount decimal.Decimal, code string) (Money, err
 
 	// Try currency path first (preserves correct precision for fiat)
 	cur := Currency(code)
-	if cur.IsValid() {
+	if cur.IsValid() { //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 		return NewMoney(amount, cur)
 	}
 
@@ -353,7 +353,7 @@ func MoneyToMinorUnits(m Money) (int64, error) {
 	maxInt64 := decimal.NewFromInt(9223372036854775807)  // math.MaxInt64
 	minInt64 := decimal.NewFromInt(-9223372036854775808) // math.MinInt64
 	if rounded.GreaterThan(maxInt64) || rounded.LessThan(minInt64) {
-		return 0, money.ErrOverflow
+		return 0, money.ErrOverflow //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 	}
 
 	return rounded.IntPart(), nil

--- a/shared/domain/money/money.go
+++ b/shared/domain/money/money.go
@@ -1,14 +1,10 @@
 // Package money provides a unified Money type for monetary amounts across all services.
 //
-// This package consolidates the various Money implementations that existed across
-// current-account, financial-accounting, and position-keeping services into a single,
-// currency-aware decimal-based Money type.
-//
-// Key features:
-//   - Decimal-based arithmetic for precision (no floating-point errors)
-//   - Currency-aware decimal places (JPY=0, most others=2)
-//   - Overflow protection when converting to minor units
-//   - Immutable value semantics
+// Deprecated: This package is superseded by the Universal Asset System. Use
+// shared/pkg/refdata.InstrumentResolver for instrument lookup and
+// shared/platform/quantity for dimensioned quantities. The money package only
+// supports a hardcoded set of fiat currencies and cannot represent non-monetary
+// assets (energy, compute, carbon). It will be removed in a future release.
 package money
 
 import (
@@ -20,6 +16,8 @@ import (
 )
 
 // Errors for Money operations.
+//
+// Deprecated: Use shared/platform/quantity error types instead.
 var (
 	ErrCurrencyMismatch = errors.New("currency mismatch")
 	ErrInvalidCurrency  = errors.New("invalid currency")
@@ -28,9 +26,15 @@ var (
 )
 
 // Currency represents an ISO 4217 currency code.
+//
+// Deprecated: Use shared/pkg/refdata.InstrumentResolver to resolve instrument
+// properties by code. Currency is a string typedef with a hardcoded validation
+// set that cannot represent non-monetary instruments.
 type Currency string
 
 // Supported currencies following ISO 4217 standard.
+//
+// Deprecated: Use shared/pkg/refdata.InstrumentResolver for dynamic instrument lookup.
 const (
 	CurrencyGBP Currency = "GBP" // British Pound Sterling
 	CurrencyUSD Currency = "USD" // United States Dollar
@@ -42,6 +46,9 @@ const (
 )
 
 // IsValid checks if the currency is a supported ISO 4217 code.
+//
+// Deprecated: Use shared/pkg/refdata.InstrumentResolver.Resolve() which validates
+// against the Reference Data service rather than a hardcoded set.
 func (c Currency) IsValid() bool {
 	switch c {
 	case CurrencyGBP, CurrencyUSD, CurrencyEUR, CurrencyJPY, CurrencyCHF, CurrencyCAD, CurrencyAUD:
@@ -57,6 +64,8 @@ func (c Currency) String() string {
 
 // DecimalPlaces returns the number of decimal places for the currency.
 // Most currencies use 2 decimal places, but some (like JPY) use 0.
+//
+// Deprecated: Use shared/pkg/refdata.InstrumentProperties.Precision instead.
 func (c Currency) DecimalPlaces() int32 {
 	switch c {
 	case CurrencyJPY:
@@ -69,6 +78,8 @@ func (c Currency) DecimalPlaces() int32 {
 }
 
 // ParseCurrency converts a string to a Currency type with validation.
+//
+// Deprecated: Use shared/pkg/refdata.InstrumentResolver.Resolve() instead.
 func ParseCurrency(s string) (Currency, error) {
 	c := Currency(s)
 	if !c.IsValid() {
@@ -80,12 +91,8 @@ func ParseCurrency(s string) (Currency, error) {
 // Money represents an immutable monetary amount with currency.
 // It uses decimal.Decimal for precise arithmetic operations.
 //
-// Concurrency: Money is safe for concurrent read access. All methods that
-// perform calculations (Add, Subtract, etc.) return new Money instances
-// rather than modifying the receiver, following value semantics.
-// However, the underlying decimal.Decimal is not inherently thread-safe
-// for concurrent writes; since Money values are immutable, this is not
-// a concern for normal usage patterns.
+// Deprecated: Use shared/platform/quantity.Money (Qty[Monetary]) which supports
+// any instrument dimension, not just currencies.
 type Money struct {
 	amount   decimal.Decimal
 	currency Currency
@@ -93,6 +100,8 @@ type Money struct {
 
 // New creates a Money value with the given amount and currency.
 // Returns an error if the currency is not supported.
+//
+// Deprecated: Use quantity.NewMoney(amount, instrument) instead.
 func New(amount decimal.Decimal, currency Currency) (Money, error) {
 	if !currency.IsValid() {
 		return Money{}, fmt.Errorf("%w: %s", ErrInvalidCurrency, currency)
@@ -105,6 +114,8 @@ func New(amount decimal.Decimal, currency Currency) (Money, error) {
 
 // MustNew creates a Money value, panicking if the currency is invalid.
 // Use only in tests or when the currency is known to be valid at compile time.
+//
+// Deprecated: Use quantity.NewMoney(amount, instrument) instead.
 func MustNew(amount decimal.Decimal, currency Currency) Money {
 	m, err := New(amount, currency)
 	if err != nil {
@@ -115,12 +126,16 @@ func MustNew(amount decimal.Decimal, currency Currency) Money {
 
 // NewFromInt64 creates Money from an int64 amount in the currency's major units.
 // For example, NewFromInt64(100, CurrencyGBP) creates £100.00.
+//
+// Deprecated: Use quantity.NewMoney(decimal.NewFromInt(amount), instrument) instead.
 func NewFromInt64(amount int64, currency Currency) (Money, error) {
 	return New(decimal.NewFromInt(amount), currency)
 }
 
 // NewFromMinorUnits creates Money from minor units (cents, pence, etc.).
 // For example, NewFromMinorUnits(10000, CurrencyGBP) creates £100.00.
+//
+// Deprecated: Use quantity.NewMoney with decimal shifted by instrument precision.
 func NewFromMinorUnits(minorUnits int64, currency Currency) (Money, error) {
 	if !currency.IsValid() {
 		return Money{}, fmt.Errorf("%w: %s", ErrInvalidCurrency, currency)
@@ -134,6 +149,8 @@ func NewFromMinorUnits(minorUnits int64, currency Currency) (Money, error) {
 }
 
 // Zero returns a zero Money value for the given currency.
+//
+// Deprecated: Use quantity.NewMoney(decimal.Zero, instrument) instead.
 func Zero(currency Currency) (Money, error) {
 	return New(decimal.Zero, currency)
 }

--- a/shared/pkg/amount/amount.go
+++ b/shared/pkg/amount/amount.go
@@ -72,7 +72,7 @@ func NewFromInstrument(code, dimension string, precision int, amountMinorUnits i
 	var inst quantity.Instrument
 	if normalizedDim == quantity.DimensionCurrency {
 		// For currency, look up canonical instrument (ignores caller-supplied precision).
-		currInst, ok := currency.ByCode(strings.ToUpper(code))
+		currInst, ok := currency.ByCode(strings.ToUpper(code)) //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 		if !ok {
 			return Amount{}, fmt.Errorf("%w: unrecognized currency code %s", ErrInvalidDimension, code)
 		}

--- a/shared/pkg/money/money.go
+++ b/shared/pkg/money/money.go
@@ -75,7 +75,7 @@ type Money struct {
 // instrumentForCurrency returns the quantity.Instrument for the given currency code.
 // Returns an error if the currency is not recognized.
 func instrumentForCurrency(code string) (quantity.Instrument, error) {
-	inst, ok := currency.ByCode(strings.ToUpper(code))
+	inst, ok := currency.ByCode(strings.ToUpper(code)) //nolint:staticcheck // Will migrate to refdata.InstrumentResolver
 	if !ok {
 		return quantity.Instrument{}, fmt.Errorf("%w: %s", ErrInvalidCurrency, code)
 	}

--- a/shared/platform/quantity/currency/currency.go
+++ b/shared/platform/quantity/currency/currency.go
@@ -1,24 +1,10 @@
 // Package currency provides predefined Instrument instances for major fiat currencies.
 //
-// # ISO 4217 Standard
-//
-// Currency codes and precisions follow the ISO 4217 standard:
-//   - Most currencies use 2 decimal places (cents, pence, etc.)
-//   - JPY uses 0 decimal places (no minor units)
-//
-// # Usage
-//
-// Use predefined instruments for compile-time safety:
-//
-//	usdAmount := currency.USD(decimal.NewFromInt(100))    // $100.00
-//	jpyAmount := currency.JPY(decimal.NewFromInt(10000))  // ¥10000
-//
-// Look up currencies by code:
-//
-//	instrument, ok := currency.ByCode("EUR")
-//	if ok {
-//	    euroAmount := quantity.NewMoney(decimal.NewFromInt(50), instrument)
-//	}
+// Deprecated: This package uses hardcoded instrument definitions. Use
+// shared/pkg/refdata.InstrumentResolver to resolve instrument properties from the
+// Reference Data service at runtime. The resolver supports all instrument dimensions
+// (currency, energy, compute, carbon) and stays in sync with the reference data
+// catalog. This package will be removed in a future release.
 package currency
 
 import (
@@ -29,6 +15,9 @@ import (
 
 // Currency instruments for major fiat currencies.
 // All instruments use version 0 (initial/unversioned) and CURRENCY dimension.
+//
+// Deprecated: Use shared/pkg/refdata.InstrumentResolver.Resolve() to obtain
+// instrument metadata dynamically from Reference Data.
 var (
 	// InstrumentUSD is the US Dollar instrument (2 decimal places).
 	InstrumentUSD = mustNewCurrency("USD", 2)
@@ -81,12 +70,17 @@ func mustNewCurrency(code string, precision int) quantity.Instrument {
 // Returns the instrument and true if found, or a zero Instrument and false if not found.
 //
 // Supported codes: USD, EUR, GBP, JPY, CHF, AUD, CAD, NZD.
+//
+// Deprecated: Use shared/pkg/refdata.InstrumentResolver.Resolve() instead, which
+// validates against the Reference Data service and supports all instrument types.
 func ByCode(code string) (quantity.Instrument, bool) {
 	inst, ok := currencies[code]
 	return inst, ok
 }
 
 // All returns a copy of all supported currency instruments.
+//
+// Deprecated: Query the Reference Data service for the full instrument catalog.
 func All() []quantity.Instrument {
 	result := make([]quantity.Instrument, 0, len(currencies))
 	for _, inst := range currencies {
@@ -96,6 +90,8 @@ func All() []quantity.Instrument {
 }
 
 // Codes returns all supported currency codes.
+//
+// Deprecated: Query the Reference Data service for the full instrument catalog.
 func Codes() []string {
 	codes := make([]string, 0, len(currencies))
 	for code := range currencies {
@@ -105,41 +101,65 @@ func Codes() []string {
 }
 
 // USD creates a Money quantity in US Dollars.
+//
+// Deprecated: Use quantity.NewMoney(amount, instrument) with an instrument
+// resolved via shared/pkg/refdata.InstrumentResolver.
 func USD(amount decimal.Decimal) quantity.Money {
 	return quantity.NewMoney(amount, InstrumentUSD)
 }
 
 // EUR creates a Money quantity in Euros.
+//
+// Deprecated: Use quantity.NewMoney(amount, instrument) with an instrument
+// resolved via shared/pkg/refdata.InstrumentResolver.
 func EUR(amount decimal.Decimal) quantity.Money {
 	return quantity.NewMoney(amount, InstrumentEUR)
 }
 
 // GBP creates a Money quantity in British Pounds.
+//
+// Deprecated: Use quantity.NewMoney(amount, instrument) with an instrument
+// resolved via shared/pkg/refdata.InstrumentResolver.
 func GBP(amount decimal.Decimal) quantity.Money {
 	return quantity.NewMoney(amount, InstrumentGBP)
 }
 
 // JPY creates a Money quantity in Japanese Yen.
+//
+// Deprecated: Use quantity.NewMoney(amount, instrument) with an instrument
+// resolved via shared/pkg/refdata.InstrumentResolver.
 func JPY(amount decimal.Decimal) quantity.Money {
 	return quantity.NewMoney(amount, InstrumentJPY)
 }
 
 // CHF creates a Money quantity in Swiss Francs.
+//
+// Deprecated: Use quantity.NewMoney(amount, instrument) with an instrument
+// resolved via shared/pkg/refdata.InstrumentResolver.
 func CHF(amount decimal.Decimal) quantity.Money {
 	return quantity.NewMoney(amount, InstrumentCHF)
 }
 
 // AUD creates a Money quantity in Australian Dollars.
+//
+// Deprecated: Use quantity.NewMoney(amount, instrument) with an instrument
+// resolved via shared/pkg/refdata.InstrumentResolver.
 func AUD(amount decimal.Decimal) quantity.Money {
 	return quantity.NewMoney(amount, InstrumentAUD)
 }
 
 // CAD creates a Money quantity in Canadian Dollars.
+//
+// Deprecated: Use quantity.NewMoney(amount, instrument) with an instrument
+// resolved via shared/pkg/refdata.InstrumentResolver.
 func CAD(amount decimal.Decimal) quantity.Money {
 	return quantity.NewMoney(amount, InstrumentCAD)
 }
 
 // NZD creates a Money quantity in New Zealand Dollars.
+//
+// Deprecated: Use quantity.NewMoney(amount, instrument) with an instrument
+// resolved via shared/pkg/refdata.InstrumentResolver.
 func NZD(amount decimal.Decimal) quantity.Money {
 	return quantity.NewMoney(amount, InstrumentNZD)
 }


### PR DESCRIPTION
## Summary

- Deprecate `shared/domain/money` package with godoc annotations directing to `shared/pkg/refdata.InstrumentResolver` and `shared/platform/quantity`
- Deprecate `shared/platform/quantity/currency` package with godoc annotations directing to `shared/pkg/refdata.InstrumentResolver`
- Document payment-order service currency-only constraint as an intentional business rule
- Add `ValidateCurrencyDimension()` helper and `ErrNonCurrencyInstrument` error to `services/payment-order/domain`
- Add targeted `nolint:staticcheck` directives to all consumers of deprecated packages

## Changes Made

### Task multi-asset-purity.4: Deprecate shared/domain/money
All exported types (`Currency`, `Money`), functions (`New`, `MustNew`, `ParseCurrency`, `Zero`, `NewFromInt64`, `NewFromMinorUnits`), constants, and error variables carry `Deprecated` godoc annotations with specific migration targets. Package remains fully functional.

### Task multi-asset-purity.5: Deprecate shared/platform/quantity/currency
Package-level deprecation plus individual annotations on `ByCode()`, `All()`, `Codes()`, instrument variables, and convenience constructors (`USD`, `EUR`, `GBP`, `JPY`, `CHF`, `AUD`, `CAD`, `NZD`). Package remains fully functional.

### Task multi-asset-purity.10: Document payment-order currency-only constraint
- Enhanced package godoc in `services/payment-order/domain/quantity.go` explaining the permanent business rule
- Added `ValidateCurrencyDimension()` for enforcing CURRENCY dimension at service boundary
- Added `ErrNonCurrencyInstrument` sentinel error
- Documented constraint in `services/payment-order/README.md`

### Lint suppression
Added per-line `nolint:staticcheck` directives to all files that reference deprecated symbols. This is preferred over global `.golangci.yml` exclusions as it is more precise and self-documenting.

## Test plan

- [x] All modified packages compile
- [x] All tests pass
- [x] Pre-commit hooks pass (gofumpt, golangci-lint, gitleaks, markdownlint)
- [x] No functional changes - deprecation is advisory only