### PR TITLE
refactor: Migrate position-keeping to Reference Data resolution

### DIFF
--- a/services/position-keeping/adapters/balance_mapper.go
+++ b/services/position-keeping/adapters/balance_mapper.go
@@ -2,6 +2,7 @@
 package adapters
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -12,6 +13,7 @@ import (
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/meridianhub/meridian/shared/pkg/refdata"
 )
 
 // ErrUnspecifiedBalanceType is returned when attempting to convert BALANCE_TYPE_UNSPECIFIED
@@ -213,8 +215,9 @@ func ToDomainMoneyFromInstrumentAmount(protoAmount *quantityv1.InstrumentAmount)
 
 // ToDomainAssetFromInstrumentAmount converts a protobuf InstrumentAmount to its domain Asset representation.
 // This function is for non-monetary quantities like energy (KWH), compute (GPU_HOUR), and carbon credits.
-// Returns an error if the amount is invalid or the instrument code is empty.
-func ToDomainAssetFromInstrumentAmount(protoAmount *quantityv1.InstrumentAmount) (domain.Asset, error) {
+// Resolves instrument dimension and precision from Reference Data via the provided resolver.
+// Returns an error if the amount is invalid, the instrument code is empty, or the instrument is unknown.
+func ToDomainAssetFromInstrumentAmount(ctx context.Context, resolver refdata.InstrumentResolver, protoAmount *quantityv1.InstrumentAmount) (domain.Asset, error) {
 	if protoAmount == nil {
 		return domain.Asset{}, ErrNilInstrumentAmount
 	}
@@ -228,8 +231,11 @@ func ToDomainAssetFromInstrumentAmount(protoAmount *quantityv1.InstrumentAmount)
 		return domain.Asset{}, fmt.Errorf("%w: %s", ErrInvalidAmount, protoAmount.Amount)
 	}
 
-	// Infer dimension and precision from instrument code
-	dimension, precision := inferInstrumentProperties(protoAmount.InstrumentCode)
+	// Resolve dimension and precision from Reference Data
+	props, err := resolver.Resolve(ctx, protoAmount.InstrumentCode)
+	if err != nil {
+		return domain.Asset{}, fmt.Errorf("%w: failed to resolve instrument %q: %w", ErrInvalidInstrumentCode, protoAmount.InstrumentCode, err)
+	}
 
 	// Reject negative version values (would wrap to large uint32)
 	if protoAmount.Version < 0 {
@@ -241,33 +247,10 @@ func ToDomainAssetFromInstrumentAmount(protoAmount *quantityv1.InstrumentAmount)
 		version = 1 // Default version
 	}
 
-	instrument, err := domain.NewInstrument(protoAmount.InstrumentCode, version, dimension, precision)
+	instrument, err := domain.NewInstrument(protoAmount.InstrumentCode, version, props.Dimension, props.Precision)
 	if err != nil {
 		return domain.Asset{}, fmt.Errorf("%w: %w", ErrInvalidInstrumentCode, err)
 	}
 
 	return domain.NewAsset(amount, instrument), nil
-}
-
-// inferInstrumentProperties returns the dimension and precision for a given instrument code.
-// Known instrument codes get specific precision, others default to 6 decimal places.
-func inferInstrumentProperties(code string) (dimension string, precision int) {
-	// Currency codes (3-char uppercase letters)
-	switch code {
-	case "USD", "EUR", "GBP", "CHF", "CAD", "AUD":
-		return domain.DimensionCurrency, 2
-	case "JPY":
-		return domain.DimensionCurrency, 0
-	case "KWH":
-		return "ENERGY", 6 // Kilowatt-hours
-	case "GPU_HOUR":
-		return "COMPUTE", 6 // GPU compute hours
-	case "CARBON_TONNE":
-		return "CARBON", 3 // Carbon credits
-	case "CARBON_CREDIT":
-		return "CARBON", 3 // Carbon credits
-	default:
-		// Default to commodity dimension with 6 decimal places
-		return "COMMODITY", 6
-	}
 }

--- a/services/position-keeping/adapters/balance_mapper.go
+++ b/services/position-keeping/adapters/balance_mapper.go
@@ -234,7 +234,7 @@ func ToDomainAssetFromInstrumentAmount(ctx context.Context, resolver refdata.Ins
 	// Resolve dimension and precision from Reference Data
 	props, err := resolver.Resolve(ctx, protoAmount.InstrumentCode)
 	if err != nil {
-		return domain.Asset{}, fmt.Errorf("%w: failed to resolve instrument %q: %w", ErrInvalidInstrumentCode, protoAmount.InstrumentCode, err)
+		return domain.Asset{}, fmt.Errorf("failed to resolve instrument %q: %w", protoAmount.InstrumentCode, err)
 	}
 
 	// Reject negative version values (would wrap to large uint32)

--- a/services/position-keeping/adapters/balance_mapper_test.go
+++ b/services/position-keeping/adapters/balance_mapper_test.go
@@ -1,6 +1,7 @@
 package adapters_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/shopspring/decimal"
@@ -13,7 +14,31 @@ import (
 	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/adapters"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/meridianhub/meridian/shared/pkg/refdata"
 )
+
+// stubResolver is a test InstrumentResolver that returns predefined properties.
+type stubResolver struct {
+	instruments map[string]refdata.InstrumentProperties
+}
+
+func (s *stubResolver) Resolve(_ context.Context, code string) (refdata.InstrumentProperties, error) {
+	props, ok := s.instruments[code]
+	if !ok {
+		return refdata.InstrumentProperties{}, refdata.ErrUnknownInstrument
+	}
+	return props, nil
+}
+
+func newTestResolver() *stubResolver {
+	return &stubResolver{
+		instruments: map[string]refdata.InstrumentProperties{
+			"KWH":          {Code: "KWH", Dimension: "ENERGY", Precision: 6, RoundingMode: "HALF_EVEN"},
+			"GPU_HOUR":     {Code: "GPU_HOUR", Dimension: "COMPUTE", Precision: 6, RoundingMode: "HALF_EVEN"},
+			"CARBON_TONNE": {Code: "CARBON_TONNE", Dimension: "CARBON", Precision: 3, RoundingMode: "HALF_EVEN"},
+		},
+	}
+}
 
 // TestToProtoBalanceType tests conversion of all 7 domain balance types to proto.
 func TestToProtoBalanceType(t *testing.T) {
@@ -777,6 +802,9 @@ func TestToDomainMoneyFromInstrumentAmount(t *testing.T) {
 
 // TestToDomainAssetFromInstrumentAmount tests conversion of proto InstrumentAmount to domain Asset.
 func TestToDomainAssetFromInstrumentAmount(t *testing.T) {
+	resolver := newTestResolver()
+	ctx := context.Background()
+
 	tests := []struct {
 		name         string
 		proto        *quantityv1.InstrumentAmount
@@ -865,11 +893,21 @@ func TestToDomainAssetFromInstrumentAmount(t *testing.T) {
 			expectError: true,
 			errContains: "version",
 		},
+		{
+			name: "unknown instrument returns error",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "100",
+				InstrumentCode: "UNKNOWN_ASSET",
+				Version:        1,
+			},
+			expectError: true,
+			errContains: "instrument",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := adapters.ToDomainAssetFromInstrumentAmount(tt.proto)
+			result, err := adapters.ToDomainAssetFromInstrumentAmount(ctx, resolver, tt.proto)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/services/position-keeping/adapters/persistence/postgres_repository.go
+++ b/services/position-keeping/adapters/persistence/postgres_repository.go
@@ -329,8 +329,6 @@ func (r *PostgresRepository) FindByID(ctx context.Context, logID uuid.UUID) (*do
 		log.StatusTracking = &statusTracking
 
 		// Parse opening balance (supports both currency and non-currency codes)
-		// Trim spaces since PostgreSQL CHAR(3) may pad with spaces
-		openingBalanceCurrency = strings.TrimSpace(openingBalanceCurrency)
 		openingBalance, err := domain.NewMoneyFromInstrumentCode(openingBalanceAmount, openingBalanceCurrency)
 		if err != nil {
 			return fmt.Errorf("failed to create opening balance Money for instrument %q: %w", openingBalanceCurrency, err)
@@ -960,7 +958,6 @@ func (r *PostgresRepository) loadTransactionLogEntriesTx(ctx context.Context, tx
 
 		// Convert cents to decimal and create Money (supports both currency and non-currency codes)
 		amount := centsToDecimal(amountCents)
-		currency = strings.TrimSpace(currency)
 		money, err := domain.NewMoneyFromInstrumentCode(amount, currency)
 		if err != nil {
 			return fmt.Errorf("failed to create Money value for instrument %q: %w", currency, err)
@@ -1168,7 +1165,6 @@ func (r *PostgresRepository) loadTransactionLogEntriesBatchTx(ctx context.Contex
 
 		// Convert cents to decimal and create Money (supports both currency and non-currency codes)
 		amount := centsToDecimal(amountCents)
-		currency = strings.TrimSpace(currency)
 		money, err := domain.NewMoneyFromInstrumentCode(amount, currency)
 		if err != nil {
 			return fmt.Errorf("failed to create Money value for instrument %q in batch: %w", currency, err)
@@ -1387,8 +1383,6 @@ func (r *PostgresRepository) scanLogsTx(ctx context.Context, tx pgx.Tx, rows pgx
 		log.StatusTracking = &statusTracking
 
 		// Parse opening balance (supports both currency and non-currency codes)
-		// Trim spaces since PostgreSQL CHAR(3) may pad with spaces
-		openingBalanceCurrency = strings.TrimSpace(openingBalanceCurrency)
 		openingBalance, err := domain.NewMoneyFromInstrumentCode(openingBalanceAmount, openingBalanceCurrency)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create opening balance Money for instrument %q: %w", openingBalanceCurrency, err)

--- a/services/position-keeping/app/config.go
+++ b/services/position-keeping/app/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Observability     ObservabilityConfig
 	Compaction        CompactionConfig
 	AccountValidation AccountValidationConfig
+	ReferenceData     ReferenceDataConfig
 }
 
 // ServerConfig holds gRPC server configuration
@@ -139,6 +140,13 @@ type AccountValidationConfig struct {
 	ConnectionTimeout time.Duration
 }
 
+// ReferenceDataConfig holds Reference Data service connection configuration.
+type ReferenceDataConfig struct {
+	// ServiceURL is the gRPC address of the Reference Data service.
+	// Optional - if not specified, instrument resolution is unavailable.
+	ServiceURL string
+}
+
 // LoadConfig loads configuration from environment variables with defaults
 func LoadConfig() (*Config, error) {
 	config := &Config{
@@ -150,6 +158,7 @@ func LoadConfig() (*Config, error) {
 		Observability:     loadObservabilityConfig(),
 		Compaction:        loadCompactionConfig(),
 		AccountValidation: loadAccountValidationConfig(),
+		ReferenceData:     loadReferenceDataConfig(),
 	}
 
 	if err := config.Validate(); err != nil {
@@ -251,6 +260,13 @@ func loadAccountValidationConfig() AccountValidationConfig {
 			env.GetEnvOrDefault("INTERNAL_BANK_ACCOUNT_SERVICE_URL", "")),
 		CacheTTL:          env.GetEnvAsDuration("ACCOUNT_VALIDATION_CACHE_TTL", 1*time.Minute),
 		ConnectionTimeout: env.GetEnvAsDuration("ACCOUNT_VALIDATION_CONNECTION_TIMEOUT", 5*time.Second),
+	}
+}
+
+// loadReferenceDataConfig loads Reference Data service configuration from environment variables.
+func loadReferenceDataConfig() ReferenceDataConfig {
+	return ReferenceDataConfig{
+		ServiceURL: env.GetEnvOrDefault("REFERENCE_DATA_SERVICE_URL", ""),
 	}
 }
 

--- a/services/position-keeping/cmd/main.go
+++ b/services/position-keeping/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	internalaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/app"
 	"github.com/meridianhub/meridian/services/position-keeping/observability"
 	"github.com/meridianhub/meridian/services/position-keeping/service"
@@ -22,6 +23,7 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/health"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/pkg/interceptors"
+	"github.com/meridianhub/meridian/shared/pkg/refdata"
 	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
@@ -395,6 +397,47 @@ func run(logger *slog.Logger) error {
 		if internalAccountConn != nil {
 			if err := internalAccountConn.Close(); err != nil {
 				logger.Error("failed to close internal account connection", "error", err)
+			}
+		}
+	}()
+
+	// Initialize InstrumentResolver from Reference Data service (optional)
+	var refDataConn *grpc.ClientConn
+	if config.ReferenceData.ServiceURL != "" {
+		var connErr error
+		refDataConn, connErr = grpc.NewClient(
+			config.ReferenceData.ServiceURL,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if connErr != nil {
+			return fmt.Errorf("failed to create reference data client at %s: %w",
+				config.ReferenceData.ServiceURL, connErr)
+		}
+
+		refDataClient := referencedatav1.NewReferenceDataServiceClient(refDataConn)
+		dataSource := refdata.NewGRPCDataSource(refDataClient)
+		cachedResolver := refdata.NewCachedResolver(dataSource, refdata.CachedResolverConfig{
+			Logger: logger,
+		})
+
+		// Preload cache at startup (log warning on failure, don't block startup)
+		if preloadErr := cachedResolver.Preload(ctx); preloadErr != nil {
+			logger.Warn("failed to preload instrument cache from reference data, will resolve on demand",
+				"error", preloadErr)
+		}
+
+		serviceOpts = append(serviceOpts, service.WithInstrumentResolver(cachedResolver))
+		logger.Info("instrument resolver configured",
+			"url", config.ReferenceData.ServiceURL)
+	} else {
+		logger.Info("instrument resolver disabled (REFERENCE_DATA_SERVICE_URL not configured)")
+	}
+
+	// Ensure reference data connection is closed on shutdown
+	defer func() {
+		if refDataConn != nil {
+			if err := refDataConn.Close(); err != nil {
+				logger.Error("failed to close reference data connection", "error", err)
 			}
 		}
 	}()

--- a/services/position-keeping/domain/money_test.go
+++ b/services/position-keeping/domain/money_test.go
@@ -432,16 +432,25 @@ func TestNewMoneyFromInstrumentCode(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "overlength code rejected",
-			amount:  decimal.NewFromInt(100),
-			code:    "KWHR",
-			wantErr: true,
+			name:           "multi-char non-currency instrument KWHR",
+			amount:         decimal.NewFromInt(100),
+			code:           "KWHR",
+			expectedCode:   "KWHR",
+			expectedAmount: decimal.NewFromInt(100),
 		},
 		{
-			name:    "single char code rejected",
-			amount:  decimal.NewFromInt(100),
-			code:    "X",
-			wantErr: true,
+			name:           "long instrument code CARBON_CREDIT",
+			amount:         decimal.NewFromFloat(25.50),
+			code:           "CARBON_CREDIT",
+			expectedCode:   "CARBON_CREDIT",
+			expectedAmount: decimal.NewFromFloat(25.50),
+		},
+		{
+			name:           "long instrument code GPU_HOUR",
+			amount:         decimal.NewFromFloat(3.75),
+			code:           "GPU_HOUR",
+			expectedCode:   "GPU_HOUR",
+			expectedAmount: decimal.NewFromFloat(3.75),
 		},
 		{
 			name:           "zero amount with non-currency",
@@ -495,6 +504,9 @@ func TestNewMoneyFromInstrumentCode_RoundTrip(t *testing.T) {
 		{"CO2", decimal.NewFromFloat(50.00)},
 		{"GPU", decimal.NewFromFloat(3.75)},
 		{"GAS", decimal.NewFromFloat(1.25)},
+		{"CARBON_CREDIT", decimal.NewFromFloat(100.00)},
+		{"GPU_HOUR", decimal.NewFromFloat(42.50)},
+		{"TONNE_CO2E", decimal.NewFromFloat(12.34)},
 	}
 
 	for _, inst := range instruments {

--- a/services/position-keeping/domain/quantity.go
+++ b/services/position-keeping/domain/quantity.go
@@ -12,8 +12,6 @@
 package domain
 
 import (
-	"fmt"
-
 	"github.com/meridianhub/meridian/shared/domain/money"
 	sharedamount "github.com/meridianhub/meridian/shared/pkg/amount"
 	"github.com/meridianhub/meridian/shared/platform/quantity"
@@ -296,8 +294,8 @@ func ParseCurrency(s string) (Currency, error) {
 // currency validation. This enables position-keeping to track any registered instrument while
 // reusing the same Money type for persistence and domain logic.
 //
-// Persistence constraint: the transaction_log_entry.currency column is CHAR(3), so codes must be
-// exactly 3 characters to persist correctly.
+// Callers are expected to have resolved instrument properties from Reference Data before calling
+// this function. The domain layer trusts that the code is a valid registered instrument.
 func NewMoneyFromInstrumentCode(amount decimal.Decimal, code string) (Money, error) {
 	if code == "" {
 		return Money{}, ErrEmptyCode
@@ -307,12 +305,6 @@ func NewMoneyFromInstrumentCode(amount decimal.Decimal, code string) (Money, err
 	cur := Currency(code)
 	if cur.IsValid() {
 		return NewMoney(amount, cur)
-	}
-
-	// Fail fast: the transaction_log_entry.currency column is CHAR(3), so non-currency
-	// codes must also be exactly 3 characters to persist correctly.
-	if len(code) != 3 {
-		return Money{}, fmt.Errorf("%w: non-currency instrument code %q must be exactly 3 characters for persistence", ErrInvalidCodeFormat, code)
 	}
 
 	// Non-currency instrument: use precision 2 to match the persistence layer's

--- a/services/position-keeping/service/service.go
+++ b/services/position-keeping/service/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/meridianhub/meridian/services/position-keeping/adapters/messaging"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
+	"github.com/meridianhub/meridian/shared/pkg/refdata"
 )
 
 // Service initialization errors
@@ -66,6 +67,9 @@ type PositionKeepingService struct {
 	reservationRepo domain.ReservationRepository
 	// positionRepo is OPTIONAL - if nil, projected balance RPCs return FailedPrecondition.
 	positionRepo domain.PositionRepository
+	// instrumentResolver is OPTIONAL - if nil, asset instrument resolution falls back to defaults.
+	// When set, resolves instrument dimension and precision from Reference Data.
+	instrumentResolver refdata.InstrumentResolver
 }
 
 // Option configures optional dependencies for PositionKeepingService.
@@ -131,6 +135,15 @@ func WithReservationRepository(repo domain.ReservationRepository) Option {
 func WithPositionRepository(repo domain.PositionRepository) Option {
 	return func(s *PositionKeepingService) {
 		s.positionRepo = repo
+	}
+}
+
+// WithInstrumentResolver sets the InstrumentResolver for resolving instrument properties
+// (dimension, precision) from Reference Data. If not set, asset instrument resolution
+// uses hardcoded defaults for backwards compatibility.
+func WithInstrumentResolver(resolver refdata.InstrumentResolver) Option {
+	return func(s *PositionKeepingService) {
+		s.instrumentResolver = resolver
 	}
 }
 

--- a/services/position-keeping/service/service.go
+++ b/services/position-keeping/service/service.go
@@ -67,7 +67,7 @@ type PositionKeepingService struct {
 	reservationRepo domain.ReservationRepository
 	// positionRepo is OPTIONAL - if nil, projected balance RPCs return FailedPrecondition.
 	positionRepo domain.PositionRepository
-	// instrumentResolver is OPTIONAL - if nil, asset instrument resolution falls back to defaults.
+	// instrumentResolver is OPTIONAL - if nil, asset RPCs requiring instrument resolution will error.
 	// When set, resolves instrument dimension and precision from Reference Data.
 	instrumentResolver refdata.InstrumentResolver
 }

--- a/shared/pkg/refdata/grpc_datasource.go
+++ b/shared/pkg/refdata/grpc_datasource.go
@@ -1,0 +1,83 @@
+package refdata
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// GRPCDataSource implements DataSource by calling the Reference Data gRPC service.
+type GRPCDataSource struct {
+	client referencedatav1.ReferenceDataServiceClient
+}
+
+// NewGRPCDataSource creates a DataSource backed by the Reference Data gRPC service.
+func NewGRPCDataSource(client referencedatav1.ReferenceDataServiceClient) *GRPCDataSource {
+	return &GRPCDataSource{client: client}
+}
+
+// FetchInstrument retrieves properties for a single instrument code from Reference Data.
+func (s *GRPCDataSource) FetchInstrument(ctx context.Context, code string) (InstrumentProperties, error) {
+	resp, err := s.client.RetrieveInstrument(ctx, &referencedatav1.RetrieveInstrumentRequest{
+		Code:    code,
+		Version: 0, // Latest active version
+	})
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return InstrumentProperties{}, ErrUnknownInstrument
+		}
+		return InstrumentProperties{}, fmt.Errorf("retrieve instrument %q: %w", code, err)
+	}
+
+	return protoToProperties(resp.Instrument), nil
+}
+
+// FetchAllActive retrieves all active instrument properties from Reference Data.
+func (s *GRPCDataSource) FetchAllActive(ctx context.Context) ([]InstrumentProperties, error) {
+	var all []InstrumentProperties
+	var pageToken string
+
+	for {
+		resp, err := s.client.ListInstruments(ctx, &referencedatav1.ListInstrumentsRequest{
+			StatusFilter: referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+			PageSize:     100,
+			PageToken:    pageToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list active instruments: %w", err)
+		}
+
+		for _, inst := range resp.Instruments {
+			all = append(all, protoToProperties(inst))
+		}
+
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+
+	return all, nil
+}
+
+// protoToProperties converts a proto InstrumentDefinition to InstrumentProperties.
+func protoToProperties(inst *referencedatav1.InstrumentDefinition) InstrumentProperties {
+	return InstrumentProperties{
+		Code:         inst.Code,
+		Dimension:    dimensionToString(inst.Dimension),
+		Precision:    int(inst.Precision),
+		RoundingMode: DefaultRoundingMode,
+	}
+}
+
+// dimensionToString converts a proto Dimension enum to its string representation.
+// The string format strips the "DIMENSION_" prefix to match the domain convention
+// (e.g., DIMENSION_CURRENCY -> "CURRENCY", DIMENSION_ENERGY -> "ENERGY").
+func dimensionToString(d referencedatav1.Dimension) string {
+	name := d.String()
+	return strings.TrimPrefix(name, "DIMENSION_")
+}

--- a/shared/pkg/refdata/grpc_datasource_test.go
+++ b/shared/pkg/refdata/grpc_datasource_test.go
@@ -1,0 +1,135 @@
+package refdata
+
+import (
+	"context"
+	"testing"
+
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// mockReferenceDataClient implements referencedatav1.ReferenceDataServiceClient for testing.
+type mockReferenceDataClient struct {
+	referencedatav1.ReferenceDataServiceClient
+	instruments map[string]*referencedatav1.InstrumentDefinition
+}
+
+func (m *mockReferenceDataClient) RetrieveInstrument(_ context.Context, req *referencedatav1.RetrieveInstrumentRequest, _ ...grpc.CallOption) (*referencedatav1.RetrieveInstrumentResponse, error) {
+	inst, ok := m.instruments[req.Code]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "instrument not found")
+	}
+	return &referencedatav1.RetrieveInstrumentResponse{Instrument: inst}, nil
+}
+
+func (m *mockReferenceDataClient) ListInstruments(_ context.Context, _ *referencedatav1.ListInstrumentsRequest, _ ...grpc.CallOption) (*referencedatav1.ListInstrumentsResponse, error) {
+	instruments := make([]*referencedatav1.InstrumentDefinition, 0, len(m.instruments))
+	for _, inst := range m.instruments {
+		instruments = append(instruments, inst)
+	}
+	return &referencedatav1.ListInstrumentsResponse{Instruments: instruments}, nil
+}
+
+func TestDimensionToString(t *testing.T) {
+	tests := []struct {
+		dimension referencedatav1.Dimension
+		expected  string
+	}{
+		{referencedatav1.Dimension_DIMENSION_CURRENCY, "CURRENCY"},
+		{referencedatav1.Dimension_DIMENSION_ENERGY, "ENERGY"},
+		{referencedatav1.Dimension_DIMENSION_COMPUTE, "COMPUTE"},
+		{referencedatav1.Dimension_DIMENSION_CARBON, "CARBON"},
+		{referencedatav1.Dimension_DIMENSION_COUNT, "COUNT"},
+		{referencedatav1.Dimension_DIMENSION_UNSPECIFIED, "UNSPECIFIED"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := dimensionToString(tt.dimension)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestProtoToProperties(t *testing.T) {
+	inst := &referencedatav1.InstrumentDefinition{
+		Code:      "KWH",
+		Dimension: referencedatav1.Dimension_DIMENSION_ENERGY,
+		Precision: 6,
+		Status:    referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+		CreatedAt: timestamppb.Now(),
+	}
+
+	props := protoToProperties(inst)
+
+	assert.Equal(t, "KWH", props.Code)
+	assert.Equal(t, "ENERGY", props.Dimension)
+	assert.Equal(t, 6, props.Precision)
+	assert.Equal(t, DefaultRoundingMode, props.RoundingMode)
+}
+
+func TestGRPCDataSource_FetchInstrument(t *testing.T) {
+	client := &mockReferenceDataClient{
+		instruments: map[string]*referencedatav1.InstrumentDefinition{
+			"KWH": {
+				Code:      "KWH",
+				Dimension: referencedatav1.Dimension_DIMENSION_ENERGY,
+				Precision: 6,
+				CreatedAt: timestamppb.Now(),
+			},
+		},
+	}
+	ds := NewGRPCDataSource(client)
+	ctx := context.Background()
+
+	t.Run("known instrument", func(t *testing.T) {
+		props, err := ds.FetchInstrument(ctx, "KWH")
+		require.NoError(t, err)
+		assert.Equal(t, "KWH", props.Code)
+		assert.Equal(t, "ENERGY", props.Dimension)
+		assert.Equal(t, 6, props.Precision)
+	})
+
+	t.Run("unknown instrument", func(t *testing.T) {
+		_, err := ds.FetchInstrument(ctx, "UNKNOWN")
+		require.ErrorIs(t, err, ErrUnknownInstrument)
+	})
+}
+
+func TestGRPCDataSource_FetchAllActive(t *testing.T) {
+	client := &mockReferenceDataClient{
+		instruments: map[string]*referencedatav1.InstrumentDefinition{
+			"USD": {
+				Code:      "USD",
+				Dimension: referencedatav1.Dimension_DIMENSION_CURRENCY,
+				Precision: 2,
+				CreatedAt: timestamppb.Now(),
+			},
+			"KWH": {
+				Code:      "KWH",
+				Dimension: referencedatav1.Dimension_DIMENSION_ENERGY,
+				Precision: 6,
+				CreatedAt: timestamppb.Now(),
+			},
+		},
+	}
+	ds := NewGRPCDataSource(client)
+	ctx := context.Background()
+
+	instruments, err := ds.FetchAllActive(ctx)
+	require.NoError(t, err)
+	assert.Len(t, instruments, 2)
+
+	// Verify all instruments are present (order not guaranteed with map iteration)
+	codes := make(map[string]bool)
+	for _, inst := range instruments {
+		codes[inst.Code] = true
+	}
+	assert.True(t, codes["USD"])
+	assert.True(t, codes["KWH"])
+}


### PR DESCRIPTION
## Summary

Migrates the position-keeping service to resolve instrument properties (dimension, precision) from Reference Data instead of using hardcoded fallbacks. This is part of the multi-asset-purity initiative (multi-asset-purity.7).

- Removes `CHAR(3)` length guard from `NewMoneyFromInstrumentCode()` - instrument codes like `CARBON_CREDIT` and `GPU_HOUR` are now accepted (columns already widened to `VARCHAR(32)` in #1471)
- Removes `strings.TrimSpace()` workarounds from `postgres_repository.go` - no longer needed after column widening
- Replaces `inferInstrumentProperties()` hardcoded switch statement in `balance_mapper.go` with `InstrumentResolver.Resolve()` calls
- Adds `WithInstrumentResolver()` option to `PositionKeepingService` for optional dependency injection
- Wires `InstrumentResolver` through `main.go` with `CachedResolver` backed by a new `GRPCDataSource` adapter
- Adds `ReferenceDataConfig` for `REFERENCE_DATA_SERVICE_URL` environment variable

## Changes Made

| Subtask | File | Change |
|---------|------|--------|
| 7.1 | `domain/quantity.go` | Remove CHAR(3) length check, update tests for long codes |
| 7.2 | `adapters/persistence/postgres_repository.go` | Remove 4x `strings.TrimSpace()` workarounds |
| 7.3 | `adapters/balance_mapper.go` | Replace `inferInstrumentProperties()` with `InstrumentResolver` |
| 7.4 | `service/service.go`, `cmd/main.go`, `app/config.go` | Wire `InstrumentResolver`, add config |
| New | `shared/pkg/refdata/grpc_datasource.go` | gRPC DataSource adapter for Reference Data service |

## Test Plan

- [x] `domain/money_test.go` - Updated: long instrument codes (CARBON_CREDIT, GPU_HOUR, TONNE_CO2E) now accepted
- [x] `adapters/balance_mapper_test.go` - Updated: uses stub resolver, adds unknown instrument error test
- [x] `shared/pkg/refdata/grpc_datasource_test.go` - New: tests GRPCDataSource FetchInstrument/FetchAllActive
- [x] All 12 packages pass with `-short` flag
- [x] Pre-commit hooks pass (gitleaks, gofumpt, golangci-lint)