### PR TITLE
feat: Migrate financial-accounting to InstrumentResolver for instrument validation

### DIFF
--- a/services/financial-accounting/service/financial_accounting_service.go
+++ b/services/financial-accounting/service/financial_accounting_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
 	"github.com/meridianhub/meridian/services/financial-accounting/domain"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
+	"github.com/meridianhub/meridian/shared/pkg/refdata"
 	"github.com/meridianhub/meridian/shared/platform/events"
 )
 
@@ -185,6 +186,11 @@ type FinancialAccountingService struct {
 	// May be nil if fungibility validation is disabled (e.g., in tests or legacy mode).
 	// When nil, fungibility validation is skipped (all instruments treated as fully fungible).
 	registry InstrumentRegistry
+
+	// instrumentResolver resolves instrument properties from Reference Data.
+	// Used for validating instrument codes (replacing legacy isValidCurrencyCode).
+	// May be nil if Reference Data is unavailable; validation is skipped when nil.
+	instrumentResolver refdata.InstrumentResolver
 }
 
 // Option configures a FinancialAccountingService.
@@ -196,6 +202,16 @@ type Option func(*FinancialAccountingService)
 func WithRegistry(registry InstrumentRegistry) Option {
 	return func(s *FinancialAccountingService) {
 		s.registry = registry
+	}
+}
+
+// WithInstrumentResolver enables instrument code validation via Reference Data lookup.
+// When configured, instrument codes are validated by resolving them through the resolver
+// instead of the legacy isValidCurrencyCode() check (which only accepted 3-char ISO 4217 codes).
+// When nil or not used, instrument code validation in list filters is skipped.
+func WithInstrumentResolver(resolver refdata.InstrumentResolver) Option {
+	return func(s *FinancialAccountingService) {
+		s.instrumentResolver = resolver
 	}
 }
 

--- a/services/financial-accounting/service/grpc_booking_endpoints.go
+++ b/services/financial-accounting/service/grpc_booking_endpoints.go
@@ -14,6 +14,7 @@ import (
 	"github.com/meridianhub/meridian/services/financial-accounting/domain"
 	"github.com/meridianhub/meridian/services/financial-accounting/observability"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
+	"github.com/meridianhub/meridian/shared/pkg/refdata"
 	"github.com/shopspring/decimal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -92,6 +93,14 @@ func (s *FinancialAccountingService) InitiateFinancialBookingLog(
 	// Validate base instrument code
 	if req.BaseInstrumentCode == "" {
 		return nil, status.Error(codes.InvalidArgument, "base_instrument_code must be specified")
+	}
+	if s.instrumentResolver != nil {
+		if _, err := s.instrumentResolver.Resolve(ctx, req.BaseInstrumentCode); err != nil {
+			if errors.Is(err, refdata.ErrUnknownInstrument) {
+				return nil, status.Errorf(codes.InvalidArgument, "unknown base_instrument_code: %s", req.BaseInstrumentCode)
+			}
+			return nil, status.Errorf(codes.Unavailable, "instrument lookup failed for %s, please retry", req.BaseInstrumentCode)
+		}
 	}
 	baseCurrency := domain.Currency(req.BaseInstrumentCode)
 

--- a/services/financial-accounting/service/grpc_ledger_endpoints.go
+++ b/services/financial-accounting/service/grpc_ledger_endpoints.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -9,6 +10,7 @@ import (
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
 	"github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
+	"github.com/meridianhub/meridian/shared/pkg/refdata"
 )
 
 // ListFinancialBookingLogs lists booking logs with optional filtering and pagination.
@@ -184,11 +186,15 @@ func (s *FinancialAccountingService) ListLedgerPostings(
 		}
 	}
 
-	// Apply currency filter if provided
+	// Apply instrument code filter if provided (field is named "currency" for backwards compatibility)
 	if req.Currency != "" {
-		// Validate currency code format (must be 3 uppercase letters per ISO 4217)
-		if !isValidCurrencyCode(req.Currency) {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid currency code: %s (must be 3 uppercase letters)", req.Currency)
+		if s.instrumentResolver != nil {
+			if _, err := s.instrumentResolver.Resolve(ctx, req.Currency); err != nil {
+				if errors.Is(err, refdata.ErrUnknownInstrument) {
+					return nil, status.Errorf(codes.InvalidArgument, "unknown instrument code: %s", req.Currency)
+				}
+				return nil, status.Errorf(codes.Unavailable, "instrument lookup failed for %s, please retry", req.Currency)
+			}
 		}
 		params.Currency = req.Currency
 	}

--- a/services/financial-accounting/service/grpc_posting_endpoints.go
+++ b/services/financial-accounting/service/grpc_posting_endpoints.go
@@ -540,17 +540,3 @@ func (s *FinancialAccountingService) executeUpdateLedgerPosting(
 		LedgerPosting: toProtoLedgerPosting(posting),
 	}, nil
 }
-
-// isValidCurrencyCode validates that a currency code matches ISO 4217 format.
-// Valid codes are exactly 3 uppercase letters (e.g., USD, GBP, EUR).
-func isValidCurrencyCode(code string) bool {
-	if len(code) != 3 {
-		return false
-	}
-	for _, r := range code {
-		if r < 'A' || r > 'Z' {
-			return false
-		}
-	}
-	return true
-}

--- a/services/financial-accounting/service/list_ledger_postings_test.go
+++ b/services/financial-accounting/service/list_ledger_postings_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -8,8 +10,10 @@ import (
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
 	"github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
+	"github.com/meridianhub/meridian/shared/pkg/refdata"
 	"github.com/meridianhub/meridian/shared/platform/events"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -438,4 +442,339 @@ func TestListLedgerPostings_MultipleFilters(t *testing.T) {
 		assert.Equal(t, "USD", posting.PostingAmount.CurrencyCode)
 		assert.Equal(t, commonv1.TransactionStatus_TRANSACTION_STATUS_PENDING, posting.Status)
 	}
+}
+
+// mockInstrumentResolver is a test double for refdata.InstrumentResolver.
+type mockInstrumentResolver struct {
+	instruments map[string]refdata.InstrumentProperties
+	err         error // if set, all calls return this error
+}
+
+func (m *mockInstrumentResolver) Resolve(_ context.Context, code string) (refdata.InstrumentProperties, error) {
+	if m.err != nil {
+		return refdata.InstrumentProperties{}, m.err
+	}
+	props, ok := m.instruments[code]
+	if !ok {
+		return refdata.InstrumentProperties{}, refdata.ErrUnknownInstrument
+	}
+	return props, nil
+}
+
+// TestListLedgerPostings_InstrumentResolverValidation tests instrument code validation
+// via InstrumentResolver, replacing the legacy isValidCurrencyCode check.
+func TestListLedgerPostings_InstrumentResolverValidation(t *testing.T) {
+	resolver := &mockInstrumentResolver{
+		instruments: map[string]refdata.InstrumentProperties{
+			"GBP":           {Code: "GBP", Dimension: "MONETARY", Precision: 2, RoundingMode: "HALF_EVEN"},
+			"USD":           {Code: "USD", Dimension: "MONETARY", Precision: 2, RoundingMode: "HALF_EVEN"},
+			"KWH":           {Code: "KWH", Dimension: "ENERGY", Precision: 3, RoundingMode: "HALF_EVEN"},
+			"GPU_HOUR":      {Code: "GPU_HOUR", Dimension: "COMPUTE", Precision: 6, RoundingMode: "HALF_EVEN"},
+			"CARBON_CREDIT": {Code: "CARBON_CREDIT", Dimension: "ENVIRONMENTAL", Precision: 2, RoundingMode: "HALF_EVEN"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		currency string
+		wantCode codes.Code
+		wantErr  bool
+	}{
+		{
+			name:     "valid currency instrument (GBP)",
+			currency: "GBP",
+			wantCode: codes.OK,
+			wantErr:  false,
+		},
+		{
+			name:     "valid non-currency instrument (KWH)",
+			currency: "KWH",
+			wantCode: codes.OK,
+			wantErr:  false,
+		},
+		{
+			name:     "valid multi-word instrument code (GPU_HOUR)",
+			currency: "GPU_HOUR",
+			wantCode: codes.OK,
+			wantErr:  false,
+		},
+		{
+			name:     "valid multi-word instrument code (CARBON_CREDIT)",
+			currency: "CARBON_CREDIT",
+			wantCode: codes.OK,
+			wantErr:  false,
+		},
+		{
+			name:     "unknown instrument code rejected",
+			currency: "INVALID_INSTRUMENT",
+			wantCode: codes.InvalidArgument,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, ctx, cleanup := setupTestDB(t)
+			defer cleanup()
+
+			// Seed a posting with the instrument code to verify filter works end-to-end
+			if !tt.wantErr {
+				bookingLogID := uuid.New()
+				bookingLog := persistence.FinancialBookingLogEntity{
+					ID:                      bookingLogID,
+					FinancialAccountType:    "ASSET",
+					ProductServiceReference: "PROD-INST",
+					BusinessUnitReference:   "BU-INST",
+					ChartOfAccountsRules:    "Standard",
+					BaseCurrency:            tt.currency,
+					Status:                  "PENDING",
+					IdempotencyKey:          uuid.New().String(),
+					CreatedAt:               time.Now().UTC(),
+					UpdatedAt:               time.Now().UTC(),
+					Version:                 1,
+				}
+				db.Create(&bookingLog)
+
+				posting := persistence.LedgerPostingEntity{
+					ID:                    uuid.New(),
+					FinancialBookingLogID: bookingLogID,
+					PostingDirection:      "DEBIT",
+					AmountMinorUnits:      100000,
+					Currency:              tt.currency,
+					AccountID:             "ACC-INST",
+					ValueDate:             time.Now().UTC(),
+					Status:                "PENDING",
+					CorrelationID:         uuid.New().String(),
+					CreatedAt:             time.Now().UTC(),
+				}
+				db.Create(&posting)
+			}
+
+			repo := persistence.NewLedgerRepository(db)
+			publisher := &mockEventPublisher{}
+			idempotencySvc := &mockIdempotencyService{}
+			outboxPublisher := events.NewOutboxPublisher("financial-accounting")
+			outboxRepo := events.NewPostgresOutboxRepository(db)
+
+			svc, err := NewFinancialAccountingService(
+				repo, publisher, idempotencySvc, outboxPublisher, outboxRepo,
+				WithInstrumentResolver(resolver),
+			)
+			if err != nil {
+				t.Fatalf("failed to create service: %v", err)
+			}
+
+			resp, err := svc.ListLedgerPostings(ctx, &financialaccountingv1.ListLedgerPostingsRequest{
+				Pagination: &commonv1.Pagination{PageSize: 50},
+				Currency:   tt.currency,
+			})
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				st, ok := status.FromError(err)
+				assert.True(t, ok)
+				assert.Equal(t, tt.wantCode, st.Code())
+				assert.Nil(t, resp)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+				assert.Equal(t, 1, len(resp.LedgerPostings))
+			}
+		})
+	}
+}
+
+// TestListLedgerPostings_ResolverUnavailable verifies fail-closed behavior when the
+// instrument resolver is unavailable (returns a transient error).
+func TestListLedgerPostings_ResolverUnavailable(t *testing.T) {
+	resolver := &mockInstrumentResolver{
+		err: errors.New("connection refused"),
+	}
+
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewLedgerRepository(db)
+	publisher := &mockEventPublisher{}
+	idempotencySvc := &mockIdempotencyService{}
+	outboxPublisher := events.NewOutboxPublisher("financial-accounting")
+	outboxRepo := events.NewPostgresOutboxRepository(db)
+
+	svc, err := NewFinancialAccountingService(
+		repo, publisher, idempotencySvc, outboxPublisher, outboxRepo,
+		WithInstrumentResolver(resolver),
+	)
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+
+	resp, err := svc.ListLedgerPostings(ctx, &financialaccountingv1.ListLedgerPostingsRequest{
+		Pagination: &commonv1.Pagination{PageSize: 50},
+		Currency:   "GBP",
+	})
+
+	assert.Error(t, err)
+	st, ok := status.FromError(err)
+	assert.True(t, ok)
+	assert.Equal(t, codes.Unavailable, st.Code())
+	assert.Nil(t, resp)
+}
+
+// TestListLedgerPostings_NoResolverSkipsValidation verifies backwards compatibility:
+// when no InstrumentResolver is configured, currency filter is passed through without validation.
+func TestListLedgerPostings_NoResolverSkipsValidation(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewLedgerRepository(db)
+	publisher := &mockEventPublisher{}
+	idempotencySvc := &mockIdempotencyService{}
+	outboxPublisher := events.NewOutboxPublisher("financial-accounting")
+	outboxRepo := events.NewPostgresOutboxRepository(db)
+
+	// No WithInstrumentResolver - nil resolver
+	svc, err := NewFinancialAccountingService(
+		repo, publisher, idempotencySvc, outboxPublisher, outboxRepo,
+	)
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+
+	// Previously "GPU_HOUR" would have been rejected by isValidCurrencyCode.
+	// With nil resolver, it passes through to the database filter.
+	resp, err := svc.ListLedgerPostings(ctx, &financialaccountingv1.ListLedgerPostingsRequest{
+		Pagination: &commonv1.Pagination{PageSize: 50},
+		Currency:   "GPU_HOUR",
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 0, len(resp.LedgerPostings))
+}
+
+// TestInitiateFinancialBookingLog_InstrumentResolverValidation tests that
+// InitiateFinancialBookingLog validates BaseInstrumentCode via InstrumentResolver.
+func TestInitiateFinancialBookingLog_InstrumentResolverValidation(t *testing.T) {
+	resolver := &mockInstrumentResolver{
+		instruments: map[string]refdata.InstrumentProperties{
+			"GBP":      {Code: "GBP", Dimension: "MONETARY", Precision: 2, RoundingMode: "HALF_EVEN"},
+			"KWH":      {Code: "KWH", Dimension: "ENERGY", Precision: 3, RoundingMode: "HALF_EVEN"},
+			"GPU_HOUR": {Code: "GPU_HOUR", Dimension: "COMPUTE", Precision: 6, RoundingMode: "HALF_EVEN"},
+		},
+	}
+
+	tests := []struct {
+		name               string
+		baseInstrumentCode string
+		wantCode           codes.Code
+		wantErr            bool
+	}{
+		{
+			name:               "valid currency (GBP)",
+			baseInstrumentCode: "GBP",
+			wantCode:           codes.OK,
+			wantErr:            false,
+		},
+		{
+			name:               "valid non-currency (KWH)",
+			baseInstrumentCode: "KWH",
+			wantCode:           codes.OK,
+			wantErr:            false,
+		},
+		{
+			name:               "valid multi-word (GPU_HOUR)",
+			baseInstrumentCode: "GPU_HOUR",
+			wantCode:           codes.OK,
+			wantErr:            false,
+		},
+		{
+			name:               "unknown instrument rejected",
+			baseInstrumentCode: "INVALID",
+			wantCode:           codes.InvalidArgument,
+			wantErr:            true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, ctx, cleanup := setupTestDB(t)
+			defer cleanup()
+
+			repo := persistence.NewLedgerRepository(db)
+			publisher := &mockEventPublisher{}
+			idempotencySvc := &mockIdempotencyService{}
+			outboxPublisher := events.NewOutboxPublisher("financial-accounting")
+			outboxRepo := events.NewPostgresOutboxRepository(db)
+
+			svc, err := NewFinancialAccountingService(
+				repo, publisher, idempotencySvc, outboxPublisher, outboxRepo,
+				WithInstrumentResolver(resolver),
+			)
+			if err != nil {
+				t.Fatalf("failed to create service: %v", err)
+			}
+
+			req := &financialaccountingv1.InitiateFinancialBookingLogRequest{
+				FinancialAccountType:    "ASSET",
+				ProductServiceReference: "PROD-RESOLVER-TEST",
+				BusinessUnitReference:   "BU-RESOLVER-TEST",
+				ChartOfAccountsRules:    "Standard",
+				BaseInstrumentCode:      tt.baseInstrumentCode,
+				IdempotencyKey:          &commonv1.IdempotencyKey{Key: uuid.New().String()},
+			}
+
+			resp, err := svc.InitiateFinancialBookingLog(ctx, req)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				st, ok := status.FromError(err)
+				assert.True(t, ok)
+				assert.Equal(t, tt.wantCode, st.Code())
+				assert.Nil(t, resp)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				assert.Equal(t, tt.baseInstrumentCode, resp.FinancialBookingLog.BaseInstrumentCode)
+			}
+		})
+	}
+}
+
+// TestInitiateFinancialBookingLog_ResolverUnavailable tests fail-closed on resolver error.
+func TestInitiateFinancialBookingLog_ResolverUnavailable(t *testing.T) {
+	resolver := &mockInstrumentResolver{
+		err: errors.New("connection refused"),
+	}
+
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewLedgerRepository(db)
+	publisher := &mockEventPublisher{}
+	idempotencySvc := &mockIdempotencyService{}
+	outboxPublisher := events.NewOutboxPublisher("financial-accounting")
+	outboxRepo := events.NewPostgresOutboxRepository(db)
+
+	svc, err := NewFinancialAccountingService(
+		repo, publisher, idempotencySvc, outboxPublisher, outboxRepo,
+		WithInstrumentResolver(resolver),
+	)
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+
+	resp, err := svc.InitiateFinancialBookingLog(ctx, &financialaccountingv1.InitiateFinancialBookingLogRequest{
+		FinancialAccountType:    "ASSET",
+		ProductServiceReference: "PROD-UNAVAILABLE",
+		BusinessUnitReference:   "BU-UNAVAILABLE",
+		ChartOfAccountsRules:    "Standard",
+		BaseInstrumentCode:      "GBP",
+		IdempotencyKey:          &commonv1.IdempotencyKey{Key: uuid.New().String()},
+	})
+
+	assert.Error(t, err)
+	st, ok := status.FromError(err)
+	assert.True(t, ok)
+	assert.Equal(t, codes.Unavailable, st.Code())
+	assert.Nil(t, resp)
 }

--- a/services/financial-accounting/service/posting_service_test.go
+++ b/services/financial-accounting/service/posting_service_test.go
@@ -46,7 +46,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		product_service_reference VARCHAR(255) NOT NULL,
 		business_unit_reference VARCHAR(255) NOT NULL,
 		chart_of_accounts_rules TEXT NOT NULL,
-		base_currency VARCHAR(3) NOT NULL,
+		base_currency VARCHAR(32) NOT NULL,
 		status VARCHAR(20) NOT NULL,
 		idempotency_key VARCHAR(255) NOT NULL UNIQUE,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,


### PR DESCRIPTION
## Summary

- Remove `isValidCurrencyCode()` from financial-accounting service which hardcoded 3-char uppercase validation, rejecting valid multi-asset instruments like `GPU_HOUR`, `CARBON_CREDIT`, `KWH`
- Replace with `InstrumentResolver` from `shared/pkg/refdata` which validates instrument codes against Reference Data
- Add instrument validation to `InitiateFinancialBookingLog` for `BaseInstrumentCode`

## Task Master

Tag: `multi-asset-purity`, Task: 9 — Migrate financial-accounting Service to Reference Data Resolution

## Changes Made

**9.1: Remove isValidCurrencyCode() and integrate InstrumentResolver in grpc_posting_endpoints.go**
- Removed `isValidCurrencyCode()` function (was lines 544-556)
- Added `instrumentResolver refdata.InstrumentResolver` field to `FinancialAccountingService`
- Added `WithInstrumentResolver()` option for dependency injection

**9.2: Update grpc_ledger_endpoints.go to use InstrumentResolver**
- Replaced `isValidCurrencyCode()` usage in `ListLedgerPostings` currency filter with `InstrumentResolver.Resolve()` lookup
- Unknown instruments return `codes.InvalidArgument`
- Transient resolver errors return `codes.Unavailable` (fail-closed)
- When resolver is nil (not configured), validation is skipped for backwards compatibility

**9.3: Update grpc_booking_endpoints.go and add integration tests**
- Added `InstrumentResolver.Resolve()` validation for `BaseInstrumentCode` in `InitiateFinancialBookingLog`
- Widened test schema `base_currency` from `VARCHAR(3)` to `VARCHAR(32)` to match production migration
- Added integration tests covering:
  - Currency instruments (GBP, USD)
  - Non-currency instruments (KWH, GPU_HOUR, CARBON_CREDIT)
  - Unknown instrument rejection
  - Fail-closed behavior when resolver is unavailable
  - Backwards compatibility when resolver is nil

## Test Plan

- [x] Existing `TestListLedgerPostings_DefensiveTests` pass (backwards compatibility)
- [x] Existing `TestListLedgerPostings_MultipleFilters` pass (currency filter still works)
- [x] New `TestListLedgerPostings_InstrumentResolverValidation` — validates currency and non-currency instruments
- [x] New `TestListLedgerPostings_ResolverUnavailable` — fail-closed on transient errors
- [x] New `TestListLedgerPostings_NoResolverSkipsValidation` — nil resolver backwards compatibility
- [x] New `TestInitiateFinancialBookingLog_InstrumentResolverValidation` — validates base instrument codes
- [x] New `TestInitiateFinancialBookingLog_ResolverUnavailable` — fail-closed on booking log creation
- [x] All pre-commit checks pass (gitleaks, gofumpt, golangci-lint)