### PR TITLE
feat: add saga writes_to and uses_valuation edges from output analysis

### DIFF
--- a/frontend/src/features/manifests/lib/manifest-graph-model.test.ts
+++ b/frontend/src/features/manifests/lib/manifest-graph-model.test.ts
@@ -213,6 +213,251 @@ describe('buildManifestGraph', () => {
     })
   })
 
+  describe('writes_to edges', () => {
+    it('creates edges from saga to account types for static instrument_code', () => {
+      const manifest = createMockManifest({
+        instruments: [
+          { code: 'KWH', name: 'Kilowatt Hour', type: 2, dimensions: { unit: 'kWh', precision: 4 } },
+        ],
+        accountTypes: [
+          { code: 'ENERGY_HOLDING', name: 'Energy Holding', normalBalance: 1, allowedInstruments: ['KWH'] },
+          { code: 'REVENUE', name: 'Revenue', normalBalance: 2, allowedInstruments: ['KWH'] },
+        ],
+        sagas: [{
+          name: 'log_energy',
+          trigger: 'event:meter.reading.v1',
+          script: [
+            'saga(name="log_energy")',
+            'step(name="record")',
+            'position_keeping.initiate_log(instrument_code="KWH", direction="CREDIT", amount=qty)',
+          ].join('\n'),
+        }],
+      })
+      const graph = buildManifestGraph(manifest)
+      const writesTo = graph.edges.filter((e) => e.relationship === 'writes_to')
+
+      expect(writesTo).toHaveLength(2)
+      expect(writesTo).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            source: 'saga:log_energy',
+            target: 'account_type:ENERGY_HOLDING',
+            relationship: 'writes_to',
+          }),
+          expect.objectContaining({
+            source: 'saga:log_energy',
+            target: 'account_type:REVENUE',
+            relationship: 'writes_to',
+          }),
+        ]),
+      )
+    })
+
+    it('creates no writes_to edges for fully dynamic sagas', () => {
+      const manifest = createMockManifest({
+        instruments: [
+          { code: 'KWH', name: 'Kilowatt Hour', type: 2, dimensions: { unit: 'kWh', precision: 4 } },
+        ],
+        accountTypes: [
+          { code: 'ENERGY_HOLDING', name: 'Energy Holding', normalBalance: 1, allowedInstruments: ['KWH'] },
+        ],
+        sagas: [{
+          name: 'dynamic_saga',
+          trigger: 'event:some.event.v1',
+          script: [
+            'saga(name="dynamic_saga")',
+            'step(name="record")',
+            'position_keeping.initiate_log(instrument_code=instr_var, direction="CREDIT", amount=qty)',
+          ].join('\n'),
+        }],
+      })
+      const graph = buildManifestGraph(manifest)
+      const writesTo = graph.edges.filter((e) => e.relationship === 'writes_to')
+
+      expect(writesTo).toHaveLength(0)
+    })
+
+    it('creates unique edge IDs for multiple writes to same account type', () => {
+      const manifest = createMockManifest({
+        instruments: [
+          { code: 'GBP', name: 'British Pound', type: 1, dimensions: { unit: 'GBP', precision: 2 } },
+        ],
+        accountTypes: [
+          { code: 'REVENUE', name: 'Revenue', normalBalance: 2, allowedInstruments: ['GBP'] },
+        ],
+        sagas: [{
+          name: 'double_write',
+          trigger: 'event:payment.v1',
+          script: [
+            'saga(name="double_write")',
+            'step(name="debit")',
+            'position_keeping.initiate_log(instrument_code="GBP", direction="DEBIT", amount=amt)',
+            'step(name="credit")',
+            'position_keeping.initiate_log(instrument_code="GBP", direction="CREDIT", amount=amt)',
+          ].join('\n'),
+        }],
+      })
+      const graph = buildManifestGraph(manifest)
+      const writesTo = graph.edges.filter((e) => e.relationship === 'writes_to')
+
+      expect(writesTo).toHaveLength(2)
+      const ids = writesTo.map((e) => e.id)
+      expect(new Set(ids).size).toBe(2)
+    })
+  })
+
+  describe('uses_valuation edges', () => {
+    it('creates edges from saga to matching valuation rules', () => {
+      const manifest = createMockManifest({
+        instruments: [
+          { code: 'KWH', name: 'Kilowatt Hour', type: 2, dimensions: { unit: 'kWh', precision: 4 } },
+          { code: 'GBP', name: 'British Pound', type: 1, dimensions: { unit: 'GBP', precision: 2 } },
+        ],
+        valuationRules: [
+          { fromInstrument: 'KWH', toInstrument: 'GBP', method: 1, source: 'nordpool_spot' },
+        ],
+        sagas: [{
+          name: 'convert_energy',
+          trigger: 'event:meter.reading.v1',
+          script: [
+            'saga(name="convert_energy")',
+            'step(name="valuate")',
+            'valuation_engine.compute(from_instrument="KWH", to_instrument="GBP", amount=qty)',
+          ].join('\n'),
+        }],
+      })
+      const graph = buildManifestGraph(manifest)
+      const usesVal = graph.edges.filter((e) => e.relationship === 'uses_valuation')
+
+      expect(usesVal).toHaveLength(1)
+      expect(usesVal[0]).toMatchObject({
+        source: 'saga:convert_energy',
+        target: 'valuation_rule:KWH:GBP:0',
+        relationship: 'uses_valuation',
+      })
+    })
+
+    it('creates no uses_valuation edges when instruments are dynamic', () => {
+      const manifest = createMockManifest({
+        valuationRules: [
+          { fromInstrument: 'KWH', toInstrument: 'GBP', method: 1, source: 'test' },
+        ],
+        sagas: [{
+          name: 'dynamic_val',
+          trigger: 'event:some.v1',
+          script: [
+            'saga(name="dynamic_val")',
+            'step(name="valuate")',
+            'valuation_engine.compute(from_instrument=from_var, to_instrument=to_var, amount=qty)',
+          ].join('\n'),
+        }],
+      })
+      const graph = buildManifestGraph(manifest)
+      const usesVal = graph.edges.filter((e) => e.relationship === 'uses_valuation')
+
+      expect(usesVal).toHaveLength(0)
+    })
+  })
+
+  describe('dynamic targets', () => {
+    it('records dynamic targets when instrument_code is a variable', () => {
+      const manifest = createMockManifest({
+        sagas: [{
+          name: 'dynamic_saga',
+          trigger: 'event:some.v1',
+          script: [
+            'saga(name="dynamic_saga")',
+            'step(name="record")',
+            'position_keeping.initiate_log(instrument_code=instr_var, direction="CREDIT", amount=qty)',
+          ].join('\n'),
+        }],
+      })
+      const graph = buildManifestGraph(manifest)
+      const sagaNode = graph.nodes.find((n) => n.id === 'saga:dynamic_saga')
+
+      expect(sagaNode?.dynamicTargets).toBeDefined()
+      expect(sagaNode!.dynamicTargets!.length).toBeGreaterThan(0)
+      expect(sagaNode!.dynamicTargets![0]).toMatchObject({
+        variableName: 'instr_var',
+      })
+    })
+
+    it('does not set dynamicTargets for static sagas', () => {
+      const manifest = createMockManifest({
+        sagas: [{
+          name: 'static_saga',
+          trigger: 'event:some.v1',
+          script: [
+            'saga(name="static_saga")',
+            'step(name="record")',
+            'position_keeping.initiate_log(instrument_code="GBP", direction="CREDIT", amount=qty)',
+          ].join('\n'),
+        }],
+      })
+      const graph = buildManifestGraph(manifest)
+      const sagaNode = graph.nodes.find((n) => n.id === 'saga:static_saga')
+
+      expect(sagaNode?.dynamicTargets).toBeUndefined()
+    })
+  })
+
+  describe('integration: energy-settlement manifest', () => {
+    it('produces expected graph with writes_to and uses_valuation edges', () => {
+      const manifest = createMockManifest({
+        instruments: [
+          { code: 'KWH', name: 'Kilowatt Hour', type: 2, dimensions: { unit: 'kWh', precision: 4 } },
+          { code: 'GBP', name: 'British Pound', type: 1, dimensions: { unit: 'GBP', precision: 2 } },
+        ],
+        accountTypes: [
+          { code: 'ENERGY_HOLDING', name: 'Energy Holding', normalBalance: 1, allowedInstruments: ['KWH'] },
+          { code: 'REVENUE', name: 'Revenue', normalBalance: 2, allowedInstruments: ['GBP', 'KWH'] },
+        ],
+        valuationRules: [
+          { fromInstrument: 'KWH', toInstrument: 'GBP', method: 1, source: 'nordpool_spot' },
+        ],
+        sagas: [{
+          name: 'energy_settlement',
+          trigger: 'event:meter.reading.v1',
+          filter: 'event.type == "HH"',
+          script: [
+            'saga(name="energy_settlement")',
+            'step(name="record_usage")',
+            'position_keeping.initiate_log(instrument_code="KWH", direction="DEBIT", amount=usage)',
+            'step(name="valuate")',
+            'valuation_engine.compute(from_instrument="KWH", to_instrument="GBP", amount=usage)',
+            'step(name="record_revenue")',
+            'position_keeping.initiate_log(instrument_code="GBP", direction="CREDIT", amount=value)',
+          ].join('\n'),
+        }],
+      })
+      const graph = buildManifestGraph(manifest)
+
+      // Saga writes_to edges
+      const writesTo = graph.edges.filter((e) => e.relationship === 'writes_to')
+      // KWH -> ENERGY_HOLDING and REVENUE (step record_usage)
+      // GBP -> REVENUE (step record_revenue)
+      expect(writesTo).toHaveLength(3)
+      expect(writesTo).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ target: 'account_type:ENERGY_HOLDING' }),
+          expect.objectContaining({ target: 'account_type:REVENUE' }),
+        ]),
+      )
+
+      // uses_valuation edge
+      const usesVal = graph.edges.filter((e) => e.relationship === 'uses_valuation')
+      expect(usesVal).toHaveLength(1)
+      expect(usesVal[0]).toMatchObject({
+        source: 'saga:energy_settlement',
+        target: 'valuation_rule:KWH:GBP:0',
+      })
+
+      // No dynamic targets (all static)
+      const sagaNode = graph.nodes.find((n) => n.id === 'saga:energy_settlement')
+      expect(sagaNode?.dynamicTargets).toBeUndefined()
+    })
+  })
+
   describe('edge cases', () => {
     it('returns empty graph for empty manifest', () => {
       const manifest = createMockManifest()

--- a/frontend/src/features/manifests/lib/manifest-graph-model.ts
+++ b/frontend/src/features/manifests/lib/manifest-graph-model.ts
@@ -1,4 +1,5 @@
 import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
+import { analyzeSagaOutputs } from '@/lib/visualization/star-parser'
 
 interface ManifestInstrument {
   code: string
@@ -24,6 +25,7 @@ interface ManifestSaga {
   name: string
   trigger: string
   filter?: string
+  script?: string
   [key: string]: unknown
 }
 
@@ -47,13 +49,15 @@ export interface ManifestNode {
   label: string
   data: Record<string, unknown>
   triggerMetadata?: SagaTriggerMetadata
-  dynamicTargets?: string[]
+  dynamicTargets?: { variableName: string; codeSnippet: string }[]
 }
 
 export type ManifestRelationship =
   | 'allowed_by'
   | 'converts_from'
   | 'converts_to'
+  | 'writes_to'
+  | 'uses_valuation'
 
 export interface ManifestEdge {
   id: string
@@ -154,17 +158,77 @@ export function buildManifestGraph(manifest: Manifest): ManifestGraph {
     }
   }
 
-  for (const saga of sagas) {
-    const { name, trigger, filter } = saga
-    const triggerMetadata = parseSagaTrigger(trigger, filter)
+  // Build lookup: instrument code -> account type codes that allow it
+  const instrumentToAccountTypes = new Map<string, string[]>()
+  for (const at of accountTypes) {
+    if (at.allowedInstruments) {
+      for (const ic of at.allowedInstruments) {
+        const list = instrumentToAccountTypes.get(ic) ?? []
+        list.push(at.code)
+        instrumentToAccountTypes.set(ic, list)
+      }
+    }
+  }
 
-    nodes.push({
-      id: `saga:${name}`,
+  for (const saga of sagas) {
+    const { name, trigger, filter, script } = saga
+    const triggerMetadata = parseSagaTrigger(trigger, filter)
+    const sagaNodeId = `saga:${name}`
+
+    const sagaNode: ManifestNode = {
+      id: sagaNodeId,
       type: 'saga',
       label: name,
       data: { ...saga },
       triggerMetadata,
-    })
+    }
+
+    if (script) {
+      const outputs = analyzeSagaOutputs(script)
+
+      // writes_to edges: saga -> account types that allow the produced instrument
+      for (const event of outputs.producedEvents) {
+        if (event.instrumentCode) {
+          const targetAccountTypes = instrumentToAccountTypes.get(event.instrumentCode) ?? []
+          for (const accountTypeCode of targetAccountTypes) {
+            edges.push({
+              id: `writes_to:${sagaNodeId}:${accountTypeCode}:${event.stepName}`,
+              source: sagaNodeId,
+              target: `account_type:${accountTypeCode}`,
+              relationship: 'writes_to',
+            })
+          }
+        }
+      }
+
+      // uses_valuation edges: saga -> matching valuation rules
+      for (const vc of outputs.valuationCalls) {
+        if (vc.fromInstrument && vc.toInstrument) {
+          for (let i = 0; i < valuationRules.length; i++) {
+            const rule = valuationRules[i]
+            if (rule.fromInstrument === vc.fromInstrument && rule.toInstrument === vc.toInstrument) {
+              const ruleId = `valuation_rule:${rule.fromInstrument}:${rule.toInstrument}:${i}`
+              edges.push({
+                id: `uses_valuation:${sagaNodeId}:${ruleId}`,
+                source: sagaNodeId,
+                target: ruleId,
+                relationship: 'uses_valuation',
+              })
+            }
+          }
+        }
+      }
+
+      // Record dynamic targets
+      if (outputs.dynamicTargets.length > 0) {
+        sagaNode.dynamicTargets = outputs.dynamicTargets.map((dt) => ({
+          variableName: dt.variableName,
+          codeSnippet: dt.codeSnippet,
+        }))
+      }
+    }
+
+    nodes.push(sagaNode)
   }
 
   return { nodes, edges }


### PR DESCRIPTION
## Summary

- Integrates `analyzeSagaOutputs` into `buildManifestGraph()` to derive saga relationship edges
- Adds `writes_to` edges from saga nodes to account types that allow the produced instrument codes
- Adds `uses_valuation` edges from saga nodes to matching valuation rules for `valuation_engine.compute` calls
- Records `dynamicTargets` on saga nodes when instrument codes are variable references

## Changes Made

- `manifest-graph-model.ts`: Import `analyzeSagaOutputs`, build instrument-to-account-type lookup, analyze saga scripts, create `writes_to` and `uses_valuation` edges, record dynamic targets
- `manifest-graph-model.test.ts`: 10 new tests covering writes_to edges, uses_valuation edges, dynamic targets, and integration with energy-settlement manifest

## Test Plan

- [x] Static instrument_code produces writes_to edges to matching account types
- [x] Dynamic instrument_code produces no writes_to edges but records dynamicTargets
- [x] Multiple writes to same account type produce unique edge IDs
- [x] Static valuation calls produce uses_valuation edges to matching rules
- [x] Dynamic valuation calls produce no uses_valuation edges
- [x] Integration test: energy-settlement manifest produces expected graph
- [x] All 24 tests pass (10 new + 14 existing)

Task: 038-manifest-business-model-visualization.11