### PR TITLE
feat: add Graph tab to Manifests page

### DIFF
--- a/frontend/src/features/manifests/pages/index.tsx
+++ b/frontend/src/features/manifests/pages/index.tsx
@@ -1,10 +1,55 @@
 import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Skeleton } from '@/components/ui/skeleton'
 import { ManifestCurrentView } from './manifest-current-view'
 import { ManifestHistoryTable } from './manifest-history-table'
 import { ManifestApplyDialog } from './manifest-apply-dialog'
+import { ManifestGraph } from '../components/manifest-graph'
 import { Button } from '@/components/ui/button'
 import { Plus } from 'lucide-react'
+import { manifestKeys } from '@/lib/query-keys'
+
+function ManifestGraphTab() {
+  const { manifestHistory } = useApiClients()
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: manifestKeys.current(),
+    queryFn: () => manifestHistory.getCurrentManifest({}),
+  })
+
+  if (isLoading) {
+    return (
+      <div data-testid="graph-loading" className="space-y-4">
+        <Skeleton className="h-[500px] w-full" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div data-testid="graph-error" className="flex flex-col items-center gap-2 py-8 text-muted-foreground">
+        <span className="text-sm font-medium">Unable to load manifest graph</span>
+        {error instanceof Error && error.message && (
+          <span className="text-xs max-w-md text-center">{error.message}</span>
+        )}
+      </div>
+    )
+  }
+
+  const manifest = data?.version?.manifest
+  if (!manifest) {
+    return (
+      <div data-testid="graph-empty" className="flex flex-col items-center gap-2 py-8 text-muted-foreground">
+        <span className="text-sm font-medium">No manifest applied</span>
+        <span className="text-xs">Apply a manifest to see the graph visualization.</span>
+      </div>
+    )
+  }
+
+  return <ManifestGraph manifest={manifest} />
+}
 
 export function ManifestsPage() {
   const [applyDialogOpen, setApplyDialogOpen] = useState(false)
@@ -28,12 +73,16 @@ export function ManifestsPage() {
         <TabsList>
           <TabsTrigger value="current">Current Manifest</TabsTrigger>
           <TabsTrigger value="history">Version History</TabsTrigger>
+          <TabsTrigger value="graph">Graph</TabsTrigger>
         </TabsList>
         <TabsContent value="current">
           <ManifestCurrentView />
         </TabsContent>
         <TabsContent value="history">
           <ManifestHistoryTable />
+        </TabsContent>
+        <TabsContent value="graph">
+          <ManifestGraphTab />
         </TabsContent>
       </Tabs>
 

--- a/frontend/src/features/manifests/pages/manifests-page.test.tsx
+++ b/frontend/src/features/manifests/pages/manifests-page.test.tsx
@@ -11,12 +11,20 @@ vi.mock('@/api/context', () => ({
   ApiClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
+vi.mock('../components/manifest-graph', () => ({
+  ManifestGraph: ({ manifest }: { manifest: unknown }) => (
+    <div data-testid="manifest-graph">Graph rendered</div>
+  ),
+}))
+
 import { useApiClients } from '@/api/context'
 
-function mockApiClients() {
+function mockApiClients(overrides?: {
+  getCurrentManifest?: ReturnType<typeof vi.fn>
+}) {
   vi.mocked(useApiClients).mockReturnValue({
     manifestHistory: {
-      getCurrentManifest: vi.fn().mockResolvedValue({ version: null }),
+      getCurrentManifest: overrides?.getCurrentManifest ?? vi.fn().mockResolvedValue({ version: null }),
       listManifestVersions: vi.fn().mockResolvedValue({ versions: [], totalCount: 0 }),
       getManifestVersion: vi.fn(),
     },
@@ -68,12 +76,13 @@ describe('ManifestsPage', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument()
   })
 
-  it('renders Current Manifest and Version History tabs', async () => {
+  it('renders Current Manifest, Version History, and Graph tabs', async () => {
     renderManifestsPage()
 
     await waitFor(() => {
       expect(screen.getByRole('tab', { name: /current manifest/i })).toBeInTheDocument()
       expect(screen.getByRole('tab', { name: /version history/i })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /graph/i })).toBeInTheDocument()
     })
   })
 
@@ -97,5 +106,71 @@ describe('ManifestsPage', () => {
 
     const historyTab = screen.getByRole('tab', { name: /version history/i })
     expect(historyTab).toHaveAttribute('data-state', 'active')
+  })
+
+  it('switches to Graph tab', async () => {
+    renderManifestsPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /graph/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('tab', { name: /graph/i }))
+
+    const graphTab = screen.getByRole('tab', { name: /graph/i })
+    expect(graphTab).toHaveAttribute('data-state', 'active')
+  })
+
+  it('shows empty state in Graph tab when no manifest is applied', async () => {
+    renderManifestsPage()
+
+    await userEvent.click(screen.getByRole('tab', { name: /graph/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('graph-empty')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error state in Graph tab on fetch failure', async () => {
+    mockApiClients({
+      getCurrentManifest: vi.fn().mockRejectedValue(new Error('Network error')),
+    })
+
+    renderManifestsPage()
+
+    await userEvent.click(screen.getByRole('tab', { name: /graph/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('graph-error')).toBeInTheDocument()
+      expect(screen.getByText(/network error/i)).toBeInTheDocument()
+    })
+  })
+
+  it('renders ManifestGraph when manifest data is available', async () => {
+    mockApiClients({
+      getCurrentManifest: vi.fn().mockResolvedValue({
+        version: {
+          version: 1,
+          manifest: {
+            metadata: { name: 'Test', industry: 'energy' },
+            instruments: [],
+            accountTypes: [],
+            valuationRules: [],
+            sagas: [],
+          },
+          appliedAt: { seconds: BigInt(1700000000), nanos: 0 },
+          appliedBy: 'admin',
+          applyStatus: 1,
+        },
+      }),
+    })
+
+    renderManifestsPage()
+
+    await userEvent.click(screen.getByRole('tab', { name: /graph/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('manifest-graph')).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/features/manifests/pages/manifests-page.test.tsx
+++ b/frontend/src/features/manifests/pages/manifests-page.test.tsx
@@ -12,7 +12,7 @@ vi.mock('@/api/context', () => ({
 }))
 
 vi.mock('../components/manifest-graph', () => ({
-  ManifestGraph: ({ manifest }: { manifest: unknown }) => (
+  ManifestGraph: (_props: { manifest: unknown }) => (
     <div data-testid="manifest-graph">Graph rendered</div>
   ),
 }))


### PR DESCRIPTION
## Summary

- Adds a third "Graph" tab to the Manifests page that renders the `ManifestGraph` ReactFlow component
- Graph tab fetches manifest data via the same React Query key as the Current Manifest tab (automatic cache deduplication)
- Handles loading, error, and empty states within the Graph tab content

## Changes Made

- `frontend/src/features/manifests/pages/index.tsx`: Added `ManifestGraphTab` wrapper component and "Graph" `TabsTrigger`/`TabsContent`
- `frontend/src/features/manifests/pages/manifests-page.test.tsx`: Added 4 new tests for Graph tab (tab switching, empty state, error state, graph rendering)

## Test Plan

- [x] All 87 manifest feature tests pass (including 4 new Graph tab tests)
- [x] Tab switching between Current/History/Graph verified
- [x] Graph tab shows loading skeleton during fetch
- [x] Graph tab shows error state on failure
- [x] Graph tab shows empty state when no manifest applied
- [x] Graph renders ManifestGraph component when manifest data available
- [x] Existing tabs unaffected (regression)

## Task Master

Task: 038-manifest-business-model-visualization.4