### PR TITLE
feat: add manifest version diff graph with comparison UI

### DIFF
--- a/frontend/src/features/manifests/components/manifest-diff-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-graph.tsx
@@ -1,0 +1,305 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  ReactFlow,
+  Controls,
+  Background,
+  useNodesState,
+  useEdgesState,
+  type Node,
+  type Edge,
+  BackgroundVariant,
+  Position,
+  Handle,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import {
+  TooltipProvider,
+} from '@/components/ui/tooltip'
+import {
+  layoutWithELK,
+  NODE_WIDTH,
+  NODE_BASE_HEIGHT,
+  NODE_PADDING,
+} from '@/lib/visualization/graph-layout'
+import type {
+  ManifestNode,
+  ManifestEdge,
+  ManifestGraph,
+  ManifestNodeType,
+} from '../lib/manifest-graph-model'
+import { computeManifestDiff, type ManifestDiff } from '../lib/manifest-diff'
+
+type DiffStatus = 'added' | 'removed' | 'modified' | 'unchanged'
+
+const DIFF_COLORS: Record<DiffStatus, { border: string; bg: string }> = {
+  added: { border: '#16a34a', bg: '#16a34a18' },
+  removed: { border: '#dc2626', bg: '#dc262618' },
+  modified: { border: '#d97706', bg: '#d9770618' },
+  unchanged: { border: '#6b7280', bg: '#6b728010' },
+}
+
+const LAYER_PRIORITY: Record<ManifestNodeType, string> = {
+  instrument: '40',
+  account_type: '30',
+  valuation_rule: '20',
+  saga: '10',
+}
+
+interface DiffNodeData {
+  manifestNode: ManifestNode
+  diffStatus: DiffStatus
+  [key: string]: unknown
+}
+
+function DiffNode({ data }: { data: DiffNodeData }) {
+  const node = data.manifestNode
+  const colors = DIFF_COLORS[data.diffStatus]
+  return (
+    <>
+      <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <div
+        className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center"
+        style={{
+          width: 180,
+          borderColor: colors.border,
+          backgroundColor: colors.bg,
+          textDecoration: data.diffStatus === 'removed' ? 'line-through' : undefined,
+        }}
+        data-testid={`diff-node-${data.diffStatus}`}
+      >
+        <span className="text-[11px] font-bold font-mono text-foreground">{node.label}</span>
+        <span className="text-[9px] text-muted-foreground">{node.type.replace('_', ' ')}</span>
+      </div>
+      <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
+    </>
+  )
+}
+
+const nodeTypes = {
+  diff_node: DiffNode,
+}
+
+function buildDiffEdgeStyle(status: DiffStatus): React.CSSProperties {
+  const colors = DIFF_COLORS[status]
+  return {
+    stroke: colors.border,
+    strokeWidth: 2,
+    strokeDasharray: status === 'removed' ? '4 4' : undefined,
+  }
+}
+
+function buildReactFlowElements(
+  diff: ManifestDiff,
+  before: ManifestGraph,
+  after: ManifestGraph,
+): { allNodes: ManifestNode[]; allEdges: ManifestEdge[]; nodeStatusMap: Map<string, DiffStatus>; edgeStatusMap: Map<string, DiffStatus> } {
+  const nodeStatusMap = new Map<string, DiffStatus>()
+  const edgeStatusMap = new Map<string, DiffStatus>()
+
+  const addedIds = new Set(diff.addedNodes.map((n) => n.id))
+  const removedIds = new Set(diff.removedNodes.map((n) => n.id))
+  const modifiedIds = new Set(diff.modifiedNodes.map((m) => m.after.id))
+
+  // Build unified node list: after nodes + removed nodes from before
+  const allNodes: ManifestNode[] = []
+  for (const node of after.nodes) {
+    allNodes.push(node)
+    if (addedIds.has(node.id)) {
+      nodeStatusMap.set(node.id, 'added')
+    } else if (modifiedIds.has(node.id)) {
+      nodeStatusMap.set(node.id, 'modified')
+    } else {
+      nodeStatusMap.set(node.id, 'unchanged')
+    }
+  }
+  for (const node of diff.removedNodes) {
+    allNodes.push(node)
+    nodeStatusMap.set(node.id, 'removed')
+  }
+
+  const addedEdgeIds = new Set(diff.addedEdges.map((e) => e.id))
+  const removedEdgeIds = new Set(diff.removedEdges.map((e) => e.id))
+
+  const allEdges: ManifestEdge[] = []
+  for (const edge of after.edges) {
+    allEdges.push(edge)
+    edgeStatusMap.set(edge.id, addedEdgeIds.has(edge.id) ? 'added' : 'unchanged')
+  }
+  for (const edge of diff.removedEdges) {
+    allEdges.push(edge)
+    edgeStatusMap.set(edge.id, 'removed')
+  }
+
+  return { allNodes, allEdges, nodeStatusMap, edgeStatusMap }
+}
+
+async function layoutDiffGraph(
+  allNodes: ManifestNode[],
+  allEdges: ManifestEdge[],
+  nodeStatusMap: Map<string, DiffStatus>,
+  edgeStatusMap: Map<string, DiffStatus>,
+): Promise<{ nodes: Node[]; edges: Edge[] }> {
+  if (allNodes.length === 0) {
+    return { nodes: [], edges: [] }
+  }
+
+  const layoutNodes = allNodes.map((n) => ({
+    id: n.id,
+    width: NODE_WIDTH,
+    height: NODE_BASE_HEIGHT + NODE_PADDING,
+    layoutOptions: {
+      'elk.layered.layering.layerChoiceConstraint': LAYER_PRIORITY[n.type],
+    },
+  }))
+
+  const rfEdges: Edge[] = allEdges.map((e) => {
+    const status = edgeStatusMap.get(e.id) ?? 'unchanged'
+    return {
+      id: e.id,
+      source: e.source,
+      target: e.target,
+      style: buildDiffEdgeStyle(status),
+      data: { diffStatus: status },
+    }
+  })
+
+  const rfNodes = await layoutWithELK<DiffNodeData>(
+    layoutNodes,
+    rfEdges,
+    (id, position) => {
+      const mn = allNodes.find((n) => n.id === id)!
+      const status = nodeStatusMap.get(id) ?? 'unchanged'
+      return {
+        id,
+        type: 'diff_node',
+        position,
+        data: {
+          manifestNode: mn,
+          diffStatus: status,
+        } satisfies DiffNodeData,
+      }
+    },
+    {
+      direction: 'DOWN',
+      nodeNodeSpacing: '50',
+      layerSpacing: '80',
+    },
+  )
+
+  return { nodes: rfNodes, edges: rfEdges }
+}
+
+function DiffLegendItem({ label, color, dashed }: { label: string; color: string; dashed?: boolean }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-3 h-3 rounded-sm border-2" style={{ borderColor: color, backgroundColor: `${color}18` }} />
+      {dashed !== undefined && (
+        <svg width="20" height="12">
+          <line x1="0" y1="6" x2="20" y2="6" stroke={color} strokeWidth={2} strokeDasharray={dashed ? '4 4' : undefined} />
+        </svg>
+      )}
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  )
+}
+
+interface ManifestDiffGraphProps {
+  before: ManifestGraph
+  after: ManifestGraph
+  className?: string
+}
+
+export function ManifestDiffGraph({ before, after, className }: ManifestDiffGraphProps) {
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([])
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
+  const [diffSummary, setDiffSummary] = useState<ManifestDiff | null>(null)
+
+  const diff = useMemo(() => computeManifestDiff(before, after), [before, after])
+
+  useEffect(() => {
+    setDiffSummary(diff)
+    const { allNodes, allEdges, nodeStatusMap, edgeStatusMap } = buildReactFlowElements(diff, before, after)
+
+    let cancelled = false
+    void layoutDiffGraph(allNodes, allEdges, nodeStatusMap, edgeStatusMap)
+      .then((result) => {
+        if (!cancelled) {
+          setNodes(result.nodes)
+          setEdges(result.edges)
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error('[ManifestDiffGraph] layout failed:', err)
+        }
+      })
+    return () => { cancelled = true }
+  }, [diff, before, after, setNodes, setEdges])
+
+  const noDiff = diff.addedNodes.length === 0
+    && diff.removedNodes.length === 0
+    && diff.modifiedNodes.length === 0
+    && diff.addedEdges.length === 0
+    && diff.removedEdges.length === 0
+
+  if (noDiff) {
+    return (
+      <div className={className} data-testid="manifest-diff-no-changes" style={{ width: '100%', height: '100%' }}>
+        <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+          No differences between versions.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={className} style={{ width: '100%', height: '100%', position: 'relative' }} data-testid="manifest-diff-graph">
+      <TooltipProvider>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          nodeTypes={nodeTypes}
+          fitView
+          proOptions={{ hideAttribution: true }}
+          nodesDraggable={false}
+        >
+          <Controls />
+          <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
+        </ReactFlow>
+      </TooltipProvider>
+
+      {/* Diff summary */}
+      {diffSummary && (
+        <div className="absolute top-3 left-3 z-10 flex flex-col gap-1 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm" data-testid="diff-summary">
+          <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">Changes</span>
+          {diffSummary.addedNodes.length > 0 && (
+            <span className="text-xs text-green-600">+{diffSummary.addedNodes.length} added</span>
+          )}
+          {diffSummary.removedNodes.length > 0 && (
+            <span className="text-xs text-red-600">-{diffSummary.removedNodes.length} removed</span>
+          )}
+          {diffSummary.modifiedNodes.length > 0 && (
+            <span className="text-xs text-amber-600">~{diffSummary.modifiedNodes.length} modified</span>
+          )}
+          {diffSummary.addedEdges.length > 0 && (
+            <span className="text-xs text-green-600">+{diffSummary.addedEdges.length} edge{diffSummary.addedEdges.length !== 1 ? 's' : ''}</span>
+          )}
+          {diffSummary.removedEdges.length > 0 && (
+            <span className="text-xs text-red-600">-{diffSummary.removedEdges.length} edge{diffSummary.removedEdges.length !== 1 ? 's' : ''}</span>
+          )}
+        </div>
+      )}
+
+      {/* Legend */}
+      <div className="absolute bottom-3 left-3 z-10 flex flex-col gap-1 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm">
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">Legend</span>
+        <DiffLegendItem label="Added" color="#16a34a" />
+        <DiffLegendItem label="Removed" color="#dc2626" dashed />
+        <DiffLegendItem label="Modified" color="#d97706" />
+        <DiffLegendItem label="Unchanged" color="#6b7280" />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/manifests/components/manifest-diff-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-graph.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo } from 'react'
 import {
   ReactFlow,
   Controls,
@@ -97,7 +97,6 @@ function buildReactFlowElements(
   const edgeStatusMap = new Map<string, DiffStatus>()
 
   const addedIds = new Set(diff.addedNodes.map((n) => n.id))
-  const removedIds = new Set(diff.removedNodes.map((n) => n.id))
   const modifiedIds = new Set(diff.modifiedNodes.map((m) => m.after.id))
 
   // Build unified node list: after nodes + removed nodes from before
@@ -118,7 +117,6 @@ function buildReactFlowElements(
   }
 
   const addedEdgeIds = new Set(diff.addedEdges.map((e) => e.id))
-  const removedEdgeIds = new Set(diff.removedEdges.map((e) => e.id))
 
   const allEdges: ManifestEdge[] = []
   for (const edge of after.edges) {
@@ -212,12 +210,10 @@ interface ManifestDiffGraphProps {
 export function ManifestDiffGraph({ before, after, className }: ManifestDiffGraphProps) {
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([])
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
-  const [diffSummary, setDiffSummary] = useState<ManifestDiff | null>(null)
 
   const diff = useMemo(() => computeManifestDiff(before, after), [before, after])
 
   useEffect(() => {
-    setDiffSummary(diff)
     const { allNodes, allEdges, nodeStatusMap, edgeStatusMap } = buildReactFlowElements(diff, before, after)
 
     let cancelled = false
@@ -271,26 +267,24 @@ export function ManifestDiffGraph({ before, after, className }: ManifestDiffGrap
       </TooltipProvider>
 
       {/* Diff summary */}
-      {diffSummary && (
-        <div className="absolute top-3 left-3 z-10 flex flex-col gap-1 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm" data-testid="diff-summary">
-          <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">Changes</span>
-          {diffSummary.addedNodes.length > 0 && (
-            <span className="text-xs text-green-600">+{diffSummary.addedNodes.length} added</span>
-          )}
-          {diffSummary.removedNodes.length > 0 && (
-            <span className="text-xs text-red-600">-{diffSummary.removedNodes.length} removed</span>
-          )}
-          {diffSummary.modifiedNodes.length > 0 && (
-            <span className="text-xs text-amber-600">~{diffSummary.modifiedNodes.length} modified</span>
-          )}
-          {diffSummary.addedEdges.length > 0 && (
-            <span className="text-xs text-green-600">+{diffSummary.addedEdges.length} edge{diffSummary.addedEdges.length !== 1 ? 's' : ''}</span>
-          )}
-          {diffSummary.removedEdges.length > 0 && (
-            <span className="text-xs text-red-600">-{diffSummary.removedEdges.length} edge{diffSummary.removedEdges.length !== 1 ? 's' : ''}</span>
-          )}
-        </div>
-      )}
+      <div className="absolute top-3 left-3 z-10 flex flex-col gap-1 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm" data-testid="diff-summary">
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">Changes</span>
+        {diff.addedNodes.length > 0 && (
+          <span className="text-xs text-green-600">+{diff.addedNodes.length} added</span>
+        )}
+        {diff.removedNodes.length > 0 && (
+          <span className="text-xs text-red-600">-{diff.removedNodes.length} removed</span>
+        )}
+        {diff.modifiedNodes.length > 0 && (
+          <span className="text-xs text-amber-600">~{diff.modifiedNodes.length} modified</span>
+        )}
+        {diff.addedEdges.length > 0 && (
+          <span className="text-xs text-green-600">+{diff.addedEdges.length} edge{diff.addedEdges.length !== 1 ? 's' : ''}</span>
+        )}
+        {diff.removedEdges.length > 0 && (
+          <span className="text-xs text-red-600">-{diff.removedEdges.length} edge{diff.removedEdges.length !== 1 ? 's' : ''}</span>
+        )}
+      </div>
 
       {/* Legend */}
       <div className="absolute bottom-3 left-3 z-10 flex flex-col gap-1 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm">

--- a/frontend/src/features/manifests/lib/manifest-diff.test.ts
+++ b/frontend/src/features/manifests/lib/manifest-diff.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest'
+import type { ManifestGraph, ManifestNode, ManifestEdge } from './manifest-graph-model'
+import { computeManifestDiff } from './manifest-diff'
+
+function makeNode(overrides: Partial<ManifestNode> & { id: string }): ManifestNode {
+  return {
+    type: 'instrument',
+    label: overrides.id,
+    data: {},
+    ...overrides,
+  }
+}
+
+function makeEdge(overrides: Partial<ManifestEdge> & { id: string }): ManifestEdge {
+  return {
+    source: 'a',
+    target: 'b',
+    relationship: 'allowed_by',
+    ...overrides,
+  }
+}
+
+function makeGraph(nodes: ManifestNode[], edges: ManifestEdge[] = []): ManifestGraph {
+  return { nodes, edges }
+}
+
+describe('computeManifestDiff', () => {
+  it('detects added nodes', () => {
+    const before = makeGraph([makeNode({ id: 'n1' })])
+    const after = makeGraph([makeNode({ id: 'n1' }), makeNode({ id: 'n2' })])
+
+    const diff = computeManifestDiff(before, after)
+
+    expect(diff.addedNodes).toHaveLength(1)
+    expect(diff.addedNodes[0].id).toBe('n2')
+    expect(diff.removedNodes).toHaveLength(0)
+    expect(diff.modifiedNodes).toHaveLength(0)
+  })
+
+  it('detects removed nodes', () => {
+    const before = makeGraph([makeNode({ id: 'n1' }), makeNode({ id: 'n2' })])
+    const after = makeGraph([makeNode({ id: 'n1' })])
+
+    const diff = computeManifestDiff(before, after)
+
+    expect(diff.removedNodes).toHaveLength(1)
+    expect(diff.removedNodes[0].id).toBe('n2')
+    expect(diff.addedNodes).toHaveLength(0)
+  })
+
+  it('detects modified nodes by label change', () => {
+    const before = makeGraph([makeNode({ id: 'n1', label: 'Old Label' })])
+    const after = makeGraph([makeNode({ id: 'n1', label: 'New Label' })])
+
+    const diff = computeManifestDiff(before, after)
+
+    expect(diff.modifiedNodes).toHaveLength(1)
+    expect(diff.modifiedNodes[0].before.label).toBe('Old Label')
+    expect(diff.modifiedNodes[0].after.label).toBe('New Label')
+  })
+
+  it('detects modified nodes by data change', () => {
+    const before = makeGraph([makeNode({ id: 'n1', data: { foo: 'bar' } })])
+    const after = makeGraph([makeNode({ id: 'n1', data: { foo: 'baz' } })])
+
+    const diff = computeManifestDiff(before, after)
+
+    expect(diff.modifiedNodes).toHaveLength(1)
+  })
+
+  it('detects added edges', () => {
+    const n1 = makeNode({ id: 'n1' })
+    const n2 = makeNode({ id: 'n2' })
+    const edge = makeEdge({ id: 'e1', source: 'n1', target: 'n2' })
+
+    const before = makeGraph([n1, n2])
+    const after = makeGraph([n1, n2], [edge])
+
+    const diff = computeManifestDiff(before, after)
+
+    expect(diff.addedEdges).toHaveLength(1)
+    expect(diff.addedEdges[0].id).toBe('e1')
+    expect(diff.removedEdges).toHaveLength(0)
+  })
+
+  it('detects removed edges', () => {
+    const n1 = makeNode({ id: 'n1' })
+    const n2 = makeNode({ id: 'n2' })
+    const edge = makeEdge({ id: 'e1', source: 'n1', target: 'n2' })
+
+    const before = makeGraph([n1, n2], [edge])
+    const after = makeGraph([n1, n2])
+
+    const diff = computeManifestDiff(before, after)
+
+    expect(diff.removedEdges).toHaveLength(1)
+    expect(diff.removedEdges[0].id).toBe('e1')
+    expect(diff.addedEdges).toHaveLength(0)
+  })
+
+  it('returns empty diff for identical graphs', () => {
+    const n1 = makeNode({ id: 'n1', label: 'Test', data: { code: 'A' } })
+    const e1 = makeEdge({ id: 'e1', source: 'n1', target: 'n1' })
+    const graph = makeGraph([n1], [e1])
+
+    const diff = computeManifestDiff(graph, graph)
+
+    expect(diff.addedNodes).toHaveLength(0)
+    expect(diff.removedNodes).toHaveLength(0)
+    expect(diff.modifiedNodes).toHaveLength(0)
+    expect(diff.addedEdges).toHaveLength(0)
+    expect(diff.removedEdges).toHaveLength(0)
+  })
+
+  it('handles empty graphs', () => {
+    const diff = computeManifestDiff(makeGraph([]), makeGraph([]))
+
+    expect(diff.addedNodes).toHaveLength(0)
+    expect(diff.removedNodes).toHaveLength(0)
+    expect(diff.modifiedNodes).toHaveLength(0)
+    expect(diff.addedEdges).toHaveLength(0)
+    expect(diff.removedEdges).toHaveLength(0)
+  })
+
+  it('handles complex diff with adds, removes, and modifications', () => {
+    const before = makeGraph(
+      [
+        makeNode({ id: 'n1', label: 'Keep' }),
+        makeNode({ id: 'n2', label: 'Remove' }),
+        makeNode({ id: 'n3', label: 'Modify Old' }),
+      ],
+      [makeEdge({ id: 'e1', source: 'n1', target: 'n2' })],
+    )
+    const after = makeGraph(
+      [
+        makeNode({ id: 'n1', label: 'Keep' }),
+        makeNode({ id: 'n3', label: 'Modify New' }),
+        makeNode({ id: 'n4', label: 'Added' }),
+      ],
+      [makeEdge({ id: 'e2', source: 'n1', target: 'n4' })],
+    )
+
+    const diff = computeManifestDiff(before, after)
+
+    expect(diff.addedNodes).toHaveLength(1)
+    expect(diff.addedNodes[0].id).toBe('n4')
+    expect(diff.removedNodes).toHaveLength(1)
+    expect(diff.removedNodes[0].id).toBe('n2')
+    expect(diff.modifiedNodes).toHaveLength(1)
+    expect(diff.modifiedNodes[0].after.label).toBe('Modify New')
+    expect(diff.addedEdges).toHaveLength(1)
+    expect(diff.removedEdges).toHaveLength(1)
+  })
+})

--- a/frontend/src/features/manifests/lib/manifest-diff.ts
+++ b/frontend/src/features/manifests/lib/manifest-diff.ts
@@ -1,0 +1,53 @@
+import type { ManifestGraph, ManifestNode, ManifestEdge } from './manifest-graph-model'
+
+export interface ManifestDiff {
+  addedNodes: ManifestNode[]
+  removedNodes: ManifestNode[]
+  modifiedNodes: Array<{ before: ManifestNode; after: ManifestNode }>
+  addedEdges: ManifestEdge[]
+  removedEdges: ManifestEdge[]
+}
+
+function nodesEqual(a: ManifestNode, b: ManifestNode): boolean {
+  if (a.label !== b.label) return false
+  const aKeys = Object.keys(a.data).sort()
+  const bKeys = Object.keys(b.data).sort()
+  if (aKeys.length !== bKeys.length) return false
+  for (let i = 0; i < aKeys.length; i++) {
+    if (aKeys[i] !== bKeys[i]) return false
+    if (JSON.stringify(a.data[aKeys[i]]) !== JSON.stringify(b.data[bKeys[i]])) return false
+  }
+  return true
+}
+
+export function computeManifestDiff(before: ManifestGraph, after: ManifestGraph): ManifestDiff {
+  const beforeNodeMap = new Map(before.nodes.map((n) => [n.id, n]))
+  const afterNodeMap = new Map(after.nodes.map((n) => [n.id, n]))
+
+  const addedNodes: ManifestNode[] = []
+  const removedNodes: ManifestNode[] = []
+  const modifiedNodes: Array<{ before: ManifestNode; after: ManifestNode }> = []
+
+  for (const node of after.nodes) {
+    const prev = beforeNodeMap.get(node.id)
+    if (!prev) {
+      addedNodes.push(node)
+    } else if (!nodesEqual(prev, node)) {
+      modifiedNodes.push({ before: prev, after: node })
+    }
+  }
+
+  for (const node of before.nodes) {
+    if (!afterNodeMap.has(node.id)) {
+      removedNodes.push(node)
+    }
+  }
+
+  const beforeEdgeIds = new Set(before.edges.map((e) => e.id))
+  const afterEdgeIds = new Set(after.edges.map((e) => e.id))
+
+  const addedEdges = after.edges.filter((e) => !beforeEdgeIds.has(e.id))
+  const removedEdges = before.edges.filter((e) => !afterEdgeIds.has(e.id))
+
+  return { addedNodes, removedNodes, modifiedNodes, addedEdges, removedEdges }
+}

--- a/frontend/src/features/manifests/pages/manifest-history-table.test.tsx
+++ b/frontend/src/features/manifests/pages/manifest-history-table.test.tsx
@@ -156,4 +156,80 @@ describe('ManifestHistoryTable', () => {
     })
     expect(screen.getByText(/Manifest Version 1.0/)).toBeInTheDocument()
   })
+
+  it('renders compare checkboxes for each version', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compare-checkbox-1.0')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('compare-checkbox-1.1')).toBeInTheDocument()
+    expect(screen.getByTestId('compare-checkbox-1.2')).toBeInTheDocument()
+  })
+
+  it('shows compare toolbar when versions are selected', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compare-checkbox-1.0')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByTestId('compare-checkbox-1.0'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compare-toolbar')).toBeInTheDocument()
+    })
+    expect(screen.getByText('1/2 versions selected')).toBeInTheDocument()
+  })
+
+  it('enables compare button when exactly 2 versions selected', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compare-checkbox-1.0')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByTestId('compare-checkbox-1.0'))
+    await userEvent.click(screen.getByTestId('compare-checkbox-1.1'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compare-button')).not.toBeDisabled()
+    })
+    expect(screen.getByText('2/2 versions selected')).toBeInTheDocument()
+  })
+
+  it('disables additional checkboxes when 2 versions already selected', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compare-checkbox-1.0')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByTestId('compare-checkbox-1.0'))
+    await userEvent.click(screen.getByTestId('compare-checkbox-1.1'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compare-checkbox-1.2')).toBeDisabled()
+    })
+  })
+
+  it('clears selection when clear button is clicked', async () => {
+    renderComponent()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compare-checkbox-1.0')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByTestId('compare-checkbox-1.0'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compare-toolbar')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /clear/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('compare-toolbar')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/features/manifests/pages/manifest-history-table.tsx
+++ b/frontend/src/features/manifests/pages/manifest-history-table.tsx
@@ -137,7 +137,14 @@ export function ManifestHistoryTable() {
 
   const diffGraphs = useMemo(() => {
     if (!showDiff || compareVersions.length !== 2) return null
-    const [v1, v2] = compareVersions
+    // Sort by appliedAt so earlier version is always "before"
+    const sorted = [...compareVersions].sort((a, b) => {
+      const aTime = Number(a.appliedAt?.seconds ?? 0n)
+      const bTime = Number(b.appliedAt?.seconds ?? 0n)
+      return aTime - bTime
+    })
+    const [v1, v2] = sorted
+    if (!v1.manifest || !v2.manifest) return null
     const before = buildManifestGraph(v1.manifest as unknown as Manifest)
     const after = buildManifestGraph(v2.manifest as unknown as Manifest)
     return { before, after, v1Label: v1.version, v2Label: v2.version }

--- a/frontend/src/features/manifests/pages/manifest-history-table.tsx
+++ b/frontend/src/features/manifests/pages/manifest-history-table.tsx
@@ -126,7 +126,7 @@ export function ManifestHistoryTable() {
   }
 
   function handleCompare() {
-    if (compareVersions.length === 2) {
+    if (compareVersions.length === 2 && compareVersions[0].manifest && compareVersions[1].manifest) {
       setShowDiff(true)
     }
   }
@@ -196,7 +196,7 @@ export function ManifestHistoryTable() {
       </Dialog>
 
       <Dialog open={showDiff} onOpenChange={closeDiff}>
-        <DialogContent className="max-w-5xl h-[80vh]">
+        <DialogContent className="max-w-5xl h-[80vh] flex flex-col">
           <DialogHeader>
             <DialogTitle>
               Diff: Version {diffGraphs?.v1Label} vs {diffGraphs?.v2Label}

--- a/frontend/src/features/manifests/pages/manifest-history-table.tsx
+++ b/frontend/src/features/manifests/pages/manifest-history-table.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { ColumnDef } from '@tanstack/react-table'
 import { DataTable, type DataTableQueryParams, type DataTableResult } from '@/shared/data-table'
 import { useApiClients } from '@/api/context'
 import { StatusBadge } from '@/shared/status-badge'
 import { TimeDisplay } from '@/shared/time-display'
+import { Button } from '@/components/ui/button'
 import {
   Dialog,
   DialogContent,
@@ -13,6 +14,9 @@ import {
 import { manifestKeys } from '@/lib/query-keys'
 import type { ManifestVersion } from '@/api/gen/meridian/control_plane/v1/manifest_history_service_pb'
 import { ApplyStatus } from '@/api/gen/meridian/control_plane/v1/manifest_history_service_pb'
+import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
+import { buildManifestGraph } from '../lib/manifest-graph-model'
+import { ManifestDiffGraph } from '../components/manifest-diff-graph'
 
 const APPLY_STATUS_LABEL: Record<number, string> = {
   [ApplyStatus.APPLIED]: 'APPLIED',
@@ -20,42 +24,92 @@ const APPLY_STATUS_LABEL: Record<number, string> = {
   [ApplyStatus.ROLLED_BACK]: 'ROLLED_BACK',
 }
 
-const columns: ColumnDef<ManifestVersion>[] = [
-  {
-    accessorKey: 'version',
-    header: 'Version',
-  },
-  {
-    accessorKey: 'appliedAt',
-    header: 'Applied At',
-    cell: ({ row }) => <TimeDisplay timestamp={row.original.appliedAt} />,
-  },
-  {
-    accessorKey: 'appliedBy',
-    header: 'Applied By',
-  },
-  {
-    accessorKey: 'applyStatus',
-    header: 'Status',
-    cell: ({ row }) => {
-      const label = APPLY_STATUS_LABEL[row.original.applyStatus] ?? 'UNKNOWN'
-      return <StatusBadge status={label} />
+function buildColumns(
+  compareSet: Set<string>,
+  onToggleCompare: (version: ManifestVersion) => void,
+): ColumnDef<ManifestVersion>[] {
+  return [
+    {
+      id: 'compare',
+      header: 'Compare',
+      cell: ({ row }) => {
+        const v = row.original
+        const versionId = v.id ?? v.version
+        const isSelected = compareSet.has(versionId)
+        const disabled = !isSelected && compareSet.size >= 2
+        return (
+          <input
+            type="checkbox"
+            checked={isSelected}
+            disabled={disabled}
+            onChange={() => onToggleCompare(v)}
+            onClick={(e) => e.stopPropagation()}
+            aria-label={`Select version ${v.version} for comparison`}
+            className="rounded"
+            data-testid={`compare-checkbox-${v.version}`}
+          />
+        )
+      },
+      enableSorting: false,
     },
-  },
-  {
-    accessorKey: 'diffSummary',
-    header: 'Changes',
-    cell: ({ row }) => (
-      <span className="text-sm text-muted-foreground">
-        {row.original.diffSummary ?? '\u2014'}
-      </span>
-    ),
-  },
-]
+    {
+      accessorKey: 'version',
+      header: 'Version',
+    },
+    {
+      accessorKey: 'appliedAt',
+      header: 'Applied At',
+      cell: ({ row }) => <TimeDisplay timestamp={row.original.appliedAt} />,
+    },
+    {
+      accessorKey: 'appliedBy',
+      header: 'Applied By',
+    },
+    {
+      accessorKey: 'applyStatus',
+      header: 'Status',
+      cell: ({ row }) => {
+        const label = APPLY_STATUS_LABEL[row.original.applyStatus] ?? 'UNKNOWN'
+        return <StatusBadge status={label} />
+      },
+    },
+    {
+      accessorKey: 'diffSummary',
+      header: 'Changes',
+      cell: ({ row }) => (
+        <span className="text-sm text-muted-foreground">
+          {row.original.diffSummary ?? '\u2014'}
+        </span>
+      ),
+    },
+  ]
+}
 
 export function ManifestHistoryTable() {
   const { manifestHistory } = useApiClients()
   const [selectedVersion, setSelectedVersion] = useState<ManifestVersion | null>(null)
+  const [compareVersions, setCompareVersions] = useState<ManifestVersion[]>([])
+  const [showDiff, setShowDiff] = useState(false)
+
+  const compareSet = useMemo(
+    () => new Set(compareVersions.map((v) => v.id ?? v.version)),
+    [compareVersions],
+  )
+
+  function toggleCompare(version: ManifestVersion) {
+    const versionId = version.id ?? version.version
+    setCompareVersions((prev) => {
+      const exists = prev.find((v) => (v.id ?? v.version) === versionId)
+      if (exists) return prev.filter((v) => (v.id ?? v.version) !== versionId)
+      if (prev.length >= 2) return prev
+      return [...prev, version]
+    })
+  }
+
+  const columns = useMemo(
+    () => buildColumns(compareSet, toggleCompare),
+    [compareSet],
+  )
 
   async function fetchVersions(params: DataTableQueryParams): Promise<DataTableResult<ManifestVersion>> {
     const parsed = params.pageToken ? parseInt(params.pageToken, 10) : 0
@@ -71,9 +125,49 @@ export function ManifestHistoryTable() {
     }
   }
 
+  function handleCompare() {
+    if (compareVersions.length === 2) {
+      setShowDiff(true)
+    }
+  }
+
+  function closeDiff() {
+    setShowDiff(false)
+  }
+
+  const diffGraphs = useMemo(() => {
+    if (!showDiff || compareVersions.length !== 2) return null
+    const [v1, v2] = compareVersions
+    const before = buildManifestGraph(v1.manifest as unknown as Manifest)
+    const after = buildManifestGraph(v2.manifest as unknown as Manifest)
+    return { before, after, v1Label: v1.version, v2Label: v2.version }
+  }, [showDiff, compareVersions])
+
   return (
     <>
       <div data-testid="manifest-history-table">
+        {compareVersions.length > 0 && (
+          <div className="flex items-center gap-3 pb-3" data-testid="compare-toolbar">
+            <span className="text-sm text-muted-foreground">
+              {compareVersions.length}/2 versions selected
+            </span>
+            <Button
+              size="sm"
+              disabled={compareVersions.length !== 2}
+              onClick={handleCompare}
+              data-testid="compare-button"
+            >
+              Compare
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setCompareVersions([])}
+            >
+              Clear
+            </Button>
+          </div>
+        )}
         <DataTable<ManifestVersion>
           queryKey={manifestKeys.history()}
           queryFn={fetchVersions}
@@ -91,6 +185,25 @@ export function ManifestHistoryTable() {
           <pre className="max-h-[400px] overflow-auto rounded bg-muted p-3 text-xs font-mono">
             {JSON.stringify(selectedVersion?.manifest, null, 2)}
           </pre>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showDiff} onOpenChange={closeDiff}>
+        <DialogContent className="max-w-5xl h-[80vh]">
+          <DialogHeader>
+            <DialogTitle>
+              Diff: Version {diffGraphs?.v1Label} vs {diffGraphs?.v2Label}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="flex-1 min-h-0 h-full">
+            {diffGraphs && (
+              <ManifestDiffGraph
+                before={diffGraphs.before}
+                after={diffGraphs.after}
+                className="h-full"
+              />
+            )}
+          </div>
         </DialogContent>
       </Dialog>
     </>


### PR DESCRIPTION
## Summary

- Add `computeManifestDiff` function that performs Set-based diffing of manifest graph nodes and edges, detecting additions, removals, and modifications
- Add `ManifestDiffGraph` ReactFlow component that renders color-coded overlay: green (added), red with strikethrough (removed), amber (modified), gray (unchanged)
- Extend `ManifestHistoryTable` with checkbox column for version selection (max 2), toolbar with Compare/Clear buttons, and diff dialog

Task: 038-manifest-business-model-visualization.12

## Changes Made

| File | Description |
|------|-------------|
| `frontend/src/features/manifests/lib/manifest-diff.ts` | `computeManifestDiff()` function with `ManifestDiff` type |
| `frontend/src/features/manifests/components/manifest-diff-graph.tsx` | `ManifestDiffGraph` component using ReactFlow + ELK layout |
| `frontend/src/features/manifests/pages/manifest-history-table.tsx` | Compare checkbox column, toolbar, and diff dialog |
| `frontend/src/features/manifests/lib/manifest-diff.test.ts` | 9 unit tests for diff computation |
| `frontend/src/features/manifests/pages/manifest-history-table.test.tsx` | 5 new integration tests for version selector UI |

## Test plan

- [x] Diff computation: added/removed/modified nodes detected correctly
- [x] Diff computation: added/removed edges detected correctly
- [x] Diff computation: identical graphs produce empty diff
- [x] Diff computation: complex scenario with mixed changes
- [x] Compare checkboxes render for each version row
- [x] Toolbar appears when versions selected, shows count
- [x] Compare button enabled only with exactly 2 selections
- [x] Third checkbox disabled when 2 already selected
- [x] Clear button resets selection
- [x] All 97 manifest tests pass (8 files)