### PR TITLE
feat: Migrate current-account to Reference Data resolution

### DIFF
--- a/services/current-account/adapters/persistence/multi_asset_repository_test.go
+++ b/services/current-account/adapters/persistence/multi_asset_repository_test.go
@@ -24,7 +24,7 @@ func TestSaveAndFindAccount_GBP(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	err = repo.Save(ctx, account)
@@ -143,7 +143,7 @@ func TestPrecisionPersistedAndRetrieved(t *testing.T) {
 			var account domain.CurrentAccount
 			var err error
 			if tc.dimension == "CURRENCY" {
-				account, err = domain.NewCurrentAccount(tc.accountID, tc.iban, partyID, tc.instrumentCode)
+				account, err = domain.NewCurrentAccountWithDimension(tc.accountID, tc.iban, partyID, tc.instrumentCode, "CURRENCY", 2)
 			} else {
 				account, err = domain.NewCurrentAccountWithDimension(tc.accountID, tc.iban, partyID, tc.instrumentCode, tc.dimension, tc.precision)
 			}

--- a/services/current-account/adapters/persistence/org_scoped_account_test.go
+++ b/services/current-account/adapters/persistence/org_scoped_account_test.go
@@ -74,7 +74,7 @@ func TestOrgScopedAccount_SaveWithOrgPartyID(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP",
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2,
 		domain.WithOrgPartyID(orgPartyID))
 	require.NoError(t, err)
 
@@ -98,7 +98,7 @@ func TestOrgScopedAccount_RoundTripPreservesOrgPartyID(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP",
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2,
 		domain.WithOrgPartyID(orgPartyID))
 	require.NoError(t, err)
 
@@ -122,7 +122,7 @@ func TestOrgScopedAccount_PersonalAccountHasNullOrgPartyID(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST98765432123456"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	err = repo.Save(ctx, account)
@@ -145,7 +145,7 @@ func TestOrgScopedAccount_FindByScopedParty(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP",
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2,
 		domain.WithOrgPartyID(orgPartyID))
 	require.NoError(t, err)
 
@@ -179,7 +179,7 @@ func TestOrgScopedAccount_FindByScopedParty_WrongCurrency(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP",
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2,
 		domain.WithOrgPartyID(orgPartyID))
 	require.NoError(t, err)
 
@@ -201,16 +201,16 @@ func TestOrgScopedAccount_ListByOrganization(t *testing.T) {
 	party1 := uuid.New().String()
 	party2 := uuid.New().String()
 
-	acc1, err := domain.NewCurrentAccount("ACC-"+uuid.New().String()[:8], "GB82WEST12345698765432", party1, "GBP",
+	acc1, err := domain.NewCurrentAccountWithDimension("ACC-"+uuid.New().String()[:8], "GB82WEST12345698765432", party1, "GBP", "CURRENCY", 2,
 		domain.WithOrgPartyID(orgPartyID))
 	require.NoError(t, err)
 
-	acc2, err := domain.NewCurrentAccount("ACC-"+uuid.New().String()[:8], "GB82WEST98765432123456", party2, "GBP",
+	acc2, err := domain.NewCurrentAccountWithDimension("ACC-"+uuid.New().String()[:8], "GB82WEST98765432123456", party2, "GBP", "CURRENCY", 2,
 		domain.WithOrgPartyID(orgPartyID))
 	require.NoError(t, err)
 
 	// Create a personal account (not org-scoped) - should not appear
-	acc3, err := domain.NewCurrentAccount("ACC-"+uuid.New().String()[:8], "GB82WEST55555555555555", uuid.New().String(), "GBP")
+	acc3, err := domain.NewCurrentAccountWithDimension("ACC-"+uuid.New().String()[:8], "GB82WEST55555555555555", uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	err = repo.Save(ctx, acc1)
@@ -250,7 +250,7 @@ func TestOrgScopedAccount_ListByOrganization_ExcludesDeleted(t *testing.T) {
 	partyID := uuid.New().String()
 	accountID := "ACC-" + uuid.New().String()[:8]
 
-	account, err := domain.NewCurrentAccount(accountID, "GB82WEST12345698765432", partyID, "GBP",
+	account, err := domain.NewCurrentAccountWithDimension(accountID, "GB82WEST12345698765432", partyID, "GBP", "CURRENCY", 2,
 		domain.WithOrgPartyID(orgPartyID))
 	require.NoError(t, err)
 
@@ -273,7 +273,7 @@ func TestToEntity_MapsOrgPartyID(t *testing.T) {
 	orgPartyID := uuid.New()
 	partyID := uuid.New().String()
 
-	account, err := domain.NewCurrentAccount("ACC-001", "GB82WEST12345698765432", partyID, "GBP",
+	account, err := domain.NewCurrentAccountWithDimension("ACC-001", "GB82WEST12345698765432", partyID, "GBP", "CURRENCY", 2,
 		domain.WithOrgPartyID(orgPartyID))
 	require.NoError(t, err)
 
@@ -287,7 +287,7 @@ func TestToEntity_MapsOrgPartyID(t *testing.T) {
 func TestToEntity_NilOrgPartyIDForPersonalAccount(t *testing.T) {
 	partyID := uuid.New().String()
 
-	account, err := domain.NewCurrentAccount("ACC-001", "GB82WEST12345698765432", partyID, "GBP")
+	account, err := domain.NewCurrentAccountWithDimension("ACC-001", "GB82WEST12345698765432", partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	entity, err := toEntity(context.Background(), account)

--- a/services/current-account/adapters/persistence/repository_contract_test.go
+++ b/services/current-account/adapters/persistence/repository_contract_test.go
@@ -39,7 +39,7 @@ func TestFindByID_UsesAccountID(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]     // Short ID like "ACC-12345678"
 	accountIdentification := "GB82WEST12345698765432" // IBAN
 
-	account, err := domain.NewCurrentAccount(accountID, accountIdentification, partyID, "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, accountIdentification, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	err = repo.Save(ctx, account)
@@ -69,7 +69,7 @@ func TestFindByIDForUpdate_UsesAccountID(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	accountIdentification := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, accountIdentification, partyID, "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, accountIdentification, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	err = repo.Save(ctx, account)
@@ -93,7 +93,7 @@ func TestDelete_UsesAccountID(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	accountIdentification := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, accountIdentification, partyID, "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, accountIdentification, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	err = repo.Save(ctx, account)

--- a/services/current-account/adapters/persistence/repository_test.go
+++ b/services/current-account/adapters/persistence/repository_test.go
@@ -81,7 +81,7 @@ func TestSaveNewAccount(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	// ctx already provided by setupTestDB
@@ -110,7 +110,7 @@ func TestSaveNewAccount_InitialVersion(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	// ctx already provided by setupTestDB
@@ -133,7 +133,7 @@ func TestSaveUpdateExisting(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	// ctx already provided by setupTestDB
@@ -191,7 +191,7 @@ func TestFindByIBAN(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	// ctx already provided by setupTestDB
@@ -226,9 +226,9 @@ func TestFindByPartyID(t *testing.T) {
 	iban1 := "GB82WEST12345698765432"
 	iban2 := "GB82WEST98765432123456"
 
-	account1, err := domain.NewCurrentAccount(accountID1, iban1, partyID, "GBP")
+	account1, err := domain.NewCurrentAccountWithDimension(accountID1, iban1, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
-	account2, err := domain.NewCurrentAccount(accountID2, iban2, partyID, "EUR")
+	account2, err := domain.NewCurrentAccountWithDimension(accountID2, iban2, partyID, "EUR", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	// ctx already provided by setupTestDB
@@ -258,7 +258,7 @@ func TestDeleteAccount(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	// ctx already provided by setupTestDB
@@ -290,7 +290,7 @@ func TestOptimisticLocking(t *testing.T) {
 	// ctx already provided by setupTestDB
 
 	// Create initial account
-	account1, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP")
+	account1, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 	if err := repo.Save(ctx, account1); err != nil {
 		t.Fatalf("Initial save failed: %v", err)
@@ -354,7 +354,7 @@ func TestSave_InstrumentCodeAndDimensionRoundTrip(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "EUR")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "EUR", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	err = repo.Save(ctx, account)
@@ -376,7 +376,7 @@ func TestSave_InstrumentCodePersistedOnEntity(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	err = repo.Save(ctx, account)
@@ -525,7 +525,7 @@ func TestSave_PopulatesAuditFieldsFromContext(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	// Create context with authenticated user AND tenant (tenant required for multi-tenant operations)
@@ -554,7 +554,7 @@ func TestSave_UsesSystemWhenNoUserInContext(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	// Use empty context (no user)
@@ -582,7 +582,7 @@ func TestSave_UpdatePreservesCreatedByButUpdatesUpdatedBy(t *testing.T) {
 	accountID := "ACC-" + uuid.New().String()[:8]
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(accountID, iban, partyID, "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, iban, partyID, "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	// Create with user1 (ctx already has tenant from setupTestDB)

--- a/services/current-account/domain/account.go
+++ b/services/current-account/domain/account.go
@@ -3,14 +3,12 @@ package domain
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/meridianhub/meridian/shared/platform/quantity"
-	"github.com/meridianhub/meridian/shared/platform/quantity/currency"
 )
 
 // Domain errors
@@ -24,7 +22,6 @@ var (
 	ErrNonZeroBalance          = errors.New("account balance must be zero to close")
 	ErrActiveLiens             = errors.New("account has active liens and cannot be closed")
 	ErrOrgScopedWithoutParty   = errors.New("org-scoped account requires a party ID")
-	ErrPrecisionMismatch       = errors.New("precision mismatch for currency instrument")
 )
 
 // AccountStatus represents the lifecycle state of an account
@@ -112,42 +109,22 @@ func WithBehaviorClass(behaviorClass string) AccountOption {
 // Returns a value type (not pointer) following immutability principles.
 // Use WithOrgPartyID option to create an org-scoped account.
 //
-// instrumentCode must be a recognized ISO 4217 currency code (e.g. "GBP").
-// Precision is derived automatically from the currency registry.
-// Dimension defaults to "CURRENCY". Use NewCurrentAccountWithDimension for explicit dimensions.
+// instrumentCode must be a valid instrument code (e.g. "GBP", "KWH").
+// Dimension defaults to "CURRENCY" and precision to 2.
+// Use NewCurrentAccountWithDimension for explicit dimension and precision control.
+//
+// Deprecated: Prefer NewCurrentAccountWithDimension with caller-provided dimension and precision
+// resolved from Reference Data. This constructor assumes CURRENCY dimension with precision 2.
 func NewCurrentAccount(accountID, externalIdentifier, partyID, instrumentCode string, opts ...AccountOption) (CurrentAccount, error) {
-	inst, ok := currency.ByCode(strings.ToUpper(instrumentCode))
-	if !ok {
-		return CurrentAccount{}, fmt.Errorf("%w: %s", ErrInvalidCurrency, instrumentCode)
-	}
-	return NewCurrentAccountWithDimension(accountID, externalIdentifier, partyID, instrumentCode, quantity.DimensionCurrency, inst.Precision, opts...)
+	return NewCurrentAccountWithDimension(accountID, externalIdentifier, partyID, instrumentCode, quantity.DimensionCurrency, 2, opts...)
 }
 
 // NewCurrentAccountWithDimension creates a new current account with explicit instrument code,
-// dimension, and precision.
-//
-// For CURRENCY dimension, precision is validated against the currency registry: the caller-supplied
-// precision must match the canonical precision for the currency (e.g. GBP=2, JPY=0). A mismatch
-// returns ErrPrecisionMismatch.
-//
-// For non-CURRENCY dimensions, precision is trusted as provided by the caller (validated at the
-// API boundary by the gRPC service layer using Reference Data).
+// dimension, and precision. All properties are trusted as provided by the caller - the gRPC
+// service layer validates them against Reference Data before calling this constructor.
 func NewCurrentAccountWithDimension(accountID, externalIdentifier, partyID, instrumentCode, dimension string, precision int, opts ...AccountOption) (CurrentAccount, error) {
 	now := time.Now()
 	normalizedDimension := strings.ToUpper(dimension)
-
-	// For CURRENCY, validate precision against canonical registry value.
-	// If the currency code is not in the local registry (e.g. a currency only defined in
-	// the Reference Data service), precision validation is deferred: NewAmountFromInstrument
-	// will return ErrInvalidCurrency if the code is genuinely unknown.
-	if normalizedDimension == quantity.DimensionCurrency {
-		if inst, ok := currency.ByCode(strings.ToUpper(instrumentCode)); ok {
-			if inst.Precision != precision {
-				return CurrentAccount{}, fmt.Errorf("%w: currency %s requires precision %d, got %d",
-					ErrPrecisionMismatch, strings.ToUpper(instrumentCode), inst.Precision, precision)
-			}
-		}
-	}
 
 	zeroAmount, err := NewAmountFromInstrument(instrumentCode, normalizedDimension, precision, 0)
 	if err != nil {

--- a/services/current-account/domain/account_test.go
+++ b/services/current-account/domain/account_test.go
@@ -1358,28 +1358,32 @@ func TestNewCurrentAccountWithDimension_CURRENCY_CorrectPrecision_Succeeds(t *te
 	}
 }
 
-func TestNewCurrentAccountWithDimension_CURRENCY_PrecisionMismatch_ReturnsError(t *testing.T) {
+func TestNewCurrentAccountWithDimension_CURRENCY_PrecisionFromCallerAccepted(t *testing.T) {
+	// Domain trusts caller-provided precision. For CURRENCY dimension, the underlying
+	// Amount package uses the canonical registry precision regardless of caller input.
 	tests := []struct {
 		name      string
 		currency  string
 		precision int
 	}{
-		{"GBP with precision 3 (expected 2)", "GBP", 3},
-		{"JPY with precision 2 (expected 0)", "JPY", 2},
-		{"USD with precision 0 (expected 2)", "USD", 0},
+		{"GBP with precision 3 (registry overrides to 2)", "GBP", 3},
+		{"JPY with precision 2 (registry overrides to 0)", "JPY", 2},
+		{"USD with precision 0 (registry overrides to 2)", "USD", 0},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewCurrentAccountWithDimension("ACC-001", "IDENT-001", "PARTY-001", tt.currency, "CURRENCY", tt.precision)
-			require.Error(t, err)
-			assert.ErrorIs(t, err, ErrPrecisionMismatch)
+			account, err := NewCurrentAccountWithDimension("ACC-001", "IDENT-001", "PARTY-001", tt.currency, "CURRENCY", tt.precision)
+			require.NoError(t, err, "domain should accept caller precision without validation")
+			assert.Equal(t, tt.currency, account.InstrumentCode())
+			assert.Equal(t, "CURRENCY", account.Dimension())
 		})
 	}
 }
 
-func TestNewCurrentAccount_DerivesCorrectPrecision(t *testing.T) {
-	// NewCurrentAccount derives precision from the currency registry automatically.
+func TestNewCurrentAccount_DefaultsCurrencyDimension(t *testing.T) {
+	// NewCurrentAccount defaults to CURRENCY dimension with precision 2.
+	// The underlying Amount package resolves canonical precision from the currency registry.
 	tests := []struct {
 		currency string
 	}{
@@ -1398,8 +1402,9 @@ func TestNewCurrentAccount_DerivesCorrectPrecision(t *testing.T) {
 	}
 }
 
-func TestNewCurrentAccount_InvalidCurrency_StillReturnsError(t *testing.T) {
+func TestNewCurrentAccount_UnknownCurrencyCode_StillReturnsError(t *testing.T) {
+	// NewCurrentAccount delegates to NewAmountFromInstrument which validates
+	// currency codes against the registry for CURRENCY dimension.
 	_, err := NewCurrentAccount("ACC-001", "IDENT-001", "PARTY-001", "INVALID")
 	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrInvalidCurrency)
 }

--- a/services/current-account/service/account_control_integration_test.go
+++ b/services/current-account/service/account_control_integration_test.go
@@ -122,7 +122,7 @@ func setupControlTestDB(t *testing.T) (*persistence.Repository, *persistence.Lie
 // createTestAccountForControl creates a test account with a unique ID for control tests.
 func createTestAccountForControl(t *testing.T, ctx context.Context, repo *persistence.Repository, accountID string) domain.CurrentAccount {
 	t.Helper()
-	account, err := domain.NewCurrentAccount(accountID, accountID, uuid.New().String(), "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, accountID, uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err, "Failed to create test account")
 	require.NoError(t, repo.Save(ctx, account), "Failed to save test account")
 	return account

--- a/services/current-account/service/grpc_account_endpoints.go
+++ b/services/current-account/service/grpc_account_endpoints.go
@@ -17,7 +17,6 @@ import (
 	celutil "github.com/meridianhub/meridian/services/reference-data/cel"
 	"github.com/meridianhub/meridian/services/reference-data/registry"
 	vf "github.com/meridianhub/meridian/shared/pkg/valuationfeature"
-	"github.com/meridianhub/meridian/shared/platform/quantity/currency"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -46,48 +45,41 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 		return nil, status.Errorf(codes.InvalidArgument, "instrument_code is required")
 	}
 
-	// Resolve dimension and precision from Reference Data service when available.
+	// Resolve dimension and precision from Reference Data service.
 	// Dimension classifies the instrument type (e.g. "CURRENCY", "ENERGY", "COMPUTE").
-	// When the getter is not configured, falls back to CURRENCY with precision derived
-	// from the currency registry (so JPY/0-decimal currencies work correctly in the fallback path).
-	dimension := "CURRENCY"
-	precision := 2 // safe default, overridden below
-	if s.instrumentGetter != nil {
-		cachedInstrument, err := s.instrumentGetter.GetInstrument(ctx, instrumentCode, 0)
-		if err != nil {
-			if errors.Is(err, registry.ErrNotFound) {
-				// Instrument does not exist in Reference Data - caller supplied an invalid instrument_code
-				operationStatus = "instrument_not_found"
-				s.logger.Warn("instrument not found in Reference Data, cannot create account",
-					"instrument_code", instrumentCode,
-					"account_id", accountID)
-				return nil, status.Errorf(codes.InvalidArgument, "unknown instrument_code: %s", instrumentCode)
-			}
-			// Transient failure (network error, service unavailable, timeout)
-			operationStatus = "instrument_lookup_failed"
-			s.logger.Error("instrument lookup failed due to transient error, cannot create account",
-				"instrument_code", instrumentCode,
-				"account_id", accountID,
-				"error", err)
-			caobservability.RecordExternalServiceError("reference_data", "get_instrument")
-			return nil, status.Errorf(codes.Unavailable, "instrument lookup failed, please retry")
-		}
-		// Map from reference-data registry dimension ("MONETARY") to domain quantity
-		// dimension ("CURRENCY"). The registry uses "MONETARY" while the domain quantity
-		// package uses "CURRENCY" - other dimensions are identical across both packages.
-		dimension = mapRegistryDimension(string(cachedInstrument.Definition.Dimension))
-		precision = cachedInstrument.Definition.Precision
-	} else {
-		// Fallback path: no Reference Data service configured.
-		// Derive precision from the currency registry for correctness (e.g. JPY needs 0, not 2).
-		if inst, ok := currency.ByCode(strings.ToUpper(instrumentCode)); ok {
-			precision = inst.Precision
-		} else {
-			s.logger.Warn("currency not found in local registry, using default precision",
-				"instrument_code", instrumentCode,
-				"default_precision", precision)
-		}
+	// Reference Data is required - fail closed if unavailable.
+	if s.instrumentGetter == nil {
+		operationStatus = "reference_data_unavailable"
+		s.logger.Error("instrumentGetter not configured, cannot create account",
+			"instrument_code", instrumentCode,
+			"account_id", accountID)
+		return nil, status.Errorf(codes.FailedPrecondition, "Reference Data service is required for account creation")
 	}
+
+	cachedInstrument, err := s.instrumentGetter.GetInstrument(ctx, instrumentCode, 0)
+	if err != nil {
+		if errors.Is(err, registry.ErrNotFound) {
+			// Instrument does not exist in Reference Data - caller supplied an invalid instrument_code
+			operationStatus = "instrument_not_found"
+			s.logger.Warn("instrument not found in Reference Data, cannot create account",
+				"instrument_code", instrumentCode,
+				"account_id", accountID)
+			return nil, status.Errorf(codes.InvalidArgument, "unknown instrument_code: %s", instrumentCode)
+		}
+		// Transient failure (network error, service unavailable, timeout)
+		operationStatus = "instrument_lookup_failed"
+		s.logger.Error("instrument lookup failed due to transient error, cannot create account",
+			"instrument_code", instrumentCode,
+			"account_id", accountID,
+			"error", err)
+		caobservability.RecordExternalServiceError("reference_data", "get_instrument")
+		return nil, status.Errorf(codes.Unavailable, "instrument lookup failed, please retry")
+	}
+	// Map from reference-data registry dimension ("MONETARY") to domain quantity
+	// dimension ("CURRENCY"). The registry uses "MONETARY" while the domain quantity
+	// package uses "CURRENCY" - other dimensions are identical across both packages.
+	dimension := mapRegistryDimension(string(cachedInstrument.Definition.Dimension))
+	precision := cachedInstrument.Definition.Precision
 
 	// Validate party exists and is active (if party client is configured)
 	if s.partyClient != nil {

--- a/services/current-account/service/grpc_refdata_resolution_test.go
+++ b/services/current-account/service/grpc_refdata_resolution_test.go
@@ -1,0 +1,160 @@
+package service
+
+// Integration tests for Reference Data resolution during account creation.
+// Validates that InitiateCurrentAccount resolves instrument properties (dimension, precision)
+// from the InstrumentGetter (Reference Data service) and rejects unknown instruments.
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
+	"github.com/meridianhub/meridian/services/reference-data/cache"
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestInitiateCurrentAccount_RefDataResolution_CurrencyGBP validates account creation
+// with a CURRENCY instrument resolved from Reference Data.
+func TestInitiateCurrentAccount_RefDataResolution_CurrencyGBP(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	svc := mustNewService(t, repo, nil)
+
+	req := &pb.InitiateCurrentAccountRequest{
+		ExternalIdentifier: "GB82WEST12345698765432",
+		PartyId:            uuid.New().String(),
+		InstrumentCode:     "GBP",
+	}
+
+	resp, err := svc.InitiateCurrentAccount(ctx, req)
+	require.NoError(t, err, "GBP account creation should succeed")
+	assert.NotEmpty(t, resp.AccountId)
+	assert.Equal(t, "GBP", resp.Facility.InstrumentCode)
+
+	// Verify persisted account has correct dimension
+	account, err := repo.FindByID(ctx, resp.AccountId)
+	require.NoError(t, err)
+	assert.Equal(t, "GBP", account.InstrumentCode())
+	assert.Equal(t, "CURRENCY", account.Dimension())
+	assert.Equal(t, 2, account.Balance().Precision(), "GBP should have precision 2")
+}
+
+// TestInitiateCurrentAccount_RefDataResolution_EnergyKWH validates account creation
+// with an ENERGY instrument resolved from Reference Data with precision 6.
+func TestInitiateCurrentAccount_RefDataResolution_EnergyKWH(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	svc := mustNewService(t, repo, nil)
+
+	// The defaultInstrumentGetter provides KWH with ENERGY dimension and precision 6
+	req := &pb.InitiateCurrentAccountRequest{
+		ExternalIdentifier: "KWH-IDENT-001",
+		PartyId:            uuid.New().String(),
+		InstrumentCode:     "KWH",
+	}
+
+	resp, err := svc.InitiateCurrentAccount(ctx, req)
+	require.NoError(t, err, "KWH account creation should succeed")
+	assert.NotEmpty(t, resp.AccountId)
+
+	// Verify persisted account has correct energy dimension and precision
+	account, err := repo.FindByID(ctx, resp.AccountId)
+	require.NoError(t, err)
+	assert.Equal(t, "KWH", account.InstrumentCode())
+	assert.Equal(t, "ENERGY", account.Dimension())
+	assert.Equal(t, 6, account.Balance().Precision(), "KWH should have precision 6")
+}
+
+// TestInitiateCurrentAccount_RefDataResolution_UnknownInstrument validates that
+// account creation fails with InvalidArgument for instruments not in Reference Data.
+func TestInitiateCurrentAccount_RefDataResolution_UnknownInstrument(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	svc := mustNewService(t, repo, nil)
+
+	req := &pb.InitiateCurrentAccountRequest{
+		ExternalIdentifier: "UNKNOWN-IDENT-001",
+		PartyId:            uuid.New().String(),
+		InstrumentCode:     "IMAGINARY_COIN",
+	}
+
+	_, err := svc.InitiateCurrentAccount(ctx, req)
+	require.Error(t, err, "unknown instrument should be rejected")
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code(), "unknown instrument should return InvalidArgument")
+	assert.Contains(t, st.Message(), "unknown instrument_code")
+}
+
+// TestInitiateCurrentAccount_RefDataResolution_NoInstrumentGetter validates that
+// account creation fails with FailedPrecondition when Reference Data is not configured.
+func TestInitiateCurrentAccount_RefDataResolution_NoInstrumentGetter(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	svc, err := NewService(repo, nil)
+	require.NoError(t, err)
+	// Deliberately do NOT set instrumentGetter
+
+	req := &pb.InitiateCurrentAccountRequest{
+		ExternalIdentifier: "GB82WEST12345698765432",
+		PartyId:            uuid.New().String(),
+		InstrumentCode:     "GBP",
+	}
+
+	_, err = svc.InitiateCurrentAccount(ctx, req)
+	require.Error(t, err, "should fail without instrumentGetter")
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code(), "missing Reference Data should return FailedPrecondition")
+	assert.Contains(t, st.Message(), "Reference Data")
+}
+
+// TestInitiateCurrentAccount_RefDataResolution_CustomPrecision validates that
+// custom precision from Reference Data is correctly propagated to the account.
+func TestInitiateCurrentAccount_RefDataResolution_CustomPrecision(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	svc := mustNewService(t, repo, nil)
+
+	// Override the default instrument getter with one that includes CARBON_CREDIT
+	svc.instrumentGetter = &mockInstrumentGetter{
+		instruments: map[string]*cache.CachedInstrument{
+			"CARBON_CREDIT": {Definition: &registry.InstrumentDefinition{
+				Code: "CARBON_CREDIT", Dimension: registry.DimensionCarbon, Precision: 4, Version: 1,
+			}},
+		},
+	}
+
+	req := &pb.InitiateCurrentAccountRequest{
+		ExternalIdentifier: "CC-IDENT-001",
+		PartyId:            uuid.New().String(),
+		InstrumentCode:     "CARBON_CREDIT",
+	}
+
+	resp, err := svc.InitiateCurrentAccount(ctx, req)
+	require.NoError(t, err, "CARBON_CREDIT account creation should succeed")
+
+	// Verify persisted account has correct carbon dimension and precision
+	account, err := repo.FindByID(ctx, resp.AccountId)
+	require.NoError(t, err)
+	assert.Equal(t, "CARBON_CREDIT", account.InstrumentCode())
+	assert.Equal(t, "CARBON", account.Dimension())
+	assert.Equal(t, 4, account.Balance().Precision(), "CARBON_CREDIT should have precision 4")
+}

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -146,8 +146,8 @@ type AccountTypeCache interface {
 type Option func(*Service)
 
 // WithInstrumentGetter sets the instrument getter for dimension resolution from Reference Data.
-// When set, the service resolves the account dimension from the instrument_code during account creation.
-// When nil, dimension defaults to CURRENCY (backward-compatible behavior).
+// The service resolves the account dimension and precision from the instrument_code during account creation.
+// Required: account creation will fail with FailedPrecondition if not configured.
 func WithInstrumentGetter(getter InstrumentGetter) Option {
 	return func(s *Service) {
 		s.instrumentGetter = getter
@@ -210,7 +210,7 @@ type Service struct {
 	posKeepingClient       PositionKeepingClient
 	finAcctClient          FinancialAccountingClient
 	partyClient            PartyClient
-	instrumentGetter       InstrumentGetter // Optional: resolves dimension from instrument_code via Reference Data
+	instrumentGetter       InstrumentGetter // Required for account creation: resolves dimension and precision from instrument_code via Reference Data
 	accountTypeCache       AccountTypeCache // Optional: resolves product type definitions
 	valuationEngine        ValuationEngine  // Optional: executes valuation method logic
 	accountConfig          *config.AccountConfig

--- a/services/current-account/service/grpc_service_integration_test.go
+++ b/services/current-account/service/grpc_service_integration_test.go
@@ -458,7 +458,7 @@ func createTestAccount(t *testing.T, ctx context.Context, repo *persistence.Repo
 	t.Helper()
 	// Use accountID as AccountIdentification (stored in account_number column) for lookup compatibility.
 	// The repository's FindByID searches by account_number, so AccountIdentification must match the lookup key.
-	account, err := domain.NewCurrentAccount(accountID, accountID, uuid.New().String(), "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, accountID, uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err, "Failed to create test account")
 	require.NoError(t, repo.Save(ctx, account), "Failed to save test account")
 	return account

--- a/services/current-account/service/grpc_service_party_integration_test.go
+++ b/services/current-account/service/grpc_service_party_integration_test.go
@@ -194,9 +194,10 @@ func TestInitiateCurrentAccount_WithPartyValidation_Success(t *testing.T) {
 
 	// Create service with party client
 	svc := &Service{
-		repo:        repo,
-		partyClient: mockParty,
-		logger:      slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		repo:             repo,
+		partyClient:      mockParty,
+		instrumentGetter: defaultInstrumentGetter(),
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 
 	// Execute account creation with valid UUID party ID
@@ -237,9 +238,10 @@ func TestInitiateCurrentAccount_PartyNotFound(t *testing.T) {
 	}
 
 	svc := &Service{
-		repo:        repo,
-		partyClient: mockParty,
-		logger:      slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		repo:             repo,
+		partyClient:      mockParty,
+		instrumentGetter: defaultInstrumentGetter(),
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 
 	// Execute account creation with valid UUID party ID (even though party doesn't exist)
@@ -303,9 +305,10 @@ func TestInitiateCurrentAccount_InactiveParty(t *testing.T) {
 			}
 
 			svc := &Service{
-				repo:        repo,
-				partyClient: mockParty,
-				logger:      slog.New(slog.NewTextHandler(os.Stdout, nil)),
+				repo:             repo,
+				partyClient:      mockParty,
+				instrumentGetter: defaultInstrumentGetter(),
+				logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 			}
 
 			// Execute account creation with valid UUID party ID
@@ -348,9 +351,10 @@ func TestInitiateCurrentAccount_PartyServiceUnavailable(t *testing.T) {
 	}
 
 	svc := &Service{
-		repo:        repo,
-		partyClient: mockParty,
-		logger:      slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		repo:             repo,
+		partyClient:      mockParty,
+		instrumentGetter: defaultInstrumentGetter(),
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 
 	// Execute account creation with valid UUID party ID
@@ -392,9 +396,10 @@ func TestInitiateCurrentAccount_PartyServiceTimeout(t *testing.T) {
 	}
 
 	svc := &Service{
-		repo:        repo,
-		partyClient: mockParty,
-		logger:      slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		repo:             repo,
+		partyClient:      mockParty,
+		instrumentGetter: defaultInstrumentGetter(),
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 
 	// Create context with short timeout, preserving tenant from baseCtx
@@ -433,9 +438,10 @@ func TestInitiateCurrentAccount_ConcurrentCreationSameParty(t *testing.T) {
 	}
 
 	svc := &Service{
-		repo:        repo,
-		partyClient: mockParty,
-		logger:      slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		repo:             repo,
+		partyClient:      mockParty,
+		instrumentGetter: defaultInstrumentGetter(),
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 
 	// Create multiple accounts concurrently for the same party
@@ -487,9 +493,10 @@ func TestInitiateCurrentAccount_PartyValidationCalledBeforeAccountCreation(t *te
 	}
 
 	svc := &Service{
-		repo:        repo,
-		partyClient: mockParty,
-		logger:      slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		repo:             repo,
+		partyClient:      mockParty,
+		instrumentGetter: defaultInstrumentGetter(),
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 
 	// Execute account creation (will fail)
@@ -572,9 +579,10 @@ func TestInitiateCurrentAccount_TableDriven(t *testing.T) {
 			}
 
 			svc := &Service{
-				repo:        repo,
-				partyClient: mockParty,
-				logger:      slog.New(slog.NewTextHandler(os.Stdout, nil)),
+				repo:             repo,
+				partyClient:      mockParty,
+				instrumentGetter: defaultInstrumentGetter(),
+				logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 			}
 
 			// Execute with valid UUID party ID

--- a/services/current-account/service/grpc_service_product_type_test.go
+++ b/services/current-account/service/grpc_service_product_type_test.go
@@ -162,6 +162,7 @@ func TestInitiateCurrentAccount_WithProductType_Success(t *testing.T) {
 	svc := &Service{
 		repo:             repo,
 		partyClient:      mockParty,
+		instrumentGetter: defaultInstrumentGetter(),
 		accountTypeCache: cache,
 		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
@@ -205,6 +206,7 @@ func TestInitiateCurrentAccount_WithProductType_VersionOverride(t *testing.T) {
 	svc := &Service{
 		repo:             repo,
 		partyClient:      mockParty,
+		instrumentGetter: defaultInstrumentGetter(),
 		accountTypeCache: cache,
 		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
@@ -243,6 +245,7 @@ func TestInitiateCurrentAccount_WithProductType_NotFound(t *testing.T) {
 	svc := &Service{
 		repo:             repo,
 		partyClient:      mockParty,
+		instrumentGetter: defaultInstrumentGetter(),
 		accountTypeCache: cache,
 		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
@@ -298,6 +301,7 @@ func TestInitiateCurrentAccount_WithProductType_NonCustomerBehaviorClass(t *test
 			svc := &Service{
 				repo:             repo,
 				partyClient:      mockParty,
+				instrumentGetter: defaultInstrumentGetter(),
 				accountTypeCache: cache,
 				logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 			}
@@ -355,6 +359,7 @@ func TestInitiateCurrentAccount_WithProductType_CELEligibility(t *testing.T) {
 			repo:             repo,
 			partyClient:      mockParty,
 			accountTypeCache: cache,
+			instrumentGetter: defaultInstrumentGetter(),
 			logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 		}
 
@@ -402,6 +407,7 @@ func TestInitiateCurrentAccount_WithProductType_CELEligibility(t *testing.T) {
 			repo:             repo,
 			partyClient:      mockParty,
 			accountTypeCache: cache,
+			instrumentGetter: defaultInstrumentGetter(),
 			logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 		}
 
@@ -448,6 +454,7 @@ func TestInitiateCurrentAccount_WithProductType_EligibilityRequiresPartyClient(t
 		repo:             repo,
 		partyClient:      nil, // No party client configured
 		accountTypeCache: cache,
+		instrumentGetter: defaultInstrumentGetter(),
 		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 
@@ -491,6 +498,7 @@ func TestInitiateCurrentAccount_WithProductType_VersionExceedsLatest(t *testing.
 	svc := &Service{
 		repo:             repo,
 		partyClient:      mockParty,
+		instrumentGetter: defaultInstrumentGetter(),
 		accountTypeCache: cache,
 		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
@@ -555,6 +563,7 @@ func TestInitiateCurrentAccount_WithProductType_AttributeValidation(t *testing.T
 			repo:             repo,
 			partyClient:      mockParty,
 			accountTypeCache: cache,
+			instrumentGetter: defaultInstrumentGetter(),
 			logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 		}
 
@@ -599,6 +608,7 @@ func TestInitiateCurrentAccount_WithProductType_AttributeValidation(t *testing.T
 			repo:             repo,
 			partyClient:      mockParty,
 			accountTypeCache: cache,
+			instrumentGetter: defaultInstrumentGetter(),
 			logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 		}
 
@@ -647,6 +657,7 @@ func TestInitiateCurrentAccount_WithProductType_AttributeValidation(t *testing.T
 			repo:             repo,
 			partyClient:      mockParty,
 			accountTypeCache: cache,
+			instrumentGetter: defaultInstrumentGetter(),
 			logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 		}
 
@@ -713,6 +724,7 @@ func TestInitiateCurrentAccount_WithProductType_ValuationFeatureSeeding(t *testi
 	svc := &Service{
 		repo:                 repo,
 		partyClient:          mockParty,
+		instrumentGetter:     defaultInstrumentGetter(),
 		accountTypeCache:     cache,
 		valuationFeatureRepo: vfRepo,
 		logger:               slog.New(slog.NewTextHandler(os.Stdout, nil)),
@@ -767,9 +779,10 @@ func TestInitiateCurrentAccount_BackwardsCompatibility(t *testing.T) {
 	}
 
 	svc := &Service{
-		repo:        repo,
-		partyClient: mockParty,
-		logger:      slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		repo:             repo,
+		partyClient:      mockParty,
+		instrumentGetter: defaultInstrumentGetter(),
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 
 	// No product_type_code - legacy behavior
@@ -805,7 +818,8 @@ func TestInitiateCurrentAccount_WithProductType_NoCacheConfigured(t *testing.T) 
 		repo:        repo,
 		partyClient: mockParty,
 		// accountTypeCache is nil - not configured
-		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		instrumentGetter: defaultInstrumentGetter(),
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 
 	req := &pb.InitiateCurrentAccountRequest{
@@ -839,6 +853,7 @@ func TestInitiateCurrentAccount_WithProductType_MissingTenantContext(t *testing.
 
 	svc := &Service{
 		repo:             repo,
+		instrumentGetter: defaultInstrumentGetter(),
 		accountTypeCache: cache,
 		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
@@ -879,6 +894,7 @@ func TestInitiateCurrentAccount_WithProductType_CacheError(t *testing.T) {
 	svc := &Service{
 		repo:             repo,
 		partyClient:      mockParty,
+		instrumentGetter: defaultInstrumentGetter(),
 		accountTypeCache: cache,
 		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
@@ -922,6 +938,7 @@ func TestInitiateCurrentAccount_WithProductType_BehaviorClassPersisted(t *testin
 	svc := &Service{
 		repo:             repo,
 		partyClient:      mockParty,
+		instrumentGetter: defaultInstrumentGetter(),
 		accountTypeCache: cache,
 		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
@@ -960,9 +977,10 @@ func TestInitiateCurrentAccount_BackwardsCompatibility_NoBehaviorClass(t *testin
 	}
 
 	svc := &Service{
-		repo:        repo,
-		partyClient: mockParty,
-		logger:      slog.New(slog.NewTextHandler(os.Stdout, nil)),
+		repo:             repo,
+		partyClient:      mockParty,
+		instrumentGetter: defaultInstrumentGetter(),
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 
 	req := &pb.InitiateCurrentAccountRequest{

--- a/services/current-account/service/grpc_service_test.go
+++ b/services/current-account/service/grpc_service_test.go
@@ -18,6 +18,8 @@ import (
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/domain"
+	"github.com/meridianhub/meridian/services/reference-data/cache"
+	"github.com/meridianhub/meridian/services/reference-data/registry"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
@@ -84,8 +86,33 @@ func testSagaRunner(t *testing.T) (*saga.StarlarkSagaRunner, string, string) {
 	return sagaRunner, depositScript, withdrawalScript
 }
 
-// injectMandatoryClients sets up mock Position Keeping and Financial Accounting clients with orchestrators.
-// Position Keeping and orchestration are now mandatory for all deposit/withdrawal operations.
+// defaultInstrumentGetter returns a mock InstrumentGetter pre-populated with common instruments.
+// Tests that need custom instruments can create their own mockInstrumentGetter instead.
+func defaultInstrumentGetter() *mockInstrumentGetter {
+	return &mockInstrumentGetter{
+		instruments: map[string]*cache.CachedInstrument{
+			"GBP": {Definition: &registry.InstrumentDefinition{
+				Code: "GBP", Dimension: registry.DimensionMonetary, Precision: 2, Version: 1,
+			}},
+			"USD": {Definition: &registry.InstrumentDefinition{
+				Code: "USD", Dimension: registry.DimensionMonetary, Precision: 2, Version: 1,
+			}},
+			"EUR": {Definition: &registry.InstrumentDefinition{
+				Code: "EUR", Dimension: registry.DimensionMonetary, Precision: 2, Version: 1,
+			}},
+			"JPY": {Definition: &registry.InstrumentDefinition{
+				Code: "JPY", Dimension: registry.DimensionMonetary, Precision: 0, Version: 1,
+			}},
+			"KWH": {Definition: &registry.InstrumentDefinition{
+				Code: "KWH", Dimension: registry.DimensionEnergy, Precision: 6, Version: 1,
+			}},
+		},
+	}
+}
+
+// injectMandatoryClients sets up mock Position Keeping, Financial Accounting, and Reference Data
+// clients with orchestrators. Position Keeping and orchestration are now mandatory for all
+// deposit/withdrawal operations. Reference Data (instrumentGetter) is required for account creation.
 func injectMandatoryClients(t *testing.T, svc *Service, repo *persistence.Repository, accountBalances map[string]int64) {
 	t.Helper()
 	if accountBalances == nil {
@@ -96,6 +123,11 @@ func injectMandatoryClients(t *testing.T, svc *Service, repo *persistence.Reposi
 
 	svc.posKeepingClient = mockPosKeeping
 	svc.finAcctClient = mockFinAcct
+
+	// Reference Data instrumentGetter is required for account creation
+	if svc.instrumentGetter == nil {
+		svc.instrumentGetter = defaultInstrumentGetter()
+	}
 
 	// Create saga runner and load scripts
 	sagaRunner, depositScript, withdrawalScript := testSagaRunner(t)
@@ -378,7 +410,7 @@ func TestExecuteDeposit(t *testing.T) {
 	})
 
 	// Create account first
-	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
+	account, err := domain.NewCurrentAccountWithDimension("ACC-001", "ACC-001", uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 	if err := repo.Save(ctx, account); err != nil {
 		t.Fatalf("Failed to create test account: %v", err)
@@ -466,7 +498,7 @@ func TestExecuteDepositInvalidAmount(t *testing.T) {
 	svc := mustNewService(t, repo, nil)
 
 	// Create account first
-	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
+	account, err := domain.NewCurrentAccountWithDimension("ACC-001", "ACC-001", uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 	if err := repo.Save(ctx, account); err != nil {
 		t.Fatalf("Failed to create test account: %v", err)
@@ -510,7 +542,7 @@ func TestRetrieveCurrentAccount(t *testing.T) {
 	})
 
 	// Create account first
-	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
+	account, err := domain.NewCurrentAccountWithDimension("ACC-001", "ACC-001", uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 	if err := repo.Save(ctx, account); err != nil {
 		t.Fatalf("Failed to create test account: %v", err)
@@ -607,7 +639,7 @@ func TestExecuteDepositCurrencyMismatch(t *testing.T) {
 	svc := mustNewService(t, repo, nil)
 
 	// Create GBP account
-	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
+	account, err := domain.NewCurrentAccountWithDimension("ACC-001", "ACC-001", uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 	if err := repo.Save(ctx, account); err != nil {
 		t.Fatalf("Failed to create test account: %v", err)
@@ -746,7 +778,7 @@ func TestExecuteDeposit_OverflowPrevention_UnitsTooCents(t *testing.T) {
 	svc := mustNewService(t, repo, nil)
 
 	// Create account
-	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
+	account, err := domain.NewCurrentAccountWithDimension("ACC-001", "ACC-001", uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 	require.NoError(t, repo.Save(ctx, account))
 
@@ -811,7 +843,7 @@ func TestExecuteDeposit_SafeAddition_UnitsAndNanos(t *testing.T) {
 	svc := mustNewService(t, repo, nil)
 
 	// Create account
-	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
+	account, err := domain.NewCurrentAccountWithDimension("ACC-001", "ACC-001", uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 	require.NoError(t, repo.Save(ctx, account))
 
@@ -970,7 +1002,7 @@ func TestExecuteDeposit_IdempotencyReturnsCachedResponse(t *testing.T) {
 	svc := mustNewServiceWithIdempotency(t, repo, nil, mockIdemp)
 
 	// Create account
-	account, err := domain.NewCurrentAccount("ACC-IDEMP-001", "ACC-IDEMP-001", uuid.New().String(), "GBP")
+	account, err := domain.NewCurrentAccountWithDimension("ACC-IDEMP-001", "ACC-IDEMP-001", uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 	require.NoError(t, repo.Save(ctx, account))
 
@@ -1021,7 +1053,7 @@ func TestExecuteDeposit_IdempotencyReturnsAbortedWhenInProgress(t *testing.T) {
 	svc := mustNewServiceWithIdempotency(t, repo, nil, mockIdemp)
 
 	// Create account
-	account, err := domain.NewCurrentAccount("ACC-IDEMP-002", "ACC-IDEMP-002", uuid.New().String(), "GBP")
+	account, err := domain.NewCurrentAccountWithDimension("ACC-IDEMP-002", "ACC-IDEMP-002", uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 	require.NoError(t, repo.Save(ctx, account))
 
@@ -1067,7 +1099,7 @@ func TestExecuteDeposit_IdempotencyProceedsWithoutKey(t *testing.T) {
 	})
 
 	// Create account
-	account, err := domain.NewCurrentAccount("ACC-IDEMP-003", "ACC-IDEMP-003", uuid.New().String(), "GBP")
+	account, err := domain.NewCurrentAccountWithDimension("ACC-IDEMP-003", "ACC-IDEMP-003", uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 	require.NoError(t, repo.Save(ctx, account))
 
@@ -1095,7 +1127,7 @@ func TestExecuteDeposit_IdempotencyCleanupOnFailure(t *testing.T) {
 	svc := mustNewServiceWithIdempotency(t, repo, nil, mockIdemp)
 
 	// Create account but with wrong currency
-	account, err := domain.NewCurrentAccount("ACC-IDEMP-004", "ACC-IDEMP-004", uuid.New().String(), "GBP")
+	account, err := domain.NewCurrentAccountWithDimension("ACC-IDEMP-004", "ACC-IDEMP-004", uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 	require.NoError(t, repo.Save(ctx, account))
 
@@ -1153,11 +1185,11 @@ func TestListCurrentAccounts(t *testing.T) {
 		svc := mustNewService(t, repo, nil)
 
 		// Create two accounts
-		acc1, err := domain.NewCurrentAccount("ACC-001", "GB82WEST12345698765432", uuid.New().String(), "GBP")
+		acc1, err := domain.NewCurrentAccountWithDimension("ACC-001", "GB82WEST12345698765432", uuid.New().String(), "GBP", "CURRENCY", 2)
 		require.NoError(t, err)
 		require.NoError(t, repo.Save(ctx, acc1))
 
-		acc2, err := domain.NewCurrentAccount("ACC-002", "DE89370400440532013000", uuid.New().String(), "EUR")
+		acc2, err := domain.NewCurrentAccountWithDimension("ACC-002", "DE89370400440532013000", uuid.New().String(), "EUR", "CURRENCY", 2)
 		require.NoError(t, err)
 		require.NoError(t, repo.Save(ctx, acc2))
 
@@ -1175,12 +1207,12 @@ func TestListCurrentAccounts(t *testing.T) {
 		svc := mustNewService(t, repo, nil)
 
 		// Create an active account
-		acc1, err := domain.NewCurrentAccount("ACC-001", "GB82WEST12345698765432", uuid.New().String(), "GBP")
+		acc1, err := domain.NewCurrentAccountWithDimension("ACC-001", "GB82WEST12345698765432", uuid.New().String(), "GBP", "CURRENCY", 2)
 		require.NoError(t, err)
 		require.NoError(t, repo.Save(ctx, acc1))
 
 		// Create account and freeze it
-		acc2, err := domain.NewCurrentAccount("ACC-002", "DE89370400440532013000", uuid.New().String(), "EUR")
+		acc2, err := domain.NewCurrentAccountWithDimension("ACC-002", "DE89370400440532013000", uuid.New().String(), "EUR", "CURRENCY", 2)
 		require.NoError(t, err)
 		acc2, err = acc2.Freeze("test freeze")
 		require.NoError(t, err)
@@ -1202,11 +1234,11 @@ func TestListCurrentAccounts(t *testing.T) {
 		repo := persistence.NewRepository(db)
 		svc := mustNewService(t, repo, nil)
 
-		acc1, err := domain.NewCurrentAccount("ACC-001", "GB82WEST12345698765432", uuid.New().String(), "GBP")
+		acc1, err := domain.NewCurrentAccountWithDimension("ACC-001", "GB82WEST12345698765432", uuid.New().String(), "GBP", "CURRENCY", 2)
 		require.NoError(t, err)
 		require.NoError(t, repo.Save(ctx, acc1))
 
-		acc2, err := domain.NewCurrentAccount("ACC-002", "DE89370400440532013000", uuid.New().String(), "EUR")
+		acc2, err := domain.NewCurrentAccountWithDimension("ACC-002", "DE89370400440532013000", uuid.New().String(), "EUR", "CURRENCY", 2)
 		require.NoError(t, err)
 		require.NoError(t, repo.Save(ctx, acc2))
 
@@ -1229,7 +1261,7 @@ func TestListCurrentAccounts(t *testing.T) {
 		// Create 3 accounts
 		for i := 0; i < 3; i++ {
 			iban := fmt.Sprintf("GB%02dWEST1234569876543%d", 10+i, i)
-			acc, err := domain.NewCurrentAccount(fmt.Sprintf("ACC-%03d", i), iban, uuid.New().String(), "GBP")
+			acc, err := domain.NewCurrentAccountWithDimension(fmt.Sprintf("ACC-%03d", i), iban, uuid.New().String(), "GBP", "CURRENCY", 2)
 			require.NoError(t, err)
 			require.NoError(t, repo.Save(ctx, acc))
 			time.Sleep(2 * time.Millisecond) // ensure distinct created_at for cursor ordering

--- a/services/current-account/service/lien_service_test.go
+++ b/services/current-account/service/lien_service_test.go
@@ -82,7 +82,7 @@ func createTestAccountWithBalance(t *testing.T, ctx context.Context, repo *persi
 	t.Helper()
 	// Use accountID as AccountIdentification (stored in account_number column) for lookup compatibility.
 	// The repository's FindByID searches by account_number, so AccountIdentification must match the lookup key.
-	account, err := domain.NewCurrentAccount(accountID, accountID, uuid.New().String(), "GBP")
+	account, err := domain.NewCurrentAccountWithDimension(accountID, accountID, uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	if balanceCents > 0 {

--- a/services/current-account/service/withdrawal_test.go
+++ b/services/current-account/service/withdrawal_test.go
@@ -238,7 +238,7 @@ func TestExecuteWithdrawal_AccountFrozen(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	// Create account, deposit funds, then freeze it
-	account, err := domain.NewCurrentAccount("ACC-WTH-FROZEN", "ACC-WTH-FROZEN", uuid.New().String(), "GBP")
+	account, err := domain.NewCurrentAccountWithDimension("ACC-WTH-FROZEN", "ACC-WTH-FROZEN", uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	depositAmount, err := domain.NewMoney("GBP", 100000) // $1000
@@ -272,7 +272,7 @@ func TestExecuteWithdrawal_AccountClosed(t *testing.T) {
 	repo := persistence.NewRepository(db)
 	// Create account with zero balance and close it
 	// Per domain rules, accounts must have zero balance to close
-	account, err := domain.NewCurrentAccount("ACC-WTH-CLOSED", "ACC-WTH-CLOSED", uuid.New().String(), "GBP")
+	account, err := domain.NewCurrentAccountWithDimension("ACC-WTH-CLOSED", "ACC-WTH-CLOSED", uuid.New().String(), "GBP", "CURRENCY", 2)
 	require.NoError(t, err)
 
 	// Close the zero-balance account

--- a/tests/integration/balance_ownership_test.go
+++ b/tests/integration/balance_ownership_test.go
@@ -242,7 +242,7 @@ func NewMockCurrentAccountService() *MockCurrentAccountService {
 
 // CreateAccount creates a new account.
 func (m *MockCurrentAccountService) CreateAccount(ctx context.Context, accountID, iban, partyID, currency string) (cadomain.CurrentAccount, error) {
-	account, err := cadomain.NewCurrentAccount(accountID, iban, partyID, currency)
+	account, err := cadomain.NewCurrentAccountWithDimension(accountID, iban, partyID, currency, "CURRENCY", 2)
 	if err != nil {
 		return cadomain.CurrentAccount{}, err
 	}


### PR DESCRIPTION
## Summary

- Remove `currency.ByCode()` fallback from `InitiateCurrentAccount` -- instrumentGetter (Reference Data) is now required for all account creation
- Service returns `FailedPrecondition` when Reference Data is unavailable (fail-closed pattern)
- Domain layer trusts caller-provided dimension and precision from Reference Data, removing internal currency registry validation
- Replace all deprecated `NewCurrentAccount` calls with `NewCurrentAccountWithDimension` across service, persistence, and integration tests

## Task Master

Tag: `multi-asset-purity`, Task: 6 -- Migrate current-account Service to Reference Data Resolution

### Subtasks

| ID | Description | Status |
|----|-------------|--------|
| 6.1 | Remove `currency.ByCode()` fallback in `grpc_account_endpoints.go` | Done |
| 6.2 | Update `domain/account.go` to trust caller-provided instrument properties | Done |
| 6.3 | Verify persistence layer supports VARCHAR(32) instrument codes | Done (no changes needed) |
| 6.4 | Add integration tests with mock InstrumentResolver | Done |

## Changes

### Service layer (`grpc_account_endpoints.go`)
- `instrumentGetter == nil` now returns `codes.FailedPrecondition` instead of falling back to `currency.ByCode()`
- Removed `currency` import entirely

### Domain layer (`account.go`)
- `NewCurrentAccount` marked `Deprecated` -- delegates to `NewCurrentAccountWithDimension` with CURRENCY/2 defaults
- `NewCurrentAccountWithDimension` no longer validates precision against `currency.ByCode()` registry
- Removed `ErrPrecisionMismatch` error

### Test fixtures
- Added `defaultInstrumentGetter()` providing GBP, USD, EUR, JPY (MONETARY/2), KWH (ENERGY/6)
- `injectMandatoryClients()` auto-injects instrumentGetter when nil
- All `&Service{}` struct literals and `domain.NewCurrentAccount` calls updated

### New integration tests (`grpc_refdata_resolution_test.go`)
- GBP resolves to CURRENCY dimension with precision 2
- KWH resolves to ENERGY dimension with precision 6
- Unknown instrument returns `InvalidArgument`
- Missing instrumentGetter returns `FailedPrecondition`
- Custom CARBON_CREDIT instrument with precision 4

## Test plan

- [x] Domain tests pass
- [x] Service tests pass (4 pre-existing lien valuation failures unrelated to this change)
- [x] Persistence tests compile (pre-existing timeout issue)
- [x] golangci-lint clean (no deprecated call warnings)