### PR TITLE
feat: add event chain panel component

### DIFF
--- a/frontend/src/features/manifests/components/event-chain-panel.test.tsx
+++ b/frontend/src/features/manifests/components/event-chain-panel.test.tsx
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { EventChainPanel } from './event-chain-panel'
+import type { EventChain, EventHop } from '../lib/transitive-closure'
+
+function makeHop(overrides: Partial<EventHop> = {}): EventHop {
+  return {
+    depth: 1,
+    trigger: {
+      channel: 'position-keeping.transaction-captured.v1',
+      instrumentCode: 'GBP',
+      accountId: null,
+      direction: null,
+    },
+    saga: 'process-payment',
+    filterExpression: 'event.instrumentCode == "GBP"',
+    filterResult: 'pass',
+    filterReason: 'Instrument matches literal',
+    producedEvents: [
+      {
+        channel: 'position-keeping.transaction-captured.v1',
+        instrumentCode: 'USD',
+        accountId: 'fees',
+        direction: 'DEBIT',
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function makeChain(overrides: Partial<EventChain> = {}): EventChain {
+  return {
+    hops: [makeHop()],
+    terminationReason: 'no_matching_sagas',
+    maxDepthUsed: 1,
+    ...overrides,
+  }
+}
+
+describe('EventChainPanel', () => {
+  it('renders multi-hop chain with depth indicators', () => {
+    const chain = makeChain({
+      hops: [
+        makeHop({ depth: 1, saga: 'saga-a' }),
+        makeHop({ depth: 2, saga: 'saga-b' }),
+      ],
+      maxDepthUsed: 2,
+    })
+
+    render(<EventChainPanel chain={chain} startNodeLabel="GBP Instrument" />)
+
+    expect(screen.getByText('Event chain from GBP Instrument')).toBeDefined()
+    expect(screen.getByText('Depth: 2')).toBeDefined()
+    expect(screen.getByText('Hop 1')).toBeDefined()
+    expect(screen.getByText('Hop 2')).toBeDefined()
+  })
+
+  it('renders accordion items that expand on click', async () => {
+    const user = userEvent.setup()
+    const chain = makeChain()
+
+    render(<EventChainPanel chain={chain} startNodeLabel="GBP" />)
+
+    // Accordion content should not be visible initially
+    expect(screen.queryByText('Trigger:')).toBeNull()
+
+    // Click the accordion trigger to expand
+    const trigger = screen.getByText('process-payment')
+    await user.click(trigger.closest('[data-slot="accordion-trigger"]')!)
+
+    expect(screen.getByText('Trigger:')).toBeDefined()
+    expect(screen.getByText('Reason:')).toBeDefined()
+  })
+
+  it('shows pass filter badge with green styling', () => {
+    const chain = makeChain({
+      hops: [makeHop({ filterResult: 'pass' })],
+    })
+
+    render(<EventChainPanel chain={chain} startNodeLabel="GBP" />)
+
+    const badge = screen.getByTestId('filter-badge-pass')
+    expect(badge.textContent).toBe('pass')
+    expect(badge.className).toContain('bg-emerald-100')
+  })
+
+  it('shows fail filter badge with red styling', () => {
+    const chain = makeChain({
+      hops: [makeHop({ filterResult: 'fail' })],
+    })
+
+    render(<EventChainPanel chain={chain} startNodeLabel="GBP" />)
+
+    const badge = screen.getByTestId('filter-badge-fail')
+    expect(badge.textContent).toBe('fail')
+    expect(badge.className).toContain('bg-red-100')
+  })
+
+  it('shows indeterminate filter badge with amber styling', () => {
+    const chain = makeChain({
+      hops: [makeHop({ filterResult: 'indeterminate' })],
+    })
+
+    render(<EventChainPanel chain={chain} startNodeLabel="GBP" />)
+
+    const badge = screen.getByTestId('filter-badge-indeterminate')
+    expect(badge.textContent).toBe('indeterminate')
+    expect(badge.className).toContain('bg-amber-100')
+  })
+
+  it('displays termination reason for filter_rejection', () => {
+    const chain = makeChain({ terminationReason: 'filter_rejection' })
+
+    render(<EventChainPanel chain={chain} startNodeLabel="GBP" />)
+
+    const reason = screen.getByTestId('termination-reason')
+    expect(reason.textContent).toContain('all sagas filtered out')
+  })
+
+  it('displays termination reason for chain_depth_limit', () => {
+    const chain = makeChain({ terminationReason: 'chain_depth_limit' })
+
+    render(<EventChainPanel chain={chain} startNodeLabel="GBP" />)
+
+    const reason = screen.getByTestId('termination-reason')
+    expect(reason.textContent).toContain('maximum depth reached')
+  })
+
+  it('displays termination reason for no_matching_sagas', () => {
+    const chain = makeChain({ terminationReason: 'no_matching_sagas' })
+
+    render(<EventChainPanel chain={chain} startNodeLabel="GBP" />)
+
+    const reason = screen.getByTestId('termination-reason')
+    expect(reason.textContent).toContain('no matching sagas found')
+  })
+
+  it('fires onSagaClick when saga name is clicked', async () => {
+    const user = userEvent.setup()
+    const onSagaClick = vi.fn()
+    const chain = makeChain({
+      hops: [makeHop({ saga: 'my-saga' })],
+    })
+
+    render(
+      <EventChainPanel
+        chain={chain}
+        startNodeLabel="GBP"
+        onSagaClick={onSagaClick}
+      />,
+    )
+
+    await user.click(screen.getByTestId('saga-link-my-saga'))
+    expect(onSagaClick).toHaveBeenCalledWith('my-saga')
+  })
+
+  it('renders empty chain with message', () => {
+    const chain = makeChain({ hops: [], maxDepthUsed: 0 })
+
+    render(<EventChainPanel chain={chain} startNodeLabel="kWh" />)
+
+    expect(screen.getByText('No event chain from kWh.')).toBeDefined()
+  })
+
+  it('shows produced events in expanded accordion', async () => {
+    const user = userEvent.setup()
+    const chain = makeChain({
+      hops: [
+        makeHop({
+          producedEvents: [
+            {
+              channel: 'position-keeping.transaction-captured.v1',
+              instrumentCode: 'USD',
+              accountId: null,
+              direction: 'CREDIT',
+            },
+          ],
+        }),
+      ],
+    })
+
+    render(<EventChainPanel chain={chain} startNodeLabel="GBP" />)
+
+    // Expand accordion
+    const trigger = screen.getByText('process-payment')
+    await user.click(trigger.closest('[data-slot="accordion-trigger"]')!)
+
+    expect(screen.getByText('Produced events:')).toBeDefined()
+    expect(screen.getByText(/\[USD\].*\(CREDIT\)/)).toBeDefined()
+  })
+
+  it('shows saga diagram toggle button', async () => {
+    const user = userEvent.setup()
+    const chain = makeChain({
+      hops: [makeHop({ saga: 'test-saga' })],
+    })
+
+    render(<EventChainPanel chain={chain} startNodeLabel="GBP" />)
+
+    // Expand accordion first
+    const trigger = screen.getByText('test-saga')
+    await user.click(trigger.closest('[data-slot="accordion-trigger"]')!)
+
+    const toggleBtn = screen.getByTestId('saga-diagram-toggle-test-saga')
+    expect(toggleBtn.textContent).toBe('Show saga flow')
+
+    await user.click(toggleBtn)
+    expect(screen.getByTestId('saga-diagram-test-saga')).toBeDefined()
+    expect(toggleBtn.textContent).toBe('Hide saga flow')
+  })
+})

--- a/frontend/src/features/manifests/components/event-chain-panel.test.tsx
+++ b/frontend/src/features/manifests/components/event-chain-panel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { EventChainPanel } from './event-chain-panel'
 import type { EventChain, EventHop } from '../lib/transitive-closure'

--- a/frontend/src/features/manifests/components/event-chain-panel.test.tsx
+++ b/frontend/src/features/manifests/components/event-chain-panel.test.tsx
@@ -66,8 +66,8 @@ describe('EventChainPanel', () => {
     expect(screen.queryByText('Trigger:')).toBeNull()
 
     // Click the accordion trigger to expand
-    const trigger = screen.getByText('process-payment')
-    await user.click(trigger.closest('[data-slot="accordion-trigger"]')!)
+    const accordionTrigger = document.querySelector('[data-slot="accordion-trigger"]')!
+    await user.click(accordionTrigger)
 
     expect(screen.getByText('Trigger:')).toBeDefined()
     expect(screen.getByText('Reason:')).toBeDefined()
@@ -183,8 +183,8 @@ describe('EventChainPanel', () => {
     render(<EventChainPanel chain={chain} startNodeLabel="GBP" />)
 
     // Expand accordion
-    const trigger = screen.getByText('process-payment')
-    await user.click(trigger.closest('[data-slot="accordion-trigger"]')!)
+    const accordionTrigger = document.querySelector('[data-slot="accordion-trigger"]')!
+    await user.click(accordionTrigger)
 
     expect(screen.getByText('Produced events:')).toBeDefined()
     expect(screen.getByText(/\[USD\].*\(CREDIT\)/)).toBeDefined()
@@ -199,8 +199,8 @@ describe('EventChainPanel', () => {
     render(<EventChainPanel chain={chain} startNodeLabel="GBP" />)
 
     // Expand accordion first
-    const trigger = screen.getByText('test-saga')
-    await user.click(trigger.closest('[data-slot="accordion-trigger"]')!)
+    const accordionTrigger = document.querySelector('[data-slot="accordion-trigger"]')!
+    await user.click(accordionTrigger)
 
     const toggleBtn = screen.getByTestId('saga-diagram-toggle-test-saga')
     expect(toggleBtn.textContent).toBe('Show saga flow')

--- a/frontend/src/features/manifests/components/event-chain-panel.tsx
+++ b/frontend/src/features/manifests/components/event-chain-panel.tsx
@@ -151,7 +151,10 @@ function HopItem({ hop, index, onSagaClick }: HopItemProps) {
           {hop.filterResult}
         </Badge>
         <div className="ml-auto">
-          <AccordionTrigger className="py-0 text-sm hover:no-underline" />
+          <AccordionTrigger
+            aria-label={`Toggle details for ${hop.saga}`}
+            className="py-0 text-sm hover:no-underline"
+          />
         </div>
       </div>
       <AccordionContent>

--- a/frontend/src/features/manifests/components/event-chain-panel.tsx
+++ b/frontend/src/features/manifests/components/event-chain-panel.tsx
@@ -128,36 +128,32 @@ function HopItem({ hop, index, onSagaClick }: HopItemProps) {
 
   return (
     <AccordionItem value={`${hop.saga}-${index}`} className="border rounded-md px-3">
-      <AccordionTrigger className="py-2 text-sm hover:no-underline">
-        <div className="flex flex-1 items-center gap-2">
-          <span
-            role="link"
-            tabIndex={0}
-            className="font-medium text-sm hover:underline text-left cursor-pointer"
-            onClick={(e) => {
-              e.stopPropagation()
-              onSagaClick?.(hop.saga)
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.stopPropagation()
-                e.preventDefault()
-                onSagaClick?.(hop.saga)
-              }
-            }}
+      <div className="flex items-center gap-2 py-2">
+        {onSagaClick ? (
+          <button
+            type="button"
+            className="font-medium text-sm hover:underline text-left"
+            onClick={() => onSagaClick(hop.saga)}
             data-testid={`saga-link-${hop.saga}`}
           >
             {hop.saga}
+          </button>
+        ) : (
+          <span className="font-medium text-sm" data-testid={`saga-link-${hop.saga}`}>
+            {hop.saga}
           </span>
-          <Badge
-            variant="outline"
-            className={`text-[10px] ${filterStyle}`}
-            data-testid={`filter-badge-${hop.filterResult}`}
-          >
-            {hop.filterResult}
-          </Badge>
+        )}
+        <Badge
+          variant="outline"
+          className={`text-[10px] ${filterStyle}`}
+          data-testid={`filter-badge-${hop.filterResult}`}
+        >
+          {hop.filterResult}
+        </Badge>
+        <div className="ml-auto">
+          <AccordionTrigger className="py-0 text-sm hover:no-underline" />
         </div>
-      </AccordionTrigger>
+      </div>
       <AccordionContent>
         <div className="space-y-3 text-xs">
           {hop.trigger && (

--- a/frontend/src/features/manifests/components/event-chain-panel.tsx
+++ b/frontend/src/features/manifests/components/event-chain-panel.tsx
@@ -1,0 +1,244 @@
+import { useState } from 'react'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion'
+import { Badge } from '@/components/ui/badge'
+import type { EventChain, EventHop } from '../lib/transitive-closure'
+
+const FILTER_BADGE_STYLES: Record<string, string> = {
+  pass: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300',
+  fail: 'bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-300',
+  indeterminate: 'bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300',
+}
+
+const TERMINATION_LABELS: Record<string, string> = {
+  filter_rejection: 'Chain terminated: all sagas filtered out',
+  chain_depth_limit: 'Chain terminated: maximum depth reached',
+  no_matching_sagas: 'Chain terminated: no matching sagas found',
+}
+
+interface EventChainPanelProps {
+  chain: EventChain
+  startNodeLabel: string
+  onSagaClick?: (sagaName: string) => void
+}
+
+export function EventChainPanel({ chain, startNodeLabel, onSagaClick }: EventChainPanelProps) {
+  if (chain.hops.length === 0) {
+    return (
+      <div className="rounded-lg border p-4" data-testid="event-chain-panel">
+        <div className="text-sm text-muted-foreground">
+          No event chain from {startNodeLabel}.
+        </div>
+        <TerminationBadge reason={chain.terminationReason} />
+      </div>
+    )
+  }
+
+  const hopsByDepth = groupHopsByDepth(chain.hops)
+
+  return (
+    <div className="rounded-lg border p-4" data-testid="event-chain-panel">
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-sm font-semibold">
+          Event chain from {startNodeLabel}
+        </h3>
+        <Badge variant="outline" className="text-xs">
+          Depth: {chain.maxDepthUsed}
+        </Badge>
+      </div>
+
+      <div className="relative ml-3 border-l-2 border-muted-foreground/20 pl-6">
+        {[...hopsByDepth.entries()].map(([depth, hops]) => (
+          <DepthGroup
+            key={depth}
+            depth={depth}
+            hops={hops}
+            onSagaClick={onSagaClick}
+          />
+        ))}
+      </div>
+
+      <div className="mt-4">
+        <TerminationBadge reason={chain.terminationReason} />
+      </div>
+    </div>
+  )
+}
+
+function TerminationBadge({ reason }: { reason: EventChain['terminationReason'] }) {
+  return (
+    <div className="mt-2" data-testid="termination-reason">
+      <Badge variant="secondary" className="text-xs">
+        {TERMINATION_LABELS[reason] ?? reason}
+      </Badge>
+    </div>
+  )
+}
+
+function groupHopsByDepth(hops: EventHop[]): Map<number, EventHop[]> {
+  const map = new Map<number, EventHop[]>()
+  for (const hop of hops) {
+    const group = map.get(hop.depth) ?? []
+    group.push(hop)
+    map.set(hop.depth, group)
+  }
+  return map
+}
+
+interface DepthGroupProps {
+  depth: number
+  hops: EventHop[]
+  onSagaClick?: (sagaName: string) => void
+}
+
+function DepthGroup({ depth, hops, onSagaClick }: DepthGroupProps) {
+  return (
+    <div className="relative mb-4 last:mb-0">
+      <div className="absolute -left-[31px] top-1 h-3 w-3 rounded-full border-2 border-muted-foreground/40 bg-background" />
+      <div className="mb-2 text-xs font-medium text-muted-foreground">
+        Hop {depth}
+      </div>
+      <Accordion type="multiple" className="space-y-1">
+        {hops.map((hop, idx) => (
+          <HopItem
+            key={`${hop.saga}-${idx}`}
+            hop={hop}
+            index={idx}
+            onSagaClick={onSagaClick}
+          />
+        ))}
+      </Accordion>
+    </div>
+  )
+}
+
+interface HopItemProps {
+  hop: EventHop
+  index: number
+  onSagaClick?: (sagaName: string) => void
+}
+
+function HopItem({ hop, index, onSagaClick }: HopItemProps) {
+  const [showDiagram, setShowDiagram] = useState(false)
+  const filterStyle = FILTER_BADGE_STYLES[hop.filterResult] ?? ''
+
+  return (
+    <AccordionItem value={`${hop.saga}-${index}`} className="border rounded-md px-3">
+      <AccordionTrigger className="py-2 text-sm hover:no-underline">
+        <div className="flex flex-1 items-center gap-2">
+          <span
+            role="link"
+            tabIndex={0}
+            className="font-medium text-sm hover:underline text-left cursor-pointer"
+            onClick={(e) => {
+              e.stopPropagation()
+              onSagaClick?.(hop.saga)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.stopPropagation()
+                e.preventDefault()
+                onSagaClick?.(hop.saga)
+              }
+            }}
+            data-testid={`saga-link-${hop.saga}`}
+          >
+            {hop.saga}
+          </span>
+          <Badge
+            variant="outline"
+            className={`text-[10px] ${filterStyle}`}
+            data-testid={`filter-badge-${hop.filterResult}`}
+          >
+            {hop.filterResult}
+          </Badge>
+        </div>
+      </AccordionTrigger>
+      <AccordionContent>
+        <div className="space-y-3 text-xs">
+          {hop.trigger && (
+            <div>
+              <span className="font-medium text-muted-foreground">Trigger: </span>
+              <span>{hop.trigger.channel}</span>
+              {hop.trigger.instrumentCode && (
+                <span className="ml-1 text-muted-foreground">({hop.trigger.instrumentCode})</span>
+              )}
+            </div>
+          )}
+
+          {hop.filterExpression && (
+            <div>
+              <span className="font-medium text-muted-foreground">Filter: </span>
+              <code className="rounded bg-muted px-1 py-0.5 text-[11px]">
+                {hop.filterExpression}
+              </code>
+            </div>
+          )}
+
+          {hop.filterReason && (
+            <div>
+              <span className="font-medium text-muted-foreground">Reason: </span>
+              <span>{hop.filterReason}</span>
+            </div>
+          )}
+
+          {hop.producedEvents.length > 0 && (
+            <div>
+              <span className="font-medium text-muted-foreground">Produced events:</span>
+              <ul className="mt-1 space-y-0.5 list-disc list-inside">
+                {hop.producedEvents.map((pe, i) => (
+                  <li key={i}>
+                    {pe.channel}
+                    {pe.instrumentCode && ` [${pe.instrumentCode}]`}
+                    {pe.direction && ` (${pe.direction})`}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <SagaDiagramToggle
+            showDiagram={showDiagram}
+            onToggle={() => setShowDiagram(!showDiagram)}
+            sagaId={hop.saga}
+          />
+        </div>
+      </AccordionContent>
+    </AccordionItem>
+  )
+}
+
+interface SagaDiagramToggleProps {
+  showDiagram: boolean
+  onToggle: () => void
+  sagaId: string
+}
+
+function SagaDiagramToggle({ showDiagram, onToggle, sagaId }: SagaDiagramToggleProps) {
+  // The saga source would need to come from the manifest graph node data.
+  // For now, we show a toggle button. The SagaFlowDiagram requires a parsed SagaFlow.
+  // In real usage, the parent would provide saga sources via context or props.
+  return (
+    <div>
+      <button
+        type="button"
+        className="text-xs text-primary hover:underline"
+        onClick={onToggle}
+        data-testid={`saga-diagram-toggle-${sagaId}`}
+      >
+        {showDiagram ? 'Hide saga flow' : 'Show saga flow'}
+      </button>
+      {showDiagram && (
+        <div className="mt-2 h-64 rounded border" data-testid={`saga-diagram-${sagaId}`}>
+          <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+            Saga flow diagram requires source for {sagaId}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `EventChainPanel` component that visualizes transitive closure results from the manifest event chain engine
- Displays hop-by-hop detail with vertical timeline (border-l-2 pattern), connected depth dots, and accordion expand/collapse
- Color-coded filter badges: green (pass), red (fail), amber (indeterminate)
- Shows trigger info, filter expression with reason, produced events list, and saga diagram toggle
- Termination reason badge at bottom (filter rejection, depth limit, no matching sagas)
- Clickable saga names fire `onSagaClick` callback

Task: 038-manifest-business-model-visualization.8

## Test plan

- [x] Renders multi-hop chain with depth indicators
- [x] Accordion expand/collapse functionality
- [x] Filter badge colors match results (pass=green, fail=red, indeterminate=amber)
- [x] All three termination reasons display correctly
- [x] Saga click callback fires with saga name
- [x] Empty chain renders appropriate message
- [x] Produced events shown in expanded view
- [x] Saga diagram toggle button works
- [x] 12/12 tests passing