### PR TITLE
feat: add event chain button and side panel to manifest graph

### DIFF
--- a/frontend/src/features/manifests/components/manifest-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.test.tsx
@@ -28,15 +28,19 @@ vi.mock('@xyflow/react', () => {
 
   function Handle() { return null }
 
-  function ReactFlow({ nodes, edges, onNodeClick, children }: {
+  function ReactFlow({ nodes, edges, onNodeClick, onNodeDoubleClick, onPaneClick, children }: {
     nodes: { id: string; type?: string; data: Record<string, unknown> }[]
     edges: { id: string; source: string; target: string; data?: Record<string, unknown> }[]
     onNodeClick?: (event: unknown, node: unknown) => void
+    onNodeDoubleClick?: (event: unknown, node: unknown) => void
+    onPaneClick?: () => void
     children?: React.ReactNode
     [key: string]: unknown
   }) {
     return (
-      <div data-testid="react-flow" data-node-count={nodes.length} data-edge-count={edges.length}>
+      <div data-testid="react-flow" data-node-count={nodes.length} data-edge-count={edges.length} onClick={(e) => {
+        if ((e.target as HTMLElement).getAttribute('data-testid') === 'react-flow') onPaneClick?.()
+      }}>
         {nodes.map((n) => {
           const mn = (n.data as { manifestNode?: { type: string; label: string; data: Record<string, unknown> } }).manifestNode
           return (
@@ -46,7 +50,8 @@ vi.mock('@xyflow/react', () => {
               data-node-type={n.type}
               data-dimmed={String((n.data as { dimmed?: boolean }).dimmed ?? false)}
               data-highlighted={String((n.data as { highlighted?: boolean }).highlighted ?? false)}
-              onClick={() => onNodeClick?.({}, n)}
+              onClick={(e) => { e.stopPropagation(); onNodeClick?.({}, n) }}
+              onDoubleClick={() => onNodeDoubleClick?.({}, n)}
             >
               {mn?.label ?? n.id}
             </div>
@@ -257,26 +262,102 @@ describe('ManifestGraph', () => {
     })
   })
 
-  describe('click navigation', () => {
-    it('navigates to instruments page on instrument click', async () => {
+  describe('double-click navigation', () => {
+    it('navigates to instruments page on instrument double-click', async () => {
       renderGraph(energyManifest)
       const node = await screen.findByTestId('node-instrument:KWH')
-      fireEvent.click(node)
+      fireEvent.doubleClick(node)
       expect(mockNavigate).toHaveBeenCalledWith('/reference-data/instruments')
     })
 
-    it('navigates to account types page on account type click', async () => {
+    it('navigates to account types page on account type double-click', async () => {
       renderGraph(energyManifest)
       const node = await screen.findByTestId('node-account_type:ENERGY_HOLDING')
-      fireEvent.click(node)
+      fireEvent.doubleClick(node)
       expect(mockNavigate).toHaveBeenCalledWith('/reference-data/account-types')
     })
 
-    it('navigates to saga detail page on saga click', async () => {
+    it('navigates to saga detail page on saga double-click', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-saga:usage_to_value')
+      fireEvent.doubleClick(node)
+      expect(mockNavigate).toHaveBeenCalledWith('/sagas/usage_to_value')
+    })
+  })
+
+  describe('node selection', () => {
+    it('shows toolbar when an instrument node is clicked', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-instrument:KWH')
+      fireEvent.click(node)
+      const toolbar = await screen.findByTestId('node-toolbar')
+      expect(toolbar).toBeInTheDocument()
+      expect(toolbar.textContent).toContain('Kilowatt Hour')
+    })
+
+    it('shows "Show Event Chain" button for instrument nodes', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-instrument:KWH')
+      fireEvent.click(node)
+      expect(await screen.findByTestId('show-event-chain-button')).toBeInTheDocument()
+    })
+
+    it('shows "Show Event Chain" button for account_type nodes', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-account_type:ENERGY_HOLDING')
+      fireEvent.click(node)
+      expect(await screen.findByTestId('show-event-chain-button')).toBeInTheDocument()
+    })
+
+    it('does not show "Show Event Chain" button for saga nodes', async () => {
       renderGraph(energyManifest)
       const node = await screen.findByTestId('node-saga:usage_to_value')
       fireEvent.click(node)
-      expect(mockNavigate).toHaveBeenCalledWith('/sagas/usage_to_value')
+      expect(await screen.findByTestId('node-toolbar')).toBeInTheDocument()
+      expect(screen.queryByTestId('show-event-chain-button')).not.toBeInTheDocument()
+    })
+
+    it('deselects node when clicking the same node again', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-instrument:KWH')
+      fireEvent.click(node)
+      expect(await screen.findByTestId('node-toolbar')).toBeInTheDocument()
+      fireEvent.click(node)
+      expect(screen.queryByTestId('node-toolbar')).not.toBeInTheDocument()
+    })
+
+    it('deselects node when clicking the pane', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-instrument:KWH')
+      fireEvent.click(node)
+      expect(await screen.findByTestId('node-toolbar')).toBeInTheDocument()
+      const pane = screen.getByTestId('react-flow')
+      fireEvent.click(pane)
+      expect(screen.queryByTestId('node-toolbar')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('event chain panel', () => {
+    it('opens event chain panel when "Show Event Chain" is clicked', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-instrument:KWH')
+      fireEvent.click(node)
+      const button = await screen.findByTestId('show-event-chain-button')
+      fireEvent.click(button)
+      expect(await screen.findByTestId('event-chain-side-panel')).toBeInTheDocument()
+      expect(screen.getByTestId('event-chain-panel')).toBeInTheDocument()
+    })
+
+    it('closes event chain panel when close button is clicked', async () => {
+      renderGraph(energyManifest)
+      const node = await screen.findByTestId('node-instrument:KWH')
+      fireEvent.click(node)
+      const button = await screen.findByTestId('show-event-chain-button')
+      fireEvent.click(button)
+      expect(await screen.findByTestId('event-chain-side-panel')).toBeInTheDocument()
+      const closeButton = screen.getByTestId('close-event-chain-panel')
+      fireEvent.click(closeButton)
+      expect(screen.queryByTestId('event-chain-side-panel')).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -603,7 +603,7 @@ export function ManifestGraph({ manifest, className }: ManifestGraphProps) {
             <EventChainPanel
               chain={eventChain}
               startNodeLabel={selectedManifestNode.label}
-              onSagaClick={(sagaName) => navigate(`/sagas/${sagaName}`)}
+              onSagaClick={(sagaId) => navigate(`/sagas/${sagaId.replace(/^saga:/, '')}`)}
             />
           </div>
         </div>

--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -468,7 +468,12 @@ export function ManifestGraph({ manifest, className }: ManifestGraphProps) {
       }
       return next
     })
-  }, [])
+    // Clear selection if the selected node's type was just hidden
+    if (selectedManifestNode?.type === type) {
+      setSelectedNode(null)
+      setShowEventChain(false)
+    }
+  }, [selectedManifestNode])
 
   const totalVisible = nodes.length
 

--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -15,12 +15,14 @@ import {
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { useNavigate } from 'react-router-dom'
+import { X } from 'lucide-react'
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { Button } from '@/components/ui/button'
 import {
   layoutWithELK,
   NODE_WIDTH,
@@ -35,6 +37,8 @@ import {
   type ManifestGraph as ManifestGraphModel,
 } from '../lib/manifest-graph-model'
 import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
+import { useEventChain } from '../hooks/use-event-chain'
+import { EventChainPanel } from './event-chain-panel'
 
 // Theme colors per node type
 const NODE_THEMES: Record<ManifestNodeType, { color: string; label: string }> = {
@@ -316,11 +320,23 @@ export function ManifestGraph({ manifest, className }: ManifestGraphProps) {
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([])
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
   const [hoveredNode, setHoveredNode] = useState<string | null>(null)
+  const [selectedNode, setSelectedNode] = useState<string | null>(null)
+  const [showEventChain, setShowEventChain] = useState(false)
   const [visibleTypes, setVisibleTypes] = useState<Set<ManifestNodeType>>(
     () => new Set<ManifestNodeType>(['instrument', 'account_type', 'valuation_rule', 'saga']),
   )
 
   const graph = useMemo(() => buildManifestGraph(manifest), [manifest])
+
+  const selectedManifestNode = useMemo(
+    () => (selectedNode ? graph.nodes.find((n) => n.id === selectedNode) ?? null : null),
+    [graph, selectedNode],
+  )
+
+  const canShowEventChain = selectedManifestNode?.type === 'instrument' || selectedManifestNode?.type === 'account_type'
+
+  const eventChainNodeId = showEventChain ? selectedNode : null
+  const eventChain = useEventChain(graph, eventChainNodeId)
 
   const nodeCountByType = useMemo(() => {
     const counts: Record<ManifestNodeType, number> = {
@@ -363,13 +379,14 @@ export function ManifestGraph({ manifest, className }: ManifestGraphProps) {
     return () => { cancelled = true }
   }, [graph, visibleTypes, setNodes, setEdges])
 
-  // Hover highlighting
+  // Hover + selection highlighting
   useEffect(() => {
+    const activeNode = hoveredNode ?? selectedNode
     const connectedNodes = new Set<string>()
-    if (hoveredNode) {
-      connectedNodes.add(hoveredNode)
+    if (activeNode) {
+      connectedNodes.add(activeNode)
       for (const e of currentEdges) {
-        if (e.source === hoveredNode || e.target === hoveredNode) {
+        if (e.source === activeNode || e.target === activeNode) {
           connectedNodes.add(e.source)
           connectedNodes.add(e.target)
         }
@@ -379,8 +396,8 @@ export function ManifestGraph({ manifest, className }: ManifestGraphProps) {
     setNodes((nds) => {
       let changed = false
       const next = nds.map((n) => {
-        const highlighted = hoveredNode ? n.id === hoveredNode : false
-        const dimmed = hoveredNode ? !connectedNodes.has(n.id) : false
+        const highlighted = activeNode ? n.id === activeNode : false
+        const dimmed = activeNode ? !connectedNodes.has(n.id) : false
         const current = n.data as ManifestNodeData
         if (current.highlighted === highlighted && current.dimmed === dimmed) return n
         changed = true
@@ -399,9 +416,17 @@ export function ManifestGraph({ manifest, className }: ManifestGraphProps) {
       })
       return changed ? next : eds
     })
-  }, [hoveredNode, currentEdges, setNodes, setEdges])
+  }, [hoveredNode, selectedNode, currentEdges, setNodes, setEdges])
 
   const onNodeClick: NodeMouseHandler = useCallback(
+    (_event, node) => {
+      setSelectedNode((prev) => (prev === node.id ? null : node.id))
+      setShowEventChain(false)
+    },
+    [],
+  )
+
+  const onNodeDoubleClick: NodeMouseHandler = useCallback(
     (_event, node) => {
       const data = node.data as ManifestNodeData
       const mn = data.manifestNode
@@ -419,6 +444,11 @@ export function ManifestGraph({ manifest, className }: ManifestGraphProps) {
     },
     [navigate],
   )
+
+  const onPaneClick = useCallback(() => {
+    setSelectedNode(null)
+    setShowEventChain(false)
+  }, [])
 
   const onNodeMouseEnter: NodeMouseHandler = useCallback((_event, node) => {
     setHoveredNode(node.id)
@@ -461,6 +491,8 @@ export function ManifestGraph({ manifest, className }: ManifestGraphProps) {
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
           onNodeClick={onNodeClick}
+          onNodeDoubleClick={onNodeDoubleClick}
+          onPaneClick={onPaneClick}
           onNodeMouseEnter={onNodeMouseEnter}
           onNodeMouseLeave={onNodeMouseLeave}
           nodeTypes={nodeTypes}
@@ -510,6 +542,67 @@ export function ManifestGraph({ manifest, className }: ManifestGraphProps) {
           <LegendItem key={item.label} {...item} />
         ))}
       </div>
+
+      {/* Selection toolbar */}
+      {selectedManifestNode && (
+        <div
+          className="absolute top-3 right-3 z-10 flex items-center gap-2 rounded-lg border bg-background/95 p-2 backdrop-blur-sm shadow-sm"
+          data-testid="node-toolbar"
+        >
+          <span className="text-xs font-medium text-foreground px-1">
+            {selectedManifestNode.label}
+          </span>
+          {canShowEventChain && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="text-xs h-7"
+              onClick={() => setShowEventChain(true)}
+              data-testid="show-event-chain-button"
+            >
+              Show Event Chain
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 w-7 p-0"
+            onClick={() => { setSelectedNode(null); setShowEventChain(false) }}
+            aria-label="Deselect node"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      )}
+
+      {/* Event chain side panel */}
+      {showEventChain && eventChain && selectedManifestNode && (
+        <div
+          className="absolute top-0 right-0 z-20 h-full w-96 border-l bg-background shadow-lg overflow-y-auto"
+          data-testid="event-chain-side-panel"
+        >
+          <div className="flex items-center justify-between p-3 border-b">
+            <h3 className="text-sm font-semibold">Event Chain</h3>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 w-7 p-0"
+              onClick={() => setShowEventChain(false)}
+              aria-label="Close event chain panel"
+              data-testid="close-event-chain-panel"
+            >
+              <X className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+          <div className="p-3">
+            <EventChainPanel
+              chain={eventChain}
+              startNodeLabel={selectedManifestNode.label}
+              onSagaClick={(sagaName) => navigate(`/sagas/${sagaName}`)}
+            />
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -328,14 +328,20 @@ export function ManifestGraph({ manifest, className }: ManifestGraphProps) {
 
   const graph = useMemo(() => buildManifestGraph(manifest), [manifest])
 
+  // Derive effective selection: clear if the selected node no longer exists in the graph
+  const effectiveSelectedNode = useMemo(
+    () => (selectedNode && graph.nodes.some((n) => n.id === selectedNode) ? selectedNode : null),
+    [selectedNode, graph],
+  )
+
   const selectedManifestNode = useMemo(
-    () => (selectedNode ? graph.nodes.find((n) => n.id === selectedNode) ?? null : null),
-    [graph, selectedNode],
+    () => (effectiveSelectedNode ? graph.nodes.find((n) => n.id === effectiveSelectedNode) ?? null : null),
+    [graph, effectiveSelectedNode],
   )
 
   const canShowEventChain = selectedManifestNode?.type === 'instrument' || selectedManifestNode?.type === 'account_type'
 
-  const eventChainNodeId = showEventChain ? selectedNode : null
+  const eventChainNodeId = showEventChain ? effectiveSelectedNode : null
   const eventChain = useEventChain(graph, eventChainNodeId)
 
   const nodeCountByType = useMemo(() => {
@@ -381,7 +387,7 @@ export function ManifestGraph({ manifest, className }: ManifestGraphProps) {
 
   // Hover + selection highlighting
   useEffect(() => {
-    const activeNode = hoveredNode ?? selectedNode
+    const activeNode = hoveredNode ?? effectiveSelectedNode
     const connectedNodes = new Set<string>()
     if (activeNode) {
       connectedNodes.add(activeNode)
@@ -416,7 +422,7 @@ export function ManifestGraph({ manifest, className }: ManifestGraphProps) {
       })
       return changed ? next : eds
     })
-  }, [hoveredNode, selectedNode, currentEdges, setNodes, setEdges])
+  }, [hoveredNode, effectiveSelectedNode, currentEdges, setNodes, setEdges])
 
   const onNodeClick: NodeMouseHandler = useCallback(
     (_event, node) => {
@@ -592,7 +598,7 @@ export function ManifestGraph({ manifest, className }: ManifestGraphProps) {
               size="sm"
               variant="ghost"
               className="h-7 w-7 p-0"
-              onClick={() => setShowEventChain(false)}
+              onClick={() => { setSelectedNode(null); setShowEventChain(false) }}
               aria-label="Close event chain panel"
               data-testid="close-event-chain-panel"
             >

--- a/frontend/src/features/manifests/hooks/use-event-chain.test.ts
+++ b/frontend/src/features/manifests/hooks/use-event-chain.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useEventChain } from './use-event-chain'
+import type { ManifestGraph } from '../lib/manifest-graph-model'
+
+const emptyGraph: ManifestGraph = { nodes: [], edges: [] }
+
+const graphWithInstrument: ManifestGraph = {
+  nodes: [
+    {
+      id: 'instrument:GBP',
+      type: 'instrument',
+      label: 'British Pound',
+      data: { code: 'GBP' },
+    },
+  ],
+  edges: [],
+}
+
+describe('useEventChain', () => {
+  it('returns null when graph is null', () => {
+    const { result } = renderHook(() => useEventChain(null, 'instrument:GBP'))
+    expect(result.current).toBeNull()
+  })
+
+  it('returns null when nodeId is null', () => {
+    const { result } = renderHook(() => useEventChain(graphWithInstrument, null))
+    expect(result.current).toBeNull()
+  })
+
+  it('returns null when both are null', () => {
+    const { result } = renderHook(() => useEventChain(null, null))
+    expect(result.current).toBeNull()
+  })
+
+  it('returns an EventChain when both graph and nodeId are provided', () => {
+    const { result } = renderHook(() => useEventChain(graphWithInstrument, 'instrument:GBP'))
+    expect(result.current).not.toBeNull()
+    expect(result.current).toHaveProperty('hops')
+    expect(result.current).toHaveProperty('terminationReason')
+    expect(result.current).toHaveProperty('maxDepthUsed')
+  })
+
+  it('returns no_matching_sagas for instrument with no sagas in graph', () => {
+    const { result } = renderHook(() => useEventChain(graphWithInstrument, 'instrument:GBP'))
+    expect(result.current!.terminationReason).toBe('no_matching_sagas')
+    expect(result.current!.hops).toHaveLength(0)
+  })
+
+  it('returns no_matching_sagas for non-existent node', () => {
+    const { result } = renderHook(() => useEventChain(emptyGraph, 'instrument:FAKE'))
+    expect(result.current!.terminationReason).toBe('no_matching_sagas')
+  })
+
+  it('memoizes result when inputs do not change', () => {
+    const { result, rerender } = renderHook(() =>
+      useEventChain(graphWithInstrument, 'instrument:GBP'),
+    )
+    const first = result.current
+    rerender()
+    expect(result.current).toBe(first)
+  })
+})

--- a/frontend/src/features/manifests/hooks/use-event-chain.ts
+++ b/frontend/src/features/manifests/hooks/use-event-chain.ts
@@ -1,0 +1,10 @@
+import { useMemo } from 'react'
+import { computeTransitiveClosure, type EventChain } from '../lib/transitive-closure'
+import type { ManifestGraph } from '../lib/manifest-graph-model'
+
+export function useEventChain(graph: ManifestGraph | null, nodeId: string | null): EventChain | null {
+  return useMemo(() => {
+    if (!graph || !nodeId) return null
+    return computeTransitiveClosure(graph, nodeId)
+  }, [graph, nodeId])
+}


### PR DESCRIPTION
## Summary

- Add node selection to the manifest graph: single click selects a node and shows a toolbar, double click navigates to detail pages (previous behavior)
- Show "Show Event Chain" button in the toolbar for instrument and account_type nodes only
- Create `useEventChain` hook that wraps `computeTransitiveClosure` with memoization
- Display `EventChainPanel` in a right-side slide-out panel when event chain is activated
- Clicking the pane or the X button deselects the node and closes the panel

## Changes Made

- **New file**: `frontend/src/features/manifests/hooks/use-event-chain.ts` - hook wrapping transitive closure computation
- **Modified**: `frontend/src/features/manifests/components/manifest-graph.tsx` - added selection state, toolbar, side panel, separated click (select) from double-click (navigate)
- **Updated**: `frontend/src/features/manifests/components/manifest-graph.test.tsx` - updated click navigation tests to use double-click, added tests for node selection, event chain button visibility, and panel open/close
- **New file**: `frontend/src/features/manifests/hooks/use-event-chain.test.ts` - unit tests for the hook

## Test Plan

- [x] `useEventChain` hook: 7 tests (null inputs, valid computation, memoization)
- [x] Node selection via click shows toolbar
- [x] "Show Event Chain" button appears for instrument/account_type nodes
- [x] "Show Event Chain" button does NOT appear for saga nodes
- [x] Event chain panel opens with computed data
- [x] Closing panel clears event chain view
- [x] Double-click navigation still works for all node types
- [x] All 148 manifest feature tests passing