### PR TITLE
Validate cookbook event triggers against AsyncAPI topic registry

### DIFF
--- a/cookbook/patterns/patterns_test.go
+++ b/cookbook/patterns/patterns_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -560,6 +561,66 @@ func TestRegistry_ContainsAllPatterns(t *testing.T) {
 	allPatterns := append([]string{"base-fiat-gbp", "base-fiat-usd"}, allEconomyPatterns...)
 	for _, name := range allPatterns {
 		assert.True(t, registryNames[name], "registry.json should contain %s entry", name)
+	}
+}
+
+// --- event trigger validation ---
+
+// allPatternDirs returns all directories under the patterns dir that contain a manifest-fragment.yaml.
+func allPatternDirs(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(patternsDir(t))
+	require.NoError(t, err)
+
+	var dirs []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		manifestPath := filepath.Join(patternsDir(t), e.Name(), "manifest-fragment.yaml")
+		if _, err := os.Stat(manifestPath); err == nil {
+			dirs = append(dirs, e.Name())
+		}
+	}
+	return dirs
+}
+
+func TestAllPatterns_EventTriggersMapToValidTopics(t *testing.T) {
+	validTopics := make(map[string]bool, len(topics.All()))
+	for _, topic := range topics.All() {
+		validTopics[topic] = true
+	}
+
+	for _, name := range allPatternDirs(t) {
+		t.Run(name, func(t *testing.T) {
+			fragment := loadManifestFragment(t, name)
+
+			sagas, ok := fragment["sagas"].([]any)
+			if !ok {
+				return // no sagas in this pattern
+			}
+
+			for i, s := range sagas {
+				saga, ok := s.(map[string]any)
+				if !ok {
+					continue
+				}
+				trigger, ok := saga["trigger"].(string)
+				if !ok {
+					continue
+				}
+
+				if !strings.HasPrefix(trigger, "event:") {
+					continue // only validate event triggers against topic registry
+				}
+
+				channel := strings.TrimPrefix(trigger, "event:")
+				sagaName, _ := saga["name"].(string)
+				assert.True(t, validTopics[channel],
+					"saga[%d] %q has trigger %q but %q is not a registered topic; see shared/platform/events/topics/topics.go",
+					i, sagaName, trigger, channel)
+			}
+		})
 	}
 }
 

--- a/cookbook/patterns/patterns_test.go
+++ b/cookbook/patterns/patterns_test.go
@@ -595,19 +595,19 @@ func TestAllPatterns_EventTriggersMapToValidTopics(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			fragment := loadManifestFragment(t, name)
 
-			sagas, ok := fragment["sagas"].([]any)
-			if !ok {
+			sagasRaw, hasSagas := fragment["sagas"]
+			if !hasSagas {
 				return // no sagas in this pattern
 			}
+			sagas, ok := sagasRaw.([]any)
+			require.True(t, ok, "sagas must be a list in %s", name)
 
 			for i, s := range sagas {
 				saga, ok := s.(map[string]any)
-				if !ok {
-					continue
-				}
+				require.True(t, ok, "saga[%d] in %s must be an object", i, name)
 				trigger, ok := saga["trigger"].(string)
 				if !ok {
-					continue
+					continue // saga may not have a trigger (e.g. manual invocation)
 				}
 
 				if !strings.HasPrefix(trigger, "event:") {

--- a/cookbook/patterns/phantom-cost-basis/corporate_action_cost_adjustment.star
+++ b/cookbook/patterns/phantom-cost-basis/corporate_action_cost_adjustment.star
@@ -1,7 +1,7 @@
 # Saga: corporate_action_cost_adjustment
-# Version: 2.0.0
-# Previous: 1.0.0
-# Changed: Clarify this consumes a hypothetical corporate-action event type
+# Version: 3.0.0
+# Previous: 2.0.0
+# Changed: Use observation-recorded.v1 channel instead of aspirational corporate-action.v1
 # Author: Tenant Configuration (Wealth Management)
 # Date: 2026-03-03
 #
@@ -9,14 +9,14 @@
 # occurs. Handles "phantom events" where no cash or units move but the tax
 # position changes (e.g., accumulating ETF dividends).
 #
-# Trigger: event:market-information.corporate-action.v1
-# Filter:  event.action_type == 'ACCUMULATING_DIVIDEND'
+# Trigger: event:market-information.observation-recorded.v1
+# Filter:  event.observation_type == 'CORPORATE_ACTION' && event.metadata.action_type == 'ACCUMULATING_DIVIDEND'
 #
-# NOTE: The corporate-action.v1 channel is aspirational — it does not exist in
-# the current event inventory. When implemented, the proto would define fields
-# such as instrument_code, action_type, amount_per_unit, and ex_date. This
-# example validates the platform's ability to support wealth management use cases
-# once the event is defined.
+# Uses the market-information.observation-recorded.v1 channel with a CEL filter
+# to select corporate action observations. The observation payload carries
+# instrument_code, action_type, amount_per_unit, and ex_date in its metadata.
+# This demonstrates how wealth management use cases compose on top of the
+# existing market information event infrastructure.
 #
 # Account model:
 #   - Custody Account (instrument units): what you own (unchanged by this saga)

--- a/cookbook/patterns/phantom-cost-basis/manifest-fragment.yaml
+++ b/cookbook/patterns/phantom-cost-basis/manifest-fragment.yaml
@@ -1,4 +1,4 @@
 sagas:
   - name: corporate_action_cost_adjustment
-    trigger: "event:market-information.corporate-action.v1"
-    filter: "event.action_type == 'ACCUMULATING_DIVIDEND'"
+    trigger: "event:market-information.observation-recorded.v1"
+    filter: "event.observation_type == 'CORPORATE_ACTION' && event.metadata.action_type == 'ACCUMULATING_DIVIDEND'"


### PR DESCRIPTION
## Summary

- Add CI test that validates all `event:` triggers in cookbook `manifest-fragment.yaml` files reference valid topics from the AsyncAPI spec (via `topics.All()`)
- Fix phantom-cost-basis pattern: `market-information.corporate-action.v1` (non-existent) → `market-information.observation-recorded.v1` with CEL filter for corporate action observations

## Context

The AsyncAPI specs define the canonical set of event channels. Cookbook patterns reference these as saga triggers (`event:<channel>`). Without validation, patterns can reference channels that don't exist — as phantom-cost-basis did with an aspirational `corporate-action.v1` channel.

The test dynamically discovers all pattern directories and validates their event triggers, so new patterns automatically get coverage.

## Test plan

- [x] New test fails before fix (catches `market-information.corporate-action.v1`)
- [x] New test passes after fix (all 12 patterns green)
- [x] All existing cookbook pattern tests still pass
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)