### PR TITLE
feat: Webhook trigger and scheduled trigger validation

### DIFF
--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -267,7 +267,13 @@ func (v *ManifestValidator) Validate(
 	// 9. Event trigger channel and filter validation
 	v.validateEventTriggers(manifest, result)
 
-	// 10. Immutability checks
+	// 10. Webhook trigger validation against provider connections
+	v.validateWebhookTriggers(manifest, result)
+
+	// 11. Scheduled trigger name uniqueness
+	v.validateScheduledTriggers(manifest, result)
+
+	// 12. Immutability checks
 	if previousManifest != nil {
 		v.validateImmutability(manifest, previousManifest, result)
 	}
@@ -1095,6 +1101,81 @@ func (v *ManifestValidator) validateEventFilterCEL(
 // availableChannels returns a sorted list of all registered event channel names.
 func (v *ManifestValidator) availableChannels() []string {
 	return mapKeys(v.channelRegistry)
+}
+
+// validateWebhookTriggers checks that webhook triggers reference provider connections
+// defined in the manifest's operational_gateway.provider_connections section.
+func (v *ManifestValidator) validateWebhookTriggers(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	// Build lookup of available provider connection IDs.
+	connectionIDs := make(map[string]bool)
+	var availableIDs []string
+	if gw := manifest.GetOperationalGateway(); gw != nil {
+		for _, pc := range gw.GetProviderConnections() {
+			cid := pc.GetConnectionId()
+			connectionIDs[cid] = true
+			availableIDs = append(availableIDs, cid)
+		}
+	}
+	sort.Strings(availableIDs)
+
+	for i, saga := range manifest.GetSagas() {
+		trigger := saga.GetTrigger()
+		if !strings.HasPrefix(trigger, "webhook:") {
+			continue
+		}
+
+		// Parse webhook:<source>.<event> — source is the first dot-separated segment.
+		remainder := strings.TrimPrefix(trigger, "webhook:")
+		source := remainder
+		if dotIdx := strings.Index(remainder, "."); dotIdx > 0 {
+			source = remainder[:dotIdx]
+		}
+
+		if !connectionIDs[source] {
+			ve := ValidationError{
+				Severity:        SeverityError,
+				Path:            fmt.Sprintf("sagas[%d].trigger", i),
+				Code:            "UNKNOWN_WEBHOOK_SOURCE",
+				Message:         fmt.Sprintf("webhook source %q does not match any provider connection in operational_gateway.provider_connections", source),
+				AvailableFields: availableIDs,
+			}
+			if suggestion := findClosestMatch(source, availableIDs); suggestion != "" {
+				ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+			}
+			addError(result, ve)
+		}
+	}
+}
+
+// validateScheduledTriggers enforces that scheduled trigger names are unique across all sagas.
+func (v *ManifestValidator) validateScheduledTriggers(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	// Track seen schedule names → first saga index.
+	seen := make(map[string]int)
+
+	for i, saga := range manifest.GetSagas() {
+		trigger := saga.GetTrigger()
+		if !strings.HasPrefix(trigger, "scheduled:") {
+			continue
+		}
+
+		name := strings.TrimPrefix(trigger, "scheduled:")
+		if firstIdx, exists := seen[name]; exists {
+			addError(result, ValidationError{
+				Severity: SeverityError,
+				Path:     fmt.Sprintf("sagas[%d].trigger", i),
+				Code:     "DUPLICATE_SCHEDULED_TRIGGER",
+				Message:  fmt.Sprintf("scheduled trigger name %q already defined at sagas[%d]", name, firstIdx),
+			})
+		} else {
+			seen[name] = i
+		}
+	}
 }
 
 // accountIDPattern matches valid Stripe Connect account IDs (acct_ followed by 16+ alphanumeric chars).

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -1638,3 +1638,207 @@ func TestValidatePartyTypes_MultipleErrors_ReportedAll(t *testing.T) {
 	assert.Contains(t, codes, "INVALID_JSON_SCHEMA")
 	assert.Contains(t, codes, "CEL_UNDECLARED_REFERENCE")
 }
+
+// --- Webhook trigger validation tests (Task 3) ---
+
+func TestValidate_WebhookTrigger_UnknownSource_Error(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_payment_webhook",
+		Trigger: "webhook:nonexistent.payment.succeeded",
+		Script:  "def execute(ctx):\n    return {}\n",
+	})
+
+	result := v.Validate(m, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "UNKNOWN_WEBHOOK_SOURCE" {
+			found = true
+			assert.Contains(t, e.Message, "nonexistent")
+			assert.Equal(t, "sagas[1].trigger", e.Path)
+			break
+		}
+	}
+	assert.True(t, found, "expected UNKNOWN_WEBHOOK_SOURCE error, got errors: %v", result.Errors)
+}
+
+func TestValidate_WebhookTrigger_ValidSource_Passes(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.OperationalGateway = &controlplanev1.OperationalGatewayConfig{
+		ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+			{
+				ConnectionId: "stripe-payments",
+				ProviderName: "Stripe",
+				ProviderType: "payment_gateway",
+				Protocol:     controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_HTTPS,
+			},
+		},
+	}
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_stripe_webhook",
+		Trigger: "webhook:stripe-payments.payment.succeeded",
+		Script:  "def execute(ctx):\n    return {}\n",
+	})
+
+	result := v.Validate(m, nil)
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "UNKNOWN_WEBHOOK_SOURCE", e.Code,
+			"unexpected UNKNOWN_WEBHOOK_SOURCE error: %v", e)
+	}
+}
+
+func TestValidate_WebhookTrigger_SuggestsCloseMatch(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.OperationalGateway = &controlplanev1.OperationalGatewayConfig{
+		ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+			{
+				ConnectionId: "stripe-payments",
+				ProviderName: "Stripe",
+				ProviderType: "payment_gateway",
+				Protocol:     controlplanev1.ProviderProtocol_PROVIDER_PROTOCOL_HTTPS,
+			},
+		},
+	}
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_stripe_webhook",
+		Trigger: "webhook:stripe-payment.payment.succeeded",
+		Script:  "def execute(ctx):\n    return {}\n",
+	})
+
+	result := v.Validate(m, nil)
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "UNKNOWN_WEBHOOK_SOURCE" {
+			found = true
+			assert.Contains(t, e.Suggestion, "stripe-payments")
+			assert.Contains(t, e.AvailableFields, "stripe-payments")
+			break
+		}
+	}
+	assert.True(t, found, "expected UNKNOWN_WEBHOOK_SOURCE error with suggestion")
+}
+
+func TestValidate_WebhookTrigger_NoOperationalGateway_Error(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.OperationalGateway = nil
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_webhook",
+		Trigger: "webhook:some-provider.event.received",
+		Script:  "def execute(ctx):\n    return {}\n",
+	})
+
+	result := v.Validate(m, nil)
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "UNKNOWN_WEBHOOK_SOURCE" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected UNKNOWN_WEBHOOK_SOURCE error when no operational_gateway defined")
+}
+
+// --- Scheduled trigger uniqueness tests (Task 4) ---
+
+func TestValidate_ScheduledTrigger_DuplicateName_Error(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "billing_saga_1",
+			Trigger: "scheduled:monthly_billing",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+		{
+			Name:    "another_saga",
+			Trigger: "api:/v1/other",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+		{
+			Name:    "billing_saga_2",
+			Trigger: "scheduled:monthly_billing",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "DUPLICATE_SCHEDULED_TRIGGER" {
+			found = true
+			assert.Equal(t, "sagas[2].trigger", e.Path)
+			assert.Contains(t, e.Message, "monthly_billing")
+			assert.Contains(t, e.Message, "sagas[0]")
+			break
+		}
+	}
+	assert.True(t, found, "expected DUPLICATE_SCHEDULED_TRIGGER error, got errors: %v", result.Errors)
+}
+
+func TestValidate_ScheduledTrigger_UniqueNames_Passes(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "daily_report",
+			Trigger: "scheduled:daily_report",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+		{
+			Name:    "monthly_billing",
+			Trigger: "scheduled:monthly_billing",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "DUPLICATE_SCHEDULED_TRIGGER", e.Code,
+			"unexpected DUPLICATE_SCHEDULED_TRIGGER error: %v", e)
+	}
+}
+
+func TestValidate_ScheduledTrigger_SameNameDifferentTriggerType_NoConflict(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "monthly_billing_scheduled",
+			Trigger: "scheduled:monthly_billing",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+		{
+			Name:    "monthly_billing_api",
+			Trigger: "api:/v1/monthly_billing",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "DUPLICATE_SCHEDULED_TRIGGER", e.Code,
+			"unexpected DUPLICATE_SCHEDULED_TRIGGER error: %v", e)
+	}
+}


### PR DESCRIPTION
## Summary

- Validate webhook triggers reference provider connections defined in `operational_gateway.provider_connections`, producing `UNKNOWN_WEBHOOK_SOURCE` errors with suggestions for close matches
- Enforce scheduled trigger name uniqueness across all sagas, producing `DUPLICATE_SCHEDULED_TRIGGER` errors when the same schedule name appears on multiple sagas

## Task Master

- 039-meridian-vm.3 - Webhook Trigger Validation Against Provider Connections
- 039-meridian-vm.4 - Scheduled Trigger Name Uniqueness Validation

## Changes

- `manifest_validator.go`: Added `validateWebhookTriggers` and `validateScheduledTriggers` methods, wired into the `Validate` pipeline
- `manifest_validator_test.go`: 7 new tests covering happy paths, error cases, suggestions, and edge cases

## Test plan

- [x] Webhook trigger with unknown source produces UNKNOWN_WEBHOOK_SOURCE error
- [x] Webhook trigger matching a provider connection passes
- [x] Close match suggestions for webhook source typos
- [x] No operational_gateway section handled gracefully
- [x] Duplicate scheduled trigger names produce DUPLICATE_SCHEDULED_TRIGGER error
- [x] Unique scheduled trigger names pass
- [x] Same name across different trigger types (scheduled vs api) causes no conflict
- [x] Full validator test suite passes