### PR TITLE
feat: Manifest RBAC authorization interceptor

### DIFF
--- a/services/control-plane/cmd/main.go
+++ b/services/control-plane/cmd/main.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/services/control-plane/internal/server"
 	"github.com/meridianhub/meridian/services/control-plane/service"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/meridianhub/meridian/shared/platform/env"
@@ -93,9 +94,11 @@ func run(logger *slog.Logger) error {
 		return fmt.Errorf("failed to initialize auth: %w", err)
 	}
 
-	// Create gRPC server
+	// Create gRPC server with RBAC interceptor for manifest operations
 	grpcServer := bootstrap.NewGrpcServerBuilder(tracer, logger).
 		WithAuthInterceptor(authInterceptor).
+		WithUnaryInterceptor(server.ManifestRBACUnaryInterceptor()).
+		WithStreamInterceptor(server.ManifestRBACStreamInterceptor()).
 		Build()
 
 	// Register ApplyManifestService.

--- a/services/control-plane/internal/server/interceptors.go
+++ b/services/control-plane/internal/server/interceptors.go
@@ -130,9 +130,11 @@ func checkManifestRBAC(ctx context.Context, fullMethod string) error {
 		return status.Error(codes.Unauthenticated, "authentication required")
 	}
 
-	// Check API key scope enforcement
-	if len(claims.Scopes) > 0 {
-		if !hasSufficientScope(claims.Scopes, requiredRole) {
+	// Check API key scope enforcement.
+	// Scopes may come from Claims (JWT) or from context (API key validation).
+	effectiveScopes := getEffectiveScopes(ctx, claims)
+	if len(effectiveScopes) > 0 {
+		if !hasSufficientScope(effectiveScopes, requiredRole) {
 			return status.Error(codes.PermissionDenied,
 				fmt.Sprintf("API key scope insufficient: requires %s-level access", requiredRole))
 		}
@@ -146,12 +148,27 @@ func checkManifestRBAC(ctx context.Context, fullMethod string) error {
 	return nil
 }
 
+// getEffectiveScopes returns scopes from Claims or from context (API key validation).
+// The gateway injects API key scopes into ScopesContextKey, while JWT tokens
+// carry scopes directly in Claims.Scopes.
+func getEffectiveScopes(ctx context.Context, claims *auth.Claims) []string {
+	if len(claims.Scopes) > 0 {
+		return claims.Scopes
+	}
+	// Fall back to context-level scopes (set by API key validation middleware)
+	if ctxScopes, ok := auth.GetScopesFromContext(ctx); ok && len(ctxScopes) > 0 {
+		return ctxScopes
+	}
+	return nil
+}
+
 // requiredScopeLevel maps roles to scope-specific levels, decoupled from roleLevel.
-// Only roles used in manifestRoleRequirements need entries here.
+// All roles used in manifestRoleRequirements must have entries here.
 var requiredScopeLevel = map[auth.Role]int{
 	auth.RoleAuditor:  1,
 	auth.RoleOperator: 2,
 	auth.RoleAdmin:    3,
+	auth.RoleService:  3, // Service accounts require admin-level scope access
 }
 
 // manifestScopeLevel maps manifest-specific scope strings to their access level.

--- a/services/control-plane/internal/server/interceptors.go
+++ b/services/control-plane/internal/server/interceptors.go
@@ -120,32 +120,37 @@ func checkManifestRBAC(ctx context.Context, fullMethod string) error {
 	return nil
 }
 
+// requiredScopeLevel maps roles to scope-specific levels, decoupled from roleLevel.
+// Only roles used in manifestRoleRequirements need entries here.
+var requiredScopeLevel = map[auth.Role]int{
+	auth.RoleAuditor:  1,
+	auth.RoleOperator: 2,
+	auth.RoleAdmin:    3,
+}
+
+// manifestScopeLevel maps manifest-specific scope strings to their access level.
+var manifestScopeLevel = map[string]int{
+	"manifest:read":  1,
+	"manifest:write": 2,
+	"manifest:admin": 3,
+}
+
 // hasSufficientScope checks whether the API key's scopes cover the required role level.
 // Scope naming convention: "manifest:read" (auditor), "manifest:write" (operator), "manifest:admin" (admin).
+// If the API key has no manifest-specific scopes, the check passes (role check handles authorization).
 func hasSufficientScope(scopes []string, requiredRole auth.Role) bool {
-	scopeLevel := map[string]int{
-		"manifest:read":  1,
-		"manifest:write": 2,
-		"manifest:admin": 3,
-	}
-
-	requiredLevel, ok := roleLevel[requiredRole]
+	requiredLevel, ok := requiredScopeLevel[requiredRole]
 	if !ok {
 		return false
 	}
 
-	for _, scope := range scopes {
-		if level, exists := scopeLevel[scope]; exists && level >= requiredLevel {
-			return true
-		}
-	}
-
-	// If no manifest-specific scopes are present, allow (role check handles it)
 	hasManifestScope := false
 	for _, scope := range scopes {
-		if _, exists := scopeLevel[scope]; exists {
+		if level, exists := manifestScopeLevel[scope]; exists {
 			hasManifestScope = true
-			break
+			if level >= requiredLevel {
+				return true
+			}
 		}
 	}
 

--- a/services/control-plane/internal/server/interceptors.go
+++ b/services/control-plane/internal/server/interceptors.go
@@ -132,8 +132,10 @@ func checkManifestRBAC(ctx context.Context, fullMethod string) error {
 
 	// Check API key scope enforcement.
 	// Scopes may come from Claims (JWT) or from context (API key validation).
+	// Skip scope checks for service-to-service RPCs (RoleService) since manifest
+	// scopes are not meaningful for internal service calls like ValidateAPIKey.
 	effectiveScopes := getEffectiveScopes(ctx, claims)
-	if len(effectiveScopes) > 0 {
+	if requiredRole != auth.RoleService && len(effectiveScopes) > 0 {
 		if !hasSufficientScope(effectiveScopes, requiredRole) {
 			return status.Error(codes.PermissionDenied,
 				fmt.Sprintf("API key scope insufficient: requires %s-level access", requiredRole))
@@ -189,8 +191,10 @@ func hasSufficientScope(scopes []string, requiredRole auth.Role) bool {
 
 	hasManifestScope := false
 	for _, scope := range scopes {
-		if level, exists := manifestScopeLevel[scope]; exists {
+		if strings.HasPrefix(scope, "manifest:") {
 			hasManifestScope = true
+		}
+		if level, exists := manifestScopeLevel[scope]; exists {
 			if level >= requiredLevel {
 				return true
 			}

--- a/services/control-plane/internal/server/interceptors.go
+++ b/services/control-plane/internal/server/interceptors.go
@@ -1,0 +1,153 @@
+// Package server provides gRPC server interceptors for the control-plane service.
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/meridianhub/meridian/shared/platform/auth"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// roleLevel maps roles to numeric levels for hierarchy comparison.
+// Higher numbers indicate more privileged roles.
+var roleLevel = map[auth.Role]int{
+	auth.RoleAuditor:       1,
+	auth.RoleOperator:      2,
+	auth.RoleAdmin:         3,
+	auth.RoleTenantOwner:   4,
+	auth.RolePlatformAdmin: 5,
+	auth.RoleSuperAdmin:    6,
+	auth.RoleService:       3, // Service accounts have admin-equivalent access
+}
+
+// manifestRoleRequirements maps gRPC full method names to the minimum role required.
+// Roles are hierarchical: admin > operator > auditor.
+// A user with a higher role can access methods requiring a lower role.
+var manifestRoleRequirements = map[string]auth.Role{
+	// ManifestHistoryService - read-only, auditor level
+	"/meridian.control_plane.v1.ManifestHistoryService/GetCurrentManifest":   auth.RoleAuditor,
+	"/meridian.control_plane.v1.ManifestHistoryService/GetManifestVersion":   auth.RoleAuditor,
+	"/meridian.control_plane.v1.ManifestHistoryService/ListManifestVersions": auth.RoleAuditor,
+
+	// ApplyManifestService - mutating, admin level
+	"/meridian.control_plane.v1.ApplyManifestService/ApplyManifest": auth.RoleAdmin,
+
+	// SagaExecutionService - operational, operator level
+	"/meridian.control_plane.v1.SagaExecutionService/ExecuteSaga": auth.RoleOperator,
+}
+
+// meetsMinimumRole checks whether any of the user's roles meets or exceeds
+// the required minimum role in the hierarchy.
+func meetsMinimumRole(userRoles []string, minimumRole auth.Role) bool {
+	requiredLevel, ok := roleLevel[minimumRole]
+	if !ok {
+		return false
+	}
+
+	for _, r := range userRoles {
+		role := auth.Role(r)
+		if level, exists := roleLevel[role]; exists && level >= requiredLevel {
+			return true
+		}
+	}
+	return false
+}
+
+// ManifestRBACUnaryInterceptor returns a gRPC unary interceptor that enforces
+// role-based access control on control-plane RPCs.
+//
+// Methods not listed in manifestRoleRequirements are allowed through (e.g., health checks).
+// The interceptor expects claims to be present in the context (populated by the auth interceptor).
+func ManifestRBACUnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		if err := checkManifestRBAC(ctx, info.FullMethod); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+// ManifestRBACStreamInterceptor returns a gRPC stream interceptor that enforces
+// role-based access control on control-plane RPCs.
+func ManifestRBACStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		if err := checkManifestRBAC(ss.Context(), info.FullMethod); err != nil {
+			return err
+		}
+		return handler(srv, ss)
+	}
+}
+
+// checkManifestRBAC validates that the authenticated user has sufficient role
+// for the requested method.
+func checkManifestRBAC(ctx context.Context, fullMethod string) error {
+	requiredRole, protected := manifestRoleRequirements[fullMethod]
+	if !protected {
+		return nil
+	}
+
+	claims, ok := auth.GetClaimsFromContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "authentication required")
+	}
+
+	// Check API key scope enforcement
+	if len(claims.Scopes) > 0 {
+		if !hasSufficientScope(claims.Scopes, requiredRole) {
+			return status.Error(codes.PermissionDenied,
+				fmt.Sprintf("API key scope insufficient: requires %s-level access", requiredRole))
+		}
+	}
+
+	if !meetsMinimumRole(claims.Roles, requiredRole) {
+		return status.Error(codes.PermissionDenied,
+			fmt.Sprintf("permission denied: %s role required, have roles %v", requiredRole, claims.Roles))
+	}
+
+	return nil
+}
+
+// hasSufficientScope checks whether the API key's scopes cover the required role level.
+// Scope naming convention: "manifest:read" (auditor), "manifest:write" (operator), "manifest:admin" (admin).
+func hasSufficientScope(scopes []string, requiredRole auth.Role) bool {
+	scopeLevel := map[string]int{
+		"manifest:read":  1,
+		"manifest:write": 2,
+		"manifest:admin": 3,
+	}
+
+	requiredLevel, ok := roleLevel[requiredRole]
+	if !ok {
+		return false
+	}
+
+	for _, scope := range scopes {
+		if level, exists := scopeLevel[scope]; exists && level >= requiredLevel {
+			return true
+		}
+	}
+
+	// If no manifest-specific scopes are present, allow (role check handles it)
+	hasManifestScope := false
+	for _, scope := range scopes {
+		if _, exists := scopeLevel[scope]; exists {
+			hasManifestScope = true
+			break
+		}
+	}
+
+	return !hasManifestScope
+}

--- a/services/control-plane/internal/server/interceptors.go
+++ b/services/control-plane/internal/server/interceptors.go
@@ -4,12 +4,16 @@ package server
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/meridianhub/meridian/shared/platform/auth"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// controlPlanePrefix is the gRPC namespace for control-plane services.
+const controlPlanePrefix = "/meridian.control_plane.v1."
 
 // roleLevel maps roles to numeric levels for hierarchy comparison.
 // Higher numbers indicate more privileged roles.
@@ -26,6 +30,9 @@ var roleLevel = map[auth.Role]int{
 // manifestRoleRequirements maps gRPC full method names to the minimum role required.
 // Roles are hierarchical: admin > operator > auditor.
 // A user with a higher role can access methods requiring a lower role.
+//
+// IMPORTANT: All control-plane RPCs must be listed here. Unlisted control-plane
+// RPCs are denied by the fail-closed check in checkManifestRBAC.
 var manifestRoleRequirements = map[string]auth.Role{
 	// ManifestHistoryService - read-only, auditor level
 	"/meridian.control_plane.v1.ManifestHistoryService/GetCurrentManifest":   auth.RoleAuditor,
@@ -37,6 +44,19 @@ var manifestRoleRequirements = map[string]auth.Role{
 
 	// SagaExecutionService - operational, operator level
 	"/meridian.control_plane.v1.SagaExecutionService/ExecuteSaga": auth.RoleOperator,
+
+	// CausationVisualizerService - read-only debugging, auditor level
+	"/meridian.control_plane.v1.CausationVisualizerService/GetCausationTreeForPosition":    auth.RoleAuditor,
+	"/meridian.control_plane.v1.CausationVisualizerService/GetCausationTreeForTransaction": auth.RoleAuditor,
+	"/meridian.control_plane.v1.CausationVisualizerService/GetCausationTreeForEvent":       auth.RoleAuditor,
+
+	// BalanceSheetService - read-only reporting, auditor level
+	"/meridian.control_plane.v1.BalanceSheetService/GetBalanceSheet":       auth.RoleAuditor,
+	"/meridian.control_plane.v1.BalanceSheetService/GetPositionDetails":    auth.RoleAuditor,
+	"/meridian.control_plane.v1.BalanceSheetService/ExportBalanceSheetCSV": auth.RoleAuditor,
+
+	// AuthService - internal service-to-service, service level
+	"/meridian.control_plane.v1.AuthService/ValidateAPIKey": auth.RoleService,
 }
 
 // meetsMinimumRole checks whether any of the user's roles meets or exceeds
@@ -59,8 +79,9 @@ func meetsMinimumRole(userRoles []string, minimumRole auth.Role) bool {
 // ManifestRBACUnaryInterceptor returns a gRPC unary interceptor that enforces
 // role-based access control on control-plane RPCs.
 //
-// Methods not listed in manifestRoleRequirements are allowed through (e.g., health checks).
-// The interceptor expects claims to be present in the context (populated by the auth interceptor).
+// The interceptor fails closed: any control-plane RPC not explicitly listed in
+// manifestRoleRequirements is denied. Non-control-plane methods (health, reflection)
+// pass through.
 func ManifestRBACUnaryInterceptor() grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
@@ -92,10 +113,15 @@ func ManifestRBACStreamInterceptor() grpc.StreamServerInterceptor {
 }
 
 // checkManifestRBAC validates that the authenticated user has sufficient role
-// for the requested method.
+// for the requested method. Fails closed for unlisted control-plane RPCs.
 func checkManifestRBAC(ctx context.Context, fullMethod string) error {
 	requiredRole, protected := manifestRoleRequirements[fullMethod]
 	if !protected {
+		// Fail closed: deny unlisted control-plane RPCs
+		if strings.HasPrefix(fullMethod, controlPlanePrefix) {
+			return status.Errorf(codes.PermissionDenied,
+				"permission denied: no RBAC rule configured for %s", fullMethod)
+		}
 		return nil
 	}
 

--- a/services/control-plane/internal/server/interceptors_test.go
+++ b/services/control-plane/internal/server/interceptors_test.go
@@ -1,0 +1,303 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func contextWithClaims(roles []string, scopes []string) context.Context {
+	claims := &auth.Claims{
+		UserID: "test-user",
+		Roles:  roles,
+		Scopes: scopes,
+	}
+	return context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
+}
+
+func noopUnaryHandler(_ context.Context, _ interface{}) (interface{}, error) {
+	return "ok", nil
+}
+
+func TestManifestRBACUnaryInterceptor_AuditorCanReadHistory(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+	ctx := contextWithClaims([]string{"auditor"}, nil)
+
+	methods := []string{
+		"/meridian.control_plane.v1.ManifestHistoryService/GetCurrentManifest",
+		"/meridian.control_plane.v1.ManifestHistoryService/GetManifestVersion",
+		"/meridian.control_plane.v1.ManifestHistoryService/ListManifestVersions",
+	}
+
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: method}, noopUnaryHandler)
+			require.NoError(t, err)
+			assert.Equal(t, "ok", resp)
+		})
+	}
+}
+
+func TestManifestRBACUnaryInterceptor_AuditorCannotApplyManifest(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+	ctx := contextWithClaims([]string{"auditor"}, nil)
+
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+		FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
+	}, noopUnaryHandler)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+	assert.Contains(t, st.Message(), "admin role required")
+	assert.Contains(t, st.Message(), "auditor")
+}
+
+func TestManifestRBACUnaryInterceptor_AuditorCannotExecuteSaga(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+	ctx := contextWithClaims([]string{"auditor"}, nil)
+
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+		FullMethod: "/meridian.control_plane.v1.SagaExecutionService/ExecuteSaga",
+	}, noopUnaryHandler)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+	assert.Contains(t, st.Message(), "operator role required")
+}
+
+func TestManifestRBACUnaryInterceptor_OperatorCanExecuteSaga(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+	ctx := contextWithClaims([]string{"operator"}, nil)
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+		FullMethod: "/meridian.control_plane.v1.SagaExecutionService/ExecuteSaga",
+	}, noopUnaryHandler)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+func TestManifestRBACUnaryInterceptor_OperatorCannotApplyManifest(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+	ctx := contextWithClaims([]string{"operator"}, nil)
+
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+		FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
+	}, noopUnaryHandler)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+	assert.Contains(t, st.Message(), "admin role required")
+}
+
+func TestManifestRBACUnaryInterceptor_AdminCanCallAll(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+	ctx := contextWithClaims([]string{"admin"}, nil)
+
+	methods := []string{
+		"/meridian.control_plane.v1.ManifestHistoryService/GetCurrentManifest",
+		"/meridian.control_plane.v1.ManifestHistoryService/GetManifestVersion",
+		"/meridian.control_plane.v1.ManifestHistoryService/ListManifestVersions",
+		"/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
+		"/meridian.control_plane.v1.SagaExecutionService/ExecuteSaga",
+	}
+
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: method}, noopUnaryHandler)
+			require.NoError(t, err)
+			assert.Equal(t, "ok", resp)
+		})
+	}
+}
+
+func TestManifestRBACUnaryInterceptor_TenantOwnerCanCallAll(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+	ctx := contextWithClaims([]string{"tenant-owner"}, nil)
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+		FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
+	}, noopUnaryHandler)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+func TestManifestRBACUnaryInterceptor_Unauthenticated(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+	ctx := context.Background() // no claims
+
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+		FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
+	}, noopUnaryHandler)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unauthenticated, st.Code())
+}
+
+func TestManifestRBACUnaryInterceptor_UnprotectedMethodAllowed(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+	ctx := context.Background() // no claims
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+		FullMethod: "/grpc.health.v1.Health/Check",
+	}, noopUnaryHandler)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+func TestManifestRBACUnaryInterceptor_OperatorCanReadHistory(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+	ctx := contextWithClaims([]string{"operator"}, nil)
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+		FullMethod: "/meridian.control_plane.v1.ManifestHistoryService/GetCurrentManifest",
+	}, noopUnaryHandler)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+func TestManifestRBACUnaryInterceptor_ServiceRoleCanApply(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+	ctx := contextWithClaims([]string{"service"}, nil)
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+		FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
+	}, noopUnaryHandler)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+func TestManifestRBACUnaryInterceptor_APIKeyScopeEnforcement(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+
+	t.Run("read scope can access history", func(t *testing.T) {
+		ctx := contextWithClaims([]string{"admin"}, []string{"manifest:read"})
+
+		resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+			FullMethod: "/meridian.control_plane.v1.ManifestHistoryService/GetCurrentManifest",
+		}, noopUnaryHandler)
+
+		require.NoError(t, err)
+		assert.Equal(t, "ok", resp)
+	})
+
+	t.Run("read scope cannot apply manifest", func(t *testing.T) {
+		ctx := contextWithClaims([]string{"admin"}, []string{"manifest:read"})
+
+		_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+			FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
+		}, noopUnaryHandler)
+
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+		assert.Contains(t, st.Message(), "API key scope insufficient")
+	})
+
+	t.Run("admin scope can apply manifest", func(t *testing.T) {
+		ctx := contextWithClaims([]string{"admin"}, []string{"manifest:admin"})
+
+		resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+			FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
+		}, noopUnaryHandler)
+
+		require.NoError(t, err)
+		assert.Equal(t, "ok", resp)
+	})
+
+	t.Run("write scope can execute saga", func(t *testing.T) {
+		ctx := contextWithClaims([]string{"operator"}, []string{"manifest:write"})
+
+		resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+			FullMethod: "/meridian.control_plane.v1.SagaExecutionService/ExecuteSaga",
+		}, noopUnaryHandler)
+
+		require.NoError(t, err)
+		assert.Equal(t, "ok", resp)
+	})
+
+	t.Run("no manifest scopes passes through to role check", func(t *testing.T) {
+		ctx := contextWithClaims([]string{"admin"}, []string{"other:read"})
+
+		resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+			FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
+		}, noopUnaryHandler)
+
+		require.NoError(t, err)
+		assert.Equal(t, "ok", resp)
+	})
+}
+
+func TestManifestRBACUnaryInterceptor_DescriptiveErrorMessages(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+
+	t.Run("includes required role in error", func(t *testing.T) {
+		ctx := contextWithClaims([]string{"auditor"}, nil)
+		_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+			FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
+		}, noopUnaryHandler)
+
+		st, _ := status.FromError(err)
+		assert.Contains(t, st.Message(), "admin role required")
+	})
+
+	t.Run("includes actual roles in error", func(t *testing.T) {
+		ctx := contextWithClaims([]string{"auditor"}, nil)
+		_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+			FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
+		}, noopUnaryHandler)
+
+		st, _ := status.FromError(err)
+		assert.Contains(t, st.Message(), "auditor")
+	})
+}
+
+func TestMeetsMinimumRole(t *testing.T) {
+	tests := []struct {
+		name        string
+		userRoles   []string
+		minimumRole auth.Role
+		expected    bool
+	}{
+		{"auditor meets auditor", []string{"auditor"}, auth.RoleAuditor, true},
+		{"operator meets auditor", []string{"operator"}, auth.RoleAuditor, true},
+		{"admin meets auditor", []string{"admin"}, auth.RoleAuditor, true},
+		{"auditor does not meet operator", []string{"auditor"}, auth.RoleOperator, false},
+		{"auditor does not meet admin", []string{"auditor"}, auth.RoleAdmin, false},
+		{"operator meets operator", []string{"operator"}, auth.RoleOperator, true},
+		{"operator does not meet admin", []string{"operator"}, auth.RoleAdmin, false},
+		{"admin meets admin", []string{"admin"}, auth.RoleAdmin, true},
+		{"super-admin meets admin", []string{"super-admin"}, auth.RoleAdmin, true},
+		{"tenant-owner meets admin", []string{"tenant-owner"}, auth.RoleAdmin, true},
+		{"platform-admin meets admin", []string{"platform-admin"}, auth.RoleAdmin, true},
+		{"empty roles meets nothing", []string{}, auth.RoleAuditor, false},
+		{"invalid role meets nothing", []string{"viewer"}, auth.RoleAuditor, false},
+		{"multiple roles use highest", []string{"auditor", "admin"}, auth.RoleAdmin, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := meetsMinimumRole(tt.userRoles, tt.minimumRole)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/services/control-plane/internal/server/interceptors_test.go
+++ b/services/control-plane/internal/server/interceptors_test.go
@@ -21,6 +21,18 @@ func contextWithClaims(roles []string, scopes []string) context.Context {
 	return context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
 }
 
+// contextWithClaimsAndContextScopes creates a context with Claims (no Claims.Scopes)
+// but with scopes injected via ScopesContextKey (as API key validation does).
+func contextWithClaimsAndContextScopes(roles []string, ctxScopes []string) context.Context {
+	claims := &auth.Claims{
+		UserID: "test-user",
+		Roles:  roles,
+	}
+	ctx := context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
+	ctx = context.WithValue(ctx, auth.ScopesContextKey, ctxScopes)
+	return ctx
+}
+
 func noopUnaryHandler(_ context.Context, _ interface{}) (interface{}, error) {
 	return "ok", nil
 }
@@ -287,6 +299,63 @@ func TestManifestRBACUnaryInterceptor_DescriptiveErrorMessages(t *testing.T) {
 		st, ok := status.FromError(err)
 		require.True(t, ok)
 		assert.Contains(t, st.Message(), "auditor")
+	})
+}
+
+func TestManifestRBACStreamInterceptor_AuditorDeniedApply(t *testing.T) {
+	interceptor := ManifestRBACStreamInterceptor()
+
+	ctx := contextWithClaims([]string{"auditor"}, nil)
+	ss := &fakeServerStream{ctx: ctx}
+
+	err := interceptor(nil, ss, &grpc.StreamServerInfo{
+		FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
+	}, func(_ interface{}, _ grpc.ServerStream) error {
+		t.Fatal("handler should not be called")
+		return nil
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+}
+
+// fakeServerStream implements grpc.ServerStream for testing the stream interceptor.
+type fakeServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (f *fakeServerStream) Context() context.Context { return f.ctx }
+
+func TestManifestRBACUnaryInterceptor_APIKeyContextScopes(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+
+	t.Run("context scopes enforce manifest restrictions", func(t *testing.T) {
+		// API key with read scope in context (not in Claims.Scopes)
+		ctx := contextWithClaimsAndContextScopes([]string{"admin"}, []string{"manifest:read"})
+
+		_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+			FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
+		}, noopUnaryHandler)
+
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+		assert.Contains(t, st.Message(), "API key scope insufficient")
+	})
+
+	t.Run("context scopes allow matching access", func(t *testing.T) {
+		ctx := contextWithClaimsAndContextScopes([]string{"admin"}, []string{"manifest:admin"})
+
+		resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+			FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
+		}, noopUnaryHandler)
+
+		require.NoError(t, err)
+		assert.Equal(t, "ok", resp)
 	})
 }
 

--- a/services/control-plane/internal/server/interceptors_test.go
+++ b/services/control-plane/internal/server/interceptors_test.go
@@ -359,6 +359,38 @@ func TestManifestRBACUnaryInterceptor_APIKeyContextScopes(t *testing.T) {
 	})
 }
 
+func TestManifestRBACUnaryInterceptor_ServiceRoleSkipsScopeCheck(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+
+	// Service account with manifest:read scope calling ValidateAPIKey should succeed
+	// because scope checks are skipped for RoleService RPCs.
+	ctx := contextWithClaims([]string{"service"}, []string{"manifest:read"})
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+		FullMethod: "/meridian.control_plane.v1.AuthService/ValidateAPIKey",
+	}, noopUnaryHandler)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+func TestManifestRBACUnaryInterceptor_UnknownManifestScopeDenied(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+
+	// API key with typo scope "manifest:writer" should be denied (fail closed)
+	ctx := contextWithClaims([]string{"admin"}, []string{"manifest:writer"})
+
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+		FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
+	}, noopUnaryHandler)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+	assert.Contains(t, st.Message(), "API key scope insufficient")
+}
+
 func TestMeetsMinimumRole(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/services/control-plane/internal/server/interceptors_test.go
+++ b/services/control-plane/internal/server/interceptors_test.go
@@ -161,6 +161,21 @@ func TestManifestRBACUnaryInterceptor_UnprotectedMethodAllowed(t *testing.T) {
 	assert.Equal(t, "ok", resp)
 }
 
+func TestManifestRBACUnaryInterceptor_UnlistedControlPlaneRPCDenied(t *testing.T) {
+	interceptor := ManifestRBACUnaryInterceptor()
+	ctx := contextWithClaims([]string{"admin"}, nil)
+
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+		FullMethod: "/meridian.control_plane.v1.SomeNewService/SomeMethod",
+	}, noopUnaryHandler)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.PermissionDenied, st.Code())
+	assert.Contains(t, st.Message(), "no RBAC rule configured")
+}
+
 func TestManifestRBACUnaryInterceptor_OperatorCanReadHistory(t *testing.T) {
 	interceptor := ManifestRBACUnaryInterceptor()
 	ctx := contextWithClaims([]string{"operator"}, nil)
@@ -256,7 +271,9 @@ func TestManifestRBACUnaryInterceptor_DescriptiveErrorMessages(t *testing.T) {
 			FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
 		}, noopUnaryHandler)
 
-		st, _ := status.FromError(err)
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
 		assert.Contains(t, st.Message(), "admin role required")
 	})
 
@@ -266,7 +283,9 @@ func TestManifestRBACUnaryInterceptor_DescriptiveErrorMessages(t *testing.T) {
 			FullMethod: "/meridian.control_plane.v1.ApplyManifestService/ApplyManifest",
 		}, noopUnaryHandler)
 
-		st, _ := status.FromError(err)
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
 		assert.Contains(t, st.Message(), "auditor")
 	})
 }


### PR DESCRIPTION
## Summary

- Add gRPC unary and stream interceptors that enforce role-based access control on control-plane RPCs
- Map each RPC to a minimum required role using a hierarchical model (admin > operator > auditor > none)
- Wire the interceptor into the control-plane gRPC server after the auth interceptor

### Role Requirements

| RPC | Minimum Role |
|-----|-------------|
| ManifestHistoryService/* (read) | auditor |
| SagaExecutionService/ExecuteSaga | operator |
| ApplyManifestService/ApplyManifest | admin |

### API Key Scope Enforcement

API keys with manifest-specific scopes (`manifest:read`, `manifest:write`, `manifest:admin`) are checked independently of roles, preventing scope escalation.

## Test plan

- [x] Auditor can read manifest history but not apply or execute
- [x] Operator can read history and execute sagas but not apply
- [x] Admin can call all manifest operations
- [x] Tenant-owner and super-admin inherit admin-level access via hierarchy
- [x] Service accounts have admin-equivalent access
- [x] Unauthenticated requests to protected methods return Unauthenticated
- [x] Unprotected methods (health checks) pass through without claims
- [x] API key scopes are enforced independently of roles
- [x] Error messages include required role and actual roles
- [x] Role hierarchy unit tests cover all combinations