### PR TITLE
feat: Add handler evolution with version and conversion rules

### DIFF
--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -584,7 +584,7 @@ func (v *ManifestValidator) validateSingleStarlarkScript(
 		return
 	}
 
-	predeclared, callLog, err := v.buildStarlarkPredeclared()
+	predeclared, callLog, deprecationWarnings, err := v.buildStarlarkPredeclared()
 	if err != nil {
 		addError(result, ValidationError{
 			Severity: SeverityError,
@@ -613,6 +613,19 @@ func (v *ManifestValidator) validateSingleStarlarkScript(
 		addStarlarkUndefinedSuggestion(execErr, &ve)
 		addError(result, ve)
 		return
+	}
+
+	// Propagate deprecation warnings from handler evolution
+	if deprecationWarnings != nil {
+		for _, w := range *deprecationWarnings {
+			addError(result, ValidationError{
+				Severity:   SeverityWarning,
+				Path:       path,
+				Code:       w.Code,
+				Message:    w.Message,
+				Suggestion: w.Suggestion,
+			})
+		}
 	}
 
 	// Capture handler call metadata in the result
@@ -1448,14 +1461,15 @@ func (v *ManifestValidator) validateImmutability(
 // buildStarlarkPredeclared creates the predeclared dictionary for Starlark compilation.
 // It uses typed service modules from the schema registry for handler parameter validation.
 // Returns the predeclared dict, handler call log, and any error.
-func (v *ManifestValidator) buildStarlarkPredeclared() (starlark.StringDict, *[]schema.HandlerCallInfo, error) {
+func (v *ManifestValidator) buildStarlarkPredeclared() (starlark.StringDict, *[]schema.HandlerCallInfo, *[]schema.ValidationWarning, error) {
 	predeclared := make(starlark.StringDict)
 
-	// Build typed service modules from schema registry
+	// Build typed service modules from schema registry with deprecation warning collection
 	var callLog []schema.HandlerCallInfo
-	modules, err := schema.BuildValidationModules(v.schemaRegistry, &callLog)
+	var deprecationWarnings []schema.ValidationWarning
+	modules, err := schema.BuildValidationModulesWithWarnings(v.schemaRegistry, &callLog, &deprecationWarnings)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	for name, module := range modules {
 		predeclared[name] = module
@@ -1473,7 +1487,7 @@ func (v *ManifestValidator) buildStarlarkPredeclared() (starlark.StringDict, *[]
 			return starlark.String("0"), nil
 		})
 
-	return predeclared, &callLog, nil
+	return predeclared, &callLog, &deprecationWarnings, nil
 }
 
 // enrichHandlerValidationError checks if a Starlark execution error is a handler

--- a/shared/pkg/saga/schema/handler_evolution_test.go
+++ b/shared/pkg/saga/schema/handler_evolution_test.go
@@ -1,0 +1,553 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+func TestHandlerEvolution_VersionAndDeprecatedFields(t *testing.T) {
+	yamlData := `
+service: test_service
+version: "2.0"
+handlers:
+  test.record_entry:
+    description: "Record an entry (v2)"
+    version: 2
+    compensation_strategy: none
+    params:
+      quantity:
+        type: Decimal
+        required: true
+      instrument_code:
+        type: string
+        required: true
+      side:
+        type: enum
+        values: [DEBIT, CREDIT]
+        required: true
+    returns:
+      entry_id:
+        type: string
+    conversions:
+      - from_version: 1
+        from_name: test.initiate_log
+        param_mapping:
+          quantity: amount
+          instrument_code: currency
+          side: direction
+        defaults:
+          instrument_code: "'GBP'"
+        sunset: "3.0"
+  test.old_handler:
+    description: "An old handler still present but deprecated"
+    deprecated: true
+    compensation_strategy: none
+    params:
+      id:
+        type: string
+        required: true
+    returns:
+      status:
+        type: string
+`
+
+	schema, err := Parse([]byte(yamlData))
+	require.NoError(t, err)
+
+	// Verify version field parsed
+	recordEntry := schema.Handlers["test.record_entry"]
+	require.NotNil(t, recordEntry)
+	assert.Equal(t, 2, recordEntry.Version)
+	assert.False(t, recordEntry.Deprecated)
+
+	// Verify conversions parsed
+	require.Len(t, recordEntry.Conversions, 1)
+	conv := recordEntry.Conversions[0]
+	assert.Equal(t, 1, conv.FromVersion)
+	assert.Equal(t, "test.initiate_log", conv.FromName)
+	assert.Equal(t, map[string]string{
+		"quantity":        "amount",
+		"instrument_code": "currency",
+		"side":            "direction",
+	}, conv.ParamMapping)
+	assert.Equal(t, map[string]string{
+		"instrument_code": "'GBP'",
+	}, conv.Defaults)
+	assert.Equal(t, "3.0", conv.Sunset)
+
+	// Verify deprecated field
+	oldHandler := schema.Handlers["test.old_handler"]
+	require.NotNil(t, oldHandler)
+	assert.True(t, oldHandler.Deprecated)
+}
+
+func TestHandlerEvolution_ConversionRuleValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "from_version must be positive",
+			yaml: `
+service: test
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test"
+    version: 2
+    compensation_strategy: none
+    params:
+      id:
+        type: string
+        required: true
+    conversions:
+      - from_version: 0
+        from_name: test.old
+`,
+			wantErr: "from_version must be positive",
+		},
+		{
+			name: "from_version must be less than current version",
+			yaml: `
+service: test
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test"
+    version: 2
+    compensation_strategy: none
+    params:
+      id:
+        type: string
+        required: true
+    conversions:
+      - from_version: 2
+        from_name: test.old
+`,
+			wantErr: "from_version (2) must be less than current version (2)",
+		},
+		{
+			name: "param_mapping references unknown parameter",
+			yaml: `
+service: test
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test"
+    version: 2
+    compensation_strategy: none
+    params:
+      id:
+        type: string
+        required: true
+    conversions:
+      - from_version: 1
+        param_mapping:
+          nonexistent: old_param
+`,
+			wantErr: "param_mapping references unknown parameter \"nonexistent\"",
+		},
+		{
+			name: "defaults references unknown parameter",
+			yaml: `
+service: test
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test"
+    version: 2
+    compensation_strategy: none
+    params:
+      id:
+        type: string
+        required: true
+    conversions:
+      - from_version: 1
+        defaults:
+          missing_param: "'default'"
+`,
+			wantErr: "defaults references unknown parameter \"missing_param\"",
+		},
+		{
+			name: "valid conversion rule passes",
+			yaml: `
+service: test
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test"
+    version: 2
+    compensation_strategy: none
+    params:
+      id:
+        type: string
+        required: true
+    conversions:
+      - from_version: 1
+        from_name: test.old_handler
+        param_mapping:
+          id: old_id
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.yaml))
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestHandlerEvolution_RegistryDeprecatedLookup(t *testing.T) {
+	yamlData := `
+service: test_service
+version: "2.0"
+handlers:
+  test.record_entry:
+    description: "Record an entry (v2)"
+    version: 2
+    compensation_strategy: none
+    params:
+      quantity:
+        type: Decimal
+        required: true
+      instrument_code:
+        type: string
+        required: true
+    returns:
+      entry_id:
+        type: string
+    conversions:
+      - from_version: 1
+        from_name: test.initiate_log
+        param_mapping:
+          quantity: amount
+          instrument_code: currency
+        sunset: "3.0"
+`
+
+	registry := NewRegistry()
+	err := registry.LoadFromYAML([]byte(yamlData))
+	require.NoError(t, err)
+
+	// Current handler exists
+	assert.True(t, registry.HasHandler("test.record_entry"))
+
+	// Deprecated name is indexed
+	mapping := registry.LookupDeprecated("test.initiate_log")
+	require.NotNil(t, mapping)
+	assert.Equal(t, "test.record_entry", mapping.CurrentName)
+	assert.Equal(t, 1, mapping.ConversionRule.FromVersion)
+	assert.Equal(t, "3.0", mapping.ConversionRule.Sunset)
+
+	// Non-deprecated name returns nil
+	assert.Nil(t, registry.LookupDeprecated("test.record_entry"))
+	assert.Nil(t, registry.LookupDeprecated("nonexistent"))
+}
+
+func TestHandlerEvolution_IsDeprecated(t *testing.T) {
+	yamlData := `
+service: test_service
+version: "1.0"
+handlers:
+  test.current:
+    description: "Current handler"
+    compensation_strategy: none
+    params:
+      id:
+        type: string
+        required: true
+  test.old:
+    description: "Old handler"
+    deprecated: true
+    compensation_strategy: none
+    params:
+      id:
+        type: string
+        required: true
+`
+
+	registry := NewRegistry()
+	err := registry.LoadFromYAML([]byte(yamlData))
+	require.NoError(t, err)
+
+	assert.False(t, registry.IsDeprecated("test.current"))
+	assert.True(t, registry.IsDeprecated("test.old"))
+	assert.False(t, registry.IsDeprecated("nonexistent"))
+}
+
+func TestHandlerEvolution_LinterMetadataDeprecation(t *testing.T) {
+	yamlData := `
+service: test_service
+version: "2.0"
+handlers:
+  test.record_entry:
+    description: "Record an entry (v2)"
+    version: 2
+    compensation_strategy: none
+    params:
+      quantity:
+        type: Decimal
+        required: true
+    conversions:
+      - from_version: 1
+        from_name: test.initiate_log
+        param_mapping:
+          quantity: amount
+  test.deprecated_handler:
+    description: "Old handler"
+    deprecated: true
+    compensation_strategy: none
+    params:
+      id:
+        type: string
+        required: true
+`
+
+	registry := NewRegistry()
+	err := registry.LoadFromYAML([]byte(yamlData))
+	require.NoError(t, err)
+
+	metadata := registry.BuildLinterMetadata()
+
+	// Current handler not deprecated
+	assert.False(t, metadata["test.record_entry"].IsDeprecated)
+	assert.Equal(t, "", metadata["test.record_entry"].ReplacedBy)
+
+	// Deprecated handler marked
+	assert.True(t, metadata["test.deprecated_handler"].IsDeprecated)
+
+	// Deprecated name alias also in metadata
+	deprecatedAlias, ok := metadata["test.initiate_log"]
+	require.True(t, ok)
+	assert.True(t, deprecatedAlias.IsDeprecated)
+	assert.Equal(t, "test.record_entry", deprecatedAlias.ReplacedBy)
+}
+
+func TestHandlerEvolution_ValidationModulesDeprecatedWarning(t *testing.T) {
+	yamlData := `
+service: test_service
+version: "2.0"
+handlers:
+  test.record_entry:
+    description: "Record an entry (v2)"
+    version: 2
+    compensation_strategy: none
+    params:
+      quantity:
+        type: Decimal
+        required: true
+    returns:
+      entry_id:
+        type: string
+    conversions:
+      - from_version: 1
+        from_name: test.initiate_log
+        param_mapping:
+          quantity: amount
+        sunset: "3.0"
+`
+
+	registry := NewRegistry()
+	err := registry.LoadFromYAML([]byte(yamlData))
+	require.NoError(t, err)
+
+	var warnings []ValidationWarning
+	modules, err := BuildValidationModulesWithWarnings(registry, nil, &warnings)
+	require.NoError(t, err)
+	require.NotNil(t, modules)
+
+	// Current handler should be accessible and produce no warnings
+	thread := &starlark.Thread{Name: "test"}
+	testModule, ok := modules["test"]
+	require.True(t, ok)
+
+	recordEntry, err := testModule.(*starlarkstruct.Struct).Attr("record_entry")
+	require.NoError(t, err)
+
+	_, err = starlark.Call(thread, recordEntry, nil, []starlark.Tuple{
+		{starlark.String("quantity"), starlark.String("100.00")},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	// Deprecated handler name should also be accessible and produce a warning
+	initiateLog, err := testModule.(*starlarkstruct.Struct).Attr("initiate_log")
+	require.NoError(t, err)
+
+	_, err = starlark.Call(thread, initiateLog, nil, nil)
+	require.NoError(t, err)
+
+	require.Len(t, warnings, 1)
+	assert.Equal(t, ValidationCodeDeprecatedHandler, warnings[0].Code)
+	assert.Contains(t, warnings[0].Message, "test.initiate_log")
+	assert.Contains(t, warnings[0].Message, "deprecated")
+	assert.Contains(t, warnings[0].Suggestion, "test.record_entry")
+	assert.Contains(t, warnings[0].Suggestion, "amount->quantity")
+	assert.Contains(t, warnings[0].Suggestion, "version 3.0")
+}
+
+func TestHandlerEvolution_DeprecatedCurrentHandlerWarning(t *testing.T) {
+	yamlData := `
+service: test_service
+version: "1.0"
+handlers:
+  test.old_handler:
+    description: "Old handler"
+    deprecated: true
+    compensation_strategy: none
+    params:
+      id:
+        type: string
+        required: true
+    returns:
+      status:
+        type: string
+`
+
+	registry := NewRegistry()
+	err := registry.LoadFromYAML([]byte(yamlData))
+	require.NoError(t, err)
+
+	var warnings []ValidationWarning
+	modules, err := BuildValidationModulesWithWarnings(registry, nil, &warnings)
+	require.NoError(t, err)
+
+	thread := &starlark.Thread{Name: "test"}
+	testModule := modules["test"].(*starlarkstruct.Struct)
+
+	oldHandler, err := testModule.Attr("old_handler")
+	require.NoError(t, err)
+
+	// Calling the deprecated handler still validates params
+	_, err = starlark.Call(thread, oldHandler, nil, []starlark.Tuple{
+		{starlark.String("id"), starlark.String("123")},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, warnings, 1)
+	assert.Equal(t, ValidationCodeDeprecatedHandler, warnings[0].Code)
+	assert.Contains(t, warnings[0].Message, "test.old_handler")
+
+	// Validation still works — unknown param rejected
+	_, err = starlark.Call(thread, oldHandler, nil, []starlark.Tuple{
+		{starlark.String("nonexistent"), starlark.String("123")},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "UNKNOWN_PARAM")
+}
+
+func TestHandlerEvolution_CurrentVersionHandlerNoWarning(t *testing.T) {
+	yamlData := `
+service: test_service
+version: "2.0"
+handlers:
+  test.handler:
+    description: "Current handler"
+    version: 2
+    compensation_strategy: none
+    params:
+      id:
+        type: string
+        required: true
+    returns:
+      result:
+        type: string
+`
+
+	registry := NewRegistry()
+	err := registry.LoadFromYAML([]byte(yamlData))
+	require.NoError(t, err)
+
+	var warnings []ValidationWarning
+	modules, err := BuildValidationModulesWithWarnings(registry, nil, &warnings)
+	require.NoError(t, err)
+
+	thread := &starlark.Thread{Name: "test"}
+	testModule := modules["test"].(*starlarkstruct.Struct)
+
+	handler, err := testModule.Attr("handler")
+	require.NoError(t, err)
+
+	_, err = starlark.Call(thread, handler, nil, []starlark.Tuple{
+		{starlark.String("id"), starlark.String("123")},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+}
+
+func TestHandlerEvolution_HandlersYAMLVersionConversion(t *testing.T) {
+	// Verify the embedded handlers.yaml can add versioned handlers with conversions
+	// by testing with a custom YAML that mimics the real handlers.yaml structure
+	yamlData := `
+service: platform
+version: "2.0"
+handlers:
+  position_keeping.record_entry:
+    description: "Record a position entry (v2)"
+    version: 2
+    compensation_strategy: none
+    params:
+      quantity:
+        type: Decimal
+        required: true
+      instrument_code:
+        type: string
+        required: true
+      side:
+        type: enum
+        values: [DEBIT, CREDIT]
+        required: true
+      correlation_id:
+        type: string
+        required: false
+    returns:
+      entry_id:
+        type: string
+    conversions:
+      - from_version: 1
+        from_name: position_keeping.initiate_log
+        param_mapping:
+          quantity: amount
+          instrument_code: currency
+          side: direction
+        defaults:
+          correlation_id: "'auto_' + old_params.account_id"
+        sunset: "3.0"
+`
+
+	registry := NewRegistry()
+	err := registry.LoadFromYAML([]byte(yamlData))
+	require.NoError(t, err)
+
+	// Verify the deprecated name is indexed
+	mapping := registry.LookupDeprecated("position_keeping.initiate_log")
+	require.NotNil(t, mapping)
+	assert.Equal(t, "position_keeping.record_entry", mapping.CurrentName)
+
+	// Verify validation modules expose both old and new names
+	var warnings []ValidationWarning
+	modules, err := BuildValidationModulesWithWarnings(registry, nil, &warnings)
+	require.NoError(t, err)
+
+	pk := modules["position_keeping"].(*starlarkstruct.Struct)
+
+	// New name works
+	_, err = pk.Attr("record_entry")
+	require.NoError(t, err)
+
+	// Old name works (deprecated alias)
+	_, err = pk.Attr("initiate_log")
+	require.NoError(t, err)
+}

--- a/shared/pkg/saga/schema/handler_evolution_test.go
+++ b/shared/pkg/saga/schema/handler_evolution_test.go
@@ -383,10 +383,13 @@ handlers:
 	assert.Empty(t, warnings)
 
 	// Deprecated handler name should also be accessible and produce a warning
+	// Pass old param names (amount -> quantity via param_mapping)
 	initiateLog, err := testModule.(*starlarkstruct.Struct).Attr("initiate_log")
 	require.NoError(t, err)
 
-	_, err = starlark.Call(thread, initiateLog, nil, nil)
+	_, err = starlark.Call(thread, initiateLog, nil, []starlark.Tuple{
+		{starlark.String("amount"), starlark.String("100.00")},
+	})
 	require.NoError(t, err)
 
 	require.Len(t, warnings, 1)
@@ -550,4 +553,132 @@ handlers:
 	// Old name works (deprecated alias)
 	_, err = pk.Attr("initiate_log")
 	require.NoError(t, err)
+}
+
+func TestHandlerEvolution_DuplicateDeprecatedAlias(t *testing.T) {
+	yamlData := `
+service: test_service
+version: "2.0"
+handlers:
+  test.handler_a:
+    description: "Handler A"
+    version: 2
+    compensation_strategy: none
+    params:
+      id:
+        type: string
+        required: true
+    conversions:
+      - from_version: 1
+        from_name: test.old_name
+  test.handler_b:
+    description: "Handler B"
+    version: 2
+    compensation_strategy: none
+    params:
+      id:
+        type: string
+        required: true
+    conversions:
+      - from_version: 1
+        from_name: test.old_name
+`
+
+	registry := NewRegistry()
+	err := registry.LoadFromYAML([]byte(yamlData))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate deprecated alias")
+	assert.Contains(t, err.Error(), "test.old_name")
+}
+
+func TestHandlerEvolution_DeprecatedAliasParamTranslation(t *testing.T) {
+	yamlData := `
+service: test_service
+version: "2.0"
+handlers:
+  test.record_entry:
+    description: "Record an entry (v2)"
+    version: 2
+    compensation_strategy: none
+    params:
+      quantity:
+        type: Decimal
+        required: true
+      instrument_code:
+        type: string
+        required: true
+    returns:
+      entry_id:
+        type: string
+    conversions:
+      - from_version: 1
+        from_name: test.initiate_log
+        param_mapping:
+          quantity: amount
+          instrument_code: currency
+`
+
+	registry := NewRegistry()
+	err := registry.LoadFromYAML([]byte(yamlData))
+	require.NoError(t, err)
+
+	var warnings []ValidationWarning
+	modules, err := BuildValidationModulesWithWarnings(registry, nil, &warnings)
+	require.NoError(t, err)
+
+	thread := &starlark.Thread{Name: "test"}
+	testModule := modules["test"].(*starlarkstruct.Struct)
+
+	initiateLog, err := testModule.Attr("initiate_log")
+	require.NoError(t, err)
+
+	// Old param names should be translated and validated
+	_, err = starlark.Call(thread, initiateLog, nil, []starlark.Tuple{
+		{starlark.String("amount"), starlark.String("100.00")},
+		{starlark.String("currency"), starlark.String("GBP")},
+	})
+	require.NoError(t, err)
+
+	// Missing required old param should fail (amount maps to required quantity)
+	warnings = nil
+	_, err = starlark.Call(thread, initiateLog, nil, []starlark.Tuple{
+		{starlark.String("currency"), starlark.String("GBP")},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MISSING_REQUIRED_PARAM")
+	assert.Contains(t, err.Error(), "quantity")
+
+	// Unknown old param should fail
+	warnings = nil
+	_, err = starlark.Call(thread, initiateLog, nil, []starlark.Tuple{
+		{starlark.String("amount"), starlark.String("100.00")},
+		{starlark.String("currency"), starlark.String("GBP")},
+		{starlark.String("totally_unknown"), starlark.String("bad")},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "UNKNOWN_PARAM")
+}
+
+func TestHandlerEvolution_VersionDefaultsTo1(t *testing.T) {
+	// A handler with no explicit version should default to 1,
+	// making from_version: 1 invalid (must be < current version)
+	yamlData := `
+service: test
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test"
+    compensation_strategy: none
+    params:
+      id:
+        type: string
+        required: true
+    conversions:
+      - from_version: 1
+        from_name: test.old
+`
+
+	_, err := Parse([]byte(yamlData))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "from_version (1) must be less than current version (1)")
 }

--- a/shared/pkg/saga/schema/handlers.yaml
+++ b/shared/pkg/saga/schema/handlers.yaml
@@ -1,6 +1,28 @@
 # Platform Default Handler Schemas
 # These schemas define the type signatures for all platform-provided saga handlers.
 # Handlers are invoked from Starlark scripts via invoke_handler("handler.name", params).
+#
+# Handler Evolution:
+#   Handlers support versioning and conversion rules for backwards-compatible evolution.
+#   When a handler is renamed or its parameters change, add a `conversions` block:
+#
+#   Example:
+#     service_name.new_handler:
+#       version: 2
+#       params: { ... }
+#       conversions:
+#         - from_version: 1
+#           from_name: service_name.old_handler
+#           param_mapping:
+#             new_param: old_param      # maps old param names to new ones
+#           defaults:
+#             new_required_param: "'default_value'"
+#           sunset: "3.0"              # version when old name is removed
+#
+#   Deprecated handlers (still present but discouraged):
+#     service_name.old_handler:
+#       deprecated: true
+#       ...
 
 service: platform
 version: "1.0"

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -84,6 +84,8 @@ var (
 	ErrMissingCompensationStrategy  = errors.New("handler must declare either 'compensate' or 'compensation_strategy'")
 	ErrInvalidCompensationStrategy  = errors.New("invalid compensation_strategy value")
 	ErrConflictCompensationStrategy = errors.New("handler with 'compensate' should not set 'compensation_strategy' to non-auto value")
+	ErrInvalidConversionRule        = errors.New("invalid conversion rule")
+	ErrDeprecatedHandler            = errors.New("deprecated handler")
 )
 
 // Schema represents a collection of handler definitions for a service.
@@ -119,6 +121,35 @@ type HandlerDef struct {
 	// CompensationStrategy declares how compensation is handled when no compensate handler is set.
 	// Valid values: "auto" (implicit when compensate is set), "saga_managed", "none".
 	CompensationStrategy CompensationStrategy `yaml:"compensation_strategy,omitempty"`
+
+	// Version is the handler version number. Defaults to 1 if unset.
+	Version int `yaml:"version,omitempty"`
+
+	// IsDeprecated marks this handler as deprecated. Scripts calling it will receive a warning.
+	Deprecated bool `yaml:"deprecated,omitempty"`
+
+	// Conversions defines rules for converting calls from previous handler versions.
+	Conversions []ConversionRule `yaml:"conversions,omitempty"`
+}
+
+// ConversionRule defines how to convert a call from a deprecated handler to the current version.
+type ConversionRule struct {
+	// FromVersion is the version being converted from.
+	FromVersion int `yaml:"from_version"`
+
+	// FromName is the old handler name (if renamed).
+	FromName string `yaml:"from_name,omitempty"`
+
+	// ParamMapping maps old parameter names to new parameter names.
+	// Key: new param name, Value: old param name.
+	ParamMapping map[string]string `yaml:"param_mapping,omitempty"`
+
+	// Defaults provides default values for new parameters not present in old versions.
+	// Key: param name, Value: default value expression.
+	Defaults map[string]string `yaml:"defaults,omitempty"`
+
+	// Sunset is the version at which the old handler will be removed entirely.
+	Sunset string `yaml:"sunset,omitempty"`
 }
 
 // FieldDef defines a single field (parameter or return value).
@@ -188,7 +219,22 @@ func (h *HandlerDef) Validate(handlerName string) error {
 		}
 	}
 
-	// Compensation coverage: every handler must declare either compensate or compensation_strategy
+	if err := h.validateCompensation(handlerName); err != nil {
+		return err
+	}
+
+	for i := range h.Conversions {
+		if err := h.validateConversionRule(handlerName, i); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateCompensation checks compensation coverage: every handler must declare
+// either compensate or compensation_strategy, and the values must be consistent.
+func (h *HandlerDef) validateCompensation(handlerName string) error {
 	if h.Compensate == "" && h.CompensationStrategy == "" {
 		return fmt.Errorf("%w: %s", ErrMissingCompensationStrategy, handlerName)
 	}
@@ -201,7 +247,32 @@ func (h *HandlerDef) Validate(handlerName string) error {
 	if h.Compensate != "" && h.CompensationStrategy != "" && h.CompensationStrategy != CompensationStrategyAuto {
 		return fmt.Errorf("%w: %s", ErrConflictCompensationStrategy, handlerName)
 	}
+	return nil
+}
 
+// validateConversionRule checks a single conversion rule is well-formed.
+func (h *HandlerDef) validateConversionRule(handlerName string, index int) error {
+	conv := h.Conversions[index]
+
+	if conv.FromVersion <= 0 {
+		return fmt.Errorf("%w: %s conversions[%d] from_version must be positive", ErrInvalidConversionRule, handlerName, index)
+	}
+	if h.Version > 0 && conv.FromVersion >= h.Version {
+		return fmt.Errorf("%w: %s conversions[%d] from_version (%d) must be less than current version (%d)",
+			ErrInvalidConversionRule, handlerName, index, conv.FromVersion, h.Version)
+	}
+	for newParam := range conv.ParamMapping {
+		if _, exists := h.Params[newParam]; !exists {
+			return fmt.Errorf("%w: %s conversions[%d] param_mapping references unknown parameter %q",
+				ErrInvalidConversionRule, handlerName, index, newParam)
+		}
+	}
+	for defaultParam := range conv.Defaults {
+		if _, exists := h.Params[defaultParam]; !exists {
+			return fmt.Errorf("%w: %s conversions[%d] defaults references unknown parameter %q",
+				ErrInvalidConversionRule, handlerName, index, defaultParam)
+		}
+	}
 	return nil
 }
 
@@ -272,18 +343,29 @@ func (f *FieldDef) validateEnumValue(name string, params map[string]any) error {
 	return fmt.Errorf("%w: %s got %q, allowed: %v", ErrInvalidEnumValue, name, strVal, f.Values)
 }
 
+// DeprecatedMapping records how a deprecated handler name maps to its current replacement.
+type DeprecatedMapping struct {
+	// CurrentName is the fully-qualified name of the current handler.
+	CurrentName string
+
+	// ConversionRule is the conversion rule that applies.
+	ConversionRule *ConversionRule
+}
+
 // Registry manages multiple handler schemas.
 type Registry struct {
-	mu       sync.RWMutex
-	schemas  []*Schema
-	handlers map[string]*HandlerDef
+	mu              sync.RWMutex
+	schemas         []*Schema
+	handlers        map[string]*HandlerDef
+	deprecatedNames map[string]*DeprecatedMapping // old name -> current handler mapping
 }
 
 // NewRegistry creates a new empty schema registry.
 func NewRegistry() *Registry {
 	return &Registry{
-		schemas:  make([]*Schema, 0),
-		handlers: make(map[string]*HandlerDef),
+		schemas:         make([]*Schema, 0),
+		handlers:        make(map[string]*HandlerDef),
+		deprecatedNames: make(map[string]*DeprecatedMapping),
 	}
 }
 
@@ -300,6 +382,16 @@ func (r *Registry) LoadFromYAML(data []byte) error {
 	r.schemas = append(r.schemas, schema)
 	for name, handler := range schema.Handlers {
 		r.handlers[name] = handler
+		// Index deprecated name mappings from conversion rules
+		for i := range handler.Conversions {
+			conv := &handler.Conversions[i]
+			if conv.FromName != "" {
+				r.deprecatedNames[conv.FromName] = &DeprecatedMapping{
+					CurrentName:    name,
+					ConversionRule: conv,
+				}
+			}
+		}
 	}
 
 	return nil
@@ -337,6 +429,27 @@ func (r *Registry) HasHandler(name string) bool {
 
 	_, ok := r.handlers[name]
 	return ok
+}
+
+// LookupDeprecated checks if a handler name is deprecated and returns
+// the mapping to the current handler, or nil if the name is not deprecated.
+func (r *Registry) LookupDeprecated(name string) *DeprecatedMapping {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.deprecatedNames[name]
+}
+
+// IsDeprecated returns true if the handler exists but is marked as deprecated.
+func (r *Registry) IsDeprecated(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	handler, ok := r.handlers[name]
+	if !ok {
+		return false
+	}
+	return handler.Deprecated
 }
 
 // LoadFromFile loads a schema from a YAML file.
@@ -418,6 +531,12 @@ type LinterMetadata struct {
 
 	// HasAutoCompensation indicates the handler has a compensate: field.
 	HasAutoCompensation bool
+
+	// IsDeprecated indicates the handler is deprecated and should produce a warning.
+	IsDeprecated bool
+
+	// ReplacedBy is the current handler name if this handler has been superseded.
+	ReplacedBy string
 }
 
 // BuildLinterMetadata extracts linter metadata from the schema registry.
@@ -441,7 +560,23 @@ func (r *Registry) BuildLinterMetadata() map[string]LinterMetadata {
 		} else {
 			meta.CompensationStrategy = string(handler.CompensationStrategy)
 		}
+		if handler.Deprecated {
+			meta.IsDeprecated = true
+		}
 		metadata[name] = meta
+	}
+
+	// Also add entries for deprecated name aliases so they can be detected
+	for oldName, mapping := range r.deprecatedNames {
+		if _, exists := metadata[oldName]; !exists {
+			// Get the current handler's metadata as a base
+			if currentMeta, ok := metadata[mapping.CurrentName]; ok {
+				deprecatedMeta := currentMeta
+				deprecatedMeta.IsDeprecated = true
+				deprecatedMeta.ReplacedBy = mapping.CurrentName
+				metadata[oldName] = deprecatedMeta
+			}
+		}
 	}
 
 	return metadata

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -207,6 +207,11 @@ func (s *Schema) Validate() error {
 
 // Validate checks that the handler definition is well-formed.
 func (h *HandlerDef) Validate(handlerName string) error {
+	// Normalize version: unset (0) defaults to 1
+	if h.Version == 0 {
+		h.Version = 1
+	}
+
 	for fieldName, field := range h.Params {
 		if err := field.Validate(fmt.Sprintf("%s.params.%s", handlerName, fieldName)); err != nil {
 			return err
@@ -386,6 +391,12 @@ func (r *Registry) LoadFromYAML(data []byte) error {
 		for i := range handler.Conversions {
 			conv := &handler.Conversions[i]
 			if conv.FromName != "" {
+				if existing, exists := r.deprecatedNames[conv.FromName]; exists {
+					return fmt.Errorf(
+						"%w: duplicate deprecated alias %q maps to both %s and %s",
+						ErrInvalidConversionRule, conv.FromName, existing.CurrentName, name,
+					)
+				}
 				r.deprecatedNames[conv.FromName] = &DeprecatedMapping{
 					CurrentName:    name,
 					ConversionRule: conv,

--- a/shared/pkg/saga/schema/validation_modules.go
+++ b/shared/pkg/saga/schema/validation_modules.go
@@ -468,8 +468,18 @@ func wrapDeprecatedValidationHandler(oldName string, mapping *DeprecatedMapping,
 			})
 		}
 
-		// Validate using old param names mapped to current params
-		// For deprecated name aliases, we accept the old param names
+		// Translate old kwargs through param_mapping and validate against current schema
+		translatedKwargs, translatedNames := translateDeprecatedKwargs(kwargs, mapping.ConversionRule)
+		if err := validateUnknownParams(mapping.CurrentName, translatedNames, currentDef); err != nil {
+			return nil, err
+		}
+		if err := validateRequiredParams(mapping.CurrentName, translatedNames, currentDef); err != nil {
+			return nil, err
+		}
+		if err := validateParamTypes(mapping.CurrentName, translatedKwargs, currentDef); err != nil {
+			return nil, err
+		}
+
 		return buildMockResult(mapping.CurrentName, currentDef), nil
 	})
 }
@@ -505,6 +515,41 @@ func wrapDeprecatedCurrentHandler(fullName string, handlerDef *HandlerDef, callL
 
 		return buildMockResult(fullName, handlerDef), nil
 	})
+}
+
+// translateDeprecatedKwargs translates old parameter names to new names using the conversion rule's
+// param_mapping. Parameters not in the mapping are passed through unchanged.
+// Returns the translated kwargs and their names for subsequent validation.
+func translateDeprecatedKwargs(kwargs []starlark.Tuple, conv *ConversionRule) ([]starlark.Tuple, []string) {
+	if conv == nil || len(conv.ParamMapping) == 0 {
+		return kwargs, collectParamNames(kwargs)
+	}
+
+	// Build reverse mapping: old name -> new name
+	reverseMapping := make(map[string]string, len(conv.ParamMapping))
+	for newParam, oldParam := range conv.ParamMapping {
+		reverseMapping[oldParam] = newParam
+	}
+
+	translated := make([]starlark.Tuple, 0, len(kwargs))
+	names := make([]string, 0, len(kwargs))
+
+	for _, kw := range kwargs {
+		keyVal, ok := kw[0].(starlark.String)
+		if !ok {
+			translated = append(translated, kw)
+			continue
+		}
+		oldName := string(keyVal)
+		newName := oldName
+		if mapped, exists := reverseMapping[oldName]; exists {
+			newName = mapped
+		}
+		translated = append(translated, starlark.Tuple{starlark.String(newName), kw[1]})
+		names = append(names, newName)
+	}
+
+	return translated, names
 }
 
 // sortedParamNames returns the sorted parameter names from a HandlerDef.

--- a/shared/pkg/saga/schema/validation_modules.go
+++ b/shared/pkg/saga/schema/validation_modules.go
@@ -95,6 +95,10 @@ const (
 
 	// ValidationCodeWrongParamType indicates a parameter value doesn't match the schema type.
 	ValidationCodeWrongParamType = "WRONG_PARAM_TYPE"
+
+	// ValidationCodeDeprecatedHandler indicates a call to a deprecated handler.
+	// This is a warning, not an error — the call will still succeed.
+	ValidationCodeDeprecatedHandler = "DEPRECATED_HANDLER"
 )
 
 // ValidationFailure represents a structured validation error from handler call checking.
@@ -121,6 +125,18 @@ func (f *ValidationFailure) Error() string {
 	return msg
 }
 
+// ValidationWarning captures a non-fatal warning encountered during validation.
+type ValidationWarning struct {
+	// Code is a machine-readable warning code.
+	Code string
+
+	// Message is a human-readable description.
+	Message string
+
+	// Suggestion is an optional conversion hint.
+	Suggestion string
+}
+
 // BuildValidationModules creates Starlark service modules from the schema registry alone.
 // Unlike BuildServiceModules, this does NOT require a HandlerRegistry — it builds
 // validation-only modules that check parameter names, types, and required fields
@@ -129,10 +145,30 @@ func (f *ValidationFailure) Error() string {
 // The optional callLog parameter, if non-nil, will be appended to with metadata
 // about each handler call encountered during validation.
 func BuildValidationModules(schemaRegistry *Registry, callLog *[]HandlerCallInfo) (starlark.StringDict, error) {
+	return BuildValidationModulesWithWarnings(schemaRegistry, callLog, nil)
+}
+
+// BuildValidationModulesWithWarnings is like BuildValidationModules but also collects
+// deprecation warnings into the provided warnings slice.
+func BuildValidationModulesWithWarnings(schemaRegistry *Registry, callLog *[]HandlerCallInfo, warnings *[]ValidationWarning) (starlark.StringDict, error) {
 	schemaHandlers := schemaRegistry.ListHandlers()
 
-	// Build handler tree
-	tree := parseHandlerTree(schemaHandlers)
+	// Build handler tree, including deprecated name aliases
+	schemaRegistry.mu.RLock()
+	deprecatedCount := len(schemaRegistry.deprecatedNames)
+	schemaRegistry.mu.RUnlock()
+
+	allNames := make([]string, len(schemaHandlers), len(schemaHandlers)+deprecatedCount)
+	copy(allNames, schemaHandlers)
+
+	// Add deprecated name aliases to the tree so they resolve
+	schemaRegistry.mu.RLock()
+	for oldName := range schemaRegistry.deprecatedNames {
+		allNames = append(allNames, oldName)
+	}
+	schemaRegistry.mu.RUnlock()
+
+	tree := parseHandlerTree(allNames)
 	if err := tree.validate(); err != nil {
 		return nil, err
 	}
@@ -140,7 +176,7 @@ func BuildValidationModules(schemaRegistry *Registry, callLog *[]HandlerCallInfo
 	// Build Starlark structs from tree
 	modules := make(starlark.StringDict)
 	for name, child := range tree.children {
-		module, err := buildValidationStruct(name, child, schemaRegistry, callLog)
+		module, err := buildValidationStruct(name, child, schemaRegistry, callLog, warnings)
 		if err != nil {
 			return nil, err
 		}
@@ -152,12 +188,12 @@ func BuildValidationModules(schemaRegistry *Registry, callLog *[]HandlerCallInfo
 
 // buildValidationStruct recursively builds a starlarkstruct from a handler tree node,
 // using validation-only wrappers instead of real handler calls.
-func buildValidationStruct(name string, node *handlerTree, schemaRegistry *Registry, callLog *[]HandlerCallInfo) (*starlarkstruct.Struct, error) {
+func buildValidationStruct(name string, node *handlerTree, schemaRegistry *Registry, callLog *[]HandlerCallInfo, warnings *[]ValidationWarning) (*starlarkstruct.Struct, error) {
 	members := make(starlark.StringDict)
 
 	// Add child namespaces as nested structs
 	for childName, childNode := range node.children {
-		childStruct, err := buildValidationStruct(childName, childNode, schemaRegistry, callLog)
+		childStruct, err := buildValidationStruct(childName, childNode, schemaRegistry, callLog, warnings)
 		if err != nil {
 			return nil, err
 		}
@@ -166,11 +202,29 @@ func buildValidationStruct(name string, node *handlerTree, schemaRegistry *Regis
 
 	// Add handlers as validation-only builtin functions
 	for handlerName, fullName := range node.handlers {
+		// Check if this is a deprecated name alias
+		if mapping := schemaRegistry.LookupDeprecated(fullName); mapping != nil {
+			// This is a deprecated handler name — wrap it to produce a warning
+			// but validate against the current handler's schema
+			currentDef, err := schemaRegistry.GetHandler(mapping.CurrentName)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get current handler schema %s: %w", mapping.CurrentName, err)
+			}
+			members[handlerName] = wrapDeprecatedValidationHandler(fullName, mapping, currentDef, callLog, warnings)
+			continue
+		}
+
 		handlerDef, err := schemaRegistry.GetHandler(fullName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get handler schema %s: %w", fullName, err)
 		}
-		members[handlerName] = wrapValidationHandler(fullName, handlerDef, callLog)
+
+		// Check if the handler itself is marked deprecated
+		if handlerDef.Deprecated {
+			members[handlerName] = wrapDeprecatedCurrentHandler(fullName, handlerDef, callLog, warnings)
+		} else {
+			members[handlerName] = wrapValidationHandler(fullName, handlerDef, callLog)
+		}
 	}
 
 	return starlarkstruct.FromStringDict(starlark.String(name), members), nil
@@ -378,6 +432,79 @@ func buildMockResult(handlerName string, handlerDef *HandlerDef) *starlarkstruct
 
 	typeName := handlerName + ".Result"
 	return starlarkstruct.FromStringDict(starlark.String(typeName), members)
+}
+
+// wrapDeprecatedValidationHandler creates a Starlark builtin for a deprecated handler name alias.
+// It records a deprecation warning and validates against the current handler's schema using
+// the conversion rule's param mapping.
+func wrapDeprecatedValidationHandler(oldName string, mapping *DeprecatedMapping, currentDef *HandlerDef, callLog *[]HandlerCallInfo, warnings *[]ValidationWarning) *starlark.Builtin {
+	return starlark.NewBuiltin(oldName, func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		if len(args) > 0 {
+			return nil, fmt.Errorf("%w: handler %s", ErrPositionalArgsNotAllowed, oldName)
+		}
+
+		paramNames := collectParamNames(kwargs)
+		logHandlerCall(callLog, oldName, paramNames)
+
+		// Record deprecation warning
+		suggestion := fmt.Sprintf("Use %s instead", mapping.CurrentName)
+		if mapping.ConversionRule != nil && len(mapping.ConversionRule.ParamMapping) > 0 {
+			var mappings []string
+			for newParam, oldParam := range mapping.ConversionRule.ParamMapping {
+				mappings = append(mappings, fmt.Sprintf("%s->%s", oldParam, newParam))
+			}
+			sort.Strings(mappings)
+			suggestion += fmt.Sprintf(" with param mapping: %s", strings.Join(mappings, ", "))
+		}
+		if mapping.ConversionRule != nil && mapping.ConversionRule.Sunset != "" {
+			suggestion += fmt.Sprintf(" (will be removed in version %s)", mapping.ConversionRule.Sunset)
+		}
+
+		if warnings != nil {
+			*warnings = append(*warnings, ValidationWarning{
+				Code:       ValidationCodeDeprecatedHandler,
+				Message:    fmt.Sprintf("handler %s is deprecated", oldName),
+				Suggestion: suggestion,
+			})
+		}
+
+		// Validate using old param names mapped to current params
+		// For deprecated name aliases, we accept the old param names
+		return buildMockResult(mapping.CurrentName, currentDef), nil
+	})
+}
+
+// wrapDeprecatedCurrentHandler creates a Starlark builtin for a handler that is marked
+// deprecated but still exists under its own name. It validates normally but records a warning.
+func wrapDeprecatedCurrentHandler(fullName string, handlerDef *HandlerDef, callLog *[]HandlerCallInfo, warnings *[]ValidationWarning) *starlark.Builtin {
+	return starlark.NewBuiltin(fullName, func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		if len(args) > 0 {
+			return nil, fmt.Errorf("%w: handler %s", ErrPositionalArgsNotAllowed, fullName)
+		}
+
+		paramNames := collectParamNames(kwargs)
+		logHandlerCall(callLog, fullName, paramNames)
+
+		// Record deprecation warning
+		if warnings != nil {
+			*warnings = append(*warnings, ValidationWarning{
+				Code:    ValidationCodeDeprecatedHandler,
+				Message: fmt.Sprintf("handler %s is deprecated", fullName),
+			})
+		}
+
+		if err := validateUnknownParams(fullName, paramNames, handlerDef); err != nil {
+			return nil, err
+		}
+		if err := validateRequiredParams(fullName, paramNames, handlerDef); err != nil {
+			return nil, err
+		}
+		if err := validateParamTypes(fullName, kwargs, handlerDef); err != nil {
+			return nil, err
+		}
+
+		return buildMockResult(fullName, handlerDef), nil
+	})
 }
 
 // sortedParamNames returns the sorted parameter names from a HandlerDef.


### PR DESCRIPTION
## Summary

- Extend handler schema to support versioned handlers with structured conversion rules for backwards-compatible evolution
- When handlers are renamed or parameters change, conversion rules document the mapping from old to new signatures
- Deprecated handlers produce `DEPRECATED_HANDLER` warnings during manifest validation instead of hard errors
- Manifest validator propagates deprecation warnings to `ValidationResult.Warnings`

## Changes Made

### Schema (`shared/pkg/saga/schema/schema.go`)
- Add `Version`, `Deprecated`, and `Conversions` fields to `HandlerDef`
- Add `ConversionRule` struct: `from_version`, `from_name`, `param_mapping`, `defaults`, `sunset`
- Add `DeprecatedMapping` struct for registry lookup of deprecated handler names
- Registry indexes deprecated name aliases from conversion rules on load
- `LookupDeprecated()` and `IsDeprecated()` methods on Registry
- `LinterMetadata` now includes `IsDeprecated` and `ReplacedBy` fields
- Conversion rule validation: `from_version` must be positive, less than current version; param mappings and defaults must reference valid current params

### Validation Modules (`shared/pkg/saga/schema/validation_modules.go`)
- `BuildValidationModulesWithWarnings()` collects `DEPRECATED_HANDLER` warnings
- Deprecated name aliases resolve in Starlark as callable builtins with warning
- Handlers marked `deprecated: true` still validate params but produce warnings

### Manifest Validator (`services/control-plane/internal/validator/manifest_validator.go`)
- `buildStarlarkPredeclared()` now returns deprecation warnings
- `validateSingleStarlarkScript()` propagates warnings to `ValidationResult`

### handlers.yaml
- Added documentation header explaining handler evolution pattern with examples

## Test Plan

- [x] Schema parsing: version, deprecated, conversions fields round-trip
- [x] Conversion rule validation: positive from_version, less than current, valid param refs
- [x] Registry deprecated lookup: indexes from_name, returns mapping
- [x] IsDeprecated: checks handler deprecated flag
- [x] LinterMetadata: includes IsDeprecated/ReplacedBy for deprecated aliases
- [x] Validation modules: deprecated handler call produces warning with suggestion
- [x] Deprecated current handler: still validates params, produces warning
- [x] Current-version handler: no warnings produced
- [x] All existing schema and validator tests pass

Task: 039-meridian-vm.6