### PR TITLE
feat: Add API trigger, AsyncAPI field, and orphan detection validation

### DIFF
--- a/examples/manifests/carbon.json
+++ b/examples/manifests/carbon.json
@@ -54,7 +54,7 @@
   "sagas": [
     {
       "name": "retire_carbon_credits",
-      "trigger": "api:/v1/carbon/retire",
+      "trigger": "api:/v1/sagas/execute",
       "script": "def execute(ctx):\n    retirement = ctx\n    amount = Decimal(str(retirement.get('tonnes', '0')))\n    position_keeping.initiate_log(amount=amount, direction='CREDIT')\n"
     }
   ]

--- a/examples/manifests/energy.json
+++ b/examples/manifests/energy.json
@@ -87,7 +87,7 @@
   "sagas": [
     {
       "name": "process_energy_settlement",
-      "trigger": "api:/v1/energy/settlements",
+      "trigger": "api:/v1/sagas/execute",
       "script": "def execute(ctx):\n    settlement = ctx\n    amount = Decimal(str(settlement.get('amount', '0')))\n    position_keeping.initiate_log(amount=amount, direction='DEBIT')\n"
     }
   ]

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -274,12 +274,14 @@ func New(opts ...Option) (*ManifestValidator, error) {
 		opt(mv)
 	}
 
-	// Try to load OpenAPI spec if not explicitly set via options.
+	// Best-effort auto-loading from repo checkout. When the spec files are not
+	// reachable (e.g. running outside a repo checkout), the corresponding checks
+	// degrade gracefully: format and duplicate checks still run, only the
+	// endpoint-existence and field-reference checks are skipped. For deterministic
+	// behavior in tests, use WithOpenAPIPaths / WithAsyncAPISchemas.
 	if !mv.apiPathsExplicit {
 		mv.apiPathRegistry = tryLoadOpenAPIPaths()
 	}
-
-	// Try to load AsyncAPI schemas if not explicitly set via options.
 	if !mv.asyncSchemasExplicit {
 		mv.asyncAPISchemas = tryLoadAsyncAPISchemas()
 	}
@@ -1902,6 +1904,17 @@ func extractSelectField(sel *exprpb.Expr_Select, fields map[string]bool) {
 }
 
 func extractCallFields(call *exprpb.Expr_Call, fields map[string]bool) {
+	// Handle index operator: event["field_name"] is represented as _[_](event, "field_name")
+	if call.GetFunction() == "_[_]" && len(call.GetArgs()) == 2 {
+		if ident, ok := call.GetArgs()[0].ExprKind.(*exprpb.Expr_IdentExpr); ok && ident.IdentExpr.GetName() == "event" {
+			if constExpr, ok := call.GetArgs()[1].ExprKind.(*exprpb.Expr_ConstExpr); ok {
+				if sv := constExpr.ConstExpr.GetStringValue(); sv != "" {
+					fields[sv] = true
+					return
+				}
+			}
+		}
+	}
 	extractFieldsFromExpr(call.GetTarget(), fields)
 	for _, arg := range call.GetArgs() {
 		extractFieldsFromExpr(arg, fields)

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -1220,16 +1220,9 @@ func (v *ManifestValidator) validateWebhookTriggers(
 	sort.Strings(availableIDs)
 
 	for i, saga := range manifest.GetSagas() {
-		trigger := saga.GetTrigger()
-		if !strings.HasPrefix(trigger, "webhook:") {
+		source := extractWebhookSource(saga.GetTrigger())
+		if source == "" {
 			continue
-		}
-
-		// Parse webhook:<source>.<event> — source is the first dot-separated segment.
-		remainder := strings.TrimPrefix(trigger, "webhook:")
-		source := remainder
-		if dotIdx := strings.Index(remainder, "."); dotIdx > 0 {
-			source = remainder[:dotIdx]
 		}
 
 		if !connectionIDs[source] {
@@ -1634,17 +1627,16 @@ func (v *ManifestValidator) listServiceHandlers(serviceName string) []string {
 var apiPathPattern = regexp.MustCompile(`^/`)
 
 // validateAPITriggers validates sagas with "api:" trigger prefix.
-// It checks path format, existence in the OpenAPI spec, and uniqueness.
+// It checks path format, uniqueness, and (when an OpenAPI spec is available) endpoint existence.
 func (v *ManifestValidator) validateAPITriggers(
 	manifest *controlplanev1.Manifest,
 	result *ValidationResult,
 ) {
-	if v.apiPathRegistry == nil {
-		return
-	}
-
 	seenPaths := make(map[string]int)
-	availablePaths := mapKeys(v.apiPathRegistry)
+	var availablePaths []string
+	if v.apiPathRegistry != nil {
+		availablePaths = mapKeys(v.apiPathRegistry)
+	}
 
 	for i, saga := range manifest.GetSagas() {
 		trigger := saga.GetTrigger()
@@ -1679,8 +1671,8 @@ func (v *ManifestValidator) validateAPITriggers(
 			seenPaths[path] = i
 		}
 
-		// Check existence in OpenAPI spec
-		if !v.apiPathRegistry[path] {
+		// Check existence in OpenAPI spec (only when spec is available)
+		if v.apiPathRegistry != nil && !v.apiPathRegistry[path] {
 			ve := ValidationError{
 				Severity:        SeverityError,
 				Path:            sagaPath,
@@ -1801,29 +1793,46 @@ func parseAsyncAPIFile(data []byte, schemas map[string]map[string]bool) {
 
 	for channelName, channel := range doc.Channels {
 		for _, msgRef := range channel.Messages {
-			msgName := extractRef(msgRef.Ref)
-			if msgName == "" {
+			fields := resolveMessageFields(msgRef, doc.Components)
+			if len(fields) == 0 {
 				continue
 			}
-			msg, ok := doc.Components.Messages[msgName]
-			if !ok {
-				continue
+			existing := schemas[channelName]
+			if existing == nil {
+				existing = make(map[string]bool, len(fields))
 			}
-			schemaName := extractRef(msg.Payload.Ref)
-			if schemaName == "" {
-				continue
+			for _, f := range fields {
+				existing[f] = true
 			}
-			s, ok := doc.Components.Schemas[schemaName]
-			if !ok {
-				continue
-			}
-			fields := make(map[string]bool, len(s.Properties))
-			for fieldName := range s.Properties {
-				fields[fieldName] = true
-			}
-			schemas[channelName] = fields
+			schemas[channelName] = existing
 		}
 	}
+}
+
+// resolveMessageFields follows $ref chains from a message reference to its schema
+// and returns the list of top-level property names.
+func resolveMessageFields(msgRef asyncAPIMessageRef, components asyncAPIComponents) []string {
+	msgName := extractRef(msgRef.Ref)
+	if msgName == "" {
+		return nil
+	}
+	msg, ok := components.Messages[msgName]
+	if !ok {
+		return nil
+	}
+	schemaName := extractRef(msg.Payload.Ref)
+	if schemaName == "" {
+		return nil
+	}
+	s, ok := components.Schemas[schemaName]
+	if !ok {
+		return nil
+	}
+	fields := make([]string, 0, len(s.Properties))
+	for fieldName := range s.Properties {
+		fields = append(fields, fieldName)
+	}
+	return fields
 }
 
 // extractRef extracts the last segment from a JSON/YAML $ref (e.g., "#/components/schemas/Foo" -> "Foo").
@@ -1948,6 +1957,9 @@ func (v *ManifestValidator) validateEventFilterCELFields(
 
 // dispatchInstructionRegex matches dispatch_instruction calls in Starlark scripts
 // to extract the instruction type, supporting both positional and keyword argument styles.
+// NOTE: This scans raw source text so it may match occurrences in comments or string
+// literals, producing false negatives (suppressing orphan warnings). A proper Starlark
+// AST walk would eliminate this, but the current approach is acceptable for a warning-level check.
 var dispatchInstructionRegex = regexp.MustCompile(
 	`dispatch_instruction\s*\(\s*(?:instruction_type\s*=\s*)?["']([^"']+)["']`,
 )

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -22,6 +24,8 @@ import (
 	"github.com/shopspring/decimal"
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	"gopkg.in/yaml.v3"
 )
 
 // Known service bindings available on the saga context object.
@@ -146,18 +150,44 @@ type ValidationResult struct {
 
 // ManifestValidator validates Meridian manifests.
 type ManifestValidator struct {
-	protoValidator  protovalidate.Validator
-	celEnv          *cel.Env
-	bucketCelEnv    *cel.Env
-	partyTypeCelEnv *cel.Env
-	mappingCelEnv   *cel.Env
-	eventFilterEnv  *cel.Env
-	channelRegistry map[string]bool
-	schemaRegistry  *schema.Registry
+	protoValidator       protovalidate.Validator
+	celEnv               *cel.Env
+	bucketCelEnv         *cel.Env
+	partyTypeCelEnv      *cel.Env
+	mappingCelEnv        *cel.Env
+	eventFilterEnv       *cel.Env
+	channelRegistry      map[string]bool
+	schemaRegistry       *schema.Registry
+	apiPathRegistry      map[string]bool            // valid API endpoint paths from OpenAPI spec
+	asyncAPISchemas      map[string]map[string]bool // topic -> set of payload field names
+	apiPathsExplicit     bool                       // true when set via option
+	asyncSchemasExplicit bool                       // true when set via option
+}
+
+// Option configures a ManifestValidator.
+type Option func(*ManifestValidator)
+
+// WithOpenAPIPaths sets the valid API paths for API trigger validation.
+// Pass nil to disable API trigger validation (skip filesystem loading).
+func WithOpenAPIPaths(paths map[string]bool) Option {
+	return func(v *ManifestValidator) {
+		v.apiPathRegistry = paths
+		v.apiPathsExplicit = true
+	}
+}
+
+// WithAsyncAPISchemas sets the event payload schemas for CEL field validation.
+// The map keys are topic names; values are sets of valid field names.
+// Pass nil to disable AsyncAPI field validation (skip filesystem loading).
+func WithAsyncAPISchemas(schemas map[string]map[string]bool) Option {
+	return func(v *ManifestValidator) {
+		v.asyncAPISchemas = schemas
+		v.asyncSchemasExplicit = true
+	}
 }
 
 // New creates a new ManifestValidator.
-func New() (*ManifestValidator, error) {
+func New(opts ...Option) (*ManifestValidator, error) {
 	pv, err := protovalidate.New()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create proto validator: %w", err)
@@ -229,7 +259,7 @@ func New() (*ManifestValidator, error) {
 		return nil, fmt.Errorf("failed to load schema registry: %w", err)
 	}
 
-	return &ManifestValidator{
+	mv := &ManifestValidator{
 		protoValidator:  pv,
 		celEnv:          celEnv,
 		bucketCelEnv:    bucketCelEnv,
@@ -238,7 +268,23 @@ func New() (*ManifestValidator, error) {
 		eventFilterEnv:  eventFilterEnv,
 		channelRegistry: channelRegistry,
 		schemaRegistry:  schemaRegistry,
-	}, nil
+	}
+
+	for _, opt := range opts {
+		opt(mv)
+	}
+
+	// Try to load OpenAPI spec if not explicitly set via options.
+	if !mv.apiPathsExplicit {
+		mv.apiPathRegistry = tryLoadOpenAPIPaths()
+	}
+
+	// Try to load AsyncAPI schemas if not explicitly set via options.
+	if !mv.asyncSchemasExplicit {
+		mv.asyncAPISchemas = tryLoadAsyncAPISchemas()
+	}
+
+	return mv, nil
 }
 
 // Validate performs full validation of a manifest.
@@ -282,7 +328,13 @@ func (v *ManifestValidator) Validate(
 	// 11. Scheduled trigger name uniqueness
 	v.validateScheduledTriggers(manifest, result)
 
-	// 12. Immutability checks
+	// 12. API trigger validation against OpenAPI spec
+	v.validateAPITriggers(manifest, result)
+
+	// 13. Operational gateway orphan detection
+	v.validateOperationalGatewayOrphans(manifest, result)
+
+	// 14. Immutability checks
 	if previousManifest != nil {
 		v.validateImmutability(manifest, previousManifest, result)
 	}
@@ -1076,6 +1128,9 @@ func (v *ManifestValidator) validateEventTrigger(
 	}
 
 	v.validateEventFilterCEL(saga.GetFilter(), path+".filter", result)
+
+	// Cross-check CEL field references against AsyncAPI schema
+	v.validateEventFilterCELFields(saga.GetFilter(), channel, path+".filter", result)
 }
 
 // validateEventFilterCEL compiles a CEL expression in the event filter environment.
@@ -1557,6 +1612,441 @@ func (v *ManifestValidator) listServiceHandlers(serviceName string) []string {
 	}
 	sort.Strings(methods)
 	return methods
+}
+
+// ─── Task 2: API Trigger Validation Against OpenAPI Spec ────────────────────
+
+// apiPathPattern validates that API trigger paths start with '/'.
+var apiPathPattern = regexp.MustCompile(`^/`)
+
+// validateAPITriggers validates sagas with "api:" trigger prefix.
+// It checks path format, existence in the OpenAPI spec, and uniqueness.
+func (v *ManifestValidator) validateAPITriggers(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	if v.apiPathRegistry == nil {
+		return
+	}
+
+	seenPaths := make(map[string]int)
+	availablePaths := mapKeys(v.apiPathRegistry)
+
+	for i, saga := range manifest.GetSagas() {
+		trigger := saga.GetTrigger()
+		if !strings.HasPrefix(trigger, "api:") {
+			continue
+		}
+
+		path := strings.TrimPrefix(trigger, "api:")
+		sagaPath := fmt.Sprintf("sagas[%d].trigger", i)
+
+		// Validate format: must start with '/'
+		if !apiPathPattern.MatchString(path) {
+			addError(result, ValidationError{
+				Severity:   SeverityError,
+				Path:       sagaPath,
+				Code:       "INVALID_API_PATH_FORMAT",
+				Message:    fmt.Sprintf("API trigger path %q must start with '/'", path),
+				Suggestion: "API paths should follow the format '/v1/resource'",
+			})
+			continue
+		}
+
+		// Check uniqueness
+		if prevIdx, exists := seenPaths[path]; exists {
+			addError(result, ValidationError{
+				Severity: SeverityError,
+				Path:     sagaPath,
+				Code:     "DUPLICATE_API_TRIGGER",
+				Message:  fmt.Sprintf("API path %q already bound to saga at sagas[%d]", path, prevIdx),
+			})
+		} else {
+			seenPaths[path] = i
+		}
+
+		// Check existence in OpenAPI spec
+		if !v.apiPathRegistry[path] {
+			ve := ValidationError{
+				Severity:        SeverityError,
+				Path:            sagaPath,
+				Code:            "UNKNOWN_API_ENDPOINT",
+				Message:         fmt.Sprintf("API path %q is not defined in the OpenAPI spec", path),
+				AvailableFields: availablePaths,
+			}
+			if suggestion := findClosestMatch(path, availablePaths); suggestion != "" {
+				ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+			}
+			addError(result, ve)
+		}
+	}
+}
+
+// tryLoadOpenAPIPaths attempts to load API paths from api/openapi/meridian.swagger.json.
+// Returns nil if the file doesn't exist or can't be parsed.
+func tryLoadOpenAPIPaths() map[string]bool {
+	specPath := findRepoFile("api/openapi/meridian.swagger.json")
+	if specPath == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		return nil
+	}
+
+	return parseOpenAPIPaths(data)
+}
+
+// parseOpenAPIPaths extracts endpoint paths from an OpenAPI/Swagger JSON spec.
+func parseOpenAPIPaths(data []byte) map[string]bool {
+	var spec struct {
+		Paths map[string]json.RawMessage `json:"paths"`
+	}
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return nil
+	}
+
+	paths := make(map[string]bool, len(spec.Paths))
+	for p := range spec.Paths {
+		paths[p] = true
+	}
+	return paths
+}
+
+// ─── Task 5: AsyncAPI CEL Field Validation ──────────────────────────────────
+
+// tryLoadAsyncAPISchemas attempts to load event payload schemas from api/asyncapi/*.yaml.
+// Returns nil if the directory doesn't exist or no files are found.
+func tryLoadAsyncAPISchemas() map[string]map[string]bool {
+	dir := findRepoFile("api/asyncapi")
+	if dir == "" {
+		return nil
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	schemas := make(map[string]map[string]bool)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		parseAsyncAPIFile(data, schemas)
+	}
+
+	if len(schemas) == 0 {
+		return nil
+	}
+	return schemas
+}
+
+// asyncAPIDoc represents the minimal structure of an AsyncAPI 3.0 document.
+type asyncAPIDoc struct {
+	Channels   map[string]asyncAPIChannel `yaml:"channels"`
+	Components asyncAPIComponents         `yaml:"components"`
+}
+
+type asyncAPIChannel struct {
+	Messages map[string]asyncAPIMessageRef `yaml:"messages"`
+}
+
+type asyncAPIMessageRef struct {
+	Ref string `yaml:"$ref"`
+}
+
+type asyncAPIComponents struct {
+	Messages map[string]asyncAPIMessage `yaml:"messages"`
+	Schemas  map[string]asyncAPISchema  `yaml:"schemas"`
+}
+
+type asyncAPIMessage struct {
+	Payload asyncAPIPayloadRef `yaml:"payload"`
+}
+
+type asyncAPIPayloadRef struct {
+	Ref string `yaml:"$ref"`
+}
+
+type asyncAPISchema struct {
+	Properties map[string]yaml.Node `yaml:"properties"`
+}
+
+// parseAsyncAPIFile parses an AsyncAPI YAML file and populates the schemas map.
+func parseAsyncAPIFile(data []byte, schemas map[string]map[string]bool) {
+	var doc asyncAPIDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return
+	}
+
+	for channelName, channel := range doc.Channels {
+		for _, msgRef := range channel.Messages {
+			msgName := extractRef(msgRef.Ref)
+			if msgName == "" {
+				continue
+			}
+			msg, ok := doc.Components.Messages[msgName]
+			if !ok {
+				continue
+			}
+			schemaName := extractRef(msg.Payload.Ref)
+			if schemaName == "" {
+				continue
+			}
+			s, ok := doc.Components.Schemas[schemaName]
+			if !ok {
+				continue
+			}
+			fields := make(map[string]bool, len(s.Properties))
+			for fieldName := range s.Properties {
+				fields[fieldName] = true
+			}
+			schemas[channelName] = fields
+		}
+	}
+}
+
+// extractRef extracts the last segment from a JSON/YAML $ref (e.g., "#/components/schemas/Foo" -> "Foo").
+func extractRef(ref string) string {
+	if ref == "" {
+		return ""
+	}
+	parts := strings.Split(ref, "/")
+	return parts[len(parts)-1]
+}
+
+// extractCELFieldRefs extracts field names accessed on the "event" variable from a CEL expression.
+// For example, "event.amount > 0 && event.currency == 'GBP'" returns ["amount", "currency"].
+func extractCELFieldRefs(expression string, env *cel.Env) []string {
+	celAST, issues := env.Compile(expression)
+	if issues != nil && issues.Err() != nil {
+		return nil
+	}
+
+	parsedExpr, err := cel.AstToParsedExpr(celAST)
+	if err != nil {
+		return nil
+	}
+
+	fields := make(map[string]bool)
+	extractFieldsFromExpr(parsedExpr.GetExpr(), fields)
+
+	result := make([]string, 0, len(fields))
+	for f := range fields {
+		result = append(result, f)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// extractFieldsFromExpr recursively walks a CEL proto expression to find
+// select expressions on the "event" variable (event.field_name).
+func extractFieldsFromExpr(expr *exprpb.Expr, fields map[string]bool) {
+	if expr == nil {
+		return
+	}
+
+	switch e := expr.ExprKind.(type) {
+	case *exprpb.Expr_SelectExpr:
+		extractSelectField(e.SelectExpr, fields)
+	case *exprpb.Expr_CallExpr:
+		extractCallFields(e.CallExpr, fields)
+	case *exprpb.Expr_ListExpr:
+		for _, elem := range e.ListExpr.GetElements() {
+			extractFieldsFromExpr(elem, fields)
+		}
+	case *exprpb.Expr_StructExpr:
+		for _, entry := range e.StructExpr.GetEntries() {
+			extractFieldsFromExpr(entry.GetValue(), fields)
+		}
+	case *exprpb.Expr_ComprehensionExpr:
+		extractComprehensionFields(e.ComprehensionExpr, fields)
+	}
+}
+
+func extractSelectField(sel *exprpb.Expr_Select, fields map[string]bool) {
+	if ident, ok := sel.GetOperand().ExprKind.(*exprpb.Expr_IdentExpr); ok && ident.IdentExpr.GetName() == "event" {
+		fields[sel.GetField()] = true
+	} else {
+		extractFieldsFromExpr(sel.GetOperand(), fields)
+	}
+}
+
+func extractCallFields(call *exprpb.Expr_Call, fields map[string]bool) {
+	extractFieldsFromExpr(call.GetTarget(), fields)
+	for _, arg := range call.GetArgs() {
+		extractFieldsFromExpr(arg, fields)
+	}
+}
+
+func extractComprehensionFields(comp *exprpb.Expr_Comprehension, fields map[string]bool) {
+	extractFieldsFromExpr(comp.GetIterRange(), fields)
+	extractFieldsFromExpr(comp.GetAccuInit(), fields)
+	extractFieldsFromExpr(comp.GetLoopCondition(), fields)
+	extractFieldsFromExpr(comp.GetLoopStep(), fields)
+	extractFieldsFromExpr(comp.GetResult(), fields)
+}
+
+// validateEventFilterCELFields cross-checks CEL expression field references against
+// the AsyncAPI schema for the given event channel. Produces warnings for unknown fields.
+func (v *ManifestValidator) validateEventFilterCELFields(
+	expression string,
+	channel string,
+	path string,
+	result *ValidationResult,
+) {
+	if v.asyncAPISchemas == nil {
+		return
+	}
+
+	schemaFields, ok := v.asyncAPISchemas[channel]
+	if !ok {
+		return
+	}
+
+	celFields := extractCELFieldRefs(expression, v.eventFilterEnv)
+	schemaFieldList := mapKeys(schemaFields)
+
+	for _, field := range celFields {
+		if !schemaFields[field] {
+			ve := ValidationError{
+				Severity:        SeverityWarning,
+				Path:            path,
+				Code:            "CEL_UNKNOWN_EVENT_FIELD",
+				Message:         fmt.Sprintf("field %q is not defined in the AsyncAPI schema for channel %q", field, channel),
+				AvailableFields: schemaFieldList,
+			}
+			if suggestion := findClosestMatch(field, schemaFieldList); suggestion != "" {
+				ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+			}
+			addError(result, ve)
+		}
+	}
+}
+
+// ─── Task 11: Operational Gateway Orphan Detection ──────────────────────────
+
+// dispatchInstructionRegex matches dispatch_instruction calls in Starlark scripts
+// to extract the instruction type, supporting both positional and keyword argument styles.
+var dispatchInstructionRegex = regexp.MustCompile(
+	`dispatch_instruction\s*\(\s*(?:instruction_type\s*=\s*)?["']([^"']+)["']`,
+)
+
+// validateOperationalGatewayOrphans detects unused provider connections and instruction routes.
+func (v *ManifestValidator) validateOperationalGatewayOrphans(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	gw := manifest.GetOperationalGateway()
+	if gw == nil {
+		return
+	}
+
+	v.detectOrphanProviderConnections(manifest, gw, result)
+	v.detectOrphanInstructionRoutes(manifest, gw, result)
+}
+
+// detectOrphanProviderConnections warns on provider connections not referenced by
+// any instruction route or webhook trigger.
+func (v *ManifestValidator) detectOrphanProviderConnections(
+	manifest *controlplanev1.Manifest,
+	gw *controlplanev1.OperationalGatewayConfig,
+	result *ValidationResult,
+) {
+	usedConnections := make(map[string]bool)
+	for _, route := range gw.GetInstructionRoutes() {
+		usedConnections[route.GetConnectionId()] = true
+		if fb := route.GetFallbackConnectionId(); fb != "" {
+			usedConnections[fb] = true
+		}
+	}
+
+	// Also count connections used as webhook sources in saga triggers
+	for _, saga := range manifest.GetSagas() {
+		if source := extractWebhookSource(saga.GetTrigger()); source != "" {
+			usedConnections[source] = true
+		}
+	}
+
+	for i, conn := range gw.GetProviderConnections() {
+		cid := conn.GetConnectionId()
+		if !usedConnections[cid] {
+			addError(result, ValidationError{
+				Severity: SeverityWarning,
+				Path:     fmt.Sprintf("operational_gateway.provider_connections[%d].connection_id", i),
+				Code:     "ORPHAN_PROVIDER_CONNECTION",
+				Message:  fmt.Sprintf("provider connection %q is not referenced by any instruction route or webhook trigger", cid),
+			})
+		}
+	}
+}
+
+// detectOrphanInstructionRoutes warns on instruction routes not dispatched by any saga.
+func (v *ManifestValidator) detectOrphanInstructionRoutes(
+	manifest *controlplanev1.Manifest,
+	gw *controlplanev1.OperationalGatewayConfig,
+	result *ValidationResult,
+) {
+	usedInstructionTypes := make(map[string]bool)
+	for _, saga := range manifest.GetSagas() {
+		for _, m := range dispatchInstructionRegex.FindAllStringSubmatch(saga.GetScript(), -1) {
+			usedInstructionTypes[m[1]] = true
+		}
+	}
+
+	for i, route := range gw.GetInstructionRoutes() {
+		instrType := route.GetInstructionType()
+		if !usedInstructionTypes[instrType] {
+			addError(result, ValidationError{
+				Severity: SeverityWarning,
+				Path:     fmt.Sprintf("operational_gateway.instruction_routes[%d].instruction_type", i),
+				Code:     "ORPHAN_INSTRUCTION_ROUTE",
+				Message:  fmt.Sprintf("instruction type %q is not dispatched by any saga script", instrType),
+			})
+		}
+	}
+}
+
+// extractWebhookSource extracts the provider connection source from a webhook trigger string.
+// Returns empty string for non-webhook triggers.
+func extractWebhookSource(trigger string) string {
+	if !strings.HasPrefix(trigger, "webhook:") {
+		return ""
+	}
+	remainder := strings.TrimPrefix(trigger, "webhook:")
+	if dotIdx := strings.Index(remainder, "."); dotIdx > 0 {
+		return remainder[:dotIdx]
+	}
+	return remainder
+}
+
+// ─── Shared Helpers ─────────────────────────────────────────────────────────
+
+// findRepoFile walks up from the current working directory to find a relative file path.
+// Returns the absolute path if found, empty string otherwise.
+func findRepoFile(relPath string) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+
+	for {
+		candidate := filepath.Join(dir, relPath)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
 }
 
 // buildFieldPath extracts a dotted field path from a protovalidate Violation.

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -2149,6 +2149,47 @@ func TestValidateAPITriggers_SkippedWhenNoSpec(t *testing.T) {
 	}
 }
 
+func TestValidateAPITriggers_FormatAndDuplicateChecksWithoutSpec(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil))
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "bad_format",
+			Trigger: "api:no-leading-slash",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+		{
+			Name:    "dup_1",
+			Trigger: "api:/v1/duped",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+		{
+			Name:    "dup_2",
+			Trigger: "api:/v1/duped",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+
+	foundFormat, foundDup, foundUnknown := false, false, false
+	for _, e := range result.Errors {
+		switch e.Code {
+		case "INVALID_API_PATH_FORMAT":
+			foundFormat = true
+		case "DUPLICATE_API_TRIGGER":
+			foundDup = true
+		case "UNKNOWN_API_ENDPOINT":
+			foundUnknown = true
+		}
+	}
+	assert.True(t, foundFormat, "format check should fire without spec")
+	assert.True(t, foundDup, "duplicate check should fire without spec")
+	assert.False(t, foundUnknown, "endpoint existence check should be skipped without spec")
+}
+
 func TestParseOpenAPIPaths(t *testing.T) {
 	spec := `{
 		"swagger": "2.0",
@@ -2378,6 +2419,51 @@ components:
 	assert.Contains(t, schemas, "test.topic.v1")
 	assert.True(t, schemas["test.topic.v1"]["field_a"])
 	assert.True(t, schemas["test.topic.v1"]["field_b"])
+}
+
+func TestParseAsyncAPIFile_MergesFieldsAcrossMessages(t *testing.T) {
+	data := []byte(`
+asyncapi: 3.0.0
+channels:
+  orders.topic.v1:
+    messages:
+      OrderCreated:
+        $ref: '#/components/messages/OrderCreated'
+      OrderUpdated:
+        $ref: '#/components/messages/OrderUpdated'
+components:
+  messages:
+    OrderCreated:
+      payload:
+        $ref: '#/components/schemas/OrderCreatedPayload'
+    OrderUpdated:
+      payload:
+        $ref: '#/components/schemas/OrderUpdatedPayload'
+  schemas:
+    OrderCreatedPayload:
+      type: object
+      properties:
+        order_id:
+          type: string
+        amount:
+          type: number
+    OrderUpdatedPayload:
+      type: object
+      properties:
+        order_id:
+          type: string
+        status:
+          type: string
+`)
+
+	schemas := make(map[string]map[string]bool)
+	parseAsyncAPIFile(data, schemas)
+
+	require.Contains(t, schemas, "orders.topic.v1")
+	fields := schemas["orders.topic.v1"]
+	assert.True(t, fields["order_id"], "order_id should be present from both messages")
+	assert.True(t, fields["amount"], "amount should be present from OrderCreated")
+	assert.True(t, fields["status"], "status should be present from OrderUpdated")
 }
 
 // ─── Task 11: Orphan Detection Tests ────────────────────────────────────────

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -2376,6 +2376,16 @@ func TestExtractCELFieldRefs(t *testing.T) {
 			expected: []string{"amount", "currency"},
 		},
 		{
+			name:     "bracket notation",
+			expr:     `event["amount_cents"] > 0`,
+			expected: []string{"amount_cents"},
+		},
+		{
+			name:     "mixed dot and bracket",
+			expr:     `event.currency == "GBP" && event["amount"] > 0`,
+			expected: []string{"amount", "currency"},
+		},
+		{
 			name:     "no event fields",
 			expr:     `true`,
 			expected: []string{},

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/cel-go/cel"
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	"github.com/stretchr/testify/assert"
@@ -66,7 +67,7 @@ func validManifest() *controlplanev1.Manifest {
 		Sagas: []*controlplanev1.SagaDefinition{
 			{
 				Name:    "process_settlement",
-				Trigger: "api:/v1/settlements",
+				Trigger: "api:/v1/sagas/execute",
 				Script:  "def execute(ctx):\n    return {\"status\": \"ok\"}\n",
 			},
 		},
@@ -228,7 +229,7 @@ func TestValidateDuplicate_SagaNames(t *testing.T) {
 	m := validManifest()
 	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
 		Name:    "process_settlement", // Duplicate
-		Trigger: "api:/v1/other",
+		Trigger: "api:/v1/tenants",
 		Script:  "def execute(ctx):\n    pass\n",
 	})
 
@@ -359,7 +360,7 @@ func TestValidate_NonEventTrigger_NoChannelCheck(t *testing.T) {
 
 	m := validManifest()
 	// api: trigger should not trigger channel validation even with a weird path
-	m.Sagas[0].Trigger = "api:/v1/some-handler"
+	m.Sagas[0].Trigger = "api:/v1/health"
 
 	result := v.Validate(m, nil)
 	assert.True(t, result.Valid, "expected valid manifest, got errors: %v", result.Errors)
@@ -1906,7 +1907,7 @@ func TestValidate_ScheduledTrigger_DuplicateName_Error(t *testing.T) {
 		},
 		{
 			Name:    "another_saga",
-			Trigger: "api:/v1/other",
+			Trigger: "api:/v1/tenants",
 			Script:  "def execute(ctx):\n    return {}\n",
 		},
 		{
@@ -1970,7 +1971,7 @@ func TestValidate_ScheduledTrigger_SameNameDifferentTriggerType_NoConflict(t *te
 		},
 		{
 			Name:    "monthly_billing_api",
-			Trigger: "api:/v1/monthly_billing",
+			Trigger: "api:/v1/postings",
 			Script:  "def execute(ctx):\n    return {}\n",
 		},
 	}
@@ -1979,5 +1980,626 @@ func TestValidate_ScheduledTrigger_SameNameDifferentTriggerType_NoConflict(t *te
 	for _, e := range result.Errors {
 		assert.NotEqual(t, "DUPLICATE_SCHEDULED_TRIGGER", e.Code,
 			"unexpected DUPLICATE_SCHEDULED_TRIGGER error: %v", e)
+	}
+}
+
+// ─── Task 2: API Trigger Validation Tests ───────────────────────────────────
+
+func TestValidateAPITriggers_UnknownEndpoint(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(map[string]bool{
+		"/v1/deposits":    true,
+		"/v1/withdrawals": true,
+	}))
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "handle_transfers",
+			Trigger: "api:/v1/transfers",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "UNKNOWN_API_ENDPOINT" {
+			found = true
+			assert.Contains(t, e.Message, "/v1/transfers")
+			assert.NotEmpty(t, e.AvailableFields)
+			break
+		}
+	}
+	assert.True(t, found, "expected UNKNOWN_API_ENDPOINT error, got: %v", result.Errors)
+}
+
+func TestValidateAPITriggers_UnknownEndpoint_WithSuggestion(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(map[string]bool{
+		"/v1/deposits":    true,
+		"/v1/withdrawals": true,
+	}))
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "handle_deposit_typo",
+			Trigger: "api:/v1/depositz",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+	assert.False(t, result.Valid)
+
+	for _, e := range result.Errors {
+		if e.Code == "UNKNOWN_API_ENDPOINT" {
+			assert.Contains(t, e.Suggestion, "/v1/deposits")
+			return
+		}
+	}
+	t.Error("expected UNKNOWN_API_ENDPOINT error with suggestion")
+}
+
+func TestValidateAPITriggers_DuplicatePath(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(map[string]bool{
+		"/v1/deposits": true,
+	}))
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "deposit_handler",
+			Trigger: "api:/v1/deposits",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+		{
+			Name:    "deposit_handler_v2",
+			Trigger: "api:/v1/deposits",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "DUPLICATE_API_TRIGGER" {
+			found = true
+			assert.Contains(t, e.Message, "/v1/deposits")
+			break
+		}
+	}
+	assert.True(t, found, "expected DUPLICATE_API_TRIGGER error, got: %v", result.Errors)
+}
+
+func TestValidateAPITriggers_InvalidPathFormat(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(map[string]bool{
+		"/v1/deposits": true,
+	}))
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "bad_path",
+			Trigger: "api:v1/deposits",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_API_PATH_FORMAT" {
+			found = true
+			assert.Contains(t, e.Message, "must start with '/'")
+			break
+		}
+	}
+	assert.True(t, found, "expected INVALID_API_PATH_FORMAT error, got: %v", result.Errors)
+}
+
+func TestValidateAPITriggers_ValidPath(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(map[string]bool{
+		"/v1/deposits": true,
+	}))
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "deposit_handler",
+			Trigger: "api:/v1/deposits",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "UNKNOWN_API_ENDPOINT", e.Code)
+		assert.NotEqual(t, "INVALID_API_PATH_FORMAT", e.Code)
+		assert.NotEqual(t, "DUPLICATE_API_TRIGGER", e.Code)
+	}
+}
+
+func TestValidateAPITriggers_SkippedWhenNoSpec(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil))
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "any_path",
+			Trigger: "api:/v1/anything",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "UNKNOWN_API_ENDPOINT", e.Code)
+	}
+}
+
+func TestParseOpenAPIPaths(t *testing.T) {
+	spec := `{
+		"swagger": "2.0",
+		"paths": {
+			"/v1/deposits": {},
+			"/v1/withdrawals": {},
+			"/v1/accounts/{id}": {}
+		}
+	}`
+
+	paths := parseOpenAPIPaths([]byte(spec))
+	assert.Len(t, paths, 3)
+	assert.True(t, paths["/v1/deposits"])
+	assert.True(t, paths["/v1/withdrawals"])
+	assert.True(t, paths["/v1/accounts/{id}"])
+}
+
+func TestParseOpenAPIPaths_InvalidJSON(t *testing.T) {
+	paths := parseOpenAPIPaths([]byte("not json"))
+	assert.Nil(t, paths)
+}
+
+// ─── Task 5: AsyncAPI CEL Field Validation Tests ────────────────────────────
+
+func TestValidateEventFilterCELFields_UnknownField_Warning(t *testing.T) {
+	asyncSchemas := map[string]map[string]bool{
+		"position-keeping.transaction-captured.v1": {
+			"log_id":          true,
+			"account_id":      true,
+			"transaction_id":  true,
+			"amount_cents":    true,
+			"instrument_code": true,
+			"direction":       true,
+		},
+	}
+
+	v, err := New(WithAsyncAPISchemas(asyncSchemas))
+	require.NoError(t, err)
+
+	filter := `event.typo_field == "X"`
+	m := validManifest()
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_captured",
+		Trigger: "event:position-keeping.transaction-captured.v1",
+		Script:  "def execute(ctx):\n    return {}\n",
+		Filter:  &filter,
+	})
+
+	result := v.Validate(m, nil)
+	assert.True(t, result.Valid, "warnings should not block validation, errors: %v", result.Errors)
+
+	found := false
+	for _, w := range result.Warnings {
+		if w.Code == "CEL_UNKNOWN_EVENT_FIELD" {
+			found = true
+			assert.Contains(t, w.Message, "typo_field")
+			assert.NotEmpty(t, w.AvailableFields)
+			break
+		}
+	}
+	assert.True(t, found, "expected CEL_UNKNOWN_EVENT_FIELD warning, got warnings: %v", result.Warnings)
+}
+
+func TestValidateEventFilterCELFields_UnknownField_WithSuggestion(t *testing.T) {
+	asyncSchemas := map[string]map[string]bool{
+		"position-keeping.transaction-captured.v1": {
+			"amount_cents":    true,
+			"instrument_code": true,
+		},
+	}
+
+	v, err := New(WithAsyncAPISchemas(asyncSchemas))
+	require.NoError(t, err)
+
+	filter := `event.amount_cent > 0`
+	m := validManifest()
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_captured_typo",
+		Trigger: "event:position-keeping.transaction-captured.v1",
+		Script:  "def execute(ctx):\n    return {}\n",
+		Filter:  &filter,
+	})
+
+	result := v.Validate(m, nil)
+
+	for _, w := range result.Warnings {
+		if w.Code == "CEL_UNKNOWN_EVENT_FIELD" {
+			assert.Contains(t, w.Suggestion, "amount_cents")
+			return
+		}
+	}
+	t.Error("expected CEL_UNKNOWN_EVENT_FIELD warning with suggestion")
+}
+
+func TestValidateEventFilterCELFields_KnownFields_NoWarning(t *testing.T) {
+	asyncSchemas := map[string]map[string]bool{
+		"position-keeping.transaction-captured.v1": {
+			"amount_cents":    true,
+			"instrument_code": true,
+			"direction":       true,
+		},
+	}
+
+	v, err := New(WithAsyncAPISchemas(asyncSchemas))
+	require.NoError(t, err)
+
+	filter := `event.amount_cents > 0 && event.direction == "CREDIT"`
+	m := validManifest()
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_captured_valid",
+		Trigger: "event:position-keeping.transaction-captured.v1",
+		Script:  "def execute(ctx):\n    return {}\n",
+		Filter:  &filter,
+	})
+
+	result := v.Validate(m, nil)
+	for _, w := range result.Warnings {
+		assert.NotEqual(t, "CEL_UNKNOWN_EVENT_FIELD", w.Code,
+			"unexpected CEL_UNKNOWN_EVENT_FIELD warning: %v", w)
+	}
+}
+
+func TestValidateEventFilterCELFields_NoSchema_NoWarning(t *testing.T) {
+	asyncSchemas := map[string]map[string]bool{
+		"some.other.topic.v1": {"field_a": true},
+	}
+
+	v, err := New(WithAsyncAPISchemas(asyncSchemas))
+	require.NoError(t, err)
+
+	filter := `event.any_field > 0`
+	m := validManifest()
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_captured_no_schema",
+		Trigger: "event:position-keeping.transaction-captured.v1",
+		Script:  "def execute(ctx):\n    return {}\n",
+		Filter:  &filter,
+	})
+
+	result := v.Validate(m, nil)
+	for _, w := range result.Warnings {
+		assert.NotEqual(t, "CEL_UNKNOWN_EVENT_FIELD", w.Code)
+	}
+}
+
+func TestValidateEventFilterCELFields_NilSchemas_NoWarning(t *testing.T) {
+	v, err := New(WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	filter := `event.any_field > 0`
+	m := validManifest()
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "on_captured_nil_schemas",
+		Trigger: "event:position-keeping.transaction-captured.v1",
+		Script:  "def execute(ctx):\n    return {}\n",
+		Filter:  &filter,
+	})
+
+	result := v.Validate(m, nil)
+	for _, w := range result.Warnings {
+		assert.NotEqual(t, "CEL_UNKNOWN_EVENT_FIELD", w.Code)
+	}
+}
+
+func TestExtractCELFieldRefs(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.Variable("event", cel.MapType(cel.StringType, cel.DynType)),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		expr     string
+		expected []string
+	}{
+		{
+			name:     "single field",
+			expr:     `event.amount > 0`,
+			expected: []string{"amount"},
+		},
+		{
+			name:     "multiple fields",
+			expr:     `event.amount > 0 && event.currency == "GBP"`,
+			expected: []string{"amount", "currency"},
+		},
+		{
+			name:     "no event fields",
+			expr:     `true`,
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := extractCELFieldRefs(tt.expr, env)
+			assert.Equal(t, tt.expected, fields)
+		})
+	}
+}
+
+func TestParseAsyncAPIFile(t *testing.T) {
+	data := []byte(`
+asyncapi: 3.0.0
+channels:
+  test.topic.v1:
+    messages:
+      TestEvent:
+        $ref: '#/components/messages/TestEvent'
+components:
+  messages:
+    TestEvent:
+      payload:
+        $ref: '#/components/schemas/TestEvent'
+  schemas:
+    TestEvent:
+      type: object
+      properties:
+        field_a:
+          type: string
+        field_b:
+          type: integer
+`)
+
+	schemas := make(map[string]map[string]bool)
+	parseAsyncAPIFile(data, schemas)
+
+	assert.Contains(t, schemas, "test.topic.v1")
+	assert.True(t, schemas["test.topic.v1"]["field_a"])
+	assert.True(t, schemas["test.topic.v1"]["field_b"])
+}
+
+// ─── Task 11: Orphan Detection Tests ────────────────────────────────────────
+
+func TestValidateOrphans_UnusedProviderConnection(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.OperationalGateway = &controlplanev1.OperationalGatewayConfig{
+		ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+			{ConnectionId: "stripe"},
+			{ConnectionId: "unused_provider"},
+		},
+		InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
+			{InstructionType: "payment.initiate", ConnectionId: "stripe"},
+		},
+	}
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "payment_saga",
+			Trigger: "api:/v1/payments",
+			Script:  "def execute(ctx):\n    operational_gateway.dispatch_instruction(instruction_type=\"payment.initiate\", payload={})\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+
+	found := false
+	for _, w := range result.Warnings {
+		if w.Code == "ORPHAN_PROVIDER_CONNECTION" {
+			found = true
+			assert.Contains(t, w.Message, "unused_provider")
+			break
+		}
+	}
+	assert.True(t, found, "expected ORPHAN_PROVIDER_CONNECTION warning, got warnings: %v", result.Warnings)
+}
+
+func TestValidateOrphans_FallbackConnectionNotOrphan(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.OperationalGateway = &controlplanev1.OperationalGatewayConfig{
+		ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+			{ConnectionId: "primary"},
+			{ConnectionId: "fallback"},
+		},
+		InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
+			{InstructionType: "payment.initiate", ConnectionId: "primary", FallbackConnectionId: "fallback"},
+		},
+	}
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "payment_saga",
+			Trigger: "api:/v1/payments",
+			Script:  "def execute(ctx):\n    operational_gateway.dispatch_instruction(\"payment.initiate\", payload={})\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+	for _, w := range result.Warnings {
+		assert.NotEqual(t, "ORPHAN_PROVIDER_CONNECTION", w.Code,
+			"fallback connection should not be flagged as orphan: %v", w)
+	}
+}
+
+func TestValidateOrphans_WebhookSourceNotOrphan(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.OperationalGateway = &controlplanev1.OperationalGatewayConfig{
+		ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+			{ConnectionId: "stripe"},
+		},
+	}
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "webhook_handler",
+			Trigger: "webhook:stripe.payment_intent.succeeded",
+			Script:  "def execute(ctx):\n    return {}\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+	for _, w := range result.Warnings {
+		assert.NotEqual(t, "ORPHAN_PROVIDER_CONNECTION", w.Code,
+			"webhook source should count as usage: %v", w)
+	}
+}
+
+func TestValidateOrphans_UnusedInstructionRoute(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.OperationalGateway = &controlplanev1.OperationalGatewayConfig{
+		ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+			{ConnectionId: "stripe"},
+		},
+		InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
+			{InstructionType: "payment.initiate", ConnectionId: "stripe"},
+			{InstructionType: "payment.refund", ConnectionId: "stripe"},
+		},
+	}
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "payment_saga",
+			Trigger: "api:/v1/payments",
+			Script:  "def execute(ctx):\n    operational_gateway.dispatch_instruction(instruction_type=\"payment.initiate\", payload={})\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+
+	found := false
+	for _, w := range result.Warnings {
+		if w.Code == "ORPHAN_INSTRUCTION_ROUTE" {
+			found = true
+			assert.Contains(t, w.Message, "payment.refund")
+			break
+		}
+	}
+	assert.True(t, found, "expected ORPHAN_INSTRUCTION_ROUTE warning, got warnings: %v", result.Warnings)
+}
+
+func TestValidateOrphans_AllConnected_NoWarnings(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.OperationalGateway = &controlplanev1.OperationalGatewayConfig{
+		ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+			{ConnectionId: "stripe"},
+		},
+		InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
+			{InstructionType: "payment.initiate", ConnectionId: "stripe"},
+		},
+	}
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "payment_saga",
+			Trigger: "api:/v1/payments",
+			Script:  "def execute(ctx):\n    operational_gateway.dispatch_instruction(\"payment.initiate\", payload={})\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+	for _, w := range result.Warnings {
+		assert.NotEqual(t, "ORPHAN_PROVIDER_CONNECTION", w.Code, "unexpected orphan warning: %v", w)
+		assert.NotEqual(t, "ORPHAN_INSTRUCTION_ROUTE", w.Code, "unexpected orphan warning: %v", w)
+	}
+}
+
+func TestValidateOrphans_DispatchRegex_KeywordArg(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.OperationalGateway = &controlplanev1.OperationalGatewayConfig{
+		ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+			{ConnectionId: "bank"},
+		},
+		InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
+			{InstructionType: "bank.transfer", ConnectionId: "bank"},
+		},
+	}
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "transfer_saga",
+			Trigger: "api:/v1/payments",
+			Script:  "def execute(ctx):\n    operational_gateway.dispatch_instruction(instruction_type='bank.transfer', payload={})\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+	for _, w := range result.Warnings {
+		assert.NotEqual(t, "ORPHAN_INSTRUCTION_ROUTE", w.Code,
+			"keyword arg dispatch should be detected: %v", w)
+	}
+}
+
+func TestValidateOrphans_DispatchRegex_PositionalArg(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.OperationalGateway = &controlplanev1.OperationalGatewayConfig{
+		ProviderConnections: []*controlplanev1.ProviderConnectionConfig{
+			{ConnectionId: "bank"},
+		},
+		InstructionRoutes: []*controlplanev1.InstructionRouteConfig{
+			{InstructionType: "bank.transfer", ConnectionId: "bank"},
+		},
+	}
+	m.Sagas = []*controlplanev1.SagaDefinition{
+		{
+			Name:    "transfer_saga",
+			Trigger: "api:/v1/payments",
+			Script:  "def execute(ctx):\n    operational_gateway.dispatch_instruction(\"bank.transfer\", payload={})\n",
+		},
+	}
+
+	result := v.Validate(m, nil)
+	for _, w := range result.Warnings {
+		assert.NotEqual(t, "ORPHAN_INSTRUCTION_ROUTE", w.Code,
+			"positional arg dispatch should be detected: %v", w)
+	}
+}
+
+func TestValidateOrphans_NoGateway_NoWarnings(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	m := validManifest()
+	m.OperationalGateway = nil
+
+	result := v.Validate(m, nil)
+	for _, w := range result.Warnings {
+		assert.NotEqual(t, "ORPHAN_PROVIDER_CONNECTION", w.Code)
+		assert.NotEqual(t, "ORPHAN_INSTRUCTION_ROUTE", w.Code)
 	}
 }


### PR DESCRIPTION
## Summary

Implements three manifest validation enhancements (039-meridian-vm tasks 2, 5, 11):

- **Task 2 - API trigger validation**: Validates `api:` trigger paths against the OpenAPI spec for existence, format (`/`-prefixed), and uniqueness across sagas. Provides "Did you mean?" suggestions via Levenshtein distance. Error codes: `UNKNOWN_API_ENDPOINT`, `DUPLICATE_API_TRIGGER`, `INVALID_API_PATH_FORMAT`.

- **Task 5 - AsyncAPI CEL field validation**: Cross-checks `event.field` references in CEL filter expressions against AsyncAPI payload schemas. Produces warnings (not errors) since AsyncAPI specs may lag behind actual payloads. Error code: `CEL_UNKNOWN_EVENT_FIELD` (severity: warning).

- **Task 11 - Orphan detection**: Detects unused provider connections (not referenced by instruction routes or webhook triggers) and instruction routes (not dispatched by any saga). Both produce warnings. Error codes: `ORPHAN_PROVIDER_CONNECTION`, `ORPHAN_INSTRUCTION_ROUTE`.

## Changes Made

- `manifest_validator.go`: Added functional options (`WithOpenAPIPaths`, `WithAsyncAPISchemas`), OpenAPI/AsyncAPI spec loading with graceful degradation, `validateAPITriggers()`, `validateEventFilterCELFields()`, `validateOperationalGatewayOrphans()`, CEL AST field extraction, AsyncAPI YAML parsing
- `manifest_validator_test.go`: 22 new test cases covering all three tasks, updated test fixture to use real API paths

## Test plan

- [x] All existing tests pass (no regressions)
- [x] Task 2: Tests for unknown endpoint, suggestions, duplicates, invalid format, valid path, skipped-when-no-spec
- [x] Task 5: Tests for unknown field warning, suggestions, known fields, no schema, nil schemas, CEL field extraction, AsyncAPI parsing
- [x] Task 11: Tests for unused provider, fallback not orphan, webhook source not orphan, unused instruction route, all connected, keyword/positional dispatch regex, no gateway