### PR TITLE
fix: Resolve account type for transaction links

### DIFF
--- a/frontend/src/features/accounts/pages/[accountId].tsx
+++ b/frontend/src/features/accounts/pages/[accountId].tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, Navigate } from 'react-router-dom'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
@@ -7,6 +7,7 @@ import { StatusBadge } from '@/shared/status-badge'
 import { TimeDisplay } from '@/shared/time-display'
 import { MoneyDisplay } from '@/shared/money-display'
 import { AuditTrail, EntityLink, Breadcrumbs } from '@/shared'
+import { useAccountResolver } from '@/shared/use-account-resolver'
 import { DepositDialog } from './deposit-dialog'
 import { WithdrawDialog } from './withdraw-dialog'
 import { ControlDialog } from './control-dialog'
@@ -353,13 +354,23 @@ export function AccountDetailPage() {
   const { accountId } = useParams<{ accountId: string }>()
 
   const { data: account, isLoading, isError, refetch, isFetching } = useAccountDetail(accountId)
+  const { data: resolved, isLoading: isResolving } = useAccountResolver(
+    // Only resolve when current-account returns 404 (null)
+    account === null && !isLoading ? accountId : undefined,
+  )
 
   if (isLoading) {
     return <AccountDetailSkeleton />
   }
 
-  // null = 404 from server; isError = network/server failure; undefined = query not yet resolved
+  // Current-account returned 404 — check if it's an internal account
   if (account === null) {
+    if (isResolving) {
+      return <AccountDetailSkeleton />
+    }
+    if (resolved?.type === 'internal') {
+      return <Navigate to={`/internal-accounts/${encodeURIComponent(resolved.accountId)}`} replace />
+    }
     return <AccountNotFound accountId={accountId} />
   }
 

--- a/frontend/src/features/accounts/pages/[accountId].tsx
+++ b/frontend/src/features/accounts/pages/[accountId].tsx
@@ -49,14 +49,10 @@ function AccountNotFound({ accountId }: { accountId?: string }) {
       <div className="mt-8 text-center">
         <h2 className="text-xl font-semibold">Account not found</h2>
         <p className="mt-2 text-sm text-muted-foreground">
-          The account you are looking for does not exist or has been removed.
+          {accountId
+            ? `Account "${accountId}" was not found in any account service.`
+            : 'The account you are looking for does not exist or has been removed.'}
         </p>
-        {accountId && (
-          <p className="mt-3 text-sm">
-            Looking for an internal account?{' '}
-            <EntityLink type="internal-account" id={accountId} label="View internal account" />
-          </p>
-        )}
       </div>
     </div>
   )
@@ -357,6 +353,8 @@ export function AccountDetailPage() {
   const { data: resolved, isLoading: isResolving } = useAccountResolver(
     // Only resolve when current-account returns 404 (null)
     account === null && !isLoading ? accountId : undefined,
+    // Skip current-account check — useAccountDetail already tried it
+    { skipServices: ['current'] },
   )
 
   if (isLoading) {

--- a/frontend/src/shared/entity-link.tsx
+++ b/frontend/src/shared/entity-link.tsx
@@ -1,5 +1,4 @@
 import { Link } from 'react-router-dom'
-import { isUuid } from '@/lib/utils'
 
 export type EntityType =
   | 'account'
@@ -14,10 +13,7 @@ function entityPath(type: EntityType, id: string): string {
   const encodedId = encodeURIComponent(id)
   switch (type) {
     case 'account':
-      // UUID → current account, human-readable code → internal account
-      return isUuid(id)
-        ? `/accounts/${encodedId}`
-        : `/internal-accounts/${encodedId}`
+      return `/accounts/${encodedId}`
     case 'current-account':
       return `/accounts/${encodedId}`
     case 'party':

--- a/frontend/src/shared/index.ts
+++ b/frontend/src/shared/index.ts
@@ -17,3 +17,6 @@ export type { BreadcrumbsProps, BreadcrumbItem } from './breadcrumbs';
 
 export { DetailSkeleton } from './detail-skeleton';
 export type { DetailSkeletonProps } from './detail-skeleton';
+
+export { useAccountResolver } from './use-account-resolver';
+export type { ResolvedAccount, ResolvedAccountType } from './use-account-resolver';

--- a/frontend/src/shared/use-account-resolver.ts
+++ b/frontend/src/shared/use-account-resolver.ts
@@ -17,38 +17,49 @@ export interface ResolvedAccount {
  * 1. Try current-account service first (most common)
  * 2. If not found, try internal-account service
  * 3. If not found in either, return null
+ *
+ * When the caller has already checked one service (e.g. AccountDetailPage already
+ * tried current-account via useAccountDetail), pass skipServices to avoid redundant calls.
  */
-export function useAccountResolver(accountId: string | undefined) {
+export function useAccountResolver(
+  accountId: string | undefined,
+  options?: { skipServices?: ResolvedAccountType[] },
+) {
   const clients = useApiClients()
   const { tenantSlug } = useTenantContext()
+  const skip = options?.skipServices ?? []
 
   return useQuery({
-    queryKey: [...tenantKeys.all(tenantSlug ?? ''), 'account-resolve', accountId],
+    queryKey: [...tenantKeys.all(tenantSlug ?? ''), 'account-resolve', accountId, skip],
     queryFn: async (): Promise<ResolvedAccount | null> => {
       if (!accountId) return null
 
-      // Try current-account first
-      try {
-        const response = await clients.currentAccount.retrieveCurrentAccount({
-          accountId,
-        })
-        if (response.facility) {
-          return { type: 'current', accountId }
+      // Try current-account
+      if (!skip.includes('current')) {
+        try {
+          const response = await clients.currentAccount.retrieveCurrentAccount({
+            accountId,
+          })
+          if (response.facility) {
+            return { type: 'current', accountId }
+          }
+        } catch {
+          // Not found or error — continue
         }
-      } catch {
-        // Not found or error — continue to internal-account
       }
 
       // Try internal-account
-      try {
-        const response = await clients.internalAccount.retrieveInternalAccount({
-          accountId,
-        })
-        if (response.facility) {
-          return { type: 'internal', accountId }
+      if (!skip.includes('internal')) {
+        try {
+          const response = await clients.internalAccount.retrieveInternalAccount({
+            accountId,
+          })
+          if (response.facility) {
+            return { type: 'internal', accountId }
+          }
+        } catch {
+          // Not found in either service
         }
-      } catch {
-        // Not found in either service
       }
 
       return null

--- a/frontend/src/shared/use-account-resolver.ts
+++ b/frontend/src/shared/use-account-resolver.ts
@@ -1,0 +1,60 @@
+import { useQuery } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
+import { useTenantContext } from '@/contexts/tenant-context'
+import { tenantKeys } from '@/lib/query-keys'
+
+export type ResolvedAccountType = 'current' | 'internal'
+
+export interface ResolvedAccount {
+  type: ResolvedAccountType
+  accountId: string
+}
+
+/**
+ * Resolves an account ID to its owning service (current-account or internal-account).
+ *
+ * Mirrors the backend CompositeAccountValidator pattern:
+ * 1. Try current-account service first (most common)
+ * 2. If not found, try internal-account service
+ * 3. If not found in either, return null
+ */
+export function useAccountResolver(accountId: string | undefined) {
+  const clients = useApiClients()
+  const { tenantSlug } = useTenantContext()
+
+  return useQuery({
+    queryKey: [...tenantKeys.all(tenantSlug ?? ''), 'account-resolve', accountId],
+    queryFn: async (): Promise<ResolvedAccount | null> => {
+      if (!accountId) return null
+
+      // Try current-account first
+      try {
+        const response = await clients.currentAccount.retrieveCurrentAccount({
+          accountId,
+        })
+        if (response.facility) {
+          return { type: 'current', accountId }
+        }
+      } catch {
+        // Not found or error — continue to internal-account
+      }
+
+      // Try internal-account
+      try {
+        const response = await clients.internalAccount.retrieveInternalAccount({
+          accountId,
+        })
+        if (response.facility) {
+          return { type: 'internal', accountId }
+        }
+      } catch {
+        // Not found in either service
+      }
+
+      return null
+    },
+    enabled: !!accountId && !!tenantSlug,
+    staleTime: 5 * 60 * 1000, // Cache resolution for 5 minutes
+    retry: false,
+  })
+}

--- a/frontend/src/shared/use-account-resolver.ts
+++ b/frontend/src/shared/use-account-resolver.ts
@@ -1,7 +1,14 @@
 import { useQuery } from '@tanstack/react-query'
+import { ConnectError, Code } from '@connectrpc/connect'
 import { useApiClients } from '@/api/context'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
+
+function isNotFoundError(err: unknown): boolean {
+  return err instanceof ConnectError && (
+    err.code === Code.NotFound || err.code === Code.InvalidArgument
+  )
+}
 
 export type ResolvedAccountType = 'current' | 'internal'
 
@@ -43,8 +50,8 @@ export function useAccountResolver(
           if (response.facility) {
             return { type: 'current', accountId }
           }
-        } catch {
-          // Not found or error — continue
+        } catch (err) {
+          if (!isNotFoundError(err)) throw err
         }
       }
 
@@ -57,8 +64,8 @@ export function useAccountResolver(
           if (response.facility) {
             return { type: 'internal', accountId }
           }
-        } catch {
-          // Not found in either service
+        } catch (err) {
+          if (!isNotFoundError(err)) throw err
         }
       }
 


### PR DESCRIPTION
## Summary

- **Problem**: Transaction page account links used a `isUuid()` heuristic to decide routing — UUIDs went to `/accounts/` (current-account), non-UUIDs went to `/internal-accounts/`. This broke for:
  - Current accounts with `ACC-*` IDs (e.g. `ACC-ceee5ad7`) — incorrectly routed to internal-accounts page
  - Clearing accounts like `CLEARING-GBP-001` — not found in either account view
- **Fix**: Remove the UUID heuristic. All `EntityLink type="account"` links now route to `/accounts/:id`. The account detail page tries current-account first, and if not found, checks internal-account and redirects via `<Navigate>`. Resolution results are cached for 5 minutes.
- This mirrors the backend `CompositeAccountValidator` pattern already used in position-keeping

## Changes

| File | Change |
|------|--------|
| `frontend/src/shared/entity-link.tsx` | Remove `isUuid` routing heuristic; all `type="account"` links go to `/accounts/:id` |
| `frontend/src/shared/use-account-resolver.ts` | New hook: tries current-account then internal-account (like backend `CompositeAccountValidator`) |
| `frontend/src/features/accounts/pages/[accountId].tsx` | On 404, resolve via internal-account and redirect if found |
| `frontend/src/shared/index.ts` | Export new resolver hook |

## Test plan

- [ ] Navigate to transactions page, click an `ACC-*` account link — should show current account detail
- [ ] Click a `CLEARING-*` account link — should redirect to internal-accounts detail page
- [ ] Click a UUID account link — should still show current account detail (no regression)
- [ ] Account not found in either service — should show "Account not found" page