### PR TITLE
feat: Add meridian_manifest_fix MCP tool

### DIFF
--- a/services/mcp-server/cmd/wire.go
+++ b/services/mcp-server/cmd/wire.go
@@ -65,8 +65,8 @@ func wireServer(srv *server.MCPServer, logger *slog.Logger, cookbookFS fs.FS) (f
 	// Manifest fix tool uses the embedded handler schema to convert deprecated calls.
 	if schemaReg, err := schema.DefaultRegistry(); err != nil {
 		logger.Warn("failed to load handler schema for manifest fix tool", "error", err)
-	} else {
-		tools.RegisterManifestFixTool(toolReg, schemaReg)
+	} else if err := tools.RegisterManifestFixTool(toolReg, schemaReg); err != nil {
+		logger.Warn("failed to register manifest fix tool", "error", err)
 	}
 
 	// Try to connect to the Meridian backend for remote tools.

--- a/services/mcp-server/cmd/wire.go
+++ b/services/mcp-server/cmd/wire.go
@@ -27,6 +27,7 @@ import (
 	"github.com/meridianhub/meridian/services/mcp-server/internal/server"
 	"github.com/meridianhub/meridian/services/mcp-server/internal/session"
 	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
 )
 
 // wireServer registers all MCP tools, resources, and prompts onto srv.
@@ -59,6 +60,13 @@ func wireServer(srv *server.MCPServer, logger *slog.Logger, cookbookFS fs.FS) (f
 	if cookbookFS != nil {
 		cookbookLoader := tools.NewFSCookbookLoader(cookbookFS)
 		tools.RegisterCookbookDiscoverTool(toolReg, cookbookLoader)
+	}
+
+	// Manifest fix tool uses the embedded handler schema to convert deprecated calls.
+	if schemaReg, err := schema.DefaultRegistry(); err != nil {
+		logger.Warn("failed to load handler schema for manifest fix tool", "error", err)
+	} else {
+		tools.RegisterManifestFixTool(toolReg, schemaReg)
 	}
 
 	// Try to connect to the Meridian backend for remote tools.

--- a/services/mcp-server/internal/tools/manifest_fix.go
+++ b/services/mcp-server/internal/tools/manifest_fix.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -12,11 +13,12 @@ import (
 )
 
 // RegisterManifestFixTool registers the meridian_manifest_fix tool into the provided Registry.
-func RegisterManifestFixTool(r *Registry, schemaRegistry *schema.Registry) {
+func RegisterManifestFixTool(r *Registry, schemaRegistry *schema.Registry) error {
 	tool := buildManifestFixTool(schemaRegistry)
 	if err := r.Register(tool); err != nil {
-		panic(fmt.Sprintf("failed to register manifest fix tool: %v", err))
+		return fmt.Errorf("register manifest fix tool: %w", err)
 	}
+	return nil
 }
 
 // buildManifestFixTool returns the meridian_manifest_fix Tool definition.
@@ -164,8 +166,9 @@ func fixScriptDeprecatedCalls(script string, sagaName string, schemaRegistry *sc
 
 	for _, oldName := range sortedNames {
 		info := deprecatedHandlers[oldName]
-		oldCall := oldName + "("
-		if !strings.Contains(result, oldCall) {
+		// Use regex to detect calls with optional whitespace before '('
+		callPattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(oldName) + `\s*\(`)
+		if !callPattern.MatchString(result) {
 			continue
 		}
 
@@ -199,8 +202,10 @@ func collectDeprecatedHandlers(schemaRegistry *schema.Registry) map[string]depre
 // applyHandlerConversion replaces the deprecated handler call and its parameter names in the script.
 // Parameter renaming is scoped to each call site's argument list to avoid corrupting other calls.
 func applyHandlerConversion(script string, oldName string, info deprecatedInfo) string {
-	oldCall := oldName + "("
 	newCall := info.currentName + "("
+	// Regex matches oldName (with word boundary) followed by optional whitespace and '('
+	callRe := regexp.MustCompile(`\b` + regexp.QuoteMeta(oldName) + `\s*\(`)
+
 	// Build reverse mapping: old param name -> new param name.
 	// Empty when no param mapping exists — handler name is still replaced
 	// using the string/comment-aware loop below to avoid modifying literals.
@@ -217,16 +222,16 @@ func applyHandlerConversion(script string, oldName string, info deprecatedInfo) 
 	var result strings.Builder
 	remaining := script
 	for {
-		idx := strings.Index(remaining, oldCall)
-		if idx < 0 {
+		loc := callRe.FindStringIndex(remaining)
+		if loc == nil {
 			result.WriteString(remaining)
 			break
 		}
 
 		// Write text before the call and the new handler name
-		result.WriteString(remaining[:idx])
+		result.WriteString(remaining[:loc[0]])
 		result.WriteString(newCall)
-		remaining = remaining[idx+len(oldCall):]
+		remaining = remaining[loc[1]:]
 
 		// Find the matching closing paren, tracking nesting depth
 		callBody, rest := extractCallBody(remaining)
@@ -368,9 +373,14 @@ func (s *kwargScanner) handleTopLevelIdent() {
 	}
 	ident := s.src[start:s.pos]
 
-	// Match "ident=" but not "ident==" (comparison operator)
-	if s.pos < len(s.src) && s.src[s.pos] == '=' &&
-		(s.pos+1 >= len(s.src) || s.src[s.pos+1] != '=') &&
+	// Match "ident=" or "ident =" but not "ident==" (comparison operator).
+	// Skip optional whitespace between identifier and '='.
+	eqPos := s.pos
+	for eqPos < len(s.src) && (s.src[eqPos] == ' ' || s.src[eqPos] == '\t') {
+		eqPos++
+	}
+	if eqPos < len(s.src) && s.src[eqPos] == '=' &&
+		(eqPos+1 >= len(s.src) || s.src[eqPos+1] != '=') &&
 		!isPrecededByIdent(s.src, start) {
 		if newName, ok := s.reverseMapping[ident]; ok {
 			s.result.WriteString(newName)

--- a/services/mcp-server/internal/tools/manifest_fix.go
+++ b/services/mcp-server/internal/tools/manifest_fix.go
@@ -219,6 +219,7 @@ func applyHandlerConversion(script string, oldName string, info deprecatedInfo) 
 
 	// Process each occurrence of the deprecated call, replacing handler name
 	// and renaming params only within the call's parentheses.
+	// Skip occurrences inside string literals or comments.
 	var result strings.Builder
 	remaining := script
 	for {
@@ -226,6 +227,14 @@ func applyHandlerConversion(script string, oldName string, info deprecatedInfo) 
 		if loc == nil {
 			result.WriteString(remaining)
 			break
+		}
+
+		// Check if the match is inside a string literal or comment
+		if isInsideStringOrComment(remaining, loc[0]) {
+			// Copy through the matched text without modification
+			result.WriteString(remaining[:loc[1]])
+			remaining = remaining[loc[1]:]
+			continue
 		}
 
 		// Write text before the call and the new handler name
@@ -304,6 +313,36 @@ func skipString(s string, i int) int {
 		i++
 	}
 	return len(s)
+}
+
+// isInsideStringOrComment returns true if position pos in s falls inside
+// a string literal or a line comment. It scans from the beginning of s,
+// tracking string and comment boundaries.
+func isInsideStringOrComment(s string, pos int) bool {
+	i := 0
+	for i < pos {
+		switch s[i] {
+		case '#':
+			// Line comment extends to end of line or end of string.
+			// If pos is anywhere in the comment, it's inside.
+			for i < len(s) && s[i] != '\n' {
+				if i == pos {
+					return true
+				}
+				i++
+			}
+		case '"', '\'':
+			start := i
+			i = skipString(s, i)
+			// If pos falls within the string literal range, it's inside.
+			if pos >= start && pos < i {
+				return true
+			}
+		default:
+			i++
+		}
+	}
+	return false
 }
 
 // kwargScanner holds state for scanning a call body and renaming top-level kwargs.

--- a/services/mcp-server/internal/tools/manifest_fix.go
+++ b/services/mcp-server/internal/tools/manifest_fix.go
@@ -197,14 +197,67 @@ func collectDeprecatedHandlers(schemaRegistry *schema.Registry) map[string]depre
 }
 
 // applyHandlerConversion replaces the deprecated handler call and its parameter names in the script.
+// Parameter renaming is scoped to each call site's argument list to avoid corrupting other calls.
 func applyHandlerConversion(script string, oldName string, info deprecatedInfo) string {
-	result := strings.ReplaceAll(script, oldName+"(", info.currentName+"(")
-	if info.rule != nil {
-		for newParam, oldParam := range info.rule.ParamMapping {
-			result = strings.ReplaceAll(result, oldParam+"=", newParam+"=")
+	oldCall := oldName + "("
+	newCall := info.currentName + "("
+	hasParamMapping := info.rule != nil && len(info.rule.ParamMapping) > 0
+
+	if !hasParamMapping {
+		return strings.ReplaceAll(script, oldCall, newCall)
+	}
+
+	// Build reverse mapping: old param name -> new param name
+	reverseMapping := make(map[string]string, len(info.rule.ParamMapping))
+	for newParam, oldParam := range info.rule.ParamMapping {
+		reverseMapping[oldParam] = newParam
+	}
+
+	// Process each occurrence of the deprecated call, replacing handler name
+	// and renaming params only within the call's parentheses.
+	var result strings.Builder
+	remaining := script
+	for {
+		idx := strings.Index(remaining, oldCall)
+		if idx < 0 {
+			result.WriteString(remaining)
+			break
+		}
+
+		// Write text before the call and the new handler name
+		result.WriteString(remaining[:idx])
+		result.WriteString(newCall)
+		remaining = remaining[idx+len(oldCall):]
+
+		// Find the matching closing paren, tracking nesting depth
+		callBody, rest := extractCallBody(remaining)
+		// Rename params within the call body
+		for oldParam, newParam := range reverseMapping {
+			callBody = strings.ReplaceAll(callBody, oldParam+"=", newParam+"=")
+		}
+		result.WriteString(callBody)
+		remaining = rest
+	}
+
+	return result.String()
+}
+
+// extractCallBody splits text at the matching closing paren for an already-opened call.
+// Returns (bodyIncludingCloseParen, rest). If no matching paren is found, returns (all, "").
+func extractCallBody(s string) (string, string) {
+	depth := 1
+	for i, ch := range s {
+		switch ch {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return s[:i+1], s[i+1:]
+			}
 		}
 	}
-	return result
+	return s, ""
 }
 
 // buildConversionMessage creates a human-readable description of a handler conversion.

--- a/services/mcp-server/internal/tools/manifest_fix.go
+++ b/services/mcp-server/internal/tools/manifest_fix.go
@@ -231,10 +231,8 @@ func applyHandlerConversion(script string, oldName string, info deprecatedInfo) 
 
 		// Find the matching closing paren, tracking nesting depth
 		callBody, rest := extractCallBody(remaining)
-		// Rename params within the call body
-		for oldParam, newParam := range reverseMapping {
-			callBody = strings.ReplaceAll(callBody, oldParam+"=", newParam+"=")
-		}
+		// Rename top-level kwargs within the call body
+		callBody = renameTopLevelKwargs(callBody, reverseMapping)
 		result.WriteString(callBody)
 		remaining = rest
 	}
@@ -243,21 +241,156 @@ func applyHandlerConversion(script string, oldName string, info deprecatedInfo) 
 }
 
 // extractCallBody splits text at the matching closing paren for an already-opened call.
+// Handles strings (single/double/triple-quoted) and comments so that parens inside
+// literals do not affect depth tracking.
 // Returns (bodyIncludingCloseParen, rest). If no matching paren is found, returns (all, "").
 func extractCallBody(s string) (string, string) {
 	depth := 1
-	for i, ch := range s {
-		switch ch {
+	i := 0
+	for i < len(s) {
+		switch s[i] {
+		case '#':
+			// Skip to end of line (comment)
+			for i < len(s) && s[i] != '\n' {
+				i++
+			}
+		case '"', '\'':
+			i = skipString(s, i)
 		case '(':
 			depth++
+			i++
 		case ')':
 			depth--
 			if depth == 0 {
 				return s[:i+1], s[i+1:]
 			}
+			i++
+		default:
+			i++
 		}
 	}
 	return s, ""
+}
+
+// skipString advances past a string literal starting at position i.
+// Handles triple-quoted strings (""", ”') and single-quoted strings with escapes.
+func skipString(s string, i int) int {
+	quote := s[i]
+	// Check for triple-quoted string
+	if i+2 < len(s) && s[i+1] == quote && s[i+2] == quote {
+		triple := string([]byte{quote, quote, quote})
+		end := strings.Index(s[i+3:], triple)
+		if end >= 0 {
+			return i + 3 + end + 3
+		}
+		return len(s)
+	}
+	// Single-quoted string: advance past closing quote, handling escapes
+	i++
+	for i < len(s) {
+		if s[i] == '\\' {
+			i += 2
+			continue
+		}
+		if s[i] == quote {
+			return i + 1
+		}
+		i++
+	}
+	return len(s)
+}
+
+// kwargScanner holds state for scanning a call body and renaming top-level kwargs.
+type kwargScanner struct {
+	src            string
+	reverseMapping map[string]string
+	result         strings.Builder
+	depth          int
+	pos            int
+}
+
+// renameTopLevelKwargs renames keyword argument names at the top level of a call body.
+// Only renames "name=" patterns that appear at kwarg position, not inside nested calls,
+// strings, or as suffixes of longer identifiers.
+func renameTopLevelKwargs(callBody string, reverseMapping map[string]string) string {
+	s := &kwargScanner{src: callBody, reverseMapping: reverseMapping}
+	s.scan()
+	return s.result.String()
+}
+
+func (s *kwargScanner) scan() {
+	for s.pos < len(s.src) {
+		switch s.src[s.pos] {
+		case '#':
+			s.copyComment()
+		case '"', '\'':
+			s.copyStringLiteral()
+		case '(':
+			s.depth++
+			s.result.WriteByte('(')
+			s.pos++
+		case ')':
+			if s.depth > 0 {
+				s.depth--
+			}
+			s.result.WriteByte(')')
+			s.pos++
+		default:
+			if s.depth == 0 && isIdentStart(s.src[s.pos]) {
+				s.handleTopLevelIdent()
+			} else {
+				s.result.WriteByte(s.src[s.pos])
+				s.pos++
+			}
+		}
+	}
+}
+
+func (s *kwargScanner) copyComment() {
+	start := s.pos
+	for s.pos < len(s.src) && s.src[s.pos] != '\n' {
+		s.pos++
+	}
+	s.result.WriteString(s.src[start:s.pos])
+}
+
+func (s *kwargScanner) copyStringLiteral() {
+	start := s.pos
+	s.pos = skipString(s.src, s.pos)
+	s.result.WriteString(s.src[start:s.pos])
+}
+
+func (s *kwargScanner) handleTopLevelIdent() {
+	start := s.pos
+	for s.pos < len(s.src) && isIdentContinue(s.src[s.pos]) {
+		s.pos++
+	}
+	ident := s.src[start:s.pos]
+
+	if s.pos < len(s.src) && s.src[s.pos] == '=' && !isPrecededByIdent(s.src, start) {
+		if newName, ok := s.reverseMapping[ident]; ok {
+			s.result.WriteString(newName)
+			return
+		}
+	}
+	s.result.WriteString(ident)
+}
+
+func isIdentStart(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_'
+}
+
+func isIdentContinue(ch byte) bool {
+	return isIdentStart(ch) || (ch >= '0' && ch <= '9')
+}
+
+// isPrecededByIdent checks if the character immediately before pos is an identifier char.
+// This prevents matching "total_amount" when looking for "amount".
+func isPrecededByIdent(s string, pos int) bool {
+	if pos == 0 {
+		return false
+	}
+	return isIdentContinue(s[pos-1])
 }
 
 // buildConversionMessage creates a human-readable description of a handler conversion.

--- a/services/mcp-server/internal/tools/manifest_fix.go
+++ b/services/mcp-server/internal/tools/manifest_fix.go
@@ -1,0 +1,225 @@
+// Package tools provides tool handlers for the MCP server.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+)
+
+// RegisterManifestFixTool registers the meridian_manifest_fix tool into the provided Registry.
+func RegisterManifestFixTool(r *Registry, schemaRegistry *schema.Registry) {
+	tool := buildManifestFixTool(schemaRegistry)
+	if err := r.Register(tool); err != nil {
+		panic(fmt.Sprintf("failed to register manifest fix tool: %v", err))
+	}
+}
+
+// buildManifestFixTool returns the meridian_manifest_fix Tool definition.
+func buildManifestFixTool(schemaRegistry *schema.Registry) Tool {
+	return Tool{
+		Name:     "meridian_manifest_fix",
+		Category: CategorySimulate,
+		Description: "Auto-convert deprecated handler calls in a manifest's saga scripts. " +
+			"Returns the fixed manifest with updated handler names and parameter mappings, " +
+			"plus a list of conversions applied. Does NOT apply the manifest.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"manifest": map[string]interface{}{
+					"type":        "object",
+					"description": "The manifest JSON object containing sagas to fix.",
+				},
+			},
+			"required": []interface{}{"manifest"},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			return handleManifestFix(ctx, schemaRegistry, params)
+		},
+	}
+}
+
+// manifestFixParams holds parsed parameters for meridian_manifest_fix.
+type manifestFixParams struct {
+	Manifest json.RawMessage `json:"manifest"`
+}
+
+// manifestFixConversion records a single conversion applied to a saga script.
+type manifestFixConversion struct {
+	Saga    string `json:"saga"`
+	Message string `json:"message"`
+}
+
+// handleManifestFix implements the meridian_manifest_fix handler logic.
+func handleManifestFix(_ context.Context, schemaRegistry *schema.Registry, params json.RawMessage) (interface{}, error) {
+	var p manifestFixParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return map[string]interface{}{
+			"error": fmt.Sprintf("invalid params: %v", err),
+		}, nil
+	}
+
+	// Parse the manifest as a generic map
+	var manifest map[string]interface{}
+	if err := json.Unmarshal(p.Manifest, &manifest); err != nil {
+		return map[string]interface{}{ //nolint:nilerr // unmarshal error is surfaced in the tool response
+			"error": fmt.Sprintf("invalid manifest JSON: %v", err),
+		}, nil
+	}
+
+	conversions, err := fixManifestSagas(manifest, schemaRegistry)
+	if err != nil {
+		return map[string]interface{}{ //nolint:nilerr // fix error is surfaced in the tool response
+			"error": err.Error(),
+		}, nil
+	}
+
+	// Build conversions as []interface{} for JSON
+	convResults := make([]interface{}, 0, len(conversions))
+	for _, c := range conversions {
+		convResults = append(convResults, map[string]interface{}{
+			"saga":    c.Saga,
+			"message": c.Message,
+		})
+	}
+
+	return map[string]interface{}{
+		"manifest":    manifest,
+		"conversions": convResults,
+	}, nil
+}
+
+// fixManifestSagas iterates over sagas in the manifest and converts deprecated handler calls.
+// It mutates the manifest in-place and returns a list of conversions applied.
+func fixManifestSagas(manifest map[string]interface{}, schemaRegistry *schema.Registry) ([]manifestFixConversion, error) {
+	sagasRaw, ok := manifest["sagas"]
+	if !ok {
+		return nil, nil
+	}
+
+	sagas, ok := sagasRaw.([]interface{})
+	if !ok {
+		return nil, nil
+	}
+
+	var allConversions []manifestFixConversion
+
+	for _, sagaRaw := range sagas {
+		saga, ok := sagaRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		scriptRaw, ok := saga["script"]
+		if !ok {
+			continue
+		}
+		script, ok := scriptRaw.(string)
+		if !ok {
+			continue
+		}
+
+		sagaName, _ := saga["name"].(string)
+
+		fixedScript, conversions := fixScriptDeprecatedCalls(script, sagaName, schemaRegistry)
+		if len(conversions) > 0 {
+			saga["script"] = fixedScript
+			allConversions = append(allConversions, conversions...)
+		}
+	}
+
+	return allConversions, nil
+}
+
+// deprecatedInfo holds the current handler name and conversion rule for a deprecated handler.
+type deprecatedInfo struct {
+	currentName string
+	rule        *schema.ConversionRule
+}
+
+// fixScriptDeprecatedCalls scans a Starlark script for deprecated handler calls and
+// rewrites them to use the current handler name and parameter names.
+// Uses text-level replacement to preserve script formatting.
+func fixScriptDeprecatedCalls(script string, sagaName string, schemaRegistry *schema.Registry) (string, []manifestFixConversion) {
+	deprecatedHandlers := collectDeprecatedHandlers(schemaRegistry)
+	if len(deprecatedHandlers) == 0 {
+		return script, nil
+	}
+
+	// Sort deprecated handler names by length (longest first) to avoid partial replacements
+	sortedNames := make([]string, 0, len(deprecatedHandlers))
+	for name := range deprecatedHandlers {
+		sortedNames = append(sortedNames, name)
+	}
+	sort.Slice(sortedNames, func(i, j int) bool {
+		return len(sortedNames[i]) > len(sortedNames[j])
+	})
+
+	var conversions []manifestFixConversion
+	result := script
+
+	for _, oldName := range sortedNames {
+		info := deprecatedHandlers[oldName]
+		oldCall := oldName + "("
+		if !strings.Contains(result, oldCall) {
+			continue
+		}
+
+		result = applyHandlerConversion(result, oldName, info)
+		conversions = append(conversions, manifestFixConversion{
+			Saga:    sagaName,
+			Message: buildConversionMessage(oldName, info),
+		})
+	}
+
+	return result, conversions
+}
+
+// collectDeprecatedHandlers builds a map of deprecated handler names to their replacement info.
+func collectDeprecatedHandlers(schemaRegistry *schema.Registry) map[string]deprecatedInfo {
+	metadata := schemaRegistry.BuildLinterMetadata()
+	result := make(map[string]deprecatedInfo)
+	for name, meta := range metadata {
+		if meta.IsDeprecated && meta.ReplacedBy != "" {
+			if mapping := schemaRegistry.LookupDeprecated(name); mapping != nil {
+				result[name] = deprecatedInfo{
+					currentName: mapping.CurrentName,
+					rule:        mapping.ConversionRule,
+				}
+			}
+		}
+	}
+	return result
+}
+
+// applyHandlerConversion replaces the deprecated handler call and its parameter names in the script.
+func applyHandlerConversion(script string, oldName string, info deprecatedInfo) string {
+	result := strings.ReplaceAll(script, oldName+"(", info.currentName+"(")
+	if info.rule != nil {
+		for newParam, oldParam := range info.rule.ParamMapping {
+			result = strings.ReplaceAll(result, oldParam+"=", newParam+"=")
+		}
+	}
+	return result
+}
+
+// buildConversionMessage creates a human-readable description of a handler conversion.
+func buildConversionMessage(oldName string, info deprecatedInfo) string {
+	msg := fmt.Sprintf("Converted %s -> %s", oldName, info.currentName)
+	if info.rule != nil && len(info.rule.ParamMapping) > 0 {
+		mappings := make([]string, 0, len(info.rule.ParamMapping))
+		for newParam, oldParam := range info.rule.ParamMapping {
+			mappings = append(mappings, fmt.Sprintf("%s->%s", oldParam, newParam))
+		}
+		sort.Strings(mappings)
+		msg += fmt.Sprintf(" (params: %s)", strings.Join(mappings, ", "))
+	}
+	if info.rule != nil && info.rule.Sunset != "" {
+		msg += fmt.Sprintf(" [deprecated, removal in v%s]", info.rule.Sunset)
+	}
+	return msg
+}

--- a/services/mcp-server/internal/tools/manifest_fix.go
+++ b/services/mcp-server/internal/tools/manifest_fix.go
@@ -201,16 +201,15 @@ func collectDeprecatedHandlers(schemaRegistry *schema.Registry) map[string]depre
 func applyHandlerConversion(script string, oldName string, info deprecatedInfo) string {
 	oldCall := oldName + "("
 	newCall := info.currentName + "("
-	hasParamMapping := info.rule != nil && len(info.rule.ParamMapping) > 0
-
-	if !hasParamMapping {
-		return strings.ReplaceAll(script, oldCall, newCall)
-	}
-
-	// Build reverse mapping: old param name -> new param name
-	reverseMapping := make(map[string]string, len(info.rule.ParamMapping))
-	for newParam, oldParam := range info.rule.ParamMapping {
-		reverseMapping[oldParam] = newParam
+	// Build reverse mapping: old param name -> new param name.
+	// Empty when no param mapping exists — handler name is still replaced
+	// using the string/comment-aware loop below to avoid modifying literals.
+	var reverseMapping map[string]string
+	if info.rule != nil && len(info.rule.ParamMapping) > 0 {
+		reverseMapping = make(map[string]string, len(info.rule.ParamMapping))
+		for newParam, oldParam := range info.rule.ParamMapping {
+			reverseMapping[oldParam] = newParam
+		}
 	}
 
 	// Process each occurrence of the deprecated call, replacing handler name
@@ -231,8 +230,10 @@ func applyHandlerConversion(script string, oldName string, info deprecatedInfo) 
 
 		// Find the matching closing paren, tracking nesting depth
 		callBody, rest := extractCallBody(remaining)
-		// Rename top-level kwargs within the call body
-		callBody = renameTopLevelKwargs(callBody, reverseMapping)
+		// Rename top-level kwargs within the call body (only when mapping exists)
+		if len(reverseMapping) > 0 {
+			callBody = renameTopLevelKwargs(callBody, reverseMapping)
+		}
 		result.WriteString(callBody)
 		remaining = rest
 	}

--- a/services/mcp-server/internal/tools/manifest_fix.go
+++ b/services/mcp-server/internal/tools/manifest_fix.go
@@ -367,7 +367,10 @@ func (s *kwargScanner) handleTopLevelIdent() {
 	}
 	ident := s.src[start:s.pos]
 
-	if s.pos < len(s.src) && s.src[s.pos] == '=' && !isPrecededByIdent(s.src, start) {
+	// Match "ident=" but not "ident==" (comparison operator)
+	if s.pos < len(s.src) && s.src[s.pos] == '=' &&
+		(s.pos+1 >= len(s.src) || s.src[s.pos+1] != '=') &&
+		!isPrecededByIdent(s.src, start) {
 		if newName, ok := s.reverseMapping[ident]; ok {
 			s.result.WriteString(newName)
 			return

--- a/services/mcp-server/internal/tools/manifest_fix_test.go
+++ b/services/mcp-server/internal/tools/manifest_fix_test.go
@@ -1,0 +1,307 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+)
+
+// testRegistryWithEvolution creates a schema.Registry with a handler that has
+// a deprecated alias via conversion rules. This mirrors the handler_evolution_test
+// pattern: test.initiate_log (deprecated) -> test.record_entry (current).
+func testRegistryWithEvolution() *schema.Registry {
+	yamlData := `
+service: test_service
+version: "2.0"
+handlers:
+  test.record_entry:
+    description: "Record an entry (v2)"
+    version: 2
+    compensation_strategy: none
+    params:
+      quantity:
+        type: Decimal
+        required: true
+      instrument_code:
+        type: string
+        required: true
+      side:
+        type: enum
+        values: [DEBIT, CREDIT]
+        required: true
+    returns:
+      entry_id:
+        type: string
+    conversions:
+      - from_version: 1
+        from_name: test.initiate_log
+        param_mapping:
+          quantity: amount
+          instrument_code: currency
+          side: direction
+        sunset: "3.0"
+  test.other_handler:
+    description: "Another handler that is not deprecated"
+    compensation_strategy: none
+    params:
+      id:
+        type: string
+        required: true
+    returns:
+      status:
+        type: string
+`
+	reg := schema.NewRegistry()
+	if err := reg.LoadFromYAML([]byte(yamlData)); err != nil {
+		panic(err)
+	}
+	return reg
+}
+
+func TestManifestFix_DeprecatedHandlerConverted(t *testing.T) {
+	reg := testRegistryWithEvolution()
+	r := tools.NewRegistry()
+	tools.RegisterManifestFixTool(r, reg)
+
+	manifest := map[string]interface{}{
+		"version": "1.0",
+		"metadata": map[string]interface{}{
+			"name":        "Test",
+			"industry":    "energy",
+			"description": "Test manifest",
+		},
+		"sagas": []interface{}{
+			map[string]interface{}{
+				"name":    "test_saga",
+				"trigger": "api:/v1/test",
+				"script": `def execute(ctx):
+    result = test.initiate_log(
+        amount="100.00",
+        currency="GBP",
+        direction="CREDIT",
+    )
+    return {"status": "done"}
+`,
+			},
+		},
+	}
+
+	manifestJSON, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	params := json.RawMessage(`{"manifest": ` + string(manifestJSON) + `}`)
+	result, err := r.Call(context.Background(), "meridian_manifest_fix", params)
+	require.NoError(t, err)
+
+	m, ok := result.(map[string]interface{})
+	require.True(t, ok)
+
+	// Should have conversions
+	conversions, ok := m["conversions"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, conversions, 1)
+
+	conv := conversions[0].(map[string]interface{})
+	assert.Equal(t, "test_saga", conv["saga"])
+	assert.Contains(t, conv["message"], "test.initiate_log")
+	assert.Contains(t, conv["message"], "test.record_entry")
+
+	// The fixed manifest should contain the converted script
+	fixedManifest, ok := m["manifest"].(map[string]interface{})
+	require.True(t, ok)
+
+	sagas, ok := fixedManifest["sagas"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, sagas, 1)
+
+	saga := sagas[0].(map[string]interface{})
+	script := saga["script"].(string)
+	assert.Contains(t, script, "test.record_entry(")
+	assert.NotContains(t, script, "test.initiate_log(")
+	assert.Contains(t, script, "quantity=")
+	assert.Contains(t, script, "instrument_code=")
+	assert.Contains(t, script, "side=")
+}
+
+func TestManifestFix_NoDeprecatedHandlers_PassesThrough(t *testing.T) {
+	reg := testRegistryWithEvolution()
+	r := tools.NewRegistry()
+	tools.RegisterManifestFixTool(r, reg)
+
+	manifest := map[string]interface{}{
+		"version": "1.0",
+		"metadata": map[string]interface{}{
+			"name":        "Test",
+			"industry":    "energy",
+			"description": "Test manifest",
+		},
+		"sagas": []interface{}{
+			map[string]interface{}{
+				"name":    "test_saga",
+				"trigger": "api:/v1/test",
+				"script": `def execute(ctx):
+    result = test.record_entry(
+        quantity="100.00",
+        instrument_code="GBP",
+        side="CREDIT",
+    )
+    return {"status": "done"}
+`,
+			},
+		},
+	}
+
+	manifestJSON, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	params := json.RawMessage(`{"manifest": ` + string(manifestJSON) + `}`)
+	result, err := r.Call(context.Background(), "meridian_manifest_fix", params)
+	require.NoError(t, err)
+
+	m, ok := result.(map[string]interface{})
+	require.True(t, ok)
+
+	conversions, ok := m["conversions"].([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, conversions)
+
+	// Manifest should be unchanged
+	fixedManifest := m["manifest"].(map[string]interface{})
+	sagas := fixedManifest["sagas"].([]interface{})
+	saga := sagas[0].(map[string]interface{})
+	assert.Contains(t, saga["script"].(string), "test.record_entry(")
+}
+
+func TestManifestFix_MultipleSagas(t *testing.T) {
+	reg := testRegistryWithEvolution()
+	r := tools.NewRegistry()
+	tools.RegisterManifestFixTool(r, reg)
+
+	manifest := map[string]interface{}{
+		"version": "1.0",
+		"metadata": map[string]interface{}{
+			"name":        "Test",
+			"industry":    "energy",
+			"description": "Test manifest",
+		},
+		"sagas": []interface{}{
+			map[string]interface{}{
+				"name":    "saga_one",
+				"trigger": "api:/v1/one",
+				"script": `def execute(ctx):
+    test.initiate_log(amount="50.00", currency="USD", direction="DEBIT")
+`,
+			},
+			map[string]interface{}{
+				"name":    "saga_two",
+				"trigger": "api:/v1/two",
+				"script": `def execute(ctx):
+    test.other_handler(id="abc")
+`,
+			},
+		},
+	}
+
+	manifestJSON, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	params := json.RawMessage(`{"manifest": ` + string(manifestJSON) + `}`)
+	result, err := r.Call(context.Background(), "meridian_manifest_fix", params)
+	require.NoError(t, err)
+
+	m := result.(map[string]interface{})
+	conversions := m["conversions"].([]interface{})
+	assert.Len(t, conversions, 1)
+
+	conv := conversions[0].(map[string]interface{})
+	assert.Equal(t, "saga_one", conv["saga"])
+}
+
+func TestManifestFix_NoSagas_ReturnsEmpty(t *testing.T) {
+	reg := testRegistryWithEvolution()
+	r := tools.NewRegistry()
+	tools.RegisterManifestFixTool(r, reg)
+
+	manifest := map[string]interface{}{
+		"version": "1.0",
+		"metadata": map[string]interface{}{
+			"name":        "Test",
+			"industry":    "energy",
+			"description": "Test manifest",
+		},
+	}
+
+	manifestJSON, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	params := json.RawMessage(`{"manifest": ` + string(manifestJSON) + `}`)
+	result, err := r.Call(context.Background(), "meridian_manifest_fix", params)
+	require.NoError(t, err)
+
+	m := result.(map[string]interface{})
+	conversions := m["conversions"].([]interface{})
+	assert.Empty(t, conversions)
+}
+
+func TestManifestFix_InvalidManifestJSON(t *testing.T) {
+	reg := testRegistryWithEvolution()
+	r := tools.NewRegistry()
+	tools.RegisterManifestFixTool(r, reg)
+
+	params := json.RawMessage(`{"manifest": "not an object"}`)
+	_, err := r.Call(context.Background(), "meridian_manifest_fix", params)
+	// JSON schema validation rejects non-object manifest
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validation failed")
+}
+
+func TestManifestFix_ParamMappingApplied(t *testing.T) {
+	reg := testRegistryWithEvolution()
+	r := tools.NewRegistry()
+	tools.RegisterManifestFixTool(r, reg)
+
+	manifest := map[string]interface{}{
+		"version": "1.0",
+		"metadata": map[string]interface{}{
+			"name":        "Test",
+			"industry":    "energy",
+			"description": "Test manifest",
+		},
+		"sagas": []interface{}{
+			map[string]interface{}{
+				"name":    "param_test",
+				"trigger": "api:/v1/test",
+				"script": `def execute(ctx):
+    test.initiate_log(amount="100.00", currency="GBP", direction="CREDIT")
+`,
+			},
+		},
+	}
+
+	manifestJSON, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	params := json.RawMessage(`{"manifest": ` + string(manifestJSON) + `}`)
+	result, err := r.Call(context.Background(), "meridian_manifest_fix", params)
+	require.NoError(t, err)
+
+	m := result.(map[string]interface{})
+	fixedManifest := m["manifest"].(map[string]interface{})
+	sagas := fixedManifest["sagas"].([]interface{})
+	saga := sagas[0].(map[string]interface{})
+	script := saga["script"].(string)
+
+	// Old param names should be replaced with new ones
+	assert.Contains(t, script, "quantity=")
+	assert.Contains(t, script, "instrument_code=")
+	assert.Contains(t, script, "side=")
+	assert.NotContains(t, script, "amount=")
+	assert.NotContains(t, script, "currency=")
+	assert.NotContains(t, script, "direction=")
+}

--- a/services/mcp-server/internal/tools/manifest_fix_test.go
+++ b/services/mcp-server/internal/tools/manifest_fix_test.go
@@ -67,7 +67,7 @@ handlers:
 func TestManifestFix_DeprecatedHandlerConverted(t *testing.T) {
 	reg := testRegistryWithEvolution()
 	r := tools.NewRegistry()
-	tools.RegisterManifestFixTool(r, reg)
+	require.NoError(t, tools.RegisterManifestFixTool(r, reg))
 
 	manifest := map[string]interface{}{
 		"version": "1.0",
@@ -132,7 +132,7 @@ func TestManifestFix_DeprecatedHandlerConverted(t *testing.T) {
 func TestManifestFix_NoDeprecatedHandlers_PassesThrough(t *testing.T) {
 	reg := testRegistryWithEvolution()
 	r := tools.NewRegistry()
-	tools.RegisterManifestFixTool(r, reg)
+	require.NoError(t, tools.RegisterManifestFixTool(r, reg))
 
 	manifest := map[string]interface{}{
 		"version": "1.0",
@@ -181,7 +181,7 @@ func TestManifestFix_NoDeprecatedHandlers_PassesThrough(t *testing.T) {
 func TestManifestFix_MultipleSagas(t *testing.T) {
 	reg := testRegistryWithEvolution()
 	r := tools.NewRegistry()
-	tools.RegisterManifestFixTool(r, reg)
+	require.NoError(t, tools.RegisterManifestFixTool(r, reg))
 
 	manifest := map[string]interface{}{
 		"version": "1.0",
@@ -226,7 +226,7 @@ func TestManifestFix_MultipleSagas(t *testing.T) {
 func TestManifestFix_NoSagas_ReturnsEmpty(t *testing.T) {
 	reg := testRegistryWithEvolution()
 	r := tools.NewRegistry()
-	tools.RegisterManifestFixTool(r, reg)
+	require.NoError(t, tools.RegisterManifestFixTool(r, reg))
 
 	manifest := map[string]interface{}{
 		"version": "1.0",
@@ -252,7 +252,7 @@ func TestManifestFix_NoSagas_ReturnsEmpty(t *testing.T) {
 func TestManifestFix_InvalidManifestJSON(t *testing.T) {
 	reg := testRegistryWithEvolution()
 	r := tools.NewRegistry()
-	tools.RegisterManifestFixTool(r, reg)
+	require.NoError(t, tools.RegisterManifestFixTool(r, reg))
 
 	params := json.RawMessage(`{"manifest": "not an object"}`)
 	_, err := r.Call(context.Background(), "meridian_manifest_fix", params)
@@ -264,7 +264,7 @@ func TestManifestFix_InvalidManifestJSON(t *testing.T) {
 func TestManifestFix_ParamRenamingScopedToCallSite(t *testing.T) {
 	reg := testRegistryWithEvolution()
 	r := tools.NewRegistry()
-	tools.RegisterManifestFixTool(r, reg)
+	require.NoError(t, tools.RegisterManifestFixTool(r, reg))
 
 	// Script has both a deprecated call AND a non-deprecated call using
 	// the same old param name "amount". Param renaming must only apply
@@ -316,7 +316,7 @@ func TestManifestFix_ParamRenamingScopedToCallSite(t *testing.T) {
 func TestManifestFix_ParensInStringLiteral(t *testing.T) {
 	reg := testRegistryWithEvolution()
 	r := tools.NewRegistry()
-	tools.RegisterManifestFixTool(r, reg)
+	require.NoError(t, tools.RegisterManifestFixTool(r, reg))
 
 	// Script has a string literal containing a closing paren.
 	// extractCallBody must not be fooled by it.
@@ -364,7 +364,7 @@ func TestManifestFix_ParensInStringLiteral(t *testing.T) {
 func TestManifestFix_SuffixParamNotRenamed(t *testing.T) {
 	reg := testRegistryWithEvolution()
 	r := tools.NewRegistry()
-	tools.RegisterManifestFixTool(r, reg)
+	require.NoError(t, tools.RegisterManifestFixTool(r, reg))
 
 	// "total_amount" should NOT be renamed even though "amount" is in the mapping.
 	manifest := map[string]interface{}{
@@ -406,7 +406,7 @@ func TestManifestFix_SuffixParamNotRenamed(t *testing.T) {
 func TestManifestFix_NestedCallParamsNotRenamed(t *testing.T) {
 	reg := testRegistryWithEvolution()
 	r := tools.NewRegistry()
-	tools.RegisterManifestFixTool(r, reg)
+	require.NoError(t, tools.RegisterManifestFixTool(r, reg))
 
 	// The deprecated call has a nested function call with a param name
 	// that matches the mapping. Only the outer kwarg should be renamed.
@@ -451,7 +451,7 @@ func TestManifestFix_NestedCallParamsNotRenamed(t *testing.T) {
 func TestManifestFix_ParamMappingApplied(t *testing.T) {
 	reg := testRegistryWithEvolution()
 	r := tools.NewRegistry()
-	tools.RegisterManifestFixTool(r, reg)
+	require.NoError(t, tools.RegisterManifestFixTool(r, reg))
 
 	manifest := map[string]interface{}{
 		"version": "1.0",

--- a/services/mcp-server/internal/tools/manifest_fix_test.go
+++ b/services/mcp-server/internal/tools/manifest_fix_test.go
@@ -261,6 +261,58 @@ func TestManifestFix_InvalidManifestJSON(t *testing.T) {
 	assert.Contains(t, err.Error(), "validation failed")
 }
 
+func TestManifestFix_ParamRenamingScopedToCallSite(t *testing.T) {
+	reg := testRegistryWithEvolution()
+	r := tools.NewRegistry()
+	tools.RegisterManifestFixTool(r, reg)
+
+	// Script has both a deprecated call AND a non-deprecated call using
+	// the same old param name "amount". Param renaming must only apply
+	// inside the deprecated call's parentheses.
+	manifest := map[string]interface{}{
+		"version": "1.0",
+		"metadata": map[string]interface{}{
+			"name":        "Test",
+			"industry":    "energy",
+			"description": "Test manifest",
+		},
+		"sagas": []interface{}{
+			map[string]interface{}{
+				"name":    "scoped_test",
+				"trigger": "api:/v1/test",
+				"script": `def execute(ctx):
+    test.initiate_log(amount="100.00", currency="GBP", direction="CREDIT")
+    test.other_handler(id="abc")
+    x = some_func(amount="200.00")
+`,
+			},
+		},
+	}
+
+	manifestJSON, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	params := json.RawMessage(`{"manifest": ` + string(manifestJSON) + `}`)
+	result, err := r.Call(context.Background(), "meridian_manifest_fix", params)
+	require.NoError(t, err)
+
+	m := result.(map[string]interface{})
+	fixedManifest := m["manifest"].(map[string]interface{})
+	sagas := fixedManifest["sagas"].([]interface{})
+	saga := sagas[0].(map[string]interface{})
+	script := saga["script"].(string)
+
+	// The deprecated call should be converted
+	assert.Contains(t, script, "test.record_entry(quantity=")
+	assert.NotContains(t, script, "test.initiate_log(")
+
+	// The non-deprecated call's "amount" param must NOT be renamed
+	assert.Contains(t, script, `some_func(amount="200.00")`)
+
+	// other_handler should be untouched
+	assert.Contains(t, script, `test.other_handler(id="abc")`)
+}
+
 func TestManifestFix_ParamMappingApplied(t *testing.T) {
 	reg := testRegistryWithEvolution()
 	r := tools.NewRegistry()

--- a/services/mcp-server/internal/tools/manifest_fix_test.go
+++ b/services/mcp-server/internal/tools/manifest_fix_test.go
@@ -313,6 +313,141 @@ func TestManifestFix_ParamRenamingScopedToCallSite(t *testing.T) {
 	assert.Contains(t, script, `test.other_handler(id="abc")`)
 }
 
+func TestManifestFix_ParensInStringLiteral(t *testing.T) {
+	reg := testRegistryWithEvolution()
+	r := tools.NewRegistry()
+	tools.RegisterManifestFixTool(r, reg)
+
+	// Script has a string literal containing a closing paren.
+	// extractCallBody must not be fooled by it.
+	manifest := map[string]interface{}{
+		"version": "1.0",
+		"metadata": map[string]interface{}{
+			"name":        "Test",
+			"industry":    "energy",
+			"description": "Test manifest",
+		},
+		"sagas": []interface{}{
+			map[string]interface{}{
+				"name":    "string_paren_test",
+				"trigger": "api:/v1/test",
+				"script": `def execute(ctx):
+    test.initiate_log(amount="100.00)", currency="GBP", direction="CREDIT")
+    return {"status": "done"}
+`,
+			},
+		},
+	}
+
+	manifestJSON, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	params := json.RawMessage(`{"manifest": ` + string(manifestJSON) + `}`)
+	result, err := r.Call(context.Background(), "meridian_manifest_fix", params)
+	require.NoError(t, err)
+
+	m := result.(map[string]interface{})
+	fixedManifest := m["manifest"].(map[string]interface{})
+	sagas := fixedManifest["sagas"].([]interface{})
+	saga := sagas[0].(map[string]interface{})
+	script := saga["script"].(string)
+
+	// Handler should be converted despite the paren in string
+	assert.Contains(t, script, "test.record_entry(")
+	assert.NotContains(t, script, "test.initiate_log(")
+	// All three params should be renamed
+	assert.Contains(t, script, "quantity=")
+	assert.Contains(t, script, "instrument_code=")
+	assert.Contains(t, script, "side=")
+}
+
+func TestManifestFix_SuffixParamNotRenamed(t *testing.T) {
+	reg := testRegistryWithEvolution()
+	r := tools.NewRegistry()
+	tools.RegisterManifestFixTool(r, reg)
+
+	// "total_amount" should NOT be renamed even though "amount" is in the mapping.
+	manifest := map[string]interface{}{
+		"version": "1.0",
+		"metadata": map[string]interface{}{
+			"name":        "Test",
+			"industry":    "energy",
+			"description": "Test manifest",
+		},
+		"sagas": []interface{}{
+			map[string]interface{}{
+				"name":    "suffix_test",
+				"trigger": "api:/v1/test",
+				"script": `def execute(ctx):
+    test.initiate_log(amount="100.00", currency="GBP", direction="CREDIT", total_amount="200.00")
+`,
+			},
+		},
+	}
+
+	manifestJSON, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	params := json.RawMessage(`{"manifest": ` + string(manifestJSON) + `}`)
+	result, err := r.Call(context.Background(), "meridian_manifest_fix", params)
+	require.NoError(t, err)
+
+	m := result.(map[string]interface{})
+	fixedManifest := m["manifest"].(map[string]interface{})
+	sagas := fixedManifest["sagas"].([]interface{})
+	saga := sagas[0].(map[string]interface{})
+	script := saga["script"].(string)
+
+	// "amount" kwarg renamed to "quantity", but "total_amount" kept as-is
+	assert.Contains(t, script, "quantity=")
+	assert.Contains(t, script, "total_amount=")
+}
+
+func TestManifestFix_NestedCallParamsNotRenamed(t *testing.T) {
+	reg := testRegistryWithEvolution()
+	r := tools.NewRegistry()
+	tools.RegisterManifestFixTool(r, reg)
+
+	// The deprecated call has a nested function call with a param name
+	// that matches the mapping. Only the outer kwarg should be renamed.
+	manifest := map[string]interface{}{
+		"version": "1.0",
+		"metadata": map[string]interface{}{
+			"name":        "Test",
+			"industry":    "energy",
+			"description": "Test manifest",
+		},
+		"sagas": []interface{}{
+			map[string]interface{}{
+				"name":    "nested_test",
+				"trigger": "api:/v1/test",
+				"script": `def execute(ctx):
+    test.initiate_log(amount=compute(currency="USD"), currency="GBP", direction="CREDIT")
+`,
+			},
+		},
+	}
+
+	manifestJSON, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	params := json.RawMessage(`{"manifest": ` + string(manifestJSON) + `}`)
+	result, err := r.Call(context.Background(), "meridian_manifest_fix", params)
+	require.NoError(t, err)
+
+	m := result.(map[string]interface{})
+	fixedManifest := m["manifest"].(map[string]interface{})
+	sagas := fixedManifest["sagas"].([]interface{})
+	saga := sagas[0].(map[string]interface{})
+	script := saga["script"].(string)
+
+	// Outer "amount" renamed to "quantity", outer "currency" renamed to "instrument_code"
+	assert.Contains(t, script, "quantity=compute(")
+	assert.Contains(t, script, "instrument_code=\"GBP\"")
+	// Inner "currency" inside compute() must NOT be renamed
+	assert.Contains(t, script, `compute(currency="USD")`)
+}
+
 func TestManifestFix_ParamMappingApplied(t *testing.T) {
 	reg := testRegistryWithEvolution()
 	r := tools.NewRegistry()

--- a/services/mcp-server/internal/tools/manifest_fix_test.go
+++ b/services/mcp-server/internal/tools/manifest_fix_test.go
@@ -492,3 +492,52 @@ func TestManifestFix_ParamMappingApplied(t *testing.T) {
 	assert.NotContains(t, script, "currency=")
 	assert.NotContains(t, script, "direction=")
 }
+
+func TestManifestFix_StringAndCommentNotModified(t *testing.T) {
+	reg := testRegistryWithEvolution()
+	r := tools.NewRegistry()
+	require.NoError(t, tools.RegisterManifestFixTool(r, reg))
+
+	// Handler calls inside strings and comments must NOT be modified.
+	// Only the actual call site on the last line should be converted.
+	manifest := map[string]interface{}{
+		"version": "1.0",
+		"metadata": map[string]interface{}{
+			"name":        "Test",
+			"industry":    "energy",
+			"description": "Test manifest",
+		},
+		"sagas": []interface{}{
+			map[string]interface{}{
+				"name":    "string_comment_test",
+				"trigger": "api:/v1/test",
+				"script": `def execute(ctx):
+    log("Calling test.initiate_log()")
+    # test.initiate_log(amount="old")
+    test.initiate_log(amount="100.00", currency="GBP", direction="CREDIT")
+`,
+			},
+		},
+	}
+
+	manifestJSON, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	params := json.RawMessage(`{"manifest": ` + string(manifestJSON) + `}`)
+	result, err := r.Call(context.Background(), "meridian_manifest_fix", params)
+	require.NoError(t, err)
+
+	m := result.(map[string]interface{})
+	fixedManifest := m["manifest"].(map[string]interface{})
+	sagas := fixedManifest["sagas"].([]interface{})
+	saga := sagas[0].(map[string]interface{})
+	script := saga["script"].(string)
+
+	// String literal must be preserved exactly
+	assert.Contains(t, script, `log("Calling test.initiate_log()")`)
+	// Comment must be preserved exactly
+	assert.Contains(t, script, `# test.initiate_log(amount="old")`)
+	// Actual call site must be converted
+	assert.Contains(t, script, "test.record_entry(")
+	assert.NotContains(t, script, "\n    test.initiate_log(")
+}


### PR DESCRIPTION
## Summary

- Adds `meridian_manifest_fix` MCP tool that auto-converts deprecated handler calls in manifest saga scripts
- Uses schema registry conversion rules to rename handlers and remap parameters
- Returns the fixed manifest plus a list of conversions applied, without applying the manifest
- Wired into the MCP server as a local tool (no gRPC dependency)

## Task Master

039-meridian-vm.9 - Add meridian_manifest_fix MCP Tool

## Changes

- `services/mcp-server/internal/tools/manifest_fix.go` - Tool implementation
- `services/mcp-server/internal/tools/manifest_fix_test.go` - 6 test cases covering deprecated handler conversion, param mapping, passthrough, edge cases
- `services/mcp-server/cmd/wire.go` - Wire tool into MCP server using DefaultRegistry

## Test plan

- [x] Deprecated handler calls are auto-converted (handler name + param names)
- [x] Conversion warnings list all changes made
- [x] Non-deprecated handlers pass through unchanged
- [x] Manifests without sagas return empty conversions
- [x] Invalid manifest JSON returns appropriate error
- [x] Multiple sagas processed independently