### PR TITLE
feat: Add API gateway saga binding cache

### DIFF
--- a/services/api-gateway/cache/manifest_binding_source.go
+++ b/services/api-gateway/cache/manifest_binding_source.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -40,7 +41,10 @@ type sagaJSON struct {
 // GetBindingsForTenant queries the latest applied manifest for the given tenant
 // and returns a map of api_path -> saga_name for all sagas with "api:" triggers.
 func (s *ManifestBindingSource) GetBindingsForTenant(ctx context.Context, tenantID string) (map[string]string, error) {
-	tid := tenant.TenantID(tenantID)
+	tid, err := tenant.NewTenantID(tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tenant ID %q: %w", tenantID, err)
+	}
 	schemaName := pq.QuoteIdentifier(tid.SchemaName())
 
 	query := fmt.Sprintf(
@@ -62,13 +66,26 @@ func (s *ManifestBindingSource) GetBindingsForTenant(ctx context.Context, tenant
 		return nil, fmt.Errorf("unmarshal manifest JSON: %w", err)
 	}
 
+	return extractAPIBindings(manifest.Sagas, tenantID), nil
+}
+
+// extractAPIBindings extracts api_path -> saga_name mappings from saga definitions.
+// Logs a warning if multiple sagas declare the same API path.
+func extractAPIBindings(sagas []sagaJSON, tenantID string) map[string]string {
 	bindings := make(map[string]string)
-	for _, saga := range manifest.Sagas {
+	for _, saga := range sagas {
 		if strings.HasPrefix(saga.Trigger, "api:") {
 			path := strings.TrimPrefix(saga.Trigger, "api:")
+			if existing, ok := bindings[path]; ok {
+				slog.Warn("duplicate api path in manifest, later saga overwrites earlier",
+					"tenant_id", tenantID,
+					"path", path,
+					"overwritten_saga", existing,
+					"overwriting_saga", saga.Name,
+				)
+			}
 			bindings[path] = saga.Name
 		}
 	}
-
-	return bindings, nil
+	return bindings
 }

--- a/services/api-gateway/cache/manifest_binding_source.go
+++ b/services/api-gateway/cache/manifest_binding_source.go
@@ -1,0 +1,70 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// ManifestBindingSource implements SagaBindingSource by querying the latest
+// applied manifest from the manifest_versions table in the tenant's schema.
+// It extracts saga definitions with "api:" trigger prefix to build the
+// (api_path -> saga_name) binding map.
+type ManifestBindingSource struct {
+	pool *pgxpool.Pool
+}
+
+// NewManifestBindingSource creates a new ManifestBindingSource.
+func NewManifestBindingSource(pool *pgxpool.Pool) *ManifestBindingSource {
+	return &ManifestBindingSource{pool: pool}
+}
+
+// manifestJSON is the minimal structure needed to extract saga triggers from the manifest.
+type manifestJSON struct {
+	Sagas []sagaJSON `json:"sagas"`
+}
+
+type sagaJSON struct {
+	Name    string `json:"name"`
+	Trigger string `json:"trigger"`
+}
+
+// GetBindingsForTenant queries the latest applied manifest for the given tenant
+// and returns a map of api_path -> saga_name for all sagas with "api:" triggers.
+func (s *ManifestBindingSource) GetBindingsForTenant(ctx context.Context, tenantID string) (map[string]string, error) {
+	tid := tenant.TenantID(tenantID)
+	schemaName := pq.QuoteIdentifier(tid.SchemaName())
+
+	query := fmt.Sprintf(
+		`SELECT manifest_json FROM %s.manifest_versions
+		 WHERE apply_status = 'APPLIED'
+		 ORDER BY applied_at DESC
+		 LIMIT 1`, schemaName)
+
+	var manifestRaw []byte
+	if err := s.pool.QueryRow(ctx, query).Scan(&manifestRaw); err != nil {
+		// No manifest applied yet - return empty bindings
+		return map[string]string{}, nil //nolint:nilerr // pgx.ErrNoRows is expected when no manifest exists
+	}
+
+	var manifest manifestJSON
+	if err := json.Unmarshal(manifestRaw, &manifest); err != nil {
+		return nil, fmt.Errorf("unmarshal manifest JSON: %w", err)
+	}
+
+	bindings := make(map[string]string)
+	for _, saga := range manifest.Sagas {
+		if strings.HasPrefix(saga.Trigger, "api:") {
+			path := strings.TrimPrefix(saga.Trigger, "api:")
+			bindings[path] = saga.Name
+		}
+	}
+
+	return bindings, nil
+}

--- a/services/api-gateway/cache/manifest_binding_source.go
+++ b/services/api-gateway/cache/manifest_binding_source.go
@@ -3,9 +3,11 @@ package cache
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/lib/pq"
 
@@ -49,8 +51,10 @@ func (s *ManifestBindingSource) GetBindingsForTenant(ctx context.Context, tenant
 
 	var manifestRaw []byte
 	if err := s.pool.QueryRow(ctx, query).Scan(&manifestRaw); err != nil {
-		// No manifest applied yet - return empty bindings
-		return map[string]string{}, nil //nolint:nilerr // pgx.ErrNoRows is expected when no manifest exists
+		if errors.Is(err, pgx.ErrNoRows) {
+			return map[string]string{}, nil
+		}
+		return nil, fmt.Errorf("query manifest bindings: %w", err)
 	}
 
 	var manifest manifestJSON

--- a/services/api-gateway/cache/manifest_binding_source_test.go
+++ b/services/api-gateway/cache/manifest_binding_source_test.go
@@ -69,12 +69,7 @@ func TestManifestJSON_ExtractAPIBindings(t *testing.T) {
 			err := json.Unmarshal([]byte(tt.json), &manifest)
 			require.NoError(t, err)
 
-			bindings := make(map[string]string)
-			for _, saga := range manifest.Sagas {
-				if len(saga.Trigger) > 4 && saga.Trigger[:4] == "api:" {
-					bindings[saga.Trigger[4:]] = saga.Name
-				}
-			}
+			bindings := extractAPIBindings(manifest.Sagas, "test-tenant")
 
 			assert.Equal(t, tt.expected, bindings)
 		})

--- a/services/api-gateway/cache/manifest_binding_source_test.go
+++ b/services/api-gateway/cache/manifest_binding_source_test.go
@@ -1,0 +1,82 @@
+package cache
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManifestJSON_ExtractAPIBindings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		json     string
+		expected map[string]string
+	}{
+		{
+			name: "multiple api triggers",
+			json: `{
+				"sagas": [
+					{"name": "process_payment", "trigger": "api:/v1/payments"},
+					{"name": "settle_trade", "trigger": "api:/v1/settlements"}
+				]
+			}`,
+			expected: map[string]string{
+				"/v1/payments":    "process_payment",
+				"/v1/settlements": "settle_trade",
+			},
+		},
+		{
+			name: "mixed trigger types",
+			json: `{
+				"sagas": [
+					{"name": "process_payment", "trigger": "api:/v1/payments"},
+					{"name": "daily_recon", "trigger": "scheduled:daily_reconciliation"},
+					{"name": "stripe_webhook", "trigger": "webhook:stripe_payment"},
+					{"name": "settle_trade", "trigger": "api:/v1/settlements"},
+					{"name": "on_capture", "trigger": "event:position-keeping.transaction-captured.v1"}
+				]
+			}`,
+			expected: map[string]string{
+				"/v1/payments":    "process_payment",
+				"/v1/settlements": "settle_trade",
+			},
+		},
+		{
+			name:     "no sagas",
+			json:     `{}`,
+			expected: map[string]string{},
+		},
+		{
+			name: "no api triggers",
+			json: `{
+				"sagas": [
+					{"name": "daily_recon", "trigger": "scheduled:daily_reconciliation"}
+				]
+			}`,
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var manifest manifestJSON
+			err := json.Unmarshal([]byte(tt.json), &manifest)
+			require.NoError(t, err)
+
+			bindings := make(map[string]string)
+			for _, saga := range manifest.Sagas {
+				if len(saga.Trigger) > 4 && saga.Trigger[:4] == "api:" {
+					bindings[saga.Trigger[4:]] = saga.Name
+				}
+			}
+
+			assert.Equal(t, tt.expected, bindings)
+		})
+	}
+}

--- a/services/api-gateway/cache/saga_binding_cache.go
+++ b/services/api-gateway/cache/saga_binding_cache.go
@@ -2,7 +2,9 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -67,7 +69,11 @@ func WithSagaBindingLogger(logger *slog.Logger) SagaBindingOption {
 }
 
 // NewSagaBindingCache creates a new SagaBindingCache.
+// Panics if source is nil.
 func NewSagaBindingCache(source SagaBindingSource, opts ...SagaBindingOption) *SagaBindingCache {
+	if source == nil {
+		panic("SagaBindingSource cannot be nil")
+	}
 	c := &SagaBindingCache{
 		entries: make(map[string]*tenantBindings),
 		source:  source,
@@ -96,23 +102,24 @@ func (c *SagaBindingCache) tenantGeneration(tenantID string) *atomic.Uint64 {
 
 // Get returns the saga name bound to the given API path for the specified tenant.
 // On cache miss or TTL expiry, it refreshes from the source.
-func (c *SagaBindingCache) Get(ctx context.Context, tenantID, path string) (sagaName string, found bool) {
+// Returns an error if the refresh fails and no cached data is available.
+func (c *SagaBindingCache) Get(ctx context.Context, tenantID, path string) (sagaName string, found bool, err error) {
 	// Fast path: check cache under read lock
 	c.mu.RLock()
 	if entry, ok := c.entries[tenantID]; ok && time.Now().Before(entry.expiresAt) {
 		sagaName, found = entry.pathToSaga[path]
 		c.mu.RUnlock()
-		return sagaName, found
+		return sagaName, found, nil
 	}
 	c.mu.RUnlock()
 
 	// Cache miss or expired: refresh from source (deduplicated via singleflight)
-	if _, err := c.doRefresh(ctx, tenantID); err != nil {
+	if _, refreshErr := c.doRefresh(ctx, tenantID); refreshErr != nil {
 		c.logger.Warn("saga binding cache refresh failed",
 			"tenant_id", tenantID,
-			"error", err,
+			"error", refreshErr,
 		)
-		return "", false
+		return "", false, fmt.Errorf("refresh saga bindings for tenant %s: %w", tenantID, refreshErr)
 	}
 
 	// Re-check cache after refresh
@@ -121,10 +128,10 @@ func (c *SagaBindingCache) Get(ctx context.Context, tenantID, path string) (saga
 
 	if entry, ok := c.entries[tenantID]; ok {
 		sagaName, found = entry.pathToSaga[path]
-		return sagaName, found
+		return sagaName, found, nil
 	}
 
-	return "", false
+	return "", false, nil
 }
 
 // Invalidate clears cached bindings for the specified tenant.
@@ -157,8 +164,13 @@ func (c *SagaBindingCache) Refresh(ctx context.Context, tenantID string) error {
 // doRefresh loads bindings from the source and populates the cache.
 // Uses singleflight to deduplicate concurrent refreshes for the same tenant.
 // Uses a generation counter to prevent stale writes after invalidation.
+// The singleflight key includes the generation so that post-invalidation callers
+// start a new flight instead of joining an obsolete one.
 func (c *SagaBindingCache) doRefresh(ctx context.Context, tenantID string) (map[string]string, error) {
-	result, err, _ := c.sfGroup.Do(tenantID, func() (interface{}, error) {
+	gen := c.tenantGeneration(tenantID).Load()
+	sfKey := tenantID + ":" + strconv.FormatUint(gen, 10)
+
+	result, err, _ := c.sfGroup.Do(sfKey, func() (interface{}, error) {
 		// Re-check cache inside singleflight to avoid redundant loads
 		c.mu.RLock()
 		if entry, ok := c.entries[tenantID]; ok && time.Now().Before(entry.expiresAt) {
@@ -166,9 +178,6 @@ func (c *SagaBindingCache) doRefresh(ctx context.Context, tenantID string) (map[
 			return entry.pathToSaga, nil
 		}
 		c.mu.RUnlock()
-
-		// Capture generation before the load
-		gen := c.tenantGeneration(tenantID).Load()
 
 		bindings, err := c.source.GetBindingsForTenant(ctx, tenantID)
 		if err != nil {

--- a/services/api-gateway/cache/saga_binding_cache.go
+++ b/services/api-gateway/cache/saga_binding_cache.go
@@ -2,7 +2,9 @@ package cache
 
 import (
 	"context"
+	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/sync/singleflight"
@@ -27,20 +29,22 @@ type SagaBindingSource interface {
 // and automatic refresh from a SagaBindingSource on cache miss.
 //
 // Thread-safety: All methods are safe for concurrent use.
+// Invalidation safety: A per-tenant generation counter prevents in-flight refreshes
+// from overwriting entries that were invalidated after the refresh started.
 type SagaBindingCache struct {
 	mu      sync.RWMutex
 	entries map[string]*tenantBindings // tenantID -> bindings
+	gens    map[string]*atomic.Uint64  // tenantID -> invalidation generation
 	source  SagaBindingSource
 	sfGroup singleflight.Group
 	ttl     time.Duration
+	logger  *slog.Logger
 }
 
 // tenantBindings holds cached saga bindings for a single tenant.
 type tenantBindings struct {
-	// pathToSaga maps api_path -> saga_name.
 	pathToSaga map[string]string
-	// expiresAt is when this cache entry becomes stale.
-	expiresAt time.Time
+	expiresAt  time.Time
 }
 
 // SagaBindingOption configures a SagaBindingCache.
@@ -55,17 +59,37 @@ func WithSagaBindingTTL(ttl time.Duration) SagaBindingOption {
 	}
 }
 
+// WithSagaBindingLogger sets the logger for the cache.
+func WithSagaBindingLogger(logger *slog.Logger) SagaBindingOption {
+	return func(c *SagaBindingCache) {
+		c.logger = logger
+	}
+}
+
 // NewSagaBindingCache creates a new SagaBindingCache.
 func NewSagaBindingCache(source SagaBindingSource, opts ...SagaBindingOption) *SagaBindingCache {
 	c := &SagaBindingCache{
 		entries: make(map[string]*tenantBindings),
+		gens:    make(map[string]*atomic.Uint64),
 		source:  source,
 		ttl:     DefaultSagaBindingTTL,
+		logger:  slog.Default(),
 	}
 	for _, opt := range opts {
 		opt(c)
 	}
 	return c
+}
+
+// tenantGeneration returns the generation counter for a tenant,
+// creating one if it doesn't exist. Must be called under c.mu (read or write).
+func (c *SagaBindingCache) tenantGeneration(tenantID string) *atomic.Uint64 {
+	g, ok := c.gens[tenantID]
+	if !ok {
+		g = &atomic.Uint64{}
+		c.gens[tenantID] = g
+	}
+	return g
 }
 
 // Get returns the saga name bound to the given API path for the specified tenant.
@@ -81,7 +105,13 @@ func (c *SagaBindingCache) Get(ctx context.Context, tenantID, path string) (saga
 	c.mu.RUnlock()
 
 	// Cache miss or expired: refresh from source (deduplicated via singleflight)
-	_, _ = c.doRefresh(ctx, tenantID)
+	if _, err := c.doRefresh(ctx, tenantID); err != nil {
+		c.logger.Warn("saga binding cache refresh failed",
+			"tenant_id", tenantID,
+			"error", err,
+		)
+		return "", false
+	}
 
 	// Re-check cache after refresh
 	c.mu.RLock()
@@ -97,8 +127,12 @@ func (c *SagaBindingCache) Get(ctx context.Context, tenantID, path string) (saga
 
 // Invalidate clears cached bindings for the specified tenant.
 // The next Get call for this tenant will trigger a refresh from the source.
+// Uses a generation counter to prevent in-flight refreshes from overwriting
+// the invalidation with stale data.
 func (c *SagaBindingCache) Invalidate(_ context.Context, tenantID string) error {
 	c.mu.Lock()
+	// Bump generation so any in-flight refresh for this tenant is fenced out
+	c.tenantGeneration(tenantID).Add(1)
 	delete(c.entries, tenantID)
 	c.mu.Unlock()
 	return nil
@@ -112,17 +146,32 @@ func (c *SagaBindingCache) Refresh(ctx context.Context, tenantID string) error {
 
 // doRefresh loads bindings from the source and populates the cache.
 // Uses singleflight to deduplicate concurrent refreshes for the same tenant.
+// Uses a generation counter to prevent stale writes after invalidation.
 func (c *SagaBindingCache) doRefresh(ctx context.Context, tenantID string) (map[string]string, error) {
 	result, err, _ := c.sfGroup.Do(tenantID, func() (interface{}, error) {
+		// Re-check cache inside singleflight to avoid redundant loads
+		c.mu.RLock()
+		if entry, ok := c.entries[tenantID]; ok && time.Now().Before(entry.expiresAt) {
+			c.mu.RUnlock()
+			return entry.pathToSaga, nil
+		}
+		// Capture generation before the load (under lock to match Invalidate)
+		gen := c.tenantGeneration(tenantID).Load()
+		c.mu.RUnlock()
+
 		bindings, err := c.source.GetBindingsForTenant(ctx, tenantID)
 		if err != nil {
 			return nil, err
 		}
 
+		// Only write if generation hasn't changed (no invalidation happened during load)
 		c.mu.Lock()
-		c.entries[tenantID] = &tenantBindings{
-			pathToSaga: bindings,
-			expiresAt:  time.Now().Add(c.ttl),
+		currentGen := c.tenantGeneration(tenantID).Load()
+		if gen == currentGen {
+			c.entries[tenantID] = &tenantBindings{
+				pathToSaga: bindings,
+				expiresAt:  time.Now().Add(c.ttl),
+			}
 		}
 		c.mu.Unlock()
 

--- a/services/api-gateway/cache/saga_binding_cache.go
+++ b/services/api-gateway/cache/saga_binding_cache.go
@@ -1,0 +1,138 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// Default configuration for the saga binding cache.
+const (
+	DefaultSagaBindingTTL = 5 * time.Minute
+)
+
+// SagaBindingSource provides the source of truth for saga bindings.
+// Implementations query the database or manifest store to resolve
+// which saga handles each API path for a given tenant.
+type SagaBindingSource interface {
+	// GetBindingsForTenant returns a map of api_path -> saga_name
+	// for all sagas with "api:" triggers configured for the given tenant.
+	GetBindingsForTenant(ctx context.Context, tenantID string) (map[string]string, error)
+}
+
+// SagaBindingCache provides an in-memory cache mapping (tenant_id, api_path) to saga_name.
+// It supports TTL-based expiry, explicit invalidation (e.g., on manifest apply),
+// and automatic refresh from a SagaBindingSource on cache miss.
+//
+// Thread-safety: All methods are safe for concurrent use.
+type SagaBindingCache struct {
+	mu      sync.RWMutex
+	entries map[string]*tenantBindings // tenantID -> bindings
+	source  SagaBindingSource
+	sfGroup singleflight.Group
+	ttl     time.Duration
+}
+
+// tenantBindings holds cached saga bindings for a single tenant.
+type tenantBindings struct {
+	// pathToSaga maps api_path -> saga_name.
+	pathToSaga map[string]string
+	// expiresAt is when this cache entry becomes stale.
+	expiresAt time.Time
+}
+
+// SagaBindingOption configures a SagaBindingCache.
+type SagaBindingOption func(*SagaBindingCache)
+
+// WithSagaBindingTTL sets the TTL for cached saga bindings.
+func WithSagaBindingTTL(ttl time.Duration) SagaBindingOption {
+	return func(c *SagaBindingCache) {
+		if ttl > 0 {
+			c.ttl = ttl
+		}
+	}
+}
+
+// NewSagaBindingCache creates a new SagaBindingCache.
+func NewSagaBindingCache(source SagaBindingSource, opts ...SagaBindingOption) *SagaBindingCache {
+	c := &SagaBindingCache{
+		entries: make(map[string]*tenantBindings),
+		source:  source,
+		ttl:     DefaultSagaBindingTTL,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Get returns the saga name bound to the given API path for the specified tenant.
+// On cache miss or TTL expiry, it refreshes from the source.
+func (c *SagaBindingCache) Get(ctx context.Context, tenantID, path string) (sagaName string, found bool) {
+	// Fast path: check cache under read lock
+	c.mu.RLock()
+	if entry, ok := c.entries[tenantID]; ok && time.Now().Before(entry.expiresAt) {
+		sagaName, found = entry.pathToSaga[path]
+		c.mu.RUnlock()
+		return sagaName, found
+	}
+	c.mu.RUnlock()
+
+	// Cache miss or expired: refresh from source (deduplicated via singleflight)
+	_, _ = c.doRefresh(ctx, tenantID)
+
+	// Re-check cache after refresh
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if entry, ok := c.entries[tenantID]; ok {
+		sagaName, found = entry.pathToSaga[path]
+		return sagaName, found
+	}
+
+	return "", false
+}
+
+// Invalidate clears cached bindings for the specified tenant.
+// The next Get call for this tenant will trigger a refresh from the source.
+func (c *SagaBindingCache) Invalidate(_ context.Context, tenantID string) error {
+	c.mu.Lock()
+	delete(c.entries, tenantID)
+	c.mu.Unlock()
+	return nil
+}
+
+// Refresh forces a reload of bindings for the specified tenant from the source.
+func (c *SagaBindingCache) Refresh(ctx context.Context, tenantID string) error {
+	_, err := c.doRefresh(ctx, tenantID)
+	return err
+}
+
+// doRefresh loads bindings from the source and populates the cache.
+// Uses singleflight to deduplicate concurrent refreshes for the same tenant.
+func (c *SagaBindingCache) doRefresh(ctx context.Context, tenantID string) (map[string]string, error) {
+	result, err, _ := c.sfGroup.Do(tenantID, func() (interface{}, error) {
+		bindings, err := c.source.GetBindingsForTenant(ctx, tenantID)
+		if err != nil {
+			return nil, err
+		}
+
+		c.mu.Lock()
+		c.entries[tenantID] = &tenantBindings{
+			pathToSaga: bindings,
+			expiresAt:  time.Now().Add(c.ttl),
+		}
+		c.mu.Unlock()
+
+		return bindings, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	bindings, _ := result.(map[string]string)
+	return bindings, nil
+}

--- a/services/api-gateway/cache/saga_binding_cache.go
+++ b/services/api-gateway/cache/saga_binding_cache.go
@@ -34,7 +34,7 @@ type SagaBindingSource interface {
 type SagaBindingCache struct {
 	mu      sync.RWMutex
 	entries map[string]*tenantBindings // tenantID -> bindings
-	gens    map[string]*atomic.Uint64  // tenantID -> invalidation generation
+	gens    sync.Map                   // tenantID -> *atomic.Uint64 (invalidation generation)
 	source  SagaBindingSource
 	sfGroup singleflight.Group
 	ttl     time.Duration
@@ -70,7 +70,6 @@ func WithSagaBindingLogger(logger *slog.Logger) SagaBindingOption {
 func NewSagaBindingCache(source SagaBindingSource, opts ...SagaBindingOption) *SagaBindingCache {
 	c := &SagaBindingCache{
 		entries: make(map[string]*tenantBindings),
-		gens:    make(map[string]*atomic.Uint64),
 		source:  source,
 		ttl:     DefaultSagaBindingTTL,
 		logger:  slog.Default(),
@@ -82,13 +81,16 @@ func NewSagaBindingCache(source SagaBindingSource, opts ...SagaBindingOption) *S
 }
 
 // tenantGeneration returns the generation counter for a tenant,
-// creating one if it doesn't exist. Must be called under c.mu (read or write).
+// creating one atomically if it doesn't exist. Safe for concurrent use
+// without external locking (uses sync.Map internally).
 func (c *SagaBindingCache) tenantGeneration(tenantID string) *atomic.Uint64 {
-	g, ok := c.gens[tenantID]
-	if !ok {
-		g = &atomic.Uint64{}
-		c.gens[tenantID] = g
+	if v, ok := c.gens.Load(tenantID); ok {
+		if g, ok := v.(*atomic.Uint64); ok {
+			return g
+		}
 	}
+	actual, _ := c.gens.LoadOrStore(tenantID, &atomic.Uint64{})
+	g, _ := actual.(*atomic.Uint64)
 	return g
 }
 
@@ -155,9 +157,10 @@ func (c *SagaBindingCache) doRefresh(ctx context.Context, tenantID string) (map[
 			c.mu.RUnlock()
 			return entry.pathToSaga, nil
 		}
-		// Capture generation before the load (under lock to match Invalidate)
-		gen := c.tenantGeneration(tenantID).Load()
 		c.mu.RUnlock()
+
+		// Capture generation before the load
+		gen := c.tenantGeneration(tenantID).Load()
 
 		bindings, err := c.source.GetBindingsForTenant(ctx, tenantID)
 		if err != nil {

--- a/services/api-gateway/cache/saga_binding_cache.go
+++ b/services/api-gateway/cache/saga_binding_cache.go
@@ -141,7 +141,13 @@ func (c *SagaBindingCache) Invalidate(_ context.Context, tenantID string) error 
 }
 
 // Refresh forces a reload of bindings for the specified tenant from the source.
+// It invalidates the cache entry first to ensure a fresh load regardless of TTL.
 func (c *SagaBindingCache) Refresh(ctx context.Context, tenantID string) error {
+	// Clear the entry so doRefresh skips the cache re-check
+	c.mu.Lock()
+	delete(c.entries, tenantID)
+	c.mu.Unlock()
+
 	_, err := c.doRefresh(ctx, tenantID)
 	return err
 }

--- a/services/api-gateway/cache/saga_binding_cache.go
+++ b/services/api-gateway/cache/saga_binding_cache.go
@@ -142,9 +142,11 @@ func (c *SagaBindingCache) Invalidate(_ context.Context, tenantID string) error 
 
 // Refresh forces a reload of bindings for the specified tenant from the source.
 // It invalidates the cache entry first to ensure a fresh load regardless of TTL.
+// Bumps the generation counter to fence out any concurrent in-flight refreshes.
 func (c *SagaBindingCache) Refresh(ctx context.Context, tenantID string) error {
-	// Clear the entry so doRefresh skips the cache re-check
+	// Bump generation and clear entry so doRefresh fetches fresh data
 	c.mu.Lock()
+	c.tenantGeneration(tenantID).Add(1)
 	delete(c.entries, tenantID)
 	c.mu.Unlock()
 

--- a/services/api-gateway/cache/saga_binding_cache_test.go
+++ b/services/api-gateway/cache/saga_binding_cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -29,13 +30,15 @@ func TestSagaBindingCache_Get_CacheHit(t *testing.T) {
 	ctx := tenant.WithTenant(context.Background(), "tenant-1")
 
 	// First call triggers source refresh
-	sagaName, found := cache.Get(ctx, "tenant-1", "/v1/payments")
+	sagaName, found, err := cache.Get(ctx, "tenant-1", "/v1/payments")
+	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, "process_payment", sagaName)
 	assert.Equal(t, 1, source.refreshCount("tenant-1"))
 
 	// Second call should use cache (no additional source call)
-	sagaName, found = cache.Get(ctx, "tenant-1", "/v1/payments")
+	sagaName, found, err = cache.Get(ctx, "tenant-1", "/v1/payments")
+	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, "process_payment", sagaName)
 	assert.Equal(t, 1, source.refreshCount("tenant-1"))
@@ -56,7 +59,8 @@ func TestSagaBindingCache_Get_CacheMiss_NoBinding(t *testing.T) {
 
 	ctx := tenant.WithTenant(context.Background(), "tenant-1")
 
-	sagaName, found := cache.Get(ctx, "tenant-1", "/v1/unknown")
+	sagaName, found, err := cache.Get(ctx, "tenant-1", "/v1/unknown")
+	require.NoError(t, err)
 	assert.False(t, found)
 	assert.Empty(t, sagaName)
 }
@@ -77,13 +81,14 @@ func TestSagaBindingCache_Invalidate_ClearsTenantBindings(t *testing.T) {
 	ctx := tenant.WithTenant(context.Background(), "tenant-1")
 
 	// Populate cache
-	sagaName, found := cache.Get(ctx, "tenant-1", "/v1/payments")
+	sagaName, found, err := cache.Get(ctx, "tenant-1", "/v1/payments")
+	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, "process_payment", sagaName)
 	assert.Equal(t, 1, source.refreshCount("tenant-1"))
 
 	// Invalidate tenant
-	err := cache.Invalidate(ctx, "tenant-1")
+	err = cache.Invalidate(ctx, "tenant-1")
 	require.NoError(t, err)
 
 	// Update source to return different binding
@@ -92,7 +97,8 @@ func TestSagaBindingCache_Invalidate_ClearsTenantBindings(t *testing.T) {
 	source.mu.Unlock()
 
 	// Next Get should trigger re-fetch from source
-	sagaName, found = cache.Get(ctx, "tenant-1", "/v1/payments")
+	sagaName, found, err = cache.Get(ctx, "tenant-1", "/v1/payments")
+	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, "process_payment_v2", sagaName)
 	assert.Equal(t, 2, source.refreshCount("tenant-1"))
@@ -117,11 +123,13 @@ func TestSagaBindingCache_Refresh_PopulatesCache(t *testing.T) {
 	err := cache.Refresh(ctx, "tenant-1")
 	require.NoError(t, err)
 
-	sagaName, found := cache.Get(ctx, "tenant-1", "/v1/payments")
+	sagaName, found, err := cache.Get(ctx, "tenant-1", "/v1/payments")
+	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, "process_payment", sagaName)
 
-	sagaName, found = cache.Get(ctx, "tenant-1", "/v1/settlements")
+	sagaName, found, err = cache.Get(ctx, "tenant-1", "/v1/settlements")
+	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, "settle_trade", sagaName)
 
@@ -146,20 +154,23 @@ func TestSagaBindingCache_TTLExpiry_TriggersRefresh(t *testing.T) {
 	ctx := tenant.WithTenant(context.Background(), "tenant-1")
 
 	// First call
-	sagaName, found := cache.Get(ctx, "tenant-1", "/v1/payments")
+	sagaName, found, err := cache.Get(ctx, "tenant-1", "/v1/payments")
+	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, "process_payment", sagaName)
 	assert.Equal(t, 1, source.refreshCount("tenant-1"))
 
 	// Wait for TTL to expire, then trigger a re-fetch
-	err := await.New().
+	var getErr error
+	err = await.New().
 		AtMost(1 * time.Second).
 		PollInterval(1 * time.Millisecond).
 		Until(func() bool {
-			sagaName, found = cache.Get(ctx, "tenant-1", "/v1/payments")
+			sagaName, found, getErr = cache.Get(ctx, "tenant-1", "/v1/payments")
 			return source.refreshCount("tenant-1") >= 2
 		})
 	require.NoError(t, err)
+	require.NoError(t, getErr)
 	require.True(t, found)
 	assert.Equal(t, "process_payment", sagaName)
 }
@@ -184,7 +195,8 @@ func TestSagaBindingCache_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			sagaName, found := cache.Get(ctx, "tenant-1", "/v1/payments")
+			sagaName, found, err := cache.Get(ctx, "tenant-1", "/v1/payments")
+			assert.NoError(t, err)
 			assert.True(t, found)
 			assert.Equal(t, "process_payment", sagaName)
 		}()
@@ -214,11 +226,13 @@ func TestSagaBindingCache_MultipleTenants(t *testing.T) {
 	ctx1 := tenant.WithTenant(context.Background(), "tenant-1")
 	ctx2 := tenant.WithTenant(context.Background(), "tenant-2")
 
-	sagaName, found := cache.Get(ctx1, "tenant-1", "/v1/payments")
+	sagaName, found, err := cache.Get(ctx1, "tenant-1", "/v1/payments")
+	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, "process_payment_v1", sagaName)
 
-	sagaName, found = cache.Get(ctx2, "tenant-2", "/v1/payments")
+	sagaName, found, err = cache.Get(ctx2, "tenant-2", "/v1/payments")
+	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, "process_payment_v2", sagaName)
 }
@@ -243,22 +257,26 @@ func TestSagaBindingCache_Invalidate_OnlyAffectsSpecifiedTenant(t *testing.T) {
 	ctx2 := tenant.WithTenant(context.Background(), "tenant-2")
 
 	// Populate both tenants
-	cache.Get(ctx1, "tenant-1", "/v1/payments")
-	cache.Get(ctx2, "tenant-2", "/v1/payments")
+	_, _, err := cache.Get(ctx1, "tenant-1", "/v1/payments")
+	require.NoError(t, err)
+	_, _, err = cache.Get(ctx2, "tenant-2", "/v1/payments")
+	require.NoError(t, err)
 
 	assert.Equal(t, 1, source.refreshCount("tenant-1"))
 	assert.Equal(t, 1, source.refreshCount("tenant-2"))
 
 	// Invalidate tenant-1 only
-	err := cache.Invalidate(ctx1, "tenant-1")
+	err = cache.Invalidate(ctx1, "tenant-1")
 	require.NoError(t, err)
 
 	// Access tenant-2 should still use cache
-	cache.Get(ctx2, "tenant-2", "/v1/payments")
+	_, _, err = cache.Get(ctx2, "tenant-2", "/v1/payments")
+	require.NoError(t, err)
 	assert.Equal(t, 1, source.refreshCount("tenant-2"))
 
 	// Access tenant-1 should trigger refresh
-	cache.Get(ctx1, "tenant-1", "/v1/payments")
+	_, _, err = cache.Get(ctx1, "tenant-1", "/v1/payments")
+	require.NoError(t, err)
 	assert.Equal(t, 2, source.refreshCount("tenant-1"))
 }
 
@@ -273,9 +291,44 @@ func TestSagaBindingCache_SourceReturnsEmpty(t *testing.T) {
 
 	ctx := tenant.WithTenant(context.Background(), "tenant-1")
 
-	sagaName, found := cache.Get(ctx, "tenant-1", "/v1/payments")
+	sagaName, found, err := cache.Get(ctx, "tenant-1", "/v1/payments")
+	require.NoError(t, err)
 	assert.False(t, found)
 	assert.Empty(t, sagaName)
+}
+
+func TestSagaBindingCache_NilSource_Panics(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		NewSagaBindingCache(nil)
+	})
+}
+
+func TestSagaBindingCache_Get_SourceError_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	source := &errorSagaBindingSource{
+		err: fmt.Errorf("database connection refused"),
+	}
+
+	cache := NewSagaBindingCache(source, WithSagaBindingTTL(5*time.Minute))
+
+	ctx := tenant.WithTenant(context.Background(), "tenant-1")
+
+	_, found, err := cache.Get(ctx, "tenant-1", "/v1/payments")
+	assert.False(t, found)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database connection refused")
+}
+
+// errorSagaBindingSource always returns an error.
+type errorSagaBindingSource struct {
+	err error
+}
+
+func (e *errorSagaBindingSource) GetBindingsForTenant(_ context.Context, _ string) (map[string]string, error) {
+	return nil, e.err
 }
 
 // mockSagaBindingSource is a test double for SagaBindingSource.

--- a/services/api-gateway/cache/saga_binding_cache_test.go
+++ b/services/api-gateway/cache/saga_binding_cache_test.go
@@ -1,0 +1,310 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+func TestSagaBindingCache_Get_CacheHit(t *testing.T) {
+	t.Parallel()
+
+	source := &mockSagaBindingSource{
+		bindings: map[string]map[string]string{
+			"tenant-1": {
+				"/v1/payments": "process_payment",
+			},
+		},
+	}
+
+	cache := NewSagaBindingCache(source, WithSagaBindingTTL(5*time.Minute))
+
+	ctx := tenant.WithTenant(context.Background(), "tenant-1")
+
+	// First call triggers source refresh
+	sagaName, found := cache.Get(ctx, "tenant-1", "/v1/payments")
+	require.True(t, found)
+	assert.Equal(t, "process_payment", sagaName)
+	assert.Equal(t, 1, source.refreshCount("tenant-1"))
+
+	// Second call should use cache (no additional source call)
+	sagaName, found = cache.Get(ctx, "tenant-1", "/v1/payments")
+	require.True(t, found)
+	assert.Equal(t, "process_payment", sagaName)
+	assert.Equal(t, 1, source.refreshCount("tenant-1"))
+}
+
+func TestSagaBindingCache_Get_CacheMiss_NoBinding(t *testing.T) {
+	t.Parallel()
+
+	source := &mockSagaBindingSource{
+		bindings: map[string]map[string]string{
+			"tenant-1": {
+				"/v1/payments": "process_payment",
+			},
+		},
+	}
+
+	cache := NewSagaBindingCache(source, WithSagaBindingTTL(5*time.Minute))
+
+	ctx := tenant.WithTenant(context.Background(), "tenant-1")
+
+	sagaName, found := cache.Get(ctx, "tenant-1", "/v1/unknown")
+	assert.False(t, found)
+	assert.Empty(t, sagaName)
+}
+
+func TestSagaBindingCache_Invalidate_ClearsTenantBindings(t *testing.T) {
+	t.Parallel()
+
+	source := &mockSagaBindingSource{
+		bindings: map[string]map[string]string{
+			"tenant-1": {
+				"/v1/payments": "process_payment",
+			},
+		},
+	}
+
+	cache := NewSagaBindingCache(source, WithSagaBindingTTL(5*time.Minute))
+
+	ctx := tenant.WithTenant(context.Background(), "tenant-1")
+
+	// Populate cache
+	sagaName, found := cache.Get(ctx, "tenant-1", "/v1/payments")
+	require.True(t, found)
+	assert.Equal(t, "process_payment", sagaName)
+	assert.Equal(t, 1, source.refreshCount("tenant-1"))
+
+	// Invalidate tenant
+	err := cache.Invalidate(ctx, "tenant-1")
+	require.NoError(t, err)
+
+	// Update source to return different binding
+	source.mu.Lock()
+	source.bindings["tenant-1"]["/v1/payments"] = "process_payment_v2"
+	source.mu.Unlock()
+
+	// Next Get should trigger re-fetch from source
+	sagaName, found = cache.Get(ctx, "tenant-1", "/v1/payments")
+	require.True(t, found)
+	assert.Equal(t, "process_payment_v2", sagaName)
+	assert.Equal(t, 2, source.refreshCount("tenant-1"))
+}
+
+func TestSagaBindingCache_Refresh_PopulatesCache(t *testing.T) {
+	t.Parallel()
+
+	source := &mockSagaBindingSource{
+		bindings: map[string]map[string]string{
+			"tenant-1": {
+				"/v1/payments":    "process_payment",
+				"/v1/settlements": "settle_trade",
+			},
+		},
+	}
+
+	cache := NewSagaBindingCache(source, WithSagaBindingTTL(5*time.Minute))
+
+	ctx := tenant.WithTenant(context.Background(), "tenant-1")
+
+	err := cache.Refresh(ctx, "tenant-1")
+	require.NoError(t, err)
+
+	sagaName, found := cache.Get(ctx, "tenant-1", "/v1/payments")
+	require.True(t, found)
+	assert.Equal(t, "process_payment", sagaName)
+
+	sagaName, found = cache.Get(ctx, "tenant-1", "/v1/settlements")
+	require.True(t, found)
+	assert.Equal(t, "settle_trade", sagaName)
+
+	// Only one refresh call
+	assert.Equal(t, 1, source.refreshCount("tenant-1"))
+}
+
+func TestSagaBindingCache_TTLExpiry_TriggersRefresh(t *testing.T) {
+	t.Parallel()
+
+	source := &mockSagaBindingSource{
+		bindings: map[string]map[string]string{
+			"tenant-1": {
+				"/v1/payments": "process_payment",
+			},
+		},
+	}
+
+	// Use a very short TTL
+	cache := NewSagaBindingCache(source, WithSagaBindingTTL(1*time.Millisecond))
+
+	ctx := tenant.WithTenant(context.Background(), "tenant-1")
+
+	// First call
+	sagaName, found := cache.Get(ctx, "tenant-1", "/v1/payments")
+	require.True(t, found)
+	assert.Equal(t, "process_payment", sagaName)
+	assert.Equal(t, 1, source.refreshCount("tenant-1"))
+
+	// Wait for TTL to expire
+	time.Sleep(5 * time.Millisecond)
+
+	// Should trigger a re-fetch
+	sagaName, found = cache.Get(ctx, "tenant-1", "/v1/payments")
+	require.True(t, found)
+	assert.Equal(t, "process_payment", sagaName)
+	assert.Equal(t, 2, source.refreshCount("tenant-1"))
+}
+
+func TestSagaBindingCache_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	source := &mockSagaBindingSource{
+		bindings: map[string]map[string]string{
+			"tenant-1": {
+				"/v1/payments": "process_payment",
+			},
+		},
+	}
+
+	cache := NewSagaBindingCache(source, WithSagaBindingTTL(5*time.Minute))
+
+	ctx := tenant.WithTenant(context.Background(), "tenant-1")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sagaName, found := cache.Get(ctx, "tenant-1", "/v1/payments")
+			assert.True(t, found)
+			assert.Equal(t, "process_payment", sagaName)
+		}()
+	}
+	wg.Wait()
+
+	// Source should be called fewer times than goroutines (singleflight dedup)
+	assert.Less(t, source.refreshCount("tenant-1"), 100)
+}
+
+func TestSagaBindingCache_MultipleTenants(t *testing.T) {
+	t.Parallel()
+
+	source := &mockSagaBindingSource{
+		bindings: map[string]map[string]string{
+			"tenant-1": {
+				"/v1/payments": "process_payment_v1",
+			},
+			"tenant-2": {
+				"/v1/payments": "process_payment_v2",
+			},
+		},
+	}
+
+	cache := NewSagaBindingCache(source, WithSagaBindingTTL(5*time.Minute))
+
+	ctx1 := tenant.WithTenant(context.Background(), "tenant-1")
+	ctx2 := tenant.WithTenant(context.Background(), "tenant-2")
+
+	sagaName, found := cache.Get(ctx1, "tenant-1", "/v1/payments")
+	require.True(t, found)
+	assert.Equal(t, "process_payment_v1", sagaName)
+
+	sagaName, found = cache.Get(ctx2, "tenant-2", "/v1/payments")
+	require.True(t, found)
+	assert.Equal(t, "process_payment_v2", sagaName)
+}
+
+func TestSagaBindingCache_Invalidate_OnlyAffectsSpecifiedTenant(t *testing.T) {
+	t.Parallel()
+
+	source := &mockSagaBindingSource{
+		bindings: map[string]map[string]string{
+			"tenant-1": {
+				"/v1/payments": "process_payment_v1",
+			},
+			"tenant-2": {
+				"/v1/payments": "process_payment_v2",
+			},
+		},
+	}
+
+	cache := NewSagaBindingCache(source, WithSagaBindingTTL(5*time.Minute))
+
+	ctx1 := tenant.WithTenant(context.Background(), "tenant-1")
+	ctx2 := tenant.WithTenant(context.Background(), "tenant-2")
+
+	// Populate both tenants
+	cache.Get(ctx1, "tenant-1", "/v1/payments")
+	cache.Get(ctx2, "tenant-2", "/v1/payments")
+
+	assert.Equal(t, 1, source.refreshCount("tenant-1"))
+	assert.Equal(t, 1, source.refreshCount("tenant-2"))
+
+	// Invalidate tenant-1 only
+	err := cache.Invalidate(ctx1, "tenant-1")
+	require.NoError(t, err)
+
+	// Access tenant-2 should still use cache
+	cache.Get(ctx2, "tenant-2", "/v1/payments")
+	assert.Equal(t, 1, source.refreshCount("tenant-2"))
+
+	// Access tenant-1 should trigger refresh
+	cache.Get(ctx1, "tenant-1", "/v1/payments")
+	assert.Equal(t, 2, source.refreshCount("tenant-1"))
+}
+
+func TestSagaBindingCache_SourceReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	source := &mockSagaBindingSource{
+		bindings: map[string]map[string]string{},
+	}
+
+	cache := NewSagaBindingCache(source, WithSagaBindingTTL(5*time.Minute))
+
+	ctx := tenant.WithTenant(context.Background(), "tenant-1")
+
+	sagaName, found := cache.Get(ctx, "tenant-1", "/v1/payments")
+	assert.False(t, found)
+	assert.Empty(t, sagaName)
+}
+
+// mockSagaBindingSource is a test double for SagaBindingSource.
+type mockSagaBindingSource struct {
+	mu       sync.Mutex
+	bindings map[string]map[string]string
+	calls    map[string]int
+}
+
+func (m *mockSagaBindingSource) GetBindingsForTenant(_ context.Context, tenantID string) (map[string]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.calls == nil {
+		m.calls = make(map[string]int)
+	}
+	m.calls[tenantID]++
+
+	bindings := m.bindings[tenantID]
+	if bindings == nil {
+		return map[string]string{}, nil
+	}
+
+	// Return a copy
+	result := make(map[string]string, len(bindings))
+	for k, v := range bindings {
+		result[k] = v
+	}
+	return result, nil
+}
+
+func (m *mockSagaBindingSource) refreshCount(tenantID string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls[tenantID]
+}

--- a/services/api-gateway/cache/saga_binding_cache_test.go
+++ b/services/api-gateway/cache/saga_binding_cache_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
@@ -150,14 +151,17 @@ func TestSagaBindingCache_TTLExpiry_TriggersRefresh(t *testing.T) {
 	assert.Equal(t, "process_payment", sagaName)
 	assert.Equal(t, 1, source.refreshCount("tenant-1"))
 
-	// Wait for TTL to expire
-	time.Sleep(5 * time.Millisecond)
-
-	// Should trigger a re-fetch
-	sagaName, found = cache.Get(ctx, "tenant-1", "/v1/payments")
+	// Wait for TTL to expire, then trigger a re-fetch
+	err := await.New().
+		AtMost(1 * time.Second).
+		PollInterval(1 * time.Millisecond).
+		Until(func() bool {
+			sagaName, found = cache.Get(ctx, "tenant-1", "/v1/payments")
+			return source.refreshCount("tenant-1") >= 2
+		})
+	require.NoError(t, err)
 	require.True(t, found)
 	assert.Equal(t, "process_payment", sagaName)
-	assert.Equal(t, 2, source.refreshCount("tenant-1"))
 }
 
 func TestSagaBindingCache_ConcurrentAccess(t *testing.T) {

--- a/services/control-plane/internal/applier/grpc_handler.go
+++ b/services/control-plane/internal/applier/grpc_handler.go
@@ -212,11 +212,24 @@ func (h *ApplyManifestHandler) ApplyManifest(
 	logger.Info("manifest applied successfully", "job_id", execResult.jobID)
 
 	// Invoke post-apply hooks (e.g., cache invalidation)
-	for _, hook := range h.postApplyHooks {
-		hook(ctx, string(tenantID))
-	}
+	h.runPostApplyHooks(ctx, string(tenantID), logger)
 
 	return response, nil
+}
+
+// runPostApplyHooks invokes each post-apply hook with panic recovery
+// to prevent a misbehaving hook from crashing the gRPC handler.
+func (h *ApplyManifestHandler) runPostApplyHooks(ctx context.Context, tenantID string, logger *slog.Logger) {
+	for i, hook := range h.postApplyHooks {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					logger.Error("post-apply hook panicked", "hook_index", i, "panic", r)
+				}
+			}()
+			hook(ctx, tenantID)
+		}()
+	}
 }
 
 // validationOutput holds the results of manifest validation.

--- a/services/control-plane/internal/applier/grpc_handler.go
+++ b/services/control-plane/internal/applier/grpc_handler.go
@@ -37,8 +37,14 @@ type ApplyManifestHandler struct {
 	executor       *ManifestExecutor
 	historyService *manifest.HistoryService
 	versionStore   differ.ManifestVersionStore
+	postApplyHooks []PostApplyHook
 	logger         *slog.Logger
 }
+
+// PostApplyHook is called after a manifest is successfully applied.
+// The tenantID identifies the tenant whose manifest was applied.
+// Implementations must be safe for concurrent use and should not block.
+type PostApplyHook func(ctx context.Context, tenantID string)
 
 // ApplyManifestHandlerConfig contains dependencies for creating an ApplyManifestHandler.
 type ApplyManifestHandlerConfig struct {
@@ -49,6 +55,10 @@ type ApplyManifestHandlerConfig struct {
 	HistoryService *manifest.HistoryService
 	VersionStore   differ.ManifestVersionStore
 	Logger         *slog.Logger
+
+	// PostApplyHooks are called after a manifest is successfully applied.
+	// Used for cache invalidation (e.g., saga binding cache in the API gateway).
+	PostApplyHooks []PostApplyHook
 }
 
 // NewApplyManifestHandler creates a new ApplyManifestHandler with the given dependencies.
@@ -73,6 +83,7 @@ func NewApplyManifestHandler(cfg ApplyManifestHandlerConfig) (*ApplyManifestHand
 		executor:       cfg.Executor,
 		historyService: cfg.HistoryService,
 		versionStore:   cfg.VersionStore,
+		postApplyHooks: cfg.PostApplyHooks,
 		logger:         cfg.Logger.With("component", "apply_manifest_handler"),
 	}, nil
 }
@@ -199,6 +210,11 @@ func (h *ApplyManifestHandler) ApplyManifest(
 
 	response.Status = controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_APPLIED
 	logger.Info("manifest applied successfully", "job_id", execResult.jobID)
+
+	// Invoke post-apply hooks (e.g., cache invalidation)
+	for _, hook := range h.postApplyHooks {
+		hook(ctx, string(tenantID))
+	}
 
 	return response, nil
 }

--- a/services/control-plane/internal/applier/grpc_handler_test.go
+++ b/services/control-plane/internal/applier/grpc_handler_test.go
@@ -107,6 +107,32 @@ func TestNewApplyManifestHandler_RequiredDependencies(t *testing.T) {
 	}
 }
 
+func TestNewApplyManifestHandler_PostApplyHooksStored(t *testing.T) {
+	v, err := validator.New()
+	require.NoError(t, err)
+
+	d := differ.New(nil, nil)
+	p := planner.NewManifestPlanner()
+
+	called := false
+	hook := PostApplyHook(func(_ context.Context, _ string) {
+		called = true
+	})
+
+	handler, err := NewApplyManifestHandler(ApplyManifestHandlerConfig{
+		Validator:      v,
+		Differ:         d,
+		Planner:        p,
+		PostApplyHooks: []PostApplyHook{hook},
+	})
+	require.NoError(t, err)
+	assert.Len(t, handler.postApplyHooks, 1)
+
+	// Verify the hook is callable
+	handler.postApplyHooks[0](context.Background(), "test-tenant")
+	assert.True(t, called)
+}
+
 func TestApplyManifest_NilManifest(t *testing.T) {
 	handler := newTestHandler(t)
 


### PR DESCRIPTION
## Summary

- Implement in-memory `SagaBindingCache` in the API gateway that maps `(tenant_id, api_path)` to `saga_name` for efficient routing of API-triggered sagas
- Cache supports TTL-based expiry, explicit per-tenant invalidation, and automatic refresh from a `SagaBindingSource` on cache miss
- Uses `singleflight` to deduplicate concurrent refresh requests for the same tenant
- Add `ManifestBindingSource` that queries the latest applied manifest from `manifest_versions` to extract `api:` trigger bindings
- Add `PostApplyHook` mechanism to `ApplyManifestHandler` for cache invalidation on manifest apply

## Test plan

- [x] Cache hit returns correct saga binding without additional source calls
- [x] Cache miss for unknown path returns not-found
- [x] Invalidation clears tenant bindings and triggers re-fetch
- [x] Explicit refresh populates cache from source
- [x] TTL expiry triggers automatic refresh
- [x] Concurrent access is safe (singleflight dedup verified)
- [x] Multiple tenants are isolated (invalidation only affects specified tenant)
- [x] Empty source returns empty bindings
- [x] Manifest JSON parsing correctly extracts API trigger bindings from mixed trigger types
- [x] PostApplyHook is stored and callable on handler construction