### PR TITLE
feat: Implement destructive change detection for manifest validation

### DIFF
--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -1602,6 +1602,10 @@ func (v *ManifestValidator) validateDestructiveChanges(
 	}
 
 	// Check removed account types.
+	// Note: In the current graph structure, account types are only sources (denominated_in
+	// edges to instruments), not targets. Saga-to-account-type dependencies are captured
+	// via dynamic edges when call logs are provided (e.g., from a saga execution engine).
+	// Without call logs, this check relies on graph edges populated externally.
 	for _, acct := range previous.GetAccountTypes() {
 		code := acct.GetCode()
 		if currentAccountTypes[code] {

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -293,12 +293,32 @@ func New(opts ...Option) (*ManifestValidator, error) {
 	return mv, nil
 }
 
+// ValidateOption configures validation behavior.
+type ValidateOption func(*validateConfig)
+
+type validateConfig struct {
+	forceDestructiveChanges bool
+}
+
+// WithForceDestructiveChanges converts destructive change errors into warnings,
+// allowing removal of in-use resources when explicitly requested.
+func WithForceDestructiveChanges() ValidateOption {
+	return func(c *validateConfig) {
+		c.forceDestructiveChanges = true
+	}
+}
+
 // Validate performs full validation of a manifest.
-// If previousManifest is non-nil, immutability checks are also performed.
+// If previousManifest is non-nil, immutability and destructive change checks are also performed.
 func (v *ManifestValidator) Validate(
 	manifest *controlplanev1.Manifest,
 	previousManifest *controlplanev1.Manifest,
+	opts ...ValidateOption,
 ) *ValidationResult {
+	cfg := &validateConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
 	result := &ValidationResult{Valid: true}
 
 	// 1. Structural validation (protobuf constraints)
@@ -343,6 +363,11 @@ func (v *ManifestValidator) Validate(
 	// 14. Immutability checks
 	if previousManifest != nil {
 		v.validateImmutability(manifest, previousManifest, result)
+	}
+
+	// 15. Destructive change detection
+	if previousManifest != nil {
+		v.validateDestructiveChanges(manifest, previousManifest, callLogs, cfg, result)
 	}
 
 	// Set valid flag based on error count
@@ -1519,6 +1544,96 @@ func (v *ManifestValidator) validateImmutability(
 					Message:  fmt.Sprintf("account type code changed from %q to %q; codes are immutable primary keys", prevCode, acct.GetCode()),
 				})
 			}
+		}
+	}
+}
+
+// validateDestructiveChanges detects removal of resources that have dependencies in the
+// previous manifest. Removing an instrument used by account types or valuation rules,
+// an account type referenced in sagas, or a saga with dependents produces an error.
+// When force is set via WithForceDestructiveChanges, these errors become warnings.
+func (v *ManifestValidator) validateDestructiveChanges(
+	current *controlplanev1.Manifest,
+	previous *controlplanev1.Manifest,
+	callLogs map[string][]schema.HandlerCallInfo,
+	cfg *validateConfig,
+	result *ValidationResult,
+) {
+	// Build the relationship graph from the previous manifest to check dependencies.
+	prevGraph := ExtractRelationshipGraph(previous, callLogs)
+
+	// Build lookup sets for current manifest resources.
+	currentInstruments := make(map[string]bool)
+	for _, inst := range current.GetInstruments() {
+		currentInstruments[inst.GetCode()] = true
+	}
+	currentAccountTypes := make(map[string]bool)
+	for _, acct := range current.GetAccountTypes() {
+		currentAccountTypes[acct.GetCode()] = true
+	}
+	currentSagas := make(map[string]bool)
+	for _, saga := range current.GetSagas() {
+		currentSagas[saga.GetName()] = true
+	}
+
+	severity := SeverityError
+	if cfg.forceDestructiveChanges {
+		severity = SeverityWarning
+	}
+
+	// Check removed instruments. Use Impact (all connected edges) because instruments
+	// can be both targets (denominated_in from account types) and sources (converts in
+	// valuation rules).
+	for _, inst := range previous.GetInstruments() {
+		code := inst.GetCode()
+		if currentInstruments[code] {
+			continue
+		}
+		nodeID := "instrument:" + code
+		impact := prevGraph.Impact(nodeID)
+		if len(impact.AffectedNodes) > 0 {
+			addError(result, ValidationError{
+				Severity: severity,
+				Path:     "instruments",
+				Code:     "DESTRUCTIVE_INSTRUMENT_REMOVAL",
+				Message:  fmt.Sprintf("cannot remove instrument %q: it is referenced by %s", code, strings.Join(impact.AffectedNodes, ", ")),
+			})
+		}
+	}
+
+	// Check removed account types.
+	for _, acct := range previous.GetAccountTypes() {
+		code := acct.GetCode()
+		if currentAccountTypes[code] {
+			continue
+		}
+		nodeID := "account_type:" + code
+		dependents := prevGraph.Dependents(nodeID)
+		if len(dependents) > 0 {
+			addError(result, ValidationError{
+				Severity: severity,
+				Path:     "account_types",
+				Code:     "DESTRUCTIVE_ACCOUNT_TYPE_REMOVAL",
+				Message:  fmt.Sprintf("cannot remove account type %q: it is referenced by %s", code, strings.Join(dependents, ", ")),
+			})
+		}
+	}
+
+	// Check removed sagas.
+	for _, saga := range previous.GetSagas() {
+		name := saga.GetName()
+		if currentSagas[name] {
+			continue
+		}
+		nodeID := "saga:" + name
+		dependents := prevGraph.Dependents(nodeID)
+		if len(dependents) > 0 {
+			addError(result, ValidationError{
+				Severity: severity,
+				Path:     "sagas",
+				Code:     "DESTRUCTIVE_SAGA_REMOVAL",
+				Message:  fmt.Sprintf("cannot remove saga %q: it is referenced by %s", name, strings.Join(dependents, ", ")),
+			})
 		}
 	}
 }

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -366,8 +366,12 @@ func (v *ManifestValidator) Validate(
 	}
 
 	// 15. Destructive change detection
+	// Use the previous manifest's call logs for graph construction so that
+	// dependencies that existed in the previous version are correctly detected,
+	// even if a saga was modified or removed in the current manifest.
 	if previousManifest != nil {
-		v.validateDestructiveChanges(manifest, previousManifest, callLogs, cfg, result)
+		previousCallLogs := v.validateStarlarkScripts(previousManifest, &ValidationResult{})
+		v.validateDestructiveChanges(manifest, previousManifest, previousCallLogs, cfg, result)
 	}
 
 	// Set valid flag based on error count

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -2699,3 +2699,213 @@ func TestValidateOrphans_NoGateway_NoWarnings(t *testing.T) {
 		assert.NotEqual(t, "ORPHAN_INSTRUCTION_ROUTE", w.Code)
 	}
 }
+
+// --- Destructive change detection tests ---
+
+func TestValidateDestructiveChanges_RemoveInstrumentUsedByAccountType(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	prev := validManifest() // Has GBP instrument used by SETTLEMENT account type
+	curr := validManifest()
+	// Remove GBP instrument (index 0), keep KWH
+	curr.Instruments = curr.Instruments[1:] // Only KWH remains
+	// Remove the account type that references GBP so cross-ref passes
+	// but the destructive check should still fire based on previous manifest
+	curr.AccountTypes = nil
+
+	result := v.Validate(curr, prev)
+	assert.False(t, result.Valid, "should be invalid when removing instrument used by account_type")
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "DESTRUCTIVE_INSTRUMENT_REMOVAL" {
+			found = true
+			assert.Contains(t, e.Message, "GBP")
+			assert.Contains(t, e.Message, "account_type:SETTLEMENT")
+			break
+		}
+	}
+	assert.True(t, found, "expected DESTRUCTIVE_INSTRUMENT_REMOVAL error, got: %v", result.Errors)
+}
+
+func TestValidateDestructiveChanges_RemoveAccountTypeWithNoDependents(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	// The SETTLEMENT account type has outgoing edges (denominated_in -> instrument)
+	// but no incoming edges (nothing depends on it in the graph). Removing it should
+	// not produce a destructive error.
+	prev := validManifest()
+	curr := validManifest()
+	curr.AccountTypes = nil
+
+	result := v.Validate(curr, prev)
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "DESTRUCTIVE_ACCOUNT_TYPE_REMOVAL", e.Code,
+			"account type with no dependents should not produce destructive error")
+	}
+}
+
+func TestValidateDestructiveChanges_RemoveAccountTypeWithDependents(t *testing.T) {
+	// Test via the relationship graph Dependents method directly, since creating
+	// a saga script that produces dynamic edges requires handler call logging.
+	g := &RelationshipGraph{
+		Nodes: []GraphNode{
+			{ID: "account_type:SETTLEMENT", Type: NodeTypeAccountType, Name: "Settlement"},
+			{ID: "saga:process_payment", Type: NodeTypeSaga, Name: "process_payment"},
+		},
+		Edges: []GraphEdge{
+			{
+				Source:       "saga:process_payment",
+				Target:       "account_type:SETTLEMENT",
+				Relationship: RelWritesTo,
+				IsDynamic:    true,
+			},
+		},
+	}
+
+	dependents := g.Dependents("account_type:SETTLEMENT")
+	assert.Equal(t, []string{"saga:process_payment"}, dependents,
+		"SETTLEMENT should have saga:process_payment as dependent")
+}
+
+func TestValidateDestructiveChanges_RemoveSagaWithNoSubscriptions(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	prev := validManifest()
+	curr := validManifest()
+	curr.Sagas = nil // Remove the saga
+
+	result := v.Validate(curr, prev)
+	// Removing a saga with no active subscriptions should succeed
+	// (other validation errors may occur, but no DESTRUCTIVE_SAGA_REMOVAL)
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "DESTRUCTIVE_SAGA_REMOVAL", e.Code,
+			"should not produce DESTRUCTIVE_SAGA_REMOVAL for saga with no dependents")
+	}
+}
+
+func TestValidateDestructiveChanges_RemoveUnusedInstrument(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	prev := validManifest()
+	// Add an unused instrument to the previous manifest
+	prev.Instruments = append(prev.Instruments, &controlplanev1.InstrumentDefinition{
+		Code: "EUR",
+		Name: "Euro",
+		Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+		Dimensions: &controlplanev1.InstrumentDimensions{
+			Unit:      "EUR",
+			Precision: 2,
+		},
+	})
+
+	curr := validManifest() // Does not have EUR
+
+	result := v.Validate(curr, prev)
+	// Should not produce destructive error for unused instrument
+	for _, e := range result.Errors {
+		if e.Code == "DESTRUCTIVE_INSTRUMENT_REMOVAL" {
+			assert.NotContains(t, e.Message, "EUR",
+				"should not flag removal of unused instrument EUR")
+		}
+	}
+}
+
+func TestValidateDestructiveChanges_AddNewResourcesNeverTriggersWarning(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	prev := validManifest()
+	curr := validManifest()
+	// Add new resources
+	curr.Instruments = append(curr.Instruments, &controlplanev1.InstrumentDefinition{
+		Code: "EUR",
+		Name: "Euro",
+		Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+		Dimensions: &controlplanev1.InstrumentDimensions{
+			Unit:      "EUR",
+			Precision: 2,
+		},
+	})
+	curr.AccountTypes = append(curr.AccountTypes, &controlplanev1.AccountTypeDefinition{
+		Code:               "REVENUE",
+		Name:               "Revenue Account",
+		NormalBalance:      controlplanev1.NormalBalance_NORMAL_BALANCE_CREDIT,
+		AllowedInstruments: []string{"GBP"},
+		Policies: &controlplanev1.AccountTypePolicies{
+			Validation: "amount > 0",
+		},
+	})
+
+	result := v.Validate(curr, prev)
+	for _, e := range result.Errors {
+		assert.NotContains(t, e.Code, "DESTRUCTIVE_",
+			"adding new resources should never trigger destructive warnings")
+	}
+}
+
+func TestValidateDestructiveChanges_ForceOverrideBypassesChecks(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	prev := validManifest()
+	curr := validManifest()
+	curr.Instruments = curr.Instruments[1:] // Remove GBP
+	curr.AccountTypes = nil                 // Remove account types
+
+	result := v.Validate(curr, prev, WithForceDestructiveChanges())
+	// With force, destructive errors become warnings
+	for _, e := range result.Errors {
+		assert.NotContains(t, e.Code, "DESTRUCTIVE_",
+			"force override should convert destructive errors to warnings")
+	}
+
+	// Verify they appear as warnings instead
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w.Code, "DESTRUCTIVE_") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "force override should produce destructive warnings, not errors")
+}
+
+func TestValidateDestructiveChanges_NilPreviousNoCheck(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	result := v.Validate(validManifest(), nil)
+	for _, e := range result.Errors {
+		assert.NotContains(t, e.Code, "DESTRUCTIVE_",
+			"nil previous manifest should never trigger destructive checks")
+	}
+}
+
+func TestValidateDestructiveChanges_RemoveInstrumentUsedByValuationRule(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	prev := validManifest() // Has KWH->GBP valuation rule
+	curr := validManifest()
+	// Remove KWH instrument (index 1)
+	curr.Instruments = curr.Instruments[:1] // Only GBP remains
+	// Remove valuation rules that reference KWH
+	curr.ValuationRules = nil
+
+	result := v.Validate(curr, prev)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "DESTRUCTIVE_INSTRUMENT_REMOVAL" && strings.Contains(e.Message, "KWH") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected DESTRUCTIVE_INSTRUMENT_REMOVAL for KWH used in valuation rule, got: %v", result.Errors)
+}

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -2733,9 +2733,8 @@ func TestValidateDestructiveChanges_RemoveAccountTypeWithNoDependents(t *testing
 	v, err := New()
 	require.NoError(t, err)
 
-	// The SETTLEMENT account type has outgoing edges (denominated_in -> instrument)
-	// but no incoming edges (nothing depends on it in the graph). Removing it should
-	// not produce a destructive error.
+	// The default saga has a simple script with no handler calls referencing accounts.
+	// Removing the account type should not produce a destructive error.
 	prev := validManifest()
 	curr := validManifest()
 	curr.AccountTypes = nil
@@ -2747,9 +2746,8 @@ func TestValidateDestructiveChanges_RemoveAccountTypeWithNoDependents(t *testing
 	}
 }
 
-func TestValidateDestructiveChanges_RemoveAccountTypeWithDependents(t *testing.T) {
-	// Test via the relationship graph Dependents method directly, since creating
-	// a saga script that produces dynamic edges requires handler call logging.
+func TestValidateDestructiveChanges_RemoveAccountTypeWithDependentsViaGraph(t *testing.T) {
+	// Test via the relationship graph Dependents method directly.
 	g := &RelationshipGraph{
 		Nodes: []GraphNode{
 			{ID: "account_type:SETTLEMENT", Type: NodeTypeAccountType, Name: "Settlement"},

--- a/services/control-plane/internal/validator/relationship_graph.go
+++ b/services/control-plane/internal/validator/relationship_graph.go
@@ -96,6 +96,24 @@ func (g *RelationshipGraph) Impact(nodeID string) *ImpactResult {
 	}
 }
 
+// Dependents returns nodes that depend on the given node ID (i.e., nodes that reference it
+// via incoming edges where nodeID is the target). This is distinct from Impact which considers
+// all connected edges. Dependents answers "what breaks if I remove this node?"
+func (g *RelationshipGraph) Dependents(nodeID string) []string {
+	seen := make(map[string]bool)
+	for _, edge := range g.Edges {
+		if edge.Target == nodeID && edge.Source != nodeID {
+			seen[edge.Source] = true
+		}
+	}
+	nodes := make([]string, 0, len(seen))
+	for n := range seen {
+		nodes = append(nodes, n)
+	}
+	sort.Strings(nodes)
+	return nodes
+}
+
 // ExtractRelationshipGraph builds a relationship graph from a manifest and Starlark handler call logs.
 // The callLogs map is keyed by saga name, with each value being the handler calls made by that saga's script.
 // Returns a graph containing nodes (instruments, account_types, sagas, handlers) and edges

--- a/services/control-plane/internal/validator/relationship_graph_test.go
+++ b/services/control-plane/internal/validator/relationship_graph_test.go
@@ -297,6 +297,42 @@ func assertNodeExists(t *testing.T, g *RelationshipGraph, id string, nodeType No
 }
 
 // assertEdgeExists checks that an edge with the given source, target, and relationship exists.
+func TestDependents(t *testing.T) {
+	g := &RelationshipGraph{
+		Nodes: []GraphNode{
+			{ID: "instrument:GBP", Type: NodeTypeInstrument},
+			{ID: "instrument:KWH", Type: NodeTypeInstrument},
+			{ID: "account_type:SETTLEMENT", Type: NodeTypeAccountType},
+			{ID: "saga:process_payment", Type: NodeTypeSaga},
+		},
+		Edges: []GraphEdge{
+			{Source: "account_type:SETTLEMENT", Target: "instrument:GBP", Relationship: RelDenominatedIn},
+			{Source: "instrument:KWH", Target: "instrument:GBP", Relationship: RelConverts},
+			{Source: "saga:process_payment", Target: "account_type:SETTLEMENT", Relationship: RelWritesTo},
+		},
+	}
+
+	t.Run("instrument with incoming edges", func(t *testing.T) {
+		deps := g.Dependents("instrument:GBP")
+		assert.Equal(t, []string{"account_type:SETTLEMENT", "instrument:KWH"}, deps)
+	})
+
+	t.Run("account type with incoming edge", func(t *testing.T) {
+		deps := g.Dependents("account_type:SETTLEMENT")
+		assert.Equal(t, []string{"saga:process_payment"}, deps)
+	})
+
+	t.Run("saga with no incoming edges", func(t *testing.T) {
+		deps := g.Dependents("saga:process_payment")
+		assert.Empty(t, deps)
+	})
+
+	t.Run("nonexistent node", func(t *testing.T) {
+		deps := g.Dependents("instrument:EUR")
+		assert.Empty(t, deps)
+	})
+}
+
 func assertEdgeExists(t *testing.T, g *RelationshipGraph, source, target string, rel RelationshipType) {
 	t.Helper()
 	for _, e := range g.Edges {


### PR DESCRIPTION
## Summary

- Add destructive change detection to manifest validation that blocks removal of resources with dependencies in the previous manifest
- Instruments used by account types or valuation rules, account types referenced by sagas, and sagas with dependents cannot be removed without explicit force override
- Add `Dependents` method to `RelationshipGraph` for querying incoming edges (what depends on a given node)
- Add `WithForceDestructiveChanges()` validation option to convert destructive errors into warnings

## Changes Made

- `manifest_validator.go`: Add `ValidateOption`/`validateConfig` types, `WithForceDestructiveChanges` option, and `validateDestructiveChanges` method as step 15 in the validation pipeline
- `relationship_graph.go`: Add `Dependents` method that returns nodes with incoming edges to a given node (complement to the existing `Impact` method which considers all edges)
- Test coverage for 9 scenarios including instrument removal with dependents, unused resource removal, force override, nil previous manifest

## Technical Details

- Instruments use `Impact` (all connected edges) since they can be both sources (`converts` in valuation rules) and targets (`denominated_in` from account types)
- Account types and sagas use `Dependents` (incoming edges only) since their outgoing edges represent their own dependencies, not things that depend on them
- Error codes: `DESTRUCTIVE_INSTRUMENT_REMOVAL`, `DESTRUCTIVE_ACCOUNT_TYPE_REMOVAL`, `DESTRUCTIVE_SAGA_REMOVAL`

## Test Plan

- [x] Removing instrument used by account_type produces DESTRUCTIVE_INSTRUMENT_REMOVAL error
- [x] Removing instrument used by valuation rule produces DESTRUCTIVE_INSTRUMENT_REMOVAL error
- [x] Removing unused instrument succeeds
- [x] Removing account type with no dependents succeeds
- [x] Removing account type with dependents (via graph unit test) detected correctly
- [x] Removing saga with no subscriptions succeeds
- [x] Adding new resources never triggers destructive warnings
- [x] Force override converts destructive errors to warnings
- [x] Nil previous manifest skips destructive checks
- [x] Full validator test suite passes (existing tests unbroken)

Task: 039-meridian-vm.12