### PR TITLE
feat: Add forecasting, market info, reference data, and internal account handler definitions

### DIFF
--- a/services/control-plane/internal/applier/handlers.yaml
+++ b/services/control-plane/internal/applier/handlers.yaml
@@ -121,12 +121,12 @@ handlers:
     description: "Delete an account type (compensation for register)"
     compensation_strategy: none
     params:
-      account_type_code:
+      code:
         type: string
         required: true
         description: "Account type code to delete"
     returns:
-      account_type_code:
+      code:
         type: string
         description: "The deleted account type code"
       status:

--- a/services/current-account/service/saga_handlers.go
+++ b/services/current-account/service/saga_handlers.go
@@ -140,6 +140,25 @@ func RegisterCurrentAccountHandlers(registry *saga.HandlerRegistry) error {
 		{"financial_gateway.dispatch_payment", stubNotImplemented("financial_gateway.dispatch_payment")},
 		{"financial_gateway.cancel_payment", stubNotImplemented("financial_gateway.cancel_payment")},
 		{"financial_gateway.dispatch_refund", stubNotImplemented("financial_gateway.dispatch_refund")},
+
+		// Forecasting handlers (stubs - defined in schema for forecasting service)
+		{"forecasting.compute_forward_curve", stubNotImplemented("forecasting.compute_forward_curve")},
+
+		// Market Information handlers (stubs - defined in schema for market information service)
+		{"market_information.publish_observation", stubNotImplemented("market_information.publish_observation")},
+		{"market_information.query_latest", stubNotImplemented("market_information.query_latest")},
+		{"market_information.manage_dataset", stubNotImplemented("market_information.manage_dataset")},
+
+		// Reference Data handlers (stubs - defined in schema for reference data service)
+		{"reference_data.register_instrument", stubNotImplemented("reference_data.register_instrument")},
+		{"reference_data.delete_instrument", stubNotImplemented("reference_data.delete_instrument")},
+		{"reference_data.register_account_type", stubNotImplemented("reference_data.register_account_type")},
+		{"reference_data.delete_account_type", stubNotImplemented("reference_data.delete_account_type")},
+		{"reference_data.register_valuation_rule", stubNotImplemented("reference_data.register_valuation_rule")},
+		{"reference_data.register_saga_definition", stubNotImplemented("reference_data.register_saga_definition")},
+
+		// Internal Account handlers (stubs - defined in schema for internal account service)
+		{"internal_account.initiate", stubNotImplemented("internal_account.initiate")},
 	}
 
 	for _, h := range handlers {

--- a/shared/pkg/saga/schema/handlers.yaml
+++ b/shared/pkg/saga/schema/handlers.yaml
@@ -1249,12 +1249,12 @@ handlers:
     description: "Delete an account type (compensation for register)"
     compensation_strategy: none
     params:
-      account_type_code:
+      code:
         type: string
         required: true
         description: "Account type code to delete"
     returns:
-      account_type_code:
+      code:
         type: string
         description: "The deleted account type code"
       status:

--- a/shared/pkg/saga/schema/handlers.yaml
+++ b/shared/pkg/saga/schema/handlers.yaml
@@ -997,3 +997,378 @@ handlers:
       status:
         type: string
         description: "Status of the refund dispatch (e.g., ACCEPTED, PENDING)"
+
+  # Forecasting Service
+  forecasting.compute_forward_curve:
+    description: "Trigger forward curve computation from market data for a given strategy and instrument"
+    compensation_strategy: saga_managed
+    params:
+      strategy_name:
+        type: string
+        required: true
+        description: "Name of the forecasting strategy to execute"
+      instrument_code:
+        type: string
+        required: true
+        description: "Instrument code to compute the forward curve for (e.g., KWH, GBP)"
+      from_date:
+        type: string
+        required: true
+        description: "Start date for the forward curve period (ISO 8601 date)"
+      to_date:
+        type: string
+        required: true
+        description: "End date for the forward curve period (ISO 8601 date)"
+    returns:
+      curve_id:
+        type: string
+        description: "Generated forward curve identifier (UUID)"
+      strategy_name:
+        type: string
+        description: "Echo of the input strategy name"
+      instrument_code:
+        type: string
+        description: "Echo of the input instrument code"
+      status:
+        type: string
+        description: "Status of the computation (COMPLETED)"
+
+  # Market Information Service
+  market_information.publish_observation:
+    description: "Publish a price or rate observation to a market data set"
+    compensation_strategy: saga_managed
+    params:
+      dataset_code:
+        type: string
+        required: true
+        description: "Code of the data set to publish to"
+      dataset_version:
+        type: int64
+        required: true
+        description: "Version of the data set schema"
+      value:
+        type: Decimal
+        required: true
+        description: "Observed value (price, rate, etc.)"
+      quality_level:
+        type: enum
+        values: [ESTIMATE, COEFFICIENT, ACTUAL, REVISED]
+        required: true
+        description: "Data quality level of the observation"
+      valid_from:
+        type: string
+        required: true
+        description: "Start of the validity period (ISO 8601 timestamp)"
+      valid_to:
+        type: string
+        required: true
+        description: "End of the validity period (ISO 8601 timestamp)"
+    returns:
+      observation_id:
+        type: string
+        description: "Generated observation identifier (UUID)"
+      dataset_code:
+        type: string
+        description: "Echo of the input data set code"
+      status:
+        type: string
+        description: "Status of the observation (PUBLISHED)"
+
+  market_information.query_latest:
+    description: "Query the latest observation for a market data set"
+    compensation_strategy: none
+    params:
+      dataset_code:
+        type: string
+        required: true
+        description: "Code of the data set to query"
+      as_of:
+        type: string
+        required: false
+        description: "Point-in-time for the query (ISO 8601 timestamp, default: now)"
+    returns:
+      observation_id:
+        type: string
+        description: "Identifier of the latest observation"
+      dataset_code:
+        type: string
+        description: "Echo of the input data set code"
+      value:
+        type: Decimal
+        description: "Observed value"
+      quality_level:
+        type: string
+        description: "Quality level of the observation"
+      valid_from:
+        type: string
+        description: "Start of validity period"
+      valid_to:
+        type: string
+        description: "End of validity period"
+
+  market_information.manage_dataset:
+    description: "Create or update a market data set definition"
+    compensation_strategy: saga_managed
+    params:
+      dataset_code:
+        type: string
+        required: true
+        description: "Unique code for the data set"
+      display_name:
+        type: string
+        required: true
+        description: "Human-readable name for the data set"
+      dimension:
+        type: string
+        required: true
+        description: "Physical dimension (CURRENCY, ENERGY, etc.)"
+      unit:
+        type: string
+        required: true
+        description: "Unit of measurement (e.g., GBP, KWH, TONNE_CO2E)"
+    returns:
+      dataset_code:
+        type: string
+        description: "Echo of the input data set code"
+      status:
+        type: string
+        description: "Status of the operation (CREATED or UPDATED)"
+
+  # Reference Data Service
+  reference_data.register_instrument:
+    description: "Register a new instrument definition in Reference Data service"
+    params:
+      instrument_code:
+        type: string
+        required: true
+        description: "Unique instrument code (e.g., USD, KWH)"
+      display_name:
+        type: string
+        required: false
+        description: "Human-readable instrument name"
+      dimension:
+        type: string
+        required: false
+        description: "Physical dimension (CURRENCY, ENERGY, etc.)"
+      decimal_places:
+        type: int64
+        required: false
+        description: "Decimal precision (0-18)"
+      description:
+        type: string
+        required: false
+        description: "Instrument description"
+    returns:
+      instrument_code:
+        type: string
+        description: "The registered instrument code"
+      status:
+        type: string
+        description: "Registration status (REGISTERED)"
+    compensate: reference_data.delete_instrument
+
+  reference_data.delete_instrument:
+    description: "Delete an instrument (compensation for register)"
+    compensation_strategy: none
+    params:
+      instrument_code:
+        type: string
+        required: true
+        description: "Instrument code to delete"
+    returns:
+      instrument_code:
+        type: string
+        description: "The deleted instrument code"
+      status:
+        type: string
+        description: "Deletion status (DELETED)"
+
+  reference_data.register_account_type:
+    description: "Register a new account type definition in Reference Data service"
+    params:
+      code:
+        type: string
+        required: true
+        description: "Unique account type code (e.g., CUSTOMER_CURRENT)"
+      display_name:
+        type: string
+        required: true
+        description: "Human-readable account type name"
+      behavior_class:
+        type: enum
+        values: [CUSTOMER, CLEARING, NOSTRO, VOSTRO, HOLDING, SUSPENSE, REVENUE, EXPENSE, INVENTORY]
+        required: true
+        description: "Accounting behavior class"
+      normal_balance:
+        type: enum
+        values: [DEBIT, CREDIT]
+        required: true
+        description: "Normal balance direction"
+      instrument_code:
+        type: string
+        required: true
+        description: "Default instrument code for this account type (e.g., GBP)"
+      description:
+        type: string
+        required: false
+        description: "Account type description"
+      default_saga_prefix:
+        type: string
+        required: false
+        description: "Saga prefix for operations on accounts of this type"
+      default_conversion_method:
+        type: string
+        required: false
+        description: "Named valuation method for conversion (resolved to UUID by handler)"
+      validation_cel:
+        type: string
+        required: false
+        description: "CEL expression for validating account operations"
+      eligibility_cel:
+        type: string
+        required: false
+        description: "CEL expression for determining account eligibility"
+      attribute_schema:
+        type: map
+        required: false
+        description: "JSON Schema defining valid attributes for this account type"
+      valuation_methods:
+        type: array
+        required: false
+        description: "List of valuation method templates (each with input_instrument and method_name)"
+    returns:
+      code:
+        type: string
+        description: "The registered account type code"
+      version:
+        type: int32
+        description: "The version of the registered account type definition"
+    compensate: reference_data.delete_account_type
+
+  reference_data.delete_account_type:
+    description: "Delete an account type (compensation for register)"
+    compensation_strategy: none
+    params:
+      account_type_code:
+        type: string
+        required: true
+        description: "Account type code to delete"
+    returns:
+      account_type_code:
+        type: string
+        description: "The deleted account type code"
+      status:
+        type: string
+        description: "Deletion status (DELETED)"
+
+  reference_data.register_valuation_rule:
+    description: "Register a valuation rule for cross-instrument conversion"
+    compensation_strategy: none
+    params:
+      from_instrument:
+        type: string
+        required: true
+        description: "Source instrument code"
+      to_instrument:
+        type: string
+        required: true
+        description: "Target instrument code"
+      rule_type:
+        type: string
+        required: false
+        description: "Rule type (FIXED_RATE, MARKET, etc.)"
+      expression:
+        type: string
+        required: false
+        description: "CEL expression for valuation computation"
+      description:
+        type: string
+        required: false
+        description: "Rule description"
+    returns:
+      from_instrument:
+        type: string
+        description: "Source instrument code"
+      to_instrument:
+        type: string
+        description: "Target instrument code"
+      status:
+        type: string
+        description: "Registration status (REGISTERED)"
+
+  reference_data.register_saga_definition:
+    description: "Register a saga definition in the saga registry"
+    compensation_strategy: none
+    params:
+      saga_name:
+        type: string
+        required: true
+        description: "Saga identifier name"
+      display_name:
+        type: string
+        required: false
+        description: "Human-readable saga name"
+      description:
+        type: string
+        required: false
+        description: "Saga description"
+      script:
+        type: string
+        required: false
+        description: "Starlark script content"
+      version:
+        type: string
+        required: false
+        description: "Saga version (semver format)"
+    returns:
+      saga_name:
+        type: string
+        description: "The registered saga name"
+      status:
+        type: string
+        description: "Registration status (REGISTERED)"
+
+  # Internal Account Service
+  internal_account.initiate:
+    description: "Initiate a new internal account"
+    compensation_strategy: none
+    params:
+      account_code:
+        type: string
+        required: true
+        description: "Business-friendly account code"
+      name:
+        type: string
+        required: true
+        description: "Human-readable account name"
+      account_type:
+        type: string
+        required: true
+        description: "Account type (CLEARING, NOSTRO, etc.)"
+      instrument_code:
+        type: string
+        required: true
+        description: "Instrument code (e.g., USD, KWH)"
+      description:
+        type: string
+        required: false
+        description: "Account description"
+    returns:
+      account_id:
+        type: string
+        description: "Generated account identifier"
+      account_code:
+        type: string
+        description: "Echo of account code"
+      name:
+        type: string
+        description: "Echo of account name"
+      account_type:
+        type: string
+        description: "Echo of account type"
+      status:
+        type: string
+        description: "Account status (ACTIVE)"
+      instrument_code:
+        type: string
+        description: "Echo of instrument code"

--- a/shared/pkg/saga/schema/handlers.yaml
+++ b/shared/pkg/saga/schema/handlers.yaml
@@ -1130,6 +1130,9 @@ handlers:
       dataset_code:
         type: string
         description: "Echo of the input data set code"
+      dataset_version:
+        type: int64
+        description: "Current version of the data set schema after the operation"
       status:
         type: string
         description: "Status of the operation (CREATED or UPDATED)"

--- a/shared/pkg/saga/schema/handlers.yaml
+++ b/shared/pkg/saga/schema/handlers.yaml
@@ -1344,10 +1344,10 @@ handlers:
         type: string
         required: true
         description: "Human-readable account name"
-      account_type:
+      product_type_code:
         type: string
         required: true
-        description: "Account type (CLEARING, NOSTRO, etc.)"
+        description: "Product type code from the Product Directory (e.g., CLEARING, NOSTRO)"
       instrument_code:
         type: string
         required: true
@@ -1366,9 +1366,9 @@ handlers:
       name:
         type: string
         description: "Echo of account name"
-      account_type:
+      behavior_class:
         type: string
-        description: "Echo of account type"
+        description: "Behavior class derived from product type (e.g., NOSTRO, CLEARING)"
       status:
         type: string
         description: "Account status (ACTIVE)"

--- a/shared/pkg/saga/schema/handlers_test.go
+++ b/shared/pkg/saga/schema/handlers_test.go
@@ -56,6 +56,17 @@ func TestPlatformHandlersSchema(t *testing.T) {
 		"financial_gateway.dispatch_payment",
 		"financial_gateway.cancel_payment",
 		"financial_gateway.dispatch_refund",
+		"forecasting.compute_forward_curve",
+		"market_information.publish_observation",
+		"market_information.query_latest",
+		"market_information.manage_dataset",
+		"reference_data.register_instrument",
+		"reference_data.delete_instrument",
+		"reference_data.register_account_type",
+		"reference_data.delete_account_type",
+		"reference_data.register_valuation_rule",
+		"reference_data.register_saga_definition",
+		"internal_account.initiate",
 	}
 
 	assert.Len(t, schema.Handlers, len(expectedHandlers),
@@ -204,7 +215,7 @@ func TestRegistryLoadPlatformHandlers(t *testing.T) {
 	require.NoError(t, err)
 
 	handlers := registry.ListHandlers()
-	assert.Len(t, handlers, 36, "registry should contain all 36 platform handlers")
+	assert.Len(t, handlers, 47, "registry should contain all 47 platform handlers")
 
 	// Verify we can get each handler
 	for _, name := range handlers {


### PR DESCRIPTION
## Summary

- Add 11 new handler schemas to the shared platform `handlers.yaml` for forecasting, market information, reference data, and internal account services
- These definitions enable saga scripts to invoke these service handlers with type-safe validation via the service modules system
- Reference data and internal account handlers are promoted from the control-plane's local `handlers.yaml` to the shared platform schema

## Changes Made

**Forecasting Service (Task 039-meridian-vm.13)**
- `forecasting.compute_forward_curve` - Trigger forward curve computation from market data

**Market Information Service (Task 039-meridian-vm.14)**
- `market_information.publish_observation` - Publish price/rate observations
- `market_information.query_latest` - Query latest observation for a data set
- `market_information.manage_dataset` - Create/update data set definitions

**Reference Data and Internal Account (Task 039-meridian-vm.15)**
- `reference_data.register_instrument` / `delete_instrument` - Instrument lifecycle
- `reference_data.register_account_type` / `delete_account_type` - Account type lifecycle
- `reference_data.register_valuation_rule` - Valuation rule registration
- `reference_data.register_saga_definition` - Saga definition registration
- `internal_account.initiate` - Internal account provisioning

## Testing

- Updated `handlers_test.go` to validate all 47 handlers (was 36)
- All `shared/pkg/saga/schema/...` tests pass
- Compensation coverage, handler existence, and param type tests all green