### PR TITLE
Fix provisioner DSN derivation in unified binary

### DIFF
--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -583,8 +583,20 @@ func startProvisioningWorker(ctx context.Context, platformDB *gorm.DB, logger *s
 		return nil, nil, nil
 	}
 
-	// Create provisioner with default config (reads service DB URLs from env).
+	// Create provisioner config and derive service DSNs from DATABASE_URL.
+	// DefaultConfig() falls back to cockroachdb:26257 when per-service env vars
+	// are unset. The unified binary derives all connections from a single base DSN,
+	// so we override each service's DatabaseURL to match.
 	config := tenantprovisioner.DefaultConfig()
+	baseDSN := env.GetEnvOrDefault("DATABASE_URL", "")
+	if baseDSN != "" {
+		for i := range config.Services {
+			svc := &config.Services[i]
+			if sdb, ok := migrations.ServiceDatabases[svc.Name]; ok {
+				svc.DatabaseURL = replaceDSNDatabase(baseDSN, sdb.Database)
+			}
+		}
+	}
 	prov, err := tenantprovisioner.NewPostgresProvisioner(platformDB, config)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create schema provisioner: %w", err)


### PR DESCRIPTION
## Summary

- Derives provisioner service database URLs from `DATABASE_URL` instead of relying on `DefaultConfig()` fallback to `cockroachdb:26257`
- Fixes provisioning worker crash on demo (which uses PostgreSQL at `postgres:5432`)

## Root cause

`DefaultConfig()` in the provisioner package checks per-service env vars (e.g., `PARTY_DATABASE_URL`) and falls back to `cockroachdb:26257`. The unified binary doesn't set per-service env vars — it derives all DSNs from a single `DATABASE_URL`. The provisioning worker (added in #1513) used `DefaultConfig()` without overriding the DSNs.

## Changes Made

- In `startProvisioningWorker()`, after calling `DefaultConfig()`, iterate over services and replace each `DatabaseURL` using `replaceDSNDatabase(baseDSN, sdb.Database)` — the same pattern used by `newServiceConns()`

## Test plan

- [ ] `go build ./cmd/meridian/` compiles
- [ ] Deploy to demo with `SCHEMA_PROVISIONING_ENABLED=true` — worker starts without connection errors
- [ ] Create tenant via UI — schemas provisioned in all service DBs