### PR TITLE
Fix subdomain routing for tenant subdomains

### DIFF
--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -19,6 +19,21 @@ export const apiConfig = {
   useBinaryFormat: import.meta.env.PROD && import.meta.env.VITE_E2E_MODE !== 'true',
 } as const
 
+/**
+ * Returns true if the browser is on a tenant subdomain (e.g. acme.demo.meridianhub.cloud).
+ * Detects this by checking if the hostname has more segments than the configured base URL.
+ */
+export function isOnTenantSubdomain(): boolean {
+  const base = apiConfig.baseUrl
+  try {
+    const baseParts = new URL(base).hostname.split('.')
+    const currentParts = window.location.hostname.split('.')
+    return currentParts.length > baseParts.length
+  } catch {
+    return false
+  }
+}
+
 export function buildTenantBaseUrl(tenantSlug: string): string {
   const base = apiConfig.baseUrl
   const parsed = new URL(base)

--- a/frontend/src/api/transport.ts
+++ b/frontend/src/api/transport.ts
@@ -20,8 +20,9 @@ export function createTenantTransport(
   const useHeaderRouting =
     !onSubdomain &&
     (import.meta.env.DEV || import.meta.env.VITE_DEMO_MODE === 'true')
+  const configuredPath = new URL(apiConfig.baseUrl).pathname.replace(/\/$/, '')
   const baseUrl = onSubdomain
-    ? window.location.origin
+    ? `${window.location.origin}${configuredPath}`
     : tenantSlug && !useHeaderRouting
       ? buildTenantBaseUrl(tenantSlug)
       : apiConfig.baseUrl

--- a/frontend/src/api/transport.ts
+++ b/frontend/src/api/transport.ts
@@ -5,7 +5,7 @@ import {
   createTenantInterceptor,
   type TenantSlugGetter,
 } from './interceptors/tenant-interceptor'
-import { apiConfig, buildTenantBaseUrl } from './config'
+import { apiConfig, buildTenantBaseUrl, isOnTenantSubdomain } from './config'
 
 export function createTenantTransport(
   tenantSlug: string | null,
@@ -13,13 +13,18 @@ export function createTenantTransport(
   getTenantSlug: TenantSlugGetter,
   onUnauthenticated?: () => void,
 ): Transport {
-  // In development or demo mode, keep the base URL and route via X-Tenant-Slug header
-  // (the gateway's LOCAL_DEV_MODE resolves tenants from the header).
-  // In production, use subdomain-based URL for tenant routing.
+  // If the browser is already on a tenant subdomain, API calls go to the same
+  // origin (subdomain routing). Otherwise in dev/demo mode, route via
+  // X-Tenant-Slug header (the gateway's LOCAL_DEV_MODE resolves from the header).
+  const onSubdomain = isOnTenantSubdomain()
   const useHeaderRouting =
-    import.meta.env.DEV || import.meta.env.VITE_DEMO_MODE === 'true'
-  const baseUrl =
-    tenantSlug && !useHeaderRouting ? buildTenantBaseUrl(tenantSlug) : apiConfig.baseUrl
+    !onSubdomain &&
+    (import.meta.env.DEV || import.meta.env.VITE_DEMO_MODE === 'true')
+  const baseUrl = onSubdomain
+    ? window.location.origin
+    : tenantSlug && !useHeaderRouting
+      ? buildTenantBaseUrl(tenantSlug)
+      : apiConfig.baseUrl
 
   return createConnectTransport({
     baseUrl,

--- a/frontend/src/test/api/transport.test.ts
+++ b/frontend/src/test/api/transport.test.ts
@@ -15,7 +15,7 @@ vi.mock('@/api/config', () => ({
 }))
 
 import { createConnectTransport } from '@connectrpc/connect-web'
-import { buildTenantBaseUrl, apiConfig } from '@/api/config'
+import { buildTenantBaseUrl, apiConfig, isOnTenantSubdomain } from '@/api/config'
 
 describe('createTenantTransport', () => {
   const getTenantSlug = vi.fn(() => null)
@@ -58,6 +58,17 @@ describe('createTenantTransport', () => {
 
     expect(createConnectTransport).toHaveBeenCalledWith(
       expect.objectContaining({ useBinaryFormat: false }),
+    )
+  })
+
+  it('uses window.location.origin when on a tenant subdomain', () => {
+    vi.mocked(isOnTenantSubdomain).mockReturnValue(true)
+    const getToken = vi.fn(() => 'token')
+    createTenantTransport('acme', getToken, getTenantSlug)
+
+    expect(buildTenantBaseUrl).not.toHaveBeenCalled()
+    expect(createConnectTransport).toHaveBeenCalledWith(
+      expect.objectContaining({ baseUrl: window.location.origin }),
     )
   })
 })

--- a/frontend/src/test/api/transport.test.ts
+++ b/frontend/src/test/api/transport.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/api/config', () => ({
     useBinaryFormat: false,
   },
   buildTenantBaseUrl: vi.fn((slug: string) => `https://${slug}.api.meridian.io`),
+  isOnTenantSubdomain: vi.fn(() => false),
 }))
 
 import { createConnectTransport } from '@connectrpc/connect-web'


### PR DESCRIPTION
## Summary

- When the browser is on a tenant subdomain (e.g. `volterra-energy.demo.meridianhub.cloud`), API calls now go to the same origin instead of the base domain
- `VITE_DEMO_MODE` previously forced all requests through `demo.meridianhub.cloud` with `X-Tenant-Slug` headers, which broke subdomain-based access

## Changes Made

- Added `isOnTenantSubdomain()` to `config.ts` — detects if the current hostname has more segments than the configured base URL
- Updated `transport.ts` — when on a subdomain, uses `window.location.origin` as the API base URL and skips header routing

## Test plan

- [ ] Access `demo.meridianhub.cloud` — API calls still use base domain with header routing (unchanged)
- [ ] Access `volterra-energy.demo.meridianhub.cloud` — API calls go to same origin, backend resolves tenant from subdomain
- [ ] Local dev (`localhost`) — unchanged behavior