### PR TITLE
feat: add Connect client for identity service

### DIFF
--- a/frontend/src/api/clients.ts
+++ b/frontend/src/api/clients.ts
@@ -19,6 +19,7 @@ import { ForecastingService } from './gen/meridian/forecasting/v1/forecasting_pb
 import { ManifestHistoryService } from './gen/meridian/control_plane/v1/manifest_history_service_pb'
 import { ApplyManifestService } from './gen/meridian/control_plane/v1/apply_manifest_service_pb'
 import { AuditService } from './gen/meridian/audit/v1/audit_service_pb'
+import { IdentityService } from './gen/meridian/identity/v1/identity_pb'
 
 export function createServiceClients(transport: Transport) {
   return {
@@ -41,6 +42,7 @@ export function createServiceClients(transport: Transport) {
     manifestHistory: createClient(ManifestHistoryService, transport),
     manifestApplier: createClient(ApplyManifestService, transport),
     audit: createClient(AuditService, transport),
+    identity: createClient(IdentityService, transport),
   }
 }
 

--- a/frontend/src/test/api/clients.test.ts
+++ b/frontend/src/test/api/clients.test.ts
@@ -52,7 +52,13 @@ describe('createServiceClients', () => {
     expect(clients).toHaveProperty('manifestApplier')
     expect(clients).toHaveProperty('audit')
     expect(clients).toHaveProperty('identity')
-    expect((clients.identity as any).__service).toBe(IdentityService.typeName)
+  })
+
+  it('wires identity client to IdentityService descriptor', () => {
+    const transport = makeTransport()
+    createServiceClients(transport)
+
+    expect(createClient).toHaveBeenCalledWith(IdentityService, transport)
   })
 
   it('calls createClient for each service with the provided transport', () => {

--- a/frontend/src/test/api/clients.test.ts
+++ b/frontend/src/test/api/clients.test.ts
@@ -56,8 +56,9 @@ describe('createServiceClients', () => {
 
   it('wires identity client to IdentityService descriptor', () => {
     const transport = makeTransport()
-    createServiceClients(transport)
+    const clients = createServiceClients(transport)
 
+    expect((clients.identity as { __service: string }).__service).toBe(IdentityService.typeName)
     expect(createClient).toHaveBeenCalledWith(IdentityService, transport)
   })
 

--- a/frontend/src/test/api/clients.test.ts
+++ b/frontend/src/test/api/clients.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createServiceClients } from '@/api/clients'
+import { IdentityService } from '@/api/gen/meridian/identity/v1/identity_pb'
 import type { Transport } from '@connectrpc/connect'
 
 vi.mock('@connectrpc/connect', () => ({
@@ -51,6 +52,7 @@ describe('createServiceClients', () => {
     expect(clients).toHaveProperty('manifestApplier')
     expect(clients).toHaveProperty('audit')
     expect(clients).toHaveProperty('identity')
+    expect((clients.identity as any).__service).toBe(IdentityService.typeName)
   })
 
   it('calls createClient for each service with the provided transport', () => {

--- a/frontend/src/test/api/clients.test.ts
+++ b/frontend/src/test/api/clients.test.ts
@@ -24,7 +24,7 @@ describe('createServiceClients', () => {
     const transport = makeTransport()
     const clients = createServiceClients(transport)
 
-    expect(Object.keys(clients)).toHaveLength(19)
+    expect(Object.keys(clients)).toHaveLength(20)
   })
 
   it('creates clients for all expected services', () => {
@@ -50,13 +50,14 @@ describe('createServiceClients', () => {
     expect(clients).toHaveProperty('manifestHistory')
     expect(clients).toHaveProperty('manifestApplier')
     expect(clients).toHaveProperty('audit')
+    expect(clients).toHaveProperty('identity')
   })
 
   it('calls createClient for each service with the provided transport', () => {
     const transport = makeTransport()
     createServiceClients(transport)
 
-    expect(createClient).toHaveBeenCalledTimes(19)
+    expect(createClient).toHaveBeenCalledTimes(20)
     vi.mocked(createClient).mock.calls.forEach(([, t]) => {
       expect(t).toBe(transport)
     })


### PR DESCRIPTION
## Summary

- Add `IdentityService` Connect client to `frontend/src/api/clients.ts`, enabling the frontend to call the 16 identity RPCs (CRUD, authentication, password management, role management, invitations, lifecycle)
- Update client test assertions from 19 to 20 services and add `identity` property check

## Test plan

- [x] `npm run typecheck` passes
- [x] All 1873 frontend tests pass (`npx vitest run`)
- [x] Generated `identity_pb.ts` exports `IdentityService` with all 16 RPCs

## Task Master

Tag: `embedded-dex-identity`, Task: 14