### PR TITLE
feat: seed demo operator user on identity bootstrap

### DIFF
--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -412,6 +412,12 @@ func registerServices(
 		logger.Warn("identity bootstrap failed, service startup continues", "error", err)
 	}
 
+	// Seed demo users (operator, etc.) from environment variables.
+	// No-op if env vars are not set. Idempotent on every boot.
+	if err := identitybootstrap.SeedDemoUsers(ctx, identityRepo); err != nil {
+		logger.Warn("demo user seeding failed, service startup continues", "error", err)
+	}
+
 	// Tier 1: Depend on Tier 0 via loopback
 	for _, wire := range []struct {
 		name string

--- a/deploy/demo/.env.demo.example
+++ b/deploy/demo/.env.demo.example
@@ -99,6 +99,17 @@ BASE_DOMAIN=demo.meridianhub.cloud
 LOCAL_DEV_MODE=true
 
 # ---------------------------------------------------------------------------
+# Demo Users (Identity Bootstrap)
+# ---------------------------------------------------------------------------
+
+# [OPTIONAL] Demo operator user seeded on first boot.
+# If both EMAIL and PASSWORD are set, the user is created idempotently
+# in the specified tenant with the OPERATOR role.
+DEMO_OPERATOR_EMAIL=operator@volterra.energy
+DEMO_OPERATOR_PASSWORD=demo2026
+DEMO_OPERATOR_TENANT=volterra
+
+# ---------------------------------------------------------------------------
 # Billing
 # ---------------------------------------------------------------------------
 

--- a/services/identity/bootstrap/bootstrap.go
+++ b/services/identity/bootstrap/bootstrap.go
@@ -148,6 +148,153 @@ func reconcileRoles(ctx context.Context, repo domain.Repository, identity *domai
 	return nil
 }
 
+// DemoUser holds the configuration for a demo user to be seeded on boot.
+type DemoUser struct {
+	Email    string
+	Password string
+	TenantID string
+	Role     string // domain role string, e.g. "OPERATOR"
+}
+
+// loadDemoUsers reads demo user configuration from environment variables.
+// Returns an empty slice if required variables are not set.
+func loadDemoUsers() []DemoUser {
+	email := os.Getenv("DEMO_OPERATOR_EMAIL")
+	password := os.Getenv("DEMO_OPERATOR_PASSWORD")
+	if email == "" || password == "" {
+		return nil
+	}
+
+	tenantID := os.Getenv("DEMO_OPERATOR_TENANT")
+	if tenantID == "" {
+		tenantID = "volterra"
+	}
+
+	return []DemoUser{{
+		Email:    email,
+		Password: password,
+		TenantID: tenantID,
+		Role:     string(domain.RoleOperator),
+	}}
+}
+
+// SeedDemoUsers creates demo user identities from environment variables.
+// Each user is created idempotently in its configured tenant with the specified role.
+//
+// Environment variables:
+//   - DEMO_OPERATOR_EMAIL: Email address for the demo operator
+//   - DEMO_OPERATOR_PASSWORD: Password for the demo operator
+//   - DEMO_OPERATOR_TENANT: Tenant ID (default: "volterra")
+func SeedDemoUsers(ctx context.Context, repo domain.Repository) error {
+	if repo == nil {
+		return ErrNilRepository
+	}
+
+	users := loadDemoUsers()
+	if len(users) == 0 {
+		slog.InfoContext(ctx, "demo user seeding skipped: no demo users configured")
+		return nil
+	}
+
+	for _, u := range users {
+		if err := seedDemoUser(ctx, repo, u); err != nil {
+			return fmt.Errorf("seeding demo user %s: %w", u.Email, err)
+		}
+	}
+	return nil
+}
+
+// seedDemoUser creates a single demo user identity idempotently.
+func seedDemoUser(ctx context.Context, repo domain.Repository, u DemoUser) error {
+	tid, err := tenant.NewTenantID(u.TenantID)
+	if err != nil {
+		return fmt.Errorf("invalid tenant ID %q: %w", u.TenantID, err)
+	}
+	tenantCtx := tenant.WithTenant(ctx, tid)
+
+	// Check if the user already exists.
+	existing, err := repo.FindByEmail(tenantCtx, u.Email)
+	if err != nil && !errors.Is(err, domain.ErrIdentityNotFound) {
+		return fmt.Errorf("checking for existing demo user: %w", err)
+	}
+
+	if existing != nil {
+		// User already exists — reconcile the role.
+		return reconcileDemoRole(tenantCtx, repo, existing, u.Role)
+	}
+
+	// Hash the password.
+	hash, err := credentials.HashPassword(u.Password)
+	if err != nil {
+		return fmt.Errorf("hashing demo user password: %w", err)
+	}
+
+	// Build identity.
+	identity, err := domain.NewIdentity(u.Email)
+	if err != nil {
+		return fmt.Errorf("creating demo user identity: %w", err)
+	}
+	if err := identity.SetPassword(hash); err != nil {
+		return fmt.Errorf("setting demo user password: %w", err)
+	}
+	if err := identity.Activate(); err != nil {
+		return fmt.Errorf("activating demo user identity: %w", err)
+	}
+
+	now := time.Now()
+	ra := domain.ReconstructRoleAssignment(
+		uuid.New(),
+		identity.ID(),
+		identity.ID(),
+		domain.Role(u.Role),
+		nil, nil, nil,
+		now, now,
+	)
+
+	if err := repo.SaveIdentityWithRoles(tenantCtx, identity, []*domain.RoleAssignment{ra}); err != nil {
+		return fmt.Errorf("persisting demo user: %w", err)
+	}
+
+	slog.InfoContext(tenantCtx, "demo user seeded successfully",
+		"email", u.Email,
+		"tenant", u.TenantID,
+		"role", u.Role)
+	return nil
+}
+
+// reconcileDemoRole ensures the demo user has the expected role assigned.
+func reconcileDemoRole(ctx context.Context, repo domain.Repository, identity *domain.Identity, role string) error {
+	existing, err := repo.FindRoleAssignments(ctx, identity.ID())
+	if err != nil {
+		return fmt.Errorf("fetching existing role assignments: %w", err)
+	}
+
+	for _, ra := range existing {
+		if ra.IsActive() && string(ra.Role()) == role {
+			slog.InfoContext(ctx, "demo user already exists with required role, skipping",
+				"email", identity.Email(),
+				"role", role)
+			return nil
+		}
+	}
+
+	slog.InfoContext(ctx, "demo user exists but missing role, adding",
+		"email", identity.Email(),
+		"role", role)
+
+	now := time.Now()
+	ra := domain.ReconstructRoleAssignment(
+		uuid.New(),
+		identity.ID(),
+		identity.ID(),
+		domain.Role(role),
+		nil, nil, nil,
+		now, now,
+	)
+
+	return repo.SaveRoleAssignments(ctx, []*domain.RoleAssignment{ra})
+}
+
 // buildRoleAssignments constructs RoleAssignment domain objects for each role.
 // Bootstrap is a trusted system operation; ReconstructRoleAssignment is used to
 // bypass the privilege hierarchy check that would otherwise require a granting identity.

--- a/services/identity/bootstrap/demo_users_test.go
+++ b/services/identity/bootstrap/demo_users_test.go
@@ -185,3 +185,28 @@ func TestSeedDemoUsers_Idempotent_ExistingUser(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, repo.saveWithRolesCalled, "should not create identity again")
 }
+
+func TestSeedDemoUsers_ReconcilesRole_ExistingUserMissingRole(t *testing.T) {
+	t.Setenv("DEMO_OPERATOR_EMAIL", "operator@volterra.energy")
+	t.Setenv("DEMO_OPERATOR_PASSWORD", "demo2026")
+	t.Setenv("DEMO_OPERATOR_TENANT", "volterra")
+
+	repo := newFakeRepo()
+
+	// Pre-seed an identity with no role assignments.
+	identity, err := domain.NewIdentity("operator@volterra.energy")
+	require.NoError(t, err)
+	require.NoError(t, identity.Activate())
+	repo.identities["operator@volterra.energy"] = identity
+
+	err = SeedDemoUsers(context.Background(), repo)
+	require.NoError(t, err)
+
+	// Should NOT have called SaveIdentityWithRoles (user already exists).
+	assert.False(t, repo.saveWithRolesCalled)
+
+	// Should have reconciled the missing role via SaveRoleAssignments.
+	roles := repo.roles[identity.ID()]
+	require.Len(t, roles, 1)
+	assert.Equal(t, domain.RoleOperator, roles[0].Role())
+}

--- a/services/identity/bootstrap/demo_users_test.go
+++ b/services/identity/bootstrap/demo_users_test.go
@@ -1,0 +1,187 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/identity/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRepo implements domain.Repository for bootstrap unit tests.
+type fakeRepo struct {
+	identities map[string]*domain.Identity            // keyed by email
+	roles      map[uuid.UUID][]*domain.RoleAssignment // keyed by identity ID
+
+	saveWithRolesCalled bool
+}
+
+func newFakeRepo() *fakeRepo {
+	return &fakeRepo{
+		identities: make(map[string]*domain.Identity),
+		roles:      make(map[uuid.UUID][]*domain.RoleAssignment),
+	}
+}
+
+func (f *fakeRepo) Save(_ context.Context, identity *domain.Identity) error {
+	f.identities[identity.Email()] = identity
+	return nil
+}
+
+func (f *fakeRepo) FindByID(_ context.Context, id uuid.UUID) (*domain.Identity, error) {
+	for _, ident := range f.identities {
+		if ident.ID() == id {
+			return ident, nil
+		}
+	}
+	return nil, domain.ErrIdentityNotFound
+}
+
+func (f *fakeRepo) FindByEmail(_ context.Context, email string) (*domain.Identity, error) {
+	if ident, ok := f.identities[email]; ok {
+		return ident, nil
+	}
+	return nil, domain.ErrIdentityNotFound
+}
+
+func (f *fakeRepo) ListByTenant(_ context.Context) ([]*domain.Identity, error) {
+	result := make([]*domain.Identity, 0, len(f.identities))
+	for _, ident := range f.identities {
+		result = append(result, ident)
+	}
+	return result, nil
+}
+
+func (f *fakeRepo) SaveRoleAssignment(_ context.Context, assignment *domain.RoleAssignment) error {
+	f.roles[assignment.IdentityID()] = append(f.roles[assignment.IdentityID()], assignment)
+	return nil
+}
+
+func (f *fakeRepo) FindRoleAssignments(_ context.Context, identityID uuid.UUID) ([]*domain.RoleAssignment, error) {
+	return f.roles[identityID], nil
+}
+
+func (f *fakeRepo) SaveIdentityWithInvitation(_ context.Context, identity *domain.Identity, _ *domain.Invitation) error {
+	f.identities[identity.Email()] = identity
+	return nil
+}
+
+func (f *fakeRepo) SaveIdentityWithRoles(_ context.Context, identity *domain.Identity, roles []*domain.RoleAssignment) error {
+	f.saveWithRolesCalled = true
+	f.identities[identity.Email()] = identity
+	f.roles[identity.ID()] = append(f.roles[identity.ID()], roles...)
+	return nil
+}
+
+func (f *fakeRepo) SaveRoleAssignments(_ context.Context, assignments []*domain.RoleAssignment) error {
+	for _, a := range assignments {
+		f.roles[a.IdentityID()] = append(f.roles[a.IdentityID()], a)
+	}
+	return nil
+}
+
+func (f *fakeRepo) SaveInvitation(_ context.Context, _ *domain.Invitation) error {
+	return nil
+}
+
+func (f *fakeRepo) FindInvitationByTokenHash(_ context.Context, _ string) (*domain.Invitation, error) {
+	return nil, errors.New("not found")
+}
+
+// --- Tests for DemoUser and loadDemoUsers ---
+
+func TestLoadDemoUsers_ReturnsConfiguredUsers(t *testing.T) {
+	t.Setenv("DEMO_OPERATOR_EMAIL", "operator@volterra.energy")
+	t.Setenv("DEMO_OPERATOR_PASSWORD", "demo2026")
+	t.Setenv("DEMO_OPERATOR_TENANT", "volterra")
+
+	users := loadDemoUsers()
+
+	require.Len(t, users, 1)
+	assert.Equal(t, "operator@volterra.energy", users[0].Email)
+	assert.Equal(t, "demo2026", users[0].Password)
+	assert.Equal(t, "volterra", users[0].TenantID)
+	assert.Equal(t, "OPERATOR", users[0].Role)
+}
+
+func TestLoadDemoUsers_DefaultTenant(t *testing.T) {
+	t.Setenv("DEMO_OPERATOR_EMAIL", "operator@volterra.energy")
+	t.Setenv("DEMO_OPERATOR_PASSWORD", "demo2026")
+
+	users := loadDemoUsers()
+
+	require.Len(t, users, 1)
+	assert.Equal(t, "volterra", users[0].TenantID)
+}
+
+func TestLoadDemoUsers_MissingEmail_Skipped(t *testing.T) {
+	t.Setenv("DEMO_OPERATOR_PASSWORD", "demo2026")
+
+	users := loadDemoUsers()
+	assert.Empty(t, users)
+}
+
+func TestLoadDemoUsers_MissingPassword_Skipped(t *testing.T) {
+	t.Setenv("DEMO_OPERATOR_EMAIL", "operator@volterra.energy")
+
+	users := loadDemoUsers()
+	assert.Empty(t, users)
+}
+
+// --- Tests for SeedDemoUsers ---
+
+func TestSeedDemoUsers_NilRepo(t *testing.T) {
+	err := SeedDemoUsers(context.Background(), nil)
+	assert.ErrorIs(t, err, ErrNilRepository)
+}
+
+func TestSeedDemoUsers_NoEnvVars_NoOp(t *testing.T) {
+	repo := newFakeRepo()
+	err := SeedDemoUsers(context.Background(), repo)
+
+	require.NoError(t, err)
+	assert.False(t, repo.saveWithRolesCalled)
+}
+
+func TestSeedDemoUsers_CreatesNewUser(t *testing.T) {
+	t.Setenv("DEMO_OPERATOR_EMAIL", "operator@volterra.energy")
+	t.Setenv("DEMO_OPERATOR_PASSWORD", "demo2026")
+	t.Setenv("DEMO_OPERATOR_TENANT", "volterra")
+
+	repo := newFakeRepo()
+	err := SeedDemoUsers(context.Background(), repo)
+
+	require.NoError(t, err)
+	assert.True(t, repo.saveWithRolesCalled)
+
+	ident, ok := repo.identities["operator@volterra.energy"]
+	require.True(t, ok, "identity should exist in repo")
+	assert.Equal(t, "operator@volterra.energy", ident.Email())
+	assert.Equal(t, domain.IdentityStatusActive, ident.Status())
+	assert.NotEmpty(t, ident.PasswordHash())
+
+	roles := repo.roles[ident.ID()]
+	require.Len(t, roles, 1)
+	assert.Equal(t, domain.RoleOperator, roles[0].Role())
+}
+
+func TestSeedDemoUsers_Idempotent_ExistingUser(t *testing.T) {
+	t.Setenv("DEMO_OPERATOR_EMAIL", "operator@volterra.energy")
+	t.Setenv("DEMO_OPERATOR_PASSWORD", "demo2026")
+	t.Setenv("DEMO_OPERATOR_TENANT", "volterra")
+
+	repo := newFakeRepo()
+
+	err := SeedDemoUsers(context.Background(), repo)
+	require.NoError(t, err)
+	assert.True(t, repo.saveWithRolesCalled)
+
+	repo.saveWithRolesCalled = false
+
+	err = SeedDemoUsers(context.Background(), repo)
+	require.NoError(t, err)
+	assert.False(t, repo.saveWithRolesCalled, "should not create identity again")
+}


### PR DESCRIPTION
## Summary

- Extends identity bootstrap to seed a demo operator user (`operator@volterra.energy`) with the `OPERATOR` role in the `volterra` tenant on first boot
- Adds `DemoUser` struct, `loadDemoUsers()`, and `SeedDemoUsers()` to the bootstrap package, following the existing platform admin seeding pattern
- The process is idempotent: existing users are skipped, missing roles are reconciled

## Changes

- `services/identity/bootstrap/bootstrap.go`: Add `DemoUser`, `loadDemoUsers()`, `SeedDemoUsers()`, `seedDemoUser()`, and `reconcileDemoRole()`
- `services/identity/bootstrap/demo_users_test.go`: Unit tests for loading config from env vars, creating users, nil repo, no-op when env vars missing, and idempotency
- `cmd/meridian/main.go`: Call `SeedDemoUsers()` after the existing platform admin bootstrap
- `deploy/demo/.env.demo.example`: Document `DEMO_OPERATOR_EMAIL`, `DEMO_OPERATOR_PASSWORD`, `DEMO_OPERATOR_TENANT` env vars

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `DEMO_OPERATOR_EMAIL` | (none) | Email for the demo operator |
| `DEMO_OPERATOR_PASSWORD` | (none) | Password for the demo operator |
| `DEMO_OPERATOR_TENANT` | `volterra` | Tenant ID to create the user in |

## Test plan

- [x] Unit tests for `loadDemoUsers()`: configured users, default tenant, missing email, missing password
- [x] Unit tests for `SeedDemoUsers()`: nil repo, no env vars, creates new user with correct role, idempotent on second call