### PR TITLE
fix: cookbook saga diagram improvements and party account linking

### DIFF
--- a/frontend/src/features/cookbook/components/linked-detail.test.tsx
+++ b/frontend/src/features/cookbook/components/linked-detail.test.tsx
@@ -96,13 +96,13 @@ describe('LinkedPatternDetail', () => {
   })
 
   it('renders diagram and handler reference panels', () => {
-    render(<LinkedPatternDetail flow={sampleFlow} />)
+    render(<LinkedPatternDetail flows={[sampleFlow]} />)
     expect(screen.getByTestId('react-flow')).toBeInTheDocument()
     expect(screen.getByTestId('handler-reference')).toBeInTheDocument()
   })
 
   it('renders full-width layout without editor panel', () => {
-    const { container } = render(<LinkedPatternDetail flow={sampleFlow} />)
+    const { container } = render(<LinkedPatternDetail flows={[sampleFlow]} />)
     const detail = container.querySelector('[data-testid="linked-detail"]')
     expect(detail).toBeInTheDocument()
     // Should not contain starlark editor
@@ -110,7 +110,7 @@ describe('LinkedPatternDetail', () => {
   })
 
   it('highlights handler reference when step is clicked in diagram', () => {
-    render(<LinkedPatternDetail flow={sampleFlow} />)
+    render(<LinkedPatternDetail flows={[sampleFlow]} />)
 
     const stepNode = screen.getByTestId('flow-node-step-0')
     fireEvent.click(stepNode)
@@ -120,7 +120,7 @@ describe('LinkedPatternDetail', () => {
   })
 
   it('updates selected step state when diagram step is clicked', () => {
-    render(<LinkedPatternDetail flow={sampleFlow} />)
+    render(<LinkedPatternDetail flows={[sampleFlow]} />)
 
     const step1 = screen.getByTestId('flow-node-step-1')
     fireEvent.click(step1)
@@ -130,7 +130,7 @@ describe('LinkedPatternDetail', () => {
   })
 
   it('passes service names to handler reference from flow', () => {
-    render(<LinkedPatternDetail flow={sampleFlow} />)
+    render(<LinkedPatternDetail flows={[sampleFlow]} />)
 
     const handlerRef = screen.getByTestId('handler-reference')
     const services = handlerRef.dataset.services?.split(',') ?? []
@@ -147,7 +147,7 @@ describe('LinkedPatternDetail', () => {
       ],
     }
 
-    render(<LinkedPatternDetail flow={flowWithNoop} />)
+    render(<LinkedPatternDetail flows={[flowWithNoop]} />)
 
     fireEvent.click(screen.getByTestId('flow-node-step-0'))
     expect(screen.getByTestId('handler-reference').dataset.highlighted).toBe('position_keeping.initiate_log')
@@ -164,7 +164,7 @@ describe('LinkedPatternDetail', () => {
       steps: [],
     }
 
-    render(<LinkedPatternDetail flow={emptyFlow} />)
+    render(<LinkedPatternDetail flows={[emptyFlow]} />)
 
     expect(screen.getByTestId('linked-detail')).toBeInTheDocument()
   })

--- a/frontend/src/features/cookbook/components/linked-detail.tsx
+++ b/frontend/src/features/cookbook/components/linked-detail.tsx
@@ -4,37 +4,42 @@ import { SagaFlowDiagram } from './saga-flow'
 import type { SagaFlow } from '../lib/star-parser'
 
 interface LinkedPatternDetailProps {
-  flow: SagaFlow
+  flows: SagaFlow[]
 }
 
-export function LinkedPatternDetail({ flow }: LinkedPatternDetailProps) {
+export function LinkedPatternDetail({ flows }: LinkedPatternDetailProps) {
   const [highlightedHandler, setHighlightedHandler] = useState<string | null>(null)
 
   const serviceNames = useMemo(() => {
     const names = new Set<string>()
-    for (const step of flow.steps) {
-      for (const call of step.serviceCalls) {
-        names.add(call.service)
+    for (const flow of flows) {
+      for (const step of flow.steps) {
+        for (const call of step.serviceCalls) {
+          names.add(call.service)
+        }
       }
     }
     return Array.from(names)
-  }, [flow])
+  }, [flows])
 
   const handleStepClick = useCallback((_stepName: string, _lineNumber: number) => {
-    const step = flow.steps.find((s) => s.name === _stepName)
-    if (step && step.serviceCalls.length > 0) {
-      const firstCall = step.serviceCalls[0]
-      setHighlightedHandler(`${firstCall.service}.${firstCall.method}`)
-    } else {
-      setHighlightedHandler(null)
+    // Find the step across all flows
+    for (const flow of flows) {
+      const step = flow.steps.find((s) => s.name === _stepName)
+      if (step && step.serviceCalls.length > 0) {
+        const firstCall = step.serviceCalls[0]
+        setHighlightedHandler(`${firstCall.service}.${firstCall.method}`)
+        return
+      }
     }
-  }, [flow])
+    setHighlightedHandler(null)
+  }, [flows])
 
   return (
     <div data-testid="linked-detail" className="flex flex-col gap-4">
       <div className="h-[400px] rounded-lg border">
         <SagaFlowDiagram
-          flow={flow}
+          flows={flows}
           onStepClick={handleStepClick}
         />
       </div>

--- a/frontend/src/features/cookbook/components/saga-flow.test.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.test.tsx
@@ -210,7 +210,7 @@ describe('SagaFlowDiagram', () => {
 
 describe('parseTriggerService', () => {
   it('extracts service from event trigger', () => {
-    expect(parseTriggerService('event:position-keeping.transaction-captured.v1')).toBe('position-keeping')
+    expect(parseTriggerService('event:position-keeping.transaction-captured.v1')).toBe('position_keeping')
   })
 
   it('extracts service from webhook trigger', () => {

--- a/frontend/src/features/cookbook/components/saga-flow.test.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.test.tsx
@@ -108,66 +108,80 @@ const flowWithEarlyExit: SagaFlow = {
   ],
 }
 
+const secondFlow: SagaFlow = {
+  name: 'settlement',
+  trigger: 'event:position-keeping.transaction-captured.v1',
+  filter: null,
+  steps: [
+    {
+      name: 'compute_value',
+      lineNumber: 3,
+      serviceCalls: [{ service: 'valuation_engine', method: 'compute', params: ['amount'] }],
+      earlyExit: null,
+    },
+  ],
+}
+
 describe('SagaFlowDiagram', () => {
   it('renders ReactFlow container', () => {
-    render(<SagaFlowDiagram flow={emptyFlow} />)
+    render(<SagaFlowDiagram flows={[emptyFlow]} />)
     expect(screen.getByTestId('react-flow')).toBeInTheDocument()
   })
 
   it('renders start and end nodes for empty flow', () => {
-    render(<SagaFlowDiagram flow={emptyFlow} />)
+    render(<SagaFlowDiagram flows={[emptyFlow]} />)
     expect(screen.getByTestId('node-start')).toBeInTheDocument()
     expect(screen.getByTestId('node-end')).toBeInTheDocument()
   })
 
   it('renders step nodes for each step', () => {
-    render(<SagaFlowDiagram flow={simpleFlow} />)
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
     expect(screen.getByTestId('node-step-0')).toBeInTheDocument()
     expect(screen.getByTestId('node-step-1')).toBeInTheDocument()
   })
 
   it('displays step names', () => {
-    render(<SagaFlowDiagram flow={simpleFlow} />)
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
     expect(screen.getByText('lookup_account')).toBeInTheDocument()
     expect(screen.getByText('book_position')).toBeInTheDocument()
   })
 
   it('displays saga name in start node', () => {
-    render(<SagaFlowDiagram flow={simpleFlow} />)
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
     expect(screen.getByText('deposit')).toBeInTheDocument()
   })
 
   it('renders decision and exit nodes for early exit', () => {
-    render(<SagaFlowDiagram flow={flowWithEarlyExit} />)
+    render(<SagaFlowDiagram flows={[flowWithEarlyExit]} />)
     expect(screen.getByTestId('node-decision-0')).toBeInTheDocument()
     expect(screen.getByTestId('node-exit-0')).toBeInTheDocument()
   })
 
   it('renders controls', () => {
-    render(<SagaFlowDiagram flow={simpleFlow} />)
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
     expect(screen.getByTestId('controls')).toBeInTheDocument()
   })
 
   it('renders services legend', () => {
-    render(<SagaFlowDiagram flow={simpleFlow} />)
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
     expect(screen.getByText('reference_data')).toBeInTheDocument()
     expect(screen.getByText('position_keeping')).toBeInTheDocument()
   })
 
   it('shows correct node count', () => {
-    render(<SagaFlowDiagram flow={simpleFlow} />)
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
     // start + 2 steps + end = 4 nodes
     expect(screen.getByTestId('react-flow')).toHaveAttribute('data-node-count', '4')
   })
 
   it('shows correct edge count for simple flow', () => {
-    render(<SagaFlowDiagram flow={simpleFlow} />)
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
     // start->step0, step0->step1, step1->end = 3 edges
     expect(screen.getByTestId('react-flow')).toHaveAttribute('data-edge-count', '3')
   })
 
   it('renders service legend items as clickable buttons', () => {
-    render(<SagaFlowDiagram flow={simpleFlow} />)
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
     const refDataBtn = screen.getByRole('button', { name: /reference_data/ })
     expect(refDataBtn).toBeInTheDocument()
     const posKeepBtn = screen.getByRole('button', { name: /position_keeping/ })
@@ -175,7 +189,7 @@ describe('SagaFlowDiagram', () => {
   })
 
   it('toggles service highlight on legend click', () => {
-    render(<SagaFlowDiagram flow={simpleFlow} />)
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
     const refDataBtn = screen.getByRole('button', { name: /reference_data/ })
 
     // Click to highlight
@@ -188,7 +202,7 @@ describe('SagaFlowDiagram', () => {
   })
 
   it('assigns distinct colors to different services', () => {
-    render(<SagaFlowDiagram flow={simpleFlow} />)
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
     const refDataBtn = screen.getByRole('button', { name: /reference_data/ })
     const posKeepBtn = screen.getByRole('button', { name: /position_keeping/ })
     const refDot = refDataBtn.querySelector('span[class*="rounded-full"]')
@@ -197,14 +211,44 @@ describe('SagaFlowDiagram', () => {
   })
 
   it('includes trigger service in legend', () => {
-    render(<SagaFlowDiagram flow={simpleFlow} />)
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
     // simpleFlow has trigger "event:payments.received.v1" → service "payments"
     expect(screen.getByRole('button', { name: /payments/ })).toBeInTheDocument()
   })
 
   it('shows trigger label next to trigger service in legend', () => {
-    render(<SagaFlowDiagram flow={simpleFlow} />)
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
     expect(screen.getByText('trigger')).toBeInTheDocument()
+  })
+
+  // Multi-saga tests
+  it('renders multiple sagas with prefixed node IDs', () => {
+    render(<SagaFlowDiagram flows={[simpleFlow, secondFlow]} />)
+    // First saga: s0-start, s0-step-0, s0-step-1, s0-end
+    expect(screen.getByTestId('node-s0-start')).toBeInTheDocument()
+    expect(screen.getByTestId('node-s0-step-0')).toBeInTheDocument()
+    // Second saga: s1-start, s1-step-0, s1-end
+    expect(screen.getByTestId('node-s1-start')).toBeInTheDocument()
+    expect(screen.getByTestId('node-s1-step-0')).toBeInTheDocument()
+  })
+
+  it('shows saga legend for multi-saga patterns', () => {
+    render(<SagaFlowDiagram flows={[simpleFlow, secondFlow]} />)
+    expect(screen.getByText('Sagas')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /deposit/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /settlement/ })).toBeInTheDocument()
+  })
+
+  it('does not show saga legend for single saga', () => {
+    render(<SagaFlowDiagram flows={[simpleFlow]} />)
+    expect(screen.queryByText('Sagas')).not.toBeInTheDocument()
+  })
+
+  it('merges services from all sagas into one legend', () => {
+    render(<SagaFlowDiagram flows={[simpleFlow, secondFlow]} />)
+    // Services from both: payments (trigger), reference_data, position_keeping, valuation_engine
+    expect(screen.getByRole('button', { name: /valuation_engine/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reference_data/ })).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -26,21 +26,39 @@ const SERVICE_PALETTE = [
   { bg: 'hsl(330, 60%, 92%)', fg: 'hsl(330, 60%, 45%)' },  // Pink
 ]
 
-function buildServiceColorMap(flow: SagaFlow): Map<string, { bg: string; fg: string }> {
+// Separate palette for saga highlighting (border/outline colors)
+const SAGA_PALETTE = [
+  'hsl(220, 70%, 50%)',   // Blue
+  'hsl(150, 60%, 40%)',   // Green
+  'hsl(30, 80%, 50%)',    // Orange
+  'hsl(280, 60%, 50%)',   // Purple
+  'hsl(0, 70%, 50%)',     // Red
+  'hsl(180, 60%, 40%)',   // Teal
+]
+
+function buildServiceColorMap(flows: SagaFlow[]): Map<string, { bg: string; fg: string }> {
   const services = new Set<string>()
-  // Include trigger producing service
-  const triggerSvc = parseTriggerService(flow.trigger)
-  if (triggerSvc) services.add(triggerSvc)
-  // Include called services
-  for (const step of flow.steps) {
-    for (const call of step.serviceCalls) {
-      services.add(call.service)
+  for (const flow of flows) {
+    const triggerSvc = parseTriggerService(flow.trigger)
+    if (triggerSvc) services.add(triggerSvc)
+    for (const step of flow.steps) {
+      for (const call of step.serviceCalls) {
+        services.add(call.service)
+      }
     }
   }
   const sorted = [...services].sort()
   const map = new Map<string, { bg: string; fg: string }>()
   sorted.forEach((svc, i) => {
     map.set(svc, SERVICE_PALETTE[i % SERVICE_PALETTE.length])
+  })
+  return map
+}
+
+function buildSagaColorMap(flows: SagaFlow[]): Map<string, string> {
+  const map = new Map<string, string>()
+  flows.forEach((flow, i) => {
+    map.set(flow.name, SAGA_PALETTE[i % SAGA_PALETTE.length])
   })
   return map
 }
@@ -53,21 +71,31 @@ interface StartNodeData {
   triggerService: string | null
   serviceColors: Map<string, { bg: string; fg: string }>
   highlightedService: string | null
+  sagaName: string
+  highlightedSaga: string | null
+  sagaColor: string | undefined
   [key: string]: unknown
 }
 
 function StartNode({ data }: { data: StartNodeData }) {
   const triggerColors = data.triggerService ? data.serviceColors.get(data.triggerService) : undefined
   const isTriggerHighlighted = data.highlightedService === data.triggerService && data.triggerService != null
-  const dimmed = data.highlightedService && !isTriggerHighlighted
+  const dimmedByService = data.highlightedService && !isTriggerHighlighted
+  const dimmedBySaga = data.highlightedSaga && data.highlightedSaga !== data.sagaName
+  const dimmed = dimmedByService || dimmedBySaga
 
   return (
     <>
       <div
         className={`flex flex-col items-center justify-center rounded-full border-2 border-emerald-500 bg-emerald-50 px-4 py-2 dark:bg-emerald-950/40 transition-opacity ${dimmed ? 'opacity-30' : 'opacity-100'}`}
-        style={isTriggerHighlighted && triggerColors
-          ? { borderColor: triggerColors.fg, boxShadow: `0 0 0 2px ${triggerColors.fg}`, outline: `2px solid ${triggerColors.fg}`, outlineOffset: '2px' }
-          : {}}
+        style={{
+          ...(isTriggerHighlighted && triggerColors
+            ? { borderColor: triggerColors.fg, boxShadow: `0 0 0 2px ${triggerColors.fg}`, outline: `2px solid ${triggerColors.fg}`, outlineOffset: '2px' }
+            : {}),
+          ...(data.highlightedSaga === data.sagaName && data.sagaColor
+            ? { borderColor: data.sagaColor, boxShadow: `0 0 0 2px ${data.sagaColor}` }
+            : {}),
+        }}
       >
         <span className="text-xs font-semibold text-emerald-700 dark:text-emerald-300">{data.label}</span>
         {data.trigger && (
@@ -91,6 +119,9 @@ interface StepNodeData {
   serviceCalls: { service: string; method: string }[]
   serviceColors: Map<string, { bg: string; fg: string }>
   highlightedService: string | null
+  sagaName: string
+  highlightedSaga: string | null
+  sagaColor: string | undefined
   [key: string]: unknown
 }
 
@@ -102,7 +133,13 @@ function StepNode({ data }: { data: StepNodeData }) {
   const usesHighlighted = data.highlightedService
     ? data.serviceCalls.some((c) => c.service === data.highlightedService)
     : true
-  const dimmed = data.highlightedService && !usesHighlighted
+  const dimmedByService = data.highlightedService && !usesHighlighted
+  const dimmedBySaga = data.highlightedSaga && data.highlightedSaga !== data.sagaName
+  const dimmed = dimmedByService || dimmedBySaga
+
+  const activeBorder = data.highlightedSaga === data.sagaName && data.sagaColor
+    ? data.sagaColor
+    : (data.highlightedService && usesHighlighted ? borderColor : undefined)
 
   return (
     <>
@@ -111,8 +148,8 @@ function StepNode({ data }: { data: StepNodeData }) {
         className={`flex flex-col gap-1 rounded-lg border-2 bg-background px-3 py-2 shadow-sm min-w-[180px] transition-opacity ${dimmed ? 'opacity-30' : 'opacity-100'}`}
         style={{
           borderColor,
-          ...(data.highlightedService && usesHighlighted
-            ? { boxShadow: `0 0 0 2px ${borderColor}`, outline: `2px solid ${borderColor}`, outlineOffset: '2px' }
+          ...(activeBorder
+            ? { boxShadow: `0 0 0 2px ${activeBorder}`, outline: `2px solid ${activeBorder}`, outlineOffset: '2px' }
             : {}),
         }}
       >
@@ -144,15 +181,18 @@ function StepNode({ data }: { data: StepNodeData }) {
 
 interface DecisionNodeData {
   label: string
+  sagaName: string
+  highlightedSaga: string | null
   [key: string]: unknown
 }
 
 function DecisionNode({ data }: { data: DecisionNodeData }) {
+  const dimmed = data.highlightedSaga && data.highlightedSaga !== data.sagaName
   return (
     <>
       <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
       <div
-        className="flex items-center justify-center border-2 border-amber-500 bg-amber-50 dark:bg-amber-950/40"
+        className={`flex items-center justify-center border-2 border-amber-500 bg-amber-50 dark:bg-amber-950/40 transition-opacity ${dimmed ? 'opacity-30' : 'opacity-100'}`}
         style={{
           width: 120,
           height: 80,
@@ -171,25 +211,35 @@ function DecisionNode({ data }: { data: DecisionNodeData }) {
 
 interface ExitNodeData {
   label: string
+  sagaName: string
+  highlightedSaga: string | null
   [key: string]: unknown
 }
 
 function ExitNode({ data }: { data: ExitNodeData }) {
+  const dimmed = data.highlightedSaga && data.highlightedSaga !== data.sagaName
   return (
     <>
       <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
-      <div className="flex items-center justify-center rounded-full border-2 border-red-500 bg-red-50 px-3 py-1.5 dark:bg-red-950/40">
+      <div className={`flex items-center justify-center rounded-full border-2 border-red-500 bg-red-50 px-3 py-1.5 dark:bg-red-950/40 transition-opacity ${dimmed ? 'opacity-30' : 'opacity-100'}`}>
         <span className="text-[10px] font-semibold text-red-700 dark:text-red-300">{data.label}</span>
       </div>
     </>
   )
 }
 
-function EndNode() {
+interface EndNodeData {
+  sagaName: string
+  highlightedSaga: string | null
+  [key: string]: unknown
+}
+
+function EndNode({ data }: { data: EndNodeData }) {
+  const dimmed = data.highlightedSaga && data.highlightedSaga !== data.sagaName
   return (
     <>
       <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
-      <div className="flex items-center justify-center rounded-full border-2 border-slate-500 bg-slate-100 px-4 py-2 dark:bg-slate-800">
+      <div className={`flex items-center justify-center rounded-full border-2 border-slate-500 bg-slate-100 px-4 py-2 dark:bg-slate-800 transition-opacity ${dimmed ? 'opacity-30' : 'opacity-100'}`}>
         <span className="text-xs font-semibold text-slate-600 dark:text-slate-300">COMPLETED</span>
       </div>
     </>
@@ -242,136 +292,144 @@ function layoutNodes(nodes: Node[], edges: Edge[]): Node[] {
   })
 }
 
-// --- Build Graph from SagaFlow ---
+// --- Build Combined Graph from multiple SagaFlows ---
 
-function buildFlowGraph(
-  flow: SagaFlow,
+function buildCombinedFlowGraph(
+  flows: SagaFlow[],
   serviceColors: Map<string, { bg: string; fg: string }>,
+  sagaColors: Map<string, string>,
   highlightedService: string | null,
+  highlightedSaga: string | null,
 ): { nodes: Node[]; edges: Edge[] } {
   const nodes: Node[] = []
   const edges: Edge[] = []
 
-  const triggerService = parseTriggerService(flow.trigger)
+  for (let fi = 0; fi < flows.length; fi++) {
+    const flow = flows[fi]
+    const prefix = flows.length > 1 ? `s${fi}-` : ''
+    const triggerService = parseTriggerService(flow.trigger)
+    const sagaColor = sagaColors.get(flow.name)
 
-  // Start node
-  nodes.push({
-    id: 'start',
-    type: 'sagaStart',
-    position: { x: 0, y: 0 },
-    data: {
-      label: flow.name,
-      trigger: flow.trigger,
-      triggerService,
-      serviceColors,
-      highlightedService,
-    } satisfies StartNodeData,
-  })
-
-  if (flow.steps.length === 0) {
+    // Start node
     nodes.push({
-      id: 'end',
-      type: 'sagaEnd',
-      position: { x: 0, y: 0 },
-      data: {},
-    })
-    edges.push({ id: 'start-end', source: 'start', target: 'end' })
-    return { nodes: layoutNodes(nodes, edges), edges }
-  }
-
-  // Step + decision + exit nodes
-  let prevId: string | null = 'start'
-
-  for (let i = 0; i < flow.steps.length; i++) {
-    const step = flow.steps[i]
-    const stepId = `step-${i}`
-    const nextId = i + 1 < flow.steps.length ? `step-${i + 1}` : 'end'
-
-    nodes.push({
-      id: stepId,
-      type: 'sagaStep',
+      id: `${prefix}start`,
+      type: 'sagaStart',
       position: { x: 0, y: 0 },
       data: {
-        label: step.name,
-        serviceCalls: step.serviceCalls,
+        label: flow.name,
+        trigger: flow.trigger,
+        triggerService,
         serviceColors,
         highlightedService,
-      } satisfies StepNodeData,
+        sagaName: flow.name,
+        highlightedSaga,
+        sagaColor,
+      } satisfies StartNodeData,
     })
 
-    // Connect from previous node (null when previous decision's "No" edge already connects)
+    if (flow.steps.length === 0) {
+      nodes.push({
+        id: `${prefix}end`,
+        type: 'sagaEnd',
+        position: { x: 0, y: 0 },
+        data: { sagaName: flow.name, highlightedSaga } satisfies EndNodeData,
+      })
+      edges.push({ id: `${prefix}start-end`, source: `${prefix}start`, target: `${prefix}end` })
+      continue
+    }
+
+    let prevId: string | null = `${prefix}start`
+
+    for (let i = 0; i < flow.steps.length; i++) {
+      const step = flow.steps[i]
+      const stepId = `${prefix}step-${i}`
+      const nextId = i + 1 < flow.steps.length ? `${prefix}step-${i + 1}` : `${prefix}end`
+
+      nodes.push({
+        id: stepId,
+        type: 'sagaStep',
+        position: { x: 0, y: 0 },
+        data: {
+          label: step.name,
+          serviceCalls: step.serviceCalls,
+          serviceColors,
+          highlightedService,
+          sagaName: flow.name,
+          highlightedSaga,
+          sagaColor,
+        } satisfies StepNodeData,
+      })
+
+      if (prevId) {
+        edges.push({
+          id: `${prevId}-${stepId}`,
+          source: prevId,
+          target: stepId,
+        })
+      }
+
+      if (step.earlyExit) {
+        const decisionId = `${prefix}decision-${i}`
+        const exitId = `${prefix}exit-${i}`
+
+        nodes.push({
+          id: decisionId,
+          type: 'sagaDecision',
+          position: { x: 0, y: 0 },
+          data: { label: step.earlyExit.condition, sagaName: flow.name, highlightedSaga } satisfies DecisionNodeData,
+        })
+
+        nodes.push({
+          id: exitId,
+          type: 'sagaExit',
+          position: { x: 0, y: 0 },
+          data: { label: step.earlyExit.returnStatus, sagaName: flow.name, highlightedSaga } satisfies ExitNodeData,
+        })
+
+        edges.push({
+          id: `${stepId}-${decisionId}`,
+          source: stepId,
+          target: decisionId,
+        })
+
+        edges.push({
+          id: `${decisionId}-${exitId}`,
+          source: decisionId,
+          sourceHandle: 'exit',
+          target: exitId,
+          label: 'Yes',
+          style: { stroke: '#ef4444', strokeDasharray: '6 3' },
+        })
+
+        edges.push({
+          id: `${decisionId}-${nextId}`,
+          source: decisionId,
+          sourceHandle: 'no',
+          target: nextId,
+          label: 'No',
+        })
+
+        prevId = null
+      } else {
+        prevId = stepId
+      }
+    }
+
+    // End node
+    nodes.push({
+      id: `${prefix}end`,
+      type: 'sagaEnd',
+      position: { x: 0, y: 0 },
+      data: { sagaName: flow.name, highlightedSaga } satisfies EndNodeData,
+    })
+
     if (prevId) {
       edges.push({
-        id: `${prevId}-${stepId}`,
+        id: `${prevId}-${prefix}end`,
         source: prevId,
-        target: stepId,
+        target: `${prefix}end`,
       })
     }
-
-    if (step.earlyExit) {
-      const decisionId = `decision-${i}`
-      const exitId = `exit-${i}`
-
-      nodes.push({
-        id: decisionId,
-        type: 'sagaDecision',
-        position: { x: 0, y: 0 },
-        data: { label: step.earlyExit.condition } satisfies DecisionNodeData,
-      })
-
-      nodes.push({
-        id: exitId,
-        type: 'sagaExit',
-        position: { x: 0, y: 0 },
-        data: { label: step.earlyExit.returnStatus } satisfies ExitNodeData,
-      })
-
-      edges.push({
-        id: `${stepId}-${decisionId}`,
-        source: stepId,
-        target: decisionId,
-      })
-
-      // "Yes" -> exit
-      edges.push({
-        id: `${decisionId}-${exitId}`,
-        source: decisionId,
-        sourceHandle: 'exit',
-        target: exitId,
-        label: 'Yes',
-        style: { stroke: '#ef4444', strokeDasharray: '6 3' },
-      })
-
-      // "No" -> next step (already connects to nextId, so skip prevId for next iteration)
-      edges.push({
-        id: `${decisionId}-${nextId}`,
-        source: decisionId,
-        sourceHandle: 'no',
-        target: nextId,
-        label: 'No',
-      })
-
-      prevId = null
-    } else {
-      prevId = stepId
-    }
-  }
-
-  // End node
-  nodes.push({
-    id: 'end',
-    type: 'sagaEnd',
-    position: { x: 0, y: 0 },
-    data: {},
-  })
-
-  // Connect last step to end (only if no early exit on last step already connected it)
-  if (prevId) {
-    edges.push({
-      id: `${prevId}-end`,
-      source: prevId,
-      target: 'end',
-    })
   }
 
   return { nodes: layoutNodes(nodes, edges), edges }
@@ -380,28 +438,42 @@ function buildFlowGraph(
 // --- Component ---
 
 interface SagaFlowDiagramProps {
-  flow: SagaFlow
+  flows: SagaFlow[]
   onStepClick?: (stepName: string, lineNumber: number) => void
   className?: string
 }
 
-export function SagaFlowDiagram({ flow, onStepClick, className }: SagaFlowDiagramProps) {
+export function SagaFlowDiagram({ flows, onStepClick, className }: SagaFlowDiagramProps) {
   const [highlightedService, setHighlightedService] = useState<string | null>(null)
+  const [highlightedSaga, setHighlightedSaga] = useState<string | null>(null)
 
-  const serviceColors = useMemo(() => buildServiceColorMap(flow), [flow])
+  const serviceColors = useMemo(() => buildServiceColorMap(flows), [flows])
+  const sagaColors = useMemo(() => buildSagaColorMap(flows), [flows])
 
-  // Derive effective highlight — auto-clears when selected service no longer exists
-  const effectiveHighlight = highlightedService && serviceColors.has(highlightedService)
+  const effectiveServiceHighlight = highlightedService && serviceColors.has(highlightedService)
     ? highlightedService
     : null
 
+  const effectiveSagaHighlight = highlightedSaga && sagaColors.has(highlightedSaga)
+    ? highlightedSaga
+    : null
+
   const { nodes, edges } = useMemo(
-    () => buildFlowGraph(flow, serviceColors, effectiveHighlight),
-    [flow, serviceColors, effectiveHighlight],
+    () => buildCombinedFlowGraph(flows, serviceColors, sagaColors, effectiveServiceHighlight, effectiveSagaHighlight),
+    [flows, serviceColors, sagaColors, effectiveServiceHighlight, effectiveSagaHighlight],
   )
 
-  // Collect unique services for the legend
   const services = useMemo(() => [...serviceColors.keys()].sort(), [serviceColors])
+
+  // Collect all trigger services for labeling
+  const triggerServices = useMemo(() => {
+    const set = new Set<string>()
+    for (const flow of flows) {
+      const svc = parseTriggerService(flow.trigger)
+      if (svc) set.add(svc)
+    }
+    return set
+  }, [flows])
 
   return (
     <div className={`relative ${className ?? ''}`} style={{ width: '100%', height: '100%', minHeight: 300 }}>
@@ -411,8 +483,13 @@ export function SagaFlowDiagram({ flow, onStepClick, className }: SagaFlowDiagra
         nodeTypes={nodeTypes}
         onNodeClick={(_event, node) => {
           if (node.type === 'sagaStep' && onStepClick) {
-            const stepIndex = parseInt(node.id.replace('step-', ''), 10)
-            const step = flow.steps[stepIndex]
+            // Extract step index — node id is either "step-N" or "sN-step-N"
+            const parts = node.id.split('step-')
+            const stepIndex = parseInt(parts[parts.length - 1], 10)
+            // Find which flow this node belongs to
+            const sagaName = (node.data as StepNodeData).sagaName
+            const flow = flows.find((f) => f.name === sagaName)
+            const step = flow?.steps[stepIndex]
             if (step) onStepClick(step.name, step.lineNumber)
           }
         }}
@@ -425,33 +502,70 @@ export function SagaFlowDiagram({ flow, onStepClick, className }: SagaFlowDiagra
         <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
       </ReactFlow>
 
-      {services.length > 0 && (
-        <div className="absolute bottom-3 left-3 z-10 flex flex-col gap-1 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm">
-          <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">Services</span>
-          {services.map((svc) => {
-            const colors = serviceColors.get(svc)
-            const isActive = effectiveHighlight === svc
-            return (
-              <button
-                key={svc}
-                type="button"
-                aria-pressed={isActive}
-                className={`flex items-center gap-2 cursor-pointer rounded px-1 -mx-1 transition-colors hover:bg-muted/50 ${isActive ? 'font-semibold' : ''}`}
-                onClick={() => setHighlightedService((prev) => (prev === svc ? null : svc))}
-              >
-                <span
-                  className={`inline-block h-2.5 w-2.5 rounded-full ${isActive ? 'ring-2 ring-offset-1' : ''}`}
-                  style={{ backgroundColor: colors?.fg }}
-                />
-                <span className="text-xs text-muted-foreground">{svc}</span>
-                {svc === parseTriggerService(flow.trigger) && (
-                  <span className="text-[9px] text-muted-foreground/60 italic">trigger</span>
-                )}
-              </button>
-            )
-          })}
-        </div>
-      )}
+      {/* Legend panel */}
+      <div className="absolute bottom-3 left-3 z-10 flex flex-col gap-2 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm max-w-[200px]">
+        {/* Saga filter (only shown for multi-saga patterns) */}
+        {flows.length > 1 && (
+          <div className="flex flex-col gap-1">
+            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Sagas</span>
+            {flows.map((flow) => {
+              const color = sagaColors.get(flow.name)
+              const isActive = effectiveSagaHighlight === flow.name
+              return (
+                <button
+                  key={flow.name}
+                  type="button"
+                  aria-pressed={isActive}
+                  className={`flex items-center gap-2 cursor-pointer rounded px-1 -mx-1 transition-colors hover:bg-muted/50 ${isActive ? 'font-semibold' : ''}`}
+                  onClick={() => {
+                    setHighlightedSaga((prev) => (prev === flow.name ? null : flow.name))
+                    setHighlightedService(null)
+                  }}
+                >
+                  <span
+                    className={`inline-block h-2.5 w-2.5 rounded-sm ${isActive ? 'ring-2 ring-offset-1' : ''}`}
+                    style={{ backgroundColor: color }}
+                  />
+                  <span className="text-xs text-muted-foreground truncate">{flow.name}</span>
+                </button>
+              )
+            })}
+          </div>
+        )}
+
+        {/* Service filter */}
+        {services.length > 0 && (
+          <div className="flex flex-col gap-1">
+            {flows.length > 1 && <div className="border-t my-1" />}
+            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Services</span>
+            {services.map((svc) => {
+              const colors = serviceColors.get(svc)
+              const isActive = effectiveServiceHighlight === svc
+              return (
+                <button
+                  key={svc}
+                  type="button"
+                  aria-pressed={isActive}
+                  className={`flex items-center gap-2 cursor-pointer rounded px-1 -mx-1 transition-colors hover:bg-muted/50 ${isActive ? 'font-semibold' : ''}`}
+                  onClick={() => {
+                    setHighlightedService((prev) => (prev === svc ? null : svc))
+                    setHighlightedSaga(null)
+                  }}
+                >
+                  <span
+                    className={`inline-block h-2.5 w-2.5 rounded-full ${isActive ? 'ring-2 ring-offset-1' : ''}`}
+                    style={{ backgroundColor: colors?.fg }}
+                  />
+                  <span className="text-xs text-muted-foreground">{svc}</span>
+                  {triggerServices.has(svc) && (
+                    <span className="text-[9px] text-muted-foreground/60 italic">trigger</span>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/frontend/src/features/cookbook/hooks/use-pattern-files.ts
+++ b/frontend/src/features/cookbook/hooks/use-pattern-files.ts
@@ -7,9 +7,16 @@ export interface StarlarkFile {
   content: string
 }
 
+export interface ManifestSaga {
+  name?: string
+  trigger?: string
+  filter?: string
+}
+
 export interface PatternFilesState {
   starlarkFiles: StarlarkFile[]
   manifestContent: string | null
+  manifestSagas: ManifestSaga[]
   hasSagas: boolean
   sagaTrigger: string | null
   isLoading: false
@@ -19,12 +26,6 @@ function isValidContent(content: string | undefined): content is string {
   if (!content) return false
   const trimmed = content.trimStart()
   return !trimmed.startsWith('<!DOCTYPE') && !trimmed.startsWith('<html')
-}
-
-interface ManifestSaga {
-  name?: string
-  trigger?: string
-  filter?: string
 }
 
 function parseManifestSagas(manifestContent: string | null): ManifestSaga[] {
@@ -42,7 +43,7 @@ function parseManifestSagas(manifestContent: string | null): ManifestSaga[] {
 
 export function usePatternFiles(item: CookbookItem | undefined): PatternFilesState {
   return useMemo(() => {
-    const empty: PatternFilesState = { starlarkFiles: [], manifestContent: null, hasSagas: false, sagaTrigger: null, isLoading: false }
+    const empty: PatternFilesState = { starlarkFiles: [], manifestContent: null, manifestSagas: [], hasSagas: false, sagaTrigger: null, isLoading: false }
     if (!item || item.type !== 'registry:pattern') return empty
 
     const files = item.files ?? []
@@ -62,6 +63,6 @@ export function usePatternFiles(item: CookbookItem | undefined): PatternFilesSta
     const hasSagas = starlarkFiles.length > 0 || manifestSagas.length > 0
     const sagaTrigger = manifestSagas[0]?.trigger ?? null
 
-    return { starlarkFiles, manifestContent, hasSagas, sagaTrigger, isLoading: false }
+    return { starlarkFiles, manifestContent, manifestSagas, hasSagas, sagaTrigger, isLoading: false }
   }, [item])
 }

--- a/frontend/src/features/cookbook/lib/star-parser.ts
+++ b/frontend/src/features/cookbook/lib/star-parser.ts
@@ -1,6 +1,7 @@
 export {
   parseStarlarkSaga,
   parseTriggerService,
+  countFlowNodes,
 } from '@/lib/visualization/star-parser'
 
 export type {

--- a/frontend/src/features/cookbook/pages/detail.tsx
+++ b/frontend/src/features/cookbook/pages/detail.tsx
@@ -9,7 +9,8 @@ import { StarlarkEditor } from '@/features/sagas/components/starlark-editor'
 import { ManifestViewer } from '../components/manifest-viewer'
 import { ComponentDetail } from '../components/component-detail'
 import { LinkedPatternDetail } from '../components/linked-detail'
-import { parseStarlarkSaga } from '../lib/star-parser'
+import { parseStarlarkSaga, countFlowNodes } from '../lib/star-parser'
+import type { SagaFlow } from '../lib/star-parser'
 import { useCookbook } from '../hooks/use-cookbook'
 import type { CookbookItem, PatternMeta } from '../hooks/use-cookbook'
 import { usePatternFiles } from '../hooks/use-pattern-files'
@@ -27,17 +28,18 @@ function complexityColor(score: number): string {
   return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
 }
 
-function PatternInfoSection({ item }: { item: CookbookItem }) {
+function PatternInfoSection({ item, computedComplexity }: { item: CookbookItem; computedComplexity: number | null }) {
   const meta = item.meta as PatternMeta | undefined
+  const complexity = computedComplexity ?? meta?.complexity
 
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-2">
         <h1 className="text-2xl font-semibold">{item.title}</h1>
         <Badge variant="outline">{item.type === 'registry:pattern' ? 'Pattern' : 'UI Component'}</Badge>
-        {meta?.complexity != null && (
-          <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${complexityColor(meta.complexity)}`}>
-            Complexity: {meta.complexity} ({complexityLabel(meta.complexity)})
+        {complexity != null && (
+          <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${complexityColor(complexity)}`}>
+            Complexity: {complexity} ({complexityLabel(complexity)})
           </span>
         )}
       </div>
@@ -157,18 +159,18 @@ function CompositionSection({ meta }: { meta: PatternMeta }) {
   )
 }
 
-function HandlerReferenceTab({ starlarkContent }: { starlarkContent: string | null }) {
+function HandlerReferenceTab({ flows }: { flows: SagaFlow[] }) {
   const serviceNames = useMemo(() => {
-    if (!starlarkContent) return []
-    const flow = parseStarlarkSaga(starlarkContent)
     const names = new Set<string>()
-    for (const step of flow.steps) {
-      for (const call of step.serviceCalls) {
-        names.add(call.service)
+    for (const flow of flows) {
+      for (const step of flow.steps) {
+        for (const call of step.serviceCalls) {
+          names.add(call.service)
+        }
       }
     }
     return Array.from(names)
-  }, [starlarkContent])
+  }, [flows])
 
   return (
     <HandlerReference
@@ -217,17 +219,31 @@ export function CookbookDetailPage() {
   const { items, isLoading: catalogueLoading } = useCookbook()
 
   const item = items.find((i) => i.name === name)
-  const { starlarkFiles, manifestContent, hasSagas, sagaTrigger } = usePatternFiles(item)
+  const { starlarkFiles, manifestContent, manifestSagas, hasSagas } = usePatternFiles(item)
 
-  const firstStarlarkContent = starlarkFiles.length > 0 ? starlarkFiles[0].content : null
+  // Parse ALL starlark files into flows, matching each to its manifest saga trigger
+  const sagaFlows = useMemo(() => {
+    const flows: SagaFlow[] = []
+    for (const file of starlarkFiles) {
+      const flow = parseStarlarkSaga(file.content)
+      // Match this starlark file to its manifest saga by name to get the trigger
+      const manifestSaga = manifestSagas.find((ms) => ms.name === flow.name)
+      if (manifestSaga?.trigger) {
+        flow.trigger = manifestSaga.trigger
+      }
+      if (manifestSaga?.filter) {
+        flow.filter = manifestSaga.filter
+      }
+      flows.push(flow)
+    }
+    return flows
+  }, [starlarkFiles, manifestSagas])
 
-  const sagaFlow = useMemo(() => {
-    if (!firstStarlarkContent) return null
-    const flow = parseStarlarkSaga(firstStarlarkContent)
-    // Manifest YAML is source of truth for trigger
-    flow.trigger = sagaTrigger
-    return flow
-  }, [firstStarlarkContent, sagaTrigger])
+  // Auto-compute complexity from node count
+  const computedComplexity = useMemo(() => {
+    if (sagaFlows.length === 0) return null
+    return countFlowNodes(sagaFlows)
+  }, [sagaFlows])
 
   if (catalogueLoading) {
     return <DetailSkeleton fieldCount={3} tabCount={3} showBackNav />
@@ -250,11 +266,13 @@ export function CookbookDetailPage() {
     ? { label: 'Patterns', href: '/cookbook/patterns' }
     : { label: 'UI Components', href: '/cookbook/components' }
 
+  const hasFlowSteps = sagaFlows.some((f) => f.steps.length > 0)
+
   return (
     <div className="space-y-6">
       <Breadcrumbs items={[{ label: 'Cookbook', href: '/cookbook' }, parentSection, { label: item.title }]} />
 
-      <PatternInfoSection item={item} />
+      <PatternInfoSection item={item} computedComplexity={computedComplexity} />
 
       {isPattern ? (
         <Tabs defaultValue="manifest">
@@ -282,8 +300,8 @@ export function CookbookDetailPage() {
 
           {hasSagas && (
             <TabsContent value="flow" className="mt-4">
-              {sagaFlow && sagaFlow.steps.length > 0 && firstStarlarkContent ? (
-                <LinkedPatternDetail flow={sagaFlow} />
+              {hasFlowSteps ? (
+                <LinkedPatternDetail flows={sagaFlows} />
               ) : (
                 <p className="text-sm text-muted-foreground">No saga flow detected in Starlark source.</p>
               )}
@@ -292,7 +310,7 @@ export function CookbookDetailPage() {
 
           {hasSagas && (
             <TabsContent value="handlers" className="mt-4">
-              <HandlerReferenceTab starlarkContent={firstStarlarkContent} />
+              <HandlerReferenceTab flows={sagaFlows} />
             </TabsContent>
           )}
 

--- a/frontend/src/features/parties/pages/tabs/accounts-tab.tsx
+++ b/frontend/src/features/parties/pages/tabs/accounts-tab.tsx
@@ -93,7 +93,7 @@ export function AccountsTab({ partyId }: AccountsTabProps) {
         })
 
         for (const a of response.accounts ?? []) {
-          if (a.orgPartyId === partyId) {
+          if (a.orgPartyId === partyId || a.partyId === partyId) {
             collected.push({
               accountId: a.accountId,
               externalReference: a.externalIdentifier ?? '',

--- a/frontend/src/lib/visualization/index.ts
+++ b/frontend/src/lib/visualization/index.ts
@@ -1,4 +1,4 @@
-export { parseStarlarkSaga, parseTriggerService } from './star-parser'
+export { parseStarlarkSaga, parseTriggerService, countFlowNodes } from './star-parser'
 export type { SagaFlow, SagaFlowStep, ServiceCall, EarlyExit } from './star-parser'
 
 export { generateMermaidMarkup } from './saga-mermaid'

--- a/frontend/src/lib/visualization/star-parser.ts
+++ b/frontend/src/lib/visualization/star-parser.ts
@@ -52,6 +52,25 @@ export interface EarlyExit {
 }
 
 /**
+ * Count total diagram nodes for a set of saga flows.
+ * Nodes: 1 start + steps + decisions + exits + 1 end per saga.
+ */
+export function countFlowNodes(flows: SagaFlow[]): number {
+  let count = 0
+  for (const flow of flows) {
+    count += 1 // start node
+    count += 1 // end node
+    for (const step of flow.steps) {
+      count += 1 // step node
+      if (step.earlyExit) {
+        count += 2 // decision + exit nodes
+      }
+    }
+  }
+  return count
+}
+
+/**
  * Extract the producing service name from a trigger string.
  * Returns the service name in snake_case to match Starlark module names.
  * - "event:position-keeping.transaction-captured.v1" → "position_keeping"

--- a/frontend/src/lib/visualization/star-parser.ts
+++ b/frontend/src/lib/visualization/star-parser.ts
@@ -53,7 +53,8 @@ export interface EarlyExit {
 
 /**
  * Extract the producing service name from a trigger string.
- * - "event:position-keeping.transaction-captured.v1" → "position-keeping"
+ * Returns the service name in snake_case to match Starlark module names.
+ * - "event:position-keeping.transaction-captured.v1" → "position_keeping"
  * - "webhook:stripe.payment_intent.succeeded" → "stripe"
  * - "api:/v1/payments/stripe" → null (no service)
  */
@@ -62,7 +63,9 @@ export function parseTriggerService(trigger: string | null): string | null {
   if (trigger.startsWith('event:') || trigger.startsWith('webhook:')) {
     const rest = trigger.slice(trigger.indexOf(':') + 1)
     const dotIdx = rest.indexOf('.')
-    return dotIdx > 0 ? rest.slice(0, dotIdx) : rest
+    const raw = dotIdx > 0 ? rest.slice(0, dotIdx) : rest
+    // Normalize kebab-case topic prefix to snake_case Starlark module name
+    return raw.replace(/-/g, '_')
   }
   return null
 }


### PR DESCRIPTION
## Summary

- Normalize event topic service prefixes (kebab-case) to snake_case to match Starlark module names in the saga flow diagram legend
- Combine all sagas from a pattern into a single flow diagram with saga-level filter
- Auto-compute complexity score from diagram node count instead of static pattern.json value
- Fix party accounts tab to match accounts by both `partyId` and `orgPartyId`

## Changes

### Saga flow diagram: service name normalization
`parseTriggerService()` now converts kebab-case topic prefixes (e.g. `position-keeping`) to snake_case (`position_keeping`) so the trigger service and Starlark module calls are recognized as the same service.

### Combined multi-saga diagram
Patterns with multiple `.star` files (e.g. saas-billing with 3 sagas) now render all sagas in a single combined diagram. A **Sagas** legend (square indicators) lets you highlight nodes by source saga, alongside the existing **Services** legend (round indicators) for service highlighting. Single-saga patterns render identically to before.

### Auto-computed complexity
The detail page derives complexity from `countFlowNodes()` across all sagas (start + steps + decisions + exits + end per saga). The catalogue grid still uses the static `pattern.json` complexity for card display since file content isn't parsed at that level.

### Party accounts tab filter fix
`accounts-tab.tsx` was only matching `orgPartyId === partyId`, missing personal accounts that only have `partyId` set. Now matches on either field.

## Test plan

- [ ] Updated `parseTriggerService` test expectation for snake_case output
- [ ] Updated `SagaFlowDiagram` tests to use `flows` prop (array)
- [ ] Added multi-saga tests: prefixed node IDs, saga legend visibility, merged service legend
- [ ] Updated `LinkedPatternDetail` tests for `flows` prop
- [ ] TypeScript compiles with no errors
- [ ] Verify in cookbook UI: saas-billing shows 3 sagas in combined diagram
- [ ] Verify precious-metals shows single saga (no saga legend)
- [ ] Verify party detail page shows linked accounts for both personal and org accounts