### PR TITLE
feat: identity management UI - users list, detail, and invite

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import { AuthProvider, useAuth } from '@/contexts/auth-context'
 import { TenantProvider, useTenantContext } from '@/contexts/tenant-context'
 import { useTenants } from '@/hooks/use-tenants'
 import { ApiClientProvider } from '@/api/context'
-import { ProtectedRoute, PlatformOnlyRoute } from '@/components/routing'
+import { ProtectedRoute, PlatformOnlyRoute, AdminOnlyRoute } from '@/components/routing'
 import { FeatureGuard } from '@/components/feature-guard'
 import { AppShell } from '@/components/layout/app-shell'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -30,6 +30,7 @@ import { DashboardPage } from '@/features/dashboard'
 import { ManifestsPage } from '@/features/manifests'
 import { McpConfigPage } from '@/features/mcp-config'
 import { TransactionsPage } from '@/features/transactions'
+import { UsersListPage, UserDetailPage } from '@/features/identity'
 import { CookbookPage } from '@/features/cookbook'
 
 const CookbookPatternsPage = lazy(() =>
@@ -276,6 +277,24 @@ function AppShellLayout() {
         <Route path="/cookbook/graph" element={guarded(<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}><CookbookGraphPage /></Suspense>)} />
         <Route path="/cookbook/:name" element={guarded(<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}><CookbookDetailPage /></Suspense>)} />
         <Route path="/audit-log" element={<FeatureGuard feature="audit">{guarded(<AuditLogPage />)}</FeatureGuard>} />
+
+        {/* Admin-only routes */}
+        <Route
+          path="/users"
+          element={
+            <AdminOnlyRoute>
+              {guarded(<UsersListPage />)}
+            </AdminOnlyRoute>
+          }
+        />
+        <Route
+          path="/users/:userId"
+          element={
+            <AdminOnlyRoute>
+              {guarded(<UserDetailPage />)}
+            </AdminOnlyRoute>
+          }
+        />
 
         {/* Platform-only routes */}
         <Route

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Building2,
   Activity,
   Users,
+  UserCog,
   TrendingUp,
   BookOpen,
   Code,
@@ -68,6 +69,7 @@ const TENANT_NAV_GROUPS: NavGroup[] = [
   {
     label: 'Admin',
     items: [
+      { label: 'Users', href: '/users', icon: UserCog },
       { label: 'Audit Log', href: '/audit-log', icon: ClipboardList, feature: 'audit' },
     ],
   },

--- a/frontend/src/components/routing.tsx
+++ b/frontend/src/components/routing.tsx
@@ -33,3 +33,23 @@ export function PlatformOnlyRoute({ children }: PlatformOnlyRouteProps) {
   }
   return <>{children}</>
 }
+
+interface AdminOnlyRouteProps {
+  children: ReactNode
+}
+
+const ADMIN_ROLES = ['admin', 'tenant-admin', 'super-admin', 'platform-admin', 'tenant-owner']
+
+/**
+ * Redirects users without admin-level roles to /.
+ * Wrap routes that require admin access (e.g., identity management).
+ */
+export function AdminOnlyRoute({ children }: AdminOnlyRouteProps) {
+  const { claims, lens } = useAuth()
+  const roles = claims?.roles ?? []
+  const hasAdminRole = lens === 'platform' || roles.some((r) => ADMIN_ROLES.includes(r))
+  if (!hasAdminRole) {
+    return <Navigate to="/" replace />
+  }
+  return <>{children}</>
+}

--- a/frontend/src/features/identity/components/admin-only-route.test.tsx
+++ b/frontend/src/features/identity/components/admin-only-route.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { createPlatformAdminToken, createTestToken } from '@/test/jwt-helpers'
+import { AdminOnlyRoute } from '@/components/routing'
+
+function renderWithRoute(token: string) {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/admin']}>
+      <Routes>
+        <Route
+          path="/admin"
+          element={
+            <AdminOnlyRoute>
+              <div data-testid="admin-content">Admin Content</div>
+            </AdminOnlyRoute>
+          }
+        />
+        <Route path="/" element={<div data-testid="home">Home</div>} />
+      </Routes>
+    </MemoryRouter>,
+    { initialToken: token },
+  )
+}
+
+describe('AdminOnlyRoute', () => {
+  it('renders children for platform admin', () => {
+    renderWithRoute(createPlatformAdminToken())
+    expect(screen.getByTestId('admin-content')).toBeInTheDocument()
+  })
+
+  it('redirects non-admin users to home', () => {
+    const viewerToken = createTestToken({ roles: ['viewer'] })
+    renderWithRoute(viewerToken)
+    expect(screen.getByTestId('home')).toBeInTheDocument()
+  })
+
+  it('renders children for tenant-admin', () => {
+    const tenantAdminToken = createTestToken({
+      roles: ['tenant-admin'],
+      tenantId: 'test-tenant',
+    })
+    renderWithRoute(tenantAdminToken)
+    expect(screen.getByTestId('admin-content')).toBeInTheDocument()
+  })
+
+  it('renders children for super-admin', () => {
+    const superAdminToken = createTestToken({ roles: ['super-admin'] })
+    renderWithRoute(superAdminToken)
+    expect(screen.getByTestId('admin-content')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/identity/components/invite-dialog.tsx
+++ b/frontend/src/features/identity/components/invite-dialog.tsx
@@ -25,14 +25,16 @@ export function InviteDialog({ open, onOpenChange, currentUserRoles }: InviteDia
   const [errors, setErrors] = React.useState<{ email?: string }>({})
 
   const grantableRoles = getGrantableRoles(currentUserRoles)
+  const defaultRole = grantableRoles[0] ?? Role.OPERATOR
 
   React.useEffect(() => {
     if (!open) {
       setEmail('')
-      setRole(Role.OPERATOR)
+      setRole(defaultRole)
       setErrors({})
+      inviteUser.reset()
     }
-  }, [open])
+  }, [open, defaultRole]) // eslint-disable-line react-hooks/exhaustive-deps
 
   function validate(): boolean {
     const newErrors: { email?: string } = {}

--- a/frontend/src/features/identity/components/invite-dialog.tsx
+++ b/frontend/src/features/identity/components/invite-dialog.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Role } from '@/api/gen/meridian/identity/v1/identity_pb'
+import { useInviteUser } from '../hooks/use-identities'
+import { ROLE_LABELS, getGrantableRoles } from '../lib/roles'
+
+interface InviteDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  currentUserRoles: string[]
+}
+
+export function InviteDialog({ open, onOpenChange, currentUserRoles }: InviteDialogProps) {
+  const inviteUser = useInviteUser()
+  const [email, setEmail] = React.useState('')
+  const [role, setRole] = React.useState<Role>(Role.OPERATOR)
+  const [errors, setErrors] = React.useState<{ email?: string }>({})
+
+  const grantableRoles = getGrantableRoles(currentUserRoles)
+
+  React.useEffect(() => {
+    if (!open) {
+      setEmail('')
+      setRole(Role.OPERATOR)
+      setErrors({})
+    }
+  }, [open])
+
+  function validate(): boolean {
+    const newErrors: { email?: string } = {}
+    if (!email.trim()) {
+      newErrors.email = 'Email is required'
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      newErrors.email = 'Invalid email address'
+    }
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+
+    try {
+      await inviteUser.mutateAsync({ email, role })
+      onOpenChange(false)
+    } catch {
+      // error handled by mutation state
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Invite User</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={(e) => void handleSubmit(e)} id="invite-user-form">
+          <div className="space-y-4 py-2">
+            <div className="space-y-1">
+              <label htmlFor="invite-email" className="text-sm font-medium">
+                Email
+              </label>
+              <Input
+                id="invite-email"
+                type="email"
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value)
+                  if (errors.email) setErrors({})
+                }}
+                placeholder="user@example.com"
+                aria-describedby={errors.email ? 'invite-email-error' : undefined}
+              />
+              {errors.email && (
+                <p id="invite-email-error" className="text-sm text-destructive">
+                  {errors.email}
+                </p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="invite-role" className="text-sm font-medium">
+                Role
+              </label>
+              <select
+                id="invite-role"
+                value={role}
+                onChange={(e) => setRole(Number(e.target.value) as Role)}
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+              >
+                {grantableRoles.map((r) => (
+                  <option key={r} value={r}>
+                    {ROLE_LABELS[r]}
+                  </option>
+                ))}
+              </select>
+            </div>
+            {inviteUser.error && (
+              <p className="text-sm text-destructive">
+                Failed to send invitation. Please try again.
+              </p>
+            )}
+          </div>
+        </form>
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="submit" form="invite-user-form" disabled={inviteUser.isPending}>
+            {inviteUser.isPending ? 'Sending...' : 'Send Invitation'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/identity/components/role-management.tsx
+++ b/frontend/src/features/identity/components/role-management.tsx
@@ -1,0 +1,145 @@
+import * as React from 'react'
+import { Role } from '@/api/gen/meridian/identity/v1/identity_pb'
+import type { RoleAssignment } from '@/api/gen/meridian/identity/v1/identity_pb'
+import { Button } from '@/components/ui/button'
+import { TimeDisplay } from '@/shared/time-display'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { useGrantRole, useRevokeRole } from '../hooks/use-identities'
+import { ROLE_LABELS, getGrantableRoles } from '../lib/roles'
+
+interface RoleManagementProps {
+  identityId: string
+  roleAssignments: RoleAssignment[]
+  currentUserRoles: string[]
+}
+
+export function RoleManagement({
+  identityId,
+  roleAssignments,
+  currentUserRoles,
+}: RoleManagementProps) {
+  const grantRole = useGrantRole()
+  const revokeRole = useRevokeRole()
+  const [grantDialogOpen, setGrantDialogOpen] = React.useState(false)
+  const [selectedRole, setSelectedRole] = React.useState<Role>(Role.OPERATOR)
+
+  const grantableRoles = getGrantableRoles(currentUserRoles)
+  const canGrant = grantableRoles.length > 0
+  const activeAssignments = roleAssignments.filter((ra) => !ra.revoked)
+
+  async function handleGrantRole() {
+    try {
+      await grantRole.mutateAsync({ identityId, role: selectedRole })
+      setGrantDialogOpen(false)
+    } catch {
+      // error handled by mutation state
+    }
+  }
+
+  async function handleRevokeRole(roleAssignmentId: string) {
+    try {
+      await revokeRole.mutateAsync({ identityId, roleAssignmentId })
+    } catch {
+      // error handled by mutation state
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-medium">Roles</h3>
+        {canGrant && (
+          <Button size="sm" onClick={() => setGrantDialogOpen(true)}>
+            Grant Role
+          </Button>
+        )}
+      </div>
+
+      {activeAssignments.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No roles assigned.</p>
+      ) : (
+        <div className="rounded-md border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/50">
+                <th className="px-4 py-2 text-left font-medium">Role</th>
+                <th className="px-4 py-2 text-left font-medium">Granted</th>
+                <th className="px-4 py-2 text-left font-medium">Expires</th>
+                <th className="px-4 py-2 text-right font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {activeAssignments.map((ra) => (
+                <tr key={ra.id} className="border-b last:border-0">
+                  <td className="px-4 py-2">{ROLE_LABELS[ra.role] ?? 'Unknown'}</td>
+                  <td className="px-4 py-2">
+                    <TimeDisplay timestamp={ra.grantedAt} />
+                  </td>
+                  <td className="px-4 py-2">
+                    {ra.expiresAt ? <TimeDisplay timestamp={ra.expiresAt} /> : 'Never'}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    {canGrant && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => void handleRevokeRole(ra.id)}
+                        disabled={revokeRole.isPending}
+                      >
+                        Revoke
+                      </Button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <Dialog open={grantDialogOpen} onOpenChange={setGrantDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Grant Role</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-1">
+              <label htmlFor="grant-role-select" className="text-sm font-medium">
+                Role
+              </label>
+              <select
+                id="grant-role-select"
+                value={selectedRole}
+                onChange={(e) => setSelectedRole(Number(e.target.value) as Role)}
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+              >
+                {grantableRoles.map((r) => (
+                  <option key={r} value={r}>
+                    {ROLE_LABELS[r]}
+                  </option>
+                ))}
+              </select>
+            </div>
+            {grantRole.error && (
+              <p className="text-sm text-destructive">Failed to grant role. Please try again.</p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setGrantDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={() => void handleGrantRole()} disabled={grantRole.isPending}>
+              {grantRole.isPending ? 'Granting...' : 'Grant Role'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/frontend/src/features/identity/hooks/use-identities.ts
+++ b/frontend/src/features/identity/hooks/use-identities.ts
@@ -1,0 +1,154 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
+import { platformKeys } from '@/lib/query-keys'
+import type { IdentityStatus, Role } from '@/api/gen/meridian/identity/v1/identity_pb'
+
+export function useIdentities() {
+  const { identity } = useApiClients()
+
+  return {
+    queryKey: platformKeys.identities(),
+    queryFn: async (params: {
+      pageToken?: string
+      pageSize: number
+      filters?: Record<string, string>
+    }) => {
+      const statusFilter = params.filters?.statusFilter
+        ? (Number(params.filters.statusFilter) as IdentityStatus)
+        : undefined
+      const response = await identity.listIdentities({
+        pageSize: params.pageSize,
+        pageToken: params.pageToken ?? '',
+        statusFilter: statusFilter ?? 0,
+      })
+      return {
+        items: response.identities ?? [],
+        nextPageToken: response.nextPageToken || undefined,
+      }
+    },
+  }
+}
+
+export function useIdentity(identityId: string) {
+  const { identity } = useApiClients()
+
+  return useQuery({
+    queryKey: platformKeys.identity(identityId),
+    queryFn: async () => {
+      const response = await identity.retrieveIdentity({ id: identityId })
+      return response.identity
+    },
+    enabled: !!identityId,
+  })
+}
+
+export function useIdentityRoles(identityId: string) {
+  const { identity } = useApiClients()
+
+  return useQuery({
+    queryKey: platformKeys.identityRoles(identityId),
+    queryFn: async () => {
+      const response = await identity.listRoleAssignments({
+        identityId,
+        includeRevoked: false,
+      })
+      return response.roleAssignments ?? []
+    },
+    enabled: !!identityId,
+  })
+}
+
+export function useInviteUser() {
+  const { identity } = useApiClients()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (request: { email: string; role: Role }) => {
+      return identity.inviteUser({
+        email: request.email,
+        role: request.role,
+      })
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: platformKeys.identities() })
+    },
+  })
+}
+
+export function useSuspendIdentity() {
+  const { identity } = useApiClients()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (request: { id: string; reason: string }) => {
+      const response = await identity.suspendIdentity({
+        id: request.id,
+        reason: request.reason,
+      })
+      return response.identity
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({ queryKey: platformKeys.identity(variables.id) })
+      void queryClient.invalidateQueries({ queryKey: platformKeys.identities() })
+    },
+  })
+}
+
+export function useReactivateIdentity() {
+  const { identity } = useApiClients()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (request: { id: string; reason: string }) => {
+      const response = await identity.reactivateIdentity({
+        id: request.id,
+        reason: request.reason,
+      })
+      return response.identity
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({ queryKey: platformKeys.identity(variables.id) })
+      void queryClient.invalidateQueries({ queryKey: platformKeys.identities() })
+    },
+  })
+}
+
+export function useGrantRole() {
+  const { identity } = useApiClients()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (request: { identityId: string; role: Role }) => {
+      const response = await identity.grantRole({
+        identityId: request.identityId,
+        role: request.role,
+      })
+      return response.roleAssignment
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: platformKeys.identityRoles(variables.identityId),
+      })
+    },
+  })
+}
+
+export function useRevokeRole() {
+  const { identity } = useApiClients()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (request: { identityId: string; roleAssignmentId: string }) => {
+      const response = await identity.revokeRole({
+        identityId: request.identityId,
+        roleAssignmentId: request.roleAssignmentId,
+      })
+      return response.roleAssignment
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: platformKeys.identityRoles(variables.identityId),
+      })
+    },
+  })
+}

--- a/frontend/src/features/identity/hooks/use-identities.ts
+++ b/frontend/src/features/identity/hooks/use-identities.ts
@@ -1,29 +1,38 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useApiClients } from '@/api/context'
 import { platformKeys } from '@/lib/query-keys'
-import type { IdentityStatus, Role } from '@/api/gen/meridian/identity/v1/identity_pb'
+import type { Role } from '@/api/gen/meridian/identity/v1/identity_pb'
+import { IdentityStatus } from '@/api/gen/meridian/identity/v1/identity_pb'
 
 export function useIdentities() {
   const { identity } = useApiClients()
 
   return {
     queryKey: platformKeys.identities(),
-    queryFn: async (params: {
+    queryFn: async (_params: {
       pageToken?: string
       pageSize: number
       filters?: Record<string, string>
     }) => {
-      const statusFilter = params.filters?.statusFilter
-        ? (Number(params.filters.statusFilter) as IdentityStatus)
-        : undefined
+      // Backend does not yet support pagination or status filtering.
+      // Pass zeros to avoid Unimplemented error.
       const response = await identity.listIdentities({
-        pageSize: params.pageSize,
-        pageToken: params.pageToken ?? '',
-        statusFilter: statusFilter ?? 0,
+        pageSize: 0,
+        pageToken: '',
+        statusFilter: IdentityStatus.UNSPECIFIED,
       })
+
+      // Client-side status filtering until backend implements it
+      let items = response.identities ?? []
+      const statusFilterValue = _params.filters?.statusFilter
+      if (statusFilterValue) {
+        const filterNum = Number(statusFilterValue)
+        items = items.filter((i) => i.status === filterNum)
+      }
+
       return {
-        items: response.identities ?? [],
-        nextPageToken: response.nextPageToken || undefined,
+        items,
+        nextPageToken: undefined,
       }
     },
   }

--- a/frontend/src/features/identity/index.ts
+++ b/frontend/src/features/identity/index.ts
@@ -1,0 +1,2 @@
+export { UsersListPage } from './pages/users-list-page'
+export { UserDetailPage } from './pages/user-detail-page'

--- a/frontend/src/features/identity/lib/roles.test.ts
+++ b/frontend/src/features/identity/lib/roles.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { Role } from '@/api/gen/meridian/identity/v1/identity_pb'
+import { getGrantableRoles, ROLE_LABELS } from './roles'
+
+describe('ROLE_LABELS', () => {
+  it('has labels for all non-unspecified roles', () => {
+    expect(ROLE_LABELS[Role.ADMIN]).toBe('Admin')
+    expect(ROLE_LABELS[Role.OPERATOR]).toBe('Operator')
+    expect(ROLE_LABELS[Role.AUDITOR]).toBe('Auditor')
+    expect(ROLE_LABELS[Role.TENANT_OWNER]).toBe('Tenant Owner')
+    expect(ROLE_LABELS[Role.PLATFORM_ADMIN]).toBe('Platform Admin')
+    expect(ROLE_LABELS[Role.SUPER_ADMIN]).toBe('Super Admin')
+  })
+})
+
+describe('getGrantableRoles', () => {
+  it('super-admin can grant all roles', () => {
+    const result = getGrantableRoles(['super-admin'])
+    expect(result).toContain(Role.ADMIN)
+    expect(result).toContain(Role.SUPER_ADMIN)
+    expect(result).toContain(Role.PLATFORM_ADMIN)
+    expect(result).toHaveLength(6)
+  })
+
+  it('platform-admin can grant tenant-level roles', () => {
+    const result = getGrantableRoles(['platform-admin'])
+    expect(result).toContain(Role.ADMIN)
+    expect(result).toContain(Role.OPERATOR)
+    expect(result).toContain(Role.AUDITOR)
+    expect(result).toContain(Role.TENANT_OWNER)
+    expect(result).not.toContain(Role.PLATFORM_ADMIN)
+    expect(result).not.toContain(Role.SUPER_ADMIN)
+  })
+
+  it('admin can grant operator and auditor', () => {
+    const result = getGrantableRoles(['admin'])
+    expect(result).toEqual([Role.OPERATOR, Role.AUDITOR])
+  })
+
+  it('tenant-admin can grant operator and auditor', () => {
+    const result = getGrantableRoles(['tenant-admin'])
+    expect(result).toEqual([Role.OPERATOR, Role.AUDITOR])
+  })
+
+  it('operator cannot grant any roles', () => {
+    const result = getGrantableRoles(['operator'])
+    expect(result).toEqual([])
+  })
+
+  it('empty roles cannot grant any roles', () => {
+    const result = getGrantableRoles([])
+    expect(result).toEqual([])
+  })
+})

--- a/frontend/src/features/identity/lib/roles.ts
+++ b/frontend/src/features/identity/lib/roles.ts
@@ -1,0 +1,40 @@
+import { Role } from '@/api/gen/meridian/identity/v1/identity_pb'
+
+export const ROLE_LABELS: Record<number, string> = {
+  [Role.ADMIN]: 'Admin',
+  [Role.OPERATOR]: 'Operator',
+  [Role.AUDITOR]: 'Auditor',
+  [Role.TENANT_OWNER]: 'Tenant Owner',
+  [Role.PLATFORM_ADMIN]: 'Platform Admin',
+  [Role.SUPER_ADMIN]: 'Super Admin',
+}
+
+/**
+ * Returns the list of roles the current user can grant based on role hierarchy.
+ * SUPER_ADMIN can grant all. ADMIN can grant OPERATOR and AUDITOR.
+ * PLATFORM_ADMIN can grant all tenant-level roles.
+ */
+export function getGrantableRoles(currentUserRoles: string[]): Role[] {
+  const isSuperAdmin = currentUserRoles.includes('super-admin')
+  const isPlatformAdmin = currentUserRoles.includes('platform-admin')
+  const isAdmin =
+    currentUserRoles.includes('admin') || currentUserRoles.includes('tenant-admin')
+
+  if (isSuperAdmin) {
+    return [
+      Role.ADMIN,
+      Role.OPERATOR,
+      Role.AUDITOR,
+      Role.TENANT_OWNER,
+      Role.PLATFORM_ADMIN,
+      Role.SUPER_ADMIN,
+    ]
+  }
+  if (isPlatformAdmin) {
+    return [Role.ADMIN, Role.OPERATOR, Role.AUDITOR, Role.TENANT_OWNER]
+  }
+  if (isAdmin) {
+    return [Role.OPERATOR, Role.AUDITOR]
+  }
+  return []
+}

--- a/frontend/src/features/identity/pages/user-detail-page.test.tsx
+++ b/frontend/src/features/identity/pages/user-detail-page.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { createPlatformAdminToken } from '@/test/jwt-helpers'
+import { IdentityStatus, Role } from '@/api/gen/meridian/identity/v1/identity_pb'
+import { UserDetailPage } from './user-detail-page'
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+  ApiClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+import { useApiClients } from '@/api/context'
+
+const mockIdentity = {
+  id: 'user-1',
+  email: 'alice@example.com',
+  externalIdp: '',
+  externalIdpSub: '',
+  status: IdentityStatus.ACTIVE,
+  lastLoginAt: { seconds: BigInt(1700000000), nanos: 0 },
+  failedAttempts: 0,
+  lockedUntil: undefined,
+  mfaEnabled: true,
+  createdAt: { seconds: BigInt(1699000000), nanos: 0 },
+  updatedAt: { seconds: BigInt(1700000000), nanos: 0 },
+  version: 1,
+}
+
+const mockRoleAssignments = [
+  {
+    id: 'ra-1',
+    identityId: 'user-1',
+    role: Role.ADMIN,
+    grantedBy: 'admin-1',
+    grantedAt: { seconds: BigInt(1699000000), nanos: 0 },
+    expiresAt: undefined,
+    revoked: false,
+    revokedAt: undefined,
+    revokedBy: '',
+  },
+]
+
+function mockApiClients() {
+  vi.mocked(useApiClients).mockReturnValue({
+    identity: {
+      retrieveIdentity: vi.fn().mockResolvedValue({ identity: mockIdentity }),
+      listRoleAssignments: vi.fn().mockResolvedValue({
+        roleAssignments: mockRoleAssignments,
+      }),
+      suspendIdentity: vi.fn().mockResolvedValue({
+        identity: { ...mockIdentity, status: IdentityStatus.SUSPENDED },
+      }),
+      reactivateIdentity: vi.fn().mockResolvedValue({
+        identity: { ...mockIdentity, status: IdentityStatus.ACTIVE },
+      }),
+      grantRole: vi.fn().mockResolvedValue({ roleAssignment: mockRoleAssignments[0] }),
+      revokeRole: vi.fn().mockResolvedValue({ roleAssignment: mockRoleAssignments[0] }),
+      listIdentities: vi.fn(),
+      inviteUser: vi.fn(),
+    },
+  } as unknown as ReturnType<typeof useApiClients>)
+}
+
+function renderUserDetailPage(token: string) {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/users/user-1']}>
+      <Routes>
+        <Route path="/users/:userId" element={<UserDetailPage />} />
+        <Route path="/users" element={<div data-testid="users-list">List</div>} />
+      </Routes>
+    </MemoryRouter>,
+    { initialToken: token },
+  )
+}
+
+describe('UserDetailPage', () => {
+  beforeEach(() => mockApiClients())
+
+  it('renders user email as heading', async () => {
+    renderUserDetailPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByText('alice@example.com')).toBeInTheDocument()
+    })
+  })
+
+  it('shows user ID', async () => {
+    renderUserDetailPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByText(/ID: user-1/)).toBeInTheDocument()
+    })
+  })
+
+  it('shows identity status badge', async () => {
+    renderUserDetailPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByText('ACTIVE')).toBeInTheDocument()
+    })
+  })
+
+  it('shows MFA status', async () => {
+    renderUserDetailPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByText('Enabled')).toBeInTheDocument()
+    })
+  })
+
+  it('shows suspend button for active users', async () => {
+    renderUserDetailPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /suspend/i })).toBeInTheDocument()
+    })
+  })
+
+  it('opens suspend dialog on button click', async () => {
+    renderUserDetailPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /suspend/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /suspend/i }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('Suspending this user will prevent them from logging in.')).toBeInTheDocument()
+  })
+
+  it('shows role assignments table', async () => {
+    renderUserDetailPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByText('Admin')).toBeInTheDocument()
+    })
+  })
+
+  it('shows back link to users list', async () => {
+    renderUserDetailPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByText('Back to Users')).toBeInTheDocument()
+    })
+  })
+
+  it('shows grant role button', async () => {
+    renderUserDetailPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /grant role/i })).toBeInTheDocument()
+    })
+  })
+})
+
+describe('UserDetailPage - suspended user', () => {
+  it('shows reactivate button for suspended users', async () => {
+    const suspendedIdentity = { ...mockIdentity, status: IdentityStatus.SUSPENDED }
+    vi.mocked(useApiClients).mockReturnValue({
+      identity: {
+        retrieveIdentity: vi.fn().mockResolvedValue({ identity: suspendedIdentity }),
+        listRoleAssignments: vi.fn().mockResolvedValue({ roleAssignments: [] }),
+        suspendIdentity: vi.fn(),
+        reactivateIdentity: vi.fn(),
+        grantRole: vi.fn(),
+        revokeRole: vi.fn(),
+        listIdentities: vi.fn(),
+        inviteUser: vi.fn(),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderUserDetailPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /reactivate/i })).toBeInTheDocument()
+    })
+  })
+})
+
+describe('UserDetailPage - error state', () => {
+  it('shows error message when API fails', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      identity: {
+        retrieveIdentity: vi.fn().mockRejectedValue(new Error('Not Found')),
+        listRoleAssignments: vi.fn().mockResolvedValue({ roleAssignments: [] }),
+        suspendIdentity: vi.fn(),
+        reactivateIdentity: vi.fn(),
+        grantRole: vi.fn(),
+        revokeRole: vi.fn(),
+        listIdentities: vi.fn(),
+        inviteUser: vi.fn(),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderUserDetailPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load user details/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/features/identity/pages/user-detail-page.tsx
+++ b/frontend/src/features/identity/pages/user-detail-page.tsx
@@ -1,0 +1,225 @@
+import * as React from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { ArrowLeft } from 'lucide-react'
+import { useAuth } from '@/contexts/auth-context'
+import { StatusBadge } from '@/shared/status-badge'
+import { TimeDisplay } from '@/shared/time-display'
+import { DetailSkeleton } from '@/shared/detail-skeleton'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { IdentityStatus } from '@/api/gen/meridian/identity/v1/identity_pb'
+import {
+  useIdentity,
+  useIdentityRoles,
+  useSuspendIdentity,
+  useReactivateIdentity,
+} from '../hooks/use-identities'
+import { RoleManagement } from '../components/role-management'
+
+const STATUS_LABEL: Record<number, string> = {
+  [IdentityStatus.UNSPECIFIED]: 'UNKNOWN',
+  [IdentityStatus.PENDING_INVITE]: 'PENDING_INVITE',
+  [IdentityStatus.ACTIVE]: 'ACTIVE',
+  [IdentityStatus.SUSPENDED]: 'SUSPENDED',
+  [IdentityStatus.LOCKED]: 'LOCKED',
+}
+
+export function UserDetailPage() {
+  const { userId } = useParams<{ userId: string }>()
+  const { claims } = useAuth()
+  const { data: identity, isLoading, isError } = useIdentity(userId ?? '')
+  const { data: roleAssignments } = useIdentityRoles(userId ?? '')
+  const suspendIdentity = useSuspendIdentity()
+  const reactivateIdentity = useReactivateIdentity()
+
+  const [actionDialogOpen, setActionDialogOpen] = React.useState(false)
+  const [actionType, setActionType] = React.useState<'suspend' | 'reactivate'>('suspend')
+  const [reason, setReason] = React.useState('')
+
+  const currentUserRoles = claims?.roles ?? []
+
+  if (isLoading) return <DetailSkeleton />
+
+  if (isError || !identity) {
+    return (
+      <div className="p-6">
+        <Link to="/users" className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-4">
+          <ArrowLeft className="size-4" />
+          Back to Users
+        </Link>
+        <p className="text-destructive">Failed to load user details.</p>
+      </div>
+    )
+  }
+
+  const statusLabel = STATUS_LABEL[identity.status] ?? 'UNKNOWN'
+  const canSuspend = identity.status === IdentityStatus.ACTIVE
+  const canReactivate =
+    identity.status === IdentityStatus.SUSPENDED || identity.status === IdentityStatus.LOCKED
+
+  function openAction(type: 'suspend' | 'reactivate') {
+    setActionType(type)
+    setReason('')
+    setActionDialogOpen(true)
+  }
+
+  async function handleAction() {
+    if (!reason.trim() || !userId) return
+    try {
+      if (actionType === 'suspend') {
+        await suspendIdentity.mutateAsync({ id: userId, reason })
+      } else {
+        await reactivateIdentity.mutateAsync({ id: userId, reason })
+      }
+      setActionDialogOpen(false)
+    } catch {
+      // error handled by mutation state
+    }
+  }
+
+  const isPending = suspendIdentity.isPending || reactivateIdentity.isPending
+
+  return (
+    <div className="p-6 space-y-6">
+      <Link to="/users" className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft className="size-4" />
+        Back to Users
+      </Link>
+
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">{identity.email}</h1>
+          <p className="mt-1 text-sm text-muted-foreground">ID: {identity.id}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          {canSuspend && (
+            <Button variant="destructive" size="sm" onClick={() => openAction('suspend')}>
+              Suspend
+            </Button>
+          )}
+          {canReactivate && (
+            <Button variant="outline" size="sm" onClick={() => openAction('reactivate')}>
+              Reactivate
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <div className="rounded-lg border p-4 space-y-3">
+          <h2 className="text-lg font-medium">Identity Details</h2>
+          <dl className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <dt className="text-muted-foreground">Status</dt>
+              <dd><StatusBadge status={statusLabel} /></dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-muted-foreground">MFA</dt>
+              <dd>{identity.mfaEnabled ? 'Enabled' : 'Disabled'}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-muted-foreground">Last Login</dt>
+              <dd>
+                {identity.lastLoginAt ? (
+                  <TimeDisplay timestamp={identity.lastLoginAt} />
+                ) : (
+                  'Never'
+                )}
+              </dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-muted-foreground">Created</dt>
+              <dd><TimeDisplay timestamp={identity.createdAt} /></dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-muted-foreground">Updated</dt>
+              <dd><TimeDisplay timestamp={identity.updatedAt} /></dd>
+            </div>
+            {identity.failedAttempts > 0 && (
+              <div className="flex justify-between">
+                <dt className="text-muted-foreground">Failed Attempts</dt>
+                <dd className="text-destructive">{identity.failedAttempts}</dd>
+              </div>
+            )}
+            {identity.lockedUntil && (
+              <div className="flex justify-between">
+                <dt className="text-muted-foreground">Locked Until</dt>
+                <dd><TimeDisplay timestamp={identity.lockedUntil} /></dd>
+              </div>
+            )}
+            {identity.externalIdp && (
+              <div className="flex justify-between">
+                <dt className="text-muted-foreground">External IdP</dt>
+                <dd className="truncate max-w-48">{identity.externalIdp}</dd>
+              </div>
+            )}
+          </dl>
+        </div>
+
+        <div className="rounded-lg border p-4">
+          <RoleManagement
+            identityId={identity.id}
+            roleAssignments={roleAssignments ?? []}
+            currentUserRoles={currentUserRoles}
+          />
+        </div>
+      </div>
+
+      <Dialog open={actionDialogOpen} onOpenChange={setActionDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {actionType === 'suspend' ? 'Suspend User' : 'Reactivate User'}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <p className="text-sm text-muted-foreground">
+              {actionType === 'suspend'
+                ? 'Suspending this user will prevent them from logging in.'
+                : 'Reactivating this user will restore their access.'}
+            </p>
+            <div className="space-y-1">
+              <label htmlFor="action-reason" className="text-sm font-medium">
+                Reason
+              </label>
+              <Input
+                id="action-reason"
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                placeholder="Provide a reason for this action"
+              />
+            </div>
+            {(suspendIdentity.error || reactivateIdentity.error) && (
+              <p className="text-sm text-destructive">
+                Action failed. Please try again.
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setActionDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant={actionType === 'suspend' ? 'destructive' : 'default'}
+              onClick={() => void handleAction()}
+              disabled={isPending || !reason.trim()}
+            >
+              {isPending
+                ? 'Processing...'
+                : actionType === 'suspend'
+                  ? 'Suspend User'
+                  : 'Reactivate User'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/frontend/src/features/identity/pages/user-detail-page.tsx
+++ b/frontend/src/features/identity/pages/user-detail-page.tsx
@@ -67,6 +67,8 @@ export function UserDetailPage() {
   function openAction(type: 'suspend' | 'reactivate') {
     setActionType(type)
     setReason('')
+    suspendIdentity.reset()
+    reactivateIdentity.reset()
     setActionDialogOpen(true)
   }
 

--- a/frontend/src/features/identity/pages/users-list-page.test.tsx
+++ b/frontend/src/features/identity/pages/users-list-page.test.tsx
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { createPlatformAdminToken } from '@/test/jwt-helpers'
+import { IdentityStatus } from '@/api/gen/meridian/identity/v1/identity_pb'
+import { UsersListPage } from './users-list-page'
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+  ApiClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+import { useApiClients } from '@/api/context'
+
+const mockIdentities = [
+  {
+    id: 'user-1',
+    email: 'alice@example.com',
+    externalIdp: '',
+    externalIdpSub: '',
+    status: IdentityStatus.ACTIVE,
+    lastLoginAt: { seconds: BigInt(1700000000), nanos: 0 },
+    failedAttempts: 0,
+    lockedUntil: undefined,
+    mfaEnabled: true,
+    createdAt: { seconds: BigInt(1699000000), nanos: 0 },
+    updatedAt: { seconds: BigInt(1700000000), nanos: 0 },
+    version: 1,
+  },
+  {
+    id: 'user-2',
+    email: 'bob@example.com',
+    externalIdp: '',
+    externalIdpSub: '',
+    status: IdentityStatus.SUSPENDED,
+    lastLoginAt: undefined,
+    failedAttempts: 0,
+    lockedUntil: undefined,
+    mfaEnabled: false,
+    createdAt: { seconds: BigInt(1699001000), nanos: 0 },
+    updatedAt: { seconds: BigInt(1699001000), nanos: 0 },
+    version: 1,
+  },
+  {
+    id: 'user-3',
+    email: 'carol@example.com',
+    externalIdp: '',
+    externalIdpSub: '',
+    status: IdentityStatus.PENDING_INVITE,
+    lastLoginAt: undefined,
+    failedAttempts: 0,
+    lockedUntil: undefined,
+    mfaEnabled: false,
+    createdAt: { seconds: BigInt(1699002000), nanos: 0 },
+    updatedAt: { seconds: BigInt(1699002000), nanos: 0 },
+    version: 1,
+  },
+]
+
+function mockApiClients() {
+  vi.mocked(useApiClients).mockReturnValue({
+    identity: {
+      listIdentities: vi.fn().mockResolvedValue({
+        identities: mockIdentities,
+        nextPageToken: '',
+        totalCount: 3,
+      }),
+      inviteUser: vi.fn().mockResolvedValue({
+        invitation: { id: 'inv-1' },
+        identity: mockIdentities[0],
+        invitationToken: 'token-123',
+      }),
+      retrieveIdentity: vi.fn(),
+      listRoleAssignments: vi.fn(),
+      grantRole: vi.fn(),
+      revokeRole: vi.fn(),
+      suspendIdentity: vi.fn(),
+      reactivateIdentity: vi.fn(),
+    },
+  } as unknown as ReturnType<typeof useApiClients>)
+}
+
+function renderUsersListPage(token: string) {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/users']}>
+      <Routes>
+        <Route path="/users" element={<UsersListPage />} />
+        <Route path="/users/:userId" element={<div data-testid="user-detail-page">Detail</div>} />
+      </Routes>
+    </MemoryRouter>,
+    { initialToken: token },
+  )
+}
+
+describe('UsersListPage', () => {
+  beforeEach(() => mockApiClients())
+
+  it('renders page heading', async () => {
+    renderUsersListPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /users/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders user list table', async () => {
+    renderUsersListPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByText('alice@example.com')).toBeInTheDocument()
+    })
+    expect(screen.getByText('bob@example.com')).toBeInTheDocument()
+    expect(screen.getByText('carol@example.com')).toBeInTheDocument()
+  })
+
+  it('shows status badges', async () => {
+    renderUsersListPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByText('ACTIVE')).toBeInTheDocument()
+    })
+    expect(screen.getByText('SUSPENDED')).toBeInTheDocument()
+    expect(screen.getByText('PENDING INVITE')).toBeInTheDocument()
+  })
+
+  it('shows MFA status', async () => {
+    renderUsersListPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByText('Enabled')).toBeInTheDocument()
+    })
+    expect(screen.getAllByText('Disabled').length).toBeGreaterThan(0)
+  })
+
+  it('shows invite user button', async () => {
+    renderUsersListPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /invite user/i })).toBeInTheDocument()
+    })
+  })
+
+  it('opens invite dialog when button is clicked', async () => {
+    renderUsersListPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /invite user/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /invite user/i }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+  })
+
+  it('navigates to user detail on row click', async () => {
+    renderUsersListPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByText('alice@example.com')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByText('alice@example.com'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-detail-page')).toBeInTheDocument()
+    })
+  })
+
+  it('shows status filter dropdown', async () => {
+    renderUsersListPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: /status/i })).toBeInTheDocument()
+    })
+  })
+})
+
+describe('UsersListPage - empty state', () => {
+  it('shows empty state when no users', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      identity: {
+        listIdentities: vi.fn().mockResolvedValue({
+          identities: [],
+          nextPageToken: '',
+          totalCount: 0,
+        }),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderUsersListPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByText('No users found')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('UsersListPage - error state', () => {
+  it('shows error state when API fails', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      identity: {
+        listIdentities: vi.fn().mockRejectedValue(new Error('Internal Server Error')),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderUsersListPage(createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/features/identity/pages/users-list-page.tsx
+++ b/frontend/src/features/identity/pages/users-list-page.tsx
@@ -1,0 +1,126 @@
+import * as React from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { ColumnDef } from '@tanstack/react-table'
+import { UserPlus } from 'lucide-react'
+import { useAuth } from '@/contexts/auth-context'
+import { DataTable } from '@/shared/data-table'
+import { StatusBadge } from '@/shared/status-badge'
+import { TimeDisplay } from '@/shared/time-display'
+import { Button } from '@/components/ui/button'
+import type { Identity } from '@/api/gen/meridian/identity/v1/identity_pb'
+import { IdentityStatus } from '@/api/gen/meridian/identity/v1/identity_pb'
+import type { FilterConfig } from '@/shared/data-table'
+import { useIdentities } from '../hooks/use-identities'
+import { InviteDialog } from '../components/invite-dialog'
+
+const STATUS_LABEL: Record<number, string> = {
+  [IdentityStatus.UNSPECIFIED]: 'UNKNOWN',
+  [IdentityStatus.PENDING_INVITE]: 'PENDING_INVITE',
+  [IdentityStatus.ACTIVE]: 'ACTIVE',
+  [IdentityStatus.SUSPENDED]: 'SUSPENDED',
+  [IdentityStatus.LOCKED]: 'LOCKED',
+}
+
+const columns: ColumnDef<Identity>[] = [
+  {
+    accessorKey: 'email',
+    header: 'Email',
+  },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    cell: ({ row }) => {
+      const statusLabel = STATUS_LABEL[row.original.status] ?? 'UNKNOWN'
+      return <StatusBadge status={statusLabel} />
+    },
+  },
+  {
+    accessorKey: 'mfaEnabled',
+    header: 'MFA',
+    cell: ({ row }) => (
+      <span className="text-sm text-muted-foreground">
+        {row.original.mfaEnabled ? 'Enabled' : 'Disabled'}
+      </span>
+    ),
+  },
+  {
+    accessorKey: 'lastLoginAt',
+    header: 'Last Login',
+    cell: ({ row }) =>
+      row.original.lastLoginAt ? (
+        <TimeDisplay timestamp={row.original.lastLoginAt} />
+      ) : (
+        <span className="text-sm text-muted-foreground">Never</span>
+      ),
+  },
+  {
+    accessorKey: 'createdAt',
+    header: 'Created',
+    cell: ({ row }) => <TimeDisplay timestamp={row.original.createdAt} />,
+  },
+]
+
+const statusFilterOptions: FilterConfig[] = [
+  {
+    field: 'statusFilter',
+    label: 'Status',
+    type: 'select',
+    options: [
+      { label: 'Active', value: String(IdentityStatus.ACTIVE) },
+      { label: 'Pending Invite', value: String(IdentityStatus.PENDING_INVITE) },
+      { label: 'Suspended', value: String(IdentityStatus.SUSPENDED) },
+      { label: 'Locked', value: String(IdentityStatus.LOCKED) },
+    ],
+  },
+]
+
+export function UsersListPage() {
+  const navigate = useNavigate()
+  const { claims } = useAuth()
+  const { queryKey, queryFn } = useIdentities()
+  const [inviteOpen, setInviteOpen] = React.useState(false)
+  const [tableKey, setTableKey] = React.useState(0)
+
+  const currentUserRoles = claims?.roles ?? []
+
+  function handleRowClick(row: Identity) {
+    void navigate(`/users/${row.id}`)
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Users</h1>
+        <Button onClick={() => setInviteOpen(true)}>
+          <UserPlus className="mr-2 size-4" />
+          Invite User
+        </Button>
+      </div>
+
+      <DataTable<Identity>
+        key={tableKey}
+        queryKey={queryKey}
+        queryFn={queryFn}
+        columns={columns}
+        pageSize={25}
+        filters={statusFilterOptions}
+        onRowClick={handleRowClick}
+        emptyState={
+          <div className="flex flex-col items-center gap-2 py-12 text-muted-foreground">
+            <span className="text-sm font-medium">No users found</span>
+            <span className="text-xs">Invite a user to get started.</span>
+          </div>
+        }
+      />
+
+      <InviteDialog
+        open={inviteOpen}
+        onOpenChange={(open) => {
+          setInviteOpen(open)
+          if (!open) setTableKey((k) => k + 1)
+        }}
+        currentUserRoles={currentUserRoles}
+      />
+    </div>
+  )
+}

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -104,6 +104,11 @@ export const platformKeys = {
   health: () => [...platformKeys.all, 'health'] as const,
 
   metrics: () => [...platformKeys.all, 'metrics'] as const,
+
+  identities: () => [...platformKeys.all, 'identities'] as const,
+  identity: (identityId: string) => [...platformKeys.identities(), identityId] as const,
+  identityRoles: (identityId: string) =>
+    [...platformKeys.identity(identityId), 'roles'] as const,
 } as const
 
 export const manifestKeys = {

--- a/frontend/src/shared/status-badge.tsx
+++ b/frontend/src/shared/status-badge.tsx
@@ -26,6 +26,9 @@ const STATUS_MAP: Record<string, StatusVariant> = {
   PROVISIONING_PENDING: 'info',
   PROVISIONING_FAILED: 'error',
   DEPROVISIONED: 'neutral',
+  // Identity statuses
+  PENDING_INVITE: 'info',
+  LOCKED: 'error',
   // Manifest apply statuses
   APPLIED: 'success',
   ROLLED_BACK: 'warning',


### PR DESCRIPTION
## Summary

- **Users list page**: Data table with email, status badges (ACTIVE/SUSPENDED/LOCKED/PENDING_INVITE), MFA status, last login, created date. Includes status filter dropdown, skeleton loading, and empty state.
- **User detail page**: Identity info panel, role assignments table with grant/revoke actions, suspend/reactivate dialogs with reason input.
- **Invite user dialog**: Email input with validation, role select filtered by current user's role hierarchy (SUPER_ADMIN > PLATFORM_ADMIN > ADMIN).
- **Navigation and routing**: AdminOnlyRoute guard for /users routes, "Users" link in sidebar Admin section.

Implements Task Master tasks embedded-dex-identity.15, embedded-dex-identity.16, embedded-dex-identity.17.

## Changes Made

- `frontend/src/features/identity/` - New feature module with pages, hooks, components, and lib
- `frontend/src/components/routing.tsx` - Added `AdminOnlyRoute` guard
- `frontend/src/components/layout/sidebar.tsx` - Added Users nav item under Admin
- `frontend/src/App.tsx` - Added /users and /users/:userId routes
- `frontend/src/lib/query-keys.ts` - Added identity query keys
- `frontend/src/shared/status-badge.tsx` - Added PENDING_INVITE and LOCKED status mappings

## Test plan

- [x] 32 tests passing (roles lib, users list page, user detail page, admin route guard)
- [x] TypeScript type check passes
- [x] ESLint passes (0 errors)
- [x] Vite build succeeds