### PR TITLE
fix: resolve internal account lookup by business ID

### DIFF
--- a/services/internal-account/adapters/persistence/repository.go
+++ b/services/internal-account/adapters/persistence/repository.go
@@ -218,6 +218,29 @@ func (r *Repository) FindByIDForUpdate(ctx context.Context, id uuid.UUID) (domai
 	return account, nil
 }
 
+// FindByAccountID retrieves an account by its business identifier (e.g. IBA-xxx).
+func (r *Repository) FindByAccountID(ctx context.Context, accountID string) (domain.InternalAccount, error) {
+	var account domain.InternalAccount
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var entity InternalAccountEntity
+		result := tx.Where("account_id = ? AND deleted_at IS NULL", accountID).First(&entity)
+
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return ErrAccountNotFound
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+
+		account = toDomain(&entity)
+		return nil
+	})
+	if err != nil {
+		return domain.InternalAccount{}, err
+	}
+	return account, nil
+}
+
 // FindByCode retrieves an account by its unique code.
 func (r *Repository) FindByCode(ctx context.Context, accountCode string) (domain.InternalAccount, error) {
 	var account domain.InternalAccount

--- a/services/internal-account/domain/repository.go
+++ b/services/internal-account/domain/repository.go
@@ -22,6 +22,10 @@ type Repository interface {
 	// Returns ErrAccountNotFound if the account does not exist.
 	FindByID(ctx context.Context, id uuid.UUID) (InternalAccount, error)
 
+	// FindByAccountID retrieves an account by its business identifier (e.g. IBA-xxx).
+	// Returns ErrAccountNotFound if the account does not exist.
+	FindByAccountID(ctx context.Context, accountID string) (InternalAccount, error)
+
 	// FindByCode retrieves an account by its unique code.
 	// Returns ErrAccountNotFound if the account does not exist.
 	FindByCode(ctx context.Context, accountCode string) (InternalAccount, error)

--- a/services/internal-account/service/server.go
+++ b/services/internal-account/service/server.go
@@ -931,8 +931,17 @@ func (s *Service) findAccountByID(ctx context.Context, accountID string) (domain
 		return account, nil
 	}
 
-	// Try to find by account code
-	account, err := s.repo.FindByCode(ctx, accountID)
+	// Try to find by business account ID (e.g. IBA-xxx)
+	account, err := s.repo.FindByAccountID(ctx, accountID)
+	if err == nil {
+		return account, nil
+	}
+	if !errors.Is(err, domain.ErrAccountNotFound) && !errors.Is(err, persistence.ErrAccountNotFound) {
+		return domain.InternalAccount{}, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+	}
+
+	// Fall back to account code
+	account, err = s.repo.FindByCode(ctx, accountID)
 	if err != nil {
 		if errors.Is(err, domain.ErrAccountNotFound) || errors.Is(err, persistence.ErrAccountNotFound) {
 			return domain.InternalAccount{}, status.Errorf(codes.NotFound, "account not found: %s", accountID)

--- a/services/internal-account/service/server_test.go
+++ b/services/internal-account/service/server_test.go
@@ -24,19 +24,22 @@ import (
 
 // mockRepository implements service.Repository for testing.
 type mockRepository struct {
-	accounts        map[uuid.UUID]domain.InternalAccount
-	accountsByCode  map[string]domain.InternalAccount
-	saveErr         error
-	findByIDErr     error
-	findByCodeErr   error
-	listErr         error
-	existsByCodeErr error
+	accounts           map[uuid.UUID]domain.InternalAccount
+	accountsByCode     map[string]domain.InternalAccount
+	accountsByAcctID   map[string]domain.InternalAccount
+	saveErr            error
+	findByIDErr        error
+	findByAccountIDErr error
+	findByCodeErr      error
+	listErr            error
+	existsByCodeErr    error
 }
 
 func newMockRepository() *mockRepository {
 	return &mockRepository{
-		accounts:       make(map[uuid.UUID]domain.InternalAccount),
-		accountsByCode: make(map[string]domain.InternalAccount),
+		accounts:         make(map[uuid.UUID]domain.InternalAccount),
+		accountsByCode:   make(map[string]domain.InternalAccount),
+		accountsByAcctID: make(map[string]domain.InternalAccount),
 	}
 }
 
@@ -46,6 +49,7 @@ func (m *mockRepository) Save(_ context.Context, account domain.InternalAccount)
 	}
 	m.accounts[account.ID()] = account
 	m.accountsByCode[account.AccountCode()] = account
+	m.accountsByAcctID[account.AccountID()] = account
 	return nil
 }
 
@@ -54,6 +58,17 @@ func (m *mockRepository) FindByID(_ context.Context, id uuid.UUID) (domain.Inter
 		return domain.InternalAccount{}, m.findByIDErr
 	}
 	account, ok := m.accounts[id]
+	if !ok {
+		return domain.InternalAccount{}, domain.ErrAccountNotFound
+	}
+	return account, nil
+}
+
+func (m *mockRepository) FindByAccountID(_ context.Context, accountID string) (domain.InternalAccount, error) {
+	if m.findByAccountIDErr != nil {
+		return domain.InternalAccount{}, m.findByAccountIDErr
+	}
+	account, ok := m.accountsByAcctID[accountID]
 	if !ok {
 		return domain.InternalAccount{}, domain.ErrAccountNotFound
 	}


### PR DESCRIPTION
## Summary

- `findAccountByID` only tried UUID parse then `account_code` lookup, but the frontend navigates to `/internal-accounts/{accountId}` using the business ID (e.g. `IBA-0dd2512c-...`)
- This value is stored in the `account_id` column, not `account_code` (which holds short codes like `CLA2`, `GSP-KWH-SEEB`)
- Added `FindByAccountID` repository method that searches the `account_id` column
- Updated lookup chain: UUID → business account_id → account_code

## Test plan

- [x] Unit tests pass (`go test ./services/internal-account/service/...`)
- [x] Build passes
- [ ] Verify on demo: clicking an internal account in the list navigates to detail page successfully