### PR TITLE
feat: tenant context propagation for Dex routes + JWKS auto-config

### DIFF
--- a/services/api-gateway/config.go
+++ b/services/api-gateway/config.go
@@ -247,7 +247,7 @@ func LoadAuthConfig() AuthConfig {
 // resolveAuthEndpoints determines the JWKS URL and JWT issuer, applying
 // embedded Dex defaults when DEX_ISSUER is set and explicit values are absent.
 func resolveAuthEndpoints() (jwksURL, jwtIssuer string) {
-	dexIssuer := os.Getenv("DEX_ISSUER")
+	dexIssuer := strings.TrimRight(os.Getenv("DEX_ISSUER"), "/")
 
 	jwksURL = os.Getenv("JWKS_URL")
 	if jwksURL == "" && dexIssuer != "" {

--- a/services/api-gateway/config.go
+++ b/services/api-gateway/config.go
@@ -206,42 +206,26 @@ func LoadConfig() (*Config, error) {
 //
 // Environment variables:
 //   - AUTH_ENABLED: Enable authentication (default: false)
-//   - JWKS_URL: JWKS endpoint URL for JWT validation
+//   - JWKS_URL: JWKS endpoint URL for JWT validation (defaults to DEX_ISSUER/keys when DEX_ISSUER is set)
 //   - JWKS_CACHE_TTL: Cache duration for JWKS keys (default: 24h)
 //   - JWKS_REFRESH_TTL: Background refresh interval (default: 1h)
-//   - JWT_ISSUER: Expected JWT issuer (optional)
+//   - JWT_ISSUER: Expected JWT issuer (defaults to DEX_ISSUER when set)
 //   - JWT_AUDIENCE: Expected JWT audience (optional)
 //   - API_KEYS: Comma-separated list of "key:identity" pairs
 //   - API_KEY_RATE_LIMIT_PER_SECOND: Requests per second per key (default: 100)
 //   - API_KEY_RATE_LIMIT_BURST: Burst size for rate limiting (default: 200)
 func LoadAuthConfig() AuthConfig {
+	jwksURL, jwtIssuer := resolveAuthEndpoints()
+
 	config := AuthConfig{
 		Enabled:            env.GetEnvAsBool("AUTH_ENABLED", false),
-		JWKSURL:            os.Getenv("JWKS_URL"),
-		Issuer:             os.Getenv("JWT_ISSUER"),
+		JWKSURL:            jwksURL,
+		JWKSCacheTTL:       getEnvAsDurationOrDefault("JWKS_CACHE_TTL", 24*time.Hour),
+		JWKSRefreshTTL:     getEnvAsDurationOrDefault("JWKS_REFRESH_TTL", 1*time.Hour),
+		Issuer:             jwtIssuer,
 		Audience:           os.Getenv("JWT_AUDIENCE"),
 		RateLimitPerSecond: 100,
 		RateLimitBurst:     200,
-	}
-
-	// Parse JWKS cache TTL
-	if ttl := os.Getenv("JWKS_CACHE_TTL"); ttl != "" {
-		if d, err := time.ParseDuration(ttl); err == nil {
-			config.JWKSCacheTTL = d
-		}
-	}
-	if config.JWKSCacheTTL == 0 {
-		config.JWKSCacheTTL = 24 * time.Hour
-	}
-
-	// Parse JWKS refresh TTL
-	if ttl := os.Getenv("JWKS_REFRESH_TTL"); ttl != "" {
-		if d, err := time.ParseDuration(ttl); err == nil {
-			config.JWKSRefreshTTL = d
-		}
-	}
-	if config.JWKSRefreshTTL == 0 {
-		config.JWKSRefreshTTL = 1 * time.Hour
 	}
 
 	// Parse API keys (format: "key1:identity1,key2:identity2")
@@ -249,21 +233,47 @@ func LoadAuthConfig() AuthConfig {
 		config.APIKeys = parseAPIKeysEnv(apiKeysEnv)
 	}
 
-	// Parse rate limit per second
-	if rps := os.Getenv("API_KEY_RATE_LIMIT_PER_SECOND"); rps != "" {
-		if v := env.GetEnvAsInt("API_KEY_RATE_LIMIT_PER_SECOND", 100); v > 0 {
-			config.RateLimitPerSecond = float64(v)
-		}
+	// Parse rate limit overrides
+	if v := env.GetEnvAsInt("API_KEY_RATE_LIMIT_PER_SECOND", 0); v > 0 {
+		config.RateLimitPerSecond = float64(v)
 	}
-
-	// Parse rate limit burst
-	if burst := os.Getenv("API_KEY_RATE_LIMIT_BURST"); burst != "" {
-		if v := env.GetEnvAsInt("API_KEY_RATE_LIMIT_BURST", 200); v > 0 {
-			config.RateLimitBurst = v
-		}
+	if v := env.GetEnvAsInt("API_KEY_RATE_LIMIT_BURST", 0); v > 0 {
+		config.RateLimitBurst = v
 	}
 
 	return config
+}
+
+// resolveAuthEndpoints determines the JWKS URL and JWT issuer, applying
+// embedded Dex defaults when DEX_ISSUER is set and explicit values are absent.
+func resolveAuthEndpoints() (jwksURL, jwtIssuer string) {
+	dexIssuer := os.Getenv("DEX_ISSUER")
+
+	jwksURL = os.Getenv("JWKS_URL")
+	if jwksURL == "" && dexIssuer != "" {
+		jwksURL = dexIssuer + "/keys"
+	}
+
+	jwtIssuer = os.Getenv("JWT_ISSUER")
+	if jwtIssuer == "" && dexIssuer != "" {
+		jwtIssuer = dexIssuer
+	}
+
+	return jwksURL, jwtIssuer
+}
+
+// getEnvAsDurationOrDefault parses an environment variable as a time.Duration,
+// returning the default value if the variable is unset or unparseable.
+func getEnvAsDurationOrDefault(key string, defaultVal time.Duration) time.Duration {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return defaultVal
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return defaultVal
+	}
+	return d
 }
 
 // loadEventStreamConfig loads event streaming configuration from environment variables.

--- a/services/api-gateway/config_test.go
+++ b/services/api-gateway/config_test.go
@@ -824,6 +824,14 @@ func TestLoadAuthConfig_DexIssuerDefaults(t *testing.T) {
 			wantIssuer:  "https://auth.example.com",
 		},
 		{
+			name: "DEX_ISSUER with trailing slash — normalised",
+			env: map[string]string{
+				"DEX_ISSUER": "http://localhost:8090/dex/",
+			},
+			wantJWKSURL: "http://localhost:8090/dex/keys",
+			wantIssuer:  "http://localhost:8090/dex",
+		},
+		{
 			name: "all explicitly set — DEX_ISSUER has no effect",
 			env: map[string]string{
 				"DEX_ISSUER": "http://localhost:8090/dex",

--- a/services/api-gateway/config_test.go
+++ b/services/api-gateway/config_test.go
@@ -507,11 +507,12 @@ func TestConfig_Validate_AuthEnabled(t *testing.T) {
 }
 
 func TestLoadAuthConfig_Defaults(t *testing.T) {
-	// Clear all auth-related env vars
+	// Clear all auth-related env vars (including DEX_ISSUER which can set defaults)
 	authEnvVars := []string{
 		"AUTH_ENABLED", "JWKS_URL", "JWKS_CACHE_TTL", "JWKS_REFRESH_TTL",
 		"JWT_ISSUER", "JWT_AUDIENCE", "API_KEYS",
 		"API_KEY_RATE_LIMIT_PER_SECOND", "API_KEY_RATE_LIMIT_BURST",
+		"DEX_ISSUER",
 	}
 	for _, key := range authEnvVars {
 		os.Unsetenv(key)
@@ -781,6 +782,78 @@ func setEventStreamEnvVars(t *testing.T, vars map[string]string) func() {
 	}
 }
 
+// TestLoadAuthConfig_DexIssuerDefaults verifies that DEX_ISSUER sets sensible
+// defaults for JWKS_URL and JWT_ISSUER when they are not explicitly set.
+func TestLoadAuthConfig_DexIssuerDefaults(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         map[string]string
+		wantJWKSURL string
+		wantIssuer  string
+	}{
+		{
+			name:        "no DEX_ISSUER, no JWKS_URL — both empty",
+			env:         map[string]string{},
+			wantJWKSURL: "",
+			wantIssuer:  "",
+		},
+		{
+			name: "DEX_ISSUER set, JWKS_URL not set — defaults to Dex keys endpoint",
+			env: map[string]string{
+				"DEX_ISSUER": "http://localhost:8090/dex",
+			},
+			wantJWKSURL: "http://localhost:8090/dex/keys",
+			wantIssuer:  "http://localhost:8090/dex",
+		},
+		{
+			name: "DEX_ISSUER set, JWKS_URL explicitly set — explicit wins",
+			env: map[string]string{
+				"DEX_ISSUER": "http://localhost:8090/dex",
+				"JWKS_URL":   "https://custom.example.com/.well-known/jwks.json",
+			},
+			wantJWKSURL: "https://custom.example.com/.well-known/jwks.json",
+			wantIssuer:  "http://localhost:8090/dex",
+		},
+		{
+			name: "DEX_ISSUER set, JWT_ISSUER explicitly set — explicit wins",
+			env: map[string]string{
+				"DEX_ISSUER": "http://localhost:8090/dex",
+				"JWT_ISSUER": "https://auth.example.com",
+			},
+			wantJWKSURL: "http://localhost:8090/dex/keys",
+			wantIssuer:  "https://auth.example.com",
+		},
+		{
+			name: "all explicitly set — DEX_ISSUER has no effect",
+			env: map[string]string{
+				"DEX_ISSUER": "http://localhost:8090/dex",
+				"JWKS_URL":   "https://custom.example.com/jwks",
+				"JWT_ISSUER": "https://auth.example.com",
+			},
+			wantJWKSURL: "https://custom.example.com/jwks",
+			wantIssuer:  "https://auth.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear all auth+dex env vars for isolation
+			for _, k := range []string{"DEX_ISSUER", "JWKS_URL", "JWT_ISSUER", "JWT_AUDIENCE", "AUTH_ENABLED", "API_KEYS"} {
+				t.Setenv(k, "")
+				os.Unsetenv(k)
+			}
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			config := LoadAuthConfig()
+
+			assert.Equal(t, tt.wantJWKSURL, config.JWKSURL, "JWKSURL")
+			assert.Equal(t, tt.wantIssuer, config.Issuer, "Issuer")
+		})
+	}
+}
+
 func setAuthEnvVars(t *testing.T, vars map[string]string) func() {
 	t.Helper()
 
@@ -788,6 +861,7 @@ func setAuthEnvVars(t *testing.T, vars map[string]string) func() {
 		"AUTH_ENABLED", "JWKS_URL", "JWKS_CACHE_TTL", "JWKS_REFRESH_TTL",
 		"JWT_ISSUER", "JWT_AUDIENCE", "API_KEYS",
 		"API_KEY_RATE_LIMIT_PER_SECOND", "API_KEY_RATE_LIMIT_BURST",
+		"DEX_ISSUER",
 	}
 
 	// Store original values

--- a/services/api-gateway/server.go
+++ b/services/api-gateway/server.go
@@ -81,8 +81,10 @@ func WithEventStreamHandlerHTTP(handler http.Handler) ServerOption {
 }
 
 // WithDexHandler sets the Dex OIDC handler to be mounted at /dex/*.
-// The handler is mounted WITHOUT auth or tenant middleware since Dex
-// manages its own authentication flows.
+// The handler is mounted with tenant resolution middleware (so that the
+// MeridianConnector can resolve the tenant from the subdomain) but WITHOUT
+// auth or tenant-authorization middleware since Dex manages its own
+// authentication flows (login forms, token issuance, etc.).
 func WithDexHandler(handler http.Handler) ServerOption {
 	return func(s *Server) {
 		s.dexHandler = handler
@@ -131,6 +133,10 @@ func NewServer(config *Config, logger *slog.Logger, tenantResolver *platformgate
 // WITHOUT any middleware. This is required for K8s probes which do not provide
 // authentication credentials or tenant context.
 //
+// Dex endpoints (/dex/*) go through tenant resolution only (no auth or tenant-authz).
+// This allows the MeridianConnector to resolve the tenant from the subdomain for
+// credential lookups while Dex manages its own authentication flows.
+//
 // API routes go through the middleware chain in this order:
 // 1. Auth middleware (validates JWT or API key, injects identity into context)
 // 2. Tenant middleware (resolves tenant from subdomain, injects tenant into context)
@@ -176,12 +182,16 @@ func (s *Server) registerRoutes() {
 		apiHandler = http.HandlerFunc(s.handleAPI)
 	}
 
-	// Dex OIDC endpoints - NO auth/tenant middleware.
-	// Dex manages its own authentication flows (login forms, token issuance, etc.).
+	// Dex OIDC endpoints - tenant resolution only, NO auth or tenant-authz.
+	// Tenant resolution is required so that MeridianConnector.Login can call
+	// tenant.RequireFromContext(ctx) to scope credential lookups to the correct
+	// tenant. Auth and tenant-authorization are skipped because Dex manages its
+	// own authentication flows (login forms, token issuance, JWKS, etc.).
 	// Must be registered BEFORE the "/" catch-all to take precedence.
 	// No StripPrefix: Dex includes the issuer path (/dex) in its internal routing.
 	if s.dexHandler != nil {
-		s.mux.Handle("/dex/", s.dexHandler)
+		dexHandler := s.wrapWithTenantOnly(s.dexHandler)
+		s.mux.Handle("/dex/", dexHandler)
 	}
 
 	// Build middleware chain: auth → tenant → tenant_authz → transcoder/proxy
@@ -218,6 +228,17 @@ func (s *Server) buildEventStreamHandler() http.Handler {
 	})
 
 	return s.wrapWithAuthChain(claimsBridge)
+}
+
+// wrapWithTenantOnly wraps a handler with tenant resolution middleware only.
+// No auth or tenant-authorization is applied. This is used for Dex endpoints
+// that need tenant context for credential lookups but manage their own
+// authentication flows.
+func (s *Server) wrapWithTenantOnly(inner http.Handler) http.Handler {
+	if s.tenantResolver != nil {
+		return s.tenantResolver.Handler(inner)
+	}
+	return inner
 }
 
 // wrapWithAuthChain wraps a handler with the auth middleware chain:

--- a/services/api-gateway/server_test.go
+++ b/services/api-gateway/server_test.go
@@ -12,7 +12,11 @@ import (
 
 	"github.com/meridianhub/meridian/services/api-gateway/auth"
 	gwhealth "github.com/meridianhub/meridian/services/api-gateway/health"
+	tenantdomain "github.com/meridianhub/meridian/services/tenant/domain"
 	"github.com/meridianhub/meridian/shared/pkg/health"
+	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
+	platformgateway "github.com/meridianhub/meridian/shared/platform/gateway"
+	tenantpkg "github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -968,4 +972,180 @@ func TestWithHealthChecker(t *testing.T) {
 	server := NewServer(config, logger, nil, WithHealthChecker(healthChecker))
 
 	assert.Equal(t, healthChecker, server.healthChecker)
+}
+
+// TestWithDexHandler_TenantContextPropagated verifies that Dex routes receive
+// tenant context from the tenant resolver middleware. The MeridianConnector
+// requires tenant.RequireFromContext(ctx) to succeed for credential lookups.
+func TestWithDexHandler_TenantContextPropagated(t *testing.T) {
+	var capturedTenantID string
+	fakeDex := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Extract tenant from context (set by tenant resolver middleware)
+		tid, ok := tenantpkg.FromContext(r.Context())
+		if ok {
+			capturedTenantID = string(tid)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	config := &Config{
+		Port:         8080,
+		BaseDomain:   "api.example.com",
+		DatabaseURL:  "postgres://localhost/test",
+		LocalDevMode: true,
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Create a real tenant resolver in LOCAL_DEV_MODE so we can use X-Tenant-Slug header
+	slugCache := platformgateway.NewInMemorySlugCache()
+	tenantRepo := &stubTenantRepo{
+		tenants: map[string]*tenantdomain.Tenant{
+			"volterra": {ID: "volterra", Slug: "volterra", DisplayName: "Volterra"},
+		},
+	}
+	tenantResolver, err := platformgateway.NewTenantResolverMiddleware(
+		slugCache, tenantRepo, "api.example.com", logger, true,
+	)
+	require.NoError(t, err)
+
+	server := NewServer(config, logger, tenantResolver, WithDexHandler(fakeDex))
+
+	// Request with X-Tenant-Slug header (LOCAL_DEV_MODE)
+	req := httptest.NewRequest(http.MethodPost, "/dex/token", nil)
+	req.Header.Set("X-Tenant-Slug", "volterra")
+	rec := httptest.NewRecorder()
+
+	server.mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "volterra", capturedTenantID, "tenant ID should be propagated to Dex handler")
+}
+
+// TestWithDexHandler_NoAuthRequired verifies that Dex routes do NOT require
+// authentication even when auth middleware is configured.
+func TestWithDexHandler_NoAuthRequired(t *testing.T) {
+	dexCalled := false
+	fakeDex := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		dexCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	config := &Config{
+		Port:         8080,
+		BaseDomain:   "api.example.com",
+		DatabaseURL:  "postgres://localhost/test",
+		LocalDevMode: true,
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Create a real tenant resolver
+	slugCache := platformgateway.NewInMemorySlugCache()
+	tenantRepo := &stubTenantRepo{
+		tenants: map[string]*tenantdomain.Tenant{
+			"volterra": {ID: "volterra", Slug: "volterra", DisplayName: "Volterra"},
+		},
+	}
+	tenantResolver, err := platformgateway.NewTenantResolverMiddleware(
+		slugCache, tenantRepo, "api.example.com", logger, true,
+	)
+	require.NoError(t, err)
+
+	// Create auth middleware with a rejecting JWT validator (simulates requiring auth)
+	rejectAll, err := auth.NewCombinedAuthMiddleware(auth.CombinedAuthConfig{
+		JWTValidator: &rejectingJWTValidator{},
+		Logger:       logger,
+	})
+	require.NoError(t, err)
+
+	server := NewServer(config, logger, tenantResolver,
+		WithDexHandler(fakeDex),
+		WithAuthMiddleware(rejectAll),
+	)
+
+	// Request to Dex endpoint WITHOUT any auth token
+	req := httptest.NewRequest(http.MethodGet, "/dex/keys", nil)
+	req.Header.Set("X-Tenant-Slug", "volterra")
+	rec := httptest.NewRecorder()
+
+	server.mux.ServeHTTP(rec, req)
+
+	assert.True(t, dexCalled, "Dex handler should be called without auth")
+	assert.Equal(t, http.StatusOK, rec.Code, "Dex should not require authentication")
+
+	// Verify that API routes DO require auth (to confirm auth middleware is active)
+	dexCalled = false
+	apiReq := httptest.NewRequest(http.MethodGet, "/v1/some-api", nil)
+	apiReq.Header.Set("X-Tenant-Slug", "volterra")
+	apiRec := httptest.NewRecorder()
+
+	server.mux.ServeHTTP(apiRec, apiReq)
+
+	assert.False(t, dexCalled, "Dex handler should not be called for API routes")
+	assert.Equal(t, http.StatusUnauthorized, apiRec.Code, "API routes should require authentication")
+}
+
+// TestWithDexHandler_SubdomainTenantResolution verifies tenant resolution via
+// subdomain for Dex routes (non-LOCAL_DEV_MODE).
+func TestWithDexHandler_SubdomainTenantResolution(t *testing.T) {
+	var capturedTenantID string
+	fakeDex := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tid, ok := tenantpkg.FromContext(r.Context())
+		if ok {
+			capturedTenantID = string(tid)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	config := &Config{
+		Port:        8080,
+		BaseDomain:  "demo.meridianhub.cloud",
+		DatabaseURL: "postgres://localhost/test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	slugCache := platformgateway.NewInMemorySlugCache()
+	tenantRepo := &stubTenantRepo{
+		tenants: map[string]*tenantdomain.Tenant{
+			"volterra": {ID: "volterra", Slug: "volterra", DisplayName: "Volterra"},
+		},
+	}
+	tenantResolver, err := platformgateway.NewTenantResolverMiddleware(
+		slugCache, tenantRepo, "demo.meridianhub.cloud", logger, false,
+	)
+	require.NoError(t, err)
+
+	server := NewServer(config, logger, tenantResolver, WithDexHandler(fakeDex))
+
+	// Request with subdomain-based tenant resolution
+	req := httptest.NewRequest(http.MethodPost, "/dex/token", nil)
+	req.Host = "volterra.demo.meridianhub.cloud"
+	rec := httptest.NewRecorder()
+
+	server.mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "volterra", capturedTenantID, "tenant should be resolved from subdomain")
+}
+
+// stubTenantRepo is a test stub for the tenant repository interface used by
+// TenantResolverMiddleware. It satisfies the unexported tenantRepository
+// interface via Go's structural typing.
+type stubTenantRepo struct {
+	tenants map[string]*tenantdomain.Tenant
+}
+
+func (s *stubTenantRepo) GetBySlug(_ context.Context, slug string) (*tenantdomain.Tenant, error) {
+	t, ok := s.tenants[slug]
+	if !ok {
+		return nil, tenantdomain.ErrNotFound
+	}
+	return t, nil
+}
+
+// rejectingJWTValidator always returns an error for any token. Used to verify
+// that Dex routes bypass auth while API routes are rejected.
+type rejectingJWTValidator struct{}
+
+func (r *rejectingJWTValidator) ValidateToken(_ string) (*platformauth.Claims, error) {
+	return nil, errors.New("token rejected by test validator")
 }


### PR DESCRIPTION
## Summary

- **Task 6**: Dex routes (`/dex/*`) are now wrapped with tenant resolution middleware so that `MeridianConnector.Login` can call `tenant.RequireFromContext(ctx)` to scope credential lookups to the correct tenant. Auth and tenant-authorization middleware remain skipped since Dex manages its own authentication flows.
- **Task 10**: When `DEX_ISSUER` is set, `JWKS_URL` defaults to `{DEX_ISSUER}/keys` and `JWT_ISSUER` defaults to `DEX_ISSUER`, removing the need for operators to configure these separately. Explicit env vars take precedence.

## Changes Made

**`services/api-gateway/server.go`**:
- Added `wrapWithTenantOnly()` method that applies only tenant resolution middleware (no auth, no tenant-authz)
- Changed Dex handler mounting from raw (no middleware) to tenant-resolved
- Updated route registration comments to document the Dex middleware chain

**`services/api-gateway/config.go`**:
- Extracted `resolveAuthEndpoints()` to derive JWKS URL and JWT issuer from `DEX_ISSUER` when explicit values are absent
- Extracted `getEnvAsDurationOrDefault()` helper to reduce cyclomatic complexity
- Refactored `LoadAuthConfig()` to use the extracted helpers

**`services/api-gateway/server_test.go`**:
- `TestWithDexHandler_TenantContextPropagated`: verifies tenant ID flows through to Dex handler via `X-Tenant-Slug` header
- `TestWithDexHandler_NoAuthRequired`: verifies Dex routes bypass auth even when `CombinedAuthMiddleware` is active, while API routes still require auth
- `TestWithDexHandler_SubdomainTenantResolution`: verifies subdomain-based tenant resolution for Dex routes

**`services/api-gateway/config_test.go`**:
- `TestLoadAuthConfig_DexIssuerDefaults`: 5 subtests covering all combinations of DEX_ISSUER, JWKS_URL, and JWT_ISSUER

## Test plan

- [x] All existing api-gateway tests pass (47s)
- [x] New tenant propagation tests verify tenant context in Dex handler
- [x] New config tests verify DEX_ISSUER defaulting with precedence rules
- [x] Auth bypass test confirms Dex routes work without auth while API routes reject unauthenticated requests