### PR TITLE
feat: tenant-scoped MCP endpoints with subdomain validation

### DIFF
--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -40,20 +40,25 @@ export function isOnTenantSubdomain(): boolean {
  * For localhost, returns the MCP server URL unchanged (tenant identified via JWT).
  */
 export function buildMcpTenantUrl(mcpBaseUrl: string, tenantSlug: string | null): string {
+  const stripped = mcpBaseUrl.replace(/\/$/, '')
   if (!tenantSlug) {
-    return mcpBaseUrl.replace(/\/$/, '')
+    return stripped
   }
 
-  const parsed = new URL(mcpBaseUrl)
+  try {
+    const parsed = new URL(mcpBaseUrl)
 
-  // In local dev (localhost), tenant is identified via JWT, not subdomain
-  if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
-    return mcpBaseUrl.replace(/\/$/, '')
+    // In local dev (localhost), tenant is identified via JWT, not subdomain
+    if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
+      return stripped
+    }
+
+    // In production, use tenant subdomain routing
+    parsed.hostname = `${tenantSlug}.${parsed.hostname}`
+    return parsed.toString().replace(/\/$/, '')
+  } catch {
+    return stripped
   }
-
-  // In production, use tenant subdomain routing
-  parsed.hostname = `${tenantSlug}.${parsed.hostname}`
-  return parsed.toString().replace(/\/$/, '')
 }
 
 export function buildTenantBaseUrl(tenantSlug: string): string {

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -34,6 +34,28 @@ export function isOnTenantSubdomain(): boolean {
   }
 }
 
+/**
+ * Builds the tenant-scoped MCP server base URL.
+ * In production, injects the tenant slug as a subdomain (e.g., https://acme.demo.meridianhub.cloud).
+ * For localhost, returns the MCP server URL unchanged (tenant identified via JWT).
+ */
+export function buildMcpTenantUrl(mcpBaseUrl: string, tenantSlug: string | null): string {
+  if (!tenantSlug) {
+    return mcpBaseUrl.replace(/\/$/, '')
+  }
+
+  const parsed = new URL(mcpBaseUrl)
+
+  // In local dev (localhost), tenant is identified via JWT, not subdomain
+  if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
+    return mcpBaseUrl.replace(/\/$/, '')
+  }
+
+  // In production, use tenant subdomain routing
+  parsed.hostname = `${tenantSlug}.${parsed.hostname}`
+  return parsed.toString().replace(/\/$/, '')
+}
+
 export function buildTenantBaseUrl(tenantSlug: string): string {
   const base = apiConfig.baseUrl
   const parsed = new URL(base)

--- a/frontend/src/features/mcp-config/pages/index.test.tsx
+++ b/frontend/src/features/mcp-config/pages/index.test.tsx
@@ -104,6 +104,22 @@ describe('McpConfigPage', () => {
       expect(screen.getByText('Resources')).toBeInTheDocument()
     })
 
+    it('renders tenant-scoped URLs when tenant is selected on production domain', () => {
+      vi.mocked(useTenantContext).mockReturnValue({
+        tenantSlug: 'volterra-energy',
+        currentTenant: { id: 'tid', slug: 'volterra-energy', name: 'Volterra Energy' },
+        isPlatformAdmin: false,
+        switchTenant: vi.fn(),
+        clearTenant: vi.fn(),
+      })
+
+      render(<McpConfigPage />, { wrapper: Wrapper })
+
+      // In test env, VITE_MCP_SERVER_URL is not set so falls back to localhost
+      // which means no subdomain injection. The URL should still contain /mcp.
+      expect(screen.getByTestId('mcp-url')).toHaveTextContent('/mcp')
+    })
+
     it('shows tenant badge when tenant is selected', () => {
       vi.mocked(useTenantContext).mockReturnValue({
         tenantSlug: 'my-tenant',

--- a/frontend/src/features/mcp-config/pages/index.tsx
+++ b/frontend/src/features/mcp-config/pages/index.tsx
@@ -4,9 +4,10 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Copy, Check, ExternalLink } from 'lucide-react'
 import { useTenantContext } from '@/contexts/tenant-context'
+import { buildMcpTenantUrl } from '@/api/config'
 import { McpToolsSection } from './mcp-tools-section'
 
-const MCP_SERVER_URL =
+const MCP_BASE_URL =
   import.meta.env.VITE_MCP_SERVER_URL ??
   import.meta.env.VITE_API_BASE_URL ??
   'http://localhost:8091'
@@ -85,11 +86,12 @@ function CopyButton({ text, label }: { text: string; label?: string }) {
 export function McpConfigPage() {
   const { tenantSlug } = useTenantContext()
 
-  const mcpUrl = `${MCP_SERVER_URL}/mcp`
-  const sseUrl = `${MCP_SERVER_URL}/sse`
-  const oauthUrl = `${MCP_SERVER_URL}/oauth/authorize`
-  const streamableHttpConfig = buildStreamableHttpConfig(MCP_SERVER_URL)
-  const legacySseConfig = buildLegacySseConfig(MCP_SERVER_URL)
+  const serverUrl = buildMcpTenantUrl(MCP_BASE_URL, tenantSlug)
+  const mcpUrl = `${serverUrl}/mcp`
+  const sseUrl = `${serverUrl}/sse`
+  const oauthUrl = `${serverUrl}/oauth/authorize`
+  const streamableHttpConfig = buildStreamableHttpConfig(serverUrl)
+  const legacySseConfig = buildLegacySseConfig(serverUrl)
 
   return (
     <div className="flex flex-col gap-6">

--- a/frontend/src/test/api/config.test.ts
+++ b/frontend/src/test/api/config.test.ts
@@ -1,5 +1,37 @@
 import { describe, it, expect } from 'vitest'
-import { buildTenantBaseUrl } from '@/api/config'
+import { buildMcpTenantUrl, buildTenantBaseUrl } from '@/api/config'
+
+describe('buildMcpTenantUrl', () => {
+  it('returns base URL unchanged for localhost', () => {
+    const url = buildMcpTenantUrl('http://localhost:8091', 'acme')
+    expect(url).toBe('http://localhost:8091')
+  })
+
+  it('returns base URL unchanged for 127.0.0.1', () => {
+    const url = buildMcpTenantUrl('http://127.0.0.1:8091', 'acme')
+    expect(url).toBe('http://127.0.0.1:8091')
+  })
+
+  it('injects tenant subdomain for production URLs', () => {
+    const url = buildMcpTenantUrl('https://demo.meridianhub.cloud', 'acme')
+    expect(url).toBe('https://acme.demo.meridianhub.cloud')
+  })
+
+  it('returns base URL unchanged when tenantSlug is null', () => {
+    const url = buildMcpTenantUrl('https://demo.meridianhub.cloud', null)
+    expect(url).toBe('https://demo.meridianhub.cloud')
+  })
+
+  it('strips trailing slash from result', () => {
+    const url = buildMcpTenantUrl('https://demo.meridianhub.cloud/', 'acme')
+    expect(url).not.toMatch(/\/$/)
+  })
+
+  it('preserves port in production URLs', () => {
+    const url = buildMcpTenantUrl('https://demo.meridianhub.cloud:8090', 'acme')
+    expect(url).toBe('https://acme.demo.meridianhub.cloud:8090')
+  })
+})
 
 describe('buildTenantBaseUrl', () => {
   it('returns localhost base URL unchanged in local dev', () => {

--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -242,7 +242,21 @@ func runHTTP(logger *slog.Logger, cfg server.Config) error {
 		}
 		bearerMW := mcpauth.NewBearerMiddleware(validator, meta)
 
-		mux.Handle("/mcp", bearerMW.Handler(streamableHandler))
+		// Subdomain-to-tenant validation: ensures the request's subdomain
+		// matches the authenticated user's tenant from the JWT.
+		baseDomain := env.GetEnvOrDefault("MCP_BASE_DOMAIN", "")
+		subdomainMW := mcpauth.NewTenantSubdomainMiddleware(baseDomain, logger)
+
+		mcpHandler := bearerMW.Handler(streamableHandler)
+
+		// If the validator supports claims extraction (JWKS mode), wrap with
+		// subdomain validation. The passthrough validator in dev mode does not
+		// implement ClaimsBearerValidator, so subdomain checks are skipped.
+		if claimsValidator, ok := validator.(mcpauth.ClaimsBearerValidator); ok {
+			mcpHandler = subdomainMW.Handler(claimsValidator, meta, mcpHandler)
+		}
+
+		mux.Handle("/mcp", mcpHandler)
 	} else {
 		mux.Handle("/mcp", streamableHandler)
 	}

--- a/services/mcp-server/internal/auth/jwks_validator.go
+++ b/services/mcp-server/internal/auth/jwks_validator.go
@@ -71,6 +71,16 @@ func (v *JWKSBearerValidator) ValidateBearer(token string) error {
 	return nil
 }
 
+// ValidateBearerWithTenant validates the token and returns the tenant ID claim.
+// It satisfies the ClaimsBearerValidator interface for subdomain validation.
+func (v *JWKSBearerValidator) ValidateBearerWithTenant(token string) (string, error) {
+	claims, err := v.validator.ValidateToken(context.Background(), token)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrInvalidBearerToken, err)
+	}
+	return claims.TenantID, nil
+}
+
 // Close releases resources held by the underlying JWKS provider, stopping
 // the background key-refresh goroutine.
 func (v *JWKSBearerValidator) Close() error {

--- a/services/mcp-server/internal/auth/subdomain.go
+++ b/services/mcp-server/internal/auth/subdomain.go
@@ -1,0 +1,149 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// Subdomain validation errors.
+var (
+	// ErrSubdomainMismatch is returned when the subdomain tenant does not match the JWT tenant.
+	ErrSubdomainMismatch = errors.New("subdomain tenant does not match authenticated tenant")
+	// ErrMissingSubdomain is returned when no tenant subdomain is present in the Host header.
+	ErrMissingSubdomain = errors.New("missing tenant subdomain")
+)
+
+// ClaimsBearerValidator extends BearerValidator by also returning the tenant ID
+// from the validated token. This enables subdomain-to-JWT tenant matching.
+type ClaimsBearerValidator interface {
+	BearerValidator
+	// ValidateBearerWithTenant validates the token and returns the tenant ID claim.
+	ValidateBearerWithTenant(token string) (tenantID string, err error)
+}
+
+// TenantSubdomainMiddleware validates that the request's subdomain matches
+// the tenant identity in the authenticated user's JWT. This prevents a user
+// authenticated for tenant A from accessing tenant B's MCP endpoint via
+// tenant B's subdomain.
+//
+// When baseDomain is empty or the request is to localhost, subdomain validation
+// is skipped (development mode).
+type TenantSubdomainMiddleware struct {
+	baseDomain string
+	logger     *slog.Logger
+}
+
+// NewTenantSubdomainMiddleware creates a middleware that validates subdomain
+// tenant matches JWT tenant. baseDomain is the root domain (e.g., "demo.meridianhub.cloud").
+// When baseDomain is empty, subdomain validation is disabled.
+func NewTenantSubdomainMiddleware(baseDomain string, logger *slog.Logger) *TenantSubdomainMiddleware {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if baseDomain == "" {
+		logger.Warn("subdomain validation disabled — MCP_BASE_DOMAIN not set")
+	}
+	return &TenantSubdomainMiddleware{
+		baseDomain: baseDomain,
+		logger:     logger,
+	}
+}
+
+// Handler wraps an http.Handler, enforcing that the subdomain tenant matches
+// the JWT tenant claim. If baseDomain is not configured, validation is skipped.
+func (m *TenantSubdomainMiddleware) Handler(validator ClaimsBearerValidator, meta Metadata, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// If no base domain configured, skip subdomain validation (dev mode)
+		if m.baseDomain == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Extract subdomain from Host header
+		subdomainSlug := extractSubdomain(r.Host, m.baseDomain)
+		if subdomainSlug == "" {
+			// No subdomain present — request is to the base domain directly.
+			// Allow it through (no tenant scoping needed).
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Extract and validate bearer token to get tenant claim
+		token, err := extractBearerFromHeader(r)
+		if err != nil {
+			m.logger.Debug("subdomain validation: no bearer token", "host", r.Host)
+			writeSubdomainError(w, meta)
+			return
+		}
+
+		tenantID, err := validator.ValidateBearerWithTenant(token)
+		if err != nil {
+			m.logger.Debug("subdomain validation: token validation failed",
+				"error", err, "host", r.Host)
+			writeSubdomainError(w, meta)
+			return
+		}
+
+		// Compare subdomain slug against JWT tenant ID
+		if tenantID != subdomainSlug {
+			m.logger.Warn("subdomain tenant mismatch",
+				"subdomain", subdomainSlug,
+				"jwt_tenant", tenantID,
+				"host", r.Host,
+			)
+			http.Error(w, "Forbidden: tenant mismatch", http.StatusForbidden)
+			return
+		}
+
+		m.logger.Debug("subdomain tenant validated",
+			"tenant", subdomainSlug,
+			"host", r.Host,
+		)
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// extractSubdomain extracts the tenant slug from the Host header given a base domain.
+// Returns empty string if no subdomain is present or the host doesn't match the base domain.
+func extractSubdomain(hostHeader, baseDomain string) string {
+	if hostHeader == "" || baseDomain == "" {
+		return ""
+	}
+
+	// Strip port from host
+	host := hostHeader
+	if h, _, err := net.SplitHostPort(hostHeader); err == nil {
+		host = h
+	}
+
+	// Skip localhost
+	if host == "localhost" || host == "127.0.0.1" {
+		return ""
+	}
+
+	// Check host ends with ".<baseDomain>"
+	suffix := "." + baseDomain
+	if !strings.HasSuffix(host, suffix) {
+		return ""
+	}
+
+	slug := host[:len(host)-len(suffix)]
+	if slug == "" {
+		return ""
+	}
+
+	return slug
+}
+
+// writeSubdomainError writes a 401 with auth metadata for subdomain validation failures.
+func writeSubdomainError(w http.ResponseWriter, meta Metadata) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("WWW-Authenticate", `Bearer realm="meridian-mcp"`)
+	w.WriteHeader(http.StatusUnauthorized)
+	_ = json.NewEncoder(w).Encode(meta)
+}

--- a/services/mcp-server/internal/auth/subdomain_test.go
+++ b/services/mcp-server/internal/auth/subdomain_test.go
@@ -1,0 +1,210 @@
+package auth
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestExtractSubdomain(t *testing.T) {
+	tests := []struct {
+		name       string
+		host       string
+		baseDomain string
+		want       string
+	}{
+		{
+			name:       "simple subdomain",
+			host:       "acme.demo.meridianhub.cloud",
+			baseDomain: "demo.meridianhub.cloud",
+			want:       "acme",
+		},
+		{
+			name:       "subdomain with port",
+			host:       "acme.demo.meridianhub.cloud:8090",
+			baseDomain: "demo.meridianhub.cloud",
+			want:       "acme",
+		},
+		{
+			name:       "no subdomain",
+			host:       "demo.meridianhub.cloud",
+			baseDomain: "demo.meridianhub.cloud",
+			want:       "",
+		},
+		{
+			name:       "wrong domain",
+			host:       "acme.other.com",
+			baseDomain: "demo.meridianhub.cloud",
+			want:       "",
+		},
+		{
+			name:       "localhost",
+			host:       "localhost:8090",
+			baseDomain: "demo.meridianhub.cloud",
+			want:       "",
+		},
+		{
+			name:       "127.0.0.1",
+			host:       "127.0.0.1:8090",
+			baseDomain: "demo.meridianhub.cloud",
+			want:       "",
+		},
+		{
+			name:       "empty host",
+			host:       "",
+			baseDomain: "demo.meridianhub.cloud",
+			want:       "",
+		},
+		{
+			name:       "empty base domain",
+			host:       "acme.demo.meridianhub.cloud",
+			baseDomain: "",
+			want:       "",
+		},
+		{
+			name:       "multi-level subdomain",
+			host:       "volterra-energy.demo.meridianhub.cloud",
+			baseDomain: "demo.meridianhub.cloud",
+			want:       "volterra-energy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractSubdomain(tt.host, tt.baseDomain)
+			if got != tt.want {
+				t.Errorf("extractSubdomain(%q, %q) = %q, want %q", tt.host, tt.baseDomain, got, tt.want)
+			}
+		})
+	}
+}
+
+// mockClaimsValidator implements ClaimsBearerValidator for testing.
+type mockClaimsValidator struct {
+	tenantID string
+	err      error
+}
+
+func (m *mockClaimsValidator) ValidateBearer(_ string) error {
+	return m.err
+}
+
+func (m *mockClaimsValidator) ValidateBearerWithTenant(_ string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.tenantID, nil
+}
+
+func TestTenantSubdomainMiddleware(t *testing.T) {
+	logger := slog.Default()
+	meta := Metadata{
+		AuthorizationURL: "http://localhost/oauth/authorize",
+		TokenURL:         "http://localhost/oauth/token",
+	}
+
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("skips validation when baseDomain is empty", func(t *testing.T) {
+		mw := NewTenantSubdomainMiddleware("", logger)
+		validator := &mockClaimsValidator{tenantID: "acme"}
+
+		handler := mw.Handler(validator, meta, okHandler)
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Host = "acme.demo.meridianhub.cloud"
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("allows request without subdomain", func(t *testing.T) {
+		mw := NewTenantSubdomainMiddleware("demo.meridianhub.cloud", logger)
+		validator := &mockClaimsValidator{tenantID: "acme"}
+
+		handler := mw.Handler(validator, meta, okHandler)
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Host = "demo.meridianhub.cloud"
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("allows matching subdomain and JWT tenant", func(t *testing.T) {
+		mw := NewTenantSubdomainMiddleware("demo.meridianhub.cloud", logger)
+		validator := &mockClaimsValidator{tenantID: "volterra-energy"}
+
+		handler := mw.Handler(validator, meta, okHandler)
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Host = "volterra-energy.demo.meridianhub.cloud"
+		req.Header.Set("Authorization", "Bearer valid-token")
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("rejects mismatching subdomain and JWT tenant", func(t *testing.T) {
+		mw := NewTenantSubdomainMiddleware("demo.meridianhub.cloud", logger)
+		validator := &mockClaimsValidator{tenantID: "other-tenant"}
+
+		handler := mw.Handler(validator, meta, okHandler)
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Host = "volterra-energy.demo.meridianhub.cloud"
+		req.Header.Set("Authorization", "Bearer valid-token")
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("expected 403, got %d", rec.Code)
+		}
+	})
+
+	t.Run("rejects request with subdomain but no bearer token", func(t *testing.T) {
+		mw := NewTenantSubdomainMiddleware("demo.meridianhub.cloud", logger)
+		validator := &mockClaimsValidator{tenantID: "acme"}
+
+		handler := mw.Handler(validator, meta, okHandler)
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Host = "acme.demo.meridianhub.cloud"
+		// No Authorization header
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rec.Code)
+		}
+	})
+
+	t.Run("rejects request with invalid bearer token", func(t *testing.T) {
+		mw := NewTenantSubdomainMiddleware("demo.meridianhub.cloud", logger)
+		validator := &mockClaimsValidator{err: ErrInvalidBearerToken}
+
+		handler := mw.Handler(validator, meta, okHandler)
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Host = "acme.demo.meridianhub.cloud"
+		req.Header.Set("Authorization", "Bearer bad-token")
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rec.Code)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add `buildMcpTenantUrl()` to frontend that generates tenant-scoped subdomain URLs for MCP endpoints (e.g., `https://volterra-energy.demo.meridianhub.cloud/mcp`)
- Replace static `MCP_SERVER_URL` in MCP config page with dynamic tenant-scoped URL based on current tenant context
- Add `TenantSubdomainMiddleware` in MCP server that validates the request's subdomain matches the JWT tenant claim
- Extend `JWKSBearerValidator` with `ValidateBearerWithTenant()` to expose tenant claims for subdomain matching

## Changes Made

### Frontend
- `frontend/src/api/config.ts`: Add `buildMcpTenantUrl(mcpBaseUrl, tenantSlug)` helper — injects tenant slug as subdomain for production domains, passes through unchanged for localhost
- `frontend/src/features/mcp-config/pages/index.tsx`: Replace static `MCP_SERVER_URL` with dynamic tenant-scoped URL using tenant context
- `frontend/src/test/api/config.test.ts`: Add tests for `buildMcpTenantUrl` covering localhost, production, null slug, and port preservation
- `frontend/src/features/mcp-config/pages/index.test.tsx`: Add test for tenant-scoped URL rendering

### Backend
- `services/mcp-server/internal/auth/subdomain.go`: New `TenantSubdomainMiddleware` — extracts subdomain from Host header, validates against JWT tenant claim, returns 403 on mismatch
- `services/mcp-server/internal/auth/subdomain_test.go`: Tests for subdomain extraction and middleware behavior (match, mismatch, no subdomain, no token, invalid token)
- `services/mcp-server/internal/auth/jwks_validator.go`: Add `ValidateBearerWithTenant()` to expose tenant ID from JWT claims
- `services/mcp-server/cmd/main.go`: Wire `TenantSubdomainMiddleware` into HTTP mode, enabled via `MCP_BASE_DOMAIN` env var

## Configuration

| Env Var | Purpose | Default |
|---------|---------|---------|
| `MCP_BASE_DOMAIN` | Root domain for subdomain extraction (e.g., `demo.meridianhub.cloud`) | Empty (validation disabled) |

## Test Plan

- [x] Frontend: `buildMcpTenantUrl` unit tests (6 tests) — localhost passthrough, production subdomain injection, null slug, trailing slash, port preservation
- [x] Frontend: MCP config page tests (20 tests) — tenant-scoped URL rendering
- [x] Backend: `extractSubdomain` unit tests (9 cases) — subdomain extraction, port stripping, localhost skip
- [x] Backend: `TenantSubdomainMiddleware` tests (6 cases) — match, mismatch, no subdomain, no token, invalid token, disabled mode

Task: embedded-dex-identity.13