### PR TITLE
feat: extend HandlerMetadata with proto type references and AllWithMetadata

### DIFF
--- a/shared/pkg/saga/handlers.go
+++ b/shared/pkg/saga/handlers.go
@@ -475,6 +475,18 @@ func (r *HandlerRegistry) Has(name string) bool {
 	return exists
 }
 
+// AllWithMetadata returns a map of all registered handler names to their metadata.
+func (r *HandlerRegistry) AllWithMetadata() map[string]*HandlerMetadata {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make(map[string]*HandlerMetadata, len(r.metadata))
+	for name, meta := range r.metadata {
+		result[name] = meta
+	}
+	return result
+}
+
 // List returns a sorted list of all registered handler names.
 func (r *HandlerRegistry) List() []string {
 	r.mu.RLock()

--- a/shared/pkg/saga/handlers.go
+++ b/shared/pkg/saga/handlers.go
@@ -475,37 +475,63 @@ func (r *HandlerRegistry) Has(name string) bool {
 	return exists
 }
 
-// AllWithMetadata returns a snapshot map of all registered handler names to their metadata.
-// The returned metadata values are shallow copies; callers may read freely without affecting
-// the registry. For deeply nested mutable fields (slices, maps), treat as read-only.
+// AllWithMetadata returns a deep-copy snapshot of all registered handler names to their metadata.
+// Callers may freely mutate the returned values without affecting the registry.
 func (r *HandlerRegistry) AllWithMetadata() map[string]*HandlerMetadata {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	result := make(map[string]*HandlerMetadata, len(r.metadata))
 	for name, meta := range r.metadata {
-		if meta == nil {
-			result[name] = nil
-			continue
-		}
-		clone := *meta
-		if meta.ProducesInstruments != nil {
-			clone.ProducesInstruments = make([]string, len(meta.ProducesInstruments))
-			copy(clone.ProducesInstruments, meta.ProducesInstruments)
-		}
-		if meta.ParamOverrides != nil {
-			clone.ParamOverrides = make(map[string]ParamOverride, len(meta.ParamOverrides))
-			for k, v := range meta.ParamOverrides {
-				clone.ParamOverrides[k] = v
-			}
-		}
-		if meta.Conversions != nil {
-			clone.Conversions = make([]HandlerConversion, len(meta.Conversions))
-			copy(clone.Conversions, meta.Conversions)
-		}
-		result[name] = &clone
+		result[name] = cloneHandlerMetadata(meta)
 	}
 	return result
+}
+
+// cloneHandlerMetadata returns a deep copy of a HandlerMetadata, including all
+// nested slices and maps. Returns nil for nil input.
+func cloneHandlerMetadata(meta *HandlerMetadata) *HandlerMetadata {
+	if meta == nil {
+		return nil
+	}
+	clone := *meta
+	if meta.ProducesInstruments != nil {
+		clone.ProducesInstruments = make([]string, len(meta.ProducesInstruments))
+		copy(clone.ProducesInstruments, meta.ProducesInstruments)
+	}
+	if meta.ParamOverrides != nil {
+		clone.ParamOverrides = make(map[string]ParamOverride, len(meta.ParamOverrides))
+		for k, v := range meta.ParamOverrides {
+			clone.ParamOverrides[k] = v
+		}
+	}
+	if meta.Conversions != nil {
+		clone.Conversions = make([]HandlerConversion, len(meta.Conversions))
+		for i, conv := range meta.Conversions {
+			clone.Conversions[i] = cloneHandlerConversion(conv)
+		}
+	}
+	return &clone
+}
+
+// cloneHandlerConversion returns a deep copy of a HandlerConversion.
+func cloneHandlerConversion(conv HandlerConversion) HandlerConversion {
+	c := conv
+	c.ParamMapping = cloneStringMap(conv.ParamMapping)
+	c.Defaults = cloneStringMap(conv.Defaults)
+	return c
+}
+
+// cloneStringMap returns a deep copy of a string-to-string map. Returns nil for nil input.
+func cloneStringMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	clone := make(map[string]string, len(m))
+	for k, v := range m {
+		clone[k] = v
+	}
+	return clone
 }
 
 // List returns a sorted list of all registered handler names.

--- a/shared/pkg/saga/handlers.go
+++ b/shared/pkg/saga/handlers.go
@@ -502,6 +502,10 @@ func cloneHandlerMetadata(meta *HandlerMetadata) *HandlerMetadata {
 	if meta.ParamOverrides != nil {
 		clone.ParamOverrides = make(map[string]ParamOverride, len(meta.ParamOverrides))
 		for k, v := range meta.ParamOverrides {
+			if v.Required != nil {
+				reqCopy := *v.Required
+				v.Required = &reqCopy
+			}
 			clone.ParamOverrides[k] = v
 		}
 	}

--- a/shared/pkg/saga/handlers.go
+++ b/shared/pkg/saga/handlers.go
@@ -475,14 +475,35 @@ func (r *HandlerRegistry) Has(name string) bool {
 	return exists
 }
 
-// AllWithMetadata returns a map of all registered handler names to their metadata.
+// AllWithMetadata returns a snapshot map of all registered handler names to their metadata.
+// The returned metadata values are shallow copies; callers may read freely without affecting
+// the registry. For deeply nested mutable fields (slices, maps), treat as read-only.
 func (r *HandlerRegistry) AllWithMetadata() map[string]*HandlerMetadata {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	result := make(map[string]*HandlerMetadata, len(r.metadata))
 	for name, meta := range r.metadata {
-		result[name] = meta
+		if meta == nil {
+			result[name] = nil
+			continue
+		}
+		clone := *meta
+		if meta.ProducesInstruments != nil {
+			clone.ProducesInstruments = make([]string, len(meta.ProducesInstruments))
+			copy(clone.ProducesInstruments, meta.ProducesInstruments)
+		}
+		if meta.ParamOverrides != nil {
+			clone.ParamOverrides = make(map[string]ParamOverride, len(meta.ParamOverrides))
+			for k, v := range meta.ParamOverrides {
+				clone.ParamOverrides[k] = v
+			}
+		}
+		if meta.Conversions != nil {
+			clone.Conversions = make([]HandlerConversion, len(meta.Conversions))
+			copy(clone.Conversions, meta.Conversions)
+		}
+		result[name] = &clone
 	}
 	return result
 }

--- a/shared/pkg/saga/handlers_test.go
+++ b/shared/pkg/saga/handlers_test.go
@@ -628,6 +628,73 @@ func TestHandlerRegistry_GetWithMetadata_NoMetadata(t *testing.T) {
 	assert.Nil(t, md, "handlers registered without metadata should return nil metadata")
 }
 
+// TestHandlerRegistry_AllWithMetadata tests retrieving all handlers with metadata.
+func TestHandlerRegistry_AllWithMetadata(t *testing.T) {
+	t.Run("returns empty map for empty registry", func(t *testing.T) {
+		registry := NewHandlerRegistry()
+		result := registry.AllWithMetadata()
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns all registered handlers with metadata", func(t *testing.T) {
+		registry := NewHandlerRegistry()
+
+		handler := func(_ *StarlarkContext, _ map[string]any) (any, error) {
+			return nil, nil
+		}
+
+		meta1 := &HandlerMetadata{
+			Category:    HandlerCategoryIngestion,
+			Description: "Ingest meter readings",
+		}
+		meta2 := &HandlerMetadata{
+			Category:    HandlerCategorySettlement,
+			Description: "Settle positions",
+		}
+
+		require.NoError(t, registry.RegisterWithMetadata("handler.a", handler, meta1))
+		require.NoError(t, registry.RegisterWithMetadata("handler.b", handler, meta2))
+
+		result := registry.AllWithMetadata()
+		assert.Len(t, result, 2)
+		assert.Equal(t, meta1, result["handler.a"])
+		assert.Equal(t, meta2, result["handler.b"])
+	})
+
+	t.Run("returns nil metadata for handlers registered without metadata", func(t *testing.T) {
+		registry := NewHandlerRegistry()
+
+		handler := func(_ *StarlarkContext, _ map[string]any) (any, error) {
+			return nil, nil
+		}
+
+		require.NoError(t, registry.Register("handler.no-meta", handler))
+
+		result := registry.AllWithMetadata()
+		assert.Len(t, result, 1)
+		assert.Nil(t, result["handler.no-meta"])
+	})
+
+	t.Run("returns a copy that does not affect registry", func(t *testing.T) {
+		registry := NewHandlerRegistry()
+
+		handler := func(_ *StarlarkContext, _ map[string]any) (any, error) {
+			return nil, nil
+		}
+
+		meta := &HandlerMetadata{Category: HandlerCategoryValuation}
+		require.NoError(t, registry.RegisterWithMetadata("handler.x", handler, meta))
+
+		result := registry.AllWithMetadata()
+		// Mutate the returned map
+		delete(result, "handler.x")
+
+		// Registry should be unaffected
+		assert.True(t, registry.Has("handler.x"))
+		assert.Len(t, registry.AllWithMetadata(), 1)
+	})
+}
+
 // TestHandlerCategory_Values tests handler category constants.
 func TestHandlerCategory_Values(t *testing.T) {
 	assert.Equal(t, HandlerCategory("ingestion"), HandlerCategoryIngestion)

--- a/shared/pkg/saga/handlers_test.go
+++ b/shared/pkg/saga/handlers_test.go
@@ -682,16 +682,31 @@ func TestHandlerRegistry_AllWithMetadata(t *testing.T) {
 			return nil, nil
 		}
 
-		meta := &HandlerMetadata{Category: HandlerCategoryValuation}
+		meta := &HandlerMetadata{
+			Category:            HandlerCategoryValuation,
+			ProducesInstruments: []string{"USD", "NZD"},
+			Description:         "original",
+		}
 		require.NoError(t, registry.RegisterWithMetadata("handler.x", handler, meta))
 
 		result := registry.AllWithMetadata()
+
 		// Mutate the returned map
 		delete(result, "handler.x")
-
 		// Registry should be unaffected
 		assert.True(t, registry.Has("handler.x"))
 		assert.Len(t, registry.AllWithMetadata(), 1)
+
+		// Mutate the returned metadata fields
+		result2 := registry.AllWithMetadata()
+		result2["handler.x"].Description = "mutated"
+		result2["handler.x"].ProducesInstruments[0] = "MUTATED"
+
+		// Original registry metadata should be unaffected
+		_, origMeta, err := registry.GetWithMetadata("handler.x")
+		require.NoError(t, err)
+		assert.Equal(t, "original", origMeta.Description)
+		assert.Equal(t, "USD", origMeta.ProducesInstruments[0])
 	})
 }
 

--- a/shared/pkg/saga/linter.go
+++ b/shared/pkg/saga/linter.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"go.starlark.net/syntax"
+	"google.golang.org/protobuf/proto"
 )
 
 // LintIssueType categorizes the kind of lint issue detected.
@@ -78,6 +79,49 @@ const (
 	HandlerCategoryValuation HandlerCategory = "valuation"
 )
 
+// OverrideFieldType is a string alias for schema.FieldType, used to avoid circular imports
+// between saga and saga/schema packages. Values should match schema.FieldType constants
+// (e.g., "string", "Decimal", "uuid", "int64", "enum", etc.).
+type OverrideFieldType = string
+
+// ParamOverride defines Starlark-specific behavior overrides for a handler parameter.
+// These allow handler authors to customize how proto-derived parameters appear in Starlark.
+type ParamOverride struct {
+	// Type overrides the proto-derived type (e.g., "Decimal" for string fields
+	// that actually represent decimal values in Starlark). Use schema.FieldType values.
+	Type OverrideFieldType
+
+	// Alias provides an alternative name for the parameter in Starlark scripts.
+	Alias string
+
+	// Derived indicates the parameter is computed and should not appear in Starlark input.
+	Derived bool
+
+	// Deprecated marks the parameter as deprecated with a migration message.
+	Deprecated string
+
+	// Required overrides the proto-derived requiredness. Nil means use proto default.
+	Required *bool
+}
+
+// HandlerConversion defines how to migrate from an older handler version or name.
+type HandlerConversion struct {
+	// FromVersion is the version number being migrated from.
+	FromVersion int
+
+	// FromName is the previous handler name (for handler renames).
+	FromName string
+
+	// ParamMapping maps old parameter names to new parameter names.
+	ParamMapping map[string]string
+
+	// Defaults provides default values for new parameters not present in old versions.
+	Defaults map[string]string
+
+	// Sunset is an ISO date string after which the old version is no longer accepted.
+	Sunset string
+}
+
 // HandlerMetadata describes a step handler's characteristics.
 type HandlerMetadata struct {
 	// IsExternal indicates the handler calls external systems (non-idempotent).
@@ -101,6 +145,31 @@ type HandlerMetadata struct {
 
 	// HasAutoCompensation indicates the handler has a compensate: field.
 	HasAutoCompensation bool
+
+	// Compensate is the name of the compensation handler (from handlers.yaml compensate: field).
+	Compensate string
+
+	// ProtoRequestType is a nil instance of the handler's proto request message for reflection.
+	ProtoRequestType proto.Message
+
+	// ProtoResponseType is a nil instance of the handler's proto response message for reflection.
+	ProtoResponseType proto.Message
+
+	// Description is a human-readable description of the handler's purpose.
+	Description string
+
+	// ParamOverrides customizes Starlark-specific behavior for individual parameters.
+	// Keys are parameter names as they appear in the proto message.
+	ParamOverrides map[string]ParamOverride
+
+	// Version is the handler's schema version for evolution tracking.
+	Version int
+
+	// Conversions defines migration rules from older handler versions or names.
+	Conversions []HandlerConversion
+
+	// When true, indicates this handler is deprecated and should not be used in new sagas.
+	Deprecated bool
 }
 
 // SemanticLinter performs AST-based semantic analysis on Starlark scripts.

--- a/shared/pkg/saga/linter.go
+++ b/shared/pkg/saga/linter.go
@@ -168,8 +168,10 @@ type HandlerMetadata struct {
 	// Conversions defines migration rules from older handler versions or names.
 	Conversions []HandlerConversion
 
-	// When true, indicates this handler is deprecated and should not be used in new sagas.
-	Deprecated bool
+	// DeprecatedMessage, when non-empty, indicates this handler is deprecated.
+	// The value provides a migration message (e.g., "use handler_v2 instead").
+	// Empty string means the handler is not deprecated.
+	DeprecatedMessage string
 }
 
 // SemanticLinter performs AST-based semantic analysis on Starlark scripts.


### PR DESCRIPTION
## Summary

- Extend `HandlerMetadata` struct with fields for proto-driven schema derivation: `ProtoRequestType`, `ProtoResponseType`, `Description`, `Compensate`, `ParamOverrides`, `Version`, `Conversions`, and `Deprecated`
- Add supporting types `ParamOverride` (with `OverrideFieldType` string alias to avoid circular saga/schema imports) and `HandlerConversion`
- Add `HandlerRegistry.AllWithMetadata()` method returning all registered handlers with their metadata

## Context

Tasks handler-schema-alignment.1 and handler-schema-alignment.3 from the handler-schema-alignment epic. These are foundation types that subsequent tasks (proto reflection derivation, handler annotation) build upon.

## Test plan

- [x] Unit tests for `AllWithMetadata`: empty registry, populated registry, nil metadata for legacy handlers, map copy isolation
- [x] All existing saga package tests pass (`go test ./shared/pkg/saga/...`)
- [x] Build passes (`go build ./shared/pkg/saga/...`)
- [x] Lint passes (golangci-lint via pre-commit hook)