### PR TITLE
feat: redirect tenant-scoped routes to tenant subdomain

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import { AuthProvider, useAuth } from '@/contexts/auth-context'
 import { TenantProvider, useTenantContext } from '@/contexts/tenant-context'
 import { useTenants } from '@/hooks/use-tenants'
 import { ApiClientProvider } from '@/api/context'
-import { ProtectedRoute, PlatformOnlyRoute, AdminOnlyRoute } from '@/components/routing'
+import { ProtectedRoute, PlatformOnlyRoute, AdminOnlyRoute, TenantSubdomainEnforcer } from '@/components/routing'
 import { FeatureGuard } from '@/components/feature-guard'
 import { AppShell } from '@/components/layout/app-shell'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -401,7 +401,9 @@ function AuthenticatedApp() {
                 path="/*"
                 element={
                   <ProtectedRoute>
-                    <AppShellLayout />
+                    <TenantSubdomainEnforcer>
+                      <AppShellLayout />
+                    </TenantSubdomainEnforcer>
                   </ProtectedRoute>
                 }
               />

--- a/frontend/src/components/routing.tsx
+++ b/frontend/src/components/routing.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from 'react'
-import { Navigate } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/contexts/auth-context'
+import { useTenantContext } from '@/contexts/tenant-context'
+import { apiConfig, isOnTenantSubdomain } from '@/api/config'
 
 interface ProtectedRouteProps {
   children: ReactNode
@@ -51,5 +53,59 @@ export function AdminOnlyRoute({ children }: AdminOnlyRouteProps) {
   if (!hasAdminRole) {
     return <Navigate to="/" replace />
   }
+  return <>{children}</>
+}
+
+/** Routes that live on the root domain (no tenant subdomain needed). */
+const PLATFORM_PATHS = ['/login', '/tenants', '/platform', '/users']
+
+function isPlatformPath(pathname: string): boolean {
+  return PLATFORM_PATHS.some((p) => pathname === p || pathname.startsWith(p + '/'))
+}
+
+function isLocalDev(): boolean {
+  const hostname = window.location.hostname
+  return hostname === 'localhost' || hostname === '127.0.0.1'
+}
+
+/**
+ * Redirects to the tenant subdomain when the user is on the root domain
+ * but navigating to a tenant-scoped route with a selected tenant.
+ *
+ * Platform routes (/tenants, /platform, /users, /login) stay on root.
+ * Local dev is never redirected (no subdomain support).
+ */
+export function TenantSubdomainEnforcer({ children }: { children: ReactNode }) {
+  const { pathname, search, hash } = useLocation()
+  const { tenantSlug } = useTenantContext()
+
+  // Skip in local dev — subdomains don't work on localhost
+  if (isLocalDev()) {
+    return <>{children}</>
+  }
+
+  // Already on a tenant subdomain — no redirect needed
+  if (isOnTenantSubdomain()) {
+    return <>{children}</>
+  }
+
+  // Platform routes stay on root domain
+  if (isPlatformPath(pathname)) {
+    return <>{children}</>
+  }
+
+  // Tenant-scoped route on root domain with a tenant selected → redirect
+  if (tenantSlug) {
+    const parsed = new URL(apiConfig.baseUrl)
+    const target = new URL(window.location.href)
+    target.hostname = `${tenantSlug}.${parsed.hostname}`
+    target.pathname = pathname
+    target.search = search
+    target.hash = hash
+    window.location.href = target.toString()
+    return null
+  }
+
+  // No tenant selected — show content (DevTenantAutoSelector may still be loading)
   return <>{children}</>
 }


### PR DESCRIPTION
## Summary

- When accessing tenant-scoped routes (e.g. `/parties`, `/accounts`, `/positions`) from the root domain (`demo.meridianhub.cloud`), the backend has no tenant context and returns errors
- Added `TenantSubdomainEnforcer` component that detects this situation and redirects to `{slug}.demo.meridianhub.cloud/{path}`
- Platform routes (`/tenants`, `/platform`, `/users`, `/login`) stay on root domain
- Local dev excluded (subdomains don't work on localhost)

## How it works

1. User logs in at `demo.meridianhub.cloud/login`
2. `DevTenantAutoSelector` picks first tenant (e.g. `volterra-energy`)
3. User navigates to `/parties`
4. `TenantSubdomainEnforcer` detects: root domain + tenant route + tenant selected
5. Redirects to `volterra-energy.demo.meridianhub.cloud/parties`

## Test plan

- [x] TypeScript compiles clean
- [x] Transport tests pass
- [ ] Verify on demo: navigating to /parties from root domain redirects to tenant subdomain
- [ ] Verify /tenants page stays on root domain (no redirect)
- [ ] Verify local dev is unaffected