### PR TITLE
fix: defer JWKS initial fetch to avoid embedded Dex startup race

### DIFF
--- a/shared/platform/auth/jwks.go
+++ b/shared/platform/auth/jwks.go
@@ -66,16 +66,21 @@ type JWKSProvider struct {
 	cacheTTL   time.Duration
 	refreshTTL time.Duration
 
-	mu          sync.RWMutex
-	keys        map[string]*rsa.PublicKey
-	lastFetch   time.Time
-	stopRefresh chan struct{}
-	closeOnce   sync.Once
+	mu              sync.RWMutex
+	keys            map[string]*rsa.PublicKey
+	lastFetch       time.Time
+	stopRefresh     chan struct{}
+	closeOnce       sync.Once
+	autoRefreshOnce sync.Once
 }
 
 // NewJWKSProvider creates a new JWKS provider with the specified configuration.
-// It validates the configuration and starts automatic key refresh if RefreshTTL is set.
-func NewJWKSProvider(ctx context.Context, cfg *JWKSProviderConfig) (*JWKSProvider, error) {
+// It validates the configuration and defers the initial JWKS fetch to the first
+// GetKey call, enabling the provider to be created before the JWKS endpoint is
+// available (e.g. when the OIDC server is embedded in the same process).
+//
+// Automatic key refresh starts after the first successful fetch.
+func NewJWKSProvider(_ context.Context, cfg *JWKSProviderConfig) (*JWKSProvider, error) {
 	if cfg.URL == "" {
 		return nil, fmt.Errorf("failed to create JWKS provider: %w", ErrJWKSURLEmpty)
 	}
@@ -103,15 +108,9 @@ func NewJWKSProvider(ctx context.Context, cfg *JWKSProviderConfig) (*JWKSProvide
 		stopRefresh: make(chan struct{}),
 	}
 
-	// Perform initial fetch
-	if err := provider.refresh(ctx); err != nil {
-		return nil, fmt.Errorf("failed to perform initial JWKS fetch: %w", err)
-	}
-
-	// Start automatic refresh if configured
-	if cfg.RefreshTTL > 0 {
-		go provider.autoRefresh(ctx)
-	}
+	// No initial fetch — keys are fetched lazily on first GetKey call.
+	// This avoids a startup race when the JWKS endpoint is served by the
+	// same process (embedded Dex OIDC).
 
 	return provider, nil
 }
@@ -136,6 +135,14 @@ func (p *JWKSProvider) GetKey(ctx context.Context, kid string) (*rsa.PublicKey, 
 			return key, nil
 		}
 		return nil, fmt.Errorf("failed to refresh JWKS: %w", err)
+	}
+
+	// Start auto-refresh goroutine after first successful fetch
+	if p.refreshTTL > 0 {
+		refreshCtx := ctx //nolint:contextcheck // auto-refresh runs independently of the triggering request
+		p.autoRefreshOnce.Do(func() {
+			go p.autoRefresh(refreshCtx)
+		})
 	}
 
 	// Try again after refresh

--- a/shared/platform/auth/jwks_test.go
+++ b/shared/platform/auth/jwks_test.go
@@ -131,7 +131,7 @@ func TestNewJWKSProvider(t *testing.T) {
 		assert.Nil(t, provider)
 	})
 
-	t.Run("error when initial fetch fails", func(t *testing.T) {
+	t.Run("error surfaces on GetKey when endpoint fails", func(t *testing.T) {
 		// Create server that returns error
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -143,10 +143,15 @@ func TestNewJWKSProvider(t *testing.T) {
 			Client: http.DefaultClient,
 		}
 
+		// Provider creation succeeds (fetch is deferred)
 		provider, err := NewJWKSProvider(ctx, cfg)
+		assert.NoError(t, err)
+		assert.NotNil(t, provider)
+		defer provider.Close()
 
+		// Error surfaces on first GetKey call
+		_, err = provider.GetKey(ctx, "test-kid")
 		assert.Error(t, err)
-		assert.Nil(t, provider)
 	})
 
 	t.Run("default cache TTL when not specified", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- With embedded Dex (#1518/#1526), the JWKS endpoint (`/dex/keys`) is served by the same process
- `NewJWKSProvider` performed an initial JWKS fetch during gateway initialization, before the HTTP server started listening
- This caused a fatal startup error: `failed to perform initial JWKS fetch: JWKS endpoint returned error: status 502`
- Fix: defer the initial JWKS fetch to the first `GetKey` call, breaking the circular dependency
- Auto-refresh goroutine starts after the first successful fetch via `sync.Once`

## Test plan

- [x] All JWKS unit tests pass (updated test for deferred behavior)
- [x] All gateway tests pass
- [x] Pre-commit checks pass (gofumpt, golangci-lint)
- [ ] Deploy to demo and verify service starts without JWKS errors