### PR TITLE
feat: contract test for proto-handler schema alignment (handler-schema-alignment.4)

### DIFF
--- a/services/position-keeping/client/starlark.go
+++ b/services/position-keeping/client/starlark.go
@@ -52,7 +52,7 @@ func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, client *Client) er
 						Alias:    "position_id",
 						Required: boolPtr(true),
 					},
-					"currency":           {Deprecated: "use instrument_code instead"},
+					"currency":           {Type: "string", Deprecated: "use instrument_code instead"},
 					"valuation_analysis": {Derived: true},
 				},
 			},

--- a/shared/pkg/saga/schema/contract_test.go
+++ b/shared/pkg/saga/schema/contract_test.go
@@ -1,0 +1,240 @@
+package schema
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	currentaccountclient "github.com/meridianhub/meridian/services/current-account/client"
+	financialaccountingclient "github.com/meridianhub/meridian/services/financial-accounting/client"
+	financialgatewayclient "github.com/meridianhub/meridian/services/financial-gateway/client"
+	internalaccountclient "github.com/meridianhub/meridian/services/internal-account/client"
+	marketinformationclient "github.com/meridianhub/meridian/services/market-information/client"
+	operationalgatewayclient "github.com/meridianhub/meridian/services/operational-gateway/client"
+	partyclient "github.com/meridianhub/meridian/services/party/client"
+	positionkeepingclient "github.com/meridianhub/meridian/services/position-keeping/client"
+	reconciliationclient "github.com/meridianhub/meridian/services/reconciliation/client"
+	referencedataclient "github.com/meridianhub/meridian/services/reference-data/client"
+)
+
+// buildFullHandlerRegistry creates a handler registry with all services registered.
+// Uses zero-value clients since registration only populates metadata, never calls gRPC.
+func buildFullHandlerRegistry(t *testing.T) *saga.HandlerRegistry {
+	t.Helper()
+	registry := saga.NewHandlerRegistry()
+
+	type registrar struct {
+		name string
+		fn   func() error
+	}
+
+	registrars := []registrar{
+		{"current-account", func() error {
+			return currentaccountclient.RegisterStarlarkHandlers(registry, &currentaccountclient.Client{})
+		}},
+		{"financial-accounting", func() error {
+			return financialaccountingclient.RegisterStarlarkHandlers(registry, &financialaccountingclient.Client{})
+		}},
+		{"financial-gateway", func() error {
+			return financialgatewayclient.RegisterStarlarkHandlers(registry, &financialgatewayclient.Client{})
+		}},
+		{"internal-account", func() error {
+			return internalaccountclient.RegisterStarlarkHandlers(registry, &internalaccountclient.Client{})
+		}},
+		{"market-information", func() error {
+			return marketinformationclient.RegisterStarlarkHandlers(registry, &marketinformationclient.Client{})
+		}},
+		{"operational-gateway", func() error {
+			return operationalgatewayclient.RegisterStarlarkHandlers(registry, &operationalgatewayclient.Client{})
+		}},
+		{"party", func() error {
+			return partyclient.RegisterStarlarkHandlers(registry, &partyclient.Client{})
+		}},
+		{"position-keeping", func() error {
+			return positionkeepingclient.RegisterStarlarkHandlers(registry, &positionkeepingclient.Client{})
+		}},
+		{"reconciliation", func() error {
+			return reconciliationclient.RegisterStarlarkHandlers(registry, &reconciliationclient.Client{})
+		}},
+		{"reference-data", func() error {
+			return referencedataclient.RegisterStarlarkHandlers(registry, &referencedataclient.Client{})
+		}},
+	}
+
+	for _, r := range registrars {
+		require.NoError(t, r.fn(), "failed to register %s handlers", r.name)
+	}
+
+	return registry
+}
+
+func TestHandlerProtoAlignment(t *testing.T) {
+	registry := buildFullHandlerRegistry(t)
+	yamlRegistry, err := DefaultRegistry()
+	require.NoError(t, err, "failed to load YAML registry")
+
+	allMeta := registry.AllWithMetadata()
+	require.NotEmpty(t, allMeta, "handler registry should not be empty")
+
+	var annotatedCount int
+
+	for name, metadata := range allMeta {
+		t.Run(name, func(t *testing.T) {
+			// 1. Proto type must be set — skip if not yet annotated
+			if metadata == nil || metadata.ProtoRequestType == nil {
+				t.Skipf("handler %s: missing ProtoRequestType (not yet annotated)", name)
+				return
+			}
+			annotatedCount++
+
+			// 2. Derive schema from proto — validates derivation works
+			derived := DeriveHandlerDef(name, metadata)
+			require.NotNil(t, derived, "DeriveHandlerDef returned nil for %s", name)
+
+			// 3. Enum params from proto reflection must have non-empty values.
+			// Params created by ParamOverrides may have enum type without values
+			// (annotation bug) — log these for visibility but don't fail the test.
+			for paramName, field := range derived.Params {
+				if field.Type == TypeEnum && len(field.Values) == 0 {
+					if isProtoField(metadata, paramName) {
+						t.Errorf("handler %s param %s: proto enum type must have values", name, paramName)
+					} else {
+						t.Logf("WARNING: handler %s param %s: override sets enum type but no values (fix annotation)", name, paramName)
+					}
+				}
+			}
+
+			// 4. Compensation handler must exist in registry
+			if metadata.Compensate != "" {
+				assert.True(t, registry.Has(metadata.Compensate),
+					"handler %s: compensation handler %q not found in registry", name, metadata.Compensate)
+			}
+
+			// 5. Compare with handlers.yaml for regression safety
+			yamlHandler, yamlErr := yamlRegistry.GetHandler(name)
+			if yamlErr != nil {
+				// Handler exists in proto but not in YAML — acceptable during migration
+				t.Logf("handler %s: present in proto registry but not in handlers.yaml (new handler)", name)
+				return
+			}
+
+			// Compare with handlers.yaml — log drift for visibility during migration.
+			// Proto is the source of truth; YAML mismatches are informational, not failures.
+			for yamlParamName, yamlField := range yamlHandler.Params {
+				derivedField, exists := derived.Params[yamlParamName]
+				if !exists {
+					t.Logf("DRIFT: handler %s param %s: in YAML but not in derived schema (aliased or derived)", name, yamlParamName)
+					continue
+				}
+
+				if yamlField.Type != derivedField.Type {
+					t.Logf("DRIFT: handler %s param %s: type YAML=%s derived=%s", name, yamlParamName, yamlField.Type, derivedField.Type)
+				}
+
+				if yamlField.Type == TypeEnum && derivedField.Type == TypeEnum {
+					yamlVals := sorted(yamlField.Values)
+					derivedVals := sorted(derivedField.Values)
+					if !stringSliceEqual(yamlVals, derivedVals) {
+						t.Logf("DRIFT: handler %s param %s: enum values YAML=%v derived=%v", name, yamlParamName, yamlVals, derivedVals)
+					}
+				}
+			}
+		})
+	}
+
+	t.Logf("Total handlers: %d, annotated with proto: %d", len(allMeta), annotatedCount)
+}
+
+// TestAllYAMLHandlersHaveRegistration tracks YAML handlers that lack runtime registration.
+// During migration, some YAML handlers are aspirational (services not built yet).
+// This test logs unregistered handlers for visibility without failing.
+func TestAllYAMLHandlersHaveRegistration(t *testing.T) {
+	registry := buildFullHandlerRegistry(t)
+	yamlRegistry, err := DefaultRegistry()
+	require.NoError(t, err)
+
+	var registered, unregistered int
+	for _, name := range yamlRegistry.ListHandlers() {
+		if registry.Has(name) {
+			registered++
+		} else {
+			unregistered++
+			t.Logf("UNREGISTERED: handler %s is in handlers.yaml but not registered at runtime", name)
+		}
+	}
+
+	t.Logf("YAML handlers: %d registered, %d unregistered (aspirational)", registered, unregistered)
+	assert.Greater(t, registered, 0, "at least one YAML handler should be registered")
+}
+
+// TestCompensationChainIntegrity verifies all compensation references form valid chains.
+func TestCompensationChainIntegrity(t *testing.T) {
+	registry := buildFullHandlerRegistry(t)
+	allMeta := registry.AllWithMetadata()
+
+	for name, metadata := range allMeta {
+		if metadata == nil || metadata.Compensate == "" {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			assert.True(t, registry.Has(metadata.Compensate),
+				"handler %s references compensation handler %q which is not registered",
+				name, metadata.Compensate)
+
+			// Compensation handler should not itself have a compensation (no chains of chains)
+			_, compMeta, err := registry.GetWithMetadata(metadata.Compensate)
+			require.NoError(t, err)
+			if compMeta != nil {
+				assert.Empty(t, compMeta.Compensate,
+					"compensation handler %s should not itself reference another compensation handler %q",
+					metadata.Compensate, compMeta.Compensate)
+			}
+		})
+	}
+}
+
+// TestDeriveSchemaFullRegistry runs DeriveSchema on the full registry and
+// validates the result is a well-formed schema.
+func TestDeriveSchemaFullRegistry(t *testing.T) {
+	registry := buildFullHandlerRegistry(t)
+
+	derived, err := DeriveSchema(registry)
+	require.NoError(t, err)
+	require.NotNil(t, derived)
+	assert.NotEmpty(t, derived.Handlers, "derived schema should contain handlers")
+
+	t.Logf("Derived schema contains %d handlers", len(derived.Handlers))
+}
+
+func sorted(vals []string) []string {
+	out := make([]string, len(vals))
+	copy(out, vals)
+	sort.Strings(out)
+	return out
+}
+
+// isProtoField returns true if the field name exists in the proto request message
+// (as opposed to being created by a ParamOverride).
+func isProtoField(meta *saga.HandlerMetadata, fieldName string) bool {
+	if meta == nil || meta.ProtoRequestType == nil {
+		return false
+	}
+	fd := meta.ProtoRequestType.ProtoReflect().Descriptor().Fields().ByName(protoreflect.Name(fieldName))
+	return fd != nil
+}
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/shared/pkg/saga/schema/contract_test.go
+++ b/shared/pkg/saga/schema/contract_test.go
@@ -92,7 +92,8 @@ func TestHandlerProtoAlignment(t *testing.T) {
 			annotatedCount++
 
 			// 2. Derive schema from proto — validates derivation works
-			derived := DeriveHandlerDef(name, metadata)
+			derived, deriveErr := DeriveHandlerDef(name, metadata)
+			require.NoError(t, deriveErr, "DeriveHandlerDef failed for %s", name)
 			require.NotNil(t, derived, "DeriveHandlerDef returned nil for %s", name)
 
 			// 3. Enum params from proto reflection must have non-empty values.

--- a/shared/pkg/saga/schema/derive.go
+++ b/shared/pkg/saga/schema/derive.go
@@ -1,0 +1,261 @@
+package schema
+
+import (
+	"strings"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// DeriveSchema builds a Schema from the handler registry using proto reflection.
+// Handlers without ProtoRequestType get empty params; handlers without ProtoResponseType
+// get empty returns. ParamOverrides are applied after proto-derived fields.
+func DeriveSchema(registry *saga.HandlerRegistry) (*Schema, error) {
+	allMeta := registry.AllWithMetadata()
+
+	s := &Schema{
+		Handlers: make(map[string]*HandlerDef, len(allMeta)),
+	}
+
+	for name, meta := range allMeta {
+		s.Handlers[name] = DeriveHandlerDef(name, meta)
+	}
+
+	return s, nil
+}
+
+// DeriveHandlerDef builds a single HandlerDef from handler metadata.
+// Exported for use by contract tests (Task 4).
+func DeriveHandlerDef(_ string, meta *saga.HandlerMetadata) *HandlerDef {
+	hd := &HandlerDef{
+		Params:  make(map[string]*FieldDef),
+		Returns: make(map[string]*FieldDef),
+		Version: 1,
+	}
+
+	if meta == nil {
+		return hd
+	}
+
+	hd.Description = meta.Description
+	hd.Compensate = meta.Compensate
+	hd.Version = meta.Version
+	if hd.Version == 0 {
+		hd.Version = 1
+	}
+	hd.Deprecated = meta.DeprecatedMessage != ""
+
+	// Set compensation strategy
+	if meta.Compensate != "" {
+		hd.CompensationStrategy = CompensationStrategyAuto
+	} else if meta.CompensationStrategy != "" {
+		hd.CompensationStrategy = CompensationStrategy(meta.CompensationStrategy)
+	}
+
+	// Derive params from proto request type
+	if meta.ProtoRequestType != nil {
+		deriveFields(meta.ProtoRequestType.ProtoReflect().Descriptor(), hd.Params)
+	}
+
+	// Apply param overrides
+	applyParamOverrides(hd.Params, meta.ParamOverrides)
+
+	// Derive returns from proto response type
+	if meta.ProtoResponseType != nil {
+		deriveFields(meta.ProtoResponseType.ProtoReflect().Descriptor(), hd.Returns)
+	}
+
+	// Convert handler conversions to schema conversion rules
+	for _, conv := range meta.Conversions {
+		hd.Conversions = append(hd.Conversions, ConversionRule{
+			FromVersion:  conv.FromVersion,
+			FromName:     conv.FromName,
+			ParamMapping: conv.ParamMapping,
+			Defaults:     conv.Defaults,
+			Sunset:       conv.Sunset,
+		})
+	}
+
+	return hd
+}
+
+// deriveFields populates a field map from a proto message descriptor.
+func deriveFields(md protoreflect.MessageDescriptor, fields map[string]*FieldDef) {
+	fds := md.Fields()
+	for i := 0; i < fds.Len(); i++ {
+		fd := fds.Get(i)
+		fieldName := string(fd.Name())
+
+		fieldDef := deriveFieldDef(fd)
+		fields[fieldName] = fieldDef
+	}
+}
+
+// deriveFieldDef converts a single proto field descriptor to a FieldDef.
+func deriveFieldDef(fd protoreflect.FieldDescriptor) *FieldDef {
+	// Handle map fields first (they appear as repeated message with map_entry option)
+	if fd.IsMap() {
+		keyFD := fd.MapKey()
+		valFD := fd.MapValue()
+		return &FieldDef{
+			Type:      TypeMap,
+			KeyType:   protoKindToFieldType(keyFD.Kind(), keyFD),
+			ValueType: protoKindToFieldType(valFD.Kind(), valFD),
+		}
+	}
+
+	// Handle repeated (non-map) fields
+	if fd.IsList() {
+		itemType := protoKindToFieldType(fd.Kind(), fd)
+		return &FieldDef{
+			Type:     TypeArray,
+			ItemType: itemType,
+		}
+	}
+
+	// Scalar and enum fields
+	ft := protoKindToFieldType(fd.Kind(), fd)
+	def := &FieldDef{
+		Type: ft,
+	}
+
+	// For enum fields, extract values with prefix stripping
+	if fd.Kind() == protoreflect.EnumKind {
+		def.Values = deriveEnumValues(fd.Enum())
+	}
+
+	return def
+}
+
+// protoKindToFieldType maps a protoreflect.Kind to our FieldType.
+func protoKindToFieldType(kind protoreflect.Kind, _ protoreflect.FieldDescriptor) FieldType {
+	switch kind {
+	case protoreflect.StringKind:
+		return TypeString
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+		return TypeInt32
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		return TypeInt64
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		return TypeUint32
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		return TypeInt64 // no TypeUint64, map to int64
+	case protoreflect.BoolKind:
+		return TypeBool
+	case protoreflect.BytesKind:
+		return TypeString // base64
+	case protoreflect.EnumKind:
+		return TypeEnum
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		return TypeMap
+	case protoreflect.FloatKind, protoreflect.DoubleKind:
+		return TypeString // floats as string to preserve precision
+	default:
+		return TypeString
+	}
+}
+
+// deriveEnumValues extracts enum value names with prefix stripping,
+// skipping the 0-valued UNSPECIFIED entry.
+func deriveEnumValues(ed protoreflect.EnumDescriptor) []string {
+	vals := ed.Values()
+	raw := make([]string, 0, vals.Len())
+	for i := 0; i < vals.Len(); i++ {
+		v := vals.Get(i)
+		if v.Number() == 0 {
+			continue // Skip UNSPECIFIED
+		}
+		raw = append(raw, string(v.Name()))
+	}
+	return StripEnumPrefix(raw)
+}
+
+// StripEnumPrefix removes the common ENUM_NAME_ prefix from proto enum values.
+// For example: ["POSTING_DIRECTION_DEBIT", "POSTING_DIRECTION_CREDIT"] -> ["DEBIT", "CREDIT"].
+func StripEnumPrefix(values []string) []string {
+	if len(values) == 0 {
+		return values
+	}
+
+	// Find common prefix by splitting on '_' and finding shared segments
+	prefix := findCommonEnumPrefix(values)
+	if prefix == "" {
+		return values
+	}
+
+	result := make([]string, len(values))
+	for i, v := range values {
+		result[i] = strings.TrimPrefix(v, prefix)
+	}
+	return result
+}
+
+// findCommonEnumPrefix finds the common UPPER_CASE_ prefix across all values.
+func findCommonEnumPrefix(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+
+	// Split first value into segments
+	firstParts := strings.Split(values[0], "_")
+	if len(firstParts) <= 1 {
+		return ""
+	}
+
+	// Try progressively shorter prefixes (all but last segment, all but last 2, etc.)
+	for prefixLen := len(firstParts) - 1; prefixLen > 0; prefixLen-- {
+		candidate := strings.Join(firstParts[:prefixLen], "_") + "_"
+
+		allMatch := true
+		for _, v := range values {
+			if !strings.HasPrefix(v, candidate) {
+				allMatch = false
+				break
+			}
+		}
+
+		if allMatch {
+			return candidate
+		}
+	}
+
+	return ""
+}
+
+// applyParamOverrides applies ParamOverrides to the derived params map.
+func applyParamOverrides(params map[string]*FieldDef, overrides map[string]saga.ParamOverride) {
+	if overrides == nil {
+		return
+	}
+
+	for fieldName, override := range overrides {
+		// Handle derived fields: remove from params
+		if override.Derived {
+			delete(params, fieldName)
+			continue
+		}
+
+		fd, exists := params[fieldName]
+		if !exists {
+			// Override for a field not in proto - create it
+			fd = &FieldDef{Type: TypeString}
+			params[fieldName] = fd
+		}
+
+		// Apply type override
+		if override.Type != "" {
+			fd.Type = FieldType(override.Type)
+		}
+
+		// Apply required override
+		if override.Required != nil {
+			fd.Required = *override.Required
+		}
+
+		// Apply alias: rename the field
+		if override.Alias != "" {
+			delete(params, fieldName)
+			params[override.Alias] = fd
+		}
+	}
+}

--- a/shared/pkg/saga/schema/derive.go
+++ b/shared/pkg/saga/schema/derive.go
@@ -269,6 +269,9 @@ func applyParamOverrides(params map[string]*FieldDef, overrides map[string]saga.
 
 		// Apply alias: rename the field
 		if override.Alias != "" {
+			if _, collision := params[override.Alias]; collision {
+				return fmt.Errorf("%w: alias %q for field %q", ErrOverrideAliasCollision, override.Alias, fieldName)
+			}
 			delete(params, fieldName)
 			params[override.Alias] = fd
 		}

--- a/shared/pkg/saga/schema/derive.go
+++ b/shared/pkg/saga/schema/derive.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/meridianhub/meridian/shared/pkg/saga"
@@ -18,15 +19,21 @@ func DeriveSchema(registry *saga.HandlerRegistry) (*Schema, error) {
 	}
 
 	for name, meta := range allMeta {
-		s.Handlers[name] = DeriveHandlerDef(name, meta)
+		hd, err := DeriveHandlerDef(name, meta)
+		if err != nil {
+			return nil, fmt.Errorf("handler %s: %w", name, err)
+		}
+		s.Handlers[name] = hd
 	}
 
 	return s, nil
 }
 
 // DeriveHandlerDef builds a single HandlerDef from handler metadata.
+// Returns an error if a ParamOverride references a field not in the proto
+// without providing an explicit Type.
 // Exported for use by contract tests (Task 4).
-func DeriveHandlerDef(_ string, meta *saga.HandlerMetadata) *HandlerDef {
+func DeriveHandlerDef(_ string, meta *saga.HandlerMetadata) (*HandlerDef, error) {
 	hd := &HandlerDef{
 		Params:  make(map[string]*FieldDef),
 		Returns: make(map[string]*FieldDef),
@@ -34,7 +41,7 @@ func DeriveHandlerDef(_ string, meta *saga.HandlerMetadata) *HandlerDef {
 	}
 
 	if meta == nil {
-		return hd
+		return hd, nil
 	}
 
 	hd.Description = meta.Description
@@ -58,7 +65,9 @@ func DeriveHandlerDef(_ string, meta *saga.HandlerMetadata) *HandlerDef {
 	}
 
 	// Apply param overrides
-	applyParamOverrides(hd.Params, meta.ParamOverrides)
+	if err := applyParamOverrides(hd.Params, meta.ParamOverrides); err != nil {
+		return nil, err
+	}
 
 	// Derive returns from proto response type
 	if meta.ProtoResponseType != nil {
@@ -76,7 +85,7 @@ func DeriveHandlerDef(_ string, meta *saga.HandlerMetadata) *HandlerDef {
 		})
 	}
 
-	return hd
+	return hd, nil
 }
 
 // deriveFields populates a field map from a proto message descriptor.
@@ -139,7 +148,7 @@ func protoKindToFieldType(kind protoreflect.Kind, _ protoreflect.FieldDescriptor
 	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
 		return TypeUint32
 	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
-		return TypeInt64 // no TypeUint64, map to int64
+		return TypeString // no TypeUint64; use string to preserve full unsigned range
 	case protoreflect.BoolKind:
 		return TypeBool
 	case protoreflect.BytesKind:
@@ -223,9 +232,12 @@ func findCommonEnumPrefix(values []string) string {
 }
 
 // applyParamOverrides applies ParamOverrides to the derived params map.
-func applyParamOverrides(params map[string]*FieldDef, overrides map[string]saga.ParamOverride) {
+// Returns an error if an override references a field not in the proto
+// without providing an explicit Type — this catches naming drift between
+// proto fields and handler annotations.
+func applyParamOverrides(params map[string]*FieldDef, overrides map[string]saga.ParamOverride) error {
 	if overrides == nil {
-		return
+		return nil
 	}
 
 	for fieldName, override := range overrides {
@@ -237,8 +249,11 @@ func applyParamOverrides(params map[string]*FieldDef, overrides map[string]saga.
 
 		fd, exists := params[fieldName]
 		if !exists {
-			// Override for a field not in proto - create it
-			fd = &FieldDef{Type: TypeString}
+			// Override for a field not in proto — require explicit Type
+			if override.Type == "" {
+				return fmt.Errorf("%w: %q", ErrOverrideMissingType, fieldName)
+			}
+			fd = &FieldDef{Type: FieldType(override.Type)}
 			params[fieldName] = fd
 		}
 
@@ -258,4 +273,5 @@ func applyParamOverrides(params map[string]*FieldDef, overrides map[string]saga.
 			params[override.Alias] = fd
 		}
 	}
+	return nil
 }

--- a/shared/pkg/saga/schema/derive_test.go
+++ b/shared/pkg/saga/schema/derive_test.go
@@ -498,7 +498,8 @@ func TestDeriveHandlerDef_Exported(t *testing.T) {
 		Version:              1,
 	}
 
-	hd := schema.DeriveHandlerDef("test.exported", meta)
+	hd, err := schema.DeriveHandlerDef("test.exported", meta)
+	require.NoError(t, err)
 	require.NotNil(t, hd)
 	assert.Equal(t, "exported function test", hd.Description)
 }

--- a/shared/pkg/saga/schema/derive_test.go
+++ b/shared/pkg/saga/schema/derive_test.go
@@ -1,0 +1,582 @@
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/dynamicpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"google.golang.org/protobuf/reflect/protodesc"
+	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+)
+
+// buildTestProto creates a synthetic proto file descriptor for testing.
+// This avoids depending on generated .pb.go files that may not exist in the worktree.
+func buildTestProto(t *testing.T) (proto.Message, proto.Message) {
+	t.Helper()
+
+	// Build an enum descriptor: POSTING_DIRECTION_{UNSPECIFIED, DEBIT, CREDIT}
+	enumName := protoreflect.Name("PostingDirection")
+	enumFullName := protoreflect.FullName("test.PostingDirection")
+	_ = enumFullName
+
+	unspecified := "POSTING_DIRECTION_UNSPECIFIED"
+	debit := "POSTING_DIRECTION_DEBIT"
+	credit := "POSTING_DIRECTION_CREDIT"
+
+	enumVal0 := int32(0)
+	enumVal1 := int32(1)
+	enumVal2 := int32(2)
+
+	enumDescProto := &descriptorpb.EnumDescriptorProto{
+		Name: strPtr(string(enumName)),
+		Value: []*descriptorpb.EnumValueDescriptorProto{
+			{Name: &unspecified, Number: &enumVal0},
+			{Name: &debit, Number: &enumVal1},
+			{Name: &credit, Number: &enumVal2},
+		},
+	}
+
+	// Build request message: TestRequest
+	reqMsg := &descriptorpb.DescriptorProto{
+		Name: strPtr("TestRequest"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:     strPtr("account_id"),
+				Number:   int32Ptr(1),
+				Type:     fieldType(descriptorpb.FieldDescriptorProto_TYPE_STRING),
+				Label:    fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				JsonName: strPtr("accountId"),
+			},
+			{
+				Name:     strPtr("amount"),
+				Number:   int32Ptr(2),
+				Type:     fieldType(descriptorpb.FieldDescriptorProto_TYPE_STRING),
+				Label:    fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				JsonName: strPtr("amount"),
+			},
+			{
+				Name:     strPtr("direction"),
+				Number:   int32Ptr(3),
+				Type:     fieldType(descriptorpb.FieldDescriptorProto_TYPE_ENUM),
+				TypeName: strPtr(".test.PostingDirection"),
+				Label:    fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				JsonName: strPtr("direction"),
+			},
+			{
+				Name:     strPtr("count"),
+				Number:   int32Ptr(4),
+				Type:     fieldType(descriptorpb.FieldDescriptorProto_TYPE_INT32),
+				Label:    fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				JsonName: strPtr("count"),
+			},
+			{
+				Name:     strPtr("is_active"),
+				Number:   int32Ptr(5),
+				Type:     fieldType(descriptorpb.FieldDescriptorProto_TYPE_BOOL),
+				Label:    fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				JsonName: strPtr("isActive"),
+			},
+			{
+				Name:     strPtr("version"),
+				Number:   int32Ptr(6),
+				Type:     fieldType(descriptorpb.FieldDescriptorProto_TYPE_INT64),
+				Label:    fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				JsonName: strPtr("version"),
+			},
+			{
+				Name:     strPtr("tags"),
+				Number:   int32Ptr(7),
+				Type:     fieldType(descriptorpb.FieldDescriptorProto_TYPE_STRING),
+				Label:    fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_REPEATED),
+				JsonName: strPtr("tags"),
+			},
+			{
+				Name:     strPtr("flags"),
+				Number:   int32Ptr(8),
+				Type:     fieldType(descriptorpb.FieldDescriptorProto_TYPE_UINT32),
+				Label:    fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				JsonName: strPtr("flags"),
+			},
+			{
+				Name:     strPtr("payload"),
+				Number:   int32Ptr(9),
+				Type:     fieldType(descriptorpb.FieldDescriptorProto_TYPE_BYTES),
+				Label:    fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				JsonName: strPtr("payload"),
+			},
+		},
+	}
+
+	// Build response message: TestResponse
+	respMsg := &descriptorpb.DescriptorProto{
+		Name: strPtr("TestResponse"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:     strPtr("log_id"),
+				Number:   int32Ptr(1),
+				Type:     fieldType(descriptorpb.FieldDescriptorProto_TYPE_STRING),
+				Label:    fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				JsonName: strPtr("logId"),
+			},
+			{
+				Name:     strPtr("success"),
+				Number:   int32Ptr(2),
+				Type:     fieldType(descriptorpb.FieldDescriptorProto_TYPE_BOOL),
+				Label:    fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				JsonName: strPtr("success"),
+			},
+		},
+	}
+
+	syntax := "proto3"
+	fileDesc := &descriptorpb.FileDescriptorProto{
+		Name:        strPtr("test.proto"),
+		Package:     strPtr("test"),
+		Syntax:      &syntax,
+		EnumType:    []*descriptorpb.EnumDescriptorProto{enumDescProto},
+		MessageType: []*descriptorpb.DescriptorProto{reqMsg, respMsg},
+	}
+
+	fd, err := protodesc.NewFile(fileDesc, nil)
+	require.NoError(t, err)
+
+	reqMsgDesc := fd.Messages().ByName("TestRequest")
+	require.NotNil(t, reqMsgDesc)
+	respMsgDesc := fd.Messages().ByName("TestResponse")
+	require.NotNil(t, respMsgDesc)
+
+	return dynamicpb.NewMessage(reqMsgDesc), dynamicpb.NewMessage(respMsgDesc)
+}
+
+func strPtr(s string) *string { return &s }
+func int32Ptr(i int32) *int32 { return &i }
+func fieldType(t descriptorpb.FieldDescriptorProto_Type) *descriptorpb.FieldDescriptorProto_Type {
+	return &t
+}
+
+func fieldLabel(l descriptorpb.FieldDescriptorProto_Label) *descriptorpb.FieldDescriptorProto_Label {
+	return &l
+}
+
+func TestDeriveSchema_EmptyRegistry(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	s, err := schema.DeriveSchema(registry)
+	require.NoError(t, err)
+	assert.Empty(t, s.Handlers)
+}
+
+func TestDeriveSchema_HandlerWithoutProto(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	meta := &saga.HandlerMetadata{
+		Description:          "A handler without proto types",
+		Compensate:           "undo_foo",
+		CompensationStrategy: "auto",
+		Version:              2,
+	}
+	err := registry.RegisterWithMetadata("test.do_foo", func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return nil, nil
+	}, meta)
+	require.NoError(t, err)
+
+	s, err := schema.DeriveSchema(registry)
+	require.NoError(t, err)
+
+	h, ok := s.Handlers["test.do_foo"]
+	require.True(t, ok)
+	assert.Equal(t, "A handler without proto types", h.Description)
+	assert.Equal(t, "undo_foo", h.Compensate)
+	assert.Equal(t, 2, h.Version)
+	assert.Empty(t, h.Params)
+	assert.Empty(t, h.Returns)
+}
+
+func TestDeriveSchema_HandlerWithNilMetadata(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	err := registry.RegisterWithMetadata("test.nil_meta", func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return nil, nil
+	}, nil)
+	require.NoError(t, err)
+
+	s, err := schema.DeriveSchema(registry)
+	require.NoError(t, err)
+
+	h, ok := s.Handlers["test.nil_meta"]
+	require.True(t, ok)
+	assert.Empty(t, h.Params)
+	assert.Empty(t, h.Returns)
+}
+
+func TestDeriveSchema_ProtoFieldMapping(t *testing.T) {
+	reqProto, respProto := buildTestProto(t)
+
+	registry := saga.NewHandlerRegistry()
+	meta := &saga.HandlerMetadata{
+		Description:          "Test handler with proto types",
+		Compensate:           "test.undo",
+		CompensationStrategy: "auto",
+		ProtoRequestType:     reqProto,
+		ProtoResponseType:    respProto,
+		Version:              1,
+	}
+	err := registry.RegisterWithMetadata("test.create", func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return nil, nil
+	}, meta)
+	require.NoError(t, err)
+
+	s, err := schema.DeriveSchema(registry)
+	require.NoError(t, err)
+
+	h := s.Handlers["test.create"]
+	require.NotNil(t, h)
+
+	// Verify field type mappings
+	tests := []struct {
+		field    string
+		wantType schema.FieldType
+	}{
+		{"account_id", schema.TypeString},
+		{"amount", schema.TypeString},
+		{"count", schema.TypeInt32},
+		{"is_active", schema.TypeBool},
+		{"version", schema.TypeInt64},
+		{"flags", schema.TypeUint32},
+		{"payload", schema.TypeString}, // bytes -> string (base64)
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.field, func(t *testing.T) {
+			f, ok := h.Params[tc.field]
+			require.True(t, ok, "param %s not found", tc.field)
+			assert.Equal(t, tc.wantType, f.Type, "param %s type mismatch", tc.field)
+		})
+	}
+
+	// Verify enum field
+	dirField, ok := h.Params["direction"]
+	require.True(t, ok)
+	assert.Equal(t, schema.TypeEnum, dirField.Type)
+	assert.ElementsMatch(t, []string{"DEBIT", "CREDIT"}, dirField.Values)
+
+	// Verify repeated field
+	tagsField, ok := h.Params["tags"]
+	require.True(t, ok)
+	assert.Equal(t, schema.TypeArray, tagsField.Type)
+	assert.Equal(t, schema.TypeString, tagsField.ItemType)
+
+	// Verify response fields
+	logIDField, ok := h.Returns["log_id"]
+	require.True(t, ok)
+	assert.Equal(t, schema.TypeString, logIDField.Type)
+
+	successField, ok := h.Returns["success"]
+	require.True(t, ok)
+	assert.Equal(t, schema.TypeBool, successField.Type)
+}
+
+func TestDeriveSchema_ParamOverrides(t *testing.T) {
+	reqProto, _ := buildTestProto(t)
+
+	reqTrue := true
+
+	registry := saga.NewHandlerRegistry()
+	meta := &saga.HandlerMetadata{
+		ProtoRequestType:     reqProto,
+		Compensate:           "test.undo",
+		CompensationStrategy: "auto",
+		ParamOverrides: map[string]saga.ParamOverride{
+			"amount": {
+				Type:  "Decimal", // Override string -> Decimal
+				Alias: "qty",     // Rename in Starlark
+			},
+			"account_id": {
+				Required: &reqTrue,
+			},
+			"count": {
+				Derived: true, // Should be excluded from params
+			},
+			"is_active": {
+				Deprecated: "use status field instead",
+			},
+		},
+		Version: 1,
+	}
+	err := registry.RegisterWithMetadata("test.overridden", func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return nil, nil
+	}, meta)
+	require.NoError(t, err)
+
+	s, err := schema.DeriveSchema(registry)
+	require.NoError(t, err)
+
+	h := s.Handlers["test.overridden"]
+	require.NotNil(t, h)
+
+	// Alias: "amount" should appear as "qty"
+	_, hasAmount := h.Params["amount"]
+	assert.False(t, hasAmount, "original name 'amount' should not appear when alias is set")
+	qtyField, ok := h.Params["qty"]
+	require.True(t, ok, "alias 'qty' should be present")
+	assert.Equal(t, schema.TypeDecimal, qtyField.Type)
+
+	// Required override
+	accField, ok := h.Params["account_id"]
+	require.True(t, ok)
+	assert.True(t, accField.Required)
+
+	// Derived: "count" should be excluded
+	_, hasCount := h.Params["count"]
+	assert.False(t, hasCount, "derived param 'count' should be excluded")
+
+	// Deprecated: "is_active" should still be present but we track deprecation
+	// (FieldDef doesn't have a Deprecated field, so the param is just present)
+	_, hasActive := h.Params["is_active"]
+	assert.True(t, hasActive, "deprecated param should still be present")
+}
+
+func TestDeriveSchema_EnumPrefixStripping(t *testing.T) {
+	// Test various enum naming patterns
+	tests := []struct {
+		name     string
+		values   []string
+		expected []string
+	}{
+		{
+			name:     "POSTING_DIRECTION prefix",
+			values:   []string{"POSTING_DIRECTION_DEBIT", "POSTING_DIRECTION_CREDIT"},
+			expected: []string{"DEBIT", "CREDIT"},
+		},
+		{
+			name:     "with UNSPECIFIED included",
+			values:   []string{"POSTING_DIRECTION_UNSPECIFIED", "POSTING_DIRECTION_DEBIT", "POSTING_DIRECTION_CREDIT"},
+			expected: []string{"UNSPECIFIED", "DEBIT", "CREDIT"},
+		},
+		{
+			name:     "single segment values",
+			values:   []string{"FOO", "BAR"},
+			expected: []string{"FOO", "BAR"},
+		},
+		{
+			name:     "empty",
+			values:   []string{},
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stripped := schema.StripEnumPrefix(tc.values)
+			assert.Equal(t, tc.expected, stripped)
+		})
+	}
+}
+
+func TestDeriveSchema_HandlerMetadataFields(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	meta := &saga.HandlerMetadata{
+		Description:          "Transfer funds between accounts",
+		Compensate:           "test.reverse_transfer",
+		CompensationStrategy: "auto",
+		HasAutoCompensation:  true,
+		Version:              3,
+		DeprecatedMessage:    "use test.transfer_v2 instead",
+		Conversions: []saga.HandlerConversion{
+			{
+				FromVersion:  2,
+				FromName:     "test.old_transfer",
+				ParamMapping: map[string]string{"source": "from_account"},
+				Defaults:     map[string]string{"currency": "USD"},
+			},
+		},
+	}
+	err := registry.RegisterWithMetadata("test.transfer", func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return nil, nil
+	}, meta)
+	require.NoError(t, err)
+
+	s, err := schema.DeriveSchema(registry)
+	require.NoError(t, err)
+
+	h := s.Handlers["test.transfer"]
+	require.NotNil(t, h)
+
+	assert.Equal(t, "Transfer funds between accounts", h.Description)
+	assert.Equal(t, "test.reverse_transfer", h.Compensate)
+	assert.Equal(t, schema.CompensationStrategyAuto, h.CompensationStrategy)
+	assert.Equal(t, 3, h.Version)
+	assert.True(t, h.Deprecated)
+
+	require.Len(t, h.Conversions, 1)
+	conv := h.Conversions[0]
+	assert.Equal(t, 2, conv.FromVersion)
+	assert.Equal(t, "test.old_transfer", conv.FromName)
+	assert.Equal(t, map[string]string{"source": "from_account"}, conv.ParamMapping)
+	assert.Equal(t, map[string]string{"currency": "USD"}, conv.Defaults)
+}
+
+func TestDeriveSchema_MessageField(t *testing.T) {
+	// Test that nested message fields map to TypeMap
+	// Use wrapperspb.StringValue as a well-known message type
+	reqProto := &wrapperspb.StringValue{}
+	_ = reqProto
+
+	// Build a proto with a message-typed field
+	nestedMsg := &descriptorpb.DescriptorProto{
+		Name: strPtr("InnerMessage"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:     strPtr("value"),
+				Number:   int32Ptr(1),
+				Type:     fieldType(descriptorpb.FieldDescriptorProto_TYPE_STRING),
+				Label:    fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				JsonName: strPtr("value"),
+			},
+		},
+	}
+
+	outerMsg := &descriptorpb.DescriptorProto{
+		Name: strPtr("OuterMessage"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:     strPtr("inner"),
+				Number:   int32Ptr(1),
+				Type:     fieldType(descriptorpb.FieldDescriptorProto_TYPE_MESSAGE),
+				TypeName: strPtr(".test2.InnerMessage"),
+				Label:    fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				JsonName: strPtr("inner"),
+			},
+		},
+	}
+
+	syntax := "proto3"
+	fileDesc := &descriptorpb.FileDescriptorProto{
+		Name:        strPtr("test2.proto"),
+		Package:     strPtr("test2"),
+		Syntax:      &syntax,
+		MessageType: []*descriptorpb.DescriptorProto{nestedMsg, outerMsg},
+	}
+
+	fd, err := protodesc.NewFile(fileDesc, nil)
+	require.NoError(t, err)
+
+	outerMsgDesc := fd.Messages().ByName("OuterMessage")
+	require.NotNil(t, outerMsgDesc)
+
+	registry := saga.NewHandlerRegistry()
+	meta := &saga.HandlerMetadata{
+		ProtoRequestType:     dynamicpb.NewMessage(outerMsgDesc),
+		CompensationStrategy: "none",
+		Version:              1,
+	}
+	err = registry.RegisterWithMetadata("test.nested", func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return nil, nil
+	}, meta)
+	require.NoError(t, err)
+
+	s, err := schema.DeriveSchema(registry)
+	require.NoError(t, err)
+
+	h := s.Handlers["test.nested"]
+	require.NotNil(t, h)
+
+	innerField, ok := h.Params["inner"]
+	require.True(t, ok)
+	assert.Equal(t, schema.TypeMap, innerField.Type)
+}
+
+func TestDeriveHandlerDef_Exported(t *testing.T) {
+	// Verify DeriveHandlerDef is exported for contract tests (Task 4)
+	meta := &saga.HandlerMetadata{
+		Description:          "exported function test",
+		CompensationStrategy: "none",
+		Version:              1,
+	}
+
+	hd := schema.DeriveHandlerDef("test.exported", meta)
+	require.NotNil(t, hd)
+	assert.Equal(t, "exported function test", hd.Description)
+}
+
+func TestDeriveSchema_MapField(t *testing.T) {
+	// Proto map<string,string> fields should derive as TypeMap with key/value types
+	mapEntry := &descriptorpb.DescriptorProto{
+		Name: strPtr("AttributesEntry"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:   strPtr("key"),
+				Number: int32Ptr(1),
+				Type:   fieldType(descriptorpb.FieldDescriptorProto_TYPE_STRING),
+				Label:  fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+			},
+			{
+				Name:   strPtr("value"),
+				Number: int32Ptr(2),
+				Type:   fieldType(descriptorpb.FieldDescriptorProto_TYPE_STRING),
+				Label:  fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+			},
+		},
+		Options: &descriptorpb.MessageOptions{
+			MapEntry: boolPtr(true),
+		},
+	}
+
+	outerMsg := &descriptorpb.DescriptorProto{
+		Name: strPtr("MapMessage"),
+		Field: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:     strPtr("attributes"),
+				Number:   int32Ptr(1),
+				Type:     fieldType(descriptorpb.FieldDescriptorProto_TYPE_MESSAGE),
+				TypeName: strPtr(".test3.MapMessage.AttributesEntry"),
+				Label:    fieldLabel(descriptorpb.FieldDescriptorProto_LABEL_REPEATED),
+				JsonName: strPtr("attributes"),
+			},
+		},
+		NestedType: []*descriptorpb.DescriptorProto{mapEntry},
+	}
+
+	syntax := "proto3"
+	fileDesc := &descriptorpb.FileDescriptorProto{
+		Name:        strPtr("test3.proto"),
+		Package:     strPtr("test3"),
+		Syntax:      &syntax,
+		MessageType: []*descriptorpb.DescriptorProto{outerMsg},
+	}
+
+	fd, err := protodesc.NewFile(fileDesc, nil)
+	require.NoError(t, err)
+
+	msgDesc := fd.Messages().ByName("MapMessage")
+	require.NotNil(t, msgDesc)
+
+	registry := saga.NewHandlerRegistry()
+	meta := &saga.HandlerMetadata{
+		ProtoRequestType:     dynamicpb.NewMessage(msgDesc),
+		CompensationStrategy: "none",
+		Version:              1,
+	}
+	err = registry.RegisterWithMetadata("test.with_map", func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return nil, nil
+	}, meta)
+	require.NoError(t, err)
+
+	s, err := schema.DeriveSchema(registry)
+	require.NoError(t, err)
+
+	h := s.Handlers["test.with_map"]
+	require.NotNil(t, h)
+
+	attrField, ok := h.Params["attributes"]
+	require.True(t, ok)
+	assert.Equal(t, schema.TypeMap, attrField.Type)
+	assert.Equal(t, schema.TypeString, attrField.KeyType)
+	assert.Equal(t, schema.TypeString, attrField.ValueType)
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -86,6 +86,7 @@ var (
 	ErrConflictCompensationStrategy = errors.New("handler with 'compensate' should not set 'compensation_strategy' to non-auto value")
 	ErrInvalidConversionRule        = errors.New("invalid conversion rule")
 	ErrDeprecatedHandler            = errors.New("deprecated handler")
+	ErrOverrideMissingType          = errors.New("ParamOverride for non-proto field requires explicit Type")
 )
 
 // Schema represents a collection of handler definitions for a service.

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -87,6 +87,7 @@ var (
 	ErrInvalidConversionRule        = errors.New("invalid conversion rule")
 	ErrDeprecatedHandler            = errors.New("deprecated handler")
 	ErrOverrideMissingType          = errors.New("ParamOverride for non-proto field requires explicit Type")
+	ErrOverrideAliasCollision       = errors.New("ParamOverride alias would overwrite existing field")
 )
 
 // Schema represents a collection of handler definitions for a service.


### PR DESCRIPTION
## Summary

- Adds `contract_test.go` in `shared/pkg/saga/schema/` that validates proto-handler alignment across all 10 services
- Builds a full handler registry (35 handlers) using zero-value clients for metadata-only registration
- Includes merge of task 2 branch (`handler-schema-alignment--2--derive-schema`) for `DeriveSchema` access

## Test Coverage

| Test | What it validates |
|------|-------------------|
| `TestHandlerProtoAlignment` | DeriveSchema works for all annotated handlers; enum params have values; compensation refs exist; YAML drift logged |
| `TestAllYAMLHandlersHaveRegistration` | Tracks which YAML handlers have runtime registrations (29/47 registered, 18 aspirational) |
| `TestCompensationChainIntegrity` | All compensation references point to registered handlers; no chains-of-chains |
| `TestDeriveSchemaFullRegistry` | `DeriveSchema` produces valid schema from full registry |

## Design Decisions

- **YAML comparison is informational, not assertive**: Proto is the source of truth; type/enum mismatches between YAML and derived schema are logged as `DRIFT:` for visibility but don't fail the test
- **Enum overrides without values are warnings**: Handler annotations that set `Type: "enum"` via `ParamOverride` without proto enum backing are logged as `WARNING:` (3 cases identified)
- **Unannotated handlers are skipped**: `financial_accounting.post_entries` lacks `ProtoRequestType` and is skipped with a message

## Findings

The test identified these annotation issues for follow-up:
- `current_account.control`: `action` param override sets enum type but proto field is `control_action` (different name)
- `position_keeping.initiate_log`: `direction` override sets enum type but no proto enum values
- `financial_accounting.capture_posting`: same `direction` issue

## Test plan

- [x] `go test ./shared/pkg/saga/schema/... -count=1` passes
- [x] `go vet` clean
- [x] Pre-commit hooks pass (gofumpt, golangci-lint, gitleaks)