### PR TITLE
fix: align JWKS validator test with lazy key fetch behavior

### DIFF
--- a/services/mcp-server/internal/auth/jwks_validator_test.go
+++ b/services/mcp-server/internal/auth/jwks_validator_test.go
@@ -87,11 +87,16 @@ func TestNewJWKSBearerValidator_EmptyURL(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestNewJWKSBearerValidator_UnreachableURL verifies that a failed initial
-// JWKS fetch returns an error.
+// TestNewJWKSBearerValidator_UnreachableURL verifies that an unreachable JWKS
+// endpoint causes token validation to fail. Construction succeeds because the
+// JWKS provider uses lazy key fetching (deferred to first GetKey call).
 func TestNewJWKSBearerValidator_UnreachableURL(t *testing.T) {
-	_, err := auth.NewJWKSBearerValidator(context.Background(), "http://127.0.0.1:0/keys")
-	require.Error(t, err)
+	validator, err := auth.NewJWKSBearerValidator(context.Background(), "http://127.0.0.1:0/keys")
+	require.NoError(t, err, "construction should succeed with lazy fetch")
+	t.Cleanup(func() { _ = validator.Close() })
+
+	err = validator.ValidateBearer("eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5In0.eyJzdWIiOiJ0ZXN0In0.invalid")
+	require.Error(t, err, "validation should fail when JWKS endpoint is unreachable")
 }
 
 // TestJWKSBearerValidator_ValidToken verifies that a validly-signed JWT is accepted.


### PR DESCRIPTION
## Summary
- `NewJWKSProvider` was changed to defer the initial JWKS fetch to the first `GetKey` call (lazy loading), enabling the provider to be created before the JWKS endpoint is available (e.g. embedded Dex)
- `TestNewJWKSBearerValidator_UnreachableURL` expected construction to fail with an unreachable URL, but construction now succeeds since no HTTP request is made
- Updated the test to verify the error surfaces at validation time instead, matching the lazy fetch behavior

## Test plan
- [x] `TestNewJWKSBearerValidator_UnreachableURL` passes locally
- [x] `TestNewJWKSBearerValidator_EmptyURL` still passes (construction-time validation unchanged)
- [ ] CI passes on this branch