### PR TITLE
feat: OAuth PKCE flow and external auth provider UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,11 +7,16 @@ import { PageErrorBoundary, RouteErrorBoundary } from '@/components/error-bounda
 import { AuthProvider, useAuth } from '@/contexts/auth-context'
 import { TenantProvider, useTenantContext } from '@/contexts/tenant-context'
 import { useTenants } from '@/hooks/use-tenants'
+import { useAuthProviders, type AuthProvider as AuthProviderType } from '@/hooks/use-auth-providers'
+import { useOAuthFlow } from '@/hooks/use-oauth-flow'
 import { ApiClientProvider } from '@/api/context'
 import { ProtectedRoute, PlatformOnlyRoute, AdminOnlyRoute, TenantSubdomainEnforcer } from '@/components/routing'
 import { FeatureGuard } from '@/components/feature-guard'
 import { AppShell } from '@/components/layout/app-shell'
 import { TooltipProvider } from '@/components/ui/tooltip'
+import { CallbackPage } from '@/pages/callback'
+import { ProviderButton } from '@/components/auth/provider-button'
+import { AuthDivider } from '@/components/auth/auth-divider'
 import { AccountsPage, AccountDetailPage } from '@/features/accounts'
 import { PaymentsPage, PaymentDetailPage } from '@/features/payments'
 import { LedgerPage, BookingLogDetailPage } from '@/features/ledger'
@@ -64,6 +69,10 @@ function LoginPage() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+  const { data: providers } = useAuthProviders()
+  const { startFlow } = useOAuthFlow()
+
+  const externalProviders = providers?.filter((p: AuthProviderType) => p.type === 'oidc') ?? []
 
   const handleDexLogin = useCallback(
     async (e: FormEvent) => {
@@ -180,6 +189,22 @@ function LoginPage() {
               {loading ? 'Signing in...' : 'Sign in'}
             </button>
           </form>
+        )}
+
+        {/* External auth provider buttons */}
+        {externalProviders.length > 0 && (
+          <>
+            {(import.meta.env.VITE_DEMO_MODE === 'true' || !import.meta.env.DEV) && <AuthDivider />}
+            <div className="space-y-2">
+              {externalProviders.map((provider: AuthProviderType) => (
+                <ProviderButton
+                  key={provider.id}
+                  provider={provider}
+                  onClick={() => startFlow(provider.id)}
+                />
+              ))}
+            </div>
+          </>
         )}
 
         {/* Dev-only fake JWT buttons */}
@@ -397,6 +422,7 @@ function AuthenticatedApp() {
           <BrowserRouter>
             <Routes>
               <Route path="/login" element={<LoginPage />} />
+              <Route path="/callback" element={<CallbackPage />} />
               <Route
                 path="/*"
                 element={

--- a/frontend/src/components/auth/auth-divider.tsx
+++ b/frontend/src/components/auth/auth-divider.tsx
@@ -1,0 +1,12 @@
+export function AuthDivider() {
+  return (
+    <div className="relative">
+      <div className="absolute inset-0 flex items-center">
+        <span className="w-full border-t border-muted" />
+      </div>
+      <div className="relative flex justify-center text-xs uppercase">
+        <span className="bg-background px-2 text-muted-foreground">Or continue with</span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/auth/provider-button.tsx
+++ b/frontend/src/components/auth/provider-button.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { getProviderIcon } from './provider-icons'
+import type { AuthProvider } from '@/hooks/use-auth-providers'
+
+interface ProviderButtonProps {
+  provider: AuthProvider
+  onClick: () => Promise<void>
+}
+
+export function ProviderButton({ provider, onClick }: ProviderButtonProps) {
+  const [loading, setLoading] = useState(false)
+  const Icon = getProviderIcon(provider.id)
+
+  const handleClick = async () => {
+    setLoading(true)
+    try {
+      await onClick()
+    } catch {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Button
+      variant="outline"
+      className="w-full"
+      disabled={loading}
+      onClick={() => void handleClick()}
+    >
+      <Icon className="size-4" />
+      {loading ? 'Redirecting...' : `Sign in with ${provider.displayName}`}
+    </Button>
+  )
+}

--- a/frontend/src/components/auth/provider-button.tsx
+++ b/frontend/src/components/auth/provider-button.tsx
@@ -18,25 +18,31 @@ function ProviderIcon({ providerId }: { providerId: string }) {
 
 export function ProviderButton({ provider, onClick }: ProviderButtonProps) {
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const handleClick = async () => {
     setLoading(true)
+    setError(null)
     try {
       await onClick()
     } catch {
+      setError('Failed to start sign-in. Please try again.')
       setLoading(false)
     }
   }
 
   return (
-    <Button
-      variant="outline"
-      className="w-full"
-      disabled={loading}
-      onClick={() => void handleClick()}
-    >
-      <ProviderIcon providerId={provider.id} />
-      {loading ? 'Redirecting...' : `Sign in with ${provider.displayName}`}
-    </Button>
+    <div>
+      <Button
+        variant="outline"
+        className="w-full"
+        disabled={loading}
+        onClick={() => void handleClick()}
+      >
+        <ProviderIcon providerId={provider.id} />
+        {loading ? 'Redirecting...' : `Sign in with ${provider.displayName}`}
+      </Button>
+      {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
+    </div>
   )
 }

--- a/frontend/src/components/auth/provider-button.tsx
+++ b/frontend/src/components/auth/provider-button.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
-import { getProviderIcon } from './provider-icons'
+import { GoogleIcon, GitHubIcon, MicrosoftIcon, DefaultProviderIcon } from './provider-icons'
 import type { AuthProvider } from '@/hooks/use-auth-providers'
 
 interface ProviderButtonProps {
@@ -8,9 +8,16 @@ interface ProviderButtonProps {
   onClick: () => Promise<void>
 }
 
+function ProviderIcon({ providerId }: { providerId: string }) {
+  const normalized = providerId.toLowerCase()
+  if (normalized.includes('google')) return <GoogleIcon className="size-4" />
+  if (normalized.includes('github')) return <GitHubIcon className="size-4" />
+  if (normalized.includes('microsoft')) return <MicrosoftIcon className="size-4" />
+  return <DefaultProviderIcon className="size-4" />
+}
+
 export function ProviderButton({ provider, onClick }: ProviderButtonProps) {
   const [loading, setLoading] = useState(false)
-  const Icon = getProviderIcon(provider.id)
 
   const handleClick = async () => {
     setLoading(true)
@@ -28,7 +35,7 @@ export function ProviderButton({ provider, onClick }: ProviderButtonProps) {
       disabled={loading}
       onClick={() => void handleClick()}
     >
-      <Icon className="size-4" />
+      <ProviderIcon providerId={provider.id} />
       {loading ? 'Redirecting...' : `Sign in with ${provider.displayName}`}
     </Button>
   )

--- a/frontend/src/components/auth/provider-icons.tsx
+++ b/frontend/src/components/auth/provider-icons.tsx
@@ -1,6 +1,4 @@
-import type { ReactNode } from 'react'
-
-function GoogleIcon({ className }: { className?: string }) {
+export function GoogleIcon({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="currentColor">
       <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
@@ -11,7 +9,7 @@ function GoogleIcon({ className }: { className?: string }) {
   )
 }
 
-function GitHubIcon({ className }: { className?: string }) {
+export function GitHubIcon({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="currentColor">
       <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z" />
@@ -19,7 +17,7 @@ function GitHubIcon({ className }: { className?: string }) {
   )
 }
 
-function MicrosoftIcon({ className }: { className?: string }) {
+export function MicrosoftIcon({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="currentColor">
       <path d="M3 3h8.5v8.5H3V3zm9.5 0H21v8.5h-8.5V3zM3 12.5h8.5V21H3v-8.5zm9.5 0H21V21h-8.5v-8.5z" />
@@ -27,7 +25,7 @@ function MicrosoftIcon({ className }: { className?: string }) {
   )
 }
 
-function DefaultProviderIcon({ className }: { className?: string }) {
+export function DefaultProviderIcon({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
@@ -35,20 +33,4 @@ function DefaultProviderIcon({ className }: { className?: string }) {
       <line x1="15" y1="12" x2="3" y2="12" />
     </svg>
   )
-}
-
-const PROVIDER_ICONS: Record<string, (props: { className?: string }) => ReactNode> = {
-  google: GoogleIcon,
-  github: GitHubIcon,
-  microsoft: MicrosoftIcon,
-}
-
-export function getProviderIcon(providerId: string): (props: { className?: string }) => ReactNode {
-  const normalized = providerId.toLowerCase()
-  for (const [key, icon] of Object.entries(PROVIDER_ICONS)) {
-    if (normalized.includes(key)) {
-      return icon
-    }
-  }
-  return DefaultProviderIcon
 }

--- a/frontend/src/components/auth/provider-icons.tsx
+++ b/frontend/src/components/auth/provider-icons.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from 'react'
+
+function GoogleIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
+      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+    </svg>
+  )
+}
+
+function GitHubIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z" />
+    </svg>
+  )
+}
+
+function MicrosoftIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M3 3h8.5v8.5H3V3zm9.5 0H21v8.5h-8.5V3zM3 12.5h8.5V21H3v-8.5zm9.5 0H21V21h-8.5v-8.5z" />
+    </svg>
+  )
+}
+
+function DefaultProviderIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+      <polyline points="10 17 15 12 10 7" />
+      <line x1="15" y1="12" x2="3" y2="12" />
+    </svg>
+  )
+}
+
+const PROVIDER_ICONS: Record<string, (props: { className?: string }) => ReactNode> = {
+  google: GoogleIcon,
+  github: GitHubIcon,
+  microsoft: MicrosoftIcon,
+}
+
+export function getProviderIcon(providerId: string): (props: { className?: string }) => ReactNode {
+  const normalized = providerId.toLowerCase()
+  for (const [key, icon] of Object.entries(PROVIDER_ICONS)) {
+    if (normalized.includes(key)) {
+      return icon
+    }
+  }
+  return DefaultProviderIcon
+}

--- a/frontend/src/hooks/use-auth-providers.test.ts
+++ b/frontend/src/hooks/use-auth-providers.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/msw-handlers'
+import { useAuthProviders } from './use-auth-providers'
+import type { ReactNode } from 'react'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return QueryClientProvider({ client: queryClient, children })
+  }
+}
+
+describe('useAuthProviders', () => {
+  it('returns empty data when API returns 404', async () => {
+    // Default MSW handler returns 404
+    const { result } = renderHook(() => useAuthProviders(), { wrapper: createWrapper() })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+  })
+
+  it('returns providers when API succeeds', async () => {
+    server.use(
+      http.get('/api/auth/providers', () => {
+        return HttpResponse.json({
+          providers: [
+            { id: 'local', type: 'password', displayName: 'Email' },
+            { id: 'google', type: 'oidc', displayName: 'Google' },
+          ],
+        })
+      }),
+    )
+
+    const { result } = renderHook(() => useAuthProviders(), { wrapper: createWrapper() })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(result.current.data).toHaveLength(2)
+    expect(result.current.data?.[1]?.id).toBe('google')
+    expect(result.current.data?.[1]?.type).toBe('oidc')
+  })
+})

--- a/frontend/src/hooks/use-auth-providers.test.ts
+++ b/frontend/src/hooks/use-auth-providers.test.ts
@@ -16,13 +16,15 @@ function createWrapper() {
 }
 
 describe('useAuthProviders', () => {
-  it('returns empty data when API returns 404', async () => {
+  it('returns empty array when API returns 404 (password-only mode)', async () => {
     // Default MSW handler returns 404
     const { result } = renderHook(() => useAuthProviders(), { wrapper: createWrapper() })
 
     await waitFor(() => {
-      expect(result.current.isError).toBe(true)
+      expect(result.current.isSuccess).toBe(true)
     })
+
+    expect(result.current.data).toEqual([])
   })
 
   it('returns providers when API succeeds', async () => {

--- a/frontend/src/hooks/use-auth-providers.ts
+++ b/frontend/src/hooks/use-auth-providers.ts
@@ -13,6 +13,10 @@ interface ProvidersResponse {
 
 async function fetchProviders(): Promise<AuthProvider[]> {
   const response = await fetch('/api/auth/providers')
+  if (response.status === 404) {
+    // Provider discovery API not available - password-only mode
+    return []
+  }
   if (!response.ok) {
     throw new Error(`Failed to fetch providers: ${response.status}`)
   }

--- a/frontend/src/hooks/use-auth-providers.ts
+++ b/frontend/src/hooks/use-auth-providers.ts
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query'
+
+export interface AuthProvider {
+  id: string
+  type: 'password' | 'oidc'
+  displayName: string
+  iconUrl?: string
+}
+
+interface ProvidersResponse {
+  providers: AuthProvider[]
+}
+
+async function fetchProviders(): Promise<AuthProvider[]> {
+  const response = await fetch('/api/auth/providers')
+  if (!response.ok) {
+    throw new Error(`Failed to fetch providers: ${response.status}`)
+  }
+  const data = (await response.json()) as ProvidersResponse
+  return data.providers
+}
+
+/**
+ * Fetches available authentication providers from the backend.
+ * Gracefully falls back to empty array on error (password-only mode).
+ */
+export function useAuthProviders() {
+  return useQuery<AuthProvider[]>({
+    queryKey: ['auth', 'providers'],
+    queryFn: fetchProviders,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  })
+}

--- a/frontend/src/hooks/use-oauth-flow.ts
+++ b/frontend/src/hooks/use-oauth-flow.ts
@@ -1,0 +1,37 @@
+import { useCallback } from 'react'
+import { generateCodeVerifier, generateCodeChallenge, generateState } from '@/lib/pkce'
+
+const PKCE_VERIFIER_KEY = 'meridian_pkce_verifier'
+const PKCE_STATE_KEY = 'meridian_pkce_state'
+
+/**
+ * Hook that initiates an OAuth authorization code flow with PKCE.
+ * Generates PKCE parameters, stores them in sessionStorage, and redirects to Dex.
+ */
+export function useOAuthFlow() {
+  const startFlow = useCallback(async (connectorId: string) => {
+    const verifier = generateCodeVerifier()
+    const challenge = await generateCodeChallenge(verifier)
+    const state = generateState()
+
+    sessionStorage.setItem(PKCE_VERIFIER_KEY, verifier)
+    sessionStorage.setItem(PKCE_STATE_KEY, state)
+
+    const params = new URLSearchParams({
+      client_id: 'meridian-service',
+      response_type: 'code',
+      scope: 'openid email profile',
+      redirect_uri: `${window.location.origin}/callback`,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+      state,
+      connector_id: connectorId,
+    })
+
+    window.location.href = `/dex/auth?${params.toString()}`
+  }, [])
+
+  return { startFlow }
+}
+
+export { PKCE_VERIFIER_KEY, PKCE_STATE_KEY }

--- a/frontend/src/lib/__tests__/pkce.test.ts
+++ b/frontend/src/lib/__tests__/pkce.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { generateCodeVerifier, generateCodeChallenge, generateState } from '../pkce'
+
+describe('PKCE utilities', () => {
+  describe('generateCodeVerifier', () => {
+    it('generates a 64-character string', () => {
+      const verifier = generateCodeVerifier()
+      expect(verifier).toHaveLength(64)
+    })
+
+    it('uses only unreserved characters (RFC 7636 4.1)', () => {
+      const verifier = generateCodeVerifier()
+      expect(verifier).toMatch(/^[A-Za-z0-9\-._~]+$/)
+    })
+
+    it('generates unique verifiers', () => {
+      const v1 = generateCodeVerifier()
+      const v2 = generateCodeVerifier()
+      expect(v1).not.toEqual(v2)
+    })
+  })
+
+  describe('generateCodeChallenge', () => {
+    it('produces a base64url string without padding', async () => {
+      const verifier = generateCodeVerifier()
+      const challenge = await generateCodeChallenge(verifier)
+      expect(challenge).toMatch(/^[A-Za-z0-9\-_]+$/)
+      expect(challenge).not.toContain('=')
+    })
+
+    it('produces a consistent challenge for the same verifier', async () => {
+      const verifier = 'test-verifier-for-consistency'
+      const c1 = await generateCodeChallenge(verifier)
+      const c2 = await generateCodeChallenge(verifier)
+      expect(c1).toEqual(c2)
+    })
+
+    it('produces different challenges for different verifiers', async () => {
+      const c1 = await generateCodeChallenge('verifier-one')
+      const c2 = await generateCodeChallenge('verifier-two')
+      expect(c1).not.toEqual(c2)
+    })
+  })
+
+  describe('generateState', () => {
+    it('generates a base64url string', () => {
+      const state = generateState()
+      expect(state).toMatch(/^[A-Za-z0-9\-_]+$/)
+    })
+
+    it('generates unique states', () => {
+      const s1 = generateState()
+      const s2 = generateState()
+      expect(s1).not.toEqual(s2)
+    })
+  })
+})

--- a/frontend/src/lib/pkce.ts
+++ b/frontend/src/lib/pkce.ts
@@ -1,0 +1,49 @@
+/**
+ * PKCE (Proof Key for Code Exchange) utilities for OAuth 2.0 authorization code flow.
+ * Implements RFC 7636 sections 4.1 and 4.2.
+ */
+
+const VERIFIER_CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~'
+const VERIFIER_LENGTH = 64
+
+/**
+ * Generate a cryptographically random code verifier (RFC 7636 4.1).
+ * Returns a 64-character string from the unreserved character set.
+ */
+export function generateCodeVerifier(): string {
+  const array = new Uint8Array(VERIFIER_LENGTH)
+  crypto.getRandomValues(array)
+  return Array.from(array, (byte) => VERIFIER_CHARSET[byte % VERIFIER_CHARSET.length]).join('')
+}
+
+/**
+ * Generate a S256 code challenge from a code verifier (RFC 7636 4.2).
+ * challenge = BASE64URL(SHA256(verifier))
+ */
+export async function generateCodeChallenge(verifier: string): Promise<string> {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(verifier)
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return base64UrlEncode(digest)
+}
+
+/**
+ * Base64 URL encoding without padding (RFC 4648 section 5).
+ */
+function base64UrlEncode(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/**
+ * Generate a random state parameter for CSRF protection.
+ */
+export function generateState(): string {
+  const array = new Uint8Array(32)
+  crypto.getRandomValues(array)
+  return base64UrlEncode(array.buffer)
+}

--- a/frontend/src/pages/callback.test.tsx
+++ b/frontend/src/pages/callback.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/test/msw-handlers'
+import { AuthProvider } from '@/contexts/auth-context'
+import { CallbackPage } from './callback'
+
+function renderCallback(initialUrl: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <MemoryRouter initialEntries={[initialUrl]}>
+          <Routes>
+            <Route path="/callback" element={<CallbackPage />} />
+            <Route path="/login" element={<div data-testid="login-page">Login</div>} />
+            <Route path="/" element={<div data-testid="home-page">Home</div>} />
+          </Routes>
+        </MemoryRouter>
+      </AuthProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('CallbackPage', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('shows error when error param is present', async () => {
+    renderCallback('/callback?error=access_denied&error_description=User+denied+access')
+
+    await waitFor(() => {
+      expect(screen.getByText('User denied access')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Return to Login')).toBeInTheDocument()
+  })
+
+  it('shows error when code or state is missing', async () => {
+    renderCallback('/callback')
+
+    await waitFor(() => {
+      expect(screen.getByText('Missing authorization code or state parameter')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when state does not match', async () => {
+    sessionStorage.setItem('meridian_pkce_state', 'expected-state')
+    renderCallback('/callback?code=test-code&state=wrong-state')
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid state parameter - possible CSRF attack')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when verifier is missing', async () => {
+    sessionStorage.setItem('meridian_pkce_state', 'test-state')
+    renderCallback('/callback?code=test-code&state=test-state')
+
+    await waitFor(() => {
+      expect(screen.getByText('Missing PKCE verifier - please try signing in again')).toBeInTheDocument()
+    })
+  })
+
+  it('exchanges code for token and navigates home on success', async () => {
+    const validJwt = [
+      btoa(JSON.stringify({ alg: 'none', typ: 'JWT' })),
+      btoa(JSON.stringify({ sub: 'user-1', exp: Math.floor(Date.now() / 1000) + 3600, iss: 'dex', aud: 'meridian-service' })),
+      'sig',
+    ].join('.')
+
+    server.use(
+      http.post('*/dex/token', () => {
+        return HttpResponse.json({ id_token: validJwt })
+      }),
+    )
+
+    sessionStorage.setItem('meridian_pkce_state', 'test-state')
+    sessionStorage.setItem('meridian_pkce_verifier', 'test-verifier')
+    renderCallback('/callback?code=test-code&state=test-state')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home-page')).toBeInTheDocument()
+    })
+
+    // PKCE values should be cleaned up
+    expect(sessionStorage.getItem('meridian_pkce_state')).toBeNull()
+    expect(sessionStorage.getItem('meridian_pkce_verifier')).toBeNull()
+  })
+
+  it('shows error on token exchange failure', async () => {
+    server.use(
+      http.post('*/dex/token', () => {
+        return HttpResponse.json({ error: 'invalid_grant' }, { status: 400 })
+      }),
+    )
+
+    sessionStorage.setItem('meridian_pkce_state', 'test-state')
+    sessionStorage.setItem('meridian_pkce_verifier', 'test-verifier')
+    renderCallback('/callback?code=test-code&state=test-state')
+
+    await waitFor(() => {
+      expect(screen.getByText('Authorization code expired or invalid')).toBeInTheDocument()
+    })
+  })
+
+  it('navigates to login when Return to Login is clicked', async () => {
+    const user = userEvent.setup()
+    renderCallback('/callback?error=access_denied')
+
+    await waitFor(() => {
+      expect(screen.getByText('Return to Login')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Return to Login'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('login-page')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/pages/callback.test.tsx
+++ b/frontend/src/pages/callback.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'

--- a/frontend/src/pages/callback.tsx
+++ b/frontend/src/pages/callback.tsx
@@ -91,7 +91,7 @@ export function CallbackPage() {
         }
 
         login(token)
-        navigate('/')
+        navigate('/', { replace: true })
       } catch {
         setExchangeError('Unable to reach identity provider')
       }
@@ -109,7 +109,7 @@ export function CallbackPage() {
           <h1 className="text-2xl font-semibold">Authentication Failed</h1>
           <p className="text-sm text-destructive">{error}</p>
           <button
-            onClick={() => navigate('/login')}
+            onClick={() => navigate('/login', { replace: true })}
             className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
           >
             Return to Login

--- a/frontend/src/pages/callback.tsx
+++ b/frontend/src/pages/callback.tsx
@@ -37,10 +37,6 @@ function validateCallbackParams(searchParams: URLSearchParams): {
     return { valid: false, error: 'Missing PKCE verifier - please try signing in again' }
   }
 
-  // Clean up stored PKCE values
-  sessionStorage.removeItem(PKCE_STATE_KEY)
-  sessionStorage.removeItem(PKCE_VERIFIER_KEY)
-
   return { valid: true, code, verifier }
 }
 
@@ -60,6 +56,10 @@ export function CallbackPage() {
     if (!validation.valid) return
 
     const { code, verifier } = validation
+
+    // Clean up PKCE values from sessionStorage (side effect belongs here, not in useMemo)
+    sessionStorage.removeItem(PKCE_STATE_KEY)
+    sessionStorage.removeItem(PKCE_VERIFIER_KEY)
 
     const exchangeCode = async () => {
       try {

--- a/frontend/src/pages/callback.tsx
+++ b/frontend/src/pages/callback.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useAuth } from '@/contexts/auth-context'
+import { PKCE_VERIFIER_KEY, PKCE_STATE_KEY } from '@/hooks/use-oauth-flow'
+
+/**
+ * OAuth callback page that handles the authorization code exchange.
+ * Validates state, retrieves PKCE verifier, and exchanges the code for tokens.
+ */
+export function CallbackPage() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const { login } = useAuth()
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const code = searchParams.get('code')
+    const state = searchParams.get('state')
+    const errorParam = searchParams.get('error')
+    const errorDescription = searchParams.get('error_description')
+
+    if (errorParam) {
+      setError(errorDescription ?? errorParam)
+      return
+    }
+
+    if (!code || !state) {
+      setError('Missing authorization code or state parameter')
+      return
+    }
+
+    const storedState = sessionStorage.getItem(PKCE_STATE_KEY)
+    if (state !== storedState) {
+      setError('Invalid state parameter - possible CSRF attack')
+      return
+    }
+
+    const verifier = sessionStorage.getItem(PKCE_VERIFIER_KEY)
+    if (!verifier) {
+      setError('Missing PKCE verifier - please try signing in again')
+      return
+    }
+
+    // Clean up stored PKCE values
+    sessionStorage.removeItem(PKCE_STATE_KEY)
+    sessionStorage.removeItem(PKCE_VERIFIER_KEY)
+
+    const exchangeCode = async () => {
+      try {
+        const body = new URLSearchParams({
+          grant_type: 'authorization_code',
+          client_id: 'meridian-service',
+          code,
+          redirect_uri: `${window.location.origin}/callback`,
+          code_verifier: verifier,
+        })
+
+        const response = await fetch('/dex/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: body.toString(),
+        })
+
+        if (!response.ok) {
+          const text = await response.text()
+          setError(text.includes('invalid_grant') ? 'Authorization code expired or invalid' : 'Token exchange failed')
+          return
+        }
+
+        const data = (await response.json()) as { id_token?: string; access_token?: string }
+        const token = data.id_token ?? data.access_token
+        if (!token) {
+          setError('No token received from identity provider')
+          return
+        }
+
+        login(token)
+        navigate('/')
+      } catch {
+        setError('Unable to reach identity provider')
+      }
+    }
+
+    void exchangeCode()
+  }, [searchParams, login, navigate])
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="w-full max-w-sm space-y-4 px-4 text-center">
+          <h1 className="text-2xl font-semibold">Authentication Failed</h1>
+          <p className="text-sm text-destructive">{error}</p>
+          <button
+            onClick={() => navigate('/login')}
+            className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Return to Login
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="text-center">
+        <p className="text-muted-foreground">Completing sign in...</p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/callback.tsx
+++ b/frontend/src/pages/callback.tsx
@@ -1,7 +1,48 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '@/contexts/auth-context'
 import { PKCE_VERIFIER_KEY, PKCE_STATE_KEY } from '@/hooks/use-oauth-flow'
+
+/**
+ * Synchronously validate the callback URL parameters and PKCE state.
+ * Returns either a validated payload for code exchange or an error message.
+ */
+function validateCallbackParams(searchParams: URLSearchParams): {
+  valid: false
+  error: string
+} | {
+  valid: true
+  code: string
+  verifier: string
+} {
+  const errorParam = searchParams.get('error')
+  const errorDescription = searchParams.get('error_description')
+  if (errorParam) {
+    return { valid: false, error: errorDescription ?? errorParam }
+  }
+
+  const code = searchParams.get('code')
+  const state = searchParams.get('state')
+  if (!code || !state) {
+    return { valid: false, error: 'Missing authorization code or state parameter' }
+  }
+
+  const storedState = sessionStorage.getItem(PKCE_STATE_KEY)
+  if (state !== storedState) {
+    return { valid: false, error: 'Invalid state parameter - possible CSRF attack' }
+  }
+
+  const verifier = sessionStorage.getItem(PKCE_VERIFIER_KEY)
+  if (!verifier) {
+    return { valid: false, error: 'Missing PKCE verifier - please try signing in again' }
+  }
+
+  // Clean up stored PKCE values
+  sessionStorage.removeItem(PKCE_STATE_KEY)
+  sessionStorage.removeItem(PKCE_VERIFIER_KEY)
+
+  return { valid: true, code, verifier }
+}
 
 /**
  * OAuth callback page that handles the authorization code exchange.
@@ -11,39 +52,14 @@ export function CallbackPage() {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
   const { login } = useAuth()
-  const [error, setError] = useState<string | null>(null)
+  const [exchangeError, setExchangeError] = useState<string | null>(null)
+
+  const validation = useMemo(() => validateCallbackParams(searchParams), [searchParams])
 
   useEffect(() => {
-    const code = searchParams.get('code')
-    const state = searchParams.get('state')
-    const errorParam = searchParams.get('error')
-    const errorDescription = searchParams.get('error_description')
+    if (!validation.valid) return
 
-    if (errorParam) {
-      setError(errorDescription ?? errorParam)
-      return
-    }
-
-    if (!code || !state) {
-      setError('Missing authorization code or state parameter')
-      return
-    }
-
-    const storedState = sessionStorage.getItem(PKCE_STATE_KEY)
-    if (state !== storedState) {
-      setError('Invalid state parameter - possible CSRF attack')
-      return
-    }
-
-    const verifier = sessionStorage.getItem(PKCE_VERIFIER_KEY)
-    if (!verifier) {
-      setError('Missing PKCE verifier - please try signing in again')
-      return
-    }
-
-    // Clean up stored PKCE values
-    sessionStorage.removeItem(PKCE_STATE_KEY)
-    sessionStorage.removeItem(PKCE_VERIFIER_KEY)
+    const { code, verifier } = validation
 
     const exchangeCode = async () => {
       try {
@@ -63,26 +79,28 @@ export function CallbackPage() {
 
         if (!response.ok) {
           const text = await response.text()
-          setError(text.includes('invalid_grant') ? 'Authorization code expired or invalid' : 'Token exchange failed')
+          setExchangeError(text.includes('invalid_grant') ? 'Authorization code expired or invalid' : 'Token exchange failed')
           return
         }
 
         const data = (await response.json()) as { id_token?: string; access_token?: string }
         const token = data.id_token ?? data.access_token
         if (!token) {
-          setError('No token received from identity provider')
+          setExchangeError('No token received from identity provider')
           return
         }
 
         login(token)
         navigate('/')
       } catch {
-        setError('Unable to reach identity provider')
+        setExchangeError('Unable to reach identity provider')
       }
     }
 
     void exchangeCode()
-  }, [searchParams, login, navigate])
+  }, [validation, login, navigate])
+
+  const error = validation.valid ? exchangeError : validation.error
 
   if (error) {
     return (

--- a/frontend/src/pages/callback.tsx
+++ b/frontend/src/pages/callback.tsx
@@ -56,6 +56,7 @@ export function CallbackPage() {
     if (!validation.valid) return
 
     const { code, verifier } = validation
+    const controller = new AbortController()
 
     // Clean up PKCE values from sessionStorage (side effect belongs here, not in useMemo)
     sessionStorage.removeItem(PKCE_STATE_KEY)
@@ -75,6 +76,7 @@ export function CallbackPage() {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           body: body.toString(),
+          signal: controller.signal,
         })
 
         if (!response.ok) {
@@ -92,12 +94,14 @@ export function CallbackPage() {
 
         login(token)
         navigate('/', { replace: true })
-      } catch {
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') return
         setExchangeError('Unable to reach identity provider')
       }
     }
 
     void exchangeCode()
+    return () => controller.abort()
   }, [validation, login, navigate])
 
   const error = validation.valid ? exchangeError : validation.error

--- a/frontend/src/pages/callback.tsx
+++ b/frontend/src/pages/callback.tsx
@@ -58,9 +58,10 @@ export function CallbackPage() {
     const { code, verifier } = validation
     const controller = new AbortController()
 
-    // Clean up PKCE values from sessionStorage (side effect belongs here, not in useMemo)
-    sessionStorage.removeItem(PKCE_STATE_KEY)
-    sessionStorage.removeItem(PKCE_VERIFIER_KEY)
+    function cleanupPkce() {
+      sessionStorage.removeItem(PKCE_STATE_KEY)
+      sessionStorage.removeItem(PKCE_VERIFIER_KEY)
+    }
 
     const exchangeCode = async () => {
       try {
@@ -81,6 +82,8 @@ export function CallbackPage() {
 
         if (!response.ok) {
           const text = await response.text()
+          // Terminal failure - clean up PKCE since the code is spent
+          cleanupPkce()
           setExchangeError(text.includes('invalid_grant') ? 'Authorization code expired or invalid' : 'Token exchange failed')
           return
         }
@@ -88,14 +91,17 @@ export function CallbackPage() {
         const data = (await response.json()) as { id_token?: string; access_token?: string }
         const token = data.id_token ?? data.access_token
         if (!token) {
+          cleanupPkce()
           setExchangeError('No token received from identity provider')
           return
         }
 
+        cleanupPkce()
         login(token)
         navigate('/', { replace: true })
       } catch (err) {
         if (err instanceof DOMException && err.name === 'AbortError') return
+        // Transient failure (network error) - keep PKCE values for retry on refresh
         setExchangeError('Unable to reach identity provider')
       }
     }

--- a/frontend/src/test/msw-handlers.ts
+++ b/frontend/src/test/msw-handlers.ts
@@ -105,6 +105,11 @@ export const handlers = [
   http.post('/api/auth/refresh', () => {
     return HttpResponse.json({}, { status: 401 })
   }),
+
+  // Auth providers discovery endpoint - returns 404 by default (no external providers configured)
+  http.get('/api/auth/providers', () => {
+    return HttpResponse.json({}, { status: 404 })
+  }),
 ]
 
 export const server = setupServer(...handlers)


### PR DESCRIPTION
## Summary

- Implement OAuth authorization code flow with PKCE (RFC 7636) for redirect-based authentication via Dex external connectors
- Add login page UI for external auth provider buttons (Google, GitHub, Microsoft) with graceful fallback when the provider discovery API is unavailable
- Add `/callback` route for handling authorization code exchange with CSRF and PKCE validation

## Changes

### Task 20: OAuth PKCE Flow
- **`frontend/src/lib/pkce.ts`** - PKCE utilities: cryptographic code verifier generation (RFC 7636 4.1), S256 code challenge (RFC 7636 4.2), base64url encoding without padding, random state for CSRF protection
- **`frontend/src/hooks/use-oauth-flow.ts`** - Hook that generates PKCE params, stores verifier/state in sessionStorage, builds authorization URL with `connector_id`, and redirects to `/dex/auth`
- **`frontend/src/pages/callback.tsx`** - Callback route handler: validates state (CSRF), retrieves PKCE verifier, exchanges authorization code for tokens via POST `/dex/token`, logs in via AuthProvider, handles errors with "Return to Login" button

### Task 21: External Auth Provider UI
- **`frontend/src/hooks/use-auth-providers.ts`** - Fetches available providers from `GET /api/auth/providers` using react-query with 5min staleTime; graceful fallback on error (password-only mode)
- **`frontend/src/components/auth/provider-icons.tsx`** - SVG icons for Google, GitHub, Microsoft with fallback default icon
- **`frontend/src/components/auth/provider-button.tsx`** - Full-width outline button with provider icon and loading state
- **`frontend/src/components/auth/auth-divider.tsx`** - "Or continue with" separator between password form and external providers
- **`frontend/src/App.tsx`** - Updated LoginPage to render external provider buttons below divider; added `/callback` route

### Infrastructure
- **`frontend/src/test/msw-handlers.ts`** - Added default 404 handler for `/api/auth/providers` to prevent unhandled request errors in tests

## Test Plan
- [x] 8 tests for PKCE utilities (verifier format, challenge consistency, state uniqueness)
- [x] 7 tests for CallbackPage (error params, missing code/state, CSRF validation, missing verifier, successful exchange, token failure, return-to-login navigation)
- [x] 2 tests for useAuthProviders hook (404 fallback, successful fetch)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] No new test failures vs develop baseline

## Design Decisions
- **Graceful degradation**: If `/api/auth/providers` returns 404 (task 19 not yet merged), only the password form is shown. No visual or functional regression.
- **sessionStorage for PKCE**: Verifier and state stored in sessionStorage (cleared on tab close) rather than localStorage for security.
- **CSRF protection**: State parameter validated against sessionStorage before code exchange.