### PR TITLE
feat: OIDC connector config and provider discovery API

### DIFF
--- a/services/api-gateway/providers.go
+++ b/services/api-gateway/providers.go
@@ -1,0 +1,107 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// AuthProvider represents a configured authentication provider returned by the
+// provider discovery endpoint. The frontend uses this to render login buttons.
+type AuthProvider struct {
+	// ID is the unique identifier for this provider (e.g., "meridian", "google").
+	ID string `json:"id"`
+	// Type is the provider type: "password" for local login, "oidc" for external.
+	Type string `json:"type"`
+	// DisplayName is the human-readable label for the login button.
+	DisplayName string `json:"displayName"`
+	// AuthURL is the Dex authorization URL for OIDC providers.
+	// Empty for password-type providers.
+	AuthURL string `json:"authUrl,omitempty"`
+}
+
+// ProvidersResponse is the JSON response for GET /api/auth/providers.
+type ProvidersResponse struct {
+	Providers []AuthProvider `json:"providers"`
+}
+
+// ProvidersConfig holds the configuration for the provider discovery endpoint.
+type ProvidersConfig struct {
+	// Enabled controls whether the /api/auth/providers endpoint is registered.
+	Enabled bool
+	// Providers is the list of configured authentication providers.
+	Providers []AuthProvider
+}
+
+// LoadProvidersConfig loads provider configuration from environment variables.
+//
+// Environment variables:
+//   - AUTH_PROVIDERS_ENABLED: Enable the /api/auth/providers endpoint (default: false)
+//   - AUTH_PROVIDERS: JSON array of provider objects
+//   - DEX_ISSUER: Used to construct authUrl for OIDC providers when not explicitly set
+//   - AUTH_DEFAULT_PROVIDER: ID of the default provider (informational)
+//
+// When AUTH_PROVIDERS is not set but AUTH_PROVIDERS_ENABLED is true, a default
+// "meridian" password provider is included.
+func LoadProvidersConfig() ProvidersConfig {
+	config := ProvidersConfig{
+		Enabled: getEnvBool("AUTH_PROVIDERS_ENABLED", false),
+	}
+
+	if !config.Enabled {
+		return config
+	}
+
+	dexIssuer := strings.TrimRight(os.Getenv("DEX_ISSUER"), "/")
+
+	if raw := os.Getenv("AUTH_PROVIDERS"); raw != "" {
+		var providers []AuthProvider
+		if err := json.Unmarshal([]byte(raw), &providers); err == nil {
+			// Populate authUrl for OIDC providers that don't have one set
+			for i := range providers {
+				if providers[i].Type == "oidc" && providers[i].AuthURL == "" && dexIssuer != "" {
+					providers[i].AuthURL = dexIssuer + "/auth/" + providers[i].ID
+				}
+			}
+			config.Providers = providers
+		}
+	}
+
+	// Default to just the local password provider if nothing configured
+	if len(config.Providers) == 0 {
+		config.Providers = []AuthProvider{
+			{ID: "meridian", Type: "password", DisplayName: "Email & Password"},
+		}
+	}
+
+	return config
+}
+
+// getEnvBool parses a boolean from an environment variable.
+func getEnvBool(key string, defaultVal bool) bool {
+	v := os.Getenv(key)
+	switch strings.ToLower(v) {
+	case "true", "1", "yes":
+		return true
+	case "false", "0", "no":
+		return false
+	default:
+		return defaultVal
+	}
+}
+
+// handleProviders returns the configured authentication providers as JSON.
+// This endpoint is public (no auth required) because the frontend needs
+// to know which login methods are available before the user authenticates.
+func (s *Server) handleProviders(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+
+	resp := ProvidersResponse{Providers: s.providersConfig.Providers}
+	if resp.Providers == nil {
+		resp.Providers = []AuthProvider{}
+	}
+
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/services/api-gateway/providers.go
+++ b/services/api-gateway/providers.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -57,7 +58,10 @@ func LoadProvidersConfig() ProvidersConfig {
 
 	if raw := os.Getenv("AUTH_PROVIDERS"); raw != "" {
 		var providers []AuthProvider
-		if err := json.Unmarshal([]byte(raw), &providers); err == nil {
+		if err := json.Unmarshal([]byte(raw), &providers); err != nil {
+			slog.Error("failed to parse AUTH_PROVIDERS, falling back to default provider",
+				"error", err)
+		} else {
 			// Populate authUrl for OIDC providers that don't have one set
 			for i := range providers {
 				if providers[i].Type == "oidc" && providers[i].AuthURL == "" && dexIssuer != "" {

--- a/services/api-gateway/providers.go
+++ b/services/api-gateway/providers.go
@@ -61,13 +61,21 @@ func LoadProvidersConfig() ProvidersConfig {
 			slog.Error("failed to parse AUTH_PROVIDERS, falling back to default provider",
 				"error", err)
 		} else {
-			// Populate authUrl for OIDC providers that don't have one set
+			// Populate authUrl for OIDC providers and filter out those
+			// that would have no usable auth URL.
+			filtered := make([]AuthProvider, 0, len(providers))
 			for i := range providers {
-				if providers[i].Type == "oidc" && providers[i].AuthURL == "" && dexIssuer != "" {
+				if providers[i].Type == "oidc" && providers[i].AuthURL == "" {
+					if dexIssuer == "" {
+						slog.Error("skipping OIDC provider without authUrl and DEX_ISSUER",
+							"provider_id", providers[i].ID)
+						continue
+					}
 					providers[i].AuthURL = dexIssuer + "/auth/" + providers[i].ID
 				}
+				filtered = append(filtered, providers[i])
 			}
-			config.Providers = providers
+			config.Providers = filtered
 		}
 	}
 

--- a/services/api-gateway/providers.go
+++ b/services/api-gateway/providers.go
@@ -41,7 +41,6 @@ type ProvidersConfig struct {
 //   - AUTH_PROVIDERS_ENABLED: Enable the /api/auth/providers endpoint (default: false)
 //   - AUTH_PROVIDERS: JSON array of provider objects
 //   - DEX_ISSUER: Used to construct authUrl for OIDC providers when not explicitly set
-//   - AUTH_DEFAULT_PROVIDER: ID of the default provider (informational)
 //
 // When AUTH_PROVIDERS is not set but AUTH_PROVIDERS_ENABLED is true, a default
 // "meridian" password provider is included.

--- a/services/api-gateway/providers_test.go
+++ b/services/api-gateway/providers_test.go
@@ -1,0 +1,183 @@
+package gateway
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvidersEndpoint_ReturnsProviders(t *testing.T) {
+	providers := []AuthProvider{
+		{ID: "meridian", Type: "password", DisplayName: "Email & Password"},
+		{ID: "google", Type: "oidc", DisplayName: "Google", AuthURL: "https://dex.example.com/dex/auth/google"},
+	}
+
+	server := newTestServerWithProviders(t, ProvidersConfig{
+		Enabled:   true,
+		Providers: providers,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/providers", nil)
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "public, max-age=300", resp.Header.Get("Cache-Control"))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var result ProvidersResponse
+	require.NoError(t, json.Unmarshal(body, &result))
+	require.Len(t, result.Providers, 2)
+	assert.Equal(t, "meridian", result.Providers[0].ID)
+	assert.Equal(t, "password", result.Providers[0].Type)
+	assert.Equal(t, "google", result.Providers[1].ID)
+	assert.Equal(t, "oidc", result.Providers[1].Type)
+	assert.Equal(t, "https://dex.example.com/dex/auth/google", result.Providers[1].AuthURL)
+}
+
+func TestProvidersEndpoint_EmptyProviders_ReturnsEmptyArray(t *testing.T) {
+	server := newTestServerWithProviders(t, ProvidersConfig{
+		Enabled:   true,
+		Providers: nil,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/providers", nil)
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var result ProvidersResponse
+	require.NoError(t, json.Unmarshal(body, &result))
+	assert.NotNil(t, result.Providers)
+	assert.Empty(t, result.Providers)
+}
+
+func TestProvidersEndpoint_PostReturns405(t *testing.T) {
+	server := newTestServerWithProviders(t, ProvidersConfig{
+		Enabled:   true,
+		Providers: []AuthProvider{{ID: "meridian", Type: "password", DisplayName: "Email & Password"}},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/providers", nil)
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Result().StatusCode)
+}
+
+func TestProvidersEndpoint_DisabledReturns404(t *testing.T) {
+	server := newTestServerWithProviders(t, ProvidersConfig{
+		Enabled: false,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/providers", nil)
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+
+	// When disabled, the route is not registered. The "/" catch-all will handle it.
+	// With no backend configured, it returns 503.
+	resp := w.Result()
+	defer resp.Body.Close()
+	assert.NotEqual(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestProvidersEndpoint_OmitsEmptyAuthURL(t *testing.T) {
+	server := newTestServerWithProviders(t, ProvidersConfig{
+		Enabled: true,
+		Providers: []AuthProvider{
+			{ID: "meridian", Type: "password", DisplayName: "Email & Password"},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/providers", nil)
+	w := httptest.NewRecorder()
+	server.mux.ServeHTTP(w, req)
+
+	body, err := io.ReadAll(w.Result().Body)
+	require.NoError(t, err)
+
+	// authUrl should be omitted (omitempty) for password type
+	assert.NotContains(t, string(body), "authUrl")
+}
+
+func TestLoadProvidersConfig_Disabled(t *testing.T) {
+	cfg := LoadProvidersConfig()
+	assert.False(t, cfg.Enabled)
+	assert.Nil(t, cfg.Providers)
+}
+
+func TestLoadProvidersConfig_EnabledWithDefaults(t *testing.T) {
+	t.Setenv("AUTH_PROVIDERS_ENABLED", "true")
+
+	cfg := LoadProvidersConfig()
+	assert.True(t, cfg.Enabled)
+	require.Len(t, cfg.Providers, 1)
+	assert.Equal(t, "meridian", cfg.Providers[0].ID)
+	assert.Equal(t, "password", cfg.Providers[0].Type)
+}
+
+func TestLoadProvidersConfig_JSONProviders(t *testing.T) {
+	t.Setenv("AUTH_PROVIDERS_ENABLED", "true")
+	t.Setenv("AUTH_PROVIDERS", `[
+		{"id":"meridian","type":"password","displayName":"Email & Password"},
+		{"id":"google","type":"oidc","displayName":"Google"}
+	]`)
+	t.Setenv("DEX_ISSUER", "https://dex.example.com/dex")
+
+	cfg := LoadProvidersConfig()
+	assert.True(t, cfg.Enabled)
+	require.Len(t, cfg.Providers, 2)
+	assert.Equal(t, "meridian", cfg.Providers[0].ID)
+	assert.Empty(t, cfg.Providers[0].AuthURL) // password type gets no authUrl
+	assert.Equal(t, "google", cfg.Providers[1].ID)
+	assert.Equal(t, "https://dex.example.com/dex/auth/google", cfg.Providers[1].AuthURL)
+}
+
+func TestLoadProvidersConfig_ExplicitAuthURL(t *testing.T) {
+	t.Setenv("AUTH_PROVIDERS_ENABLED", "true")
+	t.Setenv("AUTH_PROVIDERS", `[{"id":"custom","type":"oidc","displayName":"Custom","authUrl":"https://custom.example.com/auth"}]`)
+	t.Setenv("DEX_ISSUER", "https://dex.example.com/dex")
+
+	cfg := LoadProvidersConfig()
+	require.Len(t, cfg.Providers, 1)
+	// Explicit authUrl should NOT be overwritten
+	assert.Equal(t, "https://custom.example.com/auth", cfg.Providers[0].AuthURL)
+}
+
+func TestLoadProvidersConfig_InvalidJSON_FallsBackToDefault(t *testing.T) {
+	t.Setenv("AUTH_PROVIDERS_ENABLED", "true")
+	t.Setenv("AUTH_PROVIDERS", `{invalid`)
+
+	cfg := LoadProvidersConfig()
+	require.Len(t, cfg.Providers, 1)
+	assert.Equal(t, "meridian", cfg.Providers[0].ID)
+}
+
+func newTestServerWithProviders(t *testing.T, providersCfg ProvidersConfig) *Server {
+	t.Helper()
+	config := &Config{
+		Port:         8080,
+		BaseDomain:   "test.example.com",
+		DatabaseURL:  "postgres://test",
+		LocalDevMode: true,
+	}
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	return NewServer(config, logger, nil, WithProvidersConfig(providersCfg))
+}

--- a/services/api-gateway/providers_test.go
+++ b/services/api-gateway/providers_test.go
@@ -161,6 +161,20 @@ func TestLoadProvidersConfig_ExplicitAuthURL(t *testing.T) {
 	assert.Equal(t, "https://custom.example.com/auth", cfg.Providers[0].AuthURL)
 }
 
+func TestLoadProvidersConfig_OIDCWithoutIssuer_Filtered(t *testing.T) {
+	t.Setenv("AUTH_PROVIDERS_ENABLED", "true")
+	t.Setenv("AUTH_PROVIDERS", `[
+		{"id":"meridian","type":"password","displayName":"Email & Password"},
+		{"id":"google","type":"oidc","displayName":"Google"}
+	]`)
+	// No DEX_ISSUER set
+
+	cfg := LoadProvidersConfig()
+	// Google OIDC provider should be filtered out (no authUrl, no DEX_ISSUER)
+	require.Len(t, cfg.Providers, 1)
+	assert.Equal(t, "meridian", cfg.Providers[0].ID)
+}
+
 func TestLoadProvidersConfig_InvalidJSON_FallsBackToDefault(t *testing.T) {
 	t.Setenv("AUTH_PROVIDERS_ENABLED", "true")
 	t.Setenv("AUTH_PROVIDERS", `{invalid`)

--- a/services/api-gateway/server.go
+++ b/services/api-gateway/server.go
@@ -34,6 +34,7 @@ type Server struct {
 	eventStreamHandler    *eventstream.Handler
 	rawEventStreamHandler http.Handler // used by tests and WithEventStreamHandlerHTTP
 	versionInfo           *VersionInfo
+	providersConfig       ProvidersConfig
 }
 
 // ServerOption is a functional option for configuring the server.
@@ -83,6 +84,14 @@ func WithEventStreamHandlerHTTP(handler http.Handler) ServerOption {
 func WithVersionInfo(info *VersionInfo) ServerOption {
 	return func(s *Server) {
 		s.versionInfo = info
+	}
+}
+
+// WithProvidersConfig sets the authentication provider discovery configuration.
+// When enabled, the GET /api/auth/providers endpoint is registered.
+func WithProvidersConfig(cfg ProvidersConfig) ServerOption {
+	return func(s *Server) {
+		s.providersConfig = cfg
 	}
 }
 
@@ -144,6 +153,11 @@ func (s *Server) registerRoutes() {
 
 	// Build version endpoint - NO middleware (public, like health)
 	s.mux.HandleFunc("/version", s.getOnly(s.handleVersion))
+
+	// Provider discovery endpoint - NO middleware (public, needed before login)
+	if s.providersConfig.Enabled {
+		s.mux.HandleFunc("/api/auth/providers", s.getOnly(s.handleProviders))
+	}
 
 	// API routes - with auth and tenant middleware chain.
 	// Prefer the Vanguard transcoder when configured; fall back to the legacy

--- a/services/identity/oidc/connector_config.go
+++ b/services/identity/oidc/connector_config.go
@@ -1,0 +1,226 @@
+// Package oidc provides configuration models for external OIDC identity providers
+// that can be registered with the Dex sidecar container.
+package oidc
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ConnectorType identifies the kind of external identity provider.
+type ConnectorType string
+
+const (
+	// ConnectorTypeOIDC is a generic OpenID Connect provider.
+	ConnectorTypeOIDC ConnectorType = "oidc"
+	// ConnectorTypeGoogle is a Google OAuth2 connector.
+	ConnectorTypeGoogle ConnectorType = "google"
+	// ConnectorTypeGitHub is a GitHub OAuth connector.
+	ConnectorTypeGitHub ConnectorType = "github"
+	// ConnectorTypeMicrosoft is a Microsoft/Azure AD connector.
+	ConnectorTypeMicrosoft ConnectorType = "microsoft"
+)
+
+// Connector configuration errors.
+var (
+	// ErrConnectorIDRequired is returned when a connector has no ID.
+	ErrConnectorIDRequired = errors.New("connector: id is required")
+	// ErrConnectorTypeRequired is returned when a connector has no type.
+	ErrConnectorTypeRequired = errors.New("connector: type is required")
+	// ErrConnectorTypeInvalid is returned when a connector has an unrecognized type.
+	ErrConnectorTypeInvalid = errors.New("connector: type is invalid")
+	// ErrClientIDRequired is returned when client_id is missing.
+	ErrClientIDRequired = errors.New("connector: client_id is required")
+	// ErrClientSecretRequired is returned when client_secret is missing.
+	ErrClientSecretRequired = errors.New("connector: client_secret is required")
+	// ErrIssuerURLRequired is returned when issuer_url is missing for OIDC connectors.
+	ErrIssuerURLRequired = errors.New("connector: issuer_url is required for oidc type")
+	// ErrDuplicateConnectorID is returned when two connectors share the same ID.
+	ErrDuplicateConnectorID = errors.New("connector: duplicate connector id")
+)
+
+// ConnectorConfig represents the configuration for an external identity provider
+// registered with the Dex sidecar. This model is used both for generating the
+// Dex sidecar configuration and for the provider discovery API.
+type ConnectorConfig struct {
+	// ID is the unique identifier for this connector (e.g., "google", "github").
+	ID string `json:"id"`
+	// Type is the connector type (oidc, google, github, microsoft).
+	Type ConnectorType `json:"type"`
+	// Name is the human-readable display name (e.g., "Google", "GitHub").
+	Name string `json:"name"`
+	// ClientID is the OAuth2 client ID.
+	ClientID string `json:"clientId"`
+	// ClientSecret is the OAuth2 client secret.
+	ClientSecret string `json:"clientSecret"`
+	// IssuerURL is the OIDC issuer URL. Required for generic OIDC connectors.
+	IssuerURL string `json:"issuerUrl,omitempty"`
+	// RedirectURI is the OAuth2 callback URI registered with the provider.
+	RedirectURI string `json:"redirectUri,omitempty"`
+	// Scopes overrides the default OAuth2 scopes requested.
+	Scopes []string `json:"scopes,omitempty"`
+	// HostedDomain restricts login to a specific domain (Google-specific).
+	HostedDomain string `json:"hostedDomain,omitempty"`
+	// Tenant is the Azure AD tenant ID (Microsoft-specific).
+	Tenant string `json:"tenant,omitempty"`
+}
+
+// Validate checks that the connector configuration has all required fields
+// for its type.
+func (c *ConnectorConfig) Validate() error {
+	if c.ID == "" {
+		return ErrConnectorIDRequired
+	}
+	if c.Type == "" {
+		return ErrConnectorTypeRequired
+	}
+	if !isValidConnectorType(c.Type) {
+		return fmt.Errorf("%w: %s", ErrConnectorTypeInvalid, c.Type)
+	}
+	if c.ClientID == "" {
+		return ErrClientIDRequired
+	}
+	if c.ClientSecret == "" {
+		return ErrClientSecretRequired
+	}
+	if c.Type == ConnectorTypeOIDC && c.IssuerURL == "" {
+		return ErrIssuerURLRequired
+	}
+	return nil
+}
+
+func isValidConnectorType(t ConnectorType) bool {
+	switch t {
+	case ConnectorTypeOIDC, ConnectorTypeGoogle, ConnectorTypeGitHub, ConnectorTypeMicrosoft:
+		return true
+	default:
+		return false
+	}
+}
+
+// ValidateConnectors validates a slice of connector configurations,
+// checking each individually and ensuring no duplicate IDs.
+func ValidateConnectors(connectors []ConnectorConfig) error {
+	seen := make(map[string]struct{}, len(connectors))
+	for i := range connectors {
+		if err := connectors[i].Validate(); err != nil {
+			return fmt.Errorf("connector[%d] (%s): %w", i, connectors[i].ID, err)
+		}
+		if _, exists := seen[connectors[i].ID]; exists {
+			return fmt.Errorf("%w: %s", ErrDuplicateConnectorID, connectors[i].ID)
+		}
+		seen[connectors[i].ID] = struct{}{}
+	}
+	return nil
+}
+
+// LoadConnectorsFromEnv loads connector configurations from environment variables.
+// It supports two modes:
+//
+//  1. JSON mode: DEX_CONNECTORS contains a JSON array of connector configs.
+//  2. Individual mode: DEX_CONNECTOR_{TYPE}_{FIELD} environment variables
+//     (e.g., DEX_CONNECTOR_GOOGLE_CLIENT_ID, DEX_CONNECTOR_GITHUB_CLIENT_SECRET).
+//
+// JSON mode takes precedence. Returns nil (no error) when no connectors are configured.
+func LoadConnectorsFromEnv() ([]ConnectorConfig, error) {
+	// JSON mode
+	if raw := os.Getenv("DEX_CONNECTORS"); raw != "" {
+		var connectors []ConnectorConfig
+		if err := json.Unmarshal([]byte(raw), &connectors); err != nil {
+			return nil, fmt.Errorf("connector: failed to parse DEX_CONNECTORS: %w", err)
+		}
+		if err := ValidateConnectors(connectors); err != nil {
+			return nil, err
+		}
+		return connectors, nil
+	}
+
+	// Individual environment variable mode
+	connectors := loadConnectorsFromIndividualEnv()
+
+	if len(connectors) > 0 {
+		if err := ValidateConnectors(connectors); err != nil {
+			return nil, err
+		}
+	}
+
+	return connectors, nil
+}
+
+// envConnectorDef describes a well-known connector that can be configured
+// via individual environment variables.
+type envConnectorDef struct {
+	envPrefix string
+	id        string
+	connType  ConnectorType
+	name      string
+}
+
+// knownConnectorDefs lists the well-known connector types that can be
+// configured via individual environment variables.
+var knownConnectorDefs = []envConnectorDef{
+	{"DEX_CONNECTOR_GOOGLE", "google", ConnectorTypeGoogle, "Google"},
+	{"DEX_CONNECTOR_GITHUB", "github", ConnectorTypeGitHub, "GitHub"},
+	{"DEX_CONNECTOR_MICROSOFT", "microsoft", ConnectorTypeMicrosoft, "Microsoft"},
+}
+
+// loadConnectorsFromIndividualEnv scans for connectors configured via
+// DEX_CONNECTOR_{TYPE}_{FIELD} environment variables.
+func loadConnectorsFromIndividualEnv() []ConnectorConfig {
+	var connectors []ConnectorConfig
+
+	for _, kc := range knownConnectorDefs {
+		if cc, ok := loadSingleConnectorFromEnv(kc); ok {
+			connectors = append(connectors, cc)
+		}
+	}
+
+	return connectors
+}
+
+// loadSingleConnectorFromEnv attempts to load a single connector from
+// environment variables matching the given definition.
+func loadSingleConnectorFromEnv(def envConnectorDef) (ConnectorConfig, bool) {
+	clientID := os.Getenv(def.envPrefix + "_CLIENT_ID")
+	clientSecret := os.Getenv(def.envPrefix + "_CLIENT_SECRET")
+	if clientID == "" || clientSecret == "" {
+		return ConnectorConfig{}, false
+	}
+
+	cc := ConnectorConfig{
+		ID:           def.id,
+		Type:         def.connType,
+		Name:         def.name,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURI:  os.Getenv(def.envPrefix + "_REDIRECT_URI"),
+	}
+
+	if scopesRaw := os.Getenv(def.envPrefix + "_SCOPES"); scopesRaw != "" {
+		cc.Scopes = splitAndTrim(scopesRaw, ",")
+	}
+
+	if def.connType == ConnectorTypeGoogle {
+		cc.HostedDomain = os.Getenv(def.envPrefix + "_HOSTED_DOMAIN")
+	}
+	if def.connType == ConnectorTypeMicrosoft {
+		cc.Tenant = os.Getenv(def.envPrefix + "_TENANT")
+	}
+
+	return cc, true
+}
+
+// splitAndTrim splits a string by sep and trims whitespace from each element.
+func splitAndTrim(s, sep string) []string {
+	parts := strings.Split(s, sep)
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}

--- a/services/identity/oidc/connector_config_test.go
+++ b/services/identity/oidc/connector_config_test.go
@@ -1,0 +1,255 @@
+package oidc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectorConfig_Validate_Success(t *testing.T) {
+	tests := []struct {
+		name      string
+		connector ConnectorConfig
+	}{
+		{
+			name: "valid google connector",
+			connector: ConnectorConfig{
+				ID:           "google",
+				Type:         ConnectorTypeGoogle,
+				Name:         "Google",
+				ClientID:     "google-client-id",
+				ClientSecret: "google-client-secret",
+			},
+		},
+		{
+			name: "valid github connector",
+			connector: ConnectorConfig{
+				ID:           "github",
+				Type:         ConnectorTypeGitHub,
+				Name:         "GitHub",
+				ClientID:     "github-client-id",
+				ClientSecret: "github-client-secret",
+			},
+		},
+		{
+			name: "valid microsoft connector",
+			connector: ConnectorConfig{
+				ID:           "microsoft",
+				Type:         ConnectorTypeMicrosoft,
+				Name:         "Microsoft",
+				ClientID:     "ms-client-id",
+				ClientSecret: "ms-client-secret",
+				Tenant:       "my-tenant",
+			},
+		},
+		{
+			name: "valid generic oidc connector with issuer",
+			connector: ConnectorConfig{
+				ID:           "custom-idp",
+				Type:         ConnectorTypeOIDC,
+				Name:         "Custom IDP",
+				ClientID:     "custom-client-id",
+				ClientSecret: "custom-client-secret",
+				IssuerURL:    "https://idp.example.com",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.connector.Validate()
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestConnectorConfig_Validate_Errors(t *testing.T) {
+	tests := []struct {
+		name      string
+		connector ConnectorConfig
+		wantErr   error
+	}{
+		{
+			name:      "missing id",
+			connector: ConnectorConfig{Type: ConnectorTypeGoogle, ClientID: "x", ClientSecret: "y"},
+			wantErr:   ErrConnectorIDRequired,
+		},
+		{
+			name:      "missing type",
+			connector: ConnectorConfig{ID: "google", ClientID: "x", ClientSecret: "y"},
+			wantErr:   ErrConnectorTypeRequired,
+		},
+		{
+			name:      "invalid type",
+			connector: ConnectorConfig{ID: "x", Type: "invalid", ClientID: "x", ClientSecret: "y"},
+			wantErr:   ErrConnectorTypeInvalid,
+		},
+		{
+			name:      "missing client_id",
+			connector: ConnectorConfig{ID: "google", Type: ConnectorTypeGoogle, ClientSecret: "y"},
+			wantErr:   ErrClientIDRequired,
+		},
+		{
+			name:      "missing client_secret",
+			connector: ConnectorConfig{ID: "google", Type: ConnectorTypeGoogle, ClientID: "x"},
+			wantErr:   ErrClientSecretRequired,
+		},
+		{
+			name: "oidc type missing issuer_url",
+			connector: ConnectorConfig{
+				ID: "custom", Type: ConnectorTypeOIDC,
+				ClientID: "x", ClientSecret: "y",
+			},
+			wantErr: ErrIssuerURLRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.connector.Validate()
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestValidateConnectors_DuplicateID(t *testing.T) {
+	connectors := []ConnectorConfig{
+		{ID: "google", Type: ConnectorTypeGoogle, Name: "Google", ClientID: "a", ClientSecret: "b"},
+		{ID: "google", Type: ConnectorTypeGoogle, Name: "Google 2", ClientID: "c", ClientSecret: "d"},
+	}
+
+	err := ValidateConnectors(connectors)
+	require.ErrorIs(t, err, ErrDuplicateConnectorID)
+}
+
+func TestValidateConnectors_PropagatesValidationError(t *testing.T) {
+	connectors := []ConnectorConfig{
+		{ID: "google", Type: ConnectorTypeGoogle, Name: "Google", ClientID: "a", ClientSecret: "b"},
+		{ID: "bad", Type: ConnectorTypeOIDC, Name: "Bad", ClientID: "c", ClientSecret: "d"},
+		// Missing IssuerURL for OIDC type
+	}
+
+	err := ValidateConnectors(connectors)
+	require.ErrorIs(t, err, ErrIssuerURLRequired)
+	assert.Contains(t, err.Error(), "connector[1]")
+}
+
+func TestValidateConnectors_EmptySlice(t *testing.T) {
+	err := ValidateConnectors(nil)
+	require.NoError(t, err)
+}
+
+func TestLoadConnectorsFromEnv_JSONMode(t *testing.T) {
+	t.Setenv("DEX_CONNECTORS", `[
+		{"id":"google","type":"google","name":"Google","clientId":"gid","clientSecret":"gsecret"},
+		{"id":"github","type":"github","name":"GitHub","clientId":"ghid","clientSecret":"ghsecret"}
+	]`)
+
+	connectors, err := LoadConnectorsFromEnv()
+	require.NoError(t, err)
+	require.Len(t, connectors, 2)
+	assert.Equal(t, "google", connectors[0].ID)
+	assert.Equal(t, ConnectorTypeGoogle, connectors[0].Type)
+	assert.Equal(t, "github", connectors[1].ID)
+}
+
+func TestLoadConnectorsFromEnv_JSONMode_InvalidJSON(t *testing.T) {
+	t.Setenv("DEX_CONNECTORS", `{invalid`)
+
+	_, err := LoadConnectorsFromEnv()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse DEX_CONNECTORS")
+}
+
+func TestLoadConnectorsFromEnv_JSONMode_ValidationError(t *testing.T) {
+	t.Setenv("DEX_CONNECTORS", `[{"id":"","type":"google","clientId":"x","clientSecret":"y"}]`)
+
+	_, err := LoadConnectorsFromEnv()
+	require.ErrorIs(t, err, ErrConnectorIDRequired)
+}
+
+func TestLoadConnectorsFromEnv_IndividualMode_Google(t *testing.T) {
+	t.Setenv("DEX_CONNECTOR_GOOGLE_CLIENT_ID", "google-id")
+	t.Setenv("DEX_CONNECTOR_GOOGLE_CLIENT_SECRET", "google-secret")
+	t.Setenv("DEX_CONNECTOR_GOOGLE_HOSTED_DOMAIN", "example.com")
+	t.Setenv("DEX_CONNECTOR_GOOGLE_REDIRECT_URI", "https://dex.example.com/callback")
+	t.Setenv("DEX_CONNECTOR_GOOGLE_SCOPES", "openid, email, profile")
+
+	connectors, err := LoadConnectorsFromEnv()
+	require.NoError(t, err)
+	require.Len(t, connectors, 1)
+
+	c := connectors[0]
+	assert.Equal(t, "google", c.ID)
+	assert.Equal(t, ConnectorTypeGoogle, c.Type)
+	assert.Equal(t, "Google", c.Name)
+	assert.Equal(t, "google-id", c.ClientID)
+	assert.Equal(t, "google-secret", c.ClientSecret)
+	assert.Equal(t, "example.com", c.HostedDomain)
+	assert.Equal(t, "https://dex.example.com/callback", c.RedirectURI)
+	assert.Equal(t, []string{"openid", "email", "profile"}, c.Scopes)
+}
+
+func TestLoadConnectorsFromEnv_IndividualMode_GitHub(t *testing.T) {
+	t.Setenv("DEX_CONNECTOR_GITHUB_CLIENT_ID", "gh-id")
+	t.Setenv("DEX_CONNECTOR_GITHUB_CLIENT_SECRET", "gh-secret")
+
+	connectors, err := LoadConnectorsFromEnv()
+	require.NoError(t, err)
+	require.Len(t, connectors, 1)
+	assert.Equal(t, "github", connectors[0].ID)
+	assert.Equal(t, ConnectorTypeGitHub, connectors[0].Type)
+}
+
+func TestLoadConnectorsFromEnv_IndividualMode_Microsoft(t *testing.T) {
+	t.Setenv("DEX_CONNECTOR_MICROSOFT_CLIENT_ID", "ms-id")
+	t.Setenv("DEX_CONNECTOR_MICROSOFT_CLIENT_SECRET", "ms-secret")
+	t.Setenv("DEX_CONNECTOR_MICROSOFT_TENANT", "my-org-tenant")
+
+	connectors, err := LoadConnectorsFromEnv()
+	require.NoError(t, err)
+	require.Len(t, connectors, 1)
+	assert.Equal(t, "microsoft", connectors[0].ID)
+	assert.Equal(t, "my-org-tenant", connectors[0].Tenant)
+}
+
+func TestLoadConnectorsFromEnv_IndividualMode_MultipleProviders(t *testing.T) {
+	t.Setenv("DEX_CONNECTOR_GOOGLE_CLIENT_ID", "g-id")
+	t.Setenv("DEX_CONNECTOR_GOOGLE_CLIENT_SECRET", "g-secret")
+	t.Setenv("DEX_CONNECTOR_GITHUB_CLIENT_ID", "gh-id")
+	t.Setenv("DEX_CONNECTOR_GITHUB_CLIENT_SECRET", "gh-secret")
+
+	connectors, err := LoadConnectorsFromEnv()
+	require.NoError(t, err)
+	require.Len(t, connectors, 2)
+	assert.Equal(t, "google", connectors[0].ID)
+	assert.Equal(t, "github", connectors[1].ID)
+}
+
+func TestLoadConnectorsFromEnv_NoConnectors(t *testing.T) {
+	connectors, err := LoadConnectorsFromEnv()
+	require.NoError(t, err)
+	assert.Nil(t, connectors)
+}
+
+func TestLoadConnectorsFromEnv_PartialEnvVars_Skipped(t *testing.T) {
+	// Only client_id set, no secret - should be skipped
+	t.Setenv("DEX_CONNECTOR_GOOGLE_CLIENT_ID", "g-id")
+
+	connectors, err := LoadConnectorsFromEnv()
+	require.NoError(t, err)
+	assert.Nil(t, connectors)
+}
+
+func TestLoadConnectorsFromEnv_JSONTakesPrecedence(t *testing.T) {
+	t.Setenv("DEX_CONNECTORS", `[{"id":"google","type":"google","name":"From JSON","clientId":"j-id","clientSecret":"j-secret"}]`)
+	t.Setenv("DEX_CONNECTOR_GOOGLE_CLIENT_ID", "env-id")
+	t.Setenv("DEX_CONNECTOR_GOOGLE_CLIENT_SECRET", "env-secret")
+
+	connectors, err := LoadConnectorsFromEnv()
+	require.NoError(t, err)
+	require.Len(t, connectors, 1)
+	assert.Equal(t, "From JSON", connectors[0].Name)
+	assert.Equal(t, "j-id", connectors[0].ClientID)
+}


### PR DESCRIPTION
## Summary

- Add external OIDC connector configuration model in `services/identity/oidc/` supporting Google, GitHub, Microsoft, and generic OIDC providers (embedded-dex-identity.18)
- Add `GET /api/auth/providers` endpoint to the API gateway for frontend login button rendering (embedded-dex-identity.19)

## Changes

### Task 18: Connector Configuration (`services/identity/oidc/connector_config.go`)
- `ConnectorConfig` struct with validation for each provider type (OIDC requires issuer URL, all require client ID/secret)
- `LoadConnectorsFromEnv()` supports two modes: JSON via `DEX_CONNECTORS` env var, or individual `DEX_CONNECTOR_{TYPE}_{FIELD}` variables
- `ValidateConnectors()` checks individual configs and rejects duplicate IDs
- Connector types: `oidc`, `google`, `github`, `microsoft`

### Task 19: Provider Discovery API (`services/api-gateway/providers.go`)
- `GET /api/auth/providers` returns configured auth providers as JSON
- Public endpoint (no auth required) since frontend needs it before login
- `LoadProvidersConfig()` reads from `AUTH_PROVIDERS_ENABLED`, `AUTH_PROVIDERS` JSON, and `DEX_ISSUER`
- Auto-constructs `authUrl` for OIDC providers from `DEX_ISSUER` when not explicitly set
- Includes `Cache-Control: public, max-age=300` header
- Returns 405 for non-GET methods
- Falls back to default `meridian` password provider when no providers configured

## Test Plan

- [x] Connector config validation: all required fields, type-specific requirements (OIDC issuer), duplicate ID detection
- [x] Environment variable loading: JSON mode, individual mode, multiple providers, partial configs skipped, JSON precedence
- [x] Provider endpoint: returns correct JSON, omits empty authUrl, 405 for POST, disabled returns non-200
- [x] Config loading: disabled by default, defaults to password provider, JSON parsing, explicit authUrl preserved
- [x] All existing api-gateway tests still pass