### PR TITLE
fix: resolve CI failures on develop (lint, test, DDL)

### DIFF
--- a/frontend/src/components/routing.tsx
+++ b/frontend/src/components/routing.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/contexts/auth-context'
 import { useTenantContext } from '@/contexts/tenant-context'
@@ -79,33 +79,32 @@ export function TenantSubdomainEnforcer({ children }: { children: ReactNode }) {
   const { pathname, search, hash } = useLocation()
   const { tenantSlug } = useTenantContext()
 
-  // Skip in local dev — subdomains don't work on localhost
-  if (isLocalDev()) {
-    return <>{children}</>
-  }
+  // Compute redirect URL only when needed: not local dev, not already on
+  // subdomain, not a platform path, and a tenant is selected.
+  const needsRedirect =
+    !isLocalDev() && !isOnTenantSubdomain() && !isPlatformPath(pathname) && !!tenantSlug
 
-  // Already on a tenant subdomain — no redirect needed
-  if (isOnTenantSubdomain()) {
-    return <>{children}</>
-  }
+  const redirectUrl = needsRedirect
+    ? (() => {
+        const parsed = new URL(apiConfig.baseUrl)
+        const target = new URL(window.location.href)
+        target.hostname = `${tenantSlug}.${parsed.hostname}`
+        target.pathname = pathname
+        target.search = search
+        target.hash = hash
+        return target.toString()
+      })()
+    : null
 
-  // Platform routes stay on root domain
-  if (isPlatformPath(pathname)) {
-    return <>{children}</>
-  }
+  useEffect(() => {
+    if (redirectUrl) {
+      window.location.assign(redirectUrl)
+    }
+  }, [redirectUrl])
 
-  // Tenant-scoped route on root domain with a tenant selected → redirect
-  if (tenantSlug) {
-    const parsed = new URL(apiConfig.baseUrl)
-    const target = new URL(window.location.href)
-    target.hostname = `${tenantSlug}.${parsed.hostname}`
-    target.pathname = pathname
-    target.search = search
-    target.hash = hash
-    window.location.href = target.toString()
+  if (redirectUrl) {
     return null
   }
 
-  // No tenant selected — show content (DevTenantAutoSelector may still be loading)
   return <>{children}</>
 }

--- a/frontend/src/features/cookbook/pages/detail.test.tsx
+++ b/frontend/src/features/cookbook/pages/detail.test.tsx
@@ -38,7 +38,7 @@ vi.mock('../hooks/use-cookbook', () => ({
   useCookbook: () => mockUseCookbook(),
 }))
 
-const mockUsePatternFiles = vi.fn<() => { starlarkFiles: Array<{ name: string; content: string }>; manifestContent: string | null; hasSagas: boolean; isLoading: false }>()
+const mockUsePatternFiles = vi.fn<() => { starlarkFiles: Array<{ name: string; content: string }>; manifestContent: string | null; manifestSagas: Array<{ name: string; trigger?: string; filter?: string }>; hasSagas: boolean; isLoading: false }>()
 vi.mock('../hooks/use-pattern-files', () => ({
   usePatternFiles: () => mockUsePatternFiles(),
 }))
@@ -82,7 +82,7 @@ describe('CookbookDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockUseCookbook.mockReturnValue({ items: [patternItem, uiItem], isLoading: false })
-    mockUsePatternFiles.mockReturnValue({ starlarkFiles: [], manifestContent: null, hasSagas: false, isLoading: false as const })
+    mockUsePatternFiles.mockReturnValue({ starlarkFiles: [], manifestContent: null, manifestSagas: [], hasSagas: false, isLoading: false as const })
   })
 
   it('shows loading skeleton while catalogue is loading', () => {
@@ -141,6 +141,7 @@ describe('CookbookDetailPage', () => {
     mockUsePatternFiles.mockReturnValue({
       starlarkFiles: [{ name: 'saga.star', content: 'def execute(): pass' }],
       manifestContent: 'name: test',
+      manifestSagas: [],
       hasSagas: true,
       isLoading: false as const,
     })
@@ -177,6 +178,7 @@ describe('CookbookDetailPage', () => {
     mockUsePatternFiles.mockReturnValue({
       starlarkFiles: [],
       manifestContent: 'name: test\ntype: registry:pattern',
+      manifestSagas: [],
       hasSagas: false,
       isLoading: false as const,
     })

--- a/services/control-plane/internal/manifest/repository_test.go
+++ b/services/control-plane/internal/manifest/repository_test.go
@@ -22,6 +22,7 @@ const manifestVersionsDDL = `CREATE TABLE IF NOT EXISTS %s.manifest_versions (
 	apply_status VARCHAR(20) NOT NULL DEFAULT 'APPLIED',
 	apply_job_id UUID,
 	diff_summary TEXT,
+	relationship_graph JSONB,
 	created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 	CONSTRAINT valid_apply_status CHECK (apply_status IN ('APPLIED', 'FAILED', 'ROLLED_BACK'))
 )`


### PR DESCRIPTION
## Summary
- **Lint**: `routing.tsx` — React Compiler's `react-hooks/immutability` rule flagged `window.location.href = ...` assignment. Moved redirect into `useEffect` and removed early returns before hooks.
- **Frontend test**: `detail.test.tsx` — `usePatternFiles` mock was missing `manifestSagas` field, causing `undefined.find()` TypeError in `CookbookDetailPage`.
- **Nightly integration**: `repository_test.go` — Test DDL for `manifest_versions` was missing `relationship_graph JSONB` column added in migration `20260308000001`.

## Test plan
- [x] `detail.test.tsx` — all 13 tests pass locally
- [x] `routing.tsx` — eslint passes with no errors
- [x] Pre-commit hooks pass (gofumpt, golangci-lint, gitleaks)
- [ ] CI passes on this branch