### PR TITLE
fix: use relative URL for /version endpoint

### DIFF
--- a/frontend/src/components/layout/build-info.tsx
+++ b/frontend/src/components/layout/build-info.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import { apiConfig } from '@/api/config'
 
 interface VersionInfo {
   version: string
@@ -11,7 +10,7 @@ export function BuildInfo() {
   const [info, setInfo] = useState<VersionInfo | null>(null)
 
   useEffect(() => {
-    fetch(`${apiConfig.baseUrl}/version`)
+    fetch('/version')
       .then((res) => (res.ok ? res.json() : Promise.reject(res)))
       .then((data: VersionInfo) => setInfo(data))
       .catch(() => {


### PR DESCRIPTION
## Summary

- Fix BuildInfo component to use relative `/version` URL instead of constructing from `apiConfig.baseUrl`
- The previous approach always resolved to the API subdomain regardless of which subdomain the browser was on
- Using a relative URL ensures the request goes to the current origin, where Caddy proxies it to the backend

## Changes

- `frontend/src/components/layout/build-info.tsx`: Replace `fetch(\`${apiConfig.baseUrl}/version\`)` with `fetch('/version')` and remove unused `apiConfig` import

## Test plan

- [x] TypeScript type check passes
- [x] ESLint passes (no new warnings)
- [x] Existing layout tests pass (sidebar, header, app-shell)
- [ ] Manual verification: `/version` returns build info on demo subdomain