### PR TITLE
feat: Proto-referenced slim schema format for handler definitions

### DIFF
--- a/shared/pkg/saga/schema/handlers.yaml
+++ b/shared/pkg/saga/schema/handlers.yaml
@@ -1,0 +1,278 @@
+# Slim Handler Schema - Proto-Referenced Format
+#
+# This file defines saga handler schemas using proto RPC references.
+# Type information (params/returns) is resolved from proto reflection at load time,
+# eliminating duplication between YAML and proto definitions.
+#
+# Format:
+#   handler_name:
+#     proto_ref:
+#       proto_rpc: "package.Service/Method"
+#       exposed_params: [field paths exposed to Starlark]
+#       exposed_returns: [field paths exposed to Starlark]
+#       param_aliases: {proto_field: starlark_name}
+#     description: "Handler purpose"
+#     compensate: "compensation_handler_name"        # or
+#     compensation_strategy: none|saga_managed       # if no compensate
+#
+# Legacy handlers without proto_ref use inline params/returns definitions.
+# Both formats are supported and can coexist in the same schema.
+
+service: meridian
+version: "2.0"
+
+handlers:
+
+  # ---------------------------------------------------------------------------
+  # Position Keeping
+  # ---------------------------------------------------------------------------
+  position_keeping.initiate_log:
+    description: "Initiate a position log entry for a DEBIT or CREDIT transaction"
+    compensate: position_keeping.cancel_log
+    proto_ref:
+      proto_rpc: "meridian.position_keeping.v1.PositionKeepingService/InitiateFinancialPositionLog"
+      exposed_params:
+        - account_id
+      param_aliases:
+        account_id: position_id
+
+  position_keeping.update_log:
+    description: "Update an existing position log entry"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.position_keeping.v1.PositionKeepingService/UpdateFinancialPositionLog"
+      exposed_params:
+        - log_id
+
+  position_keeping.cancel_log:
+    description: "Cancel a position log entry (compensation handler)"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.position_keeping.v1.PositionKeepingService/UpdateFinancialPositionLog"
+      exposed_params:
+        - log_id
+
+  # ---------------------------------------------------------------------------
+  # Current Account
+  # ---------------------------------------------------------------------------
+  current_account.create_lien:
+    description: "Create a lien (hold) on an account for a specified amount"
+    compensate: current_account.terminate_lien
+    proto_ref:
+      proto_rpc: "meridian.current_account.v1.CurrentAccountService/InitiateLien"
+
+  current_account.execute_lien:
+    description: "Execute (consume) a previously created lien"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.current_account.v1.CurrentAccountService/ExecuteLien"
+
+  current_account.terminate_lien:
+    description: "Terminate (release) a lien without execution (compensation handler)"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.current_account.v1.CurrentAccountService/TerminateLien"
+
+  current_account.save:
+    description: "Persist current account metadata for a transaction"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.current_account.v1.CurrentAccountService/UpdateCurrentAccount"
+
+  current_account.control:
+    description: "Perform lifecycle control action on an account (FREEZE, UNFREEZE, CLOSE)"
+    compensation_strategy: saga_managed
+    proto_ref:
+      proto_rpc: "meridian.current_account.v1.CurrentAccountService/ControlCurrentAccount"
+
+  # ---------------------------------------------------------------------------
+  # Financial Accounting
+  # ---------------------------------------------------------------------------
+  financial_accounting.initiate_booking_log:
+    description: "Initiate a booking log for a deposit or withdrawal transaction"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.financial_accounting.v1.FinancialAccountingService/InitiateFinancialBookingLog"
+
+  financial_accounting.update_booking_log:
+    description: "Update the status of an existing booking log"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.financial_accounting.v1.FinancialAccountingService/UpdateFinancialBookingLog"
+
+  financial_accounting.capture_posting:
+    description: "Capture a single-sided posting entry within a booking log"
+    compensate: financial_accounting.compensate_posting
+    proto_ref:
+      proto_rpc: "meridian.financial_accounting.v1.FinancialAccountingService/CaptureLedgerPosting"
+
+  financial_accounting.compensate_posting:
+    description: "Compensate (reverse) a captured posting entry"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.financial_accounting.v1.FinancialAccountingService/UpdateLedgerPosting"
+
+  financial_accounting.create_booking:
+    description: "Create a booking log entry for audit purposes"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.financial_accounting.v1.FinancialAccountingService/InitiateFinancialBookingLog"
+
+  # post_entries is a composite handler (iterates over entries calling CaptureLedgerPosting).
+  # No single proto type; uses legacy inline format.
+  financial_accounting.post_entries:
+    description: "Post double-entry accounting entries to the ledger"
+    compensate: financial_accounting.reverse_entries
+    params: {}
+
+  financial_accounting.reverse_entries:
+    description: "Reverse previously posted accounting entries (compensation handler)"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.financial_accounting.v1.FinancialAccountingService/UpdateFinancialBookingLog"
+
+  # ---------------------------------------------------------------------------
+  # Financial Gateway
+  # ---------------------------------------------------------------------------
+  financial_gateway.dispatch_payment:
+    description: "Dispatch a payment to an external provider via the Financial Gateway"
+    compensate: financial_gateway.cancel_payment
+    external: true
+    proto_ref:
+      proto_rpc: "meridian.financial_gateway.v1.FinancialGatewayService/DispatchPayment"
+
+  financial_gateway.cancel_payment:
+    description: "Cancel a pending payment dispatch (compensation handler)"
+    compensation_strategy: none
+    external: true
+    proto_ref:
+      proto_rpc: "meridian.financial_gateway.v1.FinancialGatewayService/CancelPayment"
+
+  financial_gateway.dispatch_refund:
+    description: "Dispatch a refund for a previously processed payment"
+    compensation_strategy: none
+    external: true
+    proto_ref:
+      proto_rpc: "meridian.financial_gateway.v1.FinancialGatewayService/DispatchRefund"
+
+  # ---------------------------------------------------------------------------
+  # Operational Gateway
+  # ---------------------------------------------------------------------------
+  operational_gateway.dispatch_instruction:
+    description: "Queue an instruction for dispatch to an external provider"
+    compensate: operational_gateway.cancel_instruction
+    external: true
+    proto_ref:
+      proto_rpc: "meridian.operational_gateway.v1.OperationalGatewayService/DispatchInstruction"
+
+  operational_gateway.cancel_instruction:
+    description: "Cancel a pending instruction before dispatch (compensation handler)"
+    compensation_strategy: none
+    external: true
+    proto_ref:
+      proto_rpc: "meridian.operational_gateway.v1.OperationalGatewayService/CancelInstruction"
+
+  operational_gateway.get_instruction:
+    description: "Get instruction status and details by ID"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.operational_gateway.v1.OperationalGatewayService/GetInstruction"
+
+  # ---------------------------------------------------------------------------
+  # Reconciliation
+  # ---------------------------------------------------------------------------
+  reconciliation.initiate_run:
+    description: "Initiate a new settlement reconciliation run"
+    compensate: reconciliation.cancel_run
+    proto_ref:
+      proto_rpc: "meridian.reconciliation.v1.AccountReconciliationService/InitiateAccountReconciliation"
+
+  reconciliation.execute_run:
+    description: "Trigger execution of a pending settlement run"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.reconciliation.v1.AccountReconciliationService/ExecuteAccountReconciliation"
+
+  reconciliation.retrieve_run:
+    description: "Retrieve a settlement run summary"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.reconciliation.v1.AccountReconciliationService/RetrieveAccountReconciliation"
+
+  reconciliation.cancel_run:
+    description: "Cancel a settlement run (compensation handler)"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.reconciliation.v1.AccountReconciliationService/ControlAccountReconciliation"
+
+  reconciliation.assert_balance:
+    description: "Evaluate a balance assertion against current positions"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.reconciliation.v1.AccountReconciliationService/AssertBalance"
+
+  reconciliation.initiate_dispute:
+    description: "Raise a formal dispute against a detected variance"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.reconciliation.v1.AccountReconciliationService/InitiateDispute"
+
+  # ---------------------------------------------------------------------------
+  # Party
+  # ---------------------------------------------------------------------------
+  party.get_default_payment_method:
+    description: "Retrieve the default payment method for a party"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.party.v1.PartyService/GetDefaultPaymentMethod"
+
+  party.list_participants:
+    description: "List active participants for a syndicate organization"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.party.v1.PartyService/ListParticipants"
+
+  party.get_structuring_data:
+    description: "Retrieve structuring metadata for a participant in a syndicate"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.party.v1.PartyService/GetStructuringData"
+
+  # ---------------------------------------------------------------------------
+  # Internal Account
+  # ---------------------------------------------------------------------------
+  internal_account.initiate:
+    description: "Initiate a new internal account"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.internal_account.v1.InternalAccountService/InitiateInternalAccount"
+
+  internal_account.retrieve:
+    description: "Retrieve an internal account by ID"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.internal_account.v1.InternalAccountService/RetrieveInternalAccount"
+
+  internal_account.get_balance:
+    description: "Query the current balance for an internal account"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.internal_account.v1.InternalAccountService/GetBalance"
+
+  # ---------------------------------------------------------------------------
+  # Market Information
+  # ---------------------------------------------------------------------------
+  market_information.get_rate:
+    description: "Fetch FX rates for currency pair conversion"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.market_information.v1.MarketInformationService/ListObservations"
+
+  # ---------------------------------------------------------------------------
+  # Reference Data
+  # ---------------------------------------------------------------------------
+  reference_data.retrieve_instrument:
+    description: "Retrieve an instrument definition by code and version"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.reference_data.v1.ReferenceDataService/RetrieveInstrument"

--- a/shared/pkg/saga/schema/handlers_yaml_test.go
+++ b/shared/pkg/saga/schema/handlers_yaml_test.go
@@ -1,0 +1,259 @@
+package schema
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	// Import all service protos to register them in the global registry
+	_ "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	_ "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
+	_ "github.com/meridianhub/meridian/api/proto/meridian/financial_gateway/v1"
+	_ "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
+	_ "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	_ "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	_ "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	_ "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	_ "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	_ "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+)
+
+// testdataDir returns the directory containing this test file (same as handlers.yaml).
+func testdataDir() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Dir(filename)
+}
+
+func TestLoadHandlersYAML(t *testing.T) {
+	yamlPath := filepath.Join(testdataDir(), "handlers.yaml")
+	data, err := os.ReadFile(yamlPath)
+	require.NoError(t, err, "handlers.yaml should exist")
+
+	schema, err := Parse(data)
+	require.NoError(t, err, "handlers.yaml should parse without errors")
+
+	assert.Equal(t, "meridian", schema.Service)
+	assert.Equal(t, "2.0", schema.Version)
+	assert.GreaterOrEqual(t, len(schema.Handlers), 35, "should have at least 35 handlers")
+}
+
+func TestHandlersYAML_ProtoResolution(t *testing.T) {
+	yamlPath := filepath.Join(testdataDir(), "handlers.yaml")
+	data, err := os.ReadFile(yamlPath)
+	require.NoError(t, err)
+
+	schema, err := Parse(data)
+	require.NoError(t, err)
+
+	err = schema.ResolveProtoTypes(protoregistry.GlobalFiles)
+	require.NoError(t, err, "proto resolution should succeed for all handlers")
+
+	// Verify proto-referenced handlers have populated params
+	protoRefHandlers := 0
+	legacyHandlers := 0
+
+	for name, handler := range schema.Handlers {
+		if handler.HasProtoRef() {
+			protoRefHandlers++
+			// Proto-referenced handlers should have resolved params
+			assert.NotNil(t, handler.Params,
+				"handler %s: params should be resolved from proto", name)
+			assert.NotNil(t, handler.Returns,
+				"handler %s: returns should be resolved from proto", name)
+		} else {
+			legacyHandlers++
+		}
+	}
+
+	t.Logf("Proto-referenced: %d, Legacy: %d, Total: %d",
+		protoRefHandlers, legacyHandlers, protoRefHandlers+legacyHandlers)
+
+	assert.GreaterOrEqual(t, protoRefHandlers, 34,
+		"at least 34 handlers should use proto-referenced format")
+}
+
+func TestHandlersYAML_AllExpectedHandlersPresent(t *testing.T) {
+	yamlPath := filepath.Join(testdataDir(), "handlers.yaml")
+	data, err := os.ReadFile(yamlPath)
+	require.NoError(t, err)
+
+	schema, err := Parse(data)
+	require.NoError(t, err)
+
+	err = schema.ResolveProtoTypes(protoregistry.GlobalFiles)
+	require.NoError(t, err)
+
+	expectedHandlers := []string{
+		"position_keeping.initiate_log",
+		"position_keeping.update_log",
+		"position_keeping.cancel_log",
+		"current_account.create_lien",
+		"current_account.execute_lien",
+		"current_account.terminate_lien",
+		"current_account.save",
+		"current_account.control",
+		"financial_accounting.initiate_booking_log",
+		"financial_accounting.update_booking_log",
+		"financial_accounting.capture_posting",
+		"financial_accounting.compensate_posting",
+		"financial_accounting.create_booking",
+		"financial_accounting.post_entries",
+		"financial_accounting.reverse_entries",
+		"financial_gateway.dispatch_payment",
+		"financial_gateway.cancel_payment",
+		"financial_gateway.dispatch_refund",
+		"operational_gateway.dispatch_instruction",
+		"operational_gateway.cancel_instruction",
+		"operational_gateway.get_instruction",
+		"reconciliation.initiate_run",
+		"reconciliation.execute_run",
+		"reconciliation.retrieve_run",
+		"reconciliation.cancel_run",
+		"reconciliation.assert_balance",
+		"reconciliation.initiate_dispute",
+		"party.get_default_payment_method",
+		"party.list_participants",
+		"party.get_structuring_data",
+		"internal_account.initiate",
+		"internal_account.retrieve",
+		"internal_account.get_balance",
+		"market_information.get_rate",
+		"reference_data.retrieve_instrument",
+	}
+
+	for _, name := range expectedHandlers {
+		handler, exists := schema.Handlers[name]
+		assert.True(t, exists, "handler %q should be in handlers.yaml", name)
+		if exists {
+			assert.NotEmpty(t, handler.Description,
+				"handler %q should have a description", name)
+		}
+	}
+}
+
+func TestHandlersYAML_CompensationCoverage(t *testing.T) {
+	yamlPath := filepath.Join(testdataDir(), "handlers.yaml")
+	data, err := os.ReadFile(yamlPath)
+	require.NoError(t, err)
+
+	schema, err := Parse(data)
+	require.NoError(t, err)
+
+	for name, handler := range schema.Handlers {
+		t.Run(name, func(t *testing.T) {
+			hasCompensate := handler.Compensate != ""
+			hasStrategy := handler.CompensationStrategy != ""
+
+			assert.True(t, hasCompensate || hasStrategy,
+				"handler %q must declare either 'compensate' or 'compensation_strategy'", name)
+
+			// If compensate is set, verify the target handler exists
+			if hasCompensate {
+				_, targetExists := schema.Handlers[handler.Compensate]
+				assert.True(t, targetExists,
+					"handler %q references compensate handler %q which is not in the schema",
+					name, handler.Compensate)
+			}
+		})
+	}
+}
+
+func TestHandlersYAML_PositionKeepingAlias(t *testing.T) {
+	yamlPath := filepath.Join(testdataDir(), "handlers.yaml")
+	data, err := os.ReadFile(yamlPath)
+	require.NoError(t, err)
+
+	schema, err := Parse(data)
+	require.NoError(t, err)
+
+	err = schema.ResolveProtoTypes(protoregistry.GlobalFiles)
+	require.NoError(t, err)
+
+	handler := schema.Handlers["position_keeping.initiate_log"]
+	require.NotNil(t, handler)
+
+	// account_id should be aliased to position_id
+	_, hasAccountID := handler.Params["account_id"]
+	assert.False(t, hasAccountID, "account_id should be aliased away")
+
+	_, hasPositionID := handler.Params["position_id"]
+	assert.True(t, hasPositionID, "position_id alias should be present")
+}
+
+func TestHandlersYAML_ExternalHandlers(t *testing.T) {
+	yamlPath := filepath.Join(testdataDir(), "handlers.yaml")
+	data, err := os.ReadFile(yamlPath)
+	require.NoError(t, err)
+
+	schema, err := Parse(data)
+	require.NoError(t, err)
+
+	expectedExternal := []string{
+		"financial_gateway.dispatch_payment",
+		"financial_gateway.cancel_payment",
+		"financial_gateway.dispatch_refund",
+		"operational_gateway.dispatch_instruction",
+		"operational_gateway.cancel_instruction",
+	}
+
+	for _, name := range expectedExternal {
+		handler := schema.Handlers[name]
+		require.NotNil(t, handler, "handler %s should exist", name)
+		assert.True(t, handler.External,
+			"handler %s should be marked as external", name)
+	}
+
+	// Verify internal handlers are NOT external
+	internalHandlers := []string{
+		"position_keeping.initiate_log",
+		"financial_accounting.capture_posting",
+		"reconciliation.initiate_run",
+	}
+
+	for _, name := range internalHandlers {
+		handler := schema.Handlers[name]
+		require.NotNil(t, handler, "handler %s should exist", name)
+		assert.False(t, handler.External,
+			"handler %s should NOT be marked as external", name)
+	}
+}
+
+func TestHandlersYAML_LegacyPostEntries(t *testing.T) {
+	yamlPath := filepath.Join(testdataDir(), "handlers.yaml")
+	data, err := os.ReadFile(yamlPath)
+	require.NoError(t, err)
+
+	schema, err := Parse(data)
+	require.NoError(t, err)
+
+	// post_entries is a legacy handler (no proto_ref)
+	handler := schema.Handlers["financial_accounting.post_entries"]
+	require.NotNil(t, handler)
+	assert.Nil(t, handler.ProtoRef, "post_entries should not have proto_ref")
+	assert.Equal(t, "financial_accounting.reverse_entries", handler.Compensate)
+}
+
+func TestHandlersYAML_SizeReduction(t *testing.T) {
+	yamlPath := filepath.Join(testdataDir(), "handlers.yaml")
+	data, err := os.ReadFile(yamlPath)
+	require.NoError(t, err)
+
+	// The slim format should be significantly smaller than a verbose format
+	// with full inline param/return definitions. Target: under 500 lines.
+	lineCount := 1
+	for _, b := range data {
+		if b == '\n' {
+			lineCount++
+		}
+	}
+	t.Logf("handlers.yaml: %d lines, %d bytes", lineCount, len(data))
+
+	// Verify under 500 lines (was targeting ~400 in task description)
+	assert.LessOrEqual(t, lineCount, 500,
+		"slim handlers.yaml should be under 500 lines")
+}

--- a/shared/pkg/saga/schema/proto_resolve_test.go
+++ b/shared/pkg/saga/schema/proto_resolve_test.go
@@ -1,0 +1,308 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	// Import to register proto descriptors in global registry
+	_ "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	_ "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+)
+
+func TestResolveProtoTypes_PositionKeeping(t *testing.T) {
+	s := &Schema{
+		Service: "test",
+		Version: "1.0",
+		Handlers: map[string]*HandlerDef{
+			"position_keeping.initiate_log": {
+				Description:          "Initiate a position log entry",
+				CompensationStrategy: CompensationStrategyNone,
+				ProtoRef: &ProtoReference{
+					FullMethod: "meridian.position_keeping.v1.PositionKeepingService/InitiateFinancialPositionLog",
+					ExposedParams: []string{
+						"account_id",
+					},
+					ExposedReturns: []string{
+						"log",
+					},
+					ParamAliases: map[string]string{
+						"account_id": "position_id",
+					},
+				},
+			},
+		},
+	}
+
+	err := s.ResolveProtoTypes(protoregistry.GlobalFiles)
+	require.NoError(t, err)
+
+	handler := s.Handlers["position_keeping.initiate_log"]
+
+	// Verify params were resolved
+	require.NotEmpty(t, handler.Params, "params should be populated from proto")
+
+	// account_id should be aliased to position_id
+	_, hasAccountID := handler.Params["account_id"]
+	assert.False(t, hasAccountID, "account_id should be aliased away")
+
+	positionID, hasPositionID := handler.Params["position_id"]
+	assert.True(t, hasPositionID, "position_id alias should exist")
+	assert.Equal(t, TypeString, positionID.Type)
+
+	// Returns should have "log" field (nested message -> TypeMap)
+	require.NotEmpty(t, handler.Returns, "returns should be populated from proto")
+	logField, hasLog := handler.Returns["log"]
+	assert.True(t, hasLog, "log return field should exist")
+	assert.Equal(t, TypeMap, logField.Type) // Nested message maps to TypeMap
+}
+
+func TestResolveProtoTypes_AllFields(t *testing.T) {
+	// When ExposedParams is empty, all top-level fields should be included
+	s := &Schema{
+		Service: "test",
+		Version: "1.0",
+		Handlers: map[string]*HandlerDef{
+			"position_keeping.initiate_log_all": {
+				Description:          "All fields exposed",
+				CompensationStrategy: CompensationStrategyNone,
+				ProtoRef: &ProtoReference{
+					FullMethod: "meridian.position_keeping.v1.PositionKeepingService/InitiateFinancialPositionLog",
+				},
+			},
+		},
+	}
+
+	err := s.ResolveProtoTypes(protoregistry.GlobalFiles)
+	require.NoError(t, err)
+
+	handler := s.Handlers["position_keeping.initiate_log_all"]
+	require.NotEmpty(t, handler.Params, "all top-level params should be included")
+
+	// account_id is a known field on InitiateFinancialPositionLogRequest
+	_, hasAccountID := handler.Params["account_id"]
+	assert.True(t, hasAccountID, "account_id should be present when all fields exposed")
+}
+
+func TestResolveProtoTypes_ServiceNotFound(t *testing.T) {
+	s := &Schema{
+		Service: "test",
+		Version: "1.0",
+		Handlers: map[string]*HandlerDef{
+			"test.handler": {
+				Description:          "Test",
+				CompensationStrategy: CompensationStrategyNone,
+				ProtoRef: &ProtoReference{
+					FullMethod: "nonexistent.v1.FakeService/FakeMethod",
+				},
+			},
+		},
+	}
+
+	err := s.ResolveProtoTypes(protoregistry.GlobalFiles)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProtoServiceNotFound)
+}
+
+func TestResolveProtoTypes_MethodNotFound(t *testing.T) {
+	s := &Schema{
+		Service: "test",
+		Version: "1.0",
+		Handlers: map[string]*HandlerDef{
+			"test.handler": {
+				Description:          "Test",
+				CompensationStrategy: CompensationStrategyNone,
+				ProtoRef: &ProtoReference{
+					FullMethod: "meridian.position_keeping.v1.PositionKeepingService/NonexistentMethod",
+				},
+			},
+		},
+	}
+
+	err := s.ResolveProtoTypes(protoregistry.GlobalFiles)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProtoMethodNotFound)
+}
+
+func TestResolveProtoTypes_LegacyHandlersUntouched(t *testing.T) {
+	s := &Schema{
+		Service: "test",
+		Version: "1.0",
+		Handlers: map[string]*HandlerDef{
+			"test.legacy_handler": {
+				Description:          "Legacy handler with inline params",
+				CompensationStrategy: CompensationStrategyNone,
+				Params: map[string]*FieldDef{
+					"id": {Type: TypeString, Required: true},
+				},
+				Returns: map[string]*FieldDef{
+					"status": {Type: TypeString},
+				},
+			},
+		},
+	}
+
+	err := s.ResolveProtoTypes(protoregistry.GlobalFiles)
+	require.NoError(t, err)
+
+	handler := s.Handlers["test.legacy_handler"]
+	assert.Len(t, handler.Params, 1)
+	assert.Equal(t, TypeString, handler.Params["id"].Type)
+	assert.Len(t, handler.Returns, 1)
+}
+
+func TestResolveProtoTypes_MixedFormat(t *testing.T) {
+	// Schema with both legacy and proto-referenced handlers
+	s := &Schema{
+		Service: "test",
+		Version: "1.0",
+		Handlers: map[string]*HandlerDef{
+			"test.legacy": {
+				Description:          "Legacy inline handler",
+				CompensationStrategy: CompensationStrategyNone,
+				Params: map[string]*FieldDef{
+					"name": {Type: TypeString, Required: true},
+				},
+			},
+			"position_keeping.proto_ref": {
+				Description:          "Proto-referenced handler",
+				CompensationStrategy: CompensationStrategyNone,
+				ProtoRef: &ProtoReference{
+					FullMethod:    "meridian.position_keeping.v1.PositionKeepingService/InitiateFinancialPositionLog",
+					ExposedParams: []string{"account_id"},
+				},
+			},
+		},
+	}
+
+	err := s.ResolveProtoTypes(protoregistry.GlobalFiles)
+	require.NoError(t, err)
+
+	// Legacy handler unchanged
+	legacy := s.Handlers["test.legacy"]
+	assert.Len(t, legacy.Params, 1)
+	assert.Equal(t, TypeString, legacy.Params["name"].Type)
+
+	// Proto-referenced handler resolved
+	protoRef := s.Handlers["position_keeping.proto_ref"]
+	require.NotEmpty(t, protoRef.Params)
+	_, hasAccountID := protoRef.Params["account_id"]
+	assert.True(t, hasAccountID)
+}
+
+func TestParseProtoReferencedHandler(t *testing.T) {
+	yaml := `
+service: test
+version: "1.0"
+handlers:
+  position_keeping.initiate_log:
+    description: "Initiate a position log entry"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.position_keeping.v1.PositionKeepingService/InitiateFinancialPositionLog"
+      exposed_params:
+        - account_id
+      exposed_returns:
+        - log
+      param_aliases:
+        account_id: position_id
+`
+	schema, err := Parse([]byte(yaml))
+	require.NoError(t, err)
+
+	handler := schema.Handlers["position_keeping.initiate_log"]
+	require.NotNil(t, handler.ProtoRef)
+	assert.Equal(t,
+		"meridian.position_keeping.v1.PositionKeepingService/InitiateFinancialPositionLog",
+		handler.ProtoRef.FullMethod)
+	assert.Equal(t, []string{"account_id"}, handler.ProtoRef.ExposedParams)
+	assert.Equal(t, []string{"log"}, handler.ProtoRef.ExposedReturns)
+	assert.Equal(t, map[string]string{"account_id": "position_id"}, handler.ProtoRef.ParamAliases)
+
+	// Params should be empty until ResolveProtoTypes is called
+	assert.Empty(t, handler.Params)
+}
+
+func TestProtoRefValidation_EmptyRPC(t *testing.T) {
+	yaml := `
+service: test
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: ""
+`
+	_, err := Parse([]byte(yaml))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidProtoRPC)
+}
+
+func TestProtoRefValidation_MissingSlash(t *testing.T) {
+	yaml := `
+service: test
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test"
+    compensation_strategy: none
+    proto_ref:
+      proto_rpc: "meridian.v1.Service.Method"
+`
+	_, err := Parse([]byte(yaml))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidProtoRPC)
+}
+
+func TestResolveFieldPath(t *testing.T) {
+	// Find the InitiateFinancialPositionLog method's request message
+	serviceDesc, err := findServiceDescriptor(protoregistry.GlobalFiles,
+		"meridian.position_keeping.v1.PositionKeepingService")
+	require.NoError(t, err)
+
+	method := serviceDesc.Methods().ByName(protoreflect.Name("InitiateFinancialPositionLog"))
+	require.NotNil(t, method)
+
+	reqMsg := method.Input()
+
+	// Test simple field path
+	fd := resolveFieldPath(reqMsg, "account_id")
+	require.NotNil(t, fd, "account_id should exist in request message")
+	assert.Equal(t, "account_id", string(fd.Name()))
+
+	// Test invalid field path
+	fd = resolveFieldPath(reqMsg, "nonexistent_field")
+	assert.Nil(t, fd, "nonexistent field should return nil")
+}
+
+func TestLeafFieldName(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{"account_id", "account_id"},
+		{"log.log_id", "log_id"},
+		{"log.status_tracking.current_status", "current_status"},
+		{"", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			assert.Equal(t, tc.expected, leafFieldName(tc.path))
+		})
+	}
+}
+
+func TestHasProtoRef(t *testing.T) {
+	withRef := &HandlerDef{
+		ProtoRef: &ProtoReference{FullMethod: "pkg.Svc/Method"},
+	}
+	assert.True(t, withRef.HasProtoRef())
+
+	withoutRef := &HandlerDef{}
+	assert.False(t, withoutRef.HasProtoRef())
+}

--- a/shared/pkg/saga/schema/proto_resolve_test.go
+++ b/shared/pkg/saga/schema/proto_resolve_test.go
@@ -297,6 +297,48 @@ func TestLeafFieldName(t *testing.T) {
 	}
 }
 
+func TestResolveProtoTypes_InvalidExposedParam(t *testing.T) {
+	s := &Schema{
+		Service: "test",
+		Version: "1.0",
+		Handlers: map[string]*HandlerDef{
+			"test.bad_field": {
+				Description:          "Handler with invalid exposed param",
+				CompensationStrategy: CompensationStrategyNone,
+				ProtoRef: &ProtoReference{
+					FullMethod:    "meridian.position_keeping.v1.PositionKeepingService/InitiateFinancialPositionLog",
+					ExposedParams: []string{"nonexistent_field"},
+				},
+			},
+		},
+	}
+
+	err := s.ResolveProtoTypes(protoregistry.GlobalFiles)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProtoFieldPathNotFound)
+}
+
+func TestResolveProtoTypes_InvalidExposedReturn(t *testing.T) {
+	s := &Schema{
+		Service: "test",
+		Version: "1.0",
+		Handlers: map[string]*HandlerDef{
+			"test.bad_return": {
+				Description:          "Handler with invalid exposed return",
+				CompensationStrategy: CompensationStrategyNone,
+				ProtoRef: &ProtoReference{
+					FullMethod:     "meridian.position_keeping.v1.PositionKeepingService/InitiateFinancialPositionLog",
+					ExposedReturns: []string{"nonexistent_return_field"},
+				},
+			},
+		},
+	}
+
+	err := s.ResolveProtoTypes(protoregistry.GlobalFiles)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProtoFieldPathNotFound)
+}
+
 func TestHasProtoRef(t *testing.T) {
 	withRef := &HandlerDef{
 		ProtoRef: &ProtoReference{FullMethod: "pkg.Svc/Method"},

--- a/shared/pkg/saga/schema/proto_resolve_test.go
+++ b/shared/pkg/saga/schema/proto_resolve_test.go
@@ -339,6 +339,54 @@ func TestResolveProtoTypes_InvalidExposedReturn(t *testing.T) {
 	assert.ErrorIs(t, err, ErrProtoFieldPathNotFound)
 }
 
+func TestResolveProtoTypes_UnknownAliasSource(t *testing.T) {
+	s := &Schema{
+		Service: "test",
+		Version: "1.0",
+		Handlers: map[string]*HandlerDef{
+			"test.bad_alias": {
+				Description:          "Handler with unknown alias source",
+				CompensationStrategy: CompensationStrategyNone,
+				ProtoRef: &ProtoReference{
+					FullMethod:    "meridian.position_keeping.v1.PositionKeepingService/InitiateFinancialPositionLog",
+					ExposedParams: []string{"account_id"},
+					ParamAliases:  map[string]string{"typo_field": "position_id"},
+				},
+			},
+		},
+	}
+
+	err := s.ResolveProtoTypes(protoregistry.GlobalFiles)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownAliasSource)
+}
+
+func TestResolveProtoTypes_AliasCollision(t *testing.T) {
+	s := &Schema{
+		Service: "test",
+		Version: "1.0",
+		Handlers: map[string]*HandlerDef{
+			"test.collision": {
+				Description:          "Handler with alias collision",
+				CompensationStrategy: CompensationStrategyNone,
+				ProtoRef: &ProtoReference{
+					FullMethod: "meridian.position_keeping.v1.PositionKeepingService/InitiateFinancialPositionLog",
+					// Both fields are present, then alias one to the other's name
+					ParamAliases: map[string]string{"account_id": "log_id"},
+				},
+			},
+		},
+	}
+
+	err := s.ResolveProtoTypes(protoregistry.GlobalFiles)
+	// This should fail because log_id already exists in the request message
+	// (if it does - otherwise it just renames cleanly)
+	// Let's check if this error occurs
+	if err != nil {
+		assert.ErrorIs(t, err, ErrAliasCollision)
+	}
+}
+
 func TestHasProtoRef(t *testing.T) {
 	withRef := &HandlerDef{
 		ProtoRef: &ProtoReference{FullMethod: "pkg.Svc/Method"},

--- a/shared/pkg/saga/schema/proto_resolve_test.go
+++ b/shared/pkg/saga/schema/proto_resolve_test.go
@@ -371,20 +371,16 @@ func TestResolveProtoTypes_AliasCollision(t *testing.T) {
 				CompensationStrategy: CompensationStrategyNone,
 				ProtoRef: &ProtoReference{
 					FullMethod: "meridian.position_keeping.v1.PositionKeepingService/InitiateFinancialPositionLog",
-					// Both fields are present, then alias one to the other's name
-					ParamAliases: map[string]string{"account_id": "log_id"},
+					// Alias account_id to initial_entry which already exists in the request message
+					ParamAliases: map[string]string{"account_id": "initial_entry"},
 				},
 			},
 		},
 	}
 
 	err := s.ResolveProtoTypes(protoregistry.GlobalFiles)
-	// This should fail because log_id already exists in the request message
-	// (if it does - otherwise it just renames cleanly)
-	// Let's check if this error occurs
-	if err != nil {
-		assert.ErrorIs(t, err, ErrAliasCollision)
-	}
+	require.Error(t, err, "aliasing to an existing field name should fail")
+	assert.ErrorIs(t, err, ErrAliasCollision)
 }
 
 func TestHasProtoRef(t *testing.T) {

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -91,6 +91,8 @@ var (
 	ErrProtoMethodNotFound          = errors.New("proto method not found in service")
 	ErrProtoFieldPathNotFound       = errors.New("proto field path not found in message")
 	ErrInvalidProtoRPC              = errors.New("proto_rpc must be in format 'package.Service/Method'")
+	ErrUnknownAliasSource           = errors.New("param_alias references unknown field")
+	ErrAliasCollision               = errors.New("param_alias target already exists as a field")
 )
 
 // Schema represents a collection of handler definitions for a service.
@@ -778,12 +780,17 @@ func resolveExposedFields(md protoreflect.MessageDescriptor, exposed []string, a
 		}
 	}
 
-	// Apply aliases
+	// Apply aliases with validation
 	for original, alias := range aliases {
-		if def, ok := fields[original]; ok {
-			delete(fields, original)
-			fields[alias] = def
+		def, ok := fields[original]
+		if !ok {
+			return nil, fmt.Errorf("%w: %q (alias target: %q)", ErrUnknownAliasSource, original, alias)
 		}
+		if _, collision := fields[alias]; collision && alias != original {
+			return nil, fmt.Errorf("%w: %q (from alias of %q)", ErrAliasCollision, alias, original)
+		}
+		delete(fields, original)
+		fields[alias] = def
 	}
 
 	return fields, nil

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -720,11 +720,19 @@ func resolveHandlerProto(_ string, handler *HandlerDef, files *protoregistry.Fil
 
 	// Resolve params from request message
 	reqMsg := methodDesc.Input()
-	handler.Params = resolveExposedFields(reqMsg, ref.ExposedParams, ref.ParamAliases)
+	params, err := resolveExposedFields(reqMsg, ref.ExposedParams, ref.ParamAliases)
+	if err != nil {
+		return fmt.Errorf("params: %w", err)
+	}
+	handler.Params = params
 
 	// Resolve returns from response message
 	respMsg := methodDesc.Output()
-	handler.Returns = resolveExposedFields(respMsg, ref.ExposedReturns, nil)
+	returns, err := resolveExposedFields(respMsg, ref.ExposedReturns, nil)
+	if err != nil {
+		return fmt.Errorf("returns: %w", err)
+	}
+	handler.Returns = returns
 
 	return nil
 }
@@ -745,7 +753,8 @@ func findServiceDescriptor(files *protoregistry.Files, fqn protoreflect.FullName
 // resolveExposedFields builds a FieldDef map from a proto message descriptor,
 // filtered to only the exposed field paths. If exposed is nil/empty, all top-level
 // fields are included. Aliases are applied to param fields.
-func resolveExposedFields(md protoreflect.MessageDescriptor, exposed []string, aliases map[string]string) map[string]*FieldDef {
+// Returns ErrProtoFieldPathNotFound if any exposed path cannot be resolved.
+func resolveExposedFields(md protoreflect.MessageDescriptor, exposed []string, aliases map[string]string) (map[string]*FieldDef, error) {
 	fields := make(map[string]*FieldDef)
 
 	if len(exposed) == 0 {
@@ -761,7 +770,7 @@ func resolveExposedFields(md protoreflect.MessageDescriptor, exposed []string, a
 		for _, path := range exposed {
 			fd := resolveFieldPath(md, path)
 			if fd == nil {
-				continue // Skip unresolvable paths (validation catches this separately)
+				return nil, fmt.Errorf("%w: %q in message %s", ErrProtoFieldPathNotFound, path, md.FullName())
 			}
 			// Use the leaf field name as the key
 			leafName := leafFieldName(path)
@@ -777,7 +786,7 @@ func resolveExposedFields(md protoreflect.MessageDescriptor, exposed []string, a
 		}
 	}
 
-	return fields
+	return fields, nil
 }
 
 // resolveFieldPath resolves a dot-separated field path (e.g., "log.status_tracking.current_status")

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -8,8 +8,11 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 	"gopkg.in/yaml.v3"
 )
 
@@ -84,6 +87,10 @@ var (
 	ErrDeprecatedHandler            = errors.New("deprecated handler")
 	ErrOverrideMissingType          = errors.New("ParamOverride for non-proto field requires explicit Type")
 	ErrOverrideAliasCollision       = errors.New("ParamOverride alias would overwrite existing field")
+	ErrProtoServiceNotFound         = errors.New("proto service not found in registry")
+	ErrProtoMethodNotFound          = errors.New("proto method not found in service")
+	ErrProtoFieldPathNotFound       = errors.New("proto field path not found in message")
+	ErrInvalidProtoRPC              = errors.New("proto_rpc must be in format 'package.Service/Method'")
 )
 
 // Schema represents a collection of handler definitions for a service.
@@ -98,15 +105,42 @@ type Schema struct {
 	Handlers map[string]*HandlerDef `yaml:"handlers"`
 }
 
+// ProtoReference maps a handler to its proto RPC definition for slim schema format.
+// When present, Params and Returns are resolved from proto reflection at load time
+// rather than being defined inline in YAML.
+type ProtoReference struct {
+	// FullMethod is the proto RPC path, e.g.,
+	// "meridian.position_keeping.v1.PositionKeepingService/InitiateFinancialPositionLog".
+	FullMethod string `yaml:"proto_rpc"`
+
+	// ExposedParams lists proto request field paths exposed to Starlark scripts.
+	// Simple fields: ["account_id", "amount"]. Nested: ["log.status_tracking.current_status"].
+	ExposedParams []string `yaml:"exposed_params,omitempty"`
+
+	// ExposedReturns lists proto response field paths exposed to Starlark scripts.
+	ExposedReturns []string `yaml:"exposed_returns,omitempty"`
+
+	// ParamAliases maps proto field names to Starlark-visible aliases.
+	// Example: {"account_id": "position_id"} renames account_id to position_id in Starlark.
+	ParamAliases map[string]string `yaml:"param_aliases,omitempty"`
+}
+
 // HandlerDef defines the schema for a single handler.
 type HandlerDef struct {
 	// Description provides human-readable documentation.
 	Description string `yaml:"description"`
 
+	// ProtoRef holds the proto RPC reference for slim schema format.
+	// When set, Params and Returns are resolved from proto reflection at load time.
+	// Mutually exclusive with inline Params/Returns definitions in YAML.
+	ProtoRef *ProtoReference `yaml:"proto_ref,omitempty"`
+
 	// Params defines the input parameters.
+	// For proto-referenced handlers, populated by ResolveProtoTypes.
 	Params map[string]*FieldDef `yaml:"params"`
 
 	// Returns defines the return value fields.
+	// For proto-referenced handlers, populated by ResolveProtoTypes.
 	Returns map[string]*FieldDef `yaml:"returns"`
 
 	// Compensate is the handler name used for compensation/rollback.
@@ -210,15 +244,26 @@ func (h *HandlerDef) Validate(handlerName string) error {
 		h.Version = 1
 	}
 
-	for fieldName, field := range h.Params {
-		if err := field.Validate(fmt.Sprintf("%s.params.%s", handlerName, fieldName)); err != nil {
+	// Proto-referenced handlers: validate the reference format.
+	// Params/Returns are resolved later via ResolveProtoTypes, so skip field validation.
+	if h.ProtoRef != nil {
+		if err := h.ProtoRef.validate(handlerName); err != nil {
 			return err
 		}
 	}
 
-	for fieldName, field := range h.Returns {
-		if err := field.Validate(fmt.Sprintf("%s.returns.%s", handlerName, fieldName)); err != nil {
-			return err
+	// Only validate inline params/returns for non-proto-referenced handlers
+	if h.ProtoRef == nil {
+		for fieldName, field := range h.Params {
+			if err := field.Validate(fmt.Sprintf("%s.params.%s", handlerName, fieldName)); err != nil {
+				return err
+			}
+		}
+
+		for fieldName, field := range h.Returns {
+			if err := field.Validate(fmt.Sprintf("%s.returns.%s", handlerName, fieldName)); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -232,6 +277,19 @@ func (h *HandlerDef) Validate(handlerName string) error {
 		}
 	}
 
+	return nil
+}
+
+// validate checks that a ProtoReference is well-formed.
+func (pr *ProtoReference) validate(handlerName string) error {
+	if pr.FullMethod == "" {
+		return fmt.Errorf("%w: handler %s has empty proto_rpc", ErrInvalidProtoRPC, handlerName)
+	}
+	// Must contain exactly one '/' separating service from method
+	parts := strings.SplitN(pr.FullMethod, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("%w: handler %s has %q", ErrInvalidProtoRPC, handlerName, pr.FullMethod)
+	}
 	return nil
 }
 
@@ -615,4 +673,146 @@ func (r *Registry) BuildLinterMetadata() map[string]LinterMetadata {
 	}
 
 	return metadata
+}
+
+// ResolveProtoTypes resolves proto-referenced handlers in the schema by looking up
+// proto service/method descriptors and populating Params/Returns from proto reflection.
+// Handlers without ProtoRef are left unchanged (legacy inline format).
+// Uses the global proto registry by default; pass a custom resolver for testing.
+func (s *Schema) ResolveProtoTypes(files *protoregistry.Files) error {
+	if files == nil {
+		files = protoregistry.GlobalFiles
+	}
+	for handlerName, handler := range s.Handlers {
+		if handler.ProtoRef == nil {
+			continue
+		}
+		if err := resolveHandlerProto(handlerName, handler, files); err != nil {
+			return fmt.Errorf("handler %s: %w", handlerName, err)
+		}
+	}
+	return nil
+}
+
+// resolveHandlerProto resolves a single handler's proto reference into Params/Returns.
+func resolveHandlerProto(_ string, handler *HandlerDef, files *protoregistry.Files) error {
+	ref := handler.ProtoRef
+
+	// Parse "package.Service/Method" into service and method names
+	parts := strings.SplitN(ref.FullMethod, "/", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("%w: %s", ErrInvalidProtoRPC, ref.FullMethod)
+	}
+	serviceFQN := protoreflect.FullName(parts[0])
+	methodName := protoreflect.Name(parts[1])
+
+	// Look up the service descriptor
+	serviceDesc, err := findServiceDescriptor(files, serviceFQN)
+	if err != nil {
+		return err
+	}
+
+	// Look up the method
+	methodDesc := serviceDesc.Methods().ByName(methodName)
+	if methodDesc == nil {
+		return fmt.Errorf("%w: %s in service %s", ErrProtoMethodNotFound, methodName, serviceFQN)
+	}
+
+	// Resolve params from request message
+	reqMsg := methodDesc.Input()
+	handler.Params = resolveExposedFields(reqMsg, ref.ExposedParams, ref.ParamAliases)
+
+	// Resolve returns from response message
+	respMsg := methodDesc.Output()
+	handler.Returns = resolveExposedFields(respMsg, ref.ExposedReturns, nil)
+
+	return nil
+}
+
+// findServiceDescriptor searches the proto registry for a service by fully-qualified name.
+func findServiceDescriptor(files *protoregistry.Files, fqn protoreflect.FullName) (protoreflect.ServiceDescriptor, error) {
+	desc, err := files.FindDescriptorByName(fqn)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s (%w)", ErrProtoServiceNotFound, fqn, err)
+	}
+	sd, ok := desc.(protoreflect.ServiceDescriptor)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s is not a service descriptor", ErrProtoServiceNotFound, fqn)
+	}
+	return sd, nil
+}
+
+// resolveExposedFields builds a FieldDef map from a proto message descriptor,
+// filtered to only the exposed field paths. If exposed is nil/empty, all top-level
+// fields are included. Aliases are applied to param fields.
+func resolveExposedFields(md protoreflect.MessageDescriptor, exposed []string, aliases map[string]string) map[string]*FieldDef {
+	fields := make(map[string]*FieldDef)
+
+	if len(exposed) == 0 {
+		// Include all top-level fields
+		fds := md.Fields()
+		for i := 0; i < fds.Len(); i++ {
+			fd := fds.Get(i)
+			fieldName := string(fd.Name())
+			fields[fieldName] = deriveFieldDef(fd)
+		}
+	} else {
+		// Only include exposed field paths
+		for _, path := range exposed {
+			fd := resolveFieldPath(md, path)
+			if fd == nil {
+				continue // Skip unresolvable paths (validation catches this separately)
+			}
+			// Use the leaf field name as the key
+			leafName := leafFieldName(path)
+			fields[leafName] = deriveFieldDef(fd)
+		}
+	}
+
+	// Apply aliases
+	for original, alias := range aliases {
+		if def, ok := fields[original]; ok {
+			delete(fields, original)
+			fields[alias] = def
+		}
+	}
+
+	return fields
+}
+
+// resolveFieldPath resolves a dot-separated field path (e.g., "log.status_tracking.current_status")
+// through nested proto message descriptors. Returns the leaf field descriptor, or nil if not found.
+func resolveFieldPath(md protoreflect.MessageDescriptor, path string) protoreflect.FieldDescriptor {
+	parts := strings.Split(path, ".")
+	current := md
+
+	for i, part := range parts {
+		fd := current.Fields().ByName(protoreflect.Name(part))
+		if fd == nil {
+			return nil
+		}
+		// If this is the last part, return the field descriptor
+		if i == len(parts)-1 {
+			return fd
+		}
+		// Otherwise, navigate into the nested message
+		if fd.Kind() != protoreflect.MessageKind {
+			return nil // Can't traverse into non-message field
+		}
+		current = fd.Message()
+	}
+	return nil
+}
+
+// leafFieldName returns the last segment of a dot-separated path.
+func leafFieldName(path string) string {
+	if idx := strings.LastIndex(path, "."); idx >= 0 {
+		return path[idx+1:]
+	}
+	return path
+}
+
+// HasProtoRef returns true if the handler uses proto-referenced format.
+func (h *HandlerDef) HasProtoRef() bool {
+	return h.ProtoRef != nil
 }

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -93,6 +93,7 @@ var (
 	ErrInvalidProtoRPC              = errors.New("proto_rpc must be in format 'package.Service/Method'")
 	ErrUnknownAliasSource           = errors.New("param_alias references unknown field")
 	ErrAliasCollision               = errors.New("param_alias target already exists as a field")
+	ErrDuplicateLeafName            = errors.New("duplicate leaf field name from exposed paths")
 )
 
 // Schema represents a collection of handler definitions for a service.
@@ -776,6 +777,9 @@ func resolveExposedFields(md protoreflect.MessageDescriptor, exposed []string, a
 			}
 			// Use the leaf field name as the key
 			leafName := leafFieldName(path)
+			if _, dup := fields[leafName]; dup {
+				return nil, fmt.Errorf("%w: %q from path %q in message %s", ErrDuplicateLeafName, leafName, path, md.FullName())
+			}
 			fields[leafName] = deriveFieldDef(fd)
 		}
 	}


### PR DESCRIPTION
## Summary

- Add `ProtoReference` struct to `HandlerDef` enabling YAML-based handler definitions to reference proto RPC methods instead of duplicating type information inline
- Implement `ResolveProtoTypes()` that resolves proto field descriptors into `Params`/`Returns` FieldDefs at load time using proto reflection via `protoregistry`
- Create `handlers.yaml` with all 35 registered handlers in slim proto-referenced format (279 lines vs ~1000+ with inline definitions)
- Support both legacy inline format and proto-referenced format in the same schema (backwards compatible)

## Changes Made

**`shared/pkg/saga/schema/schema.go`**:
- `ProtoReference` struct with `proto_rpc`, `exposed_params`, `exposed_returns`, `param_aliases` fields
- `ResolveProtoTypes()` on `Schema` - resolves all proto-referenced handlers via `protoregistry.Files`
- `resolveFieldPath()` - resolves dot-separated nested field paths through proto message descriptors
- `resolveExposedFields()` - builds FieldDef map from proto message, filtered to exposed paths with alias support
- `findServiceDescriptor()` - looks up proto service by fully-qualified name
- Updated `HandlerDef.Validate()` to handle proto-referenced handlers (skip inline field validation when `proto_ref` is set)
- New error sentinels: `ErrProtoServiceNotFound`, `ErrProtoMethodNotFound`, `ErrProtoFieldPathNotFound`, `ErrInvalidProtoRPC`

**`shared/pkg/saga/schema/handlers.yaml`** (new):
- Slim proto-referenced format for all 35 handlers across 10 services
- Only saga-specific metadata (compensation, external flags, description) in YAML
- All type information derived from proto reflection
- 1 legacy handler (`financial_accounting.post_entries` - composite handler with no single proto type)

**`shared/pkg/saga/schema/proto_resolve_test.go`** (new):
- Tests for `ResolveProtoTypes` with real proto descriptors (position_keeping, reconciliation)
- Tests for field path resolution, aliases, error cases (service not found, method not found)
- Tests for mixed format (legacy + proto-referenced in same schema)
- Tests for YAML parsing of proto-referenced handlers

**`shared/pkg/saga/schema/handlers_yaml_test.go`** (new):
- Integration tests loading `handlers.yaml` and resolving against global proto registry
- Validates all 35 expected handlers are present
- Validates compensation coverage, external handler flags, alias resolution
- Validates file size stays under 500 lines

## Test plan

- [ ] All existing tests pass (backwards compatible - no changes to existing code paths)
- [ ] New proto resolution tests pass (12 tests in `proto_resolve_test.go`)
- [ ] New handlers.yaml integration tests pass (8 tests in `handlers_yaml_test.go`)
- [ ] `go vet` clean
- [ ] CI passes

## Task Master

Tag: `039-meridian-vm`, Task: 17 - Refactor handlers.yaml to Proto-Referenced Format with Slim Schema