### PR TITLE
fix: Add missing DialogDescription to all dialog components

### DIFF
--- a/frontend/src/features/identity/components/invite-dialog.tsx
+++ b/frontend/src/features/identity/components/invite-dialog.tsx
@@ -4,6 +4,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
@@ -64,6 +65,7 @@ export function InviteDialog({ open, onOpenChange, currentUserRoles }: InviteDia
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Invite User</DialogTitle>
+          <DialogDescription>Send an invitation to a new user with a designated role.</DialogDescription>
         </DialogHeader>
         <form onSubmit={(e) => void handleSubmit(e)} id="invite-user-form">
           <div className="space-y-4 py-2">

--- a/frontend/src/features/identity/components/role-management.tsx
+++ b/frontend/src/features/identity/components/role-management.tsx
@@ -8,6 +8,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
 import { useGrantRole, useRevokeRole } from '../hooks/use-identities'
@@ -107,6 +108,7 @@ export function RoleManagement({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Grant Role</DialogTitle>
+            <DialogDescription>Select a role to grant to this user.</DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-2">
             <div className="space-y-1">

--- a/frontend/src/features/identity/pages/user-detail-page.tsx
+++ b/frontend/src/features/identity/pages/user-detail-page.tsx
@@ -11,6 +11,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
@@ -180,6 +181,11 @@ export function UserDetailPage() {
             <DialogTitle>
               {actionType === 'suspend' ? 'Suspend User' : 'Reactivate User'}
             </DialogTitle>
+            <DialogDescription>
+              {actionType === 'suspend'
+                ? 'Provide a reason for suspending this user.'
+                : 'Provide a reason for reactivating this user.'}
+            </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-2">
             <p className="text-sm text-muted-foreground">

--- a/frontend/src/features/manifests/pages/manifest-apply-dialog.tsx
+++ b/frontend/src/features/manifests/pages/manifest-apply-dialog.tsx
@@ -5,6 +5,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
@@ -115,6 +116,7 @@ export function ManifestApplyDialog({ open, onOpenChange }: ManifestApplyDialogP
       <DialogContent className="max-w-2xl">
         <DialogHeader>
           <DialogTitle>Apply Manifest</DialogTitle>
+          <DialogDescription>Paste manifest JSON to preview and apply configuration changes.</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">

--- a/frontend/src/features/manifests/pages/manifest-history-table.tsx
+++ b/frontend/src/features/manifests/pages/manifest-history-table.tsx
@@ -10,6 +10,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
 } from '@/components/ui/dialog'
 import { manifestKeys } from '@/lib/query-keys'
 import type { ManifestVersion } from '@/api/gen/meridian/control_plane/v1/manifest_history_service_pb'
@@ -188,6 +189,7 @@ export function ManifestHistoryTable() {
         <DialogContent className="max-w-2xl">
           <DialogHeader>
             <DialogTitle>Manifest Version {selectedVersion?.version}</DialogTitle>
+            <DialogDescription>Raw manifest content for this version.</DialogDescription>
           </DialogHeader>
           <pre className="max-h-[400px] overflow-auto rounded bg-muted p-3 text-xs font-mono">
             {JSON.stringify(selectedVersion?.manifest, null, 2)}
@@ -201,6 +203,7 @@ export function ManifestHistoryTable() {
             <DialogTitle>
               Diff: Version {diffGraphs?.v1Label} vs {diffGraphs?.v2Label}
             </DialogTitle>
+            <DialogDescription>Visual comparison of manifest changes between versions.</DialogDescription>
           </DialogHeader>
           <div className="flex-1 min-h-0 h-full">
             {diffGraphs && (

--- a/frontend/src/features/parties/pages/tabs/payment-methods-tab.tsx
+++ b/frontend/src/features/parties/pages/tabs/payment-methods-tab.tsx
@@ -6,7 +6,7 @@ import { EmptyState } from '@/components/ui/empty-state'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card } from '@/components/ui/card'
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
 import { useForm } from 'react-hook-form'
 
 interface PaymentMethodsTabProps {
@@ -93,6 +93,7 @@ export function PaymentMethodsTab({ partyId }: PaymentMethodsTabProps) {
           <DialogContent>
             <DialogHeader>
               <DialogTitle>Add Payment Method</DialogTitle>
+              <DialogDescription>Link a payment provider method to this party.</DialogDescription>
             </DialogHeader>
             <form onSubmit={handleSubmit((data) => void addMutation.mutateAsync(data))} className="space-y-4">
               <div>

--- a/frontend/src/features/tenants/pages/index.tsx
+++ b/frontend/src/features/tenants/pages/index.tsx
@@ -12,6 +12,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
@@ -141,6 +142,7 @@ function InitiateTenantDialog({ open, onOpenChange, onSuccess }: InitiateTenantD
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Initiate Tenant</DialogTitle>
+          <DialogDescription>Create a new tenant with the required details.</DialogDescription>
         </DialogHeader>
         <form onSubmit={(e) => void handleSubmit(e)} id="initiate-tenant-form">
           <div className="space-y-4 py-2">


### PR DESCRIPTION
## Summary

- Added missing `DialogDescription` component to all 7 dialog components that were triggering Radix UI ARIA warnings (`Missing Description or aria-describedby`)
- Covers tasks 026-operations-console.97 and 026-operations-console.98

## Files Changed

| File | Dialog | Description Added |
|------|--------|-------------------|
| `features/tenants/pages/index.tsx` | Initiate Tenant | "Create a new tenant with the required details." |
| `features/parties/pages/tabs/payment-methods-tab.tsx` | Add Payment Method | "Link a payment provider method to this party." |
| `features/manifests/pages/manifest-history-table.tsx` | Manifest Version (detail) | "Raw manifest content for this version." |
| `features/manifests/pages/manifest-history-table.tsx` | Manifest Diff | "Visual comparison of manifest changes between versions." |
| `features/manifests/pages/manifest-apply-dialog.tsx` | Apply Manifest | "Paste manifest JSON to preview and apply configuration changes." |
| `features/identity/pages/user-detail-page.tsx` | Suspend/Reactivate User | Dynamic based on action type |
| `features/identity/components/invite-dialog.tsx` | Invite User | "Send an invitation to a new user with a designated role." |
| `features/identity/components/role-management.tsx` | Grant Role | "Select a role to grant to this user." |

## Test Plan

- [x] TypeScript typecheck passes
- [x] ESLint passes (no new warnings)
- [x] Dialog a11y test suite passes (9/9 tests)
- [x] All dialogs now have `DialogDescription` after `DialogTitle`