### PR TITLE
feat: add toast notification system with error-handling integration

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "react-dom": "^19.2.0",
         "react-hook-form": "^7.71.2",
         "react-router-dom": "^7.13.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "zod": "^4.3.6"
       },
@@ -10772,6 +10773,16 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.71.2",
     "react-router-dom": "^7.13.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { ProtectedRoute, PlatformOnlyRoute, AdminOnlyRoute, TenantSubdomainEnfor
 import { FeatureGuard } from '@/components/feature-guard'
 import { AppShell } from '@/components/layout/app-shell'
 import { TooltipProvider } from '@/components/ui/tooltip'
+import { Toaster } from 'sonner'
 import { CallbackPage } from '@/pages/callback'
 import { ProviderButton } from '@/components/auth/provider-button'
 import { AuthDivider } from '@/components/auth/auth-divider'
@@ -419,6 +420,7 @@ function AuthenticatedApp() {
       <ApiClientBridge>
         {(import.meta.env.DEV || import.meta.env.VITE_E2E_MODE === 'true' || import.meta.env.VITE_DEMO_MODE === 'true') && <DevTenantAutoSelector />}
         <TooltipProvider>
+          <Toaster position="top-right" richColors closeButton />
           <BrowserRouter>
             <Routes>
               <Route path="/login" element={<LoginPage />} />

--- a/frontend/src/lib/error-handling.ts
+++ b/frontend/src/lib/error-handling.ts
@@ -1,5 +1,6 @@
 import { Code, ConnectError } from '@connectrpc/connect'
 import { useCallback } from 'react'
+import { toast } from 'sonner'
 
 /**
  * Structured result from handling a ConnectError.
@@ -86,6 +87,8 @@ function extractFieldErrors(details: (IncomingDetail | object)[]): Record<string
 export interface HandleConnectErrorOptions {
   /** When provided, sets redirectTo to this path for NotFound errors */
   navigateToParent?: string
+  /** When true, shows a toast notification for the error */
+  showToast?: boolean
 }
 
 /**
@@ -118,6 +121,10 @@ export function handleConnectError(
   }
 
   const shouldRetry = code === Code.Unavailable
+
+  if (options.showToast) {
+    toast.error(message)
+  }
 
   return {
     message,
@@ -160,6 +167,32 @@ export function withErrorHandling(options: WithErrorHandlingOptions) {
       }
     },
   }
+}
+
+/**
+ * Convenience wrapper for mutations that should show toast errors.
+ * Shows a toast notification and optionally calls onError/onRedirect.
+ *
+ * Usage:
+ *   useMutation({
+ *     ...withToastErrorHandling()
+ *   })
+ *
+ *   useMutation({
+ *     ...withToastErrorHandling({
+ *       onError: (result) => setFieldErrors(result.fieldErrors),
+ *       onRedirect: (path) => navigate(path),
+ *     })
+ *   })
+ */
+export function withToastErrorHandling(
+  options: Partial<WithErrorHandlingOptions> = {},
+) {
+  return withErrorHandling({
+    ...options,
+    showToast: true,
+    onError: options.onError ?? (() => {}),
+  })
 }
 
 /**

--- a/frontend/src/lib/error-handling.ts
+++ b/frontend/src/lib/error-handling.ts
@@ -203,6 +203,6 @@ export function useErrorHandler(options: HandleConnectErrorOptions = {}) {
   return useCallback(
     (error: unknown) => handleConnectError(error, options),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [options.navigateToParent],
+    [options.navigateToParent, options.showToast],
   )
 }

--- a/frontend/src/test/lib/error-handling.test.ts
+++ b/frontend/src/test/lib/error-handling.test.ts
@@ -3,9 +3,17 @@ import { Code, ConnectError } from '@connectrpc/connect'
 import {
   handleConnectError,
   withErrorHandling,
+  withToastErrorHandling,
   useErrorHandler,
   type ConnectErrorResult,
 } from '@/lib/error-handling'
+import { toast } from 'sonner'
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}))
 
 // Helper to create a ConnectError with debug details (simulating wire format)
 function makeConnectError(
@@ -353,5 +361,70 @@ describe('withErrorHandling', () => {
 describe('useErrorHandler', () => {
   it('is exported and is a function', () => {
     expect(typeof useErrorHandler).toBe('function')
+  })
+})
+
+describe('toast integration', () => {
+  beforeEach(() => {
+    vi.mocked(toast.error).mockClear()
+  })
+
+  it('does not show toast by default', () => {
+    const err = makeConnectError('test', Code.Internal)
+    handleConnectError(err)
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('shows toast when showToast option is true', () => {
+    const err = makeConnectError('test', Code.Internal)
+    handleConnectError(err, { showToast: true })
+    expect(toast.error).toHaveBeenCalledWith(
+      'An internal server error occurred. Please contact support if the problem persists.',
+    )
+  })
+
+  it('shows toast with correct message for different error codes', () => {
+    const err = makeConnectError('not found', Code.NotFound)
+    handleConnectError(err, { showToast: true })
+    expect(toast.error).toHaveBeenCalledWith('The requested resource was not found.')
+  })
+})
+
+describe('withToastErrorHandling', () => {
+  beforeEach(() => {
+    vi.mocked(toast.error).mockClear()
+  })
+
+  it('shows toast and calls onError', () => {
+    const onError = vi.fn()
+    const handler = withToastErrorHandling({ onError })
+    const err = makeConnectError('test', Code.Internal)
+
+    handler.onError(err)
+
+    expect(toast.error).toHaveBeenCalledWith(
+      'An internal server error occurred. Please contact support if the problem persists.',
+    )
+    expect(onError).toHaveBeenCalledOnce()
+  })
+
+  it('works without onError callback', () => {
+    const handler = withToastErrorHandling()
+    const err = makeConnectError('test', Code.NotFound)
+
+    handler.onError(err)
+
+    expect(toast.error).toHaveBeenCalledWith('The requested resource was not found.')
+  })
+
+  it('calls onRedirect for Unauthenticated errors', () => {
+    const onRedirect = vi.fn()
+    const handler = withToastErrorHandling({ onRedirect })
+    const err = makeConnectError('expired', Code.Unauthenticated)
+
+    handler.onError(err)
+
+    expect(onRedirect).toHaveBeenCalledWith('/login')
+    expect(toast.error).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

- Install Sonner and add `<Toaster />` to App.tsx root for toast notifications
- Add `showToast` option to `handleConnectError()` for opt-in toast display on errors
- Add `withToastErrorHandling()` convenience wrapper for mutations that should show toasts
- Add tests covering toast integration (toast shown/not shown, different error codes, redirect behavior)

## Test plan

- [x] All 48 error-handling tests pass
- [x] TypeScript type check passes
- [x] ESLint passes (no new warnings)
- [ ] Manual: trigger an API error and verify toast appears in top-right