### PR TITLE
fix: tenant subdomain redirect and dashboard error handling

### DIFF
--- a/frontend/src/components/routing.tsx
+++ b/frontend/src/components/routing.tsx
@@ -3,6 +3,7 @@ import { Navigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/contexts/auth-context'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { apiConfig, isOnTenantSubdomain } from '@/api/config'
+import { Loader2 } from 'lucide-react'
 
 interface ProtectedRouteProps {
   children: ReactNode
@@ -74,15 +75,23 @@ function isLocalDev(): boolean {
  *
  * Platform routes (/tenants, /platform, /users, /login) stay on root.
  * Local dev is never redirected (no subdomain support).
+ *
+ * When the user is on the root domain viewing a tenant-scoped route but
+ * the tenant slug is not yet available (e.g. right after OIDC login before
+ * DevTenantAutoSelector resolves), a loading spinner is shown to prevent
+ * child components from rendering and firing API calls without tenant context.
  */
 export function TenantSubdomainEnforcer({ children }: { children: ReactNode }) {
   const { pathname, search, hash } = useLocation()
-  const { tenantSlug } = useTenantContext()
+  const { tenantSlug, isPlatformAdmin } = useTenantContext()
+
+  const onLocalDev = isLocalDev()
+  const onSubdomain = isOnTenantSubdomain()
+  const onPlatformPath = isPlatformPath(pathname)
 
   // Compute redirect URL only when needed: not local dev, not already on
   // subdomain, not a platform path, and a tenant is selected.
-  const needsRedirect =
-    !isLocalDev() && !isOnTenantSubdomain() && !isPlatformPath(pathname) && !!tenantSlug
+  const needsRedirect = !onLocalDev && !onSubdomain && !onPlatformPath && !!tenantSlug
 
   const redirectUrl = needsRedirect
     ? (() => {
@@ -104,6 +113,23 @@ export function TenantSubdomainEnforcer({ children }: { children: ReactNode }) {
 
   if (redirectUrl) {
     return null
+  }
+
+  // When a platform admin is on the root domain viewing a tenant-scoped route
+  // but no tenant is selected yet (e.g. waiting for DevTenantAutoSelector),
+  // show a loading state to prevent API calls without tenant context.
+  const awaitingTenant =
+    !onLocalDev && !onSubdomain && !onPlatformPath && isPlatformAdmin && !tenantSlug
+
+  if (awaitingTenant) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-center">
+          <Loader2 className="mx-auto h-6 w-6 animate-spin text-muted-foreground" />
+          <p className="mt-2 text-sm text-muted-foreground">Loading tenant context...</p>
+        </div>
+      </div>
+    )
   }
 
   return <>{children}</>

--- a/frontend/src/features/dashboard/pages/index.tsx
+++ b/frontend/src/features/dashboard/pages/index.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { CreditCard, FileText, BarChart3, ArrowRight, RefreshCw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useApiClients } from '@/api/context'
 import { useTenantContext } from '@/contexts/tenant-context'
@@ -204,13 +205,15 @@ export function DashboardPage() {
                 <p className="text-sm text-muted-foreground">
                   Unable to load recent activity.
                 </p>
-                <button
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="mt-3"
                   onClick={() => void activityQuery.refetch()}
-                  className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-xs font-medium hover:bg-accent hover:text-accent-foreground"
                 >
                   <RefreshCw className="h-3 w-3" />
                   Retry
-                </button>
+                </Button>
               </div>
             ) : (
               <ActivityFeed items={activityItems} isLoading={activityQuery.isLoading} />

--- a/frontend/src/features/dashboard/pages/index.tsx
+++ b/frontend/src/features/dashboard/pages/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
-import { CreditCard, FileText, BarChart3, ArrowRight } from 'lucide-react'
+import { CreditCard, FileText, BarChart3, ArrowRight, RefreshCw } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useApiClients } from '@/api/context'
 import { useTenantContext } from '@/contexts/tenant-context'
@@ -200,8 +200,17 @@ export function DashboardPage() {
           </CardHeader>
           <CardContent>
             {activityQuery.isError ? (
-              <div className="py-8 text-center text-sm text-muted-foreground">
-                Failed to load recent activity
+              <div className="py-8 text-center">
+                <p className="text-sm text-muted-foreground">
+                  Unable to load recent activity.
+                </p>
+                <button
+                  onClick={() => void activityQuery.refetch()}
+                  className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-xs font-medium hover:bg-accent hover:text-accent-foreground"
+                >
+                  <RefreshCw className="h-3 w-3" />
+                  Retry
+                </button>
               </div>
             ) : (
               <ActivityFeed items={activityItems} isLoading={activityQuery.isLoading} />

--- a/frontend/src/test/app-routing.test.tsx
+++ b/frontend/src/test/app-routing.test.tsx
@@ -1,10 +1,10 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider } from '@/contexts/auth-context'
 import { TenantProvider } from '@/contexts/tenant-context'
-import { ProtectedRoute, PlatformOnlyRoute } from '@/components/routing'
+import { ProtectedRoute, PlatformOnlyRoute, TenantSubdomainEnforcer } from '@/components/routing'
 import {
   createTestToken,
   createPlatformAdminToken,
@@ -102,6 +102,51 @@ describe('ProtectedRoute', () => {
 
     expect(screen.getByText('Login Page')).toBeInTheDocument()
     expect(screen.queryByText('Protected Content')).not.toBeInTheDocument()
+  })
+})
+
+describe('TenantSubdomainEnforcer', () => {
+  it('renders children on localhost (local dev bypass)', () => {
+    // On localhost, isLocalDev() returns true, the enforcer is fully bypassed
+    const token = createPlatformAdminToken()
+    render(
+      <TestWrapper initialToken={token}>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <TenantSubdomainEnforcer>
+                <div>Dashboard Content</div>
+              </TenantSubdomainEnforcer>
+            }
+          />
+        </Routes>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByText('Dashboard Content')).toBeInTheDocument()
+    expect(screen.queryByText('Loading tenant context...')).not.toBeInTheDocument()
+  })
+
+  it('renders children on platform paths without tenant context', () => {
+    const token = createPlatformAdminToken()
+    render(
+      <TestWrapper initialToken={token} initialPath="/tenants">
+        <Routes>
+          <Route
+            path="/tenants"
+            element={
+              <TenantSubdomainEnforcer>
+                <div>Tenants Page</div>
+              </TenantSubdomainEnforcer>
+            }
+          />
+        </Routes>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByText('Tenants Page')).toBeInTheDocument()
+    expect(screen.queryByText('Loading tenant context...')).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/test/tenant-subdomain-enforcer.test.tsx
+++ b/frontend/src/test/tenant-subdomain-enforcer.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Tests for TenantSubdomainEnforcer in production-like environments
+ * (non-localhost hostname). Requires module-level mocks for @/api/config.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { AuthProvider } from '@/contexts/auth-context'
+import { TenantProvider } from '@/contexts/tenant-context'
+import { createPlatformAdminToken } from './jwt-helpers'
+import { createTestQueryClient } from './test-utils'
+
+// Mock isOnTenantSubdomain to return false (simulating root domain)
+vi.mock('@/api/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/config')>()
+  return {
+    ...actual,
+    isOnTenantSubdomain: vi.fn(() => false),
+  }
+})
+
+// Import AFTER mock setup
+import { TenantSubdomainEnforcer } from '@/components/routing'
+
+// Save and restore window.location for production hostname simulation
+const originalLocation = window.location
+
+function setProductionHostname() {
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    configurable: true,
+    value: {
+      ...originalLocation,
+      hostname: 'demo.meridianhub.cloud',
+      href: 'https://demo.meridianhub.cloud/',
+      assign: vi.fn(),
+    },
+  })
+}
+
+function restoreLocation() {
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    configurable: true,
+    value: originalLocation,
+  })
+}
+
+function TestWrapper({
+  children,
+  initialToken,
+  initialPath = '/',
+}: {
+  children: React.ReactNode
+  initialToken?: string
+  initialPath?: string
+}) {
+  const queryClient = createTestQueryClient()
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider initialToken={initialToken}>
+        <TenantProvider>
+          <MemoryRouter initialEntries={[initialPath]}>{children}</MemoryRouter>
+        </TenantProvider>
+      </AuthProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('TenantSubdomainEnforcer (production hostname)', () => {
+  beforeEach(() => {
+    setProductionHostname()
+    return () => restoreLocation()
+  })
+
+  it('shows loading state when platform admin has no tenant selected', () => {
+    const token = createPlatformAdminToken()
+    render(
+      <TestWrapper initialToken={token}>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <TenantSubdomainEnforcer>
+                <div>Dashboard Content</div>
+              </TenantSubdomainEnforcer>
+            }
+          />
+        </Routes>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByText('Loading tenant context...')).toBeInTheDocument()
+    expect(screen.queryByText('Dashboard Content')).not.toBeInTheDocument()
+  })
+
+  it('renders children on platform paths even without tenant context', () => {
+    const token = createPlatformAdminToken()
+    render(
+      <TestWrapper initialToken={token} initialPath="/tenants">
+        <Routes>
+          <Route
+            path="/tenants"
+            element={
+              <TenantSubdomainEnforcer>
+                <div>Tenants Page</div>
+              </TenantSubdomainEnforcer>
+            }
+          />
+        </Routes>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByText('Tenants Page')).toBeInTheDocument()
+    expect(screen.queryByText('Loading tenant context...')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- **Task 92**: Fix `TenantSubdomainEnforcer` post-login race condition where platform admins land on tenant-scoped routes before `DevTenantAutoSelector` resolves the tenant context. The enforcer now shows a loading spinner while awaiting tenant selection, preventing child components from rendering and firing API calls without tenant context.
- **Task 93**: The `ListPaymentOrders` 400 errors were caused by the same race condition -- dashboard widgets attempted API calls before tenant context was available. Fixed by the task 92 loading gate.
- **Task 95**: Improve Recent Activity widget error state with a retry button and clearer error message instead of a static "Failed to load recent activity" text.

## Changes Made

- `frontend/src/components/routing.tsx`: Added `awaitingTenant` check in `TenantSubdomainEnforcer` that shows a loading spinner when a platform admin is on the root domain viewing a tenant-scoped route without a selected tenant
- `frontend/src/features/dashboard/pages/index.tsx`: Replaced static error message with retry button using `activityQuery.refetch()`

## Test plan

- [x] TypeScript type check passes
- [x] ESLint passes (no new warnings)
- [x] Existing routing tests pass (`app-routing.test.tsx`)
- [x] Dashboard tests pass (`index.test.tsx`, `activity-feed.test.tsx`, `stat-card.test.tsx`)
- [ ] Manual: Log in via OIDC on demo environment, verify loading spinner shows briefly before redirect to tenant subdomain
- [ ] Manual: Verify no 400 errors on ListPaymentOrders after login
- [ ] Manual: Trigger activity feed error, verify retry button appears and works