### PR TITLE
feat: provision admin identity in tenant schemas during bootstrap

### DIFF
--- a/cmd/meridian/main.go
+++ b/cmd/meridian/main.go
@@ -279,7 +279,7 @@ func run(logger *slog.Logger, grpcPort, httpPort int) error {
 
 	// ─── Provisioning Worker (optional) ─────────────────────────────────
 
-	provisioningWorker, provisionerCleanup, err := startProvisioningWorker(ctx, conns.gormDB("tenant"), logger)
+	provisioningWorker, provisionerCleanup, err := startProvisioningWorker(ctx, conns.gormDB("tenant"), conns.gormDB("identity"), logger)
 	if err != nil {
 		return fmt.Errorf("provisioning worker: %w", err)
 	}
@@ -586,7 +586,7 @@ func wireTenant(server *grpc.Server, db *gorm.DB, logger *slog.Logger) error {
 // SCHEMA_PROVISIONING_ENABLED=true. It returns the worker (for graceful Stop)
 // and a cleanup function that closes provisioner database connections.
 // When provisioning is disabled both return values are nil.
-func startProvisioningWorker(ctx context.Context, platformDB *gorm.DB, logger *slog.Logger) (*tenantworker.ProvisioningWorker, func(), error) {
+func startProvisioningWorker(ctx context.Context, platformDB *gorm.DB, identityDB *gorm.DB, logger *slog.Logger) (*tenantworker.ProvisioningWorker, func(), error) {
 	if env.GetEnvOrDefault("SCHEMA_PROVISIONING_ENABLED", "false") != "true" {
 		logger.Info("provisioning worker disabled",
 			"hint", "set SCHEMA_PROVISIONING_ENABLED=true to enable background provisioning")
@@ -635,6 +635,10 @@ func startProvisioningWorker(ctx context.Context, platformDB *gorm.DB, logger *s
 		_ = prov.Close()
 		return nil, nil, fmt.Errorf("create provisioning worker: %w", err)
 	}
+
+	// Register post-provisioning hooks before starting the worker.
+	identityRepo := identitypersistence.NewRepository(identityDB)
+	w.RegisterPostProvisioningHook("admin-identity", identitybootstrap.AsPostProvisioningHook(identityRepo))
 
 	go w.Start(ctx)
 	logger.Info("provisioning worker started")

--- a/services/identity/bootstrap/bootstrap.go
+++ b/services/identity/bootstrap/bootstrap.go
@@ -295,6 +295,86 @@ func reconcileDemoRole(ctx context.Context, repo domain.Repository, identity *do
 	return repo.SaveRoleAssignments(ctx, []*domain.RoleAssignment{ra})
 }
 
+// ProvisionAdminForTenant provisions the platform admin identity into a specific
+// tenant's schema. This ensures the platform admin is visible when querying
+// identities within that tenant (e.g., via ListIdentities).
+//
+// The function reads platform admin credentials from the same environment
+// variables as Run (PLATFORM_ADMIN_EMAIL, PLATFORM_ADMIN_PASSWORD).
+// If either is empty, the function is a no-op.
+//
+// Idempotency: If the admin already exists in the tenant schema, missing roles
+// are reconciled atomically.
+func ProvisionAdminForTenant(ctx context.Context, repo domain.Repository, tenantID tenant.TenantID) error {
+	if repo == nil {
+		return ErrNilRepository
+	}
+
+	email := os.Getenv("PLATFORM_ADMIN_EMAIL")
+	password := os.Getenv("PLATFORM_ADMIN_PASSWORD")
+
+	if email == "" || password == "" {
+		slog.InfoContext(ctx, "tenant admin provisioning skipped: PLATFORM_ADMIN_EMAIL or PLATFORM_ADMIN_PASSWORD not set",
+			"tenant_id", tenantID)
+		return nil
+	}
+
+	tenantCtx := tenant.WithTenant(ctx, tenantID)
+
+	// Check if admin already exists in this tenant.
+	existing, err := repo.FindByEmail(tenantCtx, email)
+	if err != nil && !errors.Is(err, domain.ErrIdentityNotFound) {
+		return fmt.Errorf("checking for existing platform admin in tenant %s: %w", tenantID, err)
+	}
+
+	if existing != nil {
+		return reconcileRoles(tenantCtx, repo, existing)
+	}
+
+	// Hash the password.
+	hash, err := credentials.HashPassword(password)
+	if err != nil {
+		return fmt.Errorf("hashing platform admin password: %w", err)
+	}
+
+	// Build domain objects.
+	identity, err := domain.NewIdentity(email)
+	if err != nil {
+		return fmt.Errorf("creating platform admin identity for tenant %s: %w", tenantID, err)
+	}
+	if err := identity.SetPassword(hash); err != nil {
+		return fmt.Errorf("setting platform admin password: %w", err)
+	}
+	if err := identity.Activate(); err != nil {
+		return fmt.Errorf("activating platform admin identity: %w", err)
+	}
+
+	roleAssignments := buildRoleAssignments(identity.ID(), platformAdminRoles)
+
+	if err := repo.SaveIdentityWithRoles(tenantCtx, identity, roleAssignments); err != nil {
+		return fmt.Errorf("provisioning platform admin in tenant %s: %w", tenantID, err)
+	}
+
+	slog.InfoContext(tenantCtx, "platform admin provisioned in tenant",
+		"tenant_id", tenantID,
+		"email", email,
+		"roles", len(platformAdminRoles))
+	return nil
+}
+
+// AsPostProvisioningHook returns a post-provisioning hook that provisions the
+// platform admin identity into newly created tenant schemas.
+//
+// Usage:
+//
+//	repo := persistence.NewRepository(db)
+//	worker.RegisterPostProvisioningHook("admin-identity", bootstrap.AsPostProvisioningHook(repo))
+func AsPostProvisioningHook(repo domain.Repository) func(ctx context.Context, tenantID tenant.TenantID) error {
+	return func(ctx context.Context, tenantID tenant.TenantID) error {
+		return ProvisionAdminForTenant(ctx, repo, tenantID)
+	}
+}
+
 // buildRoleAssignments constructs RoleAssignment domain objects for each role.
 // Bootstrap is a trusted system operation; ReconstructRoleAssignment is used to
 // bypass the privilege hierarchy check that would otherwise require a granting identity.

--- a/services/identity/bootstrap/bootstrap_test.go
+++ b/services/identity/bootstrap/bootstrap_test.go
@@ -246,3 +246,103 @@ func TestBootstrapPlatformAdmin_ReconcilesMissingRoles(t *testing.T) {
 	assert.Contains(t, activeRoles, "super-admin")
 	assert.Contains(t, activeRoles, "tenant-owner")
 }
+
+// --- Tests for ProvisionAdminForTenant ---
+
+// TestProvisionAdminForTenant_CreatesAdminInTenantSchema verifies that calling
+// ProvisionAdminForTenant provisions the platform admin in a non-master tenant schema.
+func TestProvisionAdminForTenant_CreatesAdminInTenantSchema(t *testing.T) {
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	defer cleanup()
+
+	tenantTID := tenant.MustNewTenantID("acme_corp")
+	setupTenantSchema(t, db, tenantTID)
+
+	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("PLATFORM_ADMIN_PASSWORD", "SecurePassword1!")
+
+	repo := persistence.NewRepository(db)
+	err := bootstrap.ProvisionAdminForTenant(context.Background(), repo, tenantTID)
+	require.NoError(t, err)
+
+	tenantCtx := tenant.WithTenant(context.Background(), tenantTID)
+	identity, err := repo.FindByEmail(tenantCtx, "admin@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, domain.IdentityStatusActive, identity.Status())
+
+	assignments, err := repo.FindRoleAssignments(tenantCtx, identity.ID())
+	require.NoError(t, err)
+	assert.Len(t, assignments, 3)
+}
+
+// TestProvisionAdminForTenant_Idempotent verifies that calling the function twice
+// for the same tenant does not create duplicates.
+func TestProvisionAdminForTenant_Idempotent(t *testing.T) {
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	defer cleanup()
+
+	tenantTID := tenant.MustNewTenantID("acme_corp")
+	setupTenantSchema(t, db, tenantTID)
+
+	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("PLATFORM_ADMIN_PASSWORD", "SecurePassword1!")
+
+	repo := persistence.NewRepository(db)
+	require.NoError(t, bootstrap.ProvisionAdminForTenant(context.Background(), repo, tenantTID))
+	require.NoError(t, bootstrap.ProvisionAdminForTenant(context.Background(), repo, tenantTID))
+
+	tenantCtx := tenant.WithTenant(context.Background(), tenantTID)
+	identities, err := repo.ListByTenant(tenantCtx)
+	require.NoError(t, err)
+	assert.Len(t, identities, 1)
+}
+
+// TestProvisionAdminForTenant_SkipsWhenEnvVarsEmpty verifies that provisioning
+// is skipped when platform admin credentials are not configured.
+func TestProvisionAdminForTenant_SkipsWhenEnvVarsEmpty(t *testing.T) {
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	defer cleanup()
+
+	tenantTID := tenant.MustNewTenantID("acme_corp")
+	setupTenantSchema(t, db, tenantTID)
+
+	t.Setenv("PLATFORM_ADMIN_EMAIL", "")
+	t.Setenv("PLATFORM_ADMIN_PASSWORD", "")
+
+	repo := persistence.NewRepository(db)
+	require.NoError(t, bootstrap.ProvisionAdminForTenant(context.Background(), repo, tenantTID))
+
+	tenantCtx := tenant.WithTenant(context.Background(), tenantTID)
+	identities, err := repo.ListByTenant(tenantCtx)
+	require.NoError(t, err)
+	assert.Empty(t, identities)
+}
+
+// TestProvisionAdminForTenant_NilRepo verifies that a nil repository returns an error.
+func TestProvisionAdminForTenant_NilRepo(t *testing.T) {
+	tenantTID := tenant.MustNewTenantID("acme_corp")
+	err := bootstrap.ProvisionAdminForTenant(context.Background(), nil, tenantTID)
+	assert.ErrorIs(t, err, bootstrap.ErrNilRepository)
+}
+
+// TestAsPostProvisioningHook_InvokesProvisionAdmin verifies that the hook
+// returned by AsPostProvisioningHook correctly provisions the admin.
+func TestAsPostProvisioningHook_InvokesProvisionAdmin(t *testing.T) {
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	defer cleanup()
+
+	tenantTID := tenant.MustNewTenantID("beta_corp")
+	setupTenantSchema(t, db, tenantTID)
+
+	t.Setenv("PLATFORM_ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("PLATFORM_ADMIN_PASSWORD", "SecurePassword1!")
+
+	repo := persistence.NewRepository(db)
+	hook := bootstrap.AsPostProvisioningHook(repo)
+	require.NoError(t, hook(context.Background(), tenantTID))
+
+	tenantCtx := tenant.WithTenant(context.Background(), tenantTID)
+	identity, err := repo.FindByEmail(tenantCtx, "admin@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, domain.IdentityStatusActive, identity.Status())
+}

--- a/services/identity/service/grpc_service.go
+++ b/services/identity/service/grpc_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/credentials"
 	"github.com/meridianhub/meridian/shared/pkg/tokens"
 	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
@@ -117,13 +118,23 @@ func (s *Service) UpdateIdentity(ctx context.Context, req *pb.UpdateIdentityRequ
 // ListIdentities returns all identities within the tenant.
 // Pagination and status filtering are not yet implemented.
 func (s *Service) ListIdentities(ctx context.Context, req *pb.ListIdentitiesRequest) (*pb.ListIdentitiesResponse, error) {
+	tenantID, hasTenant := tenant.FromContext(ctx)
+	s.logger.DebugContext(ctx, "ListIdentities called",
+		"tenant_id", tenantID,
+		"has_tenant_context", hasTenant,
+		"page_size", req.GetPageSize(),
+		"page_token", req.GetPageToken(),
+		"status_filter", req.GetStatusFilter().String())
+
 	if req.GetPageSize() > 0 || req.GetPageToken() != "" || req.GetStatusFilter() != pb.IdentityStatus_IDENTITY_STATUS_UNSPECIFIED {
 		return nil, status.Errorf(codes.Unimplemented, "pagination and status filtering are not yet supported")
 	}
 
 	identities, err := s.repo.ListByTenant(ctx)
 	if err != nil {
-		s.logger.ErrorContext(ctx, "failed to list identities", "error", err)
+		s.logger.ErrorContext(ctx, "failed to list identities",
+			"tenant_id", tenantID,
+			"error", err)
 		return nil, status.Errorf(codes.Internal, "failed to list identities")
 	}
 
@@ -131,6 +142,10 @@ func (s *Service) ListIdentities(ctx context.Context, req *pb.ListIdentitiesRequ
 	for _, ident := range identities {
 		pbIdentities = append(pbIdentities, identityToProto(ident))
 	}
+
+	s.logger.DebugContext(ctx, "ListIdentities completed",
+		"tenant_id", tenantID,
+		"result_count", len(pbIdentities))
 
 	return &pb.ListIdentitiesResponse{
 		Identities: pbIdentities,


### PR DESCRIPTION
## Summary

- Add `ProvisionAdminForTenant` to the identity bootstrap package to create the platform admin identity in each tenant's schema during provisioning
- Expose `AsPostProvisioningHook` for integration with the tenant provisioning worker
- Wire the hook into the unified binary's `startProvisioningWorker`, so new tenants automatically receive the platform admin identity
- Add diagnostic debug logging to `ListIdentities` to trace tenant context and result counts

## Context

The platform admin identity was only created in the `meridian_master` tenant schema. When `ListIdentities` queries a specific tenant (e.g., `volterra`), it scopes via `SET LOCAL search_path` to that tenant's schema, making the admin invisible.

This change ensures the admin identity is provisioned in every tenant's schema as a post-provisioning hook, matching the existing pattern used by internal-account default accounts and reference-data blueprint seeding.

## Task Master

- 026-operations-console.102 - Provision admin identity in tenant schema during bootstrap
- 026-operations-console.107 - Add diagnostic logging for identity list debugging

## Test plan

- [x] `TestProvisionAdminForTenant_CreatesAdminInTenantSchema` - verifies admin creation in non-master tenant
- [x] `TestProvisionAdminForTenant_Idempotent` - verifies no duplicates on repeat calls
- [x] `TestProvisionAdminForTenant_SkipsWhenEnvVarsEmpty` - verifies no-op without credentials
- [x] `TestProvisionAdminForTenant_NilRepo` - verifies error on nil repository
- [x] `TestAsPostProvisioningHook_InvokesProvisionAdmin` - verifies hook integration
- [x] All existing identity bootstrap and service tests pass
- [x] `go build ./...` compiles (identity service + unified binary)