### PR TITLE
fix: resolve ListFinancialPositionLogs 500 error on Positions page

### DIFF
--- a/frontend/src/features/positions/pages/detail.tsx
+++ b/frontend/src/features/positions/pages/detail.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useParams } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { MoneyDisplay } from '@/shared/money-display'
@@ -182,7 +183,7 @@ function MeasurementHistory({ entries }: MeasurementHistoryProps) {
 export function PositionDetailPage() {
   const { logId } = useParams<{ logId: string }>()
 
-  const { data, isLoading, isError } = usePositionLogDetail(logId)
+  const { data, isLoading, isError, refetch } = usePositionLogDetail(logId)
 
   const log = data?.log as FinancialPositionLog | undefined
 
@@ -204,7 +205,12 @@ export function PositionDetailPage() {
 
       {isError && (
         <Card className="p-6">
-          <p className="text-sm text-destructive">Failed to load position log.</p>
+          <div className="flex flex-col items-center gap-3 text-destructive">
+            <span className="text-sm font-medium">Failed to load position log</span>
+            <Button variant="outline" size="sm" onClick={() => void refetch()}>
+              Retry
+            </Button>
+          </div>
         </Card>
       )}
 

--- a/services/position-keeping/service/list_test.go
+++ b/services/position-keeping/service/list_test.go
@@ -264,6 +264,71 @@ func TestListFinancialPositionLogs_EmptyResults(t *testing.T) {
 	mockRepo.AssertExpectations(t)
 }
 
+// TestListFinancialPositionLogs_ZeroPageSize_UsesDefault tests that zero page_size
+// uses the default (50) instead of rejecting. Proto3 int32 defaults to 0, and
+// connect-es clients may send Pagination with zero page_size.
+func TestListFinancialPositionLogs_ZeroPageSize_UsesDefault(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
+
+	// Setup mock to expect default limit of 50
+	mockRepo.On("List", ctx, domain.PositionLogFilter{
+		Limit:  50,
+		Offset: 0,
+	}).Return([]*domain.FinancialPositionLog{}, nil)
+
+	req := &positionkeepingv1.ListFinancialPositionLogsRequest{
+		Pagination: &commonv1.Pagination{
+			PageSize: 0, // Proto3 default
+		},
+	}
+
+	// Act
+	resp, err := svc.ListFinancialPositionLogs(ctx, req)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.Logs)
+	mockRepo.AssertExpectations(t)
+}
+
+// TestListFinancialPositionLogs_NilPagination_UsesDefault tests that nil pagination
+// uses the default page size (50).
+func TestListFinancialPositionLogs_NilPagination_UsesDefault(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
+
+	// Setup mock to expect default limit of 50
+	mockRepo.On("List", ctx, domain.PositionLogFilter{
+		Limit:  50,
+		Offset: 0,
+	}).Return([]*domain.FinancialPositionLog{}, nil)
+
+	req := &positionkeepingv1.ListFinancialPositionLogsRequest{
+		// No pagination at all
+	}
+
+	// Act
+	resp, err := svc.ListFinancialPositionLogs(ctx, req)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.Logs)
+	mockRepo.AssertExpectations(t)
+}
+
 // TestListFinancialPositionLogs_InvalidPagination tests invalid pagination parameters
 func TestListFinancialPositionLogs_InvalidPagination(t *testing.T) {
 	tests := []struct {
@@ -272,12 +337,6 @@ func TestListFinancialPositionLogs_InvalidPagination(t *testing.T) {
 		expectedCode  codes.Code
 		expectedError string
 	}{
-		{
-			name:          "zero page size",
-			pageSize:      0,
-			expectedCode:  codes.InvalidArgument,
-			expectedError: "page_size must be positive",
-		},
 		{
 			name:          "negative page size",
 			pageSize:      -1,

--- a/services/position-keeping/service/service.go
+++ b/services/position-keeping/service/service.go
@@ -236,14 +236,14 @@ func (s *PositionKeepingService) ListFinancialPositionLogs(
 	offset := 0
 
 	if req.Pagination != nil {
-		if req.Pagination.PageSize == 0 {
-			return nil, status.Error(codes.InvalidArgument, "page_size must be positive")
-		} else if req.Pagination.PageSize < 0 {
+		if req.Pagination.PageSize < 0 {
 			return nil, status.Error(codes.InvalidArgument, "page_size must be positive")
 		} else if req.Pagination.PageSize > 1000 {
 			return nil, status.Error(codes.InvalidArgument, "page_size exceeds maximum of 1000")
+		} else if req.Pagination.PageSize > 0 {
+			pageSize = req.Pagination.PageSize
 		}
-		pageSize = req.Pagination.PageSize
+		// PageSize == 0 uses the default (50)
 
 		// Parse page token as offset
 		if req.Pagination.PageToken != "" {
@@ -305,6 +305,12 @@ func (s *PositionKeepingService) ListFinancialPositionLogs(
 	// Query repository
 	logs, err := s.repository.List(ctx, filter)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, status.Errorf(codes.Canceled, "request cancelled: %v", err)
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, status.Errorf(codes.DeadlineExceeded, "request timed out: %v", err)
+		}
 		return nil, status.Errorf(codes.Internal, "failed to list financial position logs: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

- Fix consistent HTTP 500 error on the Positions page (`/positions`) caused by `ListFinancialPositionLogs` rejecting `page_size=0` as invalid instead of treating it as "use default"
- Add context-aware error mapping for repository errors (Canceled, DeadlineExceeded)
- Add retry button to position detail page error state

## Changes

**Backend** (`services/position-keeping/service/service.go`):
- `page_size=0` now uses the default page size (50) instead of returning `InvalidArgument`. Proto3 `int32` defaults to 0, and connect-es clients may send a `Pagination` message with zero `page_size` when no explicit value is set.
- Repository errors now map `context.Canceled` to `codes.Canceled` and `context.DeadlineExceeded` to `codes.DeadlineExceeded` instead of always returning `codes.Internal`.

**Frontend** (`frontend/src/features/positions/pages/detail.tsx`):
- Position detail page error state now includes a retry button (matching the DataTable pattern).

**Tests** (`services/position-keeping/service/list_test.go`):
- Added `TestListFinancialPositionLogs_ZeroPageSize_UsesDefault` -- verifies zero page_size uses default 50
- Added `TestListFinancialPositionLogs_NilPagination_UsesDefault` -- verifies nil pagination uses default 50
- Updated invalid pagination tests to remove the zero page_size rejection case

## Test plan

- [x] Backend service tests pass (`go test ./services/position-keeping/service/...`)
- [x] Frontend typecheck passes (`npm run typecheck`)
- [x] Frontend positions tests pass (38/38 passing)
- [x] Go build succeeds
- [x] Pre-commit hooks pass (gitleaks, gofumpt, golangci-lint)

## Task Master

026-operations-console.112 -- Fix ListFinancialPositionLogs 500 Error