### PR TITLE
feat: document multi-tenant redirect URI strategy in Dex config

### DIFF
--- a/deploy/demo/dex.yaml
+++ b/deploy/demo/dex.yaml
@@ -54,7 +54,13 @@ staticClients:
       - "https://demo.meridianhub.cloud/callback"
       # Tenant subdomains — add one entry per onboarded tenant
       - "https://volterra.demo.meridianhub.cloud/callback"
-      # Local development
+    public: true
+
+  # Separate client for local development. Keeps localhost redirect URIs
+  # isolated from the deployed demo client above.
+  - id: meridian-dev
+    name: Meridian (dev)
+    redirectURIs:
       - "http://localhost:8090/callback"
       - "http://localhost:3000/callback"
     public: true

--- a/deploy/demo/dex.yaml
+++ b/deploy/demo/dex.yaml
@@ -45,11 +45,18 @@ oauth2:
 staticClients:
   - id: meridian-service
     name: Meridian
+    # Dex requires exact redirect URI matching per the OAuth 2.0 / OIDC spec
+    # (no wildcard or pattern support). Each tenant subdomain must be listed
+    # explicitly. When onboarding a new tenant, add its callback URL here and
+    # restart Dex.
     redirectURIs:
+      # Platform root
       - "https://demo.meridianhub.cloud/callback"
-      # Subdomain-based tenants — e.g. volterra.demo.meridianhub.cloud
+      # Tenant subdomains — add one entry per onboarded tenant
       - "https://volterra.demo.meridianhub.cloud/callback"
+      # Local development
       - "http://localhost:8090/callback"
+      - "http://localhost:3000/callback"
     public: true
 
 enablePasswordDB: true

--- a/deploy/demo/dex.yaml
+++ b/deploy/demo/dex.yaml
@@ -54,13 +54,9 @@ staticClients:
       - "https://demo.meridianhub.cloud/callback"
       # Tenant subdomains — add one entry per onboarded tenant
       - "https://volterra.demo.meridianhub.cloud/callback"
-    public: true
-
-  # Separate client for local development. Keeps localhost redirect URIs
-  # isolated from the deployed demo client above.
-  - id: meridian-dev
-    name: Meridian (dev)
-    redirectURIs:
+      # Local development — the frontend hardcodes client_id "meridian-service"
+      # in use-oauth-flow.ts, App.tsx, and callback.tsx, so localhost callbacks
+      # must be registered on this client for PKCE auth to work locally.
       - "http://localhost:8090/callback"
       - "http://localhost:3000/callback"
     public: true


### PR DESCRIPTION
## Summary

- Dex v2.41.1 does not support wildcard or regex redirect URI matching (per OAuth 2.0/OIDC spec requirement for exact string comparison)
- Updated `deploy/demo/dex.yaml` to clearly document that each tenant subdomain must be explicitly listed
- Added `localhost:3000` callback for frontend development use

## Changes Made

- Added comments explaining the per-tenant onboarding process for redirect URIs
- Organized redirect URIs with inline comments (platform root, tenant subdomains, local dev)
- Added `http://localhost:3000/callback` for frontend development

## Context

Task `embedded-dex-identity.30` — Dex `staticClients` redirect URI configuration for multi-tenant support.

## Test plan

- [ ] Verify existing demo login flow still works with `demo.meridianhub.cloud/callback`
- [ ] Verify `volterra.demo.meridianhub.cloud/callback` redirect still works
- [ ] Confirm YAML is syntactically valid (Dex starts without errors)