### PR TITLE
test: E2E tests for admin user visibility and suspend flow

### DIFF
--- a/frontend/e2e/admin-users.spec.ts
+++ b/frontend/e2e/admin-users.spec.ts
@@ -1,0 +1,491 @@
+import { test, expect, navigateTo } from './fixtures'
+
+/**
+ * E2E tests for admin user visibility and suspend flow.
+ *
+ * Tests run against the Vite dev server. Some tests use page.route() to mock
+ * gRPC-web API responses so they can verify toast/redirect behaviour without
+ * a live backend.
+ *
+ * The /users route is wrapped in AdminOnlyRoute. Both the platform-admin and
+ * admin-role fixtures satisfy that guard, so they are used throughout.
+ *
+ * Connect-ES serialisation note:
+ *   In dev/E2E mode useBinaryFormat is false — the transport uses the Connect
+ *   JSON protocol (Content-Type: application/json). Error responses use the
+ *   Connect error shape: { "code": "<snake_case>", "message": "..." }.
+ *
+ * Toast selectors:
+ *   Sonner renders toasts in [data-sonner-toaster] → [data-sonner-toast].
+ *   The toast title text is inside a [data-title] element.
+ */
+
+// ─── Users list ───────────────────────────────────────────────────────────────
+
+test.describe('Users list - admin access', () => {
+  test('renders Users heading for platform admin', async ({ platformAdminPage: page }) => {
+    await navigateTo(page, '/users')
+    await expect(page.getByRole('heading', { name: 'Users' })).toBeVisible()
+  })
+
+  test('shows Invite User button', async ({ platformAdminPage: page }) => {
+    await navigateTo(page, '/users')
+    await expect(page.getByRole('button', { name: /invite user/i })).toBeVisible()
+  })
+
+  test('renders user table with Email, Status, MFA, Last Login, Created columns', async ({ platformAdminPage: page }) => {
+    await navigateTo(page, '/users')
+    await expect(page.getByRole('columnheader', { name: 'Email' })).toBeVisible()
+    await expect(page.getByRole('columnheader', { name: 'Status' })).toBeVisible()
+    await expect(page.getByRole('columnheader', { name: 'MFA' })).toBeVisible()
+  })
+
+  test('shows status filter dropdown', async ({ platformAdminPage: page }) => {
+    await navigateTo(page, '/users')
+    await expect(page.getByRole('combobox', { name: /status/i })).toBeVisible()
+  })
+
+  test('platform admin appears in the users list after login', async ({ platformAdminPage: page }) => {
+    await navigateTo(page, '/users')
+    // The table must be present — either loading, empty, or populated
+    await expect(page.locator('table')).toBeVisible()
+    // If users are returned by the backend, at least one row must render
+    const rowCount = await page.locator('table tbody tr').count()
+    if (rowCount > 0) {
+      await expect(page.locator('table tbody tr').first()).toBeVisible()
+    } else {
+      // Empty state is also valid — UI renders without error
+      await expect(page.getByText('No users found').or(page.locator('table'))).toBeVisible({ timeout: 15_000 })
+    }
+  })
+
+  test('tenant users are listed in the table when backend returns data', async ({ platformAdminPage: page }) => {
+    await navigateTo(page, '/users')
+    await expect(page.locator('table')).toBeVisible()
+
+    const rowCount = await page.locator('table tbody tr').count()
+    if (rowCount === 0) {
+      // No users seeded — table renders without error
+      await expect(page.getByText(/no users found/i).or(page.locator('table tbody'))).toBeVisible({ timeout: 15_000 })
+      return
+    }
+
+    // At least one user row visible — verify it has an email cell
+    await expect(page.locator('table tbody tr').first()).toBeVisible()
+    // Email column renders a value (non-empty cell)
+    const firstEmailCell = page.locator('table tbody tr').first().locator('td').first()
+    await expect(firstEmailCell).not.toBeEmpty()
+  })
+
+  test('row click navigates to user detail page', async ({ platformAdminPage: page }) => {
+    await navigateTo(page, '/users')
+    await expect(page.locator('table')).toBeVisible()
+
+    const rowCount = await page.locator('table tbody tr').count()
+    if (rowCount === 0) {
+      test.skip()
+      return
+    }
+
+    await page.locator('table tbody tr').first().click()
+    await expect(page).toHaveURL(/\/users\/[a-zA-Z0-9-]+/)
+  })
+})
+
+// ─── User detail — suspend dialog ─────────────────────────────────────────────
+
+test.describe('User detail - suspend dialog', () => {
+  /**
+   * Navigate to the first available user detail page.
+   * Returns false if no users are present (caller should skip the test).
+   */
+  async function navigateToFirstUser(page: import('@playwright/test').Page): Promise<boolean> {
+    await navigateTo(page, '/users')
+    await expect(page.locator('table')).toBeVisible()
+    const rowCount = await page.locator('table tbody tr').count()
+    if (rowCount === 0) return false
+    await page.locator('table tbody tr').first().click()
+    await page.waitForURL(/\/users\/[a-zA-Z0-9-]+/)
+    return true
+  }
+
+  test('shows user email as heading on detail page', async ({ platformAdminPage: page }) => {
+    const found = await navigateToFirstUser(page)
+    if (!found) { test.skip(); return }
+    // h1 contains the user email
+    const heading = page.getByRole('heading', { level: 1 })
+    await expect(heading).toBeVisible({ timeout: 15_000 })
+    await expect(heading).not.toBeEmpty()
+  })
+
+  test('shows Identity Details card', async ({ platformAdminPage: page }) => {
+    const found = await navigateToFirstUser(page)
+    if (!found) { test.skip(); return }
+    await expect(page.getByText('Identity Details')).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('shows Back to Users link', async ({ platformAdminPage: page }) => {
+    const found = await navigateToFirstUser(page)
+    if (!found) { test.skip(); return }
+    await expect(page.getByText('Back to Users')).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('Suspend button opens confirm dialog for active user', async ({ platformAdminPage: page }) => {
+    const found = await navigateToFirstUser(page)
+    if (!found) { test.skip(); return }
+
+    const suspendBtn = page.getByRole('button', { name: /^suspend$/i })
+    const hasSuspendBtn = await suspendBtn.isVisible()
+    if (!hasSuspendBtn) {
+      // User is not ACTIVE (e.g. already suspended) — skip
+      test.skip()
+      return
+    }
+
+    await suspendBtn.click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByRole('heading', { name: 'Suspend User' })).toBeVisible()
+    await expect(dialog.getByText('Suspending this user will prevent them from logging in.')).toBeVisible()
+    await expect(dialog.getByLabel('Reason')).toBeVisible()
+  })
+
+  test('Suspend dialog requires a reason before confirming', async ({ platformAdminPage: page }) => {
+    const found = await navigateToFirstUser(page)
+    if (!found) { test.skip(); return }
+
+    const suspendBtn = page.getByRole('button', { name: /^suspend$/i })
+    if (!await suspendBtn.isVisible()) { test.skip(); return }
+
+    await suspendBtn.click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    // The Suspend User confirm button must be disabled when reason is empty
+    const confirmBtn = dialog.getByRole('button', { name: 'Suspend User' })
+    await expect(confirmBtn).toBeDisabled()
+  })
+
+  test('Suspend dialog closes on Cancel', async ({ platformAdminPage: page }) => {
+    const found = await navigateToFirstUser(page)
+    if (!found) { test.skip(); return }
+
+    const suspendBtn = page.getByRole('button', { name: /^suspend$/i })
+    if (!await suspendBtn.isVisible()) { test.skip(); return }
+
+    await suspendBtn.click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click()
+    await expect(dialog).not.toBeVisible()
+  })
+})
+
+// ─── Suspend API mock tests ───────────────────────────────────────────────────
+//
+// These tests inject a dev auth token then mock specific gRPC-web endpoints via
+// page.route() so they run without a live backend. They verify error toast
+// behaviour and redirect semantics for 403 (PermissionDenied) and 401
+// (Unauthenticated) responses from the SuspendIdentity RPC.
+//
+// The /users route requires AdminOnlyRoute to pass (platformAdminPage satisfies
+// this). The mock returns a user whose status is ACTIVE so the Suspend button
+// is visible. Then a second route intercepts the SuspendIdentity call and
+// returns the desired error.
+
+/**
+ * Mock the IdentityService to return a single ACTIVE user.
+ * Connect JSON protocol: ListIdentities response.
+ */
+async function mockListIdentities(page: import('@playwright/test').Page) {
+  await page.route(`**/meridian.identity.v1.IdentityService/ListIdentities`, (route) => {
+    void route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        identities: [
+          {
+            id: 'mock-user-1',
+            email: 'alice@example.com',
+            status: 2, // ACTIVE
+            mfaEnabled: false,
+            failedAttempts: 0,
+            externalIdp: '',
+            externalIdpSub: '',
+            createdAt: { seconds: '1699000000', nanos: 0 },
+            updatedAt: { seconds: '1700000000', nanos: 0 },
+            version: 1,
+          },
+        ],
+        nextPageToken: '',
+        totalCount: 1,
+      }),
+    })
+  })
+}
+
+/**
+ * Mock RetrieveIdentity to return an ACTIVE user.
+ */
+async function mockRetrieveIdentity(page: import('@playwright/test').Page) {
+  await page.route(`**/meridian.identity.v1.IdentityService/RetrieveIdentity`, (route) => {
+    void route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        identity: {
+          id: 'mock-user-1',
+          email: 'alice@example.com',
+          status: 2, // ACTIVE
+          mfaEnabled: false,
+          failedAttempts: 0,
+          externalIdp: '',
+          externalIdpSub: '',
+          createdAt: { seconds: '1699000000', nanos: 0 },
+          updatedAt: { seconds: '1700000000', nanos: 0 },
+          version: 1,
+        },
+      }),
+    })
+  })
+}
+
+/**
+ * Mock ListRoleAssignments to return empty roles.
+ */
+async function mockListRoleAssignments(page: import('@playwright/test').Page) {
+  await page.route(`**/meridian.identity.v1.IdentityService/ListRoleAssignments`, (route) => {
+    void route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ roleAssignments: [] }),
+    })
+  })
+}
+
+test.describe('Suspend API — 403 permission denied', () => {
+  test.beforeEach(async ({ platformAdminPage: page }) => {
+    await mockListIdentities(page)
+    await mockRetrieveIdentity(page)
+    await mockListRoleAssignments(page)
+
+    // Mock SuspendIdentity to return 403 PermissionDenied
+    await page.route(`**/meridian.identity.v1.IdentityService/SuspendIdentity`, (route) => {
+      void route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 'permission_denied',
+          message: 'You do not have permission to perform this action.',
+        }),
+      })
+    })
+  })
+
+  test('shows permission denied toast when suspend returns 403', async ({ platformAdminPage: page }) => {
+    // Navigate to the mocked user detail page
+    await navigateTo(page, '/users/mock-user-1')
+
+    await expect(page.getByRole('button', { name: /^suspend$/i })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('button', { name: /^suspend$/i }).click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByLabel('Reason').fill('Policy violation')
+    await dialog.getByRole('button', { name: 'Suspend User' }).click()
+
+    // Toast must appear with the permission denied message
+    await expect(
+      page.getByText('You do not have permission to perform this action.'),
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('403 error does not redirect to login', async ({ platformAdminPage: page }) => {
+    await navigateTo(page, '/users/mock-user-1')
+
+    await expect(page.getByRole('button', { name: /^suspend$/i })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('button', { name: /^suspend$/i }).click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByLabel('Reason').fill('Policy violation')
+    await dialog.getByRole('button', { name: 'Suspend User' }).click()
+
+    // Wait for toast to appear
+    await expect(
+      page.getByText('You do not have permission to perform this action.'),
+    ).toBeVisible({ timeout: 10_000 })
+
+    // URL must remain on the user detail page — no redirect to /login
+    await expect(page).toHaveURL(/\/users\/mock-user-1/)
+  })
+})
+
+test.describe('Suspend API — successful suspend', () => {
+  test('closes dialog and page stays on user detail after successful suspend', async ({ platformAdminPage: page }) => {
+    await mockListIdentities(page)
+    await mockListRoleAssignments(page)
+    await mockRetrieveIdentity(page)
+
+    // First call returns ACTIVE, after suspend it returns SUSPENDED
+    let suspendCalled = false
+    await page.route(`**/meridian.identity.v1.IdentityService/RetrieveIdentity`, (route) => {
+      if (suspendCalled) {
+        void route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            identity: {
+              id: 'mock-user-1',
+              email: 'alice@example.com',
+              status: 3, // SUSPENDED
+              mfaEnabled: false,
+              failedAttempts: 0,
+              externalIdp: '',
+              externalIdpSub: '',
+              createdAt: { seconds: '1699000000', nanos: 0 },
+              updatedAt: { seconds: '1700000001', nanos: 0 },
+              version: 2,
+            },
+          }),
+        })
+      } else {
+        void route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            identity: {
+              id: 'mock-user-1',
+              email: 'alice@example.com',
+              status: 2, // ACTIVE
+              mfaEnabled: false,
+              failedAttempts: 0,
+              externalIdp: '',
+              externalIdpSub: '',
+              createdAt: { seconds: '1699000000', nanos: 0 },
+              updatedAt: { seconds: '1700000000', nanos: 0 },
+              version: 1,
+            },
+          }),
+        })
+      }
+    })
+
+    await page.route(`**/meridian.identity.v1.IdentityService/SuspendIdentity`, (route) => {
+      suspendCalled = true
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          identity: {
+            id: 'mock-user-1',
+            email: 'alice@example.com',
+            status: 3, // SUSPENDED
+            mfaEnabled: false,
+            failedAttempts: 0,
+            externalIdp: '',
+            externalIdpSub: '',
+            createdAt: { seconds: '1699000000', nanos: 0 },
+            updatedAt: { seconds: '1700000001', nanos: 0 },
+            version: 2,
+          },
+        }),
+      })
+    })
+
+    await navigateTo(page, '/users/mock-user-1')
+    await expect(page.getByRole('button', { name: /^suspend$/i })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('button', { name: /^suspend$/i }).click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByLabel('Reason').fill('Compliance review')
+    await dialog.getByRole('button', { name: 'Suspend User' }).click()
+
+    // Dialog closes on success
+    await expect(dialog).not.toBeVisible({ timeout: 10_000 })
+
+    // URL stays on user detail
+    await expect(page).toHaveURL(/\/users\/mock-user-1/)
+  })
+})
+
+test.describe('Suspend API — 401 unauthenticated', () => {
+  test('401 from SuspendIdentity clears auth and redirects to /login', async ({ platformAdminPage: page }) => {
+    await mockListIdentities(page)
+    await mockRetrieveIdentity(page)
+    await mockListRoleAssignments(page)
+
+    // Mock SuspendIdentity to return 401 Unauthenticated
+    await page.route(`**/meridian.identity.v1.IdentityService/SuspendIdentity`, (route) => {
+      void route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 'unauthenticated',
+          message: 'Your session has expired. Please sign in again.',
+        }),
+      })
+    })
+
+    await navigateTo(page, '/users/mock-user-1')
+    await expect(page.getByRole('button', { name: /^suspend$/i })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('button', { name: /^suspend$/i }).click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByLabel('Reason').fill('Compliance review')
+    await dialog.getByRole('button', { name: 'Suspend User' }).click()
+
+    // Auth interceptor calls onUnauthenticated → logout() → token cleared →
+    // ProtectedRoute redirects to /login. The toast also fires.
+    await expect(page).toHaveURL('/login', { timeout: 10_000 })
+  })
+
+  test('session expiry toast appears before redirect on 401', async ({ platformAdminPage: page }) => {
+    await mockListIdentities(page)
+    await mockRetrieveIdentity(page)
+    await mockListRoleAssignments(page)
+
+    await page.route(`**/meridian.identity.v1.IdentityService/SuspendIdentity`, (route) => {
+      void route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 'unauthenticated',
+          message: 'Your session has expired. Please sign in again.',
+        }),
+      })
+    })
+
+    await navigateTo(page, '/users/mock-user-1')
+    await expect(page.getByRole('button', { name: /^suspend$/i })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole('button', { name: /^suspend$/i }).click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByLabel('Reason').fill('Compliance review')
+    await dialog.getByRole('button', { name: 'Suspend User' }).click()
+
+    // The session expiry error toast fires from withToastErrorHandling
+    // before the auth state clears and ProtectedRoute redirects.
+    // Because the redirect is fast, check URL destination.
+    await expect(page).toHaveURL('/login', { timeout: 10_000 })
+    // Login page must render (confirms redirect completed, not a blank page)
+    await expect(page.getByRole('heading', { name: 'Meridian Operations Console' })).toBeVisible()
+  })
+})
+
+// ─── Non-admin access ─────────────────────────────────────────────────────────
+
+test.describe('Users page - non-admin redirect', () => {
+  test('tenant-user without admin role is redirected from /users', async ({ authenticatedPage: page }) => {
+    await navigateTo(page, '/users')
+    // AdminOnlyRoute redirects non-admin users to /
+    await expect(page).toHaveURL('/', { timeout: 5_000 })
+  })
+})

--- a/frontend/e2e/admin-users.spec.ts
+++ b/frontend/e2e/admin-users.spec.ts
@@ -50,19 +50,17 @@ test.describe('Users list - admin access', () => {
 
   test('platform admin appears in the users list after login', async ({ platformAdminPage: page }) => {
     await navigateTo(page, '/users')
-    // Wait for the list to settle: either a row or the empty state must appear
-    const firstRow = page.locator('table tbody tr').first()
-    const emptyState = page.getByText(/no users found/i)
-    await expect(firstRow.or(emptyState)).toBeVisible({ timeout: 15_000 })
+    // Wait for the list to settle: a tbody row appears for both real data and the empty state
+    await expect(page.locator('table tbody tr').first()).toBeVisible({ timeout: 15_000 })
   })
 
   test('tenant users are listed in the table when backend returns data', async ({ platformAdminPage: page }) => {
     await navigateTo(page, '/users')
     // Wait for list to settle before inspecting row count
     const firstRow = page.locator('table tbody tr').first()
-    const emptyState = page.getByText(/no users found/i)
-    await expect(firstRow.or(emptyState)).toBeVisible({ timeout: 15_000 })
+    await expect(firstRow).toBeVisible({ timeout: 15_000 })
 
+    const emptyState = page.getByRole('row', { name: /no users found/i })
     if (await emptyState.isVisible()) {
       // No users seeded — table renders without error
       return
@@ -79,9 +77,9 @@ test.describe('Users list - admin access', () => {
     await navigateTo(page, '/users')
     // Wait for list to settle before checking row count
     const firstRow = page.locator('table tbody tr').first()
-    const emptyState = page.getByText(/no users found/i)
-    await expect(firstRow.or(emptyState)).toBeVisible({ timeout: 15_000 })
+    await expect(firstRow).toBeVisible({ timeout: 15_000 })
 
+    const emptyState = page.getByRole('row', { name: /no users found/i })
     if (await emptyState.isVisible()) {
       test.skip()
       return
@@ -104,8 +102,8 @@ test.describe('User detail - suspend dialog', () => {
   async function navigateToFirstUser(page: Page): Promise<boolean> {
     await navigateTo(page, '/users')
     const firstRow = page.locator('table tbody tr').first()
-    const emptyState = page.getByText(/no users found/i)
-    await expect(firstRow.or(emptyState)).toBeVisible({ timeout: 15_000 })
+    await expect(firstRow).toBeVisible({ timeout: 15_000 })
+    const emptyState = page.getByRole('row', { name: /no users found/i })
     if (await emptyState.isVisible()) return false
     await firstRow.click()
     await page.waitForURL(/\/users\/[a-zA-Z0-9-]+/)
@@ -211,7 +209,7 @@ async function mockListIdentities(page: Page) {
   await page.route(`**/meridian.identity.v1.IdentityService/ListIdentities`, (route) => {
     void route.fulfill({
       status: 200,
-      contentType: 'application/json',
+      contentType: 'application/connect+json',
       body: JSON.stringify({
         identities: [
           {
@@ -241,7 +239,7 @@ async function mockRetrieveIdentity(page: Page) {
   await page.route(`**/meridian.identity.v1.IdentityService/RetrieveIdentity`, (route) => {
     void route.fulfill({
       status: 200,
-      contentType: 'application/json',
+      contentType: 'application/connect+json',
       body: JSON.stringify({
         identity: {
           id: 'mock-user-1',
@@ -267,7 +265,7 @@ async function mockListRoleAssignments(page: Page) {
   await page.route(`**/meridian.identity.v1.IdentityService/ListRoleAssignments`, (route) => {
     void route.fulfill({
       status: 200,
-      contentType: 'application/json',
+      contentType: 'application/connect+json',
       body: JSON.stringify({ roleAssignments: [] }),
     })
   })
@@ -342,7 +340,7 @@ test.describe('Suspend API — successful suspend', () => {
       if (suspendCalled) {
         void route.fulfill({
           status: 200,
-          contentType: 'application/json',
+          contentType: 'application/connect+json',
           body: JSON.stringify({
             identity: {
               id: 'mock-user-1',
@@ -361,7 +359,7 @@ test.describe('Suspend API — successful suspend', () => {
       } else {
         void route.fulfill({
           status: 200,
-          contentType: 'application/json',
+          contentType: 'application/connect+json',
           body: JSON.stringify({
             identity: {
               id: 'mock-user-1',
@@ -384,7 +382,7 @@ test.describe('Suspend API — successful suspend', () => {
       suspendCalled = true
       void route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: 'application/connect+json',
         body: JSON.stringify({
           identity: {
             id: 'mock-user-1',

--- a/frontend/e2e/admin-users.spec.ts
+++ b/frontend/e2e/admin-users.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from '@playwright/test'
 import { test, expect, navigateTo } from './fixtures'
 
 /**
@@ -99,7 +100,7 @@ test.describe('User detail - suspend dialog', () => {
    * Navigate to the first available user detail page.
    * Returns false if no users are present (caller should skip the test).
    */
-  async function navigateToFirstUser(page: import('@playwright/test').Page): Promise<boolean> {
+  async function navigateToFirstUser(page: Page): Promise<boolean> {
     await navigateTo(page, '/users')
     await expect(page.locator('table')).toBeVisible()
     const rowCount = await page.locator('table tbody tr').count()
@@ -201,7 +202,7 @@ test.describe('User detail - suspend dialog', () => {
  * Mock the IdentityService to return a single ACTIVE user.
  * Connect JSON protocol: ListIdentities response.
  */
-async function mockListIdentities(page: import('@playwright/test').Page) {
+async function mockListIdentities(page: Page) {
   await page.route(`**/meridian.identity.v1.IdentityService/ListIdentities`, (route) => {
     void route.fulfill({
       status: 200,
@@ -231,7 +232,7 @@ async function mockListIdentities(page: import('@playwright/test').Page) {
 /**
  * Mock RetrieveIdentity to return an ACTIVE user.
  */
-async function mockRetrieveIdentity(page: import('@playwright/test').Page) {
+async function mockRetrieveIdentity(page: Page) {
   await page.route(`**/meridian.identity.v1.IdentityService/RetrieveIdentity`, (route) => {
     void route.fulfill({
       status: 200,
@@ -257,7 +258,7 @@ async function mockRetrieveIdentity(page: import('@playwright/test').Page) {
 /**
  * Mock ListRoleAssignments to return empty roles.
  */
-async function mockListRoleAssignments(page: import('@playwright/test').Page) {
+async function mockListRoleAssignments(page: Page) {
   await page.route(`**/meridian.identity.v1.IdentityService/ListRoleAssignments`, (route) => {
     void route.fulfill({
       status: 200,

--- a/frontend/e2e/admin-users.spec.ts
+++ b/frontend/e2e/admin-users.spec.ts
@@ -51,7 +51,16 @@ test.describe('Users list - admin access', () => {
   test('platform admin appears in the users list after login', async ({ platformAdminPage: page }) => {
     await navigateTo(page, '/users')
     // Wait for the list to settle: a tbody row appears for both real data and the empty state
-    await expect(page.locator('table tbody tr').first()).toBeVisible({ timeout: 15_000 })
+    const firstRow = page.locator('table tbody tr').first()
+    await expect(firstRow).toBeVisible({ timeout: 15_000 })
+
+    // If no users seeded, the empty state row is still a valid outcome
+    const emptyState = page.getByRole('row', { name: /no users found/i })
+    if (await emptyState.isVisible()) return
+
+    // At least one real user row visible
+    const firstEmailCell = firstRow.locator('td').first()
+    await expect(firstEmailCell).not.toBeEmpty()
   })
 
   test('tenant users are listed in the table when backend returns data', async ({ platformAdminPage: page }) => {
@@ -209,7 +218,7 @@ async function mockListIdentities(page: Page) {
   await page.route(`**/meridian.identity.v1.IdentityService/ListIdentities`, (route) => {
     void route.fulfill({
       status: 200,
-      contentType: 'application/connect+json',
+      contentType: 'application/json',
       body: JSON.stringify({
         identities: [
           {
@@ -239,7 +248,7 @@ async function mockRetrieveIdentity(page: Page) {
   await page.route(`**/meridian.identity.v1.IdentityService/RetrieveIdentity`, (route) => {
     void route.fulfill({
       status: 200,
-      contentType: 'application/connect+json',
+      contentType: 'application/json',
       body: JSON.stringify({
         identity: {
           id: 'mock-user-1',
@@ -265,7 +274,7 @@ async function mockListRoleAssignments(page: Page) {
   await page.route(`**/meridian.identity.v1.IdentityService/ListRoleAssignments`, (route) => {
     void route.fulfill({
       status: 200,
-      contentType: 'application/connect+json',
+      contentType: 'application/json',
       body: JSON.stringify({ roleAssignments: [] }),
     })
   })
@@ -340,7 +349,7 @@ test.describe('Suspend API — successful suspend', () => {
       if (suspendCalled) {
         void route.fulfill({
           status: 200,
-          contentType: 'application/connect+json',
+          contentType: 'application/json',
           body: JSON.stringify({
             identity: {
               id: 'mock-user-1',
@@ -359,7 +368,7 @@ test.describe('Suspend API — successful suspend', () => {
       } else {
         void route.fulfill({
           status: 200,
-          contentType: 'application/connect+json',
+          contentType: 'application/json',
           body: JSON.stringify({
             identity: {
               id: 'mock-user-1',
@@ -382,7 +391,7 @@ test.describe('Suspend API — successful suspend', () => {
       suspendCalled = true
       void route.fulfill({
         status: 200,
-        contentType: 'application/connect+json',
+        contentType: 'application/json',
         body: JSON.stringify({
           identity: {
             id: 'mock-user-1',

--- a/frontend/e2e/admin-users.spec.ts
+++ b/frontend/e2e/admin-users.spec.ts
@@ -212,13 +212,17 @@ test.describe('User detail - suspend dialog', () => {
 
 /**
  * Mock the IdentityService to return a single ACTIVE user.
- * Connect JSON protocol: ListIdentities response.
+ *
+ * Connect protocol unary success responses require Content-Type:
+ * application/connect+json (not application/json). The Connect-ES client
+ * rejects plain application/json 200 responses as parse errors.
+ * Error responses (4xx/5xx) use application/json per the Connect spec.
  */
 async function mockListIdentities(page: Page) {
   await page.route(/IdentityService\/ListIdentities/, (route) => {
     void route.fulfill({
       status: 200,
-      contentType: 'application/json',
+      contentType: 'application/connect+json',
       body: JSON.stringify({
         identities: [
           {
@@ -248,7 +252,7 @@ async function mockRetrieveIdentity(page: Page) {
   await page.route(/IdentityService\/RetrieveIdentity/, (route) => {
     void route.fulfill({
       status: 200,
-      contentType: 'application/json',
+      contentType: 'application/connect+json',
       body: JSON.stringify({
         identity: {
           id: 'mock-user-1',
@@ -274,7 +278,7 @@ async function mockListRoleAssignments(page: Page) {
   await page.route(/IdentityService\/ListRoleAssignments/, (route) => {
     void route.fulfill({
       status: 200,
-      contentType: 'application/json',
+      contentType: 'application/connect+json',
       body: JSON.stringify({ roleAssignments: [] }),
     })
   })
@@ -349,7 +353,7 @@ test.describe('Suspend API — successful suspend', () => {
       if (suspendCalled) {
         void route.fulfill({
           status: 200,
-          contentType: 'application/json',
+          contentType: 'application/connect+json',
           body: JSON.stringify({
             identity: {
               id: 'mock-user-1',
@@ -368,7 +372,7 @@ test.describe('Suspend API — successful suspend', () => {
       } else {
         void route.fulfill({
           status: 200,
-          contentType: 'application/json',
+          contentType: 'application/connect+json',
           body: JSON.stringify({
             identity: {
               id: 'mock-user-1',
@@ -391,7 +395,7 @@ test.describe('Suspend API — successful suspend', () => {
       suspendCalled = true
       void route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: 'application/connect+json',
         body: JSON.stringify({
           identity: {
             id: 'mock-user-1',

--- a/frontend/e2e/admin-users.spec.ts
+++ b/frontend/e2e/admin-users.spec.ts
@@ -145,8 +145,8 @@ test.describe('User detail - suspend dialog', () => {
     if (!found) { test.skip(); return }
 
     const suspendBtn = page.getByRole('button', { name: /^suspend$/i })
-    // Wait for detail page to settle before checking if suspend button is present
-    await page.waitForLoadState('networkidle').catch(() => {/* ignore timeout */})
+    // Wait for the detail page to finish loading (skeleton disappears)
+    await expect(page.getByTestId('detail-skeleton')).toBeHidden({ timeout: 15_000 }).catch(() => {})
     if (await suspendBtn.isHidden()) {
       // User is not ACTIVE (e.g. already suspended) — skip
       test.skip()

--- a/frontend/e2e/admin-users.spec.ts
+++ b/frontend/e2e/admin-users.spec.ts
@@ -145,8 +145,8 @@ test.describe('User detail - suspend dialog', () => {
     if (!found) { test.skip(); return }
 
     const suspendBtn = page.getByRole('button', { name: /^suspend$/i })
-    // Wait for the detail page to finish loading (skeleton disappears)
-    await expect(page.getByTestId('detail-skeleton')).toBeHidden({ timeout: 15_000 }).catch(() => {})
+    // Wait for the Identity Details card to appear (confirms detail page is loaded)
+    await expect(page.getByText('Identity Details')).toBeVisible({ timeout: 15_000 })
     if (await suspendBtn.isHidden()) {
       // User is not ACTIVE (e.g. already suspended) — skip
       test.skip()
@@ -167,7 +167,8 @@ test.describe('User detail - suspend dialog', () => {
     if (!found) { test.skip(); return }
 
     const suspendBtn = page.getByRole('button', { name: /^suspend$/i })
-    await page.waitForLoadState('networkidle').catch(() => {/* ignore timeout */})
+    // Wait for the Identity Details card — confirms the detail page has fully loaded
+    await expect(page.getByText('Identity Details')).toBeVisible({ timeout: 15_000 })
     if (await suspendBtn.isHidden()) { test.skip(); return }
 
     await suspendBtn.click()
@@ -185,7 +186,8 @@ test.describe('User detail - suspend dialog', () => {
     if (!found) { test.skip(); return }
 
     const suspendBtn = page.getByRole('button', { name: /^suspend$/i })
-    await page.waitForLoadState('networkidle').catch(() => {/* ignore timeout */})
+    // Wait for the Identity Details card — confirms the detail page has fully loaded
+    await expect(page.getByText('Identity Details')).toBeVisible({ timeout: 15_000 })
     if (await suspendBtn.isHidden()) { test.skip(); return }
 
     await suspendBtn.click()

--- a/frontend/e2e/admin-users.spec.ts
+++ b/frontend/e2e/admin-users.spec.ts
@@ -215,7 +215,7 @@ test.describe('User detail - suspend dialog', () => {
  * Connect JSON protocol: ListIdentities response.
  */
 async function mockListIdentities(page: Page) {
-  await page.route(`**/meridian.identity.v1.IdentityService/ListIdentities`, (route) => {
+  await page.route(/IdentityService\/ListIdentities/, (route) => {
     void route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -245,7 +245,7 @@ async function mockListIdentities(page: Page) {
  * Mock RetrieveIdentity to return an ACTIVE user.
  */
 async function mockRetrieveIdentity(page: Page) {
-  await page.route(`**/meridian.identity.v1.IdentityService/RetrieveIdentity`, (route) => {
+  await page.route(/IdentityService\/RetrieveIdentity/, (route) => {
     void route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -271,7 +271,7 @@ async function mockRetrieveIdentity(page: Page) {
  * Mock ListRoleAssignments to return empty roles.
  */
 async function mockListRoleAssignments(page: Page) {
-  await page.route(`**/meridian.identity.v1.IdentityService/ListRoleAssignments`, (route) => {
+  await page.route(/IdentityService\/ListRoleAssignments/, (route) => {
     void route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -287,7 +287,7 @@ test.describe('Suspend API — 403 permission denied', () => {
     await mockListRoleAssignments(page)
 
     // Mock SuspendIdentity to return 403 PermissionDenied
-    await page.route(`**/meridian.identity.v1.IdentityService/SuspendIdentity`, (route) => {
+    await page.route(/IdentityService\/SuspendIdentity/, (route) => {
       void route.fulfill({
         status: 403,
         contentType: 'application/json',
@@ -345,7 +345,7 @@ test.describe('Suspend API — successful suspend', () => {
 
     // First RetrieveIdentity returns ACTIVE, post-suspend returns SUSPENDED
     let suspendCalled = false
-    await page.route(`**/meridian.identity.v1.IdentityService/RetrieveIdentity`, (route) => {
+    await page.route(/IdentityService\/RetrieveIdentity/, (route) => {
       if (suspendCalled) {
         void route.fulfill({
           status: 200,
@@ -387,7 +387,7 @@ test.describe('Suspend API — successful suspend', () => {
       }
     })
 
-    await page.route(`**/meridian.identity.v1.IdentityService/SuspendIdentity`, (route) => {
+    await page.route(/IdentityService\/SuspendIdentity/, (route) => {
       suspendCalled = true
       void route.fulfill({
         status: 200,
@@ -439,7 +439,7 @@ test.describe('Suspend API — 401 unauthenticated', () => {
     await mockListRoleAssignments(page)
 
     // Mock SuspendIdentity to return 401 Unauthenticated
-    await page.route(`**/meridian.identity.v1.IdentityService/SuspendIdentity`, (route) => {
+    await page.route(/IdentityService\/SuspendIdentity/, (route) => {
       void route.fulfill({
         status: 401,
         contentType: 'application/json',
@@ -469,7 +469,7 @@ test.describe('Suspend API — 401 unauthenticated', () => {
     await mockRetrieveIdentity(page)
     await mockListRoleAssignments(page)
 
-    await page.route(`**/meridian.identity.v1.IdentityService/SuspendIdentity`, (route) => {
+    await page.route(/IdentityService\/SuspendIdentity/, (route) => {
       void route.fulfill({
         status: 401,
         contentType: 'application/json',

--- a/frontend/e2e/admin-users.spec.ts
+++ b/frontend/e2e/admin-users.spec.ts
@@ -39,6 +39,8 @@ test.describe('Users list - admin access', () => {
     await expect(page.getByRole('columnheader', { name: 'Email' })).toBeVisible()
     await expect(page.getByRole('columnheader', { name: 'Status' })).toBeVisible()
     await expect(page.getByRole('columnheader', { name: 'MFA' })).toBeVisible()
+    await expect(page.getByRole('columnheader', { name: 'Last Login' })).toBeVisible()
+    await expect(page.getByRole('columnheader', { name: 'Created' })).toBeVisible()
   })
 
   test('shows status filter dropdown', async ({ platformAdminPage: page }) => {
@@ -48,47 +50,44 @@ test.describe('Users list - admin access', () => {
 
   test('platform admin appears in the users list after login', async ({ platformAdminPage: page }) => {
     await navigateTo(page, '/users')
-    // The table must be present — either loading, empty, or populated
-    await expect(page.locator('table')).toBeVisible()
-    // If users are returned by the backend, at least one row must render
-    const rowCount = await page.locator('table tbody tr').count()
-    if (rowCount > 0) {
-      await expect(page.locator('table tbody tr').first()).toBeVisible()
-    } else {
-      // Empty state is also valid — UI renders without error
-      await expect(page.getByText('No users found').or(page.locator('table'))).toBeVisible({ timeout: 15_000 })
-    }
+    // Wait for the list to settle: either a row or the empty state must appear
+    const firstRow = page.locator('table tbody tr').first()
+    const emptyState = page.getByText(/no users found/i)
+    await expect(firstRow.or(emptyState)).toBeVisible({ timeout: 15_000 })
   })
 
   test('tenant users are listed in the table when backend returns data', async ({ platformAdminPage: page }) => {
     await navigateTo(page, '/users')
-    await expect(page.locator('table')).toBeVisible()
+    // Wait for list to settle before inspecting row count
+    const firstRow = page.locator('table tbody tr').first()
+    const emptyState = page.getByText(/no users found/i)
+    await expect(firstRow.or(emptyState)).toBeVisible({ timeout: 15_000 })
 
-    const rowCount = await page.locator('table tbody tr').count()
-    if (rowCount === 0) {
+    if (await emptyState.isVisible()) {
       // No users seeded — table renders without error
-      await expect(page.getByText(/no users found/i).or(page.locator('table tbody'))).toBeVisible({ timeout: 15_000 })
       return
     }
 
     // At least one user row visible — verify it has an email cell
-    await expect(page.locator('table tbody tr').first()).toBeVisible()
+    await expect(firstRow).toBeVisible()
     // Email column renders a value (non-empty cell)
-    const firstEmailCell = page.locator('table tbody tr').first().locator('td').first()
+    const firstEmailCell = firstRow.locator('td').first()
     await expect(firstEmailCell).not.toBeEmpty()
   })
 
   test('row click navigates to user detail page', async ({ platformAdminPage: page }) => {
     await navigateTo(page, '/users')
-    await expect(page.locator('table')).toBeVisible()
+    // Wait for list to settle before checking row count
+    const firstRow = page.locator('table tbody tr').first()
+    const emptyState = page.getByText(/no users found/i)
+    await expect(firstRow.or(emptyState)).toBeVisible({ timeout: 15_000 })
 
-    const rowCount = await page.locator('table tbody tr').count()
-    if (rowCount === 0) {
+    if (await emptyState.isVisible()) {
       test.skip()
       return
     }
 
-    await page.locator('table tbody tr').first().click()
+    await firstRow.click()
     await expect(page).toHaveURL(/\/users\/[a-zA-Z0-9-]+/)
   })
 })
@@ -99,13 +98,16 @@ test.describe('User detail - suspend dialog', () => {
   /**
    * Navigate to the first available user detail page.
    * Returns false if no users are present (caller should skip the test).
+   * Waits for the list to settle before checking for rows to avoid acting
+   * before the API response arrives.
    */
   async function navigateToFirstUser(page: Page): Promise<boolean> {
     await navigateTo(page, '/users')
-    await expect(page.locator('table')).toBeVisible()
-    const rowCount = await page.locator('table tbody tr').count()
-    if (rowCount === 0) return false
-    await page.locator('table tbody tr').first().click()
+    const firstRow = page.locator('table tbody tr').first()
+    const emptyState = page.getByText(/no users found/i)
+    await expect(firstRow.or(emptyState)).toBeVisible({ timeout: 15_000 })
+    if (await emptyState.isVisible()) return false
+    await firstRow.click()
     await page.waitForURL(/\/users\/[a-zA-Z0-9-]+/)
     return true
   }
@@ -136,8 +138,9 @@ test.describe('User detail - suspend dialog', () => {
     if (!found) { test.skip(); return }
 
     const suspendBtn = page.getByRole('button', { name: /^suspend$/i })
-    const hasSuspendBtn = await suspendBtn.isVisible()
-    if (!hasSuspendBtn) {
+    // Wait for detail page to settle before checking if suspend button is present
+    await page.waitForLoadState('networkidle').catch(() => {/* ignore timeout */})
+    if (await suspendBtn.isHidden()) {
       // User is not ACTIVE (e.g. already suspended) — skip
       test.skip()
       return
@@ -157,7 +160,8 @@ test.describe('User detail - suspend dialog', () => {
     if (!found) { test.skip(); return }
 
     const suspendBtn = page.getByRole('button', { name: /^suspend$/i })
-    if (!await suspendBtn.isVisible()) { test.skip(); return }
+    await page.waitForLoadState('networkidle').catch(() => {/* ignore timeout */})
+    if (await suspendBtn.isHidden()) { test.skip(); return }
 
     await suspendBtn.click()
 
@@ -174,7 +178,8 @@ test.describe('User detail - suspend dialog', () => {
     if (!found) { test.skip(); return }
 
     const suspendBtn = page.getByRole('button', { name: /^suspend$/i })
-    if (!await suspendBtn.isVisible()) { test.skip(); return }
+    await page.waitForLoadState('networkidle').catch(() => {/* ignore timeout */})
+    if (await suspendBtn.isHidden()) { test.skip(); return }
 
     await suspendBtn.click()
 
@@ -327,12 +332,11 @@ test.describe('Suspend API — 403 permission denied', () => {
 })
 
 test.describe('Suspend API — successful suspend', () => {
-  test('closes dialog and page stays on user detail after successful suspend', async ({ platformAdminPage: page }) => {
+  test('closes dialog and shows suspended state after successful suspend', async ({ platformAdminPage: page }) => {
     await mockListIdentities(page)
     await mockListRoleAssignments(page)
-    await mockRetrieveIdentity(page)
 
-    // First call returns ACTIVE, after suspend it returns SUSPENDED
+    // First RetrieveIdentity returns ACTIVE, post-suspend returns SUSPENDED
     let suspendCalled = false
     await page.route(`**/meridian.identity.v1.IdentityService/RetrieveIdentity`, (route) => {
       if (suspendCalled) {
@@ -412,6 +416,12 @@ test.describe('Suspend API — successful suspend', () => {
 
     // URL stays on user detail
     await expect(page).toHaveURL(/\/users\/mock-user-1/)
+
+    // Post-suspend: the page refetches and renders the SUSPENDED status badge.
+    // The Suspend button disappears (user is no longer ACTIVE).
+    await expect(page.getByRole('button', { name: /^suspend$/i })).toBeHidden({ timeout: 10_000 })
+    // The SUSPENDED status badge must be visible after the query invalidation.
+    await expect(page.getByText('SUSPENDED')).toBeVisible({ timeout: 10_000 })
   })
 })
 
@@ -443,11 +453,11 @@ test.describe('Suspend API — 401 unauthenticated', () => {
     await dialog.getByRole('button', { name: 'Suspend User' }).click()
 
     // Auth interceptor calls onUnauthenticated → logout() → token cleared →
-    // ProtectedRoute redirects to /login. The toast also fires.
+    // ProtectedRoute redirects to /login.
     await expect(page).toHaveURL('/login', { timeout: 10_000 })
   })
 
-  test('session expiry toast appears before redirect on 401', async ({ platformAdminPage: page }) => {
+  test('session expiry toast appears on 401 before redirect', async ({ platformAdminPage: page }) => {
     await mockListIdentities(page)
     await mockRetrieveIdentity(page)
     await mockListRoleAssignments(page)
@@ -472,11 +482,15 @@ test.describe('Suspend API — 401 unauthenticated', () => {
     await dialog.getByLabel('Reason').fill('Compliance review')
     await dialog.getByRole('button', { name: 'Suspend User' }).click()
 
-    // The session expiry error toast fires from withToastErrorHandling
-    // before the auth state clears and ProtectedRoute redirects.
-    // Because the redirect is fast, check URL destination.
+    // The session expiry error toast fires from withToastErrorHandling.
+    // Capture the toast before the redirect clears the DOM.
+    await expect(
+      page.getByText(/your session has expired/i),
+    ).toBeVisible({ timeout: 5_000 })
+
+    // Auth state clears and ProtectedRoute redirects to /login
     await expect(page).toHaveURL('/login', { timeout: 10_000 })
-    // Login page must render (confirms redirect completed, not a blank page)
+    // Login page renders after redirect
     await expect(page.getByRole('heading', { name: 'Meridian Operations Console' })).toBeVisible()
   })
 })

--- a/frontend/e2e/admin-users.spec.ts
+++ b/frontend/e2e/admin-users.spec.ts
@@ -213,16 +213,16 @@ test.describe('User detail - suspend dialog', () => {
 /**
  * Mock the IdentityService to return a single ACTIVE user.
  *
- * Connect protocol unary success responses require Content-Type:
- * application/connect+json (not application/json). The Connect-ES client
- * rejects plain application/json 200 responses as parse errors.
- * Error responses (4xx/5xx) use application/json per the Connect spec.
+ * Connect protocol unary responses use Content-Type: application/json
+ * (not application/connect+json — that's for streaming only).
+ * See @connectrpc/connect content-type.ts: contentTypeUnaryJson = "application/json".
+ * Error responses also use application/json per the Connect spec.
  */
 async function mockListIdentities(page: Page) {
   await page.route(/IdentityService\/ListIdentities/, (route) => {
     void route.fulfill({
       status: 200,
-      contentType: 'application/connect+json',
+      contentType: 'application/json',
       body: JSON.stringify({
         identities: [
           {
@@ -233,8 +233,8 @@ async function mockListIdentities(page: Page) {
             failedAttempts: 0,
             externalIdp: '',
             externalIdpSub: '',
-            createdAt: { seconds: '1699000000', nanos: 0 },
-            updatedAt: { seconds: '1700000000', nanos: 0 },
+            createdAt: '2023-11-03T12:26:40Z',
+            updatedAt: '2023-11-15T12:26:40Z',
             version: 1,
           },
         ],
@@ -252,7 +252,7 @@ async function mockRetrieveIdentity(page: Page) {
   await page.route(/IdentityService\/RetrieveIdentity/, (route) => {
     void route.fulfill({
       status: 200,
-      contentType: 'application/connect+json',
+      contentType: 'application/json',
       body: JSON.stringify({
         identity: {
           id: 'mock-user-1',
@@ -262,8 +262,8 @@ async function mockRetrieveIdentity(page: Page) {
           failedAttempts: 0,
           externalIdp: '',
           externalIdpSub: '',
-          createdAt: { seconds: '1699000000', nanos: 0 },
-          updatedAt: { seconds: '1700000000', nanos: 0 },
+          createdAt: '2023-11-03T12:26:40Z',
+          updatedAt: '2023-11-15T12:26:40Z',
           version: 1,
         },
       }),
@@ -278,7 +278,7 @@ async function mockListRoleAssignments(page: Page) {
   await page.route(/IdentityService\/ListRoleAssignments/, (route) => {
     void route.fulfill({
       status: 200,
-      contentType: 'application/connect+json',
+      contentType: 'application/json',
       body: JSON.stringify({ roleAssignments: [] }),
     })
   })
@@ -353,7 +353,7 @@ test.describe('Suspend API — successful suspend', () => {
       if (suspendCalled) {
         void route.fulfill({
           status: 200,
-          contentType: 'application/connect+json',
+          contentType: 'application/json',
           body: JSON.stringify({
             identity: {
               id: 'mock-user-1',
@@ -363,8 +363,8 @@ test.describe('Suspend API — successful suspend', () => {
               failedAttempts: 0,
               externalIdp: '',
               externalIdpSub: '',
-              createdAt: { seconds: '1699000000', nanos: 0 },
-              updatedAt: { seconds: '1700000001', nanos: 0 },
+              createdAt: '2023-11-03T12:26:40Z',
+              updatedAt: '2023-11-15T12:26:41Z',
               version: 2,
             },
           }),
@@ -372,7 +372,7 @@ test.describe('Suspend API — successful suspend', () => {
       } else {
         void route.fulfill({
           status: 200,
-          contentType: 'application/connect+json',
+          contentType: 'application/json',
           body: JSON.stringify({
             identity: {
               id: 'mock-user-1',
@@ -382,8 +382,8 @@ test.describe('Suspend API — successful suspend', () => {
               failedAttempts: 0,
               externalIdp: '',
               externalIdpSub: '',
-              createdAt: { seconds: '1699000000', nanos: 0 },
-              updatedAt: { seconds: '1700000000', nanos: 0 },
+              createdAt: '2023-11-03T12:26:40Z',
+              updatedAt: '2023-11-15T12:26:40Z',
               version: 1,
             },
           }),
@@ -395,7 +395,7 @@ test.describe('Suspend API — successful suspend', () => {
       suspendCalled = true
       void route.fulfill({
         status: 200,
-        contentType: 'application/connect+json',
+        contentType: 'application/json',
         body: JSON.stringify({
           identity: {
             id: 'mock-user-1',
@@ -405,8 +405,8 @@ test.describe('Suspend API — successful suspend', () => {
             failedAttempts: 0,
             externalIdp: '',
             externalIdpSub: '',
-            createdAt: { seconds: '1699000000', nanos: 0 },
-            updatedAt: { seconds: '1700000001', nanos: 0 },
+            createdAt: '2023-11-03T12:26:40Z',
+            updatedAt: '2023-11-15T12:26:41Z',
             version: 2,
           },
         }),


### PR DESCRIPTION
## Summary

- Adds Playwright E2E tests for admin user management (`/users` and `/users/:userId`)
- Covers user list rendering, suspend dialog lifecycle, and API error handling (403/401)
- Uses `page.route()` to mock gRPC-web calls in Connect JSON format so error-path tests run without a live backend

## Changes Made

- `frontend/e2e/admin-users.spec.ts` — new E2E test file (19 tests across 5 describe blocks)

### Test coverage

| Scenario | Approach |
|----------|----------|
| Users list renders for platform admin | Live (graceful when backend unavailable) |
| User table columns and status filter | Structure assertion |
| Non-admin redirect from `/users` | Via `authenticatedPage` fixture |
| Suspend dialog opens, requires reason, closes on Cancel | Via conditional navigation to first user row |
| 403 PermissionDenied → toast, no redirect | `page.route()` mock |
| Successful suspend → dialog closes, stays on page | `page.route()` mock |
| 401 Unauthenticated → auth cleared, redirects to `/login` | `page.route()` mock |

## Technical Details

- Connect-ES in dev/E2E mode uses JSON (`useBinaryFormat: false`), so `page.route()` intercepts with `application/json` responses using the Connect error shape `{"code":"<snake_case>","message":"..."}`
- 401 redirect path: auth interceptor calls `onUnauthenticated` → `logout()` → token cleared → `ProtectedRoute` redirects to `/login`
- Follows existing patterns: `platformAdminPage` fixture, `navigateTo()` helper, conditional `test.skip()` for data-dependent paths

## Test plan

- [ ] `npx playwright test e2e/admin-users.spec.ts --list` lists 19 tests (verified)
- [ ] TypeScript compiles without errors (verified)
- [ ] CI E2E shard run passes