### PR TITLE
docs: address review feedback on PRDs 041 and 042

### DIFF
--- a/docs/prd/041-economy-generator.md
+++ b/docs/prd/041-economy-generator.md
@@ -412,10 +412,17 @@ For modifying existing economies. Adds current state awareness:
 1. Load current manifest via `meridian_economy_structure`
 2. Load relationship graph via `meridian_economy_graph`
 3. Assemble context including current state
-4. Generate **diff instructions**: what to add, modify, remove
-5. Apply diff to current manifest
-6. Validate-fix loop (with destructive change detection)
-7. Return result with impact analysis
+4. Generate a **complete replacement manifest** incorporating the requested
+   changes (the LLM outputs a full manifest, not patches or instructions)
+5. Validate-fix loop (with destructive change detection)
+6. Return result with impact analysis (diff between current and proposed)
+
+**Output format**: Amend mode produces a full replacement manifest, not JSON
+patches or diff instructions. The LLM receives the current manifest and the
+change request, then outputs a complete new manifest. The backend diffs the
+current vs proposed manifest to produce the impact analysis and detect
+destructive changes. This is simpler and more reliable than asking the LLM
+to produce structured patches.
 
 Amend mode is harder than create — the LLM must understand the existing economy
 and produce changes that don't break running operations. The relationship graph

--- a/docs/prd/042-economy-ide.md
+++ b/docs/prd/042-economy-ide.md
@@ -579,13 +579,15 @@ Compose pending modifications before creating a new manifest version.
 - Draft merge: combine pending changes into candidate manifest
 - Aggregate plan diff (current version vs candidate)
 - Apply creates new immutable manifest version
-- Draft permalink for sharing
 - Route: `/economy/draft`
 
 ### Phase 8: Team Review (Optional Enhancement)
 
-Four-eye principle for manifest changes.
+Four-eye principle for manifest changes. Requires server-side draft
+storage (migrates from browser-local to server-persisted drafts).
 
+- Server-side draft persistence (replaces localStorage)
+- Draft permalink for sharing (requires server-side storage)
 - Draft review workflow: drafter submits, reviewer approves
 - Audit trail: who drafted, who reviewed, timestamps
 - Configurable: can disable four-eye for solo operators
@@ -671,10 +673,10 @@ two PRDs can run in parallel.
    or only on explicit "Validate" button click? (Recommendation: debounced at
    500ms for a responsive feel, with explicit button as fallback.)
 
-5. **Draft persistence**: Should drafts be stored in the browser (localStorage)
-   or on the server? Browser storage is simpler and works offline; server
-   storage enables sharing and survives browser clears. (Recommendation:
-   browser-local for v1, server-side in Phase 8 when team review is added.)
+5. **Draft persistence**: Phase 7 uses browser-local storage (localStorage)
+   for simplicity. Phase 8 migrates to server-side storage when team review
+   requires draft sharing via permalinks. Browser storage works offline but
+   cannot support cross-user sharing.
 
 6. **Four-eye enforcement**: Should the four-eye review be a hard gate
    (cannot apply without reviewer) or soft (warning but allowed)?


### PR DESCRIPTION
## Summary

- **PRD-041**: Clarify amend mode output format — LLM produces a complete replacement manifest, not patches or diff instructions. Backend diffs current vs proposed for impact analysis.
- **PRD-042**: Move draft permalink sharing from Phase 7 (browser-local) to Phase 8 (server-side storage) since cross-user sharing requires server persistence.

These changes address claude[bot] review feedback from PR #1572 that was merged before the fixes were pushed.

## Test plan

- [ ] Verify markdown lint passes
- [ ] Verify no contradictions between PRD-041 amend pipeline and output format description
- [ ] Verify PRD-042 Phase 7/8 split is consistent with open question 5