### PR TITLE
feat: add economy feature module structure, core hooks, and graph panel

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ import { McpConfigPage } from '@/features/mcp-config'
 import { TransactionsPage } from '@/features/transactions'
 import { UsersListPage, UserDetailPage } from '@/features/identity'
 import { CookbookPage } from '@/features/cookbook'
+import { EconomyOverviewPage, EconomyCreatePage, EconomyEditPage, EconomyExplorePage, EconomyDraftPage } from '@/features/economy'
 
 const CookbookPatternsPage = lazy(() =>
   import('@/features/cookbook/pages/patterns').then((m) => ({ default: m.CookbookPatternsPage })),
@@ -319,6 +320,11 @@ function AppShellLayout() {
         <Route path="/reference-data/nodes" element={<FeatureGuard feature="reference-data">{guarded(<NodesPage />)}</FeatureGuard>} />
         <Route path="/gateway-mappings" element={<FeatureGuard feature="mappings">{guarded(<MappingsPage />)}</FeatureGuard>} />
         <Route path="/gateway-mappings/:mappingId" element={<FeatureGuard feature="mappings">{guarded(<MappingDetailPage />)}</FeatureGuard>} />
+        <Route path="/economy" element={<FeatureGuard feature="economy">{guarded(<EconomyOverviewPage />)}</FeatureGuard>} />
+        <Route path="/economy/create" element={<FeatureGuard feature="economy">{guarded(<EconomyCreatePage />)}</FeatureGuard>} />
+        <Route path="/economy/edit" element={<FeatureGuard feature="economy">{guarded(<EconomyEditPage />)}</FeatureGuard>} />
+        <Route path="/economy/explore" element={<FeatureGuard feature="economy">{guarded(<EconomyExplorePage />)}</FeatureGuard>} />
+        <Route path="/economy/draft" element={<FeatureGuard feature="economy">{guarded(<EconomyDraftPage />)}</FeatureGuard>} />
         <Route path="/manifests" element={<FeatureGuard feature="manifests">{guarded(<ManifestsPage />)}</FeatureGuard>} />
         <Route path="/mcp-config" element={<FeatureGuard feature="mcp-config">{guarded(<McpConfigPage />)}</FeatureGuard>} />
         <Route path="/cookbook" element={guarded(<CookbookPage />)} />

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -21,6 +21,7 @@ import {
   FileJson,
   Bot,
   Library,
+  Boxes,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useTenantFeatures } from '@/hooks/use-tenant-features'
@@ -61,6 +62,7 @@ const TENANT_NAV_GROUPS: NavGroup[] = [
       { label: 'Forecasting', href: '/forecasting', icon: BarChart3, feature: 'forecasting' },
       { label: 'Reference Data', href: '/reference-data', icon: Database, feature: 'reference-data' },
       { label: 'Gateway Mappings', href: '/gateway-mappings', icon: Map, feature: 'mappings' },
+      { label: 'Economy', href: '/economy', icon: Boxes, feature: 'economy' },
       { label: 'Manifests', href: '/manifests', icon: FileJson, feature: 'manifests' },
       { label: 'MCP Config', href: '/mcp-config', icon: Bot, feature: 'mcp-config' },
       { label: 'Cookbook', href: '/cookbook', icon: Library },

--- a/frontend/src/features/economy/components/editor-graph-panel.tsx
+++ b/frontend/src/features/economy/components/editor-graph-panel.tsx
@@ -1,0 +1,45 @@
+import { cn } from '@/lib/utils'
+import { ManifestGraph } from '@/features/manifests/components/manifest-graph'
+import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
+
+interface EditorGraphPanelProps {
+  manifest: Manifest | null
+  validationPassed: boolean
+  className?: string
+}
+
+export function EditorGraphPanel({
+  manifest,
+  validationPassed,
+  className,
+}: EditorGraphPanelProps) {
+  if (!manifest) {
+    return (
+      <div
+        className={cn(
+          'flex items-center justify-center rounded-lg border border-dashed bg-muted/20 text-sm text-muted-foreground',
+          className,
+        )}
+      >
+        No valid manifest to visualize
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn('relative rounded-lg border', className)}>
+      {!validationPassed && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-background/60 backdrop-blur-[1px]">
+          <span className="rounded-md bg-muted px-3 py-1.5 text-xs font-medium text-muted-foreground">
+            Graph stale -- fix validation errors to update
+          </span>
+        </div>
+      )}
+      <div
+        className={cn(!validationPassed && 'pointer-events-none opacity-50')}
+      >
+        <ManifestGraph manifest={manifest} className="h-full w-full" />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/economy/hooks/use-manifest-plan.ts
+++ b/frontend/src/features/economy/hooks/use-manifest-plan.ts
@@ -1,0 +1,67 @@
+import { useMutation } from '@tanstack/react-query'
+import { useApiClients } from '@/api/context'
+import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
+import type {
+  ApplyManifestResponse,
+  StepResult,
+  ValidationError,
+} from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+import { ApplyManifestStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+
+export interface ManifestPlan {
+  /** The raw response status. */
+  status: ApplyManifestStatus
+  /** Human-readable diff summary from the server. */
+  diffSummary: string
+  /** Individual step results from the dry-run. */
+  stepResults: StepResult[]
+  /** Validation errors encountered during planning. */
+  validationErrors: ValidationError[]
+  /** Counts parsed from the diff summary. */
+  counts: {
+    add: number
+    modify: number
+    remove: number
+  }
+}
+
+function parseDiffCounts(diffSummary: string): { add: number; modify: number; remove: number } {
+  const add = parseInt(diffSummary.match(/(\d+)\s*add/i)?.[1] ?? '0', 10)
+  const modify = parseInt(diffSummary.match(/(\d+)\s*modif/i)?.[1] ?? '0', 10)
+  const remove = parseInt(diffSummary.match(/(\d+)\s*(?:remove|delet)/i)?.[1] ?? '0', 10)
+  return { add, modify, remove }
+}
+
+function toManifestPlan(response: ApplyManifestResponse): ManifestPlan {
+  return {
+    status: response.status,
+    diffSummary: response.diffSummary,
+    stepResults: response.stepResults,
+    validationErrors: response.validationErrors,
+    counts: parseDiffCounts(response.diffSummary),
+  }
+}
+
+export function useManifestPlan() {
+  const { manifestApplier } = useApiClients()
+
+  const mutation = useMutation({
+    mutationFn: async (manifest: Manifest): Promise<ManifestPlan> => {
+      const response = await manifestApplier.applyManifest({
+        manifest,
+        dryRun: true,
+        force: false,
+        appliedBy: '',
+      })
+      return toManifestPlan(response)
+    },
+  })
+
+  return {
+    plan: mutation.data ?? null,
+    planManifest: mutation.mutate,
+    planManifestAsync: mutation.mutateAsync,
+    isPlanning: mutation.isPending,
+    error: mutation.error,
+  }
+}

--- a/frontend/src/features/economy/hooks/use-manifest-plan.ts
+++ b/frontend/src/features/economy/hooks/use-manifest-plan.ts
@@ -6,7 +6,7 @@ import type {
   StepResult,
   ValidationError,
 } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
-import { ApplyManifestStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+import type { ApplyManifestStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
 
 export interface ManifestPlan {
   /** The raw response status. */

--- a/frontend/src/features/economy/hooks/use-manifest-validate.ts
+++ b/frontend/src/features/economy/hooks/use-manifest-validate.ts
@@ -5,7 +5,7 @@ import type {
   ApplyManifestResponse,
   ValidationError,
 } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
-import { ApplyManifestStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+import { ApplyManifestStatus, StepResultStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
 
 export interface ValidationResult {
   errors: ValidationError[]
@@ -68,7 +68,7 @@ export function useManifestValidate() {
               // The status indicates failure but no structured errors came back;
               // surface step-level messages as errors.
               for (const step of response.stepResults) {
-                if (step.status !== 1 && step.message) {
+                if (step.status !== StepResultStatus.SUCCESS && step.message) {
                   errors.push({
                     severity: 'ERROR',
                     path: '',

--- a/frontend/src/features/economy/hooks/use-manifest-validate.ts
+++ b/frontend/src/features/economy/hooks/use-manifest-validate.ts
@@ -1,11 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { create } from '@bufbuild/protobuf'
 import { useApiClients } from '@/api/context'
 import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
 import type {
   ApplyManifestResponse,
   ValidationError,
 } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
-import { ApplyManifestStatus, StepResultStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+import {
+  ApplyManifestStatus,
+  StepResultStatus,
+  ValidationErrorSchema,
+} from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
 
 export interface ValidationResult {
   errors: ValidationError[]
@@ -13,20 +18,14 @@ export interface ValidationResult {
   sequenceNumber: number
 }
 
-// Constructs a client-side ValidationError for cases where the server returns
-// no structured errors (e.g., network failures, step-level failures without
-// validation details). The cast is required because protobuf-es Message types
-// include internal fields ($typeName, $unknown) that cannot be set via create().
 function createValidationError(code: string, message: string): ValidationError {
-  return {
+  return create(ValidationErrorSchema, {
     severity: 'ERROR',
     path: '',
     code,
     message,
     suggestion: '',
-    $typeName: 'meridian.control_plane.v1.ValidationError',
-    $unknown: undefined,
-  } as unknown as ValidationError
+  })
 }
 
 export function useManifestValidate() {
@@ -120,7 +119,7 @@ export function useManifestValidate() {
             })
           })
           .finally(() => {
-            if (seq >= latestCompletedRef.current) {
+            if (seq >= sequenceRef.current) {
               setIsValidating(false)
             }
           })

--- a/frontend/src/features/economy/hooks/use-manifest-validate.ts
+++ b/frontend/src/features/economy/hooks/use-manifest-validate.ts
@@ -13,6 +13,10 @@ export interface ValidationResult {
   sequenceNumber: number
 }
 
+// Constructs a client-side ValidationError for cases where the server returns
+// no structured errors (e.g., network failures, step-level failures without
+// validation details). The cast is required because protobuf-es Message types
+// include internal fields ($typeName, $unknown) that cannot be set via create().
 function createValidationError(code: string, message: string): ValidationError {
   return {
     severity: 'ERROR',

--- a/frontend/src/features/economy/hooks/use-manifest-validate.ts
+++ b/frontend/src/features/economy/hooks/use-manifest-validate.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useApiClients } from '@/api/context'
 import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
 import type {
@@ -13,6 +13,18 @@ export interface ValidationResult {
   sequenceNumber: number
 }
 
+function createValidationError(code: string, message: string): ValidationError {
+  return {
+    severity: 'ERROR',
+    path: '',
+    code,
+    message,
+    suggestion: '',
+    $typeName: 'meridian.control_plane.v1.ValidationError',
+    $unknown: undefined,
+  } as unknown as ValidationError
+}
+
 export function useManifestValidate() {
   const { manifestApplier } = useApiClients()
   const [isValidating, setIsValidating] = useState(false)
@@ -22,6 +34,17 @@ export function useManifestValidate() {
   const latestCompletedRef = useRef(0)
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const abortControllerRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current)
+      }
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort()
+      }
+    }
+  }, [])
 
   const validate = useCallback(
     (manifest: Manifest) => {
@@ -69,15 +92,7 @@ export function useManifestValidate() {
               // surface step-level messages as errors.
               for (const step of response.stepResults) {
                 if (step.status !== StepResultStatus.SUCCESS && step.message) {
-                  errors.push({
-                    severity: 'ERROR',
-                    path: '',
-                    code: step.stepName,
-                    message: step.message,
-                    suggestion: '',
-                    $typeName: 'meridian.control_plane.v1.ValidationError',
-                    $unknown: undefined as never,
-                  } as unknown as ValidationError)
+                  errors.push(createValidationError(step.stepName, step.message))
                 }
               }
             }
@@ -91,16 +106,10 @@ export function useManifestValidate() {
             latestCompletedRef.current = seq
             setResult({
               errors: [
-                {
-                  severity: 'ERROR',
-                  path: '',
-                  code: 'NETWORK_ERROR',
-                  message:
-                    err instanceof Error ? err.message : 'Validation request failed',
-                  suggestion: '',
-                  $typeName: 'meridian.control_plane.v1.ValidationError',
-                  $unknown: undefined as never,
-                } as unknown as ValidationError,
+                createValidationError(
+                  'NETWORK_ERROR',
+                  err instanceof Error ? err.message : 'Validation request failed',
+                ),
               ],
               warnings: [],
               sequenceNumber: seq,

--- a/frontend/src/features/economy/hooks/use-manifest-validate.ts
+++ b/frontend/src/features/economy/hooks/use-manifest-validate.ts
@@ -1,0 +1,120 @@
+import { useCallback, useRef, useState } from 'react'
+import { useApiClients } from '@/api/context'
+import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
+import type {
+  ApplyManifestResponse,
+  ValidationError,
+} from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+import { ApplyManifestStatus } from '@/api/gen/meridian/control_plane/v1/apply_manifest_service_pb'
+
+export interface ValidationResult {
+  errors: ValidationError[]
+  warnings: ValidationError[]
+  sequenceNumber: number
+}
+
+export function useManifestValidate() {
+  const { manifestApplier } = useApiClients()
+  const [isValidating, setIsValidating] = useState(false)
+  const [result, setResult] = useState<ValidationResult | null>(null)
+
+  const sequenceRef = useRef(0)
+  const latestCompletedRef = useRef(0)
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const abortControllerRef = useRef<AbortController | null>(null)
+
+  const validate = useCallback(
+    (manifest: Manifest) => {
+      // Clear any pending debounced call
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current)
+      }
+
+      debounceTimerRef.current = setTimeout(() => {
+        const seq = ++sequenceRef.current
+
+        // Abort previous in-flight request
+        if (abortControllerRef.current) {
+          abortControllerRef.current.abort()
+        }
+        const controller = new AbortController()
+        abortControllerRef.current = controller
+
+        setIsValidating(true)
+
+        manifestApplier
+          .applyManifest(
+            { manifest, dryRun: true, force: false, appliedBy: '' },
+            { signal: controller.signal },
+          )
+          .then((response: ApplyManifestResponse) => {
+            // Discard stale responses
+            if (seq < latestCompletedRef.current) return
+
+            latestCompletedRef.current = seq
+
+            const errors = response.validationErrors.filter(
+              (e) => e.severity === 'ERROR',
+            )
+            const warnings = response.validationErrors.filter(
+              (e) => e.severity !== 'ERROR',
+            )
+
+            // Also treat VALIDATION_FAILED status as an error signal
+            if (
+              response.status === ApplyManifestStatus.VALIDATION_FAILED &&
+              errors.length === 0
+            ) {
+              // The status indicates failure but no structured errors came back;
+              // surface step-level messages as errors.
+              for (const step of response.stepResults) {
+                if (step.status !== 1 && step.message) {
+                  errors.push({
+                    severity: 'ERROR',
+                    path: '',
+                    code: step.stepName,
+                    message: step.message,
+                    suggestion: '',
+                    $typeName: 'meridian.control_plane.v1.ValidationError',
+                    $unknown: undefined as never,
+                  } as unknown as ValidationError)
+                }
+              }
+            }
+
+            setResult({ errors, warnings, sequenceNumber: seq })
+          })
+          .catch((err: unknown) => {
+            if ((err as Error).name === 'AbortError') return
+            if (seq < latestCompletedRef.current) return
+
+            latestCompletedRef.current = seq
+            setResult({
+              errors: [
+                {
+                  severity: 'ERROR',
+                  path: '',
+                  code: 'NETWORK_ERROR',
+                  message:
+                    err instanceof Error ? err.message : 'Validation request failed',
+                  suggestion: '',
+                  $typeName: 'meridian.control_plane.v1.ValidationError',
+                  $unknown: undefined as never,
+                } as unknown as ValidationError,
+              ],
+              warnings: [],
+              sequenceNumber: seq,
+            })
+          })
+          .finally(() => {
+            if (seq >= latestCompletedRef.current) {
+              setIsValidating(false)
+            }
+          })
+      }, 500)
+    },
+    [manifestApplier],
+  )
+
+  return { validate, isValidating, result }
+}

--- a/frontend/src/features/economy/index.ts
+++ b/frontend/src/features/economy/index.ts
@@ -1,0 +1,15 @@
+// Public API for economy module
+
+// Pages
+export { EconomyOverviewPage } from './pages/economy-overview-page'
+export { EconomyCreatePage } from './pages/economy-create-page'
+export { EconomyEditPage } from './pages/economy-edit-page'
+export { EconomyExplorePage } from './pages/economy-explore-page'
+export { EconomyDraftPage } from './pages/economy-draft-page'
+
+// Hooks
+export { useManifestValidate } from './hooks/use-manifest-validate'
+export { useManifestPlan } from './hooks/use-manifest-plan'
+
+// Components
+export { EditorGraphPanel } from './components/editor-graph-panel'

--- a/frontend/src/features/economy/index.ts
+++ b/frontend/src/features/economy/index.ts
@@ -9,7 +9,9 @@ export { EconomyDraftPage } from './pages/economy-draft-page'
 
 // Hooks
 export { useManifestValidate } from './hooks/use-manifest-validate'
+export type { ValidationResult } from './hooks/use-manifest-validate'
 export { useManifestPlan } from './hooks/use-manifest-plan'
+export type { ManifestPlan } from './hooks/use-manifest-plan'
 
 // Components
 export { EditorGraphPanel } from './components/editor-graph-panel'

--- a/frontend/src/features/economy/pages/economy-create-page.tsx
+++ b/frontend/src/features/economy/pages/economy-create-page.tsx
@@ -1,0 +1,8 @@
+export function EconomyCreatePage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold">Create Economy</h1>
+      <p className="mt-2 text-muted-foreground">Define a new economy configuration.</p>
+    </div>
+  )
+}

--- a/frontend/src/features/economy/pages/economy-draft-page.tsx
+++ b/frontend/src/features/economy/pages/economy-draft-page.tsx
@@ -1,0 +1,8 @@
+export function EconomyDraftPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold">Draft Changes</h1>
+      <p className="mt-2 text-muted-foreground">Review and apply draft changes.</p>
+    </div>
+  )
+}

--- a/frontend/src/features/economy/pages/economy-edit-page.tsx
+++ b/frontend/src/features/economy/pages/economy-edit-page.tsx
@@ -1,0 +1,8 @@
+export function EconomyEditPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold">Edit Economy</h1>
+      <p className="mt-2 text-muted-foreground">Edit manifest configuration.</p>
+    </div>
+  )
+}

--- a/frontend/src/features/economy/pages/economy-explore-page.tsx
+++ b/frontend/src/features/economy/pages/economy-explore-page.tsx
@@ -1,0 +1,8 @@
+export function EconomyExplorePage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold">Economy Explorer</h1>
+      <p className="mt-2 text-muted-foreground">Explore your economy graph.</p>
+    </div>
+  )
+}

--- a/frontend/src/features/economy/pages/economy-overview-page.tsx
+++ b/frontend/src/features/economy/pages/economy-overview-page.tsx
@@ -1,0 +1,8 @@
+export function EconomyOverviewPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold">Economy</h1>
+      <p className="mt-2 text-muted-foreground">Manage your economy configuration.</p>
+    </div>
+  )
+}

--- a/frontend/src/lib/__tests__/tenant-ui-config.test.ts
+++ b/frontend/src/lib/__tests__/tenant-ui-config.test.ts
@@ -139,8 +139,8 @@ describe("tenant-ui-config", () => {
       expect(DEFAULT_UI_CONFIG.features?.defaultFeature).toBe("dashboard")
     })
 
-    it("contains all 17 features", () => {
-      expect(DEFAULT_UI_CONFIG.features?.enabled).toHaveLength(17)
+    it("contains all features", () => {
+      expect(DEFAULT_UI_CONFIG.features?.enabled).toHaveLength(ALL_FEATURES.length)
     })
   })
 

--- a/frontend/src/lib/tenant-ui-config.ts
+++ b/frontend/src/lib/tenant-ui-config.ts
@@ -20,6 +20,7 @@ export const ALL_FEATURES = [
   "mappings",
   "audit",
   "mcp-config",
+  "economy",
 ] as const
 
 export type FeatureId = (typeof ALL_FEATURES)[number]


### PR DESCRIPTION
## Summary

- Create economy feature module at `frontend/src/features/economy/` with directory structure (components, hooks, pages, lib) and barrel exports
- Add five routes (`/economy`, `/economy/create`, `/economy/edit`, `/economy/explore`, `/economy/draft`) with `FeatureGuard` and placeholder pages
- Add sidebar entry under Configuration group with `Boxes` icon
- Implement `useManifestValidate` hook with 500ms debounce, AbortController cancellation, and sequence number tracking to discard stale responses
- Implement `useManifestPlan` hook wrapping `ApplyManifest` dry-run with diff count parsing
- Implement `EditorGraphPanel` component wrapping existing `ManifestGraph` with stale overlay and empty-state placeholder

## Task Master

| Task | Description |
|------|-------------|
| economy-ide.1 | Create Economy Feature Module Structure |
| economy-ide.2 | useManifestValidate Hook |
| economy-ide.5 | useManifestPlan Hook |
| economy-ide.8 | EditorGraphPanel Component |

## Test plan

- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Verify economy routes render placeholder pages at each path
- [ ] Verify sidebar shows Economy entry when feature flag is enabled
- [ ] Verify `useManifestValidate` debounces and cancels stale requests
- [ ] Verify `useManifestPlan` returns structured plan with counts
- [ ] Verify `EditorGraphPanel` shows stale overlay when validation fails