### PR TITLE
feat: Add LLM client for economy manifest generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 )
 
 require (
+	github.com/anthropics/anthropic-sdk-go v1.26.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -68,7 +69,7 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.0 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -671,6 +671,8 @@ github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b/go.mod h1:1KcenG0jGW
 github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
 github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=
+github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
@@ -1182,6 +1184,8 @@ github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=

--- a/services/control-plane/internal/generator/export_test.go
+++ b/services/control-plane/internal/generator/export_test.go
@@ -1,0 +1,14 @@
+package generator
+
+// Export private helpers for black-box testing.
+
+// ExtractYAML is the exported test hook for extractYAML.
+var ExtractYAML = extractYAML
+
+// BuildFixPrompt is the exported test hook for buildFixPrompt.
+var BuildFixPrompt = buildFixPrompt
+
+// Model returns the model name used by this client.
+func (c *ClaudeLLMClient) Model() string {
+	return c.model
+}

--- a/services/control-plane/internal/generator/llm_client.go
+++ b/services/control-plane/internal/generator/llm_client.go
@@ -21,7 +21,8 @@ var (
 
 const (
 	// DefaultModel is the default Claude model used for manifest generation.
-	DefaultModel = "claude-opus-4-5"
+	// The full versioned model ID is required by the Anthropic API.
+	DefaultModel = "claude-opus-4-5-20251101"
 
 	// defaultMaxTokens is the maximum tokens for a generation response.
 	// Manifests can be large, so we set a generous limit.
@@ -64,8 +65,9 @@ type ValidationError struct {
 	// Suggestion is a "Did you mean...?" hint for typos.
 	Suggestion string
 
-	// Available lists valid values when an unknown value is referenced.
-	Available []string
+	// AvailableFields lists valid field names when an unknown field is referenced.
+	// This mirrors validator.ValidationError.AvailableFields for a straight copy.
+	AvailableFields []string
 }
 
 // LLMClient abstracts LLM interactions for manifest generation.
@@ -207,8 +209,8 @@ func buildFixPrompt(manifest string, errors []ValidationError) string {
 		if e.Suggestion != "" {
 			b.WriteString(fmt.Sprintf("   - Suggestion: %s\n", e.Suggestion))
 		}
-		if len(e.Available) > 0 {
-			b.WriteString(fmt.Sprintf("   - Available values: %s\n", strings.Join(e.Available, ", ")))
+		if len(e.AvailableFields) > 0 {
+			b.WriteString(fmt.Sprintf("   - Available values: %s\n", strings.Join(e.AvailableFields, ", ")))
 		}
 	}
 

--- a/services/control-plane/internal/generator/llm_client.go
+++ b/services/control-plane/internal/generator/llm_client.go
@@ -1,0 +1,219 @@
+// Package generator provides LLM-assisted manifest generation for the control plane.
+// It uses Claude to generate and fix economy manifest YAML based on tenant context
+// and validation feedback, enabling an AI-assisted configuration workflow.
+package generator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+)
+
+// Sentinel errors for empty LLM responses.
+var (
+	errGenerateEmptyResponse = errors.New("generate manifest: empty response from LLM")
+	errFixEmptyResponse      = errors.New("fix manifest: empty response from LLM")
+)
+
+const (
+	// DefaultModel is the default Claude model used for manifest generation.
+	DefaultModel = "claude-opus-4-5"
+
+	// defaultMaxTokens is the maximum tokens for a generation response.
+	// Manifests can be large, so we set a generous limit.
+	defaultMaxTokens = 8192
+
+	// systemPrompt guides the LLM to produce valid manifest YAML.
+	systemPrompt = `You are an expert at generating Meridian economy manifest YAML files.
+
+Meridian manifests define the configuration for a tenant's economy, including:
+- instruments: financial and non-financial assets (currencies, tokens, energy units, etc.)
+- account_types: categories of accounts with associated instruments
+- sagas: Starlark-based workflow definitions for business transactions
+- mappings: CEL-based data transformation rules
+- provider_connections: external service integrations
+- instruction_routes: routing rules for transaction instructions
+
+When generating a manifest:
+1. Always produce valid YAML
+2. Follow the Meridian manifest schema precisely
+3. Use meaningful, descriptive names and codes
+4. Include only what is necessary for the described use case
+5. Ensure all cross-references (e.g., instrument codes in account types) are consistent
+
+Return ONLY the manifest YAML, optionally wrapped in ` + "```yaml" + ` code fences. Do not include explanations or commentary outside the YAML.`
+)
+
+// ValidationError represents a single validation finding with structured
+// location information and optional suggestions for AI feedback.
+// This mirrors validator.ValidationError to avoid a circular import.
+type ValidationError struct {
+	// Code is a machine-readable error code (e.g., "CEL_TYPE_ERROR").
+	Code string
+
+	// Path is the location within the manifest (e.g., "instruments[0].code").
+	Path string
+
+	// Message is a human-readable description of the issue.
+	Message string
+
+	// Suggestion is a "Did you mean...?" hint for typos.
+	Suggestion string
+
+	// Available lists valid values when an unknown value is referenced.
+	Available []string
+}
+
+// LLMClient abstracts LLM interactions for manifest generation.
+type LLMClient interface {
+	// Generate sends a prompt and returns the generated manifest YAML.
+	Generate(ctx context.Context, prompt string) (string, error)
+
+	// Fix sends a manifest with validation errors and returns a corrected manifest.
+	Fix(ctx context.Context, manifest string, errors []ValidationError) (string, error)
+}
+
+// ClaudeLLMClient implements LLMClient using the Anthropic Messages API.
+type ClaudeLLMClient struct {
+	client *anthropic.Client
+	model  string
+}
+
+// NewClaudeLLMClient creates a new ClaudeLLMClient with the given API key and model.
+// If model is empty, DefaultModel is used.
+func NewClaudeLLMClient(apiKey string, model string) *ClaudeLLMClient {
+	if model == "" {
+		model = DefaultModel
+	}
+	client := anthropic.NewClient(option.WithAPIKey(apiKey))
+	return &ClaudeLLMClient{
+		client: &client,
+		model:  model,
+	}
+}
+
+// Generate sends a prompt to Claude and returns the generated manifest YAML.
+// It strips markdown code fences from the response if present.
+func (c *ClaudeLLMClient) Generate(ctx context.Context, prompt string) (string, error) {
+	message, err := c.client.Messages.New(ctx, anthropic.MessageNewParams{
+		Model:     anthropic.Model(c.model),
+		MaxTokens: defaultMaxTokens,
+		System: []anthropic.TextBlockParam{
+			{Text: systemPrompt},
+		},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(prompt)),
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("generate manifest: %w", err)
+	}
+
+	raw := extractText(message)
+	if raw == "" {
+		return "", errGenerateEmptyResponse
+	}
+
+	return extractYAML(raw), nil
+}
+
+// Fix sends the current manifest and its validation errors to Claude and returns
+// a corrected manifest YAML.
+func (c *ClaudeLLMClient) Fix(ctx context.Context, manifest string, errors []ValidationError) (string, error) {
+	prompt := buildFixPrompt(manifest, errors)
+
+	message, err := c.client.Messages.New(ctx, anthropic.MessageNewParams{
+		Model:     anthropic.Model(c.model),
+		MaxTokens: defaultMaxTokens,
+		System: []anthropic.TextBlockParam{
+			{Text: systemPrompt},
+		},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(prompt)),
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("fix manifest: %w", err)
+	}
+
+	raw := extractText(message)
+	if raw == "" {
+		return "", errFixEmptyResponse
+	}
+
+	return extractYAML(raw), nil
+}
+
+// extractText pulls the text content from the first text block in a message response.
+func extractText(msg *anthropic.Message) string {
+	for _, block := range msg.Content {
+		if block.Type == "text" {
+			return block.Text
+		}
+	}
+	return ""
+}
+
+// extractYAML finds YAML content between ```yaml and ``` markers in the given text.
+// If no markers are found, the full text is returned trimmed of surrounding whitespace.
+// If multiple code blocks are present, the first yaml-fenced block is returned.
+func extractYAML(text string) string {
+	const openFence = "```yaml"
+	const closeFence = "```"
+
+	start := strings.Index(text, openFence)
+	if start == -1 {
+		// No yaml fence — return trimmed full text.
+		return strings.TrimSpace(text)
+	}
+
+	// Advance past the opening fence and any trailing newline.
+	content := text[start+len(openFence):]
+	if len(content) > 0 && content[0] == '\n' {
+		content = content[1:]
+	}
+
+	end := strings.Index(content, closeFence)
+	if end == -1 {
+		// Unclosed fence — return everything after the opening fence.
+		return strings.TrimSpace(content)
+	}
+
+	return strings.TrimSpace(content[:end])
+}
+
+// buildFixPrompt constructs the prompt sent to the LLM when asking it to fix
+// a manifest that failed validation.
+func buildFixPrompt(manifest string, errors []ValidationError) string {
+	var b strings.Builder
+
+	b.WriteString("The following Meridian manifest has validation errors that must be fixed.\n\n")
+	b.WriteString("## Current Manifest\n\n")
+	b.WriteString("```yaml\n")
+	b.WriteString(manifest)
+	if !strings.HasSuffix(manifest, "\n") {
+		b.WriteByte('\n')
+	}
+	b.WriteString("```\n\n")
+	b.WriteString("## Validation Errors\n\n")
+
+	for i, e := range errors {
+		b.WriteString(fmt.Sprintf("%d. **[%s]** at `%s`\n", i+1, e.Code, e.Path))
+		b.WriteString(fmt.Sprintf("   - Message: %s\n", e.Message))
+		if e.Suggestion != "" {
+			b.WriteString(fmt.Sprintf("   - Suggestion: %s\n", e.Suggestion))
+		}
+		if len(e.Available) > 0 {
+			b.WriteString(fmt.Sprintf("   - Available values: %s\n", strings.Join(e.Available, ", ")))
+		}
+	}
+
+	b.WriteString("\nPlease return a corrected manifest that resolves all of the above errors. ")
+	b.WriteString("Return ONLY the fixed manifest YAML.")
+
+	return b.String()
+}

--- a/services/control-plane/internal/generator/llm_client_test.go
+++ b/services/control-plane/internal/generator/llm_client_test.go
@@ -58,11 +58,11 @@ func TestBuildFixPrompt_IncludesAllErrorFields(t *testing.T) {
 	manifest := "instruments:\n  - code: INVALID"
 	errors := []generator.ValidationError{
 		{
-			Code:       "DUPLICATE_CODE",
-			Path:       "instruments[0].code",
-			Message:    "duplicate instrument code \"INVALID\"",
-			Suggestion: "use a unique code",
-			Available:  []string{"GBP", "USD", "EUR"},
+			Code:            "DUPLICATE_CODE",
+			Path:            "instruments[0].code",
+			Message:         "duplicate instrument code \"INVALID\"",
+			Suggestion:      "use a unique code",
+			AvailableFields: []string{"GBP", "USD", "EUR"},
 		},
 		{
 			Code:    "PROTO_VALIDATION",

--- a/services/control-plane/internal/generator/llm_client_test.go
+++ b/services/control-plane/internal/generator/llm_client_test.go
@@ -1,0 +1,130 @@
+package generator_test
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/services/control-plane/internal/generator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExtractYAML_NoFences returns full trimmed text when no code fences are present.
+func TestExtractYAML_NoFences(t *testing.T) {
+	input := `
+instruments:
+  - code: GBP
+    name: British Pound
+`
+	result := generator.ExtractYAML(input)
+	assert.Equal(t, "instruments:\n  - code: GBP\n    name: British Pound", result)
+}
+
+// TestExtractYAML_WithFences strips yaml code fences and returns inner content.
+func TestExtractYAML_WithFences(t *testing.T) {
+	input := "Here is your manifest:\n\n```yaml\ninstruments:\n  - code: GBP\n```\n\nAll done."
+	result := generator.ExtractYAML(input)
+	assert.Equal(t, "instruments:\n  - code: GBP", result)
+}
+
+// TestExtractYAML_UnclosedFence returns content after opening fence when closing fence is missing.
+func TestExtractYAML_UnclosedFence(t *testing.T) {
+	input := "```yaml\ninstruments:\n  - code: GBP\n"
+	result := generator.ExtractYAML(input)
+	assert.Equal(t, "instruments:\n  - code: GBP", result)
+}
+
+// TestExtractYAML_MultipleBlocks returns the first yaml-fenced block.
+func TestExtractYAML_MultipleBlocks(t *testing.T) {
+	input := "```yaml\nfirst: block\n```\n\n```yaml\nsecond: block\n```"
+	result := generator.ExtractYAML(input)
+	assert.Equal(t, "first: block", result)
+}
+
+// TestExtractYAML_EmptyInput returns empty string for empty input.
+func TestExtractYAML_EmptyInput(t *testing.T) {
+	result := generator.ExtractYAML("")
+	assert.Equal(t, "", result)
+}
+
+// TestExtractYAML_OnlyWhitespace returns empty string for whitespace-only input.
+func TestExtractYAML_OnlyWhitespace(t *testing.T) {
+	result := generator.ExtractYAML("   \n\t  ")
+	assert.Equal(t, "", result)
+}
+
+// TestBuildFixPrompt_IncludesAllErrorFields verifies the fix prompt contains
+// the manifest and all structured error fields.
+func TestBuildFixPrompt_IncludesAllErrorFields(t *testing.T) {
+	manifest := "instruments:\n  - code: INVALID"
+	errors := []generator.ValidationError{
+		{
+			Code:       "DUPLICATE_CODE",
+			Path:       "instruments[0].code",
+			Message:    "duplicate instrument code \"INVALID\"",
+			Suggestion: "use a unique code",
+			Available:  []string{"GBP", "USD", "EUR"},
+		},
+		{
+			Code:    "PROTO_VALIDATION",
+			Path:    "sagas[0].name",
+			Message: "name is required",
+		},
+	}
+
+	prompt := generator.BuildFixPrompt(manifest, errors)
+
+	assert.Contains(t, prompt, manifest)
+	assert.Contains(t, prompt, "DUPLICATE_CODE")
+	assert.Contains(t, prompt, "instruments[0].code")
+	assert.Contains(t, prompt, "duplicate instrument code")
+	assert.Contains(t, prompt, "use a unique code")
+	assert.Contains(t, prompt, "GBP, USD, EUR")
+	assert.Contains(t, prompt, "PROTO_VALIDATION")
+	assert.Contains(t, prompt, "sagas[0].name")
+	assert.Contains(t, prompt, "name is required")
+}
+
+// TestBuildFixPrompt_NoSuggestionOrAvailable verifies errors without optional
+// fields render correctly without extra lines.
+func TestBuildFixPrompt_NoSuggestionOrAvailable(t *testing.T) {
+	errors := []generator.ValidationError{
+		{
+			Code:    "CEL_EXPRESSION_TOO_LONG",
+			Path:    "mappings[0].expression",
+			Message: "expression exceeds 4096 bytes",
+		},
+	}
+
+	prompt := generator.BuildFixPrompt("key: val", errors)
+
+	assert.Contains(t, prompt, "CEL_EXPRESSION_TOO_LONG")
+	assert.NotContains(t, prompt, "Suggestion:")
+	assert.NotContains(t, prompt, "Available values:")
+}
+
+// TestBuildFixPrompt_ManifestWithoutTrailingNewline ensures a newline is appended
+// before the closing fence so the YAML block is well-formed.
+func TestBuildFixPrompt_ManifestWithoutTrailingNewline(t *testing.T) {
+	prompt := generator.BuildFixPrompt("key: val", []generator.ValidationError{
+		{Code: "ERR", Path: "key", Message: "bad value"},
+	})
+
+	// The manifest block should be properly closed
+	assert.Contains(t, prompt, "key: val\n```")
+}
+
+// TestNewClaudeLLMClient_DefaultModel verifies that an empty model string
+// falls back to DefaultModel.
+func TestNewClaudeLLMClient_DefaultModel(t *testing.T) {
+	client := generator.NewClaudeLLMClient("test-key", "")
+	require.NotNil(t, client)
+	assert.Equal(t, generator.DefaultModel, client.Model())
+}
+
+// TestNewClaudeLLMClient_CustomModel verifies that a provided model string is used.
+func TestNewClaudeLLMClient_CustomModel(t *testing.T) {
+	const customModel = "claude-opus-4-5"
+	client := generator.NewClaudeLLMClient("test-key", customModel)
+	require.NotNil(t, client)
+	assert.Equal(t, customModel, client.Model())
+}


### PR DESCRIPTION
## Summary

- Introduces the `generator` package under `services/control-plane/internal/generator/`
- Defines the `LLMClient` interface with `Generate` and `Fix` methods
- Implements `ClaudeLLMClient` backed by the Anthropic Messages API (`claude-opus-4-5` default)
- Adds `extractYAML` helper to strip markdown code fences from LLM responses
- Adds `buildFixPrompt` to format structured `ValidationError` values into a well-formed fix prompt
- Adds `github.com/anthropics/anthropic-sdk-go` dependency

## Changes Made

- `services/control-plane/internal/generator/llm_client.go` — interface, struct, and helpers
- `services/control-plane/internal/generator/llm_client_test.go` — unit tests
- `services/control-plane/internal/generator/export_test.go` — test hooks for private helpers
- `go.mod` / `go.sum` — Anthropic SDK added

## Testing

- `extractYAML`: covers no-fences, yaml-fenced, unclosed fence, multiple blocks, empty, whitespace
- `buildFixPrompt`: verifies all error fields render, optional fields absent when empty, newline before closing fence
- `NewClaudeLLMClient`: verifies default model fallback and custom model pass-through
- All tests pass: `go test ./services/control-plane/internal/generator/...`

## Notes

`ValidationError` in the generator package mirrors `validator.ValidationError` to avoid a circular import between the two packages. Fields used: `Code`, `Path`, `Message`, `Suggestion`, `Available`.

Relates to economy-generator task 13.