### PR TITLE
feat: Add cookbook pattern matcher for economy generation

### DIFF
--- a/services/control-plane/internal/generator/pattern_matcher.go
+++ b/services/control-plane/internal/generator/pattern_matcher.go
@@ -1,0 +1,458 @@
+// Package generator provides economy configuration generation utilities for the control-plane.
+// It assembles a GenerationContext from live services and matches cookbook patterns to
+// a tenant's business description.
+package generator
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+)
+
+// scoredEntry pairs a PatternMatch with its computed relevance score for internal sorting.
+type scoredEntry struct {
+	Match PatternMatch
+	Score float64
+}
+
+// PatternMatch describes a cookbook pattern that was selected by MatchPatterns.
+type PatternMatch struct {
+	// Name is the kebab-case registry name (e.g. "energy-settlement").
+	Name string
+	// Title is the human-readable title from the registry.
+	Title string
+	// Score is the relevance score computed by the multi-factor scoring algorithm.
+	Score float64
+	// Provides lists the instruments, account types, and sagas contributed by this pattern.
+	Provides []string
+	// Requires lists the external prerequisites (instruments, market data) needed.
+	Requires []string
+	// ComposesWith lists patterns that work well alongside this one.
+	ComposesWith []string
+	// ConflictsWith lists patterns that are incompatible with this one.
+	ConflictsWith []string
+	// ManifestFragment is the YAML fragment from the pattern's manifest-fragment.yaml file.
+	ManifestFragment string
+	// SagaScript is the content of the first Starlark saga file found for the pattern.
+	SagaScript string
+}
+
+// MatchPatterns loads all registry:pattern entries from cookbookFS, scores each against
+// the provided description and industry, resolves extends dependencies, applies conflict
+// filtering, and returns the top maxResults results ordered by descending score.
+//
+// cookbookFS must expose registry.json at its root and pattern files under
+// patterns/<name>/pattern.json, patterns/<name>/manifest-fragment.yaml, and
+// patterns/<name>/*.star.
+func MatchPatterns(cookbookFS fs.FS, description string, industry string, maxResults int) ([]PatternMatch, error) {
+	// --- Subtask 5.1: Load and parse pattern metadata ---
+
+	reg, err := loadRegistry(cookbookFS)
+	if err != nil {
+		return nil, fmt.Errorf("load registry: %w", err)
+	}
+
+	// Load all pattern details upfront.
+	allDetails := make(map[string]*patternDetail, len(reg.Items))
+	for _, item := range reg.Items {
+		if item.Type != "registry:pattern" {
+			continue
+		}
+		detail, loadErr := loadPatternDetail(cookbookFS, item.Name)
+		if loadErr != nil {
+			// Skip patterns that fail to load — non-fatal.
+			continue
+		}
+		allDetails[item.Name] = detail
+	}
+
+	// --- Subtask 5.2: Multi-factor scoring ---
+
+	descWords := tokenise(description)
+	industryLower := strings.ToLower(industry)
+
+	var scored []scoredEntry
+
+	for _, item := range reg.Items {
+		if item.Type != "registry:pattern" {
+			continue
+		}
+		detail := allDetails[item.Name]
+		if detail == nil {
+			continue
+		}
+
+		score := scorePattern(detail, descWords, industryLower)
+
+		match := buildPatternMatch(cookbookFS, item, detail)
+		match.Score = score
+		scored = append(scored, scoredEntry{Match: match, Score: score})
+	}
+
+	// Sort by score descending, then name ascending for determinism.
+	sort.Slice(scored, func(i, j int) bool {
+		if scored[i].Score != scored[j].Score {
+			return scored[i].Score > scored[j].Score
+		}
+		return scored[i].Match.Name < scored[j].Match.Name
+	})
+
+	// --- Subtask 5.3: Conflict filtering, extends resolution, top-N selection ---
+
+	selected := applyConflictFilterAndExtends(scored, allDetails, maxResults)
+
+	return selected, nil
+}
+
+// scorePattern computes the relevance score for a pattern against the description tokens and industry.
+func scorePattern(detail *patternDetail, descWords []string, industryLower string) float64 {
+	if detail.Meta == nil {
+		return 0
+	}
+
+	score := scoreIndustry(detail.Meta, industryLower)
+	if len(descWords) > 0 {
+		score += scoreKeywords(detail, descWords)
+	}
+
+	return score
+}
+
+// scoreIndustry returns +10 when the industry matches meta.industries, 0 otherwise.
+func scoreIndustry(meta *patternMeta, industryLower string) float64 {
+	if industryLower == "" {
+		return 0
+	}
+	for _, ind := range meta.Industries {
+		if strings.ToLower(ind) == industryLower {
+			return 10
+		}
+	}
+	return 0
+}
+
+// scoreKeywords returns keyword match (+1 per word that appears in provides terms)
+// and fuzzy title/description match (+0.5 per word).
+func scoreKeywords(detail *patternDetail, descWords []string) float64 {
+	providedTerms := collectProvidedTerms(detail.Meta)
+	titleLower := strings.ToLower(detail.Title)
+	descLower := strings.ToLower(detail.Description)
+
+	var score float64
+	for _, word := range descWords {
+		if matchesAnyTerm(word, providedTerms) {
+			score++
+		}
+		if strings.Contains(titleLower, word) || strings.Contains(descLower, word) {
+			score += 0.5
+		}
+	}
+	return score
+}
+
+// collectProvidedTerms returns all lowercase tokens from the provides block.
+func collectProvidedTerms(meta *patternMeta) []string {
+	if meta == nil || meta.Provides == nil {
+		return nil
+	}
+	p := meta.Provides
+	terms := make([]string, 0, len(p.Instruments)+len(p.AccountTypes)+len(p.Sagas))
+	for _, s := range p.Instruments {
+		terms = append(terms, strings.ToLower(s))
+	}
+	for _, s := range p.AccountTypes {
+		terms = append(terms, strings.ToLower(s))
+	}
+	for _, s := range p.Sagas {
+		terms = append(terms, strings.ToLower(s))
+	}
+	return terms
+}
+
+// matchesAnyTerm returns true when word is a substring of any term in terms.
+func matchesAnyTerm(word string, terms []string) bool {
+	for _, term := range terms {
+		if strings.Contains(term, word) {
+			return true
+		}
+	}
+	return false
+}
+
+// applyConflictFilterAndExtends applies three operations in order:
+//  1. Conflict filtering: skip patterns that conflict with already-selected ones.
+//  2. Extends resolution: prepend base patterns required by extends declarations.
+//  3. Top-N selection: return at most maxResults patterns.
+func applyConflictFilterAndExtends(
+	scored []scoredEntry,
+	allDetails map[string]*patternDetail,
+	maxResults int,
+) []PatternMatch {
+	selectedNames := make(map[string]bool)
+	conflictSet := make(map[string]bool) // patterns blocked by conflicts
+
+	var result []PatternMatch
+
+	// Collect patterns with conflict filtering.
+	var candidates []PatternMatch
+	for _, s := range scored {
+		if conflictSet[s.Match.Name] {
+			continue
+		}
+		candidates = append(candidates, s.Match)
+		selectedNames[s.Match.Name] = true
+
+		// Register conflicts: any pattern that conflicts_with this one is blocked.
+		detail := allDetails[s.Match.Name]
+		if detail != nil && detail.Meta != nil {
+			for _, conflictName := range detail.Meta.ConflictsWith {
+				conflictSet[conflictName] = true
+			}
+		}
+	}
+
+	// Resolve extends: collect all base patterns required by the selected candidates.
+	// Use a worklist to handle transitive extends.
+	basePatterns := resolveExtends(candidates, allDetails, selectedNames)
+
+	// Prepend base patterns (they have no score on their own but are required).
+	result = append(result, basePatterns...)
+	result = append(result, candidates...)
+
+	// Apply top-N.
+	if maxResults > 0 && len(result) > maxResults {
+		result = result[:maxResults]
+	}
+
+	return result
+}
+
+// resolveExtends returns the set of base patterns required by the extends fields of candidates,
+// excluding patterns already in selectedNames, in dependency order (bases first).
+func resolveExtends(candidates []PatternMatch, allDetails map[string]*patternDetail, selectedNames map[string]bool) []PatternMatch {
+	worklist := collectExtendsWorklist(candidates, allDetails, selectedNames)
+	if len(worklist) == 0 {
+		return nil
+	}
+	return buildBaseMatches(worklist, allDetails)
+}
+
+// collectExtendsWorklist performs a BFS over the extends graph starting from candidates.
+// It returns all base pattern names in BFS discovery order, skipping already-selected names.
+func collectExtendsWorklist(candidates []PatternMatch, allDetails map[string]*patternDetail, selectedNames map[string]bool) []string {
+	needed := make(map[string]bool)
+	var worklist []string
+
+	enqueue := func(name string) {
+		if !selectedNames[name] && !needed[name] {
+			needed[name] = true
+			worklist = append(worklist, name)
+		}
+	}
+
+	for _, c := range candidates {
+		if d := allDetails[c.Name]; d != nil && d.Meta != nil {
+			for _, base := range d.Meta.Extends {
+				enqueue(base)
+			}
+		}
+	}
+
+	for i := 0; i < len(worklist); i++ {
+		if d := allDetails[worklist[i]]; d != nil && d.Meta != nil {
+			for _, base := range d.Meta.Extends {
+				enqueue(base)
+			}
+		}
+	}
+
+	return worklist
+}
+
+// buildBaseMatches converts a BFS-ordered worklist into PatternMatch values, bases first.
+func buildBaseMatches(worklist []string, allDetails map[string]*patternDetail) []PatternMatch {
+	bases := make([]PatternMatch, 0, len(worklist))
+	seen := make(map[string]bool, len(worklist))
+	for i := len(worklist) - 1; i >= 0; i-- {
+		name := worklist[i]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		if detail := allDetails[name]; detail != nil {
+			bases = append(bases, buildPatternMatchFromDetail(name, detail))
+		}
+	}
+	return bases
+}
+
+// buildPatternMatch constructs a PatternMatch from a registry item and its full detail,
+// including loading manifest fragment and saga script from the FS.
+func buildPatternMatch(cookbookFS fs.FS, item registryItem, detail *patternDetail) PatternMatch {
+	m := buildPatternMatchFromDetail(item.Name, detail)
+
+	// Load manifest fragment.
+	fragmentPath := fmt.Sprintf("patterns/%s/manifest-fragment.yaml", item.Name)
+	if data, err := fs.ReadFile(cookbookFS, fragmentPath); err == nil {
+		m.ManifestFragment = string(data)
+	}
+
+	// Load the first .star saga file found.
+	m.SagaScript = loadFirstStarFile(cookbookFS, item.Name)
+
+	return m
+}
+
+// buildPatternMatchFromDetail constructs a PatternMatch from a pattern detail without file loading.
+func buildPatternMatchFromDetail(name string, detail *patternDetail) PatternMatch {
+	m := PatternMatch{
+		Name:  name,
+		Title: detail.Title,
+	}
+
+	if detail.Meta == nil {
+		return m
+	}
+
+	// Populate Provides.
+	if detail.Meta.Provides != nil {
+		p := detail.Meta.Provides
+		provides := make([]string, 0, len(p.Instruments)+len(p.AccountTypes)+len(p.Sagas))
+		provides = append(provides, p.Instruments...)
+		provides = append(provides, p.AccountTypes...)
+		provides = append(provides, p.Sagas...)
+		m.Provides = provides
+	}
+
+	// Populate Requires.
+	if detail.Meta.Requires != nil {
+		r := detail.Meta.Requires
+		requires := make([]string, 0, len(r.Instruments)+len(r.MarketData))
+		requires = append(requires, r.Instruments...)
+		requires = append(requires, r.MarketData...)
+		m.Requires = requires
+	}
+
+	m.ComposesWith = detail.Meta.ComposesWith
+	m.ConflictsWith = detail.Meta.ConflictsWith
+
+	return m
+}
+
+// loadFirstStarFile returns the content of the first *.star file found under patterns/<name>/.
+func loadFirstStarFile(cookbookFS fs.FS, name string) string {
+	dir := fmt.Sprintf("patterns/%s", name)
+	entries, err := fs.ReadDir(cookbookFS, dir)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(entry.Name(), ".star") {
+			path := fmt.Sprintf("%s/%s", dir, entry.Name())
+			if data, err := fs.ReadFile(cookbookFS, path); err == nil {
+				return string(data)
+			}
+		}
+	}
+	return ""
+}
+
+// tokenise splits a description into lowercase words, stripping punctuation.
+func tokenise(s string) []string {
+	if s == "" {
+		return nil
+	}
+	s = strings.ToLower(s)
+	// Replace punctuation with spaces.
+	var b strings.Builder
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune(' ')
+		}
+	}
+	parts := strings.Fields(b.String())
+	// Deduplicate and filter very short tokens.
+	seen := make(map[string]bool)
+	result := parts[:0]
+	for _, p := range parts {
+		if len(p) >= 2 && !seen[p] {
+			seen[p] = true
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+// --- Internal types for JSON parsing ---
+
+type registryItem struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Title string `json:"title"`
+}
+
+type registry struct {
+	Items []registryItem `json:"items"`
+}
+
+type patternDetail struct {
+	Name        string       `json:"name"`
+	Type        string       `json:"type"`
+	Title       string       `json:"title"`
+	Description string       `json:"description"`
+	Meta        *patternMeta `json:"meta,omitempty"`
+}
+
+type patternMeta struct {
+	Industries    []string         `json:"industries,omitempty"`
+	Provides      *patternProvides `json:"provides,omitempty"`
+	Requires      *patternRequires `json:"requires,omitempty"`
+	ComposesWith  []string         `json:"composes_with,omitempty"`
+	ConflictsWith []string         `json:"conflicts_with,omitempty"`
+	Extends       []string         `json:"extends,omitempty"`
+}
+
+type patternProvides struct {
+	Instruments  []string `json:"instruments,omitempty"`
+	AccountTypes []string `json:"account_types,omitempty"`
+	Sagas        []string `json:"sagas,omitempty"`
+}
+
+type patternRequires struct {
+	Instruments []string `json:"instruments,omitempty"`
+	MarketData  []string `json:"market_data,omitempty"`
+}
+
+// loadRegistry reads and parses registry.json from the given FS.
+func loadRegistry(cookbookFS fs.FS) (*registry, error) {
+	data, err := fs.ReadFile(cookbookFS, "registry.json")
+	if err != nil {
+		return nil, fmt.Errorf("read registry.json: %w", err)
+	}
+	var reg registry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		return nil, fmt.Errorf("parse registry.json: %w", err)
+	}
+	return &reg, nil
+}
+
+// loadPatternDetail reads and parses patterns/<name>/pattern.json from the given FS.
+func loadPatternDetail(cookbookFS fs.FS, name string) (*patternDetail, error) {
+	path := fmt.Sprintf("patterns/%s/pattern.json", name)
+	data, err := fs.ReadFile(cookbookFS, path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var detail patternDetail
+	if err := json.Unmarshal(data, &detail); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return &detail, nil
+}

--- a/services/control-plane/internal/generator/pattern_matcher.go
+++ b/services/control-plane/internal/generator/pattern_matcher.go
@@ -46,6 +46,9 @@ type PatternMatch struct {
 // cookbookFS must expose registry.json at its root and pattern files under
 // patterns/<name>/pattern.json, patterns/<name>/manifest-fragment.yaml, and
 // patterns/<name>/*.star.
+//
+// A missing or malformed pattern.json is treated as a cookbook regression and
+// returns an error rather than silently skipping the entry.
 func MatchPatterns(cookbookFS fs.FS, description string, industry string, maxResults int) ([]PatternMatch, error) {
 	// --- Subtask 5.1: Load and parse pattern metadata ---
 
@@ -54,7 +57,7 @@ func MatchPatterns(cookbookFS fs.FS, description string, industry string, maxRes
 		return nil, fmt.Errorf("load registry: %w", err)
 	}
 
-	// Load all pattern details upfront.
+	// Load all pattern details upfront. A load error is a cookbook regression — fail fast.
 	allDetails := make(map[string]*patternDetail, len(reg.Items))
 	for _, item := range reg.Items {
 		if item.Type != "registry:pattern" {
@@ -62,8 +65,7 @@ func MatchPatterns(cookbookFS fs.FS, description string, industry string, maxRes
 		}
 		detail, loadErr := loadPatternDetail(cookbookFS, item.Name)
 		if loadErr != nil {
-			// Skip patterns that fail to load — non-fatal.
-			continue
+			return nil, fmt.Errorf("load pattern %q: %w", item.Name, loadErr)
 		}
 		allDetails[item.Name] = detail
 	}
@@ -101,7 +103,7 @@ func MatchPatterns(cookbookFS fs.FS, description string, industry string, maxRes
 
 	// --- Subtask 5.3: Conflict filtering, extends resolution, top-N selection ---
 
-	selected := applyConflictFilterAndExtends(scored, allDetails, maxResults)
+	selected := applyConflictFilterAndExtends(cookbookFS, scored, allDetails, maxResults)
 
 	return selected, nil
 }
@@ -158,7 +160,8 @@ func collectProvidedTerms(meta *patternMeta) []string {
 		return nil
 	}
 	p := meta.Provides
-	terms := make([]string, 0, len(p.Instruments)+len(p.AccountTypes)+len(p.Sagas))
+	termCap := len(p.Instruments) + len(p.AccountTypes) + len(p.Sagas) + len(p.ValuationRules) + len(p.Triggers)
+	terms := make([]string, 0, termCap)
 	for _, s := range p.Instruments {
 		terms = append(terms, strings.ToLower(s))
 	}
@@ -166,6 +169,12 @@ func collectProvidedTerms(meta *patternMeta) []string {
 		terms = append(terms, strings.ToLower(s))
 	}
 	for _, s := range p.Sagas {
+		terms = append(terms, strings.ToLower(s))
+	}
+	for _, s := range p.ValuationRules {
+		terms = append(terms, strings.ToLower(s))
+	}
+	for _, s := range p.Triggers {
 		terms = append(terms, strings.ToLower(s))
 	}
 	return terms
@@ -183,17 +192,19 @@ func matchesAnyTerm(word string, terms []string) bool {
 
 // applyConflictFilterAndExtends applies three operations in order:
 //  1. Conflict filtering: skip patterns that conflict with already-selected ones.
-//  2. Extends resolution: prepend base patterns required by extends declarations.
-//  3. Top-N selection: return at most maxResults patterns.
+//  2. Top-N selection: apply maxResults cap to the scored candidates.
+//  3. Extends resolution: prepend base patterns required by the final candidate set.
+//
+// Base patterns from extends are prepended outside the maxResults cap so that
+// required dependencies never evict higher-scored matches.
 func applyConflictFilterAndExtends(
+	cookbookFS fs.FS,
 	scored []scoredEntry,
 	allDetails map[string]*patternDetail,
 	maxResults int,
 ) []PatternMatch {
 	selectedNames := make(map[string]bool)
 	conflictSet := make(map[string]bool) // patterns blocked by conflicts
-
-	var result []PatternMatch
 
 	// Collect patterns with conflict filtering.
 	var candidates []PatternMatch
@@ -202,7 +213,6 @@ func applyConflictFilterAndExtends(
 			continue
 		}
 		candidates = append(candidates, s.Match)
-		selectedNames[s.Match.Name] = true
 
 		// Register conflicts: any pattern that conflicts_with this one is blocked.
 		detail := allDetails[s.Match.Name]
@@ -213,40 +223,59 @@ func applyConflictFilterAndExtends(
 		}
 	}
 
-	// Resolve extends: collect all base patterns required by the selected candidates.
-	// Use a worklist to handle transitive extends.
-	basePatterns := resolveExtends(candidates, allDetails, selectedNames)
+	// Apply top-N to candidates only — base patterns from extends do not consume the budget.
+	if maxResults > 0 && len(candidates) > maxResults {
+		candidates = candidates[:maxResults]
+	}
 
-	// Prepend base patterns (they have no score on their own but are required).
+	// Build selectedNames from the final candidate set so that extends resolution
+	// knows which patterns are already represented and avoids duplicating them.
+	for _, c := range candidates {
+		selectedNames[c.Name] = true
+	}
+
+	// Resolve extends for the final candidate set. Passes conflictSet so that a base that
+	// was already rejected by the conflict pass cannot be re-added via extends.
+	basePatterns := resolveExtends(cookbookFS, candidates, allDetails, selectedNames, conflictSet)
+
+	// Prepend base patterns (bases first, then scored candidates).
+	result := make([]PatternMatch, 0, len(basePatterns)+len(candidates))
 	result = append(result, basePatterns...)
 	result = append(result, candidates...)
-
-	// Apply top-N.
-	if maxResults > 0 && len(result) > maxResults {
-		result = result[:maxResults]
-	}
 
 	return result
 }
 
 // resolveExtends returns the set of base patterns required by the extends fields of candidates,
-// excluding patterns already in selectedNames, in dependency order (bases first).
-func resolveExtends(candidates []PatternMatch, allDetails map[string]*patternDetail, selectedNames map[string]bool) []PatternMatch {
-	worklist := collectExtendsWorklist(candidates, allDetails, selectedNames)
+// excluding patterns already in selectedNames or blocked by conflictSet, in dependency order (bases first).
+func resolveExtends(
+	cookbookFS fs.FS,
+	candidates []PatternMatch,
+	allDetails map[string]*patternDetail,
+	selectedNames map[string]bool,
+	conflictSet map[string]bool,
+) []PatternMatch {
+	worklist := collectExtendsWorklist(candidates, allDetails, selectedNames, conflictSet)
 	if len(worklist) == 0 {
 		return nil
 	}
-	return buildBaseMatches(worklist, allDetails)
+	return buildBaseMatches(cookbookFS, worklist, allDetails)
 }
 
 // collectExtendsWorklist performs a BFS over the extends graph starting from candidates.
-// It returns all base pattern names in BFS discovery order, skipping already-selected names.
-func collectExtendsWorklist(candidates []PatternMatch, allDetails map[string]*patternDetail, selectedNames map[string]bool) []string {
+// It returns all base pattern names in BFS discovery order, skipping already-selected names
+// and patterns blocked by conflictSet.
+func collectExtendsWorklist(
+	candidates []PatternMatch,
+	allDetails map[string]*patternDetail,
+	selectedNames map[string]bool,
+	conflictSet map[string]bool,
+) []string {
 	needed := make(map[string]bool)
 	var worklist []string
 
 	enqueue := func(name string) {
-		if !selectedNames[name] && !needed[name] {
+		if !selectedNames[name] && !needed[name] && !conflictSet[name] {
 			needed[name] = true
 			worklist = append(worklist, name)
 		}
@@ -271,8 +300,8 @@ func collectExtendsWorklist(candidates []PatternMatch, allDetails map[string]*pa
 	return worklist
 }
 
-// buildBaseMatches converts a BFS-ordered worklist into PatternMatch values, bases first.
-func buildBaseMatches(worklist []string, allDetails map[string]*patternDetail) []PatternMatch {
+// buildBaseMatches converts a BFS-ordered worklist into PatternMatch values with full assets, bases first.
+func buildBaseMatches(cookbookFS fs.FS, worklist []string, allDetails map[string]*patternDetail) []PatternMatch {
 	bases := make([]PatternMatch, 0, len(worklist))
 	seen := make(map[string]bool, len(worklist))
 	for i := len(worklist) - 1; i >= 0; i-- {
@@ -281,9 +310,13 @@ func buildBaseMatches(worklist []string, allDetails map[string]*patternDetail) [
 			continue
 		}
 		seen[name] = true
-		if detail := allDetails[name]; detail != nil {
-			bases = append(bases, buildPatternMatchFromDetail(name, detail))
+		detail := allDetails[name]
+		if detail == nil {
+			continue
 		}
+		// Use buildPatternMatch to include ManifestFragment and SagaScript for base patterns.
+		item := registryItem{Name: name, Type: "registry:pattern", Title: detail.Title}
+		bases = append(bases, buildPatternMatch(cookbookFS, item, detail))
 	}
 	return bases
 }
@@ -316,13 +349,15 @@ func buildPatternMatchFromDetail(name string, detail *patternDetail) PatternMatc
 		return m
 	}
 
-	// Populate Provides.
+	// Populate Provides (instruments, account types, sagas, valuation rules, triggers).
 	if detail.Meta.Provides != nil {
 		p := detail.Meta.Provides
-		provides := make([]string, 0, len(p.Instruments)+len(p.AccountTypes)+len(p.Sagas))
+		provides := make([]string, 0, len(p.Instruments)+len(p.AccountTypes)+len(p.Sagas)+len(p.ValuationRules)+len(p.Triggers))
 		provides = append(provides, p.Instruments...)
 		provides = append(provides, p.AccountTypes...)
 		provides = append(provides, p.Sagas...)
+		provides = append(provides, p.ValuationRules...)
+		provides = append(provides, p.Triggers...)
 		m.Provides = provides
 	}
 
@@ -420,9 +455,11 @@ type patternMeta struct {
 }
 
 type patternProvides struct {
-	Instruments  []string `json:"instruments,omitempty"`
-	AccountTypes []string `json:"account_types,omitempty"`
-	Sagas        []string `json:"sagas,omitempty"`
+	Instruments    []string `json:"instruments,omitempty"`
+	AccountTypes   []string `json:"account_types,omitempty"`
+	Sagas          []string `json:"sagas,omitempty"`
+	ValuationRules []string `json:"valuation_rules,omitempty"`
+	Triggers       []string `json:"triggers,omitempty"`
 }
 
 type patternRequires struct {

--- a/services/control-plane/internal/generator/pattern_matcher_test.go
+++ b/services/control-plane/internal/generator/pattern_matcher_test.go
@@ -1,0 +1,329 @@
+package generator_test
+
+import (
+	"encoding/json"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/meridianhub/meridian/cookbook"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/control-plane/internal/generator"
+)
+
+// realCookbookFS returns the embedded cookbook FS for integration-style tests.
+func realCookbookFS() fs.FS {
+	return cookbook.FS
+}
+
+// TestMatchPatterns_EnergySettlementMatch verifies that "EV charging UK energy" matches
+// the energy-settlement pattern as the top result.
+func TestMatchPatterns_EnergySettlementMatch(t *testing.T) {
+	matches, err := generator.MatchPatterns(realCookbookFS(), "EV charging UK energy", "energy", 5)
+	require.NoError(t, err)
+	require.NotEmpty(t, matches, "expected at least one match for energy description")
+
+	names := make([]string, len(matches))
+	for i, m := range matches {
+		names[i] = m.Name
+	}
+
+	assert.Contains(t, names, "energy-settlement",
+		"energy-settlement should appear in top results for energy description; got %v", names)
+
+	// energy-settlement must outrank non-energy patterns.
+	var energyIdx int
+	for i, m := range matches {
+		if m.Name == "energy-settlement" {
+			energyIdx = i
+			break
+		}
+	}
+	// The energy-settlement pattern should be highly ranked (top 3).
+	assert.LessOrEqual(t, energyIdx, 2,
+		"energy-settlement should be in top 3 results; got index %d in %v", energyIdx, names)
+}
+
+// TestMatchPatterns_SaasBillingMatch verifies that "SaaS compute billing" matches
+// the saas-billing pattern in the top results.
+func TestMatchPatterns_SaasBillingMatch(t *testing.T) {
+	matches, err := generator.MatchPatterns(realCookbookFS(), "SaaS compute billing", "saas", 5)
+	require.NoError(t, err)
+	require.NotEmpty(t, matches, "expected at least one match for SaaS description")
+
+	names := make([]string, len(matches))
+	for i, m := range matches {
+		names[i] = m.Name
+	}
+
+	assert.Contains(t, names, "saas-billing",
+		"saas-billing should appear in results for SaaS compute billing description; got %v", names)
+
+	// saas-billing should be highly ranked.
+	var saasIdx int
+	found := false
+	for i, m := range matches {
+		if m.Name == "saas-billing" {
+			saasIdx = i
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "saas-billing must be present in results")
+	assert.LessOrEqual(t, saasIdx, 2,
+		"saas-billing should be in top 3 results; got index %d in %v", saasIdx, names)
+}
+
+// TestMatchPatterns_ScoreFields verifies that returned PatternMatch structs have
+// populated Name, Title, Score, and Provides fields.
+func TestMatchPatterns_ScoreFields(t *testing.T) {
+	matches, err := generator.MatchPatterns(realCookbookFS(), "energy settlement billing", "energy", 3)
+	require.NoError(t, err)
+	require.NotEmpty(t, matches)
+
+	for _, m := range matches {
+		assert.NotEmpty(t, m.Name, "Name should be non-empty")
+		assert.NotEmpty(t, m.Title, "Title should be non-empty")
+		assert.GreaterOrEqual(t, m.Score, float64(0), "Score should be non-negative")
+	}
+}
+
+// TestMatchPatterns_ManifestFragmentLoaded verifies that ManifestFragment is populated.
+func TestMatchPatterns_ManifestFragmentLoaded(t *testing.T) {
+	matches, err := generator.MatchPatterns(realCookbookFS(), "EV charging UK energy", "energy", 5)
+	require.NoError(t, err)
+
+	for _, m := range matches {
+		if m.Name == "energy-settlement" {
+			assert.NotEmpty(t, m.ManifestFragment,
+				"ManifestFragment should be populated for energy-settlement")
+			assert.Contains(t, m.ManifestFragment, "KWH",
+				"ManifestFragment should contain KWH instrument")
+			return
+		}
+	}
+	t.Fatal("energy-settlement not found in matches")
+}
+
+// TestMatchPatterns_SagaScriptLoaded verifies that SagaScript is populated for saga-bearing patterns.
+func TestMatchPatterns_SagaScriptLoaded(t *testing.T) {
+	matches, err := generator.MatchPatterns(realCookbookFS(), "EV charging UK energy", "energy", 5)
+	require.NoError(t, err)
+
+	for _, m := range matches {
+		if m.Name == "energy-settlement" {
+			assert.NotEmpty(t, m.SagaScript,
+				"SagaScript should be populated for energy-settlement which has .star files")
+			return
+		}
+	}
+	t.Fatal("energy-settlement not found in matches")
+}
+
+// TestMatchPatterns_ConflictFiltering verifies that conflicting patterns are excluded.
+// energy-a explicitly declares conflicts_with: [conflict-b].
+// When energy-a is selected first (higher score), conflict-b must be excluded.
+func TestMatchPatterns_ConflictFiltering(t *testing.T) {
+	mockFS := buildConflictTestFS(t)
+
+	// "kwh energy inventory" matches energy-a's provides (KWH, ENERGY_INVENTORY) directly.
+	// conflict-b provides SOLAR_PANEL (no keyword overlap), so energy-a scores higher.
+	matches, err := generator.MatchPatterns(mockFS, "kwh energy inventory settlement", "energy", 10)
+	require.NoError(t, err)
+
+	names := namesFromMatches(matches)
+
+	// energy-a should be selected and conflict-b should be filtered.
+	assert.Contains(t, names, "energy-a", "energy-a should be selected")
+	assert.NotContains(t, names, "conflict-b",
+		"conflict-b should be filtered because energy-a conflicts_with it; got %v", names)
+}
+
+// TestMatchPatterns_ExtendsResolution verifies that base patterns required via extends
+// are included in the results even if not explicitly matched.
+func TestMatchPatterns_ExtendsResolution(t *testing.T) {
+	// saas-billing extends base-fiat-usd. When saas-billing matches, base-fiat-usd
+	// should appear in results even though it has no industry or keyword overlap.
+	matches, err := generator.MatchPatterns(realCookbookFS(), "SaaS compute billing GPU hours", "saas", 10)
+	require.NoError(t, err)
+
+	names := make([]string, len(matches))
+	for i, m := range matches {
+		names[i] = m.Name
+	}
+
+	assert.Contains(t, names, "saas-billing",
+		"saas-billing should be in results; got %v", names)
+	assert.Contains(t, names, "base-fiat-usd",
+		"base-fiat-usd should be resolved via saas-billing extends; got %v", names)
+}
+
+// TestMatchPatterns_MaxResults verifies that at most maxResults patterns are returned.
+func TestMatchPatterns_MaxResults(t *testing.T) {
+	matches, err := generator.MatchPatterns(realCookbookFS(), "billing energy compute payments", "", 3)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(matches), 3, "should return at most 3 results")
+}
+
+// TestMatchPatterns_ZeroMaxResults verifies that 0 maxResults returns all matches.
+func TestMatchPatterns_ZeroMaxResults(t *testing.T) {
+	matches, err := generator.MatchPatterns(realCookbookFS(), "energy billing", "", 0)
+	require.NoError(t, err)
+	assert.Greater(t, len(matches), 3, "with maxResults=0 should return more than 3 patterns")
+}
+
+// TestMatchPatterns_EmptyDescription returns results ordered by registry order (no scoring boost).
+func TestMatchPatterns_EmptyDescription(t *testing.T) {
+	matches, err := generator.MatchPatterns(realCookbookFS(), "", "", 5)
+	require.NoError(t, err)
+	// Should still return patterns even with no description.
+	assert.NotEmpty(t, matches, "should return patterns even with empty description")
+}
+
+// TestMatchPatterns_InvalidFS returns an error for an FS missing registry.json.
+func TestMatchPatterns_InvalidFS(t *testing.T) {
+	emptyFS := fstest.MapFS{}
+	_, err := generator.MatchPatterns(emptyFS, "energy", "energy", 5)
+	assert.Error(t, err, "should return error when registry.json is missing")
+}
+
+// TestMatchPatterns_ProvidesPopulated verifies that Provides is populated correctly.
+func TestMatchPatterns_ProvidesPopulated(t *testing.T) {
+	matches, err := generator.MatchPatterns(realCookbookFS(), "EV charging UK energy", "energy", 5)
+	require.NoError(t, err)
+
+	for _, m := range matches {
+		if m.Name == "energy-settlement" {
+			assert.Contains(t, m.Provides, "KWH",
+				"energy-settlement Provides should contain KWH instrument")
+			assert.Contains(t, m.Provides, "usage_to_value",
+				"energy-settlement Provides should contain usage_to_value saga")
+			return
+		}
+	}
+	t.Fatal("energy-settlement not found in matches")
+}
+
+// TestMatchPatterns_RequiresPopulated verifies that Requires is populated correctly.
+func TestMatchPatterns_RequiresPopulated(t *testing.T) {
+	matches, err := generator.MatchPatterns(realCookbookFS(), "EV charging UK energy", "energy", 5)
+	require.NoError(t, err)
+
+	for _, m := range matches {
+		if m.Name == "energy-settlement" {
+			assert.Contains(t, m.Requires, "GBP",
+				"energy-settlement Requires should contain GBP")
+			return
+		}
+	}
+	t.Fatal("energy-settlement not found in matches")
+}
+
+// TestMatchPatterns_IndustryBoost verifies that matching industry boosts score significantly.
+func TestMatchPatterns_IndustryBoost(t *testing.T) {
+	// With explicit industry match, the relevant pattern should score higher than without.
+	matchesWithIndustry, err := generator.MatchPatterns(realCookbookFS(), "billing", "saas", 5)
+	require.NoError(t, err)
+
+	matchesNoIndustry, err := generator.MatchPatterns(realCookbookFS(), "billing", "", 5)
+	require.NoError(t, err)
+
+	// Find saas-billing score in both result sets.
+	scoreWith := float64(-1)
+	for _, m := range matchesWithIndustry {
+		if m.Name == "saas-billing" {
+			scoreWith = m.Score
+			break
+		}
+	}
+	scoreWithout := float64(-1)
+	for _, m := range matchesNoIndustry {
+		if m.Name == "saas-billing" {
+			scoreWithout = m.Score
+			break
+		}
+	}
+
+	if scoreWith >= 0 && scoreWithout >= 0 {
+		assert.Greater(t, scoreWith, scoreWithout,
+			"saas-billing should score higher when industry=saas is specified")
+	}
+}
+
+// --- helpers ---
+
+// buildConflictTestFS creates a minimal fstest.MapFS with two patterns:
+// energy-a (conflicts_with: [conflict-b]) and conflict-b.
+func buildConflictTestFS(t *testing.T) fs.FS {
+	t.Helper()
+
+	energyA := map[string]interface{}{
+		"name":  "energy-a",
+		"type":  "registry:pattern",
+		"title": "Energy A",
+		"meta": map[string]interface{}{
+			"industries": []string{"energy"},
+			"provides": map[string]interface{}{
+				"instruments":   []string{"KWH"},
+				"account_types": []string{"ENERGY_INVENTORY"},
+				"sagas":         []string{},
+			},
+			"requires":       map[string]interface{}{"instruments": []string{}, "market_data": []string{}},
+			"composes_with":  []string{},
+			"conflicts_with": []string{"conflict-b"},
+			"extends":        []string{},
+		},
+	}
+
+	conflictB := map[string]interface{}{
+		"name":  "conflict-b",
+		"type":  "registry:pattern",
+		"title": "Conflict B (incompatible flat rate)",
+		"meta": map[string]interface{}{
+			"industries": []string{},
+			"provides": map[string]interface{}{
+				"instruments":   []string{"SOLAR_PANEL"},
+				"account_types": []string{"FLAT_RATE"},
+				"sagas":         []string{},
+			},
+			"requires":       map[string]interface{}{"instruments": []string{}, "market_data": []string{}},
+			"composes_with":  []string{},
+			"conflicts_with": []string{},
+			"extends":        []string{},
+		},
+	}
+
+	reg := map[string]interface{}{
+		"name": "test-registry",
+		"items": []interface{}{
+			map[string]interface{}{"name": "energy-a", "type": "registry:pattern", "title": "Energy A"},
+			map[string]interface{}{"name": "conflict-b", "type": "registry:pattern", "title": "Conflict B"},
+		},
+	}
+
+	regData, err := json.Marshal(reg)
+	require.NoError(t, err)
+	energyAData, err := json.Marshal(energyA)
+	require.NoError(t, err)
+	conflictBData, err := json.Marshal(conflictB)
+	require.NoError(t, err)
+
+	return fstest.MapFS{
+		"registry.json":                              {Data: regData},
+		"patterns/energy-a/pattern.json":             {Data: energyAData},
+		"patterns/energy-a/manifest-fragment.yaml":   {Data: []byte("instruments:\n  - code: KWH\n")},
+		"patterns/conflict-b/pattern.json":           {Data: conflictBData},
+		"patterns/conflict-b/manifest-fragment.yaml": {Data: []byte("instruments:\n  - code: ELECTRICITY\n")},
+	}
+}
+
+// namesFromMatches extracts pattern names for readability in assertion messages.
+func namesFromMatches(matches []generator.PatternMatch) []string {
+	names := make([]string, len(matches))
+	for i, m := range matches {
+		names[i] = m.Name
+	}
+	return names
+}

--- a/services/control-plane/internal/generator/pattern_matcher_test.go
+++ b/services/control-plane/internal/generator/pattern_matcher_test.go
@@ -33,7 +33,8 @@ func TestMatchPatterns_EnergySettlementMatch(t *testing.T) {
 	assert.Contains(t, names, "energy-settlement",
 		"energy-settlement should appear in top results for energy description; got %v", names)
 
-	// energy-settlement must outrank non-energy patterns.
+	// energy-settlement must appear before non-energy scored patterns.
+	// Base patterns (from extends resolution) may be prepended, so we search among all results.
 	var energyIdx int
 	for i, m := range matches {
 		if m.Name == "energy-settlement" {
@@ -41,9 +42,10 @@ func TestMatchPatterns_EnergySettlementMatch(t *testing.T) {
 			break
 		}
 	}
-	// The energy-settlement pattern should be highly ranked (top 3).
-	assert.LessOrEqual(t, energyIdx, 2,
-		"energy-settlement should be in top 3 results; got index %d in %v", energyIdx, names)
+	// The energy-settlement pattern should be highly ranked (within first 5 results,
+	// accounting for any base patterns prepended via extends).
+	assert.LessOrEqual(t, energyIdx, 4,
+		"energy-settlement should be in top 5 results; got index %d in %v", energyIdx, names)
 }
 
 // TestMatchPatterns_SaasBillingMatch verifies that "SaaS compute billing" matches
@@ -61,7 +63,7 @@ func TestMatchPatterns_SaasBillingMatch(t *testing.T) {
 	assert.Contains(t, names, "saas-billing",
 		"saas-billing should appear in results for SaaS compute billing description; got %v", names)
 
-	// saas-billing should be highly ranked.
+	// saas-billing should be highly ranked (within first 5, accounting for extends bases).
 	var saasIdx int
 	found := false
 	for i, m := range matches {
@@ -72,8 +74,8 @@ func TestMatchPatterns_SaasBillingMatch(t *testing.T) {
 		}
 	}
 	require.True(t, found, "saas-billing must be present in results")
-	assert.LessOrEqual(t, saasIdx, 2,
-		"saas-billing should be in top 3 results; got index %d in %v", saasIdx, names)
+	assert.LessOrEqual(t, saasIdx, 4,
+		"saas-billing should be in top 5 results; got index %d in %v", saasIdx, names)
 }
 
 // TestMatchPatterns_ScoreFields verifies that returned PatternMatch structs have
@@ -160,11 +162,50 @@ func TestMatchPatterns_ExtendsResolution(t *testing.T) {
 		"base-fiat-usd should be resolved via saas-billing extends; got %v", names)
 }
 
-// TestMatchPatterns_MaxResults verifies that at most maxResults patterns are returned.
+// TestMatchPatterns_ExtendsBaseHasAssets verifies that base patterns resolved via extends
+// include ManifestFragment so callers can compose them.
+func TestMatchPatterns_ExtendsBaseHasAssets(t *testing.T) {
+	// saas-billing extends base-fiat-usd; base-fiat-usd should appear with ManifestFragment.
+	matches, err := generator.MatchPatterns(realCookbookFS(), "SaaS compute billing GPU hours", "saas", 10)
+	require.NoError(t, err)
+
+	for _, m := range matches {
+		if m.Name == "base-fiat-usd" {
+			assert.NotEmpty(t, m.ManifestFragment,
+				"base-fiat-usd resolved via extends should have ManifestFragment populated")
+			return
+		}
+	}
+	t.Fatal("base-fiat-usd not found in results via extends resolution")
+}
+
+// TestMatchPatterns_MaxResultsDoesNotExcludeBases verifies that extends bases are prepended
+// outside the maxResults cap so required dependencies do not evict higher-scored candidates.
+func TestMatchPatterns_MaxResultsDoesNotExcludeBases(t *testing.T) {
+	// With maxResults=1, we should get saas-billing AND base-fiat-usd (via extends),
+	// i.e. the extends base is not counted against the cap.
+	matches, err := generator.MatchPatterns(realCookbookFS(), "SaaS compute billing GPU hours", "saas", 1)
+	require.NoError(t, err)
+
+	names := namesFromMatches(matches)
+	assert.Contains(t, names, "saas-billing", "saas-billing should be in results; got %v", names)
+	assert.Contains(t, names, "base-fiat-usd",
+		"base-fiat-usd (extends base) should be prepended outside maxResults cap; got %v", names)
+}
+
+// TestMatchPatterns_MaxResults verifies that at most maxResults scored candidates are returned.
+// Base patterns resolved via extends are prepended outside the cap, so total count may exceed maxResults.
 func TestMatchPatterns_MaxResults(t *testing.T) {
 	matches, err := generator.MatchPatterns(realCookbookFS(), "billing energy compute payments", "", 3)
 	require.NoError(t, err)
-	assert.LessOrEqual(t, len(matches), 3, "should return at most 3 results")
+	// Count only scored candidates (those with Score > 0 or any non-base pattern).
+	// The simplest check: if any extends bases are added they push the count above 3,
+	// but the scored candidates are capped at 3.
+	require.NotEmpty(t, matches, "should return at least one result")
+	// A loose upper bound: with 3 candidates and at most 13 patterns in the real cookbook,
+	// we should never exceed 3 + number_of_base_patterns.
+	assert.LessOrEqual(t, len(matches), 6,
+		"should return at most 3 candidates + any extends bases; got %d: %v", len(matches), namesFromMatches(matches))
 }
 
 // TestMatchPatterns_ZeroMaxResults verifies that 0 maxResults returns all matches.
@@ -187,6 +228,26 @@ func TestMatchPatterns_InvalidFS(t *testing.T) {
 	emptyFS := fstest.MapFS{}
 	_, err := generator.MatchPatterns(emptyFS, "energy", "energy", 5)
 	assert.Error(t, err, "should return error when registry.json is missing")
+}
+
+// TestMatchPatterns_BrokenPatternJSON returns an error for malformed pattern.json.
+func TestMatchPatterns_BrokenPatternJSON(t *testing.T) {
+	reg := map[string]interface{}{
+		"name": "test-registry",
+		"items": []interface{}{
+			map[string]interface{}{"name": "bad-pattern", "type": "registry:pattern", "title": "Bad"},
+		},
+	}
+	regData, err := json.Marshal(reg)
+	require.NoError(t, err)
+
+	brokenFS := fstest.MapFS{
+		"registry.json":                     {Data: regData},
+		"patterns/bad-pattern/pattern.json": {Data: []byte("not valid json {{{")},
+	}
+
+	_, err = generator.MatchPatterns(brokenFS, "energy", "energy", 5)
+	assert.Error(t, err, "malformed pattern.json should surface as an error")
 }
 
 // TestMatchPatterns_ProvidesPopulated verifies that Provides is populated correctly.
@@ -246,10 +307,12 @@ func TestMatchPatterns_IndustryBoost(t *testing.T) {
 		}
 	}
 
-	if scoreWith >= 0 && scoreWithout >= 0 {
-		assert.Greater(t, scoreWith, scoreWithout,
-			"saas-billing should score higher when industry=saas is specified")
-	}
+	require.GreaterOrEqual(t, scoreWith, float64(0),
+		"expected saas-billing in industry-scoped results")
+	require.GreaterOrEqual(t, scoreWithout, float64(0),
+		"expected saas-billing in baseline results")
+	assert.Greater(t, scoreWith, scoreWithout,
+		"saas-billing should score higher when industry=saas is specified")
 }
 
 // --- helpers ---


### PR DESCRIPTION
## Summary

- Implements `MatchPatterns` in `services/control-plane/internal/generator/pattern_matcher.go`
- Three-phase algorithm: load all `registry:pattern` entries from the cookbook embedded FS, score each against description and industry, then apply conflict filtering + extends resolution before returning top-N results
- 14 tests covering all required scenarios: energy-settlement match, saas-billing match, conflict filtering, extends resolution, maxResults, empty inputs, and field population

## Changes Made

**New package**: `services/control-plane/internal/generator`

**`pattern_matcher.go`**
- `PatternMatch` struct with Name, Title, Score, Provides, Requires, ComposesWith, ConflictsWith, ManifestFragment, SagaScript
- `MatchPatterns(cookbookFS, description, industry, maxResults)` — public entry point
- Scoring: +10 for industry match, +1 per keyword in provides terms, +0.5 per keyword in title/description
- Conflict filtering: patterns declared in `conflicts_with` of a higher-ranked selection are excluded
- Extends resolution: base patterns required by `extends` are prepended to results (transitive BFS)
- ManifestFragment loaded from `patterns/<name>/manifest-fragment.yaml`
- SagaScript loaded from the first `*.star` file in the pattern directory

**`pattern_matcher_test.go`**
- Uses `cookbook.FS` (embedded) for integration-style tests
- Uses `fstest.MapFS` for the conflict filtering test (controlled scenario)

## Test plan

- [x] `go test ./services/control-plane/internal/generator/...` — all 14 tests pass
- [x] `golangci-lint` — 0 issues
- [x] `gofumpt` — passes