### PR TITLE
feat: Add context component generators for economy generation

### DIFF
--- a/services/control-plane/internal/generator/handler_reference.go
+++ b/services/control-plane/internal/generator/handler_reference.go
@@ -1,0 +1,158 @@
+// Package generator provides context component generators for AI-assisted manifest generation.
+// These generators produce structured text documents optimized for LLM consumption.
+package generator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+)
+
+// BuildHandlerReferenceCard generates a markdown-style reference document listing all
+// handlers registered in the schema registry. The output is optimized for LLM consumption:
+// compact but complete, grouped by service domain.
+func BuildHandlerReferenceCard(registry *schema.Registry) string {
+	var sb strings.Builder
+
+	sb.WriteString("## Handler Reference Card\n\n")
+	sb.WriteString("Use these handler names in Starlark saga scripts via `ctx.<service>.<handler>(...)`.\n\n")
+
+	// Group handlers by service domain (prefix before the first dot)
+	type handlerEntry struct {
+		fullName string
+		def      *schema.HandlerDef
+	}
+
+	byService := make(map[string][]handlerEntry)
+	for _, name := range registry.ListHandlers() {
+		def, err := registry.GetHandler(name)
+		if err != nil {
+			continue
+		}
+		service := servicePrefix(name)
+		byService[service] = append(byService[service], handlerEntry{fullName: name, def: def})
+	}
+
+	// Sort service names for deterministic output
+	services := make([]string, 0, len(byService))
+	for svc := range byService {
+		services = append(services, svc)
+	}
+	sort.Strings(services)
+
+	for _, svc := range services {
+		handlers := byService[svc]
+		sort.Slice(handlers, func(i, j int) bool {
+			return handlers[i].fullName < handlers[j].fullName
+		})
+
+		sb.WriteString(fmt.Sprintf("### %s\n\n", svc))
+
+		for _, h := range handlers {
+			writeHandlerEntry(&sb, h.fullName, h.def)
+		}
+	}
+
+	return sb.String()
+}
+
+// writeHandlerEntry writes a single handler entry to the string builder.
+func writeHandlerEntry(sb *strings.Builder, fullName string, def *schema.HandlerDef) {
+	// Handler name and deprecation status
+	if def.Deprecated {
+		fmt.Fprintf(sb, "#### `%s` *(deprecated)*\n", fullName)
+	} else {
+		fmt.Fprintf(sb, "#### `%s`\n", fullName)
+	}
+
+	if def.Description != "" {
+		fmt.Fprintf(sb, "%s\n", def.Description)
+	}
+
+	// Parameters
+	if len(def.Params) > 0 {
+		sb.WriteString("**Params:**\n")
+		paramNames := sortedKeys(def.Params)
+		for _, paramName := range paramNames {
+			field := def.Params[paramName]
+			fmt.Fprintf(sb, "- `%s`: %s", paramName, formatFieldType(field))
+			if field.Required {
+				sb.WriteString(" *(required)*")
+			}
+			if field.Description != "" {
+				fmt.Fprintf(sb, " — %s", field.Description)
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	// Returns
+	if len(def.Returns) > 0 {
+		sb.WriteString("**Returns:**\n")
+		returnNames := sortedKeys(def.Returns)
+		for _, returnName := range returnNames {
+			field := def.Returns[returnName]
+			fmt.Fprintf(sb, "- `%s`: %s", returnName, formatFieldType(field))
+			if field.Description != "" {
+				fmt.Fprintf(sb, " — %s", field.Description)
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	// Compensation
+	switch {
+	case def.Compensate != "":
+		fmt.Fprintf(sb, "**Compensation:** `%s`\n", def.Compensate)
+	case def.CompensationStrategy == schema.CompensationStrategyNone:
+		sb.WriteString("**Compensation:** none\n")
+	case def.CompensationStrategy == schema.CompensationStrategySagaManaged:
+		sb.WriteString("**Compensation:** saga-managed\n")
+	}
+
+	sb.WriteString("\n")
+}
+
+// servicePrefix extracts the service domain from a fully-qualified handler name.
+// For "position_keeping.initiate_log" it returns "position_keeping".
+// For handlers with no dot, returns the full name.
+func servicePrefix(handlerName string) string {
+	if idx := strings.Index(handlerName, "."); idx >= 0 {
+		return handlerName[:idx]
+	}
+	return handlerName
+}
+
+// formatFieldType returns a compact string representation of a field type.
+func formatFieldType(field *schema.FieldDef) string {
+	switch field.Type {
+	case schema.TypeEnum:
+		return fmt.Sprintf("enum(%s)", strings.Join(field.Values, "|"))
+	case schema.TypeArray:
+		if field.ItemType != "" {
+			return fmt.Sprintf("array<%s>", field.ItemType)
+		}
+		return "array"
+	case schema.TypeMap:
+		if field.KeyType != "" && field.ValueType != "" {
+			return fmt.Sprintf("map<%s,%s>", field.KeyType, field.ValueType)
+		}
+		return "map"
+	case schema.TypeString, schema.TypeInt32, schema.TypeInt64, schema.TypeUint32,
+		schema.TypeBool, schema.TypeDecimal, schema.TypeUUID:
+		return string(field.Type)
+	}
+	return string(field.Type)
+}
+
+// sortedKeys returns the keys of a FieldDef map in sorted order.
+func sortedKeys(m map[string]*schema.FieldDef) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/services/control-plane/internal/generator/handler_reference_test.go
+++ b/services/control-plane/internal/generator/handler_reference_test.go
@@ -1,0 +1,201 @@
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildHandlerReferenceCard_EmptyRegistry(t *testing.T) {
+	registry := schema.NewRegistry()
+	result := BuildHandlerReferenceCard(registry)
+
+	assert.Contains(t, result, "## Handler Reference Card")
+	assert.Contains(t, result, "ctx.<service>.<handler>")
+}
+
+func TestBuildHandlerReferenceCard_SingleHandler(t *testing.T) {
+	registry := schema.NewRegistry()
+	err := registry.LoadFromYAML([]byte(`
+service: position_keeping
+version: "1.0"
+handlers:
+  position_keeping.initiate_log:
+    description: Initiates a financial position log entry.
+    params:
+      account_id:
+        type: uuid
+        required: true
+        description: The account identifier.
+      amount:
+        type: Decimal
+        required: true
+    returns:
+      log_id:
+        type: uuid
+        description: The created log identifier.
+    compensate: position_keeping.void_log
+`))
+	require.NoError(t, err)
+
+	result := BuildHandlerReferenceCard(registry)
+
+	assert.Contains(t, result, "### position_keeping")
+	assert.Contains(t, result, "`position_keeping.initiate_log`")
+	assert.Contains(t, result, "Initiates a financial position log entry.")
+	assert.Contains(t, result, "`account_id`: uuid *(required)*")
+	assert.Contains(t, result, "`amount`: Decimal *(required)*")
+	assert.Contains(t, result, "`log_id`: uuid")
+	assert.Contains(t, result, "**Compensation:** `position_keeping.void_log`")
+}
+
+func TestBuildHandlerReferenceCard_DeprecatedHandler(t *testing.T) {
+	registry := schema.NewRegistry()
+	err := registry.LoadFromYAML([]byte(`
+service: financial_accounting
+version: "1.0"
+handlers:
+  financial_accounting.old_booking:
+    description: Old booking handler.
+    deprecated: true
+    params:
+      amount:
+        type: Decimal
+        required: true
+    compensation_strategy: none
+`))
+	require.NoError(t, err)
+
+	result := BuildHandlerReferenceCard(registry)
+
+	assert.Contains(t, result, "`financial_accounting.old_booking` *(deprecated)*")
+}
+
+func TestBuildHandlerReferenceCard_EnumField(t *testing.T) {
+	registry := schema.NewRegistry()
+	err := registry.LoadFromYAML([]byte(`
+service: current_account
+version: "1.0"
+handlers:
+  current_account.update_status:
+    params:
+      direction:
+        type: enum
+        values: [DEBIT, CREDIT]
+        required: true
+    compensation_strategy: none
+`))
+	require.NoError(t, err)
+
+	result := BuildHandlerReferenceCard(registry)
+
+	assert.Contains(t, result, "`direction`: enum(DEBIT|CREDIT) *(required)*")
+}
+
+func TestBuildHandlerReferenceCard_MultipleServices(t *testing.T) {
+	registry := schema.NewRegistry()
+	err := registry.LoadFromYAML([]byte(`
+service: position_keeping
+version: "1.0"
+handlers:
+  position_keeping.capture:
+    params:
+      amount:
+        type: Decimal
+        required: true
+    compensate: position_keeping.reverse_capture
+`))
+	require.NoError(t, err)
+
+	err = registry.LoadFromYAML([]byte(`
+service: current_account
+version: "1.0"
+handlers:
+  current_account.freeze:
+    params:
+      account_id:
+        type: uuid
+        required: true
+    compensation_strategy: none
+`))
+	require.NoError(t, err)
+
+	result := BuildHandlerReferenceCard(registry)
+
+	// Both services should appear
+	assert.Contains(t, result, "### position_keeping")
+	assert.Contains(t, result, "### current_account")
+
+	// current_account should appear before position_keeping (alphabetical order)
+	caIdx := strings.Index(result, "### current_account")
+	pkIdx := strings.Index(result, "### position_keeping")
+	assert.Less(t, caIdx, pkIdx, "services should be sorted alphabetically")
+}
+
+func TestBuildHandlerReferenceCard_CompensationStrategySagaManaged(t *testing.T) {
+	registry := schema.NewRegistry()
+	err := registry.LoadFromYAML([]byte(`
+service: payment_order
+version: "1.0"
+handlers:
+  payment_order.execute:
+    params:
+      order_id:
+        type: uuid
+        required: true
+    compensation_strategy: saga_managed
+`))
+	require.NoError(t, err)
+
+	result := BuildHandlerReferenceCard(registry)
+
+	assert.Contains(t, result, "**Compensation:** saga-managed")
+}
+
+func TestBuildHandlerReferenceCard_ArrayAndMapFields(t *testing.T) {
+	registry := schema.NewRegistry()
+	err := registry.LoadFromYAML([]byte(`
+service: reconciliation
+version: "1.0"
+handlers:
+  reconciliation.batch_check:
+    params:
+      entry_ids:
+        type: array
+        item_type: uuid
+        required: true
+      metadata:
+        type: map
+        key_type: string
+        value_type: string
+    compensation_strategy: none
+`))
+	require.NoError(t, err)
+
+	result := BuildHandlerReferenceCard(registry)
+
+	assert.Contains(t, result, "`entry_ids`: array<uuid>")
+	assert.Contains(t, result, "`metadata`: map<string,string>")
+}
+
+func TestServicePrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "WithDot", input: "position_keeping.initiate_log", expected: "position_keeping"},
+		{name: "NoDot", input: "standalone_handler", expected: "standalone_handler"},
+		{name: "MultipleDots", input: "a.b.c", expected: "a"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := servicePrefix(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/services/control-plane/internal/generator/schema_summary.go
+++ b/services/control-plane/internal/generator/schema_summary.go
@@ -1,0 +1,139 @@
+package generator
+
+import (
+	"fmt"
+	"strings"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// BuildManifestSchemaSummary generates a compact schema summary of the Manifest proto message
+// using proto reflection. The output is optimized for LLM understanding when generating
+// manifest YAML files.
+func BuildManifestSchemaSummary() string {
+	var sb strings.Builder
+
+	sb.WriteString("## Manifest Schema Summary\n\n")
+	sb.WriteString("The Manifest is the atomic configuration snapshot for a Meridian tenant.\n\n")
+
+	msg := &controlplanev1.Manifest{}
+	md := msg.ProtoReflect().Descriptor()
+
+	writeMessageSummary(&sb, md, 0, 2)
+
+	return sb.String()
+}
+
+// writeMessageSummary writes a summary of a proto message descriptor up to maxDepth levels deep.
+func writeMessageSummary(sb *strings.Builder, md protoreflect.MessageDescriptor, depth, maxDepth int) {
+	fields := md.Fields()
+	for i := 0; i < fields.Len(); i++ {
+		fd := fields.Get(i)
+		indent := strings.Repeat("  ", depth)
+		fieldName := string(fd.Name())
+		typeSummary := fieldTypeSummary(fd)
+
+		required := isRequiredField(fd)
+		requiredStr := ""
+		if required {
+			requiredStr = " *(required)*"
+		}
+
+		if fd.IsList() {
+			fmt.Fprintf(sb, "%s- `%s`: repeated %s%s\n", indent, fieldName, typeSummary, requiredStr)
+		} else {
+			fmt.Fprintf(sb, "%s- `%s`: %s%s\n", indent, fieldName, typeSummary, requiredStr)
+		}
+
+		// Recurse into nested messages up to maxDepth
+		if depth < maxDepth && fd.Kind() == protoreflect.MessageKind && !isWellKnownType(fd) {
+			writeMessageSummary(sb, fd.Message(), depth+1, maxDepth)
+		}
+	}
+}
+
+// fieldTypeSummary returns a compact type description for a field descriptor.
+func fieldTypeSummary(fd protoreflect.FieldDescriptor) string {
+	switch fd.Kind() {
+	case protoreflect.EnumKind:
+		ed := fd.Enum()
+		values := enumValueNames(ed)
+		if len(values) <= 5 {
+			return fmt.Sprintf("enum(%s)", strings.Join(values, "|"))
+		}
+		return fmt.Sprintf("enum(%s|...)", strings.Join(values[:3], "|"))
+	case protoreflect.MessageKind:
+		if isWellKnownType(fd) {
+			return wellKnownTypeName(fd)
+		}
+		return string(fd.Message().Name())
+	case protoreflect.BoolKind:
+		return "bool"
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+		return "int32"
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		return "uint32"
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		return "int64"
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		return "uint64"
+	case protoreflect.FloatKind:
+		return "float"
+	case protoreflect.DoubleKind:
+		return "double"
+	case protoreflect.StringKind:
+		return "string"
+	case protoreflect.BytesKind:
+		return "bytes"
+	case protoreflect.GroupKind:
+		return "group"
+	}
+	return fd.Kind().String()
+}
+
+// enumValueNames returns the names of all enum values, excluding the UNSPECIFIED value.
+func enumValueNames(ed protoreflect.EnumDescriptor) []string {
+	values := ed.Values()
+	names := make([]string, 0, values.Len())
+	for i := 0; i < values.Len(); i++ {
+		name := string(values.Get(i).Name())
+		// Skip UNSPECIFIED values to reduce noise
+		if strings.Contains(name, "UNSPECIFIED") {
+			continue
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+// isWellKnownType returns true if the field is a well-known proto type that
+// should not be expanded further.
+func isWellKnownType(fd protoreflect.FieldDescriptor) bool {
+	if fd.Kind() != protoreflect.MessageKind {
+		return false
+	}
+	fullName := string(fd.Message().FullName())
+	return strings.HasPrefix(fullName, "google.protobuf.") ||
+		strings.HasPrefix(fullName, "google.type.")
+}
+
+// wellKnownTypeName returns a compact name for well-known proto types.
+func wellKnownTypeName(fd protoreflect.FieldDescriptor) string {
+	fullName := string(fd.Message().FullName())
+	parts := strings.Split(fullName, ".")
+	return parts[len(parts)-1]
+}
+
+// isRequiredField checks if a field is marked required via buf validate annotations.
+// Since we can't easily read buf validate options at runtime without the extension descriptors,
+// we use a heuristic: message fields with non-nil defaults that appear in the proto are likely required.
+// For accuracy, we check the field name against known required fields in the Manifest.
+func isRequiredField(fd protoreflect.FieldDescriptor) bool {
+	// Fields marked as required in the Manifest proto via buf validate
+	knownRequired := map[string]bool{
+		"version":  true,
+		"metadata": true,
+	}
+	return knownRequired[string(fd.Name())]
+}

--- a/services/control-plane/internal/generator/schema_summary.go
+++ b/services/control-plane/internal/generator/schema_summary.go
@@ -40,9 +40,12 @@ func writeMessageSummary(sb *strings.Builder, md protoreflect.MessageDescriptor,
 			requiredStr = " *(required)*"
 		}
 
-		if fd.IsList() {
+		switch {
+		case fd.IsMap():
+			fmt.Fprintf(sb, "%s- `%s`: map%s\n", indent, fieldName, requiredStr)
+		case fd.IsList():
 			fmt.Fprintf(sb, "%s- `%s`: repeated %s%s\n", indent, fieldName, typeSummary, requiredStr)
-		} else {
+		default:
 			fmt.Fprintf(sb, "%s- `%s`: %s%s\n", indent, fieldName, typeSummary, requiredStr)
 		}
 
@@ -126,11 +129,11 @@ func wellKnownTypeName(fd protoreflect.FieldDescriptor) string {
 }
 
 // isRequiredField checks if a field is marked required via buf validate annotations.
-// Since we can't easily read buf validate options at runtime without the extension descriptors,
-// we use a heuristic: message fields with non-nil defaults that appear in the proto are likely required.
-// For accuracy, we check the field name against known required fields in the Manifest.
+// Since buf validate options cannot be read at runtime without the extension descriptors,
+// this uses a hardcoded list derived from api/proto/meridian/control_plane/v1/manifest.proto.
+// Update this list when required fields change in the proto.
 func isRequiredField(fd protoreflect.FieldDescriptor) bool {
-	// Fields marked as required in the Manifest proto via buf validate
+	// Source of truth: buf.validate.field.required = true in manifest.proto
 	knownRequired := map[string]bool{
 		"version":  true,
 		"metadata": true,

--- a/services/control-plane/internal/generator/schema_summary_test.go
+++ b/services/control-plane/internal/generator/schema_summary_test.go
@@ -1,0 +1,65 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildManifestSchemaSummary_ContainsHeader(t *testing.T) {
+	result := BuildManifestSchemaSummary()
+
+	assert.Contains(t, result, "## Manifest Schema Summary")
+	assert.Contains(t, result, "Manifest is the atomic configuration snapshot")
+}
+
+func TestBuildManifestSchemaSummary_ContainsTopLevelFields(t *testing.T) {
+	result := BuildManifestSchemaSummary()
+
+	// Top-level Manifest fields
+	assert.Contains(t, result, "`version`")
+	assert.Contains(t, result, "`metadata`")
+	assert.Contains(t, result, "`instruments`")
+	assert.Contains(t, result, "`account_types`")
+	assert.Contains(t, result, "`sagas`")
+	assert.Contains(t, result, "`valuation_rules`")
+}
+
+func TestBuildManifestSchemaSummary_RequiredFieldsMarked(t *testing.T) {
+	result := BuildManifestSchemaSummary()
+
+	// version and metadata are required in the proto
+	assert.Contains(t, result, "`version`: string *(required)*")
+	assert.Contains(t, result, "`metadata`: ManifestMetadata *(required)*")
+}
+
+func TestBuildManifestSchemaSummary_NestedFieldsExpanded(t *testing.T) {
+	result := BuildManifestSchemaSummary()
+
+	// ManifestMetadata nested fields should be visible (depth 1)
+	assert.Contains(t, result, "`name`")
+	assert.Contains(t, result, "`industry`")
+	assert.Contains(t, result, "`description`")
+}
+
+func TestBuildManifestSchemaSummary_RepeatedFieldsMarked(t *testing.T) {
+	result := BuildManifestSchemaSummary()
+
+	assert.Contains(t, result, "repeated InstrumentDefinition")
+	assert.Contains(t, result, "repeated AccountTypeDefinition")
+	assert.Contains(t, result, "repeated SagaDefinition")
+}
+
+func TestBuildManifestSchemaSummary_EnumsExpanded(t *testing.T) {
+	result := BuildManifestSchemaSummary()
+
+	// InstrumentType enum values should appear
+	assert.Contains(t, result, "INSTRUMENT_TYPE_FIAT")
+}
+
+func TestBuildManifestSchemaSummary_NonEmpty(t *testing.T) {
+	result := BuildManifestSchemaSummary()
+
+	// Should produce a non-trivial output
+	assert.Greater(t, len(result), 500, "summary should be substantial")
+}

--- a/services/control-plane/internal/generator/topic_list.go
+++ b/services/control-plane/internal/generator/topic_list.go
@@ -1,0 +1,87 @@
+package generator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
+)
+
+// BuildTopicList generates a formatted list of all available Kafka event topics.
+// Topics are grouped by service domain. The output is optimized for LLM consumption
+// when generating saga triggers that use the "event:" prefix.
+func BuildTopicList() string {
+	var sb strings.Builder
+
+	sb.WriteString("## Available Event Topics (for saga trigger: \"event:\")\n\n")
+	sb.WriteString("Use these topics as saga triggers: `trigger: \"event:<topic-name>\"`\n\n")
+
+	// Group topics by service domain (prefix before the first dot)
+	byService := make(map[string][]string)
+	for _, topic := range topics.All() {
+		svc := topicServicePrefix(topic)
+		byService[svc] = append(byService[svc], topic)
+	}
+
+	// Sort service names for deterministic output
+	services := make([]string, 0, len(byService))
+	for svc := range byService {
+		services = append(services, svc)
+	}
+	sort.Strings(services)
+
+	for _, svc := range services {
+		topicList := byService[svc]
+		sort.Strings(topicList)
+
+		sb.WriteString(fmt.Sprintf("### %s\n\n", svc))
+		for _, topic := range topicList {
+			desc := describeTopicName(topic)
+			sb.WriteString(fmt.Sprintf("- `%s` — %s\n", topic, desc))
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// topicServicePrefix extracts the service domain from a topic name.
+// Topics follow the pattern: <service>.<event-name>.<version>
+// For "position-keeping.transaction-captured.v1" returns "position-keeping".
+func topicServicePrefix(topic string) string {
+	if idx := strings.Index(topic, "."); idx >= 0 {
+		return topic[:idx]
+	}
+	return topic
+}
+
+// describeTopicName derives a human-readable description from a topic name.
+// Strips the version suffix and converts kebab-case to title-case words.
+func describeTopicName(topic string) string {
+	parts := strings.SplitN(topic, ".", 3)
+	if len(parts) < 2 {
+		return topic
+	}
+
+	// Use the event name part (index 1), strip version (index 2)
+	eventPart := parts[1]
+
+	// Convert kebab-case event name to readable words
+	words := strings.Split(eventPart, "-")
+	for i, w := range words {
+		if len(w) > 0 {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+
+	service := parts[0]
+	serviceWords := strings.Split(service, "-")
+	for i, w := range serviceWords {
+		if len(w) > 0 {
+			serviceWords[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+
+	return fmt.Sprintf("%s %s event", strings.Join(serviceWords, " "), strings.Join(words, " "))
+}

--- a/services/control-plane/internal/generator/topic_list_test.go
+++ b/services/control-plane/internal/generator/topic_list_test.go
@@ -1,0 +1,124 @@
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildTopicList_ContainsHeader(t *testing.T) {
+	result := BuildTopicList()
+
+	assert.Contains(t, result, "## Available Event Topics (for saga trigger: \"event:\")")
+	assert.Contains(t, result, "trigger: \"event:<topic-name>\"")
+}
+
+func TestBuildTopicList_ContainsKnownTopics(t *testing.T) {
+	result := BuildTopicList()
+
+	// Known topics from the topics package
+	assert.Contains(t, result, "position-keeping.transaction-captured.v1")
+	assert.Contains(t, result, "payment-order.initiated.v1")
+	assert.Contains(t, result, "current-account.account-frozen.v1")
+	assert.Contains(t, result, "audit.events.v1")
+}
+
+func TestBuildTopicList_GroupedByService(t *testing.T) {
+	result := BuildTopicList()
+
+	// Should have service group headers
+	assert.Contains(t, result, "### position-keeping")
+	assert.Contains(t, result, "### payment-order")
+	assert.Contains(t, result, "### current-account")
+	assert.Contains(t, result, "### audit")
+}
+
+func TestBuildTopicList_TopicsFormattedAsListItems(t *testing.T) {
+	result := BuildTopicList()
+
+	// Each topic should be formatted as a markdown list item with backtick name
+	assert.Contains(t, result, "- `position-keeping.transaction-captured.v1`")
+}
+
+func TestBuildTopicList_ServicesSortedAlphabetically(t *testing.T) {
+	result := BuildTopicList()
+
+	// audit should come before position-keeping alphabetically
+	auditIdx := strings.Index(result, "### audit")
+	pkIdx := strings.Index(result, "### position-keeping")
+	assert.Less(t, auditIdx, pkIdx, "services should be sorted alphabetically")
+}
+
+func TestBuildTopicList_TopicsHaveDescriptions(t *testing.T) {
+	result := BuildTopicList()
+
+	// Each topic line should have a description after " — "
+	lines := strings.Split(result, "\n")
+	topicLines := 0
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "- `") {
+			assert.Contains(t, line, " — ", "topic line should have description: %s", line)
+			topicLines++
+		}
+	}
+	assert.Greater(t, topicLines, 0, "should have at least one topic line")
+}
+
+func TestBuildTopicList_NonZeroTopics(t *testing.T) {
+	result := BuildTopicList()
+
+	// Count topic lines
+	count := strings.Count(result, "\n- `")
+	assert.Greater(t, count, 10, "should contain more than 10 topics")
+}
+
+func TestTopicServicePrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "StandardTopic", input: "position-keeping.transaction-captured.v1", expected: "position-keeping"},
+		{name: "AuditTopic", input: "audit.events.v1", expected: "audit"},
+		{name: "NoDot", input: "standalone", expected: "standalone"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := topicServicePrefix(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestDescribeTopicName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		contains string
+	}{
+		{
+			name:     "TransactionCaptured",
+			input:    "position-keeping.transaction-captured.v1",
+			contains: "Transaction Captured",
+		},
+		{
+			name:     "AccountFrozen",
+			input:    "current-account.account-frozen.v1",
+			contains: "Account Frozen",
+		},
+		{
+			name:     "PaymentInitiated",
+			input:    "payment-order.initiated.v1",
+			contains: "Initiated",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := describeTopicName(tc.input)
+			assert.Contains(t, result, tc.contains)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `services/control-plane/internal/generator` package with three context component generators
- `BuildHandlerReferenceCard`: produces a markdown reference card of all handlers from `schema.Registry`, grouped by service domain with params, returns, compensation, and deprecation status
- `BuildTopicList`: formats all Kafka event topics from `topics.All()` grouped by service domain, for use as saga `event:` triggers
- `BuildManifestSchemaSummary`: uses proto reflection on the `Manifest` message to produce a compact schema summary (fields, types, required markers, enum values) for LLM-assisted manifest generation

## Test plan

- [ ] `go test ./services/control-plane/internal/generator/...` passes (all 3 generator functions covered)
- [ ] `go build ./services/control-plane/...` compiles cleanly
- [ ] golangci-lint passes (exhaustive switches, no WriteString(fmt.Sprintf(...)) patterns)

## Task Master

economy-generator.2, economy-generator.3, economy-generator.4