### PR TITLE
feat: Add context assembler for economy generation

### DIFF
--- a/services/control-plane/internal/generator/context_assembler.go
+++ b/services/control-plane/internal/generator/context_assembler.go
@@ -158,7 +158,9 @@ func buildPrompt(
 	sb.WriteString("- Use only event topic names listed in the Available Event Topics section for saga triggers.\n")
 	sb.WriteString("- All saga scripts must be valid Starlark (no while loops, no recursion).\n")
 	sb.WriteString("- Follow the Manifest Schema Reference for field names and types.\n")
-	sb.WriteString("- Copy and adapt the Relevant Patterns where applicable.\n")
+	if len(patterns) > 0 {
+		sb.WriteString("- Copy and adapt the Relevant Patterns where applicable.\n")
+	}
 	if currentEconomyJSON != "" {
 		sb.WriteString("- Preserve existing instruments, account types, and sagas from the Current Economy unless explicitly asked to change them.\n")
 	}

--- a/services/control-plane/internal/generator/context_assembler.go
+++ b/services/control-plane/internal/generator/context_assembler.go
@@ -17,6 +17,9 @@ var ErrBlankDescription = errors.New("description is required")
 // ErrMissingCurrentManifest is returned when IncludeCurrentEconomy is true but CurrentManifest is nil.
 var ErrMissingCurrentManifest = errors.New("CurrentManifest is required when IncludeCurrentEconomy is true")
 
+// ErrMissingRegistry is returned when AssembleContext is called with a nil schema registry.
+var ErrMissingRegistry = errors.New("registry is required")
+
 // ContextAssemblerOptions configures the context assembly process.
 type ContextAssemblerOptions struct {
 	// Description is the tenant's business description (required).
@@ -57,6 +60,9 @@ func AssembleContext(opts ContextAssemblerOptions, registry *schema.Registry, co
 	// Validate required fields.
 	if strings.TrimSpace(opts.Description) == "" {
 		return nil, ErrBlankDescription
+	}
+	if registry == nil {
+		return nil, ErrMissingRegistry
 	}
 	if opts.IncludeCurrentEconomy && opts.CurrentManifest == nil {
 		return nil, ErrMissingCurrentManifest
@@ -130,42 +136,66 @@ func buildPrompt(
 	// Available Event Topics
 	sb.WriteString(topicList)
 
-	// Relevant Patterns
-	if len(patterns) > 0 {
-		sb.WriteString("## Relevant Patterns (copy and adapt)\n\n")
-		for _, p := range patterns {
-			fmt.Fprintf(&sb, "### Pattern: %s\n\n", p.Title)
-			if p.ManifestFragment != "" {
-				sb.WriteString("**Manifest Fragment:**\n\n```yaml\n")
-				sb.WriteString(p.ManifestFragment)
-				sb.WriteString("```\n\n")
+	writePatternsSection(&sb, patterns)
+	writeCurrentEconomySection(&sb, currentEconomyJSON)
+	writeRelationshipGraphSection(&sb, opts.RelationshipGraph)
+	writeInstructionsSection(&sb, patterns, currentEconomyJSON)
+
+	return sb.String()
+}
+
+// writePatternsSection writes the Relevant Patterns section to sb, or nothing if empty.
+func writePatternsSection(sb *strings.Builder, patterns []PatternMatch) {
+	if len(patterns) == 0 {
+		return
+	}
+	sb.WriteString("## Relevant Patterns (copy and adapt)\n\n")
+	for _, p := range patterns {
+		fmt.Fprintf(sb, "### Pattern: %s\n\n", p.Title)
+		if p.ManifestFragment != "" {
+			sb.WriteString("**Manifest Fragment:**\n\n```yaml\n")
+			sb.WriteString(p.ManifestFragment)
+			if !strings.HasSuffix(p.ManifestFragment, "\n") {
+				sb.WriteString("\n")
 			}
-			if p.SagaScript != "" {
-				sb.WriteString("**Saga Script:**\n\n```python\n")
-				sb.WriteString(p.SagaScript)
-				sb.WriteString("```\n\n")
+			sb.WriteString("```\n\n")
+		}
+		if p.SagaScript != "" {
+			sb.WriteString("**Saga Script:**\n\n```python\n")
+			sb.WriteString(p.SagaScript)
+			if !strings.HasSuffix(p.SagaScript, "\n") {
+				sb.WriteString("\n")
 			}
+			sb.WriteString("```\n\n")
 		}
 	}
+}
 
-	// Current Economy (amend mode only)
-	if currentEconomyJSON != "" {
-		sb.WriteString("## Current Economy\n\n")
-		sb.WriteString("The following is the tenant's existing manifest. Amend it according to the business description above.\n\n")
-		sb.WriteString("```json\n")
-		sb.WriteString(currentEconomyJSON)
-		sb.WriteString("\n```\n\n")
+// writeCurrentEconomySection writes the Current Economy section to sb, or nothing if empty.
+func writeCurrentEconomySection(sb *strings.Builder, currentEconomyJSON string) {
+	if currentEconomyJSON == "" {
+		return
 	}
+	sb.WriteString("## Current Economy\n\n")
+	sb.WriteString("The following is the tenant's existing manifest. Amend it according to the business description above.\n\n")
+	sb.WriteString("```json\n")
+	sb.WriteString(currentEconomyJSON)
+	sb.WriteString("\n```\n\n")
+}
 
-	// Relationship Graph (optional)
-	if opts.RelationshipGraph != "" {
-		sb.WriteString("## Economy Relationship Graph\n\n")
-		sb.WriteString("```json\n")
-		sb.WriteString(opts.RelationshipGraph)
-		sb.WriteString("\n```\n\n")
+// writeRelationshipGraphSection writes the Economy Relationship Graph section to sb, or nothing if empty.
+func writeRelationshipGraphSection(sb *strings.Builder, graph string) {
+	if graph == "" {
+		return
 	}
+	sb.WriteString("## Economy Relationship Graph\n\n")
+	sb.WriteString("```json\n")
+	sb.WriteString(graph)
+	sb.WriteString("\n```\n\n")
+}
 
-	// Instructions
+// writeInstructionsSection writes the Instructions section to sb.
+func writeInstructionsSection(sb *strings.Builder, patterns []PatternMatch, currentEconomyJSON string) {
 	sb.WriteString("## Instructions\n\n")
 	sb.WriteString("Generate a complete Meridian manifest YAML that implements the business description above.\n\n")
 	sb.WriteString("Rules:\n")
@@ -180,8 +210,6 @@ func buildPrompt(
 		sb.WriteString("- Preserve existing instruments, account types, and sagas from the Current Economy unless explicitly asked to change them.\n")
 	}
 	sb.WriteString("- Output only the YAML manifest. Do not include explanations or markdown fencing.\n")
-
-	return sb.String()
 }
 
 // estimateTokens returns a rough token estimate for the prompt.

--- a/services/control-plane/internal/generator/context_assembler.go
+++ b/services/control-plane/internal/generator/context_assembler.go
@@ -1,0 +1,172 @@
+package generator
+
+import (
+	"fmt"
+	"io/fs"
+	"strings"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// ContextAssemblerOptions configures the context assembly process.
+type ContextAssemblerOptions struct {
+	// Description is the tenant's business description (required).
+	Description string
+	// Industry is an optional industry hint used to improve pattern matching.
+	Industry string
+	// IncludePatterns controls whether cookbook patterns are matched and included.
+	// Defaults to true in the constructor helper.
+	IncludePatterns bool
+	// MaxPatterns is the maximum number of patterns to include. Defaults to 3.
+	MaxPatterns int
+	// IncludeCurrentEconomy controls whether the current manifest is serialized and included.
+	// Used in amend mode.
+	IncludeCurrentEconomy bool
+	// CurrentManifest is the current tenant manifest. Required when IncludeCurrentEconomy is true.
+	CurrentManifest *controlplanev1.Manifest
+	// RelationshipGraph is the economy graph JSON summary (optional, included if non-empty).
+	RelationshipGraph string
+}
+
+// AssembledContext holds the fully assembled generation prompt and metadata.
+type AssembledContext struct {
+	// Prompt is the complete LLM prompt ready for submission.
+	Prompt string
+	// MatchedPatterns are the cookbook patterns selected during assembly.
+	MatchedPatterns []PatternMatch
+	// TokenEstimate is a rough estimate of prompt token count (words * 1.3).
+	TokenEstimate int
+}
+
+// AssembleContext combines handler reference, topic list, schema summary, and cookbook
+// patterns into a complete LLM generation prompt. Pattern matching failures are non-fatal
+// and result in an empty pattern list rather than an error.
+func AssembleContext(opts ContextAssemblerOptions, registry *schema.Registry, cookbookFS fs.FS) (*AssembledContext, error) {
+	// Apply defaults.
+	if opts.MaxPatterns <= 0 {
+		opts.MaxPatterns = 3
+	}
+
+	// Build static sections from registry and schema.
+	handlerRef := BuildHandlerReferenceCard(registry)
+	topicList := BuildTopicList()
+	schemaSummary := BuildManifestSchemaSummary()
+
+	// Match patterns. Failure is non-fatal — generation can proceed without patterns.
+	var matched []PatternMatch
+	if opts.IncludePatterns && cookbookFS != nil {
+		var matchErr error
+		matched, matchErr = MatchPatterns(cookbookFS, opts.Description, opts.Industry, opts.MaxPatterns)
+		if matchErr != nil {
+			// Non-fatal: log via the returned context but do not block generation.
+			matched = nil
+		}
+	}
+
+	// Serialize current manifest to JSON (amend mode).
+	currentEconomyJSON := ""
+	if opts.IncludeCurrentEconomy && opts.CurrentManifest != nil {
+		marshaler := protojson.MarshalOptions{Multiline: true, Indent: "  ", EmitUnpopulated: false}
+		data, err := marshaler.Marshal(opts.CurrentManifest)
+		if err != nil {
+			return nil, fmt.Errorf("serialize current manifest: %w", err)
+		}
+		currentEconomyJSON = string(data)
+	}
+
+	prompt := buildPrompt(opts, handlerRef, topicList, schemaSummary, matched, currentEconomyJSON)
+
+	return &AssembledContext{
+		Prompt:          prompt,
+		MatchedPatterns: matched,
+		TokenEstimate:   estimateTokens(prompt),
+	}, nil
+}
+
+// buildPrompt assembles the complete LLM prompt from the provided context components.
+func buildPrompt(
+	opts ContextAssemblerOptions,
+	handlerRef, topicList, schemaSummary string,
+	patterns []PatternMatch,
+	currentEconomyJSON string,
+) string {
+	var sb strings.Builder
+
+	sb.WriteString("You are generating a Meridian economy manifest.\n\n")
+
+	// Business Description
+	sb.WriteString("## Business Description\n\n")
+	sb.WriteString(opts.Description)
+	sb.WriteString("\n\n")
+
+	// Manifest Schema Reference
+	sb.WriteString(schemaSummary)
+	sb.WriteString("\n")
+
+	// Available Handlers
+	sb.WriteString(handlerRef)
+	sb.WriteString("\n")
+
+	// Available Event Topics
+	sb.WriteString(topicList)
+
+	// Relevant Patterns
+	if len(patterns) > 0 {
+		sb.WriteString("## Relevant Patterns (copy and adapt)\n\n")
+		for _, p := range patterns {
+			fmt.Fprintf(&sb, "### Pattern: %s\n\n", p.Title)
+			if p.ManifestFragment != "" {
+				sb.WriteString("**Manifest Fragment:**\n\n```yaml\n")
+				sb.WriteString(p.ManifestFragment)
+				sb.WriteString("```\n\n")
+			}
+			if p.SagaScript != "" {
+				sb.WriteString("**Saga Script:**\n\n```python\n")
+				sb.WriteString(p.SagaScript)
+				sb.WriteString("```\n\n")
+			}
+		}
+	}
+
+	// Current Economy (amend mode only)
+	if currentEconomyJSON != "" {
+		sb.WriteString("## Current Economy\n\n")
+		sb.WriteString("The following is the tenant's existing manifest. Amend it according to the business description above.\n\n")
+		sb.WriteString("```json\n")
+		sb.WriteString(currentEconomyJSON)
+		sb.WriteString("\n```\n\n")
+	}
+
+	// Relationship Graph (optional)
+	if opts.RelationshipGraph != "" {
+		sb.WriteString("## Economy Relationship Graph\n\n")
+		sb.WriteString("```json\n")
+		sb.WriteString(opts.RelationshipGraph)
+		sb.WriteString("\n```\n\n")
+	}
+
+	// Instructions
+	sb.WriteString("## Instructions\n\n")
+	sb.WriteString("Generate a complete Meridian manifest YAML that implements the business description above.\n\n")
+	sb.WriteString("Rules:\n")
+	sb.WriteString("- Use only handlers listed in the Handler Reference Card above.\n")
+	sb.WriteString("- Use only event topic names listed in the Available Event Topics section for saga triggers.\n")
+	sb.WriteString("- All saga scripts must be valid Starlark (no while loops, no recursion).\n")
+	sb.WriteString("- Follow the Manifest Schema Reference for field names and types.\n")
+	sb.WriteString("- Copy and adapt the Relevant Patterns where applicable.\n")
+	if currentEconomyJSON != "" {
+		sb.WriteString("- Preserve existing instruments, account types, and sagas from the Current Economy unless explicitly asked to change them.\n")
+	}
+	sb.WriteString("- Output only the YAML manifest. Do not include explanations or markdown fencing.\n")
+
+	return sb.String()
+}
+
+// estimateTokens returns a rough token estimate for the prompt.
+// Token count is approximated as word count * 1.3.
+func estimateTokens(prompt string) int {
+	words := len(strings.Fields(prompt))
+	return int(float64(words) * 1.3)
+}

--- a/services/control-plane/internal/generator/context_assembler.go
+++ b/services/control-plane/internal/generator/context_assembler.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"strings"
@@ -9,6 +10,12 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
 	"google.golang.org/protobuf/encoding/protojson"
 )
+
+// ErrBlankDescription is returned when AssembleContext is called with an empty description.
+var ErrBlankDescription = errors.New("description is required")
+
+// ErrMissingCurrentManifest is returned when IncludeCurrentEconomy is true but CurrentManifest is nil.
+var ErrMissingCurrentManifest = errors.New("CurrentManifest is required when IncludeCurrentEconomy is true")
 
 // ContextAssemblerOptions configures the context assembly process.
 type ContextAssemblerOptions struct {
@@ -47,6 +54,14 @@ type AssembledContext struct {
 // patterns into a complete LLM generation prompt. Pattern matching failures are non-fatal
 // and result in an empty pattern list rather than an error.
 func AssembleContext(opts ContextAssemblerOptions, registry *schema.Registry, cookbookFS fs.FS) (*AssembledContext, error) {
+	// Validate required fields.
+	if strings.TrimSpace(opts.Description) == "" {
+		return nil, ErrBlankDescription
+	}
+	if opts.IncludeCurrentEconomy && opts.CurrentManifest == nil {
+		return nil, ErrMissingCurrentManifest
+	}
+
 	// Apply defaults.
 	if opts.MaxPatterns <= 0 {
 		opts.MaxPatterns = 3

--- a/services/control-plane/internal/generator/context_assembler.go
+++ b/services/control-plane/internal/generator/context_assembler.go
@@ -38,6 +38,9 @@ type AssembledContext struct {
 	MatchedPatterns []PatternMatch
 	// TokenEstimate is a rough estimate of prompt token count (words * 1.3).
 	TokenEstimate int
+	// PatternMatchError is non-nil when pattern matching failed. Generation
+	// proceeds without patterns but callers can inspect or log this error.
+	PatternMatchError error
 }
 
 // AssembleContext combines handler reference, topic list, schema summary, and cookbook
@@ -56,11 +59,10 @@ func AssembleContext(opts ContextAssemblerOptions, registry *schema.Registry, co
 
 	// Match patterns. Failure is non-fatal — generation can proceed without patterns.
 	var matched []PatternMatch
+	var patternMatchErr error
 	if opts.IncludePatterns && cookbookFS != nil {
-		var matchErr error
-		matched, matchErr = MatchPatterns(cookbookFS, opts.Description, opts.Industry, opts.MaxPatterns)
-		if matchErr != nil {
-			// Non-fatal: log via the returned context but do not block generation.
+		matched, patternMatchErr = MatchPatterns(cookbookFS, opts.Description, opts.Industry, opts.MaxPatterns)
+		if patternMatchErr != nil {
 			matched = nil
 		}
 	}
@@ -79,9 +81,10 @@ func AssembleContext(opts ContextAssemblerOptions, registry *schema.Registry, co
 	prompt := buildPrompt(opts, handlerRef, topicList, schemaSummary, matched, currentEconomyJSON)
 
 	return &AssembledContext{
-		Prompt:          prompt,
-		MatchedPatterns: matched,
-		TokenEstimate:   estimateTokens(prompt),
+		Prompt:            prompt,
+		MatchedPatterns:   matched,
+		TokenEstimate:     estimateTokens(prompt),
+		PatternMatchError: patternMatchErr,
 	}, nil
 }
 

--- a/services/control-plane/internal/generator/context_assembler_test.go
+++ b/services/control-plane/internal/generator/context_assembler_test.go
@@ -165,15 +165,27 @@ func TestAssembleContext_DefaultMaxPatterns(t *testing.T) {
 	reg := buildMinimalRegistry()
 
 	// MaxPatterns = 0 should default to 3.
-	result, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+	// MatchPatterns may prepend base patterns from extends resolution outside the cap,
+	// but we verify that at most 3 patterns come from direct scoring by also running
+	// with explicit MaxPatterns=3 and confirming results are equivalent.
+	resultDefault, err := generator.AssembleContext(generator.ContextAssemblerOptions{
 		Description:     "EV charging UK energy settlement",
 		Industry:        "energy",
 		IncludePatterns: true,
 		MaxPatterns:     0, // should default to 3
 	}, reg, realCookbookFS())
-
 	require.NoError(t, err)
-	assert.LessOrEqual(t, len(result.MatchedPatterns), 5, "should not return more patterns than expected with default max")
+
+	resultExplicit, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+		Description:     "EV charging UK energy settlement",
+		Industry:        "energy",
+		IncludePatterns: true,
+		MaxPatterns:     3,
+	}, reg, realCookbookFS())
+	require.NoError(t, err)
+
+	assert.Equal(t, len(resultDefault.MatchedPatterns), len(resultExplicit.MatchedPatterns),
+		"MaxPatterns=0 should default to 3 and produce the same result as MaxPatterns=3")
 }
 
 func TestAssembleContext_TokenEstimateReasonable(t *testing.T) {
@@ -240,6 +252,24 @@ func TestAssembleContext_NilCookbookFS_PatternsDisabled(t *testing.T) {
 	}, reg, nil)
 
 	require.NoError(t, err)
+	assert.Empty(t, result.MatchedPatterns)
+}
+
+func TestAssembleContext_BrokenCookbookFS_ExposesPatternMatchError(t *testing.T) {
+	reg := buildMinimalRegistry()
+
+	// An FS without registry.json will cause MatchPatterns to fail.
+	brokenFS := fstest.MapFS{}
+
+	result, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+		Description:     "A platform",
+		IncludePatterns: true,
+	}, reg, brokenFS)
+
+	// AssembleContext should succeed (non-fatal).
+	require.NoError(t, err)
+	// Pattern match error is exposed on the result.
+	assert.Error(t, result.PatternMatchError)
 	assert.Empty(t, result.MatchedPatterns)
 }
 

--- a/services/control-plane/internal/generator/context_assembler_test.go
+++ b/services/control-plane/internal/generator/context_assembler_test.go
@@ -257,6 +257,16 @@ func TestAssembleContext_BlankDescription_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestAssembleContext_NilRegistry_ReturnsError(t *testing.T) {
+	_, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+		Description:     "A platform",
+		IncludePatterns: false,
+	}, nil, emptyFS())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, generator.ErrMissingRegistry)
+}
+
 func TestAssembleContext_NilCookbookFS_PatternsDisabled(t *testing.T) {
 	reg := buildMinimalRegistry()
 

--- a/services/control-plane/internal/generator/context_assembler_test.go
+++ b/services/control-plane/internal/generator/context_assembler_test.go
@@ -134,18 +134,19 @@ func TestAssembleContext_AmendMode_IncludesCurrentManifest(t *testing.T) {
 	assert.Contains(t, result.Prompt, "test-economy")
 }
 
-func TestAssembleContext_AmendMode_NilManifest_NoCurrentEconomySection(t *testing.T) {
+func TestAssembleContext_AmendMode_NilManifest_ReturnsError(t *testing.T) {
 	reg := buildMinimalRegistry()
 
-	result, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+	// IncludeCurrentEconomy=true with nil CurrentManifest is a caller error.
+	_, err := generator.AssembleContext(generator.ContextAssemblerOptions{
 		Description:           "A payment platform",
 		IncludePatterns:       false,
 		IncludeCurrentEconomy: true,
 		CurrentManifest:       nil,
 	}, reg, emptyFS())
 
-	require.NoError(t, err)
-	assert.NotContains(t, result.Prompt, "## Current Economy")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, generator.ErrMissingCurrentManifest)
 }
 
 func TestAssembleContext_WithRelationshipGraph_IncludesGraphSection(t *testing.T) {
@@ -241,6 +242,19 @@ func TestAssembleContext_AmendMode_InstructionsIncludePreservation(t *testing.T)
 
 	require.NoError(t, err)
 	assert.Contains(t, result.Prompt, "Preserve existing")
+}
+
+func TestAssembleContext_BlankDescription_ReturnsError(t *testing.T) {
+	reg := buildMinimalRegistry()
+
+	for _, desc := range []string{"", "   ", "\t\n"} {
+		_, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+			Description:     desc,
+			IncludePatterns: false,
+		}, reg, emptyFS())
+		require.Error(t, err, "expected error for blank description %q", desc)
+		assert.ErrorIs(t, err, generator.ErrBlankDescription)
+	}
 }
 
 func TestAssembleContext_NilCookbookFS_PatternsDisabled(t *testing.T) {

--- a/services/control-plane/internal/generator/context_assembler_test.go
+++ b/services/control-plane/internal/generator/context_assembler_test.go
@@ -1,0 +1,276 @@
+package generator_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/control-plane/internal/generator"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+)
+
+// buildMinimalRegistry creates a registry with a single test handler for use in unit tests.
+func buildMinimalRegistry() *schema.Registry {
+	reg := schema.NewRegistry()
+	yaml := `
+service: test_service
+version: "1.0"
+handlers:
+  test_service.do_thing:
+    description: "Test handler"
+    compensation_strategy: none
+    params:
+      amount:
+        type: Decimal
+        required: true
+    returns:
+      result:
+        type: string
+`
+	if err := reg.LoadFromYAML([]byte(yaml)); err != nil {
+		panic("buildMinimalRegistry: " + err.Error())
+	}
+	return reg
+}
+
+// emptyFS returns an FS with only the registry.json required by MatchPatterns.
+func emptyFS() fstest.MapFS {
+	return fstest.MapFS{
+		"registry.json": &fstest.MapFile{Data: []byte(`{"items":[]}`)},
+	}
+}
+
+func TestAssembleContext_CreateMode_AllStaticSectionsPresent(t *testing.T) {
+	reg := buildMinimalRegistry()
+
+	result, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+		Description:     "An energy trading platform for UK markets",
+		Industry:        "energy",
+		IncludePatterns: false,
+	}, reg, emptyFS())
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Contains(t, result.Prompt, "## Business Description")
+	assert.Contains(t, result.Prompt, "An energy trading platform for UK markets")
+	assert.Contains(t, result.Prompt, "## Manifest Schema Summary")
+	assert.Contains(t, result.Prompt, "## Handler Reference Card")
+	assert.Contains(t, result.Prompt, "## Available Event Topics")
+	assert.Contains(t, result.Prompt, "## Instructions")
+}
+
+func TestAssembleContext_CreateMode_NoCurrentEconomy(t *testing.T) {
+	reg := buildMinimalRegistry()
+
+	result, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+		Description:           "A payment platform",
+		IncludePatterns:       false,
+		IncludeCurrentEconomy: false,
+	}, reg, emptyFS())
+
+	require.NoError(t, err)
+	assert.NotContains(t, result.Prompt, "## Current Economy")
+}
+
+func TestAssembleContext_WithIndustryHint_IncludesMatchedPatterns(t *testing.T) {
+	reg := buildMinimalRegistry()
+
+	result, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+		Description:     "EV charging UK energy settlement",
+		Industry:        "energy",
+		IncludePatterns: true,
+		MaxPatterns:     3,
+	}, reg, realCookbookFS())
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Contains(t, result.Prompt, "## Relevant Patterns (copy and adapt)")
+	assert.NotEmpty(t, result.MatchedPatterns)
+}
+
+func TestAssembleContext_WithoutIndustryHint_PatternsOptional(t *testing.T) {
+	reg := buildMinimalRegistry()
+
+	// With an empty FS that has no patterns, IncludePatterns should not error.
+	result, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+		Description:     "A fintech platform",
+		IncludePatterns: true,
+		MaxPatterns:     3,
+	}, reg, emptyFS())
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	// No patterns matched — section should be absent.
+	assert.NotContains(t, result.Prompt, "## Relevant Patterns")
+	assert.Empty(t, result.MatchedPatterns)
+}
+
+func TestAssembleContext_AmendMode_IncludesCurrentManifest(t *testing.T) {
+	reg := buildMinimalRegistry()
+
+	manifest := &controlplanev1.Manifest{
+		Version: "1.0.0",
+		Metadata: &controlplanev1.ManifestMetadata{
+			Name:        "test-economy",
+			Description: "Existing economy",
+		},
+	}
+
+	result, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+		Description:           "A payment platform with energy add-ons",
+		IncludePatterns:       false,
+		IncludeCurrentEconomy: true,
+		CurrentManifest:       manifest,
+	}, reg, emptyFS())
+
+	require.NoError(t, err)
+	assert.Contains(t, result.Prompt, "## Current Economy")
+	assert.Contains(t, result.Prompt, "test-economy")
+}
+
+func TestAssembleContext_AmendMode_NilManifest_NoCurrentEconomySection(t *testing.T) {
+	reg := buildMinimalRegistry()
+
+	result, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+		Description:           "A payment platform",
+		IncludePatterns:       false,
+		IncludeCurrentEconomy: true,
+		CurrentManifest:       nil,
+	}, reg, emptyFS())
+
+	require.NoError(t, err)
+	assert.NotContains(t, result.Prompt, "## Current Economy")
+}
+
+func TestAssembleContext_WithRelationshipGraph_IncludesGraphSection(t *testing.T) {
+	reg := buildMinimalRegistry()
+
+	result, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+		Description:       "An energy platform",
+		IncludePatterns:   false,
+		RelationshipGraph: `{"nodes":[],"edges":[]}`,
+	}, reg, emptyFS())
+
+	require.NoError(t, err)
+	assert.Contains(t, result.Prompt, "## Economy Relationship Graph")
+	assert.Contains(t, result.Prompt, `{"nodes":[],"edges":[]}`)
+}
+
+func TestAssembleContext_DefaultMaxPatterns(t *testing.T) {
+	reg := buildMinimalRegistry()
+
+	// MaxPatterns = 0 should default to 3.
+	result, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+		Description:     "EV charging UK energy settlement",
+		Industry:        "energy",
+		IncludePatterns: true,
+		MaxPatterns:     0, // should default to 3
+	}, reg, realCookbookFS())
+
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(result.MatchedPatterns), 5, "should not return more patterns than expected with default max")
+}
+
+func TestAssembleContext_TokenEstimateReasonable(t *testing.T) {
+	reg := buildMinimalRegistry()
+
+	result, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+		Description:     "An energy trading platform",
+		IncludePatterns: false,
+	}, reg, emptyFS())
+
+	require.NoError(t, err)
+
+	// Token estimate should be positive.
+	assert.Greater(t, result.TokenEstimate, 0)
+
+	// Rough sanity check: estimate should be between 0.5x and 2.5x the word count.
+	wordCount := len(splitWords(result.Prompt))
+	assert.GreaterOrEqual(t, result.TokenEstimate, wordCount/2)
+	assert.LessOrEqual(t, result.TokenEstimate, wordCount*3)
+}
+
+func TestAssembleContext_InstructionsSectionPresent(t *testing.T) {
+	reg := buildMinimalRegistry()
+
+	result, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+		Description:     "A carbon credit trading platform",
+		IncludePatterns: false,
+	}, reg, emptyFS())
+
+	require.NoError(t, err)
+	assert.Contains(t, result.Prompt, "## Instructions")
+	assert.Contains(t, result.Prompt, "Generate a complete Meridian manifest YAML")
+	assert.Contains(t, result.Prompt, "valid Starlark")
+}
+
+func TestAssembleContext_AmendMode_InstructionsIncludePreservation(t *testing.T) {
+	reg := buildMinimalRegistry()
+
+	manifest := &controlplanev1.Manifest{
+		Version: "1.0.0",
+		Metadata: &controlplanev1.ManifestMetadata{
+			Name: "existing",
+		},
+	}
+
+	result, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+		Description:           "Extended energy platform",
+		IncludePatterns:       false,
+		IncludeCurrentEconomy: true,
+		CurrentManifest:       manifest,
+	}, reg, emptyFS())
+
+	require.NoError(t, err)
+	assert.Contains(t, result.Prompt, "Preserve existing")
+}
+
+func TestAssembleContext_NilCookbookFS_PatternsDisabled(t *testing.T) {
+	reg := buildMinimalRegistry()
+
+	// A nil cookbookFS with IncludePatterns=true should be handled gracefully.
+	result, err := generator.AssembleContext(generator.ContextAssemblerOptions{
+		Description:     "A platform",
+		IncludePatterns: true,
+	}, reg, nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, result.MatchedPatterns)
+}
+
+// splitWords splits a string into whitespace-delimited words, used only for test assertions.
+func splitWords(s string) []string {
+	var words []string
+	for _, f := range splitFields(s) {
+		if f != "" {
+			words = append(words, f)
+		}
+	}
+	return words
+}
+
+func splitFields(s string) []string {
+	result := []string{}
+	start := -1
+	for i, r := range s {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			if start >= 0 {
+				result = append(result, s[start:i])
+				start = -1
+			}
+		} else {
+			if start < 0 {
+				start = i
+			}
+		}
+	}
+	if start >= 0 {
+		result = append(result, s[start:])
+	}
+	return result
+}

--- a/services/control-plane/internal/generator/context_assembler_test.go
+++ b/services/control-plane/internal/generator/context_assembler_test.go
@@ -1,6 +1,7 @@
 package generator_test
 
 import (
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -275,32 +276,5 @@ func TestAssembleContext_BrokenCookbookFS_ExposesPatternMatchError(t *testing.T)
 
 // splitWords splits a string into whitespace-delimited words, used only for test assertions.
 func splitWords(s string) []string {
-	var words []string
-	for _, f := range splitFields(s) {
-		if f != "" {
-			words = append(words, f)
-		}
-	}
-	return words
-}
-
-func splitFields(s string) []string {
-	result := []string{}
-	start := -1
-	for i, r := range s {
-		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
-			if start >= 0 {
-				result = append(result, s[start:i])
-				start = -1
-			}
-		} else {
-			if start < 0 {
-				start = i
-			}
-		}
-	}
-	if start >= 0 {
-		result = append(result, s[start:])
-	}
-	return result
+	return strings.Fields(s)
 }


### PR DESCRIPTION
## Summary

- Implements `AssembleContext` which combines handler reference card, topic list, manifest schema summary, and cookbook patterns into a single LLM generation prompt
- Supports create mode (no current economy) and amend mode (serializes current `Manifest` proto as JSON)
- Handles nil/empty cookbook FS gracefully — pattern matching failure does not block generation
- Adds `TokenEstimate` (word count × 1.3) and `RelationshipGraph` section support

## Changes Made

- `services/control-plane/internal/generator/context_assembler.go` — `ContextAssemblerOptions`, `AssembledContext`, `AssembleContext`, `buildPrompt`, `estimateTokens`
- `services/control-plane/internal/generator/context_assembler_test.go` — 12 unit and integration tests covering all modes

## Technical Details

- `ContextAssemblerOptions.MaxPatterns` defaults to 3 when zero
- Pattern matching errors are non-fatal; result is empty pattern list
- Current manifest serialized via `protojson.MarshalOptions` with multiline output
- Amend mode instructions include a preservation note for existing instruments/sagas

## Testing

- All 61 tests in the generator package pass (`go test ./services/control-plane/internal/generator/...`)
- Integration tests use the real embedded cookbook FS (`cookbook.FS`) for pattern matching assertions

## Task

economy-generator.6 - Build Context Assembler