### PR TITLE
feat: Add validate-fix loop for economy generation

### DIFF
--- a/services/control-plane/internal/generator/export_test.go
+++ b/services/control-plane/internal/generator/export_test.go
@@ -27,8 +27,19 @@ func NewDeprecatedHandlerInfo(currentName string) deprecatedHandlerInfo {
 	return deprecatedHandlerInfo{currentName: currentName}
 }
 
+// NewDeprecatedHandlerInfoWithDefaults creates a deprecatedHandlerInfo with a ConversionRule for tests.
+func NewDeprecatedHandlerInfoWithDefaults(currentName string, defaults map[string]string) deprecatedHandlerInfo {
+	return deprecatedHandlerInfo{
+		currentName: currentName,
+		rule:        &schema.ConversionRule{Defaults: defaults},
+	}
+}
+
 // FindHandlerCall is the exported test hook for findHandlerCall.
 var FindHandlerCall = findHandlerCall
+
+// InjectMissingDefaults is the exported test hook for injectMissingDefaults.
+var InjectMissingDefaults = injectMissingDefaults
 
 // ExtractHandlerName is the exported test hook for extractHandlerName.
 var ExtractHandlerName = extractHandlerName

--- a/services/control-plane/internal/generator/export_test.go
+++ b/services/control-plane/internal/generator/export_test.go
@@ -1,5 +1,7 @@
 package generator
 
+import "github.com/meridianhub/meridian/shared/pkg/saga/schema"
+
 // Export private helpers for black-box testing.
 
 // ExtractYAML is the exported test hook for extractYAML.
@@ -7,6 +9,17 @@ var ExtractYAML = extractYAML
 
 // BuildFixPrompt is the exported test hook for buildFixPrompt.
 var BuildFixPrompt = buildFixPrompt
+
+// EnrichErrors is the exported test hook for enrichErrors.
+var EnrichErrors = enrichErrors
+
+// ApplyMutatingPhase is the exported test hook for applyMutatingPhase.
+var ApplyMutatingPhase = applyMutatingPhase
+
+// NewEmptySchemaRegistry returns an empty schema registry for test use.
+func NewEmptySchemaRegistry() *schema.Registry {
+	return schema.NewRegistry()
+}
 
 // Model returns the model name used by this client.
 func (c *ClaudeLLMClient) Model() string {

--- a/services/control-plane/internal/generator/export_test.go
+++ b/services/control-plane/internal/generator/export_test.go
@@ -16,6 +16,23 @@ var EnrichErrors = enrichErrors
 // ApplyMutatingPhase is the exported test hook for applyMutatingPhase.
 var ApplyMutatingPhase = applyMutatingPhase
 
+// ReplaceDeprecatedHandler is the exported test hook for replaceDeprecatedHandler.
+var ReplaceDeprecatedHandler = replaceDeprecatedHandler
+
+// DeprecatedHandlerInfo is the exported type for deprecatedHandlerInfo.
+type DeprecatedHandlerInfo = deprecatedHandlerInfo
+
+// NewDeprecatedHandlerInfo creates a deprecatedHandlerInfo for tests.
+func NewDeprecatedHandlerInfo(currentName string) deprecatedHandlerInfo {
+	return deprecatedHandlerInfo{currentName: currentName}
+}
+
+// FindHandlerCall is the exported test hook for findHandlerCall.
+var FindHandlerCall = findHandlerCall
+
+// ExtractHandlerName is the exported test hook for extractHandlerName.
+var ExtractHandlerName = extractHandlerName
+
 // NewEmptySchemaRegistry returns an empty schema registry for test use.
 func NewEmptySchemaRegistry() *schema.Registry {
 	return schema.NewRegistry()

--- a/services/control-plane/internal/generator/validate_fix.go
+++ b/services/control-plane/internal/generator/validate_fix.go
@@ -1,0 +1,664 @@
+package generator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+	"github.com/meridianhub/meridian/shared/platform/events/topics"
+)
+
+// errUnexpectedLoopExit is returned when the validate-fix loop exits unexpectedly.
+// This is a sentinel for an unreachable code path.
+var errUnexpectedLoopExit = errors.New("validate-fix: unexpected loop exit")
+
+// ManifestValidator abstracts the validation pipeline for the validate-fix loop.
+// It performs a dry-run validation returning structured errors without persisting anything.
+type ManifestValidator interface {
+	// ValidateDryRun validates the manifest YAML and returns structured results.
+	// No side effects are performed — this is a pure validation check.
+	ValidateDryRun(ctx context.Context, manifestYAML string) (*ValidationResult, error)
+}
+
+// ValidationResult holds the structured outcome of a dry-run validation.
+type ValidationResult struct {
+	// Valid is true when there are no error-severity findings.
+	Valid bool
+
+	// Errors contains all error-severity findings that block activation.
+	Errors []ValidationError
+
+	// Warnings contains all warning-severity findings.
+	Warnings []ValidationError
+}
+
+// ValidateFixOptions configures the validate-fix loop.
+type ValidateFixOptions struct {
+	// MaxIterations is the maximum number of LLM fix iterations to attempt.
+	// A value of 0 means no LLM fix attempts are made (validate only).
+	MaxIterations int
+
+	// LLMClient is used to request fixes from the LLM after validation failures.
+	LLMClient LLMClient
+
+	// Validator performs dry-run manifest validation.
+	Validator ManifestValidator
+
+	// SchemaRegistry is used for error enrichment (available handlers, topics).
+	// May be nil — enrichment is skipped when no registry is provided.
+	SchemaRegistry *schema.Registry
+}
+
+// ValidateFixResult is the outcome of a validate-fix loop run.
+type ValidateFixResult struct {
+	// FinalManifest is the last manifest produced (may still have errors if the loop exhausted).
+	FinalManifest string
+
+	// Valid is true when the final manifest passed validation with no errors.
+	Valid bool
+
+	// Errors contains any remaining error-severity findings after all iterations.
+	Errors []ValidationError
+
+	// Warnings contains any warning-severity findings from the final validation.
+	Warnings []ValidationError
+
+	// IterationsUsed is the number of LLM fix iterations consumed (0 if valid on first pass).
+	IterationsUsed int
+}
+
+// ValidateAndFix runs the validate-fix feedback loop:
+//  1. Apply mutating phase (auto-convert deprecated handlers)
+//  2. Validate via ManifestValidator.ValidateDryRun
+//  3. If valid: return success with warnings
+//  4. If errors: enrich errors, send to LLM via LLMClient.Fix, repeat
+//  5. After MaxIterations: return with remaining errors and Valid=false
+func ValidateAndFix(ctx context.Context, manifestYAML string, opts ValidateFixOptions) (*ValidateFixResult, error) {
+	current := manifestYAML
+
+	for iter := 0; iter <= opts.MaxIterations; iter++ {
+		// Step 1: Apply mutating phase (auto-fix deprecated handlers)
+		current = applyMutatingPhase(current, opts.SchemaRegistry)
+
+		// Step 2: Validate
+		result, err := opts.Validator.ValidateDryRun(ctx, current)
+		if err != nil {
+			return nil, fmt.Errorf("validate manifest (iteration %d): %w", iter, err)
+		}
+
+		// Step 3: If valid, we are done
+		if result.Valid {
+			return &ValidateFixResult{
+				FinalManifest:  current,
+				Valid:          true,
+				Errors:         nil,
+				Warnings:       result.Warnings,
+				IterationsUsed: iter,
+			}, nil
+		}
+
+		// Step 4: Errors remain — if we've used all iterations, stop
+		if iter >= opts.MaxIterations {
+			return &ValidateFixResult{
+				FinalManifest:  current,
+				Valid:          false,
+				Errors:         result.Errors,
+				Warnings:       result.Warnings,
+				IterationsUsed: iter,
+			}, nil
+		}
+
+		// Step 5: Enrich errors and ask LLM to fix
+		enriched := enrichErrors(result.Errors, opts.SchemaRegistry)
+		fixed, err := opts.LLMClient.Fix(ctx, current, enriched)
+		if err != nil {
+			return nil, fmt.Errorf("fix manifest (iteration %d): %w", iter, err)
+		}
+		current = fixed
+	}
+
+	// Unreachable: the loop always returns inside the body.
+	return nil, errUnexpectedLoopExit
+}
+
+// applyMutatingPhase auto-converts deprecated handler calls in Starlark scripts
+// embedded in the manifest YAML. When no schema registry is provided or no
+// deprecated handlers are present, the manifest is returned unchanged.
+//
+// The function operates on YAML text by finding saga script blocks and applying
+// the same text-level handler conversion logic used by the MCP manifest_fix tool.
+func applyMutatingPhase(manifestYAML string, registry *schema.Registry) string {
+	if registry == nil {
+		return manifestYAML
+	}
+
+	deprecatedHandlers := collectDeprecatedHandlersFromRegistry(registry)
+	if len(deprecatedHandlers) == 0 {
+		return manifestYAML
+	}
+
+	// Find and replace deprecated handler calls within Starlark script blocks.
+	// YAML multi-line strings appear after "script: |" or "script: |-" markers.
+	// We process the full YAML text line-by-line, isolating script blocks.
+	lines := strings.Split(manifestYAML, "\n")
+	result := make([]string, 0, len(lines))
+	inScript := false
+	var scriptIndent int
+	var scriptLines []string
+	var scriptStartIdx int
+
+	for i, line := range lines {
+		if !inScript {
+			// Detect "script: |" or "script: |-" at any indentation level
+			trimmed := strings.TrimLeft(line, " \t")
+			if strings.HasPrefix(trimmed, "script: |") {
+				indent := len(line) - len(trimmed)
+				inScript = true
+				scriptIndent = indent
+				scriptLines = nil
+				scriptStartIdx = i
+				result = append(result, line)
+				continue
+			}
+			result = append(result, line)
+			continue
+		}
+
+		// Inside a script block: collect lines until de-indented
+		if line == "" {
+			scriptLines = append(scriptLines, line)
+			continue
+		}
+
+		currentIndent := len(line) - len(strings.TrimLeft(line, " \t"))
+		if currentIndent <= scriptIndent && strings.TrimSpace(line) != "" {
+			// End of script block — apply fixes to the accumulated script lines
+			script := strings.Join(scriptLines, "\n")
+			fixed := applyDeprecatedHandlerFixes(script, deprecatedHandlers)
+			fixedLines := strings.Split(fixed, "\n")
+			// Replace the script lines in result (they were already appended as empty during collection)
+			// We need to backfill: scriptLines were NOT yet appended — we deferred them
+			result = append(result, fixedLines...)
+			inScript = false
+			scriptLines = nil
+			_ = scriptStartIdx
+			result = append(result, line)
+			continue
+		}
+
+		scriptLines = append(scriptLines, line)
+	}
+
+	// Flush remaining script lines if YAML ended while inside a script block
+	if inScript && len(scriptLines) > 0 {
+		script := strings.Join(scriptLines, "\n")
+		fixed := applyDeprecatedHandlerFixes(script, deprecatedHandlers)
+		fixedLines := strings.Split(fixed, "\n")
+		result = append(result, fixedLines...)
+	}
+
+	return strings.Join(result, "\n")
+}
+
+// deprecatedHandlerInfo holds conversion info for a deprecated handler.
+type deprecatedHandlerInfo struct {
+	currentName string
+	rule        *schema.ConversionRule
+}
+
+// collectDeprecatedHandlersFromRegistry builds a map of deprecated handler names.
+func collectDeprecatedHandlersFromRegistry(registry *schema.Registry) map[string]deprecatedHandlerInfo {
+	metadata := registry.BuildLinterMetadata()
+	result := make(map[string]deprecatedHandlerInfo)
+	for name, meta := range metadata {
+		if meta.IsDeprecated && meta.ReplacedBy != "" {
+			if mapping := registry.LookupDeprecated(name); mapping != nil {
+				result[name] = deprecatedHandlerInfo{
+					currentName: mapping.CurrentName,
+					rule:        mapping.ConversionRule,
+				}
+			}
+		}
+	}
+	return result
+}
+
+// applyDeprecatedHandlerFixes applies all deprecated handler conversions to a Starlark script string.
+// It replaces deprecated handler call names with current names and renames parameters as needed.
+func applyDeprecatedHandlerFixes(script string, deprecated map[string]deprecatedHandlerInfo) string {
+	if len(deprecated) == 0 {
+		return script
+	}
+
+	// Sort by name length (longest first) to avoid partial replacements
+	sorted := make([]string, 0, len(deprecated))
+	for name := range deprecated {
+		sorted = append(sorted, name)
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return len(sorted[i]) > len(sorted[j])
+	})
+
+	result := script
+	for _, oldName := range sorted {
+		info := deprecated[oldName]
+		result = replaceDeprecatedHandler(result, oldName, info)
+	}
+	return result
+}
+
+// replaceDeprecatedHandler replaces a single deprecated handler call in a Starlark script.
+// It replaces the call name and renames keyword arguments using parameter mapping.
+func replaceDeprecatedHandler(script string, oldName string, info deprecatedHandlerInfo) string {
+	// Quick check: does the old name appear at all?
+	if !strings.Contains(script, oldName) {
+		return script
+	}
+
+	newCall := info.currentName + "("
+
+	// Build reverse mapping: old param -> new param
+	var reverseMapping map[string]string
+	if info.rule != nil && len(info.rule.ParamMapping) > 0 {
+		reverseMapping = make(map[string]string, len(info.rule.ParamMapping))
+		for newParam, oldParam := range info.rule.ParamMapping {
+			reverseMapping[oldParam] = newParam
+		}
+	}
+
+	var result strings.Builder
+	remaining := script
+	for {
+		// Find the next occurrence of oldName followed by optional whitespace and '('
+		idx := findHandlerCall(remaining, oldName)
+		if idx < 0 {
+			result.WriteString(remaining)
+			break
+		}
+
+		// Write text before the match
+		result.WriteString(remaining[:idx])
+		result.WriteString(newCall)
+
+		// Advance past "oldName(" (find the '(' after the name)
+		parenIdx := strings.Index(remaining[idx+len(oldName):], "(")
+		remaining = remaining[idx+len(oldName)+parenIdx+1:]
+
+		// Extract call body up to matching closing paren
+		callBody, rest := splitAtMatchingParen(remaining)
+		if len(reverseMapping) > 0 {
+			callBody = renameKwargs(callBody, reverseMapping)
+		}
+		result.WriteString(callBody)
+		remaining = rest
+	}
+	return result.String()
+}
+
+// findHandlerCall finds the index of oldName followed by optional whitespace and '(' in s.
+// Returns -1 if not found. Only matches at word boundaries (preceded by non-ident or start of string).
+func findHandlerCall(s, oldName string) int {
+	idx := 0
+	for {
+		pos := strings.Index(s[idx:], oldName)
+		if pos < 0 {
+			return -1
+		}
+		pos += idx
+
+		// Check word boundary before
+		if pos > 0 && isScriptIdentChar(s[pos-1]) {
+			idx = pos + 1
+			continue
+		}
+
+		// Check that something follows: optional whitespace then '('
+		rest := s[pos+len(oldName):]
+		wsEnd := 0
+		for wsEnd < len(rest) && (rest[wsEnd] == ' ' || rest[wsEnd] == '\t') {
+			wsEnd++
+		}
+		if wsEnd >= len(rest) || rest[wsEnd] != '(' {
+			idx = pos + 1
+			continue
+		}
+
+		return pos
+	}
+}
+
+func isScriptIdentChar(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_'
+}
+
+// splitAtMatchingParen splits s at the matching closing paren for an already-opened call.
+// Returns (bodyIncludingCloseParen, rest).
+func splitAtMatchingParen(s string) (string, string) {
+	depth := 1
+	i := 0
+	for i < len(s) {
+		switch s[i] {
+		case '(':
+			depth++
+			i++
+		case ')':
+			depth--
+			if depth == 0 {
+				return s[:i+1], s[i+1:]
+			}
+			i++
+		case '"', '\'':
+			i = advancePastString(s, i)
+		case '#':
+			for i < len(s) && s[i] != '\n' {
+				i++
+			}
+		default:
+			i++
+		}
+	}
+	return s, ""
+}
+
+// advancePastString advances past a string literal starting at i.
+func advancePastString(s string, i int) int {
+	q := s[i]
+	if i+2 < len(s) && s[i+1] == q && s[i+2] == q {
+		// Triple-quoted
+		triple := string([]byte{q, q, q})
+		end := strings.Index(s[i+3:], triple)
+		if end >= 0 {
+			return i + 3 + end + 3
+		}
+		return len(s)
+	}
+	i++
+	for i < len(s) {
+		if s[i] == '\\' {
+			i += 2
+			continue
+		}
+		if s[i] == q {
+			return i + 1
+		}
+		i++
+	}
+	return len(s)
+}
+
+// renameKwargs renames keyword arguments in a call body string.
+// Only renames top-level (depth=0) identifier=value patterns.
+func renameKwargs(callBody string, reverseMapping map[string]string) string {
+	var result strings.Builder
+	i := 0
+	for i < len(callBody) {
+		i = renameKwargsStep(&result, callBody, i, reverseMapping)
+	}
+	return result.String()
+}
+
+// renameKwargsStep processes one token at position i and returns the next position.
+func renameKwargsStep(result *strings.Builder, s string, i int, reverseMapping map[string]string) int {
+	ch := s[i]
+	if ch == '"' || ch == '\'' {
+		start := i
+		i = advancePastString(s, i)
+		result.WriteString(s[start:i])
+		return i
+	}
+	if ch == '#' {
+		start := i
+		for i < len(s) && s[i] != '\n' {
+			i++
+		}
+		result.WriteString(s[start:i])
+		return i
+	}
+	if isIdentStart(ch) {
+		return renameKwargIdent(result, s, i, reverseMapping)
+	}
+	result.WriteByte(ch)
+	return i + 1
+}
+
+// renameKwargIdent handles an identifier at position i, renaming it if it is a kwarg.
+func renameKwargIdent(result *strings.Builder, s string, i int, reverseMapping map[string]string) int {
+	start := i
+	for i < len(s) && isScriptIdentChar(s[i]) {
+		i++
+	}
+	ident := s[start:i]
+
+	// Check for "ident=" (not "ident==")
+	eqIdx := i
+	for eqIdx < len(s) && (s[eqIdx] == ' ' || s[eqIdx] == '\t') {
+		eqIdx++
+	}
+	isKwarg := eqIdx < len(s) && s[eqIdx] == '=' && (eqIdx+1 >= len(s) || s[eqIdx+1] != '=')
+	if isKwarg {
+		if newName, ok := reverseMapping[ident]; ok {
+			result.WriteString(newName)
+			return i
+		}
+	}
+	result.WriteString(ident)
+	return i
+}
+
+func isIdentStart(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_'
+}
+
+// enrichErrors augments validation errors with additional context to help the LLM
+// produce better fixes. When no schema registry is provided, errors are returned unchanged.
+func enrichErrors(errs []ValidationError, registry *schema.Registry) []ValidationError {
+	if len(errs) == 0 {
+		return errs
+	}
+
+	enriched := make([]ValidationError, len(errs))
+	copy(enriched, errs)
+
+	for i := range enriched {
+		switch enriched[i].Code {
+		case "UNKNOWN_HANDLER":
+			enrichUnknownHandler(&enriched[i], registry)
+		case "UNKNOWN_EVENT_TOPIC":
+			enrichUnknownEventTopic(&enriched[i])
+		case "MISSING_REQUIRED_PARAM":
+			enrichMissingRequiredParam(&enriched[i], registry)
+		case "WRONG_PARAM_TYPE":
+			enrichWrongParamType(&enriched[i], registry)
+		}
+	}
+
+	return enriched
+}
+
+func enrichUnknownHandler(e *ValidationError, registry *schema.Registry) {
+	if registry != nil {
+		e.AvailableFields = registry.ListHandlers()
+	}
+}
+
+func enrichUnknownEventTopic(e *ValidationError) {
+	allTopics := topics.All()
+	if e.Suggestion == "" {
+		closest := findClosestTopicMatch(e.Message, allTopics)
+		if closest != "" {
+			e.Suggestion = closest
+		}
+	}
+	if len(e.AvailableFields) == 0 {
+		e.AvailableFields = allTopics
+	}
+}
+
+func enrichMissingRequiredParam(e *ValidationError, registry *schema.Registry) {
+	if registry == nil {
+		return
+	}
+	handlerName := extractHandlerName(e.Path)
+	if handlerName == "" {
+		return
+	}
+	h, err := registry.GetHandler(handlerName)
+	if err != nil {
+		return
+	}
+	var required []string
+	for paramName, field := range h.Params {
+		if field.Required {
+			required = append(required, fmt.Sprintf("%s (%s)", paramName, field.Type))
+		}
+	}
+	sort.Strings(required)
+	if len(required) > 0 {
+		e.Message = fmt.Sprintf("%s. Required params: %s", e.Message, strings.Join(required, ", "))
+	}
+}
+
+func enrichWrongParamType(e *ValidationError, registry *schema.Registry) {
+	if registry == nil {
+		return
+	}
+	handlerName := extractHandlerName(e.Path)
+	paramName := extractParamName(e.Path)
+	if handlerName == "" || paramName == "" {
+		return
+	}
+	h, err := registry.GetHandler(handlerName)
+	if err != nil {
+		return
+	}
+	if field, ok := h.Params[paramName]; ok {
+		e.Message = fmt.Sprintf("%s. Expected type: %s", e.Message, field.Type)
+	}
+}
+
+// findClosestTopicMatch finds the most similar topic name to any word in the message.
+// Returns empty string if no candidate is close enough.
+func findClosestTopicMatch(message string, allTopics []string) string {
+	if message == "" || len(allTopics) == 0 {
+		return ""
+	}
+
+	// Try to find a word in the message that looks like a topic name (contains dots or underscores)
+	words := strings.Fields(message)
+	for _, word := range words {
+		// Strip surrounding quotes and punctuation
+		word = strings.Trim(word, `"'`+"`.,;:()")
+		if strings.ContainsAny(word, "._") && len(word) > 3 {
+			best := findClosestTopicString(word, allTopics)
+			if best != "" {
+				return best
+			}
+		}
+	}
+	return ""
+}
+
+// findClosestTopicString finds the closest topic name using Levenshtein distance.
+func findClosestTopicString(target string, candidates []string) string {
+	if len(candidates) == 0 || target == "" {
+		return ""
+	}
+
+	bestMatch := ""
+	bestDist := len(target)/2 + 1
+
+	for _, candidate := range candidates {
+		dist := levenshteinDist(strings.ToLower(target), strings.ToLower(candidate))
+		if dist < bestDist {
+			bestDist = dist
+			bestMatch = candidate
+		}
+	}
+	return bestMatch
+}
+
+// levenshteinDist computes edit distance between two strings.
+func levenshteinDist(a, b string) int {
+	la := len(a)
+	lb := len(b)
+
+	if la > lb {
+		a, b = b, a
+		la, lb = lb, la
+	}
+
+	prev := make([]int, la+1)
+	curr := make([]int, la+1)
+
+	for i := 0; i <= la; i++ {
+		prev[i] = i
+	}
+
+	for j := 1; j <= lb; j++ {
+		curr[0] = j
+		for i := 1; i <= la; i++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			del := prev[i] + 1
+			ins := curr[i-1] + 1
+			sub := prev[i-1] + cost
+			curr[i] = min3(del, ins, sub)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[la]
+}
+
+func min3(a, b, c int) int {
+	if a < b {
+		if a < c {
+			return a
+		}
+		return c
+	}
+	if b < c {
+		return b
+	}
+	return c
+}
+
+// extractHandlerName extracts the handler name from an error path like
+// "sagas[0].script:position_keeping.initiate_log" or "sagas[0]:position_keeping.initiate_log".
+// Returns empty string when no handler name can be determined.
+func extractHandlerName(path string) string {
+	// Look for a pattern like "service_name.handler_name" in the path
+	colon := strings.LastIndex(path, ":")
+	if colon >= 0 && colon < len(path)-1 {
+		candidate := path[colon+1:]
+		if strings.Contains(candidate, ".") {
+			return candidate
+		}
+	}
+	// Fallback: find the last dotted segment if no colon delimiter
+	parts := strings.Split(path, ".")
+	if len(parts) >= 2 {
+		// Return "service.method" from the last two path components
+		last := parts[len(parts)-1]
+		prev := parts[len(parts)-2]
+		if !strings.Contains(prev, "[") {
+			return prev + "." + last
+		}
+	}
+	return ""
+}
+
+// extractParamName extracts the parameter name from an error path like
+// "sagas[0]:position_keeping.initiate_log#amount".
+// Returns empty string when no parameter name can be determined.
+func extractParamName(path string) string {
+	hash := strings.LastIndex(path, "#")
+	if hash >= 0 && hash < len(path)-1 {
+		return path[hash+1:]
+	}
+	return ""
+}

--- a/services/control-plane/internal/generator/validate_fix.go
+++ b/services/control-plane/internal/generator/validate_fix.go
@@ -305,6 +305,11 @@ func replaceDeprecatedHandler(script string, oldName string, info deprecatedHand
 		if len(reverseMapping) > 0 {
 			callBody = renameKwargs(callBody, reverseMapping)
 		}
+		// Apply ConversionRule.Defaults: inject default values for any required args
+		// that the old caller did not provide (e.g., a new param added in the replacement).
+		if info.rule != nil && len(info.rule.Defaults) > 0 {
+			callBody = injectMissingDefaults(callBody, info.rule.Defaults)
+		}
 		result.WriteString(callBody)
 		remaining = rest
 	}
@@ -484,6 +489,108 @@ func renameKwargIdent(result *strings.Builder, s string, i int, reverseMapping m
 
 func isIdentStart(ch byte) bool {
 	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_'
+}
+
+// injectMissingDefaults appends keyword arguments from defaults that are not already
+// present at the top level of callBody (the content inside parentheses, including the
+// closing ')').  Only top-level kwargs are checked; nested calls are ignored.
+//
+// callBody is expected to end with ')'.  When defaults must be injected the result
+// is something like "existing_arg=v, new_param="default_value")".
+func injectMissingDefaults(callBody string, defaults map[string]string) string {
+	// Collect kwarg names already present at the top level (depth == 0).
+	present := collectTopLevelKwargNames(callBody)
+
+	// Determine which defaults are missing and need to be injected.
+	type kv struct{ k, v string }
+	var missing []kv
+	for param, val := range defaults {
+		if !present[param] {
+			missing = append(missing, kv{param, val})
+		}
+	}
+	if len(missing) == 0 {
+		return callBody
+	}
+
+	// Sort for deterministic output.
+	sort.Slice(missing, func(i, j int) bool { return missing[i].k < missing[j].k })
+
+	// Strip the trailing ')' and inject the missing args.
+	// callBody ends with ')'; content before it is the existing args.
+	closeParen := strings.LastIndex(callBody, ")")
+	if closeParen < 0 {
+		return callBody
+	}
+	before := strings.TrimRight(callBody[:closeParen], " \t\n")
+	var sb strings.Builder
+	sb.WriteString(before)
+	for _, entry := range missing {
+		if len(before) > 0 && !strings.HasSuffix(before, "(") {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(entry.k)
+		sb.WriteString("=")
+		sb.WriteString(entry.v)
+		before = sb.String() // update before for subsequent iterations
+	}
+	sb.WriteString(callBody[closeParen:]) // append rest from closing paren onwards
+	return sb.String()
+}
+
+// collectTopLevelKwargNames scans callBody and returns the set of keyword argument
+// names found at depth 0 (i.e. not inside nested calls or string literals).
+func collectTopLevelKwargNames(callBody string) map[string]bool {
+	present := make(map[string]bool)
+	i := 0
+	depth := 0
+	for i < len(callBody) {
+		i, depth = collectKwargStep(callBody, i, depth, present)
+	}
+	return present
+}
+
+// collectKwargStep processes one position in a call body, updating depth and the present set.
+// Returns the next position and new depth.
+func collectKwargStep(s string, i int, depth int, present map[string]bool) (int, int) {
+	if s[i] == '"' || s[i] == '\'' {
+		return advancePastString(s, i), depth
+	}
+	if next, skip := advancePastToken(s, i); skip {
+		return next, depth
+	}
+	if s[i] == '(' {
+		return i + 1, depth + 1
+	}
+	if s[i] == ')' {
+		if depth > 0 {
+			depth--
+		}
+		return i + 1, depth
+	}
+	if depth == 0 && isIdentStart(s[i]) {
+		return collectKwargIdent(s, i, present), depth
+	}
+	return i + 1, depth
+}
+
+// collectKwargIdent scans an identifier at position i and records it in present
+// when it is a keyword argument (followed by '=' but not '==').
+// Returns the position after the identifier.
+func collectKwargIdent(s string, i int, present map[string]bool) int {
+	start := i
+	for i < len(s) && isScriptIdentChar(s[i]) {
+		i++
+	}
+	ident := s[start:i]
+	j := i
+	for j < len(s) && (s[j] == ' ' || s[j] == '\t') {
+		j++
+	}
+	if j < len(s) && s[j] == '=' && (j+1 >= len(s) || s[j+1] != '=') {
+		present[ident] = true
+	}
+	return i
 }
 
 // enrichErrors augments validation errors with additional context to help the LLM

--- a/services/control-plane/internal/generator/validate_fix.go
+++ b/services/control-plane/internal/generator/validate_fix.go
@@ -11,9 +11,14 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/events/topics"
 )
 
-// errUnexpectedLoopExit is returned when the validate-fix loop exits unexpectedly.
-// This is a sentinel for an unreachable code path.
-var errUnexpectedLoopExit = errors.New("validate-fix: unexpected loop exit")
+// Sentinel errors for ValidateAndFix option validation and loop guards.
+var (
+	errUnexpectedLoopExit        = errors.New("validate-fix: unexpected loop exit")
+	errNegativeMaxIterations     = errors.New("validate-fix: MaxIterations must be >= 0")
+	errValidatorRequired         = errors.New("validate-fix: validator is required")
+	errLLMClientRequiredForFixes = errors.New("validate-fix: LLM client is required when MaxIterations > 0")
+	errNilValidatorResult        = errors.New("validate-fix: nil result from validator")
+)
 
 // ManifestValidator abstracts the validation pipeline for the validate-fix loop.
 // It performs a dry-run validation returning structured errors without persisting anything.
@@ -77,6 +82,16 @@ type ValidateFixResult struct {
 //  4. If errors: enrich errors, send to LLM via LLMClient.Fix, repeat
 //  5. After MaxIterations: return with remaining errors and Valid=false
 func ValidateAndFix(ctx context.Context, manifestYAML string, opts ValidateFixOptions) (*ValidateFixResult, error) {
+	if opts.MaxIterations < 0 {
+		return nil, errNegativeMaxIterations
+	}
+	if opts.Validator == nil {
+		return nil, errValidatorRequired
+	}
+	if opts.MaxIterations > 0 && opts.LLMClient == nil {
+		return nil, errLLMClientRequiredForFixes
+	}
+
 	current := manifestYAML
 
 	for iter := 0; iter <= opts.MaxIterations; iter++ {
@@ -87,6 +102,9 @@ func ValidateAndFix(ctx context.Context, manifestYAML string, opts ValidateFixOp
 		result, err := opts.Validator.ValidateDryRun(ctx, current)
 		if err != nil {
 			return nil, fmt.Errorf("validate manifest (iteration %d): %w", iter, err)
+		}
+		if result == nil {
+			return nil, fmt.Errorf("validate manifest (iteration %d): %w", iter, errNilValidatorResult)
 		}
 
 		// Step 3: If valid, we are done
@@ -148,9 +166,8 @@ func applyMutatingPhase(manifestYAML string, registry *schema.Registry) string {
 	inScript := false
 	var scriptIndent int
 	var scriptLines []string
-	var scriptStartIdx int
 
-	for i, line := range lines {
+	for _, line := range lines {
 		if !inScript {
 			// Detect "script: |" or "script: |-" at any indentation level
 			trimmed := strings.TrimLeft(line, " \t")
@@ -159,7 +176,6 @@ func applyMutatingPhase(manifestYAML string, registry *schema.Registry) string {
 				inScript = true
 				scriptIndent = indent
 				scriptLines = nil
-				scriptStartIdx = i
 				result = append(result, line)
 				continue
 			}
@@ -179,12 +195,9 @@ func applyMutatingPhase(manifestYAML string, registry *schema.Registry) string {
 			script := strings.Join(scriptLines, "\n")
 			fixed := applyDeprecatedHandlerFixes(script, deprecatedHandlers)
 			fixedLines := strings.Split(fixed, "\n")
-			// Replace the script lines in result (they were already appended as empty during collection)
-			// We need to backfill: scriptLines were NOT yet appended — we deferred them
 			result = append(result, fixedLines...)
 			inScript = false
 			scriptLines = nil
-			_ = scriptStartIdx
 			result = append(result, line)
 			continue
 		}
@@ -299,35 +312,56 @@ func replaceDeprecatedHandler(script string, oldName string, info deprecatedHand
 }
 
 // findHandlerCall finds the index of oldName followed by optional whitespace and '(' in s.
-// Returns -1 if not found. Only matches at word boundaries (preceded by non-ident or start of string).
+// Returns -1 if not found. Only matches at word boundaries outside string literals and comments.
 func findHandlerCall(s, oldName string) int {
-	idx := 0
-	for {
-		pos := strings.Index(s[idx:], oldName)
-		if pos < 0 {
-			return -1
-		}
-		pos += idx
-
-		// Check word boundary before
-		if pos > 0 && isScriptIdentChar(s[pos-1]) {
-			idx = pos + 1
+	for i := 0; i < len(s); {
+		// Skip string literals and line comments to avoid false matches.
+		if next, skip := advancePastToken(s, i); skip {
+			i = next
 			continue
 		}
 
-		// Check that something follows: optional whitespace then '('
-		rest := s[pos+len(oldName):]
-		wsEnd := 0
-		for wsEnd < len(rest) && (rest[wsEnd] == ' ' || rest[wsEnd] == '\t') {
-			wsEnd++
-		}
-		if wsEnd >= len(rest) || rest[wsEnd] != '(' {
-			idx = pos + 1
-			continue
+		// Check for oldName at position i (outside string/comment).
+		if isHandlerCallAt(s, i, oldName) {
+			return i
 		}
 
-		return pos
+		i++
 	}
+	return -1
+}
+
+// advancePastToken advances past a string literal or line comment starting at i.
+// Returns (next position, true) when a token was skipped, or (i, false) otherwise.
+func advancePastToken(s string, i int) (int, bool) {
+	if s[i] == '"' || s[i] == '\'' {
+		return advancePastString(s, i), true
+	}
+	if s[i] == '#' {
+		j := i
+		for j < len(s) && s[j] != '\n' {
+			j++
+		}
+		return j, true
+	}
+	return i, false
+}
+
+// isHandlerCallAt returns true when oldName appears at position i in s followed by
+// optional whitespace and '(', at a word boundary (not preceded by an ident char).
+func isHandlerCallAt(s string, i int, oldName string) bool {
+	if !strings.HasPrefix(s[i:], oldName) {
+		return false
+	}
+	if i > 0 && isScriptIdentChar(s[i-1]) {
+		return false
+	}
+	rest := s[i+len(oldName):]
+	wsEnd := 0
+	for wsEnd < len(rest) && (rest[wsEnd] == ' ' || rest[wsEnd] == '\t') {
+		wsEnd++
+	}
+	return wsEnd < len(rest) && rest[wsEnd] == '('
 }
 
 func isScriptIdentChar(ch byte) bool {
@@ -628,9 +662,14 @@ func min3(a, b, c int) int {
 }
 
 // extractHandlerName extracts the handler name from an error path like
-// "sagas[0].script:position_keeping.initiate_log" or "sagas[0]:position_keeping.initiate_log".
+// "sagas[0].script:position_keeping.initiate_log" or "sagas[0]:position_keeping.initiate_log#amount".
 // Returns empty string when no handler name can be determined.
 func extractHandlerName(path string) string {
+	// Strip any #param suffix before extracting the handler name.
+	if hash := strings.LastIndex(path, "#"); hash >= 0 {
+		path = path[:hash]
+	}
+
 	// Look for a pattern like "service_name.handler_name" in the path
 	colon := strings.LastIndex(path, ":")
 	if colon >= 0 && colon < len(path)-1 {

--- a/services/control-plane/internal/generator/validate_fix_test.go
+++ b/services/control-plane/internal/generator/validate_fix_test.go
@@ -309,3 +309,130 @@ func TestApplyMutatingPhase_NoDeprecatedHandlers(t *testing.T) {
 	result := generator.ApplyMutatingPhase(manifest, reg)
 	assert.Equal(t, manifest, result)
 }
+
+// --- ValidateAndFix input validation tests ---
+
+// TestValidateAndFix_NilValidator returns an error immediately.
+func TestValidateAndFix_NilValidator(t *testing.T) {
+	_, err := generator.ValidateAndFix(context.Background(), "x: 1", generator.ValidateFixOptions{
+		MaxIterations: 0,
+		Validator:     nil,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validator is required")
+}
+
+// TestValidateAndFix_NegativeMaxIterations returns an error immediately.
+func TestValidateAndFix_NegativeMaxIterations(t *testing.T) {
+	_, err := generator.ValidateAndFix(context.Background(), "x: 1", generator.ValidateFixOptions{
+		MaxIterations: -1,
+		Validator:     &mockValidator{},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MaxIterations must be >= 0")
+}
+
+// TestValidateAndFix_NilLLMClientWithIterations returns an error when fixes are expected.
+func TestValidateAndFix_NilLLMClientWithIterations(t *testing.T) {
+	_, err := generator.ValidateAndFix(context.Background(), "x: 1", generator.ValidateFixOptions{
+		MaxIterations: 2,
+		Validator:     &mockValidator{},
+		LLMClient:     nil,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "LLM client is required")
+}
+
+// --- replaceDeprecatedHandler (text manipulation) tests ---
+
+// TestReplaceDeprecatedHandler_BasicRename verifies a simple handler name replacement.
+func TestReplaceDeprecatedHandler_BasicRename(t *testing.T) {
+	script := "old_handler(amount=100, direction='CREDIT')"
+	info := generator.NewDeprecatedHandlerInfo("new_handler")
+	result := generator.ReplaceDeprecatedHandler(script, "old_handler", info)
+	assert.Equal(t, "new_handler(amount=100, direction='CREDIT')", result)
+}
+
+// TestReplaceDeprecatedHandler_SkipsStringLiteral verifies that handler names inside
+// string literals are not replaced.
+func TestReplaceDeprecatedHandler_SkipsStringLiteral(t *testing.T) {
+	script := `x = "old_handler(amount=1)"` + "\nold_handler(amount=2)"
+	info := generator.NewDeprecatedHandlerInfo("new_handler")
+	result := generator.ReplaceDeprecatedHandler(script, "old_handler", info)
+	// The string literal occurrence must be preserved; only the real call is replaced.
+	assert.Contains(t, result, `"old_handler(amount=1)"`)
+	assert.Contains(t, result, "new_handler(amount=2)")
+}
+
+// TestReplaceDeprecatedHandler_SkipsLineComment verifies that handler names in comments
+// are not replaced.
+func TestReplaceDeprecatedHandler_SkipsLineComment(t *testing.T) {
+	script := "# old_handler(amount=1)\nold_handler(amount=2)"
+	info := generator.NewDeprecatedHandlerInfo("new_handler")
+	result := generator.ReplaceDeprecatedHandler(script, "old_handler", info)
+	assert.Contains(t, result, "# old_handler(amount=1)")
+	assert.Contains(t, result, "new_handler(amount=2)")
+}
+
+// TestReplaceDeprecatedHandler_WordBoundary verifies that "old_handler_extended" is not
+// matched when looking for "old_handler".
+func TestReplaceDeprecatedHandler_WordBoundary(t *testing.T) {
+	script := "old_handler_extended(amount=1)\nold_handler(amount=2)"
+	info := generator.NewDeprecatedHandlerInfo("new_handler")
+	result := generator.ReplaceDeprecatedHandler(script, "old_handler", info)
+	assert.Contains(t, result, "old_handler_extended(amount=1)")
+	assert.Contains(t, result, "new_handler(amount=2)")
+}
+
+// TestReplaceDeprecatedHandler_NoOccurrence returns script unchanged when name absent.
+func TestReplaceDeprecatedHandler_NoOccurrence(t *testing.T) {
+	script := "different_handler(amount=1)"
+	info := generator.NewDeprecatedHandlerInfo("new_handler")
+	result := generator.ReplaceDeprecatedHandler(script, "old_handler", info)
+	assert.Equal(t, script, result)
+}
+
+// --- findHandlerCall tests ---
+
+// TestFindHandlerCall_BasicMatch finds a handler call in plain text.
+func TestFindHandlerCall_BasicMatch(t *testing.T) {
+	s := "old_handler(x=1)"
+	idx := generator.FindHandlerCall(s, "old_handler")
+	assert.Equal(t, 0, idx)
+}
+
+// TestFindHandlerCall_InsideString returns -1 for occurrences inside string literals.
+func TestFindHandlerCall_InsideString(t *testing.T) {
+	s := `msg = "old_handler(x=1)"`
+	idx := generator.FindHandlerCall(s, "old_handler")
+	assert.Equal(t, -1, idx)
+}
+
+// TestFindHandlerCall_InsideComment returns -1 for occurrences in line comments.
+func TestFindHandlerCall_InsideComment(t *testing.T) {
+	s := "# old_handler(x=1)"
+	idx := generator.FindHandlerCall(s, "old_handler")
+	assert.Equal(t, -1, idx)
+}
+
+// --- extractHandlerName tests ---
+
+// TestExtractHandlerName_WithHashParam strips the #param suffix before extraction.
+func TestExtractHandlerName_WithHashParam(t *testing.T) {
+	path := "sagas[0]:position_keeping.initiate_log#amount"
+	name := generator.ExtractHandlerName(path)
+	assert.Equal(t, "position_keeping.initiate_log", name)
+}
+
+// TestExtractHandlerName_WithoutHash extracts handler from colon-delimited path.
+func TestExtractHandlerName_WithoutHash(t *testing.T) {
+	path := "sagas[0]:position_keeping.initiate_log"
+	name := generator.ExtractHandlerName(path)
+	assert.Equal(t, "position_keeping.initiate_log", name)
+}
+
+// TestExtractHandlerName_Empty returns empty for unrecognized path.
+func TestExtractHandlerName_Empty(t *testing.T) {
+	name := generator.ExtractHandlerName("sagas[0].name")
+	assert.Equal(t, "", name)
+}

--- a/services/control-plane/internal/generator/validate_fix_test.go
+++ b/services/control-plane/internal/generator/validate_fix_test.go
@@ -1,0 +1,311 @@
+package generator_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/control-plane/internal/generator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock implementations ---
+
+// mockValidator implements generator.ManifestValidator for tests.
+type mockValidator struct {
+	// responses is a queue of results to return on successive calls.
+	// Each call pops the first response.
+	responses []*generator.ValidationResult
+	errors    []error
+}
+
+func (m *mockValidator) ValidateDryRun(_ context.Context, _ string) (*generator.ValidationResult, error) {
+	if len(m.errors) > 0 {
+		err := m.errors[0]
+		m.errors = m.errors[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(m.responses) == 0 {
+		return &generator.ValidationResult{Valid: true}, nil
+	}
+	r := m.responses[0]
+	m.responses = m.responses[1:]
+	return r, nil
+}
+
+// mockLLMClient implements generator.LLMClient for tests.
+type mockLLMClient struct {
+	// fixResponses is a queue of manifests to return on Fix calls.
+	fixResponses []string
+	fixErrors    []error
+	fixCallCount int
+}
+
+func (m *mockLLMClient) Generate(_ context.Context, _ string) (string, error) {
+	return "", errors.New("Generate not expected in validate-fix tests")
+}
+
+func (m *mockLLMClient) Fix(_ context.Context, _ string, _ []generator.ValidationError) (string, error) {
+	m.fixCallCount++
+	if len(m.fixErrors) > 0 {
+		err := m.fixErrors[0]
+		m.fixErrors = m.fixErrors[1:]
+		if err != nil {
+			return "", err
+		}
+	}
+	if len(m.fixResponses) == 0 {
+		return "fixed: manifest", nil
+	}
+	r := m.fixResponses[0]
+	m.fixResponses = m.fixResponses[1:]
+	return r, nil
+}
+
+// --- ValidateAndFix tests ---
+
+// TestValidateAndFix_ValidOnFirstPass checks that no LLM calls are made when
+// the manifest passes validation immediately.
+func TestValidateAndFix_ValidOnFirstPass(t *testing.T) {
+	ctx := context.Background()
+
+	validator := &mockValidator{
+		responses: []*generator.ValidationResult{
+			{Valid: true, Warnings: []generator.ValidationError{{Code: "WARN", Message: "minor issue"}}},
+		},
+	}
+	llm := &mockLLMClient{}
+
+	result, err := generator.ValidateAndFix(ctx, "instruments: []", generator.ValidateFixOptions{
+		MaxIterations: 3,
+		LLMClient:     llm,
+		Validator:     validator,
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.Valid)
+	assert.Equal(t, 0, result.IterationsUsed)
+	assert.Equal(t, 0, llm.fixCallCount)
+	assert.Len(t, result.Warnings, 1)
+	assert.Len(t, result.Errors, 0)
+	assert.Equal(t, "instruments: []", result.FinalManifest)
+}
+
+// TestValidateAndFix_FixOnFirstIteration checks that one LLM call fixes the manifest.
+func TestValidateAndFix_FixOnFirstIteration(t *testing.T) {
+	ctx := context.Background()
+
+	const fixedYAML = "instruments:\n  - code: GBP"
+
+	validator := &mockValidator{
+		responses: []*generator.ValidationResult{
+			// First call: errors
+			{Valid: false, Errors: []generator.ValidationError{
+				{Code: "MISSING_FIELD", Path: "instruments[0].code", Message: "code is required"},
+			}},
+			// Second call: valid
+			{Valid: true},
+		},
+	}
+	llm := &mockLLMClient{
+		fixResponses: []string{fixedYAML},
+	}
+
+	result, err := generator.ValidateAndFix(ctx, "instruments:\n  - name: GBP", generator.ValidateFixOptions{
+		MaxIterations: 3,
+		LLMClient:     llm,
+		Validator:     validator,
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.Valid)
+	assert.Equal(t, 1, result.IterationsUsed)
+	assert.Equal(t, 1, llm.fixCallCount)
+	assert.Equal(t, fixedYAML, result.FinalManifest)
+}
+
+// TestValidateAndFix_MaxIterationsExceeded checks that the loop stops after MaxIterations
+// and returns the remaining errors with Valid=false.
+func TestValidateAndFix_MaxIterationsExceeded(t *testing.T) {
+	ctx := context.Background()
+
+	errResult := &generator.ValidationResult{
+		Valid: false,
+		Errors: []generator.ValidationError{
+			{Code: "PERSISTENT_ERROR", Path: "instruments", Message: "still broken"},
+		},
+	}
+
+	// Always return errors
+	validator := &mockValidator{
+		responses: []*generator.ValidationResult{errResult, errResult, errResult, errResult},
+	}
+	llm := &mockLLMClient{
+		fixResponses: []string{"attempt1", "attempt2", "attempt3"},
+	}
+
+	result, err := generator.ValidateAndFix(ctx, "broken: manifest", generator.ValidateFixOptions{
+		MaxIterations: 3,
+		LLMClient:     llm,
+		Validator:     validator,
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Valid)
+	assert.Equal(t, 3, result.IterationsUsed)
+	assert.Equal(t, 3, llm.fixCallCount)
+	assert.Len(t, result.Errors, 1)
+	assert.Equal(t, "PERSISTENT_ERROR", result.Errors[0].Code)
+}
+
+// TestValidateAndFix_ZeroMaxIterations validates without attempting any LLM fixes.
+func TestValidateAndFix_ZeroMaxIterations(t *testing.T) {
+	ctx := context.Background()
+
+	validator := &mockValidator{
+		responses: []*generator.ValidationResult{
+			{Valid: false, Errors: []generator.ValidationError{
+				{Code: "ERR", Path: "x", Message: "broken"},
+			}},
+		},
+	}
+	llm := &mockLLMClient{}
+
+	result, err := generator.ValidateAndFix(ctx, "broken: yes", generator.ValidateFixOptions{
+		MaxIterations: 0,
+		LLMClient:     llm,
+		Validator:     validator,
+	})
+
+	require.NoError(t, err)
+	assert.False(t, result.Valid)
+	assert.Equal(t, 0, result.IterationsUsed)
+	assert.Equal(t, 0, llm.fixCallCount)
+}
+
+// TestValidateAndFix_ValidatorError propagates errors from the validator.
+func TestValidateAndFix_ValidatorError(t *testing.T) {
+	ctx := context.Background()
+
+	validator := &mockValidator{
+		errors: []error{errors.New("database unavailable")},
+	}
+	llm := &mockLLMClient{}
+
+	_, err := generator.ValidateAndFix(ctx, "valid: yaml", generator.ValidateFixOptions{
+		MaxIterations: 3,
+		LLMClient:     llm,
+		Validator:     validator,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database unavailable")
+}
+
+// TestValidateAndFix_LLMError propagates errors from the LLM Fix call.
+func TestValidateAndFix_LLMError(t *testing.T) {
+	ctx := context.Background()
+
+	validator := &mockValidator{
+		responses: []*generator.ValidationResult{
+			{Valid: false, Errors: []generator.ValidationError{
+				{Code: "ERR", Path: "x", Message: "broken"},
+			}},
+		},
+	}
+	llm := &mockLLMClient{
+		fixErrors: []error{errors.New("LLM rate limited")},
+	}
+
+	_, err := generator.ValidateAndFix(ctx, "broken: yes", generator.ValidateFixOptions{
+		MaxIterations: 2,
+		LLMClient:     llm,
+		Validator:     validator,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "LLM rate limited")
+}
+
+// --- enrichErrors tests ---
+
+// TestEnrichErrors_UnknownHandler_NilRegistry returns errors unchanged when no registry.
+func TestEnrichErrors_UnknownHandler_NilRegistry(t *testing.T) {
+	errs := []generator.ValidationError{
+		{Code: "UNKNOWN_HANDLER", Path: "sagas[0]", Message: "unknown handler: foo.bar"},
+	}
+	enriched := generator.EnrichErrors(errs, nil)
+	require.Len(t, enriched, 1)
+	assert.Nil(t, enriched[0].AvailableFields)
+}
+
+// TestEnrichErrors_UnknownEventTopic_AddsSuggestion verifies that an unknown event topic
+// error gets available topics added.
+func TestEnrichErrors_UnknownEventTopic_AddsSuggestion(t *testing.T) {
+	errs := []generator.ValidationError{
+		{
+			Code:    "UNKNOWN_EVENT_TOPIC",
+			Path:    "sagas[0].triggers[0].event_topic",
+			Message: "unknown topic: position_keeping.transaction_captur.v1",
+		},
+	}
+	enriched := generator.EnrichErrors(errs, nil)
+	require.Len(t, enriched, 1)
+	// Should have available topics populated (from topics.All())
+	assert.NotEmpty(t, enriched[0].AvailableFields, "expected available topics to be populated")
+}
+
+// TestEnrichErrors_UnknownEventTopic_PreservesExistingSuggestion verifies that if a
+// suggestion is already present, it is not overwritten.
+func TestEnrichErrors_UnknownEventTopic_PreservesExistingSuggestion(t *testing.T) {
+	errs := []generator.ValidationError{
+		{
+			Code:       "UNKNOWN_EVENT_TOPIC",
+			Path:       "sagas[0]",
+			Message:    "unknown topic",
+			Suggestion: "position_keeping.transaction_captured.v1",
+		},
+	}
+	enriched := generator.EnrichErrors(errs, nil)
+	require.Len(t, enriched, 1)
+	assert.Equal(t, "position_keeping.transaction_captured.v1", enriched[0].Suggestion)
+}
+
+// TestEnrichErrors_UnknownCode_PassesThrough verifies that errors with unrecognized codes
+// are returned unchanged.
+func TestEnrichErrors_UnknownCode_PassesThrough(t *testing.T) {
+	errs := []generator.ValidationError{
+		{Code: "SOME_OTHER_CODE", Path: "foo", Message: "bar"},
+	}
+	enriched := generator.EnrichErrors(errs, nil)
+	require.Len(t, enriched, 1)
+	assert.Equal(t, "SOME_OTHER_CODE", enriched[0].Code)
+	assert.Nil(t, enriched[0].AvailableFields)
+	assert.Equal(t, "", enriched[0].Suggestion)
+}
+
+// TestEnrichErrors_EmptySlice returns an empty slice unchanged.
+func TestEnrichErrors_EmptySlice(t *testing.T) {
+	enriched := generator.EnrichErrors(nil, nil)
+	assert.Nil(t, enriched)
+}
+
+// --- applyMutatingPhase tests ---
+
+// TestApplyMutatingPhase_NilRegistry returns manifest unchanged.
+func TestApplyMutatingPhase_NilRegistry(t *testing.T) {
+	manifest := "sagas:\n  - name: test\n    script: |\n      old_handler(amount=100)"
+	result := generator.ApplyMutatingPhase(manifest, nil)
+	assert.Equal(t, manifest, result)
+}
+
+// TestApplyMutatingPhase_NoDeprecatedHandlers returns manifest unchanged when registry has no deprecated handlers.
+func TestApplyMutatingPhase_NoDeprecatedHandlers(t *testing.T) {
+	reg := generator.NewEmptySchemaRegistry()
+	manifest := "sagas:\n  - name: test\n    script: |\n      print('hello')"
+	result := generator.ApplyMutatingPhase(manifest, reg)
+	assert.Equal(t, manifest, result)
+}

--- a/services/control-plane/internal/generator/validate_fix_test.go
+++ b/services/control-plane/internal/generator/validate_fix_test.go
@@ -3,6 +3,7 @@ package generator_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/meridianhub/meridian/services/control-plane/internal/generator"
@@ -435,4 +436,47 @@ func TestExtractHandlerName_WithoutHash(t *testing.T) {
 func TestExtractHandlerName_Empty(t *testing.T) {
 	name := generator.ExtractHandlerName("sagas[0].name")
 	assert.Equal(t, "", name)
+}
+
+// --- injectMissingDefaults tests ---
+
+// TestInjectMissingDefaults_InjectsAbsentArg adds a missing default kwarg.
+func TestInjectMissingDefaults_InjectsAbsentArg(t *testing.T) {
+	// callBody is the content inside the parens including the closing paren.
+	callBody := "amount=100)"
+	defaults := map[string]string{"direction": `"CREDIT"`}
+	result := generator.InjectMissingDefaults(callBody, defaults)
+	assert.Contains(t, result, `direction="CREDIT"`)
+	assert.Contains(t, result, "amount=100")
+}
+
+// TestInjectMissingDefaults_SkipsPresentArg does not duplicate a kwarg already present.
+func TestInjectMissingDefaults_SkipsPresentArg(t *testing.T) {
+	callBody := `amount=100, direction="DEBIT")`
+	defaults := map[string]string{"direction": `"CREDIT"`}
+	result := generator.InjectMissingDefaults(callBody, defaults)
+	// direction is already present — should not appear twice
+	assert.Equal(t, 1, strings.Count(result, "direction="))
+	// Value should remain the caller's value, not the default
+	assert.Contains(t, result, `direction="DEBIT"`)
+}
+
+// TestInjectMissingDefaults_EmptyDefaults returns callBody unchanged.
+func TestInjectMissingDefaults_EmptyDefaults(t *testing.T) {
+	callBody := "amount=100)"
+	result := generator.InjectMissingDefaults(callBody, map[string]string{})
+	assert.Equal(t, callBody, result)
+}
+
+// TestReplaceDeprecatedHandler_AppliesDefaults verifies that ConversionRule.Defaults
+// are injected when the old call does not supply the new required param.
+func TestReplaceDeprecatedHandler_AppliesDefaults(t *testing.T) {
+	script := "old_handler(amount=50)"
+	info := generator.NewDeprecatedHandlerInfoWithDefaults("new_handler", map[string]string{
+		"currency": `"GBP"`,
+	})
+	result := generator.ReplaceDeprecatedHandler(script, "old_handler", info)
+	assert.Contains(t, result, "new_handler(")
+	assert.Contains(t, result, "amount=50")
+	assert.Contains(t, result, `currency="GBP"`)
 }


### PR DESCRIPTION
## Summary

- Adds `ValidateAndFix` function implementing the generate→validate→fix feedback loop for AI-assisted manifest generation
- Adds `ManifestValidator` interface to abstract dry-run validation, enabling independent testing without the full validator stack
- Adds `enrichErrors` that augments validation errors with contextual hints (available handler names, topic suggestions, required param types) to improve LLM fix quality
- Adds `applyMutatingPhase` that auto-converts deprecated handler calls in Starlark script blocks embedded in manifest YAML
- Exports test hooks via `export_test.go` for black-box testing of enrichment and mutating phase

## Changes Made

**New file**: `services/control-plane/internal/generator/validate_fix.go`
- `ValidateFixOptions` / `ValidateFixResult` / `ValidationResult` types
- `ManifestValidator` interface
- `ValidateAndFix` loop: apply mutating phase → validate → enrich → LLM fix → repeat up to MaxIterations
- `enrichErrors` with per-code enrichment (UNKNOWN_HANDLER, UNKNOWN_EVENT_TOPIC, MISSING_REQUIRED_PARAM, WRONG_PARAM_TYPE)
- `applyMutatingPhase` with YAML script block detection and deprecated handler text replacement

**New file**: `services/control-plane/internal/generator/validate_fix_test.go`
- 14 tests using mock implementations of `ManifestValidator` and `LLMClient`

**Modified**: `services/control-plane/internal/generator/export_test.go`
- Exports `EnrichErrors`, `ApplyMutatingPhase`, and `NewEmptySchemaRegistry` for black-box testing

## Test Plan

- [x] `TestValidateAndFix_ValidOnFirstPass` — no LLM calls on immediate success
- [x] `TestValidateAndFix_FixOnFirstIteration` — one LLM call resolves errors
- [x] `TestValidateAndFix_MaxIterationsExceeded` — stops after MaxIterations with errors
- [x] `TestValidateAndFix_ZeroMaxIterations` — validates only, no LLM calls
- [x] `TestValidateAndFix_ValidatorError` — propagates validator errors
- [x] `TestValidateAndFix_LLMError` — propagates LLM errors
- [x] `TestEnrichErrors_UnknownHandler_NilRegistry` — nil registry leaves errors unchanged
- [x] `TestEnrichErrors_UnknownEventTopic_AddsSuggestion` — populates available topics
- [x] `TestEnrichErrors_UnknownEventTopic_PreservesExistingSuggestion` — does not overwrite
- [x] `TestEnrichErrors_UnknownCode_PassesThrough` — unknown codes passed through unchanged
- [x] `TestEnrichErrors_EmptySlice` — empty input returns nil
- [x] `TestApplyMutatingPhase_NilRegistry` — nil registry returns manifest unchanged
- [x] `TestApplyMutatingPhase_NoDeprecatedHandlers` — empty registry returns manifest unchanged
- All existing generator tests continue to pass

## Task

economy-generator.9 — Validate-Fix Loop