### PR TITLE
feat: Add context assembly caching for economy generation

### DIFF
--- a/services/control-plane/internal/generator/cached_context.go
+++ b/services/control-plane/internal/generator/cached_context.go
@@ -1,0 +1,86 @@
+package generator
+
+import (
+	"io/fs"
+	"sync"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+)
+
+// defaultRefreshInterval is the default time before cached static components are refreshed.
+const defaultRefreshInterval = 5 * time.Minute
+
+// CachedContextAssembler wraps AssembleContext with a caching layer for the static
+// components (handler reference card, topic list, schema summary) that are expensive
+// to compute but rarely change. Pattern matching remains uncached because it varies
+// per request based on the business description and industry.
+type CachedContextAssembler struct {
+	mu              sync.RWMutex
+	handlerCard     string
+	topicList       string
+	schemaSummary   string
+	lastRefresh     time.Time
+	refreshInterval time.Duration
+
+	registry   *schema.Registry
+	cookbookFS fs.FS
+}
+
+// NewCachedContextAssembler creates a CachedContextAssembler with the given dependencies
+// and refresh interval. If refreshInterval is zero, defaultRefreshInterval (5 minutes) is used.
+func NewCachedContextAssembler(registry *schema.Registry, cookbookFS fs.FS, refreshInterval time.Duration) *CachedContextAssembler {
+	if refreshInterval <= 0 {
+		refreshInterval = defaultRefreshInterval
+	}
+	return &CachedContextAssembler{
+		registry:        registry,
+		cookbookFS:      cookbookFS,
+		refreshInterval: refreshInterval,
+	}
+}
+
+// AssembleContext assembles a generation prompt using cached static components and
+// fresh per-request pattern matching. It is a drop-in replacement for the package-level
+// AssembleContext function and returns the same types.
+func (c *CachedContextAssembler) AssembleContext(opts ContextAssemblerOptions) (*AssembledContext, error) {
+	handlerCard, topicList, schemaSummary := c.cachedStatics()
+	return assembleContextWithStatics(opts, handlerCard, topicList, schemaSummary, c.registry, c.cookbookFS)
+}
+
+// Invalidate clears the cached static components, forcing a refresh on the next call.
+// Useful in tests or when the registry changes at runtime.
+func (c *CachedContextAssembler) Invalidate() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lastRefresh = time.Time{}
+}
+
+// cachedStatics returns the three static prompt components, refreshing them if the cache
+// is stale or has not been populated yet.
+func (c *CachedContextAssembler) cachedStatics() (handlerCard, topicList, schemaSummary string) {
+	// Fast path: read lock — cache is fresh.
+	c.mu.RLock()
+	if !c.lastRefresh.IsZero() && time.Since(c.lastRefresh) <= c.refreshInterval {
+		handlerCard, topicList, schemaSummary = c.handlerCard, c.topicList, c.schemaSummary
+		c.mu.RUnlock()
+		return
+	}
+	c.mu.RUnlock()
+
+	// Slow path: write lock — refresh the cache.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Double-check after acquiring write lock to avoid redundant work.
+	if !c.lastRefresh.IsZero() && time.Since(c.lastRefresh) <= c.refreshInterval {
+		return c.handlerCard, c.topicList, c.schemaSummary
+	}
+
+	c.handlerCard = BuildHandlerReferenceCard(c.registry)
+	c.topicList = BuildTopicList()
+	c.schemaSummary = BuildManifestSchemaSummary()
+	c.lastRefresh = time.Now()
+
+	return c.handlerCard, c.topicList, c.schemaSummary
+}

--- a/services/control-plane/internal/generator/cached_context.go
+++ b/services/control-plane/internal/generator/cached_context.go
@@ -11,20 +11,29 @@ import (
 // defaultRefreshInterval is the default time before cached static components are refreshed.
 const defaultRefreshInterval = 5 * time.Minute
 
+// staticComponents holds the three cached static prompt sections.
+type staticComponents struct {
+	handlerCard   string
+	topicList     string
+	schemaSummary string
+}
+
 // CachedContextAssembler wraps AssembleContext with a caching layer for the static
 // components (handler reference card, topic list, schema summary) that are expensive
 // to compute but rarely change. Pattern matching remains uncached because it varies
 // per request based on the business description and industry.
 type CachedContextAssembler struct {
 	mu              sync.RWMutex
-	handlerCard     string
-	topicList       string
-	schemaSummary   string
+	cached          staticComponents
 	lastRefresh     time.Time
 	refreshInterval time.Duration
 
 	registry   *schema.Registry
 	cookbookFS fs.FS
+
+	// buildStatics is the function used to compute static components. It is a field
+	// so tests can inject a counting wrapper to verify cache behavior.
+	buildStatics func(registry *schema.Registry) staticComponents
 }
 
 // NewCachedContextAssembler creates a CachedContextAssembler with the given dependencies
@@ -37,34 +46,40 @@ func NewCachedContextAssembler(registry *schema.Registry, cookbookFS fs.FS, refr
 		registry:        registry,
 		cookbookFS:      cookbookFS,
 		refreshInterval: refreshInterval,
+		buildStatics:    defaultBuildStatics,
 	}
 }
 
 // AssembleContext assembles a generation prompt using cached static components and
 // fresh per-request pattern matching. It is a drop-in replacement for the package-level
 // AssembleContext function and returns the same types.
+//
+// Returns ErrMissingRegistry if the assembler was constructed with a nil registry.
 func (c *CachedContextAssembler) AssembleContext(opts ContextAssemblerOptions) (*AssembledContext, error) {
-	handlerCard, topicList, schemaSummary := c.cachedStatics()
-	return assembleContextWithStatics(opts, handlerCard, topicList, schemaSummary, c.registry, c.cookbookFS)
+	if c.registry == nil {
+		return nil, ErrMissingRegistry
+	}
+	statics := c.getStatics()
+	return assembleContextWithStatics(opts, statics.handlerCard, statics.topicList, statics.schemaSummary, c.registry, c.cookbookFS)
 }
 
 // Invalidate clears the cached static components, forcing a refresh on the next call.
-// Useful in tests or when the registry changes at runtime.
+// Useful when the registry changes at runtime.
 func (c *CachedContextAssembler) Invalidate() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.lastRefresh = time.Time{}
 }
 
-// cachedStatics returns the three static prompt components, refreshing them if the cache
-// is stale or has not been populated yet.
-func (c *CachedContextAssembler) cachedStatics() (handlerCard, topicList, schemaSummary string) {
+// getStatics returns the cached static components, refreshing them if the cache is
+// stale or has not been populated yet.
+func (c *CachedContextAssembler) getStatics() staticComponents {
 	// Fast path: read lock — cache is fresh.
 	c.mu.RLock()
 	if !c.lastRefresh.IsZero() && time.Since(c.lastRefresh) <= c.refreshInterval {
-		handlerCard, topicList, schemaSummary = c.handlerCard, c.topicList, c.schemaSummary
+		s := c.cached
 		c.mu.RUnlock()
-		return
+		return s
 	}
 	c.mu.RUnlock()
 
@@ -72,15 +87,22 @@ func (c *CachedContextAssembler) cachedStatics() (handlerCard, topicList, schema
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Double-check after acquiring write lock to avoid redundant work.
+	// Double-check after acquiring write lock to avoid redundant work from concurrent refreshes.
 	if !c.lastRefresh.IsZero() && time.Since(c.lastRefresh) <= c.refreshInterval {
-		return c.handlerCard, c.topicList, c.schemaSummary
+		return c.cached
 	}
 
-	c.handlerCard = BuildHandlerReferenceCard(c.registry)
-	c.topicList = BuildTopicList()
-	c.schemaSummary = BuildManifestSchemaSummary()
+	c.cached = c.buildStatics(c.registry)
 	c.lastRefresh = time.Now()
 
-	return c.handlerCard, c.topicList, c.schemaSummary
+	return c.cached
+}
+
+// defaultBuildStatics computes the three static prompt sections from the registry.
+func defaultBuildStatics(registry *schema.Registry) staticComponents {
+	return staticComponents{
+		handlerCard:   BuildHandlerReferenceCard(registry),
+		topicList:     BuildTopicList(),
+		schemaSummary: BuildManifestSchemaSummary(),
+	}
 }

--- a/services/control-plane/internal/generator/cached_context_test.go
+++ b/services/control-plane/internal/generator/cached_context_test.go
@@ -1,0 +1,170 @@
+package generator_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/control-plane/internal/generator"
+)
+
+func TestCachedContextAssembler_PopulatesOnFirstCall(t *testing.T) {
+	reg := buildMinimalRegistry()
+	assembler := generator.NewCachedContextAssembler(reg, emptyFS(), time.Minute)
+
+	result, err := assembler.AssembleContext(generator.ContextAssemblerOptions{
+		Description:     "A carbon credit trading platform",
+		IncludePatterns: false,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.NotEmpty(t, result.Prompt)
+	assert.Contains(t, result.Prompt, "## Handler Reference Card")
+	assert.Contains(t, result.Prompt, "## Available Event Topics")
+	assert.Contains(t, result.Prompt, "## Manifest Schema Summary")
+}
+
+func TestCachedContextAssembler_ReturnsCachedValuesWithinInterval(t *testing.T) {
+	reg := buildMinimalRegistry()
+	// Use a long refresh interval so it won't expire during the test.
+	assembler := generator.NewCachedContextAssembler(reg, emptyFS(), time.Hour)
+
+	opts := generator.ContextAssemblerOptions{
+		Description:     "An energy trading platform",
+		IncludePatterns: false,
+	}
+
+	first, err := assembler.AssembleContext(opts)
+	require.NoError(t, err)
+
+	second, err := assembler.AssembleContext(opts)
+	require.NoError(t, err)
+
+	// Both calls should produce identical static content.
+	assert.Equal(t, first.Prompt, second.Prompt)
+}
+
+func TestCachedContextAssembler_RefreshesAfterIntervalExpires(t *testing.T) {
+	reg := buildMinimalRegistry()
+	// Use a very short interval, then invalidate to simulate expiry.
+	assembler := generator.NewCachedContextAssembler(reg, emptyFS(), time.Hour)
+
+	opts := generator.ContextAssemblerOptions{
+		Description:     "A payment processing platform",
+		IncludePatterns: false,
+	}
+
+	first, err := assembler.AssembleContext(opts)
+	require.NoError(t, err)
+
+	// Invalidate the cache to force a refresh on the next call.
+	assembler.Invalidate()
+
+	second, err := assembler.AssembleContext(opts)
+	require.NoError(t, err)
+
+	// After invalidation the static content is rebuilt — content should still match
+	// since the registry hasn't changed, confirming that the refresh path executes
+	// without error and produces a valid prompt.
+	assert.Equal(t, first.Prompt, second.Prompt)
+}
+
+func TestCachedContextAssembler_ConcurrentAccess(t *testing.T) {
+	reg := buildMinimalRegistry()
+	assembler := generator.NewCachedContextAssembler(reg, emptyFS(), time.Minute)
+
+	const goroutines = 20
+	results := make([]*generator.AssembledContext, goroutines)
+	errors := make([]error, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := range goroutines {
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], errors[idx] = assembler.AssembleContext(generator.ContextAssemblerOptions{
+				Description:     "A concurrent test platform",
+				IncludePatterns: false,
+			})
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, err := range errors {
+		require.NoError(t, err, "goroutine %d returned error", i)
+		require.NotNil(t, results[i])
+		assert.NotEmpty(t, results[i].Prompt)
+	}
+
+	// All goroutines should produce identical static content.
+	for i := 1; i < goroutines; i++ {
+		assert.Equal(t, results[0].Prompt, results[i].Prompt,
+			"goroutine %d produced different result", i)
+	}
+}
+
+func TestCachedContextAssembler_PatternMatchingRemainsUncached(t *testing.T) {
+	reg := buildMinimalRegistry()
+	assembler := generator.NewCachedContextAssembler(reg, realCookbookFS(), time.Hour)
+
+	// First call: energy description should match energy patterns.
+	energyResult, err := assembler.AssembleContext(generator.ContextAssemblerOptions{
+		Description:     "EV charging UK energy settlement",
+		Industry:        "energy",
+		IncludePatterns: true,
+		MaxPatterns:     3,
+	})
+	require.NoError(t, err)
+
+	// Second call: unrelated description should produce no/different patterns.
+	genericResult, err := assembler.AssembleContext(generator.ContextAssemblerOptions{
+		Description:     "Generic fintech platform with no patterns",
+		IncludePatterns: false,
+	})
+	require.NoError(t, err)
+
+	// Pattern-specific content should differ between calls.
+	assert.NotEqual(t, energyResult.Prompt, genericResult.Prompt,
+		"different descriptions should produce different prompts")
+}
+
+func TestCachedContextAssembler_DefaultRefreshInterval(t *testing.T) {
+	reg := buildMinimalRegistry()
+	// Zero interval should use the default (5 minutes), not panic or error.
+	assembler := generator.NewCachedContextAssembler(reg, emptyFS(), 0)
+
+	result, err := assembler.AssembleContext(generator.ContextAssemblerOptions{
+		Description:     "A platform with default interval",
+		IncludePatterns: false,
+	})
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, result.Prompt)
+}
+
+func TestCachedContextAssembler_ProducesEquivalentOutputToAssembleContext(t *testing.T) {
+	reg := buildMinimalRegistry()
+	assembler := generator.NewCachedContextAssembler(reg, emptyFS(), time.Hour)
+
+	opts := generator.ContextAssemblerOptions{
+		Description:     "A payment platform",
+		IncludePatterns: false,
+	}
+
+	cached, err := assembler.AssembleContext(opts)
+	require.NoError(t, err)
+
+	direct, err := generator.AssembleContext(opts, reg, emptyFS())
+	require.NoError(t, err)
+
+	// The cached assembler must produce the same output as the direct function.
+	assert.Equal(t, direct.Prompt, cached.Prompt)
+	assert.Equal(t, direct.TokenEstimate, cached.TokenEstimate)
+	assert.Equal(t, direct.MatchedPatterns, cached.MatchedPatterns)
+}

--- a/services/control-plane/internal/generator/cached_context_test.go
+++ b/services/control-plane/internal/generator/cached_context_test.go
@@ -2,6 +2,7 @@ package generator_test
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -9,107 +10,110 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/meridianhub/meridian/services/control-plane/internal/generator"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
 )
 
-func TestCachedContextAssembler_PopulatesOnFirstCall(t *testing.T) {
-	reg := buildMinimalRegistry()
-	assembler := generator.NewCachedContextAssembler(reg, emptyFS(), time.Minute)
+// countingBuildStatics returns a buildStatics function that increments a counter each
+// time it is called. The counter lets tests verify cache hit vs. cache miss behavior.
+func countingBuildStatics(counter *atomic.Int64) func(*schema.Registry) generator.StaticComponents {
+	return func(_ *schema.Registry) generator.StaticComponents {
+		counter.Add(1)
+		return generator.StaticComponents{} // content is irrelevant for cache behavior tests
+	}
+}
 
-	result, err := assembler.AssembleContext(generator.ContextAssemblerOptions{
+func newCountingAssembler(t *testing.T, interval time.Duration) (*generator.CachedContextAssembler, *atomic.Int64) {
+	t.Helper()
+	reg := buildMinimalRegistry()
+	assembler := generator.NewCachedContextAssembler(reg, emptyFS(), interval)
+	var counter atomic.Int64
+	assembler.SetBuildStatics(countingBuildStatics(&counter))
+	return assembler, &counter
+}
+
+func TestCachedContextAssembler_PopulatesOnFirstCall(t *testing.T) {
+	assembler, counter := newCountingAssembler(t, time.Hour)
+
+	_, err := assembler.AssembleContext(generator.ContextAssemblerOptions{
 		Description:     "A carbon credit trading platform",
 		IncludePatterns: false,
 	})
 
 	require.NoError(t, err)
-	require.NotNil(t, result)
-	assert.NotEmpty(t, result.Prompt)
-	assert.Contains(t, result.Prompt, "## Handler Reference Card")
-	assert.Contains(t, result.Prompt, "## Available Event Topics")
-	assert.Contains(t, result.Prompt, "## Manifest Schema Summary")
+	assert.Equal(t, int64(1), counter.Load(), "buildStatics should be called exactly once on first call")
 }
 
 func TestCachedContextAssembler_ReturnsCachedValuesWithinInterval(t *testing.T) {
-	reg := buildMinimalRegistry()
-	// Use a long refresh interval so it won't expire during the test.
-	assembler := generator.NewCachedContextAssembler(reg, emptyFS(), time.Hour)
+	assembler, counter := newCountingAssembler(t, time.Hour)
 
 	opts := generator.ContextAssemblerOptions{
 		Description:     "An energy trading platform",
 		IncludePatterns: false,
 	}
 
-	first, err := assembler.AssembleContext(opts)
+	_, err := assembler.AssembleContext(opts)
 	require.NoError(t, err)
 
-	second, err := assembler.AssembleContext(opts)
+	_, err = assembler.AssembleContext(opts)
 	require.NoError(t, err)
 
-	// Both calls should produce identical static content.
-	assert.Equal(t, first.Prompt, second.Prompt)
+	_, err = assembler.AssembleContext(opts)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), counter.Load(), "buildStatics should only be called once within the refresh interval")
 }
 
 func TestCachedContextAssembler_RefreshesAfterIntervalExpires(t *testing.T) {
-	reg := buildMinimalRegistry()
-	// Use a very short interval, then invalidate to simulate expiry.
-	assembler := generator.NewCachedContextAssembler(reg, emptyFS(), time.Hour)
+	assembler, counter := newCountingAssembler(t, time.Hour)
 
 	opts := generator.ContextAssemblerOptions{
 		Description:     "A payment processing platform",
 		IncludePatterns: false,
 	}
 
-	first, err := assembler.AssembleContext(opts)
+	_, err := assembler.AssembleContext(opts)
 	require.NoError(t, err)
+	assert.Equal(t, int64(1), counter.Load())
 
-	// Invalidate the cache to force a refresh on the next call.
+	// Force cache expiry.
 	assembler.Invalidate()
 
-	second, err := assembler.AssembleContext(opts)
+	_, err = assembler.AssembleContext(opts)
 	require.NoError(t, err)
 
-	// After invalidation the static content is rebuilt — content should still match
-	// since the registry hasn't changed, confirming that the refresh path executes
-	// without error and produces a valid prompt.
-	assert.Equal(t, first.Prompt, second.Prompt)
+	assert.Equal(t, int64(2), counter.Load(), "buildStatics should be called again after Invalidate")
 }
 
 func TestCachedContextAssembler_ConcurrentAccess(t *testing.T) {
-	reg := buildMinimalRegistry()
-	assembler := generator.NewCachedContextAssembler(reg, emptyFS(), time.Minute)
+	assembler, counter := newCountingAssembler(t, time.Hour)
 
-	const goroutines = 20
-	results := make([]*generator.AssembledContext, goroutines)
-	errors := make([]error, goroutines)
-
+	const goroutines = 50
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
 
-	for i := range goroutines {
-		go func(idx int) {
+	for range goroutines {
+		go func() {
 			defer wg.Done()
-			results[idx], errors[idx] = assembler.AssembleContext(generator.ContextAssemblerOptions{
+			_, _ = assembler.AssembleContext(generator.ContextAssemblerOptions{
 				Description:     "A concurrent test platform",
 				IncludePatterns: false,
 			})
-		}(i)
+		}()
 	}
 
 	wg.Wait()
 
-	for i, err := range errors {
-		require.NoError(t, err, "goroutine %d returned error", i)
-		require.NotNil(t, results[i])
-		assert.NotEmpty(t, results[i].Prompt)
-	}
-
-	// All goroutines should produce identical static content.
-	for i := 1; i < goroutines; i++ {
-		assert.Equal(t, results[0].Prompt, results[i].Prompt,
-			"goroutine %d produced different result", i)
-	}
+	// With double-checked locking, at most a small number of concurrent goroutines
+	// may race past the read lock before the write lock is taken. In practice with
+	// a 1-hour interval only one refresh should occur, but allow a small buffer for
+	// concurrent first-call races.
+	assert.LessOrEqual(t, counter.Load(), int64(5),
+		"buildStatics should be called very few times under concurrent access (expected ~1)")
+	assert.GreaterOrEqual(t, counter.Load(), int64(1), "buildStatics must be called at least once")
 }
 
 func TestCachedContextAssembler_PatternMatchingRemainsUncached(t *testing.T) {
+	// Use a real assembler with actual buildStatics so pattern matching runs.
 	reg := buildMinimalRegistry()
 	assembler := generator.NewCachedContextAssembler(reg, realCookbookFS(), time.Hour)
 
@@ -121,17 +125,20 @@ func TestCachedContextAssembler_PatternMatchingRemainsUncached(t *testing.T) {
 		MaxPatterns:     3,
 	})
 	require.NoError(t, err)
+	assert.NotEmpty(t, energyResult.MatchedPatterns, "energy description should match patterns")
 
-	// Second call: unrelated description should produce no/different patterns.
+	// Second call: same assembler (cache warm) but no patterns requested.
 	genericResult, err := assembler.AssembleContext(generator.ContextAssemblerOptions{
-		Description:     "Generic fintech platform with no patterns",
+		Description:     "EV charging UK energy settlement",
+		Industry:        "energy",
 		IncludePatterns: false,
 	})
 	require.NoError(t, err)
+	assert.Empty(t, genericResult.MatchedPatterns, "pattern matching should be skipped when IncludePatterns=false")
 
-	// Pattern-specific content should differ between calls.
+	// The prompts should differ only in pattern content, proving pattern matching is per-request.
 	assert.NotEqual(t, energyResult.Prompt, genericResult.Prompt,
-		"different descriptions should produce different prompts")
+		"with/without patterns should produce different prompts even when static cache is shared")
 }
 
 func TestCachedContextAssembler_DefaultRefreshInterval(t *testing.T) {
@@ -146,6 +153,18 @@ func TestCachedContextAssembler_DefaultRefreshInterval(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.Prompt)
+}
+
+func TestCachedContextAssembler_NilRegistry_ReturnsError(t *testing.T) {
+	assembler := generator.NewCachedContextAssembler(nil, emptyFS(), time.Hour)
+
+	_, err := assembler.AssembleContext(generator.ContextAssemblerOptions{
+		Description:     "A platform",
+		IncludePatterns: false,
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, generator.ErrMissingRegistry)
 }
 
 func TestCachedContextAssembler_ProducesEquivalentOutputToAssembleContext(t *testing.T) {

--- a/services/control-plane/internal/generator/cached_context_test.go
+++ b/services/control-plane/internal/generator/cached_context_test.go
@@ -117,7 +117,10 @@ func TestCachedContextAssembler_PatternMatchingRemainsUncached(t *testing.T) {
 	reg := buildMinimalRegistry()
 	assembler := generator.NewCachedContextAssembler(reg, realCookbookFS(), time.Hour)
 
-	// First call: energy description should match energy patterns.
+	// Both calls use IncludePatterns: true so pattern matching runs in each.
+	// The difference is the description/industry hint — energy vs. generic.
+	// If MatchedPatterns were being cached and reused, the second call would
+	// incorrectly return energy patterns for a generic description.
 	energyResult, err := assembler.AssembleContext(generator.ContextAssemblerOptions{
 		Description:     "EV charging UK energy settlement",
 		Industry:        "energy",
@@ -126,19 +129,18 @@ func TestCachedContextAssembler_PatternMatchingRemainsUncached(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.NotEmpty(t, energyResult.MatchedPatterns, "energy description should match patterns")
+	assert.Contains(t, energyResult.Prompt, "## Relevant Patterns")
 
-	// Second call: same assembler (cache warm) but no patterns requested.
 	genericResult, err := assembler.AssembleContext(generator.ContextAssemblerOptions{
-		Description:     "EV charging UK energy settlement",
-		Industry:        "energy",
-		IncludePatterns: false,
+		Description:     "A generic fintech platform with no industry patterns",
+		IncludePatterns: true,
+		MaxPatterns:     3,
 	})
 	require.NoError(t, err)
-	assert.Empty(t, genericResult.MatchedPatterns, "pattern matching should be skipped when IncludePatterns=false")
 
-	// The prompts should differ only in pattern content, proving pattern matching is per-request.
-	assert.NotEqual(t, energyResult.Prompt, genericResult.Prompt,
-		"with/without patterns should produce different prompts even when static cache is shared")
+	// Pattern sets must differ: energy patterns should not appear for a generic description.
+	assert.NotEqual(t, energyResult.MatchedPatterns, genericResult.MatchedPatterns,
+		"MatchedPatterns must be computed per-request, not reused from cache")
 }
 
 func TestCachedContextAssembler_DefaultRefreshInterval(t *testing.T) {

--- a/services/control-plane/internal/generator/context_assembler.go
+++ b/services/control-plane/internal/generator/context_assembler.go
@@ -57,6 +57,24 @@ type AssembledContext struct {
 // patterns into a complete LLM generation prompt. Pattern matching failures are non-fatal
 // and result in an empty pattern list rather than an error.
 func AssembleContext(opts ContextAssemblerOptions, registry *schema.Registry, cookbookFS fs.FS) (*AssembledContext, error) {
+	if registry == nil {
+		return nil, ErrMissingRegistry
+	}
+	handlerRef := BuildHandlerReferenceCard(registry)
+	topicList := BuildTopicList()
+	schemaSummary := BuildManifestSchemaSummary()
+	return assembleContextWithStatics(opts, handlerRef, topicList, schemaSummary, registry, cookbookFS)
+}
+
+// assembleContextWithStatics is the inner implementation of context assembly. It accepts
+// pre-computed static components so that callers (e.g. CachedContextAssembler) can supply
+// cached values instead of recomputing them on every call.
+func assembleContextWithStatics(
+	opts ContextAssemblerOptions,
+	handlerRef, topicList, schemaSummary string,
+	registry *schema.Registry,
+	cookbookFS fs.FS,
+) (*AssembledContext, error) {
 	// Validate required fields.
 	if strings.TrimSpace(opts.Description) == "" {
 		return nil, ErrBlankDescription
@@ -72,11 +90,6 @@ func AssembleContext(opts ContextAssemblerOptions, registry *schema.Registry, co
 	if opts.MaxPatterns <= 0 {
 		opts.MaxPatterns = 3
 	}
-
-	// Build static sections from registry and schema.
-	handlerRef := BuildHandlerReferenceCard(registry)
-	topicList := BuildTopicList()
-	schemaSummary := BuildManifestSchemaSummary()
 
 	// Match patterns. Failure is non-fatal — generation can proceed without patterns.
 	var matched []PatternMatch

--- a/services/control-plane/internal/generator/export_test.go
+++ b/services/control-plane/internal/generator/export_test.go
@@ -49,6 +49,15 @@ func NewEmptySchemaRegistry() *schema.Registry {
 	return schema.NewRegistry()
 }
 
+// SetBuildStatics replaces the buildStatics function on a CachedContextAssembler for testing.
+// This allows tests to count how many times static sections are actually recomputed.
+func (c *CachedContextAssembler) SetBuildStatics(fn func(registry *schema.Registry) staticComponents) {
+	c.buildStatics = fn
+}
+
+// StaticComponents is the exported type for staticComponents.
+type StaticComponents = staticComponents
+
 // Model returns the model name used by this client.
 func (c *ClaudeLLMClient) Model() string {
 	return c.model


### PR DESCRIPTION
## Summary

- Introduces `CachedContextAssembler` that caches the three static prompt components (handler reference card, topic list, schema summary) with a configurable TTL (default 5 minutes)
- Pattern matching remains uncached — it varies per request based on description and industry
- Uses `sync.RWMutex` with double-checked locking for safe concurrent access
- Extracts `assembleContextWithStatics` from `AssembleContext` to allow injecting pre-computed statics without duplicating logic

## Changes

- `cached_context.go` — `CachedContextAssembler` struct, `NewCachedContextAssembler`, `AssembleContext` method, `Invalidate` method
- `context_assembler.go` — extract `assembleContextWithStatics` inner function; `AssembleContext` delegates to it after building statics
- `cached_context_test.go` — 7 tests covering: first-call population, cache reuse within interval, refresh after invalidation, concurrent access safety, per-request pattern matching variation, zero interval default, output equivalence with direct `AssembleContext`

## Test plan

- [x] All 7 new `CachedContextAssembler` tests pass
- [x] Full existing generator test suite passes (no regressions)
- [x] `golangci-lint` and `gofumpt` pass (pre-commit hooks clean)