### PR TITLE
feat: Add GenerateManifest gRPC handler (create mode)

### DIFF
--- a/services/control-plane/internal/generator/export_test.go
+++ b/services/control-plane/internal/generator/export_test.go
@@ -53,3 +53,6 @@ func NewEmptySchemaRegistry() *schema.Registry {
 func (c *ClaudeLLMClient) Model() string {
 	return c.model
 }
+
+// YAMLToProtoManifest is the exported test hook for yamlToProtoManifest.
+var YAMLToProtoManifest = yamlToProtoManifest

--- a/services/control-plane/internal/generator/service.go
+++ b/services/control-plane/internal/generator/service.go
@@ -1,0 +1,317 @@
+package generator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"gopkg.in/yaml.v3"
+)
+
+// defaultMaxFixIterations is applied when the request leaves max_fix_iterations at 0.
+const defaultMaxFixIterations = 3
+
+// ManifestHistorian retrieves current manifest state for amend mode.
+// Implemented by an adapter wrapping the manifest history service.
+type ManifestHistorian interface {
+	// GetCurrentManifest retrieves the latest applied manifest for the given tenant.
+	// Returns the manifest proto and any error. Used in amend mode (task 12).
+	GetCurrentManifest(ctx context.Context, tenantID string) (*controlplanev1.Manifest, error)
+}
+
+// Sentinel errors for Service construction.
+var (
+	ErrSchemaRegistryRequired = errors.New("generator service: schema registry is required")
+	ErrCookbookFSRequired     = errors.New("generator service: cookbook FS is required")
+	ErrLLMClientRequired      = errors.New("generator service: LLM client is required")
+	ErrValidatorRequired      = errors.New("generator service: validator is required")
+)
+
+// Service implements the EconomyService gRPC interface.
+// It assembles a generation context, calls the LLM, and runs the validate-fix loop.
+type Service struct {
+	controlplanev1.UnimplementedEconomyGeneratorServiceServer
+
+	schemaRegistry *schema.Registry
+	manifestClient ManifestHistorian
+	cookbookFS     fs.FS
+	llmClient      LLMClient
+	validator      ManifestValidator
+	logger         *slog.Logger
+}
+
+// Config contains dependencies for creating a Service.
+type Config struct {
+	SchemaRegistry *schema.Registry
+	ManifestClient ManifestHistorian
+	CookbookFS     fs.FS
+	LLMClient      LLMClient
+	Validator      ManifestValidator
+	Logger         *slog.Logger
+}
+
+// NewService creates a new Service with the given dependencies.
+// ManifestClient is optional — it is only required for amend mode (task 12).
+func NewService(cfg Config) (*Service, error) {
+	if cfg.SchemaRegistry == nil {
+		return nil, ErrSchemaRegistryRequired
+	}
+	if cfg.CookbookFS == nil {
+		return nil, ErrCookbookFSRequired
+	}
+	if cfg.LLMClient == nil {
+		return nil, ErrLLMClientRequired
+	}
+	if cfg.Validator == nil {
+		return nil, ErrValidatorRequired
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	return &Service{
+		schemaRegistry: cfg.SchemaRegistry,
+		manifestClient: cfg.ManifestClient,
+		cookbookFS:     cfg.CookbookFS,
+		llmClient:      cfg.LLMClient,
+		validator:      cfg.Validator,
+		logger:         cfg.Logger,
+	}, nil
+}
+
+// GenerateManifest generates a new economy manifest from a natural language description.
+// Create mode only — amend mode returns Unimplemented.
+func (s *Service) GenerateManifest(
+	ctx context.Context,
+	req *controlplanev1.GenerateManifestRequest,
+) (*controlplanev1.GenerateManifestResponse, error) {
+	// Amend mode is not yet implemented (task 12).
+	if req.GetMode() == controlplanev1.GenerationMode_GENERATION_MODE_AMEND {
+		return nil, status.Error(codes.Unimplemented, "GENERATION_MODE_AMEND is not yet implemented")
+	}
+
+	// Validate request.
+	if req.GetDescription() == "" {
+		return nil, status.Error(codes.InvalidArgument, "description is required")
+	}
+
+	// Determine max fix iterations.
+	maxIter := int(req.GetMaxFixIterations())
+	if maxIter == 0 {
+		maxIter = defaultMaxFixIterations
+	}
+
+	// Assemble the generation context / prompt.
+	assembleOpts := ContextAssemblerOptions{
+		Description:     req.GetDescription(),
+		IncludePatterns: true,
+		MaxPatterns:     3,
+	}
+	if prefs := req.GetPreferences(); prefs != nil {
+		assembleOpts.Industry = prefs.GetIndustry()
+	}
+
+	assembled, err := AssembleContext(assembleOpts, s.schemaRegistry, s.cookbookFS)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "failed to assemble generation context", "error", err)
+		return nil, status.Errorf(codes.Internal, "assemble context: %v", err)
+	}
+
+	// Call the LLM to generate the initial manifest YAML.
+	generatedYAML, err := s.llmClient.Generate(ctx, assembled.Prompt)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "LLM generation failed", "error", err)
+		return nil, status.Errorf(codes.Internal, "generate manifest: %v", err)
+	}
+
+	// Run the validate-fix loop.
+	fixResult, err := ValidateAndFix(ctx, generatedYAML, ValidateFixOptions{
+		MaxIterations:  maxIter,
+		LLMClient:      s.llmClient,
+		Validator:      s.validator,
+		SchemaRegistry: s.schemaRegistry,
+	})
+	if err != nil {
+		s.logger.ErrorContext(ctx, "validate-fix loop failed", "error", err)
+		return nil, status.Errorf(codes.Internal, "validate and fix manifest: %v", err)
+	}
+
+	// Extract metadata from the final manifest YAML.
+	meta, extractErr := extractManifestMetadata(fixResult.FinalManifest)
+	if extractErr != nil {
+		// Non-fatal: metadata extraction failure doesn't block returning the manifest.
+		s.logger.WarnContext(ctx, "failed to extract manifest metadata", "error", extractErr)
+		meta = &controlplanev1.GenerationMetadata{}
+	}
+
+	// Populate metadata from generation process.
+	meta.FixIterations = int32(fixResult.IterationsUsed)
+	meta.PatternsUsed = patternNames(assembled.MatchedPatterns)
+
+	// Convert validation findings to proto.
+	protoErrors := toProtoValidationErrors(fixResult.Errors)
+	protoWarnings := toProtoValidationErrors(fixResult.Warnings)
+
+	return &controlplanev1.GenerateManifestResponse{
+		ManifestYaml:       fixResult.FinalManifest,
+		Valid:              fixResult.Valid,
+		ValidationErrors:   protoErrors,
+		ValidationWarnings: protoWarnings,
+		GenerationMetadata: meta,
+	}, nil
+}
+
+// patternNames extracts the name field from each PatternMatch.
+func patternNames(patterns []PatternMatch) []string {
+	if len(patterns) == 0 {
+		return nil
+	}
+	names := make([]string, len(patterns))
+	for i, p := range patterns {
+		names[i] = p.Name
+	}
+	return names
+}
+
+// toProtoValidationErrors converts generator.ValidationError slices to proto ValidationError slices.
+func toProtoValidationErrors(errs []ValidationError) []*controlplanev1.ValidationError {
+	if len(errs) == 0 {
+		return nil
+	}
+	out := make([]*controlplanev1.ValidationError, len(errs))
+	for i, e := range errs {
+		out[i] = &controlplanev1.ValidationError{
+			Code:       e.Code,
+			Path:       e.Path,
+			Message:    e.Message,
+			Suggestion: e.Suggestion,
+		}
+	}
+	return out
+}
+
+// manifestYAML is a minimal struct for extracting top-level manifest keys from YAML.
+// We use interface{} values to avoid having to mirror the full proto structure.
+type manifestYAML struct {
+	Instruments  []map[string]interface{} `yaml:"instruments"`
+	AccountTypes []map[string]interface{} `yaml:"account_types"`
+	Sagas        []map[string]interface{} `yaml:"sagas"`
+}
+
+// extractManifestMetadata parses the manifest YAML to extract created resource names.
+func extractManifestMetadata(manifestYAMLStr string) (*controlplanev1.GenerationMetadata, error) {
+	var doc manifestYAML
+	if err := yaml.Unmarshal([]byte(manifestYAMLStr), &doc); err != nil {
+		return nil, fmt.Errorf("parse manifest YAML: %w", err)
+	}
+
+	meta := &controlplanev1.GenerationMetadata{}
+
+	for _, inst := range doc.Instruments {
+		if code, ok := inst["code"].(string); ok && code != "" {
+			meta.InstrumentsCreated = append(meta.InstrumentsCreated, code)
+		}
+	}
+
+	for _, at := range doc.AccountTypes {
+		if code, ok := at["code"].(string); ok && code != "" {
+			meta.AccountTypesCreated = append(meta.AccountTypesCreated, code)
+		}
+	}
+
+	for _, saga := range doc.Sagas {
+		if name, ok := saga["name"].(string); ok && name != "" {
+			meta.SagasCreated = append(meta.SagasCreated, name)
+		}
+	}
+
+	return meta, nil
+}
+
+// manifestValidatorAdapter implements generator.ManifestValidator by wrapping
+// a function that validates manifest YAML. This allows the generator service to
+// inject any validation implementation without a circular dependency.
+type manifestValidatorAdapter struct {
+	validateFn func(ctx context.Context, manifestYAML string) (*ValidationResult, error)
+}
+
+// ValidateDryRun implements ManifestValidator.
+func (a *manifestValidatorAdapter) ValidateDryRun(ctx context.Context, manifestYAML string) (*ValidationResult, error) {
+	return a.validateFn(ctx, manifestYAML)
+}
+
+// NewManifestValidatorAdapter creates a ManifestValidator from a function that converts
+// YAML to a proto Manifest and validates it. The provided validateFn should parse the
+// YAML, call the real validator, and return structured results.
+//
+// Typical use: wrap a *validator.ManifestValidator by converting YAML → JSON → proto.
+func NewManifestValidatorAdapter(
+	validateFn func(ctx context.Context, manifestYAML string) (*ValidationResult, error),
+) ManifestValidator {
+	return &manifestValidatorAdapter{validateFn: validateFn}
+}
+
+// yamlToProtoManifest converts a YAML manifest string to a controlplanev1.Manifest proto.
+// It first marshals YAML to a generic Go map, then re-encodes to JSON, then uses
+// protojson to unmarshal into the proto type.
+func yamlToProtoManifest(manifestYAML string) (*controlplanev1.Manifest, error) {
+	// Parse YAML into a generic map.
+	var raw interface{}
+	if err := yaml.Unmarshal([]byte(manifestYAML), &raw); err != nil {
+		return nil, fmt.Errorf("parse manifest YAML: %w", err)
+	}
+
+	// Convert YAML-decoded value to JSON-compatible representation.
+	jsonCompatible := convertYAMLToJSONCompatible(raw)
+
+	// Marshal to JSON.
+	jsonBytes, err := json.Marshal(jsonCompatible)
+	if err != nil {
+		return nil, fmt.Errorf("re-encode manifest to JSON: %w", err)
+	}
+
+	// Unmarshal JSON into proto.
+	m := &controlplanev1.Manifest{}
+	opts := protojson.UnmarshalOptions{DiscardUnknown: true}
+	if err := opts.Unmarshal(jsonBytes, m); err != nil {
+		return nil, fmt.Errorf("unmarshal manifest proto: %w", err)
+	}
+	return m, nil
+}
+
+// convertYAMLToJSONCompatible recursively converts yaml.v3-decoded values to
+// JSON-compatible Go types. yaml.v3 uses map[string]interface{} for mappings and
+// []interface{} for sequences, which are already JSON-compatible. However, map keys
+// decoded from YAML may occasionally be non-string types (e.g., int) which JSON
+// cannot marshal. This function normalises those to strings.
+func convertYAMLToJSONCompatible(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(val))
+		for k, v2 := range val {
+			out[k] = convertYAMLToJSONCompatible(v2)
+		}
+		return out
+	case map[interface{}]interface{}:
+		out := make(map[string]interface{}, len(val))
+		for k, v2 := range val {
+			out[fmt.Sprintf("%v", k)] = convertYAMLToJSONCompatible(v2)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(val))
+		for i, item := range val {
+			out[i] = convertYAMLToJSONCompatible(item)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/services/control-plane/internal/generator/service_test.go
+++ b/services/control-plane/internal/generator/service_test.go
@@ -1,0 +1,456 @@
+package generator_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"testing/fstest"
+
+	"github.com/meridianhub/meridian/services/control-plane/internal/generator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// --- Mock implementations ---
+
+// mockGenerateLLMClient implements generator.LLMClient for service tests.
+type mockGenerateLLMClient struct {
+	generateResponse string
+	generateErr      error
+	fixResponse      string
+	fixErr           error
+	fixCallCount     int
+}
+
+func (m *mockGenerateLLMClient) Generate(_ context.Context, _ string) (string, error) {
+	return m.generateResponse, m.generateErr
+}
+
+func (m *mockGenerateLLMClient) Fix(_ context.Context, _ string, _ []generator.ValidationError) (string, error) {
+	m.fixCallCount++
+	return m.fixResponse, m.fixErr
+}
+
+// mockValidatorAlwaysValid implements generator.ManifestValidator and always returns valid.
+type mockValidatorAlwaysValid struct{}
+
+func (m *mockValidatorAlwaysValid) ValidateDryRun(_ context.Context, _ string) (*generator.ValidationResult, error) {
+	return &generator.ValidationResult{Valid: true}, nil
+}
+
+// mockValidatorSequence implements generator.ManifestValidator with a queue of responses.
+type mockValidatorSequence struct {
+	responses []*generator.ValidationResult
+	errs      []error
+}
+
+func (m *mockValidatorSequence) ValidateDryRun(_ context.Context, _ string) (*generator.ValidationResult, error) {
+	if len(m.errs) > 0 {
+		e := m.errs[0]
+		m.errs = m.errs[1:]
+		if e != nil {
+			return nil, e
+		}
+	}
+	if len(m.responses) == 0 {
+		return &generator.ValidationResult{Valid: true}, nil
+	}
+	r := m.responses[0]
+	m.responses = m.responses[1:]
+	return r, nil
+}
+
+// --- helpers ---
+
+// minimalValidYAML is a well-formed manifest YAML for testing.
+const minimalValidYAML = `
+instruments:
+  - code: GBP
+    name: British Pound
+    asset_class: CURRENCY
+account_types:
+  - code: CURRENT
+    name: Current Account
+    allowed_instruments:
+      - GBP
+sagas:
+  - name: simple_transfer
+    trigger:
+      topic: payment_order.created
+    script: |
+      result = {}
+`
+
+// buildServiceConfig returns a GeneratorServiceConfig wired with the provided mocks.
+func buildServiceConfig(llm generator.LLMClient, val generator.ManifestValidator) generator.Config {
+	return generator.Config{
+		SchemaRegistry: buildMinimalRegistry(),
+		CookbookFS:     emptyFS(),
+		LLMClient:      llm,
+		Validator:      val,
+	}
+}
+
+// --- Constructor tests ---
+
+func TestNewGeneratorService_RequiresSchemaRegistry(t *testing.T) {
+	cfg := buildServiceConfig(&mockGenerateLLMClient{}, &mockValidatorAlwaysValid{})
+	cfg.SchemaRegistry = nil
+	_, err := generator.NewService(cfg)
+	require.ErrorIs(t, err, generator.ErrSchemaRegistryRequired)
+}
+
+func TestNewGeneratorService_RequiresCookbookFS(t *testing.T) {
+	cfg := buildServiceConfig(&mockGenerateLLMClient{}, &mockValidatorAlwaysValid{})
+	cfg.CookbookFS = nil
+	_, err := generator.NewService(cfg)
+	require.ErrorIs(t, err, generator.ErrCookbookFSRequired)
+}
+
+func TestNewGeneratorService_RequiresLLMClient(t *testing.T) {
+	cfg := buildServiceConfig(nil, &mockValidatorAlwaysValid{})
+	_, err := generator.NewService(cfg)
+	require.ErrorIs(t, err, generator.ErrLLMClientRequired)
+}
+
+func TestNewGeneratorService_RequiresValidator(t *testing.T) {
+	cfg := buildServiceConfig(&mockGenerateLLMClient{}, nil)
+	_, err := generator.NewService(cfg)
+	require.ErrorIs(t, err, generator.ErrValidatorRequired)
+}
+
+func TestNewGeneratorService_AcceptsNilManifestClient(t *testing.T) {
+	cfg := buildServiceConfig(&mockGenerateLLMClient{generateResponse: minimalValidYAML}, &mockValidatorAlwaysValid{})
+	cfg.ManifestClient = nil
+	svc, err := generator.NewService(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+}
+
+// --- GenerateManifest tests ---
+
+func TestGenerateManifest_AmendModeReturnsUnimplemented(t *testing.T) {
+	cfg := buildServiceConfig(&mockGenerateLLMClient{}, &mockValidatorAlwaysValid{})
+	svc, err := generator.NewService(cfg)
+	require.NoError(t, err)
+
+	_, err = svc.GenerateManifest(context.Background(), &controlplanev1.GenerateManifestRequest{
+		Description: "a fintech",
+		Mode:        controlplanev1.GenerationMode_GENERATION_MODE_AMEND,
+		TenantId:    "tenant-1",
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unimplemented, st.Code())
+}
+
+func TestGenerateManifest_EmptyDescriptionReturnsInvalidArgument(t *testing.T) {
+	cfg := buildServiceConfig(&mockGenerateLLMClient{}, &mockValidatorAlwaysValid{})
+	svc, err := generator.NewService(cfg)
+	require.NoError(t, err)
+
+	_, err = svc.GenerateManifest(context.Background(), &controlplanev1.GenerateManifestRequest{
+		Description: "",
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestGenerateManifest_CreateMode_ValidOnFirstPass(t *testing.T) {
+	llm := &mockGenerateLLMClient{generateResponse: minimalValidYAML}
+	val := &mockValidatorAlwaysValid{}
+	cfg := buildServiceConfig(llm, val)
+	svc, err := generator.NewService(cfg)
+	require.NoError(t, err)
+
+	resp, err := svc.GenerateManifest(context.Background(), &controlplanev1.GenerateManifestRequest{
+		Description: "A simple bank account service",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.True(t, resp.Valid)
+	assert.Equal(t, minimalValidYAML, resp.ManifestYaml)
+	assert.Empty(t, resp.ValidationErrors)
+	assert.NotNil(t, resp.GenerationMetadata)
+	// fix_iterations == 0 because the manifest was valid on the first pass
+	assert.Equal(t, int32(0), resp.GenerationMetadata.FixIterations)
+}
+
+func TestGenerateManifest_CreateMode_MetadataExtracted(t *testing.T) {
+	llm := &mockGenerateLLMClient{generateResponse: minimalValidYAML}
+	val := &mockValidatorAlwaysValid{}
+	cfg := buildServiceConfig(llm, val)
+	svc, err := generator.NewService(cfg)
+	require.NoError(t, err)
+
+	resp, err := svc.GenerateManifest(context.Background(), &controlplanev1.GenerateManifestRequest{
+		Description: "A bank",
+	})
+	require.NoError(t, err)
+
+	meta := resp.GenerationMetadata
+	require.NotNil(t, meta)
+	assert.Contains(t, meta.InstrumentsCreated, "GBP")
+	assert.Contains(t, meta.AccountTypesCreated, "CURRENT")
+	assert.Contains(t, meta.SagasCreated, "simple_transfer")
+}
+
+func TestGenerateManifest_CreateMode_FixIterationsRespected(t *testing.T) {
+	// First validation fails, then succeeds.
+	val := &mockValidatorSequence{
+		responses: []*generator.ValidationResult{
+			{
+				Valid: false,
+				Errors: []generator.ValidationError{
+					{Code: "UNKNOWN_HANDLER", Path: "sagas[0]", Message: "unknown handler"},
+				},
+			},
+			{Valid: true},
+		},
+	}
+	llm := &mockGenerateLLMClient{
+		generateResponse: minimalValidYAML,
+		fixResponse:      minimalValidYAML,
+	}
+	cfg := buildServiceConfig(llm, val)
+	svc, err := generator.NewService(cfg)
+	require.NoError(t, err)
+
+	resp, err := svc.GenerateManifest(context.Background(), &controlplanev1.GenerateManifestRequest{
+		Description:      "A bank",
+		MaxFixIterations: 3,
+	})
+	require.NoError(t, err)
+
+	assert.True(t, resp.Valid)
+	assert.Equal(t, int32(1), resp.GenerationMetadata.FixIterations)
+	assert.Equal(t, 1, llm.fixCallCount)
+}
+
+func TestGenerateManifest_CreateMode_MaxFixIterationsExhausted(t *testing.T) {
+	// Validator always returns errors.
+	val := &mockValidatorSequence{
+		responses: []*generator.ValidationResult{
+			{Valid: false, Errors: []generator.ValidationError{{Code: "ERR", Path: "x", Message: "bad"}}},
+			{Valid: false, Errors: []generator.ValidationError{{Code: "ERR", Path: "x", Message: "bad"}}},
+			{Valid: false, Errors: []generator.ValidationError{{Code: "ERR", Path: "x", Message: "bad"}}},
+			{Valid: false, Errors: []generator.ValidationError{{Code: "ERR", Path: "x", Message: "bad"}}},
+		},
+	}
+	llm := &mockGenerateLLMClient{
+		generateResponse: minimalValidYAML,
+		fixResponse:      minimalValidYAML,
+	}
+	cfg := buildServiceConfig(llm, val)
+	svc, err := generator.NewService(cfg)
+	require.NoError(t, err)
+
+	resp, err := svc.GenerateManifest(context.Background(), &controlplanev1.GenerateManifestRequest{
+		Description:      "A bank",
+		MaxFixIterations: 2,
+	})
+	require.NoError(t, err)
+
+	// Response is returned even when invalid (caller sees the errors).
+	assert.False(t, resp.Valid)
+	assert.NotEmpty(t, resp.ValidationErrors)
+	assert.Equal(t, int32(2), resp.GenerationMetadata.FixIterations)
+}
+
+func TestGenerateManifest_CreateMode_DefaultMaxIterationsApplied(t *testing.T) {
+	// Validator always valid immediately — just checking no error on max_fix_iterations=0.
+	llm := &mockGenerateLLMClient{generateResponse: minimalValidYAML}
+	val := &mockValidatorAlwaysValid{}
+	cfg := buildServiceConfig(llm, val)
+	svc, err := generator.NewService(cfg)
+	require.NoError(t, err)
+
+	// max_fix_iterations is 0 → server applies default (3).
+	resp, err := svc.GenerateManifest(context.Background(), &controlplanev1.GenerateManifestRequest{
+		Description:      "A bank",
+		MaxFixIterations: 0,
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Valid)
+}
+
+func TestGenerateManifest_CreateMode_LLMGenerateError(t *testing.T) {
+	llm := &mockGenerateLLMClient{generateErr: errors.New("API unavailable")}
+	val := &mockValidatorAlwaysValid{}
+	cfg := buildServiceConfig(llm, val)
+	svc, err := generator.NewService(cfg)
+	require.NoError(t, err)
+
+	_, err = svc.GenerateManifest(context.Background(), &controlplanev1.GenerateManifestRequest{
+		Description: "A bank",
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+func TestGenerateManifest_CreateMode_ValidationWarningsIncluded(t *testing.T) {
+	val := &mockValidatorSequence{
+		responses: []*generator.ValidationResult{
+			{
+				Valid: true,
+				Warnings: []generator.ValidationError{
+					{Code: "WARN_001", Path: "instruments[0]", Message: "consider adding a description"},
+				},
+			},
+		},
+	}
+	llm := &mockGenerateLLMClient{generateResponse: minimalValidYAML}
+	cfg := buildServiceConfig(llm, val)
+	svc, err := generator.NewService(cfg)
+	require.NoError(t, err)
+
+	resp, err := svc.GenerateManifest(context.Background(), &controlplanev1.GenerateManifestRequest{
+		Description: "A bank",
+	})
+	require.NoError(t, err)
+
+	assert.True(t, resp.Valid)
+	require.Len(t, resp.ValidationWarnings, 1)
+	assert.Equal(t, "WARN_001", resp.ValidationWarnings[0].Code)
+}
+
+func TestGenerateManifest_CreateMode_UnspecifiedModeTreatedAsCreate(t *testing.T) {
+	llm := &mockGenerateLLMClient{generateResponse: minimalValidYAML}
+	val := &mockValidatorAlwaysValid{}
+	cfg := buildServiceConfig(llm, val)
+	svc, err := generator.NewService(cfg)
+	require.NoError(t, err)
+
+	// GENERATION_MODE_UNSPECIFIED should be treated as CREATE.
+	resp, err := svc.GenerateManifest(context.Background(), &controlplanev1.GenerateManifestRequest{
+		Description: "A bank",
+		Mode:        controlplanev1.GenerationMode_GENERATION_MODE_UNSPECIFIED,
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Valid)
+}
+
+// --- yamlToProtoManifest / metadata extraction tests ---
+
+func TestExtractManifestMetadata_InstrumentsAccountTypesSagas(t *testing.T) {
+	svc, err := generator.NewService(buildServiceConfig(
+		&mockGenerateLLMClient{generateResponse: minimalValidYAML},
+		&mockValidatorAlwaysValid{},
+	))
+	require.NoError(t, err)
+
+	resp, err := svc.GenerateManifest(context.Background(), &controlplanev1.GenerateManifestRequest{
+		Description: "Test economy",
+	})
+	require.NoError(t, err)
+
+	meta := resp.GenerationMetadata
+	require.NotNil(t, meta)
+	assert.Equal(t, []string{"GBP"}, meta.InstrumentsCreated)
+	assert.Equal(t, []string{"CURRENT"}, meta.AccountTypesCreated)
+	assert.Equal(t, []string{"simple_transfer"}, meta.SagasCreated)
+}
+
+func TestExtractManifestMetadata_EmptyManifest(t *testing.T) {
+	emptyYAML := `instruments: []
+account_types: []
+sagas: []
+`
+	llm := &mockGenerateLLMClient{generateResponse: emptyYAML}
+	val := &mockValidatorAlwaysValid{}
+	svc, err := generator.NewService(buildServiceConfig(llm, val))
+	require.NoError(t, err)
+
+	resp, err := svc.GenerateManifest(context.Background(), &controlplanev1.GenerateManifestRequest{
+		Description: "empty",
+	})
+	require.NoError(t, err)
+
+	meta := resp.GenerationMetadata
+	require.NotNil(t, meta)
+	assert.Empty(t, meta.InstrumentsCreated)
+	assert.Empty(t, meta.AccountTypesCreated)
+	assert.Empty(t, meta.SagasCreated)
+}
+
+// --- NewManifestValidatorAdapter tests ---
+
+func TestNewManifestValidatorAdapter_CallsDelegate(t *testing.T) {
+	called := false
+	adapter := generator.NewManifestValidatorAdapter(func(_ context.Context, yaml string) (*generator.ValidationResult, error) {
+		called = true
+		assert.Equal(t, "test: yaml", yaml)
+		return &generator.ValidationResult{Valid: true}, nil
+	})
+
+	result, err := adapter.ValidateDryRun(context.Background(), "test: yaml")
+	require.NoError(t, err)
+	assert.True(t, result.Valid)
+	assert.True(t, called)
+}
+
+func TestNewManifestValidatorAdapter_PropagatesError(t *testing.T) {
+	wantErr := errors.New("validation backend down")
+	adapter := generator.NewManifestValidatorAdapter(func(_ context.Context, _ string) (*generator.ValidationResult, error) {
+		return nil, wantErr
+	})
+
+	_, err := adapter.ValidateDryRun(context.Background(), "any: yaml")
+	require.ErrorIs(t, err, wantErr)
+}
+
+// --- cookbookFS with patterns tests ---
+
+func TestGenerateManifest_PatternNamesPopulated(t *testing.T) {
+	// Build a cookbook FS with one simple pattern.
+	cookFS := fstest.MapFS{
+		"registry.json": &fstest.MapFile{Data: []byte(`{
+			"items":[{"name":"energy-settlement","title":"Energy Settlement","tags":["energy","settlement"]}]
+		}`)},
+		"patterns/energy-settlement/pattern.json": &fstest.MapFile{Data: []byte(`{
+			"name":"energy-settlement",
+			"title":"Energy Settlement",
+			"description":"Handles energy asset settlement",
+			"tags":["energy","settlement"],
+			"provides":[],
+			"requires":[],
+			"composes_with":[],
+			"conflicts_with":[]
+		}`)},
+		"patterns/energy-settlement/manifest-fragment.yaml": &fstest.MapFile{Data: []byte(`instruments:
+  - code: KWH
+    name: Kilowatt Hour
+`)},
+	}
+
+	llm := &mockGenerateLLMClient{generateResponse: minimalValidYAML}
+	val := &mockValidatorAlwaysValid{}
+	cfg := generator.Config{
+		SchemaRegistry: buildMinimalRegistry(),
+		CookbookFS:     cookFS,
+		LLMClient:      llm,
+		Validator:      val,
+	}
+	svc, err := generator.NewService(cfg)
+	require.NoError(t, err)
+
+	resp, err := svc.GenerateManifest(context.Background(), &controlplanev1.GenerateManifestRequest{
+		Description: "Energy grid settlement system for kilowatt-hour tracking",
+	})
+	require.NoError(t, err)
+	// Generation metadata is always populated.
+	assert.NotNil(t, resp.GenerationMetadata)
+	// The patterns_used field is populated from matched patterns (may be empty if scorer
+	// does not find a match above threshold — that's acceptable).
+	assert.True(t, resp.Valid)
+}

--- a/services/control-plane/service/economy_generator.go
+++ b/services/control-plane/service/economy_generator.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -11,18 +10,6 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
 	"google.golang.org/grpc"
 )
-
-// ErrGeneratorSchemaRegistryRequired is returned when SchemaRegistry is nil.
-var ErrGeneratorSchemaRegistryRequired = errors.New("economy generator service: schema registry is required")
-
-// ErrGeneratorCookbookFSRequired is returned when CookbookFS is nil.
-var ErrGeneratorCookbookFSRequired = errors.New("economy generator service: cookbook FS is required")
-
-// ErrGeneratorLLMClientRequired is returned when LLMClient is nil.
-var ErrGeneratorLLMClientRequired = errors.New("economy generator service: LLM client is required")
-
-// ErrGeneratorValidatorRequired is returned when Validator is nil.
-var ErrGeneratorValidatorRequired = errors.New("economy generator service: validator is required")
 
 // EconomyGeneratorConfig holds configuration for the EconomyGeneratorService.
 type EconomyGeneratorConfig struct {
@@ -46,21 +33,8 @@ type EconomyGeneratorConfig struct {
 }
 
 // RegisterEconomyGeneratorService creates and registers the EconomyGeneratorService
-// on the given gRPC server.
+// on the given gRPC server. Validation of required fields is delegated to NewService.
 func RegisterEconomyGeneratorService(server *grpc.Server, cfg EconomyGeneratorConfig) error {
-	if cfg.SchemaRegistry == nil {
-		return ErrGeneratorSchemaRegistryRequired
-	}
-	if cfg.CookbookFS == nil {
-		return ErrGeneratorCookbookFSRequired
-	}
-	if cfg.LLMClient == nil {
-		return ErrGeneratorLLMClientRequired
-	}
-	if cfg.Validator == nil {
-		return ErrGeneratorValidatorRequired
-	}
-
 	svc, err := generator.NewService(generator.Config{
 		SchemaRegistry: cfg.SchemaRegistry,
 		CookbookFS:     cfg.CookbookFS,

--- a/services/control-plane/service/economy_generator.go
+++ b/services/control-plane/service/economy_generator.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/control-plane/internal/generator"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+	"google.golang.org/grpc"
+)
+
+// ErrGeneratorSchemaRegistryRequired is returned when SchemaRegistry is nil.
+var ErrGeneratorSchemaRegistryRequired = errors.New("economy generator service: schema registry is required")
+
+// ErrGeneratorCookbookFSRequired is returned when CookbookFS is nil.
+var ErrGeneratorCookbookFSRequired = errors.New("economy generator service: cookbook FS is required")
+
+// ErrGeneratorLLMClientRequired is returned when LLMClient is nil.
+var ErrGeneratorLLMClientRequired = errors.New("economy generator service: LLM client is required")
+
+// ErrGeneratorValidatorRequired is returned when Validator is nil.
+var ErrGeneratorValidatorRequired = errors.New("economy generator service: validator is required")
+
+// EconomyGeneratorConfig holds configuration for the EconomyGeneratorService.
+type EconomyGeneratorConfig struct {
+	// SchemaRegistry provides handler metadata for prompt assembly and error enrichment (required).
+	SchemaRegistry *schema.Registry
+
+	// CookbookFS is the filesystem containing cookbook patterns (required).
+	CookbookFS fs.FS
+
+	// LLMClient is used to generate and fix manifests (required).
+	LLMClient generator.LLMClient
+
+	// Validator validates manifest YAML in the validate-fix loop (required).
+	Validator generator.ManifestValidator
+
+	// ManifestClient retrieves current tenant manifests for amend mode (optional).
+	ManifestClient generator.ManifestHistorian
+
+	// Logger is the structured logger. Defaults to slog.Default() if nil.
+	Logger *slog.Logger
+}
+
+// RegisterEconomyGeneratorService creates and registers the EconomyGeneratorService
+// on the given gRPC server.
+func RegisterEconomyGeneratorService(server *grpc.Server, cfg EconomyGeneratorConfig) error {
+	if cfg.SchemaRegistry == nil {
+		return ErrGeneratorSchemaRegistryRequired
+	}
+	if cfg.CookbookFS == nil {
+		return ErrGeneratorCookbookFSRequired
+	}
+	if cfg.LLMClient == nil {
+		return ErrGeneratorLLMClientRequired
+	}
+	if cfg.Validator == nil {
+		return ErrGeneratorValidatorRequired
+	}
+
+	svc, err := generator.NewService(generator.Config{
+		SchemaRegistry: cfg.SchemaRegistry,
+		CookbookFS:     cfg.CookbookFS,
+		LLMClient:      cfg.LLMClient,
+		Validator:      cfg.Validator,
+		ManifestClient: cfg.ManifestClient,
+		Logger:         cfg.Logger,
+	})
+	if err != nil {
+		return fmt.Errorf("create generator service: %w", err)
+	}
+
+	controlplanev1.RegisterEconomyGeneratorServiceServer(server, svc)
+	return nil
+}


### PR DESCRIPTION
## Summary

- Implements `EconomyGeneratorService.GenerateManifest` RPC for create mode
- Assembles generation context from schema registry and cookbook patterns, generates manifest YAML via LLM, and runs the validate-fix loop (up to `max_fix_iterations`, default 3)
- Extracts metadata (instruments, account types, sagas, matched patterns) from the final YAML and returns structured `GenerateManifestResponse`
- Amend mode (`GENERATION_MODE_AMEND`) returns `codes.Unimplemented` — deferred to task 12

## Changes Made

- `services/control-plane/internal/generator/service.go`: `generator.Service` struct implementing `EconomyGeneratorServiceServer`, `generator.Config`, `ManifestHistorian` interface, `ManifestValidator` adapter factory (`NewManifestValidatorAdapter`), `yamlToProtoManifest` helper
- `services/control-plane/internal/generator/service_test.go`: Unit tests covering create mode end-to-end, amend mode rejection, max iterations, metadata extraction, error paths, and adapter behavior
- `services/control-plane/internal/generator/export_test.go`: Added `YAMLToProtoManifest` export hook
- `services/control-plane/service/economy_generator.go`: `RegisterEconomyGeneratorService` for wiring into the gRPC server

## Test Plan

- [x] `go test ./services/control-plane/internal/generator/...` — all tests pass
- [x] `go test ./services/control-plane/service/...` — all tests pass
- [x] `go build ./services/control-plane/...` — clean build
- [x] golangci-lint — no issues
- [x] Create mode valid on first pass
- [x] Create mode with fix iterations (validator fails then passes)
- [x] Max iterations exhausted returns invalid response with errors
- [x] Amend mode returns `codes.Unimplemented`
- [x] Empty description returns `codes.InvalidArgument`
- [x] Metadata correctly extracted (instruments, account types, sagas)
- [x] Validation warnings propagated to response

## Technical Details

The `ManifestHistorian` and `ManifestValidator` interfaces enable clean dependency injection without circular imports. `yamlToProtoManifest` converts LLM-generated YAML → generic Go map → JSON → proto using `protojson.UnmarshalOptions{DiscardUnknown: true}`, matching the pattern used in the MCP server tools.

Builds on: validate_fix.go (task 9), context_assembler.go (task 6), llm_client.go (task 13)