### PR TITLE
feat: Add economy generator MCP tools (tasks 8+11)

### DIFF
--- a/services/mcp-server/cmd/wire.go
+++ b/services/mcp-server/cmd/wire.go
@@ -129,6 +129,9 @@ func wireServer(srv *server.MCPServer, logger *slog.Logger, cookbookFS fs.FS) (f
 		Historian: mhAdapter,
 	})
 
+	// -- Economy generator tools (generate context + generate manifest) --
+	tools.RegisterEconomyGeneratorTools(toolReg, economyGeneratorAdapter{c: mc.EconomyGenerator})
+
 	// -- Simulation tools --
 	// CELEvaluator, ManifestDiffer, ValuationSimulator, and SagaSimulator
 	// require dedicated implementations that don't exist yet. Tools with
@@ -368,4 +371,17 @@ func (a gatewayConnectionAdapter) ListConnections(ctx context.Context, req *opga
 
 func (a gatewayConnectionAdapter) GetConnection(ctx context.Context, req *opgatewayv1.GetConnectionRequest) (*opgatewayv1.GetConnectionResponse, error) {
 	return a.c.GetConnection(ctx, req)
+}
+
+// economyGeneratorAdapter satisfies tools.EconomyGeneratorClient.
+type economyGeneratorAdapter struct {
+	c controlplanev1.EconomyGeneratorServiceClient
+}
+
+func (a economyGeneratorAdapter) GenerateManifest(ctx context.Context, req *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error) {
+	return a.c.GenerateManifest(ctx, req)
+}
+
+func (a economyGeneratorAdapter) GetGenerationContext(ctx context.Context, req *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error) {
+	return a.c.GetGenerationContext(ctx, req)
 }

--- a/services/mcp-server/internal/clients/clients.go
+++ b/services/mcp-server/internal/clients/clients.go
@@ -50,6 +50,8 @@ type MeridianClients struct {
 	ProviderConnection opgatewayv1.ProviderConnectionServiceClient
 	// Health allows the MCP server to check gateway liveness.
 	Health grpc_health_v1.HealthClient
+	// EconomyGenerator generates tenant manifests from natural language descriptions.
+	EconomyGenerator controlplanev1.EconomyGeneratorServiceClient
 
 	// conn is the underlying connection; callers must call Close when done.
 	conn *grpc.ClientConn
@@ -95,6 +97,7 @@ func New(cfg *auth.Config) (*MeridianClients, error) {
 		OperationalGateway: opgatewayv1.NewOperationalGatewayServiceClient(conn),
 		ProviderConnection: opgatewayv1.NewProviderConnectionServiceClient(conn),
 		Health:             grpc_health_v1.NewHealthClient(conn),
+		EconomyGenerator:   controlplanev1.NewEconomyGeneratorServiceClient(conn),
 		conn:               conn,
 	}, nil
 }

--- a/services/mcp-server/internal/tools/economy_generator.go
+++ b/services/mcp-server/internal/tools/economy_generator.go
@@ -1,0 +1,277 @@
+// Package tools provides the tool registry for the MCP server.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	mcperrors "github.com/meridianhub/meridian/services/mcp-server/internal/errors"
+)
+
+// EconomyGeneratorClient is the minimal interface for the EconomyGeneratorService RPCs.
+type EconomyGeneratorClient interface {
+	GenerateManifest(ctx context.Context, req *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error)
+	GetGenerationContext(ctx context.Context, req *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error)
+}
+
+// RegisterEconomyGeneratorTools registers the economy generator MCP tools into the registry.
+// Tools are silently skipped if the client is nil.
+func RegisterEconomyGeneratorTools(registry *Registry, client EconomyGeneratorClient) {
+	if client == nil {
+		return
+	}
+	candidates := []Tool{
+		buildEconomyGenerateContextTool(client),
+		buildEconomyGenerateTool(client),
+	}
+	for _, t := range candidates {
+		if err := registry.Register(t); err != nil {
+			panic("failed to register economy generator tool " + t.Name + ": " + err.Error())
+		}
+	}
+}
+
+// buildEconomyGenerateContextTool returns the meridian_economy_generate_context tool.
+func buildEconomyGenerateContextTool(client EconomyGeneratorClient) Tool {
+	return Tool{
+		Name:     "meridian_economy_generate_context",
+		Category: CategoryRead,
+		Description: "Retrieve the context that would be used to generate a manifest from a natural language description, " +
+			"without performing the actual generation. " +
+			"Returns the handler reference card, available topics, manifest schema summary, and matched cookbook patterns. " +
+			"Use this to understand which handlers and patterns are relevant before calling meridian_economy_generate.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"description": map[string]interface{}{
+					"type":        "string",
+					"description": "Natural language description of the economy to inspect context for.",
+				},
+				"include_patterns": map[string]interface{}{
+					"type":        "boolean",
+					"description": "When false, excludes matched pattern fragments from the response. Defaults to true.",
+				},
+				"include_current_economy": map[string]interface{}{
+					"type":        "boolean",
+					"description": "When true, includes the tenant's current manifest YAML in the response. Requires tenant_id.",
+				},
+				"tenant_id": map[string]interface{}{
+					"type":        "string",
+					"description": "Tenant identifier. Required when include_current_economy is true.",
+				},
+			},
+			"required": []interface{}{"description"},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			return handleEconomyGenerateContext(ctx, client, params)
+		},
+	}
+}
+
+// economyGenerateContextParams holds parsed parameters for meridian_economy_generate_context.
+type economyGenerateContextParams struct {
+	Description           string `json:"description"`
+	IncludePatterns       *bool  `json:"include_patterns"`
+	IncludeCurrentEconomy bool   `json:"include_current_economy"`
+	TenantID              string `json:"tenant_id"`
+}
+
+// handleEconomyGenerateContext implements the meridian_economy_generate_context handler.
+func handleEconomyGenerateContext(ctx context.Context, client EconomyGeneratorClient, params json.RawMessage) (interface{}, error) {
+	var p economyGenerateContextParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	// include_patterns defaults to true; exclude_patterns is the inverse field in the proto.
+	excludePatterns := p.IncludePatterns != nil && !*p.IncludePatterns
+
+	req := &controlplanev1.GetGenerationContextRequest{
+		Description:           p.Description,
+		ExcludePatterns:       excludePatterns,
+		IncludeCurrentEconomy: p.IncludeCurrentEconomy,
+		TenantId:              p.TenantID,
+	}
+
+	resp, err := client.GetGenerationContext(ctx, req)
+	if err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	result := map[string]interface{}{
+		"handler_reference_card":  resp.HandlerReferenceCard,
+		"topic_list":              resp.TopicList,
+		"manifest_schema_summary": resp.ManifestSchemaSummary,
+	}
+
+	if len(resp.MatchedPatterns) > 0 {
+		patterns := make([]map[string]interface{}, 0, len(resp.MatchedPatterns))
+		for _, pc := range resp.MatchedPatterns {
+			entry := map[string]interface{}{
+				"name":  pc.Name,
+				"title": pc.Title,
+				"score": pc.Score,
+			}
+			if pc.ManifestFragment != "" {
+				entry["manifest_fragment"] = pc.ManifestFragment
+			}
+			if pc.SagaScript != "" {
+				entry["saga_script"] = pc.SagaScript
+			}
+			patterns = append(patterns, entry)
+		}
+		result["matched_patterns"] = patterns
+	}
+
+	if resp.CurrentEconomyYaml != "" {
+		result["current_economy_yaml"] = resp.CurrentEconomyYaml
+	}
+
+	return result, nil
+}
+
+// buildEconomyGenerateTool returns the meridian_economy_generate tool.
+func buildEconomyGenerateTool(client EconomyGeneratorClient) Tool {
+	return Tool{
+		Name:     "meridian_economy_generate",
+		Category: CategorySimulate,
+		Description: "Generate a tenant manifest from a natural language description using AI assistance. " +
+			"Produces a manifest YAML, validates it, and iterates to fix any validation errors. " +
+			"Does not apply the manifest — use meridian_manifest_plan and meridian_manifest_apply to deploy it. " +
+			"Use mode=amend with a tenant_id to incorporate changes into an existing economy.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"description": map[string]interface{}{
+					"type":        "string",
+					"description": "Natural language description of the economy to generate.",
+				},
+				"mode": map[string]interface{}{
+					"type":        "string",
+					"description": "Generation mode: 'create' (default) generates a fresh manifest; 'amend' incorporates changes into the existing manifest (requires tenant_id).",
+					"enum":        []interface{}{"create", "amend"},
+				},
+				"tenant_id": map[string]interface{}{
+					"type":        "string",
+					"description": "Tenant identifier. Required when mode is 'amend'.",
+				},
+				"preferences": map[string]interface{}{
+					"type":        "object",
+					"description": "Optional hints to guide generation.",
+					"properties": map[string]interface{}{
+						"industry": map[string]interface{}{
+							"type":        "string",
+							"description": "The tenant's industry (e.g., 'energy', 'fintech', 'healthcare').",
+						},
+						"instruments": map[string]interface{}{
+							"type":        "array",
+							"description": "Asset types the tenant works with (e.g., 'GBP', 'kWh', 'TONNE_CO2E').",
+							"items":       map[string]interface{}{"type": "string"},
+						},
+						"patterns": map[string]interface{}{
+							"type":        "array",
+							"description": "Saga or workflow patterns to include (e.g., 'payment', 'settlement').",
+							"items":       map[string]interface{}{"type": "string"},
+						},
+					},
+				},
+				"max_fix_iterations": map[string]interface{}{
+					"type":        "integer",
+					"description": "Maximum validation-fix cycles (0–5). Defaults to 3 when unset.",
+					"minimum":     0,
+					"maximum":     5,
+				},
+			},
+			"required": []interface{}{"description"},
+		},
+		Handler: func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+			return handleEconomyGenerate(ctx, client, params)
+		},
+	}
+}
+
+// economyGeneratePreferences holds nested preferences for meridian_economy_generate.
+type economyGeneratePreferences struct {
+	Industry    string   `json:"industry"`
+	Instruments []string `json:"instruments"`
+	Patterns    []string `json:"patterns"`
+}
+
+// economyGenerateParams holds parsed parameters for meridian_economy_generate.
+type economyGenerateParams struct {
+	Description      string                      `json:"description"`
+	Mode             string                      `json:"mode"`
+	TenantID         string                      `json:"tenant_id"`
+	Preferences      *economyGeneratePreferences `json:"preferences"`
+	MaxFixIterations int32                       `json:"max_fix_iterations"`
+}
+
+// handleEconomyGenerate implements the meridian_economy_generate handler.
+func handleEconomyGenerate(ctx context.Context, client EconomyGeneratorClient, params json.RawMessage) (interface{}, error) {
+	var p economyGenerateParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	mode := controlplanev1.GenerationMode_GENERATION_MODE_CREATE
+	if p.Mode == "amend" {
+		mode = controlplanev1.GenerationMode_GENERATION_MODE_AMEND
+	}
+
+	req := &controlplanev1.GenerateManifestRequest{
+		Description:      p.Description,
+		Mode:             mode,
+		TenantId:         p.TenantID,
+		MaxFixIterations: p.MaxFixIterations,
+	}
+
+	if p.Preferences != nil {
+		req.Preferences = &controlplanev1.GenerationPreferences{
+			Industry:    p.Preferences.Industry,
+			Instruments: p.Preferences.Instruments,
+			Patterns:    p.Preferences.Patterns,
+		}
+	}
+
+	resp, err := client.GenerateManifest(ctx, req)
+	if err != nil {
+		return mcperrors.FormatGRPCError(err), nil
+	}
+
+	result := map[string]interface{}{
+		"manifest_yaml": resp.ManifestYaml,
+		"valid":         resp.Valid,
+	}
+
+	if len(resp.ValidationErrors) > 0 {
+		result["validation_errors"] = formatProtoValidationErrors(resp.ValidationErrors)
+	}
+	if len(resp.ValidationWarnings) > 0 {
+		result["validation_warnings"] = formatProtoValidationErrors(resp.ValidationWarnings)
+	}
+
+	if m := resp.GenerationMetadata; m != nil {
+		meta := map[string]interface{}{
+			"fix_iterations": m.FixIterations,
+		}
+		if len(m.PatternsUsed) > 0 {
+			meta["patterns_used"] = m.PatternsUsed
+		}
+		if len(m.InstrumentsCreated) > 0 {
+			meta["instruments_created"] = m.InstrumentsCreated
+		}
+		if len(m.AccountTypesCreated) > 0 {
+			meta["account_types_created"] = m.AccountTypesCreated
+		}
+		if len(m.SagasCreated) > 0 {
+			meta["sagas_created"] = m.SagasCreated
+		}
+		if len(m.Decisions) > 0 {
+			meta["decisions"] = m.Decisions
+		}
+		result["generation_metadata"] = meta
+	}
+
+	return result, nil
+}

--- a/services/mcp-server/internal/tools/economy_generator.go
+++ b/services/mcp-server/internal/tools/economy_generator.go
@@ -81,7 +81,14 @@ type economyGenerateContextParams struct {
 func handleEconomyGenerateContext(ctx context.Context, client EconomyGeneratorClient, params json.RawMessage) (interface{}, error) {
 	var p economyGenerateContextParams
 	if err := json.Unmarshal(params, &p); err != nil {
-		return mcperrors.FormatGRPCError(err), nil
+		return mcperrors.FormatGRPCError(err), nil //nolint:nilerr // err is surfaced in the tool response
+	}
+
+	if p.IncludeCurrentEconomy && p.TenantID == "" {
+		return map[string]interface{}{
+			"error":   "tenant_id is required when include_current_economy is true",
+			"message": "Provide a tenant_id to include the current economy in the context.",
+		}, nil
 	}
 
 	// include_patterns defaults to true; exclude_patterns is the inverse field in the proto.
@@ -96,7 +103,7 @@ func handleEconomyGenerateContext(ctx context.Context, client EconomyGeneratorCl
 
 	resp, err := client.GetGenerationContext(ctx, req)
 	if err != nil {
-		return mcperrors.FormatGRPCError(err), nil
+		return mcperrors.FormatGRPCError(err), nil //nolint:nilerr // err is surfaced in the tool response
 	}
 
 	result := map[string]interface{}{
@@ -211,12 +218,26 @@ type economyGenerateParams struct {
 func handleEconomyGenerate(ctx context.Context, client EconomyGeneratorClient, params json.RawMessage) (interface{}, error) {
 	var p economyGenerateParams
 	if err := json.Unmarshal(params, &p); err != nil {
-		return mcperrors.FormatGRPCError(err), nil
+		return mcperrors.FormatGRPCError(err), nil //nolint:nilerr // err is surfaced in the tool response
 	}
 
-	mode := controlplanev1.GenerationMode_GENERATION_MODE_CREATE
-	if p.Mode == "amend" {
+	var mode controlplanev1.GenerationMode
+	switch p.Mode {
+	case "", "create":
+		mode = controlplanev1.GenerationMode_GENERATION_MODE_CREATE
+	case "amend":
 		mode = controlplanev1.GenerationMode_GENERATION_MODE_AMEND
+		if p.TenantID == "" {
+			return map[string]interface{}{
+				"error":   "tenant_id is required when mode is 'amend'",
+				"message": "Provide a tenant_id to amend the tenant's existing manifest.",
+			}, nil
+		}
+	default:
+		return map[string]interface{}{
+			"error":   "invalid mode: " + p.Mode,
+			"message": "mode must be 'create' or 'amend'",
+		}, nil
 	}
 
 	req := &controlplanev1.GenerateManifestRequest{
@@ -236,7 +257,7 @@ func handleEconomyGenerate(ctx context.Context, client EconomyGeneratorClient, p
 
 	resp, err := client.GenerateManifest(ctx, req)
 	if err != nil {
-		return mcperrors.FormatGRPCError(err), nil
+		return mcperrors.FormatGRPCError(err), nil //nolint:nilerr // err is surfaced in the tool response
 	}
 
 	result := map[string]interface{}{

--- a/services/mcp-server/internal/tools/economy_generator_test.go
+++ b/services/mcp-server/internal/tools/economy_generator_test.go
@@ -1,0 +1,354 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+)
+
+// --- Mock ---
+
+type mockEconomyGeneratorClient struct {
+	generateFn func(ctx context.Context, req *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error)
+	contextFn  func(ctx context.Context, req *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error)
+}
+
+func (m *mockEconomyGeneratorClient) GenerateManifest(ctx context.Context, req *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error) {
+	return m.generateFn(ctx, req)
+}
+
+func (m *mockEconomyGeneratorClient) GetGenerationContext(ctx context.Context, req *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error) {
+	return m.contextFn(ctx, req)
+}
+
+// --- RegisterEconomyGeneratorTools ---
+
+func TestRegisterEconomyGeneratorTools_NilClient_NoRegistration(t *testing.T) {
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, nil)
+	assert.Empty(t, reg.List())
+}
+
+func TestRegisterEconomyGeneratorTools_RegistersBothTools(t *testing.T) {
+	reg := tools.NewRegistry()
+	mock := &mockEconomyGeneratorClient{}
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	names := make(map[string]bool)
+	for _, t := range reg.List() {
+		names[t.Name] = true
+	}
+	assert.True(t, names["meridian_economy_generate_context"])
+	assert.True(t, names["meridian_economy_generate"])
+}
+
+// --- meridian_economy_generate_context ---
+
+func TestEconomyGenerateContext_MapsParamsToRequest(t *testing.T) {
+	var capturedReq *controlplanev1.GetGenerationContextRequest
+	mock := &mockEconomyGeneratorClient{
+		contextFn: func(_ context.Context, req *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error) {
+			capturedReq = req
+			return &controlplanev1.GetGenerationContextResponse{
+				HandlerReferenceCard:  "handlers",
+				TopicList:             "topics",
+				ManifestSchemaSummary: "schema",
+			}, nil
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	params := json.RawMessage(`{
+		"description": "energy trading platform",
+		"include_patterns": false,
+		"include_current_economy": true,
+		"tenant_id": "tenant-abc"
+	}`)
+	result, err := reg.Call(context.Background(), "meridian_economy_generate_context", params)
+	require.NoError(t, err)
+
+	assert.Equal(t, "energy trading platform", capturedReq.Description)
+	assert.True(t, capturedReq.ExcludePatterns)
+	assert.True(t, capturedReq.IncludeCurrentEconomy)
+	assert.Equal(t, "tenant-abc", capturedReq.TenantId)
+
+	m := result.(map[string]interface{})
+	assert.Equal(t, "handlers", m["handler_reference_card"])
+	assert.Equal(t, "topics", m["topic_list"])
+	assert.Equal(t, "schema", m["manifest_schema_summary"])
+}
+
+func TestEconomyGenerateContext_IncludePatternsDefault_ExcludeFalse(t *testing.T) {
+	var capturedReq *controlplanev1.GetGenerationContextRequest
+	mock := &mockEconomyGeneratorClient{
+		contextFn: func(_ context.Context, req *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error) {
+			capturedReq = req
+			return &controlplanev1.GetGenerationContextResponse{}, nil
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	params := json.RawMessage(`{"description": "fintech ledger"}`)
+	_, err := reg.Call(context.Background(), "meridian_economy_generate_context", params)
+	require.NoError(t, err)
+
+	// When include_patterns is not specified, exclude_patterns should be false (default = include).
+	assert.False(t, capturedReq.ExcludePatterns)
+}
+
+func TestEconomyGenerateContext_MatchedPatterns_Included(t *testing.T) {
+	mock := &mockEconomyGeneratorClient{
+		contextFn: func(_ context.Context, _ *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error) {
+			return &controlplanev1.GetGenerationContextResponse{
+				MatchedPatterns: []*controlplanev1.PatternContext{
+					{
+						Name:             "energy_settlement",
+						Title:            "Energy Settlement",
+						Score:            0.92,
+						ManifestFragment: "instruments:\n  - code: kWh",
+						SagaScript:       "def run(): pass",
+					},
+				},
+			}, nil
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	result, err := reg.Call(context.Background(), "meridian_economy_generate_context", json.RawMessage(`{"description": "energy"}`))
+	require.NoError(t, err)
+
+	m := result.(map[string]interface{})
+	patterns, ok := m["matched_patterns"].([]map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, patterns, 1)
+	assert.Equal(t, "energy_settlement", patterns[0]["name"])
+	assert.Equal(t, "Energy Settlement", patterns[0]["title"])
+	assert.Equal(t, 0.92, patterns[0]["score"])
+	assert.Equal(t, "instruments:\n  - code: kWh", patterns[0]["manifest_fragment"])
+	assert.Equal(t, "def run(): pass", patterns[0]["saga_script"])
+}
+
+func TestEconomyGenerateContext_CurrentEconomyYaml_IncludedWhenPresent(t *testing.T) {
+	mock := &mockEconomyGeneratorClient{
+		contextFn: func(_ context.Context, _ *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error) {
+			return &controlplanev1.GetGenerationContextResponse{
+				CurrentEconomyYaml: "version: 1.0\n",
+			}, nil
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	result, err := reg.Call(context.Background(), "meridian_economy_generate_context", json.RawMessage(`{"description": "amend"}`))
+	require.NoError(t, err)
+
+	m := result.(map[string]interface{})
+	assert.Equal(t, "version: 1.0\n", m["current_economy_yaml"])
+}
+
+func TestEconomyGenerateContext_GRPCError_ReturnsFormattedError(t *testing.T) {
+	mock := &mockEconomyGeneratorClient{
+		contextFn: func(_ context.Context, _ *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error) {
+			return nil, status.Error(codes.InvalidArgument, "description too short")
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	result, err := reg.Call(context.Background(), "meridian_economy_generate_context", json.RawMessage(`{"description": "x"}`))
+	require.NoError(t, err)
+
+	// Result should be non-nil (a FormattedError from mcperrors).
+	assert.NotNil(t, result)
+}
+
+// --- meridian_economy_generate ---
+
+func TestEconomyGenerate_CreateMode_MapsParamsToRequest(t *testing.T) {
+	var capturedReq *controlplanev1.GenerateManifestRequest
+	mock := &mockEconomyGeneratorClient{
+		generateFn: func(_ context.Context, req *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error) {
+			capturedReq = req
+			return &controlplanev1.GenerateManifestResponse{
+				ManifestYaml: "version: 1.0\n",
+				Valid:        true,
+				GenerationMetadata: &controlplanev1.GenerationMetadata{
+					PatternsUsed:       []string{"payment"},
+					InstrumentsCreated: []string{"GBP"},
+					SagasCreated:       []string{"transfer"},
+					FixIterations:      1,
+					Decisions:          []string{"chose payment pattern"},
+				},
+			}, nil
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	params := json.RawMessage(`{
+		"description": "simple payment system",
+		"mode": "create",
+		"preferences": {
+			"industry": "fintech",
+			"instruments": ["GBP", "USD"],
+			"patterns": ["payment"]
+		},
+		"max_fix_iterations": 2
+	}`)
+
+	result, err := reg.Call(context.Background(), "meridian_economy_generate", params)
+	require.NoError(t, err)
+
+	assert.Equal(t, "simple payment system", capturedReq.Description)
+	assert.Equal(t, controlplanev1.GenerationMode_GENERATION_MODE_CREATE, capturedReq.Mode)
+	assert.Equal(t, int32(2), capturedReq.MaxFixIterations)
+	require.NotNil(t, capturedReq.Preferences)
+	assert.Equal(t, "fintech", capturedReq.Preferences.Industry)
+	assert.Equal(t, []string{"GBP", "USD"}, capturedReq.Preferences.Instruments)
+	assert.Equal(t, []string{"payment"}, capturedReq.Preferences.Patterns)
+
+	m := result.(map[string]interface{})
+	assert.Equal(t, "version: 1.0\n", m["manifest_yaml"])
+	assert.Equal(t, true, m["valid"])
+
+	meta, ok := m["generation_metadata"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, int32(1), meta["fix_iterations"])
+	assert.Equal(t, []string{"payment"}, meta["patterns_used"])
+	assert.Equal(t, []string{"GBP"}, meta["instruments_created"])
+	assert.Equal(t, []string{"transfer"}, meta["sagas_created"])
+	assert.Equal(t, []string{"chose payment pattern"}, meta["decisions"])
+}
+
+func TestEconomyGenerate_AmendMode_SetsCorrectProtoMode(t *testing.T) {
+	var capturedReq *controlplanev1.GenerateManifestRequest
+	mock := &mockEconomyGeneratorClient{
+		generateFn: func(_ context.Context, req *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error) {
+			capturedReq = req
+			return &controlplanev1.GenerateManifestResponse{Valid: true}, nil
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	params := json.RawMessage(`{
+		"description": "add carbon credits",
+		"mode": "amend",
+		"tenant_id": "tenant-xyz"
+	}`)
+
+	_, err := reg.Call(context.Background(), "meridian_economy_generate", params)
+	require.NoError(t, err)
+
+	assert.Equal(t, controlplanev1.GenerationMode_GENERATION_MODE_AMEND, capturedReq.Mode)
+	assert.Equal(t, "tenant-xyz", capturedReq.TenantId)
+}
+
+func TestEconomyGenerate_DefaultMode_IsCreate(t *testing.T) {
+	var capturedReq *controlplanev1.GenerateManifestRequest
+	mock := &mockEconomyGeneratorClient{
+		generateFn: func(_ context.Context, req *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error) {
+			capturedReq = req
+			return &controlplanev1.GenerateManifestResponse{Valid: true}, nil
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	_, err := reg.Call(context.Background(), "meridian_economy_generate", json.RawMessage(`{"description": "no mode specified"}`))
+	require.NoError(t, err)
+
+	assert.Equal(t, controlplanev1.GenerationMode_GENERATION_MODE_CREATE, capturedReq.Mode)
+}
+
+func TestEconomyGenerate_ValidationErrors_IncludedInResponse(t *testing.T) {
+	mock := &mockEconomyGeneratorClient{
+		generateFn: func(_ context.Context, _ *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error) {
+			return &controlplanev1.GenerateManifestResponse{
+				ManifestYaml: "",
+				Valid:        false,
+				ValidationErrors: []*controlplanev1.ValidationError{
+					{Message: "missing instruments section", Path: "instruments", Code: "REQUIRED"},
+				},
+				ValidationWarnings: []*controlplanev1.ValidationError{
+					{Message: "no sagas defined", Severity: "warning"},
+				},
+			}, nil
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	result, err := reg.Call(context.Background(), "meridian_economy_generate", json.RawMessage(`{"description": "incomplete"}`))
+	require.NoError(t, err)
+
+	m := result.(map[string]interface{})
+	assert.Equal(t, false, m["valid"])
+
+	errs, ok := m["validation_errors"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, errs, 1)
+	e := errs[0].(map[string]interface{})
+	assert.Equal(t, "missing instruments section", e["message"])
+	assert.Equal(t, "instruments", e["path"])
+	assert.Equal(t, "REQUIRED", e["code"])
+
+	warns, ok := m["validation_warnings"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, warns, 1)
+}
+
+func TestEconomyGenerate_NoPreferences_NilPreferencesInRequest(t *testing.T) {
+	var capturedReq *controlplanev1.GenerateManifestRequest
+	mock := &mockEconomyGeneratorClient{
+		generateFn: func(_ context.Context, req *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error) {
+			capturedReq = req
+			return &controlplanev1.GenerateManifestResponse{Valid: true}, nil
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	_, err := reg.Call(context.Background(), "meridian_economy_generate", json.RawMessage(`{"description": "minimal"}`))
+	require.NoError(t, err)
+
+	assert.Nil(t, capturedReq.Preferences)
+}
+
+func TestEconomyGenerate_GRPCError_ReturnsFormattedError(t *testing.T) {
+	mock := &mockEconomyGeneratorClient{
+		generateFn: func(_ context.Context, _ *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error) {
+			return nil, status.Error(codes.Internal, "LLM unavailable")
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	result, err := reg.Call(context.Background(), "meridian_economy_generate", json.RawMessage(`{"description": "error case"}`))
+	require.NoError(t, err)
+
+	// Result should be non-nil (a FormattedError from mcperrors).
+	assert.NotNil(t, result)
+}

--- a/services/mcp-server/internal/tools/economy_generator_test.go
+++ b/services/mcp-server/internal/tools/economy_generator_test.go
@@ -161,6 +161,28 @@ func TestEconomyGenerateContext_CurrentEconomyYaml_IncludedWhenPresent(t *testin
 	assert.Equal(t, "version: 1.0\n", m["current_economy_yaml"])
 }
 
+func TestEconomyGenerateContext_IncludeCurrentEconomy_WithoutTenantID_ReturnsError(t *testing.T) {
+	mock := &mockEconomyGeneratorClient{
+		contextFn: func(_ context.Context, _ *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error) {
+			t.Error("should not call RPC when tenant_id is missing")
+			return nil, nil
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	result, err := reg.Call(context.Background(), "meridian_economy_generate_context", json.RawMessage(`{
+		"description": "energy",
+		"include_current_economy": true
+	}`))
+	require.NoError(t, err)
+
+	m, ok := result.(map[string]interface{})
+	require.True(t, ok)
+	assert.Contains(t, m["error"], "tenant_id")
+}
+
 func TestEconomyGenerateContext_GRPCError_ReturnsFormattedError(t *testing.T) {
 	mock := &mockEconomyGeneratorClient{
 		contextFn: func(_ context.Context, _ *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error) {
@@ -260,6 +282,48 @@ func TestEconomyGenerate_AmendMode_SetsCorrectProtoMode(t *testing.T) {
 
 	assert.Equal(t, controlplanev1.GenerationMode_GENERATION_MODE_AMEND, capturedReq.Mode)
 	assert.Equal(t, "tenant-xyz", capturedReq.TenantId)
+}
+
+func TestEconomyGenerate_AmendMode_WithoutTenantID_ReturnsError(t *testing.T) {
+	mock := &mockEconomyGeneratorClient{
+		generateFn: func(_ context.Context, _ *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error) {
+			t.Error("should not call RPC when tenant_id is missing for amend")
+			return nil, nil
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	result, err := reg.Call(context.Background(), "meridian_economy_generate", json.RawMessage(`{
+		"description": "add carbon credits",
+		"mode": "amend"
+	}`))
+	require.NoError(t, err)
+
+	m, ok := result.(map[string]interface{})
+	require.True(t, ok)
+	assert.Contains(t, m["error"], "tenant_id")
+}
+
+func TestEconomyGenerate_UnknownMode_ReturnsError(t *testing.T) {
+	mock := &mockEconomyGeneratorClient{
+		generateFn: func(_ context.Context, _ *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error) {
+			t.Error("should not call RPC for unknown mode")
+			return nil, nil
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	// JSON schema enum validation rejects invalid mode values before the handler runs.
+	_, err := reg.Call(context.Background(), "meridian_economy_generate", json.RawMessage(`{
+		"description": "test",
+		"mode": "replace"
+	}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mode")
 }
 
 func TestEconomyGenerate_DefaultMode_IsCreate(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `meridian_economy_generate_context` MCP tool (CategoryRead) — thin wrapper around `EconomyGeneratorService.GetGenerationContext`. Returns the handler reference card, topic list, schema summary, and matched cookbook patterns for a given description.
- Adds `meridian_economy_generate` MCP tool (CategorySimulate) — thin wrapper around `EconomyGeneratorService.GenerateManifest`. Accepts description, mode (create/amend), tenant_id, preferences, and max_fix_iterations. Returns manifest_yaml, valid, validation_errors/warnings, and generation_metadata.
- Adds `EconomyGeneratorServiceClient` to `clients.MeridianClients` and wires it through `wire.go` via a new `economyGeneratorAdapter`.

## Test plan

- [ ] `go test ./services/mcp-server/...` — all packages pass
- [ ] Parameter mapping tests: JSON → proto request (mode enum, exclude_patterns inversion, preferences struct)
- [ ] Response formatting tests: matched patterns, current_economy_yaml, validation_errors/warnings, generation_metadata fields
- [ ] Nil-client skip test: `RegisterEconomyGeneratorTools(reg, nil)` registers no tools
- [ ] gRPC error tests: `FormatGRPCError` result returned without panic