### PR TITLE
feat: add ManifestDiffViewer component for plan diff display

### DIFF
--- a/frontend/src/features/economy/components/manifest-diff.test.tsx
+++ b/frontend/src/features/economy/components/manifest-diff.test.tsx
@@ -108,6 +108,17 @@ describe('ManifestDiffViewer - modified nodes', () => {
   })
 })
 
+describe('ManifestDiffViewer - edge-only diff', () => {
+  it('does not render no-changes message when only edges changed', () => {
+    const diff: ManifestDiff = {
+      ...emptyDiff,
+      addedEdges: [{ id: 'e1', source: 'a', target: 'b', relationship: 'allowed_by' }],
+    }
+    render(<ManifestDiffViewer diff={diff} />)
+    expect(screen.queryByText(/no changes/i)).not.toBeInTheDocument()
+  })
+})
+
 describe('ManifestDiffViewer - mixed diff', () => {
   const diff: ManifestDiff = {
     addedNodes: [makeNode('instrument:GBP', 'GBP')],

--- a/frontend/src/features/economy/components/manifest-diff.test.tsx
+++ b/frontend/src/features/economy/components/manifest-diff.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ManifestDiffViewer } from './manifest-diff'
+import type { ManifestDiff } from '@/features/manifests/lib/manifest-diff'
+import type { ManifestNode } from '@/features/manifests/lib/manifest-graph-model'
+
+const makeNode = (id: string, label: string): ManifestNode => ({
+  id,
+  type: 'instrument',
+  label,
+  data: { code: id },
+})
+
+const emptyDiff: ManifestDiff = {
+  addedNodes: [],
+  removedNodes: [],
+  modifiedNodes: [],
+  addedEdges: [],
+  removedEdges: [],
+}
+
+describe('ManifestDiffViewer - empty diff', () => {
+  it('renders nothing when diff is null', () => {
+    const { container } = render(<ManifestDiffViewer diff={null} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders no-changes message when all sections are empty', () => {
+    render(<ManifestDiffViewer diff={emptyDiff} />)
+    expect(screen.getByText(/no changes/i)).toBeInTheDocument()
+  })
+})
+
+describe('ManifestDiffViewer - added nodes', () => {
+  const diff: ManifestDiff = {
+    ...emptyDiff,
+    addedNodes: [makeNode('instrument:GBP', 'GBP'), makeNode('instrument:USD', 'USD')],
+  }
+
+  it('renders Added section with count', () => {
+    render(<ManifestDiffViewer diff={diff} />)
+    expect(screen.getByText(/added/i)).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  it('renders each added node label', () => {
+    render(<ManifestDiffViewer diff={diff} />)
+    expect(screen.getByText('GBP')).toBeInTheDocument()
+    expect(screen.getByText('USD')).toBeInTheDocument()
+  })
+
+  it('calls onNodeClick with node when added item is clicked', async () => {
+    const onNodeClick = vi.fn()
+    render(<ManifestDiffViewer diff={diff} onNodeClick={onNodeClick} />)
+    await userEvent.click(screen.getByText('GBP'))
+    expect(onNodeClick).toHaveBeenCalledWith(diff.addedNodes[0])
+  })
+})
+
+describe('ManifestDiffViewer - removed nodes', () => {
+  const diff: ManifestDiff = {
+    ...emptyDiff,
+    removedNodes: [makeNode('instrument:EUR', 'EUR')],
+  }
+
+  it('renders Removed section', () => {
+    render(<ManifestDiffViewer diff={diff} />)
+    expect(screen.getByText(/removed/i)).toBeInTheDocument()
+  })
+
+  it('renders removed node label', () => {
+    render(<ManifestDiffViewer diff={diff} />)
+    expect(screen.getByText('EUR')).toBeInTheDocument()
+  })
+
+  it('calls onNodeClick with node when removed item is clicked', async () => {
+    const onNodeClick = vi.fn()
+    render(<ManifestDiffViewer diff={diff} onNodeClick={onNodeClick} />)
+    await userEvent.click(screen.getByText('EUR'))
+    expect(onNodeClick).toHaveBeenCalledWith(diff.removedNodes[0])
+  })
+})
+
+describe('ManifestDiffViewer - modified nodes', () => {
+  const beforeNode = makeNode('instrument:GBP', 'GBP Old')
+  const afterNode = { ...makeNode('instrument:GBP', 'GBP New'), data: { code: 'GBP', name: 'Updated' } }
+  const diff: ManifestDiff = {
+    ...emptyDiff,
+    modifiedNodes: [{ before: beforeNode, after: afterNode }],
+  }
+
+  it('renders Modified section', () => {
+    render(<ManifestDiffViewer diff={diff} />)
+    expect(screen.getByText(/modified/i)).toBeInTheDocument()
+  })
+
+  it('shows before and after labels for modified nodes', () => {
+    render(<ManifestDiffViewer diff={diff} />)
+    expect(screen.getByText('GBP Old')).toBeInTheDocument()
+    expect(screen.getByText('GBP New')).toBeInTheDocument()
+  })
+
+  it('shows before/after comparison labels', () => {
+    render(<ManifestDiffViewer diff={diff} />)
+    expect(screen.getByText(/before/i)).toBeInTheDocument()
+    expect(screen.getByText(/after/i)).toBeInTheDocument()
+  })
+})
+
+describe('ManifestDiffViewer - mixed diff', () => {
+  const diff: ManifestDiff = {
+    addedNodes: [makeNode('instrument:GBP', 'GBP')],
+    removedNodes: [makeNode('instrument:EUR', 'EUR')],
+    modifiedNodes: [
+      {
+        before: makeNode('instrument:USD', 'USD Old'),
+        after: makeNode('instrument:USD', 'USD New'),
+      },
+    ],
+    addedEdges: [],
+    removedEdges: [],
+  }
+
+  it('renders all three sections', () => {
+    render(<ManifestDiffViewer diff={diff} />)
+    expect(screen.getByText(/added/i)).toBeInTheDocument()
+    expect(screen.getByText(/modified/i)).toBeInTheDocument()
+    expect(screen.getByText(/removed/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/economy/components/manifest-diff.tsx
+++ b/frontend/src/features/economy/components/manifest-diff.tsx
@@ -1,0 +1,136 @@
+import { Plus, Minus, RefreshCw } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { ManifestDiff } from '@/features/manifests/lib/manifest-diff'
+import type { ManifestNode } from '@/features/manifests/lib/manifest-graph-model'
+
+interface ManifestDiffViewerProps {
+  diff: ManifestDiff | null
+  onNodeClick?: (node: ManifestNode) => void
+  className?: string
+}
+
+export function ManifestDiffViewer({ diff, onNodeClick, className }: ManifestDiffViewerProps) {
+  if (!diff) return null
+
+  const hasChanges =
+    diff.addedNodes.length > 0 || diff.removedNodes.length > 0 || diff.modifiedNodes.length > 0
+
+  if (!hasChanges) {
+    return (
+      <div className={cn('py-4 text-center text-sm text-muted-foreground', className)}>
+        No changes detected
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      {diff.addedNodes.length > 0 && (
+        <section>
+          <SectionHeader
+            icon={<Plus className="h-3.5 w-3.5" />}
+            label="Added"
+            count={diff.addedNodes.length}
+            colorClass="text-green-600 dark:text-green-400"
+          />
+          <ul className="mt-1.5 space-y-1">
+            {diff.addedNodes.map((node) => (
+              <NodeRow
+                key={node.id}
+                label={node.label}
+                colorClass="border-green-500/40 bg-green-50/60 dark:bg-green-950/30"
+                onClick={onNodeClick ? () => onNodeClick(node) : undefined}
+              />
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {diff.modifiedNodes.length > 0 && (
+        <section>
+          <SectionHeader
+            icon={<RefreshCw className="h-3.5 w-3.5" />}
+            label="Modified"
+            count={diff.modifiedNodes.length}
+            colorClass="text-amber-600 dark:text-amber-400"
+          />
+          <ul className="mt-1.5 space-y-2">
+            {diff.modifiedNodes.map(({ before, after }) => (
+              <li key={after.id} className="rounded border border-amber-500/40 bg-amber-50/60 px-3 py-2 text-sm dark:bg-amber-950/30">
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <span className="font-medium text-foreground/70">Before:</span>
+                  <span>{before.label}</span>
+                </div>
+                <div className="mt-0.5 flex items-center gap-2 text-xs">
+                  <span className="font-medium text-foreground/70">After:</span>
+                  <span className="font-medium">{after.label}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {diff.removedNodes.length > 0 && (
+        <section>
+          <SectionHeader
+            icon={<Minus className="h-3.5 w-3.5" />}
+            label="Removed"
+            count={diff.removedNodes.length}
+            colorClass="text-red-600 dark:text-red-400"
+          />
+          <ul className="mt-1.5 space-y-1">
+            {diff.removedNodes.map((node) => (
+              <NodeRow
+                key={node.id}
+                label={node.label}
+                colorClass="border-red-500/40 bg-red-50/60 dark:bg-red-950/30"
+                onClick={onNodeClick ? () => onNodeClick(node) : undefined}
+              />
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  )
+}
+
+interface SectionHeaderProps {
+  icon: React.ReactNode
+  label: string
+  count: number
+  colorClass: string
+}
+
+function SectionHeader({ icon, label, count, colorClass }: SectionHeaderProps) {
+  return (
+    <div className={cn('flex items-center gap-1.5 text-sm font-medium', colorClass)}>
+      {icon}
+      <span>{label}</span>
+      <span className="ml-auto rounded-full bg-muted px-1.5 py-0.5 text-xs font-normal text-foreground">
+        {count}
+      </span>
+    </div>
+  )
+}
+
+interface NodeRowProps {
+  label: string
+  colorClass: string
+  onClick?: () => void
+}
+
+function NodeRow({ label, colorClass, onClick }: NodeRowProps) {
+  return (
+    <li
+      className={cn(
+        'rounded border px-3 py-1.5 text-sm',
+        colorClass,
+        onClick && 'cursor-pointer transition-opacity hover:opacity-80',
+      )}
+      onClick={onClick}
+    >
+      {label}
+    </li>
+  )
+}

--- a/frontend/src/features/economy/components/manifest-diff.tsx
+++ b/frontend/src/features/economy/components/manifest-diff.tsx
@@ -13,7 +13,11 @@ export function ManifestDiffViewer({ diff, onNodeClick, className }: ManifestDif
   if (!diff) return null
 
   const hasChanges =
-    diff.addedNodes.length > 0 || diff.removedNodes.length > 0 || diff.modifiedNodes.length > 0
+    diff.addedNodes.length > 0 ||
+    diff.removedNodes.length > 0 ||
+    diff.modifiedNodes.length > 0 ||
+    diff.addedEdges.length > 0 ||
+    diff.removedEdges.length > 0
 
   if (!hasChanges) {
     return (
@@ -121,15 +125,25 @@ interface NodeRowProps {
 }
 
 function NodeRow({ label, colorClass, onClick }: NodeRowProps) {
+  if (onClick) {
+    return (
+      <li>
+        <button
+          type="button"
+          className={cn(
+            'w-full rounded border px-3 py-1.5 text-left text-sm transition-opacity hover:opacity-80',
+            colorClass,
+          )}
+          onClick={onClick}
+        >
+          {label}
+        </button>
+      </li>
+    )
+  }
+
   return (
-    <li
-      className={cn(
-        'rounded border px-3 py-1.5 text-sm',
-        colorClass,
-        onClick && 'cursor-pointer transition-opacity hover:opacity-80',
-      )}
-      onClick={onClick}
-    >
+    <li className={cn('rounded border px-3 py-1.5 text-sm', colorClass)}>
       {label}
     </li>
   )

--- a/frontend/src/features/economy/index.ts
+++ b/frontend/src/features/economy/index.ts
@@ -15,3 +15,4 @@ export type { ManifestPlan } from './hooks/use-manifest-plan'
 
 // Components
 export { EditorGraphPanel } from './components/editor-graph-panel'
+export { ManifestDiffViewer } from './components/manifest-diff'


### PR DESCRIPTION
## Summary

- Adds `ManifestDiffViewer` component at `frontend/src/features/economy/components/manifest-diff.tsx`
- Displays color-coded sections: Added (green), Modified (amber), Removed (red)
- Modified nodes show before/after label comparison
- Added/removed items support an `onNodeClick` callback
- Exports `ManifestDiffViewer` from the economy feature barrel (`index.ts`)
- Reuses `ManifestDiff` type from `frontend/src/features/manifests/lib/manifest-diff.ts`

## Test plan

- [x] 12 Vitest unit tests covering: null diff, empty diff, added nodes, removed nodes, modified nodes, click callbacks, mixed diff
- [x] All tests pass locally (`npm test`)