### PR TITLE
feat: Economy Overview page with stats, graph, and version history

### DIFF
--- a/frontend/src/features/economy/pages/economy-overview-page.test.tsx
+++ b/frontend/src/features/economy/pages/economy-overview-page.test.tsx
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { EconomyOverviewPage } from './economy-overview-page'
+import { ApplyStatus } from '@/api/gen/meridian/control_plane/v1/manifest_history_service_pb'
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+  ApiClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+// ManifestGraph and ManifestHistoryTable are complex components — stub them for unit tests
+vi.mock('@/features/manifests/components/manifest-graph', () => ({
+  ManifestGraph: () => <div data-testid="manifest-graph" />,
+}))
+
+vi.mock('@/features/manifests/pages/manifest-history-table', () => ({
+  ManifestHistoryTable: () => <div data-testid="manifest-history-table" />,
+}))
+
+import { useApiClients } from '@/api/context'
+
+const mockManifestVersion = {
+  id: 'mv-1',
+  version: '2.0',
+  manifest: {
+    version: '2.0',
+    metadata: {
+      name: 'Acme Energy',
+      industry: 'energy',
+      description: 'An energy economy for testing',
+    },
+    instruments: [
+      { code: 'GBP', name: 'British Pound', type: 1, dimensions: { unit: 'GBP', precision: 2 } },
+      { code: 'KWH', name: 'Kilowatt Hour', type: 2, dimensions: { unit: 'kWh', precision: 4 } },
+    ],
+    accountTypes: [
+      { code: 'CURRENT', name: 'Current Account', normalBalance: 1, allowedInstruments: [] },
+    ],
+    valuationRules: [
+      { fromInstrument: 'KWH', toInstrument: 'GBP', cel: 'price * 0.1' },
+    ],
+    sagas: [
+      { name: 'process_payment', trigger: 'api:/v1/payments', script: 'def main(): pass' },
+      { name: 'settle_energy', trigger: 'scheduled:daily', script: 'def main(): pass' },
+    ],
+    seedData: undefined,
+    paymentRails: [],
+    partyTypes: [],
+    mappings: [],
+    handlers: [
+      { name: 'charge_customer', module: 'payments' },
+      { name: 'create_lien', module: 'payments' },
+      { name: 'settle_trade', module: 'trading' },
+    ],
+  },
+  appliedAt: { seconds: BigInt(1700000000), nanos: 0 },
+  appliedBy: 'admin@example.com',
+  applyStatus: ApplyStatus.APPLIED,
+  applyJobId: 'job-1',
+  diffSummary: 'Added energy instruments',
+}
+
+function mockApiClients(overrides: Record<string, unknown> = {}) {
+  vi.mocked(useApiClients).mockReturnValue({
+    manifestHistory: {
+      getCurrentManifest: vi.fn().mockResolvedValue({ version: mockManifestVersion }),
+      listManifestVersions: vi.fn().mockResolvedValue({ versions: [], totalCount: 0 }),
+      ...overrides,
+    },
+  } as unknown as ReturnType<typeof useApiClients>)
+}
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+function renderPage() {
+  return renderWithProviders(
+    <MemoryRouter>
+      <EconomyOverviewPage />
+    </MemoryRouter>,
+    { initialToken: createTenantUserToken() },
+  )
+}
+
+describe('EconomyOverviewPage', () => {
+  beforeEach(() => {
+    mockApiClients()
+    mockNavigate.mockClear()
+  })
+
+  it('renders loading skeleton while fetching manifest', () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: {
+        getCurrentManifest: vi.fn().mockReturnValue(new Promise(() => {})),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderPage()
+
+    expect(screen.getByTestId('overview-loading')).toBeInTheDocument()
+  })
+
+  it('renders economy name from manifest metadata', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('Acme Energy')).toBeInTheDocument()
+    })
+  })
+
+  it('renders economy description from manifest metadata', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('An energy economy for testing')).toBeInTheDocument()
+    })
+  })
+
+  it('renders industry tag from manifest metadata', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('energy')).toBeInTheDocument()
+    })
+  })
+
+  it('renders stats cards with correct counts', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('stat-instruments')).toHaveTextContent('2')
+    })
+    expect(screen.getByTestId('stat-account-types')).toHaveTextContent('1')
+    expect(screen.getByTestId('stat-sagas')).toHaveTextContent('2')
+  })
+
+  it('renders Explore button that navigates to /economy/explore', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /explore/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /explore/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/economy/explore')
+  })
+
+  it('renders Edit Economy button that navigates to /economy/edit', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /edit economy/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /edit economy/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/economy/edit')
+  })
+
+  it('renders ManifestGraph component', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('manifest-graph')).toBeInTheDocument()
+    })
+  })
+
+  it('renders ManifestHistoryTable component', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('manifest-history-table')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no manifest applied', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: {
+        getCurrentManifest: vi.fn().mockResolvedValue({ version: undefined }),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('overview-empty')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error state when API fails', async () => {
+    vi.mocked(useApiClients).mockReturnValue({
+      manifestHistory: {
+        getCurrentManifest: vi.fn().mockRejectedValue(new Error('Network error')),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('overview-error')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/features/economy/pages/economy-overview-page.test.tsx
+++ b/frontend/src/features/economy/pages/economy-overview-page.test.tsx
@@ -139,6 +139,7 @@ describe('EconomyOverviewPage', () => {
     })
     expect(screen.getByTestId('stat-account-types')).toHaveTextContent('1')
     expect(screen.getByTestId('stat-sagas')).toHaveTextContent('2')
+    expect(screen.getByTestId('stat-valuation-rules')).toHaveTextContent('1')
   })
 
   it('renders Explore button that navigates to /economy/explore', async () => {
@@ -179,7 +180,7 @@ describe('EconomyOverviewPage', () => {
     })
   })
 
-  it('shows empty state when no manifest applied', async () => {
+  it('shows empty state when no manifest version applied', async () => {
     vi.mocked(useApiClients).mockReturnValue({
       manifestHistory: {
         getCurrentManifest: vi.fn().mockResolvedValue({ version: undefined }),

--- a/frontend/src/features/economy/pages/economy-overview-page.test.tsx
+++ b/frontend/src/features/economy/pages/economy-overview-page.test.tsx
@@ -75,8 +75,8 @@ function mockApiClients(overrides: Record<string, unknown> = {}) {
 }
 
 const mockNavigate = vi.fn()
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   return { ...actual, useNavigate: () => mockNavigate }
 })
 

--- a/frontend/src/features/economy/pages/economy-overview-page.tsx
+++ b/frontend/src/features/economy/pages/economy-overview-page.tsx
@@ -93,14 +93,14 @@ export function EconomyOverviewPage() {
 
   if (isLoading) return <LoadingSkeleton />
   if (error) return <ErrorState onRetry={() => void refetch()} />
-  if (!data?.version) return <EmptyState />
+  if (!data?.version?.manifest) return <EmptyState />
 
   const { manifest } = data.version
-  const metadata = manifest?.metadata
-  const instruments = manifest?.instruments ?? []
-  const accountTypes = manifest?.accountTypes ?? []
-  const sagas = manifest?.sagas ?? []
-  const handlers = (manifest as Record<string, unknown> | undefined)?.handlers as unknown[] | undefined
+  const metadata = manifest.metadata
+  const instruments = manifest.instruments ?? []
+  const accountTypes = manifest.accountTypes ?? []
+  const sagas = manifest.sagas ?? []
+  const valuationRules = manifest.valuationRules ?? []
 
   return (
     <div className="p-6 space-y-8">
@@ -139,14 +139,14 @@ export function EconomyOverviewPage() {
         <StatCard label="Instruments" value={instruments.length} testId="stat-instruments" />
         <StatCard label="Account Types" value={accountTypes.length} testId="stat-account-types" />
         <StatCard label="Sagas" value={sagas.length} testId="stat-sagas" />
-        <StatCard label="Handlers" value={handlers?.length ?? 0} testId="stat-handlers" />
+        <StatCard label="Valuation Rules" value={valuationRules.length} testId="stat-valuation-rules" />
       </div>
 
       {/* Relationship graph */}
       <section className="space-y-3">
         <h2 className="text-base font-semibold">Relationship Graph</h2>
         <div className="h-[480px] rounded-lg border overflow-hidden">
-          <ManifestGraph manifest={manifest!} className="h-full w-full" />
+          <ManifestGraph manifest={manifest} className="h-full w-full" />
         </div>
       </section>
 

--- a/frontend/src/features/economy/pages/economy-overview-page.tsx
+++ b/frontend/src/features/economy/pages/economy-overview-page.tsx
@@ -1,8 +1,160 @@
-export function EconomyOverviewPage() {
+import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { useApiClients } from '@/api/context'
+import { manifestKeys } from '@/lib/query-keys'
+import { ManifestGraph } from '@/features/manifests/components/manifest-graph'
+import { ManifestHistoryTable } from '@/features/manifests/pages/manifest-history-table'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Badge } from '@/components/ui/badge'
+import { Edit, Compass } from 'lucide-react'
+
+function LoadingSkeleton() {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold">Economy</h1>
-      <p className="mt-2 text-muted-foreground">Manage your economy configuration.</p>
+    <div data-testid="overview-loading" className="p-6 space-y-6">
+      <div className="flex items-start justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-64" />
+          <Skeleton className="h-4 w-96" />
+          <Skeleton className="h-5 w-20" />
+        </div>
+        <div className="flex gap-2">
+          <Skeleton className="h-9 w-24" />
+          <Skeleton className="h-9 w-32" />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24" />
+        ))}
+      </div>
+      <Skeleton className="h-[480px] w-full" />
+      <Skeleton className="h-64 w-full" />
+    </div>
+  )
+}
+
+function EmptyState() {
+  const navigate = useNavigate()
+  return (
+    <div data-testid="overview-empty" className="p-6 flex flex-col items-center gap-4 py-16 text-muted-foreground">
+      <span className="text-lg font-medium">No economy configured</span>
+      <span className="text-sm text-center max-w-md">
+        Apply a manifest to configure instruments, account types, sagas, and more.
+      </span>
+      <Button onClick={() => navigate('/economy/edit')}>Configure Economy</Button>
+    </div>
+  )
+}
+
+function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div data-testid="overview-error" className="p-6 flex flex-col items-center gap-3 py-16 text-muted-foreground">
+      <span className="text-sm font-medium">Unable to load economy</span>
+      <Button variant="outline" size="sm" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  )
+}
+
+interface StatCardProps {
+  label: string
+  value: number
+  testId: string
+}
+
+function StatCard({ label, value, testId }: StatCardProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-1 pt-4 px-4">
+        <CardTitle className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          {label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="px-4 pb-4">
+        <span className="text-3xl font-bold" data-testid={testId}>
+          {value}
+        </span>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function EconomyOverviewPage() {
+  const { manifestHistory } = useApiClients()
+  const navigate = useNavigate()
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: manifestKeys.current(),
+    queryFn: () => manifestHistory.getCurrentManifest({}),
+  })
+
+  if (isLoading) return <LoadingSkeleton />
+  if (error) return <ErrorState onRetry={() => void refetch()} />
+  if (!data?.version) return <EmptyState />
+
+  const { manifest } = data.version
+  const metadata = manifest?.metadata
+  const instruments = manifest?.instruments ?? []
+  const accountTypes = manifest?.accountTypes ?? []
+  const sagas = manifest?.sagas ?? []
+  const handlers = (manifest as Record<string, unknown> | undefined)?.handlers as unknown[] | undefined
+
+  return (
+    <div className="p-6 space-y-8">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold">
+            {metadata?.name ?? 'Economy'}
+          </h1>
+          {metadata?.description && (
+            <p className="text-sm text-muted-foreground">{metadata.description}</p>
+          )}
+          {metadata?.industry && (
+            <Badge variant="secondary" className="mt-1">
+              {metadata.industry}
+            </Badge>
+          )}
+        </div>
+        <div className="flex gap-2 shrink-0">
+          <Button
+            variant="outline"
+            onClick={() => navigate('/economy/explore')}
+          >
+            <Compass className="mr-2 size-4" />
+            Explore
+          </Button>
+          <Button onClick={() => navigate('/economy/edit')}>
+            <Edit className="mr-2 size-4" />
+            Edit Economy
+          </Button>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <StatCard label="Instruments" value={instruments.length} testId="stat-instruments" />
+        <StatCard label="Account Types" value={accountTypes.length} testId="stat-account-types" />
+        <StatCard label="Sagas" value={sagas.length} testId="stat-sagas" />
+        <StatCard label="Handlers" value={handlers?.length ?? 0} testId="stat-handlers" />
+      </div>
+
+      {/* Relationship graph */}
+      <section className="space-y-3">
+        <h2 className="text-base font-semibold">Relationship Graph</h2>
+        <div className="h-[480px] rounded-lg border overflow-hidden">
+          <ManifestGraph manifest={manifest!} className="h-full w-full" />
+        </div>
+      </section>
+
+      {/* Version history */}
+      <section className="space-y-3">
+        <h2 className="text-base font-semibold">Version History</h2>
+        <ManifestHistoryTable />
+      </section>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Implements `EconomyOverviewPage` (`economy-ide.11`) with full loading, empty, and error states
- Displays economy metadata (name, description, industry tag) from the current manifest
- Stats cards showing counts of instruments, account types, sagas, and handlers
- Reuses `ManifestGraph` for the relationship graph visualisation
- Reuses `ManifestHistoryTable` for version history timeline
- Explore and Edit Economy action buttons with navigation

## Changes Made

- `frontend/src/features/economy/pages/economy-overview-page.tsx` — full implementation replacing the stub
- `frontend/src/features/economy/pages/economy-overview-page.test.tsx` — 11 Vitest unit tests covering all states and interactions

## Testing

- All 11 new unit tests pass
- No regressions introduced (pre-existing failures are unrelated baseline failures)

## Risk Assessment

Low. No new shared code introduced; only updates a stub page file and adds a colocated test.