### PR TITLE
feat: handler autocomplete extension for CodeMirror (economy-ide.10)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
+        "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/lang-python": "^6.2.1",
         "@codemirror/lang-yaml": "^6.1.2",
         "@codemirror/lint": "^6.9.4",
@@ -835,9 +836,9 @@
       }
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
-      "integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
+    "@codemirror/autocomplete": "^6.20.1",
     "@codemirror/lang-python": "^6.2.1",
     "@codemirror/lang-yaml": "^6.1.2",
     "@codemirror/lint": "^6.9.4",

--- a/frontend/src/features/economy/index.ts
+++ b/frontend/src/features/economy/index.ts
@@ -18,3 +18,6 @@ export { EditorGraphPanel } from './components/editor-graph-panel'
 export { ManifestEditor } from './components/manifest-editor'
 export { ValidationPanel } from './components/validation-panel'
 export { ManifestDiffViewer } from './components/manifest-diff'
+
+// Lib
+export { handlerAutocomplete, buildHandlerCompletionSource, generateParameterTemplate } from './lib/handler-autocomplete'

--- a/frontend/src/features/economy/index.ts
+++ b/frontend/src/features/economy/index.ts
@@ -20,4 +20,4 @@ export { ValidationPanel } from './components/validation-panel'
 export { ManifestDiffViewer } from './components/manifest-diff'
 
 // Lib
-export { handlerAutocomplete, buildHandlerCompletionSource, generateParameterTemplate } from './lib/handler-autocomplete'
+export { handlerAutocomplete, buildHandlerCompletionSource, generateParameterTemplate, generateHandlerCallTemplate } from './lib/handler-autocomplete'

--- a/frontend/src/features/economy/lib/handler-autocomplete.test.ts
+++ b/frontend/src/features/economy/lib/handler-autocomplete.test.ts
@@ -192,6 +192,16 @@ describe('buildHandlerCompletionSource', () => {
       const handler = result!.options.find((o) => o.label === 'no_params')
       expect(handler?.apply).toBe('position_keeping.no_params()')
     })
+
+    it('from starts at beginning of service name to avoid duplicate prefix on apply', async () => {
+      // "position_keeping." starts at position 0 in doc "position_keeping."
+      const ctx = makeContext('position_keeping.')
+      const result = await source(ctx)
+      expect(result).not.toBeNull()
+      // from must be 0 (start of "position_keeping.") so that apply replaces
+      // the whole "position_keeping." and not just the part after the dot
+      expect(result!.from).toBe(0)
+    })
   })
 
   describe('with null schema', () => {

--- a/frontend/src/features/economy/lib/handler-autocomplete.test.ts
+++ b/frontend/src/features/economy/lib/handler-autocomplete.test.ts
@@ -5,6 +5,7 @@ import type { HandlerSchemaResponse } from '@/shared/handler-reference'
 import {
   buildHandlerCompletionSource,
   generateParameterTemplate,
+  generateHandlerCallTemplate,
 } from './handler-autocomplete'
 
 const mockSchema: HandlerSchemaResponse = {
@@ -81,6 +82,18 @@ describe('generateParameterTemplate', () => {
     const handler = mockSchema.services[0].handlers[1] // finalize_log
     const result = generateParameterTemplate('position_keeping', handler)
     expect(result).toBe('position_keeping.finalize_log(log_id="")')
+  })
+})
+
+describe('generateHandlerCallTemplate', () => {
+  it('generates handler call without service name prefix', () => {
+    const handler = mockSchema.services[0].handlers[0] // initiate_log
+    expect(generateHandlerCallTemplate(handler)).toBe('initiate_log(amount="", direction="DEBIT")')
+  })
+
+  it('generates bare call for handler with no params', () => {
+    const handler = mockSchema.services[0].handlers[2] // no_params
+    expect(generateHandlerCallTemplate(handler)).toBe('no_params()')
   })
 })
 
@@ -177,32 +190,32 @@ describe('buildHandlerCompletionSource', () => {
       }
     })
 
-    it('apply inserts full parameter template', async () => {
+    it('apply inserts handler call without service name prefix', async () => {
+      // apply must NOT include the service name — it's already in the document
       const ctx = makeContext('position_keeping.')
       const result = await source(ctx)
       expect(result).not.toBeNull()
       const handler = result!.options.find((o) => o.label === 'initiate_log')
-      expect(handler?.apply).toContain('position_keeping.initiate_log(')
-      expect(handler?.apply).toContain('amount=')
-      expect(handler?.apply).toContain('direction=')
+      expect(handler?.apply).toBe('initiate_log(amount="", direction="DEBIT")')
+      expect(handler?.apply).not.toContain('position_keeping')
     })
 
-    it('apply for handler with no params inserts empty call', async () => {
+    it('apply for handler with no params inserts bare call', async () => {
       const ctx = makeContext('position_keeping.')
       const result = await source(ctx)
       expect(result).not.toBeNull()
       const handler = result!.options.find((o) => o.label === 'no_params')
-      expect(handler?.apply).toBe('position_keeping.no_params()')
+      expect(handler?.apply).toBe('no_params()')
     })
 
-    it('from starts at beginning of service name to avoid duplicate prefix on apply', async () => {
-      // "position_keeping." starts at position 0 in doc "position_keeping."
-      const ctx = makeContext('position_keeping.')
+    it('from is set after the dot so serviceName. in document is preserved', async () => {
+      // doc: "position_keeping." — dot is at index 16, so from should be 17
+      const doc = 'position_keeping.'
+      const ctx = makeContext(doc)
       const result = await source(ctx)
       expect(result).not.toBeNull()
-      // from must be 0 (start of "position_keeping.") so that apply replaces
-      // the whole "position_keeping." and not just the part after the dot
-      expect(result!.from).toBe(0)
+      // from must be right after the dot (dotIndex + 1 = 17)
+      expect(result!.from).toBe(doc.indexOf('.') + 1)
     })
   })
 

--- a/frontend/src/features/economy/lib/handler-autocomplete.test.ts
+++ b/frontend/src/features/economy/lib/handler-autocomplete.test.ts
@@ -96,12 +96,14 @@ describe('buildHandlerCompletionSource', () => {
       expect(labels).toContain('position_keeping')
     })
 
-    it('returns all services when at start of word with no prefix', async () => {
+    it('returns matching services when typing a single-character prefix', async () => {
       const ctx = makeContext('p')
       const result = await source(ctx)
       expect(result).not.toBeNull()
       const labels = result!.options.map((o) => o.label)
       expect(labels).toContain('position_keeping')
+      // 'current_account' does not start with 'p' so should not appear
+      expect(labels).not.toContain('current_account')
     })
 
     it('service completions have namespace type', async () => {

--- a/frontend/src/features/economy/lib/handler-autocomplete.test.ts
+++ b/frontend/src/features/economy/lib/handler-autocomplete.test.ts
@@ -7,6 +7,8 @@ import {
   generateParameterTemplate,
   generateHandlerCallTemplate,
 } from './handler-autocomplete'
+// generateParameterTemplate and generateHandlerCallTemplate are re-exported from
+// @/shared/handler-template via handler-autocomplete for backwards compatibility
 
 const mockSchema: HandlerSchemaResponse = {
   services: [

--- a/frontend/src/features/economy/lib/handler-autocomplete.test.ts
+++ b/frontend/src/features/economy/lib/handler-autocomplete.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest'
+import { EditorState } from '@codemirror/state'
+import { CompletionContext } from '@codemirror/autocomplete'
+import type { HandlerSchemaResponse } from '@/shared/handler-reference'
+import {
+  buildHandlerCompletionSource,
+  generateParameterTemplate,
+} from './handler-autocomplete'
+
+const mockSchema: HandlerSchemaResponse = {
+  services: [
+    {
+      serviceName: 'position_keeping',
+      handlers: [
+        {
+          name: 'initiate_log',
+          description: 'Initiates a position log entry',
+          params: [
+            { name: 'amount', type: 'Decimal', required: true, enumValues: [] },
+            { name: 'direction', type: 'enum', required: true, enumValues: ['DEBIT', 'CREDIT'] },
+          ],
+        },
+        {
+          name: 'finalize_log',
+          description: 'Finalizes a position log entry',
+          params: [
+            { name: 'log_id', type: 'string', required: true, enumValues: [] },
+          ],
+        },
+        {
+          name: 'no_params',
+          description: 'Handler with no params',
+          params: [],
+        },
+      ],
+    },
+    {
+      serviceName: 'current_account',
+      handlers: [
+        {
+          name: 'debit',
+          description: 'Debits an account',
+          params: [
+            { name: 'account_id', type: 'string', required: true, enumValues: [] },
+            { name: 'amount', type: 'Decimal', required: true, enumValues: [] },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+/** Helper to create a CompletionContext for the given document text at the end of text */
+function makeContext(doc: string, pos?: number): CompletionContext {
+  const state = EditorState.create({ doc })
+  const cursorPos = pos ?? doc.length
+  // explicit=true simulates manual Ctrl+Space trigger
+  return new CompletionContext(state, cursorPos, true)
+}
+
+describe('generateParameterTemplate', () => {
+  it('generates template with multiple params', () => {
+    const handler = mockSchema.services[0].handlers[0] // initiate_log
+    const result = generateParameterTemplate('position_keeping', handler)
+    expect(result).toBe('position_keeping.initiate_log(amount="", direction="DEBIT")')
+  })
+
+  it('generates template for enum param using first enum value', () => {
+    const handler = mockSchema.services[0].handlers[0] // initiate_log
+    const result = generateParameterTemplate('position_keeping', handler)
+    expect(result).toContain('direction="DEBIT"')
+  })
+
+  it('generates template for handler with no params', () => {
+    const handler = mockSchema.services[0].handlers[2] // no_params
+    const result = generateParameterTemplate('position_keeping', handler)
+    expect(result).toBe('position_keeping.no_params()')
+  })
+
+  it('generates template for handler with single param', () => {
+    const handler = mockSchema.services[0].handlers[1] // finalize_log
+    const result = generateParameterTemplate('position_keeping', handler)
+    expect(result).toBe('position_keeping.finalize_log(log_id="")')
+  })
+})
+
+describe('buildHandlerCompletionSource', () => {
+  const source = buildHandlerCompletionSource(mockSchema)
+
+  describe('service name completions', () => {
+    it('returns service name completions when typing a partial service name', async () => {
+      const ctx = makeContext('pos')
+      const result = await source(ctx)
+      expect(result).not.toBeNull()
+      const labels = result!.options.map((o) => o.label)
+      expect(labels).toContain('position_keeping')
+    })
+
+    it('returns all services when at start of word with no prefix', async () => {
+      const ctx = makeContext('p')
+      const result = await source(ctx)
+      expect(result).not.toBeNull()
+      const labels = result!.options.map((o) => o.label)
+      expect(labels).toContain('position_keeping')
+    })
+
+    it('service completions have namespace type', async () => {
+      const ctx = makeContext('pos')
+      const result = await source(ctx)
+      expect(result).not.toBeNull()
+      const pos = result!.options.find((o) => o.label === 'position_keeping')
+      expect(pos?.type).toBe('namespace')
+    })
+
+    it('returns null when no services match', async () => {
+      const ctx = makeContext('zzznomatch')
+      const result = await source(ctx)
+      // When no completions match the word, result is null or has empty options
+      if (result !== null) {
+        expect(result.options.length).toBe(0)
+      }
+    })
+  })
+
+  describe('handler completions after dot', () => {
+    it('returns handler completions after service name and dot', async () => {
+      const ctx = makeContext('position_keeping.')
+      const result = await source(ctx)
+      expect(result).not.toBeNull()
+      const labels = result!.options.map((o) => o.label)
+      expect(labels).toContain('initiate_log')
+      expect(labels).toContain('finalize_log')
+    })
+
+    it('handler completions have function type', async () => {
+      const ctx = makeContext('position_keeping.')
+      const result = await source(ctx)
+      expect(result).not.toBeNull()
+      const handler = result!.options.find((o) => o.label === 'initiate_log')
+      expect(handler?.type).toBe('function')
+    })
+
+    it('handler completions include detail with description', async () => {
+      const ctx = makeContext('position_keeping.')
+      const result = await source(ctx)
+      expect(result).not.toBeNull()
+      const handler = result!.options.find((o) => o.label === 'initiate_log')
+      expect(handler?.detail).toBe('Initiates a position log entry')
+    })
+
+    it('filters handlers by partial name after dot', async () => {
+      const ctx = makeContext('position_keeping.init')
+      const result = await source(ctx)
+      expect(result).not.toBeNull()
+      const labels = result!.options.map((o) => o.label)
+      expect(labels).toContain('initiate_log')
+      expect(labels).not.toContain('finalize_log')
+    })
+
+    it('returns handlers for different service', async () => {
+      const ctx = makeContext('current_account.')
+      const result = await source(ctx)
+      expect(result).not.toBeNull()
+      const labels = result!.options.map((o) => o.label)
+      expect(labels).toContain('debit')
+      expect(labels).not.toContain('initiate_log')
+    })
+
+    it('returns null for unknown service', async () => {
+      const ctx = makeContext('unknown_service.')
+      const result = await source(ctx)
+      // Either null or empty options
+      if (result !== null) {
+        expect(result.options.length).toBe(0)
+      }
+    })
+
+    it('apply inserts full parameter template', async () => {
+      const ctx = makeContext('position_keeping.')
+      const result = await source(ctx)
+      expect(result).not.toBeNull()
+      const handler = result!.options.find((o) => o.label === 'initiate_log')
+      expect(handler?.apply).toContain('position_keeping.initiate_log(')
+      expect(handler?.apply).toContain('amount=')
+      expect(handler?.apply).toContain('direction=')
+    })
+
+    it('apply for handler with no params inserts empty call', async () => {
+      const ctx = makeContext('position_keeping.')
+      const result = await source(ctx)
+      expect(result).not.toBeNull()
+      const handler = result!.options.find((o) => o.label === 'no_params')
+      expect(handler?.apply).toBe('position_keeping.no_params()')
+    })
+  })
+
+  describe('with null schema', () => {
+    it('returns null when schema is null', async () => {
+      const nullSource = buildHandlerCompletionSource(null)
+      const ctx = makeContext('position_keeping.')
+      const result = await nullSource(ctx)
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/frontend/src/features/economy/lib/handler-autocomplete.ts
+++ b/frontend/src/features/economy/lib/handler-autocomplete.ts
@@ -1,34 +1,9 @@
 import { autocompletion, type CompletionSource, type Completion } from '@codemirror/autocomplete'
 import type { Extension } from '@codemirror/state'
-import type { Handler, HandlerSchemaResponse } from '@/shared/handler-reference'
+import type { HandlerSchemaResponse } from '@/shared/handler-reference'
+import { generateHandlerCallTemplate } from '@/shared/handler-template'
 
-/**
- * Generates a Starlark call template for a handler including the service name.
- * Example: position_keeping.initiate_log(amount="", direction="DEBIT")
- */
-export function generateParameterTemplate(serviceName: string, handler: Handler): string {
-  const params = buildParamString(handler)
-  return `${serviceName}.${handler.name}(${params})`
-}
-
-/**
- * Generates only the handler call portion (no service name prefix).
- * Used as the `apply` value in handler completions where the service name
- * and dot are already present in the document.
- * Example: initiate_log(amount="", direction="DEBIT")
- */
-export function generateHandlerCallTemplate(handler: Handler): string {
-  return `${handler.name}(${buildParamString(handler)})`
-}
-
-function buildParamString(handler: Handler): string {
-  return handler.params
-    .map((p) => {
-      const value = p.type === 'enum' ? `"${p.enumValues[0] ?? ''}"` : '""'
-      return `${p.name}=${value}`
-    })
-    .join(', ')
-}
+export { generateParameterTemplate, generateHandlerCallTemplate } from '@/shared/handler-template'
 
 /**
  * Builds a CodeMirror CompletionSource from a HandlerSchemaResponse.

--- a/frontend/src/features/economy/lib/handler-autocomplete.ts
+++ b/frontend/src/features/economy/lib/handler-autocomplete.ts
@@ -1,0 +1,83 @@
+import { autocompletion, type CompletionSource, type Completion } from '@codemirror/autocomplete'
+import type { Extension } from '@codemirror/state'
+import type { Handler, HandlerSchemaResponse } from '@/shared/handler-reference'
+
+/**
+ * Generates a Starlark call template for a handler.
+ * Example: position_keeping.initiate_log(amount="", direction="DEBIT")
+ */
+export function generateParameterTemplate(serviceName: string, handler: Handler): string {
+  const params = handler.params
+    .map((p) => {
+      const value = p.type === 'enum' ? `"${p.enumValues[0] ?? ''}"` : '""'
+      return `${p.name}=${value}`
+    })
+    .join(', ')
+  return `${serviceName}.${handler.name}(${params})`
+}
+
+/**
+ * Builds a CodeMirror CompletionSource from a HandlerSchemaResponse.
+ *
+ * Provides two levels of completion:
+ * 1. Service name completions (type: 'namespace') — triggered when typing a word
+ * 2. Handler completions (type: 'function') — triggered after "serviceName."
+ *
+ * @param schema The handler schema, or null if not yet loaded
+ * @returns A CompletionSource for use with autocompletion()
+ */
+export function buildHandlerCompletionSource(schema: HandlerSchemaResponse | null): CompletionSource {
+  return (context) => {
+    if (!schema) return null
+
+    // Check for "serviceName." pattern — handler completion
+    const dotMatch = context.matchBefore(/[\w_]+\.[\w_]*/)
+    if (dotMatch) {
+      const text = dotMatch.text
+      const dotIndex = text.indexOf('.')
+      const serviceName = text.slice(0, dotIndex)
+      const handlerPrefix = text.slice(dotIndex + 1)
+
+      const service = schema.services.find((s) => s.serviceName === serviceName)
+      if (!service) return { from: dotMatch.from + dotIndex + 1, options: [] }
+
+      const options: Completion[] = service.handlers
+        .filter((h) => h.name.startsWith(handlerPrefix))
+        .map((h) => ({
+          label: h.name,
+          type: 'function',
+          detail: h.description || undefined,
+          apply: generateParameterTemplate(serviceName, h),
+        }))
+
+      return { from: dotMatch.from + dotIndex + 1, options }
+    }
+
+    // Service name completion — triggered when typing a word (no dot yet)
+    const wordMatch = context.matchBefore(/[\w_]+/)
+    if (!wordMatch) return null
+
+    const prefix = wordMatch.text
+    const options: Completion[] = schema.services
+      .filter((s) => s.serviceName.startsWith(prefix))
+      .map((s) => ({
+        label: s.serviceName,
+        type: 'namespace',
+      }))
+
+    if (options.length === 0) return null
+    return { from: wordMatch.from, options }
+  }
+}
+
+/**
+ * Creates a CodeMirror extension that provides handler autocomplete.
+ *
+ * @param schema The handler schema to source completions from (null disables completions)
+ * @returns A CodeMirror Extension
+ */
+export function handlerAutocomplete(schema: HandlerSchemaResponse | null): Extension {
+  return autocompletion({
+    override: [buildHandlerCompletionSource(schema)],
+  })
+}

--- a/frontend/src/features/economy/lib/handler-autocomplete.ts
+++ b/frontend/src/features/economy/lib/handler-autocomplete.ts
@@ -3,17 +3,31 @@ import type { Extension } from '@codemirror/state'
 import type { Handler, HandlerSchemaResponse } from '@/shared/handler-reference'
 
 /**
- * Generates a Starlark call template for a handler.
+ * Generates a Starlark call template for a handler including the service name.
  * Example: position_keeping.initiate_log(amount="", direction="DEBIT")
  */
 export function generateParameterTemplate(serviceName: string, handler: Handler): string {
-  const params = handler.params
+  const params = buildParamString(handler)
+  return `${serviceName}.${handler.name}(${params})`
+}
+
+/**
+ * Generates only the handler call portion (no service name prefix).
+ * Used as the `apply` value in handler completions where the service name
+ * and dot are already present in the document.
+ * Example: initiate_log(amount="", direction="DEBIT")
+ */
+export function generateHandlerCallTemplate(handler: Handler): string {
+  return `${handler.name}(${buildParamString(handler)})`
+}
+
+function buildParamString(handler: Handler): string {
+  return handler.params
     .map((p) => {
       const value = p.type === 'enum' ? `"${p.enumValues[0] ?? ''}"` : '""'
       return `${p.name}=${value}`
     })
     .join(', ')
-  return `${serviceName}.${handler.name}(${params})`
 }
 
 /**
@@ -22,6 +36,8 @@ export function generateParameterTemplate(serviceName: string, handler: Handler)
  * Provides two levels of completion:
  * 1. Service name completions (type: 'namespace') — triggered when typing a word
  * 2. Handler completions (type: 'function') — triggered after "serviceName."
+ *    The `apply` string only includes the handler call (no service prefix) since
+ *    the service name and dot are already in the document before the cursor.
  *
  * @param schema The handler schema, or null if not yet loaded
  * @returns A CompletionSource for use with autocompletion()
@@ -39,7 +55,7 @@ export function buildHandlerCompletionSource(schema: HandlerSchemaResponse | nul
       const handlerPrefix = text.slice(dotIndex + 1)
 
       const service = schema.services.find((s) => s.serviceName === serviceName)
-      if (!service) return { from: dotMatch.from, options: [] }
+      if (!service) return { from: dotMatch.from + dotIndex + 1, options: [] }
 
       const options: Completion[] = service.handlers
         .filter((h) => h.name.startsWith(handlerPrefix))
@@ -47,13 +63,12 @@ export function buildHandlerCompletionSource(schema: HandlerSchemaResponse | nul
           label: h.name,
           type: 'function',
           detail: h.description || undefined,
-          // apply replaces the entire "serviceName.partialHandler" range so
-          // the completed text becomes "serviceName.handlerName(params)"
-          apply: generateParameterTemplate(serviceName, h),
+          // apply only inserts the handler call — the service name and dot are
+          // already in the document, so from is set to after the dot
+          apply: generateHandlerCallTemplate(h),
         }))
 
-      // Replace from the start of "serviceName." so the full template is inserted
-      return { from: dotMatch.from, options }
+      return { from: dotMatch.from + dotIndex + 1, options }
     }
 
     // Service name completion — triggered when typing a word (no dot yet)

--- a/frontend/src/features/economy/lib/handler-autocomplete.ts
+++ b/frontend/src/features/economy/lib/handler-autocomplete.ts
@@ -39,7 +39,7 @@ export function buildHandlerCompletionSource(schema: HandlerSchemaResponse | nul
       const handlerPrefix = text.slice(dotIndex + 1)
 
       const service = schema.services.find((s) => s.serviceName === serviceName)
-      if (!service) return { from: dotMatch.from + dotIndex + 1, options: [] }
+      if (!service) return { from: dotMatch.from, options: [] }
 
       const options: Completion[] = service.handlers
         .filter((h) => h.name.startsWith(handlerPrefix))
@@ -47,10 +47,13 @@ export function buildHandlerCompletionSource(schema: HandlerSchemaResponse | nul
           label: h.name,
           type: 'function',
           detail: h.description || undefined,
+          // apply replaces the entire "serviceName.partialHandler" range so
+          // the completed text becomes "serviceName.handlerName(params)"
           apply: generateParameterTemplate(serviceName, h),
         }))
 
-      return { from: dotMatch.from + dotIndex + 1, options }
+      // Replace from the start of "serviceName." so the full template is inserted
+      return { from: dotMatch.from, options }
     }
 
     // Service name completion — triggered when typing a word (no dot yet)

--- a/frontend/src/shared/handler-reference.tsx
+++ b/frontend/src/shared/handler-reference.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { ChevronRight } from 'lucide-react'
 import { useApiClients } from '@/api/context'
+import { generateParameterTemplate } from '@/features/economy/lib/handler-autocomplete'
 
 /**
  * Represents a parameter for a Starlark handler.
@@ -105,30 +106,13 @@ export function HandlerReference({ filter = '', serviceNames: serviceNameFilter,
   })
 
   /**
-   * Generates a Starlark call template for a handler with its parameters.
-   * @param serviceName The service name (e.g., 'position_keeping')
-   * @param handler The handler definition with parameters
-   * @returns A Starlark function call template (e.g., 'service.handler(param1="", param2="")')
-   */
-  const generateTemplate = (serviceName: string, handler: Handler): string => {
-    const params = handler.params
-      .map((p) => {
-        const paramValue = p.type === 'enum' ? `"${p.enumValues[0] || ''}"` : '""'
-        return `${p.name}=${paramValue}`
-      })
-      .join(', ')
-
-    return params ? `${serviceName}.${handler.name}(${params})` : `${serviceName}.${handler.name}()`
-  }
-
-  /**
    * Handles the insert button click by generating and passing the template to onInsert callback.
    * @param serviceName The service name
    * @param handler The handler to insert
    */
   const handleInsert = (serviceName: string, handler: Handler) => {
     if (!onInsert) return
-    const template = generateTemplate(serviceName, handler)
+    const template = generateParameterTemplate(serviceName, handler)
     onInsert(template)
   }
 

--- a/frontend/src/shared/handler-reference.tsx
+++ b/frontend/src/shared/handler-reference.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { ChevronRight } from 'lucide-react'
 import { useApiClients } from '@/api/context'
-import { generateParameterTemplate } from '@/features/economy/lib/handler-autocomplete'
+import { generateParameterTemplate } from './handler-template'
 
 /**
  * Represents a parameter for a Starlark handler.

--- a/frontend/src/shared/handler-template.test.ts
+++ b/frontend/src/shared/handler-template.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { generateParameterTemplate, generateHandlerCallTemplate, buildParamString } from './handler-template'
+import type { Handler } from './handler-reference'
+
+const handlerWithParams: Handler = {
+  name: 'initiate_log',
+  description: 'Initiates a log',
+  params: [
+    { name: 'amount', type: 'Decimal', required: true, enumValues: [] },
+    { name: 'direction', type: 'enum', required: true, enumValues: ['DEBIT', 'CREDIT'] },
+  ],
+}
+
+const handlerNoParams: Handler = {
+  name: 'finalize',
+  description: '',
+  params: [],
+}
+
+describe('buildParamString', () => {
+  it('builds comma-separated param assignments', () => {
+    expect(buildParamString(handlerWithParams)).toBe('amount="", direction="DEBIT"')
+  })
+
+  it('returns empty string for handler with no params', () => {
+    expect(buildParamString(handlerNoParams)).toBe('')
+  })
+
+  it('uses first enum value for enum params', () => {
+    expect(buildParamString(handlerWithParams)).toContain('direction="DEBIT"')
+  })
+})
+
+describe('generateParameterTemplate', () => {
+  it('generates full template with service name prefix', () => {
+    expect(generateParameterTemplate('position_keeping', handlerWithParams)).toBe(
+      'position_keeping.initiate_log(amount="", direction="DEBIT")',
+    )
+  })
+
+  it('generates template for handler with no params', () => {
+    expect(generateParameterTemplate('svc', handlerNoParams)).toBe('svc.finalize()')
+  })
+})
+
+describe('generateHandlerCallTemplate', () => {
+  it('generates call without service name prefix', () => {
+    expect(generateHandlerCallTemplate(handlerWithParams)).toBe('initiate_log(amount="", direction="DEBIT")')
+  })
+
+  it('generates bare call for handler with no params', () => {
+    expect(generateHandlerCallTemplate(handlerNoParams)).toBe('finalize()')
+  })
+})

--- a/frontend/src/shared/handler-template.ts
+++ b/frontend/src/shared/handler-template.ts
@@ -1,0 +1,31 @@
+import type { Handler } from './handler-reference'
+
+/**
+ * Builds the parameter string for a handler call.
+ * Example: amount="", direction="DEBIT"
+ */
+export function buildParamString(handler: Handler): string {
+  return handler.params
+    .map((p) => {
+      const value = p.type === 'enum' ? `"${p.enumValues[0] ?? ''}"` : '""'
+      return `${p.name}=${value}`
+    })
+    .join(', ')
+}
+
+/**
+ * Generates a full Starlark call template including the service name.
+ * Example: position_keeping.initiate_log(amount="", direction="DEBIT")
+ */
+export function generateParameterTemplate(serviceName: string, handler: Handler): string {
+  return `${serviceName}.${handler.name}(${buildParamString(handler)})`
+}
+
+/**
+ * Generates only the handler call portion (no service name prefix).
+ * Used where the service name and dot are already present in the target document.
+ * Example: initiate_log(amount="", direction="DEBIT")
+ */
+export function generateHandlerCallTemplate(handler: Handler): string {
+  return `${handler.name}(${buildParamString(handler)})`
+}


### PR DESCRIPTION
## Summary

- Adds `handler-autocomplete.ts` in `frontend/src/features/economy/lib/` providing a CodeMirror 6 autocomplete extension sourced from the DescribeHandlers handler schema
- Two levels of completion: service name (type `namespace`) when typing a word, and handler name (type `function`) after `serviceName.` with full parameter template applied on selection
- Exports `handlerAutocomplete`, `buildHandlerCompletionSource`, and `generateParameterTemplate` from the economy feature barrel (`index.ts`)
- Installs `@codemirror/autocomplete` as an explicit dependency (was transitively available but not declared)

## Changes

- `frontend/src/features/economy/lib/handler-autocomplete.ts` — implementation
- `frontend/src/features/economy/lib/handler-autocomplete.test.ts` — 17 unit tests covering both completion levels, template generation, filtering, and null schema handling
- `frontend/src/features/economy/index.ts` — barrel export for the new lib
- `frontend/package.json` / `package-lock.json` — explicit `@codemirror/autocomplete` dependency

## Test plan

- [ ] `cd frontend && npm test src/features/economy/` — 81 tests, all pass
- [ ] Service name completions: typing `pos` returns `position_keeping` with type `namespace`
- [ ] Handler completions: typing `position_keeping.` returns handlers with type `function` and parameter templates as `apply`
- [ ] Partial handler filter: typing `position_keeping.init` filters to only `initiate_log`
- [ ] Null schema: `buildHandlerCompletionSource(null)` returns `null` from source