### PR TITLE
Cookbook UX: pattern taxonomy, fullscreen flow, mobile responsiveness

### DIFF
--- a/frontend/src/features/cookbook/components/catalogue-grid.tsx
+++ b/frontend/src/features/cookbook/components/catalogue-grid.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { EmptyState } from '@/components/ui/empty-state'
 import type { CookbookItem, PatternMeta, ComponentMeta } from '../hooks/use-cookbook'
+import { derivePatternKind } from '../hooks/use-filter-state'
 
 interface CatalogueGridProps {
   items: CookbookItem[]
@@ -78,9 +79,19 @@ function CookbookCard({ item }: { item: CookbookItem }) {
             )}
             <CardTitle className="text-sm">{item.title}</CardTitle>
           </div>
-          <Badge variant={isPattern ? 'default' : 'secondary'} className="text-[10px] shrink-0">
-            {isPattern ? 'Pattern' : 'UI'}
-          </Badge>
+          <div className="flex items-center gap-1 shrink-0">
+            {isPattern && (() => {
+              const kind = derivePatternKind(item)
+              return kind ? (
+                <Badge variant="outline" className="text-[10px] capitalize">
+                  {kind}
+                </Badge>
+              ) : null
+            })()}
+            <Badge variant={isPattern ? 'default' : 'secondary'} className="text-[10px]">
+              {isPattern ? 'Pattern' : 'UI'}
+            </Badge>
+          </div>
         </div>
         {item.description && (
           <CardDescription className="line-clamp-2 text-xs">

--- a/frontend/src/features/cookbook/components/filter-bar.test.ts
+++ b/frontend/src/features/cookbook/components/filter-bar.test.ts
@@ -39,7 +39,7 @@ const mockItems: CookbookItem[] = [
   },
 ]
 
-const emptyFilters: FilterState = { search: '', type: '', category: '', industry: '' }
+const emptyFilters: FilterState = { search: '', type: '', category: '', industry: '', kind: '' }
 
 describe('applyFilters', () => {
   it('returns all items when no filters active', () => {

--- a/frontend/src/features/cookbook/components/filter-bar.tsx
+++ b/frontend/src/features/cookbook/components/filter-bar.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import type { CookbookItem, PatternMeta } from '../hooks/use-cookbook'
 import type { FilterState } from '../hooks/use-filter-state'
+import { PATTERN_KINDS, derivePatternKind } from '../hooks/use-filter-state'
 
 function getUniqueCategories(items: CookbookItem[]): string[] {
   const set = new Set<string>()
@@ -26,17 +27,28 @@ function getUniqueIndustries(items: CookbookItem[]): string[] {
   return Array.from(set).sort()
 }
 
+function getAvailableKinds(items: CookbookItem[]): { value: string; label: string }[] {
+  const present = new Set<string>()
+  for (const item of items) {
+    const kind = derivePatternKind(item)
+    if (kind) present.add(kind)
+  }
+  return PATTERN_KINDS.filter((k) => present.has(k.value))
+}
+
 interface FilterBarProps {
   items: CookbookItem[]
   filters: FilterState
   onFilterChange: (patch: Partial<FilterState>) => void
   hideTypeFilter?: boolean
+  showKindFilter?: boolean
 }
 
-export function FilterBar({ items, filters, onFilterChange, hideTypeFilter }: FilterBarProps) {
+export function FilterBar({ items, filters, onFilterChange, hideTypeFilter, showKindFilter }: FilterBarProps) {
   const categories = getUniqueCategories(items)
   const industries = getUniqueIndustries(items)
-  const hasActiveFilters = filters.search || filters.type || filters.category || filters.industry
+  const kinds = showKindFilter ? getAvailableKinds(items) : []
+  const hasActiveFilters = filters.search || filters.type || filters.category || filters.industry || filters.kind
 
   return (
     <div className="space-y-3">
@@ -63,6 +75,15 @@ export function FilterBar({ items, filters, onFilterChange, hideTypeFilter }: Fi
           />
         )}
 
+        {kinds.length > 1 && (
+          <FilterChipGroup
+            label="Kind"
+            options={kinds}
+            value={filters.kind}
+            onChange={(value) => onFilterChange({ kind: value })}
+          />
+        )}
+
         {categories.length > 0 && (
           <FilterChipGroup
             label="Category"
@@ -85,7 +106,7 @@ export function FilterBar({ items, filters, onFilterChange, hideTypeFilter }: Fi
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => onFilterChange({ search: '', type: '', category: '', industry: '' })}
+            onClick={() => onFilterChange({ search: '', type: '', category: '', industry: '', kind: '' })}
             className="h-7 text-xs"
           >
             <X className="size-3 mr-1" />

--- a/frontend/src/features/cookbook/components/linked-detail.tsx
+++ b/frontend/src/features/cookbook/components/linked-detail.tsx
@@ -15,15 +15,16 @@ import type { SagaFlow } from '../lib/star-parser'
 const MOBILE_BREAKPOINT = 640
 
 function useIsMobile() {
-  const [isMobile, setIsMobile] = useState(
-    typeof window !== 'undefined' ? window.innerWidth < MOBILE_BREAKPOINT : false,
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined'
+      ? window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`).matches
+      : false,
   )
 
   useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches)
     mql.addEventListener('change', onChange)
-    setIsMobile(mql.matches)
     return () => mql.removeEventListener('change', onChange)
   }, [])
 

--- a/frontend/src/features/cookbook/components/linked-detail.tsx
+++ b/frontend/src/features/cookbook/components/linked-detail.tsx
@@ -1,7 +1,34 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo, useCallback, useEffect } from 'react'
+import { Maximize2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { HandlerReference } from '@/shared/handler-reference'
 import { SagaFlowDiagram } from './saga-flow'
+import type { FlowDirection } from './saga-flow'
 import type { SagaFlow } from '../lib/star-parser'
+
+const MOBILE_BREAKPOINT = 640
+
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined' ? window.innerWidth < MOBILE_BREAKPOINT : false,
+  )
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches)
+    mql.addEventListener('change', onChange)
+    setIsMobile(mql.matches)
+    return () => mql.removeEventListener('change', onChange)
+  }, [])
+
+  return isMobile
+}
 
 interface LinkedPatternDetailProps {
   flows: SagaFlow[]
@@ -9,6 +36,10 @@ interface LinkedPatternDetailProps {
 
 export function LinkedPatternDetail({ flows }: LinkedPatternDetailProps) {
   const [highlightedHandler, setHighlightedHandler] = useState<string | null>(null)
+  const [fullscreen, setFullscreen] = useState(false)
+  const isMobile = useIsMobile()
+
+  const direction: FlowDirection = isMobile ? 'TB' : 'LR'
 
   const serviceNames = useMemo(() => {
     const names = new Set<string>()
@@ -23,7 +54,6 @@ export function LinkedPatternDetail({ flows }: LinkedPatternDetailProps) {
   }, [flows])
 
   const handleStepClick = useCallback((_stepName: string, _lineNumber: number) => {
-    // Find the step across all flows
     for (const flow of flows) {
       const step = flow.steps.find((s) => s.name === _stepName)
       if (step && step.serviceCalls.length > 0) {
@@ -37,12 +67,37 @@ export function LinkedPatternDetail({ flows }: LinkedPatternDetailProps) {
 
   return (
     <div data-testid="linked-detail" className="flex flex-col gap-4">
-      <div className="h-[400px] rounded-lg border">
+      <div className="relative h-[300px] sm:h-[400px] rounded-lg border">
         <SagaFlowDiagram
           flows={flows}
           onStepClick={handleStepClick}
+          direction={direction}
         />
+        <Button
+          variant="outline"
+          size="icon"
+          className="absolute top-2 right-2 z-10 size-8 bg-background/80 backdrop-blur-sm"
+          onClick={() => setFullscreen(true)}
+          aria-label="View fullscreen"
+        >
+          <Maximize2 className="size-4" />
+        </Button>
       </div>
+
+      <Dialog open={fullscreen} onOpenChange={setFullscreen}>
+        <DialogContent className="max-w-[calc(100vw-2rem)] h-[calc(100vh-2rem)] sm:max-w-[calc(100vw-4rem)] sm:h-[calc(100vh-4rem)] flex flex-col p-4">
+          <DialogHeader className="shrink-0">
+            <DialogTitle>Saga Flow</DialogTitle>
+          </DialogHeader>
+          <div className="flex-1 min-h-0 rounded-lg border">
+            <SagaFlowDiagram
+              flows={flows}
+              onStepClick={handleStepClick}
+              direction={direction}
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
 
       <div className="rounded-lg border p-3">
         <h3 className="mb-2 text-sm font-medium text-muted-foreground">Handler Reference</h3>

--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -74,6 +74,7 @@ interface StartNodeData {
   sagaName: string
   highlightedSaga: string | null
   sagaColor: string | undefined
+  direction: FlowDirection
   [key: string]: unknown
 }
 
@@ -109,7 +110,7 @@ function StartNode({ data }: { data: StartNodeData }) {
           </span>
         )}
       </div>
-      <Handle type="source" position={Position.Right} className="!bg-emerald-500 !border-0 !w-2 !h-2" />
+      <Handle type="source" position={data.direction === 'TB' ? Position.Bottom : Position.Right} className="!bg-emerald-500 !border-0 !w-2 !h-2" />
     </>
   )
 }
@@ -122,6 +123,7 @@ interface StepNodeData {
   sagaName: string
   highlightedSaga: string | null
   sagaColor: string | undefined
+  direction: FlowDirection
   [key: string]: unknown
 }
 
@@ -143,9 +145,9 @@ function StepNode({ data }: { data: StepNodeData }) {
 
   return (
     <>
-      <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="target" position={data.direction === 'TB' ? Position.Top : Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
       <div
-        className={`flex flex-col gap-1 rounded-lg border-2 bg-background px-3 py-2 shadow-sm min-w-[180px] transition-opacity ${dimmed ? 'opacity-30' : 'opacity-100'}`}
+        className={`flex flex-col gap-1 rounded-lg border-2 bg-background px-3 py-2 shadow-sm min-w-[140px] sm:min-w-[180px] transition-opacity ${dimmed ? 'opacity-30' : 'opacity-100'}`}
         style={{
           borderColor,
           ...(activeBorder
@@ -174,7 +176,7 @@ function StepNode({ data }: { data: StepNodeData }) {
           </div>
         )}
       </div>
-      <Handle type="source" position={Position.Right} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="source" position={data.direction === 'TB' ? Position.Bottom : Position.Right} className="!bg-transparent !border-0 !w-0 !h-0" />
     </>
   )
 }
@@ -183,6 +185,7 @@ interface DecisionNodeData {
   label: string
   sagaName: string
   highlightedSaga: string | null
+  direction: FlowDirection
   [key: string]: unknown
 }
 
@@ -190,7 +193,7 @@ function DecisionNode({ data }: { data: DecisionNodeData }) {
   const dimmed = data.highlightedSaga && data.highlightedSaga !== data.sagaName
   return (
     <>
-      <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="target" position={data.direction === 'TB' ? Position.Top : Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
       <div
         className={`flex items-center justify-center border-2 border-amber-500 bg-amber-50 dark:bg-amber-950/40 transition-opacity ${dimmed ? 'opacity-30' : 'opacity-100'}`}
         style={{
@@ -203,8 +206,8 @@ function DecisionNode({ data }: { data: DecisionNodeData }) {
           {data.label}
         </span>
       </div>
-      <Handle type="source" position={Position.Bottom} id="exit" className="!bg-transparent !border-0 !w-0 !h-0" />
-      <Handle type="source" position={Position.Right} id="no" className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="source" position={data.direction === 'TB' ? Position.Right : Position.Bottom} id="exit" className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="source" position={data.direction === 'TB' ? Position.Bottom : Position.Right} id="no" className="!bg-transparent !border-0 !w-0 !h-0" />
     </>
   )
 }
@@ -213,6 +216,7 @@ interface ExitNodeData {
   label: string
   sagaName: string
   highlightedSaga: string | null
+  direction: FlowDirection
   [key: string]: unknown
 }
 
@@ -220,7 +224,7 @@ function ExitNode({ data }: { data: ExitNodeData }) {
   const dimmed = data.highlightedSaga && data.highlightedSaga !== data.sagaName
   return (
     <>
-      <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="target" position={data.direction === 'TB' ? Position.Top : Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
       <div className={`flex items-center justify-center rounded-full border-2 border-red-500 bg-red-50 px-3 py-1.5 dark:bg-red-950/40 transition-opacity ${dimmed ? 'opacity-30' : 'opacity-100'}`}>
         <span className="text-[10px] font-semibold text-red-700 dark:text-red-300">{data.label}</span>
       </div>
@@ -231,6 +235,7 @@ function ExitNode({ data }: { data: ExitNodeData }) {
 interface EndNodeData {
   sagaName: string
   highlightedSaga: string | null
+  direction: FlowDirection
   [key: string]: unknown
 }
 
@@ -238,7 +243,7 @@ function EndNode({ data }: { data: EndNodeData }) {
   const dimmed = data.highlightedSaga && data.highlightedSaga !== data.sagaName
   return (
     <>
-      <Handle type="target" position={Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
+      <Handle type="target" position={data.direction === 'TB' ? Position.Top : Position.Left} className="!bg-transparent !border-0 !w-0 !h-0" />
       <div className={`flex items-center justify-center rounded-full border-2 border-slate-500 bg-slate-100 px-4 py-2 dark:bg-slate-800 transition-opacity ${dimmed ? 'opacity-30' : 'opacity-100'}`}>
         <span className="text-xs font-semibold text-slate-600 dark:text-slate-300">COMPLETED</span>
       </div>
@@ -264,9 +269,11 @@ const NODE_DIMENSIONS: Record<string, { width: number; height: number }> = {
   sagaEnd: { width: 140, height: 44 },
 }
 
-function layoutNodes(nodes: Node[], edges: Edge[]): Node[] {
+export type FlowDirection = 'LR' | 'TB'
+
+function layoutNodes(nodes: Node[], edges: Edge[], direction: FlowDirection = 'LR'): Node[] {
   const g = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}))
-  g.setGraph({ rankdir: 'LR', nodesep: 60, ranksep: 100 })
+  g.setGraph({ rankdir: direction, nodesep: 60, ranksep: 100 })
 
   for (const n of nodes) {
     const dims = NODE_DIMENSIONS[n.type ?? 'sagaStep'] ?? { width: 200, height: 60 }
@@ -300,6 +307,7 @@ function buildCombinedFlowGraph(
   sagaColors: Map<string, string>,
   highlightedService: string | null,
   highlightedSaga: string | null,
+  direction: FlowDirection = 'LR',
 ): { nodes: Node[]; edges: Edge[] } {
   const nodes: Node[] = []
   const edges: Edge[] = []
@@ -324,6 +332,7 @@ function buildCombinedFlowGraph(
         sagaName: flow.name,
         highlightedSaga,
         sagaColor,
+        direction,
       } satisfies StartNodeData,
     })
 
@@ -332,7 +341,7 @@ function buildCombinedFlowGraph(
         id: `${prefix}end`,
         type: 'sagaEnd',
         position: { x: 0, y: 0 },
-        data: { sagaName: flow.name, highlightedSaga } satisfies EndNodeData,
+        data: { sagaName: flow.name, highlightedSaga, direction } satisfies EndNodeData,
       })
       edges.push({ id: `${prefix}start-end`, source: `${prefix}start`, target: `${prefix}end` })
       continue
@@ -357,6 +366,7 @@ function buildCombinedFlowGraph(
           sagaName: flow.name,
           highlightedSaga,
           sagaColor,
+          direction,
         } satisfies StepNodeData,
       })
 
@@ -376,14 +386,14 @@ function buildCombinedFlowGraph(
           id: decisionId,
           type: 'sagaDecision',
           position: { x: 0, y: 0 },
-          data: { label: step.earlyExit.condition, sagaName: flow.name, highlightedSaga } satisfies DecisionNodeData,
+          data: { label: step.earlyExit.condition, sagaName: flow.name, highlightedSaga, direction } satisfies DecisionNodeData,
         })
 
         nodes.push({
           id: exitId,
           type: 'sagaExit',
           position: { x: 0, y: 0 },
-          data: { label: step.earlyExit.returnStatus, sagaName: flow.name, highlightedSaga } satisfies ExitNodeData,
+          data: { label: step.earlyExit.returnStatus, sagaName: flow.name, highlightedSaga, direction } satisfies ExitNodeData,
         })
 
         edges.push({
@@ -420,7 +430,7 @@ function buildCombinedFlowGraph(
       id: `${prefix}end`,
       type: 'sagaEnd',
       position: { x: 0, y: 0 },
-      data: { sagaName: flow.name, highlightedSaga } satisfies EndNodeData,
+      data: { sagaName: flow.name, highlightedSaga, direction } satisfies EndNodeData,
     })
 
     if (prevId) {
@@ -432,7 +442,7 @@ function buildCombinedFlowGraph(
     }
   }
 
-  return { nodes: layoutNodes(nodes, edges), edges }
+  return { nodes: layoutNodes(nodes, edges, direction), edges }
 }
 
 // --- Component ---
@@ -441,11 +451,13 @@ interface SagaFlowDiagramProps {
   flows: SagaFlow[]
   onStepClick?: (stepName: string, lineNumber: number) => void
   className?: string
+  direction?: FlowDirection
 }
 
-export function SagaFlowDiagram({ flows, onStepClick, className }: SagaFlowDiagramProps) {
+export function SagaFlowDiagram({ flows, onStepClick, className, direction = 'LR' }: SagaFlowDiagramProps) {
   const [highlightedService, setHighlightedService] = useState<string | null>(null)
   const [highlightedSaga, setHighlightedSaga] = useState<string | null>(null)
+  const [legendOpen, setLegendOpen] = useState(true)
 
   const serviceColors = useMemo(() => buildServiceColorMap(flows), [flows])
   const sagaColors = useMemo(() => buildSagaColorMap(flows), [flows])
@@ -459,8 +471,8 @@ export function SagaFlowDiagram({ flows, onStepClick, className }: SagaFlowDiagr
     : null
 
   const { nodes, edges } = useMemo(
-    () => buildCombinedFlowGraph(flows, serviceColors, sagaColors, effectiveServiceHighlight, effectiveSagaHighlight),
-    [flows, serviceColors, sagaColors, effectiveServiceHighlight, effectiveSagaHighlight],
+    () => buildCombinedFlowGraph(flows, serviceColors, sagaColors, effectiveServiceHighlight, effectiveSagaHighlight, direction),
+    [flows, serviceColors, sagaColors, effectiveServiceHighlight, effectiveSagaHighlight, direction],
   )
 
   const services = useMemo(() => [...serviceColors.keys()].sort(), [serviceColors])
@@ -502,68 +514,89 @@ export function SagaFlowDiagram({ flows, onStepClick, className }: SagaFlowDiagr
         <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
       </ReactFlow>
 
-      {/* Legend panel */}
-      <div className="absolute bottom-3 left-3 z-10 flex flex-col gap-2 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm max-w-[200px]">
-        {/* Saga filter (only shown for multi-saga patterns) */}
-        {flows.length > 1 && (
-          <div className="flex flex-col gap-1">
-            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Sagas</span>
-            {flows.map((flow) => {
-              const color = sagaColors.get(flow.name)
-              const isActive = effectiveSagaHighlight === flow.name
-              return (
-                <button
-                  key={flow.name}
-                  type="button"
-                  aria-pressed={isActive}
-                  className={`flex items-center gap-2 cursor-pointer rounded px-1 -mx-1 transition-colors hover:bg-muted/50 ${isActive ? 'font-semibold' : ''}`}
-                  onClick={() => {
-                    setHighlightedSaga((prev) => (prev === flow.name ? null : flow.name))
-                    setHighlightedService(null)
-                  }}
-                >
-                  <span
-                    className={`inline-block h-2.5 w-2.5 rounded-sm ${isActive ? 'ring-2 ring-offset-1' : ''}`}
-                    style={{ backgroundColor: color }}
-                  />
-                  <span className="text-xs text-muted-foreground truncate">{flow.name}</span>
-                </button>
-              )
-            })}
-          </div>
-        )}
+      {/* Legend panel — collapsible to avoid overlapping diagram on small screens */}
+      <div className="absolute bottom-3 left-3 z-10">
+        {legendOpen ? (
+          <div className="flex flex-col gap-2 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm max-w-[200px]">
+            <button
+              type="button"
+              className="text-[10px] text-muted-foreground/60 self-end hover:text-muted-foreground"
+              onClick={() => setLegendOpen(false)}
+              aria-label="Collapse legend"
+            >
+              hide
+            </button>
+            {/* Saga filter (only shown for multi-saga patterns) */}
+            {flows.length > 1 && (
+              <div className="flex flex-col gap-1">
+                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Sagas</span>
+                {flows.map((flow) => {
+                  const color = sagaColors.get(flow.name)
+                  const isActive = effectiveSagaHighlight === flow.name
+                  return (
+                    <button
+                      key={flow.name}
+                      type="button"
+                      aria-pressed={isActive}
+                      className={`flex items-center gap-2 cursor-pointer rounded px-1 -mx-1 transition-colors hover:bg-muted/50 ${isActive ? 'font-semibold' : ''}`}
+                      onClick={() => {
+                        setHighlightedSaga((prev) => (prev === flow.name ? null : flow.name))
+                        setHighlightedService(null)
+                      }}
+                    >
+                      <span
+                        className={`inline-block h-2.5 w-2.5 rounded-sm ${isActive ? 'ring-2 ring-offset-1' : ''}`}
+                        style={{ backgroundColor: color }}
+                      />
+                      <span className="text-xs text-muted-foreground truncate">{flow.name}</span>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
 
-        {/* Service filter */}
-        {services.length > 0 && (
-          <div className="flex flex-col gap-1">
-            {flows.length > 1 && <div className="border-t my-1" />}
-            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Services</span>
-            {services.map((svc) => {
-              const colors = serviceColors.get(svc)
-              const isActive = effectiveServiceHighlight === svc
-              return (
-                <button
-                  key={svc}
-                  type="button"
-                  aria-pressed={isActive}
-                  className={`flex items-center gap-2 cursor-pointer rounded px-1 -mx-1 transition-colors hover:bg-muted/50 ${isActive ? 'font-semibold' : ''}`}
-                  onClick={() => {
-                    setHighlightedService((prev) => (prev === svc ? null : svc))
-                    setHighlightedSaga(null)
-                  }}
-                >
-                  <span
-                    className={`inline-block h-2.5 w-2.5 rounded-full ${isActive ? 'ring-2 ring-offset-1' : ''}`}
-                    style={{ backgroundColor: colors?.fg }}
-                  />
-                  <span className="text-xs text-muted-foreground">{svc}</span>
-                  {triggerServices.has(svc) && (
-                    <span className="text-[9px] text-muted-foreground/60 italic">trigger</span>
-                  )}
-                </button>
-              )
-            })}
+            {/* Service filter */}
+            {services.length > 0 && (
+              <div className="flex flex-col gap-1">
+                {flows.length > 1 && <div className="border-t my-1" />}
+                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Services</span>
+                {services.map((svc) => {
+                  const colors = serviceColors.get(svc)
+                  const isActive = effectiveServiceHighlight === svc
+                  return (
+                    <button
+                      key={svc}
+                      type="button"
+                      aria-pressed={isActive}
+                      className={`flex items-center gap-2 cursor-pointer rounded px-1 -mx-1 transition-colors hover:bg-muted/50 ${isActive ? 'font-semibold' : ''}`}
+                      onClick={() => {
+                        setHighlightedService((prev) => (prev === svc ? null : svc))
+                        setHighlightedSaga(null)
+                      }}
+                    >
+                      <span
+                        className={`inline-block h-2.5 w-2.5 rounded-full ${isActive ? 'ring-2 ring-offset-1' : ''}`}
+                        style={{ backgroundColor: colors?.fg }}
+                      />
+                      <span className="text-xs text-muted-foreground">{svc}</span>
+                      {triggerServices.has(svc) && (
+                        <span className="text-[9px] text-muted-foreground/60 italic">trigger</span>
+                      )}
+                    </button>
+                  )
+                })}
+              </div>
+            )}
           </div>
+        ) : (
+          <button
+            type="button"
+            className="rounded-lg border bg-background/95 px-2.5 py-1.5 text-xs text-muted-foreground backdrop-blur-sm shadow-sm hover:text-foreground transition-colors"
+            onClick={() => setLegendOpen(true)}
+            aria-label="Show legend"
+          >
+            Legend
+          </button>
         )}
       </div>
     </div>

--- a/frontend/src/features/cookbook/hooks/use-filter-state.test.tsx
+++ b/frontend/src/features/cookbook/hooks/use-filter-state.test.tsx
@@ -30,6 +30,7 @@ describe('useFilterState', () => {
     expect(state.type).toBe('')
     expect(state.category).toBe('')
     expect(state.industry).toBe('')
+    expect(state.kind).toBe('')
   })
 
   it('reads initial state from URL search params', () => {
@@ -93,7 +94,7 @@ describe('useFilterState', () => {
     })
 
     act(() => {
-      result.current[1]({ search: '', type: '', category: '', industry: '' })
+      result.current[1]({ search: '', type: '', category: '', industry: '', kind: '' })
     })
 
     const [state] = result.current

--- a/frontend/src/features/cookbook/hooks/use-filter-state.ts
+++ b/frontend/src/features/cookbook/hooks/use-filter-state.ts
@@ -6,6 +6,7 @@ export interface FilterState {
   type: string
   category: string
   industry: string
+  kind: string
 }
 
 export function useFilterState(): [FilterState, (patch: Partial<FilterState>) => void] {
@@ -16,6 +17,7 @@ export function useFilterState(): [FilterState, (patch: Partial<FilterState>) =>
     type: searchParams.get('type') ?? '',
     category: searchParams.get('category') ?? '',
     industry: searchParams.get('industry') ?? '',
+    kind: searchParams.get('kind') ?? '',
   }
 
   function update(patch: Partial<FilterState>) {
@@ -35,12 +37,38 @@ export function useFilterState(): [FilterState, (patch: Partial<FilterState>) =>
   return [state, update]
 }
 
+/** Derive a human-readable kind from pattern metadata. */
+export function derivePatternKind(item: CookbookItem): string | null {
+  if (item.type !== 'registry:pattern') return null
+  const meta = item.meta as PatternMeta | undefined
+  const dp = meta?.design_pattern ?? ''
+  if (dp.startsWith('foundation')) return 'foundation'
+  const hasSagas = (meta?.provides?.sagas?.length ?? 0) > 0
+  const categories = item.categories ?? []
+  if (categories.includes('gateway') || categories.includes('integration') || categories.includes('payments') || categories.includes('compliance')) {
+    return 'integration'
+  }
+  if (hasSagas) return 'economy'
+  return 'definition'
+}
+
+export const PATTERN_KINDS = [
+  { value: 'economy', label: 'Economy' },
+  { value: 'foundation', label: 'Foundation' },
+  { value: 'integration', label: 'Integration' },
+  { value: 'definition', label: 'Definition' },
+] as const
+
 export function applyFilters(items: CookbookItem[], filters: FilterState): CookbookItem[] {
   return items.filter((item) => {
     if (filters.type) {
       const typeMap: Record<string, string> = { pattern: 'registry:pattern', ui: 'registry:ui' }
       const typeLabel = typeMap[filters.type]
       if (!typeLabel || item.type !== typeLabel) return false
+    }
+
+    if (filters.kind) {
+      if (derivePatternKind(item) !== filters.kind) return false
     }
 
     if (filters.category) {

--- a/frontend/src/features/cookbook/pages/patterns.tsx
+++ b/frontend/src/features/cookbook/pages/patterns.tsx
@@ -10,7 +10,7 @@ export function CookbookPatternsPage() {
   const [filters, setFilters] = useFilterState()
   const effectiveFilters = { ...filters, type: '' }
   const filtered = applyFilters(patterns, effectiveFilters)
-  const hasActiveFilters = !!(filters.search || filters.category || filters.industry)
+  const hasActiveFilters = !!(filters.search || filters.category || filters.industry || filters.kind)
 
   return (
     <div className="space-y-6">
@@ -19,7 +19,7 @@ export function CookbookPatternsPage() {
         <h1 className="text-2xl font-semibold">Economy Patterns</h1>
         <p className="text-muted-foreground">Saga definitions, manifest fragments, and instrument configurations</p>
       </div>
-      <FilterBar items={patterns} filters={filters} onFilterChange={setFilters} hideTypeFilter />
+      <FilterBar items={patterns} filters={filters} onFilterChange={setFilters} hideTypeFilter showKindFilter />
       <CatalogueGrid items={filtered} hasActiveFilters={hasActiveFilters} />
     </div>
   )

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -16,6 +16,21 @@ global.ResizeObserver = class ResizeObserver {
 // Polyfill scrollIntoView for cmdk keyboard navigation in jsdom
 Element.prototype.scrollIntoView = function () {}
 
+// Polyfill matchMedia for responsive hooks in jsdom
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+})
+
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 afterEach(() => {
   cleanup()


### PR DESCRIPTION
## Summary

- **Pattern taxonomy filter**: Patterns page now has a "Kind" filter (Economy, Foundation, Integration, Definition) derived from pattern metadata. Kind badges also appear on catalogue cards for at-a-glance identification.
- **Fullscreen flow diagram**: Added a dedicated expand button (Maximize icon) that opens the saga flow in a near-viewport-sized dialog, replacing reliance on the small ReactFlow fit-view control button.
- **Mobile responsiveness**: Flow diagrams switch from left-to-right to top-to-bottom layout on screens below 640px. Step nodes use smaller minimum widths on mobile. Legend panel is now collapsible to avoid overlapping the diagram. Flow container height adjusts per breakpoint (300px mobile, 400px desktop).

## Test plan

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] All 118 cookbook tests pass
- [ ] Manual: verify Kind filter chips appear on `/cookbook/patterns` and filter correctly
- [ ] Manual: verify expand button opens fullscreen dialog with saga flow
- [ ] Manual: resize browser to <640px and verify TB layout + collapsible legend
- [ ] Manual: verify catalogue cards show kind badges (Economy, Foundation, etc.)