### PR TITLE
feat: implement EconomyCreatePage with generation entry point

### DIFF
--- a/frontend/src/features/economy/pages/economy-create-page.test.tsx
+++ b/frontend/src/features/economy/pages/economy-create-page.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { renderWithProviders } from '@/test/test-utils'
+import { createTenantUserToken } from '@/test/jwt-helpers'
+import { EconomyCreatePage } from './economy-create-page'
+
+vi.mock('@/api/context', () => ({
+  useApiClients: vi.fn(),
+  ApiClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+// Mock react-router-dom navigate
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+function renderPage() {
+  return renderWithProviders(
+    <MemoryRouter>
+      <EconomyCreatePage />
+    </MemoryRouter>,
+    { initialToken: createTenantUserToken() },
+  )
+}
+
+describe('EconomyCreatePage', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset()
+  })
+
+  it('renders page title and subtitle', () => {
+    renderPage()
+    expect(screen.getByText('Create Your Economy')).toBeInTheDocument()
+    expect(screen.getByText(/Describe your business or start with a blank template/i)).toBeInTheDocument()
+  })
+
+  it('renders textarea for business description', () => {
+    renderPage()
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+
+  it('renders three option cards', () => {
+    renderPage()
+    expect(screen.getAllByText('Build My Economy').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText("I'm Feeling Lucky").length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('Start from Scratch').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('navigates to /economy/edit when Start from Scratch is clicked', async () => {
+    renderPage()
+    const scratchButton = screen.getByRole('button', { name: /start from scratch/i })
+    await userEvent.click(scratchButton)
+    expect(mockNavigate).toHaveBeenCalledWith('/economy/edit')
+  })
+
+  it('Start from Scratch is always enabled regardless of prompt', () => {
+    renderPage()
+    const scratchButton = screen.getByRole('button', { name: /start from scratch/i })
+    expect(scratchButton).not.toBeDisabled()
+  })
+
+  it('Build My Economy and I\'m Feeling Lucky are disabled when prompt is empty', () => {
+    renderPage()
+    const buildButton = screen.getByRole('button', { name: /build my economy/i })
+    const luckyButton = screen.getByRole('button', { name: /i'm feeling lucky/i })
+    expect(buildButton).toBeDisabled()
+    expect(luckyButton).toBeDisabled()
+  })
+
+  it('Build My Economy and I\'m Feeling Lucky remain disabled (generator unavailable) even with prompt', async () => {
+    renderPage()
+    const textarea = screen.getByRole('textbox')
+    await userEvent.type(textarea, 'An energy trading platform')
+
+    // Generator not wired up in clients — should remain disabled
+    const buildButton = screen.getByRole('button', { name: /build my economy/i })
+    const luckyButton = screen.getByRole('button', { name: /i'm feeling lucky/i })
+    expect(buildButton).toBeDisabled()
+    expect(luckyButton).toBeDisabled()
+  })
+})

--- a/frontend/src/features/economy/pages/economy-create-page.test.tsx
+++ b/frontend/src/features/economy/pages/economy-create-page.test.tsx
@@ -14,11 +14,8 @@ vi.mock('@/api/context', () => ({
 // Mock react-router-dom navigate
 const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('react-router-dom')>()
-  return {
-    ...actual,
-    useNavigate: () => mockNavigate,
-  }
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, useNavigate: () => mockNavigate }
 })
 
 function renderPage() {

--- a/frontend/src/features/economy/pages/economy-create-page.tsx
+++ b/frontend/src/features/economy/pages/economy-create-page.tsx
@@ -1,8 +1,130 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Wand2, Sparkles, FileCode } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+// Generator service is not yet wired into the API clients.
+// When it is, replace this constant with a check against the client.
+const GENERATOR_AVAILABLE = false
+
 export function EconomyCreatePage() {
+  const navigate = useNavigate()
+  const [prompt, setPrompt] = useState('')
+
+  const promptEmpty = prompt.trim().length === 0
+  const generatorDisabled = !GENERATOR_AVAILABLE || promptEmpty
+
+  const generatorTooltip = !GENERATOR_AVAILABLE
+    ? 'Coming soon'
+    : promptEmpty
+      ? 'Enter a description first'
+      : undefined
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold">Create Economy</h1>
-      <p className="mt-2 text-muted-foreground">Define a new economy configuration.</p>
+    <div className="flex min-h-full items-start justify-center p-8">
+      <div className="w-full max-w-2xl space-y-6">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold">Create Your Economy</h1>
+          <p className="text-sm text-muted-foreground">
+            Describe your business or start with a blank template
+          </p>
+        </div>
+
+        <textarea
+          className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-none"
+          rows={5}
+          placeholder="e.g. An energy trading platform that manages kWh contracts and carbon credits for renewable energy co-ops..."
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+        />
+
+        <div className="grid grid-cols-3 gap-4">
+          {/* Build My Economy */}
+          <OptionCard
+            icon={<Wand2 className="size-5" />}
+            title="Build My Economy"
+            description="Interactive refinement with AI guidance"
+            disabled={generatorDisabled}
+            tooltip={generatorTooltip}
+            onClick={() => {
+              // Future: call generator service and navigate with result
+            }}
+          />
+
+          {/* I'm Feeling Lucky */}
+          <OptionCard
+            icon={<Sparkles className="size-5 text-amber-500" />}
+            title="I'm Feeling Lucky"
+            description="Single-pass AI generation"
+            disabled={generatorDisabled}
+            tooltip={generatorTooltip}
+            onClick={() => {
+              // Future: call generator service in single-pass mode
+            }}
+          />
+
+          {/* Start from Scratch */}
+          <OptionCard
+            icon={<FileCode className="size-5 text-green-500" />}
+            title="Start from Scratch"
+            description="Open the editor with a blank template"
+            disabled={false}
+            onClick={() => navigate('/economy/edit')}
+          />
+        </div>
+      </div>
     </div>
   )
+}
+
+interface OptionCardProps {
+  icon: React.ReactNode
+  title: string
+  description: string
+  disabled: boolean
+  tooltip?: string
+  onClick: () => void
+}
+
+function OptionCard({ icon, title, description, disabled, tooltip, onClick }: OptionCardProps) {
+  const card = (
+    <Card
+      className={disabled ? 'opacity-50' : 'cursor-pointer hover:border-primary transition-colors'}
+    >
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          {icon}
+          <CardTitle className="text-sm">{title}</CardTitle>
+        </div>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full"
+          disabled={disabled}
+          onClick={onClick}
+        >
+          {title}
+        </Button>
+      </CardContent>
+    </Card>
+  )
+
+  if (tooltip) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          {/* span needed so tooltip works on disabled button parent */}
+          <span className="block">{card}</span>
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  return card
 }

--- a/frontend/src/features/economy/pages/economy-create-page.tsx
+++ b/frontend/src/features/economy/pages/economy-create-page.tsx
@@ -33,6 +33,7 @@ export function EconomyCreatePage() {
         </div>
 
         <textarea
+          aria-label="Business description"
           className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-none"
           rows={5}
           placeholder="e.g. An energy trading platform that manages kWh contracts and carbon credits for renewable energy co-ops..."
@@ -91,7 +92,7 @@ interface OptionCardProps {
 function OptionCard({ icon, title, description, disabled, tooltip, onClick }: OptionCardProps) {
   const card = (
     <Card
-      className={disabled ? 'opacity-50' : 'cursor-pointer hover:border-primary transition-colors'}
+      className={disabled ? 'opacity-50' : 'hover:border-primary transition-colors'}
     >
       <CardHeader>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

- Implements the economy creation entry page at `/economy/create`
- Centered layout with `max-w-2xl`, textarea for business description, and three option cards
- **Start from Scratch** always enabled — navigates directly to `/economy/edit`
- **Build My Economy** and **I'm Feeling Lucky** disabled (generator service not yet wired) with "Coming Soon" tooltip
- Disabling logic is isolated behind a `GENERATOR_AVAILABLE` constant for easy future wiring

## Changes Made

- `economy-create-page.tsx`: Full implementation replacing the stub
- `economy-create-page.test.tsx`: 7 Vitest tests covering rendering, navigation, and disabled states

## Testing

- All 7 new tests pass
- All 109 economy feature tests pass (`npm test -- --run src/features/economy/`)

## Risk Assessment

Low — replaces a stub with no existing tests or dependents. No API calls made.