### PR TITLE
feat: implement draft changes system with localStorage persistence (economy-ide.14)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,7 +38,8 @@
         "react-router-dom": "^7.13.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
-        "zod": "^4.3.6"
+        "zod": "^4.3.6",
+        "zustand": "^5.0.11"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.65.0",
@@ -5561,6 +5562,34 @@
       "peerDependencies": {
         "react": ">=17",
         "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/react/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@xyflow/system": {
@@ -12303,20 +12332,18 @@
       }
     },
     "node_modules/zustand": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
       "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.2"
-      },
       "engines": {
-        "node": ">=12.7.0"
+        "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
+        "@types/react": ">=18.0.0",
         "immer": ">=9.0.6",
-        "react": ">=16.8"
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -12326,6 +12353,9 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,7 +51,8 @@
     "react-router-dom": "^7.13.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "zustand": "^5.0.11"
   },
   "overrides": {
     "hono": "^4.12.4",

--- a/frontend/src/features/economy/index.ts
+++ b/frontend/src/features/economy/index.ts
@@ -23,3 +23,5 @@ export type { DeployWizardProps } from './components/deploy-wizard'
 
 // Lib
 export { handlerAutocomplete, buildHandlerCompletionSource, generateParameterTemplate, generateHandlerCallTemplate } from './lib/handler-autocomplete'
+export { useDraftStore, mergeDraftChanges } from './lib/draft-manager'
+export type { DraftChange } from './lib/draft-manager'

--- a/frontend/src/features/economy/lib/draft-manager.test.ts
+++ b/frontend/src/features/economy/lib/draft-manager.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { act } from '@testing-library/react'
+
+// Must reset store between tests
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+// Import after clearing localStorage
+async function getDraftStore() {
+  // Reset zustand persist state between tests by reimporting
+  const { useDraftStore } = await import('./draft-manager')
+  return useDraftStore
+}
+
+describe('draft-manager: DraftChange types', () => {
+  it('exports useDraftStore', async () => {
+    const { useDraftStore } = await import('./draft-manager')
+    expect(useDraftStore).toBeDefined()
+  })
+
+  it('exports mergeDraftChanges', async () => {
+    const { mergeDraftChanges } = await import('./draft-manager')
+    expect(mergeDraftChanges).toBeDefined()
+  })
+})
+
+describe('draft-manager: store operations', () => {
+  beforeEach(() => {
+    // Reset module between tests to clear in-memory store
+    vi.resetModules()
+  })
+
+  it('starts with empty changes and null baseVersion', async () => {
+    const useDraftStore = await getDraftStore()
+    const state = useDraftStore.getState()
+    expect(state.changes).toEqual([])
+    expect(state.baseVersion).toBeNull()
+  })
+
+  it('addChange generates id and createdAt', async () => {
+    const useDraftStore = await getDraftStore()
+    act(() => {
+      useDraftStore.getState().addChange({
+        type: 'add_saga',
+        description: 'Add payment saga',
+        patch: { sagas: [{ name: 'pay' }] },
+      })
+    })
+    const { changes } = useDraftStore.getState()
+    expect(changes).toHaveLength(1)
+    expect(changes[0].id).toBeDefined()
+    expect(typeof changes[0].id).toBe('string')
+    expect(changes[0].createdAt).toBeDefined()
+    expect(typeof changes[0].createdAt).toBe('number')
+    expect(changes[0].type).toBe('add_saga')
+    expect(changes[0].description).toBe('Add payment saga')
+  })
+
+  it('removeChange removes by id', async () => {
+    const useDraftStore = await getDraftStore()
+    act(() => {
+      useDraftStore.getState().addChange({
+        type: 'override_default',
+        description: 'Override default',
+        patch: {},
+      })
+    })
+    const { changes } = useDraftStore.getState()
+    const id = changes[0].id
+    act(() => {
+      useDraftStore.getState().removeChange(id)
+    })
+    expect(useDraftStore.getState().changes).toHaveLength(0)
+  })
+
+  it('clearAll removes all changes', async () => {
+    const useDraftStore = await getDraftStore()
+    act(() => {
+      useDraftStore.getState().addChange({ type: 'add_saga', description: 'A', patch: {} })
+      useDraftStore.getState().addChange({ type: 'add_instrument', description: 'B', patch: {} })
+    })
+    expect(useDraftStore.getState().changes).toHaveLength(2)
+    act(() => {
+      useDraftStore.getState().clearAll()
+    })
+    expect(useDraftStore.getState().changes).toHaveLength(0)
+  })
+
+  it('setBaseVersion stores the version', async () => {
+    const useDraftStore = await getDraftStore()
+    act(() => {
+      useDraftStore.getState().setBaseVersion('2.5')
+    })
+    expect(useDraftStore.getState().baseVersion).toBe('2.5')
+  })
+})
+
+describe('mergeDraftChanges', () => {
+  it('returns base manifest when no changes', async () => {
+    const { mergeDraftChanges } = await import('./draft-manager')
+    const base = { version: '1.0', metadata: { name: 'Test' }, instruments: [] }
+    const result = mergeDraftChanges(base, [])
+    expect(result).toEqual(base)
+  })
+
+  it('merges patch fields into the base manifest', async () => {
+    const { mergeDraftChanges } = await import('./draft-manager')
+    const base = { version: '1.0', instruments: [], sagas: [] }
+    const changes = [
+      {
+        id: 'c1',
+        type: 'add_saga' as const,
+        description: 'Add saga',
+        patch: { sagas: [{ name: 'process_payment' }] },
+        createdAt: Date.now(),
+      },
+    ]
+    const result = mergeDraftChanges(base, changes)
+    expect(result.sagas).toEqual([{ name: 'process_payment' }])
+    // Original not mutated
+    expect(base.sagas).toEqual([])
+  })
+
+  it('applies multiple patches in order (last wins)', async () => {
+    const { mergeDraftChanges } = await import('./draft-manager')
+    const base = { version: '1.0', metadata: { name: 'Original' } }
+    const changes = [
+      {
+        id: 'c1',
+        type: 'override_default' as const,
+        description: 'First',
+        patch: { metadata: { name: 'First Override' } },
+        createdAt: 1000,
+      },
+      {
+        id: 'c2',
+        type: 'override_default' as const,
+        description: 'Second',
+        patch: { metadata: { name: 'Second Override' } },
+        createdAt: 2000,
+      },
+    ]
+    const result = mergeDraftChanges(base, changes)
+    expect(result.metadata).toEqual({ name: 'Second Override' })
+  })
+})
+
+// Required for top-level vi.resetModules() usage
+import { vi } from 'vitest'

--- a/frontend/src/features/economy/lib/draft-manager.ts
+++ b/frontend/src/features/economy/lib/draft-manager.ts
@@ -1,0 +1,67 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export interface DraftChange {
+  id: string
+  type: 'add_saga' | 'override_default' | 'add_instrument' | 'modify_account_type'
+  description: string
+  patch: Record<string, unknown>
+  createdAt: number
+}
+
+interface DraftState {
+  baseVersion: string | null
+  changes: DraftChange[]
+  addChange: (change: Omit<DraftChange, 'id' | 'createdAt'>) => void
+  removeChange: (id: string) => void
+  clearAll: () => void
+  setBaseVersion: (version: string) => void
+}
+
+export const useDraftStore = create<DraftState>()(
+  persist(
+    (set) => ({
+      baseVersion: null,
+      changes: [],
+
+      addChange: (change) =>
+        set((state) => ({
+          changes: [
+            ...state.changes,
+            {
+              ...change,
+              id: crypto.randomUUID(),
+              createdAt: Date.now(),
+            },
+          ],
+        })),
+
+      removeChange: (id) =>
+        set((state) => ({
+          changes: state.changes.filter((c) => c.id !== id),
+        })),
+
+      clearAll: () => set({ changes: [] }),
+
+      setBaseVersion: (version) => set({ baseVersion: version }),
+    }),
+    {
+      name: 'economy-draft',
+    }
+  )
+)
+
+/**
+ * Applies draft changes to a base manifest, returning a merged copy.
+ * Patches are applied in order; later patches override earlier ones for top-level keys.
+ * The original manifest is not mutated.
+ */
+export function mergeDraftChanges(
+  baseManifest: Record<string, unknown>,
+  changes: DraftChange[]
+): Record<string, unknown> {
+  return changes.reduce<Record<string, unknown>>(
+    (acc, change) => ({ ...acc, ...change.patch }),
+    { ...baseManifest }
+  )
+}

--- a/frontend/src/features/economy/pages/economy-draft-page.test.tsx
+++ b/frontend/src/features/economy/pages/economy-draft-page.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { EconomyDraftPage } from './economy-draft-page'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+// Mock the draft store to control state in tests
+const mockAddChange = vi.fn()
+const mockRemoveChange = vi.fn()
+const mockClearAll = vi.fn()
+const mockSetBaseVersion = vi.fn()
+
+let mockStoreState = {
+  baseVersion: null as string | null,
+  changes: [] as Array<{
+    id: string
+    type: 'add_saga' | 'override_default' | 'add_instrument' | 'modify_account_type'
+    description: string
+    patch: Record<string, unknown>
+    createdAt: number
+  }>,
+  addChange: mockAddChange,
+  removeChange: mockRemoveChange,
+  clearAll: mockClearAll,
+  setBaseVersion: mockSetBaseVersion,
+}
+
+vi.mock('../lib/draft-manager', () => ({
+  useDraftStore: (selector: (s: typeof mockStoreState) => unknown) => selector(mockStoreState),
+  mergeDraftChanges: vi.fn(),
+}))
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <EconomyDraftPage />
+    </MemoryRouter>
+  )
+}
+
+describe('EconomyDraftPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear()
+    mockRemoveChange.mockClear()
+    mockClearAll.mockClear()
+    mockStoreState = {
+      baseVersion: null,
+      changes: [],
+      addChange: mockAddChange,
+      removeChange: mockRemoveChange,
+      clearAll: mockClearAll,
+      setBaseVersion: mockSetBaseVersion,
+    }
+  })
+
+  it('renders page title', () => {
+    renderPage()
+    expect(screen.getByText('Draft Changes')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no draft changes', () => {
+    renderPage()
+    expect(screen.getByTestId('draft-empty-state')).toBeInTheDocument()
+  })
+
+  it('does not show empty state when changes exist', () => {
+    mockStoreState = {
+      ...mockStoreState,
+      changes: [
+        {
+          id: 'c1',
+          type: 'add_saga',
+          description: 'Add payment saga',
+          patch: {},
+          createdAt: 1700000000000,
+        },
+      ],
+    }
+    renderPage()
+    expect(screen.queryByTestId('draft-empty-state')).not.toBeInTheDocument()
+  })
+
+  it('renders change descriptions', () => {
+    mockStoreState = {
+      ...mockStoreState,
+      changes: [
+        {
+          id: 'c1',
+          type: 'add_saga',
+          description: 'Add payment saga',
+          patch: {},
+          createdAt: 1700000000000,
+        },
+        {
+          id: 'c2',
+          type: 'add_instrument',
+          description: 'Add GBP instrument',
+          patch: {},
+          createdAt: 1700000001000,
+        },
+      ],
+    }
+    renderPage()
+    expect(screen.getByText('Add payment saga')).toBeInTheDocument()
+    expect(screen.getByText('Add GBP instrument')).toBeInTheDocument()
+  })
+
+  it('renders Revert button for each change', () => {
+    mockStoreState = {
+      ...mockStoreState,
+      changes: [
+        { id: 'c1', type: 'add_saga', description: 'A', patch: {}, createdAt: 1700000000000 },
+        { id: 'c2', type: 'add_instrument', description: 'B', patch: {}, createdAt: 1700000001000 },
+      ],
+    }
+    renderPage()
+    const revertButtons = screen.getAllByRole('button', { name: /revert/i })
+    expect(revertButtons).toHaveLength(2)
+  })
+
+  it('calls removeChange with correct id when Revert is clicked', async () => {
+    mockStoreState = {
+      ...mockStoreState,
+      changes: [
+        { id: 'c1', type: 'add_saga', description: 'A', patch: {}, createdAt: 1700000000000 },
+      ],
+    }
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: /revert/i }))
+    expect(mockRemoveChange).toHaveBeenCalledWith('c1')
+  })
+
+  it('renders Clear All button when changes exist', () => {
+    mockStoreState = {
+      ...mockStoreState,
+      changes: [
+        { id: 'c1', type: 'add_saga', description: 'A', patch: {}, createdAt: 1700000000000 },
+      ],
+    }
+    renderPage()
+    expect(screen.getByRole('button', { name: /clear all/i })).toBeInTheDocument()
+  })
+
+  it('calls clearAll when Clear All is clicked', async () => {
+    mockStoreState = {
+      ...mockStoreState,
+      changes: [
+        { id: 'c1', type: 'add_saga', description: 'A', patch: {}, createdAt: 1700000000000 },
+      ],
+    }
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: /clear all/i }))
+    expect(mockClearAll).toHaveBeenCalled()
+  })
+
+  it('renders Review Draft button when changes exist', () => {
+    mockStoreState = {
+      ...mockStoreState,
+      changes: [
+        { id: 'c1', type: 'add_saga', description: 'A', patch: {}, createdAt: 1700000000000 },
+      ],
+    }
+    renderPage()
+    expect(screen.getByRole('button', { name: /review draft/i })).toBeInTheDocument()
+  })
+
+  it('navigates to /economy/edit with reviewDraft state when Review Draft is clicked', async () => {
+    mockStoreState = {
+      ...mockStoreState,
+      changes: [
+        { id: 'c1', type: 'add_saga', description: 'A', patch: {}, createdAt: 1700000000000 },
+      ],
+    }
+    renderPage()
+    await userEvent.click(screen.getByRole('button', { name: /review draft/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/economy/edit', { state: { reviewDraft: true } })
+  })
+
+  it('does not show Review Draft and Clear All buttons when no changes', () => {
+    renderPage()
+    expect(screen.queryByRole('button', { name: /review draft/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /clear all/i })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/economy/pages/economy-draft-page.tsx
+++ b/frontend/src/features/economy/pages/economy-draft-page.tsx
@@ -1,8 +1,92 @@
+import { useNavigate } from 'react-router-dom'
+import { FileEdit, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { EmptyState } from '@/components/ui/empty-state'
+import { useDraftStore } from '../lib/draft-manager'
+
+const CHANGE_TYPE_LABELS: Record<string, string> = {
+  add_saga: 'Add Saga',
+  override_default: 'Override Default',
+  add_instrument: 'Add Instrument',
+  modify_account_type: 'Modify Account Type',
+}
+
+function formatTimestamp(ms: number): string {
+  return new Date(ms).toLocaleString()
+}
+
 export function EconomyDraftPage() {
+  const navigate = useNavigate()
+  const changes = useDraftStore((s) => s.changes)
+  const removeChange = useDraftStore((s) => s.removeChange)
+  const clearAll = useDraftStore((s) => s.clearAll)
+
+  const hasChanges = changes.length > 0
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold">Draft Changes</h1>
-      <p className="mt-2 text-muted-foreground">Review and apply draft changes.</p>
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Draft Changes</h1>
+          <p className="mt-1 text-muted-foreground">
+            {hasChanges
+              ? `${changes.length} pending change${changes.length === 1 ? '' : 's'}`
+              : 'No pending changes'}
+          </p>
+        </div>
+
+        {hasChanges && (
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => clearAll()}>
+              Clear All
+            </Button>
+            <Button onClick={() => navigate('/economy/edit', { state: { reviewDraft: true } })}>
+              Review Draft
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {!hasChanges && (
+        <div data-testid="draft-empty-state">
+          <EmptyState
+            icon={FileEdit}
+            title="No draft changes"
+            description="Changes you make in the economy editor will appear here before being applied."
+          />
+        </div>
+      )}
+
+      {hasChanges && (
+        <div className="space-y-3">
+          {changes.map((change) => (
+            <div
+              key={change.id}
+              className="flex items-start justify-between rounded-lg border p-4 gap-4"
+            >
+              <div className="space-y-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <Badge variant="secondary" className="shrink-0">
+                    {CHANGE_TYPE_LABELS[change.type] ?? change.type}
+                  </Badge>
+                </div>
+                <p className="text-sm font-medium">{change.description}</p>
+                <p className="text-xs text-muted-foreground">{formatTimestamp(change.createdAt)}</p>
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => removeChange(change.id)}
+                className="shrink-0 text-destructive hover:text-destructive"
+              >
+                <Trash2 className="size-4 mr-1" />
+                Revert
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Add `useDraftStore` Zustand store with `persist` middleware (localStorage key: `economy-draft`) storing typed `DraftChange` entries
- Add `mergeDraftChanges` function that applies draft patches to a base manifest, returning a merged copy
- Implement `EconomyDraftPage` with: change list showing type badge/description/timestamp, per-change Revert button, Clear All and Review Draft actions
- Export `useDraftStore`, `mergeDraftChanges`, and `DraftChange` type from the economy feature barrel
- Install `zustand` as an explicit dependency (was already a transitive dep via `@xyflow/react`)

## Changes Made

- `frontend/src/features/economy/lib/draft-manager.ts` — Zustand store + `mergeDraftChanges`
- `frontend/src/features/economy/lib/draft-manager.test.ts` — 10 tests covering store operations and merge logic
- `frontend/src/features/economy/pages/economy-draft-page.tsx` — Full page implementation replacing stub
- `frontend/src/features/economy/pages/economy-draft-page.test.tsx` — 11 tests covering UI states and interactions
- `frontend/src/features/economy/index.ts` — barrel exports for new symbols

## Test plan

- [x] All 123 economy feature tests pass
- [x] `draft-manager` unit tests: store CRUD operations, `mergeDraftChanges` patch ordering
- [x] `EconomyDraftPage` tests: empty state, change list rendering, Revert, Clear All, Review Draft navigation