### PR TITLE
Fix expand button overlapping zoom controls

### DIFF
--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -510,7 +510,7 @@ export function SagaFlowDiagram({ flows, onStepClick, className, direction = 'LR
         nodesDraggable={false}
         nodesConnectable={false}
       >
-        <Controls showInteractive={false} position="top-right" />
+        <Controls showInteractive={false} position="bottom-right" />
         <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
       </ReactFlow>
 


### PR DESCRIPTION
## Summary

- Move ReactFlow zoom controls from top-right to bottom-right so they don't overlap the fullscreen expand button added in #1595

## Test plan

- [ ] Visual: expand button and zoom +/- controls no longer overlap