### PR TITLE
feat: SSO BFF handlers and Dex SSO-only config

### DIFF
--- a/deploy/demo/dex.yaml
+++ b/deploy/demo/dex.yaml
@@ -1,23 +1,22 @@
 # Dex OIDC provider configuration for Meridian demo environment.
 #
-# Dex is a lightweight, Go-based OIDC identity provider (~20MB RAM vs ~500MB for Keycloak).
-# It serves JWKS keys and issues JWTs that the Meridian gateway validates.
+# Architecture: SSO-only mode with BFF (Backend For Frontend) pattern.
 #
-# Authentication is handled by the MeridianConnector (services/identity/connector/),
-# a Go-level integration wired directly into the Dex PasswordConnector interface at
-# process startup. It validates credentials by calling the identity domain repository
-# in-process — no network hop required.
+# Dex acts as an OIDC federation hub — it connects to upstream identity providers
+# (Google, GitHub, SAML, etc.) and issues ID tokens that the Meridian BFF consumes.
+# The BFF handles the full OAuth2 authorization code flow with PKCE:
 #
-# Demo users are seeded by the identity service bootstrap (services/identity/bootstrap/)
-# from DEMO_OPERATOR_EMAIL / DEMO_OPERATOR_PASSWORD environment variables.
+#   1. Frontend → GET /api/auth/sso/{connector_id} (BFF generates PKCE, redirects to Dex)
+#   2. Dex → upstream IdP (Google, GitHub, etc.) → Dex callback
+#   3. Dex → GET /api/auth/callback (BFF exchanges code with PKCE verifier)
+#   4. BFF resolves identity, signs Meridian JWT, redirects frontend with token
 #
-# Token acquisition (password grant):
-#   curl -X POST http://dex:5556/dex/token \
-#     -d "grant_type=password" \
-#     -d "client_id=meridian-service" \
-#     -d "scope=openid email profile" \
-#     -d "username=tenant:<slug>/${DEMO_OPERATOR_EMAIL}" \
-#     -d "password=${DEMO_OPERATOR_PASSWORD}"
+# Password authentication is handled directly by the BFF (POST /api/auth/login)
+# without involving Dex at all. The password grant type is therefore removed from
+# Dex's configuration.
+#
+# The single BFF callback URL (/api/auth/callback) replaces per-tenant/per-frontend
+# redirect URIs — tenant context is preserved in the PKCE state parameter.
 
 issuer: https://demo.meridianhub.cloud/dex
 
@@ -30,38 +29,23 @@ web:
   http: 0.0.0.0:5556
 
 oauth2:
-  # Dex v2.41.1 defaults do not include "password" in grantTypes. List it
-  # explicitly so the Resource Owner Password grant works with the connector.
   grantTypes:
     - authorization_code
     - refresh_token
-    - password
-  # "meridian" routes password grants through the Meridian identity connector.
-  # The connector validates credentials against the identity domain repository
-  # and resolves tenant context from the username field.
-  #
-  # Username format for password grant: "tenant:<slug>/<email>"
-  # Example: "tenant:volterra/admin@volterra.energy"
-  passwordConnector: meridian
   skipApprovalScreen: true
 
 staticClients:
   - id: meridian-service
     name: Meridian
-    # Dex requires exact redirect URI matching per the OAuth 2.0 / OIDC spec
-    # (no wildcard or pattern support). Each tenant subdomain must be listed
-    # explicitly. When onboarding a new tenant, add its callback URL here and
-    # restart Dex.
+    # Single BFF callback URL — the gateway handles all SSO callbacks centrally.
+    # Tenant context is preserved in the PKCE state parameter, so per-tenant
+    # redirect URIs are no longer needed.
     redirectURIs:
-      # Platform root
-      - "https://demo.meridianhub.cloud/callback"
-      # Tenant subdomains — add one entry per onboarded tenant
-      - "https://volterra.demo.meridianhub.cloud/callback"
-      # Local development — the frontend hardcodes client_id "meridian-service"
-      # in use-oauth-flow.ts, App.tsx, and callback.tsx, so localhost callbacks
-      # must be registered on this client for PKCE auth to work locally.
-      - "http://localhost:8090/callback"
-      - "http://localhost:3000/callback"
+      # Production BFF callback
+      - "https://demo.meridianhub.cloud/api/auth/callback"
+      # Local development
+      - "http://localhost:8090/api/auth/callback"
+      - "http://localhost:3000/api/auth/callback"
     public: true
 
 enablePasswordDB: false

--- a/services/api-gateway/auth_sso_handler.go
+++ b/services/api-gateway/auth_sso_handler.go
@@ -90,9 +90,22 @@ type SSOHandlerConfig struct {
 }
 
 // NewSSOHandler creates a handler for BFF SSO authentication via Dex.
+//
+// Security: The token exchange with Dex relies on server-to-server TLS for
+// integrity (ID token signature verification is skipped). In production, the
+// DexIssuerURL MUST use HTTPS. A warning is logged if HTTP is configured
+// (acceptable only in local development with trusted networks).
 func NewSSOHandler(cfg SSOHandlerConfig) (*SSOHandler, error) {
 	if cfg.DexIssuerURL == "" {
 		return nil, ErrSSODexIssuerRequired
+	}
+	issuerURL, err := url.Parse(cfg.DexIssuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("sso handler: invalid dex issuer URL: %w", err)
+	}
+	if issuerURL.Scheme != "https" && cfg.Logger != nil {
+		cfg.Logger.Warn("sso handler: Dex issuer URL is not HTTPS — token exchange is not protected by TLS",
+			"dex_issuer_url", cfg.DexIssuerURL)
 	}
 	if cfg.ClientID == "" {
 		return nil, ErrSSOClientIDRequired
@@ -171,7 +184,7 @@ func (h *SSOHandler) HandleInitiate(w http.ResponseWriter, r *http.Request) {
 
 	codeChallenge := computeCodeChallenge(codeVerifier)
 
-	returnURL := r.URL.Query().Get("return_url")
+	returnURL := sanitizeReturnURL(r.URL.Query().Get("return_url"))
 
 	stateKey, err := h.stateStore.Set(StateData{
 		CodeVerifier: codeVerifier,
@@ -186,8 +199,9 @@ func (h *SSOHandler) HandleInitiate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build Dex authorization URL.
-	authURL := h.dexIssuerURL + "/auth/" + connectorID
+	// Build Dex authorization URL. Path-escape the connector ID to prevent
+	// path traversal (e.g., "../../admin" → "%2E%2E%2Fadmin").
+	authURL := h.dexIssuerURL + "/auth/" + url.PathEscape(connectorID)
 	params := url.Values{
 		"client_id":             {h.clientID},
 		"redirect_uri":          {h.callbackURL},
@@ -434,6 +448,32 @@ func generateCodeVerifier() (string, error) {
 func computeCodeChallenge(verifier string) string {
 	h := sha256.Sum256([]byte(verifier))
 	return base64.RawURLEncoding.EncodeToString(h[:])
+}
+
+// sanitizeReturnURL validates that the return URL is a safe relative path.
+// This prevents open redirect attacks where an attacker crafts a return_url
+// pointing to an external domain to steal the JWT from the URL fragment.
+//
+// Only paths starting with "/" (relative to the origin) are accepted.
+// Absolute URLs, protocol-relative URLs (//evil.com), and malformed input
+// are rejected and replaced with "/".
+func sanitizeReturnURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "" || u.Host != "" {
+		return "/"
+	}
+	// Reject protocol-relative URLs like "//evil.com/steal"
+	if strings.HasPrefix(raw, "//") {
+		return "/"
+	}
+	// Must be a relative path starting with "/"
+	if !strings.HasPrefix(raw, "/") {
+		return "/"
+	}
+	return raw
 }
 
 // buildTokenRedirectURL appends the access token as a fragment to the return URL.

--- a/services/api-gateway/auth_sso_handler.go
+++ b/services/api-gateway/auth_sso_handler.go
@@ -45,6 +45,8 @@ var (
 	ErrSSOCallbackURLRequired = errors.New("sso handler: callback URL is required")
 	// ErrSSOCallbackURLInvalid is returned when the callback URL is not a valid absolute URL.
 	ErrSSOCallbackURLInvalid = errors.New("sso handler: callback URL must be a valid absolute URL")
+	// ErrSSODexIssuerInvalid is returned when the Dex issuer URL is not a valid absolute URL.
+	ErrSSODexIssuerInvalid = errors.New("sso handler: dex issuer URL must be an absolute URL with scheme and host")
 )
 
 // IdentityResolver resolves an identity by email without password validation.
@@ -98,8 +100,9 @@ func validateSSOConfig(cfg SSOHandlerConfig) error {
 	if cfg.DexIssuerURL == "" {
 		return ErrSSODexIssuerRequired
 	}
-	if _, err := url.Parse(cfg.DexIssuerURL); err != nil {
-		return fmt.Errorf("sso handler: invalid dex issuer URL: %w", err)
+	issuerURL, err := url.Parse(cfg.DexIssuerURL)
+	if err != nil || !issuerURL.IsAbs() || issuerURL.Host == "" {
+		return fmt.Errorf("%w: %q", ErrSSODexIssuerInvalid, cfg.DexIssuerURL)
 	}
 	if cfg.CallbackURL == "" {
 		return ErrSSOCallbackURLRequired
@@ -314,7 +317,6 @@ func (h *SSOHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		h.logger.ErrorContext(ctx, "sso: identity resolution error",
 			"tenant_id", stateData.TenantID,
-			"email", email,
 			"error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
 			"error": "failed to resolve identity",
@@ -323,8 +325,7 @@ func (h *SSOHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 	if !found {
 		h.logger.WarnContext(ctx, "sso: no matching identity for SSO email",
-			"tenant_id", stateData.TenantID,
-			"email", email)
+			"tenant_id", stateData.TenantID)
 		writeJSON(w, http.StatusForbidden, map[string]string{
 			"error": "no matching account for this SSO identity",
 		})

--- a/services/api-gateway/auth_sso_handler.go
+++ b/services/api-gateway/auth_sso_handler.go
@@ -1,0 +1,456 @@
+package gateway
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/meridianhub/meridian/services/identity/connector"
+	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+var (
+	// ErrSSODexIssuerRequired is returned when no Dex issuer URL is provided.
+	ErrSSODexIssuerRequired = errors.New("sso handler: dex issuer URL is required")
+	// ErrSSOClientIDRequired is returned when no OAuth client ID is provided.
+	ErrSSOClientIDRequired = errors.New("sso handler: client ID is required")
+	// ErrSSOSignerRequired is returned when no signer is provided.
+	ErrSSOSignerRequired = errors.New("sso handler: signer is required")
+	// ErrSSOResolverRequired is returned when no identity resolver is provided.
+	ErrSSOResolverRequired = errors.New("sso handler: identity resolver is required")
+	// ErrSSOLoggerRequired is returned when no logger is provided.
+	ErrSSOLoggerRequired = errors.New("sso handler: logger is required")
+	// ErrDexTokenError is returned when Dex's token endpoint returns an error response.
+	ErrDexTokenError = errors.New("dex token error")
+	// ErrDexTokenStatus is returned when Dex's token endpoint returns a non-200 status.
+	ErrDexTokenStatus = errors.New("dex token endpoint returned unexpected status")
+	// ErrDexEmptyIDToken is returned when Dex returns an empty id_token.
+	ErrDexEmptyIDToken = errors.New("dex returned empty id_token")
+	// ErrInvalidJWTFormat is returned when the ID token is not a valid JWT.
+	ErrInvalidJWTFormat = errors.New("invalid JWT format")
+	// ErrEmailClaimMissing is returned when the ID token has no email claim.
+	ErrEmailClaimMissing = errors.New("email claim missing from ID token")
+)
+
+// IdentityResolver resolves an identity by email without password validation.
+// This is a subset of the connector.Connector capabilities needed for SSO callback
+// processing — after Dex authenticates the user, we look them up by email to
+// populate Meridian-specific claims (roles, tenant membership).
+type IdentityResolver interface {
+	Resolve(ctx context.Context, email string) (connector.Identity, bool, error)
+}
+
+// SSOHandler handles the OAuth2/OIDC SSO flow via Dex as the BFF intermediary.
+// The frontend never talks to Dex directly — all authorization and token exchange
+// happens server-side through PKCE-protected endpoints.
+type SSOHandler struct {
+	dexIssuerURL string
+	clientID     string
+	callbackURL  string
+	stateStore   *StateStore
+	signer       *platformauth.JWTSigner
+	resolver     IdentityResolver
+	tokenTTL     time.Duration
+	logger       *slog.Logger
+	httpClient   *http.Client // pluggable for tests
+}
+
+// SSOHandlerConfig holds configuration for creating an SSOHandler.
+type SSOHandlerConfig struct {
+	// DexIssuerURL is the base URL for the Dex OIDC provider (e.g., "https://demo.meridianhub.cloud/dex").
+	DexIssuerURL string
+	// ClientID is the OAuth2 client ID registered with Dex.
+	ClientID string
+	// CallbackURL is the absolute URL for the BFF callback endpoint
+	// (e.g., "https://demo.meridianhub.cloud/api/auth/callback").
+	CallbackURL string
+	// Signer signs Meridian JWTs after SSO completes.
+	Signer *platformauth.JWTSigner
+	// Resolver looks up identities by email after SSO authentication.
+	Resolver IdentityResolver
+	// TokenTTL is the lifetime of issued JWTs. Defaults to 1 hour.
+	TokenTTL time.Duration
+	// Logger for structured logging. Required.
+	Logger *slog.Logger
+	// HTTPClient is used for the token exchange with Dex. Defaults to http.DefaultClient.
+	HTTPClient *http.Client
+	// StateStore is the PKCE state store. If nil, a default store is created.
+	StateStore *StateStore
+}
+
+// NewSSOHandler creates a handler for BFF SSO authentication via Dex.
+func NewSSOHandler(cfg SSOHandlerConfig) (*SSOHandler, error) {
+	if cfg.DexIssuerURL == "" {
+		return nil, ErrSSODexIssuerRequired
+	}
+	if cfg.ClientID == "" {
+		return nil, ErrSSOClientIDRequired
+	}
+	if cfg.Signer == nil {
+		return nil, ErrSSOSignerRequired
+	}
+	if cfg.Resolver == nil {
+		return nil, ErrSSOResolverRequired
+	}
+	if cfg.Logger == nil {
+		return nil, ErrSSOLoggerRequired
+	}
+	ttl := cfg.TokenTTL
+	if ttl == 0 {
+		ttl = time.Hour
+	}
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	stateStore := cfg.StateStore
+	if stateStore == nil {
+		stateStore = NewStateStore(defaultStateTTL)
+	}
+	return &SSOHandler{
+		dexIssuerURL: strings.TrimRight(cfg.DexIssuerURL, "/"),
+		clientID:     cfg.ClientID,
+		callbackURL:  cfg.CallbackURL,
+		stateStore:   stateStore,
+		signer:       cfg.Signer,
+		resolver:     cfg.Resolver,
+		tokenTTL:     ttl,
+		logger:       cfg.Logger,
+		httpClient:   httpClient,
+	}, nil
+}
+
+// HandleInitiate handles GET /api/auth/sso/{connector_id}.
+// It generates PKCE parameters, stores state, and redirects the user to Dex.
+func (h *SSOHandler) HandleInitiate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	connectorID := r.PathValue("connector_id")
+	if connectorID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "connector_id is required",
+		})
+		return
+	}
+
+	ctx := r.Context()
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		h.logger.WarnContext(ctx, "sso: no tenant in context for initiate",
+			"host", r.Host)
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "unable to determine tenant from request",
+		})
+		return
+	}
+
+	// Generate PKCE code verifier (43-128 chars of unreserved URI chars per RFC 7636).
+	codeVerifier, err := generateCodeVerifier()
+	if err != nil {
+		h.logger.ErrorContext(ctx, "sso: failed to generate code verifier", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error": "failed to initiate SSO",
+		})
+		return
+	}
+
+	codeChallenge := computeCodeChallenge(codeVerifier)
+
+	returnURL := r.URL.Query().Get("return_url")
+
+	stateKey, err := h.stateStore.Set(StateData{
+		CodeVerifier: codeVerifier,
+		TenantID:     tenantID,
+		ReturnURL:    returnURL,
+	})
+	if err != nil {
+		h.logger.ErrorContext(ctx, "sso: failed to store state", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error": "failed to initiate SSO",
+		})
+		return
+	}
+
+	// Build Dex authorization URL.
+	authURL := h.dexIssuerURL + "/auth/" + connectorID
+	params := url.Values{
+		"client_id":             {h.clientID},
+		"redirect_uri":          {h.callbackURL},
+		"response_type":         {"code"},
+		"scope":                 {"openid email profile"},
+		"state":                 {stateKey},
+		"code_challenge":        {codeChallenge},
+		"code_challenge_method": {"S256"},
+	}
+
+	redirectURL := authURL + "?" + params.Encode()
+
+	h.logger.InfoContext(ctx, "sso: initiating SSO flow",
+		"tenant_id", tenantID,
+		"connector_id", connectorID)
+
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// HandleCallback handles GET /api/auth/callback.
+// It validates the state, exchanges the authorization code for tokens with Dex,
+// resolves the user identity, and redirects with a Meridian JWT.
+func (h *SSOHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ctx := r.Context()
+
+	// Check for OAuth error from Dex.
+	if errParam := r.URL.Query().Get("error"); errParam != "" {
+		desc := r.URL.Query().Get("error_description")
+		h.logger.WarnContext(ctx, "sso: Dex returned error",
+			"error", errParam,
+			"description", desc)
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "SSO authentication failed: " + errParam,
+		})
+		return
+	}
+
+	stateKey := r.URL.Query().Get("state")
+	code := r.URL.Query().Get("code")
+
+	if stateKey == "" || code == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "missing state or code parameter",
+		})
+		return
+	}
+
+	// Retrieve and consume state (one-time use).
+	stateData, ok := h.stateStore.Get(stateKey)
+	if !ok {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "invalid or expired state parameter",
+		})
+		return
+	}
+
+	// Exchange authorization code for tokens with Dex.
+	idToken, err := h.exchangeCode(ctx, code, stateData.CodeVerifier)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "sso: token exchange failed",
+			"tenant_id", stateData.TenantID,
+			"error", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error": "SSO token exchange failed",
+		})
+		return
+	}
+
+	// Parse the email from Dex's ID token (we trust the claims since we got them
+	// directly from the token endpoint over a server-to-server connection).
+	email, err := extractEmailFromIDToken(idToken)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "sso: failed to extract email from ID token",
+			"tenant_id", stateData.TenantID,
+			"error", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error": "failed to process SSO identity",
+		})
+		return
+	}
+
+	// Resolve the identity in Meridian's identity store to get roles and tenant context.
+	tenantCtx := tenant.WithTenant(ctx, stateData.TenantID)
+	identity, found, err := h.resolver.Resolve(tenantCtx, email)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "sso: identity resolution error",
+			"tenant_id", stateData.TenantID,
+			"email", email,
+			"error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error": "failed to resolve identity",
+		})
+		return
+	}
+	if !found {
+		h.logger.WarnContext(ctx, "sso: no matching identity for SSO email",
+			"tenant_id", stateData.TenantID,
+			"email", email)
+		writeJSON(w, http.StatusForbidden, map[string]string{
+			"error": "no matching account for this SSO identity",
+		})
+		return
+	}
+
+	// Sign Meridian JWT.
+	claims := connector.BuildClaims(identity, stateData.TenantID)
+	tokenStr, err := h.signer.SignClaims(claims, h.tokenTTL)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "sso: failed to sign token",
+			"tenant_id", stateData.TenantID,
+			"identity_id", identity.UserID,
+			"error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error": "failed to create session",
+		})
+		return
+	}
+
+	h.logger.InfoContext(ctx, "sso: login successful",
+		"tenant_id", stateData.TenantID,
+		"identity_id", identity.UserID)
+
+	// Redirect to frontend with token.
+	returnURL := stateData.ReturnURL
+	if returnURL == "" {
+		returnURL = "/"
+	}
+	redirectURL, err := buildTokenRedirectURL(returnURL, tokenStr)
+	if err != nil {
+		// Fallback: return token as JSON if URL building fails.
+		writeJSON(w, http.StatusOK, loginResponse{
+			AccessToken: tokenStr,
+			TokenType:   "Bearer",
+			ExpiresIn:   int(h.tokenTTL.Seconds()),
+		})
+		return
+	}
+
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// dexTokenResponse is the JSON response from Dex's token endpoint.
+type dexTokenResponse struct {
+	IDToken     string `json:"id_token"`
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+	Error       string `json:"error,omitempty"`
+	ErrorDesc   string `json:"error_description,omitempty"`
+}
+
+// exchangeCode exchanges an authorization code for tokens at the Dex token endpoint.
+func (h *SSOHandler) exchangeCode(ctx context.Context, code, codeVerifier string) (string, error) {
+	tokenURL := h.dexIssuerURL + "/token"
+	data := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {h.clientID},
+		"code":          {code},
+		"redirect_uri":  {h.callbackURL},
+		"code_verifier": {codeVerifier},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token endpoint request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return "", fmt.Errorf("read token response: %w", err)
+	}
+
+	var tokenResp dexTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("parse token response: %w", err)
+	}
+
+	if tokenResp.Error != "" {
+		return "", fmt.Errorf("%w: %s: %s", ErrDexTokenError, tokenResp.Error, tokenResp.ErrorDesc)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%w: %d", ErrDexTokenStatus, resp.StatusCode)
+	}
+
+	if tokenResp.IDToken == "" {
+		return "", ErrDexEmptyIDToken
+	}
+
+	return tokenResp.IDToken, nil
+}
+
+// extractEmailFromIDToken decodes the JWT payload (without verification — we trust
+// the server-to-server response from Dex) and extracts the email claim.
+func extractEmailFromIDToken(idToken string) (string, error) {
+	parts := strings.Split(idToken, ".")
+	if len(parts) != 3 {
+		return "", ErrInvalidJWTFormat
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decode JWT payload: %w", err)
+	}
+
+	var claims struct {
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("parse JWT claims: %w", err)
+	}
+
+	if claims.Email == "" {
+		return "", ErrEmailClaimMissing
+	}
+
+	return claims.Email, nil
+}
+
+// generateCodeVerifier generates a PKCE code verifier per RFC 7636.
+// Returns a 43-character base64url-encoded random string (32 bytes of entropy).
+func generateCodeVerifier() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// computeCodeChallenge computes the S256 PKCE code challenge from a code verifier.
+func computeCodeChallenge(verifier string) string {
+	h := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(h[:])
+}
+
+// buildTokenRedirectURL appends the access token as a fragment to the return URL.
+// Using a fragment (#) ensures the token is not sent to the server in subsequent requests.
+func buildTokenRedirectURL(returnURL, token string) (string, error) {
+	u, err := url.Parse(returnURL)
+	if err != nil {
+		return "", err
+	}
+	u.Fragment = "access_token=" + token
+	return u.String(), nil
+}
+
+// WithSSOHandler sets the BFF SSO handler for the server.
+// When set, GET /api/auth/sso/{connector_id} and GET /api/auth/callback are registered.
+func WithSSOHandler(handler *SSOHandler) ServerOption {
+	return func(s *Server) {
+		s.ssoHandler = handler
+	}
+}

--- a/services/api-gateway/auth_sso_handler.go
+++ b/services/api-gateway/auth_sso_handler.go
@@ -41,6 +41,10 @@ var (
 	ErrInvalidJWTFormat = errors.New("invalid JWT format")
 	// ErrEmailClaimMissing is returned when the ID token has no email claim.
 	ErrEmailClaimMissing = errors.New("email claim missing from ID token")
+	// ErrSSOCallbackURLRequired is returned when no callback URL is provided.
+	ErrSSOCallbackURLRequired = errors.New("sso handler: callback URL is required")
+	// ErrSSOCallbackURLInvalid is returned when the callback URL is not a valid absolute URL.
+	ErrSSOCallbackURLInvalid = errors.New("sso handler: callback URL must be a valid absolute URL")
 )
 
 // IdentityResolver resolves an identity by email without password validation.
@@ -89,6 +93,36 @@ type SSOHandlerConfig struct {
 	StateStore *StateStore
 }
 
+// validateSSOConfig checks that all required fields are present and valid.
+func validateSSOConfig(cfg SSOHandlerConfig) error {
+	if cfg.DexIssuerURL == "" {
+		return ErrSSODexIssuerRequired
+	}
+	if _, err := url.Parse(cfg.DexIssuerURL); err != nil {
+		return fmt.Errorf("sso handler: invalid dex issuer URL: %w", err)
+	}
+	if cfg.CallbackURL == "" {
+		return ErrSSOCallbackURLRequired
+	}
+	callbackURL, err := url.Parse(cfg.CallbackURL)
+	if err != nil || !callbackURL.IsAbs() || callbackURL.Host == "" {
+		return fmt.Errorf("%w: %q", ErrSSOCallbackURLInvalid, cfg.CallbackURL)
+	}
+	if cfg.ClientID == "" {
+		return ErrSSOClientIDRequired
+	}
+	if cfg.Signer == nil {
+		return ErrSSOSignerRequired
+	}
+	if cfg.Resolver == nil {
+		return ErrSSOResolverRequired
+	}
+	if cfg.Logger == nil {
+		return ErrSSOLoggerRequired
+	}
+	return nil
+}
+
 // NewSSOHandler creates a handler for BFF SSO authentication via Dex.
 //
 // Security: The token exchange with Dex relies on server-to-server TLS for
@@ -96,28 +130,13 @@ type SSOHandlerConfig struct {
 // DexIssuerURL MUST use HTTPS. A warning is logged if HTTP is configured
 // (acceptable only in local development with trusted networks).
 func NewSSOHandler(cfg SSOHandlerConfig) (*SSOHandler, error) {
-	if cfg.DexIssuerURL == "" {
-		return nil, ErrSSODexIssuerRequired
+	if err := validateSSOConfig(cfg); err != nil {
+		return nil, err
 	}
-	issuerURL, err := url.Parse(cfg.DexIssuerURL)
-	if err != nil {
-		return nil, fmt.Errorf("sso handler: invalid dex issuer URL: %w", err)
-	}
-	if issuerURL.Scheme != "https" && cfg.Logger != nil {
+	issuerURL, _ := url.Parse(cfg.DexIssuerURL) // already validated
+	if issuerURL.Scheme != "https" {
 		cfg.Logger.Warn("sso handler: Dex issuer URL is not HTTPS — token exchange is not protected by TLS",
 			"dex_issuer_url", cfg.DexIssuerURL)
-	}
-	if cfg.ClientID == "" {
-		return nil, ErrSSOClientIDRequired
-	}
-	if cfg.Signer == nil {
-		return nil, ErrSSOSignerRequired
-	}
-	if cfg.Resolver == nil {
-		return nil, ErrSSOResolverRequired
-	}
-	if cfg.Logger == nil {
-		return nil, ErrSSOLoggerRequired
 	}
 	ttl := cfg.TokenTTL
 	if ttl == 0 {

--- a/services/api-gateway/auth_sso_handler_test.go
+++ b/services/api-gateway/auth_sso_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -444,6 +445,139 @@ func TestSSOHandler_CallbackTokenExchangeError(t *testing.T) {
 	handler.HandleCallback(rec, req)
 
 	assert.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+// --- Open redirect protection tests ---
+
+func TestSSOHandler_InitiateRejectsAbsoluteReturnURL(t *testing.T) {
+	// Verifies that an absolute URL in return_url is sanitized to "/" to prevent
+	// open redirect attacks that could steal the JWT from the URL fragment.
+	fakeEmail := "alice@volterra.energy"
+	idToken := buildFakeIDToken(t, fakeEmail)
+
+	dexServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id_token":     idToken,
+			"access_token": "at",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer dexServer.Close()
+
+	resolver := &stubResolver{
+		resolveFn: func(_ context.Context, _ string) (connector.Identity, bool, error) {
+			return connector.Identity{
+				UserID: "user-1", Email: fakeEmail, Groups: []string{},
+			}, true, nil
+		},
+	}
+
+	stateStore := gateway.NewStateStore(5 * time.Minute)
+	handler, err := gateway.NewSSOHandler(gateway.SSOHandlerConfig{
+		DexIssuerURL: dexServer.URL,
+		ClientID:     "meridian-service",
+		CallbackURL:  "https://demo.meridianhub.cloud/api/auth/callback",
+		Signer:       newSSOTestSigner(t),
+		Resolver:     resolver,
+		Logger:       slog.Default(),
+		HTTPClient:   dexServer.Client(),
+		StateStore:   stateStore,
+	})
+	require.NoError(t, err)
+
+	// Simulate initiate with malicious return_url
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/sso/google?return_url=https://evil.com/steal", nil)
+	tid, _ := tenant.NewTenantID("volterra")
+	req = req.WithContext(tenant.WithTenant(req.Context(), tid))
+	req.SetPathValue("connector_id", "google")
+
+	rec := httptest.NewRecorder()
+	handler.HandleInitiate(rec, req)
+
+	assert.Equal(t, http.StatusFound, rec.Code)
+
+	// Extract state from the redirect to Dex
+	location := rec.Header().Get("Location")
+	u, err := url.Parse(location)
+	require.NoError(t, err)
+	stateKey := u.Query().Get("state")
+	require.NotEmpty(t, stateKey)
+
+	// Now simulate the callback with that state
+	callbackReq := httptest.NewRequest(http.MethodGet, "/api/auth/callback?state="+stateKey+"&code=auth-code", nil)
+	callbackRec := httptest.NewRecorder()
+	handler.HandleCallback(callbackRec, callbackReq)
+
+	assert.Equal(t, http.StatusFound, callbackRec.Code)
+
+	// The redirect should go to "/" (sanitized), NOT "https://evil.com/steal"
+	callbackLocation := callbackRec.Header().Get("Location")
+	assert.NotContains(t, callbackLocation, "evil.com")
+	assert.True(t, strings.HasPrefix(callbackLocation, "/"), "redirect should be relative, got: %s", callbackLocation)
+}
+
+func TestSSOHandler_InitiateAcceptsRelativeReturnURL(t *testing.T) {
+	fakeEmail := "bob@volterra.energy"
+	idToken := buildFakeIDToken(t, fakeEmail)
+
+	dexServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id_token":     idToken,
+			"access_token": "at",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer dexServer.Close()
+
+	resolver := &stubResolver{
+		resolveFn: func(_ context.Context, _ string) (connector.Identity, bool, error) {
+			return connector.Identity{
+				UserID: "user-2", Email: fakeEmail, Groups: []string{},
+			}, true, nil
+		},
+	}
+
+	stateStore := gateway.NewStateStore(5 * time.Minute)
+	handler, err := gateway.NewSSOHandler(gateway.SSOHandlerConfig{
+		DexIssuerURL: dexServer.URL,
+		ClientID:     "meridian-service",
+		CallbackURL:  "https://demo.meridianhub.cloud/api/auth/callback",
+		Signer:       newSSOTestSigner(t),
+		Resolver:     resolver,
+		Logger:       slog.Default(),
+		HTTPClient:   dexServer.Client(),
+		StateStore:   stateStore,
+	})
+	require.NoError(t, err)
+
+	// Initiate with valid relative return_url
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/sso/google?return_url=/dashboard/overview", nil)
+	tid, _ := tenant.NewTenantID("volterra")
+	req = req.WithContext(tenant.WithTenant(req.Context(), tid))
+	req.SetPathValue("connector_id", "google")
+
+	rec := httptest.NewRecorder()
+	handler.HandleInitiate(rec, req)
+
+	assert.Equal(t, http.StatusFound, rec.Code)
+
+	location := rec.Header().Get("Location")
+	u, err := url.Parse(location)
+	require.NoError(t, err)
+	stateKey := u.Query().Get("state")
+
+	callbackReq := httptest.NewRequest(http.MethodGet, "/api/auth/callback?state="+stateKey+"&code=auth-code", nil)
+	callbackRec := httptest.NewRecorder()
+	handler.HandleCallback(callbackRec, callbackReq)
+
+	assert.Equal(t, http.StatusFound, callbackRec.Code)
+
+	callbackLocation := callbackRec.Header().Get("Location")
+	assert.Contains(t, callbackLocation, "/dashboard/overview")
 }
 
 // --- Helpers ---

--- a/services/api-gateway/auth_sso_handler_test.go
+++ b/services/api-gateway/auth_sso_handler_test.go
@@ -1,0 +1,461 @@
+package gateway_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	gateway "github.com/meridianhub/meridian/services/api-gateway"
+	"github.com/meridianhub/meridian/services/identity/connector"
+	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubResolver is a test implementation of gateway.IdentityResolver.
+type stubResolver struct {
+	resolveFn func(ctx context.Context, email string) (connector.Identity, bool, error)
+}
+
+func (s *stubResolver) Resolve(ctx context.Context, email string) (connector.Identity, bool, error) {
+	return s.resolveFn(ctx, email)
+}
+
+func newSSOTestSigner(t *testing.T) *platformauth.JWTSigner {
+	t.Helper()
+	signer, err := platformauth.NewJWTSigner(platformauth.JWTSignerConfig{
+		KeyID:  "test-sso-1",
+		Issuer: "test-meridian",
+	})
+	require.NoError(t, err)
+	return signer
+}
+
+func newTestSSOHandler(t *testing.T, dexURL string, resolver gateway.IdentityResolver, httpClient *http.Client) *gateway.SSOHandler {
+	t.Helper()
+	handler, err := gateway.NewSSOHandler(gateway.SSOHandlerConfig{
+		DexIssuerURL: dexURL,
+		ClientID:     "meridian-service",
+		CallbackURL:  "https://demo.meridianhub.cloud/api/auth/callback",
+		Signer:       newSSOTestSigner(t),
+		Resolver:     resolver,
+		Logger:       slog.Default(),
+		HTTPClient:   httpClient,
+		StateStore:   gateway.NewStateStore(5 * time.Minute),
+	})
+	require.NoError(t, err)
+	return handler
+}
+
+// --- Constructor validation tests ---
+
+func TestNewSSOHandler_Validation(t *testing.T) {
+	signer := newSSOTestSigner(t)
+	resolver := &stubResolver{}
+	logger := slog.Default()
+
+	tests := []struct {
+		name    string
+		cfg     gateway.SSOHandlerConfig
+		wantErr error
+	}{
+		{
+			name:    "missing dex issuer",
+			cfg:     gateway.SSOHandlerConfig{ClientID: "c", Signer: signer, Resolver: resolver, Logger: logger},
+			wantErr: gateway.ErrSSODexIssuerRequired,
+		},
+		{
+			name:    "missing client ID",
+			cfg:     gateway.SSOHandlerConfig{DexIssuerURL: "http://dex", Signer: signer, Resolver: resolver, Logger: logger},
+			wantErr: gateway.ErrSSOClientIDRequired,
+		},
+		{
+			name:    "missing signer",
+			cfg:     gateway.SSOHandlerConfig{DexIssuerURL: "http://dex", ClientID: "c", Resolver: resolver, Logger: logger},
+			wantErr: gateway.ErrSSOSignerRequired,
+		},
+		{
+			name:    "missing resolver",
+			cfg:     gateway.SSOHandlerConfig{DexIssuerURL: "http://dex", ClientID: "c", Signer: signer, Logger: logger},
+			wantErr: gateway.ErrSSOResolverRequired,
+		},
+		{
+			name:    "missing logger",
+			cfg:     gateway.SSOHandlerConfig{DexIssuerURL: "http://dex", ClientID: "c", Signer: signer, Resolver: resolver},
+			wantErr: gateway.ErrSSOLoggerRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := gateway.NewSSOHandler(tt.cfg)
+			assert.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+// --- HandleInitiate tests ---
+
+func TestSSOHandler_InitiateRedirectsToDex(t *testing.T) {
+	handler := newTestSSOHandler(t, "https://demo.meridianhub.cloud/dex", &stubResolver{}, nil)
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/auth/sso/{connector_id}", http.HandlerFunc(handler.HandleInitiate))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/sso/google?return_url=/dashboard", nil)
+	tid, _ := tenant.NewTenantID("volterra")
+	req = req.WithContext(tenant.WithTenant(req.Context(), tid))
+	req.SetPathValue("connector_id", "google")
+
+	rec := httptest.NewRecorder()
+	handler.HandleInitiate(rec, req)
+
+	assert.Equal(t, http.StatusFound, rec.Code)
+
+	location := rec.Header().Get("Location")
+	require.NotEmpty(t, location)
+
+	u, err := url.Parse(location)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https", u.Scheme)
+	assert.Equal(t, "demo.meridianhub.cloud", u.Host)
+	assert.Equal(t, "/dex/auth/google", u.Path)
+
+	params := u.Query()
+	assert.Equal(t, "meridian-service", params.Get("client_id"))
+	assert.Equal(t, "https://demo.meridianhub.cloud/api/auth/callback", params.Get("redirect_uri"))
+	assert.Equal(t, "code", params.Get("response_type"))
+	assert.Equal(t, "openid email profile", params.Get("scope"))
+	assert.Equal(t, "S256", params.Get("code_challenge_method"))
+	assert.NotEmpty(t, params.Get("state"))
+	assert.NotEmpty(t, params.Get("code_challenge"))
+}
+
+func TestSSOHandler_InitiateNoTenant(t *testing.T) {
+	handler := newTestSSOHandler(t, "http://dex:5556/dex", &stubResolver{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/sso/google", nil)
+	req.SetPathValue("connector_id", "google")
+	// No tenant context
+
+	rec := httptest.NewRecorder()
+	handler.HandleInitiate(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestSSOHandler_InitiateMissingConnectorID(t *testing.T) {
+	handler := newTestSSOHandler(t, "http://dex:5556/dex", &stubResolver{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/sso/", nil)
+	tid, _ := tenant.NewTenantID("volterra")
+	req = req.WithContext(tenant.WithTenant(req.Context(), tid))
+	// No path value set for connector_id
+
+	rec := httptest.NewRecorder()
+	handler.HandleInitiate(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestSSOHandler_InitiateMethodNotAllowed(t *testing.T) {
+	handler := newTestSSOHandler(t, "http://dex:5556/dex", &stubResolver{}, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/sso/google", nil)
+	req.SetPathValue("connector_id", "google")
+
+	rec := httptest.NewRecorder()
+	handler.HandleInitiate(rec, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+// --- HandleCallback tests ---
+
+func TestSSOHandler_CallbackSuccess(t *testing.T) {
+	// Set up a fake Dex token endpoint that returns a mock ID token.
+	fakeEmail := "alice@volterra.energy"
+	idToken := buildFakeIDToken(t, fakeEmail)
+
+	dexServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+
+		err := r.ParseForm()
+		require.NoError(t, err)
+		assert.Equal(t, "authorization_code", r.FormValue("grant_type"))
+		assert.Equal(t, "meridian-service", r.FormValue("client_id"))
+		assert.NotEmpty(t, r.FormValue("code_verifier"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id_token":     idToken,
+			"access_token": "dex-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer dexServer.Close()
+
+	resolver := &stubResolver{
+		resolveFn: func(_ context.Context, email string) (connector.Identity, bool, error) {
+			if email == fakeEmail {
+				return connector.Identity{
+					UserID:   "user-alice",
+					Username: "Alice",
+					Email:    fakeEmail,
+					Groups:   []string{"operator"},
+				}, true, nil
+			}
+			return connector.Identity{}, false, nil
+		},
+	}
+
+	stateStore := gateway.NewStateStore(5 * time.Minute)
+	signer := newSSOTestSigner(t)
+
+	handler, err := gateway.NewSSOHandler(gateway.SSOHandlerConfig{
+		DexIssuerURL: dexServer.URL,
+		ClientID:     "meridian-service",
+		CallbackURL:  "https://demo.meridianhub.cloud/api/auth/callback",
+		Signer:       signer,
+		Resolver:     resolver,
+		Logger:       slog.Default(),
+		HTTPClient:   dexServer.Client(),
+		StateStore:   stateStore,
+	})
+	require.NoError(t, err)
+
+	// Pre-populate state (simulating what HandleInitiate would do).
+	tid, _ := tenant.NewTenantID("volterra")
+	stateKey, err := stateStore.Set(gateway.StateData{
+		CodeVerifier: "test-verifier-abc",
+		TenantID:     tid,
+		ReturnURL:    "/dashboard",
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?state="+stateKey+"&code=auth-code-123", nil)
+	rec := httptest.NewRecorder()
+	handler.HandleCallback(rec, req)
+
+	assert.Equal(t, http.StatusFound, rec.Code)
+
+	location := rec.Header().Get("Location")
+	require.NotEmpty(t, location)
+	assert.Contains(t, location, "/dashboard")
+	assert.Contains(t, location, "access_token=")
+}
+
+func TestSSOHandler_CallbackInvalidState(t *testing.T) {
+	handler := newTestSSOHandler(t, "http://dex:5556/dex", &stubResolver{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?state=bogus&code=abc", nil)
+	rec := httptest.NewRecorder()
+	handler.HandleCallback(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var resp map[string]string
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	assert.Equal(t, "invalid or expired state parameter", resp["error"])
+}
+
+func TestSSOHandler_CallbackMissingParams(t *testing.T) {
+	handler := newTestSSOHandler(t, "http://dex:5556/dex", &stubResolver{}, nil)
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{"missing both", ""},
+		{"missing code", "?state=abc"},
+		{"missing state", "?code=abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/auth/callback"+tt.query, nil)
+			rec := httptest.NewRecorder()
+			handler.HandleCallback(rec, req)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+	}
+}
+
+func TestSSOHandler_CallbackDexError(t *testing.T) {
+	handler := newTestSSOHandler(t, "http://dex:5556/dex", &stubResolver{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?error=access_denied&error_description=user+denied", nil)
+	rec := httptest.NewRecorder()
+	handler.HandleCallback(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	var resp map[string]string
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	assert.Contains(t, resp["error"], "access_denied")
+}
+
+func TestSSOHandler_CallbackIdentityNotFound(t *testing.T) {
+	fakeEmail := "unknown@volterra.energy"
+	idToken := buildFakeIDToken(t, fakeEmail)
+
+	dexServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id_token":     idToken,
+			"access_token": "dex-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer dexServer.Close()
+
+	resolver := &stubResolver{
+		resolveFn: func(_ context.Context, _ string) (connector.Identity, bool, error) {
+			return connector.Identity{}, false, nil
+		},
+	}
+
+	stateStore := gateway.NewStateStore(5 * time.Minute)
+	handler, err := gateway.NewSSOHandler(gateway.SSOHandlerConfig{
+		DexIssuerURL: dexServer.URL,
+		ClientID:     "meridian-service",
+		CallbackURL:  "https://demo.meridianhub.cloud/api/auth/callback",
+		Signer:       newSSOTestSigner(t),
+		Resolver:     resolver,
+		Logger:       slog.Default(),
+		HTTPClient:   dexServer.Client(),
+		StateStore:   stateStore,
+	})
+	require.NoError(t, err)
+
+	tid, _ := tenant.NewTenantID("volterra")
+	stateKey, _ := stateStore.Set(gateway.StateData{
+		CodeVerifier: "verifier",
+		TenantID:     tid,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?state="+stateKey+"&code=code", nil)
+	rec := httptest.NewRecorder()
+	handler.HandleCallback(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestSSOHandler_CallbackResolverError(t *testing.T) {
+	fakeEmail := "err@volterra.energy"
+	idToken := buildFakeIDToken(t, fakeEmail)
+
+	dexServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id_token":     idToken,
+			"access_token": "at",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer dexServer.Close()
+
+	resolver := &stubResolver{
+		resolveFn: func(_ context.Context, _ string) (connector.Identity, bool, error) {
+			return connector.Identity{}, false, errors.New("db connection lost")
+		},
+	}
+
+	stateStore := gateway.NewStateStore(5 * time.Minute)
+	handler, err := gateway.NewSSOHandler(gateway.SSOHandlerConfig{
+		DexIssuerURL: dexServer.URL,
+		ClientID:     "meridian-service",
+		CallbackURL:  "https://demo.meridianhub.cloud/api/auth/callback",
+		Signer:       newSSOTestSigner(t),
+		Resolver:     resolver,
+		Logger:       slog.Default(),
+		HTTPClient:   dexServer.Client(),
+		StateStore:   stateStore,
+	})
+	require.NoError(t, err)
+
+	tid, _ := tenant.NewTenantID("volterra")
+	stateKey, _ := stateStore.Set(gateway.StateData{
+		CodeVerifier: "verifier",
+		TenantID:     tid,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?state="+stateKey+"&code=code", nil)
+	rec := httptest.NewRecorder()
+	handler.HandleCallback(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestSSOHandler_CallbackMethodNotAllowed(t *testing.T) {
+	handler := newTestSSOHandler(t, "http://dex:5556/dex", &stubResolver{}, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/callback?state=abc&code=xyz", nil)
+	rec := httptest.NewRecorder()
+	handler.HandleCallback(rec, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestSSOHandler_CallbackTokenExchangeError(t *testing.T) {
+	dexServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":             "invalid_grant",
+			"error_description": "code expired",
+		})
+	}))
+	defer dexServer.Close()
+
+	stateStore := gateway.NewStateStore(5 * time.Minute)
+	handler, err := gateway.NewSSOHandler(gateway.SSOHandlerConfig{
+		DexIssuerURL: dexServer.URL,
+		ClientID:     "meridian-service",
+		CallbackURL:  "https://demo.meridianhub.cloud/api/auth/callback",
+		Signer:       newSSOTestSigner(t),
+		Resolver:     &stubResolver{},
+		Logger:       slog.Default(),
+		HTTPClient:   dexServer.Client(),
+		StateStore:   stateStore,
+	})
+	require.NoError(t, err)
+
+	tid, _ := tenant.NewTenantID("volterra")
+	stateKey, _ := stateStore.Set(gateway.StateData{
+		CodeVerifier: "verifier",
+		TenantID:     tid,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?state="+stateKey+"&code=expired-code", nil)
+	rec := httptest.NewRecorder()
+	handler.HandleCallback(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+// --- Helpers ---
+
+// buildFakeIDToken creates a minimal unsigned JWT with an email claim.
+// The SSO handler only base64-decodes the payload (no signature verification)
+// since it trusts the server-to-server response from Dex.
+func buildFakeIDToken(t *testing.T, email string) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload, err := json.Marshal(map[string]string{"email": email})
+	require.NoError(t, err)
+	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
+	return header + "." + encodedPayload + ".fake-sig"
+}

--- a/services/api-gateway/auth_sso_handler_test.go
+++ b/services/api-gateway/auth_sso_handler_test.go
@@ -75,23 +75,33 @@ func TestNewSSOHandler_Validation(t *testing.T) {
 		},
 		{
 			name:    "missing client ID",
-			cfg:     gateway.SSOHandlerConfig{DexIssuerURL: "http://dex", Signer: signer, Resolver: resolver, Logger: logger},
+			cfg:     gateway.SSOHandlerConfig{DexIssuerURL: "http://dex", CallbackURL: "https://example.com/cb", Signer: signer, Resolver: resolver, Logger: logger},
 			wantErr: gateway.ErrSSOClientIDRequired,
 		},
 		{
 			name:    "missing signer",
-			cfg:     gateway.SSOHandlerConfig{DexIssuerURL: "http://dex", ClientID: "c", Resolver: resolver, Logger: logger},
+			cfg:     gateway.SSOHandlerConfig{DexIssuerURL: "http://dex", ClientID: "c", CallbackURL: "https://example.com/cb", Resolver: resolver, Logger: logger},
 			wantErr: gateway.ErrSSOSignerRequired,
 		},
 		{
 			name:    "missing resolver",
-			cfg:     gateway.SSOHandlerConfig{DexIssuerURL: "http://dex", ClientID: "c", Signer: signer, Logger: logger},
+			cfg:     gateway.SSOHandlerConfig{DexIssuerURL: "http://dex", ClientID: "c", CallbackURL: "https://example.com/cb", Signer: signer, Logger: logger},
 			wantErr: gateway.ErrSSOResolverRequired,
 		},
 		{
 			name:    "missing logger",
-			cfg:     gateway.SSOHandlerConfig{DexIssuerURL: "http://dex", ClientID: "c", Signer: signer, Resolver: resolver},
+			cfg:     gateway.SSOHandlerConfig{DexIssuerURL: "http://dex", ClientID: "c", CallbackURL: "https://example.com/callback", Signer: signer, Resolver: resolver},
 			wantErr: gateway.ErrSSOLoggerRequired,
+		},
+		{
+			name:    "missing callback URL",
+			cfg:     gateway.SSOHandlerConfig{DexIssuerURL: "http://dex", ClientID: "c", Signer: signer, Resolver: resolver, Logger: logger},
+			wantErr: gateway.ErrSSOCallbackURLRequired,
+		},
+		{
+			name:    "invalid callback URL (relative)",
+			cfg:     gateway.SSOHandlerConfig{DexIssuerURL: "http://dex", ClientID: "c", CallbackURL: "/api/auth/callback", Signer: signer, Resolver: resolver, Logger: logger},
+			wantErr: gateway.ErrSSOCallbackURLInvalid,
 		},
 	}
 

--- a/services/api-gateway/auth_sso_state.go
+++ b/services/api-gateway/auth_sso_state.go
@@ -25,6 +25,12 @@ type stateEntry struct {
 // StateStore is a thread-safe in-memory TTL cache for PKCE state parameters.
 // Entries are automatically removed on Get (one-time use) and lazily purged
 // on Set when more than maxLazyPurge expired entries have accumulated.
+//
+// Limitation: In-memory storage only works with a single gateway replica. With
+// horizontal scaling, the initiate and callback requests may hit different
+// replicas. For multi-replica deployments, swap this for a shared store (Redis,
+// CockroachDB, or signed encrypted state tokens). The injectable StateStore
+// design makes this straightforward.
 type StateStore struct {
 	mu    sync.Mutex
 	items map[string]stateEntry

--- a/services/api-gateway/auth_sso_state.go
+++ b/services/api-gateway/auth_sso_state.go
@@ -3,11 +3,17 @@ package gateway
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"sync"
 	"time"
 
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
+
+// ErrStateStoreFull is returned when the state store has reached its maximum
+// capacity and cannot accept new entries. This prevents memory exhaustion
+// from unauthenticated SSO initiation requests.
+var ErrStateStoreFull = errors.New("state store: capacity limit reached")
 
 // StateData holds the PKCE and tenant context for an in-flight SSO authorization.
 type StateData struct {
@@ -41,7 +47,8 @@ type StateStore struct {
 const (
 	defaultStateTTL = 5 * time.Minute
 	maxLazyPurge    = 100
-	stateKeyBytes   = 16 // 128-bit random state keys
+	maxStoreEntries = 10000 // hard cap to prevent memory exhaustion from unauthenticated requests
+	stateKeyBytes   = 16    // 128-bit random state keys
 )
 
 // NewStateStore creates a StateStore with the given TTL.
@@ -67,14 +74,20 @@ func (s *StateStore) Set(data StateData) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// Purge expired entries if approaching capacity to make room.
+	if len(s.items) >= maxLazyPurge {
+		s.purgeExpiredLocked()
+	}
+
+	// Hard cap: reject new entries if the store is full after purging.
+	// This prevents memory exhaustion from unauthenticated SSO initiation flood.
+	if len(s.items) >= maxStoreEntries {
+		return "", ErrStateStoreFull
+	}
+
 	s.items[key] = stateEntry{
 		data:      data,
 		expiresAt: s.now().Add(s.ttl),
-	}
-
-	// Lazy purge: if too many entries, sweep expired ones.
-	if len(s.items) > maxLazyPurge {
-		s.purgeExpiredLocked()
 	}
 
 	return key, nil

--- a/services/api-gateway/auth_sso_state.go
+++ b/services/api-gateway/auth_sso_state.go
@@ -1,0 +1,120 @@
+package gateway
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// StateData holds the PKCE and tenant context for an in-flight SSO authorization.
+type StateData struct {
+	CodeVerifier string
+	TenantID     tenant.TenantID
+	ReturnURL    string
+}
+
+// stateEntry pairs data with an expiry time.
+type stateEntry struct {
+	data      StateData
+	expiresAt time.Time
+}
+
+// StateStore is a thread-safe in-memory TTL cache for PKCE state parameters.
+// Entries are automatically removed on Get (one-time use) and lazily purged
+// on Set when more than maxLazyPurge expired entries have accumulated.
+type StateStore struct {
+	mu    sync.Mutex
+	items map[string]stateEntry
+	ttl   time.Duration
+	now   func() time.Time // pluggable clock for tests
+}
+
+const (
+	defaultStateTTL = 5 * time.Minute
+	maxLazyPurge    = 100
+	stateKeyBytes   = 16 // 128-bit random state keys
+)
+
+// NewStateStore creates a StateStore with the given TTL.
+// If ttl is zero, defaults to 5 minutes.
+func NewStateStore(ttl time.Duration) *StateStore {
+	if ttl == 0 {
+		ttl = defaultStateTTL
+	}
+	return &StateStore{
+		items: make(map[string]stateEntry),
+		ttl:   ttl,
+		now:   time.Now,
+	}
+}
+
+// Set stores state data under a new random key and returns the key.
+func (s *StateStore) Set(data StateData) (string, error) {
+	key, err := generateRandomHex(stateKeyBytes)
+	if err != nil {
+		return "", err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.items[key] = stateEntry{
+		data:      data,
+		expiresAt: s.now().Add(s.ttl),
+	}
+
+	// Lazy purge: if too many entries, sweep expired ones.
+	if len(s.items) > maxLazyPurge {
+		s.purgeExpiredLocked()
+	}
+
+	return key, nil
+}
+
+// Get retrieves and deletes state data for the given key (one-time use).
+// Returns the data and true if found and not expired, or zero value and false otherwise.
+func (s *StateStore) Get(key string) (StateData, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.items[key]
+	if !ok {
+		return StateData{}, false
+	}
+	delete(s.items, key)
+
+	if s.now().After(entry.expiresAt) {
+		return StateData{}, false
+	}
+
+	return entry.data, true
+}
+
+// Len returns the number of entries (including expired, not yet purged).
+func (s *StateStore) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.items)
+}
+
+// purgeExpiredLocked removes all expired entries. Caller must hold s.mu.
+func (s *StateStore) purgeExpiredLocked() {
+	now := s.now()
+	for k, v := range s.items {
+		if now.After(v.expiresAt) {
+			delete(s.items, k)
+		}
+	}
+}
+
+// generateRandomHex returns a hex-encoded random string of n bytes.
+func generateRandomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/services/api-gateway/auth_sso_state_test.go
+++ b/services/api-gateway/auth_sso_state_test.go
@@ -1,0 +1,119 @@
+package gateway_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	gateway "github.com/meridianhub/meridian/services/api-gateway"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateStore_SetAndGet(t *testing.T) {
+	store := gateway.NewStateStore(5 * time.Minute)
+	tid, _ := tenant.NewTenantID("volterra")
+
+	data := gateway.StateData{
+		CodeVerifier: "test-verifier",
+		TenantID:     tid,
+		ReturnURL:    "https://volterra.demo.meridianhub.cloud/dashboard",
+	}
+
+	key, err := store.Set(data)
+	require.NoError(t, err)
+	assert.NotEmpty(t, key)
+
+	got, ok := store.Get(key)
+	assert.True(t, ok)
+	assert.Equal(t, data.CodeVerifier, got.CodeVerifier)
+	assert.Equal(t, data.TenantID, got.TenantID)
+	assert.Equal(t, data.ReturnURL, got.ReturnURL)
+}
+
+func TestStateStore_GetDeletesEntry(t *testing.T) {
+	store := gateway.NewStateStore(5 * time.Minute)
+	tid, _ := tenant.NewTenantID("volterra")
+
+	key, err := store.Set(gateway.StateData{
+		CodeVerifier: "v",
+		TenantID:     tid,
+	})
+	require.NoError(t, err)
+
+	_, ok := store.Get(key)
+	assert.True(t, ok)
+
+	// Second get returns false (one-time use)
+	_, ok = store.Get(key)
+	assert.False(t, ok)
+}
+
+func TestStateStore_GetUnknownKey(t *testing.T) {
+	store := gateway.NewStateStore(5 * time.Minute)
+
+	_, ok := store.Get("nonexistent")
+	assert.False(t, ok)
+}
+
+func TestStateStore_ExpiredEntry(t *testing.T) {
+	store := gateway.NewStateStore(1 * time.Millisecond)
+	tid, _ := tenant.NewTenantID("volterra")
+
+	key, err := store.Set(gateway.StateData{
+		CodeVerifier: "v",
+		TenantID:     tid,
+	})
+	require.NoError(t, err)
+
+	time.Sleep(5 * time.Millisecond)
+
+	_, ok := store.Get(key)
+	assert.False(t, ok, "expired entry should not be returned")
+}
+
+func TestStateStore_ConcurrentAccess(t *testing.T) {
+	store := gateway.NewStateStore(5 * time.Minute)
+	tid, _ := tenant.NewTenantID("volterra")
+
+	var wg sync.WaitGroup
+	keys := make(chan string, 50)
+
+	// Concurrent writes
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			key, err := store.Set(gateway.StateData{
+				CodeVerifier: "v",
+				TenantID:     tid,
+			})
+			require.NoError(t, err)
+			keys <- key
+		}()
+	}
+
+	wg.Wait()
+	close(keys)
+
+	// All keys should be retrievable exactly once
+	for key := range keys {
+		_, ok := store.Get(key)
+		assert.True(t, ok)
+	}
+}
+
+func TestStateStore_DefaultTTL(t *testing.T) {
+	store := gateway.NewStateStore(0) // should default to 5 min
+	tid, _ := tenant.NewTenantID("volterra")
+
+	key, err := store.Set(gateway.StateData{
+		CodeVerifier: "v",
+		TenantID:     tid,
+	})
+	require.NoError(t, err)
+
+	_, ok := store.Get(key)
+	assert.True(t, ok, "entry should still be valid with default TTL")
+}

--- a/services/api-gateway/server.go
+++ b/services/api-gateway/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	versionInfo           *VersionInfo
 	providersConfig       ProvidersConfig
 	authHandler           *AuthHandler
+	ssoHandler            *SSOHandler
 }
 
 // ServerOption is a functional option for configuring the server.
@@ -173,6 +174,22 @@ func (s *Server) registerRoutes() {
 		if s.authHandler.signer != nil {
 			s.mux.HandleFunc("GET /api/auth/jwks", s.authHandler.signer.ServeJWKS())
 		}
+	}
+
+	// BFF SSO endpoints - tenant resolution but NO auth middleware (pre-auth).
+	// GET /api/auth/sso/{connector_id}: initiates PKCE flow, redirects to Dex.
+	// GET /api/auth/callback: handles Dex callback, exchanges code, issues Meridian JWT.
+	if s.ssoHandler != nil {
+		initiateHandler := http.Handler(http.HandlerFunc(s.ssoHandler.HandleInitiate))
+		if s.tenantResolver != nil {
+			initiateHandler = s.tenantResolver.Handler(initiateHandler)
+		}
+		s.mux.Handle("GET /api/auth/sso/{connector_id}", initiateHandler)
+
+		// Callback does NOT use tenant resolver — tenant context is recovered from the
+		// state parameter stored during initiation. The callback URL is a single global
+		// endpoint (no tenant subdomain required).
+		s.mux.Handle("GET /api/auth/callback", http.HandlerFunc(s.ssoHandler.HandleCallback))
 	}
 
 	// API routes - with auth and tenant middleware chain.


### PR DESCRIPTION
## Summary

Implements tasks 1598-auth-multi-tenant.8 (SSO BFF Handlers) and 1598-auth-multi-tenant.9 (Dex Config Update) as part of the multi-tenant auth epic.

- Add server-side SSO authentication flow via Dex as BFF intermediary with PKCE protection
- Update Dex configuration for SSO-only mode (remove password grant, use single BFF callback)

## Changes

### Task 8: SSO BFF Handlers

**New files:**
- `services/api-gateway/auth_sso_handler.go` - SSO handler with two endpoints:
  - `GET /api/auth/sso/{connector_id}` - Initiates PKCE flow, generates code verifier/challenge, stores state with tenant context, redirects to Dex
  - `GET /api/auth/callback` - Validates state (one-time use), exchanges authorization code with PKCE verifier, parses Dex ID token for email, resolves identity via `IdentityResolver`, signs Meridian JWT, redirects frontend with token in URL fragment
- `services/api-gateway/auth_sso_state.go` - Thread-safe in-memory StateStore with TTL for PKCE state parameters, lazy expiry purge
- `services/api-gateway/auth_sso_handler_test.go` - 12 tests covering happy path and all error cases (invalid state, missing params, Dex errors, identity not found, resolver errors, method not allowed, token exchange failures)
- `services/api-gateway/auth_sso_state_test.go` - 6 tests for StateStore (set/get, one-time use, unknown key, expiry, concurrent access, default TTL)
- `services/api-gateway/server.go` - Register SSO routes with tenant resolver on initiate, no middleware on callback (tenant recovered from state)

**Design decisions:**
- `IdentityResolver` interface decouples SSO handler from concrete connector (testable, follows existing `PasswordConnector` pattern)
- Token delivered via URL fragment (`#access_token=...`) so it is not sent to server in subsequent requests
- Callback endpoint has no tenant middleware -- tenant context is recovered from the PKCE state stored during initiation

### Task 9: Dex Config Update

- Remove `password` from `grantTypes` (password auth handled by BFF directly)
- Remove `passwordConnector: meridian` directive
- Replace per-tenant/per-frontend redirect URIs with single BFF callback: `/api/auth/callback`
- Update header documentation to describe new SSO-only architecture

## Test Plan

- [x] All 18 new unit tests pass (`go test ./services/api-gateway/ -run "TestSSO|TestStateStore"`)
- [x] Full gateway test suite passes (`go test ./services/api-gateway/`)
- [x] Pre-commit hooks pass (gitleaks, gofumpt, golangci-lint)
- [ ] CI pipeline passes

## Related

- Epic: https://github.com/meridianhub/meridian/issues/1598
- Task Master: 1598-auth-multi-tenant.8, 1598-auth-multi-tenant.9