### PR TITLE
Add deprovision confirmation and filter deprovisioned tenants

### DIFF
--- a/frontend/src/components/layout/tenant-selector.test.tsx
+++ b/frontend/src/components/layout/tenant-selector.test.tsx
@@ -224,6 +224,39 @@ describe('TenantSelector', () => {
         expect(selectedItem).toHaveAttribute('aria-selected', 'true')
       })
     })
+
+    it('excludes deprovisioned tenants from the dropdown', async () => {
+      const user = userEvent.setup()
+      const tenantsWithDeprovisioned = [
+        ...mockTenants,
+        {
+          tenantId: 'decom_corp',
+          slug: 'decom-corp',
+          displayName: 'Decommissioned Corp',
+          status: 3, // DEPROVISIONED = 3
+          settlementAsset: 'GBP',
+          subdomain: '',
+          partyId: '',
+          errorMessage: '',
+          version: 1,
+          createdAt: undefined,
+          deprovisionedAt: undefined,
+          metadata: undefined,
+        },
+      ]
+      setupMocks({ tenants: tenantsWithDeprovisioned })
+      renderWithProviders(<TenantSelector />, { initialToken: token })
+
+      const button = screen.getByRole('combobox')
+      await user.click(button)
+
+      await waitFor(() => {
+        expect(screen.getByText('Acme Bank')).toBeInTheDocument()
+        expect(screen.getByText('Beta Financial')).toBeInTheDocument()
+        expect(screen.getByText('Gamma Energy')).toBeInTheDocument()
+        expect(screen.queryByText('Decommissioned Corp')).not.toBeInTheDocument()
+      })
+    })
   })
 
   describe('search', () => {

--- a/frontend/src/components/layout/tenant-selector.tsx
+++ b/frontend/src/components/layout/tenant-selector.tsx
@@ -17,14 +17,17 @@ import {
 } from '@/components/ui/popover'
 import { useTenants } from '@/hooks/use-tenants'
 import { useTenantContext } from '@/contexts/tenant-context'
+import { TenantStatus } from '@/api/gen/meridian/tenant/v1/tenant_pb'
 
 export function TenantSelector() {
   const [open, setOpen] = React.useState(false)
   const { data: tenants, isLoading } = useTenants()
   const { tenantSlug, currentTenant: contextTenant, switchTenant } = useTenantContext()
 
+  const activeTenants = tenants?.filter((t) => t.status !== TenantStatus.DEPROVISIONED)
+
   // Use the loaded tenant data first, fall back to context (e.g., on error or partial data)
-  const resolvedTenant = tenants?.find((t) => t.slug === tenantSlug) ?? contextTenant
+  const resolvedTenant = activeTenants?.find((t) => t.slug === tenantSlug) ?? contextTenant
 
   if (isLoading) {
     return (
@@ -67,7 +70,7 @@ export function TenantSelector() {
             >
               <CommandEmpty>No tenants found.</CommandEmpty>
               <CommandGroup>
-                {tenants?.map((tenant) => (
+                {activeTenants?.map((tenant) => (
                   <CommandItem
                     key={tenant.tenantId}
                     value={`${tenant.displayName} ${tenant.slug}`}

--- a/frontend/src/components/layout/tenant-selector.tsx
+++ b/frontend/src/components/layout/tenant-selector.tsx
@@ -26,8 +26,10 @@ export function TenantSelector() {
 
   const activeTenants = tenants?.filter((t) => t.status !== TenantStatus.DEPROVISIONED)
 
-  // Use the loaded tenant data first, fall back to context (e.g., on error or partial data)
-  const resolvedTenant = activeTenants?.find((t) => t.slug === tenantSlug) ?? contextTenant
+  // Use loaded tenant data when available; only fall back to context while loading
+  const resolvedTenant = tenants
+    ? activeTenants?.find((t) => t.slug === tenantSlug)
+    : contextTenant
 
   if (isLoading) {
     return (

--- a/frontend/src/features/tenants/pages/[tenantId].tsx
+++ b/frontend/src/features/tenants/pages/[tenantId].tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { CheckCircle2, Circle, Loader2, XCircle } from 'lucide-react'
 import { Breadcrumbs } from '@/shared'
@@ -5,7 +6,16 @@ import { StatusBadge } from '@/shared/status-badge'
 import { TimeDisplay } from '@/shared/time-display'
 import { DetailSkeleton } from '@/shared/detail-skeleton'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog'
 import { useTenant, useTenantProvisioningStatus, useUpdateTenantStatus } from '@/hooks/use-tenant'
 import {
   TenantStatus,
@@ -94,6 +104,14 @@ export function TenantDetailPage() {
     tenant?.status,
   )
   const updateStatus = useUpdateTenantStatus(tenantId ?? '')
+  const [deprovisionDialogOpen, setDeprovisionDialogOpen] = useState(false)
+  const [slugConfirmation, setSlugConfirmation] = useState('')
+
+  useEffect(() => {
+    if (!deprovisionDialogOpen) {
+      setSlugConfirmation('')
+    }
+  }, [deprovisionDialogOpen])
 
   if (tenantLoading) {
     return <DetailSkeleton fieldCount={4} tabCount={0} showBackNav={true} />
@@ -120,7 +138,9 @@ export function TenantDetailPage() {
   }
 
   function handleDeprovision() {
-    void updateStatus.mutateAsync(TenantStatus.DEPROVISIONED)
+    void updateStatus.mutateAsync(TenantStatus.DEPROVISIONED).then(() => {
+      setDeprovisionDialogOpen(false)
+    })
   }
 
   return (
@@ -164,7 +184,7 @@ export function TenantDetailPage() {
             <Button
               variant="destructive"
               size="sm"
-              onClick={handleDeprovision}
+              onClick={() => setDeprovisionDialogOpen(true)}
               disabled={updateStatus.isPending}
             >
               Deprovision
@@ -247,6 +267,44 @@ export function TenantDetailPage() {
           )}
         </CardContent>
       </Card>
+
+      {/* Deprovision Confirmation Dialog */}
+      <Dialog open={deprovisionDialogOpen} onOpenChange={setDeprovisionDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Deprovision Tenant</DialogTitle>
+            <DialogDescription>
+              This will mark <span className="font-medium">{tenant.displayName}</span> as
+              deprovisioned. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 py-2">
+            <label htmlFor="slug-confirmation" className="text-sm">
+              To confirm, type{' '}
+              <span className="font-mono font-medium">{tenant.slug}</span> below:
+            </label>
+            <Input
+              id="slug-confirmation"
+              value={slugConfirmation}
+              onChange={(e) => setSlugConfirmation(e.target.value)}
+              placeholder={tenant.slug}
+              autoComplete="off"
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeprovisionDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDeprovision}
+              disabled={slugConfirmation !== tenant.slug || updateStatus.isPending}
+            >
+              {updateStatus.isPending ? 'Deprovisioning...' : 'Confirm Deprovision'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/frontend/src/features/tenants/pages/[tenantId].tsx
+++ b/frontend/src/features/tenants/pages/[tenantId].tsx
@@ -139,6 +139,7 @@ export function TenantDetailPage() {
 
   function handleDeprovision() {
     void updateStatus.mutateAsync(TenantStatus.DEPROVISIONED).then(() => {
+      setSlugConfirmation('')
       setDeprovisionDialogOpen(false)
     })
   }

--- a/frontend/src/features/tenants/pages/[tenantId].tsx
+++ b/frontend/src/features/tenants/pages/[tenantId].tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { CheckCircle2, Circle, Loader2, XCircle } from 'lucide-react'
 import { Breadcrumbs } from '@/shared'
@@ -107,11 +107,11 @@ export function TenantDetailPage() {
   const [deprovisionDialogOpen, setDeprovisionDialogOpen] = useState(false)
   const [slugConfirmation, setSlugConfirmation] = useState('')
 
-  useEffect(() => {
-    if (!deprovisionDialogOpen) {
-      setSlugConfirmation('')
-    }
-  }, [deprovisionDialogOpen])
+  function handleDeprovisionDialogChange(open: boolean) {
+    if (updateStatus.isPending) return
+    setDeprovisionDialogOpen(open)
+    if (!open) setSlugConfirmation('')
+  }
 
   if (tenantLoading) {
     return <DetailSkeleton fieldCount={4} tabCount={0} showBackNav={true} />
@@ -269,7 +269,7 @@ export function TenantDetailPage() {
       </Card>
 
       {/* Deprovision Confirmation Dialog */}
-      <Dialog open={deprovisionDialogOpen} onOpenChange={setDeprovisionDialogOpen}>
+      <Dialog open={deprovisionDialogOpen} onOpenChange={handleDeprovisionDialogChange}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Deprovision Tenant</DialogTitle>
@@ -289,10 +289,15 @@ export function TenantDetailPage() {
               onChange={(e) => setSlugConfirmation(e.target.value)}
               placeholder={tenant.slug}
               autoComplete="off"
+              disabled={updateStatus.isPending}
             />
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setDeprovisionDialogOpen(false)}>
+            <Button
+              variant="outline"
+              onClick={() => handleDeprovisionDialogChange(false)}
+              disabled={updateStatus.isPending}
+            >
               Cancel
             </Button>
             <Button

--- a/frontend/src/features/tenants/pages/tenant-detail-page.test.tsx
+++ b/frontend/src/features/tenants/pages/tenant-detail-page.test.tsx
@@ -428,6 +428,29 @@ describe('TenantDetailPage - deprovision confirmation', () => {
       )
     })
   })
+
+  it('resets slug confirmation when dialog is closed and reopened', async () => {
+    vi.mocked(useApiClients).mockReturnValue(
+      makeTenantApi() as unknown as ReturnType<typeof useApiClients>,
+    )
+
+    renderTenantDetailPage('acme_corp', createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /deprovision/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /deprovision/i }))
+    await userEvent.type(screen.getByPlaceholderText('acme-corp'), 'acme-corp')
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+    await userEvent.click(screen.getByRole('button', { name: /deprovision/i }))
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('acme-corp')).toHaveValue('')
+      expect(screen.getByRole('button', { name: /confirm deprovision/i })).toBeDisabled()
+    })
+  })
 })
 
 describe('TenantDetailPage - back navigation', () => {

--- a/frontend/src/features/tenants/pages/tenant-detail-page.test.tsx
+++ b/frontend/src/features/tenants/pages/tenant-detail-page.test.tsx
@@ -355,6 +355,81 @@ describe('TenantDetailPage - lifecycle actions', () => {
   })
 })
 
+describe('TenantDetailPage - deprovision confirmation', () => {
+  it('opens confirmation dialog when Deprovision is clicked', async () => {
+    vi.mocked(useApiClients).mockReturnValue(
+      makeTenantApi() as unknown as ReturnType<typeof useApiClients>,
+    )
+
+    renderTenantDetailPage('acme_corp', createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /deprovision/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /deprovision/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/This action cannot be undone/i)).toBeInTheDocument()
+    })
+  })
+
+  it('disables confirm button until slug is typed correctly', async () => {
+    vi.mocked(useApiClients).mockReturnValue(
+      makeTenantApi() as unknown as ReturnType<typeof useApiClients>,
+    )
+
+    renderTenantDetailPage('acme_corp', createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /deprovision/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /deprovision/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /confirm deprovision/i })).toBeDisabled()
+    })
+
+    await userEvent.type(screen.getByPlaceholderText('acme-corp'), 'acme-corp')
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /confirm deprovision/i })).toBeEnabled()
+    })
+  })
+
+  it('calls UpdateTenantStatus with DEPROVISIONED after slug confirmation', async () => {
+    const updateStatusMock = vi.fn().mockResolvedValue({ tenant: { ...mockActiveTenant, status: 3 } })
+
+    vi.mocked(useApiClients).mockReturnValue({
+      tenant: {
+        retrieveTenant: vi.fn().mockResolvedValue({ tenant: mockActiveTenant }),
+        getTenantProvisioningStatus: vi.fn().mockResolvedValue(mockProvisioningStatus),
+        updateTenantStatus: updateStatusMock,
+        listTenants: vi.fn(),
+        initiateTenant: vi.fn(),
+        reconcileMigrations: vi.fn(),
+      },
+    } as unknown as ReturnType<typeof useApiClients>)
+
+    renderTenantDetailPage('acme_corp', createPlatformAdminToken())
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /deprovision/i })).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /deprovision/i }))
+    await userEvent.type(screen.getByPlaceholderText('acme-corp'), 'acme-corp')
+    await userEvent.click(screen.getByRole('button', { name: /confirm deprovision/i }))
+
+    await waitFor(() => {
+      expect(updateStatusMock).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: 'acme_corp', status: 3 }), // DEPROVISIONED = 3
+      )
+    })
+  })
+})
+
 describe('TenantDetailPage - back navigation', () => {
   beforeEach(() => {
     vi.mocked(useApiClients).mockReturnValue(


### PR DESCRIPTION
## Summary

- Add confirmation dialog to tenant deprovision action requiring the user to type the tenant slug (GitHub repo-deletion pattern) before confirming
- Filter deprovisioned tenants from the tenant selector dropdown so they no longer appear as selectable options
- Add 3 new tests for the deprovision confirmation flow

## Changes

**`frontend/src/features/tenants/pages/[tenantId].tsx`**
- Deprovision button now opens a confirmation dialog instead of firing immediately
- Dialog requires typing the tenant slug to enable the confirm button
- Dialog resets state on close

**`frontend/src/components/layout/tenant-selector.tsx`**
- Filter out tenants with `DEPROVISIONED` status from the dropdown list

**`frontend/src/features/tenants/pages/tenant-detail-page.test.tsx`**
- Test: opens confirmation dialog on deprovision click
- Test: confirm button disabled until slug typed correctly
- Test: calls UpdateTenantStatus with DEPROVISIONED after slug confirmation

## Test plan

- [x] All 18 tenant detail page tests pass (including 3 new)
- [x] All 19 tenant selector tests pass
- [ ] Manual: verify deprovision dialog requires slug input on demo
- [ ] Manual: verify deprovisioned tenants no longer appear in selector