### PR TITLE
feat: normalize JWT role names to lowercase

### DIFF
--- a/services/identity/connector/claims.go
+++ b/services/identity/connector/claims.go
@@ -1,6 +1,10 @@
 package connector
 
-import "github.com/meridianhub/meridian/shared/platform/tenant"
+import (
+	"strings"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
 
 // BuildClaims constructs the JWT custom claims map for an authenticated identity.
 // The map is consumed by Dex's ID-token builder when enriching tokens with
@@ -19,9 +23,13 @@ func BuildClaims(identity Identity, tenantID tenant.TenantID) map[string]interfa
 		name = identity.Email
 	}
 
-	roles := identity.Groups
-	if roles == nil {
-		roles = []string{}
+	rawRoles := identity.Groups
+	if rawRoles == nil {
+		rawRoles = []string{}
+	}
+	roles := make([]string, len(rawRoles))
+	for i, r := range rawRoles {
+		roles[i] = strings.ToLower(r)
 	}
 
 	return map[string]interface{}{

--- a/services/identity/connector/claims_test.go
+++ b/services/identity/connector/claims_test.go
@@ -26,8 +26,8 @@ func TestBuildClaims_FullIdentity(t *testing.T) {
 	assert.Equal(t, "alice@example.com", claims["email"])
 	assert.Equal(t, "Alice", claims["name"])
 	assert.Equal(t, "volterra", claims["x-tenant-id"])
-	assert.Equal(t, []string{"ADMIN", "OPERATOR"}, claims["roles"])
-	assert.Equal(t, []string{"ADMIN", "OPERATOR"}, claims["groups"])
+	assert.Equal(t, []string{"admin", "operator"}, claims["roles"])
+	assert.Equal(t, []string{"admin", "operator"}, claims["groups"])
 }
 
 func TestBuildClaims_EmptyUsernameDefaultsToEmail(t *testing.T) {
@@ -60,6 +60,53 @@ func TestBuildClaims_NilGroupsProducesEmptySlice(t *testing.T) {
 	roles, ok := claims["roles"].([]string)
 	require.True(t, ok)
 	assert.Empty(t, roles)
+}
+
+func TestBuildClaims_RoleNormalization(t *testing.T) {
+	tid, err := tenant.NewTenantID("volterra")
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "UPPERCASE input produces lowercase output",
+			input:    []string{"ADMIN", "OPERATOR"},
+			expected: []string{"admin", "operator"},
+		},
+		{
+			name:     "Mixed-Case input produces lowercase output",
+			input:    []string{"Admin", "ReadOnly"},
+			expected: []string{"admin", "readonly"},
+		},
+		{
+			name:     "already-lowercase input is unchanged",
+			input:    []string{"admin", "viewer"},
+			expected: []string{"admin", "viewer"},
+		},
+		{
+			name:     "empty roles produces empty slice",
+			input:    []string{},
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id := connector.Identity{
+				UserID: "user-uuid-norm",
+				Email:  "norm@example.com",
+				Groups: tc.input,
+			}
+
+			claims := connector.BuildClaims(id, tid)
+
+			assert.Equal(t, tc.expected, claims["roles"])
+			assert.Equal(t, tc.expected, claims["groups"])
+		})
+	}
 }
 
 func TestBuildClaims_TenantIDPropagated(t *testing.T) {


### PR DESCRIPTION
## Summary

- Normalizes role names to lowercase in `BuildClaims` so all JWT `roles`/`groups` claims are consistently lowercased regardless of how they were stored in the identity provider
- Updates `TestBuildClaims_FullIdentity` to expect lowercase roles
- Adds `TestBuildClaims_RoleNormalization` with table-driven cases covering UPPERCASE, Mixed-Case, already-lowercase, and empty inputs

## Changes Made

- `services/identity/connector/claims.go`: Added `strings.ToLower` normalization loop over `identity.Groups` before building the claims map
- `services/identity/connector/claims_test.go`: Updated existing full-identity test expectations; added new normalization table test

## Test plan

- [x] All existing connector tests pass
- [x] New `TestBuildClaims_RoleNormalization` table tests pass (4 sub-cases)
- [x] `go test ./connector/... -v` green

## Task Master

1598-auth-remaining.1 + 1598-auth-remaining.2