### PR TITLE
feat: normalize JWT roles and groups to lowercase in frontend parseJWT

### DIFF
--- a/frontend/src/contexts/auth-context.test.tsx
+++ b/frontend/src/contexts/auth-context.test.tsx
@@ -107,6 +107,31 @@ describe('parseJWT', () => {
     expect(claims).not.toBeNull()
     expect(claims!.roles).toEqual([])
   })
+
+  it('normalizes UPPERCASE and mixed-case roles to lowercase', () => {
+    const token = createTestToken({
+      userId: 'user-case',
+      roles: ['PLATFORM-ADMIN', 'Tenant-Admin', 'SUPER-ADMIN'],
+      iss: 'meridian-auth',
+      aud: 'meridian-console',
+    })
+    const claims = parseJWT(token)
+    expect(claims).not.toBeNull()
+    expect(claims!.roles).toEqual(['platform-admin', 'tenant-admin', 'super-admin'])
+  })
+
+  it('normalizes UPPERCASE groups to lowercase when used as effective roles', () => {
+    const token = createTestToken({
+      userId: 'dex-user',
+      roles: [],
+      groups: ['PLATFORM-ADMIN', 'Operator'],
+      iss: 'dex',
+      aud: 'meridian',
+    })
+    const claims = parseJWT(token)
+    expect(claims).not.toBeNull()
+    expect(claims!.roles).toEqual(['platform-admin', 'operator'])
+  })
 })
 
 describe('getUserLens', () => {

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -70,10 +70,10 @@ export function parseJWT(token: unknown): JWTClaims | null {
           : ''
 
     const roles = Array.isArray(decoded.roles)
-      ? (decoded.roles as unknown[]).filter((r): r is string => typeof r === 'string')
+      ? (decoded.roles as unknown[]).filter((r): r is string => typeof r === 'string').map(r => r.toLowerCase())
       : []
     const groups = Array.isArray(decoded.groups)
-      ? (decoded.groups as unknown[]).filter((g): g is string => typeof g === 'string')
+      ? (decoded.groups as unknown[]).filter((g): g is string => typeof g === 'string').map(g => g.toLowerCase())
       : []
     // Use roles if present, else fall back to groups (Dex uses groups instead of roles)
     const effectiveRoles = roles.length > 0 ? roles : groups

--- a/frontend/src/features/identity/lib/roles.test.ts
+++ b/frontend/src/features/identity/lib/roles.test.ts
@@ -51,4 +51,29 @@ describe('getGrantableRoles', () => {
     const result = getGrantableRoles([])
     expect(result).toEqual([])
   })
+
+  it('works correctly with UPPERCASE input pre-normalized to lowercase (super-admin)', () => {
+    // parseJWT normalizes roles to lowercase; verify getGrantableRoles handles normalized input
+    const normalizedRoles = ['SUPER-ADMIN'].map(r => r.toLowerCase())
+    const result = getGrantableRoles(normalizedRoles)
+    expect(result).toContain(Role.SUPER_ADMIN)
+    expect(result).toContain(Role.PLATFORM_ADMIN)
+    expect(result).toContain(Role.ADMIN)
+    expect(result).toHaveLength(6)
+  })
+
+  it('works correctly with UPPERCASE input pre-normalized to lowercase (platform-admin)', () => {
+    const normalizedRoles = ['PLATFORM-ADMIN'].map(r => r.toLowerCase())
+    const result = getGrantableRoles(normalizedRoles)
+    expect(result).toContain(Role.ADMIN)
+    expect(result).toContain(Role.TENANT_OWNER)
+    expect(result).not.toContain(Role.PLATFORM_ADMIN)
+    expect(result).not.toContain(Role.SUPER_ADMIN)
+  })
+
+  it('works correctly with mixed-case input pre-normalized to lowercase (admin)', () => {
+    const normalizedRoles = ['Admin'].map(r => r.toLowerCase())
+    const result = getGrantableRoles(normalizedRoles)
+    expect(result).toEqual([Role.OPERATOR, Role.AUDITOR])
+  })
 })


### PR DESCRIPTION
## Summary

- Adds `.map(r => r.toLowerCase())` to `roles` and `groups` extraction in `parseJWT` (`frontend/src/contexts/auth-context.tsx`) so uppercase or mixed-case role values from identity providers are normalized before reaching downstream role-checking logic
- Adds test cases to `auth-context.test.tsx` verifying UPPERCASE and mixed-case roles/groups are normalized
- Adds test cases to `roles.test.ts` verifying `getGrantableRoles` works correctly with pre-normalized lowercase input from UPPERCASE originals

## Changes Made

- `frontend/src/contexts/auth-context.tsx`: Added `.map(r => r.toLowerCase())` to roles and groups filter chains in `parseJWT`
- `frontend/src/contexts/auth-context.test.tsx`: Added 2 test cases for UPPERCASE/mixed-case role normalization
- `frontend/src/features/identity/lib/roles.test.ts`: Added 3 test cases verifying `getGrantableRoles` handles UPPERCASE input pre-normalized to lowercase

## Test plan

- [ ] All 43 frontend unit tests pass locally
- [ ] `parseJWT` normalizes UPPERCASE roles (e.g., `PLATFORM-ADMIN` → `platform-admin`)
- [ ] `parseJWT` normalizes UPPERCASE groups used as effective roles
- [ ] `getGrantableRoles` returns correct grantable roles for UPPERCASE input after normalization
- [ ] CI frontend workflow passes (runs `npm run generate` before tests)