### PR TITLE
feat: Wire SSO BFF handler into standalone api-gateway service

### DIFF
--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -29,6 +29,11 @@ import (
 // ErrRedisURLRequired is returned when Redis fan-out is enabled but no REDIS_URL is configured.
 var ErrRedisURLRequired = errors.New("redis fan-out requires REDIS_URL to be configured")
 
+// ErrJWTSigningKeyRequired is returned when SSO is enabled but JWT_SIGNING_KEY is not set
+// outside local dev mode. Auto-generation would produce instance-local keys that break
+// multi-replica deployments and any gateway restart.
+var ErrJWTSigningKeyRequired = errors.New("JWT_SIGNING_KEY must be set when SSO is enabled outside local dev mode")
+
 // Build information set via ldflags during compilation.
 var (
 	Version   = "dev"
@@ -139,9 +144,12 @@ func run(logger *slog.Logger) error {
 	}
 
 	// Wire BFF SSO if configured
-	ssoOpt, err := wireBFFSSO(config, logger)
+	ssoOpt, ssoCleanup, err := wireBFFSSO(config, logger)
 	if err != nil {
 		return bootstrap.Permanent(fmt.Errorf("failed to wire BFF SSO: %w", err))
+	}
+	if ssoCleanup != nil {
+		defer ssoCleanup()
 	}
 	if ssoOpt != nil {
 		serverOpts = append(serverOpts, ssoOpt)
@@ -305,43 +313,61 @@ func buildEventStreamComponents(
 }
 
 // wireBFFSSO creates the BFF SSO handler for OIDC-based login via Dex.
-// Returns nil (no error) when SSO_DEX_ISSUER_URL is unset — SSO is optional.
+// Returns (nil, nil, nil) when SSO_DEX_ISSUER_URL is unset — SSO is optional.
+// The returned cleanup func must be called on shutdown to close the identity DB pool.
 //
 // Environment variables:
 //   - SSO_DEX_ISSUER_URL: Dex issuer URL (e.g., "https://demo.meridianhub.cloud/dex"). Required to enable SSO.
 //   - SSO_CLIENT_ID: OAuth client ID (default: "meridian-service")
 //   - SSO_CALLBACK_URL: BFF callback URL (e.g., "https://demo.meridianhub.cloud/api/auth/callback")
-//   - JWT_SIGNING_KEY: RSA private key in PEM format (auto-generated if unset)
+//   - JWT_SIGNING_KEY: RSA private key in PEM format. Required unless LocalDevMode is enabled.
 //   - JWT_SIGNING_KEY_ID: kid header value (default: "meridian-1")
 //   - JWT_SIGNING_ISSUER: iss claim value (default: "meridian")
 //   - JWT_TOKEN_TTL: token lifetime (default: "1h")
-func wireBFFSSO(config *gateway.Config, logger *slog.Logger) (gateway.ServerOption, error) {
+func wireBFFSSO(config *gateway.Config, logger *slog.Logger) (gateway.ServerOption, func(), error) {
 	dexIssuerURL := os.Getenv("SSO_DEX_ISSUER_URL")
 	if dexIssuerURL == "" {
 		logger.Info("SSO_DEX_ISSUER_URL not set, BFF SSO disabled")
-		return nil, nil //nolint:nilnil // SSO is optional; absent config intentionally returns no option and no error
+		return nil, nil, nil //nolint:nilnil // SSO is optional; absent config intentionally returns no option and no error
+	}
+
+	privateKeyPEM := os.Getenv("JWT_SIGNING_KEY")
+	if privateKeyPEM == "" && !config.LocalDevMode {
+		return nil, nil, ErrJWTSigningKeyRequired
 	}
 
 	signer, err := platformauth.NewJWTSigner(platformauth.JWTSignerConfig{
-		PrivateKeyPEM: os.Getenv("JWT_SIGNING_KEY"),
+		PrivateKeyPEM: privateKeyPEM,
 		KeyID:         env.GetEnvOrDefault("JWT_SIGNING_KEY_ID", "meridian-1"),
 		Issuer:        env.GetEnvOrDefault("JWT_SIGNING_ISSUER", "meridian"),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create JWT signer for SSO: %w", err)
+		return nil, nil, fmt.Errorf("failed to create JWT signer for SSO: %w", err)
 	}
 
 	identityDB, err := gorm.Open(postgres.Open(config.DatabaseURL), &gorm.Config{
 		SkipDefaultTransaction: true,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to open identity DB for SSO: %w", err)
+		return nil, nil, fmt.Errorf("failed to open identity DB for SSO: %w", err)
+	}
+
+	cleanup := func() {
+		sqlDB, dbErr := identityDB.DB()
+		if dbErr != nil {
+			logger.Warn("failed to get underlying DB for SSO cleanup", "error", dbErr)
+			return
+		}
+		if closeErr := sqlDB.Close(); closeErr != nil {
+			logger.Warn("failed to close SSO identity DB connection", "error", closeErr)
+		}
 	}
 
 	identityRepo := identitypersistence.NewRepository(identityDB)
 	conn, err := identityconnector.New(identityRepo, logger)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create identity connector for SSO: %w", err)
+		cleanup()
+		return nil, nil, fmt.Errorf("failed to create identity connector for SSO: %w", err)
 	}
 
 	tokenTTL := env.GetEnvAsDuration("JWT_TOKEN_TTL", time.Hour)
@@ -356,7 +382,8 @@ func wireBFFSSO(config *gateway.Config, logger *slog.Logger) (gateway.ServerOpti
 		Logger:       logger,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create SSO handler: %w", err)
+		cleanup()
+		return nil, nil, fmt.Errorf("failed to create SSO handler: %w", err)
 	}
 
 	logger.Info("BFF SSO handler initialized",
@@ -364,7 +391,7 @@ func wireBFFSSO(config *gateway.Config, logger *slog.Logger) (gateway.ServerOpti
 		"client_id", env.GetEnvOrDefault("SSO_CLIENT_ID", "meridian-service"),
 		"token_ttl", tokenTTL)
 
-	return gateway.WithSSOHandler(handler), nil
+	return gateway.WithSSOHandler(handler), cleanup, nil
 }
 
 // parseLogLevel converts a string log level to slog.Level.

--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -14,9 +14,13 @@ import (
 	"github.com/meridianhub/meridian/services/api-gateway/eventstream"
 	"github.com/meridianhub/meridian/services/api-gateway/eventstream/adapters"
 	gwhealth "github.com/meridianhub/meridian/services/api-gateway/health"
+	identitypersistence "github.com/meridianhub/meridian/services/identity/adapters/persistence"
+	identityconnector "github.com/meridianhub/meridian/services/identity/connector"
 	"github.com/meridianhub/meridian/shared/pkg/health"
+	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/meridianhub/meridian/shared/platform/db"
+	"github.com/meridianhub/meridian/shared/platform/env"
 	"github.com/redis/go-redis/v9"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -132,6 +136,15 @@ func run(logger *slog.Logger) error {
 		if authMiddleware != nil {
 			serverOpts = append(serverOpts, gateway.WithAuthMiddleware(authMiddleware))
 		}
+	}
+
+	// Wire BFF SSO if configured
+	ssoOpt, err := wireBFFSSO(config, logger)
+	if err != nil {
+		return bootstrap.Permanent(fmt.Errorf("failed to wire BFF SSO: %w", err))
+	}
+	if ssoOpt != nil {
+		serverOpts = append(serverOpts, ssoOpt)
 	}
 
 	// Wire event streaming if enabled
@@ -289,6 +302,69 @@ func buildEventStreamComponents(
 	handler := eventstream.NewHandler(router, logger)
 
 	return router, handler, cleanup, nil
+}
+
+// wireBFFSSO creates the BFF SSO handler for OIDC-based login via Dex.
+// Returns nil (no error) when SSO_DEX_ISSUER_URL is unset — SSO is optional.
+//
+// Environment variables:
+//   - SSO_DEX_ISSUER_URL: Dex issuer URL (e.g., "https://demo.meridianhub.cloud/dex"). Required to enable SSO.
+//   - SSO_CLIENT_ID: OAuth client ID (default: "meridian-service")
+//   - SSO_CALLBACK_URL: BFF callback URL (e.g., "https://demo.meridianhub.cloud/api/auth/callback")
+//   - JWT_SIGNING_KEY: RSA private key in PEM format (auto-generated if unset)
+//   - JWT_SIGNING_KEY_ID: kid header value (default: "meridian-1")
+//   - JWT_SIGNING_ISSUER: iss claim value (default: "meridian")
+//   - JWT_TOKEN_TTL: token lifetime (default: "1h")
+func wireBFFSSO(config *gateway.Config, logger *slog.Logger) (gateway.ServerOption, error) {
+	dexIssuerURL := os.Getenv("SSO_DEX_ISSUER_URL")
+	if dexIssuerURL == "" {
+		logger.Info("SSO_DEX_ISSUER_URL not set, BFF SSO disabled")
+		return nil, nil //nolint:nilnil // SSO is optional; absent config intentionally returns no option and no error
+	}
+
+	signer, err := platformauth.NewJWTSigner(platformauth.JWTSignerConfig{
+		PrivateKeyPEM: os.Getenv("JWT_SIGNING_KEY"),
+		KeyID:         env.GetEnvOrDefault("JWT_SIGNING_KEY_ID", "meridian-1"),
+		Issuer:        env.GetEnvOrDefault("JWT_SIGNING_ISSUER", "meridian"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWT signer for SSO: %w", err)
+	}
+
+	identityDB, err := gorm.Open(postgres.Open(config.DatabaseURL), &gorm.Config{
+		SkipDefaultTransaction: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open identity DB for SSO: %w", err)
+	}
+
+	identityRepo := identitypersistence.NewRepository(identityDB)
+	conn, err := identityconnector.New(identityRepo, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create identity connector for SSO: %w", err)
+	}
+
+	tokenTTL := env.GetEnvAsDuration("JWT_TOKEN_TTL", time.Hour)
+
+	handler, err := gateway.NewSSOHandler(gateway.SSOHandlerConfig{
+		DexIssuerURL: dexIssuerURL,
+		ClientID:     env.GetEnvOrDefault("SSO_CLIENT_ID", "meridian-service"),
+		CallbackURL:  os.Getenv("SSO_CALLBACK_URL"),
+		Signer:       signer,
+		Resolver:     conn,
+		TokenTTL:     tokenTTL,
+		Logger:       logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SSO handler: %w", err)
+	}
+
+	logger.Info("BFF SSO handler initialized",
+		"dex_issuer_url", dexIssuerURL,
+		"client_id", env.GetEnvOrDefault("SSO_CLIENT_ID", "meridian-service"),
+		"token_ttl", tokenTTL)
+
+	return gateway.WithSSOHandler(handler), nil
 }
 
 // parseLogLevel converts a string log level to slog.Level.


### PR DESCRIPTION
## Summary

- Adds `wireBFFSSO` function to `services/api-gateway/cmd/main.go`
- When `SSO_DEX_ISSUER_URL` is set, creates a `JWTSigner`, identity repository (via GORM), and `Connector`, then registers `WithSSOHandler` to activate the BFF PKCE endpoints
- When `SSO_DEX_ISSUER_URL` is absent, the function is a no-op — SSO remains optional
- Mirrors the pattern established by `wireBFFAuth` in `cmd/meridian/main.go`

## Environment Variables

| Variable | Required | Default | Description |
|---|---|---|---|
| `SSO_DEX_ISSUER_URL` | Yes (to enable) | — | Dex issuer base URL |
| `SSO_CLIENT_ID` | No | `meridian-service` | OAuth client ID |
| `SSO_CALLBACK_URL` | Yes (when SSO enabled) | — | BFF callback URL |
| `JWT_SIGNING_KEY` | No | auto-generated | RSA private key PEM |
| `JWT_SIGNING_KEY_ID` | No | `meridian-1` | JWT kid header |
| `JWT_SIGNING_ISSUER` | No | `meridian` | JWT iss claim |
| `JWT_TOKEN_TTL` | No | `1h` | Issued token lifetime |

## Test plan

- [x] `go vet ./services/api-gateway/...` passes
- [x] `go test ./services/api-gateway/...` — all 49s test suite passes
- [x] Pre-commit hooks (gofumpt, golangci-lint, gitleaks) all pass