### PR TITLE
feat: Add PageHeader, PageShell, and ErrorState shared components

### DIFF
--- a/frontend/src/shared/error-state.test.tsx
+++ b/frontend/src/shared/error-state.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ErrorState } from './error-state'
+
+describe('ErrorState', () => {
+  it('renders default title and message', () => {
+    render(<ErrorState />)
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Failed to load')
+    expect(screen.getByText('There was a problem loading this content. Please try again.')).toBeInTheDocument()
+  })
+
+  it('renders custom title and message', () => {
+    render(<ErrorState title="Custom Error" message="Something broke" />)
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Custom Error')
+    expect(screen.getByText('Something broke')).toBeInTheDocument()
+  })
+
+  it('renders retry button when onRetry provided', () => {
+    render(<ErrorState onRetry={() => {}} />)
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+  })
+
+  it('does not render retry button when onRetry not provided', () => {
+    render(<ErrorState />)
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('calls onRetry when retry button clicked', async () => {
+    const user = userEvent.setup()
+    const onRetry = vi.fn()
+    render(<ErrorState onRetry={onRetry} />)
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+
+  it('applies custom className', () => {
+    const { container } = render(<ErrorState className="custom-class" />)
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+})

--- a/frontend/src/shared/error-state.tsx
+++ b/frontend/src/shared/error-state.tsx
@@ -1,0 +1,32 @@
+import { AlertTriangle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+export interface ErrorStateProps {
+  title?: string
+  message?: string
+  onRetry?: () => void
+  retryLabel?: string
+  className?: string
+}
+
+export function ErrorState({
+  title = 'Failed to load',
+  message = 'There was a problem loading this content. Please try again.',
+  onRetry,
+  retryLabel = 'Retry',
+  className,
+}: ErrorStateProps) {
+  return (
+    <div className={cn('flex flex-col items-center justify-center py-12 px-4', className)}>
+      <AlertTriangle className="size-10 text-destructive mb-4" />
+      <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+      <p className="mt-2 text-sm text-muted-foreground text-center max-w-sm">{message}</p>
+      {onRetry && (
+        <Button variant="outline" size="sm" onClick={onRetry} className="mt-4">
+          {retryLabel}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/shared/index.ts
+++ b/frontend/src/shared/index.ts
@@ -20,3 +20,12 @@ export type { DetailSkeletonProps } from './detail-skeleton';
 
 export { useAccountResolver } from './use-account-resolver';
 export type { ResolvedAccount, ResolvedAccountType } from './use-account-resolver';
+
+export { PageHeader } from './page-header';
+export type { PageHeaderProps } from './page-header';
+
+export { PageShell } from './page-shell';
+export type { PageShellProps } from './page-shell';
+
+export { ErrorState } from './error-state';
+export type { ErrorStateProps } from './error-state';

--- a/frontend/src/shared/page-header.test.tsx
+++ b/frontend/src/shared/page-header.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PageHeader } from './page-header'
+
+describe('PageHeader', () => {
+  it('renders title with correct heading level', () => {
+    render(<PageHeader title="Test Title" />)
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading).toHaveTextContent('Test Title')
+  })
+
+  it('renders description when provided', () => {
+    render(<PageHeader title="Title" description="A description" />)
+    expect(screen.getByText('A description')).toBeInTheDocument()
+  })
+
+  it('renders actions when provided', () => {
+    render(<PageHeader title="Title" actions={<button>Action</button>} />)
+    expect(screen.getByRole('button', { name: 'Action' })).toBeInTheDocument()
+  })
+
+  it('does not render description when not provided', () => {
+    const { container } = render(<PageHeader title="Title" />)
+    expect(container.querySelector('p')).toBeNull()
+  })
+
+  it('does not render actions when not provided', () => {
+    const { container } = render(<PageHeader title="Title" />)
+    // The actions wrapper div should not be present
+    const divs = container.querySelectorAll('div')
+    // Only root div and the space-y-1 div for title
+    expect(divs.length).toBe(2)
+  })
+
+  it('applies custom className', () => {
+    const { container } = render(<PageHeader title="Title" className="custom-class" />)
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+})

--- a/frontend/src/shared/page-header.tsx
+++ b/frontend/src/shared/page-header.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface PageHeaderProps {
+  title: string
+  description?: string
+  actions?: React.ReactNode
+  className?: string
+}
+
+export function PageHeader({ title, description, actions, className }: PageHeaderProps) {
+  return (
+    <div className={cn('flex items-start justify-between', className)}>
+      <div className="space-y-1">
+        <h1 className="text-3xl font-bold tracking-tight">{title}</h1>
+        {description && (
+          <p className="text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {actions && <div className="flex items-center gap-2">{actions}</div>}
+    </div>
+  )
+}

--- a/frontend/src/shared/page-shell.test.tsx
+++ b/frontend/src/shared/page-shell.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PageShell } from './page-shell'
+
+describe('PageShell', () => {
+  it('renders children', () => {
+    render(<PageShell><p>Child content</p></PageShell>)
+    expect(screen.getByText('Child content')).toBeInTheDocument()
+  })
+
+  it('applies space-y-6 class', () => {
+    const { container } = render(<PageShell><p>Content</p></PageShell>)
+    expect(container.firstChild).toHaveClass('space-y-6')
+  })
+
+  it('applies custom className', () => {
+    const { container } = render(<PageShell className="custom-class"><p>Content</p></PageShell>)
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+})

--- a/frontend/src/shared/page-shell.tsx
+++ b/frontend/src/shared/page-shell.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface PageShellProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export function PageShell({ children, className }: PageShellProps) {
+  return (
+    <div className={cn('space-y-6', className)}>
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Add `PageHeader` component for consistent page title, description, and action layouts
- Add `PageShell` component for consistent page-level spacing
- Add `ErrorState` component for unified error display with optional retry
- Update `src/shared/index.ts` barrel exports for all three components

Implements frontend-ux-consistency tasks 1, 2, 3, and 14.

## Test plan

- [x] PageHeader: 6 tests (title rendering, description, actions, className)
- [x] PageShell: 3 tests (children rendering, spacing class, className)
- [x] ErrorState: 6 tests (defaults, custom props, retry button, click handler, className)
- [x] All 15 tests passing
- [x] ESLint clean on all new files