### PR TITLE
test: E2E auth flow, role normalization, and callback tests

### DIFF
--- a/frontend/e2e/auth-flows.spec.ts
+++ b/frontend/e2e/auth-flows.spec.ts
@@ -135,17 +135,22 @@ test.describe('Callback page - token from fragment', () => {
 })
 
 test.describe('Login page - password form', () => {
-  test('password form is hidden in dev mode (shown only in demo/production)', async ({ page }) => {
-    // The password form is only rendered when VITE_DEMO_MODE=true or not in DEV mode.
-    // In the E2E dev server, it should NOT be present.
+  // The password form renders when !import.meta.env.DEV (preview/production builds).
+  // CI runs preview mode with VITE_E2E_MODE=true, so the form is always present.
+  test('password form has email, password fields and submit button', async ({ page }) => {
     await page.goto('/login')
+    await expect(page.getByRole('heading', { name: 'Meridian Operations Console' })).toBeVisible()
 
-    // Dev login buttons are always present in dev/E2E mode
-    await expect(page.getByRole('button', { name: /platform.admin/i })).toBeVisible()
-    await expect(page.getByRole('button', { name: /tenant.user/i })).toBeVisible()
+    // In local dev mode (npm run dev), the form is hidden. Skip gracefully.
+    const emailField = page.locator('input[type="email"]')
+    const count = await emailField.count()
+    if (count === 0) {
+      test.skip()
+      return
+    }
 
-    // Password form should not be rendered in standard dev mode
-    await expect(page.locator('input[type="email"]')).toHaveCount(0)
-    await expect(page.locator('input[type="password"]')).toHaveCount(0)
+    await expect(emailField).toBeVisible()
+    await expect(page.locator('input[type="password"]')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible()
   })
 })

--- a/frontend/e2e/auth-flows.spec.ts
+++ b/frontend/e2e/auth-flows.spec.ts
@@ -1,7 +1,25 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import { test as authTest, expect as authExpect, navigateTo, buildDevToken } from './fixtures'
 
 type DevWindow = Window & { __DEV_LOGIN__?: (token: string) => void }
+
+/**
+ * Inject a token via __DEV_LOGIN__ and navigate to / to render the authenticated app.
+ */
+async function injectTokenAndNavigate(page: Page, token: string) {
+  await page.goto('/')
+  await page.waitForFunction(
+    () => typeof (window as Record<string, unknown>).__DEV_LOGIN__ === 'function',
+  )
+  await page.evaluate((t) => {
+    ;(window as unknown as DevWindow).__DEV_LOGIN__?.(t)
+  }, token)
+  await page.evaluate(() => {
+    window.history.pushState({}, '', '/')
+    window.dispatchEvent(new PopStateEvent('popstate'))
+  })
+  await page.waitForSelector('main', { timeout: 10_000 })
+}
 
 /**
  * Auth flow E2E tests covering:
@@ -16,21 +34,7 @@ test.describe('Role normalization', () => {
   authTest(
     'UPPERCASE roles are normalized - platform admin can access dashboard',
     async ({ page }) => {
-      const token = buildDevToken('platform-admin', { uppercaseRoles: true })
-
-      await page.goto('/')
-      await page.waitForFunction(
-        () => typeof (window as Record<string, unknown>).__DEV_LOGIN__ === 'function',
-      )
-      await page.evaluate((t) => {
-        ;(window as unknown as DevWindow).__DEV_LOGIN__?.(t)
-      }, token)
-      await page.evaluate(() => {
-        window.history.pushState({}, '', '/')
-        window.dispatchEvent(new PopStateEvent('popstate'))
-      })
-
-      await authExpect(page.locator('main')).toBeVisible({ timeout: 10_000 })
+      await injectTokenAndNavigate(page, buildDevToken('platform-admin', { uppercaseRoles: true }))
       await authExpect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
     },
   )
@@ -38,21 +42,7 @@ test.describe('Role normalization', () => {
   authTest(
     'UPPERCASE roles are normalized - tenant user sees tenant context',
     async ({ page }) => {
-      const token = buildDevToken('tenant-user', { uppercaseRoles: true })
-
-      await page.goto('/')
-      await page.waitForFunction(
-        () => typeof (window as Record<string, unknown>).__DEV_LOGIN__ === 'function',
-      )
-      await page.evaluate((t) => {
-        ;(window as unknown as DevWindow).__DEV_LOGIN__?.(t)
-      }, token)
-      await page.evaluate(() => {
-        window.history.pushState({}, '', '/')
-        window.dispatchEvent(new PopStateEvent('popstate'))
-      })
-
-      await authExpect(page.locator('main')).toBeVisible({ timeout: 10_000 })
+      await injectTokenAndNavigate(page, buildDevToken('tenant-user', { uppercaseRoles: true }))
       await authExpect(page.getByText(/Overview for dev-tenant/)).toBeVisible({ timeout: 15_000 })
     },
   )
@@ -60,21 +50,7 @@ test.describe('Role normalization', () => {
   authTest(
     'UPPERCASE platform-admin role grants access to tenant list',
     async ({ page }) => {
-      const token = buildDevToken('platform-admin', { uppercaseRoles: true })
-
-      await page.goto('/')
-      await page.waitForFunction(
-        () => typeof (window as Record<string, unknown>).__DEV_LOGIN__ === 'function',
-      )
-      await page.evaluate((t) => {
-        ;(window as unknown as DevWindow).__DEV_LOGIN__?.(t)
-      }, token)
-      await page.evaluate(() => {
-        window.history.pushState({}, '', '/')
-        window.dispatchEvent(new PopStateEvent('popstate'))
-      })
-
-      await authExpect(page.locator('main')).toBeVisible({ timeout: 10_000 })
+      await injectTokenAndNavigate(page, buildDevToken('platform-admin', { uppercaseRoles: true }))
 
       await navigateTo(page, '/tenants')
       await authExpect(

--- a/frontend/e2e/auth-flows.spec.ts
+++ b/frontend/e2e/auth-flows.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect } from '@playwright/test'
+import { test as authTest, expect as authExpect, navigateTo, buildDevToken } from './fixtures'
+
+/**
+ * Auth flow E2E tests covering:
+ * - Role normalization (UPPERCASE roles work correctly)
+ * - SSO BFF redirect wiring
+ * - Callback page token extraction and error handling
+ *
+ * Login page basics and post-login navigation are covered in login-redirect.spec.ts.
+ */
+
+test.describe('Role normalization', () => {
+  authTest(
+    'UPPERCASE roles are normalized - platform admin can access dashboard',
+    async ({ page }) => {
+      const token = buildDevToken('platform-admin', { uppercaseRoles: true })
+
+      await page.goto('/')
+      await page.waitForFunction(
+        () => typeof (window as Record<string, unknown>).__DEV_LOGIN__ === 'function',
+      )
+      await page.evaluate((t) => {
+        ;(window as Record<string, unknown>).__DEV_LOGIN__(t)
+      }, token)
+      await page.evaluate(() => {
+        window.history.pushState({}, '', '/')
+        window.dispatchEvent(new PopStateEvent('popstate'))
+      })
+
+      await authExpect(page.locator('main')).toBeVisible({ timeout: 10_000 })
+      await authExpect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
+    },
+  )
+
+  authTest(
+    'UPPERCASE roles are normalized - tenant user sees tenant context',
+    async ({ page }) => {
+      const token = buildDevToken('tenant-user', { uppercaseRoles: true })
+
+      await page.goto('/')
+      await page.waitForFunction(
+        () => typeof (window as Record<string, unknown>).__DEV_LOGIN__ === 'function',
+      )
+      await page.evaluate((t) => {
+        ;(window as Record<string, unknown>).__DEV_LOGIN__(t)
+      }, token)
+      await page.evaluate(() => {
+        window.history.pushState({}, '', '/')
+        window.dispatchEvent(new PopStateEvent('popstate'))
+      })
+
+      await authExpect(page.locator('main')).toBeVisible({ timeout: 10_000 })
+      await authExpect(page.getByText(/Overview for dev-tenant/)).toBeVisible({ timeout: 15_000 })
+    },
+  )
+
+  authTest(
+    'UPPERCASE platform-admin role grants access to tenant list',
+    async ({ page }) => {
+      const token = buildDevToken('platform-admin', { uppercaseRoles: true })
+
+      await page.goto('/')
+      await page.waitForFunction(
+        () => typeof (window as Record<string, unknown>).__DEV_LOGIN__ === 'function',
+      )
+      await page.evaluate((t) => {
+        ;(window as Record<string, unknown>).__DEV_LOGIN__(t)
+      }, token)
+      await page.evaluate(() => {
+        window.history.pushState({}, '', '/')
+        window.dispatchEvent(new PopStateEvent('popstate'))
+      })
+
+      await authExpect(page.locator('main')).toBeVisible({ timeout: 10_000 })
+
+      await navigateTo(page, '/tenants')
+      await authExpect(
+        page.getByRole('heading', { level: 1 }).filter({ hasText: /Tenant/i }),
+      ).toBeVisible({ timeout: 10_000 })
+    },
+  )
+})
+
+test.describe('SSO BFF redirect', () => {
+  test('login page renders SSO provider buttons when providers are available', async ({
+    page,
+  }) => {
+    // In dev mode without a real backend, the providers API returns empty/error.
+    // We verify the login page structure is correct - SSO buttons only appear
+    // when providers are returned from the API.
+    await page.goto('/login')
+    await expect(page.getByRole('heading', { name: 'Meridian Operations Console' })).toBeVisible()
+
+    // The dev login buttons should always be present in dev/E2E mode
+    await expect(page.getByRole('button', { name: /platform.admin/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /tenant.user/i })).toBeVisible()
+  })
+
+  test.skip('SSO button redirects to BFF endpoint', () => {
+    // Requires a real backend with auth providers configured.
+    // The useOAuthFlow hook redirects to /api/auth/sso/{connector_id}
+    // which is a server-side endpoint that initiates the PKCE flow.
+    // Cannot test without a running BFF server.
+  })
+})
+
+test.describe('Callback page - token from fragment', () => {
+  authTest('callback with valid token in fragment logs user in', async ({ page }) => {
+    const token = buildDevToken('tenant-user')
+
+    // Navigate to callback with token in fragment
+    await page.goto(`/callback#access_token=${token}`)
+
+    // Should process the token and redirect to dashboard
+    await authExpect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible({
+      timeout: 10_000,
+    })
+    await authExpect(page.getByText(/Overview for dev-tenant/)).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('callback with no token shows error message', async ({ page }) => {
+    await page.goto('/callback')
+
+    await expect(page.getByText('Authentication Failed')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('No authentication token received')).toBeVisible()
+  })
+
+  test('callback with error param shows error description', async ({ page }) => {
+    await page.goto('/callback?error=access_denied&error_description=User+denied+access')
+
+    await expect(page.getByText('Authentication Failed')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('User denied access')).toBeVisible()
+  })
+
+  test('callback error page has return to login button', async ({ page }) => {
+    await page.goto('/callback?error=server_error')
+
+    await expect(page.getByText('Authentication Failed')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByRole('button', { name: 'Return to Login' })).toBeVisible()
+  })
+})
+
+test.describe('Login page - password form', () => {
+  test('login page has email and password fields in demo mode', async ({ page }) => {
+    // The password form is only rendered when VITE_DEMO_MODE=true or not in DEV mode.
+    // In standard dev mode, only the dev login buttons are shown.
+    // We verify the dev login buttons are present (covered by login-redirect.spec.ts)
+    // and check for the password form conditionally.
+    await page.goto('/login')
+
+    // Dev login buttons are always present
+    await expect(page.getByRole('button', { name: /platform.admin/i })).toBeVisible()
+
+    // Password form fields - only present in demo mode or production.
+    // In standard E2E dev mode, these may not be rendered.
+    const emailField = page.locator('input[type="email"]')
+    const passwordField = page.locator('input[type="password"]')
+    const emailCount = await emailField.count()
+
+    if (emailCount > 0) {
+      await expect(emailField).toBeVisible()
+      await expect(passwordField).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible()
+    }
+    // If not visible, the form is correctly hidden in dev mode - that's fine.
+  })
+})

--- a/frontend/e2e/auth-flows.spec.ts
+++ b/frontend/e2e/auth-flows.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test'
 import { test as authTest, expect as authExpect, navigateTo, buildDevToken } from './fixtures'
 
+type DevWindow = Window & { __DEV_LOGIN__?: (token: string) => void }
+
 /**
  * Auth flow E2E tests covering:
  * - Role normalization (UPPERCASE roles work correctly)
@@ -21,7 +23,7 @@ test.describe('Role normalization', () => {
         () => typeof (window as Record<string, unknown>).__DEV_LOGIN__ === 'function',
       )
       await page.evaluate((t) => {
-        ;(window as Record<string, unknown>).__DEV_LOGIN__(t)
+        ;(window as unknown as DevWindow).__DEV_LOGIN__?.(t)
       }, token)
       await page.evaluate(() => {
         window.history.pushState({}, '', '/')
@@ -43,7 +45,7 @@ test.describe('Role normalization', () => {
         () => typeof (window as Record<string, unknown>).__DEV_LOGIN__ === 'function',
       )
       await page.evaluate((t) => {
-        ;(window as Record<string, unknown>).__DEV_LOGIN__(t)
+        ;(window as unknown as DevWindow).__DEV_LOGIN__?.(t)
       }, token)
       await page.evaluate(() => {
         window.history.pushState({}, '', '/')
@@ -65,7 +67,7 @@ test.describe('Role normalization', () => {
         () => typeof (window as Record<string, unknown>).__DEV_LOGIN__ === 'function',
       )
       await page.evaluate((t) => {
-        ;(window as Record<string, unknown>).__DEV_LOGIN__(t)
+        ;(window as unknown as DevWindow).__DEV_LOGIN__?.(t)
       }, token)
       await page.evaluate(() => {
         window.history.pushState({}, '', '/')

--- a/frontend/e2e/auth-flows.spec.ts
+++ b/frontend/e2e/auth-flows.spec.ts
@@ -83,25 +83,13 @@ test.describe('Role normalization', () => {
 })
 
 test.describe('SSO BFF redirect', () => {
-  test('login page renders SSO provider buttons when providers are available', async ({
-    page,
-  }) => {
-    // In dev mode without a real backend, the providers API returns empty/error.
-    // We verify the login page structure is correct - SSO buttons only appear
-    // when providers are returned from the API.
-    await page.goto('/login')
-    await expect(page.getByRole('heading', { name: 'Meridian Operations Console' })).toBeVisible()
-
-    // The dev login buttons should always be present in dev/E2E mode
-    await expect(page.getByRole('button', { name: /platform.admin/i })).toBeVisible()
-    await expect(page.getByRole('button', { name: /tenant.user/i })).toBeVisible()
-  })
-
   test.skip('SSO button redirects to BFF endpoint', () => {
     // Requires a real backend with auth providers configured.
     // The useOAuthFlow hook redirects to /api/auth/sso/{connector_id}
     // which is a server-side endpoint that initiates the PKCE flow.
     // Cannot test without a running BFF server.
+    // SSO provider buttons only render when the /api/auth/providers API
+    // returns OIDC providers, which requires a live backend with Dex.
   })
 })
 
@@ -109,8 +97,8 @@ test.describe('Callback page - token from fragment', () => {
   authTest('callback with valid token in fragment logs user in', async ({ page }) => {
     const token = buildDevToken('tenant-user')
 
-    // Navigate to callback with token in fragment
-    await page.goto(`/callback#access_token=${token}`)
+    // Navigate to callback with token in fragment (encode to handle +/=/chars)
+    await page.goto(`/callback#access_token=${encodeURIComponent(token)}`)
 
     // Should process the token and redirect to dashboard
     await authExpect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible({
@@ -133,36 +121,31 @@ test.describe('Callback page - token from fragment', () => {
     await expect(page.getByText('User denied access')).toBeVisible()
   })
 
-  test('callback error page has return to login button', async ({ page }) => {
+  test('callback error page return-to-login button navigates to /login', async ({ page }) => {
     await page.goto('/callback?error=server_error')
 
     await expect(page.getByText('Authentication Failed')).toBeVisible({ timeout: 10_000 })
-    await expect(page.getByRole('button', { name: 'Return to Login' })).toBeVisible()
+    const returnButton = page.getByRole('button', { name: 'Return to Login' })
+    await expect(returnButton).toBeVisible()
+
+    await returnButton.click()
+    await expect(page).toHaveURL('/login', { timeout: 10_000 })
+    await expect(page.getByRole('heading', { name: 'Meridian Operations Console' })).toBeVisible()
   })
 })
 
 test.describe('Login page - password form', () => {
-  test('login page has email and password fields in demo mode', async ({ page }) => {
+  test('password form is hidden in dev mode (shown only in demo/production)', async ({ page }) => {
     // The password form is only rendered when VITE_DEMO_MODE=true or not in DEV mode.
-    // In standard dev mode, only the dev login buttons are shown.
-    // We verify the dev login buttons are present (covered by login-redirect.spec.ts)
-    // and check for the password form conditionally.
+    // In the E2E dev server, it should NOT be present.
     await page.goto('/login')
 
-    // Dev login buttons are always present
+    // Dev login buttons are always present in dev/E2E mode
     await expect(page.getByRole('button', { name: /platform.admin/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /tenant.user/i })).toBeVisible()
 
-    // Password form fields - only present in demo mode or production.
-    // In standard E2E dev mode, these may not be rendered.
-    const emailField = page.locator('input[type="email"]')
-    const passwordField = page.locator('input[type="password"]')
-    const emailCount = await emailField.count()
-
-    if (emailCount > 0) {
-      await expect(emailField).toBeVisible()
-      await expect(passwordField).toBeVisible()
-      await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible()
-    }
-    // If not visible, the form is correctly hidden in dev mode - that's fine.
+    // Password form should not be rendered in standard dev mode
+    await expect(page.locator('input[type="email"]')).toHaveCount(0)
+    await expect(page.locator('input[type="password"]')).toHaveCount(0)
   })
 })

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -4,13 +4,17 @@ import { test as base, type Page } from '@playwright/test'
  * Build a dev-mode JWT that satisfies the AuthProvider's parseJWT validation.
  * These tokens are only accepted in DEV mode (import.meta.env.DEV).
  */
-function buildDevToken(role: 'platform-admin' | 'tenant-user'): string {
+export function buildDevToken(
+  role: 'platform-admin' | 'tenant-user',
+  options?: { uppercaseRoles?: boolean },
+): string {
   const header = btoa(JSON.stringify({ alg: 'none', typ: 'JWT' }))
+  const roleValue = options?.uppercaseRoles ? role.toUpperCase() : role
   const payload = btoa(
     JSON.stringify({
       userId: 'e2e-user',
       tenantId: role === 'tenant-user' ? 'dev-tenant' : undefined,
-      roles: [role],
+      roles: [roleValue],
       scopes: ['read', 'write'],
       // 24 hours from now
       exp: Math.floor(Date.now() / 1000) + 86_400,


### PR DESCRIPTION
## Summary

- Adds E2E tests for the auth flows introduced in 1598-auth-remaining tasks 1-7 and 12
- Tests role normalization: verifies UPPERCASE roles (e.g., `PLATFORM-ADMIN`) are correctly lowercased by `parseJWT` and the app renders correctly
- Tests callback page: token extraction from URL fragment, error states, and return-to-login flow
- Tests SSO BFF redirect structure (skipped where real backend required)
- Exports `buildDevToken` from fixtures with `uppercaseRoles` option for reuse

## Changes

- `frontend/e2e/auth-flows.spec.ts` — new test file with 8 tests across 4 describe blocks
- `frontend/e2e/fixtures.ts` — export `buildDevToken`, add `uppercaseRoles` option

## Test plan

- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] ESLint passes on new files
- [ ] E2E tests pass against Vite dev server
- [ ] No duplication with existing `login-redirect.spec.ts` tests