### PR TITLE
feat: Align payments, positions, reconciliation list pages to canonical pattern

### DIFF
--- a/frontend/src/features/payments/pages/index.tsx
+++ b/frontend/src/features/payments/pages/index.tsx
@@ -4,6 +4,9 @@ import { DataTable } from '@/shared/data-table'
 import { MoneyDisplay } from '@/shared/money-display'
 import { StatusBadge } from '@/shared/status-badge'
 import { TimeDisplay } from '@/shared/time-display'
+import { PageHeader } from '@/shared/page-header'
+import { PageShell } from '@/shared/page-shell'
+import { Card } from '@/components/ui/card'
 import { usePaymentsTable } from '../hooks'
 import type { PaymentOrder } from './payments-query'
 
@@ -75,21 +78,23 @@ export function PaymentsPage({ onRowNavigate }: PaymentsPageProps = {}) {
   }
 
   return (
-    <div className="p-6">
-      <h1 className="mb-6 text-2xl font-semibold">Payments</h1>
-      <DataTable
-        queryKey={queryKey}
-        queryFn={queryFn}
-        columns={columns}
-        filters={FILTER_CONFIGS}
-        onRowClick={handleRowClick}
-        emptyState={
-          <div className="flex flex-col items-center gap-2 py-12 text-muted-foreground">
-            <span className="text-sm font-medium">No payments yet</span>
-            <span className="text-xs">Payments will appear here once initiated.</span>
-          </div>
-        }
-      />
-    </div>
+    <PageShell>
+      <PageHeader title="Payments" />
+      <Card>
+        <DataTable
+          queryKey={queryKey}
+          queryFn={queryFn}
+          columns={columns}
+          filters={FILTER_CONFIGS}
+          onRowClick={handleRowClick}
+          emptyState={
+            <div className="flex flex-col items-center gap-2 py-12 text-muted-foreground">
+              <span className="text-sm font-medium">No payments yet</span>
+              <span className="text-xs">Payments will appear here once initiated.</span>
+            </div>
+          }
+        />
+      </Card>
+    </PageShell>
   )
 }

--- a/frontend/src/features/positions/pages/index.tsx
+++ b/frontend/src/features/positions/pages/index.tsx
@@ -3,6 +3,8 @@ import type { ColumnDef } from '@tanstack/react-table'
 import { DataTable } from '@/shared/data-table'
 import { TimeDisplay } from '@/shared/time-display'
 import { Card } from '@/components/ui/card'
+import { PageHeader } from '@/shared/page-header'
+import { PageShell } from '@/shared/page-shell'
 import { TransactionStatus } from '@/api/gen/meridian/common/v1/types_pb'
 import { usePositionLogsTable } from '../hooks'
 
@@ -123,15 +125,13 @@ export function PositionsPage() {
   }
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Positions</h1>
-        <p className="mt-2 text-muted-foreground">
-          Financial position logs with bi-temporal data quality tracking.
-        </p>
-      </div>
+    <PageShell>
+      <PageHeader
+        title="Positions"
+        description="Financial position logs with bi-temporal data quality tracking."
+      />
 
-      <Card className="p-6">
+      <Card>
         <DataTable
           queryKey={queryKey}
           queryFn={queryFn}
@@ -141,7 +141,7 @@ export function PositionsPage() {
           onRowClick={handleRowClick}
         />
       </Card>
-    </div>
+    </PageShell>
   )
 }
 

--- a/frontend/src/features/reconciliation/pages/index.tsx
+++ b/frontend/src/features/reconciliation/pages/index.tsx
@@ -3,8 +3,11 @@ import { useNavigate } from 'react-router-dom'
 import type { ColumnDef } from '@tanstack/react-table'
 import { DataTable } from '@/shared/data-table'
 import { StatusBadge } from '@/shared/status-badge'
+import { PageHeader } from '@/shared/page-header'
+import { PageShell } from '@/shared/page-shell'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
 import { useReconciliationRunsTable } from '../hooks'
 import { InitiateReconciliationDialog } from './initiate-reconciliation-dialog'
 
@@ -92,47 +95,45 @@ export function ReconciliationPage() {
   }
 
   return (
-    <div className="p-6">
-      <div className="mb-6 flex items-start justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold">Reconciliation</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Settlement runs, variance detection, and dispute resolution.
-          </p>
-        </div>
-        <Button onClick={() => setDialogOpen(true)}>Start Reconciliation</Button>
-      </div>
+    <PageShell>
+      <PageHeader
+        title="Reconciliation"
+        description="Settlement runs, variance detection, and dispute resolution."
+        actions={<Button onClick={() => setDialogOpen(true)}>Start Reconciliation</Button>}
+      />
       <InitiateReconciliationDialog
         open={dialogOpen}
         onOpenChange={setDialogOpen}
         onSuccess={handleReconciliationSuccess}
       />
-      <DataTable
-        queryKey={queryKey}
-        queryFn={queryFn}
-        columns={columns}
-        pageSize={25}
-        emptyState={
-          <div data-testid="empty-state" className="flex flex-col items-center gap-2 py-12 text-muted-foreground">
-            <span className="text-sm font-medium">No reconciliation runs yet</span>
-            <span className="text-xs">Start a reconciliation to see results here.</span>
-          </div>
-        }
-        filters={[
-          {
-            field: 'status',
-            label: 'Status',
-            type: 'select',
-            options: [
-              { label: 'Running', value: 'RUN_STATUS_RUNNING' },
-              { label: 'Completed', value: 'RUN_STATUS_COMPLETED' },
-              { label: 'Failed', value: 'RUN_STATUS_FAILED' },
-            ],
-          },
-          { field: 'account_id', label: 'Account ID', type: 'text' },
-        ]}
-        onRowClick={handleRowClick}
-      />
-    </div>
+      <Card>
+        <DataTable
+          queryKey={queryKey}
+          queryFn={queryFn}
+          columns={columns}
+          pageSize={25}
+          emptyState={
+            <div data-testid="empty-state" className="flex flex-col items-center gap-2 py-12 text-muted-foreground">
+              <span className="text-sm font-medium">No reconciliation runs yet</span>
+              <span className="text-xs">Start a reconciliation to see results here.</span>
+            </div>
+          }
+          filters={[
+            {
+              field: 'status',
+              label: 'Status',
+              type: 'select',
+              options: [
+                { label: 'Running', value: 'RUN_STATUS_RUNNING' },
+                { label: 'Completed', value: 'RUN_STATUS_COMPLETED' },
+                { label: 'Failed', value: 'RUN_STATUS_FAILED' },
+              ],
+            },
+            { field: 'account_id', label: 'Account ID', type: 'text' },
+          ]}
+          onRowClick={handleRowClick}
+        />
+      </Card>
+    </PageShell>
   )
 }


### PR DESCRIPTION
## Summary

- Replace ad-hoc `div` wrappers and inline `h1` headers in payments, positions, and reconciliation list pages with `PageShell` and `PageHeader` shared components
- Wrap `DataTable` in `Card` on all three pages for consistent layout
- Use direct file imports (`@/shared/page-header`, `@/shared/page-shell`) to avoid barrel export side effects in tests

## Changes Made

- `frontend/src/features/payments/pages/index.tsx` — Replace `<div className="p-6">` + `<h1>` with `<PageShell>` + `<PageHeader title="Payments" />`
- `frontend/src/features/positions/pages/index.tsx` — Replace `<div className="space-y-6">` + nested header with `<PageShell>` + `<PageHeader title="Positions" description="..." />`; remove inline padding from Card
- `frontend/src/features/reconciliation/pages/index.tsx` — Replace ad-hoc flex header with `<PageHeader title="Reconciliation" description="..." actions={<Button>} />`; wrap DataTable in `<Card>`

## Testing

- Payments tests: 6/6 passing
- Positions tests: 12/12 passing
- Reconciliation tests: 11 pre-existing failures (unrelated — `AuditService` proto broken in `renderWithProviders` test helper, present before this PR)
- ESLint: clean
- TypeScript: clean