### PR TITLE
feat: Align parties pages to canonical PageShell/PageHeader pattern

### DIFF
--- a/frontend/src/features/parties/pages/[partyId].test.tsx
+++ b/frontend/src/features/parties/pages/[partyId].test.tsx
@@ -104,8 +104,10 @@ describe('PartyDetailPage', () => {
   it('renders all seven tabs', async () => {
     const { container } = renderAtRoute(<PartyDetailPage />, '/parties/test-party-1')
 
-    // Check that tabs container is rendered
-    expect(container.querySelector('[role="tablist"]')).toBeInTheDocument()
+    // Check that tabs container is rendered (wait for data to load)
+    await waitFor(() => {
+      expect(container.querySelector('[role="tablist"]')).toBeInTheDocument()
+    })
   })
 
   it('renders overview tab by default', async () => {

--- a/frontend/src/features/parties/pages/[partyId].tsx
+++ b/frontend/src/features/parties/pages/[partyId].tsx
@@ -34,10 +34,11 @@ export function PartyDetailPage() {
       />
 
       {isLoading && <DetailSkeleton />}
-      {isError && <ErrorState onRetry={refetch} />}
 
-      {!isLoading && !isError && (
+      {!isLoading && (
         <>
+          {isError && <ErrorState onRetry={refetch} />}
+
           <Card>
             <PartyHeader partyId={partyId} />
           </Card>

--- a/frontend/src/features/parties/pages/[partyId].tsx
+++ b/frontend/src/features/parties/pages/[partyId].tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom'
 import { Card } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Breadcrumbs } from '@/shared'
+import { Breadcrumbs, DetailSkeleton, ErrorState, PageShell } from '@/shared'
 import { usePartyDetail } from '../hooks'
 import { PartyHeader } from './components/party-header'
 import { OverviewTab } from './tabs/overview-tab'
@@ -16,7 +16,7 @@ import { AccountsTab } from './tabs/accounts-tab'
 export function PartyDetailPage() {
   const { partyId } = useParams<{ partyId: string }>()
 
-  const { data: party } = usePartyDetail(partyId)
+  const { data: party, isLoading, isError, refetch } = usePartyDetail(partyId)
 
   if (!partyId) {
     return <div className="p-6 text-destructive">Party ID not found</div>
@@ -25,7 +25,7 @@ export function PartyDetailPage() {
   const partyLabel = party?.legalName ?? partyId
 
   return (
-    <div className="space-y-6">
+    <PageShell>
       <Breadcrumbs
         items={[
           { label: 'Parties', href: '/parties' },
@@ -33,58 +33,65 @@ export function PartyDetailPage() {
         ]}
       />
 
-      <Card>
-        <PartyHeader partyId={partyId} />
-      </Card>
+      {isLoading && <DetailSkeleton />}
+      {isError && <ErrorState onRetry={refetch} />}
 
-      <Card>
-        <Tabs defaultValue="overview" className="w-full">
-          <TabsList className="grid w-full grid-cols-8 border-b rounded-none">
-            <TabsTrigger value="overview">Overview</TabsTrigger>
-            <TabsTrigger value="demographics">Demographics</TabsTrigger>
-            <TabsTrigger value="references">References</TabsTrigger>
-            <TabsTrigger value="associations">Associations</TabsTrigger>
-            <TabsTrigger value="bank-relations">Bank Relations</TabsTrigger>
-            <TabsTrigger value="payment-methods">Payment Methods</TabsTrigger>
-            <TabsTrigger value="accounts">Accounts</TabsTrigger>
-            <TabsTrigger value="audit-trail">Audit Trail</TabsTrigger>
-          </TabsList>
+      {party && (
+        <>
+          <Card>
+            <PartyHeader partyId={partyId} />
+          </Card>
 
-          <div className="p-6">
-            <TabsContent value="overview" className="mt-0">
-              <OverviewTab partyId={partyId} />
-            </TabsContent>
+          <Card>
+            <Tabs defaultValue="overview" className="w-full">
+              <TabsList className="grid w-full grid-cols-8 border-b rounded-none">
+                <TabsTrigger value="overview">Overview</TabsTrigger>
+                <TabsTrigger value="demographics">Demographics</TabsTrigger>
+                <TabsTrigger value="references">References</TabsTrigger>
+                <TabsTrigger value="associations">Associations</TabsTrigger>
+                <TabsTrigger value="bank-relations">Bank Relations</TabsTrigger>
+                <TabsTrigger value="payment-methods">Payment Methods</TabsTrigger>
+                <TabsTrigger value="accounts">Accounts</TabsTrigger>
+                <TabsTrigger value="audit-trail">Audit Trail</TabsTrigger>
+              </TabsList>
 
-            <TabsContent value="demographics" className="mt-0">
-              <DemographicsTab partyId={partyId} />
-            </TabsContent>
+              <div className="p-6">
+                <TabsContent value="overview" className="mt-0">
+                  <OverviewTab partyId={partyId} />
+                </TabsContent>
 
-            <TabsContent value="references" className="mt-0">
-              <ReferencesTab partyId={partyId} />
-            </TabsContent>
+                <TabsContent value="demographics" className="mt-0">
+                  <DemographicsTab partyId={partyId} />
+                </TabsContent>
 
-            <TabsContent value="associations" className="mt-0">
-              <AssociationsTab partyId={partyId} />
-            </TabsContent>
+                <TabsContent value="references" className="mt-0">
+                  <ReferencesTab partyId={partyId} />
+                </TabsContent>
 
-            <TabsContent value="bank-relations" className="mt-0">
-              <BankRelationsTab partyId={partyId} />
-            </TabsContent>
+                <TabsContent value="associations" className="mt-0">
+                  <AssociationsTab partyId={partyId} />
+                </TabsContent>
 
-            <TabsContent value="payment-methods" className="mt-0">
-              <PaymentMethodsTab partyId={partyId} />
-            </TabsContent>
+                <TabsContent value="bank-relations" className="mt-0">
+                  <BankRelationsTab partyId={partyId} />
+                </TabsContent>
 
-            <TabsContent value="accounts" className="mt-0">
-              <AccountsTab partyId={partyId} />
-            </TabsContent>
+                <TabsContent value="payment-methods" className="mt-0">
+                  <PaymentMethodsTab partyId={partyId} />
+                </TabsContent>
 
-            <TabsContent value="audit-trail" className="mt-0">
-              <AuditTrailTab partyId={partyId} />
-            </TabsContent>
-          </div>
-        </Tabs>
-      </Card>
-    </div>
+                <TabsContent value="accounts" className="mt-0">
+                  <AccountsTab partyId={partyId} />
+                </TabsContent>
+
+                <TabsContent value="audit-trail" className="mt-0">
+                  <AuditTrailTab partyId={partyId} />
+                </TabsContent>
+              </div>
+            </Tabs>
+          </Card>
+        </>
+      )}
+    </PageShell>
   )
 }

--- a/frontend/src/features/parties/pages/[partyId].tsx
+++ b/frontend/src/features/parties/pages/[partyId].tsx
@@ -36,7 +36,7 @@ export function PartyDetailPage() {
       {isLoading && <DetailSkeleton />}
       {isError && <ErrorState onRetry={refetch} />}
 
-      {party && (
+      {!isLoading && (
         <>
           <Card>
             <PartyHeader partyId={partyId} />

--- a/frontend/src/features/parties/pages/[partyId].tsx
+++ b/frontend/src/features/parties/pages/[partyId].tsx
@@ -36,7 +36,7 @@ export function PartyDetailPage() {
       {isLoading && <DetailSkeleton />}
       {isError && <ErrorState onRetry={refetch} />}
 
-      {!isLoading && (
+      {!isLoading && !isError && (
         <>
           <Card>
             <PartyHeader partyId={partyId} />

--- a/frontend/src/features/parties/pages/index.tsx
+++ b/frontend/src/features/parties/pages/index.tsx
@@ -4,6 +4,7 @@ import type { ColumnDef } from '@tanstack/react-table'
 import { DataTable } from '@/shared/data-table'
 import { TimeDisplay } from '@/shared/time-display'
 import { StatusBadge } from '@/shared/status-badge'
+import { PageHeader, PageShell } from '@/shared'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { usePartiesTable } from '../hooks'
@@ -98,21 +99,19 @@ export function PartiesPage() {
   if (!tenantSlug) return null
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Parties</h1>
-          <p className="mt-2 text-muted-foreground">
-            Manage parties, their demographics, and linked accounts.
-          </p>
-        </div>
-        <div className="flex gap-2">
-          <Button onClick={() => setRegisterOpen(true)}>Register Party</Button>
-          <Button variant="outline" onClick={() => setAddPartyTypeOpen(true)}>
-            Add Party Type
-          </Button>
-        </div>
-      </div>
+    <PageShell>
+      <PageHeader
+        title="Parties"
+        description="Manage parties, their demographics, and linked accounts."
+        actions={
+          <>
+            <Button onClick={() => setRegisterOpen(true)}>Register Party</Button>
+            <Button variant="outline" onClick={() => setAddPartyTypeOpen(true)}>
+              Add Party Type
+            </Button>
+          </>
+        }
+      />
 
       <RegisterPartyDialog open={registerOpen} onOpenChange={setRegisterOpen} />
       <RegisterPartyTypeDialog
@@ -130,6 +129,6 @@ export function PartiesPage() {
           onRowClick={handleRowClick}
         />
       </Card>
-    </div>
+    </PageShell>
   )
 }


### PR DESCRIPTION
## Summary

- Replace manual \`div\`/\`h1\` layout in \`PartiesPage\` with \`PageShell\` and \`PageHeader\` shared components
- Add \`DetailSkeleton\` for loading state and \`ErrorState\` for error state to \`PartyDetailPage\`
- Show \`DetailSkeleton\` during initial load; after load, show \`ErrorState\` (if applicable) inline above \`PartyHeader\` and tabs
- Tabs remain visible after load regardless of error state, since each tab fetches its own data by \`partyId\`
- Update existing test to use \`waitFor\` for tab rendering (tabs render after async data resolves)

## Changes

- \`frontend/src/features/parties/pages/index.tsx\` — Replace outer \`div\`/header block with \`PageShell\`/\`PageHeader\`
- \`frontend/src/features/parties/pages/[partyId].tsx\` — Replace outer \`div\` with \`PageShell\`, add \`DetailSkeleton\` during loading, show \`ErrorState\` inline after load on error, always show tabs post-load
- \`frontend/src/features/parties/pages/[partyId].test.tsx\` — Add \`waitFor\` to tab rendering assertion

## Task

frontend-ux-consistency.5 — Align parties list and detail pages