### PR TITLE
feat: Align payments, positions, reconciliation detail pages to canonical pattern

### DIFF
--- a/frontend/src/features/payments/pages/payment-detail.tsx
+++ b/frontend/src/features/payments/pages/payment-detail.tsx
@@ -131,7 +131,7 @@ export function PaymentDetailPage() {
   if (isError || !data) {
     return (
       <div data-testid="payment-detail-error">
-        <PageShell>
+        <PageShell className="p-6">
           <Breadcrumbs items={[{ label: 'Payments', href: '/payments' }, { label: 'Error' }]} />
           <ErrorState message="Failed to load payment order details." />
         </PageShell>
@@ -140,7 +140,7 @@ export function PaymentDetailPage() {
   }
 
   return (
-    <PageShell>
+    <PageShell className="p-6">
       {/* Breadcrumb navigation */}
       <Breadcrumbs
         items={[

--- a/frontend/src/features/payments/pages/payment-detail.tsx
+++ b/frontend/src/features/payments/pages/payment-detail.tsx
@@ -10,7 +10,7 @@ import { StatusBadge } from '@/shared/status-badge'
 import { TimeDisplay } from '@/shared/time-display'
 import { SagaTimeline } from '@/features/sagas/components/saga-timeline'
 import { AuditTrail } from '@/shared/audit-trail'
-import { EntityLink, Breadcrumbs } from '@/shared'
+import { EntityLink, Breadcrumbs, PageShell, ErrorState } from '@/shared'
 import { tenantKeys } from '@/lib/query-keys'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { usePaymentDetail } from '../hooks'
@@ -130,15 +130,17 @@ export function PaymentDetailPage() {
 
   if (isError || !data) {
     return (
-      <div data-testid="payment-detail-error" className="p-6">
-        <Breadcrumbs items={[{ label: 'Payments', href: '/payments' }, { label: 'Error' }]} />
-        <p className="mt-4 text-sm text-destructive">Failed to load payment order details.</p>
+      <div data-testid="payment-detail-error">
+        <PageShell>
+          <Breadcrumbs items={[{ label: 'Payments', href: '/payments' }, { label: 'Error' }]} />
+          <ErrorState message="Failed to load payment order details." />
+        </PageShell>
       </div>
     )
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <PageShell>
       {/* Breadcrumb navigation */}
       <Breadcrumbs
         items={[
@@ -244,6 +246,6 @@ export function PaymentDetailPage() {
         onOpenChange={setInitiateOpen}
         onSuccess={handleInitiateSuccess}
       />
-    </div>
+    </PageShell>
   )
 }

--- a/frontend/src/features/positions/pages/detail.test.tsx
+++ b/frontend/src/features/positions/pages/detail.test.tsx
@@ -85,22 +85,29 @@ describe('PositionDetailPage', () => {
     mockRetrieveFinancialPositionLog.mockResolvedValue({ log: null })
   })
 
-  it('renders page title', () => {
+  it('renders page title', async () => {
     renderDetailPage()
-    expect(screen.getByText('Position Log')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByText('Position Log')).toBeInTheDocument()
+    })
   })
 
-  it('renders back link to positions list', () => {
+  it('renders back link to positions list', async () => {
     renderDetailPage()
-    const positionsLink = screen.getByRole('link', { name: 'Positions' })
-    expect(positionsLink).toBeInTheDocument()
-    expect(positionsLink).toHaveAttribute('href', '/positions')
+    await waitFor(() => {
+      const positionsLink = screen.getByRole('link', { name: 'Positions' })
+      expect(positionsLink).toBeInTheDocument()
+      expect(positionsLink).toHaveAttribute('href', '/positions')
+    })
   })
 
   it('navigates back to positions list on breadcrumb link click', async () => {
     const user = userEvent.setup()
     renderDetailPage()
 
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Positions' })).toBeInTheDocument()
+    })
     const positionsLink = screen.getByRole('link', { name: 'Positions' })
     await user.click(positionsLink)
 

--- a/frontend/src/features/positions/pages/detail.tsx
+++ b/frontend/src/features/positions/pages/detail.tsx
@@ -189,7 +189,7 @@ export function PositionDetailPage() {
     return <DetailSkeleton fieldCount={5} tabCount={2} showBackNav />
   }
 
-  if (isError) {
+  if (isError || !log) {
     return (
       <PageShell>
         <Breadcrumbs
@@ -200,8 +200,8 @@ export function PositionDetailPage() {
         />
         <h1 className="text-3xl font-bold tracking-tight">Position Log</h1>
         <ErrorState
-          message="Failed to load position log"
-          onRetry={() => void refetch()}
+          message={isError ? 'Failed to load position log' : 'Position log not found'}
+          onRetry={isError ? () => void refetch() : undefined}
         />
       </PageShell>
     )

--- a/frontend/src/features/positions/pages/detail.tsx
+++ b/frontend/src/features/positions/pages/detail.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react'
 import { useParams } from 'react-router-dom'
-import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { MoneyDisplay } from '@/shared/money-display'
 import { TimeDisplay } from '@/shared/time-display'
 import { QualityLadderBadge } from '@/features/positions/components/quality-ladder-badge'
 import { DirectionBadge } from '@/shared/direction-badge'
-import { EntityLink, Breadcrumbs } from '@/shared'
+import { EntityLink, Breadcrumbs, PageShell, DetailSkeleton, ErrorState } from '@/shared'
 import { accountEntityType } from '@/shared/account-entity-type'
-import { Skeleton } from '@/components/ui/skeleton'
 import { usePositionLogDetail } from '../hooks'
 import type { FinancialPositionLog, TransactionLogEntry } from './index'
 
@@ -187,8 +185,29 @@ export function PositionDetailPage() {
 
   const log = data?.log as FinancialPositionLog | undefined
 
+  if (isLoading) {
+    return <DetailSkeleton fieldCount={5} tabCount={2} showBackNav />
+  }
+
+  if (isError) {
+    return (
+      <PageShell>
+        <Breadcrumbs
+          items={[
+            { label: 'Positions', href: '/positions' },
+            { label: logId ?? 'Position Log' },
+          ]}
+        />
+        <ErrorState
+          message="Failed to load position log"
+          onRetry={() => void refetch()}
+        />
+      </PageShell>
+    )
+  }
+
   return (
-    <div className="space-y-6">
+    <PageShell>
       <Breadcrumbs
         items={[
           { label: 'Positions', href: '/positions' },
@@ -203,61 +222,39 @@ export function PositionDetailPage() {
         )}
       </div>
 
-      {isError && (
+      {log && (
         <Card className="p-6">
-          <div className="flex flex-col items-center gap-3 text-destructive">
-            <span className="text-sm font-medium">Failed to load position log</span>
-            <Button variant="outline" size="sm" onClick={() => void refetch()}>
-              Retry
-            </Button>
-          </div>
-        </Card>
-      )}
+          <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <LabeledField label="Log ID">
+              <span className="font-mono text-xs">{log?.logId ?? '—'}</span>
+            </LabeledField>
 
-      {(isLoading || log) && (
-        <Card className="p-6">
-          {isLoading ? (
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {Array.from({ length: 5 }).map((_, i) => (
-                <div key={i}>
-                  <Skeleton className="h-4 w-24 mb-2" />
-                  <Skeleton className="h-5 w-40" />
-                </div>
-              ))}
-            </div>
-          ) : (
-            <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              <LabeledField label="Log ID">
-                <span className="font-mono text-xs">{log?.logId ?? '—'}</span>
-              </LabeledField>
-
-              <LabeledField label="Account ID">
-                {log?.accountId ? (
-                  accountEntityType(log.accountServiceDomain) ? (
-                    <EntityLink type={accountEntityType(log.accountServiceDomain)!} id={log.accountId} className="font-mono text-xs text-blue-600 hover:underline dark:text-blue-400" />
-                  ) : (
-                    <span className="font-mono text-xs">{log.accountId}</span>
-                  )
+            <LabeledField label="Account ID">
+              {log?.accountId ? (
+                accountEntityType(log.accountServiceDomain) ? (
+                  <EntityLink type={accountEntityType(log.accountServiceDomain)!} id={log.accountId} className="font-mono text-xs text-blue-600 hover:underline dark:text-blue-400" />
                 ) : (
-                  <span>—</span>
-                )}
-              </LabeledField>
+                  <span className="font-mono text-xs">{log.accountId}</span>
+                )
+              ) : (
+                <span>—</span>
+              )}
+            </LabeledField>
 
-              <LabeledField label="Status">
-                <span>
-                  {typeof log?.statusTracking?.currentStatus === 'string' ? log.statusTracking.currentStatus.replace(/_/g, ' ') : '—'}
-                </span>
-              </LabeledField>
+            <LabeledField label="Status">
+              <span>
+                {typeof log?.statusTracking?.currentStatus === 'string' ? log.statusTracking.currentStatus.replace(/_/g, ' ') : '—'}
+              </span>
+            </LabeledField>
 
-              <LabeledField label="Created">
-                <TimeDisplay timestamp={log?.createdAt} />
-              </LabeledField>
+            <LabeledField label="Created">
+              <TimeDisplay timestamp={log?.createdAt} />
+            </LabeledField>
 
-              <LabeledField label="Last Updated">
-                <TimeDisplay timestamp={log?.updatedAt} />
-              </LabeledField>
-            </dl>
-          )}
+            <LabeledField label="Last Updated">
+              <TimeDisplay timestamp={log?.updatedAt} />
+            </LabeledField>
+          </dl>
         </Card>
       )}
 
@@ -279,6 +276,6 @@ export function PositionDetailPage() {
           </TabsContent>
         </Tabs>
       )}
-    </div>
+    </PageShell>
   )
 }

--- a/frontend/src/features/positions/pages/detail.tsx
+++ b/frontend/src/features/positions/pages/detail.tsx
@@ -198,6 +198,7 @@ export function PositionDetailPage() {
             { label: logId ?? 'Position Log' },
           ]}
         />
+        <h1 className="text-3xl font-bold tracking-tight">Position Log</h1>
         <ErrorState
           message="Failed to load position log"
           onRetry={() => void refetch()}

--- a/frontend/src/features/reconciliation/pages/detail.tsx
+++ b/frontend/src/features/reconciliation/pages/detail.tsx
@@ -565,6 +565,12 @@ export function ReconciliationDetailPage() {
   if (isError || !run) {
     return (
       <PageShell className="p-6">
+        <Breadcrumbs
+          items={[
+            { label: 'Reconciliation', href: '/reconciliation' },
+            { label: runId },
+          ]}
+        />
         <ErrorState message="Failed to load reconciliation run." />
       </PageShell>
     )

--- a/frontend/src/features/reconciliation/pages/detail.tsx
+++ b/frontend/src/features/reconciliation/pages/detail.tsx
@@ -7,8 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { StatusBadge } from '@/shared/status-badge'
 import { CELEditor } from '@/features/sagas/components/cel-editor'
-import { Breadcrumbs } from '@/shared'
-import { DetailSkeleton } from '@/shared/detail-skeleton'
+import { Breadcrumbs, DetailSkeleton, ErrorState, PageShell } from '@/shared'
 import {
   VarianceDetail,
   type Variance,
@@ -565,14 +564,14 @@ export function ReconciliationDetailPage() {
 
   if (isError || !run) {
     return (
-      <div className="p-6">
-        <p className="text-destructive text-sm">Failed to load reconciliation run.</p>
-      </div>
+      <PageShell className="p-6">
+        <ErrorState message="Failed to load reconciliation run." />
+      </PageShell>
     )
   }
 
   return (
-    <div className="p-6">
+    <PageShell className="p-6">
       {/* Breadcrumb navigation */}
       <div className="mb-6">
         <Breadcrumbs
@@ -620,6 +619,6 @@ export function ReconciliationDetailPage() {
           <BalanceAssertionsTab runId={runId} />
         </TabsContent>
       </Tabs>
-    </div>
+    </PageShell>
   )
 }


### PR DESCRIPTION
## Summary

- Wrap payment, position, and reconciliation detail pages with `PageShell` shared component
- Replace custom error markup with `ErrorState` shared component (with retry support where applicable)
- Replace inline skeleton markup in position detail with `DetailSkeleton` shared component
- Extract early returns for loading/error states in position detail for cleaner control flow

## Changes Made

**`frontend/src/features/payments/pages/payment-detail.tsx`**
- Main page wrapper: `<div className="p-6 space-y-6">` → `<PageShell>`
- Error state: plain div → `<ErrorState>` wrapped in `data-testid` div (preserves test assertion)

**`frontend/src/features/positions/pages/detail.tsx`**
- Loading state: inline `Skeleton` grid → `<DetailSkeleton fieldCount={5} tabCount={2} />`
- Error state: `Card` with custom buttons → `<ErrorState onRetry={...}>` with early return
- Main page wrapper: `<div className="space-y-6">` → `<PageShell>`
- Removed unused `Button` and `Skeleton` imports

**`frontend/src/features/reconciliation/pages/detail.tsx`**
- Main page wrapper: `<div className="p-6">` → `<PageShell className="p-6">`
- Error state: plain `<p>` in div → `<ErrorState>`
- Already used `DetailSkeleton` — kept as-is

## Test plan

- [ ] ESLint: clean (`npx eslint` on all 3 files — passes)
- [ ] TypeScript: clean (`npx tsc --noEmit` — passes)
- [ ] Test failures pre-exist on develop (`AuditOperationEnum.INSERT` missing generated proto) — not introduced by this PR
- [ ] All functionality preserved: tabs, data fetching, actions, dialogs, breadcrumbs, status badges