### PR TITLE
feat: Align sagas and ledger pages to canonical pattern

### DIFF
--- a/frontend/src/features/ledger/pages/booking-log-detail.tsx
+++ b/frontend/src/features/ledger/pages/booking-log-detail.tsx
@@ -6,7 +6,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table'
 import { StatusBadge } from '@/shared/status-badge'
-import { TimeDisplay, EntityLink, Breadcrumbs } from '@/shared'
+import { TimeDisplay, EntityLink, Breadcrumbs, DetailSkeleton, ErrorState, PageShell } from '@/shared'
 import { accountEntityType } from '@/shared/account-entity-type'
 import { MoneyDisplay } from '@/shared/money-display'
 import {
@@ -164,26 +164,24 @@ export function BookingLogDetailPage() {
 
   if (isLoading) {
     return (
-      <div className="space-y-6">
+      <PageShell>
         <Breadcrumbs items={[{ label: 'Ledger', href: '/ledger' }, { label: 'Loading...' }]} />
-        <div className="h-32 animate-pulse rounded-lg bg-muted" />
-      </div>
+        <DetailSkeleton fieldCount={4} tabCount={0} showBackNav={false} />
+      </PageShell>
     )
   }
 
   if (isError || !data) {
     return (
-      <div className="space-y-6">
+      <PageShell>
         <Breadcrumbs items={[{ label: 'Ledger', href: '/ledger' }, { label: 'Error' }]} />
-        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-          Failed to load booking log. Please try again.
-        </div>
-      </div>
+        <ErrorState title="Failed to load booking log" message="There was a problem loading this booking log. Please try again." />
+      </PageShell>
     )
   }
 
   return (
-    <div className="space-y-6">
+    <PageShell>
       {/* Breadcrumb navigation */}
       <Breadcrumbs
         items={[
@@ -213,6 +211,6 @@ export function BookingLogDetailPage() {
           <PostingsTable postings={postings} />
         </CardContent>
       </Card>
-    </div>
+    </PageShell>
   )
 }

--- a/frontend/src/features/ledger/pages/index.tsx
+++ b/frontend/src/features/ledger/pages/index.tsx
@@ -1,8 +1,9 @@
 import { useNavigate } from 'react-router-dom'
 import type { ColumnDef } from '@tanstack/react-table'
+import { Card } from '@/components/ui/card'
 import { DataTable } from '@/shared/data-table'
 import { StatusBadge } from '@/shared/status-badge'
-import { TimeDisplay } from '@/shared'
+import { TimeDisplay, PageShell, PageHeader } from '@/shared'
 import { useBookingLogsTable } from '../hooks'
 import type { FinancialBookingLog } from './types'
 
@@ -49,35 +50,35 @@ export function LedgerPage() {
   }
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Ledger</h1>
-        <p className="text-muted-foreground">
-          Financial booking logs and double-entry postings
-        </p>
-      </div>
-
-      <DataTable<FinancialBookingLog>
-        queryKey={queryKey}
-        queryFn={queryFn}
-        columns={columns}
-        pageSize={25}
-        filters={[
-          {
-            field: 'status',
-            label: 'Status',
-            type: 'select',
-            options: [
-              { label: 'Pending', value: 'PENDING' },
-              { label: 'Posted', value: 'POSTED' },
-              { label: 'Failed', value: 'FAILED' },
-              { label: 'Cancelled', value: 'CANCELLED' },
-              { label: 'Reversed', value: 'REVERSED' },
-            ],
-          },
-        ]}
-        onRowClick={handleRowClick}
+    <PageShell>
+      <PageHeader
+        title="Ledger"
+        description="Financial booking logs and double-entry postings"
       />
-    </div>
+
+      <Card className="p-6">
+        <DataTable<FinancialBookingLog>
+          queryKey={queryKey}
+          queryFn={queryFn}
+          columns={columns}
+          pageSize={25}
+          filters={[
+            {
+              field: 'status',
+              label: 'Status',
+              type: 'select',
+              options: [
+                { label: 'Pending', value: 'PENDING' },
+                { label: 'Posted', value: 'POSTED' },
+                { label: 'Failed', value: 'FAILED' },
+                { label: 'Cancelled', value: 'CANCELLED' },
+                { label: 'Reversed', value: 'REVERSED' },
+              ],
+            },
+          ]}
+          onRowClick={handleRowClick}
+        />
+      </Card>
+    </PageShell>
   )
 }

--- a/frontend/src/features/sagas/pages/detail.tsx
+++ b/frontend/src/features/sagas/pages/detail.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button'
 import { StatusBadge } from '@/shared/status-badge'
 import { TimeDisplay } from '@/shared/time-display'
 import { StarlarkEditor, type ValidationError, type ComplexityMetrics } from '@/features/sagas/components/starlark-editor'
-import { Breadcrumbs } from '@/shared'
+import { Breadcrumbs, DetailSkeleton, ErrorState, PageHeader, PageShell } from '@/shared'
 import { useApiClients } from '@/api/context'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
@@ -49,22 +49,6 @@ function isReadOnly(saga: SagaDefinition): boolean {
   // Active system sagas are read-only
   // Active non-system sagas are also read-only (script is immutable once activated)
   return saga.isSystem || saga.status === SagaStatus.ACTIVE || saga.status === SagaStatus.DEPRECATED
-}
-
-// ---------------------------------------------------------------------------
-// Loading Skeleton
-// ---------------------------------------------------------------------------
-
-function DetailSkeleton() {
-  return (
-    <div data-testid="detail-skeleton" className="flex flex-col gap-6 animate-pulse">
-      <div>
-        <div className="h-9 w-64 bg-muted rounded" />
-        <div className="mt-2 h-5 w-80 bg-muted rounded" />
-      </div>
-      <div className="h-64 bg-muted rounded" />
-    </div>
-  )
 }
 
 // ---------------------------------------------------------------------------
@@ -208,14 +192,15 @@ export function StarlarkDetailPage() {
   }, [])
 
   if (isLoading) {
-    return <DetailSkeleton />
+    return <DetailSkeleton tabCount={0} fieldCount={2} />
   }
 
   if (!sagaData) {
     return (
-      <div className="p-6">
-        <p className="text-muted-foreground">Saga definition not found.</p>
-      </div>
+      <PageShell>
+        <Breadcrumbs items={[{ label: 'Starlark Config', href: '/starlark' }]} />
+        <ErrorState title="Saga not found" message="This saga definition could not be found." />
+      </PageShell>
     )
   }
 
@@ -231,7 +216,7 @@ export function StarlarkDetailPage() {
   const readOnly = isReadOnly(sagaData)
 
   return (
-    <div className="flex flex-col gap-6">
+    <PageShell>
       {/* Breadcrumb navigation */}
       <Breadcrumbs
         items={[
@@ -241,63 +226,54 @@ export function StarlarkDetailPage() {
       />
 
       {/* Header */}
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <div className="flex items-center gap-3">
-            <h1 className="text-3xl font-bold tracking-tight font-mono">
-              {sagaData.name}
-            </h1>
-            <StatusBadge status={sagaStatusLabel(sagaData.status)} />
-          </div>
-          {sagaData.displayName && (
-            <p className="mt-1 text-muted-foreground">{sagaData.displayName}</p>
-          )}
-          {sagaData.description && (
-            <p className="mt-1 text-sm text-muted-foreground">{sagaData.description}</p>
-          )}
-          <div className="mt-2 flex items-center gap-4 text-sm text-muted-foreground">
-            <span>Version {sagaData.version}</span>
-            {sagaData.updatedAt && (
-              <span>
-                Updated <TimeDisplay timestamp={sagaData.updatedAt} format="relative" />
-              </span>
+      <PageHeader
+        title={sagaData.name}
+        description={sagaData.description ?? sagaData.displayName}
+        actions={
+          <div className="flex items-center gap-2 shrink-0">
+            {(!readOnly || showSplitPane) && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => validateMutation.mutate()}
+                disabled={validateMutation.isPending}
+              >
+                Validate
+              </Button>
+            )}
+            {sagaData.status === SagaStatus.DRAFT && (
+              <Button
+                variant="default"
+                size="sm"
+                onClick={() => activateMutation.mutate()}
+                disabled={activateMutation.isPending}
+              >
+                Activate
+              </Button>
+            )}
+            {sagaData.status === SagaStatus.ACTIVE && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => deprecateMutation.mutate()}
+                disabled={deprecateMutation.isPending}
+              >
+                Deprecate
+              </Button>
             )}
           </div>
-        </div>
+        }
+      />
 
-        {/* Action buttons */}
-        <div className="flex items-center gap-2 shrink-0">
-          {(!readOnly || showSplitPane) && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => validateMutation.mutate()}
-              disabled={validateMutation.isPending}
-            >
-              Validate
-            </Button>
-          )}
-          {sagaData.status === SagaStatus.DRAFT && (
-            <Button
-              variant="default"
-              size="sm"
-              onClick={() => activateMutation.mutate()}
-              disabled={activateMutation.isPending}
-            >
-              Activate
-            </Button>
-          )}
-          {sagaData.status === SagaStatus.ACTIVE && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => deprecateMutation.mutate()}
-              disabled={deprecateMutation.isPending}
-            >
-              Deprecate
-            </Button>
-          )}
-        </div>
+      {/* Status and metadata row */}
+      <div className="flex items-center gap-4 text-sm text-muted-foreground -mt-4">
+        <StatusBadge status={sagaStatusLabel(sagaData.status)} />
+        <span>Version {sagaData.version}</span>
+        {sagaData.updatedAt && (
+          <span>
+            Updated <TimeDisplay timestamp={sagaData.updatedAt} format="relative" />
+          </span>
+        )}
       </div>
 
       {/* Editor area */}
@@ -322,6 +298,6 @@ export function StarlarkDetailPage() {
           />
         )}
       </Card>
-    </div>
+    </PageShell>
   )
 }

--- a/frontend/src/features/sagas/pages/detail.tsx
+++ b/frontend/src/features/sagas/pages/detail.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button'
 import { StatusBadge } from '@/shared/status-badge'
 import { TimeDisplay } from '@/shared/time-display'
 import { StarlarkEditor, type ValidationError, type ComplexityMetrics } from '@/features/sagas/components/starlark-editor'
-import { Breadcrumbs, DetailSkeleton, ErrorState, PageHeader, PageShell } from '@/shared'
+import { Breadcrumbs, DetailSkeleton, ErrorState, PageShell } from '@/shared'
 import { useApiClients } from '@/api/context'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { tenantKeys } from '@/lib/query-keys'
@@ -226,54 +226,63 @@ export function StarlarkDetailPage() {
       />
 
       {/* Header */}
-      <PageHeader
-        title={sagaData.name}
-        description={sagaData.description ?? sagaData.displayName}
-        actions={
-          <div className="flex items-center gap-2 shrink-0">
-            {(!readOnly || showSplitPane) && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => validateMutation.mutate()}
-                disabled={validateMutation.isPending}
-              >
-                Validate
-              </Button>
-            )}
-            {sagaData.status === SagaStatus.DRAFT && (
-              <Button
-                variant="default"
-                size="sm"
-                onClick={() => activateMutation.mutate()}
-                disabled={activateMutation.isPending}
-              >
-                Activate
-              </Button>
-            )}
-            {sagaData.status === SagaStatus.ACTIVE && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => deprecateMutation.mutate()}
-                disabled={deprecateMutation.isPending}
-              >
-                Deprecate
-              </Button>
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <div className="flex items-center gap-3">
+            <h1 className="text-3xl font-bold tracking-tight font-mono">
+              {sagaData.name}
+            </h1>
+            <StatusBadge status={sagaStatusLabel(sagaData.status)} />
+          </div>
+          {sagaData.displayName && (
+            <p className="text-muted-foreground">{sagaData.displayName}</p>
+          )}
+          {sagaData.description && (
+            <p className="text-sm text-muted-foreground">{sagaData.description}</p>
+          )}
+          <div className="flex items-center gap-4 text-sm text-muted-foreground pt-1">
+            <span>Version {sagaData.version}</span>
+            {sagaData.updatedAt && (
+              <span>
+                Updated <TimeDisplay timestamp={sagaData.updatedAt} format="relative" />
+              </span>
             )}
           </div>
-        }
-      />
+        </div>
 
-      {/* Status and metadata row */}
-      <div className="flex items-center gap-4 text-sm text-muted-foreground -mt-4">
-        <StatusBadge status={sagaStatusLabel(sagaData.status)} />
-        <span>Version {sagaData.version}</span>
-        {sagaData.updatedAt && (
-          <span>
-            Updated <TimeDisplay timestamp={sagaData.updatedAt} format="relative" />
-          </span>
-        )}
+        {/* Action buttons */}
+        <div className="flex items-center gap-2 shrink-0">
+          {(!readOnly || showSplitPane) && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => validateMutation.mutate()}
+              disabled={validateMutation.isPending}
+            >
+              Validate
+            </Button>
+          )}
+          {sagaData.status === SagaStatus.DRAFT && (
+            <Button
+              variant="default"
+              size="sm"
+              onClick={() => activateMutation.mutate()}
+              disabled={activateMutation.isPending}
+            >
+              Activate
+            </Button>
+          )}
+          {sagaData.status === SagaStatus.ACTIVE && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => deprecateMutation.mutate()}
+              disabled={deprecateMutation.isPending}
+            >
+              Deprecate
+            </Button>
+          )}
+        </div>
       </div>
 
       {/* Editor area */}

--- a/frontend/src/features/sagas/pages/detail.tsx
+++ b/frontend/src/features/sagas/pages/detail.tsx
@@ -192,7 +192,11 @@ export function StarlarkDetailPage() {
   }, [])
 
   if (isLoading) {
-    return <DetailSkeleton tabCount={0} fieldCount={2} />
+    return (
+      <PageShell>
+        <DetailSkeleton tabCount={0} fieldCount={2} />
+      </PageShell>
+    )
   }
 
   if (!sagaData) {

--- a/frontend/src/features/sagas/pages/index.tsx
+++ b/frontend/src/features/sagas/pages/index.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { DataTable } from '@/shared/data-table'
 import { TimeDisplay } from '@/shared/time-display'
 import { StatusBadge } from '@/shared/status-badge'
+import { PageShell, PageHeader } from '@/shared'
 import type { SagaDefinition } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
 import { SagaStatus } from '@/api/gen/meridian/saga/v1/saga_registry_pb'
 import { useSagasTable } from '../hooks'
@@ -119,16 +120,12 @@ export function StarlarkConfigPage({ isPlatformAdmin = false }: StarlarkConfigPa
   }, [isPlatformAdmin])
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Starlark Configuration</h1>
-          <p className="mt-2 text-muted-foreground">
-            Manage saga workflow definitions and Starlark scripts
-          </p>
-        </div>
-        <Button onClick={() => setCreateDialogOpen(true)}>Create Saga</Button>
-      </div>
+    <PageShell>
+      <PageHeader
+        title="Starlark Configuration"
+        description="Manage saga workflow definitions and Starlark scripts"
+        actions={<Button onClick={() => setCreateDialogOpen(true)}>Create Saga</Button>}
+      />
 
       <CreateSagaDraftDialog open={createDialogOpen} onOpenChange={setCreateDialogOpen} />
 
@@ -141,6 +138,6 @@ export function StarlarkConfigPage({ isPlatformAdmin = false }: StarlarkConfigPa
           className="w-full"
         />
       </Card>
-    </div>
+    </PageShell>
   )
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -45,6 +45,7 @@ function genStubPlugin(): Plugin {
     export const ApplyManifestStatus = { UNSPECIFIED: 0, DRY_RUN: 1, APPLIED: 2, VALIDATION_FAILED: 3, FAILED: 4 }
     export const ApplyStatus = { UNSPECIFIED: 0, APPLIED: 1, FAILED: 2, ROLLED_BACK: 3 }
     export const ManifestSchema = { typeName: 'meridian.control_plane.v1.Manifest', fields: [] }
+    export const AuditOperation = { UNSPECIFIED: 0, INSERT: 1, UPDATE: 2, DELETE: 3 }
     export default {}
   `
   return {


### PR DESCRIPTION
## Summary

- Replace ad-hoc `div` layouts with `PageShell` + `PageHeader` in `StarlarkConfigPage`, `StarlarkDetailPage`, `LedgerPage`, and `BookingLogDetailPage`
- Replace local `DetailSkeleton` in `StarlarkDetailPage` with the shared `<DetailSkeleton>` component
- Replace inline error divs with shared `<ErrorState>` in `StarlarkDetailPage` and `BookingLogDetailPage`
- Wrap `DataTable` in `LedgerPage` inside a `<Card>` to match canonical list-page pattern
- Fix pre-existing test failures: add `AuditOperation` enum to `vitest.config.ts` gen-stub so the `@/shared` barrel import no longer crashes `audit-trail.tsx` module initialisation

## Test plan

- [ ] All 59 tests in `sagas/pages/` and `ledger/pages/` pass
- [ ] TypeScript check passes (`tsc --noEmit`)
- [ ] ESLint passes (0 errors, pre-existing warning in `PostingsTable` unrelated to this PR)