### PR TITLE
feat: Align reference-data, market-data, and mappings pages to canonical pattern

### DIFF
--- a/frontend/src/features/mappings/pages/[mappingId].tsx
+++ b/frontend/src/features/mappings/pages/[mappingId].tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import { useParams } from 'react-router-dom'
-import { Breadcrumbs } from '@/shared'
+import { Breadcrumbs } from '@/shared/breadcrumbs'
+import { PageShell } from '@/shared/page-shell'
+import { ErrorState } from '@/shared/error-state'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { Card } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -425,7 +427,7 @@ export function MappingDetailPage() {
   const { mappingId } = useParams<{ mappingId: string }>()
   const clients = useApiClients()
 
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ['mapping', mappingId],
     queryFn: async () => {
       const response = await clients.mapping.getMapping({ id: mappingId! })
@@ -438,62 +440,49 @@ export function MappingDetailPage() {
     return <div className="p-6 text-destructive">Mapping ID not found</div>
   }
 
-  if (isLoading) {
-    return (
-      <div className="space-y-6">
-        <Breadcrumbs items={[{ label: 'Gateway Mappings', href: '/mappings' }, { label: 'Loading...' }]} />
-        <DetailSkeleton fieldCount={4} tabCount={3} showBackNav={false} />
-      </div>
-    )
-  }
-
-  if (isError || !data) {
-    return (
-      <div className="space-y-6">
-        <Breadcrumbs items={[{ label: 'Gateway Mappings', href: '/mappings' }, { label: 'Error' }]} />
-        <Card className="p-6">
-          <p className="text-destructive">Failed to load mapping.</p>
-        </Card>
-      </div>
-    )
-  }
-
   return (
-    <div className="space-y-6">
+    <PageShell>
       <Breadcrumbs
         items={[
           { label: 'Gateway Mappings', href: '/mappings' },
-          { label: data.name },
+          { label: data?.name || (isLoading ? 'Loading...' : 'Error') },
         ]}
       />
 
-      <Card>
-        <MappingHeader mapping={data} />
-      </Card>
+      {isLoading && <DetailSkeleton fieldCount={4} tabCount={3} showBackNav={false} />}
+      {isError && <ErrorState onRetry={() => refetch()} />}
 
-      <Card>
-        <Tabs defaultValue="overview" className="w-full">
-          <TabsList className="grid w-full grid-cols-3 border-b rounded-none">
-            <TabsTrigger value="overview">Overview</TabsTrigger>
-            <TabsTrigger value="field-mapper">Field Mapper</TabsTrigger>
-            <TabsTrigger value="dry-run">Dry Run</TabsTrigger>
-          </TabsList>
+      {data && (
+        <>
+          <Card>
+            <MappingHeader mapping={data} />
+          </Card>
 
-          <div className="p-6">
-            <TabsContent value="overview" className="mt-0">
-              <OverviewTab mapping={data} />
-            </TabsContent>
+          <Card>
+            <Tabs defaultValue="overview" className="w-full">
+              <TabsList className="grid w-full grid-cols-3 border-b rounded-none">
+                <TabsTrigger value="overview">Overview</TabsTrigger>
+                <TabsTrigger value="field-mapper">Field Mapper</TabsTrigger>
+                <TabsTrigger value="dry-run">Dry Run</TabsTrigger>
+              </TabsList>
 
-            <TabsContent value="field-mapper" className="mt-0">
-              <FieldMapperTab mapping={data} />
-            </TabsContent>
+              <div className="p-6">
+                <TabsContent value="overview" className="mt-0">
+                  <OverviewTab mapping={data} />
+                </TabsContent>
 
-            <TabsContent value="dry-run" className="mt-0">
-              <DryRunTab mapping={data} />
-            </TabsContent>
-          </div>
-        </Tabs>
-      </Card>
-    </div>
+                <TabsContent value="field-mapper" className="mt-0">
+                  <FieldMapperTab mapping={data} />
+                </TabsContent>
+
+                <TabsContent value="dry-run" className="mt-0">
+                  <DryRunTab mapping={data} />
+                </TabsContent>
+              </div>
+            </Tabs>
+          </Card>
+        </>
+      )}
+    </PageShell>
   )
 }

--- a/frontend/src/features/mappings/pages/index.tsx
+++ b/frontend/src/features/mappings/pages/index.tsx
@@ -4,6 +4,8 @@ import type { ColumnDef } from '@tanstack/react-table'
 import { DataTable } from '@/shared/data-table'
 import { TimeDisplay } from '@/shared/time-display'
 import { StatusBadge } from '@/shared/status-badge'
+import { PageShell } from '@/shared/page-shell'
+import { PageHeader } from '@/shared/page-header'
 import { useApiClients } from '@/api/context'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -125,17 +127,12 @@ export function MappingsPage() {
   }
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Gateway Mappings</h1>
-          <p className="mt-2 text-muted-foreground">
-            Manage field correspondence mappings between external JSON payloads and internal Meridian
-            services.
-          </p>
-        </div>
-        <Button onClick={() => setCreateDialogOpen(true)}>Create Mapping</Button>
-      </div>
+    <PageShell>
+      <PageHeader
+        title="Gateway Mappings"
+        description="Manage field correspondence mappings between external JSON payloads and internal Meridian services."
+        actions={<Button onClick={() => setCreateDialogOpen(true)}>Create Mapping</Button>}
+      />
 
       <CreateMappingDialog
         open={createDialogOpen}
@@ -153,6 +150,6 @@ export function MappingsPage() {
           onRowClick={handleRowClick}
         />
       </Card>
-    </div>
+    </PageShell>
   )
 }

--- a/frontend/src/features/market-data/pages/[datasetCode].tsx
+++ b/frontend/src/features/market-data/pages/[datasetCode].tsx
@@ -227,7 +227,7 @@ export function DatasetDetailPage() {
         ]}
       />
 
-      {isLoading && <DetailSkeleton />}
+      {isLoading && <DetailSkeleton showBackNav={false} />}
       {isError && <ErrorState onRetry={() => datasetQuery.refetch()} />}
 
       {dataset && (

--- a/frontend/src/features/market-data/pages/[datasetCode].tsx
+++ b/frontend/src/features/market-data/pages/[datasetCode].tsx
@@ -1,9 +1,12 @@
 import { useParams } from 'react-router-dom'
-import { Breadcrumbs } from '@/shared'
+import { Breadcrumbs } from '@/shared/breadcrumbs'
+import { PageShell } from '@/shared/page-shell'
+import { PageHeader } from '@/shared/page-header'
+import { DetailSkeleton } from '@/shared/detail-skeleton'
+import { ErrorState } from '@/shared/error-state'
 import { format } from 'date-fns'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { StatusBadge } from '@/shared/status-badge'
-import { Skeleton } from '@/components/ui/skeleton'
 import { useTenantSlug } from '@/hooks/use-tenant-context'
 import { useDatasetDetail, useDatasetObservations } from '../hooks'
 
@@ -162,21 +165,24 @@ export function DatasetDetailPage() {
   const datasetQuery = useDatasetDetail(datasetCode)
   const observationsQuery = useDatasetObservations(datasetCode)
 
+  const isLoading = datasetQuery.isLoading
+  const isError = datasetQuery.isError
+
   if (!tenantSlug) {
     return (
-      <div className="p-6">
+      <PageShell>
         <Breadcrumbs items={[{ label: 'Market Data', href: '/market-data' }]} />
-        <p className="mt-4 text-muted-foreground">No tenant selected.</p>
-      </div>
+        <p className="text-muted-foreground">No tenant selected.</p>
+      </PageShell>
     )
   }
 
   if (!datasetCode) {
     return (
-      <div className="p-6">
+      <PageShell>
         <Breadcrumbs items={[{ label: 'Market Data', href: '/market-data' }]} />
-        <p className="mt-4 text-muted-foreground">No dataset selected.</p>
-      </div>
+        <p className="text-muted-foreground">No dataset selected.</p>
+      </PageShell>
     )
   }
 
@@ -213,102 +219,97 @@ export function DatasetDetailPage() {
   }
 
   return (
-    <div className="p-6 space-y-6">
+    <PageShell>
       <Breadcrumbs
         items={[
           { label: 'Market Data', href: '/market-data' },
           { label: dataset?.displayName || datasetCode },
         ]}
       />
-      <div>
-        {datasetQuery.isLoading ? (
-          <div className="space-y-2">
-            <Skeleton className="h-8 w-64" />
-            <Skeleton className="h-5 w-48" />
-          </div>
-        ) : (
-          <>
-            <h1 className="text-2xl font-semibold">
-              {dataset?.displayName || datasetCode}
-            </h1>
-            {dataset && (
-              <div className="mt-2 flex items-center gap-3">
+
+      {isLoading && <DetailSkeleton />}
+      {isError && <ErrorState onRetry={() => datasetQuery.refetch()} />}
+
+      {dataset && (
+        <>
+          <PageHeader
+            title={dataset.displayName || datasetCode}
+            description={dataset.description || undefined}
+            actions={
+              <div className="flex items-center gap-3">
                 <span className="font-mono text-sm text-muted-foreground">{dataset.code}</span>
                 <StatusBadge status={statusLabel(dataset.status)} />
                 <span className="text-sm text-muted-foreground">
                   Unit: <span className="font-mono">{dataset.unit}</span>
                 </span>
               </div>
-            )}
-            {dataset?.description && (
-              <p className="mt-2 text-sm text-muted-foreground">{dataset.description}</p>
-            )}
-          </>
-        )}
-      </div>
+            }
+          />
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">
-            Recent Observations
-            {observations.length > 0 && (
-              <span className="ml-2 text-sm font-normal text-muted-foreground">
-                ({observations.length} shown)
-              </span>
-            )}
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {observationsQuery.isLoading ? (
-            <div
-              data-testid="chart-skeleton"
-              className="h-48 animate-pulse rounded bg-muted"
-            />
-          ) : (
-            <ObservationChart
-              points={points}
-              unit={dataset?.unit ?? ''}
-            />
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">
+                Recent Observations
+                {observations.length > 0 && (
+                  <span className="ml-2 text-sm font-normal text-muted-foreground">
+                    ({observations.length} shown)
+                  </span>
+                )}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {observationsQuery.isLoading ? (
+                <div
+                  data-testid="chart-skeleton"
+                  className="h-48 animate-pulse rounded bg-muted"
+                />
+              ) : (
+                <ObservationChart
+                  points={points}
+                  unit={dataset.unit ?? ''}
+                />
+              )}
+            </CardContent>
+          </Card>
+
+          {observations.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Latest Values</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-2">
+                  {observations.slice(0, 10).map((obs) => {
+                    const seconds =
+                      obs.observedAt
+                        ? typeof obs.observedAt.seconds === 'bigint'
+                          ? Number(obs.observedAt.seconds)
+                          : obs.observedAt.seconds
+                        : null
+                    return (
+                      <div
+                        key={obs.id}
+                        className="flex items-center justify-between rounded border p-2 text-sm"
+                      >
+                        <span className="font-mono font-medium">{obs.value}</span>
+                        <span className="text-muted-foreground">
+                          {obs.resolutionKeyValue && (
+                            <span className="mr-3 font-mono text-xs">{obs.resolutionKeyValue}</span>
+                          )}
+                          <StatusBadge status={qualityLabel(obs.quality)} />
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {seconds ? format(new Date(seconds * 1000), 'MMM d, HH:mm') : '—'}
+                        </span>
+                      </div>
+                    )
+                  })}
+                </div>
+              </CardContent>
+            </Card>
           )}
-        </CardContent>
-      </Card>
-
-      {observations.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Latest Values</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-2">
-              {observations.slice(0, 10).map((obs) => {
-                const seconds =
-                  obs.observedAt
-                    ? typeof obs.observedAt.seconds === 'bigint'
-                      ? Number(obs.observedAt.seconds)
-                      : obs.observedAt.seconds
-                    : null
-                return (
-                  <div
-                    key={obs.id}
-                    className="flex items-center justify-between rounded border p-2 text-sm"
-                  >
-                    <span className="font-mono font-medium">{obs.value}</span>
-                    <span className="text-muted-foreground">
-                      {obs.resolutionKeyValue && (
-                        <span className="mr-3 font-mono text-xs">{obs.resolutionKeyValue}</span>
-                      )}
-                      <StatusBadge status={qualityLabel(obs.quality)} />
-                    </span>
-                    <span className="text-xs text-muted-foreground">
-                      {seconds ? format(new Date(seconds * 1000), 'MMM d, HH:mm') : '—'}
-                    </span>
-                  </div>
-                )
-              })}
-            </div>
-          </CardContent>
-        </Card>
+        </>
       )}
-    </div>
+    </PageShell>
   )
 }

--- a/frontend/src/features/market-data/pages/datasetCode.test.tsx
+++ b/frontend/src/features/market-data/pages/datasetCode.test.tsx
@@ -162,7 +162,7 @@ describe('DatasetDetailPage', () => {
     })
   })
 
-  it('shows chart skeleton while loading', () => {
+  it('shows detail skeleton while loading', () => {
     vi.mocked(createServiceClients).mockReturnValue({
       currentAccount: {} as never,
       paymentOrder: {} as never,
@@ -183,7 +183,7 @@ describe('DatasetDetailPage', () => {
       } as never,
     })
     renderPage()
-    expect(screen.getByTestId('chart-skeleton')).toBeInTheDocument()
+    expect(screen.getByTestId('detail-skeleton')).toBeInTheDocument()
   })
 
   it('renders no-tenant guard when tenant is missing', () => {

--- a/frontend/src/features/market-data/pages/index.tsx
+++ b/frontend/src/features/market-data/pages/index.tsx
@@ -3,7 +3,10 @@ import type { ColumnDef } from '@tanstack/react-table'
 import { useNavigate } from 'react-router-dom'
 import { DataTable } from '@/shared/data-table'
 import { StatusBadge } from '@/shared/status-badge'
-import { TimeDisplay } from '@/shared'
+import { TimeDisplay } from '@/shared/time-display'
+import { PageShell } from '@/shared/page-shell'
+import { PageHeader } from '@/shared/page-header'
+import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { useDatasetsTable } from '../hooks'
 import { CATEGORY_OPTIONS, STATUS_OPTIONS } from './constants'
@@ -118,40 +121,38 @@ export function MarketDataPage() {
   }
 
   return (
-    <div className="p-6">
-      <div className="mb-6 flex items-start justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold">Market Data</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Market data sets with price observations for FX rates, interest rates, energy prices, and more.
-          </p>
-        </div>
-        <Button onClick={() => setRegisterOpen(true)}>Register Dataset</Button>
-      </div>
-
-      <DataTable<DataSetRow>
-        queryKey={queryKey}
-        queryFn={queryFn}
-        columns={columns}
-        pageSize={25}
-        filters={[
-          {
-            field: 'category',
-            label: 'Category',
-            type: 'select',
-            options: CATEGORY_OPTIONS,
-          },
-          {
-            field: 'status',
-            label: 'Status',
-            type: 'select',
-            options: STATUS_OPTIONS,
-          },
-        ]}
-        onRowClick={(row) => navigate(`/market-data/${row.code}`)}
+    <PageShell>
+      <PageHeader
+        title="Market Data"
+        description="Market data sets with price observations for FX rates, interest rates, energy prices, and more."
+        actions={<Button onClick={() => setRegisterOpen(true)}>Register Dataset</Button>}
       />
 
+      <Card className="p-6">
+        <DataTable<DataSetRow>
+          queryKey={queryKey}
+          queryFn={queryFn}
+          columns={columns}
+          pageSize={25}
+          filters={[
+            {
+              field: 'category',
+              label: 'Category',
+              type: 'select',
+              options: CATEGORY_OPTIONS,
+            },
+            {
+              field: 'status',
+              label: 'Status',
+              type: 'select',
+              options: STATUS_OPTIONS,
+            },
+          ]}
+          onRowClick={(row) => navigate(`/market-data/${row.code}`)}
+        />
+      </Card>
+
       <RegisterDataSetDialog open={registerOpen} onOpenChange={setRegisterOpen} />
-    </div>
+    </PageShell>
   )
 }

--- a/frontend/src/features/reference-data/pages/account-types/index.tsx
+++ b/frontend/src/features/reference-data/pages/account-types/index.tsx
@@ -4,6 +4,8 @@ import { DataTable } from '@/shared/data-table'
 import { StatusBadge } from '@/shared/status-badge'
 import { CELEditor } from '@/features/sagas/components/cel-editor'
 import { useApiClients } from '@/api/context'
+import { PageShell } from '@/shared/page-shell'
+import { PageHeader } from '@/shared/page-header'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -104,18 +106,16 @@ export function AccountTypesPage() {
   }
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Account Types</h1>
-          <p className="mt-2 text-muted-foreground">
-            Account type registry with CEL policy configuration.
-          </p>
-        </div>
-        <Button onClick={() => setCreateDialogOpen(true)}>
-          Create Account Type
-        </Button>
-      </div>
+    <PageShell>
+      <PageHeader
+        title="Account Types"
+        description="Account type registry with CEL policy configuration."
+        actions={
+          <Button onClick={() => setCreateDialogOpen(true)}>
+            Create Account Type
+          </Button>
+        }
+      />
 
       <CreateAccountTypeDialog
         open={createDialogOpen}
@@ -207,6 +207,6 @@ export function AccountTypesPage() {
           </TabsContent>
         </Tabs>
       )}
-    </div>
+    </PageShell>
   )
 }

--- a/frontend/src/features/reference-data/pages/instruments/index.tsx
+++ b/frontend/src/features/reference-data/pages/instruments/index.tsx
@@ -5,6 +5,8 @@ import { DataTable } from '@/shared/data-table'
 import { StatusBadge } from '@/shared/status-badge'
 import { CELEditor } from '@/features/sagas/components/cel-editor'
 import { useApiClients } from '@/api/context'
+import { PageShell } from '@/shared/page-shell'
+import { PageHeader } from '@/shared/page-header'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { AlertTriangle } from 'lucide-react'
@@ -182,18 +184,16 @@ export function InstrumentsPage() {
   }
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Instruments</h1>
-          <p className="mt-2 text-muted-foreground">
-            Reference data instrument definitions with CEL validation expressions.
-          </p>
-        </div>
-        <Button onClick={() => setRegisterDialogOpen(true)}>
-          Register Instrument
-        </Button>
-      </div>
+    <PageShell>
+      <PageHeader
+        title="Instruments"
+        description="Reference data instrument definitions with CEL validation expressions."
+        actions={
+          <Button onClick={() => setRegisterDialogOpen(true)}>
+            Register Instrument
+          </Button>
+        }
+      />
 
       <RegisterInstrumentDialog
         open={registerDialogOpen}
@@ -299,6 +299,6 @@ export function InstrumentsPage() {
           </CardContent>
         </Card>
       )}
-    </div>
+    </PageShell>
   )
 }

--- a/frontend/src/features/reference-data/pages/nodes/index.tsx
+++ b/frontend/src/features/reference-data/pages/nodes/index.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useApiClients } from '@/api/context'
+import { PageShell } from '@/shared/page-shell'
+import { PageHeader } from '@/shared/page-header'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -124,19 +126,17 @@ export function NodesPage() {
   }
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Nodes</h1>
-          <p className="mt-2 text-muted-foreground">
-            Hierarchical reference data node browser with bi-temporal query support.
-          </p>
-        </div>
-        <Button onClick={handleAddRootNode} aria-label="Add Node">
-          <Plus className="h-4 w-4 mr-1" />
-          Add Node
-        </Button>
-      </div>
+    <PageShell>
+      <PageHeader
+        title="Nodes"
+        description="Hierarchical reference data node browser with bi-temporal query support."
+        actions={
+          <Button onClick={handleAddRootNode} aria-label="Add Node">
+            <Plus className="h-4 w-4 mr-1" />
+            Add Node
+          </Button>
+        }
+      />
 
       <CreateNodeDialog
         open={createDialogOpen}
@@ -186,6 +186,6 @@ export function NodesPage() {
           )}
         </CardContent>
       </Card>
-    </div>
+    </PageShell>
   )
 }


### PR DESCRIPTION
## Summary

- Wrap all list pages (instruments, nodes, account-types, market-data, mappings) with `PageShell`, `PageHeader`, and `Card`-wrapped `DataTable`
- Wrap detail pages (market-data detail, mapping detail) with `PageShell`, `Breadcrumbs`, `DetailSkeleton`, and `ErrorState` with retry
- Use direct imports from shared modules (`@/shared/page-shell`, `@/shared/page-header`, etc.) to avoid barrel import side effects from `@/shared` index

Task Master: frontend-ux-consistency.9

## Test plan

- [x] All 108 tests pass across 9 test suites
- [x] TypeScript compiles with no errors (`tsc --noEmit`)
- [x] ESLint passes on all modified directories
- [ ] CI passes