### PR TITLE
test: Add Playwright structural conformance tests for aligned pages

### DIFF
--- a/frontend/e2e/visual-consistency.spec.ts
+++ b/frontend/e2e/visual-consistency.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect, navigateTo } from './fixtures'
+
+/**
+ * Structural conformance tests for the canonical page layout.
+ *
+ * Every feature page should follow the shared layout pattern:
+ *   - PageShell: div.space-y-6 wrapper
+ *   - PageHeader: h1 with text-3xl font-bold tracking-tight
+ *   - List pages: DataTable wrapped in a Card (data-slot="card")
+ *   - Detail pages: Breadcrumbs nav + h1 + tab navigation
+ *
+ * These tests verify structural conformance only — no backend required.
+ * Auth tokens are memory-only; all navigation uses navigateTo() to preserve state.
+ */
+
+// ─── List pages ────────────────────────────────────────────────────────────────
+
+const LIST_PAGES = [
+  { path: '/accounts', heading: 'Accounts' },
+  { path: '/parties', heading: 'Parties' },
+  { path: '/payments', heading: 'Payments' },
+  { path: '/positions', heading: 'Positions' },
+  { path: '/reconciliation', heading: 'Reconciliation' },
+  { path: '/starlark-config', heading: 'Starlark Configuration' },
+  { path: '/ledger', heading: 'Ledger' },
+  { path: '/internal-accounts', heading: 'Internal Accounts' },
+  { path: '/audit-log', heading: 'Audit Log' },
+  { path: '/market-data', heading: 'Market Data' },
+  { path: '/gateway-mappings', heading: 'Gateway Mappings' },
+] as const
+
+const REFERENCE_DATA_PAGES = [
+  { path: '/reference-data/instruments', heading: 'Instruments' },
+  { path: '/reference-data/nodes', heading: 'Nodes' },
+  { path: '/reference-data/account-types', heading: 'Account Types' },
+] as const
+
+const ADMIN_LIST_PAGES = [
+  { path: '/users', heading: 'Users' },
+] as const
+
+test.describe('Structural conformance — list pages (tenant-user)', () => {
+  for (const page of [...LIST_PAGES, ...REFERENCE_DATA_PAGES]) {
+    test.describe(page.path, () => {
+      test('has PageShell wrapper (space-y-6)', async ({ authenticatedPage }) => {
+        await navigateTo(authenticatedPage, page.path)
+        // Wait for the heading to confirm page rendered
+        await expect(
+          authenticatedPage.getByRole('heading', { level: 1 }),
+        ).toBeVisible({ timeout: 10_000 })
+        // PageShell renders a div.space-y-6 containing the h1
+        const shell = authenticatedPage.locator('.space-y-6').filter({
+          has: authenticatedPage.getByRole('heading', { level: 1 }),
+        })
+        await expect(shell).toBeVisible()
+      })
+
+      test('has PageHeader h1 with correct styling', async ({ authenticatedPage }) => {
+        await navigateTo(authenticatedPage, page.path)
+        const h1 = authenticatedPage.getByRole('heading', { level: 1 })
+        await expect(h1).toBeVisible({ timeout: 10_000 })
+        await expect(h1).toHaveClass(/text-3xl/)
+        await expect(h1).toHaveClass(/font-bold/)
+        await expect(h1).toHaveClass(/tracking-tight/)
+      })
+
+      test('has DataTable inside a Card', async ({ authenticatedPage }) => {
+        await navigateTo(authenticatedPage, page.path)
+        await expect(
+          authenticatedPage.getByRole('heading', { level: 1 }),
+        ).toBeVisible({ timeout: 10_000 })
+        // Card uses data-slot="card", table is rendered inside it
+        const card = authenticatedPage.locator('[data-slot="card"]').first()
+        await expect(card).toBeVisible({ timeout: 10_000 })
+        // DataTable renders a <table> element
+        const table = card.locator('table')
+        await expect(table).toBeVisible()
+      })
+    })
+  }
+})
+
+test.describe('Structural conformance — list pages (platform-admin)', () => {
+  for (const page of ADMIN_LIST_PAGES) {
+    test.describe(page.path, () => {
+      test('has PageShell wrapper (space-y-6)', async ({ platformAdminPage }) => {
+        await navigateTo(platformAdminPage, page.path)
+        await expect(
+          platformAdminPage.getByRole('heading', { level: 1 }),
+        ).toBeVisible({ timeout: 10_000 })
+        const shell = platformAdminPage.locator('.space-y-6').filter({
+          has: platformAdminPage.getByRole('heading', { level: 1 }),
+        })
+        await expect(shell).toBeVisible()
+      })
+
+      test('has PageHeader h1 with correct styling', async ({ platformAdminPage }) => {
+        await navigateTo(platformAdminPage, page.path)
+        const h1 = platformAdminPage.getByRole('heading', { level: 1 })
+        await expect(h1).toBeVisible({ timeout: 10_000 })
+        await expect(h1).toHaveClass(/text-3xl/)
+        await expect(h1).toHaveClass(/font-bold/)
+        await expect(h1).toHaveClass(/tracking-tight/)
+      })
+
+      test('has DataTable inside a Card', async ({ platformAdminPage }) => {
+        await navigateTo(platformAdminPage, page.path)
+        await expect(
+          platformAdminPage.getByRole('heading', { level: 1 }),
+        ).toBeVisible({ timeout: 10_000 })
+        const card = platformAdminPage.locator('[data-slot="card"]').first()
+        await expect(card).toBeVisible({ timeout: 10_000 })
+        const table = card.locator('table')
+        await expect(table).toBeVisible()
+      })
+    })
+  }
+})
+
+// ─── Detail pages ──────────────────────────────────────────────────────────────
+
+/**
+ * Detail pages are tested by navigating to a known-invalid ID.
+ * Even for "not found" states, the canonical layout should render:
+ *   - Breadcrumbs (nav[aria-label="Breadcrumb"])
+ *   - PageShell wrapper (space-y-6)
+ *
+ * Detail pages that render a full detail view (with tabs) require a live backend
+ * and seeded data. Those structural checks are skipped unless a backend is available.
+ */
+
+const DETAIL_PAGES = [
+  { path: '/accounts/test-id-000', listPath: '/accounts', label: 'Accounts' },
+  { path: '/parties/test-id-000', listPath: '/parties', label: 'Parties' },
+  { path: '/payments/test-id-000', listPath: '/payments', label: 'Payments' },
+  { path: '/positions/test-id-000', listPath: '/positions', label: 'Positions' },
+  { path: '/starlark-config/test-id-000', listPath: '/starlark-config', label: 'Starlark' },
+  { path: '/gateway-mappings/test-id-000', listPath: '/gateway-mappings', label: 'Mappings' },
+] as const
+
+test.describe('Structural conformance — detail pages', () => {
+  for (const page of DETAIL_PAGES) {
+    test.describe(page.path, () => {
+      test('has Breadcrumbs navigation', async ({ authenticatedPage }) => {
+        await navigateTo(authenticatedPage, page.path)
+        // Breadcrumbs component renders nav[aria-label="Breadcrumb"]
+        const breadcrumbs = authenticatedPage.getByLabel('Breadcrumb')
+        await expect(breadcrumbs).toBeVisible({ timeout: 10_000 })
+      })
+
+      test('has PageShell wrapper (space-y-6)', async ({ authenticatedPage }) => {
+        await navigateTo(authenticatedPage, page.path)
+        // Even error/not-found states should use PageShell
+        const shell = authenticatedPage.locator('.space-y-6').first()
+        await expect(shell).toBeVisible({ timeout: 10_000 })
+      })
+    })
+  }
+})
+
+// ─── Reference Data hub page ───────────────────────────────────────────────────
+
+test.describe('Structural conformance — Reference Data hub', () => {
+  test('has PageShell and PageHeader', async ({ authenticatedPage }) => {
+    await navigateTo(authenticatedPage, '/reference-data')
+    const h1 = authenticatedPage.getByRole('heading', { level: 1 })
+    await expect(h1).toBeVisible({ timeout: 10_000 })
+    await expect(h1).toHaveClass(/text-3xl/)
+    await expect(h1).toHaveClass(/font-bold/)
+    await expect(h1).toHaveClass(/tracking-tight/)
+    const shell = authenticatedPage.locator('.space-y-6').filter({
+      has: authenticatedPage.getByRole('heading', { level: 1 }),
+    })
+    await expect(shell).toBeVisible()
+  })
+})

--- a/frontend/e2e/visual-consistency.spec.ts
+++ b/frontend/e2e/visual-consistency.spec.ts
@@ -61,10 +61,11 @@ test.describe('Structural conformance — list pages (tenant-user)', () => {
         await expect(shell).toBeVisible()
       })
 
-      test('has PageHeader h1 with correct styling', async ({ authenticatedPage }) => {
+      test('has PageHeader h1 with correct text and styling', async ({ authenticatedPage }) => {
         await navigateTo(authenticatedPage, page.path)
         const h1 = authenticatedPage.getByRole('heading', { level: 1 })
         await expect(h1).toBeVisible({ timeout: 10_000 })
+        await expect(h1).toHaveText(page.heading)
         await expect(h1).toHaveClass(/text-3xl/)
         await expect(h1).toHaveClass(/font-bold/)
         await expect(h1).toHaveClass(/tracking-tight/)
@@ -111,10 +112,11 @@ test.describe('Structural conformance — list pages (platform-admin)', () => {
         await expect(shell).toBeVisible()
       })
 
-      test('has PageHeader h1 with correct styling', async ({ platformAdminPage }) => {
+      test('has PageHeader h1 with correct text and styling', async ({ platformAdminPage }) => {
         await navigateTo(platformAdminPage, page.path)
         const h1 = platformAdminPage.getByRole('heading', { level: 1 })
         await expect(h1).toBeVisible({ timeout: 10_000 })
+        await expect(h1).toHaveText(page.heading)
         await expect(h1).toHaveClass(/text-3xl/)
         await expect(h1).toHaveClass(/font-bold/)
         await expect(h1).toHaveClass(/tracking-tight/)
@@ -167,9 +169,12 @@ test.describe('Structural conformance — detail pages', () => {
 
       test('has PageShell wrapper (space-y-6)', async ({ authenticatedPage }) => {
         await navigateTo(authenticatedPage, page.path)
-        // Even error/not-found states should use PageShell
-        const shell = authenticatedPage.locator('.space-y-6').first()
-        await expect(shell).toBeVisible({ timeout: 10_000 })
+        // Wait for breadcrumbs to confirm page rendered, then check PageShell
+        await expect(authenticatedPage.getByLabel('Breadcrumb')).toBeVisible({ timeout: 10_000 })
+        const shell = authenticatedPage.locator('.space-y-6').filter({
+          has: authenticatedPage.getByLabel('Breadcrumb'),
+        })
+        await expect(shell).toBeVisible()
       })
     })
   }
@@ -182,6 +187,7 @@ test.describe('Structural conformance — Reference Data hub', () => {
     await navigateTo(authenticatedPage, '/reference-data')
     const h1 = authenticatedPage.getByRole('heading', { level: 1 })
     await expect(h1).toBeVisible({ timeout: 10_000 })
+    await expect(h1).toHaveText('Reference Data')
     await expect(h1).toHaveClass(/text-3xl/)
     await expect(h1).toHaveClass(/font-bold/)
     await expect(h1).toHaveClass(/tracking-tight/)

--- a/frontend/e2e/visual-consistency.spec.ts
+++ b/frontend/e2e/visual-consistency.spec.ts
@@ -29,18 +29,24 @@ const LIST_PAGES = [
   { path: '/gateway-mappings', heading: 'Gateway Mappings' },
 ] as const
 
-const REFERENCE_DATA_PAGES = [
+const REFERENCE_DATA_TABLE_PAGES = [
   { path: '/reference-data/instruments', heading: 'Instruments' },
-  { path: '/reference-data/nodes', heading: 'Nodes' },
   { path: '/reference-data/account-types', heading: 'Account Types' },
+] as const
+
+// Nodes uses a tree view inside a Card, not a DataTable
+const REFERENCE_DATA_CARD_PAGES = [
+  { path: '/reference-data/nodes', heading: 'Nodes' },
 ] as const
 
 const ADMIN_LIST_PAGES = [
   { path: '/users', heading: 'Users' },
 ] as const
 
+const ALL_TENANT_LIST_PAGES = [...LIST_PAGES, ...REFERENCE_DATA_TABLE_PAGES, ...REFERENCE_DATA_CARD_PAGES]
+
 test.describe('Structural conformance — list pages (tenant-user)', () => {
-  for (const page of [...LIST_PAGES, ...REFERENCE_DATA_PAGES]) {
+  for (const page of ALL_TENANT_LIST_PAGES) {
     test.describe(page.path, () => {
       test('has PageShell wrapper (space-y-6)', async ({ authenticatedPage }) => {
         await navigateTo(authenticatedPage, page.path)
@@ -64,18 +70,29 @@ test.describe('Structural conformance — list pages (tenant-user)', () => {
         await expect(h1).toHaveClass(/tracking-tight/)
       })
 
-      test('has DataTable inside a Card', async ({ authenticatedPage }) => {
+      test('has content inside a Card', async ({ authenticatedPage }) => {
         await navigateTo(authenticatedPage, page.path)
         await expect(
           authenticatedPage.getByRole('heading', { level: 1 }),
         ).toBeVisible({ timeout: 10_000 })
-        // Card uses data-slot="card", table is rendered inside it
+        // Card uses data-slot="card"
         const card = authenticatedPage.locator('[data-slot="card"]').first()
         await expect(card).toBeVisible({ timeout: 10_000 })
-        // DataTable renders a <table> element
-        const table = card.locator('table')
-        await expect(table).toBeVisible()
       })
+    })
+  }
+
+  // DataTable-specific: verify <table> element exists inside the Card
+  for (const page of [...LIST_PAGES, ...REFERENCE_DATA_TABLE_PAGES]) {
+    test(`${page.path} has DataTable (table element) inside Card`, async ({ authenticatedPage }) => {
+      await navigateTo(authenticatedPage, page.path)
+      await expect(
+        authenticatedPage.getByRole('heading', { level: 1 }),
+      ).toBeVisible({ timeout: 10_000 })
+      const card = authenticatedPage.locator('[data-slot="card"]').first()
+      await expect(card).toBeVisible({ timeout: 10_000 })
+      const table = card.locator('table')
+      await expect(table).toBeVisible()
     })
   }
 })


### PR DESCRIPTION
## Summary

- Adds `visual-consistency.spec.ts` with Playwright E2E tests that verify all feature pages follow the canonical layout pattern established by the UX consistency epic
- Tests structural conformance only (no backend required): PageShell wrapper, PageHeader styling, Card-wrapped DataTable on list pages, and Breadcrumbs on detail pages
- Covers 14 list pages (accounts, parties, payments, positions, reconciliation, starlark-config, ledger, internal-accounts, audit-log, market-data, gateway-mappings, reference-data sub-pages, admin users) and 6 detail page routes

## Test plan

- [ ] TypeScript compiles cleanly (`tsc --noEmit` passes)
- [ ] ESLint passes with no warnings
- [ ] Tests run against Vite dev server (no backend needed)
- [ ] All structural assertions match the canonical PageShell/PageHeader/Card/Breadcrumbs patterns