### PR TITLE
feat: add IsBaseDomainAccess context annotation to TenantSubdomainMiddleware

### DIFF
--- a/services/mcp-server/internal/auth/subdomain.go
+++ b/services/mcp-server/internal/auth/subdomain.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -8,6 +9,20 @@ import (
 	"net/http"
 	"strings"
 )
+
+// baseDomainAccessKeyType is an unexported type for the base domain access context key,
+// preventing collisions with other packages' context keys.
+type baseDomainAccessKeyType struct{}
+
+var baseDomainAccessKey = baseDomainAccessKeyType{}
+
+// IsBaseDomainAccess reports whether the request was made to the base domain
+// (i.e., no tenant subdomain was present). Tools can query this to determine
+// whether to operate in multi-tenant discovery mode vs. single-tenant mode.
+func IsBaseDomainAccess(ctx context.Context) bool {
+	v, _ := ctx.Value(baseDomainAccessKey).(bool)
+	return v
+}
 
 // Subdomain validation errors.
 var (
@@ -67,8 +82,9 @@ func (m *TenantSubdomainMiddleware) Handler(validator ClaimsBearerValidator, met
 		subdomainSlug := extractSubdomain(r.Host, m.baseDomain)
 		if subdomainSlug == "" {
 			// No subdomain present — request is to the base domain directly.
-			// Allow it through (no tenant scoping needed).
-			next.ServeHTTP(w, r)
+			// Annotate context so tools can detect base domain access mode.
+			ctx := context.WithValue(r.Context(), baseDomainAccessKey, true)
+			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
 

--- a/services/mcp-server/internal/auth/subdomain_test.go
+++ b/services/mcp-server/internal/auth/subdomain_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -95,6 +96,29 @@ func (m *mockClaimsValidator) ValidateBearerWithTenant(_ string) (string, error)
 		return "", m.err
 	}
 	return m.tenantID, nil
+}
+
+func TestIsBaseDomainAccess(t *testing.T) {
+	t.Run("returns true when context has baseDomainAccessKey=true", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), baseDomainAccessKey, true)
+		if !IsBaseDomainAccess(ctx) {
+			t.Error("expected IsBaseDomainAccess to return true")
+		}
+	})
+
+	t.Run("returns false when context lacks the key", func(t *testing.T) {
+		ctx := context.Background()
+		if IsBaseDomainAccess(ctx) {
+			t.Error("expected IsBaseDomainAccess to return false")
+		}
+	})
+
+	t.Run("returns false when context has key set to false", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), baseDomainAccessKey, false)
+		if IsBaseDomainAccess(ctx) {
+			t.Error("expected IsBaseDomainAccess to return false")
+		}
+	})
 }
 
 func TestTenantSubdomainMiddleware(t *testing.T) {
@@ -205,6 +229,57 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 
 		if rec.Code != http.StatusUnauthorized {
 			t.Errorf("expected 401, got %d", rec.Code)
+		}
+	})
+
+	t.Run("annotates context with baseDomainAccessKey when no subdomain present", func(t *testing.T) {
+		mw := NewTenantSubdomainMiddleware("demo.meridianhub.cloud", logger)
+		validator := &mockClaimsValidator{tenantID: "acme"}
+
+		var capturedCtx context.Context
+		captureHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := mw.Handler(validator, meta, captureHandler)
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Host = "demo.meridianhub.cloud"
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rec.Code)
+		}
+		if !IsBaseDomainAccess(capturedCtx) {
+			t.Error("expected IsBaseDomainAccess to be true for base domain request")
+		}
+	})
+
+	t.Run("does not annotate context with baseDomainAccessKey when subdomain present", func(t *testing.T) {
+		mw := NewTenantSubdomainMiddleware("demo.meridianhub.cloud", logger)
+		validator := &mockClaimsValidator{tenantID: "acme"}
+
+		var capturedCtx context.Context
+		captureHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+
+		handler := mw.Handler(validator, meta, captureHandler)
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Host = "acme.demo.meridianhub.cloud"
+		req.Header.Set("Authorization", "Bearer valid-token")
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rec.Code)
+		}
+		if IsBaseDomainAccess(capturedCtx) {
+			t.Error("expected IsBaseDomainAccess to be false for subdomain request")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Adds `IsBaseDomainAccess(ctx context.Context) bool` helper function to `services/mcp-server/internal/auth/subdomain.go`
- Updates `TenantSubdomainMiddleware.Handler` to annotate the request context with `baseDomainAccessKey=true` when no tenant subdomain is present (base domain access)
- Downstream MCP tools can call `IsBaseDomainAccess(ctx)` to determine whether to operate in multi-tenant discovery mode vs. single-tenant mode

## Changes Made

- `subdomain.go`: Added unexported `baseDomainAccessKeyType` context key, `baseDomainAccessKey` var, and exported `IsBaseDomainAccess` helper. Updated empty-subdomain case in `Handler` to annotate context instead of passing request through unchanged.
- `subdomain_test.go`: Added `TestIsBaseDomainAccess` (3 cases) and 2 new middleware annotation tests.

## Test Plan

- [x] `TestIsBaseDomainAccess/returns_true_when_context_has_baseDomainAccessKey=true`
- [x] `TestIsBaseDomainAccess/returns_false_when_context_lacks_the_key`
- [x] `TestIsBaseDomainAccess/returns_false_when_context_has_key_set_to_false`
- [x] `TestTenantSubdomainMiddleware/annotates_context_with_baseDomainAccessKey_when_no_subdomain_present`
- [x] `TestTenantSubdomainMiddleware/does_not_annotate_context_with_baseDomainAccessKey_when_subdomain_present`
- [x] All existing subdomain middleware tests continue to pass

Part of 043-mcp-manifest-tenant-isolation epic.