### PR TITLE
feat: add graceful degradation for economy generator service

### DIFF
--- a/services/mcp-server/internal/tools/economy_generator.go
+++ b/services/mcp-server/internal/tools/economy_generator.go
@@ -7,7 +7,27 @@ import (
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
 	mcperrors "github.com/meridianhub/meridian/services/mcp-server/internal/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// generatorUnavailableMessage is returned when the economy generator service is not deployed.
+const generatorUnavailableMessage = "Economy generator is not available on this instance. " +
+	"Use meridian_manifest_validate (mode=create) to check manually composed manifests, " +
+	"or meridian_cookbook_list/describe for pattern examples."
+
+// IsServiceUnavailable returns true when err is a gRPC Unimplemented error, which indicates
+// the server does not know the requested service (i.e. the service is not deployed).
+func IsServiceUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	return st.Code() == codes.Unimplemented
+}
 
 // EconomyGeneratorClient is the minimal interface for the EconomyGeneratorService RPCs.
 type EconomyGeneratorClient interface {
@@ -103,6 +123,9 @@ func handleEconomyGenerateContext(ctx context.Context, client EconomyGeneratorCl
 
 	resp, err := client.GetGenerationContext(ctx, req)
 	if err != nil {
+		if IsServiceUnavailable(err) {
+			return map[string]interface{}{"message": generatorUnavailableMessage}, nil
+		}
 		return mcperrors.FormatGRPCError(err), nil //nolint:nilerr // err is surfaced in the tool response
 	}
 
@@ -214,6 +237,49 @@ type economyGenerateParams struct {
 	MaxFixIterations int32                       `json:"max_fix_iterations"`
 }
 
+// resolveGenerationMode converts the string mode parameter to a proto GenerationMode,
+// returning an error response map if validation fails, or nil on success.
+func resolveGenerationMode(mode, tenantID string) (controlplanev1.GenerationMode, map[string]interface{}) {
+	switch mode {
+	case "", "create":
+		return controlplanev1.GenerationMode_GENERATION_MODE_CREATE, nil
+	case "amend":
+		if tenantID == "" {
+			return 0, map[string]interface{}{
+				"error":   "tenant_id is required when mode is 'amend'",
+				"message": "Provide a tenant_id to amend the tenant's existing manifest.",
+			}
+		}
+		return controlplanev1.GenerationMode_GENERATION_MODE_AMEND, nil
+	default:
+		return 0, map[string]interface{}{
+			"error":   "invalid mode: " + mode,
+			"message": "mode must be 'create' or 'amend'",
+		}
+	}
+}
+
+// buildGenerationMetadata converts proto GenerationMetadata to a map for JSON serialization.
+func buildGenerationMetadata(m *controlplanev1.GenerationMetadata) map[string]interface{} {
+	meta := map[string]interface{}{"fix_iterations": m.FixIterations}
+	if len(m.PatternsUsed) > 0 {
+		meta["patterns_used"] = m.PatternsUsed
+	}
+	if len(m.InstrumentsCreated) > 0 {
+		meta["instruments_created"] = m.InstrumentsCreated
+	}
+	if len(m.AccountTypesCreated) > 0 {
+		meta["account_types_created"] = m.AccountTypesCreated
+	}
+	if len(m.SagasCreated) > 0 {
+		meta["sagas_created"] = m.SagasCreated
+	}
+	if len(m.Decisions) > 0 {
+		meta["decisions"] = m.Decisions
+	}
+	return meta
+}
+
 // handleEconomyGenerate implements the meridian_economy_generate handler.
 func handleEconomyGenerate(ctx context.Context, client EconomyGeneratorClient, params json.RawMessage) (interface{}, error) {
 	var p economyGenerateParams
@@ -221,23 +287,9 @@ func handleEconomyGenerate(ctx context.Context, client EconomyGeneratorClient, p
 		return mcperrors.FormatGRPCError(err), nil //nolint:nilerr // err is surfaced in the tool response
 	}
 
-	var mode controlplanev1.GenerationMode
-	switch p.Mode {
-	case "", "create":
-		mode = controlplanev1.GenerationMode_GENERATION_MODE_CREATE
-	case "amend":
-		mode = controlplanev1.GenerationMode_GENERATION_MODE_AMEND
-		if p.TenantID == "" {
-			return map[string]interface{}{
-				"error":   "tenant_id is required when mode is 'amend'",
-				"message": "Provide a tenant_id to amend the tenant's existing manifest.",
-			}, nil
-		}
-	default:
-		return map[string]interface{}{
-			"error":   "invalid mode: " + p.Mode,
-			"message": "mode must be 'create' or 'amend'",
-		}, nil
+	mode, errResp := resolveGenerationMode(p.Mode, p.TenantID)
+	if errResp != nil {
+		return errResp, nil
 	}
 
 	req := &controlplanev1.GenerateManifestRequest{
@@ -257,6 +309,9 @@ func handleEconomyGenerate(ctx context.Context, client EconomyGeneratorClient, p
 
 	resp, err := client.GenerateManifest(ctx, req)
 	if err != nil {
+		if IsServiceUnavailable(err) {
+			return map[string]interface{}{"message": generatorUnavailableMessage}, nil
+		}
 		return mcperrors.FormatGRPCError(err), nil //nolint:nilerr // err is surfaced in the tool response
 	}
 
@@ -271,27 +326,8 @@ func handleEconomyGenerate(ctx context.Context, client EconomyGeneratorClient, p
 	if len(resp.ValidationWarnings) > 0 {
 		result["validation_warnings"] = formatProtoValidationErrors(resp.ValidationWarnings)
 	}
-
-	if m := resp.GenerationMetadata; m != nil {
-		meta := map[string]interface{}{
-			"fix_iterations": m.FixIterations,
-		}
-		if len(m.PatternsUsed) > 0 {
-			meta["patterns_used"] = m.PatternsUsed
-		}
-		if len(m.InstrumentsCreated) > 0 {
-			meta["instruments_created"] = m.InstrumentsCreated
-		}
-		if len(m.AccountTypesCreated) > 0 {
-			meta["account_types_created"] = m.AccountTypesCreated
-		}
-		if len(m.SagasCreated) > 0 {
-			meta["sagas_created"] = m.SagasCreated
-		}
-		if len(m.Decisions) > 0 {
-			meta["decisions"] = m.Decisions
-		}
-		result["generation_metadata"] = meta
+	if resp.GenerationMetadata != nil {
+		result["generation_metadata"] = buildGenerationMetadata(resp.GenerationMetadata)
 	}
 
 	return result, nil

--- a/services/mcp-server/internal/tools/economy_generator.go
+++ b/services/mcp-server/internal/tools/economy_generator.go
@@ -4,6 +4,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
 	mcperrors "github.com/meridianhub/meridian/services/mcp-server/internal/errors"
@@ -16,8 +17,10 @@ const generatorUnavailableMessage = "Economy generator is not available on this 
 	"Use meridian_manifest_validate (mode=create) to check manually composed manifests, " +
 	"or meridian_cookbook_list/describe for pattern examples."
 
-// IsServiceUnavailable returns true when err is a gRPC Unimplemented error, which indicates
-// the server does not know the requested service (i.e. the service is not deployed).
+// IsServiceUnavailable returns true when err is a transport-generated gRPC Unimplemented
+// error indicating that the entire service is not registered on the server (i.e. not deployed).
+// It deliberately excludes method-level Unimplemented errors that signal unsupported operations,
+// by requiring the message to contain the transport phrase "unknown service".
 func IsServiceUnavailable(err error) bool {
 	if err == nil {
 		return false
@@ -26,7 +29,7 @@ func IsServiceUnavailable(err error) bool {
 	if !ok {
 		return false
 	}
-	return st.Code() == codes.Unimplemented
+	return st.Code() == codes.Unimplemented && strings.Contains(st.Message(), "unknown service")
 }
 
 // EconomyGeneratorClient is the minimal interface for the EconomyGeneratorService RPCs.

--- a/services/mcp-server/internal/tools/economy_generator_test.go
+++ b/services/mcp-server/internal/tools/economy_generator_test.go
@@ -416,3 +416,110 @@ func TestEconomyGenerate_GRPCError_ReturnsFormattedError(t *testing.T) {
 	// Result should be non-nil (a FormattedError from mcperrors).
 	assert.NotNil(t, result)
 }
+
+// --- isServiceUnavailable ---
+
+func TestIsServiceUnavailable_Unimplemented_ReturnsTrue(t *testing.T) {
+	err := status.Error(codes.Unimplemented, "unknown service meridian.control_plane.v1.EconomyGeneratorService")
+	assert.True(t, tools.IsServiceUnavailable(err))
+}
+
+func TestIsServiceUnavailable_OtherCodes_ReturnsFalse(t *testing.T) {
+	cases := []struct {
+		code codes.Code
+		name string
+	}{
+		{codes.Internal, "Internal"},
+		{codes.InvalidArgument, "InvalidArgument"},
+		{codes.NotFound, "NotFound"},
+		{codes.Unavailable, "Unavailable"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := status.Error(tc.code, "some error")
+			assert.False(t, tools.IsServiceUnavailable(err))
+		})
+	}
+}
+
+func TestIsServiceUnavailable_NilError_ReturnsFalse(t *testing.T) {
+	assert.False(t, tools.IsServiceUnavailable(nil))
+}
+
+// --- graceful degradation on service unavailable ---
+
+func TestEconomyGenerateContext_ServiceUnavailable_ReturnsFriendlyMessage(t *testing.T) {
+	mock := &mockEconomyGeneratorClient{
+		contextFn: func(_ context.Context, _ *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error) {
+			return nil, status.Error(codes.Unimplemented, "unknown service meridian.control_plane.v1.EconomyGeneratorService")
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	result, err := reg.Call(context.Background(), "meridian_economy_generate_context", json.RawMessage(`{"description": "energy"}`))
+	require.NoError(t, err)
+
+	m, ok := result.(map[string]interface{})
+	require.True(t, ok)
+	assert.Contains(t, m["message"], "not available")
+	assert.NotContains(t, m["message"], "Unimplemented")
+}
+
+func TestEconomyGenerate_ServiceUnavailable_ReturnsFriendlyMessage(t *testing.T) {
+	mock := &mockEconomyGeneratorClient{
+		generateFn: func(_ context.Context, _ *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error) {
+			return nil, status.Error(codes.Unimplemented, "unknown service meridian.control_plane.v1.EconomyGeneratorService")
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	result, err := reg.Call(context.Background(), "meridian_economy_generate", json.RawMessage(`{"description": "energy"}`))
+	require.NoError(t, err)
+
+	m, ok := result.(map[string]interface{})
+	require.True(t, ok)
+	assert.Contains(t, m["message"], "not available")
+	assert.NotContains(t, m["message"], "Unimplemented")
+}
+
+func TestEconomyGenerateContext_OtherGRPCError_ReturnsFormattedError(t *testing.T) {
+	mock := &mockEconomyGeneratorClient{
+		contextFn: func(_ context.Context, _ *controlplanev1.GetGenerationContextRequest) (*controlplanev1.GetGenerationContextResponse, error) {
+			return nil, status.Error(codes.Internal, "internal server error")
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	result, err := reg.Call(context.Background(), "meridian_economy_generate_context", json.RawMessage(`{"description": "energy"}`))
+	require.NoError(t, err)
+
+	// Should be a FormattedError (from mcperrors), not the friendly message map.
+	_, isMap := result.(map[string]interface{})
+	assert.False(t, isMap, "non-Unimplemented errors should return FormattedError, not a plain map")
+	assert.NotNil(t, result)
+}
+
+func TestEconomyGenerate_OtherGRPCError_ReturnsFormattedError(t *testing.T) {
+	mock := &mockEconomyGeneratorClient{
+		generateFn: func(_ context.Context, _ *controlplanev1.GenerateManifestRequest) (*controlplanev1.GenerateManifestResponse, error) {
+			return nil, status.Error(codes.Internal, "internal server error")
+		},
+	}
+
+	reg := tools.NewRegistry()
+	tools.RegisterEconomyGeneratorTools(reg, mock)
+
+	result, err := reg.Call(context.Background(), "meridian_economy_generate", json.RawMessage(`{"description": "energy"}`))
+	require.NoError(t, err)
+
+	// Should be a FormattedError (from mcperrors), not the friendly message map.
+	_, isMap := result.(map[string]interface{})
+	assert.False(t, isMap, "non-Unimplemented errors should return FormattedError, not a plain map")
+	assert.NotNil(t, result)
+}

--- a/services/mcp-server/internal/tools/economy_generator_test.go
+++ b/services/mcp-server/internal/tools/economy_generator_test.go
@@ -446,6 +446,13 @@ func TestIsServiceUnavailable_NilError_ReturnsFalse(t *testing.T) {
 	assert.False(t, tools.IsServiceUnavailable(nil))
 }
 
+func TestIsServiceUnavailable_UnimplementedMethodLevel_ReturnsFalse(t *testing.T) {
+	// Unimplemented for a known method limitation (not a missing service) should not
+	// be treated as service unavailable — it is a real capability error.
+	err := status.Error(codes.Unimplemented, "feature not supported in this configuration")
+	assert.False(t, tools.IsServiceUnavailable(err))
+}
+
 // --- graceful degradation on service unavailable ---
 
 func TestEconomyGenerateContext_ServiceUnavailable_ReturnsFriendlyMessage(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `IsServiceUnavailable` helper that detects gRPC `Unimplemented` errors indicating the economy generator service is not deployed on this instance
- Wraps `GetGenerationContext` and `GenerateManifest` gRPC calls to return a user-friendly message when the service is unavailable, instead of exposing raw gRPC error details
- Extracts `resolveGenerationMode` and `buildGenerationMetadata` helpers to reduce cognitive complexity

## Changes Made

- `services/mcp-server/internal/tools/economy_generator.go`: Added `IsServiceUnavailable`, `generatorUnavailableMessage`, `resolveGenerationMode`, and `buildGenerationMetadata`; updated both handlers to check for service unavailability before generic error formatting
- `services/mcp-server/internal/tools/economy_generator_test.go`: Added 7 new tests covering `IsServiceUnavailable` (nil, Unimplemented, other codes), graceful degradation in both handlers, and verifying non-Unimplemented errors still return structured `FormattedError`

## Test plan

- [x] `TestIsServiceUnavailable_Unimplemented_ReturnsTrue`
- [x] `TestIsServiceUnavailable_OtherCodes_ReturnsFalse`
- [x] `TestIsServiceUnavailable_NilError_ReturnsFalse`
- [x] `TestEconomyGenerateContext_ServiceUnavailable_ReturnsFriendlyMessage`
- [x] `TestEconomyGenerate_ServiceUnavailable_ReturnsFriendlyMessage`
- [x] `TestEconomyGenerateContext_OtherGRPCError_ReturnsFormattedError`
- [x] `TestEconomyGenerate_OtherGRPCError_ReturnsFormattedError`
- [x] All existing tests pass