### PR TITLE
feat: Add skip_immutability_checks to ApplyManifestRequest proto

### DIFF
--- a/api/proto/meridian/control_plane/v1/apply_manifest_service.proto
+++ b/api/proto/meridian/control_plane/v1/apply_manifest_service.proto
@@ -38,6 +38,12 @@ message ApplyManifestRequest {
     min_len: 1
     max_len: 255
   }];
+
+  // skip_immutability_checks when true bypasses immutability enforcement and
+  // destructive removal checks. Use with dry_run=true to validate a manifest
+  // that is intended for a new tenant (create mode) without comparing against
+  // existing tenant state. Has no effect when dry_run=false.
+  bool skip_immutability_checks = 5;
 }
 
 // ApplyManifestResponse contains the result of a manifest application.

--- a/services/control-plane/internal/applier/grpc_handler.go
+++ b/services/control-plane/internal/applier/grpc_handler.go
@@ -259,21 +259,18 @@ func (h *ApplyManifestHandler) validate(
 	mf *controlplanev1.Manifest,
 	skipImmutability bool,
 ) validationOutput {
-	// Get the previous manifest for immutability checks (best-effort)
+	// Get the previous manifest for immutability checks (best-effort).
+	// When skipImmutability is true we model a new-tenant create, so there
+	// is no previous manifest to compare against.
 	var previousManifest *controlplanev1.Manifest
-	if h.versionStore != nil {
+	if h.versionStore != nil && !skipImmutability {
 		prev, err := h.versionStore.GetLatestApplied(ctx)
 		if err == nil && prev != nil {
 			previousManifest = prev.Manifest
 		}
 	}
 
-	var opts []validator.ValidateOption
-	if skipImmutability {
-		opts = append(opts, validator.WithSkipImmutabilityChecks())
-	}
-
-	result := h.validator.Validate(mf, previousManifest, opts...)
+	result := h.validator.Validate(mf, previousManifest)
 
 	step := &controlplanev1.StepResult{
 		StepName: "validate",
@@ -326,9 +323,11 @@ func (h *ApplyManifestHandler) diff(
 	mf *controlplanev1.Manifest,
 	skipImmutability bool,
 ) diffOutput {
-	// Get the last-applied manifest (nil means first apply)
+	// Get the last-applied manifest (nil means first apply).
+	// When skipImmutability is true we model a new-tenant create, so there
+	// is no baseline to diff against — everything is treated as CREATE.
 	var lastApplied *controlplanev1.Manifest
-	if h.versionStore != nil {
+	if h.versionStore != nil && !skipImmutability {
 		prev, err := h.versionStore.GetLatestApplied(ctx)
 		if err != nil {
 			return diffOutput{
@@ -345,12 +344,7 @@ func (h *ApplyManifestHandler) diff(
 		}
 	}
 
-	var diffOpts []differ.DiffOption
-	if skipImmutability {
-		diffOpts = append(diffOpts, differ.WithSkipSafetyChecks())
-	}
-
-	diffPlan, err := h.differ.Diff(ctx, lastApplied, mf, diffOpts...)
+	diffPlan, err := h.differ.Diff(ctx, lastApplied, mf)
 	if err != nil {
 		return diffOutput{
 			err: err,

--- a/services/control-plane/internal/applier/grpc_handler.go
+++ b/services/control-plane/internal/applier/grpc_handler.go
@@ -108,9 +108,13 @@ func (h *ApplyManifestHandler) ApplyManifest(
 
 	response := &controlplanev1.ApplyManifestResponse{}
 
+	// Determine whether to skip immutability/safety checks.
+	// Only respected during dry-run; ignored for real applies.
+	skipImmutability := req.GetSkipImmutabilityChecks() && req.GetDryRun()
+
 	// Step 1: Validate the manifest
 	logger.Info("step 1: validating manifest")
-	validationResult := h.validate(ctx, req.GetManifest())
+	validationResult := h.validate(ctx, req.GetManifest(), skipImmutability)
 	response.StepResults = append(response.StepResults, validationResult.stepResult)
 
 	if !validationResult.valid {
@@ -122,7 +126,7 @@ func (h *ApplyManifestHandler) ApplyManifest(
 
 	// Step 2: Diff against current manifest
 	logger.Info("step 2: diffing against current manifest")
-	diffResult := h.diff(ctx, req.GetManifest())
+	diffResult := h.diff(ctx, req.GetManifest(), skipImmutability)
 	response.StepResults = append(response.StepResults, diffResult.stepResult)
 	response.DiffSummary = diffResult.summary
 
@@ -133,22 +137,9 @@ func (h *ApplyManifestHandler) ApplyManifest(
 	}
 
 	// Check for blocked deletions
-	if diffResult.plan.HasBlockedDeletions() && !req.GetForce() {
-		logger.Warn("apply blocked by safety checks",
-			"blocked_deletions", len(diffResult.plan.BlockedDeletions))
+	if blocked := h.checkBlockedDeletions(diffResult.plan, req.GetForce(), logger); blocked != nil {
 		response.Status = controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_BLOCKED
-
-		blockStep := &controlplanev1.StepResult{
-			StepName: "safety_check",
-			Status:   controlplanev1.StepResultStatus_STEP_RESULT_STATUS_FAILED,
-			Message:  "Deletions blocked by safety checks (use force=true to override)",
-			Details:  make(map[string]string),
-		}
-		for i, bd := range diffResult.plan.BlockedDeletions {
-			blockStep.Details[fmt.Sprintf("blocked_%d", i)] = fmt.Sprintf(
-				"%s %s: %s", bd.ResourceType, bd.ResourceCode, bd.Reason)
-		}
-		response.StepResults = append(response.StepResults, blockStep)
+		response.StepResults = append(response.StepResults, blocked)
 		return response, nil
 	}
 
@@ -232,6 +223,28 @@ func (h *ApplyManifestHandler) runPostApplyHooks(ctx context.Context, tenantID s
 	}
 }
 
+// checkBlockedDeletions returns a StepResult if the plan contains blocked deletions
+// and force is not set. Returns nil if there are no blocked deletions or force overrides them.
+func (h *ApplyManifestHandler) checkBlockedDeletions(plan *differ.DiffPlan, force bool, logger *slog.Logger) *controlplanev1.StepResult {
+	if !plan.HasBlockedDeletions() || force {
+		return nil
+	}
+	logger.Warn("apply blocked by safety checks",
+		"blocked_deletions", len(plan.BlockedDeletions))
+
+	step := &controlplanev1.StepResult{
+		StepName: "safety_check",
+		Status:   controlplanev1.StepResultStatus_STEP_RESULT_STATUS_FAILED,
+		Message:  "Deletions blocked by safety checks (use force=true to override)",
+		Details:  make(map[string]string),
+	}
+	for i, bd := range plan.BlockedDeletions {
+		step.Details[fmt.Sprintf("blocked_%d", i)] = fmt.Sprintf(
+			"%s %s: %s", bd.ResourceType, bd.ResourceCode, bd.Reason)
+	}
+	return step
+}
+
 // validationOutput holds the results of manifest validation.
 type validationOutput struct {
 	valid      bool
@@ -244,6 +257,7 @@ type validationOutput struct {
 func (h *ApplyManifestHandler) validate(
 	ctx context.Context,
 	mf *controlplanev1.Manifest,
+	skipImmutability bool,
 ) validationOutput {
 	// Get the previous manifest for immutability checks (best-effort)
 	var previousManifest *controlplanev1.Manifest
@@ -254,7 +268,12 @@ func (h *ApplyManifestHandler) validate(
 		}
 	}
 
-	result := h.validator.Validate(mf, previousManifest)
+	var opts []validator.ValidateOption
+	if skipImmutability {
+		opts = append(opts, validator.WithSkipImmutabilityChecks())
+	}
+
+	result := h.validator.Validate(mf, previousManifest, opts...)
 
 	step := &controlplanev1.StepResult{
 		StepName: "validate",
@@ -305,6 +324,7 @@ type diffOutput struct {
 func (h *ApplyManifestHandler) diff(
 	ctx context.Context,
 	mf *controlplanev1.Manifest,
+	skipImmutability bool,
 ) diffOutput {
 	// Get the last-applied manifest (nil means first apply)
 	var lastApplied *controlplanev1.Manifest
@@ -325,7 +345,12 @@ func (h *ApplyManifestHandler) diff(
 		}
 	}
 
-	diffPlan, err := h.differ.Diff(ctx, lastApplied, mf)
+	var diffOpts []differ.DiffOption
+	if skipImmutability {
+		diffOpts = append(diffOpts, differ.WithSkipSafetyChecks())
+	}
+
+	diffPlan, err := h.differ.Diff(ctx, lastApplied, mf, diffOpts...)
 	if err != nil {
 		return diffOutput{
 			err: err,

--- a/services/control-plane/internal/applier/grpc_handler_test.go
+++ b/services/control-plane/internal/applier/grpc_handler_test.go
@@ -368,3 +368,103 @@ func TestBuildExecutorInput(t *testing.T) {
 	require.Len(t, input.SagaDefinitions, 1)
 	assert.Equal(t, "test_saga", input.SagaDefinitions[0].Name)
 }
+
+// --- skip_immutability_checks tests ---
+
+// mockVersionStore returns a fixed manifest as the latest applied version.
+type mockVersionStore struct {
+	manifest *controlplanev1.Manifest
+}
+
+func (m *mockVersionStore) GetLatestApplied(_ context.Context) (*differ.ManifestVersion, error) {
+	if m.manifest == nil {
+		return nil, nil
+	}
+	return &differ.ManifestVersion{Manifest: m.manifest}, nil
+}
+
+func (m *mockVersionStore) Save(_ context.Context, _ *controlplanev1.Manifest, _ string) error {
+	return nil
+}
+
+// newTestHandlerWithVersionStore creates a handler backed by a version store
+// that returns prev as the last-applied manifest.
+func newTestHandlerWithVersionStore(t *testing.T, prev *controlplanev1.Manifest) *ApplyManifestHandler {
+	t.Helper()
+
+	v, err := validator.New()
+	require.NoError(t, err)
+
+	d := differ.New(nil, nil)
+	p := planner.NewManifestPlanner()
+
+	handler, err := NewApplyManifestHandler(ApplyManifestHandlerConfig{
+		Validator:    v,
+		Differ:       d,
+		Planner:      p,
+		VersionStore: &mockVersionStore{manifest: prev},
+	})
+	require.NoError(t, err)
+	return handler
+}
+
+func TestApplyManifest_SkipImmutabilityChecks_DryRun_SkipsImmutabilityErrors(t *testing.T) {
+	prev := newTestManifest()
+	handler := newTestHandlerWithVersionStore(t, prev)
+
+	// Change instrument code — normally triggers IMMUTABLE_FIELD_CHANGED
+	curr := newTestManifest()
+	curr.Instruments[0].Code = "USD"
+	curr.AccountTypes[0].AllowedInstruments = []string{"USD"}
+
+	resp, err := handler.ApplyManifest(context.Background(), &controlplanev1.ApplyManifestRequest{
+		Manifest:               curr,
+		DryRun:                 true,
+		SkipImmutabilityChecks: true,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Should succeed as dry-run, not fail validation
+	assert.Equal(t, controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN, resp.Status,
+		"expected DRY_RUN status when skip_immutability_checks is set with dry_run=true")
+
+	// No IMMUTABLE_FIELD_CHANGED in validation errors
+	for _, ve := range resp.ValidationErrors {
+		assert.NotEqual(t, "IMMUTABLE_FIELD_CHANGED", ve.Code)
+	}
+}
+
+func TestApplyManifest_SkipImmutabilityChecks_NotDryRun_StillEnforces(t *testing.T) {
+	prev := newTestManifest()
+	handler := newTestHandlerWithVersionStore(t, prev)
+
+	// Change instrument code — triggers IMMUTABLE_FIELD_CHANGED
+	curr := newTestManifest()
+	curr.Instruments[0].Code = "USD"
+	curr.AccountTypes[0].AllowedInstruments = []string{"USD"}
+
+	resp, err := handler.ApplyManifest(context.Background(), &controlplanev1.ApplyManifestRequest{
+		Manifest:               curr,
+		DryRun:                 false,
+		AppliedBy:              "test-user",
+		SkipImmutabilityChecks: true, // should be ignored because dry_run=false
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Should fail validation because skip_immutability_checks is ignored when dry_run=false
+	assert.Equal(t, controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_VALIDATION_FAILED, resp.Status,
+		"expected VALIDATION_FAILED when skip_immutability_checks is set but dry_run=false")
+
+	found := false
+	for _, ve := range resp.ValidationErrors {
+		if ve.Code == "IMMUTABLE_FIELD_CHANGED" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected IMMUTABLE_FIELD_CHANGED error when dry_run=false, regardless of skip flag")
+}

--- a/services/control-plane/internal/differ/manifest_differ.go
+++ b/services/control-plane/internal/differ/manifest_differ.go
@@ -40,11 +40,32 @@ func New(safety SafetyChecker, drift DriftDetector) *ManifestDiffer {
 	}
 }
 
+// DiffOption configures optional behavior of a Diff call.
+type DiffOption func(*diffConfig)
+
+type diffConfig struct {
+	skipSafetyChecks bool
+}
+
+// WithSkipSafetyChecks skips safety checks (blocked deletions) and breaking
+// change flagging. Use when validating a manifest for a new tenant that has
+// no existing state.
+func WithSkipSafetyChecks() DiffOption {
+	return func(c *diffConfig) {
+		c.skipSafetyChecks = true
+	}
+}
+
 // Diff compares lastApplied against newManifest and returns a plan.
 // If lastApplied is nil, all resources in newManifest are treated as CREATE.
-func (d *ManifestDiffer) Diff(ctx context.Context, lastApplied, newManifest *controlplanev1.Manifest) (*DiffPlan, error) {
+func (d *ManifestDiffer) Diff(ctx context.Context, lastApplied, newManifest *controlplanev1.Manifest, opts ...DiffOption) (*DiffPlan, error) {
 	if newManifest == nil {
 		return nil, ErrNilManifest
+	}
+
+	cfg := &diffConfig{}
+	for _, opt := range opts {
+		opt(cfg)
 	}
 
 	plan := &DiffPlan{}
@@ -58,16 +79,20 @@ func (d *ManifestDiffer) Diff(ctx context.Context, lastApplied, newManifest *con
 	d.diffMappings(lastApplied, newManifest, plan)
 	d.diffOperationalGateway(lastApplied, newManifest, plan)
 
-	// Run safety checks on all DELETE actions
-	if err := d.runSafetyChecks(ctx, plan); err != nil {
-		return nil, fmt.Errorf("safety check failed: %w", err)
+	// Run safety checks on all DELETE actions (skip when validating for a new tenant)
+	if !cfg.skipSafetyChecks {
+		if err := d.runSafetyChecks(ctx, plan); err != nil {
+			return nil, fmt.Errorf("safety check failed: %w", err)
+		}
 	}
 
-	// Flag breaking changes
-	for i := range plan.Actions {
-		if plan.Actions[i].Action == ActionDelete {
-			plan.Actions[i].Breaking = true
-			plan.HasBreakingChanges = true
+	// Flag breaking changes (skip when validating for a new tenant)
+	if !cfg.skipSafetyChecks {
+		for i := range plan.Actions {
+			if plan.Actions[i].Action == ActionDelete {
+				plan.Actions[i].Breaking = true
+				plan.HasBreakingChanges = true
+			}
 		}
 	}
 

--- a/services/control-plane/internal/differ/manifest_differ_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_test.go
@@ -903,3 +903,76 @@ func TestDiff_ModifiedSagaFilter_DescribesChange(t *testing.T) {
 	assert.Len(t, updates, 1)
 	assert.Contains(t, updates[0].Description, "filter changed")
 }
+
+func TestDiff_WithSkipSafetyChecks_SkipsSafetyChecksAndBreakingFlags(t *testing.T) {
+	checker := &mockSafetyChecker{
+		instrumentBlocked: map[string]*BlockedDeletion{
+			"KWH": {
+				ResourceType: ResourceInstrument,
+				ResourceCode: "KWH",
+				Reason:       "referenced by 3 active valuation rules",
+			},
+		},
+	}
+	d := New(checker, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.Instruments = newManifest.Instruments[:1] // remove KWH
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest, WithSkipSafetyChecks())
+	require.NoError(t, err)
+
+	// DELETE actions should still be present
+	deletes := filterActions(plan.Actions, ActionDelete)
+	assert.Len(t, deletes, 1)
+	assert.Equal(t, "KWH", deletes[0].ResourceCode)
+
+	// But they should NOT be flagged as breaking
+	assert.False(t, deletes[0].Breaking)
+	assert.False(t, plan.HasBreakingChanges)
+
+	// And no blocked deletions should be recorded (safety checks skipped)
+	assert.False(t, plan.HasBlockedDeletions())
+	assert.Empty(t, plan.BlockedDeletions)
+}
+
+func TestDiff_WithSkipSafetyChecks_SafetyCheckerErrorNotReturned(t *testing.T) {
+	checker := &mockSafetyChecker{
+		err: fmt.Errorf("connection refused"),
+	}
+	d := New(checker, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.AccountTypes = nil
+
+	// With skip, the safety checker error should not propagate
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest, WithSkipSafetyChecks())
+	require.NoError(t, err)
+	assert.NotNil(t, plan)
+}
+
+func TestDiff_WithoutSkipSafetyChecks_SafetyChecksStillRun(t *testing.T) {
+	checker := &mockSafetyChecker{
+		instrumentBlocked: map[string]*BlockedDeletion{
+			"KWH": {
+				ResourceType: ResourceInstrument,
+				ResourceCode: "KWH",
+				Reason:       "referenced by active rules",
+			},
+		},
+	}
+	d := New(checker, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.Instruments = newManifest.Instruments[:1]
+
+	// Without skip option, safety checks run as normal
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	assert.True(t, plan.HasBlockedDeletions())
+	assert.True(t, plan.HasBreakingChanges)
+}

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -361,6 +361,7 @@ type ValidateOption func(*validateConfig)
 
 type validateConfig struct {
 	forceDestructiveChanges bool
+	skipImmutabilityChecks  bool
 }
 
 // WithForceDestructiveChanges converts destructive change errors into warnings,
@@ -368,6 +369,15 @@ type validateConfig struct {
 func WithForceDestructiveChanges() ValidateOption {
 	return func(c *validateConfig) {
 		c.forceDestructiveChanges = true
+	}
+}
+
+// WithSkipImmutabilityChecks skips immutability enforcement and destructive
+// change detection. Use when validating a manifest intended for a new tenant
+// (create mode) that has no existing state to compare against.
+func WithSkipImmutabilityChecks() ValidateOption {
+	return func(c *validateConfig) {
+		c.skipImmutabilityChecks = true
 	}
 }
 
@@ -423,16 +433,16 @@ func (v *ManifestValidator) Validate(
 	// 13. Operational gateway orphan detection
 	v.validateOperationalGatewayOrphans(manifest, result)
 
-	// 14. Immutability checks
-	if previousManifest != nil {
+	// 14. Immutability checks (skipped when validating for a new tenant)
+	if previousManifest != nil && !cfg.skipImmutabilityChecks {
 		v.validateImmutability(manifest, previousManifest, result)
 	}
 
-	// 15. Destructive change detection
+	// 15. Destructive change detection (skipped when validating for a new tenant)
 	// Use the previous manifest's call logs for graph construction so that
 	// dependencies that existed in the previous version are correctly detected,
 	// even if a saga was modified or removed in the current manifest.
-	if previousManifest != nil {
+	if previousManifest != nil && !cfg.skipImmutabilityChecks {
 		previousCallLogs := v.validateStarlarkScripts(previousManifest, &ValidationResult{})
 		v.validateDestructiveChanges(manifest, previousManifest, previousCallLogs, cfg, result)
 	}

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -2931,3 +2931,57 @@ func TestValidateDestructiveChanges_RemoveInstrumentUsedByValuationRule(t *testi
 	}
 	assert.True(t, found, "expected DESTRUCTIVE_INSTRUMENT_REMOVAL for KWH used in valuation rule, got: %v", result.Errors)
 }
+
+func TestWithSkipImmutabilityChecks_SkipsImmutableFieldChanged(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	prev := validManifest()
+	curr := validManifest()
+	curr.Instruments[0].Code = "USD" // Changed from GBP - normally triggers IMMUTABLE_FIELD_CHANGED
+
+	result := v.Validate(curr, prev, WithSkipImmutabilityChecks())
+
+	// Should NOT contain IMMUTABLE_FIELD_CHANGED errors
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "IMMUTABLE_FIELD_CHANGED", e.Code,
+			"expected no IMMUTABLE_FIELD_CHANGED errors when skip_immutability_checks is set")
+	}
+}
+
+func TestWithSkipImmutabilityChecks_SkipsDestructiveRemoval(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	prev := validManifest()
+	curr := validManifest()
+	curr.Instruments = curr.Instruments[:1] // Remove KWH - normally triggers DESTRUCTIVE_INSTRUMENT_REMOVAL
+
+	result := v.Validate(curr, prev, WithSkipImmutabilityChecks())
+
+	for _, e := range result.Errors {
+		assert.NotEqual(t, "DESTRUCTIVE_INSTRUMENT_REMOVAL", e.Code,
+			"expected no DESTRUCTIVE_INSTRUMENT_REMOVAL errors when skip_immutability_checks is set")
+	}
+}
+
+func TestWithoutSkipImmutabilityChecks_StillEnforcesImmutability(t *testing.T) {
+	v, err := New()
+	require.NoError(t, err)
+
+	prev := validManifest()
+	curr := validManifest()
+	curr.Instruments[0].Code = "USD" // Changed from GBP
+
+	result := v.Validate(curr, prev)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "IMMUTABLE_FIELD_CHANGED" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected IMMUTABLE_FIELD_CHANGED error without skip option")
+}


### PR DESCRIPTION
## Summary

Add `skip_immutability_checks` field to `ApplyManifestRequest` proto message, enabling tenant-agnostic manifest validation for new economies. When set with `dry_run=true`, bypasses immutability enforcement and destructive removal checks that would otherwise compare against existing tenant state.

**Task**: 043-mcp-manifest-tenant-isolation.2

## Changes Made

- **Proto**: Added `bool skip_immutability_checks = 5` to `ApplyManifestRequest` message
- **Validator**: Added `WithSkipImmutabilityChecks()` option that skips immutability checks (step 14) and destructive change detection (step 15)
- **Differ**: Added `WithSkipSafetyChecks()` `DiffOption` that skips blocked deletion checks and breaking change flagging
- **Handler**: Reads `skip_immutability_checks` from request, computes `skipImmutability = skip_immutability_checks && dry_run`, and passes through to validator and differ
- **Refactor**: Extracted `checkBlockedDeletions` helper to reduce cyclomatic complexity of `ApplyManifest`

## Safety

The flag is only respected when `dry_run=true`. Setting it on a real apply (`dry_run=false`) has no effect -- immutability and safety checks still run.

## Test Plan

- [x] Differ: `WithSkipSafetyChecks` skips safety checks and breaking flags
- [x] Differ: `WithSkipSafetyChecks` prevents safety checker errors from propagating
- [x] Differ: Without option, safety checks still run as normal
- [x] Validator: `WithSkipImmutabilityChecks` skips `IMMUTABLE_FIELD_CHANGED` errors
- [x] Validator: `WithSkipImmutabilityChecks` skips `DESTRUCTIVE_INSTRUMENT_REMOVAL` errors
- [x] Validator: Without option, immutability still enforced
- [x] Handler: `skip_immutability_checks=true` + `dry_run=true` returns `DRY_RUN` status (no validation failures)
- [x] Handler: `skip_immutability_checks=true` + `dry_run=false` still enforces immutability (`VALIDATION_FAILED`)
- [x] All existing tests pass unchanged