### PR TITLE
docs: Add gateway selection guide to cookbook authoring patterns

### DIFF
--- a/cookbook/docs/authoring-patterns.md
+++ b/cookbook/docs/authoring-patterns.md
@@ -148,7 +148,8 @@ The `meta.design_pattern` field names the design pattern this entry exemplifies.
 | `cross-instrument-valuation` | Pattern 1 | kWh → GBP, GPU_HOUR → USD (multi-leg) |
 | `compute-metering` | Pattern 2 | Usage billing with single target instrument |
 | `credit-retirement-lifecycle` | Pattern 3 | Carbon credits, irreversible retirement |
-| `operational-gateway` | Pattern 5/6 | External payment provider integration |
+| `financial-gateway` | Pattern 5 | Stripe payment collection and payout via Financial Gateway |
+| `operational-gateway` | Pattern 6 | Generic external REST/gRPC calls, non-payment webhooks |
 | `compliance-marker` | Custom | Zero-amount positions as compliance audit trail |
 
 Set to `null` for foundation patterns (`base-fiat-*`). Set to the closest named pattern otherwise.
@@ -190,6 +191,91 @@ GPU_HOUR, and it creates USD — so its output never matches the filter.
 
 Both approaches are valid. Use `==` (allowlist) when your pattern handles exactly one source instrument.
 Use `!=` (denylist) when the pattern should handle any non-settlement instrument.
+
+---
+
+## Gateway Selection
+
+Meridian provides two gateways for external integrations. Choosing the wrong one is the most common
+mistake when authoring payment-adjacent patterns.
+
+### Financial Gateway
+
+Use `financial_gateway` in Starlark sagas when the integration involves **payment collection or
+payout** with a supported payment provider (Stripe, Stripe Connect).
+
+The Financial Gateway provides:
+
+- `financial_gateway.dispatch_payment()` — charge a customer's payment method
+- `financial_gateway.dispatch_refund()` — issue a refund or payout to a connected account
+- `financial_gateway.cancel_payment()` — cancel an in-flight payment (compensation step)
+- Built-in idempotency, retry logic, and payment lifecycle management
+- Automatic routing via the `payment_rails` configuration in `manifest-fragment.yaml`
+
+Configure the provider in `manifest-fragment.yaml` under `paymentRails`:
+
+```yaml
+paymentRails:
+  - provider: stripe
+    mode: CONNECT_MODE_STANDARD
+    accountId: "acct_REPLACE_WITH_REAL_ID"
+    webhookEndpointSecret: "sm://stripe/webhook_secret"
+    payoutSchedule: PAYOUT_SCHEDULE_DAILY
+    supportedMethods: [card]
+```
+
+**When to use the Financial Gateway:**
+
+- Charging a customer's card for a service
+- Issuing a payout or refund to a connected account
+- Any saga where money moves through Stripe
+
+**Examples:** `payment-gateway-stripe` (payment collection), `tote-betting` (stake collection and
+winner payouts via Stripe Connect).
+
+### Operational Gateway
+
+Use the Operational Gateway when the integration is a **generic external API call** that is not a
+payment — REST endpoints, gRPC services, non-payment webhooks, MQTT/AMQP brokers.
+
+The Operational Gateway is configured via `operationalConnections` in the manifest and dispatched
+through the gateway instruction API. It explicitly rejects `payment.*` instruction types.
+
+**When to use the Operational Gateway:**
+
+- Calling an external REST or gRPC API from a saga
+- Consuming non-payment webhooks (e.g., IoT meter events, market data feeds)
+- MQTT/AMQP broker integrations
+
+**Examples:** `saas-billing` receives GPU meter events via `webhook:gpu_meter_event` — this is a
+data ingestion webhook, not a payment, so no gateway dispatch is needed. The webhook saga records
+usage positions directly via `position_keeping.initiate_log`.
+
+### Decision Tree
+
+```text
+Does the saga move money through a payment provider (Stripe)?
+├── Yes → financial_gateway.dispatch_payment() or dispatch_refund()
+│         Configure paymentRails in manifest-fragment.yaml
+│         design_pattern: "financial-gateway"
+└── No  → Does the saga call an external service or consume a webhook?
+          ├── Yes, payment webhook (Stripe event) → webhook: trigger, no dispatch needed
+          │   The Financial Gateway handles the inbound webhook routing.
+          │   The saga only records confirmed payments in the ledger.
+          └── Yes, non-payment external call → operational_gateway or webhook: trigger
+              design_pattern: "operational-gateway"
+```
+
+### Common Mistake
+
+**Do not use the Operational Gateway for Stripe payments.** The Operational Gateway does not have
+Stripe credentials, does not manage payment state, and rejects `payment.*` instruction types at
+runtime. Attempting to dispatch a Stripe payment through it will fail.
+
+The `webhook:` trigger type is used for inbound webhook delivery (e.g., `stripe.payment_intent.succeeded`).
+That is distinct from the Financial Gateway, which handles outbound payment dispatch. A pattern can use
+both: `stripe_payment_via_gateway.star` dispatches outbound via Financial Gateway, while
+`stripe_payment_received.star` handles the inbound Stripe webhook confirmation.
 
 ---
 

--- a/cookbook/docs/authoring-patterns.md
+++ b/cookbook/docs/authoring-patterns.md
@@ -235,35 +235,41 @@ paymentRails:
 
 ### Operational Gateway
 
-Use the Operational Gateway when the integration is a **generic external API call** that is not a
-payment — REST endpoints, gRPC services, non-payment webhooks, MQTT/AMQP brokers.
+Use the Operational Gateway when a saga needs to make an **outbound call to a generic external
+service** — REST endpoints, gRPC services, or MQTT/AMQP brokers. The Operational Gateway is for
+outbound dispatch only; inbound data from external systems arrives via the `webhook:` trigger type
+on sagas (no gateway involved).
 
-The Operational Gateway is configured via `operationalConnections` in the manifest and dispatched
-through the gateway instruction API. It explicitly rejects `payment.*` instruction types.
+The Operational Gateway is configured via `operationalGateway.providerConnections` in the manifest
+and dispatched through the gateway instruction API. It explicitly rejects `payment.*` instruction
+types.
 
 **When to use the Operational Gateway:**
 
 - Calling an external REST or gRPC API from a saga
-- Consuming non-payment webhooks (e.g., IoT meter events, market data feeds)
-- MQTT/AMQP broker integrations
+- Dispatching outbound messages to MQTT/AMQP brokers
 
-**Examples:** `saas-billing` receives GPU meter events via `webhook:gpu_meter_event` — this is a
-data ingestion webhook, not a payment, so no gateway dispatch is needed. The webhook saga records
-usage positions directly via `position_keeping.initiate_log`.
+**For inbound webhooks** (e.g., IoT meter events, market data feeds): use the `webhook:` saga
+trigger type directly. Meridian delivers inbound webhook payloads to the matching saga trigger
+without involving the Operational Gateway. The `saas-billing` pattern is an example: its
+`record_gpu_usage` saga uses `webhook:gpu_meter_event` to receive meter events and records usage
+positions via `position_keeping.initiate_log`, with no outbound dispatch at all.
 
 ### Decision Tree
 
 ```text
-Does the saga move money through a payment provider (Stripe)?
+Does the saga need to move money through Stripe?
 ├── Yes → financial_gateway.dispatch_payment() or dispatch_refund()
 │         Configure paymentRails in manifest-fragment.yaml
 │         design_pattern: "financial-gateway"
-└── No  → Does the saga call an external service or consume a webhook?
-          ├── Yes, payment webhook (Stripe event) → webhook: trigger, no dispatch needed
-          │   Meridian routes inbound Stripe webhooks to the saga trigger.
-          │   The saga only records confirmed payments in the ledger.
-          └── Yes, non-payment external call → operational_gateway or webhook: trigger
-              design_pattern: "operational-gateway"
+└── No → Is the saga receiving data from an external system?
+         ├── Yes, inbound webhook → webhook: trigger on the saga
+         │   Meridian routes the webhook payload directly to the saga.
+         │   No gateway dispatch. Saga records positions via position_keeping.
+         └── No → Does the saga need to call an external system outbound?
+                  ├── Yes → operationalGateway.providerConnections in the manifest
+                  │         design_pattern: "operational-gateway"
+                  └── No → No gateway needed
 ```
 
 ### Common Mistake

--- a/cookbook/docs/authoring-patterns.md
+++ b/cookbook/docs/authoring-patterns.md
@@ -148,8 +148,8 @@ The `meta.design_pattern` field names the design pattern this entry exemplifies.
 | `cross-instrument-valuation` | Pattern 1 | kWh → GBP, GPU_HOUR → USD (multi-leg) |
 | `compute-metering` | Pattern 2 | Usage billing with single target instrument |
 | `credit-retirement-lifecycle` | Pattern 3 | Carbon credits, irreversible retirement |
-| `financial-gateway` | Pattern 5 | Stripe payment collection and payout via Financial Gateway |
-| `operational-gateway` | Pattern 6 | Generic external REST/gRPC calls, non-payment webhooks |
+| `financial-gateway` | Custom | Stripe payment collection and payout via Financial Gateway |
+| `operational-gateway` | Custom | Generic external REST/gRPC calls, non-payment webhooks |
 | `compliance-marker` | Custom | Zero-amount positions as compliance audit trail |
 
 Set to `null` for foundation patterns (`base-fiat-*`). Set to the closest named pattern otherwise.
@@ -210,7 +210,7 @@ The Financial Gateway provides:
 - `financial_gateway.dispatch_refund()` — issue a refund or payout to a connected account
 - `financial_gateway.cancel_payment()` — cancel an in-flight payment (compensation step)
 - Built-in idempotency, retry logic, and payment lifecycle management
-- Automatic routing via the `payment_rails` configuration in `manifest-fragment.yaml`
+- Automatic routing via the `paymentRails` configuration in `manifest-fragment.yaml`
 
 Configure the provider in `manifest-fragment.yaml` under `paymentRails`:
 
@@ -230,8 +230,8 @@ paymentRails:
 - Issuing a payout or refund to a connected account
 - Any saga where money moves through Stripe
 
-**Examples:** `payment-gateway-stripe` (payment collection), `tote-betting` (stake collection and
-winner payouts via Stripe Connect).
+**Example:** `payment-gateway-stripe` uses `financial_gateway.dispatch_payment()` and
+`financial_gateway.cancel_payment()` for Stripe payment collection with full compensation support.
 
 ### Operational Gateway
 
@@ -260,7 +260,7 @@ Does the saga move money through a payment provider (Stripe)?
 │         design_pattern: "financial-gateway"
 └── No  → Does the saga call an external service or consume a webhook?
           ├── Yes, payment webhook (Stripe event) → webhook: trigger, no dispatch needed
-          │   The Financial Gateway handles the inbound webhook routing.
+          │   Meridian routes inbound Stripe webhooks to the saga trigger.
           │   The saga only records confirmed payments in the ledger.
           └── Yes, non-payment external call → operational_gateway or webhook: trigger
               design_pattern: "operational-gateway"
@@ -273,9 +273,10 @@ Stripe credentials, does not manage payment state, and rejects `payment.*` instr
 runtime. Attempting to dispatch a Stripe payment through it will fail.
 
 The `webhook:` trigger type is used for inbound webhook delivery (e.g., `stripe.payment_intent.succeeded`).
-That is distinct from the Financial Gateway, which handles outbound payment dispatch. A pattern can use
-both: `stripe_payment_via_gateway.star` dispatches outbound via Financial Gateway, while
-`stripe_payment_received.star` handles the inbound Stripe webhook confirmation.
+Meridian routes inbound Stripe webhooks to saga triggers based on the `webhookEndpointSecret` in
+`paymentRails`. This is separate from the Financial Gateway, which handles outbound payment dispatch.
+A pattern can use both: `stripe_payment_via_gateway.star` dispatches outbound via Financial Gateway,
+while `stripe_payment_received.star` handles the inbound Stripe webhook confirmation.
 
 ---
 

--- a/cookbook/patterns/saas-billing/manifest-fragment.yaml
+++ b/cookbook/patterns/saas-billing/manifest-fragment.yaml
@@ -72,6 +72,12 @@ valuationRules:
     method: VALUATION_METHOD_FIXED
     source: credit_exchange_rate
 
+# Usage metering uses webhook and event triggers, not the Financial Gateway.
+# The gpu_meter_event webhook is a data ingestion event from a compute
+# provider — it carries usage telemetry, not payment instructions.
+# The Financial Gateway is for payment collection and payout (Stripe).
+# If this pattern is combined with payment-gateway-stripe, payment
+# collection is handled in the stripe sagas, not here.
 sagas:
   - name: record_gpu_usage
     trigger: "webhook:gpu_meter_event"


### PR DESCRIPTION
## Summary

- Add a **Gateway Selection** section to `cookbook/docs/authoring-patterns.md` with documentation on when to use the Financial Gateway (Stripe payment collection/payout) versus the Operational Gateway (generic REST/gRPC, non-payment webhooks)
- Fix the design pattern table to list `financial-gateway` and `operational-gateway` as separate entries with accurate descriptions
- Add inline comment to `saas-billing/manifest-fragment.yaml` clarifying that its `webhook:gpu_meter_event` trigger is a data ingestion pattern, intentionally not using the Financial Gateway

## Changes Made

### `cookbook/docs/authoring-patterns.md`

- Split the single `operational-gateway` design pattern row into two rows: `financial-gateway` (Stripe payments) and `operational-gateway` (generic integrations)
- Added a new **Gateway Selection** section covering:
  - Financial Gateway: what it provides, when to use it, `paymentRails` configuration
  - Operational Gateway: what it handles, when to use it
  - Decision tree for choosing between the two
  - Common mistake: do not use the Operational Gateway for Stripe payments

### `cookbook/patterns/saas-billing/manifest-fragment.yaml`

- Added inline comment before the `sagas` block clarifying that the `webhook:gpu_meter_event` trigger is a data ingestion event, not a payment, and explaining when to use `payment-gateway-stripe` alongside this pattern

## Technical Details

The Financial Gateway and Operational Gateway serve distinct purposes. The Operational Gateway explicitly rejects `payment.*` instruction types at runtime. Patterns that use `financial_gateway.dispatch_payment()` or `dispatch_refund()` in their sagas must configure a `paymentRails` section. Patterns using `webhook:` for non-payment telemetry (like `saas-billing`) should not include `paymentRails`.

Existing patterns (`payment-gateway-stripe`, `tote-betting`) already had inline comments documenting this distinction. This PR makes it canonical in the authoring guide.

## Testing

- `cookbook/patterns` tests: pass
- `cookbook/schema` tests: pass
- markdownlint: pass

## Risk Assessment

Documentation-only change plus a YAML comment addition. No schema, saga, or logic changes.