### PR TITLE
feat: Accept YAML/JSON string input in manifest tools

### DIFF
--- a/services/mcp-server/internal/tools/economy.go
+++ b/services/mcp-server/internal/tools/economy.go
@@ -86,9 +86,10 @@ func manifestJSONToProto(manifestJSON json.RawMessage) (*controlplanev1.Manifest
 }
 
 // parseManifestInput converts the raw manifest field value into JSON suitable for
-// manifestJSONToProto. It accepts:
+// manifestJSONToProto. When Manifest is typed as interface{} in the param struct,
+// json.Unmarshal decodes JSON strings as string and JSON objects as map[string]interface{}.
+// It accepts:
 //   - string: parsed as YAML (which is a superset of JSON), then marshaled to JSON
-//   - json.RawMessage: passed through as-is
 //   - map[string]interface{}: marshaled to JSON
 //
 // Any other type returns an error.
@@ -105,8 +106,6 @@ func parseManifestInput(v interface{}) (json.RawMessage, error) {
 			return nil, fmt.Errorf("failed to convert YAML to JSON: %w", err)
 		}
 		return json.RawMessage(b), nil
-	case json.RawMessage:
-		return val, nil
 	case map[string]interface{}:
 		b, err := json.Marshal(val)
 		if err != nil {

--- a/services/mcp-server/internal/tools/economy.go
+++ b/services/mcp-server/internal/tools/economy.go
@@ -6,17 +6,23 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
 
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"gopkg.in/yaml.v3"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
 	mcperrors "github.com/meridianhub/meridian/services/mcp-server/internal/errors"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
+
+// errUnsupportedManifestType is returned by parseManifestInput when the value is not
+// a string, json.RawMessage, or map.
+var errUnsupportedManifestType = errors.New("manifest must be a YAML/JSON string or object")
 
 // PlanStore abstracts the session plan cache to avoid an import cycle
 // between tools and session packages. The session.Session type satisfies
@@ -79,6 +85,39 @@ func manifestJSONToProto(manifestJSON json.RawMessage) (*controlplanev1.Manifest
 	return m, nil
 }
 
+// parseManifestInput converts the raw manifest field value into JSON suitable for
+// manifestJSONToProto. It accepts:
+//   - string: parsed as YAML (which is a superset of JSON), then marshaled to JSON
+//   - json.RawMessage: passed through as-is
+//   - map[string]interface{}: marshaled to JSON
+//
+// Any other type returns an error.
+func parseManifestInput(v interface{}) (json.RawMessage, error) {
+	switch val := v.(type) {
+	case string:
+		// Parse YAML (superset of JSON) into a generic map, then re-encode as JSON.
+		var parsed interface{}
+		if err := yaml.Unmarshal([]byte(val), &parsed); err != nil {
+			return nil, fmt.Errorf("invalid YAML/JSON string: %w", err)
+		}
+		b, err := json.Marshal(parsed)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert YAML to JSON: %w", err)
+		}
+		return json.RawMessage(b), nil
+	case json.RawMessage:
+		return val, nil
+	case map[string]interface{}:
+		b, err := json.Marshal(val)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal manifest object: %w", err)
+		}
+		return json.RawMessage(b), nil
+	default:
+		return nil, errUnsupportedManifestType
+	}
+}
+
 // buildManifestValidateTool returns the meridian_manifest_validate tool.
 func buildManifestValidateTool(client ManifestApplier) Tool {
 	return Tool{
@@ -91,8 +130,11 @@ func buildManifestValidateTool(client ManifestApplier) Tool {
 			"type": "object",
 			"properties": map[string]interface{}{
 				"manifest": map[string]interface{}{
-					"type":        "object",
-					"description": "The manifest JSON object to validate.",
+					"oneOf": []interface{}{
+						map[string]interface{}{"type": "object"},
+						map[string]interface{}{"type": "string"},
+					},
+					"description": "The manifest to validate, as a YAML/JSON string or a JSON object.",
 				},
 				"mode": map[string]interface{}{
 					"type":        "string",
@@ -114,9 +156,9 @@ func buildManifestValidateTool(client ManifestApplier) Tool {
 
 // manifestValidateParams holds parsed parameters for meridian_manifest_validate.
 type manifestValidateParams struct {
-	Manifest json.RawMessage `json:"manifest"`
-	Mode     string          `json:"mode"`      // "create" or "amend"
-	TenantID string          `json:"tenant_id"` // Required for amend mode
+	Manifest interface{} `json:"manifest"` // string (YAML/JSON) or object
+	Mode     string      `json:"mode"`     // "create" or "amend"
+	TenantID string      `json:"tenant_id"`
 }
 
 // handleManifestValidate implements the meridian_manifest_validate handler logic.
@@ -149,7 +191,14 @@ func handleManifestValidate(ctx context.Context, client ManifestApplier, params 
 		}, nil
 	}
 
-	manifest, err := manifestJSONToProto(p.Manifest)
+	manifestJSON, err := parseManifestInput(p.Manifest)
+	if err != nil {
+		return map[string]interface{}{ //nolint:nilerr // err is surfaced in the tool response
+			"valid":  false,
+			"errors": []interface{}{map[string]interface{}{"type": mcperrors.TypeManifestValidation, "message": err.Error()}},
+		}, nil
+	}
+	manifest, err := manifestJSONToProto(manifestJSON)
 	if err != nil {
 		return map[string]interface{}{ //nolint:nilerr // err is surfaced in the tool response
 			"valid":  false,
@@ -196,8 +245,11 @@ func buildManifestPlanTool(client ManifestApplier, sess PlanStore) Tool {
 			"type": "object",
 			"properties": map[string]interface{}{
 				"manifest": map[string]interface{}{
-					"type":        "object",
-					"description": "The manifest JSON object to plan.",
+					"oneOf": []interface{}{
+						map[string]interface{}{"type": "object"},
+						map[string]interface{}{"type": "string"},
+					},
+					"description": "The manifest to plan, as a YAML/JSON string or a JSON object.",
 				},
 			},
 			"required": []interface{}{"manifest"},
@@ -210,7 +262,7 @@ func buildManifestPlanTool(client ManifestApplier, sess PlanStore) Tool {
 
 // manifestPlanParams holds parsed parameters for meridian_manifest_plan.
 type manifestPlanParams struct {
-	Manifest json.RawMessage `json:"manifest"`
+	Manifest interface{} `json:"manifest"` // string (YAML/JSON) or object
 }
 
 // handleManifestPlan implements the meridian_manifest_plan handler logic.
@@ -220,7 +272,14 @@ func handleManifestPlan(ctx context.Context, client ManifestApplier, sess PlanSt
 		return mcperrors.FormatGRPCError(err), nil
 	}
 
-	manifest, err := manifestJSONToProto(p.Manifest)
+	manifestJSON, err := parseManifestInput(p.Manifest)
+	if err != nil {
+		return map[string]interface{}{ //nolint:nilerr // err is surfaced in the tool response
+			"valid":  false,
+			"errors": []interface{}{map[string]interface{}{"type": mcperrors.TypeManifestValidation, "message": err.Error()}},
+		}, nil
+	}
+	manifest, err := manifestJSONToProto(manifestJSON)
 	if err != nil {
 		return map[string]interface{}{ //nolint:nilerr // err is surfaced in the tool response
 			"valid":  false,
@@ -281,8 +340,11 @@ func buildManifestApplyTool(client ManifestApplier, sess PlanStore) Tool {
 			"type": "object",
 			"properties": map[string]interface{}{
 				"manifest": map[string]interface{}{
-					"type":        "object",
-					"description": "The manifest JSON object to apply (must match the planned manifest).",
+					"oneOf": []interface{}{
+						map[string]interface{}{"type": "object"},
+						map[string]interface{}{"type": "string"},
+					},
+					"description": "The manifest to apply (must match the planned manifest), as a YAML/JSON string or a JSON object.",
 				},
 				"plan_hash": map[string]interface{}{
 					"type":        "string",
@@ -303,9 +365,9 @@ func buildManifestApplyTool(client ManifestApplier, sess PlanStore) Tool {
 
 // manifestApplyParams holds parsed parameters for meridian_manifest_apply.
 type manifestApplyParams struct {
-	Manifest  json.RawMessage `json:"manifest"`
-	PlanHash  string          `json:"plan_hash"`
-	AppliedBy string          `json:"applied_by"`
+	Manifest  interface{} `json:"manifest"` // string (YAML/JSON) or object
+	PlanHash  string      `json:"plan_hash"`
+	AppliedBy string      `json:"applied_by"`
 }
 
 // handleManifestApply implements the meridian_manifest_apply handler logic.
@@ -323,7 +385,14 @@ func handleManifestApply(ctx context.Context, client ManifestApplier, sess PlanS
 		}, nil
 	}
 
-	manifest, err := manifestJSONToProto(p.Manifest)
+	manifestJSON, err := parseManifestInput(p.Manifest)
+	if err != nil {
+		return map[string]interface{}{ //nolint:nilerr // err is surfaced in the tool response
+			"valid":  false,
+			"errors": []interface{}{map[string]interface{}{"type": mcperrors.TypeManifestValidation, "message": err.Error()}},
+		}, nil
+	}
+	manifest, err := manifestJSONToProto(manifestJSON)
 	if err != nil {
 		return map[string]interface{}{ //nolint:nilerr // err is surfaced in the tool response
 			"valid":  false,

--- a/services/mcp-server/internal/tools/parse_manifest_input_test.go
+++ b/services/mcp-server/internal/tools/parse_manifest_input_test.go
@@ -1,0 +1,226 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/mcp-server/internal/tools"
+)
+
+// validManifestYAML returns a valid manifest in YAML string form.
+func validManifestYAML() string {
+	return `version: "1.0"
+metadata:
+  name: Test Economy
+  industry: energy
+  description: Test`
+}
+
+// validManifestJSONString returns the same manifest as a JSON string (not object).
+func validManifestJSONString() string {
+	return `{"version":"1.0","metadata":{"name":"Test Economy","industry":"energy","description":"Test"}}`
+}
+
+// --- parseManifestInput via handleManifestValidate integration tests ---
+
+func TestManifestValidate_YAMLStringInput_Accepted(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, req *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			if req.Manifest == nil {
+				t.Error("expected non-nil manifest in request")
+			}
+			return &controlplanev1.ApplyManifestResponse{
+				Status: controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN,
+			}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	// Pass manifest as a YAML string (not an object)
+	yamlStr, _ := json.Marshal(validManifestYAML())
+	params := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, yamlStr))
+	result, err := r.Call(context.Background(), "meridian_manifest_validate", params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if valid, _ := m["valid"].(bool); !valid {
+		t.Errorf("expected valid=true for YAML string input, got %v", m)
+	}
+}
+
+func TestManifestValidate_JSONStringInput_Accepted(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, req *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			if req.Manifest == nil {
+				t.Error("expected non-nil manifest in request")
+			}
+			return &controlplanev1.ApplyManifestResponse{
+				Status: controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN,
+			}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	// Pass manifest as a JSON string (YAML is a superset of JSON)
+	jsonStr, _ := json.Marshal(validManifestJSONString())
+	params := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, jsonStr))
+	result, err := r.Call(context.Background(), "meridian_manifest_validate", params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if valid, _ := m["valid"].(bool); !valid {
+		t.Errorf("expected valid=true for JSON string input, got %v", m)
+	}
+}
+
+func TestManifestValidate_InvalidYAMLString_ReturnsError(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			t.Error("should not call backend with invalid YAML")
+			return nil, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	// Pass an invalid YAML string
+	invalidYAML := `"invalid: yaml: [unclosed bracket"`
+	params := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, invalidYAML))
+	result, err := r.Call(context.Background(), "meridian_manifest_validate", params)
+	if err != nil {
+		t.Fatalf("expected handler error in result, not Go error: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if valid, _ := m["valid"].(bool); valid {
+		t.Error("expected valid=false for invalid YAML string")
+	}
+	if _, hasErrors := m["errors"]; !hasErrors {
+		t.Error("expected errors in response for invalid YAML")
+	}
+}
+
+func TestManifestPlan_YAMLStringInput_Accepted(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			return &controlplanev1.ApplyManifestResponse{
+				Status: controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN,
+			}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	yamlStr, _ := json.Marshal(validManifestYAML())
+	params := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, yamlStr))
+	result, err := r.Call(context.Background(), "meridian_manifest_plan", params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if valid, _ := m["valid"].(bool); !valid {
+		t.Errorf("expected valid=true for YAML string input in plan, got %v", m)
+	}
+	if _, ok := m["plan_hash"]; !ok {
+		t.Error("expected plan_hash in response")
+	}
+}
+
+func TestManifestApply_YAMLStringInput_Accepted(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, req *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			if req.DryRun {
+				return &controlplanev1.ApplyManifestResponse{
+					Status: controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN,
+				}, nil
+			}
+			return &controlplanev1.ApplyManifestResponse{
+				Status: controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_APPLIED,
+				JobId:  "job-yaml-test",
+			}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	yamlStr, _ := json.Marshal(validManifestYAML())
+	planParams := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, yamlStr))
+
+	// First plan
+	planResult, err := r.Call(context.Background(), "meridian_manifest_plan", planParams)
+	if err != nil {
+		t.Fatalf("plan unexpected error: %v", err)
+	}
+	planMap := planResult.(map[string]interface{})
+	planHash := planMap["plan_hash"].(string)
+
+	// Then apply with same YAML string
+	applyParams := json.RawMessage(fmt.Sprintf(`{"manifest": %s, "plan_hash": %q, "applied_by": "test@example.com"}`, yamlStr, planHash))
+	result, err := r.Call(context.Background(), "meridian_manifest_apply", applyParams)
+	if err != nil {
+		t.Fatalf("apply unexpected error: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if status, _ := m["status"].(string); status != controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_APPLIED.String() {
+		t.Errorf("expected applied status, got %v", m)
+	}
+}
+
+func TestManifestValidate_JSONObjectInput_StillWorks(t *testing.T) {
+	mock := &mockManifestApplier{
+		applyFn: func(_ context.Context, _ *controlplanev1.ApplyManifestRequest) (*controlplanev1.ApplyManifestResponse, error) {
+			return &controlplanev1.ApplyManifestResponse{
+				Status: controlplanev1.ApplyManifestStatus_APPLY_MANIFEST_STATUS_DRY_RUN,
+			}, nil
+		},
+	}
+
+	r := tools.NewRegistry()
+	sess := newTestSession()
+	tools.RegisterEconomyTools(r, sess, tools.EconomyDeps{Applier: mock})
+
+	// Pass manifest as a JSON object (the original behavior)
+	params := json.RawMessage(fmt.Sprintf(`{"manifest": %s}`, validManifestJSON()))
+	result, err := r.Call(context.Background(), "meridian_manifest_validate", params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if valid, _ := m["valid"].(bool); !valid {
+		t.Errorf("expected valid=true for JSON object input, got %v", m)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `parseManifestInput` helper in `economy.go` that accepts a YAML/JSON string, `json.RawMessage`, or `map[string]interface{}` and returns `json.RawMessage` for proto conversion
- Update `InputSchema` for `meridian_manifest_validate`, `meridian_manifest_plan`, and `meridian_manifest_apply` to accept `oneOf: [object, string]` for the `manifest` field
- Update `manifestValidateParams`, `manifestPlanParams`, and `manifestApplyParams` structs to use `interface{}` for the `Manifest` field
- Apply `parseManifestInput` in all three handlers before calling `manifestJSONToProto`

## Technical Details

- YAML is a superset of JSON, so JSON strings are also accepted via the YAML parser
- Canonical proto hashing in plan/apply means YAML and equivalent JSON representations produce the same `plan_hash` — plan with YAML, apply with YAML works correctly
- Uses `gopkg.in/yaml.v3` (already in go.mod) for YAML parsing
- Sentinel error `errUnsupportedManifestType` used for unsupported types (satisfies err113 lint rule)

## Testing

6 new integration tests covering:
1. YAML string input accepted in validate
2. JSON string input accepted in validate (YAML superset)
3. Invalid YAML string returns meaningful error in response
4. YAML string input accepted in plan
5. YAML string plan + YAML string apply works end-to-end
6. JSON object input still works (backwards compatibility)

## Risk Assessment

Low risk — additive change. Existing JSON object input is unchanged; string input is now additionally accepted. Schema change is backwards compatible (`oneOf` allows both).