### PR TITLE
feat: Add OAuth 2.1 authentication for MCP server

### DIFF
--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -18,7 +18,7 @@ demo.meridianhub.cloud, *.demo.meridianhub.cloud {
 	# MCP Server: streamable HTTP transport + OAuth 2.1 endpoints
 	# Also handles /.well-known/* for OAuth metadata discovery.
 	@mcp_transport {
-		path /mcp /mcp/* /oauth/*
+		path /mcp /mcp/* /oauth/* /.well-known/oauth-authorization-server
 	}
 	handle @mcp_transport {
 		reverse_proxy mcp-server:8090

--- a/deploy/demo/Caddyfile
+++ b/deploy/demo/Caddyfile
@@ -15,16 +15,10 @@ demo.meridianhub.cloud, *.demo.meridianhub.cloud {
 		reverse_proxy meridian:8090
 	}
 
-	# OAuth well-known discovery — return 404 when OAuth is not enabled.
-	# This must come before the SPA catch-all so MCP clients get a proper
-	# HTTP error instead of HTML, which they interpret as "needs auth".
-	handle /.well-known/* {
-		respond "Not Found" 404
-	}
-
-	# MCP Server: streamable HTTP transport
+	# MCP Server: streamable HTTP transport + OAuth 2.1 endpoints
+	# Also handles /.well-known/* for OAuth metadata discovery.
 	@mcp_transport {
-		path /mcp /mcp/*
+		path /mcp /mcp/* /oauth/*
 	}
 	handle @mcp_transport {
 		reverse_proxy mcp-server:8090

--- a/deploy/demo/dex.yaml
+++ b/deploy/demo/dex.yaml
@@ -43,9 +43,12 @@ staticClients:
     redirectURIs:
       # Production BFF callback
       - "https://demo.meridianhub.cloud/api/auth/callback"
+      # MCP server OAuth callback (OIDC-delegated auth for MCP clients)
+      - "https://demo.meridianhub.cloud/oauth/callback"
       # Local development
       - "http://localhost:8090/api/auth/callback"
       - "http://localhost:3000/api/auth/callback"
+      - "http://localhost:8091/oauth/callback"
     public: true
 
 enablePasswordDB: false

--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -134,10 +134,23 @@ services:
       # --- Application ---
       LOG_LEVEL: ${LOG_LEVEL:-info}
 
-      # --- OAuth (optional) ---
+      # --- OAuth 2.1 + OIDC (optional) ---
       MCP_OAUTH_ENABLED: ${MCP_OAUTH_ENABLED:-false}
-      MCP_OAUTH_CLIENT_ID: ${MCP_OAUTH_CLIENT_ID:-}      # required when MCP_OAUTH_ENABLED=true
-      MCP_OAUTH_REDIRECT_URI: ${MCP_OAUTH_REDIRECT_URI:-} # required when MCP_OAUTH_ENABLED=true
+      MCP_OAUTH_CLIENT_ID: ${MCP_OAUTH_CLIENT_ID:-meridian-mcp}
+      MCP_BASE_DOMAIN: ${BASE_DOMAIN:-}
+
+      # --- Dex OIDC (delegates authentication to Dex when MCP_OAUTH_ENABLED=true) ---
+      MCP_DEX_ISSUER_URL: ${MCP_DEX_ISSUER_URL:-}                 # e.g. http://dex:5556/dex (internal) or https://demo.meridianhub.cloud/dex
+      MCP_DEX_CLIENT_ID: ${MCP_DEX_CLIENT_ID:-meridian-service}   # Dex static client ID
+      MCP_DEX_CALLBACK_URL: ${MCP_DEX_CALLBACK_URL:-}             # e.g. https://demo.meridianhub.cloud/oauth/callback
+
+      # --- JWT signing (shared with BFF for session interoperability) ---
+      JWT_SIGNING_KEY: ${JWT_SIGNING_KEY:-}
+      JWT_SIGNING_KEY_ID: ${JWT_SIGNING_KEY_ID:-meridian-1}
+      JWT_SIGNING_ISSUER: ${JWT_SIGNING_ISSUER:-meridian}
+
+      # --- Bearer token validation ---
+      MCP_JWKS_URL: ${MCP_JWKS_URL:-}                             # e.g. https://demo.meridianhub.cloud/api/auth/jwks
     # Not exposed to host — accessed only by caddy on the internal network
     # Caddy proxies /mcp to this container
 

--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	mcpauth "github.com/meridianhub/meridian/services/mcp-server/internal/auth"
 	"github.com/meridianhub/meridian/services/mcp-server/internal/server"
 	"github.com/meridianhub/meridian/services/mcp-server/internal/transport"
+	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/meridianhub/meridian/shared/platform/env"
 )
@@ -217,13 +218,13 @@ func runHTTP(logger *slog.Logger, cfg server.Config) error {
 			"authorization_url", oauthCfg.AuthorizationURL,
 			"token_url", oauthCfg.TokenURL)
 
-		store := mcpauth.NewCodeStore()
-		defer store.Close()
-		issuer := &passthroughIssuer{logger: logger}
-		authzHandler := mcpauth.NewAuthorizationHandler(oauthCfg, store)
-		tokenHandler := mcpauth.NewTokenHandler(oauthCfg, store, issuer)
+		codeStore := mcpauth.NewCodeStore()
+		defer codeStore.Close()
 
-		mux.Handle("/oauth/authorize", authzHandler)
+		// Token endpoint uses passthrough issuer as fallback; the OIDC flow
+		// stores pre-signed JWTs directly via StoreWithToken.
+		issuer := &passthroughIssuer{logger: logger}
+		tokenHandler := mcpauth.NewTokenHandler(oauthCfg, codeStore, issuer)
 		mux.Handle("/oauth/token", tokenHandler)
 
 		meta := mcpauth.Metadata{
@@ -231,8 +232,58 @@ func runHTTP(logger *slog.Logger, cfg server.Config) error {
 			TokenURL:         oauthCfg.TokenURL,
 		}
 
-		// The JWKS provider uses its own Close() to stop the background refresh
-		// goroutine on shutdown.
+		baseDomain := env.GetEnvOrDefault("MCP_BASE_DOMAIN", "")
+
+		// OIDC-backed authorization flow: /oauth/authorize → Dex → /oauth/callback.
+		dexIssuerURL := env.GetEnvOrDefault("MCP_DEX_ISSUER_URL", "")
+		dexClientID := env.GetEnvOrDefault("MCP_DEX_CLIENT_ID", "meridian-service")
+		dexCallbackURL := env.GetEnvOrDefault("MCP_DEX_CALLBACK_URL", baseURL+"/oauth/callback")
+
+		if dexIssuerURL != "" {
+			// Build JWT signer with the same key as BFF for session sharing.
+			signer, err := platformauth.NewJWTSigner(platformauth.JWTSignerConfig{
+				PrivateKeyPEM: env.GetEnvOrDefault("JWT_SIGNING_KEY", ""),
+				KeyID:         env.GetEnvOrDefault("JWT_SIGNING_KEY_ID", "meridian-1"),
+				Issuer:        env.GetEnvOrDefault("JWT_SIGNING_ISSUER", "meridian"),
+			})
+			if err != nil {
+				return fmt.Errorf("jwt signer: %w", err)
+			}
+
+			oidcStateStore := mcpauth.NewOIDCStateStore()
+			defer oidcStateStore.Close()
+
+			oidcHandler, err := mcpauth.NewOIDCHandler(mcpauth.OIDCHandlerConfig{
+				OIDC: mcpauth.OIDCConfig{
+					DexIssuerURL: dexIssuerURL,
+					ClientID:     dexClientID,
+					CallbackURL:  dexCallbackURL,
+				},
+				OAuth:      oauthCfg,
+				StateStore: oidcStateStore,
+				CodeStore:  codeStore,
+				Signer:     signer,
+				BaseDomain: baseDomain,
+				Logger:     logger,
+			})
+			if err != nil {
+				return fmt.Errorf("oidc handler: %w", err)
+			}
+
+			mux.HandleFunc("/oauth/authorize", oidcHandler.HandleAuthorize)
+			mux.HandleFunc("/oauth/callback", oidcHandler.HandleCallback)
+
+			logger.Info("OIDC-backed OAuth enabled",
+				"dex_issuer", dexIssuerURL,
+				"callback", dexCallbackURL)
+		} else {
+			// No Dex configured — use the direct authorization handler (dev/CI only).
+			logger.Warn("MCP_DEX_ISSUER_URL not set — /oauth/authorize issues codes without authentication")
+			authzHandler := mcpauth.NewAuthorizationHandler(oauthCfg, codeStore)
+			mux.Handle("/oauth/authorize", authzHandler)
+		}
+
+		// Bearer token validation on the /mcp endpoint.
 		validator, validatorCleanup, err := buildBearerValidator(context.Background(), logger)
 		if err != nil {
 			return fmt.Errorf("bearer validator: %w", err)
@@ -244,7 +295,6 @@ func runHTTP(logger *slog.Logger, cfg server.Config) error {
 
 		// Subdomain-to-tenant validation: ensures the request's subdomain
 		// matches the authenticated user's tenant from the JWT.
-		baseDomain := env.GetEnvOrDefault("MCP_BASE_DOMAIN", "")
 		subdomainMW := mcpauth.NewTenantSubdomainMiddleware(baseDomain, logger)
 
 		mcpHandler := bearerMW.Handler(streamableHandler)

--- a/services/mcp-server/internal/auth/oauth.go
+++ b/services/mcp-server/internal/auth/oauth.go
@@ -63,6 +63,10 @@ type CodeEntry struct {
 	ClientID      string
 	RedirectURI   string
 	IssuedAt      time.Time
+	// Token is the pre-signed JWT to return at token exchange time.
+	// When set (by the OIDC callback flow), the TokenHandler returns this
+	// token directly instead of calling the TokenIssuer.
+	Token string
 }
 
 // CodeStore is a thread-safe in-memory store for authorization codes.
@@ -71,6 +75,7 @@ type CodeEntry struct {
 type CodeStore struct {
 	mu        sync.Mutex
 	codes     map[string]CodeEntry
+	tokens    map[string]string // code → pre-signed JWT (set by OIDC flow)
 	stop      chan struct{}
 	closeOnce sync.Once
 }
@@ -79,8 +84,9 @@ type CodeStore struct {
 // Call [CodeStore.Close] to stop the eviction goroutine when the store is no longer needed.
 func NewCodeStore() *CodeStore {
 	s := &CodeStore{
-		codes: make(map[string]CodeEntry),
-		stop:  make(chan struct{}),
+		codes:  make(map[string]CodeEntry),
+		tokens: make(map[string]string),
+		stop:   make(chan struct{}),
 	}
 	go s.evictLoop()
 	return s
@@ -112,6 +118,7 @@ func (s *CodeStore) evictExpired() {
 	for code, entry := range s.codes {
 		if time.Since(entry.IssuedAt) > authCodeTTL {
 			delete(s.codes, code)
+			delete(s.tokens, code)
 		}
 	}
 }
@@ -123,9 +130,21 @@ func (s *CodeStore) Store(code string, entry CodeEntry) {
 	s.codes[code] = entry
 }
 
+// StoreWithToken saves an authorization code entry alongside a pre-signed JWT.
+// The token is returned directly by the TokenHandler during code exchange,
+// bypassing the TokenIssuer. Used by the OIDC callback flow.
+func (s *CodeStore) StoreWithToken(code string, entry CodeEntry, token string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.codes[code] = entry
+	s.tokens[code] = token
+}
+
 // Consume atomically retrieves and deletes an authorization code.
 // Returns (entry, true) if the code exists and has not expired.
 // Returns (zero, false) if the code is unknown or expired.
+// If a pre-signed token was stored with StoreWithToken, the entry's Token
+// field is populated.
 func (s *CodeStore) Consume(code string) (CodeEntry, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -135,8 +154,14 @@ func (s *CodeStore) Consume(code string) (CodeEntry, bool) {
 		return CodeEntry{}, false
 	}
 
+	// Retrieve pre-signed token if present.
+	if token, hasToken := s.tokens[code]; hasToken {
+		entry.Token = token
+	}
+
 	// Always delete (one-time use), even if expired.
 	delete(s.codes, code)
+	delete(s.tokens, code)
 
 	if time.Since(entry.IssuedAt) > authCodeTTL {
 		return CodeEntry{}, false
@@ -332,16 +357,22 @@ func (h *TokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Issue token via the configured issuer.
-	claims := map[string]any{
-		"client_id": clientID,
-		"iat":       time.Now().Unix(),
-	}
-	token, err := h.issuer.Issue(claims)
-	if err != nil {
-		h.logger.Error("token issuer failed", "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-		return
+	// Use pre-signed token from OIDC flow if available, otherwise issue via TokenIssuer.
+	var token string
+	if entry.Token != "" {
+		token = entry.Token
+	} else {
+		claims := map[string]any{
+			"client_id": clientID,
+			"iat":       time.Now().Unix(),
+		}
+		var err error
+		token, err = h.issuer.Issue(claims)
+		if err != nil {
+			h.logger.Error("token issuer failed", "error", err)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	h.logger.Info("access token issued", "client_id", clientID)

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -1,0 +1,525 @@
+// Package auth provides OIDC integration for the MCP server's OAuth 2.1 flow.
+//
+// The MCP server acts as an OAuth 2.1 authorization server for MCP clients
+// (e.g., Claude.ai). Authentication is delegated to Dex via standard OIDC:
+//
+//  1. MCP client POSTs to /mcp → receives 401 with auth metadata
+//  2. MCP client opens browser → /oauth/authorize
+//  3. /oauth/authorize stores PKCE state, redirects to Dex
+//  4. User authenticates via Dex (Google, GitHub, password, etc.)
+//  5. Dex redirects to /oauth/callback with authorization code
+//  6. MCP server exchanges code for ID token, extracts email
+//  7. MCP server signs a Meridian JWT with tenant context
+//  8. MCP server redirects to MCP client's redirect_uri with auth code
+//  9. MCP client exchanges auth code for JWT at /oauth/token
+//
+// The JWT is signed with the same key as the BFF (shared JWT_SIGNING_KEY),
+// so MCP-issued tokens are validated by the same JWKS endpoint. If the user
+// is already authenticated via the UI, their BFF-issued JWT is also accepted.
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
+)
+
+var (
+	errOIDCDexIssuerRequired = errors.New("oidc handler: dex issuer URL is required")
+	errOIDCClientIDRequired  = errors.New("oidc handler: client ID is required")
+	errOIDCCallbackRequired  = errors.New("oidc handler: callback URL is required")
+	errOIDCSignerRequired    = errors.New("oidc handler: JWT signer is required")
+	errOIDCLoggerRequired    = errors.New("oidc handler: logger is required")
+	errDexTokenError         = errors.New("dex token error")
+	errDexBadStatus          = errors.New("dex token endpoint returned non-200 status")
+	errDexEmptyIDToken       = errors.New("dex returned empty id_token")
+	errInvalidJWTFormat      = errors.New("invalid JWT format")
+	errEmailClaimMissing     = errors.New("email claim missing from ID token")
+)
+
+const (
+	// oidcStateTTL is how long OIDC flow state remains valid.
+	oidcStateTTL = 10 * time.Minute
+	// oidcStateBytes is the number of random bytes in a state token.
+	oidcStateBytes = 32
+	// oidcCodeVerifierBytes is the number of random bytes for PKCE code verifier.
+	oidcCodeVerifierBytes = 32
+	// oidcMaxTokenResponseBytes limits the Dex token response body size.
+	oidcMaxTokenResponseBytes = 64 * 1024
+	// oidcHTTPTimeout is the timeout for Dex token exchange.
+	oidcHTTPTimeout = 10 * time.Second
+	// oidcStateEvictInterval is how often expired state entries are swept.
+	oidcStateEvictInterval = 5 * time.Minute
+
+	// defaultTokenTTL is the default JWT token lifetime.
+	defaultTokenTTL = time.Hour
+)
+
+// OIDCConfig holds configuration for the Dex OIDC integration.
+type OIDCConfig struct {
+	// DexIssuerURL is the Dex issuer URL (e.g., "https://demo.meridianhub.cloud/dex").
+	DexIssuerURL string
+	// ClientID is the OAuth2 client ID registered with Dex.
+	ClientID string
+	// CallbackURL is the MCP server's OIDC callback URL
+	// (e.g., "https://demo.meridianhub.cloud/oauth/callback").
+	CallbackURL string
+}
+
+// OIDCFlowState holds the state for an in-progress OIDC authorization flow.
+// It bridges the MCP client's OAuth request with the Dex OIDC flow.
+type OIDCFlowState struct {
+	// MCP client's PKCE code challenge (from the original /oauth/authorize request).
+	MCPCodeChallenge string
+	// MCP client's OAuth client ID.
+	MCPClientID string
+	// MCP client's redirect URI (where to send the auth code after authentication).
+	MCPRedirectURI string
+	// MCP client's state parameter (forwarded back after authentication).
+	MCPState string
+	// PKCE code verifier for the Dex authorization code exchange.
+	DexCodeVerifier string
+	// TenantSlug extracted from the request subdomain.
+	TenantSlug string
+	// IssuedAt is when this state was created.
+	IssuedAt time.Time
+}
+
+// OIDCStateStore is a thread-safe in-memory store for OIDC flow state.
+type OIDCStateStore struct {
+	mu        sync.Mutex
+	entries   map[string]OIDCFlowState
+	stop      chan struct{}
+	closeOnce sync.Once
+}
+
+// NewOIDCStateStore creates an empty state store and starts the background eviction goroutine.
+func NewOIDCStateStore() *OIDCStateStore {
+	s := &OIDCStateStore{
+		entries: make(map[string]OIDCFlowState),
+		stop:    make(chan struct{}),
+	}
+	go s.evictLoop()
+	return s
+}
+
+// Close stops the background eviction goroutine.
+func (s *OIDCStateStore) Close() {
+	s.closeOnce.Do(func() { close(s.stop) })
+}
+
+func (s *OIDCStateStore) evictLoop() {
+	ticker := time.NewTicker(oidcStateEvictInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.evictExpired()
+		case <-s.stop:
+			return
+		}
+	}
+}
+
+func (s *OIDCStateStore) evictExpired() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key, entry := range s.entries {
+		if time.Since(entry.IssuedAt) > oidcStateTTL {
+			delete(s.entries, key)
+		}
+	}
+}
+
+// Store saves an OIDC flow state entry and returns a key for retrieval.
+func (s *OIDCStateStore) Store(entry OIDCFlowState) (string, error) {
+	key, err := generateRandomToken(oidcStateBytes)
+	if err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[key] = entry
+	return key, nil
+}
+
+// Consume atomically retrieves and deletes an OIDC flow state entry.
+func (s *OIDCStateStore) Consume(key string) (OIDCFlowState, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.entries[key]
+	if !ok {
+		return OIDCFlowState{}, false
+	}
+	delete(s.entries, key)
+	if time.Since(entry.IssuedAt) > oidcStateTTL {
+		return OIDCFlowState{}, false
+	}
+	return entry, true
+}
+
+// OIDCHandler manages the OIDC authorization flow with Dex.
+type OIDCHandler struct {
+	cfg        OIDCConfig
+	oauthCfg   OAuthConfig
+	stateStore *OIDCStateStore
+	codeStore  *CodeStore
+	signer     *platformauth.JWTSigner
+	tokenTTL   time.Duration
+	baseDomain string
+	httpClient *http.Client
+	logger     *slog.Logger
+}
+
+// OIDCHandlerConfig holds configuration for creating an OIDCHandler.
+type OIDCHandlerConfig struct {
+	OIDC       OIDCConfig
+	OAuth      OAuthConfig
+	StateStore *OIDCStateStore
+	CodeStore  *CodeStore
+	Signer     *platformauth.JWTSigner
+	TokenTTL   time.Duration
+	BaseDomain string
+	HTTPClient *http.Client
+	Logger     *slog.Logger
+}
+
+// NewOIDCHandler creates a handler for the OIDC-backed OAuth 2.1 flow.
+func NewOIDCHandler(cfg OIDCHandlerConfig) (*OIDCHandler, error) {
+	if cfg.OIDC.DexIssuerURL == "" {
+		return nil, errOIDCDexIssuerRequired
+	}
+	if cfg.OIDC.ClientID == "" {
+		return nil, errOIDCClientIDRequired
+	}
+	if cfg.OIDC.CallbackURL == "" {
+		return nil, errOIDCCallbackRequired
+	}
+	if cfg.Signer == nil {
+		return nil, errOIDCSignerRequired
+	}
+	if cfg.Logger == nil {
+		return nil, errOIDCLoggerRequired
+	}
+
+	ttl := cfg.TokenTTL
+	if ttl == 0 {
+		ttl = defaultTokenTTL
+	}
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: oidcHTTPTimeout}
+	}
+
+	return &OIDCHandler{
+		cfg:        cfg.OIDC,
+		oauthCfg:   cfg.OAuth,
+		stateStore: cfg.StateStore,
+		codeStore:  cfg.CodeStore,
+		signer:     cfg.Signer,
+		tokenTTL:   ttl,
+		baseDomain: cfg.BaseDomain,
+		httpClient: httpClient,
+		logger:     cfg.Logger,
+	}, nil
+}
+
+// HandleAuthorize handles GET /oauth/authorize from the MCP client.
+// It stores the MCP client's PKCE state and redirects to Dex for authentication.
+func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	q := r.URL.Query()
+
+	clientID := q.Get("client_id")
+	if clientID != h.oauthCfg.ClientID {
+		http.Error(w, "invalid client_id", http.StatusBadRequest)
+		return
+	}
+
+	if q.Get("response_type") != "code" {
+		http.Error(w, "response_type must be 'code'", http.StatusBadRequest)
+		return
+	}
+
+	challenge := q.Get("code_challenge")
+	if challenge == "" {
+		http.Error(w, "code_challenge is required (PKCE S256)", http.StatusBadRequest)
+		return
+	}
+
+	method := q.Get("code_challenge_method")
+	if method != "S256" {
+		http.Error(w, "only code_challenge_method=S256 is supported", http.StatusBadRequest)
+		return
+	}
+
+	redirectURI := q.Get("redirect_uri")
+	if redirectURI == "" {
+		http.Error(w, "redirect_uri is required", http.StatusBadRequest)
+		return
+	}
+
+	// Extract tenant slug from request subdomain.
+	tenantSlug := extractSubdomain(r.Host, h.baseDomain)
+
+	// Generate PKCE code verifier for the Dex exchange.
+	dexVerifier, err := generateRandomToken(oidcCodeVerifierBytes)
+	if err != nil {
+		h.logger.Error("oidc: failed to generate code verifier", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	dexChallenge := computeS256Challenge(dexVerifier)
+
+	// Store state bridging MCP client request ↔ Dex OIDC flow.
+	stateKey, err := h.stateStore.Store(OIDCFlowState{
+		MCPCodeChallenge: challenge,
+		MCPClientID:      clientID,
+		MCPRedirectURI:   redirectURI,
+		MCPState:         q.Get("state"),
+		DexCodeVerifier:  dexVerifier,
+		TenantSlug:       tenantSlug,
+		IssuedAt:         time.Now(),
+	})
+	if err != nil {
+		h.logger.Error("oidc: failed to store state", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Redirect to Dex authorization endpoint.
+	// Use the "local" connector for password-based auth, or omit connector_id
+	// to let Dex show its connector selection page.
+	dexAuthURL := h.cfg.DexIssuerURL + "/auth"
+	params := url.Values{
+		"client_id":             {h.cfg.ClientID},
+		"redirect_uri":          {h.cfg.CallbackURL},
+		"response_type":         {"code"},
+		"scope":                 {"openid email profile"},
+		"state":                 {stateKey},
+		"code_challenge":        {dexChallenge},
+		"code_challenge_method": {"S256"},
+	}
+
+	redirectURL := dexAuthURL + "?" + params.Encode()
+
+	h.logger.Info("oidc: initiating Dex authorization",
+		"tenant", tenantSlug,
+		"client_id", clientID)
+
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// HandleCallback handles GET /oauth/callback from Dex.
+// It exchanges the Dex authorization code for an ID token, extracts the email,
+// signs a Meridian JWT, and redirects back to the MCP client's redirect_uri.
+func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ctx := r.Context()
+	q := r.URL.Query()
+
+	// Check for Dex error.
+	if errParam := q.Get("error"); errParam != "" {
+		desc := q.Get("error_description")
+		h.logger.Warn("oidc: Dex returned error",
+			"error", errParam, "description", desc)
+		http.Error(w, "authentication failed: "+errParam, http.StatusBadRequest)
+		return
+	}
+
+	stateKey := q.Get("state")
+	code := q.Get("code")
+	if stateKey == "" || code == "" {
+		http.Error(w, "missing state or code parameter", http.StatusBadRequest)
+		return
+	}
+
+	// Retrieve and consume state (one-time use).
+	flowState, ok := h.stateStore.Consume(stateKey)
+	if !ok {
+		http.Error(w, "invalid or expired state parameter", http.StatusBadRequest)
+		return
+	}
+
+	// Exchange Dex authorization code for tokens.
+	idToken, err := h.exchangeDexCode(ctx, code, flowState.DexCodeVerifier)
+	if err != nil {
+		h.logger.Error("oidc: Dex token exchange failed",
+			"tenant", flowState.TenantSlug, "error", err)
+		http.Error(w, "authentication token exchange failed", http.StatusBadGateway)
+		return
+	}
+
+	// Extract email from Dex ID token (trusted server-to-server response).
+	email, err := extractEmailFromJWT(idToken)
+	if err != nil {
+		h.logger.Error("oidc: failed to extract email from ID token",
+			"tenant", flowState.TenantSlug, "error", err)
+		http.Error(w, "failed to process identity", http.StatusBadGateway)
+		return
+	}
+
+	// Sign Meridian JWT with tenant context.
+	claims := map[string]interface{}{
+		"sub":         email, // Use email as subject until identity resolution is wired
+		"email":       email,
+		"x-tenant-id": flowState.TenantSlug,
+	}
+	tokenStr, err := h.signer.SignClaims(claims, h.tokenTTL)
+	if err != nil {
+		h.logger.Error("oidc: failed to sign JWT",
+			"tenant", flowState.TenantSlug, "error", err)
+		http.Error(w, "failed to create session", http.StatusInternalServerError)
+		return
+	}
+
+	// Generate MCP authorization code and store it with the JWT.
+	mcpCode, err := generateCode()
+	if err != nil {
+		h.logger.Error("oidc: failed to generate auth code", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	h.codeStore.StoreWithToken(mcpCode, CodeEntry{
+		CodeChallenge: flowState.MCPCodeChallenge,
+		ClientID:      flowState.MCPClientID,
+		RedirectURI:   flowState.MCPRedirectURI,
+		IssuedAt:      time.Now(),
+	}, tokenStr)
+
+	h.logger.Info("oidc: authentication successful",
+		"tenant", flowState.TenantSlug,
+		"email", email)
+
+	// Redirect to MCP client's redirect_uri with the authorization code.
+	target, err := url.Parse(flowState.MCPRedirectURI)
+	if err != nil {
+		h.logger.Error("oidc: invalid redirect URI", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	params := target.Query()
+	params.Set("code", mcpCode)
+	if flowState.MCPState != "" {
+		params.Set("state", flowState.MCPState)
+	}
+	target.RawQuery = params.Encode()
+
+	http.Redirect(w, r, target.String(), http.StatusFound)
+}
+
+// exchangeDexCode exchanges a Dex authorization code for an ID token.
+func (h *OIDCHandler) exchangeDexCode(ctx context.Context, code, codeVerifier string) (string, error) {
+	tokenURL := h.cfg.DexIssuerURL + "/token"
+	data := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {h.cfg.ClientID},
+		"code":          {code},
+		"redirect_uri":  {h.cfg.CallbackURL},
+		"code_verifier": {codeVerifier},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token endpoint request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, oidcMaxTokenResponseBytes))
+	if err != nil {
+		return "", fmt.Errorf("read token response: %w", err)
+	}
+
+	var tokenResp struct {
+		IDToken string `json:"id_token"`
+		Error   string `json:"error,omitempty"`
+		ErrDesc string `json:"error_description,omitempty"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("parse token response: %w", err)
+	}
+
+	if tokenResp.Error != "" {
+		return "", fmt.Errorf("%w: %s: %s", errDexTokenError, tokenResp.Error, tokenResp.ErrDesc)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%w: status %d", errDexBadStatus, resp.StatusCode)
+	}
+
+	if tokenResp.IDToken == "" {
+		return "", errDexEmptyIDToken
+	}
+
+	return tokenResp.IDToken, nil
+}
+
+// extractEmailFromJWT extracts the email claim from a JWT payload without
+// signature verification (trusted server-to-server response from Dex).
+func extractEmailFromJWT(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", errInvalidJWTFormat
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decode JWT payload: %w", err)
+	}
+
+	var claims struct {
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("parse JWT claims: %w", err)
+	}
+
+	if claims.Email == "" {
+		return "", errEmailClaimMissing
+	}
+
+	return claims.Email, nil
+}
+
+// generateRandomToken generates a cryptographically random URL-safe token.
+func generateRandomToken(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate random token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// computeS256Challenge computes the S256 PKCE code challenge from a verifier.
+func computeS256Challenge(verifier string) string {
+	h := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(h[:])
+}

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -48,6 +48,7 @@ var (
 	errDexTokenError          = errors.New("dex token error")
 	errDexBadStatus           = errors.New("dex token endpoint returned non-200 status")
 	errDexEmptyIDToken        = errors.New("dex returned empty id_token")
+	errOIDCStateFull          = errors.New("oidc state store is full")
 	errInvalidJWTFormat       = errors.New("invalid JWT format")
 	errEmailClaimMissing      = errors.New("email claim missing from ID token")
 )
@@ -65,6 +66,9 @@ const (
 	oidcHTTPTimeout = 10 * time.Second
 	// oidcStateEvictInterval is how often expired state entries are swept.
 	oidcStateEvictInterval = 5 * time.Minute
+	// oidcStateMaxEntries caps the number of in-flight OIDC authorizations
+	// to prevent memory exhaustion from unauthenticated requests.
+	oidcStateMaxEntries = 10_000
 
 	// defaultTokenTTL is the default JWT token lifetime.
 	defaultTokenTTL = time.Hour
@@ -147,6 +151,7 @@ func (s *OIDCStateStore) evictExpired() {
 }
 
 // Store saves an OIDC flow state entry and returns a key for retrieval.
+// Returns errOIDCStateFull if the store has reached its capacity limit.
 func (s *OIDCStateStore) Store(entry OIDCFlowState) (string, error) {
 	key, err := generateRandomToken(oidcStateBytes)
 	if err != nil {
@@ -154,6 +159,9 @@ func (s *OIDCStateStore) Store(entry OIDCFlowState) (string, error) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if len(s.entries) >= oidcStateMaxEntries {
+		return "", errOIDCStateFull
+	}
 	s.entries[key] = entry
 	return key, nil
 }

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -284,6 +284,15 @@ func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate redirect_uri scheme to prevent open-redirect attacks.
+	// MCP clients provide dynamic callback URIs, so we validate the scheme
+	// rather than matching a single registered URI: HTTPS is required for
+	// production; HTTP is allowed only for localhost (development).
+	if !isAllowedRedirectURI(redirectURI) {
+		http.Error(w, "redirect_uri must use https (or http://localhost for development)", http.StatusBadRequest)
+		return
+	}
+
 	// Extract tenant slug from request subdomain.
 	tenantSlug := extractSubdomain(r.Host, h.baseDomain)
 
@@ -529,4 +538,21 @@ func generateRandomToken(n int) (string, error) {
 func computeS256Challenge(verifier string) string {
 	h := sha256.Sum256([]byte(verifier))
 	return base64.RawURLEncoding.EncodeToString(h[:])
+}
+
+// isAllowedRedirectURI validates that a redirect URI is safe to redirect to.
+// HTTPS is required for production; HTTP is allowed only for localhost (development).
+func isAllowedRedirectURI(uri string) bool {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return false
+	}
+	if parsed.Scheme == "https" {
+		return true
+	}
+	if parsed.Scheme == "http" {
+		host := parsed.Hostname()
+		return host == "localhost" || host == "127.0.0.1" || host == "::1"
+	}
+	return false
 }

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -72,6 +72,9 @@ const (
 
 	// defaultTokenTTL is the default JWT token lifetime.
 	defaultTokenTTL = time.Hour
+
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
 )
 
 // OIDCConfig holds configuration for the Dex OIDC integration.
@@ -212,6 +215,17 @@ func NewOIDCHandler(cfg OIDCHandlerConfig) (*OIDCHandler, error) {
 	if cfg.OIDC.DexIssuerURL == "" {
 		return nil, errOIDCDexIssuerRequired
 	}
+	// Parse and validate the Dex issuer URL scheme. HTTPS is required because
+	// the OIDC callback trusts the Dex token response without signature
+	// verification (server-to-server over TLS). HTTP is allowed for local
+	// development (e.g., http://dex:5556/dex) but logged as a warning.
+	issuerURL, err := url.Parse(cfg.OIDC.DexIssuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("oidc handler: invalid dex issuer URL: %w", err)
+	}
+	if issuerURL.Scheme != schemeHTTPS && issuerURL.Scheme != schemeHTTP {
+		return nil, fmt.Errorf("oidc handler: dex issuer URL must use http or https: %w", errOIDCDexIssuerRequired)
+	}
 	if cfg.OIDC.ClientID == "" {
 		return nil, errOIDCClientIDRequired
 	}
@@ -229,6 +243,11 @@ func NewOIDCHandler(cfg OIDCHandlerConfig) (*OIDCHandler, error) {
 	}
 	if cfg.Logger == nil {
 		return nil, errOIDCLoggerRequired
+	}
+
+	if issuerURL.Scheme == schemeHTTP {
+		cfg.Logger.Warn("oidc: Dex issuer URL uses HTTP — ID token integrity depends on network trust; use HTTPS in production",
+			"issuer_url", cfg.OIDC.DexIssuerURL)
 	}
 
 	ttl := cfg.TokenTTL
@@ -555,10 +574,10 @@ func isAllowedRedirectURI(uri string) bool {
 	if err != nil {
 		return false
 	}
-	if parsed.Scheme == "https" {
+	if parsed.Scheme == schemeHTTPS {
 		return true
 	}
-	if parsed.Scheme == "http" {
+	if parsed.Scheme == schemeHTTP {
 		host := parsed.Hostname()
 		return host == "localhost" || host == "127.0.0.1" || host == "::1"
 	}

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -38,16 +38,18 @@ import (
 )
 
 var (
-	errOIDCDexIssuerRequired = errors.New("oidc handler: dex issuer URL is required")
-	errOIDCClientIDRequired  = errors.New("oidc handler: client ID is required")
-	errOIDCCallbackRequired  = errors.New("oidc handler: callback URL is required")
-	errOIDCSignerRequired    = errors.New("oidc handler: JWT signer is required")
-	errOIDCLoggerRequired    = errors.New("oidc handler: logger is required")
-	errDexTokenError         = errors.New("dex token error")
-	errDexBadStatus          = errors.New("dex token endpoint returned non-200 status")
-	errDexEmptyIDToken       = errors.New("dex returned empty id_token")
-	errInvalidJWTFormat      = errors.New("invalid JWT format")
-	errEmailClaimMissing     = errors.New("email claim missing from ID token")
+	errOIDCDexIssuerRequired  = errors.New("oidc handler: dex issuer URL is required")
+	errOIDCClientIDRequired   = errors.New("oidc handler: client ID is required")
+	errOIDCCallbackRequired   = errors.New("oidc handler: callback URL is required")
+	errOIDCStateStoreRequired = errors.New("oidc handler: state store is required")
+	errOIDCCodeStoreRequired  = errors.New("oidc handler: code store is required")
+	errOIDCSignerRequired     = errors.New("oidc handler: JWT signer is required")
+	errOIDCLoggerRequired     = errors.New("oidc handler: logger is required")
+	errDexTokenError          = errors.New("dex token error")
+	errDexBadStatus           = errors.New("dex token endpoint returned non-200 status")
+	errDexEmptyIDToken        = errors.New("dex returned empty id_token")
+	errInvalidJWTFormat       = errors.New("invalid JWT format")
+	errEmailClaimMissing      = errors.New("email claim missing from ID token")
 )
 
 const (
@@ -207,6 +209,12 @@ func NewOIDCHandler(cfg OIDCHandlerConfig) (*OIDCHandler, error) {
 	}
 	if cfg.OIDC.CallbackURL == "" {
 		return nil, errOIDCCallbackRequired
+	}
+	if cfg.StateStore == nil {
+		return nil, errOIDCStateStoreRequired
+	}
+	if cfg.CodeStore == nil {
+		return nil, errOIDCCodeStoreRequired
 	}
 	if cfg.Signer == nil {
 		return nil, errOIDCSignerRequired
@@ -410,8 +418,7 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	}, tokenStr)
 
 	h.logger.Info("oidc: authentication successful",
-		"tenant", flowState.TenantSlug,
-		"email", email)
+		"tenant", flowState.TenantSlug)
 
 	// Redirect to MCP client's redirect_uri with the authorization code.
 	target, err := url.Parse(flowState.MCPRedirectURI)

--- a/services/mcp-server/internal/auth/oidc_test.go
+++ b/services/mcp-server/internal/auth/oidc_test.go
@@ -257,6 +257,67 @@ func TestOIDCHandler_Authorize_MissingPKCE(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestOIDCHandler_Authorize_RejectsHTTPRedirect(t *testing.T) {
+	signer := newTestSigner(t)
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: "https://dex.example.com/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth:      auth.OAuthConfig{ClientID: "meridian-mcp"},
+		StateStore: newTestOIDCStateStore(t),
+		CodeStore:  newTestStore(t),
+		Signer:     signer,
+		Logger:     slog.Default(),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"meridian-mcp"},
+		"redirect_uri":          {"http://evil.example.com/steal"},
+		"code_challenge":        {"abc123"},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleAuthorize(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "redirect_uri must use https")
+}
+
+func TestOIDCHandler_Authorize_AllowsLocalhostHTTP(t *testing.T) {
+	dexSrv := fakeDexServer(t, "admin@acme.com")
+	signer := newTestSigner(t)
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth:      auth.OAuthConfig{ClientID: "meridian-mcp"},
+		StateStore: newTestOIDCStateStore(t),
+		CodeStore:  newTestStore(t),
+		Signer:     signer,
+		Logger:     slog.Default(),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"meridian-mcp"},
+		"redirect_uri":          {"http://localhost:3000/callback"},
+		"code_challenge":        {"abc123"},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleAuthorize(w, req)
+
+	// Should redirect to Dex (302), not reject
+	assert.Equal(t, http.StatusFound, w.Code)
+}
+
 // -----------------------------------------------------------------------
 // OIDCHandler — HandleCallback
 // -----------------------------------------------------------------------

--- a/services/mcp-server/internal/auth/oidc_test.go
+++ b/services/mcp-server/internal/auth/oidc_test.go
@@ -622,6 +622,24 @@ func TestNewOIDCHandler_MissingConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "missing state store",
+			cfg: auth.OIDCHandlerConfig{
+				OIDC:      auth.OIDCConfig{DexIssuerURL: "https://dex", ClientID: "c", CallbackURL: "https://x/cb"},
+				CodeStore: newTestStore(t),
+				Signer:    signer,
+				Logger:    slog.Default(),
+			},
+		},
+		{
+			name: "missing code store",
+			cfg: auth.OIDCHandlerConfig{
+				OIDC:       auth.OIDCConfig{DexIssuerURL: "https://dex", ClientID: "c", CallbackURL: "https://x/cb"},
+				StateStore: newTestOIDCStateStore(t),
+				Signer:     signer,
+				Logger:     slog.Default(),
+			},
+		},
+		{
 			name: "missing signer",
 			cfg: auth.OIDCHandlerConfig{
 				OIDC:       auth.OIDCConfig{DexIssuerURL: "https://dex", ClientID: "c", CallbackURL: "https://x/cb"},

--- a/services/mcp-server/internal/auth/oidc_test.go
+++ b/services/mcp-server/internal/auth/oidc_test.go
@@ -52,9 +52,30 @@ func fakeDexServer(t *testing.T, email string) *httptest.Server {
 		http.Redirect(w, r, target.String(), http.StatusFound)
 	})
 
-	// Simulate Dex token endpoint — return a fake ID token
-	mux.HandleFunc("/dex/token", func(w http.ResponseWriter, _ *http.Request) {
-		// Build a fake JWT with just the email claim (no signature validation needed)
+	// Simulate Dex token endpoint — return a fake ID token.
+	// Asserts required PKCE exchange fields to catch regressions in exchangeDexCode.
+	mux.HandleFunc("/dex/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+		// Assert required token exchange parameters.
+		for _, field := range []string{"grant_type", "code", "redirect_uri", "code_verifier", "client_id"} {
+			if r.PostForm.Get(field) == "" {
+				http.Error(w, "missing required field: "+field, http.StatusBadRequest)
+				return
+			}
+		}
+		if r.PostForm.Get("grant_type") != "authorization_code" {
+			http.Error(w, "wrong grant_type", http.StatusBadRequest)
+			return
+		}
+
+		// Build a fake JWT with just the email claim (no signature validation needed).
 		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
 		payload := base64.RawURLEncoding.EncodeToString([]byte(`{"email":"` + email + `","sub":"fake-sub"}`))
 		fakeJWT := header + "." + payload + ".fake-signature"

--- a/services/mcp-server/internal/auth/oidc_test.go
+++ b/services/mcp-server/internal/auth/oidc_test.go
@@ -1,0 +1,650 @@
+package auth_test
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/auth"
+	platformauth "github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestSigner creates a JWTSigner with an auto-generated dev key.
+func newTestSigner(t *testing.T) *platformauth.JWTSigner {
+	t.Helper()
+	signer, err := platformauth.NewJWTSigner(platformauth.JWTSignerConfig{})
+	require.NoError(t, err)
+	return signer
+}
+
+// newTestOIDCStateStore creates an OIDCStateStore and registers cleanup with t.
+func newTestOIDCStateStore(t *testing.T) *auth.OIDCStateStore {
+	t.Helper()
+	s := auth.NewOIDCStateStore()
+	t.Cleanup(s.Close)
+	return s
+}
+
+// fakeDexServer creates a test HTTP server that simulates Dex's token endpoint.
+// It returns a server that responds with a fake ID token containing the given email.
+func fakeDexServer(t *testing.T, email string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// Simulate Dex authorization endpoint — redirect immediately with a code
+	mux.HandleFunc("/dex/auth", func(w http.ResponseWriter, r *http.Request) {
+		redirectURI := r.URL.Query().Get("redirect_uri")
+		state := r.URL.Query().Get("state")
+		target, _ := url.Parse(redirectURI)
+		q := target.Query()
+		q.Set("code", "fake-dex-code")
+		q.Set("state", state)
+		target.RawQuery = q.Encode()
+		http.Redirect(w, r, target.String(), http.StatusFound)
+	})
+
+	// Simulate Dex token endpoint — return a fake ID token
+	mux.HandleFunc("/dex/token", func(w http.ResponseWriter, _ *http.Request) {
+		// Build a fake JWT with just the email claim (no signature validation needed)
+		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+		payload := base64.RawURLEncoding.EncodeToString([]byte(`{"email":"` + email + `","sub":"fake-sub"}`))
+		fakeJWT := header + "." + payload + ".fake-signature"
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id_token":     fakeJWT,
+			"access_token": "fake-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// -----------------------------------------------------------------------
+// OIDCStateStore
+// -----------------------------------------------------------------------
+
+func TestOIDCStateStore_StoreAndConsume(t *testing.T) {
+	store := newTestOIDCStateStore(t)
+
+	entry := auth.OIDCFlowState{
+		MCPCodeChallenge: "test-challenge",
+		MCPClientID:      "meridian-mcp",
+		MCPRedirectURI:   "https://claude.ai/callback",
+		MCPState:         "client-state",
+		DexCodeVerifier:  "dex-verifier",
+		TenantSlug:       "acme",
+		IssuedAt:         time.Now(),
+	}
+
+	key, err := store.Store(entry)
+	require.NoError(t, err)
+	require.NotEmpty(t, key)
+
+	consumed, ok := store.Consume(key)
+	require.True(t, ok)
+	assert.Equal(t, "test-challenge", consumed.MCPCodeChallenge)
+	assert.Equal(t, "meridian-mcp", consumed.MCPClientID)
+	assert.Equal(t, "acme", consumed.TenantSlug)
+
+	// Second consume should fail (one-time use)
+	_, ok2 := store.Consume(key)
+	assert.False(t, ok2)
+}
+
+func TestOIDCStateStore_ExpiredEntry(t *testing.T) {
+	store := newTestOIDCStateStore(t)
+
+	entry := auth.OIDCFlowState{
+		MCPCodeChallenge: "expired-challenge",
+		MCPClientID:      "meridian-mcp",
+		IssuedAt:         time.Now().Add(-11 * time.Minute), // expired
+	}
+
+	key, err := store.Store(entry)
+	require.NoError(t, err)
+
+	_, ok := store.Consume(key)
+	assert.False(t, ok, "expired entry must not be consumable")
+}
+
+func TestOIDCStateStore_UnknownKey(t *testing.T) {
+	store := newTestOIDCStateStore(t)
+
+	_, ok := store.Consume("nonexistent-key")
+	assert.False(t, ok)
+}
+
+// -----------------------------------------------------------------------
+// OIDCHandler — HandleAuthorize
+// -----------------------------------------------------------------------
+
+func TestOIDCHandler_Authorize_RedirectsToDex(t *testing.T) {
+	dexSrv := fakeDexServer(t, "user@example.com")
+	signer := newTestSigner(t)
+	codeStore := newTestStore(t)
+	stateStore := newTestOIDCStateStore(t)
+
+	oauthCfg := auth.OAuthConfig{
+		ClientID:         "meridian-mcp",
+		AuthorizationURL: "https://demo.meridianhub.cloud/oauth/authorize",
+		TokenURL:         "https://demo.meridianhub.cloud/oauth/token",
+	}
+
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth:      oauthCfg,
+		StateStore: stateStore,
+		CodeStore:  codeStore,
+		Signer:     signer,
+		BaseDomain: "demo.meridianhub.cloud",
+		Logger:     slog.Default(),
+	})
+	require.NoError(t, err)
+
+	_, challenge := generatePKCEPair(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"meridian-mcp"},
+		"redirect_uri":          {"https://claude.ai/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"client-state-123"},
+	}.Encode(), nil)
+	req.Host = "acme.demo.meridianhub.cloud"
+	w := httptest.NewRecorder()
+	handler.HandleAuthorize(w, req)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+
+	location := resp.Header.Get("Location")
+	require.NotEmpty(t, location)
+
+	redirectURL, err := url.Parse(location)
+	require.NoError(t, err)
+
+	// Should redirect to Dex auth endpoint
+	assert.Contains(t, redirectURL.Path, "/dex/auth")
+	assert.Equal(t, "meridian-service", redirectURL.Query().Get("client_id"))
+	assert.Equal(t, "code", redirectURL.Query().Get("response_type"))
+	assert.Equal(t, "S256", redirectURL.Query().Get("code_challenge_method"))
+	assert.NotEmpty(t, redirectURL.Query().Get("state"))
+	assert.NotEmpty(t, redirectURL.Query().Get("code_challenge"))
+}
+
+func TestOIDCHandler_Authorize_InvalidClientID(t *testing.T) {
+	dexSrv := fakeDexServer(t, "user@example.com")
+	signer := newTestSigner(t)
+
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID: "meridian-mcp",
+		},
+		StateStore: newTestOIDCStateStore(t),
+		CodeStore:  newTestStore(t),
+		Signer:     signer,
+		Logger:     slog.Default(),
+	})
+	require.NoError(t, err)
+
+	_, challenge := generatePKCEPair(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"wrong-client"},
+		"redirect_uri":          {"https://claude.ai/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleAuthorize(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestOIDCHandler_Authorize_MissingPKCE(t *testing.T) {
+	dexSrv := fakeDexServer(t, "user@example.com")
+	signer := newTestSigner(t)
+
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID: "meridian-mcp",
+		},
+		StateStore: newTestOIDCStateStore(t),
+		CodeStore:  newTestStore(t),
+		Signer:     signer,
+		Logger:     slog.Default(),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type": {"code"},
+		"client_id":     {"meridian-mcp"},
+		"redirect_uri":  {"https://claude.ai/callback"},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleAuthorize(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// -----------------------------------------------------------------------
+// OIDCHandler — HandleCallback
+// -----------------------------------------------------------------------
+
+func TestOIDCHandler_Callback_ExchangesAndRedirects(t *testing.T) {
+	dexSrv := fakeDexServer(t, "admin@acme.com")
+	signer := newTestSigner(t)
+	codeStore := newTestStore(t)
+	stateStore := newTestOIDCStateStore(t)
+
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID: "meridian-mcp",
+		},
+		StateStore: stateStore,
+		CodeStore:  codeStore,
+		Signer:     signer,
+		BaseDomain: "demo.meridianhub.cloud",
+		Logger:     slog.Default(),
+	})
+	require.NoError(t, err)
+
+	_, challenge := generatePKCEPair(t)
+
+	// Pre-store OIDC flow state (simulates what HandleAuthorize would do)
+	stateKey, err := stateStore.Store(auth.OIDCFlowState{
+		MCPCodeChallenge: challenge,
+		MCPClientID:      "meridian-mcp",
+		MCPRedirectURI:   "https://claude.ai/callback",
+		MCPState:         "client-state-456",
+		DexCodeVerifier:  "test-verifier",
+		TenantSlug:       "acme",
+		IssuedAt:         time.Now(),
+	})
+	require.NoError(t, err)
+
+	// Simulate Dex callback
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?"+url.Values{
+		"code":  {"fake-dex-code"},
+		"state": {stateKey},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleCallback(w, req)
+
+	resp := w.Result()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	location := resp.Header.Get("Location")
+	require.NotEmpty(t, location)
+
+	redirectURL, err := url.Parse(location)
+	require.NoError(t, err)
+
+	// Should redirect to Claude's callback with auth code
+	assert.Equal(t, "claude.ai", redirectURL.Host)
+	assert.Equal(t, "/callback", redirectURL.Path)
+	assert.NotEmpty(t, redirectURL.Query().Get("code"), "must include authorization code")
+	assert.Equal(t, "client-state-456", redirectURL.Query().Get("state"))
+
+	// The auth code should be consumable from the code store
+	mcpCode := redirectURL.Query().Get("code")
+	entry, ok := codeStore.Consume(mcpCode)
+	require.True(t, ok)
+	assert.Equal(t, challenge, entry.CodeChallenge)
+	assert.Equal(t, "meridian-mcp", entry.ClientID)
+	assert.NotEmpty(t, entry.Token, "must have pre-signed JWT")
+
+	// Validate the JWT
+	validator, err := platformauth.NewJWTValidator(signer.PublicKey())
+	require.NoError(t, err)
+	claims, err := validator.ValidateToken(entry.Token)
+	require.NoError(t, err)
+	assert.Equal(t, "admin@acme.com", claims.Email)
+	assert.Equal(t, "acme", claims.TenantID)
+}
+
+func TestOIDCHandler_Callback_InvalidState(t *testing.T) {
+	dexSrv := fakeDexServer(t, "user@example.com")
+	signer := newTestSigner(t)
+
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID: "meridian-mcp",
+		},
+		StateStore: newTestOIDCStateStore(t),
+		CodeStore:  newTestStore(t),
+		Signer:     signer,
+		Logger:     slog.Default(),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?"+url.Values{
+		"code":  {"fake-dex-code"},
+		"state": {"invalid-state-key"},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleCallback(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestOIDCHandler_Callback_DexError(t *testing.T) {
+	dexSrv := fakeDexServer(t, "user@example.com")
+	signer := newTestSigner(t)
+
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID: "meridian-mcp",
+		},
+		StateStore: newTestOIDCStateStore(t),
+		CodeStore:  newTestStore(t),
+		Signer:     signer,
+		Logger:     slog.Default(),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?"+url.Values{
+		"error":             {"access_denied"},
+		"error_description": {"user cancelled"},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleCallback(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// -----------------------------------------------------------------------
+// End-to-end: Authorize → Callback → Token Exchange
+// -----------------------------------------------------------------------
+
+func TestOIDCFlow_EndToEnd(t *testing.T) {
+	dexSrv := fakeDexServer(t, "operator@acme.com")
+	signer := newTestSigner(t)
+	codeStore := newTestStore(t)
+	stateStore := newTestOIDCStateStore(t)
+
+	oauthCfg := auth.OAuthConfig{
+		ClientID:         "meridian-mcp",
+		AuthorizationURL: "https://demo.meridianhub.cloud/oauth/authorize",
+		TokenURL:         "https://demo.meridianhub.cloud/oauth/token",
+	}
+
+	oidcHandler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth:      oauthCfg,
+		StateStore: stateStore,
+		CodeStore:  codeStore,
+		Signer:     signer,
+		BaseDomain: "demo.meridianhub.cloud",
+		Logger:     slog.Default(),
+	})
+	require.NoError(t, err)
+
+	tokenHandler := auth.NewTokenHandler(oauthCfg, codeStore, &fakeTokenIssuer{token: "fallback"})
+
+	verifier, challenge := generatePKCEPair(t)
+
+	// Step 1: Authorize — get redirect to Dex
+	authReq := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"meridian-mcp"},
+		"redirect_uri":          {"https://claude.ai/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"e2e-state"},
+	}.Encode(), nil)
+	authReq.Host = "acme.demo.meridianhub.cloud"
+	authW := httptest.NewRecorder()
+	oidcHandler.HandleAuthorize(authW, authReq)
+	require.Equal(t, http.StatusFound, authW.Code)
+
+	// Extract state from Dex redirect
+	dexRedirect, err := url.Parse(authW.Header().Get("Location"))
+	require.NoError(t, err)
+	internalState := dexRedirect.Query().Get("state")
+	require.NotEmpty(t, internalState)
+
+	// Step 2: Callback — simulate Dex returning with code
+	cbReq := httptest.NewRequest(http.MethodGet, "/oauth/callback?"+url.Values{
+		"code":  {"fake-dex-code"},
+		"state": {internalState},
+	}.Encode(), nil)
+	cbW := httptest.NewRecorder()
+	oidcHandler.HandleCallback(cbW, cbReq)
+	require.Equal(t, http.StatusFound, cbW.Code)
+
+	// Extract auth code from redirect to Claude
+	claudeRedirect, err := url.Parse(cbW.Header().Get("Location"))
+	require.NoError(t, err)
+	mcpCode := claudeRedirect.Query().Get("code")
+	require.NotEmpty(t, mcpCode)
+	assert.Equal(t, "e2e-state", claudeRedirect.Query().Get("state"))
+
+	// Step 3: Token exchange — exchange code for JWT
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {mcpCode},
+		"client_id":     {"meridian-mcp"},
+		"code_verifier": {verifier},
+	}
+	tokenReq := httptest.NewRequest(http.MethodPost, "/oauth/token",
+		strings.NewReader(form.Encode()))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenW := httptest.NewRecorder()
+	tokenHandler.ServeHTTP(tokenW, tokenReq)
+	require.Equal(t, http.StatusOK, tokenW.Code)
+
+	var tokenResp map[string]any
+	require.NoError(t, json.Unmarshal(tokenW.Body.Bytes(), &tokenResp))
+	assert.Equal(t, "Bearer", tokenResp["token_type"])
+
+	accessToken, ok := tokenResp["access_token"].(string)
+	require.True(t, ok)
+	assert.NotEqual(t, "fallback", accessToken, "must use pre-signed JWT, not fallback issuer")
+
+	// Validate the JWT
+	validator, err := platformauth.NewJWTValidator(signer.PublicKey())
+	require.NoError(t, err)
+	claims, err := validator.ValidateToken(accessToken)
+	require.NoError(t, err)
+	assert.Equal(t, "operator@acme.com", claims.Email)
+	assert.Equal(t, "acme", claims.TenantID)
+}
+
+// -----------------------------------------------------------------------
+// CodeStore with pre-signed token
+// -----------------------------------------------------------------------
+
+func TestCodeStore_StoreWithToken(t *testing.T) {
+	store := newTestStore(t)
+
+	_, challenge := generatePKCEPair(t)
+	store.StoreWithToken("code-with-token", auth.CodeEntry{
+		CodeChallenge: challenge,
+		ClientID:      "meridian-mcp",
+		RedirectURI:   "https://claude.ai/callback",
+		IssuedAt:      time.Now(),
+	}, "pre-signed-jwt-token")
+
+	entry, ok := store.Consume("code-with-token")
+	require.True(t, ok)
+	assert.Equal(t, "pre-signed-jwt-token", entry.Token)
+	assert.Equal(t, challenge, entry.CodeChallenge)
+}
+
+func TestCodeStore_StoreWithoutToken_HasEmptyToken(t *testing.T) {
+	store := newTestStore(t)
+
+	_, challenge := generatePKCEPair(t)
+	store.Store("code-no-token", auth.CodeEntry{
+		CodeChallenge: challenge,
+		ClientID:      "meridian-mcp",
+		RedirectURI:   "https://claude.ai/callback",
+		IssuedAt:      time.Now(),
+	})
+
+	entry, ok := store.Consume("code-no-token")
+	require.True(t, ok)
+	assert.Empty(t, entry.Token)
+}
+
+func TestTokenHandler_UsesPreSignedToken(t *testing.T) {
+	store := newTestStore(t)
+	cfg := auth.OAuthConfig{
+		ClientID:    "meridian-mcp",
+		RedirectURI: "http://localhost:8090/oauth/callback",
+	}
+
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	h := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(h[:])
+
+	preSignedJWT := "eyJhbGciOiJSUzI1NiJ9.eyJlbWFpbCI6InVzZXJAZXhhbXBsZS5jb20ifQ.signature"
+
+	store.StoreWithToken("code-presigned", auth.CodeEntry{
+		CodeChallenge: challenge,
+		ClientID:      cfg.ClientID,
+		RedirectURI:   cfg.RedirectURI,
+		IssuedAt:      time.Now(),
+	}, preSignedJWT)
+
+	// The issuer should NOT be called when a pre-signed token exists
+	issuer := &fakeTokenIssuer{token: "should-not-be-used"}
+	handler := auth.NewTokenHandler(cfg, store, issuer)
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {"code-presigned"},
+		"client_id":     {cfg.ClientID},
+		"code_verifier": {verifier},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, preSignedJWT, resp["access_token"], "must return pre-signed JWT, not issuer token")
+}
+
+// -----------------------------------------------------------------------
+// OIDCHandler — validation
+// -----------------------------------------------------------------------
+
+func TestNewOIDCHandler_MissingConfig(t *testing.T) {
+	signer := newTestSigner(t)
+
+	tests := []struct {
+		name string
+		cfg  auth.OIDCHandlerConfig
+	}{
+		{
+			name: "missing dex issuer",
+			cfg: auth.OIDCHandlerConfig{
+				OIDC:       auth.OIDCConfig{ClientID: "c", CallbackURL: "https://x/cb"},
+				CodeStore:  newTestStore(t),
+				StateStore: newTestOIDCStateStore(t),
+				Signer:     signer,
+				Logger:     slog.Default(),
+			},
+		},
+		{
+			name: "missing client ID",
+			cfg: auth.OIDCHandlerConfig{
+				OIDC:       auth.OIDCConfig{DexIssuerURL: "https://dex", CallbackURL: "https://x/cb"},
+				CodeStore:  newTestStore(t),
+				StateStore: newTestOIDCStateStore(t),
+				Signer:     signer,
+				Logger:     slog.Default(),
+			},
+		},
+		{
+			name: "missing callback URL",
+			cfg: auth.OIDCHandlerConfig{
+				OIDC:       auth.OIDCConfig{DexIssuerURL: "https://dex", ClientID: "c"},
+				CodeStore:  newTestStore(t),
+				StateStore: newTestOIDCStateStore(t),
+				Signer:     signer,
+				Logger:     slog.Default(),
+			},
+		},
+		{
+			name: "missing signer",
+			cfg: auth.OIDCHandlerConfig{
+				OIDC:       auth.OIDCConfig{DexIssuerURL: "https://dex", ClientID: "c", CallbackURL: "https://x/cb"},
+				CodeStore:  newTestStore(t),
+				StateStore: newTestOIDCStateStore(t),
+				Logger:     slog.Default(),
+			},
+		},
+		{
+			name: "missing logger",
+			cfg: auth.OIDCHandlerConfig{
+				OIDC:       auth.OIDCConfig{DexIssuerURL: "https://dex", ClientID: "c", CallbackURL: "https://x/cb"},
+				CodeStore:  newTestStore(t),
+				StateStore: newTestOIDCStateStore(t),
+				Signer:     signer,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := auth.NewOIDCHandler(tt.cfg)
+			assert.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Implement OAuth 2.1 authorization code flow with PKCE for the MCP server, delegating identity verification to Dex OIDC
- MCP-issued JWTs use shared `JWT_SIGNING_KEY` with BFF for cross-subdomain session interoperability
- Pre-signed JWT pattern: OIDC callback signs token at auth time, TokenHandler returns it directly (no second signing step)

## Architecture

```
MCP Client (Claude.ai)
  → GET /oauth/authorize (MCP PKCE)
    → Redirect to Dex /auth (Dex PKCE)
      → User authenticates (Google, GitHub, etc.)
    → GET /oauth/callback (Dex code exchange → email → Meridian JWT)
  → POST /oauth/token (MCP code exchange → pre-signed JWT)
```

Two-layer PKCE: MCP client's PKCE protects the MCP auth code, MCP server's PKCE protects the Dex auth code. `OIDCFlowState` bridges both flows.

## Changes

- **`services/mcp-server/internal/auth/oidc.go`** — `OIDCHandler` (authorize + callback), `OIDCStateStore` (in-memory state with TTL + eviction)
- **`services/mcp-server/internal/auth/oauth.go`** — `StoreWithToken` for pre-signed JWT storage, `TokenHandler` returns pre-signed token when available
- **`services/mcp-server/cmd/main.go`** — Wire OIDC handler when `MCP_DEX_ISSUER_URL` is set, fall back to direct authorize for dev/CI
- **`deploy/demo/`** — Caddyfile routes `/oauth/*` to MCP server, Dex static client includes MCP callback URI, docker-compose adds OAuth env vars

## Test plan

- [x] 48 unit tests covering full OIDC flow, state store TTL/eviction, pre-signed token pattern, error paths
- [ ] Enable on demo: set `MCP_OAUTH_ENABLED=true` + Dex/JWT env vars in `/opt/meridian/.env`
- [ ] Verify Claude.ai MCP connection triggers OAuth flow and receives valid JWT
- [ ] Verify UI-issued BFF tokens are accepted by MCP bearer validation