### PR TITLE
fix: Resolve economy page UI issues

### DIFF
--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -108,8 +108,14 @@ function getUserLens(claims: JWTClaims | null): 'platform' | 'tenant' {
     claims.roles.includes('platform-admin') || claims.roles.includes('super-admin')
   if (isPlatformLevel) return 'platform'
   // In demo mode, standard OIDC tokens lack tenant and role claims.
-  // Default to 'platform' lens so DevTenantAutoSelector picks a tenant automatically.
-  if (import.meta.env.VITE_DEMO_MODE === 'true') return 'platform'
+  // Default to 'platform' lens only on the root domain so
+  // DevTenantAutoSelector can pick a tenant. On a tenant subdomain the
+  // user is implicitly scoped to that tenant and should see tenant lens
+  // (no tenant selector dropdown).
+  if (import.meta.env.VITE_DEMO_MODE === 'true') {
+    const slug = getTenantSlugFromSubdomain(window.location.hostname)
+    if (!slug) return 'platform'
+  }
   return 'tenant'
 }
 

--- a/frontend/src/contexts/tenant-context.tsx
+++ b/frontend/src/contexts/tenant-context.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '@/contexts/auth-context'
 import { DEFAULT_UI_CONFIG, type TenantThemeConfig, type TenantUIConfig } from '@/lib/tenant-ui-config'
 import { applyTenantTheme, resetTheme } from '@/lib/theme-utils'
+import { getTenantSlugFromSubdomain } from '@/lib/tenant-utils'
 
 export interface Tenant {
   id: string
@@ -73,8 +74,11 @@ export function TenantProvider({ children }: { children: ReactNode }) {
     setTenantTheme(theme)
   }, [])
 
-  // For tenant admins, tenant slug is fixed from JWT claims
-  const tenantSlug = isPlatformAdmin ? selectedTenant?.slug ?? null : claims?.tenantId ?? null
+  // For tenant users, slug comes from JWT claims or falls back to the current
+  // subdomain (needed in demo mode where OIDC tokens lack tenantId).
+  const tenantSlug = isPlatformAdmin
+    ? selectedTenant?.slug ?? null
+    : claims?.tenantId ?? getTenantSlugFromSubdomain(window.location.hostname)
 
   const value: TenantContextValue = {
     currentTenant: isPlatformAdmin ? selectedTenant : null,

--- a/frontend/src/features/economy/pages/economy-overview-page.tsx
+++ b/frontend/src/features/economy/pages/economy-overview-page.tsx
@@ -146,9 +146,9 @@ export function EconomyOverviewPage() {
 
       {/* Stats - compact inline bar */}
       <div className="flex flex-wrap gap-3" data-testid="stats-bar">
-        <StatChip label="Instruments" value={instruments.length} testId="stat-instruments" onClick={scrollToGraph} />
-        <StatChip label="Account Types" value={accountTypes.length} testId="stat-account-types" onClick={scrollToGraph} />
-        <StatChip label="Sagas" value={sagas.length} testId="stat-sagas" onClick={scrollToGraph} />
+        <StatChip label="Instruments" value={instruments.length} testId="stat-instruments" onClick={() => navigate('/reference-data/instruments')} />
+        <StatChip label="Account Types" value={accountTypes.length} testId="stat-account-types" onClick={() => navigate('/reference-data/account-types')} />
+        <StatChip label="Sagas" value={sagas.length} testId="stat-sagas" onClick={() => navigate('/starlark-config')} />
         <StatChip label="Valuation Rules" value={valuationRules.length} testId="stat-valuation-rules" onClick={scrollToGraph} />
       </div>
 

--- a/frontend/src/features/manifests/components/manifest-graph.test.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.test.tsx
@@ -281,7 +281,7 @@ describe('ManifestGraph', () => {
       renderGraph(energyManifest)
       const node = await screen.findByTestId('node-saga:usage_to_value')
       fireEvent.doubleClick(node)
-      expect(mockNavigate).toHaveBeenCalledWith('/sagas/usage_to_value')
+      expect(mockNavigate).toHaveBeenCalledWith('/starlark-config/usage_to_value')
     })
   })
 

--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -453,7 +453,7 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
           navigate('/reference-data/account-types')
           break
         case 'saga':
-          navigate(`/sagas/${mn.label}`)
+          navigate(`/starlark-config/${mn.label}`)
           break
       }
     },
@@ -517,6 +517,7 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
           onNodeMouseLeave={onNodeMouseLeave}
           nodeTypes={nodeTypes}
           fitView
+          fitViewOptions={{ padding: 0.3 }}
           proOptions={{ hideAttribution: true }}
         >
           <Controls />
@@ -618,7 +619,7 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
             <EventChainPanel
               chain={eventChain}
               startNodeLabel={selectedManifestNode.label}
-              onSagaClick={(sagaId) => navigate(`/sagas/${sagaId.replace(/^saga:/, '')}`)}
+              onSagaClick={(sagaId) => navigate(`/starlark-config/${sagaId.replace(/^saga:/, '')}`)}
             />
           </div>
         </div>

--- a/frontend/src/lib/visualization/star-parser.test.ts
+++ b/frontend/src/lib/visualization/star-parser.test.ts
@@ -241,8 +241,8 @@ position_keeping.initiate_log(account_id=aid)
       expect(result.name).toBe('stripe_payment_received')
       // No trigger/filter headers in this file
       expect(result.steps.length).toBe(2)
-      expect(result.steps[0].name).toBe('debit_stripe_nostro')
-      expect(result.steps[1].name).toBe('credit_customer_prepaid')
+      expect(result.steps[0].name).toBe('debit_clearing')
+      expect(result.steps[1].name).toBe('credit_customer')
 
       // Both steps call position_keeping.initiate_log
       expect(result.steps[0].serviceCalls[0].service).toBe('position_keeping')
@@ -495,8 +495,8 @@ account = reference_data.get_account(id=aid)
 
       // Two position_keeping.initiate_log calls
       expect(result.producedEvents).toHaveLength(2)
-      expect(result.producedEvents[0].stepName).toBe('debit_stripe_nostro')
-      expect(result.producedEvents[1].stepName).toBe('credit_customer_prepaid')
+      expect(result.producedEvents[0].stepName).toBe('debit_clearing')
+      expect(result.producedEvents[1].stepName).toBe('credit_customer')
 
       // No valuation calls
       expect(result.valuationCalls).toHaveLength(0)


### PR DESCRIPTION
## Summary

- Fix saga navigation 404 from economy graph: navigates to `/starlark-config/:id` instead of non-existent `/sagas/:id` route
- Make stat chips (Instruments, Account Types, Sagas) navigate to their respective pages instead of only scrolling to the graph
- Add `fitView` padding (0.3) to prevent graph nodes from overlapping the Element Types filter panel on initial render
- Fix tenant selector dropdown showing for non-admin users in demo mode: on tenant subdomains, users now get tenant lens (no dropdown) with subdomain-based tenant slug fallback when OIDC tokens lack `tenantId` claim

## Test plan

- [ ] Navigate to `/economy` on demo, click a saga node in the graph -- should open `/starlark-config/:id` (no more 404)
- [ ] Click stat chips (Instruments, Account Types, Sagas) -- should navigate to respective pages
- [ ] Verify graph nodes don't overlap the Element Types filter on initial load
- [ ] Log in on a tenant subdomain (e.g. `volterra-energy.demo.meridianhub.cloud`) -- tenant selector dropdown should not appear
- [ ] Log in on root domain (`demo.meridianhub.cloud`) -- tenant selector should appear for admin users, auto-select first tenant
- [ ] Run `npx vitest run` in `frontend/` -- affected tests pass (manifest-graph, economy-overview, auth-context, tenant-context)