### PR TITLE
fix: Handle escaped newlines in PEM keys from env vars

### DIFF
--- a/shared/platform/auth/jwt_signer.go
+++ b/shared/platform/auth/jwt_signer.go
@@ -171,6 +171,7 @@ func (s *JWTSigner) ServeJWKS() http.HandlerFunc {
 // Handles escaped newlines (literal \n) commonly found in environment variables
 // where multiline values are not supported (e.g., docker-compose .env files).
 func parseRSAPrivateKey(pemStr string) (*rsa.PrivateKey, error) {
+	pemStr = strings.ReplaceAll(pemStr, `\r\n`, "\n")
 	pemStr = strings.ReplaceAll(pemStr, `\n`, "\n")
 	block, _ := pem.Decode([]byte(pemStr))
 	if block == nil {

--- a/shared/platform/auth/jwt_signer.go
+++ b/shared/platform/auth/jwt_signer.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -167,7 +168,10 @@ func (s *JWTSigner) ServeJWKS() http.HandlerFunc {
 
 // parseRSAPrivateKey decodes a PEM-encoded RSA private key.
 // Supports both PKCS#1 and PKCS#8 formats.
+// Handles escaped newlines (literal \n) commonly found in environment variables
+// where multiline values are not supported (e.g., docker-compose .env files).
 func parseRSAPrivateKey(pemStr string) (*rsa.PrivateKey, error) {
+	pemStr = strings.ReplaceAll(pemStr, `\n`, "\n")
 	block, _ := pem.Decode([]byte(pemStr))
 	if block == nil {
 		return nil, ErrInvalidPEM

--- a/shared/platform/auth/jwt_signer_test.go
+++ b/shared/platform/auth/jwt_signer_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -170,6 +171,26 @@ func TestJWTSigner_RoundTripWithJWKS(t *testing.T) {
 	assert.Equal(t, "admin@acme.com", parsed.Email)
 	assert.Equal(t, "acme", parsed.TenantID)
 	assert.Equal(t, []string{"platform-admin", "super-admin"}, parsed.Roles)
+}
+
+func TestNewJWTSigner_EscapedNewlinePEM(t *testing.T) {
+	// Simulate environment variable injection where real newlines
+	// are replaced with literal \n (e.g., docker-compose .env files).
+	pemKey := generateTestPEM(t)
+	escapedPEM := strings.ReplaceAll(pemKey, "\n", `\n`)
+
+	signer, err := auth.NewJWTSigner(auth.JWTSignerConfig{
+		PrivateKeyPEM: escapedPEM,
+		KeyID:         "escaped-key",
+	})
+	require.NoError(t, err)
+
+	// Verify the signer works end-to-end.
+	tokenStr, err := signer.SignClaims(map[string]interface{}{
+		"sub": "user-escaped",
+	}, time.Hour)
+	require.NoError(t, err)
+	assert.NotEmpty(t, tokenStr)
 }
 
 func generateTestPEM(t *testing.T) string {


### PR DESCRIPTION
## Summary

- Docker-compose `.env` files don't support multiline values, so PEM private keys must be stored with literal `\n` characters
- `parseRSAPrivateKey` now replaces `\n` literals with real newlines before PEM decoding
- Supports both raw PEM format and escaped-newline format transparently

## Context

Required for MCP OAuth 2.1 deployment where `JWT_SIGNING_KEY` is passed via docker-compose `.env` file. Without this fix, the PEM decoder fails with "failed to decode PEM block".

## Test plan

- [x] Existing `shared/platform/auth` tests pass
- [ ] Deploy to demo with escaped-newline PEM key in `.env`