### PR TITLE
docs: Add MCP OAuth 2.1 deployment configuration

### DIFF
--- a/deploy/demo/.env.demo.example
+++ b/deploy/demo/.env.demo.example
@@ -176,6 +176,42 @@ MCP_BASE_URL=https://demo.meridianhub.cloud
 # Must match an entry in API_KEYS above (format: "key:identity").
 MERIDIAN_API_KEY=changeme
 
+# [OPTIONAL] Enable OAuth 2.1 for MCP clients (Claude.ai, etc.).
+# When true, MCP clients must complete an OAuth flow to get a JWT.
+MCP_OAUTH_ENABLED=false
+
+# [OPTIONAL] OAuth client ID that MCP clients use to authenticate.
+#MCP_OAUTH_CLIENT_ID=meridian-mcp
+
+# [OPTIONAL] Base domain for subdomain-based tenant resolution on MCP requests.
+#MCP_BASE_DOMAIN=demo.meridianhub.cloud
+
+# [OPTIONAL — required when MCP_OAUTH_ENABLED=true] Dex OIDC issuer URL (internal).
+# The MCP server acts as an OIDC client of Dex for delegated authentication.
+#MCP_DEX_ISSUER_URL=http://dex:5556/dex
+
+# [OPTIONAL] Dex static client ID for the MCP server's OIDC integration.
+#MCP_DEX_CLIENT_ID=meridian-service
+
+# [OPTIONAL] MCP server's OIDC callback URL (must be registered in dex.yaml).
+#MCP_DEX_CALLBACK_URL=https://demo.meridianhub.cloud/oauth/callback
+
+# [OPTIONAL] JWKS URL for validating bearer tokens on MCP requests.
+# Points to the BFF's JWKS endpoint so BFF-issued tokens are accepted.
+#MCP_JWKS_URL=https://demo.meridianhub.cloud/api/auth/jwks
+
+# [OPTIONAL — required when MCP_OAUTH_ENABLED=true] RSA private key for JWT signing.
+# Must be the same key used by the BFF for cross-subdomain session sharing.
+# Store as a single line with literal \n for newlines (docker-compose .env limitation).
+# Generate: openssl genrsa 2048 | awk '{printf "%s\\n", $0}'
+#JWT_SIGNING_KEY=-----BEGIN PRIVATE KEY-----\nMIIEv...base64...==\n-----END PRIVATE KEY-----
+
+# [OPTIONAL] Key ID for the JWT signing key (must match JWKS).
+#JWT_SIGNING_KEY_ID=meridian-1
+
+# [OPTIONAL] JWT issuer claim.
+#JWT_SIGNING_ISSUER=meridian
+
 # ---------------------------------------------------------------------------
 # Frontend
 # ---------------------------------------------------------------------------

--- a/deploy/demo/.env.demo.example
+++ b/deploy/demo/.env.demo.example
@@ -186,24 +186,26 @@ MCP_OAUTH_ENABLED=false
 # [OPTIONAL] Base domain for subdomain-based tenant resolution on MCP requests.
 #MCP_BASE_DOMAIN=demo.meridianhub.cloud
 
-# [OPTIONAL — required when MCP_OAUTH_ENABLED=true] Dex OIDC issuer URL (internal).
+# [REQUIRED when MCP_OAUTH_ENABLED=true] Dex OIDC issuer URL (internal).
 # The MCP server acts as an OIDC client of Dex for delegated authentication.
 #MCP_DEX_ISSUER_URL=http://dex:5556/dex
 
 # [OPTIONAL] Dex static client ID for the MCP server's OIDC integration.
 #MCP_DEX_CLIENT_ID=meridian-service
 
-# [OPTIONAL] MCP server's OIDC callback URL (must be registered in dex.yaml).
+# [REQUIRED when MCP_OAUTH_ENABLED=true] MCP server's OIDC callback URL (must be registered in dex.yaml).
 #MCP_DEX_CALLBACK_URL=https://demo.meridianhub.cloud/oauth/callback
 
-# [OPTIONAL] JWKS URL for validating bearer tokens on MCP requests.
+# [REQUIRED when MCP_OAUTH_ENABLED=true] JWKS URL for validating bearer tokens on MCP requests.
 # Points to the BFF's JWKS endpoint so BFF-issued tokens are accepted.
 #MCP_JWKS_URL=https://demo.meridianhub.cloud/api/auth/jwks
 
-# [OPTIONAL — required when MCP_OAUTH_ENABLED=true] RSA private key for JWT signing.
+# [REQUIRED when MCP_OAUTH_ENABLED=true] RSA private key for JWT signing.
 # Must be the same key used by the BFF for cross-subdomain session sharing.
 # Store as a single line with literal \n for newlines (docker-compose .env limitation).
 # Generate: openssl genrsa 2048 | awk '{printf "%s\\n", $0}'
+# NOTE: The Meridian binary must include the escaped-newline PEM fix
+# (strings.ReplaceAll for \n literals) for this format to work.
 #JWT_SIGNING_KEY=-----BEGIN PRIVATE KEY-----\nMIIEv...base64...==\n-----END PRIVATE KEY-----
 
 # [OPTIONAL] Key ID for the JWT signing key (must match JWKS).


### PR DESCRIPTION
## Summary

- Add all MCP OAuth 2.1 env vars to `.env.demo.example` with descriptions
- Document PEM key format for docker-compose `.env` (single-line with escaped newlines)
- Include key generation command: `openssl genrsa 2048 | awk '{printf "%s\\n", $0}'`

## Deployment Steps for MCP OAuth

1. **Merge PR #1637** (PEM escaped newlines fix) — required for `.env` key format
2. **Generate RSA key**: `openssl genrsa 2048 | awk '{printf "%s\\n", $0}'`
3. **Add to `/opt/meridian/.env`**:
   ```
   MCP_OAUTH_ENABLED=true
   MCP_OAUTH_CLIENT_ID=meridian-mcp
   MCP_BASE_DOMAIN=demo.meridianhub.cloud
   MCP_DEX_ISSUER_URL=http://dex:5556/dex
   MCP_DEX_CLIENT_ID=meridian-service
   MCP_DEX_CALLBACK_URL=https://demo.meridianhub.cloud/oauth/callback
   MCP_JWKS_URL=https://demo.meridianhub.cloud/api/auth/jwks
   JWT_SIGNING_KEY=<generated-key-single-line>
   JWT_SIGNING_KEY_ID=meridian-1
   JWT_SIGNING_ISSUER=meridian
   ```
4. **Restart**: `docker compose up -d --force-recreate meridian mcp-server`
5. **Verify**: `docker logs meridian-mcp-server-1 --tail 5` should show "OAuth 2.1 enabled"

## Test plan

- [x] Verify `.env.demo.example` parses correctly
- [ ] Follow deployment steps on demo after #1637 merges