### PR TITLE
feat: Add RFC 8414 OAuth metadata endpoint for MCP auth discovery

### DIFF
--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -227,6 +227,10 @@ func runHTTP(logger *slog.Logger, cfg server.Config) error {
 		tokenHandler := mcpauth.NewTokenHandler(oauthCfg, codeStore, issuer)
 		mux.Handle("/oauth/token", tokenHandler)
 
+		// RFC 8414 OAuth Authorization Server Metadata — required by MCP clients
+		// (e.g. Claude.ai) to discover auth endpoints before connecting.
+		mux.HandleFunc("/.well-known/oauth-authorization-server", mcpauth.NewMetadataHandler(baseURL, oauthCfg))
+
 		meta := mcpauth.Metadata{
 			AuthorizationURL: oauthCfg.AuthorizationURL,
 			TokenURL:         oauthCfg.TokenURL,

--- a/services/mcp-server/internal/auth/oauth.go
+++ b/services/mcp-server/internal/auth/oauth.go
@@ -183,6 +183,53 @@ type BearerValidator interface {
 }
 
 // -----------------------------------------------------------------------
+// Authorization Server Metadata — GET /.well-known/oauth-authorization-server
+// -----------------------------------------------------------------------
+
+// AuthorizationServerMetadata represents the OAuth 2.0 Authorization Server
+// Metadata response per RFC 8414. MCP clients (e.g. Claude.ai) fetch this
+// endpoint to discover how to authenticate.
+type AuthorizationServerMetadata struct {
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	ResponseTypesSupported            []string `json:"response_types_supported"`
+	GrantTypesSupported               []string `json:"grant_types_supported"`
+	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
+}
+
+// NewMetadataHandler returns an http.HandlerFunc that serves the OAuth 2.0
+// Authorization Server Metadata document (RFC 8414) at
+// /.well-known/oauth-authorization-server.
+//
+// The response is pre-serialized at construction time for efficiency.
+func NewMetadataHandler(baseURL string, cfg OAuthConfig) http.HandlerFunc {
+	meta := AuthorizationServerMetadata{
+		Issuer:                            baseURL,
+		AuthorizationEndpoint:             cfg.AuthorizationURL,
+		TokenEndpoint:                     cfg.TokenURL,
+		ResponseTypesSupported:            []string{"code"},
+		GrantTypesSupported:               []string{"authorization_code"},
+		CodeChallengeMethodsSupported:     []string{"S256"},
+		TokenEndpointAuthMethodsSupported: []string{"none"},
+	}
+
+	body, err := json.Marshal(meta)
+	if err != nil {
+		return func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "internal error: failed to serialize metadata", http.StatusInternalServerError)
+		}
+	}
+
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		_, _ = w.Write(body)
+	}
+}
+
+// -----------------------------------------------------------------------
 // AuthorizationHandler — GET /oauth/authorize
 // -----------------------------------------------------------------------
 

--- a/services/mcp-server/internal/auth/oauth_test.go
+++ b/services/mcp-server/internal/auth/oauth_test.go
@@ -1,6 +1,7 @@
 package auth_test
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -81,7 +82,7 @@ func TestMetadataHandler_ServesRFC8414(t *testing.T) {
 	}
 
 	handler := auth.NewMetadataHandler("https://mcp.example.com", cfg)
-	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/.well-known/oauth-authorization-server", nil)
 	rec := httptest.NewRecorder()
 	handler(rec, req)
 
@@ -117,7 +118,7 @@ func TestAuthorizationHandler_GeneratesCode(t *testing.T) {
 
 	_, challenge := generatePKCEPair(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
 		"response_type":         {"code"},
 		"client_id":             {cfg.ClientID},
 		"redirect_uri":          {cfg.RedirectURI},
@@ -151,7 +152,7 @@ func TestAuthorizationHandler_MissingChallenge_ReturnsBadRequest(t *testing.T) {
 	}
 	handler := auth.NewAuthorizationHandler(cfg, store)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?response_type=code&client_id=meridian-mcp", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?response_type=code&client_id=meridian-mcp", nil)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 
@@ -168,7 +169,7 @@ func TestAuthorizationHandler_WrongClientID_ReturnsBadRequest(t *testing.T) {
 
 	_, challenge := generatePKCEPair(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
 		"response_type":         {"code"},
 		"client_id":             {"wrong-client"},
 		"redirect_uri":          {cfg.RedirectURI},
@@ -191,7 +192,7 @@ func TestAuthorizationHandler_WrongRedirectURI_ReturnsBadRequest(t *testing.T) {
 
 	_, challenge := generatePKCEPair(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
 		"response_type":         {"code"},
 		"client_id":             {cfg.ClientID},
 		"redirect_uri":          {"https://evil.example.com/steal"},
@@ -212,7 +213,7 @@ func TestAuthorizationHandler_NonGetMethod_ReturnsMethodNotAllowed(t *testing.T)
 	}
 	handler := auth.NewAuthorizationHandler(cfg, store)
 
-	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/authorize", nil)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 
@@ -252,7 +253,7 @@ func TestTokenHandler_ExchangesCodeForToken(t *testing.T) {
 		"client_id":     {cfg.ClientID},
 		"code_verifier": {verifier},
 	}
-	req := httptest.NewRequest(http.MethodPost, "/oauth/token",
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/token",
 		strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
@@ -293,7 +294,7 @@ func TestTokenHandler_InvalidVerifier_ReturnsBadRequest(t *testing.T) {
 		"client_id":     {cfg.ClientID},
 		"code_verifier": {"wrong-verifier-AAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}, // 43+ chars per RFC 7636
 	}
-	req := httptest.NewRequest(http.MethodPost, "/oauth/token",
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/token",
 		strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
@@ -330,7 +331,7 @@ func TestTokenHandler_ExpiredCode_ReturnsBadRequest(t *testing.T) {
 		"client_id":     {cfg.ClientID},
 		"code_verifier": {verifier},
 	}
-	req := httptest.NewRequest(http.MethodPost, "/oauth/token",
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/token",
 		strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
@@ -358,7 +359,7 @@ func TestTokenHandler_UnknownCode_ReturnsBadRequest(t *testing.T) {
 		"client_id":     {cfg.ClientID},
 		"code_verifier": {verifier},
 	}
-	req := httptest.NewRequest(http.MethodPost, "/oauth/token",
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/token",
 		strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
@@ -394,7 +395,7 @@ func TestTokenHandler_CodeIsConsumedAfterExchange(t *testing.T) {
 			"client_id":     {cfg.ClientID},
 			"code_verifier": {verifier},
 		}
-		req := httptest.NewRequest(http.MethodPost, "/oauth/token",
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/token",
 			strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		w := httptest.NewRecorder()
@@ -437,7 +438,7 @@ func TestTokenHandler_MismatchedRedirectURI_ReturnsBadRequest(t *testing.T) {
 		"client_id":     {cfg.ClientID},
 		"code_verifier": {verifier},
 	}
-	req := httptest.NewRequest(http.MethodPost, "/oauth/token",
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/token",
 		strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
@@ -502,7 +503,7 @@ func TestBearerMiddleware_RejectsUnauthenticated(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/mcp", nil)
 	w := httptest.NewRecorder()
 	mw.Handler(inner).ServeHTTP(w, req)
 
@@ -528,7 +529,7 @@ func TestBearerMiddleware_AcceptsValidToken(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer valid-token")
 	w := httptest.NewRecorder()
 	mw.Handler(inner).ServeHTTP(w, req)

--- a/services/mcp-server/internal/auth/oauth_test.go
+++ b/services/mcp-server/internal/auth/oauth_test.go
@@ -70,6 +70,38 @@ func TestAuthMetadata_JSON(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------
+// MetadataHandler — /.well-known/oauth-authorization-server
+// -----------------------------------------------------------------------
+
+func TestMetadataHandler_ServesRFC8414(t *testing.T) {
+	cfg := auth.OAuthConfig{
+		ClientID:         "meridian-mcp",
+		AuthorizationURL: "https://mcp.example.com/oauth/authorize",
+		TokenURL:         "https://mcp.example.com/oauth/token",
+	}
+
+	handler := auth.NewMetadataHandler("https://mcp.example.com", cfg)
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json; charset=utf-8", rec.Header().Get("Content-Type"))
+	assert.Contains(t, rec.Header().Get("Cache-Control"), "public")
+
+	var meta auth.AuthorizationServerMetadata
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &meta))
+
+	assert.Equal(t, "https://mcp.example.com", meta.Issuer)
+	assert.Equal(t, "https://mcp.example.com/oauth/authorize", meta.AuthorizationEndpoint)
+	assert.Equal(t, "https://mcp.example.com/oauth/token", meta.TokenEndpoint)
+	assert.Equal(t, []string{"code"}, meta.ResponseTypesSupported)
+	assert.Equal(t, []string{"authorization_code"}, meta.GrantTypesSupported)
+	assert.Equal(t, []string{"S256"}, meta.CodeChallengeMethodsSupported)
+	assert.Equal(t, []string{"none"}, meta.TokenEndpointAuthMethodsSupported)
+}
+
+// -----------------------------------------------------------------------
 // AuthorizationHandler
 // -----------------------------------------------------------------------
 

--- a/services/mcp-server/internal/auth/oidc_test.go
+++ b/services/mcp-server/internal/auth/oidc_test.go
@@ -1,6 +1,7 @@
 package auth_test
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -182,7 +183,7 @@ func TestOIDCHandler_Authorize_RedirectsToDex(t *testing.T) {
 
 	_, challenge := generatePKCEPair(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
 		"response_type":         {"code"},
 		"client_id":             {"meridian-mcp"},
 		"redirect_uri":          {"https://claude.ai/callback"},
@@ -234,7 +235,7 @@ func TestOIDCHandler_Authorize_InvalidClientID(t *testing.T) {
 
 	_, challenge := generatePKCEPair(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
 		"response_type":         {"code"},
 		"client_id":             {"wrong-client"},
 		"redirect_uri":          {"https://claude.ai/callback"},
@@ -267,7 +268,7 @@ func TestOIDCHandler_Authorize_MissingPKCE(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
 		"response_type": {"code"},
 		"client_id":     {"meridian-mcp"},
 		"redirect_uri":  {"https://claude.ai/callback"},
@@ -294,7 +295,7 @@ func TestOIDCHandler_Authorize_RejectsHTTPRedirect(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
 		"response_type":         {"code"},
 		"client_id":             {"meridian-mcp"},
 		"redirect_uri":          {"http://evil.example.com/steal"},
@@ -325,7 +326,7 @@ func TestOIDCHandler_Authorize_AllowsLocalhostHTTP(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
 		"response_type":         {"code"},
 		"client_id":             {"meridian-mcp"},
 		"redirect_uri":          {"http://localhost:3000/callback"},
@@ -381,7 +382,7 @@ func TestOIDCHandler_Callback_ExchangesAndRedirects(t *testing.T) {
 	require.NoError(t, err)
 
 	// Simulate Dex callback
-	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?"+url.Values{
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/callback?"+url.Values{
 		"code":  {"fake-dex-code"},
 		"state": {stateKey},
 	}.Encode(), nil)
@@ -440,7 +441,7 @@ func TestOIDCHandler_Callback_InvalidState(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?"+url.Values{
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/callback?"+url.Values{
 		"code":  {"fake-dex-code"},
 		"state": {"invalid-state-key"},
 	}.Encode(), nil)
@@ -470,7 +471,7 @@ func TestOIDCHandler_Callback_DexError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?"+url.Values{
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/callback?"+url.Values{
 		"error":             {"access_denied"},
 		"error_description": {"user cancelled"},
 	}.Encode(), nil)
@@ -516,7 +517,7 @@ func TestOIDCFlow_EndToEnd(t *testing.T) {
 	verifier, challenge := generatePKCEPair(t)
 
 	// Step 1: Authorize — get redirect to Dex
-	authReq := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+url.Values{
+	authReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
 		"response_type":         {"code"},
 		"client_id":             {"meridian-mcp"},
 		"redirect_uri":          {"https://claude.ai/callback"},
@@ -536,7 +537,7 @@ func TestOIDCFlow_EndToEnd(t *testing.T) {
 	require.NotEmpty(t, internalState)
 
 	// Step 2: Callback — simulate Dex returning with code
-	cbReq := httptest.NewRequest(http.MethodGet, "/oauth/callback?"+url.Values{
+	cbReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/callback?"+url.Values{
 		"code":  {"fake-dex-code"},
 		"state": {internalState},
 	}.Encode(), nil)
@@ -558,7 +559,7 @@ func TestOIDCFlow_EndToEnd(t *testing.T) {
 		"client_id":     {"meridian-mcp"},
 		"code_verifier": {verifier},
 	}
-	tokenReq := httptest.NewRequest(http.MethodPost, "/oauth/token",
+	tokenReq := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/token",
 		strings.NewReader(form.Encode()))
 	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	tokenW := httptest.NewRecorder()
@@ -649,7 +650,7 @@ func TestTokenHandler_UsesPreSignedToken(t *testing.T) {
 		"client_id":     {cfg.ClientID},
 		"code_verifier": {verifier},
 	}
-	req := httptest.NewRequest(http.MethodPost, "/oauth/token",
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/token",
 		strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()

--- a/services/mcp-server/internal/auth/subdomain_test.go
+++ b/services/mcp-server/internal/auth/subdomain_test.go
@@ -137,7 +137,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 		validator := &mockClaimsValidator{tenantID: "acme"}
 
 		handler := mw.Handler(validator, meta, okHandler)
-		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "acme.demo.meridianhub.cloud"
 		rec := httptest.NewRecorder()
 
@@ -153,7 +153,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 		validator := &mockClaimsValidator{tenantID: "acme"}
 
 		handler := mw.Handler(validator, meta, okHandler)
-		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "demo.meridianhub.cloud"
 		rec := httptest.NewRecorder()
 
@@ -169,7 +169,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 		validator := &mockClaimsValidator{tenantID: "volterra-energy"}
 
 		handler := mw.Handler(validator, meta, okHandler)
-		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "volterra-energy.demo.meridianhub.cloud"
 		req.Header.Set("Authorization", "Bearer valid-token")
 		rec := httptest.NewRecorder()
@@ -186,7 +186,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 		validator := &mockClaimsValidator{tenantID: "other-tenant"}
 
 		handler := mw.Handler(validator, meta, okHandler)
-		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "volterra-energy.demo.meridianhub.cloud"
 		req.Header.Set("Authorization", "Bearer valid-token")
 		rec := httptest.NewRecorder()
@@ -203,7 +203,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 		validator := &mockClaimsValidator{tenantID: "acme"}
 
 		handler := mw.Handler(validator, meta, okHandler)
-		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "acme.demo.meridianhub.cloud"
 		// No Authorization header
 		rec := httptest.NewRecorder()
@@ -220,7 +220,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 		validator := &mockClaimsValidator{err: ErrInvalidBearerToken}
 
 		handler := mw.Handler(validator, meta, okHandler)
-		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "acme.demo.meridianhub.cloud"
 		req.Header.Set("Authorization", "Bearer bad-token")
 		rec := httptest.NewRecorder()
@@ -243,7 +243,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 		})
 
 		handler := mw.Handler(validator, meta, captureHandler)
-		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "demo.meridianhub.cloud"
 		rec := httptest.NewRecorder()
 
@@ -268,7 +268,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 		})
 
 		handler := mw.Handler(validator, meta, captureHandler)
-		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "acme.demo.meridianhub.cloud"
 		req.Header.Set("Authorization", "Bearer valid-token")
 		rec := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

- Adds `/.well-known/oauth-authorization-server` endpoint (RFC 8414) to the MCP server
- MCP clients (e.g. Claude.ai) require this endpoint to discover OAuth configuration before initiating authentication
- Without it, clients treat the MCP server as not requiring auth — which is what we observed on the Claude.ai plugins UI

## Changes Made

- `services/mcp-server/internal/auth/oauth.go`: New `AuthorizationServerMetadata` type and `NewMetadataHandler` function serving pre-serialized JSON with issuer, authorization/token endpoints, supported response types, grant types, PKCE methods, and auth methods
- `services/mcp-server/cmd/main.go`: Register the handler at `/.well-known/oauth-authorization-server` when OAuth is enabled
- `services/mcp-server/internal/auth/oauth_test.go`: Test verifying correct RFC 8414 response structure

## Test plan

- [x] Unit test `TestMetadataHandler_ServesRFC8414` passes
- [x] Full auth test suite passes (29 tests)
- [x] Build passes
- [x] golangci-lint passes
- [ ] Deploy to demo and verify Claude.ai recognizes auth requirement