### PR TITLE
feat: Add dynamic client registration (RFC 7591) for MCP OAuth

### DIFF
--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -221,6 +221,13 @@ func runHTTP(logger *slog.Logger, cfg server.Config) error {
 		codeStore := mcpauth.NewCodeStore()
 		defer codeStore.Close()
 
+		// Dynamic client registration (RFC 7591) — MCP clients like Claude.ai
+		// register themselves before starting the OAuth flow.
+		clientRegistry := mcpauth.NewClientRegistry()
+		defer clientRegistry.Close()
+		regHandler := mcpauth.NewRegistrationHandler(clientRegistry, logger)
+		mux.Handle("/oauth/register", regHandler)
+
 		// Token endpoint uses passthrough issuer as fallback; the OIDC flow
 		// stores pre-signed JWTs directly via StoreWithToken.
 		issuer := &passthroughIssuer{logger: logger}
@@ -266,6 +273,7 @@ func runHTTP(logger *slog.Logger, cfg server.Config) error {
 				OAuth:      oauthCfg,
 				StateStore: oidcStateStore,
 				CodeStore:  codeStore,
+				Registry:   clientRegistry,
 				Signer:     signer,
 				BaseDomain: baseDomain,
 				Logger:     logger,
@@ -283,7 +291,7 @@ func runHTTP(logger *slog.Logger, cfg server.Config) error {
 		} else {
 			// No Dex configured — use the direct authorization handler (dev/CI only).
 			logger.Warn("MCP_DEX_ISSUER_URL not set — /oauth/authorize issues codes without authentication")
-			authzHandler := mcpauth.NewAuthorizationHandler(oauthCfg, codeStore)
+			authzHandler := mcpauth.NewAuthorizationHandler(oauthCfg, codeStore, clientRegistry)
 			mux.Handle("/oauth/authorize", authzHandler)
 		}
 

--- a/services/mcp-server/internal/auth/oauth.go
+++ b/services/mcp-server/internal/auth/oauth.go
@@ -193,6 +193,7 @@ type AuthorizationServerMetadata struct {
 	Issuer                            string   `json:"issuer"`
 	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
 	TokenEndpoint                     string   `json:"token_endpoint"`
+	RegistrationEndpoint              string   `json:"registration_endpoint,omitempty"`
 	ResponseTypesSupported            []string `json:"response_types_supported"`
 	GrantTypesSupported               []string `json:"grant_types_supported"`
 	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`
@@ -209,6 +210,7 @@ func NewMetadataHandler(baseURL string, cfg OAuthConfig) http.HandlerFunc {
 		Issuer:                            baseURL,
 		AuthorizationEndpoint:             cfg.AuthorizationURL,
 		TokenEndpoint:                     cfg.TokenURL,
+		RegistrationEndpoint:              baseURL + "/oauth/register",
 		ResponseTypesSupported:            []string{"code"},
 		GrantTypesSupported:               []string{"authorization_code"},
 		CodeChallengeMethodsSupported:     []string{"S256"},
@@ -237,18 +239,50 @@ func NewMetadataHandler(baseURL string, cfg OAuthConfig) http.HandlerFunc {
 // It validates the PKCE challenge, generates an authorization code,
 // and redirects the client back to redirect_uri.
 type AuthorizationHandler struct {
-	cfg    OAuthConfig
-	store  *CodeStore
-	logger *slog.Logger
+	cfg      OAuthConfig
+	store    *CodeStore
+	registry *ClientRegistry
+	logger   *slog.Logger
 }
 
 // NewAuthorizationHandler creates a new AuthorizationHandler.
-func NewAuthorizationHandler(cfg OAuthConfig, store *CodeStore) *AuthorizationHandler {
+// If registry is non-nil, dynamically registered clients are accepted
+// in addition to the static client ID from cfg.
+func NewAuthorizationHandler(cfg OAuthConfig, store *CodeStore, registry *ClientRegistry) *AuthorizationHandler {
 	return &AuthorizationHandler{
-		cfg:    cfg,
-		store:  store,
-		logger: slog.Default(),
+		cfg:      cfg,
+		store:    store,
+		registry: registry,
+		logger:   slog.Default(),
 	}
+}
+
+// resolveClient validates the client_id and redirect_uri combination.
+// Returns the resolved redirect URI or an error description string.
+func (h *AuthorizationHandler) resolveClient(clientID, redirectURI string) (string, string) {
+	if clientID == h.cfg.ClientID {
+		if redirectURI != "" && redirectURI != h.cfg.RedirectURI {
+			return "", "redirect_uri does not match registered value"
+		}
+		if redirectURI == "" {
+			return h.cfg.RedirectURI, ""
+		}
+		return redirectURI, ""
+	}
+	if h.registry != nil {
+		client, ok := h.registry.Lookup(clientID)
+		if !ok {
+			return "", "invalid client_id"
+		}
+		if redirectURI == "" {
+			return "", "redirect_uri is required for dynamic clients"
+		}
+		if !client.HasRedirectURI(redirectURI) {
+			return "", "redirect_uri does not match registered value"
+		}
+		return redirectURI, ""
+	}
+	return "", "invalid client_id"
 }
 
 // ServeHTTP implements http.Handler.
@@ -261,24 +295,17 @@ func (h *AuthorizationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	q := r.URL.Query()
 
-	clientID := q.Get("client_id")
-	if clientID != h.cfg.ClientID {
-		http.Error(w, "invalid client_id", http.StatusBadRequest)
+	redirectURI, errMsg := h.resolveClient(q.Get("client_id"), q.Get("redirect_uri"))
+	if errMsg != "" {
+		http.Error(w, errMsg, http.StatusBadRequest)
 		return
 	}
+
+	clientID := q.Get("client_id")
 
 	// Require response_type=code (only supported grant).
 	if q.Get("response_type") != "code" {
 		http.Error(w, "response_type must be 'code'", http.StatusBadRequest)
-		return
-	}
-
-	// Validate redirect_uri against the registered value to prevent open redirect.
-	// If the client provides one it must match exactly; reject mismatches.
-	// After validation, always redirect to the registered URI (not the client-supplied one)
-	// so the redirect target is never user-controlled.
-	if clientRedirect := q.Get("redirect_uri"); clientRedirect != "" && clientRedirect != h.cfg.RedirectURI {
-		http.Error(w, "redirect_uri does not match registered value", http.StatusBadRequest)
 		return
 	}
 
@@ -305,15 +332,16 @@ func (h *AuthorizationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	h.store.Store(code, CodeEntry{
 		CodeChallenge: challenge,
 		ClientID:      clientID,
-		RedirectURI:   h.cfg.RedirectURI,
+		RedirectURI:   redirectURI,
 		IssuedAt:      time.Now(),
 	})
 
 	h.logger.Info("authorization code issued", "client_id", clientID)
 
-	// Build redirect URL via url.Parse using the registered (trusted) URI.
-	// The redirect target is never derived from user-supplied input.
-	target, err := url.Parse(h.cfg.RedirectURI)
+	// Build redirect URL via url.Parse using the validated redirect URI.
+	// For static clients this is the registered URI; for dynamic clients
+	// it was validated against the client's registered redirect_uris.
+	target, err := url.Parse(redirectURI)
 	if err != nil {
 		h.logger.Error("invalid registered redirect URI", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)

--- a/services/mcp-server/internal/auth/oauth_test.go
+++ b/services/mcp-server/internal/auth/oauth_test.go
@@ -114,7 +114,7 @@ func TestAuthorizationHandler_GeneratesCode(t *testing.T) {
 		TokenURL:         "https://auth.example.com/token",
 		RedirectURI:      "http://localhost:8090/oauth/callback",
 	}
-	handler := auth.NewAuthorizationHandler(cfg, store)
+	handler := auth.NewAuthorizationHandler(cfg, store, nil)
 
 	_, challenge := generatePKCEPair(t)
 
@@ -150,7 +150,7 @@ func TestAuthorizationHandler_MissingChallenge_ReturnsBadRequest(t *testing.T) {
 		ClientID:    "meridian-mcp",
 		RedirectURI: "http://localhost:8090/oauth/callback",
 	}
-	handler := auth.NewAuthorizationHandler(cfg, store)
+	handler := auth.NewAuthorizationHandler(cfg, store, nil)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?response_type=code&client_id=meridian-mcp", nil)
 	w := httptest.NewRecorder()
@@ -165,7 +165,7 @@ func TestAuthorizationHandler_WrongClientID_ReturnsBadRequest(t *testing.T) {
 		ClientID:    "meridian-mcp",
 		RedirectURI: "http://localhost:8090/oauth/callback",
 	}
-	handler := auth.NewAuthorizationHandler(cfg, store)
+	handler := auth.NewAuthorizationHandler(cfg, store, nil)
 
 	_, challenge := generatePKCEPair(t)
 
@@ -188,7 +188,7 @@ func TestAuthorizationHandler_WrongRedirectURI_ReturnsBadRequest(t *testing.T) {
 		ClientID:    "meridian-mcp",
 		RedirectURI: "http://localhost:8090/oauth/callback",
 	}
-	handler := auth.NewAuthorizationHandler(cfg, store)
+	handler := auth.NewAuthorizationHandler(cfg, store, nil)
 
 	_, challenge := generatePKCEPair(t)
 
@@ -211,7 +211,7 @@ func TestAuthorizationHandler_NonGetMethod_ReturnsMethodNotAllowed(t *testing.T)
 		ClientID:    "meridian-mcp",
 		RedirectURI: "http://localhost:8090/oauth/callback",
 	}
-	handler := auth.NewAuthorizationHandler(cfg, store)
+	handler := auth.NewAuthorizationHandler(cfg, store, nil)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/authorize", nil)
 	w := httptest.NewRecorder()

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -288,8 +288,17 @@ func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	clientID := q.Get("client_id")
 	redirectURI := q.Get("redirect_uri")
 
-	// Accept static client ID or dynamically registered clients.
-	if clientID != h.oauthCfg.ClientID {
+	// Validate client_id and redirect_uri for both static and dynamic clients.
+	if clientID == h.oauthCfg.ClientID {
+		// Static client: default to configured redirect_uri, reject mismatches.
+		if redirectURI == "" {
+			redirectURI = h.oauthCfg.RedirectURI
+		} else if redirectURI != h.oauthCfg.RedirectURI {
+			http.Error(w, "redirect_uri does not match registered value", http.StatusBadRequest)
+			return
+		}
+	} else {
+		// Dynamic client: must be in registry with a matching redirect_uri.
 		if h.registry == nil {
 			http.Error(w, "invalid client_id", http.StatusBadRequest)
 			return
@@ -299,8 +308,11 @@ func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "invalid client_id", http.StatusBadRequest)
 			return
 		}
-		// Dynamic client: redirect_uri must match a registered URI.
-		if redirectURI != "" && !client.HasRedirectURI(redirectURI) {
+		if redirectURI == "" {
+			http.Error(w, "redirect_uri is required for dynamic clients", http.StatusBadRequest)
+			return
+		}
+		if !client.HasRedirectURI(redirectURI) {
 			http.Error(w, "redirect_uri does not match registered value", http.StatusBadRequest)
 			return
 		}
@@ -320,11 +332,6 @@ func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	method := q.Get("code_challenge_method")
 	if method != "S256" {
 		http.Error(w, "only code_challenge_method=S256 is supported", http.StatusBadRequest)
-		return
-	}
-
-	if redirectURI == "" {
-		http.Error(w, "redirect_uri is required", http.StatusBadRequest)
 		return
 	}
 

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -190,6 +190,7 @@ type OIDCHandler struct {
 	oauthCfg   OAuthConfig
 	stateStore *OIDCStateStore
 	codeStore  *CodeStore
+	registry   *ClientRegistry
 	signer     *platformauth.JWTSigner
 	tokenTTL   time.Duration
 	baseDomain string
@@ -203,6 +204,7 @@ type OIDCHandlerConfig struct {
 	OAuth      OAuthConfig
 	StateStore *OIDCStateStore
 	CodeStore  *CodeStore
+	Registry   *ClientRegistry
 	Signer     *platformauth.JWTSigner
 	TokenTTL   time.Duration
 	BaseDomain string
@@ -264,6 +266,7 @@ func NewOIDCHandler(cfg OIDCHandlerConfig) (*OIDCHandler, error) {
 		oauthCfg:   cfg.OAuth,
 		stateStore: cfg.StateStore,
 		codeStore:  cfg.CodeStore,
+		registry:   cfg.Registry,
 		signer:     cfg.Signer,
 		tokenTTL:   ttl,
 		baseDomain: cfg.BaseDomain,
@@ -283,9 +286,24 @@ func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
 	clientID := q.Get("client_id")
+	redirectURI := q.Get("redirect_uri")
+
+	// Accept static client ID or dynamically registered clients.
 	if clientID != h.oauthCfg.ClientID {
-		http.Error(w, "invalid client_id", http.StatusBadRequest)
-		return
+		if h.registry == nil {
+			http.Error(w, "invalid client_id", http.StatusBadRequest)
+			return
+		}
+		client, ok := h.registry.Lookup(clientID)
+		if !ok {
+			http.Error(w, "invalid client_id", http.StatusBadRequest)
+			return
+		}
+		// Dynamic client: redirect_uri must match a registered URI.
+		if redirectURI != "" && !client.HasRedirectURI(redirectURI) {
+			http.Error(w, "redirect_uri does not match registered value", http.StatusBadRequest)
+			return
+		}
 	}
 
 	if q.Get("response_type") != "code" {
@@ -305,16 +323,13 @@ func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	redirectURI := q.Get("redirect_uri")
 	if redirectURI == "" {
 		http.Error(w, "redirect_uri is required", http.StatusBadRequest)
 		return
 	}
 
 	// Validate redirect_uri scheme to prevent open-redirect attacks.
-	// MCP clients provide dynamic callback URIs, so we validate the scheme
-	// rather than matching a single registered URI: HTTPS is required for
-	// production; HTTP is allowed only for localhost (development).
+	// HTTPS is required for production; HTTP is allowed only for localhost.
 	if !isAllowedRedirectURI(redirectURI) {
 		http.Error(w, "redirect_uri must use https (or http://localhost for development)", http.StatusBadRequest)
 		return

--- a/services/mcp-server/internal/auth/oidc_test.go
+++ b/services/mcp-server/internal/auth/oidc_test.go
@@ -162,6 +162,7 @@ func TestOIDCHandler_Authorize_RedirectsToDex(t *testing.T) {
 
 	oauthCfg := auth.OAuthConfig{
 		ClientID:         "meridian-mcp",
+		RedirectURI:      "https://claude.ai/callback",
 		AuthorizationURL: "https://demo.meridianhub.cloud/oauth/authorize",
 		TokenURL:         "https://demo.meridianhub.cloud/oauth/token",
 	}
@@ -259,7 +260,8 @@ func TestOIDCHandler_Authorize_MissingPKCE(t *testing.T) {
 			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
 		},
 		OAuth: auth.OAuthConfig{
-			ClientID: "meridian-mcp",
+			ClientID:    "meridian-mcp",
+			RedirectURI: "https://claude.ai/callback",
 		},
 		StateStore: newTestOIDCStateStore(t),
 		CodeStore:  newTestStore(t),
@@ -280,6 +282,7 @@ func TestOIDCHandler_Authorize_MissingPKCE(t *testing.T) {
 }
 
 func TestOIDCHandler_Authorize_RejectsHTTPRedirect(t *testing.T) {
+	registry := newTestRegistry(t)
 	signer := newTestSigner(t)
 	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
 		OIDC: auth.OIDCConfig{
@@ -288,6 +291,7 @@ func TestOIDCHandler_Authorize_RejectsHTTPRedirect(t *testing.T) {
 			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
 		},
 		OAuth:      auth.OAuthConfig{ClientID: "meridian-mcp"},
+		Registry:   registry,
 		StateStore: newTestOIDCStateStore(t),
 		CodeStore:  newTestStore(t),
 		Signer:     signer,
@@ -295,9 +299,15 @@ func TestOIDCHandler_Authorize_RejectsHTTPRedirect(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Register a dynamic client with an HTTP redirect to test scheme validation.
+	client, err := registry.Register(auth.RegisteredClient{
+		RedirectURIs: []string{"http://evil.example.com/steal"},
+	})
+	require.NoError(t, err)
+
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
 		"response_type":         {"code"},
-		"client_id":             {"meridian-mcp"},
+		"client_id":             {client.ClientID},
 		"redirect_uri":          {"http://evil.example.com/steal"},
 		"code_challenge":        {"abc123"},
 		"code_challenge_method": {"S256"},
@@ -318,7 +328,10 @@ func TestOIDCHandler_Authorize_AllowsLocalhostHTTP(t *testing.T) {
 			ClientID:     "meridian-service",
 			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
 		},
-		OAuth:      auth.OAuthConfig{ClientID: "meridian-mcp"},
+		OAuth: auth.OAuthConfig{
+			ClientID:    "meridian-mcp",
+			RedirectURI: "http://localhost:3000/callback",
+		},
 		StateStore: newTestOIDCStateStore(t),
 		CodeStore:  newTestStore(t),
 		Signer:     signer,
@@ -493,6 +506,7 @@ func TestOIDCFlow_EndToEnd(t *testing.T) {
 
 	oauthCfg := auth.OAuthConfig{
 		ClientID:         "meridian-mcp",
+		RedirectURI:      "https://claude.ai/callback",
 		AuthorizationURL: "https://demo.meridianhub.cloud/oauth/authorize",
 		TokenURL:         "https://demo.meridianhub.cloud/oauth/token",
 	}
@@ -748,4 +762,41 @@ func TestNewOIDCHandler_MissingConfig(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
+}
+
+func TestOIDCHandler_Authorize_RejectsStaticClientEvilRedirect(t *testing.T) {
+	dexSrv := fakeDexServer(t, "user@example.com")
+	signer := newTestSigner(t)
+
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID:    "meridian-mcp",
+			RedirectURI: "https://claude.ai/callback",
+		},
+		StateStore: newTestOIDCStateStore(t),
+		CodeStore:  newTestStore(t),
+		Signer:     signer,
+		Logger:     slog.Default(),
+	})
+	require.NoError(t, err)
+
+	_, challenge := generatePKCEPair(t)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"meridian-mcp"},
+		"redirect_uri":          {"https://evil.example.com/cb"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleAuthorize(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "redirect_uri does not match registered value")
 }

--- a/services/mcp-server/internal/auth/registration.go
+++ b/services/mcp-server/internal/auth/registration.go
@@ -23,6 +23,13 @@ const (
 	// clientTTL is how long a dynamically registered client remains valid.
 	// MCP clients must re-register after this period.
 	clientTTL = 24 * time.Hour
+	// registrationBodyLimit is the maximum request body size for /oauth/register.
+	registrationBodyLimit = 64 << 10 // 64 KiB
+
+	// Supported OAuth 2.1 values for MCP.
+	supportedGrantType    = "authorization_code"
+	supportedResponseType = "code"
+	supportedAuthMethod   = "none"
 )
 
 var (
@@ -160,6 +167,33 @@ type registrationRequest struct {
 	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
 }
 
+// validateMetadata validates and defaults the registration metadata fields.
+// Returns the resolved values and an error description if validation fails.
+func (req registrationRequest) validateMetadata() (grantTypes, responseTypes []string, authMethod, errDesc string) {
+	grantTypes = req.GrantTypes
+	if len(grantTypes) == 0 {
+		grantTypes = []string{supportedGrantType}
+	} else if len(grantTypes) != 1 || grantTypes[0] != supportedGrantType {
+		return nil, nil, "", "unsupported grant_types: only authorization_code is supported"
+	}
+
+	responseTypes = req.ResponseTypes
+	if len(responseTypes) == 0 {
+		responseTypes = []string{supportedResponseType}
+	} else if len(responseTypes) != 1 || responseTypes[0] != supportedResponseType {
+		return nil, nil, "", "unsupported response_types: only code is supported"
+	}
+
+	authMethod = req.TokenEndpointAuthMethod
+	if authMethod == "" {
+		authMethod = supportedAuthMethod
+	} else if authMethod != supportedAuthMethod {
+		return nil, nil, "", "unsupported token_endpoint_auth_method: only none is supported"
+	}
+
+	return grantTypes, responseTypes, authMethod, ""
+}
+
 // RegistrationHandler handles POST /oauth/register for dynamic client
 // registration per RFC 7591.
 type RegistrationHandler struct {
@@ -183,7 +217,7 @@ func (h *RegistrationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var req registrationRequest
-	r.Body = http.MaxBytesReader(w, r.Body, 64<<10) // 64 KiB
+	r.Body = http.MaxBytesReader(w, r.Body, registrationBodyLimit)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {
@@ -199,7 +233,6 @@ func (h *RegistrationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Validate all redirect URIs.
 	for _, uri := range req.RedirectURIs {
 		if !isAllowedRedirectURI(uri) {
 			writeRegistrationError(w, fmt.Sprintf("%s: %s", errInvalidRedirectFn.Error(), uri))
@@ -207,18 +240,10 @@ func (h *RegistrationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// Default grant/response types per MCP OAuth 2.1.
-	grantTypes := req.GrantTypes
-	if len(grantTypes) == 0 {
-		grantTypes = []string{"authorization_code"}
-	}
-	responseTypes := req.ResponseTypes
-	if len(responseTypes) == 0 {
-		responseTypes = []string{"code"}
-	}
-	authMethod := req.TokenEndpointAuthMethod
-	if authMethod == "" {
-		authMethod = "none"
+	grantTypes, responseTypes, authMethod, errDesc := req.validateMetadata()
+	if errDesc != "" {
+		writeRegistrationError(w, errDesc)
+		return
 	}
 
 	client, err := h.registry.Register(RegisteredClient{

--- a/services/mcp-server/internal/auth/registration.go
+++ b/services/mcp-server/internal/auth/registration.go
@@ -94,6 +94,15 @@ func (r *ClientRegistry) Register(client RegisteredClient) (RegisteredClient, er
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Evict expired clients before enforcing the cap so that stale entries
+	// don't block legitimate registrations between background sweeps.
+	now := time.Now()
+	for id, existing := range r.clients {
+		if now.Sub(existing.registeredAt) > clientTTL {
+			delete(r.clients, id)
+		}
+	}
+
 	if len(r.clients) >= registryMaxClients {
 		return RegisteredClient{}, errRegistryFull
 	}
@@ -104,7 +113,7 @@ func (r *ClientRegistry) Register(client RegisteredClient) (RegisteredClient, er
 	}
 
 	client.ClientID = id
-	client.registeredAt = time.Now()
+	client.registeredAt = now
 	r.clients[id] = client
 	return client, nil
 }
@@ -174,7 +183,13 @@ func (h *RegistrationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var req registrationRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 64<<10) // 64 KiB
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, "invalid JSON body", http.StatusBadRequest)
 		return
 	}

--- a/services/mcp-server/internal/auth/registration.go
+++ b/services/mcp-server/internal/auth/registration.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"sync"
@@ -218,12 +219,18 @@ func (h *RegistrationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	var req registrationRequest
 	r.Body = http.MaxBytesReader(w, r.Body, registrationBodyLimit)
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&req); err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {
 			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
 			return
 		}
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	// Reject trailing data after the JSON object.
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
 		http.Error(w, "invalid JSON body", http.StatusBadRequest)
 		return
 	}

--- a/services/mcp-server/internal/auth/registration.go
+++ b/services/mcp-server/internal/auth/registration.go
@@ -1,0 +1,243 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	// clientIDBytes is the number of random bytes in a generated client ID.
+	clientIDBytes = 16
+	// registryMaxClients caps the number of registered clients to prevent
+	// memory exhaustion from unauthenticated registration requests.
+	registryMaxClients = 10000
+	// registryEvictInterval is how often the registry sweeps expired entries.
+	registryEvictInterval = 10 * time.Minute
+	// clientTTL is how long a dynamically registered client remains valid.
+	// MCP clients must re-register after this period.
+	clientTTL = 24 * time.Hour
+)
+
+var (
+	errRegistryFull      = errors.New("client registry is full")
+	errNoRedirectURIs    = errors.New("redirect_uris is required")
+	errInvalidRedirectFn = errors.New("redirect_uri is not allowed")
+)
+
+// RegisteredClient holds metadata for a dynamically registered OAuth client.
+type RegisteredClient struct {
+	ClientID                string   `json:"client_id"`
+	ClientName              string   `json:"client_name,omitempty"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types"`
+	ResponseTypes           []string `json:"response_types"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+	registeredAt            time.Time
+}
+
+// ClientRegistry is a thread-safe in-memory store for dynamically registered
+// OAuth clients (RFC 7591). Registrations are ephemeral and expire after clientTTL.
+type ClientRegistry struct {
+	mu        sync.RWMutex
+	clients   map[string]RegisteredClient
+	stop      chan struct{}
+	closeOnce sync.Once
+}
+
+// NewClientRegistry creates an empty registry and starts background eviction.
+func NewClientRegistry() *ClientRegistry {
+	r := &ClientRegistry{
+		clients: make(map[string]RegisteredClient),
+		stop:    make(chan struct{}),
+	}
+	go r.evictLoop()
+	return r
+}
+
+// Close stops the background eviction goroutine.
+func (r *ClientRegistry) Close() {
+	r.closeOnce.Do(func() { close(r.stop) })
+}
+
+func (r *ClientRegistry) evictLoop() {
+	ticker := time.NewTicker(registryEvictInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			r.evictExpired()
+		case <-r.stop:
+			return
+		}
+	}
+}
+
+func (r *ClientRegistry) evictExpired() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for id, client := range r.clients {
+		if time.Since(client.registeredAt) > clientTTL {
+			delete(r.clients, id)
+		}
+	}
+}
+
+// Register adds a new client and returns the generated client ID.
+func (r *ClientRegistry) Register(client RegisteredClient) (RegisteredClient, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.clients) >= registryMaxClients {
+		return RegisteredClient{}, errRegistryFull
+	}
+
+	id, err := generateClientID()
+	if err != nil {
+		return RegisteredClient{}, fmt.Errorf("generate client ID: %w", err)
+	}
+
+	client.ClientID = id
+	client.registeredAt = time.Now()
+	r.clients[id] = client
+	return client, nil
+}
+
+// Lookup returns a registered client by ID.
+func (r *ClientRegistry) Lookup(clientID string) (RegisteredClient, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	client, ok := r.clients[clientID]
+	if !ok {
+		return RegisteredClient{}, false
+	}
+	if time.Since(client.registeredAt) > clientTTL {
+		return RegisteredClient{}, false
+	}
+	return client, true
+}
+
+// HasRedirectURI checks if the given redirect URI is registered for the client.
+func (c RegisteredClient) HasRedirectURI(uri string) bool {
+	for _, u := range c.RedirectURIs {
+		if u == uri {
+			return true
+		}
+	}
+	return false
+}
+
+// generateClientID returns a random hex-encoded client identifier.
+func generateClientID() (string, error) {
+	b := make([]byte, clientIDBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate client ID: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// registrationRequest is the RFC 7591 client registration request body.
+type registrationRequest struct {
+	ClientName              string   `json:"client_name"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types"`
+	ResponseTypes           []string `json:"response_types"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+}
+
+// RegistrationHandler handles POST /oauth/register for dynamic client
+// registration per RFC 7591.
+type RegistrationHandler struct {
+	registry *ClientRegistry
+	logger   *slog.Logger
+}
+
+// NewRegistrationHandler creates a new RegistrationHandler.
+func NewRegistrationHandler(registry *ClientRegistry, logger *slog.Logger) *RegistrationHandler {
+	return &RegistrationHandler{
+		registry: registry,
+		logger:   logger,
+	}
+}
+
+// ServeHTTP implements http.Handler.
+func (h *RegistrationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req registrationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	if len(req.RedirectURIs) == 0 {
+		writeRegistrationError(w, errNoRedirectURIs.Error())
+		return
+	}
+
+	// Validate all redirect URIs.
+	for _, uri := range req.RedirectURIs {
+		if !isAllowedRedirectURI(uri) {
+			writeRegistrationError(w, fmt.Sprintf("%s: %s", errInvalidRedirectFn.Error(), uri))
+			return
+		}
+	}
+
+	// Default grant/response types per MCP OAuth 2.1.
+	grantTypes := req.GrantTypes
+	if len(grantTypes) == 0 {
+		grantTypes = []string{"authorization_code"}
+	}
+	responseTypes := req.ResponseTypes
+	if len(responseTypes) == 0 {
+		responseTypes = []string{"code"}
+	}
+	authMethod := req.TokenEndpointAuthMethod
+	if authMethod == "" {
+		authMethod = "none"
+	}
+
+	client, err := h.registry.Register(RegisteredClient{
+		ClientName:              req.ClientName,
+		RedirectURIs:            req.RedirectURIs,
+		GrantTypes:              grantTypes,
+		ResponseTypes:           responseTypes,
+		TokenEndpointAuthMethod: authMethod,
+	})
+	if err != nil {
+		if errors.Is(err, errRegistryFull) {
+			h.logger.Warn("client registry full, rejecting registration")
+			http.Error(w, "too many registered clients", http.StatusServiceUnavailable)
+			return
+		}
+		h.logger.Error("client registration failed", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	h.logger.Info("dynamic client registered",
+		"client_id", client.ClientID,
+		"client_name", client.ClientName)
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(client)
+}
+
+func writeRegistrationError(w http.ResponseWriter, description string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":             "invalid_client_metadata",
+		"error_description": description,
+	})
+}

--- a/services/mcp-server/internal/auth/registration_test.go
+++ b/services/mcp-server/internal/auth/registration_test.go
@@ -118,6 +118,22 @@ func TestRegisteredClient_HasRedirectURI(t *testing.T) {
 	assert.False(t, client.HasRedirectURI("https://c.com/cb"))
 }
 
+func TestRegistrationHandler_RejectsOversizedBody(t *testing.T) {
+	registry := newTestRegistry(t)
+	handler := auth.NewRegistrationHandler(registry, slog.Default())
+
+	// Build valid-looking JSON that exceeds 64 KiB.
+	// The key is a long string value that forces the reader past the limit.
+	body := strings.NewReader(`{"client_name":"` + strings.Repeat("a", 128<<10) + `"}`)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/register", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
 func TestMetadataHandler_IncludesRegistrationEndpoint(t *testing.T) {
 	cfg := auth.OAuthConfig{
 		ClientID:         "meridian-mcp",

--- a/services/mcp-server/internal/auth/registration_test.go
+++ b/services/mcp-server/internal/auth/registration_test.go
@@ -1,0 +1,136 @@
+package auth_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/mcp-server/internal/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRegistry(t *testing.T) *auth.ClientRegistry {
+	t.Helper()
+	r := auth.NewClientRegistry()
+	t.Cleanup(r.Close)
+	return r
+}
+
+func TestRegistrationHandler_RegistersClient(t *testing.T) {
+	registry := newTestRegistry(t)
+	handler := auth.NewRegistrationHandler(registry, slog.Default())
+
+	body := `{"client_name":"test-client","redirect_uris":["https://example.com/callback"]}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	var client auth.RegisteredClient
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &client))
+	assert.NotEmpty(t, client.ClientID)
+	assert.Equal(t, "test-client", client.ClientName)
+	assert.Equal(t, []string{"https://example.com/callback"}, client.RedirectURIs)
+	assert.Equal(t, []string{"authorization_code"}, client.GrantTypes)
+	assert.Equal(t, []string{"code"}, client.ResponseTypes)
+	assert.Equal(t, "none", client.TokenEndpointAuthMethod)
+
+	// Verify client is in the registry.
+	looked, ok := registry.Lookup(client.ClientID)
+	assert.True(t, ok)
+	assert.Equal(t, client.ClientID, looked.ClientID)
+}
+
+func TestRegistrationHandler_RejectsNoRedirectURIs(t *testing.T) {
+	registry := newTestRegistry(t)
+	handler := auth.NewRegistrationHandler(registry, slog.Default())
+
+	body := `{"client_name":"test"}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRegistrationHandler_RejectsHTTPRedirectURI(t *testing.T) {
+	registry := newTestRegistry(t)
+	handler := auth.NewRegistrationHandler(registry, slog.Default())
+
+	body := `{"redirect_uris":["http://evil.com/callback"]}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRegistrationHandler_AllowsLocalhostHTTP(t *testing.T) {
+	registry := newTestRegistry(t)
+	handler := auth.NewRegistrationHandler(registry, slog.Default())
+
+	body := `{"redirect_uris":["http://localhost:12345/callback"]}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusCreated, rec.Code)
+}
+
+func TestRegistrationHandler_MethodNotAllowed(t *testing.T) {
+	registry := newTestRegistry(t)
+	handler := auth.NewRegistrationHandler(registry, slog.Default())
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/register", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestClientRegistry_LookupUnknown(t *testing.T) {
+	registry := newTestRegistry(t)
+	_, ok := registry.Lookup("nonexistent")
+	assert.False(t, ok)
+}
+
+func TestRegisteredClient_HasRedirectURI(t *testing.T) {
+	client := auth.RegisteredClient{
+		RedirectURIs: []string{"https://a.com/cb", "https://b.com/cb"},
+	}
+	assert.True(t, client.HasRedirectURI("https://a.com/cb"))
+	assert.True(t, client.HasRedirectURI("https://b.com/cb"))
+	assert.False(t, client.HasRedirectURI("https://c.com/cb"))
+}
+
+func TestMetadataHandler_IncludesRegistrationEndpoint(t *testing.T) {
+	cfg := auth.OAuthConfig{
+		ClientID:         "meridian-mcp",
+		AuthorizationURL: "https://mcp.example.com/oauth/authorize",
+		TokenURL:         "https://mcp.example.com/oauth/token",
+	}
+
+	handler := auth.NewMetadataHandler("https://mcp.example.com", cfg)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	var meta auth.AuthorizationServerMetadata
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &meta))
+	assert.Equal(t, "https://mcp.example.com/oauth/register", meta.RegistrationEndpoint)
+}

--- a/services/mcp-server/internal/server/server.go
+++ b/services/mcp-server/internal/server/server.go
@@ -16,7 +16,7 @@ import (
 )
 
 // ProtocolVersion is the MCP protocol version this server implements.
-const ProtocolVersion = "2024-11-05"
+const ProtocolVersion = "2025-03-26"
 
 // Info contains metadata about the MCP server.
 type Info struct {


### PR DESCRIPTION
## Summary

- Implements RFC 7591 dynamic client registration at `POST /oauth/register`
- MCP clients (e.g. Claude.ai) register themselves to obtain a `client_id` before starting the OAuth 2.1 flow
- Without this, Claude.ai reports "Incompatible auth server: does not support dynamic client registration"

## Changes Made

- **`services/mcp-server/internal/auth/registration.go`**: New `ClientRegistry` (in-memory, TTL-based, bounded to 10k entries) and `RegistrationHandler` serving RFC 7591 responses
- **`services/mcp-server/internal/auth/oauth.go`**: Updated `AuthorizationHandler` to accept dynamically registered client IDs; extracted `resolveClient` helper to reduce cognitive complexity; added `registration_endpoint` to RFC 8414 metadata
- **`services/mcp-server/internal/auth/oidc.go`**: Updated `OIDCHandler` to accept dynamically registered client IDs via `ClientRegistry`
- **`services/mcp-server/cmd/main.go`**: Wire `ClientRegistry` and registration handler; pass registry to auth handlers

## Test plan

- [x] `TestRegistrationHandler_RegistersClient` — successful registration returns 201 with client_id
- [x] `TestRegistrationHandler_RejectsNoRedirectURIs` — missing redirect_uris returns 400
- [x] `TestRegistrationHandler_RejectsHTTPRedirectURI` — non-localhost HTTP rejected
- [x] `TestRegistrationHandler_AllowsLocalhostHTTP` — localhost HTTP accepted
- [x] `TestMetadataHandler_IncludesRegistrationEndpoint` — metadata includes registration URL
- [x] All existing auth tests pass with updated signatures
- [x] golangci-lint passes (0 issues)
- [ ] Deploy to demo and verify Claude.ai can complete full OAuth flow