### PR TITLE
fix: Improve frontend accessibility

### DIFF
--- a/frontend/src/components/layout/app-shell.tsx
+++ b/frontend/src/components/layout/app-shell.tsx
@@ -36,7 +36,7 @@ export function AppShell({ children, currentPath = '/' }: AppShellProps) {
           sidebarOpen={sidebarOpen}
           sidebarId={SIDEBAR_ID}
         />
-        <main id="main-content" className="flex-1 overflow-y-auto p-4">
+        <main id="main-content" tabIndex={-1} className="flex-1 overflow-y-auto p-4">
           {children}
         </main>
       </div>

--- a/frontend/src/components/layout/app-shell.tsx
+++ b/frontend/src/components/layout/app-shell.tsx
@@ -16,6 +16,12 @@ export function AppShell({ children, currentPath = '/' }: AppShellProps) {
 
   return (
     <div className="flex h-screen overflow-hidden bg-gray-100">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-background focus:text-foreground"
+      >
+        Skip to main content
+      </a>
       <Sidebar
         id={SIDEBAR_ID}
         lens={lens}
@@ -30,7 +36,7 @@ export function AppShell({ children, currentPath = '/' }: AppShellProps) {
           sidebarOpen={sidebarOpen}
           sidebarId={SIDEBAR_ID}
         />
-        <main className="flex-1 overflow-y-auto p-4">
+        <main id="main-content" className="flex-1 overflow-y-auto p-4">
           {children}
         </main>
       </div>

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -116,7 +116,6 @@ export function Sidebar({ lens, currentPath = '/', isOpen = false, id, onClose }
           className="fixed inset-0 z-30 bg-black/50 md:hidden"
           aria-hidden="true"
           role="presentation"
-          tabIndex={-1}
           onClick={onClose}
         />
       )}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -105,7 +105,10 @@ export function Sidebar({ lens, currentPath = '/', isOpen = false, id, onClose }
         <div
           className="fixed inset-0 z-30 bg-black/50 md:hidden"
           aria-hidden="true"
+          role="presentation"
+          tabIndex={-1}
           onClick={onClose}
+          onKeyDown={(e) => { if (e.key === 'Escape') onClose() }}
         />
       )}
       <aside

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { BuildInfo } from './build-info'
 import {
@@ -93,6 +94,15 @@ export function Sidebar({ lens, currentPath = '/', isOpen = false, id, onClose }
   const { isFeatureEnabled } = useTenantFeatures()
   const { isPlatformAdmin } = useTenantContext()
 
+  useEffect(() => {
+    if (!isOpen || !onClose) return
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose!()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
   function isItemVisible(item: NavItem): boolean {
     if (!item.feature) return true
     if (isPlatformAdmin) return true
@@ -108,7 +118,6 @@ export function Sidebar({ lens, currentPath = '/', isOpen = false, id, onClose }
           role="presentation"
           tabIndex={-1}
           onClick={onClose}
-          onKeyDown={(e) => { if (e.key === 'Escape') onClose() }}
         />
       )}
       <aside

--- a/frontend/src/features/cookbook/components/catalogue-grid.test.tsx
+++ b/frontend/src/features/cookbook/components/catalogue-grid.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { renderWithProviders } from '@/test/test-utils'
 import { CatalogueGrid } from './catalogue-grid'
@@ -32,12 +31,6 @@ const mockItems: CookbookItem[] = [
     meta: { feature_module: 'accounts', configurable: true },
   },
 ]
-
-const mockNavigate = vi.fn()
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom')
-  return { ...actual, useNavigate: () => mockNavigate }
-})
 
 function renderGrid(items: CookbookItem[], hasActiveFilters = false) {
   return renderWithProviders(
@@ -77,11 +70,10 @@ describe('CatalogueGrid', () => {
     expect(screen.getByText('No matching items')).toBeInTheDocument()
   })
 
-  it('navigates on card click', async () => {
-    const user = userEvent.setup()
+  it('navigates on card click', () => {
     renderGrid(mockItems)
-    await user.click(screen.getByText('Energy Trading'))
-    expect(mockNavigate).toHaveBeenCalledWith('/cookbook/energy-trading')
+    const link = screen.getByText('Energy Trading').closest('a')
+    expect(link).toHaveAttribute('href', '/cookbook/energy-trading')
   })
 
   it('shows complexity indicator for patterns', () => {

--- a/frontend/src/features/cookbook/components/catalogue-grid.tsx
+++ b/frontend/src/features/cookbook/components/catalogue-grid.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { Blocks, BookOpen, SearchX } from 'lucide-react'
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -30,7 +30,6 @@ function ComplexityIndicator({ score }: { score: number }) {
     <Tooltip>
       <TooltipTrigger asChild>
         <span
-          tabIndex={0}
           aria-label={`Complexity: ${score} — ${label}`}
           className="flex items-center gap-1"
           data-testid="complexity-indicator"
@@ -51,23 +50,14 @@ function ComplexityIndicator({ score }: { score: number }) {
 }
 
 function CookbookCard({ item }: { item: CookbookItem }) {
-  const navigate = useNavigate()
   const isPattern = item.type === 'registry:pattern'
   const meta = item.meta
   const patternMeta = isPatternMeta(meta) ? meta : undefined
 
   return (
+    <Link to={`/cookbook/${item.name}`} className="rounded-xl outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]">
     <Card
-      role="link"
-      tabIndex={0}
-      className="cursor-pointer transition-colors hover:border-primary/50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none"
-      onClick={() => navigate(`/cookbook/${item.name}`)}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          navigate(`/cookbook/${item.name}`)
-        }
-      }}
+      className="h-full cursor-pointer transition-colors hover:border-primary/50"
     >
       <CardHeader>
         <div className="flex items-start justify-between gap-2">
@@ -118,6 +108,7 @@ function CookbookCard({ item }: { item: CookbookItem }) {
         </CardFooter>
       )}
     </Card>
+    </Link>
   )
 }
 

--- a/frontend/src/shared/data-table.tsx
+++ b/frontend/src/shared/data-table.tsx
@@ -322,7 +322,6 @@ export function DataTable<T>({
                 className={onRowClick ? 'cursor-pointer' : undefined}
                 {...(onRowClick ? {
                   tabIndex: 0,
-                  role: 'link',
                   onKeyDown: (e: React.KeyboardEvent) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                       e.preventDefault()

--- a/frontend/src/shared/data-table.tsx
+++ b/frontend/src/shared/data-table.tsx
@@ -76,7 +76,7 @@ function SortableHeader({ label, isSorted, onToggle }: SortableHeaderProps) {
       onClick={onToggle}
       aria-sort={ariaSort}
       aria-label={ariaLabel}
-      className="flex items-center gap-1 font-medium hover:text-foreground"
+      className="flex items-center gap-1 font-medium hover:text-foreground focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
     >
       {label}
       {isSorted === 'asc' ? (
@@ -320,6 +320,16 @@ export function DataTable<T>({
                 key={row.id}
                 onClick={() => onRowClick?.(row.original)}
                 className={onRowClick ? 'cursor-pointer' : undefined}
+                {...(onRowClick ? {
+                  tabIndex: 0,
+                  role: 'link',
+                  onKeyDown: (e: React.KeyboardEvent) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      onRowClick(row.original)
+                    }
+                  },
+                } : {})}
               >
                 {row.getVisibleCells().map((cell) => (
                   <TableCell key={cell.id}>


### PR DESCRIPTION
## Summary
- Add skip-to-content link for keyboard navigation (WCAG 2.4.1)
- Add keyboard support to clickable data table rows (WCAG 2.1.1)
- Add Escape key handler to mobile sidebar overlay
- Add focus indicators to sortable table headers (WCAG 2.4.7)
- Replace role="link" on div with semantic navigation in cookbook
- Remove redundant tabIndex from tooltip-wrapped elements

## Test plan
- [ ] Tab through the app — skip link appears on focus, jumps to main content
- [ ] Navigate data tables with keyboard — Enter/Space on rows triggers navigation
- [ ] Open mobile sidebar, press Escape — sidebar closes
- [ ] Tab to sortable headers — focus ring visible
- [ ] Cookbook grid items navigable via keyboard