### PR TITLE
fix: Add responsive grid breakpoints for mobile

### DIFF
--- a/frontend/src/features/audit/pages/index.tsx
+++ b/frontend/src/features/audit/pages/index.tsx
@@ -120,7 +120,7 @@ function AuditDetailPanel({ entry, onClose }: AuditDetailPanelProps) {
           {/* Content */}
           <div className="p-6 space-y-6">
             {/* Metadata */}
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <p className="text-sm font-medium text-muted-foreground">Table</p>
                 <p className="mt-1 text-sm font-mono">{entry.tableName}</p>

--- a/frontend/src/features/economy/pages/economy-create-page.tsx
+++ b/frontend/src/features/economy/pages/economy-create-page.tsx
@@ -41,7 +41,7 @@ export function EconomyCreatePage() {
           onChange={(e) => setPrompt(e.target.value)}
         />
 
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {/* Build My Economy */}
           <OptionCard
             icon={<Wand2 className="size-5" />}

--- a/frontend/src/features/payments/pages/dialogs/initiate-payment-dialog.tsx
+++ b/frontend/src/features/payments/pages/dialogs/initiate-payment-dialog.tsx
@@ -185,7 +185,7 @@ export function InitiatePaymentDialog({
               )}
             </div>
 
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div className="space-y-1">
                 <label htmlFor="amount" className="text-sm font-medium">
                   Amount

--- a/frontend/src/features/payments/pages/payment-detail.tsx
+++ b/frontend/src/features/payments/pages/payment-detail.tsx
@@ -32,7 +32,7 @@ function PaymentDetailSkeleton() {
 
 function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <div className="grid grid-cols-[180px_1fr] gap-4 py-2 border-b last:border-0">
+    <div className="grid grid-cols-1 sm:grid-cols-[180px_1fr] gap-4 py-2 border-b last:border-0">
       <span className="text-sm font-medium text-muted-foreground">{label}</span>
       <span className="text-sm">{children}</span>
     </div>

--- a/frontend/src/features/sagas/components/starlark-editor.tsx
+++ b/frontend/src/features/sagas/components/starlark-editor.tsx
@@ -261,7 +261,7 @@ function ComplexityMetricsPanel({ metrics }: ComplexityMetricsPanelProps) {
       <p className="mb-1.5 text-xs font-medium text-muted-foreground">
         Complexity Metrics
       </p>
-      <div className="grid grid-cols-4 gap-3 text-xs">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 text-xs">
         <div className="flex flex-col gap-0.5">
           <span className="text-muted-foreground">Handler Calls</span>
           <span className="font-mono font-semibold">{handlerCalls}</span>

--- a/frontend/src/features/sagas/pages/detail.tsx
+++ b/frontend/src/features/sagas/pages/detail.tsx
@@ -73,7 +73,7 @@ function SplitPane({
   complexityMetrics,
 }: SplitPaneProps) {
   return (
-    <div data-testid="split-pane" className="grid grid-cols-2 gap-4">
+    <div data-testid="split-pane" className="grid grid-cols-1 lg:grid-cols-2 gap-4">
       <div className="flex flex-col gap-2">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-muted-foreground">Platform Default</span>


### PR DESCRIPTION
## Summary
- Add mobile breakpoints to 6 grid layouts that broke on narrow viewports
- Economy create page: 3-col → stacks to 1-col on mobile
- Saga detail split-pane: 2-col editors → stack on mobile
- Payment dialog: 2-col form fields → stack on mobile
- Audit detail metadata: 2-col → stack on mobile
- Payment detail rows: fixed label column → stack on mobile
- Starlark metrics: 4-col → 2-col on mobile

## Test plan
- [ ] Economy create page renders 1 column on mobile, 3 on desktop
- [ ] Saga detail editors stack vertically on mobile
- [ ] Payment dialog form fields stack on mobile
- [ ] All grids maintain desktop layout at appropriate breakpoints