### PR TITLE
refactor: Replace remaining hardcoded colors and memoize graph nodes

### DIFF
--- a/frontend/src/components/layout/build-info.tsx
+++ b/frontend/src/components/layout/build-info.tsx
@@ -34,7 +34,7 @@ export function BuildInfo() {
   const label = shortCommit ? `${info.version} (${shortCommit})` : info.version
 
   return (
-    <div className="px-3 py-2 text-xs text-gray-500">
+    <div className="px-3 py-2 text-xs text-muted-foreground">
       <span title={info.commit}>{label}</span>
     </div>
   )

--- a/frontend/src/features/cookbook/components/composition-graph.tsx
+++ b/frontend/src/features/cookbook/components/composition-graph.tsx
@@ -31,26 +31,27 @@ import {
 } from '@/lib/visualization/graph-layout'
 import type { CookbookItem, PatternMeta } from '../hooks/use-cookbook'
 
-// Category color mapping
+// Category color mapping — uses CSS variables where possible for dark mode support
+// Note: these are used as inline styles for ReactFlow nodes
 const CATEGORY_COLORS: Record<string, string> = {
-  foundation: '#6366f1', // indigo
-  energy: '#f59e0b',     // amber
-  economy: '#10b981',    // emerald
-  carbon: '#22c55e',     // green
-  compute: '#8b5cf6',    // violet
-  compliance: '#ef4444', // red
-  payments: '#3b82f6',   // blue
-  trading: '#ec4899',    // pink
-  billing: '#06b6d4',    // cyan
-  commodities: '#d97706', // amber-dark
+  foundation: 'var(--chart-1)',
+  energy: 'var(--graph-valuation-rule)',
+  economy: 'var(--graph-account-type)',
+  carbon: 'var(--graph-account-type)',
+  compute: 'var(--graph-saga)',
+  compliance: 'var(--destructive)',
+  payments: 'var(--graph-instrument)',
+  trading: 'var(--chart-5)',
+  billing: 'var(--chart-2)',
+  commodities: 'var(--graph-valuation-rule)',
 }
 
 function getCategoryColor(categories?: string[]): string {
-  if (!categories?.length) return '#71717a' // zinc-500
+  if (!categories?.length) return 'var(--muted-foreground)' // zinc-500
   for (const cat of categories) {
     if (CATEGORY_COLORS[cat]) return CATEGORY_COLORS[cat]
   }
-  return '#71717a'
+  return 'var(--muted-foreground)'
 }
 
 // Custom node component
@@ -99,7 +100,7 @@ const PatternNode = memo(function PatternNode({ data }: { data: PatternNodeData 
             </span>
             {data.complexity > 0 && (
               <span
-                className="mt-0.5 inline-flex items-center justify-center rounded-full text-[8px] font-bold text-white"
+                className="mt-0.5 inline-flex items-center justify-center rounded-full text-[8px] font-bold text-primary-foreground"
                 style={badgeStyle}
               >
                 {data.complexity}
@@ -138,7 +139,7 @@ function buildEdges(patterns: CookbookItem[]): Edge[] {
             source: dep,
             target: pattern.name,
             style: EDGE_STYLES.registryDependencies,
-            markerEnd: { type: 'arrowclosed' as const, color: '#3b82f6' },
+            markerEnd: { type: 'arrowclosed' as const, color: 'var(--graph-instrument)' },
             data: { type: 'registryDependencies' as RelationshipType },
           })
         }
@@ -174,7 +175,7 @@ function buildEdges(patterns: CookbookItem[]): Edge[] {
             source: base,
             target: pattern.name,
             style: EDGE_STYLES.extends,
-            markerEnd: { type: 'arrowclosed' as const, color: '#8b5cf6' },
+            markerEnd: { type: 'arrowclosed' as const, color: 'var(--graph-saga)' },
             data: { type: 'extends' as RelationshipType },
           })
         }
@@ -439,10 +440,10 @@ export function CompositionGraph({ patterns, className }: CompositionGraphProps)
       {/* Legend */}
       <div className="absolute bottom-3 left-3 z-10 flex flex-col gap-1 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm">
         <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">Edges</span>
-        <LegendItem label="Dependency" color="#3b82f6" />
-        <LegendItem label="Composes with" color="#22c55e" dashed />
-        <LegendItem label="Extends" color="#8b5cf6" thick />
-        <LegendItem label="Conflicts" color="#ef4444" dashed />
+        <LegendItem label="Dependency" color="var(--graph-instrument)" />
+        <LegendItem label="Composes with" color="var(--graph-account-type)" dashed />
+        <LegendItem label="Extends" color="var(--graph-saga)" thick />
+        <LegendItem label="Conflicts" color="var(--destructive)" dashed />
       </div>
     </div>
   )

--- a/frontend/src/features/cookbook/components/manifest-viewer.tsx
+++ b/frontend/src/features/cookbook/components/manifest-viewer.tsx
@@ -67,7 +67,7 @@ export function ManifestViewer({ content, className }: ManifestViewerProps) {
         aria-label="Copy manifest"
       >
         {copied ? (
-          <Check className="h-3.5 w-3.5 text-green-600" />
+          <Check className="h-3.5 w-3.5 text-success" />
         ) : (
           <Copy className="h-3.5 w-3.5" />
         )}

--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -136,7 +136,7 @@ interface StepNodeData {
 const StepNode = memo(function StepNode({ data }: { data: StepNodeData }) {
   const primaryService = data.serviceCalls[0]?.service
   const primaryColors = primaryService ? data.serviceColors.get(primaryService) : undefined
-  const borderColor = primaryColors?.fg ?? '#71717a'
+  const borderColor = primaryColors?.fg ?? 'var(--muted-foreground)'
 
   const usesHighlighted = data.highlightedService
     ? data.serviceCalls.some((c) => c.service === data.highlightedService)
@@ -418,7 +418,7 @@ function buildCombinedFlowGraph(
           sourceHandle: 'exit',
           target: exitId,
           label: 'Yes',
-          style: { stroke: '#ef4444', strokeDasharray: '6 3' },
+          style: { stroke: 'var(--destructive)', strokeDasharray: '6 3' },
         })
 
         edges.push({

--- a/frontend/src/features/cookbook/pages/detail.tsx
+++ b/frontend/src/features/cookbook/pages/detail.tsx
@@ -23,9 +23,9 @@ function complexityLabel(score: number): string {
 }
 
 function complexityColor(score: number): string {
-  if (score <= 3) return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
-  if (score <= 6) return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400'
-  return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
+  if (score <= 3) return 'bg-success-muted text-success-foreground'
+  if (score <= 6) return 'bg-warning-muted text-warning-foreground'
+  return 'bg-destructive/10 text-destructive'
 }
 
 function PatternInfoSection({ item, computedComplexity }: { item: CookbookItem; computedComplexity: number | null }) {

--- a/frontend/src/features/economy/components/manifest-diff.tsx
+++ b/frontend/src/features/economy/components/manifest-diff.tsx
@@ -35,14 +35,14 @@ export function ManifestDiffViewer({ diff, onNodeClick, className }: ManifestDif
             icon={<Plus className="h-3.5 w-3.5" />}
             label="Added"
             count={diff.addedNodes.length}
-            colorClass="text-green-600 dark:text-green-400"
+            colorClass="text-success-foreground"
           />
           <ul className="mt-1.5 space-y-1">
             {diff.addedNodes.map((node) => (
               <NodeRow
                 key={node.id}
                 label={node.label}
-                colorClass="border-green-500/40 bg-green-50/60 dark:bg-green-950/30"
+                colorClass="border-success/40 bg-success-muted"
                 onClick={onNodeClick ? () => onNodeClick(node) : undefined}
               />
             ))}
@@ -56,11 +56,11 @@ export function ManifestDiffViewer({ diff, onNodeClick, className }: ManifestDif
             icon={<RefreshCw className="h-3.5 w-3.5" />}
             label="Modified"
             count={diff.modifiedNodes.length}
-            colorClass="text-amber-600 dark:text-amber-400"
+            colorClass="text-warning-foreground"
           />
           <ul className="mt-1.5 space-y-2">
             {diff.modifiedNodes.map(({ before, after }) => (
-              <li key={after.id} className="rounded border border-amber-500/40 bg-amber-50/60 px-3 py-2 text-sm dark:bg-amber-950/30">
+              <li key={after.id} className="rounded border border-warning/40 bg-warning-muted px-3 py-2 text-sm">
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <span className="font-medium text-foreground/70">Before:</span>
                   <span>{before.label}</span>
@@ -81,14 +81,14 @@ export function ManifestDiffViewer({ diff, onNodeClick, className }: ManifestDif
             icon={<Minus className="h-3.5 w-3.5" />}
             label="Removed"
             count={diff.removedNodes.length}
-            colorClass="text-red-600 dark:text-red-400"
+            colorClass="text-destructive"
           />
           <ul className="mt-1.5 space-y-1">
             {diff.removedNodes.map((node) => (
               <NodeRow
                 key={node.id}
                 label={node.label}
-                colorClass="border-red-500/40 bg-red-50/60 dark:bg-red-950/30"
+                colorClass="border-destructive/40 bg-destructive/10"
                 onClick={onNodeClick ? () => onNodeClick(node) : undefined}
               />
             ))}

--- a/frontend/src/features/economy/pages/economy-create-page.tsx
+++ b/frontend/src/features/economy/pages/economy-create-page.tsx
@@ -56,7 +56,7 @@ export function EconomyCreatePage() {
 
           {/* I'm Feeling Lucky */}
           <OptionCard
-            icon={<Sparkles className="size-5 text-amber-500" />}
+            icon={<Sparkles className="size-5 text-warning" />}
             title="I'm Feeling Lucky"
             description="Single-pass AI generation"
             disabled={generatorDisabled}
@@ -68,7 +68,7 @@ export function EconomyCreatePage() {
 
           {/* Start from Scratch */}
           <OptionCard
-            icon={<FileCode className="size-5 text-green-500" />}
+            icon={<FileCode className="size-5 text-success" />}
             title="Start from Scratch"
             description="Open the editor with a blank template"
             disabled={false}

--- a/frontend/src/features/economy/pages/economy-explore-page.tsx
+++ b/frontend/src/features/economy/pages/economy-explore-page.tsx
@@ -88,7 +88,7 @@ function EventChannelsPanel({ sagas }: { sagas: SagaDefinition[] }) {
         <Card key={ch.channel}>
           <CardContent className="flex items-center justify-between px-4 py-3">
             <span className="font-mono text-sm font-medium text-foreground">{ch.channel}</span>
-            <Badge className="bg-green-100 text-green-800 hover:bg-green-100 dark:bg-green-900 dark:text-green-200">
+            <Badge className="bg-success-muted text-success-foreground hover:bg-success-muted">
               {ch.sagas.length} saga{ch.sagas.length === 1 ? '' : 's'} attached
             </Badge>
           </CardContent>

--- a/frontend/src/features/manifests/components/event-chain-panel.test.tsx
+++ b/frontend/src/features/manifests/components/event-chain-panel.test.tsx
@@ -82,7 +82,7 @@ describe('EventChainPanel', () => {
 
     const badge = screen.getByTestId('filter-badge-pass')
     expect(badge.textContent).toBe('pass')
-    expect(badge.className).toContain('bg-emerald-100')
+    expect(badge.className).toContain('bg-success-muted')
   })
 
   it('shows fail filter badge with red styling', () => {
@@ -94,7 +94,7 @@ describe('EventChainPanel', () => {
 
     const badge = screen.getByTestId('filter-badge-fail')
     expect(badge.textContent).toBe('fail')
-    expect(badge.className).toContain('bg-red-100')
+    expect(badge.className).toContain('bg-destructive/10')
   })
 
   it('shows indeterminate filter badge with amber styling', () => {
@@ -106,7 +106,7 @@ describe('EventChainPanel', () => {
 
     const badge = screen.getByTestId('filter-badge-indeterminate')
     expect(badge.textContent).toBe('indeterminate')
-    expect(badge.className).toContain('bg-amber-100')
+    expect(badge.className).toContain('bg-warning-muted')
   })
 
   it('displays termination reason for filter_rejection', () => {

--- a/frontend/src/features/manifests/components/event-chain-panel.tsx
+++ b/frontend/src/features/manifests/components/event-chain-panel.tsx
@@ -9,9 +9,9 @@ import { Badge } from '@/components/ui/badge'
 import type { EventChain, EventHop } from '../lib/transitive-closure'
 
 const FILTER_BADGE_STYLES: Record<string, string> = {
-  pass: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300',
-  fail: 'bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-300',
-  indeterminate: 'bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300',
+  pass: 'bg-success-muted text-success-foreground',
+  fail: 'bg-destructive/10 text-destructive',
+  indeterminate: 'bg-warning-muted text-warning-foreground',
 }
 
 const TERMINATION_LABELS: Record<string, string> = {

--- a/frontend/src/features/manifests/components/manifest-diff-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-graph.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { memo, useEffect, useMemo } from 'react'
 import {
   ReactFlow,
   Controls,
@@ -32,10 +32,10 @@ import { computeManifestDiff, type ManifestDiff } from '../lib/manifest-diff'
 type DiffStatus = 'added' | 'removed' | 'modified' | 'unchanged'
 
 const DIFF_COLORS: Record<DiffStatus, { border: string; bg: string }> = {
-  added: { border: '#16a34a', bg: '#16a34a18' },
-  removed: { border: '#dc2626', bg: '#dc262618' },
-  modified: { border: '#d97706', bg: '#d9770618' },
-  unchanged: { border: '#6b7280', bg: '#6b728010' },
+  added: { border: 'var(--graph-diff-added)', bg: 'color-mix(in oklch, var(--graph-diff-added) 10%, transparent)' },
+  removed: { border: 'var(--graph-diff-removed)', bg: 'color-mix(in oklch, var(--graph-diff-removed) 10%, transparent)' },
+  modified: { border: 'var(--graph-diff-modified)', bg: 'color-mix(in oklch, var(--graph-diff-modified) 10%, transparent)' },
+  unchanged: { border: 'var(--graph-diff-unchanged)', bg: 'color-mix(in oklch, var(--graph-diff-unchanged) 6%, transparent)' },
 }
 
 const LAYER_PRIORITY: Record<ManifestNodeType, string> = {
@@ -51,20 +51,23 @@ interface DiffNodeData {
   [key: string]: unknown
 }
 
-function DiffNode({ data }: { data: DiffNodeData }) {
+const DiffNode = memo(function DiffNode({ data }: { data: DiffNodeData }) {
   const node = data.manifestNode
   const colors = DIFF_COLORS[data.diffStatus]
+
+  const containerStyle = useMemo(() => ({
+    width: 180,
+    borderColor: colors.border,
+    backgroundColor: colors.bg,
+    textDecoration: data.diffStatus === 'removed' ? 'line-through' as const : undefined,
+  }), [colors.border, colors.bg, data.diffStatus])
+
   return (
     <>
       <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
       <div
         className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center"
-        style={{
-          width: 180,
-          borderColor: colors.border,
-          backgroundColor: colors.bg,
-          textDecoration: data.diffStatus === 'removed' ? 'line-through' : undefined,
-        }}
+        style={containerStyle}
         data-testid={`diff-node-${data.diffStatus}`}
       >
         <span className="text-[11px] font-bold font-mono text-foreground">{node.label}</span>
@@ -73,7 +76,7 @@ function DiffNode({ data }: { data: DiffNodeData }) {
       <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
     </>
   )
-}
+})
 
 const nodeTypes = {
   diff_node: DiffNode,
@@ -240,7 +243,7 @@ export function ManifestDiffGraph({ before, after, className }: ManifestDiffGrap
 
   if (noDiff) {
     return (
-      <div className={className} data-testid="manifest-diff-no-changes" style={{ width: '100%', height: '100%' }}>
+      <div className={`${className ?? ''} w-full h-full`} data-testid="manifest-diff-no-changes">
         <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
           No differences between versions.
         </div>
@@ -249,7 +252,7 @@ export function ManifestDiffGraph({ before, after, className }: ManifestDiffGrap
   }
 
   return (
-    <div className={className} style={{ width: '100%', height: '100%', position: 'relative' }} data-testid="manifest-diff-graph">
+    <div className={`${className ?? ''} w-full h-full relative`} data-testid="manifest-diff-graph">
       <TooltipProvider>
         <ReactFlow
           nodes={nodes}
@@ -270,29 +273,29 @@ export function ManifestDiffGraph({ before, after, className }: ManifestDiffGrap
       <div className="absolute top-3 left-3 z-10 flex flex-col gap-1 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm" data-testid="diff-summary">
         <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">Changes</span>
         {diff.addedNodes.length > 0 && (
-          <span className="text-xs text-green-600">+{diff.addedNodes.length} added</span>
+          <span className="text-xs text-success-foreground">+{diff.addedNodes.length} added</span>
         )}
         {diff.removedNodes.length > 0 && (
-          <span className="text-xs text-red-600">-{diff.removedNodes.length} removed</span>
+          <span className="text-xs text-destructive">-{diff.removedNodes.length} removed</span>
         )}
         {diff.modifiedNodes.length > 0 && (
-          <span className="text-xs text-amber-600">~{diff.modifiedNodes.length} modified</span>
+          <span className="text-xs text-warning-foreground">~{diff.modifiedNodes.length} modified</span>
         )}
         {diff.addedEdges.length > 0 && (
-          <span className="text-xs text-green-600">+{diff.addedEdges.length} edge{diff.addedEdges.length !== 1 ? 's' : ''}</span>
+          <span className="text-xs text-success-foreground">+{diff.addedEdges.length} edge{diff.addedEdges.length !== 1 ? 's' : ''}</span>
         )}
         {diff.removedEdges.length > 0 && (
-          <span className="text-xs text-red-600">-{diff.removedEdges.length} edge{diff.removedEdges.length !== 1 ? 's' : ''}</span>
+          <span className="text-xs text-destructive">-{diff.removedEdges.length} edge{diff.removedEdges.length !== 1 ? 's' : ''}</span>
         )}
       </div>
 
       {/* Legend */}
       <div className="absolute bottom-3 left-3 z-10 flex flex-col gap-1 rounded-lg border bg-background/95 p-3 backdrop-blur-sm shadow-sm">
         <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">Legend</span>
-        <DiffLegendItem label="Added" color="#16a34a" />
-        <DiffLegendItem label="Removed" color="#dc2626" dashed />
-        <DiffLegendItem label="Modified" color="#d97706" />
-        <DiffLegendItem label="Unchanged" color="#6b7280" />
+        <DiffLegendItem label="Added" color="var(--graph-diff-added)" />
+        <DiffLegendItem label="Removed" color="var(--graph-diff-removed)" dashed />
+        <DiffLegendItem label="Modified" color="var(--graph-diff-modified)" />
+        <DiffLegendItem label="Unchanged" color="var(--graph-diff-unchanged)" />
       </div>
     </div>
   )

--- a/frontend/src/features/manifests/components/manifest-diff-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-diff-graph.tsx
@@ -193,7 +193,7 @@ async function layoutDiffGraph(
 function DiffLegendItem({ label, color, dashed }: { label: string; color: string; dashed?: boolean }) {
   return (
     <div className="flex items-center gap-2">
-      <span className="w-3 h-3 rounded-sm border-2" style={{ borderColor: color, backgroundColor: `${color}18` }} />
+      <span className="w-3 h-3 rounded-sm border-2" style={{ borderColor: color, backgroundColor: `color-mix(in oklch, ${color} 10%, transparent)` }} />
       {dashed !== undefined && (
         <svg width="20" height="12">
           <line x1="0" y1="6" x2="20" y2="6" stroke={color} strokeWidth={2} strokeDasharray={dashed ? '4 4' : undefined} />

--- a/frontend/src/features/manifests/components/manifest-graph.tsx
+++ b/frontend/src/features/manifests/components/manifest-graph.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import {
   ReactFlow,
   Controls,
@@ -46,25 +46,25 @@ import type { Manifest } from '@/api/gen/meridian/control_plane/v1/manifest_pb'
 import { useEventChain } from '../hooks/use-event-chain'
 import { EventChainPanel } from './event-chain-panel'
 
-// Theme colors per node type
+// Theme colors per node type — uses CSS variables for dark mode support
 const NODE_THEMES: Record<ManifestNodeType, { color: string; label: string }> = {
-  instrument: { color: '#3b82f6', label: 'Instruments' },
-  account_type: { color: '#22c55e', label: 'Account Types' },
-  valuation_rule: { color: '#f59e0b', label: 'Valuation Rules' },
-  saga: { color: '#8b5cf6', label: 'Sagas' },
+  instrument: { color: 'var(--graph-instrument)', label: 'Instruments' },
+  account_type: { color: 'var(--graph-account-type)', label: 'Account Types' },
+  valuation_rule: { color: 'var(--graph-valuation-rule)', label: 'Valuation Rules' },
+  saga: { color: 'var(--graph-saga)', label: 'Sagas' },
 }
 
 // Edge styles per relationship type
 const MANIFEST_EDGE_STYLES: Record<string, React.CSSProperties> = {
-  allowed_by: { stroke: '#3b82f6', strokeWidth: 2 },
-  converts_from: { stroke: '#f59e0b', strokeWidth: 1.5, strokeDasharray: '6 3' },
-  converts_to: { stroke: '#f59e0b', strokeWidth: 1.5 },
+  allowed_by: { stroke: 'var(--graph-instrument)', strokeWidth: 2 },
+  converts_from: { stroke: 'var(--graph-valuation-rule)', strokeWidth: 1.5, strokeDasharray: '6 3' },
+  converts_to: { stroke: 'var(--graph-valuation-rule)', strokeWidth: 1.5 },
 }
 
 const EDGE_LEGEND: { label: string; color: string; dashed?: boolean }[] = [
-  { label: 'Allowed by', color: '#3b82f6' },
-  { label: 'Converts from', color: '#f59e0b', dashed: true },
-  { label: 'Converts to', color: '#f59e0b' },
+  { label: 'Allowed by', color: 'var(--graph-instrument)' },
+  { label: 'Converts from', color: 'var(--graph-valuation-rule)', dashed: true },
+  { label: 'Converts to', color: 'var(--graph-valuation-rule)' },
 ]
 
 // ELK layer priority: higher values are placed earlier (top in DOWN direction)
@@ -77,10 +77,10 @@ const LAYER_PRIORITY: Record<ManifestNodeType, string> = {
 
 // Trigger type display
 function getTriggerBadge(trigger: string): { label: string; variant: string } {
-  if (trigger.startsWith('event:')) return { label: 'event', variant: 'bg-purple-100 text-purple-800' }
-  if (trigger.startsWith('scheduled:')) return { label: 'scheduled', variant: 'bg-blue-100 text-blue-800' }
-  if (trigger.startsWith('api:')) return { label: 'api', variant: 'bg-green-100 text-green-800' }
-  return { label: 'unknown', variant: 'bg-gray-100 text-gray-800' }
+  if (trigger.startsWith('event:')) return { label: 'event', variant: 'bg-accent text-accent-foreground' }
+  if (trigger.startsWith('scheduled:')) return { label: 'scheduled', variant: 'bg-info-muted text-info-foreground' }
+  if (trigger.startsWith('api:')) return { label: 'api', variant: 'bg-success-muted text-success-foreground' }
+  return { label: 'unknown', variant: 'bg-muted text-muted-foreground' }
 }
 
 // Custom node data interface
@@ -93,10 +93,19 @@ interface ManifestNodeData {
   [key: string]: unknown
 }
 
-function InstrumentNode({ data }: { data: ManifestNodeData }) {
+const InstrumentNode = memo(function InstrumentNode({ data }: { data: ManifestNodeData }) {
   const node = data.manifestNode
   const code = node.data.code as string
   const unit = (node.data.dimensions as Record<string, unknown> | undefined)?.unit as string | undefined
+
+  const containerStyle = useMemo(() => ({
+    width: 180,
+    borderColor: data.color,
+    backgroundColor: `color-mix(in oklch, ${data.color} 10%, transparent)`,
+    opacity: data.dimmed ? 0.25 : 1,
+    boxShadow: data.highlighted ? `0 0 12px color-mix(in oklch, ${data.color} 53%, transparent)` : undefined,
+  }), [data.color, data.dimmed, data.highlighted])
+
   return (
     <>
       <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
@@ -104,13 +113,7 @@ function InstrumentNode({ data }: { data: ManifestNodeData }) {
         <TooltipTrigger asChild>
           <div
             className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
-            style={{
-              width: 180,
-              borderColor: data.color,
-              backgroundColor: `${data.color}18`,
-              opacity: data.dimmed ? 0.25 : 1,
-              boxShadow: data.highlighted ? `0 0 12px ${data.color}88` : undefined,
-            }}
+            style={containerStyle}
           >
             <span className="text-[11px] font-bold font-mono text-foreground">{code}</span>
             <span className="text-[10px] text-muted-foreground truncate w-full">{node.label}</span>
@@ -122,12 +125,21 @@ function InstrumentNode({ data }: { data: ManifestNodeData }) {
       <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
     </>
   )
-}
+})
 
-function AccountTypeNode({ data }: { data: ManifestNodeData }) {
+const AccountTypeNode = memo(function AccountTypeNode({ data }: { data: ManifestNodeData }) {
   const node = data.manifestNode
   const code = node.data.code as string
   const allowedCount = data.connectedInstrumentCount ?? 0
+
+  const containerStyle = useMemo(() => ({
+    width: 180,
+    borderColor: data.color,
+    backgroundColor: `color-mix(in oklch, ${data.color} 10%, transparent)`,
+    opacity: data.dimmed ? 0.25 : 1,
+    boxShadow: data.highlighted ? `0 0 12px color-mix(in oklch, ${data.color} 53%, transparent)` : undefined,
+  }), [data.color, data.dimmed, data.highlighted])
+
   return (
     <>
       <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
@@ -135,13 +147,7 @@ function AccountTypeNode({ data }: { data: ManifestNodeData }) {
         <TooltipTrigger asChild>
           <div
             className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
-            style={{
-              width: 180,
-              borderColor: data.color,
-              backgroundColor: `${data.color}18`,
-              opacity: data.dimmed ? 0.25 : 1,
-              boxShadow: data.highlighted ? `0 0 12px ${data.color}88` : undefined,
-            }}
+            style={containerStyle}
           >
             <span className="text-[11px] font-bold font-mono text-foreground">{code}</span>
             <span className="text-[10px] text-muted-foreground truncate w-full">{node.label}</span>
@@ -153,12 +159,21 @@ function AccountTypeNode({ data }: { data: ManifestNodeData }) {
       <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
     </>
   )
-}
+})
 
-function ValuationRuleNode({ data }: { data: ManifestNodeData }) {
+const ValuationRuleNode = memo(function ValuationRuleNode({ data }: { data: ManifestNodeData }) {
   const node = data.manifestNode
   const from = node.data.fromInstrument as string
   const to = node.data.toInstrument as string
+
+  const containerStyle = useMemo(() => ({
+    width: 180,
+    borderColor: data.color,
+    backgroundColor: `color-mix(in oklch, ${data.color} 10%, transparent)`,
+    opacity: data.dimmed ? 0.25 : 1,
+    boxShadow: data.highlighted ? `0 0 12px color-mix(in oklch, ${data.color} 53%, transparent)` : undefined,
+  }), [data.color, data.dimmed, data.highlighted])
+
   return (
     <>
       <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
@@ -166,13 +181,7 @@ function ValuationRuleNode({ data }: { data: ManifestNodeData }) {
         <TooltipTrigger asChild>
           <div
             className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150"
-            style={{
-              width: 180,
-              borderColor: data.color,
-              backgroundColor: `${data.color}18`,
-              opacity: data.dimmed ? 0.25 : 1,
-              boxShadow: data.highlighted ? `0 0 12px ${data.color}88` : undefined,
-            }}
+            style={containerStyle}
           >
             <span className="text-[10px] font-semibold text-foreground">{from} &rarr; {to}</span>
           </div>
@@ -182,12 +191,21 @@ function ValuationRuleNode({ data }: { data: ManifestNodeData }) {
       <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
     </>
   )
-}
+})
 
-function SagaNode({ data }: { data: ManifestNodeData }) {
+const SagaNode = memo(function SagaNode({ data }: { data: ManifestNodeData }) {
   const node = data.manifestNode
   const trigger = node.data.trigger as string
   const badge = getTriggerBadge(trigger)
+
+  const containerStyle = useMemo(() => ({
+    width: 180,
+    borderColor: data.color,
+    backgroundColor: `color-mix(in oklch, ${data.color} 10%, transparent)`,
+    opacity: data.dimmed ? 0.25 : 1,
+    boxShadow: data.highlighted ? `0 0 12px color-mix(in oklch, ${data.color} 53%, transparent)` : undefined,
+  }), [data.color, data.dimmed, data.highlighted])
+
   return (
     <>
       <Handle type="target" position={Position.Top} className="!bg-transparent !border-0 !w-0 !h-0" />
@@ -195,13 +213,7 @@ function SagaNode({ data }: { data: ManifestNodeData }) {
         <TooltipTrigger asChild>
           <div
             className="flex flex-col items-center justify-center rounded-lg border-2 px-3 py-2 text-center transition-opacity duration-150 cursor-pointer"
-            style={{
-              width: 180,
-              borderColor: data.color,
-              backgroundColor: `${data.color}18`,
-              opacity: data.dimmed ? 0.25 : 1,
-              boxShadow: data.highlighted ? `0 0 12px ${data.color}88` : undefined,
-            }}
+            style={containerStyle}
           >
             <span className="text-[11px] font-bold text-foreground truncate w-full">{node.label}</span>
             <span className={`mt-0.5 text-[9px] font-medium px-1.5 py-0.5 rounded-full ${badge.variant}`}>
@@ -214,7 +226,7 @@ function SagaNode({ data }: { data: ManifestNodeData }) {
       <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0 !w-0 !h-0" />
     </>
   )
-}
+})
 
 const nodeTypes = {
   instrument: InstrumentNode,
@@ -494,7 +506,7 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
 
   if (graph.nodes.length === 0) {
     return (
-      <div className={className} data-testid="manifest-graph-empty" style={{ width: '100%', height: '100%' }}>
+      <div className={`${className ?? ''} w-full h-full`} data-testid="manifest-graph-empty">
         <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
           No elements in manifest to visualize.
         </div>
@@ -503,7 +515,7 @@ export function ManifestGraph({ manifest, className, _fullscreen }: ManifestGrap
   }
 
   return (
-    <div className={className} style={{ width: '100%', height: '100%', position: 'relative' }}>
+    <div className={`${className ?? ''} w-full h-full relative`}>
       <TooltipProvider>
         <ReactFlow
           nodes={nodes}

--- a/frontend/src/features/market-data/pages/[datasetCode].tsx
+++ b/frontend/src/features/market-data/pages/[datasetCode].tsx
@@ -137,7 +137,7 @@ function ObservationChart({ points, unit }: { points: ObservationPoint[]; unit: 
         <path
           d={pathData}
           fill="none"
-          stroke="#3b82f6"
+          stroke="var(--info)"
           strokeWidth={2}
           strokeLinejoin="round"
           strokeLinecap="round"
@@ -150,7 +150,7 @@ function ObservationChart({ points, unit }: { points: ObservationPoint[]; unit: 
             cx={toSvgX(p.x)}
             cy={toSvgY(p.y)}
             r={3}
-            fill="#3b82f6"
+            fill="var(--info)"
           />
         ))}
       </svg>

--- a/frontend/src/features/parties/pages/tabs/payment-methods-tab.tsx
+++ b/frontend/src/features/parties/pages/tabs/payment-methods-tab.tsx
@@ -145,7 +145,7 @@ export function PaymentMethodsTab({ partyId }: PaymentMethodsTabProps) {
                   <div className="flex items-center gap-2">
                     <span className="font-medium font-mono text-sm">{method.providerMethodId}</span>
                     {method.isDefault && (
-                      <span className="inline-block rounded bg-blue-100 px-2 py-1 text-xs font-medium text-blue-700">
+                      <span className="inline-block rounded bg-info-muted px-2 py-1 text-xs font-medium text-info-foreground">
                         Default
                       </span>
                     )}

--- a/frontend/src/features/payments/pages/dialogs/cancel-payment-dialog.tsx
+++ b/frontend/src/features/payments/pages/dialogs/cancel-payment-dialog.tsx
@@ -82,7 +82,7 @@ export function CancelPaymentDialog({
             {!canCancel && (
               <div
                 role="alert"
-                className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+                className="rounded-md border border-warning/30 bg-warning-muted px-3 py-2 text-sm text-warning-foreground"
               >
                 This payment cannot be cancelled while executing. It must wait for the gateway
                 response.

--- a/frontend/src/features/payments/pages/dialogs/reverse-payment-dialog.tsx
+++ b/frontend/src/features/payments/pages/dialogs/reverse-payment-dialog.tsx
@@ -80,7 +80,7 @@ export function ReversePaymentDialog({
             {!canReverse && (
               <div
                 role="alert"
-                className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+                className="rounded-md border border-warning/30 bg-warning-muted px-3 py-2 text-sm text-warning-foreground"
               >
                 This payment can only be reversed when completed. Current status: {currentStatus}
               </div>

--- a/frontend/src/features/positions/pages/detail.tsx
+++ b/frontend/src/features/positions/pages/detail.tsx
@@ -233,7 +233,7 @@ export function PositionDetailPage() {
             <LabeledField label="Account ID">
               {log?.accountId ? (
                 accountEntityType(log.accountServiceDomain) ? (
-                  <EntityLink type={accountEntityType(log.accountServiceDomain)!} id={log.accountId} className="font-mono text-xs text-blue-600 hover:underline dark:text-blue-400" />
+                  <EntityLink type={accountEntityType(log.accountServiceDomain)!} id={log.accountId} className="font-mono text-xs text-primary hover:underline" />
                 ) : (
                   <span className="font-mono text-xs">{log.accountId}</span>
                 )

--- a/frontend/src/features/reference-data/pages/account-types/create-account-type-dialog.tsx
+++ b/frontend/src/features/reference-data/pages/account-types/create-account-type-dialog.tsx
@@ -254,7 +254,7 @@ export function CreateAccountTypeDialog({ open, onOpenChange }: CreateAccountTyp
             {successMessage && (
               <div
                 role="status"
-                className="rounded-md border border-green-500/50 bg-green-50 px-3 py-2 text-sm text-green-800 dark:bg-green-950/30 dark:text-green-300"
+                className="rounded-md border border-success/50 bg-success-muted px-3 py-2 text-sm text-success-foreground"
               >
                 {successMessage}
               </div>

--- a/frontend/src/features/reference-data/pages/instruments/index.tsx
+++ b/frontend/src/features/reference-data/pages/instruments/index.tsx
@@ -123,7 +123,7 @@ export function InstrumentsPage() {
             <span className="text-sm">{p}</span>
             {p > 12 && (
               <span data-testid="precision-overflow-warning" title="High precision may cause display overflow">
-                <AlertTriangle className="h-3.5 w-3.5 text-yellow-500" />
+                <AlertTriangle className="h-3.5 w-3.5 text-warning" />
               </span>
             )}
           </div>
@@ -257,7 +257,7 @@ export function InstrumentsPage() {
             <div data-testid="cel-result" className="rounded border bg-muted/30 p-4 space-y-2">
               <div className="flex items-center gap-2 text-sm">
                 <span className="font-medium">Validation:</span>
-                <span className={celResult.validationResult ? 'text-green-600' : 'text-red-600'}>
+                <span className={celResult.validationResult ? 'text-success-foreground' : 'text-destructive'}>
                   {celResult.validationResult ? 'PASS' : 'FAIL'}
                 </span>
               </div>
@@ -270,12 +270,12 @@ export function InstrumentsPage() {
                 </div>
               )}
               {celResult.errorMessage && (
-                <div className="text-sm text-red-600">
+                <div className="text-sm text-destructive">
                   <span className="font-medium">Error:</span> {celResult.errorMessage}
                 </div>
               )}
               {celResult.compileErrors.length > 0 && (
-                <div className="text-sm text-red-600">
+                <div className="text-sm text-destructive">
                   <span className="font-medium">Compile Errors:</span>
                   <ul className="mt-1 list-disc list-inside">
                     {celResult.compileErrors.map((e, i) => (

--- a/frontend/src/features/reference-data/pages/instruments/register-instrument-dialog.tsx
+++ b/frontend/src/features/reference-data/pages/instruments/register-instrument-dialog.tsx
@@ -192,7 +192,7 @@ export function RegisterInstrumentDialog({ open, onOpenChange }: RegisterInstrum
             {successMessage && (
               <div
                 role="status"
-                className="rounded-md border border-green-500/50 bg-green-50 px-3 py-2 text-sm text-green-800 dark:bg-green-950/30 dark:text-green-300"
+                className="rounded-md border border-success/50 bg-success-muted px-3 py-2 text-sm text-success-foreground"
               >
                 {successMessage}
               </div>

--- a/frontend/src/features/sagas/components/starlark-editor.tsx
+++ b/frontend/src/features/sagas/components/starlark-editor.tsx
@@ -215,7 +215,7 @@ export function StarlarkEditor({
                   data-testid={`error-item-${index}`}
                   className={cn(
                     'flex w-full cursor-pointer items-start gap-2 px-3 py-1.5 text-left hover:bg-destructive/10',
-                    error.category === 'WARNING' && 'text-yellow-700 dark:text-yellow-400',
+                    error.category === 'WARNING' && 'text-warning-foreground',
                     error.category !== 'WARNING' && 'text-destructive',
                   )}
                   onClick={() => onErrorClick?.(error)}
@@ -248,10 +248,10 @@ function ComplexityMetricsPanel({ metrics }: ComplexityMetricsPanelProps) {
 
   const scoreColor =
     complexityScore <= 3
-      ? 'text-green-600 dark:text-green-400'
+      ? 'text-success-foreground'
       : complexityScore <= 6
-        ? 'text-yellow-600 dark:text-yellow-400'
-        : 'text-red-600 dark:text-red-400'
+        ? 'text-warning-foreground'
+        : 'text-destructive'
 
   return (
     <div

--- a/frontend/src/features/tenants/pages/[tenantId].tsx
+++ b/frontend/src/features/tenants/pages/[tenantId].tsx
@@ -44,13 +44,13 @@ const SERVICE_STATUS_LABEL: Record<number, string> = {
 function ServiceStatusIcon({ status }: { status: ServiceProvisioningStatus_Status }) {
   switch (status) {
     case ServiceProvisioningStatus_Status.COMPLETED:
-      return <CheckCircle2 className="size-4 text-green-600" aria-label="Completed" />
+      return <CheckCircle2 className="size-4 text-success" aria-label="Completed" />
     case ServiceProvisioningStatus_Status.IN_PROGRESS:
-      return <Loader2 className="size-4 animate-spin text-blue-600" aria-label="In Progress" />
+      return <Loader2 className="size-4 animate-spin text-info" aria-label="In Progress" />
     case ServiceProvisioningStatus_Status.FAILED:
-      return <XCircle className="size-4 text-red-600" aria-label="Failed" />
+      return <XCircle className="size-4 text-destructive" aria-label="Failed" />
     default:
-      return <Circle className="size-4 text-gray-400" aria-label="Pending" />
+      return <Circle className="size-4 text-muted-foreground" aria-label="Pending" />
   }
 }
 
@@ -72,9 +72,9 @@ function ProvisioningStatusGrid({ services }: ProvisioningStatusGridProps) {
           key={svc.serviceName}
           className={cn(
             'flex items-start gap-3 rounded-md border p-3',
-            svc.status === ServiceProvisioningStatus_Status.FAILED && 'border-red-200 bg-red-50',
-            svc.status === ServiceProvisioningStatus_Status.IN_PROGRESS && 'border-blue-200 bg-blue-50',
-            svc.status === ServiceProvisioningStatus_Status.COMPLETED && 'border-green-200 bg-green-50',
+            svc.status === ServiceProvisioningStatus_Status.FAILED && 'border-destructive/30 bg-destructive/10',
+            svc.status === ServiceProvisioningStatus_Status.IN_PROGRESS && 'border-info/30 bg-info-muted',
+            svc.status === ServiceProvisioningStatus_Status.COMPLETED && 'border-success/30 bg-success-muted',
           )}
         >
           <ServiceStatusIcon status={svc.status} />
@@ -87,7 +87,7 @@ function ProvisioningStatusGrid({ services }: ProvisioningStatusGridProps) {
               <p className="text-xs text-muted-foreground font-mono">{svc.migrationVersion}</p>
             )}
             {svc.errorMessage && (
-              <p className="mt-1 text-xs text-red-700">{svc.errorMessage}</p>
+              <p className="mt-1 text-xs text-destructive">{svc.errorMessage}</p>
             )}
           </div>
         </div>
@@ -247,9 +247,9 @@ export function TenantDetailPage() {
             </div>
           </dl>
           {tenant.errorMessage && (
-            <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-3">
-              <p className="text-sm font-medium text-red-800">Error</p>
-              <p className="text-sm text-red-700">{tenant.errorMessage}</p>
+            <div className="mt-4 rounded-md border border-destructive/30 bg-destructive/10 p-3">
+              <p className="text-sm font-medium text-destructive">Error</p>
+              <p className="text-sm text-destructive">{tenant.errorMessage}</p>
             </div>
           )}
         </CardContent>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -100,6 +100,16 @@
     --info-muted: oklch(0.95 0.04 250);
     --destructive-foreground: oklch(1 0 0);
     --overlay: oklch(0 0 0 / 50%);
+
+    /* Graph node/edge colors */
+    --graph-instrument: oklch(0.59 0.15 250);
+    --graph-account-type: oklch(0.59 0.15 145);
+    --graph-valuation-rule: oklch(0.75 0.15 85);
+    --graph-saga: oklch(0.59 0.15 295);
+    --graph-diff-added: oklch(0.59 0.15 145);
+    --graph-diff-removed: oklch(0.577 0.245 27.325);
+    --graph-diff-modified: oklch(0.75 0.15 85);
+    --graph-diff-unchanged: oklch(0.554 0.046 257.417);
 }
 
 .dark {
@@ -145,6 +155,16 @@
     --info-muted: oklch(0.25 0.06 250);
     --destructive-foreground: oklch(1 0 0);
     --overlay: oklch(0 0 0 / 60%);
+
+    /* Graph node/edge colors */
+    --graph-instrument: oklch(0.65 0.18 250);
+    --graph-account-type: oklch(0.65 0.18 145);
+    --graph-valuation-rule: oklch(0.75 0.18 85);
+    --graph-saga: oklch(0.65 0.18 295);
+    --graph-diff-added: oklch(0.65 0.18 145);
+    --graph-diff-removed: oklch(0.704 0.191 22.216);
+    --graph-diff-modified: oklch(0.75 0.18 85);
+    --graph-diff-unchanged: oklch(0.704 0.04 256.788);
 }
 
 @layer base {

--- a/frontend/src/shared/entity-link.tsx
+++ b/frontend/src/shared/entity-link.tsx
@@ -42,7 +42,7 @@ export function EntityLink({ type, id, label, className }: EntityLinkProps) {
   return (
     <Link
       to={entityPath(type, id)}
-      className={className ?? 'text-blue-600 hover:underline dark:text-blue-400'}
+      className={className ?? 'text-primary hover:underline'}
     >
       {label ?? id}
     </Link>

--- a/frontend/src/shared/time-display.tsx
+++ b/frontend/src/shared/time-display.tsx
@@ -61,7 +61,7 @@ export function TimeDisplay({
       <TooltipTrigger asChild>
         <span className="cursor-help">
           {relative}
-          <span className="text-xs text-gray-500 ml-1">({absolute} UTC)</span>
+          <span className="text-xs text-muted-foreground ml-1">({absolute} UTC)</span>
         </span>
       </TooltipTrigger>
       <TooltipContent>


### PR DESCRIPTION
## Summary
- Replace 40+ remaining hardcoded Tailwind semantic colors with design tokens across 20+ files
- Convert hex color maps in graph components to use CSS variables / token references
- Wrap manifest graph node components in React.memo with memoized styles
- Memoize remaining inline styles in saga-flow legend and service calls

## Test plan
- [ ] Toggle dark mode — all remaining status indicators, links, and feedback UI adapts
- [ ] Graph visualizations render correctly (manifest graph, diff graph, composition graph)
- [ ] Verify entity links, time displays, build info use correct foreground tokens
- [ ] Check tenant detail page renders correctly in both themes