### PR TITLE
fix: Prevent party detail tabs from overlapping

### DIFF
--- a/frontend/src/features/parties/pages/[partyId].tsx
+++ b/frontend/src/features/parties/pages/[partyId].tsx
@@ -45,7 +45,7 @@ export function PartyDetailPage() {
 
           <Card>
             <Tabs defaultValue="overview" className="w-full">
-              <TabsList className="grid w-full grid-cols-8 border-b rounded-none">
+              <TabsList variant="line" className="w-full justify-start overflow-x-auto border-b">
                 <TabsTrigger value="overview">Overview</TabsTrigger>
                 <TabsTrigger value="demographics">Demographics</TabsTrigger>
                 <TabsTrigger value="references">References</TabsTrigger>


### PR DESCRIPTION
## Summary
- Replace rigid `grid-cols-8` layout on party detail tabs with flex-based `line` variant
- Tabs now take their natural width and scroll horizontally when needed
- Fixes overlapping tab labels visible at https://volterra-energy.demo.meridianhub.cloud/parties/

## Test plan
- [ ] Party detail page tabs display without overlapping
- [ ] All 8 tabs remain clickable and correctly routed
- [ ] Tabs scroll horizontally on narrow viewports