### PR TITLE
fix: Use external URL for Dex browser redirects in MCP OAuth flow

### DIFF
--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -275,6 +275,7 @@ func runHTTP(logger *slog.Logger, cfg server.Config) error {
 				CodeStore:  codeStore,
 				Registry:   clientRegistry,
 				Signer:     signer,
+				BaseURL:    baseURL,
 				BaseDomain: baseDomain,
 				Logger:     logger,
 			})

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -186,16 +186,17 @@ func (s *OIDCStateStore) Consume(key string) (OIDCFlowState, bool) {
 
 // OIDCHandler manages the OIDC authorization flow with Dex.
 type OIDCHandler struct {
-	cfg        OIDCConfig
-	oauthCfg   OAuthConfig
-	stateStore *OIDCStateStore
-	codeStore  *CodeStore
-	registry   *ClientRegistry
-	signer     *platformauth.JWTSigner
-	tokenTTL   time.Duration
-	baseDomain string
-	httpClient *http.Client
-	logger     *slog.Logger
+	cfg            OIDCConfig
+	oauthCfg       OAuthConfig
+	stateStore     *OIDCStateStore
+	codeStore      *CodeStore
+	registry       *ClientRegistry
+	signer         *platformauth.JWTSigner
+	tokenTTL       time.Duration
+	baseDomain     string
+	dexAuthBaseURL string // External Dex base URL for browser redirects (derived from BaseURL + DexIssuerURL path).
+	httpClient     *http.Client
+	logger         *slog.Logger
 }
 
 // OIDCHandlerConfig holds configuration for creating an OIDCHandler.
@@ -207,6 +208,10 @@ type OIDCHandlerConfig struct {
 	Registry   *ClientRegistry
 	Signer     *platformauth.JWTSigner
 	TokenTTL   time.Duration
+	// BaseURL is the public-facing base URL of the MCP server
+	// (e.g., "https://demo.meridianhub.cloud"). Used to construct browser-facing
+	// Dex redirect URLs when DexIssuerURL is an internal Docker hostname.
+	BaseURL    string
 	BaseDomain string
 	HTTPClient *http.Client
 	Logger     *slog.Logger
@@ -252,6 +257,8 @@ func NewOIDCHandler(cfg OIDCHandlerConfig) (*OIDCHandler, error) {
 			"issuer_url", cfg.OIDC.DexIssuerURL)
 	}
 
+	dexAuthBaseURL := resolveDexAuthBaseURL(cfg.BaseURL, issuerURL, cfg.OIDC.DexIssuerURL, cfg.Logger)
+
 	ttl := cfg.TokenTTL
 	if ttl == 0 {
 		ttl = defaultTokenTTL
@@ -262,17 +269,40 @@ func NewOIDCHandler(cfg OIDCHandlerConfig) (*OIDCHandler, error) {
 	}
 
 	return &OIDCHandler{
-		cfg:        cfg.OIDC,
-		oauthCfg:   cfg.OAuth,
-		stateStore: cfg.StateStore,
-		codeStore:  cfg.CodeStore,
-		registry:   cfg.Registry,
-		signer:     cfg.Signer,
-		tokenTTL:   ttl,
-		baseDomain: cfg.BaseDomain,
-		httpClient: httpClient,
-		logger:     cfg.Logger,
+		cfg:            cfg.OIDC,
+		oauthCfg:       cfg.OAuth,
+		stateStore:     cfg.StateStore,
+		codeStore:      cfg.CodeStore,
+		registry:       cfg.Registry,
+		signer:         cfg.Signer,
+		tokenTTL:       ttl,
+		baseDomain:     cfg.BaseDomain,
+		dexAuthBaseURL: dexAuthBaseURL,
+		httpClient:     httpClient,
+		logger:         cfg.Logger,
 	}, nil
+}
+
+// resolveDexAuthBaseURL computes the browser-facing Dex base URL. When
+// DexIssuerURL is an internal hostname (e.g., http://dex:5556/dex), browsers
+// can't reach it. If publicBaseURL is set, we combine its scheme+host with
+// the path from the internal issuer URL so the browser is redirected to the
+// external reverse proxy instead.
+func resolveDexAuthBaseURL(publicBaseURL string, issuerURL *url.URL, dexIssuerURL string, logger *slog.Logger) string {
+	if publicBaseURL == "" {
+		return dexIssuerURL
+	}
+	parsed, err := url.Parse(publicBaseURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return dexIssuerURL
+	}
+	external := *parsed
+	external.Path = issuerURL.Path
+	result := external.String()
+	logger.Info("oidc: using external Dex URL for browser redirects",
+		"dex_auth_base_url", result,
+		"dex_internal_url", dexIssuerURL)
+	return result
 }
 
 // HandleAuthorize handles GET /oauth/authorize from the MCP client.
@@ -370,10 +400,10 @@ func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Redirect to Dex authorization endpoint.
-	// Use the "local" connector for password-based auth, or omit connector_id
-	// to let Dex show its connector selection page.
-	dexAuthURL := h.cfg.DexIssuerURL + "/auth"
+	// Redirect to Dex authorization endpoint via the external URL so the
+	// browser can reach Dex through the reverse proxy, even when the internal
+	// DexIssuerURL points to a Docker-internal hostname.
+	dexAuthURL := h.dexAuthBaseURL + "/auth"
 	params := url.Values{
 		"client_id":             {h.cfg.ClientID},
 		"redirect_uri":          {h.cfg.CallbackURL},

--- a/services/mcp-server/internal/auth/oidc_test.go
+++ b/services/mcp-server/internal/auth/oidc_test.go
@@ -764,6 +764,58 @@ func TestNewOIDCHandler_MissingConfig(t *testing.T) {
 	}
 }
 
+func TestOIDCHandler_Authorize_UsesExternalDexURL(t *testing.T) {
+	// When BaseURL is set and DexIssuerURL points to an internal Docker hostname,
+	// the browser redirect should use the external URL, not the internal one.
+	dexSrv := fakeDexServer(t, "user@example.com")
+	signer := newTestSigner(t)
+
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex", // Internal: http://127.0.0.1:PORT/dex
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID:    "meridian-mcp",
+			RedirectURI: "https://claude.ai/callback",
+		},
+		BaseURL:    "https://demo.meridianhub.cloud",
+		StateStore: newTestOIDCStateStore(t),
+		CodeStore:  newTestStore(t),
+		Signer:     signer,
+		BaseDomain: "demo.meridianhub.cloud",
+		Logger:     slog.Default(),
+	})
+	require.NoError(t, err)
+
+	_, challenge := generatePKCEPair(t)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"meridian-mcp"},
+		"redirect_uri":          {"https://claude.ai/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"client-state-123"},
+	}.Encode(), nil)
+	req.Host = "acme.demo.meridianhub.cloud"
+	w := httptest.NewRecorder()
+	handler.HandleAuthorize(w, req)
+
+	resp := w.Result()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	location := resp.Header.Get("Location")
+	redirectURL, err := url.Parse(location)
+	require.NoError(t, err)
+
+	// The redirect should go to the external host, not the internal test server.
+	assert.Equal(t, "demo.meridianhub.cloud", redirectURL.Host)
+	assert.Equal(t, "https", redirectURL.Scheme)
+	assert.Equal(t, "/dex/auth", redirectURL.Path)
+}
+
 func TestOIDCHandler_Authorize_RejectsStaticClientEvilRedirect(t *testing.T) {
 	dexSrv := fakeDexServer(t, "user@example.com")
 	signer := newTestSigner(t)


### PR DESCRIPTION
## Summary

- When `MCP_DEX_ISSUER_URL` points to an internal Docker hostname (e.g., `http://dex:5556/dex`), the MCP OAuth authorize endpoint redirects the browser to that internal URL, which is unreachable
- Derive the browser-facing Dex URL from the MCP server's public `BaseURL` (scheme+host) combined with the path from `DexIssuerURL`
- Server-to-server token exchange continues using the internal URL for direct Docker network access

## Changes

- Add `BaseURL` field to `OIDCHandlerConfig` and `dexAuthBaseURL` field to `OIDCHandler`
- Extract `resolveDexAuthBaseURL()` helper to compute the external URL (also reduces cyclomatic complexity of `NewOIDCHandler`)
- Browser redirect in `HandleAuthorize` now uses `dexAuthBaseURL` instead of `DexIssuerURL`
- Token exchange in `exchangeDexCode` still uses internal `DexIssuerURL`

## Test plan

- [x] New test `TestOIDCHandler_Authorize_UsesExternalDexURL` verifies redirect goes to external host
- [x] All existing auth tests pass
- [ ] Deploy to demo and verify MCP OAuth flow completes end-to-end