### PR TITLE
Add Codecov configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: ./coverage/coverage.out
+          files: ./coverage/coverage-filtered.out
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Nightly](https://github.com/meridianhub/meridian/actions/workflows/nightly.yml/badge.svg)](https://github.com/meridianhub/meridian/actions/workflows/nightly.yml)
 [![Code Quality](https://github.com/meridianhub/meridian/actions/workflows/quality.yml/badge.svg?branch=develop)](https://github.com/meridianhub/meridian/actions/workflows/quality.yml?query=branch%3Adevelop)
 [![Security Scanning](https://github.com/meridianhub/meridian/actions/workflows/security.yml/badge.svg?branch=develop)](https://github.com/meridianhub/meridian/actions/workflows/security.yml?query=branch%3Adevelop)
+[![codecov](https://codecov.io/gh/meridianhub/meridian/branch/develop/graph/badge.svg)](https://codecov.io/gh/meridianhub/meridian)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/meridianhub/meridian)](https://go.dev/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 50%
+        threshold: 2%
+    patch:
+      default:
+        target: 60%
+
+ignore:
+  - "**/*.pb.go"
+  - "**/*.pb.validate.go"
+  - "**/*_grpc.pb.go"
+  - "**/mocks/**"
+  - "utilities/**"
+  - "frontend/**"
+
+comment:
+  layout: "condensed_header, condensed_files, condensed_footer"
+  behavior: default
+  require_changes: true
+
+flags:
+  unittests:
+    paths:
+      - "services/"
+      - "shared/"
+    carryforward: true


### PR DESCRIPTION
## Summary

- Adds `codecov.yml` with project coverage target (50%), patch coverage target (60%), and condensed PR comments
- Ignores generated proto files, mocks, utilities, and frontend from coverage reporting
- Switches Codecov upload to use filtered coverage profile (excluding `.pb.go` files) so Codecov numbers match CI threshold checks

## Test plan

- [ ] Verify Codecov bot posts coverage summary on this PR after CI runs
- [ ] Check https://app.codecov.io/gh/meridianhub/meridian shows coverage data