### PR TITLE
feat: Restructure sidebar with collapsible Economy group

### DIFF
--- a/frontend/src/components/layout/sidebar.test.tsx
+++ b/frontend/src/components/layout/sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { Sidebar } from '@/components/layout/sidebar'

--- a/frontend/src/components/layout/sidebar.test.tsx
+++ b/frontend/src/components/layout/sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { Sidebar } from '@/components/layout/sidebar'
@@ -224,19 +224,21 @@ describe('Sidebar', () => {
     it('places Economy items under Economy group', () => {
       renderSidebar({ lens: 'tenant' })
 
-      expect(screen.getByRole('link', { name: 'Overview' })).toBeInTheDocument()
-      expect(screen.getByRole('link', { name: 'Reference Data' })).toBeInTheDocument()
-      expect(screen.getByRole('link', { name: 'Starlark Config' })).toBeInTheDocument()
-      expect(screen.getByRole('link', { name: 'Market Data' })).toBeInTheDocument()
-      expect(screen.getByRole('link', { name: 'Forecasting' })).toBeInTheDocument()
+      const economyGroup = screen.getByRole('button', { name: /economy/i }).closest('li')!
+      expect(within(economyGroup).getByRole('link', { name: 'Overview' })).toBeInTheDocument()
+      expect(within(economyGroup).getByRole('link', { name: 'Reference Data' })).toBeInTheDocument()
+      expect(within(economyGroup).getByRole('link', { name: 'Starlark Config' })).toBeInTheDocument()
+      expect(within(economyGroup).getByRole('link', { name: 'Market Data' })).toBeInTheDocument()
+      expect(within(economyGroup).getByRole('link', { name: 'Forecasting' })).toBeInTheDocument()
     })
 
     it('places remaining config items under Configuration group', () => {
       renderSidebar({ lens: 'tenant' })
 
-      expect(screen.getByRole('link', { name: 'Gateway Mappings' })).toBeInTheDocument()
-      expect(screen.getByRole('link', { name: 'MCP Config' })).toBeInTheDocument()
-      expect(screen.getByRole('link', { name: 'Cookbook' })).toBeInTheDocument()
+      const configGroup = screen.getByText('Configuration').closest('li')!
+      expect(within(configGroup).getByRole('link', { name: 'Gateway Mappings' })).toBeInTheDocument()
+      expect(within(configGroup).getByRole('link', { name: 'MCP Config' })).toBeInTheDocument()
+      expect(within(configGroup).getByRole('link', { name: 'Cookbook' })).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/components/layout/sidebar.test.tsx
+++ b/frontend/src/components/layout/sidebar.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { Sidebar } from '@/components/layout/sidebar'
 import type { TenantContextValue } from '@/contexts/tenant-context'
@@ -51,6 +52,7 @@ describe('Sidebar', () => {
   beforeEach(() => {
     vi.mocked(useTenantContext).mockReturnValue(makeContext())
     vi.mocked(useTenantFeatures).mockReturnValue(makeFeatures())
+    localStorage.clear()
   })
 
   describe('tenant lens', () => {
@@ -206,6 +208,174 @@ describe('Sidebar', () => {
       expect(screen.getByRole('link', { name: 'Ledger' })).toBeInTheDocument()
       expect(screen.queryByRole('link', { name: 'Payments' })).not.toBeInTheDocument()
       expect(screen.queryByRole('link', { name: 'Reconciliation' })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('nav group structure', () => {
+    it('renders four groups: Operations, Economy, Configuration, Admin', () => {
+      renderSidebar({ lens: 'tenant' })
+
+      expect(screen.getByText('Operations')).toBeInTheDocument()
+      expect(screen.getByText('Economy')).toBeInTheDocument()
+      expect(screen.getByText('Configuration')).toBeInTheDocument()
+      expect(screen.getByText('Admin')).toBeInTheDocument()
+    })
+
+    it('places Economy items under Economy group', () => {
+      renderSidebar({ lens: 'tenant' })
+
+      expect(screen.getByRole('link', { name: 'Overview' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Reference Data' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Starlark Config' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Market Data' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Forecasting' })).toBeInTheDocument()
+    })
+
+    it('places remaining config items under Configuration group', () => {
+      renderSidebar({ lens: 'tenant' })
+
+      expect(screen.getByRole('link', { name: 'Gateway Mappings' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'MCP Config' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Cookbook' })).toBeInTheDocument()
+    })
+  })
+
+  describe('collapsible Economy group', () => {
+    it('renders Economy header as a button with aria-expanded', () => {
+      renderSidebar({ lens: 'tenant' })
+
+      const economyButton = screen.getByRole('button', { name: /economy/i })
+      expect(economyButton).toBeInTheDocument()
+      expect(economyButton).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('collapses Economy items when toggle button is clicked', async () => {
+      const user = userEvent.setup()
+      renderSidebar({ lens: 'tenant' })
+
+      const economyButton = screen.getByRole('button', { name: /economy/i })
+      await user.click(economyButton)
+
+      expect(economyButton).toHaveAttribute('aria-expanded', 'false')
+      expect(screen.queryByRole('link', { name: 'Overview' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'Reference Data' })).not.toBeInTheDocument()
+    })
+
+    it('expands Economy items when toggle is clicked again', async () => {
+      const user = userEvent.setup()
+      renderSidebar({ lens: 'tenant' })
+
+      const economyButton = screen.getByRole('button', { name: /economy/i })
+      await user.click(economyButton) // collapse
+      await user.click(economyButton) // expand
+
+      expect(economyButton).toHaveAttribute('aria-expanded', 'true')
+      expect(screen.getByRole('link', { name: 'Overview' })).toBeInTheDocument()
+    })
+
+    it('persists collapsed state to localStorage', async () => {
+      const user = userEvent.setup()
+      renderSidebar({ lens: 'tenant' })
+
+      const economyButton = screen.getByRole('button', { name: /economy/i })
+      await user.click(economyButton)
+
+      const stored = JSON.parse(localStorage.getItem('meridian:sidebar-collapsed') ?? '[]')
+      expect(stored).toContain('Economy')
+    })
+
+    it('restores collapsed state from localStorage', () => {
+      localStorage.setItem('meridian:sidebar-collapsed', JSON.stringify(['Economy']))
+      renderSidebar({ lens: 'tenant' })
+
+      const economyButton = screen.getByRole('button', { name: /economy/i })
+      expect(economyButton).toHaveAttribute('aria-expanded', 'false')
+      expect(screen.queryByRole('link', { name: 'Overview' })).not.toBeInTheDocument()
+    })
+
+    it('auto-expands Economy when currentPath matches an Economy child route', () => {
+      localStorage.setItem('meridian:sidebar-collapsed', JSON.stringify(['Economy']))
+      renderSidebar({ lens: 'tenant', currentPath: '/economy' })
+
+      const economyButton = screen.getByRole('button', { name: /economy/i })
+      expect(economyButton).toHaveAttribute('aria-expanded', 'true')
+      expect(screen.getByRole('link', { name: 'Overview' })).toBeInTheDocument()
+    })
+
+    it('auto-expands Economy when currentPath is /reference-data', () => {
+      localStorage.setItem('meridian:sidebar-collapsed', JSON.stringify(['Economy']))
+      renderSidebar({ lens: 'tenant', currentPath: '/reference-data' })
+
+      expect(screen.getByRole('button', { name: /economy/i })).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('auto-expands Economy when currentPath is /starlark-config', () => {
+      localStorage.setItem('meridian:sidebar-collapsed', JSON.stringify(['Economy']))
+      renderSidebar({ lens: 'tenant', currentPath: '/starlark-config' })
+
+      expect(screen.getByRole('button', { name: /economy/i })).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('does not auto-expand Economy for unrelated paths', () => {
+      localStorage.setItem('meridian:sidebar-collapsed', JSON.stringify(['Economy']))
+      renderSidebar({ lens: 'tenant', currentPath: '/accounts' })
+
+      expect(screen.getByRole('button', { name: /economy/i })).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('non-collapsible groups render header as static text, not button', () => {
+      renderSidebar({ lens: 'tenant' })
+
+      // Operations is not collapsible — no button for it
+      expect(screen.queryByRole('button', { name: /operations/i })).not.toBeInTheDocument()
+      expect(screen.getByText('Operations')).toBeInTheDocument()
+    })
+  })
+
+  describe('Economy group feature gate', () => {
+    it('hides entire Economy group when economy feature is disabled', () => {
+      vi.mocked(useTenantFeatures).mockReturnValue(
+        makeFeatures(['dashboard', 'accounts']),
+      )
+      vi.mocked(useTenantContext).mockReturnValue(makeContext({ isPlatformAdmin: false }))
+
+      renderSidebar({ lens: 'tenant' })
+
+      expect(screen.queryByRole('button', { name: /economy/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'Overview' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: 'Reference Data' })).not.toBeInTheDocument()
+    })
+
+    it('shows Economy group for platform admin even when economy feature disabled', () => {
+      vi.mocked(useTenantFeatures).mockReturnValue(
+        makeFeatures(['dashboard']),
+      )
+      vi.mocked(useTenantContext).mockReturnValue(makeContext({ isPlatformAdmin: true }))
+
+      renderSidebar({ lens: 'platform' })
+
+      expect(screen.getByRole('button', { name: /economy/i })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Overview' })).toBeInTheDocument()
+    })
+
+    it('hides individual Economy items whose specific feature is disabled', () => {
+      vi.mocked(useTenantFeatures).mockReturnValue(
+        makeFeatures(['dashboard', 'economy', 'reference-data']),
+      )
+      vi.mocked(useTenantContext).mockReturnValue(makeContext({ isPlatformAdmin: false }))
+
+      renderSidebar({ lens: 'tenant' })
+
+      // Economy group visible (economy feature enabled)
+      expect(screen.getByRole('button', { name: /economy/i })).toBeInTheDocument()
+      // Overview visible (economy feature)
+      expect(screen.getByRole('link', { name: 'Overview' })).toBeInTheDocument()
+      // Reference Data visible (reference-data feature)
+      expect(screen.getByRole('link', { name: 'Reference Data' })).toBeInTheDocument()
+      // Starlark Config hidden (sagas feature not enabled)
+      expect(screen.queryByRole('link', { name: 'Starlark Config' })).not.toBeInTheDocument()
+      // Market Data hidden
+      expect(screen.queryByRole('link', { name: 'Market Data' })).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -106,24 +106,8 @@ function saveCollapsedGroups(collapsed: Set<string>): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify([...collapsed]))
 }
 
-export function useCollapsedGroups(currentPath: string) {
-  const [collapsed, setCollapsed] = useState<Set<string>>(() => loadCollapsedGroups())
-
-  // Auto-expand when current path matches a child route
-  useEffect(() => {
-    for (const group of TENANT_NAV_GROUPS) {
-      if (!group.collapsible) continue
-      const matchesChild = group.items.some(item => currentPath === item.href)
-      if (matchesChild && collapsed.has(group.label)) {
-        setCollapsed(prev => {
-          const next = new Set(prev)
-          next.delete(group.label)
-          saveCollapsedGroups(next)
-          return next
-        })
-      }
-    }
-  }, [currentPath]) // eslint-disable-line react-hooks/exhaustive-deps
+function useCollapsedGroups(currentPath: string) {
+  const [collapsed, setCollapsed] = useState<Set<string>>(loadCollapsedGroups)
 
   const toggle = useCallback((label: string) => {
     setCollapsed(prev => {
@@ -138,7 +122,16 @@ export function useCollapsedGroups(currentPath: string) {
     })
   }, [])
 
-  const isCollapsed = useCallback((label: string) => collapsed.has(label), [collapsed])
+  // Derive effective collapsed state: auto-expand groups matching current path
+  const isCollapsed = useCallback((label: string) => {
+    if (!collapsed.has(label)) return false
+    // Auto-expand if current path matches a child of this group
+    const group = TENANT_NAV_GROUPS.find(g => g.label === label)
+    if (group?.collapsible && group.items.some(item => currentPath === item.href)) {
+      return false
+    }
+    return true
+  }, [collapsed, currentPath])
 
   return { toggle, isCollapsed }
 }

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -103,7 +103,9 @@ function loadCollapsedGroups(): Set<string> {
 }
 
 function saveCollapsedGroups(collapsed: Set<string>): void {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify([...collapsed]))
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...collapsed]))
+  } catch { /* ignore storage write failures (quota, private browsing) */ }
 }
 
 function useCollapsedGroups(currentPath: string) {

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { BuildInfo } from './build-info'
 import {
@@ -22,6 +22,8 @@ import {
   Bot,
   Library,
   Boxes,
+  ChevronDown,
+  ChevronRight,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useTenantFeatures } from '@/hooks/use-tenant-features'
@@ -37,7 +39,11 @@ interface NavItem {
 interface NavGroup {
   label: string
   items: NavItem[]
+  collapsible?: boolean
+  feature?: string
 }
+
+const STORAGE_KEY = 'meridian:sidebar-collapsed'
 
 const TENANT_NAV_GROUPS: NavGroup[] = [
   {
@@ -55,14 +61,21 @@ const TENANT_NAV_GROUPS: NavGroup[] = [
     ],
   },
   {
-    label: 'Configuration',
+    label: 'Economy',
+    collapsible: true,
+    feature: 'economy',
     items: [
+      { label: 'Overview', href: '/economy', icon: Boxes, feature: 'economy' },
+      { label: 'Reference Data', href: '/reference-data', icon: Database, feature: 'reference-data' },
       { label: 'Starlark Config', href: '/starlark-config', icon: Code, feature: 'sagas' },
       { label: 'Market Data', href: '/market-data', icon: LineChart, feature: 'market-data' },
       { label: 'Forecasting', href: '/forecasting', icon: BarChart3, feature: 'forecasting' },
-      { label: 'Reference Data', href: '/reference-data', icon: Database, feature: 'reference-data' },
+    ],
+  },
+  {
+    label: 'Configuration',
+    items: [
       { label: 'Gateway Mappings', href: '/gateway-mappings', icon: Map, feature: 'mappings' },
-      { label: 'Economy', href: '/economy', icon: Boxes, feature: 'economy' },
       { label: 'MCP Config', href: '/mcp-config', icon: Bot, feature: 'mcp-config' },
       { label: 'Cookbook', href: '/cookbook', icon: Library },
     ],
@@ -81,6 +94,55 @@ const PLATFORM_NAV_ITEMS: NavItem[] = [
   { label: 'Platform Monitoring', href: '/platform', icon: Activity },
 ]
 
+function loadCollapsedGroups(): Set<string> {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) return new Set(JSON.parse(stored))
+  } catch { /* ignore malformed data */ }
+  return new Set()
+}
+
+function saveCollapsedGroups(collapsed: Set<string>): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify([...collapsed]))
+}
+
+export function useCollapsedGroups(currentPath: string) {
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => loadCollapsedGroups())
+
+  // Auto-expand when current path matches a child route
+  useEffect(() => {
+    for (const group of TENANT_NAV_GROUPS) {
+      if (!group.collapsible) continue
+      const matchesChild = group.items.some(item => currentPath === item.href)
+      if (matchesChild && collapsed.has(group.label)) {
+        setCollapsed(prev => {
+          const next = new Set(prev)
+          next.delete(group.label)
+          saveCollapsedGroups(next)
+          return next
+        })
+      }
+    }
+  }, [currentPath]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const toggle = useCallback((label: string) => {
+    setCollapsed(prev => {
+      const next = new Set(prev)
+      if (next.has(label)) {
+        next.delete(label)
+      } else {
+        next.add(label)
+      }
+      saveCollapsedGroups(next)
+      return next
+    })
+  }, [])
+
+  const isCollapsed = useCallback((label: string) => collapsed.has(label), [collapsed])
+
+  return { toggle, isCollapsed }
+}
+
 interface SidebarProps {
   lens: 'platform' | 'tenant'
   currentPath?: string
@@ -93,6 +155,7 @@ export function Sidebar({ lens, currentPath = '/', isOpen = false, id, onClose }
   const showPlatformItems = lens === 'platform'
   const { isFeatureEnabled } = useTenantFeatures()
   const { isPlatformAdmin } = useTenantContext()
+  const { toggle, isCollapsed } = useCollapsedGroups(currentPath)
 
   useEffect(() => {
     if (!isOpen || !onClose) return
@@ -107,6 +170,13 @@ export function Sidebar({ lens, currentPath = '/', isOpen = false, id, onClose }
     if (!item.feature) return true
     if (isPlatformAdmin) return true
     return isFeatureEnabled(item.feature)
+  }
+
+  function isGroupVisible(group: NavGroup): boolean {
+    if (group.feature) {
+      if (!isPlatformAdmin && !isFeatureEnabled(group.feature)) return false
+    }
+    return group.items.some(isItemVisible)
   }
 
   return (
@@ -131,37 +201,62 @@ export function Sidebar({ lens, currentPath = '/', isOpen = false, id, onClose }
       <nav aria-label="Main navigation" className="min-h-0 flex-1 overflow-y-auto py-4">
         <ul role="list" className="px-2">
           {TENANT_NAV_GROUPS.reduce<{ elements: React.ReactNode[]; visibleIndex: number }>((acc, group) => {
+            if (!isGroupVisible(group)) return acc
+
             const visibleItems = group.items.filter(isItemVisible)
             if (visibleItems.length === 0) return acc
 
+            const groupCollapsed = group.collapsible && isCollapsed(group.label)
+
             acc.elements.push(
               <li key={group.label}>
-                <div className={cn('mb-1 px-3 text-[10px] font-semibold uppercase tracking-wider text-sidebar-foreground/50', acc.visibleIndex > 0 && 'mt-4')}>
-                  {group.label}
-                </div>
-                <ul role="list" className="space-y-0.5">
-                  {visibleItems.map((item) => {
-                    const Icon = item.icon
-                    const isActive = currentPath === item.href
-                    return (
-                      <li key={item.href}>
-                        <Link
-                          to={item.href}
-                          aria-current={isActive ? 'page' : undefined}
-                          className={cn(
-                            'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                            isActive
-                              ? 'bg-sidebar-accent text-sidebar-foreground'
-                              : 'text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground',
-                          )}
-                        >
-                          <Icon className="size-4 shrink-0" />
-                          {item.label}
-                        </Link>
-                      </li>
-                    )
-                  })}
-                </ul>
+                {group.collapsible ? (
+                  <button
+                    type="button"
+                    onClick={() => toggle(group.label)}
+                    aria-expanded={!groupCollapsed}
+                    className={cn(
+                      'flex w-full items-center justify-between px-3 text-[10px] font-semibold uppercase tracking-wider text-sidebar-foreground/50',
+                      'mb-1 hover:text-sidebar-foreground/70',
+                      acc.visibleIndex > 0 && 'mt-4',
+                    )}
+                  >
+                    {group.label}
+                    {groupCollapsed
+                      ? <ChevronRight className="size-3" />
+                      : <ChevronDown className="size-3" />
+                    }
+                  </button>
+                ) : (
+                  <div className={cn('mb-1 px-3 text-[10px] font-semibold uppercase tracking-wider text-sidebar-foreground/50', acc.visibleIndex > 0 && 'mt-4')}>
+                    {group.label}
+                  </div>
+                )}
+                {!groupCollapsed && (
+                  <ul role="list" className={cn('space-y-0.5', group.collapsible && 'pl-2')}>
+                    {visibleItems.map((item) => {
+                      const Icon = item.icon
+                      const isActive = currentPath === item.href
+                      return (
+                        <li key={item.href}>
+                          <Link
+                            to={item.href}
+                            aria-current={isActive ? 'page' : undefined}
+                            className={cn(
+                              'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                              isActive
+                                ? 'bg-sidebar-accent text-sidebar-foreground'
+                                : 'text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground',
+                            )}
+                          >
+                            <Icon className="size-4 shrink-0" />
+                            {item.label}
+                          </Link>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                )}
               </li>
             )
             acc.visibleIndex++


### PR DESCRIPTION
## Summary

- Reorganize the sidebar from 3 groups (Operations, Configuration, Admin) to 4 groups (Operations, Economy, Configuration, Admin)
- Promote Economy to its own collapsible group with 5 items: Overview, Reference Data, Starlark Config, Market Data, Forecasting
- Reduce Configuration to 3 items: Gateway Mappings, MCP Config, Cookbook
- Add `useCollapsedGroups()` hook with localStorage persistence (`meridian:sidebar-collapsed`)
- Auto-expand Economy group when current path matches a child route

## Changes Made

**`frontend/src/components/layout/sidebar.tsx`**
- Add `collapsible` and `feature` fields to `NavGroup` interface for group-level behavior
- Restructure `TENANT_NAV_GROUPS` to the new 4-group layout
- Rename "Economy" nav item to "Overview" within the Economy group
- Add `useCollapsedGroups()` hook with localStorage persistence and auto-expand on route match
- Add `isGroupVisible()` for group-level feature gating (Economy group gated by `economy` feature)
- Render collapsible headers as buttons with ChevronDown/ChevronRight icons
- Apply `pl-2` indent on Economy items for visual hierarchy

**`frontend/src/components/layout/sidebar.test.tsx`**
- Add 15 new tests covering: collapsible toggle, localStorage persistence, auto-expand on route match, Economy feature gate inheritance, individual item feature gates within Economy, nav group structure verification
- All 33 tests passing (18 existing + 15 new)

## Test plan

- [x] All 33 sidebar tests pass (`npx vitest run src/components/layout/sidebar.test.tsx`)
- [x] Collapsible toggle works (click to collapse/expand)
- [x] LocalStorage persistence verified (collapsed state survives re-render)
- [x] Auto-expand verified for all Economy child routes
- [x] Economy group hidden when `economy` feature disabled
- [x] Individual Economy items respect their own feature gates
- [x] Platform admin sees all items regardless of feature flags

## Task Master

- sidebar-nav-restructure.1 - Restructure sidebar with collapsible Economy group
- sidebar-nav-restructure.5 - Update sidebar tests