### PR TITLE
fix: Navigate Valuation Rules stat chip to /reference-data/valuation-rules

### DIFF
--- a/frontend/src/features/economy/pages/economy-overview-page.test.tsx
+++ b/frontend/src/features/economy/pages/economy-overview-page.test.tsx
@@ -238,6 +238,18 @@ describe('EconomyOverviewPage', () => {
     expect(statsBar.querySelector('[data-testid="stat-instruments"]')).toBeInTheDocument()
   })
 
+  it('clicking Valuation Rules stat chip navigates to /reference-data/valuation-rules', async () => {
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('stat-valuation-rules')).toBeInTheDocument()
+    })
+
+    const chip = screen.getByTestId('stat-valuation-rules').closest('button')!
+    await userEvent.click(chip)
+    expect(mockNavigate).toHaveBeenCalledWith('/reference-data/valuation-rules')
+  })
+
   it('stat cards are clickable buttons', async () => {
     renderPage()
 

--- a/frontend/src/features/economy/pages/economy-overview-page.tsx
+++ b/frontend/src/features/economy/pages/economy-overview-page.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { ConnectError, Code } from '@connectrpc/connect'
@@ -94,10 +93,6 @@ export function EconomyOverviewPage() {
     queryFn: () => manifestHistory.getCurrentManifest({}),
   })
 
-  const scrollToGraph = useCallback(() => {
-    document.getElementById('relationship-graph')?.scrollIntoView({ behavior: 'smooth' })
-  }, [])
-
   const isNotFound = error instanceof ConnectError && error.code === Code.NotFound
 
   const content = (() => {
@@ -149,7 +144,7 @@ export function EconomyOverviewPage() {
         <StatChip label="Instruments" value={instruments.length} testId="stat-instruments" onClick={() => navigate('/reference-data/instruments')} />
         <StatChip label="Account Types" value={accountTypes.length} testId="stat-account-types" onClick={() => navigate('/reference-data/account-types')} />
         <StatChip label="Sagas" value={sagas.length} testId="stat-sagas" onClick={() => navigate('/starlark-config')} />
-        <StatChip label="Valuation Rules" value={valuationRules.length} testId="stat-valuation-rules" onClick={scrollToGraph} />
+        <StatChip label="Valuation Rules" value={valuationRules.length} testId="stat-valuation-rules" onClick={() => navigate('/reference-data/valuation-rules')} />
       </div>
 
       {/* Relationship graph */}


### PR DESCRIPTION
## Summary

- Replace `scrollToGraph` scroll behavior on the Valuation Rules stat chip with navigation to `/reference-data/valuation-rules`
- Remove unused `scrollToGraph` callback and `useCallback` import
- All four stat chips now consistently navigate to dedicated list pages

## Changes Made

**`frontend/src/features/economy/pages/economy-overview-page.tsx`**
- Removed `useCallback` import (no longer used)
- Removed `scrollToGraph` callback
- Updated Valuation Rules `StatChip` `onClick` to `() => navigate('/reference-data/valuation-rules')`

**`frontend/src/features/economy/pages/economy-overview-page.test.tsx`**
- Added test: clicking Valuation Rules stat chip navigates to `/reference-data/valuation-rules`

## Testing

All 17 tests passing (`npx vitest run src/features/economy/pages/economy-overview-page.test.tsx`).