### PR TITLE
Upload nightly and frontend coverage to Codecov

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -56,10 +56,21 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-report
+          name: frontend-coverage-report
           path: frontend/coverage/
           retention-days: 7
           if-no-files-found: ignore
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./frontend/coverage/coverage-final.json
+          flags: frontend
+          name: frontend-vitest
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Check 80% line coverage threshold
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -125,11 +125,30 @@ jobs:
       run: |
         # Run WITHOUT -short flag to include all timing-sensitive tests
         # Regular CI runs with -short, but nightly runs the full suite
+        mkdir -p coverage
         echo "Running full test suite including timing-sensitive tests..."
         gotestsum --format testdox \
           --junitfile test-results.xml \
           --jsonfile test-results.json \
-          -- -race -timeout 15m ./...
+          -- -race -coverprofile=coverage/coverage.out -covermode=atomic -timeout 15m ./...
+
+    - name: Filter generated files from coverage
+      if: always()
+      run: |
+        if [ -f coverage/coverage.out ]; then
+          grep -v -E '\.pb\.go|\.pb\.validate\.go|_grpc\.pb\.go' coverage/coverage.out > coverage/coverage-filtered.out || true
+        fi
+
+    - name: Upload coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@v5
+      with:
+        files: ./coverage/coverage-filtered.out
+        flags: integration
+        name: nightly-full-suite
+        fail_ci_if_error: false
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload test results
       uses: actions/upload-artifact@v7

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,7 +14,7 @@ ignore:
   - "**/*_grpc.pb.go"
   - "**/mocks/**"
   - "utilities/**"
-  - "frontend/**"
+  - "frontend/src/api/gen/**"
 
 comment:
   layout: "condensed_header, condensed_files, condensed_footer"
@@ -26,4 +26,13 @@ flags:
     paths:
       - "services/"
       - "shared/"
+    carryforward: true
+  integration:
+    paths:
+      - "services/"
+      - "shared/"
+    carryforward: true
+  frontend:
+    paths:
+      - "frontend/src/"
     carryforward: true


### PR DESCRIPTION
## Summary

- **Nightly workflow**: Add `-coverprofile` to the full test suite (runs without `-short`), filter generated proto files, upload to Codecov with `integration` flag
- **Frontend workflow**: Upload Vitest `coverage-final.json` to Codecov with `frontend` flag
- **codecov.yml**: Add `integration` and `frontend` flag definitions, stop ignoring all of `frontend/` (only ignore generated `api/gen/`)

After this, Codecov will show three coverage sources:

| Flag | Source | Frequency |
|------|--------|-----------|
| `unittests` | Go unit tests (`-short`) | Every push/PR |
| `frontend` | Vitest unit tests | Every push/PR touching frontend |
| `integration` | Go full suite (no `-short`) | Nightly |

## Test plan

- [ ] Trigger nightly workflow manually (`workflow_dispatch`) and verify Codecov receives `integration` flag upload
- [ ] Push a frontend change and verify Codecov receives `frontend` flag upload
- [ ] Check Codecov flags page shows all three sources