### PR TITLE
fix: Add focus trap to mobile sidebar for keyboard accessibility

### DIFF
--- a/frontend/src/components/layout/sidebar.test.tsx
+++ b/frontend/src/components/layout/sidebar.test.tsx
@@ -147,6 +147,95 @@ describe('Sidebar', () => {
     })
   })
 
+  describe('mobile focus trap', () => {
+    it('moves focus into sidebar when opened on mobile', async () => {
+      const onClose = vi.fn()
+      renderSidebar({ lens: 'tenant', isOpen: true, onClose })
+
+      // Focus should be inside the sidebar (complementary landmark)
+      const sidebar = screen.getByRole('complementary')
+      expect(sidebar.contains(document.activeElement)).toBe(true)
+    })
+
+    it('Tab key wraps from last focusable to first within sidebar', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      renderSidebar({ lens: 'tenant', isOpen: true, onClose })
+
+      const sidebar = screen.getByRole('complementary')
+      const focusables = sidebar.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      )
+      const lastFocusable = focusables[focusables.length - 1]
+      lastFocusable.focus()
+      expect(lastFocusable).toHaveFocus()
+
+      await user.tab()
+
+      // Should have wrapped back to first focusable in sidebar
+      expect(sidebar.contains(document.activeElement)).toBe(true)
+      expect(document.activeElement).toBe(focusables[0])
+    })
+
+    it('Shift+Tab from first focusable wraps to last within sidebar', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      renderSidebar({ lens: 'tenant', isOpen: true, onClose })
+
+      const sidebar = screen.getByRole('complementary')
+      const focusables = sidebar.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      )
+      focusables[0].focus()
+      expect(focusables[0]).toHaveFocus()
+
+      await user.tab({ shift: true })
+
+      // Should have wrapped to last focusable in sidebar
+      expect(document.activeElement).toBe(focusables[focusables.length - 1])
+    })
+
+    it('restores focus to previously focused element when sidebar closes', async () => {
+      const onClose = vi.fn()
+      const button = document.createElement('button')
+      button.textContent = 'Menu'
+      document.body.appendChild(button)
+      button.focus()
+
+      const { rerender } = render(
+        <MemoryRouter>
+          <Sidebar lens="tenant" isOpen={true} onClose={onClose} />
+        </MemoryRouter>,
+      )
+
+      // Re-render with closed state
+      rerender(
+        <MemoryRouter>
+          <Sidebar lens="tenant" isOpen={false} onClose={onClose} />
+        </MemoryRouter>,
+      )
+
+      expect(document.activeElement).toBe(button)
+      document.body.removeChild(button)
+    })
+
+    it('does not trap focus when sidebar has no onClose (desktop mode)', async () => {
+      const user = userEvent.setup()
+      // On desktop, sidebar renders without onClose — no focus trap
+      renderSidebar({ lens: 'tenant', isOpen: false })
+
+      const dashboardLink = screen.getByRole('link', { name: /dashboard/i })
+      dashboardLink.focus()
+      expect(dashboardLink).toHaveFocus()
+
+      // Tab should move to next element freely (no wrapping enforced)
+      await user.tab()
+      // Focus should have moved to some other element (not stuck in sidebar trap)
+      // We just verify no errors were thrown and focus moved
+      expect(document.activeElement).not.toBe(dashboardLink)
+    })
+  })
+
   describe('navigation label', () => {
     it('has an accessible nav landmark', () => {
       renderSidebar({ lens: 'tenant' })

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { BuildInfo } from './build-info'
 import {
@@ -44,6 +44,55 @@ interface NavGroup {
 }
 
 const STORAGE_KEY = 'meridian:sidebar-collapsed'
+
+const FOCUSABLE_SELECTORS =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+function useFocusTrap(containerRef: React.RefObject<HTMLElement | null>, active: boolean) {
+  const previousFocusRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    if (!active) return
+
+    previousFocusRef.current = document.activeElement as HTMLElement
+
+    const container = containerRef.current
+    if (!container) return
+
+    const focusables = () =>
+      Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)).filter(
+        el => !el.closest('[hidden]') && getComputedStyle(el).display !== 'none',
+      )
+
+    const first = focusables()[0]
+    if (first) first.focus()
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Tab') return
+      const items = focusables()
+      if (items.length === 0) return
+      const firstItem = items[0]
+      const lastItem = items[items.length - 1]
+      if (e.shiftKey) {
+        if (document.activeElement === firstItem) {
+          e.preventDefault()
+          lastItem.focus()
+        }
+      } else {
+        if (document.activeElement === lastItem) {
+          e.preventDefault()
+          firstItem.focus()
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      previousFocusRef.current?.focus()
+    }
+  }, [active, containerRef])
+}
 
 const TENANT_NAV_GROUPS: NavGroup[] = [
   {
@@ -151,6 +200,10 @@ export function Sidebar({ lens, currentPath = '/', isOpen = false, id, onClose }
   const { isFeatureEnabled } = useTenantFeatures()
   const { isPlatformAdmin } = useTenantContext()
   const { toggle, isCollapsed } = useCollapsedGroups(currentPath)
+  const sidebarRef = useRef<HTMLElement>(null)
+
+  // Only trap focus when sidebar is acting as a mobile overlay (isOpen + onClose present)
+  useFocusTrap(sidebarRef, isOpen && !!onClose)
 
   useEffect(() => {
     if (!isOpen || !onClose) return
@@ -185,6 +238,7 @@ export function Sidebar({ lens, currentPath = '/', isOpen = false, id, onClose }
         />
       )}
       <aside
+      ref={sidebarRef}
       id={id}
       data-open={String(isOpen)}
       className={cn(


### PR DESCRIPTION
## Summary

- Adds a lightweight `useFocusTrap` hook to `sidebar.tsx` that activates only when the sidebar is in mobile overlay mode (`isOpen && onClose` both present)
- On open: saves the previously focused element and moves focus to the first focusable item inside the sidebar
- Tab/Shift+Tab wrap within the sidebar rather than escaping to elements behind the backdrop
- On close: restores focus to the previously focused element (e.g. the hamburger button)
- Desktop sidebar (always visible, no `onClose`) is unaffected

## Test plan

- [ ] All 38 existing sidebar tests pass
- [ ] 5 new `mobile focus trap` tests cover: focus moves in on open, Tab wraps forward, Shift+Tab wraps backward, focus restored on close, no trap on desktop
- [ ] Run: `cd frontend && npx vitest run src/components/layout/sidebar.test.tsx`