### PR TITLE
Make Codecov status checks informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,9 +4,11 @@ coverage:
       default:
         target: 50%
         threshold: 2%
+        informational: true
     patch:
       default:
         target: 60%
+        informational: true
 
 ignore:
   - "**/*.pb.go"


### PR DESCRIPTION
## Summary

- Sets `informational: true` on both project and patch Codecov status checks
- Coverage comments still appear on PRs showing the diff, but checks never block merging
- The real coverage gate remains the 50% threshold in `test.yml` (CI-enforced)

This prevents `/fix-pr` and `/tm` automation loops from trying to "fix" Codecov failures, which require writing meaningful tests rather than automated fixes.

## Test plan

- [ ] Verify Codecov status shows as neutral (grey) not failing (red) on this PR