### PR TITLE
fix: Update E2E party tabs test to match line-variant layout

### DIFF
--- a/frontend/e2e/specs/parties.spec.ts
+++ b/frontend/e2e/specs/parties.spec.ts
@@ -120,11 +120,11 @@ test.describe('Party detail — 8-tab layout', () => {
     }
   })
 
-  test('tab list has 8-column grid layout', async ({ authenticatedPage: page }) => {
+  test('tab list uses line variant with horizontal scroll', async ({ authenticatedPage: page }) => {
     const tabList = page.getByRole('tablist')
     await expect(tabList).toBeVisible()
-    // Verify the CSS grid class from [partyId].tsx:34
-    await expect(tabList).toHaveClass(/grid-cols-8/)
+    // Verify the line-variant tab layout from [partyId].tsx:48
+    await expect(tabList).toHaveClass(/border-b/)
   })
 
   test('Overview tab is selected by default', async ({ authenticatedPage: page }) => {


### PR DESCRIPTION
## Summary
- E2E test `tab list has 8-column grid layout` was failing because the Party detail page tab list was changed from grid layout (`grid-cols-8`) to line variant with horizontal scroll (`border-b`), but the test wasn't updated
- Updates the test assertion to match the current `variant="line"` TabsList implementation

## Evidence
- Failing runs: E2E Shard 3/4 consistently failing across 3+ commits on develop
- Error: `expect(tabList).toHaveClass(/grid-cols-8/)` — class not present, actual class uses `border-b`

## Test plan
- [ ] E2E Tests workflow passes (specifically Shard 3/4)
- [ ] Party detail tab structure tests all pass