### PR TITLE
fix: Prevent mobile sidebar from overlapping behind header

### DIFF
--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -231,7 +231,7 @@ export function Sidebar({ lens, currentPath = '/', isOpen = false, id, onClose }
     <>
       {isOpen && onClose && (
         <div
-          className="fixed inset-0 z-30 bg-overlay md:hidden"
+          className="fixed inset-0 top-14 z-30 bg-overlay md:hidden"
           aria-hidden="true"
           role="presentation"
           onClick={onClose}
@@ -243,7 +243,7 @@ export function Sidebar({ lens, currentPath = '/', isOpen = false, id, onClose }
       data-open={String(isOpen)}
       className={cn(
         'flex h-full w-64 flex-col bg-sidebar text-sidebar-foreground transition-transform duration-200',
-        'max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-40',
+        'max-md:fixed max-md:top-14 max-md:bottom-0 max-md:left-0 max-md:z-40',
         !isOpen && 'max-md:-translate-x-full',
       )}
     >


### PR DESCRIPTION
## Summary
- Mobile sidebar used `inset-y-0` (top: 0), placing it behind the header (z-50 > z-40)
- First ~56px of sidebar content was hidden behind the header
- Changed sidebar and overlay to start at `top-14` (below header) on mobile

## Test plan
- [x] All 38 sidebar tests pass
- [ ] Verify on mobile viewport: sidebar content starts below header
- [ ] Verify overlay doesn't cover header (menu button remains clickable)
- [ ] Desktop layout unchanged