### PR TITLE
fix: Exempt /dex/ OIDC endpoints from tenant subdomain resolution

### DIFF
--- a/shared/platform/gateway/tenant_resolver.go
+++ b/shared/platform/gateway/tenant_resolver.go
@@ -67,13 +67,13 @@ type tenantRepository interface {
 }
 
 // platformPaths lists URL path prefixes that operate at the platform level
-// (e.g., tenant creation, listing tenants) and do not require tenant context.
-// Requests matching these prefixes bypass tenant resolution entirely.
-// Both REST (gRPC-Gateway transcoding) and Connect/gRPC paths are listed
-// because the Vanguard transcoder accepts requests in either format.
+// (e.g., tenant creation, identity provider endpoints) and do not require
+// tenant context. Requests matching these prefixes bypass tenant resolution
+// entirely.
 var platformPaths = []string{
 	"/v1/tenants",                        // REST transcoding path
 	"/meridian.tenant.v1.TenantService/", // Connect/gRPC path
+	"/dex/",                              // Embedded OIDC identity provider
 }
 
 // IsPlatformPath returns true if the request path is a platform-level endpoint

--- a/shared/platform/gateway/tenant_resolver_test.go
+++ b/shared/platform/gateway/tenant_resolver_test.go
@@ -938,6 +938,12 @@ func TestIsPlatformPath(t *testing.T) {
 	assert.True(t, IsPlatformPath("/meridian.tenant.v1.TenantService/CreateTenant"))
 	assert.True(t, IsPlatformPath("/meridian.tenant.v1.TenantService/GetTenant"))
 
+	// Dex OIDC identity provider paths
+	assert.True(t, IsPlatformPath("/dex/auth"))
+	assert.True(t, IsPlatformPath("/dex/callback"))
+	assert.True(t, IsPlatformPath("/dex/keys"))
+	assert.True(t, IsPlatformPath("/dex/token"))
+
 	// Non-platform paths
 	assert.False(t, IsPlatformPath("/v1/accounts"))
 	assert.False(t, IsPlatformPath("/v1/parties"))


### PR DESCRIPTION
## Summary

- Add `/dex/` to `platformPaths` in `TenantResolverMiddleware` so embedded Dex OIDC endpoints bypass tenant subdomain resolution
- Dex endpoints are platform-level authentication infrastructure that operates before tenant context is established

## Problem

When MCP OAuth flow redirects to `/dex/auth` on the base domain (`demo.meridianhub.cloud`), the gateway's tenant resolver rejects the request with "Invalid subdomain" because there's no tenant subdomain prefix. The Dex auth flow is inherently tenant-agnostic — it authenticates users before tenant context exists.

## Test plan

- [x] Existing `TestIsPlatformPath` updated with Dex path assertions
- [x] `TestPlatformPathBypassesTenantResolution` covers the bypass behavior
- [ ] Verify MCP OAuth flow completes on demo after deploy