### PR TITLE
fix: Resolve CockroachDB serialization issues causing CI failures

### DIFF
--- a/services/operational-gateway/adapters/persistence/instruction_repository.go
+++ b/services/operational-gateway/adapters/persistence/instruction_repository.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"strings"
 	"time"
@@ -155,6 +156,10 @@ func (r *InstructionRepository) FetchDispatchable(ctx context.Context, params po
 
 	var entities []InstructionEntity
 
+	// Use READ COMMITTED isolation: CockroachDB's SERIALIZABLE default causes
+	// unpredictable behavior with FOR UPDATE SKIP LOCKED, where recently-committed
+	// rows may be skipped. READ COMMITTED matches PostgreSQL semantics and is the
+	// recommended isolation level for queue-like claim patterns.
 	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Step 1: Lock candidate IDs. RETRYING rows are only eligible when next_retry_at has passed.
 		lockSQL := `
@@ -195,7 +200,7 @@ func (r *InstructionRepository) FetchDispatchable(ctx context.Context, params po
 		return tx.Where("id IN ?", ids).
 			Order("priority DESC, scheduled_at ASC NULLS FIRST").
 			Find(&entities).Error
-	})
+	}, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
 		return nil, err
 	}

--- a/services/reference-data/saga/override_api.go
+++ b/services/reference-data/saga/override_api.go
@@ -20,9 +20,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/lib/pq"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
@@ -222,7 +224,7 @@ func (s *OverrideService) MigrateToPlatformRef(
 	logger := s.logger.With("tenant_id", tenantID.String(), "dry_run", dryRun)
 	logger.Info("starting platform reference migration")
 
-	// Get all platform sagas
+	// Get all platform sagas (read-only, outside the retryable transaction).
 	platformSagas, err := s.loadPlatformSagas(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("load platform sagas: %w", err)
@@ -230,37 +232,46 @@ func (s *OverrideService) MigrateToPlatformRef(
 
 	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
 
-	tx, err := s.pool.Begin(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("begin transaction: %w", err)
-	}
-	defer func() {
-		_ = tx.Rollback(ctx)
-	}()
+	var results []MigrationResult
+	err = withCRDBRetry(ctx, func() error {
+		tx, txErr := s.pool.Begin(ctx)
+		if txErr != nil {
+			return fmt.Errorf("begin transaction: %w", txErr)
+		}
+		defer func() {
+			_ = tx.Rollback(ctx)
+		}()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName))
-	if err != nil {
-		return nil, fmt.Errorf("set search_path: %w", err)
-	}
+		_, txErr = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName))
+		if txErr != nil {
+			return fmt.Errorf("set search_path: %w", txErr)
+		}
 
-	candidates, err := s.loadTenantSagaCandidates(ctx, tx)
+		candidates, txErr := s.loadTenantSagaCandidates(ctx, tx)
+		if txErr != nil {
+			return txErr
+		}
+
+		txResults := make([]MigrationResult, 0, len(candidates))
+		for _, ts := range candidates {
+			result, migrateErr := s.evaluateCandidate(ctx, tx, ts, platformSagas, dryRun, logger)
+			if migrateErr != nil {
+				return migrateErr
+			}
+			txResults = append(txResults, result)
+		}
+
+		if !dryRun {
+			if txErr = tx.Commit(ctx); txErr != nil {
+				return fmt.Errorf("commit migration: %w", txErr)
+			}
+		}
+
+		results = txResults
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-
-	results := make([]MigrationResult, 0, len(candidates))
-	for _, ts := range candidates {
-		result, migrateErr := s.evaluateCandidate(ctx, tx, ts, platformSagas, dryRun, logger)
-		if migrateErr != nil {
-			return nil, migrateErr
-		}
-		results = append(results, result)
-	}
-
-	if !dryRun {
-		if err := tx.Commit(ctx); err != nil {
-			return nil, fmt.Errorf("commit migration: %w", err)
-		}
 	}
 
 	logger.Info("platform reference migration completed",
@@ -268,6 +279,41 @@ func (s *OverrideService) MigrateToPlatformRef(
 		"dry_run", dryRun)
 
 	return results, nil
+}
+
+// withCRDBRetry retries the provided function on CockroachDB serialization errors
+// (SQLSTATE 40001). These errors are expected under SERIALIZABLE isolation and are
+// safe to retry by re-executing the entire transaction.
+func withCRDBRetry(ctx context.Context, fn func() error) error {
+	const maxRetries = 5
+	backoff := 50 * time.Millisecond
+
+	for attempt := 0; ; attempt++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if attempt >= maxRetries || !isCRDBRetryError(err) {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+		if backoff > 2*time.Second {
+			backoff = 2 * time.Second
+		}
+	}
+}
+
+// isCRDBRetryError returns true if the error is a CockroachDB serialization conflict
+// (SQLSTATE 40001) that can be resolved by retrying the transaction.
+func isCRDBRetryError(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "40001"
 }
 
 // tenantSaga represents a tenant's saga definition candidate for migration.

--- a/services/reference-data/saga/override_api.go
+++ b/services/reference-data/saga/override_api.go
@@ -234,49 +234,72 @@ func (s *OverrideService) MigrateToPlatformRef(
 
 	var results []MigrationResult
 	err = withCRDBRetry(ctx, func() error {
-		tx, txErr := s.pool.Begin(ctx)
-		if txErr != nil {
-			return fmt.Errorf("begin transaction: %w", txErr)
-		}
-		defer func() {
-			_ = tx.Rollback(ctx)
-		}()
-
-		_, txErr = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName))
-		if txErr != nil {
-			return fmt.Errorf("set search_path: %w", txErr)
-		}
-
-		candidates, txErr := s.loadTenantSagaCandidates(ctx, tx)
-		if txErr != nil {
-			return txErr
-		}
-
-		txResults := make([]MigrationResult, 0, len(candidates))
-		for _, ts := range candidates {
-			result, migrateErr := s.evaluateCandidate(ctx, tx, ts, platformSagas, dryRun, logger)
-			if migrateErr != nil {
-				return migrateErr
-			}
-			txResults = append(txResults, result)
-		}
-
-		if !dryRun {
-			if txErr = tx.Commit(ctx); txErr != nil {
-				return fmt.Errorf("commit migration: %w", txErr)
-			}
-		}
-
-		results = txResults
-		return nil
+		var txErr error
+		results, txErr = s.runMigrationTx(ctx, schemaName, platformSagas, dryRun)
+		return txErr
 	})
 	if err != nil {
 		return nil, err
 	}
 
+	// Log per-saga outcomes after the transaction has committed successfully,
+	// so retried transactions don't produce duplicate log entries.
+	for _, r := range results {
+		if r.Action == MigrationActionMigrated {
+			logger.Info("migrated saga to platform reference",
+				"saga_name", r.SagaName,
+				"saga_id", r.SagaID,
+				"platform_ref", r.PlatformRefID,
+				"similarity", r.SimilarityRatio)
+		}
+	}
+
 	logger.Info("platform reference migration completed",
 		"total", len(results),
 		"dry_run", dryRun)
+
+	return results, nil
+}
+
+// runMigrationTx executes the migration within a single transaction.
+func (s *OverrideService) runMigrationTx(
+	ctx context.Context,
+	schemaName string,
+	platformSagas map[string]PlatformSagaDefinition,
+	dryRun bool,
+) ([]MigrationResult, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName))
+	if err != nil {
+		return nil, fmt.Errorf("set search_path: %w", err)
+	}
+
+	candidates, err := s.loadTenantSagaCandidates(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]MigrationResult, 0, len(candidates))
+	for _, ts := range candidates {
+		result, migrateErr := s.evaluateCandidate(ctx, tx, ts, platformSagas, dryRun)
+		if migrateErr != nil {
+			return nil, migrateErr
+		}
+		results = append(results, result)
+	}
+
+	if !dryRun {
+		if err = tx.Commit(ctx); err != nil {
+			return nil, fmt.Errorf("commit migration: %w", err)
+		}
+	}
 
 	return results, nil
 }
@@ -358,13 +381,14 @@ func (s *OverrideService) loadTenantSagaCandidates(ctx context.Context, tx pgx.T
 }
 
 // evaluateCandidate determines the migration action for a single tenant saga.
+// Does not log outcomes — the caller logs after the transaction commits to avoid
+// duplicate entries on CockroachDB transaction retries.
 func (s *OverrideService) evaluateCandidate(
 	ctx context.Context,
 	tx pgx.Tx,
 	ts tenantSaga,
 	platformSagas map[string]PlatformSagaDefinition,
 	dryRun bool,
-	logger *slog.Logger,
 ) (MigrationResult, error) {
 	if ts.platformRef != nil {
 		return MigrationResult{
@@ -415,12 +439,6 @@ func (s *OverrideService) evaluateCandidate(
 	if err != nil {
 		return MigrationResult{}, fmt.Errorf("migrate saga %s: %w", ts.name, err)
 	}
-
-	logger.Info("migrated saga to platform reference",
-		"saga_name", ts.name,
-		"saga_id", ts.id,
-		"platform_ref", platformSaga.ID,
-		"similarity", simResult.Ratio)
 
 	return MigrationResult{
 		SagaName:        ts.name,


### PR DESCRIPTION
## Summary
- **FetchDispatchable** (operational-gateway): Use READ COMMITTED isolation for the `FOR UPDATE SKIP LOCKED` transaction. CockroachDB's default SERIALIZABLE isolation causes recently-committed rows to be unpredictably skipped, producing flaky `TestInstructionRepository_FetchDispatchable_*` failures on develop (different tests fail in different runs, unrelated to code changes).
- **MigrateToPlatformRef** (reference-data/saga): Add transaction retry loop for CockroachDB SQLSTATE 40001 (serialization conflict) errors. The nightly `TestE2E_ProvisioningOverrideMigration` fails when concurrent saga migrations hit the same rows under SERIALIZABLE isolation.

## Evidence
- Failing nightly run: https://github.com/meridianhub/meridian/actions/runs/23080156680 (`TestE2E_ProvisioningOverrideMigration`)
- Failing test run: https://github.com/meridianhub/meridian/actions/runs/23067834267 (`TestInstructionRepository_FetchDispatchable_RespectsScheduledAt`)
- Previous test run failed with a *different* FetchDispatchable test: https://github.com/meridianhub/meridian/actions/runs/23066390546 (`TestInstructionRepository_FetchDispatchable_PriorityOrdering`)
- Commits between last-pass and first-fail are all unrelated (frontend/auth changes), confirming flakiness

## Test plan
- [x] All FetchDispatchable tests pass 15/15 (5 tests x 3 runs) locally against CockroachDB v24.3
- [x] MigrateToPlatformRef unit tests pass locally
- [ ] CI passes on this PR