### PR TITLE
Add dark mode toggle to header

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,14 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Meridian Operations Console</title>
+    <script>
+      // Prevent flash of wrong theme before React hydrates
+      (function() {
+        var t = localStorage.getItem('meridian:theme');
+        var dark = t === 'dark' || (t !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches);
+        if (dark) document.documentElement.classList.add('dark');
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,11 +7,11 @@
     <title>Meridian Operations Console</title>
     <script>
       // Prevent flash of wrong theme before React hydrates
-      (function() {
+      try {
         var t = localStorage.getItem('meridian:theme');
         var dark = t === 'dark' || (t !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches);
         if (dark) document.documentElement.classList.add('dark');
-      })();
+      } catch (_) {}
     </script>
   </head>
   <body>

--- a/frontend/src/components/layout/app-shell.test.tsx
+++ b/frontend/src/components/layout/app-shell.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AppShell } from '@/components/layout/app-shell'
 import { AuthProvider } from '@/contexts/auth-context'
 import { TenantProvider } from '@/contexts/tenant-context'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { createPlatformAdminToken, createTenantUserToken } from '@/test/jwt-helpers'
 
 // Mock TenantSelector to avoid dependency on ungenerated proto clients
@@ -23,9 +24,11 @@ function renderWithProviders(ui: React.ReactElement, token?: string) {
     <QueryClientProvider client={queryClient}>
       <AuthProvider initialToken={token}>
         <TenantProvider>
-          <MemoryRouter>
-            {ui}
-          </MemoryRouter>
+          <TooltipProvider>
+            <MemoryRouter>
+              {ui}
+            </MemoryRouter>
+          </TooltipProvider>
         </TenantProvider>
       </AuthProvider>
     </QueryClientProvider>

--- a/frontend/src/components/layout/header.test.tsx
+++ b/frontend/src/components/layout/header.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Header } from '@/components/layout/header'
 import { AuthProvider } from '@/contexts/auth-context'
 import { TenantProvider } from '@/contexts/tenant-context'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { createPlatformAdminToken, createTenantUserToken } from '@/test/jwt-helpers'
 
 // Mock TenantSelector to avoid dependency on ungenerated proto clients
@@ -22,7 +23,9 @@ function renderWithProviders(ui: React.ReactElement, token?: string) {
     <QueryClientProvider client={queryClient}>
       <AuthProvider initialToken={token}>
         <TenantProvider>
-          {ui}
+          <TooltipProvider>
+            {ui}
+          </TooltipProvider>
         </TenantProvider>
       </AuthProvider>
     </QueryClientProvider>

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -9,6 +9,7 @@ import {
 import { useAuth } from '@/contexts/auth-context'
 import { useTenantContext } from '@/contexts/tenant-context'
 import { TenantSelector } from '@/components/layout/tenant-selector'
+import { ThemeToggle } from '@/components/layout/theme-toggle'
 
 interface HeaderProps {
   onMenuToggle: () => void
@@ -40,6 +41,8 @@ export function Header({ onMenuToggle, sidebarOpen, sidebarId }: HeaderProps) {
 
       <div className="ml-auto flex items-center gap-4">
         {isPlatformAdmin && <TenantSelector />}
+
+        <ThemeToggle />
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/frontend/src/components/layout/theme-toggle.test.tsx
+++ b/frontend/src/components/layout/theme-toggle.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest"
+import { describe, it, expect, beforeEach } from "vitest"
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { TooltipProvider } from "@/components/ui/tooltip"

--- a/frontend/src/components/layout/theme-toggle.test.tsx
+++ b/frontend/src/components/layout/theme-toggle.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { ThemeToggle } from "./theme-toggle"
+
+function renderToggle() {
+  return render(
+    <TooltipProvider>
+      <ThemeToggle />
+    </TooltipProvider>,
+  )
+}
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.classList.remove("dark")
+  })
+
+  it("renders with system theme by default", () => {
+    renderToggle()
+    expect(screen.getByRole("button", { name: /theme: system/i })).toBeInTheDocument()
+  })
+
+  it("cycles through themes: system -> light -> dark -> system", async () => {
+    const user = userEvent.setup()
+    renderToggle()
+
+    const button = screen.getByRole("button", { name: /theme/i })
+
+    // system -> light
+    await user.click(button)
+    expect(button).toHaveAccessibleName("Theme: Light")
+    expect(localStorage.getItem("meridian:theme")).toBe("light")
+
+    // light -> dark
+    await user.click(button)
+    expect(button).toHaveAccessibleName("Theme: Dark")
+    expect(localStorage.getItem("meridian:theme")).toBe("dark")
+    expect(document.documentElement.classList.contains("dark")).toBe(true)
+
+    // dark -> system
+    await user.click(button)
+    expect(button).toHaveAccessibleName("Theme: System")
+    expect(localStorage.getItem("meridian:theme")).toBe("system")
+  })
+
+  it("applies dark class when dark theme is selected", async () => {
+    const user = userEvent.setup()
+    renderToggle()
+
+    const button = screen.getByRole("button", { name: /theme/i })
+
+    // system -> light -> dark
+    await user.click(button)
+    await user.click(button)
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true)
+  })
+
+  it("removes dark class when light theme is selected", async () => {
+    document.documentElement.classList.add("dark")
+    const user = userEvent.setup()
+    renderToggle()
+
+    const button = screen.getByRole("button", { name: /theme/i })
+
+    // system -> light
+    await user.click(button)
+    expect(document.documentElement.classList.contains("dark")).toBe(false)
+  })
+
+  it("restores theme from localStorage", () => {
+    localStorage.setItem("meridian:theme", "dark")
+
+    // Need to re-import the module to pick up localStorage.
+    // Since the module is already loaded, we simulate by setting and rendering.
+    // The useTheme hook reads localStorage on init.
+    renderToggle()
+
+    // The hook should have applied dark class
+    expect(document.documentElement.classList.contains("dark")).toBe(true)
+  })
+
+  it("is keyboard accessible", async () => {
+    const user = userEvent.setup()
+    renderToggle()
+
+    await user.tab()
+    const button = screen.getByRole("button", { name: /theme/i })
+    expect(button).toHaveFocus()
+
+    await user.keyboard("{Enter}")
+    expect(button).toHaveAccessibleName("Theme: Light")
+  })
+})

--- a/frontend/src/components/layout/theme-toggle.test.tsx
+++ b/frontend/src/components/layout/theme-toggle.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { ThemeToggle } from "./theme-toggle"
+import { _resetForTesting } from "@/lib/use-theme"
 
 function renderToggle() {
   return render(
@@ -16,6 +17,7 @@ describe("ThemeToggle", () => {
   beforeEach(() => {
     localStorage.clear()
     document.documentElement.classList.remove("dark")
+    _resetForTesting()
   })
 
   it("renders with system theme by default", () => {
@@ -73,13 +75,10 @@ describe("ThemeToggle", () => {
 
   it("restores theme from localStorage", () => {
     localStorage.setItem("meridian:theme", "dark")
+    _resetForTesting()
 
-    // Need to re-import the module to pick up localStorage.
-    // Since the module is already loaded, we simulate by setting and rendering.
-    // The useTheme hook reads localStorage on init.
     renderToggle()
 
-    // The hook should have applied dark class
     expect(document.documentElement.classList.contains("dark")).toBe(true)
   })
 

--- a/frontend/src/components/layout/theme-toggle.tsx
+++ b/frontend/src/components/layout/theme-toggle.tsx
@@ -1,0 +1,37 @@
+import { Sun, Moon, Monitor } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { useTheme, type Theme } from "@/lib/use-theme"
+
+const LABELS: Record<Theme, string> = {
+  system: "Theme: System",
+  light: "Theme: Light",
+  dark: "Theme: Dark",
+}
+
+export function ThemeToggle() {
+  const { theme, resolvedTheme, cycleTheme } = useTheme()
+
+  const Icon =
+    theme === "system" ? Monitor : resolvedTheme === "dark" ? Moon : Sun
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={LABELS[theme]}
+          onClick={cycleTheme}
+        >
+          <Icon className="size-5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{LABELS[theme]}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/frontend/src/lib/use-theme.ts
+++ b/frontend/src/lib/use-theme.ts
@@ -58,6 +58,12 @@ function setTheme(theme: Theme): void {
   }
 }
 
+/** Reset module state for test isolation. Not for production use. */
+export function _resetForTesting(): void {
+  currentTheme = getStoredTheme()
+  listeners = []
+}
+
 export function useTheme() {
   const theme = useSyncExternalStore(subscribe, getSnapshot)
 

--- a/frontend/src/lib/use-theme.ts
+++ b/frontend/src/lib/use-theme.ts
@@ -18,6 +18,7 @@ function getStoredTheme(): Theme {
 
 function getResolvedTheme(theme: Theme): "light" | "dark" {
   if (theme === "system") {
+    if (typeof window === "undefined") return "light"
     return window.matchMedia("(prefers-color-scheme: dark)").matches
       ? "dark"
       : "light"
@@ -26,6 +27,7 @@ function getResolvedTheme(theme: Theme): "light" | "dark" {
 }
 
 function applyTheme(theme: Theme): void {
+  if (typeof document === "undefined") return
   const resolved = getResolvedTheme(theme)
   document.documentElement.classList.toggle("dark", resolved === "dark")
 }

--- a/frontend/src/lib/use-theme.ts
+++ b/frontend/src/lib/use-theme.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useSyncExternalStore } from "react"
+
+export type Theme = "system" | "light" | "dark"
+
+const STORAGE_KEY = "meridian:theme"
+
+function getStoredTheme(): Theme {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === "light" || stored === "dark" || stored === "system") {
+      return stored
+    }
+  } catch {
+    // localStorage unavailable (SSR, iframe sandbox, etc.)
+  }
+  return "system"
+}
+
+function getResolvedTheme(theme: Theme): "light" | "dark" {
+  if (theme === "system") {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light"
+  }
+  return theme
+}
+
+function applyTheme(theme: Theme): void {
+  const resolved = getResolvedTheme(theme)
+  document.documentElement.classList.toggle("dark", resolved === "dark")
+}
+
+// Simple pub/sub so useSyncExternalStore can react to changes
+let listeners: Array<() => void> = []
+let currentTheme: Theme = getStoredTheme()
+
+function subscribe(listener: () => void): () => void {
+  listeners = [...listeners, listener]
+  return () => {
+    listeners = listeners.filter((l) => l !== listener)
+  }
+}
+
+function getSnapshot(): Theme {
+  return currentTheme
+}
+
+function setTheme(theme: Theme): void {
+  currentTheme = theme
+  try {
+    localStorage.setItem(STORAGE_KEY, theme)
+  } catch {
+    // localStorage unavailable
+  }
+  applyTheme(theme)
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+export function useTheme() {
+  const theme = useSyncExternalStore(subscribe, getSnapshot)
+
+  // Sync from localStorage on mount (covers cases where localStorage was
+  // set before this module loaded, e.g. by the inline script in index.html)
+  useEffect(() => {
+    const stored = getStoredTheme()
+    if (stored !== currentTheme) {
+      currentTheme = stored
+      for (const l of listeners) l()
+    }
+    applyTheme(currentTheme)
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
+    const handleChange = () => {
+      if (currentTheme === "system") {
+        applyTheme("system")
+        for (const listener of listeners) {
+          listener()
+        }
+      }
+    }
+    mediaQuery.addEventListener("change", handleChange)
+    return () => mediaQuery.removeEventListener("change", handleChange)
+  }, [])
+
+  const cycleTheme = useCallback(() => {
+    const next: Record<Theme, Theme> = {
+      system: "light",
+      light: "dark",
+      dark: "system",
+    }
+    setTheme(next[currentTheme])
+  }, [])
+
+  return {
+    theme,
+    resolvedTheme: getResolvedTheme(theme),
+    setTheme,
+    cycleTheme,
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a theme toggle button to the header (between tenant selector and user menu) that cycles through System, Light, and Dark modes
- Persists user preference to `localStorage` (`meridian:theme` key) and respects `prefers-color-scheme: dark` as the default
- Adds inline script in `index.html` to apply the `.dark` class before React hydrates, preventing flash of wrong theme

## Changes

- `frontend/src/lib/use-theme.ts` - Theme state hook using `useSyncExternalStore` with localStorage persistence and system preference detection
- `frontend/src/components/layout/theme-toggle.tsx` - Toggle button component with Sun/Moon/Monitor icons and tooltip
- `frontend/src/components/layout/header.tsx` - Import and render `ThemeToggle` between tenant selector and user menu
- `frontend/index.html` - Inline script for flash prevention
- `frontend/src/components/layout/theme-toggle.test.tsx` - 6 tests covering rendering, cycling, persistence, class application, and keyboard accessibility

## Test plan

- [x] All 6 theme toggle tests passing locally
- [ ] CI passes
- [ ] Manual verification: toggle cycles correctly, persists across reload, respects system preference