### PR TITLE
fix: add aria-live, aria-label, and role=alert for screen reader accessibility

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -240,7 +240,7 @@ function LoginPage() {
                 className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               />
             </div>
-            {error && <p className="text-sm text-destructive">{error}</p>}
+            {error && <p role="alert" className="text-sm text-destructive">{error}</p>}
             <button
               type="submit"
               disabled={loading}

--- a/frontend/src/components/auth/provider-button.tsx
+++ b/frontend/src/components/auth/provider-button.tsx
@@ -37,12 +37,15 @@ export function ProviderButton({ provider, onClick }: ProviderButtonProps) {
         variant="outline"
         className="w-full"
         disabled={loading}
+        aria-busy={loading}
         onClick={() => void handleClick()}
       >
         <ProviderIcon providerId={provider.id} />
-        {loading ? 'Redirecting...' : `Sign in with ${provider.displayName}`}
+        <span aria-live="polite">
+          {loading ? 'Redirecting...' : `Sign in with ${provider.displayName}`}
+        </span>
       </Button>
-      {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
+      {error && <p role="alert" className="mt-1 text-xs text-destructive">{error}</p>}
     </div>
   )
 }

--- a/frontend/src/features/reconciliation/pages/detail.test.tsx
+++ b/frontend/src/features/reconciliation/pages/detail.test.tsx
@@ -392,7 +392,7 @@ describe('ReconciliationDetailPage - disputes tab', () => {
     })
 
     // Click OPEN filter
-    await userEvent.click(screen.getByRole('button', { name: 'OPEN' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Show open disputes' }))
     await waitFor(() => {
       expect(screen.getAllByTestId('dispute-card').length).toBe(1)
       expect(screen.getByText('disp-001')).toBeInTheDocument()
@@ -406,7 +406,7 @@ describe('ReconciliationDetailPage - disputes tab', () => {
     })
 
     // Click REJECTED filter - no disputes are REJECTED
-    await userEvent.click(screen.getByRole('button', { name: 'REJECTED' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Show rejected disputes' }))
     await waitFor(() => {
       expect(screen.getByTestId('disputes-empty')).toBeInTheDocument()
     })

--- a/frontend/src/features/reconciliation/pages/detail.tsx
+++ b/frontend/src/features/reconciliation/pages/detail.tsx
@@ -147,7 +147,7 @@ function VariancesTab({ runId }: { runId: string }) {
 
   if (isError) {
     return (
-      <div className="rounded-lg border border-destructive p-4 text-destructive text-sm">
+      <div role="alert" className="rounded-lg border border-destructive p-4 text-destructive text-sm">
         Failed to load variances.
       </div>
     )
@@ -301,7 +301,7 @@ function DisputeCard({
             ))}
           </div>
           {mutation.isError && (
-            <p className="text-xs text-destructive">Failed to update dispute.</p>
+            <p role="alert" className="text-xs text-destructive">Failed to update dispute.</p>
           )}
         </div>
       )}
@@ -344,7 +344,7 @@ function DisputesTab({ runId }: { runId: string }) {
 
   if (isError) {
     return (
-      <div className="rounded-lg border border-destructive p-4 text-destructive text-sm">
+      <div role="alert" className="rounded-lg border border-destructive p-4 text-destructive text-sm">
         Failed to load disputes.
       </div>
     )
@@ -358,12 +358,13 @@ function DisputesTab({ runId }: { runId: string }) {
             key={f}
             onClick={() => setFilter(f)}
             className={cn(
-              'rounded-md border px-3 py-1 text-sm transition-colors',
+              'rounded-md border px-3 py-1 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
               filter === f
                 ? 'bg-primary text-primary-foreground border-primary'
                 : 'bg-background hover:bg-accent',
             )}
             aria-pressed={filter === f}
+            aria-label={f === 'ALL' ? 'Show all disputes' : `Show ${f.toLowerCase()} disputes`}
           >
             {f}
           </button>
@@ -467,7 +468,7 @@ function BalanceAssertionsTab({ runId }: { runId: string }) {
 
   if (isError) {
     return (
-      <div className="rounded-lg border border-destructive p-4 text-destructive text-sm">
+      <div role="alert" className="rounded-lg border border-destructive p-4 text-destructive text-sm">
         Failed to load balance assertions.
       </div>
     )
@@ -520,7 +521,7 @@ function BalanceAssertionsTab({ runId }: { runId: string }) {
             </p>
           </div>
           {saveError && (
-            <p data-testid="assertion-error" className="text-xs text-destructive">
+            <p role="alert" data-testid="assertion-error" className="text-xs text-destructive">
               {saveError}
             </p>
           )}


### PR DESCRIPTION
## Summary

- Add `role="alert"` to dynamic error messages in reconciliation detail page (variances, disputes, balance assertions tabs) and App.tsx login form so screen readers announce errors when they appear
- Add `aria-label` to dispute filter toggle buttons describing the filter action (e.g. \"Show open disputes\") and `focus-visible:ring-2 focus-visible:ring-ring` for keyboard users
- Add `aria-busy` and `aria-live="polite"` on provider auth button so screen readers announce the loading state change from \"Sign in with...\" to \"Redirecting...\"
- Add `role="alert"` to provider button error message

## Changes Made

**`frontend/src/features/reconciliation/pages/detail.tsx`**
- Issue 10: Dispute filter buttons — added `aria-label` (\"Show all/open/resolved/rejected disputes\") and `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`
- Issue 12: Variances, Disputes, Balance Assertions load error divs — added `role="alert"`
- Issue 12: Dispute update mutation error `<p>` — added `role="alert"`
- Issue 12: Balance assertion save validation error `<p>` — added `role="alert"`

**`frontend/src/components/auth/provider-button.tsx`**
- Issue 11: Button — added `aria-busy={loading}`
- Issue 11: Button text span — added `aria-live="polite"` so state change is announced
- Issue 12: Error `<p>` — added `role="alert"`

**`frontend/src/App.tsx`**
- Issue 12: Login form error `<p>` — added `role="alert"`

**`frontend/src/features/reconciliation/pages/detail.test.tsx`**
- Updated filter button queries to use new `aria-label` values

## Test Plan

- [x] `npx vitest run src/features/reconciliation/pages/detail.test.tsx` — all 30 tests pass
- [x] Pre-existing failures in other test files are unrelated (proto/API client issues)