### PR TITLE
fix: currency select a11y + memoize context provider values

### DIFF
--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useCallback, useRef, type ReactNode } from 'react'
+import { createContext, useContext, useState, useEffect, useCallback, useRef, useMemo, type ReactNode } from 'react'
 import { toast } from 'sonner'
 import { getTenantSlugFromSubdomain } from '@/lib/tenant-utils'
 
@@ -347,15 +347,18 @@ export function AuthProvider({ children, initialToken }: AuthProviderProps) {
     }
   }, [login])
 
-  const value: AuthContextValue = {
-    isAuthenticated,
-    claims,
-    accessToken,
-    lens,
-    login,
-    logout,
-    refreshToken,
-  }
+  const value: AuthContextValue = useMemo(
+    () => ({
+      isAuthenticated,
+      claims,
+      accessToken,
+      lens,
+      login,
+      logout,
+      refreshToken,
+    }),
+    [isAuthenticated, claims, accessToken, lens, login, logout, refreshToken],
+  )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }

--- a/frontend/src/contexts/tenant-context.tsx
+++ b/frontend/src/contexts/tenant-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react'
+import { createContext, useContext, useState, useCallback, useEffect, useMemo, type ReactNode } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useAuth } from '@/contexts/auth-context'
 import { DEFAULT_UI_CONFIG, type TenantThemeConfig, type TenantUIConfig } from '@/lib/tenant-ui-config'
@@ -80,15 +80,18 @@ export function TenantProvider({ children }: { children: ReactNode }) {
     ? selectedTenant?.slug ?? null
     : claims?.tenantId ?? getTenantSlugFromSubdomain(window.location.hostname)
 
-  const value: TenantContextValue = {
-    currentTenant: isPlatformAdmin ? selectedTenant : null,
-    tenantSlug,
-    isPlatformAdmin,
-    switchTenant,
-    clearTenant,
-    applyTheme,
-    tenantConfig: DEFAULT_UI_CONFIG,
-  }
+  const value: TenantContextValue = useMemo(
+    () => ({
+      currentTenant: isPlatformAdmin ? selectedTenant : null,
+      tenantSlug,
+      isPlatformAdmin,
+      switchTenant,
+      clearTenant,
+      applyTheme,
+      tenantConfig: DEFAULT_UI_CONFIG,
+    }),
+    [isPlatformAdmin, selectedTenant, tenantSlug, switchTenant, clearTenant, applyTheme],
+  )
 
   return <TenantContext.Provider value={value}>{children}</TenantContext.Provider>
 }

--- a/frontend/src/features/payments/pages/dialogs/initiate-payment-dialog.tsx
+++ b/frontend/src/features/payments/pages/dialogs/initiate-payment-dialog.tsx
@@ -214,11 +214,17 @@ export function InitiatePaymentDialog({
                   value={formData.currency}
                   onChange={handleChange('currency')}
                   className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs"
+                  aria-describedby={errors.currency ? 'currency-error' : undefined}
                 >
                   <option value="GBP">GBP</option>
                   <option value="USD">USD</option>
                   <option value="EUR">EUR</option>
                 </select>
+                {errors.currency && (
+                  <p id="currency-error" className="text-sm text-destructive">
+                    {errors.currency}
+                  </p>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Add `aria-describedby` and error paragraph to the currency `<select>` in `InitiatePaymentDialog`, matching the pattern used by all other form fields in the same dialog
- Wrap `TenantContextValue` in `useMemo` so `useTenantContext()` consumers only re-render when actual tenant state changes
- Wrap `AuthContextValue` in `useMemo` so `useAuth()` consumers only re-render when auth state changes

## Changes Made

### `frontend/src/features/payments/pages/dialogs/initiate-payment-dialog.tsx`
- Added `aria-describedby={errors.currency ? 'currency-error' : undefined}` to the `<select>` element
- Added `<p id="currency-error">` error paragraph, matching pattern of `debtorAccountId`, `creditorReference`, and `amount` fields

### `frontend/src/contexts/tenant-context.tsx`
- Added `useMemo` import
- Wrapped inline `TenantContextValue` object in `useMemo` with deps `[isPlatformAdmin, selectedTenant, tenantSlug, switchTenant, clearTenant, applyTheme]`

### `frontend/src/contexts/auth-context.tsx`
- Added `useMemo` import
- Wrapped inline `AuthContextValue` object in `useMemo` with deps `[isAuthenticated, claims, accessToken, lens, login, logout, refreshToken]`

## Testing

All 173 test files / 2193 tests pass.