### PR TITLE
fix: replace hard-coded graph colors with CSS custom properties

### DIFF
--- a/frontend/src/features/cookbook/components/saga-flow.tsx
+++ b/frontend/src/features/cookbook/components/saga-flow.tsx
@@ -14,26 +14,26 @@ import Dagre from '@dagrejs/dagre'
 import type { SagaFlow } from '../lib/star-parser'
 import { parseTriggerService } from '../lib/star-parser'
 
-// Curated palette of visually distinct service colors
+// Curated palette of visually distinct service colors using CSS custom properties
 const SERVICE_PALETTE = [
-  { bg: 'hsl(220, 70%, 92%)', fg: 'hsl(220, 70%, 45%)' },  // Blue
-  { bg: 'hsl(150, 60%, 90%)', fg: 'hsl(150, 60%, 35%)' },  // Green
-  { bg: 'hsl(30, 80%, 92%)', fg: 'hsl(30, 80%, 45%)' },    // Orange
-  { bg: 'hsl(280, 60%, 92%)', fg: 'hsl(280, 60%, 45%)' },  // Purple
-  { bg: 'hsl(0, 70%, 92%)', fg: 'hsl(0, 70%, 45%)' },      // Red
-  { bg: 'hsl(180, 60%, 90%)', fg: 'hsl(180, 60%, 35%)' },  // Teal
-  { bg: 'hsl(50, 80%, 90%)', fg: 'hsl(50, 80%, 35%)' },    // Yellow
-  { bg: 'hsl(330, 60%, 92%)', fg: 'hsl(330, 60%, 45%)' },  // Pink
+  { bg: 'var(--saga-service-1-bg)', fg: 'var(--saga-service-1-fg)' },  // Blue
+  { bg: 'var(--saga-service-2-bg)', fg: 'var(--saga-service-2-fg)' },  // Green
+  { bg: 'var(--saga-service-3-bg)', fg: 'var(--saga-service-3-fg)' },  // Orange
+  { bg: 'var(--saga-service-4-bg)', fg: 'var(--saga-service-4-fg)' },  // Purple
+  { bg: 'var(--saga-service-5-bg)', fg: 'var(--saga-service-5-fg)' },  // Red
+  { bg: 'var(--saga-service-6-bg)', fg: 'var(--saga-service-6-fg)' },  // Teal
+  { bg: 'var(--saga-service-7-bg)', fg: 'var(--saga-service-7-fg)' },  // Yellow
+  { bg: 'var(--saga-service-8-bg)', fg: 'var(--saga-service-8-fg)' },  // Pink
 ]
 
 // Separate palette for saga highlighting (border/outline colors)
 const SAGA_PALETTE = [
-  'hsl(220, 70%, 50%)',   // Blue
-  'hsl(150, 60%, 40%)',   // Green
-  'hsl(30, 80%, 50%)',    // Orange
-  'hsl(280, 60%, 50%)',   // Purple
-  'hsl(0, 70%, 50%)',     // Red
-  'hsl(180, 60%, 40%)',   // Teal
+  'var(--saga-service-1-fg)',  // Blue
+  'var(--saga-service-2-fg)',  // Green
+  'var(--saga-service-3-fg)',  // Orange
+  'var(--saga-service-4-fg)',  // Purple
+  'var(--saga-service-5-fg)',  // Red
+  'var(--saga-service-6-fg)',  // Teal
 ]
 
 function buildServiceColorMap(flows: SagaFlow[]): Map<string, { bg: string; fg: string }> {
@@ -173,8 +173,8 @@ const StepNode = memo(function StepNode({ data }: { data: StepNodeData }) {
                   key={`${call.service}.${call.method}.${idx}`}
                   className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium"
                   style={{
-                    backgroundColor: colors?.bg ?? 'hsl(0, 0%, 92%)',
-                    color: colors?.fg ?? 'hsl(0, 0%, 45%)',
+                    backgroundColor: colors?.bg ?? 'var(--muted)',
+                    color: colors?.fg ?? 'var(--muted-foreground)',
                   }}
                 >
                   {call.service}.{call.method}

--- a/frontend/src/features/forecasting/pages/index.tsx
+++ b/frontend/src/features/forecasting/pages/index.tsx
@@ -126,7 +126,7 @@ function CurveChart({ points, label }: CurveChartProps) {
         <path
           d={pathData}
           fill="none"
-          stroke="#f59e0b"
+          stroke="var(--chart-4)"
           strokeWidth={2}
           strokeDasharray="6 3"
           strokeLinejoin="round"
@@ -139,7 +139,7 @@ function CurveChart({ points, label }: CurveChartProps) {
             cx={toSvgX(p.x)}
             cy={toSvgY(p.y)}
             r={3}
-            fill="#f59e0b"
+            fill="var(--chart-4)"
           />
         ))}
       </svg>

--- a/frontend/src/features/reference-data/components/execution-subgraph.tsx
+++ b/frontend/src/features/reference-data/components/execution-subgraph.tsx
@@ -32,18 +32,18 @@ import type {
 import { filterSubgraph } from '@/features/reference-data/lib/filter-subgraph'
 
 const NODE_THEMES: Record<ManifestNodeType, { color: string }> = {
-  instrument: { color: '#3b82f6' },
-  account_type: { color: '#22c55e' },
-  valuation_rule: { color: '#f59e0b' },
-  saga: { color: '#8b5cf6' },
+  instrument: { color: 'var(--graph-instrument)' },
+  account_type: { color: 'var(--graph-account-type)' },
+  valuation_rule: { color: 'var(--graph-valuation-rule)' },
+  saga: { color: 'var(--graph-saga)' },
 }
 
 const EDGE_STYLES: Record<string, React.CSSProperties> = {
-  allowed_by: { stroke: '#3b82f6', strokeWidth: 2 },
-  converts_from: { stroke: '#f59e0b', strokeWidth: 1.5, strokeDasharray: '6 3' },
-  converts_to: { stroke: '#f59e0b', strokeWidth: 1.5 },
-  writes_to: { stroke: '#8b5cf6', strokeWidth: 1.5 },
-  uses_valuation: { stroke: '#f59e0b', strokeWidth: 1.5, strokeDasharray: '4 2' },
+  allowed_by: { stroke: 'var(--graph-instrument)', strokeWidth: 2 },
+  converts_from: { stroke: 'var(--graph-valuation-rule)', strokeWidth: 1.5, strokeDasharray: '6 3' },
+  converts_to: { stroke: 'var(--graph-valuation-rule)', strokeWidth: 1.5 },
+  writes_to: { stroke: 'var(--graph-saga)', strokeWidth: 1.5 },
+  uses_valuation: { stroke: 'var(--graph-valuation-rule)', strokeWidth: 1.5, strokeDasharray: '4 2' },
 }
 
 interface SubgraphNodeData {
@@ -123,7 +123,7 @@ export function ExecutionSubgraph({ graph, focusNodeId }: ExecutionSubgraphProps
       source: e.source,
       target: e.target,
       style: EDGE_STYLES[e.relationship] ?? {},
-      markerEnd: { type: 'arrowclosed' as const, color: (EDGE_STYLES[e.relationship]?.stroke as string) ?? '#999' },
+      markerEnd: { type: 'arrowclosed' as const, color: (EDGE_STYLES[e.relationship]?.stroke as string) ?? 'var(--graph-diff-unchanged)' },
     }))
 
     const nodeMap = new Map(subgraph.nodes.map((n) => [n.id, n]))

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -110,6 +110,24 @@
     --graph-diff-removed: oklch(0.577 0.245 27.325);
     --graph-diff-modified: oklch(0.75 0.15 85);
     --graph-diff-unchanged: oklch(0.554 0.046 257.417);
+
+    /* Saga service palette — rotating colors for dynamically assigned services */
+    --saga-service-1-bg: oklch(0.93 0.04 250);
+    --saga-service-1-fg: oklch(0.45 0.15 250);
+    --saga-service-2-bg: oklch(0.93 0.04 145);
+    --saga-service-2-fg: oklch(0.40 0.13 145);
+    --saga-service-3-bg: oklch(0.93 0.05 55);
+    --saga-service-3-fg: oklch(0.50 0.16 55);
+    --saga-service-4-bg: oklch(0.93 0.04 295);
+    --saga-service-4-fg: oklch(0.45 0.15 295);
+    --saga-service-5-bg: oklch(0.93 0.05 27);
+    --saga-service-5-fg: oklch(0.45 0.18 27);
+    --saga-service-6-bg: oklch(0.93 0.04 195);
+    --saga-service-6-fg: oklch(0.40 0.13 195);
+    --saga-service-7-bg: oklch(0.93 0.05 85);
+    --saga-service-7-fg: oklch(0.42 0.14 85);
+    --saga-service-8-bg: oklch(0.93 0.04 340);
+    --saga-service-8-fg: oklch(0.45 0.15 340);
 }
 
 .dark {
@@ -165,6 +183,24 @@
     --graph-diff-removed: oklch(0.704 0.191 22.216);
     --graph-diff-modified: oklch(0.75 0.18 85);
     --graph-diff-unchanged: oklch(0.704 0.04 256.788);
+
+    /* Saga service palette — rotating colors for dynamically assigned services */
+    --saga-service-1-bg: oklch(0.22 0.06 250);
+    --saga-service-1-fg: oklch(0.65 0.18 250);
+    --saga-service-2-bg: oklch(0.22 0.06 145);
+    --saga-service-2-fg: oklch(0.65 0.18 145);
+    --saga-service-3-bg: oklch(0.22 0.07 55);
+    --saga-service-3-fg: oklch(0.72 0.18 55);
+    --saga-service-4-bg: oklch(0.22 0.06 295);
+    --saga-service-4-fg: oklch(0.65 0.18 295);
+    --saga-service-5-bg: oklch(0.22 0.07 27);
+    --saga-service-5-fg: oklch(0.70 0.19 27);
+    --saga-service-6-bg: oklch(0.22 0.06 195);
+    --saga-service-6-fg: oklch(0.65 0.17 195);
+    --saga-service-7-bg: oklch(0.22 0.07 85);
+    --saga-service-7-fg: oklch(0.75 0.18 85);
+    --saga-service-8-bg: oklch(0.22 0.06 340);
+    --saga-service-8-fg: oklch(0.65 0.18 340);
 }
 
 @layer base {


### PR DESCRIPTION
## Summary

Three components used hard-coded hex/HSL color values for graph and chart rendering, which broke dark mode theming. This PR replaces all hard-coded colors with CSS custom properties already defined in `index.css`.

## Changes Made

### `execution-subgraph.tsx`
- `NODE_THEMES` maps node types to hard-coded hex values (`#3b82f6`, `#22c55e`, `#f59e0b`, `#8b5cf6`) — replaced with `var(--graph-instrument)`, `var(--graph-account-type)`, `var(--graph-valuation-rule)`, `var(--graph-saga)`
- `EDGE_STYLES` stroke colors likewise replaced with graph tokens
- Fallback arrow color `#999` replaced with `var(--graph-diff-unchanged)`

### `saga-flow.tsx`
- `SERVICE_PALETTE` (8 entries, rotating bg+fg pairs) used hard-coded HSL with 92% lightness — unusable in dark mode
- `SAGA_PALETTE` (6 border/outline colors) used hard-coded HSL values
- Both palettes replaced with references to new `--saga-service-N-bg` / `--saga-service-N-fg` tokens
- Fallback badge colors `hsl(0,0%,92%)` / `hsl(0,0%,45%)` replaced with `var(--muted)` / `var(--muted-foreground)`

### `index.css`
- Added 8-entry saga service palette in both `:root` (light) and `.dark` sections
- Light: high-lightness bg tokens with saturated fg tokens
- Dark: low-lightness bg tokens with lighter fg tokens for sufficient contrast

### `forecasting/pages/index.tsx`
- SVG `stroke` and `fill` on the forward curve chart replaced `#f59e0b` with `var(--chart-4)` (amber in both modes)

## Testing

All tests for the three modified components pass:
- `execution-subgraph.test.tsx` — 7 tests passing
- `saga-flow.test.tsx` — 20+ tests passing
- `forecasting/pages/index.test.tsx` — 10 tests passing