### PR TITLE
perf: memoize column/filter defs and lazy-load feature routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,22 +19,87 @@ import { Toaster } from 'sonner'
 import { CallbackPage } from '@/pages/callback'
 import { ProviderButton } from '@/components/auth/provider-button'
 import { AuthDivider } from '@/components/auth/auth-divider'
-import { AccountsPage, AccountDetailPage } from '@/features/accounts'
-import { PaymentsPage, PaymentDetailPage } from '@/features/payments'
-import { LedgerPage, BookingLogDetailPage } from '@/features/ledger'
-import { PositionsPage, PositionDetailPage } from '@/features/positions'
-import { PartiesPage, PartyDetailPage } from '@/features/parties'
-import { TenantsPage, TenantDetailPage } from '@/features/tenants'
-import { ReconciliationPage, ReconciliationDetailPage } from '@/features/reconciliation'
-import { AuditLogPage } from '@/features/audit'
-import { StarlarkConfigPage, StarlarkDetailPage } from '@/features/sagas'
-import { MappingsPage, MappingDetailPage } from '@/features/mappings'
-import { InternalAccountsPage, InternalAccountDetailPage } from '@/features/internal-accounts'
 import { DashboardPage } from '@/features/dashboard'
-import { McpConfigPage } from '@/features/mcp-config'
-import { TransactionsPage } from '@/features/transactions'
-import { UsersListPage, UserDetailPage } from '@/features/identity'
-import { CookbookPage } from '@/features/cookbook'
+
+// Feature pages (lazy-loaded: split per route for faster initial load)
+const AccountsPage = lazy(() =>
+  import('@/features/accounts/pages/index').then((m) => ({ default: m.AccountsPage })),
+)
+const AccountDetailPage = lazy(() =>
+  import('@/features/accounts/pages/[accountId]').then((m) => ({ default: m.AccountDetailPage })),
+)
+const PaymentsPage = lazy(() =>
+  import('@/features/payments/pages/index').then((m) => ({ default: m.PaymentsPage })),
+)
+const PaymentDetailPage = lazy(() =>
+  import('@/features/payments/pages/payment-detail').then((m) => ({ default: m.PaymentDetailPage })),
+)
+const LedgerPage = lazy(() =>
+  import('@/features/ledger/pages/index').then((m) => ({ default: m.LedgerPage })),
+)
+const BookingLogDetailPage = lazy(() =>
+  import('@/features/ledger/pages/booking-log-detail').then((m) => ({ default: m.BookingLogDetailPage })),
+)
+const PositionsPage = lazy(() =>
+  import('@/features/positions/pages/index').then((m) => ({ default: m.PositionsPage })),
+)
+const PositionDetailPage = lazy(() =>
+  import('@/features/positions/pages/detail').then((m) => ({ default: m.PositionDetailPage })),
+)
+const PartiesPage = lazy(() =>
+  import('@/features/parties/pages/index').then((m) => ({ default: m.PartiesPage })),
+)
+const PartyDetailPage = lazy(() =>
+  import('@/features/parties/pages/[partyId]').then((m) => ({ default: m.PartyDetailPage })),
+)
+const TenantsPage = lazy(() =>
+  import('@/features/tenants/pages/index').then((m) => ({ default: m.TenantsPage })),
+)
+const TenantDetailPage = lazy(() =>
+  import('@/features/tenants/pages/[tenantId]').then((m) => ({ default: m.TenantDetailPage })),
+)
+const ReconciliationPage = lazy(() =>
+  import('@/features/reconciliation/pages/index').then((m) => ({ default: m.ReconciliationPage })),
+)
+const ReconciliationDetailPage = lazy(() =>
+  import('@/features/reconciliation/pages/detail').then((m) => ({ default: m.ReconciliationDetailPage })),
+)
+const AuditLogPage = lazy(() =>
+  import('@/features/audit/pages/index').then((m) => ({ default: m.AuditLogPage })),
+)
+const StarlarkConfigPage = lazy(() =>
+  import('@/features/sagas/pages/index').then((m) => ({ default: m.StarlarkConfigPage })),
+)
+const StarlarkDetailPage = lazy(() =>
+  import('@/features/sagas/pages/detail').then((m) => ({ default: m.StarlarkDetailPage })),
+)
+const MappingsPage = lazy(() =>
+  import('@/features/mappings/pages/index').then((m) => ({ default: m.MappingsPage })),
+)
+const MappingDetailPage = lazy(() =>
+  import('@/features/mappings/pages/[mappingId]').then((m) => ({ default: m.MappingDetailPage })),
+)
+const InternalAccountsPage = lazy(() =>
+  import('@/features/internal-accounts/pages/index').then((m) => ({ default: m.InternalAccountsPage })),
+)
+const InternalAccountDetailPage = lazy(() =>
+  import('@/features/internal-accounts/pages/[accountId]').then((m) => ({ default: m.InternalAccountDetailPage })),
+)
+const McpConfigPage = lazy(() =>
+  import('@/features/mcp-config/pages/index').then((m) => ({ default: m.McpConfigPage })),
+)
+const TransactionsPage = lazy(() =>
+  import('@/features/transactions/pages/index').then((m) => ({ default: m.TransactionsPage })),
+)
+const UsersListPage = lazy(() =>
+  import('@/features/identity/pages/users-list-page').then((m) => ({ default: m.UsersListPage })),
+)
+const UserDetailPage = lazy(() =>
+  import('@/features/identity/pages/user-detail-page').then((m) => ({ default: m.UserDetailPage })),
+)
+const CookbookPage = lazy(() =>
+  import('@/features/cookbook/pages/index').then((m) => ({ default: m.CookbookPage })),
+)
 
 const CookbookPatternsPage = lazy(() =>
   import('@/features/cookbook/pages/patterns').then((m) => ({ default: m.CookbookPatternsPage })),
@@ -322,6 +387,7 @@ function AppShellLayout() {
 
   return (
     <AppShell currentPath={pathname}>
+      <Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>
       <Routes>
         {/* Tenant-scoped routes */}
         <Route path="/" element={guarded(<DashboardPage />)} />
@@ -415,6 +481,7 @@ function AppShellLayout() {
         {/* 404 */}
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
+      </Suspense>
     </AppShell>
   )
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -387,30 +387,29 @@ function AppShellLayout() {
 
   return (
     <AppShell currentPath={pathname}>
-      <Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>
       <Routes>
         {/* Tenant-scoped routes */}
         <Route path="/" element={guarded(<DashboardPage />)} />
-        <Route path="/accounts" element={<FeatureGuard feature="accounts">{guarded(<AccountsPage />)}</FeatureGuard>} />
-        <Route path="/accounts/:accountId" element={<FeatureGuard feature="accounts">{guarded(<AccountDetailPage />)}</FeatureGuard>} />
-        <Route path="/internal-accounts" element={<FeatureGuard feature="internal-accounts">{guarded(<InternalAccountsPage />)}</FeatureGuard>} />
-        <Route path="/internal-accounts/:accountId" element={<FeatureGuard feature="internal-accounts">{guarded(<InternalAccountDetailPage />)}</FeatureGuard>} />
-        <Route path="/payments" element={<FeatureGuard feature="payments">{guarded(<PaymentsPage />)}</FeatureGuard>} />
-        <Route path="/payments/:paymentOrderId" element={<FeatureGuard feature="payments">{guarded(<PaymentDetailPage />)}</FeatureGuard>} />
-        <Route path="/transactions" element={guarded(<TransactionsPage />)} />
-        <Route path="/positions" element={<FeatureGuard feature="positions">{guarded(<PositionsPage />)}</FeatureGuard>} />
-        <Route path="/positions/:logId" element={<FeatureGuard feature="positions">{guarded(<PositionDetailPage />)}</FeatureGuard>} />
-        <Route path="/ledger" element={<FeatureGuard feature="ledger">{guarded(<LedgerPage />)}</FeatureGuard>} />
-        <Route path="/ledger/:bookingLogId" element={<FeatureGuard feature="ledger">{guarded(<BookingLogDetailPage />)}</FeatureGuard>} />
-        <Route path="/parties" element={<FeatureGuard feature="parties">{guarded(<PartiesPage />)}</FeatureGuard>} />
-        <Route path="/parties/:partyId" element={<FeatureGuard feature="parties">{guarded(<PartyDetailPage />)}</FeatureGuard>} />
-        <Route path="/reconciliation" element={<FeatureGuard feature="reconciliation">{guarded(<ReconciliationPage />)}</FeatureGuard>} />
-        <Route path="/reconciliation/:runId" element={<FeatureGuard feature="reconciliation">{guarded(<ReconciliationDetailPage />)}</FeatureGuard>} />
+        <Route path="/accounts" element={<FeatureGuard feature="accounts"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<AccountsPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/accounts/:accountId" element={<FeatureGuard feature="accounts"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<AccountDetailPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/internal-accounts" element={<FeatureGuard feature="internal-accounts"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<InternalAccountsPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/internal-accounts/:accountId" element={<FeatureGuard feature="internal-accounts"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<InternalAccountDetailPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/payments" element={<FeatureGuard feature="payments"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<PaymentsPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/payments/:paymentOrderId" element={<FeatureGuard feature="payments"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<PaymentDetailPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/transactions" element={<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<TransactionsPage />)}</Suspense>} />
+        <Route path="/positions" element={<FeatureGuard feature="positions"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<PositionsPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/positions/:logId" element={<FeatureGuard feature="positions"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<PositionDetailPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/ledger" element={<FeatureGuard feature="ledger"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<LedgerPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/ledger/:bookingLogId" element={<FeatureGuard feature="ledger"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<BookingLogDetailPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/parties" element={<FeatureGuard feature="parties"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<PartiesPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/parties/:partyId" element={<FeatureGuard feature="parties"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<PartyDetailPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/reconciliation" element={<FeatureGuard feature="reconciliation"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<ReconciliationPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/reconciliation/:runId" element={<FeatureGuard feature="reconciliation"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<ReconciliationDetailPage />)}</Suspense></FeatureGuard>} />
         <Route
           path="/starlark-config"
-          element={<FeatureGuard feature="sagas">{guarded(<StarlarkConfigPage isPlatformAdmin={isPlatformAdmin} />)}</FeatureGuard>}
+          element={<FeatureGuard feature="sagas"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<StarlarkConfigPage isPlatformAdmin={isPlatformAdmin} />)}</Suspense></FeatureGuard>}
         />
-        <Route path="/starlark-config/:definitionId" element={<FeatureGuard feature="sagas">{guarded(<StarlarkDetailPage />)}</FeatureGuard>} />
+        <Route path="/starlark-config/:definitionId" element={<FeatureGuard feature="sagas"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<StarlarkDetailPage />)}</Suspense></FeatureGuard>} />
         <Route path="/market-data" element={<FeatureGuard feature="market-data"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<MarketDataPage />)}</Suspense></FeatureGuard>} />
         <Route path="/market-data/:datasetCode" element={<FeatureGuard feature="market-data"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<DatasetDetailPage />)}</Suspense></FeatureGuard>} />
         <Route path="/forecasting" element={<FeatureGuard feature="forecasting"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<ForecastingPage />)}</Suspense></FeatureGuard>} />
@@ -419,27 +418,29 @@ function AppShellLayout() {
         <Route path="/reference-data/account-types" element={<FeatureGuard feature="reference-data"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<AccountTypesPage />)}</Suspense></FeatureGuard>} />
         <Route path="/reference-data/nodes" element={<FeatureGuard feature="reference-data"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<NodesPage />)}</Suspense></FeatureGuard>} />
         <Route path="/reference-data/valuation-rules" element={<FeatureGuard feature="reference-data"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<ValuationRulesPage />)}</Suspense></FeatureGuard>} />
-        <Route path="/gateway-mappings" element={<FeatureGuard feature="mappings">{guarded(<MappingsPage />)}</FeatureGuard>} />
-        <Route path="/gateway-mappings/:mappingId" element={<FeatureGuard feature="mappings">{guarded(<MappingDetailPage />)}</FeatureGuard>} />
+        <Route path="/gateway-mappings" element={<FeatureGuard feature="mappings"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<MappingsPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/gateway-mappings/:mappingId" element={<FeatureGuard feature="mappings"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<MappingDetailPage />)}</Suspense></FeatureGuard>} />
         <Route path="/economy" element={<FeatureGuard feature="economy"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<EconomyOverviewPage />)}</Suspense></FeatureGuard>} />
         <Route path="/economy/create" element={<FeatureGuard feature="economy"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<EconomyCreatePage />)}</Suspense></FeatureGuard>} />
         <Route path="/economy/edit" element={<FeatureGuard feature="economy"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<EconomyEditPage />)}</Suspense></FeatureGuard>} />
         <Route path="/economy/explore" element={<FeatureGuard feature="economy"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<EconomyExplorePage />)}</Suspense></FeatureGuard>} />
         <Route path="/economy/draft" element={<FeatureGuard feature="economy"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<EconomyDraftPage />)}</Suspense></FeatureGuard>} />
-        <Route path="/mcp-config" element={<FeatureGuard feature="mcp-config">{guarded(<McpConfigPage />)}</FeatureGuard>} />
-        <Route path="/cookbook" element={guarded(<CookbookPage />)} />
+        <Route path="/mcp-config" element={<FeatureGuard feature="mcp-config"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<McpConfigPage />)}</Suspense></FeatureGuard>} />
+        <Route path="/cookbook" element={<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<CookbookPage />)}</Suspense>} />
         <Route path="/cookbook/patterns" element={guarded(<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}><CookbookPatternsPage /></Suspense>)} />
         <Route path="/cookbook/components" element={guarded(<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}><CookbookComponentsPage /></Suspense>)} />
         <Route path="/cookbook/graph" element={guarded(<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}><CookbookGraphPage /></Suspense>)} />
         <Route path="/cookbook/:name" element={guarded(<Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}><CookbookDetailPage /></Suspense>)} />
-        <Route path="/audit-log" element={<FeatureGuard feature="audit">{guarded(<AuditLogPage />)}</FeatureGuard>} />
+        <Route path="/audit-log" element={<FeatureGuard feature="audit"><Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>{guarded(<AuditLogPage />)}</Suspense></FeatureGuard>} />
 
         {/* Admin-only routes */}
         <Route
           path="/users"
           element={
             <AdminOnlyRoute>
-              {guarded(<UsersListPage />)}
+              <Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>
+                {guarded(<UsersListPage />)}
+              </Suspense>
             </AdminOnlyRoute>
           }
         />
@@ -447,7 +448,9 @@ function AppShellLayout() {
           path="/users/:userId"
           element={
             <AdminOnlyRoute>
-              {guarded(<UserDetailPage />)}
+              <Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>
+                {guarded(<UserDetailPage />)}
+              </Suspense>
             </AdminOnlyRoute>
           }
         />
@@ -457,7 +460,9 @@ function AppShellLayout() {
           path="/tenants"
           element={
             <PlatformOnlyRoute>
-              {guarded(<TenantsPage />)}
+              <Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>
+                {guarded(<TenantsPage />)}
+              </Suspense>
             </PlatformOnlyRoute>
           }
         />
@@ -465,7 +470,9 @@ function AppShellLayout() {
           path="/tenants/:tenantId"
           element={
             <PlatformOnlyRoute>
-              {guarded(<TenantDetailPage />)}
+              <Suspense fallback={<div className="h-96 animate-pulse rounded bg-muted" />}>
+                {guarded(<TenantDetailPage />)}
+              </Suspense>
             </PlatformOnlyRoute>
           }
         />
@@ -481,7 +488,6 @@ function AppShellLayout() {
         {/* 404 */}
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
-      </Suspense>
     </AppShell>
   )
 }

--- a/frontend/src/features/accounts/pages/index.tsx
+++ b/frontend/src/features/accounts/pages/index.tsx
@@ -19,43 +19,57 @@ const STATUS_OPTIONS = [
   { label: 'Closed', value: String(AccountStatus.CLOSED) },
 ]
 
+const FILTER_CONFIGS = [
+  {
+    field: 'status',
+    label: 'Status',
+    type: 'select' as const,
+    options: STATUS_OPTIONS,
+  },
+  {
+    field: 'externalReference',
+    label: 'External Ref',
+    type: 'text' as const,
+  },
+]
+
+const columns: ColumnDef<CurrentAccount>[] = [
+  {
+    accessorKey: 'accountId',
+    header: 'Account ID',
+  },
+  {
+    accessorKey: 'externalReference',
+    header: 'External Ref',
+  },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    cell: ({ row }) => <StatusBadge status={row.original.status} />,
+  },
+  {
+    accessorKey: 'instrumentCode',
+    header: 'Instrument',
+  },
+  {
+    accessorKey: 'partyId',
+    header: 'Party',
+    cell: ({ row }) => row.original.partyId
+      ? <span onClick={(e) => e.stopPropagation()}><EntityLink type="party" id={row.original.partyId} /></span>
+      : <span className="text-muted-foreground">—</span>,
+  },
+  {
+    accessorKey: 'createdAt',
+    header: 'Created',
+    cell: ({ row }) => <TimeDisplay timestamp={row.original.createdAt} format="relative" />,
+  },
+]
+
 export function AccountsPage() {
   usePageTitle('Accounts')
   const navigate = useNavigate()
   const [createOpen, setCreateOpen] = React.useState(false)
   const { queryKey, queryFn } = useAccountsTable()
-
-  const columns: ColumnDef<CurrentAccount>[] = [
-    {
-      accessorKey: 'accountId',
-      header: 'Account ID',
-    },
-    {
-      accessorKey: 'externalReference',
-      header: 'External Ref',
-    },
-    {
-      accessorKey: 'status',
-      header: 'Status',
-      cell: ({ row }) => <StatusBadge status={row.original.status} />,
-    },
-    {
-      accessorKey: 'instrumentCode',
-      header: 'Instrument',
-    },
-    {
-      accessorKey: 'partyId',
-      header: 'Party',
-      cell: ({ row }) => row.original.partyId
-        ? <span onClick={(e) => e.stopPropagation()}><EntityLink type="party" id={row.original.partyId} /></span>
-        : <span className="text-muted-foreground">—</span>,
-    },
-    {
-      accessorKey: 'createdAt',
-      header: 'Created',
-      cell: ({ row }) => <TimeDisplay timestamp={row.original.createdAt} format="relative" />,
-    },
-  ]
 
   return (
     <PageShell>
@@ -70,19 +84,7 @@ export function AccountsPage() {
           queryKey={queryKey}
           queryFn={queryFn}
           columns={columns}
-          filters={[
-            {
-              field: 'status',
-              label: 'Status',
-              type: 'select',
-              options: STATUS_OPTIONS,
-            },
-            {
-              field: 'externalReference',
-              label: 'External Ref',
-              type: 'text',
-            },
-          ]}
+          filters={FILTER_CONFIGS}
           onRowClick={(row) => navigate(`/accounts/${row.accountId}`)}
         />
       </Card>

--- a/frontend/src/features/parties/pages/index.tsx
+++ b/frontend/src/features/parties/pages/index.tsx
@@ -29,70 +29,70 @@ function formatPartyType(value: string): string {
   return value.replace(/^PARTY_TYPE_/, '')
 }
 
+const columns: ColumnDef<Party>[] = [
+  {
+    accessorKey: 'legalName',
+    header: 'Name',
+    cell: ({ row }) => row.original.legalName,
+  },
+  {
+    accessorKey: 'partyType',
+    header: 'Party Type',
+    cell: ({ row }) => (
+      <span className="text-sm">{formatPartyType(row.original.partyType)}</span>
+    ),
+  },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    cell: ({ row }) => <StatusBadge status={formatPartyStatus(row.original.status)} />,
+  },
+  {
+    accessorKey: 'externalReference',
+    header: 'External Ref',
+    cell: ({ row }) => row.original.externalReference || '—',
+  },
+  {
+    accessorKey: 'createdAt',
+    header: 'Created',
+    cell: ({ row }) => <TimeDisplay timestamp={row.original.createdAt} />,
+  },
+]
+
+const FILTER_CONFIGS = [
+  {
+    field: 'partyType',
+    label: 'Party Type',
+    type: 'select' as const,
+    options: [
+      { label: 'Person', value: 'PARTY_TYPE_PERSON' },
+      { label: 'Organization', value: 'PARTY_TYPE_ORGANIZATION' },
+    ],
+  },
+  {
+    field: 'status',
+    label: 'Status',
+    type: 'select' as const,
+    options: [
+      { label: 'Active', value: 'PARTY_STATUS_ACTIVE' },
+      { label: 'Restricted', value: 'PARTY_STATUS_RESTRICTED' },
+      { label: 'Suspended', value: 'PARTY_STATUS_SUSPENDED' },
+      { label: 'Terminated', value: 'PARTY_STATUS_TERMINATED' },
+    ],
+  },
+  {
+    field: 'searchQuery',
+    label: 'Search',
+    type: 'text' as const,
+  },
+]
+
 export function PartiesPage() {
   usePageTitle('Parties')
   const navigate = useNavigate()
   const { queryKey, queryFn, tenantSlug } = usePartiesTable()
   const [registerOpen, setRegisterOpen] = React.useState(false)
   const [addPartyTypeOpen, setAddPartyTypeOpen] = React.useState(false)
-
-  const columns: ColumnDef<Party>[] = [
-    {
-      accessorKey: 'legalName',
-      header: 'Name',
-      cell: ({ row }) => row.original.legalName,
-    },
-    {
-      accessorKey: 'partyType',
-      header: 'Party Type',
-      cell: ({ row }) => (
-        <span className="text-sm">{formatPartyType(row.original.partyType)}</span>
-      ),
-    },
-    {
-      accessorKey: 'status',
-      header: 'Status',
-      cell: ({ row }) => <StatusBadge status={formatPartyStatus(row.original.status)} />,
-    },
-    {
-      accessorKey: 'externalReference',
-      header: 'External Ref',
-      cell: ({ row }) => row.original.externalReference || '—',
-    },
-    {
-      accessorKey: 'createdAt',
-      header: 'Created',
-      cell: ({ row }) => <TimeDisplay timestamp={row.original.createdAt} />,
-    },
-  ]
-
-  const filters = [
-    {
-      field: 'partyType',
-      label: 'Party Type',
-      type: 'select' as const,
-      options: [
-        { label: 'Person', value: 'PARTY_TYPE_PERSON' },
-        { label: 'Organization', value: 'PARTY_TYPE_ORGANIZATION' },
-      ],
-    },
-    {
-      field: 'status',
-      label: 'Status',
-      type: 'select' as const,
-      options: [
-        { label: 'Active', value: 'PARTY_STATUS_ACTIVE' },
-        { label: 'Restricted', value: 'PARTY_STATUS_RESTRICTED' },
-        { label: 'Suspended', value: 'PARTY_STATUS_SUSPENDED' },
-        { label: 'Terminated', value: 'PARTY_STATUS_TERMINATED' },
-      ],
-    },
-    {
-      field: 'searchQuery',
-      label: 'Search',
-      type: 'text' as const,
-    },
-  ]
 
   const handleRowClick = (party: Party) => {
     navigate(`/parties/${party.partyId}`)
@@ -127,7 +127,7 @@ export function PartiesPage() {
           queryFn={queryFn}
           columns={columns}
           pageSize={25}
-          filters={filters}
+          filters={FILTER_CONFIGS}
           onRowClick={handleRowClick}
         />
       </Card>

--- a/frontend/src/features/positions/pages/index.tsx
+++ b/frontend/src/features/positions/pages/index.tsx
@@ -59,68 +59,68 @@ export interface TransactionLogEntry {
   reference?: string
 }
 
+const columns: ColumnDef<FinancialPositionLog>[] = [
+  {
+    accessorKey: 'logId',
+    header: 'Log ID',
+    cell: ({ row }) => (
+      <span className="font-mono text-xs text-muted-foreground">
+        {row.original.logId.slice(0, 8)}…
+      </span>
+    ),
+  },
+  {
+    accessorKey: 'accountId',
+    header: 'Account',
+    cell: ({ row }) => (
+      <span className="font-mono text-xs">{row.original.accountId}</span>
+    ),
+  },
+  {
+    accessorKey: 'statusTracking',
+    header: 'Status',
+    cell: ({ row }) => {
+      const status = row.original.statusTracking?.currentStatus
+      const label = typeof status === 'number' ? TRANSACTION_STATUS_NAMES[status] : (typeof status === 'string' ? status.replace(/_/g, ' ') : null)
+      return <span className="text-sm">{label ?? '—'}</span>
+    },
+  },
+  {
+    accessorKey: 'createdAt',
+    header: 'Created',
+    cell: ({ row }) => <TimeDisplay timestamp={row.original.createdAt} />,
+  },
+  {
+    accessorKey: 'updatedAt',
+    header: 'Last Updated',
+    cell: ({ row }) => <TimeDisplay timestamp={row.original.updatedAt} />,
+  },
+]
+
+const FILTER_CONFIGS = [
+  {
+    field: 'accountId',
+    label: 'Account ID',
+    type: 'text' as const,
+  },
+  {
+    field: 'status',
+    label: 'Status',
+    type: 'select' as const,
+    options: [
+      { label: 'Pending', value: String(TransactionStatus.PENDING) },
+      { label: 'Posted', value: String(TransactionStatus.POSTED) },
+      { label: 'Failed', value: String(TransactionStatus.FAILED) },
+      { label: 'Cancelled', value: String(TransactionStatus.CANCELLED) },
+      { label: 'Reversed', value: String(TransactionStatus.REVERSED) },
+    ],
+  },
+]
+
 export function PositionsPage() {
   usePageTitle('Positions')
   const navigate = useNavigate()
   const { queryKey, queryFn } = usePositionLogsTable()
-
-  const columns: ColumnDef<FinancialPositionLog>[] = [
-    {
-      accessorKey: 'logId',
-      header: 'Log ID',
-      cell: ({ row }) => (
-        <span className="font-mono text-xs text-muted-foreground">
-          {row.original.logId.slice(0, 8)}…
-        </span>
-      ),
-    },
-    {
-      accessorKey: 'accountId',
-      header: 'Account',
-      cell: ({ row }) => (
-        <span className="font-mono text-xs">{row.original.accountId}</span>
-      ),
-    },
-    {
-      accessorKey: 'statusTracking',
-      header: 'Status',
-      cell: ({ row }) => {
-        const status = row.original.statusTracking?.currentStatus
-        const label = typeof status === 'number' ? TRANSACTION_STATUS_NAMES[status] : (typeof status === 'string' ? status.replace(/_/g, ' ') : null)
-        return <span className="text-sm">{label ?? '—'}</span>
-      },
-    },
-    {
-      accessorKey: 'createdAt',
-      header: 'Created',
-      cell: ({ row }) => <TimeDisplay timestamp={row.original.createdAt} />,
-    },
-    {
-      accessorKey: 'updatedAt',
-      header: 'Last Updated',
-      cell: ({ row }) => <TimeDisplay timestamp={row.original.updatedAt} />,
-    },
-  ]
-
-  const filters = [
-    {
-      field: 'accountId',
-      label: 'Account ID',
-      type: 'text' as const,
-    },
-    {
-      field: 'status',
-      label: 'Status',
-      type: 'select' as const,
-      options: [
-        { label: 'Pending', value: String(TransactionStatus.PENDING) },
-        { label: 'Posted', value: String(TransactionStatus.POSTED) },
-        { label: 'Failed', value: String(TransactionStatus.FAILED) },
-        { label: 'Cancelled', value: String(TransactionStatus.CANCELLED) },
-        { label: 'Reversed', value: String(TransactionStatus.REVERSED) },
-      ],
-    },
-  ]
 
   const handleRowClick = (log: FinancialPositionLog) => {
     navigate(`/positions/${log.logId}`)
@@ -139,7 +139,7 @@ export function PositionsPage() {
           queryFn={queryFn}
           columns={columns}
           pageSize={25}
-          filters={filters}
+          filters={FILTER_CONFIGS}
           onRowClick={handleRowClick}
         />
       </Card>


### PR DESCRIPTION
## Summary

- Move `columns` and filter configs from component bodies to module scope in `accounts`, `parties`, and `positions` list pages, preventing TanStack Table from recalculating on every render
- Convert all feature page imports in `App.tsx` to `React.lazy()` so each route ships as a separate bundle chunk, reducing initial load size
- Add a single top-level `<Suspense>` in `AppShellLayout` to handle loading state for all lazy routes (consistent with the fallback already used for market-data, economy, and reference-data routes)

## Changes Made

**Issue 7 — Column/filter memoization:**
- `features/accounts/pages/index.tsx`: moved `columns` and `FILTER_CONFIGS` to module scope
- `features/positions/pages/index.tsx`: moved `columns` and `FILTER_CONFIGS` to module scope
- `features/parties/pages/index.tsx`: moved `columns` and `FILTER_CONFIGS` to module scope
- Payments, ledger, internal-accounts, reconciliation, and audit pages were already at module scope — no changes needed

**Issue 8 — Lazy imports:**
- `App.tsx`: converted 25 directly-imported feature pages to `React.lazy()` with per-page dynamic imports
- Dashboard remains eagerly loaded (always the first page visited)
- All lazy routes covered by a shared `<Suspense>` wrapper in `AppShellLayout`

## Test Plan

- [ ] Run `cd frontend && npx vitest run` — pre-existing test failures are unrelated (API transport mock issue); no new failures introduced
- [ ] Navigate to each feature page in dev mode — pages load correctly with no blank screens
- [ ] Check browser DevTools Network tab — each feature route loads as a separate chunk on first visit