### PR TITLE
fix: Improve touch targets and dark mode muted text contrast

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -22,7 +22,7 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
+        xs: "h-7 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9 min-w-11 min-h-11",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -142,7 +142,7 @@
     --secondary: oklch(0.279 0.041 260.031);
     --secondary-foreground: oklch(0.984 0.003 247.858);
     --muted: oklch(0.279 0.041 260.031);
-    --muted-foreground: oklch(0.704 0.04 256.788);
+    --muted-foreground: oklch(0.75 0.04 256.788);
     --accent: oklch(0.279 0.041 260.031);
     --accent-foreground: oklch(0.984 0.003 247.858);
     --destructive: oklch(0.704 0.191 22.216);


### PR DESCRIPTION
## Summary
- Bump `xs` button height from `h-6` (24px) to `h-7` (28px) for better mobile tap targets (WCAG 2.5.5)
- Increase dark mode `--muted-foreground` lightness from 0.704 to 0.75 for improved contrast ratio approaching WCAG AAA (7:1)

## Test plan
- [x] Pre-existing test failures confirmed (245 failures on unmodified develop — not caused by this change)
- [ ] Verify xs buttons are visually slightly taller but still compact
- [ ] Verify dark mode muted text is more readable