### PR TITLE
docs: PRD 044 - Manifest as sole source of truth

### DIFF
--- a/docs/prd/044-manifest-as-sole-source-of-truth.md
+++ b/docs/prd/044-manifest-as-sole-source-of-truth.md
@@ -228,22 +228,89 @@ Rewrite `cmd/seed-demo/main.go` to:
 
 This serves as both validation and documentation of the manifest-first approach.
 
-### R8: Manifest Export
+### R8: Manifest Export and Drift Reconciliation
 
-Add `ExportManifest` RPC to the control plane that reconstructs a manifest from the current tenant state. This enables:
+Add `ExportManifest` RPC to the control plane that reconstructs a
+manifest from the current tenant state. This serves two purposes:
+
+**Export**: Generates a manifest from live state, enabling:
 
 - Migrating existing tenants to manifest-first
-- Auditing drift between manifest and runtime state
 - Backing up tenant configuration
+
+**Reconciliation**: Compare the last-applied manifest against
+live state to detect drift. Any resource that was created or
+modified outside the manifest pipeline is flagged.
+
+- `ReconcileManifest` RPC returns a drift report: resources
+  present in live state but absent from manifest, resources
+  whose live state differs from manifest-declared state
+- Operators can choose to either update the manifest to match
+  reality or re-apply the manifest to force convergence
+- Drift detection runs on-demand (via RPC) and optionally on
+  a schedule (e.g., daily reconciliation saga)
+
+This is the enforcement mechanism for R9 below. Even if a direct
+gRPC call somehow bypasses the write guard, reconciliation
+catches it.
+
+### R9: Manifest-Only Write Path (Economy Lockdown)
+
+**All structural changes to a tenant's economy MUST go through
+the manifest.** Direct gRPC mutations to structural resources
+are rejected at the service layer when a manifest is active.
+
+This means:
+
+- `RegisterInstrument`, `CreateDraft` (account types),
+  `RegisterDataSet`, `RegisterDataSource`,
+  `RegisterParty` (organizational), `InitiateAccount` (internal),
+  `CreateSagaDraft`, `CreateMapping`,
+  `UpsertProviderConnection`, `UpsertInstructionRoute`
+  all return `FAILED_PRECONDITION` with message
+  "resource managed by manifest - update the manifest and
+  re-apply" when called directly for a manifest-managed tenant.
+
+- Runtime/operational endpoints remain open:
+  `RecordObservation`, `RegisterParty` (customer type),
+  `InitiateAccount` (customer accounts), saga execution, etc.
+
+- Every `ApplyManifest` call increments the manifest version.
+  The version history provides a full audit trail of every
+  structural change to the economy.
+
+**Implementation approach**:
+
+- Each structural service checks a `manifest_managed` flag on
+  the tenant. If true, reject direct writes for resource types
+  the manifest owns.
+- The manifest executor bypasses this guard via an internal
+  service credential / context flag.
+- Operational gateway changes (new ingest/egress routes,
+  provider connections) follow the same rule: modify the
+  manifest's `operationalGateway` section, re-apply.
+
+**Version control integration**: Because the manifest is a JSON
+file checked into the repo, every economy change flows through
+the normal PR/review/merge cycle. The git history IS the audit
+trail. No structural change happens without a commit.
 
 ## Success Criteria
 
-1. A tenant's entire structural economy can be defined in a single manifest file
-2. `ApplyManifest` with that file creates a fully operational economy (no seed-demo workarounds needed)
+1. A tenant's entire structural economy can be defined in a single
+   manifest file
+2. `ApplyManifest` with that file creates a fully operational economy
+   (no seed-demo workarounds needed)
 3. Market data set definitions are version-controlled in the manifest
-4. Organizational parties and internal accounts are version-controlled in the manifest
+4. Organizational parties and internal accounts are version-controlled
+   in the manifest
 5. The Volt Energy demo runs with manifest-only structural setup
 6. Existing manifests (v1.0) continue to work without modification
+7. Direct gRPC calls to structural endpoints return
+   `FAILED_PRECONDITION` for manifest-managed tenants
+8. `ReconcileManifest` detects resources created outside the manifest
+9. Every structural change is traceable to a manifest version
+   (and therefore a git commit)
 
 ## Non-Goals
 
@@ -256,10 +323,12 @@ Add `ExportManifest` RPC to the control plane that reconstructs a manifest from 
 
 | Risk | Mitigation |
 |------|------------|
-| Proto changes to Manifest message could break existing clients | Additive-only changes, version field gates parsing |
-| Market data sets have complex lifecycle (DRAFT -> ACTIVE -> DEPRECATED) | Manifest apply always targets ACTIVE; deprecation remains a manual operation |
-| Organization references create ordering dependencies | Planner already handles phase ordering; add phases for new resource types |
+| Proto changes could break existing clients | Additive-only changes, version field gates parsing |
+| Market data sets have complex lifecycle | Manifest apply targets ACTIVE; deprecation stays manual |
+| Organization references create ordering deps | Planner already handles phase ordering |
 | Large manifests become unwieldy | Future PRD for manifest composition / includes |
+| Write guards break existing integrations | Feature-flagged rollout per tenant; `manifest_managed` opt-in |
+| Emergency changes blocked by manifest flow | Escape hatch: admin `--force` flag with audit log entry |
 
 ## Implementation Notes
 

--- a/docs/prd/044-manifest-as-sole-source-of-truth.md
+++ b/docs/prd/044-manifest-as-sole-source-of-truth.md
@@ -2,78 +2,190 @@
 
 ## Problem Statement
 
-Meridian currently has two paths to define an economy: the manifest
-(declarative, versioned in DB) and direct gRPC calls (imperative,
-untracked). In practice, tenants like Volt Energy use both: the
-manifest declares instruments and account types, but seed-demo then
-re-registers them via gRPC because "the manifest executor is not
-wired yet." Market data definitions, data sources, and organizational
+Meridian has two paths to define an economy: the manifest
+(declarative) and direct gRPC calls (imperative). In practice,
+tenants like Volt Energy use both: the manifest declares
+instruments and account types, but seed-demo re-registers them
+via gRPC because the manifest executor doesn't fully activate
+them. Market data definitions, data sources, and organizational
 parties are created entirely outside the manifest.
 
-This dual-path architecture undermines Meridian's core value
-proposition: **declare your economy in a manifest and the platform
-operates it**. If half the economy lives in imperative gRPC calls,
-it isn't versioned, isn't reproducible, and can't be diffed or
-audited through the manifest pipeline. Tenants are created
-dynamically - each tenant's economy must be fully defined and
-versioned through their manifest, stored in the DB.
+This means economy state is scattered across services with no
+unified versioning, no diffs, and no audit trail. A tenant
+cannot answer "what changed in my economy last week?" or
+"roll back to yesterday's configuration."
 
-## Current State
+**The goal**: One declarative control plane that owns all
+structural economy state, versions every change, supports
+both full-manifest and granular resource mutations, and
+enables AI/cookbook-driven economy composition.
 
-### What the manifest handles today
+## Architecture: Control Plane Owns Declarations, Services Own Runtime
 
-| Resource | Manifest Section | Executor Wired | Notes |
-|----------|-----------------|---------------|-------|
-| Instruments | `instruments[]` | Partially | Manifest stores definition, but seed-demo re-registers via `ReferenceDataService.RegisterInstrument` because executor doesn't activate |
-| Account Types | `accountTypes[]` | Partially | Same issue - manifest stores, seed-demo activates via `AccountTypeRegistryService` |
-| Valuation Rules | `valuationRules[]` | Yes | Mapped to `RegisterInstrument` in planner |
-| Sagas | `sagas[]` | Yes | Full lifecycle support |
-| Party Types | `partyTypes[]` | Yes | Schema-level definitions |
-| Mappings | `mappings[]` | Yes | Bidirectional field mapping |
-| Operational Gateway | `operationalGateway` | Yes | Provider connections + instruction routes |
-| Payment Rails | `paymentRails[]` | No executor | Proto defined, no planner mapping |
+### The separation
 
-### What is NOT in the manifest at all
+```text
+┌─────────────────────────────────────────────┐
+│              Control Plane                   │
+│                                              │
+│  Owns: All structural resource declarations  │
+│  Stores: Composite manifest (versioned in DB)│
+│  Validates: Cross-service references         │
+│  Executes: Phased dispatch to services       │
+│                                              │
+│  Public APIs:                                │
+│    ApplyManifest  (full economy)             │
+│    ApplyResource  (single resource change)   │
+│    GetManifest    (current composite state)  │
+│    DiffManifest   (compare versions)         │
+│    ListVersions   (audit trail)              │
+│                                              │
+├──────────┬──────────┬──────────┬─────────────┤
+│ ref-data │ market   │ party    │ saga        │
+│          │ info     │          │             │
+│ Owns:    │ Owns:    │ Owns:    │ Owns:       │
+│ runtime  │ runtime  │ runtime  │ runtime     │
+│ state    │ state    │ state    │ state       │
+│          │          │          │             │
+│ Public:  │ Public:  │ Public:  │ Public:     │
+│ read/    │ read/    │ read/    │ read/       │
+│ query    │ query +  │ query +  │ query +     │
+│ only     │ observe  │ customer │ execute     │
+│          │          │ parties  │             │
+│ Internal:│ Internal:│ Internal:│ Internal:   │
+│ register │ register │ register │ create/     │
+│ activate │ activate │ org      │ activate    │
+└──────────┴──────────┴──────────┴─────────────┘
+```
 
-| Resource | Current Path | Why It Matters |
-|----------|-------------|---------------|
-| **Market Data Set Definitions** | `MarketInformationService.RegisterDataSet` | Defines what market data a tenant tracks (WHOLESALE_ENERGY_GBP_KWH, USD_EUR_FX). These are structural, not operational. |
-| **Market Data Sources** | `MarketInformationService.RegisterDataSource` | Defines where data comes from (NORDPOOL, BLOOMBERG). Structural reference data. |
-| **Organizational Parties** | `PartyService.RegisterParty` | DNOs, grid supply points, clearinghouses - structural entities that define the economy's topology. |
-| **Internal Accounts** | `InternalAccountService.InitiateAccount` | Inventory accounts, settlement accounts - the chart of accounts. |
+**Control plane owns declarations** because an economy is a
+coherent dependency graph. Instruments, account types, market
+data, sagas form cross-service references that require
+whole-graph validation:
 
-### What should STAY outside the manifest
+- Account type `ENERGY_TRADING` references instruments
+  `[GBP, KWH]` - must validate they exist
+- Valuation rule `KWH→GBP` references two instruments and
+  a market data source - must validate all three
+- Saga `process_settlement` references account types and
+  instruments - must validate the full chain
 
-| Resource | Why | Path |
-|----------|-----|------|
-| **Customer parties** | Runtime data - customers sign up dynamically | gRPC / API |
-| **Customer accounts** | Runtime data - opened per customer | gRPC / API |
-| **Market data observations** | Operational data - prices arrive continuously | gRPC / feeds |
-| **Transactions / ledger entries** | Operational data | Saga execution |
-| **Account balances** | Derived from transactions | Read-only queries |
+No single service can validate these. The control plane can.
 
-## Desired State
+**Services own runtime** - the actual registered instruments,
+active account types, recorded observations, customer accounts,
+running sagas. Services receive provisioning instructions from
+the control plane executor via internal APIs.
 
-The manifest becomes the **sole source of truth** for everything that defines an economy's structure. The distinction is:
+### Structural vs operational
 
-- **Manifest (structural)**: What *types* of things exist, how they relate, what rules govern them
-- **Runtime (operational)**: Individual *instances* of those types, created by users/systems/sagas
+| Structural (control plane) | Operational (services) |
+|---------------------------|----------------------|
+| Instrument definitions | Registered instrument state |
+| Account type definitions | Active account types, customer accounts |
+| Market data set/source definitions | Price observations |
+| Organizational parties (DNOs, GSPs) | Customer parties |
+| Internal accounts (chart of accounts) | Account balances, transactions |
+| Saga definitions | Saga executions |
+| Valuation rules | Computed valuations |
+| Mappings, operational gateway config | Dispatched instructions |
+| Payment rail config | Payment transactions |
 
-### New manifest sections
+## Two Write Paths, One Source of Truth
+
+### Path 1: ApplyManifest (full economy)
+
+For provisioning new tenants, cookbook-generated economies,
+or wholesale reconfiguration.
+
+```text
+Cookbook/AI/UI generates manifest
+  → ApplyManifest(manifest)
+  → Control plane diffs against current version
+  → Validates full dependency graph
+  → Persists new manifest version to DB
+  → Executes changes in dependency order (phases)
+  → Returns diff summary
+```
+
+### Path 2: ApplyResource (granular change)
+
+For adding one account type, updating a saga, adding a
+market data source. This is the shadcn-style "just add
+this one thing" path.
+
+```text
+Tenant/AI/UI submits one resource change
+  → ApplyResource(instrument_definition)
+  → Control plane reads current manifest from DB
+  → Patches the resource into the composite document
+  → Validates full dependency graph (cross-service refs)
+  → Computes diff (shown to caller if dry_run)
+  → Persists new manifest version to DB
+  → Executes only the affected phases
+  → Returns diff summary
+```
+
+Both paths produce the same result: a new manifest version
+in the DB with a computable diff. The composite manifest is
+always the full picture regardless of how it was assembled.
+
+### Manifest versioning in DB
+
+Every change (whether via `ApplyManifest` or `ApplyResource`)
+creates a new version:
+
+```text
+manifest_versions table:
+  tenant_id       — which tenant
+  version         — monotonically increasing (1, 2, 3...)
+  manifest        — full composite JSON document
+  diff            — what changed from previous version
+  applied_by      — who/what made the change (user, AI, cookbook)
+  applied_at      — timestamp
+  checksum        — SHA-256 of the manifest document
+  source          — "apply_manifest" or "apply_resource"
+  resource_path   — if apply_resource: "instruments/KWH"
+```
+
+### Control plane RPCs
+
+```text
+ApplyManifest         — submit full manifest, diff + apply
+ApplyResource         — submit single resource, patch + diff + apply
+GetManifest           — current active manifest (full composite)
+GetManifestVersion    — specific historical version
+ListManifestVersions  — version history with metadata
+DiffManifestVersions  — diff between any two versions
+ExportManifest        — reconstruct manifest from live state
+ReconcileManifest     — compare DB manifest vs live state
+```
+
+## Current Gaps
+
+### Resources missing from the manifest
+
+| Resource | Current Path | Action |
+|----------|-------------|--------|
+| Market data sets | `RegisterDataSet` | Add to manifest |
+| Market data sources | `RegisterDataSource` | Add to manifest |
+| Organizational parties | `RegisterParty` | Add to manifest |
+| Internal accounts | `InitiateAccount` | Add to manifest |
+
+### Executor gaps
+
+| Resource | Issue | Action |
+|----------|-------|--------|
+| Instruments | Executor doesn't fully activate | Fix lifecycle |
+| Account types | Executor doesn't fully activate | Fix lifecycle |
+| Payment rails | Proto defined, no planner mapping | Wire executor |
+
+## New Manifest Sections
+
+### Market data
 
 ```json
 {
-  "version": "1.1",
-  "metadata": { ... },
-  "instruments": [ ... ],
-  "accountTypes": [ ... ],
-  "valuationRules": [ ... ],
-  "sagas": [ ... ],
-  "partyTypes": [ ... ],
-  "mappings": [ ... ],
-  "operationalGateway": { ... },
-  "paymentRails": [ ... ],
-
   "marketData": {
     "sources": [
       {
@@ -81,12 +193,6 @@ The manifest becomes the **sole source of truth** for everything that defines an
         "name": "Nord Pool Spot Market",
         "description": "Nordic/Baltic electricity exchange",
         "trustLevel": 90
-      },
-      {
-        "code": "INTERNAL_TARIFF",
-        "name": "Internal Tariff Engine",
-        "description": "Internally computed retail tariffs",
-        "trustLevel": 100
       }
     ],
     "dataSets": [
@@ -94,15 +200,23 @@ The manifest becomes the **sole source of truth** for everything that defines an
         "code": "WHOLESALE_ENERGY_GBP_KWH",
         "category": "DATA_CATEGORY_ENERGY_PRICE",
         "unit": "GBP/kWh",
-        "displayName": "Wholesale Energy Price (GBP per kWh)",
-        "description": "Day-ahead wholesale electricity price",
+        "displayName": "Wholesale Energy Price",
         "resolutionKeyExpression": "'spot'",
         "validationExpression": "value > 0 && value < 10.0",
         "sourceCode": "NORDPOOL"
       }
     ]
-  },
+  }
+}
+```
 
+Observations (`RecordObservation`) remain operational - the
+manifest declares *what* you track, not the prices themselves.
+
+### Organizations
+
+```json
+{
   "organizations": [
     {
       "code": "UK_POWER_NETWORKS",
@@ -122,8 +236,17 @@ The manifest becomes the **sole source of truth** for everything that defines an
         "parent_dno": "UK_POWER_NETWORKS"
       }
     }
-  ],
+  ]
+}
+```
 
+Customer parties remain operational - organizations are the
+economy's topology, customers are runtime data.
+
+### Internal accounts (chart of accounts)
+
+```json
+{
   "internalAccounts": [
     {
       "code": "GSP_SOUTH_EAST_KWH_INVENTORY",
@@ -142,249 +265,254 @@ The manifest becomes the **sole source of truth** for everything that defines an
 }
 ```
 
-### Execution phases (updated planner)
+Customer accounts remain operational - internal accounts are
+the economy's plumbing.
+
+## Execution Phases
+
+The control plane executor dispatches changes in dependency
+order. Each phase completes before the next begins:
 
 ```text
-Phase 1: Instruments          (register + activate)
-Phase 2: Account Types        (draft + activate)
-Phase 3: Valuation Rules
-Phase 4: Market Data Sources  (register)
-Phase 5: Market Data Sets     (register + activate)
-Phase 6: Party Types          (schema definitions)
-Phase 7: Organizations        (register structural parties)
-Phase 8: Internal Accounts    (initiate)
-Phase 9: Sagas                (create + activate)
+Phase 1:  Instruments          (register + activate)
+Phase 2:  Account Types        (draft + activate)
+Phase 3:  Valuation Rules
+Phase 4:  Market Data Sources  (register)
+Phase 5:  Market Data Sets     (register + activate)
+Phase 6:  Party Types          (schema definitions)
+Phase 7:  Organizations        (register structural parties)
+Phase 8:  Internal Accounts    (initiate)
+Phase 9:  Sagas                (create + activate)
 Phase 10: Mappings
 Phase 11: Operational Gateway
 Phase 12: Payment Rails
 ```
 
-## Requirements
+`ApplyResource` skips phases that are unaffected by the change.
 
-### R1: Market Data Definitions in Manifest
+## Service API Surface
 
-Add `marketData` section to the Manifest proto with:
+### Structural mutation APIs become internal-only
 
-- `sources[]` - Data source definitions (code, name, trust level)
-- `dataSets[]` - Data set definitions (code, category, unit, CEL expressions)
+These RPCs are removed from the public gateway. The control
+plane executor calls them on the internal service mesh:
 
-**Executor behavior**: On `ApplyManifest`, register data sources first,
-then register and activate data sets. Diff against existing state -
-only create/update what changed.
-
-**What stays runtime**: Actual price observations (`RecordObservation`)
-remain gRPC-only. The manifest declares *what* you track, not
-*what the prices are*.
-
-### R2: Organizational Parties in Manifest
-
-Add `organizations[]` section for structural/institutional parties that define the economy's topology.
-
-**Distinction from customer parties**: Organizations are part of the
-economy's structure (a DNO, a clearinghouse, a grid supply point).
-They exist before any customer signs up. Customer parties are
-runtime data.
-
-**Executor behavior**: Register parties via
-`PartyService.RegisterParty` during manifest apply. Support UPDATE
-for attribute changes. No DELETE (organizations can be deactivated
-but not removed).
-
-### R3: Internal Accounts (Chart of Accounts) in Manifest
-
-Add `internalAccounts[]` section for the structural chart of accounts -
-inventory accounts, settlement accounts, clearing accounts.
-
-**Distinction from customer accounts**: Internal accounts are the
-economy's plumbing. Customer accounts are opened dynamically per
-customer.
-
-**Executor behavior**: Create via
-`InternalAccountService.InitiateAccount`. Support idempotent
-re-creation. Reference organizations by code.
-
-### R4: Fix Instrument and Account Type Executor Wiring
-
-The manifest planner already maps instruments and account types to
-gRPC methods, but the executor doesn't complete the full lifecycle
-(draft -> active). Fix this so `ApplyManifest` fully activates
-instruments and account types without needing seed-demo workarounds.
-
-### R5: Payment Rails Executor
-
-Payment rails are defined in the manifest proto but have no planner
-mapping. Add the mapping so `ApplyManifest` processes them.
-
-### R6: Manifest Version Bump
-
-Bump manifest schema version to `1.1` to signal the expanded schema.
-Maintain backwards compatibility - `1.0` manifests without the new
-sections continue to work.
-
-### R7: Update seed-demo to Manifest-Only
-
-Rewrite `cmd/seed-demo/main.go` to:
-
-1. Apply a single manifest that contains everything (instruments, account types, market data, organizations, internal accounts)
-2. Use gRPC only for runtime operational data (customer parties, customer accounts, meter reads, price observations)
-
-This serves as both validation and documentation of the manifest-first approach.
-
-### R8: Manifest Persistence, Export, and Reconciliation
-
-**The database is the sole source of truth for every tenant's
-economy definition.** Tenants are created dynamically (via API,
-UI, onboarding flows). Each tenant's manifest is submitted via
-`ApplyManifest` and versioned in the DB. There is no assumption
-of a git workflow - the platform owns the version history.
-
-**Manifest version store**: Every `ApplyManifest` call persists
-the full manifest document to a `manifest_versions` table:
-
-- `tenant_id`, `version` (monotonically increasing),
-  `manifest_document` (full JSON), `applied_by`,
-  `applied_at`, `diff_summary`, `checksum` (SHA-256)
-- The current active manifest is always queryable via
-  `GetManifest` RPC
-- Previous versions are retained for audit and rollback
-- The diff between any two versions is computable via
-  `DiffManifestVersions` RPC
-- Rollback to a previous version via
-  `ApplyManifest` with a prior version's document
-
-**Manifest lifecycle**:
-
-```text
-Tenant created -> First ApplyManifest (v1) -> economy provisioned
-             -> ApplyManifest (v2) -> diff computed, changes applied
-             -> ApplyManifest (v3) -> ...
-             -> GetManifest -> returns current active manifest
-             -> ListManifestVersions -> full version history
-             -> DiffManifestVersions(v2, v3) -> what changed
-```
-
-**Export** (`ExportManifest` RPC): Reconstructs a manifest from
-the current live state. Used for:
-
-- Migrating existing tenants that were set up via direct gRPC
-  before this feature existed
-- Bootstrapping the first manifest version for a tenant
-
-**Reconciliation** (`ReconcileManifest` RPC): Compares the
-last-applied manifest (from DB) against live resource state.
-Reports any drift. This is a safety net, not the primary
-enforcement (R9 removes the APIs that could cause drift).
-
-### R9: Remove Public Structural Mutation APIs
-
-**Don't guard the APIs - remove them from the public surface.**
-If the endpoints don't exist publicly, drift is impossible by
-construction rather than by runtime checks.
-
-The following RPCs are removed from the public gateway / HTTP
-routes and become **internal-only** (callable only by the
-manifest executor via internal service mesh):
-
-- `ReferenceDataService`: `RegisterInstrument`,
-  `UpdateInstrument`, `DeprecateInstrument`
-- `AccountTypeRegistryService`: `CreateDraft`,
-  `ActivateAccountType`
-- `MarketInformationService`: `RegisterDataSet`,
-  `ActivateDataSet`, `DeprecateDataSet`,
-  `RegisterDataSource`, `DeactivateDataSource`
-- `PartyService`: `RegisterParty` (organizational types only),
-  `UpdateSchema`
-- `InternalAccountService`: `InitiateAccount` (structural)
-- `SagaService`: `CreateSagaDraft`, `ActivateSaga`,
-  `DeprecateSaga`
-- `MappingService`: `CreateMapping`, `UpdateMapping`,
+- **reference-data**: `RegisterInstrument`, `UpdateInstrument`,
+  `DeprecateInstrument`, `CreateDraft`, `ActivateAccountType`
+- **market-information**: `RegisterDataSet`, `ActivateDataSet`,
+  `DeprecateDataSet`, `RegisterDataSource`,
+  `DeactivateDataSource`
+- **party**: `RegisterParty` (organizational), `UpdateSchema`
+- **internal-account**: `InitiateAccount` (structural)
+- **saga**: `CreateSagaDraft`, `ActivateSaga`, `DeprecateSaga`
+- **mapping**: `CreateMapping`, `UpdateMapping`,
   `DeprecateMapping`
-- `OperationalGatewayService`: `UpsertProviderConnection`,
+- **operational-gateway**: `UpsertProviderConnection`,
   `UpsertInstructionRoute`
 
-**What remains public** (runtime/operational endpoints):
+### Public APIs per service (read + operational)
 
-- `MarketInformationService`: `RecordObservation`,
-  `RecordObservationBatch`, `RetrieveObservation`,
-  `ListObservations`, `RetrieveDataSet`, `ListDataSets`
-  (read-only for data sets)
-- `PartyService`: `RegisterParty` (customer types),
-  all read/query endpoints
-- `CurrentAccountService`: all endpoints (customer accounts)
-- `InternalAccountService`: read/query endpoints
-- All saga execution endpoints
-- All read/query endpoints on every service
+Each service retains its own independent API surface for
+reads and operational data. No single monolithic swagger -
+the composite API is assembled from per-service specs:
 
-**Implementation approach**:
+- **reference-data**: Read/query instruments, account types
+- **market-information**: `RecordObservation`,
+  `RecordObservationBatch`, read/query observations and
+  data sets
+- **party**: `RegisterParty` (customer types), read/query
+- **current-account**: All endpoints (customer accounts)
+- **internal-account**: Read/query endpoints
+- **saga**: Execution endpoints, read/query
+- **position-keeping**: All endpoints (operational)
+- **control-plane**: All manifest management RPCs
 
-- Remove structural mutation routes from the gRPC gateway
-  HTTP annotations and public proto surface
-- Structural mutation RPCs become internal service methods
-  callable only via the manifest executor's internal gRPC
-  connection (no external exposure)
-- The manifest executor calls them on the internal service
-  mesh during `ApplyManifest`
-- Operational gateway changes (new ingest/egress routes,
-  provider connections) follow the same rule: update the
-  manifest, re-apply
+### Composite API specification
 
-**Migration path**: Existing tenants using direct gRPC calls
-run `ExportManifest` to generate their initial manifest, then
-switch to manifest-only. A deprecation period warns on direct
-calls before removal.
+The platform API is assembled from per-service specs, not
+maintained as a single monolithic document. Each service
+publishes its own OpenAPI/AsyncAPI spec. The gateway
+composes them under service-scoped paths:
 
-**How tenants update their economy**: Submit a new manifest via
-`ApplyManifest`. The control plane diffs it against the current
-version, computes the execution plan, and applies changes. The
-DB stores every version with full audit trail. Tenants can
-query their manifest history, diff versions, and rollback.
+```text
+/v1/reference-data/...      → reference-data spec
+/v1/market-information/...   → market-information spec
+/v1/parties/...              → party spec
+/v1/control-plane/...        → manifest management spec
+/v1/accounts/...             → current-account spec
+```
+
+## AI and Cookbook Integration
+
+### Economy creation (cookbook → ApplyManifest)
+
+```text
+AI: "What does your business do?"
+  → Selects cookbook recipes (energy trading, carbon, etc.)
+  → Composes recipes into a complete manifest
+  → ApplyManifest(manifest, dry_run=true)
+  → Shows diff to user: "This will create 3 instruments,
+    2 account types, 1 market data source..."
+  → User confirms
+  → ApplyManifest(manifest, dry_run=false)
+  → Economy provisioned
+```
+
+### Economy modification (AI → ApplyResource)
+
+```text
+AI: "Add a carbon credit instrument"
+  → ApplyResource(instrument: {code: "CARBON_CREDIT", ...},
+                   dry_run=true)
+  → Control plane patches into current manifest
+  → Validates: no broken references
+  → Shows diff: "+1 instrument: CARBON_CREDIT"
+  → User confirms
+  → ApplyResource(..., dry_run=false)
+  → New manifest version (v4)
+```
+
+The AI never needs the full manifest in context to make a
+safe change. `ApplyResource` handles the patching, validation,
+and versioning.
+
+### Structured validation errors
+
+Both `ApplyManifest` and `ApplyResource` return structured
+validation errors that humans and AI can act on:
+
+```json
+{
+  "validationErrors": [
+    {
+      "path": "accountTypes[0].allowedInstruments[1]",
+      "code": "REFERENCE_NOT_FOUND",
+      "message": "Instrument 'CARBON' not found. Did you mean 'CARBON_CREDIT'?",
+      "suggestion": "CARBON_CREDIT"
+    },
+    {
+      "path": "marketData.dataSets[0].sourceCode",
+      "code": "REFERENCE_NOT_FOUND",
+      "message": "Data source 'NORDPOOL' not defined in marketData.sources",
+      "suggestion": null
+    },
+    {
+      "path": "sagas[2].script",
+      "code": "STARLARK_SYNTAX_ERROR",
+      "message": "Line 14: undefined: position_keepng (did you mean position_keeping?)",
+      "line": 14,
+      "suggestion": "position_keeping"
+    }
+  ]
+}
+```
+
+Error categories:
+
+- **REFERENCE_NOT_FOUND**: Cross-resource reference to
+  something that doesn't exist (with fuzzy-match suggestions)
+- **DUPLICATE_CODE**: Two resources with the same code
+- **STARLARK_SYNTAX_ERROR**: Saga script compilation failure
+  (with line number)
+- **CEL_SYNTAX_ERROR**: Validation/bucketing expression error
+- **INVALID_VALUE**: Field value fails proto validation
+- **CIRCULAR_DEPENDENCY**: Resource dependency cycle detected
+- **BREAKING_CHANGE**: Change would break existing runtime
+  state (e.g., removing an instrument that has active accounts)
+
+AI receives these errors, fixes the manifest/resource, and
+resubmits. The dry_run flag lets AI validate before applying,
+creating a tight feedback loop without side effects.
+
+### Diff visibility
+
+Every change is diffable:
+
+```text
+DiffManifestVersions(v3, v4):
+  + instruments[2]: CARBON_CREDIT (COMMODITY, 4 decimals)
+
+DiffManifestVersions(v1, v4):
+  + instruments[2]: CARBON_CREDIT
+  ~ accountTypes[0].allowedInstruments: [GBP, KWH] → [GBP, KWH, CARBON_CREDIT]
+  + marketData.dataSets[1]: CARBON_PRICE_GBP
+```
+
+## Reconciliation and Export
+
+**ReconcileManifest**: Compares the DB-stored manifest against
+live resource state across services. Reports drift. With
+structural APIs removed from the public surface, drift should
+be impossible - reconciliation is a safety net.
+
+**ExportManifest**: Reconstructs a manifest from live state.
+Used to migrate existing tenants (set up via direct gRPC
+before this feature) to the manifest-first model.
+
+## Seed-Demo Migration
+
+Rewrite `cmd/seed-demo/main.go` to demonstrate the new model:
+
+1. Create tenant
+2. `ApplyManifest` with complete energy economy (instruments,
+   account types, market data, organizations, internal
+   accounts, sagas)
+3. Operational data via public service APIs (customer parties,
+   customer accounts, meter reads, price observations)
+
+No direct structural gRPC calls. The manifest handles all
+structural provisioning.
 
 ## Success Criteria
 
-1. A tenant's entire structural economy can be defined in a single
-   manifest file
-2. `ApplyManifest` with that file creates a fully operational economy
-   (no seed-demo workarounds needed)
-3. Market data set definitions are version-controlled in the manifest
-4. Organizational parties and internal accounts are version-controlled
-   in the manifest
-5. The Volt Energy demo runs with manifest-only structural setup
-6. Existing manifests (v1.0) continue to work without modification
-7. Structural mutation APIs are not exposed on the public gateway;
-   only the manifest executor can call them internally
-8. `ReconcileManifest` confirms zero drift between DB-stored
-   manifest and live resource state
-9. Every structural change is traceable to a manifest version
-   stored in the DB with full audit metadata
-10. Full manifest version history is queryable per tenant
-    (`GetManifest`, `ListManifestVersions`,
-    `DiffManifestVersions`)
+1. `ApplyManifest` provisions a fully operational economy
+   from a single document (no seed-demo workarounds)
+2. `ApplyResource` modifies a single resource with full
+   validation, diff, and versioning
+3. Every structural change produces a new manifest version
+   in the DB with computable diff
+4. Structural mutation APIs are internal-only; not exposed
+   on the public gateway
+5. Market data definitions, organizations, and internal
+   accounts are part of the manifest
+6. AI/cookbook can create economies via `ApplyManifest` and
+   modify them via `ApplyResource`
+7. `ReconcileManifest` confirms zero drift
+8. Each service retains its own independent API spec for
+   reads and operational endpoints
+9. `DiffManifestVersions` shows exactly what changed between
+   any two versions
+10. Existing v1.0 manifests continue to work
 
 ## Non-Goals
 
-- Migrating runtime/operational data into the manifest (observations, customer accounts, transactions)
-- Scheduled data ingestion configuration (future: operational gateway can handle this)
-- Multi-manifest composition (single manifest per tenant for now)
-- Manifest inheritance or templates (future PRD)
+- Runtime/operational data in the manifest (observations,
+  customer accounts, transactions)
+- Manifest inheritance or overlay merging at runtime
+- Scheduled data ingestion configuration
+- Multi-manifest per tenant
 
 ## Risks
 
 | Risk | Mitigation |
 |------|------------|
-| Proto changes could break existing clients | Additive-only changes, version field gates parsing |
-| Market data sets have complex lifecycle | Manifest apply targets ACTIVE; deprecation stays manual |
-| Organization references create ordering deps | Planner already handles phase ordering |
-| Large manifests become unwieldy | Future PRD for manifest composition / includes |
-| Removing public APIs breaks existing integrations | Deprecation period with warnings before removal; `ExportManifest` for migration |
-| Emergency changes blocked by manifest flow | Escape hatch: admin `--force` flag on `ApplyManifest` with audit log entry |
+| Cross-service validation complexity | Control plane already has the differ/planner; extend it |
+| `ApplyResource` concurrent conflicts | Optimistic locking on manifest version; retry on conflict |
+| Large manifests degrade diff perf | Diff operates on structured sections, not raw JSON |
+| Removing public APIs breaks integrations | Deprecation period; `ExportManifest` for migration |
+| Emergency changes blocked | `ApplyResource` is fast for single changes; admin escape hatch |
 
 ## Implementation Notes
 
-- The `differ` package already supports resource types and action types;
-  extend with `ResourceMarketDataSource`, `ResourceMarketDataSet`,
-  `ResourceOrganization`, `ResourceInternalAccount`
-- The `planner` already maps resource types to phases and gRPC methods;
-  extend the maps
-- The executor dispatches planned calls to gRPC services; new resource
-  types follow the same pattern
-- Proto changes are additive (new repeated fields on Manifest message)
+- Extend `differ` with `ResourceMarketDataSource`,
+  `ResourceMarketDataSet`, `ResourceOrganization`,
+  `ResourceInternalAccount`
+- Extend `planner` phase mapping and gRPC method mapping
+- Add `manifest_versions` table to control-plane DB
+- `ApplyResource` reuses the same differ/planner/executor
+  pipeline as `ApplyManifest` - it just patches one resource
+  into the current manifest first
+- Proto changes are additive (new repeated fields on the
+  Manifest message)
+- Service structural mutation RPCs move from public to
+  internal proto packages (or remove HTTP annotations)

--- a/docs/prd/044-manifest-as-sole-source-of-truth.md
+++ b/docs/prd/044-manifest-as-sole-source-of-truth.md
@@ -3,18 +3,20 @@
 ## Problem Statement
 
 Meridian currently has two paths to define an economy: the manifest
-(version-controlled, declarative) and direct gRPC calls (imperative,
-untracked). In practice, tenants like Volt Energy use both: the manifest
-declares instruments and account types, but seed-demo then re-registers
-them via gRPC because "the manifest executor is not wired yet." Market
-data definitions, data sources, and organizational parties are created
-entirely outside the manifest.
+(declarative, versioned in DB) and direct gRPC calls (imperative,
+untracked). In practice, tenants like Volt Energy use both: the
+manifest declares instruments and account types, but seed-demo then
+re-registers them via gRPC because "the manifest executor is not
+wired yet." Market data definitions, data sources, and organizational
+parties are created entirely outside the manifest.
 
-This dual-path architecture undermines Meridian's core value proposition:
-**declare your economy in a manifest and the platform operates it**. If
-half the economy lives in imperative gRPC calls, it isn't
-version-controlled, isn't reproducible, and can't be diffed or audited
-through the manifest pipeline.
+This dual-path architecture undermines Meridian's core value
+proposition: **declare your economy in a manifest and the platform
+operates it**. If half the economy lives in imperative gRPC calls,
+it isn't versioned, isn't reproducible, and can't be diffed or
+audited through the manifest pipeline. Tenants are created
+dynamically - each tenant's economy must be fully defined and
+versioned through their manifest, stored in the DB.
 
 ## Current State
 
@@ -228,72 +230,114 @@ Rewrite `cmd/seed-demo/main.go` to:
 
 This serves as both validation and documentation of the manifest-first approach.
 
-### R8: Manifest Export and Drift Reconciliation
+### R8: Manifest Persistence, Export, and Reconciliation
 
-Add `ExportManifest` RPC to the control plane that reconstructs a
-manifest from the current tenant state. This serves two purposes:
+**The database is the sole source of truth for every tenant's
+economy definition.** Tenants are created dynamically (via API,
+UI, onboarding flows). Each tenant's manifest is submitted via
+`ApplyManifest` and versioned in the DB. There is no assumption
+of a git workflow - the platform owns the version history.
 
-**Export**: Generates a manifest from live state, enabling:
+**Manifest version store**: Every `ApplyManifest` call persists
+the full manifest document to a `manifest_versions` table:
 
-- Migrating existing tenants to manifest-first
-- Backing up tenant configuration
+- `tenant_id`, `version` (monotonically increasing),
+  `manifest_document` (full JSON), `applied_by`,
+  `applied_at`, `diff_summary`, `checksum` (SHA-256)
+- The current active manifest is always queryable via
+  `GetManifest` RPC
+- Previous versions are retained for audit and rollback
+- The diff between any two versions is computable via
+  `DiffManifestVersions` RPC
+- Rollback to a previous version via
+  `ApplyManifest` with a prior version's document
 
-**Reconciliation**: Compare the last-applied manifest against
-live state to detect drift. Any resource that was created or
-modified outside the manifest pipeline is flagged.
+**Manifest lifecycle**:
 
-- `ReconcileManifest` RPC returns a drift report: resources
-  present in live state but absent from manifest, resources
-  whose live state differs from manifest-declared state
-- Operators can choose to either update the manifest to match
-  reality or re-apply the manifest to force convergence
-- Drift detection runs on-demand (via RPC) and optionally on
-  a schedule (e.g., daily reconciliation saga)
+```text
+Tenant created -> First ApplyManifest (v1) -> economy provisioned
+             -> ApplyManifest (v2) -> diff computed, changes applied
+             -> ApplyManifest (v3) -> ...
+             -> GetManifest -> returns current active manifest
+             -> ListManifestVersions -> full version history
+             -> DiffManifestVersions(v2, v3) -> what changed
+```
 
-This is the enforcement mechanism for R9 below. Even if a direct
-gRPC call somehow bypasses the write guard, reconciliation
-catches it.
+**Export** (`ExportManifest` RPC): Reconstructs a manifest from
+the current live state. Used for:
 
-### R9: Manifest-Only Write Path (Economy Lockdown)
+- Migrating existing tenants that were set up via direct gRPC
+  before this feature existed
+- Bootstrapping the first manifest version for a tenant
 
-**All structural changes to a tenant's economy MUST go through
-the manifest.** Direct gRPC mutations to structural resources
-are rejected at the service layer when a manifest is active.
+**Reconciliation** (`ReconcileManifest` RPC): Compares the
+last-applied manifest (from DB) against live resource state.
+Reports any drift. This is a safety net, not the primary
+enforcement (R9 removes the APIs that could cause drift).
 
-This means:
+### R9: Remove Public Structural Mutation APIs
 
-- `RegisterInstrument`, `CreateDraft` (account types),
-  `RegisterDataSet`, `RegisterDataSource`,
-  `RegisterParty` (organizational), `InitiateAccount` (internal),
-  `CreateSagaDraft`, `CreateMapping`,
-  `UpsertProviderConnection`, `UpsertInstructionRoute`
-  all return `FAILED_PRECONDITION` with message
-  "resource managed by manifest - update the manifest and
-  re-apply" when called directly for a manifest-managed tenant.
+**Don't guard the APIs - remove them from the public surface.**
+If the endpoints don't exist publicly, drift is impossible by
+construction rather than by runtime checks.
 
-- Runtime/operational endpoints remain open:
-  `RecordObservation`, `RegisterParty` (customer type),
-  `InitiateAccount` (customer accounts), saga execution, etc.
+The following RPCs are removed from the public gateway / HTTP
+routes and become **internal-only** (callable only by the
+manifest executor via internal service mesh):
 
-- Every `ApplyManifest` call increments the manifest version.
-  The version history provides a full audit trail of every
-  structural change to the economy.
+- `ReferenceDataService`: `RegisterInstrument`,
+  `UpdateInstrument`, `DeprecateInstrument`
+- `AccountTypeRegistryService`: `CreateDraft`,
+  `ActivateAccountType`
+- `MarketInformationService`: `RegisterDataSet`,
+  `ActivateDataSet`, `DeprecateDataSet`,
+  `RegisterDataSource`, `DeactivateDataSource`
+- `PartyService`: `RegisterParty` (organizational types only),
+  `UpdateSchema`
+- `InternalAccountService`: `InitiateAccount` (structural)
+- `SagaService`: `CreateSagaDraft`, `ActivateSaga`,
+  `DeprecateSaga`
+- `MappingService`: `CreateMapping`, `UpdateMapping`,
+  `DeprecateMapping`
+- `OperationalGatewayService`: `UpsertProviderConnection`,
+  `UpsertInstructionRoute`
+
+**What remains public** (runtime/operational endpoints):
+
+- `MarketInformationService`: `RecordObservation`,
+  `RecordObservationBatch`, `RetrieveObservation`,
+  `ListObservations`, `RetrieveDataSet`, `ListDataSets`
+  (read-only for data sets)
+- `PartyService`: `RegisterParty` (customer types),
+  all read/query endpoints
+- `CurrentAccountService`: all endpoints (customer accounts)
+- `InternalAccountService`: read/query endpoints
+- All saga execution endpoints
+- All read/query endpoints on every service
 
 **Implementation approach**:
 
-- Each structural service checks a `manifest_managed` flag on
-  the tenant. If true, reject direct writes for resource types
-  the manifest owns.
-- The manifest executor bypasses this guard via an internal
-  service credential / context flag.
+- Remove structural mutation routes from the gRPC gateway
+  HTTP annotations and public proto surface
+- Structural mutation RPCs become internal service methods
+  callable only via the manifest executor's internal gRPC
+  connection (no external exposure)
+- The manifest executor calls them on the internal service
+  mesh during `ApplyManifest`
 - Operational gateway changes (new ingest/egress routes,
-  provider connections) follow the same rule: modify the
-  manifest's `operationalGateway` section, re-apply.
+  provider connections) follow the same rule: update the
+  manifest, re-apply
 
-**Version control integration**: Because the manifest is a JSON
-file checked into the repo, every economy change flows through
-the normal PR/review/merge cycle. The git history IS the audit
-trail. No structural change happens without a commit.
+**Migration path**: Existing tenants using direct gRPC calls
+run `ExportManifest` to generate their initial manifest, then
+switch to manifest-only. A deprecation period warns on direct
+calls before removal.
+
+**How tenants update their economy**: Submit a new manifest via
+`ApplyManifest`. The control plane diffs it against the current
+version, computes the execution plan, and applies changes. The
+DB stores every version with full audit trail. Tenants can
+query their manifest history, diff versions, and rollback.
 
 ## Success Criteria
 
@@ -306,11 +350,15 @@ trail. No structural change happens without a commit.
    in the manifest
 5. The Volt Energy demo runs with manifest-only structural setup
 6. Existing manifests (v1.0) continue to work without modification
-7. Direct gRPC calls to structural endpoints return
-   `FAILED_PRECONDITION` for manifest-managed tenants
-8. `ReconcileManifest` detects resources created outside the manifest
+7. Structural mutation APIs are not exposed on the public gateway;
+   only the manifest executor can call them internally
+8. `ReconcileManifest` confirms zero drift between DB-stored
+   manifest and live resource state
 9. Every structural change is traceable to a manifest version
-   (and therefore a git commit)
+   stored in the DB with full audit metadata
+10. Full manifest version history is queryable per tenant
+    (`GetManifest`, `ListManifestVersions`,
+    `DiffManifestVersions`)
 
 ## Non-Goals
 
@@ -327,8 +375,8 @@ trail. No structural change happens without a commit.
 | Market data sets have complex lifecycle | Manifest apply targets ACTIVE; deprecation stays manual |
 | Organization references create ordering deps | Planner already handles phase ordering |
 | Large manifests become unwieldy | Future PRD for manifest composition / includes |
-| Write guards break existing integrations | Feature-flagged rollout per tenant; `manifest_managed` opt-in |
-| Emergency changes blocked by manifest flow | Escape hatch: admin `--force` flag with audit log entry |
+| Removing public APIs breaks existing integrations | Deprecation period with warnings before removal; `ExportManifest` for migration |
+| Emergency changes blocked by manifest flow | Escape hatch: admin `--force` flag on `ApplyManifest` with audit log entry |
 
 ## Implementation Notes
 

--- a/docs/prd/044-manifest-as-sole-source-of-truth.md
+++ b/docs/prd/044-manifest-as-sole-source-of-truth.md
@@ -1,0 +1,273 @@
+# PRD 044: Manifest as Sole Source of Truth
+
+## Problem Statement
+
+Meridian currently has two paths to define an economy: the manifest
+(version-controlled, declarative) and direct gRPC calls (imperative,
+untracked). In practice, tenants like Volt Energy use both: the manifest
+declares instruments and account types, but seed-demo then re-registers
+them via gRPC because "the manifest executor is not wired yet." Market
+data definitions, data sources, and organizational parties are created
+entirely outside the manifest.
+
+This dual-path architecture undermines Meridian's core value proposition:
+**declare your economy in a manifest and the platform operates it**. If
+half the economy lives in imperative gRPC calls, it isn't
+version-controlled, isn't reproducible, and can't be diffed or audited
+through the manifest pipeline.
+
+## Current State
+
+### What the manifest handles today
+
+| Resource | Manifest Section | Executor Wired | Notes |
+|----------|-----------------|---------------|-------|
+| Instruments | `instruments[]` | Partially | Manifest stores definition, but seed-demo re-registers via `ReferenceDataService.RegisterInstrument` because executor doesn't activate |
+| Account Types | `accountTypes[]` | Partially | Same issue - manifest stores, seed-demo activates via `AccountTypeRegistryService` |
+| Valuation Rules | `valuationRules[]` | Yes | Mapped to `RegisterInstrument` in planner |
+| Sagas | `sagas[]` | Yes | Full lifecycle support |
+| Party Types | `partyTypes[]` | Yes | Schema-level definitions |
+| Mappings | `mappings[]` | Yes | Bidirectional field mapping |
+| Operational Gateway | `operationalGateway` | Yes | Provider connections + instruction routes |
+| Payment Rails | `paymentRails[]` | No executor | Proto defined, no planner mapping |
+
+### What is NOT in the manifest at all
+
+| Resource | Current Path | Why It Matters |
+|----------|-------------|---------------|
+| **Market Data Set Definitions** | `MarketInformationService.RegisterDataSet` | Defines what market data a tenant tracks (WHOLESALE_ENERGY_GBP_KWH, USD_EUR_FX). These are structural, not operational. |
+| **Market Data Sources** | `MarketInformationService.RegisterDataSource` | Defines where data comes from (NORDPOOL, BLOOMBERG). Structural reference data. |
+| **Organizational Parties** | `PartyService.RegisterParty` | DNOs, grid supply points, clearinghouses - structural entities that define the economy's topology. |
+| **Internal Accounts** | `InternalAccountService.InitiateAccount` | Inventory accounts, settlement accounts - the chart of accounts. |
+
+### What should STAY outside the manifest
+
+| Resource | Why | Path |
+|----------|-----|------|
+| **Customer parties** | Runtime data - customers sign up dynamically | gRPC / API |
+| **Customer accounts** | Runtime data - opened per customer | gRPC / API |
+| **Market data observations** | Operational data - prices arrive continuously | gRPC / feeds |
+| **Transactions / ledger entries** | Operational data | Saga execution |
+| **Account balances** | Derived from transactions | Read-only queries |
+
+## Desired State
+
+The manifest becomes the **sole source of truth** for everything that defines an economy's structure. The distinction is:
+
+- **Manifest (structural)**: What *types* of things exist, how they relate, what rules govern them
+- **Runtime (operational)**: Individual *instances* of those types, created by users/systems/sagas
+
+### New manifest sections
+
+```json
+{
+  "version": "1.1",
+  "metadata": { ... },
+  "instruments": [ ... ],
+  "accountTypes": [ ... ],
+  "valuationRules": [ ... ],
+  "sagas": [ ... ],
+  "partyTypes": [ ... ],
+  "mappings": [ ... ],
+  "operationalGateway": { ... },
+  "paymentRails": [ ... ],
+
+  "marketData": {
+    "sources": [
+      {
+        "code": "NORDPOOL",
+        "name": "Nord Pool Spot Market",
+        "description": "Nordic/Baltic electricity exchange",
+        "trustLevel": 90
+      },
+      {
+        "code": "INTERNAL_TARIFF",
+        "name": "Internal Tariff Engine",
+        "description": "Internally computed retail tariffs",
+        "trustLevel": 100
+      }
+    ],
+    "dataSets": [
+      {
+        "code": "WHOLESALE_ENERGY_GBP_KWH",
+        "category": "DATA_CATEGORY_ENERGY_PRICE",
+        "unit": "GBP/kWh",
+        "displayName": "Wholesale Energy Price (GBP per kWh)",
+        "description": "Day-ahead wholesale electricity price",
+        "resolutionKeyExpression": "'spot'",
+        "validationExpression": "value > 0 && value < 10.0",
+        "sourceCode": "NORDPOOL"
+      }
+    ]
+  },
+
+  "organizations": [
+    {
+      "code": "UK_POWER_NETWORKS",
+      "name": "UK Power Networks",
+      "partyType": "DISTRIBUTION_NETWORK_OPERATOR",
+      "attributes": {
+        "region": "South East England",
+        "license_area": "SPN"
+      }
+    },
+    {
+      "code": "GSP_SOUTH_EAST",
+      "name": "Grid Supply Point - South East",
+      "partyType": "GRID_SUPPLY_POINT",
+      "attributes": {
+        "gsp_group": "_A",
+        "parent_dno": "UK_POWER_NETWORKS"
+      }
+    }
+  ],
+
+  "internalAccounts": [
+    {
+      "code": "GSP_SOUTH_EAST_KWH_INVENTORY",
+      "accountType": "INVENTORY_KWH",
+      "ownerOrganization": "GSP_SOUTH_EAST",
+      "instrument": "KWH",
+      "description": "KWH inventory for South East GSP"
+    },
+    {
+      "code": "SETTLEMENT_GBP",
+      "accountType": "SETTLEMENT",
+      "instrument": "GBP",
+      "description": "Central GBP settlement account"
+    }
+  ]
+}
+```
+
+### Execution phases (updated planner)
+
+```text
+Phase 1: Instruments          (register + activate)
+Phase 2: Account Types        (draft + activate)
+Phase 3: Valuation Rules
+Phase 4: Market Data Sources  (register)
+Phase 5: Market Data Sets     (register + activate)
+Phase 6: Party Types          (schema definitions)
+Phase 7: Organizations        (register structural parties)
+Phase 8: Internal Accounts    (initiate)
+Phase 9: Sagas                (create + activate)
+Phase 10: Mappings
+Phase 11: Operational Gateway
+Phase 12: Payment Rails
+```
+
+## Requirements
+
+### R1: Market Data Definitions in Manifest
+
+Add `marketData` section to the Manifest proto with:
+
+- `sources[]` - Data source definitions (code, name, trust level)
+- `dataSets[]` - Data set definitions (code, category, unit, CEL expressions)
+
+**Executor behavior**: On `ApplyManifest`, register data sources first,
+then register and activate data sets. Diff against existing state -
+only create/update what changed.
+
+**What stays runtime**: Actual price observations (`RecordObservation`)
+remain gRPC-only. The manifest declares *what* you track, not
+*what the prices are*.
+
+### R2: Organizational Parties in Manifest
+
+Add `organizations[]` section for structural/institutional parties that define the economy's topology.
+
+**Distinction from customer parties**: Organizations are part of the
+economy's structure (a DNO, a clearinghouse, a grid supply point).
+They exist before any customer signs up. Customer parties are
+runtime data.
+
+**Executor behavior**: Register parties via
+`PartyService.RegisterParty` during manifest apply. Support UPDATE
+for attribute changes. No DELETE (organizations can be deactivated
+but not removed).
+
+### R3: Internal Accounts (Chart of Accounts) in Manifest
+
+Add `internalAccounts[]` section for the structural chart of accounts -
+inventory accounts, settlement accounts, clearing accounts.
+
+**Distinction from customer accounts**: Internal accounts are the
+economy's plumbing. Customer accounts are opened dynamically per
+customer.
+
+**Executor behavior**: Create via
+`InternalAccountService.InitiateAccount`. Support idempotent
+re-creation. Reference organizations by code.
+
+### R4: Fix Instrument and Account Type Executor Wiring
+
+The manifest planner already maps instruments and account types to
+gRPC methods, but the executor doesn't complete the full lifecycle
+(draft -> active). Fix this so `ApplyManifest` fully activates
+instruments and account types without needing seed-demo workarounds.
+
+### R5: Payment Rails Executor
+
+Payment rails are defined in the manifest proto but have no planner
+mapping. Add the mapping so `ApplyManifest` processes them.
+
+### R6: Manifest Version Bump
+
+Bump manifest schema version to `1.1` to signal the expanded schema.
+Maintain backwards compatibility - `1.0` manifests without the new
+sections continue to work.
+
+### R7: Update seed-demo to Manifest-Only
+
+Rewrite `cmd/seed-demo/main.go` to:
+
+1. Apply a single manifest that contains everything (instruments, account types, market data, organizations, internal accounts)
+2. Use gRPC only for runtime operational data (customer parties, customer accounts, meter reads, price observations)
+
+This serves as both validation and documentation of the manifest-first approach.
+
+### R8: Manifest Export
+
+Add `ExportManifest` RPC to the control plane that reconstructs a manifest from the current tenant state. This enables:
+
+- Migrating existing tenants to manifest-first
+- Auditing drift between manifest and runtime state
+- Backing up tenant configuration
+
+## Success Criteria
+
+1. A tenant's entire structural economy can be defined in a single manifest file
+2. `ApplyManifest` with that file creates a fully operational economy (no seed-demo workarounds needed)
+3. Market data set definitions are version-controlled in the manifest
+4. Organizational parties and internal accounts are version-controlled in the manifest
+5. The Volt Energy demo runs with manifest-only structural setup
+6. Existing manifests (v1.0) continue to work without modification
+
+## Non-Goals
+
+- Migrating runtime/operational data into the manifest (observations, customer accounts, transactions)
+- Scheduled data ingestion configuration (future: operational gateway can handle this)
+- Multi-manifest composition (single manifest per tenant for now)
+- Manifest inheritance or templates (future PRD)
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Proto changes to Manifest message could break existing clients | Additive-only changes, version field gates parsing |
+| Market data sets have complex lifecycle (DRAFT -> ACTIVE -> DEPRECATED) | Manifest apply always targets ACTIVE; deprecation remains a manual operation |
+| Organization references create ordering dependencies | Planner already handles phase ordering; add phases for new resource types |
+| Large manifests become unwieldy | Future PRD for manifest composition / includes |
+
+## Implementation Notes
+
+- The `differ` package already supports resource types and action types;
+  extend with `ResourceMarketDataSource`, `ResourceMarketDataSet`,
+  `ResourceOrganization`, `ResourceInternalAccount`
+- The `planner` already maps resource types to phases and gRPC methods;
+  extend the maps
+- The executor dispatches planned calls to gRPC services; new resource
+  types follow the same pattern
+- Proto changes are additive (new repeated fields on Manifest message)

--- a/docs/prd/044-manifest-as-sole-source-of-truth.md
+++ b/docs/prd/044-manifest-as-sole-source-of-truth.md
@@ -130,6 +130,11 @@ Both paths produce the same result: a new manifest version
 in the DB with a computable diff. The composite manifest is
 always the full picture regardless of how it was assembled.
 
+Note: until `ApplyResource` ships (Phase 2), clients achieve
+the same result via `GetManifest` → modify → `ApplyManifest`.
+The same validation, diffing, and versioning pipeline runs
+either way.
+
 ### Manifest versioning in DB
 
 Every change (whether via `ApplyManifest` or `ApplyResource`)
@@ -137,16 +142,32 @@ creates a new version:
 
 ```text
 manifest_versions table:
-  tenant_id       — which tenant
-  version         — monotonically increasing (1, 2, 3...)
-  manifest        — full composite JSON document
-  diff            — what changed from previous version
-  applied_by      — who/what made the change (user, AI, cookbook)
-  applied_at      — timestamp
-  checksum        — SHA-256 of the manifest document
-  source          — "apply_manifest" or "apply_resource"
-  resource_path   — if apply_resource: "instruments/KWH"
+  tenant_id        — which tenant
+  sequence_number  — monotonically increasing BIGINT (1, 2, 3...)
+  manifest         — full composite JSON document
+  diff             — what changed from previous version
+  phase_status     — per-phase execution status (JSON)
+  applied_by       — who/what made the change (user, AI, cookbook)
+  applied_at       — timestamp
+  apply_status     — APPLIED | PARTIAL | FAILED | ROLLED_BACK
+  checksum         — SHA-256 of the manifest document
+  source           — "apply_manifest" or "apply_resource"
+  resource_path    — if apply_resource: "instruments/KWH"
 ```
+
+**Concurrency control**: Writes use optimistic locking via
+`sequence_number`. Every write includes
+`WHERE sequence_number = $expected`. Concurrent writes fail
+with a conflict error and the caller retries with the latest
+version. This prevents the lost-update problem where two
+concurrent changes silently overwrite each other.
+
+**Partial execution**: The `phase_status` field records which
+phases completed, which failed, and which were skipped. If
+phase 7 fails after phases 1-6 succeeded, the manifest
+version is persisted with `apply_status = PARTIAL` and the
+phase-level detail. Callers can inspect what succeeded and
+either fix-and-retry or rollback.
 
 ### Control plane RPCs
 
@@ -362,19 +383,20 @@ AI: "What does your business do?"
 
 ```text
 AI: "Add a carbon credit instrument"
-  → ApplyResource(instrument: {code: "CARBON_CREDIT", ...},
-                   dry_run=true)
-  → Control plane patches into current manifest
+  → GetManifest (or ApplyResource when available)
+  → Modifies instrument section
+  → ApplyManifest(manifest, dry_run=true)
   → Validates: no broken references
   → Shows diff: "+1 instrument: CARBON_CREDIT"
   → User confirms
-  → ApplyResource(..., dry_run=false)
+  → ApplyManifest(manifest, dry_run=false)
   → New manifest version (v4)
 ```
 
-The AI never needs the full manifest in context to make a
-safe change. `ApplyResource` handles the patching, validation,
-and versioning.
+The AI modifies only the section it cares about and
+resubmits. The control plane handles validation, diffing,
+and versioning. When `ApplyResource` ships in Phase 2, this
+becomes a single RPC without needing the full manifest.
 
 ### Structured validation errors
 
@@ -417,8 +439,6 @@ Error categories:
 - **CEL_SYNTAX_ERROR**: Validation/bucketing expression error
 - **INVALID_VALUE**: Field value fails proto validation
 - **CIRCULAR_DEPENDENCY**: Resource dependency cycle detected
-- **BREAKING_CHANGE**: Change would break existing runtime
-  state (e.g., removing an instrument that has active accounts)
 
 AI receives these errors, fixes the manifest/resource, and
 resubmits. The dry_run flag lets AI validate before applying,
@@ -449,21 +469,106 @@ be impossible - reconciliation is a safety net.
 Used to migrate existing tenants (set up via direct gRPC
 before this feature) to the manifest-first model.
 
-## Seed-Demo Migration
+## Implementation Phases
 
-Rewrite `cmd/seed-demo/main.go` to demonstrate the new model:
+### Phase 1: The Manifest Actually Works
 
-1. Create tenant
-2. `ApplyManifest` with complete energy economy (instruments,
-   account types, market data, organizations, internal
-   accounts, sagas)
-3. Operational data via public service APIs (customer parties,
-   customer accounts, meter reads, price observations)
+Fix the existing pipeline so `ApplyManifest` provisions a
+fully operational economy with no workarounds.
 
-No direct structural gRPC calls. The manifest handles all
-structural provisioning.
+**Scope**:
 
-## Success Criteria
+1. Fix executor lifecycle for instruments (register +
+   activate) and account types (draft + activate). This is
+   the bug at seed-demo line 132: "manifest executor not
+   wired yet."
+2. Add 4 new resource types to manifest proto, differ,
+   planner, and executor: market data sources, market data
+   sets, organizations, internal accounts.
+3. Add concurrency control to `manifest_versions`:
+   `sequence_number BIGINT` with optimistic locking on write.
+4. Deepen diff to field-level comparison. Current
+   `CompareVersions` only checks top-level key
+   additions/removals; must detect field-level changes
+   within a resource (e.g., precision 2 → 4).
+5. Expose `DiffManifestVersions` as public RPC. The
+   internal `CompareVersions` logic already exists in
+   `HistoryService`; wire it to a proto RPC.
+6. Add partial execution tracking: `phase_status` and
+   `apply_status` fields on manifest versions so callers
+   can see what succeeded when a multi-phase apply fails.
+7. Rewrite seed-demo to use only `ApplyManifest` for
+   structural provisioning. Operational data (customer
+   parties, accounts, observations) via service APIs.
+
+**Success criteria**:
+
+- `ApplyManifest` provisions Volt Energy from a single
+  manifest document
+- seed-demo has zero direct structural gRPC calls
+- `DiffManifestVersions` shows field-level changes
+- Concurrent `ApplyManifest` calls fail safely with a
+  conflict error (no silent data loss)
+- Partial execution failures are recorded with per-phase
+  status
+
+### Phase 2: Granular Mutations
+
+Add `ApplyResource` for single-resource changes, enabling
+AI/cookbook-driven granular economy modification.
+
+**Scope**:
+
+1. `ApplyResource` RPC: read current manifest from DB,
+   patch single resource, validate full dependency graph,
+   diff, execute affected phases only. Uses same
+   differ/planner/executor pipeline as `ApplyManifest`.
+2. Enhanced structured validation errors with fuzzy-match
+   suggestions across all resource types.
+3. `dry_run` mode improvements for both `ApplyManifest`
+   and `ApplyResource` (preview diff without applying).
+4. Wire payment rails into planner (proto defined, no
+   executor mapping yet).
+
+**Success criteria**:
+
+- `ApplyResource` modifies a single resource with full
+  validation, diff, and versioning
+- AI can add an instrument via `ApplyResource` and receive
+  structured errors if references are broken
+- dry_run returns the exact diff that would be applied
+
+### Phase 3: Governance
+
+Lock down the structural mutation APIs and add tooling for
+compliance, drift detection, and tenant migration.
+
+**Scope**:
+
+1. Structural mutation APIs become internal-only. Remove
+   HTTP annotations from public gateway for all structural
+   RPCs listed in "Service API Surface" section.
+2. `ExportManifest` RPC: reconstruct a manifest from live
+   service state. Used to bootstrap the first manifest
+   version for existing tenants.
+3. `ReconcileManifest` RPC: compare DB-stored manifest
+   against live resource state across services. Report
+   drift as structured output.
+4. Migration tooling: deprecation warnings on direct
+   structural API calls during transition period. Tenants
+   run `ExportManifest` to generate their initial manifest,
+   then switch to manifest-only.
+
+**Success criteria**:
+
+- Structural mutation RPCs are not accessible via public
+  gateway
+- `ReconcileManifest` confirms zero drift between DB
+  manifest and live state
+- Existing tenants can migrate via `ExportManifest` →
+  `ApplyManifest`
+
+## Success Criteria (All Phases)
 
 1. `ApplyManifest` provisions a fully operational economy
    from a single document (no seed-demo workarounds)
@@ -491,24 +596,36 @@ structural provisioning.
 - Manifest inheritance or overlay merging at runtime
 - Scheduled data ingestion configuration
 - Multi-manifest per tenant
+- Event-sourced manifest storage (snapshot + diff is
+  sufficient at this scale)
+- Terraform-style plan/apply separation (`dry_run` provides
+  the same preview capability)
+- Runtime-state-aware `BREAKING_CHANGE` detection (requires
+  cross-service runtime queries; defer to service-level
+  rejection during execution)
 
 ## Risks
 
 | Risk | Mitigation |
 |------|------------|
 | Cross-service validation complexity | Control plane already has the differ/planner; extend it |
-| `ApplyResource` concurrent conflicts | Optimistic locking on manifest version; retry on conflict |
+| Concurrent manifest writes | Optimistic locking via `sequence_number` with CAS on write |
+| Partial execution failure | Per-phase status tracking; `apply_status = PARTIAL` with detail |
 | Large manifests degrade diff perf | Diff operates on structured sections, not raw JSON |
-| Removing public APIs breaks integrations | Deprecation period; `ExportManifest` for migration |
-| Emergency changes blocked | `ApplyResource` is fast for single changes; admin escape hatch |
+| Removing public APIs breaks integrations | Phase 3 deprecation period; `ExportManifest` for migration |
+| Shallow diff misses field changes | Deepen `CompareVersions` to use `proto.Equal` per resource |
 
 ## Implementation Notes
 
+- The differ, planner, executor, and history service already
+  exist and are working. This PRD extends them, not replaces.
+- `manifest_versions` table already exists with
+  `HistoryService` providing store, retrieve, list, compare,
+  rollback. Needs `sequence_number` column and `phase_status`.
 - Extend `differ` with `ResourceMarketDataSource`,
   `ResourceMarketDataSet`, `ResourceOrganization`,
   `ResourceInternalAccount`
 - Extend `planner` phase mapping and gRPC method mapping
-- Add `manifest_versions` table to control-plane DB
 - `ApplyResource` reuses the same differ/planner/executor
   pipeline as `ApplyManifest` - it just patches one resource
   into the current manifest first
@@ -516,3 +633,5 @@ structural provisioning.
   Manifest message)
 - Service structural mutation RPCs move from public to
   internal proto packages (or remove HTTP annotations)
+- Reuse the existing `differ.ManifestDiffer` output as the
+  user-facing diff rather than building a second diff engine

--- a/docs/prd/045-manifest-as-sole-source-of-truth.md
+++ b/docs/prd/045-manifest-as-sole-source-of-truth.md
@@ -768,6 +768,52 @@ to typed proto fields. The `seed_data` field continues to
 serve as a catch-all for tenant-specific reference data
 that doesn't warrant its own typed section.
 
+## Manifest Schema Migrations
+
+When the manifest schema evolves (new sections, renamed
+fields, restructured data), stored manifests in
+`manifest_versions` must remain usable for diffs, rollbacks,
+and display. This is the same problem Flyway solves with data
+migrations alongside schema migrations.
+
+**Approach: migrate on read, not on write.** Historical
+manifests are stored as-is, preserving the original document.
+When a stored manifest is read (for diff, rollback, or
+display), a `ManifestMigrator` applies a chain of transforms
+to bring it to the current schema version:
+
+```text
+ManifestMigrator:
+  v1.0 → v1.1: If no internalAccounts section, derive
+                from accountTypes (legacy auto-creation)
+  v1.0 → v1.1: If no marketData section, treat as empty
+  v1.1 → v1.2: (future) If valuationRules reference
+                source by name, resolve to sourceCode
+```
+
+Each transform is:
+
+- **Registered explicitly** — a function that takes a
+  manifest at version N and returns version N+1
+- **Chained** — reading a v1.0 manifest on a v1.2 system
+  applies v1.0→v1.1 then v1.1→v1.2
+- **Idempotent** — running the same transform twice
+  produces the same result
+- **Tested** — each transform has a test with a fixture
+  manifest at the old version
+
+**Rollback with schema evolution**: When a tenant rolls back
+to v2 (stored as schema v1.0), the migrator transforms it
+to the current schema before applying. The saga sees a valid
+current-schema manifest. The historical document is
+preserved — the diff shows what the tenant intended at the
+time, not what it looks like after migration.
+
+**Why not migrate in place**: Batch-updating stored manifests
+mutates the audit trail. Regulators and compliance teams need
+to see the original document as it was applied. Migrate-on-read
+preserves this while keeping the system functional.
+
 ## Non-Goals
 
 - Runtime/operational data in the manifest (observations,

--- a/docs/prd/045-manifest-as-sole-source-of-truth.md
+++ b/docs/prd/045-manifest-as-sole-source-of-truth.md
@@ -187,9 +187,35 @@ GetManifest           — current active manifest (full composite)
 GetManifestVersion    — specific historical version
 ListManifestVersions  — version history with metadata
 DiffManifestVersions  — diff between any two versions
+RollbackManifest      — revert to a previous version
 ExportManifest        — reconstruct manifest from live state
 ReconcileManifest     — compare DB manifest vs live state
 ```
+
+### Rollback
+
+Tenants can revert their economy to any previous manifest
+version:
+
+```text
+Tenant: "Something broke after the last change"
+  → ListManifestVersions → shows v1, v2, v3 (current)
+  → DiffManifestVersions(v2, v3) → shows what changed
+  → RollbackManifest(target_version=2, dry_run=true)
+  → Shows diff: what would change to go from v3 back to v2
+  → Tenant confirms
+  → RollbackManifest(target_version=2, dry_run=false)
+  → Creates v4 with v2's content, re-applies via saga
+  → Economy reverts to v2's structural state
+```
+
+Rollback is a forward-only operation — it creates a new
+manifest version (v4) with the target version's content and
+executes it through the normal `ApplyManifest` pipeline.
+This preserves the full audit trail (v3 is never deleted)
+and reuses the same saga compensation and idempotency
+guarantees. The `HistoryService.RollbackToVersion` method
+already exists and follows this pattern.
 
 ## Current Gaps
 

--- a/docs/prd/045-manifest-as-sole-source-of-truth.md
+++ b/docs/prd/045-manifest-as-sole-source-of-truth.md
@@ -1,4 +1,4 @@
-# PRD 044: Manifest as Sole Source of Truth
+# PRD 045: Manifest as Sole Source of Truth
 
 ## Problem Statement
 

--- a/docs/prd/045-manifest-as-sole-source-of-truth.md
+++ b/docs/prd/045-manifest-as-sole-source-of-truth.md
@@ -140,23 +140,24 @@ either way.
 Every change (whether via `ApplyManifest` or `ApplyResource`)
 creates a new version:
 
-```text
-manifest_versions table:
-  tenant_id        — which tenant
-  sequence_number  — monotonically increasing BIGINT (1, 2, 3...)
-  schema_version   — manifest format version ("1.0", "1.1")
-  manifest         — full composite JSON document
-  diff             — what changed from previous version
-  phase_status     — per-phase execution status (JSON)
-  applied_by       — who/what made the change (user, AI, cookbook)
-  applied_at       — timestamp
-  apply_status     — APPLIED | PARTIAL | FAILED | ROLLED_BACK
-  checksum         — SHA-256 of the manifest document
-  source           — "apply_manifest" or "apply_resource"
-  resource_path    — if apply_resource: "instruments/KWH"
-```
+The `manifest_versions` table already exists. Phase 1 adds:
 
-Note: `sequence_number` is the DB revision counter (1, 2, 3...),
+| Column | Type | Purpose |
+|--------|------|---------|
+| `sequence_number` | BIGINT | Monotonic counter for optimistic locking |
+| `phase_status` | JSONB | Per-phase execution status |
+| `checksum` | VARCHAR(64) | SHA-256 of manifest document |
+| `source` | VARCHAR(20) | "apply_manifest" or "apply_resource" |
+| `resource_path` | VARCHAR(255) | For apply_resource: "instruments/KWH" |
+
+Also alter `apply_status` CHECK constraint to add `PARTIAL`.
+
+Note: CockroachDB cannot alter CHECK constraints in the same
+transaction as column additions. Split into separate migration
+files: one for new columns, one for constraint alteration
+(3-4 migration files total).
+
+`sequence_number` is the DB revision counter (1, 2, 3...),
 distinct from the manifest's own `version` field which tracks
 the schema format ("1.0", "1.1"). Both are stored.
 
@@ -164,7 +165,10 @@ the schema format ("1.0", "1.1"). Both are stored.
 `sequence_number`. Every write includes
 `WHERE sequence_number = $expected`. Concurrent writes fail
 with a conflict error and the caller retries with the latest
-version. This prevents the lost-update problem where two
+version. `ApplyManifestRequest` accepts an optional
+`expected_sequence_number` field so clients performing
+read-modify-write cycles can detect conflicts (ETag
+semantics). This prevents the lost-update problem where two
 concurrent changes silently overwrite each other.
 
 **Partial execution**: The `phase_status` field records which
@@ -300,19 +304,24 @@ The control plane executor dispatches changes in dependency
 order. Each phase completes before the next begins:
 
 ```text
-Phase 1:  Instruments          (register + activate)
-Phase 2:  Account Types        (draft + activate)
-Phase 3:  Market Data Sources  (register)
-Phase 4:  Market Data Sets     (register + activate)
-Phase 5:  Valuation Rules      (via reference-data service)
-Phase 6:  Party Types          (schema definitions)
-Phase 7:  Organizations        (register structural parties)
-Phase 8:  Internal Accounts    (initiate)
-Phase 9:  Sagas                (create + activate)
-Phase 10: Mappings
-Phase 11: Operational Gateway
-Phase 12: Payment Rails
+Phase 10:  Instruments          (register + activate)
+Phase 20:  Account Types        (draft + activate)
+Phase 30:  Market Data Sources  (register)
+Phase 35:  Market Data Sets     (register + activate)
+Phase 40:  Valuation Rules      (via reference-data service)
+Phase 50:  Party Types          (schema definitions)
+Phase 55:  Organizations        (register structural parties)
+Phase 60:  Internal Accounts    (initiate)
+Phase 70:  Sagas                (create + activate)
+Phase 80:  Mappings
+Phase 90:  Operational Gateway
+Phase 100: Payment Rails
 ```
+
+Non-contiguous numbering allows future phases to be inserted
+without renumbering existing constants or breaking tests.
+Current phases 1-8 are remapped to 10-90 in the same PR
+that adds the new phases.
 
 Valuation rules execute after market data sources/sets because
 rules can reference market data sources (e.g., `source:
@@ -322,6 +331,63 @@ current planner already maps them to `RegisterInstrument` /
 `UpdateInstrument`).
 
 `ApplyResource` skips phases that are unaffected by the change.
+
+### Execution architecture
+
+The control plane executes manifest changes via a versioned
+Starlark saga (`apply_manifest`), not direct phased gRPC
+dispatch. The planner produces a dependency-ordered
+`ExecutionPlan` used for:
+
+- **Validation**: Confirms all resource types have valid
+  gRPC method mappings
+- **Dry-run visualization**: Shows callers exactly what
+  would happen, grouped by phase
+- **Diff storage**: Records what changed in each manifest
+  version
+
+The `ManifestExecutor` runs the `apply_manifest` Starlark
+saga via `StarlarkSagaRunner`, which calls registered
+handlers (e.g., `reference_data.register_instrument`). The
+saga provides automatic LIFO compensation on failure,
+idempotency via correlation IDs, and step-level
+observability. Per ADR-0028, the saga script uses platform
+default fallback.
+
+Adding new resource types requires changes in both the
+planner (for preview) and the saga (for execution):
+
+1. Proto field additions on the `Manifest` message
+2. Differ extensions (`diff*` method + `ResourceType`)
+3. Planner phase mapping (for dry-run and visualization)
+4. Go handler implementation + service client interface
+5. Handler registration in `RegisterManifestHandlers`
+6. `buildExecutorInput()` conversion for new proto fields
+7. `apply_manifest` Starlark script update to call new
+   handlers in dependency order
+8. `ManifestValidator` cross-reference validation rules
+
+A conformance test should assert that planner phase ordering
+matches saga script execution order to prevent divergence.
+
+### Failure modes
+
+**Saga compensation**: If phase N fails, the saga engine
+compensates phases N-1 through 1 in LIFO order. The manifest
+version is persisted with `apply_status = PARTIAL` and
+`phase_status` detail showing which phases succeeded, failed,
+and were compensated.
+
+**Retry semantics**: A manifest with `apply_status = PARTIAL`
+can be retried by resubmitting the same manifest. Handlers
+are idempotent (register operations use upsert semantics).
+Already-provisioned resources are no-ops on retry.
+
+**Rollback scope**: `RollbackToVersion` creates a new manifest
+version with the target version's content and re-executes via
+`ApplyManifest`. It does not directly undo service state —
+the saga provisions the "rolled back" desired state as a new
+apply. This is consistent with the K8s desired-state model.
 
 ## Service API Surface
 
@@ -454,6 +520,14 @@ Error categories:
 - **INVALID_VALUE**: Field value fails proto validation
 - **CIRCULAR_DEPENDENCY**: Resource dependency cycle detected
 
+The control plane already provides a `ValidateAndFix` loop
+(used by the economy generator) with structured validation
+errors and LLM-based auto-correction. Phase 1 unifies the
+validation error format: both `ApplyManifest` responses and
+the generator's `ValidateAndFix` use the same
+`ValidationError` proto message. This prevents tenants and
+AI consumers from needing to handle two error schemas.
+
 AI receives these errors, fixes the manifest/resource, and
 resubmits. The dry_run flag lets AI validate before applying,
 creating a tight feedback loop without side effects.
@@ -490,30 +564,68 @@ before this feature) to the manifest-first model.
 Fix the existing pipeline so `ApplyManifest` provisions a
 fully operational economy with no workarounds.
 
-**Scope**:
+**Phase 1a: Make it work** (core value — one-call
+provisioning):
 
-1. Fix executor lifecycle for instruments (register +
-   activate) and account types (draft + activate). This is
-   the bug at seed-demo line 132: "manifest executor not
-   wired yet."
-2. Add 4 new resource types to manifest proto, differ,
-   planner, and executor: market data sources, market data
-   sets, organizations, internal accounts.
-3. Add concurrency control to `manifest_versions`:
-   `sequence_number BIGINT` with optimistic locking on write.
-4. Deepen diff to field-level comparison. Current
-   `CompareVersions` only checks top-level key
-   additions/removals; must detect field-level changes
-   within a resource (e.g., precision 2 → 4).
-5. Expose `DiffManifestVersions` as public RPC. The
+1. Fix instrument activation in the `apply_manifest`
+   Starlark saga script. Add
+   `reference_data.activate_instrument` handler call after
+   `register_instrument`. Verify account type handler
+   already performs draft + activate internally (handler
+   metadata indicates it does — confirm and remove from
+   scope if so).
+2. Add 4 new resource types to the manifest pipeline. For
+   each of market data sources, market data sets,
+   organizations, and internal accounts:
+   - Add typed proto fields to `Manifest` message
+   - Add `ResourceType` constant and `diff*` method to
+     differ
+   - Add phase constant and gRPC method mapping to planner
+     (use non-contiguous phase numbers: 10, 20, 30...)
+   - Add Go handler implementation + service client
+     interface (`MarketInformationServiceClient`,
+     `PartyServiceClient` in `HandlerDependencies`)
+   - Register handler in `RegisterManifestHandlers`
+   - Add input type and conversion to
+     `buildExecutorInput()`
+   - Update `apply_manifest` Starlark script (v1.3.0) to
+     call new handlers in dependency order
+   - Extend `ManifestValidator` with cross-reference
+     validation rules for the new type
+3. Replace shallow `diffManifests()` in HistoryService with
+   output from existing `ManifestDiffer`. The differ already
+   does field-level comparison via `proto.Equal` and has
+   `describe*Changes()` helpers. Store the differ's
+   `DiffPlan` summary as `diff_summary` in
+   `manifest_versions`, replacing `generateDiffSummary()`.
+4. Expose `DiffManifestVersions` as public RPC. The
    internal `CompareVersions` logic already exists in
    `HistoryService`; wire it to a proto RPC.
-6. Add partial execution tracking: `phase_status` and
-   `apply_status` fields on manifest versions so callers
-   can see what succeeded when a multi-phase apply fails.
-7. Rewrite seed-demo to use only `ApplyManifest` for
+5. Fix account type planner mapping. Remap account type
+   actions from `MethodInitiateAccount` (Internal Account
+   Service) to Reference Data methods
+   (`CreateDraft`/`ActivateAccountType`). Internal account
+   initiation moves to `ResourceInternalAccount`.
+6. Rewrite seed-demo to use only `ApplyManifest` for
    structural provisioning. Operational data (customer
    parties, accounts, observations) via service APIs.
+
+Ship resource types as independent PRs in dependency order:
+market data sources (leaf), organizations (leaf) — these
+two can be parallel — then market data sets (depends on
+sources), then internal accounts (depends on account types,
+instruments, and organizations — most complex).
+
+**Phase 1b: Make it safe** (concurrency + observability):
+
+1. Add `sequence_number BIGINT` to `manifest_versions` with
+   optimistic locking on write (`WHERE sequence_number =
+   $expected`). Add `expected_sequence_number` to
+   `ApplyManifestRequest` proto.
+2. Add `phase_status JSONB` and `apply_status = PARTIAL` to
+   manifest versions. Requires separate CockroachDB
+   migration files for column additions vs CHECK constraint
+   alteration.
 
 **Success criteria**:
 
@@ -612,6 +724,16 @@ lists for each - the parser skips them and the planner
 generates no actions for those phases. No migration
 required for existing manifests.
 
+The separation of `internalAccounts` from `accountTypes` is a
+behavioral change. Previously, the saga script auto-created an
+internal account for each account type. With separate manifest
+sections, this coupling is removed. For backward compatibility:
+a manifest without an `internalAccounts` section continues to
+auto-derive internal accounts from account types (the saga
+script checks `if len(internal_accounts) == 0` and falls back
+to the legacy behavior). Tenants opt into explicit internal
+accounts by adding the section.
+
 The existing `seed_data` field (`google.protobuf.Struct`,
 field 7) on the Manifest proto remains unchanged. This PRD
 graduates specific concepts (market data definitions,
@@ -644,28 +766,51 @@ that doesn't warrant its own typed section.
 | Partial execution failure | Per-phase status tracking; `apply_status = PARTIAL` with detail |
 | Large manifests degrade diff perf | Diff operates on structured sections, not raw JSON |
 | Removing public APIs breaks integrations | Phase 3 deprecation period; `ExportManifest` for migration |
-| Shallow diff misses field changes | Deepen `CompareVersions` to use `proto.Equal` per resource |
+| Shallow diff misses field changes | Replace `diffManifests()` with existing `ManifestDiffer` output |
+| Planner-executor divergence | Conformance test asserts planner phase order matches saga execution |
+| AccountType/InternalAccount conflation | Remap planner; backward-compat shim for manifests without `internalAccounts` |
 
 ## Implementation Notes
 
 - The differ, planner, executor, and history service already
   exist and are working. This PRD extends them, not replaces.
-- `manifest_versions` table already exists with
-  `HistoryService` providing store, retrieve, list, compare,
-  rollback. Needs `sequence_number` column and `phase_status`.
+- The executor runs a Starlark saga, not a direct phase
+  dispatcher. Each new resource type requires: Go handler,
+  service client interface in `HandlerDependencies`,
+  handler registration, `buildExecutorInput()` extension,
+  and Starlark script update (`v1.3.0.star`). Planner
+  extensions are also required but only drive dry-run and
+  visualization, not execution.
+- `manifest_versions` table already exists. Needs 3-4
+  migration files for CockroachDB: (1) add
+  `sequence_number`, `phase_status`, `checksum`, `source`,
+  `resource_path` columns, (2) alter `apply_status` CHECK
+  constraint to add `PARTIAL`, (3) backfill
+  `sequence_number` for existing rows.
 - Extend `differ` with `ResourceMarketDataSource`,
   `ResourceMarketDataSet`, `ResourceOrganization`,
   `ResourceInternalAccount`
-- Extend `planner` phase mapping and gRPC method mapping
+- Extend `planner` with non-contiguous phase constants
+  (10, 20, 30...) and gRPC method mappings
+- Fix account type planner mapping: remap from
+  `MethodInitiateAccount` to Reference Data methods.
+  Internal account initiation moves to
+  `ResourceInternalAccount`.
 - `ApplyResource` reuses the same differ/planner/executor
   pipeline as `ApplyManifest` - it just patches one resource
-  into the current manifest first
+  into the current manifest first. The saga already no-ops
+  on empty input sections, so phase skipping works
+  implicitly.
+- Replace shallow `diffManifests()` in HistoryService with
+  serialized `DiffPlan.Actions` from `ManifestDiffer` —
+  reuse, don't rebuild
 - Proto changes are additive (new repeated fields on the
   Manifest message)
 - Service structural mutation RPCs move from public to
   internal proto packages (or remove HTTP annotations)
-- Reuse the existing `differ.ManifestDiffer` output as the
-  user-facing diff rather than building a second diff engine
+- Unify validation error format: `ApplyManifest` responses
+  and the economy generator's `ValidateAndFix` should use
+  the same `ValidationError` proto message
 - ADR-0027 establishes Market Information Service as owner
   of DataSet lifecycle. Making structural APIs internal-only
   (Phase 3) does not change ownership - the service still

--- a/docs/prd/045-manifest-as-sole-source-of-truth.md
+++ b/docs/prd/045-manifest-as-sole-source-of-truth.md
@@ -144,6 +144,7 @@ creates a new version:
 manifest_versions table:
   tenant_id        — which tenant
   sequence_number  — monotonically increasing BIGINT (1, 2, 3...)
+  schema_version   — manifest format version ("1.0", "1.1")
   manifest         — full composite JSON document
   diff             — what changed from previous version
   phase_status     — per-phase execution status (JSON)
@@ -154,6 +155,10 @@ manifest_versions table:
   source           — "apply_manifest" or "apply_resource"
   resource_path    — if apply_resource: "instruments/KWH"
 ```
+
+Note: `sequence_number` is the DB revision counter (1, 2, 3...),
+distinct from the manifest's own `version` field which tracks
+the schema format ("1.0", "1.1"). Both are stored.
 
 **Concurrency control**: Writes use optimistic locking via
 `sequence_number`. Every write includes
@@ -297,9 +302,9 @@ order. Each phase completes before the next begins:
 ```text
 Phase 1:  Instruments          (register + activate)
 Phase 2:  Account Types        (draft + activate)
-Phase 3:  Valuation Rules
-Phase 4:  Market Data Sources  (register)
-Phase 5:  Market Data Sets     (register + activate)
+Phase 3:  Market Data Sources  (register)
+Phase 4:  Market Data Sets     (register + activate)
+Phase 5:  Valuation Rules      (via reference-data service)
 Phase 6:  Party Types          (schema definitions)
 Phase 7:  Organizations        (register structural parties)
 Phase 8:  Internal Accounts    (initiate)
@@ -308,6 +313,13 @@ Phase 10: Mappings
 Phase 11: Operational Gateway
 Phase 12: Payment Rails
 ```
+
+Valuation rules execute after market data sources/sets because
+rules can reference market data sources (e.g., `source:
+"nordpool_spot"`). Valuation rules are registered via the
+reference-data service alongside instrument definitions (the
+current planner already maps them to `RegisterInstrument` /
+`UpdateInstrument`).
 
 `ApplyResource` skips phases that are unaffected by the change.
 
@@ -320,6 +332,8 @@ plane executor calls them on the internal service mesh:
 
 - **reference-data**: `RegisterInstrument`, `UpdateInstrument`,
   `DeprecateInstrument`, `CreateDraft`, `ActivateAccountType`
+  (valuation rules are registered via `RegisterInstrument` as
+  part of the instrument definition)
 - **market-information**: `RegisterDataSet`, `ActivateDataSet`,
   `DeprecateDataSet`, `RegisterDataSource`,
   `DeactivateDataSource`
@@ -589,6 +603,23 @@ compliance, drift detection, and tenant migration.
    any two versions
 10. Existing v1.0 manifests continue to work
 
+## Backward Compatibility
+
+New manifest sections (`marketData`, `organizations`,
+`internalAccounts`) are additive proto fields. A v1.0
+manifest missing these sections is treated as having empty
+lists for each - the parser skips them and the planner
+generates no actions for those phases. No migration
+required for existing manifests.
+
+The existing `seed_data` field (`google.protobuf.Struct`,
+field 7) on the Manifest proto remains unchanged. This PRD
+graduates specific concepts (market data definitions,
+organizations, internal accounts) from untyped seed_data
+to typed proto fields. The `seed_data` field continues to
+serve as a catch-all for tenant-specific reference data
+that doesn't warrant its own typed section.
+
 ## Non-Goals
 
 - Runtime/operational data in the manifest (observations,
@@ -635,3 +666,11 @@ compliance, drift detection, and tenant migration.
   internal proto packages (or remove HTTP annotations)
 - Reuse the existing `differ.ManifestDiffer` output as the
   user-facing diff rather than building a second diff engine
+- ADR-0027 establishes Market Information Service as owner
+  of DataSet lifecycle. Making structural APIs internal-only
+  (Phase 3) does not change ownership - the service still
+  owns the runtime lifecycle logic. The control plane
+  orchestrates when to call it, not how it works internally.
+  This is consistent with the K8s model where controllers
+  own reconciliation logic but the API server owns desired
+  state storage

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -95,6 +95,12 @@ stateDiagram-v2
 | [Org-Scoped Accounts](022-org-scoped-accounts.md) | Multi-party resource pooling following BIAN Syndicate Pattern |
 | [Product Directory](023-product-directory.md) | BIAN-aligned AccountTypeRegistry for runtime-configurable product catalog |
 | [Operations Console UI](026-operations-console-ui.md) | Meridian operations console frontend |
+| [Handler Schema Alignment](040-handler-schema-alignment.md) | Eliminate handlers.yaml; derive handler schemas from proto definitions |
+| [Economy Generator](041-economy-generator.md) | AI-assisted economy generation via MCP tool producing validated manifests |
+| [Economy IDE](042-economy-ide.md) | Conversational economy creation UI with manifest editor and deploy wizard |
+| [MCP Manifest Tenant Isolation](043-mcp-manifest-tenant-isolation.md) | Fix tenant leakage and create-vs-amend mode in MCP manifest validation |
+| [Auth Flow Architecture](044-auth-flow-architecture.md) | Authentication entry points (BFF, SSO, MCP OAuth) and tenant context flow |
+| [Manifest as Sole Source of Truth](045-manifest-as-sole-source-of-truth.md) | Control plane owns all structural economy declarations, versioned in DB |
 
 ### Task Master PRDs (`.taskmaster/docs/`)
 
@@ -232,6 +238,8 @@ material.
   Fourth saga trigger type (`event:`) for reactive workflows via domain events
 - [Meridian Economy Runtime](039-meridian-vm.md) -
   Formalise Meridian as programmable Economy Runtime with AI generator and IDE
+- [Handler Schema Alignment](040-handler-schema-alignment.md) -
+  Eliminate handlers.yaml; derive handler schemas from proto definitions
 
 ### Settlement & Reconciliation
 
@@ -265,6 +273,14 @@ material.
 - [Cookbook Browser](036-cookbook-browser.md) - Visual pattern and component explorer
 - [Manifest Business Model Visualization](038-manifest-business-model-visualization.md) -
   Interactive business model graph from live tenant manifest
+- [Economy Generator](041-economy-generator.md) -
+  AI-assisted economy generation via MCP tool producing validated manifests
+- [Economy IDE](042-economy-ide.md) -
+  Conversational economy creation UI with manifest editor and deploy wizard
+- [MCP Manifest Tenant Isolation](043-mcp-manifest-tenant-isolation.md) -
+  Fix tenant leakage and create-vs-amend mode in MCP manifest validation
+- [Manifest as Sole Source of Truth](045-manifest-as-sole-source-of-truth.md) -
+  Control plane owns all structural economy declarations, versioned in DB
 
 ### Identity & Access Control
 
@@ -277,6 +293,9 @@ Meridian separates access control into two service domains:
 - [Identity and Access Management](031-identity-access-management.md) -
   **Staff/operator access control**: Dynamic user management, role assignment,
   JWT claims population (operational)
+- [Auth Flow Architecture](044-auth-flow-architecture.md) -
+  **Authentication entry points**: BFF password, BFF SSO, MCP OAuth, and
+  tenant context flow through each
 
 <!-- markdownlint-enable MD013 -->
 


### PR DESCRIPTION
## Summary

- Defines the plan to eliminate dual-path economy configuration (manifest + direct gRPC)
- Adds market data definitions, organizational parties, and internal accounts to the manifest schema
- Fixes existing executor gaps (instrument/account type activation, payment rails)
- Includes manifest export RPC for migrating existing tenants

## Context

Volt Energy currently requires both `ApplyManifest` AND direct gRPC calls via seed-demo
to set up a working economy. Market data set definitions (WHOLESALE_ENERGY_GBP_KWH),
data sources (NORDPOOL), organizational parties (DNOs, GSPs), and internal accounts
(inventory, settlement) all bypass the manifest.

This PRD draws a clear line: **structural** configuration belongs in the manifest,
**operational** data (observations, customer accounts, transactions) stays runtime.

## Test plan

- [ ] Review PRD against current manifest proto and planner code
- [ ] Verify the structural vs operational distinction covers all economy primitives
- [ ] Confirm proposed JSON schema is consistent with existing manifest format