### PR TITLE
feat: Add HandlerOptionalTenant for optional tenant resolution

### DIFF
--- a/services/api-gateway/server.go
+++ b/services/api-gateway/server.go
@@ -292,12 +292,13 @@ func (s *Server) wrapWithAuthChain(inner http.Handler) http.Handler {
 	return handler
 }
 
-// wrapWithTenantOnly wraps a handler with tenant resolution only (no auth, no
-// tenant-authz). Used for Dex endpoints where the handler manages its own
-// authentication but needs tenant context for credential lookups.
+// wrapWithTenantOnly wraps a handler with optional tenant resolution (no auth,
+// no tenant-authz). Used for Dex endpoints where the handler manages its own
+// authentication but needs tenant context for credential lookups when available.
+// Requests without a tenant subdomain pass through without error.
 func (s *Server) wrapWithTenantOnly(inner http.Handler) http.Handler {
 	if s.tenantResolver != nil {
-		return s.tenantResolver.Handler(inner)
+		return s.tenantResolver.HandlerOptionalTenant(inner)
 	}
 	return inner
 }

--- a/shared/platform/gateway/tenant_resolver.go
+++ b/shared/platform/gateway/tenant_resolver.go
@@ -73,7 +73,6 @@ type tenantRepository interface {
 var platformPaths = []string{
 	"/v1/tenants",                        // REST transcoding path
 	"/meridian.tenant.v1.TenantService/", // Connect/gRPC path
-	"/dex/",                              // Embedded OIDC identity provider
 }
 
 // IsPlatformPath returns true if the request path is a platform-level endpoint
@@ -179,6 +178,70 @@ func (m *TenantResolverMiddleware) extractSlugFromRequest(w http.ResponseWriter,
 		return ""
 	}
 	return slug
+}
+
+// extractSlugFromRequestOptional extracts the tenant slug from the request
+// without writing HTTP errors. Returns the slug if found, or empty string
+// if no slug is present or the slug is invalid.
+func (m *TenantResolverMiddleware) extractSlugFromRequestOptional(r *http.Request) string {
+	// Check for X-Tenant-Slug header in local dev mode
+	if m.localDevMode {
+		slug := r.Header.Get(TenantSlugHeader)
+		if slug != "" {
+			if !isValidSlug(slug) {
+				m.logger.Debug("invalid slug in X-Tenant-Slug header (optional mode)",
+					slog.String("slug", slug),
+				)
+				return ""
+			}
+			m.logger.Debug("using X-Tenant-Slug header (LOCAL_DEV_MODE, optional mode)",
+				slog.String("slug", slug))
+			return slug
+		}
+	}
+
+	// Fall back to subdomain extraction
+	return m.extractSlug(r.Host)
+}
+
+// HandlerOptionalTenant returns an http.Handler that performs optional tenant resolution.
+// Unlike Handler, this method:
+//   - Does NOT skip resolution based on platformPaths
+//   - Does NOT return errors when no tenant can be resolved
+//   - Passes through to the next handler regardless of resolution outcome
+//
+// If a valid tenant subdomain is present, the tenant is resolved and injected
+// into the request context. Otherwise, the request proceeds without tenant context.
+func (m *TenantResolverMiddleware) HandlerOptionalTenant(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		slug := m.extractSlugFromRequestOptional(r)
+		if slug == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		ctx := r.Context()
+		tenantID, err := m.resolveTenant(ctx, slug)
+		if err != nil {
+			m.logger.Debug("optional tenant resolution failed, proceeding without tenant",
+				slog.String("slug", slug),
+				slog.String("error", err.Error()),
+			)
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		m.logger.Debug("optional tenant resolved successfully",
+			slog.String("tenant_slug", slug),
+			slog.String("tenant_id", tenantID.String()),
+		)
+
+		r.Header.Set(tenant.TenantIDKey, string(tenantID))
+		ctx = tenant.WithTenant(ctx, tenantID)
+		r = r.WithContext(ctx)
+
+		next.ServeHTTP(w, r)
+	})
 }
 
 // Handler returns an http.Handler that performs tenant resolution.

--- a/shared/platform/gateway/tenant_resolver_test.go
+++ b/shared/platform/gateway/tenant_resolver_test.go
@@ -938,11 +938,11 @@ func TestIsPlatformPath(t *testing.T) {
 	assert.True(t, IsPlatformPath("/meridian.tenant.v1.TenantService/CreateTenant"))
 	assert.True(t, IsPlatformPath("/meridian.tenant.v1.TenantService/GetTenant"))
 
-	// Dex OIDC identity provider paths
-	assert.True(t, IsPlatformPath("/dex/auth"))
-	assert.True(t, IsPlatformPath("/dex/callback"))
-	assert.True(t, IsPlatformPath("/dex/keys"))
-	assert.True(t, IsPlatformPath("/dex/token"))
+	// Dex OIDC paths are NOT platform paths (handled by HandlerOptionalTenant)
+	assert.False(t, IsPlatformPath("/dex/auth"))
+	assert.False(t, IsPlatformPath("/dex/callback"))
+	assert.False(t, IsPlatformPath("/dex/keys"))
+	assert.False(t, IsPlatformPath("/dex/token"))
 
 	// Non-platform paths
 	assert.False(t, IsPlatformPath("/v1/accounts"))
@@ -1250,4 +1250,181 @@ func TestLocalDevMode(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestHandlerOptionalTenant_WithValidSubdomain(t *testing.T) {
+	ctx := context.Background()
+	baseDomain := "api.meridian.io"
+	testSlug := "acme"
+	testHost := "acme.api.meridian.io"
+	testTenantID := tenant.MustNewTenantID("tenant_123")
+
+	mockCache := new(MockSlugCache)
+	mockRepo := new(MockTenantRepository)
+	logger := slog.Default()
+
+	mockCache.On("Get", ctx, testSlug).Return(testTenantID, nil)
+
+	middleware := &TenantResolverMiddleware{
+		slugCache:  mockCache,
+		tenantRepo: mockRepo,
+		baseDomain: baseDomain,
+		logger:     logger,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://"+testHost+"/api/test", nil)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	var capturedTenantID tenant.TenantID
+	var capturedTenantOk bool
+	var capturedHeaderValue string
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaderValue = r.Header.Get(tenant.TenantIDKey)
+		capturedTenantID, capturedTenantOk = tenant.FromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware.HandlerOptionalTenant(next)
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, capturedTenantOk, "tenant should be in context")
+	assert.Equal(t, testTenantID, capturedTenantID)
+	assert.Equal(t, string(testTenantID), capturedHeaderValue)
+	mockCache.AssertExpectations(t)
+}
+
+func TestHandlerOptionalTenant_WithoutSubdomain(t *testing.T) {
+	ctx := context.Background()
+	baseDomain := "api.meridian.io"
+
+	mockCache := new(MockSlugCache)
+	mockRepo := new(MockTenantRepository)
+	logger := slog.Default()
+
+	middleware := &TenantResolverMiddleware{
+		slugCache:  mockCache,
+		tenantRepo: mockRepo,
+		baseDomain: baseDomain,
+		logger:     logger,
+	}
+
+	// Request with base domain only (no subdomain)
+	req := httptest.NewRequest(http.MethodGet, "http://api.meridian.io/dex/auth", nil)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	nextCalled := false
+	var capturedTenantOk bool
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		_, capturedTenantOk = tenant.FromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware.HandlerOptionalTenant(next)
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, nextCalled, "next handler should be called")
+	assert.False(t, capturedTenantOk, "tenant should NOT be in context")
+	mockCache.AssertNotCalled(t, "Get")
+	mockRepo.AssertNotCalled(t, "GetBySlug")
+}
+
+func TestHandlerOptionalTenant_WithInvalidSubdomain(t *testing.T) {
+	ctx := context.Background()
+	baseDomain := "api.meridian.io"
+
+	mockCache := new(MockSlugCache)
+	mockRepo := new(MockTenantRepository)
+	logger := slog.Default()
+
+	middleware := &TenantResolverMiddleware{
+		slugCache:  mockCache,
+		tenantRepo: mockRepo,
+		baseDomain: baseDomain,
+		logger:     logger,
+	}
+
+	// Request with invalid subdomain (uppercase)
+	req := httptest.NewRequest(http.MethodGet, "http://INVALID.api.meridian.io/dex/auth", nil)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	nextCalled := false
+	var capturedTenantOk bool
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		_, capturedTenantOk = tenant.FromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware.HandlerOptionalTenant(next)
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, nextCalled, "next handler should be called even with invalid subdomain")
+	assert.False(t, capturedTenantOk, "tenant should NOT be in context")
+	mockCache.AssertNotCalled(t, "Get")
+}
+
+func TestHandlerOptionalTenant_TenantNotFoundInDB(t *testing.T) {
+	ctx := context.Background()
+	baseDomain := "api.meridian.io"
+	testSlug := "nonexistent"
+	testHost := "nonexistent.api.meridian.io"
+
+	mockCache := new(MockSlugCache)
+	mockRepo := new(MockTenantRepository)
+	logger := slog.Default()
+
+	// Cache miss, DB returns not found
+	mockCache.On("Get", ctx, testSlug).Return(tenant.TenantID(""), nil)
+	mockRepo.On("GetBySlug", ctx, testSlug).Return(nil, domain.ErrNotFound)
+
+	middleware := &TenantResolverMiddleware{
+		slugCache:  mockCache,
+		tenantRepo: mockRepo,
+		baseDomain: baseDomain,
+		logger:     logger,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://"+testHost+"/dex/auth", nil)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	nextCalled := false
+	var capturedTenantOk bool
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		_, capturedTenantOk = tenant.FromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := middleware.HandlerOptionalTenant(next)
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "should pass through even when tenant not found")
+	assert.True(t, nextCalled, "next handler should be called")
+	assert.False(t, capturedTenantOk, "tenant should NOT be in context")
+	mockCache.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestPlatformPathsDoesNotIncludeDex(t *testing.T) {
+	assert.False(t, IsPlatformPath("/dex/auth"), "/dex/auth should not be a platform path")
+	assert.False(t, IsPlatformPath("/dex/callback"), "/dex/callback should not be a platform path")
+	assert.False(t, IsPlatformPath("/dex/keys"), "/dex/keys should not be a platform path")
+	assert.False(t, IsPlatformPath("/dex/token"), "/dex/token should not be a platform path")
+	assert.False(t, IsPlatformPath("/dex/"), "/dex/ should not be a platform path")
+
+	// Existing platform paths should still work
+	assert.True(t, IsPlatformPath("/v1/tenants"))
+	assert.True(t, IsPlatformPath("/meridian.tenant.v1.TenantService/ListTenants"))
 }


### PR DESCRIPTION
## Summary

- Add `HandlerOptionalTenant` method to `TenantResolverMiddleware` that performs graceful tenant resolution — if a tenant subdomain is present and valid, it resolves and injects tenant context; otherwise, the request passes through without error
- Add `extractSlugFromRequestOptional` helper that extracts slugs without writing HTTP error responses
- Remove `/dex/` from `platformPaths` so Dex endpoints no longer bypass tenant resolution entirely — they will use `HandlerOptionalTenant` for optional resolution instead

## Technical Details

`HandlerOptionalTenant` differs from the existing `Handler` in three ways:
1. Does **not** skip resolution based on `platformPaths`
2. Does **not** return HTTP errors when no tenant can be resolved (no subdomain, invalid slug, tenant not found in DB, or DB error)
3. Always passes through to the next handler regardless of resolution outcome

This supports the auth flow architecture (PRD 044) where `/dex/` endpoints may or may not carry tenant context depending on whether the request arrives via a tenant subdomain.

## Test Plan

- [x] `TestHandlerOptionalTenant_WithValidSubdomain` — tenant subdomain resolves, context contains tenant ID
- [x] `TestHandlerOptionalTenant_WithoutSubdomain` — no subdomain passes through without error, no tenant in context
- [x] `TestHandlerOptionalTenant_WithInvalidSubdomain` — malformed subdomain passes through without error
- [x] `TestHandlerOptionalTenant_TenantNotFoundInDB` — valid slug format but non-existent tenant passes through without error
- [x] `TestPlatformPathsDoesNotIncludeDex` — verifies `/dex/` is not in `platformPaths`
- [x] All 58 existing + new tests pass

## Task Master

Tag: `044-authflow-action`, Task: `1` — Implement HandlerOptionalTenant in TenantResolverMiddleware