### PR TITLE
feat: tenant-scoped Dex redirect in BFF SSO handler

### DIFF
--- a/services/api-gateway/auth_sso_handler.go
+++ b/services/api-gateway/auth_sso_handler.go
@@ -396,7 +396,12 @@ func (h *SSOHandler) buildDexAuthURL(tenantID tenant.TenantID, connectorID strin
 	}
 
 	tenantSlug := strings.ToLower(tenantID.String())
-	issuer.Host = tenantSlug + "." + h.baseDomain
+	tenantHost := tenantSlug + "." + h.baseDomain
+	// Preserve any explicit port from the Dex issuer URL (e.g., :5556 in dev).
+	if port := issuer.Port(); port != "" {
+		tenantHost = tenantHost + ":" + port
+	}
+	issuer.Host = tenantHost
 	return issuer.String() + "/auth/" + escapedConnector
 }
 

--- a/services/api-gateway/auth_sso_handler.go
+++ b/services/api-gateway/auth_sso_handler.go
@@ -396,9 +396,11 @@ func (h *SSOHandler) buildDexAuthURL(tenantID tenant.TenantID, connectorID strin
 	}
 
 	tenantSlug := strings.ToLower(tenantID.String())
-	tenantHost := tenantSlug + "." + h.baseDomain
-	// Preserve any explicit port from the Dex issuer URL (e.g., :5556 in dev).
-	if port := issuer.Port(); port != "" {
+	baseDomain := strings.TrimSuffix(strings.TrimSpace(h.baseDomain), ".")
+	tenantHost := tenantSlug + "." + baseDomain
+	// Preserve any explicit port from the Dex issuer URL (e.g., :5556 in dev),
+	// but only if the baseDomain doesn't already contain a port.
+	if port := issuer.Port(); port != "" && !strings.Contains(tenantHost, ":") {
 		tenantHost = tenantHost + ":" + port
 	}
 	issuer.Host = tenantHost

--- a/services/api-gateway/auth_sso_handler.go
+++ b/services/api-gateway/auth_sso_handler.go
@@ -64,6 +64,7 @@ type SSOHandler struct {
 	dexIssuerURL string
 	clientID     string
 	callbackURL  string
+	baseDomain   string
 	stateStore   *StateStore
 	signer       *platformauth.JWTSigner
 	resolver     IdentityResolver
@@ -81,6 +82,10 @@ type SSOHandlerConfig struct {
 	// CallbackURL is the absolute URL for the BFF callback endpoint
 	// (e.g., "https://demo.meridianhub.cloud/api/auth/callback").
 	CallbackURL string
+	// BaseDomain is the base domain for subdomain-based tenant identification
+	// (e.g., "demo.meridianhub.cloud"). When set, the SSO initiate redirect builds
+	// a tenant-scoped Dex URL using the tenant slug as a subdomain prefix.
+	BaseDomain string
 	// Signer signs Meridian JWTs after SSO completes.
 	Signer *platformauth.JWTSigner
 	// Resolver looks up identities by email after SSO authentication.
@@ -157,6 +162,7 @@ func NewSSOHandler(cfg SSOHandlerConfig) (*SSOHandler, error) {
 		dexIssuerURL: strings.TrimRight(cfg.DexIssuerURL, "/"),
 		clientID:     cfg.ClientID,
 		callbackURL:  cfg.CallbackURL,
+		baseDomain:   cfg.BaseDomain,
 		stateStore:   stateStore,
 		signer:       cfg.Signer,
 		resolver:     cfg.Resolver,
@@ -221,9 +227,11 @@ func (h *SSOHandler) HandleInitiate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build Dex authorization URL. Path-escape the connector ID to prevent
+	// Build Dex authorization URL. When baseDomain is configured, the redirect
+	// uses a tenant-scoped URL so that the Dex MeridianConnector receives tenant
+	// context via the subdomain. Path-escape the connector ID to prevent
 	// path traversal (e.g., "../../admin" → "%2E%2E%2Fadmin").
-	authURL := h.dexIssuerURL + "/auth/" + url.PathEscape(connectorID)
+	authURL := h.buildDexAuthURL(tenantID, connectorID)
 	params := url.Values{
 		"client_id":             {h.clientID},
 		"redirect_uri":          {h.callbackURL},
@@ -367,6 +375,29 @@ func (h *SSOHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// buildDexAuthURL constructs the Dex authorization URL. When baseDomain is
+// configured, the URL includes the tenant slug as a subdomain prefix so that
+// the MeridianConnector can resolve tenant context from the request host.
+// Falls back to the bare dexIssuerURL when baseDomain is not set.
+func (h *SSOHandler) buildDexAuthURL(tenantID tenant.TenantID, connectorID string) string {
+	escapedConnector := url.PathEscape(connectorID)
+
+	if h.baseDomain == "" {
+		return h.dexIssuerURL + "/auth/" + escapedConnector
+	}
+
+	// Parse the Dex issuer URL to extract the scheme and path prefix.
+	issuer, err := url.Parse(h.dexIssuerURL)
+	if err != nil {
+		// Already validated in constructor; fall back to bare URL.
+		return h.dexIssuerURL + "/auth/" + escapedConnector
+	}
+
+	tenantSlug := strings.ToLower(tenantID.String())
+	issuer.Host = tenantSlug + "." + h.baseDomain
+	return issuer.String() + "/auth/" + escapedConnector
 }
 
 // dexTokenResponse is the JSON response from Dex's token endpoint.

--- a/services/api-gateway/auth_sso_handler_test.go
+++ b/services/api-gateway/auth_sso_handler_test.go
@@ -590,6 +590,108 @@ func TestSSOHandler_InitiateAcceptsRelativeReturnURL(t *testing.T) {
 	assert.Contains(t, callbackLocation, "/dashboard/overview")
 }
 
+// --- Tenant-scoped Dex redirect tests ---
+
+func TestHandleInitiate_RedirectsTenantScopedDexURL(t *testing.T) {
+	handler, err := gateway.NewSSOHandler(gateway.SSOHandlerConfig{
+		DexIssuerURL: "https://demo.meridianhub.cloud/dex",
+		ClientID:     "meridian-service",
+		CallbackURL:  "https://demo.meridianhub.cloud/api/auth/callback",
+		BaseDomain:   "demo.meridianhub.cloud",
+		Signer:       newSSOTestSigner(t),
+		Resolver:     &stubResolver{},
+		Logger:       slog.Default(),
+		StateStore:   gateway.NewStateStore(5 * time.Minute),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/sso/google", nil)
+	tid, _ := tenant.NewTenantID("acme")
+	req = req.WithContext(tenant.WithTenant(req.Context(), tid))
+	req.SetPathValue("connector_id", "google")
+
+	rec := httptest.NewRecorder()
+	handler.HandleInitiate(rec, req)
+
+	assert.Equal(t, http.StatusFound, rec.Code)
+
+	location := rec.Header().Get("Location")
+	require.NotEmpty(t, location)
+
+	u, err := url.Parse(location)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https", u.Scheme)
+	assert.Equal(t, "acme.demo.meridianhub.cloud", u.Host,
+		"redirect should include tenant subdomain")
+	assert.Equal(t, "/dex/auth/google", u.Path)
+}
+
+func TestHandleInitiate_MeridianConnector_HasTenantInRedirect(t *testing.T) {
+	handler, err := gateway.NewSSOHandler(gateway.SSOHandlerConfig{
+		DexIssuerURL: "https://demo.meridianhub.cloud/dex",
+		ClientID:     "meridian-service",
+		CallbackURL:  "https://demo.meridianhub.cloud/api/auth/callback",
+		BaseDomain:   "demo.meridianhub.cloud",
+		Signer:       newSSOTestSigner(t),
+		Resolver:     &stubResolver{},
+		Logger:       slog.Default(),
+		StateStore:   gateway.NewStateStore(5 * time.Minute),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/sso/meridian", nil)
+	tid, _ := tenant.NewTenantID("volterra")
+	req = req.WithContext(tenant.WithTenant(req.Context(), tid))
+	req.SetPathValue("connector_id", "meridian")
+
+	rec := httptest.NewRecorder()
+	handler.HandleInitiate(rec, req)
+
+	assert.Equal(t, http.StatusFound, rec.Code)
+
+	location := rec.Header().Get("Location")
+	u, err := url.Parse(location)
+	require.NoError(t, err)
+
+	assert.Equal(t, "volterra.demo.meridianhub.cloud", u.Host,
+		"meridian connector redirect should include tenant subdomain")
+	assert.Equal(t, "/dex/auth/meridian", u.Path)
+}
+
+func TestBuildTenantScopedDexURL_FallsBackWithoutBaseDomain(t *testing.T) {
+	// When BaseDomain is not set, redirect should use the bare DexIssuerURL
+	handler, err := gateway.NewSSOHandler(gateway.SSOHandlerConfig{
+		DexIssuerURL: "https://demo.meridianhub.cloud/dex",
+		ClientID:     "meridian-service",
+		CallbackURL:  "https://demo.meridianhub.cloud/api/auth/callback",
+		// No BaseDomain
+		Signer:     newSSOTestSigner(t),
+		Resolver:   &stubResolver{},
+		Logger:     slog.Default(),
+		StateStore: gateway.NewStateStore(5 * time.Minute),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/sso/google", nil)
+	tid, _ := tenant.NewTenantID("acme")
+	req = req.WithContext(tenant.WithTenant(req.Context(), tid))
+	req.SetPathValue("connector_id", "google")
+
+	rec := httptest.NewRecorder()
+	handler.HandleInitiate(rec, req)
+
+	assert.Equal(t, http.StatusFound, rec.Code)
+
+	location := rec.Header().Get("Location")
+	u, err := url.Parse(location)
+	require.NoError(t, err)
+
+	assert.Equal(t, "demo.meridianhub.cloud", u.Host,
+		"without BaseDomain, redirect should use bare DexIssuerURL host")
+	assert.Equal(t, "/dex/auth/google", u.Path)
+}
+
 // --- Helpers ---
 
 // buildFakeIDToken creates a minimal unsigned JWT with an email claim.

--- a/services/api-gateway/auth_sso_handler_test.go
+++ b/services/api-gateway/auth_sso_handler_test.go
@@ -692,6 +692,38 @@ func TestBuildTenantScopedDexURL_FallsBackWithoutBaseDomain(t *testing.T) {
 	assert.Equal(t, "/dex/auth/google", u.Path)
 }
 
+func TestHandleInitiate_PreservesPortInTenantScopedURL(t *testing.T) {
+	handler, err := gateway.NewSSOHandler(gateway.SSOHandlerConfig{
+		DexIssuerURL: "http://localhost:5556/dex",
+		ClientID:     "meridian-service",
+		CallbackURL:  "https://demo.meridianhub.cloud/api/auth/callback",
+		BaseDomain:   "localhost",
+		Signer:       newSSOTestSigner(t),
+		Resolver:     &stubResolver{},
+		Logger:       slog.Default(),
+		StateStore:   gateway.NewStateStore(5 * time.Minute),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/sso/meridian", nil)
+	tid, _ := tenant.NewTenantID("acme")
+	req = req.WithContext(tenant.WithTenant(req.Context(), tid))
+	req.SetPathValue("connector_id", "meridian")
+
+	rec := httptest.NewRecorder()
+	handler.HandleInitiate(rec, req)
+
+	assert.Equal(t, http.StatusFound, rec.Code)
+
+	location := rec.Header().Get("Location")
+	u, err := url.Parse(location)
+	require.NoError(t, err)
+
+	assert.Equal(t, "acme.localhost:5556", u.Host,
+		"should preserve port from DexIssuerURL in tenant-scoped redirect")
+	assert.Equal(t, "/dex/auth/meridian", u.Path)
+}
+
 // --- Helpers ---
 
 // buildFakeIDToken creates a minimal unsigned JWT with an email claim.


### PR DESCRIPTION
## Summary

- Adds `BaseDomain` field to `SSOHandlerConfig` for tenant-scoped Dex redirect URLs
- Modifies `HandleInitiate` to build redirect URLs with tenant slug as subdomain prefix (e.g., `acme.demo.meridianhub.cloud/dex/auth/meridian`) when `BaseDomain` is configured
- Falls back to bare `DexIssuerURL` when `BaseDomain` is not set, preserving backward compatibility

Fixes Flow 2 where the `meridian` connector via BFF SSO cannot resolve tenant context because the Dex redirect URL lacks a tenant subdomain.

**Task Master**: 044-authflow-action.4

## Test plan

- [x] `TestHandleInitiate_RedirectsTenantScopedDexURL` -- verifies tenant subdomain in redirect
- [x] `TestHandleInitiate_MeridianConnector_HasTenantInRedirect` -- verifies meridian connector gets tenant context
- [x] `TestBuildTenantScopedDexURL_FallsBackWithoutBaseDomain` -- verifies backward compat without BaseDomain
- [x] All existing SSO handler tests continue to pass