### PR TITLE
feat: Implement tenant-scoped MCP OAuth with fail-closed behavior

### DIFF
--- a/deploy/demo/.env.demo.example
+++ b/deploy/demo/.env.demo.example
@@ -186,6 +186,11 @@ MCP_OAUTH_ENABLED=false
 # [OPTIONAL] Base domain for subdomain-based tenant resolution on MCP requests.
 #MCP_BASE_DOMAIN=demo.meridianhub.cloud
 
+# [OPTIONAL] Default tenant slug for single-tenant deployments.
+# When set, bare-domain OAuth requests (no tenant subdomain) use this tenant.
+# When empty in multi-tenant mode, bare-domain requests fail closed with HTTP 400.
+#MCP_DEFAULT_TENANT_SLUG=volterra
+
 # [REQUIRED when MCP_OAUTH_ENABLED=true] Dex OIDC issuer URL (internal).
 # The MCP server acts as an OIDC client of Dex for delegated authentication.
 #MCP_DEX_ISSUER_URL=http://dex:5556/dex

--- a/deploy/demo/docker-compose.yml
+++ b/deploy/demo/docker-compose.yml
@@ -125,6 +125,9 @@ services:
       MCP_OAUTH_CLIENT_ID: ${MCP_OAUTH_CLIENT_ID:-meridian-mcp}
       MCP_BASE_DOMAIN: ${BASE_DOMAIN:-}
 
+      # --- Tenant defaults (single-tenant demo mode) ---
+      MCP_DEFAULT_TENANT_SLUG: ${MCP_DEFAULT_TENANT_SLUG:-}       # e.g. "volterra" — used when no tenant subdomain is present
+
       # --- Dex OIDC (delegates authentication to embedded Dex when MCP_OAUTH_ENABLED=true) ---
       MCP_DEX_ISSUER_URL: ${MCP_DEX_ISSUER_URL:-}                 # e.g. https://demo.meridianhub.cloud/dex (Dex is embedded in meridian binary)
       MCP_DEX_CLIENT_ID: ${MCP_DEX_CLIENT_ID:-meridian-service}   # Dex static client ID

--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -243,20 +243,23 @@ func runHTTP(logger *slog.Logger, srv *mcp.Server) error {
 			oidcStateStore := mcpauth.NewOIDCStateStore()
 			defer oidcStateStore.Close()
 
+			defaultTenantSlug := env.GetEnvOrDefault("MCP_DEFAULT_TENANT_SLUG", "")
+
 			oidcHandler, err := mcpauth.NewOIDCHandler(mcpauth.OIDCHandlerConfig{
 				OIDC: mcpauth.OIDCConfig{
 					DexIssuerURL: dexIssuerURL,
 					ClientID:     dexClientID,
 					CallbackURL:  dexCallbackURL,
 				},
-				OAuth:      oauthCfg,
-				StateStore: oidcStateStore,
-				CodeStore:  codeStore,
-				Registry:   clientRegistry,
-				Signer:     signer,
-				BaseURL:    baseURL,
-				BaseDomain: baseDomain,
-				Logger:     logger,
+				OAuth:             oauthCfg,
+				StateStore:        oidcStateStore,
+				CodeStore:         codeStore,
+				Registry:          clientRegistry,
+				Signer:            signer,
+				DefaultTenantSlug: defaultTenantSlug,
+				BaseURL:           baseURL,
+				BaseDomain:        baseDomain,
+				Logger:            logger,
 			})
 			if err != nil {
 				return fmt.Errorf("oidc handler: %w", err)

--- a/services/mcp-server/internal/auth/oauth.go
+++ b/services/mcp-server/internal/auth/oauth.go
@@ -262,7 +262,7 @@ func NewAuthorizationHandler(cfg OAuthConfig, store *CodeStore, registry *Client
 func (h *AuthorizationHandler) resolveClient(clientID, redirectURI string) (string, string) {
 	if clientID == h.cfg.ClientID {
 		if redirectURI != "" && redirectURI != h.cfg.RedirectURI {
-			return "", "redirect_uri does not match registered value"
+			return "", errMsgRedirectURIMismatch
 		}
 		if redirectURI == "" {
 			return h.cfg.RedirectURI, ""
@@ -272,17 +272,17 @@ func (h *AuthorizationHandler) resolveClient(clientID, redirectURI string) (stri
 	if h.registry != nil {
 		client, ok := h.registry.Lookup(clientID)
 		if !ok {
-			return "", "invalid client_id"
+			return "", errMsgInvalidClientID
 		}
 		if redirectURI == "" {
-			return "", "redirect_uri is required for dynamic clients"
+			return "", errMsgRedirectURIRequired
 		}
 		if !client.HasRedirectURI(redirectURI) {
-			return "", "redirect_uri does not match registered value"
+			return "", errMsgRedirectURIMismatch
 		}
 		return redirectURI, ""
 	}
-	return "", "invalid client_id"
+	return "", errMsgInvalidClientID
 }
 
 // ServeHTTP implements http.Handler.

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -51,6 +51,8 @@ var (
 	errOIDCStateFull          = errors.New("oidc state store is full")
 	errInvalidJWTFormat       = errors.New("invalid JWT format")
 	errEmailClaimMissing      = errors.New("email claim missing from ID token")
+	errTenantRequired         = errors.New("tenant identification required: use a tenant subdomain or configure MCP_DEFAULT_TENANT_SLUG")
+	errTenantResolutionFailed = errors.New("tenant slug resolution failed")
 )
 
 const (
@@ -75,6 +77,11 @@ const (
 
 	schemeHTTP  = "http"
 	schemeHTTPS = "https"
+
+	// Shared OAuth error messages used by both static and dynamic client validation.
+	errMsgInvalidClientID     = "invalid client_id"
+	errMsgRedirectURIMismatch = "redirect_uri does not match registered value"
+	errMsgRedirectURIRequired = "redirect_uri is required for dynamic clients"
 )
 
 // OIDCConfig holds configuration for the Dex OIDC integration.
@@ -184,19 +191,28 @@ func (s *OIDCStateStore) Consume(key string) (OIDCFlowState, bool) {
 	return entry, true
 }
 
+// TenantSlugResolver resolves a tenant slug (e.g., "acme") to its canonical
+// UUID. This ensures the x-tenant-id JWT claim contains a UUID consistent
+// with BFF-issued tokens, not the raw slug string.
+type TenantSlugResolver interface {
+	ResolveSlug(ctx context.Context, slug string) (string, error)
+}
+
 // OIDCHandler manages the OIDC authorization flow with Dex.
 type OIDCHandler struct {
-	cfg            OIDCConfig
-	oauthCfg       OAuthConfig
-	stateStore     *OIDCStateStore
-	codeStore      *CodeStore
-	registry       *ClientRegistry
-	signer         *platformauth.JWTSigner
-	tokenTTL       time.Duration
-	baseDomain     string
-	dexAuthBaseURL string // External Dex base URL for browser redirects (derived from BaseURL + DexIssuerURL path).
-	httpClient     *http.Client
-	logger         *slog.Logger
+	cfg               OIDCConfig
+	oauthCfg          OAuthConfig
+	stateStore        *OIDCStateStore
+	codeStore         *CodeStore
+	registry          *ClientRegistry
+	signer            *platformauth.JWTSigner
+	tenantResolver    TenantSlugResolver
+	tokenTTL          time.Duration
+	defaultTenantSlug string
+	baseDomain        string
+	dexAuthBaseURL    string // External Dex base URL for browser redirects (derived from BaseURL + DexIssuerURL path).
+	httpClient        *http.Client
+	logger            *slog.Logger
 }
 
 // OIDCHandlerConfig holds configuration for creating an OIDCHandler.
@@ -207,7 +223,15 @@ type OIDCHandlerConfig struct {
 	CodeStore  *CodeStore
 	Registry   *ClientRegistry
 	Signer     *platformauth.JWTSigner
-	TokenTTL   time.Duration
+	// TenantResolver resolves tenant slugs to UUIDs for JWT claims.
+	// When nil, the raw slug is used as-is (dev/test fallback).
+	TenantResolver TenantSlugResolver
+	TokenTTL       time.Duration
+	// DefaultTenantSlug is used when no tenant subdomain is present in the
+	// request. In single-tenant deployments (e.g., demo), set this to the
+	// tenant's slug so bare-domain requests work. When empty in multi-tenant
+	// mode, bare-domain requests fail closed with HTTP 400.
+	DefaultTenantSlug string
 	// BaseURL is the public-facing base URL of the MCP server
 	// (e.g., "https://demo.meridianhub.cloud"). Used to construct browser-facing
 	// Dex redirect URLs when DexIssuerURL is an internal Docker hostname.
@@ -269,17 +293,19 @@ func NewOIDCHandler(cfg OIDCHandlerConfig) (*OIDCHandler, error) {
 	}
 
 	return &OIDCHandler{
-		cfg:            cfg.OIDC,
-		oauthCfg:       cfg.OAuth,
-		stateStore:     cfg.StateStore,
-		codeStore:      cfg.CodeStore,
-		registry:       cfg.Registry,
-		signer:         cfg.Signer,
-		tokenTTL:       ttl,
-		baseDomain:     cfg.BaseDomain,
-		dexAuthBaseURL: dexAuthBaseURL,
-		httpClient:     httpClient,
-		logger:         cfg.Logger,
+		cfg:               cfg.OIDC,
+		oauthCfg:          cfg.OAuth,
+		stateStore:        cfg.StateStore,
+		codeStore:         cfg.CodeStore,
+		registry:          cfg.Registry,
+		signer:            cfg.Signer,
+		tenantResolver:    cfg.TenantResolver,
+		tokenTTL:          ttl,
+		defaultTenantSlug: cfg.DefaultTenantSlug,
+		baseDomain:        cfg.BaseDomain,
+		dexAuthBaseURL:    dexAuthBaseURL,
+		httpClient:        httpClient,
+		logger:            cfg.Logger,
 	}, nil
 }
 
@@ -305,6 +331,35 @@ func resolveDexAuthBaseURL(publicBaseURL string, issuerURL *url.URL, dexIssuerUR
 	return result
 }
 
+// validateAuthorizeClient validates the client_id and redirect_uri parameters
+// for an authorize request. Returns the resolved redirect URI or an error message.
+func (h *OIDCHandler) validateAuthorizeClient(clientID, redirectURI string) (string, string) {
+	if clientID == h.oauthCfg.ClientID {
+		if redirectURI == "" {
+			return h.oauthCfg.RedirectURI, ""
+		}
+		if redirectURI != h.oauthCfg.RedirectURI {
+			return "", errMsgRedirectURIMismatch
+		}
+		return redirectURI, ""
+	}
+
+	if h.registry == nil {
+		return "", errMsgInvalidClientID
+	}
+	client, ok := h.registry.Lookup(clientID)
+	if !ok {
+		return "", errMsgInvalidClientID
+	}
+	if redirectURI == "" {
+		return "", errMsgRedirectURIRequired
+	}
+	if !client.HasRedirectURI(redirectURI) {
+		return "", errMsgRedirectURIMismatch
+	}
+	return redirectURI, ""
+}
+
 // HandleAuthorize handles GET /oauth/authorize from the MCP client.
 // It stores the MCP client's PKCE state and redirects to Dex for authentication.
 func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
@@ -316,36 +371,10 @@ func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
 	clientID := q.Get("client_id")
-	redirectURI := q.Get("redirect_uri")
-
-	// Validate client_id and redirect_uri for both static and dynamic clients.
-	if clientID == h.oauthCfg.ClientID {
-		// Static client: default to configured redirect_uri, reject mismatches.
-		if redirectURI == "" {
-			redirectURI = h.oauthCfg.RedirectURI
-		} else if redirectURI != h.oauthCfg.RedirectURI {
-			http.Error(w, "redirect_uri does not match registered value", http.StatusBadRequest)
-			return
-		}
-	} else {
-		// Dynamic client: must be in registry with a matching redirect_uri.
-		if h.registry == nil {
-			http.Error(w, "invalid client_id", http.StatusBadRequest)
-			return
-		}
-		client, ok := h.registry.Lookup(clientID)
-		if !ok {
-			http.Error(w, "invalid client_id", http.StatusBadRequest)
-			return
-		}
-		if redirectURI == "" {
-			http.Error(w, "redirect_uri is required for dynamic clients", http.StatusBadRequest)
-			return
-		}
-		if !client.HasRedirectURI(redirectURI) {
-			http.Error(w, "redirect_uri does not match registered value", http.StatusBadRequest)
-			return
-		}
+	redirectURI, errMsg := h.validateAuthorizeClient(clientID, q.Get("redirect_uri"))
+	if errMsg != "" {
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
 	}
 
 	if q.Get("response_type") != "code" {
@@ -372,8 +401,17 @@ func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract tenant slug from request subdomain.
+	// Extract tenant slug from request subdomain, falling back to default.
 	tenantSlug := extractSubdomain(r.Host, h.baseDomain)
+	if tenantSlug == "" && h.defaultTenantSlug != "" {
+		tenantSlug = h.defaultTenantSlug
+		h.logger.Debug("oidc: using default tenant slug", "slug", tenantSlug)
+	}
+	if tenantSlug == "" {
+		h.logger.Warn("oidc: no tenant subdomain and no default configured — fail closed")
+		http.Error(w, errTenantRequired.Error(), http.StatusBadRequest)
+		return
+	}
 
 	// Generate PKCE code verifier for the Dex exchange.
 	dexVerifier, err := generateRandomToken(oidcCodeVerifierBytes)
@@ -403,7 +441,9 @@ func (h *OIDCHandler) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
 	// Redirect to Dex authorization endpoint via the external URL so the
 	// browser can reach Dex through the reverse proxy, even when the internal
 	// DexIssuerURL points to a Docker-internal hostname.
-	dexAuthURL := h.dexAuthBaseURL + "/auth"
+	// When a base domain is configured, build a tenant-scoped Dex URL so the
+	// browser hits the correct tenant subdomain (e.g., acme.demo.meridianhub.cloud/dex/auth).
+	dexAuthURL := BuildTenantScopedDexURL(h.dexAuthBaseURL, tenantSlug, h.baseDomain) + "/auth"
 	params := url.Values{
 		"client_id":             {h.cfg.ClientID},
 		"redirect_uri":          {h.cfg.CallbackURL},
@@ -476,11 +516,24 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Resolve tenant slug to UUID for JWT consistency with BFF-issued tokens.
+	tenantID := flowState.TenantSlug
+	if h.tenantResolver != nil && tenantID != "" {
+		resolved, resolveErr := h.tenantResolver.ResolveSlug(ctx, tenantID)
+		if resolveErr != nil {
+			h.logger.Error("oidc: tenant slug resolution failed",
+				"tenant_slug", tenantID, "error", resolveErr)
+			http.Error(w, errTenantResolutionFailed.Error(), http.StatusInternalServerError)
+			return
+		}
+		tenantID = resolved
+	}
+
 	// Sign Meridian JWT with tenant context.
 	claims := map[string]interface{}{
 		"sub":         email, // Use email as subject until identity resolution is wired
 		"email":       email,
-		"x-tenant-id": flowState.TenantSlug,
+		"x-tenant-id": tenantID,
 	}
 	tokenStr, err := h.signer.SignClaims(claims, h.tokenTTL)
 	if err != nil {
@@ -617,6 +670,31 @@ func generateRandomToken(n int) (string, error) {
 func computeS256Challenge(verifier string) string {
 	h := sha256.Sum256([]byte(verifier))
 	return base64.RawURLEncoding.EncodeToString(h[:])
+}
+
+// BuildTenantScopedDexURL inserts the tenant subdomain into the Dex base URL.
+// Given "https://demo.meridianhub.cloud/dex" and tenant "acme" with baseDomain
+// "demo.meridianhub.cloud", it returns "https://acme.demo.meridianhub.cloud/dex".
+// When baseDomain is empty or the URL can't be parsed, the original URL is returned.
+func BuildTenantScopedDexURL(dexBaseURL, tenantSlug, baseDomain string) string {
+	if baseDomain == "" || tenantSlug == "" {
+		return dexBaseURL
+	}
+	parsed, err := url.Parse(dexBaseURL)
+	if err != nil {
+		return dexBaseURL
+	}
+	// Only scope if the host matches or ends with the base domain.
+	host := parsed.Hostname()
+	if host != baseDomain && !strings.HasSuffix(host, "."+baseDomain) {
+		return dexBaseURL
+	}
+	// Replace the host with tenant-scoped subdomain.
+	parsed.Host = tenantSlug + "." + baseDomain
+	if parsed.Port() != "" {
+		parsed.Host = tenantSlug + "." + baseDomain + ":" + parsed.Port()
+	}
+	return parsed.String()
 }
 
 // isAllowedRedirectURI validates that a redirect URI is safe to redirect to.

--- a/services/mcp-server/internal/auth/oidc.go
+++ b/services/mcp-server/internal/auth/oidc.go
@@ -689,10 +689,11 @@ func BuildTenantScopedDexURL(dexBaseURL, tenantSlug, baseDomain string) string {
 	if host != baseDomain && !strings.HasSuffix(host, "."+baseDomain) {
 		return dexBaseURL
 	}
-	// Replace the host with tenant-scoped subdomain.
+	// Replace the host with tenant-scoped subdomain, preserving any port.
+	port := parsed.Port()
 	parsed.Host = tenantSlug + "." + baseDomain
-	if parsed.Port() != "" {
-		parsed.Host = tenantSlug + "." + baseDomain + ":" + parsed.Port()
+	if port != "" {
+		parsed.Host = tenantSlug + "." + baseDomain + ":" + port
 	}
 	return parsed.String()
 }

--- a/services/mcp-server/internal/auth/oidc_test.go
+++ b/services/mcp-server/internal/auth/oidc_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -332,10 +333,11 @@ func TestOIDCHandler_Authorize_AllowsLocalhostHTTP(t *testing.T) {
 			ClientID:    "meridian-mcp",
 			RedirectURI: "http://localhost:3000/callback",
 		},
-		StateStore: newTestOIDCStateStore(t),
-		CodeStore:  newTestStore(t),
-		Signer:     signer,
-		Logger:     slog.Default(),
+		DefaultTenantSlug: "acme",
+		StateStore:        newTestOIDCStateStore(t),
+		CodeStore:         newTestStore(t),
+		Signer:            signer,
+		Logger:            slog.Default(),
 	})
 	require.NoError(t, err)
 
@@ -810,8 +812,8 @@ func TestOIDCHandler_Authorize_UsesExternalDexURL(t *testing.T) {
 	redirectURL, err := url.Parse(location)
 	require.NoError(t, err)
 
-	// The redirect should go to the external host, not the internal test server.
-	assert.Equal(t, "demo.meridianhub.cloud", redirectURL.Host)
+	// The redirect should go to the external host with tenant subdomain, not the internal test server.
+	assert.Equal(t, "acme.demo.meridianhub.cloud", redirectURL.Host)
 	assert.Equal(t, "https", redirectURL.Scheme)
 	assert.Equal(t, "/dex/auth", redirectURL.Path)
 }
@@ -851,4 +853,385 @@ func TestOIDCHandler_Authorize_RejectsStaticClientEvilRedirect(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "redirect_uri does not match registered value")
+}
+
+// -----------------------------------------------------------------------
+// Task 3: Tenant-scoped Dex redirect in HandleAuthorize
+// -----------------------------------------------------------------------
+
+func TestHandleAuthorize_WithTenantSubdomain(t *testing.T) {
+	dexSrv := fakeDexServer(t, "user@acme.com")
+	signer := newTestSigner(t)
+
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID:    "meridian-mcp",
+			RedirectURI: "https://claude.ai/callback",
+		},
+		BaseURL:    "https://demo.meridianhub.cloud",
+		BaseDomain: "demo.meridianhub.cloud",
+		StateStore: newTestOIDCStateStore(t),
+		CodeStore:  newTestStore(t),
+		Signer:     signer,
+		Logger:     slog.Default(),
+	})
+	require.NoError(t, err)
+
+	_, challenge := generatePKCEPair(t)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"meridian-mcp"},
+		"redirect_uri":          {"https://claude.ai/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"test-state"},
+	}.Encode(), nil)
+	req.Host = "acme.demo.meridianhub.cloud"
+	w := httptest.NewRecorder()
+	handler.HandleAuthorize(w, req)
+
+	resp := w.Result()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	location := resp.Header.Get("Location")
+	redirectURL, err := url.Parse(location)
+	require.NoError(t, err)
+
+	// Dex redirect should use tenant-scoped URL
+	assert.Equal(t, "acme.demo.meridianhub.cloud", redirectURL.Host)
+	assert.Equal(t, "https", redirectURL.Scheme)
+	assert.Equal(t, "/dex/auth", redirectURL.Path)
+}
+
+func TestHandleAuthorize_WithDefaultTenant(t *testing.T) {
+	dexSrv := fakeDexServer(t, "user@acme.com")
+	signer := newTestSigner(t)
+
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID:    "meridian-mcp",
+			RedirectURI: "https://claude.ai/callback",
+		},
+		DefaultTenantSlug: "volterra",
+		BaseDomain:        "demo.meridianhub.cloud",
+		StateStore:        newTestOIDCStateStore(t),
+		CodeStore:         newTestStore(t),
+		Signer:            signer,
+		Logger:            slog.Default(),
+	})
+	require.NoError(t, err)
+
+	_, challenge := generatePKCEPair(t)
+
+	// Request on bare domain (no subdomain) — should use default tenant
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"meridian-mcp"},
+		"redirect_uri":          {"https://claude.ai/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"test-state"},
+	}.Encode(), nil)
+	req.Host = "demo.meridianhub.cloud"
+	w := httptest.NewRecorder()
+	handler.HandleAuthorize(w, req)
+
+	resp := w.Result()
+	require.Equal(t, http.StatusFound, resp.StatusCode, "bare domain with default tenant should succeed")
+}
+
+func TestHandleAuthorize_MultiTenantNoSubdomain_FailsClosed(t *testing.T) {
+	dexSrv := fakeDexServer(t, "user@acme.com")
+	signer := newTestSigner(t)
+
+	// No DefaultTenantSlug — multi-tenant mode
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID:    "meridian-mcp",
+			RedirectURI: "https://claude.ai/callback",
+		},
+		BaseDomain: "demo.meridianhub.cloud",
+		StateStore: newTestOIDCStateStore(t),
+		CodeStore:  newTestStore(t),
+		Signer:     signer,
+		Logger:     slog.Default(),
+	})
+	require.NoError(t, err)
+
+	_, challenge := generatePKCEPair(t)
+
+	// Request on bare domain with no default — should fail closed
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/authorize?"+url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"meridian-mcp"},
+		"redirect_uri":          {"https://claude.ai/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+	req.Host = "demo.meridianhub.cloud"
+	w := httptest.NewRecorder()
+	handler.HandleAuthorize(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "tenant identification required")
+}
+
+func TestBuildTenantScopedDexURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		dexBaseURL string
+		tenant     string
+		baseDomain string
+		want       string
+	}{
+		{
+			name:       "scopes URL with tenant subdomain",
+			dexBaseURL: "https://demo.meridianhub.cloud/dex",
+			tenant:     "acme",
+			baseDomain: "demo.meridianhub.cloud",
+			want:       "https://acme.demo.meridianhub.cloud/dex",
+		},
+		{
+			name:       "empty base domain returns original",
+			dexBaseURL: "https://demo.meridianhub.cloud/dex",
+			tenant:     "acme",
+			baseDomain: "",
+			want:       "https://demo.meridianhub.cloud/dex",
+		},
+		{
+			name:       "empty tenant returns original",
+			dexBaseURL: "https://demo.meridianhub.cloud/dex",
+			tenant:     "",
+			baseDomain: "demo.meridianhub.cloud",
+			want:       "https://demo.meridianhub.cloud/dex",
+		},
+		{
+			name:       "non-matching host returns original",
+			dexBaseURL: "http://dex:5556/dex",
+			tenant:     "acme",
+			baseDomain: "demo.meridianhub.cloud",
+			want:       "http://dex:5556/dex",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := auth.BuildTenantScopedDexURL(tt.dexBaseURL, tt.tenant, tt.baseDomain)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// -----------------------------------------------------------------------
+// Task 5: Tenant slug to UUID resolution in HandleCallback
+// -----------------------------------------------------------------------
+
+// mockTenantResolver is a test double for TenantSlugResolver.
+type mockTenantResolver struct {
+	mapping map[string]string
+	err     error
+}
+
+func (m *mockTenantResolver) ResolveSlug(_ context.Context, slug string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	uuid, ok := m.mapping[slug]
+	if !ok {
+		return "", fmt.Errorf("tenant not found: %s", slug)
+	}
+	return uuid, nil
+}
+
+func TestHandleCallback_ResolvesSlugToUUID(t *testing.T) {
+	dexSrv := fakeDexServer(t, "admin@acme.com")
+	signer := newTestSigner(t)
+	codeStore := newTestStore(t)
+	stateStore := newTestOIDCStateStore(t)
+
+	resolver := &mockTenantResolver{
+		mapping: map[string]string{"acme": "550e8400-e29b-41d4-a716-446655440000"},
+	}
+
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID: "meridian-mcp",
+		},
+		TenantResolver: resolver,
+		StateStore:     stateStore,
+		CodeStore:      codeStore,
+		Signer:         signer,
+		BaseDomain:     "demo.meridianhub.cloud",
+		Logger:         slog.Default(),
+	})
+	require.NoError(t, err)
+
+	_, challenge := generatePKCEPair(t)
+
+	stateKey, err := stateStore.Store(auth.OIDCFlowState{
+		MCPCodeChallenge: challenge,
+		MCPClientID:      "meridian-mcp",
+		MCPRedirectURI:   "https://claude.ai/callback",
+		DexCodeVerifier:  "test-verifier",
+		TenantSlug:       "acme",
+		IssuedAt:         time.Now(),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/callback?"+url.Values{
+		"code":  {"fake-dex-code"},
+		"state": {stateKey},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleCallback(w, req)
+
+	resp := w.Result()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	// Extract the MCP code and verify the JWT has UUID, not slug
+	location := resp.Header.Get("Location")
+	redirectURL, err := url.Parse(location)
+	require.NoError(t, err)
+
+	mcpCode := redirectURL.Query().Get("code")
+	entry, ok := codeStore.Consume(mcpCode)
+	require.True(t, ok)
+
+	validator, err := platformauth.NewJWTValidator(signer.PublicKey())
+	require.NoError(t, err)
+	claims, err := validator.ValidateToken(entry.Token)
+	require.NoError(t, err)
+
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440000", claims.TenantID, "JWT must contain UUID, not slug")
+	assert.Equal(t, "admin@acme.com", claims.Email)
+}
+
+func TestHandleCallback_ResolverFailure_ReturnsError(t *testing.T) {
+	dexSrv := fakeDexServer(t, "admin@acme.com")
+	signer := newTestSigner(t)
+	stateStore := newTestOIDCStateStore(t)
+
+	resolver := &mockTenantResolver{
+		err: fmt.Errorf("database connection failed"),
+	}
+
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID: "meridian-mcp",
+		},
+		TenantResolver: resolver,
+		StateStore:     stateStore,
+		CodeStore:      newTestStore(t),
+		Signer:         signer,
+		Logger:         slog.Default(),
+	})
+	require.NoError(t, err)
+
+	stateKey, err := stateStore.Store(auth.OIDCFlowState{
+		MCPCodeChallenge: "test-challenge",
+		MCPClientID:      "meridian-mcp",
+		MCPRedirectURI:   "https://claude.ai/callback",
+		DexCodeVerifier:  "test-verifier",
+		TenantSlug:       "acme",
+		IssuedAt:         time.Now(),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/callback?"+url.Values{
+		"code":  {"fake-dex-code"},
+		"state": {stateKey},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleCallback(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "tenant slug resolution failed")
+}
+
+func TestHandleCallback_NoResolver_FallsBackToSlug(t *testing.T) {
+	dexSrv := fakeDexServer(t, "admin@acme.com")
+	signer := newTestSigner(t)
+	codeStore := newTestStore(t)
+	stateStore := newTestOIDCStateStore(t)
+
+	// No TenantResolver set — slug should be used as-is
+	handler, err := auth.NewOIDCHandler(auth.OIDCHandlerConfig{
+		OIDC: auth.OIDCConfig{
+			DexIssuerURL: dexSrv.URL + "/dex",
+			ClientID:     "meridian-service",
+			CallbackURL:  "https://demo.meridianhub.cloud/oauth/callback",
+		},
+		OAuth: auth.OAuthConfig{
+			ClientID: "meridian-mcp",
+		},
+		StateStore: stateStore,
+		CodeStore:  codeStore,
+		Signer:     signer,
+		BaseDomain: "demo.meridianhub.cloud",
+		Logger:     slog.Default(),
+	})
+	require.NoError(t, err)
+
+	_, challenge := generatePKCEPair(t)
+
+	stateKey, err := stateStore.Store(auth.OIDCFlowState{
+		MCPCodeChallenge: challenge,
+		MCPClientID:      "meridian-mcp",
+		MCPRedirectURI:   "https://claude.ai/callback",
+		DexCodeVerifier:  "test-verifier",
+		TenantSlug:       "acme",
+		IssuedAt:         time.Now(),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/oauth/callback?"+url.Values{
+		"code":  {"fake-dex-code"},
+		"state": {stateKey},
+	}.Encode(), nil)
+	w := httptest.NewRecorder()
+	handler.HandleCallback(w, req)
+
+	resp := w.Result()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	location := resp.Header.Get("Location")
+	redirectURL, err := url.Parse(location)
+	require.NoError(t, err)
+
+	mcpCode := redirectURL.Query().Get("code")
+	entry, ok := codeStore.Consume(mcpCode)
+	require.True(t, ok)
+
+	validator, err := platformauth.NewJWTValidator(signer.PublicKey())
+	require.NoError(t, err)
+	claims, err := validator.ValidateToken(entry.Token)
+	require.NoError(t, err)
+
+	assert.Equal(t, "acme", claims.TenantID, "without resolver, JWT should contain raw slug")
 }

--- a/services/mcp-server/internal/auth/oidc_test.go
+++ b/services/mcp-server/internal/auth/oidc_test.go
@@ -1022,6 +1022,13 @@ func TestBuildTenantScopedDexURL(t *testing.T) {
 			want:       "https://demo.meridianhub.cloud/dex",
 		},
 		{
+			name:       "preserves port in URL",
+			dexBaseURL: "https://demo.meridianhub.cloud:8443/dex",
+			tenant:     "acme",
+			baseDomain: "demo.meridianhub.cloud",
+			want:       "https://acme.demo.meridianhub.cloud:8443/dex",
+		},
+		{
 			name:       "non-matching host returns original",
 			dexBaseURL: "http://dex:5556/dex",
 			tenant:     "acme",


### PR DESCRIPTION
## Summary

- **Task 3**: Add tenant-scoped Dex redirect in MCP `HandleAuthorize`. Requests without a tenant subdomain fall back to `MCP_DEFAULT_TENANT_SLUG`; if neither is available (multi-tenant mode), the request fails closed with HTTP 400. Browser redirects to Dex now use tenant-scoped URLs (e.g., `acme.demo.meridianhub.cloud/dex/auth`).
- **Task 5**: Add `TenantSlugResolver` interface in `HandleCallback` to resolve tenant slugs to UUIDs before signing JWTs, ensuring `x-tenant-id` claims contain UUIDs consistent with BFF-issued tokens. When no resolver is configured (dev/test), the raw slug is used as fallback.
- **Task 7**: Add `MCP_DEFAULT_TENANT_SLUG` environment variable to demo `docker-compose.yml` and `.env.demo.example`.

## Changes Made

### `services/mcp-server/internal/auth/oidc.go`
- Add `TenantSlugResolver` interface and `DefaultTenantSlug` / `TenantResolver` to handler config and struct
- `HandleAuthorize`: extract tenant from subdomain, fall back to default, fail closed if neither available
- `HandleCallback`: resolve tenant slug to UUID via resolver before signing JWT
- Add `BuildTenantScopedDexURL` helper to insert tenant subdomain into Dex URL
- Extract `validateAuthorizeClient` to reduce cyclomatic complexity
- Extract shared OAuth error message constants (`errMsgInvalidClientID`, `errMsgRedirectURIMismatch`, `errMsgRedirectURIRequired`)

### `services/mcp-server/internal/auth/oauth.go`
- Use shared error message constants in `resolveClient`

### `services/mcp-server/cmd/main.go`
- Read `MCP_DEFAULT_TENANT_SLUG` env var and pass to `OIDCHandlerConfig`

### `deploy/demo/docker-compose.yml` and `.env.demo.example`
- Add `MCP_DEFAULT_TENANT_SLUG` configuration

## Test Plan

- [x] `TestHandleAuthorize_WithTenantSubdomain` -- redirects to tenant-scoped Dex URL
- [x] `TestHandleAuthorize_WithDefaultTenant` -- bare domain with default configured uses default
- [x] `TestHandleAuthorize_MultiTenantNoSubdomain_FailsClosed` -- bare domain, no default -> HTTP 400
- [x] `TestBuildTenantScopedDexURL` -- URL construction helper (4 cases)
- [x] `TestHandleCallback_ResolvesSlugToUUID` -- JWT gets UUID, not slug
- [x] `TestHandleCallback_ResolverFailure_ReturnsError` -- resolver error -> 500
- [x] `TestHandleCallback_NoResolver_FallsBackToSlug` -- nil resolver -> uses slug
- [x] All existing tests updated and passing