### PR TITLE
Add Go Report Card and Go Reference badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Code Quality](https://github.com/meridianhub/meridian/actions/workflows/quality.yml/badge.svg?branch=develop)](https://github.com/meridianhub/meridian/actions/workflows/quality.yml?query=branch%3Adevelop)
 [![Security Scanning](https://github.com/meridianhub/meridian/actions/workflows/security.yml/badge.svg?branch=develop)](https://github.com/meridianhub/meridian/actions/workflows/security.yml?query=branch%3Adevelop)
 [![codecov](https://codecov.io/gh/meridianhub/meridian/branch/develop/graph/badge.svg)](https://codecov.io/gh/meridianhub/meridian)
+[![Go Report Card](https://goreportcard.com/badge/github.com/meridianhub/meridian)](https://goreportcard.com/report/github.com/meridianhub/meridian)
+[![Go Reference](https://pkg.go.dev/badge/github.com/meridianhub/meridian.svg)](https://pkg.go.dev/github.com/meridianhub/meridian)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/meridianhub/meridian)](https://go.dev/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 


### PR DESCRIPTION
## Summary

- Add [Go Report Card](https://goreportcard.com/report/github.com/meridianhub/meridian) badge — static analysis grade for Go code quality
- Add [Go Reference](https://pkg.go.dev/github.com/meridianhub/meridian) badge — links to pkg.go.dev API documentation

## Test plan

- [ ] Verify badges render correctly on the PR diff
- [ ] Confirm links resolve after merge