### PR TITLE
fix: Remap account type planner to Reference Data CreateDraft+Activate flow

### DIFF
--- a/services/control-plane/internal/planner/manifest_planner.go
+++ b/services/control-plane/internal/planner/manifest_planner.go
@@ -141,11 +141,13 @@ var grpcMethodMap = map[methodKey]GRPCMethod{
 	{differ.ResourceInstrument, differ.ActionUpdate}: MethodUpdateInstrument,
 	{differ.ResourceInstrument, differ.ActionDelete}: MethodDeprecateInstrument,
 
-	// Account Types: CREATE maps to InitiateAccount on Internal Account Service.
-	// Account types are registered as reference data AND provisioned as internal accounts.
-	{differ.ResourceAccountType, differ.ActionCreate}: MethodInitiateAccount,
-	{differ.ResourceAccountType, differ.ActionUpdate}: MethodInitiateAccount,
-	{differ.ResourceAccountType, differ.ActionDelete}: MethodInitiateAccount,
+	// Account Types: mapped to Reference Data AccountTypeRegistryService.
+	// CREATE → CreateDraft (the handler calls Activate internally for idempotent flow).
+	// UPDATE → UpdateDefinition.
+	// DELETE → DeprecateAccountType.
+	{differ.ResourceAccountType, differ.ActionCreate}: MethodCreateAccountTypeDraft,
+	{differ.ResourceAccountType, differ.ActionUpdate}: MethodUpdateAccountTypeDefinition,
+	{differ.ResourceAccountType, differ.ActionDelete}: MethodDeprecateAccountType,
 
 	// Valuation Rules: mapped to Reference Data Service instrument operations
 	// (valuation rules are registered alongside instrument definitions).

--- a/services/control-plane/internal/planner/manifest_planner_test.go
+++ b/services/control-plane/internal/planner/manifest_planner_test.go
@@ -148,6 +148,8 @@ func TestPlan_GRPCMethodMapping_AccountTypes(t *testing.T) {
 	diffPlan := &differ.DiffPlan{
 		Actions: []differ.PlannedAction{
 			{ResourceType: differ.ResourceAccountType, ResourceCode: "CURRENT", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "SAVINGS", Action: differ.ActionUpdate},
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "LEGACY", Action: differ.ActionDelete},
 		},
 	}
 
@@ -155,7 +157,28 @@ func TestPlan_GRPCMethodMapping_AccountTypes(t *testing.T) {
 	require.NoError(t, err)
 
 	callsByCode := indexCallsByResourceID(plan.Calls)
-	assert.Equal(t, MethodInitiateAccount, callsByCode["CURRENT"].GRPCMethod)
+	// CREATE maps to Reference Data CreateDraft (handler will call Activate internally)
+	assert.Equal(t, MethodCreateAccountTypeDraft, callsByCode["CURRENT"].GRPCMethod)
+	// UPDATE maps to Reference Data UpdateDefinition
+	assert.Equal(t, MethodUpdateAccountTypeDefinition, callsByCode["SAVINGS"].GRPCMethod)
+	// DELETE maps to Reference Data DeprecateAccountType
+	assert.Equal(t, MethodDeprecateAccountType, callsByCode["LEGACY"].GRPCMethod)
+}
+
+func TestPlan_AccountType_NotMappedToInternalAccount(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "CURRENT", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+
+	assert.NotEqual(t, MethodInitiateAccount, plan.Calls[0].GRPCMethod,
+		"account type CREATE must not map to Internal Account service")
 }
 
 func TestPlan_GRPCMethodMapping_Sagas(t *testing.T) {
@@ -407,7 +430,7 @@ func TestExecutionPlan_Visualize(t *testing.T) {
 		ManifestVersion: "1.0",
 		Calls: []PlannedCall{
 			{Phase: PhaseInstruments, ResourceType: differ.ResourceInstrument, ResourceID: "GBP", Action: differ.ActionCreate, GRPCMethod: MethodRegisterInstrument, Description: "Create instrument GBP"},
-			{Phase: PhaseAccountTypes, ResourceType: differ.ResourceAccountType, ResourceID: "CURRENT", Action: differ.ActionCreate, GRPCMethod: MethodInitiateAccount, Description: "Create account type CURRENT"},
+			{Phase: PhaseAccountTypes, ResourceType: differ.ResourceAccountType, ResourceID: "CURRENT", Action: differ.ActionCreate, GRPCMethod: MethodCreateAccountTypeDraft, Description: "Create account type CURRENT"},
 			{Phase: PhaseSagas, ResourceType: differ.ResourceSaga, ResourceID: "deposit", Action: differ.ActionUpdate, GRPCMethod: MethodUpdateSagaDefinition, Description: "Update saga deposit"},
 		},
 	}

--- a/services/control-plane/internal/planner/types.go
+++ b/services/control-plane/internal/planner/types.go
@@ -78,6 +78,11 @@ const (
 	MethodDeprecateInstrument GRPCMethod = "meridian.reference_data.v1.ReferenceDataService/DeprecateInstrument"
 	MethodActivateInstrument  GRPCMethod = "meridian.reference_data.v1.ReferenceDataService/ActivateInstrument"
 
+	// Account Type Registry Service (Reference Data)
+	MethodCreateAccountTypeDraft      GRPCMethod = "meridian.reference_data.v1.AccountTypeRegistryService/CreateDraft"
+	MethodUpdateAccountTypeDefinition GRPCMethod = "meridian.reference_data.v1.AccountTypeRegistryService/UpdateDefinition"
+	MethodDeprecateAccountType        GRPCMethod = "meridian.reference_data.v1.AccountTypeRegistryService/DeprecateAccountType"
+
 	// Internal Account Service
 	MethodInitiateAccount GRPCMethod = "meridian.internal_account.v1.InternalAccountService/InitiateInternalAccount"
 


### PR DESCRIPTION
## Summary

- Account type `CREATE/UPDATE/DELETE` actions in the manifest planner were incorrectly routed to `InternalAccountService/InitiateInternalAccount`
- Fixed by mapping to the correct `AccountTypeRegistryService` methods: `CreateDraft`, `UpdateDefinition`, `DeprecateAccountType`
- The applier's `registerAccountTypeHandler` already performs the idempotent `CreateDraft + ActivateAccountType` sequence internally — the planner constant now reflects the actual first RPC in that sequence

## Changes Made

- `services/control-plane/internal/planner/types.go`: Added three new `GRPCMethod` constants for `AccountTypeRegistryService` (`MethodCreateAccountTypeDraft`, `MethodUpdateAccountTypeDefinition`, `MethodDeprecateAccountType`)
- `services/control-plane/internal/planner/manifest_planner.go`: Updated `grpcMethodMap` to use the new Reference Data constants for account type actions
- `services/control-plane/internal/planner/manifest_planner_test.go`: Updated `TestPlan_GRPCMethodMapping_AccountTypes` to cover all three actions (CREATE/UPDATE/DELETE) and added `TestPlan_AccountType_NotMappedToInternalAccount` to explicitly guard against regression

## Test plan

- [x] `TestPlan_GRPCMethodMapping_AccountTypes` - verifies all three account type actions route to Reference Data methods
- [x] `TestPlan_AccountType_NotMappedToInternalAccount` - regression guard ensuring account types never route to Internal Account service
- [x] All existing planner and applier tests pass