### PR TITLE
feat: Add MarketData and Organization resource types to manifest pipeline

### DIFF
--- a/api/jsonschema/manifest.v1.schema.json
+++ b/api/jsonschema/manifest.v1.schema.json
@@ -14,7 +14,9 @@
                 "paymentRails",
                 "partyTypes",
                 "mappings",
-                "operationalGateway"
+                "operationalGateway",
+                "marketData",
+                "organizations"
             ],
             "properties": {
                 "version": {
@@ -91,6 +93,19 @@
                     "$ref": "#/definitions/meridian.control_plane.v1.OperationalGatewayConfig",
                     "additionalProperties": false,
                     "description": "operational_gateway defines external system integrations for this tenant."
+                },
+                "marketData": {
+                    "$ref": "#/definitions/meridian.control_plane.v1.MarketDataConfig",
+                    "additionalProperties": false,
+                    "description": "market_data defines market data sources and data sets for this tenant."
+                },
+                "organizations": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.control_plane.v1.OrganizationDefinition"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "organizations defines the organization entities (parties) for this tenant."
                 }
             },
             "additionalProperties": false,
@@ -522,6 +537,136 @@
             "title": "========================================\n Manifest Metadata\n ========================================",
             "description": "======================================== Manifest Metadata ========================================  ManifestMetadata contains identifying information about a manifest."
         },
+        "meridian.control_plane.v1.MarketDataConfig": {
+            "required": [
+                "sources",
+                "datasets"
+            ],
+            "properties": {
+                "sources": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.control_plane.v1.MarketDataSourceDefinition"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "sources defines the market data providers for this tenant."
+                },
+                "datasets": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.control_plane.v1.MarketDataSetDefinition"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "datasets defines the market data set definitions for this tenant."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "========================================\n Market Data Config\n ========================================",
+            "description": "======================================== Market Data Config ========================================  MarketDataConfig declares market data sources and data sets for a tenant. Sources represent providers of market data (e.g., Bloomberg, ECB). Data sets define the types of market data that can be tracked (e.g., FX rates, commodity prices)."
+        },
+        "meridian.control_plane.v1.MarketDataSetDefinition": {
+            "required": [
+                "code",
+                "category",
+                "unit",
+                "sourceCode",
+                "displayName",
+                "description"
+            ],
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": "code is the unique data set code within the tenant (e.g., \"USD_EUR_FX\", \"BRENT_CRUDE\"). Must be uppercase alphanumeric with underscores."
+                },
+                "category": {
+                    "enum": [
+                        "DATA_CATEGORY_UNSPECIFIED",
+                        0,
+                        "DATA_CATEGORY_FX_RATE",
+                        1,
+                        "DATA_CATEGORY_INTEREST_RATE",
+                        2,
+                        "DATA_CATEGORY_COMMODITY_PRICE",
+                        3,
+                        "DATA_CATEGORY_EQUITY_PRICE",
+                        4,
+                        "DATA_CATEGORY_INDEX_VALUE",
+                        5,
+                        "DATA_CATEGORY_ENERGY_PRICE",
+                        6,
+                        "DATA_CATEGORY_CARBON_PRICE",
+                        7,
+                        "DATA_CATEGORY_BENCHMARK_RATE",
+                        8,
+                        "DATA_CATEGORY_VOLATILITY",
+                        9,
+                        "DATA_CATEGORY_CREDIT_SPREAD",
+                        10
+                    ],
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "title": "========================================\n Enums\n ========================================",
+                    "description": "======================================== Enums ========================================  DataCategory defines the type of market data being tracked."
+                },
+                "unit": {
+                    "type": "string",
+                    "description": "unit describes the unit of measurement for observations (e.g., \"USD\", \"USD/EUR\", \"USD/BBL\")."
+                },
+                "sourceCode": {
+                    "type": "string",
+                    "description": "source_code identifies the market data source that provides this data set. Must match a code in market_data.sources."
+                },
+                "displayName": {
+                    "type": "string",
+                    "description": "display_name is the human-readable name for this data set."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "description provides additional context about this data set."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Market Data Set Definition",
+            "description": "MarketDataSetDefinition declares a type of market data that can be tracked within the manifest. The code field is the immutable primary key."
+        },
+        "meridian.control_plane.v1.MarketDataSourceDefinition": {
+            "required": [
+                "code",
+                "name",
+                "description",
+                "trustLevel"
+            ],
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": "code is the unique identifier for this data source (e.g., \"BLOOMBERG\", \"ECB\", \"NORDPOOL\"). Must be uppercase alphanumeric with underscores."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "name is the human-readable display name (e.g., \"Bloomberg Terminal\", \"European Central Bank\")."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "description provides additional context about this data source."
+                },
+                "trustLevel": {
+                    "type": "integer",
+                    "description": "trust_level indicates the reliability of this source (0-100). Higher values indicate more trusted sources for conflict resolution."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Market Data Source Definition",
+            "description": "MarketDataSourceDefinition declares a market data source (provider) within the manifest. The code field is the immutable primary key."
+        },
         "meridian.control_plane.v1.OAuth2AuthConfig": {
             "required": [
                 "tokenUrl",
@@ -591,6 +736,39 @@
             "type": "object",
             "title": "========================================\n Operational Gateway Config\n ========================================",
             "description": "======================================== Operational Gateway Config ========================================  OperationalGatewayConfig declares the external system integrations for a tenant. It configures provider connections, outbound instruction routing, and inbound event handling."
+        },
+        "meridian.control_plane.v1.OrganizationDefinition": {
+            "required": [
+                "code",
+                "name",
+                "partyType",
+                "attributes"
+            ],
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": "code is the unique identifier for this organization (e.g., \"ACME_ENERGY\", \"GRID_OPS\"). Must be uppercase alphanumeric with underscores."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "name is the legal or display name of the organization."
+                },
+                "partyType": {
+                    "type": "string",
+                    "description": "party_type is the party classification (e.g., \"ORGANIZATION\", \"COUNTERPARTY\"). Must match a party type code from the manifest's party_types or a built-in type."
+                },
+                "attributes": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": "object",
+                    "description": "attributes contains additional metadata for this organization as key-value pairs. Keys and values are validated against the party type's attribute_schema if defined."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "========================================\n Organization Definitions\n ========================================",
+            "description": "======================================== Organization Definitions ========================================  OrganizationDefinition declares an organization entity (party) within the manifest. Organizations are registered as parties via the Party Service. The code field is the immutable primary key."
         },
         "meridian.control_plane.v1.PaymentRails": {
             "required": [

--- a/api/proto/meridian/control_plane/v1/manifest.proto
+++ b/api/proto/meridian/control_plane/v1/manifest.proto
@@ -5,6 +5,7 @@ package meridian.control_plane.v1;
 import "buf/validate/validate.proto";
 import "google/protobuf/struct.proto";
 import "meridian/mapping/v1/mapping.proto";
+import "meridian/market_information/v1/market_information.proto";
 import "meridian/party/v1/party.proto";
 
 option go_package = "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1;controlplanev1";
@@ -63,6 +64,12 @@ message Manifest {
 
   // operational_gateway defines external system integrations for this tenant.
   OperationalGatewayConfig operational_gateway = 11;
+
+  // market_data defines market data sources and data sets for this tenant.
+  MarketDataConfig market_data = 12;
+
+  // organizations defines the organization entities (parties) for this tenant.
+  repeated OrganizationDefinition organizations = 13;
 }
 
 // ========================================
@@ -765,4 +772,120 @@ message InboundRouteConfig {
   // payload before passing it to the handler saga.
   // Must match a name in the manifest's mappings list. If empty, the payload is passed as-is.
   string mapping_id = 3 [(buf.validate.field).string.max_len = 255];
+}
+
+// ========================================
+// Market Data Config
+// ========================================
+
+// MarketDataConfig declares market data sources and data sets for a tenant.
+// Sources represent providers of market data (e.g., Bloomberg, ECB).
+// Data sets define the types of market data that can be tracked (e.g., FX rates, commodity prices).
+message MarketDataConfig {
+  // sources defines the market data providers for this tenant.
+  repeated MarketDataSourceDefinition sources = 1;
+
+  // datasets defines the market data set definitions for this tenant.
+  repeated MarketDataSetDefinition datasets = 2;
+}
+
+// MarketDataSourceDefinition declares a market data source (provider) within the manifest.
+// The code field is the immutable primary key.
+message MarketDataSourceDefinition {
+  // code is the unique identifier for this data source (e.g., "BLOOMBERG", "ECB", "NORDPOOL").
+  // Must be uppercase alphanumeric with underscores.
+  string code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // name is the human-readable display name (e.g., "Bloomberg Terminal", "European Central Bank").
+  string name = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 128
+  }];
+
+  // description provides additional context about this data source.
+  string description = 3 [(buf.validate.field).string.max_len = 1024];
+
+  // trust_level indicates the reliability of this source (0-100).
+  // Higher values indicate more trusted sources for conflict resolution.
+  int32 trust_level = 4 [(buf.validate.field).int32 = {
+    gte: 0
+    lte: 100
+  }];
+}
+
+// MarketDataSetDefinition declares a type of market data that can be tracked within the manifest.
+// The code field is the immutable primary key.
+message MarketDataSetDefinition {
+  // code is the unique data set code within the tenant (e.g., "USD_EUR_FX", "BRENT_CRUDE").
+  // Must be uppercase alphanumeric with underscores.
+  string code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // category is the type of market data this set represents.
+  meridian.market_information.v1.DataCategory category = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // unit describes the unit of measurement for observations (e.g., "USD", "USD/EUR", "USD/BBL").
+  string unit = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+  }];
+
+  // source_code identifies the market data source that provides this data set.
+  // Must match a code in market_data.sources.
+  string source_code = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // display_name is the human-readable name for this data set.
+  string display_name = 5 [(buf.validate.field).string.max_len = 128];
+
+  // description provides additional context about this data set.
+  string description = 6 [(buf.validate.field).string.max_len = 1024];
+}
+
+// ========================================
+// Organization Definitions
+// ========================================
+
+// OrganizationDefinition declares an organization entity (party) within the manifest.
+// Organizations are registered as parties via the Party Service.
+// The code field is the immutable primary key.
+message OrganizationDefinition {
+  // code is the unique identifier for this organization (e.g., "ACME_ENERGY", "GRID_OPS").
+  // Must be uppercase alphanumeric with underscores.
+  string code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // name is the legal or display name of the organization.
+  string name = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // party_type is the party classification (e.g., "ORGANIZATION", "COUNTERPARTY").
+  // Must match a party type code from the manifest's party_types or a built-in type.
+  string party_type = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // attributes contains additional metadata for this organization as key-value pairs.
+  // Keys and values are validated against the party type's attribute_schema if defined.
+  map<string, string> attributes = 4;
 }

--- a/services/control-plane/internal/differ/manifest_differ.go
+++ b/services/control-plane/internal/differ/manifest_differ.go
@@ -973,7 +973,8 @@ func attributesEqual(a, b map[string]string) bool {
 		return false
 	}
 	for k, v := range a {
-		if b[k] != v {
+		bv, ok := b[k]
+		if !ok || bv != v {
 			return false
 		}
 	}

--- a/services/control-plane/internal/differ/manifest_differ.go
+++ b/services/control-plane/internal/differ/manifest_differ.go
@@ -958,8 +958,24 @@ func describeOrganizationChanges(code string, prev, updated *controlplanev1.Orga
 	if prev.GetPartyType() != updated.GetPartyType() {
 		changes = append(changes, fmt.Sprintf("party_type: %q -> %q", prev.GetPartyType(), updated.GetPartyType()))
 	}
+	if !attributesEqual(prev.GetAttributes(), updated.GetAttributes()) {
+		changes = append(changes, "attributes changed")
+	}
 	if len(changes) == 0 {
 		return fmt.Sprintf("Update organization %s", code)
 	}
 	return fmt.Sprintf("Update organization %s (%s)", code, strings.Join(changes, "; "))
+}
+
+// attributesEqual compares two string-keyed maps for equality.
+func attributesEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
 }

--- a/services/control-plane/internal/differ/manifest_differ.go
+++ b/services/control-plane/internal/differ/manifest_differ.go
@@ -78,6 +78,9 @@ func (d *ManifestDiffer) Diff(ctx context.Context, lastApplied, newManifest *con
 	d.diffPartyTypes(lastApplied, newManifest, plan)
 	d.diffMappings(lastApplied, newManifest, plan)
 	d.diffOperationalGateway(lastApplied, newManifest, plan)
+	d.diffMarketDataSources(lastApplied, newManifest, plan)
+	d.diffMarketDataSets(lastApplied, newManifest, plan)
+	d.diffOrganizations(lastApplied, newManifest, plan)
 
 	// Run safety checks on all DELETE actions (skip when validating for a new tenant)
 	if !cfg.skipSafetyChecks {
@@ -351,18 +354,16 @@ func (d *ManifestDiffer) runSafetyChecks(ctx context.Context, plan *DiffPlan) er
 			blocked, err = d.safety.CheckInstrumentDeletion(ctx, action.ResourceCode)
 		case ResourceSaga:
 			blocked, err = d.safety.CheckSagaDeletion(ctx, action.ResourceCode)
-		case ResourceValuationRule:
-			// Valuation rules have no downstream dependencies to check
-		case ResourcePartyType:
-			// Party types have no downstream dependencies to check via safety checker
-		case ResourceMapping:
-			// Mappings have no downstream dependencies to check
-		case ResourceProviderConnection:
-			// Provider connections may have active instructions but deletions are allowed
-		case ResourceInstructionRoute:
-			// Instruction routes have no downstream dependencies to check
+		case ResourceValuationRule,
+			ResourcePartyType,
+			ResourceMapping,
+			ResourceProviderConnection,
+			ResourceInstructionRoute,
+			ResourceMarketDataSource,
+			ResourceMarketDataSet,
+			ResourceOrganization:
+			// No downstream dependency checks for these resource types.
 		}
-
 		if err != nil {
 			return fmt.Errorf("safety check for %s %s: %w", action.ResourceType, action.ResourceCode, err)
 		}
@@ -510,6 +511,138 @@ func (d *ManifestDiffer) diffInstructionRoutes(lastApplied, newManifest *control
 	}
 }
 
+func (d *ManifestDiffer) diffMarketDataSources(lastApplied, newManifest *controlplanev1.Manifest, plan *DiffPlan) {
+	oldMap := marketDataSourceMap(getMarketDataSources(lastApplied))
+	newMap := marketDataSourceMap(newManifest.GetMarketData().GetSources())
+
+	for code, updated := range newMap {
+		prev, exists := oldMap[code]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSource,
+				ResourceCode: code,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create market data source %s (%s)", code, updated.GetName()),
+			})
+			continue
+		}
+		if !proto.Equal(prev, updated) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSource,
+				ResourceCode: code,
+				Action:       ActionUpdate,
+				Description:  describeMarketDataSourceChanges(code, prev, updated),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSource,
+				ResourceCode: code,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Market data source %s unchanged", code),
+			})
+		}
+	}
+
+	for code := range oldMap {
+		if _, exists := newMap[code]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSource,
+				ResourceCode: code,
+				Action:       ActionDelete,
+				Description:  fmt.Sprintf("Delete market data source %s", code),
+			})
+		}
+	}
+}
+
+func (d *ManifestDiffer) diffMarketDataSets(lastApplied, newManifest *controlplanev1.Manifest, plan *DiffPlan) {
+	oldMap := marketDataSetMap(getMarketDataSets(lastApplied))
+	newMap := marketDataSetMap(newManifest.GetMarketData().GetDatasets())
+
+	for code, updated := range newMap {
+		prev, exists := oldMap[code]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSet,
+				ResourceCode: code,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create market data set %s (%s)", code, updated.GetUnit()),
+			})
+			continue
+		}
+		if !proto.Equal(prev, updated) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSet,
+				ResourceCode: code,
+				Action:       ActionUpdate,
+				Description:  describeMarketDataSetChanges(code, prev, updated),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSet,
+				ResourceCode: code,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Market data set %s unchanged", code),
+			})
+		}
+	}
+
+	for code := range oldMap {
+		if _, exists := newMap[code]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceMarketDataSet,
+				ResourceCode: code,
+				Action:       ActionDelete,
+				Description:  fmt.Sprintf("Delete market data set %s", code),
+			})
+		}
+	}
+}
+
+func (d *ManifestDiffer) diffOrganizations(lastApplied, newManifest *controlplanev1.Manifest, plan *DiffPlan) {
+	oldMap := organizationMap(getOrganizations(lastApplied))
+	newMap := organizationMap(newManifest.GetOrganizations())
+
+	for code, updated := range newMap {
+		prev, exists := oldMap[code]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceOrganization,
+				ResourceCode: code,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create organization %s (%s)", code, updated.GetName()),
+			})
+			continue
+		}
+		if !proto.Equal(prev, updated) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceOrganization,
+				ResourceCode: code,
+				Action:       ActionUpdate,
+				Description:  describeOrganizationChanges(code, prev, updated),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceOrganization,
+				ResourceCode: code,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Organization %s unchanged", code),
+			})
+		}
+	}
+
+	for code := range oldMap {
+		if _, exists := newMap[code]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceOrganization,
+				ResourceCode: code,
+				Action:       ActionDelete,
+				Description:  fmt.Sprintf("Delete organization %s", code),
+			})
+		}
+	}
+}
+
 // Helper functions to safely extract slices from possibly-nil manifests.
 
 func getInstruments(m *controlplanev1.Manifest) []*controlplanev1.InstrumentDefinition {
@@ -645,6 +778,51 @@ func instructionRouteMap(routes []*controlplanev1.InstructionRouteConfig) map[st
 	return m
 }
 
+func getMarketDataSources(m *controlplanev1.Manifest) []*controlplanev1.MarketDataSourceDefinition {
+	if m == nil {
+		return nil
+	}
+	return m.GetMarketData().GetSources()
+}
+
+func getMarketDataSets(m *controlplanev1.Manifest) []*controlplanev1.MarketDataSetDefinition {
+	if m == nil {
+		return nil
+	}
+	return m.GetMarketData().GetDatasets()
+}
+
+func getOrganizations(m *controlplanev1.Manifest) []*controlplanev1.OrganizationDefinition {
+	if m == nil {
+		return nil
+	}
+	return m.GetOrganizations()
+}
+
+func marketDataSourceMap(sources []*controlplanev1.MarketDataSourceDefinition) map[string]*controlplanev1.MarketDataSourceDefinition {
+	m := make(map[string]*controlplanev1.MarketDataSourceDefinition, len(sources))
+	for _, s := range sources {
+		m[s.GetCode()] = s
+	}
+	return m
+}
+
+func marketDataSetMap(datasets []*controlplanev1.MarketDataSetDefinition) map[string]*controlplanev1.MarketDataSetDefinition {
+	m := make(map[string]*controlplanev1.MarketDataSetDefinition, len(datasets))
+	for _, ds := range datasets {
+		m[ds.GetCode()] = ds
+	}
+	return m
+}
+
+func organizationMap(orgs []*controlplanev1.OrganizationDefinition) map[string]*controlplanev1.OrganizationDefinition {
+	m := make(map[string]*controlplanev1.OrganizationDefinition, len(orgs))
+	for _, o := range orgs {
+		m[o.GetCode()] = o
+	}
+	return m
+}
+
 // Change description helpers.
 
 func describeInstrumentChanges(code string, prev, updated *controlplanev1.InstrumentDefinition) string {
@@ -733,4 +911,55 @@ func describeMappingChanges(key string, prev, updated *mappingv1.MappingDefiniti
 		return fmt.Sprintf("Update mapping %s", key)
 	}
 	return fmt.Sprintf("Update mapping %s (%s)", key, strings.Join(changes, "; "))
+}
+
+func describeMarketDataSourceChanges(code string, prev, updated *controlplanev1.MarketDataSourceDefinition) string {
+	var changes []string
+	if prev.GetName() != updated.GetName() {
+		changes = append(changes, fmt.Sprintf("name: %q -> %q", prev.GetName(), updated.GetName()))
+	}
+	if prev.GetTrustLevel() != updated.GetTrustLevel() {
+		changes = append(changes, fmt.Sprintf("trust_level: %d -> %d", prev.GetTrustLevel(), updated.GetTrustLevel()))
+	}
+	if prev.GetDescription() != updated.GetDescription() {
+		changes = append(changes, "description changed")
+	}
+	if len(changes) == 0 {
+		return fmt.Sprintf("Update market data source %s", code)
+	}
+	return fmt.Sprintf("Update market data source %s (%s)", code, strings.Join(changes, "; "))
+}
+
+func describeMarketDataSetChanges(code string, prev, updated *controlplanev1.MarketDataSetDefinition) string {
+	var changes []string
+	if prev.GetCategory() != updated.GetCategory() {
+		changes = append(changes, fmt.Sprintf("category: %s -> %s", prev.GetCategory(), updated.GetCategory()))
+	}
+	if prev.GetUnit() != updated.GetUnit() {
+		changes = append(changes, fmt.Sprintf("unit: %q -> %q", prev.GetUnit(), updated.GetUnit()))
+	}
+	if prev.GetSourceCode() != updated.GetSourceCode() {
+		changes = append(changes, fmt.Sprintf("source_code: %q -> %q", prev.GetSourceCode(), updated.GetSourceCode()))
+	}
+	if prev.GetDisplayName() != updated.GetDisplayName() {
+		changes = append(changes, fmt.Sprintf("display_name: %q -> %q", prev.GetDisplayName(), updated.GetDisplayName()))
+	}
+	if len(changes) == 0 {
+		return fmt.Sprintf("Update market data set %s", code)
+	}
+	return fmt.Sprintf("Update market data set %s (%s)", code, strings.Join(changes, "; "))
+}
+
+func describeOrganizationChanges(code string, prev, updated *controlplanev1.OrganizationDefinition) string {
+	var changes []string
+	if prev.GetName() != updated.GetName() {
+		changes = append(changes, fmt.Sprintf("name: %q -> %q", prev.GetName(), updated.GetName()))
+	}
+	if prev.GetPartyType() != updated.GetPartyType() {
+		changes = append(changes, fmt.Sprintf("party_type: %q -> %q", prev.GetPartyType(), updated.GetPartyType()))
+	}
+	if len(changes) == 0 {
+		return fmt.Sprintf("Update organization %s", code)
+	}
+	return fmt.Sprintf("Update organization %s (%s)", code, strings.Join(changes, "; "))
 }

--- a/services/control-plane/internal/differ/manifest_differ_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -975,4 +976,249 @@ func TestDiff_WithoutSkipSafetyChecks_SafetyChecksStillRun(t *testing.T) {
 
 	assert.True(t, plan.HasBlockedDeletions())
 	assert.True(t, plan.HasBreakingChanges)
+}
+
+// --- Market Data Source differ tests ---
+
+func TestDiff_MarketDataSourceAdded_Create(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.MarketData = &controlplanev1.MarketDataConfig{
+		Sources: []*controlplanev1.MarketDataSourceDefinition{
+			{Code: "BLOOMBERG", Name: "Bloomberg Terminal", TrustLevel: 90},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceMarketDataSource)
+	assert.Len(t, creates, 1)
+	assert.Equal(t, "BLOOMBERG", creates[0].ResourceCode)
+	assert.Contains(t, creates[0].Description, "Bloomberg Terminal")
+}
+
+func TestDiff_MarketDataSourceRemoved_Delete(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+	oldManifest.MarketData = &controlplanev1.MarketDataConfig{
+		Sources: []*controlplanev1.MarketDataSourceDefinition{
+			{Code: "ECB", Name: "European Central Bank", TrustLevel: 95},
+		},
+	}
+
+	newManifest := testManifest()
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourceMarketDataSource)
+	assert.Len(t, deletes, 1)
+	assert.Equal(t, "ECB", deletes[0].ResourceCode)
+}
+
+func TestDiff_MarketDataSourceModified_Update(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+	oldManifest.MarketData = &controlplanev1.MarketDataConfig{
+		Sources: []*controlplanev1.MarketDataSourceDefinition{
+			{Code: "BLOOMBERG", Name: "Bloomberg Terminal", TrustLevel: 90},
+		},
+	}
+
+	newManifest := testManifest()
+	newManifest.MarketData = &controlplanev1.MarketDataConfig{
+		Sources: []*controlplanev1.MarketDataSourceDefinition{
+			{Code: "BLOOMBERG", Name: "Bloomberg Terminal (Updated)", TrustLevel: 95},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceMarketDataSource)
+	assert.Len(t, updates, 1)
+	assert.Equal(t, "BLOOMBERG", updates[0].ResourceCode)
+	assert.Contains(t, updates[0].Description, "name:")
+	assert.Contains(t, updates[0].Description, "trust_level:")
+}
+
+func TestDiff_MarketDataSourceUnchanged_NoChange(t *testing.T) {
+	d := New(nil, nil)
+	manifest := testManifest()
+	manifest.MarketData = &controlplanev1.MarketDataConfig{
+		Sources: []*controlplanev1.MarketDataSourceDefinition{
+			{Code: "ECB", Name: "ECB", TrustLevel: 100},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), manifest, manifest)
+	require.NoError(t, err)
+
+	noChanges := filterActionsByResource(plan.Actions, ActionNoChange, ResourceMarketDataSource)
+	assert.Len(t, noChanges, 1)
+	assert.Equal(t, "ECB", noChanges[0].ResourceCode)
+}
+
+// --- Market Data Set differ tests ---
+
+func TestDiff_MarketDataSetAdded_Create(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.MarketData = &controlplanev1.MarketDataConfig{
+		Datasets: []*controlplanev1.MarketDataSetDefinition{
+			{
+				Code:       "USD_EUR_FX",
+				Category:   marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+				Unit:       "USD/EUR",
+				SourceCode: "ECB",
+			},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceMarketDataSet)
+	assert.Len(t, creates, 1)
+	assert.Equal(t, "USD_EUR_FX", creates[0].ResourceCode)
+	assert.Contains(t, creates[0].Description, "USD/EUR")
+}
+
+func TestDiff_MarketDataSetRemoved_Delete(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+	oldManifest.MarketData = &controlplanev1.MarketDataConfig{
+		Datasets: []*controlplanev1.MarketDataSetDefinition{
+			{
+				Code:       "BRENT_CRUDE",
+				Category:   marketinformationv1.DataCategory_DATA_CATEGORY_COMMODITY_PRICE,
+				Unit:       "USD/BBL",
+				SourceCode: "REUTERS",
+			},
+		},
+	}
+
+	newManifest := testManifest()
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourceMarketDataSet)
+	assert.Len(t, deletes, 1)
+	assert.Equal(t, "BRENT_CRUDE", deletes[0].ResourceCode)
+}
+
+func TestDiff_MarketDataSetModified_Update(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+	oldManifest.MarketData = &controlplanev1.MarketDataConfig{
+		Datasets: []*controlplanev1.MarketDataSetDefinition{
+			{
+				Code:       "USD_EUR_FX",
+				Category:   marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+				Unit:       "USD/EUR",
+				SourceCode: "ECB",
+			},
+		},
+	}
+
+	newManifest := testManifest()
+	newManifest.MarketData = &controlplanev1.MarketDataConfig{
+		Datasets: []*controlplanev1.MarketDataSetDefinition{
+			{
+				Code:       "USD_EUR_FX",
+				Category:   marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+				Unit:       "EUR/USD",
+				SourceCode: "BLOOMBERG",
+			},
+		},
+	}
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceMarketDataSet)
+	assert.Len(t, updates, 1)
+	assert.Equal(t, "USD_EUR_FX", updates[0].ResourceCode)
+	assert.Contains(t, updates[0].Description, "unit:")
+	assert.Contains(t, updates[0].Description, "source_code:")
+}
+
+// --- Organization differ tests ---
+
+func TestDiff_OrganizationAdded_Create(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.Organizations = []*controlplanev1.OrganizationDefinition{
+		{Code: "ACME_ENERGY", Name: "Acme Energy Ltd", PartyType: "ORGANIZATION"},
+	}
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceOrganization)
+	assert.Len(t, creates, 1)
+	assert.Equal(t, "ACME_ENERGY", creates[0].ResourceCode)
+	assert.Contains(t, creates[0].Description, "Acme Energy Ltd")
+}
+
+func TestDiff_OrganizationRemoved_Delete(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+	oldManifest.Organizations = []*controlplanev1.OrganizationDefinition{
+		{Code: "GRID_OPS", Name: "Grid Operations", PartyType: "ORGANIZATION"},
+	}
+
+	newManifest := testManifest()
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourceOrganization)
+	assert.Len(t, deletes, 1)
+	assert.Equal(t, "GRID_OPS", deletes[0].ResourceCode)
+}
+
+func TestDiff_OrganizationModified_Update(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+	oldManifest.Organizations = []*controlplanev1.OrganizationDefinition{
+		{Code: "ACME_ENERGY", Name: "Acme Energy Ltd", PartyType: "ORGANIZATION"},
+	}
+
+	newManifest := testManifest()
+	newManifest.Organizations = []*controlplanev1.OrganizationDefinition{
+		{Code: "ACME_ENERGY", Name: "Acme Energy PLC", PartyType: "COUNTERPARTY"},
+	}
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceOrganization)
+	assert.Len(t, updates, 1)
+	assert.Equal(t, "ACME_ENERGY", updates[0].ResourceCode)
+	assert.Contains(t, updates[0].Description, "name:")
+	assert.Contains(t, updates[0].Description, "party_type:")
+}
+
+func TestDiff_OrganizationUnchanged_NoChange(t *testing.T) {
+	d := New(nil, nil)
+	manifest := testManifest()
+	manifest.Organizations = []*controlplanev1.OrganizationDefinition{
+		{Code: "ACME_ENERGY", Name: "Acme Energy Ltd", PartyType: "ORGANIZATION"},
+	}
+
+	plan, err := d.Diff(context.Background(), manifest, manifest)
+	require.NoError(t, err)
+
+	noChanges := filterActionsByResource(plan.Actions, ActionNoChange, ResourceOrganization)
+	assert.Len(t, noChanges, 1)
+	assert.Equal(t, "ACME_ENERGY", noChanges[0].ResourceCode)
 }

--- a/services/control-plane/internal/differ/types.go
+++ b/services/control-plane/internal/differ/types.go
@@ -36,6 +36,9 @@ const (
 	ResourceMapping            ResourceType = "mapping"
 	ResourceProviderConnection ResourceType = "provider_connection"
 	ResourceInstructionRoute   ResourceType = "instruction_route"
+	ResourceMarketDataSource   ResourceType = "market_data_source"
+	ResourceMarketDataSet      ResourceType = "market_data_set"
+	ResourceOrganization       ResourceType = "organization"
 )
 
 // PlannedAction represents a single action in the diff plan.

--- a/services/control-plane/internal/planner/manifest_planner.go
+++ b/services/control-plane/internal/planner/manifest_planner.go
@@ -111,6 +111,12 @@ func phaseForResource(rt differ.ResourceType) Phase {
 		return PhaseOperationalGateway
 	case differ.ResourceInstructionRoute:
 		return PhaseOperationalGateway
+	case differ.ResourceMarketDataSource:
+		return PhaseMarketDataSources
+	case differ.ResourceMarketDataSet:
+		return PhaseMarketDataSets
+	case differ.ResourceOrganization:
+		return PhaseOrganizations
 	default:
 		return PhaseSeedData
 	}
@@ -178,6 +184,21 @@ var grpcMethodMap = map[methodKey]GRPCMethod{
 	{differ.ResourceInstructionRoute, differ.ActionCreate}: MethodUpsertInstructionRoute,
 	{differ.ResourceInstructionRoute, differ.ActionUpdate}: MethodUpsertInstructionRoute,
 	// No delete method: proto does not define DeleteRoute RPC.
+
+	// Market Data Sources
+	{differ.ResourceMarketDataSource, differ.ActionCreate}: MethodRegisterDataSource,
+	{differ.ResourceMarketDataSource, differ.ActionUpdate}: MethodUpdateDataSource,
+	{differ.ResourceMarketDataSource, differ.ActionDelete}: MethodDeactivateDataSource,
+
+	// Market Data Sets
+	{differ.ResourceMarketDataSet, differ.ActionCreate}: MethodRegisterDataSet,
+	{differ.ResourceMarketDataSet, differ.ActionUpdate}: MethodUpdateDataSet,
+	{differ.ResourceMarketDataSet, differ.ActionDelete}: MethodDeprecateDataSet,
+
+	// Organizations
+	{differ.ResourceOrganization, differ.ActionCreate}: MethodRegisterOrganization,
+	{differ.ResourceOrganization, differ.ActionUpdate}: MethodRegisterOrganization,
+	// No delete method: organizations are deactivated, not deleted.
 }
 
 // GenerateIdempotencyKey produces a deterministic SHA-256 based idempotency key.

--- a/services/control-plane/internal/planner/manifest_planner.go
+++ b/services/control-plane/internal/planner/manifest_planner.go
@@ -19,6 +19,10 @@ var ErrNoMethodMapping = errors.New("no gRPC method mapping")
 // Party types are managed through schema updates; deletion via manifest apply is not supported.
 var ErrDeleteNotSupportedForPartyType = errors.New("delete not supported for party types: update the schema instead")
 
+// ErrDeleteNotSupportedForOrganization is returned when a DELETE action is attempted on an organization.
+// Organizations are deactivated through the Party Service; deletion via manifest apply is not supported.
+var ErrDeleteNotSupportedForOrganization = errors.New("delete not supported for organizations: deactivate the party instead")
+
 // ManifestPlanner transforms a DiffPlan into a dependency-ordered
 // ExecutionPlan of gRPC calls. It assigns each action to a phase
 // based on resource type dependencies and maps actions to the
@@ -126,6 +130,9 @@ func phaseForResource(rt differ.ResourceType) Phase {
 func grpcMethodFor(rt differ.ResourceType, action differ.ActionType) (GRPCMethod, error) {
 	if rt == differ.ResourcePartyType && action == differ.ActionDelete {
 		return "", ErrDeleteNotSupportedForPartyType
+	}
+	if rt == differ.ResourceOrganization && action == differ.ActionDelete {
+		return "", ErrDeleteNotSupportedForOrganization
 	}
 	key := methodKey{rt, action}
 	method, ok := grpcMethodMap[key]

--- a/services/control-plane/internal/planner/manifest_planner_test.go
+++ b/services/control-plane/internal/planner/manifest_planner_test.go
@@ -577,6 +577,147 @@ func TestPlan_PartyType_Delete_NotSupported(t *testing.T) {
 	assert.ErrorIs(t, err, ErrDeleteNotSupportedForPartyType)
 }
 
+// --- Market Data Source planner tests ---
+
+func TestPlan_MarketDataSourcesInPhase9(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceMarketDataSource, ResourceCode: "BLOOMBERG", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+	assert.Equal(t, PhaseMarketDataSources, plan.Calls[0].Phase)
+	assert.Equal(t, MethodRegisterDataSource, plan.Calls[0].GRPCMethod)
+}
+
+func TestPlan_MarketDataSourceUpdate(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceMarketDataSource, ResourceCode: "ECB", Action: differ.ActionUpdate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+	assert.Equal(t, MethodUpdateDataSource, plan.Calls[0].GRPCMethod)
+}
+
+func TestPlan_MarketDataSourceDelete(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceMarketDataSource, ResourceCode: "REUTERS", Action: differ.ActionDelete},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+	assert.Equal(t, MethodDeactivateDataSource, plan.Calls[0].GRPCMethod)
+}
+
+// --- Market Data Set planner tests ---
+
+func TestPlan_MarketDataSetsInPhase10(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceMarketDataSet, ResourceCode: "USD_EUR_FX", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+	assert.Equal(t, PhaseMarketDataSets, plan.Calls[0].Phase)
+	assert.Equal(t, MethodRegisterDataSet, plan.Calls[0].GRPCMethod)
+}
+
+func TestPlan_MarketDataSetUpdate(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceMarketDataSet, ResourceCode: "BRENT_CRUDE", Action: differ.ActionUpdate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+	assert.Equal(t, MethodUpdateDataSet, plan.Calls[0].GRPCMethod)
+}
+
+func TestPlan_MarketDataSetDelete(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceMarketDataSet, ResourceCode: "OLD_FX", Action: differ.ActionDelete},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+	assert.Equal(t, MethodDeprecateDataSet, plan.Calls[0].GRPCMethod)
+}
+
+// --- Organization planner tests ---
+
+func TestPlan_OrganizationsInPhase11(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceOrganization, ResourceCode: "ACME_ENERGY", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+	assert.Equal(t, PhaseOrganizations, plan.Calls[0].Phase)
+	assert.Equal(t, MethodRegisterOrganization, plan.Calls[0].GRPCMethod)
+}
+
+func TestPlan_OrganizationUpdate(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceOrganization, ResourceCode: "ACME_ENERGY", Action: differ.ActionUpdate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+	assert.Equal(t, MethodRegisterOrganization, plan.Calls[0].GRPCMethod)
+}
+
+func TestPlan_PhaseOrdering_MarketDataBeforeOrganizations(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceOrganization, ResourceCode: "ORG", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceMarketDataSet, ResourceCode: "FX", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceMarketDataSource, ResourceCode: "SRC", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 3)
+
+	// Verify phase ordering: sources (9) < sets (10) < organizations (11)
+	assert.Equal(t, PhaseMarketDataSources, plan.Calls[0].Phase)
+	assert.Equal(t, PhaseMarketDataSets, plan.Calls[1].Phase)
+	assert.Equal(t, PhaseOrganizations, plan.Calls[2].Phase)
+}
+
 // --- Test helpers ---
 
 func indexCallsByResourceID(calls []PlannedCall) map[string]PlannedCall {

--- a/services/control-plane/internal/planner/manifest_planner_test.go
+++ b/services/control-plane/internal/planner/manifest_planner_test.go
@@ -698,6 +698,19 @@ func TestPlan_OrganizationUpdate(t *testing.T) {
 	assert.Equal(t, MethodRegisterOrganization, plan.Calls[0].GRPCMethod)
 }
 
+func TestPlan_Organization_Delete_NotSupported(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceOrganization, ResourceCode: "ACME", Action: differ.ActionDelete},
+		},
+	}
+
+	_, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	assert.Error(t, err, "DELETE for organizations should fail")
+	assert.ErrorIs(t, err, ErrDeleteNotSupportedForOrganization)
+}
+
 func TestPlan_PhaseOrdering_MarketDataBeforeOrganizations(t *testing.T) {
 	p := NewManifestPlanner()
 	diffPlan := &differ.DiffPlan{

--- a/services/control-plane/internal/planner/types.go
+++ b/services/control-plane/internal/planner/types.go
@@ -41,6 +41,18 @@ const (
 	// PhaseOperationalGateway configures provider connections and instruction routes
 	// in the Operational Gateway service (can run after mappings are registered).
 	PhaseOperationalGateway Phase = 8
+
+	// PhaseMarketDataSources registers market data sources with the Market Information service
+	// (no dependencies on other manifest sections).
+	PhaseMarketDataSources Phase = 9
+
+	// PhaseMarketDataSets registers market data set definitions with the Market Information service
+	// (depends on market data sources being registered first).
+	PhaseMarketDataSets Phase = 10
+
+	// PhaseOrganizations registers organization entities with the Party service
+	// (depends on party types being registered first).
+	PhaseOrganizations Phase = 11
 )
 
 // PhaseLabel returns a human-readable label for a phase.
@@ -62,6 +74,12 @@ func PhaseLabel(p Phase) string {
 		return "Party Types"
 	case PhaseOperationalGateway:
 		return "Operational Gateway"
+	case PhaseMarketDataSources:
+		return "Market Data Sources"
+	case PhaseMarketDataSets:
+		return "Market Data Sets"
+	case PhaseOrganizations:
+		return "Organizations"
 	default:
 		return fmt.Sprintf("Phase(%d)", p)
 	}
@@ -99,6 +117,17 @@ const (
 	// Operational Gateway Service
 	MethodUpsertProviderConnection GRPCMethod = "meridian.operational_gateway.v1.ProviderConnectionService/UpsertConnection"
 	MethodUpsertInstructionRoute   GRPCMethod = "meridian.operational_gateway.v1.InstructionRouteService/UpsertRoute"
+
+	// Market Information Service
+	MethodRegisterDataSource   GRPCMethod = "meridian.market_information.v1.MarketInformationService/RegisterDataSource"
+	MethodUpdateDataSource     GRPCMethod = "meridian.market_information.v1.MarketInformationService/UpdateDataSource"
+	MethodDeactivateDataSource GRPCMethod = "meridian.market_information.v1.MarketInformationService/DeactivateDataSource"
+	MethodRegisterDataSet      GRPCMethod = "meridian.market_information.v1.MarketInformationService/RegisterDataSet"
+	MethodUpdateDataSet        GRPCMethod = "meridian.market_information.v1.MarketInformationService/UpdateDataSet"
+	MethodDeprecateDataSet     GRPCMethod = "meridian.market_information.v1.MarketInformationService/DeprecateDataSet"
+
+	// Party Service (Organizations)
+	MethodRegisterOrganization GRPCMethod = "meridian.party.v1.PartyService/RegisterParty"
 )
 
 // PlannedCall represents a single gRPC call in the execution plan.
@@ -202,7 +231,7 @@ func (p *ExecutionPlan) Visualize() string {
 	fmt.Fprintf(&b, "Total calls: %d\n\n", len(p.Calls))
 
 	byPhase := p.ByPhase()
-	for phase := PhaseInstruments; phase <= PhaseOperationalGateway; phase++ { //nolint:intrange
+	for phase := PhaseInstruments; phase <= PhaseOrganizations; phase++ { //nolint:intrange
 		calls, ok := byPhase[phase]
 		if !ok {
 			continue

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -578,6 +578,60 @@ func (v *ManifestValidator) validateDuplicates(
 
 	// Check duplicate operational_gateway connection_ids and instruction_types
 	v.validateOperationalGatewayDuplicates(manifest, result)
+
+	// Check duplicate market data and organization codes
+	v.validateMarketDataAndOrgDuplicates(manifest, result)
+}
+
+// validateMarketDataAndOrgDuplicates checks for duplicate codes in market data and organization sections.
+func (v *ManifestValidator) validateMarketDataAndOrgDuplicates(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	// Check duplicate market data source codes
+	mdSourceCodes := make(map[string]int)
+	for i, src := range manifest.GetMarketData().GetSources() {
+		if prev, exists := mdSourceCodes[src.GetCode()]; exists {
+			addError(result, ValidationError{
+				Severity: SeverityError,
+				Path:     fmt.Sprintf("market_data.sources[%d].code", i),
+				Code:     "DUPLICATE_CODE",
+				Message:  fmt.Sprintf("duplicate market data source code %q (first defined at market_data.sources[%d])", src.GetCode(), prev),
+			})
+		} else {
+			mdSourceCodes[src.GetCode()] = i
+		}
+	}
+
+	// Check duplicate market data set codes
+	mdSetCodes := make(map[string]int)
+	for i, ds := range manifest.GetMarketData().GetDatasets() {
+		if prev, exists := mdSetCodes[ds.GetCode()]; exists {
+			addError(result, ValidationError{
+				Severity: SeverityError,
+				Path:     fmt.Sprintf("market_data.datasets[%d].code", i),
+				Code:     "DUPLICATE_CODE",
+				Message:  fmt.Sprintf("duplicate market data set code %q (first defined at market_data.datasets[%d])", ds.GetCode(), prev),
+			})
+		} else {
+			mdSetCodes[ds.GetCode()] = i
+		}
+	}
+
+	// Check duplicate organization codes
+	orgCodes := make(map[string]int)
+	for i, org := range manifest.GetOrganizations() {
+		if prev, exists := orgCodes[org.GetCode()]; exists {
+			addError(result, ValidationError{
+				Severity: SeverityError,
+				Path:     fmt.Sprintf("organizations[%d].code", i),
+				Code:     "DUPLICATE_CODE",
+				Message:  fmt.Sprintf("duplicate organization code %q (first defined at organizations[%d])", org.GetCode(), prev),
+			})
+		} else {
+			orgCodes[org.GetCode()] = i
+		}
+	}
 }
 
 // validateOperationalGatewayDuplicates checks for duplicate connection_ids and instruction_types.
@@ -857,6 +911,29 @@ func (v *ManifestValidator) validateCrossReferences(
 
 	// Validate operational_gateway cross-references
 	v.validateOperationalGatewayCrossRefs(manifest, result)
+
+	// Validate market data set source_code references valid market data source
+	mdSourceCodes := make(map[string]bool)
+	for _, src := range manifest.GetMarketData().GetSources() {
+		mdSourceCodes[src.GetCode()] = true
+	}
+	mdSourceCodeList := mapKeys(mdSourceCodes)
+	for i, ds := range manifest.GetMarketData().GetDatasets() {
+		sourceCode := ds.GetSourceCode()
+		if sourceCode != "" && !mdSourceCodes[sourceCode] {
+			ve := ValidationError{
+				Severity:        SeverityError,
+				Path:            fmt.Sprintf("market_data.datasets[%d].source_code", i),
+				Code:            "INVALID_REFERENCE",
+				Message:         fmt.Sprintf("market data set %q references unknown source code %q", ds.GetCode(), sourceCode),
+				AvailableFields: mdSourceCodeList,
+			}
+			if suggestion := findClosestMatch(sourceCode, mdSourceCodeList); suggestion != "" {
+				ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+			}
+			addError(result, ve)
+		}
+	}
 }
 
 // validateOperationalGatewayCrossRefs validates referential integrity for the operational_gateway section.

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -934,6 +934,43 @@ func (v *ManifestValidator) validateCrossReferences(
 			addError(result, ve)
 		}
 	}
+
+	// Validate organization party_type references
+	v.validateOrganizationCrossRefs(manifest, result)
+}
+
+// validateOrganizationCrossRefs validates that organizations reference valid party types.
+func (v *ManifestValidator) validateOrganizationCrossRefs(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	// Built-in party types from the PartyType enum plus manifest-defined party types
+	validPartyTypes := map[string]bool{
+		"PERSON":       true,
+		"ORGANIZATION": true,
+	}
+	for _, pt := range manifest.GetPartyTypes() {
+		if ptCode := pt.GetPartyType(); ptCode != "" {
+			validPartyTypes[ptCode] = true
+		}
+	}
+	partyTypeList := mapKeys(validPartyTypes)
+	for i, org := range manifest.GetOrganizations() {
+		partyType := org.GetPartyType()
+		if partyType != "" && !validPartyTypes[partyType] {
+			ve := ValidationError{
+				Severity:        SeverityError,
+				Path:            fmt.Sprintf("organizations[%d].party_type", i),
+				Code:            "INVALID_REFERENCE",
+				Message:         fmt.Sprintf("organization %q references unknown party type %q", org.GetCode(), partyType),
+				AvailableFields: partyTypeList,
+			}
+			if suggestion := findClosestMatch(partyType, partyTypeList); suggestion != "" {
+				ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+			}
+			addError(result, ve)
+		}
+	}
 }
 
 // validateOperationalGatewayCrossRefs validates referential integrity for the operational_gateway section.

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -3117,3 +3117,64 @@ func TestValidate_DuplicateOrganizationCodes(t *testing.T) {
 	}
 	assert.True(t, found, "expected DUPLICATE_CODE error for organizations")
 }
+
+func TestValidate_OrganizationReferencesInvalidPartyType(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.Organizations = []*controlplanev1.OrganizationDefinition{
+		{Code: "ACME", Name: "Acme Corp", PartyType: "UNKNOWN_TYPE"},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_REFERENCE" && strings.Contains(e.Path, "organizations[0].party_type") {
+			found = true
+			assert.Contains(t, e.Message, "UNKNOWN_TYPE")
+			break
+		}
+	}
+	assert.True(t, found, "expected INVALID_REFERENCE error for invalid party_type")
+}
+
+func TestValidate_OrganizationReferencesBuiltInPartyType(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.Organizations = []*controlplanev1.OrganizationDefinition{
+		{Code: "ACME", Name: "Acme Corp", PartyType: "ORGANIZATION"},
+		{Code: "BOB", Name: "Bob Smith", PartyType: "PERSON"},
+	}
+
+	result := v.Validate(manifest, nil)
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_REFERENCE" && strings.Contains(e.Path, "organizations") {
+			t.Errorf("unexpected INVALID_REFERENCE error: %s", e.Message)
+		}
+	}
+}
+
+func TestValidate_OrganizationReferencesManifestDefinedPartyType(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.PartyTypes = []*partyv1.PartyTypeDefinition{
+		{TenantId: "test", PartyType: "COUNTERPARTY", AttributeSchema: `{"type":"object"}`},
+	}
+	manifest.Organizations = []*controlplanev1.OrganizationDefinition{
+		{Code: "PARTNER", Name: "Trading Partner", PartyType: "COUNTERPARTY"},
+	}
+
+	result := v.Validate(manifest, nil)
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_REFERENCE" && strings.Contains(e.Path, "organizations") {
+			t.Errorf("unexpected INVALID_REFERENCE error: %s", e.Message)
+		}
+	}
+}

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/cel-go/cel"
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
 	"github.com/stretchr/testify/assert"
@@ -2984,4 +2985,135 @@ func TestWithoutSkipImmutabilityChecks_StillEnforcesImmutability(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "expected IMMUTABLE_FIELD_CHANGED error without skip option")
+}
+
+// --- Market Data validation tests ---
+
+func TestValidate_DuplicateMarketDataSourceCodes(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.MarketData = &controlplanev1.MarketDataConfig{
+		Sources: []*controlplanev1.MarketDataSourceDefinition{
+			{Code: "BLOOMBERG", Name: "Bloomberg 1", TrustLevel: 90},
+			{Code: "BLOOMBERG", Name: "Bloomberg 2", TrustLevel: 80},
+		},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "DUPLICATE_CODE" && strings.Contains(e.Path, "market_data.sources") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected DUPLICATE_CODE error for market data sources")
+}
+
+func TestValidate_DuplicateMarketDataSetCodes(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.MarketData = &controlplanev1.MarketDataConfig{
+		Sources: []*controlplanev1.MarketDataSourceDefinition{
+			{Code: "ECB", Name: "ECB", TrustLevel: 95},
+		},
+		Datasets: []*controlplanev1.MarketDataSetDefinition{
+			{Code: "USD_EUR_FX", Category: marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE, Unit: "USD/EUR", SourceCode: "ECB"},
+			{Code: "USD_EUR_FX", Category: marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE, Unit: "EUR/USD", SourceCode: "ECB"},
+		},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "DUPLICATE_CODE" && strings.Contains(e.Path, "market_data.datasets") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected DUPLICATE_CODE error for market data sets")
+}
+
+func TestValidate_MarketDataSetReferencesInvalidSource(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.MarketData = &controlplanev1.MarketDataConfig{
+		Sources: []*controlplanev1.MarketDataSourceDefinition{
+			{Code: "ECB", Name: "ECB", TrustLevel: 95},
+		},
+		Datasets: []*controlplanev1.MarketDataSetDefinition{
+			{Code: "USD_EUR_FX", Category: marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE, Unit: "USD/EUR", SourceCode: "BLOOMBERG"},
+		},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_REFERENCE" && strings.Contains(e.Path, "market_data.datasets[0].source_code") {
+			found = true
+			assert.Contains(t, e.Message, "BLOOMBERG")
+			break
+		}
+	}
+	assert.True(t, found, "expected INVALID_REFERENCE error for invalid source_code")
+}
+
+func TestValidate_MarketDataSetValidSourceReference(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.MarketData = &controlplanev1.MarketDataConfig{
+		Sources: []*controlplanev1.MarketDataSourceDefinition{
+			{Code: "ECB", Name: "European Central Bank", TrustLevel: 95},
+		},
+		Datasets: []*controlplanev1.MarketDataSetDefinition{
+			{Code: "USD_EUR_FX", Category: marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE, Unit: "USD/EUR", SourceCode: "ECB"},
+		},
+	}
+
+	result := v.Validate(manifest, nil)
+	// No INVALID_REFERENCE errors expected for the market data section
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_REFERENCE" && strings.Contains(e.Path, "market_data") {
+			t.Errorf("unexpected INVALID_REFERENCE error: %s", e.Message)
+		}
+	}
+}
+
+// --- Organization validation tests ---
+
+func TestValidate_DuplicateOrganizationCodes(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.Organizations = []*controlplanev1.OrganizationDefinition{
+		{Code: "ACME", Name: "Acme Energy 1", PartyType: "ORGANIZATION"},
+		{Code: "ACME", Name: "Acme Energy 2", PartyType: "ORGANIZATION"},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "DUPLICATE_CODE" && strings.Contains(e.Path, "organizations") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected DUPLICATE_CODE error for organizations")
 }


### PR DESCRIPTION
## Summary

- Add `MarketDataSource`, `MarketDataSet`, and `Organization` resource types to the manifest differ, planner, and validator
- MarketData sources and data sets are managed via the Market Information Service (`RegisterDataSource`, `RegisterDataSet`, etc.)
- Organizations are registered as parties via `PartyService/RegisterParty`
- Cross-reference validation ensures data set `source_code` references a valid market data source

## Changes Made

### Proto (`manifest.proto`)
- Add `MarketDataConfig` wrapper with `sources` and `datasets` repeated fields
- Add `MarketDataSourceDefinition` (code, name, description, trust_level)
- Add `MarketDataSetDefinition` (code, category, unit, source_code, display_name, description)
- Add `OrganizationDefinition` (code, name, party_type, attributes map)
- Add `market_data` (field 12) and `organizations` (field 13) to `Manifest` message

### Differ
- Add `ResourceMarketDataSource`, `ResourceMarketDataSet`, `ResourceOrganization` constants
- Implement `diffMarketDataSources()`, `diffMarketDataSets()`, `diffOrganizations()`
- Add change description helpers for all three resource types

### Planner
- Add `PhaseMarketDataSources` (9), `PhaseMarketDataSets` (10), `PhaseOrganizations` (11)
- Add gRPC method mappings: `RegisterDataSource`/`UpdateDataSource`/`DeactivateDataSource`, `RegisterDataSet`/`UpdateDataSet`/`DeprecateDataSet`, `RegisterOrganization`

### Validator
- Add duplicate code detection for market data sources, data sets, and organizations
- Add cross-reference validation: data set `source_code` must reference a valid source in `market_data.sources`

## Task Master Context

Tasks 045-manifest-source-of-truth.1 and 045-manifest-source-of-truth.3 (combined due to shared hot files).

## Test Plan

- [x] Differ tests: CREATE/UPDATE/DELETE/NO_CHANGE for market data sources, data sets, and organizations
- [x] Planner tests: phase assignment (9/10/11), gRPC method mapping, phase ordering
- [x] Validator tests: duplicate code detection, cross-reference validation (valid and invalid source_code)
- [x] All existing tests pass (no regressions)
- [ ] CI passes