### PR TITLE
fix: Derive MCP OAuth metadata URLs from request Host header

### DIFF
--- a/services/mcp-server/cmd/main.go
+++ b/services/mcp-server/cmd/main.go
@@ -215,12 +215,9 @@ func runHTTP(logger *slog.Logger, srv *mcp.Server) error {
 
 		// RFC 8414 OAuth Authorization Server Metadata — required by MCP clients
 		// (e.g. Claude.ai) to discover auth endpoints before connecting.
-		mux.HandleFunc("/.well-known/oauth-authorization-server", mcpauth.NewMetadataHandler(baseURL, oauthCfg))
-
-		meta := mcpauth.Metadata{
-			AuthorizationURL: oauthCfg.AuthorizationURL,
-			TokenURL:         oauthCfg.TokenURL,
-		}
+		// URLs are derived at runtime from the request's Host header so that
+		// tenant-scoped subdomains receive correctly scoped endpoints.
+		mux.HandleFunc("/.well-known/oauth-authorization-server", mcpauth.NewMetadataHandler(baseURL))
 
 		baseDomain := env.GetEnvOrDefault("MCP_BASE_DOMAIN", "")
 
@@ -286,7 +283,7 @@ func runHTTP(logger *slog.Logger, srv *mcp.Server) error {
 		if validatorCleanup != nil {
 			defer validatorCleanup()
 		}
-		bearerMW := mcpauth.NewBearerMiddleware(validator, meta)
+		bearerMW := mcpauth.NewBearerMiddleware(validator, baseURL)
 
 		// Subdomain-to-tenant validation: ensures the request's subdomain
 		// matches the authenticated user's tenant from the JWT.
@@ -298,7 +295,7 @@ func runHTTP(logger *slog.Logger, srv *mcp.Server) error {
 		// subdomain validation. The passthrough validator in dev mode does not
 		// implement ClaimsBearerValidator, so subdomain checks are skipped.
 		if claimsValidator, ok := validator.(mcpauth.ClaimsBearerValidator); ok {
-			mcpHandler = subdomainMW.Handler(claimsValidator, meta, mcpHandler)
+			mcpHandler = subdomainMW.Handler(claimsValidator, baseURL, mcpHandler)
 		}
 
 		mux.Handle("/mcp", mcpHandler)

--- a/services/mcp-server/internal/auth/oauth.go
+++ b/services/mcp-server/internal/auth/oauth.go
@@ -244,7 +244,7 @@ func NewMetadataHandler(fallbackBaseURL string) http.HandlerFunc {
 // preventing client spoofing. The MCP server must NOT be exposed directly
 // to the internet without a reverse proxy that sanitizes these headers.
 func baseURLFromRequest(r *http.Request, fallback string) string {
-	host := r.Header.Get("X-Forwarded-Host")
+	host := firstCSV(r.Header.Get("X-Forwarded-Host"))
 	if host == "" {
 		host = r.Host
 	}
@@ -252,7 +252,7 @@ func baseURLFromRequest(r *http.Request, fallback string) string {
 		return fallback
 	}
 
-	scheme := r.Header.Get("X-Forwarded-Proto")
+	scheme := firstCSV(r.Header.Get("X-Forwarded-Proto"))
 	if scheme == "" {
 		if r.TLS != nil {
 			scheme = "https"
@@ -262,6 +262,17 @@ func baseURLFromRequest(r *http.Request, fallback string) string {
 	}
 
 	return scheme + "://" + host
+}
+
+// firstCSV returns the first value from a potentially comma-separated header.
+// In multi-hop proxy setups, X-Forwarded-Host and X-Forwarded-Proto may
+// contain multiple values (e.g., "client-host, proxy-host"). The first
+// value is the original client-facing value.
+func firstCSV(v string) string {
+	if i := strings.IndexByte(v, ','); i >= 0 {
+		return strings.TrimSpace(v[:i])
+	}
+	return strings.TrimSpace(v)
 }
 
 // -----------------------------------------------------------------------

--- a/services/mcp-server/internal/auth/oauth.go
+++ b/services/mcp-server/internal/auth/oauth.go
@@ -204,31 +204,58 @@ type AuthorizationServerMetadata struct {
 // Authorization Server Metadata document (RFC 8414) at
 // /.well-known/oauth-authorization-server.
 //
-// The response is pre-serialized at construction time for efficiency.
-func NewMetadataHandler(baseURL string, cfg OAuthConfig) http.HandlerFunc {
-	meta := AuthorizationServerMetadata{
-		Issuer:                            baseURL,
-		AuthorizationEndpoint:             cfg.AuthorizationURL,
-		TokenEndpoint:                     cfg.TokenURL,
-		RegistrationEndpoint:              baseURL + "/oauth/register",
-		ResponseTypesSupported:            []string{"code"},
-		GrantTypesSupported:               []string{"authorization_code"},
-		CodeChallengeMethodsSupported:     []string{"S256"},
-		TokenEndpointAuthMethodsSupported: []string{"none"},
-	}
-
-	body, err := json.Marshal(meta)
-	if err != nil {
-		return func(w http.ResponseWriter, _ *http.Request) {
-			http.Error(w, "internal error: failed to serialize metadata", http.StatusInternalServerError)
+// URLs are derived from the request's Host header at runtime so that
+// tenant-scoped subdomains (e.g., acme.demo.meridianhub.cloud) receive
+// metadata pointing back to their own origin.
+func NewMetadataHandler(fallbackBaseURL string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		base := baseURLFromRequest(r, fallbackBaseURL)
+		meta := AuthorizationServerMetadata{
+			Issuer:                            base,
+			AuthorizationEndpoint:             base + "/oauth/authorize",
+			TokenEndpoint:                     base + "/oauth/token",
+			RegistrationEndpoint:              base + "/oauth/register",
+			ResponseTypesSupported:            []string{"code"},
+			GrantTypesSupported:               []string{"authorization_code"},
+			CodeChallengeMethodsSupported:     []string{"S256"},
+			TokenEndpointAuthMethodsSupported: []string{"none"},
 		}
-	}
 
-	return func(w http.ResponseWriter, _ *http.Request) {
+		body, err := json.Marshal(meta)
+		if err != nil {
+			http.Error(w, "internal error: failed to serialize metadata", http.StatusInternalServerError)
+			return
+		}
+
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.Header().Set("Cache-Control", "public, max-age=3600")
 		_, _ = w.Write(body)
 	}
+}
+
+// baseURLFromRequest derives the base URL (scheme + host) from the incoming
+// request. It checks X-Forwarded-Host and X-Forwarded-Proto headers first
+// (set by reverse proxies like Caddy), then falls back to r.Host.
+// If the host cannot be determined, fallback is returned.
+func baseURLFromRequest(r *http.Request, fallback string) string {
+	host := r.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = r.Host
+	}
+	if host == "" {
+		return fallback
+	}
+
+	scheme := r.Header.Get("X-Forwarded-Proto")
+	if scheme == "" {
+		if r.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+
+	return scheme + "://" + host
 }
 
 // -----------------------------------------------------------------------
@@ -468,19 +495,21 @@ func (h *TokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // BearerMiddleware enforces Bearer token authentication on HTTP handlers.
 // Unauthenticated requests receive a 401 with Metadata so MCP clients
-// can start the OAuth flow.
+// can start the OAuth flow. The metadata URLs are derived from the request's
+// Host header so that tenant-scoped subdomains receive correct endpoints.
 type BearerMiddleware struct {
-	validator BearerValidator
-	meta      Metadata
-	logger    *slog.Logger
+	validator       BearerValidator
+	fallbackBaseURL string
+	logger          *slog.Logger
 }
 
-// NewBearerMiddleware creates a new BearerMiddleware.
-func NewBearerMiddleware(validator BearerValidator, meta Metadata) *BearerMiddleware {
+// NewBearerMiddleware creates a new BearerMiddleware. The fallbackBaseURL is
+// used when the request's Host header cannot be determined.
+func NewBearerMiddleware(validator BearerValidator, fallbackBaseURL string) *BearerMiddleware {
 	return &BearerMiddleware{
-		validator: validator,
-		meta:      meta,
-		logger:    slog.Default(),
+		validator:       validator,
+		fallbackBaseURL: fallbackBaseURL,
+		logger:          slog.Default(),
 	}
 }
 
@@ -489,14 +518,14 @@ func (m *BearerMiddleware) Handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token, err := extractBearerFromHeader(r)
 		if err != nil {
-			m.writeAuthRequired(w)
+			m.writeAuthRequired(w, r)
 			return
 		}
 
 		if err := m.validator.ValidateBearer(token); err != nil {
 			m.logger.Debug("bearer token validation failed",
 				"error", err, "path", r.URL.Path)
-			m.writeAuthRequired(w)
+			m.writeAuthRequired(w, r)
 			return
 		}
 
@@ -504,12 +533,17 @@ func (m *BearerMiddleware) Handler(next http.Handler) http.Handler {
 	})
 }
 
-// writeAuthRequired writes a 401 response with auth metadata.
-func (m *BearerMiddleware) writeAuthRequired(w http.ResponseWriter) {
+// writeAuthRequired writes a 401 response with auth metadata derived from the request.
+func (m *BearerMiddleware) writeAuthRequired(w http.ResponseWriter, r *http.Request) {
+	base := baseURLFromRequest(r, m.fallbackBaseURL)
+	meta := Metadata{
+		AuthorizationURL: base + "/oauth/authorize",
+		TokenURL:         base + "/oauth/token",
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("WWW-Authenticate", `Bearer realm="meridian-mcp"`)
 	w.WriteHeader(http.StatusUnauthorized)
-	_ = json.NewEncoder(w).Encode(m.meta)
+	_ = json.NewEncoder(w).Encode(meta)
 }
 
 // -----------------------------------------------------------------------

--- a/services/mcp-server/internal/auth/oauth.go
+++ b/services/mcp-server/internal/auth/oauth.go
@@ -559,6 +559,8 @@ func (m *BearerMiddleware) writeAuthRequired(w http.ResponseWriter, r *http.Requ
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("WWW-Authenticate", `Bearer realm="meridian-mcp"`)
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Vary", "Host, X-Forwarded-Host, X-Forwarded-Proto")
 	w.WriteHeader(http.StatusUnauthorized)
 	_ = json.NewEncoder(w).Encode(meta)
 }

--- a/services/mcp-server/internal/auth/oauth.go
+++ b/services/mcp-server/internal/auth/oauth.go
@@ -229,6 +229,7 @@ func NewMetadataHandler(fallbackBaseURL string) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.Header().Set("Cache-Control", "public, max-age=3600")
+		w.Header().Set("Vary", "Host, X-Forwarded-Host, X-Forwarded-Proto")
 		_, _ = w.Write(body)
 	}
 }
@@ -237,6 +238,11 @@ func NewMetadataHandler(fallbackBaseURL string) http.HandlerFunc {
 // request. It checks X-Forwarded-Host and X-Forwarded-Proto headers first
 // (set by reverse proxies like Caddy), then falls back to r.Host.
 // If the host cannot be determined, fallback is returned.
+//
+// Security: This function trusts X-Forwarded-Host/Proto headers. In production
+// these are set by Caddy which overwrites (not appends) forwarded headers,
+// preventing client spoofing. The MCP server must NOT be exposed directly
+// to the internet without a reverse proxy that sanitizes these headers.
 func baseURLFromRequest(r *http.Request, fallback string) string {
 	host := r.Header.Get("X-Forwarded-Host")
 	if host == "" {

--- a/services/mcp-server/internal/auth/oauth_test.go
+++ b/services/mcp-server/internal/auth/oauth_test.go
@@ -75,14 +75,11 @@ func TestAuthMetadata_JSON(t *testing.T) {
 // -----------------------------------------------------------------------
 
 func TestMetadataHandler_ServesRFC8414(t *testing.T) {
-	cfg := auth.OAuthConfig{
-		ClientID:         "meridian-mcp",
-		AuthorizationURL: "https://mcp.example.com/oauth/authorize",
-		TokenURL:         "https://mcp.example.com/oauth/token",
-	}
+	handler := auth.NewMetadataHandler("https://mcp.example.com")
 
-	handler := auth.NewMetadataHandler("https://mcp.example.com", cfg)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	req.Host = "mcp.example.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
 	rec := httptest.NewRecorder()
 	handler(rec, req)
 
@@ -100,6 +97,41 @@ func TestMetadataHandler_ServesRFC8414(t *testing.T) {
 	assert.Equal(t, []string{"authorization_code"}, meta.GrantTypesSupported)
 	assert.Equal(t, []string{"S256"}, meta.CodeChallengeMethodsSupported)
 	assert.Equal(t, []string{"none"}, meta.TokenEndpointAuthMethodsSupported)
+}
+
+func TestMetadataHandler_DerivesTenantScopedURLs(t *testing.T) {
+	handler := auth.NewMetadataHandler("https://demo.meridianhub.cloud")
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	req.Host = "volterra-energy.demo.meridianhub.cloud"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var meta auth.AuthorizationServerMetadata
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &meta))
+
+	assert.Equal(t, "https://volterra-energy.demo.meridianhub.cloud", meta.Issuer)
+	assert.Equal(t, "https://volterra-energy.demo.meridianhub.cloud/oauth/authorize", meta.AuthorizationEndpoint)
+	assert.Equal(t, "https://volterra-energy.demo.meridianhub.cloud/oauth/token", meta.TokenEndpoint)
+}
+
+func TestMetadataHandler_UsesFallbackWhenNoHost(t *testing.T) {
+	handler := auth.NewMetadataHandler("https://fallback.example.com")
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	req.Host = "" // Explicitly clear the default Host set by httptest
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var meta auth.AuthorizationServerMetadata
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &meta))
+
+	assert.Equal(t, "https://fallback.example.com", meta.Issuer)
 }
 
 // -----------------------------------------------------------------------
@@ -492,18 +524,16 @@ func TestAuthCodeStore_ConsumeOnlyOnce(t *testing.T) {
 // -----------------------------------------------------------------------
 
 func TestBearerMiddleware_RejectsUnauthenticated(t *testing.T) {
-	meta := auth.Metadata{
-		AuthorizationURL: "https://auth.example.com/authorize",
-		TokenURL:         "https://auth.example.com/token",
-	}
 	validator := &alwaysFailValidator{}
-	mw := auth.NewBearerMiddleware(validator, meta)
+	mw := auth.NewBearerMiddleware(validator, "https://auth.example.com")
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/mcp", nil)
+	req.Host = "auth.example.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
 	w := httptest.NewRecorder()
 	mw.Handler(inner).ServeHTTP(w, req)
 
@@ -511,17 +541,35 @@ func TestBearerMiddleware_RejectsUnauthenticated(t *testing.T) {
 
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
-	assert.Equal(t, "https://auth.example.com/authorize", body["authorization_url"])
-	assert.Equal(t, "https://auth.example.com/token", body["token_url"])
+	assert.Equal(t, "https://auth.example.com/oauth/authorize", body["authorization_url"])
+	assert.Equal(t, "https://auth.example.com/oauth/token", body["token_url"])
+}
+
+func TestBearerMiddleware_RejectsUnauthenticated_TenantScoped(t *testing.T) {
+	validator := &alwaysFailValidator{}
+	mw := auth.NewBearerMiddleware(validator, "https://demo.meridianhub.cloud")
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/mcp", nil)
+	req.Host = "volterra-energy.demo.meridianhub.cloud"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	mw.Handler(inner).ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "https://volterra-energy.demo.meridianhub.cloud/oauth/authorize", body["authorization_url"])
+	assert.Equal(t, "https://volterra-energy.demo.meridianhub.cloud/oauth/token", body["token_url"])
 }
 
 func TestBearerMiddleware_AcceptsValidToken(t *testing.T) {
-	meta := auth.Metadata{
-		AuthorizationURL: "https://auth.example.com/authorize",
-		TokenURL:         "https://auth.example.com/token",
-	}
 	validator := &alwaysOKValidator{}
-	mw := auth.NewBearerMiddleware(validator, meta)
+	mw := auth.NewBearerMiddleware(validator, "https://auth.example.com")
 
 	reached := false
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/services/mcp-server/internal/auth/registration_test.go
+++ b/services/mcp-server/internal/auth/registration_test.go
@@ -183,14 +183,10 @@ func TestRegistrationHandler_RejectsOversizedBody(t *testing.T) {
 }
 
 func TestMetadataHandler_IncludesRegistrationEndpoint(t *testing.T) {
-	cfg := auth.OAuthConfig{
-		ClientID:         "meridian-mcp",
-		AuthorizationURL: "https://mcp.example.com/oauth/authorize",
-		TokenURL:         "https://mcp.example.com/oauth/token",
-	}
-
-	handler := auth.NewMetadataHandler("https://mcp.example.com", cfg)
+	handler := auth.NewMetadataHandler("https://mcp.example.com")
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+	req.Host = "mcp.example.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
 	rec := httptest.NewRecorder()
 	handler(rec, req)
 

--- a/services/mcp-server/internal/auth/subdomain.go
+++ b/services/mcp-server/internal/auth/subdomain.go
@@ -167,6 +167,8 @@ func writeSubdomainError(w http.ResponseWriter, r *http.Request, fallbackBaseURL
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("WWW-Authenticate", `Bearer realm="meridian-mcp"`)
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Vary", "Host, X-Forwarded-Host, X-Forwarded-Proto")
 	w.WriteHeader(http.StatusUnauthorized)
 	_ = json.NewEncoder(w).Encode(meta)
 }

--- a/services/mcp-server/internal/auth/subdomain.go
+++ b/services/mcp-server/internal/auth/subdomain.go
@@ -70,7 +70,9 @@ func NewTenantSubdomainMiddleware(baseDomain string, logger *slog.Logger) *Tenan
 
 // Handler wraps an http.Handler, enforcing that the subdomain tenant matches
 // the JWT tenant claim. If baseDomain is not configured, validation is skipped.
-func (m *TenantSubdomainMiddleware) Handler(validator ClaimsBearerValidator, meta Metadata, next http.Handler) http.Handler {
+// fallbackBaseURL is used when the request Host cannot be determined, to build
+// dynamic 401 metadata responses.
+func (m *TenantSubdomainMiddleware) Handler(validator ClaimsBearerValidator, fallbackBaseURL string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// If no base domain configured, skip subdomain validation (dev mode)
 		if m.baseDomain == "" {
@@ -92,7 +94,7 @@ func (m *TenantSubdomainMiddleware) Handler(validator ClaimsBearerValidator, met
 		token, err := extractBearerFromHeader(r)
 		if err != nil {
 			m.logger.Debug("subdomain validation: no bearer token", "host", r.Host)
-			writeSubdomainError(w, meta)
+			writeSubdomainError(w, r, fallbackBaseURL)
 			return
 		}
 
@@ -100,7 +102,7 @@ func (m *TenantSubdomainMiddleware) Handler(validator ClaimsBearerValidator, met
 		if err != nil {
 			m.logger.Debug("subdomain validation: token validation failed",
 				"error", err, "host", r.Host)
-			writeSubdomainError(w, meta)
+			writeSubdomainError(w, r, fallbackBaseURL)
 			return
 		}
 
@@ -156,8 +158,13 @@ func extractSubdomain(hostHeader, baseDomain string) string {
 	return slug
 }
 
-// writeSubdomainError writes a 401 with auth metadata for subdomain validation failures.
-func writeSubdomainError(w http.ResponseWriter, meta Metadata) {
+// writeSubdomainError writes a 401 with auth metadata derived from the request.
+func writeSubdomainError(w http.ResponseWriter, r *http.Request, fallbackBaseURL string) {
+	base := baseURLFromRequest(r, fallbackBaseURL)
+	meta := Metadata{
+		AuthorizationURL: base + "/oauth/authorize",
+		TokenURL:         base + "/oauth/token",
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("WWW-Authenticate", `Bearer realm="meridian-mcp"`)
 	w.WriteHeader(http.StatusUnauthorized)

--- a/services/mcp-server/internal/auth/subdomain_test.go
+++ b/services/mcp-server/internal/auth/subdomain_test.go
@@ -123,10 +123,7 @@ func TestIsBaseDomainAccess(t *testing.T) {
 
 func TestTenantSubdomainMiddleware(t *testing.T) {
 	logger := slog.Default()
-	meta := Metadata{
-		AuthorizationURL: "http://localhost/oauth/authorize",
-		TokenURL:         "http://localhost/oauth/token",
-	}
+	fallbackBaseURL := "http://localhost"
 
 	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -136,7 +133,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 		mw := NewTenantSubdomainMiddleware("", logger)
 		validator := &mockClaimsValidator{tenantID: "acme"}
 
-		handler := mw.Handler(validator, meta, okHandler)
+		handler := mw.Handler(validator, fallbackBaseURL, okHandler)
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "acme.demo.meridianhub.cloud"
 		rec := httptest.NewRecorder()
@@ -152,7 +149,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 		mw := NewTenantSubdomainMiddleware("demo.meridianhub.cloud", logger)
 		validator := &mockClaimsValidator{tenantID: "acme"}
 
-		handler := mw.Handler(validator, meta, okHandler)
+		handler := mw.Handler(validator, fallbackBaseURL, okHandler)
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "demo.meridianhub.cloud"
 		rec := httptest.NewRecorder()
@@ -168,7 +165,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 		mw := NewTenantSubdomainMiddleware("demo.meridianhub.cloud", logger)
 		validator := &mockClaimsValidator{tenantID: "volterra-energy"}
 
-		handler := mw.Handler(validator, meta, okHandler)
+		handler := mw.Handler(validator, fallbackBaseURL, okHandler)
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "volterra-energy.demo.meridianhub.cloud"
 		req.Header.Set("Authorization", "Bearer valid-token")
@@ -185,7 +182,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 		mw := NewTenantSubdomainMiddleware("demo.meridianhub.cloud", logger)
 		validator := &mockClaimsValidator{tenantID: "other-tenant"}
 
-		handler := mw.Handler(validator, meta, okHandler)
+		handler := mw.Handler(validator, fallbackBaseURL, okHandler)
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "volterra-energy.demo.meridianhub.cloud"
 		req.Header.Set("Authorization", "Bearer valid-token")
@@ -202,7 +199,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 		mw := NewTenantSubdomainMiddleware("demo.meridianhub.cloud", logger)
 		validator := &mockClaimsValidator{tenantID: "acme"}
 
-		handler := mw.Handler(validator, meta, okHandler)
+		handler := mw.Handler(validator, fallbackBaseURL, okHandler)
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "acme.demo.meridianhub.cloud"
 		// No Authorization header
@@ -219,7 +216,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 		mw := NewTenantSubdomainMiddleware("demo.meridianhub.cloud", logger)
 		validator := &mockClaimsValidator{err: ErrInvalidBearerToken}
 
-		handler := mw.Handler(validator, meta, okHandler)
+		handler := mw.Handler(validator, fallbackBaseURL, okHandler)
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "acme.demo.meridianhub.cloud"
 		req.Header.Set("Authorization", "Bearer bad-token")
@@ -242,7 +239,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := mw.Handler(validator, meta, captureHandler)
+		handler := mw.Handler(validator, fallbackBaseURL, captureHandler)
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "demo.meridianhub.cloud"
 		rec := httptest.NewRecorder()
@@ -267,7 +264,7 @@ func TestTenantSubdomainMiddleware(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		handler := mw.Handler(validator, meta, captureHandler)
+		handler := mw.Handler(validator, fallbackBaseURL, captureHandler)
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/mcp", nil)
 		req.Host = "acme.demo.meridianhub.cloud"
 		req.Header.Set("Authorization", "Bearer valid-token")


### PR DESCRIPTION
## Summary

- OAuth metadata (RFC 8414) and 401 auth-required responses were pre-serialized at startup using `MCP_BASE_URL` (bare platform domain). MCP clients connecting via tenant subdomains received metadata pointing to the wrong origin, causing OAuth to fail with "tenant identification required".
- `NewMetadataHandler`, `BearerMiddleware`, and `TenantSubdomainMiddleware` now derive URLs at runtime from the request's `Host` and `X-Forwarded-Proto` headers, falling back to the configured base URL when absent.
- Enables multi-tenant MCP OAuth — each tenant subdomain gets correctly scoped authorization and token endpoints.

## Test plan

- [x] Existing MCP auth tests updated and passing
- [x] New tests: `TestMetadataHandler_DerivesTenantScopedURLs` verifies tenant subdomain produces scoped URLs
- [x] New tests: `TestMetadataHandler_UsesFallbackWhenNoHost` verifies fallback behavior
- [x] New tests: `TestBearerMiddleware_RejectsUnauthenticated_TenantScoped` verifies 401 returns tenant-scoped URLs
- [ ] Deploy to demo and verify Claude Code MCP authentication works via `volterra-energy.demo.meridianhub.cloud/mcp`