### PR TITLE
feat: Expose DiffManifestVersions RPC for manifest version comparison

### DIFF
--- a/api/proto/meridian/control_plane/v1/manifest_history_service.proto
+++ b/api/proto/meridian/control_plane/v1/manifest_history_service.proto
@@ -38,6 +38,15 @@ service ManifestHistoryService {
       get: "/v1/manifests/versions"
     };
   }
+
+  // DiffManifestVersions compares two manifest versions by sequence number and
+  // returns a structured diff with per-resource actions and summary statistics.
+  // This is a read-only operation.
+  rpc DiffManifestVersions(DiffManifestVersionsRequest) returns (DiffManifestVersionsResponse) {
+    option (google.api.http) = {
+      get: "/v1/manifests/diff"
+    };
+  }
 }
 
 // ========================================
@@ -155,4 +164,68 @@ message ManifestVersion {
 
   // resource_path is the file path or URL of the manifest source.
   optional string resource_path = 14;
+}
+
+// DiffManifestVersionsRequest compares two manifest versions by sequence number.
+message DiffManifestVersionsRequest {
+  // base_sequence_number is the base version to compare from.
+  // If 0 or omitted, defaults to the version immediately before target.
+  int64 base_sequence_number = 1;
+
+  // target_sequence_number is the target version to compare to (required, must be > 0).
+  int64 target_sequence_number = 2 [(buf.validate.field).int64.gt = 0];
+}
+
+// DiffManifestVersionsResponse contains the structured diff between two manifest versions.
+message DiffManifestVersionsResponse {
+  // base_sequence_number is the sequence number used as the base for comparison.
+  int64 base_sequence_number = 1;
+
+  // target_sequence_number is the sequence number used as the target for comparison.
+  int64 target_sequence_number = 2;
+
+  // actions is the list of per-resource diff actions.
+  repeated DiffAction actions = 3;
+
+  // summary contains aggregate statistics about the diff.
+  DiffSummary summary = 4;
+}
+
+// DiffAction represents a single resource-level change between two manifest versions.
+message DiffAction {
+  // resource_type is the category of the resource (e.g., "instrument", "account_type", "saga").
+  string resource_type = 1;
+
+  // action is the type of change: "CREATE", "UPDATE", "DELETE", or "NO_CHANGE".
+  string action = 2;
+
+  // resource_code is the unique identifier of the resource within its type.
+  string resource_code = 3;
+
+  // description is a human-readable summary of the change.
+  string description = 4;
+
+  // breaking indicates whether this change is a breaking change (e.g., a deletion).
+  bool breaking = 5;
+}
+
+// DiffSummary contains aggregate counts of actions in a manifest diff.
+message DiffSummary {
+  // total_actions is the total number of resource-level actions.
+  int32 total_actions = 1;
+
+  // creates is the number of new resources.
+  int32 creates = 2;
+
+  // updates is the number of modified resources.
+  int32 updates = 3;
+
+  // deletes is the number of removed resources.
+  int32 deletes = 4;
+
+  // no_changes is the number of unchanged resources.
+  int32 no_changes = 5;
+
+  // has_breaking_changes indicates whether any action is a breaking change.
+  bool has_breaking_changes = 6;
 }

--- a/services/control-plane/internal/manifest/grpc_handler.go
+++ b/services/control-plane/internal/manifest/grpc_handler.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/control-plane/internal/differ"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -113,4 +114,73 @@ func (h *HistoryHandler) ListManifestVersions(
 		Versions:   versions,
 		TotalCount: int32(totalCount),
 	}, nil
+}
+
+// DiffManifestVersions compares two manifest versions by sequence number and
+// returns a structured diff with per-resource actions and summary statistics.
+func (h *HistoryHandler) DiffManifestVersions(
+	ctx context.Context,
+	req *controlplanev1.DiffManifestVersionsRequest,
+) (*controlplanev1.DiffManifestVersionsResponse, error) {
+	if req.GetTargetSequenceNumber() <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "target_sequence_number must be greater than 0")
+	}
+
+	plan, baseSeq, targetSeq, err := h.history.DiffVersionsBySequence(
+		ctx, req.GetBaseSequenceNumber(), req.GetTargetSequenceNumber(),
+	)
+	if err != nil {
+		if errors.Is(err, ErrVersionNotFound) {
+			return nil, status.Error(codes.NotFound, "manifest version not found")
+		}
+		h.logger.Error("failed to diff manifest versions",
+			"base_seq", req.GetBaseSequenceNumber(),
+			"target_seq", req.GetTargetSequenceNumber(),
+			"error", err,
+		)
+		return nil, status.Error(codes.Internal, "failed to diff manifest versions")
+	}
+
+	return &controlplanev1.DiffManifestVersionsResponse{
+		BaseSequenceNumber:   baseSeq,
+		TargetSequenceNumber: targetSeq,
+		Actions:              diffPlanToProtoActions(plan),
+		Summary:              diffPlanToProtoSummary(plan),
+	}, nil
+}
+
+// diffPlanToProtoActions converts differ.DiffPlan actions to proto DiffAction messages.
+func diffPlanToProtoActions(plan *differ.DiffPlan) []*controlplanev1.DiffAction {
+	actions := make([]*controlplanev1.DiffAction, 0, len(plan.Actions))
+	for _, a := range plan.Actions {
+		actions = append(actions, &controlplanev1.DiffAction{
+			ResourceType: string(a.ResourceType),
+			Action:       string(a.Action),
+			ResourceCode: a.ResourceCode,
+			Description:  a.Description,
+			Breaking:     a.Breaking,
+		})
+	}
+	return actions
+}
+
+// diffPlanToProtoSummary converts a differ.DiffPlan to a proto DiffSummary.
+func diffPlanToProtoSummary(plan *differ.DiffPlan) *controlplanev1.DiffSummary {
+	summary := &controlplanev1.DiffSummary{
+		TotalActions:       int32(len(plan.Actions)),
+		HasBreakingChanges: plan.HasBreakingChanges,
+	}
+	for _, a := range plan.Actions {
+		switch a.Action {
+		case differ.ActionCreate:
+			summary.Creates++
+		case differ.ActionUpdate:
+			summary.Updates++
+		case differ.ActionDelete:
+			summary.Deletes++
+		case differ.ActionNoChange:
+			summary.NoChanges++
+		}
+	}
+	return summary
 }

--- a/services/control-plane/internal/manifest/grpc_handler_test.go
+++ b/services/control-plane/internal/manifest/grpc_handler_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/control-plane/internal/differ"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -80,4 +81,88 @@ func TestGetManifestVersion_EmptyVersionReturnsInvalidArgument(t *testing.T) {
 func TestNewHistoryHandler_ErrorSentinel(t *testing.T) {
 	_, err := NewHistoryHandler(nil, nil)
 	assert.ErrorIs(t, err, ErrHistoryServiceRequired)
+}
+
+func TestDiffManifestVersions_InvalidTargetSequenceNumber(t *testing.T) {
+	repo := &Repository{}
+	svc, err := NewHistoryService(repo)
+	require.NoError(t, err)
+	handler, err := NewHistoryHandler(svc, nil)
+	require.NoError(t, err)
+
+	_, err = handler.DiffManifestVersions(context.Background(), &controlplanev1.DiffManifestVersionsRequest{
+		TargetSequenceNumber: 0,
+	})
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "target_sequence_number")
+}
+
+func TestDiffPlanToProtoActions(t *testing.T) {
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{
+				ResourceType: differ.ResourceInstrument,
+				ResourceCode: "GBP",
+				Action:       differ.ActionCreate,
+				Description:  "Create instrument GBP",
+				Breaking:     false,
+			},
+			{
+				ResourceType: differ.ResourceSaga,
+				ResourceCode: "settle",
+				Action:       differ.ActionDelete,
+				Description:  "Delete saga settle",
+				Breaking:     true,
+			},
+		},
+	}
+
+	actions := diffPlanToProtoActions(plan)
+	require.Len(t, actions, 2)
+
+	assert.Equal(t, "instrument", actions[0].ResourceType)
+	assert.Equal(t, "CREATE", actions[0].Action)
+	assert.Equal(t, "GBP", actions[0].ResourceCode)
+	assert.Equal(t, "Create instrument GBP", actions[0].Description)
+	assert.False(t, actions[0].Breaking)
+
+	assert.Equal(t, "saga", actions[1].ResourceType)
+	assert.Equal(t, "DELETE", actions[1].Action)
+	assert.Equal(t, "settle", actions[1].ResourceCode)
+	assert.True(t, actions[1].Breaking)
+}
+
+func TestDiffPlanToProtoSummary(t *testing.T) {
+	plan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{Action: differ.ActionCreate},
+			{Action: differ.ActionCreate},
+			{Action: differ.ActionUpdate},
+			{Action: differ.ActionDelete},
+			{Action: differ.ActionNoChange},
+			{Action: differ.ActionNoChange},
+			{Action: differ.ActionNoChange},
+		},
+		HasBreakingChanges: true,
+	}
+
+	summary := diffPlanToProtoSummary(plan)
+	assert.Equal(t, int32(7), summary.TotalActions)
+	assert.Equal(t, int32(2), summary.Creates)
+	assert.Equal(t, int32(1), summary.Updates)
+	assert.Equal(t, int32(1), summary.Deletes)
+	assert.Equal(t, int32(3), summary.NoChanges)
+	assert.True(t, summary.HasBreakingChanges)
+}
+
+func TestDiffPlanToProtoSummary_Empty(t *testing.T) {
+	plan := &differ.DiffPlan{}
+
+	summary := diffPlanToProtoSummary(plan)
+	assert.Equal(t, int32(0), summary.TotalActions)
+	assert.Equal(t, int32(0), summary.Creates)
+	assert.False(t, summary.HasBreakingChanges)
 }

--- a/services/control-plane/internal/manifest/history.go
+++ b/services/control-plane/internal/manifest/history.go
@@ -181,6 +181,49 @@ func (s *HistoryService) CompareVersions(ctx context.Context, v1, v2 string) (st
 	return s.diffManifests(ctx, manifest1, manifest2)
 }
 
+// DiffVersionsBySequence computes a structured diff between two manifest versions
+// identified by sequence number. If baseSeq is 0, defaults to targetSeq-1.
+func (s *HistoryService) DiffVersionsBySequence(ctx context.Context, baseSeq, targetSeq int64) (*differ.DiffPlan, int64, int64, error) {
+	if baseSeq == 0 {
+		if targetSeq <= 1 {
+			// Target is the first version; diff against empty manifest.
+			baseSeq = 0
+		} else {
+			baseSeq = targetSeq - 1
+		}
+	}
+
+	// Load target version.
+	targetEntity, err := s.repo.GetBySequenceNumber(ctx, targetSeq)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("target sequence %d: %w", targetSeq, err)
+	}
+	targetManifest, err := unmarshalManifest(targetEntity.ManifestJSON)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("failed to unmarshal target sequence %d: %w", targetSeq, err)
+	}
+
+	// Load base version (nil manifest if baseSeq is 0).
+	var baseManifest *controlplanev1.Manifest
+	if baseSeq > 0 {
+		baseEntity, err := s.repo.GetBySequenceNumber(ctx, baseSeq)
+		if err != nil {
+			return nil, 0, 0, fmt.Errorf("base sequence %d: %w", baseSeq, err)
+		}
+		baseManifest, err = unmarshalManifest(baseEntity.ManifestJSON)
+		if err != nil {
+			return nil, 0, 0, fmt.Errorf("failed to unmarshal base sequence %d: %w", baseSeq, err)
+		}
+	}
+
+	plan, err := s.differ.Diff(ctx, baseManifest, targetManifest, differ.WithSkipSafetyChecks())
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("diff failed: %w", err)
+	}
+
+	return plan, baseSeq, targetSeq, nil
+}
+
 // RollbackToVersion creates a new manifest version with the content from a previous version.
 // This maintains the forward-only audit trail: rollback from v1.2 to v1.1 creates
 // a new record with v1.1's content, not an in-place revert.

--- a/services/control-plane/internal/manifest/repository.go
+++ b/services/control-plane/internal/manifest/repository.go
@@ -206,6 +206,33 @@ func (r *Repository) List(ctx context.Context, limit, offset int) ([]VersionEnti
 	return entities, int(totalCount), nil
 }
 
+// GetBySequenceNumber retrieves a manifest version by its sequence number.
+func (r *Repository) GetBySequenceNumber(ctx context.Context, seq int64) (*VersionEntity, error) {
+	var entity VersionEntity
+	var found bool
+
+	err := db.WithGormTenantTransaction(ctx, r.db, func(tx *gorm.DB) error {
+		result := tx.Where("sequence_number = ?", seq).First(&entity)
+
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			found = false
+			return nil
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+		found = true
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, ErrVersionNotFound
+	}
+	return &entity, nil
+}
+
 // GetPreviousApplied retrieves the applied manifest version immediately before the given timestamp.
 func (r *Repository) GetPreviousApplied(ctx context.Context, beforeTime time.Time) (*VersionEntity, error) {
 	var entity VersionEntity


### PR DESCRIPTION
## Summary

- Add `DiffManifestVersions` RPC to `ManifestHistoryService` that compares two manifest versions by sequence number and returns structured per-resource diff actions with summary statistics
- Add `GetBySequenceNumber` repository method and `DiffVersionsBySequence` service method that delegates to the existing `ManifestDiffer` engine
- Read-only operation: no data is persisted

## Changes

| File | Change |
|------|--------|
| `manifest_history_service.proto` | New RPC + request/response/DiffAction/DiffSummary messages |
| `repository.go` | `GetBySequenceNumber` method |
| `history.go` | `DiffVersionsBySequence` method |
| `grpc_handler.go` | `DiffManifestVersions` handler + conversion helpers |
| `grpc_handler_test.go` | Unit tests for validation, action/summary conversion |

## Task Master

Tag: 045-manifest-source-of-truth, Task: 7

## Test plan

- [x] Handler rejects target_sequence_number <= 0 with InvalidArgument
- [x] DiffPlan actions correctly convert to proto DiffAction messages
- [x] DiffSummary aggregates counts correctly (creates, updates, deletes, no_changes)
- [x] Empty DiffPlan produces zero-valued summary
- [x] All pre-commit checks pass (lint, gofumpt, buf lint, no breaking proto changes)