### PR TITLE
feat: Add InternalAccount resource type to manifest pipeline

### DIFF
--- a/api/jsonschema/manifest.v1.schema.json
+++ b/api/jsonschema/manifest.v1.schema.json
@@ -16,7 +16,8 @@
                 "mappings",
                 "operationalGateway",
                 "marketData",
-                "organizations"
+                "organizations",
+                "internalAccounts"
             ],
             "properties": {
                 "version": {
@@ -106,6 +107,14 @@
                     "additionalProperties": false,
                     "type": "array",
                     "description": "organizations defines the organization entities (parties) for this tenant."
+                },
+                "internalAccounts": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.control_plane.v1.InternalAccountDefinition"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "internal_accounts defines the chart of accounts — structural accounts owned by the economy. Each internal account references an account type, an instrument, and optionally an owner organization."
                 }
             },
             "additionalProperties": false,
@@ -486,6 +495,41 @@
             "type": "object",
             "title": "Instrument Dimensions",
             "description": "InstrumentDimensions describes the unit and precision of an instrument's quantities."
+        },
+        "meridian.control_plane.v1.InternalAccountDefinition": {
+            "required": [
+                "code",
+                "accountType",
+                "instrument",
+                "ownerOrganization",
+                "description"
+            ],
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": "code is the unique identifier for this internal account (e.g., \"REVENUE_GBP\", \"SETTLEMENT_KWH\"). Must be uppercase alphanumeric with underscores."
+                },
+                "accountType": {
+                    "type": "string",
+                    "description": "account_type references the account type classification for this account. Must match a code from the manifest's account_types list."
+                },
+                "instrument": {
+                    "type": "string",
+                    "description": "instrument references the instrument (asset type) this account holds. Must match a code from the manifest's instruments list."
+                },
+                "ownerOrganization": {
+                    "type": "string",
+                    "description": "owner_organization optionally references the organization that owns this account. If set, must match a code from the manifest's organizations list."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "description provides additional context about this internal account's purpose."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "========================================\n Internal Account Definitions\n ========================================",
+            "description": "======================================== Internal Account Definitions ========================================  InternalAccountDefinition declares a structural account in the chart of accounts. Internal accounts are owned by the economy (not by external parties) and are provisioned via the Internal Account Service. The code field is the immutable primary key."
         },
         "meridian.control_plane.v1.MTLSAuthConfig": {
             "required": [

--- a/api/proto/meridian/control_plane/v1/manifest.proto
+++ b/api/proto/meridian/control_plane/v1/manifest.proto
@@ -70,6 +70,11 @@ message Manifest {
 
   // organizations defines the organization entities (parties) for this tenant.
   repeated OrganizationDefinition organizations = 13;
+
+  // internal_accounts defines the chart of accounts — structural accounts
+  // owned by the economy. Each internal account references an account type,
+  // an instrument, and optionally an owner organization.
+  repeated InternalAccountDefinition internal_accounts = 14;
 }
 
 // ========================================
@@ -888,4 +893,47 @@ message OrganizationDefinition {
   // attributes contains additional metadata for this organization as key-value pairs.
   // Keys and values are validated against the party type's attribute_schema if defined.
   map<string, string> attributes = 4;
+}
+
+// ========================================
+// Internal Account Definitions
+// ========================================
+
+// InternalAccountDefinition declares a structural account in the chart of accounts.
+// Internal accounts are owned by the economy (not by external parties) and are
+// provisioned via the Internal Account Service. The code field is the immutable primary key.
+message InternalAccountDefinition {
+  // code is the unique identifier for this internal account (e.g., "REVENUE_GBP", "SETTLEMENT_KWH").
+  // Must be uppercase alphanumeric with underscores.
+  string code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // account_type references the account type classification for this account.
+  // Must match a code from the manifest's account_types list.
+  string account_type = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
+    pattern: "^[A-Z0-9_]{1,50}$"
+  }];
+
+  // instrument references the instrument (asset type) this account holds.
+  // Must match a code from the manifest's instruments list.
+  string instrument = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
+    pattern: "^[A-Z0-9_]{1,50}$"
+  }];
+
+  // owner_organization optionally references the organization that owns this account.
+  // If set, must match a code from the manifest's organizations list.
+  string owner_organization = 4 [(buf.validate.field).string = {
+    max_len: 64
+    pattern: "^$|^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // description provides additional context about this internal account's purpose.
+  string description = 5 [(buf.validate.field).string.max_len = 1024];
 }

--- a/services/control-plane/internal/differ/manifest_differ.go
+++ b/services/control-plane/internal/differ/manifest_differ.go
@@ -81,6 +81,7 @@ func (d *ManifestDiffer) Diff(ctx context.Context, lastApplied, newManifest *con
 	d.diffMarketDataSources(lastApplied, newManifest, plan)
 	d.diffMarketDataSets(lastApplied, newManifest, plan)
 	d.diffOrganizations(lastApplied, newManifest, plan)
+	d.diffInternalAccounts(lastApplied, newManifest, plan)
 
 	// Run safety checks on all DELETE actions (skip when validating for a new tenant)
 	if !cfg.skipSafetyChecks {
@@ -361,7 +362,8 @@ func (d *ManifestDiffer) runSafetyChecks(ctx context.Context, plan *DiffPlan) er
 			ResourceInstructionRoute,
 			ResourceMarketDataSource,
 			ResourceMarketDataSet,
-			ResourceOrganization:
+			ResourceOrganization,
+			ResourceInternalAccount:
 			// No downstream dependency checks for these resource types.
 		}
 		if err != nil {
@@ -643,6 +645,50 @@ func (d *ManifestDiffer) diffOrganizations(lastApplied, newManifest *controlplan
 	}
 }
 
+func (d *ManifestDiffer) diffInternalAccounts(lastApplied, newManifest *controlplanev1.Manifest, plan *DiffPlan) {
+	oldMap := internalAccountMap(getInternalAccounts(lastApplied))
+	newMap := internalAccountMap(newManifest.GetInternalAccounts())
+
+	for code, updated := range newMap {
+		prev, exists := oldMap[code]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInternalAccount,
+				ResourceCode: code,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create internal account %s (type: %s, instrument: %s)", code, updated.GetAccountType(), updated.GetInstrument()),
+			})
+			continue
+		}
+		if !proto.Equal(prev, updated) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInternalAccount,
+				ResourceCode: code,
+				Action:       ActionUpdate,
+				Description:  describeInternalAccountChanges(code, prev, updated),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInternalAccount,
+				ResourceCode: code,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Internal account %s unchanged", code),
+			})
+		}
+	}
+
+	for code := range oldMap {
+		if _, exists := newMap[code]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInternalAccount,
+				ResourceCode: code,
+				Action:       ActionDelete,
+				Description:  fmt.Sprintf("Delete internal account %s", code),
+			})
+		}
+	}
+}
+
 // Helper functions to safely extract slices from possibly-nil manifests.
 
 func getInstruments(m *controlplanev1.Manifest) []*controlplanev1.InstrumentDefinition {
@@ -823,6 +869,21 @@ func organizationMap(orgs []*controlplanev1.OrganizationDefinition) map[string]*
 	return m
 }
 
+func getInternalAccounts(m *controlplanev1.Manifest) []*controlplanev1.InternalAccountDefinition {
+	if m == nil {
+		return nil
+	}
+	return m.GetInternalAccounts()
+}
+
+func internalAccountMap(accounts []*controlplanev1.InternalAccountDefinition) map[string]*controlplanev1.InternalAccountDefinition {
+	m := make(map[string]*controlplanev1.InternalAccountDefinition, len(accounts))
+	for _, a := range accounts {
+		m[a.GetCode()] = a
+	}
+	return m
+}
+
 // Change description helpers.
 
 func describeInstrumentChanges(code string, prev, updated *controlplanev1.InstrumentDefinition) string {
@@ -965,6 +1026,26 @@ func describeOrganizationChanges(code string, prev, updated *controlplanev1.Orga
 		return fmt.Sprintf("Update organization %s", code)
 	}
 	return fmt.Sprintf("Update organization %s (%s)", code, strings.Join(changes, "; "))
+}
+
+func describeInternalAccountChanges(code string, prev, updated *controlplanev1.InternalAccountDefinition) string {
+	var changes []string
+	if prev.GetAccountType() != updated.GetAccountType() {
+		changes = append(changes, fmt.Sprintf("account_type: %q -> %q", prev.GetAccountType(), updated.GetAccountType()))
+	}
+	if prev.GetInstrument() != updated.GetInstrument() {
+		changes = append(changes, fmt.Sprintf("instrument: %q -> %q", prev.GetInstrument(), updated.GetInstrument()))
+	}
+	if prev.GetOwnerOrganization() != updated.GetOwnerOrganization() {
+		changes = append(changes, fmt.Sprintf("owner_organization: %q -> %q", prev.GetOwnerOrganization(), updated.GetOwnerOrganization()))
+	}
+	if prev.GetDescription() != updated.GetDescription() {
+		changes = append(changes, "description changed")
+	}
+	if len(changes) == 0 {
+		return fmt.Sprintf("Update internal account %s", code)
+	}
+	return fmt.Sprintf("Update internal account %s (%s)", code, strings.Join(changes, "; "))
 }
 
 // attributesEqual compares two string-keyed maps for equality.

--- a/services/control-plane/internal/differ/manifest_differ_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_test.go
@@ -1222,3 +1222,78 @@ func TestDiff_OrganizationUnchanged_NoChange(t *testing.T) {
 	assert.Len(t, noChanges, 1)
 	assert.Equal(t, "ACME_ENERGY", noChanges[0].ResourceCode)
 }
+
+// --- Internal Account differ tests ---
+
+func TestDiff_InternalAccountAdded_Create(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
+		{Code: "REVENUE_GBP", AccountType: "REVENUE", Instrument: "GBP"},
+	}
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceInternalAccount)
+	assert.Len(t, creates, 1)
+	assert.Equal(t, "REVENUE_GBP", creates[0].ResourceCode)
+	assert.Contains(t, creates[0].Description, "REVENUE")
+	assert.Contains(t, creates[0].Description, "GBP")
+}
+
+func TestDiff_InternalAccountRemoved_Delete(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+	oldManifest.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
+		{Code: "SETTLEMENT_KWH", AccountType: "SETTLEMENT", Instrument: "KWH"},
+	}
+
+	newManifest := testManifest()
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourceInternalAccount)
+	assert.Len(t, deletes, 1)
+	assert.Equal(t, "SETTLEMENT_KWH", deletes[0].ResourceCode)
+}
+
+func TestDiff_InternalAccountModified_Update(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+	oldManifest.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
+		{Code: "REVENUE_GBP", AccountType: "REVENUE", Instrument: "GBP"},
+	}
+
+	newManifest := testManifest()
+	newManifest.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
+		{Code: "REVENUE_GBP", AccountType: "CURRENT", Instrument: "GBP", OwnerOrganization: "ACME"},
+	}
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceInternalAccount)
+	assert.Len(t, updates, 1)
+	assert.Equal(t, "REVENUE_GBP", updates[0].ResourceCode)
+	assert.Contains(t, updates[0].Description, "account_type:")
+	assert.Contains(t, updates[0].Description, "owner_organization:")
+}
+
+func TestDiff_InternalAccountUnchanged_NoChange(t *testing.T) {
+	d := New(nil, nil)
+	manifest := testManifest()
+	manifest.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
+		{Code: "REVENUE_GBP", AccountType: "REVENUE", Instrument: "GBP"},
+	}
+
+	plan, err := d.Diff(context.Background(), manifest, manifest)
+	require.NoError(t, err)
+
+	noChanges := filterActionsByResource(plan.Actions, ActionNoChange, ResourceInternalAccount)
+	assert.Len(t, noChanges, 1)
+	assert.Equal(t, "REVENUE_GBP", noChanges[0].ResourceCode)
+}

--- a/services/control-plane/internal/differ/types.go
+++ b/services/control-plane/internal/differ/types.go
@@ -39,6 +39,7 @@ const (
 	ResourceMarketDataSource   ResourceType = "market_data_source"
 	ResourceMarketDataSet      ResourceType = "market_data_set"
 	ResourceOrganization       ResourceType = "organization"
+	ResourceInternalAccount    ResourceType = "internal_account"
 )
 
 // PlannedAction represents a single action in the diff plan.

--- a/services/control-plane/internal/planner/manifest_planner.go
+++ b/services/control-plane/internal/planner/manifest_planner.go
@@ -121,6 +121,8 @@ func phaseForResource(rt differ.ResourceType) Phase {
 		return PhaseMarketDataSets
 	case differ.ResourceOrganization:
 		return PhaseOrganizations
+	case differ.ResourceInternalAccount:
+		return PhaseInternalAccounts
 	default:
 		return PhaseSeedData
 	}
@@ -208,6 +210,11 @@ var grpcMethodMap = map[methodKey]GRPCMethod{
 	{differ.ResourceOrganization, differ.ActionCreate}: MethodRegisterOrganization,
 	{differ.ResourceOrganization, differ.ActionUpdate}: MethodRegisterOrganization,
 	// No delete method: organizations are deactivated, not deleted.
+
+	// Internal Accounts
+	{differ.ResourceInternalAccount, differ.ActionCreate}: MethodInitiateAccount,
+	{differ.ResourceInternalAccount, differ.ActionUpdate}: MethodUpdateInternalAccount,
+	{differ.ResourceInternalAccount, differ.ActionDelete}: MethodControlInternalAccount,
 }
 
 // GenerateIdempotencyKey produces a deterministic SHA-256 based idempotency key.

--- a/services/control-plane/internal/planner/manifest_planner_test.go
+++ b/services/control-plane/internal/planner/manifest_planner_test.go
@@ -754,6 +754,74 @@ func TestPlan_PhaseOrdering_MarketDataBeforeOrganizations(t *testing.T) {
 	assert.Equal(t, PhaseOrganizations, plan.Calls[2].Phase)
 }
 
+// --- Internal Account planner tests ---
+
+func TestPlan_InternalAccountsInPhase12(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInternalAccount, ResourceCode: "REVENUE_GBP", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+
+	assert.Equal(t, PhaseInternalAccounts, plan.Calls[0].Phase)
+	assert.Equal(t, MethodInitiateAccount, plan.Calls[0].GRPCMethod)
+}
+
+func TestPlan_InternalAccountUpdate(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInternalAccount, ResourceCode: "REVENUE_GBP", Action: differ.ActionUpdate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+
+	assert.Equal(t, MethodUpdateInternalAccount, plan.Calls[0].GRPCMethod)
+}
+
+func TestPlan_InternalAccountDelete(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInternalAccount, ResourceCode: "REVENUE_GBP", Action: differ.ActionDelete},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+
+	assert.Equal(t, MethodControlInternalAccount, plan.Calls[0].GRPCMethod)
+}
+
+func TestPlan_PhaseOrdering_InternalAccountsAfterOrganizations(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInternalAccount, ResourceCode: "ACCT", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceOrganization, ResourceCode: "ORG", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "AT", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 3)
+
+	// Verify phase ordering: account types (2) < organizations (11) < internal accounts (12)
+	assert.Equal(t, PhaseAccountTypes, plan.Calls[0].Phase)
+	assert.Equal(t, PhaseOrganizations, plan.Calls[1].Phase)
+	assert.Equal(t, PhaseInternalAccounts, plan.Calls[2].Phase)
+}
+
 // --- Test helpers ---
 
 func indexCallsByResourceID(calls []PlannedCall) map[string]PlannedCall {

--- a/services/control-plane/internal/planner/types.go
+++ b/services/control-plane/internal/planner/types.go
@@ -53,6 +53,10 @@ const (
 	// PhaseOrganizations registers organization entities with the Party service
 	// (depends on party types being registered first).
 	PhaseOrganizations Phase = 11
+
+	// PhaseInternalAccounts provisions internal accounts via the Internal Account service
+	// (depends on account types, instruments, and organizations being registered first).
+	PhaseInternalAccounts Phase = 12
 )
 
 // PhaseLabel returns a human-readable label for a phase.
@@ -80,6 +84,8 @@ func PhaseLabel(p Phase) string {
 		return "Market Data Sets"
 	case PhaseOrganizations:
 		return "Organizations"
+	case PhaseInternalAccounts:
+		return "Internal Accounts"
 	default:
 		return fmt.Sprintf("Phase(%d)", p)
 	}
@@ -102,7 +108,9 @@ const (
 	MethodDeprecateAccountType        GRPCMethod = "meridian.reference_data.v1.AccountTypeRegistryService/DeprecateAccountType"
 
 	// Internal Account Service
-	MethodInitiateAccount GRPCMethod = "meridian.internal_account.v1.InternalAccountService/InitiateInternalAccount"
+	MethodInitiateAccount        GRPCMethod = "meridian.internal_account.v1.InternalAccountService/InitiateInternalAccount"
+	MethodUpdateInternalAccount  GRPCMethod = "meridian.internal_account.v1.InternalAccountService/UpdateInternalAccount"
+	MethodControlInternalAccount GRPCMethod = "meridian.internal_account.v1.InternalAccountService/ControlInternalAccount"
 
 	// Saga Registry Service
 	MethodCreateSagaDraft      GRPCMethod = "meridian.saga.v1.SagaRegistryService/CreateSagaDraft"
@@ -236,7 +244,7 @@ func (p *ExecutionPlan) Visualize() string {
 	fmt.Fprintf(&b, "Total calls: %d\n\n", len(p.Calls))
 
 	byPhase := p.ByPhase()
-	for phase := PhaseInstruments; phase <= PhaseOrganizations; phase++ { //nolint:intrange
+	for phase := PhaseInstruments; phase <= PhaseInternalAccounts; phase++ { //nolint:intrange
 		calls, ok := byPhase[phase]
 		if !ok {
 			continue

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -632,6 +632,21 @@ func (v *ManifestValidator) validateMarketDataAndOrgDuplicates(
 			orgCodes[org.GetCode()] = i
 		}
 	}
+
+	// Check duplicate internal account codes
+	iaCodes := make(map[string]int)
+	for i, ia := range manifest.GetInternalAccounts() {
+		if prev, exists := iaCodes[ia.GetCode()]; exists {
+			addError(result, ValidationError{
+				Severity: SeverityError,
+				Path:     fmt.Sprintf("internal_accounts[%d].code", i),
+				Code:     "DUPLICATE_CODE",
+				Message:  fmt.Sprintf("duplicate internal account code %q (first defined at internal_accounts[%d])", ia.GetCode(), prev),
+			})
+		} else {
+			iaCodes[ia.GetCode()] = i
+		}
+	}
 }
 
 // validateOperationalGatewayDuplicates checks for duplicate connection_ids and instruction_types.
@@ -937,6 +952,9 @@ func (v *ManifestValidator) validateCrossReferences(
 
 	// Validate organization party_type references
 	v.validateOrganizationCrossRefs(manifest, result)
+
+	// Validate internal account cross-references
+	v.validateInternalAccountCrossRefs(manifest, result)
 }
 
 // validateOrganizationCrossRefs validates that organizations reference valid party types.
@@ -971,6 +989,63 @@ func (v *ManifestValidator) validateOrganizationCrossRefs(
 			addError(result, ve)
 		}
 	}
+}
+
+// validateInternalAccountCrossRefs validates that internal accounts reference valid
+// account types, instruments, and organizations.
+func (v *ManifestValidator) validateInternalAccountCrossRefs(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	accountTypeCodes := make(map[string]bool)
+	for _, at := range manifest.GetAccountTypes() {
+		accountTypeCodes[at.GetCode()] = true
+	}
+
+	instrumentCodes := make(map[string]bool)
+	for _, inst := range manifest.GetInstruments() {
+		instrumentCodes[inst.GetCode()] = true
+	}
+
+	orgCodes := make(map[string]bool)
+	for _, org := range manifest.GetOrganizations() {
+		orgCodes[org.GetCode()] = true
+	}
+
+	for i, ia := range manifest.GetInternalAccounts() {
+		code := ia.GetCode()
+		checkRef(ia.GetAccountType(), accountTypeCodes,
+			fmt.Sprintf("internal_accounts[%d].account_type", i),
+			fmt.Sprintf("internal account %q references unknown account type", code),
+			result)
+		checkRef(ia.GetInstrument(), instrumentCodes,
+			fmt.Sprintf("internal_accounts[%d].instrument", i),
+			fmt.Sprintf("internal account %q references unknown instrument", code),
+			result)
+		checkRef(ia.GetOwnerOrganization(), orgCodes,
+			fmt.Sprintf("internal_accounts[%d].owner_organization", i),
+			fmt.Sprintf("internal account %q references unknown organization", code),
+			result)
+	}
+}
+
+// checkRef validates that value exists in validCodes. If value is empty, no check is performed.
+func checkRef(value string, validCodes map[string]bool, path, msgPrefix string, result *ValidationResult) {
+	if value == "" || validCodes[value] {
+		return
+	}
+	codeList := mapKeys(validCodes)
+	ve := ValidationError{
+		Severity:        SeverityError,
+		Path:            path,
+		Code:            "INVALID_REFERENCE",
+		Message:         fmt.Sprintf("%s %q", msgPrefix, value),
+		AvailableFields: codeList,
+	}
+	if suggestion := findClosestMatch(value, codeList); suggestion != "" {
+		ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+	}
+	addError(result, ve)
 }
 
 // validateOperationalGatewayCrossRefs validates referential integrity for the operational_gateway section.

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -3178,3 +3178,135 @@ func TestValidate_OrganizationReferencesManifestDefinedPartyType(t *testing.T) {
 		}
 	}
 }
+
+// --- Internal Account validation tests ---
+
+func TestValidate_DuplicateInternalAccountCodes(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
+		{Code: "REVENUE_GBP", AccountType: "SETTLEMENT", Instrument: "GBP"},
+		{Code: "REVENUE_GBP", AccountType: "SETTLEMENT", Instrument: "KWH"},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "DUPLICATE_CODE" && strings.Contains(e.Path, "internal_accounts") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected DUPLICATE_CODE error for internal_accounts")
+}
+
+func TestValidate_InternalAccountReferencesInvalidAccountType(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
+		{Code: "REVENUE_GBP", AccountType: "NONEXISTENT", Instrument: "GBP"},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_REFERENCE" && strings.Contains(e.Path, "internal_accounts[0].account_type") {
+			found = true
+			assert.Contains(t, e.Message, "NONEXISTENT")
+			break
+		}
+	}
+	assert.True(t, found, "expected INVALID_REFERENCE error for invalid account_type")
+}
+
+func TestValidate_InternalAccountReferencesInvalidInstrument(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
+		{Code: "REVENUE_XYZ", AccountType: "SETTLEMENT", Instrument: "XYZ"},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_REFERENCE" && strings.Contains(e.Path, "internal_accounts[0].instrument") {
+			found = true
+			assert.Contains(t, e.Message, "XYZ")
+			break
+		}
+	}
+	assert.True(t, found, "expected INVALID_REFERENCE error for invalid instrument")
+}
+
+func TestValidate_InternalAccountReferencesInvalidOrganization(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
+		{Code: "REVENUE_GBP", AccountType: "SETTLEMENT", Instrument: "GBP", OwnerOrganization: "UNKNOWN_ORG"},
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_REFERENCE" && strings.Contains(e.Path, "internal_accounts[0].owner_organization") {
+			found = true
+			assert.Contains(t, e.Message, "UNKNOWN_ORG")
+			break
+		}
+	}
+	assert.True(t, found, "expected INVALID_REFERENCE error for invalid owner_organization")
+}
+
+func TestValidate_InternalAccountValidReferences(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.Organizations = []*controlplanev1.OrganizationDefinition{
+		{Code: "ACME", Name: "Acme Corp", PartyType: "ORGANIZATION"},
+	}
+	manifest.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
+		{Code: "REVENUE_GBP", AccountType: "SETTLEMENT", Instrument: "GBP", OwnerOrganization: "ACME"},
+		{Code: "REVENUE_KWH", AccountType: "SETTLEMENT", Instrument: "KWH"},
+	}
+
+	result := v.Validate(manifest, nil)
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_REFERENCE" && strings.Contains(e.Path, "internal_accounts") {
+			t.Errorf("unexpected INVALID_REFERENCE error: %s", e.Message)
+		}
+	}
+}
+
+func TestValidate_InternalAccountNoOwnerOrganization(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
+		{Code: "REVENUE_GBP", AccountType: "SETTLEMENT", Instrument: "GBP"},
+	}
+
+	result := v.Validate(manifest, nil)
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_REFERENCE" && strings.Contains(e.Path, "internal_accounts[0].owner_organization") {
+			t.Errorf("unexpected INVALID_REFERENCE error for empty owner_organization: %s", e.Message)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add `InternalAccountDefinition` as a distinct resource type in the manifest pipeline, separate from `AccountType` (which is reference data). Internal accounts represent the chart of accounts -- structural accounts owned by the economy.

### Changes

- **Proto**: Add `InternalAccountDefinition` message to `manifest.proto` with fields: `code`, `account_type`, `instrument`, `owner_organization`, `description`. Add `internal_accounts` repeated field to `Manifest` (field 14).
- **Differ**: Implement `diffInternalAccounts()` following existing patterns with create/update/delete/no-change detection and field-level change descriptions.
- **Planner**: Add `PhaseInternalAccounts` (phase 12) after organizations (phase 11), with gRPC method mappings to `InitiateInternalAccount`, `UpdateInternalAccount`, and `ControlInternalAccount`.
- **Validator**: Add duplicate code detection and cross-reference validation ensuring `account_type` references a valid account type, `instrument` references a valid instrument, and `owner_organization` (if set) references a valid organization.

### Task Master

045-manifest-source-of-truth task 5

## Test plan

- [x] Differ: 4 tests (create, delete, update, no-change)
- [x] Planner: 4 tests (phase assignment, update, delete, phase ordering)
- [x] Validator: 6 tests (duplicate codes, invalid account_type, invalid instrument, invalid organization, valid references, empty owner_organization)
- [x] All existing tests pass (differ, planner, validator)
- [x] Pre-commit hooks pass (gitleaks, buf lint, breaking changes, gofumpt, golangci-lint)