### PR TITLE
feat: Add MarketInformation and Party Starlark handlers

### DIFF
--- a/services/control-plane/internal/applier/handlers.go
+++ b/services/control-plane/internal/applier/handlers.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	internalaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_account/v1"
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
 	opgatewayv1 "github.com/meridianhub/meridian/api/proto/meridian/operational_gateway/v1"
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 )
@@ -13,6 +15,14 @@ import (
 // ErrNoValuationMethodService is returned when default_conversion_method is provided
 // but no ValuationMethodService was configured in HandlerDependencies.
 var ErrNoValuationMethodService = errors.New("no ValuationMethodService configured")
+
+// ErrMarketInformationNotConfigured is returned when a handler requires the market
+// information service but none was configured in HandlerDependencies.
+var ErrMarketInformationNotConfigured = errors.New("market_information service not configured")
+
+// ErrPartyNotConfigured is returned when a handler requires the party service
+// but none was configured in HandlerDependencies.
+var ErrPartyNotConfigured = errors.New("party service not configured")
 
 // RegisterManifestHandlers registers all Starlark service bindings needed by
 // the apply_manifest saga. These handlers adapt Starlark parameters to the
@@ -138,6 +148,58 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:              1,
 			},
 		},
+		// Market Information - Data source registration
+		"market_information.register_data_source": {
+			handler: registerDataSourceHandler(deps),
+			metadata: saga.HandlerMetadata{
+				Category:             saga.HandlerCategorySettlement,
+				Description:          "Register a new market data source",
+				CompensationStrategy: "none",
+				ProducesInstruments:  []string{},
+				ProtoRequestType:     (*marketinformationv1.RegisterDataSourceRequest)(nil),
+				ProtoResponseType:    (*marketinformationv1.RegisterDataSourceResponse)(nil),
+				Version:              1,
+			},
+		},
+		// Market Information - Data set registration (creates in DRAFT status)
+		"market_information.register_data_set": {
+			handler: registerDataSetHandler(deps),
+			metadata: saga.HandlerMetadata{
+				Category:             saga.HandlerCategorySettlement,
+				Description:          "Register a new market data set definition in DRAFT status",
+				CompensationStrategy: "none",
+				ProducesInstruments:  []string{},
+				ProtoRequestType:     (*marketinformationv1.RegisterDataSetRequest)(nil),
+				ProtoResponseType:    (*marketinformationv1.RegisterDataSetResponse)(nil),
+				Version:              1,
+			},
+		},
+		// Market Information - Data set activation (DRAFT → ACTIVE)
+		"market_information.activate_data_set": {
+			handler: activateDataSetHandler(deps),
+			metadata: saga.HandlerMetadata{
+				Category:             saga.HandlerCategorySettlement,
+				Description:          "Activate a market data set definition (DRAFT → ACTIVE)",
+				CompensationStrategy: "none",
+				ProducesInstruments:  []string{},
+				ProtoRequestType:     (*marketinformationv1.ActivateDataSetRequest)(nil),
+				ProtoResponseType:    (*marketinformationv1.ActivateDataSetResponse)(nil),
+				Version:              1,
+			},
+		},
+		// Party - Organization registration
+		"party.register_organization": {
+			handler: registerOrganizationHandler(deps),
+			metadata: saga.HandlerMetadata{
+				Category:             saga.HandlerCategorySettlement,
+				Description:          "Register a new organization party in the party directory",
+				CompensationStrategy: "none",
+				ProducesInstruments:  []string{},
+				ProtoRequestType:     (*partyv1.RegisterPartyRequest)(nil),
+				ProtoResponseType:    (*partyv1.RegisterPartyResponse)(nil),
+				Version:              1,
+			},
+		},
 	}
 
 	for name, h := range handlers {
@@ -161,6 +223,12 @@ type HandlerDependencies struct {
 	// OperationalGateway provides provider connection and instruction route management.
 	// May be nil if no operational_gateway section is present in the manifest.
 	OperationalGateway OperationalGatewayService
+	// MarketInformation provides market data source and data set management.
+	// May be nil if no market_information section is present in the manifest.
+	MarketInformation MarketInformationService
+	// Party provides organization and party registration.
+	// May be nil if no party section is present in the manifest.
+	Party PartyService
 }
 
 // ReferenceDataService abstracts the Reference Data gRPC client for testing.
@@ -196,6 +264,24 @@ type OperationalGatewayService interface {
 	UpsertConnection(ctx *saga.StarlarkContext, params map[string]any) (any, error)
 	// UpsertRoute creates or updates an instruction route configuration.
 	UpsertRoute(ctx *saga.StarlarkContext, params map[string]any) (any, error)
+}
+
+// MarketInformationService abstracts the Market Information gRPC client for manifest apply.
+// It provides operations for registering data sources and data sets.
+type MarketInformationService interface {
+	// RegisterDataSource creates a new market data source.
+	RegisterDataSource(ctx *saga.StarlarkContext, params map[string]any) (any, error)
+	// RegisterDataSet creates a new market data set definition in DRAFT status.
+	RegisterDataSet(ctx *saga.StarlarkContext, params map[string]any) (any, error)
+	// ActivateDataSet transitions a data set from DRAFT to ACTIVE.
+	ActivateDataSet(ctx *saga.StarlarkContext, params map[string]any) (any, error)
+}
+
+// PartyService abstracts the Party gRPC client for manifest apply.
+// It provides organization registration for the party directory.
+type PartyService interface {
+	// RegisterOrganization registers a new organization party in the party directory.
+	RegisterOrganization(ctx *saga.StarlarkContext, params map[string]any) (any, error)
 }
 
 // registerInstrumentHandler creates a handler that registers an instrument via Reference Data.
@@ -295,6 +381,50 @@ func upsertRouteHandler(deps *HandlerDependencies) saga.Handler {
 			return nil, ErrOperationalGatewayNotConfigured
 		}
 		return deps.OperationalGateway.UpsertRoute(ctx, params)
+	}
+}
+
+// registerDataSourceHandler creates a handler that registers a market data source.
+// Returns an error if MarketInformation is nil to prevent silent skipping.
+func registerDataSourceHandler(deps *HandlerDependencies) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		if deps.MarketInformation == nil {
+			return nil, ErrMarketInformationNotConfigured
+		}
+		return deps.MarketInformation.RegisterDataSource(ctx, params)
+	}
+}
+
+// registerDataSetHandler creates a handler that registers a market data set in DRAFT status.
+// Returns an error if MarketInformation is nil to prevent silent skipping.
+func registerDataSetHandler(deps *HandlerDependencies) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		if deps.MarketInformation == nil {
+			return nil, ErrMarketInformationNotConfigured
+		}
+		return deps.MarketInformation.RegisterDataSet(ctx, params)
+	}
+}
+
+// activateDataSetHandler creates a handler that activates a market data set (DRAFT → ACTIVE).
+// Returns an error if MarketInformation is nil to prevent silent skipping.
+func activateDataSetHandler(deps *HandlerDependencies) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		if deps.MarketInformation == nil {
+			return nil, ErrMarketInformationNotConfigured
+		}
+		return deps.MarketInformation.ActivateDataSet(ctx, params)
+	}
+}
+
+// registerOrganizationHandler creates a handler that registers an organization in the party directory.
+// Returns an error if Party is nil to prevent silent skipping.
+func registerOrganizationHandler(deps *HandlerDependencies) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		if deps.Party == nil {
+			return nil, ErrPartyNotConfigured
+		}
+		return deps.Party.RegisterOrganization(ctx, params)
 	}
 }
 

--- a/services/control-plane/internal/applier/handlers_test.go
+++ b/services/control-plane/internal/applier/handlers_test.go
@@ -150,6 +150,10 @@ func TestRegisterManifestHandlers(t *testing.T) {
 		"internal_account.initiate",
 		"operational_gateway.upsert_connection",
 		"operational_gateway.upsert_route",
+		"market_information.register_data_source",
+		"market_information.register_data_set",
+		"market_information.activate_data_set",
+		"party.register_organization",
 	}
 
 	for _, name := range expectedHandlers {
@@ -623,6 +627,268 @@ func TestUpsertRouteHandler(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "payment.initiate", resultMap["instruction_type"])
 	assert.Equal(t, "UPSERTED", resultMap["status"])
+}
+
+// mockMarketInformation implements MarketInformationService for testing.
+type mockMarketInformation struct {
+	registerDataSourceFn func(*saga.StarlarkContext, map[string]any) (any, error)
+	registerDataSetFn    func(*saga.StarlarkContext, map[string]any) (any, error)
+	activateDataSetFn    func(*saga.StarlarkContext, map[string]any) (any, error)
+}
+
+func (m *mockMarketInformation) RegisterDataSource(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	if m.registerDataSourceFn != nil {
+		return m.registerDataSourceFn(ctx, params)
+	}
+	return map[string]any{"code": params["code"], "status": "REGISTERED"}, nil
+}
+
+func (m *mockMarketInformation) RegisterDataSet(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	if m.registerDataSetFn != nil {
+		return m.registerDataSetFn(ctx, params)
+	}
+	return map[string]any{"code": params["code"], "status": "DRAFT"}, nil
+}
+
+func (m *mockMarketInformation) ActivateDataSet(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	if m.activateDataSetFn != nil {
+		return m.activateDataSetFn(ctx, params)
+	}
+	return map[string]any{"code": params["code"], "status": "ACTIVE"}, nil
+}
+
+// mockParty implements PartyService for testing.
+type mockParty struct {
+	registerOrganizationFn func(*saga.StarlarkContext, map[string]any) (any, error)
+}
+
+func (m *mockParty) RegisterOrganization(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	if m.registerOrganizationFn != nil {
+		return m.registerOrganizationFn(ctx, params)
+	}
+	return map[string]any{"party_id": params["party_id"], "status": "ACTIVE"}, nil
+}
+
+// TestRegisterDataSourceHandler verifies the handler delegates to MarketInformationService.
+func TestRegisterDataSourceHandler(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:     &mockReferenceData{},
+		InternalAccount:   &mockInternalAccount{},
+		MarketInformation: &mockMarketInformation{},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("market_information.register_data_source")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"code":        "BLOOMBERG",
+		"name":        "Bloomberg Financial Data",
+		"trust_level": int64(90),
+	}
+
+	result, err := handler(ctx, params)
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "BLOOMBERG", resultMap["code"])
+	assert.Equal(t, "REGISTERED", resultMap["status"])
+}
+
+// TestRegisterDataSourceHandler_Error verifies errors are propagated.
+func TestRegisterDataSourceHandler_Error(t *testing.T) {
+	expectedErr := errors.New("data source registration failed")
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:   &mockReferenceData{},
+		InternalAccount: &mockInternalAccount{},
+		MarketInformation: &mockMarketInformation{
+			registerDataSourceFn: func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+				return nil, expectedErr
+			},
+		},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("market_information.register_data_source")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{"code": "FAIL"})
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+// TestRegisterDataSetHandler verifies the handler delegates to MarketInformationService.
+func TestRegisterDataSetHandler(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:     &mockReferenceData{},
+		InternalAccount:   &mockInternalAccount{},
+		MarketInformation: &mockMarketInformation{},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("market_information.register_data_set")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"code":     "USD_EUR_FX",
+		"category": "DATA_CATEGORY_FX_RATE",
+		"unit":     "USD/EUR",
+	}
+
+	result, err := handler(ctx, params)
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "USD_EUR_FX", resultMap["code"])
+	assert.Equal(t, "DRAFT", resultMap["status"])
+}
+
+// TestActivateDataSetHandler verifies the handler delegates to MarketInformationService.
+func TestActivateDataSetHandler(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:     &mockReferenceData{},
+		InternalAccount:   &mockInternalAccount{},
+		MarketInformation: &mockMarketInformation{},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("market_information.activate_data_set")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"code":    "USD_EUR_FX",
+		"version": int64(1),
+	}
+
+	result, err := handler(ctx, params)
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "USD_EUR_FX", resultMap["code"])
+	assert.Equal(t, "ACTIVE", resultMap["status"])
+}
+
+// TestMarketInformationHandlers_NilService verifies error when MarketInformation is nil.
+func TestMarketInformationHandlers_NilService(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:     &mockReferenceData{},
+		InternalAccount:   &mockInternalAccount{},
+		MarketInformation: nil,
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+
+	for _, handlerName := range []string{
+		"market_information.register_data_source",
+		"market_information.register_data_set",
+		"market_information.activate_data_set",
+	} {
+		t.Run(handlerName, func(t *testing.T) {
+			handler, err := registry.Get(handlerName)
+			require.NoError(t, err)
+			_, err = handler(ctx, map[string]any{"code": "TEST"})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "market_information service not configured")
+		})
+	}
+}
+
+// TestRegisterOrganizationHandler verifies the handler delegates to PartyService.
+func TestRegisterOrganizationHandler(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:   &mockReferenceData{},
+		InternalAccount: &mockInternalAccount{},
+		Party:           &mockParty{},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.register_organization")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"party_id":   "acme-corp",
+		"legal_name": "Acme Corporation Ltd",
+	}
+
+	result, err := handler(ctx, params)
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "acme-corp", resultMap["party_id"])
+	assert.Equal(t, "ACTIVE", resultMap["status"])
+}
+
+// TestRegisterOrganizationHandler_Error verifies errors are propagated.
+func TestRegisterOrganizationHandler_Error(t *testing.T) {
+	expectedErr := errors.New("organization registration failed")
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:   &mockReferenceData{},
+		InternalAccount: &mockInternalAccount{},
+		Party: &mockParty{
+			registerOrganizationFn: func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+				return nil, expectedErr
+			},
+		},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.register_organization")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{"party_id": "acme-corp"})
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+// TestRegisterOrganizationHandler_NilService verifies error when Party service is nil.
+func TestRegisterOrganizationHandler_NilService(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:   &mockReferenceData{},
+		InternalAccount: &mockInternalAccount{},
+		Party:           nil,
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.register_organization")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{"party_id": "acme-corp"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "party service not configured")
 }
 
 // TestUpsertRouteHandler_NilService verifies error when service is nil.

--- a/services/control-plane/internal/applier/market_information_client.go
+++ b/services/control-plane/internal/applier/market_information_client.go
@@ -1,6 +1,7 @@
 package applier
 
 import (
+	"errors"
 	"fmt"
 
 	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
@@ -8,6 +9,9 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"google.golang.org/grpc"
 )
+
+// ErrUnknownDataCategory is returned when an unrecognized data category string is provided.
+var ErrUnknownDataCategory = errors.New("unknown data category")
 
 // MarketInformationClient wraps the market-information gRPC client to implement
 // MarketInformationService for use as a saga handler dependency.
@@ -64,7 +68,11 @@ func (c *MarketInformationClient) RegisterDataSet(ctx *saga.StarlarkContext, par
 	req.ErrorMessageExpression, _ = params["error_message_expression"].(string)
 
 	categoryStr, _ := params["category"].(string)
-	req.Category = parseDataCategory(categoryStr)
+	category, err := parseDataCategory(categoryStr)
+	if err != nil {
+		return nil, fmt.Errorf("register data set: %w", err)
+	}
+	req.Category = category
 
 	callCtx := clients.PropagateIdempotencyKey(ctx.Context, ctx.IdempotencyKey)
 	resp, err := c.client.RegisterDataSet(callCtx, req)
@@ -106,11 +114,15 @@ func (c *MarketInformationClient) ActivateDataSet(ctx *saga.StarlarkContext, par
 }
 
 // parseDataCategory converts a string category name to the proto enum value.
-func parseDataCategory(s string) marketinformationv1.DataCategory {
-	if v, ok := marketinformationv1.DataCategory_value[s]; ok {
-		return marketinformationv1.DataCategory(v)
+// Returns an error for non-empty strings that do not match a known category.
+func parseDataCategory(s string) (marketinformationv1.DataCategory, error) {
+	if s == "" {
+		return marketinformationv1.DataCategory_DATA_CATEGORY_UNSPECIFIED, nil
 	}
-	return marketinformationv1.DataCategory_DATA_CATEGORY_UNSPECIFIED
+	if v, ok := marketinformationv1.DataCategory_value[s]; ok {
+		return marketinformationv1.DataCategory(v), nil
+	}
+	return 0, fmt.Errorf("%w: %q", ErrUnknownDataCategory, s)
 }
 
 // Ensure MarketInformationClient implements MarketInformationService at compile time.

--- a/services/control-plane/internal/applier/market_information_client.go
+++ b/services/control-plane/internal/applier/market_information_client.go
@@ -1,0 +1,117 @@
+package applier
+
+import (
+	"fmt"
+
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"google.golang.org/grpc"
+)
+
+// MarketInformationClient wraps the market-information gRPC client to implement
+// MarketInformationService for use as a saga handler dependency.
+//
+// The client translates between the flat map[string]any parameter convention used
+// by saga handlers and the typed proto messages required by the gRPC service.
+type MarketInformationClient struct {
+	client marketinformationv1.MarketInformationServiceClient
+}
+
+// NewMarketInformationClient creates a new MarketInformationClient from a gRPC connection.
+func NewMarketInformationClient(conn *grpc.ClientConn) *MarketInformationClient {
+	return &MarketInformationClient{
+		client: marketinformationv1.NewMarketInformationServiceClient(conn),
+	}
+}
+
+// RegisterDataSource implements MarketInformationService.
+// Converts Starlark params to a RegisterDataSourceRequest and calls the gRPC service.
+func (c *MarketInformationClient) RegisterDataSource(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	req := &marketinformationv1.RegisterDataSourceRequest{}
+	req.Code, _ = params["code"].(string)
+	req.Name, _ = params["name"].(string)
+	req.Description, _ = params["description"].(string)
+	if tl, ok := toInt32(params["trust_level"]); ok {
+		req.TrustLevel = tl
+	}
+
+	callCtx := clients.PropagateIdempotencyKey(ctx.Context, ctx.IdempotencyKey)
+	resp, err := c.client.RegisterDataSource(callCtx, req)
+	if err != nil {
+		return nil, fmt.Errorf("register data source: %w", err)
+	}
+
+	src := resp.GetSource()
+	return map[string]any{
+		"source_id": src.GetId(),
+		"code":      src.GetCode(),
+		"status":    "REGISTERED",
+	}, nil
+}
+
+// RegisterDataSet implements MarketInformationService.
+// Converts Starlark params to a RegisterDataSetRequest and calls the gRPC service.
+// The created data set is in DRAFT status and must be activated separately.
+func (c *MarketInformationClient) RegisterDataSet(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	req := &marketinformationv1.RegisterDataSetRequest{}
+	req.Code, _ = params["code"].(string)
+	req.Unit, _ = params["unit"].(string)
+	req.DisplayName, _ = params["display_name"].(string)
+	req.Description, _ = params["description"].(string)
+	req.ResolutionKeyExpression, _ = params["resolution_key_expression"].(string)
+	req.ValidationExpression, _ = params["validation_expression"].(string)
+	req.ErrorMessageExpression, _ = params["error_message_expression"].(string)
+
+	categoryStr, _ := params["category"].(string)
+	req.Category = parseDataCategory(categoryStr)
+
+	callCtx := clients.PropagateIdempotencyKey(ctx.Context, ctx.IdempotencyKey)
+	resp, err := c.client.RegisterDataSet(callCtx, req)
+	if err != nil {
+		return nil, fmt.Errorf("register data set: %w", err)
+	}
+
+	ds := resp.GetDataset()
+	return map[string]any{
+		"dataset_id": ds.GetId(),
+		"code":       ds.GetCode(),
+		"version":    ds.GetVersion(),
+		"status":     ds.GetStatus().String(),
+	}, nil
+}
+
+// ActivateDataSet implements MarketInformationService.
+// Converts Starlark params to an ActivateDataSetRequest and calls the gRPC service.
+func (c *MarketInformationClient) ActivateDataSet(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	req := &marketinformationv1.ActivateDataSetRequest{}
+	req.Code, _ = params["code"].(string)
+	if v, ok := toInt32(params["version"]); ok {
+		req.Version = v
+	}
+
+	callCtx := clients.PropagateIdempotencyKey(ctx.Context, ctx.IdempotencyKey)
+	resp, err := c.client.ActivateDataSet(callCtx, req)
+	if err != nil {
+		return nil, fmt.Errorf("activate data set: %w", err)
+	}
+
+	ds := resp.GetDataset()
+	return map[string]any{
+		"dataset_id": ds.GetId(),
+		"code":       ds.GetCode(),
+		"version":    ds.GetVersion(),
+		"status":     ds.GetStatus().String(),
+	}, nil
+}
+
+// parseDataCategory converts a string category name to the proto enum value.
+func parseDataCategory(s string) marketinformationv1.DataCategory {
+	if v, ok := marketinformationv1.DataCategory_value[s]; ok {
+		return marketinformationv1.DataCategory(v)
+	}
+	return marketinformationv1.DataCategory_DATA_CATEGORY_UNSPECIFIED
+}
+
+// Ensure MarketInformationClient implements MarketInformationService at compile time.
+var _ MarketInformationService = (*MarketInformationClient)(nil)

--- a/services/control-plane/internal/applier/market_information_client.go
+++ b/services/control-plane/internal/applier/market_information_client.go
@@ -3,11 +3,13 @@ package applier
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // ErrUnknownDataCategory is returned when an unrecognized data category string is provided.
@@ -73,6 +75,14 @@ func (c *MarketInformationClient) RegisterDataSet(ctx *saga.StarlarkContext, par
 		return nil, fmt.Errorf("register data set: %w", err)
 	}
 	req.Category = category
+
+	if effectiveFromStr, ok := params["effective_from"].(string); ok && effectiveFromStr != "" {
+		t, parseErr := time.Parse(time.RFC3339, effectiveFromStr)
+		if parseErr != nil {
+			return nil, fmt.Errorf("register data set: invalid effective_from %q: %w", effectiveFromStr, parseErr)
+		}
+		req.EffectiveFrom = timestamppb.New(t)
+	}
 
 	callCtx := clients.PropagateIdempotencyKey(ctx.Context, ctx.IdempotencyKey)
 	resp, err := c.client.RegisterDataSet(callCtx, req)

--- a/services/control-plane/internal/applier/party_client.go
+++ b/services/control-plane/internal/applier/party_client.go
@@ -1,0 +1,65 @@
+package applier
+
+import (
+	"fmt"
+
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"google.golang.org/grpc"
+)
+
+// PartyClient wraps the party gRPC client to implement PartyService for use as a
+// saga handler dependency.
+//
+// The client translates between the flat map[string]any parameter convention used
+// by saga handlers and the typed proto messages required by the gRPC service.
+type PartyClient struct {
+	client partyv1.PartyServiceClient
+}
+
+// NewPartyClient creates a new PartyClient from a gRPC connection.
+func NewPartyClient(conn *grpc.ClientConn) *PartyClient {
+	return &PartyClient{
+		client: partyv1.NewPartyServiceClient(conn),
+	}
+}
+
+// RegisterOrganization implements PartyService.
+// Converts Starlark params to a RegisterPartyRequest with PARTY_TYPE_ORGANIZATION
+// and calls the gRPC service.
+func (c *PartyClient) RegisterOrganization(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	req := &partyv1.RegisterPartyRequest{
+		PartyType: partyv1.PartyType_PARTY_TYPE_ORGANIZATION,
+	}
+	req.LegalName, _ = params["legal_name"].(string)
+	req.DisplayName, _ = params["display_name"].(string)
+	req.ExternalReference, _ = params["external_reference"].(string)
+
+	externalRefTypeStr, _ := params["external_reference_type"].(string)
+	req.ExternalReferenceType = parseExternalReferenceType(externalRefTypeStr)
+
+	callCtx := clients.PropagateIdempotencyKey(ctx.Context, ctx.IdempotencyKey)
+	resp, err := c.client.RegisterParty(callCtx, req)
+	if err != nil {
+		return nil, fmt.Errorf("register organization: %w", err)
+	}
+
+	party := resp.GetParty()
+	return map[string]any{
+		"party_id":   party.GetPartyId(),
+		"legal_name": party.GetLegalName(),
+		"status":     party.GetStatus().String(),
+	}, nil
+}
+
+// parseExternalReferenceType converts a string to the proto ExternalReferenceType enum.
+func parseExternalReferenceType(s string) partyv1.ExternalReferenceType {
+	if v, ok := partyv1.ExternalReferenceType_value[s]; ok {
+		return partyv1.ExternalReferenceType(v)
+	}
+	return partyv1.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_UNSPECIFIED
+}
+
+// Ensure PartyClient implements PartyService at compile time.
+var _ PartyService = (*PartyClient)(nil)

--- a/services/control-plane/internal/applier/party_client.go
+++ b/services/control-plane/internal/applier/party_client.go
@@ -1,6 +1,7 @@
 package applier
 
 import (
+	"errors"
 	"fmt"
 
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
@@ -8,6 +9,9 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"google.golang.org/grpc"
 )
+
+// ErrUnknownExternalReferenceType is returned when an unrecognized external_reference_type is provided.
+var ErrUnknownExternalReferenceType = errors.New("unknown external_reference_type")
 
 // PartyClient wraps the party gRPC client to implement PartyService for use as a
 // saga handler dependency.
@@ -37,7 +41,11 @@ func (c *PartyClient) RegisterOrganization(ctx *saga.StarlarkContext, params map
 	req.ExternalReference, _ = params["external_reference"].(string)
 
 	externalRefTypeStr, _ := params["external_reference_type"].(string)
-	req.ExternalReferenceType = parseExternalReferenceType(externalRefTypeStr)
+	externalRefType, err := parseExternalReferenceType(externalRefTypeStr)
+	if err != nil {
+		return nil, fmt.Errorf("register organization: %w", err)
+	}
+	req.ExternalReferenceType = externalRefType
 
 	callCtx := clients.PropagateIdempotencyKey(ctx.Context, ctx.IdempotencyKey)
 	resp, err := c.client.RegisterParty(callCtx, req)
@@ -54,11 +62,15 @@ func (c *PartyClient) RegisterOrganization(ctx *saga.StarlarkContext, params map
 }
 
 // parseExternalReferenceType converts a string to the proto ExternalReferenceType enum.
-func parseExternalReferenceType(s string) partyv1.ExternalReferenceType {
-	if v, ok := partyv1.ExternalReferenceType_value[s]; ok {
-		return partyv1.ExternalReferenceType(v)
+// Returns an error for non-empty strings that do not match a known type.
+func parseExternalReferenceType(s string) (partyv1.ExternalReferenceType, error) {
+	if s == "" {
+		return partyv1.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_UNSPECIFIED, nil
 	}
-	return partyv1.ExternalReferenceType_EXTERNAL_REFERENCE_TYPE_UNSPECIFIED
+	if v, ok := partyv1.ExternalReferenceType_value[s]; ok {
+		return partyv1.ExternalReferenceType(v), nil
+	}
+	return 0, fmt.Errorf("%w: %q", ErrUnknownExternalReferenceType, s)
 }
 
 // Ensure PartyClient implements PartyService at compile time.


### PR DESCRIPTION
## Summary

- Registers `market_information.register_data_source`, `market_information.register_data_set`, `market_information.activate_data_set`, and `party.register_organization` handlers in the manifest apply saga handler registry (tasks 045-manifest-source-of-truth.2 and 045-manifest-source-of-truth.4)
- Adds `MarketInformationService` and `PartyService` interfaces to `HandlerDependencies` with nil-service guards that return descriptive errors matching the existing gateway pattern
- Provides gRPC client implementations (`MarketInformationClient`, `PartyClient`) that translate flat `map[string]any` saga params to typed proto requests

## Changes Made

- `services/control-plane/internal/applier/handlers.go`: Added `MarketInformationService` and `PartyService` interfaces, `MarketInformation`/`Party` fields on `HandlerDependencies`, `ErrMarketInformationNotConfigured`/`ErrPartyNotConfigured` error vars, handler registration entries with `HandlerMetadata`, and handler functions with nil-guard pattern
- `services/control-plane/internal/applier/market_information_client.go`: New — gRPC client wrapping `MarketInformationServiceClient` with `RegisterDataSource`, `RegisterDataSet`, `ActivateDataSet` methods
- `services/control-plane/internal/applier/party_client.go`: New — gRPC client wrapping `PartyServiceClient` with `RegisterOrganization` (always sets `PARTY_TYPE_ORGANIZATION`)
- `services/control-plane/internal/applier/handlers_test.go`: Mock implementations and unit tests for all new handlers (happy path, error propagation, nil-service guards)

## Test Plan

- [x] `TestRegisterDataSourceHandler` — delegates params to `MarketInformationService.RegisterDataSource`
- [x] `TestRegisterDataSourceHandler_Error` — service errors are propagated
- [x] `TestRegisterDataSetHandler` — delegates params to `MarketInformationService.RegisterDataSet`
- [x] `TestActivateDataSetHandler` — delegates params to `MarketInformationService.ActivateDataSet`
- [x] `TestMarketInformationHandlers_NilService` — all three market_information handlers return "market_information service not configured" when `MarketInformation` is nil
- [x] `TestRegisterOrganizationHandler` — delegates params to `PartyService.RegisterOrganization`
- [x] `TestRegisterOrganizationHandler_Error` — service errors are propagated
- [x] `TestRegisterOrganizationHandler_NilService` — returns "party service not configured" when `Party` is nil
- [x] `TestRegisterManifestHandlers` — all 13 handlers (including 4 new) are registered successfully