### PR TITLE
feat: Add structured validation errors with resource context and fuzzy-match suggestions

### DIFF
--- a/api/proto/meridian/control_plane/v1/apply_manifest_service.proto
+++ b/api/proto/meridian/control_plane/v1/apply_manifest_service.proto
@@ -144,4 +144,12 @@ message ValidationError {
 
   // suggestion is a "Did you mean...?" hint for typos.
   string suggestion = 5;
+
+  // resource_type is the manifest section type where the error occurred
+  // (e.g., "instrument", "account_type", "saga", "valuation_rule").
+  string resource_type = 6;
+
+  // resource_id is the identifier of the specific resource that caused the error
+  // (e.g., the instrument code, account type code, or saga name).
+  string resource_id = 7;
 }

--- a/services/control-plane/internal/applier/grpc_handler.go
+++ b/services/control-plane/internal/applier/grpc_handler.go
@@ -300,11 +300,13 @@ func (h *ApplyManifestHandler) validate(
 	protoErrors := make([]*controlplanev1.ValidationError, 0, len(result.Errors))
 	for _, ve := range result.Errors {
 		protoErrors = append(protoErrors, &controlplanev1.ValidationError{
-			Severity:   string(ve.Severity),
-			Path:       ve.Path,
-			Code:       ve.Code,
-			Message:    ve.Message,
-			Suggestion: ve.Suggestion,
+			Severity:     string(ve.Severity),
+			Path:         ve.Path,
+			Code:         ve.Code,
+			Message:      ve.Message,
+			Suggestion:   ve.Suggestion,
+			ResourceType: ve.ResourceType,
+			ResourceId:   ve.ResourceID,
 		})
 	}
 

--- a/services/control-plane/internal/generator/llm_client.go
+++ b/services/control-plane/internal/generator/llm_client.go
@@ -68,6 +68,14 @@ type ValidationError struct {
 	// AvailableFields lists valid field names when an unknown field is referenced.
 	// This mirrors validator.ValidationError.AvailableFields for a straight copy.
 	AvailableFields []string
+
+	// ResourceType is the manifest section type where the error occurred
+	// (e.g., "instrument", "account_type", "saga", "valuation_rule").
+	ResourceType string
+
+	// ResourceID is the identifier of the specific resource that caused the error
+	// (e.g., the instrument code, account type code, or saga name).
+	ResourceID string
 }
 
 // LLMClient abstracts LLM interactions for manifest generation.

--- a/services/control-plane/internal/generator/service.go
+++ b/services/control-plane/internal/generator/service.go
@@ -320,10 +320,12 @@ func toProtoValidationErrors(errs []ValidationError) []*controlplanev1.Validatio
 	out := make([]*controlplanev1.ValidationError, len(errs))
 	for i, e := range errs {
 		out[i] = &controlplanev1.ValidationError{
-			Code:       e.Code,
-			Path:       e.Path,
-			Message:    e.Message,
-			Suggestion: e.Suggestion,
+			Code:         e.Code,
+			Path:         e.Path,
+			Message:      e.Message,
+			Suggestion:   e.Suggestion,
+			ResourceType: e.ResourceType,
+			ResourceId:   e.ResourceID,
 		}
 	}
 	return out

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -595,7 +595,7 @@ func (v *ManifestValidator) validateDuplicates(
 				Code:         "DUPLICATE_MAPPING",
 				Message:      fmt.Sprintf("duplicate mapping name=%q version=%d (first defined at mappings[%d])", mp.GetName(), mp.GetVersion(), prev),
 				ResourceType: "mapping",
-				ResourceID:   mp.GetName(),
+				ResourceID:   fmt.Sprintf("%s:v%d", mp.GetName(), mp.GetVersion()),
 			})
 		} else {
 			mappingKeys[key] = i
@@ -1432,6 +1432,8 @@ func (v *ManifestValidator) validateEventTrigger(
 			Code:            "INVALID_EVENT_CHANNEL",
 			Message:         fmt.Sprintf("unknown event channel %q; must be a registered topic", channel),
 			AvailableFields: availableChans,
+			ResourceType:    "saga",
+			ResourceID:      saga.GetName(),
 		}
 		if suggestion := findClosestMatch(channel, availableChans); suggestion != "" {
 			ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
@@ -1536,6 +1538,8 @@ func (v *ManifestValidator) validateWebhookTriggers(
 				Code:            "UNKNOWN_WEBHOOK_SOURCE",
 				Message:         fmt.Sprintf("webhook source %q does not match any provider connection in operational_gateway.provider_connections", source),
 				AvailableFields: availableIDs,
+				ResourceType:    "saga",
+				ResourceID:      saga.GetName(),
 			}
 			if suggestion := findClosestMatch(source, availableIDs); suggestion != "" {
 				ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
@@ -1605,16 +1609,20 @@ func (v *ManifestValidator) validatePaymentRails(
 				Code:            "INVALID_PAYMENT_PROVIDER",
 				Message:         fmt.Sprintf("unsupported payment provider %q", rail.GetProvider()),
 				AvailableFields: providerList,
+				ResourceType:    "payment_rail",
+				ResourceID:      rail.GetProvider(),
 			})
 		}
 
 		// Validate account_id format
 		if rail.GetAccountId() != "" && !accountIDPattern.MatchString(rail.GetAccountId()) {
 			addError(result, ValidationError{
-				Severity: SeverityError,
-				Path:     basePath + ".account_id",
-				Code:     "INVALID_ACCOUNT_ID_FORMAT",
-				Message:  fmt.Sprintf("account_id %q does not match expected format acct_[A-Za-z0-9]{16,}", rail.GetAccountId()),
+				Severity:     SeverityError,
+				Path:         basePath + ".account_id",
+				Code:         "INVALID_ACCOUNT_ID_FORMAT",
+				Message:      fmt.Sprintf("account_id %q does not match expected format acct_[A-Za-z0-9]{16,}", rail.GetAccountId()),
+				ResourceType: "payment_rail",
+				ResourceID:   rail.GetProvider(),
 			})
 		}
 
@@ -1633,6 +1641,8 @@ func (v *ManifestValidator) validatePaymentRails(
 					Code:            "UNKNOWN_PAYMENT_METHOD",
 					Message:         fmt.Sprintf("payment method %q is not a recognized method", method),
 					AvailableFields: methodList,
+					ResourceType:    "payment_rail",
+					ResourceID:      rail.GetProvider(),
 				}
 				if suggestion := findClosestMatch(method, methodList); suggestion != "" {
 					ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
@@ -1735,13 +1745,13 @@ func (v *ManifestValidator) validatePartyTypes(
 
 		// Validate CEL expressions
 		if expr := pt.GetValidationCel(); expr != "" {
-			v.validateCELExpression(expr, basePath+".validation_cel", v.partyTypeCelEnv, celPartyTypeFields, result, "party_type", pt.GetPartyType())
+			v.validateCELExpression(expr, basePath+".validation_cel", v.partyTypeCelEnv, celPartyTypeFields, result, "party_type", fmt.Sprintf("%s:%s", pt.GetTenantId(), pt.GetPartyType()))
 		}
 		if expr := pt.GetEligibilityCel(); expr != "" {
-			v.validateCELExpression(expr, basePath+".eligibility_cel", v.partyTypeCelEnv, celPartyTypeFields, result, "party_type", pt.GetPartyType())
+			v.validateCELExpression(expr, basePath+".eligibility_cel", v.partyTypeCelEnv, celPartyTypeFields, result, "party_type", fmt.Sprintf("%s:%s", pt.GetTenantId(), pt.GetPartyType()))
 		}
 		if expr := pt.GetErrorMessageCel(); expr != "" {
-			v.validateCELExpression(expr, basePath+".error_message_cel", v.partyTypeCelEnv, celPartyTypeFields, result, "party_type", pt.GetPartyType())
+			v.validateCELExpression(expr, basePath+".error_message_cel", v.partyTypeCelEnv, celPartyTypeFields, result, "party_type", fmt.Sprintf("%s:%s", pt.GetTenantId(), pt.GetPartyType()))
 		}
 	}
 }
@@ -2067,11 +2077,13 @@ func (v *ManifestValidator) validateAPITriggers(
 		// Validate format: must start with '/'
 		if !apiPathPattern.MatchString(path) {
 			addError(result, ValidationError{
-				Severity:   SeverityError,
-				Path:       sagaPath,
-				Code:       "INVALID_API_PATH_FORMAT",
-				Message:    fmt.Sprintf("API trigger path %q must start with '/'", path),
-				Suggestion: "API paths should follow the format '/v1/resource'",
+				Severity:     SeverityError,
+				Path:         sagaPath,
+				Code:         "INVALID_API_PATH_FORMAT",
+				Message:      fmt.Sprintf("API trigger path %q must start with '/'", path),
+				Suggestion:   "API paths should follow the format '/v1/resource'",
+				ResourceType: "saga",
+				ResourceID:   saga.GetName(),
 			})
 			continue
 		}
@@ -2079,10 +2091,12 @@ func (v *ManifestValidator) validateAPITriggers(
 		// Check uniqueness
 		if prevIdx, exists := seenPaths[path]; exists {
 			addError(result, ValidationError{
-				Severity: SeverityError,
-				Path:     sagaPath,
-				Code:     "DUPLICATE_API_TRIGGER",
-				Message:  fmt.Sprintf("API path %q already bound to saga at sagas[%d]", path, prevIdx),
+				Severity:     SeverityError,
+				Path:         sagaPath,
+				Code:         "DUPLICATE_API_TRIGGER",
+				Message:      fmt.Sprintf("API path %q already bound to saga at sagas[%d]", path, prevIdx),
+				ResourceType: "saga",
+				ResourceID:   saga.GetName(),
 			})
 		} else {
 			seenPaths[path] = i
@@ -2096,6 +2110,8 @@ func (v *ManifestValidator) validateAPITriggers(
 				Code:            "UNKNOWN_API_ENDPOINT",
 				Message:         fmt.Sprintf("API path %q is not defined in the OpenAPI spec", path),
 				AvailableFields: availablePaths,
+				ResourceType:    "saga",
+				ResourceID:      saga.GetName(),
 			}
 			if suggestion := findClosestMatch(path, availablePaths); suggestion != "" {
 				ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
@@ -2432,10 +2448,12 @@ func (v *ManifestValidator) detectOrphanProviderConnections(
 		cid := conn.GetConnectionId()
 		if !usedConnections[cid] {
 			addError(result, ValidationError{
-				Severity: SeverityWarning,
-				Path:     fmt.Sprintf("operational_gateway.provider_connections[%d].connection_id", i),
-				Code:     "ORPHAN_PROVIDER_CONNECTION",
-				Message:  fmt.Sprintf("provider connection %q is not referenced by any instruction route or webhook trigger", cid),
+				Severity:     SeverityWarning,
+				Path:         fmt.Sprintf("operational_gateway.provider_connections[%d].connection_id", i),
+				Code:         "ORPHAN_PROVIDER_CONNECTION",
+				Message:      fmt.Sprintf("provider connection %q is not referenced by any instruction route or webhook trigger", cid),
+				ResourceType: "provider_connection",
+				ResourceID:   cid,
 			})
 		}
 	}
@@ -2458,10 +2476,12 @@ func (v *ManifestValidator) detectOrphanInstructionRoutes(
 		instrType := route.GetInstructionType()
 		if !usedInstructionTypes[instrType] {
 			addError(result, ValidationError{
-				Severity: SeverityWarning,
-				Path:     fmt.Sprintf("operational_gateway.instruction_routes[%d].instruction_type", i),
-				Code:     "ORPHAN_INSTRUCTION_ROUTE",
-				Message:  fmt.Sprintf("instruction type %q is not dispatched by any saga script", instrType),
+				Severity:     SeverityWarning,
+				Path:         fmt.Sprintf("operational_gateway.instruction_routes[%d].instruction_type", i),
+				Code:         "ORPHAN_INSTRUCTION_ROUTE",
+				Message:      fmt.Sprintf("instruction type %q is not dispatched by any saga script", instrType),
+				ResourceType: "instruction_route",
+				ResourceID:   instrType,
 			})
 		}
 	}

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -145,6 +145,14 @@ const (
 	SeverityWarning Severity = "warning"
 )
 
+// Starlark validation error codes.
+const (
+	// CodeStarlarkSyntaxError is used when a Starlark script has a syntax error.
+	CodeStarlarkSyntaxError = "STARLARK_SYNTAX_ERROR"
+	// CodeStarlarkCompilationError is used when a Starlark script fails to compile.
+	CodeStarlarkCompilationError = "STARLARK_COMPILATION_ERROR"
+)
+
 // ValidationError represents a single validation finding with structured
 // location information and optional suggestions for AI feedback.
 type ValidationError struct {
@@ -171,6 +179,14 @@ type ValidationError struct {
 
 	// AvailableFields lists valid field names when an unknown field is referenced.
 	AvailableFields []string `json:"available_fields,omitempty"`
+
+	// ResourceType is the manifest section type where the error occurred
+	// (e.g., "instrument", "account_type", "saga", "valuation_rule").
+	ResourceType string `json:"resource_type,omitempty"`
+
+	// ResourceID is the identifier of the specific resource that caused the error
+	// (e.g., the instrument code, account type code, or saga name).
+	ResourceID string `json:"resource_id,omitempty"`
 }
 
 // Error implements the error interface.
@@ -506,10 +522,12 @@ func (v *ManifestValidator) validateDuplicates(
 	for i, inst := range manifest.GetInstruments() {
 		if prev, exists := instrumentCodes[inst.GetCode()]; exists {
 			addError(result, ValidationError{
-				Severity: SeverityError,
-				Path:     fmt.Sprintf("instruments[%d].code", i),
-				Code:     "DUPLICATE_CODE",
-				Message:  fmt.Sprintf("duplicate instrument code %q (first defined at instruments[%d])", inst.GetCode(), prev),
+				Severity:     SeverityError,
+				Path:         fmt.Sprintf("instruments[%d].code", i),
+				Code:         "DUPLICATE_CODE",
+				Message:      fmt.Sprintf("duplicate instrument code %q (first defined at instruments[%d])", inst.GetCode(), prev),
+				ResourceType: "instrument",
+				ResourceID:   inst.GetCode(),
 			})
 		} else {
 			instrumentCodes[inst.GetCode()] = i
@@ -521,10 +539,12 @@ func (v *ManifestValidator) validateDuplicates(
 	for i, acct := range manifest.GetAccountTypes() {
 		if prev, exists := accountTypeCodes[acct.GetCode()]; exists {
 			addError(result, ValidationError{
-				Severity: SeverityError,
-				Path:     fmt.Sprintf("account_types[%d].code", i),
-				Code:     "DUPLICATE_CODE",
-				Message:  fmt.Sprintf("duplicate account type code %q (first defined at account_types[%d])", acct.GetCode(), prev),
+				Severity:     SeverityError,
+				Path:         fmt.Sprintf("account_types[%d].code", i),
+				Code:         "DUPLICATE_CODE",
+				Message:      fmt.Sprintf("duplicate account type code %q (first defined at account_types[%d])", acct.GetCode(), prev),
+				ResourceType: "account_type",
+				ResourceID:   acct.GetCode(),
 			})
 		} else {
 			accountTypeCodes[acct.GetCode()] = i
@@ -536,10 +556,12 @@ func (v *ManifestValidator) validateDuplicates(
 	for i, saga := range manifest.GetSagas() {
 		if prev, exists := sagaNames[saga.GetName()]; exists {
 			addError(result, ValidationError{
-				Severity: SeverityError,
-				Path:     fmt.Sprintf("sagas[%d].name", i),
-				Code:     "DUPLICATE_NAME",
-				Message:  fmt.Sprintf("duplicate saga name %q (first defined at sagas[%d])", saga.GetName(), prev),
+				Severity:     SeverityError,
+				Path:         fmt.Sprintf("sagas[%d].name", i),
+				Code:         "DUPLICATE_NAME",
+				Message:      fmt.Sprintf("duplicate saga name %q (first defined at sagas[%d])", saga.GetName(), prev),
+				ResourceType: "saga",
+				ResourceID:   saga.GetName(),
 			})
 		} else {
 			sagaNames[saga.GetName()] = i
@@ -547,11 +569,13 @@ func (v *ManifestValidator) validateDuplicates(
 		// Warn when an event-triggered saga has no filter; all events will trigger the saga
 		if strings.HasPrefix(saga.GetTrigger(), "event:") && saga.Filter == nil {
 			addError(result, ValidationError{
-				Severity:   SeverityWarning,
-				Path:       fmt.Sprintf("sagas[%d].filter", i),
-				Code:       "MISSING_EVENT_FILTER",
-				Message:    fmt.Sprintf("saga %q subscribes to event trigger %q without a filter; the saga will execute for every matching event", saga.GetName(), saga.GetTrigger()),
-				Suggestion: `Add a CEL filter expression, e.g. filter: 'event.amount > 0'`,
+				Severity:     SeverityWarning,
+				Path:         fmt.Sprintf("sagas[%d].filter", i),
+				Code:         "MISSING_EVENT_FILTER",
+				Message:      fmt.Sprintf("saga %q subscribes to event trigger %q without a filter; the saga will execute for every matching event", saga.GetName(), saga.GetTrigger()),
+				Suggestion:   `Add a CEL filter expression, e.g. filter: 'event.amount > 0'`,
+				ResourceType: "saga",
+				ResourceID:   saga.GetName(),
 			})
 		}
 	}
@@ -566,10 +590,12 @@ func (v *ManifestValidator) validateDuplicates(
 		key := mappingKey{name: mp.GetName(), version: mp.GetVersion()}
 		if prev, exists := mappingKeys[key]; exists {
 			addError(result, ValidationError{
-				Severity: SeverityError,
-				Path:     fmt.Sprintf("mappings[%d]", i),
-				Code:     "DUPLICATE_MAPPING",
-				Message:  fmt.Sprintf("duplicate mapping name=%q version=%d (first defined at mappings[%d])", mp.GetName(), mp.GetVersion(), prev),
+				Severity:     SeverityError,
+				Path:         fmt.Sprintf("mappings[%d]", i),
+				Code:         "DUPLICATE_MAPPING",
+				Message:      fmt.Sprintf("duplicate mapping name=%q version=%d (first defined at mappings[%d])", mp.GetName(), mp.GetVersion(), prev),
+				ResourceType: "mapping",
+				ResourceID:   mp.GetName(),
 			})
 		} else {
 			mappingKeys[key] = i
@@ -593,10 +619,12 @@ func (v *ManifestValidator) validateMarketDataAndOrgDuplicates(
 	for i, src := range manifest.GetMarketData().GetSources() {
 		if prev, exists := mdSourceCodes[src.GetCode()]; exists {
 			addError(result, ValidationError{
-				Severity: SeverityError,
-				Path:     fmt.Sprintf("market_data.sources[%d].code", i),
-				Code:     "DUPLICATE_CODE",
-				Message:  fmt.Sprintf("duplicate market data source code %q (first defined at market_data.sources[%d])", src.GetCode(), prev),
+				Severity:     SeverityError,
+				Path:         fmt.Sprintf("market_data.sources[%d].code", i),
+				Code:         "DUPLICATE_CODE",
+				Message:      fmt.Sprintf("duplicate market data source code %q (first defined at market_data.sources[%d])", src.GetCode(), prev),
+				ResourceType: "market_data_source",
+				ResourceID:   src.GetCode(),
 			})
 		} else {
 			mdSourceCodes[src.GetCode()] = i
@@ -608,10 +636,12 @@ func (v *ManifestValidator) validateMarketDataAndOrgDuplicates(
 	for i, ds := range manifest.GetMarketData().GetDatasets() {
 		if prev, exists := mdSetCodes[ds.GetCode()]; exists {
 			addError(result, ValidationError{
-				Severity: SeverityError,
-				Path:     fmt.Sprintf("market_data.datasets[%d].code", i),
-				Code:     "DUPLICATE_CODE",
-				Message:  fmt.Sprintf("duplicate market data set code %q (first defined at market_data.datasets[%d])", ds.GetCode(), prev),
+				Severity:     SeverityError,
+				Path:         fmt.Sprintf("market_data.datasets[%d].code", i),
+				Code:         "DUPLICATE_CODE",
+				Message:      fmt.Sprintf("duplicate market data set code %q (first defined at market_data.datasets[%d])", ds.GetCode(), prev),
+				ResourceType: "market_data_dataset",
+				ResourceID:   ds.GetCode(),
 			})
 		} else {
 			mdSetCodes[ds.GetCode()] = i
@@ -623,10 +653,12 @@ func (v *ManifestValidator) validateMarketDataAndOrgDuplicates(
 	for i, org := range manifest.GetOrganizations() {
 		if prev, exists := orgCodes[org.GetCode()]; exists {
 			addError(result, ValidationError{
-				Severity: SeverityError,
-				Path:     fmt.Sprintf("organizations[%d].code", i),
-				Code:     "DUPLICATE_CODE",
-				Message:  fmt.Sprintf("duplicate organization code %q (first defined at organizations[%d])", org.GetCode(), prev),
+				Severity:     SeverityError,
+				Path:         fmt.Sprintf("organizations[%d].code", i),
+				Code:         "DUPLICATE_CODE",
+				Message:      fmt.Sprintf("duplicate organization code %q (first defined at organizations[%d])", org.GetCode(), prev),
+				ResourceType: "organization",
+				ResourceID:   org.GetCode(),
 			})
 		} else {
 			orgCodes[org.GetCode()] = i
@@ -648,10 +680,12 @@ func (v *ManifestValidator) validateOperationalGatewayDuplicates(
 	for i, conn := range gw.GetProviderConnections() {
 		if prev, exists := connectionIDs[conn.GetConnectionId()]; exists {
 			addError(result, ValidationError{
-				Severity: SeverityError,
-				Path:     fmt.Sprintf("operational_gateway.provider_connections[%d].connection_id", i),
-				Code:     "DUPLICATE_CONNECTION_ID",
-				Message:  fmt.Sprintf("duplicate connection_id %q (first defined at provider_connections[%d])", conn.GetConnectionId(), prev),
+				Severity:     SeverityError,
+				Path:         fmt.Sprintf("operational_gateway.provider_connections[%d].connection_id", i),
+				Code:         "DUPLICATE_CONNECTION_ID",
+				Message:      fmt.Sprintf("duplicate connection_id %q (first defined at provider_connections[%d])", conn.GetConnectionId(), prev),
+				ResourceType: "provider_connection",
+				ResourceID:   conn.GetConnectionId(),
 			})
 		} else {
 			connectionIDs[conn.GetConnectionId()] = i
@@ -662,10 +696,12 @@ func (v *ManifestValidator) validateOperationalGatewayDuplicates(
 	for i, route := range gw.GetInstructionRoutes() {
 		if prev, exists := instructionTypes[route.GetInstructionType()]; exists {
 			addError(result, ValidationError{
-				Severity: SeverityError,
-				Path:     fmt.Sprintf("operational_gateway.instruction_routes[%d].instruction_type", i),
-				Code:     "DUPLICATE_INSTRUCTION_TYPE",
-				Message:  fmt.Sprintf("duplicate instruction_type %q (first defined at instruction_routes[%d])", route.GetInstructionType(), prev),
+				Severity:     SeverityError,
+				Path:         fmt.Sprintf("operational_gateway.instruction_routes[%d].instruction_type", i),
+				Code:         "DUPLICATE_INSTRUCTION_TYPE",
+				Message:      fmt.Sprintf("duplicate instruction_type %q (first defined at instruction_routes[%d])", route.GetInstructionType(), prev),
+				ResourceType: "instruction_route",
+				ResourceID:   route.GetInstructionType(),
 			})
 		} else {
 			instructionTypes[route.GetInstructionType()] = i
@@ -692,6 +728,8 @@ func (v *ManifestValidator) validateCELExpressions(
 				v.celEnv,
 				celBalanceFields,
 				result,
+				"account_type",
+				acctType.GetCode(),
 			)
 		}
 
@@ -703,26 +741,33 @@ func (v *ManifestValidator) validateCELExpressions(
 				v.bucketCelEnv,
 				[]string{"instrument_code", "attributes"},
 				result,
+				"account_type",
+				acctType.GetCode(),
 			)
 		}
 	}
 }
 
 // validateCELExpression compiles a single CEL expression and produces structured errors.
+// resourceType and resourceID are optional context identifiers (e.g., "account_type", "SETTLEMENT").
 func (v *ManifestValidator) validateCELExpression(
 	expression string,
 	path string,
 	env *cel.Env,
 	availableFields []string,
 	result *ValidationResult,
+	resourceType string,
+	resourceID string,
 ) {
 	// Check length constraint
 	if len(expression) > 4096 {
 		addError(result, ValidationError{
-			Severity: SeverityError,
-			Path:     path,
-			Code:     "CEL_EXPRESSION_TOO_LONG",
-			Message:  fmt.Sprintf("CEL expression exceeds maximum length of 4096 bytes (got %d)", len(expression)),
+			Severity:     SeverityError,
+			Path:         path,
+			Code:         "CEL_EXPRESSION_TOO_LONG",
+			Message:      fmt.Sprintf("CEL expression exceeds maximum length of 4096 bytes (got %d)", len(expression)),
+			ResourceType: resourceType,
+			ResourceID:   resourceID,
 		})
 		return
 	}
@@ -753,15 +798,19 @@ func (v *ManifestValidator) validateCELExpression(
 			Message:         errMsg,
 			Suggestion:      suggestion,
 			AvailableFields: availableFields,
+			ResourceType:    resourceType,
+			ResourceID:      resourceID,
 		})
 		return
 	}
 
 	addError(result, ValidationError{
-		Severity: SeverityError,
-		Path:     path,
-		Code:     "CEL_COMPILATION_ERROR",
-		Message:  errMsg,
+		Severity:     SeverityError,
+		Path:         path,
+		Code:         "CEL_COMPILATION_ERROR",
+		Message:      errMsg,
+		ResourceType: resourceType,
+		ResourceID:   resourceID,
 	})
 }
 
@@ -793,42 +842,52 @@ func (v *ManifestValidator) validateSingleStarlarkScript(
 	path string,
 	result *ValidationResult,
 ) []schema.HandlerCallInfo {
+	sagaName := saga.GetName()
 	if len(script) > 65536 {
 		addError(result, ValidationError{
-			Severity: SeverityError,
-			Path:     path,
-			Code:     "STARLARK_SCRIPT_TOO_LARGE",
-			Message:  fmt.Sprintf("Starlark script exceeds maximum size of 65536 bytes (got %d)", len(script)),
+			Severity:     SeverityError,
+			Path:         path,
+			Code:         "STARLARK_SCRIPT_TOO_LARGE",
+			Message:      fmt.Sprintf("Starlark script exceeds maximum size of 65536 bytes (got %d)", len(script)),
+			ResourceType: "saga",
+			ResourceID:   sagaName,
 		})
 		return nil
 	}
 
 	fileOpts := &syntax.FileOptions{}
-	_, parseErr := fileOpts.Parse(saga.GetName()+".star", script, 0)
+	_, parseErr := fileOpts.Parse(sagaName+".star", script, 0)
 	if parseErr != nil {
-		addError(result, parseStarlarkError(parseErr, path))
+		ve := parseStarlarkError(parseErr, path)
+		ve.ResourceType = "saga"
+		ve.ResourceID = sagaName
+		addError(result, ve)
 		return nil
 	}
 
 	predeclared, callLog, deprecationWarnings, err := v.buildStarlarkPredeclared()
 	if err != nil {
 		addError(result, ValidationError{
-			Severity: SeverityError,
-			Path:     path,
-			Code:     "STARLARK_MODULE_BUILD_ERROR",
-			Message:  fmt.Sprintf("failed to build typed service modules: %v", err),
+			Severity:     SeverityError,
+			Path:         path,
+			Code:         "STARLARK_MODULE_BUILD_ERROR",
+			Message:      fmt.Sprintf("failed to build typed service modules: %v", err),
+			ResourceType: "saga",
+			ResourceID:   sagaName,
 		})
 		return nil
 	}
 
 	thread := &starlark.Thread{
-		Name:  saga.GetName(),
+		Name:  sagaName,
 		Print: func(_ *starlark.Thread, _ string) {},
 	}
 
-	_, execErr := starlark.ExecFileOptions(fileOpts, thread, saga.GetName()+".star", script, predeclared)
+	_, execErr := starlark.ExecFileOptions(fileOpts, thread, sagaName+".star", script, predeclared)
 	if execErr != nil {
 		ve := parseStarlarkError(execErr, path)
+		ve.ResourceType = "saga"
+		ve.ResourceID = sagaName
 
 		// Enrich with structured error codes from handler validation failures
 		if v.enrichHandlerValidationError(execErr, &ve) {
@@ -845,11 +904,13 @@ func (v *ManifestValidator) validateSingleStarlarkScript(
 	if deprecationWarnings != nil {
 		for _, w := range *deprecationWarnings {
 			addError(result, ValidationError{
-				Severity:   SeverityWarning,
-				Path:       path,
-				Code:       w.Code,
-				Message:    w.Message,
-				Suggestion: w.Suggestion,
+				Severity:     SeverityWarning,
+				Path:         path,
+				Code:         w.Code,
+				Message:      w.Message,
+				Suggestion:   w.Suggestion,
+				ResourceType: "saga",
+				ResourceID:   sagaName,
 			})
 		}
 	}
@@ -892,6 +953,8 @@ func (v *ManifestValidator) validateCrossReferences(
 				instrCode, instrumentCodes, codeList,
 				fmt.Sprintf("account_types[%d].allowed_instruments[%d]", i, j),
 				result,
+				"account_type",
+				acctType.GetCode(),
 			)
 		}
 	}
@@ -901,11 +964,15 @@ func (v *ManifestValidator) validateCrossReferences(
 			rule.GetFromInstrument(), instrumentCodes, codeList,
 			fmt.Sprintf("valuation_rules[%d].from_instrument", i),
 			result,
+			"valuation_rule",
+			fmt.Sprintf("%s->%s", rule.GetFromInstrument(), rule.GetToInstrument()),
 		)
 		checkInstrumentRef(
 			rule.GetToInstrument(), instrumentCodes, codeList,
 			fmt.Sprintf("valuation_rules[%d].to_instrument", i),
 			result,
+			"valuation_rule",
+			fmt.Sprintf("%s->%s", rule.GetFromInstrument(), rule.GetToInstrument()),
 		)
 	}
 
@@ -927,6 +994,8 @@ func (v *ManifestValidator) validateCrossReferences(
 				Code:            "INVALID_REFERENCE",
 				Message:         fmt.Sprintf("market data set %q references unknown source code %q", ds.GetCode(), sourceCode),
 				AvailableFields: mdSourceCodeList,
+				ResourceType:    "market_data_dataset",
+				ResourceID:      ds.GetCode(),
 			}
 			if suggestion := findClosestMatch(sourceCode, mdSourceCodeList); suggestion != "" {
 				ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
@@ -964,6 +1033,8 @@ func (v *ManifestValidator) validateOrganizationCrossRefs(
 				Code:            "INVALID_REFERENCE",
 				Message:         fmt.Sprintf("organization %q references unknown party type %q", org.GetCode(), partyType),
 				AvailableFields: partyTypeList,
+				ResourceType:    "organization",
+				ResourceID:      org.GetCode(),
 			}
 			if suggestion := findClosestMatch(partyType, partyTypeList); suggestion != "" {
 				ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
@@ -1604,12 +1675,15 @@ func (v *ManifestValidator) validatePlatformFee(
 }
 
 // checkInstrumentRef validates that a referenced instrument code exists in the manifest.
+// resourceType and resourceID identify the referencing resource (e.g., "account_type", "SETTLEMENT").
 func checkInstrumentRef(
 	code string,
 	validCodes map[string]bool,
 	codeList []string,
 	path string,
 	result *ValidationResult,
+	resourceType string,
+	resourceID string,
 ) {
 	if validCodes[code] {
 		return
@@ -1620,6 +1694,8 @@ func checkInstrumentRef(
 		Code:            "UNDEFINED_INSTRUMENT_REFERENCE",
 		Message:         fmt.Sprintf("instrument code %q is not defined in instruments[]", code),
 		AvailableFields: codeList,
+		ResourceType:    resourceType,
+		ResourceID:      resourceID,
 	}
 	if suggestion := findClosestMatch(code, codeList); suggestion != "" {
 		ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
@@ -1659,13 +1735,13 @@ func (v *ManifestValidator) validatePartyTypes(
 
 		// Validate CEL expressions
 		if expr := pt.GetValidationCel(); expr != "" {
-			v.validateCELExpression(expr, basePath+".validation_cel", v.partyTypeCelEnv, celPartyTypeFields, result)
+			v.validateCELExpression(expr, basePath+".validation_cel", v.partyTypeCelEnv, celPartyTypeFields, result, "party_type", pt.GetPartyType())
 		}
 		if expr := pt.GetEligibilityCel(); expr != "" {
-			v.validateCELExpression(expr, basePath+".eligibility_cel", v.partyTypeCelEnv, celPartyTypeFields, result)
+			v.validateCELExpression(expr, basePath+".eligibility_cel", v.partyTypeCelEnv, celPartyTypeFields, result, "party_type", pt.GetPartyType())
 		}
 		if expr := pt.GetErrorMessageCel(); expr != "" {
-			v.validateCELExpression(expr, basePath+".error_message_cel", v.partyTypeCelEnv, celPartyTypeFields, result)
+			v.validateCELExpression(expr, basePath+".error_message_cel", v.partyTypeCelEnv, celPartyTypeFields, result, "party_type", pt.GetPartyType())
 		}
 	}
 }
@@ -2457,7 +2533,7 @@ func parseStarlarkError(err error, basePath string) ValidationError {
 	ve := ValidationError{
 		Severity: SeverityError,
 		Path:     basePath,
-		Code:     "STARLARK_COMPILATION_ERROR",
+		Code:     CodeStarlarkCompilationError,
 		Message:  err.Error(),
 	}
 
@@ -2476,7 +2552,7 @@ func parseStarlarkError(err error, basePath string) ValidationError {
 
 	// Detect syntax errors vs execution errors
 	if strings.Contains(errStr, "syntax") || strings.Contains(errStr, "got ") {
-		ve.Code = "STARLARK_SYNTAX_ERROR"
+		ve.Code = CodeStarlarkSyntaxError
 	}
 
 	return ve

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -614,7 +614,7 @@ func TestValidateStarlark_SyntaxError(t *testing.T) {
 
 	found := false
 	for _, e := range result.Errors {
-		if e.Code == "STARLARK_SYNTAX_ERROR" || e.Code == "STARLARK_COMPILATION_ERROR" {
+		if e.Code == CodeStarlarkSyntaxError || e.Code == CodeStarlarkCompilationError {
 			found = true
 			if e.Line == 0 && e.Column == 0 {
 				// Line info may not always be extractable, but let's not fail on this
@@ -3177,4 +3177,131 @@ func TestValidate_OrganizationReferencesManifestDefinedPartyType(t *testing.T) {
 			t.Errorf("unexpected INVALID_REFERENCE error: %s", e.Message)
 		}
 	}
+}
+
+func TestValidationError_ResourceTypeAndID_DuplicateCode(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.Instruments = append(manifest.Instruments, &controlplanev1.InstrumentDefinition{
+		Code: "GBP",
+		Name: "Duplicate GBP",
+		Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+		Dimensions: &controlplanev1.InstrumentDimensions{
+			Unit:      "GBP",
+			Precision: 2,
+		},
+	})
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "DUPLICATE_CODE" && strings.Contains(e.Path, "instruments") {
+			found = true
+			assert.Equal(t, "instrument", e.ResourceType, "expected resource_type=instrument")
+			assert.Equal(t, "GBP", e.ResourceID, "expected resource_id=GBP")
+			break
+		}
+	}
+	assert.True(t, found, "expected DUPLICATE_CODE error for instruments")
+}
+
+func TestValidationError_ResourceTypeAndID_UndefinedInstrumentRef(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	// "GBX" is a typo for "GBP" — should produce a suggestion
+	manifest.AccountTypes[0].AllowedInstruments = []string{"GBX"}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "UNDEFINED_INSTRUMENT_REFERENCE" {
+			found = true
+			assert.Equal(t, "account_type", e.ResourceType, "expected resource_type=account_type")
+			assert.Equal(t, "SETTLEMENT", e.ResourceID, "expected resource_id=SETTLEMENT")
+			assert.NotEmpty(t, e.Suggestion, "expected suggestion for unknown instrument reference")
+			assert.Contains(t, e.Suggestion, "GBP", "expected suggestion to contain GBP")
+			break
+		}
+	}
+	assert.True(t, found, "expected UNDEFINED_INSTRUMENT_REFERENCE error")
+}
+
+func TestValidationError_ResourceTypeAndID_StarlarkSyntaxError(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.Sagas[0].Script = "def execute(ctx)\n    return {}\n" // Missing colon
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == CodeStarlarkSyntaxError || e.Code == CodeStarlarkCompilationError {
+			found = true
+			assert.Equal(t, "saga", e.ResourceType, "expected resource_type=saga")
+			assert.Equal(t, "process_settlement", e.ResourceID, "expected resource_id=process_settlement")
+			break
+		}
+	}
+	assert.True(t, found, "expected STARLARK_SYNTAX_ERROR with resource context")
+}
+
+func TestValidationError_AggregatesAllErrors(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	// Introduce multiple errors: duplicate instrument + bad cross-reference
+	manifest.Instruments = append(manifest.Instruments, &controlplanev1.InstrumentDefinition{
+		Code:       "GBP",
+		Name:       "Duplicate GBP",
+		Type:       controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+		Dimensions: &controlplanev1.InstrumentDimensions{Unit: "GBP", Precision: 2},
+	})
+	manifest.AccountTypes = append(manifest.AccountTypes, &controlplanev1.AccountTypeDefinition{
+		Code:               "CASH",
+		Name:               "Cash Account",
+		NormalBalance:      controlplanev1.NormalBalance_NORMAL_BALANCE_DEBIT,
+		AllowedInstruments: []string{"UNKNOWN_INSTRUMENT"},
+	})
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+	// Must have at least 2 errors - aggregation not fail-fast
+	assert.GreaterOrEqual(t, len(result.Errors), 2,
+		"expected multiple errors aggregated, got: %v", result.Errors)
+}
+
+func TestValidationError_CELError_ResourceTypeAndID(t *testing.T) {
+	v, err := New(WithOpenAPIPaths(nil), WithAsyncAPISchemas(nil))
+	require.NoError(t, err)
+
+	manifest := validManifest()
+	manifest.AccountTypes[0].Policies = &controlplanev1.AccountTypePolicies{
+		Validation: "nonexistent_field > 0",
+	}
+
+	result := v.Validate(manifest, nil)
+	assert.False(t, result.Valid)
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "CEL_UNDECLARED_REFERENCE" || e.Code == "CEL_COMPILATION_ERROR" {
+			found = true
+			assert.Equal(t, "account_type", e.ResourceType, "expected resource_type=account_type")
+			assert.Equal(t, "SETTLEMENT", e.ResourceID, "expected resource_id=SETTLEMENT")
+			break
+		}
+	}
+	assert.True(t, found, "expected CEL error with resource context")
 }

--- a/services/control-plane/service/bootstrap.go
+++ b/services/control-plane/service/bootstrap.go
@@ -25,9 +25,11 @@ type ManifestValidationResult struct {
 
 // ManifestValidationError represents a single validation finding.
 type ManifestValidationError struct {
-	Path    string
-	Code    string
-	Message string
+	Path         string
+	Code         string
+	Message      string
+	ResourceType string
+	ResourceID   string
 }
 
 // ValidateManifest validates a manifest against the schema and business rules.
@@ -42,11 +44,13 @@ func ValidateManifest(mf *controlplanev1.Manifest, prev *controlplanev1.Manifest
 	for _, e := range internal.Errors {
 		result.Errors = append(result.Errors, ManifestValidationError{
 			Path: e.Path, Code: e.Code, Message: e.Message,
+			ResourceType: e.ResourceType, ResourceID: e.ResourceID,
 		})
 	}
 	for _, w := range internal.Warnings {
 		result.Warnings = append(result.Warnings, ManifestValidationError{
 			Path: w.Path, Code: w.Code, Message: w.Message,
+			ResourceType: w.ResourceType, ResourceID: w.ResourceID,
 		})
 	}
 	return result, nil

--- a/services/control-plane/service/bootstrap.go
+++ b/services/control-plane/service/bootstrap.go
@@ -28,6 +28,7 @@ type ManifestValidationError struct {
 	Path         string
 	Code         string
 	Message      string
+	Suggestion   string
 	ResourceType string
 	ResourceID   string
 }
@@ -43,13 +44,13 @@ func ValidateManifest(mf *controlplanev1.Manifest, prev *controlplanev1.Manifest
 	result := &ManifestValidationResult{Valid: internal.Valid}
 	for _, e := range internal.Errors {
 		result.Errors = append(result.Errors, ManifestValidationError{
-			Path: e.Path, Code: e.Code, Message: e.Message,
+			Path: e.Path, Code: e.Code, Message: e.Message, Suggestion: e.Suggestion,
 			ResourceType: e.ResourceType, ResourceID: e.ResourceID,
 		})
 	}
 	for _, w := range internal.Warnings {
 		result.Warnings = append(result.Warnings, ManifestValidationError{
-			Path: w.Path, Code: w.Code, Message: w.Message,
+			Path: w.Path, Code: w.Code, Message: w.Message, Suggestion: w.Suggestion,
 			ResourceType: w.ResourceType, ResourceID: w.ResourceID,
 		})
 	}


### PR DESCRIPTION
## Summary

- Adds `resource_type` and `resource_id` fields to the `ValidationError` proto message so callers can identify exactly which resource caused each error without parsing path strings
- Populates these fields throughout the validator: duplicate checks, CEL policy validation, Starlark script compilation, and all cross-reference checks (instrument refs, org refs, market data dataset refs)
- Introduces `CodeStarlarkSyntaxError` / `CodeStarlarkCompilationError` constants to replace repeated string literals
- Mirrors new fields in `generator.ValidationError` (avoids circular import), and propagates them through `toProtoValidationErrors` and the `applier` gRPC handler
- Exposes the fields on `service/bootstrap.ManifestValidationError` for consumers of the public API

Errors are already aggregated (not fail-fast) — this PR surfaces the context needed to act on them.

## Changes

- `api/proto/meridian/control_plane/v1/apply_manifest_service.proto`: add `resource_type` (6) and `resource_id` (7) to `ValidationError`
- `services/control-plane/internal/validator/manifest_validator.go`: extend `ValidationError` struct; populate resource context; add constants; update `checkInstrumentRef` and `validateCELExpression` signatures
- `services/control-plane/internal/validator/manifest_validator_test.go`: 5 new TDD tests covering duplicate, cross-ref, Starlark, CEL, and aggregation scenarios
- `services/control-plane/internal/applier/grpc_handler.go`: map `ResourceType`/`ResourceId` in proto conversion
- `services/control-plane/internal/generator/llm_client.go`: mirror new fields on `generator.ValidationError`
- `services/control-plane/internal/generator/service.go`: propagate new fields in `toProtoValidationErrors`
- `services/control-plane/service/bootstrap.go`: expose `ResourceType`/`ResourceID` on `ManifestValidationError`

## Test plan

- [ ] All existing validator tests still pass (no regressions)
- [ ] `TestValidationError_ResourceTypeAndID_DuplicateCode`: verifies `resource_type="instrument"`, `resource_id="GBP"` for duplicate instrument
- [ ] `TestValidationError_ResourceTypeAndID_UndefinedInstrumentRef`: verifies `resource_type="account_type"`, `resource_id="SETTLEMENT"` + fuzzy suggestion for bad instrument ref
- [ ] `TestValidationError_ResourceTypeAndID_StarlarkSyntaxError`: verifies `resource_type="saga"`, `resource_id="process_settlement"`
- [ ] `TestValidationError_AggregatesAllErrors`: verifies ≥2 errors (not fail-fast) for manifest with duplicate + bad cross-ref
- [ ] `TestValidationError_CELError_ResourceTypeAndID`: verifies `resource_type="account_type"`, `resource_id="SETTLEMENT"` for CEL errors