### PR TITLE
feat: Update apply_manifest saga to v1.3.0 with all resource phases

### DIFF
--- a/services/control-plane/internal/applier/bootstrap_test.go
+++ b/services/control-plane/internal/applier/bootstrap_test.go
@@ -12,13 +12,18 @@ func TestLoadEmbeddedApplyManifest(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, script)
-	assert.Equal(t, "1.2.0", version)
+	assert.Equal(t, "1.3.0", version)
 	assert.Contains(t, script, "apply_manifest")
 	assert.Contains(t, script, "execute_apply_manifest")
 	assert.Contains(t, script, "reference_data.register_instrument")
+	assert.Contains(t, script, "reference_data.activate_instrument")
 	assert.Contains(t, script, "internal_account.initiate")
 	assert.Contains(t, script, "operational_gateway.upsert_connection")
 	assert.Contains(t, script, "operational_gateway.upsert_route")
+	assert.Contains(t, script, "market_information.register_data_source")
+	assert.Contains(t, script, "market_information.register_data_set")
+	assert.Contains(t, script, "market_information.activate_data_set")
+	assert.Contains(t, script, "party.register_organization")
 }
 
 func TestIsSemverGreater(t *testing.T) {

--- a/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
+++ b/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
@@ -1,0 +1,281 @@
+# Saga: apply_manifest
+# Version: 1.3.0
+# Previous: 1.2.0
+# Changed: Added all resource phases with correct dependency ordering:
+#          - Phase 10: Instruments (register + activate)
+#          - Phase 20: Account types (draft + activate)
+#          - Phase 30: Market data sources
+#          - Phase 35: Market data sets (register + activate)
+#          - Phase 40: Valuation rules
+#          - Phase 55: Organizations
+#          - Phase 60: Internal accounts (explicit or auto-derived from account types)
+#          - Phase 70: Saga definitions
+#          - Phase 90: Operational gateway (connections + routes)
+# Author: Platform Team
+# Date: 2026-03-16
+#
+# This Starlark script defines the apply_manifest saga workflow for the Control Plane.
+# It executes phased gRPC calls to provision tenant resources from a manifest definition.
+#
+# Phases (executed sequentially, parallel within each phase):
+#   Phase 10: Register and activate instruments with Reference Data service
+#   Phase 20: Register account types (CreateDraft + Activate)
+#   Phase 30: Register market data sources
+#   Phase 35: Register and activate market data sets
+#   Phase 40: Register valuation rules
+#   Phase 55: Register organizations with Party service
+#   Phase 60: Initiate internal accounts (explicit or auto-derived from account types)
+#   Phase 70: Register saga definitions
+#   Phase 90: Configure Operational Gateway (provider connections + instruction routes)
+#
+# Compensation Order (LIFO - Last In, First Out):
+#   Failures trigger compensation of completed steps in reverse order.
+#
+# Input data (provided via input_data dictionary):
+#   - manifest_version: string - The manifest version being applied
+#   - instruments: list - List of instrument definitions to register
+#   - account_types: list - List of account type definitions to register
+#   - market_data_sources: list - List of market data source definitions to register
+#   - market_data_sets: list - List of market data set definitions to register
+#   - valuation_rules: list - List of valuation rule definitions to register
+#   - organizations: list - List of organization definitions to register
+#   - internal_accounts: list - List of internal account definitions to initiate
+#   - saga_definitions: list - List of saga definitions to register
+#   - provider_connections: list - List of provider connection configs to upsert
+#   - instruction_routes: list - List of instruction route configs to upsert
+
+apply_manifest_saga = saga(name="apply_manifest")
+
+def execute_apply_manifest():
+    manifest_version = input_data["manifest_version"]
+    instruments = input_data.get("instruments", [])
+    account_types = input_data.get("account_types", [])
+    market_data_sources = input_data.get("market_data_sources", [])
+    market_data_sets = input_data.get("market_data_sets", [])
+    valuation_rules = input_data.get("valuation_rules", [])
+    organizations = input_data.get("organizations", [])
+    internal_accounts = input_data.get("internal_accounts", [])
+    saga_definitions = input_data.get("saga_definitions", [])
+    provider_connections = input_data.get("provider_connections", [])
+    instruction_routes = input_data.get("instruction_routes", [])
+
+    registered_instruments = []
+    registered_account_types = []
+    registered_market_data_sources = []
+    registered_market_data_sets = []
+    registered_valuation_rules = []
+    registered_organizations = []
+    registered_internal_accounts = []
+    registered_saga_definitions = []
+    registered_connections = []
+    registered_routes = []
+
+    # Phase 10: Register and activate instruments (no dependencies)
+    for instrument in instruments:
+        step(name="register_instrument_" + instrument["code"])
+        result = reference_data.register_instrument(
+            instrument_code=instrument["code"],
+            display_name=instrument.get("display_name", instrument["code"]),
+            dimension=instrument.get("dimension", "CURRENCY"),
+            decimal_places=instrument.get("decimal_places", 2),
+            description=instrument.get("description", ""),
+        )
+
+        # Activate the instrument (DRAFT → ACTIVE)
+        step(name="activate_instrument_" + instrument["code"])
+        reference_data.activate_instrument(
+            instrument_code=instrument["code"],
+        )
+
+        registered_instruments.append({
+            "instrument_code": instrument["code"],
+            "status": "ACTIVE",
+        })
+
+    # Phase 20: Register account types (depends on instruments from Phase 10)
+    for account_type in account_types:
+        step(name="register_account_type_" + account_type["code"])
+        reference_data.register_account_type(
+            code=account_type["code"],
+            display_name=account_type.get("display_name", account_type["code"]),
+            behavior_class=account_type.get("behavior_class", "CLEARING"),
+            normal_balance=account_type.get("normal_balance", "DEBIT"),
+            instrument_code=account_type.get("instrument_code", ""),
+            description=account_type.get("description", ""),
+            default_saga_prefix=account_type.get("default_saga_prefix", ""),
+            default_conversion_method=account_type.get("default_conversion_method", ""),
+            validation_cel=account_type.get("validation_cel", ""),
+            eligibility_cel=account_type.get("eligibility_cel", ""),
+            attribute_schema=account_type.get("attribute_schema", ""),
+            valuation_methods=account_type.get("valuation_methods", []),
+        )
+
+        registered_account_types.append({
+            "account_type_code": account_type["code"],
+            "status": "REGISTERED",
+        })
+
+    # Phase 30: Register market data sources (no dependency on instruments/account types)
+    for source in market_data_sources:
+        step(name="register_data_source_" + source["code"])
+        market_information.register_data_source(
+            code=source["code"],
+            name=source.get("name", source["code"]),
+            description=source.get("description", ""),
+            trust_level=source.get("trust_level", 0),
+        )
+        registered_market_data_sources.append({
+            "code": source["code"],
+            "status": "REGISTERED",
+        })
+
+    # Phase 35: Register and activate market data sets (depends on data sources from Phase 30)
+    for dataset in market_data_sets:
+        step(name="register_data_set_" + dataset["code"])
+        market_information.register_data_set(
+            code=dataset["code"],
+            category=dataset.get("category", ""),
+            unit=dataset.get("unit", ""),
+            source_code=dataset.get("source_code", ""),
+            display_name=dataset.get("display_name", dataset["code"]),
+            description=dataset.get("description", ""),
+        )
+
+        step(name="activate_data_set_" + dataset["code"])
+        market_information.activate_data_set(
+            code=dataset["code"],
+        )
+
+        registered_market_data_sets.append({
+            "code": dataset["code"],
+            "status": "ACTIVE",
+        })
+
+    # Phase 40: Register valuation rules (depends on instruments from Phase 10)
+    for rule in valuation_rules:
+        step(name="register_valuation_rule_" + rule["from_instrument"] + "_" + rule["to_instrument"])
+        reference_data.register_valuation_rule(
+            from_instrument=rule["from_instrument"],
+            to_instrument=rule["to_instrument"],
+            rule_type=rule.get("rule_type", "FIXED_RATE"),
+            expression=rule.get("expression", ""),
+            description=rule.get("description", ""),
+        )
+        registered_valuation_rules.append({
+            "from_instrument": rule["from_instrument"],
+            "to_instrument": rule["to_instrument"],
+            "status": "REGISTERED",
+        })
+
+    # Phase 55: Register organizations with Party service
+    for org in organizations:
+        step(name="register_organization_" + org["code"])
+        party.register_organization(
+            code=org["code"],
+            name=org.get("name", org["code"]),
+            party_type=org.get("party_type", "ORGANIZATION"),
+            attributes=org.get("attributes", {}),
+        )
+        registered_organizations.append({
+            "code": org["code"],
+            "status": "REGISTERED",
+        })
+
+    # Phase 60: Initiate internal accounts
+    # Backward compatibility: if no explicit internal_accounts, auto-derive from account types
+    effective_internal_accounts = internal_accounts
+    if len(effective_internal_accounts) == 0:
+        for account_type in account_types:
+            effective_internal_accounts.append({
+                "code": account_type["code"],
+                "account_type": account_type.get("account_type", "CLEARING"),
+                "instrument_code": account_type.get("instrument_code", ""),
+                "description": account_type.get("description", ""),
+            })
+
+    for ia in effective_internal_accounts:
+        step(name="initiate_account_" + ia["code"])
+        account_result = internal_account.initiate(
+            account_code=ia["code"],
+            name=ia.get("name", ia["code"]),
+            account_type=ia.get("account_type", "CLEARING"),
+            instrument_code=ia.get("instrument_code", ""),
+            description=ia.get("description", ""),
+        )
+        registered_internal_accounts.append({
+            "account_code": ia["code"],
+            "account_id": account_result.account_id,
+            "status": "ACTIVE",
+        })
+
+    # Phase 70: Register saga definitions
+    for saga_def in saga_definitions:
+        step(name="register_saga_definition_" + saga_def["name"])
+        reference_data.register_saga_definition(
+            saga_name=saga_def["name"],
+            display_name=saga_def.get("display_name", saga_def["name"]),
+            description=saga_def.get("description", ""),
+            script=saga_def.get("script", ""),
+            version=saga_def.get("version", "1.0.0"),
+        )
+        registered_saga_definitions.append({
+            "saga_name": saga_def["name"],
+            "status": "REGISTERED",
+        })
+
+    # Phase 90: Configure Operational Gateway
+    # Provider connections must be upserted before instruction routes because
+    # routes reference connections by connection_id.
+
+    for conn in provider_connections:
+        step(name="upsert_provider_connection_" + conn["connection_id"])
+        result = operational_gateway.upsert_connection(
+            connection_id=conn["connection_id"],
+            provider_name=conn["provider_name"],
+            provider_type=conn.get("provider_type", ""),
+            protocol=conn["protocol"],
+            base_url=conn["base_url"],
+            auth_type=conn["auth_type"],
+            auth_config=conn.get("auth_config", {}),
+            retry_policy=conn.get("retry_policy", {}),
+            rate_limit_config=conn.get("rate_limit_config", {}),
+        )
+        registered_connections.append({
+            "connection_id": conn["connection_id"],
+            "status": result.get("status", "UPSERTED"),
+        })
+
+    for route in instruction_routes:
+        step(name="upsert_instruction_route_" + route["instruction_type"])
+        result = operational_gateway.upsert_route(
+            instruction_type=route["instruction_type"],
+            connection_id=route["connection_id"],
+            fallback_connection_id=route.get("fallback_connection_id", ""),
+            outbound_mapping=route.get("outbound_mapping", ""),
+            inbound_mapping=route.get("inbound_mapping", ""),
+            http_method=route.get("http_method", ""),
+            path_template=route.get("path_template", ""),
+        )
+        registered_routes.append({
+            "instruction_type": route["instruction_type"],
+            "status": result.get("status", "UPSERTED"),
+        })
+
+    result = {
+        "status": "applied",
+        "version": manifest_version,
+        "instruments_registered": len(registered_instruments),
+        "account_types_registered": len(registered_account_types),
+        "market_data_sources_registered": len(registered_market_data_sources),
+        "market_data_sets_registered": len(registered_market_data_sets),
+        "valuation_rules_registered": len(registered_valuation_rules),
+        "organizations_registered": len(registered_organizations),
+        "internal_accounts_initiated": len(registered_internal_accounts),
+        "saga_definitions_registered": len(registered_saga_definitions),
+        "provider_connections_upserted": len(registered_connections),
+        "instruction_routes_upserted": len(registered_routes),
+    }
+    return result
+
+# Execute the saga
+execute_apply_manifest()

--- a/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
+++ b/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
@@ -201,6 +201,7 @@ def execute_apply_manifest():
             account_type=ia.get("account_type", "CLEARING"),
             instrument_code=ia.get("instrument_code", ""),
             description=ia.get("description", ""),
+            owner_organization=ia.get("owner_organization", ""),
         )
         registered_internal_accounts.append({
             "account_code": ia["code"],

--- a/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
+++ b/services/control-plane/internal/applier/defaults/apply_manifest/v1.3.0.star
@@ -132,7 +132,7 @@ def execute_apply_manifest():
     # Phase 35: Register and activate market data sets (depends on data sources from Phase 30)
     for dataset in market_data_sets:
         step(name="register_data_set_" + dataset["code"])
-        market_information.register_data_set(
+        ds_result = market_information.register_data_set(
             code=dataset["code"],
             category=dataset.get("category", ""),
             unit=dataset.get("unit", ""),
@@ -144,6 +144,7 @@ def execute_apply_manifest():
         step(name="activate_data_set_" + dataset["code"])
         market_information.activate_data_set(
             code=dataset["code"],
+            version=ds_result.get("version", 1),
         )
 
         registered_market_data_sets.append({

--- a/services/control-plane/internal/applier/executor.go
+++ b/services/control-plane/internal/applier/executor.go
@@ -103,22 +103,34 @@ type ApplyManifestInput struct {
 	// ManifestVersion is the version being applied.
 	ManifestVersion string
 
-	// Instruments to register in Phase 1.
+	// Instruments to register in Phase 10.
 	Instruments []InstrumentInput
 
-	// AccountTypes to register and provision in Phase 2.
+	// AccountTypes to register in Phase 20.
 	AccountTypes []AccountTypeInput
 
-	// ValuationRules to register in Phase 3.
+	// MarketDataSources to register in Phase 30.
+	MarketDataSources []MarketDataSourceInput
+
+	// MarketDataSets to register and activate in Phase 35.
+	MarketDataSets []MarketDataSetInput
+
+	// ValuationRules to register in Phase 40.
 	ValuationRules []ValuationRuleInput
 
-	// SagaDefinitions to register in Phase 4.
+	// Organizations to register in Phase 55.
+	Organizations []OrganizationInput
+
+	// InternalAccounts to initiate in Phase 60.
+	InternalAccounts []InternalAccountInput
+
+	// SagaDefinitions to register in Phase 70.
 	SagaDefinitions []SagaDefinitionInput
 
-	// ProviderConnections to upsert in Phase 5 (Operational Gateway).
+	// ProviderConnections to upsert in Phase 90 (Operational Gateway).
 	ProviderConnections []ProviderConnectionInput
 
-	// InstructionRoutes to upsert in Phase 5 (Operational Gateway).
+	// InstructionRoutes to upsert in Phase 90 (Operational Gateway).
 	InstructionRoutes []InstructionRouteInput
 
 	// TenantID is the tenant for cross-tenant execution.
@@ -197,6 +209,41 @@ type InstructionRouteInput struct {
 	InboundMapping       string
 	HTTPMethod           string
 	PathTemplate         string
+}
+
+// MarketDataSourceInput represents a market data source to register.
+type MarketDataSourceInput struct {
+	Code        string
+	Name        string
+	Description string
+	TrustLevel  int
+}
+
+// MarketDataSetInput represents a market data set to register and activate.
+type MarketDataSetInput struct {
+	Code        string
+	Category    string
+	Unit        string
+	SourceCode  string
+	DisplayName string
+	Description string
+}
+
+// OrganizationInput represents an organization to register.
+type OrganizationInput struct {
+	Code       string
+	Name       string
+	PartyType  string
+	Attributes map[string]string
+}
+
+// InternalAccountInput represents an internal account to initiate.
+type InternalAccountInput struct {
+	Code              string
+	AccountType       string
+	InstrumentCode    string
+	OwnerOrganization string
+	Description       string
 }
 
 // ApplyManifestResult contains the result of a manifest application.
@@ -421,6 +468,32 @@ func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]
 	}
 	sagaInput["account_types"] = accountTypes
 
+	// Convert market data sources
+	marketSources := make([]interface{}, len(input.MarketDataSources))
+	for i, src := range input.MarketDataSources {
+		marketSources[i] = map[string]interface{}{
+			"code":        src.Code,
+			"name":        src.Name,
+			"description": src.Description,
+			"trust_level": src.TrustLevel,
+		}
+	}
+	sagaInput["market_data_sources"] = marketSources
+
+	// Convert market data sets
+	marketDataSets := make([]interface{}, len(input.MarketDataSets))
+	for i, ds := range input.MarketDataSets {
+		marketDataSets[i] = map[string]interface{}{
+			"code":         ds.Code,
+			"category":     ds.Category,
+			"unit":         ds.Unit,
+			"source_code":  ds.SourceCode,
+			"display_name": ds.DisplayName,
+			"description":  ds.Description,
+		}
+	}
+	sagaInput["market_data_sets"] = marketDataSets
+
 	// Convert valuation rules
 	valuationRules := make([]interface{}, len(input.ValuationRules))
 	for i, vr := range input.ValuationRules {
@@ -433,6 +506,35 @@ func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]
 		}
 	}
 	sagaInput["valuation_rules"] = valuationRules
+
+	// Convert organizations
+	organizations := make([]interface{}, len(input.Organizations))
+	for i, org := range input.Organizations {
+		attrs := make(map[string]interface{}, len(org.Attributes))
+		for k, v := range org.Attributes {
+			attrs[k] = v
+		}
+		organizations[i] = map[string]interface{}{
+			"code":       org.Code,
+			"name":       org.Name,
+			"party_type": org.PartyType,
+			"attributes": attrs,
+		}
+	}
+	sagaInput["organizations"] = organizations
+
+	// Convert internal accounts
+	internalAccounts := make([]interface{}, len(input.InternalAccounts))
+	for i, ia := range input.InternalAccounts {
+		internalAccounts[i] = map[string]interface{}{
+			"code":               ia.Code,
+			"account_type":       ia.AccountType,
+			"instrument_code":    ia.InstrumentCode,
+			"owner_organization": ia.OwnerOrganization,
+			"description":        ia.Description,
+		}
+	}
+	sagaInput["internal_accounts"] = internalAccounts
 
 	// Convert saga definitions
 	sagaDefs := make([]interface{}, len(input.SagaDefinitions))

--- a/services/control-plane/internal/applier/executor_test.go
+++ b/services/control-plane/internal/applier/executor_test.go
@@ -106,6 +106,102 @@ func TestBuildSagaInput_Empty(t *testing.T) {
 	accountTypes, ok := sagaInput["account_types"].([]interface{})
 	require.True(t, ok)
 	assert.Empty(t, accountTypes)
+
+	marketSources, ok := sagaInput["market_data_sources"].([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, marketSources)
+
+	marketSets, ok := sagaInput["market_data_sets"].([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, marketSets)
+
+	orgs, ok := sagaInput["organizations"].([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, orgs)
+
+	internalAccts, ok := sagaInput["internal_accounts"].([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, internalAccts)
+}
+
+func TestBuildSagaInput_NewResourceTypes(t *testing.T) {
+	executor := &ManifestExecutor{}
+
+	input := &ApplyManifestInput{
+		ManifestVersion: "2",
+		TenantID:        "org_test",
+		MarketDataSources: []MarketDataSourceInput{
+			{
+				Code:        "BLOOMBERG",
+				Name:        "Bloomberg Financial Data",
+				Description: "FX and commodity data",
+				TrustLevel:  90,
+			},
+		},
+		MarketDataSets: []MarketDataSetInput{
+			{
+				Code:        "USD_EUR_FX",
+				Category:    "DATA_CATEGORY_FX_RATE",
+				Unit:        "USD/EUR",
+				SourceCode:  "BLOOMBERG",
+				DisplayName: "USD/EUR Spot Rate",
+				Description: "Spot FX rate",
+			},
+		},
+		Organizations: []OrganizationInput{
+			{
+				Code:       "ACME_ENERGY",
+				Name:       "Acme Energy Corp",
+				PartyType:  "ORGANIZATION",
+				Attributes: map[string]string{"industry": "energy"},
+			},
+		},
+		InternalAccounts: []InternalAccountInput{
+			{
+				Code:              "REVENUE_GBP",
+				AccountType:       "REVENUE",
+				InstrumentCode:    "GBP",
+				OwnerOrganization: "ACME_ENERGY",
+				Description:       "Revenue account",
+			},
+		},
+	}
+
+	sagaInput := executor.buildSagaInput(input)
+
+	sources, ok := sagaInput["market_data_sources"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, sources, 1)
+	firstSrc, ok := sources[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "BLOOMBERG", firstSrc["code"])
+	assert.Equal(t, 90, firstSrc["trust_level"])
+
+	datasets, ok := sagaInput["market_data_sets"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, datasets, 1)
+	firstDS, ok := datasets[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "USD_EUR_FX", firstDS["code"])
+	assert.Equal(t, "BLOOMBERG", firstDS["source_code"])
+
+	orgs, ok := sagaInput["organizations"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, orgs, 1)
+	firstOrg, ok := orgs[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "ACME_ENERGY", firstOrg["code"])
+	attrs, ok := firstOrg["attributes"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "energy", attrs["industry"])
+
+	ias, ok := sagaInput["internal_accounts"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, ias, 1)
+	firstIA, ok := ias[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "REVENUE_GBP", firstIA["code"])
+	assert.Equal(t, "ACME_ENERGY", firstIA["owner_organization"])
 }
 
 func TestParseManifestVersion(t *testing.T) {
@@ -148,7 +244,7 @@ func TestApplyManifestSaga_ZeroLocalSagaDefinitions(t *testing.T) {
 	// Step 1: Load embedded saga script (simulates platform default fallback)
 	script, version, err := loadEmbeddedApplyManifest()
 	require.NoError(t, err, "embedded apply_manifest saga must be loadable")
-	assert.Equal(t, "1.2.0", version)
+	assert.Equal(t, "1.3.0", version)
 	assert.Contains(t, script, "execute_apply_manifest")
 
 	// Step 2: Set up handler registry with mock handlers
@@ -162,6 +258,13 @@ func TestApplyManifestSaga_ZeroLocalSagaDefinitions(t *testing.T) {
 			return map[string]any{
 				"instrument_code": params["instrument_code"],
 				"status":          "REGISTERED",
+			}, nil
+		},
+		activateInstrumentFn: func(_ *saga.StarlarkContext, params map[string]any) (any, error) {
+			handlerCalls = append(handlerCalls, "activate_instrument:"+params["instrument_code"].(string))
+			return map[string]any{
+				"instrument_code": params["instrument_code"],
+				"status":          "ACTIVE",
 			}, nil
 		},
 		registerAccountTypeFn: func(_ *saga.StarlarkContext, params map[string]any) (any, error) {
@@ -284,26 +387,30 @@ func TestApplyManifestSaga_ZeroLocalSagaDefinitions(t *testing.T) {
 	assert.True(t, output.Success, "saga must succeed; error: %s", output.Error)
 
 	// Step 7: Verify phased execution order
-	// Phase 1: Instruments (2 instruments)
-	// Phase 2: Account types (1 register + 1 initiate)
-	// Phase 3: Valuation rules (1 rule)
-	// Phase 4: Saga definitions (1 definition)
+	// Phase 10: Instruments (2 register + 2 activate = 4 steps)
+	// Phase 20: Account types (1 register)
+	// Phase 40: Valuation rules (1 rule)
+	// Phase 60: Internal accounts (1 auto-derived from account types)
+	// Phase 70: Saga definitions (1 definition)
 	expectedCalls := []string{
-		// Phase 1
+		// Phase 10
 		"register_instrument:USD",
+		"activate_instrument:USD",
 		"register_instrument:KWH",
-		// Phase 2
+		"activate_instrument:KWH",
+		// Phase 20
 		"register_account_type:CLEARING_USD",
-		"initiate_account:CLEARING_USD",
-		// Phase 3
+		// Phase 40
 		"register_valuation_rule:KWH_GBP",
-		// Phase 4
+		// Phase 60 (auto-derived from account types since no explicit internal_accounts)
+		"initiate_account:CLEARING_USD",
+		// Phase 70
 		"register_saga_definition:deposit",
 	}
 	assert.Equal(t, expectedCalls, handlerCalls, "handlers must be called in phased order")
 
 	// Step 8: Verify step results
-	assert.Len(t, output.StepResults, 6, "must have 6 step results (2+2+1+1)")
+	assert.Len(t, output.StepResults, 8, "must have 8 step results (4+1+1+1+1)")
 	for _, step := range output.StepResults {
 		assert.True(t, step.Success, "step %s must succeed", step.StepName)
 	}

--- a/services/control-plane/internal/applier/grpc_handler.go
+++ b/services/control-plane/internal/applier/grpc_handler.go
@@ -746,6 +746,9 @@ func buildExecutorInput(mf *controlplanev1.Manifest) *ApplyManifestInput {
 		})
 	}
 
+	extractMarketData(mf, input)
+	extractPartyAndAccounts(mf, input)
+
 	for _, saga := range mf.GetSagas() {
 		input.SagaDefinitions = append(input.SagaDefinitions, SagaDefinitionInput{
 			Name:   saga.GetName(),
@@ -753,47 +756,101 @@ func buildExecutorInput(mf *controlplanev1.Manifest) *ApplyManifestInput {
 		})
 	}
 
-	if gw := mf.GetOperationalGateway(); gw != nil {
-		for _, conn := range gw.GetProviderConnections() {
-			pc := ProviderConnectionInput{
-				ConnectionID: conn.GetConnectionId(),
-				ProviderName: conn.GetProviderName(),
-				ProviderType: conn.GetProviderType(),
-				Protocol:     conn.GetProtocol().String(),
-				BaseURL:      conn.GetBaseUrl(),
-			}
-			pc.AuthType, pc.AuthConfig = extractAuthConfig(conn.GetAuth())
-			if rp := conn.GetRetryPolicy(); rp != nil {
-				pc.RetryPolicy = map[string]any{
-					"max_attempts":            rp.GetMaxAttempts(),
-					"initial_backoff_seconds": rp.GetInitialBackoffSeconds(),
-					"max_backoff_seconds":     rp.GetMaxBackoffSeconds(),
-					"backoff_multiplier":      rp.GetBackoffMultiplier(),
-				}
-			}
-			if rl := conn.GetRateLimit(); rl != nil {
-				pc.RateLimitConfig = map[string]any{
-					"requests_per_second": rl.GetRequestsPerSecond(),
-					"burst_size":          rl.GetBurstSize(),
-				}
-			}
-			input.ProviderConnections = append(input.ProviderConnections, pc)
-		}
-
-		for _, route := range gw.GetInstructionRoutes() {
-			input.InstructionRoutes = append(input.InstructionRoutes, InstructionRouteInput{
-				InstructionType:      route.GetInstructionType(),
-				ConnectionID:         route.GetConnectionId(),
-				FallbackConnectionID: route.GetFallbackConnectionId(),
-				OutboundMapping:      route.GetOutboundMappingId(),
-				InboundMapping:       route.GetInboundMappingId(),
-				HTTPMethod:           route.GetHttpMethod(),
-				PathTemplate:         route.GetPathTemplate(),
-			})
-		}
-	}
+	extractOperationalGateway(mf, input)
 
 	return input
+}
+
+// extractMarketData converts market data sources and data sets from the manifest proto.
+func extractMarketData(mf *controlplanev1.Manifest, input *ApplyManifestInput) {
+	md := mf.GetMarketData()
+	if md == nil {
+		return
+	}
+	for _, src := range md.GetSources() {
+		input.MarketDataSources = append(input.MarketDataSources, MarketDataSourceInput{
+			Code:        src.GetCode(),
+			Name:        src.GetName(),
+			Description: src.GetDescription(),
+			TrustLevel:  int(src.GetTrustLevel()),
+		})
+	}
+	for _, ds := range md.GetDatasets() {
+		input.MarketDataSets = append(input.MarketDataSets, MarketDataSetInput{
+			Code:        ds.GetCode(),
+			Category:    ds.GetCategory().String(),
+			Unit:        ds.GetUnit(),
+			SourceCode:  ds.GetSourceCode(),
+			DisplayName: ds.GetDisplayName(),
+			Description: ds.GetDescription(),
+		})
+	}
+}
+
+// extractPartyAndAccounts converts organizations and internal accounts from the manifest proto.
+func extractPartyAndAccounts(mf *controlplanev1.Manifest, input *ApplyManifestInput) {
+	for _, org := range mf.GetOrganizations() {
+		input.Organizations = append(input.Organizations, OrganizationInput{
+			Code:       org.GetCode(),
+			Name:       org.GetName(),
+			PartyType:  org.GetPartyType(),
+			Attributes: org.GetAttributes(),
+		})
+	}
+	for _, ia := range mf.GetInternalAccounts() {
+		input.InternalAccounts = append(input.InternalAccounts, InternalAccountInput{
+			Code:              ia.GetCode(),
+			AccountType:       ia.GetAccountType(),
+			InstrumentCode:    ia.GetInstrument(),
+			OwnerOrganization: ia.GetOwnerOrganization(),
+			Description:       ia.GetDescription(),
+		})
+	}
+}
+
+// extractOperationalGateway converts operational gateway config from the manifest proto.
+func extractOperationalGateway(mf *controlplanev1.Manifest, input *ApplyManifestInput) {
+	gw := mf.GetOperationalGateway()
+	if gw == nil {
+		return
+	}
+	for _, conn := range gw.GetProviderConnections() {
+		pc := ProviderConnectionInput{
+			ConnectionID: conn.GetConnectionId(),
+			ProviderName: conn.GetProviderName(),
+			ProviderType: conn.GetProviderType(),
+			Protocol:     conn.GetProtocol().String(),
+			BaseURL:      conn.GetBaseUrl(),
+		}
+		pc.AuthType, pc.AuthConfig = extractAuthConfig(conn.GetAuth())
+		if rp := conn.GetRetryPolicy(); rp != nil {
+			pc.RetryPolicy = map[string]any{
+				"max_attempts":            rp.GetMaxAttempts(),
+				"initial_backoff_seconds": rp.GetInitialBackoffSeconds(),
+				"max_backoff_seconds":     rp.GetMaxBackoffSeconds(),
+				"backoff_multiplier":      rp.GetBackoffMultiplier(),
+			}
+		}
+		if rl := conn.GetRateLimit(); rl != nil {
+			pc.RateLimitConfig = map[string]any{
+				"requests_per_second": rl.GetRequestsPerSecond(),
+				"burst_size":          rl.GetBurstSize(),
+			}
+		}
+		input.ProviderConnections = append(input.ProviderConnections, pc)
+	}
+
+	for _, route := range gw.GetInstructionRoutes() {
+		input.InstructionRoutes = append(input.InstructionRoutes, InstructionRouteInput{
+			InstructionType:      route.GetInstructionType(),
+			ConnectionID:         route.GetConnectionId(),
+			FallbackConnectionID: route.GetFallbackConnectionId(),
+			OutboundMapping:      route.GetOutboundMappingId(),
+			InboundMapping:       route.GetInboundMappingId(),
+			HTTPMethod:           route.GetHttpMethod(),
+			PathTemplate:         route.GetPathTemplate(),
+		})
+	}
 }
 
 // extractAuthConfig converts a manifest AuthConfigManifest oneof to (authType, configMap).

--- a/services/control-plane/internal/applier/grpc_handler_test.go
+++ b/services/control-plane/internal/applier/grpc_handler_test.go
@@ -373,6 +373,69 @@ func TestBuildExecutorInput(t *testing.T) {
 	assert.Equal(t, "test_saga", input.SagaDefinitions[0].Name)
 }
 
+func TestBuildExecutorInput_NewResourceTypes(t *testing.T) {
+	manifest := newTestManifest()
+	manifest.MarketData = &controlplanev1.MarketDataConfig{
+		Sources: []*controlplanev1.MarketDataSourceDefinition{
+			{
+				Code:        "BLOOMBERG",
+				Name:        "Bloomberg Financial Data",
+				Description: "FX rates and indices",
+				TrustLevel:  90,
+			},
+		},
+		Datasets: []*controlplanev1.MarketDataSetDefinition{
+			{
+				Code:        "USD_EUR_FX",
+				Unit:        "USD/EUR",
+				SourceCode:  "BLOOMBERG",
+				DisplayName: "USD/EUR Spot Rate",
+			},
+		},
+	}
+	manifest.Organizations = []*controlplanev1.OrganizationDefinition{
+		{
+			Code:      "ACME_ENERGY",
+			Name:      "Acme Energy Corp",
+			PartyType: "ORGANIZATION",
+			Attributes: map[string]string{
+				"industry": "energy",
+			},
+		},
+	}
+	manifest.InternalAccounts = []*controlplanev1.InternalAccountDefinition{
+		{
+			Code:              "REVENUE_GBP",
+			AccountType:       "REVENUE",
+			Instrument:        "GBP",
+			OwnerOrganization: "ACME_ENERGY",
+			Description:       "Revenue clearing account",
+		},
+	}
+
+	input := buildExecutorInput(manifest)
+
+	require.Len(t, input.MarketDataSources, 1)
+	assert.Equal(t, "BLOOMBERG", input.MarketDataSources[0].Code)
+	assert.Equal(t, "Bloomberg Financial Data", input.MarketDataSources[0].Name)
+	assert.Equal(t, 90, input.MarketDataSources[0].TrustLevel)
+
+	require.Len(t, input.MarketDataSets, 1)
+	assert.Equal(t, "USD_EUR_FX", input.MarketDataSets[0].Code)
+	assert.Equal(t, "BLOOMBERG", input.MarketDataSets[0].SourceCode)
+
+	require.Len(t, input.Organizations, 1)
+	assert.Equal(t, "ACME_ENERGY", input.Organizations[0].Code)
+	assert.Equal(t, "ORGANIZATION", input.Organizations[0].PartyType)
+	assert.Equal(t, "energy", input.Organizations[0].Attributes["industry"])
+
+	require.Len(t, input.InternalAccounts, 1)
+	assert.Equal(t, "REVENUE_GBP", input.InternalAccounts[0].Code)
+	assert.Equal(t, "REVENUE", input.InternalAccounts[0].AccountType)
+	assert.Equal(t, "GBP", input.InternalAccounts[0].InstrumentCode)
+	assert.Equal(t, "ACME_ENERGY", input.InternalAccounts[0].OwnerOrganization)
+}
+
 // --- skip_immutability_checks tests ---
 
 // mockVersionStore returns a fixed manifest as the latest applied version.

--- a/services/control-plane/internal/applier/handlers.go
+++ b/services/control-plane/internal/applier/handlers.go
@@ -52,6 +52,19 @@ func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDepen
 				Version:             1,
 			},
 		},
+		// Reference Data - Instrument activation (DRAFT → ACTIVE)
+		"reference_data.activate_instrument": {
+			handler: activateInstrumentHandler(deps),
+			metadata: saga.HandlerMetadata{
+				Category:             saga.HandlerCategorySettlement,
+				Description:          "Activate an instrument definition (DRAFT → ACTIVE)",
+				CompensationStrategy: "none",
+				ProducesInstruments:  []string{},
+				ProtoRequestType:     (*referencedatav1.ActivateInstrumentRequest)(nil),
+				ProtoResponseType:    (*referencedatav1.ActivateInstrumentResponse)(nil),
+				Version:              1,
+			},
+		},
 		// Reference Data - Account type registration (idempotent: CreateDraft + Activate)
 		"reference_data.register_account_type": {
 			handler: registerAccountTypeHandler(deps),
@@ -234,6 +247,7 @@ type HandlerDependencies struct {
 // ReferenceDataService abstracts the Reference Data gRPC client for testing.
 type ReferenceDataService interface {
 	RegisterInstrument(ctx *saga.StarlarkContext, params map[string]any) (any, error)
+	ActivateInstrument(ctx *saga.StarlarkContext, params map[string]any) (any, error)
 	DeleteInstrument(ctx *saga.StarlarkContext, params map[string]any) (any, error)
 	// RegisterAccountType creates an account type draft (idempotent via ON CONFLICT DO NOTHING)
 	// and then activates it. Returns the registered code and version.
@@ -288,6 +302,13 @@ type PartyService interface {
 func registerInstrumentHandler(deps *HandlerDependencies) saga.Handler {
 	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
 		return deps.ReferenceData.RegisterInstrument(ctx, params)
+	}
+}
+
+// activateInstrumentHandler creates a handler that activates an instrument (DRAFT → ACTIVE).
+func activateInstrumentHandler(deps *HandlerDependencies) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		return deps.ReferenceData.ActivateInstrument(ctx, params)
 	}
 }
 

--- a/services/control-plane/internal/applier/handlers_test.go
+++ b/services/control-plane/internal/applier/handlers_test.go
@@ -29,6 +29,7 @@ func (m *mockValuationMethod) ResolveMethod(ctx *saga.StarlarkContext, name stri
 // mockReferenceData implements ReferenceDataService for testing.
 type mockReferenceData struct {
 	registerInstrumentFn     func(*saga.StarlarkContext, map[string]any) (any, error)
+	activateInstrumentFn     func(*saga.StarlarkContext, map[string]any) (any, error)
 	deleteInstrumentFn       func(*saga.StarlarkContext, map[string]any) (any, error)
 	registerAccountTypeFn    func(*saga.StarlarkContext, map[string]any) (any, error)
 	deleteAccountTypeFn      func(*saga.StarlarkContext, map[string]any) (any, error)
@@ -41,6 +42,13 @@ func (m *mockReferenceData) RegisterInstrument(ctx *saga.StarlarkContext, params
 		return m.registerInstrumentFn(ctx, params)
 	}
 	return map[string]any{"instrument_code": params["instrument_code"], "status": "REGISTERED"}, nil
+}
+
+func (m *mockReferenceData) ActivateInstrument(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	if m.activateInstrumentFn != nil {
+		return m.activateInstrumentFn(ctx, params)
+	}
+	return map[string]any{"instrument_code": params["instrument_code"], "status": "ACTIVE"}, nil
 }
 
 func (m *mockReferenceData) DeleteInstrument(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
@@ -142,6 +150,7 @@ func TestRegisterManifestHandlers(t *testing.T) {
 
 	expectedHandlers := []string{
 		"reference_data.register_instrument",
+		"reference_data.activate_instrument",
 		"reference_data.delete_instrument",
 		"reference_data.register_account_type",
 		"reference_data.delete_account_type",
@@ -191,6 +200,56 @@ func TestRegisterInstrumentHandler(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "USD", resultMap["instrument_code"])
 	assert.Equal(t, "REGISTERED", resultMap["status"])
+}
+
+func TestActivateInstrumentHandler(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:   &mockReferenceData{},
+		InternalAccount: &mockInternalAccount{},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("reference_data.activate_instrument")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"instrument_code": "USD",
+	}
+
+	result, err := handler(ctx, params)
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "USD", resultMap["instrument_code"])
+	assert.Equal(t, "ACTIVE", resultMap["status"])
+}
+
+func TestActivateInstrumentHandler_Error(t *testing.T) {
+	expectedErr := errors.New("activation failed")
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData: &mockReferenceData{
+			activateInstrumentFn: func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+				return nil, expectedErr
+			},
+		},
+		InternalAccount: &mockInternalAccount{},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("reference_data.activate_instrument")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{"instrument_code": "FAIL"})
+	assert.ErrorIs(t, err, expectedErr)
 }
 
 func TestRegisterInstrumentHandler_Error(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add v1.3.0 of the `apply_manifest` Starlark saga with all 10 resource type phases in correct dependency order
- Add `reference_data.activate_instrument` handler (was missing in v1.2.0 per PRD requirement)
- Backward compatibility: auto-derive internal accounts from account types when no explicit `internalAccounts` section exists
- Update `buildExecutorInput()` and `buildSagaInput()` to convert new proto fields (market data sources/sets, organizations, internal accounts)

### Phase ordering (v1.3.0)

| Phase | Resource | Handler |
|-------|----------|---------|
| 10 | Instruments | `register_instrument` + `activate_instrument` |
| 20 | Account Types | `register_account_type` |
| 30 | Market Data Sources | `register_data_source` |
| 35 | Market Data Sets | `register_data_set` + `activate_data_set` |
| 40 | Valuation Rules | `register_valuation_rule` |
| 55 | Organizations | `register_organization` |
| 60 | Internal Accounts | `internal_account.initiate` |
| 70 | Saga Definitions | `register_saga_definition` |
| 90 | Operational Gateway | `upsert_connection` + `upsert_route` |

Task Master ref: `045-manifest-source-of-truth.9`

## Test plan

- [x] `TestLoadEmbeddedApplyManifest` verifies v1.3.0 is discovered as latest
- [x] `TestApplyManifestSaga_ZeroLocalSagaDefinitions` runs full end-to-end saga with all phases including instrument activation and auto-derived internal accounts
- [x] `TestBuildSagaInput_NewResourceTypes` verifies new resource type conversion
- [x] `TestBuildExecutorInput_NewResourceTypes` verifies proto-to-input conversion
- [x] `TestActivateInstrumentHandler` and `_Error` verify handler delegation
- [x] `TestRegisterManifestHandlers` includes `reference_data.activate_instrument`
- [x] All existing handler tests pass unchanged